### PR TITLE
fix(QF-20260703-999): backlog-rank sentinel dependency silently blocks SD

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "QF-20260704-491",
-  "expectedBranch": "qf/QF-20260704-491",
-  "createdAt": "2026-07-04T07:59:52.778Z",
+  "sdKey": "QF-20260703-999",
+  "workType": "QF",
+  "workKey": "QF-20260703-999",
+  "expectedBranch": "qf/QF-20260703-999",
+  "createdAt": "2026-07-04T00:14:15.977Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -192,6 +192,7 @@ export async function computeClaimableLeaves(sb) {
   let awaitingConvergenceSkips = 0;
   let humanActionSkips = 0;
   let ineligibleSkips = 0;
+  let depBlockedSkips = 0;
   for (const d of (sds || [])) {
     // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-free claimable axes (claimed /
     // in-flight / fixture / the SHARED claim-eligibility predicate) are computed by one pure helper so
@@ -231,7 +232,13 @@ export async function computeClaimableLeaves(sb) {
     // SD whose blocker is not yet completed is NOT ranked/dispatched — matching worker-checkin's claim guard.
     const unmet = blockerKeysFor(d)
       .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
-    if (unmet.length) continue;
+    if (unmet.length) {
+      // QF-20260703-999: this exclusion previously had NO skip-log (unlike every other exclusion
+      // reason above), so a dep-blocked SD vanished from both ranked and skip output with zero trace.
+      depBlockedSkips++;
+      console.log(`  [skip] dependency-blocked (${unmet.join(', ')}): ${d.sd_key}`);
+      continue;
+    }
     // SD-REFILL-00MFWEGZ: an orchestrator child whose PARENT has not passed LEAD is not yet
     // dispatchable (claim-eligibility blocks it via the same gate, and it would hit the hard
     // parent-LEAD EXEC-transition block) — exclude it from fresh ranking so the ranked belt
@@ -248,6 +255,7 @@ export async function computeClaimableLeaves(sb) {
   if (awaitingConvergenceSkips) console.log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
   if (humanActionSkips) console.log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
   if (ineligibleSkips) console.log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
+  if (depBlockedSkips) console.log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
   return { sds, byKey, depStatus, claimable };
 }
 

--- a/scripts/modules/sd-next/dependency-resolver.js
+++ b/scripts/modules/sd-next/dependency-resolver.js
@@ -375,9 +375,12 @@ export async function resolveMetadataBlocker(supabase, blockerSdKey) {
   }
 
   // Blocker is a leaf SD (not an orchestrator) — recommend it directly
+  // QF-20260703-999 (drive-by): strategic_directives_v2 has no `track` column (schema-reference-lint
+  // caught it live — this select would throw whenever a blocker actually had children); `track` was
+  // never read from the result, so dropping it is a pure dead-column removal, no behavior change.
   const { data: children } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, progress_percentage, is_working_on, sequence_rank, track, sd_type, is_active, governance_metadata, metadata')
+    .select('id, sd_key, title, status, current_phase, progress_percentage, is_working_on, sequence_rank, sd_type, is_active, governance_metadata, metadata')
     .eq('parent_sd_id', blockerSD.id)
     .eq('is_active', true);
 

--- a/scripts/modules/sd-next/dependency-resolver.js
+++ b/scripts/modules/sd-next/dependency-resolver.js
@@ -159,6 +159,14 @@ export function checkMetadataDependency(metadata) {
     return { hasMetadataDep: false, blockerSdKey: null, conditionalNote: null };
   }
 
+  // QF-20260703-999: leo-create-sd's 'no blocking dependencies' sentinel ({sd_key:'none'} /
+  // bare 'none') is not a real blocker — require the same SD-key shape parseSdDependencies()
+  // already enforces for the `dependencies` column, so a sentinel here doesn't get treated as
+  // an unresolvable blocker (the sentinel's own emitter is a separate, in-flight fix).
+  if (!/^SD-[A-Z0-9-]+/.test(metadata.blocked_by_sd_key)) {
+    return { hasMetadataDep: false, blockerSdKey: null, conditionalNote: null };
+  }
+
   return {
     hasMetadataDep: true,
     blockerSdKey: metadata.blocked_by_sd_key,

--- a/tests/unit/coordinator-backlog-rank-metadata-blocker.test.js
+++ b/tests/unit/coordinator-backlog-rank-metadata-blocker.test.js
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { blockerKeysFor } from '../../scripts/coordinator-backlog-rank.mjs';
+import { checkMetadataDependency } from '../../scripts/modules/sd-next/dependency-resolver.js';
 
 describe('SD-REFILL-00AH2L4Q: backlog-rank honors metadata.blocked_by_sd_key (blockerKeysFor)', () => {
   it('no dependencies and no metadata blocker -> no blockers (claimable leaf)', () => {
@@ -42,5 +43,28 @@ describe('SD-REFILL-00AH2L4Q: backlog-rank honors metadata.blocked_by_sd_key (bl
   it('module imported without running the DB pass (entrypoint guard) — reaching here proves it', () => {
     // If main() had run on import, this suite would have errored/hung on a DB call before asserting.
     expect(typeof blockerKeysFor).toBe('function');
+  });
+});
+
+describe("QF-20260703-999: the leo-create-sd 'none' sentinel is NOT a real blocker", () => {
+  it('checkMetadataDependency treats blocked_by_sd_key:"none" as no metadata dependency', () => {
+    expect(checkMetadataDependency({ blocked_by_sd_key: 'none' })).toEqual({
+      hasMetadataDep: false, blockerSdKey: null, conditionalNote: null,
+    });
+  });
+
+  it('checkMetadataDependency still treats a real SD-key as a genuine blocker', () => {
+    const r = checkMetadataDependency({ blocked_by_sd_key: 'SD-REAL-001' });
+    expect(r).toEqual({ hasMetadataDep: true, blockerSdKey: 'SD-REAL-001', conditionalNote: null });
+  });
+
+  it('blockerKeysFor does not surface the sentinel — the bug: it used to leak "none" into unmet-dep filtering', () => {
+    const keys = blockerKeysFor({ dependencies: null, metadata: { blocked_by_sd_key: 'none' } });
+    expect(keys).toEqual([]);
+  });
+
+  it('blockerKeysFor combines a real dependencies-column blocker with a sentinel metadata field correctly (only the real one survives)', () => {
+    const keys = blockerKeysFor({ dependencies: ['SD-DEP-999'], metadata: { blocked_by_sd_key: 'none' } });
+    expect(keys).toEqual(['SD-DEP-999']);
   });
 });


### PR DESCRIPTION
## Summary
- `checkMetadataDependency()` only checked truthiness of `metadata.blocked_by_sd_key`, so the leo-create-sd 'no blocking dependencies' sentinel (`'none'`) was treated as a real blocker key — no SD has `sd_key='none'`, so the unmet-dependency filter in `coordinator-backlog-rank.mjs` always resolved it as unmet, silently excluding the SD from both ranked and skip output with zero trace.
- Fix validates `blocked_by_sd_key` against the same SD-key shape `parseSdDependencies()` already enforces for the `dependencies` column, and adds the missing skip-log line for genuine dependency exclusions (every other exclusion reason in that file already logs; this one didn't).
- Emitter side (stop writing the sentinel) is explicitly out of scope per the QF description — that belongs to the in-flight CAPA family fix.

## Test plan
- [x] New regression tests in `tests/unit/coordinator-backlog-rank-metadata-blocker.test.js` cover: sentinel-only metadata → no blocker, real SD-key metadata → still a genuine blocker, sentinel combined with a real dependencies-column blocker → only the real one survives.
- [x] Verified the new tests FAIL against the pre-fix code (stashed the fix, reran, confirmed 3 failures) and PASS after restoring it — proves the tests are a real regression guard, not vacuous.
- [x] Ran the 13 related backlog-rank/dependency-resolver test files (134 tests) — all pass, no regressions.
- [x] Ran full `npm run test:unit` (23185 passed) — 10 pre-existing failures across 3 unrelated subsystems (worktree-hygiene hook, solomon-consult subprocess, post-merge-cleanup timeout), none touching the changed files; logged separately as a harness-bug for later triage.
- [x] `test:e2e` (Playwright) skipped as inapplicable — this is a pure backend CLI-script fix with zero UI/route surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)