### PR TITLE
fix(QF-20260704-432): wire coordinator-cold-recovery.cjs into startup ritual

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -291,6 +291,26 @@ export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed), '', renderFreshness(repoRoot)].join('\n');
 }
 
+// SD-LEO-INFRA-BOOTSTRAPPABLE-SURVIVOR-AGNOSTIC-001: coordinator-cold-recovery.cjs shipped +
+// npm-wired but was never invoked from the startup ritual, leaving the survivor-agnostic
+// cold-recovery path unreachable. Dry-run by default; --execute (or COORD_COLD_RECOVERY_
+// EXECUTE=1) releases + resume-redispatches orphaned claims. Fail-open: never throws.
+export async function renderColdRecovery(argv = [], env = {}) {
+  const dryRun = !(argv.includes('--execute') || env.COORD_COLD_RECOVERY_EXECUTE === '1');
+  try {
+    const { coldRecover } = await import('./coordinator-cold-recovery.cjs');
+    const { createSupabaseServiceClient } = await import('../lib/supabase-client.cjs');
+    const report = await coldRecover({ supabase: createSupabaseServiceClient(), dryRun });
+    const lines = [`═══ COLD-RECOVERY SWEEP (${dryRun ? 'dry-run' : 'EXECUTE'}) ═══`];
+    lines.push(`  in-flight: ${report.reconstructed}   orphaned: ${report.orphaned.length}`);
+    if (report.orphaned.length) lines.push(`  ${dryRun ? 'would release+resume' : 'released+resume-redispatched'}: ${report.orphaned.join(', ')}`);
+    if (report.errors.length) lines.push(`  ⚠️  errors: ${report.errors.join('; ')}`);
+    return lines.join('\n');
+  } catch (err) {
+    return '═══ COLD-RECOVERY SWEEP ═══\n  ✅ skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 // ── Main (fail-open: always exit 0) ──
 function main() {
   try {
@@ -299,7 +319,9 @@ function main() {
   } catch (err) {
     console.warn('⚠️  coordinator-startup-check hiccup (non-blocking, fail-open): ' + (err && err.message ? err.message : String(err)));
   }
-  process.exit(0);
+  renderColdRecovery(process.argv.slice(2), process.env)
+    .then((out) => console.log(out))
+    .finally(() => process.exit(0));
 }
 
 // Only run main when invoked directly (not when imported by tests).

--- a/tests/integration/coordinator-startup-cold-recovery-reachability.db.test.js
+++ b/tests/integration/coordinator-startup-cold-recovery-reachability.db.test.js
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import { describeDb, itDb, HAS_REAL_DB } from '../helpers/db-available.js';
+import { renderColdRecovery } from '../../scripts/coordinator-startup-check.mjs';
+
+// QF-20260704-432: coordinator-cold-recovery.cjs was delivered + npm-wired but never invoked
+// from the startup ritual — the survivor-agnostic cold-recovery path was unreachable in
+// practice. coldRecover()'s own logic is already unit-tested with injected mocks
+// (tests/unit/coordinator-cold-recovery.test.js); this test instead proves REACHABILITY:
+// calling the actual startup-path function (renderColdRecovery, now wired into main())
+// against the LIVE database surfaces a real orphaned claim -- no mocking the gate.
+
+let svc;
+let fixtureSdKey;
+
+beforeAll(async () => {
+  if (!HAS_REAL_DB) return;
+  svc = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  fixtureSdKey = `QF432-FIX-${randomUUID().slice(0, 8)}`; // must fit id varchar(50)
+  const orphanSessionId = `session_orphan_${randomUUID()}`; // no matching claude_sessions row -> orphaned
+  const { error } = await svc.from('strategic_directives_v2').insert({
+    id: fixtureSdKey,
+    sd_key: fixtureSdKey,
+    sd_code_user_facing: fixtureSdKey,
+    uuid_internal_pk: randomUUID(),
+    title: 'QF-20260704-432 cold-recovery reachability fixture',
+    status: 'in_progress',
+    category: 'Infrastructure',
+    priority: 'low',
+    description: 'disposable fixture for coordinator-startup-check reachability test',
+    rationale: 'disposable fixture',
+    scope: 'disposable fixture',
+    sequence_rank: 999999,
+    claiming_session_id: orphanSessionId,
+    is_working_on: true,
+  });
+  if (error) throw error;
+});
+
+afterAll(async () => {
+  if (!HAS_REAL_DB || !fixtureSdKey) return;
+  await svc.from('strategic_directives_v2').delete().eq('sd_key', fixtureSdKey);
+});
+
+describeDb('renderColdRecovery — real startup-path reachability (no mocking the gate)', () => {
+  itDb('a real orphaned claim is REACHED and reported via the actual startup-check entrypoint (dry-run, no mutation)', async () => {
+    const out = await renderColdRecovery([], {});
+    expect(out).toMatch(/COLD-RECOVERY SWEEP \(dry-run\)/);
+    expect(out).toContain(fixtureSdKey);
+
+    // Dry-run must not have mutated the fixture's claim.
+    const { data } = await svc.from('strategic_directives_v2').select('claiming_session_id').eq('sd_key', fixtureSdKey).single();
+    expect(data.claiming_session_id).not.toBeNull();
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- `scripts/coordinator-cold-recovery.cjs` (SD-LEO-INFRA-BOOTSTRAPPABLE-SURVIVOR-AGNOSTIC-001) was delivered and npm-wired but never invoked from `coordinator-startup-check.mjs` — the survivor-agnostic cold-recovery path was unreachable in practice (grep-verified absent).
- Added `renderColdRecovery()`, invoked from `main()` after the existing synchronous report. Dry-run by default (matches the script's own CLI default); `--execute` or `COORD_COLD_RECOVERY_EXECUTE=1` releases + resume-redispatches orphans.
- `buildReport()` and all existing render functions are untouched — this is purely additive to `main()`'s tail.

## Test plan
- [x] All 12 existing `coordinator-startup-check.test.mjs` tests pass unchanged
- [x] All 13 existing `coordinator-cold-recovery.test.js` unit tests pass unchanged (coldRecover's own logic, incl. the dry-run-reports-but-releases-nothing case, was already covered)
- [x] New `tests/integration/coordinator-startup-cold-recovery-reachability.db.test.js` (live DB, no mocking the gate): proves REACHABILITY specifically — a real orphaned-claim fixture is surfaced through the actual startup-path function, with no mutation in dry-run mode
- [x] Manual CLI smoke test: `node scripts/coordinator-startup-check.mjs` — the new COLD-RECOVERY SWEEP section printed and correctly surfaced a real currently-orphaned SD with zero side effects (dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)