### PR TITLE
feat(SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C): adherence rubric scoring + convergence loop

### DIFF
--- a/lib/eva/adherence-scorer.js
+++ b/lib/eva/adherence-scorer.js
@@ -1,0 +1,262 @@
+/**
+ * Adherence Scorer — applies Child A's rubric registry to Child B's verdict-table
+ * rows, producing a behaviorally-anchored 1-5 score per dimension plus a weighted
+ * deviation ledger.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C. Pure read against post_build_verdicts +
+ * adherence_rubrics + the deviation ledger — never mutates any of Child A/B's
+ * tables (FR-3 role-separation: this module has no remediation side effects).
+ *
+ * @module lib/eva/adherence-scorer
+ */
+
+import { readDeviations } from './deviation-ledger.js';
+import { ARTIFACT_TYPES } from './artifact-types.js';
+
+/** Chairman-ratified: a deviation reason must be >=15 chars to even be considered
+ *  documented (matches Child B's DEVIATION_REASON_MIN_LENGTH) — but non-empty-and-long
+ *  is necessary, not sufficient; see classifyDeviationReason() for the sense-making pass
+ *  this module owns exclusively. */
+const DEVIATION_REASON_MIN_LENGTH = 15;
+
+/** Explicit artifact_type -> rubric dimension mapping (FR-1 technical requirement:
+ *  a single reviewable constant, never inline/ad hoc). Types not listed here are
+ *  out of this rubric's scope by design (truth_*, engine_*, marketing_*, build_mvp_build,
+ *  wireframe_screens, system_devils_advocate_review, blueprint_financial_projection). */
+export const DIMENSION_ARTIFACT_MAP = Object.freeze({
+  user_story_coverage: Object.freeze([ARTIFACT_TYPES.BLUEPRINT_USER_STORY_PACK]),
+  persona_surface_coverage: Object.freeze([
+    ARTIFACT_TYPES.IDENTITY_PERSONA_BRAND,
+    ARTIFACT_TYPES.IDENTITY_NAMING_VISUAL,
+    ARTIFACT_TYPES.IDENTITY_BRAND_GUIDELINES,
+  ]),
+  data_model_fidelity: Object.freeze([
+    ARTIFACT_TYPES.BLUEPRINT_DATA_MODEL,
+    ARTIFACT_TYPES.BLUEPRINT_ERD_DIAGRAM,
+    ARTIFACT_TYPES.BLUEPRINT_API_CONTRACT,
+    ARTIFACT_TYPES.BLUEPRINT_SCHEMA_SPEC,
+  ]),
+  architecture_conformance: Object.freeze([
+    ARTIFACT_TYPES.BLUEPRINT_TECHNICAL_ARCHITECTURE,
+    ARTIFACT_TYPES.BLUEPRINT_PRODUCT_ROADMAP,
+  ]),
+});
+
+/** Sentinel returned for a dimension with zero evidence-linked claims — distinct from
+ *  any numeric score so callers can never mistake "unscored" for a real value. */
+export const UNSCORED = Symbol('UNSCORED');
+
+const PASSING_DISPOSITIONS = new Set(['BUILT']);
+
+/**
+ * Judge whether a deviation's `why` text is SENSIBLE (names what was planned, what was
+ * done instead, and a concrete causal reason) vs THIN/NONSENSICAL (generic, circular,
+ * or a bare restatement with no causal content). This is a conservative heuristic:
+ * a reason must clear the length floor AND contain at least one causal-connective marker
+ * AND not be a pure restatement of "changed"/"different" with nothing else. Ambiguous
+ * cases fail toward THIN (never toward SENSIBLE) — mirrors Child B's evidence-linking
+ * honesty rule (could-not-verify != built).
+ *
+ * Per the parent SD's OWNERSHIP CLARIFICATION: Child A/B only validate non-empty;
+ * judging sense-making is this module's exclusive job (FR-2).
+ *
+ * @param {string} why
+ * @returns {'SENSIBLE'|'THIN'}
+ */
+const SENSIBLE_MIN_WORDS = 6;
+
+export function classifyDeviationReason(why) {
+  const text = String(why || '').trim();
+  if (text.length < DEVIATION_REASON_MIN_LENGTH) return 'THIN';
+
+  const CAUSAL_MARKERS = /\b(because|since|due to|per|requires?|so that|in order to|as a result|caused by|driven by)\b/i;
+  const GENERIC_ONLY = /^(decided to (do it|build it|make it) differently|changed (it|this|approach)|different approach|updated (per|based on) feedback)\.?$/i;
+
+  if (GENERIC_ONLY.test(text)) return 'THIN';
+  if (!CAUSAL_MARKERS.test(text)) return 'THIN';
+  // A word-count floor on top of the causal-marker check: a trivial phrase like
+  // "because reasons" trips the marker regex without saying anything — require
+  // enough surrounding content for the causal claim to be substantive.
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  if (wordCount < SENSIBLE_MIN_WORDS) return 'THIN';
+  return 'SENSIBLE';
+}
+
+/**
+ * Read all post_build_verdicts rows for a venture belonging to one dimension's
+ * mapped artifact_types.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, artifactTypes: string[]}} opts
+ * @returns {Promise<Array>}
+ */
+async function readDimensionVerdicts(supabase, { ventureId, artifactTypes }) {
+  const { data, error } = await supabase
+    .from('post_build_verdicts')
+    .select('id, artifact_type, claim_ref, disposition, deviation_artifact_id')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', artifactTypes);
+
+  if (error) {
+    throw new Error(`[adherence-scorer] readDimensionVerdicts failed: ${error.message}`);
+  }
+  return data || [];
+}
+
+/**
+ * For a DEVIATED_WITH_DOCUMENTED_REASON verdict row, look up its deviation record(s)
+ * and apply FR-2's reason-quality judgment. Returns true only if at least one linked
+ * deviation record classifies SENSIBLE.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, claimRef: string}} opts
+ * @returns {Promise<boolean>}
+ */
+async function hasSensibleDeviation(supabase, { ventureId, claimRef }) {
+  const records = await readDeviations(supabase, { ventureId, artifactRef: claimRef });
+  return records.some((r) => classifyDeviationReason(r.why).toString() === 'SENSIBLE');
+}
+
+/**
+ * Score one dimension's verdict rows into a 1-5 value (or UNSCORED).
+ * Scoring rule: fraction = (count of BUILT + count of DEVIATED_WITH_DOCUMENTED_REASON-
+ * with-a-SENSIBLE-reason) / total claims. Maps fraction to the rubric's 1-5 behavioral
+ * anchors: 0 claims => UNSCORED; fraction===1 => 5; fraction>=0.5 (but <1, or has any
+ * undocumented/thin drift) => 4 if ALL gaps are documented-sensible-deviations, else
+ * scaled down; fraction>=0.5 => 3; fraction>0 => 2; fraction===0 with claims present => 1.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, artifactTypes: string[]}} opts
+ * @returns {Promise<number|symbol>} 1-5, or UNSCORED
+ */
+export async function scoreDimension(supabase, { ventureId, artifactTypes }) {
+  const rows = await readDimensionVerdicts(supabase, { ventureId, artifactTypes });
+  if (rows.length === 0) return UNSCORED;
+
+  let passing = 0;
+  let documentedSensible = 0;
+  let undocumentedOrThin = 0;
+
+  for (const row of rows) {
+    if (PASSING_DISPOSITIONS.has(row.disposition)) {
+      passing += 1;
+      continue;
+    }
+    if (row.disposition === 'DEVIATED_WITH_DOCUMENTED_REASON') {
+      const sensible = await hasSensibleDeviation(supabase, { ventureId, claimRef: row.claim_ref });
+      if (sensible) {
+        documentedSensible += 1;
+        continue;
+      }
+    }
+    undocumentedOrThin += 1;
+  }
+
+  const total = rows.length;
+  const goodFraction = (passing + documentedSensible) / total;
+
+  if (goodFraction === 1) return 5;
+  if (goodFraction === 0) return 1;
+  if (undocumentedOrThin === 0 && goodFraction >= 0.5) return 4; // remaining gaps are all documented+sensible
+  if (goodFraction >= 0.5) return 3;
+  return 2;
+}
+
+/**
+ * Score every dimension for a venture against the published rubric row, and
+ * evaluate the frozen pass bar (dimension_floor / mean_floor / zero_unscored_fails),
+ * read live from the rubric row — never hardcoded (validation-agent LEAD finding).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, rubricKey?: string}} opts
+ * @returns {Promise<{dimensionScores: Record<string, number|null>, unscoredDimensions: string[], mean: number, pass: boolean, rubric: object}>}
+ */
+export async function scoreVerdictTable(supabase, { ventureId, rubricKey = 'post_build_adherence_v1' } = {}) {
+  if (!ventureId) throw new Error('[adherence-scorer] scoreVerdictTable requires ventureId');
+
+  const { data: rubric, error: rubricError } = await supabase
+    .from('adherence_rubrics')
+    .select('rubric_key, version, dimensions, dimension_floor, mean_floor, zero_unscored_fails')
+    .eq('rubric_key', rubricKey)
+    .eq('status', 'published')
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (rubricError) {
+    throw new Error(`[adherence-scorer] failed to load rubric: ${rubricError.message}`);
+  }
+  if (!rubric) {
+    throw new Error(`[adherence-scorer] no published rubric found for rubric_key=${rubricKey}`);
+  }
+
+  const dimensionScores = {};
+  const unscoredDimensions = [];
+  const scoredValues = [];
+
+  for (const [dimension, artifactTypes] of Object.entries(DIMENSION_ARTIFACT_MAP)) {
+    const score = await scoreDimension(supabase, { ventureId, dimension, artifactTypes });
+    if (score === UNSCORED) {
+      dimensionScores[dimension] = null;
+      unscoredDimensions.push(dimension);
+    } else {
+      dimensionScores[dimension] = score;
+      scoredValues.push(score);
+    }
+  }
+
+  const mean = scoredValues.length > 0 ? scoredValues.reduce((a, b) => a + b, 0) / scoredValues.length : 0;
+
+  let pass = true;
+  if (rubric.zero_unscored_fails && unscoredDimensions.length > 0) pass = false;
+  if (scoredValues.some((s) => s < rubric.dimension_floor)) pass = false;
+  if (mean < rubric.mean_floor) pass = false;
+  if (scoredValues.length === 0) pass = false;
+
+  return { dimensionScores, unscoredDimensions, mean, pass, rubric };
+}
+
+/**
+ * Weighted deviation ledger: all DEVIATED_* verdicts for a venture, ranked by
+ * weight (critical-tier first, per Child A's DEVIATION_WEIGHTS), for the chairman
+ * review packet (Child D) and remediation prioritization (FR-6).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string}} opts
+ * @returns {Promise<Array<{verdictId: string, claimRef: string, weight: string, why: string, quality: 'SENSIBLE'|'THIN'}>>}
+ */
+export async function buildDeviationLedger(supabase, { ventureId } = {}) {
+  if (!ventureId) throw new Error('[adherence-scorer] buildDeviationLedger requires ventureId');
+
+  const { data: verdicts, error } = await supabase
+    .from('post_build_verdicts')
+    .select('id, claim_ref, disposition')
+    .eq('venture_id', ventureId)
+    .in('disposition', ['DEVIATED_WITH_DOCUMENTED_REASON', 'DEVIATED_UNDOCUMENTED']);
+
+  if (error) {
+    throw new Error(`[adherence-scorer] buildDeviationLedger failed to read verdicts: ${error.message}`);
+  }
+
+  const ledger = [];
+  for (const verdict of verdicts || []) {
+    const records = await readDeviations(supabase, { ventureId, artifactRef: verdict.claim_ref });
+    for (const record of records) {
+      ledger.push({
+        verdictId: verdict.id,
+        claimRef: verdict.claim_ref,
+        weight: record.weight,
+        why: record.why,
+        quality: classifyDeviationReason(record.why),
+      });
+    }
+  }
+
+  // Critical-tier first (chairman ask): urgency order is critical > moderate > minor >
+  // declared-descope (an acknowledged, already-accepted gap — least urgent, not most,
+  // despite being last in DEVIATION_WEIGHTS' declaration order — so this is a dedicated
+  // priority map, not a reuse of that array's index).
+  const URGENCY_RANK = Object.freeze({ critical: 3, moderate: 2, minor: 1, 'declared-descope': 0 });
+  const weightRank = (w) => URGENCY_RANK[w] ?? -1;
+  return ledger.sort((a, b) => weightRank(b.weight) - weightRank(a.weight));
+}
+
+export default { DIMENSION_ARTIFACT_MAP, UNSCORED, classifyDeviationReason, scoreDimension, scoreVerdictTable, buildDeviationLedger };

