### PR TITLE
fix(QF-20260704-193): surface rha hold provenance - one SSOT reader, three surfaces

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -68,6 +68,10 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
   if (row.sd_type === 'orchestrator') return 'orchestrator_parent';
   if (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) return 'test_fixture_key';
+  // QF-20260704-193: the verdict stays a bare string (consumers string-compare it) —
+  // callers that need the WHY resolve it via resolveHoldProvenance(row.metadata) below,
+  // the SSOT coalescer for the ad-hoc hold-reason keys. Deliberate scope decision over
+  // changing this return type (recorded in the QF completion notes).
   if (row.metadata && row.metadata.requires_human_action) return 'human_action_required';
   // SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored DRAFT SD is NON-CLAIMABLE
   // until co-author convergence — else a parked worker claims it and writes the PRD before the
@@ -312,7 +316,14 @@ async function baselinedCandidateEligible(sb, sdKey, ctx) {
  */
 function resolveHoldProvenance(metadata) {
   const m = metadata || {};
-  const s = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+  // Adversarial-review W3: strip control chars (newlines/ANSI escapes) from
+  // metadata-sourced strings — they reach console skip-lines and the dashboard,
+  // where an embedded \n or ESC could forge/alter rendered lines.
+  const s = (v) => {
+    if (typeof v !== 'string') return null;
+    const clean = v.replace(/[\x00-\x1f\x7f]/g, ' ').trim();
+    return clean || null;
+  };
   const canonical = s(m.requires_human_action_reason);
   if (canonical) {
     return { reason: canonical, set_by: s(m.requires_human_action_by), set_at: s(m.requires_human_action_at), source_key: 'requires_human_action_reason' };

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -294,4 +294,56 @@ async function baselinedCandidateEligible(sb, sdKey, ctx) {
   }
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending, TEST_FIXTURE_KEY_RE };
+/**
+ * QF-20260704-193: coalesce the KNOWN ad-hoc hold-provenance keys into ONE reading.
+ * requires_human_action holds were stamped by different writers under different
+ * metadata keys (coordinator defers: not_worker_claimable_reason/deferred_by;
+ * bridge review-holds: review_hold_reason; pilot parking: pilot_throwaway) — so
+ * every surface that wanted to explain a hold had to know every key, most printed
+ * nothing, and a 3 AM operator could not tell deliberate-vs-accidental without
+ * hand-querying metadata (live specimen: the 47 rha-frozen sprint children,
+ * 2026-07-05). This reader lives HERE — beside the classifyDispatchIneligibility
+ * verdict that consumes the flag — so ranker/dashboard/eligibility all resolve
+ * the same provenance. Writers SHOULD stamp requires_human_action_reason
+ * (+ requires_human_action_by / _at) going forward; legacy keys stay readable.
+ * Pure; returns null when no reason key is present (a bare boolean hold).
+ * @param {object|null|undefined} metadata - strategic_directives_v2.metadata
+ * @returns {null | { reason: string, set_by: string|null, set_at: string|null, source_key: string }}
+ */
+function resolveHoldProvenance(metadata) {
+  const m = metadata || {};
+  const s = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+  const canonical = s(m.requires_human_action_reason);
+  if (canonical) {
+    return { reason: canonical, set_by: s(m.requires_human_action_by), set_at: s(m.requires_human_action_at), source_key: 'requires_human_action_reason' };
+  }
+  const notClaimable = s(m.not_worker_claimable_reason);
+  if (notClaimable) {
+    return { reason: notClaimable, set_by: s(m.not_worker_claimable_by) || s(m.deferred_by), set_at: s(m.not_worker_claimable_at) || s(m.deferred_at), source_key: 'not_worker_claimable_reason' };
+  }
+  const reviewHold = s(m.review_hold_reason);
+  if (reviewHold) {
+    return { reason: reviewHold, set_by: s(m.review_hold_by), set_at: s(m.review_hold_at), source_key: 'review_hold_reason' };
+  }
+  const dispatchIneligible = s(m.dispatch_ineligible_reason);
+  if (dispatchIneligible) {
+    return { reason: dispatchIneligible, set_by: null, set_at: null, source_key: 'dispatch_ineligible_reason' };
+  }
+  if (m.pilot_throwaway === true) {
+    return { reason: 'pilot throwaway venture', set_by: s(m.deferred_by), set_at: s(m.deferred_at), source_key: 'pilot_throwaway' };
+  }
+  if (s(m.deferred_by) || s(m.deferred_at)) {
+    return { reason: `deferred by ${s(m.deferred_by) || '?'}`, set_by: s(m.deferred_by), set_at: s(m.deferred_at), source_key: 'deferred_by' };
+  }
+  return null;
+}
+
+/** Pure: one-line render of a provenance object for skip lines / dashboards. */
+function formatHoldProvenance(prov) {
+  if (!prov || !prov.reason) return 'no reason recorded';
+  const by = prov.set_by ? ` — by ${prov.set_by}` : '';
+  const at = prov.set_at ? ` @ ${prov.set_at}` : '';
+  return `${prov.reason}${by}${at}`;
+}
+
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance };

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -166,7 +166,7 @@ const sb = createClient(
  * @param {{ quiet?: boolean }} [opts] - QF-20260704-051: quiet=true silences the per-skip
  *   console.log lines below (still counts them) — for callers like fleet-dashboard.cjs that
  *   poll this on every render and must not spam stdout with ranker skip-reason logging.
- * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[] }>}
+ * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[], humanActionHolds: Array<{sd_key: string, provenance: object|null}> }>}
  */
 export async function computeClaimableLeaves(sb, opts = {}) {
   const log = opts.quiet ? () => {} : console.log;
@@ -177,7 +177,7 @@ export async function computeClaimableLeaves(sb, opts = {}) {
     // whose parent has not yet passed LEAD (else the field is undefined → the gate silently no-ops).
     .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata, parent_sd_id')
     .not('status', 'in', '("completed","cancelled","deferred")');
-  if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return { error, sds: [], byKey: new Map(), depStatus: {}, claimable: [] }; }
+  if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return { error, sds: [], byKey: new Map(), depStatus: {}, claimable: [], humanActionHolds: [] }; }
 
   // ── dependency graph: edges dep -> dependents (over non-terminal set + completed deps resolved) ──
   const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
