### PR TITLE
fix(SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-E): wire-check exemption for journey-walk evidence layer

### DIFF
--- a/lib/eva/journey-evidence-merge.js
+++ b/lib/eva/journey-evidence-merge.js
@@ -8,12 +8,18 @@
  * claim-level rows on every invocation, and upsertVerdict() overwrites (no
  * append, no provenance). This module MUST run strictly AFTER Child B's walk
  * completes and BEFORE Child C's convergence loop scores, within the same
- * S19-exit pipeline invocation — Child D's integrator is the intended caller;
- * this module enforces the ordering via a required `walkCompletedAt` marker
- * rather than assuming callers get it right.
+ * S19-exit pipeline invocation. Child D (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-D,
+ * "S19->S20 Gate Wiring") shipped ahead of this SD and wires Child C's convergence
+ * loop only — it does not call this evidence layer, so the intended caller is a
+ * still-pending follow-up wiring step; this module enforces the ordering via a
+ * required `walkCompletedAt` marker rather than assuming callers get it right.
  *
  * @module lib/eva/journey-evidence-merge
  */
+
+// @wire-check-exempt: Child E library, same status as persona-generator.js and
+// journey-walk-driver.js (same SD) — complete and unit-tested, awaiting a follow-up
+// wiring step as its real caller.
 
 import { upsertVerdict } from './post-build-verdict-engine.js';
 

--- a/lib/eva/journey-walk-driver.js
+++ b/lib/eva/journey-walk-driver.js
@@ -15,6 +15,12 @@
  * @module lib/eva/journey-walk-driver
  */
 
+// @wire-check-exempt: Child E library, same status as persona-generator.js — complete and
+// unit-tested, but its orchestration entry point (a follow-up wiring step that drives
+// startLocalMarketLensServer -> runJourneyWalk -> mergeJourneyEvidence in sequence) has not
+// landed yet. Child D (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-D) shipped without wiring this
+// module in — its scope was Child C's convergence loop only.
+
 import { JOURNEY_STEPS } from './persona-generator.js';
 
 /** MarketLens-specific local-serve config (FR-3). Port/health path/command read

--- a/lib/eva/persona-generator.js
+++ b/lib/eva/persona-generator.js
@@ -11,6 +11,15 @@
  * @module lib/eva/persona-generator
  */
 
+// @wire-check-exempt: Child E library (persona-generator + journey-walk-driver +
+// journey-evidence-merge) landed as a complete, independently-tested evidence-production
+// unit ahead of its orchestration entry point. Child D (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-D,
+// "S19->S20 Gate Wiring") shipped first and wires Child C's convergence loop only -- it does
+// NOT call this journey-walk layer, so it is not yet reachable from any static entry point.
+// A follow-up wiring step (invoking startLocalMarketLensServer -> runJourneyWalk ->
+// mergeJourneyEvidence in sequence, gated the same way Child D gates its own S19 hook) is the
+// intended caller; until it lands this module's only real callers are its own unit tests.
+
 /** The 5 journey steps this SD's proof case walks (MarketLens). */
 export const JOURNEY_STEPS = Object.freeze(['land', 'signup', 'submit', 'results', 'feedback']);
 


### PR DESCRIPTION
## Summary
- Adds `@wire-check-exempt` comments to the 3 new Child E library modules (`lib/eva/persona-generator.js`, `lib/eva/journey-walk-driver.js`, `lib/eva/journey-evidence-merge.js`), which have no static importer yet — same WIRE_CHECK_GATE pattern already fixed for Child C (PR #5587).
- Corrects a stale doc comment in `journey-evidence-merge.js` that named Child D as the intended caller — Child D (PR #5591/#5592) has since shipped and wires Child C's convergence loop only, not this evidence layer. The intended caller is a still-pending follow-up wiring step.

## Test plan
- [x] `npx vitest run --pool=threads tests/unit/eva/{persona-generator,journey-walk-driver,journey-evidence-merge}.test.js` — 16/16 pass
- [x] `npx eslint` on the 3 changed files — clean
- [x] Comment-only change to 3 files; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)