### PR TITLE
fix(QF-20260703-742): /leo complete tail resolves the GLOBAL is_working_on spotlight, not the calling session's claim - post-completion runs against another session's SD

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-311",
+  "sdKey": "QF-20260703-742",
   "workType": "QF",
-  "workKey": "QF-20260703-311",
-  "expectedBranch": "qf/QF-20260703-311",
-  "createdAt": "2026-07-03T22:33:05.293Z",
+  "workKey": "QF-20260703-742",
+  "expectedBranch": "qf/QF-20260703-742",
+  "createdAt": "2026-07-03T22:42:02.622Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"

--- a/scripts/get-working-on-sd.js
+++ b/scripts/get-working-on-sd.js
@@ -103,18 +103,56 @@ async function checkResumeEligibility(sdUuid, currentPhase) {
   };
 }
 
+const SD_COLUMNS = 'id, sd_key, title, status, priority, is_working_on, claiming_session_id, created_at, current_phase, progress, description';
+
 async function getWorkingOnSD() {
   try {
-    // SD-LEO-INFRA-CLAIM-GUARD-001: Prefer claiming_session_id, fall back to is_working_on
-    const { data: workingOn, error: workingError } = await supabase
-      .from('strategic_directives_v2')
-      .select('id, sd_key, title, status, priority, is_working_on, claiming_session_id, created_at, current_phase, progress, description')
-      .or('claiming_session_id.not.is.null,is_working_on.eq.true')
-      .lt('progress', 100);  // Less than 100% complete
+    // QF-20260703-742: resolve THIS session's own claim first. The prior global
+    // spotlight query below has no session filter, so under concurrency it could
+    // silently return another session's SD (e.g. document/heal/learn running
+    // against the wrong SD's data).
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    let workingOn = null;
 
-    if (workingError) {
-      console.error('Error querying working_on SD:', workingError);
-      return null;
+    if (sessionId) {
+      const { data: ownClaim, error: ownError } = await supabase
+        .from('strategic_directives_v2')
+        .select(SD_COLUMNS)
+        .eq('claiming_session_id', sessionId)
+        .lt('progress', 100);
+      if (!ownError && ownClaim && ownClaim.length > 0) {
+        workingOn = ownClaim;
+      }
+    }
+
+    if (!workingOn) {
+      // No claim attributable to this session — the global spotlight is only
+      // unambiguous when this is the sole live session in the fleet.
+      const { count: liveCount, error: liveError } = await supabase
+        .from('v_active_sessions')
+        .select('session_id', { count: 'exact', head: true })
+        .eq('computed_status', 'active');
+
+      if (liveError || liveCount !== 1) {
+        console.log('\n❌ Cannot resolve a Strategic Directive for this session unambiguously.');
+        console.log(`   No SD claimed by CLAUDE_SESSION_ID=${sessionId || '(unset)'}, and`);
+        console.log(`   ${liveError ? 'the live-session count is unknown' : `${liveCount} other session(s) are active`} — the global spotlight would be ambiguous under concurrency.`);
+        console.log('   Claim your SD via sd-start.js, or resolve manually.\n');
+        return null;
+      }
+
+      // SD-LEO-INFRA-CLAIM-GUARD-001: Prefer claiming_session_id, fall back to is_working_on
+      const { data: spotlight, error: workingError } = await supabase
+        .from('strategic_directives_v2')
+        .select(SD_COLUMNS)
+        .or('claiming_session_id.not.is.null,is_working_on.eq.true')
+        .lt('progress', 100);  // Less than 100% complete
+
+      if (workingError) {
+        console.error('Error querying working_on SD:', workingError);
+        return null;
+      }
+      workingOn = spotlight;
     }
 
     if (workingOn && workingOn.length > 0) {

--- a/tests/unit/get-working-on-sd-session-scoped.test.js
+++ b/tests/unit/get-working-on-sd-session-scoped.test.js
@@ -1,0 +1,100 @@
+/**
+ * Regression test for QF-20260703-742: getWorkingOnSD() resolved the GLOBAL
+ * is_working_on/claiming_session_id spotlight with no session filter, so under
+ * concurrency the /leo complete post-completion tail could silently run
+ * document/heal/learn/completion-flags against ANOTHER session's SD. It must
+ * now resolve THIS session's own claim first, only falling back to the
+ * spotlight when exactly one session is live, and refuse otherwise.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+function buildSupabaseMock({ ownClaimResult, liveCountResult, spotlightResult }) {
+  return {
+    from(table) {
+      if (table === 'v_active_sessions') {
+        return { select: () => ({ eq: () => Promise.resolve(liveCountResult) }) };
+      }
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: (col) => {
+              if (col === 'claiming_session_id') {
+                return { lt: () => Promise.resolve(ownClaimResult) };
+              }
+              throw new Error(`Unexpected eq column: ${col}`);
+            },
+            or: () => ({ lt: () => Promise.resolve(spotlightResult) }),
+          }),
+        };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: () => ({
+            eq: () => ({ order: () => ({ limit: () => Promise.resolve({ data: [], error: null }) }) }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
+
+let mockSupabase;
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => mockSupabase,
+}));
+
+describe('QF-20260703-742: session-scoped getWorkingOnSD resolution', () => {
+  const priorSessionId = process.env.CLAUDE_SESSION_ID;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (priorSessionId === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = priorSessionId;
+  });
+
+  it('resolves the calling session\'s own claim without touching the global spotlight', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-mine';
+    mockSupabase = buildSupabaseMock({
+      ownClaimResult: { data: [{ id: 'sd-1', sd_key: 'SD-MINE', title: 'Mine', progress: 40, claiming_session_id: 'session-mine' }], error: null },
+      liveCountResult: { count: null, error: new Error('should not be called') },
+      spotlightResult: { data: null, error: new Error('should not be called') },
+    });
+
+    const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');
+    const result = await getWorkingOnSD();
+
+    expect(result.sd_key).toBe('SD-MINE');
+  });
+
+  it('falls back to the global spotlight only when exactly one session is live', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-mine';
+    mockSupabase = buildSupabaseMock({
+      ownClaimResult: { data: [], error: null },
+      liveCountResult: { count: 1, error: null },
+      spotlightResult: { data: [{ id: 'sd-2', sd_key: 'SD-SOLO', title: 'Solo', progress: 10, claiming_session_id: 'session-mine' }], error: null },
+    });
+
+    const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');
+    const result = await getWorkingOnSD();
+
+    expect(result.sd_key).toBe('SD-SOLO');
+  });
+
+  it('refuses (returns null) rather than guessing when no own claim exists and multiple sessions are live', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-mine';
+    mockSupabase = buildSupabaseMock({
+      ownClaimResult: { data: [], error: null },
+      liveCountResult: { count: 3, error: null },
+      spotlightResult: { data: null, error: new Error('must not be reached') },
+    });
+
+    const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');
+    const result = await getWorkingOnSD();
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260703-742

**Type:** bug
**Severity:** high

### Issue Description
Worker-verified live (Bravo 4af85f4b on J1, 20:37Z; coordinator priority #1): the /leo complete post-completion tail resolves its SD via scripts/get-working-on-sd.js --id-only, which returns the GLOBAL is_working_on spotlight with NO session filter (verified: getWorkingOnSD() line ~204 area takes no session predicate) - so document/heal/learn/completion-flags can silently run against ANOTHER session's SD. Live specimen: resolver returned SD-LEO-INFRA-ENABLE-TRI-PARTY-001 while the caller's claimed+completed SD was J1. With ~9 concurrent workers, every completion rolls these dice. Fix: the tail resolves the SESSION's own claim first (strategic_directives_v2 claiming_session_id = CLAUDE_SESSION_ID), falling back to the spotlight ONLY when exactly one session is live; refuse with a clear error when neither resolves unambiguously.


### Expected Behavior
Post-completion tail always operates on the calling session's own SD

### Actual Behavior
Tail ran against a different session's spotlight SD (live specimen on J1)

### Changes
- **Files Changed:** 3
  - .worktree.json
  - scripts/get-working-on-sd.js
  - tests/unit/get-working-on-sd-session-scoped.test.js
- **LOC:** 152 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Verified via 3 new unit tests (own-claim resolution, single-live-session spotlight fallback, multi-session refusal) plus full smoke suite. Also caught a live specimen of the QF-311 husky-hooks bug in this same worktree (pre-dated that fix, hooks were never provisioned) -- re-provisioned via npx husky and retroactively verified the unvetted commit via manual eslint + diff review before pushing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol