### PR TITLE
fix(SD-LEO-INFRA-START-INSTALL-SKIP-001): install-skip decides from worktree path, not coordinator repo (5th recurrence)

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-START-INSTALL-SKIP-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-START-INSTALL-SKIP-001.json
@@ -1,0 +1,86 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Decide the install skip/require verdict from the RESOLVED WORKTREE path, not the coordinator repo",
+      "description": "Root cause (found by direct code archaeology, not guesswork): scripts/sd-start.js's install-decision block called `const installRepoRoot = getRepoRoot();` -- a function that ALWAYS resolves the coordinator repo (EHG_Engineer) root regardless of cwd, deliberately stripping any `.worktrees/<key>/` suffix. This was a DELIBERATE prior fix (SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 FR5, comment still in the diff being replaced) on the assumption that 'worktrees symlink node_modules from there' -- true ONLY under the old UNCONDITIONAL-junction architecture. SD-LEO-INFRA-SMART-PER-WORKTREE-001 retired that invariant (a worktree can get a REAL isolated node_modules under concurrency, decided by lib/worktree-provision.js's decideWorktreeProvisionMode), and cross-repo venture worktrees (a target repo entirely different from EHG_Engineer, e.g. the 5 recurred specimens SD-MARKETLENS-*-C1/G1/H1/I1/J1) were NEVER covered by the junction assumption in the first place -- checking getRepoRoot() there checks EHG_Engineer's own node_modules, which is essentially always healthy, so the check ALWAYS false-positived 'skip' no matter what the actual target-repo worktree contained. Fix: `installRepoRoot = worktreeInfo.cwd` (the already-resolved worktree path, available a few lines earlier at the `if (worktreeInfo?.success && worktreeInfo.cwd)` guard). fs.existsSync (used by evaluateInstallDecision's canaryPresent check) follows symlinks, so this ONE-LINE change is simultaneously correct for junction-mode worktrees (resolves through to the real files), isolated-mode worktrees (checks the real local directory), and cross-repo worktrees (checks the actual target repo, not the coordinator) -- no repo-type branching needed. evaluateInstallDecision() and composeInstallDecision() in lib/fleet-lock-hash.mjs are NOT modified -- they were already correctly parameterized pure functions; the bug was entirely in what the ONE caller passed as repoRoot."
+    },
+    {
+      "id": "FR-2",
+      "title": "Mandatory e2e/acceptance test driving the REAL evaluateInstallDecision() against REAL temp directories (recurred-family rule)",
+      "description": "Per the recurred-family rule (QF-476 lesson: a fix without a genuine acceptance test bounces again -- this is the 5th specimen, 4 prior logic-only patches already failed): new tests/unit/sd-start-install-decision-worktree-path.test.js drives the actual exported evaluateInstallDecision() (no fs mocking) against real fs.mkdtempSync-created temp directories. Reproduces the EXACT bug directly: a fully-healthy 'coordinator repo' temp dir alongside an empty 'worktree' temp dir -- asserts evaluateInstallDecision({repoRoot: coordinatorDir}) WOULD false-positive skip:true (proving the bug is real and reproducible, not hypothetical), then asserts evaluateInstallDecision({repoRoot: worktreeDir}) correctly returns skip:false. Also covers: node_modules missing but lockfile present (still requires install -- canary check, not just hash), a genuinely healthy worktree (inverse case, must still skip -- no false negative introduced), and an isolated worktree with only a canary and no marker (interrupted isolate-install, must still require install). scripts/sd-start.js itself is NOT unit-testable directly (its `main()` runs unconditionally at module load with no CLI guard, `process.exit()`s on completion) -- the acceptance test targets the exact decision function the script calls with the exact repoRoot values a fix does/doesn't produce, which is the real regression surface."
+    },
+    {
+      "id": "FR-3",
+      "title": "Sweep for other install-decision call sites with the same coordinator-vs-worktree confusion",
+      "description": "Confirmed via grep: evaluateInstallDecision has exactly ONE production caller (scripts/sd-start.js) -- lib/worktree-provision.js and tests are the only other references. Checked every other getRepoRoot() call site touching node_modules/install logic: scripts/session-worktree.js's `provisionWorktreeNodeModulesAuto(result.path, { repoRoot: getRepoRoot() })` is CORRECT (getRepoRoot() there is the JUNCTION TARGET the worktree symlinks TO -- that's what a junction destination is supposed to be, not the same bug). scripts/create-quick-fix.js calls provisionWorktreeNodeModulesAuto with no separate install-decision logic of its own. No other duplicated/confused call site found -- the fix in FR-1 is the complete sweep."
+    },
+    {
+      "id": "FR-4",
+      "title": "SECURITY-RELEVANT: provision git hooks (.husky/_) independently of the dependency-install decision",
+      "description": "Fold-in per Adam (pre-claim 2026-07-03 23:45Z, Alpha-verified on 2 worktrees, worker-signal 59bad7ea-...): `.husky/_` (what core.hooksPath points at) is created ONLY as a side-effect of npm install's `prepare` lifecycle script. On the (common) install-skip fast path, `.husky/_` never gets created, so pre-commit secret scanning / commit-msg checks / pre-push enforcement silently NEVER FIRE for that worktree's commits -- CI-side scanning has held as the backstop so far (no active incident), but this is a live gap. Fix: in scripts/sd-start.js, right after computing the install decision (regardless of decision.skip), check `existsSync(path.join(installRepoRoot, '.husky', '_'))`; if missing, call lib/worktree-provision.js's EXISTING defaultEnsureHuskyHooks(installRepoRoot) (read-only reuse -- already used by provisionWorktreeNodeModules for the worktree-CREATION case; this closes the gap for RESUMED worktrees created before that existed, or where hooks were later wiped). Fail-open (a hook-provisioning failure never blocks sd-start), matching the existing contract of every other advisory step in this block."
+    }
+  ],
+  "technical_requirements": [
+    { "requirement": "No new migration or table" },
+    { "requirement": "lib/fleet-lock-hash.mjs's evaluateInstallDecision/composeInstallDecision are consumed UNCHANGED -- the bug and the fix are entirely in the ONE caller (scripts/sd-start.js), not the pure decision logic" },
+    { "requirement": "lib/worktree-provision.js's defaultEnsureHuskyHooks is consumed read-only (already-shipped helper, reused not reinvented)" },
+    { "requirement": "The FR-1 change is a single-line variable reassignment (installRepoRoot = worktreeInfo.cwd instead of getRepoRoot()) -- every downstream usage (evaluateInstallDecision repoRoot, npm install cwd, writeFleetLockMarker) already references the same `installRepoRoot` variable, so the fix propagates correctly with zero other line changes" }
+  ],
+  "test_scenarios": [
+    { "scenario": "A fully-healthy coordinator-repo path reproduces the historical bug (false-positive skip) when passed as repoRoot -- proves the bug is real, not hypothetical" },
+    { "scenario": "An empty worktree path (no node_modules, no lockfile) correctly requires install when passed as repoRoot" },
+    { "scenario": "A worktree with package-lock.json but no node_modules at all still requires install (canary check catches what a pure hash-only check would miss)" },
+    { "scenario": "A genuinely healthy, freshly-populated worktree still correctly SKIPS install (no false negative introduced by the fix)" },
+    { "scenario": "An isolated worktree with only a canary and no marker (interrupted isolate-install) still requires install" },
+    { "scenario": "defaultEnsureHuskyHooks is callable against a worktree path without throwing (fail-open contract)" }
+  ],
+  "acceptance_criteria": [
+    "All 4 FRs traced to file:line in the diff",
+    "The exact historical bug (coordinator-repo path false-positives skip) is reproduced by a real, non-mocked test, per the recurred-family rule",
+    "lib/fleet-lock-hash.mjs is unmodified -- zero diff",
+    "The fix is a minimal, surgical change (1-line reassignment + independent husky-hook check), not a rewrite of the decision logic (which was already correct)",
+    "Existing tests/unit/fleet-lock-hash.test.js (43 tests) and worktree-provision test suites pass unmodified",
+    "npx tsc --noEmit passes"
+  ],
+  "risks": [
+    {
+      "risk": "This is the 5th recurrence with 4 prior failed fixes -- there is a real chance this fix also misses if the true root cause is something else entirely",
+      "impact": "high",
+      "likelihood": "low",
+      "mitigation": "Unlike the (inferred) prior attempts, this fix is grounded in the ACTUAL code (the FR5 comment explaining the getRepoRoot() choice was found directly, not inferred) and is verified against a test that reproduces the exact historical failure mode on real fs state before asserting the fix. The recurred-family rule's core lesson -- e2e acceptance baked into the spec -- is satisfied by FR-2, not deferred to a future SD."
+    },
+    {
+      "risk": "The husky-hook fast-path check (FR-4) adds an existsSync + possible npx husky spawn on every sd-start invocation where hooks are missing",
+      "impact": "low",
+      "likelihood": "low",
+      "mitigation": "existsSync is a cheap single stat call; npx husky only runs when the check fails (rare -- most worktrees already have hooks from creation-time provisioning), and it already runs in ~2s per the existing defaultEnsureHuskyHooks doc comment. Fail-open -- a failure here never blocks sd-start."
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": ["scripts/sd-start.js (every SD/QF claim) -- the ONE call site, now correct for same-repo junction, same-repo isolated, and cross-repo venture worktrees alike"],
+    "dependencies": ["lib/fleet-lock-hash.mjs (unchanged, read-only)", "lib/worktree-provision.js's defaultEnsureHuskyHooks (unchanged, read-only)"],
+    "data_contracts": ["No schema changes"],
+    "runtime_config": ["None -- no new env vars"],
+    "observability_rollout": [
+      "The existing console.log lines in the install-decision block already surface the decision reason; a new git-hook-provisioned log line is added for FR-4 visibility",
+      "The recurred-family history (5 specimens across C1/G1/H1/I1/J1) is now closed by an on-disk regression test, not just a code review claim"
+    ]
+  },
+  "implementation_approach": {
+    "phases": [
+      "Phase 1: FR-1 root-cause fix (1-line change) in scripts/sd-start.js",
+      "Phase 2: FR-4 independent husky-hook check in scripts/sd-start.js",
+      "Phase 3: FR-2 e2e acceptance test (new file) + FR-3 sweep (documented, no code changes needed)"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run npx vitest run tests/unit/sd-start-install-decision-worktree-path.test.js", "expected_outcome": "5/5 pass, including the direct reproduction of the historical bug via a healthy coordinator-repo path" },
+    { "step_number": 2, "instruction": "Run npx vitest run tests/unit/fleet-lock-hash.test.js", "expected_outcome": "43/43 pass, zero regressions (file unmodified)" },
+    { "step_number": 3, "instruction": "Run npx vitest run tests/unit/worktree-provision-husky-hooks.test.js lib/__tests__/worktree-provision.test.js", "expected_outcome": "19/19 pass, zero regressions" },
+    { "step_number": 4, "instruction": "Run npx tsc --noEmit", "expected_outcome": "Clean, no type errors" }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-START-INSTALL-SKIP-001"
+  }
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -68,6 +68,11 @@ import {
   peerSessionSnapshot,
   emitFractureForDiff
 } from '../lib/fleet-lock-hash.mjs';
+// SD-LEO-INFRA-START-INSTALL-SKIP-001 FR4 (security-relevant): re-provision husky's git-hook
+// shims independently of the dependency-install decision below -- a skip-path worktree must
+// never end up with core.hooksPath pointing at a directory that doesn't exist.
+import { defaultEnsureHuskyHooks } from '../lib/worktree-provision.js';
+import { existsSync } from 'node:fs';
 // SD-LEO-INFRA-SD-CREATION-TOOLING-001 Phase 4: cross-check scope vs target_application
 import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
 import { shouldShowVenturePipelinePointer, VENTURE_PIPELINE_POINTER } from '../lib/leo/venture-pipeline-pointer.js';
@@ -1770,17 +1775,42 @@ async function main() {
   //         during the install window.
   if (worktreeInfo?.success && worktreeInfo.cwd) {
     try {
-      // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR5): Resolve repo root
-      // once (worktrees symlink node_modules from there). Using getRepoRoot()
-      // instead of `git rev-parse --show-toplevel` with cwd=worktreeInfo.cwd
-      // — the latter returns the worktree path, not the main repo.
-      const installRepoRoot = getRepoRoot();
+      // SD-LEO-INFRA-START-INSTALL-SKIP-001 (5th recurrence, FR1): the FR5 comment this
+      // replaces assumed every worktree's node_modules is ALWAYS a junction/symlink into the
+      // coordinator repo (getRepoRoot()), so checking the coordinator's own canary/hash was
+      // "equivalent". SD-LEO-INFRA-SMART-PER-WORKTREE-001 retired that invariant (worktrees can
+      // get a REAL isolated node_modules under concurrency), and cross-repo venture worktrees
+      // (a different repo entirely from the coordinator) were NEVER covered by that assumption
+      // in the first place -- checking getRepoRoot() there checks EHG_Engineer's own deps, not
+      // the target repo's, so a healthy coordinator install always false-positived "skip" no
+      // matter what the actual worktree contained (the 5 recurred specimens, e.g.
+      // SD-MARKETLENS-*-C1/G1). fs.existsSync follows symlinks, so resolving against the
+      // WORKTREE's own path (worktreeInfo.cwd) is correct for junction, isolated, AND
+      // cross-repo worktrees alike -- a broken/missing junction or a not-yet-installed isolated
+      // worktree now correctly reports canaryPresent=false instead of silently inheriting the
+      // coordinator's own unrelated install state.
+      const installRepoRoot = worktreeInfo.cwd;
 
       const forceInstall = process.argv.includes('--force-install');
       const decision = await evaluateInstallDecision({
         repoRoot: installRepoRoot,
         forceInstall
       });
+
+      // SD-LEO-INFRA-START-INSTALL-SKIP-001 FR4 (security-relevant): hook provisioning is
+      // independent of the dependency-install decision above. `.husky/_` (what core.hooksPath
+      // points at) is only ever created as a side-effect of npm install's `prepare` script, so
+      // on the (common) skip fast path it never gets created and every git hook -- pre-commit
+      // secret scanning, commit-msg checks, pre-push enforcement -- silently never fires. Check
+      // and re-link regardless of decision.skip; fail-open (never blocks sd-start).
+      if (!existsSync(path.join(installRepoRoot, '.husky', '_'))) {
+        const hooks = defaultEnsureHuskyHooks(installRepoRoot);
+        if (hooks.ok) {
+          console.log(`   ${colors.green}✓ git hooks provisioned (.husky/_ was missing)${colors.reset}`);
+        } else {
+          console.log(`   ${colors.yellow}⚠️  git hook provisioning failed (non-fatal): ${hooks.error}${colors.reset}`);
+        }
+      }
 
       if (decision.skip) {
         // SD-LEO-INFRA-FLEET-LOCK-HASH-001 FR-2: distinguish skip-due-to-hash-match

--- a/tests/unit/sd-start-install-decision-worktree-path.test.js
+++ b/tests/unit/sd-start-install-decision-worktree-path.test.js
@@ -1,0 +1,100 @@
+/**
+ * SD-LEO-INFRA-START-INSTALL-SKIP-001 (5th recurrence): mandatory e2e acceptance per the
+ * recurred-family rule -- a logic-only patch bounced 4 times because none of the prior fixes
+ * had a real, on-disk acceptance test. This drives the ACTUAL exported evaluateInstallDecision()
+ * against REAL temp directories (no fs mocking) to prove the fix: deciding from the resolved
+ * WORKTREE path is correct, while deciding from an unrelated "coordinator repo" path (the exact
+ * bug scripts/sd-start.js had via getRepoRoot()) reproduces the false-positive skip.
+ *
+ * @module tests/unit/sd-start-install-decision-worktree-path.test.js
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fsp } from 'node:fs';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { evaluateInstallDecision, writeMarker, computeLockHash } from '../../lib/fleet-lock-hash.mjs';
+import { defaultEnsureHuskyHooks } from '../../lib/worktree-provision.js';
+
+const tmpDirs = [];
+
+async function mkTmpDir(prefix) {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/** Populate a directory as a "healthy, fully installed" repo: lockfile + marker + canary. */
+async function populateHealthyRepo(dir) {
+  await fsp.writeFile(path.join(dir, 'package-lock.json'), '{"name":"x","lockfileVersion":3}');
+  await fsp.mkdir(path.join(dir, 'node_modules', '@supabase', 'supabase-js'), { recursive: true });
+  const hash = await computeLockHash(dir);
+  await writeMarker(dir, 'test-session', hash);
+  return hash;
+}
+
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+describe('FR1 acceptance: install decision must be resolved against the WORKTREE path, not an unrelated repo', () => {
+  it('a fresh worktree with NO node_modules correctly requires install, even when a healthy "coordinator repo" exists alongside it', async () => {
+    const coordinatorDir = await mkTmpDir('install-decision-coordinator-');
+    const worktreeDir = await mkTmpDir('install-decision-worktree-');
+
+    // The coordinator repo is fully healthy -- this is the state that made the OLD
+    // getRepoRoot()-based bug always report skip:true regardless of the worktree.
+    await populateHealthyRepo(coordinatorDir);
+
+    // THE BUG, reproduced directly: deciding from the coordinator path false-positives skip.
+    const buggyDecision = await evaluateInstallDecision({ repoRoot: coordinatorDir });
+    expect(buggyDecision.skip).toBe(true);
+
+    // THE FIX: deciding from the worktree's own (empty) path correctly requires install.
+    const correctDecision = await evaluateInstallDecision({ repoRoot: worktreeDir });
+    expect(correctDecision.skip).toBe(false);
+    expect(correctDecision.reason).toMatch(/no hash marker/);
+  });
+
+  it('a worktree with node_modules missing but package-lock.json present still requires install (canary check, not just hash)', async () => {
+    const worktreeDir = await mkTmpDir('install-decision-worktree-lockonly-');
+    await fsp.writeFile(path.join(worktreeDir, 'package-lock.json'), '{"name":"x"}');
+    // No node_modules at all -- no marker, no canary.
+    const decision = await evaluateInstallDecision({ repoRoot: worktreeDir });
+    expect(decision.skip).toBe(false);
+  });
+
+  it('a genuinely healthy, freshly-populated worktree correctly SKIPS install (the inverse case -- no false negative either)', async () => {
+    const worktreeDir = await mkTmpDir('install-decision-worktree-healthy-');
+    await populateHealthyRepo(worktreeDir);
+    const decision = await evaluateInstallDecision({ repoRoot: worktreeDir });
+    expect(decision.skip).toBe(true);
+    expect(decision.reason).toMatch(/lockfile hash match/);
+  });
+
+  it('an isolated worktree (real node_modules, no relation to any coordinator repo) is judged purely on its own state', async () => {
+    const worktreeDir = await mkTmpDir('install-decision-worktree-isolated-');
+    // Populate ONLY the canary, no marker/hash -- simulates a worktree isolate-install that ran
+    // but never got to write the marker (e.g. interrupted) -- must still require install.
+    await fsp.mkdir(path.join(worktreeDir, 'node_modules', '@supabase', 'supabase-js'), { recursive: true });
+    const decision = await evaluateInstallDecision({ repoRoot: worktreeDir });
+    expect(decision.skip).toBe(false);
+    expect(decision.reason).toMatch(/no hash marker/);
+  });
+});
+
+describe('FR4 acceptance: git hooks must be provisioned independently of the install-skip decision', () => {
+  it('defaultEnsureHuskyHooks provisions .husky/_ in a worktree that has no npm install at all (skip-path parity)', () => {
+    // This proves hook provisioning does not depend on npm install having run --
+    // `npx husky` alone recreates the shims in any git-initialized directory.
+    // Skipped in CI environments without a real git binary / npx on PATH is acceptable
+    // (fail-open is the documented contract); we only assert the call never throws.
+    const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-decision-husky-'));
+    tmpDirs.push(worktreeDir);
+    expect(() => defaultEnsureHuskyHooks(worktreeDir)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- RECURRED FAMILY, 5th specimen (SD-MARKETLENS-*-C1/G1/H1/I1/J1), 4 prior logic-only fixes bounced.
- Root cause: `sd-start.js`'s install-decision resolved `installRepoRoot = getRepoRoot()` (always the coordinator repo) instead of the already-resolved `worktreeInfo.cwd`. That was a deliberate but now-stale choice (SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 FR5) whose "always-junctioned" assumption was invalidated by SD-LEO-INFRA-SMART-PER-WORKTREE-001 (isolated per-worktree node_modules) and never covered cross-repo venture worktrees at all.
- Fix: `installRepoRoot = worktreeInfo.cwd` (1-line reassignment; `fs.existsSync` follows symlinks so this is correct for junction/isolated/cross-repo alike).
- Security-relevant fold-in (FR4): git hooks (`.husky/_`) are now re-provisioned independently of the install-skip decision, closing a gap where pre-commit secret scanning silently never fired on the skip fast path.
- Per the recurred-family rule, a new test drives the REAL `evaluateInstallDecision()` against real temp directories and explicitly reproduces the historical bug before proving the fix.

## Test plan
- [x] New test explicitly reproduces the historical false-positive (`skip:true` from a coordinator-repo path) and proves the fix (`skip:false` from an empty worktree path)
- [x] `npx vitest run` across the 4 relevant suites -- 67/67 pass
- [x] `npx tsc --noEmit` -- clean
- [x] TESTING/VALIDATION/REGRESSION/RETRO sub-agents all PASS with fresh evidence rows; REGRESSION independently verified junction-mode behavior is unchanged via a real Windows junction test

SD-LEO-INFRA-START-INSTALL-SKIP-001