### PR TITLE
feat(SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001): pending-age resurface + tail-inheritance + deferral discipline on the Solomon advice ledger

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-D",
-  "expectedBranch": "feat/SD-LEO-INFRA-POST-BUILD-ARTIFACT-001-D",
-  "createdAt": "2026-07-05T05:00:29.822Z",
+  "sdKey": "SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001",
+  "expectedBranch": "feat/SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001",
+  "createdAt": "2026-07-05T07:41:24.764Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260705_solomon_ledger_tail_and_deferral.sql
+++ b/database/migrations/20260705_solomon_ledger_tail_and_deferral.sql
@@ -1,0 +1,37 @@
+-- solomon_advice_outcome_ledger tail-inheritance + deferral-discipline columns.
+-- SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001 (escalated from QF-20260704-598).
+-- Chairman directive 2026-07-04 ("when Solomon speaks, we should listen"): multi-part
+-- advisories currently have no mechanism keeping sub-recommendations from rotting once the
+-- primary part is stamped, and a 'deferred' decision has no accountability mechanism forcing
+-- it to ever be re-examined. Purely additive (2 new nullable columns + one widened CHECK on
+-- an existing enum-like column) -- no existing column altered or dropped, every pre-existing
+-- row keeps its current decision value and gets NULL for both new columns.
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. This table's existing migrations all carry an
+-- @approved-by tag (chairman-apply-gated DDL convention); this file intentionally omits
+-- that tag until the chairman explicitly applies it (see check-migration-readiness.mjs's
+-- documented "staged, pending explicit chairman GO" pattern). Application code that depends
+-- on these columns (coordinator-ack-adam.cjs's tail-inheritance + deferral-trigger rejection)
+-- degrades safely if this migration has not yet been applied (columns simply won't exist yet,
+-- and the calling code paths are exercised only via unit tests with a mocked DB until then).
+--
+-- requires-chairman-apply
+
+ALTER TABLE solomon_advice_outcome_ledger
+  ADD COLUMN IF NOT EXISTS parent_correlation_id text,
+  ADD COLUMN IF NOT EXISTS defer_trigger text;
+
+CREATE INDEX IF NOT EXISTS idx_solomon_ledger_parent_correlation
+  ON solomon_advice_outcome_ledger (parent_correlation_id)
+  WHERE parent_correlation_id IS NOT NULL;
+
+ALTER TABLE solomon_advice_outcome_ledger DROP CONSTRAINT IF EXISTS solomon_advice_outcome_ledger_decision_check;
+ALTER TABLE solomon_advice_outcome_ledger ADD CONSTRAINT solomon_advice_outcome_ledger_decision_check
+  CHECK (decision IN ('pending', 'accepted', 'rejected', 'partial', 'deferred'));
+
+ALTER TABLE solomon_advice_outcome_ledger DROP CONSTRAINT IF EXISTS solomon_advice_outcome_ledger_defer_trigger_required;
+ALTER TABLE solomon_advice_outcome_ledger ADD CONSTRAINT solomon_advice_outcome_ledger_defer_trigger_required
+  CHECK (decision != 'deferred' OR defer_trigger IS NOT NULL);
+
+COMMENT ON COLUMN solomon_advice_outcome_ledger.parent_correlation_id IS 'When set, this row is a "tail" of the advisory whose correlation_id equals this value -- stamping the primary auto-inherits its decision onto all matching tail rows (coordinator-ack-adam.cjs recordLedgerDecision). NULL for a standalone/primary advisory. SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001.';
+COMMENT ON COLUMN solomon_advice_outcome_ledger.defer_trigger IS 'Required (DB-enforced) whenever decision=''deferred'' -- names the concrete re-fire event that will force this deferral back into review. NULL for every other decision value. SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001.';

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -11,16 +11,29 @@
  * invented payload.kind. The --reply leg is gated behind COORDINATOR_TWOWAY_V2=on; the
  * ack-stamp works regardless.
  *
- * `--disposition <accepted|rejected|partial>` records the coordinator's/chairman's decision on the
- * advisory into solomon_advice_outcome_ledger (SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001,
- * FR-3), keyed on the advisory's payload.correlation_id (or the explicit --correlation-id override).
+ * `--disposition <accepted|rejected|partial|deferred>` records the coordinator's/chairman's decision
+ * on the advisory into solomon_advice_outcome_ledger (SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001,
+ * FR-3; 'deferred' + tail-inheritance added by SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001),
+ * keyed on the advisory's payload.correlation_id (or the explicit --correlation-id override).
  * Idempotent (ON CONFLICT correlation_id DO UPDATE — re-running never duplicates a row). Fail-open:
  * a ledger write failure is logged but never blocks the advisory ack/retire above.
+ *
+ * `--disposition deferred` REQUIRES `--defer-trigger "<named re-fire event>"` — a deferral without a
+ * named trigger is rejected before any DB write (the DB's own CHECK constraint is a second line of
+ * defense once database/migrations/20260705_solomon_ledger_tail_and_deferral.sql is chairman-applied).
+ *
+ * TAIL-INHERITANCE (SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001, FR-4): after a primary row's
+ * decision is stamped, any still-pending rows whose parent_correlation_id references this
+ * correlation_id inherit the identical decision/decision_by/decision_at — closes the class where a
+ * multi-part advisory's sub-recommendations rotted at 'pending' forever once only the first part
+ * was ever stamped. Requires the FR-3 migration to be chairman-applied; degrades to a no-op tail
+ * count (never an error) if the parent_correlation_id column does not exist yet.
  *
  * Usage:
  *   node scripts/coordinator-ack-adam.cjs --advisory <id>
  *   node scripts/coordinator-ack-adam.cjs --advisory <id> --reply "<reply body>"
  *   node scripts/coordinator-ack-adam.cjs --advisory <id> --disposition accepted [--correlation-id <id>]
+ *   node scripts/coordinator-ack-adam.cjs --advisory <id> --disposition deferred --defer-trigger "next chairman weekly review"
  */
 require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
@@ -30,32 +43,57 @@ const { fetchAdvisory, stampActioned } = require('../lib/coordinator/adam-adviso
 const { sendCoordinatorReply } = require('./coordinator-reply.cjs');
 const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = require('../lib/coordinator/adam-identity.cjs');
 
-const VALID_DISPOSITIONS = Object.freeze(['accepted', 'rejected', 'partial']);
+const VALID_DISPOSITIONS = Object.freeze(['accepted', 'rejected', 'partial', 'deferred']);
+
+/**
+ * Fail-open: stamp the identical decision onto any still-pending tail rows referencing
+ * `correlationId` via parent_correlation_id. Never throws — returns the count inherited (0 on any
+ * error, including "column does not exist yet" for a not-yet-chairman-applied migration).
+ */
+async function inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt }) {
+  try {
+    const { data, error } = await supabase
+      .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
+      .update({ decision: disposition, decision_by: decidedBy || null, decision_at: decisionAt })
+      .eq('parent_correlation_id', correlationId)
+      .eq('decision', 'pending')
+      .select('id');
+    if (error) return { inherited: 0, reason: error.message };
+    return { inherited: (data || []).length };
+  } catch (e) {
+    return { inherited: 0, reason: (e && e.message) || String(e) };
+  }
+}
 
 /**
  * Fail-open: record a coordinator/chairman decision into solomon_advice_outcome_ledger, keyed on
- * correlation_id (idempotent upsert). Never throws — returns { recorded, reason }. Exported for tests.
+ * correlation_id (idempotent upsert), then inherit that same decision onto any pending tail rows
+ * (FR-4). Never throws — returns { recorded, reason, tailsInherited }. Exported for tests.
  */
