### PR TITLE
feat(SD-LEO-INFRA-J2A-EVA-GENERATION-001): EVA generation-layer model-tier A/B experiment harness

### DIFF
--- a/scripts/eva/j2a-model-tier-experiment.mjs
+++ b/scripts/eva/j2a-model-tier-experiment.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * J2a — EVA Generation-Layer Model-Tier A/B Experiment
+ * SD-LEO-INFRA-J2A-EVA-GENERATION-001
+ *
+ * Solomon-designed (advisory d7f5401c): settle, with evidence, whether EVA's
+ * budget-tier generation model (Gemini 2.5 Flash) is undershooting quality in
+ * the planning-artifact layer, BEFORE the remediation spec pack
+ * (SD-LEO-INFRA-MARKETLENS-REMEDIATION-TRIAGE-001) is written.
+ *
+ * Pilot sample: MarketLens's `blueprint_user_story_pack` artifact (14 stories,
+ * 13 BUILT + 1 PARTIAL at story index 5). Three arms regenerate the whole
+ * artifact from the same venture brief; the SAME mechanical evidence-matcher
+ * that produced the live scorecard (lib/eva/post-build-verdict-engine.js)
+ * re-derives disposition — no rebuild of the venture is required.
+ *
+ * AMBIGUITY RESOLUTION (per CLAUDE_EXEC.md Step 0): a freshly-regenerated
+ * artifact will not reproduce stories in the same order/count as the
+ * original, so positional index-matching across arms is unsound. Resolved by
+ * keyword-overlap matching (matchClaimToRegenerated): each arm's regenerated
+ * claim set is searched for the best keyword match to the ORIGINAL target/
+ * control claim text; a zero-overlap match means the model's regeneration did
+ * not cover that user intent at all, which conservatively counts as no
+ * evidence (mirrors post-build-verdict-engine.js's own "ambiguous -> PARTIAL/
+ * MISSING, never BUILT" bias).
+ *
+ * FR-1: the decision rule below is LOCKED before any generation call runs.
+ * EXEC MUST NOT amend it after seeing results.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { getLLMClient } from '../../lib/llm/client-factory.js';
+import {
+  extractUserStoryClaims,
+  findEvidenceForClaim,
+  computeDisposition,
+  resolveVentureRepoPath,
+} from '../../lib/eva/post-build-verdict-engine.js';
+import { rowCost } from '../../lib/cost/llm-pricing.js';
+import { systemPrompt as USER_STORY_PACK_SYSTEM_PROMPT } from '../../lib/eva/blueprint-agents/user-story-pack.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+export const SD_KEY = 'SD-LEO-INFRA-J2A-EVA-GENERATION-001';
+export const VENTURE_ID = 'ecbba50e-3c98-4493-9e77-1719cf6b6f00';
+export const ARTIFACT_TYPE = 'blueprint_user_story_pack';
+
+// FR-3: 1 PARTIAL flip target + 3 BUILT controls, confirmed live against
+// post_build_verdicts before this rule was locked (see PRD FR-3).
+export const SAMPLE = Object.freeze({
+  targetIndex: 5,
+  controlIndices: Object.freeze([0, 1, 6]),
+});
+
+export const ARMS = Object.freeze({
+  NULL_REROLL: 'null_reroll',
+  CONTROL: 'control',
+  HIGHER_TIER: 'higher_tier',
+});
+
+export const HIGHER_TIER_MODEL = 'claude-sonnet-4-6';
+
+/**
+ * FR-1: the pre-registered decision rule, locked BEFORE any generation call.
+ */
+export const DECISION_RULE = Object.freeze({
+  version: 1,
+  lockedAt: '2026-07-05',
+  description:
+    'higher_tier arm PASSES (flip-remediation) iff it flips SAMPLE.targetIndex from PARTIAL to BUILT ' +
+    'AND zero SAMPLE.controlIndices regress to non-BUILT under higher_tier, ' +
+    'AND null_reroll does NOT ALSO flip SAMPLE.targetIndex to BUILT (a null-baseline flip means the ' +
+    'observed flip is reroll luck, not a genuine tier effect -- higher_tier gets no credit for it). ' +
+    'If higher_tier flips the target but regresses a control, verdict is partial-retier. Otherwise proceed-unchanged.',
+});
+
+const STOPWORDS = new Set(['this', 'that', 'with', 'from', 'have', 'should', 'user', 'users', 'story', 'when', 'then', 'able', 'want', 'need', 'their', 'they']);
+
+/** Mirrors post-build-verdict-engine.js's private extractKeywords tokenization for
+ * consistency with the disposition engine's own matching philosophy. */
+export function extractKeywords(text) {
+  return [...new Set(
+    String(text || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w.length >= 4 && !STOPWORDS.has(w))
+  )];
+}
+
+/**
+ * Keyword-overlap match: find the regenerated claim whose keyword set overlaps
+ * most with the original claim's keyword set. Returns null (no comparable
+ * story) when the best overlap is zero -- conservative, never invents a match.
+ * @param {string} originalClaimText
+ * @param {string[]} regeneratedClaims
+ * @returns {{claim: string, overlap: number}|null}
+ */
+export function matchClaimToRegenerated(originalClaimText, regeneratedClaims) {
+  const originalKeywords = new Set(extractKeywords(originalClaimText));
+  if (originalKeywords.size === 0) return null;
+
+  let best = null;
+  for (const claim of regeneratedClaims) {
+    const claimKeywords = extractKeywords(claim);
+    const overlap = claimKeywords.filter((k) => originalKeywords.has(k)).length;
+    if (overlap > 0 && (!best || overlap > best.overlap)) {
+      best = { claim, overlap };
+    }
+  }
+  return best;
+}
+
+/**
+ * Pure function: evaluate DECISION_RULE against computed per-arm dispositions.
+ * dispositionsByArm: { [arm]: { [sampleIndex]: 'BUILT'|'PARTIAL'|'MISSING' } }
+ * No I/O, no LLM calls -- fully unit-testable.
+ */
+export function evaluateVerdict(dispositionsByArm) {
+  const { targetIndex, controlIndices } = SAMPLE;
+  const higher = dispositionsByArm[ARMS.HIGHER_TIER] || {};
+  const nullArm = dispositionsByArm[ARMS.NULL_REROLL] || {};
+
+  const higherFlipped = higher[targetIndex] === 'BUILT';
+  const nullFlipped = nullArm[targetIndex] === 'BUILT';
+  const controlsRegressed = controlIndices.filter((i) => higher[i] && higher[i] !== 'BUILT');
+
+  if (nullFlipped) {
+    return {
+      verdict: 'proceed-unchanged',
+      reason: 'null-baseline reroll also flipped the target story to BUILT -- confound not ruled out for this sample',
+    };
+  }
+  if (higherFlipped && controlsRegressed.length === 0) {
+    return {
+      verdict: 'flip-remediation',
+      reason: 'higher-tier arm flipped the target story to BUILT with zero control regressions',
+    };
+  }
+  if (higherFlipped && controlsRegressed.length > 0) {
+    return {
+      verdict: 'partial-retier',
+      reason: `higher-tier arm flipped the target story but regressed control indices [${controlsRegressed.join(', ')}]`,
+    };
+  }
+  return {
+    verdict: 'proceed-unchanged',
+    reason: 'higher-tier arm did not flip the target story to BUILT',
+  };
+}
+
+/**
+ * Build the user prompt for the blueprint_user_story_pack agent from a live
+ * venture row -- mirrors user-story-pack.js's own systemPrompt docstring
+ * ("Given the venture brief (problem, solution, target market)...").
+ */
+export function buildVentureBriefPrompt(venture) {
+  return [
+    `Venture: ${venture.name}`,
+    `Problem: ${venture.problem_statement || venture.description || ''}`,
+    venture.solution_approach ? `Solution approach: ${venture.solution_approach}` : null,
+    venture.target_market ? `Target market: ${venture.target_market}` : null,
+    venture.unique_value_proposition ? `Unique value proposition: ${venture.unique_value_proposition}` : null,
+  ].filter(Boolean).join('\n');
+}
+
+/**
+ * Anthropic (unlike Gemini's responseMimeType JSON mode) commonly wraps JSON
+ * output in a markdown code fence (```json ... ```). Strip it before parsing.
+ * A no-op on content that is already raw JSON.
+ */
+export function stripMarkdownJsonFence(content) {
+  const trimmed = String(content || '').trim();
+  if (!trimmed.startsWith('```')) return trimmed;
+  // Strip the opening fence (with optional language tag) and, if present, a
+  // closing fence -- tolerant of trailing prose/whitespace after the last
+  // fence, which a strict anchored regex would otherwise fail to match.
+  const withoutOpening = trimmed.replace(/^```[a-zA-Z]*\s*/, '');
+  const lastFenceIdx = withoutOpening.lastIndexOf('```');
+  return (lastFenceIdx >= 0 ? withoutOpening.slice(0, lastFenceIdx) : withoutOpening).trim();
+}
+
+/**
+ * FR-2: regenerate the artifact for a given arm. Returns the artifact_data
+ * shape ({epics, personas, mvp_story_count, total_story_points}).
+ * cacheTTLMs:0 on every call (TR-3) so the response cache never masks a
+ * genuine reroll or a genuine higher-tier call with a stale response.
+ */
+export async function regenerateArtifact({ arm, venture, sdId, model }) {
+  const userPrompt = buildVentureBriefPrompt(venture);
+  const client = getLLMClient({
+    purpose: 'generation',
+    model,
+    sdId,
+    phase: 'EXEC',
+    cacheTTLMs: 0,
+  });
+  const result = await client.complete(USER_STORY_PACK_SYSTEM_PROMPT, userPrompt, {
+    purpose: 'content-generation',
+    response_format: { type: 'json_object' },
+    maxTokens: 16384, // AnthropicAdapter defaults to 8192, which truncates a full 14-story epics JSON mid-string
+  });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stripMarkdownJsonFence(result.content));
+  } catch (err) {
+    throw new Error(`[j2a] arm=${arm} model=${result.model || model}: failed to parse JSON response: ${err.message}`);
+  }
+  return { artifactData: parsed, usage: { model: result.model || model, provider: result.provider, ...result.usage } };
+}
+
+/**
+ * FR-4: re-derive disposition for the sampled indices against a regenerated
+ * (or the existing control) artifact, using the SAME mechanical evidence
+ * pipeline that produced the live scorecard. Writes an audit row per
+ * (arm, index) proving only claim text + repo evidence reached
+ * computeDisposition -- never arm/model identity.
+ *
+ * findEvidenceForClaim() is called with `repoPath` only (no prebuilt
+ * fileIndex) so this reuses post-build-verdict-engine.js exactly as
+ * exported, with zero modification to that module (TR-2).
+ *
+ * @returns {{dispositions: Record<number,string>, auditRows: object[]}}
+ */
+export function rescoreSample({ arm, artifactData, originalClaims, repoPath }) {
+  const regeneratedClaims = extractUserStoryClaims({ artifact_data: artifactData });
+  const dispositions = {};
+  const auditRows = [];
+
+  const sampleIndices = [SAMPLE.targetIndex, ...SAMPLE.controlIndices];
+  for (const index of sampleIndices) {
+    const originalClaimText = originalClaims[index];
+    const match = matchClaimToRegenerated(originalClaimText, regeneratedClaims);
+    const claimTextToScore = match ? match.claim : originalClaimText;
+
+    const { confidence, evidenceRefs } = findEvidenceForClaim({ repoPath, claimText: claimTextToScore });
+    const present = confidence !== 'NONE';
+    const disposition = computeDisposition({ present, evidenceConfidence: confidence, deviationRecords: [] });
+
+    dispositions[index] = disposition;
+    auditRows.push({
+      arm,
+      sampleIndex: index,
+      // NOTE: computeDisposition's own input is logged here for the audit
+      // trail -- it never receives `arm` or `model` as a parameter.
+      computeDispositionInput: { present, evidenceConfidence: confidence, deviationRecords: [] },
+      matchedClaim: claimTextToScore,
+      matchOverlap: match?.overlap ?? 0,
+      evidenceRefs,
+      disposition,
+    });
+  }
+
+  return { dispositions, auditRows };
+}
+
+/**
+ * FR-5: cost-per-quality-point readout from model_usage_log for this SD.
+ *
+ * Scoped to subagent_type='generation' (the purpose this harness's own calls
+ * are tagged with -- excludes unrelated LEO gate-evaluation LLM calls that
+ * share this sdId via usage-logger's session-claim fallback) and, when
+ * `sinceIso` is given, to rows at/after that timestamp (excludes cost from
+ * earlier failed/debugging runs of this same harness).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{sdId: string, flipsByArm: Record<string, number>, sinceIso?: string}} opts
+ */
+export async function computeCostReadout(supabase, { sdId, flipsByArm, sinceIso }) {
+  let query = supabase
+    .from('model_usage_log')
+    .select('reported_model_name, metadata')
+    .eq('sd_id', sdId)
+    .eq('subagent_type', 'generation');
+  if (sinceIso) query = query.gte('captured_at', sinceIso);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`[j2a] computeCostReadout: model_usage_log query failed: ${error.message}`);
+
+  const byModel = {};
+  for (const row of data || []) {
+    const model = row.reported_model_name;
+    const { usd, inT, outT } = rowCost(row);
+    if (!byModel[model]) byModel[model] = { model, totalTokens: 0, totalCostUsd: 0, calls: 0 };
+    byModel[model].totalTokens += inT + outT;
+    byModel[model].totalCostUsd += usd;
+    byModel[model].calls += 1;
+  }
+
+  return Object.values(byModel).map((entry) => ({
+    ...entry,
+    storiesFlipped: flipsByArm?.[entry.model] || 0,
+    costPerFlipUsd: (flipsByArm?.[entry.model] || 0) > 0 ? entry.totalCostUsd / flipsByArm[entry.model] : null,
+  }));
+}
+
+/**
+ * Stage a chairman decision card (advisory row) when the verdict recommends
+ * any re-tier -- FR-6. Reuses the existing chairman_decisions surface rather
+ * than inventing a new notification channel.
+ */
+async function stageChairmanDecisionCard(supabase, { verdict, costReadout, dispositionsByArm }) {
+  const { error } = await supabase.from('chairman_decisions').insert({
+    venture_id: VENTURE_ID,
+    lifecycle_stage: 0, // not tied to a specific venture lifecycle stage
+    decision_type: 'model_tier_retier_recommendation',
+    status: 'pending',
+    decision: 'pending',
+    blocking: false,
+    summary: `J2a: EVA generation-layer model-tier re-tier recommendation -- verdict: ${verdict.verdict}`,
+    rationale: verdict.reason,
+    context: {
+      sd_key: SD_KEY,
+      decision_rule: DECISION_RULE,
+      verdict,
+      cost_readout: costReadout,
+      dispositions_by_arm: dispositionsByArm,
+    },
+  });
+  if (error) {
+    // Non-fatal: the verdict is already durably recorded on the SD row (main()).
+    // A missing/renamed chairman_decisions column must never block the
+    // experiment's own result from being recorded.
+    console.error('[j2a] stageChairmanDecisionCard failed (non-fatal):', error.message);
+    return { staged: false, error: error.message };
+  }
+  return { staged: true };
+}
+
+async function main() {
+  const runStartedAt = new Date().toISOString();
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const { data: venture, error: ventureError } = await supabase
+    .from('ventures')
+    .select('*')
+    .eq('id', VENTURE_ID)
+    .single();
+  if (ventureError) throw new Error(`[j2a] failed to load venture: ${ventureError.message}`);
+
+  const { data: existingRow, error: artifactError } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data')
+    .eq('venture_id', VENTURE_ID)
+    .eq('artifact_type', ARTIFACT_TYPE)
+    .eq('is_current', true)
+    .single();
+  if (artifactError) throw new Error(`[j2a] failed to load existing artifact: ${artifactError.message}`);
+
+  const originalClaims = extractUserStoryClaims({ artifact_data: existingRow.artifact_data });
+
+  const repoPath = await resolveVentureRepoPath(supabase, { ventureId: VENTURE_ID });
+  if (!repoPath) throw new Error('[j2a] could not resolve venture repo path');
+
+  console.log(`[j2a] Running 3-arm experiment against ${VENTURE_ID} / ${ARTIFACT_TYPE}`);
+  console.log(`[j2a] Decision rule (locked ${DECISION_RULE.lockedAt}): ${DECISION_RULE.description}`);
+
+  const dispositionsByArm = {};
+  const auditRowsAll = [];
+  const flipsByArm = {};
+
+  // Control arm: reuse existing artifact_data, zero LLM calls.
+  {
+    const { dispositions, auditRows } = rescoreSample({
+      arm: ARMS.CONTROL,
+      artifactData: existingRow.artifact_data,
+      originalClaims,
+      repoPath,
+    });
+    dispositionsByArm[ARMS.CONTROL] = dispositions;
+    auditRowsAll.push(...auditRows);
+  }
+
+  // Null-reroll arm: regenerate with the default (Flash) model.
+  {
+    const { artifactData, usage } = await regenerateArtifact({ arm: ARMS.NULL_REROLL, venture, sdId: SD_KEY });
+    const { dispositions, auditRows } = rescoreSample({ arm: ARMS.NULL_REROLL, artifactData, originalClaims, repoPath });
+    dispositionsByArm[ARMS.NULL_REROLL] = dispositions;
+    auditRowsAll.push(...auditRows);
+    flipsByArm[usage.model] = (flipsByArm[usage.model] || 0) + (dispositions[SAMPLE.targetIndex] === 'BUILT' ? 1 : 0);
+  }
+
+  // Higher-tier arm: regenerate with the candidate model.
+  {
+    const { artifactData, usage } = await regenerateArtifact({
+      arm: ARMS.HIGHER_TIER,
+      venture,
+      sdId: SD_KEY,
+      model: HIGHER_TIER_MODEL,
+    });
+    const { dispositions, auditRows } = rescoreSample({ arm: ARMS.HIGHER_TIER, artifactData, originalClaims, repoPath });
+    dispositionsByArm[ARMS.HIGHER_TIER] = dispositions;
+    auditRowsAll.push(...auditRows);
+    flipsByArm[usage.model] = (flipsByArm[usage.model] || 0) + (dispositions[SAMPLE.targetIndex] === 'BUILT' ? 1 : 0);
+  }
+
+  const verdict = evaluateVerdict(dispositionsByArm);
+  // lib/llm/usage-logger.js's logUsage() is deliberately fire-and-forget (never
+  // awaited by client-factory's wrapper, so LLM calls aren't slowed by logging)
+  // -- give its INSERT a moment to land before querying, or the readout can
+  // silently miss the most recent call(s).
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  const costReadout = await computeCostReadout(supabase, { sdId: SD_KEY, flipsByArm, sinceIso: runStartedAt });
+
+  console.log('[j2a] Dispositions by arm:', JSON.stringify(dispositionsByArm, null, 2));
+  console.log('[j2a] Verdict:', JSON.stringify(verdict, null, 2));
+  console.log('[j2a] Cost readout:', JSON.stringify(costReadout, null, 2));
+
+  // Persist durably on the SD row so SD-LEO-INFRA-MARKETLENS-REMEDIATION-TRIAGE-001 can read it.
+  const { data: sdRow, error: sdReadError } = await supabase
+    .from('strategic_directives_v2')
+    .select('metadata')
+    .eq('sd_key', SD_KEY)
+    .single();
+  if (sdReadError) throw new Error(`[j2a] failed to read SD row for verdict persistence: ${sdReadError.message}`);
+
+  const { error: sdWriteError } = await supabase
+    .from('strategic_directives_v2')
+    .update({
+      metadata: {
+        ...sdRow.metadata,
+        j2a_verdict: {
+          verdict,
+          dispositions_by_arm: dispositionsByArm,
+          cost_readout: costReadout,
+          audit_rows: auditRowsAll,
+          decision_rule: DECISION_RULE,
+          computed_at: new Date().toISOString(),
+        },
+      },
+    })
+    .eq('sd_key', SD_KEY);
+  if (sdWriteError) throw new Error(`[j2a] failed to persist verdict: ${sdWriteError.message}`);
+
+  if (verdict.verdict !== 'proceed-unchanged') {
+    await stageChairmanDecisionCard(supabase, { verdict, costReadout, dispositionsByArm });
+  }
+
+  console.log('[j2a] Experiment complete.');
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((err) => {
+    console.error('[j2a] fatal:', err.message);
+    process.exitCode = 1;
+  });
+}
+
+export default {
+  SD_KEY,
+  VENTURE_ID,
+  ARTIFACT_TYPE,
+  SAMPLE,
+  ARMS,
+  HIGHER_TIER_MODEL,
+  DECISION_RULE,
+  extractKeywords,
+  matchClaimToRegenerated,
+  evaluateVerdict,
+  buildVentureBriefPrompt,
+  stripMarkdownJsonFence,
+  regenerateArtifact,
+  rescoreSample,
+  computeCostReadout,
+};

