### PR TITLE
fix(QF-20260705-633): wire remediation writers into convergence gate [HOLD: chairman timing]

### DIFF
--- a/lib/eva/convergence-remediation-writers.js
+++ b/lib/eva/convergence-remediation-writers.js
@@ -1,0 +1,76 @@
+/**
+ * QF-20260705-633: minimal, side-effect-free DB writers for the convergence-loop
+ * remediation router (lib/eva/convergence-loop.js routeRemediation -> fileAdherenceFix).
+ *
+ * The full CLI creation paths (scripts/create-quick-fix.js, scripts/leo-create-sd.js)
+ * are NOT reused directly here: create-quick-fix.js's createQuickFix() also creates a
+ * git branch/worktree as a side effect (unsafe to invoke from an automated gate call
+ * site), and leo-create-sd.js is a large CLI module. These writers do ONLY the DB
+ * insert, via the same canonical helpers (routeWorkItem, generateSDKey, createSD) the
+ * CLIs use internally, so filed items still get correct tiering/key generation.
+ */
+
+import { routeWorkItem } from '../utils/work-item-router.js';
+import { generateSDKey } from '../../scripts/modules/sd-key-generator.js';
+import { createSD, resolveVenturePrefix } from '../../scripts/leo-create-sd.js';
+
+function generateQuickFixId() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const random = String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+  return `QF-${year}${month}${day}-${random}`;
+}
+
+/**
+ * Build a createQuickFixFn for routeRemediation's tier-1/2 path.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {(gap: {title: string, dimension: string}) => Promise<string>}
+ */
+export function createQuickFixWriter(supabase) {
+  return async function createQuickFixFn({ title, dimension }) {
+    const description = `Post-build convergence-gate remediation: adherence gap on dimension "${dimension}". ${title}`;
+    const routingDecision = await routeWorkItem({
+      estimatedLoc: 10, type: 'bug', description, entryPoint: 'convergence-gate-remediation',
+    }, supabase);
+    const qfId = generateQuickFixId();
+    const { error } = await supabase.from('quick_fixes').insert({
+      id: qfId,
+      title,
+      type: 'bug',
+      severity: 'medium',
+      description,
+      target_application: 'EHG',
+      estimated_loc: 10,
+      status: routingDecision.tier === 3 ? 'escalated' : 'open',
+      escalation_reason: routingDecision.tier === 3 ? routingDecision.escalationReason : null,
+      routing_tier: routingDecision.tier,
+      created_at: new Date().toISOString(),
+    });
+    if (error) throw new Error(`[convergence-remediation-writers] createQuickFixFn insert failed: ${error.message}`);
+    return qfId;
+  };
+}
+
+/**
+ * Build a createSdFn for routeRemediation's tier-3 path. No supabase param -- unlike
+ * routeWorkItem, createSD/resolveVenturePrefix instantiate their own internal client.
+ * @returns {(gap: {title: string, dimension: string}) => Promise<string>}
+ */
+export function createSdWriter() {
+  return async function createSdFn({ title, dimension }) {
+    const venturePrefix = await resolveVenturePrefix(null, 'bugfix');
+    const sdKey = await generateSDKey({ source: 'LEO', type: 'bugfix', title, venturePrefix });
+    const sd = await createSD({
+      sdKey,
+      title,
+      description: `Post-build convergence-gate remediation: adherence gap on dimension "${dimension}". ${title}`,
+      type: 'bugfix',
+      priority: 'high',
+      rationale: `Filed by the post-build adherence-scorer convergence loop for a below-floor dimension (${dimension}) that requires more than a quick-fix scope.`,
+      metadata: { source: 'convergence_gate_remediation', dimension },
+    });
+    return sd.sd_key || sdKey;
+  };
+}

