### PR TITLE
fix(QF-20260704-717): leo-create-sd's silent min_tier_rank default is unclaimable-by-construction

### DIFF
--- a/lib/fleet/sd-tier-rank.mjs
+++ b/lib/fleet/sd-tier-rank.mjs
@@ -11,7 +11,18 @@
 import { matchesKeyword, CLASSIFICATION_RULES } from '../../scripts/classify-quick-fix.js';
 import ladder from './tier-ladder.cjs';
 
-const { clamp, ladderTopRank } = ladder;
+const { clamp, ladderTopRank, LADDER } = ladder;
+
+// QF-20260704-717: the fleet-claimable baseline (the ladder's opus/low rung), read directly
+// from tier-ladder.cjs's own static LADDER definition rather than a hand-rolled "2" literal
+// (NOT rankForModelEffort(), which computes a different, larger theoretical model x effort
+// lattice rank — the LADDER array is the actual 4-rung ladder this module's callers reason
+// about). Used by stampPayloadForCreation()'s NO-SIGNAL branch instead of the fail-safe-up top
+// rung — a brand-new SD with genuinely no scoreable signal (the common leo-create-sd.js
+// --from-plan shape) must default to claimable-by-construction, or it strands invisible at the
+// fleet's actual active tier until a human manually re-stamps it (2 occurrences, coordinator-flagged).
+const OPUS_LOW_RUNG = LADDER.find((rung) => rung.model === 'opus' && rung.effort === 'low');
+export const FLEET_CLAIMABLE_BASELINE_RANK = OPUS_LOW_RUNG ? OPUS_LOW_RUNG.rank : 2;
 
 // LOC tiers mirror lib/utils/work-item-router.js DEFAULT_THRESHOLDS (kept in sync by intent;
 // the rubric is a heuristic so the default values are referenced rather than DB-fetched).
@@ -59,16 +70,15 @@ function locRank(loc) {
 }
 
 /**
- * Compute metadata.min_tier_rank — the cheapest rung that can sufficiently build this SD.
- * Takes the MAX of every available contribution (conservative-up). No scoreable signal
- * (no type, no LOC, no tier_hint, no keyword) => top rung (fail-safe-up).
- * @param {object} sd a strategic_directives_v2-shaped row
- * @returns {number} a rank in [1, ladderTopRank()]
+ * Score every available signal on an SD row. Shared by computeMinTierRank() (fail-safe-up
+ * philosophy) and stampPayloadForCreation() (claimable-by-construction philosophy) so both
+ * agree on what counts as "a real signal" from a single source of truth.
+ * @param {object} row a strategic_directives_v2-shaped row
+ * @returns {{ riskFloor: boolean, contributions: number[] }}
  */
