### PR TITLE
fix(QF-20260703-894): STORIES sub-agent derives stories from functional_requirements

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,10 +1,9 @@
 {
-  "sdKey": "QF-20260703-742",
+  "sdKey": "QF-20260703-894",
   "workType": "QF",
-  "workKey": "QF-20260703-742",
-  "expectedBranch": "qf/QF-20260703-742",
-  "createdAt": "2026-07-03T22:42:02.622Z",
+  "workKey": "QF-20260703-894",
+  "expectedBranch": "qf/QF-20260703-894",
+  "createdAt": "2026-07-03T22:43:20.067Z",
   "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
-  "baseRef": "origin/main"
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/sub-agents/modules/stories/execute.js
+++ b/lib/sub-agents/modules/stories/execute.js
@@ -234,15 +234,25 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
     return null;
   }
 
-  if (!prd.acceptance_criteria || prd.acceptance_criteria.length === 0) {
-    console.log('   PRD has no acceptance criteria');
+  // QF-20260703-894: derive story-source criteria from functional_requirements (rich,
+  // FR-specific descriptions) rather than acceptance_criteria (thin build-verification
+  // checks) -- the latter produced ~31%-scoring fake stories needing a manual delete+
+  // re-invoke cycle every SD. Falls back to acceptance_criteria only when
+  // functional_requirements is empty (no regression for PRDs authored before FRs were
+  // mandatory).
+  const storySourceCriteria = (prd.functional_requirements && prd.functional_requirements.length > 0)
+    ? prd.functional_requirements.map(fr => fr.title || fr.description || String(fr))
+    : (prd.acceptance_criteria || []);
+
+  if (!storySourceCriteria || storySourceCriteria.length === 0) {
+    console.log('   PRD has no functional requirements or acceptance criteria');
     results.verdict = 'WARNING';
     results.confidence = 50;
-    results.warnings = ['No acceptance criteria in PRD to generate user stories from.'];
+    results.warnings = ['No functional requirements or acceptance criteria in PRD to generate user stories from.'];
     return null;
   }
 
-  console.log(`   Found ${prd.acceptance_criteria.length} acceptance criteria`);
+  console.log(`   Found ${storySourceCriteria.length} story-source criteria`);
 
   // Check if LLM generation is available
   const llmAvailable = isLLMGenerationAvailable();
@@ -270,7 +280,7 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
   } catch { /* fail-open: leave null -> UI scaffold (no regression) */ }
 
   // Use batch LLM generation for efficiency
-  const batchResult = await generateStoriesBatch(prd.acceptance_criteria, prd, { sdKey }, { sd_type: sdTypeForScaffold });
+  const batchResult = await generateStoriesBatch(storySourceCriteria, prd, { sdKey }, { sd_type: sdTypeForScaffold });
   console.log(`   Generation method: ${batchResult.generated_by}`);
 
   if (batchResult.gaps && batchResult.gaps.length > 0) {
@@ -281,8 +291,8 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
     results.detected_gaps = batchResult.gaps;
   }
 
-  for (let i = 0; i < prd.acceptance_criteria.length; i++) {
-    const criterion = prd.acceptance_criteria[i];
+  for (let i = 0; i < storySourceCriteria.length; i++) {
+    const criterion = storySourceCriteria[i];
     const storyKey = `${sdKey}:US-${String(i + 1).padStart(3, '0')}`;
 
     // Get story content from batch results or generate individually

--- a/tests/unit/sub-agents/stories-execute-fr-source.test.js
+++ b/tests/unit/sub-agents/stories-execute-fr-source.test.js
@@ -1,0 +1,38 @@
+// QF-20260703-894: STORIES sub-agent auto-invocation must derive stories from
+// prd.functional_requirements (rich, FR-specific) rather than prd.acceptance_criteria
+// (thin build-verification checks) -- the latter produced ~31%-scoring fake stories
+// requiring a manual delete+re-invoke cycle every SD. Static-pattern assertions on
+// source ordering, same convention as create-quick-fix-dedup-gate.test.js (avoids
+// mocking the full Supabase + LLM generation chain).
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../lib/sub-agents/modules/stories/execute.js');
+
+describe('QF-20260703-894: createStoriesFromPRD derives criteria from functional_requirements', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  it('defines storySourceCriteria preferring functional_requirements, falling back to acceptance_criteria', () => {
+    expect(code).toMatch(/const storySourceCriteria = \(prd\.functional_requirements && prd\.functional_requirements\.length > 0\)/);
+    expect(code).toMatch(/\?\s*prd\.functional_requirements\.map\(fr => fr\.title \|\| fr\.description \|\| String\(fr\)\)/);
+    expect(code).toMatch(/:\s*\(prd\.acceptance_criteria \|\| \[\]\)/);
+  });
+
+  it('the batch generation call and the story-build loop both use storySourceCriteria, not the raw PRD field', () => {
+    expect(code).toMatch(/generateStoriesBatch\(storySourceCriteria,/);
+    expect(code).not.toMatch(/generateStoriesBatch\(prd\.acceptance_criteria,/);
+    expect(code).toMatch(/for \(let i = 0; i < storySourceCriteria\.length; i\+\+\)/);
+    expect(code).toMatch(/const criterion = storySourceCriteria\[i\];/);
+  });
+
+  it('storySourceCriteria is defined before its first use (generateStoriesBatch call)', () => {
+    const defIdx = code.indexOf('const storySourceCriteria');
+    const useIdx = code.indexOf('generateStoriesBatch(storySourceCriteria,');
+    expect(defIdx).toBeGreaterThan(0);
+    expect(useIdx).toBeGreaterThan(0);
+    expect(defIdx).toBeLessThan(useIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- Re-points the STORIES sub-agent's auto-invocation seam (lib/sub-agents/modules/stories/execute.js) from prd.acceptance_criteria to prd.functional_requirements when populated, falling back to acceptance_criteria for older PRDs
- Fixes the recurring (~6 specimens) ~31%-scoring fake-story generation that required a manual delete+re-invoke cycle every SD

## Test plan
- [x] New unit test (tests/unit/sub-agents/stories-execute-fr-source.test.js) verifies the source-ordering and fallback logic
- [x] Full sub-agents test directory (142 tests, 13 files) passes
- [x] Full unit suite: 9 pre-existing failures unrelated to this change (worktree hygiene/stage-config drift), 0 regressions from this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)