### PR TITLE
fix(SD-FDBK-ENH-SECURITY-FOLLOW-NON-001): harden husky hook re-link against registry fallthrough

### DIFF
--- a/lib/worktree-provision.js
+++ b/lib/worktree-provision.js
@@ -77,12 +77,17 @@ function defaultWriteMarker(worktreePath, modeStr) {
  * npm's "prepare" lifecycle script, so `.husky/_` — which core.hooksPath points
  * at — never gets created and EVERY git hook (commit-msg Strunkian check,
  * pre-commit secret scanning) silently never fires in a fresh worktree.
- * `npx husky` alone (no full install) recreates just the shims, in ~2s.
+ * Invoking husky's bin.js directly (no full install) recreates just the shims,
+ * in ~2s. Deliberately NOT `npx husky`: npx falls through to resolving `husky`
+ * from the public npm registry when the local binary is absent -- a
+ * supply-chain-adjacent risk on this security-relevant path. `node
+ * node_modules/husky/bin.js` has no npm/npx package resolver in the loop at
+ * all, so it is structurally incapable of reaching the registry.
  * Fail-open: a hook-provisioning failure must never make a worktree unusable.
  */
 export function defaultEnsureHuskyHooks(worktreePath, { execSyncImpl = execSync } = {}) {
   try {
-    execSyncImpl('npx husky', { cwd: worktreePath, stdio: 'pipe', timeout: 15000 });
+    execSyncImpl('node node_modules/husky/bin.js', { cwd: worktreePath, stdio: 'pipe', timeout: 15000 });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err.message };

--- a/tests/unit/sd-start-install-decision-worktree-path.test.js
+++ b/tests/unit/sd-start-install-decision-worktree-path.test.js
@@ -90,9 +90,10 @@ describe('FR1 acceptance: install decision must be resolved against the WORKTREE
 describe('FR4 acceptance: git hooks must be provisioned independently of the install-skip decision', () => {
   it('defaultEnsureHuskyHooks provisions .husky/_ in a worktree that has no npm install at all (skip-path parity)', () => {
     // This proves hook provisioning does not depend on npm install having run --
-    // `npx husky` alone recreates the shims in any git-initialized directory.
-    // Skipped in CI environments without a real git binary / npx on PATH is acceptable
-    // (fail-open is the documented contract); we only assert the call never throws.
+    // `node node_modules/husky/bin.js` recreates the shims when a local husky is
+    // present. This temp dir has no node_modules at all, so the call is expected
+    // to fail cleanly (fail-open is the documented contract); we only assert it
+    // never throws, regardless of the underlying failure mode.
     const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-decision-husky-'));
     tmpDirs.push(worktreeDir);
     expect(() => defaultEnsureHuskyHooks(worktreeDir)).not.toThrow();

--- a/tests/unit/worktree-provision-husky-hooks.test.js
+++ b/tests/unit/worktree-provision-husky-hooks.test.js
@@ -8,7 +8,7 @@
  * worktree provisioning itself if hook re-linking fails.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { provisionWorktreeNodeModules } from '../../lib/worktree-provision.js';
+import { provisionWorktreeNodeModules, defaultEnsureHuskyHooks } from '../../lib/worktree-provision.js';
 
 function makeDeps(overrides = {}) {
   return {
@@ -44,5 +44,32 @@ describe('provisionWorktreeNodeModules — husky hook re-link (QF-20260703-311)'
     const result = provisionWorktreeNodeModules('/fake/wt', { deps });
     expect(result.strategy).toBe('junction');
     expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('husky hook re-link failed'));
+  });
+});
+
+describe('defaultEnsureHuskyHooks (SD-FDBK-ENH-SECURITY-FOLLOW-NON-001)', () => {
+  it('invokes husky via a direct node call, never via npx (registry-fallthrough hardening)', () => {
+    const execSyncImpl = vi.fn(() => '');
+    defaultEnsureHuskyHooks('/fake/wt', { execSyncImpl });
+    expect(execSyncImpl).toHaveBeenCalledTimes(1);
+    const [command, options] = execSyncImpl.mock.calls[0];
+    expect(command).not.toMatch(/npx/i);
+    expect(command).toMatch(/node\s+node_modules[\\/]husky[\\/]bin\.js/);
+    expect(options.cwd).toBe('/fake/wt');
+  });
+
+  it('is fail-open: returns {ok:false, error} instead of throwing when the local husky binary is missing', () => {
+    const execSyncImpl = vi.fn(() => {
+      throw new Error("Cannot find module 'node_modules/husky/bin.js'");
+    });
+    const result = defaultEnsureHuskyHooks('/fake/wt', { execSyncImpl });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/husky/);
+  });
+
+  it('returns {ok:true} on success', () => {
+    const execSyncImpl = vi.fn(() => '');
+    const result = defaultEnsureHuskyHooks('/fake/wt', { execSyncImpl });
+    expect(result).toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
## Summary
- `defaultEnsureHuskyHooks()` (`lib/worktree-provision.js`) re-links a worktree's git hook shims (`.husky/_`) via `execSync`. It ran bare `npx husky`, which can fall through to resolving `husky` from the public npm registry when the local binary isn't present — a supply-chain-adjacent risk on a security-relevant path (this function keeps commit-msg/pre-commit/pre-push hooks working).
- Switched to `node node_modules/husky/bin.js`, which has no npm/npx package resolver in the loop at all — structurally incapable of reaching the registry, unlike any npm-flag-based approach. Empirically verified working on this Windows/git-bash environment (both via a mocked unit test and a live run against a real worktree, confirmed `.husky/_` shims present afterward).
- The `{ok,error}` contract and both production callers (`scripts/sd-start.js:1807`, and this file's own junction/isolate strategies) are unchanged — no other call sites needed changes.
- Non-blocking follow-up from SD-LEO-INFRA-START-INSTALL-SKIP-001 FR4.

## Test plan
- [x] `tests/unit/worktree-provision-husky-hooks.test.js` — 6 tests (3 existing + 3 new), all pass
- [x] `tests/unit/fleet-lock-hash.test.js`, `tests/unit/sd-start-install-decision-worktree-path.test.js` — 0 regressions (54 tests total across the 3 files)
- [x] Live-verified: ran the new invocation directly against this real worktree, confirmed `.husky/_` shims present afterward
- [x] Grepped `lib/` for `npx husky` — no remaining references outside the explanatory comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)