### PR TITLE
fix(QF-20260704-968): monitor-venture-run.cjs chairman_decisions queries scoped to decision_type=stage_gate

### DIFF
--- a/scripts/monitor-venture-run.cjs
+++ b/scripts/monitor-venture-run.cjs
@@ -195,10 +195,16 @@ async function getVentureState() {
 }
 
 async function getPendingDecision(stage) {
+  // QF-20260704-968: SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001 widened chairman_decisions
+  // uniqueness so a 'stage_gate' and a 'product_review' decision can both be pending at the
+  // same venture+stage. This ops CLI only auto-approves the blocking stage-gate lane (the
+  // one that halts the daemon walk) -- product_review is a separate human taste-review lane
+  // that must never be auto-approved here -- so decision_type is now explicit, not implicit.
   const { data } = await sb.from('chairman_decisions')
     .select('id, status, decision, lifecycle_stage, decision_type')
     .eq('venture_id', VENTURE_ID)
     .eq('lifecycle_stage', stage)
+    .eq('decision_type', 'stage_gate')
     .eq('status', 'pending')
     .is('deleted_at', null)
     .limit(1);
@@ -435,9 +441,13 @@ async function poll() {
       }
     } else {
       // Check if there are older pending decisions (from re-entry attempts)
+      // QF-20260704-968: same decision_type scoping as getPendingDecision() -- this
+      // cross-stage fallback also feeds approveDecision(), so it must not surface a
+      // product_review row (see note above).
       const { data: allPending } = await sb.from('chairman_decisions')
         .select('id, lifecycle_stage, status, decision_type, attempt_number')
         .eq('venture_id', VENTURE_ID)
+        .eq('decision_type', 'stage_gate')
         .eq('status', 'pending')
         .is('deleted_at', null)
         .order('created_at', { ascending: false })

--- a/tests/unit/monitor-venture-run-decision-type-scoped.test.js
+++ b/tests/unit/monitor-venture-run-decision-type-scoped.test.js
@@ -1,0 +1,48 @@
+/**
+ * QF-20260704-968 — scripts/monitor-venture-run.cjs's getPendingDecision(stage) and its
+ * cross-stage fallback queried chairman_decisions by venture_id/lifecycle_stage/status
+ * with no decision_type filter. SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001 widened
+ * chairman_decisions uniqueness so a 'stage_gate' and a 'product_review' decision can both
+ * be pending at the same venture+stage -- this ops CLI could then reference (and
+ * auto-approve) an arbitrary one of the two instead of only the intended stage-gate lane.
+ * product_review is a separate human taste-review decision that must never be
+ * auto-approved by this monitoring CLI.
+ *
+ * Static-pin pattern (mocking-independent), per tests/unit/sd-start-human-action-gate.test.js
+ * -- `sb` is a module-scoped Supabase client created at require-time, not easily mockable
+ * without modifying the source.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'scripts/monitor-venture-run.cjs'), 'utf8');
+
+describe('QF-20260704-968: monitor-venture-run.cjs chairman_decisions queries scoped to decision_type=stage_gate', () => {
+  it('getPendingDecision(stage) filters on decision_type=stage_gate', () => {
+    const start = src.indexOf('async function getPendingDecision');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, start + 1100);
+    expect(body).toMatch(/\.eq\('decision_type', 'stage_gate'\)/);
+  });
+
+  it('the cross-stage fallback query (re-entry attempts) also filters on decision_type=stage_gate', () => {
+    const start = src.indexOf('older pending decisions (from re-entry attempts)');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, start + 800);
+    expect(body).toMatch(/\.eq\('decision_type', 'stage_gate'\)/);
+  });
+
+  it('both queries still select decision_type in their column list (so callers can label the type)', () => {
+    const getPendingStart = src.indexOf('async function getPendingDecision');
+    const getPendingBody = src.slice(getPendingStart, getPendingStart + 700);
+    expect(getPendingBody).toMatch(/select\('id, status, decision, lifecycle_stage, decision_type'\)/);
+
+    const fallbackStart = src.indexOf('older pending decisions (from re-entry attempts)');
+    const fallbackBody = src.slice(fallbackStart, fallbackStart + 500);
+    expect(fallbackBody).toMatch(/select\('id, lifecycle_stage, status, decision_type, attempt_number'\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/monitor-venture-run.cjs`'s `getPendingDecision(stage)` (lines ~197-204) and its cross-stage re-entry fallback (lines ~438-444) queried `chairman_decisions` by `venture_id`+`lifecycle_stage`+`status=pending` with no `decision_type` filter.
- `SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001` widened `chairman_decisions` uniqueness to allow two pending `decision_type`s (`stage_gate` and `product_review`) to coexist at the same venture+stage. This ops-monitoring CLI could then reference (and **auto-approve**, via `approveDecision()`) an arbitrary one of the two instead of only the intended blocking `stage_gate` lane. `product_review` is a separate human taste-review decision that must never be rubber-stamped by an automated monitor.
- Found via adversarial review of PR #5540. Low impact: manual ops CLI keyed to one hardcoded `VENTURE_ID`, hard-stops at Stage 17 by default (`STOP_AT_STAGE` env var must be explicitly raised to reach 23) — no data-integrity or security impact at current usage, but a real risk in the shape of "auto-approve the wrong decision" once this script is used past Stage 23.
- Fix: both queries now explicitly filter `.eq('decision_type', 'stage_gate')`.

## Test plan
- [x] `node -c` syntax check, `npm run schema:lint` clean (0 violations)
- [x] New static-pin unit test `tests/unit/monitor-venture-run-decision-type-scoped.test.js` (3 tests) — pins the `decision_type='stage_gate'` filter at both call sites
- [x] Existing `monitor-venture-run-sd-required-guard.test.js` + `monitor-venture-run-validate.test.js` regression pass (31/31 total)

QF-20260704-968 · Tier 1 (10 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)