### PR TITLE
feat(SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001): mechanically-regenerated surface x checker coverage matrix

### DIFF
--- a/config/coverage-matrix-checker-map.json
+++ b/config/coverage-matrix-checker-map.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001. Human-curated (surface_class, surface_key pattern) -> checker script(s). A surface_key with no matching entry is intentionally left checker_ids=[] (checker=NONE) -- that is the loud-by-construction default THE RULE (reward-spine) requires, not a bug. Patterns are matched with a simple substring test against surface_key, not regex, to keep this file auditable by non-engineers.",
+  "entries": [
+    { "surface_class": "work_item_type", "pattern": "gauge_registry", "checker_ids": ["scripts/gauge-runner.mjs"] },
+    { "surface_class": "db_table", "pattern": "merge_witness_telemetry", "checker_ids": ["lib/ship/merge-witness-ladder.mjs"] },
+    { "surface_class": "db_table", "pattern": "issue_patterns", "checker_ids": ["lib/governance/pattern-closure.js"] },
+    { "surface_class": "db_table", "pattern": "solomon_advice_outcome_ledger", "checker_ids": ["scripts/solomon-ledger-reconcile.cjs"] },
+    { "surface_class": "db_table", "pattern": "retrospectives", "checker_ids": ["scripts/modules/handoff/executors/lead-final-approval/gates.js:retrospectiveExists"] },
+    { "surface_class": "db_table", "pattern": "coverage_matrix", "checker_ids": ["scripts/coverage-matrix-regenerate.mjs"] }
+  ]
+}

--- a/config/coverage-matrix-checker-map.json
+++ b/config/coverage-matrix-checker-map.json
@@ -5,7 +5,6 @@
     { "surface_class": "db_table", "pattern": "merge_witness_telemetry", "checker_ids": ["lib/ship/merge-witness-ladder.mjs"] },
     { "surface_class": "db_table", "pattern": "issue_patterns", "checker_ids": ["lib/governance/pattern-closure.js"] },
     { "surface_class": "db_table", "pattern": "solomon_advice_outcome_ledger", "checker_ids": ["scripts/solomon-ledger-reconcile.cjs"] },
-    { "surface_class": "db_table", "pattern": "retrospectives", "checker_ids": ["scripts/modules/handoff/executors/lead-final-approval/gates.js:retrospectiveExists"] },
-    { "surface_class": "db_table", "pattern": "coverage_matrix", "checker_ids": ["scripts/coverage-matrix-regenerate.mjs"] }
+    { "surface_class": "db_table", "pattern": "retrospectives", "checker_ids": ["scripts/modules/handoff/executors/lead-final-approval/gates.js:retrospectiveExists"] }
   ]
 }

--- a/config/coverage-matrix-exclusions.json
+++ b/config/coverage-matrix-exclusions.json
@@ -1,0 +1,14 @@
+{
+  "db_table_schema_allowlist": ["public"],
+  "db_table_name_exclusions": [
+    "schema_migrations",
+    "supabase_migrations"
+  ],
+  "db_table_name_prefix_exclusions": [
+    "pg_",
+    "_realtime",
+    "staging_",
+    "tmp_",
+    "temp_"
+  ]
+}

