### PR TITLE
fix(QF-20260703-428): STALE_PREMISE overlap match keys on category, causing cross-defect false positives

### DIFF
--- a/lib/eva/feedback-premise-adapter.js
+++ b/lib/eva/feedback-premise-adapter.js
@@ -25,19 +25,27 @@ export function extractReferencedFiles(text) {
 }
 
 /**
- * @param {Object} feedbackRow - a row from the `feedback` table (title, description, category, ...)
+ * @param {Object} feedbackRow - a row from the `feedback` table (id, title, description, category, ...)
  * @returns {Object} premise_descriptor shape consumed by checkPremiseLiveness()
  */
 export function feedbackToPremiseDescriptor(feedbackRow = {}) {
   const text = [feedbackRow.title, feedbackRow.description].filter(Boolean).join('\n');
   return {
     kind: 'feedback',
-    gate_name: feedbackRow.category || null,
+    // QF-20260703-428: `category` (e.g. "harness_backlog") is a coarse bucket shared
+    // by many unrelated feedback rows, not a defect identifier. checkPremiseLiveness's
+    // overlap match keys on `gate_name || cluster_reason` -- feeding it category let an
+    // UNRELATED row's shipped fix falsely mark every other same-category row
+    // STALE_PREMISE. Identity now comes from the per-row title (cluster_reason) and
+    // referenced_files; category is retained as a display-only field.
+    gate_name: null,
     cluster_reason: (feedbackRow.title || '').slice(0, 80) || null,
     source: 'feedback',
     severity: feedbackRow.severity || feedbackRow.priority || null,
     premise_text: text,
     referenced_files: extractReferencedFiles(text),
+    feedback_id: feedbackRow.id || null,
+    category: feedbackRow.category || null,
   };
 }
 

--- a/tests/unit/eva/feedback-premise-adapter-identity.test.js
+++ b/tests/unit/eva/feedback-premise-adapter-identity.test.js
@@ -1,0 +1,92 @@
+// QF-20260703-428: checkFeedbackPremiseLiveness must key its overlap match on
+// defect IDENTITY (referenced_files / per-row title), never on the shared
+// `category` bucket -- else an unrelated same-category row's shipped fix
+// falsely marks every other row STALE_PREMISE (recurred-family e2e per QF spec).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkFeedbackPremiseLiveness } from '../../../lib/eva/feedback-premise-adapter.js';
+
+function fakeSupabase({ handoffRows = [], completedSds = [] }) {
+  return {
+    from(table) {
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              gte: () => ({
+                limit: async () => ({ data: handoffRows, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: () => ({
+              gte: () => ({
+                // Real PostgREST `.or('title.ilike.%tok%,description.ilike.%tok%')` only
+                // matches rows whose title/description actually contain the token -- mimic
+                // that here instead of returning completedSds unconditionally, or this test
+                // can't tell a correct token (identity match) from a wrong one (category match).
+                or: (filterExpr) => {
+                  const tok = filterExpr.match(/ilike\.%(.*?)%/)?.[1]?.toLowerCase() || '';
+                  const matched = completedSds.filter(
+                    (s) => (s.title || '').toLowerCase().includes(tok) || (s.description || '').toLowerCase().includes(tok)
+                  );
+                  return { limit: async () => ({ data: matched, error: null }) };
+                },
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+const noGitHits = () => '';
+
+describe('checkFeedbackPremiseLiveness identity keying (QF-20260703-428)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does NOT mark an unrelated same-category row STALE just because another category-mate shipped', async () => {
+    // Historical bug: gate_name was `category`, so ANY completed SD whose title/description
+    // ilike-matched the broad category string ("harness_backlog") satisfied findShippedFix
+    // for every row sharing that category -- including rows about a totally different defect.
+    const rowA = {
+      id: 'fb-aaa',
+      category: 'harness_backlog',
+      title: 'Belt-rank re-fire noise on stale claims',
+      description: 'See scripts/belt-rank.js for the offending re-fire loop.',
+    };
+    const supabase = fakeSupabase({
+      handoffRows: [], // recentCount === 0
+      completedSds: [
+        { sd_key: 'SD-LEO-INFRA-HARNESS-BACKLOG-CLEANUP-001', title: 'harness_backlog triage cleanup', completion_date: '2026-06-30' },
+      ],
+    });
+
+    const verdict = await checkFeedbackPremiseLiveness(rowA, { supabase, git: noGitHits, nowMs: Date.parse('2026-07-03T00:00:00Z') });
+
+    expect(verdict.status).toBe('LIVE');
+    expect(verdict.recommendation).not.toBe('ARCHIVE');
+  });
+
+  it('still marks STALE when the SPECIFIC referenced file was fixed (genuine identity match)', async () => {
+    const rowB = {
+      id: 'fb-bbb',
+      category: 'harness_backlog',
+      title: 'sd-start.js skips husky install on worktree path',
+      description: 'Root cause in scripts/sd-start.js install-skip branch.',
+    };
+    const supabase = fakeSupabase({ handoffRows: [], completedSds: [] });
+    const gitWithFileFix = (argsString) =>
+      argsString.includes('sd-start.js') ? 'abc1234 fix(sd-start): resolve worktree install path' : '';
+
+    const verdict = await checkFeedbackPremiseLiveness(rowB, { supabase, git: gitWithFileFix, nowMs: Date.parse('2026-07-03T00:00:00Z') });
+
+    expect(verdict.status).toBe('STALE');
+    expect(verdict.recommendation).toBe('ARCHIVE');
+  });
+});


### PR DESCRIPTION
## Summary
- `feedbackToPremiseDescriptor()` fed `feedbackRow.category` into `gate_name`, the token `checkPremiseLiveness()` uses for its overlap match against rejected-handoff reasons and completed-SD titles/descriptions.
- Category (e.g. `harness_backlog`) is a coarse bucket shared across many unrelated feedback rows — not a defect identifier — so ANY completed SD whose title ilike-matched the category string satisfied `findShippedFix()` for every row in that category, falsely marking unrelated defects `STALE_PREMISE` and silently blocking their promotion to a QF/SD.
- Fix: `gate_name` is now `null`; the overlap match keys on `cluster_reason` (the per-row title) and `referenced_files`, both defect-specific. `category` stays on the descriptor as a display-only field.
- Per the recurred-family rule (this is QF-428, the first bounce of SD-FDBK-ENH-UAT-AGENT-FEEDBACK-001), a genuine e2e acceptance test is included that reproduces the exact historical collision before proving the fix (verified failing against pre-fix code via `git stash`).

## Test plan
- [x] New test `tests/unit/eva/feedback-premise-adapter-identity.test.js` — confirmed FAILS against pre-fix code (`git stash`), PASSES with the fix
- [x] All 3 pre-existing premise-liveness caller test suites (`leo-create-sd-feedback-liveness`, `create-quick-fix-liveness-gate`, `refill-auto-promote-liveness`) still pass — 15/15 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)