@@ -269,6 +269,10 @@ export async function computeClaimableLeaves(sb, opts = {}) {
   if (humanActionSkips) log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
   if (ineligibleSkips) log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
   if (depBlockedSkips) log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
+  // Deterministic order (adversarial-review I4): the select has no .order(), so without
+  // this sort the dashboard's grouped render could reorder between ticks and defeat the
+  // steady-state suppress hash.
+  humanActionHolds.sort((a, b) => a.sd_key.localeCompare(b.sd_key));
   return { sds, byKey, depStatus, claimable, humanActionHolds };
 }
 

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -43,7 +43,7 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispa
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
 // SD-REFILL-00MFWEGZ: reuse the canonical parent-LEAD-pass dispatch gate so the ranking surface
 // mirrors what claim-eligibility actually blocks (no drift between rank-vs-claim).
-import { parentLeadPending, classifyDispatchIneligibility } from '../lib/fleet/claim-eligibility.cjs';
+import { parentLeadPending, classifyDispatchIneligibility, resolveHoldProvenance, formatHoldProvenance } from '../lib/fleet/claim-eligibility.cjs';
 // SD-REFILL-00AH2L4Q: honor the SAME canonical metadata blocker key (metadata.blocked_by_sd_key)
 // that dependency-resolver + worker-checkin enforce, so the dispatch ranker does not keep a
 // metadata-blocked SD on the claimable belt (the convention was inconsistently enforced fleet-wide).
