### PR TITLE
feat(SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E): synthetic-persona journey walk evidence layer

### DIFF
--- a/lib/eva/journey-evidence-merge.js
+++ b/lib/eva/journey-evidence-merge.js
@@ -1,0 +1,133 @@
+/**
+ * Journey Evidence Merge — folds journey-walk outcomes into Child B's EXISTING
+ * post_build_verdicts rows (read-then-append, monotonic disposition upgrade
+ * only), rather than inventing a new rubric dimension.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E (FR-4/FR-5). post_build_verdicts is
+ * current-snapshot-only — Child B's runArtifactWalk() DELETEs and rewrites
+ * claim-level rows on every invocation, and upsertVerdict() overwrites (no
+ * append, no provenance). This module MUST run strictly AFTER Child B's walk
+ * completes and BEFORE Child C's convergence loop scores, within the same
+ * S19-exit pipeline invocation — Child D's integrator is the intended caller;
+ * this module enforces the ordering via a required `walkCompletedAt` marker
+ * rather than assuming callers get it right.
+ *
+ * @module lib/eva/journey-evidence-merge
+ */
+
+import { upsertVerdict } from './post-build-verdict-engine.js';
+
+/** Disposition rank for monotonic-upgrade-only comparisons — higher is "more built".
+ *  DEVIATED_* dispositions are left alone by this module (a journey run confirming
+ *  a route says nothing about whether a documented deviation is sensible — that
+ *  judgment belongs to Child C's reason-quality scoring, not this evidence layer). */
+const UPGRADEABLE_FROM = new Set(['MISSING', 'PARTIAL']);
+
+/**
+ * Read the current verdict row for (ventureId, artifactType, claimRef).
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, artifactType: string, claimRef: string}} opts
+ * @returns {Promise<object|null>}
+ */
+async function readExistingVerdict(supabase, { ventureId, artifactType, claimRef }) {
+  const { data, error } = await supabase
+    .from('post_build_verdicts')
+    .select('id, disposition, evidence_refs, deviation_artifact_id, claim_description')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', artifactType)
+    .eq('claim_ref', claimRef)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`[journey-evidence-merge] readExistingVerdict failed: ${error.message}`);
+  }
+  return data;
+}
+
+/**
+ * Merge one journey-step outcome into the existing verdict for a given claim.
+ * Read-then-append: existing evidenceRefs are preserved and the journey's
+ * evidence is appended; disposition is upgraded ONLY when it currently sits in
+ * UPGRADEABLE_FROM and the journey step succeeded — never downgraded, and never
+ * touched for a claim the journey didn't exercise (no matching row = no-op).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, artifactType: string, claimRef: string, stepOutcome: {step: string, url: string, renderedStateSummary: string, success: boolean}}} opts
+ * @returns {Promise<{merged: boolean, upgraded: boolean, verdictId: string|null}>}
+ */
+export async function mergeStepEvidence(supabase, { ventureId, artifactType, claimRef, stepOutcome }) {
+  const existing = await readExistingVerdict(supabase, { ventureId, artifactType, claimRef });
+
+  // No matching verdict row for this claim — Child B's walk is the authority on
+  // which claims exist; this is a skip, not an error (FR-4 acceptance criteria).
+  if (!existing) {
+    return { merged: false, upgraded: false, verdictId: null };
+  }
+
+  const journeyEvidenceEntry = {
+    source: 'journey-walk',
+    step: stepOutcome.step,
+    path: stepOutcome.url,
+    renderedStateSummary: stepOutcome.renderedStateSummary,
+    outcome: stepOutcome.success ? 'route-exercised' : 'route-broken',
+  };
+
+  const mergedEvidenceRefs = [...(existing.evidence_refs || []), journeyEvidenceEntry];
+  const shouldUpgrade = stepOutcome.success && UPGRADEABLE_FROM.has(existing.disposition);
+  const newDisposition = shouldUpgrade ? 'BUILT' : existing.disposition;
+
+  const verdictId = await upsertVerdict(supabase, {
+    ventureId,
+    artifactType,
+    claimRef,
+    disposition: newDisposition,
+    evidenceRefs: mergedEvidenceRefs,
+    deviationArtifactId: existing.deviation_artifact_id,
+    claimDescription: existing.claim_description,
+  });
+
+  return { merged: true, upgraded: shouldUpgrade, verdictId };
+}
+
+/**
+ * Merge a full journey walk's outcomes into existing verdicts. Requires an
+ * explicit `walkCompletedAt` timestamp asserting Child B's artifact walk has
+ * already completed for this venture (FR-5's ordering guard) — this module
+ * refuses to run without it rather than silently merging onto rows that are
+ * about to be (or were never) written by a real Child B pass.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string, journeyOutcomes: Array<{step: string, artifactType: string, claimRef: string, url: string, renderedStateSummary: string, success: boolean}>, walkCompletedAt: string}} opts
+ * @returns {Promise<{results: Array, mergedCount: number, upgradedCount: number}>}
+ */
+export async function mergeJourneyEvidence(supabase, { ventureId, journeyOutcomes, walkCompletedAt }) {
+  if (!ventureId) throw new Error('[journey-evidence-merge] mergeJourneyEvidence requires ventureId');
+  if (!walkCompletedAt) {
+    throw new Error(
+      '[journey-evidence-merge] mergeJourneyEvidence requires walkCompletedAt — '
+      + 'this asserts Child B\'s artifact walk has already completed for this venture '
+      + '(FR-5 ordering guard). Call runArtifactWalk() first, then pass its completion '
+      + 'timestamp here — never call this module speculatively before Child B\'s walk.'
+    );
+  }
+
+  const results = [];
+  let mergedCount = 0;
+  let upgradedCount = 0;
+
+  for (const outcome of journeyOutcomes || []) {
+    const { merged, upgraded, verdictId } = await mergeStepEvidence(supabase, {
+      ventureId,
+      artifactType: outcome.artifactType,
+      claimRef: outcome.claimRef,
+      stepOutcome: outcome,
+    });
+    results.push({ step: outcome.step, claimRef: outcome.claimRef, merged, upgraded, verdictId });
+    if (merged) mergedCount += 1;
+    if (upgraded) upgradedCount += 1;
+  }
+
+  return { results, mergedCount, upgradedCount };
+}
+
+export default { mergeStepEvidence, mergeJourneyEvidence };

