### PR TITLE
fix(SD-LEO-FIX-SECURITY-SCAN-CRIT-001): security scan false-positives on empty-value .env.example declarations

### DIFF
--- a/scripts/venture-conformance-check.js
+++ b/scripts/venture-conformance-check.js
@@ -66,6 +66,20 @@ const REQUIRED_EHG_PACKAGES = [
   '@ehg/lint-config',
 ];
 
+// QF-20260704-452: the KEY_NAME= patterns require a non-empty value token (\S+) after
+// the assignment, so a documented .env.example template declaration (e.g.
+// "SUPABASE_SERVICE_ROLE_KEY=", no value) no longer false-flags as a hardcoded secret.
+// The value-shaped patterns (sk-, ghp_, PRIVATE KEY) are already immune to this class
+// and are unchanged. Exported for direct unit testing.
+export const SECRET_PATTERNS = [
+  /SUPABASE_SERVICE_ROLE_KEY\s*=\s*\S+/,
+  /sk-[a-zA-Z0-9]{20,}/,
+  /ghp_[a-zA-Z0-9]{36}/,
+  /ANTHROPIC_API_KEY\s*=\s*\S+/,
+  /OPENAI_API_KEY\s*=\s*\S+/,
+  /BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY/,
+];
+
 function check(name, pass, details) {
   return { name, pass, details: details || (pass ? 'OK' : 'FAIL') };
 }
@@ -142,14 +156,6 @@ function run(projectPath) {
   // === SECURITY CHECKS (SD-LEO-INFRA-VENTURE-DEVWORKFLOW-AWARENESS-001-D) ===
 
   // 7. Secret pattern scanning
-  const SECRET_PATTERNS = [
-    /SUPABASE_SERVICE_ROLE_KEY\s*=/,
-    /sk-[a-zA-Z0-9]{20,}/,
-    /ghp_[a-zA-Z0-9]{36}/,
-    /ANTHROPIC_API_KEY\s*=/,
-    /OPENAI_API_KEY\s*=/,
-    /BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY/,
-  ];
   let secretFiles = 0;
   try {
     const tracked = execFileSync('git', ['ls-files'], { cwd: absPath, encoding: 'utf8', stdio: 'pipe' })

--- a/tests/unit/bridge/venture-conformance-secret-patterns.test.js
+++ b/tests/unit/bridge/venture-conformance-secret-patterns.test.js
@@ -1,0 +1,41 @@
+// QF-20260704-452: the security:secret-scan check's SUPABASE_SERVICE_ROLE_KEY=,
+// ANTHROPIC_API_KEY=, and OPENAI_API_KEY= patterns matched a bare assignment with no
+// value, false-flagging documented .env.example template declarations (empty values)
+// as hardcoded secrets and blocking venture P2 auto-merge. Fixed by requiring a
+// non-empty value token (\S+) after the assignment.
+import { describe, it, expect } from 'vitest';
+import { SECRET_PATTERNS } from '../../../scripts/venture-conformance-check.js';
+
+function matchesAny(content) {
+  return SECRET_PATTERNS.some((p) => p.test(content));
+}
+
+describe('venture-conformance-check — SECRET_PATTERNS empty-value false-positive fix', () => {
+  it('does not flag an empty-value .env.example template declaration (the reported bug)', () => {
+    expect(matchesAny('SUPABASE_SERVICE_ROLE_KEY=')).toBe(false);
+    expect(matchesAny('ANTHROPIC_API_KEY=')).toBe(false);
+    expect(matchesAny('OPENAI_API_KEY=')).toBe(false);
+  });
+
+  it('still flags a real value for the same variables', () => {
+    expect(matchesAny('SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiJ9.abc123')).toBe(true);
+    expect(matchesAny('ANTHROPIC_API_KEY=sk-ant-abc123def456')).toBe(true);
+    expect(matchesAny('OPENAI_API_KEY=sk-abc123def456ghi789')).toBe(true);
+  });
+
+  it('treats a whitespace-only value as still empty', () => {
+    expect(matchesAny('SUPABASE_SERVICE_ROLE_KEY=   ')).toBe(false);
+  });
+
+  it('still catches a real secret pasted into any file, including .env.example (no wholesale file exemption)', () => {
+    expect(matchesAny('sk-' + 'a'.repeat(24))).toBe(true);
+    expect(matchesAny('ghp_' + 'a'.repeat(36))).toBe(true);
+    expect(matchesAny('-----BEGIN RSA PRIVATE KEY-----')).toBe(true);
+  });
+
+  it('leaves the 3 value-shaped patterns unaffected by this change', () => {
+    expect(SECRET_PATTERNS[1].source).toBe('sk-[a-zA-Z0-9]{20,}');
+    expect(SECRET_PATTERNS[2].source).toBe('ghp_[a-zA-Z0-9]{36}');
+    expect(SECRET_PATTERNS[5].source).toBe('BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY');
+  });
+});


### PR DESCRIPTION
## Summary
- Escalated from QF-20260704-452 (the classifier's forbidden-keyword list literally includes "security", forcing Tier 3 regardless of directionality — this fix touches the security scanner itself, not app secrets).
- The ship-pipeline `security:secret-scan` check's `SUPABASE_SERVICE_ROLE_KEY=`, `ANTHROPIC_API_KEY=`, and `OPENAI_API_KEY=` patterns matched a bare assignment with no value, false-flagging documented `.env.example` template declarations (e.g. `SUPABASE_SERVICE_ROLE_KEY=`) as hardcoded secrets and blocking venture P2 auto-merge.
- Fixed by requiring a non-empty value token (`\S+`) after the assignment. The value-shaped patterns (`sk-`, `ghp_`, `PRIVATE KEY`) are already immune to this class and are unchanged — a real secret pasted into any file (including `.env.example`) still trips the scan.

## Test plan
- [x] `tests/unit/bridge/venture-conformance-secret-patterns.test.js` (new, 5 tests): empty-value non-match for all 3 corrected patterns, populated-value still matches, whitespace-only value still treated as empty, real secrets in any file still caught, unrelated patterns byte-unchanged
- [x] Existing `tests/unit/bridge/venture-conformance-stack.test.js`: still passes (0 regressions)
- [x] eslint clean on touched files (one pre-existing unrelated `readdirSync` unused-var warning confirmed via `git stash` to predate this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)