-export function computeMinTierRank(sd) {
-  const row = sd || {};
+function scoreContributions(row) {
   const text = textOf(row);
-  if (text && hasRiskKeyword(text)) return ladderTopRank(); // floor: risk/forbidden keyword
+  if (text && hasRiskKeyword(text)) return { riskFloor: true, contributions: [] };
 
   const contributions = [];
   const sdType = String(row.sd_type || '').toLowerCase();
@@ -84,7 +94,19 @@ export function computeMinTierRank(sd) {
     // work-item tier (1/2/3) -> conservative rung mapping.
     contributions.push(hint <= 1 ? 1 : hint === 2 ? midRank() : ladderTopRank());
   }
+  return { riskFloor: false, contributions };
+}
 
+/**
+ * Compute metadata.min_tier_rank — the cheapest rung that can sufficiently build this SD.
+ * Takes the MAX of every available contribution (conservative-up). No scoreable signal
+ * (no type, no LOC, no tier_hint, no keyword) => top rung (fail-safe-up).
+ * @param {object} sd a strategic_directives_v2-shaped row
+ * @returns {number} a rank in [1, ladderTopRank()]
+ */
+export function computeMinTierRank(sd) {
+  const { riskFloor, contributions } = scoreContributions(sd || {});
+  if (riskFloor) return ladderTopRank(); // floor: risk/forbidden keyword
   if (contributions.length === 0) return ladderTopRank(); // no scoreable signal -> fail-safe-up
   return clamp(Math.max(...contributions));
 }
@@ -94,4 +116,32 @@ export function stampPayload(sd) {
   return { min_tier_rank: computeMinTierRank(sd) };
 }
 
-export default { computeMinTierRank, stampPayload };
+/**
+ * Creation-time stamp helper (QF-20260704-717). Unlike stampPayload()'s general complexity
+ * rubric (fail-safe-up protects a build already assigned to a worker), a BRAND-NEW SD with
+ * genuinely no scoreable signal -- the common leo-create-sd.js --from-plan shape -- must
+ * default to CLAIMABLE-BY-CONSTRUCTION, or it strands invisible at the fleet's actual active
+ * tier until a human manually re-stamps it. An explicit override always wins (requires a
+ * recorded reason -- throws loudly without one); absent that, a no-signal SD gets the
+ * fleet-claimable baseline instead of the ladder top, while any SD with a REAL signal (risk
+ * keyword / sd_type / LOC / tier_hint) still gets its accurately-computed rank untouched.
+ * @param {object} sd a strategic_directives_v2-shaped row
+ * @param {{ explicitRank?: number, explicitReason?: string }} [opts]
+ * @returns {{ min_tier_rank: number, min_tier_rank_reason?: string }}
+ */
+export function stampPayloadForCreation(sd, opts = {}) {
+  if (opts.explicitRank != null) {
+    const reason = opts.explicitReason && String(opts.explicitReason).trim();
+    if (!reason) {
+      throw new Error('min_tier_rank explicit override requires a recorded reason (--min-tier-rank-reason)');
+    }
+    return { min_tier_rank: clamp(opts.explicitRank), min_tier_rank_reason: reason };
+  }
+
+  const { riskFloor, contributions } = scoreContributions(sd || {});
+  if (riskFloor) return { min_tier_rank: ladderTopRank() }; // real signal -> untouched
+  if (contributions.length === 0) return { min_tier_rank: Math.min(FLEET_CLAIMABLE_BASELINE_RANK, ladderTopRank()) }; // no signal -> claimable baseline
+  return { min_tier_rank: clamp(Math.max(...contributions)) }; // real signal -> untouched
+}
+
+export default { computeMinTierRank, stampPayload, stampPayloadForCreation, FLEET_CLAIMABLE_BASELINE_RANK };

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2062,12 +2062,23 @@ async function createSD(options) {
   // depending on the out-of-band stamp-sd-tier-rank.mjs — and when that stamper broke (estimated_loc
   // phantom column), the whole fleet starved on "unclaimable" unstamped work. GAP-FILL only: never
   // overwrite an Adam-sourced / child-inherited finite rank. Non-fatal (mirrors the FR derivation guard).
+  //
+  // QF-20260704-717: --min-tier-rank/--min-tier-rank-reason let a caller EXPLICITLY set a higher
+  // floor with a recorded reason (throws loudly if the reason is missing); absent that, the
+  // no-signal case (the common --from-plan shape) stamps the fleet-claimable baseline instead of
+  // the fail-safe-up ladder top, so a signal-less SD is never stranded unclaimable-by-construction.
   try {
     if (!Number.isFinite(Number(sdData.metadata?.min_tier_rank))) {
-      const { stampPayload } = await import('../lib/fleet/sd-tier-rank.mjs');
-      sdData.metadata = { ...sdData.metadata, ...stampPayload(sdData) };
+      const cliArgs = process.argv.slice(2);
+      const explicitRankIdx = cliArgs.indexOf('--min-tier-rank');
+      const explicitReasonIdx = cliArgs.indexOf('--min-tier-rank-reason');
+      const explicitRank = explicitRankIdx !== -1 ? Number(cliArgs[explicitRankIdx + 1]) : null;
+      const explicitReason = explicitReasonIdx !== -1 ? cliArgs[explicitReasonIdx + 1] : null;
+      const { stampPayloadForCreation } = await import('../lib/fleet/sd-tier-rank.mjs');
+      sdData.metadata = { ...sdData.metadata, ...stampPayloadForCreation(sdData, { explicitRank, explicitReason }) };
     }
   } catch (tierErr) {
+    if (tierErr.message?.includes('explicit override requires a recorded reason')) throw tierErr; // loud, per QF-20260704-717 acceptance criterion 3
     console.warn(`   ⚠️  min_tier_rank stamp skipped (non-blocking): ${tierErr.message}`);
   }
 
@@ -2826,6 +2837,11 @@ Flags:
                         Valid values: EHG, EHG_Engineer (case-insensitive; normalized).
                         When set, PR_MERGE_VERIFICATION at LEAD-FINAL scopes its scan
                         to ONLY these repos. Required for SDs spanning both platform repos.
+  --min-tier-rank <N>   Explicitly set metadata.min_tier_rank (requires --min-tier-rank-reason;
+                        throws without one). Absent this flag, a signal-less SD (the common
+                        --from-plan shape) stamps the fleet-claimable baseline instead of the
+                        fail-safe-up ladder top, so it is never stranded unclaimable-by-construction.
+  --min-tier-rank-reason "<text>"  Required companion to --min-tier-rank; recorded verbatim.
                         Example: --target-repos EHG,EHG_Engineer
                         Pairs with computeReposForSD() at lead-final-approval/gates.js
                         (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in: direct LEO,

--- a/tests/unit/fleet/tier-rank-claimable-by-construction.test.js
+++ b/tests/unit/fleet/tier-rank-claimable-by-construction.test.js
@@ -1,0 +1,64 @@
+/**
+ * QF-20260704-717 (2nd occurrence): leo-create-sd.js stamps unclaimable-by-construction
+ * metadata.min_tier_rank=4 as a silent default for signal-less (--from-plan) SDs, stranding
+ * them ~30min until a human manually re-stamps. computeMinTierRank()'s fail-safe-up philosophy
+ * is correct for its OTHER callers, so the fix is a separate creation-time helper,
+ * stampPayloadForCreation(), not a change to computeMinTierRank() itself.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeMinTierRank, stampPayloadForCreation, FLEET_CLAIMABLE_BASELINE_RANK } from '../../../lib/fleet/sd-tier-rank.mjs';
+
+describe('FLEET_CLAIMABLE_BASELINE_RANK', () => {
+  it('is derived from the ladder (opus/low = rank 2), not a hand-rolled literal', () => {
+    expect(FLEET_CLAIMABLE_BASELINE_RANK).toBe(2);
+  });
+});
+
+describe('stampPayloadForCreation — no explicit override', () => {
+  it('acceptance (1): a signal-less --from-plan-shaped SD stamps the claimable baseline, not the ladder top', () => {
+    const fromPlanSd = { sd_key: 'SD-X-001', metadata: { source: 'plan', plan_content: '# Some Plan\n...' } };
+    expect(computeMinTierRank(fromPlanSd)).toBeGreaterThan(FLEET_CLAIMABLE_BASELINE_RANK); // old behavior: fail-safe-up (4)
+    expect(stampPayloadForCreation(fromPlanSd)).toEqual({ min_tier_rank: FLEET_CLAIMABLE_BASELINE_RANK });
+  });
+
+  it('a real risk-keyword signal is respected untouched (not silently downgraded to baseline)', () => {
+    const riskySd = { sd_key: 'SD-RISK-001', title: 'Add payments authentication', metadata: {} };
+    const computed = computeMinTierRank(riskySd);
+    expect(stampPayloadForCreation(riskySd)).toEqual({ min_tier_rank: computed });
+    expect(computed).toBeGreaterThan(FLEET_CLAIMABLE_BASELINE_RANK);
+  });
+
+  it('a real sd_type=feature signal is respected untouched', () => {
+    const featureSd = { sd_key: 'SD-FEAT-001', sd_type: 'feature', metadata: {} };
+    expect(stampPayloadForCreation(featureSd)).toEqual({ min_tier_rank: computeMinTierRank(featureSd) });
+  });
+
+  it('a real LOC signal is respected untouched', () => {
+    const locSd = { sd_key: 'SD-LOC-001', metadata: { estimated_loc: 200 } };
+    expect(stampPayloadForCreation(locSd)).toEqual({ min_tier_rank: computeMinTierRank(locSd) });
+  });
+});
+
+describe('stampPayloadForCreation — explicit override', () => {
+  it('acceptance (2): explicit rank + reason stamps that rank with the reason recorded', () => {
+    const sd = { sd_key: 'SD-EXPLICIT-001', metadata: {} };
+    expect(stampPayloadForCreation(sd, { explicitRank: 4, explicitReason: 'known architectural complexity, per Adam triage' }))
+      .toEqual({ min_tier_rank: 4, min_tier_rank_reason: 'known architectural complexity, per Adam triage' });
+  });
+
+  it('acceptance (3): explicit rank WITHOUT a reason throws loudly', () => {
+    const sd = { sd_key: 'SD-NOREASON-001', metadata: {} };
+    expect(() => stampPayloadForCreation(sd, { explicitRank: 4 })).toThrow(/requires a recorded reason/);
+  });
+
+  it('explicit rank with an empty/whitespace-only reason also throws', () => {
+    const sd = { sd_key: 'SD-BLANKREASON-001', metadata: {} };
+    expect(() => stampPayloadForCreation(sd, { explicitRank: 4, explicitReason: '   ' })).toThrow(/requires a recorded reason/);
+  });
+
+  it('an explicit override wins even when a real signal is also present', () => {
+    const sd = { sd_key: 'SD-OVERRIDE-001', sd_type: 'feature', metadata: {} };
+    expect(stampPayloadForCreation(sd, { explicitRank: 1, explicitReason: 'trivial despite the type' }))
+      .toEqual({ min_tier_rank: 1, min_tier_rank_reason: 'trivial despite the type' });
+  });
+});


### PR DESCRIPTION
## Summary

Coordinator-flagged systemic issue (2nd occurrence, advisory 3d2fb09b): SDs created via `leo-create-sd.js --from-plan` get `metadata.min_tier_rank=4` as a silent default (the ladder's fail-safe-up top rung), which is unclaimable-by-construction at the fleet's actual active tier — the entire 6-SD morning wave sat claim-invisible ~30min until the coordinator hand-re-stamped it.

- Adds `stampPayloadForCreation()` in `lib/fleet/sd-tier-rank.mjs` — a creation-time-specific helper (does NOT change `computeMinTierRank()`'s own fail-safe-up behavior, which other callers may legitimately need):
  - No explicit override + no scoreable signal → stamps the fleet-claimable baseline (the ladder's opus/low rung, read from `tier-ladder.cjs`'s own `LADDER` definition), not the ladder top.
  - No explicit override + a REAL signal (risk keyword / `sd_type` / LOC / `tier_hint`) → untouched, same as before.
  - Explicit `--min-tier-rank <N> --min-tier-rank-reason "<text>"` → stamps N with the reason recorded.
  - Explicit `--min-tier-rank <N>` with no reason → throws loudly.
- `leo-create-sd.js`'s existing creation-time stamp block now parses the two new flags and calls `stampPayloadForCreation()` instead of `stampPayload()`.

## Test plan
- [x] 9 new tests covering all 3 acceptance directions (no-signal→baseline, explicit+reason, explicit-without-reason→throw), plus real-signal-untouched cases.
- [x] Full `tests/unit/fleet/` suite (251 tests) passes — `computeMinTierRank()`'s existing behavior is unchanged (refactored to share signal-detection logic, not altered).
- [x] All 12 existing `leo-create-sd*` test files (147 tests) pass — no regression.
- [x] Direct smoke test of the 3 CLI scenarios (no flags / explicit+reason / explicit-without-reason) confirms correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)