### PR TITLE
fix(QF-20260704-047): red-merge-detector: use identity+reachability, not raw count, to gate false-positive QF filing

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260704-319",
+  "sdKey": "QF-20260704-047",
   "workType": "QF",
-  "workKey": "QF-20260704-319",
-  "expectedBranch": "qf/QF-20260704-319",
-  "createdAt": "2026-07-04T04:10:13.014Z",
+  "workKey": "QF-20260704-047",
+  "expectedBranch": "qf/QF-20260704-047",
+  "createdAt": "2026-07-04T05:32:19.727Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -21,6 +21,7 @@
 import 'dotenv/config';
 import { execFileSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
+import { classifyRegressions } from '../lib/baseline-regression-check.mjs';
 
 const DIMENSION = 'ci_test_failure_count'; // must match compare-to-main-snapshot.mjs
 const TABLE = 'codebase_health_snapshots';
@@ -222,6 +223,29 @@ export function detectBaselineRot(snapshots = [], opts = {}) {
   };
 }
 
+/**
+ * IDENTITY + REACHABILITY gate on a count-based file_qf verdict (RCA a34446da,
+ * QF-20260704-263 — 4th confirmed count-vs-identity false positive). decide()'s
+ * count rule is a cheap pre-filter; a +1 from a flaky test in a file the merge
+ * never touched is not a red merge. Delegates to the already-shipped PR-leg
+ * comparator so the two gates never drift. Returns null (not []) when either
+ * snapshot predates failed_test_ids (legacy) — the caller must fall back to
+ * the count verdict rather than treat that as "zero regressions".
+ * @param {{findings?: Array<{failed_test_ids?: string[]}>}} latestSnap
+ * @param {{findings?: Array<{failed_test_ids?: string[]}>}} prevSnap
+ * @param {string[]|null} changedFiles
+ * @returns {string[]|null}
+ */
+export function genuineReachableRegressions(latestSnap, prevSnap, changedFiles) {
+  const currentIds = latestSnap?.findings?.[0]?.failed_test_ids;
+  const baselineIds = prevSnap?.findings?.[0]?.failed_test_ids;
+  if (!Array.isArray(currentIds) || !Array.isArray(baselineIds)) return null;
+  return classifyRegressions({
+    currentFailed: currentIds.length, currentIds,
+    baselineFailedCount: baselineIds.length, baselineIds, changedFiles,
+  }).newRegressions;
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
   const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -274,11 +298,32 @@ async function main() {
   console.log(`[red-merge-detector] ${verdict.action}: ${verdict.reason}`);
   if (verdict.action !== 'file_qf') return;
 
+  // IDENTITY+REACHABILITY GATE (RCA a34446da, QF-20260704-263): suppress unless a
+  // NEW failing identity is reachable from the merge's own diff — same rule as the
+  // PR-leg gate (shared module, no drift). Fails open to the count-fire when either
+  // snapshot lacks failed_test_ids or the diff can't be computed.
+  let changedFiles = null;
+  try {
+    changedFiles = execFileSync('git', ['show', '--name-only', '--format=', verdict.sha], { encoding: 'utf8' })
+      .split('\n').map((s) => s.trim()).filter(Boolean).map((s) => s.replace(/\\/g, '/'));
+  } catch { /* diff hiccup — fall open to identity-only (still better than count-only) */ }
+  const genuine = genuineReachableRegressions(mainSnaps[0], mainSnaps[1], changedFiles);
+  if (Array.isArray(genuine)) {
+    if (genuine.length === 0) {
+      console.log(`[red-merge-detector] noop: count ${verdict.prevFailed}->${verdict.newFailed} at ${verdict.sha.slice(0, 10)} has no NEW failing test reachable from its diff — flaky-count jitter, not a red merge`);
+      return;
+    }
+    verdict.newRegressions = genuine;
+  }
+
   if (dryRun) { console.log('[red-merge-detector] dry-run — would file QF with signature', verdict.signature); return; }
 
   // File the ci-blocking QF via the canonical creation script.
   const title = `CI red-merge: main test failures rose ${verdict.prevFailed} -> ${verdict.newFailed} at ${verdict.sha.slice(0, 10)}`;
-  const description = `${verdict.signature}\n\nA merge to main increased the unit-test failure count from ${verdict.prevFailed} to ${verdict.newFailed} (commit ${verdict.sha}). ` +
+  const namedTests = Array.isArray(verdict.newRegressions) && verdict.newRegressions.length
+    ? `\n\nNewly-failing test(s) reachable from this commit's diff:\n- ${verdict.newRegressions.join('\n- ')}`
+    : '';
+  const description = `${verdict.signature}\n\nA merge to main increased the unit-test failure count from ${verdict.prevFailed} to ${verdict.newFailed} (commit ${verdict.sha}).${namedTests}\n\n` +
     `Reproduce: node scripts/audit-test-failures.mjs --pr-only --format=json | jq .new_failures. ` +
     `Fix the regression — do NOT regenerate the baseline snapshot to absorb it. Auto-filed by scripts/ci/red-merge-detector.mjs (SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 FR-3).`;
   let out = '';

--- a/tests/unit/red-merge-baseline-rot.test.js
+++ b/tests/unit/red-merge-baseline-rot.test.js
@@ -8,7 +8,7 @@
  * and that decide() itself is UNCHANGED (additive-only, TR-1).
  */
 import { describe, it, expect } from 'vitest';
-import { detectBaselineRot, decide } from '../../scripts/ci/red-merge-detector.mjs';
+import { detectBaselineRot, decide, genuineReachableRegressions } from '../../scripts/ci/red-merge-detector.mjs';
 
 // newest-first snapshot in the shape decide()/detectBaselineRot() consume.
 const snap = (failed_count, commit_sha) => ({ findings: [{ failed_count, branch: 'main', commit_sha }] });
@@ -73,5 +73,27 @@ describe('decide() regression guard — additive change must not alter it', () =
   it('still returns noop on a single transient spike (persistence preserved)', () => {
     const v = decide(seq(100, 118, 100, 100, 100), []);
     expect(v.action).toBe('noop');
+  });
+});
+
+describe('QF-20260704-047: genuineReachableRegressions (identity+reachability gate)', () => {
+  const withIds = (failed_count, ids) => ({ findings: [{ failed_count, failed_test_ids: ids }] });
+
+  it('suppresses (QF-20260704-263 repro): a newly-failing test whose file the merge never touched', () => {
+    const latest = withIds(108, ['a.test.js::x', 'sd-completed-handler.test.js::Progress Percentage']);
+    const prev = withIds(107, ['a.test.js::x']);
+    const changedFiles = ['lib/adam/adherence-probes.js', 'scripts/adam-self-adherence-review.mjs'];
+    expect(genuineReachableRegressions(latest, prev, changedFiles)).toEqual([]);
+  });
+
+  it('still returns the regression when the blamed commit touches the newly-failing test file', () => {
+    const latest = withIds(108, ['a.test.js::x', 'sd-completed-handler.test.js::Progress Percentage']);
+    const prev = withIds(107, ['a.test.js::x']);
+    const changedFiles = ['sd-completed-handler.test.js'];
+    expect(genuineReachableRegressions(latest, prev, changedFiles)).toEqual(['sd-completed-handler.test.js::Progress Percentage']);
+  });
+
+  it('returns null (fall back to count-fire) when a snapshot predates failed_test_ids', () => {
+    expect(genuineReachableRegressions({ findings: [{ failed_count: 108 }] }, withIds(107, ['a.test.js::x']), [])).toBeNull();
   });
 });


### PR DESCRIPTION
scripts/ci/red-merge-detector.mjs::decide() fires file_qf purely on failed_count crossing NOISE_FLOOR above the settled median, without checking WHICH tests newly failed or whether the blamed commit's diff reaches them. This is the root cause of a recurring false-positive class (4th confirmed instance: QF-20260704-263). Fix: add genuineReachableRegressions() reusing the already-shipped lib/baseline-regression-check.mjs::classifyRegressions to diff failed_test_ids between the two compared main snapshots and confirm reachability via git show --name-only on the blamed sha; suppress (noop, log) when zero genuine reachable regressions are found. Fail-open to the existing count-fire when either snapshot lacks failed_test_ids or git show fails.

Tests: 59 passing across 4 red-merge-detector test files, zero regressions. TypeScript compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)