--- a/lib/eva/convergence-loop.js
+++ b/lib/eva/convergence-loop.js
@@ -1,0 +1,266 @@
+/**
+ * Convergence Loop — score, remediate, rescore, bounded and monotone-terminating,
+ * producing a 3-disposition escalation packet on exhaustion/non-convergence.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C. Wraps lib/eva/adherence-scorer.js
+ * (FR-1/2/3/4) with the orchestration loop (FR-5), remediation router (FR-6),
+ * and escalation-packet generator (FR-7). Scorer/builder/remediator role
+ * separation (FR-3) is structural: every rescore is a fresh scoreVerdictTable()
+ * invocation with no shared mutable state carried from the remediation step.
+ *
+ * @module lib/eva/convergence-loop
+ */
+
+import { scoreVerdictTable, buildDeviationLedger } from './adherence-scorer.js';
+import { isTrendingDown } from '../coordinator/convergence-ledger.js';
+import { withRetry } from './stage-zero/data-pollers/retry.js';
+
+/** Chairman-ratified constants — changing these requires fresh chairman
+ *  ratification (parent SD's gate-freeze), so they are function-parameter
+ *  defaults, never env-configurable. */
+export const DEFAULT_MAX_CYCLES = 3;
+export const DEFAULT_PER_CYCLE_CAP = 5;
+
+/** Exactly three escalation dispositions — no others are ever offered (FR-7). */
+export const ESCALATION_DISPOSITIONS = Object.freeze([
+  'descope-as-known-gap',
+  'pivot-the-artifact',
+  'hold-launch',
+]);
+
+/**
+ * Convert a scoreVerdictTable() result into a single "deficit" number where 0 means
+ * PASS and lower is always better/closer-to-passing — the natural direction for
+ * isTrendingDown() (lower-is-converging), reused from lib/coordinator/convergence-ledger.js
+ * per validation-agent's LEAD-phase finding rather than reinventing a comparator.
+ * @param {{dimensionScores: object, unscoredDimensions: string[], mean: number, rubric: object}} scoreResult
+ * @returns {number}
+ */
+export function computeDeficit(scoreResult) {
+  const { dimensionScores, unscoredDimensions, mean, rubric } = scoreResult;
+  const unscoredPenalty = unscoredDimensions.length * 10; // an unscored dimension always fails regardless of others
+  const floorDeficit = Object.values(dimensionScores)
+    .filter((v) => typeof v === 'number')
+    .reduce((sum, v) => sum + Math.max(0, rubric.dimension_floor - v), 0);
+  const meanDeficit = Math.max(0, rubric.mean_floor - mean);
+  return unscoredPenalty + floorDeficit + meanDeficit;
+}
+
+/**
+ * Classify each below-floor/unscored dimension as a completeness gap (no verdict
+ * rows at all — the artifact itself is missing) or an adherence gap (verdict rows
+ * exist but scored below the dimension floor).
+ * @param {{dimensionScores: object, unscoredDimensions: string[], rubric: object}} scoreResult
+ * @returns {Array<{dimension: string, kind: 'completeness'|'adherence', score: number|null}>}
+ */
+export function classifyGaps(scoreResult) {
+  const { dimensionScores, unscoredDimensions, rubric } = scoreResult;
+  const gaps = [];
+  for (const [dimension, score] of Object.entries(dimensionScores)) {
+    if (unscoredDimensions.includes(dimension)) {
+      gaps.push({ dimension, kind: 'completeness', score: null });
+    } else if (typeof score === 'number' && score < rubric.dimension_floor) {
+      gaps.push({ dimension, kind: 'adherence', score });
+    }
+  }
+  return gaps;
+}
+
+/**
+ * Backfill a completeness gap. REQUIRES an injected upstream source function —
+ * there is deliberately no default implementation, because any default would
+ * either (a) read from the venture's own build/repo (the circularity this guard
+ * exists to prevent) or (b) silently no-op, both worse than a loud failure.
+ * The circularity guard rejects any sourceFn result whose declared `source` is
+ * 'build' or 'repo'.
+ * @param {{dimension: string, ventureId: string}} gap
+ * @param {Function} sourceFn - async ({dimension, ventureId}) => {source: string, artifact: object}
+ * @returns {Promise<{retroactive: true, confidence: 'low', artifact: object}>}
+ */
+export async function backfillCompletenessGap(gap, sourceFn) {
+  if (typeof sourceFn !== 'function') {
+    throw new Error('[convergence-loop] backfillCompletenessGap requires an upstream sourceFn (no default — circularity guard by omission)');
+  }
+  const result = await withRetry(() => sourceFn(gap), { label: `backfill:${gap.dimension}`, maxRetries: 1 });
+  if (!result || result.source === 'build' || result.source === 'repo') {
+    throw new Error(`[convergence-loop] circularity guard: completeness backfill for dimension=${gap.dimension} rejected a build/repo-sourced result — must originate upstream`);
+  }
+  return { retroactive: true, confidence: 'low', artifact: result.artifact ?? result };
+}
+
+/**
+ * Classify an adherence gap's remediation tier. Tier 3 (full SD, LEAD path) when
+ * the gap has any critical-weight deviation attached (per the deviation ledger) —
+ * otherwise tier 1/2 (quick-fix, auto-dispatch). Injectable for override in tests;
+ * the default reads the ledger passed in by the caller.
+ * @param {{dimension: string}} gap
+ * @param {Array<{dimension?: string, weight: string}>} ledger
+ * @returns {1|2|3}
+ */
+export function classifyRemediationTier(gap, ledger) {
+  const hasCritical = (ledger || []).some((entry) => entry.dimension === gap.dimension && entry.weight === 'critical');
+  return hasCritical ? 3 : 2;
+}
+
+/**
+ * File a fix for an adherence gap via the existing SD/QF creation paths.
+ * Tier-1/2 -> create-quick-fix.js (auto-file+auto-dispatch); tier-3 ->
+ * leo-create-sd.js (auto-file-draft into the standard LEAD path).
+ * @param {{dimension: string, score: number|null}} gap
+ * @param {{tier: 1|2|3, createQuickFixFn: Function, createSdFn: Function}} opts
+ * @returns {Promise<{filed: string, id: string}>}
+ */
+export async function fileAdherenceFix(gap, { tier, createQuickFixFn, createSdFn }) {
+  const title = `Adherence gap: ${gap.dimension} scored ${gap.score ?? 'unscored'} (post-build reconciliation)`;
+  if (tier === 3) {
+    if (typeof createSdFn !== 'function') {
+      throw new Error('[convergence-loop] fileAdherenceFix requires createSdFn for tier-3 gaps');
+    }
+    const id = await withRetry(() => createSdFn({ title, dimension: gap.dimension }), { label: `file-sd:${gap.dimension}`, maxRetries: 1 });
+    return { filed: 'sd', id };
+  }
+  if (typeof createQuickFixFn !== 'function') {
+    throw new Error('[convergence-loop] fileAdherenceFix requires createQuickFixFn for tier-1/2 gaps');
+  }
+  const id = await withRetry(() => createQuickFixFn({ title, dimension: gap.dimension }), { label: `file-qf:${gap.dimension}`, maxRetries: 1 });
+  return { filed: 'quick_fix', id };
+}
+
+/**
+ * Route one cycle's below-threshold gaps to remediation, capped at perCycleCap.
+ * Overflow items are returned as `deferred`, never silently dropped or auto-filed.
+ * @param {Array} gaps
+ * @param {{ventureId: string, perCycleCap: number, ledger: Array, backfillFn?: Function, createQuickFixFn?: Function, createSdFn?: Function}} opts
+ * @returns {Promise<{routed: Array, deferred: Array, errors: Array}>}
+ */
+export async function routeRemediation(gaps, { ventureId, perCycleCap = DEFAULT_PER_CYCLE_CAP, ledger = [], backfillFn, createQuickFixFn, createSdFn }) {
+  const routed = [];
+  const deferred = [];
+  const errors = [];
+
+  const toRoute = gaps.slice(0, perCycleCap);
+  const overflow = gaps.slice(perCycleCap);
+  deferred.push(...overflow);
+
+  for (const gap of toRoute) {
+    try {
+      if (gap.kind === 'completeness') {
+        const result = await backfillCompletenessGap({ ...gap, ventureId }, backfillFn);
+        routed.push({ ...gap, remediation: 'completeness-backfill', result });
+      } else {
+        const tier = classifyRemediationTier(gap, ledger);
+        const result = await fileAdherenceFix(gap, { tier, createQuickFixFn, createSdFn });
+        routed.push({ ...gap, remediation: 'adherence-fix', tier, result });
+      }
+    } catch (err) {
+      errors.push({ ...gap, error: err.message });
+      deferred.push(gap);
+    }
+  }
+
+  return { routed, deferred, errors };
+}
+
+/**
+ * Build the escalation packet on cap exhaustion or non-convergence — exactly the
+ * three chairman-specified disposition options (FR-7), never more or fewer.
+ * @param {{scoreResult: object, ledger: Array, deferredItems: Array, isArtifactChairmanApproved?: boolean}} opts
+ * @returns {object}
+ */
+export function buildEscalationPacket({ scoreResult, ledger, deferredItems = [], isArtifactChairmanApproved = false }) {
+  return {
+    finalState: scoreResult,
+    deviationLedger: ledger,
+    deferredThisCycle: deferredItems,
+    dispositions: ESCALATION_DISPOSITIONS.map((key) => ({
+      key,
+      ...(key === 'pivot-the-artifact' ? { requires_chairman_ratification: isArtifactChairmanApproved === true } : {}),
+    })),
+  };
+}
+
+/**
+ * Run the full convergence loop for one venture: score, and if below threshold,
+ * route gaps to remediation, rescore, repeat up to maxCycles with monotone-
+ * convergence early termination. On PASS, returns immediately. On cap exhaustion
+ * or non-convergence, returns an escalation packet.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, rubricKey?: string, maxCycles?: number, perCycleCap?: number,
+ *   backfillFn?: Function, createQuickFixFn?: Function, createSdFn?: Function,
+ *   isArtifactChairmanApproved?: boolean}} opts
+ * @returns {Promise<{status: 'PASS'|'ESCALATED', cycles: number, scoreResult: object, escalationPacket?: object, remediationHistory: Array}>}
+ */
+export async function runConvergenceLoop(supabase, opts = {}) {
+  const {
+    ventureId,
+    rubricKey = 'post_build_adherence_v1',
+    maxCycles = DEFAULT_MAX_CYCLES,
+    perCycleCap = DEFAULT_PER_CYCLE_CAP,
+    backfillFn,
+    createQuickFixFn,
+    createSdFn,
+    isArtifactChairmanApproved = false,
+  } = opts;
+
+  if (!ventureId) throw new Error('[convergence-loop] runConvergenceLoop requires ventureId');
+
+  const deficitSeries = [];
+  const remediationHistory = [];
+  let scoreResult = await scoreVerdictTable(supabase, { ventureId, rubricKey });
+  let cycle = 0;
+
+  while (cycle < maxCycles) {
+    cycle += 1;
+    deficitSeries.push(computeDeficit(scoreResult));
+
+    if (scoreResult.pass) {
+      return { status: 'PASS', cycles: cycle, scoreResult, remediationHistory };
+    }
+
+    // Monotone-convergence early exit: if the deficit series is not strictly
+    // trending down so far (a rescore did not improve, or regressed), stop
+    // rather than burning remaining cycles. Skipped on the very first cycle
+    // (nothing to compare against yet).
+    if (cycle > 1 && !isTrendingDown(deficitSeries)) {
+      break;
+    }
+
+    const gaps = classifyGaps(scoreResult);
+    const ledger = await buildDeviationLedger(supabase, { ventureId });
+    const { routed, deferred, errors } = await routeRemediation(gaps, {
+      ventureId, perCycleCap, ledger, backfillFn, createQuickFixFn, createSdFn,
+    });
+    remediationHistory.push({ cycle, routed, deferred, errors });
+
+    if (cycle >= maxCycles) {
+      // Fresh, independent rescore (structural role separation, FR-3) before
+      // deciding final PASS/ESCALATE at cap exhaustion.
+      scoreResult = await scoreVerdictTable(supabase, { ventureId, rubricKey });
+      deficitSeries.push(computeDeficit(scoreResult));
+      break;
+    }
+
+    // Fresh rescore for the next loop iteration — a new, independent invocation,
+    // never reusing the pre-remediation scoreResult (FR-3).
+    scoreResult = await scoreVerdictTable(supabase, { ventureId, rubricKey });
+  }
+
+  if (scoreResult.pass) {
+    return { status: 'PASS', cycles: cycle, scoreResult, remediationHistory };
+  }
+
+  const ledger = await buildDeviationLedger(supabase, { ventureId });
+  const lastDeferred = remediationHistory[remediationHistory.length - 1]?.deferred ?? [];
+  const escalationPacket = buildEscalationPacket({
+    scoreResult, ledger, deferredItems: lastDeferred, isArtifactChairmanApproved,
+  });
+
+  return { status: 'ESCALATED', cycles: cycle, scoreResult, escalationPacket, remediationHistory };
+}
+
+export default {
+  DEFAULT_MAX_CYCLES, DEFAULT_PER_CYCLE_CAP, ESCALATION_DISPOSITIONS,
+  computeDeficit, classifyGaps, backfillCompletenessGap, classifyRemediationTier,
+  fileAdherenceFix, routeRemediation, buildEscalationPacket, runConvergenceLoop,
+};

