### PR TITLE
fix(QF-20260704-964): stall detector suppresses INTENDED-HOLD sourced_sd nodes

### DIFF
--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -59,6 +59,26 @@ async function isSdTerminal(supabase, sdKey) {
 }
 
 /**
+ * QF-20260704-964: a sourced_sd board node stops moving BY DESIGN while its linked SD is
+ * an intended hold (requires_human_action or needs_coordinator_review) -- this is not a
+ * genuine stall, it's the SD waiting on a human gate the stall-alert docstring itself says
+ * should never escalate. Fail-soft (a query error is NOT terminal -- never silently swallow
+ * a possibly-real stall).
+ */
+async function isSdIntentionallyHeld(supabase, sdKey) {
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('metadata')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    return !!data?.metadata?.requires_human_action || !!data?.metadata?.needs_coordinator_review;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * QF-20260704-319: an advisory_thread board node mirrors a session_coordination correlation
  * (node.source_ref is the correlation id), not board bookkeeping -- its true terminal state
  * lives in whether that correlation got a REPLY or a chairman decision, which can resolve
@@ -140,6 +160,13 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
     // not a genuine stall — close it instead of escalating.
     if (node.source_kind === 'sourced_sd' && node.source_ref && await isSdTerminal(supabase, node.source_ref)) {
       await setStatus(supabase, node.id, 'done').catch(() => {});
+      continue;
+    }
+    // QF-20260704-964: an intended hold (requires_human_action / needs_coordinator_review)
+    // never escalates -- the node isn't finished (don't mark it done), it's just held BY
+    // DESIGN, so suppress with a log line and skip straight to the next node.
+    if (node.source_kind === 'sourced_sd' && node.source_ref && await isSdIntentionallyHeld(supabase, node.source_ref)) {
+      console.log(`[Adam PM] Suppressing stall alert for intended-hold SD ${node.source_ref} (node ${node.id})`);
       continue;
     }
     // QF-20260704-319: same self-heal for an advisory_thread node whose correlation already

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -106,6 +106,22 @@ function sbWithSdStatus(statusBySdKey) {
   };
 }
 
+/** Minimal supabase stub for strategic_directives_v2 metadata lookups (isSdIntentionallyHeld). */
+function sbWithSdMetadata(metadataBySdKey) {
+  return {
+    from: (table) => {
+      if (table !== 'strategic_directives_v2') return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+      return {
+        select: () => ({
+          eq: (_col, val) => ({
+            maybeSingle: async () => ({ data: val in metadataBySdKey ? { metadata: metadataBySdKey[val] } : null }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
 describe('bumpMovementTicks', () => {
   it('resets to 0 when updated_at differs from the snapshot (real movement)', () => {
     const node = { id: 'p1', updated_at: '2026-07-01T12:00:00Z' };
@@ -210,6 +226,36 @@ describe('QF-20260703-229: false-stall flood fix', () => {
     expect(setStatus).not.toHaveBeenCalled();
     expect(recordPendingDecision).toHaveBeenCalledTimes(1);
     expect(alerted).toEqual([{ id: 'sd2', title: 'Ship SD-OPEN-001', escalated: true }]);
+  });
+
+  it('QF-20260704-964: suppresses a sourced_sd node whose linked SD is an intended hold (requires_human_action) — no filing, no false-done', async () => {
+    const stubSb = sbWithSdMetadata({ 'SD-HELD-001': { requires_human_action: true } });
+    const parents = [{
+      id: 'sd3', title: 'UIUX-remediation orchestrator', updated_at: 'fixed',
+      source_kind: 'sourced_sd', source_ref: 'SD-HELD-001', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { sd3: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled(); // held, not finished — must not be marked done
+    expect(alerted).toEqual([]);
+  });
+
+  it('QF-20260704-964: suppresses a sourced_sd node whose linked SD needs_coordinator_review', async () => {
+    const stubSb = sbWithSdMetadata({ 'SD-HELD-002': { needs_coordinator_review: true } });
+    const parents = [{
+      id: 'sd4', title: 'Pilot-gated SD', updated_at: 'fixed',
+      source_kind: 'sourced_sd', source_ref: 'SD-HELD-002', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { sd4: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
   });
 
   it('caps escalation at ONE digest decision for multiple genuine stalls — never per-node (the 82-row flood)', async () => {


### PR DESCRIPTION
## Summary
- The sourced_sd stall-suppression path checked completed/cancelled SD status but not `metadata.requires_human_action` / `needs_coordinator_review`, so an intentionally-held SD (e.g. an orchestrator deliberately paused behind a pilot) matured into a false genuine_stall every ~8 ticks, filing a digest and burning a rate-capped chairman email each cycle.
- Adds `isSdIntentionallyHeld()` alongside the existing `isSdTerminal()` self-heal check; a held node is suppressed with a log line (not marked done, since it isn't finished).

## Test plan
- [x] 2 new tests: a `requires_human_action:true` SD suppresses (no filing, no false-done); a `needs_coordinator_review:true` SD suppresses
- [x] Existing "still alerts a genuinely open SD" test continues to pass unmodified
- [x] Full `tests/unit/adam/` suite: 25 files / 269 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)