### PR TITLE
fix(QF-20260703-439): stage 21->22 distribution boundary is anyOf, not AND

### DIFF
--- a/lib/proving-companion/artifact-integrity-checker.js
+++ b/lib/proving-companion/artifact-integrity-checker.js
@@ -27,6 +27,7 @@ export async function checkArtifactIntegrity(ventureId, fromStage, toStage) {
 
   const allArtifactTypes = Object.values(stageConfigs)
     .flatMap(c => c.requiredArtifacts)
+    .flatMap(r => (r && typeof r === 'object' && Array.isArray(r.anyOf)) ? r.anyOf : [r])
     .filter(Boolean);
 
   const { data: artifacts, error } = await supabase
@@ -46,6 +47,25 @@ export async function checkArtifactIntegrity(ventureId, fromStage, toStage) {
     const checks = [];
 
     for (const requiredType of config.requiredArtifacts) {
+      // QF-20260703-439: an anyOf group is satisfied if ANY listed artifact has real
+      // content + a quality score -- e.g. distribution_channel_config OR distribution_ad_copy
+      // (a paid-ads artifact chairman-ratified organic-only ventures never produce).
+      if (requiredType && typeof requiredType === 'object' && Array.isArray(requiredType.anyOf)) {
+        const group = requiredType.anyOf;
+        const satisfied = group.find((t) => {
+          const a = artifactMap[t];
+          return a && a.content && a.content.length >= MIN_CONTENT_LENGTH && a.quality_score != null;
+        });
+        checks.push({
+          name: `artifact_anyOf:${group.join('|')}`,
+          pass: Boolean(satisfied),
+          detail: satisfied
+            ? `Satisfied by "${satisfied}" (${artifactMap[satisfied].content.length} chars, quality ${artifactMap[satisfied].quality_score})`
+            : `None of [${group.join(', ')}] found with sufficient content + quality score`
+        });
+        continue;
+      }
+
       const artifact = artifactMap[requiredType];
 
       if (!artifact) {

--- a/lib/proving-companion/stage-config.js
+++ b/lib/proving-companion/stage-config.js
@@ -234,7 +234,11 @@ const STAGE_CONFIG = {
     name: 'Distribution Setup',
     componentFile: 'Stage22DistributionSetup.tsx',
     filePatterns: ['src/components/stages/Stage22DistributionSetup*'],
-    requiredArtifacts: ['distribution_channel_config', 'distribution_ad_copy'],
+    // QF-20260703-439: anyOf, not AND -- matches the canonical S22 upstream requirement
+    // (lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js's
+    // UPSTREAM_REQUIREMENTS). distribution_ad_copy is a paid-ads artifact; chairman-ratified
+    // organic-only ventures (e.g. MarketLens, decision 08547ee8) legitimately never produce it.
+    requiredArtifacts: [{ anyOf: ['distribution_channel_config', 'distribution_ad_copy'] }],
     workType: 'artifact_only',
     gateType: null,
     phase: 'THE_BUILD',

--- a/tests/unit/proving-companion/artifact-integrity-anyof.test.js
+++ b/tests/unit/proving-companion/artifact-integrity-anyof.test.js
@@ -1,0 +1,60 @@
+/**
+ * QF-20260703-439: stage 21's requiredArtifacts is anyOf, not AND -- a venture with
+ * distribution_channel_config alone (no distribution_ad_copy) must pass the boundary.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockIn = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('../../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({ from: mockFrom }),
+}));
+
+let checkArtifactIntegrity;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockEq.mockReturnValue({ in: mockIn });
+  mockSelect.mockReturnValue({ eq: mockEq });
+  mockFrom.mockReturnValue({ select: mockSelect });
+  ({ checkArtifactIntegrity } = await import('../../../lib/proving-companion/artifact-integrity-checker.js'));
+});
+
+function artifact(type, contentLength = 200, qualityScore = 80) {
+  return { artifact_type: type, content: 'x'.repeat(contentLength), quality_score: qualityScore };
+}
+
+describe('checkArtifactIntegrity - stage 21 anyOf (QF-20260703-439)', () => {
+  it('passes when ONLY distribution_channel_config exists (organic-only venture, no ad copy)', async () => {
+    mockIn.mockResolvedValue({ data: [artifact('distribution_channel_config')], error: null });
+    const results = await checkArtifactIntegrity('venture-1', 21, 21);
+    const anyOfCheck = results['21'].checks.find((c) => c.name.startsWith('artifact_anyOf:'));
+    expect(anyOfCheck.pass).toBe(true);
+    expect(anyOfCheck.detail).toContain('distribution_channel_config');
+    expect(results['21'].fail_count).toBe(0);
+  });
+
+  it('passes when ONLY distribution_ad_copy exists', async () => {
+    mockIn.mockResolvedValue({ data: [artifact('distribution_ad_copy')], error: null });
+    const results = await checkArtifactIntegrity('venture-1', 21, 21);
+    expect(results['21'].checks.find((c) => c.name.startsWith('artifact_anyOf:')).pass).toBe(true);
+  });
+
+  it('fails when NEITHER distribution artifact exists', async () => {
+    mockIn.mockResolvedValue({ data: [], error: null });
+    const results = await checkArtifactIntegrity('venture-1', 21, 21);
+    const anyOfCheck = results['21'].checks.find((c) => c.name.startsWith('artifact_anyOf:'));
+    expect(anyOfCheck.pass).toBe(false);
+    expect(anyOfCheck.detail).toContain('None of');
+    expect(results['21'].fail_count).toBe(1);
+  });
+
+  it('does not count an anyOf group as satisfied by a low-quality/short-content artifact', async () => {
+    mockIn.mockResolvedValue({ data: [artifact('distribution_channel_config', 10, null)], error: null });
+    const results = await checkArtifactIntegrity('venture-1', 21, 21);
+    expect(results['21'].checks.find((c) => c.name.startsWith('artifact_anyOf:')).pass).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/proving-companion/stage-config.js`'s stage 21 `requiredArtifacts` listed `distribution_channel_config` AND `distribution_ad_copy`, but the canonical S22 upstream requirement (`stage-23-launch-readiness.js`'s `UPSTREAM_REQUIREMENTS`) defines it as anyOf.
- `distribution_ad_copy` is a paid-ads artifact; chairman-ratified organic-only ventures (MarketLens, decision 08547ee8) never produce it, so AND semantics false-escalated `ARTIFACT_MISSING` to the chairman for a venture that HAD channel config.
- Fix: stage 21's `requiredArtifacts` now carries a `{ anyOf: [...] }` group, matching the shape already established elsewhere in the codebase. `artifact-integrity-checker.js` handles both shapes; every other (plain-string) stage is untouched.

## Test plan
- [x] New test explicitly reproduces the historical false-fail (organic-only venture with only `distribution_channel_config`, no `distribution_ad_copy`) and confirms it now passes
- [x] Confirmed all 4 new tests genuinely FAIL against pre-fix code (git stash) and PASS post-fix
- [x] `npx tsc --noEmit` -- clean

QF-20260703-439