### PR TITLE
fix(QF-20260704-143): role-session QF filings skip auto-claim + worktree pre-provision

### DIFF
--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -478,6 +478,24 @@ async function createQuickFix(options = {}) {
       console.log(`   Run /leo ${qfId} to claim and create a worktree when picking up.\n`);
       return printNextSteps(qfId, false, null);
     }
+
+    // QF-20260704-143: role sessions (coordinator/Adam/Solomon) file QFs as dispatch
+    // supply for workers, not work they'll do themselves. Auto-claiming to the creator
+    // (and pre-provisioning a worktree) left every role-filed QF claim-locked and
+    // invisible to worker polls, and burned a worktree-pool slot per queued QF.
+    const { data: creatorSession } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', creatorSessionId)
+      .maybeSingle();
+    const creatorMeta = creatorSession?.metadata || {};
+    const isRoleSession = creatorMeta.is_coordinator === true || creatorMeta.role === 'adam' || creatorMeta.role === 'solomon';
+    if (isRoleSession) {
+      console.log('🌲 Worktree Isolation skipped — role-session filing, QF queued unclaimed for worker pickup.');
+      console.log(`   Run /leo ${qfId} to claim and create a worktree when picking up.\n`);
+      return printNextSteps(qfId, false, null);
+    }
+
     // Atomically set claiming_session_id; if another session already holds it, bail.
     const { data: claimed } = await supabase
       .from('quick_fixes')

--- a/tests/unit/feedback/create-quick-fix-role-session-no-claim.test.js
+++ b/tests/unit/feedback/create-quick-fix-role-session-no-claim.test.js
@@ -1,0 +1,57 @@
+// QF-20260704-143: role sessions (coordinator/Adam/Solomon) file QFs as dispatch
+// supply for workers, not work they'll do themselves. Auto-claiming to the creator
+// stamped claiming_session_id = <role session>, so the QF looked open in the queue
+// but was claim-locked and invisible to worker polls -- costing ~1.5h of lock time
+// on 5 role-filed QFs in one morning, including a CRITICAL wrong-repo-merge fix.
+// The same filing also pre-provisioned a worktree for the auto-claimed creator,
+// burning a worktree-pool slot per queued role-filed QF (11 unclaimed QFs held
+// 11/20 slots).
+//
+// Static-pattern assertions, same convention as create-quick-fix-liveness-gate.test.js
+// (avoids mocking the full Supabase chain for a top-level CLI script).
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../../scripts/create-quick-fix.js');
+
+describe('QF-20260704-143: role-session filings skip auto-claim + worktree pre-provision', () => {
+  const code = fs.readFileSync(SRC, 'utf8');
+
+  const ROLE_CHECK_RE = /creatorMeta\.is_coordinator === true \|\| creatorMeta\.role === 'adam' \|\| creatorMeta\.role === 'solomon'/;
+  const CLAIM_UPDATE_RE = /\.update\(\{\s*claiming_session_id:\s*creatorSessionId/;
+  const WORKTREE_CREATE_RE = /createWorkTypeWorktree\(/;
+
+  it('checks is_coordinator / role in {adam, solomon} from claude_sessions.metadata', () => {
+    expect(code).toMatch(/\.from\(\s*['"]claude_sessions['"]\s*\)/);
+    expect(code).toMatch(ROLE_CHECK_RE);
+  });
+
+  it('the role-session check precedes BOTH the auto-claim update and the worktree creation call', () => {
+    const roleM = code.match(ROLE_CHECK_RE);
+    const claimM = code.match(CLAIM_UPDATE_RE);
+    const worktreeM = code.match(WORKTREE_CREATE_RE);
+    expect(roleM?.index).toBeGreaterThanOrEqual(0);
+    expect(claimM?.index).toBeGreaterThanOrEqual(0);
+    expect(worktreeM?.index).toBeGreaterThanOrEqual(0);
+    expect(roleM.index).toBeLessThan(claimM.index);
+    expect(roleM.index).toBeLessThan(worktreeM.index);
+  });
+
+  it('returns early (printNextSteps with no claim/worktree) on a role-session match', () => {
+    const roleCheckStart = code.search(ROLE_CHECK_RE);
+    const nextChunk = code.slice(roleCheckStart, roleCheckStart + 500);
+    expect(nextChunk).toMatch(/return printNextSteps\(qfId, false, null\)/);
+    expect(nextChunk).toMatch(/queued unclaimed/);
+  });
+
+  it('a non-role (worker) creator still falls through to the auto-claim update', () => {
+    const roleCheckStart = code.search(ROLE_CHECK_RE);
+    const claimM = code.match(CLAIM_UPDATE_RE);
+    // The claim update must still be reachable in the same function after the role check --
+    // i.e. the fix does not remove or short-circuit the normal worker-filing path.
+    expect(claimM.index).toBeGreaterThan(roleCheckStart);
+  });
+});


### PR DESCRIPTION
## Summary
- `create-quick-fix.js` stamped `claiming_session_id = creator session` at insert — correct for a worker self-filing work it will do, but wrong for role sessions (coordinator/Adam/Solomon) whose filings are dispatch supply for workers.
- Result: role-filed QFs looked open in the queue but were claim-locked, invisible to worker polls. Cost today: coordinator filed 5 QFs in one morning (incl. a CRITICAL wrong-repo-merge fix and two time-critical gate unblocks) — all sat locked ~1.5h; only worktree-reaper evidence exposed it. Adam hits the same friction and hand-releases each.
- Same root behavior also pre-provisioned a worktree for the auto-claimed creator, burning a worktree-pool slot per queued role-filed QF (11 unclaimed QFs held 11/20 slots, tripping repeated 85-90% pool warnings).
- Fix: check the creator session's `claude_sessions.metadata` (`is_coordinator===true` or `role` in `{adam, solomon}`) before the auto-claim block. Role sessions skip **both** the claim update and worktree creation — the QF is left instantly claimable. Worker-filed QFs are unaffected (still auto-claim to that worker, still get a worktree).

## Test plan
- [x] `node -c` syntax check
- [x] New unit test `tests/unit/feedback/create-quick-fix-role-session-no-claim.test.js` (4 tests) — pins the role check, its position ahead of both the claim-update and worktree-creation call sites, the early-return shape, and that worker (non-role) filings still reach the claim update
- [x] Existing `create-quick-fix-*` test suite regression pass (21/21 total across 5 files)

QF-20260704-143 · Tier 1 (18 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)