### PR TITLE
feat(SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-A): witness taxonomy + gate_witness_registry schema

### DIFF
--- a/database/migrations/20260705_create_gate_witness_registry.sql
+++ b/database/migrations/20260705_create_gate_witness_registry.sql
@@ -1,0 +1,94 @@
+-- SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-A
+-- G1-A: Witness Taxonomy + gate_witness_registry Schema
+--
+-- Solomon's anchor finding (G1, chairman-adopted 2026-07-02): every consequential gate
+-- can currently pass on evidence authored entirely by the judged actor. This table is
+-- the durable inventory of which gates are already witnessed, by which mechanism, and
+-- which are not yet.
+--
+-- ARCHITECTURE NOTE (found during LEAD-phase investigation, before this schema was
+-- locked -- see feedback signal c54d463f, high severity): every worker session AND
+-- every CI workflow authenticate to Supabase with the IDENTICAL SUPABASE_SERVICE_ROLE_KEY
+-- secret (verified against .github/workflows/*.yml). Service-role bypasses RLS entirely
+-- by Postgres/PostgREST design. This means "not writable by worker sessions" is only
+-- STRUCTURALLY true for the EXTERNAL_SYSTEM mechanism, where the signal is read live
+-- from an external authority (GitHub's own API: CI statusCheckRollup, branch protection,
+-- PR review decision) that categorically cannot be forged by any Supabase credential.
+-- CROSS_ACTOR and REPLAY witnesses stored in a Supabase table do NOT meet that bar under
+-- the current shared-key architecture -- a worker holding the service-role key can write
+-- to any such table exactly as easily as the intended independent writer. This is
+-- captured explicitly via enforcement_strength below, rather than silently assumed away.
+--
+-- ADDITIVE ONLY: new table, no existing objects touched.
+CREATE TABLE IF NOT EXISTS gate_witness_registry (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gate_id text NOT NULL,
+  handoff_type text,
+  classification text NOT NULL CHECK (classification IN ('already_witnessed', 'self_evidence_only', 'not_consequential_exempt')),
+  witness_mechanism text CHECK (witness_mechanism IN ('cross_actor', 'external_system', 'replay')),
+  enforcement_strength text CHECK (enforcement_strength IN ('structural', 'convention')),
+  exemption_reason text,
+  existing_mechanism_ref text,
+  notes text,
+  classified_at timestamptz NOT NULL DEFAULT now(),
+  classified_by text NOT NULL DEFAULT 'unknown',
+  CONSTRAINT uq_gate_witness_registry_gate_id UNIQUE (gate_id),
+  CONSTRAINT chk_gate_witness_registry_witnessed_has_mechanism CHECK (
+    (classification = 'already_witnessed' AND witness_mechanism IS NOT NULL) OR classification <> 'already_witnessed'
+  ),
+  CONSTRAINT chk_gate_witness_registry_witnessed_has_strength CHECK (
+    (classification = 'already_witnessed' AND enforcement_strength IS NOT NULL) OR classification <> 'already_witnessed'
+  ),
+  CONSTRAINT chk_gate_witness_registry_exempt_has_reason CHECK (
+    (classification = 'not_consequential_exempt' AND exemption_reason IS NOT NULL AND length(trim(exemption_reason)) > 0) OR classification <> 'not_consequential_exempt'
+  ),
+  CONSTRAINT chk_gate_witness_registry_external_is_structural CHECK (
+    witness_mechanism <> 'external_system' OR enforcement_strength = 'structural'
+  )
+);
+
+COMMENT ON TABLE gate_witness_registry IS
+  'Inventory of every consequential LEO gate, classified as already_witnessed / '
+  'self_evidence_only / not_consequential_exempt, per SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001 '
+  '(Solomon G1, chairman-adopted 2026-07-02). Populated by Child B (inventory), consumed by '
+  'Child C (integrity check) and Child D (enforcement rung).';
+COMMENT ON COLUMN gate_witness_registry.gate_id IS
+  'Stable identifier for the gate, e.g. "LEAD-TO-PLAN.GATE_SD_TRANSITION_READINESS" or '
+  '"ship.P4_PROTECTION_INTEGRITY" for non-handoff gates. Must be unique and stable across runs.';
+COMMENT ON COLUMN gate_witness_registry.handoff_type IS
+  'One of LEAD-TO-PLAN / PLAN-TO-EXEC / EXEC-TO-PLAN / PLAN-TO-LEAD / LEAD-FINAL-APPROVAL for '
+  'handoff-pipeline gates, or NULL for out-of-handoff gates (e.g. the ship/merge lane).';
+COMMENT ON COLUMN gate_witness_registry.witness_mechanism IS
+  'cross_actor: a different session/actor attests (e.g. reviewer ack, coordinator row). '
+  'external_system: a signal from outside the actor''s write reach (CI status, branch '
+  'protection, deploy 200s). replay: deterministic re-execution by harness-owned machinery. '
+  'Required (NOT NULL) when classification=already_witnessed.';
+COMMENT ON COLUMN gate_witness_registry.enforcement_strength IS
+  'structural: the mechanism is categorically unforgeable by any Supabase-credentialed '
+  'process (true today only for witness_mechanism=external_system, re-verified live against '
+  'the external API at check-time -- see chk_gate_witness_registry_external_is_structural). '
+  'convention: the mechanism is a distinguishing data column (e.g. differing session_id) but '
+  'NOT cryptographically enforced, since every worker session and CI workflow share the same '
+  'SUPABASE_SERVICE_ROLE_KEY and RLS provides no real separation for a Supabase-stored signal. '
+  'convention-strength witnesses are an honest interim state pending per-actor-scoped '
+  'credentials or signed attestations (tracked as a follow-on, not silently assumed solved).';
+COMMENT ON COLUMN gate_witness_registry.existing_mechanism_ref IS
+  'File:function reference to the ALREADY-EXISTING implementation this row classifies (e.g. '
+  '"lib/ship/merge-witness-ladder.mjs:evaluateP3CI") -- this registry classifies and composes '
+  'with existing machinery, it does not reimplement it.';
+COMMENT ON COLUMN gate_witness_registry.exemption_reason IS
+  'Required (NOT NULL, non-empty) when classification=not_consequential_exempt. Must state '
+  'why this gate carries no meaningful blast radius from self-authored evidence.';
+
+ALTER TABLE gate_witness_registry ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anon can read gate_witness_registry" ON gate_witness_registry;
+CREATE POLICY "Anon can read gate_witness_registry"
+  ON gate_witness_registry FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Service role full access to gate_witness_registry" ON gate_witness_registry;
+CREATE POLICY "Service role full access to gate_witness_registry"
+  ON gate_witness_registry FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');

--- a/lib/eva/gate-witness-taxonomy.js
+++ b/lib/eva/gate-witness-taxonomy.js
@@ -1,0 +1,43 @@
+/**
+ * Witness taxonomy constants for SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001 (Solomon G1).
+ * Single source of truth for Child B (inventory), Child C (integrity check), and
+ * Child D (enforcement rung) so the taxonomy is never re-derived or drifted.
+ */
+
+export const CLASSIFICATION = Object.freeze({
+  ALREADY_WITNESSED: 'already_witnessed',
+  SELF_EVIDENCE_ONLY: 'self_evidence_only',
+  NOT_CONSEQUENTIAL_EXEMPT: 'not_consequential_exempt',
+});
+
+export const WITNESS_MECHANISM = Object.freeze({
+  CROSS_ACTOR: 'cross_actor',
+  EXTERNAL_SYSTEM: 'external_system',
+  REPLAY: 'replay',
+});
+
+export const ENFORCEMENT_STRENGTH = Object.freeze({
+  STRUCTURAL: 'structural',
+  CONVENTION: 'convention',
+});
+
+/**
+ * external_system is the only mechanism categorically unforgeable by a Supabase-credentialed
+ * process, because every worker session and CI workflow share the same
+ * SUPABASE_SERVICE_ROLE_KEY (verified during LEAD-phase investigation, feedback signal
+ * c54d463f). cross_actor/replay rows stored in Supabase are convention-strength until a
+ * follow-on SD introduces per-actor-scoped credentials or signed attestations.
+ */
+export function expectedEnforcementStrength(mechanism) {
+  return mechanism === WITNESS_MECHANISM.EXTERNAL_SYSTEM
+    ? ENFORCEMENT_STRENGTH.STRUCTURAL
+    : ENFORCEMENT_STRENGTH.CONVENTION;
+}
+
+export function isValidClassification(value) {
+  return Object.values(CLASSIFICATION).includes(value);
+}
+
+export function isValidWitnessMechanism(value) {
+  return Object.values(WITNESS_MECHANISM).includes(value);
+}

--- a/tests/integration/eva/gate-witness-registry.test.js
+++ b/tests/integration/eva/gate-witness-registry.test.js
@@ -1,0 +1,111 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-A: gate_witness_registry live schema tests.
+ * Runs against the applied migration (database/migrations/20260705_create_gate_witness_registry.sql).
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  CLASSIFICATION,
+  WITNESS_MECHANISM,
+  ENFORCEMENT_STRENGTH,
+} from '../../../lib/eva/gate-witness-taxonomy.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const TEST_GATE_IDS = [
+  'test.G1A_VALID_EXTERNAL',
+  'test.G1A_INVALID_EXTERNAL_CONVENTION',
+  'test.G1A_VALID_CROSS_ACTOR',
+  'test.G1A_MISSING_MECHANISM',
+  'test.G1A_EXEMPT_NO_REASON',
+  'test.G1A_EXEMPT_WITH_REASON',
+];
+
+afterAll(async () => {
+  await supabase.from('gate_witness_registry').delete().in('gate_id', TEST_GATE_IDS);
+});
+
+describe('gate_witness_registry table (live)', () => {
+  it('accepts an external_system row with structural strength', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_VALID_EXTERNAL',
+      classification: CLASSIFICATION.ALREADY_WITNESSED,
+      witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+      enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+      existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP3CI',
+      classified_by: 'vitest',
+    });
+    expect(error).toBeNull();
+  });
+
+  it('rejects an external_system row claiming convention strength', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_INVALID_EXTERNAL_CONVENTION',
+      classification: CLASSIFICATION.ALREADY_WITNESSED,
+      witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+      enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+      classified_by: 'vitest',
+    });
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/chk_gate_witness_registry_external_is_structural/);
+  });
+
+  it('accepts a cross_actor row with convention strength', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_VALID_CROSS_ACTOR',
+      classification: CLASSIFICATION.ALREADY_WITNESSED,
+      witness_mechanism: WITNESS_MECHANISM.CROSS_ACTOR,
+      enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+      existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP2Witness',
+      classified_by: 'vitest',
+    });
+    expect(error).toBeNull();
+  });
+
+  it('rejects an already_witnessed row with no witness_mechanism', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_MISSING_MECHANISM',
+      classification: CLASSIFICATION.ALREADY_WITNESSED,
+      classified_by: 'vitest',
+    });
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/chk_gate_witness_registry_witnessed_has_mechanism/);
+  });
+
+  it('rejects a not_consequential_exempt row with no exemption_reason', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_EXEMPT_NO_REASON',
+      classification: CLASSIFICATION.NOT_CONSEQUENTIAL_EXEMPT,
+      classified_by: 'vitest',
+    });
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/chk_gate_witness_registry_exempt_has_reason/);
+  });
+
+  it('accepts a not_consequential_exempt row with a non-empty exemption_reason', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_EXEMPT_WITH_REASON',
+      classification: CLASSIFICATION.NOT_CONSEQUENTIAL_EXEMPT,
+      exemption_reason: 'Advisory-only gate with no blast radius; documented in gate source comment.',
+      classified_by: 'vitest',
+    });
+    expect(error).toBeNull();
+  });
+
+  it('enforces gate_id uniqueness', async () => {
+    const { error } = await supabase.from('gate_witness_registry').insert({
+      gate_id: 'test.G1A_VALID_EXTERNAL',
+      classification: CLASSIFICATION.ALREADY_WITNESSED,
+      witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+      enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+      classified_by: 'vitest',
+    });
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/uq_gate_witness_registry_gate_id/);
+  });
+});

