### PR TITLE
fix(SD-LEO-FIX-FEEDBACK-CONSUMPTION-SLA-001): feedback-consumption SLA gauge for actionable-category dead-letters

### DIFF
--- a/lib/coordinator/feedback-sla-gauge.cjs
+++ b/lib/coordinator/feedback-sla-gauge.cjs
@@ -1,0 +1,81 @@
+'use strict';
+// Feedback-consumption SLA gauge — QF-20260704-493 (Solomon referent-audit cell [4],
+// chairman-commissioned coverage work 2026-07-04). Actionable feedback categories with
+// NO consumption deadline can rot unconsumed indefinitely — adam_adherence_drift is the
+// adherence system's own dead-letter class when nobody consumes it.
+//
+// Unbounded-generator family rules (docs/plans/archived/sd-leo-infra-chairman-email-channel-001-plan.md):
+//   primary-state check  — planSlaBreaches() recomputes fresh from live feedback rows every call.
+//   terminal suppression — only UNCONSUMED_STATUSES rows count; resolved rows never breach.
+//   rate limit            — remindSlaBreaches() sends at most one reminder per category per day
+//                            (metadata.sla_key dedup, checked before insert).
+//   probe visibility      — every reminder attempt is console-logged, success or failure.
+
+const SLA_CATEGORIES = Object.freeze({
+  adam_adherence_drift: Object.freeze({ days: 7 }),
+  completion_flag: Object.freeze({ days: 7 }),
+  coordinator_review: Object.freeze({ days: 7 }),
+  harness_backlog: Object.freeze({ days: 7, severityIn: ['high', 'critical'] }),
+});
+const UNCONSUMED_STATUSES = ['new', 'triaged'];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Pure: group already-fetched feedback rows into per-category SLA breaches. */
+function computeBreaches(rows, nowMs) {
+  const breaches = [];
+  for (const [category, cfg] of Object.entries(SLA_CATEGORIES)) {
+    const slaMs = cfg.days * DAY_MS;
+    const matches = (rows || []).filter((r) => {
+      if (r.category !== category) return false;
+      if (cfg.severityIn && !cfg.severityIn.includes(String(r.severity || '').toLowerCase())) return false;
+      return (nowMs - new Date(r.created_at).getTime()) > slaMs;
+    });
+    if (matches.length === 0) continue;
+    const oldestAgeDays = Math.floor(Math.max(...matches.map((r) => nowMs - new Date(r.created_at).getTime())) / DAY_MS);
+    breaches.push({ category, count: matches.length, oldestAgeDays });
+  }
+  return breaches;
+}
+
+/** Fetches unconsumed feedback rows and computes fresh SLA breaches (primary-state check). */
+async function planSlaBreaches(supabase, { nowMs = Date.now() } = {}) {
+  const { data, error } = await supabase
+    .from('feedback')
+    .select('category, severity, created_at')
+    .in('category', Object.keys(SLA_CATEGORIES))
+    .in('status', UNCONSUMED_STATUSES);
+  if (error) throw new Error(`planSlaBreaches query failed: ${error.message}`);
+  return computeBreaches(data || [], nowMs);
+}
+
+/** Pure: today's dedup key for a category's reminder (rate limit: one per category per day). */
+function slaKeyFor(category, nowMs) {
+  return `${category}:${new Date(nowMs).toISOString().slice(0, 10)}`;
+}
+
+/** Rate-limited, deduped daily reminder: at most one feedback row per category per day. */
+async function remindSlaBreaches(supabase, { nowMs = Date.now() } = {}) {
+  const breaches = await planSlaBreaches(supabase, { nowMs });
+  const sent = [];
+  for (const b of breaches) {
+    const key = slaKeyFor(b.category, nowMs);
+    const { data: existing } = await supabase.from('feedback').select('id')
+      .eq('category', 'feedback_sla_breach').eq('metadata->>sla_key', key).limit(1);
+    if (existing && existing.length) {
+      console.log(`[feedback-sla-gauge] category=${b.category} already reminded today (${key}) — skipping`);
+      continue;
+    }
+    const { error } = await supabase.from('feedback').insert({
+      type: 'issue', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+      category: 'feedback_sla_breach', status: 'new', severity: 'medium',
+      title: `Feedback SLA breach: ${b.category} (${b.count} unconsumed, oldest ${b.oldestAgeDays}d)`,
+      description: `${b.count} unconsumed '${b.category}' feedback row(s) exceed the ${SLA_CATEGORIES[b.category].days}-day consumption SLA; oldest is ${b.oldestAgeDays} days old.`,
+      metadata: { sla_key: key, sla_category: b.category, count: b.count, oldest_age_days: b.oldestAgeDays },
+    });
+    console.log(`[feedback-sla-gauge] ${error ? 'FAILED to remind' : 'reminded'} category=${b.category} count=${b.count} oldest=${b.oldestAgeDays}d`);
+    if (!error) sent.push(b.category);
+  }
+  return { breaches, sent };
+}
+
+module.exports = { SLA_CATEGORIES, UNCONSUMED_STATUSES, computeBreaches, planSlaBreaches, slaKeyFor, remindSlaBreaches };

