### PR TITLE
fix(QF-20260705-395): --from-qf route never honors --migration-reviewed

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -756,7 +756,8 @@ async function createFromQF(qfId, opts = {}) {
       qf_severity: qf.severity,
       qf_estimated_loc: qf.estimated_loc,
       qf_target_application: qf.target_application,
-      ...(opts.securityReviewed ? { security_reviewed: true } : {})
+      ...(opts.securityReviewed ? { security_reviewed: true } : {}),
+      ...(opts.migrationReviewed ? { migration_reviewed: true } : {})
     }
   });
 
@@ -2957,7 +2958,13 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // --child/--from-proposal), so a QF whose DESCRIPTION merely mentions security-
       // adjacent keywords (e.g. "CI DB secrets") isn't unescapably blocked by
       // GR-SECURITY-BASELINE when the actual code change touches no security-sensitive scope.
-      await createFromQF(args[1], { securityReviewed: args.includes('--security-reviewed') });
+      // QF-20260705-395: --migration-reviewed had the identical gap -- a Tier-3 QF whose
+      // description names a real schema migration was unescapably blocked by
+      // GR-MIGRATION-REVIEW, since the flag was silently dropped before reaching createFromQF.
+      await createFromQF(args[1], {
+        securityReviewed: args.includes('--security-reviewed'),
+        migrationReviewed: args.includes('--migration-reviewed'),
+      });
     } else if (args[0] === '--from-proposal') {
       // SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001: materialize PROPOSAL-*.json into DRAFT SDs.
       // path/glob = first non-flag positional after --from-proposal; --dry-run = no writes.

--- a/tests/unit/harness/leo-create-flags-parity.test.js
+++ b/tests/unit/harness/leo-create-flags-parity.test.js
@@ -35,7 +35,7 @@ describe('QF-20260509-LEO-CREATE-FLAGS: review flags sibling parity across creat
     });
 
     it('CLI args parser includes --migration-reviewed / --security-reviewed in fbKnownFlags', () => {
-      const idx = src.indexOf("const fbKnownFlags = new Set");
+      const idx = src.indexOf('const fbKnownFlags = new Set');
       expect(idx).toBeGreaterThan(0);
       const block = src.slice(idx, idx + 200);
       expect(block).toMatch(/--migration-reviewed/);
@@ -65,11 +65,19 @@ describe('QF-20260509-LEO-CREATE-FLAGS: review flags sibling parity across creat
       expect(body).toMatch(/opts\.securityReviewed\s*\?\s*\{\s*security_reviewed:\s*true\s*\}/);
     });
 
-    it('CLI passes args.includes(--security-reviewed) to createFromQF', () => {
+    // QF-20260705-395: --migration-reviewed had the identical sibling-parity gap as
+    // --security-reviewed above -- it was silently dropped before reaching createFromQF.
+    it('createFromQF metadata propagates migration_reviewed=true when the flag is set', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 3000);
+      expect(body).toMatch(/opts\.migrationReviewed\s*\?\s*\{\s*migration_reviewed:\s*true\s*\}/);
+    });
+
+    it('CLI passes args.includes(--security-reviewed) and args.includes(--migration-reviewed) to createFromQF', () => {
       const idx = src.indexOf("args[0] === '--from-qf'");
       expect(idx).toBeGreaterThan(0);
-      const block = src.slice(idx, idx + 900);
-      expect(block).toMatch(/await createFromQF\(args\[1\],\s*\{\s*securityReviewed:\s*args\.includes\(['"]--security-reviewed['"]\)\s*\}\)/);
+      const block = src.slice(idx, idx + 1200);
+      expect(block).toMatch(/await createFromQF\(args\[1\],\s*\{\s*securityReviewed:\s*args\.includes\(['"]--security-reviewed['"]\),\s*migrationReviewed:\s*args\.includes\(['"]--migration-reviewed['"]\),?\s*\}\)/);
     });
   });
 

--- a/tests/unit/leo-create-sd-from-qf-migration-reviewed.test.js
+++ b/tests/unit/leo-create-sd-from-qf-migration-reviewed.test.js
@@ -1,0 +1,47 @@
+// QF-20260705-395
+//
+// Regression-pin: `leo-create-sd.js --from-qf <id> --migration-reviewed` must actually
+// thread migrationReviewed through to createFromQF()'s metadata, mirroring the existing
+// --security-reviewed handling on the same route (fixed once already under QF-20260701-833).
+//
+// Bug (confirmed by direct source read before this fix): the `--from-qf` CLI branch called
+// `createFromQF(args[1], { securityReviewed: args.includes('--security-reviewed') })` --
+// migrationReviewed was never passed at all -- and createFromQF's own metadata builder had
+// no `opts.migrationReviewed` handling either. A Tier-3 QF whose description named a real
+// schema migration was therefore unescapably blocked by GR-MIGRATION-REVIEW even when
+// `--migration-reviewed` was passed on the command line.
+//
+// Test approach: static-source assertions (mirrors leo-create-sd-claim-pin.test.js /
+// leo-create-sd-smoke-detector.test.js patterns) since leo-create-sd.js is a script with no
+// exported functions to import directly.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const SOURCE_PATH = path.resolve(__dirname, '../../scripts/leo-create-sd.js');
+const SOURCE = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+describe('QF-20260705-395: --from-qf route honors --migration-reviewed', () => {
+  it('TS-1: the --from-qf CLI branch parses --migration-reviewed and passes migrationReviewed to createFromQF', () => {
+    const branchMatch = SOURCE.match(
+      /args\[0\] === '--from-qf'\)\s*\{[\s\S]*?await createFromQF\(args\[1\],\s*\{([\s\S]*?)\}\);/
+    );
+    expect(branchMatch).not.toBeNull();
+    const optionsBody = branchMatch[1];
+    expect(optionsBody).toMatch(/securityReviewed:\s*args\.includes\('--security-reviewed'\)/);
+    expect(optionsBody).toMatch(/migrationReviewed:\s*args\.includes\('--migration-reviewed'\)/);
+  });
+
+  it('TS-2: createFromQF\'s metadata builder spreads migration_reviewed=true when opts.migrationReviewed is set', () => {
+    const metadataMatch = SOURCE.match(
+      /qf_target_application:\s*qf\.target_application,\s*\n\s*\.\.\.\(opts\.securityReviewed[\s\S]*?\n\s*\}\s*\n\s*\}\);/
+    );
+    expect(metadataMatch).not.toBeNull();
+    const block = metadataMatch[0];
+    expect(block).toMatch(/\.\.\.\(opts\.securityReviewed \? \{ security_reviewed: true \} : \{\}\)/);
+    expect(block).toMatch(/\.\.\.\(opts\.migrationReviewed \? \{ migration_reviewed: true \} : \{\}\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- The `--from-qf` CLI branch in `scripts/leo-create-sd.js` never threaded `migrationReviewed` through to `createFromQF()`, and `createFromQF()`'s metadata builder had no handling for it either — unlike the sibling `security_reviewed` handling already fixed for this exact route under QF-20260701-833.
- A Tier-3 QF whose description names a real schema migration was therefore unescapably blocked by GR-MIGRATION-REVIEW even when `--migration-reviewed` was passed on the command line (discovered while escalating QF-20260704-216).
- Fix: pass `migrationReviewed: args.includes('--migration-reviewed')` at the call site, and spread `migration_reviewed: true` into metadata when set, mirroring the existing `security_reviewed` pattern exactly.

## Test plan
- [x] New regression test `tests/unit/leo-create-sd-from-qf-migration-reviewed.test.js` (static-source-pin pattern, matches existing `leo-create-sd-claim-pin.test.js` style since this file has no exported functions)
- [x] Existing `leo-create-sd-claim-pin.test.js` + `leo-create-sd-proposal-review-flags.test.js` still pass (27/27)
- [x] `npm run schema:lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)