### PR TITLE
fix(QF-20260705-057): claim_sd RPC fallback when p_client_gate_version isn't live

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -617,12 +617,25 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
 
   const track = sdData?.track || 'STANDALONE';
 
-  const { data: claimResult, error: claimError } = await supabase.rpc('claim_sd', {
+  let { data: claimResult, error: claimError } = await supabase.rpc('claim_sd', {
     p_sd_id: sdKey,
     p_session_id: sessionId,
     p_track: track,
     p_client_gate_version: CLAIM_GUARD_CODE_VERSION
   });
+
+  // QF-20260705-057: p_client_gate_version is added by SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001's
+  // migration, which is intentionally chairman-apply-gated and may not be live. PGRST202
+  // ("function not found") on that specific param combination means the live claim_sd()
+  // doesn't have this parameter yet — fall back to the pre-migration 3-arg signature rather
+  // than hard-failing every worker's claim path until the migration is applied.
+  if (claimError?.code === 'PGRST202' && /p_client_gate_version/.test(claimError.message || '')) {
+    ({ data: claimResult, error: claimError } = await supabase.rpc('claim_sd', {
+      p_sd_id: sdKey,
+      p_session_id: sessionId,
+      p_track: track
+    }));
+  }
 
   if (claimError) {
     throw new Error(`claimGuard: claim_sd RPC failed: ${claimError.message}`);

--- a/tests/unit/claim-guard-gate-version-fallback.test.js
+++ b/tests/unit/claim-guard-gate-version-fallback.test.js
@@ -1,0 +1,55 @@
+/**
+ * QF-20260705-057: the claim_sd RPC call in claimGuard's Case-3 (new-claim acquisition)
+ * unconditionally sent p_client_gate_version (added by SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001's
+ * intentionally chairman-apply-gated migration) with no fallback, so any environment where that
+ * migration is not yet live gets a hard PGRST202 failure on every new-SD claim. Verified live:
+ * a direct RPC call with p_client_gate_version returns PGRST202 with hint
+ * "perhaps you meant ... p_force_takeover", confirming the live claim_sd() lacks this param.
+ *
+ * Static-pin pattern (matching tests/unit/claim-guard-gate-version-stamp.test.js): the whole
+ * fleet exercises claimGuard's RPC call live on every claim, so a source-text pin catches a
+ * regression in the fallback wiring without needing to mock the Supabase client.
+ */
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = path.resolve(__dirname, '../../lib/claim-guard.mjs');
+const src = readFileSync(SRC_PATH, 'utf8');
+
+describe('claim-guard: claim_sd PGRST202 fallback (QF-20260705-057)', () => {
+  function claimGuardBody() {
+    const guardStart = src.indexOf('export async function claimGuard');
+    expect(guardStart).toBeGreaterThan(0);
+    const rpcIdx = src.indexOf("rpc('claim_sd'", guardStart);
+    expect(rpcIdx).toBeGreaterThan(guardStart);
+    const throwIdx = src.indexOf('claimGuard: claim_sd RPC failed', rpcIdx);
+    expect(throwIdx).toBeGreaterThan(rpcIdx);
+    return src.slice(rpcIdx, throwIdx);
+  }
+
+  test('checks for PGRST202 on p_client_gate_version before treating claimError as fatal', () => {
+    const body = claimGuardBody();
+    expect(body).toMatch(/claimError\?\.code\s*===\s*['"]PGRST202['"]/);
+    expect(body).toMatch(/p_client_gate_version/);
+  });
+
+  test('retries claim_sd without p_client_gate_version on that specific error', () => {
+    const body = claimGuardBody();
+    // Second rpc('claim_sd', ...) call in the fallback branch must omit p_client_gate_version.
+    const fallbackIdx = body.indexOf("rpc('claim_sd'", body.indexOf('PGRST202'));
+    expect(fallbackIdx).toBeGreaterThan(0);
+    const fallbackCall = body.slice(fallbackIdx, body.indexOf('}))', fallbackIdx));
+    expect(fallbackCall).not.toMatch(/p_client_gate_version/);
+    expect(fallbackCall).toMatch(/p_sd_id:\s*sdKey/);
+    expect(fallbackCall).toMatch(/p_session_id:\s*sessionId/);
+    expect(fallbackCall).toMatch(/p_track:\s*track/);
+  });
+
+  test('a non-PGRST202 claimError still throws (fallback is narrowly scoped)', () => {
+    const body = claimGuardBody();
+    expect(body).toMatch(/if\s*\(claimError\)\s*\{/);
+  });
+});


### PR DESCRIPTION
## Summary
**Critical fleet-wide bug**: `lib/claim-guard.mjs`'s Case-3 (new-claim acquisition) unconditionally sent `p_client_gate_version` to the `claim_sd` RPC and threw hard on any error. That parameter is added by `SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001`'s migration, which is intentionally chairman-apply-gated and is **not live** — every worker's new-SD-claim path via `sd-start.js` was broken whenever Case 3 (a genuinely new claim, not already-owned) was hit.

Reproduced directly against production: a live `claim_sd` RPC call with `p_client_gate_version` returns `PGRST202` with a hint naming the real live signature (`p_force_takeover` instead).

## Fix
Catch `PGRST202` specifically for this parameter and retry with the pre-migration 3-arg signature (`p_sd_id`, `p_session_id`, `p_track`), restoring the claim path regardless of whether/when the migration eventually applies. Scoped narrowly — any other `claimError` still throws as before.

## Test plan
- [x] New unit test `tests/unit/claim-guard-gate-version-fallback.test.js` (3 tests, static-source-pin per this file's established convention)
- [x] Existing `claim-guard-gate-version-stamp.test.js` + `claim-guard-reaffirm-sd-row.test.js` still pass (10 tests)
- [x] Verified live against the real production RPC: first call fails with `PGRST202`, fallback call succeeds and returns a real claim result
- [x] `npm run schema:lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)