### PR TITLE
feat(SD-LEO-FIX-QUICK-FIXES-NEEDS-001): durable time-gated defer for quick_fixes

### DIFF
--- a/database/migrations/20260705_quick_fixes_not_before.sql
+++ b/database/migrations/20260705_quick_fixes_not_before.sql
@@ -1,0 +1,25 @@
+-- Migration: Add not_before to quick_fixes table
+-- Purpose: Durable time-gated defer mechanism. When set, a quick-fix is not
+--          eligible for claim/processing until NOW() >= not_before. Lets the
+--          belt/coordinator snooze a QF without losing it (survives restarts,
+--          unlike an in-memory defer flag).
+-- Created: 2026-07-05
+-- Related: SD-LEO-FIX-QUICK-FIXES-NEEDS-001
+
+BEGIN;
+
+-- Add durable defer-until timestamp (NULL = no defer, immediately eligible)
+ALTER TABLE quick_fixes
+ADD COLUMN IF NOT EXISTS not_before TIMESTAMPTZ;
+
+-- Comment for documentation
+COMMENT ON COLUMN quick_fixes.not_before IS
+  'Durable time-gated defer: when set, the quick-fix is not eligible for claim
+   until NOW() >= not_before. NULL (default) means no defer / immediately
+   eligible. Added an additional WHERE predicate (e.g. not_before IS NULL OR
+   not_before <= NOW()) to claim queries; not an ORDER BY key, so no index.';
+
+COMMIT;
+
+-- Rollback:
+-- ALTER TABLE quick_fixes DROP COLUMN IF EXISTS not_before;

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-05T00:04:52.305Z",
+ "generated_at": "2026-07-05T09:04:06.163Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
  "table_count": 769,
  "view_count": 177,
@@ -479,7 +479,7 @@
   "provider_seat_assignments": "{id,session_id,seat_code,provider,model_id,round_number,created_at}",
   "public_portfolio": "{id,venture_id,sort_order,is_published,created_at,updated_at}",
   "quarantine_meta_qparity20260610": "{source_table,quarantined,captured_at}",
-  "quick_fixes": "{id,title,type,severity,found_during,description,steps_to_reproduce,expected_behavior,actual_behavior,screenshot_path,estimated_loc,actual_loc,files_changed,status,escalated_to_sd_id,escalation_reason,branch_name,commit_sha,pr_url,tests_passing,uat_verified,verified_by,verification_notes,created_at,started_at,completed_at,created_by,target_application,compliance_score,compliance_verdict,compliance_details,routing_tier,routing_threshold_id,claiming_session_id,actual_source_loc,actual_test_loc,force_completed,resolution_sd_id}",
+  "quick_fixes": "{id,title,type,severity,found_during,description,steps_to_reproduce,expected_behavior,actual_behavior,screenshot_path,estimated_loc,actual_loc,files_changed,status,escalated_to_sd_id,escalation_reason,branch_name,commit_sha,pr_url,tests_passing,uat_verified,verified_by,verification_notes,created_at,started_at,completed_at,created_by,target_application,compliance_score,compliance_verdict,compliance_details,routing_tier,routing_threshold_id,claiming_session_id,actual_source_loc,actual_test_loc,force_completed,resolution_sd_id,not_before}",
   "raid_log": "{id,type,title,description,severity_index,status,mitigation_strategy,validation_approach,resolution_details,dependency_sd,dependency_status,category,owner,venture_id,sd_id,prd_id,metadata,created_at,updated_at}",
   "rca_auto_trigger_config": "{id,trigger_type,enabled,rate_limit_per_minute,auto_create_fix_sd,recurrence_threshold,recurrence_window_days,metadata,created_at,updated_at}",
   "rca_learning_records": "{id,rcr_id,features,label,defect_class,preventable,prevention_stage,time_to_detect_hours,time_to_resolve_hours,eva_preference_id,contributed_to_retrospective,created_at,metadata}",

--- a/scripts/defer-quick-fix.js
+++ b/scripts/defer-quick-fix.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+/**
+ * Defer Quick-Fix (durable time-gated defer)
+ * SD-LEO-FIX-QUICK-FIXES-NEEDS-001
+ *
+ * Sets quick_fixes.not_before for a QF so it stops being claimable/auto-startable
+ * until the given timestamp passes -- without hand-written SQL. Both worker-checkin.cjs
+ * self-claim picker paths (via isAutoStartableQF) and the sd:next display surface
+ * (classifyQuickFixes) honor this column.
+ *
+ * Usage:
+ *   node scripts/defer-quick-fix.js QF-20260704-348 --not-before 2026-07-05T21:00:00Z
+ *   node scripts/defer-quick-fix.js QF-20260704-348 --not-before 2026-07-05T21:00:00Z --reopen
+ *
+ * --reopen also sets status='open' on the row (use when re-opening a QF previously
+ * held via status='escalated' as a manual defer workaround).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+dotenv.config();
+
+export function parseDeferArgs(argv) {
+  const args = argv.slice();
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    return { showHelp: true };
+  }
+  const qfId = args[0];
+  let notBefore = null;
+  let reopen = false;
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--not-before') {
+      notBefore = args[i + 1];
+      i++;
+    } else if (args[i] === '--reopen') {
+      reopen = true;
+    }
+  }
+  return { showHelp: false, qfId, notBefore, reopen };
+}
+
+export function validateNotBefore(value) {
+  if (!value) return { valid: false, error: '--not-before <ISO-timestamp> is required' };
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return { valid: false, error: `--not-before: could not parse "${value}" as a timestamp (expected ISO-8601, e.g. 2026-07-05T21:00:00Z)` };
+  }
+  return { valid: true, iso: new Date(parsed).toISOString() };
+}
+
+function displayHelp() {
+  console.log(`
+Defer Quick-Fix — durable time-gated defer (SD-LEO-FIX-QUICK-FIXES-NEEDS-001)
+
+Usage:
+  node scripts/defer-quick-fix.js <QF-ID> --not-before <ISO-timestamp> [--reopen]
+
+Options:
+  --not-before <ts>   Required. ISO-8601 timestamp. The QF is not claimable/
+                      auto-startable by any picker until this time passes.
+  --reopen            Also set status='open' (use when clearing a manual
+                      status='escalated' defer workaround).
+
+Example:
+  node scripts/defer-quick-fix.js QF-20260704-348 --not-before 2026-07-05T21:00:00Z --reopen
+`);
+}
+
+export async function deferQuickFix(qfId, notBefore, { reopen = false, supabaseClient = null } = {}) {
+  const validation = validateNotBefore(notBefore);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  const supabase = supabaseClient || createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const update = { not_before: validation.iso };
+  if (reopen) update.status = 'open';
+
+  const { data, error } = await supabase
+    .from('quick_fixes')
+    .update(update)
+    .eq('id', qfId)
+    .select('id, status, not_before')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to defer ${qfId}: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error(`Quick-fix not found: ${qfId}`);
+  }
+
+  return data;
+}
+
+async function main() {
+  const parsed = parseDeferArgs(process.argv.slice(2));
+  if (parsed.showHelp) {
+    displayHelp();
+    process.exit(0);
+  }
+
+  try {
+    const result = await deferQuickFix(parsed.qfId, parsed.notBefore, { reopen: parsed.reopen });
+    console.log(`✅ ${result.id}: not_before=${result.not_before}, status=${result.status}`);
+    process.exitCode = 0;
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -350,7 +350,7 @@ export async function loadOpenQuickFixes(supabase) {
     // to 'completed'. Filtering on status alone surfaces phantom QFs during the merge window.
     const { data, error } = await supabase
       .from('quick_fixes')
-      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha')
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before')
       .in('status', ['open', 'in_progress'])
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -132,7 +132,13 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
       !qf.commit_sha &&
       ageDays(qf.created_at) >= STALE_QF_DAYS;
 
-    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther, _verifyFirst: verifyFirst };
+    // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer. Mirrors the
+    // isAutoStartableQF() guard in worker-checkin.cjs so a human operator can't
+    // manually claim off this display what the auto-claim pickers already refuse.
+    const notBeforeMs = qf.not_before ? Date.parse(qf.not_before) : NaN;
+    const deferred = Number.isFinite(notBeforeMs) && notBeforeMs > Date.now();
+
+    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther, _verifyFirst: verifyFirst, _deferred: deferred };
   });
 
   classified.sort((a, b) => {
@@ -151,7 +157,7 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
   // => claiming_session_id null, no PR) would otherwise be emitted as AUTO_PROCEED_ACTION:
   // qf_start and auto-started without verify-first. in_progress is either actively owned or
   // orphaned; neither is auto-startable.
-  summary.topStartableQF = classified.find(qf => qf.status === 'open' && !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst) || null;
+  summary.topStartableQF = classified.find(qf => qf.status === 'open' && !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst && !qf._deferred) || null;
 
   return { summary, classified };
 }
@@ -184,10 +190,15 @@ export function renderQFRow(qf, indent = '') {
     const statusBadge = qf.status === 'in_progress' ? `${colors.cyan}WIP${colors.reset} ` : '';
     // QF-20260525-522: surface why a stale QF was held out of auto-start.
     const verifyBadge = qf._verifyFirst ? `${colors.yellow}⚠ VERIFY-FIRST${colors.reset} ` : '';
-    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${verifyBadge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+    // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: surface a durable time-gated defer.
+    const deferBadge = qf._deferred ? `${colors.yellow}⏳ DEFERRED${colors.reset} ` : '';
+    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${verifyBadge}${deferBadge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
     console.log(`${indent}       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
     if (qf._verifyFirst) {
       console.log(`${indent}       ${colors.dim}⚠ open ${ageDays(qf.created_at)}d & unclaimed — may already be resolved by another SD; verify before starting (not auto-routed)${colors.reset}`);
+    }
+    if (qf._deferred) {
+      console.log(`${indent}       ${colors.dim}⏳ gated until ${qf.not_before} — not claimable/auto-startable until then${colors.reset}`);
     }
   }
 }

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -441,6 +441,13 @@ function isAutoStartableQF(qf, nowMs) {
   if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
   if (qf.routing_tier != null && Number(qf.routing_tier) >= 3) return false;  // persisted Tier-3 -> full SD, not auto-QF
   if (TIER3_RISK_RE.test(qf.title || '')) return false;                        // risk-keyword drift -> hold for triage/human
+  // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer -- a QF genuinely not ready
+  // yet (e.g. needs a clean 24h observation window) stays status='open' but is ineligible
+  // for claim until not_before passes. Prevents the same worker re-claiming it every cycle.
+  if (qf.not_before) {
+    const notBefore = Date.parse(qf.not_before);
+    if (Number.isFinite(notBefore) && notBefore > nowMs) return false;
+  }
   const created = qf.created_at ? Date.parse(qf.created_at) : NaN;
   if (!Number.isFinite(created)) return false;
   const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
@@ -461,7 +468,7 @@ async function selfClaimQuickFix(sb, sessionId, base) {
   try {
     const { data: qfs } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity')
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before')
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)
@@ -1519,7 +1526,7 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     try {
       const { data: criticalQfs } = await sb
         .from('quick_fixes')
-        .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity')
+        .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before')
         .eq('status', 'open')
         .eq('severity', 'critical')
         .is('pr_url', null)

--- a/tests/unit/defer-quick-fix.test.js
+++ b/tests/unit/defer-quick-fix.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-FIX-QUICK-FIXES-NEEDS-001: operator-facing not_before setter.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { parseDeferArgs, validateNotBefore, deferQuickFix } from '../../scripts/defer-quick-fix.js';
+
+describe('parseDeferArgs', () => {
+  it('parses QF id, --not-before value, and --reopen flag', () => {
+    const parsed = parseDeferArgs(['QF-X', '--not-before', '2026-07-05T21:00:00Z', '--reopen']);
+    expect(parsed).toEqual({ showHelp: false, qfId: 'QF-X', notBefore: '2026-07-05T21:00:00Z', reopen: true });
+  });
+
+  it('defaults reopen to false when omitted', () => {
+    const parsed = parseDeferArgs(['QF-X', '--not-before', '2026-07-05T21:00:00Z']);
+    expect(parsed.reopen).toBe(false);
+  });
+
+  it('shows help with no args', () => {
+    expect(parseDeferArgs([])).toEqual({ showHelp: true });
+  });
+
+  it('shows help with --help', () => {
+    expect(parseDeferArgs(['--help'])).toEqual({ showHelp: true });
+  });
+});
+
+describe('validateNotBefore', () => {
+  it('accepts a valid ISO-8601 timestamp', () => {
+    const result = validateNotBefore('2026-07-05T21:00:00Z');
+    expect(result.valid).toBe(true);
+    expect(result.iso).toBe('2026-07-05T21:00:00.000Z');
+  });
+
+  it('rejects a missing value', () => {
+    expect(validateNotBefore(null).valid).toBe(false);
+    expect(validateNotBefore(undefined).valid).toBe(false);
+  });
+
+  it('rejects an unparseable string', () => {
+    const result = validateNotBefore('not-a-date');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/could not parse/);
+  });
+});
+
+describe('deferQuickFix', () => {
+  function makeSupabaseStub(returnData, returnError = null) {
+    const update = vi.fn().mockReturnThis();
+    const eq = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({ data: returnData, error: returnError });
+    return {
+      client: { from: () => ({ update, eq, select, single }) },
+      update, eq, select, single,
+    };
+  }
+
+  it('rejects an invalid --not-before before touching the database', async () => {
+    await expect(deferQuickFix('QF-X', 'garbage', {})).rejects.toThrow(/could not parse/);
+  });
+
+  it('updates not_before (and not status) when reopen is not set', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'escalated', not_before: '2026-07-05T21:00:00.000Z' });
+    const result = await deferQuickFix('QF-X', '2026-07-05T21:00:00Z', { supabaseClient: stub.client });
+    expect(stub.update).toHaveBeenCalledWith({ not_before: '2026-07-05T21:00:00.000Z' });
+    expect(result.id).toBe('QF-X');
+  });
+
+  it('updates both not_before and status=open when reopen=true', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', not_before: '2026-07-05T21:00:00.000Z' });
+    await deferQuickFix('QF-X', '2026-07-05T21:00:00Z', { reopen: true, supabaseClient: stub.client });
+    expect(stub.update).toHaveBeenCalledWith({ not_before: '2026-07-05T21:00:00.000Z', status: 'open' });
+  });
+
+  it('throws when the row is not found', async () => {
+    const stub = makeSupabaseStub(null, null);
+    await expect(deferQuickFix('QF-MISSING', '2026-07-05T21:00:00Z', { supabaseClient: stub.client }))
+      .rejects.toThrow(/not found/);
+  });
+
+  it('throws with the Supabase error message on a write failure', async () => {
+    const stub = makeSupabaseStub(null, { message: 'permission denied' });
+    await expect(deferQuickFix('QF-X', '2026-07-05T21:00:00Z', { supabaseClient: stub.client }))
+      .rejects.toThrow(/permission denied/);
+  });
+});

--- a/tests/unit/sd-next/quick-fix-not-before-gate.test.js
+++ b/tests/unit/sd-next/quick-fix-not-before-gate.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit test: durable time-gated defer (not_before) in classifyQuickFixes
+ * SD-LEO-FIX-QUICK-FIXES-NEEDS-001
+ *
+ * A QF with not_before set to a future timestamp is genuinely not ready yet (e.g.
+ * needs a clean 24h observation window). It must be flagged `_deferred` and held
+ * OUT of `topStartableQF` -- mirroring the worker-checkin.cjs isAutoStartableQF()
+ * guard -- so a human operator can't manually claim off the sd:next display what
+ * the auto-claim pickers already refuse (validation-agent finding, LEAD phase).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyQuickFixes } from '../../../scripts/modules/sd-next/display/quick-fixes.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+const hoursFromNow = (n) => new Date(Date.now() + n * HOUR_MS).toISOString();
+
+const qf = (over = {}) => ({
+  id: 'QF-X',
+  title: 'x',
+  type: 'bug',
+  severity: 'medium',
+  status: 'open',
+  estimated_loc: 10,
+  created_at: new Date().toISOString(),
+  claiming_session_id: null,
+  pr_url: null,
+  commit_sha: null,
+  not_before: null,
+  ...over,
+});
+
+describe('QF durable time-gated defer (SD-LEO-FIX-QUICK-FIXES-NEEDS-001)', () => {
+  it('flags a QF with a future not_before as deferred and excludes it from topStartableQF', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-GATED', not_before: hoursFromNow(1) })]);
+    expect(classified[0]._deferred).toBe(true);
+    expect(summary.topStartableQF).toBeNull();
+    expect(summary.topQF).not.toBeNull(); // still visible in the queue
+  });
+
+  it('does NOT flag a QF with a past not_before (gate has passed)', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-CLEARED', not_before: hoursFromNow(-1) })]);
+    expect(classified[0]._deferred).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-CLEARED');
+  });
+
+  it('does NOT flag a QF with not_before null (no regression to pre-existing behavior)', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-PLAIN', not_before: null })]);
+    expect(classified[0]._deferred).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-PLAIN');
+  });
+
+  it('prefers a non-gated QF over a deferred one as the auto-startable pick', () => {
+    const { summary } = classifyQuickFixes([
+      qf({ id: 'QF-GATED', not_before: hoursFromNow(5) }),
+      qf({ id: 'QF-OPEN', not_before: null }),
+    ]);
+    expect(summary.topStartableQF?.id).toBe('QF-OPEN');
+  });
+});

--- a/tests/unit/worker-checkin-qf-not-before.test.js
+++ b/tests/unit/worker-checkin-qf-not-before.test.js
@@ -1,0 +1,75 @@
+/**
+ * SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer for quick_fixes.
+ *
+ * A QF that is genuinely not ready yet (e.g. needs a clean 24h observation window) has
+ * status='open' but not_before set to a future timestamp. isAutoStartableQF() -- shared by
+ * both worker-checkin.cjs self-claim picker paths (selfClaimQuickFix + the critical-QF-jump
+ * path via isCriticalQfJumpEligible) -- must exclude such rows until not_before passes, so
+ * the same worker doesn't get re-assigned it every check-in cycle (QF-20260704-348 thrashed
+ * 2x within ~15 minutes before this fix).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { isAutoStartableQF, isCriticalQfJumpEligible } = require('../../scripts/worker-checkin.cjs');
+
+const NOW = Date.parse('2026-07-05T12:00:00Z');
+const PAST = '2026-07-05T00:00:00Z';
+const FUTURE = '2026-07-05T21:00:00Z';
+
+function qf(overrides = {}) {
+  return {
+    id: 'QF-X',
+    status: 'open',
+    pr_url: null,
+    commit_sha: null,
+    created_at: '2026-07-04T00:00:00Z',
+    routing_tier: null,
+    title: 'x',
+    severity: 'medium',
+    not_before: null,
+    ...overrides,
+  };
+}
+
+describe('isAutoStartableQF — not_before durable time-gated defer', () => {
+  it('excludes a QF with not_before in the future', () => {
+    expect(isAutoStartableQF(qf({ not_before: FUTURE }), NOW)).toBe(false);
+  });
+
+  it('includes a QF with not_before in the past', () => {
+    expect(isAutoStartableQF(qf({ not_before: PAST }), NOW)).toBe(true);
+  });
+
+  it('includes a QF with not_before null (no regression to pre-existing behavior)', () => {
+    expect(isAutoStartableQF(qf({ not_before: null }), NOW)).toBe(true);
+  });
+
+  it('includes a QF with not_before exactly equal to now (gate has passed)', () => {
+    expect(isAutoStartableQF(qf({ not_before: new Date(NOW).toISOString() }), NOW)).toBe(true);
+  });
+
+  it('a malformed not_before value does not crash the predicate (fail-open to other checks)', () => {
+    expect(() => isAutoStartableQF(qf({ not_before: 'not-a-date' }), NOW)).not.toThrow();
+  });
+});
+
+describe('isCriticalQfJumpEligible — inherits the not_before guard via isAutoStartableQF', () => {
+  it('excludes a critical, aged QF gated by a future not_before', () => {
+    const gracedCritical = qf({
+      severity: 'critical',
+      created_at: '2026-07-05T00:00:00Z', // well past the 10min grace window relative to NOW
+      not_before: FUTURE,
+    });
+    expect(isCriticalQfJumpEligible(gracedCritical, NOW)).toBe(false);
+  });
+
+  it('still allows a critical, aged QF with no not_before gate', () => {
+    const gracedCritical = qf({
+      severity: 'critical',
+      created_at: '2026-07-05T00:00:00Z',
+      not_before: null,
+    });
+    expect(isCriticalQfJumpEligible(gracedCritical, NOW)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `quick_fixes` had no durable time-gated defer state: QF-20260704-348 (needs a clean 24h fleet_dormancy window) stayed `status='open'` and got re-claimed by the same worker 2x within ~15 minutes.
- Adds `quick_fixes.not_before` (nullable timestamptz). Both `worker-checkin.cjs` self-claim picker paths (`selfClaimQuickFix` + the critical-QF-jump path) now exclude gated rows via the shared `isAutoStartableQF()` predicate.
- The `sd:next` display surface (`loadOpenQuickFixes` + `classifyQuickFixes`/`renderQFRow`) now badges/excludes `not_before`-gated rows from `topStartableQF`, so a human operator can't manually claim off the queue what the auto-claim pickers already refuse (per validation-agent's LEAD-phase finding).
- New `scripts/defer-quick-fix.js` operator CLI to set `not_before` (and optionally reopen) without hand-written SQL.
- QF-20260704-348 is durably re-opened (`status=open`, `not_before=2026-07-05T21:00:00Z`), replacing the coordinator's manual `escalated`-status workaround.

## Test plan
- [x] New unit tests: `tests/unit/worker-checkin-qf-not-before.test.js`, `tests/unit/sd-next/quick-fix-not-before-gate.test.js`, `tests/unit/defer-quick-fix.test.js`
- [x] Existing worker-checkin / sd-next / QF-classification test suites pass, no regressions
- [x] `npm run schema:lint` clean (snapshot regenerated for the new column)
- [x] Full `tests/unit/` suite run: 7 pre-existing failures (stage-config drift, worktree-hygiene, solomon-consult) confirmed unrelated via `git stash` — identical failures with this change removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)