--- a/database/migrations/20260704_coverage_matrix_surface_registry.sql
+++ b/database/migrations/20260704_coverage_matrix_surface_registry.sql
@@ -1,0 +1,44 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001
+-- Durable coverage-matrix artifact: surface x checker(s) claiming coverage x last-verified-at.
+-- Surface list is mechanically regenerated (see scripts/coverage-matrix-regenerate.mjs) so a
+-- new surface auto-appears as checker_ids=[] instead of being silently unwatched.
+
+CREATE TABLE IF NOT EXISTS coverage_matrix (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  surface_class TEXT NOT NULL CHECK (surface_class IN (
+    'db_table', 'message_lane', 'application', 'work_item_type',
+    'institutional_memory', 'periodic_process', 'external_channel'
+  )),
+  surface_key TEXT NOT NULL,
+  checker_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+  status TEXT NOT NULL DEFAULT 'unchecked' CHECK (status IN (
+    'unchecked', 'covered', 'stale', 'pending_dependency'
+  )),
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_verified_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (surface_class, surface_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_matrix_status ON coverage_matrix (status);
+CREATE INDEX IF NOT EXISTS idx_coverage_matrix_surface_class ON coverage_matrix (surface_class);
+
+COMMENT ON TABLE coverage_matrix IS
+  'SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001: mechanically-regenerated surface x checker registry. checker_ids=[] on a row is the intended, loud-by-construction default for an unwatched surface -- never treat an empty array as an error condition.';
+
+-- Tracks the last time the monthly referent-audit rotation ran, so a cold start (no prior row)
+-- treats the entire current coverage_matrix as the delta rather than crashing.
+CREATE TABLE IF NOT EXISTS coverage_matrix_rotation_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ran_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  delta_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+  sample_verified_keys JSONB NOT NULL DEFAULT '[]'::jsonb,
+  coverage_question_feedback_ids JSONB NOT NULL DEFAULT '[]'::jsonb
+);
+
+COMMENT ON TABLE coverage_matrix_rotation_runs IS
+  'SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001: audit trail of monthly referent-audit rotation runs, one row per run.';

--- a/database/migrations/20260704b_coverage_matrix_rotation_month_uniqueness.sql
+++ b/database/migrations/20260704b_coverage_matrix_rotation_month_uniqueness.sql
@@ -1,0 +1,13 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001
+-- Adversarial-review follow-up: the application-level "already ran this period" check in
+-- runRotation() is a check-then-insert with no DB-level guard, so two concurrent invocations
+-- could both pass the check and insert duplicate rotation runs for the same month. This unique
+-- index converts that race from a silent duplicate into a loud, catchable constraint violation --
+-- matching this SD's own "loud by construction" philosophy.
+
+-- date_trunc(text, timestamptz) is STABLE (session-timezone dependent), not IMMUTABLE, so it
+-- cannot be used directly in an index expression. `ran_at AT TIME ZONE 'UTC'` converts to a
+-- fixed-zone plain timestamp first, which IS immutable.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coverage_matrix_rotation_runs_month
+  ON coverage_matrix_rotation_runs (date_trunc('month', ran_at AT TIME ZONE 'UTC'));

--- a/docs/architecture/coverage-matrix-reward-spine-foldin.md
+++ b/docs/architecture/coverage-matrix-reward-spine-foldin.md
@@ -1,0 +1,28 @@
+---
+category: architecture
+status: approved
+version: 1.0.0
+author: SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001
+last_updated: 2026-07-04
+tags: [coverage-matrix, reward-spine, referent-audit, governance]
+---
+
+# Coverage Matrix x Reward Spine — Audit Cadence Fold-In (Spec-Level Only)
+
+**SD:** SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001, FR-7
+
+Both `scripts/coverage-matrix-referent-audit.mjs` (this SD) and
+SD-LEO-INFRA-REWARD-SPINE-ONE-001's periodic signal-audit share:
+
+- A **monthly cadence** for their respective audits.
+- The same anti-Goodhart principle: **closure by a different actor than the one being scored**
+  — a sample-verification finding is surfaced as a question, not auto-resolved by the same job
+  that raised it.
+
+This is ONE audit institution with two objects (signals for reward-spine, coverage for this SD),
+not two independent machineries that happen to look similar. There is deliberately **no runtime
+coupling** between the two rotation scripts — each runs independently, on its own schedule, with
+its own idempotency guard (`coverage_matrix_rotation_runs` here; reward-spine's own audit-run
+table there). Building a shared audit-orchestration layer before either job has run in production
+would be premature — this note exists so a future consumer finds the relationship documented
+without introducing that coupling prematurely.

--- a/lib/governance/coverage-matrix-referent-audit.js
+++ b/lib/governance/coverage-matrix-referent-audit.js
@@ -1,0 +1,118 @@
+/**
+ * Monthly referent-audit rotation -- SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001, FR-6.
+ *
+ * Computes the delta since the last rotation (new unchecked / newly-stale / newly-dormant
+ * surfaces), selects 2-3 claimed-covered cells for sample-verification, and emits both as
+ * coverage questions to Adam's feedback inbox. Sample-verification of a selected cell is an
+ * observational judgment call (does the claimed checker actually still cover this surface) --
+ * this module does NOT automate that verification itself; it surfaces the question so a
+ * different actor/process closes it (anti-Goodhart: closure by a different actor than the one
+ * being scored).
+ */
+
+const SAMPLE_SIZE = 3;
+
+export async function computeDelta(supabase, sinceIso) {
+  const query = supabase.from('coverage_matrix').select('surface_class, surface_key, status, is_active, first_seen_at, updated_at');
+  const { data, error } = sinceIso ? await query.gt('updated_at', sinceIso) : await query;
+  if (error) throw new Error(`computeDelta: query failed: ${error.message}`);
+
+  const rows = data || [];
+  return {
+    new_unchecked: rows.filter((r) => r.status === 'unchecked' && (!sinceIso || r.first_seen_at > sinceIso)),
+    newly_stale: rows.filter((r) => r.status === 'stale'),
+    newly_dormant: rows.filter((r) => r.is_active === false && r.status === 'covered'),
+  };
+}
+
+export function selectSampleVerificationCandidates(coveredRows, sampleSize = SAMPLE_SIZE) {
+  const shuffled = [...coveredRows].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, Math.min(sampleSize, shuffled.length));
+}
+
+export async function emitCoverageQuestions(supabase, { delta, sampleCandidates }) {
+  const feedbackIds = [];
+  const hasFindings = delta.new_unchecked.length > 0 || delta.newly_stale.length > 0 || delta.newly_dormant.length > 0;
+
+  if (hasFindings) {
+    const { data, error } = await supabase.from('feedback').insert({
+      type: 'issue',
+      category: 'coverage_audit_question',
+      priority: 'P2',
+      status: 'new',
+      title: `Coverage-matrix delta: ${delta.new_unchecked.length} new unchecked, ${delta.newly_stale.length} newly stale, ${delta.newly_dormant.length} newly dormant`,
+      description: 'Monthly referent-audit rotation delta (SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001). Review and source follow-up work for any genuinely-unwatched surface.',
+      source_type: 'coverage-matrix-referent-audit',
+      metadata: { delta },
+    }).select('id').single();
+    if (error) throw new Error(`emitCoverageQuestions: delta insert failed: ${error.message}`);
+    feedbackIds.push(data.id);
+  }
+
+  for (const candidate of sampleCandidates) {
+    const { data, error } = await supabase.from('feedback').insert({
+      type: 'issue',
+      category: 'coverage_audit_question',
+      priority: 'P3',
+      status: 'new',
+      title: `Sample-verify claimed coverage: ${candidate.surface_class}/${candidate.surface_key}`,
+      description: 'This cell claims checker coverage. Direct-observation verdict requested: is the claimed checker still real/effective for this surface? (SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001 monthly rotation, anti-Goodhart sample-verification.)',
+      source_type: 'coverage-matrix-referent-audit',
+      metadata: { candidate },
+    }).select('id').single();
+    if (error) throw new Error(`emitCoverageQuestions: sample-verify insert failed: ${error.message}`);
+    feedbackIds.push(data.id);
+  }
+
+  return feedbackIds;
+}
+
+/** Idempotent within a calendar month: a rotation that already ran this month is a no-op. */
+export async function runRotation(supabase) {
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+
+  const { data: recentRuns, error: runsError } = await supabase
+    .from('coverage_matrix_rotation_runs')
+    .select('id, ran_at')
+    .gte('ran_at', monthStart)
+    .limit(1);
+  if (runsError) throw new Error(`runRotation: rotation-runs query failed: ${runsError.message}`);
+  if (recentRuns && recentRuns.length > 0) {
+    return { skipped: true, reason: 'already_ran_this_period', priorRun: recentRuns[0] };
+  }
+
+  const { data: lastRun } = await supabase
+    .from('coverage_matrix_rotation_runs')
+    .select('ran_at')
+    .order('ran_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const sinceIso = lastRun?.ran_at || null; // null = cold start, treat entire matrix as delta
+
+  const delta = await computeDelta(supabase, sinceIso);
+
+  const { data: coveredRows, error: coveredError } = await supabase
+    .from('coverage_matrix')
+    .select('surface_class, surface_key')
+    .eq('status', 'covered');
+  if (coveredError) throw new Error(`runRotation: covered-rows query failed: ${coveredError.message}`);
+  const sampleCandidates = selectSampleVerificationCandidates(coveredRows || []);
+
+  const feedbackIds = await emitCoverageQuestions(supabase, { delta, sampleCandidates });
+
+  const { error: insertRunError } = await supabase.from('coverage_matrix_rotation_runs').insert({
+    delta_summary: {
+      new_unchecked: delta.new_unchecked.length,
+      newly_stale: delta.newly_stale.length,
+      newly_dormant: delta.newly_dormant.length,
+    },
+    sample_verified_keys: sampleCandidates.map((c) => `${c.surface_class}/${c.surface_key}`),
+    coverage_question_feedback_ids: feedbackIds,
+  });
+  if (insertRunError) throw new Error(`runRotation: rotation-run insert failed: ${insertRunError.message}`);
+
+  return { skipped: false, delta, sampleCandidates, feedbackIds };
+}
+
+export default { computeDelta, selectSampleVerificationCandidates, emitCoverageQuestions, runRotation };

--- a/lib/governance/coverage-matrix-referent-audit.js
+++ b/lib/governance/coverage-matrix-referent-audit.js
@@ -25,8 +25,13 @@ export async function computeDelta(supabase, sinceIso) {
   };
 }
 
+/** Fisher-Yates shuffle, not the biased sort-by-random-comparator pattern. */
 export function selectSampleVerificationCandidates(coveredRows, sampleSize = SAMPLE_SIZE) {
-  const shuffled = [...coveredRows].sort(() => Math.random() - 0.5);
+  const shuffled = [...coveredRows];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
   return shuffled.slice(0, Math.min(sampleSize, shuffled.length));
 }
 
@@ -82,13 +87,16 @@ export async function runRotation(supabase) {
     return { skipped: true, reason: 'already_ran_this_period', priorRun: recentRuns[0] };
   }
 
-  const { data: lastRun } = await supabase
+  const { data: lastRun, error: lastRunError } = await supabase
     .from('coverage_matrix_rotation_runs')
     .select('ran_at')
     .order('ran_at', { ascending: false })
     .limit(1)
     .maybeSingle();
-  const sinceIso = lastRun?.ran_at || null; // null = cold start, treat entire matrix as delta
+  // Fail closed: a query error here must not be silently treated as "no prior run" (cold start),
+  // which would over-broaden the delta and re-flag everything as new.
+  if (lastRunError) throw new Error(`runRotation: last-run query failed: ${lastRunError.message}`);
+  const sinceIso = lastRun?.ran_at || null; // null = genuine cold start, treat entire matrix as delta
 
   const delta = await computeDelta(supabase, sinceIso);
 
@@ -110,7 +118,15 @@ export async function runRotation(supabase) {
     sample_verified_keys: sampleCandidates.map((c) => `${c.surface_class}/${c.surface_key}`),
     coverage_question_feedback_ids: feedbackIds,
   });
-  if (insertRunError) throw new Error(`runRotation: rotation-run insert failed: ${insertRunError.message}`);
+  if (insertRunError) {
+    // The check-then-insert above is a TOCTOU race under concurrent invocation; the DB-level
+    // idx_coverage_matrix_rotation_runs_month unique index converts a lost race into a loud
+    // constraint violation (23505) here, which we treat as a graceful skip rather than a crash.
+    if (insertRunError.code === '23505') {
+      return { skipped: true, reason: 'concurrent_run_won_race', feedbackIds };
+    }
+    throw new Error(`runRotation: rotation-run insert failed: ${insertRunError.message}`);
+  }
 
   return { skipped: false, delta, sampleCandidates, feedbackIds };
 }

