### PR TITLE
fix(QF-20260704-440): resolveSDContext hardcoded repo paths cause false-low PLAN-TO-LEAD scores for venture SDs

### DIFF
--- a/scripts/modules/traceability-validation/sections/traceability-mapping.js
+++ b/scripts/modules/traceability-validation/sections/traceability-mapping.js
@@ -91,6 +91,14 @@ export async function validateTraceabilityMapping(sd_id, sdUuid, designAnalysis,
   console.log('\n   [C1] PRD -> Implementation Mapping...');
 
   try {
+    // QF-20260704-440: gitRepoPath is null when resolveSDContext couldn't resolve
+    // target_application's repo -- fail loud into the catch below instead of running
+    // git log against process.cwd(), which silently greps the wrong repo and reports
+    // a false "0 commits found" (worse than an honest "cannot verify").
+    if (!gitRepoPath) {
+      throw new Error('target_application repo path unresolved');
+    }
+
     const { stdout: gitLog } = await execAsync(
       `git log --all --grep="${sd_id}" --oneline`,
       { cwd: gitRepoPath, timeout: 10000 }
@@ -109,6 +117,7 @@ export async function validateTraceabilityMapping(sd_id, sdUuid, designAnalysis,
     }
   } catch (err) {
     sectionScore += 3;
+    validation.warnings.push(`[C1] Could not verify commits: ${err.message}`);
     console.log('   WARN Cannot verify git commits (3/7)');
     console.log(`   DEBUG: Git error: ${err.message} | cwd: ${gitRepoPath}`);
   }

--- a/scripts/modules/traceability-validation/utils.js
+++ b/scripts/modules/traceability-validation/utils.js
@@ -8,7 +8,7 @@ import { promisify } from 'util';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { resolveRepoPath } from '../../../lib/repo-paths.js';
+import { resolveRepoPath, resolveRepoPathDbFirst } from '../../../lib/repo-paths.js';
 export const execAsync = promisify(exec);
 
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
@@ -51,8 +51,17 @@ export async function resolveSDContext(sd_id, supabase, prefetchedSd = null) {
       gitRepoPath = EHG_ROOT;
     } else if (targetApp === 'EHG_Engineer') {
       gitRepoPath = EHG_ENGINEER_ROOT;
+    } else if (targetApp) {
+      // QF-20260704-440: resolve venture repos (e.g. MarketLens) via applications.local_path
+      // (DB-first, registry.json fallback) instead of silently falling through to cwd
+      // (EHG_Engineer), which made C1's git log --grep always search the wrong repo.
+      const resolvedPath = await resolveRepoPathDbFirst(targetApp, supabase);
+      gitRepoPath = resolvedPath || null; // fail-loud: unresolvable venture repo, never default to cwd
+      if (!resolvedPath) {
+        console.log(`   WARN: Could not resolve repo path for target_application="${targetApp}" -- C1 git verification will be skipped rather than run against the wrong repo`);
+      }
     }
-    console.log(`   Git Repo: ${gitRepoPath}`);
+    console.log(`   Git Repo: ${gitRepoPath || 'UNRESOLVED'}`);
   }
 
   return { sdUuid, sdKey, sdCategory, sdType, gitRepoPath };

--- a/tests/unit/traceability/c1-git-repo-path-fail-loud.test.js
+++ b/tests/unit/traceability/c1-git-repo-path-fail-loud.test.js
@@ -1,0 +1,42 @@
+// QF-20260704-440: PLAN-TO-LEAD traceability resolveSDContext hardcoded {EHG, EHG_Engineer}
+// for gitRepoPath resolution, so any venture repo (e.g. MarketLens) target_application fell
+// through to process.cwd()=EHG_Engineer root. C1's `git log --grep SD-ID` then searched the
+// WRONG repo and always reported 0 commits -- a false-low cascading into traceabilityMapping/
+// recommendationAdherence/implementationQuality gate scores for every venture-target SD.
+//
+// Fix: resolveSDContext now resolves any non-platform target_application via
+// resolveRepoPathDbFirst (applications.local_path, DB-first / registry.json fallback) and
+// returns gitRepoPath=null (fail-loud) when unresolvable, instead of silently defaulting to
+// cwd. C1 treats a null gitRepoPath as "cannot verify" (3/7) rather than running git in the
+// wrong directory and reporting a false "0 commits found" (also 3/7, but for the wrong reason
+// and masking the real defect).
+
+import { describe, it, expect } from 'vitest';
+import { validateTraceabilityMapping } from '../../../scripts/modules/traceability-validation/sections/traceability-mapping.js';
+
+function makeValidation() {
+  return { score: 0, warnings: [], gate_scores: {}, details: {} };
+}
+
+describe('QF-20260704-440: C1 gitRepoPath fail-loud handling', () => {
+  it('scores C1 as "cannot verify" (3/7) when gitRepoPath is null, without running git', async () => {
+    const v = makeValidation();
+    await validateTraceabilityMapping('SD-TEST-NULL-REPO-001', 'uuid-1', null, null, v, null, 'feature', null, 'feature');
+    expect(v.warnings.some(w => w.includes('[C1]') && w.includes('repo path unresolved'))).toBe(true);
+    expect(v.details.traceability_mapping.commits_referencing_sd).toBeUndefined();
+  });
+
+  it('runs git log against the provided gitRepoPath and finds a real commit reference', async () => {
+    const v = makeValidation();
+    // This repo's own history contains a commit referencing QF-20260704-081 (merged this session).
+    await validateTraceabilityMapping('QF-20260704-081', 'uuid-2', null, null, v, null, 'feature', process.cwd(), 'feature');
+    expect(v.details.traceability_mapping.commits_referencing_sd).toBeGreaterThan(0);
+  });
+
+  it('reports "no commits found" (not "cannot verify") for a resolvable repo with zero matches', async () => {
+    const v = makeValidation();
+    await validateTraceabilityMapping('SD-NONEXISTENT-ID-ZZZZZZZZ', 'uuid-3', null, null, v, null, 'feature', process.cwd(), 'feature');
+    expect(v.warnings.some(w => w.includes('[C1] No commits found referencing SD ID'))).toBe(true);
+    expect(v.warnings.some(w => w.includes('repo path unresolved'))).toBe(false);
+  });
+});

--- a/tests/unit/traceability/resolve-sd-context-venture-repo.test.js
+++ b/tests/unit/traceability/resolve-sd-context-venture-repo.test.js
@@ -1,0 +1,50 @@
+// QF-20260704-440: resolveSDContext hardcoded gitRepoPath resolution to {EHG, EHG_Engineer}
+// only; any venture target_application (e.g. MarketLens) fell through to process.cwd().
+// Fix: resolve any non-platform target_application via resolveRepoPathDbFirst
+// (applications.local_path, DB-first / registry.json fallback), returning null
+// (fail-loud) rather than defaulting to cwd when unresolvable.
+
+import { describe, it, expect, vi } from 'vitest';
+import path from 'path';
+import { resolveSDContext, EHG_ROOT, EHG_ENGINEER_ROOT } from '../../../scripts/modules/traceability-validation/utils.js';
+
+function mockAppsSupabase(rows) {
+  const is = vi.fn(() => Promise.resolve({ data: rows, error: null }));
+  const eq = vi.fn(() => ({ is }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return { from };
+}
+
+describe('QF-20260704-440: resolveSDContext venture repo resolution', () => {
+  it('resolves target_application=EHG to EHG_ROOT without a DB call', async () => {
+    const supabase = mockAppsSupabase([]);
+    const prefetchedSd = { id: 'u1', sd_key: 'SD-1', target_application: 'EHG' };
+    const { gitRepoPath } = await resolveSDContext('SD-1', supabase, prefetchedSd);
+    expect(gitRepoPath).toBe(EHG_ROOT);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('resolves target_application=EHG_Engineer to EHG_ENGINEER_ROOT without a DB call', async () => {
+    const supabase = mockAppsSupabase([]);
+    const prefetchedSd = { id: 'u2', sd_key: 'SD-2', target_application: 'EHG_Engineer' };
+    const { gitRepoPath } = await resolveSDContext('SD-2', supabase, prefetchedSd);
+    expect(gitRepoPath).toBe(EHG_ENGINEER_ROOT);
+  });
+
+  it('resolves a venture target_application via applications.local_path (DB-first)', async () => {
+    const dbPath = 'D:/ventures/marketlens';
+    const supabase = mockAppsSupabase([{ name: 'MarketLens', local_path: dbPath, status: 'active' }]);
+    const prefetchedSd = { id: 'u3', sd_key: 'SD-MARKETLENS-1', target_application: 'MarketLens' };
+    const { gitRepoPath } = await resolveSDContext('SD-MARKETLENS-1', supabase, prefetchedSd);
+    expect(gitRepoPath).toBe(path.resolve(dbPath));
+  });
+
+  it('returns gitRepoPath=null (fail-loud) for an unresolvable venture, never cwd', async () => {
+    const supabase = mockAppsSupabase([]);
+    const prefetchedSd = { id: 'u4', sd_key: 'SD-UNKNOWN-1', target_application: 'definitely-not-a-real-venture-xyz-440' };
+    const { gitRepoPath } = await resolveSDContext('SD-UNKNOWN-1', supabase, prefetchedSd);
+    expect(gitRepoPath).toBeNull();
+    expect(gitRepoPath).not.toBe(process.cwd());
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/modules/traceability-validation/utils.js::resolveSDContext` only resolved `gitRepoPath` for `target_application` in `{EHG, EHG_Engineer}`; any venture repo (MarketLens et al) fell through to `process.cwd()` = EHG_Engineer root, so C1's `git log --grep SD-ID` probe always searched the **wrong repository** and reported 0 commits — cascading false-low traceability scores at PLAN-TO-LEAD for every venture-target SD.
- Same class as QF-775 (cross-repo fitness gate) and other recent MarketLens routing fixes — the harness keeps hardcoding the two-repo world instead of resolving from `applications.local_path`.
- Fix: resolve any `target_application` via `resolveRepoPathDbFirst` (DB-first `applications.local_path`, `registry.json` fallback) and fail loud (`gitRepoPath=null`) instead of silently defaulting to cwd when unresolvable.
- C1 now treats an unresolved path as "cannot verify" (3/7) rather than running `git log` against the wrong repo and reporting a false "0 commits found" (masks the real defect, even though the point value happens to be the same).

## Test plan
- [x] `node -c` syntax check on both changed files
- [x] New unit tests: `tests/unit/traceability/c1-git-repo-path-fail-loud.test.js` (3 tests), `tests/unit/traceability/resolve-sd-context-venture-repo.test.js` (4 tests)
- [x] Existing `tests/unit/traceability/recommendation-adherence-backend-skip.test.js` + `tests/unit/harden-leo-handoff-gate.test.js` regression pass (18/18 total across the 4 files)

QF-20260704-440 · Tier 2 (20 LOC production, time-critical — 2 MarketLens SDs hit PLAN-TO-LEAD within hours)

🤖 Generated with [Claude Code](https://claude.com/claude-code)