--- a/scripts/one-off/_validation-write-result-sd-leo-infra-post-build-artifact-001-c-lead.mjs
+++ b/scripts/one-off/_validation-write-result-sd-leo-infra-post-build-artifact-001-c-lead.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * One-off: Write VALIDATION sub-agent LEAD-phase verdict for
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C ("Adherence Rubric Scoring + Convergence Loop")
+ * ahead of its LEAD-TO-PLAN handoff.
+ *
+ * Child C of orchestrator SD-LEO-INFRA-POST-BUILD-ARTIFACT-001. Depends on:
+ *   - Child A (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-A, completed/merged) — shipped
+ *     adherence_rubrics table + seeded post_build_adherence_v1 rubric row.
+ *   - Child B (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-B, completed/merged) — shipped
+ *     lib/eva/post-build-verdict-engine.js (runArtifactWalk / computeDisposition /
+ *     upsertVerdict) writing per-item rows to post_build_verdicts.
+ *
+ * Uses the canonical repo-evidence pattern (lib/sub-agents/resolve-repo.js
+ * applySubAgentRepoVerdict) + the canonical storage path
+ * (lib/sub-agent-executor/results-storage.js storeSubAgentResults) rather than a
+ * hand-rolled INSERT, per CLAUDE.md prologue rule 11.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '18129ef6-5615-468e-b8da-d99f9833b213';
+const SD_KEY = 'SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C';
+
+const findings = [
+  {
+    id: 'F1-child-a-rubric-input-present-and-usable',
+    severity: 'INFO',
+    summary: 'Child A input CONFIRMED usable. database/migrations/20260704_create_adherence_rubrics.sql creates adherence_rubrics and seeds row rubric_key=post_build_adherence_v1 (version 1, status=published) whose dimensions jsonb contains EXACTLY the 4 dimensions Child C scores — user_story_coverage, persona_surface_coverage, data_model_fidelity, architecture_conformance — each with scale "1-5", evidence_required=true, and a full behavioral_anchors map keyed "1".."5". dimension_floor=3, mean_floor=4, zero_unscored_fails=true match the chairman-ratified frozen pass bar in Child C\'s scope verbatim (every dim>=3 AND mean>=4 AND zero unscored). Table has NO dimension-name restriction (unlike leo_scoring_rubrics\' hard-coded 6-key trigger) so the 4-dim set is accepted. Immutable-via-trigger + supersedes chain means Child C reads a stable, versioned rubric — it should SELECT the published row by rubric_key and never mutate it.'
+  },
+  {
+    id: 'F2-child-b-verdict-output-shape-present-and-usable',
+    severity: 'INFO',
+    summary: 'Child B input CONFIRMED usable. lib/eva/post-build-verdict-engine.js exports runArtifactWalk(supabase,{ventureId,throughStage}) returning Array<{artifactType, claimRef, disposition}> and upserting one row per enumerated item to post_build_verdicts with the frozen 5-value disposition taxonomy (BUILT / PARTIAL / MISSING / DEVIATED_WITH_DOCUMENTED_REASON / DEVIATED_UNDOCUMENTED, exported as DISPOSITIONS). computeDisposition() and upsertVerdict() are also exported and directly callable. This is a clean, stable per-item disposition feed for Child C\'s scorer: Child C maps a set of dispositions per dimension -> a 1-5 anchored score. No adapter/shape-translation is required; Child C consumes runArtifactWalk\'s return (or reads post_build_verdicts rows) directly.'
+  },
+  {
+    id: 'F3-no-duplicate-adherence-scorer-or-convergence-executor',
+    severity: 'INFO',
+    summary: 'NO DUPLICATE exists. Swept lib/ + scripts/ for adherence/rubric dimension-scoring and convergence-loop logic. (a) adherence_rubrics has ZERO JS consumers today (only tests + Child-A one-off seeders reference it) — Child C is its first consumer. (b) post_build_verdicts is consumed only by Child B\'s own engine — Child C is its first downstream reader, no collision. (c) No existing code reads disposition rows (BUILT/PARTIAL/MISSING/DEVIATED_*) and emits behaviorally-anchored 1-5 per-dimension scores against a rubric. Closest adjacent code (lib/eva/blueprint-scoring/quality-scorer.js, lib/eva/taste-gate-scorer.js, lib/quickfix-compliance-rubric.js, lib/sub-agents/vetting/rubric-evaluator.js) scores DIFFERENT inputs on DIFFERENT scales (blueprint content 0-100 heuristics; taste 1-5 on pre-computed scores; QF 100-pt compliance; LLM-judged proposals 0-100) and none consume verdict rows. No in-flight duplicate SD found: only the parent orchestrator and siblings A/B match the terminology.'
+  },
+  {
+    id: 'F4-remediation-routing-targets-present-and-usable',
+    severity: 'INFO',
+    summary: 'Both convergence-loop remediation-routing targets CONFIRMED present + usable. scripts/leo-create-sd.js (executable, shebang node) is invokable as a CLI AND exports many functions (mapProposalToCreateArgs, validateProposalShape, scoreSDAtConception, etc.) enabling clean programmatic invocation from the loop for adherence-gap fix SDs. scripts/create-quick-fix.js (executable, shebang node) is a documented CLI accepting --title/--type/--severity/--description/--estimated-loc for adherence-gap fix QFs. The convergence loop\'s adherence-gap branch (file fix SD/QF) has working targets; PLAN should pick programmatic-import vs child-process invocation and specify idempotency (do not re-file a fix SD/QF for the same unresolved gap across cycles).'
+  },
+  {
+    id: 'F5-reusable-convergence-atoms-prefer-reuse-over-reinvent',
+    severity: 'WARNING',
+    summary: 'REUSE opportunity — do NOT reinvent trend/convergence math. No generic "iterate up to N cycles -> re-measure -> monotone/convergence early-exit -> escalate on exhaustion" executor exists (all candidates are domain-bound: lib/coordinator/convergence-breakers.js, convergence-ledger.js, lib/eva/clean-clone/convergence-sandbox.js, lib/vision/rung-health-convergence.mjs, lib/eva/experiments/auto-iteration.js), so Child C\'s loop BODY is legitimately new. BUT reusable pure atoms exist and should be reused: (1) isTrendingDown(series) from lib/coordinator/convergence-ledger.js — a DB-free monotone-non-improvement detector, ideal for the monotone-convergence early-termination; (2) computeCatchRateConvergence() from lib/vision/rung-health-convergence.mjs — least-squares slope trend detector; (3) withRetry() from lib/eva/stage-zero/data-pollers/retry.js — generic cap+backoff for transient DB/LLM resilience INSIDE a cycle (retries on thrown errors only, not a measure-driven loop). Additionally, per SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001, the loop SHOULD declare itself via lib/loops/loop-contract.js (goals/workflow/boundaries/budget) so the 3-cycle cap + escalation packet are self-describing and auditable rather than opaque inline constants. Pattern references for the scorer: taste-gate-scorer.js already does 1-5 mean-vs-threshold + per-dim floor (borrow shape, not code); rubric-evaluator.js has an LLM-judge + schema-validate + repair-retry skeleton if reason-quality judgment goes LLM-based.'
+  },
+  {
+    id: 'F6-completeness-vs-adherence-remediation-split-guardrails',
+    severity: 'WARNING',
+    summary: 'Scope guardrails for the two-branch convergence loop (advisory to PLAN, non-blocking). Child C\'s spec routes completeness gaps (MISSING/PARTIAL) to upstream backfill (retroactive=true stamping + circularity guard) and adherence gaps to fix SD/QF filing. The circularity guard is essential: backfill "from upstream sources only" must not read from the very artifact/verdict rows the walk is scoring (see the codebase idempotency lesson: never read input from the row you are mutating). PLAN must specify (a) what counts as an "upstream source" per dimension, (b) that retroactive=true rows are excluded from the next rescore\'s could-not-verify accounting to avoid a self-satisfying loop, and (c) an idempotency key so re-running a cycle does not double-file fix SDs/QFs or double-stamp backfills.'
+  }
+];
+
+const warnings = [
+  'Do not reinvent trend/convergence math — reuse isTrendingDown() (lib/coordinator/convergence-ledger.js) and/or computeCatchRateConvergence() (lib/vision/rung-health-convergence.mjs) for the monotone-convergence early-termination; use withRetry() only for transient in-cycle DB/LLM resilience, not as the measure-driven loop.',
+  'Declare the 3-cycle bounded loop via lib/loops/loop-contract.js (SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001) so cap + escalation-on-exhaustion are self-describing/auditable, not opaque inline constants.',
+  'Circularity guard for completeness backfill must be explicit in PLAN: upstream-source-only reads, retroactive=true rows excluded from the next rescore accounting, and an idempotency key so re-running a cycle never double-files fix SDs/QFs or double-stamps backfills.',
+  'adherence_rubrics rows are immutable and versioned; Child C must SELECT the published post_build_adherence_v1 row by rubric_key and treat thresholds as read-only data, never hard-code 3/4/true in the scorer (single source of truth = the seeded row).'
+];
+
+const recommendations = [
+  'PLAN: build a small purpose-built convergence loop as thin glue over existing pure atoms (isTrendingDown / computeCatchRateConvergence / withRetry) + a loop-contract declaration, rather than a bespoke trend implementation.',
+  'PLAN: consume Child B via runArtifactWalk() return value (or a direct post_build_verdicts read); map dispositions -> 1-5 per-dimension score; read floors from the seeded adherence_rubrics.post_build_adherence_v1 row rather than hard-coding.',
+  'PLAN: choose programmatic-import vs child-process invocation for scripts/leo-create-sd.js and scripts/create-quick-fix.js, and specify the per-gap idempotency key that prevents duplicate fix SD/QF filing across the up-to-3 cycles.',
+  'PLAN: specify per-dimension the legitimate "upstream sources" for completeness backfill, the circularity guard (no reading the row being scored / retroactive rows excluded from rescore accounting), and the exact 3-disposition escalation packet contract (descope-as-known-gap / pivot-the-artifact / hold-launch) emitted on exhaustion.',
+  'EXEC: borrow the mean-vs-threshold + per-dimension-floor SHAPE from lib/eva/taste-gate-scorer.js (already 1-5) and, if reason-quality judgment goes LLM-based, the schema-validate + repair-retry skeleton from lib/sub-agents/vetting/rubric-evaluator.js — as pattern references, not copied code.'
+];
+
+const summary = 'LEAD-phase VALIDATION PASS (confidence 88) for Child C (Adherence Rubric Scoring + Convergence Loop). All 4 requested checks confirmed. (1) NO duplicate: no existing code scores post_build_verdicts dispositions on a 1-5 anchored rubric; adherence_rubrics and post_build_verdicts each have zero downstream JS consumers today, so Child C is the first consumer of both — no collision, no in-flight duplicate SD. (2) Inputs present + directly usable: Child A\'s adherence_rubrics seeds post_build_adherence_v1 with exactly the 4 dimensions (each 1-5 with behavioral_anchors) and the frozen floors (dim>=3, mean>=4, zero_unscored_fails=true); Child B\'s post-build-verdict-engine.js exports runArtifactWalk/computeDisposition/upsertVerdict with the 5-value disposition taxonomy — no adapter needed. (3) Remediation targets present + usable: scripts/leo-create-sd.js (CLI + exported functions) and scripts/create-quick-fix.js (documented --title/--type/--severity CLI) both exist and are invokable by the convergence loop. (4) Reuse-over-reinvent flagged: no generic cap+re-measure+monotone-early-exit executor exists (loop body is legitimately new) BUT the trend/convergence math should reuse isTrendingDown() (convergence-ledger.js) / computeCatchRateConvergence() (rung-health-convergence.mjs), withRetry() for transient in-cycle resilience, and a loop-contract declaration; taste-gate-scorer.js (1-5 mean+floor) and rubric-evaluator.js (schema-validate+repair-retry) are scorer pattern references. Two non-blocking guardrails routed to PLAN: (a) circularity guard + idempotency for the completeness-backfill vs adherence-fix split; (b) read floors from the seeded rubric row, never hard-code them. None of these block LEAD-TO-PLAN.';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+
+  const resolution = await resolveSubAgentRepo({
+    sdId: SD_KEY,
+    targetApplication: 'EHG_Engineer',
+    subAgentCode: 'VALIDATION',
+    supabase,
+  });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 88,
+    findings,
+    warnings,
+    recommendations,
+    summary,
+    detailed_analysis: {
+      sd_key: SD_KEY,
+      parent_sd_key: 'SD-LEO-INFRA-POST-BUILD-ARTIFACT-001',
+      dependency_sd_keys: [
+        'SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-A (completed_and_merged)',
+        'SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-B (completed_and_merged)'
+      ],
+      checks: {
+        duplicate_adherence_scorer: 'NONE FOUND — no code maps disposition rows to 1-5 anchored dimension scores',
+        duplicate_convergence_executor: 'NONE FOUND — no generic cap+re-measure+monotone-early-exit+escalate loop exists',
+        child_a_rubric_input: 'CONFIRMED — adherence_rubrics seeds post_build_adherence_v1 with 4 dims + floors matching frozen pass bar',
+        child_b_verdict_output: 'CONFIRMED — post-build-verdict-engine.js exports runArtifactWalk/computeDisposition/upsertVerdict + 5-value DISPOSITIONS',
+        remediation_targets: 'CONFIRMED usable — scripts/leo-create-sd.js (CLI + exports) + scripts/create-quick-fix.js (CLI)',
+        reusable_infrastructure: 'REUSE isTrendingDown (convergence-ledger.js), computeCatchRateConvergence (rung-health-convergence.mjs), withRetry (data-pollers/retry.js), loop-contract.js; scorer pattern refs taste-gate-scorer.js + rubric-evaluator.js'
+      },
+      adherence_rubric_seeded_row: {
+        rubric_key: 'post_build_adherence_v1',
+        version: 1,
+        status: 'published',
+        dimensions: ['user_story_coverage', 'persona_surface_coverage', 'data_model_fidelity', 'architecture_conformance'],
+        scale: '1-5 with behavioral_anchors keyed 1..5',
+        dimension_floor: 3,
+        mean_floor: 4,
+        zero_unscored_fails: true,
+        immutable: 'BEFORE UPDATE/DELETE trigger; version via supersedes_rubric_id chain'
+      },
+      child_b_engine_exports: ['DISPOSITIONS', 'enumerateRequiredArtifacts', 'checkCompleteness', 'resolveVentureRepoPath', 'extractUserStoryClaims', 'findEvidenceForClaim', 'computeDisposition', 'upsertVerdict', 'runArtifactWalk'],
+      disposition_taxonomy: ['BUILT', 'PARTIAL', 'MISSING', 'DEVIATED_WITH_DOCUMENTED_REASON', 'DEVIATED_UNDOCUMENTED'],
+      reusable_atoms: {
+        monotone_early_exit: 'isTrendingDown(series) — lib/coordinator/convergence-ledger.js (DB-free, total)',
+        trend_slope: 'computeCatchRateConvergence() — lib/vision/rung-health-convergence.mjs (least-squares slope)',
+        transient_retry: 'withRetry(fn,{maxRetries,timeoutMs,baseDelayMs}) — lib/eva/stage-zero/data-pollers/retry.js (thrown-error retry only, NOT measure-driven)',
+        loop_declaration: 'lib/loops/loop-contract.js — declare 3-cycle bounded loop (SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001)',
+        scorer_pattern_refs: ['lib/eva/taste-gate-scorer.js (1-5 mean-vs-threshold + per-dim floor)', 'lib/sub-agents/vetting/rubric-evaluator.js (schema-validate + repair-retry LLM-judge skeleton)']
+      }
+    },
+    phase: 'LEAD',
+    validation_mode: 'prospective',
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+
+  const stored = await storeSubAgentResults(
+    'VALIDATION',
+    SD_ID,
+    { name: 'Principal Systems Analyst (validation-agent)' },
+    results,
+    { sdKey: SD_KEY, phase: 'LEAD' }
+  );
+
+  console.log('VERDICT WRITTEN:');
+  console.log('  ID:', stored.id);
+  console.log('  verdict:', stored.verdict, '@ confidence', stored.confidence);
+  console.log('  repo_path:', stored.metadata?.repo_path);
+  console.log('  repo_resolved:', stored.metadata?.repo_resolved);
+  console.log('  executed_from_cwd:', stored.metadata?.executed_from_cwd);
+  process.exit(0);
+}
+
+main().catch(e => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/tests/unit/eva/adherence-scorer.test.js
+++ b/tests/unit/eva/adherence-scorer.test.js
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for lib/eva/adherence-scorer.js.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C
+ *
+ * @module tests/unit/eva/adherence-scorer.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DIMENSION_ARTIFACT_MAP,
+  classifyDeviationReason,
+  scoreVerdictTable,
+  buildDeviationLedger,
+} from '../../../lib/eva/adherence-scorer.js';
+import { enumerateRequiredArtifacts } from '../../../lib/eva/post-build-verdict-engine.js';
+
+/** Generic filterable/sortable in-memory query-chain mock matching Supabase's
+ *  builder shape closely enough for unit testing (eq/in/contains filter,
+ *  order sorts, limit truncates, maybeSingle/single/thenable all terminal). */
+function makeChain(rows, transforms = []) {
+  const apply = (data) => transforms.reduce((acc, fn) => fn(acc), data);
+  const withTransform = (fn) => makeChain(rows, [...transforms, fn]);
+  const chain = {
+    eq: (col, val) => withTransform((data) => data.filter((r) => r[col] === val)),
+    lte: (col, val) => withTransform((data) => data.filter((r) => r[col] <= val)),
+    in: (col, vals) => withTransform((data) => data.filter((r) => vals.includes(r[col]))),
+    contains: (col, obj) => withTransform((data) => data.filter((r) => {
+      const target = r[col];
+      return target && Object.entries(obj).every(([k, v]) => target[k] === v);
+    })),
+    order: (col, opts = {}) => withTransform((data) => {
+      const sorted = [...data].sort((a, b) => (a[col] > b[col] ? 1 : a[col] < b[col] ? -1 : 0));
+      return opts.ascending === false ? sorted.reverse() : sorted;
+    }),
+    limit: (n) => withTransform((data) => data.slice(0, n)),
+    maybeSingle: async () => ({ data: apply(rows)[0] ?? null, error: null }),
+    single: async () => ({ data: apply(rows)[0] ?? null, error: null }),
+    then: (resolve) => resolve({ data: apply(rows), error: null }),
+  };
+  return chain;
+}
+
+function createMockSupabase(tableData = {}) {
+  return {
+    from: (tableName) => ({ select: () => makeChain(tableData[tableName] || []) }),
+  };
+}
+
+const PUBLISHED_RUBRIC = {
+  rubric_key: 'post_build_adherence_v1',
+  version: 1,
+  status: 'published',
+  dimensions: {},
+  dimension_floor: 3,
+  mean_floor: 4,
+  zero_unscored_fails: true,
+};
+
+describe('classifyDeviationReason()', () => {
+  it('classifies a sensible, causally-grounded reason as SENSIBLE', () => {
+    expect(classifyDeviationReason(
+      'Stripe webhook signing requires server-side handling, so we moved this off the client per Stripe\'s own security requirement.'
+    )).toBe('SENSIBLE');
+  });
+
+  it('classifies a generic/circular reason as THIN', () => {
+    expect(classifyDeviationReason('Decided to do it differently.')).toBe('THIN');
+  });
+
+  it('classifies a too-short reason as THIN regardless of content', () => {
+    expect(classifyDeviationReason('because reasons')).toBe('THIN');
+  });
+
+  it('classifies an empty/missing reason as THIN', () => {
+    expect(classifyDeviationReason('')).toBe('THIN');
+    expect(classifyDeviationReason(undefined)).toBe('THIN');
+  });
+
+  it('fails toward THIN for a long-but-non-causal reason (ambiguous never becomes SENSIBLE)', () => {
+    expect(classifyDeviationReason('We ended up building this in a completely different way than planned for the venture.')).toBe('THIN');
+  });
+});
+
+describe('scoreDimension() / scoreVerdictTable()', () => {
+  it('TS-1: all-BUILT verdicts across all 4 dimensions score 5/5/5/5 and PASS', async () => {
+    const postBuildVerdicts = [
+      { id: 'v1', venture_id: 'v-1', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-1', disposition: 'BUILT' },
+      { id: 'v2', venture_id: 'v-1', artifact_type: 'identity_persona_brand', claim_ref: 'identity_persona_brand', disposition: 'BUILT' },
+      { id: 'v3', venture_id: 'v-1', artifact_type: 'blueprint_data_model', claim_ref: 'blueprint_data_model', disposition: 'BUILT' },
+      { id: 'v4', venture_id: 'v-1', artifact_type: 'blueprint_technical_architecture', claim_ref: 'blueprint_technical_architecture', disposition: 'BUILT' },
+    ];
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: postBuildVerdicts,
+      venture_artifacts: [],
+    });
+
+    const result = await scoreVerdictTable(supabase, { ventureId: 'v-1' });
+    expect(result.dimensionScores.user_story_coverage).toBe(5);
+    expect(result.dimensionScores.persona_surface_coverage).toBe(5);
+    expect(result.dimensionScores.data_model_fidelity).toBe(5);
+    expect(result.dimensionScores.architecture_conformance).toBe(5);
+    expect(result.unscoredDimensions).toEqual([]);
+    expect(result.mean).toBe(5);
+    expect(result.pass).toBe(true);
+  });
+
+  it('TS-2: one dimension with zero verdict rows is UNSCORED, overall FAIL regardless of other 3 scores', async () => {
+    const postBuildVerdicts = [
+      // user_story_coverage: entirely missing (no rows at all)
+      { id: 'v2', venture_id: 'v-2', artifact_type: 'identity_persona_brand', claim_ref: 'identity_persona_brand', disposition: 'BUILT' },
+      { id: 'v3', venture_id: 'v-2', artifact_type: 'blueprint_data_model', claim_ref: 'blueprint_data_model', disposition: 'BUILT' },
+      { id: 'v4', venture_id: 'v-2', artifact_type: 'blueprint_technical_architecture', claim_ref: 'blueprint_technical_architecture', disposition: 'BUILT' },
+    ];
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: postBuildVerdicts,
+      venture_artifacts: [],
+    });
+
+    const result = await scoreVerdictTable(supabase, { ventureId: 'v-2' });
+    expect(result.dimensionScores.user_story_coverage).toBeNull();
+    expect(result.unscoredDimensions).toEqual(['user_story_coverage']);
+    expect(result.dimensionScores.persona_surface_coverage).toBe(5);
+    expect(result.dimensionScores.data_model_fidelity).toBe(5);
+    expect(result.dimensionScores.architecture_conformance).toBe(5);
+    // zero_unscored_fails=true -> FAIL overall despite the other 3 dimensions scoring perfectly
+    expect(result.pass).toBe(false);
+  });
+
+  it('TS-3: a DEVIATED_WITH_DOCUMENTED_REASON claim with a THIN reason scores as drift, not passing evidence', async () => {
+    const postBuildVerdicts = [
+      { id: 'v1', venture_id: 'v-3', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-thin', disposition: 'DEVIATED_WITH_DOCUMENTED_REASON' },
+    ];
+    const ventureArtifacts = [
+      {
+        id: 'dev-1',
+        venture_id: 'v-3',
+        artifact_type: 'build_deviation_record',
+        created_at: '2026-07-01T00:00:00Z',
+        artifact_data: { artifact_ref: 'story-thin', why: 'Decided to do it differently.', weight: 'minor' },
+      },
+    ];
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: postBuildVerdicts,
+      venture_artifacts: ventureArtifacts,
+    });
+
+    const result = await scoreVerdictTable(supabase, { ventureId: 'v-3' });
+    // The only claim in user_story_coverage has a THIN reason -> scores as drift (goodFraction=0) -> 1
+    expect(result.dimensionScores.user_story_coverage).toBe(1);
+  });
+
+  it('a DEVIATED_WITH_DOCUMENTED_REASON claim with a SENSIBLE reason scores as passing evidence', async () => {
+    const postBuildVerdicts = [
+      { id: 'v1', venture_id: 'v-4', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-sensible', disposition: 'DEVIATED_WITH_DOCUMENTED_REASON' },
+    ];
+    const ventureArtifacts = [
+      {
+        id: 'dev-2',
+        venture_id: 'v-4',
+        artifact_type: 'build_deviation_record',
+        created_at: '2026-07-01T00:00:00Z',
+        artifact_data: {
+          artifact_ref: 'story-sensible',
+          why: 'Combined signup and login per UX testing, since the two-step flow caused measurable drop-off in the beta cohort.',
+          weight: 'moderate',
+        },
+      },
+    ];
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: postBuildVerdicts,
+      venture_artifacts: ventureArtifacts,
+    });
+
+    const result = await scoreVerdictTable(supabase, { ventureId: 'v-4' });
+    expect(result.dimensionScores.user_story_coverage).toBe(5);
+  });
+
+  it('throws if no published rubric row exists for the given rubric_key', async () => {
+    const supabase = createMockSupabase({ adherence_rubrics: [], post_build_verdicts: [], venture_artifacts: [] });
+    await expect(scoreVerdictTable(supabase, { ventureId: 'v-5' })).rejects.toThrow(/no published rubric/);
+  });
+});
+
+describe('DIMENSION_ARTIFACT_MAP coverage', () => {
+  it('assigns every artifact_type enumerable through stage 19 to exactly one dimension, or documents the exclusion', async () => {
+    const mockSupabase = {
+      from: () => ({
+        select: () => makeChain([
+          { stage_number: 19, required_artifacts: [
+            'truth_idea_brief', 'truth_ai_critique', 'truth_validation_decision', 'truth_competitive_analysis',
+            'truth_financial_model', 'engine_risk_matrix', 'engine_pricing_model', 'engine_business_model_canvas',
+            'engine_exit_strategy', 'identity_persona_brand', 'identity_naming_visual', 'identity_brand_guidelines',
+            'identity_gtm_sales_strategy', 'blueprint_product_roadmap', 'blueprint_technical_architecture',
+            'blueprint_data_model', 'blueprint_erd_diagram', 'blueprint_api_contract', 'blueprint_schema_spec',
+            'wireframe_screens', 'blueprint_user_story_pack', 'blueprint_financial_projection',
+            'system_devils_advocate_review', 'marketing_tagline', 'marketing_app_store_desc', 'marketing_landing_hero',
+            'marketing_email_welcome', 'marketing_email_onboarding', 'marketing_email_reengagement',
+            'marketing_social_posts', 'marketing_seo_meta', 'marketing_blog_draft', 'build_mvp_build',
+          ] },
+        ]),
+      }),
+    };
+
+    const EXPLICITLY_OUT_OF_SCOPE = new Set([
+      'truth_idea_brief', 'truth_ai_critique', 'truth_validation_decision', 'truth_competitive_analysis',
+      'truth_financial_model', 'engine_risk_matrix', 'engine_pricing_model', 'engine_business_model_canvas',
+      'engine_exit_strategy', 'identity_gtm_sales_strategy', 'wireframe_screens', 'blueprint_financial_projection',
+      'system_devils_advocate_review', 'marketing_tagline', 'marketing_app_store_desc', 'marketing_landing_hero',
+      'marketing_email_welcome', 'marketing_email_onboarding', 'marketing_email_reengagement',
+      'marketing_social_posts', 'marketing_seo_meta', 'marketing_blog_draft', 'build_mvp_build',
+    ]);
+
+    const mapped = new Set(Object.values(DIMENSION_ARTIFACT_MAP).flat());
+    const allTypes = (await enumerateRequiredArtifacts(mockSupabase, { throughStage: 19 })).map((r) => r.artifactType);
+
+    for (const type of allTypes) {
+      const isMapped = mapped.has(type);
+      const isExcluded = EXPLICITLY_OUT_OF_SCOPE.has(type);
+      expect(isMapped || isExcluded, `artifact_type "${type}" is neither mapped to a dimension nor explicitly documented as out-of-scope`).toBe(true);
+      expect(isMapped && isExcluded, `artifact_type "${type}" cannot be both mapped AND excluded`).toBe(false);
+    }
+  });
+});
+
+describe('buildDeviationLedger()', () => {
+  it('ranks deviations critical-tier first, then moderate, minor, declared-descope last', async () => {
+    const postBuildVerdicts = [
+      { id: 'v1', venture_id: 'v-6', claim_ref: 'story-a', disposition: 'DEVIATED_WITH_DOCUMENTED_REASON' },
+      { id: 'v2', venture_id: 'v-6', claim_ref: 'story-b', disposition: 'DEVIATED_UNDOCUMENTED' },
+      { id: 'v3', venture_id: 'v-6', claim_ref: 'story-c', disposition: 'DEVIATED_WITH_DOCUMENTED_REASON' },
+      { id: 'v4', venture_id: 'v-6', claim_ref: 'story-d', disposition: 'DEVIATED_WITH_DOCUMENTED_REASON' },
+    ];
+    const ventureArtifacts = [
+      { id: 'd-a', venture_id: 'v-6', artifact_type: 'build_deviation_record', created_at: '2026-07-01T00:00:00Z', artifact_data: { artifact_ref: 'story-a', why: 'moderate reason here for testing purposes', weight: 'moderate' } },
+      { id: 'd-b', venture_id: 'v-6', artifact_type: 'build_deviation_record', created_at: '2026-07-01T00:00:00Z', artifact_data: { artifact_ref: 'story-b', why: 'critical because of a real production defect', weight: 'critical' } },
+      { id: 'd-c', venture_id: 'v-6', artifact_type: 'build_deviation_record', created_at: '2026-07-01T00:00:00Z', artifact_data: { artifact_ref: 'story-c', why: 'minor cosmetic reason for a small tweak', weight: 'minor' } },
+      { id: 'd-d', venture_id: 'v-6', artifact_type: 'build_deviation_record', created_at: '2026-07-01T00:00:00Z', artifact_data: { artifact_ref: 'story-d', why: 'declared descope per chairman approval', weight: 'declared-descope' } },
+    ];
+    const supabase = createMockSupabase({ post_build_verdicts: postBuildVerdicts, venture_artifacts: ventureArtifacts });
+
+    const ledger = await buildDeviationLedger(supabase, { ventureId: 'v-6' });
+    expect(ledger.map((e) => e.weight)).toEqual(['critical', 'moderate', 'minor', 'declared-descope']);
+  });
+});

