### PR TITLE
fix(QF-20260704-825): sd-start.js no longer silently falls back on an already-terminal explicit target

### DIFF
--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -383,7 +383,7 @@ async function getSDDetails(sdId) {
   // Note: legacy_id column was deprecated and removed - using sd_key instead
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id, scope, governance_metadata, metadata')
+    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id, scope, governance_metadata, metadata, completion_date, updated_at, updated_by')
     .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
@@ -1153,6 +1153,20 @@ async function main() {
   const forceReclaim = process.argv.includes('--force-reclaim');
   let claimResult = await claimGuard(effectiveId, session.session_id, { autoFallback: fallbackEnabled });
   const skippedSDs = [];
+
+  // QF-20260704-825: an explicit-target invocation on a terminal (completed/deferred) SD
+  // must NEVER silently fall through to auto-fallback selection -- that claims an unrelated
+  // SD while the operator believes they hold the one they named. This is not a claim
+  // conflict (no owner to wait on or evict); exit loud regardless of fallbackEnabled.
+  if (!claimResult.success && claimResult.error === 'sd_terminal_status') {
+    console.log(`\n${colors.red}${colors.bold}🚫 TARGET_ALREADY_TERMINAL${colors.reset}`);
+    console.log(`   ${effectiveId} has status=${claimResult.status} — already finished, cannot be (re)claimed.`);
+    console.log(`   Completed: ${sd.completion_date || sd.updated_at || 'unknown'}${sd.updated_by ? ` (updated_by: ${sd.updated_by})` : ''}`);
+    console.log(`\n   ${colors.bold}Action:${colors.reset} This was NOT a claim conflict — no fallback SD will be selected.`);
+    console.log(`   Run ${colors.cyan}npm run sd:next${colors.reset} to pick a different, workable SD.`);
+    console.log('═'.repeat(50));
+    process.exit(1);
+  }
 
   if (!claimResult.success) {
     // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 (FR2): Evidence-of-life pre-claim gate.

--- a/tests/unit/sd-start-terminal-target-no-fallback.test.js
+++ b/tests/unit/sd-start-terminal-target-no-fallback.test.js
@@ -1,0 +1,71 @@
+/**
+ * QF-20260704-825 — sd-start.js SILENTLY claimed an unrelated SD when the explicitly-named
+ * target was already 'completed'. claimGuard() correctly returns
+ * { success:false, error:'sd_terminal_status', status } for a completed/deferred SD, but the
+ * auto-fallback branch (`if (!claimResult.success && fallbackEnabled)`) treated EVERY failure
+ * reason identically -- including sd_terminal_status -- so under AUTO-PROCEED (fallbackEnabled
+ * defaults true) it searched the belt and silently claimed a DIFFERENT, unrelated SD. Worker
+ * believed they held the named SD: wrong worktree, wrong branch, wasted effort.
+ *
+ * Fix: a hard, unconditional exit (TARGET_ALREADY_TERMINAL) on sd_terminal_status BEFORE the
+ * auto-fallback branch is ever reached -- an explicit-target invocation on a terminal SD is
+ * never a "claim conflict" that fallback search should resolve.
+ *
+ * Static-pin pattern (mocking-independent), per tests/unit/sd-start-human-action-gate.test.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'scripts/sd-start.js'), 'utf8');
+
+describe('QF-20260704-825: TARGET_ALREADY_TERMINAL guard precedes auto-fallback', () => {
+  it('checks claimResult.error === "sd_terminal_status" and process.exit(1)s unconditionally', () => {
+    const idx = src.indexOf('TARGET_ALREADY_TERMINAL');
+    expect(idx).toBeGreaterThan(0);
+    const body = src.slice(idx - 400, idx + 700);
+    expect(body).toMatch(/claimResult\.error === 'sd_terminal_status'/);
+    expect(body).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('the terminal-status exit does NOT gate on fallbackEnabled (must fire regardless of AUTO-PROCEED)', () => {
+    const idx = src.indexOf('TARGET_ALREADY_TERMINAL');
+    // The `if` condition governing this block, read backwards from the marker, must not
+    // reference fallbackEnabled -- it should be unconditional once sd_terminal_status is seen.
+    const guardStart = src.lastIndexOf('if (!claimResult.success', idx);
+    const guardLine = src.slice(guardStart, src.indexOf('{', guardStart) + 1);
+    expect(guardLine).not.toMatch(/fallbackEnabled/);
+  });
+
+  it('the terminal-status guard appears BEFORE the AUTO-FALLBACK search block in source order', () => {
+    const terminalIdx = src.indexOf('TARGET_ALREADY_TERMINAL');
+    const fallbackIdx = src.indexOf('AUTO-FALLBACK: ${effectiveId} is claimed');
+    expect(terminalIdx).toBeGreaterThan(0);
+    expect(fallbackIdx).toBeGreaterThan(0);
+    expect(terminalIdx).toBeLessThan(fallbackIdx);
+  });
+
+  it('surfaces the SD status and a completion timestamp in the exit message', () => {
+    const idx = src.indexOf('TARGET_ALREADY_TERMINAL');
+    const body = src.slice(idx, idx + 700);
+    expect(body).toMatch(/status=\$\{claimResult\.status\}/);
+    expect(body).toMatch(/sd\.completion_date \|\| sd\.updated_at/);
+  });
+
+  it('getSDDetails selects completion_date/updated_at/updated_by so the exit message has real data', () => {
+    expect(src).toMatch(/select\('id, sd_key,[^']*completion_date, updated_at, updated_by'\)/);
+  });
+
+  it('a genuine claim conflict (owned by another active session) still reaches auto-fallback (regression guard)', () => {
+    // Sibling error reasons from claimGuard (e.g. 'claimed_by_other') must NOT be intercepted
+    // by the terminal-status guard -- only the literal 'sd_terminal_status' string short-circuits.
+    const idx = src.indexOf('TARGET_ALREADY_TERMINAL');
+    const guardStart = src.lastIndexOf('if (!claimResult.success', idx);
+    const guardLine = src.slice(guardStart, src.indexOf('{', guardStart) + 1);
+    expect(guardLine).toMatch(/error === 'sd_terminal_status'/);
+    expect(guardLine).not.toMatch(/claimed_by_other/);
+  });
+});


### PR DESCRIPTION
## Summary
- `claimGuard()` correctly returns `{success:false, error:'sd_terminal_status', status}` for a completed/deferred SD (`SD-LEO-FIX-CLAIM-RPC-TERMINAL-001`), but `sd-start.js`'s auto-fallback branch (`if (!claimResult.success && fallbackEnabled)`) treated **every** claim-failure reason identically — including `sd_terminal_status` — so under AUTO-PROCEED (fallback defaults on) it silently searched the belt and claimed a **different, unrelated** SD.
- Worker-confirmed repro: invoking `sd-start.js` with `SD-LEO-FEAT-MARKETLENS-CUSTOMER-FACING-001` (completed minutes earlier by another worker) returned an unrelated claim with no warning — wrong worktree, wrong branch, wasted effort.
- Fix: a hard, unconditional exit (`TARGET_ALREADY_TERMINAL`) on `sd_terminal_status`, placed **before** the auto-fallback branch is ever reached — an explicit-target invocation on a terminal SD is never a "claim conflict" for fallback search to resolve. The message names the SD's status and completion timestamp (`getSDDetails` now also selects `completion_date`/`updated_at`/`updated_by`). Genuine claim conflicts (owned by another active session) are unaffected and still reach auto-fallback.

## Test plan
- [x] `node -c` syntax check, `npm run schema:lint` clean (0 violations)
- [x] New static-pin unit test `tests/unit/sd-start-terminal-target-no-fallback.test.js` (6 tests) — pins the guard's condition, its unconditional (fallbackEnabled-independent) nature, its position ahead of the AUTO-FALLBACK block in source order, the message content, the `getSDDetails` select change, and that a genuine claim-conflict reason is NOT intercepted
- [x] Full existing `sd-start-*` unit test suite regression pass (65/65 across 9 `.test.js` files — a pre-existing `.mjs` test file isn't picked up by the vitest config's include globs at all, unrelated to this change)

QF-20260704-825 · Tier 2 (~15 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)