--- a/tests/unit/eva/j2a-model-tier-experiment.test.js
+++ b/tests/unit/eva/j2a-model-tier-experiment.test.js
@@ -1,0 +1,284 @@
+/**
+ * SD-LEO-INFRA-J2A-EVA-GENERATION-001 -- unit tests for the pure/deterministic
+ * parts of the J2a model-tier A/B experiment harness: decision-rule evaluation,
+ * claim matching, and cost-readout aggregation. No live LLM calls or Supabase
+ * writes happen in this suite (db-test-guard: pure-function tests only).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ARMS,
+  SAMPLE,
+  DECISION_RULE,
+  extractKeywords,
+  matchClaimToRegenerated,
+  evaluateVerdict,
+  buildVentureBriefPrompt,
+  stripMarkdownJsonFence,
+  computeCostReadout,
+  rescoreSample,
+} from '../../../scripts/eva/j2a-model-tier-experiment.mjs';
+
+describe('DECISION_RULE (FR-1)', () => {
+  it('is locked with a version and lockedAt date', () => {
+    expect(DECISION_RULE.version).toBe(1);
+    expect(DECISION_RULE.lockedAt).toBe('2026-07-05');
+  });
+
+  it('is frozen (cannot be amended at runtime)', () => {
+    expect(Object.isFrozen(DECISION_RULE)).toBe(true);
+    expect(() => { DECISION_RULE.version = 2; }).toThrow(); // ESM strict mode: throws on write to a frozen object
+    expect(DECISION_RULE.version).toBe(1);
+  });
+});
+
+describe('SAMPLE (FR-3)', () => {
+  it('targets story index 5 with controls at 0, 1, 6', () => {
+    expect(SAMPLE.targetIndex).toBe(5);
+    expect(SAMPLE.controlIndices).toEqual([0, 1, 6]);
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(SAMPLE)).toBe(true);
+  });
+});
+
+describe('extractKeywords', () => {
+  it('filters stopwords and short words', () => {
+    const kws = extractKeywords('As a user, I want to search for market data');
+    expect(kws).not.toContain('user');
+    expect(kws).not.toContain('want');
+    expect(kws).toContain('search');
+    expect(kws).toContain('market');
+  });
+
+  it('lowercases and dedupes', () => {
+    const kws = extractKeywords('Market MARKET market data');
+    expect(kws).toEqual(['market', 'data']);
+  });
+
+  it('returns empty array for empty/undefined input', () => {
+    expect(extractKeywords('')).toEqual([]);
+    expect(extractKeywords(undefined)).toEqual([]);
+  });
+});
+
+describe('matchClaimToRegenerated', () => {
+  it('finds the best keyword-overlap match among regenerated claims', () => {
+    const original = 'As a Small Agency Owner, I want to compare the marketing spend and channel mix';
+    const regenerated = [
+      'As a Fractional CMO, I want to view competitor pricing',
+      'As a Small Agency Owner, I want to compare marketing spend across channels',
+      'As a Strategic Consultant, I want to export data',
+    ];
+    const match = matchClaimToRegenerated(original, regenerated);
+    expect(match).not.toBeNull();
+    expect(match.claim).toBe(regenerated[1]);
+    expect(match.overlap).toBeGreaterThan(0);
+  });
+
+  it('returns null when no regenerated claim shares any keyword', () => {
+    const original = 'As a Small Agency Owner, I want to compare marketing spend';
+    const regenerated = ['As a Fractional CMO, I want to view competitor pricing'];
+    const match = matchClaimToRegenerated(original, regenerated);
+    expect(match).toBeNull();
+  });
+
+  it('returns null when the original claim has no extractable keywords', () => {
+    const match = matchClaimToRegenerated('', ['some claim text here']);
+    expect(match).toBeNull();
+  });
+});
+
+describe('evaluateVerdict (FR-1 mechanical evaluation)', () => {
+  it('returns flip-remediation when higher-tier flips target with zero control regressions', () => {
+    const result = evaluateVerdict({
+      [ARMS.NULL_REROLL]: { 5: 'PARTIAL', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+      [ARMS.HIGHER_TIER]: { 5: 'BUILT', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+    });
+    expect(result.verdict).toBe('flip-remediation');
+  });
+
+  it('returns proceed-unchanged when the null-baseline reroll also flips the target (confound)', () => {
+    const result = evaluateVerdict({
+      [ARMS.NULL_REROLL]: { 5: 'BUILT', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+      [ARMS.HIGHER_TIER]: { 5: 'BUILT', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+    });
+    expect(result.verdict).toBe('proceed-unchanged');
+    expect(result.reason).toMatch(/confound/);
+  });
+
+  it('returns partial-retier when higher-tier flips target but regresses a control', () => {
+    const result = evaluateVerdict({
+      [ARMS.NULL_REROLL]: { 5: 'PARTIAL', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+      [ARMS.HIGHER_TIER]: { 5: 'BUILT', 0: 'PARTIAL', 1: 'BUILT', 6: 'BUILT' },
+    });
+    expect(result.verdict).toBe('partial-retier');
+    expect(result.reason).toMatch(/regressed control indices \[0\]/);
+  });
+
+  it('returns proceed-unchanged when higher-tier does not flip the target', () => {
+    const result = evaluateVerdict({
+      [ARMS.NULL_REROLL]: { 5: 'PARTIAL', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+      [ARMS.HIGHER_TIER]: { 5: 'PARTIAL', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+    });
+    expect(result.verdict).toBe('proceed-unchanged');
+  });
+
+  it('is a pure function -- same input always produces the same verdict', () => {
+    const input = {
+      [ARMS.NULL_REROLL]: { 5: 'PARTIAL', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+      [ARMS.HIGHER_TIER]: { 5: 'BUILT', 0: 'BUILT', 1: 'BUILT', 6: 'BUILT' },
+    };
+    const first = evaluateVerdict(input);
+    const second = evaluateVerdict(input);
+    expect(first).toEqual(second);
+  });
+});
+
+describe('buildVentureBriefPrompt', () => {
+  it('includes problem, solution approach, target market, and UVP when present', () => {
+    const prompt = buildVentureBriefPrompt({
+      name: 'MarketLens',
+      problem_statement: 'A problem',
+      solution_approach: 'A solution',
+      target_market: 'consultants',
+      unique_value_proposition: 'A UVP',
+    });
+    expect(prompt).toContain('MarketLens');
+    expect(prompt).toContain('A problem');
+    expect(prompt).toContain('A solution');
+    expect(prompt).toContain('consultants');
+    expect(prompt).toContain('A UVP');
+  });
+
+  it('falls back to description when problem_statement is absent, and omits missing optional fields', () => {
+    const prompt = buildVentureBriefPrompt({ name: 'X', description: 'fallback problem' });
+    expect(prompt).toContain('fallback problem');
+    expect(prompt).not.toContain('Solution approach');
+    expect(prompt).not.toContain('Target market');
+  });
+});
+
+describe('stripMarkdownJsonFence', () => {
+  it('strips a ```json ... ``` fence', () => {
+    const wrapped = '```json\n{"a": 1}\n```';
+    expect(stripMarkdownJsonFence(wrapped)).toBe('{"a": 1}');
+  });
+
+  it('strips a bare ``` ... ``` fence with no language tag', () => {
+    const wrapped = '```\n{"a": 1}\n```';
+    expect(stripMarkdownJsonFence(wrapped)).toBe('{"a": 1}');
+  });
+
+  it('is a no-op on content that is already raw JSON', () => {
+    expect(stripMarkdownJsonFence('{"a": 1}')).toBe('{"a": 1}');
+  });
+
+  it('returns empty string for empty/undefined input', () => {
+    expect(stripMarkdownJsonFence('')).toBe('');
+    expect(stripMarkdownJsonFence(undefined)).toBe('');
+  });
+
+  it('tolerates trailing content after the closing fence (no strict end anchor)', () => {
+    const wrapped = '```json\n{"a": 1}\n```\n\nLet me know if you need anything else!';
+    expect(stripMarkdownJsonFence(wrapped)).toBe('{"a": 1}');
+  });
+});
+
+/** Chainable mock query builder: any number of .eq()/.gte() calls, resolves via .then(). */
+function makeMockQueryBuilder(result) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    gte: vi.fn(() => builder),
+    then: (resolve, reject) => Promise.resolve(result).then(resolve, reject),
+  };
+  return builder;
+}
+
+describe('rescoreSample (FR-4 blind-scoring audit trail, TS-2)', () => {
+  it('every audit row computeDispositionInput contains ONLY present/evidenceConfidence/deviationRecords -- never arm or model', () => {
+    const originalClaims = {
+      0: 'As a Strategic Consultant, I want to search for market data',
+      1: 'As a Fractional CMO, I want to view competitors',
+      5: 'As a Small Agency Owner, I want to compare marketing spend',
+      6: 'As a Strategic Consultant, I want to identify market gaps',
+    };
+    // A nonexistent repoPath makes findEvidenceForClaim's internal buildFileIndex
+    // return [] deterministically (no live filesystem access needed for this
+    // structural assertion) -- every claim resolves to confidence:'NONE'.
+    const { auditRows } = rescoreSample({
+      arm: ARMS.HIGHER_TIER,
+      artifactData: { epics: [] },
+      originalClaims,
+      repoPath: '/nonexistent/path/for/unit-test-only',
+    });
+
+    expect(auditRows).toHaveLength(4);
+    for (const row of auditRows) {
+      expect(Object.keys(row.computeDispositionInput).sort()).toEqual(
+        ['deviationRecords', 'evidenceConfidence', 'present'].sort()
+      );
+      expect(row.computeDispositionInput).not.toHaveProperty('arm');
+      expect(row.computeDispositionInput).not.toHaveProperty('model');
+    }
+  });
+
+  it('falls back to the original claim text when no regenerated claim overlaps', () => {
+    const originalClaims = { 5: 'As a Small Agency Owner, I want to compare marketing spend' };
+    const { auditRows } = rescoreSample({
+      arm: ARMS.NULL_REROLL,
+      artifactData: { epics: [{ stories: [{ as_a: 'X', i_want_to: 'do something unrelated' }] }] },
+      originalClaims,
+      repoPath: '/nonexistent/path/for/unit-test-only',
+    });
+    const targetRow = auditRows.find((r) => r.sampleIndex === '5' || r.sampleIndex === 5);
+    expect(targetRow.matchOverlap).toBe(0);
+    expect(targetRow.matchedClaim).toBe(originalClaims[5]);
+  });
+});
+
+describe('computeCostReadout (FR-5)', () => {
+  it('aggregates tokens/cost per model from mocked model_usage_log rows and computes cost-per-flip', async () => {
+    const rows = [
+      { reported_model_name: 'gemini-2.5-flash', metadata: { input_tokens: 1000, output_tokens: 2000 } },
+      { reported_model_name: 'claude-sonnet-4-6', metadata: { input_tokens: 1500, output_tokens: 3000 } },
+    ];
+    const builder = makeMockQueryBuilder({ data: rows, error: null });
+    const supabase = { from: vi.fn(() => builder) };
+
+    const readout = await computeCostReadout(supabase, {
+      sdId: 'SD-LEO-INFRA-J2A-EVA-GENERATION-001',
+      flipsByArm: { 'claude-sonnet-4-6': 1 },
+      sinceIso: '2026-07-05T00:00:00.000Z',
+    });
+
+    expect(builder.eq).toHaveBeenCalledWith('sd_id', 'SD-LEO-INFRA-J2A-EVA-GENERATION-001');
+    expect(builder.eq).toHaveBeenCalledWith('subagent_type', 'generation');
+    expect(builder.gte).toHaveBeenCalledWith('captured_at', '2026-07-05T00:00:00.000Z');
+
+    expect(readout).toHaveLength(2);
+    const flashEntry = readout.find((r) => r.model === 'gemini-2.5-flash');
+    const sonnetEntry = readout.find((r) => r.model === 'claude-sonnet-4-6');
+    expect(flashEntry.totalTokens).toBe(3000);
+    expect(flashEntry.costPerFlipUsd).toBeNull(); // no flips attributed
+    expect(sonnetEntry.totalTokens).toBe(4500);
+    expect(sonnetEntry.storiesFlipped).toBe(1);
+    expect(sonnetEntry.costPerFlipUsd).toBeGreaterThan(0);
+  });
+
+  it('omits the gte() call when sinceIso is not provided', async () => {
+    const builder = makeMockQueryBuilder({ data: [], error: null });
+    const supabase = { from: vi.fn(() => builder) };
+    await computeCostReadout(supabase, { sdId: 'x', flipsByArm: {} });
+    expect(builder.gte).not.toHaveBeenCalled();
+  });
+
+  it('propagates a query error clearly rather than silently returning empty', async () => {
+    const builder = makeMockQueryBuilder({ data: null, error: { message: 'boom' } });
+    const supabase = { from: vi.fn(() => builder) };
+    await expect(
+      computeCostReadout(supabase, { sdId: 'x', flipsByArm: {} })
+    ).rejects.toThrow(/boom/);
+  });
+});


