### PR TITLE
fix(QF-20260704-244): critical QF jumps ahead of SD self-claim (bounded)

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -126,6 +126,24 @@ function sortQfCandidatesBySeverity(qfs) {
     return Date.parse(a?.created_at || 0) - Date.parse(b?.created_at || 0);
   });
 }
+// QF-20260704-244 (leg 3 of the QF-lane fix family; legs 1-2 = QF-20260704-602): a CRITICAL
+// open QF outranks SD self-claim, but tightly fenced against reverse starvation of the SD
+// belt -- only 'critical' jumps (high/medium/low keep the existing SD-first order), only
+// after sitting open long enough to give directed dispatch (leg 1) a chance to route it
+// first, and at most ONE consecutive jump per worker (claude_sessions.metadata.
+// last_claim_was_qf_jump gates the NEXT pull, not this one -- see isCriticalQfJumpEligible /
+// the step-6-minus-1 block in runCheckin).
+const CRITICAL_QF_JUMP_GRACE_MS = 10 * 60 * 1000;
+
+/** Pure: is this QF eligible to jump ahead of SD self-claim (severity=critical, aged past grace)? */
+function isCriticalQfJumpEligible(qf, nowMs) {
+  if (!isAutoStartableQF(qf, nowMs)) return false;
+  if (qf.severity !== 'critical') return false;
+  const created = Date.parse(qf.created_at);
+  if (!Number.isFinite(created)) return false;
+  return (nowMs - created) >= CRITICAL_QF_JUMP_GRACE_MS;
+}
+
 const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
 // SD-LEO-FEAT-WORKER-CHECKIN-SELF-001 (FR-2): gap before confirmRowGone's confirming read so it lands
 // genuinely later than the first (defends a momentary stale-replica null). Env-overridable; tests set 0.
@@ -1486,6 +1504,49 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   //      today's behavior (read returns [] -> idle), never an error action.
   try { await ensureActiveBaseline(sb); } catch { /* fail-open: never block the checkin */ }
 
+  // 5.95 QF-20260704-244 (leg 3): a CRITICAL open QF, aged past the directed-dispatch grace
+  // window, outranks SD self-claim. Fenced to prevent reverse SD-belt starvation: only
+  // 'critical' jumps, and at most ONE consecutive jump per worker -- if the LAST pull was a
+  // jump (metadata.last_claim_was_qf_jump), this pull consumes/clears that flag and falls
+  // through to the normal SD-first order instead of jumping again immediately.
+  if (sessionMetadata?.last_claim_was_qf_jump === true) {
+    try {
+      await sb.from('claude_sessions')
+        .update({ metadata: { ...sessionMetadata, last_claim_was_qf_jump: false } })
+        .eq('session_id', sessionId);
+    } catch { /* fail-open: worst case is one extra consecutive jump */ }
+  } else {
+    try {
+      const { data: criticalQfs } = await sb
+        .from('quick_fixes')
+        .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity')
+        .eq('status', 'open')
+        .eq('severity', 'critical')
+        .is('pr_url', null)
+        .is('commit_sha', null)
+        .order('created_at', { ascending: true })
+        .limit(QF_CANDIDATE_LIMIT);
+      const nowMs = Date.now();
+      for (const qf of (criticalQfs || [])) {
+        if (!isCriticalQfJumpEligible(qf, nowMs)) continue;
+        const claimed = await tryClaim(sb, qf.id, sessionId);
+        if (claimed.ok) {
+          try {
+            await sb.from('claude_sessions')
+              .update({ metadata: { ...sessionMetadata, last_claim_was_qf_jump: true } })
+              .eq('session_id', sessionId);
+          } catch { /* fail-open: worst case the one-consecutive bound doesn't hold once */ }
+          return {
+            ...base,
+            action: 'self_claimed_qf',
+            qf: qf.id,
+            message: `Self-claimed CRITICAL quick-fix ${qf.id} (priority jump ahead of SD self-claim, QF-20260704-244). Load it: node scripts/read-quick-fix.js ${qf.id} — then run the /quick-fix workflow (implement <=50 LOC on branch qf/${qf.id}, run tests, then node scripts/complete-quick-fix.js ${qf.id}). Do NOT run sd-start.js for a QF. On completion, re-run /checkin.`,
+          };
+        }
+      }
+    } catch { /* fail-open: proceed to normal SD-first order */ }
+  }
+
   // 6. self-claim from ONE merged SD pool: baselined sd:next candidates + claimable
   //    UN-BASELINED drafts, rank-sorted TOGETHER (QF-20260610-986, feedback dc87039d).
   //    The old sequential tiers (6 then 6.25) meant a coordinator dispatch_rank could
@@ -1714,7 +1775,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-critical-qf-priority-jump.test.js
+++ b/tests/unit/worker-checkin-critical-qf-priority-jump.test.js
@@ -1,0 +1,173 @@
+/**
+ * QF-20260704-244 — leg 3 of the QF-lane fix family (legs 1-2 = QF-20260704-602). A CRITICAL
+ * open QF (aged past a 10-minute directed-dispatch grace window) outranks SD self-claim, so
+ * severity stops being decorative. Tightly fenced against reverse SD-belt starvation: only
+ * 'critical' jumps (high/medium/low keep the existing SD-first order), and at most ONE
+ * consecutive jump per worker (claude_sessions.metadata.last_claim_was_qf_jump gates the
+ * FOLLOWING pull, not the current one).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveCheckin, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS } = require('../../scripts/worker-checkin.cjs');
+
+const NOW = Date.parse('2026-07-05T00:00:00Z');
+const OLD_ENOUGH = new Date(NOW - CRITICAL_QF_JUMP_GRACE_MS - 60_000).toISOString(); // just past grace
+const TOO_FRESH = new Date(NOW - 60_000).toISOString(); // 1 minute ago
+
+describe('isCriticalQfJumpEligible (pure predicate)', () => {
+  function qf({ severity = 'critical', createdAt = OLD_ENOUGH, status = 'open', prUrl = null, commitSha = null } = {}) {
+    return { id: 'QF-X', status, severity, created_at: createdAt, pr_url: prUrl, commit_sha: commitSha, routing_tier: null, title: 'x' };
+  }
+
+  it('eligible: critical + aged past the 10min grace window', () => {
+    expect(isCriticalQfJumpEligible(qf(), NOW)).toBe(true);
+  });
+
+  it('NOT eligible: high/medium/low never jump (acceptance #2)', () => {
+    for (const severity of ['high', 'medium', 'low']) {
+      expect(isCriticalQfJumpEligible(qf({ severity }), NOW)).toBe(false);
+    }
+  });
+
+  it('NOT eligible: fresh critical (<10min old) — grace window for directed dispatch (acceptance #4)', () => {
+    expect(isCriticalQfJumpEligible(qf({ createdAt: TOO_FRESH }), NOW)).toBe(false);
+  });
+
+  it('NOT eligible: already in PR/commit (verify-first guard inherited from isAutoStartableQF)', () => {
+    expect(isCriticalQfJumpEligible(qf({ prUrl: 'https://github.com/x/y/pull/1' }), NOW)).toBe(false);
+  });
+
+  it('NOT eligible: not status=open', () => {
+    expect(isCriticalQfJumpEligible(qf({ status: 'in_progress' }), NOW)).toBe(false);
+  });
+});
+
+// ── Integration: full resolveCheckin flow with a purpose-built fake Supabase client ──
+
+function makeThenableChain(resolveTo) {
+  const chain = {
+    select() { return chain; }, eq() { return chain; }, gte() { return chain; },
+    order() { return chain; }, limit() { return chain; }, is() { return chain; },
+    in() { return chain; }, not() { return chain; },
+    maybeSingle() { return Promise.resolve(resolveTo); },
+    single() { return Promise.resolve(resolveTo); },
+    then(onFulfilled, onRejected) { return Promise.resolve(resolveTo).then(onFulfilled, onRejected); },
+  };
+  return chain;
+}
+
+/**
+ * A session-state-carrying fake: claude_sessions.metadata mutates in place via .update() so a
+ * SECOND resolveCheckin call in the same test observes the first call's write (proves the
+ * one-consecutive-jump bound persists across ticks, per acceptance #3).
+ */
+function makeFakeSb({ criticalQfs = [], sessionMetadata = {} }) {
+  const state = { metadata: { ...sessionMetadata } };
+  const sb = {
+    rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+    from(table) {
+      if (table === 'claude_sessions') {
+        return {
+          select() { return this; }, eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: { metadata: state.metadata, sd_key: null }, error: null }),
+          update(patch) {
+            return {
+              eq: () => {
+                if (patch && patch.metadata) state.metadata = patch.metadata;
+                return Promise.resolve({ error: null });
+              },
+            };
+          },
+        };
+      }
+      if (table === 'quick_fixes') {
+        // Leg-3's own query filters .eq('severity', 'critical'); selfClaimQuickFix's (leg-2)
+        // query does not. Track whether this specific chain applied the severity filter so
+        // the two call sites see different result sets, matching real Postgres semantics.
+        let filteredToCritical = false;
+        const chain = {
+          select() { return chain; },
+          eq(col, val) { if (col === 'severity' && val === 'critical') filteredToCritical = true; return chain; },
+          is() { return chain; }, order() { return chain; }, limit() { return chain; },
+          then(onFulfilled, onRejected) {
+            const rows = filteredToCritical ? criticalQfs : criticalQfs; // both call sites see the same open-QF pool here (test controls content directly)
+            return Promise.resolve({ data: rows, error: null }).then(onFulfilled, onRejected);
+          },
+        };
+        return chain;
+      }
+      // Every other table (v_sd_next_candidates, strategic_directives_v2, sd_baseline_items,
+      // sd_conflict_matrix, session_lifecycle_events, etc.) resolves empty -- the SD pool is
+      // genuinely empty, so any claim in these tests can ONLY have come from the leg-3 jump.
+      return makeThenableChain({ data: [], error: null });
+    },
+  };
+  return sb;
+}
+
+describe('resolveCheckin — critical QF jumps ahead of an empty SD pool (acceptance #1)', () => {
+  it('claims the aged critical QF via the priority-jump message, not the plain self-claim path', async () => {
+    const sb = makeFakeSb({ criticalQfs: [
+      { id: 'QF-CRIT-1', status: 'open', severity: 'critical', created_at: OLD_ENOUGH, pr_url: null, commit_sha: null, routing_tier: null, title: 'x' },
+    ] });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('self_claimed_qf');
+      expect(res.qf).toBe('QF-CRIT-1');
+      expect(res.message).toMatch(/priority jump/);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('does NOT jump for a high-severity QF (SD-first order unchanged, acceptance #2)', async () => {
+    const sb = makeFakeSb({ criticalQfs: [
+      { id: 'QF-HIGH-1', status: 'open', severity: 'high', created_at: OLD_ENOUGH, pr_url: null, commit_sha: null, routing_tier: null, title: 'x' },
+    ] });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      // Not claimed via the priority-jump path. The SD pool is empty in this fixture, so the
+      // only way this QF gets claimed at all is via the ordinary (non-jump) step-6.5 self-claim.
+      if (res.action === 'self_claimed_qf') {
+        expect(res.message).not.toMatch(/priority jump/);
+      }
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});
+
+describe('resolveCheckin — one-consecutive-jump bound across two ticks (acceptance #3)', () => {
+  it('pull 1 jumps to a critical QF; pull 2 (bound consumed) does NOT jump even with another critical still open', async () => {
+    const criticalQfs = [
+      { id: 'QF-CRIT-A', status: 'open', severity: 'critical', created_at: OLD_ENOUGH, pr_url: null, commit_sha: null, routing_tier: null, title: 'a' },
+      { id: 'QF-CRIT-B', status: 'open', severity: 'critical', created_at: OLD_ENOUGH, pr_url: null, commit_sha: null, routing_tier: null, title: 'b' },
+    ];
+    const sb = makeFakeSb({ criticalQfs });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      const res1 = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res1.action).toBe('self_claimed_qf');
+      expect(res1.message).toMatch(/priority jump/);
+
+      // Pull 2: the flag set by pull 1 must gate this pull -- no jump, even though a critical
+      // QF is still open (SD pool is still empty in this fixture, so the correct outcome here
+      // is NOT a priority-jump claim).
+      const res2 = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      if (res2.action === 'self_claimed_qf') {
+        expect(res2.message).not.toMatch(/priority jump/);
+      }
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Leg 3 of the QF-lane pull-order fix family (legs 1-2 = QF-20260704-602, merged). Worker self-claim consumed ranked SDs before ANY open QF regardless of severity, starving critical QFs behind a deep SD belt.
- Adds step 5.95 to `resolveCheckin`: a `severity=critical` open QF aged past a 10-minute directed-dispatch grace window jumps ahead of SD self-claim.
- Tightly fenced against reverse SD-belt starvation (coordinator co-designed, "reverse failure must be impossible"):
  - only `critical` jumps — high/medium/low keep the existing SD-first order
  - only fires once the QF has sat open >10min (grace window for QF-602's directed-dispatch path to route it first)
  - at most ONE consecutive jump per worker — `claude_sessions.metadata.last_claim_was_qf_jump` gates the *following* pull, consumed/cleared on read so the bound can never compound across ticks

## Test plan
- [x] New pure-predicate tests for `isCriticalQfJumpEligible` (age gate, severity gate, PR/commit guard, status guard) — 5 cases
- [x] New integration tests against `resolveCheckin` covering all 4 acceptance criteria from the QF: jump fires for an aged critical QF against an empty SD pool; high-severity QFs never jump; one-consecutive-jump bound holds across two ticks — 3 cases
- [x] Full `worker-checkin-*` suite: 127/127 passing, no regressions
- [x] `npm run schema:lint --diff`: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)