--- a/lib/eva/journey-walk-driver.js
+++ b/lib/eva/journey-walk-driver.js
@@ -1,0 +1,246 @@
+/**
+ * Journey Walk Driver — drives a locally-served MarketLens checkout through the
+ * land -> signup -> submit -> results -> feedback journey with a Playwright
+ * page, recording per-step outcomes.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E. Routes/selectors below are read
+ * directly from the real MarketLens repo (applications.local_path) — src/routes/
+ * web.js (land, signup), src/routes/app.js (login/session, generate, results,
+ * feedback), src/views/appViews.js (form field names) — not invented.
+ *
+ * MarketLens-specific local-serve scoping (FR-3): generalizing this driver to
+ * arbitrary future ventures (unknown tech stack/port/startup time) is explicitly
+ * OUT OF SCOPE for this child.
+ *
+ * @module lib/eva/journey-walk-driver
+ */
+
+import { JOURNEY_STEPS } from './persona-generator.js';
+
+/** MarketLens-specific local-serve config (FR-3). Port/health path/command read
+ *  directly from the real repo's src/app.js (PORT ?? 3001, GET /api/health) and
+ *  package.json ("start": "node src/app.js"). */
+export const MARKETLENS_SERVE_CONFIG = Object.freeze({
+  startCommand: 'node',
+  startArgs: ['src/app.js'],
+  port: 3001,
+  healthPath: '/api/health',
+  readinessTimeoutMs: 20_000,
+  readinessPollIntervalMs: 500,
+});
+
+/**
+ * Poll a health endpoint until it responds 200, or the timeout elapses.
+ * Injectable fetchFn for testability (default: global fetch).
+ * @param {{baseUrl: string, healthPath: string, timeoutMs: number, pollIntervalMs: number, fetchFn?: Function, sleepFn?: Function}} opts
+ * @returns {Promise<boolean>} true if the server became ready within the timeout
+ */
+export async function waitForServerReady(opts) {
+  const {
+    baseUrl, healthPath, timeoutMs, pollIntervalMs,
+    fetchFn = globalThis.fetch, sleepFn = (ms) => new Promise((r) => setTimeout(r, ms)),
+  } = opts;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetchFn(`${baseUrl}${healthPath}`);
+      if (res?.ok) return true;
+    } catch {
+      // Server not listening yet — expected during startup, keep polling.
+    }
+    await sleepFn(pollIntervalMs);
+  }
+  return false;
+}
+
+/**
+ * Start the MarketLens local dev server. Injectable spawnFn for testability
+ * (default: node:child_process spawn). Returns a could-not-verify outcome
+ * (never throws, never a false pass) if the server never becomes ready.
+ * @param {{repoPath: string, spawnFn?: Function, fetchFn?: Function, sleepFn?: Function}} opts
+ * @returns {Promise<{ready: boolean, process: object|null, baseUrl: string}>}
+ */
+export async function startLocalMarketLensServer({ repoPath, spawnFn, fetchFn, sleepFn } = {}) {
+  if (!repoPath) throw new Error('[journey-walk-driver] startLocalMarketLensServer requires repoPath');
+
+  let spawn = spawnFn;
+  if (!spawn) {
+    ({ spawn } = await import('node:child_process'));
+  }
+
+  const baseUrl = `http://localhost:${MARKETLENS_SERVE_CONFIG.port}`;
+  const proc = spawn(MARKETLENS_SERVE_CONFIG.startCommand, MARKETLENS_SERVE_CONFIG.startArgs, {
+    cwd: repoPath,
+    env: { ...process.env, PORT: String(MARKETLENS_SERVE_CONFIG.port) },
+  });
+
+  const ready = await waitForServerReady({
+    baseUrl,
+    healthPath: MARKETLENS_SERVE_CONFIG.healthPath,
+    timeoutMs: MARKETLENS_SERVE_CONFIG.readinessTimeoutMs,
+    pollIntervalMs: MARKETLENS_SERVE_CONFIG.readinessPollIntervalMs,
+    fetchFn,
+    sleepFn,
+  });
+
+  if (!ready) {
+    try { proc?.kill?.(); } catch { /* best-effort cleanup */ }
+    return { ready: false, process: null, baseUrl };
+  }
+
+  return { ready: true, process: proc, baseUrl };
+}
+
+/**
+ * Per-step execute functions. Each receives (page, persona, ctx) where ctx
+ * carries {baseUrl, submissionId} accumulated across steps, and returns
+ * {url, renderedStateSummary, submissionId?} on success, throwing on failure
+ * (executeJourneyStep wraps this into the outcome record).
+ */
+const STEP_EXECUTORS = {
+  async land(page, _persona, ctx) {
+    await page.goto(`${ctx.baseUrl}/`);
+    const heading = await page.locator('h1').first().textContent();
+    if (!heading) throw new Error('land: no <h1> hero content rendered');
+    return { url: `${ctx.baseUrl}/`, renderedStateSummary: heading.trim() };
+  },
+
+  async signup(page, persona, ctx) {
+    const email = `${persona.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}@journey-walk.test`;
+    const password = 'JourneyWalk-Test-Pass-1';
+
+    await page.goto(`${ctx.baseUrl}/signup`);
+    await page.fill('#email', email);
+    await page.fill('#password', password);
+    await page.click('button[type="submit"]');
+    // #signup-message is populated by an async fetch()-driven client script (not a
+    // navigation or a plain DOM mutation Playwright auto-waits for) — poll until it
+    // renders rather than reading it immediately after click() (live-run finding:
+    // reading immediately raced the fetch and always saw the empty initial text).
+    await page.waitForFunction(
+      () => (document.getElementById('signup-message')?.textContent || '').trim().length > 0,
+      { timeout: 5000 }
+    );
+    // Live-run finding: a re-run against a still-warm server (same in-memory user
+    // store) re-derives the SAME email for a given persona and gets "already
+    // registered" on the second+ run. The real goal of this sub-step is having
+    // valid credentials to log in with, not proving first-time registration —
+    // "already registered" is an equally acceptable outcome, only a genuine
+    // validation/server error is a real failure.
+    const message = await page.locator('#signup-message').textContent();
+    const registeredOrAlreadyExists = message && (message.includes('welcome') || message.includes('already registered'));
+    if (!registeredOrAlreadyExists) {
+      throw new Error(`signup: expected a welcome confirmation or an already-registered notice, got "${message}"`);
+    }
+
+    await page.goto(`${ctx.baseUrl}/app/login`);
+    await page.fill('#email', email);
+    await page.fill('#password', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/app$/);
+
+    return { url: `${ctx.baseUrl}/app`, renderedStateSummary: `logged in as ${email}`, email };
+  },
+
+  async submit(page, persona, _ctx) {
+    await page.fill('#productDescription', persona.stepIntents.submit);
+    await page.fill('#marketDescription', `Target market for ${persona.name}: ${persona.demographics?.industry || 'general'}`);
+    // Live-run finding: the /app page renders TWO button[type="submit"] elements
+    // (a "Sign out" form ships first in the markup, then the generate form) — a
+    // generic selector clicked Sign out instead, logging the persona out and
+    // hanging on waitForURL. Scope to the generate form specifically.
+    await page.click('form[action="/app/generate"] button[type="submit"]');
+    await page.waitForURL(/\/app\/results\/[^/]+$/);
+    const url = page.url();
+    const submissionId = url.split('/results/')[1];
+    return { url, renderedStateSummary: `redirected to results/${submissionId}`, submissionId };
+  },
+
+  async results(page, _persona, ctx) {
+    if (!ctx.submissionId) throw new Error('results: no submissionId from the submit step');
+    await page.goto(`${ctx.baseUrl}/app/results/${ctx.submissionId}`);
+    const bodyText = await page.locator('body').textContent();
+    if (!bodyText || /not.?found/i.test(bodyText)) {
+      throw new Error('results: submission not found');
+    }
+    if (/pending/i.test(bodyText)) {
+      throw new Error('results: generation still pending — expected synchronous completion');
+    }
+    return { url: `${ctx.baseUrl}/app/results/${ctx.submissionId}`, renderedStateSummary: 'results ready' };
+  },
+
+  async feedback(page, persona, ctx) {
+    await page.fill('#fb-title', `Feedback from ${persona.name}`);
+    await page.fill('#fb-description', persona.stepIntents.feedback);
+    await page.click('button[type="submit"]');
+    const bodyText = await page.locator('body').textContent();
+    if (!bodyText) throw new Error('feedback: no confirmation rendered');
+    return { url: `${ctx.baseUrl}/app/results/${ctx.submissionId}`, renderedStateSummary: 'feedback submitted' };
+  },
+};
+
+/**
+ * Execute one journey step against an injected Playwright-like page, capturing
+ * the outcome without letting a thrown error abort the whole walk uncaught.
+ * @param {object} page - Playwright Page (or a test-injected mock with the same shape)
+ * @param {string} step - one of JOURNEY_STEPS
+ * @param {object} persona - a generatePersonaFromArtifact() descriptor
+ * @param {object} ctx - accumulated context {baseUrl, submissionId, ...}
+ * @returns {Promise<{step: string, url: string|null, renderedStateSummary: string|null, success: boolean, failureReason: string|null, ctxUpdates: object}>}
+ */
+export async function executeJourneyStep(page, step, persona, ctx) {
+  const executor = STEP_EXECUTORS[step];
+  if (!executor) throw new Error(`[journey-walk-driver] executeJourneyStep: unknown step "${step}"`);
+
+  try {
+    const result = await executor(page, persona, ctx);
+    return {
+      step,
+      url: result.url,
+      renderedStateSummary: result.renderedStateSummary,
+      success: true,
+      failureReason: null,
+      // Live-run finding: only include keys the step's executor actually returned —
+      // blanket-including submissionId/email as `undefined` for every step clobbered
+      // an earlier step's value on merge (results/feedback losing submit's submissionId).
+      ctxUpdates: {
+        ...(result.submissionId !== undefined ? { submissionId: result.submissionId } : {}),
+        ...(result.email !== undefined ? { email: result.email } : {}),
+      },
+    };
+  } catch (err) {
+    return { step, url: null, renderedStateSummary: null, success: false, failureReason: err.message, ctxUpdates: {} };
+  }
+}
+
+/**
+ * Walk all JOURNEY_STEPS in order against an injected Playwright page. Stops at
+ * the first failure (a real user cannot proceed past a broken signup/submit
+ * step) and records the exact break point — never silently continues as if a
+ * broken step succeeded, never crashes the whole run uncaught.
+ * @param {object} page
+ * @param {object} persona
+ * @param {{baseUrl: string}} opts
+ * @returns {Promise<{outcomes: Array, completedAllSteps: boolean, brokenAtStep: string|null}>}
+ */
+export async function runJourneyWalk(page, persona, { baseUrl }) {
+  const outcomes = [];
+  let ctx = { baseUrl };
+
+  for (const step of JOURNEY_STEPS) {
+    const outcome = await executeJourneyStep(page, step, persona, ctx);
+    outcomes.push(outcome);
+    if (!outcome.success) {
+      return { outcomes, completedAllSteps: false, brokenAtStep: step };
+    }
+    ctx = { ...ctx, ...outcome.ctxUpdates };
+  }
+
+  return { outcomes, completedAllSteps: true, brokenAtStep: null };
+}
+
+export default {
+  MARKETLENS_SERVE_CONFIG, waitForServerReady, startLocalMarketLensServer,
+  executeJourneyStep, runJourneyWalk,
+};

