### PR TITLE
fix(SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001): wire-check entry point for pending-resurface CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coordinator:relay-drain": "node scripts/coordinator-relay-drain.cjs",
     "coordinator:relay-drop-gauge": "node scripts/coordinator-relay-drop-gauge.cjs",
     "coordinator:feedback-sla-gauge": "node scripts/coordinator-feedback-sla-gauge.cjs",
+    "solomon:ledger-pending-resurface": "node scripts/solomon-ledger-pending-resurface.cjs",
     "comms:three-way-drill": "node scripts/three-way-comms-drill.mjs",
     "chairman:directive:issue": "node scripts/issue-chairman-directive.cjs",
     "chairman:directive:ack": "node scripts/ack-chairman-directive.cjs",


### PR DESCRIPTION
## Summary
- WIRE_CHECK_GATE flagged `scripts/solomon-ledger-pending-resurface.cjs` as unreachable — it's a standalone daily-sweep CLI with no static importer by design, same shape as its sibling `scripts/coordinator-feedback-sla-gauge.cjs`.
- Adds the matching npm script entry (`solomon:ledger-pending-resurface`) so the gate's package.json-scripts entry-point discovery finds it.

## Test plan
- [x] package.json remains valid JSON
- [x] Matches the established sibling-script wire-check remediation pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)