### PR TITLE
fix(QF-20260703-070): board rehydrator mirrors fire-and-forget broadcasts as done, not open

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
-  "createdAt": "2026-07-03T21:29:51.107Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
-  "baseRef": "origin/main"
+  "sdKey": "QF-20260703-773",
+  "workType": "QF",
+  "workKey": "QF-20260703-773",
+  "expectedBranch": "qf/QF-20260703-773",
+  "createdAt": "2026-07-04T01:21:27.489Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,7 @@
 {
-  "sdKey": "QF-20260703-070",
-  "workType": "QF",
-  "workKey": "QF-20260703-070",
-  "expectedBranch": "qf/QF-20260703-070",
-  "createdAt": "2026-07-04T00:20:19.123Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
+  "sdKey": "SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
+  "createdAt": "2026-07-03T21:29:51.107Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "baseRef": "origin/main"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,10 +1,9 @@
 {
-  "sdKey": "QF-20260703-311",
+  "sdKey": "QF-20260703-070",
   "workType": "QF",
-  "workKey": "QF-20260703-311",
-  "expectedBranch": "qf/QF-20260703-311",
-  "createdAt": "2026-07-03T22:33:05.293Z",
+  "workKey": "QF-20260703-070",
+  "expectedBranch": "qf/QF-20260703-070",
+  "createdAt": "2026-07-04T00:20:19.123Z",
   "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
-  "baseRef": "origin/main"
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/adam/task-rehydrate.js
+++ b/lib/adam/task-rehydrate.js
@@ -9,6 +9,8 @@
  *   (a) advisory_thread — OPEN Adam advisory threads: session_coordination rows sent by Adam
  *       (sender_type='adam') carrying a correlation_id (or reply_requested) that have NO reply row
  *       (a row whose payload.reply_to matches the correlation_id). source_ref = correlation_id.
+ *       A thread whose payload.reply_class='fire-and-forget' (one-way broadcasts — belt-countdowns,
+ *       status relays) mirrors with status='done' instead of open (QF-20260703-070).
  *   (b) sourced_sd     — Adam-sourced SDs still open: strategic_directives_v2 where
  *       metadata.sourced_by='adam' AND status IN ('draft','in_progress'). source_ref = sd_key.
  *   (c) awaited_reply  — the awaited-reply markers for the open threads that explicitly requested a
@@ -28,6 +30,12 @@ const OPEN_SD_STATUSES = new Set(['draft', 'in_progress']);
 const truthy = (v) => v === true || v === 'true';
 const corrId = (row) => (row && row.payload && row.payload.correlation_id) || null;
 const replyTo = (row) => (row && row.payload && row.payload.reply_to) || null;
+// QF-20260703-070: a one-way broadcast (reply_class='fire-and-forget' — the reply-class SSOT's
+// default for `send` mode, lib/coordinator/reply-class.cjs) is terminal at send time and expects
+// no reply; mirroring it as an open thread let it age into the stall detector's window (a
+// countdown line was flagged "stalled" an hour after it was sent). Rows without a stamped
+// reply_class (legacy, pre-SSOT) fall through to the existing open-mirror behavior.
+const isFireAndForget = (row) => !!(row && row.payload && row.payload.reply_class === 'fire-and-forget');
 
 /** A short human title for a thread node (subject/body-derived, bounded). */
 function threadTitle(row) {
@@ -76,21 +84,25 @@ export async function rehydrateBoard(supabase) {
   for (const t of openThreads) {
     const ref = corrId(t);
     const title = threadTitle(t);
-    // (a) the thread/topic node
+    const fireAndForget = isFireAndForget(t);
+    // (a) the thread/topic node — a fire-and-forget broadcast mirrors DONE (terminal at send
+    // time), not open, so it never matures into a false stall.
     try {
       await createOrUpsertNode(supabase, {
         source_kind: 'advisory_thread',
         source_ref: ref,
         tier: 'parent',
         title,
+        ...(fireAndForget ? { status: 'done' } : {}),
       });
       summary.threads += 1;
       summary.parents += 1;
     } catch (e) {
       summary.errors.push(`advisory_thread upsert failed (${ref}): ${e?.message ?? e}`);
     }
-    // (c) the awaited-reply marker for threads that explicitly requested a reply
-    if (truthy(t.payload && t.payload.reply_requested)) {
+    // (c) the awaited-reply marker for threads that explicitly requested a reply — never for a
+    // fire-and-forget broadcast (a one-way send never awaits anything, by definition).
+    if (!fireAndForget && truthy(t.payload && t.payload.reply_requested)) {
       try {
         await createOrUpsertNode(supabase, {
           source_kind: 'awaited_reply',

--- a/tests/unit/adam/task-rehydrate.test.js
+++ b/tests/unit/adam/task-rehydrate.test.js
@@ -115,4 +115,47 @@ describe('rehydrateBoard — reconstruct from the 3 live sources', () => {
     expect(summary.threads).toBe(0);
     expect(summary.errors.length).toBeGreaterThan(0);
   });
+
+  // QF-20260703-070: a fire-and-forget broadcast (belt-countdowns, status relays) must never
+  // mirror as an open thread that matures into a false stall.
+  it('mirrors a fire-and-forget countdown advisory as done, not open', async () => {
+    const sb = makeSupabase({
+      coordination: [
+        {
+          id: 'sc1',
+          sender_type: 'adam',
+          payload: { correlation_id: 'corr-countdown', reply_class: 'fire-and-forget', subject: 'Belt countdown: ETA 4h' },
+        },
+      ],
+      sds: [],
+    });
+    const summary = await rehydrateBoard(sb);
+    const node = sb._ledger.find((r) => r.source_kind === 'advisory_thread' && r.source_ref === 'corr-countdown');
+    expect(node).toBeDefined();
+    expect(node.status).toBe('done');
+    // A fire-and-forget send never awaits a reply — no awaited_reply marker either.
+    expect(sb._ledger.some((r) => r.source_kind === 'awaited_reply')).toBe(false);
+    expect(summary.threads).toBe(1);
+    expect(summary.awaited).toBe(0);
+  });
+
+  it('still mirrors a reply-needed request thread open (unaffected by the fire-and-forget carve-out)', async () => {
+    const sb = makeSupabase({
+      coordination: [
+        {
+          id: 'sc1',
+          sender_type: 'adam',
+          payload: { correlation_id: 'corr-request', reply_class: 'reply-needed', reply_requested: true, subject: 'Decision needed on Y' },
+        },
+      ],
+      sds: [],
+    });
+    const summary = await rehydrateBoard(sb);
+    const node = sb._ledger.find((r) => r.source_kind === 'advisory_thread' && r.source_ref === 'corr-request');
+    expect(node).toBeDefined();
+    expect(node.status).toBe('open');
+    expect(sb._ledger.some((r) => r.source_kind === 'awaited_reply' && r.source_ref === 'corr-request')).toBe(true);
+    expect(summary.threads).toBe(1);
+    expect(summary.awaited).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- `rehydrateBoard()` mirrored every outbound Adam advisory as an open `adam_task_ledger` thread, including one-way fire-and-forget broadcasts (belt-countdowns, status relays) that expect no reply.
- Each then aged into the stall detector's window and needed a manual close (a countdown was flagged "stalled" an hour after sending).
- Now classifies at mirror time by the already-stamped `payload.reply_class` (SSOT: `lib/coordinator/reply-class.cjs`): `fire-and-forget` mirrors with `status='done'` (and skips the `awaited_reply` marker); `reply-needed`/`live-handshake` threads keep mirroring open as before. Rows without a stamped `reply_class` (legacy) fall through to the existing open-mirror behavior.

## Test plan
- [x] `npx vitest run tests/unit/adam/task-rehydrate.test.js` — 6/6 passing (2 new: fire-and-forget mirrors done, reply-needed still mirrors open)
- [x] `npx vitest run tests/unit/adam/` — 257/257 passing, no regressions

QF-20260703-070

🤖 Generated with [Claude Code](https://claude.com/claude-code)