### PR TITLE
fix(QF-20260704-468): fail-open LEAD-FINAL FR_DELIVERY_VERIFICATION gate on transient throws

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -922,6 +922,64 @@ export function createPipelineFlowGate() {
   };
 }
 
+/** The real validation body — separated so the fail-open wrapper below stays trivial. */
+async function runFRDeliveryVerification(ctx, supabase, prdRepo) {
+  console.log('\n🔒 GATE 6: FR Delivery Verification (CONST-012)');
+  console.log('-'.repeat(50));
+
+  const prd = await prdRepo?.getBySdUuid(ctx.sd.id);
+
+  if (!prd) {
+    const { data: children } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('parent_sd_id', ctx.sd.id);
+
+    if (children && children.length > 0) {
+      console.log('   ℹ️  Orchestrator SD — FR verification delegated to children');
+      return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator SD — FR verification delegated to children'] };
+    }
+
+    console.log('   ⚠️  No PRD found — skipping FR verification');
+    return { passed: true, score: 80, max_score: 100, issues: [], warnings: ['No PRD found — FR delivery verification skipped'] };
+  }
+
+  const frs = prd.functional_requirements || [];
+  if (frs.length === 0) {
+    console.log('   ℹ️  No functional requirements in PRD');
+    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No FRs defined in PRD'] };
+  }
+
+  console.log(`   📋 Checking ${frs.length} functional requirements (per-FR mapping)...`);
+
+  // SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001: real per-FR classification (validated story
+  // REFERENCING the FR id, or approver-gated descope) — NOT the prior any-completed-story
+  // proxy that marked every FR delivered if any story existed. Enforcement is gated by
+  // LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only) so this strict path cannot brick
+  // the ~every in-flight SD whose stories do not yet reference FR ids.
+  const classification = await classifyFrDelivery(supabase, {
+    sdId: ctx.sd.id,
+    sdMetadata: ctx.sd.metadata || {},
+    functionalRequirements: frs,
+    requesterSessionId: ctx.sessionId || ctx.session_id || null,
+  });
+  for (const f of classification.frs) {
+    const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
+    console.log(`   ${mark} ${f.id} [${f.status}]: ${safeTruncate(f.description || '', 56)}`);
+  }
+  const enforced = isFrTraceabilityEnforced();
+  console.log(`\n   📊 FR delivery: ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+  const result = projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_VERIFICATION' });
+  if (!result.passed) {
+    console.log(`   ❌ FR delivery FAILED — ${classification.undelivered}/${classification.total} undelivered`);
+  } else if (result.warnings.length) {
+    console.log('   ⚠️  FR delivery passed (warn-only) with undelivered FRs');
+  } else {
+    console.log('   ✅ All FRs delivered or approver-descoped');
+  }
+  return result;
+}
+
 /**
  * Create Gate 6: FR Delivery Verification (CONST-012)
  * Verifies all PRD functional requirements have delivery evidence before SD completion.
@@ -934,60 +992,22 @@ export function createFRDeliveryVerificationGate(supabase, prdRepo) {
   return {
     name: 'FR_DELIVERY_VERIFICATION',
     validator: async (ctx) => {
-      console.log('\n🔒 GATE 6: FR Delivery Verification (CONST-012)');
-      console.log('-'.repeat(50));
-
-      const prd = await prdRepo?.getBySdUuid(ctx.sd.id);
-
-      if (!prd) {
-        const { data: children } = await supabase
-          .from('strategic_directives_v2')
-          .select('id')
-          .eq('parent_sd_id', ctx.sd.id);
-
-        if (children && children.length > 0) {
-          console.log('   ℹ️  Orchestrator SD — FR verification delegated to children');
-          return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator SD — FR verification delegated to children'] };
-        }
-
-        console.log('   ⚠️  No PRD found — skipping FR verification');
-        return { passed: true, score: 80, max_score: 100, issues: [], warnings: ['No PRD found — FR delivery verification skipped'] };
+      // QF-20260704-468 (pattern-port of SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001 FR-2):
+      // ValidationOrchestrator blocks on the STATIC gate.required=true whenever a validator
+      // THROWS — so a transient classifier error would hard-fail every LEAD-FINAL even in
+      // warn-only mode. Off => thrown errors resolve to a passing warn result; ON => strict
+      // propagation preserved (a genuine FR-delivery failure still fails via projectGateResult,
+      // which never throws).
+      try {
+        return await runFRDeliveryVerification(ctx, supabase, prdRepo);
+      } catch (err) {
+        if (isFrTraceabilityEnforced()) throw err;
+        console.log(`   ⚠️  FR delivery verification errored in warn-only mode (fail-open): ${err.message}`);
+        return {
+          passed: true, score: 100, max_score: 100, issues: [],
+          warnings: [`FR delivery verification errored (warn-only, fail-open): ${err.message}`],
+        };
       }
-
-      const frs = prd.functional_requirements || [];
-      if (frs.length === 0) {
-        console.log('   ℹ️  No functional requirements in PRD');
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No FRs defined in PRD'] };
-      }
-
-      console.log(`   📋 Checking ${frs.length} functional requirements (per-FR mapping)...`);
-
-      // SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001: real per-FR classification (validated story
-      // REFERENCING the FR id, or approver-gated descope) — NOT the prior any-completed-story
-      // proxy that marked every FR delivered if any story existed. Enforcement is gated by
-      // LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only) so this strict path cannot brick
-      // the ~every in-flight SD whose stories do not yet reference FR ids.
-      const classification = await classifyFrDelivery(supabase, {
-        sdId: ctx.sd.id,
-        sdMetadata: ctx.sd.metadata || {},
-        functionalRequirements: frs,
-        requesterSessionId: ctx.sessionId || ctx.session_id || null,
-      });
-      for (const f of classification.frs) {
-        const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
-        console.log(`   ${mark} ${f.id} [${f.status}]: ${safeTruncate(f.description || '', 56)}`);
-      }
-      const enforced = isFrTraceabilityEnforced();
-      console.log(`\n   📊 FR delivery: ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
-      const result = projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_VERIFICATION' });
-      if (!result.passed) {
-        console.log(`   ❌ FR delivery FAILED — ${classification.undelivered}/${classification.total} undelivered`);
-      } else if (result.warnings.length) {
-        console.log('   ⚠️  FR delivery passed (warn-only) with undelivered FRs');
-      } else {
-        console.log('   ✅ All FRs delivered or approver-descoped');
-      }
-      return result;
     },
     // `required` is decided dynamically inside the validator result (projectGateResult sets it
     // from the enforcement flag). Keep the static flag true so the orchestrator consults the

--- a/tests/unit/lead-final-fr-delivery-verification-fail-open.test.js
+++ b/tests/unit/lead-final-fr-delivery-verification-fail-open.test.js
@@ -1,0 +1,65 @@
+// QF-20260704-468: pattern-port of SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001's FR-2
+// fail-open fix from the EXEC-TO-PLAN FR_DELIVERY_TRACEABILITY gate onto the
+// LEAD-FINAL FR_DELIVERY_VERIFICATION gate (Gate 6, CONST-012).
+//
+// ValidationOrchestrator blocks on the STATIC gate.required=true whenever a
+// validator THROWS (ValidationOrchestrator.js: `!gateResult.passed && gate.required
+// !== false`) -- so a transient error (e.g. prdRepo/classifier DB hiccup) would
+// hard-fail every LEAD-FINAL even in warn-only mode. This SD lives on the live
+// chairman-facing critical path (every SD crosses LEAD-FINAL).
+//
+// Acceptance is BOTH-DIRECTIONS: (1) a thrown/transient failure degrades to a
+// passing warn result when enforcement is OFF; (2) a genuine FR-delivery failure
+// (no throw, classifier legitimately reports undelivered FRs) still FAILS the gate.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../scripts/modules/handoff/gates/fr-delivery-classifier.js', () => ({
+  classifyFrDelivery: vi.fn(),
+  projectGateResult: vi.fn(),
+  isFrTraceabilityEnforced: vi.fn(() => process.env.LEO_FR_TRACEABILITY_ENFORCE === 'true'),
+}));
+
+const { classifyFrDelivery, projectGateResult } = await import('../../scripts/modules/handoff/gates/fr-delivery-classifier.js');
+const { createFRDeliveryVerificationGate } = await import('../../scripts/modules/handoff/executors/lead-final-approval/gates.js');
+
+function throwingPrdRepo() {
+  return { getBySdUuid: vi.fn(() => { throw new Error('transient db error'); }) };
+}
+
+function fakeSupabase() {
+  return { from: () => ({ select: () => ({ eq: () => Promise.resolve({ data: [] }) }) }) };
+}
+
+describe('QF-20260704-468: FR_DELIVERY_VERIFICATION fail-open contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.LEO_FR_TRACEABILITY_ENFORCE;
+  });
+
+  it('thrown validator body with enforcement OFF => passing warn result (never blocks)', async () => {
+    delete process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    const gate = createFRDeliveryVerificationGate(fakeSupabase(), throwingPrdRepo());
+    const result = await gate.validator({ sd: { id: 'sd-1' } });
+    expect(result.passed).toBe(true);
+    expect(result.warnings.join(' ')).toMatch(/fail-open/);
+  });
+
+  it('thrown validator body with enforcement ON => error propagates (strict)', async () => {
+    process.env.LEO_FR_TRACEABILITY_ENFORCE = 'true';
+    const gate = createFRDeliveryVerificationGate(fakeSupabase(), throwingPrdRepo());
+    await expect(gate.validator({ sd: { id: 'sd-1' } })).rejects.toThrow('transient db error');
+  });
+
+  it('a genuine FR-delivery failure (no throw) still FAILS the gate', async () => {
+    const prd = { getBySdUuid: vi.fn(() => Promise.resolve({ functional_requirements: [{ id: 'FR-1' }] })) };
+    classifyFrDelivery.mockResolvedValue({ frs: [{ id: 'FR-1', status: 'undelivered' }], delivered: 0, descoped: 0, undelivered: 1, total: 1 });
+    projectGateResult.mockReturnValue({ passed: false, score: 0, max_score: 100, issues: ['FR-1 undelivered'], warnings: [] });
+    const gate = createFRDeliveryVerificationGate(fakeSupabase(), prd);
+    const result = await gate.validator({ sd: { id: 'sd-2' } });
+    expect(result.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Pattern-port of SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001's FR-2 fix (`e868f16668`), applied to the sibling gate at the LEAD-FINAL boundary.
- `scripts/modules/handoff/executors/lead-final-approval/gates.js`'s `FR_DELIVERY_VERIFICATION` gate (Gate 6, CONST-012) carried the same static-required-vs-thrown-validator hard-fail vector already fixed at EXEC-TO-PLAN: `ValidationOrchestrator` blocks on the STATIC `gate.required=true` whenever a validator throws, so a transient `prdRepo`/classifier DB error would hard-fail LEAD-FINAL for every SD, even in warn-only mode.
- This sits on the live chairman-facing critical path — every SD crosses LEAD-FINAL.
- Fix: split the validator body into `runFRDeliveryVerification()`, wrap the call site in try/catch — a thrown error resolves to a passing warn result unless `LEO_FR_TRACEABILITY_ENFORCE` is ON (strict propagation preserved).

## Test plan
- [x] `node -c` syntax check
- [x] New unit test `tests/unit/lead-final-fr-delivery-verification-fail-open.test.js` (3 tests) — both-directions acceptance: (1) thrown/transient failure degrades to a passing warn result in warn-only mode, (2) a genuine FR-delivery failure (classifier legitimately reports undelivered FRs, no throw) still FAILS the gate
- [x] Existing regression suite for this gates module — 72/73 pass (1 pre-existing skip), no changes

QF-20260704-468 · Tier 1 (~20 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)