### PR TITLE
fix(QF-20260704-742): fleet-dashboard inbox tick add review-held SDs surface

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1205,6 +1205,44 @@ async function printInbox() {
   console.log('');
 }
 
+// ── Section: Review-held SDs (QF-20260704-742) ──
+// The inbox tick covered the worker-signal lane (printInbox) and the Adam advisory lane
+// (printAdamInbox), but had no surface at all for SDs parked with
+// metadata.needs_coordinator_review=true (lib/fleet/claim-eligibility.cjs) — a third
+// distinct intake surface the coordinator must drain (clearCoordinatorReview IS the
+// dispatch authorization). Without this, a whole wave of held SDs can sit invisible
+// while the coordinator reports belt-empty. Read-only: never mutates the flag.
+async function printReviewHeldSds() {
+  console.log('REVIEW-HELD SDS');
+  console.log('─'.repeat(72));
+
+  const { data: held, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, status')
+    .eq('metadata->>needs_coordinator_review', 'true')
+    .not('status', 'in', '(completed,cancelled)');
+
+  if (error) {
+    console.log('  (review-held query failed: ' + error.message + ')');
+    console.log('');
+    return;
+  }
+
+  if (!held || held.length === 0) {
+    console.log('  (no SDs held for coordinator review)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + held.length + ' SD(s) held for review');
+  console.log('');
+  for (const sd of held) {
+    console.log('  ' + pad(sd.sd_key, 44) + pad(sd.status, 12) + (sd.title || '').substring(0, 40));
+  }
+  console.log('  Clear a hold: node scripts/clear-coordinator-review.mjs <SD-KEY>');
+  console.log('');
+}
+
 // ── Section: Adam advisory inbox (SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B) ──
 // Surfaces Adam advisories (payload.kind=adam_advisory) in a SEPARATE section from
 // the worker-friction inbox (printInbox). Adam advisories deliberately omit
@@ -1756,6 +1794,8 @@ async function main() {
       // loop too — the ~5min 'all' loop is collapsed by FLEET_DASH_SUPPRESS during quiet
       // periods, so action-required advisories could otherwise sit unsurfaced for long stretches.
       await printAdamInbox();
+      // QF-20260704-742: third intake surface — SDs held with metadata.needs_coordinator_review.
+      await printReviewHeldSds();
     },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
     solomon:       async () => { await printSolomonInbox(); await printSolomonLedgerRollup(); }, // SD-LEO-INFRA-SOLOMON-CONSULT-001F + SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001
@@ -1778,6 +1818,7 @@ async function main() {
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printRelayDropGauge(); // FR-3 SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
+      await printReviewHeldSds(); // QF-20260704-742 — third intake surface: needs_coordinator_review holds
       await printSolomonInbox(); // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane (dormant until SOLOMON_CONSULT_V1)
       await printSolomonLedgerRollup(); // SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-5) — accuracy + cost-per-accepted rollup
       await printWorkingContext(); // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3) — standing context dual-render


### PR DESCRIPTION
## Summary
- The coordinator's inbox tick (`fleet-dashboard.cjs inbox`, cron ~5min) covered the worker-signal lane and the Adam advisory lane, but had no surface for SDs parked with `metadata.needs_coordinator_review=true` — a third distinct intake surface (`lib/fleet/claim-eligibility.cjs`, `lib/coordinator/clear-coordinator-review.js`).
- Root cause on 2026-07-04: an 8-SD wave sat in the review queue ~40min while the coordinator reported belt-empty — the cron fired every time, the lane just wasn't rendered.
- Adds a read-only `printReviewHeldSds()` section: count of non-terminal held SDs + drain command (`node scripts/clear-coordinator-review.mjs <SD-KEY>`), wired into both the `inbox` and `all` dashboard sections.

## Test plan
- [x] Verified the `metadata->>needs_coordinator_review` filter against a disposable fixture SD (inserted, confirmed it matched the query, cancelled and confirmed it dropped out) — no real SDs currently held, so this proves the query discriminates correctly rather than trivially returning empty.
- [x] Ran `node scripts/fleet-dashboard.cjs inbox` before/after — new section renders cleanly alongside the existing worker-signal and Adam advisory sections.
- [x] Smoke tests pass (pre-commit hook).

QF-20260704-742

🤖 Generated with [Claude Code](https://claude.com/claude-code)