--- a/tests/unit/eva/convergence-loop.test.js
+++ b/tests/unit/eva/convergence-loop.test.js
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for lib/eva/convergence-loop.js.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-C
+ *
+ * @module tests/unit/eva/convergence-loop.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ESCALATION_DISPOSITIONS,
+  classifyGaps,
+  backfillCompletenessGap,
+  classifyRemediationTier,
+  routeRemediation,
+  buildEscalationPacket,
+  runConvergenceLoop,
+} from '../../../lib/eva/convergence-loop.js';
+
+/** Same filterable/sortable in-memory chain mock as adherence-scorer.test.js. */
+function makeChain(rows, transforms = []) {
+  const apply = (data) => transforms.reduce((acc, fn) => fn(acc), data);
+  const withTransform = (fn) => makeChain(rows, [...transforms, fn]);
+  return {
+    eq: (col, val) => withTransform((data) => data.filter((r) => r[col] === val)),
+    in: (col, vals) => withTransform((data) => data.filter((r) => vals.includes(r[col]))),
+    contains: (col, obj) => withTransform((data) => data.filter((r) => {
+      const target = r[col];
+      return target && Object.entries(obj).every(([k, v]) => target[k] === v);
+    })),
+    order: (col, opts = {}) => withTransform((data) => {
+      const sorted = [...data].sort((a, b) => (a[col] > b[col] ? 1 : a[col] < b[col] ? -1 : 0));
+      return opts.ascending === false ? sorted.reverse() : sorted;
+    }),
+    limit: (n) => withTransform((data) => data.slice(0, n)),
+    maybeSingle: async () => ({ data: apply(rows)[0] ?? null, error: null }),
+    single: async () => ({ data: apply(rows)[0] ?? null, error: null }),
+    then: (resolve) => resolve({ data: apply(rows), error: null }),
+  };
+}
+
+/** Mutable per-table store so scoring can reflect remediation between rescores. */
+function createMockSupabase(initialTables = {}) {
+  const tables = { adherence_rubrics: [], post_build_verdicts: [], venture_artifacts: [], ...initialTables };
+  return {
+    from: (tableName) => ({ select: () => makeChain(tables[tableName] || []) }),
+    _tables: tables,
+  };
+}
+
+const PUBLISHED_RUBRIC = {
+  rubric_key: 'post_build_adherence_v1',
+  version: 1,
+  status: 'published',
+  dimensions: {},
+  dimension_floor: 3,
+  mean_floor: 4,
+  zero_unscored_fails: true,
+};
+
+const ALL_BUILT_VERDICTS = (ventureId) => ([
+  { id: 'v1', venture_id: ventureId, artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-1', disposition: 'BUILT' },
+  { id: 'v2', venture_id: ventureId, artifact_type: 'identity_persona_brand', claim_ref: 'identity_persona_brand', disposition: 'BUILT' },
+  { id: 'v3', venture_id: ventureId, artifact_type: 'blueprint_data_model', claim_ref: 'blueprint_data_model', disposition: 'BUILT' },
+  { id: 'v4', venture_id: ventureId, artifact_type: 'blueprint_technical_architecture', claim_ref: 'blueprint_technical_architecture', disposition: 'BUILT' },
+]);
+
+describe('classifyGaps()', () => {
+  it('classifies an unscored dimension as completeness and a below-floor scored dimension as adherence', () => {
+    const scoreResult = {
+      dimensionScores: { user_story_coverage: null, persona_surface_coverage: 2, data_model_fidelity: 5, architecture_conformance: 5 },
+      unscoredDimensions: ['user_story_coverage'],
+      rubric: { dimension_floor: 3, mean_floor: 4 },
+    };
+    const gaps = classifyGaps(scoreResult);
+    expect(gaps).toEqual([
+      { dimension: 'user_story_coverage', kind: 'completeness', score: null },
+      { dimension: 'persona_surface_coverage', kind: 'adherence', score: 2 },
+    ]);
+  });
+});
+
+describe('backfillCompletenessGap() — TS-6 circularity guard', () => {
+  it('rejects a build/repo-sourced backfill result', async () => {
+    const sourceFn = vi.fn().mockResolvedValue({ source: 'build', artifact: { fake: true } });
+    await expect(backfillCompletenessGap({ dimension: 'user_story_coverage' }, sourceFn))
+      .rejects.toThrow(/circularity guard/);
+  });
+
+  it('accepts a genuinely upstream-sourced backfill result and stamps retroactive=true', async () => {
+    const sourceFn = vi.fn().mockResolvedValue({ source: 'blueprint_user_story_pack_v2', artifact: { id: 'a1' } });
+    const result = await backfillCompletenessGap({ dimension: 'user_story_coverage' }, sourceFn);
+    expect(result.retroactive).toBe(true);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('throws when no sourceFn is provided at all (no default that could read from the build)', async () => {
+    await expect(backfillCompletenessGap({ dimension: 'user_story_coverage' }, undefined))
+      .rejects.toThrow(/no default/);
+  });
+});
+
+describe('classifyRemediationTier()', () => {
+  it('routes to tier 3 when a critical-weight deviation is attached to the gap dimension', () => {
+    const ledger = [{ dimension: 'architecture_conformance', weight: 'critical' }];
+    expect(classifyRemediationTier({ dimension: 'architecture_conformance' }, ledger)).toBe(3);
+  });
+
+  it('routes to tier 2 when no critical-weight deviation exists for the gap dimension', () => {
+    const ledger = [{ dimension: 'architecture_conformance', weight: 'minor' }];
+    expect(classifyRemediationTier({ dimension: 'architecture_conformance' }, ledger)).toBe(2);
+  });
+});
+
+describe('routeRemediation() — TS-5 per-cycle cap + overflow', () => {
+  it('routes exactly perCycleCap items and defers the rest, never silently dropping overflow', async () => {
+    const gaps = Array.from({ length: 7 }, (_, i) => ({ dimension: `dim-${i}`, kind: 'adherence', score: 1 }));
+    const createQuickFixFn = vi.fn().mockResolvedValue('QF-mock-id');
+    const { routed, deferred, errors } = await routeRemediation(gaps, {
+      ventureId: 'v-1', perCycleCap: 5, ledger: [], createQuickFixFn,
+    });
+
+    expect(routed).toHaveLength(5);
+    expect(deferred).toHaveLength(2);
+    expect(errors).toHaveLength(0);
+    expect(createQuickFixFn).toHaveBeenCalledTimes(5);
+  });
+
+  it('routes completeness gaps to backfillFn and adherence gaps to fix-filing separately in the same cycle', async () => {
+    const gaps = [
+      { dimension: 'user_story_coverage', kind: 'completeness', score: null },
+      { dimension: 'architecture_conformance', kind: 'adherence', score: 2 },
+    ];
+    const backfillFn = vi.fn().mockResolvedValue({ source: 'upstream-blueprint', artifact: {} });
+    const createQuickFixFn = vi.fn().mockResolvedValue('QF-1');
+    const { routed, deferred } = await routeRemediation(gaps, {
+      ventureId: 'v-1', perCycleCap: 5, ledger: [], backfillFn, createQuickFixFn,
+    });
+
+    expect(deferred).toHaveLength(0);
+    expect(routed.find((r) => r.dimension === 'user_story_coverage').remediation).toBe('completeness-backfill');
+    expect(routed.find((r) => r.dimension === 'architecture_conformance').remediation).toBe('adherence-fix');
+    expect(backfillFn).toHaveBeenCalledTimes(1);
+    expect(createQuickFixFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a filing failure into deferred rather than silently treating remediation as succeeded', async () => {
+    const gaps = [{ dimension: 'architecture_conformance', kind: 'adherence', score: 2 }];
+    const createQuickFixFn = vi.fn().mockRejectedValue(new Error('duplicate key'));
+    const { routed, deferred, errors } = await routeRemediation(gaps, {
+      ventureId: 'v-1', perCycleCap: 5, ledger: [], createQuickFixFn,
+    });
+
+    expect(routed).toHaveLength(0);
+    expect(deferred).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toMatch(/duplicate key/);
+  });
+});
+
+describe('buildEscalationPacket() — TS-7', () => {
+  it('has exactly the 3 specified dispositions', () => {
+    const packet = buildEscalationPacket({ scoreResult: { pass: false }, ledger: [], deferredItems: [] });
+    expect(packet.dispositions.map((d) => d.key)).toEqual(ESCALATION_DISPOSITIONS);
+    expect(packet.dispositions).toHaveLength(3);
+  });
+
+  it('flags pivot-the-artifact with requires_chairman_ratification when the artifact was chairman-approved', () => {
+    const packet = buildEscalationPacket({ scoreResult: { pass: false }, ledger: [], deferredItems: [], isArtifactChairmanApproved: true });
+    const pivot = packet.dispositions.find((d) => d.key === 'pivot-the-artifact');
+    expect(pivot.requires_chairman_ratification).toBe(true);
+  });
+
+  it('does not require ratification when the artifact was not chairman-approved', () => {
+    const packet = buildEscalationPacket({ scoreResult: { pass: false }, ledger: [], deferredItems: [], isArtifactChairmanApproved: false });
+    const pivot = packet.dispositions.find((d) => d.key === 'pivot-the-artifact');
+    expect(pivot.requires_chairman_ratification).toBe(false);
+  });
+});
+
+describe('runConvergenceLoop()', () => {
+  it('TS-1 (via loop): all-BUILT venture returns PASS on cycle 1 with zero remediation items filed', async () => {
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: ALL_BUILT_VERDICTS('v-1'),
+    });
+
+    const result = await runConvergenceLoop(supabase, { ventureId: 'v-1' });
+    expect(result.status).toBe('PASS');
+    expect(result.cycles).toBe(1);
+    expect(result.remediationHistory).toEqual([]);
+  });
+
+  it('TS-4: exits early before cycle 3 on monotone non-improvement between cycles', async () => {
+    // Cycle 1 (initial): user_story_coverage MISSING entirely -> FAIL.
+    // Remediation "succeeds" per the mock, but the underlying verdict table
+    // never actually changes between rescores (a stalled fix) -> deficit
+    // series is flat -> early exit before cycle 3.
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: ALL_BUILT_VERDICTS('v-4').filter((r) => r.artifact_type !== 'blueprint_user_story_pack'),
+    });
+    const createQuickFixFn = vi.fn().mockResolvedValue('QF-stall');
+    const backfillFn = vi.fn().mockResolvedValue({ source: 'upstream-noop', artifact: {} }); // never actually inserts a row
+
+    const result = await runConvergenceLoop(supabase, {
+      ventureId: 'v-4', createQuickFixFn, backfillFn,
+    });
+
+    expect(result.status).toBe('ESCALATED');
+    expect(result.cycles).toBeLessThan(3);
+    expect(result.escalationPacket).toBeTruthy();
+  });
+
+  it('TS-5/TS-6 integration: 7 gaps in one cycle cap at 5, circularity-guarded completeness backfill throws are treated as a per-item failure not a loop crash', async () => {
+    // Build a venture with all 4 mapped dimensions unscored (completeness gaps) —
+    // fewer than 7 real dimensions exist, so this exercises the cap logic at the
+    // routeRemediation unit level (already covered above) and confirms the loop
+    // itself does not throw when backfillFn is a circularity-guard rejection.
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: [],
+    });
+    const backfillFn = vi.fn().mockResolvedValue({ source: 'build', artifact: {} }); // will be rejected every time
+
+    const result = await runConvergenceLoop(supabase, { ventureId: 'v-5', backfillFn });
+
+    expect(result.status).toBe('ESCALATED');
+    expect(result.remediationHistory[0].errors.length).toBeGreaterThan(0);
+    expect(result.remediationHistory[0].errors.every((e) => /circularity guard/.test(e.error))).toBe(true);
+  });
+
+  it('TS-7 (via loop): escalation packet on cap exhaustion has exactly 3 dispositions', async () => {
+    const supabase = createMockSupabase({
+      adherence_rubrics: [PUBLISHED_RUBRIC],
+      post_build_verdicts: [],
+    });
+    const result = await runConvergenceLoop(supabase, { ventureId: 'v-7' });
+    expect(result.status).toBe('ESCALATED');
+    expect(result.escalationPacket.dispositions).toHaveLength(3);
+    expect(result.escalationPacket.dispositions.map((d) => d.key)).toEqual(ESCALATION_DISPOSITIONS);
+  });
+});


### PR DESCRIPTION
## Summary
- Child C of the Post-Build Artifact Reconciliation Gate orchestrator (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001). Applies Child A's `adherence_rubrics` registry to Child B's `post_build_verdicts` rows, producing a behaviorally-anchored 1-5 score per dimension (user-story coverage, persona-surface coverage, data-model fidelity, architecture conformance) plus a weighted deviation ledger.
- New `lib/eva/adherence-scorer.js` owns the reason-quality judgment assigned exclusively to this child (a documented-but-thin deviation reason scores as drift, not passing evidence) and reads the frozen pass bar (`dimension_floor`/`mean_floor`/`zero_unscored_fails`) live from the rubric row, never hardcoded.
- New `lib/eva/convergence-loop.js` orchestrates score → remediate → rescore, bounded to 3 cycles with monotone-convergence early termination, a remediation router with a circularity guard on completeness backfills and a per-cycle cap of 5 items (overflow deferred, never dropped), and an escalation-packet generator offering exactly the three chairman-specified dispositions on exhaustion.
- Scope explicitly excludes synthetic-persona live-UI journey walks (chairman-upgraded requirement) — filed as a separate fast-follow child, SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E, created and scoped during this SD's LEAD phase.

## Test plan
- [x] 28/28 new unit tests pass (`adherence-scorer.test.js` + `convergence-loop.test.js`)
- [x] 51/51 sibling Child A/B tests pass — 0 regressions
- [x] ESLint clean on all 4 touched files
- [x] TESTING sub-agent: CONDITIONAL_PASS (90 confidence) — backend-only, no UI surface, E2E not applicable