--- a/lib/eva/post-build-convergence-gate.js
+++ b/lib/eva/post-build-convergence-gate.js
@@ -12,17 +12,19 @@
  * chairman product-review packet it feeds ("machine diff beside the human taste-test,
  * not a replacement").
  *
- * Remediation callbacks (backfillFn/createQuickFixFn/createSdFn) are deliberately
- * OMITTED in this first wiring pass: routeRemediation/fileAdherenceFix/
- * backfillCompletenessGap already fail-safe on a missing callback (captured into
- * deferred/errors, never silently dropped), so an unremediated gap surfaces via the
- * ESCALATED chairman_decisions flag instead of risking an auto-filed SD/QF against a
- * CLI-only script with no safe importable entry point. Wiring real auto-remediation is
- * an explicit fast-follow, tracked as a completion-flag on this SD.
+ * QF-20260705-633: createQuickFixFn/createSdFn are now wired via
+ * lib/eva/convergence-remediation-writers.js (minimal DB-insert-only writers,
+ * NOT the full CLI creation paths -- those also create git branches/worktrees as a
+ * side effect and have no safe importable entry point). backfillFn for completeness
+ * gaps remains unwired: it needs genuine upstream-artifact-reader design (which
+ * planning document backs which dimension), tracked as a separate follow-up. An
+ * unremediated completeness gap still fails safe into deferred/errors (never
+ * silently dropped) and surfaces via the ESCALATED chairman_decisions flag.
  */
 import { isConvergenceSubject } from './clean-clone/launch.js';
 import { runConvergenceLoop } from './convergence-loop.js';
 import { requestProductReview } from './chairman-product-review.js';
+import { createQuickFixWriter, createSdWriter } from './convergence-remediation-writers.js';
 
 // Shares S20PauseController's venture_stage_work(venture_id, lifecycle_stage=20) row —
 // the summary rides alongside pause_state in the same advisory_data JSONB column.
@@ -112,7 +114,11 @@ export async function runS19ConvergenceGate(supabase, ventureId, opts = {}) {
 
   let loopResult;
   try {
-    loopResult = await runConvergenceLoop(supabase, { ventureId });
+    loopResult = await runConvergenceLoop(supabase, {
+      ventureId,
+      createQuickFixFn: createQuickFixWriter(supabase),
+      createSdFn: createSdWriter(),
+    });
   } catch (e) {
     logger.warn?.(`[PostBuildConvergenceGate] runConvergenceLoop threw (fail-open, non-blocking): ${e.message}`);
     return { applicable: false, reason: 'convergence_loop_error' };

--- a/tests/unit/eva/convergence-remediation-writers.test.js
+++ b/tests/unit/eva/convergence-remediation-writers.test.js
@@ -1,0 +1,86 @@
+/**
+ * QF-20260705-633: minimal DB-insert-only remediation writers for the convergence-loop
+ * router. Verifies createQuickFixWriter/createSdWriter build functions matching the
+ * (gap: {title, dimension}) => Promise<string> contract routeRemediation/fileAdherenceFix
+ * expect, without invoking the heavyweight CLI creation paths (which also create git
+ * branches/worktrees as a side effect).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/utils/work-item-router.js', () => ({
+  routeWorkItem: vi.fn(),
+}));
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn(),
+}));
+vi.mock('../../../scripts/leo-create-sd.js', () => ({
+  createSD: vi.fn(),
+  resolveVenturePrefix: vi.fn(),
+}));
+
+import { routeWorkItem } from '../../../lib/utils/work-item-router.js';
+import { generateSDKey } from '../../../scripts/modules/sd-key-generator.js';
+import { createSD, resolveVenturePrefix } from '../../../scripts/leo-create-sd.js';
+import { createQuickFixWriter, createSdWriter } from '../../../lib/eva/convergence-remediation-writers.js';
+
+function makeSupabaseInsertStub(returnError = null) {
+  const insert = vi.fn().mockResolvedValue({ error: returnError });
+  return { client: { from: () => ({ insert }) }, insert };
+}
+
+describe('createQuickFixWriter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('inserts a tier-1/2 quick_fixes row with status=open when routing tier is not 3', async () => {
+    routeWorkItem.mockResolvedValue({ tier: 2, escalationReason: null });
+    const stub = makeSupabaseInsertStub();
+    const writer = createQuickFixWriter(stub.client);
+
+    const id = await writer({ title: 'Fix X', dimension: 'user-story-coverage' });
+
+    expect(id).toMatch(/^QF-\d{8}-\d{3}$/);
+    const insertedRow = stub.insert.mock.calls[0][0];
+    expect(insertedRow.status).toBe('open');
+    expect(insertedRow.title).toBe('Fix X');
+    expect(insertedRow.description).toMatch(/user-story-coverage/);
+  });
+
+  it('inserts an escalated quick_fixes row when routing tier is 3', async () => {
+    routeWorkItem.mockResolvedValue({ tier: 3, escalationReason: 'too large for a QF' });
+    const stub = makeSupabaseInsertStub();
+    const writer = createQuickFixWriter(stub.client);
+
+    await writer({ title: 'Fix Y', dimension: 'architecture-conformance' });
+
+    const insertedRow = stub.insert.mock.calls[0][0];
+    expect(insertedRow.status).toBe('escalated');
+    expect(insertedRow.escalation_reason).toBe('too large for a QF');
+  });
+
+  it('throws (does not swallow) on an insert error, so routeRemediation records it in errors/deferred', async () => {
+    routeWorkItem.mockResolvedValue({ tier: 2 });
+    const stub = makeSupabaseInsertStub({ message: 'duplicate key' });
+    const writer = createQuickFixWriter(stub.client);
+
+    await expect(writer({ title: 'Fix Z', dimension: 'data-model-fidelity' })).rejects.toThrow(/duplicate key/);
+  });
+});
+
+describe('createSdWriter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('generates a key, creates a bugfix-type draft SD, and returns its sd_key', async () => {
+    resolveVenturePrefix.mockResolvedValue(null);
+    generateSDKey.mockResolvedValue('SD-LEO-FIX-EXAMPLE-001');
+    createSD.mockResolvedValue({ sd_key: 'SD-LEO-FIX-EXAMPLE-001' });
+
+    const writer = createSdWriter();
+    const result = await writer({ title: 'Persona surface missing', dimension: 'persona-surface-coverage' });
+
+    expect(result).toBe('SD-LEO-FIX-EXAMPLE-001');
+    expect(createSD).toHaveBeenCalledTimes(1);
+    const callArg = createSD.mock.calls[0][0];
+    expect(callArg.type).toBe('bugfix');
+    expect(callArg.metadata).toMatchObject({ source: 'convergence_gate_remediation', dimension: 'persona-surface-coverage' });
+  });
+});

--- a/tests/unit/eva/post-build-convergence-gate.test.js
+++ b/tests/unit/eva/post-build-convergence-gate.test.js
@@ -18,6 +18,10 @@ vi.mock('../../../lib/eva/convergence-loop.js', () => ({
 vi.mock('../../../lib/eva/chairman-product-review.js', () => ({
   requestProductReview: vi.fn(),
 }));
+vi.mock('../../../lib/eva/convergence-remediation-writers.js', () => ({
+  createQuickFixWriter: vi.fn(() => 'qf-writer-fn'),
+  createSdWriter: vi.fn(() => 'sd-writer-fn'),
+}));
 
 import {
   isPostBuildConvergenceGateEnabled,
@@ -29,6 +33,7 @@ import {
 import { isConvergenceSubject } from '../../../lib/eva/clean-clone/launch.js';
 import { runConvergenceLoop } from '../../../lib/eva/convergence-loop.js';
 import { requestProductReview } from '../../../lib/eva/chairman-product-review.js';
+import { createQuickFixWriter, createSdWriter } from '../../../lib/eva/convergence-remediation-writers.js';
 
 function createMockLogger() {
   return { log: vi.fn(), warn: vi.fn() };
@@ -161,6 +166,25 @@ describe('runS19ConvergenceGate — acceptance criteria', () => {
     expect(supabase._upserts).toHaveLength(1);
     expect(supabase._upserts[0].advisory_data.post_build_verdict.status).toBe('PASS');
     expect(requestProductReview).not.toHaveBeenCalled();
+  });
+
+  it('QF-20260705-633: passes createQuickFixFn/createSdFn (built via the writer factories) into runConvergenceLoop', async () => {
+    isConvergenceSubject.mockResolvedValue(true);
+    runConvergenceLoop.mockResolvedValue({
+      status: 'PASS', cycles: 1,
+      scoreResult: { mean: 91, dimensionScores: {}, unscoredDimensions: [], rubric: { dimension_floor: 60 } },
+    });
+    const supabase = makeSupabase();
+
+    await runS19ConvergenceGate(supabase, 'v-1', { logger });
+
+    expect(createQuickFixWriter).toHaveBeenCalledWith(supabase);
+    expect(createSdWriter).toHaveBeenCalledWith();
+    expect(runConvergenceLoop).toHaveBeenCalledWith(supabase, expect.objectContaining({
+      ventureId: 'v-1',
+      createQuickFixFn: 'qf-writer-fn',
+      createSdFn: 'sd-writer-fn',
+    }));
   });
 
   it('acceptance negative case: an ESCALATED verdict persists + fires the loud flag via the EXISTING chairman surface (no new channel)', async () => {


### PR DESCRIPTION
## Summary
- The FR-6 remediation router (`convergence-loop.js` `routeRemediation`/`fileAdherenceFix`) was built but never armed at its production call site (`post-build-convergence-gate.js`) -- it passed no `createQuickFixFn`/`createSdFn`, so every routed gap threw and was silently pushed to `errors`/`deferred`. Confirmed against the real 05:39Z MarketLens run: 22 gap verdicts, zero remediation filings.
- New `lib/eva/convergence-remediation-writers.js`: minimal DB-insert-only writer builders, reusing `routeWorkItem`/`generateSDKey`/`createSD` for correct tiering/key-generation -- deliberately NOT the full CLI creation paths (`create-quick-fix.js` also creates a git branch/worktree as a side effect; not safe to call from an automated gate).
- `backfillFn` (completeness-gap path) intentionally left unwired -- needs real upstream-artifact-reader design, tracked as a follow-up. Completeness gaps keep their current (safe, non-crashing) deferred behavior.

## ⚠️ DO NOT MERGE YET
This QF's own description flags: *"Coordinate timing with Adam -- chairman is mid-walkthrough with the gap list; arming mid-review changes the belt."* Merging arms real QF/SD auto-filing the next time **any** convergence-subject venture crosses S19->S20 (not just on a manual re-run). Coordinator was asked about walkthrough status (correlation `b7d8b8b2-b518-43ea-8c60-e87577ef5491`) -- no reply yet. Holding for confirmation before merge.

## Test plan
- [x] New `tests/unit/eva/convergence-remediation-writers.test.js` (4 tests)
- [x] `tests/unit/eva/post-build-convergence-gate.test.js` extended with a wiring-verification test (18 tests total, all passing)
- [x] Full `tests/unit/eva/` suite: 449 files / 5908 tests passing, 0 regressions
- [x] `npm run schema:lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)