### PR TITLE
fix(QF-20260704-434): generate-comprehensive-retrospective.js reads sub-agent evidence from the live table

### DIFF
--- a/scripts/generate-comprehensive-retrospective.js
+++ b/scripts/generate-comprehensive-retrospective.js
@@ -247,8 +247,12 @@ async function analyzePRD(sdId, sdUuid) {
  * Analyze sub-agent executions
  */
 async function analyzeSubAgents(sdId) {
+  // QF-20260704-434: sub_agent_executions is a legacy table (keyed by prd_id, no sd_id
+  // column, unpopulated by current tooling) -- every retrospective got sub_agents_involved:[]
+  // regardless of real evidence. sub_agent_execution_results is the actively-written table
+  // (CLAUDE.md prologue #2); its sd_id column holds the SD's UUID for current rows.
   const { data: executions } = await supabase
-    .from('sub_agent_executions')
+    .from('sub_agent_execution_results')
     .select('*')
     .eq('sd_id', sdId);
 
@@ -261,7 +265,7 @@ async function analyzeSubAgents(sdId) {
     verdicts: executions.map(e => ({
       agent: e.sub_agent_code,
       verdict: e.verdict,
-      confidence: e.confidence_score
+      confidence: e.confidence
     }))
   };
 }

--- a/tests/unit/generate-comprehensive-retrospective-subagent-source.test.js
+++ b/tests/unit/generate-comprehensive-retrospective-subagent-source.test.js
@@ -1,0 +1,48 @@
+/**
+ * QF-20260704-434 — analyzeSubAgents() in generate-comprehensive-retrospective.js queried
+ * the legacy `sub_agent_executions` table (128 total rows, keyed by prd_id, no sd_id
+ * column, unpopulated by current tooling) instead of the actively-written
+ * `sub_agent_execution_results` table. Every auto-generated retrospective got
+ * sub_agents_involved:[] regardless of real evidence. Discovered while generating the
+ * retrospective for SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001 (16 real rows existed,
+ * verified live -- the fix returns them; confidence_score also didn't exist on the
+ * correct table, real column is `confidence`).
+ *
+ * The script's `main()` runs unconditionally at import time (no import.meta.url guard,
+ * reads process.argv[2]) so it cannot be safely imported in a test -- static-source-pin
+ * pattern, per tests/unit/sd-start-human-action-gate.test.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'scripts/generate-comprehensive-retrospective.js'), 'utf8');
+
+describe('QF-20260704-434: analyzeSubAgents queries sub_agent_execution_results', () => {
+  const fnStart = src.indexOf('async function analyzeSubAgents');
+  const fnBody = src.slice(fnStart, fnStart + 900);
+
+  it('queries the live sub_agent_execution_results table, not the legacy sub_agent_executions', () => {
+    expect(fnStart).toBeGreaterThan(0);
+    expect(fnBody).toMatch(/\.from\('sub_agent_execution_results'\)/);
+    expect(fnBody).not.toMatch(/\.from\('sub_agent_executions'\)/);
+  });
+
+  it('reads the real confidence column, not the nonexistent confidence_score', () => {
+    expect(fnBody).toMatch(/confidence:\s*e\.confidence\b/);
+    expect(fnBody).not.toMatch(/e\.confidence_score/);
+  });
+
+  it('still maps sub_agent_code and verdict (consumer shape unchanged)', () => {
+    expect(fnBody).toMatch(/agent:\s*e\.sub_agent_code/);
+    expect(fnBody).toMatch(/verdict:\s*e\.verdict/);
+  });
+
+  it('still filters by sd_id and returns {consulted:0, verdicts:[]} on no rows', () => {
+    expect(fnBody).toMatch(/\.eq\('sd_id', sdId\)/);
+    expect(fnBody).toMatch(/consulted:\s*0,\s*verdicts:\s*\[\]/);
+  });
+});


### PR DESCRIPTION
## Summary
- `analyzeSubAgents()` in `scripts/generate-comprehensive-retrospective.js` queried the legacy `sub_agent_executions` table (128 total rows, keyed by `prd_id`, no `sd_id` column, unpopulated by current tooling) instead of the actively-written `sub_agent_execution_results` table.
- Every auto-generated retrospective for every current SD got `sub_agents_involved:[]` regardless of how much real sub-agent evidence existed, since the legacy table is never populated by current tooling.
- Found while generating the retrospective for `SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001`; worked around by manually enriching that one retrospective, but the generator itself needed the query source fixed for all future retrospectives.
- Fix corrects the table name and the `confidence` field (was `confidence_score`, which doesn't exist on either table).

## Test plan
- [x] `node -c` syntax check, `npm run schema:lint` clean (0 violations)
- [x] Live verification: querying `sub_agent_execution_results` for `SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001` now returns 16 real rows (previously always `[]` via the legacy table)
- [x] New static-pin unit test `tests/unit/generate-comprehensive-retrospective-subagent-source.test.js` (4 tests) — the script's `main()` runs unconditionally at import time (no `import.meta.url` guard), so it can't be safely imported; pins the corrected table/field names via source inspection, per the existing `sd-start-human-action-gate.test.js` convention

QF-20260704-434 · Tier 1 (~8 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)