### PR TITLE
docs(SD-LEO-DOC-CHAIRMAN-REVIEW-RUNBOOK-001): chairman product-review + QA convergence-loop runbooks

### DIFF
--- a/docs/runbooks/chairman-product-review-runbook.md
+++ b/docs/runbooks/chairman-product-review-runbook.md
@@ -1,0 +1,134 @@
+# Runbook: Chairman Product-Review Walkthrough
+
+**Category**: Protocol
+**Status**: Approved
+**Version**: 1.0.0
+**Author**: SD-LEO-DOC-CHAIRMAN-REVIEW-RUNBOOK-001
+**Last Updated**: 2026-07-05
+**Tags**: chairman-review, product-review, qa, walkthrough
+
+> **Update trigger**: This doc's precheck gate and verdict semantics are sourced from
+> `SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001`. If that gate's stages, thresholds, or
+> trigger logic change, re-verify this doc against the live implementation before
+> trusting it for the next walkthrough.
+
+## Purpose
+
+This is the repeatable procedure for staging and running a chairman hands-on
+product-review walkthrough. It exists because walkthrough #1 (2026-07-05) was
+run ad hoc, terminated at Stop 1 with a SEND-BACK verdict, and its learnings
+lived only in session context and SD metadata — nothing an operator, or a
+future Adam/coordinator session, could read end-to-end to run walkthrough #2
+correctly. This doc is that missing artifact.
+
+See also: [qa-convergence-loop-operations.md](./qa-convergence-loop-operations.md)
+(the QA loop that must complete *before* a chairman review stages) and
+`SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001` / `SD-LEO-INFRA-POST-BUILD-ARTIFACT-001`
+(the SDs that built this machinery).
+
+## Preconditions: the MACHINE-PRECHECK GATE
+
+A chairman review must **only** be staged after the following pass. This is
+the chairman's own words from walkthrough #1: *"there is nothing I'm doing
+right now that you could not have done yourself."* Every one of these is
+machine-checkable — if a stop in the walkthrough asks a question the machine
+could have answered, the precheck failed to run, or the stop should be deleted.
+
+1. **Scorecard zero-MISSING** — the venture's `post_build_verdicts` table has
+   zero rows with `disposition = 'MISSING'`. See the QA doc for how the
+   scorecard is produced.
+2. **Gating-PARTIALs closed** — any `PARTIAL` verdict flagged as gating
+   (blocks launch) has been remediated to `BUILT` or explicitly re-scored.
+3. **Styling/brand present** — the identity-asset coverage dimension
+   (brand assets, logo, tone/guidelines) is evidence-linked as rendered in
+   the product, not just wired in code.
+4. **Core journey green** — the primary user journey (land → core action →
+   result) passes automated E2E.
+5. **Synthetic-persona T3 pass** — the REQUIRED synthetic-persona journey
+   walk (see QA doc) has run and passed for this venture.
+
+If any of the five fail, do **not** stage the review. Route the gap through
+the QA convergence loop's remediation path first (see QA doc, "Remediation
+routing").
+
+## Guided Walkthrough Format
+
+Once the precheck passes, the review is staged as a **guided, one-stop-at-a-time**
+walkthrough:
+
+- **One stop at a time.** Present exactly one item, wait for the chairman to
+  say "done" (or an equivalent explicit confirmation), then advance. Never
+  batch multiple stops into one message.
+- **No opaque IDs.** Never surface a bare UUID, SD key, or internal row ID as
+  the thing the chairman is asked to judge. Translate every reference into
+  plain, product-facing language.
+- **Taste-only questions.** Every question posed to the chairman must require
+  human judgment — "does this feel right," "is this the tone you want,"
+  "would you ship this." If a stop's question is machine-answerable (a
+  scorecard number, a pass/fail check, a link that either resolves or
+  doesn't), **delete that stop** — the precheck gate already covers it. The
+  chairman's time is reserved for judgments the machine cannot make.
+
+## Environment Setup Learnings (from Walkthrough #1)
+
+Three concrete failures from walkthrough #1 that must not recur:
+
+### 1. Verify the app's OWN port
+
+Walkthrough #1 hit a **false boot-verify**: a stale daemon holding port 3001
+answered health checks, so the boot-verify step reported success while the
+chairman was actually looking at the wrong (or a dead) process. Before
+staging any review:
+- Confirm the port the chairman will actually browse to matches the port the
+  target app's own dev/preview server is bound to — do not assume a
+  health-check response on *a* port means it's *this app's* server.
+- Kill any stray process holding the expected port before starting the
+  app's own server.
+
+### 2. Screenshot-verify what the chairman actually sees
+
+Do not rely on a server-side "it's running" signal alone. Capture a
+screenshot of the actual rendered page immediately before staging the
+review, and cross-check it against what will be described to the chairman.
+A server can report healthy while the browser renders a blank or broken
+page.
+
+### 3. State the styling maturity up front
+
+Before the chairman looks at anything, tell him explicitly what styling/brand
+state to expect (e.g. "this is unstyled — layout only, no brand pass yet" or
+"brand pass complete"). Walkthrough #1's Stop 1 SEND-BACK was, in part, a
+surprise at unstyled landing — stating this up front turns a surprise into an
+expected, already-acknowledged constraint, and lets the chairman's judgment
+focus on what he's actually there to judge.
+
+## Verdict Recording and Triggers
+
+Each stop (and the walkthrough as a whole) ends in one of two verdicts:
+
+| Verdict | What it means | What it triggers |
+|---|---|---|
+| **Approve** | The chairman accepts this stop / the whole review | Advances to the launch-path / live-mode decision. If it's the final stop, the venture is cleared for its next lifecycle stage. |
+| **Send-back** | The chairman rejects this stop, with reasons | Triggers a **remediation wave**: the stated reasons are routed the same way a QA-loop deviation is routed (see QA doc, "Remediation routing"). The review **auto-re-stages** once the machine-precheck gate clears again — no manual re-invitation needed. |
+
+Record the verdict and its reasons durably (the same evidence trail the QA
+loop uses — do not let a send-back's reasons live only in chat history).
+
+## Re-Stage Semantics
+
+When a send-back's remediation completes and the precheck gate clears again,
+the re-stage invitation to the chairman **must explicitly state what changed
+since he last looked** — do not re-invite with a generic "ready for review"
+message. Name the specific items that were fixed, referencing the exact
+reasons he gave at send-back. This keeps each re-stage fast: he should be
+able to confirm the specific fix, not re-review the whole product from
+scratch.
+
+## Smoke Test
+
+To verify this runbook is current: walk its precondition section against the
+live state of MarketLens (the first venture through this gate). As of this
+writing, MarketLens's landing page is unstyled — walking this section should
+correctly report a **FAIL** on precondition 3 (styling/brand present), naming
+that exact gap. If it instead reports PASS, this runbook (or the live gate
+it describes) has drifted and needs re-verification.

--- a/docs/runbooks/qa-convergence-loop-operations.md
+++ b/docs/runbooks/qa-convergence-loop-operations.md
@@ -1,0 +1,185 @@
+# Runbook: QA Convergence-Loop Operations
+
+**Category**: Protocol
+**Status**: Approved
+**Version**: 1.0.0
+**Author**: SD-LEO-DOC-CHAIRMAN-REVIEW-RUNBOOK-001
+**Last Updated**: 2026-07-05
+**Tags**: qa, convergence-loop, adherence-rubric, post-build-verdicts
+
+> **Update trigger**: The pass-bar thresholds and verdict counts cited below are
+> sourced live from `strategic_directives_v2.metadata.rubric_thresholds_ratified`
+> (on `SD-LEO-INFRA-POST-BUILD-ARTIFACT-001`) and the `post_build_verdicts` table.
+> Both can change independently of this doc — **re-verify by direct query** before
+> trusting a cited number, and re-verify this doc whenever the ratified thresholds
+> or gate stages change (per the chairman's own change policy, see "Ratified Pass
+> Bar" below).
+
+## Purpose
+
+This is the operator-facing end-to-end description of the QA convergence
+loop: how a venture's built product is checked against what was planned,
+scored, remediated, and finally handed to the chairman for a taste-only
+review. It was built by the `SD-LEO-INFRA-POST-BUILD-ARTIFACT-001` family
+(children -A through -E) and consumed by
+`SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001`. Before this doc, the design
+substance existed only in SD metadata, DB rows, and session context.
+
+See also: [chairman-product-review-runbook.md](./chairman-product-review-runbook.md)
+(what happens after this loop converges).
+
+## Pipeline Order
+
+The loop runs in a fixed sequence, with the chairman review always **last**:
+
+1. **Completeness** — enumerate every planning artifact (blueprint user-story
+   pack, persona/brand implied surfaces, data model, technical architecture,
+   schema spec, positioning brief) and confirm each has a corresponding,
+   evidence-linked entry to score against. Nothing is silently dropped from
+   the scope of scoring.
+2. **Adherence rubric** — score each dimension (see "Ratified Pass Bar"
+   below) on a behaviorally-anchored 1-5 scale.
+3. **Deviation trichotomy** — classify every gap (see "Deviation Semantics"
+   below).
+4. **Remediation** — route every below-bar dimension or undocumented
+   deviation to a fix (see "Remediation Routing" below).
+5. **3-cycle convergence bound** — remediation + rescoring repeats for up to
+   3 cycles.
+6. **Escalation** — if the loop has not converged after 3 cycles, escalate
+   rather than looping indefinitely.
+7. **Chairman review** — runs strictly **after** convergence (or escalation
+   resolution), per
+   [chairman-product-review-runbook.md](./chairman-product-review-runbook.md).
+   The chairman elected strict QA-before-review even for the first venture
+   through this gate (MarketLens) — "let the QA design run first" — despite
+   an available concurrent-informed exception.
+
+## Ratified Pass Bar
+
+Chairman-ratified 2026-07-04, stored in
+`strategic_directives_v2.metadata.rubric_thresholds_ratified` on
+`SD-LEO-INFRA-POST-BUILD-ARTIFACT-001`:
+
+> **Every dimension >= 3 AND mean >= 4 AND zero unscored dimensions.**
+> Scale: behaviorally-anchored 1-5.
+
+**Change policy**: threshold changes are **future-ventures-only** — a fresh
+ratification is required, and the venture currently in the loop is never
+retroactively re-scored under new thresholds (the gate-freeze that applies
+to gate logic extends to rubric thresholds too).
+
+## Deviation Semantics
+
+Every planning-artifact-to-built-product gap is classified into exactly one
+of three buckets — no fourth "unclear" bucket exists:
+
+| Classification | Meaning |
+|---|---|
+| **Built-as-planned** | The built product matches the planning artifact; no deviation. |
+| **Deviated-documented** | The build differs from the plan, but the deviation carries a recorded weight and a reason-quality assessment (i.e. someone explicitly decided to deviate, and said why). |
+| **Deviated-UNDOCUMENTED** | The build differs from the plan and no reason was recorded. This is the class that matters most — it's silent scope loss. |
+
+## Scorer Independence Rules
+
+These rules exist to prevent a builder from grading its own work:
+
+- **Scorer != builder != remediator.** The person/process that built an
+  artifact does not score it; the person/process that scores it does not
+  remediate it.
+- **Blind rescores.** When a remediation cycle completes, the rescore is
+  blind to the prior score (not anchored to "well it was a 2, now it should
+  be higher").
+- **Evidence-linked-or-unscored.** A dimension cannot receive a score without
+  a linked evidence reference (route, component, schema object, test, or
+  screenshot). "Could not verify" is never silently treated as "passing" —
+  it is left unscored, which itself blocks the pass bar (see "zero unscored
+  dimensions" above).
+
+## Where Verdicts Live
+
+Per-item disposition is recorded in the `post_build_verdicts` table:
+
+- `disposition`: one of `BUILT`, `PARTIAL`, `MISSING`
+- `evidence_refs`: the linked evidence for that disposition (required —
+  see "Evidence-linked-or-unscored" above)
+- Other columns: `id`, `venture_id`, `artifact_type`, `claim_ref`,
+  `deviation_artifact_id`, `claim_description`, `created_at`, `updated_at`
+
+### Worked Example: MarketLens First Run
+
+As of this writing, `post_build_verdicts` holds **46 total rows** for the
+MarketLens first run, verified live by direct query:
+
+| Disposition | Count |
+|---|---|
+| BUILT | 24 |
+| PARTIAL | 18 |
+| MISSING | 4 |
+
+**Do not copy these numbers into a future scorecard read without
+re-querying** — they describe one specific historical run and will not
+match subsequent runs or other ventures.
+
+## Remediation Routing
+
+A below-bar dimension or an undocumented deviation is routed:
+
+```
+verdict -> router -> QF (small, ≤tier-appropriate LOC) or SD (larger scope)
+```
+
+The router (`lib/eva/convergence-loop.js`'s `routeRemediation`) dispatches
+each gap to one of two injected functions depending on the gap kind:
+- **Adherence-kind gaps** -> `fileAdherenceFix` -> tier 1/2 creates a Quick
+  Fix, tier 3 creates an SD.
+- **Completeness-kind / unscored-dimension gaps** -> `backfillCompletenessGap`
+  -> a "circularity guard" rejects any backfill sourced from the build/repo
+  itself (it must be genuinely upstream evidence, not the same artifact
+  re-asserting itself as its own proof).
+
+### Known-Failure Sidebar: QF-20260705-633 (the writer-injection gap)
+
+The router's injected functions (`createQuickFixFn`, `createSdFn`,
+`backfillFn`) have **no defaults**. When a call site omitted them, every
+routed gap silently threw inside `routeRemediation`'s own try/catch and was
+pushed into an `errors`/`deferred` array — **no QF or SD was ever actually
+created**, and nothing visibly failed. This was root-caused and fixed by
+`QF-20260705-633`: `lib/eva/post-build-convergence-gate.js` now imports
+`createQuickFixWriter(supabase)` / `createSdWriter()` from
+`lib/eva/convergence-remediation-writers.js` and passes them explicitly at
+the call site. **Operator takeaway**: if remediation counts look
+suspiciously low or zero after a scoring run, check that the call site
+wiring the convergence loop actually passes all three writer functions —
+a silent omission here produces no error, just missing remediation.
+
+## Synthetic-Persona T3 Walk (REQUIRED, not optional)
+
+A synthetic-persona journey walk — driving the assembled, deployed/local
+product UI with generated personas through the core journeys (land ->
+signup -> submit -> results -> feedback) — is a **REQUIRED** evidence layer
+of the adherence scoring, not an optional nice-to-have. It is the one layer
+that exercises the assembled whole; per-SD test gates do not cover this
+(they validate their own SD's slice in isolation). A scorecard without a
+passing synthetic-persona T3 walk is incomplete regardless of its other
+dimension scores.
+
+## Chairman-as-Formal-Holdout
+
+The chairman's own review (which runs after this loop converges, per
+[chairman-product-review-runbook.md](./chairman-product-review-runbook.md))
+doubles as a **formal holdout set** for the loop's own validity. If the
+loop is working, the chairman's catch-rate — the number of real issues he
+finds that the automated pipeline missed — should trend toward zero across
+successive walkthroughs. A catch-rate that stays flat or rises is itself a
+signal that the loop's scoring or remediation has a gap, independent of any
+single venture's outcome.
+
+## Smoke Test
+
+To verify this doc is current: query `post_build_verdicts` for the current
+disposition counts and compare against the worked-example table above (they
+will very likely differ — that's expected and fine), and confirm the
+threshold values in `strategic_directives_v2.metadata.rubric_thresholds_ratified`
+on `SD-LEO-INFRA-POST-BUILD-ARTIFACT-001` still read exactly "every
+dimension >= 3 AND mean >= 4 AND zero unscored dimensions." If either query
+fails or the values have changed, this doc needs a refresh.


### PR DESCRIPTION
## Summary
Chairman-directed 2026-07-05 during walkthrough #1 (terminated at Stop 1, SEND-BACK verdict): "this is the first time we're doing this and we're going to need to repeat it — we need to capture learnings and document it... some QA work we did yesterday is also probably missing from the documentation." Two operator-facing docs were owed; the design substance previously lived only in SD metadata, DB rows, and session context.

- `docs/runbooks/chairman-product-review-runbook.md` — the repeatable chairman walkthrough procedure: machine-precheck gate, guided one-stop-at-a-time format, walkthrough #1's environment learnings (port-verify, screenshot-verify, styling-maturity-upfront), verdict recording + triggers, re-stage semantics.
- `docs/runbooks/qa-convergence-loop-operations.md` — the QA convergence loop end-to-end: pipeline order, chairman-ratified pass bar (verified live against DB metadata), deviation trichotomy, scorer-independence rules, the MarketLens worked example (verified live against `post_build_verdicts`: 46 total, 24 BUILT/18 PARTIAL/4 MISSING), remediation routing (with QF-20260705-633 as a known-failure sidebar), synthetic-persona T3 as REQUIRED evidence, chairman-as-formal-holdout framing.

Both docs cross-link each other, cite the building SD keys (SD-LEO-INFRA-POST-BUILD-ARTIFACT-001 family, SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001), and open with a docmon-convention update-trigger note since cited numbers can drift.

## Test plan
- [x] `npm run schema:lint` clean (0 violations)
- [x] Cross-links between the two docs verified to resolve
- [x] Cited numbers (post_build_verdicts disposition counts, rubric_thresholds_ratified) verified via direct live DB query at write time, not recalled from memory
- [x] LEAD-TO-PLAN (97%), PLAN-TO-EXEC (99%), EXEC-TO-PLAN (97%), PLAN-TO-LEAD (98%) all passed
- [x] Retrospective published (quality 90/100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)