### PR TITLE
fix(SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001): S19 decomposition coverage for full-stack features

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -79,6 +79,7 @@ import { reviewBuildPayloads } from './build-sd-review-gate.js';
 // SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001: a NON-CLONE convergence subject's build-tree
 // is equally throwaway — read the same marker the S19 auto-approve carve-out uses to fence it off the belt.
 import { isConvergenceSubject } from './clean-clone/launch.js';
+import { impliesUserInteraction } from './utils/user-interaction-signal.js';
 
 // ── Amplification Caps (US-004) ─────────────────────────────────
 const MAX_CHILDREN_PER_ORCHESTRATOR = 10;
@@ -1042,6 +1043,8 @@ async function createGrandchildren({
  * @returns {Array} Applicable architecture layers
  */
 function selectApplicableLayers(payload) {
+  let layers = null;
+
   // SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-2/FR-3: honor the S19 planner's per-item
   // architectureLayer signal — right-size to the single mapped layer instead of stamping all four.
   // Skipped when REPO_GROUNDED_DECOMPOSITION is off (legacy kill-switch), when the planner gave no
@@ -1054,16 +1057,39 @@ function selectApplicableLayers(payload) {
   ) {
     const bridgeKey = PLANNER_TO_BRIDGE_LAYER[String(payload.architectureLayer).toLowerCase()];
     const layer = ARCHITECTURE_LAYERS.find(l => l.key === bridgeKey);
-    if (layer) return [layer];
+    if (layer) layers = [layer];
   }
   // Explicit bridge-taxonomy hint (already keyed data/api/ui/tests).
-  if (payload.architecture_layers && Array.isArray(payload.architecture_layers)) {
-    return payload.architecture_layers
+  if (!layers && payload.architecture_layers && Array.isArray(payload.architecture_layers)) {
+    layers = payload.architecture_layers
       .map(key => ARCHITECTURE_LAYERS.find(l => l.key === key))
       .filter(Boolean);
   }
   // Fallback: all layers apply (legacy payloads, absent signal, or decomposition_strategy='layered').
-  return ARCHITECTURE_LAYERS;
+  if (!layers) {
+    layers = ARCHITECTURE_LAYERS;
+  }
+
+  // SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 FR-2: defense-in-depth coverage assertion — a
+  // feature-type item whose title/acceptance-criteria imply user interaction MUST resolve to a
+  // layer set that includes 'ui', regardless of which branch above produced it. Catches any
+  // upstream planner regression that fails to set decomposition_strategy='layered' for a
+  // customer-facing feature (or a manually-authored payload that bypassed the planner).
+  if (
+    payload &&
+    payload.type === 'feature' &&
+    impliesUserInteraction(payload) &&
+    !layers.some(l => l.key === 'ui')
+  ) {
+    throw new Error(
+      `[LifecycleSDBridge] Sprint item "${String(payload.title || '').substring(0, 100)}" implies ` +
+      'user interaction but its decomposition would produce no ui-layer child (resolved layers: ' +
+      `${layers.map(l => l.key).join(', ') || 'none'}). Refusing to generate children for a ` +
+      'customer-facing feature with no UI surface.'
+    );
+  }
+
+  return layers;
 }
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -17,6 +17,7 @@ import { resolveTargetApplication } from '../../bridge/sd-router.js';
 import { inferDeviceType } from '../../bridge/device-type-resolver.js';
 import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../config/venture-default-capabilities.js';
 import { validateVentureDefaultCapabilities, MissingDefaultCapabilityError } from '../../utils/validate-venture-default-capabilities.js';
+import { impliesUserInteraction } from '../../utils/user-interaction-signal.js';
 
 // NOTE: These constants intentionally duplicated from stage-19.js
 // to avoid circular dependency — stage-19.js imports analyzeStage19 from this file,
@@ -374,26 +375,69 @@ Output ONLY valid JSON.`;
       milestoneRef: 'MVP',
     }];
   } else {
-    sprintItems = sprintItems.map(item => ({
-      title: String(item.title).substring(0, 200),
-      description: String(item.description || '').substring(0, 500),
-      type: SD_TYPES.includes(item.type) ? item.type : 'feature',
-      priority: PRIORITY_VALUES.includes(item.priority) ? item.priority : 'medium',
-      estimatedLoc: typeof item.estimatedLoc === 'number' && item.estimatedLoc > 0
-        ? Math.min(2000, Math.round(item.estimatedLoc))
-        : 200,
-      acceptanceCriteria: String(item.acceptanceCriteria || 'Item completed').substring(0, 500),
-      architectureLayer: ARCHITECTURE_LAYERS.includes(item.architectureLayer)
-        ? item.architectureLayer
-        : 'backend',
-      milestoneRef: String(item.milestoneRef || 'MVP').substring(0, 200),
-    }));
+    sprintItems = sprintItems.map(item => {
+      const type = SD_TYPES.includes(item.type) ? item.type : 'feature';
+      const isFeature = type === 'feature';
+      const layerRecognized = ARCHITECTURE_LAYERS.includes(item.architectureLayer);
+      // SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 FR-1: a feature-type item whose title/
+      // acceptance criteria imply user interaction opts into full multi-layer decomposition
+      // regardless of the single architectureLayer classification, guaranteeing a ui-layer
+      // grandchild is produced downstream (the vacuous-decomposition root cause: MarketLens
+      // shipped 9/10 sprint features as API-only children with no customer surface).
+      const uiImplied = isFeature && impliesUserInteraction(item);
+
+      if (isFeature && !layerRecognized && !uiImplied) {
+        // FAIL LOUD: never silently default an unrecognized/missing layer to 'backend' for a
+        // feature-type item with no detected user-interaction signal either.
+        throw new Error(
+          `[Stage19] Sprint item "${String(item.title).substring(0, 100)}" is feature-type with an ` +
+          `unrecognized/missing architectureLayer ("${item.architectureLayer}") and no detected ` +
+          'user-interaction signal in its title/description/acceptanceCriteria. Refusing to silently ' +
+          'default to \'backend\' — classify it explicitly (frontend/backend/database/infrastructure/' +
+          'integration/security) or reword it so the decomposition-coverage heuristic recognizes it.'
+        );
+      }
+
+      return {
+        title: String(item.title).substring(0, 200),
+        description: String(item.description || '').substring(0, 500),
+        type,
+        priority: PRIORITY_VALUES.includes(item.priority) ? item.priority : 'medium',
+        estimatedLoc: typeof item.estimatedLoc === 'number' && item.estimatedLoc > 0
+          ? Math.min(2000, Math.round(item.estimatedLoc))
+          : 200,
+        acceptanceCriteria: String(item.acceptanceCriteria || 'Item completed').substring(0, 500),
+        architectureLayer: layerRecognized
+          ? item.architectureLayer
+          : (isFeature ? 'frontend' : 'backend'),
+        milestoneRef: String(item.milestoneRef || 'MVP').substring(0, 200),
+        decompositionStrategy: uiImplied ? 'layered' : 'leaf',
+      };
+    });
   }
 
   // Value gate: verify sprint includes at least one core value-delivering feature
   const hasValueFeature = sprintItems.some(item => item.type === 'feature');
   if (!hasValueFeature) {
     logger.warn('[Stage19] VALUE GATE: Sprint contains no feature-type items — only infrastructure/refactor/bugfix tasks. Ventures need at least one core value-delivering feature per sprint.');
+  }
+
+  // SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 FR-3: value gate upgraded from warn-only to a
+  // real check — when the sprint contains a customer-facing feature (any item whose title/
+  // acceptance criteria imply user interaction), at least one such item MUST be marked for
+  // layered (multi-layer) decomposition, guaranteeing a ui-layer child downstream. This is a
+  // regression safety-net for the mapping above, not intended to be a live no-op.
+  const customerFacingItems = sprintItems.filter(item => item.type === 'feature' && impliesUserInteraction(item));
+  if (customerFacingItems.length > 0) {
+    const hasLayeredCoverage = customerFacingItems.some(item => item.decompositionStrategy === 'layered');
+    if (!hasLayeredCoverage) {
+      throw new Error(
+        `[Stage19] VALUE GATE: sprint contains ${customerFacingItems.length} customer-facing feature(s) ` +
+        `(e.g. "${customerFacingItems[0].title}") but none are marked for layered (multi-layer) ` +
+        'decomposition — refusing to ship a sprint plan that would silently produce zero ui-layer ' +
+        'children for a customer-facing feature.'
+      );
+    }
   }
 
   // Default-capabilities adherence (belt-and-suspenders post-parse enforcement).
@@ -463,6 +507,7 @@ Output ONLY valid JSON.`;
     story_points: typeof item.estimatedLoc === 'number' ? Math.ceil(item.estimatedLoc / 50) : 3,
     app_type: appType,
     architectureLayer: item.architectureLayer,
+    decompositionStrategy: item.decompositionStrategy,
     milestoneRef: item.milestoneRef,
   }));
 
