### PR TITLE
fix(QF-20260705-488): Solomon consult answers reach Adam — direct lane default-on + originator CC

### DIFF
--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -55,10 +55,13 @@ function isTwoWayV2Enabled() {
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: graduates ADAM_SOLOMON_TWOWAY_V1 from a
 // doc-only placeholder (docs/architecture/solomon-activation-runbook.md Stage C) to a real gate.
 // Shared by both scripts/adam-advisory.cjs and scripts/solomon-advisory.cjs's --to option so the
-// two directions can never drift onto different flag semantics. Default OFF — the existing
-// coordinator-relay path is unconditional until this is turned on.
+// two directions can never drift onto different flag semantics.
+// QF-20260705-488: default flipped ON (chairman-directed, on record 2026-07-05) — the OFF default
+// forced the chairman to hand-relay Solomon consult answer d7f5401c into Adam's session after
+// Adam's `--to solomon` hard-errored on the gate. Direct Adam<->Solomon is now the default;
+// ADAM_SOLOMON_TWOWAY_V1=off remains the explicit kill switch (any other value, incl. unset, = on).
 function isAdamSolomonTwoWayV1Enabled() {
-  return process.env.ADAM_SOLOMON_TWOWAY_V1 === 'on';
+  return process.env.ADAM_SOLOMON_TWOWAY_V1 !== 'off';
 }
 
 // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-3: deterministic single-winner election.

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -30,7 +30,8 @@
  *
  * SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send`/`request` accept `--to solomon` for
  * a DIRECT 1-hop write to Solomon's own session (no coordinator relay hop), gated by
- * ADAM_SOLOMON_TWOWAY_V1=on (default OFF). Omitting --to is byte-identical unchanged behavior —
+ * ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' is the explicit kill switch).
+ * Omitting --to is byte-identical unchanged behavior —
  * the existing coordinator-relay path is the permanent fallback, never removed.
  *   node scripts/adam-advisory.cjs send --direct "<body>"                          (shorthand for --to solomon)
  *
@@ -680,7 +681,7 @@ async function main() {
     process.exit(2);
   }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to solomon` — direct
-  // 1-hop channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default OFF; omitting --to is unchanged).
+  // 1-hop channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' kills it).
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
   // the relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) —
   // these enqueue a tracked FR-1 relay-request instead of a direct write. --direct is

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -711,7 +711,7 @@ async function main() {
   }
   const twoWayV1On = isAdamSolomonTwoWayV1Enabled();
   if (peerArg === 'solomon' && !twoWayV1On) {
-    console.error('ERROR: --to solomon is gated by ADAM_SOLOMON_TWOWAY_V1=on (currently OFF). Omit --to to route via the coordinator.');
+    console.error('ERROR: --to solomon is disabled by ADAM_SOLOMON_TWOWAY_V1=off (direct lane is ON by default since QF-20260705-488). Omit --to to route via the coordinator.');
     process.exit(3);
   }
 

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -30,8 +30,9 @@
  *
  * SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send`/`request` accept `--to adam` for a
  * DIRECT 1-hop write to Adam's own session (no coordinator relay hop), gated by
- * ADAM_SOLOMON_TWOWAY_V1=on (default OFF). Omitting --to is byte-identical unchanged behavior — the
- * existing coordinator-relay path is the permanent fallback, never removed.
+ * ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' is the explicit kill switch).
+ * Omitting --to is byte-identical unchanged behavior — the existing coordinator-relay path is
+ * the permanent fallback, never removed.
  *   node scripts/solomon-advisory.cjs send --direct "<body>"                   (shorthand for --to adam)
  *
  * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: `--to` also accepts the
@@ -214,7 +215,10 @@ async function checkConsultQuota(supabase, { sdKey = null, perSdMax = SOLOMON_PE
       .gte('created_at', since.toISOString())
       .limit(1000);
     if (error) return { allowed: true };
-    const rows = data || [];
+    // QF-20260705-488 (adversarial-review W2): an answer's originator CC copy also carries
+    // payload.oracle=true — exclude via='cc_originator' rows so a CC'd answer consumes ONE
+    // quota slot, not two (the per-day ceiling would otherwise halve in practice).
+    const rows = (data || []).filter((r) => !(r.payload && r.payload.via === 'cc_originator'));
     if (rows.length >= perDayMax) return { allowed: false, reason: `per-day quota reached (${rows.length}/${perDayMax})` };
     if (sdKey) {
       const perSd = rows.filter((r) => r.payload && (r.payload.sd_key === sdKey || r.payload.sd_id === sdKey)).length;
@@ -337,7 +341,14 @@ async function resolveConsultOriginator(supabase, value) {
       .select('sender_session, payload')
       .eq('id', value)
       .maybeSingle();
-    if (byId) return (byId.payload && byId.payload.origin_session) || byId.sender_session || null;
+    if (byId) {
+      const p = byId.payload || {};
+      // Adversarial-review I4: CC is scoped to CONSULTS only — the correlation branch below
+      // already filters on kind; without this symmetric check, replying to a non-consult row
+      // by id would CC that row's sender (an undocumented side effect on non-consult flows).
+      if (p.kind !== SOLOMON_CONSULT_KIND) return null;
+      return p.origin_session || byId.sender_session || null;
+    }
   } catch { /* fall through to correlation match */ }
   try {
     const { data } = await supabase
@@ -351,6 +362,54 @@ async function resolveConsultOriginator(supabase, value) {
     if (row) return (row.payload && row.payload.origin_session) || row.sender_session || null;
   } catch { /* fail-open: no CC */ }
   return null;
+}
+
+/**
+ * QF-20260705-488: deliver the originator's CC copy of a consult answer, idempotently.
+ * Resolves the consult's originating session, prefers the LIVE session for that role
+ * (adversarial-review W3: a consult-time session id may be dead — an Adam restart would
+ * otherwise dead-letter the CC into a session nobody polls), skips when the originator IS
+ * the answer target or Solomon itself, and skips when a row for this reply already targets
+ * the originator (idempotent — makes the dedup-branch re-run heal a previously FAILED CC,
+ * adversarial-review W1, instead of stranding it behind the primary-answer dedup forever).
+ * Never throws (fail-open). Exported for tests.
+ * @returns {Promise<{inserted: boolean, originator: string|null, error?: string}>}
+ */
+async function ensureOriginatorCc(supabase, { replyRef, replyTo, target, sessionId, subject, payload, expiresAt }, { getLiveAdamId = getActiveAdamId, insertRow = insertCoordinationRow } = {}) {
+  try {
+    let originator = await resolveConsultOriginator(supabase, replyRef);
+    if (!originator) return { inserted: false, originator: null };
+    // W3: map a dead consult-time session id to the LIVE session of the same role. Adam is
+    // the one lateral peer whose consults this lane answers; other roles keep the raw id
+    // (their outbound drains re-target unread rows on restart).
+    try {
+      const { data: sess } = await supabase.from('claude_sessions').select('metadata').eq('session_id', originator).maybeSingle();
+      if (sess && sess.metadata && sess.metadata.role === 'adam') {
+        originator = (await getLiveAdamId(supabase).catch(() => null)) || originator;
+      }
+    } catch { /* keep the raw originator */ }
+    if (originator === target || originator === sessionId) return { inserted: false, originator };
+    // Idempotence: a row for this reply already targeting the originator (a prior CC, or the
+    // primary answer itself under --to adam) means delivered — never duplicate.
+    try {
+      const { data: existing } = await supabase
+        .from('session_coordination')
+        .select('id')
+        .eq('target_session', originator)
+        .eq('payload->>reply_to', String(replyTo))
+        .limit(1);
+      if (Array.isArray(existing) && existing.length > 0) return { inserted: false, originator };
+    } catch { /* fail-open: attempt the CC */ }
+    const { error: ccErr } = await insertRow(
+      supabase,
+      { sender_session: sessionId, sender_type: 'solomon', target_session: originator, message_type: 'INFO', subject, body: payload.body, payload: { ...payload, via: 'cc_originator' }, expires_at: expiresAt },
+      { select: 'id', single: true }
+    );
+    if (ccErr) return { inserted: false, originator, error: (ccErr && ccErr.message) || String(ccErr) };
+    return { inserted: true, originator };
+  } catch (e) {
+    return { inserted: false, originator: null, error: (e && e.message) || String(e) };
+  }
 }
 
 /**
@@ -529,7 +588,7 @@ async function main() {
     process.exit(2);
   }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to adam` — direct 1-hop
-  // channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default OFF; omitting --to is unchanged).
+  // channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' kills it).
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
   // the relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) —
   // these enqueue a tracked FR-1 relay-request instead of a direct write. --direct is
@@ -595,14 +654,21 @@ async function main() {
     try { replyTo = await resolveReplyToCorrelation(supabase, replyToArg); }
     catch (e) { console.error(`ERROR: --reply-to ${replyToArg} — ${e.message}`); process.exit(2); }
   }
-  // Durable dedup: never re-answer a consult already answered (when replying to one).
-  if (replyTo && (await alreadyAnswered(supabase, replyTo))) {
-    console.log(`(dedup) consult ${String(replyTo).slice(0, 8)} already answered — not re-sending.`);
-    return;
-  }
   const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, replyTo, via, replyClass: replyClassArg, replyWindowMs });
   const subject = `[SOLOMON_ORACLE] ${payload.body.slice(0, 80)}`;
   const expiresAt = advisoryExpiresAt(Date.now());
+
+  // Durable dedup: never re-answer a consult already answered (when replying to one).
+  // QF-20260705-488 (adversarial-review W1): this return previously made a FAILED originator
+  // CC permanently unrecoverable — the primary answer existed, so a re-run short-circuited
+  // here and the originator never got its copy (the exact hand-relay gap this QF closes).
+  // The dedup branch now heals a missing CC (idempotent) before returning.
+  if (replyTo && (await alreadyAnswered(supabase, replyTo))) {
+    const healed = await ensureOriginatorCc(supabase, { replyRef: replyToArg || replyTo, replyTo, target, sessionId, subject, payload, expiresAt });
+    console.log(`(dedup) consult ${String(replyTo).slice(0, 8)} already answered — not re-sending.${healed.inserted ? ` (healed missing originator CC -> ${healed.originator})` : ''}`);
+    if (healed.error) console.error('WARN: originator CC heal failed (re-run the same --reply-to to retry):', healed.error);
+    return;
+  }
 
   let inserted;
   try {
@@ -636,22 +702,12 @@ async function main() {
 
   // QF-20260705-488 (chairman-caught): a consult ANSWER must also land in the ORIGINATOR's
   // inbox — answer d7f5401c targeted only the coordinator while the consult came from Adam,
-  // and the chairman had to hand-relay the verdict. When replying to a consult, CC the
-  // consult's originating session whenever it differs from the answer target and from
-  // Solomon itself. Fail-open: a CC failure warns, never blocks the primary send.
+  // and the chairman had to hand-relay the verdict. Fail-open: a CC failure warns, never
+  // blocks the primary send; a re-run of the same --reply-to heals a missing CC (W1).
   if (replyTo) {
-    try {
-      const originator = await resolveConsultOriginator(supabase, replyToArg || replyTo);
-      if (originator && originator !== target && originator !== sessionId) {
-        const { error: ccErr } = await insertCoordinationRow(
-          supabase,
-          { sender_session: sessionId, sender_type: 'solomon', target_session: originator, message_type: 'INFO', subject, body: payload.body, payload: { ...payload, via: 'cc_originator' }, expires_at: expiresAt },
-          { select: 'id', single: true }
-        );
-        if (ccErr) console.error('WARN: originator CC failed (primary send unaffected):', ccErr.message || ccErr);
-        else console.log('  cc_originator:', originator);
-      }
-    } catch (e) { console.error('WARN: originator CC failed (primary send unaffected):', (e && e.message) || e); }
+    const cc = await ensureOriginatorCc(supabase, { replyRef: replyToArg || replyTo, replyTo, target, sessionId, subject, payload, expiresAt });
+    if (cc.inserted) console.log('  cc_originator:', cc.originator);
+    else if (cc.error) console.error('WARN: originator CC failed (primary send unaffected; re-run the same --reply-to to retry):', cc.error);
   }
 
   console.log('✓ Solomon oracle advisory sent');
@@ -674,7 +730,7 @@ module.exports = {
   isReplyRow, isSolomonInboxRow, isOrphanedSolomonRow, SOLOMON_INBOX_KINDS, EXCLUDED_KINDS, SOLOMON_CONSULT_KIND,
   computeConsultSignature, enforceSweepBudget, SOLOMON_SWEEP_BUDGET, alreadyAnswered, checkConsultQuota,
   drainInbox, resolveReplyToCorrelation, drainSolomonOutbound, captureLedgerRow,
-  checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator,
+  checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator, ensureOriginatorCc,
 };
 
 if (require.main === module) {

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -323,6 +323,37 @@ async function resolveReplyToCorrelation(supabase, value) {
 }
 
 /**
+ * QF-20260705-488: resolve the session that ORIGINATED a consult, from the same value
+ * `--reply-to` accepts (a consult row id OR a bare correlation id). Prefers an explicit
+ * payload.origin_session (set by relay paths that preserve the true originator), else the
+ * consult row's sender_session. Null when unresolvable — the caller treats that as
+ * "no CC" (fail-open). Exported for tests.
+ */
+async function resolveConsultOriginator(supabase, value) {
+  if (!value) return null;
+  try {
+    const { data: byId } = await supabase
+      .from('session_coordination')
+      .select('sender_session, payload')
+      .eq('id', value)
+      .maybeSingle();
+    if (byId) return (byId.payload && byId.payload.origin_session) || byId.sender_session || null;
+  } catch { /* fall through to correlation match */ }
+  try {
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('sender_session, payload, created_at')
+      .eq('payload->>correlation_id', String(value))
+      .eq('payload->>kind', SOLOMON_CONSULT_KIND)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    const row = Array.isArray(data) && data[0] ? data[0] : null;
+    if (row) return (row.payload && row.payload.origin_session) || row.sender_session || null;
+  } catch { /* fail-open: no CC */ }
+  return null;
+}
+
+/**
  * Fail-open capture: upsert a solomon_advice_outcome_ledger row for this advisory send/request,
  * keyed on payload.correlation_id (idempotent — ON CONFLICT DO NOTHING). NEVER throws or blocks the
  * advisory send — a ledger write failure (table not yet applied, transient DB error) must not
@@ -526,7 +557,7 @@ async function main() {
   }
   const twoWayV1On = isAdamSolomonTwoWayV1Enabled();
   if (peerArg === 'adam' && !twoWayV1On) {
-    console.error('ERROR: --to adam is gated by ADAM_SOLOMON_TWOWAY_V1=on (currently OFF). Omit --to to route via the coordinator.');
+    console.error('ERROR: --to adam is disabled by ADAM_SOLOMON_TWOWAY_V1=off (direct lane is ON by default since QF-20260705-488). Omit --to to route via the coordinator.');
     process.exit(3);
   }
 
@@ -603,6 +634,26 @@ async function main() {
     console.error(`WARN: ledger capture failed (${ledgerCaptureFailures} this run) — ${ledgerResult.reason}`);
   }
 
+  // QF-20260705-488 (chairman-caught): a consult ANSWER must also land in the ORIGINATOR's
+  // inbox — answer d7f5401c targeted only the coordinator while the consult came from Adam,
+  // and the chairman had to hand-relay the verdict. When replying to a consult, CC the
+  // consult's originating session whenever it differs from the answer target and from
+  // Solomon itself. Fail-open: a CC failure warns, never blocks the primary send.
+  if (replyTo) {
+    try {
+      const originator = await resolveConsultOriginator(supabase, replyToArg || replyTo);
+      if (originator && originator !== target && originator !== sessionId) {
+        const { error: ccErr } = await insertCoordinationRow(
+          supabase,
+          { sender_session: sessionId, sender_type: 'solomon', target_session: originator, message_type: 'INFO', subject, body: payload.body, payload: { ...payload, via: 'cc_originator' }, expires_at: expiresAt },
+          { select: 'id', single: true }
+        );
+        if (ccErr) console.error('WARN: originator CC failed (primary send unaffected):', ccErr.message || ccErr);
+        else console.log('  cc_originator:', originator);
+      }
+    } catch (e) { console.error('WARN: originator CC failed (primary send unaffected):', (e && e.message) || e); }
+  }
+
   console.log('✓ Solomon oracle advisory sent');
   console.log('  advisory_id:', inserted.id);
   console.log('  target:', target);
@@ -623,7 +674,7 @@ module.exports = {
   isReplyRow, isSolomonInboxRow, isOrphanedSolomonRow, SOLOMON_INBOX_KINDS, EXCLUDED_KINDS, SOLOMON_CONSULT_KIND,
   computeConsultSignature, enforceSweepBudget, SOLOMON_SWEEP_BUDGET, alreadyAnswered, checkConsultQuota,
   drainInbox, resolveReplyToCorrelation, drainSolomonOutbound, captureLedgerRow,
-  checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget,
+  checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator,
 };
 
 if (require.main === module) {

--- a/scripts/three-way-comms-drill.mjs
+++ b/scripts/three-way-comms-drill.mjs
@@ -311,7 +311,10 @@ async function main() {
   const baselineFile = argVal('--baseline-file') || process.env.COMMS_DRILL_BASELINE || path.join(process.cwd(), '.comms-drill-baseline.json');
 
   const now = Date.now();
-  const twoway = /^(on|true|1)$/i.test(String(process.env.ADAM_SOLOMON_TWOWAY_V1 || ''));
+  // QF-20260705-488: read the SHARED gate (default now ON, off only on explicit 'off') instead of
+  // a private regex — the drill previously said RELAY while the real gate routed DIRECT (drift).
+  const { isAdamSolomonTwoWayV1Enabled } = await import('../lib/coordinator/resolve.cjs').then(m => m.default || m);
+  const twoway = isAdamSolomonTwoWayV1Enabled();
   const windowMs = resolveWindowMs(process.env);
   const topic = `comms_drill:${new Date(now).toISOString().replace(/[:.]/g, '-')}:${Math.random().toString(36).slice(2, 8)}`;
 

--- a/tests/unit/adam-solomon-direct-channel.test.js
+++ b/tests/unit/adam-solomon-direct-channel.test.js
@@ -17,14 +17,18 @@ const { isAdamSolomonTwoWayV1Enabled } = require('../../lib/coordinator/resolve.
 const { assertValidTarget } = require('../../lib/coordinator/dispatch.cjs');
 
 describe('isAdamSolomonTwoWayV1Enabled — flag gate correctness', () => {
-  it('true only for exactly "on"', () => {
+  // QF-20260705-488 (chairman-directed): default flipped ON — the OFF default forced a
+  // hand-relay of consult answer d7f5401c. Off ONLY on the explicit 'off' kill switch.
+  it('enabled by default; disabled only by exactly "off"', () => {
     const prev = process.env.ADAM_SOLOMON_TWOWAY_V1;
     try {
       process.env.ADAM_SOLOMON_TWOWAY_V1 = 'on';
       expect(isAdamSolomonTwoWayV1Enabled()).toBe(true);
       process.env.ADAM_SOLOMON_TWOWAY_V1 = 'true';
-      expect(isAdamSolomonTwoWayV1Enabled()).toBe(false);
+      expect(isAdamSolomonTwoWayV1Enabled()).toBe(true);
       delete process.env.ADAM_SOLOMON_TWOWAY_V1;
+      expect(isAdamSolomonTwoWayV1Enabled()).toBe(true);
+      process.env.ADAM_SOLOMON_TWOWAY_V1 = 'off';
       expect(isAdamSolomonTwoWayV1Enabled()).toBe(false);
     } finally {
       if (prev === undefined) delete process.env.ADAM_SOLOMON_TWOWAY_V1;

--- a/tests/unit/solomon-consult-originator-cc.test.js
+++ b/tests/unit/solomon-consult-originator-cc.test.js
@@ -1,0 +1,81 @@
+/**
+ * QF-20260705-488 (chairman-caught): Solomon's consult answer d7f5401c targeted ONLY the
+ * coordinator — Adam's directed-message log showed zero Solomon rows and the chairman had
+ * to hand-paste the verdict into Adam's session. Two causes, both fixed:
+ *  (1) ADAM_SOLOMON_TWOWAY_V1 defaulted OFF, hard-erroring Adam's `--to solomon` and
+ *      Solomon's `--to adam` — default flipped ON (off only on the explicit 'off' kill
+ *      switch); the pinned default-OFF test in adam-solomon-direct-channel.test.js was
+ *      updated to the chairman-directed contract.
+ *  (2) A consult ANSWER (`send --reply-to <consult>`) inserted a single row at the
+ *      coordinator target — resolveConsultOriginator() now resolves the consult's
+ *      originating session (payload.origin_session, else sender_session) so the send
+ *      path CCs the originator whenever it differs from the target and from Solomon.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveConsultOriginator, resolveSolomonAdvisoryTarget, SOLOMON_CONSULT_KIND } = require('../../scripts/solomon-advisory.cjs');
+
+const ADAM_SESSION = 'adam-sess-1111';
+const CONSULT_ROW_ID = 'row-id-2222';
+const CONSULT_CORR = 'corr-3333';
+
+function fakeSb({ byId = null, byCorrelation = [] } = {}) {
+  return {
+    from() {
+      const state = { wantsCorrelation: false };
+      const api = {
+        select() { return this; },
+        eq(col, val) {
+          if (col === 'payload->>correlation_id') state.wantsCorrelation = true;
+          state.lastEq = { col, val };
+          return this;
+        },
+        order() { return this; },
+        maybeSingle() { return Promise.resolve({ data: byId, error: null }); },
+        limit() { return Promise.resolve({ data: byCorrelation, error: null }); },
+      };
+      return api;
+    },
+  };
+}
+
+describe('resolveConsultOriginator — finds who asked the consult', () => {
+  it('resolves by row id: returns the consult row sender_session', async () => {
+    const sb = fakeSb({ byId: { sender_session: ADAM_SESSION, payload: { kind: SOLOMON_CONSULT_KIND } } });
+    expect(await resolveConsultOriginator(sb, CONSULT_ROW_ID)).toBe(ADAM_SESSION);
+  });
+
+  it('prefers an explicit payload.origin_session over sender_session (relay-preserved originator)', async () => {
+    const sb = fakeSb({ byId: { sender_session: 'coordinator-sess', payload: { origin_session: ADAM_SESSION } } });
+    expect(await resolveConsultOriginator(sb, CONSULT_ROW_ID)).toBe(ADAM_SESSION);
+  });
+
+  it('falls back to a correlation match on solomon_consult rows when no row matches the id', async () => {
+    const sb = fakeSb({ byId: null, byCorrelation: [{ sender_session: ADAM_SESSION, payload: { kind: SOLOMON_CONSULT_KIND, correlation_id: CONSULT_CORR } }] });
+    expect(await resolveConsultOriginator(sb, CONSULT_CORR)).toBe(ADAM_SESSION);
+  });
+
+  it('returns null when nothing matches (caller skips the CC — fail-open)', async () => {
+    const sb = fakeSb({ byId: null, byCorrelation: [] });
+    expect(await resolveConsultOriginator(sb, 'unknown')).toBeNull();
+  });
+
+  it('returns null for a missing value', async () => {
+    expect(await resolveConsultOriginator(fakeSb(), null)).toBeNull();
+  });
+});
+
+describe('direct lane under the flipped default — the chairman round-trip shape', () => {
+  it('--to adam with the (now default-on) flag routes DIRECT to the live Adam session', () => {
+    const { target, via } = resolveSolomonAdvisoryTarget({ toAdam: true, flagOn: true, coordinatorId: 'coord-1', adamId: ADAM_SESSION });
+    expect(target).toBe(ADAM_SESSION);
+    expect(via).toBe('direct');
+  });
+
+  it('default (no --to) remains the coordinator relay — board-reads and plain sends unchanged', () => {
+    const { target, via } = resolveSolomonAdvisoryTarget({ toAdam: false, flagOn: true, coordinatorId: 'coord-1', adamId: ADAM_SESSION });
+    expect(target).toBe('coord-1');
+    expect(via).toBeNull();
+  });
+});

--- a/tests/unit/solomon-consult-originator-cc.test.js
+++ b/tests/unit/solomon-consult-originator-cc.test.js
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { resolveConsultOriginator, resolveSolomonAdvisoryTarget, SOLOMON_CONSULT_KIND } = require('../../scripts/solomon-advisory.cjs');
+const { resolveConsultOriginator, ensureOriginatorCc, checkConsultQuota, resolveSolomonAdvisoryTarget, SOLOMON_CONSULT_KIND } = require('../../scripts/solomon-advisory.cjs');
 
 const ADAM_SESSION = 'adam-sess-1111';
 const CONSULT_ROW_ID = 'row-id-2222';
@@ -47,8 +47,13 @@ describe('resolveConsultOriginator — finds who asked the consult', () => {
   });
 
   it('prefers an explicit payload.origin_session over sender_session (relay-preserved originator)', async () => {
-    const sb = fakeSb({ byId: { sender_session: 'coordinator-sess', payload: { origin_session: ADAM_SESSION } } });
+    const sb = fakeSb({ byId: { sender_session: 'coordinator-sess', payload: { kind: SOLOMON_CONSULT_KIND, origin_session: ADAM_SESSION } } });
     expect(await resolveConsultOriginator(sb, CONSULT_ROW_ID)).toBe(ADAM_SESSION);
+  });
+
+  it('a NON-consult row resolved by id yields null — CC is scoped to consults only (review I4)', async () => {
+    const sb = fakeSb({ byId: { sender_session: 'coordinator-sess', payload: { kind: 'coordinator_reply' } } });
+    expect(await resolveConsultOriginator(sb, CONSULT_ROW_ID)).toBeNull();
   });
 
   it('falls back to a correlation match on solomon_consult rows when no row matches the id', async () => {
@@ -63,6 +68,90 @@ describe('resolveConsultOriginator — finds who asked the consult', () => {
 
   it('returns null for a missing value', async () => {
     expect(await resolveConsultOriginator(fakeSb(), null)).toBeNull();
+  });
+});
+
+describe('ensureOriginatorCc — idempotent CC delivery (review W1/W3)', () => {
+  const CONSULT = { sender_session: ADAM_SESSION, payload: { kind: SOLOMON_CONSULT_KIND } };
+  const BASE_ARGS = {
+    replyRef: CONSULT_ROW_ID, replyTo: CONSULT_CORR, target: 'coord-1', sessionId: 'solomon-1',
+    subject: '[SOLOMON_ORACLE] verdict', payload: { kind: 'adam_advisory', oracle: true, body: 'verdict', reply_to: CONSULT_CORR }, expiresAt: '2026-07-06T00:00:00Z',
+  };
+
+  function ccFakeSb({ consult = CONSULT, existingCc = [], sessionRole = null } = {}) {
+    return {
+      from(table) {
+        const api = {
+          select() { return this; },
+          eq() { return this; },
+          order() { return this; },
+          maybeSingle() {
+            if (table === 'claude_sessions') return Promise.resolve({ data: sessionRole ? { metadata: { role: sessionRole } } : null, error: null });
+            return Promise.resolve({ data: consult, error: null }); // session_coordination by id
+          },
+          limit() { return Promise.resolve({ data: existingCc, error: null }); },
+        };
+        return api;
+      },
+    };
+  }
+
+  function captureInsertRow(inserts) {
+    return async (_sb, row) => { inserts.push(row); return { data: { id: 'cc-1' }, error: null }; };
+  }
+
+  it('inserts a via:cc_originator row targeted at the consult originator', async () => {
+    const inserts = [];
+    const res = await ensureOriginatorCc(ccFakeSb(), BASE_ARGS, { insertRow: captureInsertRow(inserts) });
+    expect(res.inserted).toBe(true);
+    expect(res.originator).toBe(ADAM_SESSION);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].target_session).toBe(ADAM_SESSION);
+    expect(inserts[0].payload.via).toBe('cc_originator');
+  });
+
+  it('is idempotent: an existing row for this reply targeting the originator suppresses the CC (heal path, W1)', async () => {
+    const inserts = [];
+    const res = await ensureOriginatorCc(ccFakeSb({ existingCc: [{ id: 'prior-cc' }] }), BASE_ARGS, { insertRow: captureInsertRow(inserts) });
+    expect(res.inserted).toBe(false);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('re-resolves a dead adam consult-time session to the LIVE adam session (W3)', async () => {
+    const inserts = [];
+    const LIVE_ADAM = 'adam-sess-9999';
+    const res = await ensureOriginatorCc(ccFakeSb({ sessionRole: 'adam' }), BASE_ARGS, { getLiveAdamId: async () => LIVE_ADAM, insertRow: captureInsertRow(inserts) });
+    expect(res.inserted).toBe(true);
+    expect(res.originator).toBe(LIVE_ADAM);
+    expect(inserts[0].target_session).toBe(LIVE_ADAM);
+  });
+
+  it('skips when the originator IS the answer target (coordinator-originated consult: no duplicate)', async () => {
+    const inserts = [];
+    const res = await ensureOriginatorCc(
+      ccFakeSb({ consult: { sender_session: 'coord-1', payload: { kind: SOLOMON_CONSULT_KIND } } }),
+      BASE_ARGS,
+      { insertRow: captureInsertRow(inserts) }
+    );
+    expect(res.inserted).toBe(false);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('a failed CC insert reports the error so the caller warns with the retry hint (W1 loudness)', async () => {
+    const res = await ensureOriginatorCc(ccFakeSb(), BASE_ARGS, { insertRow: async () => ({ data: null, error: { message: 'boom' } }) });
+    expect(res.inserted).toBe(false);
+    expect(res.error).toBe('boom');
+  });
+});
+
+describe('checkConsultQuota — CC copies do not double-count (review W2)', () => {
+  it('excludes via:cc_originator rows from the per-day count', async () => {
+    const rows = [];
+    for (let i = 0; i < 19; i++) rows.push({ id: `a${i}`, payload: { oracle: true }, created_at: 'x' });
+    for (let i = 0; i < 19; i++) rows.push({ id: `c${i}`, payload: { oracle: true, via: 'cc_originator' }, created_at: 'x' });
+    const sb = { from() { return { select() { return this; }, eq() { return this; }, gte() { return this; }, limit() { return Promise.resolve({ data: rows, error: null }); } }; } };
+    // 19 real answers + 19 CC copies: with the exclusion this is still under the 20/day ceiling.
+    expect((await checkConsultQuota(sb, {})).allowed).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
Chairman-caught: Solomon consult answer d7f5401c (J2a model-tier verdict, sequencing-critical) targeted only the coordinator; Adam saw zero Solomon rows all window and the chairman hand-pasted the verdict into Adam''s session. Two verified causes, both fixed.

## Fix
- **Direct lane default-on** (`lib/coordinator/resolve.cjs`): `ADAM_SOLOMON_TWOWAY_V1` flips to on-unless-`off` — chairman expectation on record that Solomon responses route directly to Adam. Both advisory CLIs share this gate; error messages updated to the kill-switch semantics. The comms drill now reads the shared gate instead of a private `^(on|true|1)$` regex that had already drifted from it.
- **Originator CC** (`scripts/solomon-advisory.cjs`): new `resolveConsultOriginator()` resolves a consult (by row id or bare correlation, same forms `--reply-to` accepts) to its originating session (`payload.origin_session` preferred, else `sender_session`). The answer path inserts a `via: cc_originator` copy whenever the originator differs from the answer target and from Solomon. Fail-open: CC failure warns, never blocks the primary send.
- **Unchanged** (QF item c): board-reads and plain no-`--to` sends keep the coordinator-relay target.

## Test plan
- New: tests/unit/solomon-consult-originator-cc.test.js (originator by id / origin_session preference / correlation fallback / fail-open null; direct-lane routing shape)
- Updated: adam-solomon-direct-channel.test.js pinned flag test → chairman-directed contract (on by default, off only on explicit `off`)
- Drill dry-run: all six lanes `[direct] ok`, `no_gaps=true`, `adam_solomon_twoway_v1: true`
- 42 tests green across the three touched suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)