### PR TITLE
fix(QF-20260704-602): directed WORK_ASSIGNMENT can dispatch QFs; self-claim picker orders by severity

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -107,7 +107,25 @@ function antiWinddownDirective(beltRankedClaimable) {
   return `ANTI-WIND-DOWN (Mode B): ${depth} Releasing claimable RANKED work to wind down is FORBIDDEN — "scope size / design-heaviness / chairman-gated / context length / session-tail / felt drained" are CLAUDE.md's explicitly-forbidden non-pause-triggers, NOT reasons to release. Build this SD; if it is too large/design-heavy, DECOMPOSE it into children (orchestrator path) — do not release. Only a GENUINELY-BLOCKED SD may be deferred, and only with a logged blocker reason (e.g. a verified spec-conflict). Otherwise keep working.`;
 }
 const SELF_CLAIM_CANDIDATE_LIMIT = 5;
-const QF_CANDIDATE_LIMIT = 25;               // open quick_fixes to consider for self-claim
+const QF_CANDIDATE_LIMIT = 100;              // open quick_fixes to consider for self-claim
+// QF-20260704-602 (groom addendum leg 2): severity rank for the self-claim picker sort.
+// Unranked/unknown severities sort last (below 'low'), never ahead of a ranked item.
+const QF_SEVERITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
+
+/**
+ * Pure: stable-sort open QFs so higher severity always comes first (critical > high >
+ * medium > low > unranked), then by created_at ascending within the same severity.
+ * Fixes the "medium self-claimed while a critical sat beside it" specimen (717/726) —
+ * the picker was previously unordered by severity, purely filing-order (created_at).
+ */
+function sortQfCandidatesBySeverity(qfs) {
+  return (qfs || []).slice().sort((a, b) => {
+    const rankA = QF_SEVERITY_RANK[a?.severity] ?? 99;
+    const rankB = QF_SEVERITY_RANK[b?.severity] ?? 99;
+    if (rankA !== rankB) return rankA - rankB;
+    return Date.parse(a?.created_at || 0) - Date.parse(b?.created_at || 0);
+  });
+}
 const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
 // SD-LEO-FEAT-WORKER-CHECKIN-SELF-001 (FR-2): gap before confirmRowGone's confirming read so it lands
 // genuinely later than the first (defends a momentary stale-replica null). Env-overridable; tests set 0.
@@ -166,6 +184,14 @@ function extractSdFromAssignment(msg) {
   const p = msg.payload || {};
   if (typeof p.assigned_sd === 'string' && p.assigned_sd) return p.assigned_sd;
   if (typeof p.sd_key === 'string' && p.sd_key) return p.sd_key;
+  // QF-20260704-602: some dispatch paths emit a QF-specific directed assignment as
+  // payload.qf_id instead of sd_key/assigned_sd (confirmed live on QF-20260704-726's
+  // dispatch history: 4 of 6 WORK_ASSIGNMENTs carried ONLY qf_id, so this function
+  // returned null and the entire directed-assignment branch below was silently
+  // skipped -- no ack, no claim attempt -- until a later redispatch happened to use
+  // sd_key instead). claim_sd itself is already QF-aware (p_sd_id LIKE 'QF-%'); the
+  // gap was purely in this extraction step.
+  if (typeof p.qf_id === 'string' && p.qf_id) return p.qf_id;
   if (Array.isArray(p.available_sds) && p.available_sds.length) return p.available_sds[0];
   // current_sd is what the worker is ALREADY on — only use it as a last resort
   // when nothing else names a target (an assignment can reference the same SD).
@@ -417,14 +443,14 @@ async function selfClaimQuickFix(sb, sessionId, base) {
   try {
     const { data: qfs } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title')
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity')
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)
       .order('created_at', { ascending: true })
       .limit(QF_CANDIDATE_LIMIT);
     const nowMs = Date.now();
-    for (const qf of (qfs || [])) {
+    for (const qf of sortQfCandidatesBySeverity(qfs)) {
       if (!isAutoStartableQF(qf, nowMs)) continue;
       const claimed = await tryClaim(sb, qf.id, sessionId);
       if (claimed.ok) {
@@ -1350,6 +1376,12 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // in_progress->terminal race. claim_sd now refuses terminal claims, but a never-ACKed
       // assignment would re-fire every tick (the "retried on every tick" symptom), so ACK it
       // here and fall through to self-claim.
+      // QF-20260704-602: this strategic_directives_v2 lookup is intentionally SD-only. A
+      // directed QF key (sdKey starting 'QF-') always misses here (assignedSdRow stays null),
+      // which correctly skips terminalStatus/ineligibleReason below (both SD-specific concerns
+      // with no QF equivalent yet) and falls straight to tryClaim() — the claim_sd RPC is
+      // already QF-aware (p_sd_id LIKE 'QF-%' branches to the quick_fixes table) and does not
+      // need this fetch to succeed.
       let terminalStatus = null;
       let assignedSdRow = null;
       let assignedSdFetchFailed = false;
@@ -1682,7 +1714,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js
+++ b/tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js
@@ -1,0 +1,126 @@
+/**
+ * QF-20260704-602 — directed WORK_ASSIGNMENT dispatch of quick_fixes was structurally broken:
+ * some dispatch paths emit payload.qf_id (not sd_key/assigned_sd) for QF-specific directed
+ * assignments, but extractSdFromAssignment() never recognized that field -- the whole
+ * directed-assignment claim branch was silently skipped (no ack, no claim attempt). Confirmed
+ * live: QF-20260704-726 (CRITICAL) starved 5+ hours through SIX directed assignments -- 4 of 6
+ * carried ONLY payload.qf_id and never even reached tryClaim(). claim_sd itself is already
+ * QF-aware (p_sd_id LIKE 'QF-%'); the gap was purely in the extraction step.
+ *
+ * GROOM ADDENDUM leg 2: the self-claim picker (selfClaimQuickFix) ordered candidates purely by
+ * created_at, so a lower-severity QF filed earlier could self-claim ahead of a critical one
+ * filed later (specimen: QF-20260704-717 medium claimed while QF-20260704-726 critical sat
+ * beside it). sortQfCandidatesBySeverity fixes the ordering: severity DESC, then created_at ASC.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { extractSdFromAssignment, resolveCheckin, sortQfCandidatesBySeverity, QF_SEVERITY_RANK } = require('../../scripts/worker-checkin.cjs');
+
+describe('extractSdFromAssignment — recognizes payload.qf_id (leg 1)', () => {
+  it('returns qf_id when assigned_sd/sd_key are both absent', () => {
+    expect(extractSdFromAssignment({ payload: { qf_id: 'QF-20260704-726' } })).toBe('QF-20260704-726');
+  });
+
+  it('assigned_sd still takes precedence over qf_id when both present', () => {
+    expect(extractSdFromAssignment({ payload: { assigned_sd: 'QF-1', qf_id: 'QF-2' } })).toBe('QF-1');
+  });
+
+  it('sd_key still takes precedence over qf_id when both present', () => {
+    expect(extractSdFromAssignment({ payload: { sd_key: 'QF-1', qf_id: 'QF-2' } })).toBe('QF-1');
+  });
+
+  it('falls through to available_sds when qf_id is absent (unchanged prior behavior)', () => {
+    expect(extractSdFromAssignment({ payload: { available_sds: ['SD-X-001'] } })).toBe('SD-X-001');
+  });
+
+  it('returns null for a non-string/empty qf_id (defensive)', () => {
+    expect(extractSdFromAssignment({ payload: { qf_id: '' } })).toBeNull();
+    expect(extractSdFromAssignment({ payload: { qf_id: 123 } })).toBeNull();
+  });
+});
+
+describe('resolveCheckin — a qf_id-only directed assignment now reaches the claim step (leg 1 integration)', () => {
+  function fakeSbQf({ claimResult }) {
+    return {
+      rpc: () => Promise.resolve(claimResult),
+      from(table) {
+        const api = {
+          select() { return this; }, eq() { return this; }, gte() { return this; },
+          order() { return this; }, limit() { return this; }, is() { return this; },
+          maybeSingle() {
+            if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+            // A QF key genuinely misses in strategic_directives_v2 -- no row, no error.
+            if (table === 'strategic_directives_v2') return Promise.resolve({ data: null, error: null });
+            return Promise.resolve({ data: null, error: null });
+          },
+          insert() { return Promise.resolve({ error: null }); },
+          update() { return { eq() { return Promise.resolve({ error: null }); } }; },
+        };
+        return api;
+      },
+    };
+  }
+
+  it('claims the QF when the WORK_ASSIGNMENT payload carries ONLY qf_id (the QF-726 repro shape)', async () => {
+    const sb = fakeSbQf({ claimResult: { data: { success: true }, error: null } });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qfid-only', message_type: 'WORK_ASSIGNMENT', payload: { qf_id: 'QF-20260704-726' } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('claimed_assignment');
+      expect(res.sd).toBe('QF-20260704-726');
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});
+
+describe('sortQfCandidatesBySeverity (leg 2)', () => {
+  it('orders critical before high before medium before low', () => {
+    const qfs = [
+      { id: 'low-1', severity: 'low', created_at: '2026-07-01T00:00:00Z' },
+      { id: 'medium-1', severity: 'medium', created_at: '2026-07-01T00:00:00Z' },
+      { id: 'critical-1', severity: 'critical', created_at: '2026-07-04T00:00:00Z' },
+      { id: 'high-1', severity: 'high', created_at: '2026-07-01T00:00:00Z' },
+    ];
+    expect(sortQfCandidatesBySeverity(qfs).map(q => q.id)).toEqual(['critical-1', 'high-1', 'medium-1', 'low-1']);
+  });
+
+  it('reproduces the QF-717/726 specimen: a later-created critical still outranks an earlier medium', () => {
+    const qfs = [
+      { id: 'QF-20260704-717', severity: 'medium', created_at: '2026-07-04T10:00:00Z' },
+      { id: 'QF-20260704-726', severity: 'critical', created_at: '2026-07-04T12:24:24Z' },
+    ];
+    expect(sortQfCandidatesBySeverity(qfs).map(q => q.id)).toEqual(['QF-20260704-726', 'QF-20260704-717']);
+  });
+
+  it('breaks ties within the same severity by created_at ascending (older first)', () => {
+    const qfs = [
+      { id: 'newer', severity: 'high', created_at: '2026-07-04T00:00:00Z' },
+      { id: 'older', severity: 'high', created_at: '2026-07-01T00:00:00Z' },
+    ];
+    expect(sortQfCandidatesBySeverity(qfs).map(q => q.id)).toEqual(['older', 'newer']);
+  });
+
+  it('unranked/unknown severity sorts LAST, never ahead of a ranked item', () => {
+    const qfs = [
+      { id: 'unknown-sev', severity: undefined, created_at: '2026-07-01T00:00:00Z' },
+      { id: 'low-sev', severity: 'low', created_at: '2026-07-04T00:00:00Z' },
+    ];
+    expect(sortQfCandidatesBySeverity(qfs).map(q => q.id)).toEqual(['low-sev', 'unknown-sev']);
+  });
+
+  it('handles empty/null input gracefully', () => {
+    expect(sortQfCandidatesBySeverity([])).toEqual([]);
+    expect(sortQfCandidatesBySeverity(null)).toEqual([]);
+    expect(sortQfCandidatesBySeverity(undefined)).toEqual([]);
+  });
+
+  it('QF_SEVERITY_RANK is exported and ranks critical strictly ahead of the others', () => {
+    expect(QF_SEVERITY_RANK.critical).toBeLessThan(QF_SEVERITY_RANK.high);
+    expect(QF_SEVERITY_RANK.high).toBeLessThan(QF_SEVERITY_RANK.medium);
+    expect(QF_SEVERITY_RANK.medium).toBeLessThan(QF_SEVERITY_RANK.low);
+  });
+});


### PR DESCRIPTION
## Summary

**LEG 1** — `extractSdFromAssignment()` never recognized `payload.qf_id`, only `sd_key`/`assigned_sd`/`available_sds`. Some dispatch paths emit QF-specific directed assignments as `{qf_id: <id>}` with no `sd_key`/`assigned_sd` field — **confirmed live** via `QF-20260704-726`'s own dispatch history: 4 of its 6 `WORK_ASSIGNMENT`s carried ONLY `qf_id`, so extraction returned `null` and the entire directed-assignment claim branch was silently skipped (no ack, no claim attempt) — contributing to a 5+ hour starvation of a **CRITICAL** QF across six directed dispatch attempts.

Note: I verified against the live migration (`20260427_claim_sd_cross_table_consistency.sql`) that `claim_sd` itself is **already QF-aware** (`v_is_qf := p_sd_id LIKE 'QF-%'`, branches to `quick_fixes` table for the update) and confirmed via the actual claim history that a directed assignment DOES succeed once the key is extractable — so the RPC itself was never the blocker; the gap was purely in the extraction step. Added the `qf_id` branch (after `assigned_sd`/`sd_key`, so those still take precedence) plus a clarifying comment on the SD-only fitness-fetch documenting that it correctly no-ops for QF keys.

**LEG 2** (groom addendum, folded in per coordinator delegation) — `selfClaimQuickFix`'s candidate query ordered purely by `created_at`, so a lower-severity QF filed earlier could self-claim ahead of a critical one filed later (specimen: `QF-20260704-717` medium claimed while `QF-20260704-726` critical sat beside it). New `sortQfCandidatesBySeverity()` orders severity DESC (critical > high > medium > low > unranked) then `created_at` ASC within a tier; `QF_CANDIDATE_LIMIT` raised 25→100 so a later-created critical candidate is never excluded from the fetch window before the severity sort even runs.

LEG 3 (critical-QFs-outrank-SD-pull) was deliberately **not** folded in — policy blast radius, filed as a sibling QF per the groom addendum.

## Test plan
- [x] `node -c` syntax check, `npm run schema:lint` clean (0 violations)
- [x] New unit tests `tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js` (12 tests) — `qf_id` extraction + precedence, an integration test reproducing the exact QF-726 payload shape through `resolveCheckin` end-to-end (asserts `action=claimed_assignment`), and severity-ordering (including the literal QF-717/726 specimen)
- [x] Full existing `worker-checkin-*` test suite regression pass (107/107 across 13 files)
- [x] Live-verified: confirmed via direct DB query that `quick_fixes.severity` values are consistently lowercase (`critical`/`high`/`medium`/`low`), matching `QF_SEVERITY_RANK`'s keys

QF-20260704-602 · Tier 2 (36 net LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)