--- a/lib/governance/coverage-matrix-retrodiction.js
+++ b/lib/governance/coverage-matrix-retrodiction.js
@@ -1,0 +1,72 @@
+/**
+ * Retrodiction of the 4 chairman-caught gaps against the coverage matrix.
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001, FR-5.
+ *
+ * For each specimen, confirms the surface_class/surface_key it maps to would have rendered as
+ * checker=NONE or is_active=false BEFORE the chairman's catch -- a real verdict per specimen,
+ * not a single aggregate claim.
+ */
+
+export const RETRODICTION_SPECIMENS = [
+  {
+    id: 'product-touch',
+    description: 'Chairman-caught gap: no hands-on product-review stage existed pre-launch (app/customer UI/outward-facing)',
+    surface_class: 'work_item_type',
+    surface_key: 'ehg_design_decisions',
+  },
+  {
+    id: 'scope-coverage',
+    description: 'Chairman-caught gap: SD-scope edits made after PRD creation did not propagate to EXEC',
+    surface_class: 'work_item_type',
+    surface_key: 'strategic_directives_v2',
+  },
+  {
+    id: 'comms-lane',
+    description: 'Chairman-caught gap: a coordinator/Adam comms lane went unchecked (registration lapse during long inline host)',
+    surface_class: 'message_lane',
+    surface_key: 'coordinator_reply',
+  },
+  {
+    id: 'qf-scanning',
+    description: 'Chairman-caught gap: quick-fix queue was not being scanned/enumerated by any checker',
+    surface_class: 'work_item_type',
+    surface_key: 'quick_fixes',
+  },
+];
+
+/**
+ * @param {object} supabase
+ * @returns {Promise<Array<{id: string, verdict: 'pass'|'fail', evidence: object}>>}
+ */
+export async function retrodictSpecimens(supabase) {
+  const results = [];
+  for (const specimen of RETRODICTION_SPECIMENS) {
+    const { data, error } = await supabase
+      .from('coverage_matrix')
+      .select('surface_class, surface_key, checker_ids, is_active, status')
+      .eq('surface_class', specimen.surface_class)
+      .eq('surface_key', specimen.surface_key)
+      .maybeSingle();
+
+    if (error) {
+      results.push({ id: specimen.id, verdict: 'fail', evidence: { reason: 'query_error', error: error.message } });
+      continue;
+    }
+    if (!data) {
+      results.push({ id: specimen.id, verdict: 'fail', evidence: { reason: 'surface_not_in_matrix', specimen } });
+      continue;
+    }
+
+    const wasUnchecked = !Array.isArray(data.checker_ids) || data.checker_ids.length === 0;
+    const wasDormant = data.is_active === false;
+    const verdict = (wasUnchecked || wasDormant) ? 'pass' : 'fail';
+    results.push({
+      id: specimen.id,
+      verdict,
+      evidence: { checker_ids: data.checker_ids, is_active: data.is_active, status: data.status, wasUnchecked, wasDormant },
+    });
+  }
+  return results;
+}
+
+export default { RETRODICTION_SPECIMENS, retrodictSpecimens };

--- a/lib/governance/coverage-matrix.js
+++ b/lib/governance/coverage-matrix.js
@@ -168,11 +168,39 @@ export async function enumerateApplications(supabase) {
     .map((row) => ({ surface_key: row.normalized_name, is_active: true }));
 }
 
-export async function enumerateWorkItemTypes(supabase, gaugeRegistry) {
+/**
+ * `supabase.from(table).select('*', {count:'exact', head:true})` on a table that does not exist
+ * can read as count=0/error=null rather than a clear error (a documented gotcha in this
+ * codebase's own memory: "supabase-js head/count false-positives on a MISSING table"). A single
+ * batched `to_regclass` query via the pg client disambiguates "table exists but is empty" from
+ * "table does not exist at all" before any count query runs, so a dropped table surfaces as a
+ * real coverage finding instead of silently reading as merely dormant.
+ *
+ * @param {object} supabase - supabase-js client (for the count queries)
+ * @param {Array} gaugeRegistry
+ * @param {import('pg').Client} pgClient - connected pg client (for to_regclass existence checks)
+ */
+export async function enumerateWorkItemTypes(supabase, gaugeRegistry, pgClient) {
+  const existenceByTable = new Map();
+  if (pgClient) {
+    // to_regclass() (the FUNCTION form) returns NULL for a non-existent relation; the `::regclass`
+    // CAST form instead throws -- using the cast here would defeat the whole point of this check.
+    const { rows: existenceRows } = await pgClient.query(
+      'SELECT t AS table_name, to_regclass(\'public.\' || t) IS NOT NULL AS exists_check FROM unnest($1::text[]) AS t',
+      [WORK_ITEM_TYPE_TABLES]
+    ).catch(() => ({ rows: [] })); // best-effort: fall back to count-only if the batched query fails
+    for (const row of existenceRows) existenceByTable.set(row.table_name, row.exists_check);
+  }
+
   // Concurrent, not sequential -- 19 independent head-count round trips run in parallel so
   // regeneration wall-clock time doesn't scale linearly with the number of known tables.
   const countResults = await Promise.all(
-    WORK_ITEM_TYPE_TABLES.map((table) => supabase.from(table).select('*', { count: 'exact', head: true }).then((r) => ({ table, ...r })))
+    WORK_ITEM_TYPE_TABLES.map((table) => {
+      if (existenceByTable.get(table) === false) {
+        return Promise.resolve({ table, count: null, error: { message: 'table does not exist (to_regclass check)' } });
+      }
+      return supabase.from(table).select('*', { count: 'exact', head: true }).then((r) => ({ table, ...r }));
+    })
   );
   const results = countResults.map(({ table, count, error }) => (
     error
@@ -227,7 +255,7 @@ export async function regenerateCoverageMatrix(supabase, pgClient, { exclusions,
     db_table: await enumerateDbTables(pgClient, exclusions || {}),
     message_lane: await enumerateMessageLanes(pgClient, supabase),
     application: await enumerateApplications(supabase),
-    work_item_type: await enumerateWorkItemTypes(supabase, gaugeRegistry || []),
+    work_item_type: await enumerateWorkItemTypes(supabase, gaugeRegistry || [], pgClient),
     institutional_memory: enumerateInstitutionalMemory(memoryDirPath),
     periodic_process: [periodicProcessPlaceholderRow()],
     external_channel: enumerateExternalChannels(),
@@ -243,13 +271,24 @@ export async function regenerateCoverageMatrix(supabase, pgClient, { exclusions,
       .eq('surface_class', surfaceClass);
     if (fetchError) throw new Error(`regenerateCoverageMatrix: fetch existing rows failed for ${surfaceClass}: ${fetchError.message}`);
 
-    const currentKeys = new Set(rows.map((r) => r.surface_key));
+    // Defensive de-dup by surface_key: a bulk upsert with two rows sharing the same
+    // (surface_class, surface_key) conflict target fails with "ON CONFLICT DO UPDATE command
+    // cannot affect row a second time" -- e.g. enumerateMessageLanes's structural enum labels and
+    // data-driven signal_type values could theoretically collide on the same text.
+    const seenKeys = new Set();
+    const dedupedRows = rows.filter((row) => {
+      if (seenKeys.has(row.surface_key)) return false;
+      seenKeys.add(row.surface_key);
+      return true;
+    });
+
+    const currentKeys = new Set(dedupedRows.map((r) => r.surface_key));
     const existingKeys = new Set((existingRows || []).map((r) => r.surface_key));
 
     // One bulk upsert per surface class instead of one round trip per row -- db_table alone can
     // be hundreds of rows; a sequential per-row loop made regeneration take minutes.
-    if (rows.length > 0) {
-      const upsertRows = rows.map((row) => {
+    if (dedupedRows.length > 0) {
+      const upsertRows = dedupedRows.map((row) => {
         const checkerIds = row.status === 'pending_dependency'
           ? []
           : matchCheckerIds(surfaceClass, row.surface_key, checkerMapEntries || []);

--- a/lib/governance/coverage-matrix.js
+++ b/lib/governance/coverage-matrix.js
@@ -1,0 +1,303 @@
+/**
+ * Coverage Matrix -- surface x checker(s) x last-verified-at.
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001.
+ *
+ * The surface list is mechanically regenerated from real sources (never hand-enumerated), so a
+ * brand-new surface auto-appears with checker_ids=[] instead of being silently unwatched. A
+ * surface that vanishes from its source is marked status='stale', never deleted.
+ *
+ * Six surface classes are covered here (the periodic_process class is a documented placeholder,
+ * not a real registry -- SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 is still draft/LEAD and has
+ * no registry to consume as of this SD):
+ *   - db_table: information_schema.tables (public schema, minus config/coverage-matrix-exclusions.json)
+ *   - message_lane: distinct session_coordination.message_type + payload->>'signal_type' values
+ *   - application: applications table (deleted_at IS NULL)
+ *   - work_item_type: a fixed set of known SD/QF/feedback/decision/ledger tables + gauge-registry.js entries
+ *   - institutional_memory: repo-local memory/*.md files (cross-session memory explicitly out of scope)
+ *   - periodic_process: single pending_dependency placeholder row
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const RECENT_ACTIVITY_WINDOW_DAYS = 30;
+
+// A single row per (SD-key, QF-id, feedback-category-family, decision-family, ledger) surface --
+// each entry is a real, already-shipped table, not a hypothetical one.
+export const WORK_ITEM_TYPE_TABLES = [
+  'strategic_directives_v2',
+  'quick_fixes',
+  'feedback',
+  'leo_feedback',
+  'chairman_decisions',
+  'governance_decisions',
+  'venture_decisions',
+  'eva_decisions',
+  'shipping_decisions',
+  'ehg_design_decisions',
+  'adam_task_ledger',
+  'adam_adherence_ledger',
+  'bypass_ledger',
+  'conversion_ledger',
+  'solomon_advice_outcome_ledger',
+  'tool_usage_ledger',
+  'venture_token_ledger',
+  'venture_write_ledger',
+  'eva_event_ledger',
+];
+
+export const EXTERNAL_CHANNELS = ['email_resend', 'github', 'hosting', 'phone_notify'];
+
+export function loadJsonConfig(relativePath) {
+  const raw = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+  return JSON.parse(raw);
+}
+
+export function isExcludedTable(tableName, exclusions) {
+  if (exclusions.db_table_name_exclusions?.includes(tableName)) return true;
+  return (exclusions.db_table_name_prefix_exclusions || []).some((prefix) => tableName.startsWith(prefix));
+}
+
+/** Substring match against a human-curated map -- deliberately not regex, so the config stays auditable. */
+export function matchCheckerIds(surfaceClass, surfaceKey, checkerMapEntries) {
+  const matched = checkerMapEntries
+    .filter((e) => e.surface_class === surfaceClass && surfaceKey.includes(e.pattern))
+    .flatMap((e) => e.checker_ids);
+  return [...new Set(matched)];
+}
+
+function isRecentlyActive(lastActivityIso) {
+  if (!lastActivityIso) return false;
+  const ageMs = Date.now() - new Date(lastActivityIso).getTime();
+  return ageMs <= RECENT_ACTIVITY_WINDOW_DAYS * 86400000;
+}
+
+/**
+ * DB-table enumeration requires a raw system-catalog query (pg_class/information_schema), which
+ * PostgREST does not expose and this project has no `exec_sql`/`execute_sql` RPC for (confirmed
+ * live, 2026-07-04: PGRST202 "could not find the function" -- documented here so a future
+ * maintainer does not reintroduce an RPC-based attempt). The canonical live mechanism already
+ * used by scripts/lint/schema-reference-snapshot.mjs is a direct `pg` Client connection via
+ * SUPABASE_POOLER_URL -- this function takes that connected pgClient, not the supabase-js client.
+ *
+ * @param {import('pg').Client} pgClient - an already-connected pg client
+ */
+export async function enumerateDbTables(pgClient, exclusions) {
+  const { rows } = await pgClient.query(`
+    SELECT t.table_name,
+           COALESCE(s.n_live_tup, 0) AS live_rows
+    FROM information_schema.tables t
+    LEFT JOIN pg_stat_user_tables s
+      ON s.relname = t.table_name AND s.schemaname = t.table_schema
+    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
+    ORDER BY t.table_name
+  `);
+
+  return rows
+    .filter((row) => !isExcludedTable(row.table_name, exclusions))
+    .map((row) => ({
+      surface_key: row.table_name,
+      // Row-count-based activity is a pragmatic proxy, not literal 30-day windowing -- most
+      // tables lack a uniform updated_at column, so "has real data" is the honest signal
+      // available today (documented in the PRD, not a silent simplification).
+      is_active: Number(row.live_rows) > 0,
+    }));
+}
+
+const MESSAGE_LANE_LOOKBACK_DAYS = 90;
+
+/**
+ * Message-lane surfaces come from two distinct sources:
+ *   - `message_type` is a Postgres ENUM (`coordination_message_type`) -- its full label set is
+ *     read from pg_enum via the same pgClient connection used for db_table enumeration, so a
+ *     structurally-defined lane surfaces even if zero messages of that type have been sent yet
+ *     (arguably MORE correct for "unwatched surface" semantics than pure data-driven discovery).
+ *   - `payload->>'signal_type'` is free-form JSONB text with no type-system enumeration
+ *     available; those values are genuinely data-driven, discovered over a bounded 90-day
+ *     lookback window via supabase-js (a full-table scan would not be safe at this table's
+ *     scale). A signal_type used once and never again in >90 days would be missed by this
+ *     window -- an honest, documented coverage gap, not a silent one.
+ *
+ * @param {import('pg').Client} pgClient - an already-connected pg client (for the enum labels)
+ * @param {object} supabase - supabase-js client (for the recent signal_type window)
+ */
+export async function enumerateMessageLanes(pgClient, supabase) {
+  const { rows: enumRows } = await pgClient.query(`
+    SELECT e.enumlabel
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'coordination_message_type'
+    ORDER BY e.enumsortorder
+  `);
+  const messageTypeLanes = enumRows.map((r) => ({ surface_key: r.enumlabel, is_active: true }));
+
+  const since = new Date(Date.now() - MESSAGE_LANE_LOOKBACK_DAYS * 86400000).toISOString();
+  const { data, error } = await supabase
+    .from('session_coordination')
+    .select('payload, created_at')
+    .not('payload->>signal_type', 'is', null)
+    .gte('created_at', since);
+  if (error) throw new Error(`enumerateMessageLanes: signal_type window query failed: ${error.message}`);
+
+  const lastSeenBySignalType = new Map();
+  for (const row of data || []) {
+    const signalType = row.payload?.signal_type;
+    if (!signalType) continue;
+    const existing = lastSeenBySignalType.get(signalType);
+    if (!existing || row.created_at > existing) lastSeenBySignalType.set(signalType, row.created_at);
+  }
+  const signalTypeLanes = [...lastSeenBySignalType.entries()].map(([signalType, lastActivity]) => ({
+    surface_key: signalType,
+    is_active: isRecentlyActive(lastActivity),
+  }));
+
+  return [...messageTypeLanes, ...signalTypeLanes];
+}
+
+export async function enumerateApplications(supabase) {
+  const { data, error } = await supabase
+    .from('applications')
+    .select('normalized_name')
+    .is('deleted_at', null);
+  if (error) throw new Error(`enumerateApplications: query failed: ${error.message}`);
+  return (data || [])
+    .filter((row) => row.normalized_name)
+    .map((row) => ({ surface_key: row.normalized_name, is_active: true }));
+}
+
+export async function enumerateWorkItemTypes(supabase, gaugeRegistry) {
+  // Concurrent, not sequential -- 19 independent head-count round trips run in parallel so
+  // regeneration wall-clock time doesn't scale linearly with the number of known tables.
+  const countResults = await Promise.all(
+    WORK_ITEM_TYPE_TABLES.map((table) => supabase.from(table).select('*', { count: 'exact', head: true }).then((r) => ({ table, ...r })))
+  );
+  const results = countResults.map(({ table, count, error }) => (
+    error
+      // A table listed here that no longer exists/is inaccessible is itself a coverage finding --
+      // record it as inactive rather than aborting the whole enumeration run.
+      ? { surface_key: table, is_active: false, metadata: { enumeration_error: error.message } }
+      : { surface_key: table, is_active: (count || 0) > 0 }
+  ));
+  for (const gauge of gaugeRegistry || []) {
+    results.push({ surface_key: `gauge_registry:${gauge.id}`, is_active: gauge.enabled !== false });
+  }
+  return results;
+}
+
+export function enumerateInstitutionalMemory(memoryDirPath = join(REPO_ROOT, 'memory')) {
+  let files;
+  try {
+    files = readdirSync(memoryDirPath).filter((f) => f.endsWith('.md'));
+  } catch {
+    return [];
+  }
+  return files.map((f) => ({ surface_key: f, is_active: true }));
+}
+
+export function periodicProcessPlaceholderRow() {
+  return {
+    surface_key: 'periodic-process-registry',
+    is_active: false,
+    status: 'pending_dependency',
+    metadata: {
+      reason: 'SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 is still status=draft/phase=LEAD -- no registry exists yet to enumerate real per-process surfaces',
+      depends_on_sd_key: 'SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001',
+    },
+  };
+}
+
+export function enumerateExternalChannels() {
+  return EXTERNAL_CHANNELS.map((key) => ({ surface_key: key, is_active: true }));
+}
+
+/**
+ * Regenerates the full coverage_matrix: enumerates every in-scope surface class, applies the
+ * checker map, upserts rows keyed on (surface_class, surface_key), and marks any previously-seen
+ * surface_key no longer present in its source as status='stale' (never deleted).
+ *
+ * @param {object} supabase - supabase-js client (PostgREST-exposed tables)
+ * @param {import('pg').Client} pgClient - connected pg client (system-catalog introspection:
+ *   db_table enumeration + the coordination_message_type enum's label set)
+ */
+export async function regenerateCoverageMatrix(supabase, pgClient, { exclusions, checkerMapEntries, gaugeRegistry, memoryDirPath } = {}) {
+  const perClass = {
+    db_table: await enumerateDbTables(pgClient, exclusions || {}),
+    message_lane: await enumerateMessageLanes(pgClient, supabase),
+    application: await enumerateApplications(supabase),
+    work_item_type: await enumerateWorkItemTypes(supabase, gaugeRegistry || []),
+    institutional_memory: enumerateInstitutionalMemory(memoryDirPath),
+    periodic_process: [periodicProcessPlaceholderRow()],
+    external_channel: enumerateExternalChannels(),
+  };
+
+  const summary = { upserted: 0, stale: 0, unchecked: 0, covered: 0 };
+  const nowIso = new Date().toISOString();
+
+  for (const [surfaceClass, rows] of Object.entries(perClass)) {
+    const { data: existingRows, error: fetchError } = await supabase
+      .from('coverage_matrix')
+      .select('surface_key')
+      .eq('surface_class', surfaceClass);
+    if (fetchError) throw new Error(`regenerateCoverageMatrix: fetch existing rows failed for ${surfaceClass}: ${fetchError.message}`);
+
+    const currentKeys = new Set(rows.map((r) => r.surface_key));
+    const existingKeys = new Set((existingRows || []).map((r) => r.surface_key));
+
+    // One bulk upsert per surface class instead of one round trip per row -- db_table alone can
+    // be hundreds of rows; a sequential per-row loop made regeneration take minutes.
+    if (rows.length > 0) {
+      const upsertRows = rows.map((row) => {
+        const checkerIds = row.status === 'pending_dependency'
+          ? []
+          : matchCheckerIds(surfaceClass, row.surface_key, checkerMapEntries || []);
+        const status = row.status || (checkerIds.length > 0 ? 'covered' : 'unchecked');
+        summary[status] = (summary[status] || 0) + 1;
+        return {
+          surface_class: surfaceClass,
+          surface_key: row.surface_key,
+          checker_ids: checkerIds,
+          status,
+          is_active: row.is_active,
+          last_verified_at: nowIso,
+          metadata: row.metadata || {},
+        };
+      });
+
+      const { error: upsertError } = await supabase
+        .from('coverage_matrix')
+        .upsert(upsertRows, { onConflict: 'surface_class,surface_key' });
+      if (upsertError) throw new Error(`regenerateCoverageMatrix: bulk upsert failed for ${surfaceClass}: ${upsertError.message}`);
+      summary.upserted += upsertRows.length;
+    }
+
+    const vanishedKeys = [...existingKeys].filter((k) => !currentKeys.has(k));
+    if (vanishedKeys.length > 0) {
+      const { error: staleError } = await supabase
+        .from('coverage_matrix')
+        .update({ status: 'stale', last_verified_at: nowIso })
+        .eq('surface_class', surfaceClass)
+        .in('surface_key', vanishedKeys);
+      if (staleError) throw new Error(`regenerateCoverageMatrix: stale-mark failed for ${surfaceClass}: ${staleError.message}`);
+      summary.stale += vanishedKeys.length;
+    }
+  }
+
+  return summary;
+}
+
+export default {
+  loadJsonConfig,
+  isExcludedTable,
+  matchCheckerIds,
+  enumerateDbTables,
+  enumerateMessageLanes,
+  enumerateApplications,
+  enumerateWorkItemTypes,
+  enumerateInstitutionalMemory,
+  periodicProcessPlaceholderRow,
+  enumerateExternalChannels,
+  regenerateCoverageMatrix,
+};

--- a/scripts/coverage-matrix-referent-audit.mjs
+++ b/scripts/coverage-matrix-referent-audit.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Monthly referent-audit rotation CLI -- SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001.
+ * Usage: node scripts/coverage-matrix-referent-audit.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { runRotation } from '../lib/governance/coverage-matrix-referent-audit.js';
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  console.log('=== Coverage Matrix Referent-Audit Rotation ===');
+  const result = await runRotation(supabase);
+
+  if (result.skipped) {
+    console.log(`Skipped: ${result.reason} (prior run at ${result.priorRun.ran_at})`);
+    return;
+  }
+
+  console.log(`Delta: ${result.delta.new_unchecked.length} new unchecked, ${result.delta.newly_stale.length} newly stale, ${result.delta.newly_dormant.length} newly dormant`);
+  console.log(`Sample-verification candidates: ${result.sampleCandidates.map((c) => `${c.surface_class}/${c.surface_key}`).join(', ') || '(none -- no covered rows yet)'}`);
+  console.log(`Coverage questions emitted: ${result.feedbackIds.length}`);
+}
+
+main().catch((err) => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/coverage-matrix-regenerate.mjs
+++ b/scripts/coverage-matrix-regenerate.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Coverage matrix regeneration CLI -- SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001.
+ * Usage: node scripts/coverage-matrix-regenerate.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { Client } from 'pg';
+import { loadJsonConfig, regenerateCoverageMatrix } from '../lib/governance/coverage-matrix.js';
+import { GAUGE_REGISTRY } from '../lib/governance/gauge-registry.js';
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  if (!process.env.SUPABASE_POOLER_URL) {
+    console.error('SUPABASE_POOLER_URL not set -- required for db_table/message_lane system-catalog introspection.');
+    process.exit(1);
+  }
+  const pgClient = new Client({ connectionString: process.env.SUPABASE_POOLER_URL });
+  await pgClient.connect();
+
+  try {
+    const exclusions = loadJsonConfig('config/coverage-matrix-exclusions.json');
+    const checkerMap = loadJsonConfig('config/coverage-matrix-checker-map.json');
+
+    console.log('=== Coverage Matrix Regeneration ===');
+    const summary = await regenerateCoverageMatrix(supabase, pgClient, {
+      exclusions,
+      checkerMapEntries: checkerMap.entries,
+      gaugeRegistry: GAUGE_REGISTRY,
+    });
+
+    console.log(`Rows upserted: ${summary.upserted}`);
+    console.log(`  covered:     ${summary.covered || 0}`);
+    console.log(`  unchecked:   ${summary.unchecked || 0}`);
+    console.log(`  pending_dependency: ${summary.pending_dependency || 0}`);
+    console.log(`Rows marked stale (vanished from source): ${summary.stale}`);
+  } finally {
+    await pgClient.end();
+  }
+}
+
+main().catch((err) => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/integration/coverage-matrix.test.js
+++ b/tests/integration/coverage-matrix.test.js
@@ -1,0 +1,103 @@
+/**
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001 -- live-DB smoke tests for the coverage-matrix
+ * regeneration job, retrodiction, and referent-audit rotation. Skips cleanly when no real
+ * Supabase credentials are present.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { Client } from 'pg';
+import { HAS_REAL_DB } from '../helpers/db-available.js';
+import { regenerateCoverageMatrix, loadJsonConfig } from '../../lib/governance/coverage-matrix.js';
+import { retrodictSpecimens, RETRODICTION_SPECIMENS } from '../../lib/governance/coverage-matrix-retrodiction.js';
+import { runRotation } from '../../lib/governance/coverage-matrix-referent-audit.js';
+import { GAUGE_REGISTRY } from '../../lib/governance/gauge-registry.js';
+
+const URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const LIVE = HAS_REAL_DB && !!process.env.SUPABASE_POOLER_URL;
+const supabase = LIVE ? createClient(URL, KEY) : null;
+let pgClient;
+
+describe.skipIf(!LIVE)('Coverage matrix (live DB): regeneration, retrodiction, referent-audit', () => {
+  beforeAll(async () => {
+    pgClient = new Client({ connectionString: process.env.SUPABASE_POOLER_URL });
+    await pgClient.connect();
+  });
+
+  afterAll(async () => {
+    if (pgClient) await pgClient.end();
+  });
+
+  it('regeneration run inserts a periodic_process placeholder row referencing the dependency SD, never queries a non-existent registry', async () => {
+    const exclusions = loadJsonConfig('config/coverage-matrix-exclusions.json');
+    const checkerMap = loadJsonConfig('config/coverage-matrix-checker-map.json');
+    await regenerateCoverageMatrix(supabase, pgClient, { exclusions, checkerMapEntries: checkerMap.entries, gaugeRegistry: GAUGE_REGISTRY });
+
+    const { data, error } = await supabase
+      .from('coverage_matrix')
+      .select('surface_key, status, is_active, metadata')
+      .eq('surface_class', 'periodic_process')
+      .eq('surface_key', 'periodic-process-registry')
+      .single();
+
+    expect(error).toBeNull();
+    expect(data.status).toBe('pending_dependency');
+    expect(data.is_active).toBe(false);
+    expect(data.metadata.depends_on_sd_key).toBe('SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001');
+  });
+
+  it('regeneration run enumerates real work_item_type tables (strategic_directives_v2, quick_fixes)', async () => {
+    const { data, error } = await supabase
+      .from('coverage_matrix')
+      .select('surface_key, is_active')
+      .eq('surface_class', 'work_item_type')
+      .in('surface_key', ['strategic_directives_v2', 'quick_fixes']);
+
+    expect(error).toBeNull();
+    expect(data.map((r) => r.surface_key).sort()).toEqual(['quick_fixes', 'strategic_directives_v2']);
+    // strategic_directives_v2 has thousands of live rows -- must read as active, not a placeholder
+    expect(data.find((r) => r.surface_key === 'strategic_directives_v2').is_active).toBe(true);
+  });
+
+  it('db_table surface class is populated from real information_schema introspection (not empty)', async () => {
+    const { count, error } = await supabase.from('coverage_matrix').select('*', { count: 'exact', head: true }).eq('surface_class', 'db_table');
+    expect(error).toBeNull();
+    expect(count).toBeGreaterThan(50); // this project has hundreds of real public tables
+  });
+
+  it('message_lane surface class includes structural coordination_message_type enum labels', async () => {
+    const { data, error } = await supabase.from('coverage_matrix').select('surface_key').eq('surface_class', 'message_lane');
+    expect(error).toBeNull();
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  it('a second consecutive regeneration run is idempotent: row count for a stable surface class does not change', async () => {
+    const { count: before } = await supabase.from('coverage_matrix').select('*', { count: 'exact', head: true }).eq('surface_class', 'work_item_type');
+
+    const exclusions = loadJsonConfig('config/coverage-matrix-exclusions.json');
+    const checkerMap = loadJsonConfig('config/coverage-matrix-checker-map.json');
+    await regenerateCoverageMatrix(supabase, pgClient, { exclusions, checkerMapEntries: checkerMap.entries, gaugeRegistry: GAUGE_REGISTRY });
+
+    const { count: after } = await supabase.from('coverage_matrix').select('*', { count: 'exact', head: true }).eq('surface_class', 'work_item_type');
+    expect(after).toBe(before);
+  });
+
+  it('retrodicts all 4 chairman-caught specimens against the real, freshly-regenerated matrix', async () => {
+    const results = await retrodictSpecimens(supabase);
+    expect(results).toHaveLength(RETRODICTION_SPECIMENS.length);
+    // None of the 4 specimens' surface_keys have a curated checker-map entry today, so each
+    // must retrodict as 'pass' (genuinely unchecked) -- a real, non-trivial live assertion.
+    for (const result of results) {
+      expect(result.verdict).toBe('pass');
+    }
+  });
+
+  it('referent-audit rotation cold-starts or runs without throwing, and a second run in the same period is a no-op', async () => {
+    const first = await runRotation(supabase);
+    expect(first).toBeDefined();
+
+    const second = await runRotation(supabase);
+    expect(second.skipped).toBe(true);
+    expect(second.reason).toBe('already_ran_this_period');
+  });
+});

--- a/tests/unit/governance/coverage-matrix-referent-audit.test.js
+++ b/tests/unit/governance/coverage-matrix-referent-audit.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001, FR-6 -- unit coverage for the monthly referent-audit
+ * rotation's decision logic (delta computation, sample selection, period-idempotency), using
+ * injected-stub Supabase clients.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectSampleVerificationCandidates, runRotation } from '../../../lib/governance/coverage-matrix-referent-audit.js';
+
+describe('selectSampleVerificationCandidates', () => {
+  it('selects at most 3 candidates by default', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({ surface_class: 'db_table', surface_key: `t${i}` }));
+    expect(selectSampleVerificationCandidates(rows)).toHaveLength(3);
+  });
+
+  it('returns all rows (not padded/duplicated) when fewer than the sample size exist', () => {
+    const rows = [{ surface_class: 'db_table', surface_key: 't0' }];
+    expect(selectSampleVerificationCandidates(rows)).toEqual(rows);
+  });
+
+  it('returns an empty array (not a throw) with zero covered rows', () => {
+    expect(selectSampleVerificationCandidates([])).toEqual([]);
+  });
+});
+
+function fakeSupabase({ priorRunThisMonth = null, lastRun = null, coverageMatrixRows = [], coveredRows = [] } = {}) {
+  const insertedRuns = [];
+  const insertedFeedback = [];
+  return {
+    insertedRuns,
+    insertedFeedback,
+    from: (table) => {
+      if (table === 'coverage_matrix_rotation_runs') {
+        return {
+          select: () => ({
+            gte: () => ({ limit: () => Promise.resolve({ data: priorRunThisMonth ? [priorRunThisMonth] : [], error: null }) }),
+            order: () => ({ limit: () => ({ maybeSingle: () => Promise.resolve({ data: lastRun, error: null }) }) }),
+          }),
+          insert: (row) => { insertedRuns.push(row); return Promise.resolve({ error: null }); },
+        };
+      }
+      if (table === 'coverage_matrix') {
+        return {
+          select: (cols) => {
+            // computeDelta selects is_active/first_seen_at (needs .gt or bare-await for cold start);
+            // the covered-rows fetch selects only surface_class/surface_key then .eq('status', 'covered').
+            const isDeltaQuery = cols?.includes('is_active');
+            const data = isDeltaQuery ? coverageMatrixRows : coveredRows;
+            const thenableQuery = Promise.resolve({ data, error: null });
+            thenableQuery.gt = () => Promise.resolve({ data: coverageMatrixRows, error: null });
+            thenableQuery.eq = () => Promise.resolve({ data: coveredRows, error: null });
+            return thenableQuery;
+          },
+        };
+      }
+      if (table === 'feedback') {
+        return {
+          insert: (row) => ({
+            select: () => ({
+              single: () => {
+                const id = `fb-${insertedFeedback.length + 1}`;
+                insertedFeedback.push({ id, row });
+                return Promise.resolve({ data: { id }, error: null });
+              },
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('runRotation', () => {
+  it('is a no-op when a rotation already ran this calendar month', async () => {
+    const sb = fakeSupabase({ priorRunThisMonth: { id: 'r1', ran_at: new Date().toISOString() } });
+    const result = await runRotation(sb);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('already_ran_this_period');
+  });
+
+  it('cold-starts (no prior rotation row) by treating the whole matrix as delta without throwing', async () => {
+    const sb = fakeSupabase({
+      priorRunThisMonth: null,
+      lastRun: null,
+      coverageMatrixRows: [{ surface_class: 'db_table', surface_key: 'new_table', status: 'unchecked', is_active: true, first_seen_at: '2026-01-01', updated_at: '2026-01-01' }],
+      coveredRows: [{ surface_class: 'db_table', surface_key: 'covered_table' }],
+    });
+    const result = await runRotation(sb);
+    expect(result.skipped).toBe(false);
+    expect(result.delta.new_unchecked).toHaveLength(1);
+    expect(result.sampleCandidates).toHaveLength(1);
+    expect(sb.insertedRuns).toHaveLength(1);
+  });
+
+  it('emits a delta feedback item plus one per sample candidate', async () => {
+    const sb = fakeSupabase({
+      coverageMatrixRows: [{ surface_class: 'db_table', surface_key: 'new_table', status: 'unchecked', is_active: true, first_seen_at: '2026-01-01', updated_at: '2026-01-01' }],
+      coveredRows: [{ surface_class: 'db_table', surface_key: 'covered_table' }],
+    });
+    const result = await runRotation(sb);
+    expect(result.feedbackIds).toHaveLength(2); // 1 delta + 1 sample candidate
+    expect(sb.insertedFeedback).toHaveLength(2);
+  });
+
+  it('emits zero feedback items when there is no delta and no covered rows to sample', async () => {
+    const sb = fakeSupabase({ coverageMatrixRows: [], coveredRows: [] });
+    const result = await runRotation(sb);
+    expect(result.feedbackIds).toHaveLength(0);
+  });
+});

--- a/tests/unit/governance/coverage-matrix-retrodiction.test.js
+++ b/tests/unit/governance/coverage-matrix-retrodiction.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001, FR-5 -- unit coverage for per-specimen retrodiction
+ * verdicts against injected-stub coverage_matrix rows.
+ */
+import { describe, it, expect } from 'vitest';
+import { RETRODICTION_SPECIMENS, retrodictSpecimens } from '../../../lib/governance/coverage-matrix-retrodiction.js';
+
+function fakeSupabase(rowsBySpecimenId) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: (col1, val1) => ({
+          eq: (col2, val2) => ({
+            maybeSingle: () => {
+              const specimen = RETRODICTION_SPECIMENS.find((s) => s.surface_class === val1 && s.surface_key === val2);
+              const row = specimen ? rowsBySpecimenId[specimen.id] : undefined;
+              return Promise.resolve({ data: row ?? null, error: null });
+            },
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('retrodictSpecimens', () => {
+  it('all 4 specimens get an individual verdict, not a single aggregate claim', async () => {
+    const rows = Object.fromEntries(RETRODICTION_SPECIMENS.map((s) => [s.id, { checker_ids: [], is_active: true, status: 'unchecked' }]));
+    const results = await retrodictSpecimens(fakeSupabase(rows));
+    expect(results).toHaveLength(4);
+    expect(results.map((r) => r.id).sort()).toEqual(['comms-lane', 'product-touch', 'qf-scanning', 'scope-coverage'].sort());
+  });
+
+  it('a specimen with empty checker_ids retrodicts as pass (was genuinely unchecked)', async () => {
+    const rows = { 'product-touch': { checker_ids: [], is_active: true, status: 'unchecked' } };
+    const results = await retrodictSpecimens(fakeSupabase(rows));
+    const productTouch = results.find((r) => r.id === 'product-touch');
+    expect(productTouch.verdict).toBe('pass');
+  });
+
+  it('a specimen with real checker coverage AND is_active retrodicts as fail (would not have been caught by this matrix)', async () => {
+    const rows = { 'product-touch': { checker_ids: ['some-real-checker.mjs'], is_active: true, status: 'covered' } };
+    const results = await retrodictSpecimens(fakeSupabase(rows));
+    const productTouch = results.find((r) => r.id === 'product-touch');
+    expect(productTouch.verdict).toBe('fail');
+  });
+
+  it('a specimen missing from the matrix entirely retrodicts as fail with a descriptive reason, not a silent pass', async () => {
+    const results = await retrodictSpecimens(fakeSupabase({}));
+    expect(results.every((r) => r.verdict === 'fail')).toBe(true);
+    expect(results[0].evidence.reason).toBe('surface_not_in_matrix');
+  });
+});

--- a/tests/unit/governance/coverage-matrix.test.js
+++ b/tests/unit/governance/coverage-matrix.test.js
@@ -3,7 +3,7 @@
  * decision logic (checker-map matching, exclusion filtering, enumeration + upsert/stale logic),
  * using injected-stub Supabase clients so the pure logic is exercised without a live DB.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,6 +16,7 @@ import {
   enumerateApplications,
   enumerateDbTables,
   enumerateMessageLanes,
+  enumerateWorkItemTypes,
   regenerateCoverageMatrix,
 } from '../../../lib/governance/coverage-matrix.js';
 
@@ -151,6 +152,38 @@ describe('enumerateMessageLanes (pg client enum + supabase signal_type window)',
       { surface_key: 'SAVE_WARNING', is_active: true },
       { surface_key: 'stuck', is_active: true },
     ]));
+  });
+});
+
+describe('enumerateWorkItemTypes: to_regclass existence check', () => {
+  it('marks a table that to_regclass reports missing as inactive without ever issuing the count query for it (avoids the documented head/count false-positive-on-missing-table gotcha)', async () => {
+    let countQueriesIssued = 0;
+    const pgClient = {
+      query: () => Promise.resolve({ rows: [{ table_name: 'strategic_directives_v2', exists_check: false }] }),
+    };
+    const supabase = {
+      from: (table) => ({
+        select: () => { countQueriesIssued += 1; return Promise.resolve({ count: 5, error: null }); },
+      }),
+    };
+    const results = await enumerateWorkItemTypes(supabase, [], pgClient);
+    const sdRow = results.find((r) => r.surface_key === 'strategic_directives_v2');
+    expect(sdRow.is_active).toBe(false);
+    expect(sdRow.metadata.enumeration_error).toMatch(/does not exist/);
+  });
+
+  it('falls back to count-only behavior when no pgClient is provided (backward compatible)', async () => {
+    const supabase = { from: () => ({ select: () => Promise.resolve({ count: 3, error: null }) }) };
+    const results = await enumerateWorkItemTypes(supabase, []);
+    expect(results.every((r) => r.is_active === true)).toBe(true);
+  });
+
+  it('falls back gracefully when the batched to_regclass query itself fails', async () => {
+    const pgClient = { query: () => Promise.reject(new Error('connection reset')) };
+    const supabase = { from: () => ({ select: () => Promise.resolve({ count: 0, error: null }) }) };
+    const results = await enumerateWorkItemTypes(supabase, [], pgClient);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.is_active === false)).toBe(true);
   });
 });
 

--- a/tests/unit/governance/coverage-matrix.test.js
+++ b/tests/unit/governance/coverage-matrix.test.js
@@ -1,0 +1,204 @@
+/**
+ * SD-LEO-INFRA-COVERAGE-MATRIX-SURFACE-001 -- unit coverage for coverage-matrix.js's pure
+ * decision logic (checker-map matching, exclusion filtering, enumeration + upsert/stale logic),
+ * using injected-stub Supabase clients so the pure logic is exercised without a live DB.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  isExcludedTable,
+  matchCheckerIds,
+  enumerateInstitutionalMemory,
+  periodicProcessPlaceholderRow,
+  enumerateExternalChannels,
+  enumerateApplications,
+  enumerateDbTables,
+  enumerateMessageLanes,
+  regenerateCoverageMatrix,
+} from '../../../lib/governance/coverage-matrix.js';
+
+describe('isExcludedTable', () => {
+  it('excludes a table listed by exact name', () => {
+    expect(isExcludedTable('schema_migrations', { db_table_name_exclusions: ['schema_migrations'] })).toBe(true);
+  });
+
+  it('excludes a table matching a prefix', () => {
+    expect(isExcludedTable('staging_orders', { db_table_name_prefix_exclusions: ['staging_'] })).toBe(true);
+  });
+
+  it('does not exclude an unrelated table', () => {
+    expect(isExcludedTable('strategic_directives_v2', { db_table_name_exclusions: ['schema_migrations'], db_table_name_prefix_exclusions: ['staging_'] })).toBe(false);
+  });
+});
+
+describe('matchCheckerIds', () => {
+  const entries = [
+    { surface_class: 'db_table', pattern: 'merge_witness_telemetry', checker_ids: ['lib/ship/merge-witness-ladder.mjs'] },
+    { surface_class: 'work_item_type', pattern: 'gauge_registry', checker_ids: ['scripts/gauge-runner.mjs'] },
+  ];
+
+  it('matches a known surface_key by substring within the correct surface_class', () => {
+    expect(matchCheckerIds('db_table', 'merge_witness_telemetry', entries)).toEqual(['lib/ship/merge-witness-ladder.mjs']);
+  });
+
+  it('does not match across surface classes', () => {
+    expect(matchCheckerIds('message_lane', 'merge_witness_telemetry', entries)).toEqual([]);
+  });
+
+  it('returns empty (checker=NONE) for an unmapped surface -- the intended default, not an error', () => {
+    expect(matchCheckerIds('db_table', 'some_brand_new_table', entries)).toEqual([]);
+  });
+
+  it('dedupes checker_ids across multiple matching entries', () => {
+    const dupeEntries = [
+      { surface_class: 'db_table', pattern: 'foo', checker_ids: ['a.mjs'] },
+      { surface_class: 'db_table', pattern: 'foo_bar', checker_ids: ['a.mjs', 'b.mjs'] },
+    ];
+    expect(matchCheckerIds('db_table', 'foo_bar_table', dupeEntries).sort()).toEqual(['a.mjs', 'b.mjs']);
+  });
+});
+
+describe('enumerateInstitutionalMemory', () => {
+  it('enumerates repo-local memory/*.md files, ignoring non-md files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'coverage-matrix-memory-'));
+    writeFileSync(join(dir, 'feedback_example.md'), '# example');
+    writeFileSync(join(dir, 'notes.txt'), 'not markdown');
+    const result = enumerateInstitutionalMemory(dir);
+    rmSync(dir, { recursive: true, force: true });
+
+    expect(result).toEqual([{ surface_key: 'feedback_example.md', is_active: true }]);
+  });
+
+  it('returns an empty array (not a throw) when the memory directory does not exist', () => {
+    expect(enumerateInstitutionalMemory('/nonexistent/path/xyz')).toEqual([]);
+  });
+});
+
+describe('periodicProcessPlaceholderRow', () => {
+  it('is status=pending_dependency and references the dependency SD by key', () => {
+    const row = periodicProcessPlaceholderRow();
+    expect(row.status).toBe('pending_dependency');
+    expect(row.is_active).toBe(false);
+    expect(row.metadata.depends_on_sd_key).toBe('SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001');
+  });
+});
+
+describe('enumerateExternalChannels', () => {
+  it('returns the 4 known static channels, all active', () => {
+    const rows = enumerateExternalChannels();
+    expect(rows).toHaveLength(4);
+    expect(rows.every((r) => r.is_active)).toBe(true);
+  });
+});
+
+describe('enumerateApplications', () => {
+  it('excludes soft-deleted applications via the deleted_at IS NULL filter', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          is: () => Promise.resolve({ data: [{ normalized_name: 'ehg-engineer' }, { normalized_name: 'ehg' }], error: null }),
+        }),
+      }),
+    };
+    const rows = await enumerateApplications(supabase);
+    expect(rows).toEqual([
+      { surface_key: 'ehg-engineer', is_active: true },
+      { surface_key: 'ehg', is_active: true },
+    ]);
+  });
+
+  it('throws with a descriptive error on query failure rather than silently returning []', async () => {
+    const supabase = { from: () => ({ select: () => ({ is: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) };
+    await expect(enumerateApplications(supabase)).rejects.toThrow(/boom/);
+  });
+});
+
+describe('enumerateDbTables (pg client)', () => {
+  it('excludes configured tables and reports is_active from live_rows', async () => {
+    const pgClient = {
+      query: () => Promise.resolve({
+        rows: [
+          { table_name: 'strategic_directives_v2', live_rows: '4890' },
+          { table_name: 'staging_temp', live_rows: '0' },
+        ],
+      }),
+    };
+    const rows = await enumerateDbTables(pgClient, { db_table_name_prefix_exclusions: ['staging_'] });
+    expect(rows).toEqual([{ surface_key: 'strategic_directives_v2', is_active: true }]);
+  });
+});
+
+describe('enumerateMessageLanes (pg client enum + supabase signal_type window)', () => {
+  it('combines structural enum labels (always active) with data-driven signal_type lanes', async () => {
+    const pgClient = { query: () => Promise.resolve({ rows: [{ enumlabel: 'STOP_REQUESTED' }, { enumlabel: 'SAVE_WARNING' }] }) };
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          not: () => ({
+            gte: () => Promise.resolve({
+              data: [{ payload: { signal_type: 'stuck' }, created_at: new Date().toISOString() }],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+    const rows = await enumerateMessageLanes(pgClient, supabase);
+    expect(rows).toEqual(expect.arrayContaining([
+      { surface_key: 'STOP_REQUESTED', is_active: true },
+      { surface_key: 'SAVE_WARNING', is_active: true },
+      { surface_key: 'stuck', is_active: true },
+    ]));
+  });
+});
+
+describe('regenerateCoverageMatrix: stale-marking on vanished surfaces', () => {
+  it('marks a previously-seen surface_key as stale (never deletes) when it no longer appears in the current enumeration', async () => {
+    const upserts = [];
+    const staleUpdates = [];
+
+    const pgClient = {
+      query: () => Promise.resolve({ rows: [] }), // db_table query + enum-label query both empty
+    };
+
+    const supabase = {
+      from: (table) => {
+        if (table === 'applications') return { select: () => ({ is: () => Promise.resolve({ data: [], error: null }) }) };
+        if (table === 'session_coordination') {
+          return { select: () => ({ not: () => ({ gte: () => Promise.resolve({ data: [], error: null }) }) }) };
+        }
+        if (table === 'coverage_matrix') {
+          return {
+            select: () => ({
+              eq: (col, val) => {
+                if (col === 'surface_class' && val === 'db_table') {
+                  return Promise.resolve({ data: [{ surface_key: 'vanished_table' }], error: null });
+                }
+                return Promise.resolve({ data: [], error: null });
+              },
+            }),
+            upsert: (rows) => { upserts.push(...rows); return Promise.resolve({ error: null }); },
+            update: (patch) => ({
+              eq: () => ({
+                in: (col, keys) => { staleUpdates.push({ patch, keys }); return Promise.resolve({ error: null }); },
+              }),
+            }),
+          };
+        }
+        // work_item_type tables: count=0, no rows
+        return { select: () => Promise.resolve({ count: 0, error: null }) };
+      },
+    };
+
+    const summary = await regenerateCoverageMatrix(supabase, pgClient, { exclusions: {}, checkerMapEntries: [], gaugeRegistry: [], memoryDirPath: '/nonexistent-test-path-for-hermetic-unit-test' });
+
+    expect(staleUpdates).toHaveLength(1);
+    expect(staleUpdates[0].patch.status).toBe('stale');
+    expect(staleUpdates[0].keys).toEqual(['vanished_table']);
+    // The vanished table is never in the upsert list -- it is marked stale via update, not re-inserted
+    expect(upserts.find((u) => u.surface_key === 'vanished_table')).toBeUndefined();
+    expect(summary.stale).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Institutionalizes the chairman's referent-audit gap-catching method: a durable `coverage_matrix` table (surface x checker(s) x last-verified-at) whose surface list is **mechanically regenerated** across 6 real sources, so a brand-new surface auto-appears as `checker_ids=[]` instead of being silently unwatched.
- Surface classes: DB tables (direct `pg` connection introspection), message lanes (the `coordination_message_type` enum + a bounded `signal_type` window), applications, work-item-type tables (SDs/QFs/feedback/decisions/ledgers/gauge-registry), repo-local institutional memory, and a documented `pending_dependency` placeholder for the still-draft periodic-process registry (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001).
- Retrodicts the 4 chairman-caught gaps (product-touch, scope-coverage, comms-lane, QF-scanning) against the live matrix.
- Monthly referent-audit rotation: computes the delta since last run, selects sample-verification candidates, and emits coverage questions to the `feedback` table rather than self-verifying (anti-Goodhart: closure by a different actor than the one scored).

## Real findings during EXEC
- No `exec_sql`/`execute_sql` RPC exists on this Supabase project (confirmed live: `PGRST202`). DB-table and message-type-enum enumeration required a direct `pg` Client via `SUPABASE_POOLER_URL`, matching the existing pattern in `scripts/lint/schema-reference-snapshot.mjs`.
- Sequential per-row upserts took >92s and timed out; batched into one bulk upsert per surface class, bringing the full live integration suite to ~3.75s.

## Test plan
- [x] 27 unit tests (injected-stub Supabase/pg clients, no live DB) — checker-map matching, exclusion filtering, enumeration logic, stale-marking, retrodiction verdicts, rotation idempotency
- [x] 7 live-DB integration tests — periodic-process placeholder, real work-item-type enumeration, db_table count, message-lane enum labels, idempotent regeneration, retrodiction against real data, rotation cold-start + period-idempotency
- [x] DESIGN, DATABASE, RISK, STORIES, TESTING sub-agents all PASS
- [x] Live CLI run: `node scripts/coverage-matrix-regenerate.mjs` → 849 rows, 25 covered, 823 unchecked, 1 pending_dependency
- [x] Live CLI run: `node scripts/coverage-matrix-referent-audit.mjs` → correctly idempotent within the same period

🤖 Generated with [Claude Code](https://claude.com/claude-code)