### PR TITLE
feat(SD-LEO-FIX-RETROACTIVE-VENTURE-CAPTURE-001): drain the retroactive venture-capture backlog through the shipped capture path

### DIFF
--- a/lib/eva/venture-capture-forward.js
+++ b/lib/eva/venture-capture-forward.js
@@ -125,9 +125,88 @@ async function getCaptureCompleteness(supabase, venture, opts = {}) {
   return { ventureId: venture.id, expected, captured, missing, coveragePct };
 }
 
+/**
+ * QF-20260704-609: which specific stage numbers (from minStage forward) are
+ * missing a venture_capture_snapshots row for this venture. Reuses the exact
+ * query shape getCaptureCompleteness() uses, just returning the stage list
+ * instead of a count, so drainCaptureBacklog() knows exactly what to capture.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{id: string, current_lifecycle_stage: number}} venture
+ * @param {{minStage?: number}} [opts]
+ * @returns {Promise<number[]>}
+ */
+async function getMissingStages(supabase, venture, opts = {}) {
+  const minStage = resolveMinExtractStage(opts);
+  if (venture.current_lifecycle_stage < minStage) return [];
+
+  const { data: rows, error } = await supabase
+    .from('venture_capture_snapshots')
+    .select('lifecycle_stage')
+    .eq('venture_id', venture.id)
+    .gte('lifecycle_stage', minStage)
+    .lte('lifecycle_stage', venture.current_lifecycle_stage);
+
+  if (error) throw new Error(`Failed to query venture_capture_snapshots: ${error.message}`);
+
+  const captured = new Set((rows || []).map((r) => r.lifecycle_stage));
+  const missing = [];
+  for (let stage = minStage; stage <= venture.current_lifecycle_stage; stage += 1) {
+    if (!captured.has(stage)) missing.push(stage);
+  }
+  return missing;
+}
+
+/**
+ * QF-20260704-609: drain the retroactive capture backlog across ALL active
+ * ventures, through the EXACT shipped per-stage capture path
+ * (captureVentureStage) -- no second extraction implementation. Idempotent:
+ * captureVentureStage upserts on (venture_id, lifecycle_stage), so re-running
+ * this against an already-drained backlog finds zero missing stages and is a
+ * pure no-op (proves the forward path stays unbroken).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{minStage?: number}} [opts]
+ * @returns {Promise<{attempted: number, captured: number, errors: Array<{ventureId: string, stage: number, error: string}>}>}
+ */
+async function drainCaptureBacklog(supabase, opts = {}) {
+  const minStage = resolveMinExtractStage(opts);
+  const { data: ventures, error } = await supabase
+    .from('ventures')
+    .select('id, name, current_lifecycle_stage')
+    .eq('status', 'active')
+    .gte('current_lifecycle_stage', minStage);
+  if (error) throw new Error(`Failed to query ventures: ${error.message}`);
+
+  let attempted = 0;
+  let captured = 0;
+  const errors = [];
+
+  for (const venture of ventures || []) {
+    // eslint-disable-next-line no-await-in-loop -- intentionally sequential, small backlog
+    const missingStages = await getMissingStages(supabase, venture, { minStage });
+    for (const stage of missingStages) {
+      attempted += 1;
+      try {
+        // eslint-disable-next-line no-await-in-loop -- intentionally sequential, small backlog
+        await captureVentureStage(supabase, venture.id, stage);
+        captured += 1;
+        console.log(`[drain-capture-backlog] captured ${venture.name || venture.id} stage ${stage}`);
+      } catch (err) {
+        errors.push({ ventureId: venture.id, stage, error: err.message });
+        console.log(`[drain-capture-backlog] FAILED ${venture.name || venture.id} stage ${stage}: ${err.message}`);
+      }
+    }
+  }
+
+  return { attempted, captured, errors };
+}
+
 export {
   captureVentureStage,
   captureVentureRetroactive,
   getCaptureCompleteness,
+  getMissingStages,
+  drainCaptureBacklog,
   MODULE_VERSION,
 };

--- a/package.json
+++ b/package.json
@@ -395,6 +395,7 @@
     "exec-email:should-send": "node scripts/exec-email-should-send.mjs",
     "capture:chairman-summary": "node scripts/capture-chairman-summary.mjs",
     "capture:forward-venture": "node scripts/capture-forward-venture.mjs",
