### PR TITLE
fix(QF-20260704-877): worker-signal inbox counter reflects true unread total, not the 20-row display cap

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1157,7 +1157,24 @@ async function printInbox() {
     return;
   }
 
-  console.log('  ' + signals.length + ' unread signal(s)');
+  // QF-20260704-877: signals.length is capped by .limit(20) above, so it can never report
+  // more than 20 even when the true unacknowledged backlog is larger — the label read "20
+  // unread signal(s)" indefinitely regardless of triage progress. Query the true count
+  // (same filters, no limit) so the display reflects real unread rows, not the window cap.
+  const { count: totalUnread, error: countError } = await supabase
+    .from('session_coordination')
+    .select('id', { count: 'exact', head: true })
+    .eq('target_session', coordinatorId)
+    .not('payload->>signal_type', 'is', null)
+    .is('acknowledged_at', null)
+    .gte('created_at', signalSince);
+
+  const trueCount = countError || totalUnread == null ? signals.length : totalUnread;
+  console.log('  ' + trueCount + ' unread signal(s)' +
+    (trueCount > signals.length ? ' (showing newest ' + signals.length + ')' : ''));
+  if (trueCount > 0) {
+    console.log('  Ack a signal: node scripts/coordinator-ack-signal.cjs --signal <id>');
+  }
   console.log('');
   console.log('  ' + pad('Type', 16) + pad('Severity', 10) + pad('Callsign', 12) + pad('Age', 8) + 'Body');
   console.log('  ' + '─'.repeat(68));


### PR DESCRIPTION
## Summary
- `printInbox()` in scripts/fleet-dashboard.cjs printed `signals.length`, which is capped by the display query's `.limit(20)` — the "unread signal(s)" count could never exceed 20 even when the true unacknowledged backlog was larger.
- Added a separate unbounded exact-count query (same filters, no limit) so the counter reflects the true unread total; annotates "(showing newest 20)" when the display window is smaller than the true count, and surfaces the ack command hint.

## Test plan
- [x] Reproduced live: ran `node scripts/fleet-dashboard.cjs inbox` before/after — confirmed true count (335→337, growing) now displays instead of a pinned "20 unread signal(s)".
- [x] `npx tsc --noEmit` passes.
- [x] Smoke tests pass (pre-commit hook).

QF-20260704-877

🤖 Generated with [Claude Code](https://claude.com/claude-code)