### PR TITLE
fix(QF-20260704-390): durably arm eva-scheduler-watcher + self-liveness stamp

### DIFF
--- a/.github/workflows/eva-scheduler-watcher-cron.yml
+++ b/.github/workflows/eva-scheduler-watcher-cron.yml
@@ -1,0 +1,50 @@
+name: "EVA scheduler watcher (cron)"
+
+# QF-20260704-390 — scripts/cron/eva-scheduler-watcher.mjs's detect+revive path is proven
+# functional (coordinator ran it once manually and it detected/revived a 12.4-day-stale
+# scheduler), but nothing durably invoked it: no GHA workflow, not in the LEO stack, not in
+# coordinator STANDARD_LOOPS (registered-verifier-never-dispatched class). This arms it.
+#
+# --once is idempotent and no-ops (exit 0, action:'alive') when the scheduler is healthy; it
+# only spawns a replacement when the singleton heartbeat is stale. Every real invocation also
+# self-stamps periodic_process_registry (__eva_scheduler_watcher_self__, self_stamped) so this
+# watcher's OWN silent death is visible too.
+
+on:
+  schedule:
+    # Every 15 minutes.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Detect + revive a dead EvaMasterScheduler
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run watcher (--once)
+        run: node scripts/cron/eva-scheduler-watcher.mjs --once

--- a/scripts/__tests__/eva-scheduler-watcher.test.js
+++ b/scripts/__tests__/eva-scheduler-watcher.test.js
@@ -215,7 +215,13 @@ describe('confirmRevival — MF2', () => {
 });
 
 describe('main — integration', () => {
-  const base = (db, extra = {}) => ({ supabase: db, logger: silentLogger, now: fixedNow, env: CREDS, token: 'supervisor-fixedtok', stdio: 'ignore', ...extra });
+  // QF-20260704-390: main() now self-stamps its own liveness (periodic_process_registry) via an
+  // injected stampLastFired dep, BEFORE the scheduler-liveness/CAS-revive logic these TS-N cases
+  // exercise. makeHeartbeatDB's mock doesn't discriminate by table name, so a real stampLastFired
+  // call would inflate these tests' eva_scheduler_heartbeat write-count assertions. Stub it to a
+  // no-op by default -- the self-stamp behavior itself is covered by
+  // tests/unit/eva-scheduler-watcher-self-liveness.test.js.
+  const base = (db, extra = {}) => ({ supabase: db, logger: silentLogger, now: fixedNow, env: CREDS, token: 'supervisor-fixedtok', stdio: 'ignore', stampLastFired: vi.fn().mockResolvedValue({ stamped: true }), ...extra });
 
   it('TS-1: alive scheduler → no action, no spawn', async () => {
     const db = makeHeartbeatDB(freshRow());

--- a/scripts/cron/eva-scheduler-watcher.mjs
+++ b/scripts/cron/eva-scheduler-watcher.mjs
@@ -58,6 +58,7 @@ import { randomUUID } from 'crypto';
 import { spawn as realSpawn } from 'child_process';
 import { createClient } from '@supabase/supabase-js';
 import { getRepoRoot } from '../../lib/repo-paths.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -65,6 +66,12 @@ const __dirname = path.dirname(__filename);
 const DEFAULT_STALE_MS = 300000;       // 5 minutes — ~5x the daemon's 60s poll interval
 const CONFIRM_TIMEOUT_MS = 8000;       // wait up to 8s for the daemon to stamp its instance
 const CONFIRM_INTERVAL_MS = 500;       // poll the heartbeat every 500ms during confirm
+
+// QF-20260704-390: registered-verifier-never-dispatched class — this watcher's own detect+revive
+// path is proven functional, but nothing durably invoked it (13 days silent). Self-stamps its own
+// liveness (periodic_process_registry, self_stamped source) so the WATCHER's silent death is also
+// visible, not just the scheduler's.
+export const WATCHER_SELF_PROCESS_KEY = '__eva_scheduler_watcher_self__';
 
 const USAGE = 'eva-scheduler-watcher --once|--dry-run   (revives a dead EvaMasterScheduler)';
 
@@ -227,6 +234,14 @@ export async function main(argv = process.argv, deps = {}) {
   catch (err) {
     logger.error?.(`${tag} supabase client unavailable: ${err.message}`);
     return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  // Self-stamp BEFORE any liveness/revive logic so a genuine invocation is always recorded, even
+  // if the scheduler-liveness check itself errors below. Dry-run stays fully read-only (per its
+  // own contract) — never stamps.
+  if (!args.dryRun) {
+    try { await (deps.stampLastFired || stampLastFired)(supabase, WATCHER_SELF_PROCESS_KEY); }
+    catch (err) { logger.warn?.(`${tag} self-liveness stamp failed (non-fatal): ${err.message}`); }
   }
 
   // 1. Liveness by heartbeat age.

--- a/tests/unit/eva-scheduler-watcher-self-liveness.test.js
+++ b/tests/unit/eva-scheduler-watcher-self-liveness.test.js
@@ -1,0 +1,76 @@
+/**
+ * QF-20260704-390 — the watcher's detect+revive path is proven functional, but nothing
+ * durably invoked it (13 days silent, registered-verifier-never-dispatched class). This
+ * covers the new self-liveness stamp: a real invocation (--once) always records that the
+ * WATCHER itself fired, via periodic_process_registry's self_stamped mechanism, so a future
+ * silent death of the WATCHER (not just the scheduler) is also visible.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main, WATCHER_SELF_PROCESS_KEY } from '../../scripts/cron/eva-scheduler-watcher.mjs';
+
+function makeSupabase({ heartbeat = { instance_id: 'scheduler-existing', last_poll_at: new Date().toISOString(), status: 'running' } } = {}) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: heartbeat, error: null }),
+    }),
+  };
+}
+
+function makeLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('WATCHER_SELF_PROCESS_KEY', () => {
+  it('is exported and matches the __watcher_self__ naming convention', () => {
+    expect(WATCHER_SELF_PROCESS_KEY).toBe('__eva_scheduler_watcher_self__');
+  });
+});
+
+describe('eva-scheduler-watcher self-liveness stamp', () => {
+  it('stamps its own liveness on a real (--once) invocation, BEFORE the scheduler-liveness check', async () => {
+    const supabase = makeSupabase();
+    const stampLastFired = vi.fn().mockResolvedValue({ stamped: true });
+    const logger = makeLogger();
+
+    const result = await main(['node', 'eva-scheduler-watcher.mjs', '--once'], { supabase, logger, stampLastFired });
+
+    expect(stampLastFired).toHaveBeenCalledWith(supabase, WATCHER_SELF_PROCESS_KEY);
+    expect(result.action).toBe('alive'); // scheduler was healthy in this fixture
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('does NOT stamp on --dry-run (fully read-only contract preserved)', async () => {
+    const supabase = makeSupabase();
+    const stampLastFired = vi.fn().mockResolvedValue({ stamped: true });
+
+    await main(['node', 'eva-scheduler-watcher.mjs', '--dry-run'], { supabase, logger: makeLogger(), stampLastFired });
+
+    expect(stampLastFired).not.toHaveBeenCalled();
+  });
+
+  it('a failed self-stamp is non-fatal — the watcher still proceeds to its normal liveness check', async () => {
+    const supabase = makeSupabase();
+    const stampLastFired = vi.fn().mockRejectedValue(new Error('registry unreachable'));
+    const logger = makeLogger();
+
+    const result = await main(['node', 'eva-scheduler-watcher.mjs', '--once'], { supabase, logger, stampLastFired });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/self-liveness stamp failed/));
+    expect(result.action).toBe('alive');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('EVA_SCHEDULER_ENABLED=false suppresses everything, including the self-stamp (disabled means disabled)', async () => {
+    const supabase = makeSupabase();
+    const stampLastFired = vi.fn();
+
+    const result = await main(['node', 'eva-scheduler-watcher.mjs', '--once'], {
+      supabase, logger: makeLogger(), stampLastFired, env: { EVA_SCHEDULER_ENABLED: 'false' },
+    });
+
+    expect(stampLastFired).not.toHaveBeenCalled();
+    expect(result.action).toBe('disabled');
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/cron/eva-scheduler-watcher.mjs`'s detect+revive path is proven functional but nothing durably invoked it (registered-verifier-never-dispatched class) — 13 days silent, all scheduled EVA jobs dead.
- New `.github/workflows/eva-scheduler-watcher-cron.yml` runs the watcher (`--once`) every 15 minutes, mirroring the existing `fleet-worker-pulse-cron.yml`/`fleet-down-alert-cron.yml` pattern.
- The watcher now also self-stamps its own liveness (`lib/periodic-liveness/stamp-last-fired.js`'s existing `self_stamped` mechanism) on every real invocation, before the scheduler-liveness check, so the watcher's own silent death is durably visible too. New registry row `__eva_scheduler_watcher_self__` (`standalone_cron`, `self_stamped`, `expected_interval_seconds=900`).
- **Disclosed limitation**: a GHA-hosted revival's spawned daemon only survives the remainder of that ephemeral runner's job — it can't keep scheduled EVA jobs continuously alive the way a persistent LEO-stack process would. This still closes the "13 days silently dead, zero detection" gap, but a stronger long-term fix (adding the daemon to the LEO stack process set) is a fast-follow.

## Test plan
- [x] 5 new unit tests covering the self-stamp firing on a real invocation, never firing on `--dry-run` or when `EVA_SCHEDULER_ENABLED=false`, and failing non-fatally
- [x] Verified live: ran the watcher once against the real DB, confirmed `periodic_process_registry.last_fired_at` updated
- [x] `npm run schema:lint --diff`: 0 violations
- [x] GHA workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)