### PR TITLE
fix(SD-LEO-FIX-ADAM-OUTBOUND-SILENCE-001): Adam outbound-silence watchdog probes/escalates on unread outbound at a live target

### DIFF
--- a/lib/adam/outbound-silence-watchdog.js
+++ b/lib/adam/outbound-silence-watchdog.js
@@ -1,0 +1,143 @@
+/**
+ * Adam outbound-silence watchdog — SD-LEO-FIX-ADAM-OUTBOUND-SILENCE-001.
+ *
+ * Chairman-caught gap 2026-07-04: a backlog of Adam->coordinator messages sat
+ * unprocessed despite two visible-but-unacted dashboard signals (ADAM ADVISORY
+ * INBOX unactioned age, UNDELIVERED OUTBOUND). Watches Adam's own outbound rows
+ * (sender_type='adam') at a LIVE target: a reply-expected row unread >30m or
+ * read-but-unacknowledged >60m is a breach. First breach for a target -> one
+ * alternate-kind channel-health probe. A target STILL breaching after a prior
+ * probe (second consecutive breach) -> a chairman-visible feedback row.
+ * Deduped 2h/target, capped per tick (unbounded-generator family: fresh
+ * primary-state check each tick, terminal/liveness suppression, TWO independent
+ * rate-limit guards on the probe leg, visible log line for every probe/escalation
+ * -- per database-agent/risk-agent PLAN-phase review, sub_agent_execution_results
+ * 55a57f82/e99f7453).
+ *
+ * Probe rows deliberately omit correlation_id/reply_requested and set
+ * reply_class='fire-and-forget' so lib/adam/task-rehydrate.js's rehydrateBoard()
+ * never turns a probe into an advisory_thread board node (risk-agent finding C2
+ * -- that side-door would bypass both dedup guards). request_ack is never set
+ * (avoids spawning a paired transport_ack row). expires_at is stamped 24h out
+ * (database-agent finding: the session_coordination default 1h TTL would sweep
+ * a probe before the 2h dedup check ever sees it, making the second-breach
+ * escalation unreachable).
+ */
+
+import { emitFeedback } from '../governance/emit-feedback.js';
+
+export const REPLY_EXPECTED_KINDS = new Set(['coordinator_request', 'solomon_consult']);
+export const UNREAD_BREACH_MS = 30 * 60 * 1000;
+export const UNACKED_BREACH_MS = 60 * 60 * 1000;
+export const PROBE_DEDUP_MS = 2 * 60 * 60 * 1000;
+export const PROBE_KIND = 'adam_channel_health_probe';
+export const PROBE_EXPIRES_MS = 24 * 60 * 60 * 1000;
+const HEARTBEAT_FRESH_MS = 15 * 60 * 1000;
+// risk-agent C1: independent absolute cap so a probe-guard parity bug (SELECT/INSERT
+// filter divergence) degrades to a bounded per-tick ceiling, never an unbounded storm.
+export const MAX_PROBES_PER_TICK = 5;
+
+function toMs(ts) { const n = ts ? Date.parse(ts) : NaN; return Number.isFinite(n) ? n : 0; }
+
+/** Pure: reply-expected per FR (kind in REPLY_EXPECTED_KINDS, or explicit expects_reply). */
+export function isReplyExpected(row) {
+  return REPLY_EXPECTED_KINDS.has(row && row.payload && row.payload.kind) ||
+    !!(row && row.payload && row.payload.expects_reply === true);
+}
+
+/** Pure: unread >30m, or read-but-unacknowledged >60m. Never true for the watchdog's own probe rows. */
+export function isBreaching(row, nowMs) {
+  if (!row || (row.payload && row.payload.kind === PROBE_KIND)) return false;
+  if (!row.read_at) return (nowMs - toMs(row.created_at)) >= UNREAD_BREACH_MS;
+  if (row.acknowledged_at) return false;
+  return (nowMs - toMs(row.read_at)) >= UNACKED_BREACH_MS;
+}
+
+/** Pure: oldest breaching reply-expected row per live target_session. */
+export function classifyBreaches(outboundRows, liveSessionIds, nowMs) {
+  const byTarget = new Map();
+  for (const r of (outboundRows || [])) {
+    if (!r || !liveSessionIds.has(r.target_session) || !isReplyExpected(r) || !isBreaching(r, nowMs)) continue;
+    const cur = byTarget.get(r.target_session);
+    if (!cur || toMs(r.created_at) < toMs(cur.created_at)) byTarget.set(r.target_session, r);
+  }
+  return byTarget;
+}
+
+/** Pure: lane-health aggregate for fire-and-forget (non-reply-expected) rows, excluding the watchdog's own probes. */
+export function laneHealthAggregate(outboundRows, liveSessionIds, nowMs) {
+  const rows = (outboundRows || []).filter(
+    (r) => r && liveSessionIds.has(r.target_session) && !isReplyExpected(r)
+      && !r.read_at && !(r.payload && r.payload.kind === PROBE_KIND)
+  );
+  const maxAgeMs = rows.reduce((m, r) => Math.max(m, nowMs - toMs(r.created_at)), 0);
+  return { unactionedCount: rows.length, maxAgeMs };
+}
+
+/** IO: run one watchdog tick. FAIL-OPEN; never throws. */
+export async function runOutboundSilenceWatchdog(supabase, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const result = { probed: [], escalated: [], laneHealth: { unactionedCount: 0, maxAgeMs: 0 } };
+  try {
+    const since = new Date(now - 24 * 60 * 60 * 1000).toISOString();
+    const { data: outbound } = await supabase
+      .from('session_coordination')
+      .select('id, target_session, payload, read_at, acknowledged_at, created_at')
+      .eq('sender_type', 'adam')
+      .gte('created_at', since)
+      .limit(200);
+    const { data: sessions } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at')
+      .gte('heartbeat_at', new Date(now - HEARTBEAT_FRESH_MS).toISOString())
+      .limit(200);
+    const liveIds = new Set((sessions || []).map((s) => s.session_id));
+
+    result.laneHealth = laneHealthAggregate(outbound, liveIds, now);
+    const breaches = classifyBreaches(outbound, liveIds, now);
+
+    for (const [target, row] of breaches) {
+      if (result.probed.length >= MAX_PROBES_PER_TICK) break; // C1: absolute per-tick cap
+
+      const { data: priorProbes } = await supabase
+        .from('session_coordination')
+        .select('id, created_at')
+        .eq('sender_type', 'adam')
+        .eq('target_session', target)
+        .eq('payload->>kind', PROBE_KIND)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      const prior = priorProbes && priorProbes[0];
+      const priorAgeMs = prior ? now - toMs(prior.created_at) : Infinity;
+      if (prior && priorAgeMs < PROBE_DEDUP_MS) continue; // deduped — probed too recently
+
+      if (prior) {
+        const today = new Date(now).toISOString().slice(0, 10);
+        await emitFeedback({
+          supabase,
+          title: `Adam outbound-silence: target ${target} still breaching after prior probe`,
+          description: `Row ${row.id} at target ${target} remains a reply-expected breach after an earlier channel-health probe went unanswered.`,
+          category: 'harness_backlog',
+          severity: 'high',
+          dedup_key: `outbound-silence:${target}:${today}`,
+          metadata: { target_session: target, breaching_row_id: row.id, prior_probe_age_ms: priorAgeMs },
+        });
+        result.escalated.push({ target, rowId: row.id });
+      }
+
+      await supabase.from('session_coordination').insert({
+        sender_type: 'adam',
+        target_session: target,
+        message_type: 'INFO',
+        subject: '[ADAM_CHANNEL_HEALTH_PROBE]',
+        body: `Channel-health probe: row ${row.id} is a reply-expected breach. Please ack this probe.`,
+        payload: { kind: PROBE_KIND, probes_for: row.id, reply_class: 'fire-and-forget' },
+        expires_at: new Date(now + PROBE_EXPIRES_MS).toISOString(),
+      });
+      result.probed.push({ target, rowId: row.id });
+    }
+  } catch (e) {
+    result.error = e && e.message;
+  }
+  return result;
+}

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -24,6 +24,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import 'dotenv/config';
 import { rehydrateBoard } from '../lib/adam/task-rehydrate.js';
 import { checkAndAlertStalls } from '../lib/adam/stall-alert.js';
