### PR TITLE
fix(QF-20260704-319): Stall escalator must verify primary correlation state before filing - specimen escalated a delivered+ratified+closed commission 19min after closure

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-642",
+  "sdKey": "QF-20260704-319",
   "workType": "QF",
-  "workKey": "QF-20260703-642",
-  "expectedBranch": "qf/QF-20260703-642",
-  "createdAt": "2026-07-04T03:01:22.449Z",
+  "workKey": "QF-20260704-319",
+  "expectedBranch": "qf/QF-20260704-319",
+  "createdAt": "2026-07-04T04:10:13.014Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -59,6 +59,41 @@ async function isSdTerminal(supabase, sdKey) {
 }
 
 /**
+ * QF-20260704-319: an advisory_thread board node mirrors a session_coordination correlation
+ * (node.source_ref is the correlation id), not board bookkeeping -- its true terminal state
+ * lives in whether that correlation got a REPLY or a chairman decision, which can resolve
+ * without ever touching the board node's own updated_at. Live specimen: the standing
+ * strategist commission (correlation adam-solomon-standing-strategist-001) got Solomon's
+ * reply at 03:18:28Z, but the ticks-since-movement stall fired at 03:54Z anyway -- 35+
+ * minutes after the correlation was already closed, because nothing here ever looked past
+ * the board node itself. Checks BOTH signals per the acceptance ("reply delivered? decision
+ * ratified?"): a session_coordination reply keyed on payload.reply_to, or a non-pending
+ * chairman_decisions row tied to the same correlation via brief_data.context.correlation_id.
+ * Fail-soft (a query error is NOT terminal — never silently swallow a possibly-real stall).
+ */
+async function isCorrelationTerminal(supabase, correlationId) {
+  if (!correlationId) return false;
+  try {
+    const { data: replies } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .filter('payload->>reply_to', 'eq', correlationId)
+      .limit(1);
+    if (Array.isArray(replies) && replies.length > 0) return true;
+
+    const { data: decisions } = await supabase
+      .from('chairman_decisions')
+      .select('id')
+      .filter('brief_data->context->>correlation_id', 'eq', correlationId)
+      .neq('status', 'pending')
+      .limit(1);
+    return Array.isArray(decisions) && decisions.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Pure: bump (or reset) the ticks-since-movement counter for a node given its current
  * updated_at and the previous tick's snapshot for that node. No movement recorded yet
  * (or the timestamp changed) resets the counter to 0; an unchanged timestamp increments it.
@@ -104,6 +139,12 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
     // Self-heal: a sourced_sd node whose linked SD already finished is a stale board row,
     // not a genuine stall — close it instead of escalating.
     if (node.source_kind === 'sourced_sd' && node.source_ref && await isSdTerminal(supabase, node.source_ref)) {
+      await setStatus(supabase, node.id, 'done').catch(() => {});
+      continue;
+    }
+    // QF-20260704-319: same self-heal for an advisory_thread node whose correlation already
+    // got a reply or a ratified decision — the board row is stale, not a genuine stall.
+    if (node.source_kind === 'advisory_thread' && node.source_ref && await isCorrelationTerminal(supabase, node.source_ref)) {
       await setStatus(supabase, node.id, 'done').catch(() => {});
       continue;
     }

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -59,6 +59,37 @@ function makeStallDigestSupabase() {
   };
 }
 
+/** Minimal supabase stub for the QF-20260704-319 correlation-terminal check
+ *  (isCorrelationTerminal): session_coordination reply lookup + chairman_decisions
+ *  ratified-decision lookup, matching only the query shapes stall-alert.js issues. */
+function sbWithCorrelationState({ hasReply = false, hasRatifiedDecision = false } = {}) {
+  return {
+    from(table) {
+      if (table === 'session_coordination') {
+        return {
+          select: () => ({
+            filter: () => ({
+              limit: async () => ({ data: hasReply ? [{ id: 'reply-1' }] : [], error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'chairman_decisions') {
+        return {
+          select: () => ({
+            filter: () => ({
+              neq: () => ({
+                limit: async () => ({ data: hasRatifiedDecision ? [{ id: 'dec-x' }] : [], error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+    },
+  };
+}
+
 /** Minimal supabase stub for strategic_directives_v2 status lookups (isSdTerminal). */
 function sbWithSdStatus(statusBySdKey) {
   return {
@@ -196,6 +227,38 @@ describe('QF-20260703-229: false-stall flood fix', () => {
     expect(call.context.node_ids).toEqual(['a', 'b', 'c']);
     expect(alerted).toHaveLength(3);
     expect(alerted.every((a) => a.escalated === true)).toBe(true);
+  });
+});
+
+describe('QF-20260704-319: advisory_thread correlation-terminal self-heal', () => {
+  const parents = [{
+    id: 'commission-1', title: 'Standing strategist commission', updated_at: 'fixed',
+    source_kind: 'advisory_thread', source_ref: 'adam-solomon-standing-strategist-001', inFlightNextStep: false,
+  }];
+  const prevSnapshot = { 'commission-1': { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+  it('a correlation with a delivered reply self-heals — never files even at high tick-count', async () => {
+    const stubSb = sbWithCorrelationState({ hasReply: true });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(setStatus).toHaveBeenCalledWith(stubSb, 'commission-1', 'done');
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('a correlation with a ratified (non-pending) chairman decision also self-heals', async () => {
+    const stubSb = sbWithCorrelationState({ hasReply: false, hasRatifiedDecision: true });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(setStatus).toHaveBeenCalledWith(stubSb, 'commission-1', 'done');
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('a genuinely open correlation (no reply, no decision) still escalates', async () => {
+    const stubSb = sbWithCorrelationState({ hasReply: false, hasRatifiedDecision: false });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'commission-1', title: 'Standing strategist commission', escalated: true }]);
   });
 });
 


### PR DESCRIPTION
## Quick-Fix: QF-20260704-319

**Type:** bug
**Severity:** medium

### Issue Description
Solomon oversight read #2 (verified first-hand) + Adam-verified counts: the stall escalation path (lib/adam/stall-alert.js -> recordPendingDecision) still decides from ticks-since-movement AFTER the QF-229 node-status fixes - specimen 7e55cb47 escalated the standing strategist commission as a PM stall at 03:54Z, 19+ minutes after the commission was delivered, chairman-ratified, and loop-closed. QF-229 added board-status + source_ref SD checks; the remaining gap is CORRELATION/thread terminal state: before filing, resolve the node's correlation (advisory thread acked? reply delivered? decision ratified?) from session_coordination/chairman_decisions and SUPPRESS on any terminal signal. Acceptance both-directions: a closed-correlation node never files even at high tick-count; a genuinely-stalled open correlation still does.


### Expected Behavior
No escalation ever files on a terminally-resolved correlation

### Actual Behavior
Ratified+closed commission escalated as stalled 19min post-closure

### Changes
- **Files Changed:** 3
  - .worktree.json
  - lib/adam/stall-alert.js
  - tests/unit/adam/stall-alert.test.js
- **LOC:** 108 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Verified via 3 new regression tests (15 total in file, all pass; 30 pass with smoke suite): (1) a correlation with a delivered reply self-heals to done and never files, even at high tick-count; (2) a correlation with a ratified (non-pending) chairman decision also self-heals; (3) a genuinely open correlation (no reply, no decision) still escalates normally -- both directions of the acceptance criteria. Also verified the exact query shapes run error-free against the LIVE DB using the real specimen data (correlation adam-solomon-standing-strategist-001) -- the reply-detection query correctly found Solomon's real reply row.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol