### PR TITLE
feat(SD-LEO-INFRA-CANONICAL-REPO-APP-001): canonical repo/app resolution sweep

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-FEAT-MARKETLENS-OWNED-AUDIENCE-001",
-  "expectedBranch": "feat/SD-LEO-FEAT-MARKETLENS-OWNED-AUDIENCE-001",
-  "createdAt": "2026-07-04T11:00:35.223Z",
+  "sdKey": "SD-LEO-INFRA-CANONICAL-REPO-APP-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CANONICAL-REPO-APP-001",
+  "createdAt": "2026-07-04T13:29:21.988Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/docs/architecture/canonical-repo-resolution-census.md
+++ b/docs/architecture/canonical-repo-resolution-census.md
@@ -1,0 +1,88 @@
+# Canonical Repo/App Resolution Census
+
+SD-LEO-INFRA-CANONICAL-REPO-APP-001 (FR-1). File:line → disposition table for every
+hardcoded-two-repo-assumption site found while sourcing and executing this SD. No
+site is silently omitted — everything found is `swept`, `deliberately-exempt`, or
+`deferred-with-owner`.
+
+The canonical resolver is `lib/repo-paths.js` / `lib/repo-paths.cjs` (DB-first via
+`applications.local_path`, registry.json fallback). Any site NOT going through it is,
+by definition, a candidate for this class of bug.
+
+## Disposition legend
+
+- **swept** — fixed in this SD.
+- **deliberately-exempt** — an intentional anchor; fixing it would remove the floor
+  the rest of the system depends on.
+- **deferred-with-owner** — a real, tracked violation, explicitly out of this SD's
+  tractable-slice scope. Owner + reason given, not a bare "later".
+
+## Swept (fixed in this SD)
+
+| Site | Change |
+|---|---|
+| `lib/repo-paths.js` — `resolveGitHubRepo()` | Added the missing EHG_Engineer self-reference branch (mirrors `resolveRepoPath`'s existing one). Previously returned `null` for an explicit `target_application='EHG_Engineer'` string — the value 630/632 real `quick_fixes` rows actually carry. Without this fix, FR-2 below would fail-loud-throw on nearly every real QF. |
+| `scripts/orphan-qf-reaper.mjs` (both `gh pr view` / `gh pr list` call sites, ~line 53/71 pre-fix) | Both calls now pass an explicit `-R <owner/repo>` resolved via `resolveGitHubRepo(qf.target_application)` — never the ambient `gh` default. Unresolvable `target_application` fails loud (TR-2) instead of silently defaulting. |
+| `lib/ship/auto-merge.mjs` | Added `createRegistryNarrowedTrustGate(supabase)` — an opt-in, AND-composed trust predicate. The literal `AUTO_MERGE_PLATFORM_REPOS` floor (`isPlatformRepo`) always runs first and is non-negotiable; the registry's `applications.trust_tier` is consulted only to further narrow. Default wiring (`isTrustedRepo = isPlatformRepo`) is unchanged — zero behavior change to the live `/ship` path unless a caller explicitly opts in. |
+| `scripts/lint-repo-resolution-drift.mjs` (new) | Regression lint (FR-4) — AST-scoped (acorn), path-allowlisted. Stops new instances of this bug class from landing. |
+
+## Deliberately-exempt (intentional anchors)
+
+| Site | Reason |
+|---|---|
+| `lib/repo-paths.js:24` `PLATFORM_REPOS = new Set(['ehg','ehg_engineer'])` | The canonical resolver's own anchor — this is the thing everything else should defer to, not a violation of itself. |
+| `lib/repo-paths.js:27-30` `FALLBACK_REPOS` | Documented graceful-degradation fallback for when the registry file is unavailable/corrupt. |
+| `lib/ship/auto-merge.mjs:33` `AUTO_MERGE_PLATFORM_REPOS` | The FR-3 fail-closed floor (SECURITY VB-2) — deliberately hardcoded so a corrupt/mis-tagged registry can never widen unattended-merge eligibility. Confirmed live risk: `applications.trust_tier='trusted'` for MarketLens (an external venture repo) proves a registry-only check would be unsafe here. |
+| `scripts/lint-repo-resolution-drift.mjs` `FORBIDDEN_STRINGS` | The lint's own detection target — necessarily contains the literal strings it watches for. |
+| `tests/**` | Fixtures legitimately reference literal repo names for mocking (e.g. `tests/unit/audit-orphan-prs.test.js`, `tests/unit/deleteVentureFully.test.js`). Allowlisted wholesale by the FR-4 lint. |
+
+## Deferred-with-owner
+
+All entries below: **owner = fleet-worker (this session's lineage) via a dedicated
+follow-up SD/QF; reason = each requires its own scoped, regression-tested change —
+bundling all of them into this already-large SD would blow past the "tractable
+critical-path slice" this PRD deliberately scoped down to.**
+
+### High-risk (requires a golden-master regression pass before touching — TR-4)
+
+| Site | Notes |
+|---|---|
+| `scripts/modules/handoff/executors/lead-final-approval/gates.js` (`computeReposForSD`, ~line 100-152; literal `rickfelix/ehg` / `rickfelix/EHG_Engineer` at ~line 103-104, 504) | Gates **every SD's** LEAD-FINAL-APPROVAL. risk-agent flagged this HIGH risk — a naive repoint could silently change which repo(s) get scanned for open PRs/unmerged branches across the whole fleet. Requires `regression-agent` golden-master pass first. |
+
+### Category B — `target_application` inline re-derivation (bare app names, not github owner/repo strings; out of FR-4 lint's literal-string scope by design)
+
+| Site | Notes |
+|---|---|
+| `scripts/leo-create-sd.js` (~line 2137) `const PLATFORM_REPOS = new Set(['ehg', 'ehg_engineer'])` | Inline re-derivation of the exact same Set `lib/repo-paths.js` already exports (`isVentureRepo`/`PLATFORM_REPOS`). Should import the canonical helper instead of re-deriving. |
+| `scripts/modules/sd-next/rank-items.js:44` `PLATFORM_APPLICATIONS = new Set(['ehg', 'ehg_engineer'])` | Same re-derivation pattern, different module. |
+
+### Category C — literal `owner/repo` GitHub strings (surfaced by the FR-4 lint's first full-repo AST sweep; none were in the PRD's original ~20-site estimate from the earlier manual grep pass — the comprehensive AST sweep found more, consistent with "no silent caps")
+
+| File | Lines |
+|---|---|
+| `lib/deleteVentureFully.js` | 42-44 |
+| `lib/multi-repo/index.js` | 62, 70, 81, 87 |
+| `scripts/adam-github-assessment.mjs` | 25 |
+| `scripts/archive/one-time/monitor-scheduled-jobs.js` | 29 (archived one-time script — lowest-priority of this group) |
+| `scripts/audit-orphan-prs.mjs` | 21 |
+| `scripts/backfill-pr-tracking.js` | 42 (one-time backfill script — low priority) |
+| `scripts/check-migration-readiness.mjs` | 86 |
+| `scripts/clockwork/gh-failure-monitor.cjs` | 184 |
+| `scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js` | 75 |
+| `scripts/modules/handoff/executors/lead-final-approval/hooks/ship-review-findings-populator.js` | 34 |
+| `scripts/one-off/_design-agent-evidence-stage23-reject.cjs` | 31 (one-off script — lowest priority) |
+
+All of the above are individually allowlisted (by exact path) in
+`scripts/lint-repo-resolution-drift.mjs`'s `ALLOWLIST_EXACT` set, each with a
+one-line comment pointing back to this census — so the FR-4 lint passes clean
+today while still making every deferred site discoverable and accountable, not
+silently capped. **Un-allowlisting any one of these** (as part of its own
+follow-up fix) is how the regression lint will confirm the fix actually resolved
+that specific site, rather than just trusting the fix description.
+
+## Not re-fixed here (explicitly out of scope — TR-3)
+
+The following tactical QFs land independently per this SD's own description and
+are not re-fixed by this PRD; their pattern is folded into this census and the
+FR-4 lint instead of a duplicate fix: `QF-20260703-775`, `QF-20260704-180`,
+`QF-20260704-440`, `QF-20260704-726`, and the `QF-401` lineage.

--- a/docs/architecture/canonical-repo-resolution-census.md
+++ b/docs/architecture/canonical-repo-resolution-census.md
@@ -26,6 +26,24 @@ by definition, a candidate for this class of bug.
 | `lib/ship/auto-merge.mjs` | Added `createRegistryNarrowedTrustGate(supabase)` — an opt-in, AND-composed trust predicate. The literal `AUTO_MERGE_PLATFORM_REPOS` floor (`isPlatformRepo`) always runs first and is non-negotiable; the registry's `applications.trust_tier` is consulted only to further narrow. Default wiring (`isTrustedRepo = isPlatformRepo`) is unchanged — zero behavior change to the live `/ship` path unless a caller explicitly opts in. |
 | `scripts/lint-repo-resolution-drift.mjs` (new) | Regression lint (FR-4) — AST-scoped (acorn), path-allowlisted. Stops new instances of this bug class from landing. |
 
+### Side effect of the FR-2 `resolveGitHubRepo()` fix (VALIDATION-agent finding, PLAN_VERIFICATION)
+
+`scripts/modules/shipping/ShippingPreflightVerifier.js` and
+`scripts/modules/shipping/SDGitStateReconciler.js` both build a `REPO_PATHS` map via
+`buildRepoPaths()`, which iterates `getRepoPaths()` (always has an `EHG_Engineer` key)
+and keeps only entries where `resolveGitHubRepo(name)` is truthy. Before this SD,
+`resolveGitHubRepo('EHG_Engineer')` returned `null`, so `rickfelix/EHG_Engineer` was
+**silently absent** from `REPO_PATHS` — these two shipping-preflight scanners were blind
+to the platform repo where nearly every SD's branch actually lives. The FR-2 fix
+corrects this as a side effect: `REPO_PATHS` now includes `rickfelix/EHG_Engineer` (6
+repos → 7, confirmed empirically by the VALIDATION sub-agent). This is net-positive and
+low-risk — both call sites only use the map to scan for the *current SD's own*
+unmerged branches/PRs, so the corrected behavior can only surface true positives, never
+introduce a false one. **Deferred-with-owner** (not fixed further here): a dedicated
+regression test locking in the corrected `buildRepoPaths()` output for these two
+specific callers, since it wasn't a directly-scoped component of this SD's system
+architecture (owner=fleet-worker follow-up QF).
+
 ## Deliberately-exempt (intentional anchors)
 
 | Site | Reason |

--- a/lib/repo-paths.js
+++ b/lib/repo-paths.js
@@ -244,6 +244,11 @@ export function resolveGitHubRepo(targetApp) {
   const { apps } = loadValidatedRegistry();
   const needle = normalizeAppName(targetApp);
 
+  // EHG_Engineer self-reference (mirrors resolveRepoPath — EHG_Engineer is never
+  // itself a registry.json entry, so without this branch every explicit
+  // target_application='EHG_Engineer' caller would get a false "unresolvable" miss).
+  if (needle === 'ehgengineer') return 'rickfelix/EHG_Engineer';
+
   for (const app of apps) {
     if (normalizeAppName(app.name) === needle && app.github_repo) {
       return app.github_repo.replace(/\.git$/, '');

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -38,6 +38,55 @@ export function isPlatformRepo(repoOwner, repoName) {
   return AUTO_MERGE_PLATFORM_REPOS.has(`${repoOwner}/${repoName}`.toLowerCase());
 }
 
+/**
+ * FR-3 (SD-LEO-INFRA-CANONICAL-REPO-APP-001): registry-AND-composed trust gate.
+ *
+ * `isPlatformRepo` (the literal AUTO_MERGE_PLATFORM_REPOS Set) remains the
+ * non-negotiable floor — this factory NEVER widens eligibility beyond it, only
+ * narrows. Concretely: applications.trust_tier is a live example of the exact
+ * risk this guards against — MarketLens (an external venture repo requiring a
+ * human merge) is tagged trust_tier='trusted' in the registry, NOT 'external'.
+ * A registry-only check (or an OR-composed check) would wrongly auto-merge-
+ * enable it; the floor check below runs FIRST and short-circuits false for any
+ * repo outside the hardcoded Set, so no registry value can ever flip it to true.
+ *
+ * For a floor-eligible repo (rickfelix/ehg, rickfelix/EHG_Engineer), the registry
+ * is consulted only to further RESTRICT: if the matching applications row's
+ * trust_tier is present and is NOT 'platform' (e.g. operationally revoked/
+ * suspended without a code deploy), auto-merge is refused. No matching row, a
+ * lookup error, or no supabase client supplied all fall back to the floor
+ * result alone (fail-open only within the floor — never beyond it).
+ *
+ * Returns an `isTrustedRepo`-compatible predicate: `(repoOwner, repoName) => Promise<boolean>`.
+ * The default `attemptAutoMerge` wiring (`isTrustedRepo = isPlatformRepo`) is
+ * UNCHANGED — this is an opt-in extension point, not a default-path behavior change.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} [supabase]
+ * @returns {(repoOwner: string, repoName: string) => Promise<boolean>}
+ */
+export function createRegistryNarrowedTrustGate(supabase) {
+  return async function isTrustedPlatformRepo(repoOwner, repoName) {
+    if (!isPlatformRepo(repoOwner, repoName)) return false; // floor: non-negotiable
+    if (!supabase) return true; // no registry consultation available — floor alone stands
+
+    try {
+      const githubRepo = `${repoOwner}/${repoName}`.toLowerCase();
+      const { data, error } = await supabase
+        .from('applications')
+        .select('trust_tier, github_repo')
+        .not('github_repo', 'is', null);
+      if (error || !Array.isArray(data)) return true; // DB unavailable — floor alone stands
+
+      const row = data.find((a) => String(a.github_repo || '').replace(/\.git$/i, '').toLowerCase() === githubRepo);
+      if (!row) return true; // no registry row — nothing to narrow with, floor alone stands
+
+      return row.trust_tier === 'platform';
+    } catch {
+      return true; // DB unavailable is NOT an authoritative narrowing signal — floor alone stands
+    }
+  };
+}
+
 /** Default runner: invokes gh CLI synchronously and returns { code, stdout, stderr }. */
 function defaultRunner(args) {
   const result = spawnSync('gh', args, { encoding: 'utf8' });

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
     "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
     "lint:session-coordination-insert": "node scripts/lint/session-coordination-insert-classguard-lint.mjs",
+    "lint:repo-resolution-drift": "node scripts/lint-repo-resolution-drift.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",

--- a/scripts/lint-repo-resolution-drift.mjs
+++ b/scripts/lint-repo-resolution-drift.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * lint-repo-resolution-drift — regression guard for SD-LEO-INFRA-CANONICAL-REPO-APP-001 (FR-4).
+ *
+ * Flags NEW literal references to the two platform repos (rickfelix/ehg,
+ * rickfelix/EHG_Engineer) outside an explicit allowlist. This is the class of
+ * bug the SD exists to stop recurring: code that assumes the codebase only
+ * ever has these two repos instead of going through the canonical
+ * lib/repo-paths.js resolver.
+ *
+ * AST-scoped (via acorn) rather than pure regex, per risk-agent's too-loose
+ * failure-mode note: also catches a fully-literal string concatenation
+ * (`'rickfelix' + '/' + 'ehg'`) that a naive substring regex could miss if
+ * split across a `+` expression. A genuinely dynamic concatenation
+ * (`owner + '/' + repoNameVar`) is NOT flagged — its value isn't statically
+ * known, so it can't be the literal-repo-string bug this lint targets.
+ *
+ * Allowlist (per risk-agent, PRD FR-4):
+ *   - lib/repo-paths.js / lib/repo-paths.cjs — the resolver's own intentional anchor
+ *   - lib/ship/auto-merge.mjs — the FR-3 fail-closed floor (AUTO_MERGE_PLATFORM_REPOS)
+ *   - tests/** — fixtures legitimately reference literal repo names for mocking
+ *
+ * Exit codes: 0=clean, 1=drift found, 2=execution error.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as acorn from 'acorn';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const SCAN_ROOTS = ['lib', 'scripts', 'tests'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
+const EXCLUDED_DIR_NAMES = new Set(['node_modules', '.worktrees', '.git', 'coverage', 'dist', 'build']);
+
+const FORBIDDEN_STRINGS = new Set(['rickfelix/ehg', 'rickfelix/ehg_engineer']);
+
+// Each entry documented in docs/architecture/canonical-repo-resolution-census.md (FR-1).
+// "Self-anchor" entries are this SD's own intentional literals (the resolver, the FR-3
+// floor, this lint's own FORBIDDEN_STRINGS definition). "Deferred" entries are real,
+// pre-existing sites this lint's first-run AST sweep surfaced — out of this SD's
+// tractable-slice scope (TR-3/TR-4) but explicitly tracked, not silently dropped.
+const ALLOWLIST_EXACT = new Set([
+  // Self-anchors (intentional, per risk-agent)
+  'lib/repo-paths.js',
+  'lib/repo-paths.cjs',
+  'lib/ship/auto-merge.mjs',
+  'scripts/lint-repo-resolution-drift.mjs',
+  // Deferred — pre-existing sites surfaced by this lint's first run (census: deferred-with-owner)
+  'lib/deleteVentureFully.js',
+  'lib/multi-repo/index.js',
+  'scripts/adam-github-assessment.mjs',
+  'scripts/archive/one-time/monitor-scheduled-jobs.js',
+  'scripts/audit-orphan-prs.mjs',
+  'scripts/backfill-pr-tracking.js',
+  'scripts/check-migration-readiness.mjs',
+  'scripts/clockwork/gh-failure-monitor.cjs',
+  'scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js',
+  'scripts/modules/handoff/executors/lead-final-approval/gates.js', // TR-4: HIGH-risk, requires golden-master regression pass
+  'scripts/modules/handoff/executors/lead-final-approval/hooks/ship-review-findings-populator.js',
+  'scripts/one-off/_design-agent-evidence-stage23-reject.cjs',
+]);
+const ALLOWLIST_PREFIXES = ['tests/'];
+
+function toRelPosix(absPath) {
+  return path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+}
+
+function isAllowlisted(relPath) {
+  if (ALLOWLIST_EXACT.has(relPath)) return true;
+  return ALLOWLIST_PREFIXES.some((p) => relPath.startsWith(p));
+}
+
+function collectFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out; // scan root doesn't exist — skip silently (e.g. no tests/ dir in some checkouts)
+  }
+  for (const entry of entries) {
+    if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(full, out);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Statically evaluate a fully-literal `+`-concatenation to a string, or return null. */
+function evalIfFullyLiteral(node) {
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis.map((q) => q.value.cooked ?? '').join('');
+  }
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    const left = evalIfFullyLiteral(node.left);
+    const right = evalIfFullyLiteral(node.right);
+    if (left === null || right === null) return null;
+    return left + right;
+  }
+  return null;
+}
+
+/** Generic recursive AST walk (no acorn-walk dependency — visits every own enumerable node). */
+function walk(node, visit, seen = new Set()) {
+  if (!node || typeof node !== 'object' || seen.has(node)) return;
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item, visit, seen);
+    return;
+  }
+  if (typeof node.type !== 'string') return;
+  seen.add(node);
+  visit(node);
+  for (const key of Object.keys(node)) {
+    if (key === 'loc' || key === 'range' || key === 'start' || key === 'end' || key === 'parent') continue;
+    const value = node[key];
+    if (value && typeof value === 'object') walk(value, visit, seen);
+  }
+}
+
+function scanFile(absPath) {
+  const relPath = toRelPosix(absPath);
+  const findings = [];
+  if (isAllowlisted(relPath)) return findings;
+
+  const source = readFileSync(absPath, 'utf8');
+  let ast;
+  try {
+    ast = acorn.parse(source, { ecmaVersion: 'latest', sourceType: 'module', allowHashBang: true, locations: true });
+  } catch {
+    return findings; // unparsable file (e.g. a non-JS-family .cjs edge case) — not this lint's concern
+  }
+
+  const alreadyFlaggedConcatRoots = new Set();
+
+  walk(ast, (node) => {
+    let value = null;
+    if (node.type === 'Literal' && typeof node.value === 'string') {
+      value = node.value;
+    } else if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+      value = node.quasis.map((q) => q.value.cooked ?? '').join('');
+    } else if (node.type === 'BinaryExpression' && node.operator === '+' && !alreadyFlaggedConcatRoots.has(node)) {
+      value = evalIfFullyLiteral(node);
+      if (value !== null) {
+        // Mark descendants so a nested +-chain doesn't double-report the same literal.
+        walk(node, (n) => alreadyFlaggedConcatRoots.add(n));
+      }
+    }
+    if (value !== null && FORBIDDEN_STRINGS.has(value.toLowerCase())) {
+      findings.push({ file: relPath, line: node.loc?.start?.line ?? '?', value });
+    }
+  });
+
+  return findings;
+}
+
+export function runLint() {
+  const files = SCAN_ROOTS.flatMap((root) => collectFiles(path.join(REPO_ROOT, root)));
+  const findings = files.flatMap(scanFile);
+  return { filesScanned: files.length, findings };
+}
+
+function main() {
+  const { filesScanned, findings } = runLint();
+  console.log(`🔍 lint-repo-resolution-drift: scanned ${filesScanned} files under ${SCAN_ROOTS.join(', ')}/`);
+  if (findings.length === 0) {
+    console.log('✅ No new hardcoded platform-repo literals found outside the allowlist.');
+    process.exit(0);
+  }
+  console.log(`❌ ${findings.length} hardcoded platform-repo literal(s) found outside the allowlist:\n`);
+  for (const f of findings) {
+    console.log(`   ${f.file}:${f.line}  "${f.value}"`);
+  }
+  console.log(
+    '\n   Fix: resolve the repo via lib/repo-paths.js (resolveGitHubRepo/resolveRepoPath) instead of a ' +
+    'literal string, or add a justified allowlist entry to scripts/lint-repo-resolution-drift.mjs if this ' +
+    'really is an intentional anchor (SD-LEO-INFRA-CANONICAL-REPO-APP-001).',
+  );
+  process.exit(1);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (isMain) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`❌ Linter error: ${err.message}`);
+    process.exit(2);
+  }
+}