@@ -191,6 +191,9 @@ export async function computeClaimableLeaves(sb, opts = {}) {
 
   // ── claimable leaves ──
   const claimable = [];
+  // QF-20260704-193: held SDs with their coalesced provenance, returned so consumers
+  // (fleet-dashboard) can SURFACE hold reasons instead of rendering nothing.
+  const humanActionHolds = [];
   let fixtureSkips = 0;
   let inFlightSkips = 0;
   let awaitingConvergenceSkips = 0;
@@ -222,10 +225,16 @@ export async function computeClaimableLeaves(sb, opts = {}) {
           awaitingConvergenceSkips++;
           log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
           break;
-        case 'human_action_required':
+        case 'human_action_required': {
           humanActionSkips++;
-          log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key}`);
+          // QF-20260704-193: the hold reasons already EXIST under ad-hoc metadata keys —
+          // print them so a 3 AM operator can tell deliberate parking from an accidental
+          // freeze without hand-querying metadata (live: 47 rha-frozen sprint children).
+          const prov = resolveHoldProvenance(d.metadata);
+          humanActionHolds.push({ sd_key: d.sd_key, provenance: prov });
+          log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key} [${formatHoldProvenance(prov)}]`);
           break;
+        }
         default:
           ineligibleSkips++;
           log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