--- a/lib/eva/persona-generator.js
+++ b/lib/eva/persona-generator.js
@@ -1,0 +1,103 @@
+/**
+ * Persona Generator — produces an executable, journey-scriptable persona
+ * descriptor from the existing identity_persona_brand planning artifact.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E. identity_persona_brand is a
+ * descriptive-only artifact (Stage 10 output, artifact_data.personas[]) — it
+ * has never been executed. This module is the first thing that turns one of
+ * its personas into a scripted set of per-journey-step intents, WITHOUT
+ * re-deriving persona traits independently (reuses goals/painPoints as-is).
+ *
+ * @module lib/eva/persona-generator
+ */
+
+/** The 5 journey steps this SD's proof case walks (MarketLens). */
+export const JOURNEY_STEPS = Object.freeze(['land', 'signup', 'submit', 'results', 'feedback']);
+
+/**
+ * Read the venture's current identity_persona_brand artifact.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId: string}} opts
+ * @returns {Promise<{personas: Array}|null>} artifact_data, or null if absent
+ */
+export async function readIdentityPersonaBrand(supabase, { ventureId }) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'identity_persona_brand')
+    .eq('is_current', true)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`[persona-generator] readIdentityPersonaBrand failed: ${error.message}`);
+  }
+  return data?.artifact_data || null;
+}
+
+/**
+ * Script one journey step's intent from a persona's goals/painPoints — a short,
+ * human-readable description of what this persona would do/type at this step,
+ * derived from their actual goals rather than generic filler.
+ * @param {string} step - one of JOURNEY_STEPS
+ * @param {{name: string, goals: string[], painPoints: string[]}} persona
+ * @returns {string}
+ */
+function scriptStepIntent(step, persona) {
+  const primaryGoal = persona.goals?.[0] || 'accomplish their goal';
+  const primaryPain = persona.painPoints?.[0] || 'a pain point';
+  switch (step) {
+    case 'land':
+      return `${persona.name} arrives looking to solve: ${primaryPain}`;
+    case 'signup':
+      return `${persona.name} signs up, motivated by wanting to ${primaryGoal}`;
+    case 'submit':
+      return `${persona.name} submits a persona/WTP analysis reflecting their goal: ${primaryGoal}`;
+    case 'results':
+      return `${persona.name} reviews results looking for confirmation their pain point (${primaryPain}) is addressed`;
+    case 'feedback':
+      return `${persona.name} leaves feedback framed around whether ${primaryGoal} was achieved`;
+    default:
+      throw new Error(`[persona-generator] scriptStepIntent: unknown step "${step}"`);
+  }
+}
+
+/**
+ * Produce an executable persona descriptor from a raw identity_persona_brand
+ * artifact_data payload: the first persona in artifact_data.personas[], plus a
+ * scripted intent for every journey step. Fails loud (never fabricates) if the
+ * artifact is missing or has no personas — matches Child B's honesty rule
+ * (could-not-verify != built).
+ *
+ * @param {{personas: Array<{name: string, demographics?: object, goals?: string[], painPoints?: string[], behaviors?: string[], motivations?: string[]}>}|null} artifactData
+ * @returns {{name: string, demographics: object, goals: string[], painPoints: string[], stepIntents: Record<string, string>}}
+ */
+export function generatePersonaFromArtifact(artifactData) {
+  const personas = artifactData?.personas;
+  if (!Array.isArray(personas) || personas.length === 0) {
+    throw new Error('[persona-generator] generatePersonaFromArtifact requires a non-empty identity_persona_brand artifact (artifact_data.personas[]) — refusing to fabricate a persona from nothing');
+  }
+
+  const source = personas[0];
+  if (!source?.name) {
+    throw new Error('[persona-generator] generatePersonaFromArtifact: persona is missing a name — cannot script a journey');
+  }
+
+  const persona = {
+    name: source.name,
+    demographics: source.demographics || {},
+    goals: source.goals || [],
+    painPoints: source.painPoints || [],
+  };
+
+  const stepIntents = {};
+  for (const step of JOURNEY_STEPS) {
+    stepIntents[step] = scriptStepIntent(step, persona);
+  }
+
+  return { ...persona, stepIntents };
+}
+
+export default { JOURNEY_STEPS, readIdentityPersonaBrand, generatePersonaFromArtifact };

