### PR TITLE
fix(QF-20260704-748): decision_rubric self-probe blind to machine-raised escalations - widen denominator to include raised_by=adam automated rows

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-642",
+  "sdKey": "QF-20260704-748",
   "workType": "QF",
-  "workKey": "QF-20260703-642",
-  "expectedBranch": "qf/QF-20260703-642",
-  "createdAt": "2026-07-04T03:01:22.449Z",
+  "workKey": "QF-20260704-748",
+  "expectedBranch": "qf/QF-20260704-748",
+  "createdAt": "2026-07-04T04:12:22.829Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -294,13 +294,14 @@ export function classifyDecisionQuestion(body) {
  * an Adam->chairman decision-question that matches NO COMES-TO-HIM trigger AND is already-determined
  * (an over-ask — Adam asked the chairman to ratify a decision that was already his to take).
  * ADVISORY: a FAIL is a propose-only self-review note, never a block of Adam's comms (CONST-002).
- * @param {{ adamChairmanDecisionQuestionsInWindow?: Array<{body?:string}>|null }} facts
+ * @param {{ adamChairmanDecisionQuestionsInWindow?: Array<{body?:string}>|null, adamMachineRaisedNoiseInWindow?: Array<{id?:string}>|null }} facts
  */
 export function probeDecisionRubric(facts = {}) {
   const duty = 'decision-rubric: Adam escalates to the chairman only for COMES-TO-HIM decisions (new strategy/policy, reserved kill gate, ratified-deviation, irreversible/external) and decides the rest itself (advisory; CONST-002)';
   const items = facts.adamChairmanDecisionQuestionsInWindow;
-  if (unresolved(items) || !Array.isArray(items)) {
-    return bar('decision_rubric', duty, VERDICT.UNKNOWN, 'adamChairmanDecisionQuestionsInWindow unresolved — cannot assess over-asks (not a pass)');
+  const machineNoise = facts.adamMachineRaisedNoiseInWindow;
+  if (unresolved(items) || !Array.isArray(items) || unresolved(machineNoise) || !Array.isArray(machineNoise)) {
+    return bar('decision_rubric', duty, VERDICT.UNKNOWN, 'adamChairmanDecisionQuestionsInWindow / adamMachineRaisedNoiseInWindow unresolved — cannot assess over-asks (not a pass)');
   }
   // SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001: measure CURRENT adherence. The corpus is the
   // in-window message set the resolver supplies (windowBasis reported for interpretability); over-asks
@@ -308,20 +309,28 @@ export function probeDecisionRubric(facts = {}) {
   // rows that carry a remediation_ref) are EXCLUDED so a resolved/historical over-ask never re-fails.
   const windowBasis = facts.decisionRubricWindowBasis || `${facts.windowDays ?? 1}-day rolling window`;
   const resolved = new Set(Array.isArray(facts.resolvedOverAskFingerprints) ? facts.resolvedOverAskFingerprints : []);
-  const overAsks = items
+  const textOverAsks = items
     .map((it) => ({ it, c: classifyDecisionQuestion(it && it.body), fp: fingerprintOverAsk(it && it.body) }))
     .filter((x) => x.c.overAsk);
+  // QF-20260704-748: a machine-raised chairman_decisions row (stall-detector escalation) that was
+  // later cancelled without real chairman action carries no free-text body to classify — the
+  // cancellation-without-action IS the over-ask signal, so it counts directly (fingerprinted on the
+  // row id, which is stable per-row, rather than on absent body text).
+  const noiseOverAsks = machineNoise.map((it) => ({ it, fp: fingerprintOverAsk(it && it.id) }));
+  const overAsks = [...textOverAsks, ...noiseOverAsks];
   const fpsTail = encodeFingerprintsTail(overAsks.map((x) => x.fp));   // persisted so a later remediation resolves them
   const fresh = overAsks.filter((x) => !resolved.has(x.fp));
   const excluded = overAsks.length - fresh.length;
   const exclNote = excluded > 0 ? `, ${excluded} excluded as already-remediated` : '';
+  const totalExamined = items.length + machineNoise.length;
   if (fresh.length === 0) {
     return bar('decision_rubric', duty, VERDICT.PASS,
-      `${items.length} decision-question(s) examined in ${windowBasis} — 0 NEW over-asks${exclNote}${fpsTail}`);
+      `${totalExamined} decision-question(s) examined in ${windowBasis} — 0 NEW over-asks${exclNote}${fpsTail}`);
   }
-  const sample = String(fresh[0].it && fresh[0].it.body || '').slice(0, 120);
+  const freshText = fresh.find((x) => x.it && typeof x.it.body === 'string');
+  const sample = freshText ? String(freshText.it.body).slice(0, 120) : `machine-raised decision ${fresh[0].it?.id ?? ''} cancelled without chairman action`;
   return bar('decision_rubric', duty, VERDICT.FAIL,
-    `${fresh.length} NEW likely over-ask(s) of ${items.length} in ${windowBasis}${exclNote} — Adam asked the chairman to ratify an already-determined, reversible decision matching no COMES-TO-HIM trigger (e.g. "${sample}…")${fpsTail}`);
+    `${fresh.length} NEW likely over-ask(s) of ${totalExamined} in ${windowBasis}${exclNote} — Adam asked the chairman to ratify an already-determined, reversible decision matching no COMES-TO-HIM trigger (e.g. "${sample}…")${fpsTail}`);
 }
 
 /**

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -46,6 +46,7 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     signalsInWindow: null,
     adamAuthoredBuildsInWindow: null,
     adamChairmanDecisionQuestionsInWindow: null,
+    adamMachineRaisedNoiseInWindow: null,
     pmBoardSnapshot: null,
     pmBoardPriorSnapshot: null,
   };
@@ -178,6 +179,27 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
       facts.adamChairmanDecisionQuestionsInWindow = data.map((r) => ({
         body: r && r.payload ? (r.payload.body ?? r.payload.message ?? r.payload.subject ?? '') : '',
         created_at: r ? r.created_at : null,
+      }));
+    }
+  } catch { /* leave null -> unknown */ }
+
+  // QF-20260704-748: the decision_rubric probe above only sees Adam's free-text advisory channel.
+  // The stall detector (lib/adam/stall-alert.js) raises a SEPARATE, structured escalation channel --
+  // chairman_decisions rows inserted via recordPendingDecision(raisedBy:'adam') -- that carries no
+  // free-text body to classify. A row later cancelled without real chairman action IS itself the
+  // over-ask signal (Adam auto-escalated something that resolved as noise). HONEST: only a thrown
+  // query error leaves this null -> unknown; a real 0 is a real 0.
+  try {
+    const { data, error } = await supabase
+      .from('chairman_decisions')
+      .select('id, summary, created_at')
+      .gte('created_at', since)
+      .eq('status', 'cancelled')
+      .or('brief_data->>raised_by.eq.adam,brief_data->>recorded_via.eq.record-pending-decision');
+    if (error) throw error;
+    if (Array.isArray(data)) {
+      facts.adamMachineRaisedNoiseInWindow = data.map((r) => ({
+        id: r.id, summary: r.summary, created_at: r.created_at,
       }));
     }
   } catch { /* leave null -> unknown */ }

