### PR TITLE
fix(QF-20260704-491): Read-stamped-but-unactioned Solomon-directed rows go invisible - resurface them in the solomon directives safety net

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,8 @@
 {
-  "sdKey": "SD-LEO-FIX-TEST-FIXTURE-VENTURES-001",
-  "expectedBranch": "feat/SD-LEO-FIX-TEST-FIXTURE-VENTURES-001",
-  "createdAt": "2026-07-04T03:39:17.826Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "sdKey": "QF-20260704-491",
+  "expectedBranch": "qf/QF-20260704-491",
+  "createdAt": "2026-07-04T07:59:52.778Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/read-solomon-directives.cjs
+++ b/scripts/read-solomon-directives.cjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * read-solomon-directives.cjs — QF-20260704-491 (mirrors read-adam-directives.cjs / QF-20260703-946).
+ * drainInbox's kind-based lane classifier misses out-of-allowlist kinds (e.g. Adam-sent
+ * kind=adam_advisory); once ANY poll stamps read_at on such a row, its own unread-scoped orphan
+ * detector never sees it again — a 9h-buried reply-needed consult, live 2026-07-04.
+ * peekStaleReadUnacked surfaces Solomon-targeted rows read_at-stamped, acknowledged_at-null, and
+ * older than a threshold (default 60min) — REGARDLESS OF KIND. Stamps nothing (recoverable until acked).
+ * Usage: node scripts/read-solomon-directives.cjs [--threshold-min 60]
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+
+const DEFAULT_THRESHOLD_MIN = 60;
+
+function parseThresholdMin(argv) {
+  const idx = argv.indexOf('--threshold-min');
+  const n = idx >= 0 ? Number(argv[idx + 1]) : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_THRESHOLD_MIN;
+}
+
+// Query + print; nowMs is injectable for deterministic tests. Returns the surfaced rows.
+async function peekStaleReadUnacked(supabase, solomonId, { thresholdMin = DEFAULT_THRESHOLD_MIN, nowMs = Date.now() } = {}) {
+  const cutoff = new Date(nowMs - thresholdMin * 60_000).toISOString();
+  const { data: rows, error } = await supabase
+    .from('session_coordination')
+    .select('id, message_type, subject, body, payload, sender_type, sender_session, created_at, read_at, acknowledged_at')
+    .eq('target_session', solomonId)
+    .not('read_at', 'is', null)
+    .is('acknowledged_at', null)
+    .lte('read_at', cutoff)
+    .order('created_at', { ascending: true })
+    .limit(20);
+  if (error) { console.error('ERROR: directive query failed:', error.message); process.exitCode = 1; return []; }
+  console.log(`SOLOMON DIRECTIVE PEEK — read-but-unacknowledged >${thresholdMin}m (read-only — stamps nothing)\n${'─'.repeat(60)}`);
+  if (!rows || !rows.length) { console.log('  (no stale read-but-unacked rows targeting Solomon)'); return []; }
+  console.log(`  ${rows.length} stale read-but-unacked row(s):`);
+  for (const r of rows) {
+    const kind = (r.payload && r.payload.kind) || r.message_type || '(untyped)';
+    const ageMin = Math.floor((nowMs - new Date(r.created_at).getTime()) / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    const body = (r.body || (r.payload && r.payload.body) || r.subject || '').replace(/\n/g, ' ');
+    console.log(`  • ${r.id}\n      ${r.sender_type || '?'} | ${kind} | READ-unacked | ${ageStr} ago\n      ${body}`);
+  }
+  console.log('\n  These rows stay visible until acknowledged_at is stamped (genuine Solomon action).');
+  return rows;
+}
+
+async function main() {
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+  const solomonId = await getActiveSolomonId(supabase);
+  if (!solomonId) { console.log('SOLOMON DIRECTIVE PEEK: no active Solomon session found — nothing to surface.'); return; }
+  const thresholdMin = parseThresholdMin(process.argv.slice(2));
+  await peekStaleReadUnacked(supabase, solomonId, { thresholdMin });
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}
+
+module.exports = { parseThresholdMin, peekStaleReadUnacked, DEFAULT_THRESHOLD_MIN };

--- a/tests/unit/read-solomon-directives.test.js
+++ b/tests/unit/read-solomon-directives.test.js
@@ -1,0 +1,77 @@
+/**
+ * QF-20260704-491 — read-solomon-directives.cjs safety net.
+ *
+ * Root cause: solomon-advisory.cjs's drainInbox classifies rows by payload.kind, so an
+ * out-of-allowlist kind (e.g. Adam-sent kind=adam_advisory) that gets read_at-stamped by ANY
+ * poll (not just drainInbox) vanishes from the orphan-warn path (itself scoped to unread rows)
+ * and stays invisible until acknowledged_at is stamped. peekStaleReadUnacked resurfaces exactly
+ * that read-but-unacked-and-stale tier, regardless of kind.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parseThresholdMin, peekStaleReadUnacked, DEFAULT_THRESHOLD_MIN } = require('../../scripts/read-solomon-directives.cjs');
+
+// Minimal chainable supabase mock capturing the filter chain so tests can assert the built query,
+// while still returning caller-supplied rows (mirrors adam-inbox-window-sweep.test.js's convention).
+function makeSupabase(rows) {
+  const calls = {};
+  const q = {
+    select: (v) => { calls.select = v; return q; },
+    eq: (col, val) => { calls.eq = [col, val]; return q; },
+    not: (col, op, val) => { calls.not = [col, op, val]; return q; },
+    is: (col, val) => { calls.is = [col, val]; return q; },
+    lte: (col, val) => { calls.lte = [col, val]; return q; },
+    order: () => q,
+    limit: () => Promise.resolve({ data: rows, error: null }),
+  };
+  return { from: () => q, calls };
+}
+
+describe('parseThresholdMin', () => {
+  it('defaults to 60min when --threshold-min is absent', () => {
+    expect(parseThresholdMin([])).toBe(DEFAULT_THRESHOLD_MIN);
+  });
+  it('parses an explicit override', () => {
+    expect(parseThresholdMin(['--threshold-min', '120'])).toBe(120);
+  });
+  it('falls back to the default on a malformed value (fail-open)', () => {
+    expect(parseThresholdMin(['--threshold-min', 'garbage'])).toBe(DEFAULT_THRESHOLD_MIN);
+  });
+});
+
+describe('peekStaleReadUnacked (QF-20260704-491)', () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+  afterEach(() => { logSpy.mockRestore(); });
+
+  it('surfaces a read-unacked 2h-old row regardless of kind (repro: kind=adam_advisory)', async () => {
+    const rows = [{
+      id: 'row-1', message_type: 'INFO', subject: null, sender_type: 'adam',
+      payload: { kind: 'adam_advisory', body: 'buried consult reply' },
+      created_at: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+      read_at: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+      acknowledged_at: null,
+    }];
+    const surfaced = await peekStaleReadUnacked(makeSupabase(rows), 'solomon-sid', { thresholdMin: 60 });
+    expect(surfaced).toHaveLength(1);
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('buried consult reply');
+    expect(out).toContain('adam_advisory');
+    expect(out).toContain('READ-unacked');
+  });
+
+  it('queries acknowledged_at IS NULL server-side, so an acked row is excluded before it ever surfaces', async () => {
+    const sb = makeSupabase([]); // an acked row would never be returned by the real query
+    const surfaced = await peekStaleReadUnacked(sb, 'solomon-sid', { thresholdMin: 60 });
+    expect(sb.calls.is).toEqual(['acknowledged_at', null]);
+    expect(sb.calls.not).toEqual(['read_at', 'is', null]);
+    expect(surfaced).toEqual([]);
+  });
+
+  it('empty result prints a confirmation line', async () => {
+    await peekStaleReadUnacked(makeSupabase([]), 'solomon-sid');
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('no stale read-but-unacked rows');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260704-491

**Type:** bug
**Severity:** medium

### Issue Description
Root cause of a 9h-buried consult (Solomon self-diagnosed, 2026-07-04): Solomon's inbox auto-drain keys on kind=solomon_consult (or reply_to-bearing rows) and shows untyped orphans ONLY WHILE UNREAD - Adam's consult was sent kind=adam_advisory, something stamped read_at without action, and the reply-needed row went invisible for 9 hours until a manual nudge. Same read-stamp-without-action hole class as QF-20260703-946 on the Adam side. Fix in the read-solomon-directives safety net: resurface Solomon-directed rows that are read_at-stamped but acknowledged_at-null and older than a threshold (e.g. 60min), regardless of kind. Acceptance both-directions: a read-unacked 2h-old consult row surfaces in the drain; an acked row does not. COMPANION CONVENTION (behavior, not code): consult senders use kind=solomon_consult - Adam adopting immediately.


### Expected Behavior
No reply-needed Solomon row can go invisible via a read stamp

### Actual Behavior
A reply-needed consult sat buried 9h despite Solomon being active

### Changes
- **Files Changed:** 3
  - .worktree.json
  - scripts/read-solomon-directives.cjs
  - tests/unit/read-solomon-directives.test.js
- **LOC:** 147 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Created scripts/read-solomon-directives.cjs mirroring read-adam-directives.cjs (QF-20260703-946 companion). Live-verified against real DB: immediately surfaced real stale read-unacked rows targeting the live Solomon session, including buried reply-needed coordinator_reply rows (9h, 3h old) — exact repro of the bug class described. 6 new unit tests pass (parseThresholdMin + peekStaleReadUnacked). Full unit suite: 6 pre-existing unrelated failures confirmed (change adds only new files + .worktree.json bookkeeping).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol