### PR TITLE
feat(SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001): G3 PR1 - machinery-class activation-evidence gate

### DIFF
--- a/database/migrations/20260705b_scope_completion_chain_activation_evidence.sql
+++ b/database/migrations/20260705b_scope_completion_chain_activation_evidence.sql
@@ -1,0 +1,41 @@
+-- requires-chairman-apply
+-- SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 (G3, FR-3): activation-evidence columns on
+-- scope_completion_chain. STAGED, NOT APPLIED — scope_completion_chain carries an
+-- @approved-by tag (see 20260516130000_add_scope_completion_chain.sql), so this ALTER is
+-- chairman-gated per repo convention. Application code (checkActivationEvidence in
+-- scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js)
+-- fails open (returns false, never throws) if these columns do not yet exist, so nothing
+-- breaks pre-approval.
+--
+-- real_event_ref: id/correlation id of the real production event this row evidences.
+-- evidence_kind: advisory (non-blocking trigger) vocab distinguishing a genuine production
+-- event from a replayed test fixture — a replayed_fixture row must NOT satisfy G3's
+-- ACTIVATED requirement.
+
+ALTER TABLE scope_completion_chain
+  ADD COLUMN IF NOT EXISTS real_event_ref TEXT,
+  ADD COLUMN IF NOT EXISTS evidence_kind TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_scope_completion_chain_evidence_kind ON scope_completion_chain (evidence_kind);
+
+-- Advisory-only vocab check (mirrors bypass_ledger's non-blocking vocab trigger convention) —
+-- does NOT block writes; future vocab additions need no migration.
+CREATE OR REPLACE FUNCTION scope_completion_chain_evidence_kind_advisory_trigger()
+RETURNS trigger AS $$
+DECLARE
+  known_vocab TEXT[] := ARRAY['real_event', 'replayed_fixture', 'armed_declaration'];
+BEGIN
+  IF NEW.evidence_kind IS NOT NULL AND NOT (NEW.evidence_kind = ANY(known_vocab)) THEN
+    RAISE NOTICE 'scope_completion_chain: advisory — evidence_kind ''%'' not in known vocab list %', NEW.evidence_kind, known_vocab;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS scope_completion_chain_evidence_kind_advisory ON scope_completion_chain;
+CREATE TRIGGER scope_completion_chain_evidence_kind_advisory
+  BEFORE INSERT OR UPDATE ON scope_completion_chain
+  FOR EACH ROW EXECUTE FUNCTION scope_completion_chain_evidence_kind_advisory_trigger();
+
+COMMENT ON COLUMN scope_completion_chain.real_event_ref IS 'G3 (SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001): id/correlation id of the real production event this row evidences.';
+COMMENT ON COLUMN scope_completion_chain.evidence_kind IS 'G3 (SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001): advisory vocab (real_event | replayed_fixture | armed_declaration) — a replayed_fixture row does NOT satisfy the ACTIVATED requirement.';

--- a/lib/machinery-class/classify.js
+++ b/lib/machinery-class/classify.js
@@ -1,0 +1,81 @@
+/**
+ * Machinery-class classifier — SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 (G3, FR-2).
+ *
+ * Decides whether an SD/QF's deliverable is "event-processing machinery" (a worker,
+ * watcher, router, gate, cron, or hook) — the class subject to the amended Definition-
+ * of-Done (FR-1: must reach ACTIVATED or ARMED, never just "merged + tests green").
+ *
+ * Deliberately NOT the same predicate as scripts/modules/activation-invariant/
+ * trigger-evaluator.js's evaluateTrigger(): that evaluator requires a SCHEMA match
+ * AND a consumer match (schema+UI or schema+worker chain) — a pure cron/watcher fix
+ * with no schema change (the common case for G3's own named specimens: an
+ * eva-scheduler watcher, a capture gauge, a remediation router) would never trigger
+ * it. Machinery-class has no schema precondition; a worker/watcher/router/gate/
+ * cron/hook is machinery-class on its own, schema or not.
+ *
+ * Reuses the SAME dual-scan signal-extraction pattern (structured key_changes[].type
+ * + negation-aware free-text) and the same hasAffirmativeMatch/collectFreeText
+ * helpers as trigger-evaluator.js, imported via its TRIGGER_INTERNALS export, so the
+ * two classifiers share one negation/clause-boundary implementation rather than
+ * diverging copies.
+ *
+ * Conservative-DOWN on ambiguity (defaults to 'none'): over-gating here blocks real
+ * work, the opposite bias from tier-rank normalization's conservative-UP.
+ */
+import { TRIGGER_INTERNALS } from '../../scripts/modules/activation-invariant/trigger-evaluator.js';
+
+const { hasAffirmativeMatch, collectStructuredTypes, collectFreeText } = TRIGGER_INTERNALS;
+
+/** Structured key_changes[].type tokens that mark a machinery-class deliverable. */
+export const MACHINERY_TYPES = new Set(['worker', 'consumer', 'job', 'cron', 'watcher', 'router', 'gate', 'hook', 'service']);
+
+/**
+ * Free-text anchors for machinery-class deliverables. Phrase-bound (not bare single
+ * words like "gate"/"hook" alone) to avoid the same 58% FP class trigger-evaluator.js
+ * tuned away from (QF-20260513-725) — "gate" and "hook" are common English words in
+ * SD prose unrelated to a literal gate/hook file.
+ */
+const MACHINERY_TEXT_REGEX = /\b(cron job|scheduled job|background worker|watcher process|periodic watcher|remediation router|event router|validation gate|gate file|lifecycle hook|git hook|webhook handler|new (worker|watcher|router|cron)|worker[^.]*(populates|writes|consumes|processes)|watcher[^.]*(polls|monitors|checks))\b/i;
+
+/**
+ * Classify an SD/QF row as machinery-class or not.
+ * @param {Object} sd - a strategic_directives_v2 or quick_fixes-shaped row (key_changes, description, scope, title)
+ * @returns {{ machineryClass: boolean, kind: string, reason: string }}
+ */
+export function classifyMachineryClass(sd) {
+  if (!sd || typeof sd !== 'object') {
+    return { machineryClass: false, kind: 'none', reason: 'no_sd_provided' };
+  }
+
+  const types = collectStructuredTypes(sd.key_changes);
+  const structuredMatch = [...MACHINERY_TYPES].some((t) => types.has(t));
+
+  const text = collectFreeText(sd);
+  const textMatch = hasAffirmativeMatch(MACHINERY_TEXT_REGEX, text);
+
+  const machineryClass = structuredMatch || textMatch;
+  let reason = 'neither_lane_detected_machinery';
+  if (structuredMatch && textMatch) reason = 'both_lanes_match';
+  else if (structuredMatch) reason = 'structured_type_match';
+  else if (textMatch) reason = 'free_text_match';
+
+  return {
+    machineryClass,
+    kind: machineryClass ? matchedKind(types, text) : 'none',
+    reason,
+  };
+}
+
+/** Best-effort specific kind for the metadata.machinery_class stamp (informational only). */
+function matchedKind(types, text) {
+  for (const t of MACHINERY_TYPES) {
+    if (types.has(t)) return t;
+  }
+  const lower = (text || '').toLowerCase();
+  if (/watcher/.test(lower)) return 'watcher';
+  if (/cron/.test(lower)) return 'cron';
+  if (/router/.test(lower)) return 'router';
+  if (/hook/.test(lower)) return 'hook';
+  if (/gate/.test(lower)) return 'gate';
+  return 'worker';
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
@@ -25,6 +25,8 @@ import { detectInvocationPath, loadTriggerSources } from '../../../../../../lib/
 import { classifyRequiresInvocation } from '../../../../../../lib/invocation-detector/requires-invocation.js';
 import { getMainRef } from '../../../shared-git-context.js';
 import { isVentureRepo } from '../../../../../../lib/repo-paths.js';
+import { classifyMachineryClass } from '../../../../../../lib/machinery-class/classify.js';
+import { isOrchestratorSync } from '../../../../../../lib/sd/type-detection.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -45,6 +47,98 @@ function safeRead(absPath) {
  */
 export function resolveInvocationMode(env = process.env) {
   return (env && env.INVOCATION_PATH_PROOF_MODE) === 'block' ? 'block' : 'advisory';
+}
+
+/**
+ * SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 (G3, FR-1): activation-evidence rollout mode
+ * resolver. Mirrors resolveInvocationMode's advisory-first precedent — a brand-new blocking
+ * requirement must not mass-fail every in-flight machinery-class SD on day one. Advisory
+ * (default) surfaces the finding as a warning; ACTIVATION_EVIDENCE_MODE=block promotes to a
+ * hard fail once the classifier has been validated against real traffic (FR-6 retro sweep).
+ * @param {object} [env] @returns {'advisory'|'block'}
+ */
+export function resolveActivationEvidenceMode(env = process.env) {
+  return (env && env.ACTIVATION_EVIDENCE_MODE) === 'block' ? 'block' : 'advisory';
+}
+
+/**
+ * G3 FR-1: classify a machinery-class SD's activation state.
+ * - UNWIRED: machinery-class, not an orchestrator parent, no ACTIVATED evidence, no ARMED
+ *   registration. The state the amended DoD blocks (in 'block' mode) or warns on (advisory).
+ * - ACTIVATED: a real (non-replayed-fixture) event-processed evidence row exists.
+ * - ARMED: no real-event evidence yet, but a liveness-watch registration exists (legitimate
+ *   pre-fire state — the trigger structurally cannot have fired yet).
+ * - not_applicable: non-machinery SD, or an orchestrator parent (FR-5 exemption).
+ *
+ * PURE: takes the classification + evidence booleans as arguments so the DB lookups
+ * (checkActivationEvidence/checkArmedRegistration) can be injected/mocked in tests.
+ *
+ * @param {object} sd
+ * @param {{ hasActivatedEvidence: boolean, hasArmedRegistration: boolean }} evidence
+ * @returns {{ state: 'not_applicable'|'UNWIRED'|'ACTIVATED'|'ARMED', machineryKind: string }}
+ */
+export function evaluateActivationEvidence(sd, evidence = {}) {
+  if (isOrchestratorSync(sd)) return { state: 'not_applicable', machineryKind: 'none', reason: 'orchestrator_parent_exempt' };
+  const classification = classifyMachineryClass(sd);
+  if (!classification.machineryClass) return { state: 'not_applicable', machineryKind: 'none', reason: 'not_machinery_class' };
+  if (evidence.hasActivatedEvidence) return { state: 'ACTIVATED', machineryKind: classification.kind };
+  if (evidence.hasArmedRegistration) return { state: 'ARMED', machineryKind: classification.kind };
+  return { state: 'UNWIRED', machineryKind: classification.kind };
+}
+
+/**
+ * G3 FR-3: does this SD have >=1 REAL (not replayed-fixture) activation-evidence row in
+ * scope_completion_chain? Reuses the existing generic completion-chain table (entity_type
+ * IN ('sd','child_sd')) rather than bypass_ledger — bypass_ledger's every row represents an
+ * actual bypass event (bypass_type/bypass_reason NOT NULL); forcing G3 evidence through it
+ * would misuse a narrowly-scoped audit ledger for an unrelated purpose. Fail-open (false) on
+ * any query error — a DB hiccup must not itself manufacture a false UNWIRED verdict beyond
+ * what advisory mode already tolerates.
+ * @param {object} supabase
+ * @param {object} sd
+ * @returns {Promise<boolean>}
+ */
+export async function checkActivationEvidence(supabase, sd) {
+  try {
+    const sdKey = sd?.sd_key || sd?.id;
+    if (!sdKey) return false;
+    const { data, error } = await supabase
+      .from('scope_completion_chain')
+      .select('id')
+      .in('entity_type', ['sd', 'child_sd'])
+      .eq('entity_id', sd?.uuid_id || sd?.id)
+      .eq('evidence_kind', 'real_event')
+      .not('runtime_observed_at', 'is', null)
+      .limit(1);
+    if (error) return false;
+    return Array.isArray(data) && data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * G3 FR-4: does this SD have an ARMED liveness-watch registration in
+ * periodic_process_registry? Reuses the existing table's liveness_source_ref JSONB column
+ * for SD linkage — no new table, no schema change. Fail-open (false) on any query error.
+ * @param {object} supabase
+ * @param {object} sd
+ * @returns {Promise<boolean>}
+ */
+export async function checkArmedRegistration(supabase, sd) {
+  try {
+    const sdKey = sd?.sd_key || sd?.id;
+    if (!sdKey) return false;
+    const { data, error } = await supabase
+      .from('periodic_process_registry')
+      .select('id')
+      .contains('liveness_source_ref', { sd_key: sdKey })
+      .limit(1);
+    if (error) return false;
+    return Array.isArray(data) && data.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -109,24 +203,87 @@ export function evaluateInvocationViolations(changedFiles, sources, readFile = (
 }
 
 /**
+ * G3 FR-1: merge the (always-computed) activation-evidence verdict into whichever
+ * early-return path the existing invocation-path logic takes below. Additive only —
+ * never removes an existing issue/warning, never flips passed:true to false unless the
+ * activation verdict itself blocks.
+ * @param {{passed:boolean, score:number, max_score:number, issues:string[], warnings:string[], details?:object}} base
+ * @param {{passed:boolean, issues:string[], warnings:string[], details?:object}} activation
+ */
+function mergeActivationVerdict(base, activation) {
+  if (!activation || (activation.issues.length === 0 && activation.warnings.length === 0)) return base;
+  return {
+    ...base,
+    passed: base.passed && activation.passed,
+    score: activation.passed ? base.score : 0,
+    issues: [...base.issues, ...activation.issues],
+    warnings: [...base.warnings, ...activation.warnings],
+    details: { ...(base.details || {}), activationEvidence: activation.details },
+  };
+}
+
+/**
+ * G3 FR-1/FR-3/FR-4/FR-5: compute the activation-evidence verdict for this SD. Runs
+ * independently of the file-diff logic below (a machinery-class SD may need this check
+ * even on a PR that touches no scripts/lib files, e.g. a wiring-only follow-up). Async
+ * DB lookups are fail-open (never throw); advisory mode never fails the gate.
+ * @param {object} supabase
+ * @param {object} sd
+ * @returns {Promise<{passed:boolean, issues:string[], warnings:string[], details:object}>}
+ */
+async function computeActivationEvidenceVerdict(supabase, sd) {
+  const evaluation = evaluateActivationEvidence(sd, {});
+  if (evaluation.state === 'not_applicable') {
+    return { passed: true, issues: [], warnings: [], details: { state: 'not_applicable', reason: evaluation.reason } };
+  }
+  let hasActivatedEvidence = false;
+  let hasArmedRegistration = false;
+  if (supabase) {
+    [hasActivatedEvidence, hasArmedRegistration] = await Promise.all([
+      checkActivationEvidence(supabase, sd),
+      checkArmedRegistration(supabase, sd),
+    ]);
+  }
+  const finalState = evaluateActivationEvidence(sd, { hasActivatedEvidence, hasArmedRegistration });
+  const mode = resolveActivationEvidenceMode();
+  console.log(`   Machinery-class (${finalState.machineryKind}): activation state = ${finalState.state}`);
+  if (finalState.state !== 'UNWIRED') {
+    return { passed: true, issues: [], warnings: [], details: finalState };
+  }
+  const headline = `Machinery-class deliverable (${finalState.machineryKind}) has no ACTIVATED evidence and no ARMED registration (G3 Definition-of-Done amendment).`;
+  const remediation = 'Record a scope_completion_chain evidence row (evidence_kind=real_event, runtime_observed_at set) once a real event is processed, OR register a periodic_process_registry row (liveness_source_ref.sd_key) with a named activation trigger if real events cannot occur yet.';
+  if (mode === 'block') {
+    return { passed: false, issues: [headline, remediation], warnings: [], details: finalState };
+  }
+  return { passed: true, issues: [], warnings: [`[ADVISORY] ${headline} ${remediation} Set ACTIVATION_EVIDENCE_MODE=block to enforce.`], details: finalState };
+}
+
+/**
  * Create the invocation-path proof gate.
- * @param {Object} _supabase - kept for gate-interface consistency (unused)
+ * @param {Object} supabase - service-role client; used by the G3 activation-evidence check
  * @returns {Object} Gate definition
  */
-export function createInvocationPathGate(_supabase) {
+export function createInvocationPathGate(supabase) {
   return {
     name: GATE_NAME,
     validator: async (ctx) => {
       console.log('\n🔌 GATE: Invocation-Path Proof (autonomous code must be wired to fire)');
       console.log('-'.repeat(50));
 
+      const sd = ctx?.sd || {};
+      const activationVerdict = await computeActivationEvidenceVerdict(supabase, sd);
+
       // Venture opt-out: the detector's trigger sources (GHA workflows, package.json, the
       // loop-contract registry) are EHG_Engineer-rooted, so a venture-targeted SD's separate repo
       // would not resolve meaningfully here. Opt out unless the SD forces wiring. (Mirrors WIRE_CHECK.)
-      const sd = ctx?.sd || {};
+      // The G3 activation-evidence check above is NOT repo-scoped (its DB tables are
+      // EHG_Engineer-native regardless of target_application), so it still applies here.
       if (isVentureRepo(sd.target_application) && sd?.metadata?.wiring_required !== true) {
         console.log(`   ⏭️  Venture SD (target_application=${sd.target_application}) — INVOCATION_PATH_PROOF opted out (set metadata.wiring_required=true to force).`);
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF skipped for venture target_application=${sd.target_application}`], details: { skipped: 'venture_opt_out' } };
+        return mergeActivationVerdict(
+          { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF skipped for venture target_application=${sd.target_application}`], details: { skipped: 'venture_opt_out' } },
+          activationVerdict
+        );
       }
 
       // Step 1: ADDED JS in scripts/ & lib/ vs origin/main. Fail-OPEN on diff error.
@@ -147,12 +304,15 @@ export function createInvocationPathGate(_supabase) {
       } catch (err) {
         const message = err?.message || String(err);
         console.log(`   ⚠️  git diff against ${mainRef} failed — fail-open (advisory): ${message}`);
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not compute git diff (fail-open): ${message}`], details: { mainRef, error: message } };
+        return mergeActivationVerdict(
+          { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not compute git diff (fail-open): ${message}`], details: { mainRef, error: message } },
+          activationVerdict
+        );
       }
 
       if (changed.length === 0) {
         console.log('   No changed JS in scripts/ or lib/ — auto-pass');
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [] };
+        return mergeActivationVerdict({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] }, activationVerdict);
       }
 
       // Step 2: load the live trigger sources ONCE, then classify+detect per file.
@@ -162,7 +322,10 @@ export function createInvocationPathGate(_supabase) {
       } catch (err) {
         const message = err?.message || String(err);
         console.log(`   ⚠️  trigger-source load failed — fail-open (advisory): ${message}`);
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not load trigger sources (fail-open): ${message}`], details: { error: message } };
+        return mergeActivationVerdict(
+          { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not load trigger sources (fail-open): ${message}`], details: { error: message } },
+          activationVerdict
+        );
       }
 
       const { violations, autonomousChecked } = evaluateInvocationViolations(
@@ -185,7 +348,7 @@ export function createInvocationPathGate(_supabase) {
       // violations as warnings (passed:true); INVOCATION_PATH_PROOF_MODE=block restores -C's hard fail.
       const mode = resolveInvocationMode();
       if (violations.length > 0) console.log(`   Mode: ${mode}${mode === 'advisory' ? ' (advisory — warns, does not fail; set INVOCATION_PATH_PROOF_MODE=block to enforce)' : ' (BLOCKING)'}`);
-      return resolveInvocationVerdict({ violations, autonomousChecked }, mode, remediation);
+      return mergeActivationVerdict(resolveInvocationVerdict({ violations, autonomousChecked }, mode, remediation), activationVerdict);
     },
     required: true,
   };

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
@@ -100,13 +100,15 @@ export function evaluateActivationEvidence(sd, evidence = {}) {
  */
 export async function checkActivationEvidence(supabase, sd) {
   try {
-    const sdKey = sd?.sd_key || sd?.id;
-    if (!sdKey) return false;
+    // entity_id references strategic_directives_v2's own PRIMARY KEY (sd.id) — the canonical
+    // UUID identity, not sd_key (TEXT) or the secondary uuid_id field.
+    const entityId = sd?.id;
+    if (!entityId) return false;
     const { data, error } = await supabase
       .from('scope_completion_chain')
       .select('id')
       .in('entity_type', ['sd', 'child_sd'])
-      .eq('entity_id', sd?.uuid_id || sd?.id)
+      .eq('entity_id', entityId)
       .eq('evidence_kind', 'real_event')
       .not('runtime_observed_at', 'is', null)
       .limit(1);
@@ -121,6 +123,8 @@ export async function checkActivationEvidence(supabase, sd) {
  * G3 FR-4: does this SD have an ARMED liveness-watch registration in
  * periodic_process_registry? Reuses the existing table's liveness_source_ref JSONB column
  * for SD linkage — no new table, no schema change. Fail-open (false) on any query error.
+ * periodic_process_registry's PRIMARY KEY is process_key (TEXT) — the table has NO `id`
+ * column, so the select below must reference the real key.
  * @param {object} supabase
  * @param {object} sd
  * @returns {Promise<boolean>}
@@ -131,7 +135,7 @@ export async function checkArmedRegistration(supabase, sd) {
     if (!sdKey) return false;
     const { data, error } = await supabase
       .from('periodic_process_registry')
-      .select('id')
+      .select('process_key')
       .contains('liveness_source_ref', { sd_key: sdKey })
       .limit(1);
     if (error) return false;

--- a/tests/unit/invocation-detector/activation-evidence-gate.test.js
+++ b/tests/unit/invocation-detector/activation-evidence-gate.test.js
@@ -1,0 +1,158 @@
+/**
+ * SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 (G3) — activation-evidence extension to the
+ * INVOCATION_PATH_PROOF gate. FR-1 (tri-state classification), FR-3 (real-event evidence via
+ * scope_completion_chain), FR-4 (ARMED via periodic_process_registry), FR-5 (parent exemption).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  createInvocationPathGate,
+  evaluateActivationEvidence,
+  resolveActivationEvidenceMode,
+  checkActivationEvidence,
+  checkArmedRegistration,
+} from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js';
+
+const WORKER_SD = { sd_key: 'SD-TEST-WORKER-001', id: 'sd-1', key_changes: [{ type: 'worker', change: 'Add a new worker' }] };
+const DOCS_SD = { sd_key: 'SD-TEST-DOCS-001', id: 'sd-2', key_changes: [{ type: 'documentation', change: 'docs' }] };
+const ORCH_PARENT_SD = { sd_key: 'SD-TEST-ORCH-001', id: 'sd-3', sd_type: 'orchestrator', key_changes: [{ type: 'worker', change: 'children build workers' }] };
+
+describe('resolveActivationEvidenceMode', () => {
+  it('defaults to advisory', () => {
+    expect(resolveActivationEvidenceMode({})).toBe('advisory');
+  });
+  it('promotes to block only on the exact literal', () => {
+    expect(resolveActivationEvidenceMode({ ACTIVATION_EVIDENCE_MODE: 'block' })).toBe('block');
+    expect(resolveActivationEvidenceMode({ ACTIVATION_EVIDENCE_MODE: 'BLOCK' })).toBe('advisory');
+  });
+});
+
+describe('evaluateActivationEvidence — pure tri-state classification', () => {
+  it('non-machinery SD is not_applicable regardless of evidence', () => {
+    expect(evaluateActivationEvidence(DOCS_SD, {}).state).toBe('not_applicable');
+  });
+
+  it('FR-5: orchestrator parent is exempt even with a machinery-class type', () => {
+    const result = evaluateActivationEvidence(ORCH_PARENT_SD, {});
+    expect(result.state).toBe('not_applicable');
+    expect(result.reason).toBe('orchestrator_parent_exempt');
+  });
+
+  it('machinery-class SD with no evidence is UNWIRED', () => {
+    expect(evaluateActivationEvidence(WORKER_SD, {}).state).toBe('UNWIRED');
+  });
+
+  it('machinery-class SD with real-event evidence is ACTIVATED', () => {
+    expect(evaluateActivationEvidence(WORKER_SD, { hasActivatedEvidence: true }).state).toBe('ACTIVATED');
+  });
+
+  it('machinery-class SD with only an ARMED registration is ARMED', () => {
+    expect(evaluateActivationEvidence(WORKER_SD, { hasArmedRegistration: true }).state).toBe('ARMED');
+  });
+
+  it('ACTIVATED wins over ARMED when both are present', () => {
+    expect(evaluateActivationEvidence(WORKER_SD, { hasActivatedEvidence: true, hasArmedRegistration: true }).state).toBe('ACTIVATED');
+  });
+});
+
+describe('checkActivationEvidence / checkArmedRegistration — DB lookups (fail-open)', () => {
+  function fakeSb({ activationRows = [], armedRows = [], errorOn = null } = {}) {
+    return {
+      from(table) {
+        return {
+          select() {
+            const chain = {
+              in: () => chain,
+              eq: () => chain,
+              not: () => chain,
+              contains: () => chain,
+              limit: () => {
+                if (errorOn === table) return Promise.resolve({ data: null, error: { message: 'boom' } });
+                return Promise.resolve({ data: table === 'scope_completion_chain' ? activationRows : armedRows, error: null });
+              },
+            };
+            return chain;
+          },
+        };
+      },
+    };
+  }
+
+  it('returns true when scope_completion_chain has a matching real-event row', async () => {
+    const sb = fakeSb({ activationRows: [{ id: 'row-1' }] });
+    expect(await checkActivationEvidence(sb, WORKER_SD)).toBe(true);
+  });
+
+  it('returns false when scope_completion_chain has no matching row', async () => {
+    const sb = fakeSb({ activationRows: [] });
+    expect(await checkActivationEvidence(sb, WORKER_SD)).toBe(false);
+  });
+
+  it('fails open (false) on a query error, never throws', async () => {
+    const sb = fakeSb({ errorOn: 'scope_completion_chain' });
+    await expect(checkActivationEvidence(sb, WORKER_SD)).resolves.toBe(false);
+  });
+
+  it('returns true when periodic_process_registry has a matching liveness_source_ref', async () => {
+    const sb = fakeSb({ armedRows: [{ id: 'row-2' }] });
+    expect(await checkArmedRegistration(sb, WORKER_SD)).toBe(true);
+  });
+
+  it('fails open (false) when supabase is null/undefined', async () => {
+    expect(await checkActivationEvidence(null, WORKER_SD)).toBe(false);
+    expect(await checkArmedRegistration(undefined, WORKER_SD)).toBe(false);
+  });
+});
+
+describe('createInvocationPathGate — end-to-end activation-evidence merge (advisory default)', () => {
+  const ORIGINAL_ENV = process.env.ACTIVATION_EVIDENCE_MODE;
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.ACTIVATION_EVIDENCE_MODE;
+    else process.env.ACTIVATION_EVIDENCE_MODE = ORIGINAL_ENV;
+  });
+
+  function fakeSbNoEvidence() {
+    return {
+      from() {
+        return {
+          select() {
+            const chain = { in: () => chain, eq: () => chain, not: () => chain, contains: () => chain, limit: () => Promise.resolve({ data: [], error: null }) };
+            return chain;
+          },
+        };
+      },
+    };
+  }
+
+  it('advisory (default): a machinery-class SD with no evidence still PASSES, with a warning', async () => {
+    delete process.env.ACTIVATION_EVIDENCE_MODE;
+    const g = createInvocationPathGate(fakeSbNoEvidence());
+    const res = await g.validator({ sd: WORKER_SD });
+    expect(res.passed).toBe(true);
+    expect(res.warnings.some((w) => w.includes('Machinery-class deliverable'))).toBe(true);
+  });
+
+  it('block mode: a machinery-class SD with no evidence FAILS, naming the requirement', async () => {
+    process.env.ACTIVATION_EVIDENCE_MODE = 'block';
+    const g = createInvocationPathGate(fakeSbNoEvidence());
+    const res = await g.validator({ sd: WORKER_SD });
+    expect(res.passed).toBe(false);
+    expect(res.issues.some((i) => i.includes('Machinery-class deliverable'))).toBe(true);
+  });
+
+  it('a non-machinery SD is unaffected (no activation warnings/issues at all)', async () => {
+    process.env.ACTIVATION_EVIDENCE_MODE = 'block';
+    const g = createInvocationPathGate(fakeSbNoEvidence());
+    const res = await g.validator({ sd: DOCS_SD });
+    expect(res.passed).toBe(true);
+    expect(res.warnings.some((w) => w.includes('Machinery-class'))).toBe(false);
+    expect(res.issues.some((i) => i.includes('Machinery-class'))).toBe(false);
+  });
+
+  it('FR-5: an orchestrator-parent machinery-class SD is exempt even in block mode', async () => {
+    process.env.ACTIVATION_EVIDENCE_MODE = 'block';
+    const g = createInvocationPathGate(fakeSbNoEvidence());
+    const res = await g.validator({ sd: ORCH_PARENT_SD });
+    expect(res.passed).toBe(true);
+    expect(res.issues.some((i) => i.includes('Machinery-class'))).toBe(false);
+  });
+});

--- a/tests/unit/invocation-detector/activation-evidence-gate.test.js
+++ b/tests/unit/invocation-detector/activation-evidence-gate.test.js
@@ -55,11 +55,13 @@ describe('evaluateActivationEvidence — pure tri-state classification', () => {
 });
 
 describe('checkActivationEvidence / checkArmedRegistration — DB lookups (fail-open)', () => {
-  function fakeSb({ activationRows = [], armedRows = [], errorOn = null } = {}) {
+  function fakeSb({ activationRows = [], armedRows = [], errorOn = null, selectCalls = [] } = {}) {
     return {
+      selectCalls,
       from(table) {
         return {
-          select() {
+          select(cols) {
+            selectCalls.push({ table, cols });
             const chain = {
               in: () => chain,
               eq: () => chain,
@@ -76,6 +78,26 @@ describe('checkActivationEvidence / checkArmedRegistration — DB lookups (fail-
       },
     };
   }
+
+  // Regression: periodic_process_registry's PRIMARY KEY is process_key (TEXT) — the table
+  // has NO `id` column. A `.select('id')` against it does not error in this mock (which
+  // doesn't validate real column existence), but WOULD error against the live schema,
+  // silently making checkArmedRegistration always fail-open to false. Pin the real column.
+  it("checkArmedRegistration selects 'process_key' (periodic_process_registry has no id column)", async () => {
+    const calls = [];
+    const sb = fakeSb({ selectCalls: calls });
+    await checkArmedRegistration(sb, WORKER_SD);
+    const call = calls.find((c) => c.table === 'periodic_process_registry');
+    expect(call.cols).toBe('process_key');
+  });
+
+  it("checkActivationEvidence selects 'id' (scope_completion_chain DOES have an id PK)", async () => {
+    const calls = [];
+    const sb = fakeSb({ selectCalls: calls });
+    await checkActivationEvidence(sb, WORKER_SD);
+    const call = calls.find((c) => c.table === 'scope_completion_chain');
+    expect(call.cols).toBe('id');
+  });
 
   it('returns true when scope_completion_chain has a matching real-event row', async () => {
     const sb = fakeSb({ activationRows: [{ id: 'row-1' }] });

--- a/tests/unit/machinery-class/classify.test.js
+++ b/tests/unit/machinery-class/classify.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 (G3, FR-2) — machinery-class classifier.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyMachineryClass, MACHINERY_TYPES } from '../../../lib/machinery-class/classify.js';
+
+describe('classifyMachineryClass — structured lane', () => {
+  it('classifies a worker-typed SD as machinery-class', () => {
+    const sd = { key_changes: [{ type: 'worker', change: 'Add stage-9 worker' }] };
+    const result = classifyMachineryClass(sd);
+    expect(result.machineryClass).toBe(true);
+    expect(result.kind).toBe('worker');
+  });
+
+  it('classifies each MACHINERY_TYPES token as machinery-class', () => {
+    for (const type of MACHINERY_TYPES) {
+      const sd = { key_changes: [{ type, change: 'x' }] };
+      expect(classifyMachineryClass(sd).machineryClass).toBe(true);
+    }
+  });
+
+  it('does NOT require a schema/database type (unlike evaluateTrigger)', () => {
+    const sd = { key_changes: [{ type: 'cron', change: 'Add a nightly sweep cron, no schema change' }] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(true);
+  });
+});
+
+describe('classifyMachineryClass — free-text lane', () => {
+  it('classifies a description mentioning a new watcher process', () => {
+    const sd = { description: 'Adds a new watcher process that polls the queue every 30s.', key_changes: [] };
+    const result = classifyMachineryClass(sd);
+    expect(result.machineryClass).toBe(true);
+    expect(result.kind).toBe('watcher');
+  });
+
+  it('classifies a remediation router description', () => {
+    const sd = { description: 'Ship the remediation router that consumes triage events.', key_changes: [] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(true);
+  });
+
+  it('does not false-positive on bare "gate" mentioned in unrelated prose', () => {
+    const sd = { description: 'This SD updates the CLAUDE.md gate documentation table for clarity.', key_changes: [] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(false);
+  });
+
+  it('respects negation (no cron job shipped)', () => {
+    const sd = { description: 'This SD explicitly ships no cron job, only a manual CLI helper.', key_changes: [] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(false);
+  });
+});
+
+describe('classifyMachineryClass — non-machinery SDs (zero false gating)', () => {
+  it('a docs-only SD classifies as none', () => {
+    const sd = { description: 'Update the README with new setup instructions.', key_changes: [{ type: 'documentation', change: 'docs' }] };
+    expect(classifyMachineryClass(sd)).toMatchObject({ machineryClass: false, kind: 'none' });
+  });
+
+  it('a schema-only migration SD classifies as none', () => {
+    const sd = { description: 'Add a new column to the ventures table.', key_changes: [{ type: 'schema', change: 'migration' }] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(false);
+  });
+
+  it('a pure UI/refactor SD classifies as none', () => {
+    const sd = { description: 'Refactor the dashboard React component for readability.', key_changes: [{ type: 'feature', change: 'ui' }] };
+    expect(classifyMachineryClass(sd).machineryClass).toBe(false);
+  });
+
+  it('handles a missing/malformed sd without throwing', () => {
+    expect(classifyMachineryClass(null)).toMatchObject({ machineryClass: false, reason: 'no_sd_provided' });
+    expect(classifyMachineryClass(undefined)).toMatchObject({ machineryClass: false });
+  });
+});


### PR DESCRIPTION
## Summary
G3 is a chairman-ratified protocol amendment. Problem: SDs/QFs repeatedly ship "code merged + tests green" while the actual event-processing machinery (worker/watcher/router/gate/cron/hook) never processes a single real production event — 5+ specimens this week alone (cold-recovery never wired, a quarantined test, dormant verifiers, an eva-scheduler watcher dead 13 days, a frozen capture gauge, a remediation router whose writers were never injected).

This is **PR1 of 2** for the SD, covering FR-1 (tri-state gate), FR-2 (machinery-class classifier), FR-3 (evidence shape), and FR-5 (parent-orchestrator exemption). PR2 covers FR-4 (ARMED registration wiring), FR-6 (30-day retro sweep), and FR-7 (protocol text amendment).

Per VALIDATION and Plan sub-agent findings during this SD's PLAN phase, this is a **reuse-first extension**, not new parallel machinery: it extends the existing `INVOCATION_PATH_PROOF` gate (`invocation-path-gate.js`), reuses `scripts/modules/activation-invariant/trigger-evaluator.js`'s signal-extraction helpers, and reuses the existing `scope_completion_chain` table rather than the narrower `bypass_ledger`.

## Changes
- **`lib/machinery-class/classify.js`** (new): classifies an SD/QF as machinery-class via the same dual-scan pattern (structured `key_changes[].type` + negation-aware free-text) as `trigger-evaluator.js`, but deliberately WITHOUT requiring a schema match — a pure cron/watcher fix with no schema change is still machinery-class on its own (trigger-evaluator.js's own `evaluateTrigger` requires schema+consumer, which would miss G3's own named specimens).
- **`invocation-path-gate.js`**: adds `evaluateActivationEvidence` (pure tri-state UNWIRED/ACTIVATED/ARMED/not_applicable resolver — checks `isOrchestratorSync(sd)` FIRST so an orchestrator parent is exempt regardless of its rollup text), `checkActivationEvidence` (queries `scope_completion_chain` for `evidence_kind='real_event'` + `runtime_observed_at` set, fail-open on error), `checkArmedRegistration` (queries `periodic_process_registry` for a `liveness_source_ref` match, fail-open on error), and `computeActivationEvidenceVerdict`/`mergeActivationVerdict` wiring the new check into all 5 of the existing gate's return points. **Advisory by default** (`ACTIVATION_EVIDENCE_MODE=block` to enforce) — mirrors this same file's existing `INVOCATION_PATH_PROOF_MODE` rollout precedent, so the new requirement cannot mass-fail every in-flight SD on day one.
- **`database/migrations/20260705b_scope_completion_chain_activation_evidence.sql`** (staged, **chairman-gated, NOT applied** — marked `-- requires-chairman-apply`; `scope_completion_chain` carries an `@approved-by` tag): adds nullable `real_event_ref TEXT` + `evidence_kind TEXT` columns + an advisory (non-blocking) vocab trigger. Application code fails open if these columns don't exist yet, so nothing breaks pre-approval. `strategic_directives_v2.metadata.requires_chairman_apply=true` set on this SD.
- 28 new tests (11 classifier, 17 gate-integration).

## Verification
- `tests/unit/invocation-detector/`: 82/82 pass (65 pre-existing + 17 new) — zero regressions on the existing gate's own suite.
- `tests/unit/machinery-class/ + invocation-detector/ + gates/ + handoff/`: 1070 passed, 1 skipped (pre-existing quarantine, unrelated), 100 files.
- Migration-ordinal CI checks pass; chairman-gated marker regex confirmed matching.
- **Independent TESTING sub-agent verdict: PASS, 95% confidence.** Independently re-read all 3 files, re-ran every suite from scratch (matching counts exactly), confirmed the orchestrator-exemption check runs before machinery classification, confirmed all 5 (not 4) of the gate's return points are wrapped by the new check, confirmed fail-open behavior on null/malformed `ctx.sd` and DB errors, confirmed the only production call site (`gates.js:1240`) passes a compatible client, and confirmed a non-machinery-class SD (the fleet majority) gets a byte-identical zero-warning result (the merge helper short-circuits when the activation verdict carries no issues/warnings). One non-blocking rollout note: apply the migration before promoting to `block` mode, or `ACTIVATED` becomes unreachable (still fully shielded by the advisory default).

## Blast radius
This modifies a `required: true` gate that runs at LEAD-FINAL-APPROVAL for every SD in the fleet. The change is additive and advisory-by-default; verified zero behavior change for non-machinery-class SDs (the overwhelming majority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)