### PR TITLE
feat(SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001): parent scope-coverage check for orchestrator completion

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001",
-  "createdAt": "2026-07-04T16:25:32.385Z",
+  "sdKey": "SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001",
+  "createdAt": "2026-07-04T14:57:48.456Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/sd/child-linkage.js
+++ b/lib/sd/child-linkage.js
@@ -18,8 +18,16 @@
  * follow-up — see [[feedback-singleton-identity-atomic-jsonb-not-js-rmw]]; same-parent
  * child creation is effectively sequential today (orchestrator loops / Adam one-at-a-time).
  *
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001: linkChild() now also computes a non-blocking
+ * scope-coverage snapshot (lib/sd/scope-coverage.js) after registration and stores it at
+ * metadata.scope_coverage, logging a loud (but never throwing) warning when the current
+ * child set leaves parent scope elements uncovered. This is advisory-only — see
+ * scope-coverage.js's module doc for why a hard-blocking check here would be wrong.
+ *
  * @module lib/sd/child-linkage
  */
+
+import { computeScopeCoverage } from './scope-coverage.js';
 
 /**
  * Derive the autonomy child suffix letter from a child key (…-001-F → 'F').
@@ -114,7 +122,7 @@ export async function linkChild(supabase, parent, childKey, opts = {}) {
   // Re-fetch the parent's CURRENT metadata so the registry merge uses fresh state.
   const { data: fresh, error: fErr } = await supabase
     .from('strategic_directives_v2')
-    .select('id, uuid_id, sd_key, metadata')
+    .select('id, uuid_id, sd_key, metadata, scope, success_criteria')
     .eq('sd_key', parent.sd_key)
     .single();
   const parentNow = (!fErr && fresh) ? fresh : parent;
@@ -144,6 +152,34 @@ export async function linkChild(supabase, parent, childKey, opts = {}) {
     } else {
       registered = true;
     }
+  }
+
+  // 3) Scope-coverage snapshot — advisory-only, never blocks/throws on failure.
+  // Base metadata for the patch: prefer the just-written parentMetadata (carries the
+  // fresh registry entry) over parentNow.metadata (already-registered / no-op case).
+  try {
+    const parentRef = parentNow.id ?? parentNow.uuid_id ?? null;
+    const { data: allChildren } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, scope, scope_slice')
+      .eq('parent_sd_id', parentRef);
+
+    const coverage = computeScopeCoverage(parentNow, allChildren || []);
+    if (coverage.coverage_pct < 100) {
+      const uncovered = coverage.elements.filter((e) => !e.covered).map((e) => e.element);
+      console.warn(
+        `[linkChild] ⚠️  scope coverage incomplete (${coverage.coverage_pct}%) for parent ${parentNow.sd_key} — uncovered: ${uncovered.join('; ')}`
+      );
+    }
+
+    const baseMetadata = parentMetadata || (parentNow.metadata && typeof parentNow.metadata === 'object' ? parentNow.metadata : {});
+    const { error: covErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ metadata: { ...baseMetadata, scope_coverage: coverage } })
+      .eq('sd_key', parentNow.sd_key);
+    if (covErr) console.warn(`[linkChild] ⚠️  scope-coverage write non-fatal: ${covErr.message}`);
+  } catch (covErr) {
+    console.warn(`[linkChild] ⚠️  scope-coverage computation failed (non-fatal): ${covErr.message}`);
   }
 
   return {

--- a/lib/sd/child-linkage.js
+++ b/lib/sd/child-linkage.js
@@ -159,10 +159,15 @@ export async function linkChild(supabase, parent, childKey, opts = {}) {
   // fresh registry entry) over parentNow.metadata (already-registered / no-op case).
   try {
     const parentRef = parentNow.id ?? parentNow.uuid_id ?? null;
-    const { data: allChildren } = await supabase
+    const { data: allChildren, error: childrenFetchErr } = await supabase
       .from('strategic_directives_v2')
       .select('sd_key, title, scope, scope_slice')
       .eq('parent_sd_id', parentRef);
+    // A failed re-fetch is NOT "zero children" -- treating it that way would persist a
+    // wrong low/0% coverage snapshot (clobbering a previously-correct one) on a transient
+    // DB hiccup. Bail out of the advisory computation entirely; the try/catch below still
+    // makes this non-fatal to linkChild's real work (child fields + registry).
+    if (childrenFetchErr) throw new Error(`children re-fetch failed: ${childrenFetchErr.message}`);
 
     const coverage = computeScopeCoverage(parentNow, allChildren || []);
     if (coverage.coverage_pct < 100) {

--- a/lib/sd/scope-coverage.js
+++ b/lib/sd/scope-coverage.js
@@ -1,0 +1,170 @@
+/**
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001: canonical scope-coverage utility.
+ *
+ * A parent orchestrator SD's children can silently fail to cover the parent's declared
+ * scope — PARENT_DELEGATED_COMPLETION only checks that >=1 child row exists, never that
+ * the children's union actually implements the parent's scope/success_criteria. Real
+ * incident: a parent titled "Develop MarketLens Landing Page with Hero and CTA" completed
+ * green with children that only built an API layer; no landing page was ever built.
+ *
+ * Pure, DB-free core (extractScopeElements, computeScopeCoverage) so both the
+ * decomposition-time hook (lib/sd/child-linkage.js) and the completion-time gate
+ * (scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js) share ONE
+ * implementation instead of each growing its own scope parser. Reuses the item-splitting
+ * pattern from scripts/modules/handoff/executors/plan-to-lead/gates/scope-audit.js and the
+ * keyword-overlap heuristic already proven in
+ * scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js — no new
+ * fuzzy-matching algorithm is introduced.
+ *
+ * Advisory-only by design: children are registered incrementally, one at a time (see
+ * child-linkage.js's own JSDoc), so a strict "fully covered" check at registration time
+ * would throw on the very first child. This module never throws and never blocks; callers
+ * decide what to do with an incomplete-coverage result (warn, flag, or ignore).
+ *
+ * @module lib/sd/scope-coverage
+ */
+
+const MIN_KEYWORD_LENGTH = 4;
+const STOPWORDS = new Set([
+  'this', 'that', 'with', 'from', 'into', 'when', 'what', 'have', 'will',
+  'shall', 'should', 'must', 'they', 'their', 'them', 'each', 'every',
+  'element', 'elements', 'scope', 'parent', 'child', 'children',
+]);
+
+/**
+ * Split a free-text scope string into discrete phrases.
+ * Handles numbered-list markers ("1. Foo", "2) Bar"), markdown bullets ("- Baz", "* Baz"),
+ * and plain newline-separated paragraphs. Never fabricates an element from blank input.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function splitScopeText(text) {
+  if (!text || typeof text !== 'string') return [];
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const phrases = [];
+  for (const line of lines) {
+    // Strip leading numbered/bulleted markers: "1.", "1)", "-", "*", "**1.**"
+    const stripped = line.replace(/^[*_\s]*\d+[.)]\s*[*_]*/, '').replace(/^[-*]\s+/, '').trim();
+    if (stripped.length > 0) phrases.push(stripped);
+  }
+  // Fallback: no line-level structure found (single-paragraph free text) — treat as one phrase.
+  if (phrases.length === 0 && text.trim().length > 0) phrases.push(text.trim());
+  return phrases;
+}
+
+/**
+ * Normalize an SD success_criteria/success_metrics array entry to a plain string.
+ * Handles string entries and the {criterion,measure} / {description,title} object shapes
+ * used elsewhere in the codebase (scope-audit.js's same fallback chain).
+ * @param {*} entry
+ * @returns {string}
+ */
+function normalizeCriterionEntry(entry) {
+  if (typeof entry === 'string') return entry;
+  if (entry && typeof entry === 'object') {
+    return entry.criterion || entry.criteria || entry.description || entry.title || '';
+  }
+  return '';
+}
+
+/**
+ * PURE: parse an SD's declared scope + success_criteria into discrete, checkable elements.
+ * Returns an empty array (never a fabricated element) when both fields are blank/unparseable.
+ * @param {object} sd - SD row with .scope (string) and/or .success_criteria (array)
+ * @returns {Array<{element: string, source: 'scope'|'success_criteria'}>}
+ */
+export function extractScopeElements(sd) {
+  if (!sd || typeof sd !== 'object') return [];
+  const elements = [];
+
+  for (const phrase of splitScopeText(sd.scope)) {
+    elements.push({ element: phrase, source: 'scope' });
+  }
+
+  if (Array.isArray(sd.success_criteria)) {
+    for (const entry of sd.success_criteria) {
+      const text = normalizeCriterionEntry(entry).trim();
+      if (text.length > 0) elements.push({ element: text, source: 'success_criteria' });
+    }
+  }
+
+  return elements;
+}
+
+/**
+ * Extract lowercase keywords (length > MIN_KEYWORD_LENGTH, stopwords removed) from text.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function extractKeywords(text) {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w.length > MIN_KEYWORD_LENGTH && !STOPWORDS.has(w));
+}
+
+/**
+ * Build the searchable text blob for a single child (title + scope + scope_slice).
+ * @param {object} child
+ * @returns {string}
+ */
+function childSearchText(child) {
+  if (!child) return '';
+  const parts = [child.title || '', child.scope || ''];
+  if (child.scope_slice && typeof child.scope_slice === 'object') {
+    if (Array.isArray(child.scope_slice.stages)) parts.push(child.scope_slice.stages.join(' '));
+    if (Array.isArray(child.scope_slice.deliverable_globs)) parts.push(child.scope_slice.deliverable_globs.join(' '));
+  }
+  return parts.filter(Boolean).join(' ');
+}
+
+/**
+ * Same substring/word-overlap heuristic already proven in
+ * scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js
+ * (lines 88-101) — reused verbatim rather than inventing a new fuzzy matcher.
+ * @param {string} elementText
+ * @param {string} childText (already lowercased)
+ * @returns {boolean}
+ */
+function isElementCoveredByChildText(elementText, childText) {
+  const el = elementText.toLowerCase();
+  if (childText.includes(el) || el.includes(childText)) return true;
+  const keywords = extractKeywords(elementText);
+  return keywords.some((word) => childText.includes(word));
+}
+
+/**
+ * PURE: compute scope-coverage of a parent's declared scope/success_criteria against its
+ * current children set. Never throws. Advisory-only — callers decide how to act on an
+ * incomplete result (warn, flag, ignore); this function performs no side effects.
+ * @param {object} sd - parent SD row (.scope, .success_criteria)
+ * @param {Array<object>} children - child SD rows (.title, .scope, .scope_slice, .sd_key)
+ * @returns {{elements: Array<{element:string, source:string, covered:boolean, coveringChildren:string[]}>,
+ *            coverage_pct: number, computed_at: string}}
+ */
+export function computeScopeCoverage(sd, children) {
+  const elements = extractScopeElements(sd);
+  const childList = Array.isArray(children) ? children : [];
+  const childTexts = childList.map((c) => ({ sd_key: c?.sd_key || null, text: childSearchText(c).toLowerCase() }));
+
+  const scored = elements.map(({ element, source }) => {
+    const coveringChildren = childTexts
+      .filter(({ text }) => text.length > 0 && isElementCoveredByChildText(element, text))
+      .map(({ sd_key }) => sd_key)
+      .filter(Boolean);
+    return { element, source, covered: coveringChildren.length > 0, coveringChildren };
+  });
+
+  const coveredCount = scored.filter((s) => s.covered).length;
+  const coverage_pct = scored.length === 0 ? 100 : Math.round((coveredCount / scored.length) * 100);
+
+  return {
+    elements: scored,
+    coverage_pct,
+    computed_at: new Date().toISOString(),
+  };
+}
+
+export default { extractScopeElements, computeScopeCoverage };

--- a/scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js
@@ -14,7 +14,19 @@
  * This file mirrors plan-to-exec/parent-orchestrator.js for the EXEC-TO-PLAN
  * direction — a reduced gate set that asserts only what's actually verifiable
  * for a parent: that its children exist and the decomposition is wired up.
+ *
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001: PARENT_DELEGATED_COMPLETION previously asserted
+ * only "children.length > 0" — it never compared the children's union against the
+ * parent's declared scope/success_criteria. A real incident shipped a parent titled
+ * "Develop MarketLens Landing Page with Hero and CTA" to completion with children that
+ * only built an API layer; no landing page was ever built. The gate now also computes a
+ * scope-coverage verdict (lib/sd/scope-coverage.js) and, when incomplete, raises a
+ * non-blocking needs_decision completion_flag naming the uncovered elements. The gate's
+ * passed/score return value is UNCHANGED by coverage — this is visibility, not enforcement.
  */
+
+import { computeScopeCoverage } from '../../../../../lib/sd/scope-coverage.js';
+import { captureCompletionFlags } from '../../../../capture-completion-flags.js';
 
 /**
  * Get reduced EXEC-TO-PLAN gates for parent orchestrator SDs.
@@ -34,7 +46,7 @@ export function getParentOrchestratorExecToPlanGates(supabase, sd) {
 
       const { data: children, error } = await supabase
         .from('strategic_directives_v2')
-        .select('id, sd_key, status, current_phase')
+        .select('id, sd_key, status, current_phase, title, scope, scope_slice')
         .eq('parent_sd_id', sd.id);
 
       if (error) {
@@ -69,6 +81,36 @@ export function getParentOrchestratorExecToPlanGates(supabase, sd) {
       console.log('   ✓ SKIPPED: SCOPE_COMPLETION_VERIFICATION (deliverables tracked by children)');
       console.log('   ✓ SKIPPED: integration/E2E/wireframe gates (no parent-owned UI/code)');
 
+      // Scope-coverage advisory (SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001): never affects
+      // passed/score above — visibility only, wrapped so a failure here cannot fail the gate.
+      let coverage = null;
+      try {
+        coverage = computeScopeCoverage(sd, children);
+        console.log(`   📊 Scope coverage: ${coverage.coverage_pct}% (${coverage.elements.length} declared element(s))`);
+
+        const baseMetadata = (sd.metadata && typeof sd.metadata === 'object' && !Array.isArray(sd.metadata)) ? sd.metadata : {};
+        const { error: metaErr } = await supabase
+          .from('strategic_directives_v2')
+          .update({ metadata: { ...baseMetadata, scope_coverage: coverage } })
+          .eq('id', sd.id);
+        if (metaErr) console.warn(`   ⚠️  scope-coverage metadata write non-fatal: ${metaErr.message}`);
+
+        if (coverage.coverage_pct < 100) {
+          const uncovered = coverage.elements.filter(e => !e.covered).map(e => e.element);
+          console.warn(`   ⚠️  ${uncovered.length} scope element(s) not covered by any child: ${uncovered.join('; ')}`);
+          await captureCompletionFlags({
+            supabase,
+            sdKey: sd.sd_key,
+            flags: [{
+              type: 'needs_decision',
+              item: `Parent scope coverage incomplete (${coverage.coverage_pct}%) — uncovered element(s): ${uncovered.join('; ')}`,
+            }],
+          });
+        }
+      } catch (covErr) {
+        console.warn(`   ⚠️  scope-coverage check failed (non-fatal, gate unaffected): ${covErr.message}`);
+      }
+
       return {
         passed: true,
         score: 100,
@@ -79,6 +121,7 @@ export function getParentOrchestratorExecToPlanGates(supabase, sd) {
           childrenCount: children.length,
           children: children.map(c => ({ sd_key: c.sd_key, status: c.status, phase: c.current_phase })),
           delegated_to_children: true,
+          scope_coverage: coverage ? { coverage_pct: coverage.coverage_pct, elementCount: coverage.elements.length } : null,
         },
       };
     },

--- a/scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js
@@ -88,7 +88,18 @@ export function getParentOrchestratorExecToPlanGates(supabase, sd) {
         coverage = computeScopeCoverage(sd, children);
         console.log(`   📊 Scope coverage: ${coverage.coverage_pct}% (${coverage.elements.length} declared element(s))`);
 
-        const baseMetadata = (sd.metadata && typeof sd.metadata === 'object' && !Array.isArray(sd.metadata)) ? sd.metadata : {};
+        // Re-fetch metadata fresh immediately before the write to narrow the read-modify-write
+        // window -- `sd` may have been fetched earlier in this handoff, and a full-object
+        // metadata overwrite using a stale copy would silently clobber any concurrent write
+        // to this parent's metadata JSON column.
+        const { data: freshSd } = await supabase
+          .from('strategic_directives_v2')
+          .select('metadata')
+          .eq('id', sd.id)
+          .maybeSingle();
+        const baseMetadata = (freshSd?.metadata && typeof freshSd.metadata === 'object' && !Array.isArray(freshSd.metadata))
+          ? freshSd.metadata
+          : (sd.metadata && typeof sd.metadata === 'object' && !Array.isArray(sd.metadata) ? sd.metadata : {});
         const { error: metaErr } = await supabase
           .from('strategic_directives_v2')
           .update({ metadata: { ...baseMetadata, scope_coverage: coverage } })

--- a/tests/integration/parent-scope-coverage.test.js
+++ b/tests/integration/parent-scope-coverage.test.js
@@ -1,0 +1,132 @@
+/**
+ * Parent Scope-Coverage Check — full integration test
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001 (FR-2, FR-3, FR-4)
+ *
+ * Replays the real incident specimen against the REAL production code paths — no mocked
+ * gates: lib/sd/child-linkage.js's linkChild() (decomposition-time) and the exported
+ * getParentOrchestratorExecToPlanGates()'s PARENT_DELEGATED_COMPLETION validator
+ * (completion-time), both against a disposable test parent/children set, cleaned up in
+ * afterAll.
+ */
+
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { linkChild } = await import('../../lib/sd/child-linkage.js');
+const { getParentOrchestratorExecToPlanGates } = await import(
+  '../../scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js'
+);
+
+const supabase = createSupabaseServiceClient();
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+describe.skipIf(!HAS_REAL_DB)('Parent Scope-Coverage Check (integration — MarketLens specimen)', () => {
+  const runId = Date.now();
+  const parentKey = `SD-TEST-SCOPE-COV-MKLENS-${runId}`;
+  const childApiKey = `${parentKey}-A`;
+  const childUiKey = `${parentKey}-B`;
+
+  beforeAll(async () => {
+    await supabase.from('strategic_directives_v2').insert({
+      sd_key: parentKey, id: parentKey, title: 'Develop MarketLens Landing Page with Hero and CTA (TEST SPECIMEN)',
+      status: 'draft', sd_type: 'orchestrator', category: 'infrastructure', priority: 'medium',
+      target_application: 'EHG_Engineer',
+      scope: '1. Landing page UI\n2. Signup UI',
+      description: 'Test specimen replaying the real MarketLens landing-page scope-coverage incident.',
+      rationale: 'Regression fixture for SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001.',
+      metadata: {},
+    });
+    await supabase.from('strategic_directives_v2').insert({
+      sd_key: childApiKey, id: childApiKey, title: 'Build the API layer',
+      status: 'draft', sd_type: 'infrastructure', category: 'infrastructure', priority: 'medium',
+      target_application: 'EHG_Engineer', scope: 'REST endpoints for venture data',
+      description: 'API-only child (deliberately under-scoped specimen)', rationale: 'Test fixture.',
+    });
+    await supabase.from('strategic_directives_v2').insert({
+      sd_key: childUiKey, id: childUiKey, title: 'Build the landing page UI and the signup UI',
+      status: 'draft', sd_type: 'infrastructure', category: 'infrastructure', priority: 'medium',
+      target_application: 'EHG_Engineer', scope: 'Landing page UI and signup UI implementation',
+      description: 'Covering child added in the second half of the specimen', rationale: 'Test fixture.',
+    });
+  });
+
+  afterAll(async () => {
+    await supabase.from('feedback').delete().eq('metadata->>source_sd', parentKey);
+    await supabase.from('strategic_directives_v2').delete().eq('sd_key', childUiKey);
+    await supabase.from('strategic_directives_v2').delete().eq('sd_key', childApiKey);
+    await supabase.from('strategic_directives_v2').delete().eq('sd_key', parentKey);
+  });
+
+  async function fetchParent() {
+    const { data } = await supabase.from('strategic_directives_v2').select('*').eq('sd_key', parentKey).single();
+    return data;
+  }
+
+  async function runCompletionGate() {
+    const parent = await fetchParent();
+    const gate = getParentOrchestratorExecToPlanGates(supabase, parent).find((g) => g.name === 'PARENT_DELEGATED_COMPLETION');
+    return gate.validator();
+  }
+
+  it('Step 1: linkChild() for the API-only child produces a decomposition-time coverage warning', async () => {
+    const parent = await fetchParent();
+    const result = await linkChild(supabase, parent, childApiKey, { registeredBy: 'test-fixture', today: '2026-07-04' });
+    expect(result.childKey).toBe(childApiKey);
+
+    const updatedParent = await fetchParent();
+    const coverage = updatedParent.metadata?.scope_coverage;
+    expect(coverage).toBeTruthy();
+    expect(coverage.coverage_pct).toBe(0);
+    expect(coverage.elements.map((e) => e.element)).toEqual(expect.arrayContaining(['Landing page UI', 'Signup UI']));
+    expect(coverage.elements.every((e) => !e.covered)).toBe(true);
+  });
+
+  it('Step 2: PARENT_DELEGATED_COMPLETION still passes but raises a needs_decision completion_flag', async () => {
+    const result = await runCompletionGate();
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.details.scope_coverage.coverage_pct).toBe(0);
+
+    const { data: flags } = await supabase
+      .from('feedback')
+      .select('id, category, metadata')
+      .eq('metadata->>source_sd', parentKey);
+    expect(flags.length).toBe(1);
+    expect(flags[0].category).toBe('completion_flag');
+    expect(flags[0].metadata.flag_class).toBe('needs_decision');
+  });
+
+  it('Step 2b: re-running the completion gate does not create a duplicate completion_flag row', async () => {
+    await runCompletionGate();
+    const { data: flags } = await supabase
+      .from('feedback')
+      .select('id')
+      .eq('metadata->>source_sd', parentKey);
+    expect(flags.length).toBe(1);
+  });
+
+  it('Step 3: registering the covering child closes the gap — 100% coverage, zero new flags', async () => {
+    const parent = await fetchParent();
+    await linkChild(supabase, parent, childUiKey, { registeredBy: 'test-fixture', today: '2026-07-04' });
+
+    const updatedParent = await fetchParent();
+    expect(updatedParent.metadata.scope_coverage.coverage_pct).toBe(100);
+
+    const result = await runCompletionGate();
+    expect(result.passed).toBe(true);
+    expect(result.details.scope_coverage.coverage_pct).toBe(100);
+
+    const { data: flags } = await supabase
+      .from('feedback')
+      .select('id')
+      .eq('metadata->>source_sd', parentKey);
+    expect(flags.length).toBe(1); // still just the one flag from the under-covered state — no new flag on a clean completion
+  });
+});

--- a/tests/unit/sd-child-linkage-coverage-resilience.test.js
+++ b/tests/unit/sd-child-linkage-coverage-resilience.test.js
@@ -1,0 +1,67 @@
+/**
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001 (FR-2, AC-3).
+ *
+ * linkChild()'s scope-coverage computation must be non-fatal: a thrown error inside
+ * computeScopeCoverage() must not prevent the child's parent_sd_id/relationship_type
+ * write from succeeding. Mocks computeScopeCoverage to throw (the real function is
+ * defensively coded and won't throw on realistic input — this proves the resilience
+ * path itself, which the real-DB integration test can't trigger without a fault-inject).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../lib/sd/scope-coverage.js', () => ({
+  computeScopeCoverage: vi.fn(() => {
+    throw new Error('simulated scope-coverage failure');
+  }),
+}));
+
+const { linkChild } = await import('../../lib/sd/child-linkage.js');
+
+function buildFakeSupabase({ parentRow, childrenRows = [] }) {
+  const updates = [];
+  return {
+    from(table) {
+      expect(table).toBe('strategic_directives_v2');
+      return {
+        select() {
+          return {
+            eq(_col, value) {
+              // Re-fetch of the parent (linkChild's first query) vs the children-fetch
+              // (the new coverage-resilience query) are distinguished by chain shape below.
+              return {
+                single: async () => ({ data: { ...parentRow }, error: null }),
+                // children fetch has no .single() call in child-linkage.js
+                then: undefined,
+              };
+            },
+          };
+        },
+        update(fields) {
+          return {
+            eq: async (col, value) => {
+              updates.push({ table, fields, col, value });
+              return { error: null };
+            },
+          };
+        },
+      };
+    },
+    __updates: updates,
+  };
+}
+
+describe('linkChild — scope-coverage resilience', () => {
+  it('still writes child parent_sd_id/relationship_type when computeScopeCoverage throws', async () => {
+    const parentRow = { id: 'PARENT-1', uuid_id: 'uuid-parent-1', sd_key: 'SD-PARENT-001', metadata: {}, scope: '1. Something', success_criteria: [] };
+    const supabase = buildFakeSupabase({ parentRow });
+
+    const result = await linkChild(supabase, parentRow, 'SD-PARENT-001-A', { registryOptional: true });
+
+    expect(result.childKey).toBe('SD-PARENT-001-A');
+    expect(result.relationship_type).toBe('child');
+
+    const childWrite = supabase.__updates.find((u) => u.value === 'SD-PARENT-001-A');
+    expect(childWrite).toBeTruthy();
+    expect(childWrite.fields).toEqual({ parent_sd_id: 'PARENT-1', relationship_type: 'child' });
+  });
+});

--- a/tests/unit/sd-scope-coverage.test.js
+++ b/tests/unit/sd-scope-coverage.test.js
@@ -1,0 +1,84 @@
+/**
+ * SD-LEO-INFRA-PARENT-SCOPE-COVERAGE-001 (FR-1 / activation test).
+ *
+ * Pure core: extractScopeElements(sd) parses declared scope/success_criteria into
+ * discrete elements; computeScopeCoverage(sd, children) matches each element against
+ * the children's title/scope/scope_slice text. No DB/IO — every assertion is over the
+ * pure functions.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractScopeElements, computeScopeCoverage } from '../../lib/sd/scope-coverage.js';
+
+describe('extractScopeElements', () => {
+  it('splits a numbered-list scope string into discrete elements', () => {
+    const sd = { scope: '1. Build the landing page UI\n2. Build the signup UI\n3. Wire analytics' };
+    const elements = extractScopeElements(sd);
+    expect(elements).toHaveLength(3);
+    expect(elements[0]).toEqual({ element: 'Build the landing page UI', source: 'scope' });
+    expect(elements.every((e) => e.source === 'scope')).toBe(true);
+  });
+
+  it('extracts success_criteria entries in {criterion,measure} shape', () => {
+    const sd = { success_criteria: [{ criterion: 'Users can sign up', measure: 'E2E test passes' }, 'Plain string criterion'] };
+    const elements = extractScopeElements(sd);
+    expect(elements).toHaveLength(2);
+    expect(elements[0]).toEqual({ element: 'Users can sign up', source: 'success_criteria' });
+    expect(elements[1]).toEqual({ element: 'Plain string criterion', source: 'success_criteria' });
+  });
+
+  it('returns an empty array (never a fabricated element) when scope and success_criteria are both blank', () => {
+    expect(extractScopeElements({ scope: '', success_criteria: [] })).toEqual([]);
+    expect(extractScopeElements({})).toEqual([]);
+    expect(extractScopeElements(null)).toEqual([]);
+  });
+
+  it('falls back to treating a single unstructured paragraph as one element', () => {
+    const sd = { scope: 'A single free-text scope paragraph with no list structure' };
+    expect(extractScopeElements(sd)).toEqual([
+      { element: 'A single free-text scope paragraph with no list structure', source: 'scope' },
+    ]);
+  });
+});
+
+describe('computeScopeCoverage', () => {
+  const parent = { scope: '1. Landing page UI\n2. Signup UI' };
+
+  it('reports 100% coverage when every element matches a child', () => {
+    const children = [
+      { sd_key: 'CHILD-A', title: 'Build the landing page UI', scope: '' },
+      { sd_key: 'CHILD-B', title: 'Build the signup UI', scope: '' },
+    ];
+    const result = computeScopeCoverage(parent, children);
+    expect(result.coverage_pct).toBe(100);
+    expect(result.elements.every((e) => e.covered)).toBe(true);
+    expect(result.elements.find((e) => e.element === 'Landing page UI').coveringChildren).toContain('CHILD-A');
+  });
+
+  it('reports partial coverage — the real incident specimen (API-only child)', () => {
+    const children = [{ sd_key: 'CHILD-API', title: 'Build the API layer', scope: 'REST endpoints for venture data' }];
+    const result = computeScopeCoverage(parent, children);
+    expect(result.coverage_pct).toBe(0);
+    expect(result.elements.filter((e) => !e.covered)).toHaveLength(2);
+    expect(result.elements.every((e) => e.coveringChildren.length === 0)).toBe(true);
+  });
+
+  it('reports 0% (not a crash) for a parent with zero children', () => {
+    const result = computeScopeCoverage(parent, []);
+    expect(result.coverage_pct).toBe(0);
+    expect(result.elements).toHaveLength(2);
+  });
+
+  it('reports 100% (zero elements, not a fabricated verdict) for an empty-scope parent', () => {
+    const result = computeScopeCoverage({ scope: '', success_criteria: [] }, [{ sd_key: 'X', title: 'anything' }]);
+    expect(result.coverage_pct).toBe(100);
+    expect(result.elements).toEqual([]);
+  });
+
+  it('matches via child.scope_slice text when title/scope alone would not match', () => {
+    const children = [
+      { sd_key: 'CHILD-A', title: 'Frontend work', scope: '', scope_slice: { stages: ['landing page ui rollout'] } },
+    ];
+    const result = computeScopeCoverage({ scope: '1. Landing page UI rollout' }, children);
+    expect(result.coverage_pct).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- `PARENT_DELEGATED_COMPLETION` previously only checked that a parent orchestrator SD had ≥1 child row, never that the children's union actually covered the parent's declared scope/success_criteria. Real incident: a parent titled "Develop MarketLens Landing Page with Hero and CTA" completed green with children that only built an API layer — no landing page was ever built.
- Adds a canonical, reusable scope-coverage utility (`lib/sd/scope-coverage.js`), used non-blockingly at two points:
  - **Decomposition-time** (`lib/sd/child-linkage.js`): logs a loud warning, never throws — children are registered incrementally by design.
  - **Completion-time** (`scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js`): raises an advisory `needs_decision` completion_flag via `captureCompletionFlags()` when coverage is incomplete, without changing the gate's pass/score.
- Includes a regression fixture that replays the real incident end-to-end against production code paths.

**Adversarial review response** (independent review before merge, since this SD was taken over from a session that went unresponsive mid-flight — see coordinator-authorized handoff): fixed two WARNING-level findings:
1. `child-linkage.js`'s children re-fetch never checked its query error, so a transient DB failure silently became "zero children" and persisted a wrong low/0% coverage snapshot. Now propagates the error into the existing non-fatal try/catch.
2. `parent-orchestrator.js`'s completion-time metadata write reused a possibly-stale `sd` object for a full-object overwrite. Now re-fetches metadata fresh immediately before the write, narrowing the RMW window.

The reviewer also flagged that the keyword-overlap coverage heuristic is permissive (single shared keyword ≥5 chars marks an element "covered") — left unchanged, since the code intentionally reuses the identical heuristic already proven in `plan-to-lead/gates/child-scope-coverage.js` "verbatim rather than inventing a new fuzzy matcher" (per its own docstring); diverging here would create inconsistency between two supposedly-identical implementations. Both are advisory-only paths that never affect gate pass/fail.

## Test plan
- [x] `node -c` syntax check on both fixed files, `npm run schema:lint` clean (0 violations)
- [x] Full SD test suite: `tests/unit/sd-scope-coverage.test.js`, `tests/unit/sd-child-linkage-coverage-resilience.test.js`, `tests/integration/parent-scope-coverage.test.js` — 14/14 pass (integration test replays the real MarketLens incident against a real DB)
- [x] LEAD-TO-PLAN (93), PLAN-TO-EXEC (91), EXEC-TO-PLAN (93), PLAN-TO-LEAD (96) handoffs all accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)