### PR TITLE
fix(QF-20260704-993): exclude needs_decision completion_flag rows from /leo assist Phase 1

### DIFF
--- a/lib/quality/assist-engine.js
+++ b/lib/quality/assist-engine.js
@@ -96,6 +96,27 @@ function splitEnhancementsExcludingHarnessBacklog(enriched) {
 }
 
 /**
+ * QF-20260704-993: Exclude category='completion_flag' rows from the issues stream.
+ *
+ * scripts/capture-completion-flags.js deliberately stamps `needs_decision` completion
+ * flags with type='issue' (category='completion_flag') for general inbox visibility --
+ * but Phase 1's autonomous bug-fix loop has no business attempting a code fix for a pure
+ * decision item. Confirmed live: 86/86 rows in the issues stream were completion_flag rows
+ * with zero genuine bugs. Excluded rows still surface via /leo inbox for chairman/coordinator
+ * review; this only removes them from the autonomous-fix retry loop.
+ *
+ * @param {Array<object>} enriched - Sensemaking-enriched feedback rows
+ * @returns {{issues: Array<object>, skippedNeedsDecision: number}}
+ */
+const NEEDS_DECISION_CATEGORY = 'completion_flag';
+function filterIssuesExcludingNeedsDecision(enriched) {
+  const all = (enriched || []).filter(i => i.type === 'issue');
+  const issues = all.filter(i => i.category !== NEEDS_DECISION_CATEGORY);
+  const skippedNeedsDecision = all.length - issues.length;
+  return { issues, skippedNeedsDecision };
+}
+
+/**
  * AssistEngine - Main class for /leo assist processing
  */
 class AssistEngine {
@@ -223,7 +244,11 @@ class AssistEngine {
     const { enriched, discardedCount } = enrichWithSensemaking(triaged);
 
     // Separate issues from enhancements; harness_backlog filtered out per QF-20260509-149.
-    const issues = enriched.filter(i => i.type === 'issue');
+    // needs_decision completion_flag rows filtered out per QF-20260704-993.
+    const { issues, skippedNeedsDecision } = filterIssuesExcludingNeedsDecision(enriched);
+    if (skippedNeedsDecision > 0) {
+      console.log(`[assist-engine] Excluded ${skippedNeedsDecision} needs_decision completion_flag row(s) from Phase 1 autonomous-fix stream (QF-20260704-993)`);
+    }
     const { enhancements, skippedHarnessBacklog } = splitEnhancementsExcludingHarnessBacklog(enriched);
     if (skippedHarnessBacklog > 0) {
       console.log(`[assist-engine] Excluded ${skippedHarnessBacklog} harness_backlog row(s) from enhancements stream (campaign-mode workflow)`);
@@ -799,7 +824,9 @@ export {
   RESULT_TYPES,
   filterStaleUntriaged,
   STALE_UNTRIAGED_GRACE_MS,
-  splitEnhancementsExcludingHarnessBacklog
+  splitEnhancementsExcludingHarnessBacklog,
+  filterIssuesExcludingNeedsDecision,
+  NEEDS_DECISION_CATEGORY
 };
 
 // Default export

--- a/tests/unit/assist-engine-needs-decision-filter.test.js
+++ b/tests/unit/assist-engine-needs-decision-filter.test.js
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for QF-20260704-993: needs_decision completion_flag exclusion from
+ * /leo assist Phase 1's autonomous issue stream.
+ *
+ * scripts/capture-completion-flags.js stamps needs_decision flags with type='issue'
+ * (category='completion_flag') for general inbox visibility. Confirmed live: all 86
+ * rows in the issues stream were category='completion_flag' with zero genuine bugs --
+ * Phase 1's autonomous fix-retry loop was attempting code fixes for pure decision items.
+ * Fix excludes them at the source (lib/quality/assist-engine.js).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterIssuesExcludingNeedsDecision, NEEDS_DECISION_CATEGORY } from '../../lib/quality/assist-engine.js';
+
+function row({ id, type = 'issue', category = null }) {
+  return { id, type, category };
+}
+
+describe('QF-20260704-993: filterIssuesExcludingNeedsDecision', () => {
+  it('excludes type=issue rows with category=completion_flag', () => {
+    const enriched = [
+      row({ id: 'a', category: 'completion_flag' }),
+      row({ id: 'b', category: 'bug' }),
+      row({ id: 'c', category: 'completion_flag' }),
+      row({ id: 'd', category: null }),
+    ];
+    const { issues, skippedNeedsDecision } = filterIssuesExcludingNeedsDecision(enriched);
+    expect(issues.map(e => e.id)).toEqual(['b', 'd']);
+    expect(skippedNeedsDecision).toBe(2);
+  });
+
+  it('does not affect type=enhancement rows', () => {
+    const enriched = [
+      row({ id: 'e1', type: 'enhancement', category: 'completion_flag' }),
+      row({ id: 'i1', type: 'issue', category: 'completion_flag' }),
+    ];
+    const { issues, skippedNeedsDecision } = filterIssuesExcludingNeedsDecision(enriched);
+    expect(issues).toEqual([]);
+    expect(skippedNeedsDecision).toBe(1);
+  });
+
+  it('returns empty + zero on empty input', () => {
+    const { issues, skippedNeedsDecision } = filterIssuesExcludingNeedsDecision([]);
+    expect(issues).toEqual([]);
+    expect(skippedNeedsDecision).toBe(0);
+  });
+
+  it('returns empty + zero on null/undefined', () => {
+    expect(filterIssuesExcludingNeedsDecision(null)).toEqual({ issues: [], skippedNeedsDecision: 0 });
+    expect(filterIssuesExcludingNeedsDecision(undefined)).toEqual({ issues: [], skippedNeedsDecision: 0 });
+  });
+
+  it('passes through issues when none are completion_flag', () => {
+    const enriched = [
+      row({ id: 'i1', category: 'bug' }),
+      row({ id: 'i2', category: 'regression' }),
+    ];
+    const { issues, skippedNeedsDecision } = filterIssuesExcludingNeedsDecision(enriched);
+    expect(issues.map(e => e.id)).toEqual(['i1', 'i2']);
+    expect(skippedNeedsDecision).toBe(0);
+  });
+
+  it('exports the NEEDS_DECISION_CATEGORY constant used by capture-completion-flags.js', () => {
+    expect(NEEDS_DECISION_CATEGORY).toBe('completion_flag');
+  });
+});


### PR DESCRIPTION
## Summary
- \`scripts/capture-completion-flags.js\` stamps \`needs_decision\` completion flags with `type='issue'` (`category='completion_flag'`) for general inbox visibility — but Phase 1's autonomous bug-fix loop treated every one of those as an autonomously-fixable code bug.
- Confirmed live: 86/86 rows in the issues stream were `category='completion_flag'` with `priority=null` — zero genuine bugs.
- Extracted a pure `filterIssuesExcludingNeedsDecision()` function (matching the existing `splitEnhancementsExcludingHarnessBacklog` pattern from QF-20260509-149) and wired it into `AssistEngine.loadInboxItems()`. Excluded rows still surface via `/leo inbox` for chairman/coordinator review — they're just no longer fed into the autonomous fix-retry loop.

## Test plan
- [x] `node -c lib/quality/assist-engine.js` — syntax check
- [x] New unit test `tests/unit/assist-engine-needs-decision-filter.test.js` (6 tests)
- [x] Existing `assist-engine-harness-backlog-filter.test.js` + `assist-engine-stale-filter.test.js` regression pass (17/17 total)
- [x] Live dry-run verification: `Issues: 0 Enhancements: 191 Total: 998` (previously `Issues: 86`)

QF-20260704-993 · Tier 2 (97 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)