-async function recordLedgerDecision(supabase, { correlationId, disposition, decidedBy }) {
+async function recordLedgerDecision(supabase, { correlationId, disposition, decidedBy, deferTrigger }) {
   if (!correlationId) return { recorded: false, reason: 'no correlation_id' };
   if (!VALID_DISPOSITIONS.includes(disposition)) return { recorded: false, reason: `invalid disposition: ${disposition}` };
+  if (disposition === 'deferred' && !deferTrigger) {
+    return { recorded: false, reason: 'disposition=deferred requires --defer-trigger (a named re-fire event)' };
+  }
+  const decisionAt = new Date().toISOString();
   try {
+    const row = {
+      correlation_id: correlationId,
+      decision: disposition,
+      decision_by: decidedBy || null,
+      decision_at: decisionAt,
+    };
+    if (disposition === 'deferred') row.defer_trigger = deferTrigger;
     const { error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
-      .upsert(
-        {
-          correlation_id: correlationId,
-          decision: disposition,
-          decision_by: decidedBy || null,
-          decision_at: new Date().toISOString(),
-        },
-        { onConflict: 'correlation_id' }
-      );
+      .upsert(row, { onConflict: 'correlation_id' });
     if (error) return { recorded: false, reason: error.message };
-    return { recorded: true };
   } catch (e) {
     return { recorded: false, reason: (e && e.message) || String(e) };
   }
+  const { inherited: tailsInherited } = await inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt });
+  return { recorded: true, tailsInherited };
 }
 
 function parseArgs(argv) {
@@ -111,11 +149,13 @@ async function main() {
     const correlationId = typeof flags['correlation-id'] === 'string'
       ? flags['correlation-id']
       : (adv.payload && adv.payload.correlation_id);
-    const result = await recordLedgerDecision(supabase, { correlationId, disposition, decidedBy: coordinatorSession });
+    const deferTrigger = typeof flags['defer-trigger'] === 'string' ? flags['defer-trigger'] : null;
+    const result = await recordLedgerDecision(supabase, { correlationId, disposition, decidedBy: coordinatorSession, deferTrigger });
     if (result.recorded) {
       console.log('✓ Ledger decision recorded');
       console.log('  correlation_id:', correlationId);
       console.log('  decision:', disposition);
+      if (result.tailsInherited > 0) console.log('  tails inherited:', result.tailsInherited);
     } else {
       console.warn(`⚠ Ledger decision NOT recorded (advisory still actioned): ${result.reason}`);
     }
@@ -152,7 +192,7 @@ async function main() {
   }
 }
 
-module.exports = { parseArgs, recordLedgerDecision, VALID_DISPOSITIONS };
+module.exports = { parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -50,11 +50,15 @@ const VALID_DISPOSITIONS = Object.freeze(['accepted', 'rejected', 'partial', 'de
  * `correlationId` via parent_correlation_id. Never throws — returns the count inherited (0 on any
  * error, including "column does not exist yet" for a not-yet-chairman-applied migration).
  */
-async function inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt }) {
+async function inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger }) {
   try {
+    const patch = { decision: disposition, decision_by: decidedBy || null, decision_at: decisionAt };
+    // A deferred primary's tails must carry the SAME defer_trigger, or the DB's
+    // defer_trigger_required CHECK would reject the tail update once the migration is applied.
+    if (disposition === 'deferred') patch.defer_trigger = deferTrigger;
     const { data, error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
-      .update({ decision: disposition, decision_by: decidedBy || null, decision_at: decisionAt })
+      .update(patch)
       .eq('parent_correlation_id', correlationId)
       .eq('decision', 'pending')
       .select('id');
@@ -92,7 +96,7 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
   } catch (e) {
     return { recorded: false, reason: (e && e.message) || String(e) };
   }
-  const { inherited: tailsInherited } = await inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt });
+  const { inherited: tailsInherited } = await inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger });
   return { recorded: true, tailsInherited };
 }
 

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1493,19 +1493,41 @@ async function printSolomonInbox() {
   console.log('');
 }
 
