### PR TITLE
feat(QF-20260703-793): handoff rejection-rate analytics + consultant detector root-cause note

### DIFF
--- a/scripts/analytics/handoff-rejection-rates.mjs
+++ b/scripts/analytics/handoff-rejection-rates.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Handoff rejection-rate report (QF-20260703-793, Solomon Mode-B #14 disposition part 3).
+ *
+ * Read-only. Reports per-handoff_type rejection rates (lifetime + trailing-30d), top rejection
+ * reasons, and a per-SD-type breakdown -- keyed on handoff_type rather than from_phase->to_phase
+ * (see QF completion notes for why: LEAD-FINAL-APPROVAL legitimately has from=to='LEAD').
+ *
+ * Usage: node scripts/analytics/handoff-rejection-rates.mjs [--json]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const JSON_MODE = process.argv.includes('--json');
+const PAGE_SIZE = 1000;
+const TRAILING_DAYS = 30;
+
+/** Fetch ALL rows via keyset pagination -- avoids PostgREST's default page-size truncating a
+ *  30k+ row table into a silently-wrong lifetime total. */
+async function fetchAllHandoffs(supabase) {
+  const rows = [];
+  let from = 0;
+  for (;;) {
+    const { data, error } = await supabase
+      .from('sd_phase_handoffs')
+      .select('sd_id, handoff_type, status, rejection_reason, created_at')
+      .range(from, from + PAGE_SIZE - 1)
+      .order('created_at', { ascending: true });
+    if (error) throw new Error('fetchAllHandoffs failed: ' + error.message);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+  return rows;
+}
+
+/** Pure: leading gate-name token from a rejection_reason, e.g. "RETROSPECTIVE_QUALITY_GATE
+ *  validation failed - ..." -> "RETROSPECTIVE_QUALITY_GATE". Falls back to a truncated snippet. */
+export function bucketRejectionReason(reason) {
+  if (!reason) return '(no reason recorded)';
+  const m = reason.match(/^([A-Z][A-Z0-9_]{3,})\b/);
+  return m ? m[1] : reason.slice(0, 40);
+}
+
+/** Pure: {total, rejected} -> rate string. */
+function rate(stats) {
+  if (!stats || stats.total === 0) return 'n/a';
+  return `${((stats.rejected / stats.total) * 100).toFixed(1)}%`;
+}
+
+export function computeTransitionStats(rows, { sinceMs = null } = {}) {
+  const byType = {};
+  for (const h of rows) {
+    if (sinceMs !== null && Date.parse(h.created_at + 'Z') < sinceMs) continue;
+    if (!byType[h.handoff_type]) byType[h.handoff_type] = { total: 0, rejected: 0 };
+    byType[h.handoff_type].total++;
+    if (h.status === 'rejected') byType[h.handoff_type].rejected++;
+  }
+  return byType;
+}
+
+export function computeTopRejectionReasons(rows, limit = 5) {
+  const counts = {};
+  for (const h of rows) {
+    if (h.status !== 'rejected') continue;
+    const bucket = bucketRejectionReason(h.rejection_reason);
+    counts[bucket] = (counts[bucket] || 0) + 1;
+  }
+  return Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, limit);
+}
+
+async function fetchSdTypeMap(supabase) {
+  const { data, error } = await supabase.from('strategic_directives_v2').select('id, sd_type');
+  if (error) throw new Error('fetchSdTypeMap failed: ' + error.message);
+  const map = new Map();
+  for (const r of data || []) map.set(r.id, r.sd_type || 'unknown');
+  return map;
+}
+
+export function computeSdTypeStats(rows, sdTypeMap) {
+  const byType = {};
+  for (const h of rows) {
+    const type = sdTypeMap.get(h.sd_id) || 'unknown';
+    if (!byType[type]) byType[type] = { total: 0, rejected: 0 };
+    byType[type].total++;
+    if (h.status === 'rejected') byType[type].rejected++;
+  }
+  return byType;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required'); process.exit(1); }
+  const supabase = createClient(url, key);
+
+  const rows = await fetchAllHandoffs(supabase);
+  const sdTypeMap = await fetchSdTypeMap(supabase);
+
+  const lifetime = computeTransitionStats(rows);
+  const trailing = computeTransitionStats(rows, { sinceMs: Date.now() - TRAILING_DAYS * 24 * 3600 * 1000 });
+  const topReasons = computeTopRejectionReasons(rows);
+  const sdTypeStats = computeSdTypeStats(rows, sdTypeMap);
+
+  const totalRejected = rows.filter((h) => h.status === 'rejected').length;
+  const totalAll = rows.length;
+
+  if (JSON_MODE) {
+    console.log(JSON.stringify({ totalAll, totalRejected, lifetime, trailing, topReasons, sdTypeStats }, null, 2));
+    return;
+  }
+
+  console.log(`\nHANDOFF REJECTION RATES  (${totalRejected}/${totalAll} = ${rate({ total: totalAll, rejected: totalRejected })} lifetime rejection rate)\n`);
+  console.log('Per handoff_type (lifetime vs trailing 30d):');
+  for (const type of Object.keys(lifetime).sort()) {
+    const l = lifetime[type];
+    const t = trailing[type] || { total: 0, rejected: 0 };
+    console.log(`  ${type.padEnd(20)} lifetime ${rate(l).padStart(6)} (${l.rejected}/${l.total})   30d ${rate(t).padStart(6)} (${t.rejected}/${t.total})`);
+  }
+  console.log('\nTop rejection reasons:');
+  for (const [reason, count] of topReasons) console.log(`  ${String(count).padStart(5)}  ${reason}`);
+  console.log('\nPer SD-type:');
+  for (const type of Object.keys(sdTypeStats).sort()) {
+    const s = sdTypeStats[type];
+    console.log(`  ${type.padEnd(16)} ${rate(s).padStart(6)} (${s.rejected}/${s.total})`);
+  }
+  console.log('');
+}
+
+main().catch((e) => { console.error('[handoff-rejection-rates] FATAL: ' + (e?.message || e)); process.exit(1); });

--- a/scripts/analytics/handoff-rejection-rates.mjs
+++ b/scripts/analytics/handoff-rejection-rates.mjs
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 /**
- * Handoff rejection-rate report (QF-20260703-793, Solomon Mode-B #14 disposition part 3).
- *
- * Read-only. Reports per-handoff_type rejection rates (lifetime + trailing-30d), top rejection
- * reasons, and a per-SD-type breakdown -- keyed on handoff_type rather than from_phase->to_phase
- * (see QF completion notes for why: LEAD-FINAL-APPROVAL legitimately has from=to='LEAD').
- *
+ * Handoff rejection-rate report (QF-20260703-793). Read-only. Per-handoff_type rejection rates
+ * (lifetime + trailing-30d), top rejection reasons, per-SD-type breakdown. Keyed on handoff_type,
+ * not from_phase->to_phase (LEAD-FINAL-APPROVAL legitimately has from=to='LEAD' -- see QF notes).
  * Usage: node scripts/analytics/handoff-rejection-rates.mjs [--json]
  */
 import 'dotenv/config';
@@ -15,46 +12,36 @@ const JSON_MODE = process.argv.includes('--json');
 const PAGE_SIZE = 1000;
 const TRAILING_DAYS = 30;
 
-/** Fetch ALL rows via keyset pagination -- avoids PostgREST's default page-size truncating a
- *  30k+ row table into a silently-wrong lifetime total. */
 async function fetchAllHandoffs(supabase) {
   const rows = [];
-  let from = 0;
-  for (;;) {
-    const { data, error } = await supabase
-      .from('sd_phase_handoffs')
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase.from('sd_phase_handoffs')
       .select('sd_id, handoff_type, status, rejection_reason, created_at')
-      .range(from, from + PAGE_SIZE - 1)
-      .order('created_at', { ascending: true });
+      .range(from, from + PAGE_SIZE - 1).order('created_at', { ascending: true });
     if (error) throw new Error('fetchAllHandoffs failed: ' + error.message);
     if (!data || data.length === 0) break;
     rows.push(...data);
     if (data.length < PAGE_SIZE) break;
-    from += PAGE_SIZE;
   }
   return rows;
 }
 
-/** Pure: leading gate-name token from a rejection_reason, e.g. "RETROSPECTIVE_QUALITY_GATE
- *  validation failed - ..." -> "RETROSPECTIVE_QUALITY_GATE". Falls back to a truncated snippet. */
+/** Pure: leading GATE_NAME token, or a truncated snippet. */
 export function bucketRejectionReason(reason) {
   if (!reason) return '(no reason recorded)';
   const m = reason.match(/^([A-Z][A-Z0-9_]{3,})\b/);
   return m ? m[1] : reason.slice(0, 40);
 }
 
-/** Pure: {total, rejected} -> rate string. */
 function rate(stats) {
-  if (!stats || stats.total === 0) return 'n/a';
-  return `${((stats.rejected / stats.total) * 100).toFixed(1)}%`;
+  return !stats || stats.total === 0 ? 'n/a' : `${((stats.rejected / stats.total) * 100).toFixed(1)}%`;
 }
 
 export function computeTransitionStats(rows, { sinceMs = null } = {}) {
   const byType = {};
   for (const h of rows) {
     if (sinceMs !== null && Date.parse(h.created_at + 'Z') < sinceMs) continue;
-    if (!byType[h.handoff_type]) byType[h.handoff_type] = { total: 0, rejected: 0 };
-    byType[h.handoff_type].total++;
+    (byType[h.handoff_type] ??= { total: 0, rejected: 0 }).total++;
     if (h.status === 'rejected') byType[h.handoff_type].rejected++;
   }
   return byType;
@@ -70,23 +57,20 @@ export function computeTopRejectionReasons(rows, limit = 5) {
   return Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, limit);
 }
 
-async function fetchSdTypeMap(supabase) {
-  const { data, error } = await supabase.from('strategic_directives_v2').select('id, sd_type');
-  if (error) throw new Error('fetchSdTypeMap failed: ' + error.message);
-  const map = new Map();
-  for (const r of data || []) map.set(r.id, r.sd_type || 'unknown');
-  return map;
-}
-
 export function computeSdTypeStats(rows, sdTypeMap) {
   const byType = {};
   for (const h of rows) {
     const type = sdTypeMap.get(h.sd_id) || 'unknown';
-    if (!byType[type]) byType[type] = { total: 0, rejected: 0 };
-    byType[type].total++;
+    (byType[type] ??= { total: 0, rejected: 0 }).total++;
     if (h.status === 'rejected') byType[type].rejected++;
   }
   return byType;
+}
+
+async function fetchSdTypeMap(supabase) {
+  const { data, error } = await supabase.from('strategic_directives_v2').select('id, sd_type');
+  if (error) throw new Error('fetchSdTypeMap failed: ' + error.message);
+  return new Map((data || []).map((r) => [r.id, r.sd_type || 'unknown']));
 }
 
 async function main() {
@@ -94,28 +78,22 @@ async function main() {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) { console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required'); process.exit(1); }
   const supabase = createClient(url, key);
-
   const rows = await fetchAllHandoffs(supabase);
   const sdTypeMap = await fetchSdTypeMap(supabase);
-
   const lifetime = computeTransitionStats(rows);
   const trailing = computeTransitionStats(rows, { sinceMs: Date.now() - TRAILING_DAYS * 24 * 3600 * 1000 });
   const topReasons = computeTopRejectionReasons(rows);
   const sdTypeStats = computeSdTypeStats(rows, sdTypeMap);
-
   const totalRejected = rows.filter((h) => h.status === 'rejected').length;
-  const totalAll = rows.length;
 
   if (JSON_MODE) {
-    console.log(JSON.stringify({ totalAll, totalRejected, lifetime, trailing, topReasons, sdTypeStats }, null, 2));
+    console.log(JSON.stringify({ totalAll: rows.length, totalRejected, lifetime, trailing, topReasons, sdTypeStats }, null, 2));
     return;
   }
-
-  console.log(`\nHANDOFF REJECTION RATES  (${totalRejected}/${totalAll} = ${rate({ total: totalAll, rejected: totalRejected })} lifetime rejection rate)\n`);
+  console.log(`\nHANDOFF REJECTION RATES (${totalRejected}/${rows.length} = ${rate({ total: rows.length, rejected: totalRejected })} lifetime)\n`);
   console.log('Per handoff_type (lifetime vs trailing 30d):');
   for (const type of Object.keys(lifetime).sort()) {
-    const l = lifetime[type];
-    const t = trailing[type] || { total: 0, rejected: 0 };
+    const l = lifetime[type], t = trailing[type] || { total: 0, rejected: 0 };
     console.log(`  ${type.padEnd(20)} lifetime ${rate(l).padStart(6)} (${l.rejected}/${l.total})   30d ${rate(t).padStart(6)} (${t.rejected}/${t.total})`);
   }
   console.log('\nTop rejection reasons:');

--- a/tests/unit/analytics/handoff-rejection-rates.test.js
+++ b/tests/unit/analytics/handoff-rejection-rates.test.js
@@ -1,0 +1,74 @@
+/**
+ * QF-20260703-793: pure-function tests for handoff-rejection-rates.mjs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  bucketRejectionReason,
+  computeTransitionStats,
+  computeTopRejectionReasons,
+  computeSdTypeStats,
+} from '../../../scripts/analytics/handoff-rejection-rates.mjs';
+
+describe('bucketRejectionReason', () => {
+  it('extracts a leading GATE_NAME-style token', () => {
+    expect(bucketRejectionReason('RETROSPECTIVE_QUALITY_GATE validation failed - no retro')).toBe('RETROSPECTIVE_QUALITY_GATE');
+    expect(bucketRejectionReason('GATE_CLAIM_VALIDITY validation failed: NO_CLAIM')).toBe('GATE_CLAIM_VALIDITY');
+  });
+
+  it('falls back to a truncated (40-char) snippet when there is no leading gate token', () => {
+    const reason = 'Strategic Directive does not meet completeness bar for this phase';
+    expect(bucketRejectionReason(reason)).toBe(reason.slice(0, 40));
+  });
+
+  it('handles null/empty reasons', () => {
+    expect(bucketRejectionReason(null)).toBe('(no reason recorded)');
+    expect(bucketRejectionReason('')).toBe('(no reason recorded)');
+  });
+});
+
+describe('computeTransitionStats', () => {
+  const rows = [
+    { handoff_type: 'LEAD-TO-PLAN', status: 'accepted', created_at: '2026-01-01T00:00:00' },
+    { handoff_type: 'LEAD-TO-PLAN', status: 'rejected', created_at: '2026-06-01T00:00:00' },
+    { handoff_type: 'LEAD-FINAL-APPROVAL', status: 'accepted', created_at: '2026-06-01T00:00:00' },
+  ];
+
+  it('groups by handoff_type (not from_phase->to_phase)', () => {
+    const stats = computeTransitionStats(rows);
+    expect(stats['LEAD-TO-PLAN']).toEqual({ total: 2, rejected: 1 });
+    expect(stats['LEAD-FINAL-APPROVAL']).toEqual({ total: 1, rejected: 0 });
+  });
+
+  it('respects a sinceMs cutoff for a trailing window', () => {
+    const stats = computeTransitionStats(rows, { sinceMs: Date.parse('2026-03-01T00:00:00Z') });
+    expect(stats['LEAD-TO-PLAN']).toEqual({ total: 1, rejected: 1 });
+  });
+});
+
+describe('computeTopRejectionReasons', () => {
+  it('ranks reasons by count, only counting rejected rows', () => {
+    const rows = [
+      { status: 'rejected', rejection_reason: 'GATE_X validation failed' },
+      { status: 'rejected', rejection_reason: 'GATE_X validation failed' },
+      { status: 'accepted', rejection_reason: 'GATE_X validation failed' },
+      { status: 'rejected', rejection_reason: 'GATE_Y validation failed' },
+    ];
+    const top = computeTopRejectionReasons(rows, 2);
+    expect(top[0]).toEqual(['GATE_X', 2]);
+    expect(top[1]).toEqual(['GATE_Y', 1]);
+  });
+});
+
+describe('computeSdTypeStats', () => {
+  it('resolves sd_id via the provided map and falls back to unknown', () => {
+    const rows = [
+      { sd_id: 'a', status: 'rejected' },
+      { sd_id: 'a', status: 'accepted' },
+      { sd_id: 'missing', status: 'rejected' },
+    ];
+    const map = new Map([['a', 'infrastructure']]);
+    const stats = computeSdTypeStats(rows, map);
+    expect(stats.infrastructure).toEqual({ total: 2, rejected: 1 });
+    expect(stats.unknown).toEqual({ total: 1, rejected: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- Part 3 of the Solomon Mode-B #14 disposition.
- New `scripts/analytics/handoff-rejection-rates.mjs`: read-only report of per-handoff_type rejection rates (lifetime + trailing-30d), top rejection reasons, per-SD-type breakdown, from `sd_phase_handoffs` ground truth (~40% lifetime rejection rate).
- Investigated the consultant detector's "impossible LEAD->LEAD x40" finding: root cause is `scripts/eva/consultant-analysis-round.mjs` bucketing by `from_phase->to_phase` alone, without `handoff_type`. `LEAD-FINAL-APPROVAL` legitimately has `from=to='LEAD'` (verified: 4255 real rows). NOT a uuid/id-family mislabel — `sd_phase_handoffs.sd_id` correctly joins to `strategic_directives_v2.id`.

## Test plan
- [x] `npx vitest run tests/unit/analytics/handoff-rejection-rates.test.js` — 7/7 pass
- [x] Script run live against the dev DB, produces a real report matching the ~40% ground-truth rate

QF-20260703-793