--- a/tests/unit/eva/journey-evidence-merge.test.js
+++ b/tests/unit/eva/journey-evidence-merge.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for lib/eva/journey-evidence-merge.js.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E
+ *
+ * @module tests/unit/eva/journey-evidence-merge.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mergeStepEvidence, mergeJourneyEvidence } from '../../../lib/eva/journey-evidence-merge.js';
+import { DIMENSION_ARTIFACT_MAP } from '../../../lib/eva/adherence-scorer.js';
+
+/** Mutable in-memory post_build_verdicts mock supporting select + upsert. */
+function createMockSupabase(initialRows = []) {
+  const rows = [...initialRows];
+  return {
+    from: (table) => {
+      if (table !== 'post_build_verdicts') throw new Error(`unexpected table ${table}`);
+      return {
+        select: () => ({
+          eq: (col1, val1) => ({
+            eq: (col2, val2) => ({
+              eq: (col3, val3) => ({
+                maybeSingle: async () => {
+                  const row = rows.find((r) => r[col1] === val1 && r[col2] === val2 && r[col3] === val3);
+                  return { data: row || null, error: null };
+                },
+              }),
+            }),
+          }),
+        }),
+        upsert: (payload) => ({
+          select: () => ({
+            single: async () => {
+              const idx = rows.findIndex(
+                (r) => r.venture_id === payload.venture_id && r.artifact_type === payload.artifact_type && r.claim_ref === payload.claim_ref
+              );
+              const merged = { id: idx >= 0 ? rows[idx].id : `v-${rows.length}`, ...payload };
+              if (idx >= 0) rows[idx] = merged; else rows.push(merged);
+              return { data: { id: merged.id }, error: null };
+            },
+          }),
+        }),
+      };
+    },
+    _rows: rows,
+  };
+}
+
+describe('mergeStepEvidence() — TS-5 (upgrade + append)', () => {
+  it('upgrades PARTIAL to BUILT and appends evidenceRefs (never replaces) on a successful journey step', async () => {
+    const supabase = createMockSupabase([
+      { id: 'v1', venture_id: 'v-1', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-1', disposition: 'PARTIAL', evidence_refs: [{ path: 'src/foo.js', line: 3 }] },
+    ]);
+
+    const result = await mergeStepEvidence(supabase, {
+      ventureId: 'v-1', artifactType: 'blueprint_user_story_pack', claimRef: 'story-1',
+      stepOutcome: { step: 'submit', url: '/app', renderedStateSummary: 'ok', success: true },
+    });
+
+    expect(result.merged).toBe(true);
+    expect(result.upgraded).toBe(true);
+    const row = supabase._rows.find((r) => r.claim_ref === 'story-1');
+    expect(row.disposition).toBe('BUILT');
+    expect(row.evidence_refs).toHaveLength(2);
+    expect(row.evidence_refs[0]).toEqual({ path: 'src/foo.js', line: 3 });
+    expect(row.evidence_refs[1].source).toBe('journey-walk');
+  });
+});
+
+describe('mergeStepEvidence() — TS-6 (no downgrade, no-op on unmatched claim)', () => {
+  it('leaves an existing BUILT verdict disposition unchanged when the journey step did not confirm it', async () => {
+    const supabase = createMockSupabase([
+      { id: 'v1', venture_id: 'v-1', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-1', disposition: 'BUILT', evidence_refs: [] },
+    ]);
+
+    const result = await mergeStepEvidence(supabase, {
+      ventureId: 'v-1', artifactType: 'blueprint_user_story_pack', claimRef: 'story-1',
+      stepOutcome: { step: 'submit', url: '/app', renderedStateSummary: 'ok', success: false },
+    });
+
+    expect(result.upgraded).toBe(false);
+    const row = supabase._rows.find((r) => r.claim_ref === 'story-1');
+    expect(row.disposition).toBe('BUILT');
+  });
+
+  it('is a no-op (not an error) when no existing verdict row matches the claim', async () => {
+    const supabase = createMockSupabase([]);
+    const result = await mergeStepEvidence(supabase, {
+      ventureId: 'v-1', artifactType: 'blueprint_user_story_pack', claimRef: 'story-unmatched',
+      stepOutcome: { step: 'submit', url: '/app', renderedStateSummary: 'ok', success: true },
+    });
+    expect(result.merged).toBe(false);
+    expect(result.verdictId).toBeNull();
+  });
+});
+
+describe('DIMENSION_ARTIFACT_MAP — TS-7 (no new rubric dimension introduced)', () => {
+  it('remains exactly the 4 chairman-ratified dimensions', () => {
+    expect(Object.keys(DIMENSION_ARTIFACT_MAP).sort()).toEqual(
+      ['architecture_conformance', 'data_model_fidelity', 'persona_surface_coverage', 'user_story_coverage'].sort()
+    );
+  });
+});
+
+describe('mergeJourneyEvidence() — TS-8 (ordering guard)', () => {
+  it('throws when walkCompletedAt is not provided, refusing to merge onto possibly-stale rows', async () => {
+    const supabase = createMockSupabase([]);
+    await expect(mergeJourneyEvidence(supabase, { ventureId: 'v-1', journeyOutcomes: [] }))
+      .rejects.toThrow(/walkCompletedAt/);
+  });
+
+  it('merges all outcomes when walkCompletedAt is provided', async () => {
+    const supabase = createMockSupabase([
+      { id: 'v1', venture_id: 'v-1', artifact_type: 'blueprint_user_story_pack', claim_ref: 'story-1', disposition: 'PARTIAL', evidence_refs: [] },
+      { id: 'v2', venture_id: 'v-1', artifact_type: 'identity_persona_brand', claim_ref: 'identity_persona_brand', disposition: 'PARTIAL', evidence_refs: [] },
+    ]);
+    const journeyOutcomes = [
+      { step: 'submit', artifactType: 'blueprint_user_story_pack', claimRef: 'story-1', url: '/app', renderedStateSummary: 'ok', success: true },
+      { step: 'land', artifactType: 'identity_persona_brand', claimRef: 'identity_persona_brand', url: '/', renderedStateSummary: 'ok', success: true },
+    ];
+
+    const { results, mergedCount, upgradedCount } = await mergeJourneyEvidence(supabase, {
+      ventureId: 'v-1', journeyOutcomes, walkCompletedAt: new Date().toISOString(),
+    });
+
+    expect(mergedCount).toBe(2);
+    expect(upgradedCount).toBe(2);
+    expect(results).toHaveLength(2);
+  });
+});

--- a/tests/unit/eva/journey-walk-driver.test.js
+++ b/tests/unit/eva/journey-walk-driver.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for lib/eva/journey-walk-driver.js.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E
+ *
+ * @module tests/unit/eva/journey-walk-driver.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  waitForServerReady,
+  startLocalMarketLensServer,
+  runJourneyWalk,
+} from '../../../lib/eva/journey-walk-driver.js';
+import { generatePersonaFromArtifact } from '../../../lib/eva/persona-generator.js';
+
+const PERSONA = generatePersonaFromArtifact({
+  personas: [{
+    name: 'Test Persona',
+    demographics: { industry: 'Technology' },
+    goals: ['Validate an idea fast'],
+    painPoints: ['Too much uncertainty'],
+  }],
+});
+
+/** A fake Playwright-like page that succeeds every step, matching the real
+ *  MarketLens app's rendered content/URLs. */
+function makeHappyPathPage() {
+  let currentUrl = '';
+  const locatorText = {
+    'h1': 'Validate your idea in minutes',
+    '#signup-message': 'Account created — welcome to MarketLens!',
+    'body': 'Your persona and willingness-to-pay analysis is complete.',
+  };
+  return {
+    goto: vi.fn(async (url) => { currentUrl = url; }),
+    fill: vi.fn(async () => {}),
+    click: vi.fn(async (selector) => {
+      if (selector === 'button[type="submit"]' && currentUrl.endsWith('/app/login')) currentUrl = 'http://localhost:3001/app';
+      if (selector === 'form[action="/app/generate"] button[type="submit"]') currentUrl = 'http://localhost:3001/app/results/sub-123';
+    }),
+    waitForURL: vi.fn(async () => {}),
+    waitForFunction: vi.fn(async () => {}),
+    url: vi.fn(() => currentUrl),
+    locator: vi.fn((sel) => ({
+      first: () => ({ textContent: async () => locatorText[sel] }),
+      textContent: async () => locatorText[sel] || 'ok',
+    })),
+  };
+}
+
+describe('runJourneyWalk() — TS-3 (broken step is recorded precisely, walk stops)', () => {
+  it('completes all 5 steps on the happy path', async () => {
+    const page = makeHappyPathPage();
+    const result = await runJourneyWalk(page, PERSONA, { baseUrl: 'http://localhost:3001' });
+
+    expect(result.completedAllSteps).toBe(true);
+    expect(result.brokenAtStep).toBeNull();
+    expect(result.outcomes).toHaveLength(5);
+    expect(result.outcomes.every((o) => o.success)).toBe(true);
+  });
+
+  it('records the exact break point when a step fails, and does not continue past it', async () => {
+    const page = makeHappyPathPage();
+    // Force the "submit" step to fail. signup's step internally fills 4 fields
+    // (register email/password, then login email/password) before submit's first
+    // fill (productDescription) is the 5th call.
+    let fillCalls = 0;
+    page.fill = vi.fn(async () => {
+      fillCalls += 1;
+      if (fillCalls === 5) throw new Error('productDescription field not found (route broken)');
+    });
+
+    const result = await runJourneyWalk(page, PERSONA, { baseUrl: 'http://localhost:3001' });
+
+    expect(result.completedAllSteps).toBe(false);
+    expect(result.brokenAtStep).toBe('submit');
+    // land + signup succeeded, submit failed, results/feedback never attempted.
+    expect(result.outcomes).toHaveLength(3);
+    expect(result.outcomes[0].success).toBe(true);
+    expect(result.outcomes[1].success).toBe(true);
+    expect(result.outcomes[2].success).toBe(false);
+    expect(result.outcomes[2].failureReason).toMatch(/route broken/);
+  });
+});
+
+describe('waitForServerReady() / startLocalMarketLensServer() — TS-4 (graceful degradation)', () => {
+  it('returns true once the health endpoint responds ok', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    const ready = await waitForServerReady({
+      baseUrl: 'http://localhost:3001', healthPath: '/api/health',
+      timeoutMs: 5000, pollIntervalMs: 10, fetchFn, sleepFn: async () => {},
+    });
+    expect(ready).toBe(true);
+  });
+
+  it('returns false (never throws) when the server never becomes ready within the timeout', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const sleepFn = async () => {};
+    const ready = await waitForServerReady({
+      baseUrl: 'http://localhost:3001', healthPath: '/api/health',
+      timeoutMs: 50, pollIntervalMs: 10, fetchFn, sleepFn,
+    });
+    expect(ready).toBe(false);
+  });
+
+  it('startLocalMarketLensServer returns ready:false (not a crash, not a false pass) when the server never becomes ready', async () => {
+    const spawnFn = vi.fn(() => ({ kill: vi.fn() }));
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await startLocalMarketLensServer({
+      repoPath: '/fake/path', spawnFn, fetchFn, sleepFn: async () => {},
+    });
+    expect(result.ready).toBe(false);
+    expect(result.process).toBeNull();
+  });
+
+  it('startLocalMarketLensServer returns ready:true with the process handle when the server becomes ready', async () => {
+    const killFn = vi.fn();
+    const spawnFn = vi.fn(() => ({ kill: killFn }));
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    const result = await startLocalMarketLensServer({
+      repoPath: '/fake/path', spawnFn, fetchFn, sleepFn: async () => {},
+    });
+    expect(result.ready).toBe(true);
+    expect(result.process).toBeTruthy();
+    expect(killFn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/eva/persona-generator.test.js
+++ b/tests/unit/eva/persona-generator.test.js
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for lib/eva/persona-generator.js.
+ *
+ * SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E
+ *
+ * @module tests/unit/eva/persona-generator.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { JOURNEY_STEPS, generatePersonaFromArtifact } from '../../../lib/eva/persona-generator.js';
+
+const SAMPLE_ARTIFACT = {
+  personas: [
+    {
+      name: 'Tech-Savvy Startup Founder',
+      demographics: { ageRange: '25-40', role: 'Founder/CEO', industry: 'Technology' },
+      goals: ['Validate product-market fit quickly', 'Raise a seed round'],
+      painPoints: ['Wasting time on ideas nobody wants', 'Unclear willingness-to-pay signal'],
+      behaviors: ['Researches competitors obsessively'],
+      motivations: ['Building something that matters'],
+    },
+  ],
+};
+
+describe('generatePersonaFromArtifact() — TS-1', () => {
+  it('produces a persona descriptor with non-empty name/goals/painPoints and a scripted intent per journey step', () => {
+    const persona = generatePersonaFromArtifact(SAMPLE_ARTIFACT);
+
+    expect(persona.name).toBe('Tech-Savvy Startup Founder');
+    expect(persona.goals.length).toBeGreaterThan(0);
+    expect(persona.painPoints.length).toBeGreaterThan(0);
+
+    for (const step of JOURNEY_STEPS) {
+      expect(persona.stepIntents[step]).toBeTruthy();
+      expect(typeof persona.stepIntents[step]).toBe('string');
+    }
+    // Intents are grounded in the persona's actual goals/pain points, not generic filler.
+    expect(persona.stepIntents.land).toContain('Wasting time on ideas nobody wants');
+    expect(persona.stepIntents.signup).toContain('Validate product-market fit quickly');
+  });
+});
+
+describe('generatePersonaFromArtifact() — TS-2', () => {
+  it('throws when the artifact has no personas — never fabricates one from nothing', () => {
+    expect(() => generatePersonaFromArtifact({ personas: [] })).toThrow(/refusing to fabricate/);
+  });
+
+  it('throws when the artifact is null (identity_persona_brand missing entirely)', () => {
+    expect(() => generatePersonaFromArtifact(null)).toThrow(/refusing to fabricate/);
+  });
+
+  it('throws when the first persona has no name', () => {
+    expect(() => generatePersonaFromArtifact({ personas: [{ goals: ['x'] }] })).toThrow(/missing a name/);
+  });
+});


### PR DESCRIPTION
## Summary
- Child E (fast-follow) of the Post-Build Artifact Reconciliation Gate orchestrator (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001), scoped and created during Child C's own LEAD phase after the chairman upgraded synthetic-persona live-UI journey walks to a required adherence-scoring evidence layer mid-flight.
- `lib/eva/persona-generator.js`: generates an executable persona (scripted per-journey-step intent) from the existing `identity_persona_brand` planning artifact — descriptive-only today, never previously executed.
- `lib/eva/journey-walk-driver.js`: drives a locally-served MarketLens checkout through land → signup → submit → results → feedback with Playwright. Routes/selectors read directly from the real MarketLens repo, not invented.
- `lib/eva/journey-evidence-merge.js`: folds journey outcomes into Child B's **existing** `post_build_verdicts` rows (read-then-append, monotonic disposition upgrade only) — deliberately does **not** invent a 5th rubric dimension, since Child A's `adherence_rubrics` registry is frozen/chairman-ratified with exactly 4.
- **Live-verified** against the real local MarketLens checkout (port 3099, avoiding the fleet's own daemon on 3001) with actual Playwright — caught and fixed 3 real bugs no unit test would have found: an async-DOM race in the signup confirmation, a button-selector collision (`Sign out` vs `Generate`), and a context-merge bug that clobbered `submissionId` across steps.

## Test plan
- [x] 16/16 new unit tests pass (`persona-generator`, `journey-walk-driver`, `journey-evidence-merge`)
- [x] 79/79 sibling Child A/B/C tests pass — 0 regressions
- [x] ESLint clean on all 6 touched files
- [x] TESTING sub-agent: CONDITIONAL_PASS (90 confidence) — unit tests cover logic with mocked Playwright; genuine live-browser verification was done manually against the real external MarketLens app (not repeatable in CI without that app running)
- [x] Full live journey walk (all 5 steps) executed successfully end-to-end against the real MarketLens app after the 3 fixes above