### PR TITLE
fix(QF-20260704-051): dashboard AVAILABLE FOR CLAIM count matches ranker's true claimable depth

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -163,9 +163,13 @@ const sb = createClient(
  * from what the ranker (and therefore worker-checkin) actually considers claimable. main() below is
  * byte-identical in behavior; it now calls this function instead of inlining the fetch+filter.
  * @param {object} sb - supabase service-role client
+ * @param {{ quiet?: boolean }} [opts] - QF-20260704-051: quiet=true silences the per-skip
+ *   console.log lines below (still counts them) — for callers like fleet-dashboard.cjs that
+ *   poll this on every render and must not spam stdout with ranker skip-reason logging.
  * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[] }>}
  */
-export async function computeClaimableLeaves(sb) {
+export async function computeClaimableLeaves(sb, opts = {}) {
+  const log = opts.quiet ? () => {} : console.log;
   const { data: sds, error } = await sb.from('strategic_directives_v2')
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
     // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + current_phase for the in-flight (started) guard.
@@ -206,25 +210,25 @@ export async function computeClaimableLeaves(sb) {
         case 'claimed': break;                              // claimed by a live session — silent (not a skip-log)
         case 'in_flight':
           inFlightSkips++;
-          console.log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
+          log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
           break;
         case 'fixture':
           fixtureSkips++;
-          console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
+          log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
           break;
         case 'co_author_pending':
           // NOT idle-belt depth: a co-authored SD awaiting convergence would let a parked worker write
           // the PRD before the co-author input lands (SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001).
           awaitingConvergenceSkips++;
-          console.log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
+          log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
           break;
         case 'human_action_required':
           humanActionSkips++;
-          console.log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key}`);
+          log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key}`);
           break;
         default:
           ineligibleSkips++;
-          console.log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
+          log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
       }
       continue;
     }
@@ -236,7 +240,7 @@ export async function computeClaimableLeaves(sb) {
       // QF-20260703-999: this exclusion previously had NO skip-log (unlike every other exclusion
       // reason above), so a dep-blocked SD vanished from both ranked and skip output with zero trace.
       depBlockedSkips++;
-      console.log(`  [skip] dependency-blocked (${unmet.join(', ')}): ${d.sd_key}`);
+      log(`  [skip] dependency-blocked (${unmet.join(', ')}): ${d.sd_key}`);
       continue;
     }
     // SD-REFILL-00MFWEGZ: an orchestrator child whose PARENT has not passed LEAD is not yet
@@ -245,17 +249,17 @@ export async function computeClaimableLeaves(sb) {
     // matches the actually-claimable set. parentLeadPending early-returns false for parentless
     // SDs (no fetch) and fail-opens on error (never strands a child).
     if (await parentLeadPending(sb, d)) {
-      console.log(`  [skip] parent not past LEAD — child not yet dispatchable: ${d.sd_key}`);
+      log(`  [skip] parent not past LEAD — child not yet dispatchable: ${d.sd_key}`);
       continue;
     }
     claimable.push(d);
   }