+import { runOutboundSilenceWatchdog } from '../lib/adam/outbound-silence-watchdog.js';
 import { TABLE as TASK_LEDGER_TABLE } from '../lib/adam/task-ledger.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
@@ -172,6 +173,16 @@ async function main() {
     stall = { snapshot: priorStallSnapshot, alerted: [], error: e && e.message };
   }
 
+  // SD-LEO-FIX-ADAM-OUTBOUND-SILENCE-001: watch Adam's own outbound rows at a live
+  // target for reply-expected silence (probe then, on a second consecutive breach,
+  // a chairman-visible feedback row). Fail-soft — never blocks the rest of the tick.
+  let outboundSilence = { probed: [], escalated: [], laneHealth: { unactionedCount: 0, maxAgeMs: 0 } };
+  try {
+    outboundSilence = await runOutboundSilenceWatchdog(sb, {});
+  } catch (e) {
+    outboundSilence = { probed: [], escalated: [], laneHealth: { unactionedCount: 0, maxAgeMs: 0 }, error: e && e.message };
+  }
+
   // FR-4: belt-countdown + offer-help collapse to a salient-delta check — Adam only
   // reaches the coordinator on a real belt/venture delta, never a "still idle" status.
   const salient = await readSalientState(sb);
@@ -188,6 +199,7 @@ async function main() {
     failedCount: tick.failedCount,
     boardReconcile,
     stallAlerted: stall.alerted,
+    outboundSilence,
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
     nextWakeSeconds: delaySeconds,
@@ -201,6 +213,7 @@ async function main() {
       `fail=${tick.failedCount} ` +
       `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
       `stalls=${stall.alerted.length} ` +
+      `probes=${outboundSilence.probed.length} esc=${outboundSilence.escalated.length} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
@@ -209,6 +222,9 @@ async function main() {
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);
+    }
+    for (const p of outboundSilence.probed) {
+      console.log(`QUIET_TICK_OUTBOUND_PROBE=adam target=${p.target} row=${p.rowId}`);
     }
   }
   return result;