-// ── Section: Solomon advice-outcome rollup (SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001, FR-5) ──
+// ── Section: Solomon advice-outcome rollup (SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001, FR-5;
+//    pending-visibility extended QF-20260704-598 — decay was invisible until a decided row existed) ──
 // Read-only accuracy + cost-per-accepted-proposal rollup over solomon_advice_outcome_ledger. Pending
 // (undecided) rows are excluded from the accuracy denominator so an in-flight advisory never counts
 // as a failure. Dormant-safe: an absent table or empty ledger renders "(no data yet)" rather than
 // crashing or dividing by zero.
 /**
- * Pure: compute the accuracy + cost-per-accepted-proposal rollup from raw ledger rows.
- * Pending (undecided) rows are excluded from the accuracy denominator. Returns null when there is
- * no decided data yet (renderer prints "no data yet" rather than dividing by zero). Exported for tests.
+ * Pure: compute the accuracy + cost-per-accepted-proposal rollup from raw ledger rows, plus
+ * pending-count + oldest-pending-age (QF-20260704-598 — pending decay was archaeology-only before
+ * this, since the old contract returned null whenever there were zero DECIDED rows, hiding an
+ * all-pending ledger from the dashboard entirely). Returns null only when there are literally zero
+ * ledger rows at all; an all-pending ledger now returns decidedCount=0 with pending fields populated
+ * so decay is visible from day one. Exported for tests.
  */
-function computeSolomonLedgerRollup(rows) {
-  const decided = (rows || []).filter((r) => r.decision && r.decision !== 'pending');
-  if (decided.length === 0) return null;
+function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
+  const all = rows || [];
+  if (all.length === 0) return null;
+
+  const decided = all.filter((r) => r.decision && r.decision !== 'pending');
+  const pending = all.filter((r) => !r.decision || r.decision === 'pending');
+  const oldestPendingAgeMs = pending.length > 0
+    ? Math.max(...pending.map((r) => nowMs - new Date(r.created_at).getTime()))
+    : null;
+
+  if (decided.length === 0) {
+    return {
+      decidedCount: 0,
+      pendingCount: pending.length,
+      oldestPendingAgeMs,
+      acceptedShippedClean: 0,
+      accuracyPct: null,
+      acceptedCount: 0,
+      costPerAccepted: null,
+    };
+  }
 
   const acceptedShippedClean = decided.filter((r) => r.decision === 'accepted' && r.outcome === 'shipped_clean').length;
   const accuracyPct = Math.round((acceptedShippedClean / decided.length) * 100);
@@ -1516,7 +1538,8 @@ function computeSolomonLedgerRollup(rows) {
 
   return {
     decidedCount: decided.length,
-    pendingCount: (rows || []).length - decided.length,
+    pendingCount: pending.length,
+    oldestPendingAgeMs,
     acceptedShippedClean,
     accuracyPct,
     acceptedCount: accepted.length,
@@ -1532,7 +1555,7 @@ async function printSolomonLedgerRollup() {
   try {
     const { data, error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
-      .select('decision, outcome, cost_tokens')
+      .select('decision, outcome, cost_tokens, created_at')
       .limit(5000);
     if (error) {
       console.log('  (ledger query failed: ' + error.message + ')');
@@ -1553,7 +1576,16 @@ async function printSolomonLedgerRollup() {
     return;
   }
 
-  console.log('  ' + rollup.decidedCount + ' decided proposal(s) (' + rollup.pendingCount + ' pending, excluded)');
+  const oldestPendingStr = rollup.oldestPendingAgeMs !== null
+    ? Math.floor(rollup.oldestPendingAgeMs / (60 * 60 * 1000)) + 'h'
+    : 'n/a';
+  if (rollup.decidedCount === 0) {
+    console.log('  0 decided proposal(s) yet (' + rollup.pendingCount + ' pending, oldest ' + oldestPendingStr + ')');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + rollup.decidedCount + ' decided proposal(s) (' + rollup.pendingCount + ' pending, oldest ' + oldestPendingStr + ')');
   console.log('  accuracy: ' + rollup.accuracyPct + '% (' + rollup.acceptedShippedClean + '/' + rollup.decidedCount + ' accepted+shipped_clean)');
   console.log('  cost-per-accepted-proposal: ' + (rollup.costPerAccepted !== null ? rollup.costPerAccepted + ' tokens' : 'n/a (0 accepted)'));
   console.log('');

--- a/scripts/solomon-ledger-pending-resurface.cjs
+++ b/scripts/solomon-ledger-pending-resurface.cjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * solomon-ledger-pending-resurface.cjs — QF-20260704-598 (chairman directive 2026-07-04:
+ * "when Solomon speaks, we should listen"). solomon_advice_outcome_ledger rows sit at
+ * decision='pending' indefinitely once nothing re-checks them -- live specimen: a >24h-old
+ * pending recommendation only got adopted when a chairman question forced it 3h later.
+ * Read-mostly sweep (mirrors feedback-sla-gauge.cjs's dedup-before-insert discipline): finds
+ * ledger rows pending longer than the threshold and resurfaces each into Adam's inbox at most
+ * once per row per day (payload.dedup_key checked before insert). Stamps nothing on the ledger
+ * row itself -- it stays visible every day until a real decision is recorded.
+ * Usage: node scripts/solomon-ledger-pending-resurface.cjs [--threshold-hours 24]
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
+
+const DEFAULT_THRESHOLD_HOURS = 24;
+
+function parseThresholdHours(argv) {
+  const idx = argv.indexOf('--threshold-hours');
+  const n = idx >= 0 ? Number(argv[idx + 1]) : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_THRESHOLD_HOURS;
+}
+
+/** Pure: today's dedup key for a ledger row's resurface (rate limit: one per row per day). */
+function dedupKeyFor(ledgerId, nowMs) {
+  return `solomon_ledger_pending:${ledgerId}:${new Date(nowMs).toISOString().slice(0, 10)}`;
+}
+
+/** Fetches ledger rows still pending past the threshold (primary-state check — no caching). */
+async function planStalePending(supabase, { thresholdHours = DEFAULT_THRESHOLD_HOURS, nowMs = Date.now() } = {}) {
+  const cutoff = new Date(nowMs - thresholdHours * 60 * 60 * 1000).toISOString();
+  const { data, error } = await supabase
+    .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
+    .select('id, correlation_id, sd_key, proposal_summary, created_at')
+    .eq('decision', 'pending')
+    .lte('created_at', cutoff)
+    .order('created_at', { ascending: true })
+    .limit(50);
+  if (error) throw new Error(`planStalePending query failed: ${error.message}`);
+  return data || [];
+}
+
+/** Rate-limited, deduped daily resurface: at most one inbox row per stale ledger item per day. */
+async function resurfaceStalePending(supabase, adamId, { thresholdHours = DEFAULT_THRESHOLD_HOURS, nowMs = Date.now() } = {}) {
+  const candidates = await planStalePending(supabase, { thresholdHours, nowMs });
+  const resurfaced = [];
+  for (const r of candidates) {
+    const key = dedupKeyFor(r.id, nowMs);
+    const { data: existing } = await supabase.from('session_coordination').select('id')
+      .eq('target_session', adamId).eq('payload->>dedup_key', key).limit(1);
+    if (existing && existing.length) {
+      console.log(`[solomon-ledger-pending-resurface] ${r.id} already resurfaced today (${key}) — skipping`);
+      continue;
+    }
+    const ageHours = Math.floor((nowMs - new Date(r.created_at).getTime()) / (60 * 60 * 1000));
+    const { error } = await supabase.from('session_coordination').insert({
+      sender_session: null,
+      sender_type: 'sweep',
+      target_session: adamId,
+      message_type: 'INFO',
+      subject: `[SOLOMON_LEDGER_PENDING] aged ${ageHours}h: ${(r.proposal_summary || '').slice(0, 80)}`,
+      body: (r.proposal_summary || '').slice(0, 500),
+      payload: { kind: 'solomon_ledger_pending_resurface', dedup_key: key, ledger_id: r.id, correlation_id: r.correlation_id, sd_key: r.sd_key, age_hours: ageHours },
+    });
+    console.log(`[solomon-ledger-pending-resurface] ${error ? 'FAILED to resurface' : 'resurfaced'} ${r.id} age=${ageHours}h`);
+    if (!error) resurfaced.push(r.id);
+  }
+  return { candidates, resurfaced };
+}
+
+async function main() {
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+  const adamId = await getActiveAdamId(supabase);
+  if (!adamId) { console.log('SOLOMON LEDGER PENDING RESURFACE: no active Adam session found — nothing to resurface into.'); return; }
+  const thresholdHours = parseThresholdHours(process.argv.slice(2));
+  const { candidates, resurfaced } = await resurfaceStalePending(supabase, adamId, { thresholdHours });
+  console.log(`SOLOMON LEDGER PENDING RESURFACE — ${candidates.length} candidate(s) pending >${thresholdHours}h, ${resurfaced.length} newly resurfaced`);
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}
+
+module.exports = { parseThresholdHours, dedupKeyFor, planStalePending, resurfaceStalePending, DEFAULT_THRESHOLD_HOURS };

--- a/tests/unit/coordinator-ack-adam-disposition.test.js
+++ b/tests/unit/coordinator-ack-adam-disposition.test.js
@@ -96,6 +96,14 @@ describe('FR-4: recordLedgerDecision — tail-inheritance', () => {
     expect(result.recorded).toBe(true); // primary write still succeeds
     expect(result.tailsInherited).toBe(0);
   });
+
+  it('TESTING-OBS-1 fix: a deferred primary propagates its defer_trigger onto inherited tails (never a bare deferred with no trigger)', async () => {
+    const sb = makeStubSupabase({ updatedTailIds: ['tail-1'] });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'deferred', deferTrigger: 'next chairman weekly review' });
+    expect(result.tailsInherited).toBe(1);
+    expect(sb._updates[0].patch.decision).toBe('deferred');
+    expect(sb._updates[0].patch.defer_trigger).toBe('next chairman weekly review');
+  });
 });
 
 describe('FR-6: recordLedgerDecision — deferral-discipline enforcement', () => {

--- a/tests/unit/coordinator-ack-adam-disposition.test.js
+++ b/tests/unit/coordinator-ack-adam-disposition.test.js
@@ -1,34 +1,50 @@
 /**
  * SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-3, TS-3) — coordinator-ack-adam.cjs
  * --disposition support: idempotent decision recording into solomon_advice_outcome_ledger.
- * Injected-stub coverage (no real DB).
+ * Tail-inheritance (FR-4) and deferral-discipline (FR-6) added by
+ * SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001. Injected-stub coverage (no real DB).
  */
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const m = require('../../scripts/coordinator-ack-adam.cjs');
 
+/** Mock supabase supporting upsert (primary row) + update (tail-inheritance). */
+function makeStubSupabase({ upsertError = null, updateError = null, updatedTailIds = [] } = {}) {
+  const upserts = [];
+  const updates = [];
+  return {
+    _upserts: upserts,
+    _updates: updates,
+    from: () => ({
+      upsert: (row, opts) => { upserts.push({ row, opts }); return Promise.resolve({ error: upsertError }); },
+      update: (patch) => ({
+        eq: (col1, val1) => ({
+          eq: (col2, val2) => ({
+            select: () => {
+              updates.push({ patch, col1, val1, col2, val2 });
+              return Promise.resolve({ data: updateError ? null : updatedTailIds.map((id) => ({ id })), error: updateError });
+            },
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
 describe('FR-3: recordLedgerDecision — idempotent decision update', () => {
   it('TS-3: upserts decision/decision_by/decision_at keyed on correlation_id (ON CONFLICT DO UPDATE)', async () => {
-    const calls = [];
-    const sb = {
-      from: () => ({
-        upsert: (row, opts) => {
-          calls.push({ row, opts });
-          return Promise.resolve({ error: null });
-        },
-      }),
-    };
+    const sb = makeStubSupabase();
     const r1 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x' });
     const r2 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x' });
     expect(r1.recorded).toBe(true);
     expect(r2.recorded).toBe(true);
-    expect(calls).toHaveLength(2); // two upsert calls, both keyed on the SAME correlation_id (idempotent — never a second row)
-    expect(calls[0].row.correlation_id).toBe('corr-1');
-    expect(calls[0].row.decision).toBe('accepted');
-    expect(calls[0].row.decision_by).toBe('session-x');
-    expect(calls[0].opts.onConflict).toBe('correlation_id');
-    expect(calls[1].row.correlation_id).toBe(calls[0].row.correlation_id);
+    expect(sb._upserts).toHaveLength(2); // two upsert calls, both keyed on the SAME correlation_id (idempotent — never a second row)
+    expect(sb._upserts[0].row.correlation_id).toBe('corr-1');
+    expect(sb._upserts[0].row.decision).toBe('accepted');
+    expect(sb._upserts[0].row.decision_by).toBe('session-x');
+    expect(sb._upserts[0].opts.onConflict).toBe('correlation_id');
+    expect(sb._upserts[1].row.correlation_id).toBe(sb._upserts[0].row.correlation_id);
   });
 
   it('rejects an invalid disposition without touching the DB', async () => {
@@ -36,11 +52,11 @@ describe('FR-3: recordLedgerDecision — idempotent decision update', () => {
     const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'maybe' });
     expect(result.recorded).toBe(false);
     expect(result.reason).toMatch(/invalid disposition/);
-    expect(m.VALID_DISPOSITIONS).toEqual(['accepted', 'rejected', 'partial']);
+    expect(m.VALID_DISPOSITIONS).toEqual(['accepted', 'rejected', 'partial', 'deferred']);
   });
 
   it('is fail-open on a DB error (never throws)', async () => {
-    const sb = { from: () => ({ upsert: () => Promise.resolve({ error: { message: 'db down' } }) }) };
+    const sb = makeStubSupabase({ upsertError: { message: 'db down' } });
     const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'rejected' });
     expect(result.recorded).toBe(false);
     expect(result.reason).toBe('db down');
@@ -51,5 +67,49 @@ describe('FR-3: recordLedgerDecision — idempotent decision update', () => {
     const result = await m.recordLedgerDecision(sb, { disposition: 'accepted' });
     expect(result.recorded).toBe(false);
     expect(result.reason).toMatch(/correlation_id/);
+  });
+});
+
+describe('FR-4: recordLedgerDecision — tail-inheritance', () => {
+  it('TS-3 (guardrail): stamping a primary auto-inherits the same decision onto matching pending tails', async () => {
+    const sb = makeStubSupabase({ updatedTailIds: ['tail-1', 'tail-2'] });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-primary', disposition: 'accepted', decidedBy: 'session-x' });
+    expect(result.recorded).toBe(true);
+    expect(result.tailsInherited).toBe(2);
+    expect(sb._updates).toHaveLength(1);
+    expect(sb._updates[0].patch.decision).toBe('accepted');
+    expect(sb._updates[0].col1).toBe('parent_correlation_id');
+    expect(sb._updates[0].val1).toBe('corr-primary');
+    expect(sb._updates[0].col2).toBe('decision');
+    expect(sb._updates[0].val2).toBe('pending'); // only pending tails inherit — never downgrades an already-decided tail
+  });
+
+  it('never touches an unrelated tail (no matching parent_correlation_id) — inheritTailDecisions is scoped, not global', async () => {
+    const sb = makeStubSupabase({ updatedTailIds: [] });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-lonely', disposition: 'rejected' });
+    expect(result.tailsInherited).toBe(0);
+  });
+
+  it('degrades to inherited:0 (never throws) when the migration has not been applied yet (column-missing error)', async () => {
+    const sb = makeStubSupabase({ updateError: { message: 'column "parent_correlation_id" does not exist' } });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted' });
+    expect(result.recorded).toBe(true); // primary write still succeeds
+    expect(result.tailsInherited).toBe(0);
+  });
+});
+
+describe('FR-6: recordLedgerDecision — deferral-discipline enforcement', () => {
+  it('TS-4 (guardrail): rejects disposition=deferred with no defer_trigger, before any DB write', async () => {
+    const sb = { from: () => ({ upsert: () => { throw new Error('should not be called'); }, update: () => { throw new Error('should not be called'); } }) };
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'deferred' });
+    expect(result.recorded).toBe(false);
+    expect(result.reason).toMatch(/defer-trigger/);
+  });
+
+  it('accepts disposition=deferred when a defer_trigger is supplied, writing it onto the row', async () => {
+    const sb = makeStubSupabase();
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'deferred', deferTrigger: 'next chairman weekly review' });
+    expect(result.recorded).toBe(true);
+    expect(sb._upserts[0].row.defer_trigger).toBe('next chairman weekly review');
   });
 });

--- a/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
+++ b/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
@@ -2,6 +2,9 @@
  * SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-5, TS-4, TS-5) — the accuracy +
  * cost-per-accepted-proposal rollup over solomon_advice_outcome_ledger. Pure-function coverage
  * (no DB, no console output) against the exported computeSolomonLedgerRollup.
+ * QF-20260704-598 extends TS-5: an all-pending ledger used to render "(no data yet)", hiding
+ * pending decay from the dashboard entirely until the FIRST decision was ever recorded. It now
+ * returns decidedCount=0 with pending fields populated instead of null.
  */
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
@@ -11,9 +14,9 @@ const { computeSolomonLedgerRollup } = require('../../scripts/fleet-dashboard.cj
 describe('FR-5: computeSolomonLedgerRollup', () => {
   it('TS-4: excludes pending rows from the accuracy denominator', () => {
     const rows = [
-      { decision: 'pending', outcome: 'unknown' },
-      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 100 },
-      { decision: 'rejected', outcome: 'unknown' },
+      { decision: 'pending', outcome: 'unknown', created_at: '2026-07-04T00:00:00Z' },
+      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 100, created_at: '2026-07-04T00:00:00Z' },
+      { decision: 'rejected', outcome: 'unknown', created_at: '2026-07-04T00:00:00Z' },
     ];
     const r = computeSolomonLedgerRollup(rows);
     expect(r.decidedCount).toBe(2);       // pending excluded
@@ -22,9 +25,30 @@ describe('FR-5: computeSolomonLedgerRollup', () => {
     expect(r.accuracyPct).toBe(50);       // 1/2
   });
 
-  it('TS-5: returns null (renderer prints "no data yet") when there are zero decided rows', () => {
+  it('TS-5: returns null only when there are literally zero ledger rows', () => {
     expect(computeSolomonLedgerRollup([])).toBeNull();
-    expect(computeSolomonLedgerRollup([{ decision: 'pending', outcome: 'unknown' }])).toBeNull();
+  });
+
+  it('QF-20260704-598: an all-pending ledger returns decidedCount=0 with pending/oldest-age populated (not null)', () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const rows = [
+      { decision: 'pending', outcome: 'unknown', created_at: '2026-07-04T12:00:00Z' }, // 24h old
+      { decision: 'pending', outcome: 'unknown', created_at: '2026-07-03T12:00:00Z' }, // 48h old (oldest)
+    ];
+    const r = computeSolomonLedgerRollup(rows, nowMs);
+    expect(r).not.toBeNull();
+    expect(r.decidedCount).toBe(0);
+    expect(r.pendingCount).toBe(2);
+    expect(r.oldestPendingAgeMs).toBe(48 * 60 * 60 * 1000);
+    expect(r.accuracyPct).toBeNull();
+    expect(r.costPerAccepted).toBeNull();
+  });
+
+  it('QF-20260704-598: oldestPendingAgeMs is null when there are zero pending rows', () => {
+    const rows = [{ decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 10, created_at: '2026-07-04T00:00:00Z' }];
+    const r = computeSolomonLedgerRollup(rows, Date.now());
+    expect(r.pendingCount).toBe(0);
+    expect(r.oldestPendingAgeMs).toBeNull();
   });
 
   it('computes cost-per-accepted-proposal from accepted rows only', () => {

--- a/tests/unit/solomon-ledger-pending-resurface.test.js
+++ b/tests/unit/solomon-ledger-pending-resurface.test.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for scripts/solomon-ledger-pending-resurface.cjs — QF-20260704-598.
+ * Pending Solomon-ledger rows can decay silently past their SLA; this mirrors
+ * feedback-sla-gauge.cjs's dedup-before-insert discipline into Adam's inbox instead.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  dedupKeyFor,
+  planStalePending,
+  resurfaceStalePending,
+} = require('../../scripts/solomon-ledger-pending-resurface.cjs');
+
+const ADAM_ID = 'adam-session-1';
+
+/** Mutable in-memory mock for the 2 tables this module touches. */
+function createMockSupabase({ ledgerRows = [], inboxRows = [] } = {}) {
+  const ledger = [...ledgerRows];
+  const inbox = [...inboxRows];
+  return {
+    from(table) {
+      if (table === 'solomon_advice_outcome_ledger') {
+        return {
+          select: () => ({
+            eq: (col, val) => ({
+              lte: (col2, val2) => ({
+                order: () => ({
+                  limit: async () => ({
+                    data: ledger.filter((r) => r[col] === val && r[col2] <= val2),
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'session_coordination') {
+        return {
+          select: () => ({
+            eq: (col1, val1) => ({
+              eq: (col2, val2) => ({
+                limit: async () => ({
+                  data: inbox.filter((r) => r[col1] === val1 && (r.payload || {}).dedup_key === val2),
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+          insert: async (row) => { inbox.push(row); return { error: null }; },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+    _inbox: inbox,
+  };
+}
+
+describe('dedupKeyFor()', () => {
+  it('is stable for the same ledger row + day, and changes across days', () => {
+    const day1 = new Date('2026-07-04T10:00:00Z').getTime();
+    const day2 = new Date('2026-07-05T10:00:00Z').getTime();
+    expect(dedupKeyFor('ledger-1', day1)).toBe(dedupKeyFor('ledger-1', day1));
+    expect(dedupKeyFor('ledger-1', day1)).not.toBe(dedupKeyFor('ledger-1', day2));
+  });
+});
+
+describe('planStalePending()', () => {
+  it('surfaces only pending rows older than the threshold', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const supabase = createMockSupabase({
+      ledgerRows: [
+        { id: 'l1', decision: 'pending', created_at: '2026-07-04T00:00:00Z' }, // 36h old — stale
+        { id: 'l2', decision: 'pending', created_at: '2026-07-05T11:00:00Z' }, // 1h old — fresh
+        { id: 'l3', decision: 'accepted', created_at: '2026-07-01T00:00:00Z' }, // decided — excluded
+      ],
+    });
+    const rows = await planStalePending(supabase, { thresholdHours: 24, nowMs });
+    expect(rows.map((r) => r.id)).toEqual(['l1']);
+  });
+});
+
+describe('resurfaceStalePending() — daily dedup + no-noise-on-fresh-rows', () => {
+  it('resurfaces a stale pending row into Adams inbox exactly once', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const supabase = createMockSupabase({
+      ledgerRows: [{ id: 'l1', decision: 'pending', correlation_id: 'corr-1', sd_key: null, proposal_summary: 'do the thing', created_at: '2026-07-04T00:00:00Z' }],
+    });
+    const { candidates, resurfaced } = await resurfaceStalePending(supabase, ADAM_ID, { thresholdHours: 24, nowMs });
+    expect(candidates).toHaveLength(1);
+    expect(resurfaced).toEqual(['l1']);
+    expect(supabase._inbox).toHaveLength(1);
+    expect(supabase._inbox[0].target_session).toBe(ADAM_ID);
+    expect(supabase._inbox[0].payload.ledger_id).toBe('l1');
+  });
+
+  it('does not re-resurface the same row on a second run the same day (dedup)', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const supabase = createMockSupabase({
+      ledgerRows: [{ id: 'l1', decision: 'pending', correlation_id: 'corr-1', sd_key: null, proposal_summary: 'do the thing', created_at: '2026-07-04T00:00:00Z' }],
+    });
+    await resurfaceStalePending(supabase, ADAM_ID, { thresholdHours: 24, nowMs });
+    const second = await resurfaceStalePending(supabase, ADAM_ID, { thresholdHours: 24, nowMs: nowMs + 60_000 });
+    expect(second.resurfaced).toEqual([]);
+    expect(supabase._inbox).toHaveLength(1); // no duplicate insert
+  });
+
+  it('produces zero candidates and zero noise when no pending row is stale', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const supabase = createMockSupabase({
+      ledgerRows: [{ id: 'l1', decision: 'pending', correlation_id: 'corr-1', sd_key: null, proposal_summary: 'fresh', created_at: '2026-07-05T11:00:00Z' }],
+    });
+    const { candidates, resurfaced } = await resurfaceStalePending(supabase, ADAM_ID, { thresholdHours: 24, nowMs });
+    expect(candidates).toHaveLength(0);
+    expect(resurfaced).toHaveLength(0);
+    expect(supabase._inbox).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Escalated from QF-20260704-598 (chairman directive 2026-07-04: "when Solomon speaks, we should listen") — the achievable subset already exceeded the 75-LOC quick-fix cap, and the remaining scope requires a schema change (always Tier 3 per CLAUDE.md routing).
- **Pending-age resurface**: new `scripts/solomon-ledger-pending-resurface.cjs` resurfaces stale-pending `solomon_advice_outcome_ledger` rows into Adam's inbox, dedup-keyed once per row per day (mirrors `feedback-sla-gauge.cjs`'s discipline).
- **Dashboard visibility**: `fleet-dashboard.cjs`'s Solomon ledger rollup now surfaces pending-count + oldest-age even when zero rows are decided (previously rendered "no data yet", hiding an all-pending ledger entirely).
- **Tail-inheritance + deferral discipline** (staged, chairman-apply-gated): new migration `20260705_solomon_ledger_tail_and_deferral.sql` adds `parent_correlation_id` + `defer_trigger` columns and widens the `decision` CHECK to include `'deferred'`. `coordinator-ack-adam.cjs`'s `recordLedgerDecision` rejects an untriggered `--disposition deferred` before any write, and auto-inherits a stamped primary's decision (including `defer_trigger`, per a TESTING-sub-agent-found fix) onto matching pending tail rows. The migration is intentionally NOT applied yet — `metadata.requires_chairman_apply=true` is set on the SD; application code fails open (never throws) if the new columns don't exist.

## Test plan
- [x] 53 tests across 7 files pass (16 new + 37 pre-existing regression), 0 regressions
- [x] TESTING sub-agent: CONDITIONAL_PASS (90% confidence) — items 1-2 live-verified against the real ledger schema; items 3-4 fully unit-tested with fail-open degradation confirmed, live E2E legitimately gated behind the deliberate chairman-apply-gated migration
- [x] eslint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)