### PR TITLE
fix(QF-20260704-058): splitPostgreSQLStatements comment-in-body corruption

### DIFF
--- a/scripts/lib/supabase-connection.js
+++ b/scripts/lib/supabase-connection.js
@@ -470,13 +470,18 @@ export function splitPostgreSQLStatements(sql) {
     if (ch === ';') {
       const trimmed = current.trim();
       if (trimmed.length > 0) {
-        // Strip comment-only lines so the executor doesn't get a no-op statement.
-        const lines = trimmed.split('\n').filter(line => {
+        // Push the chunk verbatim if it has any real (non-comment) content;
+        // drop it only if it's entirely blank/comment lines. Line-by-line
+        // stripping would also mutate comment lines INSIDE a $$...$$ function
+        // body (dollar-quote state isn't preserved once flattened here) --
+        // whole-chunk keep/drop has no such blast radius since a statement
+        // like CREATE FUNCTION always has a non-comment line.
+        const hasRealContent = trimmed.split('\n').some(line => {
           const l = line.trim();
           return l.length > 0 && !l.startsWith('--');
         });
-        if (lines.length > 0) {
-          statements.push(lines.join('\n'));
+        if (hasRealContent) {
+          statements.push(trimmed);
         }
       }
       current = '';

--- a/tests/unit/split-postgresql-statements.test.js
+++ b/tests/unit/split-postgresql-statements.test.js
@@ -78,6 +78,22 @@ SELECT 99;`;
     expect(stmts[1]).toContain('SELECT 99');
   });
 
+  it('preserves a standalone `--` comment line INSIDE a $$...$$ function body (QF-20260704-058)', () => {
+    // Regression for the bug this QF fixes: a whole-line filter used to strip
+    // any line starting with `--` from the flattened statement text, with no
+    // awareness that some of those lines are literal source INSIDE the
+    // dollar-quoted body (not top-level comments in the surrounding script).
+    const sql = `CREATE OR REPLACE FUNCTION f() RETURNS void AS $$
+BEGIN
+  -- this standalone comment must survive inside the function body
+  PERFORM 1;
+END;
+$$ LANGUAGE plpgsql;`;
+    const stmts = splitPostgreSQLStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]).toContain('this standalone comment must survive inside the function body');
+  });
+
   it('drops comment-only segments (no SQL after stripping `--` lines)', () => {
     const sql = '-- header comment\n-- another comment\n;\nSELECT 1;';
     const stmts = splitPostgreSQLStatements(sql);


### PR DESCRIPTION
## Summary
- `splitPostgreSQLStatements`'s comment-only-chunk filter operated on the whole flattened statement with no dollar-quote awareness, silently stripping standalone `--` comment lines from inside any `$$...$$` function body (inline/trailing same-line comments were unaffected).
- Found via a real CI failure: `check-migration-readiness.mjs`'s prosrc-drift gate on SD-LEO-INFRA-UNIVERSAL-VENTURE-TELEMETRY-001's PR #5556 correctly caught that the live `record_venture_error` function was missing comments present in its migration file.
- Fix: replaced the per-line strip with keep-whole-vs-drop-whole — push the chunk verbatim if it has any non-comment content (a real statement like `CREATE FUNCTION` always does), drop only genuinely comment-only/blank chunks.

## Test plan
- [x] `tests/unit/split-postgresql-statements.test.js` — 10 existing cases + 1 new regression (standalone comment inside a `$$...$$` body survives), 11/11 pass
- [x] Regression: `tests/unit/migration-tier-classifier.test.js` + `tests/database/migration-tester.test.js` (95 tests) — other consumers of the splitter unaffected
- [x] TypeScript compile passes
- [x] Manually verified end-to-end: re-ran `database/migrations/20260704d_venture_error_aggregation_rpc.sql` against the live DB and confirmed `check-migration-readiness.mjs` now reports MATCHES for all functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)