--- a/tests/unit/adam/adherence-probes.test.js
+++ b/tests/unit/adam/adherence-probes.test.js
@@ -68,7 +68,7 @@ describe('runAdherenceProbes + hasDrift', () => {
     const bars = runAdherenceProbes({
       sourcedInWindow: 1, visionGaugeReadInWindow: true, recurrencesInWindow: 0, signalsInWindow: 0,
       adamAuthoredBuildsInWindow: 0, claimableBelt: 1, idleWorkers: 0, sourceableBacklogCount: 0,
-      advisoryBody: 'ok', adamChairmanDecisionQuestionsInWindow: [],
+      advisoryBody: 'ok', adamChairmanDecisionQuestionsInWindow: [], adamMachineRaisedNoiseInWindow: [],
       pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map(),
     });
     expect(bars).toHaveLength(8);

--- a/tests/unit/adam/decision-rubric-probe.test.js
+++ b/tests/unit/adam/decision-rubric-probe.test.js
@@ -75,25 +75,63 @@ describe('probeDecisionRubric — verdict', () => {
   const escalationBody = 'New pricing strategy proposed for venture-2 — this is your call, approve?';
 
   it('FAILs with an over-ask detail when >=1 likely over-ask is present', () => {
-    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: overAskBody }, { body: escalationBody }] });
+    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: overAskBody }, { body: escalationBody }], adamMachineRaisedNoiseInWindow: [] });
     expect(b.verdict).toBe(VERDICT.FAIL);
     expect(b.probe).toBe('decision_rubric');
     expect(b.detail).toMatch(/over-ask/i);
   });
 
   it('PASSes when there are no over-asks (only legitimate escalations)', () => {
-    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: escalationBody }] });
+    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: escalationBody }], adamMachineRaisedNoiseInWindow: [] });
     expect(b.verdict).toBe(VERDICT.PASS);
   });
 
   it('PASSes on an honest empty window (nothing to flag)', () => {
-    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [] });
+    const b = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [], adamMachineRaisedNoiseInWindow: [] });
     expect(b.verdict).toBe(VERDICT.PASS);
   });
 
   it('is advisory + fail-loud: a null fact yields UNKNOWN, never a silent pass', () => {
-    expect(probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: null }).verdict).toBe(VERDICT.UNKNOWN);
+    expect(probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: null, adamMachineRaisedNoiseInWindow: [] }).verdict).toBe(VERDICT.UNKNOWN);
+    expect(probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [], adamMachineRaisedNoiseInWindow: null }).verdict).toBe(VERDICT.UNKNOWN);
     expect(probeDecisionRubric({}).verdict).toBe(VERDICT.UNKNOWN);