--- a/scripts/coordinator-feedback-sla-gauge.cjs
+++ b/scripts/coordinator-feedback-sla-gauge.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+// Daily coordinator-tick reminder for feedback-consumption SLA breaches — QF-20260704-493.
+// Fail-open: any error is logged and exits 0 (never blocks the coordinator's cron cadence).
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { remindSlaBreaches } = require('../lib/coordinator/feedback-sla-gauge.cjs');
+
+(async () => {
+  const supabase = createSupabaseServiceClient();
+  const { breaches, sent } = await remindSlaBreaches(supabase, {});
+  if (breaches.length === 0) {
+    console.log('[feedback-sla-gauge] no SLA breaches — all actionable categories consumed within SLA.');
+    return;
+  }
+  console.log(`[feedback-sla-gauge] ${breaches.length} categor${breaches.length === 1 ? 'y' : 'ies'} breaching, ${sent.length} new reminder(s) sent.`);
+})().catch((e) => {
+  console.error('[feedback-sla-gauge] FATAL (fail-open)', e && e.message ? e.message : e);
+  process.exit(0);
+});

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -174,6 +174,12 @@ export const STANDARD_LOOPS = [
   // detector functions are internally due-gated/idempotent, so an extra run is a no-op.
   { key: 'gauge-runner', label: 'Invariant-gauges execution surface (hourly, durable)', script: 'gauge-runner.mjs', cron: '0 * * * *',
     prompt: 'node scripts/gauge-runner.mjs --json' },
+  // QF-20260704-493: feedback-consumption SLA gauge daily reminder (Solomon referent-audit
+  // cell [4]) — actionable feedback categories (adam_adherence_drift, completion_flag,
+  // coordinator_review, harness_backlog escalations) had no consumption deadline. Internally
+  // rate-limited/deduped per category per day (metadata.sla_key), so an extra run is a no-op.
+  { key: 'feedback-sla', label: 'Feedback-consumption SLA breach reminder (daily)', script: 'coordinator-feedback-sla-gauge.cjs', cron: '45 9 * * *',
+    prompt: 'node scripts/coordinator-feedback-sla-gauge.cjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1615,6 +1615,31 @@ async function printChairmanDirectives() {
   console.log('');
 }
 
+// QF-20260704-493: feedback-consumption SLA gauge — actionable categories with no
+// consumption deadline (adam_adherence_drift, completion_flag, coordinator_review,
+// harness_backlog escalations) can rot unconsumed indefinitely. Recomputes fresh every
+// render (primary-state check); the daily reminder itself lives in the cron-scheduled
+// scripts/coordinator-feedback-sla-gauge.cjs, not here — this is read-only visibility.
+async function printFeedbackSlaGauge() {
+  const { planSlaBreaches } = require('../lib/coordinator/feedback-sla-gauge.cjs');
+
+  console.log('FEEDBACK-CONSUMPTION SLA GAUGE');
+  console.log('─'.repeat(72));
+
+  const breaches = await planSlaBreaches(supabase);
+  if (breaches.length === 0) {
+    console.log('  (all actionable feedback categories consumed within SLA)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + breaches.length + ' categor' + (breaches.length === 1 ? 'y' : 'ies') + ' breaching consumption SLA:');
+  for (const b of breaches) {
+    console.log('  • ' + pad(b.category, 22) + b.count + ' unconsumed, oldest ' + b.oldestAgeDays + 'd');
+  }
+  console.log('');
+}
+
 // FR-4 surfacing: rows the stale-session sweep dead-lettered (payload.dead_letter=true)
 // in the last 24h — undelivered traffic no longer vanishes tracelessly; the coordinator
 // can re-send to the successor session. Read-only.
@@ -1770,6 +1795,7 @@ async function main() {
     solomon:       async () => { await printSolomonInbox(); await printSolomonLedgerRollup(); }, // SD-LEO-INFRA-SOLOMON-CONSULT-001F + SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001
     context:       async () => await printWorkingContext(), // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3)
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
+    slagauge:      async () => await printFeedbackSlaGauge(), // QF-20260704-493
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
     all:           async () => {
       // Team banner appears at top of /coordinator all when active teams exist (otherwise no-op)
@@ -1786,6 +1812,7 @@ async function main() {
       await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printRelayDropGauge(); // FR-3 SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001
+      await printFeedbackSlaGauge(); // QF-20260704-493 — feedback-consumption SLA gauge
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
       await printSolomonInbox(); // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane (dormant until SOLOMON_CONSULT_V1)
       await printSolomonLedgerRollup(); // SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-5) — accuracy + cost-per-accepted rollup
@@ -1802,7 +1829,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, solomon, context, feedback, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, solomon, context, feedback, slagauge, team, all');
     process.exit(1);
   }
 

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -37,9 +37,12 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // QF-20260702-272 added the durable twice-daily 'roles-review' self-audit (after 'retention').
   // QF-20260703-563 added the durable hourly 'gauge-runner' loop (after 'roles-review') — the
   // invariant-gauges execution surface had no scheduled venue anywhere and went 29h stale.
-  assert.equal(STANDARD_LOOPS.length, 22);
+  // QF-20260704-493 added the daily 'feedback-sla' reminder (after 'gauge-runner') — actionable
+  // feedback categories (adam_adherence_drift, completion_flag, coordinator_review,
+  // harness_backlog escalations) had no consumption deadline.
+  assert.equal(STANDARD_LOOPS.length, 23);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention', 'roles-review', 'gauge-runner']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention', 'roles-review', 'gauge-runner', 'feedback-sla']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -107,7 +110,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(22\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(23\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -125,7 +128,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   ];
   const armed = parseArmedSet(['--armed', armedTokens.join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 22 standard loops armed/);
+  assert.match(out, /All 23 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {

--- a/tests/unit/coordinator/feedback-sla-gauge.test.js
+++ b/tests/unit/coordinator/feedback-sla-gauge.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SLA_CATEGORIES, UNCONSUMED_STATUSES, computeBreaches, slaKeyFor, planSlaBreaches, remindSlaBreaches } from '../../../lib/coordinator/feedback-sla-gauge.cjs';
+
+// QF-20260704-493: feedback-consumption SLA gauge. computeBreaches/slaKeyFor are pure
+// (no DB); planSlaBreaches/remindSlaBreaches are tested here with an injected fake
+// supabase client (network-free), mirroring the coordinator-cold-recovery.test.js
+// injectable-dependency convention.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 6, 4, 12, 0, 0); // 2026-07-04T12:00:00Z
+
+describe('computeBreaches (pure)', () => {
+  it('flags rows older than the category SLA, ignores fresh ones', () => {
+    const rows = [
+      { category: 'coordinator_review', severity: 'low', created_at: new Date(NOW - 10 * DAY_MS).toISOString() }, // stale (>7d)
+      { category: 'coordinator_review', severity: 'low', created_at: new Date(NOW - 1 * DAY_MS).toISOString() },  // fresh
+    ];
+    const breaches = computeBreaches(rows, NOW);
+    expect(breaches).toEqual([{ category: 'coordinator_review', count: 1, oldestAgeDays: 10 }]);
+  });
+
+  it('harness_backlog only counts high/critical severity (escalations)', () => {
+    const rows = [
+      { category: 'harness_backlog', severity: 'medium', created_at: new Date(NOW - 30 * DAY_MS).toISOString() }, // stale but not escalation-severity
+      { category: 'harness_backlog', severity: 'high', created_at: new Date(NOW - 8 * DAY_MS).toISOString() },
+    ];
+    const breaches = computeBreaches(rows, NOW);
+    expect(breaches).toEqual([{ category: 'harness_backlog', count: 1, oldestAgeDays: 8 }]);
+  });
+
+  it('reports the oldest age and full count across multiple stale rows in one category', () => {
+    const rows = [
+      { category: 'adam_adherence_drift', severity: 'high', created_at: new Date(NOW - 8 * DAY_MS).toISOString() },
+      { category: 'adam_adherence_drift', severity: 'high', created_at: new Date(NOW - 25 * DAY_MS).toISOString() },
+    ];
+    const breaches = computeBreaches(rows, NOW);
+    expect(breaches).toEqual([{ category: 'adam_adherence_drift', count: 2, oldestAgeDays: 25 }]);
+  });
+
+  it('returns an empty array when every category is within SLA (zero orphans -> no noise)', () => {
+    const rows = Object.keys(SLA_CATEGORIES).map((category) => ({
+      category, severity: 'high', created_at: new Date(NOW - 1 * DAY_MS).toISOString(),
+    }));
+    expect(computeBreaches(rows, NOW)).toEqual([]);
+  });
+});
+
+describe('slaKeyFor (pure)', () => {
+  it('is stable within the same UTC day and differs across days', () => {
+    const a = slaKeyFor('coordinator_review', NOW);
+    const b = slaKeyFor('coordinator_review', NOW + 60_000);
+    const c = slaKeyFor('coordinator_review', NOW + DAY_MS);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toBe('coordinator_review:2026-07-04');
+  });
+});
+
+// planSlaBreaches's fetch ends on .in() (no .limit()) and relies on the chain being
+// awaitable directly (thenable); the reminder-existence check ends on .limit(). The two
+// paths are distinguished by whether .eq('category','feedback_sla_breach') was called.
+function fakeSupabase({ feedbackRows = [], existingReminderIds = [] } = {}) {
+  const inserted = [];
+  return {
+    inserted,
+    from(table) {
+      expect(table).toBe('feedback');
+      let checkingReminder = false;
+      const chain = {
+        select: () => chain,
+        in: () => chain,
+        eq(col, val) {
+          if (col === 'category' && val === 'feedback_sla_breach') checkingReminder = true;
+          return chain;
+        },
+        limit: () => Promise.resolve(
+          checkingReminder ? { data: existingReminderIds.map((id) => ({ id })) } : { data: feedbackRows, error: null }
+        ),
+        then: (resolve, reject) => Promise.resolve({ data: feedbackRows, error: null }).then(resolve, reject),
+        insert: (row) => { inserted.push(row); return Promise.resolve({ error: null }); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('planSlaBreaches (injected fake supabase, no mocking the gate logic itself)', () => {
+  it('recomputes fresh from live-shaped rows (primary-state check)', async () => {
+    const supabase = fakeSupabase({
+      feedbackRows: [{ category: 'coordinator_review', severity: 'low', created_at: new Date(NOW - 10 * DAY_MS).toISOString() }],
+    });
+    const breaches = await planSlaBreaches(supabase, { nowMs: NOW });
+    expect(breaches).toEqual([{ category: 'coordinator_review', count: 1, oldestAgeDays: 10 }]);
+  });
+});
+
+describe('remindSlaBreaches (rate limit: one reminder per category per day)', () => {
+  it('inserts exactly one reminder on the first call for a breaching category', async () => {
+    const supabase = fakeSupabase({
+      feedbackRows: [{ category: 'coordinator_review', severity: 'low', created_at: new Date(NOW - 10 * DAY_MS).toISOString() }],
+      existingReminderIds: [],
+    });
+    const { breaches, sent } = await remindSlaBreaches(supabase, { nowMs: NOW });
+    expect(breaches).toHaveLength(1);
+    expect(sent).toEqual(['coordinator_review']);
+    expect(supabase.inserted).toHaveLength(1);
+    expect(supabase.inserted[0].metadata.sla_key).toBe('coordinator_review:2026-07-04');
+  });
+
+  it('dedup proven on second run: an already-reminded-today category sends nothing more', async () => {
+    const supabase = fakeSupabase({
+      feedbackRows: [{ category: 'coordinator_review', severity: 'low', created_at: new Date(NOW - 10 * DAY_MS).toISOString() }],
+      existingReminderIds: ['existing-reminder-row'],
+    });
+    const { breaches, sent } = await remindSlaBreaches(supabase, { nowMs: NOW });
+    expect(breaches).toHaveLength(1); // dashboard visibility still reports the live breach...
+    expect(sent).toEqual([]); // ...but no new reminder row is inserted (rate limit).
+    expect(supabase.inserted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Escalated from QF-20260704-493 (source LOC 136 exceeded the 75-LOC QF Tier-3 cap; classified via `leo-create-sd.js --from-qf`).
- Adds a feedback-consumption SLA gauge: `lib/coordinator/feedback-sla-gauge.cjs` flags unconsumed rows in the 4 actionable feedback categories (`adam_adherence_drift`, `completion_flag`, `coordinator_review`, `harness_backlog` high/critical) that exceed a 7-day consumption SLA, with per-category-per-day dedup so at most one reminder fires per breach per day.
- Wires the gauge into `scripts/fleet-dashboard.cjs` (new `slagauge` section) and into `scripts/coordinator-startup-check.mjs`'s `STANDARD_LOOPS` (new daily `feedback-sla` cron entry).
- Supersedes PR #5563 (same commit content, retargeted onto the SD-named branch per `ShippingPreflightVerifier`'s branch-pattern convention).

## Test plan
- [x] `tests/unit/coordinator/feedback-sla-gauge.test.js` — 8 tests: pure `computeBreaches`/`slaKeyFor` cases, injected-fake-supabase `planSlaBreaches`/`remindSlaBreaches` cases (first-run reminder + second-run dedup)
- [x] `tests/unit/coordinator-startup-check.test.mjs` — updated pinned STANDARD_LOOPS assertions (22→23, new `feedback-sla` key)
- [x] Verified live end-to-end: `fleet-dashboard.cjs slagauge` surfaced 3 real breaching categories (76 unconsumed rows); `coordinator-feedback-sla-gauge.cjs` run twice — first run sent 3 reminders, second run deduped all 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)