### PR TITLE
fix(QF-20260704-348): re-enable LEO_MASKED_STALL_DETECT after clean 24h monitoring window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -303,7 +303,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-signing-secret
 # process_alive_at (written only by the session-tick.cjs daemon) was historically
 # unreliable due to bugs fixed by SD-LEO-INFRA-FIX-WINDOWS-SESSION-001 (steady-state
 # self-exit on idle/stale rows, inert Windows PID rediscovery, first-tick resurrection
-# risk). Two downstream detectors key on this signal and are gated OFF by default until
-# it is proven trustworthy; both are advisory/detector-only, never a destructive action.
+# risk). Two downstream detectors key on this signal and were gated OFF by default until
+# proven trustworthy; both are non-destructive (alert/escalation-only, never a reap/kill action).
 # LEO_DORMANCY_WATCHDOG_ENABLED=on                          # fleet_dormancy alert (stale-session-sweep.cjs); flipped ON by SD-LEO-INFRA-FIX-WINDOWS-SESSION-001
-# LEO_MASKED_STALL_DETECT=on                                # masked-stall detector (coordinator-capacity-forecast.mjs); intentionally left OFF -- drives capacity decisions, deferred to a follow-up SD with its own monitoring window
+# LEO_MASKED_STALL_DETECT=on                                # masked-stall detector (coordinator-capacity-forecast.mjs); drives an operator re-paste escalation (higher blast radius than the watchdog above -- an actual capacity/escalation decision, not just a log line), so it got its own tracked 24h clean-monitoring-window before flipping ON by QF-20260704-348


### PR DESCRIPTION
## Summary
- Follow-up to SD-LEO-INFRA-FIX-WINDOWS-SESSION-001 FR-5, which deliberately deferred this flag pending its own tracked monitoring window (higher blast radius than the advisory-only `LEO_DORMANCY_WATCHDOG_ENABLED` flag already flipped — this one drives a real operator escalation decision in `coordinator-capacity-forecast.mjs`/`lib/coordinator/detectors.cjs`).
- Both required preconditions verified clean before flipping: (1) full 24h elapsed since the 2026-07-04T11:36:23Z merge; (2) `fleet_dormancy` feedback stayed flat at 19 events with zero new occurrences in ~16.7h.
- `LEO_MASKED_STALL_DETECT=on` is set in the local (gitignored) `.env`; this PR updates `.env.example`'s documentation to match the sibling flag's convention.

## Test plan
- [x] `tests/unit/detect-masked-stall.test.js` — 12/12 pass unchanged
- [x] Verified `LEO_MASKED_STALL_DETECT` reads `"on"` at runtime with a fresh process

🤖 Generated with [Claude Code](https://claude.com/claude-code)