+  });
+});
+
+// QF-20260704-748: the stall detector raises machine-escalations directly into chairman_decisions
+// (no free-text advisory body), so a cancelled-as-noise row must count as an over-ask even though
+// the text classifier never sees it — closing the blind spot that let a 197-row flood window PASS.
+describe('probeDecisionRubric — machine-raised noise channel (QF-20260704-748)', () => {
+  const cleanTextOnly = [{ body: 'New pricing strategy proposed for venture-2 — this is your call, approve?' }];
+
+  it('FAILs when machine-raised noise rows exist even with zero text over-asks', () => {
+    const noise = Array.from({ length: 3 }, (_, i) => ({ id: `dec-${i}`, summary: 'stall alert' }));
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: cleanTextOnly, adamMachineRaisedNoiseInWindow: noise });
+    expect(r.verdict).toBe(VERDICT.FAIL);
+    expect(r.detail).toMatch(/3 NEW likely over-ask\(s\) of 4/);
+  });
+
+  it('replays the flood specimen: 128 clean text questions + 197 cancelled-noise rows -> FAIL', () => {
+    const noise = Array.from({ length: 197 }, (_, i) => ({ id: `flood-${i}` }));
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: cleanTextOnly.slice(0).concat(Array(127).fill(cleanTextOnly[0])), adamMachineRaisedNoiseInWindow: noise });
+    expect(r.verdict).toBe(VERDICT.FAIL);
+    expect(r.detail).toMatch(/197 NEW likely over-ask\(s\) of 325/);
+  });
+
+  it('a clean window (no text over-asks, no machine noise) still PASSes', () => {
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: cleanTextOnly, adamMachineRaisedNoiseInWindow: [] });
+    expect(r.verdict).toBe(VERDICT.PASS);
+  });
+
+  it('a resolved machine-noise fingerprint (by row id) is excluded on replay', () => {
+    const fp = fingerprintOverAsk('dec-1');
+    const r = probeDecisionRubric({
+      adamChairmanDecisionQuestionsInWindow: [],
+      adamMachineRaisedNoiseInWindow: [{ id: 'dec-1' }],
+      resolvedOverAskFingerprints: [fp],
+    });
+    expect(r.verdict).toBe(VERDICT.PASS);
+    expect(r.detail).toMatch(/1 excluded as already-remediated/);
   });
 });
 
@@ -112,7 +150,7 @@ describe('decision_rubric resolved-exclusion (SD-LEO-INFRA-ADAM-DECISION-RUBRIC-
   });
 
   it('FAILS on a NEW over-ask and emits its fingerprint on the detail tail', () => {
-    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], windowDays: 1 });
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], adamMachineRaisedNoiseInWindow: [], windowDays: 1 });
     expect(r.verdict).toBe(VERDICT.FAIL);
     expect(parseFingerprintsTail(r.detail)).toEqual([fingerprintOverAsk(OVER_ASK)]);
     expect(r.detail).toMatch(/NEW/);
