### PR TITLE
QF-20260704-081: stale-session-sweep flags HEADLESS_ZOMBIE sessions

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -47,6 +47,16 @@ const { detectDormantWorkers } = require('../lib/fleet/dormancy-watchdog.cjs'); 
 function isDormancyWatchdogEnabled(env = process.env) {
   return env.LEO_DORMANCY_WATCHDOG_ENABLED === 'on';
 }
+
+const HEADLESS_ZOMBIE_MIN_MS = 15 * 60 * 1000;
+
+// QF-20260704-081: pure predicate, exported so it can be unit-tested without a live
+// claude_sessions table. See call site (classification loop) for full context/RCA.
+function isHeadlessZombie(session, telemetry, nowMs) {
+  if (!session || (session.terminal_id || session.tty || telemetry?.worktree_path)) return false;
+  const claimAgeMs = session.claimed_at ? nowMs - Date.parse(session.claimed_at) : 0;
+  return claimAgeMs > HEADLESS_ZOMBIE_MIN_MS;
+}
 // SD-LEO-INFRA-STALE-SWEEP-PID-LIVENESS-GUARD-001: PID-liveness guard for the conflict-eviction path.
 const { shouldHoldClaim } = require('../lib/fleet/claim-release-guard.cjs');
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3b — top-level require so wire-check
@@ -756,7 +766,9 @@ async function main() {
     if (sessionIds.length > 0) {
       const { data: telemetryRows } = await supabase
         .from('claude_sessions')
-        .select('session_id,process_alive_at,expected_silence_until,current_tool,current_tool_expected_end_at,last_activity_kind')
+        // worktree_path: not exposed by v_active_sessions -- needed for the QF-20260704-081
+        // HEADLESS_ZOMBIE discriminator (fresh heartbeat + terminal_id/tty/worktree_path all null).
+        .select('session_id,process_alive_at,expected_silence_until,current_tool,current_tool_expected_end_at,last_activity_kind,worktree_path')
         .in('session_id', sessionIds);
       for (const row of telemetryRows || []) {
         telemetryMap.set(row.session_id, row);
@@ -866,6 +878,16 @@ async function main() {
       status = 'STALE_UNKNOWN'; // Between 5-15min, no PID match = might be on another host
     }
 
+    // QF-20260704-081: a session with a fresh heartbeat (never ages into DEAD via the
+    // staleness path above) but terminal_id, tty, AND worktree_path ALL null for 15min+ is a
+    // binding signature no real windowed session has -- its parked loop keeps
+    // heartbeating/rescheduling while the window itself is gone (confirmed specimen: PID 23348
+    // survived windowless 14.7h holding a claim). Detected here, released below -- never auto-kill
+    // the OS process; surfaced for a coordinator kill decision.
+    if (status === 'ACTIVE' && isHeadlessZombie(s, telemetryMap.get(s.session_id), now.getTime())) {
+      status = 'HEADLESS_ZOMBIE';
+    }
+
     return {
       ...s,
       isStale: isStale && !hasPidAlive && !(sourceSide && sourceSide.alive),
@@ -876,6 +898,25 @@ async function main() {
   });
   if (collisions.length > 0) {
     await splitCollidingSessions(supabase, collisions, actions, warnings);
+  }
+
+  // 2b-2. QF-20260704-081: release HEADLESS_ZOMBIE claims. Verify PID, release the claim, mark
+  // released -- NEVER auto-kill the OS process; surface via session_coordination so a coordinator
+  // makes the kill decision (the process may be doing unrelated harmless work post-window-death).
+  const headlessZombies = classified.filter(s => s.status === 'HEADLESS_ZOMBIE');
+  for (const s of headlessZombies) {
+    const pidLive = s.pid ? isProcessRunning(Number(s.pid)) : false;
+    await supabase.from('claude_sessions').update({
+      sd_key: null, status: 'released', released_at: now.toISOString(), released_reason: 'SWEEP_HEADLESS_ZOMBIE',
+    }).eq('session_id', s.session_id);
+    actions.push('HEADLESS_ZOMBIE: released ' + s.session_id + ' (sd=' + (s.sd_key || 'none') + ', pid=' + s.pid + ', pid_live=' + pidLive + ')');
+    await supabase.from('session_coordination').insert({
+      message_type: 'INFO',
+      subject: 'HEADLESS_ZOMBIE released: ' + s.session_id,
+      body: 'Fresh heartbeat but terminal_id/tty/worktree_path all null for 15min+ -- claim released. pid=' + s.pid + ' live=' + pidLive + '. Verify and kill the OS process if still live and truly orphaned.',
+      sender_type: 'sweep',
+      payload: { kind: 'headless_zombie_released', session_id: s.session_id, pid: s.pid, pid_live: pidLive },
+    });
   }
 
   // 2c. npm install lock cleanup (Layer 3)
@@ -2610,6 +2651,8 @@ module.exports.anyClaudeProcessRunning = anyClaudeProcessRunning;
 // does — no production behavior change.
 module.exports.isSweepResetAllowed = isSweepResetAllowed;
 module.exports.isDormancyWatchdogEnabled = isDormancyWatchdogEnabled; // SD-FDBK-ENH-CONFIRMED-LIVE-TODAY-001
+module.exports.isHeadlessZombie = isHeadlessZombie; // QF-20260704-081
+module.exports.HEADLESS_ZOMBIE_MIN_MS = HEADLESS_ZOMBIE_MIN_MS; // QF-20260704-081
 module.exports.__setExecContextGuardForTest = (mock) => { _execContextGuardCache = mock; };
 
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): export the guarded

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -52,8 +52,12 @@ const HEADLESS_ZOMBIE_MIN_MS = 15 * 60 * 1000;
 
 // QF-20260704-081: pure predicate, exported so it can be unit-tested without a live
 // claude_sessions table. See call site (classification loop) for full context/RCA.
+// is_virtual sessions (lib/virtual-session-factory.mjs) are excluded: they legitimately never
+// set terminal_id/tty/worktree_path at all (no window to bind to), so without this guard every
+// virtual/drain session would false-positive as headless after 15 minutes.
 function isHeadlessZombie(session, telemetry, nowMs) {
-  if (!session || (session.terminal_id || session.tty || telemetry?.worktree_path)) return false;
+  if (!session || session.is_virtual) return false;
+  if (session.terminal_id || session.tty || telemetry?.worktree_path) return false;
   const claimAgeMs = session.claimed_at ? nowMs - Date.parse(session.claimed_at) : 0;
   return claimAgeMs > HEADLESS_ZOMBIE_MIN_MS;
 }

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -910,8 +910,11 @@ async function main() {
   const headlessZombies = classified.filter(s => s.status === 'HEADLESS_ZOMBIE');
   for (const s of headlessZombies) {
     const pidLive = s.pid ? isProcessRunning(Number(s.pid)) : false;
+    // QF-20260508-230: ck_claude_sessions_worktree_state_consistency requires sd_key IS NOT NULL
+    // OR (worktree_path IS NULL AND worktree_branch IS NULL) -- every release site must clear both.
     await supabase.from('claude_sessions').update({
       sd_key: null, status: 'released', released_at: now.toISOString(), released_reason: 'SWEEP_HEADLESS_ZOMBIE',
+      worktree_path: null, worktree_branch: null, has_uncommitted_changes: false, current_branch: null,
     }).eq('session_id', s.session_id);
     actions.push('HEADLESS_ZOMBIE: released ' + s.session_id + ' (sd=' + (s.sd_key || 'none') + ', pid=' + s.pid + ', pid_live=' + pidLive + ')');
     await supabase.from('session_coordination').insert({

--- a/tests/unit/stale-session-sweep-headless-zombie.test.js
+++ b/tests/unit/stale-session-sweep-headless-zombie.test.js
@@ -54,4 +54,9 @@ describe('isHeadlessZombie', () => {
     const session = { session_id: 's7', terminal_id: null, tty: null, claimed_at: OLD_CLAIM };
     expect(isHeadlessZombie(session, undefined, NOW)).toBe(true);
   });
+
+  it('does NOT flag a legitimate is_virtual (drain) session -- these never set terminal_id/tty/worktree_path by design', () => {
+    const session = { session_id: 's8', is_virtual: true, terminal_id: null, tty: null, claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(false);
+  });
 });

--- a/tests/unit/stale-session-sweep-headless-zombie.test.js
+++ b/tests/unit/stale-session-sweep-headless-zombie.test.js
@@ -1,0 +1,57 @@
+/**
+ * QF-20260704-081 — HEADLESS_ZOMBIE discriminator.
+ *
+ * A pre-Cursor-crash claude process (PID 23348) survived windowless for 14.7h holding
+ * QF-20260703-665: its parked loop kept waking->heartbeating->rescheduling, so every sweep
+ * read it healthy, while terminal_id, tty, AND worktree_path were all NULL -- a binding
+ * signature no real windowed session has. The sweep only aged heartbeats, so this
+ * work-alive/comms-dead orphan was invisible until a human noticed the callsign had no window.
+ *
+ * These tests exercise ONLY the pure predicate -- no claude_sessions access, matching the
+ * established pattern in stale-session-sweep-dormancy-gate.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { isHeadlessZombie, HEADLESS_ZOMBIE_MIN_MS } = require('../../scripts/stale-session-sweep.cjs');
+
+const NOW = Date.parse('2026-07-04T12:00:00Z');
+const OLD_CLAIM = new Date(NOW - HEADLESS_ZOMBIE_MIN_MS - 60_000).toISOString(); // just past the threshold
+const RECENT_CLAIM = new Date(NOW - 60_000).toISOString(); // 1 minute ago
+
+describe('isHeadlessZombie', () => {
+  it('flags a session with terminal_id/tty/worktree_path all null, claimed well past the threshold', () => {
+    const session = { session_id: 's1', terminal_id: null, tty: null, claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(true);
+  });
+
+  it('does NOT flag a real windowed session (terminal_id present)', () => {
+    const session = { session_id: 's2', terminal_id: 'win-cc-13596-22408', tty: null, claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(false);
+  });
+
+  it('does NOT flag a session with tty set (Unix terminal)', () => {
+    const session = { session_id: 's3', terminal_id: null, tty: '/dev/ttys001', claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(false);
+  });
+
+  it('does NOT flag a session with a worktree_path set', () => {
+    const session = { session_id: 's4', terminal_id: null, tty: null, claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: 'C:/Users/rickf/Projects/foo' }, NOW)).toBe(false);
+  });
+
+  it('does NOT flag a session that JUST went headless (grace period, avoids a startup race false-positive)', () => {
+    const session = { session_id: 's5', terminal_id: null, tty: null, claimed_at: RECENT_CLAIM };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(false);
+  });
+
+  it('does NOT flag a session with no claimed_at at all (never held a claim long enough to matter)', () => {
+    const session = { session_id: 's6', terminal_id: null, tty: null, claimed_at: null };
+    expect(isHeadlessZombie(session, { worktree_path: null }, NOW)).toBe(false);
+  });
+
+  it('handles a missing telemetry row gracefully (no worktree_path signal available)', () => {
+    const session = { session_id: 's7', terminal_id: null, tty: null, claimed_at: OLD_CLAIM };
+    expect(isHeadlessZombie(session, undefined, NOW)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- A pre-Cursor-crash claude process survived windowless for 14.7h holding a claim: fresh heartbeat kept it reading ACTIVE forever, while `terminal_id`/`tty`/`worktree_path` were all NULL -- a binding signature no real windowed session has
- Adds `isHeadlessZombie()` (pure, exported) detecting this signature past a 15-minute grace period
- Flagged sessions are released (claim cleared) and surfaced via `session_coordination` for a coordinator kill decision -- never auto-killed

## Test plan
- [x] 7 unit tests for `isHeadlessZombie()` covering the discriminator, all 3 "not a zombie" cases (terminal_id/tty/worktree_path present), the grace-period race guard, and the missing-telemetry-row fallback
- [x] All 17 pre-existing stale-session-sweep tests pass unchanged
- [x] Broader regression sweep: 321/321 tests pass across `tests/unit/*sweep*` and `tests/unit/fleet/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)