--- a/tests/unit/eva/gate-witness-taxonomy.test.js
+++ b/tests/unit/eva/gate-witness-taxonomy.test.js
@@ -1,0 +1,40 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-A: pure taxonomy helper tests (no DB).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CLASSIFICATION,
+  WITNESS_MECHANISM,
+  ENFORCEMENT_STRENGTH,
+  expectedEnforcementStrength,
+  isValidClassification,
+  isValidWitnessMechanism,
+} from '../../../lib/eva/gate-witness-taxonomy.js';
+
+describe('gate-witness-taxonomy.js', () => {
+  it('freezes the 3 classifications', () => {
+    expect(Object.values(CLASSIFICATION).sort()).toEqual(
+      ['already_witnessed', 'not_consequential_exempt', 'self_evidence_only'].sort()
+    );
+  });
+
+  it('freezes the 3 witness mechanisms', () => {
+    expect(Object.values(WITNESS_MECHANISM).sort()).toEqual(
+      ['cross_actor', 'external_system', 'replay'].sort()
+    );
+  });
+
+  it('expectedEnforcementStrength maps external_system -> structural, others -> convention', () => {
+    expect(expectedEnforcementStrength(WITNESS_MECHANISM.EXTERNAL_SYSTEM)).toBe(ENFORCEMENT_STRENGTH.STRUCTURAL);
+    expect(expectedEnforcementStrength(WITNESS_MECHANISM.CROSS_ACTOR)).toBe(ENFORCEMENT_STRENGTH.CONVENTION);
+    expect(expectedEnforcementStrength(WITNESS_MECHANISM.REPLAY)).toBe(ENFORCEMENT_STRENGTH.CONVENTION);
+  });
+
+  it('isValidClassification / isValidWitnessMechanism reject unknown values', () => {
+    expect(isValidClassification('bogus')).toBe(false);
+    expect(isValidClassification(CLASSIFICATION.SELF_EVIDENCE_ONLY)).toBe(true);
+    expect(isValidWitnessMechanism('bogus')).toBe(false);
+    expect(isValidWitnessMechanism(WITNESS_MECHANISM.REPLAY)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Child A of the G1 orchestrator (Solomon's anchor finding, chairman-adopted 2026-07-02): every consequential LEO gate can currently pass on evidence authored entirely by the judged actor. This child creates the foundational data model.

- New `gate_witness_registry` table: 3-mechanism taxonomy (CROSS_ACTOR, EXTERNAL_SYSTEM, REPLAY), classification (already_witnessed/self_evidence_only/not_consequential_exempt), and an `enforcement_strength` column (structural/convention).
- New `lib/eva/gate-witness-taxonomy.js`: single source-of-truth constants module for Children B/C/D.

**Key finding surfaced before locking the schema** (worker-signal c54d463f, high severity): every worker session AND every CI workflow authenticate to Supabase with the identical `SUPABASE_SERVICE_ROLE_KEY` (verified against `.github/workflows/*.yml`). Postgres RLS is bypassed entirely for service-role connections. This means "not writable by worker sessions" is only structurally true for `EXTERNAL_SYSTEM` witnesses (a live GitHub API read, categorically unforgeable by any Supabase credential) — not for `CROSS_ACTOR`/`REPLAY` witnesses stored in a Supabase table, since a worker with the shared key can write to any such table just as easily. This is encoded directly in the schema via `enforcement_strength` and a CHECK constraint (`chk_gate_witness_registry_external_is_structural`), not silently assumed away.

## Test plan
- [x] Migration applied live (not staged) and verified with real valid/invalid inserts
- [x] `tests/unit/eva/gate-witness-taxonomy.test.js` (4 tests, pure constants)
- [x] `tests/integration/eva/gate-witness-registry.test.js` (7 tests, live CHECK-constraint verification)
- [x] `npm run schema:lint` clean
- [x] LEAD-TO-PLAN (96%), PLAN-TO-EXEC (98%), EXEC-TO-PLAN (94%), PLAN-TO-LEAD (95%) all accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)