### PR TITLE
fix(QF-20260704-784): exempt gh pr checks from LEARN-129 repeat-guard

### DIFF
--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -74,6 +74,16 @@ const EXEMPT_PATTERNS = [
   // phase/percent progressFingerprint (Control 3), so it needs this allowlist backstop the same
   // way the other mutating-but-idempotent scheduled scripts above do.
   /\bscripts[/\\]apply-migration\.js\b/,
+  // QF-20260704-784: `gh pr checks <PR#> --repo ...` is the fleet's standard CI-wait poll --
+  // documented and used fleet-wide while waiting on slow CI. It returns NON-ZERO while checks
+  // are still pending/running (that IS the expected in-progress signal, not a failure), so the
+  // read-only-classifier's noFailureSignal branch (recordAndCount, below) never applies to it --
+  // a non-zero exit is, by that classifier's design, indistinguishable from a genuine failure.
+  // THREE distinct workers tripped LEARN-129 on this exact command class within 90min while
+  // legitimately waiting on slow CI. Exempt unconditionally, like the other idempotent
+  // scheduled/monitoring commands above -- a genuinely stuck/broken PR is caught by other
+  // signals (claim TTL, coordinator liveness), not this repeat-guard.
+  /\bgh\s+pr\s+checks\b/,
 ];
 
 /**

--- a/tests/unit/retry-state-exempt-gh-pr-checks.test.js
+++ b/tests/unit/retry-state-exempt-gh-pr-checks.test.js
@@ -1,0 +1,52 @@
+/**
+ * QF-20260704-784 — three distinct workers (Alpha, Foxtrot, Echo-3) tripped LEARN-129 on the
+ * exact same command class within ~90min: `gh pr checks <PR#> --repo ...`, the fleet's
+ * documented, standard CI-wait poll. It returns non-zero WHILE checks are pending -- the
+ * expected in-progress state, not a failure -- so the read-only-classifier's exit-0-only
+ * exemption never applies. Backstop: add to EXEMPT_PATTERNS (same precedent as the other
+ * idempotent scheduled/monitoring commands already there).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const { isExempt, recordAndCount } = require('../../scripts/hooks/retry-state-manager.cjs');
+
+describe('isExempt — gh pr checks', () => {
+  it('exempts the standard CI-wait poll regardless of PR number/repo', () => {
+    expect(isExempt('gh pr checks 5593 --repo rickfelix/EHG_Engineer')).toBe(true);
+    expect(isExempt('gh pr checks 1234 --repo rickfelix/ehg')).toBe(true);
+  });
+
+  it('does not exempt an unrelated gh subcommand (scoped match)', () => {
+    expect(isExempt('gh pr list --repo rickfelix/EHG_Engineer')).toBe(false);
+    expect(isExempt('gh pr merge 5593 --squash --admin')).toBe(false);
+    expect(isExempt('gh run view 12345')).toBe(false);
+  });
+});
+
+describe('recordAndCount honors the gh pr checks exemption while CI is pending (non-zero exit)', () => {
+  let tmpDir;
+  const SESSION = 'sess-exempt-gh-pr-checks';
+  const noReset = async () => null;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-exempt-gh-pr-checks-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('polling the SAME PR 4x while checks stay pending (non-zero exit each time) never accumulates -- the Alpha/Foxtrot/Echo-3 repro', async () => {
+    const cmd = 'gh pr checks 5593 --repo rickfelix/EHG_Engineer';
+    for (let i = 0; i < 4; i++) {
+      const lastOutcome = i === 0 ? null : { exit_code: 8, stderr_sha: null };
+      const r = await recordAndCount(SESSION, null, 'Bash', { command: cmd }, { rcaCheck: noReset, now: 1000 + i * 1000, lastOutcome });
+      expect(r.attempts).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Three distinct workers (Alpha, Foxtrot, Echo-3) tripped LEARN-129 within ~90min while legitimately polling `gh pr checks <PR#> --repo ...` — the fleet's documented, standard CI-wait poll.
- Root cause: `gh pr checks` returns non-zero while checks are pending — the expected in-progress signal, not a failure. The existing "succeeding-poll" exemption only fires on exit_code 0, so it never applies here; the structural read-only classifier doesn't help either (`gh` isn't in its recognized verb list, and its own noFailureSignal branch has the same gap).
- Fix: add `gh pr checks` to `EXEMPT_PATTERNS`, the existing unconditional allowlist backstop already used for other idempotent scheduled/monitoring commands.

## Test plan
- [x] New `isExempt` scoping tests (matches `gh pr checks`, not `gh pr list`/`merge`/`gh run view`)
- [x] New `recordAndCount` repro of the exact Alpha/Foxtrot/Echo-3 scenario (polling the same PR 4x with non-zero exit each time never accumulates)
- [x] 18/18 across the new + 3 existing retry-state exemption test files
- [x] Broader retry-state/enforcement suite (55 tests): only pre-existing worktree-hygiene flakes unrelated to this change (different enforcement number, environment-coupled)
- [x] `npm run schema:lint --diff`: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)