### PR TITLE
fix(QF-20260705-938): repo-scope every gh call in the auto-merge lane

### DIFF
--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -106,9 +106,18 @@ const defaultLogger = {
 /**
  * Detect whether a PR is in draft state.
  * Returns true / false / null (null on lookup failure).
+ *
+ * QF-20260705-938: repo-scoped when repoOwner/repoName are supplied — an
+ * unscoped `gh pr view` resolves the PR NUMBER against the ambient cwd repo
+ * (the QF-20260703-401/197 class at yet another callsite).
  */
-export function detectDraftState(prNumber, runner = defaultRunner) {
-  const r = runner(['pr', 'view', String(prNumber), '--json', 'isDraft', '--jq', '.isDraft']);
+export function detectDraftState(prNumber, repoOwner, repoName, runner = defaultRunner) {
+  // Back-compat: legacy 2-arg callers pass the runner in the second slot.
+  if (typeof repoOwner === 'function') { runner = repoOwner; repoOwner = undefined; repoName = undefined; }
+  const args = ['pr', 'view', String(prNumber)];
+  if (repoOwner && repoName) args.push('-R', `${repoOwner}/${repoName}`);
+  args.push('--json', 'isDraft', '--jq', '.isDraft');
+  const r = runner(args);
   if (r.code !== 0) return null;
   const trimmed = r.stdout.trim();
   if (trimmed === 'true') return true;
@@ -146,9 +155,20 @@ export function detectBranchProtectionEnabled(repoOwner, repoName, branch = 'mai
   return null;
 }
 
-/** Build the gh pr merge argv. Exported for unit tests. */
-export function buildMergeArgs(prNumber, { admin } = {}) {
-  const args = ['pr', 'merge', String(prNumber), '--merge', '--delete-branch'];
+/**
+ * Build the gh pr merge argv. Exported for unit tests.
+ *
+ * QF-20260705-938 (critical, live near-miss ehg PR #734): the merge argv MUST
+ * carry -R <owner>/<repo> when the caller knows the target repo — without it,
+ * gh resolves the PR NUMBER against the ambient cwd repo. verifyMerged was
+ * already scoped (QF-20260703-197), so the failure mode was a silent no-op or,
+ * worst case, MERGING THE WRONG REPO'S PR WITH --admin when the number
+ * collides with an open PR in the cwd repo.
+ */
+export function buildMergeArgs(prNumber, { admin, repoOwner, repoName } = {}) {
+  const args = ['pr', 'merge', String(prNumber)];
+  if (repoOwner && repoName) args.push('-R', `${repoOwner}/${repoName}`);
+  args.push('--merge', '--delete-branch');
   if (admin) args.push('--admin');
   return args;
 }
@@ -365,11 +385,13 @@ export async function attemptAutoMerge({
     }
   }
 
-  // 1. Detect + handle draft state.
-  const isDraft = detectDraftState(prNumber, runner);
+  // 1. Detect + handle draft state (repo-scoped, QF-20260705-938).
+  const isDraft = detectDraftState(prNumber, repoOwner, repoName, runner);
   if (isDraft === true) {
     logger.info(`🔧 PR #${prNumber} is draft — marking ready for review...`);
-    const r = runner(['pr', 'ready', String(prNumber)]);
+    const readyArgs = ['pr', 'ready', String(prNumber)];
+    if (repoOwner && repoName) readyArgs.push('-R', `${repoOwner}/${repoName}`);
+    const r = runner(readyArgs);
     if (r.code !== 0) {
       return { ok: false, reason: `gh pr ready failed: ${r.stderr.trim()}`, exitCode: r.code };
     }
@@ -381,8 +403,8 @@ export async function attemptAutoMerge({
     logger.info('ℹ️  Branch protection enforce_admins=true — passing --admin');
   }
 
-  // 3. Attempt merge.
-  const mergeArgs = buildMergeArgs(prNumber, { admin: enforceAdmins });
+  // 3. Attempt merge (repo-scoped, QF-20260705-938 — the live-near-miss callsite).
+  const mergeArgs = buildMergeArgs(prNumber, { admin: enforceAdmins, repoOwner, repoName });
   logger.info(`🚀 Merging PR #${prNumber}...`);
   const merge = runner(mergeArgs);
 

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -83,6 +83,28 @@ describe('buildMergeArgs', () => {
       '--admin',
     ]);
   });
+
+  // QF-20260705-938 (critical, live near-miss ehg PR #734): without -R, gh resolves
+  // the PR NUMBER against the ambient cwd repo — a cross-repo caller from EHG_Engineer
+  // cwd merging an ehg PR silently no-ops (or, on an open-number collision, merges the
+  // WRONG repo's PR with --admin). Cross-repo merge args MUST carry -R.
+  it('carries -R owner/repo when repoOwner/repoName are supplied (cross-repo, QF-20260705-938)', () => {
+    expect(buildMergeArgs(734, { admin: true, repoOwner: 'rickfelix', repoName: 'ehg' })).toEqual([
+      'pr',
+      'merge',
+      '734',
+      '-R',
+      'rickfelix/ehg',
+      '--merge',
+      '--delete-branch',
+      '--admin',
+    ]);
+  });
+
+  it('omits -R when the target repo is unknown (legacy ambient behavior preserved)', () => {
+    expect(buildMergeArgs(5, {})).toEqual(['pr', 'merge', '5', '--merge', '--delete-branch']);
+    expect(buildMergeArgs(5, { repoOwner: 'rickfelix' })).toEqual(['pr', 'merge', '5', '--merge', '--delete-branch']);
+  });
 });
 
 describe('detectDraftState', () => {
@@ -103,6 +125,22 @@ describe('detectDraftState', () => {
   it('returns null on lookup failure', () => {
     const runner = () => ({ code: 1, stdout: '', stderr: 'auth required' });
     expect(detectDraftState(7, runner)).toBe(null);
+  });
+
+  // QF-20260705-938: the draft probe is repo-scoped for cross-repo callers, and the
+  // legacy 2-arg (prNumber, runner) form keeps working via the back-compat shim.
+  it('scopes the pr view with -R when repoOwner/repoName are supplied', () => {
+    const seen = [];
+    const runner = (argv) => { seen.push(argv); return { code: 0, stdout: 'true\n', stderr: '' }; };
+    expect(detectDraftState(734, 'rickfelix', 'ehg', runner)).toBe(true);
+    expect(seen[0]).toEqual(['pr', 'view', '734', '-R', 'rickfelix/ehg', '--json', 'isDraft', '--jq', '.isDraft']);
+  });
+
+  it('legacy 2-arg form (prNumber, runner) still resolves unscoped', () => {
+    const seen = [];
+    const runner = (argv) => { seen.push(argv); return { code: 0, stdout: 'false\n', stderr: '' }; };
+    expect(detectDraftState(7, runner)).toBe(false);
+    expect(seen[0]).toEqual(['pr', 'view', '7', '--json', 'isDraft', '--jq', '.isDraft']);
   });
 });
 


### PR DESCRIPTION
## Summary
`buildMergeArgs` omitted `-R <owner>/<repo>`, so `gh pr merge` resolved the PR NUMBER against the ambient cwd repo — while `verifyMerged` was already repo-scoped (the QF-20260703-197/401 class at the two remaining callsites). Live near-miss today: shipping ehg PR #734 from EHG_Engineer cwd silently no-opped against EHG_Engineer''s long-merged PR #734 (harmless purely by number luck) and hard-failed the ship lane twice; an open-number collision would have merged the wrong repo''s PR **with --admin**. Fleet exposure: the whole UIUX family + MarketLens wave ship EHG-app PRs from EHG_Engineer sessions.

## Fix
- `buildMergeArgs(prNumber, {admin, repoOwner, repoName})` threads `-R` (position before `--merge`, unchanged argv when repo unknown)
- `detectDraftState` repo-scoped with a back-compat shim for the legacy `(prNumber, runner)` form
- the `gh pr ready` draft path scoped identically
- `attemptAutoMerge` threads its own repoOwner/repoName into all three call sites

## Test plan
4 new regression tests (cross-repo `-R` argv for merge + draft probe, legacy unscoped forms preserved); full auto-merge suite 57/57 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)