@@ -121,7 +159,7 @@ describe('decision_rubric resolved-exclusion (SD-LEO-INFRA-ADAM-DECISION-RUBRIC-
 
   it('PASSES when the only over-ask was already remediated (its fingerprint is in resolvedOverAskFingerprints)', () => {
     const fp = fingerprintOverAsk(OVER_ASK);
-    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], resolvedOverAskFingerprints: [fp], windowDays: 1 });
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], adamMachineRaisedNoiseInWindow: [], resolvedOverAskFingerprints: [fp], windowDays: 1 });
     expect(r.verdict).toBe(VERDICT.PASS);
     expect(r.detail).toMatch(/0 NEW over-asks/);
     expect(r.detail).toMatch(/1 excluded as already-remediated/);
@@ -130,6 +168,7 @@ describe('decision_rubric resolved-exclusion (SD-LEO-INFRA-ADAM-DECISION-RUBRIC-
   it('still FAILS on a NEW over-ask even when a DIFFERENT historical over-ask is resolved (improving-but-not-clean)', () => {
     const r = probeDecisionRubric({
       adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }],
+      adamMachineRaisedNoiseInWindow: [],
       resolvedOverAskFingerprints: ['someotherfp01'],
       windowDays: 1,
     });

--- a/tests/unit/adam/execute-vs-escalate.test.js
+++ b/tests/unit/adam/execute-vs-escalate.test.js
@@ -98,12 +98,12 @@ describe('classifyDecisionQuestion (routed through the 3-gate classifier)', () =
 // ── TS-4: probeDecisionRubric end-to-end ─────────────────────────────────────
 describe('probeDecisionRubric', () => {
   it('PASS when there are zero over-asks', () => {
-    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'Irreversible launch — your call?' }] };
+    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'Irreversible launch — your call?' }], adamMachineRaisedNoiseInWindow: [] };
     expect(probeDecisionRubric(facts).verdict).toBe('pass');
   });
 
   it('FAIL when an over-ask is present', () => {
-    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'I recommend we shelve this reversible item — should I proceed?' }] };
+    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'I recommend we shelve this reversible item — should I proceed?' }], adamMachineRaisedNoiseInWindow: [] };
     expect(probeDecisionRubric(facts).verdict).toBe('fail');
   });
 


### PR DESCRIPTION
## Quick-Fix: QF-20260704-748

**Type:** bug
**Severity:** medium

### Issue Description
Solomon oversight read #2: the adam-self-adherence decision_rubric probe examined 128 decision-questions in the same 9h window where the stall detector filed 197 machine-raised chairman_decisions rows and scored PASS with 0 over-asks - machine-raised escalations are outside its denominator, so the largest over-escalation channel is structurally invisible to the probe (same shape as the 06-30 incident it also missed). Fix in lib/adam/adherence-probes.js decision_rubric: include chairman_decisions rows with raised_by=adam (or recorded_via=record-pending-decision) in the over-ask denominator, counting cancelled-as-noise rows as over-escalations. Acceptance both-directions: replaying the 07-03 19:00Z-04:00Z window the probe FAILS (197 noise rows); a clean window still PASSES.


### Expected Behavior
Probe counts machine-raised escalations; the flood window retro-fails

### Actual Behavior
Probe scored PASS during a 197-row machine flood

### Changes
- **Files Changed:** 6
  - .worktree.json
  - lib/adam/adherence-probes.js
  - scripts/adam-self-adherence-review.mjs
  - tests/unit/adam/adherence-probes.test.js
  - tests/unit/adam/decision-rubric-probe.test.js
  - tests/unit/adam/execute-vs-escalate.test.js
- **LOC:** 90 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Traced the exact schema (chairman_decisions.brief_data JSONB, no top-level raised_by column; confirmed via lib/chairman/record-pending-decision.mjs + live query: 199 cancelled / 7 approved Adam-raised rows). Widened the decision_rubric resolver to also query chairman_decisions for Adam-raised rows cancelled within the window, and widened probeDecisionRubric to count each as a structural over-ask (fingerprinted by row id). Replay test with 128 clean text + 197 cancelled-noise rows now FAILs; a clean window still PASSes. 395 unit tests pass across the full adam test directory with zero regressions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol