### PR TITLE
feat(SD-LEO-INFRA-009-LEAF-RECURSION-001): recursion governor -- meta-to-product throughput KPI gauge

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-009-LEAF-RECURSION-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-009-LEAF-RECURSION-001.json
@@ -1,0 +1,91 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Pure recursion-governor detectors in a new lib/governance/recursion-governor.js, reusing the existing taper-rule classifier",
+      "description": "New pure functions, generalized from the chairman taper rule already computed ad-hoc for the exec-summary email (lib/fleet/exec-email-alignment.mjs's isMetaSd + META_PREFIX regex, consumed READ-ONLY, zero modifications): computeRecursionRatio(items, {windowDays=30}) classifies each item ({key}) via the reused isMetaSd() and returns {meta, product, ratio, windowDays} -- ratio = meta/product (null when product=0, matching the existing exec-email convention rather than a divide-by-zero). isBandBreach(result, {maxRatio=3}) is pure: breach=true when product===0 && meta>0 (all-meta, zero product is the worst case of the taper rule, not a null-safe pass), or when ratio!==null && ratio>maxRatio. detectSustainedBreach(recentSnapshots, {requiredConsecutive=3}) is pure: given the most recent N gauge-runner snapshot rows (each carrying a `breach` boolean, newest first), returns {sustained: boolean, streak: number} -- sustained=true only when the streak of consecutive breaches (counting from the newest snapshot backward) reaches requiredConsecutive; a single-tick blip (breach not yet repeated requiredConsecutive times) never trips the gate, matching the SD's own 'alert only on sustained breach' contract (mirrors the N-consecutive-days pattern in lib/ship/witness-adoption.mjs's computeAdoptionReadiness, generalized from calendar-days to snapshot-count since gauge-runner's cadence, not the calendar, is the natural tick)."
+    },
+    {
+      "id": "FR-2",
+      "title": "Wire a new GAUGE_REGISTRY entry with durable snapshot history in codebase_health_snapshots (existing table, no migration)",
+      "description": "New additive GAUGE_REGISTRY entry ('recursion-governor-ratio', ownerRole: 'chairman' -- per the SD's own framing, 'a number the chairman sees without asking', the 5 pre-existing entries all route to coordinator/chairman already so this follows precedent) in lib/governance/gauge-registry.js; the 4 pre-existing + 3 leaf-5 entries (7 total) are untouched. scripts/gauge-runner.mjs's buildDetectorResolvers gets one new resolver: fetches completed strategic_directives_v2 (status='completed', completion_date within windowDays) UNION completed quick_fixes (status='completed', completed_at within windowDays) via a new I/O helper fetchThroughputItems(supabase, {windowDays}) (both tables' key columns -- sd_key and id respectively -- already carry the QF-/SD-LEO- prefixes isMetaSd() classifies on, so quick_fixes rows need no separate classifier), computes the ratio (FR-1), reads back the last N snapshot rows for dimension='recursion-governor-ratio' from codebase_health_snapshots via a new fetchRecentSnapshots(supabase, {dimension, limit}) I/O helper, evaluates detectSustainedBreach, WRITES the current run's own {breach, ratio, meta, product} as a new codebase_health_snapshots row (dimension='recursion-governor-ratio') via a new writeThroughputSnapshot(supabase, result) I/O helper (so every run both reads history and extends it -- the durable log IS the gauge's own accumulated evidence, no new table), and returns {count: sustained ? 1 : 0, ...} matching the runner's generic tripWhen convention. No new migration -- codebase_health_snapshots is the EXISTING table gauge-runner.mjs's own writeHeartbeat() already writes to (dimension='gauge_runner_heartbeat')."
+    },
+    {
+      "id": "FR-3",
+      "title": "Tests",
+      "description": "New tests/unit/governance/recursion-governor.test.js: computeRecursionRatio classifies meta (SD-LEO-*, SD-LEARN-FIX-*, SD-MAN-INFRA-*, QF-*) vs product correctly via the reused isMetaSd, ratio math (including the product=0 null case), windowDays passthrough. isBandBreach: breaches when ratio>maxRatio, breaches on all-meta-zero-product, does NOT breach when ratio<=maxRatio or when there are zero items (product=0 && meta=0). detectSustainedBreach: sustained=true only at exactly requiredConsecutive consecutive breaches counting from newest, NOT sustained on a single blip (one breach then a pass), NOT sustained when the streak is broken partway through, handles an empty/short snapshot history defensively (fewer rows than requiredConsecutive never sustains). Extend tests/unit/governance/gauge-registry.test.js's hard-coded counts (7 -> 8) and sorted-id list to include 'recursion-governor-ratio', with the same per-entry detectorFn/ownerRole/tripWhen assertion pattern used for the leaf-5 entries."
+    }
+  ],
+  "technical_requirements": [
+    { "requirement": "No new migration or table -- reuses the EXISTING codebase_health_snapshots table (already written by gauge-runner.mjs's writeHeartbeat) as the durable rolling-history store for sustained-breach evaluation" },
+    { "requirement": "lib/fleet/exec-email-alignment.mjs's isMetaSd is consumed read-only -- zero modifications; computeMetaToProductRatio is NOT reused directly (it counts FILED items by created_at; this SD needs SHIPPED/completed throughput, a different query, so FR-1 defines its own computeRecursionRatio using the same classifier but different row semantics)" },
+    { "requirement": "gauge-registry.js's 7 pre-existing entries (4 original + 3 from SD-LEO-INFRA-009-LEAF-WORK-001) are untouched -- purely additive" },
+    { "requirement": "New module is ESM (import/export), matching gauge-runner.mjs's existing ESM-import convention for pure-logic sibling modules" }
+  ],
+  "test_scenarios": [
+    { "scenario": "computeRecursionRatio classifies SD-LEO-*, SD-LEARN-FIX-*, SD-MAN-INFRA-*, QF-* as meta and everything else as product, computing ratio=meta/product" },
+    { "scenario": "computeRecursionRatio returns ratio=null (not divide-by-zero) when product=0 and meta>0" },
+    { "scenario": "isBandBreach breaches when ratio exceeds maxRatio, and breaches on the all-meta/zero-product edge case even though ratio is null" },
+    { "scenario": "isBandBreach does not breach when ratio is within band, or when there are zero items at all" },
+    { "scenario": "detectSustainedBreach requires an unbroken streak of exactly requiredConsecutive breaches from the newest snapshot backward -- a single blip or a broken streak never sustains" },
+    { "scenario": "detectSustainedBreach handles a snapshot history shorter than requiredConsecutive defensively (never sustains)" },
+    { "scenario": "gauge-registry.test.js's entry-count assertion updated from 7 to 8, sorted-id list includes 'recursion-governor-ratio', enabled:true, ownerRole:'chairman', resolvable detectorFn" }
+  ],
+  "acceptance_criteria": [
+    "All 3 FRs traced to file:line in the diff",
+    "The 7 pre-existing gauge-registry entries and their own tests are unmodified in behavior -- purely additive",
+    "lib/fleet/exec-email-alignment.mjs's isMetaSd is consumed read-only, zero modifications",
+    "All 3 new detectors (computeRecursionRatio, isBandBreach, detectSustainedBreach) are pure functions independently unit-testable without a DB round-trip",
+    "No new migration -- codebase_health_snapshots is reused as-is",
+    "gauge-registry.test.js and recursion-governor.test.js both pass; existing governance suite passes unmodified"
+  ],
+  "risks": [
+    {
+      "risk": "The declared band (maxRatio=3, requiredConsecutive=3) is an initial, reasoned default with no prior chairman-specified number to anchor against",
+      "impact": "low",
+      "likelihood": "medium",
+      "mitigation": "Both constants are named, single-source-of-truth values in the new module (not scattered magic numbers) so a future SD can retune them from real observed data with a one-line change; the gauge fails open (never trips) on any query error, matching every other gauge-registry entry's contract"
+    },
+    {
+      "risk": "codebase_health_snapshots could accumulate unbounded rows over time as every gauge-runner tick appends one more dimension='recursion-governor-ratio' row",
+      "impact": "low",
+      "likelihood": "low",
+      "mitigation": "fetchRecentSnapshots only ever reads the last N (requiredConsecutive, small) rows via an ORDER BY scanned_at DESC LIMIT N query -- unbounded growth affects storage, not correctness or read latency; matches the existing gauge_runner_heartbeat dimension's own already-accepted growth pattern in the same table"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "scripts/gauge-runner.mjs (1 new registry entry) -- existing cron/duty-loop cadence, no new scheduling infra",
+      "chairman-facing signal via the existing feedback-table routeFinding pipeline when sustained breach trips, same as every other gauge-registry entry"
+    ],
+    "dependencies": [
+      "lib/fleet/exec-email-alignment.mjs's isMetaSd (existing, read-only)",
+      "lib/governance/gauge-registry.js, scripts/gauge-runner.mjs (existing invariant-gauge framework, additively extended)",
+      "codebase_health_snapshots (existing table, read+write -- already written by gauge-runner's own heartbeat)",
+      "strategic_directives_v2, quick_fixes (existing tables, read-only)"
+    ],
+    "data_contracts": ["No schema changes"],
+    "runtime_config": ["None -- no new env vars; maxRatio/requiredConsecutive/windowDays are named constants in the new module"],
+    "observability_rollout": [
+      "Sustained-breach findings surface through the existing gauge-runner -> feedback table -> chairman pipeline, same as the stale-tree entry (also ownerRole:'chairman')",
+      "Every gauge-runner tick's ratio reading is itself now durable evidence in codebase_health_snapshots, independent of whether it breaches -- the chairman (or a future dashboard) can query the raw trend directly"
+    ]
+  },
+  "implementation_approach": {
+    "phases": [
+      "Phase 1: FR-1 pure detectors (computeRecursionRatio, isBandBreach, detectSustainedBreach) in lib/governance/recursion-governor.js",
+      "Phase 2: FR-2 gauge-registry.js entry + gauge-runner.mjs resolver wiring (fetchThroughputItems, fetchRecentSnapshots, writeThroughputSnapshot)",
+      "Phase 3: FR-3 unit tests (new + gauge-registry.test.js extension)"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run computeRecursionRatio against a fixture of 3 meta items and 1 product item", "expected_outcome": "meta=3, product=1, ratio=3.0" },
+    { "step_number": 2, "instruction": "Run isBandBreach against ratio=3.0 with maxRatio=3, then against ratio=4.0", "expected_outcome": "First call: breach=false (at, not over, the band); second call: breach=true" },
+    { "step_number": 3, "instruction": "Run detectSustainedBreach against a fixture of [breach, breach, breach, pass] (newest first) with requiredConsecutive=3", "expected_outcome": "sustained=true, streak=3" },
+    { "step_number": 4, "instruction": "Run node scripts/gauge-runner.mjs --json against a live/dev DB", "expected_outcome": "GAUGE line prints for 'recursion-governor-ratio' alongside the 7 existing ids, with no thrown errors, and a new codebase_health_snapshots row is written" },
+    { "step_number": 5, "instruction": "Run npx vitest run tests/unit/governance/", "expected_outcome": "All governance tests pass, including the updated gauge-registry.test.js counts (8)" }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-009-LEAF-RECURSION-001"
+  }
+}

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -103,4 +103,14 @@ export const GAUGE_REGISTRY = [
     prevent: 'SD-LEO-INFRA-009-LEAF-WORK-001 (C-009 leaf 5) — this gauge itself is the durable detection of the Solomon-never-dispatches boundary.',
     enabled: true,
   },
+  {
+    id: 'recursion-governor-ratio',
+    name: 'Sustained meta-to-product throughput breach (chairman taper rule)',
+    detectorFn: 'recursion-governor-ratio',
+    thresholdConfig: { tripWhen: (result) => (result?.count || 0) > 0 },
+    ownerRole: 'chairman',
+    remediation: 'Self-improvement (meta) throughput has sustainably outpaced product throughput — review the belt for over-indexing on harness/infra work vs shippable product SDs and taper meta-work back toward the declared band.',
+    prevent: 'SD-LEO-INFRA-009-LEAF-RECURSION-001 (C-009 leaf 4) — this gauge itself is the durable, KPI-owned detection of the taper rule; a genuine fix is sustained discipline in SD selection, not this gauge.',
+    enabled: true,
+  },
 ];

--- a/lib/governance/recursion-governor.js
+++ b/lib/governance/recursion-governor.js
@@ -1,0 +1,128 @@
+/**
+ * Recursion governor (SD-LEO-INFRA-009-LEAF-RECURSION-001)
+ *
+ * Generalizes the chairman taper rule -- self-improvement (meta) throughput must decline toward
+ * solo-operator launch relative to product throughput -- from an ad-hoc exec-summary email line
+ * (lib/fleet/exec-email-alignment.mjs) into a KPI-owned gauge with a declared band and an alert
+ * only on SUSTAINED breach, not a single-tick blip. Reuses lib/fleet/exec-email-alignment.mjs's
+ * isMetaSd() read-only -- zero modifications to that module.
+ *
+ * @module lib/governance/recursion-governor
+ */
+
+import { isMetaSd } from '../fleet/exec-email-alignment.mjs';
+
+/** Initial declared band: >3 meta items shipped per 1 product item is a taper-rule breach. Named,
+ *  single-source-of-truth constant -- retune from observed data with a one-line change. */
+export const DEFAULT_MAX_RATIO = 3;
+
+/** A breach must repeat this many consecutive gauge-runner ticks (newest-first) before it's
+ *  "sustained" -- a single blip never trips the alert. */
+export const DEFAULT_REQUIRED_CONSECUTIVE = 3;
+
+/** Rolling window (days) of completed throughput considered per tick. */
+export const DEFAULT_WINDOW_DAYS = 30;
+
+/**
+ * Pure: classify completed items into meta vs product and compute the ratio.
+ * @param {Array<{key: string}>} items
+ * @param {{windowDays?: number}} [opts]
+ * @returns {{meta: number, product: number, ratio: (number|null), windowDays: number}}
+ */
+export function computeRecursionRatio(items, { windowDays = DEFAULT_WINDOW_DAYS } = {}) {
+  const rows = Array.isArray(items) ? items : [];
+  let meta = 0, product = 0;
+  for (const r of rows) (isMetaSd(r && r.key) ? meta++ : product++);
+  const ratio = product > 0 ? meta / product : null;
+  return { meta, product, ratio, windowDays };
+}
+
+/**
+ * Pure: does this tick's ratio breach the declared band? All-meta/zero-product is the worst case
+ * of the taper rule and breaches even though ratio is null (no divide-by-zero to hide behind).
+ * @param {{meta: number, product: number, ratio: (number|null)}} result
+ * @param {{maxRatio?: number}} [opts]
+ * @returns {boolean}
+ */
+export function isBandBreach(result, { maxRatio = DEFAULT_MAX_RATIO } = {}) {
+  const meta = result?.meta || 0;
+  const product = result?.product || 0;
+  if (product === 0) return meta > 0;
+  return typeof result?.ratio === 'number' && result.ratio > maxRatio;
+}
+
+/**
+ * Pure: given past gauge-runner snapshots (newest first, each carrying a boolean `breach`), is the
+ * breach SUSTAINED -- an unbroken streak of requiredConsecutive breaches counting from the newest?
+ * @param {Array<{breach: boolean}>} recentSnapshots
+ * @param {{requiredConsecutive?: number}} [opts]
+ * @returns {{sustained: boolean, streak: number}}
+ */
+export function detectSustainedBreach(recentSnapshots, { requiredConsecutive = DEFAULT_REQUIRED_CONSECUTIVE } = {}) {
+  const rows = Array.isArray(recentSnapshots) ? recentSnapshots : [];
+  let streak = 0;
+  for (const s of rows) {
+    if (s && s.breach) streak++;
+    else break;
+  }
+  return { sustained: streak >= requiredConsecutive, streak };
+}
+
+/**
+ * I/O: completed strategic_directives_v2 + quick_fixes rows within the rolling window, normalized
+ * to {key}. Both tables' key columns (sd_key / id) already carry the QF-/SD-LEO- prefixes isMetaSd
+ * classifies on -- no separate classifier needed for quick_fixes.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{windowDays?: number}} [opts]
+ * @returns {Promise<Array<{key: string}>>}
+ */
+export async function fetchThroughputItems(supabase, { windowDays = DEFAULT_WINDOW_DAYS } = {}) {
+  const sinceIso = new Date(Date.now() - windowDays * 24 * 3600 * 1000).toISOString();
+
+  const [sdResult, qfResult] = await Promise.all([
+    supabase.from('strategic_directives_v2').select('sd_key').eq('status', 'completed').gte('completion_date', sinceIso),
+    supabase.from('quick_fixes').select('id').eq('status', 'completed').gte('completed_at', sinceIso),
+  ]);
+  if (sdResult.error) throw new Error('fetchThroughputItems (SD) failed: ' + sdResult.error.message);
+  if (qfResult.error) throw new Error('fetchThroughputItems (QF) failed: ' + qfResult.error.message);
+
+  const sdItems = (sdResult.data || []).map((r) => ({ key: r.sd_key }));
+  const qfItems = (qfResult.data || []).map((r) => ({ key: r.id }));
+  return [...sdItems, ...qfItems];
+}
+
+/**
+ * I/O: the last `limit` codebase_health_snapshots rows for a dimension, newest first, normalized
+ * to {breach}. Reuses the EXISTING table gauge-runner.mjs's own heartbeat already writes to.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{dimension: string, limit?: number}} opts
+ * @returns {Promise<Array<{breach: boolean}>>}
+ */
+export async function fetchRecentSnapshots(supabase, { dimension, limit = DEFAULT_REQUIRED_CONSECUTIVE }) {
+  const { data, error } = await supabase
+    .from('codebase_health_snapshots')
+    .select('metadata')
+    .eq('dimension', dimension)
+    .order('scanned_at', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error('fetchRecentSnapshots failed: ' + error.message);
+  return (data || []).map((r) => ({ breach: Boolean(r?.metadata?.breach) }));
+}
+
+/**
+ * I/O: append this tick's ratio reading as a new codebase_health_snapshots row, extending the
+ * durable evidence log that fetchRecentSnapshots reads back from on the NEXT tick.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{dimension: string, ratioResult: object, breach: boolean}} opts
+ */
+export async function writeThroughputSnapshot(supabase, { dimension, ratioResult, breach }) {
+  const { error } = await supabase.from('codebase_health_snapshots').insert({
+    dimension,
+    target_application: 'EHG_Engineer',
+    score: typeof ratioResult?.ratio === 'number' ? ratioResult.ratio : 0,
+    findings: [{ ...ratioResult, breach }],
+    trend_direction: breach ? 'declining' : 'stable',
+    metadata: { ...ratioResult, breach },
+  });
+  if (error) throw new Error('writeThroughputSnapshot failed: ' + error.message);
+}

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -38,6 +38,16 @@ import {
   detectRoleDispatched,
   fetchSdBoundaryRows,
 } from '../lib/governance/work-boundary-gauges.js';
+import {
+  computeRecursionRatio,
+  isBandBreach,
+  detectSustainedBreach,
+  fetchThroughputItems,
+  fetchRecentSnapshots,
+  writeThroughputSnapshot,
+} from '../lib/governance/recursion-governor.js';
+
+const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
 
 // relay-drop-gauge.cjs, adam-identity.cjs, solomon-identity.cjs are CommonJS -- createRequire is
 // this codebase's established ESM-import-CJS seam (mirrors gauge-unranked-claimable-leaves.mjs's
@@ -111,6 +121,15 @@ function buildDetectorResolvers(supabase) {
     'solomon-dispatched-sd': async () => {
       const solomons = await fetchAllSolomons(supabase);
       return detectRoleDispatched(await boundaryRows(), solomons.map((s) => s.session_id));
+    },
+    'recursion-governor-ratio': async () => {
+      const items = await fetchThroughputItems(supabase);
+      const ratioResult = computeRecursionRatio(items);
+      const breach = isBandBreach(ratioResult);
+      await writeThroughputSnapshot(supabase, { dimension: RECURSION_GOVERNOR_DIMENSION, ratioResult, breach });
+      const recent = await fetchRecentSnapshots(supabase, { dimension: RECURSION_GOVERNOR_DIMENSION });
+      const { sustained, streak } = detectSustainedBreach(recent);
+      return { count: sustained ? 1 : 0, ...ratioResult, breach, streak };
     },
   };
 }

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -19,14 +19,14 @@ import {
 const VALID_FEEDBACK_TYPES = ['issue', 'enhancement'];
 
 describe('GAUGE_REGISTRY shape', () => {
-  it('exports exactly 7 seed entries (4 prior + 3 work-boundary gauges, SD-LEO-INFRA-009-LEAF-WORK-001)', () => {
-    expect(GAUGE_REGISTRY).toHaveLength(7);
+  it('exports exactly 8 seed entries (7 prior + recursion-governor-ratio, SD-LEO-INFRA-009-LEAF-RECURSION-001)', () => {
+    expect(GAUGE_REGISTRY).toHaveLength(8);
   });
 
-  it('all 7 entries are activated — no stub entries remain', () => {
+  it('all 8 entries are activated — no stub entries remain', () => {
     const live = GAUGE_REGISTRY.filter((e) => e.enabled === true);
     const stubs = GAUGE_REGISTRY.filter((e) => e.enabled === false);
-    expect(live).toHaveLength(7);
+    expect(live).toHaveLength(8);
     expect(stubs).toHaveLength(0);
   });
 
@@ -84,12 +84,13 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
     expect(selectEnabledEntries(undefined)).toEqual([]);
   });
 
-  it('the real GAUGE_REGISTRY selects all 7 entries now that every stub is activated', () => {
+  it('the real GAUGE_REGISTRY selects all 8 entries now that every stub is activated', () => {
     const selected = selectEnabledEntries(GAUGE_REGISTRY);
-    expect(selected).toHaveLength(7);
+    expect(selected).toHaveLength(8);
     expect(selected.map((e) => e.id).sort()).toEqual([
       'adam-claimed-or-built-sd',
       'coordinator-sourced-sd',
+      'recursion-governor-ratio',
       'relay-drop',
       'ship-witness-unwitnessed-merge',
       'solomon-dispatched-sd',
@@ -115,6 +116,15 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
       expect(entry.thresholdConfig.tripWhen({ count: 1 })).toBe(true);
       expect(entry.thresholdConfig.tripWhen({ count: 0 })).toBe(false);
     }
+  });
+
+  it('SD-LEO-INFRA-009-LEAF-RECURSION-001: the recursion-governor entry has a resolvable detectorFn, ownerRole chairman, and the >0-count tripWhen convention', () => {
+    const entry = GAUGE_REGISTRY.find((e) => e.id === 'recursion-governor-ratio');
+    expect(entry).toBeTruthy();
+    expect(entry.detectorFn).toBe('recursion-governor-ratio');
+    expect(entry.ownerRole).toBe('chairman');
+    expect(entry.thresholdConfig.tripWhen({ count: 1 })).toBe(true);
+    expect(entry.thresholdConfig.tripWhen({ count: 0 })).toBe(false);
   });
 });
 

--- a/tests/unit/governance/recursion-governor.test.js
+++ b/tests/unit/governance/recursion-governor.test.js
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for lib/governance/recursion-governor.js's pure detectors.
+ *
+ * SD-LEO-INFRA-009-LEAF-RECURSION-001 (C-009 leaf 4): recursion governor - self-improvement
+ * throughput as a KPI-owned ratio of product throughput (the chairman taper rule formalized).
+ *
+ * @module tests/unit/governance/recursion-governor.test.js
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeRecursionRatio,
+  isBandBreach,
+  detectSustainedBreach,
+} from '../../../lib/governance/recursion-governor.js';
+
+describe('computeRecursionRatio', () => {
+  it('classifies SD-LEO-*, SD-LEARN-FIX-*, SD-MAN-INFRA-*, QF-* as meta and everything else as product', () => {
+    const items = [
+      { key: 'SD-LEO-INFRA-FOO-001' },
+      { key: 'SD-LEARN-FIX-BAR-001' },
+      { key: 'SD-MAN-INFRA-BAZ-001' },
+      { key: 'QF-20260703-001' },
+      { key: 'SD-MARKETLENS-VENTURE-001' },
+    ];
+    const result = computeRecursionRatio(items, { windowDays: 30 });
+    expect(result.meta).toBe(4);
+    expect(result.product).toBe(1);
+    expect(result.ratio).toBe(4);
+    expect(result.windowDays).toBe(30);
+  });
+
+  it('returns ratio=null (not a divide-by-zero) when product=0 and meta>0', () => {
+    const items = [{ key: 'QF-1' }, { key: 'QF-2' }];
+    const result = computeRecursionRatio(items);
+    expect(result.meta).toBe(2);
+    expect(result.product).toBe(0);
+    expect(result.ratio).toBeNull();
+  });
+
+  it('handles an empty item list defensively', () => {
+    expect(computeRecursionRatio([])).toMatchObject({ meta: 0, product: 0, ratio: null });
+    expect(computeRecursionRatio(undefined)).toMatchObject({ meta: 0, product: 0, ratio: null });
+  });
+});
+
+describe('isBandBreach', () => {
+  it('breaches when ratio exceeds maxRatio', () => {
+    expect(isBandBreach({ meta: 4, product: 1, ratio: 4 }, { maxRatio: 3 })).toBe(true);
+  });
+
+  it('does not breach when ratio is at or below maxRatio', () => {
+    expect(isBandBreach({ meta: 3, product: 1, ratio: 3 }, { maxRatio: 3 })).toBe(false);
+    expect(isBandBreach({ meta: 1, product: 1, ratio: 1 }, { maxRatio: 3 })).toBe(false);
+  });
+
+  it('breaches on the all-meta/zero-product edge case even though ratio is null', () => {
+    expect(isBandBreach({ meta: 2, product: 0, ratio: null }, { maxRatio: 3 })).toBe(true);
+  });
+
+  it('does not breach when there are zero items at all', () => {
+    expect(isBandBreach({ meta: 0, product: 0, ratio: null }, { maxRatio: 3 })).toBe(false);
+  });
+
+  it('uses the default maxRatio when no options are supplied', () => {
+    expect(isBandBreach({ meta: 10, product: 1, ratio: 10 })).toBe(true);
+    expect(isBandBreach({ meta: 2, product: 1, ratio: 2 })).toBe(false);
+  });
+});
+
+describe('detectSustainedBreach', () => {
+  it('is sustained only after an unbroken streak of exactly requiredConsecutive breaches from newest', () => {
+    const snapshots = [{ breach: true }, { breach: true }, { breach: true }, { breach: false }];
+    const result = detectSustainedBreach(snapshots, { requiredConsecutive: 3 });
+    expect(result.sustained).toBe(true);
+    expect(result.streak).toBe(3);
+  });
+
+  it('is NOT sustained on a single blip (one breach then a pass)', () => {
+    const snapshots = [{ breach: true }, { breach: false }, { breach: true }, { breach: true }];
+    const result = detectSustainedBreach(snapshots, { requiredConsecutive: 3 });
+    expect(result.sustained).toBe(false);
+    expect(result.streak).toBe(1);
+  });
+
+  it('is NOT sustained when the streak breaks partway through', () => {
+    const snapshots = [{ breach: true }, { breach: true }, { breach: false }, { breach: true }];
+    const result = detectSustainedBreach(snapshots, { requiredConsecutive: 3 });
+    expect(result.sustained).toBe(false);
+    expect(result.streak).toBe(2);
+  });
+
+  it('handles a snapshot history shorter than requiredConsecutive defensively (never sustains)', () => {
+    const snapshots = [{ breach: true }, { breach: true }];
+    const result = detectSustainedBreach(snapshots, { requiredConsecutive: 3 });
+    expect(result.sustained).toBe(false);
+    expect(result.streak).toBe(2);
+  });
+
+  it('handles an empty/undefined snapshot history defensively', () => {
+    expect(detectSustainedBreach([])).toEqual({ sustained: false, streak: 0 });
+    expect(detectSustainedBreach(undefined)).toEqual({ sustained: false, streak: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- C-009 leaf 4: generalizes the chairman taper rule (meta/self-improvement throughput must decline relative to product throughput) from an ad-hoc exec-summary email line into a durable gauge-registry entry.
- New `lib/governance/recursion-governor.js`: pure `computeRecursionRatio`/`isBandBreach`/`detectSustainedBreach` + I/O helpers, reusing `lib/fleet/exec-email-alignment.mjs`'s `isMetaSd` read-only.
- 1 new additive `GAUGE_REGISTRY` entry (`recursion-governor-ratio`, `ownerRole: chairman`), declared band (maxRatio=3), alert only on sustained breach (3 consecutive gauge-runner ticks) -- not a single blip.
- Reuses the EXISTING `codebase_health_snapshots` table as the rolling-history store -- no new migration.
- 7 pre-existing gauge-registry entries untouched.

## Test plan
- [x] `npx vitest run tests/unit/governance/` -- 467/467 pass
- [x] `npx tsc --noEmit` -- clean
- [x] `node scripts/gauge-runner.mjs --json` against live DB -- all 8 gauges execute, new snapshot row confirmed written
- [x] TESTING/VALIDATION/REGRESSION/RETRO sub-agents all PASS with fresh evidence rows

SD-LEO-INFRA-009-LEAF-RECURSION-001