@@ -485,10 +530,11 @@ Output ONLY valid JSON.`;
     // SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-1: forward the planner's per-item
     // architectureLayer decomposition signal (previously stripped here) so the bridge can
     // right-size decomposition to one SD per item instead of stamping all four layers.
-    // decomposition_strategy defaults to 'leaf' (one SD); a future planner enhancement may
-    // mark a genuinely large item 'layered' to opt back into multi-layer grandchildren.
+    // SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 FR-1: decomposition_strategy now reflects the
+    // per-item user-interaction signal computed above ('layered' for a customer-facing feature,
+    // 'leaf' otherwise) instead of being hardcoded to 'leaf' for every item.
     architectureLayer: item.architectureLayer,
-    decomposition_strategy: 'leaf',
+    decomposition_strategy: item.decompositionStrategy || 'leaf',
   }));
 
   logger.log('[Stage19] Analysis complete', { duration: Date.now() - startTime });

--- a/lib/eva/utils/user-interaction-signal.js
+++ b/lib/eva/utils/user-interaction-signal.js
@@ -1,0 +1,50 @@
+/**
+ * SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001: shared heuristic for whether a sprint item's
+ * title/description/acceptance-criteria imply a user-facing surface (and therefore need a
+ * ui-layer grandchild). Used by both the S19 planner (to opt a feature item into layered
+ * decomposition) and the lifecycle bridge (to assert ui-layer coverage), so the two checks
+ * cannot drift apart. Biased toward recall over precision: a missed customer-facing feature
+ * (the original defect) is far more costly than an extra ui-layer child on a borderline item.
+ *
+ * @module lib/eva/utils/user-interaction-signal
+ */
+
+const UI_SIGNAL_PATTERNS = [
+  /\bpage\b/, /\bpages\b/, /\bscreen\b/, /\bscreens\b/, /\blanding\b/,
+  /\bsignup\b/, /\bsign-up\b/, /\bsign up\b/, /\bsignin\b/, /\bsign-in\b/, /\bsign in\b/,
+  /\blogin\b/, /\blog-in\b/, /\blog in\b/, /\blogout\b/,
+  /\bregistration\b/, /\bregister\b/, /\bform\b/, /\bforms\b/, /\bbutton\b/, /\bbuttons\b/,
+  /\bcta\b/, /\bcall-to-action\b/, /\bcall to action\b/,
+  /\bdashboard\b/, /\bfrontend\b/, /\bfront-end\b/, /\bmodal\b/, /\bdialog\b/,
+  /\bwidget\b/, /\bwidgets\b/, /\bcomponent\b/, /\bcomponents\b/, /\bresponsive\b/,
+  /\bcheckout\b/, /\bcart\b/, /\bprofile\b/, /\bonboarding\b/, /\bhero\b/, /\bwireframe\b/,
+  /\bbrowser\b/, /\bwebpage\b/, /\bweb page\b/, /\buser interface\b/, /\bui layer\b/,
+  /\bsignup flow\b/, /\bsign-up flow\b/,
+];
+
+/**
+ * @param {Object} item - Sprint item (planner or bridge shape)
+ * @param {string} [item.title]
+ * @param {string} [item.description]
+ * @param {string} [item.acceptanceCriteria]
+ * @param {string} [item.acceptance_criteria]
+ * @param {string} [item.success_criteria]
+ * @returns {boolean}
+ */
+export function impliesUserInteraction(item) {
+  const text = [
+    item?.title,
+    item?.description,
+    item?.acceptanceCriteria,
+    item?.acceptance_criteria,
+    item?.success_criteria,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (!text) return false;
+  return UI_SIGNAL_PATTERNS.some(pattern => pattern.test(text));
+}
+
+export { UI_SIGNAL_PATTERNS };

--- a/tests/unit/eva/lifecycle-sd-bridge.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge.test.js
@@ -261,6 +261,65 @@ describe('LifecycleSDBridge', () => {
     });
   });
 
+  describe('selectApplicableLayers — SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 coverage assertion', () => {
+    it('throws when a feature item implies user interaction but resolves to no ui layer', () => {
+      expect(() => selectApplicableLayers({
+        type: 'feature',
+        title: 'Develop Landing Page with Hero and CTA',
+        architectureLayer: 'backend',
+        decomposition_strategy: 'leaf',
+      })).toThrow(/implies user interaction/);
+    });
+
+    it('throws when architecture_layers explicitly omits ui for a user-facing feature', () => {
+      expect(() => selectApplicableLayers({
+        type: 'feature',
+        title: 'User Registration and Login Flow',
+        architecture_layers: ['api', 'data'],
+      })).toThrow(/implies user interaction/);
+    });
+
+    it('does not throw when decomposition_strategy=layered resolves all 4 layers (ui included)', () => {
+      const layers = selectApplicableLayers({
+        type: 'feature',
+        title: 'Develop Landing Page with Hero and CTA',
+        architectureLayer: 'backend',
+        decomposition_strategy: 'layered',
+      });
+      expect(layers.map(l => l.key)).toContain('ui');
+    });
+
+    it('does not throw when the single mapped layer already resolves to ui', () => {
+      const layers = selectApplicableLayers({
+        type: 'feature',
+        title: 'Develop Landing Page with Hero and CTA',
+        architectureLayer: 'frontend',
+        decomposition_strategy: 'leaf',
+      });
+      expect(layers.map(l => l.key)).toEqual(['ui']);
+    });
+
+    it('does not throw for a genuinely backend-only feature item (no user-interaction signal)', () => {
+      const layers = selectApplicableLayers({
+        type: 'feature',
+        title: 'Wire Error Capture Middleware',
+        architectureLayer: 'backend',
+        decomposition_strategy: 'leaf',
+      });
+      expect(layers.map(l => l.key)).toEqual(['api']);
+    });
+
+    it('does not throw for a non-feature item even if the title implies user interaction', () => {
+      const layers = selectApplicableLayers({
+        type: 'bugfix',
+        title: 'Fix landing page CTA button click handler',
+        architectureLayer: 'backend',
+        decomposition_strategy: 'leaf',
+      });
+      expect(layers.map(l => l.key)).toEqual(['api']);
+    });
+  });
+
   describe('filterLayersByCapability — target_application capability gate', () => {
     it('should suppress api layer when target_application=ehg (Vite SPA, no serverless API)', () => {
       const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/tests/unit/eva/s19-decomposition-coverage.test.js
+++ b/tests/unit/eva/s19-decomposition-coverage.test.js
@@ -1,0 +1,161 @@
+/**
+ * SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 — end-to-end regression proof.
+ *
+ * Runs the REAL planner-normalization (analyzeStage19) output through the REAL bridge
+ * decomposition logic (selectApplicableLayers, exported via lifecycle-sd-bridge.js's
+ * _internal) — no mocking of either the planner-normalization or the bridge-decomposition
+ * gate under test. Only the LLM client and JSON-parsing plumbing are mocked, matching the
+ * established pattern in stage-19-architectureLayer-forwarding.test.js.
+ *
+ * Fixes the Stage-19 defect that shipped MarketLens to Stage 24 with no customer interface:
+ * 9 of 10 sprint features (including "Develop Landing Page with Hero and CTA" and "User
+ * Registration and Login Flow") produced ONLY api-layer children.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../../lib/eva/config/venture-default-capabilities.js';
+
+const MANDATORY_ITEMS = EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => ({
+  title: c.name,
+  description: c.description.slice(0, 60),
+  type: 'infra',
+  priority: 'medium',
+  estimatedLoc: 30,
+  acceptanceCriteria: 'Mandatory capability present',
+  architectureLayer: 'infrastructure',
+  milestoneRef: 'MVP',
+}));
+
+const mockComplete = vi.fn();
+
+vi.mock('../../../lib/llm/index.js', () => ({ getLLMClient: () => ({ complete: mockComplete }) }));
+vi.mock('../../../lib/eva/utils/parse-json.js', () => ({ parseJSON: (str) => JSON.parse(str), extractUsage: () => ({}) }));
+vi.mock('../../../lib/eva/utils/four-buckets-prompt.js', () => ({ getFourBucketsPrompt: () => '' }));
+vi.mock('../../../lib/eva/utils/four-buckets-parser.js', () => ({ parseFourBuckets: () => ({}) }));
+vi.mock('../../../lib/eva/bridge/sd-router.js', () => ({ resolveTargetApplication: () => ({ targetApp: 'EHG_Engineer' }) }));
+
+const { analyzeStage19 } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js');
+const { _internal } = await import('../../../lib/eva/lifecycle-sd-bridge.js');
+const { selectApplicableLayers } = _internal;
+
+const baseStage18 = {
+  buildReadiness: { decision: 'go', rationale: 'ok' },
+  ventureDescription: 'MarketLens venture',
+  problemStatement: 'Customer-facing SaaS front door',
+};
+const logger = { log: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() };
+const callArgs = { stage18Data: baseStage18, stage17Data: { decision: 'PASS' }, ventureName: 'MarketLens', logger };
+
+describe('SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 — real planner + bridge path', () => {
+  it('a customer-facing feature decomposes into BOTH ui and api children', async () => {
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      sprintGoal: 'Ship the front door',
+      sprintItems: [
+        {
+          title: 'Develop Landing Page with Hero and CTA', description: 'Public landing page',
+          type: 'feature', priority: 'high', estimatedLoc: 150,
+          acceptanceCriteria: 'Visitor sees hero + CTA and can click through',
+          architectureLayer: 'backend', // deliberately wrong single-layer, as the real LLM emitted
+          milestoneRef: 'MVP',
+        },
+        ...MANDATORY_ITEMS,
+      ],
+    }));
+
+    const result = await analyzeStage19(callArgs);
+    const payload = result.sd_bridge_payloads.find(p => p.title === 'Develop Landing Page with Hero and CTA');
+    expect(payload.decomposition_strategy).toBe('layered');
+
+    const layers = selectApplicableLayers(payload).map(l => l.key);
+    expect(layers).toContain('ui');
+    expect(layers).toContain('api');
+  });
+
+  it('a genuinely backend-only item still produces EXACTLY one api child (no regression)', async () => {
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      sprintGoal: 'Harden observability',
+      sprintItems: [
+        {
+          title: 'Wire Error Capture Middleware', description: 'Express error middleware',
+          type: 'feature', priority: 'medium', estimatedLoc: 60,
+          acceptanceCriteria: 'Errors are captured and logged',
+          architectureLayer: 'backend',
+          milestoneRef: 'MVP',
+        },
+        ...MANDATORY_ITEMS,
+      ],
+    }));
+
+    const result = await analyzeStage19(callArgs);
+    const payload = result.sd_bridge_payloads.find(p => p.title === 'Wire Error Capture Middleware');
+    expect(payload.decomposition_strategy).toBe('leaf');
+
+    const layers = selectApplicableLayers(payload).map(l => l.key);
+    expect(layers).toEqual(['api']);
+  });
+
+  it('a feature item with an unrecognized architectureLayer and no UI signal fails loud, naming the item', async () => {
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      sprintGoal: 'Ship something ambiguous',
+      sprintItems: [
+        {
+          title: 'Reconcile Ledger Batch Job', description: 'Nightly reconciliation job',
+          type: 'feature', priority: 'medium', estimatedLoc: 90,
+          acceptanceCriteria: 'Ledger reconciles nightly',
+          architectureLayer: 'bogus',
+          milestoneRef: 'MVP',
+        },
+        ...MANDATORY_ITEMS,
+      ],
+    }));
+
+    await expect(analyzeStage19(callArgs)).rejects.toThrow(/Reconcile Ledger Batch Job/);
+  });
+
+  it('re-running the MarketLens sprint fixture yields ui children for every customer-facing feature', async () => {
+    // The 9 real MarketLens sprint features that shipped API-only, plus the 1 genuinely
+    // backend-only item ("Wire Error Capture Middleware") that must NOT regress.
+    const marketLensFeatures = [
+      'Develop Landing Page with Hero and CTA',
+      'User Registration and Login Flow',
+      'Persona Generation Results Page',
+      'WTP Survey Form and Submission',
+      'Chairman Decision Card Dashboard',
+      'Feedback Widget UI',
+      'Pricing Tier Signup Flow',
+      'Account Profile Settings Page',
+      'Onboarding Welcome Screen',
+    ];
+
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      sprintGoal: 'MarketLens full sprint',
+      sprintItems: [
+        ...marketLensFeatures.map(title => ({
+          title, description: `${title} for MarketLens customers`,
+          type: 'feature', priority: 'high', estimatedLoc: 100,
+          acceptanceCriteria: 'Customer can complete the flow',
+          architectureLayer: 'backend', // as the real LLM mis-emitted for all 9
+          milestoneRef: 'MVP',
+        })),
+        {
+          title: 'Wire Error Capture Middleware', description: 'Express error middleware',
+          type: 'feature', priority: 'medium', estimatedLoc: 60,
+          acceptanceCriteria: 'Errors are captured and logged',
+          architectureLayer: 'backend',
+          milestoneRef: 'MVP',
+        },
+        ...MANDATORY_ITEMS,
+      ],
+    }));
+
+    const result = await analyzeStage19(callArgs);
+    const byTitle = Object.fromEntries(result.sd_bridge_payloads.map(p => [p.title, p]));
+
+    for (const title of marketLensFeatures) {
+      const layers = selectApplicableLayers(byTitle[title]).map(l => l.key);
+      expect(layers, `${title} must include a ui-layer child`).toContain('ui');
+    }
+
+    const backendOnlyLayers = selectApplicableLayers(byTitle['Wire Error Capture Middleware']).map(l => l.key);
+    expect(backendOnlyLayers).toEqual(['api']);
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
@@ -55,10 +55,23 @@ describe('SD-LEO-INFRA-REPO-GROUNDED-INTELLIGENT-001 FR-1 — planner forwards a
     expect(byTitle['Signup API'].architectureLayer).toBe('backend');
   });
 
-  it('defaults decomposition_strategy to "leaf" (one SD per item) on every payload', async () => {
+  it('defaults decomposition_strategy to "leaf" for infra items with no user-interaction signal', async () => {
     const result = await analyzeStage19(callArgs);
-    for (const p of result.sd_bridge_payloads) {
-      expect(p.decomposition_strategy).toBe('leaf');
+    const byTitle = Object.fromEntries(result.sd_bridge_payloads.map(p => [p.title, p]));
+    for (const cap of EHG_VENTURE_DEFAULT_CAPABILITIES) {
+      expect(byTitle[cap.name].decomposition_strategy).toBe('leaf');
     }
+  });
+
+  // SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001 FR-1: a feature-type item whose title/description
+  // implies user interaction now opts into 'layered' decomposition regardless of its single
+  // architectureLayer classification, guaranteeing a ui-layer grandchild downstream. Both "Landing
+  // Hero" (hero/landing) and "Signup API" (signup) carry a user-interaction signal in this fixture
+  // — biased toward recall, since a missed customer-facing feature is the costlier failure mode.
+  it('marks feature items with a user-interaction signal as decomposition_strategy=layered', async () => {
+    const result = await analyzeStage19(callArgs);
+    const byTitle = Object.fromEntries(result.sd_bridge_payloads.map(p => [p.title, p]));
+    expect(byTitle['Landing Hero'].decomposition_strategy).toBe('layered');
+    expect(byTitle['Signup API'].decomposition_strategy).toBe('layered');
   });
 });

--- a/tests/unit/eva/utils/user-interaction-signal.test.js
+++ b/tests/unit/eva/utils/user-interaction-signal.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { impliesUserInteraction } from '../../../../lib/eva/utils/user-interaction-signal.js';
+
+describe('impliesUserInteraction — SD-LEO-INFRA-S19-DECOMPOSITION-COVERAGE-001', () => {
+  it('matches the two named MarketLens defect specimens', () => {
+    expect(impliesUserInteraction({ title: 'Develop Landing Page with Hero and CTA' })).toBe(true);
+    expect(impliesUserInteraction({ title: 'User Registration and Login Flow' })).toBe(true);
+  });
+
+  it('does not match the genuinely backend-only counter-example', () => {
+    expect(impliesUserInteraction({
+      title: 'Wire Error Capture Middleware',
+      description: 'Express error middleware for API request handling',
+      acceptanceCriteria: 'Errors are captured and logged server-side',
+    })).toBe(false);
+  });
+
+  it('does not false-positive on common backend words containing "ui" as a substring', () => {
+    expect(impliesUserInteraction({
+      title: 'Build the requirements pipeline',
+      description: 'Quick build for the acquire-lead pipeline',
+    })).toBe(false);
+  });
+
+  it('checks description and acceptanceCriteria, not just title', () => {
+    expect(impliesUserInteraction({ title: 'Backend Task', description: 'Renders a modal dialog on error' })).toBe(true);
+    expect(impliesUserInteraction({ title: 'Backend Task', acceptanceCriteria: 'User completes the checkout flow' })).toBe(true);
+  });
+
+  it('returns false for empty/missing fields', () => {
+    expect(impliesUserInteraction({})).toBe(false);
+    expect(impliesUserInteraction(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the Stage-19 build-decomposition defect that shipped MarketLens to Stage 24 with no customer interface (chairman-directed root-cause, 2026-07-04). The planner's single-value `architectureLayer` taxonomy couldn't express a full-stack feature, and unrecognized/missing values silently defaulted to `'backend'` -- 9 of 10 MarketLens sprint features produced API-only children with zero UI surface.
- New shared heuristic `impliesUserInteraction()` (`lib/eva/utils/user-interaction-signal.js`), used by both the planner and the bridge so the two checks can't drift apart.
- `stage-19-sprint-planning.js`: a feature-type item whose title/acceptance criteria imply user interaction now opts into `decomposition_strategy='layered'` regardless of its single `architectureLayer` classification. A feature-type item with an unrecognized/missing layer AND no UI signal fails loud instead of silently defaulting to `'backend'`. The value gate is upgraded from warn-only to a real check.
- `lifecycle-sd-bridge.js` `selectApplicableLayers`: defense-in-depth coverage assertion -- throws a clear, actionable error naming the item if a user-facing feature would resolve to no `ui`-layer child.
- Both directions tested: backend-only items (`Wire Error Capture Middleware`) still produce exactly one `api` child (no regression); a re-run of the real MarketLens sprint fixture yields `ui` children for all 9 affected features.

## Test plan
- [x] New e2e test (`tests/unit/eva/s19-decomposition-coverage.test.js`) runs the real planner-normalization + real bridge-decomposition path (no mocking the gate under test), covering: customer-facing feature -> both ui+api; backend-only item -> exactly one api child; unrecognized layer + no UI signal -> fail loud naming the item; full MarketLens fixture re-run -> ui children for all 9 features.
- [x] New unit tests for the shared heuristic, including a false-positive guard (words containing "ui" as a substring like "build"/"quick"/"require").
- [x] Updated pre-existing `stage-19-architectureLayer-forwarding.test.js` to reflect the intentional behavior change.
- [x] Full `tests/unit/eva` + `tests/unit/lifecycle-sd-bridge*` sweep: 5798+ tests passing, 0 regressions (1 unrelated hook-timeout flake confirmed passing in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)