### PR TITLE
fix(QF-20260705-303): session-register upserts nonexistent started_at, error swallowed silently

### DIFF
--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -131,8 +131,7 @@ async function main() {
     tty: getTTY(),
     codebase: detectCurrentRepo(),
     status: 'active',
-    heartbeat_at: now,
-    started_at: now
+    heartbeat_at: now
   });
 
   const { error } = await supabase
@@ -144,6 +143,8 @@ async function main() {
 
   if (!error) {
     console.log(`session-register: registered ${sessionId.slice(0, 12)}...`);
+  } else {
+    process.stderr.write(`[session-register] upsert.failed session=${sessionId.slice(0, 12)} error=${error.message}\n`);
   }
 
   // SD-LEO-INFRA-SESSION-IDENTITY-RECONCILIATION-001 (FR-1): wire reconcileAtBoot
@@ -196,4 +197,9 @@ async function main() {
   } catch { /* best-effort observability; never block SessionStart */ }
 }
 
-main().catch(() => { /* fail silently */ });
+main().catch((err) => {
+  // Never throw — SessionStart must not abort — but surface the error so it's
+  // no longer invisible (was previously swallowed with no trace, hiding schema
+  // drift like the started_at column removal from every session's boot).
+  process.stderr.write(`[session-register] main.failed error=${err?.message || String(err)}\n`);
+});

--- a/tests/unit/session-register-started-at-fix.test.js
+++ b/tests/unit/session-register-started-at-fix.test.js
@@ -1,0 +1,51 @@
+/**
+ * QF-20260705-303 — session-register.cjs upserted a nonexistent `started_at`
+ * column into claude_sessions (the live schema only has created_at/updated_at),
+ * causing PostgREST to reject the upsert. The surrounding main().catch(() => {})
+ * swallowed that error silently, so every new session's SessionStart registration
+ * failed invisibly.
+ *
+ * The hook's main() auto-invokes at require-time and talks to live Supabase, so
+ * we use static-string regression pins (same convention as
+ * tests/unit/session-start-hook-reconcile.test.js) rather than importing it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const hookPath = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'session-register.cjs');
+
+describe('QF-20260705-303: session-register no longer writes nonexistent started_at column', () => {
+  let hookSource;
+
+  it('reads the hook source once', () => {
+    hookSource = fs.readFileSync(hookPath, 'utf8');
+    expect(hookSource.length).toBeGreaterThan(500);
+  });
+
+  it('the claude_sessions upsert payload no longer includes started_at', () => {
+    hookSource = fs.readFileSync(hookPath, 'utf8');
+    const payloadMatch = hookSource.match(/const payload = stampBranch\(\{[\s\S]*?\}\);/);
+    expect(payloadMatch).not.toBeNull();
+    expect(payloadMatch[0]).not.toMatch(/started_at/);
+  });
+
+  it('a failed upsert is surfaced to stderr, not silently ignored', () => {
+    hookSource = fs.readFileSync(hookPath, 'utf8');
+    expect(hookSource).toMatch(/if \(!error\) \{[\s\S]*?\} else \{[\s\S]*?process\.stderr\.write\([\s\S]*?upsert\.failed/);
+  });
+
+  it('main().catch() surfaces the error to stderr instead of failing silently', () => {
+    hookSource = fs.readFileSync(hookPath, 'utf8');
+    expect(hookSource).not.toMatch(/main\(\)\.catch\(\(\) => \{\s*\/\*\s*fail silently\s*\*\/\s*\}\);/);
+    expect(hookSource).toMatch(/main\(\)\.catch\(\(err\) => \{[\s\S]*?process\.stderr\.write\([\s\S]*?main\.failed/);
+  });
+
+  it('regression-pin: fix references QF-20260705-303', () => {
+    hookSource = fs.readFileSync(hookPath, 'utf8');
+    expect(hookSource).toMatch(/QF-20260705-303|started_at column removal/);
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/hooks/session-register.cjs` upserted `started_at` into `claude_sessions`, a column that doesn't exist in the live schema (only `created_at`/`updated_at` do) — PostgREST rejected the upsert on every SessionStart.
- `main().catch(() => { /* fail silently */ })` swallowed that failure with zero trace, so session registration has been silently failing fleet-wide since whenever the column was dropped/renamed.
- Reproduced directly: manual upsert WITH `started_at` errors; WITHOUT it succeeds.
- Real-world impact cited in the QF: coordinator dispatch to new sessions dead-lettered (no `claude_sessions` row until first worker-checkin), callsign stamps became 0-row no-ops, roll-call acks lost, and `claim_sd` could write orphanable claims.

## Changes
- Drop `started_at` from the upsert payload (DB's own `created_at` default covers session-creation timestamping).
- Surface the upsert error to stderr (`[session-register] upsert.failed ...`) instead of silently continuing.
- Surface the top-level `main().catch()` error to stderr too (`[session-register] main.failed ...`) — still never throws, so SessionStart is never blocked.
- Added `tests/unit/session-register-started-at-fix.test.js` (static-source-pin regression tests, same convention as the existing `session-start-hook-reconcile.test.js` for this same hook file, since `main()` auto-invokes at require-time against live Supabase).

## Test plan
- [x] New unit tests pass (`tests/unit/session-register-started-at-fix.test.js`, 5/5)
- [x] Existing hook tests still pass (`scripts/hooks/__tests__`, 268 passed | 1 todo)
- [x] `npm run schema:lint` clean (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)