### PR TITLE
fix(QF-20260703-472): FR-C generator: remap legacy 'info' severity to 'low' instead of 'medium' fallback

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-642",
+  "sdKey": "QF-20260703-472",
   "workType": "QF",
-  "workKey": "QF-20260703-642",
-  "expectedBranch": "qf/QF-20260703-642",
-  "createdAt": "2026-07-04T03:01:22.449Z",
+  "workKey": "QF-20260703-472",
+  "expectedBranch": "qf/QF-20260703-472",
+  "createdAt": "2026-07-04T03:46:38.096Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/quality-findings/legacy-adapter.js
+++ b/lib/eva/quality-findings/legacy-adapter.js
@@ -57,7 +57,15 @@ export function transformLegacyFinding(legacy, ctx) {
   if (!ctx?.venture_id) return null;
 
   const category = LEGACY_CHECK_MAP[legacy.check] || 'capability';
-  const severity = SEVERITY_LEVELS.includes(legacy.severity) ? legacy.severity : 'medium';
+  // QF-20260703-472: legacy producers emit severity:'info' for couldn't-run/passed
+  // conditions (e.g. "No package.json", "Tests passed") — 'info' has no canonical
+  // SEVERITY_LEVELS slot. Map it to 'low', which FR_C_REMEDIATION_SEVERITIES already
+  // excludes, instead of falling through to 'medium' (which does NOT exclude it and
+  // was silently promoting these into auto-filed remediation SDs — see feedback
+  // dc25b3da and SD-LEO-FIX-REMEDIATION-TEST-SUITE-001/003/004).
+  const severity = SEVERITY_LEVELS.includes(legacy.severity)
+    ? legacy.severity
+    : legacy.severity === 'info' ? 'low' : 'medium';
   const finding_signature = String(legacy.title || legacy.detail || legacy.check || 'unknown')
     .slice(0, 256);
   const finding_hash = computeFindingHash({

--- a/tests/unit/eva/quality-findings/legacy-adapter.test.js
+++ b/tests/unit/eva/quality-findings/legacy-adapter.test.js
@@ -41,6 +41,25 @@ describe('transformLegacyFinding', () => {
     expect(r.severity).toBe('medium');
   });
 
+  // QF-20260703-472: legacy producers emit severity:'info' for couldn't-run/passed
+  // conditions ("No package.json", "Tests passed", etc.) — 'info' is not a canonical
+  // SEVERITY_LEVELS value. It must remap to 'low' (excluded from FR_C_REMEDIATION_SEVERITIES),
+  // NOT fall through to 'medium' (included), or these get auto-filed as bogus remediation SDs.
+  it('remaps legacy info severity to low, not medium', () => {
+    const r = transformLegacyFinding(
+      { check: 'test_suite', title: 'No package.json', detail: 'Skipped tests', severity: 'info' },
+      ctx
+    );
+    expect(r.severity).toBe('low');
+  });
+
+  it('remaps info severity to low across every legacy check type', () => {
+    for (const check of ['npm_audit', 'test_suite', 'unit_test', 'e2e_test', 'feedback_widget_present', 'error_capture_wired']) {
+      const r = transformLegacyFinding({ check, title: 't', severity: 'info' }, ctx);
+      expect(r.severity).toBe('low');
+    }
+  });
+
   it('returns null for malformed input', () => {
     expect(transformLegacyFinding(null, ctx)).toBeNull();
     expect(transformLegacyFinding({ check: 'lint' }, {})).toBeNull(); // no venture_id


### PR DESCRIPTION
## Quick-Fix: QF-20260703-472

**Type:** bug
**Severity:** medium

### Issue Description
lib/eva/quality-findings/legacy-adapter.js transformLegacyFinding() maps any legacy.severity not in canonical SEVERITY_LEVELS (['critical','high','medium','low'], no 'info') to 'medium' via a blanket fallback. Every Stage-20 check producer legitimately emits severity:'info' for couldn't-run/passed conditions (e.g. runTestSuite's 'No package.json'/'Skipped tests', 'Tests passed'; runNpmAudit's 'No package.json found'; detectUnitTests/detectE2eTests/scanFeedbackWidget/scanErrorCapture's 'No package.json -- X undetectable'). The fallback silently promotes ALL of these to medium severity, which sails past FR_C_REMEDIATION_SEVERITIES=['critical','high','medium'] and isInformationalSkippedFinding()'s narrower regex (which only catches 'could not run'/'not available for'/'deps unavailable' phrasing), causing bogus full-LEAD remediation SDs to auto-file for conditions that are not real defects. Confirmed root cause of SD-LEO-FIX-REMEDIATION-TEST-SUITE-001/003/004 (3 of 4 instances of this SD family were premise-invalid cancellations tracing to this exact bug) and tracked as harness backlog in feedback dc25b3da.

### Steps to Reproduce
1. Run S20 analyzer against any venture repo where a check legitimately returns severity:'info' (e.g. package.json genuinely absent from a fresh clone, or a passing test suite). 2. Inspect the persisted venture_quality_findings row for that check.

### Expected Behavior
The persisted finding's severity is a value that does not spuriously trigger FR-C auto-filing for a non-defect ('info'-equivalent -- proposal: remap to 'low', which FR_C_REMEDIATION_SEVERITIES already excludes).

### Actual Behavior
The persisted finding's severity is silently promoted to 'medium' (legacy-adapter.js line 60's non-canonical-severity fallback), which IS in FR_C_REMEDIATION_SEVERITIES, so a full LEAD remediation SD gets auto-filed for a condition that was never a real defect.

### Changes
- **Files Changed:** 4
  - .worktree-nm-mode
  - .worktree.json
  - lib/eva/quality-findings/legacy-adapter.js
  - tests/unit/eva/quality-findings/legacy-adapter.test.js
- **LOC:** 33 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Reproduced against MarketLens live venture (S20 analyzer re-run + 4-instance historical review of SD-LEO-FIX-REMEDIATION-TEST-SUITE-001/002/003/004): legacy info-severity findings previously fell through to 'medium' via the non-canonical-severity fallback, sailing past FR_C_REMEDIATION_SEVERITIES and auto-filing bogus remediation SDs. Fix remaps info->low; 185 unit tests pass across the full quality-findings suite with zero regressions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol