### PR TITLE
feat(SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001): universal venture telemetry rail (record_venture_error RPC + RLS fixes)

### DIFF
--- a/database/migrations/20260704d_venture_error_aggregation_rpc.sql
+++ b/database/migrations/20260704d_venture_error_aggregation_rpc.sql
@@ -1,0 +1,216 @@
+-- Migration: Venture Error Aggregation RPC (anon-safe, storm-resistant)
+-- SD: SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 (FR-2)
+-- Purpose: extend the feedback table's feedback_type CHECK to add 'venture_error',
+--          and add a SECURITY DEFINER RPC (record_venture_error) the anon role can
+--          EXECUTE to safely aggregate venture-forwarded application errors —
+--          the client NEVER writes occurrence_count/first_seen/last_seen directly,
+--          only this function's internal server-side logic does. Mirrors the
+--          established SECURITY DEFINER pattern from
+--          20260401_venture_user_feedback_channel.sql (check_feedback_rate_limit),
+--          extended with a fixed search_path (SECURITY sub-agent condition C1) and
+--          a per-venture distinct-fingerprint storm ceiling (C6) that the sibling
+--          migration's plain-INSERT feedback path doesn't need.
+-- Date: 2026-07-04
+
+BEGIN;
+
+-- ============================================================
+-- 1. Extend feedback_type CHECK to add 'venture_error'
+-- ============================================================
+ALTER TABLE public.feedback
+  DROP CONSTRAINT IF EXISTS feedback_feedback_type_check;
+
+ALTER TABLE public.feedback
+  ADD CONSTRAINT feedback_feedback_type_check
+  CHECK (feedback_type IN (
+    'sentry_error',
+    'user_bug',
+    'user_feature_request',
+    'user_usability',
+    'user_other',
+    'venture_error'
+  ));
+
+-- ============================================================
+-- 2. Partial unique index — the ON CONFLICT arbiter for the RPC's UPSERT.
+--    SECURITY condition C3: scoped to feedback_type='venture_error' only, so
+--    the RPC can never match/increment a 'sentry_error' row (no cross-type
+--    forge-increment via a shared (venture_id, error_hash) collision).
+-- ============================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feedback_venture_error_hash
+  ON public.feedback (venture_id, error_hash)
+  WHERE feedback_type = 'venture_error' AND venture_id IS NOT NULL;
+
+-- ============================================================
+-- 3. Per-venture distinct-fingerprint storm ceiling (SECURITY condition C6).
+--    A repeat of an ALREADY-SEEN error_hash for a venture always aggregates
+--    normally (the whole point of dedup). A NEW distinct fingerprint past the
+--    ceiling within the trailing window is NOT inserted as its own row —
+--    instead a per-venture watermark row is bumped, so a storm of distinct
+--    fingerprints is fail-closed-but-counted (observable), never silently
+--    dropped and never floods the chairman's inbox with N distinct rows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._venture_error_storm_watermark_hash()
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  -- Fixed sentinel hash (64 hex chars, same charset as a real sha256 error_hash)
+  -- reserved for the per-venture storm watermark row. Never a real error_hash.
+  SELECT 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+$$;
+
+-- ============================================================
+-- 4. record_venture_error RPC.
+--    SECURITY condition C1: search_path pinned so the function cannot be
+--    tricked by a session-level search_path override into resolving an
+--    attacker-controlled object.
+--    SECURITY condition C2: SECURITY DEFINER + GRANT EXECUTE (not a table
+--    grant) is the ONLY way the anon role can write these columns.
+--    SECURITY condition C4: p_error_hash validated to a fixed hex charset
+--    and length before use, preventing hash-collision gaming and unbounded
+--    distinct-fingerprint cardinality abuse.
+--    SECURITY condition C5: no dynamic SQL; p_message length-capped;
+--    p_context size-bounded via jsonb (no unbounded text concatenation).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.record_venture_error(
+  p_venture_id uuid,
+  p_error_hash text,
+  p_message text,
+  p_context jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_ceiling constant integer := 20; -- distinct fingerprints per venture per hour
+  v_window constant interval := interval '1 hour';
+  v_distinct_count integer;
+  v_watermark_hash text := public._venture_error_storm_watermark_hash();
+  v_existing_row_id uuid;
+  v_result jsonb;
+BEGIN
+  -- Validate error_hash: exactly 64 lowercase hex chars (sha256-shaped).
+  IF p_error_hash IS NULL OR p_error_hash !~ '^[0-9a-f]{64}$' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_error_hash');
+  END IF;
+
+  -- Bound message/context size (defense-in-depth; app-side already caps these).
+  IF p_message IS NOT NULL AND length(p_message) > 2000 THEN
+    p_message := left(p_message, 2000);
+  END IF;
+  IF p_context IS NOT NULL AND octet_length(p_context::text) > 8000 THEN
+    p_context := jsonb_build_object('truncated', true);
+  END IF;
+
+  -- Venture must exist, not be soft-deleted, and not have ingestion explicitly
+  -- disabled (FR-4 revocation — metadata->>'telemetry_ingestion_enabled'='false').
+  -- Absent/null means enabled (existing ventures are not silently disabled).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.ventures v
+    WHERE v.id = p_venture_id
+      AND v.deleted_at IS NULL
+      AND COALESCE(v.metadata->>'telemetry_ingestion_enabled', 'true') <> 'false'
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'venture_not_eligible');
+  END IF;
+
+  -- Repeat of an already-seen fingerprint: always aggregate, ceiling doesn't apply.
+  SELECT id INTO v_existing_row_id
+  FROM public.feedback
+  WHERE venture_id = p_venture_id
+    AND feedback_type = 'venture_error'
+    AND error_hash = p_error_hash
+  LIMIT 1;
+
+  IF v_existing_row_id IS NOT NULL THEN
+    UPDATE public.feedback
+    SET occurrence_count = occurrence_count + 1,
+        last_seen = now(),
+        updated_at = now()
+    WHERE id = v_existing_row_id;
+
+    RETURN jsonb_build_object('ok', true, 'action', 'aggregated', 'id', v_existing_row_id);
+  END IF;
+
+  -- New distinct fingerprint: check the per-venture storm ceiling.
+  SELECT count(DISTINCT error_hash) INTO v_distinct_count
+  FROM public.feedback
+  WHERE venture_id = p_venture_id
+    AND feedback_type = 'venture_error'
+    AND error_hash <> v_watermark_hash
+    AND created_at > now() - v_window;
+
+  IF v_distinct_count >= v_ceiling THEN
+    -- Fail closed-but-counted: bump the per-venture watermark, do not create
+    -- a new per-fingerprint row. Observable — a watermark spike is an alertable
+    -- "this venture is storming" signal, not a silent drop.
+    INSERT INTO public.feedback (
+      venture_id, feedback_type, source_type, source_application,
+      error_hash, error_message, occurrence_count, first_seen, last_seen,
+      title, description, type, status, severity
+    ) VALUES (
+      p_venture_id, 'venture_error', 'error_capture',
+      (SELECT name FROM public.ventures WHERE id = p_venture_id),
+      v_watermark_hash, '[STORM SUPPRESSED] distinct-fingerprint ceiling exceeded',
+      1, now(), now(),
+      'Venture error storm watermark', 'Distinct-fingerprint ceiling exceeded for this venture in the trailing window',
+      'issue', 'new', 'high'
+    )
+    ON CONFLICT (venture_id, error_hash) WHERE feedback_type = 'venture_error' AND venture_id IS NOT NULL
+    DO UPDATE SET occurrence_count = feedback.occurrence_count + 1, last_seen = now(), updated_at = now();
+
+    RETURN jsonb_build_object('ok', true, 'action', 'storm_suppressed');
+  END IF;
+
+  -- New distinct fingerprint, under the ceiling: insert normally.
+  INSERT INTO public.feedback (
+    venture_id, feedback_type, source_type, source_application,
+    error_hash, error_message, occurrence_count, first_seen, last_seen,
+    title, description, type, status, severity, metadata
+  ) VALUES (
+    p_venture_id, 'venture_error', 'error_capture',
+    (SELECT name FROM public.ventures WHERE id = p_venture_id),
+    p_error_hash, p_message, 1, now(), now(),
+    left(coalesce(p_message, 'Venture error'), 200), coalesce(p_message, ''),
+    'issue', 'new', 'medium', p_context
+  )
+  RETURNING id INTO v_existing_row_id;
+
+  RETURN jsonb_build_object('ok', true, 'action', 'created', 'id', v_existing_row_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_venture_error(uuid, text, text, jsonb)
+  IS 'Anon-callable SECURITY DEFINER RPC: aggregates venture-forwarded application errors into the feedback table. Client never writes occurrence_count/first_seen/last_seen directly. Per-venture distinct-fingerprint storm ceiling fails closed-but-counted via a watermark row. SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 FR-2.';
+
+-- SECURITY condition C2: EXECUTE only, no table-level grant. anon already has
+-- no direct INSERT/UPDATE path to venture_error rows (the existing
+-- venture_user_insert_feedback RLS policy only matches feedback_type LIKE
+-- 'user_%', which 'venture_error' does not) — this REVOKE is defense-in-depth
+-- documentation, not a functional change.
+REVOKE ALL ON FUNCTION public.record_venture_error(uuid, text, text, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_venture_error(uuid, text, text, jsonb) TO anon;
+
+-- ============================================================
+-- 5. Index to support the storm-ceiling window query.
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_feedback_venture_error_created
+  ON public.feedback (venture_id, created_at DESC)
+  WHERE feedback_type = 'venture_error';
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed):
+-- ============================================================
+-- REVOKE EXECUTE ON FUNCTION public.record_venture_error(uuid, text, text, jsonb) FROM anon;
+-- DROP FUNCTION IF EXISTS public.record_venture_error(uuid, text, text, jsonb);
+-- DROP FUNCTION IF EXISTS public._venture_error_storm_watermark_hash();
+-- DROP INDEX IF EXISTS idx_feedback_venture_error_created;
+-- DROP INDEX IF EXISTS idx_feedback_venture_error_hash;
+-- ALTER TABLE public.feedback DROP CONSTRAINT IF EXISTS feedback_feedback_type_check;
+-- ALTER TABLE public.feedback ADD CONSTRAINT feedback_feedback_type_check
+--   CHECK (feedback_type IN ('sentry_error','user_bug','user_feature_request','user_usability','user_other'));

--- a/database/migrations/20260704e_widen_feedback_source_application.sql
+++ b/database/migrations/20260704e_widen_feedback_source_application.sql
@@ -1,0 +1,105 @@
+-- Migration: Widen feedback.source_application varchar(50) -> varchar(255)
+-- SD: SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 (RCA follow-up, TS-7)
+-- Purpose: record_venture_error() (20260704d) and the pre-existing service-role
+--          captureError() writer (lib/factory/feedback-writer.js) both denormalize
+--          the full ventures.name into feedback.source_application, but that column
+--          was varchar(50) while ventures.name is varchar(255) — any venture name
+--          over 50 chars raised PG 22001 "value too long", silently dropping
+--          feedback-writer.js rows (logged + swallowed) and hard-failing the new RPC
+--          (surfaced by TS-7's "TS-fixture-other-<uuid>" fixture name, 53 chars).
+--          9 live ventures already exceed 30 chars. Widening (not truncating) preserves
+--          the exact-name correlation lib/factory/daily-digest.js and
+--          lib/quality/burst-detector.js depend on (.eq('source_application', venture.name)).
+--          Bound to varchar(255) (matching ventures.name), not text, so this stays a
+--          deliberate width match rather than an unbounded column.
+-- Date: 2026-07-04
+--
+-- v_feedback_with_sensemaking is the only view depending on feedback.source_application
+-- (verified via pg_depend) — must be dropped and recreated around the ALTER COLUMN.
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.v_feedback_with_sensemaking;
+
+ALTER TABLE public.feedback
+  ALTER COLUMN source_application TYPE varchar(255);
+
+CREATE VIEW public.v_feedback_with_sensemaking AS
+ SELECT f.id,
+    f.type,
+    f.source_application,
+    f.source_type,
+    f.source_id,
+    f.title,
+    f.description,
+    f.status,
+    f.priority,
+    f.sd_id,
+    f.user_id,
+    f.session_id,
+    f.page_url,
+    f.command,
+    f.environment,
+    f.severity,
+    f.category,
+    f.error_message,
+    f.stack_trace,
+    f.error_hash,
+    f.occurrence_count,
+    f.first_seen,
+    f.last_seen,
+    f.resolution_type,
+    f.value_estimate,
+    f.effort_estimate,
+    f.votes,
+    f.use_case,
+    f.original_type,
+    f.converted_at,
+    f.conversion_reason,
+    f.triaged_at,
+    f.triaged_by,
+    f.snoozed_until,
+    f.ignore_pattern,
+    f.ai_triage_suggestion,
+    f.assigned_to,
+    f.resolution_sd_id,
+    f.resolution_notes,
+    f.created_at,
+    f.updated_at,
+    f.resolved_at,
+    f.cluster_processed_at,
+    f.quick_fix_id,
+    f.strategic_directive_id,
+    f.duplicate_of_id,
+    f.ai_triage_confidence,
+    f.ai_triage_classification,
+    f.ai_triage_source,
+    f.rubric_score,
+    f.quality_assessment,
+    f.metadata,
+    sa.id AS sensemaking_analysis_id,
+    sa.disposition AS sensemaking_disposition,
+    sa.disposition_at AS sensemaking_disposition_at,
+    sa.overall_confidence AS sensemaking_confidence,
+    sa.status AS sensemaking_status
+   FROM feedback f
+     LEFT JOIN sensemaking_analyses sa ON (f.metadata ->> 'sensemaking_correlation_id'::text) = sa.correlation_id;
+
+-- Restore the pre-existing ACL (verified via pg_class.relacl before the drop:
+-- postgres=arwdDxtm, anon=arwdDxtm, authenticated=arwdDxtm, service_role=arwdDxtm --
+-- a blanket "GRANT ALL ON ALL TABLES/VIEWS IN SCHEMA public" pattern, not a
+-- hand-curated per-object grant).
+GRANT ALL ON public.v_feedback_with_sensemaking TO anon, authenticated, service_role;
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed — narrows back to varchar(50); will fail if any
+-- row's source_application already exceeds 50 chars post-widening):
+-- ============================================================
+-- BEGIN;
+-- DROP VIEW IF EXISTS public.v_feedback_with_sensemaking;
+-- ALTER TABLE public.feedback ALTER COLUMN source_application TYPE varchar(50);
+-- CREATE VIEW public.v_feedback_with_sensemaking AS <same SELECT as above>;
+-- GRANT ALL ON public.v_feedback_with_sensemaking TO anon, authenticated, service_role;
+-- COMMIT;

--- a/database/migrations/20260704f_fix_venture_user_feedback_ventures_visibility.sql
+++ b/database/migrations/20260704f_fix_venture_user_feedback_ventures_visibility.sql
@@ -1,0 +1,73 @@
+-- Migration: Fix venture_user_insert_feedback RLS — ventures visibility gap
+-- SD: SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 (RCA follow-up, TS-1)
+-- Purpose: the venture_user_insert_feedback policy (20260401_venture_user_feedback_channel.sql)
+--          gates on `EXISTS (SELECT 1 FROM ventures v WHERE v.id = venture_id AND v.deleted_at
+--          IS NULL)`, evaluated AS THE CALLING ROLE (anon) since it's a plain RLS expression,
+--          not a SECURITY DEFINER function. ventures_select_policy on public.ventures requires
+--          `current_setting('role')='service_role' OR portfolio.has_venture_access(id)` for
+--          ALL roles (including anon) — has_venture_access() is an authenticated-user check
+--          anon can never satisfy. So the EXISTS subquery has returned FALSE for every anon
+--          caller since ventures' own RLS was tightened, silently breaking the ENTIRE
+--          venture_user_insert_feedback INSERT path — confirmed live: a real MarketLens
+--          feedback submission produced a genuine 401 "new row violates row-level security
+--          policy" with the venture demonstrably existing and not deleted.
+--          Fix: move the existence+active check into a SECURITY DEFINER helper function
+--          (mirrors the existing check_feedback_rate_limit pattern) so it runs with the
+--          function owner's privileges, bypassing ventures' RLS for this narrow read, without
+--          granting anon direct table-level SELECT on ventures (which would leak the full
+--          ventures table). Also folds in the FR-4 per-venture ingestion-enabled flag so
+--          feedback forwarding, not just error forwarding, honors venture-scoped revocation.
+-- Date: 2026-07-04
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.venture_exists_and_active(p_venture_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.ventures v
+    WHERE v.id = p_venture_id
+      AND v.deleted_at IS NULL
+      AND COALESCE(v.metadata->>'telemetry_ingestion_enabled', 'true') <> 'false'
+  );
+$$;
+
+COMMENT ON FUNCTION public.venture_exists_and_active(uuid)
+  IS 'SECURITY DEFINER: checks a venture exists, is not soft-deleted, and has telemetry ingestion enabled — bypasses ventures RLS for this narrow read so anon-role RLS policies (e.g. venture_user_insert_feedback) can gate on it without a direct SELECT grant on ventures. SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001.';
+
+REVOKE ALL ON FUNCTION public.venture_exists_and_active(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) TO anon;
+
+DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
+
+CREATE POLICY venture_user_insert_feedback
+  ON public.feedback
+  FOR INSERT
+  TO anon
+  WITH CHECK (
+    feedback_type LIKE 'user_%'
+    AND venture_id IS NOT NULL
+    AND public.venture_exists_and_active(venture_id)
+    AND NOT public.check_feedback_rate_limit(venture_id)
+  );
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed — restores the original, RLS-broken EXISTS subquery):
+-- ============================================================
+-- BEGIN;
+-- DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
+-- CREATE POLICY venture_user_insert_feedback ON public.feedback FOR INSERT TO anon
+--   WITH CHECK (
+--     feedback_type LIKE 'user_%' AND venture_id IS NOT NULL
+--     AND EXISTS (SELECT 1 FROM public.ventures v WHERE v.id = venture_id AND v.deleted_at IS NULL)
+--     AND NOT public.check_feedback_rate_limit(venture_id)
+--   );
+-- REVOKE EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) FROM anon;
+-- DROP FUNCTION IF EXISTS public.venture_exists_and_active(uuid);
+-- COMMIT;

--- a/lib/eva/config/venture-default-capabilities.js
+++ b/lib/eva/config/venture-default-capabilities.js
@@ -21,28 +21,33 @@
  * @module lib/eva/config/venture-default-capabilities
  */
 
-// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: bumped from '2026.04'
-// when the portfolio-default set grew from 2 to 7 capabilities.
-export const DEFAULT_CAPABILITIES_VERSION = '2026.06';
+// SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001: bumped from '2026.06'. feedback-widget
+// and error-capture-middleware descriptions corrected to describe the actual working
+// mechanism (anon-role RLS INSERT + record_venture_error SECURITY DEFINER RPC, both in
+// database/migrations/20260401_venture_user_feedback_channel.sql +
+// database/migrations/20260704d_venture_error_aggregation_rpc.sql) rather than a
+// hypothetical Sentry-DSN integration no venture has actually provisioned — reference
+// implementation: marketlens/src/services/feedback.js + marketlens/src/lib/errorCapture.js.
+export const DEFAULT_CAPABILITIES_VERSION = '2026.07';
 
 export const EHG_VENTURE_DEFAULT_CAPABILITIES = Object.freeze([
   Object.freeze({
     capability_id: 'feedback-widget',
     name: 'Integrate Feedback Widget',
-    description: 'Add a user-facing feedback widget at /feedback that submits to the central `feedback` table with source_application=<venture_slug>, type=enhancement|issue, and dedupes by title. Visible in app header/sidebar.',
+    description: 'Add a user-facing feedback widget at /feedback that forwards to the EHG_Engineer `feedback` table via its anon-role venture_user_insert_feedback RLS INSERT policy (REST `POST /rest/v1/feedback` with an EHG_Engineer anon key, or the mirrored PostgREST endpoint) — no service-role key, no new backend service. Stamp venture_id=<this venture\'s id>, source_application=<venture_slug>, source_type=user_feedback, feedback_type=user_bug|user_feature_request (mapped from the widget\'s issue|enhancement type), and dedupe by title in the venture\'s own local store before forwarding.',
     story_points: 2,
     priority: 'high',
-    acceptance_criteria: 'Feedback page reachable from primary nav; submitted entries land in the central `feedback` table with source_application set to this venture; duplicate-title submissions within 24h are deduplicated server-side; rate limit of 50 submissions/hour/venture enforced.',
+    acceptance_criteria: 'Feedback page reachable from primary nav; submitted entries land in the central `feedback` table with venture_id, source_application, and feedback_type (user_bug|user_feature_request) set correctly; duplicate-title submissions within 24h are deduplicated server-side; the venture_user_insert_feedback policy\'s 50/hour rate ceiling is respected (forwarding failure never blocks the local response).',
     target_stack_components: ['presentation', 'api', 'data'],
     vision_source_section: 'docs/reference/vision/quality-lifecycle-system.md — Multi-Venture Architecture / Per-venture deliverables',
   }),
   Object.freeze({
     capability_id: 'error-capture-middleware',
     name: 'Wire Error Capture Middleware',
-    description: 'Initialize Sentry SDK with venture-scoped DSN; runtime errors are auto-logged to the central `feedback` table via Sentry beforeSend hook with PII redaction (authorization headers, cookies stripped). Includes graceful shutdown via SIGTERM handler.',
+    description: 'Wire runtime error capture that fire-and-forget forwards to the EHG_Engineer `record_venture_error` SECURITY DEFINER RPC (`POST /rest/v1/rpc/record_venture_error` with an EHG_Engineer anon key — no Sentry SDK/DSN required). Compute a sha256 error_hash fingerprint (message + first stack lines) per the RPC\'s 64-hex-char contract; redact PII from headers (authorization, cookie, x-api-key, etc.) and body (password, token, secret, ssn, etc.) before forwarding. The RPC aggregates repeat fingerprints server-side and fails closed-but-counted (a watermark row, never a silent drop) past a per-venture distinct-fingerprint storm ceiling.',
     story_points: 1,
     priority: 'high',
-    acceptance_criteria: 'Sentry SDK initialized at app entrypoint; thrown errors arrive in central `feedback` table within 30s; PII (auth headers, cookies) redacted via beforeSend; SENTRY_DSN sourced from Replit Secrets; SIGTERM closes Sentry cleanly.',
+    acceptance_criteria: 'Error capture initialized at app entrypoint; thrown errors arrive in the central `feedback` table (feedback_type=venture_error) within 30s of occurring; PII (auth headers, cookies, body secrets) redacted before forwarding; EHG_ENGINEER_SUPABASE_URL/EHG_ENGINEER_SUPABASE_ANON_KEY sourced from environment/secrets; forwarding is best-effort and never throws into the request path when the sink is unreachable or unconfigured.',
     target_stack_components: ['business_logic', 'infrastructure'],
     vision_source_section: 'docs/reference/vision/quality-lifecycle-system.md — Multi-Venture Architecture / Per-venture deliverables (error capture)',
   }),

--- a/lib/eva/utils/validate-venture-default-capabilities.js
+++ b/lib/eva/utils/validate-venture-default-capabilities.js
@@ -105,3 +105,51 @@ export class MissingDefaultCapabilityError extends Error {
     this.errors = errors;
   }
 }
+
+// SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 (FR-5): capability_id -> the
+// feedback.feedback_type values that prove the capability is actually WIRED
+// (a live row exists), as opposed to merely DECLARED in a Stage-19 sprint plan.
+// Only the two capabilities this SD wires have a DB-verifiable signal; the
+// other portfolio-default capabilities have no such signal yet and are not
+// covered by verifyCapabilityWired.
+export const WIRED_CAPABILITY_FEEDBACK_TYPES = Object.freeze({
+  'feedback-widget': Object.freeze(['user_bug', 'user_feature_request', 'user_usability', 'user_other']),
+  'error-capture-middleware': Object.freeze(['venture_error']),
+});
+
+/**
+ * Belt-and-suspenders enforcement layer #3: validateVentureDefaultCapabilities()
+ * (above) only checks that a Stage-19 sprint plan DECLARES a mandatory capability
+ * as a sprint item — an LLM can declare it, ship a local-only stub, and still pass.
+ * This checks the ground truth: does a live row actually exist for this venture,
+ * proving the capability is wired to the EHG inbox, not just claimed.
+ *
+ * @param {Object} supabase - Supabase client (anon or service-role) scoped to EHG_Engineer
+ * @param {string} ventureId - ventures.id to check
+ * @param {string} capabilityId - one of WIRED_CAPABILITY_FEEDBACK_TYPES' keys
+ * @returns {Promise<{ wired: boolean, reason: string }>}
+ */
+export async function verifyCapabilityWired(supabase, ventureId, capabilityId) {
+  const feedbackTypes = WIRED_CAPABILITY_FEEDBACK_TYPES[capabilityId];
+  if (!feedbackTypes) {
+    return { wired: false, reason: `capability_id ${capabilityId} has no wired-verification signal` };
+  }
+  if (!ventureId) {
+    return { wired: false, reason: 'ventureId is required' };
+  }
+
+  const { data, error } = await supabase
+    .from('feedback')
+    .select('id')
+    .eq('venture_id', ventureId)
+    .in('feedback_type', feedbackTypes)
+    .limit(1);
+
+  if (error) {
+    return { wired: false, reason: `query failed: ${error.message}` };
+  }
+
+  return (data?.length ?? 0) > 0
+    ? { wired: true, reason: `found a ${feedbackTypes.join('/')} row for this venture` }
+    : { wired: false, reason: `no ${feedbackTypes.join('/')} row exists for this venture yet` };
+}

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -1,0 +1,129 @@
+import { beforeAll, afterAll, afterEach, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { createHash, randomUUID } from 'crypto';
+import { describeDb, itDb, HAS_REAL_DB } from '../helpers/db-available.js';
+
+// SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001
+// TS-3: fingerprint aggregation — many identical errors produce ONE row.
+// TS-4: per-venture circuit-breaker on distinct-fingerprint storm.
+// TS-5: anon role cannot forge occurrence_count/first_seen/last_seen directly.
+// TS-7: ingestion revocation is venture-scoped.
+//
+// All against the LIVE database (no mocks), per each scenario's acceptance criteria.
+// Uses a disposable fixture venture (created in beforeAll, deleted in afterAll) so
+// these tests never touch a real production venture's rows.
+
+let svc;
+let anon;
+let ventureId;
+let otherVentureId;
+
+function hash(seed) {
+  return createHash('sha256').update(seed).digest('hex');
+}
+
+beforeAll(async () => {
+  if (!HAS_REAL_DB) return;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  svc = createClient(url, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const anonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  anon = createClient(url, anonKey);
+
+  const { data: v1, error: e1 } = await svc.from('ventures')
+    .insert({ name: `TS-fixture-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js' })
+    .select('id').single();
+  if (e1) throw e1;
+  ventureId = v1.id;
+
+  const { data: v2, error: e2 } = await svc.from('ventures')
+    .insert({ name: `TS-fixture-other-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js (revocation-isolation control)' })
+    .select('id').single();
+  if (e2) throw e2;
+  otherVentureId = v2.id;
+});
+
+afterEach(async () => {
+  if (!HAS_REAL_DB) return;
+  await svc.from('feedback').delete().eq('feedback_type', 'venture_error').in('venture_id', [ventureId, otherVentureId]);
+});
+
+afterAll(async () => {
+  if (!HAS_REAL_DB) return;
+  await svc.from('feedback').delete().eq('feedback_type', 'venture_error').in('venture_id', [ventureId, otherVentureId]);
+  await svc.from('ventures').delete().in('id', [ventureId, otherVentureId]);
+});
+
+describeDb('record_venture_error RPC — live aggregation, storm, security, revocation', () => {
+  itDb('TS-3: 500 identical errors produce exactly ONE row with occurrence_count=500', async () => {
+    const errorHash = hash(`ts3-${randomUUID()}`);
+    for (let i = 0; i < 500; i++) {
+      const { error } = await anon.rpc('record_venture_error', {
+        p_venture_id: ventureId, p_error_hash: errorHash, p_message: 'repeated error', p_context: {},
+      });
+      expect(error).toBeNull();
+    }
+    const { data: rows } = await svc.from('feedback')
+      .select('id, occurrence_count')
+      .eq('venture_id', ventureId).eq('feedback_type', 'venture_error').eq('error_hash', errorHash);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].occurrence_count).toBe(500);
+  }, 30000);
+
+  itDb('TS-4: a storm of many distinct fingerprints from one venture is capped by the per-venture ceiling', async () => {
+    const results = [];
+    for (let i = 0; i < 30; i++) {
+      const { data } = await anon.rpc('record_venture_error', {
+        p_venture_id: ventureId, p_error_hash: hash(`ts4-${i}-${randomUUID()}`), p_message: `distinct error ${i}`, p_context: {},
+      });
+      results.push(data);
+    }
+    const created = results.filter(r => r?.action === 'created').length;
+    const suppressed = results.filter(r => r?.action === 'storm_suppressed').length;
+    // Ceiling is 20 distinct fingerprints/hour (record_venture_error RPC) — the 21st+
+    // distinct fingerprint in the window must be suppressed, not inserted as its own row.
+    expect(created).toBeLessThanOrEqual(20);
+    expect(suppressed).toBeGreaterThan(0);
+    expect(created + suppressed).toBe(30);
+  }, 30000);
+
+  itDb('TS-5: anon cannot forge occurrence_count/first_seen/last_seen via a raw table write', async () => {
+    const errorHash = hash(`ts5-${randomUUID()}`);
+    // Legitimate path first, so the row exists.
+    await anon.rpc('record_venture_error', { p_venture_id: ventureId, p_error_hash: errorHash, p_message: 'seed row', p_context: {} });
+
+    // Attempt to forge via a raw INSERT (bypassing the RPC entirely).
+    const { error: insertError } = await anon.from('feedback').insert({
+      venture_id: ventureId, feedback_type: 'venture_error', source_type: 'error_capture',
+      error_hash: hash(`ts5-forge-${randomUUID()}`), occurrence_count: 99999,
+      title: 'forged', description: 'forged', type: 'issue', status: 'new', severity: 'low',
+    });
+    expect(insertError).not.toBeNull();
+
+    // Attempt to forge via a raw UPDATE on the legitimate row.
+    const { data: before } = await svc.from('feedback').select('id, occurrence_count').eq('venture_id', ventureId).eq('error_hash', errorHash).single();
+    const { error: updateError } = await anon.from('feedback').update({ occurrence_count: 99999 }).eq('id', before.id);
+    const { data: after } = await svc.from('feedback').select('occurrence_count').eq('id', before.id).single();
+    // Either the UPDATE is rejected outright, or (no anon UPDATE policy exists at all so
+    // PostgREST silently matches zero rows) the value is provably unchanged.
+    expect(after.occurrence_count).toBe(before.occurrence_count);
+    void updateError;
+  }, 30000);
+
+  itDb('TS-7: disabling ingestion for one venture does not affect another venture', async () => {
+    await svc.from('ventures').update({ metadata: { telemetry_ingestion_enabled: false } }).eq('id', ventureId);
+    try {
+      const { data: disabledResult } = await anon.rpc('record_venture_error', {
+        p_venture_id: ventureId, p_error_hash: hash(`ts7-disabled-${randomUUID()}`), p_message: 'should be rejected', p_context: {},
+      });
+      expect(disabledResult).toEqual({ ok: false, reason: 'venture_not_eligible' });
+
+      const { data: otherResult } = await anon.rpc('record_venture_error', {
+        p_venture_id: otherVentureId, p_error_hash: hash(`ts7-other-${randomUUID()}`), p_message: 'should still work', p_context: {},
+      });
+      expect(otherResult.ok).toBe(true);
+      expect(otherResult.action).toBe('created');
+    } finally {
+      await svc.from('ventures').update({ metadata: {} }).eq('id', ventureId);
+    }
+  }, 30000);
+});

--- a/tests/unit/eva/verify-capability-wired.test.js
+++ b/tests/unit/eva/verify-capability-wired.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { verifyCapabilityWired, WIRED_CAPABILITY_FEEDBACK_TYPES } from '../../../lib/eva/utils/validate-venture-default-capabilities.js';
+
+// SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001 TS-8: distinguishes a venture whose
+// feedback/error capture is wired to the EHG inbox (a live row exists) from one that
+// only has a local-only stub (declared in a sprint plan, never actually produced a row).
+
+function makeSupabaseStub(rows) {
+  const chain = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+  };
+  return { from: vi.fn(() => chain), _chain: chain };
+}
+
+describe('verifyCapabilityWired', () => {
+  it('fails a local-only fixture venture (no live row ever produced)', async () => {
+    const supabase = makeSupabaseStub([]);
+    const result = await verifyCapabilityWired(supabase, 'local-only-venture-id', 'feedback-widget');
+    expect(result.wired).toBe(false);
+    expect(result.reason).toMatch(/no .* row exists/);
+  });
+
+  it('passes a wired fixture venture (a real produced row exists)', async () => {
+    const supabase = makeSupabaseStub([{ id: 'row-1' }]);
+    const result = await verifyCapabilityWired(supabase, 'wired-venture-id', 'feedback-widget');
+    expect(result.wired).toBe(true);
+    expect(result.reason).toMatch(/found a/);
+  });
+
+  it('checks error-capture-middleware against venture_error feedback_type', async () => {
+    const supabase = makeSupabaseStub([{ id: 'row-2' }]);
+    const result = await verifyCapabilityWired(supabase, 'wired-venture-id', 'error-capture-middleware');
+    expect(result.wired).toBe(true);
+    expect(supabase._chain.in).toHaveBeenCalledWith('feedback_type', WIRED_CAPABILITY_FEEDBACK_TYPES['error-capture-middleware']);
+  });
+
+  it('returns wired:false with a clear reason for a capability with no verifiable signal', async () => {
+    const supabase = makeSupabaseStub([]);
+    const result = await verifyCapabilityWired(supabase, 'some-venture-id', 'cost-instrumentation');
+    expect(result.wired).toBe(false);
+    expect(result.reason).toMatch(/no wired-verification signal/);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('returns wired:false when ventureId is missing', async () => {
+    const supabase = makeSupabaseStub([{ id: 'row-1' }]);
+    const result = await verifyCapabilityWired(supabase, null, 'feedback-widget');
+    expect(result.wired).toBe(false);
+    expect(result.reason).toMatch(/ventureId is required/);
+  });
+
+  it('propagates a query error as wired:false rather than throwing', async () => {
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      in: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve({ data: null, error: { message: 'connection reset' } })),
+    };
+    const supabase = { from: vi.fn(() => chain) };
+    const result = await verifyCapabilityWired(supabase, 'some-venture-id', 'feedback-widget');
+    expect(result.wired).toBe(false);
+    expect(result.reason).toMatch(/query failed: connection reset/);
+  });
+});


### PR DESCRIPTION
## Summary
- New `record_venture_error` SECURITY DEFINER RPC (fingerprint dedup, per-venture storm ceiling fails closed-but-counted, anon-callable but cannot forge occurrence_count/first_seen/last_seen).
- Widen `feedback.source_application` varchar(50)→varchar(255) — fixes a real production bug silently breaking both the new RPC and a pre-existing service-role writer (`lib/factory/feedback-writer.js`) for venture names over 50 chars.
- Fix `venture_user_insert_feedback` RLS policy: its venture-existence subquery ran as the anon calling role, which has been unable to see any `ventures` row since `ventures_select_policy` was tightened elsewhere — meaning anon-role feedback submission has never actually worked. Fixed via a new SECURITY DEFINER helper `venture_exists_and_active()`, also folding in per-venture ingestion revocation (FR-4).
- `verifyCapabilityWired()` in `lib/eva/utils/validate-venture-default-capabilities.js` — distinguishes a venture actually wired to the EHG inbox (a live row exists) from one that merely declared the capability in a Stage-19 sprint plan.
- Corrected `lib/eva/config/venture-default-capabilities.js` capability descriptions to describe the real mechanism instead of a hypothetical Sentry-DSN integration.

Companion PR (MarketLens, the reference consumer): https://github.com/rickfelix/marketlens/pull/15

## Test plan
- [x] `tests/unit/eva/verify-capability-wired.test.js` (6 tests)
- [x] `tests/integration/venture-error-aggregation.db.test.js` — live DB, no mocks: 500-identical-error aggregation (TS-3), per-venture storm ceiling (TS-4), anon cannot forge aggregation columns (TS-5), per-venture ingestion revocation isolation (TS-7)
- [x] Regression: `tests/unit/eva/venture-default-capabilities.test.js`, `tests/unit/eva/validate-venture-default-capabilities.test.js`, stage-19 test suite (76 tests total)
- [x] TESTING sub-agent independently re-ran everything (PASS, 95% confidence)
- [x] VALIDATION sub-agent (CONDITIONAL_PASS 88% → gap closed) + REGRESSION sub-agent (PASS 90%) both recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)