--- a/tests/unit/adam/outbound-silence-watchdog.test.js
+++ b/tests/unit/adam/outbound-silence-watchdog.test.js
@@ -1,0 +1,179 @@
+/**
+ * SD-LEO-FIX-ADAM-OUTBOUND-SILENCE-001 — outbound-silence watchdog coverage.
+ *
+ * TS-1..TS-5 per the PRD's test_scenarios, plus a probe-INSERT vs prior-probe-SELECT
+ * filter-parity check (risk-agent C1: a divergence there is the real storm vector —
+ * the mocked dedup test alone can't catch a filter/column mismatch).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isReplyExpected, isBreaching, classifyBreaches, laneHealthAggregate,
+  runOutboundSilenceWatchdog, PROBE_KIND, PROBE_DEDUP_MS, PROBE_EXPIRES_MS,
+  UNREAD_BREACH_MS, UNACKED_BREACH_MS, MAX_PROBES_PER_TICK,
+} from '../../../lib/adam/outbound-silence-watchdog.js';
+
+vi.mock('../../../lib/governance/emit-feedback.js', () => ({ emitFeedback: vi.fn(async () => ({ id: 'fb-1', deduped: false })) }));
+import { emitFeedback } from '../../../lib/governance/emit-feedback.js';
+
+beforeEach(() => { emitFeedback.mockClear(); });
+
+const NOW = Date.parse('2026-07-04T12:00:00Z');
+const LIVE = 'target-live-1';
+
+/** Stub supabase: dispatches by table; session_coordination select() branches by whether
+ *  .eq('payload->>kind', ...) is chained (prior-probe lookup) vs not (outbound fetch). */
+function makeStub({ outboundRows = [], sessionRows = [{ session_id: LIVE, heartbeat_at: new Date(NOW).toISOString() }], priorProbeRows = [] } = {}) {
+  const inserts = [];
+  const priorProbeFilters = [];
+  return {
+    inserts,
+    priorProbeFilters,
+    from(table) {
+      if (table === 'claude_sessions') {
+        return { select: () => ({ gte: () => ({ limit: async () => ({ data: sessionRows }) }) }) };
+      }
+      if (table === 'session_coordination') {
+        return {
+          select: () => ({
+            eq: (col1, val1) => ({
+              gte: () => ({ limit: async () => ({ data: outboundRows }) }), // outbound fetch: .eq(sender_type).gte(created_at).limit
+              eq: (col2, val2) => ({
+                eq: (col3, val3) => {
+                  priorProbeFilters.push({ [col1]: val1, [col2]: val2, [col3]: val3 });
+                  return { order: () => ({ limit: async () => ({ data: priorProbeRows }) }) };
+                },
+              }),
+            }),
+          }),
+          insert: async (row) => { inserts.push(row); return { data: null, error: null }; },
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('outbound-silence-watchdog: pure classification (TS-1)', () => {
+  it('isReplyExpected: kind-based and expects_reply-based', () => {
+    expect(isReplyExpected({ payload: { kind: 'coordinator_request' } })).toBe(true);
+    expect(isReplyExpected({ payload: { kind: 'solomon_consult' } })).toBe(true);
+    expect(isReplyExpected({ payload: { expects_reply: true } })).toBe(true);
+    expect(isReplyExpected({ payload: { kind: 'adam_advisory' } })).toBe(false);
+  });
+
+  it('isBreaching: unread >=30m, read-unacked >=60m, acked never breaches, probe rows never breach', () => {
+    const created30 = new Date(NOW - UNREAD_BREACH_MS).toISOString();
+    const created29 = new Date(NOW - UNREAD_BREACH_MS + 60_000).toISOString();
+    expect(isBreaching({ created_at: created30, read_at: null }, NOW)).toBe(true);
+    expect(isBreaching({ created_at: created29, read_at: null }, NOW)).toBe(false);
+
+    const read60 = new Date(NOW - UNACKED_BREACH_MS).toISOString();
+    expect(isBreaching({ created_at: created30, read_at: read60 }, NOW)).toBe(true);
+    expect(isBreaching({ created_at: created30, read_at: read60, acknowledged_at: read60 }, NOW)).toBe(false);
+    expect(isBreaching({ created_at: created30, read_at: null, payload: { kind: PROBE_KIND } }, NOW)).toBe(false);
+  });
+
+  it('classifyBreaches: live-target-only, oldest-per-target', () => {
+    const older = { id: 'r1', target_session: LIVE, payload: { kind: 'coordinator_request' }, created_at: new Date(NOW - 40 * 60_000).toISOString(), read_at: null };
+    const newer = { id: 'r2', target_session: LIVE, payload: { kind: 'coordinator_request' }, created_at: new Date(NOW - 35 * 60_000).toISOString(), read_at: null };
+    const deadTarget = { id: 'r3', target_session: 'dead-1', payload: { kind: 'coordinator_request' }, created_at: new Date(NOW - 40 * 60_000).toISOString(), read_at: null };
+    const breaches = classifyBreaches([older, newer, deadTarget], new Set([LIVE]), NOW);
+    expect(breaches.size).toBe(1);
+    expect(breaches.get(LIVE).id).toBe('r1');
+  });
+
+  it('laneHealthAggregate: counts unread fire-and-forget at live targets, excludes probes', () => {
+    const ff = { target_session: LIVE, payload: { kind: 'adam_advisory' }, created_at: new Date(NOW - 10 * 60_000).toISOString(), read_at: null };
+    const probe = { target_session: LIVE, payload: { kind: PROBE_KIND }, created_at: new Date(NOW - 10 * 60_000).toISOString(), read_at: null };
+    const agg = laneHealthAggregate([ff, probe], new Set([LIVE]), NOW);
+    expect(agg.unactionedCount).toBe(1);
+  });
+});
+
+describe('outbound-silence-watchdog: tick wiring (TS-2..TS-5)', () => {
+  const breachingRow = {
+    id: 'row-1', target_session: LIVE, payload: { kind: 'coordinator_request' },
+    created_at: new Date(NOW - 45 * 60_000).toISOString(), read_at: null,
+  };
+
+  it('TS-2: first breach, no prior probe -> one probe row, zero feedback', async () => {
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.probed).toHaveLength(1);
+    expect(result.escalated).toHaveLength(0);
+    expect(sb.inserts).toHaveLength(1);
+    expect(emitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('TS-3: prior probe <2h old -> deduped, zero new rows', async () => {
+    const recentProbe = { id: 'probe-1', created_at: new Date(NOW - 30 * 60_000).toISOString() };
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [recentProbe] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.probed).toHaveLength(0);
+    expect(result.escalated).toHaveLength(0);
+    expect(sb.inserts).toHaveLength(0);
+    expect(emitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: prior probe >=2h old, still breaching -> one feedback row + fresh probe', async () => {
+    const oldProbe = { id: 'probe-1', created_at: new Date(NOW - PROBE_DEDUP_MS - 60_000).toISOString() };
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [oldProbe] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.escalated).toHaveLength(1);
+    expect(result.probed).toHaveLength(1);
+    expect(sb.inserts).toHaveLength(1);
+    expect(emitFeedback).toHaveBeenCalledTimes(1);
+    expect(emitFeedback.mock.calls[0][0].dedup_key).toBe(`outbound-silence:${LIVE}:2026-07-04`);
+  });
+
+  it('TS-5: healthy lane (acked, or no reply-expected rows) -> zero noise', async () => {
+    const healthy = { ...breachingRow, id: 'row-2', read_at: new Date(NOW - 5 * 60_000).toISOString(), acknowledged_at: new Date(NOW - 4 * 60_000).toISOString() };
+    const sb = makeStub({ outboundRows: [healthy], priorProbeRows: [] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.probed).toHaveLength(0);
+    expect(result.escalated).toHaveLength(0);
+    expect(emitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('probe-INSERT vs prior-probe-SELECT filter/column parity (risk-agent C1)', async () => {
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [] });
+    await runOutboundSilenceWatchdog(sb, { now: NOW });
+    const insertedRow = sb.inserts[0];
+    const selectFilter = sb.priorProbeFilters[0];
+    // The SELECT filter that looks up "a prior probe for this target" must match exactly
+    // the fields the INSERT actually writes -- a divergence here is the real storm vector.
+    expect(insertedRow.sender_type).toBe(selectFilter.sender_type);
+    expect(insertedRow.target_session).toBe(selectFilter.target_session);
+    expect(insertedRow.payload.kind).toBe(selectFilter['payload->>kind']);
+  });
+
+  it('fail-open: a thrown query error never propagates', async () => {
+    const sb = { from() { throw new Error('boom'); } };
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.error).toBe('boom');
+    expect(result.probed).toEqual([]);
+  });
+
+  it('probe INSERT carries the load-bearing safety fields (reply_class, expires_at, no correlation_id/request_ack)', async () => {
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [] });
+    await runOutboundSilenceWatchdog(sb, { now: NOW });
+    const inserted = sb.inserts[0];
+    expect(inserted.payload.reply_class).toBe('fire-and-forget');
+    expect(inserted.payload.correlation_id).toBeUndefined();
+    expect(inserted.payload.request_ack).toBeUndefined();
+    expect(Date.parse(inserted.expires_at) - NOW).toBe(PROBE_EXPIRES_MS);
+  });
+
+  it('MAX_PROBES_PER_TICK: more breaching live targets than the cap -> only the cap is probed', async () => {
+    const targets = Array.from({ length: MAX_PROBES_PER_TICK + 2 }, (_, i) => `target-${i}`);
+    const sessionRows = targets.map((t) => ({ session_id: t, heartbeat_at: new Date(NOW).toISOString() }));
+    const outboundRows = targets.map((t, i) => ({
+      id: `row-${i}`, target_session: t, payload: { kind: 'coordinator_request' },
+      created_at: new Date(NOW - 45 * 60_000).toISOString(), read_at: null,
+    }));
+    const sb = makeStub({ outboundRows, sessionRows, priorProbeRows: [] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.probed).toHaveLength(MAX_PROBES_PER_TICK);
+    expect(sb.inserts).toHaveLength(MAX_PROBES_PER_TICK);
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman-caught gap 2026-07-04: a backlog of Adam->coordinator messages sat unprocessed at the coordinator, and Adam never surfaced it despite two visible signals already on the dashboard (ADAM ADVISORY INBOX unactioned relays aged 4h+; UNDELIVERED OUTBOUND "consider re-sending or nudging").
- Adds `lib/adam/outbound-silence-watchdog.js`, wired into `scripts/adam-quiet-tick.mjs`'s tick: classifies Adam's own reply-expected outbound rows (kind=coordinator_request/solomon_consult, or expects_reply=true) that are unread >30m or read-but-unacknowledged >60m as a breach at a LIVE target.
- First breach for a target -> one alternate-kind channel-health probe. A target still breaching after a prior probe (second consecutive breach) -> a chairman-visible feedback row (category=harness_backlog).
- Two independent storm guards on the probe leg: a 2h/target dedup, plus an absolute per-tick cap (MAX_PROBES_PER_TICK=5) so a SELECT/INSERT filter-parity bug degrades to a bounded ceiling, never an unbounded storm.
- Escalated from an oversized quick-fix (QF-20260704-165, DB estimate 10 LOC) to this full SD after the actual implementation landed at 159 source LOC -- confirmed Tier-3 scope.

## Test plan
- [x] `npx vitest run tests/unit/adam/outbound-silence-watchdog.test.js` -- 12/12 pass (pure classification, tick-wiring TS-2..TS-5, probe-INSERT/prior-probe-SELECT filter parity, fail-open, probe safety fields, per-tick cap).
- [x] `npx vitest run tests/unit/adam/` -- 281/281 pass, zero regression.
- [x] Live (non-mocked) run of `node scripts/adam-quiet-tick.mjs --json` and human-readable mode -- clean, `outboundSilence` field present, `probes=0 esc=0`.
- [x] PLAN-phase database-agent + risk-agent review incorporated (24h probe expires_at, per-tick cap, task-rehydrate board side-door avoidance, lane-health self-exclusion).
- [x] EXEC-phase testing-agent re-review confirmed the closed coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)