### PR TITLE
fix(QF-20260704-225): intelligence-loader _loadPatterns queries real issue_patterns columns

### DIFF
--- a/lib/eva/intelligence-loader.js
+++ b/lib/eva/intelligence-loader.js
@@ -119,15 +119,16 @@ async function _loadOkrImpact(supabase, sdKey, sdUuid) {
 async function _loadPatterns(supabase, _sdKey, dimension) {
   // Query active patterns. For corrective SDs, we look for patterns
   // related to EVA/vision dimensions since that's the corrective domain.
-  // Pre-existing bug, out of scope here (tracked in QF-20260704-225): pattern_key/frequency/
-  // last_seen don't exist on issue_patterns (real columns: pattern_id, occurrence_count,
-  // updated_at) -- this silently degrades every call. schema-lint-disable-line
+  // QF-20260704-225: pattern_key/frequency/last_seen don't exist on issue_patterns
+  // (real columns: pattern_id, occurrence_count, updated_at) -- this silently
+  // degraded to [] on every call. issue_summary is the closest free-text
+  // substitute for the keyword matching pattern_key was used for below.
   const { data: patterns, error } = await supabase
     .from('issue_patterns')
-    .select('id, pattern_key, severity, frequency, status, category, last_seen') // schema-lint-disable-line
+    .select('id, pattern_id, severity, occurrence_count, status, category, issue_summary, updated_at')
     .in('status', ['active', 'monitoring'])
     .in('severity', ['critical', 'high'])
-    .order('frequency', { ascending: false })
+    .order('occurrence_count', { ascending: false })
     .limit(10);
 
   if (error || !patterns) return [];
@@ -137,7 +138,7 @@ async function _loadPatterns(supabase, _sdKey, dimension) {
     const prefix = dimension.charAt(0).toUpperCase(); // 'A' or 'V'
     const dimLower = dimension.toLowerCase();
     const scoped = patterns.filter(p => {
-      const key = (p.pattern_key || '').toLowerCase();
+      const key = (p.issue_summary || '').toLowerCase();
       const cat = (p.category || '').toLowerCase();
       return key.includes(dimLower) || key.includes(prefix.toLowerCase()) ||
              cat.includes('corrective') || cat.includes(prefix.toLowerCase());
@@ -148,7 +149,7 @@ async function _loadPatterns(supabase, _sdKey, dimension) {
 
   // Fallback: filter for patterns related to EVA/vision/corrective domain
   return patterns.filter(p => {
-    const key = (p.pattern_key || '').toLowerCase();
+    const key = (p.issue_summary || '').toLowerCase();
     const cat = (p.category || '').toLowerCase();
     return key.includes('eva') || key.includes('vision') || key.includes('corrective') ||
            cat.includes('eva') || cat.includes('vision') || cat === 'quality';

--- a/tests/unit/eva/intelligence-loader.test.js
+++ b/tests/unit/eva/intelligence-loader.test.js
@@ -113,4 +113,46 @@ describe('Intelligence Loader', () => {
       expect(result).toHaveProperty('meta');
     });
   });
+
+  describe('QF-20260704-225: _loadPatterns queries real issue_patterns columns', () => {
+    // pattern_key/frequency/last_seen don't exist on issue_patterns (real columns:
+    // pattern_id, occurrence_count, updated_at) -- the query used to 42703 on every
+    // call and silently degrade to []. These pin the corrected select/order columns
+    // and the issue_summary-based keyword filter that replaced pattern_key matching.
+    it('selects real issue_patterns columns (pattern_id, occurrence_count, issue_summary, updated_at) — not pattern_key/frequency/last_seen', async () => {
+      const supabase = createMockSupabase({ patterns: [] });
+      await loadIntelligenceSignals(supabase, 'SD-TEST-001');
+
+      const selectCall = supabase.from('issue_patterns').select.mock.calls[0][0];
+      expect(selectCall).toContain('pattern_id');
+      expect(selectCall).toContain('occurrence_count');
+      expect(selectCall).toContain('issue_summary');
+      expect(selectCall).toContain('updated_at');
+      expect(selectCall).not.toContain('pattern_key');
+      expect(selectCall).not.toContain('frequency');
+      expect(selectCall).not.toContain('last_seen');
+    });
+
+    it('surfaces no patterns error when the query succeeds (regression guard for the 42703)', async () => {
+      const supabase = createMockSupabase({
+        patterns: [{ id: '1', pattern_id: 'PAT-1', severity: 'high', occurrence_count: 3, status: 'active', category: 'eva_drift', issue_summary: 'EVA vision drift detected', updated_at: '2026-07-01T00:00:00Z' }],
+      });
+      const result = await loadIntelligenceSignals(supabase, 'SD-TEST-001');
+
+      expect(result.meta.errors.some(e => e.startsWith('patterns:'))).toBe(false);
+      expect(result.patterns).toHaveLength(1);
+    });
+
+    it('keyword-filters the fallback set using issue_summary (the pattern_key replacement)', async () => {
+      const supabase = createMockSupabase({
+        patterns: [
+          { id: '1', pattern_id: 'PAT-1', severity: 'high', occurrence_count: 5, status: 'active', category: 'handoff_failure', issue_summary: 'EVA vision alignment gap' },
+          { id: '2', pattern_id: 'PAT-2', severity: 'high', occurrence_count: 4, status: 'active', category: 'handoff_failure', issue_summary: 'Unrelated gate timeout' },
+        ],
+      });
+      const result = await loadIntelligenceSignals(supabase, 'SD-TEST-001');
+
+      expect(result.patterns.map(p => p.id)).toEqual(['1']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `lib/eva/intelligence-loader.js`'s `_loadPatterns()` selected `issue_patterns.pattern_key, frequency, last_seen` — none of which exist in the live schema (real columns: `pattern_id`, `occurrence_count`, `updated_at`). Confirmed via direct query: PostgREST `42703` "column issue_patterns.pattern_key does not exist".
- The error was swallowed into `loadIntelligenceSignals()`'s `meta.errors` array and `_loadPatterns` silently returned `[]` on every call — same silent-degradation class as SD-LEO-INFRA-PROVISION-OKR-ALIGNMENTS-001 (fixed for `okr_alignments`).
- Fix corrects the select/order columns to the real schema, and replaces `pattern_key` keyword-matching with `issue_summary` (the closest free-text substitute — the two downstream consumers of the returned array only read `.status`/`.severity` from each pattern, never `pattern_key`, so no consumer-facing shape changed).

## Test plan
- [x] `node -c` syntax check, `npm run schema:lint` clean (0 violations)
- [x] Live verification: `loadIntelligenceSignals()` now returns `meta.errors=[]` with 2 populated patterns (previously always had a `patterns:` schema error and `[]`)
- [x] New unit tests in `tests/unit/eva/intelligence-loader.test.js` (3 new) pinning the corrected select columns, the no-error regression guard, and the `issue_summary`-based keyword filter
- [x] Existing suite regression pass (8/8 total)

QF-20260704-225 · Tier 1 (~15 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)