### PR TITLE
SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001: periodic-process liveness registry + watcher-of-watchers

### DIFF
--- a/database/migrations/20260704_periodic_process_registry.sql
+++ b/database/migrations/20260704_periodic_process_registry.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- Migration: periodic_process_registry -- expected-periodic-process registry
+-- SD: SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 (FR-1)
+-- Date: 2026-07-04
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Solomon referent-audit cell [2]: periodic processes die silently as a CLASS
+-- (the consultant generator died 2026-06-20, unnoticed ~2 weeks; role-session
+-- crons die with their session with no freshness check). Fleet WORKERS already
+-- have assessFleetActivity (lib/coordinator/fleet-quiescence.cjs) for aggregate
+-- fleet quiescence; this registry covers individual non-worker periodic
+-- processes against their own expected cadence.
+--
+-- liveness_source is the load-bearing design decision: role_session and
+-- scheduler_round entries do NOT get a new last_fired_at write path -- they
+-- are resolved at watch-time from the EXISTING signal (claude_sessions
+-- .heartbeat_at / eva_scheduler_heartbeat.last_poll_at), per the binding
+-- constraint against new heartbeat machinery for signals that already exist.
+-- Only 'self_stamped' entries (standalone cron/generator scripts with no
+-- existing signal) are written to via lib/periodic-liveness/stamp-last-fired.js.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.periodic_process_registry (
+  process_key text PRIMARY KEY,
+  display_name text NOT NULL,
+  owner text,
+  process_type text NOT NULL CHECK (process_type IN ('role_session', 'scheduler_round', 'standalone_cron', 'worker_class')),
+  expected_interval_seconds integer NOT NULL CHECK (expected_interval_seconds > 0),
+  grace_multiplier numeric NOT NULL DEFAULT 3 CHECK (grace_multiplier > 0),
+  liveness_source text NOT NULL CHECK (liveness_source IN ('claude_sessions_heartbeat', 'eva_scheduler_heartbeat', 'self_stamped')),
+  liveness_source_ref jsonb NOT NULL DEFAULT '{}'::jsonb,
+  session_bound boolean NOT NULL DEFAULT false,
+  currently_expected_active boolean NOT NULL DEFAULT true,
+  last_fired_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.periodic_process_registry IS
+'Registry of expected periodic processes (role-session loops, eva-scheduler rounds,
+standalone cron/generator scripts) with owner/interval/grace for the
+watcher-of-watchers (scripts/periodic-liveness-watcher.mjs). Detection only --
+remediation stays with the owning role (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001).';
+
+COMMENT ON COLUMN public.periodic_process_registry.liveness_source IS
+'Where the watcher resolves last-fired from at watch-time: claude_sessions_heartbeat
+(role-session loops -- resolve via liveness_source_ref against claude_sessions),
+eva_scheduler_heartbeat (resolve via liveness_source_ref.instance_id against
+eva_scheduler_heartbeat.last_poll_at), or self_stamped (this row''s own
+last_fired_at, written only by lib/periodic-liveness/stamp-last-fired.js).';
+
+COMMENT ON COLUMN public.periodic_process_registry.currently_expected_active IS
+'False = intentionally stood-down (session_bound loop deliberately not running
+right now); the watcher skips staleness evaluation entirely for such rows,
+rendering INTENTIONALLY_DOWN rather than a false OVERDUE/UNVERIFIED flag.';
+
+CREATE INDEX IF NOT EXISTS idx_periodic_process_registry_type
+  ON public.periodic_process_registry (process_type);
+
+ALTER TABLE public.periodic_process_registry ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS periodic_process_registry_service_role ON public.periodic_process_registry;
+CREATE POLICY periodic_process_registry_service_role
+  ON public.periodic_process_registry
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ---------------------------------------------------------------------------
+-- Self-verification: fail the deploy if the table/columns/constraints did not land.
+-- ---------------------------------------------------------------------------
+DO $verify$
+BEGIN
+  ASSERT to_regclass('public.periodic_process_registry') IS NOT NULL,
+    'periodic_process_registry table did not land';
+  ASSERT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'periodic_process_registry' AND column_name = 'liveness_source'
+  ), 'periodic_process_registry.liveness_source column missing';
+  ASSERT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'periodic_process_registry' AND column_name = 'currently_expected_active'
+  ), 'periodic_process_registry.currently_expected_active column missing';
+END
+$verify$;

--- a/database/migrations/20260704b_periodic_process_registry_last_state.sql
+++ b/database/migrations/20260704b_periodic_process_registry_last_state.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Migration: periodic_process_registry.last_state -- per-episode OVERDUE dedup
+-- SD: SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001
+-- Date: 2026-07-04
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Adversarial-review finding on this SD's own PR (#5562, CRITICAL): the original OVERDUE
+-- session_coordination dedup checked "has this process_key EVER been flagged OVERDUE" with no
+-- time bound -- a one-shot, non-resettable latch. Once any process was flagged once, it could
+-- NEVER be re-flagged again, even after recovering and dying again months later for an unrelated
+-- reason -- reproducing the exact "dies silently, unnoticed" failure class this SD exists to
+-- prevent, one layer removed from where the original fix (this SD's core JS logic) was applied.
+--
+-- Fix: track the last OBSERVED state per row. emitOverdueSignal only fires on a genuine
+-- transition INTO OVERDUE (previous last_state was NOT 'OVERDUE'), and the watcher persists
+-- last_state after every evaluation regardless of outcome -- so a process that recovers (goes OK)
+-- and later goes OVERDUE again is correctly re-flagged.
+-- =============================================================================
+
+ALTER TABLE public.periodic_process_registry
+  ADD COLUMN IF NOT EXISTS last_state text;
+
+COMMENT ON COLUMN public.periodic_process_registry.last_state IS
+'The state (OK/OVERDUE/UNVERIFIED/INTENTIONALLY_DOWN) observed on the watcher''s most recent
+evaluation of this row. Used to detect a genuine transition INTO OVERDUE (per-episode dedup) --
+NOT a fixed-forever "has this ever been flagged" check, which was a real bug caught by
+adversarial review on this SD''s own PR (#5562).';
+
+-- ---------------------------------------------------------------------------
+-- Self-verification.
+-- ---------------------------------------------------------------------------
+DO $verify$
+BEGIN
+  ASSERT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'periodic_process_registry' AND column_name = 'last_state'
+  ), 'periodic_process_registry.last_state column did not land';
+END
+$verify$;

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-04T20:39:03.927Z",
+ "generated_at": "2026-07-05T00:04:52.305Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
- "table_count": 768,
+ "table_count": 769,
  "view_count": 177,
  "tables": {
   "_migration_metadata": "{key,value}",
@@ -438,6 +438,7 @@
   "pattern_subagent_mapping": "{id,pattern_id,sub_agent_code,mapping_type,trigger_phrase,trigger_id,confidence,created_at,updated_at}",
   "pcvp_verification_log": "{id,sd_id,sd_key,event_type,event_data,verification_score,created_at,created_by}",
   "pending_ceo_handoffs": "{id,venture_id,handoff_type,from_stage,to_stage,vp_agent_id,handoff_data,status,proposed_at,reviewed_by,reviewed_at,review_notes,created_at,updated_at}",
+  "periodic_process_registry": "{process_key,display_name,owner,process_type,expected_interval_seconds,grace_multiplier,liveness_source,liveness_source_ref,session_bound,currently_expected_active,last_fired_at,created_at,updated_at,last_state}",
   "permission_audit_log": "{id,created_at,session_id,tool_name,rule_code,rule_description,outcome,context_hash,metadata}",
   "persona_behavioral_data": "{id,venture_id,persona_type,behavioral_patterns,sample_size,aggregation_period,metadata,created_at,updated_at,created_by}",
   "persona_config": "{id,target_application,mandatory_personas,allowed_personas,forbidden_personas,optional_triggers,sd_type_overrides,is_active,created_at,updated_at}",

--- a/lib/periodic-liveness/stamp-last-fired.js
+++ b/lib/periodic-liveness/stamp-last-fired.js
@@ -1,0 +1,48 @@
+/**
+ * One tiny shared stamp helper for self_stamped periodic-process registry entries
+ * (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001, FR-2).
+ *
+ * ONLY for standalone_cron entries with liveness_source='self_stamped' -- role_session and
+ * scheduler_round entries derive their last-fired timestamp by READING their existing signal
+ * (claude_sessions.heartbeat_at / eva_scheduler_heartbeat.metadata) at watch-time; they must
+ * NEVER call this helper, per the binding constraint against new heartbeat machinery for
+ * signals that already exist.
+ *
+ * Registry membership is additive, not auto-creating: calling this for an unregistered
+ * process_key is a no-op with a logged warning (a hand-only registry list becomes its own
+ * fossil, per the SD's own design note -- but this helper does not silently grow the registry
+ * either; a new standalone process must be registered explicitly first).
+ *
+ * @module lib/periodic-liveness/stamp-last-fired
+ */
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} processKey
+ * @returns {Promise<{stamped: boolean, reason?: string}>}
+ */
+export async function stampLastFired(supabase, processKey) {
+  if (!processKey) {
+    throw new Error('[stamp-last-fired] stampLastFired requires a processKey');
+  }
+
+  const { data, error } = await supabase
+    .from('periodic_process_registry')
+    .update({ last_fired_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+    .eq('process_key', processKey)
+    .eq('liveness_source', 'self_stamped')
+    .select('process_key');
+
+  if (error) {
+    throw new Error(`[stamp-last-fired] update failed for ${processKey}: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    console.warn(`[stamp-last-fired] '${processKey}' is not a registered self_stamped process -- no-op. Register it in periodic_process_registry first.`);
+    return { stamped: false, reason: 'not_registered_as_self_stamped' };
+  }
+
+  return { stamped: true };
+}
+
+export default { stampLastFired };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -744,6 +744,66 @@ function printHealth(d) {
   console.log('');
 }
 
+// ── Section: Periodic-Process Liveness (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001, FR-5) ──
+async function printPeriodicLiveness() {
+  const { data: rows, error } = await supabase
+    .from('periodic_process_registry')
+    .select('process_key, display_name, process_type, currently_expected_active, last_fired_at, updated_at')
+    .order('process_type', { ascending: true });
+
+  console.log('PERIODIC-PROCESS LIVENESS');
+  console.log('─'.repeat(72));
+
+  if (error) {
+    console.log('  (unable to load periodic_process_registry: ' + error.message + ')');
+    console.log('');
+    return;
+  }
+  if (!rows || rows.length === 0) {
+    console.log('  (registry empty)');
+    console.log('');
+    return;
+  }
+
+  const self = rows.find((r) => r.process_key === '__watcher_self__');
+  const watcherAgeSec = self?.last_fired_at ? Math.round((Date.now() - Date.parse(self.last_fired_at)) / 1000) : null;
+  const watcherLine = watcherAgeSec == null
+    ? '  Watcher last-run: NEVER RUN'
+    : '  Watcher last-run: ' + watcherAgeSec + 's ago' + (watcherAgeSec > 3600 ? '  [STALE WATCHER]' : '');
+  console.log(watcherLine);
+  console.log('');
+
+  // Pull the most recent OVERDUE flags to avoid re-deriving state here (the watcher script,
+  // scripts/periodic-liveness-watcher.mjs, is the single source of truth for state evaluation --
+  // the dashboard renders its output, it does not re-implement the 2+-signal logic).
+  const { data: flags } = await supabase
+    .from('session_coordination')
+    .select('payload, created_at')
+    .eq('payload->>kind', 'periodic_liveness_flag')
+    .order('created_at', { ascending: false })
+    .limit(50);
+  const overdueByKey = new Map();
+  for (const f of flags || []) {
+    const key = f.payload?.process_key;
+    if (key && !overdueByKey.has(key)) overdueByKey.set(key, f);
+  }
+
+  const ageOfHours = (ts) => (ts ? Math.max(0, Math.round((Date.now() - Date.parse(ts)) / 3600000)) + 'h' : '—');
+
+  const others = rows.filter((r) => r.process_key !== '__watcher_self__');
+  for (const r of others) {
+    const state = !r.currently_expected_active
+      ? 'INTENTIONALLY_DOWN'
+      : overdueByKey.has(r.process_key)
+        ? 'OVERDUE'
+        : 'OK';
+    console.log('  ' + pad(state, 20) + pad(r.process_type, 16) + pad(ageOfHours(r.last_fired_at), 8) + (r.display_name || r.process_key));
+  }
+  console.log('');
+  console.log('  Run scripts/periodic-liveness-watcher.mjs to refresh state.');
+  console.log('');
+}
+
 // ── Section: QA ──
 function printQA(d) {
   const now = Date.now();
@@ -1888,6 +1948,7 @@ async function main() {
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
     chairmanemail: async () => await printChairmanEmailChannelHealth(), // SD-LEO-INFRA-CHAIRMAN-EMAIL-CHANNEL-001
+    periodic:      async () => await printPeriodicLiveness(), // SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 (FR-5)
     all:           async () => {
       // Team banner appears at top of /coordinator all when active teams exist (otherwise no-op)
       if (d.executeTeams && d.executeTeams.length > 0) printTeam(d);
@@ -1913,6 +1974,7 @@ async function main() {
       await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);
       printHealth(d);
+      await printPeriodicLiveness(); // SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 (FR-5)
       printQA(d);
       await printForecast(d);
       await printPredictions(d);
@@ -1922,7 +1984,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, solomon, context, feedback, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, periodic, qa, forecast, predictions, inbox, adam, solomon, context, feedback, team, all');
     process.exit(1);
   }
 

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -748,7 +748,7 @@ function printHealth(d) {
 async function printPeriodicLiveness() {
   const { data: rows, error } = await supabase
     .from('periodic_process_registry')
-    .select('process_key, display_name, process_type, currently_expected_active, last_fired_at, updated_at')
+    .select('process_key, display_name, process_type, currently_expected_active, last_fired_at, last_state, updated_at')
     .order('process_type', { ascending: true });
 
   console.log('PERIODIC-PROCESS LIVENESS');
@@ -773,30 +773,21 @@ async function printPeriodicLiveness() {
   console.log(watcherLine);
   console.log('');
 
-  // Pull the most recent OVERDUE flags to avoid re-deriving state here (the watcher script,
-  // scripts/periodic-liveness-watcher.mjs, is the single source of truth for state evaluation --
-  // the dashboard renders its output, it does not re-implement the 2+-signal logic).
-  const { data: flags } = await supabase
-    .from('session_coordination')
-    .select('payload, created_at')
-    .eq('payload->>kind', 'periodic_liveness_flag')
-    .order('created_at', { ascending: false })
-    .limit(50);
-  const overdueByKey = new Map();
-  for (const f of flags || []) {
-    const key = f.payload?.process_key;
-    if (key && !overdueByKey.has(key)) overdueByKey.set(key, f);
-  }
-
+  // Render the watcher's own persisted last_state directly (scripts/periodic-liveness-watcher.mjs
+  // is the single source of truth for state evaluation and writes last_state on every run,
+  // regardless of outcome -- the dashboard renders that column, it does not re-implement the
+  // 2+-signal logic or re-derive state from a flags lookback. A flags-table lookback was tried
+  // first and rejected: an OVERDUE flag row does not expire when the process recovers, so
+  // rendering "is there a flag" rather than "what is the CURRENT last_state" would keep showing
+  // OVERDUE forever after a single episode (the same latch defect fixed in emitOverdueSignal,
+  // adversarial review on PR #5562).
   const ageOfHours = (ts) => (ts ? Math.max(0, Math.round((Date.now() - Date.parse(ts)) / 3600000)) + 'h' : '—');
 
   const others = rows.filter((r) => r.process_key !== '__watcher_self__');
   for (const r of others) {
     const state = !r.currently_expected_active
       ? 'INTENTIONALLY_DOWN'
-      : overdueByKey.has(r.process_key)
-        ? 'OVERDUE'
-        : 'OK';
+      : (r.last_state || 'UNVERIFIED');
     console.log('  ' + pad(state, 20) + pad(r.process_type, 16) + pad(ageOfHours(r.last_fired_at), 8) + (r.display_name || r.process_key));
   }
   console.log('');

--- a/scripts/periodic-liveness-watcher.mjs
+++ b/scripts/periodic-liveness-watcher.mjs
@@ -40,11 +40,23 @@ function overdueThresholdMs(row) {
   return row.expected_interval_seconds * Number(row.grace_multiplier) * 1000;
 }
 
+// Adversarial-review finding (PR #5562, WARNING): liveness_source_ref.metadata_filter is stored
+// in a jsonb column and was previously spliced unallowlisted into a raw PostgREST .or() filter
+// string -- safe today only because RLS restricts writes to service_role and the only writer
+// (seed-periodic-process-registry.mjs) hardcodes trusted values, but a jsonb key can legally
+// contain commas/dots that would corrupt or extend the filter clause boundary if a future,
+// less-careful writer ever populated this column. Allowlist the permitted keys at the point of
+// use so this can never become exploitable even if that assumption changes later.
+const ALLOWED_METADATA_FILTER_KEYS = new Set(['role', 'is_coordinator']);
+
 async function resolveRoleSession(row) {
   const filter = row.liveness_source_ref?.metadata_filter;
   if (!filter) return { lastFiredAt: null, signals: {}, evaluableCount: 0 };
 
-  const orClauses = Object.entries(filter).map(([k, v]) => `metadata->>${k}.eq.${v}`).join(',');
+  const safeEntries = Object.entries(filter).filter(([k]) => ALLOWED_METADATA_FILTER_KEYS.has(k));
+  if (safeEntries.length === 0) return { lastFiredAt: null, signals: {}, evaluableCount: 0 };
+
+  const orClauses = safeEntries.map(([k, v]) => `metadata->>${k}.eq.${v}`).join(',');
   const { data, error } = await supabase
     .from('claude_sessions')
     .select('heartbeat_at, terminal_id, tty, process_alive_at, is_alive')
@@ -108,9 +120,11 @@ async function evaluateRow(row) {
     if (resolved.evaluableCount < 2) {
       return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'fewer_than_2_evaluable_signals', last_fired_at: lastFiredAt };
     }
-    if (staleSignals < 2) {
-      return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'signals_disagree_or_insufficient', last_fired_at: lastFiredAt };
-    }
+    // freshSignals===0 is guaranteed here (the freshSignals>0 branch above already returned), and
+    // evaluableCount>=2 is guaranteed here too -- so staleSignals (evaluableCount - freshSignals)
+    // is always >=2 at this point. There is no reachable "signals disagree" state with this
+    // 3-signal model (adversarial review, PR #5562 INFO): any single fresh signal short-circuits
+    // to OK above before this line is reached.
     signalNote = `${staleSignals} corroborating stale signals`;
   } else if (row.liveness_source === 'eva_scheduler_heartbeat') {
     const resolved = await resolveSchedulerRound(row);
@@ -128,26 +142,6 @@ async function evaluateRow(row) {
 }
 
 async function emitOverdueSignal(row, evaluation) {
-  // Only emit for a NEW transition into OVERDUE -- check registry.metadata for the last-known state
-  // to avoid one row per watcher tick (FR-5 acceptance criterion).
-  const { data: current } = await supabase
-    .from('periodic_process_registry')
-    .select('owner')
-    .eq('process_key', row.process_key)
-    .maybeSingle();
-
-  const { data: recentFlag } = await supabase
-    .from('session_coordination')
-    .select('id')
-    .eq('payload->>kind', 'periodic_liveness_flag')
-    .eq('payload->>process_key', row.process_key)
-    .eq('payload->>state', 'OVERDUE')
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (recentFlag) return; // already flagged this transition, don't spam
-
   const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
 
   await supabase.from('session_coordination').insert({
@@ -159,7 +153,7 @@ async function emitOverdueSignal(row, evaluation) {
       kind: 'periodic_liveness_flag',
       process_key: row.process_key,
       display_name: row.display_name,
-      owner: current?.owner || row.owner,
+      owner: row.owner,
       state: 'OVERDUE',
       last_fired_at: evaluation.last_fired_at,
       age_ms: evaluation.age_ms,
@@ -175,9 +169,21 @@ async function main() {
   for (const row of rows || []) {
     const evaluation = await evaluateRow(row);
     results.push(evaluation);
-    if (evaluation.state === STATE.OVERDUE) {
+
+    // Adversarial-review finding (PR #5562, CRITICAL): dedup must be a per-episode STATE
+    // TRANSITION check (row.last_state !== OVERDUE -> OVERDUE), never "has this process_key ever
+    // been flagged" -- the latter is a one-shot latch that goes permanently blind to every
+    // subsequent recovery-then-relapse, reproducing the exact silent-death failure class this SD
+    // exists to prevent. last_state is persisted below on EVERY evaluation, recovered or not, so
+    // a process that goes OK and later OVERDUE again is correctly re-flagged.
+    if (evaluation.state === STATE.OVERDUE && row.last_state !== STATE.OVERDUE) {
       await emitOverdueSignal(row, evaluation);
     }
+
+    await supabase
+      .from('periodic_process_registry')
+      .update({ last_state: evaluation.state })
+      .eq('process_key', row.process_key);
   }
 
   // Self-liveness: upsert the watcher's own last-run row (self_stamped, session_bound=false).

--- a/scripts/periodic-liveness-watcher.mjs
+++ b/scripts/periodic-liveness-watcher.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * The single watcher-of-watchers (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001, FR-3/FR-4/FR-5).
+ *
+ * Iterates every periodic_process_registry row, resolves its last-fired timestamp from its
+ * declared liveness_source, and flags OVERDUE/UNVERIFIED/INTENTIONALLY_DOWN/OK. Detection only --
+ * remediation stays with the owning role (out of scope by design).
+ *
+ * 2+-signal rule scope note: the coordinator's binding constraint ("never declare a process dead
+ * on ONE signal") targets SESSION liveness false-reads specifically (fleet memory: invocation-
+ * driven sessions false-read as dead on one signal) -- so it is applied here ONLY to
+ * claude_sessions_heartbeat (role_session) entries, via 3 independent signal fields
+ * (heartbeat_at, terminal_id/PID, process_alive_at) reused from lib/fleet/session-liveness.cjs.
+ * eva_scheduler_heartbeat (scheduler_round) and self_stamped entries have no equivalent
+ * "session might be alive some other way" ambiguity -- a stale round/self-stamp timestamp vs
+ * interval*grace is unambiguous ground truth, so those use a direct single-timestamp comparison.
+ *
+ * Writes its own last-run timestamp to periodic_process_registry.process_key='__watcher_self__'
+ * (a self-registered self_stamped row) so a stale watcher is self-evident on the same dashboard
+ * surface it renders to -- closing the who-watches-the-watcher recursion via human-visible referent.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { hasFreshHeartbeat, hasTickAlive, hasPidAlive } = require('../lib/fleet/session-liveness.cjs');
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const WATCHER_SELF_KEY = '__watcher_self__';
+const STATE = Object.freeze({ OK: 'OK', OVERDUE: 'OVERDUE', UNVERIFIED: 'UNVERIFIED', INTENTIONALLY_DOWN: 'INTENTIONALLY_DOWN' });
+
+function overdueThresholdMs(row) {
+  return row.expected_interval_seconds * Number(row.grace_multiplier) * 1000;
+}
+
+async function resolveRoleSession(row) {
+  const filter = row.liveness_source_ref?.metadata_filter;
+  if (!filter) return { lastFiredAt: null, signals: {}, evaluableCount: 0 };
+
+  const orClauses = Object.entries(filter).map(([k, v]) => `metadata->>${k}.eq.${v}`).join(',');
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('heartbeat_at, terminal_id, tty, process_alive_at, is_alive')
+    .or(orClauses)
+    .order('heartbeat_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return { lastFiredAt: null, signals: {}, evaluableCount: 0 };
+
+  const nowMs = Date.now();
+  const signals = {
+    heartbeatFresh: data.heartbeat_at != null ? hasFreshHeartbeat(data, nowMs) : null,
+    pidAlive: data.terminal_id != null ? hasPidAlive(data) : null,
+    tickAlive: data.process_alive_at != null ? hasTickAlive(data, nowMs) : null,
+  };
+  const evaluableCount = Object.values(signals).filter((v) => v !== null).length;
+
+  return { lastFiredAt: data.heartbeat_at, signals, evaluableCount };
+}
+
+async function resolveSchedulerRound(row) {
+  const ref = row.liveness_source_ref || {};
+  // eva_scheduler_heartbeat is a singleton-row table -- always resolve against whichever row is
+  // CURRENTLY live, never a fixed instance_id (a restart changes instance_id; the registry entry
+  // must not become permanently orphaned when that happens -- confirmed live mid-EXEC on this SD).
+  const { data, error } = await supabase
+    .from('eva_scheduler_heartbeat')
+    .select('last_poll_at, metadata')
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error || !data) return { lastFiredAt: null };
+
+  if (ref.column === 'last_poll_at') return { lastFiredAt: data.last_poll_at };
+
+  const epochMs = data.metadata?.[ref.metadata_path]?.[ref.round_key];
+  return { lastFiredAt: epochMs ? new Date(epochMs).toISOString() : null };
+}
+
+async function evaluateRow(row) {
+  if (!row.currently_expected_active) {
+    return { process_key: row.process_key, state: STATE.INTENTIONALLY_DOWN };
+  }
+
+  let lastFiredAt = row.last_fired_at; // self_stamped default
+  let signalNote = null;
+
+  if (row.liveness_source === 'claude_sessions_heartbeat') {
+    const resolved = await resolveRoleSession(row);
+    lastFiredAt = resolved.lastFiredAt;
+    const staleSignals = Object.entries(resolved.signals).filter(([, v]) => v === false).length;
+    const freshSignals = Object.entries(resolved.signals).filter(([, v]) => v === true).length;
+    // A single FRESH signal is unambiguous positive evidence -- no ambiguity risk in declaring OK
+    // (the "insufficient signals" gate below exists to protect the DEATH declaration only; a
+    // false-positive-alive is harmless, a false-positive-dead is the fleet's own documented
+    // recurring failure mode). Check this BEFORE the evaluable-count gate.
+    if (freshSignals > 0) {
+      return { process_key: row.process_key, state: STATE.OK, last_fired_at: lastFiredAt };
+    }
+    if (resolved.evaluableCount < 2) {
+      return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'fewer_than_2_evaluable_signals', last_fired_at: lastFiredAt };
+    }
+    if (staleSignals < 2) {
+      return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'signals_disagree_or_insufficient', last_fired_at: lastFiredAt };
+    }
+    signalNote = `${staleSignals} corroborating stale signals`;
+  } else if (row.liveness_source === 'eva_scheduler_heartbeat') {
+    const resolved = await resolveSchedulerRound(row);
+    lastFiredAt = resolved.lastFiredAt;
+  }
+  // self_stamped: lastFiredAt already = row.last_fired_at
+
+  if (!lastFiredAt) {
+    return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'no_last_fired_data_available' };
+  }
+
+  const ageMs = Date.now() - new Date(lastFiredAt).getTime();
+  const state = ageMs > overdueThresholdMs(row) ? STATE.OVERDUE : STATE.OK;
+  return { process_key: row.process_key, state, last_fired_at: lastFiredAt, age_ms: ageMs, reason: signalNote };
+}
+
+async function emitOverdueSignal(row, evaluation) {
+  // Only emit for a NEW transition into OVERDUE -- check registry.metadata for the last-known state
+  // to avoid one row per watcher tick (FR-5 acceptance criterion).
+  const { data: current } = await supabase
+    .from('periodic_process_registry')
+    .select('owner')
+    .eq('process_key', row.process_key)
+    .maybeSingle();
+
+  const { data: recentFlag } = await supabase
+    .from('session_coordination')
+    .select('id')
+    .eq('payload->>kind', 'periodic_liveness_flag')
+    .eq('payload->>process_key', row.process_key)
+    .eq('payload->>state', 'OVERDUE')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (recentFlag) return; // already flagged this transition, don't spam
+
+  const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+
+  await supabase.from('session_coordination').insert({
+    message_type: 'INFO',
+    target_session: coordinatorId || 'broadcast-coordinator',
+    subject: `[PERIODIC-LIVENESS] ${row.display_name || row.process_key} is OVERDUE`,
+    sender_type: 'periodic-liveness-watcher',
+    payload: {
+      kind: 'periodic_liveness_flag',
+      process_key: row.process_key,
+      display_name: row.display_name,
+      owner: current?.owner || row.owner,
+      state: 'OVERDUE',
+      last_fired_at: evaluation.last_fired_at,
+      age_ms: evaluation.age_ms,
+    },
+  });
+}
+
+async function main() {
+  const { data: rows, error } = await supabase.from('periodic_process_registry').select('*').neq('process_key', WATCHER_SELF_KEY);
+  if (error) throw new Error(`registry query failed: ${error.message}`);
+
+  const results = [];
+  for (const row of rows || []) {
+    const evaluation = await evaluateRow(row);
+    results.push(evaluation);
+    if (evaluation.state === STATE.OVERDUE) {
+      await emitOverdueSignal(row, evaluation);
+    }
+  }
+
+  // Self-liveness: upsert the watcher's own last-run row (self_stamped, session_bound=false).
+  await supabase.from('periodic_process_registry').upsert({
+    process_key: WATCHER_SELF_KEY,
+    display_name: 'periodic-liveness-watcher (self)',
+    owner: 'periodic-liveness-watcher',
+    process_type: 'standalone_cron',
+    expected_interval_seconds: 900,
+    liveness_source: 'self_stamped',
+    session_bound: false,
+    currently_expected_active: true,
+    last_fired_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'process_key' });
+
+  const summary = results.reduce((acc, r) => { acc[r.state] = (acc[r.state] || 0) + 1; return acc; }, {});
+  console.log(`[periodic-liveness-watcher] evaluated ${results.length} process(es): ${JSON.stringify(summary)}`);
+  for (const r of results) {
+    if (r.state !== STATE.OK) console.log(`  ${r.state.padEnd(18)} ${r.process_key}${r.reason ? ` (${r.reason})` : ''}`);
+  }
+
+  return results;
+}
+
+// Only auto-run when invoked directly (not when imported by tests/dashboard).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`[periodic-liveness-watcher] FAILED: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+export { main as runWatcher, evaluateRow, STATE };

--- a/scripts/seed-periodic-process-registry.mjs
+++ b/scripts/seed-periodic-process-registry.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Mechanically seeds periodic_process_registry (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001, FR-1).
+ *
+ * "Seed MECHANICALLY from the known cron/loop registries where possible -- hand-listing only the
+ * remainder" (SD scope). This script derives registry rows from LIVE data rather than a fixed
+ * hand-written list:
+ *   - role_session entries: distinct roles observed in claude_sessions.metadata (adam, solomon,
+ *     coordinator via is_coordinant=true) -- NOT a fixed session_id (sessions rotate; the
+ *     liveness_source_ref is a metadata FILTER the watcher re-resolves against the latest matching
+ *     row each run).
+ *   - scheduler_round entries: one row per round key found in the live
+ *     eva_scheduler_heartbeat.metadata.job_last_runs / .last_round_runs objects -- each round is its
+ *     own registry row so a single dead round (the actual Specimen A: weekly_consultant_analysis
+ *     stopped 2026-06-20/21) is independently detectable even if the scheduler's own top-level
+ *     last_poll_at looks unrelated.
+ *
+ * standalone_cron entries are NOT hand-seeded here -- registry membership for that class is
+ * additive-only via lib/periodic-liveness/stamp-last-fired.js's first call (FR-2), matching the
+ * SD's own design note that a hand-only list becomes its own fossil.
+ *
+ * Idempotent: upserts on process_key, safe to re-run (TS-5).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const ROLE_SESSION_INTERVAL_SECONDS = 1800; // 30-min tick, matches the fleet's own ScheduleWakeup idle-tick convention
+
+function intervalForRoundKey(key) {
+  if (key.startsWith('daily_') || key.startsWith('okr-mid-month')) return 86400;
+  if (key.startsWith('weekly_') || key.startsWith('friday_')) return 604800;
+  if (key.startsWith('okr-monthly') || key.startsWith('monthly_')) return 2592000;
+  return 86400; // conservative default for unrecognized prefixes
+}
+
+async function seedRoleSessions() {
+  const { data: rows, error } = await supabase
+    .from('claude_sessions')
+    .select('metadata')
+    .or('metadata->>role.not.is.null,metadata->>is_coordinator.eq.true');
+  if (error) throw new Error(`claude_sessions query failed: ${error.message}`);
+
+  // Only the 3 role loops the SD's own specimens name (Adam/coordinator/Solomon) -- sprint-reasoner-*
+  // are explicitly non-fleet/non-role sessions per established fleet convention, out of this seed.
+  const seen = new Set();
+  const upserts = [];
+  for (const row of rows || []) {
+    const md = row.metadata || {};
+    let processKey = null;
+    let displayName = null;
+    let ref = null;
+    if (md.role === 'adam') { processKey = 'role_session:adam'; displayName = 'Adam (role-session loop)'; ref = { metadata_filter: { role: 'adam' } }; }
+    else if (md.role === 'solomon') { processKey = 'role_session:solomon'; displayName = 'Solomon (role-session loop)'; ref = { metadata_filter: { role: 'solomon' } }; }
+    else if (md.is_coordinator === true) { processKey = 'role_session:coordinator'; displayName = 'Coordinator (role-session loop)'; ref = { metadata_filter: { is_coordinator: true } }; }
+    if (!processKey || seen.has(processKey)) continue;
+    seen.add(processKey);
+    upserts.push({
+      process_key: processKey,
+      display_name: displayName,
+      owner: 'chairman-fleet',
+      process_type: 'role_session',
+      expected_interval_seconds: ROLE_SESSION_INTERVAL_SECONDS,
+      liveness_source: 'claude_sessions_heartbeat',
+      liveness_source_ref: ref,
+      session_bound: true,
+      currently_expected_active: true,
+      updated_at: new Date().toISOString(),
+    });
+  }
+  return upserts;
+}
+
+async function seedSchedulerRounds() {
+  // eva_scheduler_heartbeat is a SINGLETON-row table (one instance_id at a time, replaced/updated
+  // across restarts, not accumulated) -- confirmed live (a restart mid-EXEC on this SD changed
+  // instance_id from scheduler-8b34f47a to scheduler-7f77838a with zero old rows left behind).
+  // liveness_source_ref therefore does NOT key on instance_id: it always resolves against
+  // whichever row is currently live, so a scheduler restart never orphans a registry row.
+  const { data: rows, error } = await supabase
+    .from('eva_scheduler_heartbeat')
+    .select('instance_id, metadata');
+  if (error) throw new Error(`eva_scheduler_heartbeat query failed: ${error.message}`);
+  if (!rows || rows.length === 0) return [];
+  const row = rows[0];
+
+  const upserts = [];
+  const md = row.metadata || {};
+  for (const metadataPath of ['job_last_runs', 'last_round_runs']) {
+    const bucket = md[metadataPath];
+    if (!bucket || typeof bucket !== 'object') continue;
+    for (const roundKey of Object.keys(bucket)) {
+      upserts.push({
+        process_key: `scheduler_round:${roundKey}`,
+        display_name: `eva-scheduler round: ${roundKey}`,
+        owner: 'eva-scheduler',
+        process_type: 'scheduler_round',
+        expected_interval_seconds: intervalForRoundKey(roundKey),
+        liveness_source: 'eva_scheduler_heartbeat',
+        liveness_source_ref: { metadata_path: metadataPath, round_key: roundKey },
+        session_bound: false,
+        currently_expected_active: true,
+        updated_at: new Date().toISOString(),
+      });
+    }
+  }
+  // The scheduler's own top-level poll loop, separate from any individual round.
+  upserts.push({
+    process_key: 'scheduler_round:__poll_loop__',
+    display_name: 'eva-scheduler poll loop',
+    owner: 'eva-scheduler',
+    process_type: 'scheduler_round',
+    expected_interval_seconds: 300, // poll cadence per eva-scheduler-watcher.mjs's own age-gate assumption
+    liveness_source: 'eva_scheduler_heartbeat',
+    liveness_source_ref: { column: 'last_poll_at' },
+    session_bound: false,
+    currently_expected_active: true,
+    updated_at: new Date().toISOString(),
+  });
+  return upserts;
+}
+
+async function main() {
+  const roleUpserts = await seedRoleSessions();
+  const roundUpserts = await seedSchedulerRounds();
+  const all = [...roleUpserts, ...roundUpserts];
+
+  if (all.length === 0) {
+    console.log('No mechanically-derivable registry rows found (0 role sessions, 0 scheduler rounds) -- nothing to seed.');
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('periodic_process_registry')
+    .upsert(all, { onConflict: 'process_key' })
+    .select('process_key');
+  if (error) throw new Error(`registry upsert failed: ${error.message}`);
+
+  console.log(`Seeded/updated ${data.length} periodic_process_registry row(s):`);
+  console.log(`  role_session: ${roleUpserts.length}`);
+  console.log(`  scheduler_round: ${roundUpserts.length}`);
+  for (const row of data) console.log(`  - ${row.process_key}`);
+}
+
+main().catch((err) => {
+  console.error(`[seed-periodic-process-registry] FAILED: ${err.message}`);
+  process.exit(1);
+});

--- a/tests/integration/periodic-process-liveness-realdb.test.js
+++ b/tests/integration/periodic-process-liveness-realdb.test.js
@@ -82,6 +82,34 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     expect(flags.length).toBe(1);
   });
 
+  it('regression (adversarial review, PR #5562 CRITICAL): a process that RECOVERS and later goes OVERDUE again is re-flagged, not permanently latched after its first episode', async () => {
+    const processKey = await insertFixture({ suffix: 'recovers_then_relapses' });
+
+    // Episode 1: silence it -> OVERDUE -> flagged.
+    await supabase.from('periodic_process_registry')
+      .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
+      .eq('process_key', processKey);
+    await runWatcher();
+    const { data: afterEpisode1 } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey).eq('payload->>state', 'OVERDUE');
+    expect(afterEpisode1.length).toBe(1);
+
+    // Recovery: stamp it fresh -> OK. The watcher must persist last_state=OK so a future OVERDUE
+    // is recognized as a NEW transition, not swallowed by a permanent "already flagged once" latch.
+    await stampLastFired(supabase, processKey);
+    await runWatcher();
+    const { data: row1 } = await supabase.from('periodic_process_registry').select('last_state').eq('process_key', processKey).single();
+    expect(row1.last_state).toBe(STATE.OK);
+
+    // Episode 2 (weeks later, unrelated relapse): silence it again -> must be re-flagged.
+    await supabase.from('periodic_process_registry')
+      .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
+      .eq('process_key', processKey);
+    await runWatcher();
+
+    const { data: afterEpisode2 } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey).eq('payload->>state', 'OVERDUE');
+    expect(afterEpisode2.length).toBe(2); // one row per genuine episode, not stuck at 1 forever
+  });
+
   it('TS-2: a fixture stamped fresh (within interval*grace) produces zero flags', async () => {
     const processKey = await insertFixture({ suffix: 'healthy' });
     await stampLastFired(supabase, processKey);

--- a/tests/integration/periodic-process-liveness-realdb.test.js
+++ b/tests/integration/periodic-process-liveness-realdb.test.js
@@ -1,0 +1,118 @@
+/**
+ * REAL, DB-backed integration test for SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001.
+ *
+ * Drives the real evaluateRow (scripts/periodic-liveness-watcher.mjs), stampLastFired
+ * (lib/periodic-liveness/stamp-last-fired.js), and the real session_coordination
+ * OVERDUE-emission/dedup path against disposable fixture rows in periodic_process_registry.
+ * Non-mocked, against the live Postgres schema. All fixture rows and any emitted
+ * session_coordination flags are cleaned up in afterAll -- zero residue.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { resolve } from 'path';
+
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+import { evaluateRow, runWatcher, STATE } from '../../scripts/periodic-liveness-watcher.mjs';
+
+dotenv.config({ path: resolve(process.cwd(), '.env') });
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const ts = Date.now();
+const fixtureKeys = [];
+
+async function insertFixture({ suffix = 'fixture', ...overrides } = {}) {
+  const processKey = `__e2e_periodic_liveness_${suffix}_${ts}__`;
+  fixtureKeys.push(processKey);
+  const { error } = await supabase.from('periodic_process_registry').insert({
+    process_key: processKey,
+    display_name: `E2E fixture ${processKey}`,
+    owner: 'test-fixture',
+    process_type: 'standalone_cron',
+    expected_interval_seconds: 5,
+    grace_multiplier: 3,
+    liveness_source: 'self_stamped',
+    session_bound: false,
+    currently_expected_active: true,
+    ...overrides,
+  });
+  if (error) throw new Error(`Failed to insert fixture ${processKey}: ${error.message}`);
+  return processKey;
+}
+
+describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', () => {
+  afterAll(async () => {
+    for (const key of fixtureKeys) {
+      await supabase.from('session_coordination').delete().eq('payload->>process_key', key);
+      await supabase.from('periodic_process_registry').delete().eq('process_key', key);
+    }
+  });
+
+  it('TS-1: a self-stamped fixture fired twice then silenced 3x its interval is flagged OVERDUE with exactly one session_coordination row', async () => {
+    const processKey = await insertFixture({ suffix: 'silenced' });
+    await stampLastFired(supabase, processKey);
+    // Backdate last_fired_at to simulate "silenced for 3x interval" (5s interval * 3 grace = 15s).
+    await supabase.from('periodic_process_registry')
+      .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
+      .eq('process_key', processKey);
+
+    const { data: row } = await supabase.from('periodic_process_registry').select('*').eq('process_key', processKey).single();
+    const evaluation = await evaluateRow(row);
+    expect(evaluation.state).toBe(STATE.OVERDUE);
+
+    // Run the full watcher (not just evaluateRow) to exercise the real emission+dedup path.
+    await runWatcher();
+    await runWatcher(); // second run -- must NOT double-emit
+
+    const { data: flags } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('payload->>process_key', processKey)
+      .eq('payload->>state', 'OVERDUE');
+    expect(flags.length).toBe(1);
+  });
+
+  it('TS-2: a fixture stamped fresh (within interval*grace) produces zero flags', async () => {
+    const processKey = await insertFixture({ suffix: 'healthy' });
+    await stampLastFired(supabase, processKey);
+
+    const { data: row } = await supabase.from('periodic_process_registry').select('*').eq('process_key', processKey).single();
+    const evaluation = await evaluateRow(row);
+    expect(evaluation.state).toBe(STATE.OK);
+
+    await runWatcher();
+    const { data: flags } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey);
+    expect(flags.length).toBe(0);
+  });
+
+  it('TS-4: currently_expected_active=false with a genuinely stale last_fired_at produces zero flags (INTENTIONALLY_DOWN)', async () => {
+    const processKey = await insertFixture({ suffix: 'stood_down', currently_expected_active: false });
+    await supabase.from('periodic_process_registry')
+      .update({ last_fired_at: new Date(Date.now() - 999_999_999).toISOString() })
+      .eq('process_key', processKey);
+
+    const { data: row } = await supabase.from('periodic_process_registry').select('*').eq('process_key', processKey).single();
+    const evaluation = await evaluateRow(row);
+    expect(evaluation.state).toBe(STATE.INTENTIONALLY_DOWN);
+
+    await runWatcher();
+    const { data: flags } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey);
+    expect(flags.length).toBe(0);
+  });
+
+  it('FR-2: stampLastFired is a no-op (does not throw, does not create a row) for an unregistered process_key', async () => {
+    const result = await stampLastFired(supabase, `__e2e_unregistered_${ts}__`);
+    expect(result.stamped).toBe(false);
+    expect(result.reason).toBe('not_registered_as_self_stamped');
+  });
+});

--- a/tests/integration/seed-periodic-process-registry-idempotency.test.js
+++ b/tests/integration/seed-periodic-process-registry-idempotency.test.js
@@ -1,0 +1,24 @@
+/**
+ * TS-5 (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001): re-running the mechanical seed script is
+ * idempotent -- no duplicate rows on a second run. Real DB, no fixtures needed (the seed script
+ * itself only touches role_session/scheduler_round rows, upserting on process_key).
+ */
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+describe.skipIf(!HAS_REAL_DB)('seed-periodic-process-registry.mjs -- idempotency (TS-5)', () => {
+  it('running the seed script twice produces the same row count, no duplicates', async () => {
+    const run1 = execSync('node scripts/seed-periodic-process-registry.mjs', { encoding: 'utf8', cwd: process.cwd() });
+    const count1 = Number(run1.match(/Seeded\/updated (\d+) periodic_process_registry/)?.[1]);
+    const run2 = execSync('node scripts/seed-periodic-process-registry.mjs', { encoding: 'utf8', cwd: process.cwd() });
+    const count2 = Number(run2.match(/Seeded\/updated (\d+) periodic_process_registry/)?.[1]);
+
+    expect(count1).toBeGreaterThan(0);
+    expect(count2).toBe(count1);
+  });
+});

--- a/tests/unit/periodic-liveness-watcher.test.js
+++ b/tests/unit/periodic-liveness-watcher.test.js
@@ -1,0 +1,177 @@
+/**
+ * SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001 (FR-3/FR-4) -- unit coverage for
+ * scripts/periodic-liveness-watcher.mjs::evaluateRow, the per-registry-row state evaluator.
+ *
+ * NOTE: lib/fleet/session-liveness.cjs is loaded inside the watcher via createRequire(), which
+ * bypasses Vitest's ESM mock interception -- vi.mock() on that path is a silent no-op (confirmed
+ * empirically: a mocked hasPidAlive()=>true was ignored and the REAL PID-marker check ran
+ * instead). Rather than fight that, these tests drive evaluateRow with REAL, deterministic
+ * timestamps chosen to make the actual hasFreshHeartbeat/hasTickAlive/hasPidAlive primitives
+ * produce the desired signal combination -- a genuine test of the real logic, not a mock stand-in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const state = {
+  claudeSessionsRow: null,
+  schedulerRow: null,
+};
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from(table) {
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        or: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        neq: () => chain,
+        maybeSingle: async () => {
+          if (table === 'claude_sessions') return { data: state.claudeSessionsRow, error: null };
+          if (table === 'eva_scheduler_heartbeat') return { data: state.schedulerRow, error: null };
+          return { data: null, error: null };
+        },
+      };
+      return chain;
+    },
+  }),
+}));
+
+const { evaluateRow, STATE } = await import('../../scripts/periodic-liveness-watcher.mjs');
+
+function roleSessionRow(overrides = {}) {
+  return {
+    process_key: 'role_session:adam',
+    display_name: 'Adam',
+    process_type: 'role_session',
+    expected_interval_seconds: 1800,
+    grace_multiplier: 3,
+    liveness_source: 'claude_sessions_heartbeat',
+    liveness_source_ref: { metadata_filter: { role: 'adam' } },
+    session_bound: true,
+    currently_expected_active: true,
+    last_fired_at: null,
+    ...overrides,
+  };
+}
+
+function schedulerRoundRow(overrides = {}) {
+  return {
+    process_key: 'scheduler_round:daily_digest',
+    display_name: 'eva-scheduler round: daily_digest',
+    process_type: 'scheduler_round',
+    expected_interval_seconds: 86400,
+    grace_multiplier: 3,
+    liveness_source: 'eva_scheduler_heartbeat',
+    liveness_source_ref: { metadata_path: 'last_round_runs', round_key: 'daily_digest' },
+    session_bound: false,
+    currently_expected_active: true,
+    last_fired_at: null,
+    ...overrides,
+  };
+}
+
+function selfStampedRow(overrides = {}) {
+  return {
+    process_key: 'standalone:consultant-generator',
+    display_name: 'Consultant generator',
+    process_type: 'standalone_cron',
+    expected_interval_seconds: 300,
+    grace_multiplier: 3,
+    liveness_source: 'self_stamped',
+    liveness_source_ref: {},
+    session_bound: false,
+    currently_expected_active: true,
+    last_fired_at: null,
+    ...overrides,
+  };
+}
+
+const OLD_TS = '2020-01-01T00:00:00Z'; // unambiguously stale for every signal type
+const FRESH_TS = () => new Date().toISOString();
+
+describe('evaluateRow', () => {
+  beforeEach(() => {
+    state.claudeSessionsRow = null;
+    state.schedulerRow = null;
+  });
+
+  it('INTENTIONALLY_DOWN short-circuits when currently_expected_active=false, without querying signals', async () => {
+    // No claudeSessionsRow set (would error/no-op if a signal query were attempted) -- proves the
+    // short-circuit happens before any resolution.
+    const row = roleSessionRow({ currently_expected_active: false });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.INTENTIONALLY_DOWN);
+  });
+
+  it('role_session: only heartbeat_at populated (terminal_id/process_alive_at null) -> UNVERIFIED, never OVERDUE on 1 signal', async () => {
+    state.claudeSessionsRow = { heartbeat_at: OLD_TS, terminal_id: null, process_alive_at: null, is_alive: false };
+    const row = roleSessionRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+    expect(result.reason).toBe('fewer_than_2_evaluable_signals');
+  });
+
+  it('role_session: heartbeat + terminal_id populated, both genuinely stale -> OVERDUE', async () => {
+    state.claudeSessionsRow = { heartbeat_at: OLD_TS, terminal_id: 'win-cc-1234-999999', tty: null, process_alive_at: null, is_alive: false };
+    const row = roleSessionRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OVERDUE);
+  });
+
+  it('role_session: stale heartbeat but a genuinely fresh process_alive_at tick -> OK (2nd signal saves it)', async () => {
+    state.claudeSessionsRow = { heartbeat_at: OLD_TS, terminal_id: null, process_alive_at: FRESH_TS(), is_alive: false };
+    const row = roleSessionRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK);
+  });
+
+  it('role_session: fresh heartbeat alone (only 1 evaluable signal, but it is fresh) -> OK, not UNVERIFIED', async () => {
+    // A single FRESH signal is unambiguous positive evidence -- the 2+-signal gate protects the
+    // DEATH declaration only, never blocks a legitimate ALIVE read on "not enough signals".
+    state.claudeSessionsRow = { heartbeat_at: FRESH_TS(), terminal_id: null, process_alive_at: null, is_alive: false };
+    const row = roleSessionRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK);
+  });
+
+  it('scheduler_round: stale round-key timestamp beyond interval*grace -> OVERDUE (no 2-signal requirement)', async () => {
+    state.schedulerRow = { last_poll_at: FRESH_TS(), metadata: { last_round_runs: { daily_digest: Date.now() - 10 * 86400 * 1000 } } };
+    const row = schedulerRoundRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OVERDUE);
+  });
+
+  it('scheduler_round: fresh round-key timestamp within interval*grace -> OK', async () => {
+    state.schedulerRow = { last_poll_at: FRESH_TS(), metadata: { last_round_runs: { daily_digest: Date.now() - 60 * 1000 } } };
+    const row = schedulerRoundRow();
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK);
+  });
+
+  it('scheduler_round: instance-agnostic resolution -- resolves against whatever row is live regardless of any instance_id in liveness_source_ref', async () => {
+    state.schedulerRow = { last_poll_at: FRESH_TS(), metadata: { last_round_runs: { daily_digest: Date.now() - 60 * 1000 } } };
+    const row = schedulerRoundRow({ liveness_source_ref: { instance_id: 'some-stale-old-instance-id', metadata_path: 'last_round_runs', round_key: 'daily_digest' } });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK); // resolved via the live row, not blocked by the stale instance_id
+  });
+
+  it('self_stamped: uses the row own last_fired_at directly, no external resolution', async () => {
+    const row = selfStampedRow({ last_fired_at: OLD_TS, expected_interval_seconds: 300, grace_multiplier: 3 });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OVERDUE);
+  });
+
+  it('self_stamped: fresh last_fired_at -> OK', async () => {
+    const row = selfStampedRow({ last_fired_at: FRESH_TS(), expected_interval_seconds: 300, grace_multiplier: 3 });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK);
+  });
+
+  it('self_stamped: null last_fired_at (never fired) -> UNVERIFIED, not a false OK or OVERDUE', async () => {
+    const row = selfStampedRow({ last_fired_at: null });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+    expect(result.reason).toBe('no_last_fired_data_available');
+  });
+});


### PR DESCRIPTION
## Summary
- New `periodic_process_registry` table, mechanically seeded from `claude_sessions` role-metadata (Adam/Solomon/coordinator) and `eva_scheduler_heartbeat` (14 rounds + poll loop) -- 18 rows live, not hand-listed
- One shared last-fired stamp helper (`lib/periodic-liveness/stamp-last-fired.js`) for processes with no existing signal; role-session and eva-scheduler entries instead resolve their last-fired timestamp from their **existing** signal at watch-time (no new heartbeat machinery, per the coordinator's binding constraint)
- One watcher-of-watchers (`scripts/periodic-liveness-watcher.mjs`) requiring 2+ independent signals before flagging a role-session process dead (never one, per this fleet's own documented history of session-liveness false-reads) -- scheduler-round/self-stamped entries use direct timestamp comparison since they carry no equivalent "alive some other way" ambiguity
- `node scripts/fleet-dashboard.cjs periodic` renders every registry row's state plus the watcher's own last-run timestamp (closes the who-watches-the-watcher recursion via human-visible referent)
- Overdue transitions emit a deduped `session_coordination` INFO row (one per transition, not one per tick)
- `scripts/cron/eva-scheduler-watcher.mjs` is completely untouched -- this SD adds dashboard visibility parity only, remediation stays with that existing point solution

## Real findings caught during EXEC
- **eva-scheduler was genuinely dead in production** at EXEC start (`last_poll_at` ~13 days stale, `weekly_consultant_analysis` last ran 2026-06-20/21 -- the exact Specimen A this SD was commissioned over). Signaled to the coordinator immediately (`/signal harness-bug`, high severity); it recovered independently a few minutes later.
- That recovery **rotated `eva_scheduler_heartbeat.instance_id`** (a fresh restart gets a new random instance_id on this singleton-row table). My first design keyed registry rows on `instance_id`, which would have permanently orphaned every scheduler-round entry across any future restart. Fixed to resolve instance-agnostically (always against whichever row is currently live) -- confirmed live against the real restart that happened mid-EXEC, plus a dedicated unit test.
- One genuine `OVERDUE` detection survived to production: `scheduler_round:stage_health` (last ran 2026-06-10) -- left in place as real, valid watcher output.

## Test plan
- [x] 11 unit tests (`tests/unit/periodic-liveness-watcher.test.js`) -- 2+-signal rule for role_session (including "1 fresh signal still wins" and "2 evaluable+stale -> OVERDUE"), direct-timestamp rule for scheduler_round/self_stamped, INTENTIONALLY_DOWN short-circuit, instance-agnostic resolution
- [x] 4 real-DB integration tests (`tests/integration/periodic-process-liveness-realdb.test.js`) -- OVERDUE detection + exactly-one dedup, healthy zero-flags, INTENTIONALLY_DOWN zero-flags, stampLastFired no-op on unregistered key
- [x] 1 idempotency test confirming the seed script produces identical row counts on a second run
- [x] Confirmed zero regressions in the existing `fleet-dashboard` test suite
- [x] Confirmed `scripts/cron/eva-scheduler-watcher.mjs` is unmodified (`git diff` empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)