--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -34,6 +34,7 @@ import 'dotenv/config';
 import { execSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { resolveGitHubRepo } from '../lib/repo-paths.js';
 
 const SAFETY_WINDOW_MINUTES = Number(process.env.ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES || 5);
 const DRY_RUN = process.env.ORPHAN_QF_REAPER_DRY_RUN === 'true';
@@ -48,9 +49,23 @@ function parsePrNumber(prUrl) {
   return match ? Number(match[1]) : null;
 }
 
-function fetchPrState(prNumber) {
+/**
+ * FR-2 (SD-LEO-INFRA-CANONICAL-REPO-APP-001): resolve a QF's target_application to
+ * an explicit `owner/repo` -R argument via the canonical resolver, instead of letting
+ * `gh` fall back to its ambient cwd/config default (which silently queries the wrong
+ * repo for a venture-targeted QF — the QF-726/QF-401 pattern).
+ */
+export function resolveQfGithubRepo(targetApplication) {
+  const repo = resolveGitHubRepo(targetApplication);
+  if (!repo) {
+    throw new Error(`orphan-qf-reaper: unresolvable target_application "${targetApplication}" — refusing to fall back to an ambient default repo`);
+  }
+  return repo;
+}
+
+function fetchPrState(prNumber, repo) {
   try {
-    const raw = execSync(`gh pr view ${prNumber} --json state,mergeCommit,mergedAt`, {
+    const raw = execSync(`gh pr view ${prNumber} --json state,mergeCommit,mergedAt -R ${repo}`, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 15_000,
@@ -66,10 +81,10 @@ export function isValidQfId(id) {
   return typeof id === 'string' && /^QF-\d{8}-\d{3}$/.test(id);
 }
 
-function fetchMergedPrByBranch(branchName) {
+function fetchMergedPrByBranch(branchName, repo) {
   try {
     const raw = execSync(
-      `gh pr list --head "${branchName}" --state merged --json number,url,mergeCommit,mergedAt --limit 1`,
+      `gh pr list --head "${branchName}" --state merged --json number,url,mergeCommit,mergedAt --limit 1 -R ${repo}`,
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15_000 },
     );
     const arr = JSON.parse(raw);
@@ -104,7 +119,7 @@ export async function main() {
 
   const { data: candidates, error: queryError } = await supabase
     .from('quick_fixes')
-    .select('id, status, pr_url, started_at, claiming_session_id')
+    .select('id, status, pr_url, started_at, claiming_session_id, target_application')
     .in('status', ['open', 'in_progress'])
     .not('pr_url', 'is', null)
     .lt('started_at', cutoffIso)
@@ -136,9 +151,18 @@ export async function main() {
       continue;
     }
 
-    const pr = fetchPrState(prNumber);
+    let repo;
+    try {
+      repo = resolveQfGithubRepo(qf.target_application);
+    } catch (err) {
+      log('error_unresolvable_repo', { qf_id: qf.id, target_application: qf.target_application, error: err.message });
+      summary.errored += 1;
+      continue;
+    }
+
+    const pr = fetchPrState(prNumber, repo);
     if (!pr.ok) {
-      log('error_gh_pr_view', { qf_id: qf.id, pr_number: prNumber, error: pr.error });
+      log('error_gh_pr_view', { qf_id: qf.id, pr_number: prNumber, repo, error: pr.error });
       summary.errored += 1;
       continue;
     }
@@ -204,7 +228,7 @@ export async function main() {
   // per QF-20260508-230 retro). Resolve via `qf/<id>` branch convention.
   const { data: orphanCandidates, error: orphanQueryError } = await supabase
     .from('quick_fixes')
-    .select('id, status, started_at, claiming_session_id')
+    .select('id, status, started_at, claiming_session_id, target_application')
     .in('status', ['open', 'in_progress'])
     .is('pr_url', null)
     .not('claiming_session_id', 'is', null)
@@ -221,10 +245,19 @@ export async function main() {
         summary.errored += 1;
         continue;
       }
+      let repo;
+      try {
+        repo = resolveQfGithubRepo(qf.target_application);
+      } catch (err) {
+        log('error_unresolvable_repo_orphan', { qf_id: qf.id, target_application: qf.target_application, error: err.message });
+        summary.errored += 1;
+        continue;
+      }
+
       const branchName = `qf/${qf.id}`;
-      const merged = fetchMergedPrByBranch(branchName);
+      const merged = fetchMergedPrByBranch(branchName, repo);
       if (!merged.ok) {
-        log('error_gh_pr_list_orphan', { qf_id: qf.id, branch: branchName, error: merged.error });
+        log('error_gh_pr_list_orphan', { qf_id: qf.id, branch: branchName, repo, error: merged.error });
         summary.errored += 1;
         continue;
       }

--- a/tests/unit/repo-paths-github-repo-self-reference.test.js
+++ b/tests/unit/repo-paths-github-repo-self-reference.test.js
@@ -1,0 +1,23 @@
+// SD-LEO-INFRA-CANONICAL-REPO-APP-001 (FR-2): direct, non-quarantined coverage for the
+// resolveGitHubRepo() EHG_Engineer self-reference fix. The equivalent assertions in
+// tests/unit/repo-paths.test.js are inert — that whole file is excluded by a pre-existing
+// quarantine entry (tests/quarantine-manifest.json, reason_class=assertion-drift, unrelated
+// to this SD). This file gives the fix direct unit-level regression coverage in addition to
+// the indirect coverage already provided by orphan-qf-reaper-integration.test.js's TS-1/TS-2.
+import { describe, it, expect } from 'vitest';
+import { resolveGitHubRepo } from '../../lib/repo-paths.js';
+
+describe('resolveGitHubRepo() — EHG_Engineer self-reference (FR-2 fix)', () => {
+  it('resolves an explicit EHG_Engineer string to its own repo (not null)', () => {
+    expect(resolveGitHubRepo('EHG_Engineer')).toBe('rickfelix/EHG_Engineer');
+  });
+
+  it('resolves case/separator-insensitively', () => {
+    expect(resolveGitHubRepo('ehg_engineer')).toBe('rickfelix/EHG_Engineer');
+    expect(resolveGitHubRepo('EHGEngineer')).toBe('rickfelix/EHG_Engineer');
+  });
+
+  it('still returns null for a genuinely unknown app (fail-loud contract upstream)', () => {
+    expect(resolveGitHubRepo('TotallyUnknownApp12345')).toBeNull();
+  });
+});

--- a/tests/unit/repo-paths.test.js
+++ b/tests/unit/repo-paths.test.js
@@ -97,6 +97,19 @@ describe('lib/repo-paths', () => {
     it('defaults to EHG_Engineer for null input', () => {
       expect(resolveGitHubRepo(null)).toBe('rickfelix/EHG_Engineer');
     });
+
+    // SD-LEO-INFRA-CANONICAL-REPO-APP-001 (FR-2): EHG_Engineer is never itself a
+    // registry.json entry (it's "this repo"), so resolveGitHubRepo needs an explicit
+    // self-reference branch — without it, an EXPLICIT target_application='EHG_Engineer'
+    // (630/632 of all quick_fixes rows) falsely resolved to null instead of its own repo.
+    it('resolves an explicit EHG_Engineer string to its own repo (not null)', () => {
+      expect(resolveGitHubRepo('EHG_Engineer')).toBe('rickfelix/EHG_Engineer');
+    });
+
+    it('resolves EHG_Engineer case/separator-insensitively', () => {
+      expect(resolveGitHubRepo('ehg_engineer')).toBe('rickfelix/EHG_Engineer');
+      expect(resolveGitHubRepo('EHGEngineer')).toBe('rickfelix/EHG_Engineer');
+    });
   });
 
   describe('isVentureRepo()', () => {

--- a/tests/unit/scripts/lint-repo-resolution-drift.test.js
+++ b/tests/unit/scripts/lint-repo-resolution-drift.test.js
@@ -1,5 +1,5 @@
 // SD-LEO-INFRA-CANONICAL-REPO-APP-001 FR-4 (TS-5, TS-6)
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { writeFileSync, rmSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tests/unit/scripts/lint-repo-resolution-drift.test.js
+++ b/tests/unit/scripts/lint-repo-resolution-drift.test.js
@@ -1,0 +1,53 @@
+// SD-LEO-INFRA-CANONICAL-REPO-APP-001 FR-4 (TS-5, TS-6)
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runLint } from '../../../scripts/lint-repo-resolution-drift.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const FIXTURE_PATH = path.join(REPO_ROOT, 'scripts', '__lint_repo_resolution_drift_fixture__.mjs');
+
+describe('lint-repo-resolution-drift', () => {
+  it('TS-6: passes clean against the current repo state (no false-flags on allowlisted anchors)', () => {
+    const { findings, filesScanned } = runLint();
+    expect(filesScanned).toBeGreaterThan(0);
+    expect(findings).toEqual([]);
+  });
+
+  describe('TS-5: detects a new violation outside the allowlist', () => {
+    afterAll(() => {
+      if (existsSync(FIXTURE_PATH)) rmSync(FIXTURE_PATH);
+    });
+
+    it('flags a literal platform-repo string introduced in a new, non-allowlisted file', () => {
+      writeFileSync(FIXTURE_PATH, "export const OWNER_REPO = 'rickfelix/ehg';\n", 'utf8');
+      const { findings } = runLint();
+      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
+      expect(hit).toBeDefined();
+      expect(hit.value).toBe('rickfelix/ehg');
+    });
+
+    it('flags a fully-literal string concatenation forming the same value', () => {
+      writeFileSync(FIXTURE_PATH, "export const OWNER_REPO = 'rickfelix' + '/' + 'ehg_engineer';\n", 'utf8');
+      const { findings } = runLint();
+      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
+      expect(hit).toBeDefined();
+      expect(hit.value).toBe('rickfelix/ehg_engineer');
+    });
+
+    it('does NOT flag a dynamic (non-literal) concatenation — value is not statically known', () => {
+      writeFileSync(FIXTURE_PATH, "export function buildRepo(name) { return 'rickfelix/' + name; }\n", 'utf8');
+      const { findings } = runLint();
+      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
+      expect(hit).toBeUndefined();
+    });
+  });
+
+  it('does not flag literal platform-repo strings inside tests/** (allowlisted for fixtures/mocks)', () => {
+    const { findings } = runLint();
+    expect(findings.find((f) => f.file.startsWith('tests/'))).toBeUndefined();
+  });
+});

--- a/tests/unit/scripts/orphan-qf-reaper-integration.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-integration.test.js
@@ -314,8 +314,8 @@ describe('FR-5: malformed qf.id rejection (shell-injection defense)', () => {
 });
 
 describe('FR-6: execSync argv shape regex pin', () => {
-  const PR_VIEW_RE = /^gh pr view \d+ --json state,mergeCommit,mergedAt$/;
-  const PR_LIST_RE = /^gh pr list --head "qf\/QF-\d{8}-\d{3}" --state merged --json number,url,mergeCommit,mergedAt --limit 1$/;
+  const PR_VIEW_RE = /^gh pr view \d+ --json state,mergeCommit,mergedAt -R [\w.-]+\/[\w.-]+$/;
+  const PR_LIST_RE = /^gh pr list --head "qf\/QF-\d{8}-\d{3}" --state merged --json number,url,mergeCommit,mergedAt --limit 1 -R [\w.-]+\/[\w.-]+$/;
 
   it('pr_url path invokes gh pr view with exact argv shape', async () => {
     supabaseInstance = makeSupabaseMock({
@@ -367,5 +367,108 @@ describe('FR-6: execSync argv shape regex pin', () => {
       .find(c => typeof c === 'string' && c.startsWith('gh pr list'));
     expect(ghListCmd).toBeDefined();
     expect(ghListCmd).toMatch(PR_LIST_RE);
+  });
+});
+
+// SD-LEO-INFRA-CANONICAL-REPO-APP-001 FR-2 (TS-1, TS-2): both gh calls must be
+// explicitly repo-scoped via the canonical resolver, for BOTH an EHG_Engineer QF
+// and a venture-repo QF — proving the fix generalizes beyond the historical
+// two-repo happy path (the exact QF-726/QF-401 pattern this SD exists to kill).
+describe('FR-2 (SD-LEO-INFRA-CANONICAL-REPO-APP-001): -R repo scoping via canonical resolver', () => {
+  it('TS-1: pr_url path scopes -R to rickfelix/EHG_Engineer for an EHG_Engineer-targeted QF', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260704-101', status: 'open', pr_url: 'https://github.com/rickfelix/EHG_Engineer/pull/5000', started_at: '2026-07-04T00:00:00Z', target_application: 'EHG_Engineer' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view')) return JSON.stringify({ state: 'OPEN' });
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghViewCmd = execSyncMock.mock.calls.map(c => c[0]).find(c => typeof c === 'string' && c.startsWith('gh pr view'));
+    expect(ghViewCmd).toBeDefined();
+    expect(ghViewCmd).toContain('-R rickfelix/EHG_Engineer');
+  });
+
+  it('TS-2: pr_url path scopes -R to rickfelix/marketlens for a venture-targeted QF (generalizes beyond the two-repo world)', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260704-102', status: 'open', pr_url: 'https://github.com/rickfelix/marketlens/pull/14', started_at: '2026-07-04T00:00:00Z', target_application: 'MarketLens' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr view')) return JSON.stringify({ state: 'OPEN' });
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghViewCmd = execSyncMock.mock.calls.map(c => c[0]).find(c => typeof c === 'string' && c.startsWith('gh pr view'));
+    expect(ghViewCmd).toBeDefined();
+    expect(ghViewCmd).toContain('-R rickfelix/marketlens');
+  });
+
+  it('branch-derived path scopes -R to the venture repo for a venture-targeted orphan QF', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [],
+      secondQuery: [{ id: 'QF-20260704-103', status: 'open', started_at: '2026-07-04T00:00:00Z', claiming_session_id: 'sess', target_application: 'MarketLens' }],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      if (cmd.startsWith('gh pr list')) return '[]';
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghListCmd = execSyncMock.mock.calls.map(c => c[0]).find(c => typeof c === 'string' && c.startsWith('gh pr list'));
+    expect(ghListCmd).toBeDefined();
+    expect(ghListCmd).toContain('-R rickfelix/marketlens');
+  });
+
+  it('an unresolvable target_application errors the row instead of falling back to an ambient default', async () => {
+    supabaseInstance = makeSupabaseMock({
+      firstQuery: [{ id: 'QF-20260704-104', status: 'open', pr_url: 'https://github.com/x/y/pull/1', started_at: '2026-07-04T00:00:00Z', target_application: 'TotallyUnknownApp12345' }],
+      secondQuery: [],
+    });
+    execSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh auth status') return '';
+      // If main() reaches gh pr view despite an unresolvable target_application, the fail-loud contract is broken.
+      if (cmd.startsWith('gh pr view')) throw new Error('Reached gh with an unresolvable target_application — TR-2 fail-loud broken');
+      return '{}';
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    try {
+      const { main } = await importMain();
+      await main();
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const ghViewCalls = execSyncMock.mock.calls.filter(c => typeof c[0] === 'string' && c[0].startsWith('gh pr view'));
+    expect(ghViewCalls.length).toBe(0);
+    expect(supabaseInstance._calls.updateCalls.length).toBe(0);
   });
 });

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -16,6 +16,7 @@ import {
   verifyMerged,
   verifyBranchDeleted,
   isPlatformRepo,
+  createRegistryNarrowedTrustGate,
 } from '../../../lib/ship/auto-merge.mjs';
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
@@ -643,6 +644,63 @@ describe('isPlatformRepo (C2 trust allowlist)', () => {
     expect(isPlatformRepo('someorg', 'someventure')).toBe(false);
     expect(isPlatformRepo(null, 'ehg')).toBe(false);
     expect(isPlatformRepo('rickfelix', undefined)).toBe(false);
+  });
+});
+
+// SD-LEO-INFRA-CANONICAL-REPO-APP-001 FR-3 (TS-3, TS-4): AND-composed registry
+// narrowing gate. Must NEVER widen past the isPlatformRepo floor, even under a
+// mis-tagged registry row — this is not hypothetical: the LIVE applications
+// table tags MarketLens (an external venture repo) trust_tier='trusted', which
+// is exactly the shape of row that must never grant auto-merge eligibility.
+describe('createRegistryNarrowedTrustGate (FR-3: AND-composed, never-widen trust gate)', () => {
+  function makeSupabase(rows) {
+    return {
+      from: () => ({
+        select: () => ({
+          not: () => Promise.resolve({ data: rows, error: null }),
+        }),
+      }),
+    };
+  }
+
+  it('TS-3: a mis-tagged venture repo (trust_tier=platform/trusted) STILL fails closed — floor is non-negotiable', async () => {
+    const supabase = makeSupabase([
+      { github_repo: 'rickfelix/marketlens', trust_tier: 'trusted' },
+      { github_repo: 'rickfelix/commitcraft-ai', trust_tier: 'platform' }, // hypothetical mis-tag
+    ]);
+    const gate = createRegistryNarrowedTrustGate(supabase);
+    expect(await gate('rickfelix', 'marketlens')).toBe(false);
+    expect(await gate('rickfelix', 'commitcraft-ai')).toBe(false);
+  });
+
+  it('TS-4: rickfelix/ehg and rickfelix/EHG_Engineer remain eligible when registry confirms trust_tier=platform (no regression)', async () => {
+    const supabase = makeSupabase([
+      { github_repo: 'rickfelix/ehg.git', trust_tier: 'platform' },
+      { github_repo: 'rickfelix/EHG_Engineer.git', trust_tier: 'platform' },
+    ]);
+    const gate = createRegistryNarrowedTrustGate(supabase);
+    expect(await gate('rickfelix', 'ehg')).toBe(true);
+    expect(await gate('rickfelix', 'EHG_Engineer')).toBe(true);
+  });
+
+  it('narrows a floor-eligible repo whose registry trust_tier has been revoked away from platform', async () => {
+    const supabase = makeSupabase([
+      { github_repo: 'rickfelix/ehg.git', trust_tier: 'suspended' },
+    ]);
+    const gate = createRegistryNarrowedTrustGate(supabase);
+    expect(await gate('rickfelix', 'ehg')).toBe(false);
+  });
+
+  it('falls back to the floor alone when no registry row matches, on DB error, or when no supabase client is supplied', async () => {
+    const noMatch = createRegistryNarrowedTrustGate(makeSupabase([{ github_repo: 'rickfelix/marketlens', trust_tier: 'trusted' }]));
+    expect(await noMatch('rickfelix', 'ehg')).toBe(true); // floor-eligible, no matching row — floor stands
+
+    const dbError = createRegistryNarrowedTrustGate({ from: () => ({ select: () => ({ not: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) });
+    expect(await dbError('rickfelix', 'ehg')).toBe(true);
+
+    const noSupabase = createRegistryNarrowedTrustGate(null);
+    expect(await noSupabase('rickfelix', 'ehg')).toBe(true);
+    expect(await noSupabase('rickfelix', 'marketlens')).toBe(false); // floor still applies with no registry at all
   });
 });
 


### PR DESCRIPTION
## Summary

Coordinator-requested class-kill sweep: 5 hardcoded-two-repo bugs hit in 24 hours, all assuming the codebase only ever has {EHG, EHG_Engineer} instead of going through the canonical `lib/repo-paths.js` resolver. This PR scopes the tractable critical-path slice.

- **FR-1**: `docs/architecture/canonical-repo-resolution-census.md` — file:line → disposition table for every site found (swept / deliberately-exempt / deferred-with-owner), no silent caps.
- **FR-2**: `scripts/orphan-qf-reaper.mjs`'s two `gh pr` calls now pass explicit `-R <repo>` resolved via `lib/repo-paths.js`'s `resolveGitHubRepo()`. Also fixes a real pre-existing gap in `resolveGitHubRepo()` itself (missing `EHG_Engineer` self-reference — 630/632 real `quick_fixes` rows carry that exact `target_application` value).
- **FR-3**: `lib/ship/auto-merge.mjs` gains an opt-in, AND-composed trust gate (`createRegistryNarrowedTrustGate`) — the existing fail-closed floor (`isPlatformRepo`) is unchanged and non-negotiable; a registry check can only narrow, never widen. Validated against a live mis-tagged row (MarketLens is tagged `trust_tier='trusted'` in production, not `external`).
- **FR-4**: `scripts/lint-repo-resolution-drift.mjs` — new AST-scoped (acorn) regression lint + `npm run lint:repo-resolution-drift`, catching new hardcoded platform-repo literals outside a documented allowlist.

Full LEO workflow: LEAD → LEAD-TO-PLAN (93%) → PLAN-TO-EXEC (94%) → EXEC-TO-PLAN (93%) → PLAN_VERIFICATION (VALIDATION + REGRESSION both PASS, 90% confidence) → PLAN-TO-LEAD (96%).

## Test plan

- [x] `tests/unit/scripts/orphan-qf-reaper-integration.test.js` — FR-2 `-R` scoping (EHG_Engineer + venture repo), TR-2 fail-loud on unresolvable target
- [x] `tests/unit/ship/auto-merge.test.js` — FR-3 AND-composed gate (fail-closed under mis-tagged registry, no regression to platform happy path)
- [x] `tests/unit/scripts/lint-repo-resolution-drift.test.js` — FR-4 detection (literal + literal-concat), no false-flag on dynamic concat or allowlisted anchors
- [x] `tests/unit/repo-paths-github-repo-self-reference.test.js` — direct coverage of the `resolveGitHubRepo` fix
- [x] `node scripts/lint-repo-resolution-drift.mjs` passes clean against current repo state
- [x] REGRESSION sub-agent confirmed 0 deletion lines in `auto-merge.mjs` diff (purely additive), existing callers of `resolveGitHubRepo` checked for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)