-  if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
-  if (inFlightSkips) console.log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
-  if (awaitingConvergenceSkips) console.log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
-  if (humanActionSkips) console.log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
-  if (ineligibleSkips) console.log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
-  if (depBlockedSkips) console.log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
+  if (fixtureSkips) log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
+  if (inFlightSkips) log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
+  if (awaitingConvergenceSkips) log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
+  if (humanActionSkips) log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
+  if (ineligibleSkips) log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
+  if (depBlockedSkips) log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
   return { sds, byKey, depStatus, claimable };
 }
 

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -130,7 +130,7 @@ function formatEtaTime(iso) {
 // ── Data Loading ──
 
 async function loadData() {
-  const [sessRes, allSessRes, childRes, workRes, coordRes, rawSessRes, drainRes] = await Promise.all([
+  const [sessRes, allSessRes, childRes, coordRes, rawSessRes, drainRes] = await Promise.all([
     supabase
       .from('v_active_sessions')
       .select('session_id, sd_key, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track, terminal_id, loop_state')
@@ -147,12 +147,6 @@ async function loadData() {
       .select('sd_key, title, status, current_phase, progress_percentage, completion_date, created_at, dependencies')
       .like('sd_key', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-%')
       .order('sd_key', { ascending: true }),
-    supabase
-      .from('strategic_directives_v2')
-      .select('sd_key, title, status, current_phase, progress_percentage, priority')
-      .in('status', ['draft', 'in_progress', 'ready', 'pending_approval'])
-      .not('sd_key', 'like', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001%')
-      .limit(15),
     supabase
       .from('session_coordination')
       .select('id, target_session, target_sd, message_type, subject, read_at, acknowledged_at, created_at')
@@ -189,11 +183,29 @@ async function loadData() {
     // Pre-migration clones don't have the table — silently empty.
   }
 
+  // QF-20260704-051: the "AVAILABLE FOR CLAIM" headline previously used a naive
+  // status-only filter, so requires_human_action / dependency-blocked / orchestrator-parent
+  // SDs counted as available even though the coordinator's own ranker would never dispatch
+  // them (live specimen: dashboard showed 15, true claimable depth was 0). Reuse the SAME
+  // SSOT predicate the ranker uses (classifyDispatchIneligibility + dependency + parent-LEAD
+  // gating) so the two can never diverge. Fail-soft: an error degrades to an empty list
+  // rather than crashing the dashboard.
+  let claimableLeaves = [];
+  try {
+    const { computeClaimableLeaves } = await import('./coordinator-backlog-rank.mjs');
+    const result = await computeClaimableLeaves(supabase, { quiet: true });
+    claimableLeaves = result.claimable || [];
+  } catch (e) {
+    // degrade-safe: empty claimable list, dashboard still renders
+  }
+
   const sessions = sessRes.data || [];
   const allSessions = allSessRes.data || [];
   const drainAgents = drainRes.data || [];
   const children = childRes.data || [];
-  const workable = workRes.data || [];
+  // QF-20260704-051: orchestrator children are tracked separately (above) — exclude their
+  // prefix here so a claimable child SD is never double-counted in both sections.
+  const workable = claimableLeaves.filter(sd => !sd.sd_key.startsWith('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001'));
   const coordMessages = coordRes.data || [];
   const rawSessions = rawSessRes.data || [];
 
@@ -566,10 +578,17 @@ function printAvailable(d) {
 
   if (d.unclaimedStandalone.length > 0) {
     console.log('  Standalone SDs:');
-    for (const sd of d.unclaimedStandalone) {
+    // QF-20260704-051: the headline count above is the TRUE claimable depth (no longer capped
+    // at the query level) — cap only the printed rows so a large backlog stays readable.
+    const DISPLAY_CAP = 15;
+    const displayed = d.unclaimedStandalone.slice(0, DISPLAY_CAP);
+    for (const sd of displayed) {
       const shortKey = sd.sd_key.replace('SD-LEO-', '').replace('SD-', '').substring(0, 22);
       const prio = sd.priority === 'high' ? 'HIGH' : 'MED';
       console.log('    ' + pad(shortKey, 24) + pad(sd.title.substring(0, 38), 40) + prio);
+    }
+    if (d.unclaimedStandalone.length > displayed.length) {
+      console.log('    … and ' + (d.unclaimedStandalone.length - displayed.length) + ' more');
     }
   }
 
@@ -2057,7 +2076,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth };
+module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/tests/unit/coordinator-backlog-rank-quiet-mode.test.js
+++ b/tests/unit/coordinator-backlog-rank-quiet-mode.test.js
@@ -1,0 +1,58 @@
+/**
+ * QF-20260704-051 — fleet-dashboard.cjs now calls computeClaimableLeaves() on every render to
+ * source the AVAILABLE FOR CLAIM headline count (instead of a divergent naive status filter).
+ * That function previously logged a console.log line per skipped SD unconditionally, which
+ * would spam stdout on every dashboard render. The new `{quiet:true}` option silences that
+ * logging without changing the computed claimable set — these tests pin both properties.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { computeClaimableLeaves } from '../../scripts/coordinator-backlog-rank.mjs';
+
+/** Minimal fake sb supporting the two query shapes computeClaimableLeaves issues. */
+function fakeSb(rows) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            not: () => Promise.resolve({ data: rows, error: null }),
+            in: () => Promise.resolve({ data: [], error: null }),
+          };
+        },
+      };
+    },
+  };
+}
+
+const rows = [
+  { sd_key: 'SD-CLEAN-A', sd_type: 'infrastructure', status: 'draft', current_phase: 'LEAD', claiming_session_id: null, metadata: {}, dependencies: null },
+  { sd_key: 'SD-RHA', sd_type: 'infrastructure', status: 'draft', current_phase: 'LEAD', claiming_session_id: null, metadata: { requires_human_action: true }, dependencies: null },
+];
+
+describe('computeClaimableLeaves — quiet option (QF-20260704-051)', () => {
+  it('quiet:true suppresses every console.log call the function makes', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await computeClaimableLeaves(fakeSb(rows), { quiet: true });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('default (no opts) behavior is unchanged — it still logs skip reasons', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await computeClaimableLeaves(fakeSb(rows));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('quiet mode computes the IDENTICAL claimable set as loud mode', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const loud = await computeClaimableLeaves(fakeSb(rows));
+    const quiet = await computeClaimableLeaves(fakeSb(rows), { quiet: true });
+    spy.mockRestore();
+
+    const loudKeys = loud.claimable.map((d) => d.sd_key);
+    const quietKeys = quiet.claimable.map((d) => d.sd_key);
+    expect(quietKeys).toEqual(loudKeys);
+    expect(quietKeys).toEqual(['SD-CLEAN-A']); // SD-RHA excluded (requires_human_action)
+  });
+});

--- a/tests/unit/coordinator/fleet-dashboard-available-claimable.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-available-claimable.test.js
@@ -1,0 +1,51 @@
+/**
+ * QF-20260704-051 — the AVAILABLE FOR CLAIM headline previously counted SDs from a naive
+ * status-only query, diverging from coordinator-backlog-rank.mjs's canonical claimable-leaf
+ * predicate (a live specimen showed dashboard=15 vs true claimable=0). loadData() now sources
+ * unclaimedStandalone from computeClaimableLeaves() instead, so its length is the TRUE
+ * claimable depth. printAvailable no longer relies on a query-level LIMIT to keep the display
+ * readable — these tests pin the display-cap behavior added in its place.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { printAvailable } = require('../../../scripts/fleet-dashboard.cjs');
+
+let logSpy;
+beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { logSpy.mockRestore(); });
+const output = () => logSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+
+const sd = (i) => ({ sd_key: `SD-LEO-INFRA-ITEM-${i}`, title: `Item ${i}`, priority: 'medium' });
+
+describe('printAvailable — headline count vs display cap (QF-20260704-051)', () => {
+  it('headline count equals the TRUE unclaimedStandalone depth even beyond the display cap', () => {
+    const unclaimedStandalone = Array.from({ length: 20 }, (_, i) => sd(i));
+    printAvailable({ unclaimedChildren: [], unclaimedStandalone });
+    expect(output()).toContain('AVAILABLE FOR CLAIM (20)');
+  });
+
+  it('prints only the first 15 rows and an "…and N more" summary when the true depth exceeds the cap', () => {
+    const unclaimedStandalone = Array.from({ length: 20 }, (_, i) => sd(i));
+    printAvailable({ unclaimedChildren: [], unclaimedStandalone });
+    const out = output();
+    expect(out).toContain('Item 14'); // 15th row (0-indexed 14) still shown
+    expect(out).not.toContain('Item 15'); // 16th row is beyond the cap
+    expect(out).toContain('… and 5 more');
+  });
+
+  it('prints every row with no "more" summary when depth is at or under the cap', () => {
+    const unclaimedStandalone = Array.from({ length: 3 }, (_, i) => sd(i));
+    printAvailable({ unclaimedChildren: [], unclaimedStandalone });
+    const out = output();
+    expect(out).toContain('Item 2');
+    expect(out).not.toContain('more');
+  });
+
+  it('zero claimable renders the empty-queue message, not a stale cached count', () => {
+    printAvailable({ unclaimedChildren: [], unclaimedStandalone: [] });
+    const out = output();
+    expect(out).toContain('AVAILABLE FOR CLAIM (0)');
+    expect(out).toContain('all SDs claimed or completed');
+  });
+});


### PR DESCRIPTION
## Summary
`fleet-dashboard.cjs`'s "AVAILABLE FOR CLAIM" headline (and the belt-countdown capacity signal derived from it) used a naive status-only query over `strategic_directives_v2`, so `requires_human_action`-flagged, dependency-blocked, and orchestrator-parent SDs all counted as "available" even though the coordinator's own ranker would never dispatch them. Live specimen (2026-07-05 ~11:16 PM ET): dashboard showed **15**, true claimable depth was **0** — feeding a wrong ~8h runway estimate to the chairman in the 11:01 PM belt-countdown.

This is a known recurring class (gauge-vs-action divergent-flag SSOT).

## Fix
- `scripts/fleet-dashboard.cjs`: `loadData()` now sources its standalone-SD claimable list from `coordinator-backlog-rank.mjs`'s exported `computeClaimableLeaves()` — the exact same SSOT predicate the ranker uses (`classifyDispatchIneligibility` + `requires_human_action` + dependency graph + parent-LEAD gating) — instead of a bespoke `.in('status', [...])` filter. The naive query and its dedicated `Promise.all` slot are removed entirely.
- `scripts/coordinator-backlog-rank.mjs`: `computeClaimableLeaves(sb, opts)` gains an optional `{quiet: true}` param that silences its per-skip `console.log` lines (still counts them internally) — needed because the dashboard now calls this on every render and must not spam stdout with ranker skip-reason logging. Default (no opts) CLI behavior is byte-identical.
- `printAvailable()`: the headline count is now the TRUE, unbounded claimable depth (previously capped at the query level via `.limit(15)`, which is exactly how "0 true / 15 shown" could happen). The printed row list keeps a 15-row display cap with an `"…and N more"` summary so a large backlog still renders readably — count and display are now decoupled on purpose.
- `printAvailable` is exported for direct unit testing.

## Tests
- New: `tests/unit/coordinator-backlog-rank-quiet-mode.test.js` — quiet mode suppresses all logging, computes the identical claimable set as default mode, RHA-flagged SD still excluded.
- New: `tests/unit/coordinator/fleet-dashboard-available-claimable.test.js` — headline count reflects true depth beyond the 15-row cap, cap message renders correctly, zero-claimable renders the empty-queue message.
- Full regression sweep, zero failures: all `tests/unit/coordinator/` (41 files), every existing `coordinator-backlog-rank*`/`gauge-unranked-claimable-leaves`/`fleet-dashboard-solomon-*` test — **448 tests total**.
- **Live-verified against the real DB**: ran the ranker's `computeClaimableLeaves()` and the dashboard's `available` section back-to-back on the same snapshot — both now report the identical count (5) and identical SD keys. (An earlier same-session check briefly saw a 6-vs-5 mismatch that traced to another live fleet session claiming/completing an SD in the few seconds between two separate diagnostic script invocations — not a bug in this fix; re-confirmed with a true same-moment comparison.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)