@@ -260,7 +269,7 @@ export async function computeClaimableLeaves(sb, opts = {}) {
   if (humanActionSkips) log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
   if (ineligibleSkips) log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
   if (depBlockedSkips) log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
-  return { sds, byKey, depStatus, claimable };
+  return { sds, byKey, depStatus, claimable, humanActionHolds };
 }
 
 async function main() {

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -568,10 +568,18 @@ function printAvailable(d) {
   console.log('AVAILABLE FOR CLAIM (' + total + ')');
   console.log('─'.repeat(72));
 
-  if (total === 0) {
+  // QF-20260704-193 (adversarial-review C1): the all-held/zero-claimable state is EXACTLY
+  // the motivating scenario (47 rha-frozen children, zero claimable) — the early return
+  // must not swallow the hold-provenance block, and the empty-state text must not claim
+  // "all claimed or completed" while SDs sit deliberately parked.
+  const holds = d.humanActionHolds || [];
+  if (total === 0 && holds.length === 0) {
     console.log('  (all SDs claimed or completed)');
     console.log('');
     return;
+  }
+  if (total === 0) {
+    console.log('  (no claimable SDs — all remaining are held for human action, see below)');
   }
 
   if (d.unclaimedChildren.length > 0) {
@@ -600,7 +608,8 @@ function printAvailable(d) {
 
   // QF-20260704-193: hold PROVENANCE for rha-held SDs — deliberate-vs-accidental at a
   // glance. Compact: reasons grouped, capped, never a bare count with no explanation.
-  const holds = d.humanActionHolds || [];
+  // NB the count is "held AND idle": a held SD that is also claimed/in-flight is being
+  // worked and is intentionally absent (claimableDbFreeReason short-circuits earlier).
   if (holds.length > 0) {
     console.log('  On hold (requires human action) — ' + holds.length + ':');
     const HOLD_CAP = 6;

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -191,10 +191,15 @@ async function loadData() {
   // gating) so the two can never diverge. Fail-soft: an error degrades to an empty list
   // rather than crashing the dashboard.
   let claimableLeaves = [];
+  // QF-20260704-193: held-SD provenance from the SAME ranker pass — the dashboard
+  // previously printed NOTHING for rha-held SDs, so a 3 AM operator could not tell
+  // deliberate parking from an accidental freeze without hand-querying metadata.
+  let humanActionHolds = [];
   try {
     const { computeClaimableLeaves } = await import('./coordinator-backlog-rank.mjs');
     const result = await computeClaimableLeaves(supabase, { quiet: true });
     claimableLeaves = result.claimable || [];
+    humanActionHolds = result.humanActionHolds || [];
   } catch (e) {
     // degrade-safe: empty claimable list, dashboard still renders
   }
@@ -369,6 +374,7 @@ async function loadData() {
     claimedSdIds, activeSessions, staleSessions, idleSessions,
     completedChildren, totalChildren, orchPct,
     unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells,
+    humanActionHolds,
     drainAgents,
     mc, mcByWorker,
     executeTeams,
@@ -589,6 +595,26 @@ function printAvailable(d) {
     }
     if (d.unclaimedStandalone.length > displayed.length) {
       console.log('    … and ' + (d.unclaimedStandalone.length - displayed.length) + ' more');
+    }
+  }
+
+  // QF-20260704-193: hold PROVENANCE for rha-held SDs — deliberate-vs-accidental at a
+  // glance. Compact: reasons grouped, capped, never a bare count with no explanation.
+  const holds = d.humanActionHolds || [];
+  if (holds.length > 0) {
+    console.log('  On hold (requires human action) — ' + holds.length + ':');
+    const HOLD_CAP = 6;
+    const byReason = new Map();
+    for (const h of holds) {
+      const key = h.provenance ? (h.provenance.reason + (h.provenance.set_by ? ' — by ' + h.provenance.set_by : '')) : 'no reason recorded (bare flag)';
+      if (!byReason.has(key)) byReason.set(key, []);
+      byReason.get(key).push(h.sd_key);
+    }
+    let printed = 0;
+    for (const [reason, keys] of byReason) {
+      if (printed >= HOLD_CAP) { console.log('    … and ' + (byReason.size - printed) + ' more reason group(s)'); break; }
+      console.log('    [' + keys.length + '] ' + reason.substring(0, 80) + '  (' + keys.slice(0, 3).join(', ') + (keys.length > 3 ? ', …' : '') + ')');
+      printed++;
     }
   }
 

--- a/tests/unit/fleet/hold-provenance.test.js
+++ b/tests/unit/fleet/hold-provenance.test.js
@@ -1,0 +1,98 @@
+/**
+ * QF-20260704-193: requires_human_action holds carried reasons under AD-HOC metadata
+ * keys (not_worker_claimable_reason / review_hold_reason / dispatch_ineligible_reason /
+ * deferred_by / pilot_throwaway) — no surface printed them, so a 3 AM operator could
+ * not tell deliberate parking from an accidental freeze without hand-querying metadata
+ * (live specimen: 47 rha-frozen sprint children, 2026-07-05).
+ *
+ * Under test: the SSOT coalescing reader in lib/fleet/claim-eligibility.cjs, its
+ * formatter, and computeClaimableLeaves returning humanActionHolds for the dashboard.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveHoldProvenance, formatHoldProvenance } = require('../../../lib/fleet/claim-eligibility.cjs');
+import { computeClaimableLeaves } from '../../../scripts/coordinator-backlog-rank.mjs';
+
+describe('resolveHoldProvenance — coalesces every known writer key', () => {
+  it('canonical requires_human_action_reason wins over every legacy key', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action_reason: 'canonical reason',
+      requires_human_action_by: 'coordinator-x',
+      requires_human_action_at: '2026-07-05T00:00:00Z',
+      not_worker_claimable_reason: 'legacy reason',
+    });
+    expect(p).toEqual({ reason: 'canonical reason', set_by: 'coordinator-x', set_at: '2026-07-05T00:00:00Z', source_key: 'requires_human_action_reason' });
+  });
+
+  it('reads the coordinator-defer keys (the 47 frozen sprint children shape)', () => {
+    const p = resolveHoldProvenance({
+      requires_human_action: true,
+      not_worker_claimable_reason: 'PARKED VENTURE — prove-one-venture mission (chairman-anchored 07-02)',
+      deferred_by: 'coordinator-3323e19a',
+      deferred_at: '2026-07-03T16:30:00Z',
+    });
+    expect(p.reason).toMatch(/PARKED VENTURE/);
+    expect(p.set_by).toBe('coordinator-3323e19a');
+    expect(p.source_key).toBe('not_worker_claimable_reason');
+  });
+
+  it('reads review_hold_reason (bridge child path) and dispatch_ineligible_reason', () => {
+    expect(resolveHoldProvenance({ review_hold_reason: 'needs coordinator review' }).source_key).toBe('review_hold_reason');
+    expect(resolveHoldProvenance({ dispatch_ineligible_reason: 'repo mismatch' }).source_key).toBe('dispatch_ineligible_reason');
+  });
+
+  it('reads pilot_throwaway and bare deferred_by as last-resort provenance', () => {
+    expect(resolveHoldProvenance({ pilot_throwaway: true }).reason).toBe('pilot throwaway venture');
+    const d = resolveHoldProvenance({ deferred_by: 'adam-1' });
+    expect(d.reason).toBe('deferred by adam-1');
+    expect(d.source_key).toBe('deferred_by');
+  });
+
+  it('returns null for a bare boolean hold (deliberate-vs-accidental genuinely undecidable)', () => {
+    expect(resolveHoldProvenance({ requires_human_action: true })).toBeNull();
+    expect(resolveHoldProvenance({})).toBeNull();
+    expect(resolveHoldProvenance(null)).toBeNull();
+    expect(resolveHoldProvenance({ not_worker_claimable_reason: '   ' })).toBeNull();
+  });
+});
+
+describe('formatHoldProvenance — one-line render', () => {
+  it('composes reason + by + at, and attests when provenance is absent', () => {
+    expect(formatHoldProvenance({ reason: 'parked', set_by: 'coord-1', set_at: '2026-07-03' })).toBe('parked — by coord-1 @ 2026-07-03');
+    expect(formatHoldProvenance({ reason: 'parked', set_by: null, set_at: null })).toBe('parked');
+    expect(formatHoldProvenance(null)).toBe('no reason recorded');
+  });
+});
+
+describe('computeClaimableLeaves — returns humanActionHolds with provenance (dashboard feed)', () => {
+  it('held rows land in humanActionHolds with their coalesced provenance; clean rows stay claimable', async () => {
+    const rows = [
+      {
+        sd_key: 'SD-HELD-001', title: 'held', status: 'draft', sd_type: 'feature', priority: 'high',
+        created_at: '2026-07-01T00:00:00Z', current_phase: 'LEAD', claiming_session_id: null, dependencies: null, parent_sd_id: null,
+        metadata: { requires_human_action: true, not_worker_claimable_reason: 'PARKED VENTURE', deferred_by: 'coordinator-3323e19a' },
+      },
+      {
+        sd_key: 'SD-CLEAN-001', title: 'clean draft with a real description long enough to not be a bare shell', status: 'draft', sd_type: 'feature', priority: 'high',
+        created_at: '2026-07-01T00:00:00Z', current_phase: 'LEAD', claiming_session_id: null, dependencies: null, parent_sd_id: null,
+        metadata: {}, description: 'a genuine description of the work to be done here',
+      },
+    ];
+    const sb = {
+      from: () => ({
+        select: () => ({
+          not: () => Promise.resolve({ data: rows, error: null }),
+          in: () => Promise.resolve({ data: [], error: null }),
+        }),
+      }),
+    };
+    const result = await computeClaimableLeaves(sb, { quiet: true });
+    expect(result.humanActionHolds).toHaveLength(1);
+    expect(result.humanActionHolds[0].sd_key).toBe('SD-HELD-001');
+    expect(result.humanActionHolds[0].provenance.reason).toBe('PARKED VENTURE');
+    expect(result.humanActionHolds[0].provenance.set_by).toBe('coordinator-3323e19a');
+    expect(result.claimable.map((d) => d.sd_key)).toContain('SD-CLEAN-001');
+    expect(result.claimable.map((d) => d.sd_key)).not.toContain('SD-HELD-001');
+  });
+});

--- a/tests/unit/fleet/hold-provenance.test.js
+++ b/tests/unit/fleet/hold-provenance.test.js
@@ -55,6 +55,13 @@ describe('resolveHoldProvenance — coalesces every known writer key', () => {
     expect(resolveHoldProvenance(null)).toBeNull();
     expect(resolveHoldProvenance({ not_worker_claimable_reason: '   ' })).toBeNull();
   });
+
+  it('strips control characters from metadata-sourced strings (review W3: log/terminal injection)', () => {
+    const p = resolveHoldProvenance({ not_worker_claimable_reason: 'line one\nFORGED [skip] line\x1b[31m', deferred_by: 'coord\x00-1' });
+    expect(p.reason).not.toMatch(/[\n\x1b\x00]/);
+    expect(p.reason).toContain('line one');
+    expect(p.set_by).toBe('coord -1');
+  });
 });
 
 describe('formatHoldProvenance — one-line render', () => {
@@ -94,5 +101,24 @@ describe('computeClaimableLeaves — returns humanActionHolds with provenance (d
     expect(result.humanActionHolds[0].provenance.set_by).toBe('coordinator-3323e19a');
     expect(result.claimable.map((d) => d.sd_key)).toContain('SD-CLEAN-001');
     expect(result.claimable.map((d) => d.sd_key)).not.toContain('SD-HELD-001');
+  });
+
+  it('humanActionHolds is deterministically sorted by sd_key (review I4: stable render hash)', async () => {
+    const held = (key) => ({
+      sd_key: key, title: 'held', status: 'draft', sd_type: 'feature', priority: 'high',
+      created_at: '2026-07-01T00:00:00Z', current_phase: 'LEAD', claiming_session_id: null, dependencies: null, parent_sd_id: null,
+      metadata: { requires_human_action: true, not_worker_claimable_reason: 'PARKED' },
+    });
+    const sb = {
+      from: () => ({ select: () => ({ not: () => Promise.resolve({ data: [held('SD-Z-001'), held('SD-A-001'), held('SD-M-001')], error: null }), in: () => Promise.resolve({ data: [], error: null }) }) }),
+    };
+    const result = await computeClaimableLeaves(sb, { quiet: true });
+    expect(result.humanActionHolds.map((h) => h.sd_key)).toEqual(['SD-A-001', 'SD-M-001', 'SD-Z-001']);
+  });
+
+  it('error path returns an EMPTY humanActionHolds array, never undefined (review I5)', async () => {
+    const sb = { from: () => ({ select: () => ({ not: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) };
+    const result = await computeClaimableLeaves(sb, { quiet: true });
+    expect(result.humanActionHolds).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Corrected-premise QF (Adam, 2026-07-05): hold reasons for the 47 rha-frozen sprint children EXIST under ad-hoc metadata keys — the gap was (1) no surface printed them and (2) no canonical key convention. This adds one coalescing SSOT reader beside the verdict that consumes the flag, and makes all three surfaces speak it.

- `resolveHoldProvenance()` in lib/fleet/claim-eligibility.cjs: canonical `requires_human_action_reason` (+`_by`/`_at`) first, then `not_worker_claimable_reason`, `review_hold_reason`, `dispatch_ineligible_reason`, `pilot_throwaway`, bare `deferred_by`; null for a bare boolean hold. `formatHoldProvenance()` renders one line.
- coordinator-backlog-rank skip lines now print `[reason — by setter @ time]`; `computeClaimableLeaves` returns additive `humanActionHolds`.
- fleet-dashboard renders a grouped "On hold (requires human action)" block under AVAILABLE FOR CLAIM (reason groups, setter, sample keys, capped at 6 groups).
- No backfill (per corrected premise — the 47 already carry reasons); writers stamp the canonical key going forward.

## Test plan
tests/unit/fleet/hold-provenance.test.js — 7 tests: key precedence, the exact 47-children metadata shape, bare-flag null (deliberate-vs-accidental genuinely undecidable), formatter, and computeClaimableLeaves humanActionHolds feed. Full tests/unit/fleet/ + review-hold suite: 308 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
