### PR TITLE
fix(QF-20260705-914): completion nudges are informational, never claim-driving

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -640,13 +640,22 @@ async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, availa
 
     if (existing && existing.length > 0) continue; // Don't spam
 
+    // QF-20260705-914: this completion nudge is INFORMATIONAL, never claim-driving. It used
+    // to stamp target_sd = the worker's CURRENT sd_key, and worker-checkin's assignment-claim
+    // step extracted that very key back out (via body/payload.current_sd fallbacks) — so a
+    // worker that RELEASED its QF (e.g. a not_before defer) re-claimed it on the next checkin,
+    // and the spam-guard above (no unacked WA -> send a fresh nudge) made the release->reclaim
+    // loop perpetual (live: 2 cycles in 90s, 2026-07-05 09:07Z). target_sd stays null and
+    // payload.kind='completion_nudge' marks the contract; worker-checkin skips these rows in
+    // its claim step symmetrically (isInformationalNudge). current_sd remains payload-only
+    // context so assertSdDispatchable still refuses nudging about a terminal SD.
     const row = {
       target_session: s.session_id,
-      target_sd: s.sd_key,
+      target_sd: null,
       message_type: 'WORK_ASSIGNMENT',
       subject: 'Next work available when ' + s.sd_key.split('-').pop() + ' completes',
       body: 'When you complete ' + s.sd_key + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
-      payload: { available_sds: available, current_sd: s.sd_key },
+      payload: { available_sds: available, current_sd: s.sd_key, kind: 'completion_nudge', informational: true },
       sender_type: 'sweep'
     };
     // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to nudge about a terminal/non-existent SD.

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -239,6 +239,22 @@ function extractDirectedSd(msg) {
   return null;
 }
 
+// QF-20260705-914: an INFORMATIONAL sweep completion nudge ("Next work available when X
+// completes") must never reach the step-5 assignment-claim path. Those rows name the
+// worker's CURRENT sd in body/payload.current_sd, and extractSdFromAssignment's broad
+// fallbacks turned them into a directed claim for the very QF the worker just released —
+// a perpetual release->reclaim loop (live: QF-20260704-348, 2 cycles in 90s). The sweep
+// now stamps payload.kind='completion_nudge' + informational:true; the subject-literal
+// match keeps OLD-shape rows still inside ASSIGNMENT_RECENCY_WINDOW_MS inert too (the
+// literal is owned by dispatchWorkAssignmentsIfAllowed in stale-session-sweep.cjs —
+// keep the two in sync).
+function isInformationalNudge(msg) {
+  if (!msg) return false;
+  const p = msg.payload || {};
+  if (p.kind === 'completion_nudge' || p.informational === true) return true;
+  return /^Next work available when /.test(msg.subject || '');
+}
+
 async function resolveTrack(sb, sdKey, fallback) {
   if (fallback) return fallback;
   try {
@@ -1382,7 +1398,8 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   const assignmentSinceIso = new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString();
   try {
     const msgs = await ws.getMessagesForSession(sb, sessionId, { unackedOnly: true, sinceIso: assignmentSinceIso });
-    assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
+    // QF-20260705-914: informational completion nudges are never claimable assignments.
+    assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT' && !isInformationalNudge(m));
     if (!assignment) {
       // QF-20260703-806: the unacked pull can miss a row whose acknowledged_at got stamped by a
       // path OTHER than a genuine claim outcome (the ack-before-claim race). Claim outcome, not
@@ -1390,7 +1407,7 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // The terminal/ineligible/tryClaim checks below already re-verify the target SD's LIVE
       // state and are idempotent, so resurrecting an already-genuinely-resolved row is harmless.
       const wider = await ws.getMessagesForSession(sb, sessionId, { sinceIso: assignmentSinceIso });
-      assignment = (wider || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
+      assignment = (wider || []).find(m => m.message_type === 'WORK_ASSIGNMENT' && !isInformationalNudge(m));
     }
   } catch { /* fail-open */ }
   if (assignment) {
@@ -1805,7 +1822,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/sweep-completion-nudge-informational.test.js
+++ b/tests/unit/sweep-completion-nudge-informational.test.js
@@ -1,0 +1,156 @@
+/**
+ * QF-20260705-914: the sweep's completion nudge ("Next work available when X completes")
+ * stamped target_sd = the worker's CURRENT sd_key and named that key in body/payload.current_sd.
+ * worker-checkin's step-5 assignment-claim path picked the row up as a directed assignment
+ * (extractSdFromAssignment's broad fallbacks) — so a worker that RELEASED its QF (e.g. a
+ * not_before defer, specimen QF-20260704-348) re-claimed it on the very next checkin, and the
+ * sweep spam-guard (no unacked WA -> fresh nudge) made the release->reclaim loop perpetual
+ * (live-confirmed: 2 cycles in 90s, 2026-07-05 09:07Z).
+ *
+ * Fix under test, both seams:
+ *  - SENDER (stale-session-sweep.cjs dispatchWorkAssignmentsIfAllowed): nudge rows carry
+ *    target_sd:null + payload.kind='completion_nudge' + informational:true; current_sd stays
+ *    payload-only context.
+ *  - CONSUMER (worker-checkin.cjs step 5): isInformationalNudge() rows never become the
+ *    claimable `assignment` — including OLD-shape rows (no kind marker) via the sweep's
+ *    subject literal, so rows already in the recency window go inert on deploy.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveCheckin, isInformationalNudge } = require('../../scripts/worker-checkin.cjs');
+const { dispatchWorkAssignmentsIfAllowed } = require('../../scripts/stale-session-sweep.cjs');
+
+const RELEASED_QF = 'QF-20260704-348';
+
+describe('sender seam — dispatchWorkAssignmentsIfAllowed emits an informational, non-directed nudge', () => {
+  function fakeSweepSb({ inserted }) {
+    return {
+      from(table) {
+        const api = {
+          select() { return this; }, eq() { return this; }, is() { return this; },
+          limit() { return Promise.resolve({ data: [], error: null }); }, // spam-guard: no unacked WA
+          maybeSingle() {
+            // assertSdDispatchable resolves payload.current_sd -> quick_fixes status lookup
+            if (table === 'quick_fixes') return Promise.resolve({ data: { status: 'in_progress' }, error: null });
+            return Promise.resolve({ data: null, error: null });
+          },
+          insert(row) { inserted.push(row); return Promise.resolve({ error: null }); },
+        };
+        return api;
+      },
+    };
+  }
+
+  it('nudge row has target_sd:null, kind completion_nudge, informational:true, current_sd payload-only', async () => {
+    const inserted = [];
+    const res = await dispatchWorkAssignmentsIfAllowed(
+      fakeSweepSb({ inserted }),
+      [{ session_id: 'sess-1', sd_key: RELEASED_QF }],
+      ['SD-AVAIL-001'],
+      true
+    );
+    expect(res.dispatched).toBe(1);
+    expect(inserted).toHaveLength(1);
+    const row = inserted[0];
+    expect(row.target_sd).toBeNull();
+    expect(row.payload.kind).toBe('completion_nudge');
+    expect(row.payload.informational).toBe(true);
+    expect(row.payload.current_sd).toBe(RELEASED_QF);
+    expect(isInformationalNudge(row)).toBe(true); // the consumer predicate recognizes the sender's shape
+  });
+
+  it('still respects the single-writer gate (no insert when not canonical)', async () => {
+    const inserted = [];
+    const res = await dispatchWorkAssignmentsIfAllowed(
+      fakeSweepSb({ inserted }),
+      [{ session_id: 'sess-1', sd_key: RELEASED_QF }],
+      [],
+      false
+    );
+    expect(res.blocked).toBe(true);
+    expect(inserted).toHaveLength(0);
+  });
+});
+
+describe('isInformationalNudge — recognizes new-shape and legacy-shape nudges', () => {
+  it('new shape: payload.kind completion_nudge', () => {
+    expect(isInformationalNudge({ payload: { kind: 'completion_nudge' } })).toBe(true);
+  });
+  it('legacy shape already in the recency window: sweep subject literal, no kind marker', () => {
+    expect(isInformationalNudge({ subject: 'Next work available when 348 completes', payload: { available_sds: [], current_sd: RELEASED_QF } })).toBe(true);
+  });
+  it('a genuine directed assignment is NOT informational', () => {
+    expect(isInformationalNudge({ subject: 'WORK ASSIGNMENT', payload: { qf_id: 'QF-20260704-726' } })).toBe(false);
+    expect(isInformationalNudge({ payload: { assigned_sd: 'SD-X-001' } })).toBe(false);
+  });
+});
+
+describe('consumer seam — resolveCheckin never claims off a completion nudge (the release->reclaim loop)', () => {
+  function fakeSb({ rpcCalls }) {
+    return {
+      rpc(name, args) { rpcCalls.push({ name, args }); return Promise.resolve({ data: { success: true }, error: null }); },
+      from(table) {
+        const api = {
+          select() { return this; }, eq() { return this; }, neq() { return this; },
+          gte() { return this; }, lte() { return this; }, in() { return this; },
+          is() { return this; }, or() { return this; }, not() { return this; },
+          order() { return this; }, limit() { return this; },
+          maybeSingle() {
+            if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+            return Promise.resolve({ data: null, error: null });
+          },
+          insert() { return Promise.resolve({ error: null }); },
+          update() { return { eq() { return Promise.resolve({ error: null }); } }; },
+        };
+        return api;
+      },
+    };
+  }
+
+  async function runWithNudge(sb, nudgeRow) {
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [nudgeRow];
+    try {
+      return await resolveCheckin(sb, 'sess-released-qf', { getCoordinator: async () => null });
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  }
+
+  it('new-shape nudge naming the just-released QF drives NO claim attempt', async () => {
+    const rpcCalls = [];
+    const res = await runWithNudge(fakeSb({ rpcCalls }), {
+      id: 'msg-nudge-new', message_type: 'WORK_ASSIGNMENT',
+      subject: 'Next work available when 348 completes',
+      body: 'When you complete ' + RELEASED_QF + ', pick up the next unclaimed child.',
+      payload: { available_sds: [], current_sd: RELEASED_QF, kind: 'completion_nudge', informational: true },
+    });
+    expect(res.action).not.toBe('claimed_assignment');
+    expect(rpcCalls.filter(c => JSON.stringify(c.args || {}).includes(RELEASED_QF))).toHaveLength(0);
+  });
+
+  it('legacy-shape nudge (pre-fix row still unacked in the window) also drives NO claim attempt', async () => {
+    const rpcCalls = [];
+    const res = await runWithNudge(fakeSb({ rpcCalls }), {
+      id: 'msg-nudge-old', message_type: 'WORK_ASSIGNMENT',
+      subject: 'Next work available when 348 completes',
+      body: 'When you complete ' + RELEASED_QF + ', pick up the next unclaimed child.',
+      payload: { available_sds: [], current_sd: RELEASED_QF },
+    });
+    expect(res.action).not.toBe('claimed_assignment');
+    expect(rpcCalls.filter(c => JSON.stringify(c.args || {}).includes(RELEASED_QF))).toHaveLength(0);
+  });
+
+  it('regression: a genuine directed qf_id assignment still claims', async () => {
+    const rpcCalls = [];
+    const res = await runWithNudge(fakeSb({ rpcCalls }), {
+      id: 'msg-directed', message_type: 'WORK_ASSIGNMENT',
+      subject: 'WORK ASSIGNMENT',
+      payload: { qf_id: 'QF-20260704-726' },
+    });
+    expect(res.action).toBe('claimed_assignment');
+    expect(res.sd).toBe('QF-20260704-726');
+  });
+});


### PR DESCRIPTION
## Summary
The sweep completion nudge (`Next work available when X completes`) stamped `target_sd` = the worker's CURRENT sd_key and named that key in body/`payload.current_sd`. worker-checkin's step-5 assignment path extracted it back out as a directed assignment, so a worker that RELEASED its QF (not_before defer — specimen QF-20260704-348) re-claimed it on the next checkin; the sweep spam-guard then sent a fresh nudge after each ack. Perpetual release→reclaim loop, live-confirmed at 2 cycles in 90s (2026-07-05 09:07Z, worker e2791f5b escalation).

## Fix (both seams)
- **Sender** (`stale-session-sweep.cjs` `dispatchWorkAssignmentsIfAllowed`): nudge rows carry `target_sd: null` + `payload.kind: completion_nudge` + `informational: true`. `current_sd` stays payload-only context so `assertSdDispatchable` still refuses nudging about a terminal SD.
- **Consumer** (`worker-checkin.cjs` step 5): new `isInformationalNudge()` excludes these rows from the assignment find — including legacy-shape rows still inside the recency window, matched by the sweep subject literal, so pre-fix rows go inert on deploy.

The coordinator's REQUIRED scope addition (not_before gate before tryClaim on directed QF keys) shipped separately as QF-20260705-429 / PR #5608 — together these complete the not_before contract across all claim paths.

## Test plan
- New: tests/unit/sweep-completion-nudge-informational.test.js — sender row shape, sender/consumer contract cross-check, legacy-shape inertness, release→reclaim no-claim repro, directed-assignment regression
- Adjacent green: directed-dispatch-and-severity, directed-not-before, assignment-surfacing, sweep-residuals (63 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)