### PR TITLE
fix(QF-20260704-180): DESIGN gate false-blocks non-React apps + non-deterministic dead-end flag

### DIFF
--- a/lib/sub-agents/design/checks.js
+++ b/lib/sub-agents/design/checks.js
@@ -9,6 +9,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { determineDesignThreshold, getGitDiffFiles } from './utils.js';
 
@@ -16,6 +17,18 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const execAsync = promisify(exec);
+
+/**
+ * QF-20260704-180: react-only accessibility scoring hardcodes src/components, so a
+ * legitimately non-React app (server-rendered/template, e.g. plain Express + HTML)
+ * has no such directory and the standalone design-sub-agent CLI produces no parseable
+ * "Design Score: X/100" line — the score silently defaults to 0, false-blocking a
+ * change with zero real accessibility violations. Detect that case up front and skip
+ * with a neutral result instead of scoring against a directory that cannot exist.
+ */
+export function hasReactComponentsDir(repoPath) {
+  return fs.existsSync(path.join(repoPath, 'src', 'components'));
+}
 
 /**
  * Check design system compliance
@@ -108,6 +121,18 @@ export async function analyzeComponents(repoPath, _sdId) {
  */
 export async function checkAccessibility(repoPath, sdId, supabase) {
   try {
+    if (!hasReactComponentsDir(repoPath)) {
+      console.log('   ⏭️  No src/components directory — non-React app, skipping React-specific accessibility scoring');
+      return {
+        checked: false,
+        issues: 0,
+        skipped: true,
+        reason: 'no src/components directory (non-React app)',
+        affected_files: [],
+        issue_details: []
+      };
+    }
+
     console.log('   🔍 Running design-sub-agent with git-diff-only mode...');
 
     // Get SD metadata to determine adaptive threshold
@@ -214,13 +239,16 @@ export async function checkResponsiveDesign(repoPath, _sdId) {
 
     const hasResponsive = parseInt(responsiveClasses.trim()) > 0;
     const total = parseInt(totalComponents.trim());
+    // QF-20260704-180: zero components (no src/components dir, e.g. a non-React app)
+    // cannot be "missing" responsive classes — there is nothing to flag.
+    const missingBreakpoints = total === 0 ? 0 : (hasResponsive ? 0 : 1);
 
     return {
       checked: true,
-      missing_breakpoints: hasResponsive ? 0 : 1,
+      missing_breakpoints: missingBreakpoints,
       has_responsive_classes: hasResponsive,
       total_components: total,
-      non_responsive_components: hasResponsive ? [] : ['Multiple components may need responsive classes']
+      non_responsive_components: missingBreakpoints ? ['Multiple components may need responsive classes'] : []
     };
   } catch (error) {
     return {

--- a/lib/sub-agents/design/index.js
+++ b/lib/sub-agents/design/index.js
@@ -103,6 +103,26 @@ export function applyRepoResolutionVerdict(results, resolution) {
 }
 
 /**
+ * QF-20260704-180: fetch a SD's user_stories in a DETERMINISTIC order. Without an
+ * explicit ORDER BY, buildInteractionGraph's dead-end detection (last array item = dead
+ * end candidate, per workflow-detection.js) flagged a different, effectively random
+ * story CRITICAL on every run since the DB's default return order is not guaranteed.
+ * Pure passthrough + exported so the ordering contract is directly unit-testable
+ * without mocking the full execute() pipeline.
+ *
+ * @param {Object} dbClient - Supabase client (or injectable test double)
+ * @param {string} sdId - Strategic Directive ID
+ * @returns {Promise<{data: Array|null, error: Object|null}>}
+ */
+export async function fetchOrderedUserStories(dbClient, sdId) {
+  return dbClient
+    .from('user_stories')
+    .select('*')
+    .eq('sd_id', sdId)
+    .order('id', { ascending: true });
+}
+
+/**
  * Execute DESIGN sub-agent
  * Validates UI/UX design compliance
  *
@@ -327,11 +347,8 @@ export async function execute(sdId, subAgent, options = {}) {
           .eq('sd_id', sdId)
           .single();
 
-        // Fetch user stories
-        const { data: userStories, error: storiesError } = await dbClient
-          .from('user_stories')
-          .select('*')
-          .eq('sd_id', sdId);
+        // Fetch user stories (deterministic order — see fetchOrderedUserStories)
+        const { data: userStories, error: storiesError } = await fetchOrderedUserStories(dbClient, sdId);
 
         // Fetch current workflow baseline from SD
         const { data: sdData, error: sdError } = await dbClient

--- a/tests/unit/sub-agents/design-non-react-app-accessibility.test.js
+++ b/tests/unit/sub-agents/design-non-react-app-accessibility.test.js
@@ -1,0 +1,114 @@
+/**
+ * QF-20260704-180 — DESIGN gate false-blocks non-React apps.
+ *
+ * Two defects, both witnessed via 2 independent adversarial code reviews + e2e suite
+ * against SD-LEO-FEAT-MARKETLENS-CORE-PRODUCT-001 (Express + server-rendered HTML,
+ * legitimately zero React components):
+ *
+ * 1. checkAccessibility (lib/sub-agents/design/checks.js) hardcodes `src/components`
+ *    for its standalone design-sub-agent CLI invocation. When that directory does not
+ *    exist, the CLI produces no parseable "Design Score: X/100" line, so the score
+ *    silently defaults to 0 and `issues` is reported as 1 — a false accessibility
+ *    violation with zero real evidence. Fix: detect the missing directory up front and
+ *    return a neutral skipped result instead of scoring against a path that cannot exist.
+ *
+ * 2. checkResponsiveDesign flags `missing_breakpoints: 1` whenever no responsive
+ *    Tailwind classes are found, even when total_components is 0 (no src/components at
+ *    all) — there is nothing to be "non-responsive". Fix: zero components can never be
+ *    flagged as missing breakpoints.
+ *
+ * A third, separately-witnessed defect (non-deterministic dead-end flagging from an
+ * unsorted user_stories DB fetch) is covered in design-workflow-user-stories-order.test.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// checks.js uses `promisify(exec)`. Attach util.promisify.custom to the mocked exec so
+// promisify(exec) returns our directly-controllable async fn — mirrors the established
+// pattern in design-getgitdifffiles-changeset.test.js.
+const execAsyncImpl = vi.hoisted(() => vi.fn());
+const execMock = vi.hoisted(() => {
+  const { promisify } = require('node:util');
+  const fn = vi.fn();
+  fn[promisify.custom] = execAsyncImpl;
+  return fn;
+});
+vi.mock('child_process', () => ({ exec: execMock }));
+
+const existsSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual();
+  return { ...actual, default: { ...actual.default, existsSync: existsSyncMock }, existsSync: existsSyncMock };
+});
+
+const { hasReactComponentsDir, checkAccessibility, checkResponsiveDesign } =
+  await import('../../../lib/sub-agents/design/checks.js');
+
+describe('QF-20260704-180 — hasReactComponentsDir', () => {
+  beforeEach(() => existsSyncMock.mockReset());
+
+  it('reports true when src/components exists', () => {
+    existsSyncMock.mockReturnValue(true);
+    expect(hasReactComponentsDir('/repo')).toBe(true);
+  });
+
+  it('reports false for a non-React app with no src/components', () => {
+    existsSyncMock.mockReturnValue(false);
+    expect(hasReactComponentsDir('/repo')).toBe(false);
+  });
+});
+
+describe('QF-20260704-180 — checkAccessibility skips non-React apps instead of false-blocking', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset();
+    execAsyncImpl.mockReset();
+  });
+
+  it('returns a neutral skipped result and never shells out when src/components is absent', async () => {
+    existsSyncMock.mockReturnValue(false);
+    const result = await checkAccessibility('/repo', 'SD-XXX', {});
+    expect(result).toEqual({
+      checked: false,
+      issues: 0,
+      skipped: true,
+      reason: 'no src/components directory (non-React app)',
+      affected_files: [],
+      issue_details: [],
+    });
+    expect(execAsyncImpl).not.toHaveBeenCalled();
+  });
+
+  it('still runs the normal design-sub-agent scoring path when src/components exists', async () => {
+    existsSyncMock.mockReturnValue(true);
+    execAsyncImpl.mockResolvedValue({ stdout: 'Design Score: 92/100', stderr: '' });
+    const supabase = {
+      from: () => ({ select: () => ({ eq: () => ({ single: async () => ({ data: { category: 'feature' } }) }) }) }),
+    };
+    const result = await checkAccessibility('/repo', 'SD-XXX', supabase);
+    expect(result.design_score).toBe(92);
+    expect(execAsyncImpl).toHaveBeenCalled();
+  });
+});
+
+describe('QF-20260704-180 — checkResponsiveDesign does not flag zero components as non-responsive', () => {
+  beforeEach(() => execAsyncImpl.mockReset());
+
+  it('reports missing_breakpoints: 0 when there are no components at all', async () => {
+    execAsyncImpl
+      .mockResolvedValueOnce({ stdout: '0\n', stderr: '' }) // responsive class grep
+      .mockResolvedValueOnce({ stdout: '0\n', stderr: '' }); // component find
+    const result = await checkResponsiveDesign('/repo', 'SD-XXX');
+    expect(result.total_components).toBe(0);
+    expect(result.missing_breakpoints).toBe(0);
+    expect(result.non_responsive_components).toEqual([]);
+  });
+
+  it('still flags real components that lack responsive classes', async () => {
+    execAsyncImpl
+      .mockResolvedValueOnce({ stdout: '0\n', stderr: '' }) // no responsive classes found
+      .mockResolvedValueOnce({ stdout: '3\n', stderr: '' }); // 3 real components
+    const result = await checkResponsiveDesign('/repo', 'SD-XXX');
+    expect(result.total_components).toBe(3);
+    expect(result.missing_breakpoints).toBe(1);
+    expect(result.non_responsive_components).toHaveLength(1);
+  });
+});

--- a/tests/unit/sub-agents/design-workflow-user-stories-order.test.js
+++ b/tests/unit/sub-agents/design-workflow-user-stories-order.test.js
@@ -1,0 +1,38 @@
+/**
+ * QF-20260704-180 — DESIGN workflow-review user_stories fetch must be deterministically
+ * ordered. Without an explicit ORDER BY, workflow-detection.js's buildInteractionGraph
+ * builds a linear chain from array order and flags the LAST node a dead end (unless it
+ * matches a landing-page pattern) — so an unsorted DB return order randomly flagged a
+ * different story CRITICAL on every DESIGN run, independent of any real navigation issue.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({})),
+}));
+
+const { fetchOrderedUserStories } = await import('../../../lib/sub-agents/design/index.js');
+
+describe('QF-20260704-180 — fetchOrderedUserStories', () => {
+  let chain;
+  let dbClient;
+
+  beforeEach(() => {
+    chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      order: vi.fn(() => Promise.resolve({ data: [{ id: 'US-1' }, { id: 'US-2' }], error: null })),
+    };
+    dbClient = { from: vi.fn(() => chain) };
+  });
+
+  it('queries user_stories filtered by sd_id with a deterministic id-ascending order', async () => {
+    const result = await fetchOrderedUserStories(dbClient, 'SD-XXX-001');
+
+    expect(dbClient.from).toHaveBeenCalledWith('user_stories');
+    expect(chain.select).toHaveBeenCalledWith('*');
+    expect(chain.eq).toHaveBeenCalledWith('sd_id', 'SD-XXX-001');
+    expect(chain.order).toHaveBeenCalledWith('id', { ascending: true });
+    expect(result.data).toEqual([{ id: 'US-1' }, { id: 'US-2' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Two defects in the PLAN_VERIFY/EXEC-TO-PLAN SUB_AGENT_ORCHESTRATION DESIGN gate, verified by the SD-LEO-FEAT-MARKETLENS-CORE-PRODUCT-001 worker via 2 independent adversarial code reviews + e2e suite. Blocks the flagship MarketLens UI-recovery SDs' EXEC-TO-PLAN handoffs.
- **Accessibility false-block**: `checkAccessibility` (lib/sub-agents/design/checks.js) hardcoded `src/components` for the standalone design-sub-agent CLI invocation. A legitimately non-React app (MarketLens: Express + server-rendered HTML) has no such directory, so the CLI produces no parseable "Design Score: X/100" line — the score silently defaulted to 0 and `issues` reported as 1, a phantom violation with zero real evidence. Now detects the missing directory up front (`hasReactComponentsDir`) and returns a neutral skipped result instead of scoring against a path that cannot exist. `checkResponsiveDesign` had the same class of bug (`missing_breakpoints: 1` for zero components) — fixed identically.
- **Non-deterministic dead-end flag**: the `user_stories` fetch feeding `buildInteractionGraph`'s dead-end detection (workflow-detection.js — flags the LAST array node a dead end unless it matches a landing-page pattern) had no `ORDER BY`, so whichever story landed last in the DB's unordered return became a random CRITICAL dead-end flag on every run, independent of any real navigation issue. Extracted to `fetchOrderedUserStories()` with a deterministic `.order('id', {ascending: true})`.

## Test plan
- [x] `tests/unit/sub-agents/design-non-react-app-accessibility.test.js` (new, 6 tests): `hasReactComponentsDir` true/false, `checkAccessibility` skip path (asserts zero shell-outs) + normal-path regression, `checkResponsiveDesign` zero-components guard + still-flags-real-components regression
- [x] `tests/unit/sub-agents/design-workflow-user-stories-order.test.js` (new, 1 test): asserts `fetchOrderedUserStories` calls `.order('id', {ascending: true})`
- [x] Full `tests/unit/sub-agents/` suite: 15 files / 149 tests pass, 0 regressions
- [x] eslint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)