+    "capture:drain-backlog": "node scripts/drain-capture-backlog.mjs",
     "capabilities:populate-ventures": "node scripts/populate-venture-capabilities.mjs",
     "patterns:auto-block-check": "node scripts/auto-block-check.mjs",
     "patterns:seed-auto-block": "node scripts/seed-auto-block-patterns.mjs",

--- a/scripts/drain-capture-backlog.mjs
+++ b/scripts/drain-capture-backlog.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * drain-capture-backlog — retroactively drain the venture-capture-completeness
+ * backlog across ALL active ventures, through the exact shipped per-stage
+ * capture path (captureVentureStage). QF-20260704-609.
+ *
+ * Usage:
+ *   node scripts/drain-capture-backlog.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { drainCaptureBacklog } from '../lib/eva/venture-capture-forward.js';
+
+async function main() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const { attempted, captured, errors } = await drainCaptureBacklog(supabase);
+  console.log(`\nDrained ${captured}/${attempted} missing capture(s).`);
+  if (errors.length > 0) {
+    console.log(`${errors.length} error(s):`);
+    for (const e of errors) console.log(`  ${e.ventureId} stage ${e.stage}: ${e.error}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('drain-capture-backlog failed:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/eva/venture-capture-drain-backlog.test.js
+++ b/tests/unit/eva/venture-capture-drain-backlog.test.js
@@ -1,0 +1,135 @@
+/**
+ * QF-20260704-609 — retroactive venture-capture backlog drain.
+ *
+ * The venture-capture-completeness gauge read a flat, non-zero uncaptured
+ * count (55+ items) with zero drainage: forward capture (SD-LEO-INFRA-CAPTURE-
+ * FORWARD-GATE-001) works and its gauge works, but nothing consumes the
+ * backlog. drainCaptureBacklog() reuses the EXACT shipped per-stage capture
+ * path (captureVentureStage) for every missing (venture, stage) pair across
+ * all active ventures -- no second extraction implementation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { drainCaptureBacklog, getMissingStages } from '../../../lib/eva/venture-capture-forward.js';
+
+function createMockDb({ ventures = [], snapshotsByVenture = {}, upsertShouldFailFor = null } = {}) {
+  const upsertCalls = [];
+
+  // Generic no-op chainable for every table the per-stage sub-extractors query
+  // (chairman_decisions, venture_artifacts, assumption_sets, venture_revenue_entries,
+  // etc.) -- mirrors the existing venture-capture-forward.test.js convention.
+  const genericChainable = {};
+  for (const method of ['select', 'eq', 'in', 'order', 'limit', 'gte', 'lte']) {
+    genericChainable[method] = vi.fn().mockReturnValue(genericChainable);
+  }
+  genericChainable.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
+  genericChainable.then = (resolve) => Promise.resolve({ data: [], error: null }).then(resolve);
+
+  return {
+    upsertCalls,
+    from: vi.fn((table) => {
+      if (table === 'ventures') {
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          gte: vi.fn(() => chain),
+          then: (resolve) => Promise.resolve({ data: ventures, error: null }).then(resolve),
+        };
+        return chain;
+      }
+      if (table === 'venture_capture_snapshots') {
+        let ventureId;
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn((col, val) => {
+            if (col === 'venture_id') ventureId = val;
+            return chain;
+          }),
+          gte: vi.fn(() => chain),
+          lte: vi.fn(() => chain),
+          then: (resolve) =>
+            Promise.resolve({ data: snapshotsByVenture[ventureId] || [], error: null }).then(resolve),
+          single: vi.fn(() => {
+            if (upsertShouldFailFor && upsertShouldFailFor === ventureId) {
+              return Promise.resolve({ data: null, error: { message: 'upsert failed' } });
+            }
+            const row = upsertCalls[upsertCalls.length - 1];
+            return Promise.resolve({
+              data: { id: 'snap-id', venture_id: row.venture_id, lifecycle_stage: row.lifecycle_stage },
+              error: null,
+            });
+          }),
+          upsert: vi.fn((row) => {
+            ventureId = row.venture_id;
+            upsertCalls.push(row);
+            return chain;
+          }),
+        };
+        return chain;
+      }
+      return genericChainable;
+    }),
+  };
+}
+
+describe('getMissingStages', () => {
+  it('returns the specific missing stage numbers, not just a count', async () => {
+    const db = createMockDb({ snapshotsByVenture: { v1: [{ lifecycle_stage: 15 }, { lifecycle_stage: 17 }] } });
+    const missing = await getMissingStages(db, { id: 'v1', current_lifecycle_stage: 18 }, { minStage: 15 });
+    expect(missing).toEqual([16, 18]);
+  });
+
+  it('returns an empty array when the venture has not reached minStage', async () => {
+    const db = createMockDb();
+    const missing = await getMissingStages(db, { id: 'v2', current_lifecycle_stage: 10 }, { minStage: 15 });
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('drainCaptureBacklog', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('captures every missing stage across all active ventures via the shipped per-stage path', async () => {
+    const db = createMockDb({
+      ventures: [
+        { id: 'v1', name: 'Venture One', current_lifecycle_stage: 17 },
+        { id: 'v2', name: 'Venture Two', current_lifecycle_stage: 16 },
+      ],
+      snapshotsByVenture: { v1: [{ lifecycle_stage: 15 }], v2: [] },
+    });
+
+    const result = await drainCaptureBacklog(db, { minStage: 15 });
+
+    expect(result.attempted).toBe(4); // v1: 16,17 (2) + v2: 15,16 (2)
+    expect(result.captured).toBe(4);
+    expect(result.errors).toEqual([]);
+    expect(db.upsertCalls).toHaveLength(4);
+  });
+
+  it('is idempotent -- a second run against an already-drained backlog is a no-op', async () => {
+    const db = createMockDb({
+      ventures: [{ id: 'v1', name: 'Venture One', current_lifecycle_stage: 16 }],
+      snapshotsByVenture: { v1: [{ lifecycle_stage: 15 }, { lifecycle_stage: 16 }] }, // already fully captured
+    });
+
+    const result = await drainCaptureBacklog(db, { minStage: 15 });
+
+    expect(result.attempted).toBe(0);
+    expect(result.captured).toBe(0);
+    expect(db.upsertCalls).toHaveLength(0);
+  });
+
+  it('records a per-item error and continues draining other items when one capture fails', async () => {
+    const db = createMockDb({
+      ventures: [{ id: 'v1', name: 'Venture One', current_lifecycle_stage: 16 }],
+      snapshotsByVenture: { v1: [] },
+      upsertShouldFailFor: 'v1',
+    });
+
+    const result = await drainCaptureBacklog(db, { minStage: 15 });
+
+    expect(result.attempted).toBe(2);
+    expect(result.captured).toBe(0);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toMatchObject({ ventureId: 'v1', stage: 15 });
+  });
+});


### PR DESCRIPTION
## Summary
- Escalated from QF-20260704-609 (source LOC 112 exceeded the 75-LOC QF Tier-3 cap; classified/escalated via `leo-create-sd.js --from-qf`, PRD authored and pushed through LEAD-TO-PLAN/PLAN-TO-EXEC).
- Coordinator evidence-first ask (advisory 2860345f): the venture-capture-completeness gauge (SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001) had read a flat 55-60 uncaptured items with zero drainage since it shipped.
- Adds `getMissingStages()` (which stage numbers are missing per venture) and `drainCaptureBacklog()` (loops every active venture's missing stages, calling the exact shipped `captureVentureStage()` per item — no second extraction implementation) to `lib/eva/venture-capture-forward.js`, plus a CLI wrapper `scripts/drain-capture-backlog.mjs` (registered as `capture:drain-backlog`).

## Test plan
- [x] `tests/unit/eva/venture-capture-drain-backlog.test.js` (5 tests): missing-stage diffing, full-drain across multiple ventures, idempotent no-op, per-item error handling
- [x] Existing sibling tests (`venture-capture-forward.test.js`, `template-capture-forward.test.js`, `stage-advance-worker-capture-forward.test.js`): all still pass, 0 regressions
- [x] **Live verification (not a mock)**: ran `node scripts/drain-capture-backlog.mjs` against production — drained 60/60 missing captures across 10 active ventures; live gauge query confirmed 60 → 0; re-ran a second time — 0/0, proving idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)