### PR TITLE
fix(QF-20260703-773): Test-fixture key guard misses bare TEST-*/DEMO- keys, leaked fixtures dispatched as real work

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-LAUNCH-MODE-POLICY-001",
-  "createdAt": "2026-07-03T21:29:51.107Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
-  "baseRef": "origin/main"
+  "sdKey": "QF-20260703-773",
+  "workType": "QF",
+  "workKey": "QF-20260703-773",
+  "expectedBranch": "qf/QF-20260703-773",
+  "createdAt": "2026-07-04T01:21:27.489Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -25,8 +25,12 @@
  */
 
 /** Test-fixture key families that must never be dispatched onto a worker. Word-boundary anchored so
- *  real keys that merely START with these letters (SD-TESTABLE-*, SD-DEMONSTRATE-*) are NOT excluded. */
-const TEST_FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/;
+ *  real keys that merely START with these letters (SD-TESTABLE-*, SD-DEMONSTRATE-*) are NOT excluded.
+ *  QF-20260703-773: the SD- prefix is OPTIONAL -- some fixtures (e.g. tests/integration/migrations/
+ *  trigger-audit-f3-race-fix.db.test.js) insert bare TEST- or DEMO- prefixed keys with no SD- prefix
+ *  at all; those previously passed this guard and leaked onto the real claimable belt when their
+ *  afterEach cleanup was interrupted. Mirrors FIXTURE_TITLE_RE in lib/sourcing-engine/refill-candidate-validity.js. */
+const TEST_FIXTURE_KEY_RE = /^(SD-)?(DEMO|TEST)\b/i;
 
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): claim-time fitness predicate (repo-match + premise +
 // preconditions), composed here so the same gate that excludes orchestrator parents / fixtures /

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -18,8 +18,9 @@
  */
 
 // Canonical fixture-key pattern (mirrors lib/fleet/claim-eligibility.cjs TEST_FIXTURE_KEY_RE) so a
-// TEST/DEMO fixture seeded into the corpus is never auto-promoted onto the real belt.
-export const FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/i;
+// TEST/DEMO fixture seeded into the corpus is never auto-promoted onto the real belt. The SD- prefix
+// is OPTIONAL (QF-20260703-773) -- some fixtures insert bare TEST-*/DEMO- keys with no SD- prefix.
+export const FIXTURE_KEY_RE = /^(SD-)?(DEMO|TEST)\b/i;
 // A fixture can also surface as a TEST/DEMO-prefixed title (staged items have no sd_key of their own).
 export const FIXTURE_TITLE_RE = /^\s*(SD-)?(DEMO|TEST)\b/i;
 

--- a/tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js
+++ b/tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js
@@ -8,7 +8,7 @@
  * structural guard on the exception-safety shape (TS-3), which live-DB negative-injection
  * cannot reliably exercise via the PostgREST/supabase-js surface (see comment on that test).
  */
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -72,13 +72,39 @@ describe('TRIGGER-AUDIT F-3 — static exception-safety shape (TS-3)', () => {
   });
 });
 
