### PR TITLE
chore(SD-LEO-FIX-FEEDBACK-CONSUMPTION-SLA-001): register coordinator:feedback-sla-gauge npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "singleton-relaunch:run": "node scripts/singleton-relaunch-scheduler.mjs",
     "coordinator:relay-drain": "node scripts/coordinator-relay-drain.cjs",
     "coordinator:relay-drop-gauge": "node scripts/coordinator-relay-drop-gauge.cjs",
+    "coordinator:feedback-sla-gauge": "node scripts/coordinator-feedback-sla-gauge.cjs",
     "comms:three-way-drill": "node scripts/three-way-comms-drill.mjs",
     "chairman:directive:issue": "node scripts/issue-chairman-directive.cjs",
     "chairman:directive:ack": "node scripts/ack-chairman-directive.cjs",


### PR DESCRIPTION
## Summary
- Follow-up to #5565 (SD-LEO-FIX-FEEDBACK-CONSUMPTION-SLA-001). LEAD-FINAL-APPROVAL's wire-check gate flagged `scripts/coordinator-feedback-sla-gauge.cjs` and `lib/coordinator/feedback-sla-gauge.cjs` as unreachable from any entry point, since the CLI script is invoked only by the cron schedule (no static import anywhere).
- Registers `coordinator:feedback-sla-gauge` in package.json's `scripts` map, matching the established convention for sibling cron CLIs (`coordinator:relay-drop-gauge`, `sre:row-growth`, etc.) — entry points are discovered from package.json scripts.

## Test plan
- [x] Wire-check gate re-run locally confirms both files now resolve to a reachable entry point