### PR DESCRIPTION
## Summary
Solomon-designed (advisory d7f5401c) pre-remediation experiment: settle with evidence whether EVA's budget-tier generation model (Gemini 2.5 Flash) is undershooting quality in the planning-artifact layer, BEFORE the remediation spec pack (SD-LEO-INFRA-MARKETLENS-REMEDIATION-TRIAGE-001) is written.

- New `scripts/eva/j2a-model-tier-experiment.mjs`: a 3-arm regeneration harness (Flash-reroll null baseline, current-config control, Claude Sonnet 4.6 higher-tier) against MarketLens's `blueprint_user_story_pack` artifact (14 stories, 13 BUILT + 1 PARTIAL).
- The pre-registered decision rule (FR-1) is locked in the PRD before any generation call ran, and mechanically evaluated post-hoc — no post-hoc goalpost moving.
- Disposition is re-derived via the existing, unmodified mechanical evidence-matcher (`lib/eva/post-build-verdict-engine.js`) — blind-scoring is satisfied by construction since that matcher takes no model/arm identity as input.
- Ambiguity resolution: a freshly-regenerated artifact won't reproduce stories in the same order, so cross-arm story matching uses keyword-overlap (`matchClaimToRegenerated`), conservatively falling back to the original claim text when no comparable story exists in a regeneration.
- Live run (real Gemini + Claude API calls against the real MarketLens repo) persisted `verdict=proceed-unchanged` to `strategic_directives_v2.metadata.j2a_verdict`, with a full audit trail (12 rows) and a cost-per-quality-point readout.
- Found and fixed 3 real bugs during live execution: Claude wraps JSON in markdown fences even with `response_format: json_object` requested; AnthropicAdapter's 8192-token default truncated the full story-pack JSON; the fire-and-forget usage-logger raced the cost-readout query.

## Test plan
- [x] 27 unit tests, all passing (`tests/unit/eva/j2a-model-tier-experiment.test.js`) — pure/deterministic logic only, mocked Supabase
- [x] TESTING sub-agent: PASS (confidence 92), E2E explicitly N/A (backend-only harness, no UI)
- [x] 3 live runs against real MarketLens data validated model routing, JSON parsing, blind re-scoring, and a correctly-scoped cost readout
- [x] `npm run schema:lint` clean
- [x] LEAD-TO-PLAN (96%), PLAN-TO-EXEC (95%), EXEC-TO-PLAN (93%), PLAN-TO-LEAD (95%) all passed
- [x] Retrospective published (quality 90/100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)