+// QF-20260703-773: afterEach cleanup below is interruption-fragile -- its state lives only in the
+// in-memory fixtureIds array, so a hard-killed/cancelled/timed-out process (observed live: all 5
+// TEST-F3-RACE-* rows from one run leaked and were dispatched to real fleet workers) skips it
+// entirely with no durable trace. This sweep reconciles by the durable key prefix instead, run both
+// before and after the suite so a prior run's leak is caught regardless of how it died. The age
+// threshold protects a genuinely concurrent run's own in-flight fixtures on the shared dev DB.
+const FIXTURE_KEY_PREFIX = 'TEST-F3-RACE-';
+const STALE_FIXTURE_MS = 10 * 60 * 1000;
+async function purgeStaleF3Fixtures() {
+  const cutoff = new Date(Date.now() - STALE_FIXTURE_MS).toISOString();
+  const { data: stale } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .like('sd_key', `${FIXTURE_KEY_PREFIX}%`)
+    .lt('created_at', cutoff);
+  const ids = (stale || []).map((r) => r.id);
+  if (!ids.length) return;
+  const { error: biErr } = await supabase.from('sd_baseline_items').delete().in('sd_id', ids);
+  const { error: sdErr } = await supabase.from('strategic_directives_v2').delete().in('id', ids);
+  if (biErr || sdErr) console.warn('F3 fixture sweep partial:', biErr?.message, sdErr?.message);
+}
+
 describe.skipIf(!HAS_REAL_DB)('TRIGGER-AUDIT F-3 — live concurrent-insert race fix (TS-1, TS-2, TS-4)', () => {
   const fixtureIds = [];
 
+  beforeAll(purgeStaleF3Fixtures);
+  afterAll(purgeStaleF3Fixtures);
+
   afterEach(async () => {
     if (fixtureIds.length > 0) {
-      await supabase.from('sd_baseline_items').delete().in('sd_id', fixtureIds);
-      await supabase.from('strategic_directives_v2').delete().in('id', fixtureIds);
+      const { error: biErr } = await supabase.from('sd_baseline_items').delete().in('sd_id', fixtureIds);
+      const { error: sdErr } = await supabase.from('strategic_directives_v2').delete().in('id', fixtureIds);
+      if (biErr || sdErr) console.warn('F3 fixture afterEach cleanup partial:', biErr?.message, sdErr?.message);
       fixtureIds.length = 0;
     }
   });

--- a/tests/unit/fleet/claim-eligibility-fixture-key-guard.test.js
+++ b/tests/unit/fleet/claim-eligibility-fixture-key-guard.test.js
@@ -1,0 +1,36 @@
+/**
+ * Regression test for QF-20260703-773: TEST_FIXTURE_KEY_RE required an SD- prefix
+ * (/^SD-(DEMO|TEST)\b/), so a bare TEST- or DEMO- prefixed key (e.g. TEST-F3-RACE-* rows
+ * inserted directly by tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js)
+ * passed classifyDispatchIneligibility as eligible and got dispatched to real fleet workers
+ * when that test's afterEach cleanup was interrupted. The SD- prefix must be optional.
+ */
+import { describe, it, expect } from 'vitest';
+
+const { classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+
+describe('QF-20260703-773: bare TEST-/DEMO- fixture keys are ineligible', () => {
+  it('rejects a bare TEST- prefixed key (the leaked TEST-F3-RACE-* specimen)', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'TEST-F3-RACE-1783127205641-bl0', status: 'draft' }))
+      .toBe('test_fixture_key');
+  });
+
+  it('rejects a bare DEMO- prefixed key', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'DEMO-RACE-CONDITION-XYZ', status: 'draft' }))
+      .toBe('test_fixture_key');
+  });
+
+  it('still rejects the original SD-DEMO-/SD-TEST- prefixed form', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-TEST-001', status: 'draft' })).toBe('test_fixture_key');
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-DEMO-RACE-001', status: 'draft' })).toBe('test_fixture_key');
+  });
+
+  it('does not false-positive on a real SD that merely starts with those letters', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-TESTABLE-REAL-001', status: 'draft' })).toBeNull();
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-DEMONSTRATE-VALUE-001', status: 'draft' })).toBeNull();
+  });
+
+  it('does not false-positive on a real SD-LEO-*/SD-FDBK-* key', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-INFRA-009-LEAF-IMPROVEMENT-001', status: 'draft' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260703-773

**Type:** bug
**Severity:** high

### Issue Description
TEST_FIXTURE_KEY_RE (lib/fleet/claim-eligibility.cjs) and its twin FIXTURE_KEY_RE (lib/sourcing-engine/refill-candidate-validity.js) both require an SD- prefix (/^SD-(DEMO|TEST)\b/), so a bare TEST-*/DEMO- key is classified eligible for dispatch. Live specimen: 5 fixture rows from tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js (TEST-F3-RACE-*, afterEach never ran -- interrupted process) leaked into strategic_directives_v2 and were dispatched to at least 3 separate fleet workers before being caught and manually deleted.

### Steps to Reproduce
Run tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js and kill the process before afterEach runs (or observe naturally after any interrupted run); the leaked TEST-F3-RACE-* rows get offered as claimable work via node scripts/worker-checkin.cjs

### Expected Behavior
Any TEST-*/DEMO-* prefixed sd_key is excluded from dispatch/claim eligibility regardless of an SD- prefix

### Actual Behavior
TEST_FIXTURE_KEY_RE only matches SD-DEMO-*/SD-TEST-*, so bare TEST-F3-RACE-* rows pass through as eligible and get claimed by real workers

### Changes
- **Files Changed:** 5
  - .worktree.json
  - lib/fleet/claim-eligibility.cjs
  - lib/sourcing-engine/refill-candidate-validity.js
  - tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js
  - tests/unit/fleet/claim-eligibility-fixture-key-guard.test.js
- **LOC:** 82 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Verified via RCA-agent root cause analysis + live DB evidence (5 leaked TEST-F3-RACE-* rows confirmed dispatched to 3 separate fleet workers, deleted after capture). New unit test (5 assertions) confirms bare TEST-/DEMO- keys are now rejected while real SD-TESTABLE-/SD-DEMONSTRATE-/SD-LEO- keys remain unaffected (zero false positives). Hardened the leaking test's own cleanup with a beforeAll/afterAll durable-prefix sweep. Confirmed the 2 unrelated TS-3 static-string failures in the same file are pre-existing on clean origin/main (git stash verified) -- not touched or introduced by this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol