### PR TITLE
feat(SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001): close the LEAD_FINAL strand relay

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CANONICAL-REPO-APP-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-CANONICAL-REPO-APP-001",
-  "createdAt": "2026-07-04T13:29:21.988Z",
+  "sdKey": "SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001",
+  "createdAt": "2026-07-04T16:25:32.385Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/commands/claim-command.js
+++ b/lib/commands/claim-command.js
@@ -151,6 +151,33 @@ export async function releaseClaim(sessionId) {
     console.log('Proceeding with release anyway (operator override)...');
   }
 
+  // SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-3): soft, fail-open warning when releasing a
+  // claim on an SD one handoff from shipped. NEVER blocks — per risk-agent, most LEAD_FINAL
+  // claim-clearing is AUTOMATIC (compaction_auto_reclaim, self-heal stale/dead detection, TTL
+  // sweep), so a hard block anywhere in that automatic path would leave a dead session's claim
+  // permanently stuck — a worse deadlock than the strand this SD exists to fix. Scoped to this
+  // MANUAL release path only; never touches the automatic reclaim code.
+  try {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, status, current_phase')
+      .eq('sd_key', session.sd_key)
+      .maybeSingle();
+    if (sd && sd.status === 'pending_approval' && sd.current_phase === 'LEAD_FINAL') {
+      const { data: finalHandoffs } = await supabase
+        .from('sd_phase_handoffs')
+        .select('id')
+        .eq('sd_id', sd.id)
+        .eq('handoff_type', 'LEAD-FINAL-APPROVAL')
+        .limit(1);
+      if (!finalHandoffs || finalHandoffs.length === 0) {
+        console.log(`⚠️  WARNING: ${session.sd_key} is one handoff from shipped (pending_approval/LEAD_FINAL) — releasing now strands it again.`);
+        console.log('   Run LEAD-FINAL-APPROVAL first unless you have a specific reason not to:');
+        console.log(`   node scripts/handoff.js execute LEAD-FINAL-APPROVAL ${session.sd_key}`);
+      }
+    }
+  } catch { /* fail-open: this warning must never block a release */ }
+
   // Call release_sd RPC
   const { error: releaseError } = await supabase.rpc('release_sd', {
     p_session_id: sessionId,

--- a/lib/coordinator/strand-age-gauge.cjs
+++ b/lib/coordinator/strand-age-gauge.cjs
@@ -1,0 +1,106 @@
+/**
+ * Strand-age gauge: pending_approval/LEAD_FINAL age, visible on the fleet dashboard.
+ *
+ * SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2).
+ *
+ * An SD stuck at status=pending_approval/current_phase=LEAD_FINAL is one handoff
+ * from shipped, but invisible to monitoring until this gauge — the coordinator
+ * found the MarketLens specimen (4 successive holders, 2.5+ hours) by hand. Mirrors
+ * the pure-core + read-only SHAPE of lib/coordinator/relay-drop-gauge.cjs. Age is
+ * computed from `updated_at`; when that looks unreliable (older than the row's own
+ * `created_at`, i.e. never touched, or simply absent) falls back to the SD's latest
+ * `sd_phase_handoffs.resolved_at` — a live handoff row is a more trustworthy "last
+ * touched" signal than a trigger-dependent `updated_at` column.
+ *
+ * CommonJS (.cjs) so fleet-dashboard.cjs (also .cjs) can require() it directly.
+ *
+ * @module lib/coordinator/strand-age-gauge
+ */
+
+'use strict';
+
+/** Default strand-visibility threshold: comfortably above recoverStrandedFinal's 5-min STRANDED_MIN_AGE_MS. */
+const DEFAULT_THRESHOLD_MS = 10 * 60 * 1000;
+
+function resolveThresholdMs(env) {
+  env = env || process.env;
+  const min = Number(env.STRAND_AGE_GAUGE_THRESHOLD_MIN);
+  return Number.isFinite(min) && min > 0 ? min * 60 * 1000 : DEFAULT_THRESHOLD_MS;
+}
+
+function tsMs(ts) {
+  if (!ts) return null;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Read-only: query pending_approval/LEAD_FINAL SDs and flag any older than the
+ * threshold. Never mutates strategic_directives_v2 or claiming_session_id.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ thresholdMs?: number, nowMs?: number }} [opts]
+ * @returns {Promise<{ thresholdMs: number, rows: Array<{sd_key: string, ageMs: number, ageSource: string}>, flagged: Array }>}
+ */
+async function planStrandAgeGauge(supabase, opts = {}) {
+  const thresholdMs = opts.thresholdMs ?? resolveThresholdMs();
+  const nowMs = opts.nowMs ?? Date.now();
+
+  const { data: candidates, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, id, updated_at, created_at')
+    .eq('status', 'pending_approval')
+    .eq('current_phase', 'LEAD_FINAL');
+
+  if (error || !Array.isArray(candidates) || candidates.length === 0) {
+    return { thresholdMs, rows: [], flagged: [] };
+  }
+
+  const rows = [];
+  for (const sd of candidates) {
+    let ageMs = null;
+    let ageSource = 'updated_at';
+    const updatedMs = tsMs(sd.updated_at);
+    const createdMs = tsMs(sd.created_at);
+
+    // updated_at looks unreliable when it's missing or predates created_at (never touched).
+    const updatedLooksReliable = updatedMs !== null && (createdMs === null || updatedMs >= createdMs);
+
+    if (updatedLooksReliable) {
+      ageMs = nowMs - updatedMs;
+    } else {
+      // Fall back to the latest handoff's resolved_at for this SD.
+      const { data: handoffs } = await supabase
+        .from('sd_phase_handoffs')
+        .select('resolved_at')
+        .eq('sd_id', sd.id)
+        .order('resolved_at', { ascending: false })
+        .limit(1);
+      const handoffMs = tsMs(handoffs?.[0]?.resolved_at);
+      if (handoffMs !== null) {
+        ageMs = nowMs - handoffMs;
+        ageSource = 'latest_handoff_resolved_at';
+      } else if (createdMs !== null) {
+        ageMs = nowMs - createdMs;
+        ageSource = 'created_at';
+      }
+    }
+
+    if (ageMs !== null) {
+      rows.push({ sd_key: sd.sd_key, ageMs, ageSource });
+    }
+  }
+
+  const flagged = rows.filter((r) => r.ageMs >= thresholdMs).sort((a, b) => b.ageMs - a.ageMs);
+  return { thresholdMs, rows, flagged };
+}
+
+function formatAge(ageMs) {
+  const min = Math.floor(ageMs / 60_000);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return `${hr}h${remMin ? `${remMin}m` : ''}`;
+}
+
+module.exports = { planStrandAgeGauge, resolveThresholdMs, formatAge, DEFAULT_THRESHOLD_MS };

--- a/lib/coordinator/strand-age-gauge.cjs
+++ b/lib/coordinator/strand-age-gauge.cjs
@@ -1,4 +1,10 @@
 /**
+ * @wire-check-exempt: loaded via a lazy require() inside scripts/fleet-dashboard.cjs's
+ * printStrandAgeGauge() — mirrors this file's sibling gauge modules (relay-drop-gauge.cjs,
+ * chairman-directive-gauge.cjs), none of which are traced as reachable either because
+ * fleet-dashboard.cjs itself has no package.json script entry point (pre-existing gap,
+ * out of this SD's scope).
+ *
  * Strand-age gauge: pending_approval/LEAD_FINAL age, visible on the fleet dashboard.
  *
  * SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2).

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1638,6 +1638,37 @@ async function printChairmanEmailChannelHealth() {
   console.log('');
 }
 
+// SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 / FR-2: surface SDs stranded at
+// pending_approval/LEAD_FINAL — one handoff from shipped but invisible to monitoring
+// without this gauge. Read-only + fail-open (planStrandAgeGauge never throws).
+async function printStrandAgeGauge() {
+  const { planStrandAgeGauge, formatAge } = require('../lib/coordinator/strand-age-gauge.cjs');
+
+  console.log('LEAD_FINAL STRAND-AGE GAUGE');
+  console.log('─'.repeat(72));
+
+  let gauge;
+  try {
+    gauge = await planStrandAgeGauge(supabase);
+  } catch {
+    console.log('  (gauge unavailable — non-fatal)');
+    console.log('');
+    return;
+  }
+
+  if (gauge.flagged.length === 0) {
+    console.log('  (no SD stranded at pending_approval/LEAD_FINAL past the threshold)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + gauge.flagged.length + ' SD(s) stranded at pending_approval/LEAD_FINAL:');
+  for (const r of gauge.flagged) {
+    console.log('  • ' + r.sd_key + ' — stranded ' + formatAge(r.ageMs) + ' (age source: ' + r.ageSource + ')');
+  }
+  console.log('');
+}
+
 // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3: surface the
 // relay/decision/review drop gauge — mirrors printUndeliveredOutbound()'s shape. Read-only
 // + fail-open (planRelayDrops never throws).
@@ -1834,6 +1865,7 @@ async function main() {
     forecast:      async () => await printForecast(d),
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
+    strand:        async () => await printStrandAgeGauge(), // SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2)
     inbox:         async () => {
       // FR-1 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B): chairman directives surface FIRST —
       // bypasses the printInbox signal_type gate (chairman_directive carries no signal_type).
@@ -1863,6 +1895,7 @@ async function main() {
       printOrchestrator(d);
       printAvailable(d);
       printQuickFixes(d); // QF-20260525-836
+      await printStrandAgeGauge(); // SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2)
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printChairmanDirectives(); // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 — chairman-directive compliance FIRST (bypasses the printInbox signal_type gate)

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -2016,7 +2016,41 @@ async function main() {
   // 8. Show next action
   const nextHandoff = await getNextHandoff(sd);
 
-  if (needsBrainstorm && sd.status === 'draft') {
+  // SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-1): close the strand relay. Printing the
+  // next-action command as a suggestion has failed 3x for the pending_approval/LEAD_FINAL
+  // strand class (a worker adopts a stranded SD, then idles/TTL-releases without ever
+  // running the final handoff). This is the ONLY seam where claim-ownership + worktree-cwd
+  // + phase co-hold (claim-validity-gate.js requires cwd inside worktree_path;
+  // worker-checkin.cjs runs before the worktree is attached and would always fail that
+  // gate) — so auto-chain the execution here instead of only printing it. Every other
+  // phase/status keeps the existing print-only behavior below, unchanged.
+  const wtCwdForFinal = worktreeInfo?.cwd || worktreeInfo?.worktree?.path || null;
+  const isStrandedAtLeadFinal = sd.status === 'pending_approval' && sd.current_phase === 'LEAD_FINAL';
+
+  if (isStrandedAtLeadFinal && wtCwdForFinal) {
+    console.log(`\n${colors.bold}${colors.bgYellow} AUTO-CHAINING ${nextHandoff} ${colors.reset}`);
+    console.log(`${colors.dim}   This SD was stranded at pending_approval/LEAD_FINAL — executing the final handoff now instead of only printing it.${colors.reset}`);
+    try {
+      const output = execSync(`node scripts/handoff.js execute ${nextHandoff} ${effectiveId}`, {
+        cwd: wtCwdForFinal,
+        encoding: 'utf8',
+        timeout: 300000,
+        env: { ...process.env, CLAUDE_SESSION_ID: session.session_id },
+      });
+      console.log(output);
+      console.log(`${colors.green}   ✅ ${nextHandoff} auto-chain completed.${colors.reset}`);
+    } catch (finalErr) {
+      const combined = `${finalErr.stdout || ''}\n${finalErr.stderr || ''}\n${finalErr.message || ''}`;
+      console.log(combined);
+      if (/PR_MERGE_VERIFICATION/.test(combined)) {
+        console.log(`${colors.yellow}   ⏸  ${nextHandoff} blocked on PR_MERGE_VERIFICATION — merge the open PR, then re-run:${colors.reset}`);
+        console.log(`${colors.cyan}   node scripts/sd-start.js ${effectiveId}${colors.reset}`);
+      } else {
+        console.log(`${colors.red}   ⚠ ${nextHandoff} auto-chain failed — retry manually:${colors.reset}`);
+        console.log(`${colors.cyan}   CLAUDE_SESSION_ID=${session.session_id} node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+      }
+    }
+  } else if (needsBrainstorm && sd.status === 'draft') {
     console.log(`\n${colors.bold}Next Action:${colors.reset}`);
     console.log(`   ${colors.cyan}/brainstorm ${sd.title}${colors.reset}`);
     console.log(`${colors.dim}   After brainstorm completes with vision+arch, then:${colors.reset}`);

--- a/tests/unit/claim-command-release-warning.test.js
+++ b/tests/unit/claim-command-release-warning.test.js
@@ -1,0 +1,138 @@
+/**
+ * SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-3, TS-5/TS-6)
+ *
+ * lib/commands/claim-command.js's releaseClaim() — soft, fail-open warning when
+ * releasing a claim on an SD stranded at pending_approval/LEAD_FINAL with no
+ * LEAD-FINAL-APPROVAL handoff attempt yet. Must NEVER block the release, and must
+ * NOT false-positive on the legitimate post-completion release path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let supabaseInstance;
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => supabaseInstance,
+}));
+vi.mock('../../lib/claim/stale-threshold.js', () => ({
+  getStaleThresholdSeconds: () => 300,
+}));
+
+function makeSupabase({ session, sd = null, finalHandoffs = [] }) {
+  return {
+    from: (table) => {
+      if (table === 'claude_sessions') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: session, error: session ? null : { message: 'not found' } }),
+            }),
+          }),
+        };
+      }
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: sd, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: async () => ({ data: finalHandoffs, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+    rpc: async () => ({ error: null }),
+  };
+}
+
+async function importReleaseClaim() {
+  vi.resetModules();
+  return await import('../../lib/commands/claim-command.js');
+}
+
+let logLines;
+beforeEach(() => {
+  logLines = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => { logLines.push(args.join(' ')); });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('releaseClaim — FR-3 soft strand warning', () => {
+  it('TS-5 (PREVENT direction): warns AND still releases when the SD is pending_approval/LEAD_FINAL with no final handoff yet', async () => {
+    supabaseInstance = makeSupabase({
+      session: { session_id: 'sess-1', sd_key: 'SD-STRAND-001', heartbeat_at: null, status: 'active' },
+      sd: { id: 'sd-uuid-1', status: 'pending_approval', current_phase: 'LEAD_FINAL' },
+      finalHandoffs: [],
+    });
+
+    const { releaseClaim } = await importReleaseClaim();
+    await releaseClaim('sess-1');
+
+    const output = logLines.join('\n');
+    expect(output).toMatch(/one handoff from shipped/);
+    expect(output).toMatch(/Released claim on SD-STRAND-001/);
+  });
+
+  it('TS-6 (legitimate release direction): does NOT warn when a LEAD-FINAL-APPROVAL handoff already exists', async () => {
+    supabaseInstance = makeSupabase({
+      session: { session_id: 'sess-2', sd_key: 'SD-DONE-001', heartbeat_at: null, status: 'active' },
+      sd: { id: 'sd-uuid-2', status: 'pending_approval', current_phase: 'LEAD_FINAL' },
+      finalHandoffs: [{ id: 'handoff-1' }],
+    });
+
+    const { releaseClaim } = await importReleaseClaim();
+    await releaseClaim('sess-2');
+
+    const output = logLines.join('\n');
+    expect(output).not.toMatch(/one handoff from shipped/);
+    expect(output).toMatch(/Released claim on SD-DONE-001/);
+  });
+
+  it('does NOT warn for an SD in any other phase/status (no false positive outside LEAD_FINAL)', async () => {
+    supabaseInstance = makeSupabase({
+      session: { session_id: 'sess-3', sd_key: 'SD-INPROGRESS-001', heartbeat_at: null, status: 'active' },
+      sd: { id: 'sd-uuid-3', status: 'in_progress', current_phase: 'EXEC' },
+      finalHandoffs: [],
+    });
+
+    const { releaseClaim } = await importReleaseClaim();
+    await releaseClaim('sess-3');
+
+    const output = logLines.join('\n');
+    expect(output).not.toMatch(/one handoff from shipped/);
+    expect(output).toMatch(/Released claim on SD-INPROGRESS-001/);
+  });
+
+  it('fails open: an error looking up the SD/handoff never blocks the release', async () => {
+    const session = { session_id: 'sess-4', sd_key: 'SD-ERR-001', heartbeat_at: null, status: 'active' };
+    supabaseInstance = {
+      from: (table) => {
+        if (table === 'claude_sessions') {
+          return { select: () => ({ eq: () => ({ single: async () => ({ data: session, error: null }) }) }) };
+        }
+        if (table === 'strategic_directives_v2') {
+          return { select: () => ({ eq: () => ({ maybeSingle: async () => { throw new Error('boom'); } }) }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      },
+      rpc: async () => ({ error: null }),
+    };
+
+    const { releaseClaim } = await importReleaseClaim();
+    await releaseClaim('sess-4');
+
+    const output = logLines.join('\n');
+    expect(output).toMatch(/Released claim on SD-ERR-001/);
+  });
+});

--- a/tests/unit/coordinator/strand-age-gauge.test.js
+++ b/tests/unit/coordinator/strand-age-gauge.test.js
@@ -1,0 +1,121 @@
+/**
+ * SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2, TS-4)
+ *
+ * lib/coordinator/strand-age-gauge.cjs — pending_approval/LEAD_FINAL strand-age gauge.
+ * Read-only: no test may assert a mutation to strategic_directives_v2 or claiming_session_id.
+ */
+import { describe, it, expect } from 'vitest';
+import { planStrandAgeGauge, resolveThresholdMs, formatAge, DEFAULT_THRESHOLD_MS } from '../../../lib/coordinator/strand-age-gauge.cjs';
+
+const NOW = Date.parse('2026-07-04T12:00:00Z');
+
+function makeSupabase({ candidates = [], handoffsBySdId = {} } = {}) {
+  const calls = { updates: [], deletes: [] };
+  const from = (table) => {
+    if (table === 'strategic_directives_v2') {
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        update: (payload) => { calls.updates.push({ table, payload }); return builder; },
+        delete: () => { calls.deletes.push({ table }); return builder; },
+        then: (resolve) => resolve({ data: candidates, error: null }),
+      };
+      return builder;
+    }
+    if (table === 'sd_phase_handoffs') {
+      let currentSdId = null;
+      const builder = {
+        select: () => builder,
+        eq: (col, val) => { if (col === 'sd_id') currentSdId = val; return builder; },
+        order: () => builder,
+        limit: () => Promise.resolve({ data: handoffsBySdId[currentSdId] || [], error: null }),
+      };
+      return builder;
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  };
+  return { from, _calls: calls };
+}
+
+describe('resolveThresholdMs', () => {
+  it('defaults to 10 minutes when no env override', () => {
+    expect(resolveThresholdMs({})).toBe(DEFAULT_THRESHOLD_MS);
+    expect(DEFAULT_THRESHOLD_MS).toBe(10 * 60 * 1000);
+  });
+
+  it('honors STRAND_AGE_GAUGE_THRESHOLD_MIN override', () => {
+    expect(resolveThresholdMs({ STRAND_AGE_GAUGE_THRESHOLD_MIN: '20' })).toBe(20 * 60 * 1000);
+  });
+});
+
+describe('formatAge', () => {
+  it('formats sub-hour ages in minutes', () => {
+    expect(formatAge(15 * 60 * 1000)).toBe('15m');
+  });
+  it('formats multi-hour ages as Nh + remainder minutes', () => {
+    expect(formatAge(150 * 60 * 1000)).toBe('2h30m');
+    expect(formatAge(120 * 60 * 1000)).toBe('2h');
+  });
+});
+
+describe('planStrandAgeGauge (TS-4)', () => {
+  it('flags an SD stranded past the threshold, using updated_at', () => {
+    const supabase = makeSupabase({
+      candidates: [
+        { sd_key: 'SD-STRANDED-001', id: 'uuid-1', updated_at: '2026-07-04T11:45:00Z', created_at: '2026-07-04T09:00:00Z' }, // 15min old
+      ],
+    });
+    return planStrandAgeGauge(supabase, { nowMs: NOW }).then((gauge) => {
+      expect(gauge.flagged).toHaveLength(1);
+      expect(gauge.flagged[0].sd_key).toBe('SD-STRANDED-001');
+      expect(gauge.flagged[0].ageSource).toBe('updated_at');
+    });
+  });
+
+  it('does NOT flag a fresh pending_approval/LEAD_FINAL SD younger than the threshold (no false positive)', () => {
+    const supabase = makeSupabase({
+      candidates: [
+        { sd_key: 'SD-FRESH-001', id: 'uuid-2', updated_at: '2026-07-04T11:58:00Z', created_at: '2026-07-04T11:00:00Z' }, // 2min old
+      ],
+    });
+    return planStrandAgeGauge(supabase, { nowMs: NOW }).then((gauge) => {
+      expect(gauge.flagged).toHaveLength(0);
+      expect(gauge.rows).toHaveLength(1); // still tracked, just not flagged
+    });
+  });
+
+  it('falls back to the latest sd_phase_handoffs.resolved_at when updated_at looks unreliable (predates created_at)', () => {
+    const supabase = makeSupabase({
+      candidates: [
+        { sd_key: 'SD-UNRELIABLE-001', id: 'uuid-3', updated_at: '2026-07-01T00:00:00Z', created_at: '2026-07-04T09:00:00Z' },
+      ],
+      handoffsBySdId: {
+        'uuid-3': [{ resolved_at: '2026-07-04T11:40:00Z' }], // 20min old
+      },
+    });
+    return planStrandAgeGauge(supabase, { nowMs: NOW }).then((gauge) => {
+      expect(gauge.flagged).toHaveLength(1);
+      expect(gauge.flagged[0].ageSource).toBe('latest_handoff_resolved_at');
+    });
+  });
+
+  it('returns no flagged rows and no error when there are no pending_approval/LEAD_FINAL candidates', () => {
+    const supabase = makeSupabase({ candidates: [] });
+    return planStrandAgeGauge(supabase, { nowMs: NOW }).then((gauge) => {
+      expect(gauge.flagged).toEqual([]);
+      expect(gauge.rows).toEqual([]);
+    });
+  });
+
+  it('is read-only: never calls .update() or .delete() on strategic_directives_v2', () => {
+    const supabase = makeSupabase({
+      candidates: [
+        { sd_key: 'SD-STRANDED-002', id: 'uuid-4', updated_at: '2026-07-04T11:00:00Z', created_at: '2026-07-04T09:00:00Z' },
+      ],
+    });
+    return planStrandAgeGauge(supabase, { nowMs: NOW }).then(() => {
+      expect(supabase._calls.updates).toEqual([]);
+      expect(supabase._calls.deletes).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/sd-start-lead-final-auto-chain.test.js
+++ b/tests/unit/sd-start-lead-final-auto-chain.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-1) — sd-start.js auto-chains
+ * LEAD-FINAL-APPROVAL for a stranded pending_approval/LEAD_FINAL SD instead
+ * of only printing it as a suggestion. Static-pin pattern (matches this
+ * file's own established convention — see sd-start-claim-lifecycle.test.js).
+ *
+ * TS-2 (regression): every other phase/status must be byte-identical to the
+ * pre-FR-1 print-only behavior. Covered here by asserting the new branch is
+ * gated on isStrandedAtLeadFinal && wtCwdForFinal, and that the pre-existing
+ * needsBrainstorm/else branches are untouched and still reachable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SD_START_PATH = resolve(__dirname, '..', '..', 'scripts/sd-start.js');
+const src = readFileSync(SD_START_PATH, 'utf8');
+
+function sliceAfterNextHandoff() {
+  const idx = src.indexOf('const nextHandoff = await getNextHandoff(sd);');
+  expect(idx, 'nextHandoff computation not found').toBeGreaterThan(0);
+  return src.slice(idx, idx + 3500);
+}
+
+describe('FR-1: auto-chain gating conditions', () => {
+  it('gates the new branch on status=pending_approval AND current_phase=LEAD_FINAL AND a resolved worktree cwd', () => {
+    const slice = sliceAfterNextHandoff();
+    expect(slice).toMatch(/isStrandedAtLeadFinal\s*=\s*sd\.status\s*===\s*'pending_approval'\s*&&\s*sd\.current_phase\s*===\s*'LEAD_FINAL'/);
+    expect(slice).toMatch(/wtCwdForFinal\s*=\s*worktreeInfo\?\.cwd\s*\|\|\s*worktreeInfo\?\.worktree\?\.path\s*\|\|\s*null/);
+    expect(slice).toMatch(/if\s*\(\s*isStrandedAtLeadFinal\s*&&\s*wtCwdForFinal\s*\)/);
+  });
+
+  it('executes the auto-chain via execSync scoped to the resolved worktree cwd, with a >=300000ms timeout', () => {
+    const slice = sliceAfterNextHandoff();
+    const execIdx = slice.indexOf('execSync(`node scripts/handoff.js execute ${nextHandoff} ${effectiveId}`');
+    expect(execIdx, 'execSync auto-chain call not found').toBeGreaterThan(0);
+    const execBlock = slice.slice(execIdx, execIdx + 400);
+    expect(execBlock).toMatch(/cwd:\s*wtCwdForFinal/);
+    expect(execBlock).toMatch(/timeout:\s*300000/);
+    expect(execBlock).toMatch(/CLAUDE_SESSION_ID:\s*session\.session_id/);
+  });
+
+  it('detects PR_MERGE_VERIFICATION in the failure path and prints the merge-then-retry remediation (does not treat it as an sd-start.js crash)', () => {
+    const slice = sliceAfterNextHandoff();
+    const catchIdx = slice.indexOf('catch (finalErr)');
+    expect(catchIdx, 'auto-chain catch block not found').toBeGreaterThan(0);
+    const catchBlock = slice.slice(catchIdx, catchIdx + 900);
+    expect(catchBlock).toMatch(/PR_MERGE_VERIFICATION/);
+    expect(catchBlock).toMatch(/blocked on PR_MERGE_VERIFICATION/i);
+    // The catch block itself must not re-throw / must not call process.exit — sd-start.js
+    // should complete normally (falls through to the existing progress-tick + summary tail).
+    expect(catchBlock).not.toMatch(/throw /);
+    expect(catchBlock).not.toMatch(/process\.exit/);
+  });
+});
+
+describe('TS-2 (regression): non-LEAD_FINAL / non-pending_approval behavior is unchanged', () => {
+  it('the pre-existing needsBrainstorm branch is preserved verbatim as an else-if, unreachable when isStrandedAtLeadFinal is true', () => {
+    const slice = sliceAfterNextHandoff();
+    expect(slice).toMatch(/\}\s*else if\s*\(\s*needsBrainstorm\s*&&\s*sd\.status\s*===\s*'draft'\s*\)\s*\{/);
+    expect(slice).toMatch(/\/brainstorm \$\{sd\.title\}/);
+  });
+
+  it('the pre-existing default Next Action print branch is preserved verbatim as the final else', () => {
+    const slice = sliceAfterNextHandoff();
+    expect(slice).toMatch(/\}\s*else\s*\{\s*\n\s*console\.log\(`\\n\$\{colors\.bold\}Next Action:\$\{colors\.reset\}`\);/);
+    expect(slice).toMatch(/no_deterministic_identity failures at claim-validity gate/);
+  });
+
+  it('the new branch is the FIRST condition checked (highest specificity), so a stranded SD never falls through to the generic print branch', () => {
+    const slice = sliceAfterNextHandoff();
+    const strandedIdx = slice.indexOf('if (isStrandedAtLeadFinal && wtCwdForFinal)');
+    const brainstormIdx = slice.indexOf("else if (needsBrainstorm && sd.status === 'draft')");
+    expect(strandedIdx).toBeGreaterThan(0);
+    expect(brainstormIdx).toBeGreaterThan(strandedIdx);
+  });
+});


### PR DESCRIPTION
## Summary

3rd occurrence of the pending_approval/LEAD_FINAL strand class: `recoverStrandedFinal` (`scripts/worker-checkin.cjs`) correctly re-claims a stranded SD, but nothing in code drove the adopting worker to actually execute LEAD-FINAL-APPROVAL — only prose. Real specimen: SD-LEO-FEAT-MARKETLENS-CUSTOMER-FACING-001 sat 2.5+ hours through 4 successive holders before a worker finally ran it manually (in this same fleet, this same session).

- **FR-1**: `scripts/sd-start.js` now auto-chains LEAD-FINAL-APPROVAL execution when re-attaching a stranded `pending_approval/LEAD_FINAL` SD, instead of only printing the command. Lives in `sd-start.js` specifically — `claim-validity-gate.js` requires cwd inside the SD's `worktree_path`, so `worker-checkin.cjs` (which runs before the worktree is attached) or a coordinator-main sweep can never pass that gate. Zero behavior change for every other phase/status.
- **FR-2**: new `lib/coordinator/strand-age-gauge.cjs` + a `fleet-dashboard.cjs strand` section — read-only visibility for any SD stranded past a threshold, so it's caught by monitoring instead of manual archaeology.
- **FR-3**: `lib/commands/claim-command.js`'s `releaseClaim()` prints a soft, non-blocking warning when manually releasing a claim on an SD one handoff from shipped. Scoped ONLY to the manual release path — automatic reclaim paths (session-state-sync.cjs, self-heal.js, TTL sweep) are untouched, since most LEAD_FINAL claim-clearing is automatic and a hard block there would strand the SD worse.

Full LEO workflow: LEAD (validation-agent + risk-agent, both CONDITIONAL_PASS, converging independently on the same architecture) → LEAD-TO-PLAN (94%) → PLAN-TO-EXEC (97%) → EXEC-TO-PLAN (93%) → PLAN_VERIFICATION (VALIDATION + REGRESSION both PASS at 92%) → PLAN-TO-LEAD (97%).

## Test plan

- [x] `tests/unit/sd-start-lead-final-auto-chain.test.js` — static-pin regression guard (matches this file's own established test convention) proving the new branch is gated correctly and every other phase is byte-identical
- [x] `tests/unit/coordinator/strand-age-gauge.test.js` — pure gauge logic, read-only invariant explicitly asserted
- [x] `tests/unit/claim-command-release-warning.test.js` — both directions (warn-and-release vs. legitimate no-warn release), fail-open on lookup error
- [x] Full pre-existing `sd-start-*` test suite (63 tests) — zero regressions
- [x] Manual, non-mocked verification during EXEC: created a throwaway fixture SD, ran the real `sd-start.js --force` against it, confirmed the auto-chain genuinely invoked the real `handoff.js execute LEAD-FINAL-APPROVAL` command and the real gate pipeline correctly rejected the unprepared fixture (`HANDOFF SEQUENCE VIOLATION`) without crashing `sd-start.js`
- [x] REGRESSION sub-agent independently confirmed FR-3 touches zero automatic-reclaim code paths — the single highest-risk safety property flagged at LEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)