### PR TITLE
fix(QF-20260704-737): Fleet dashboard worker enrichment columns dead: Progress/Phase/Fails/WIP all render ?/- for every worker

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,10 +1,9 @@
 {
-  "sdKey": "QF-20260703-999",
+  "sdKey": "QF-20260704-737",
   "workType": "QF",
-  "workKey": "QF-20260703-999",
-  "expectedBranch": "qf/QF-20260703-999",
-  "createdAt": "2026-07-04T00:14:15.977Z",
+  "workKey": "QF-20260704-737",
+  "expectedBranch": "qf/QF-20260704-737",
+  "createdAt": "2026-07-04T10:01:11.599Z",
   "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
-  "baseRef": "origin/main"
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -223,9 +223,13 @@ async function loadData() {
   try {
     const ids = sessions.map(s => s.session_id).filter(Boolean);
     if (ids.length > 0) {
+      // QF-20260704-737: v_active_sessions never exposed current_phase/handoff_fail_count (and its
+      // has_uncommitted_changes wasn't in sessRes's own select) — Progress/Phase/Fails/WIP rendered
+      // '?'/'-' for every worker despite the data existing on claude_sessions the whole time. Pull them
+      // through this SAME already-working telemetry-merge seam instead of a new query.
       const { data: teleRows } = await supabase
         .from('claude_sessions')
-        .select('session_id,current_tool,current_tool_expected_end_at,expected_silence_until,process_alive_at,last_activity_kind,commits_since_claim,files_modified_since_claim')
+        .select('session_id,current_tool,current_tool_expected_end_at,expected_silence_until,process_alive_at,last_activity_kind,commits_since_claim,files_modified_since_claim,current_phase,handoff_fail_count,has_uncommitted_changes')
         .in('session_id', ids);
       for (const row of teleRows || []) telemetryById.set(row.session_id, row);
     }
@@ -242,6 +246,9 @@ async function loadData() {
       last_activity_kind: t.last_activity_kind,
       commits_since_claim: t.commits_since_claim,
       files_modified_since_claim: t.files_modified_since_claim,
+      current_phase: t.current_phase,
+      handoff_fail_count: t.handoff_fail_count,
+      has_uncommitted_changes: t.has_uncommitted_changes,
     });
   }
   const hasTickAlive = (s) => {
@@ -293,7 +300,7 @@ async function loadData() {
   if (missingKeys.length > 0) {
     const { data: extraSds } = await supabase
       .from('strategic_directives_v2')
-      .select('sd_key, title, status, progress_percentage, completion_date')
+      .select('sd_key, title, status, progress_percentage, completion_date, current_phase')
       .in('sd_key', missingKeys);
     (extraSds || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
   }
@@ -428,7 +435,9 @@ function printWorkers(d) {
     // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: LoopState column (14 chars) added between WIP and Activity → 14-char wider separator.
     console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 150 : 134) : (mcOk ? 138 : 122)));
     for (const s of d.activeSessions) {
-      const child = d.children.find(c => c.sd_key === s.sd_key);
+      // QF-20260704-737: d.children is scoped to ONE orchestrator's children — every other worker's
+      // Progress always read as 0. d.sdStatusMap already covers any sd_key a worker is claiming.
+      const child = d.sdStatusMap[s.sd_key];
       const pct = child ? child.progress_percentage : 0;
       const phase = s.current_phase || (child ? child.current_phase : '?');
       const shortSd = s.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
@@ -1816,7 +1825,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup };
+module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/tests/unit/coordinator/fleet-dashboard-worker-enrichment.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-worker-enrichment.test.js
@@ -1,0 +1,59 @@
+/**
+ * QF-20260704-737 — WORKERS section Progress/Phase/Fails/WIP rendered '?'/'-'/0% for every
+ * worker despite the enriched-heartbeat pipeline (current_phase, handoff_fail_count,
+ * has_uncommitted_changes) existing on claude_sessions. Root cause: (1) the source-side
+ * telemetry merge (SD-LEO-INFRA-WORKER-SOURCE-SIDE-001) queried claude_sessions but omitted
+ * these three columns from its select + Object.assign, and (2) the Progress lookup used
+ * d.children (scoped to ONE orchestrator's children) instead of the already-comprehensive
+ * d.sdStatusMap. These tests exercise printWorkers directly with a mock `d` to prove both are
+ * now surfaced instead of falling back to the placeholder values.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { printWorkers } = require('../../../scripts/fleet-dashboard.cjs');
+
+let logSpy;
+beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { logSpy.mockRestore(); });
+const output = () => logSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+
+function baseSession(overrides = {}) {
+  return {
+    session_id: 's1', sd_key: 'SD-FOO-001', tty: 'tty1',
+    heartbeat_age_seconds: 5, heartbeat_age_human: '5s',
+    ...overrides,
+  };
+}
+
+// Fields printWorkers reads unconditionally beyond activeSessions (unrelated to this fix).
+const EMPTY_D_EXTRAS = { staleSessions: [], idleSessions: [], drainAgents: [] };
+
+describe('printWorkers — enrichment fields (QF-20260704-737)', () => {
+  it('renders real Phase/Fails/WIP from session-level enrichment instead of ?/-/-', () => {
+    const s = baseSession({ current_phase: 'EXEC', handoff_fail_count: 2, has_uncommitted_changes: true });
+    printWorkers({ activeSessions: [s], children: [], sdStatusMap: {}, mc: null, mcByWorker: {}, ...EMPTY_D_EXTRAS });
+    const out = output();
+    expect(out).toContain('EXEC');
+    expect(out).toMatch(/\b2\b/);
+    expect(out).toContain('Y');
+  });
+
+  it('falls back to ?/-/- when a session genuinely has no enrichment data', () => {
+    const s = baseSession({ current_phase: undefined, handoff_fail_count: null, has_uncommitted_changes: null });
+    printWorkers({ activeSessions: [s], children: [], sdStatusMap: {}, mc: null, mcByWorker: {}, ...EMPTY_D_EXTRAS });
+    expect(output()).toContain('?');
+  });
+
+  it('resolves Progress from d.sdStatusMap (any sd_key), not just d.children (one orchestrator)', () => {
+    const s = baseSession({ sd_key: 'SD-STANDALONE-042' });
+    printWorkers({
+      activeSessions: [s],
+      children: [], // the orchestrator-scoped list — deliberately empty
+      sdStatusMap: { 'SD-STANDALONE-042': { sd_key: 'SD-STANDALONE-042', progress_percentage: 63 } },
+      mc: null, mcByWorker: {},
+      ...EMPTY_D_EXTRAS,
+    });
+    expect(output()).toContain('63');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260704-737

**Type:** bug
**Severity:** medium

### Issue Description
Every worker row in fleet-dashboard.cjs shows Progress 0%/?, Phase ?, Fails -, WIP - even for workers mid-EXEC with fresh heartbeats. The enriched-heartbeat pipeline (current_phase, handoff_fail_count, has_uncommitted_changes, progress) exists in claude_sessions but the dashboard render path is not receiving/joining it. Coordinator oversight flies blind on phase/progress; ETA and WORKER_STRUGGLING detection degrade to heartbeat-age-only. Fix: trace why enrichment fields are null/unjoined in the workers section render, restore population, and show real values. Named by the chairman as an oversight gap to close with idle capacity (2026-07-04 06:00).

### Steps to Reproduce
Run node scripts/fleet-dashboard.cjs all while any worker is mid-EXEC

### Expected Behavior
Progress bar, Phase, Fails, WIP reflect the worker's actual enriched heartbeat state

### Actual Behavior
All rows show 0% progress, Phase ?, Fails -, WIP - regardless of real state

### Changes
- **Files Changed:** 3
  - .worktree.json
  - scripts/fleet-dashboard.cjs
  - tests/unit/coordinator/fleet-dashboard-worker-enrichment.test.js
- **LOC:** 79 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Root cause: (1) the existing source-side telemetry merge (SD-LEO-INFRA-WORKER-SOURCE-SIDE-001) already queries claude_sessions but omitted current_phase/handoff_fail_count/has_uncommitted_changes from its select+merge; (2) Progress column looked up d.children (scoped to ONE orchestrator) instead of the comprehensive d.sdStatusMap. Live-verified against the running fleet dashboard: Phase/Fails/WIP/Progress now show real values for every worker (was ?/-/-/0% universally before). 3 new unit tests pass exercising printWorkers directly. Full unit suite: 7 pre-existing unrelated failures confirmed (change scoped to fleet-dashboard.cjs + its own new test).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol