### PR TITLE
fix(QF-20260704-127): RETROSPECTIVE_EXISTS/QUALITY gates false-fail on child SDs via id/uuid_id mismatch

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -391,7 +391,7 @@ export function createRetrospectiveExistsGate(supabase) {
       // Handoff-time retros share retro_type='SD_COMPLETION' so the timestamp filter
       // is what distinguishes them from true SD-completion retrospectives.
       const { retrospective, leadToPlanAcceptedAt } =
-        await getFilteredRetrospective(ctx.sd.id, ctx.sd.created_at || null, supabase);
+        await getFilteredRetrospective(ctx.sd.id, ctx.sd.created_at || null, supabase, ctx.sd.sd_key || null);
 
       if (!retrospective) {
         const sdKey = ctx.sd?.sd_key || ctx.sdId || 'unknown';

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
@@ -54,7 +54,7 @@ export function createRetrospectiveQualityGate(supabase) {
       const sdUuid = ctx.sd?.id || ctx.sdId;
       const sdCreatedAt = ctx.sd?.created_at || null;
       const { retrospective, leadToPlanAcceptedAt, error: retroError } =
-        await getFilteredRetrospective(sdUuid, sdCreatedAt, supabase);
+        await getFilteredRetrospective(sdUuid, sdCreatedAt, supabase, ctx.sd?.sd_key || null);
 
       if (retroError && retroError.code !== 'PGRST116') {
         console.log(`   ⚠️  Retrospective query error: ${retroError.message}`);

--- a/scripts/modules/handoff/retro-filters.js
+++ b/scripts/modules/handoff/retro-filters.js
@@ -21,6 +21,33 @@
  */
 
 /**
+ * QF-20260704-127: ctx.sd.id has been observed carrying the SD's legacy uuid_id
+ * column instead of its canonical id (same corruption class as QF-20260703-906,
+ * which patched PREREQUISITE_HANDOFF_CHECK inline) — for child SDs specifically,
+ * making every .eq(sdUuid) below come back clean-empty (valid UUID, zero matches)
+ * rather than erroring, so a real retrospective silently reads as missing.
+ * Re-resolve via sd_key (unaffected by the id/uuid_id ambiguity) whenever available.
+ *
+ * @param {string} sdUuid - candidate strategic_directives_v2.id (UUID)
+ * @param {string|null} sdKey - SD's sd_key, used to re-resolve the canonical id
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<string>} the canonical id (or the original sdUuid if unresolvable)
+ */
+async function resolveCanonicalSdId(sdUuid, sdKey, supabase) {
+  if (!sdKey) return sdUuid;
+  const { data: canonical } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+  if (canonical?.id && canonical.id !== sdUuid) {
+    console.log(`   ⚠️  [retro-filters] sdUuid mismatch (${sdUuid} vs canonical ${canonical.id}) — using canonical id`);
+    return canonical.id;
+  }
+  return sdUuid;
+}
+
+/**
  * Resolve the LEAD-TO-PLAN acceptance timestamp for an SD.
  * Falls back to sdCreatedAt if no accepted LEAD-TO-PLAN handoff row exists
  * (Phase-0 / unusual SDs — see SD risk analysis, accepted permissive).
@@ -51,18 +78,20 @@ export async function resolveLeadToPlanAcceptedAt(sdUuid, sdCreatedAt, supabase)
  * Fetch the most recent SD-completion retrospective that satisfies the three
  * invariants (existence, type, freshness). Returns null when no row matches.
  *
- * @param {string} sdUuid - strategic_directives_v2.id (UUID)
+ * @param {string} sdUuid - candidate strategic_directives_v2.id (UUID)
  * @param {string|null} sdCreatedAt - SD.created_at ISO string, freshness fallback
  * @param {Object} supabase - Supabase client
+ * @param {string|null} [sdKey] - SD's sd_key, used to re-resolve the canonical id (QF-20260704-127)
  * @returns {Promise<{retrospective: Object|null, leadToPlanAcceptedAt: string, error: Object|null}>}
  */
-export async function getFilteredRetrospective(sdUuid, sdCreatedAt, supabase) {
-  const leadToPlanAcceptedAt = await resolveLeadToPlanAcceptedAt(sdUuid, sdCreatedAt, supabase);
+export async function getFilteredRetrospective(sdUuid, sdCreatedAt, supabase, sdKey = null) {
+  const canonicalId = await resolveCanonicalSdId(sdUuid, sdKey, supabase);
+  const leadToPlanAcceptedAt = await resolveLeadToPlanAcceptedAt(canonicalId, sdCreatedAt, supabase);
 
   const { data: retrospective, error } = await supabase
     .from('retrospectives')
     .select('*')
-    .eq('sd_id', sdUuid)
+    .eq('sd_id', canonicalId)
     .eq('retro_type', 'SD_COMPLETION')
     // QF-20260530-670: accept retrospective_type IS NULL (canonical generate-retrospective.js)
     // OR ='SD_COMPLETION' (retro-agent's ad-hoc inserts mistag it). Handoff-time retros tag this

--- a/scripts/modules/handoff/retro-filters.test.js
+++ b/scripts/modules/handoff/retro-filters.test.js
@@ -230,6 +230,79 @@ function buildHandoffPredicateSupabase({ handoffRows = [], rows = [] } = {}) {
   };
 }
 
+/**
+ * QF-20260704-127 — id/uuid_id canonicalization regression.
+ *
+ * Same corruption class as QF-20260703-906 (PREREQUISITE_HANDOFF_CHECK): ctx.sd.id
+ * has been observed carrying the SD's uuid_id column instead of its canonical id,
+ * for child SDs specifically. A corrupted sdUuid makes .eq('sd_id', sdUuid) come
+ * back clean-empty (valid UUID, zero matches) rather than erroring, so a real
+ * retrospective silently reads as missing. getFilteredRetrospective must re-resolve
+ * via sd_key whenever provided.
+ */
+function buildCanonicalizingSupabase({ handoffRow = null, retrospective = null, canonicalId = null } = {}) {
+  const makeChainable = (resolveValue) => {
+    const c = {
+      select: () => c, eq: () => c, or: () => c, gt: () => c, is: () => c, order: () => c, limit: () => c,
+      maybeSingle: () => Promise.resolve(resolveValue),
+      single: () => Promise.resolve(resolveValue),
+      then: (fn) => Promise.resolve(resolveValue).then(fn),
+    };
+    return c;
+  };
+  return {
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return { select: () => makeChainable({ data: canonicalId ? { id: canonicalId } : null, error: null }) };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return { select: () => makeChainable({ data: handoffRow, error: null }) };
+      }
+      if (table === 'retrospectives') {
+        return { select: () => makeChainable({ data: retrospective, error: null }) };
+      }
+      return { select: () => makeChainable({ data: null, error: null }) };
+    }),
+  };
+}
+
+describe('getFilteredRetrospective — id/uuid_id canonicalization (QF-20260704-127)', () => {
+  it('re-resolves a corrupted sdUuid via sd_key and finds the retro under the canonical id', async () => {
+    const corruptedId = 'uuid_id-value';
+    const canonicalId = 'true-id-value';
+    const retro = { id: 'r1', sd_id: canonicalId, retro_type: 'SD_COMPLETION', created_at: '2026-04-10T00:00:00.000Z' };
+    const supabase = buildCanonicalizingSupabase({
+      handoffRow: { accepted_at: '2026-04-01T00:00:00.000Z' },
+      retrospective: retro,
+      canonicalId,
+    });
+    const { retrospective } = await getFilteredRetrospective(corruptedId, null, supabase, 'SD-CHILD-001-A');
+    expect(retrospective).toBe(retro);
+  });
+
+  it('leaves sdUuid unchanged when no sdKey is provided (back-compat, no regression)', async () => {
+    const retro = { id: 'r1', retro_type: 'SD_COMPLETION', created_at: '2026-04-10T00:00:00.000Z' };
+    const supabase = buildCanonicalizingSupabase({
+      handoffRow: { accepted_at: '2026-04-01T00:00:00.000Z' },
+      retrospective: retro,
+    });
+    const { retrospective } = await getFilteredRetrospective('sd-uuid', null, supabase);
+    expect(retrospective).toBe(retro);
+  });
+
+  it('leaves sdUuid unchanged when the sd_key lookup finds no mismatch', async () => {
+    const sameId = 'consistent-id';
+    const retro = { id: 'r1', retro_type: 'SD_COMPLETION', created_at: '2026-04-10T00:00:00.000Z' };
+    const supabase = buildCanonicalizingSupabase({
+      handoffRow: { accepted_at: '2026-04-01T00:00:00.000Z' },
+      retrospective: retro,
+      canonicalId: sameId,
+    });
+    const { retrospective } = await getFilteredRetrospective(sameId, null, supabase, 'SD-CHILD-001-B');
+    expect(retrospective).toBe(retro);
+  });
+});
+
 describe('retro-gate freshness boundary is pinned to LEAD-TO-PLAN (SD-FDBK-INFRA-RETROSPECTIVE-EXISTS-GATE-001)', () => {
   const sdUuid = 'sd-uuid';
   const leadToPlanAccepted = '2026-04-01T00:00:00.000Z';   // T1 — the correct boundary


### PR DESCRIPTION
## Summary
- \`ctx.sd.id\` has been observed carrying the SD's \`uuid_id\` column instead of its canonical \`id\` for child SDs specifically (same corruption class as QF-20260703-906, previously patched inline in `PREREQUISITE_HANDOFF_CHECK` but never propagated here).
- Confirmed via direct query on SD-LEO-INFRA-REWARD-SPINE-ONE-001-A/-B: their `id` and `uuid_id` columns are genuinely different UUIDs, and `retrospectives.sd_id` is stamped with `id` — a corrupted `sdUuid` makes `.eq('sd_id', sdUuid)` come back clean-empty rather than erroring, so a real retrospective silently reads as missing.
- `getFilteredRetrospective()` now re-resolves the canonical id via `sd_key` (unaffected by the id/uuid_id ambiguity) whenever provided, fixing both call sites in one place: `RETROSPECTIVE_EXISTS` (LEAD-FINAL-APPROVAL) and `RETROSPECTIVE_QUALITY_GATE` (PLAN-TO-LEAD).

## Test plan
- [x] 26/26 unit tests pass (15 in `retro-filters.test.js` incl. 3 new regression tests, 3 in gates test, existing suites unaffected)
- [x] TypeScript compiles clean
- [x] Live-verified against production: reproduced the exact bug (corrupted uuid_id → retro reads as missing) for both real affected SDs (SD-LEO-INFRA-REWARD-SPINE-ONE-001-A/-B), then confirmed the fix resolves the correct retrospective in both cases