### PR TITLE
fix(QF-20260703-248): legacy-adapter escalates unmodeled analyzer severities (e.g. info) to medium instead of failing safe

### DIFF
--- a/lib/eva/quality-findings/legacy-adapter.js
+++ b/lib/eva/quality-findings/legacy-adapter.js
@@ -57,7 +57,13 @@ export function transformLegacyFinding(legacy, ctx) {
   if (!ctx?.venture_id) return null;
 
   const category = LEGACY_CHECK_MAP[legacy.check] || 'capability';
-  const severity = SEVERITY_LEVELS.includes(legacy.severity) ? legacy.severity : 'medium';
+  // QF-20260703-248: fail-safe, not escalating. The stage-20 analyzer emits severity='info' at
+  // several sites for skipped/inconclusive/non-actionable checks (missing package.json, lint
+  // couldn't run, even a passing test suite) -- 'info' isn't in SEVERITY_LEVELS, so this used to
+  // default to 'medium', silently promoting a benign signal into a triage-worthy one and
+  // auto-filing spurious remediation SDs. 'low' is already FR_C_REMEDIATION_SEVERITIES' excluded
+  // (non-filing) band, so an unmodeled severity now lands there instead of escalating.
+  const severity = SEVERITY_LEVELS.includes(legacy.severity) ? legacy.severity : 'low';
   const finding_signature = String(legacy.title || legacy.detail || legacy.check || 'unknown')
     .slice(0, 256);
   const finding_hash = computeFindingHash({

--- a/tests/unit/eva/quality-findings/legacy-adapter.test.js
+++ b/tests/unit/eva/quality-findings/legacy-adapter.test.js
@@ -33,12 +33,23 @@ describe('transformLegacyFinding', () => {
     expect(r.evidence_pointer.legacy_check).toBe('mystery_check');
   });
 
-  it('defaults bad severity to medium', () => {
+  it('defaults bad severity to low (fail-safe, not escalating)', () => {
     const r = transformLegacyFinding(
       { check: 'lint', title: 't', severity: 'urgent' },
       ctx
     );
-    expect(r.severity).toBe('medium');
+    expect(r.severity).toBe('low');
+  });
+
+  it('QF-20260703-248: an info-severity skipped-check finding fails safe to low, not medium', () => {
+    // The exact live specimen: stage-20-code-quality.js emits severity='info' for a skipped
+    // npm_audit check ("No package.json found"). 'info' isn't in SEVERITY_LEVELS, so it must
+    // land in the excluded (non-filing) 'low' band, not the auto-filed 'medium' band.
+    const r = transformLegacyFinding(
+      { check: 'npm_audit', title: 'No package.json found', detail: 'Skipped npm audit', severity: 'info' },
+      ctx
+    );
+    expect(r.severity).toBe('low');
   });
 
   it('returns null for malformed input', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260703-248

**Type:** bug
**Severity:** medium

### Issue Description
lib/eva/quality-findings/legacy-adapter.js:60 defaults any legacy finding severity not in SEVERITY_LEVELS (['critical','high','medium','low']) to 'medium' -- an escalating fallback. The stage-20 analyzer emits severity='info' at 11 sites for skipped/inconclusive/non-actionable checks (missing package.json, lint could not run, even a passing test suite), all of which get silently promoted to medium and can auto-file spurious remediation SDs via FR-C'. Live specimen: SD-LEO-FIX-REMEDIATION-NPM-AUDIT-004 was auto-filed and required LEAD triage for a npm_audit check that never actually ran (no package.json in the venture's sandbox checkout) -- cancelled as a false positive after investigation.

### Steps to Reproduce
Run the stage-20 quality analyzer against a venture whose sandbox checkout lacks a package.json; observe the resulting venture_quality_findings row persists with severity=medium (not info), and gets auto-filed as a remediation SD by the FR-C' generator

### Expected Behavior
An unmodeled/non-actionable severity (info) fails safe to the lowest band ('low'), which FR_C_REMEDIATION_SEVERITIES already excludes from auto-filing, rather than escalating to a triage-worthy severity

### Actual Behavior
legacy-adapter.js's fallback defaults to 'medium', silently promoting a benign analyzer signal into an actionable-looking finding

### Changes
- **Files Changed:** 2
  - lib/eva/quality-findings/legacy-adapter.js
  - tests/unit/eva/quality-findings/legacy-adapter.test.js
- **LOC:** 24 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Verified via 2 new/updated regression tests (11 total in file, all pass; 188 pass across the full quality-findings test directory + smoke suite): (1) the generic bad-severity test now asserts fail-safe to 'low' instead of escalating 'medium'; (2) a dedicated test reproduces the exact live specimen (npm_audit, severity=info, 'No package.json found') and confirms it now lands at 'low' instead of 'medium'. Live specimen SD-LEO-FIX-REMEDIATION-NPM-AUDIT-004 + its underlying venture_quality_findings row were independently cancelled as a false positive (not part of this QF's code diff).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol