### PR TITLE
fix(QF-20260705-436): quarantined wedge sessions are not dispatchable idle capacity

### DIFF
--- a/lib/fleet/session-predicates.mjs
+++ b/lib/fleet/session-predicates.mjs
@@ -93,6 +93,15 @@ export function isDispatchableFleetMember(session, coordinatorId) {
     if (session.session_id && coordinatorId && session.session_id === coordinatorId) return false;
     if (session.metadata?.role === 'adam') return false;
     if (session.metadata?.non_fleet) return false;
+    // QF-20260705-436: a coordinator-quarantined WEDGE session (PID alive + heartbeat fresh
+    // but conversationally dead — zero tool calls/acks for hours) must never count as
+    // dispatchable idle capacity. The charter-audit's DUTY-3 remediation would otherwise
+    // demand a WORK_ASSIGNMENT into a window nobody reads (live specimen 7bd4e96b,
+    // 2026-07-05) — a violation that can only clear via the exact wrong-action. The
+    // coordinator stamps metadata.quarantined_at on confirmed wedges; clearing the key
+    // restores the session to capacity. Applied HERE (the SSOT predicate) so the audit,
+    // capacity forecaster, dashboard and rollcall all agree.
+    if (session.metadata?.quarantined_at) return false;
     if (isFixtureSession(session)) return false;
     return true;
   } catch {

--- a/tests/unit/session-predicates.test.js
+++ b/tests/unit/session-predicates.test.js
@@ -124,6 +124,19 @@ describe('isDispatchableFleetMember — idle/capacity panel role guard (no everC
     expect(isDispatchableFleetMember(undefined, coordId)).toBe(false);
     expect(isDispatchableFleetMember({}, coordId)).toBe(true);   // unknown role → counted (same as legacy)
   });
+
+  // QF-20260705-436: a coordinator-quarantined WEDGE (heartbeat-fresh but conversationally
+  // dead — specimen 7bd4e96b) false-flagged as a live-idle dispatch target, so the charter
+  // audit's DUTY-3 demanded a WORK_ASSIGNMENT into a window nobody reads.
+  it('EXCLUDES a quarantined wedge session (metadata.quarantined_at set) from dispatchable capacity', () => {
+    const wedge = { session_id: '7bd4e96b-0000-4000-8000-000000000000', status: 'active', metadata: { quarantined_at: '2026-07-05T08:00:00Z' }, sd_key: null };
+    expect(isDispatchableFleetMember(wedge, coordId)).toBe(false);
+  });
+
+  it('an un-quarantined session (key cleared/absent/null) counts again — quarantine is reversible', () => {
+    expect(isDispatchableFleetMember({ session_id: 'e4c2b7aa-0000-4000-8000-000000000000', metadata: { quarantined_at: null }, sd_key: null }, coordId)).toBe(true);
+    expect(isDispatchableFleetMember({ session_id: 'e4c2b7aa-0000-4000-8000-000000000000', metadata: {}, sd_key: null }, coordId)).toBe(true);
+  });
 });
 
 describe('production wiring guard (catch idle-filter call-site deletion)', () => {


### PR DESCRIPTION
## Summary
The charter audit counted sessions as live-idle dispatch targets on heartbeat freshness alone. A quarantined wedge (PID alive + heartbeat ticking + zero tool calls/acks for 12h+) false-flagged as an idle worker, generating a DUTY-3 violation whose named remediation — dispatch a WORK_ASSIGNMENT — targets a conversationally dead window (live specimen 7bd4e96b, 2026-07-05 ~09:45Z). The violation could only clear via the exact wrong-action.

## Fix
One guard at the SSOT seam: `isDispatchableFleetMember` (lib/fleet/session-predicates.mjs) excludes sessions bearing `metadata.quarantined_at` — the marker the coordinator already stamps on confirmed wedges (present on both current wedge sessions). Because every consumer (charter audit `liveWorkers`, capacity forecaster, fleet dashboard, rollcall) shares this predicate, they all agree — the module''s stated design intent. Clearing the key restores the session to capacity.

The QF''s optional conversational-evidence axis (recent acks/sends) is left as future hardening; the marker-based exclusion is the specified fix.

## Test plan
- New: quarantined wedge excluded; un-quarantine (key cleared/null/absent) restores membership
- Adjacent green: session-predicates (full) + coordinator/charter-audit-detectors — 77 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)