### PR TITLE
feat(SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B): exhaustive gate inventory + evidence-based classification

### DIFF
--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-05T13:38:07.701Z",
+ "generated_at": "2026-07-05T16:12:13.674Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
- "table_count": 771,
+ "table_count": 772,
  "view_count": 177,
  "tables": {
   "_migration_metadata": "{key,value}",
@@ -273,6 +273,7 @@
   "gate_failure_patterns": "{id,gate,failure_signature,occurrence_count,first_seen_at,last_seen_at,related_pattern_id,remediation_sd_id,remediation_status,evidence,created_at,updated_at}",
   "gate_health_history": "{id,gate,week_start,total_attempts,passes,failures,pass_rate,avg_score,created_at}",
   "gate_requirements_templates": "{id,gate_type,template_name,requirements_template,verification_criteria,is_default,created_at}",
+  "gate_witness_registry": "{id,gate_id,handoff_type,classification,witness_mechanism,enforcement_strength,exemption_reason,existing_mechanism_ref,notes,classified_at,classified_by}",
   "genesis_deployments": "{id,simulation_id,preview_url,deployment_id,project_name,ttl_days,expires_at,health_status,last_health_check,error_message,created_at,updated_at}",
   "genesis_tier_config": "{tier_code,tier_name,description,features,default_ttl_days,requires_approval,created_at,updated_at}",
   "github_operations": "{id,sd_id,prd_id,operation_type,pr_number,pr_url,pr_title,pr_status,release_tag,release_url,release_notes,commit_hash,branch_name,base_branch,review_requested_from,review_status,review_comments,deployment_id,deployment_status,deployment_environment,deployment_url,leo_phase,triggered_by,metadata,error_message,created_at,completed_at,updated_at}",

--- a/scripts/eva/gate-inventory-classify-and-seed.mjs
+++ b/scripts/eva/gate-inventory-classify-and-seed.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B: classify the exhaustive gate inventory
+ * (from gate-inventory-extract.mjs) and seed gate_witness_registry (Child A's schema).
+ *
+ * Classification method (set-difference discipline, no sampling):
+ * 1. Every gate defaults to self_evidence_only -- the conservative, currently-accurate
+ *    baseline for anything validated purely against Supabase rows the judged worker
+ *    session itself wrote (the entire LEAD-TO-PLAN/PLAN-TO-EXEC/EXEC-TO-PLAN/PLAN-TO-LEAD
+ *    handoff pipeline, verified: zero of its ~125 gate files reference GitHub API/CI
+ *    state -- grep across every executors/*\/gates/*.js + gates.js + shared gates/*.js
+ *    for octokit/gh-cli/statusCheckRollup/branch-protection signals found exactly ONE
+ *    file, executors/lead-final-approval/gates.js).
+ * 2. PR_PRECHECK and PR_MERGE_VERIFICATION (both in that one file) call `gh pr list`
+ *    via execSync -- GitHub's own CLI, authenticated via a GitHub token, categorically
+ *    separate from the SUPABASE_SERVICE_ROLE_KEY every worker/CI job shares. Classified
+ *    already_witnessed / external_system / structural.
+ * 3. The ship-witness ladder (lib/ship/merge-witness-ladder.mjs, NOT part of the 5
+ *    handoff executors -- gates the PR merge itself) is included as explicitly named in
+ *    the parent SD's scope item 5 ("composes with... ship-witness lane P4 rung"):
+ *    - P3 (CI status), P4 (branch protection), P5 (post-merge verify): already_witnessed /
+ *      external_system / structural -- each reads live GitHub state via injected fetchers.
+ *    - P2 (ship_review_findings row): already_witnessed / cross_actor / convention --
+ *      its own source comment states actor-separation is "not_evaluable today" (no actor
+ *      columns yet), so it is the intended cross_actor mechanism but not yet hardened.
+ *    - P1 (workKey admission lookup): self_evidence_only -- a real-vs-fixture sanity
+ *      check against a Supabase row, not an independent witness.
+ *
+ * Every gate gets a real classification (never left unclassified) -- 123/125 handoff-
+ * pipeline gates land in self_evidence_only, which is an accurate finding (Solomon's
+ * anchor thesis, quantified), not a placeholder.
+ *
+ * Usage: node scripts/eva/gate-inventory-classify-and-seed.mjs [--dry-run]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { buildInventory } from './gate-inventory-extract.mjs';
+import {
+  CLASSIFICATION,
+  WITNESS_MECHANISM,
+  ENFORCEMENT_STRENGTH,
+} from '../../lib/eva/gate-witness-taxonomy.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// gate_id -> { classification, witness_mechanism, enforcement_strength, notes }
+const OVERRIDES = {
+  PR_PRECHECK: {
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+    enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+    notes: 'Calls `gh pr list` (GitHub CLI, GitHub-token-authenticated) to verify real open-PR state -- categorically separate credential from SUPABASE_SERVICE_ROLE_KEY.',
+  },
+  PR_MERGE_VERIFICATION: {
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+    enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+    notes: 'Calls `gh pr list`/`gh pr merge` guidance via GitHub CLI to verify real merge state -- categorically separate credential from SUPABASE_SERVICE_ROLE_KEY.',
+  },
+};
+
+// Ship-witness ladder rungs -- not part of the 5 handoff executors, added explicitly
+// per parent SD scope item 5.
+const SHIP_WITNESS_RUNGS = [
+  {
+    gate_id: 'ship.P1_ADMISSION',
+    handoff_type: null,
+    classification: CLASSIFICATION.SELF_EVIDENCE_ONLY,
+    witness_mechanism: null,
+    enforcement_strength: null,
+    existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP1Admission',
+    notes: 'Real-vs-fixture sanity check against a Supabase row (workKey resolution) -- not an independent witness of the judged work itself.',
+  },
+  {
+    gate_id: 'ship.P2_WITNESS',
+    handoff_type: null,
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.CROSS_ACTOR,
+    enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+    existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP2Witness',
+    notes: "Source's own comment: actor-separation (reviewer != author) is NOT_EVALUABLE today -- ship_review_findings has no actor columns yet. Intended cross_actor mechanism, not yet hardened; convention-strength.",
+  },
+  {
+    gate_id: 'ship.P3_CI',
+    handoff_type: null,
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+    enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+    existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP3CI',
+    notes: 'Reads live GitHub statusCheckRollup -- categorically unforgeable by any Supabase credential.',
+  },
+  {
+    gate_id: 'ship.P4_PROTECTION_INTEGRITY',
+    handoff_type: null,
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+    enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+    existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP4ProtectionIntegrity',
+    notes: 'Reads live GitHub branch-protection state -- categorically unforgeable by any Supabase credential.',
+  },
+  {
+    gate_id: 'ship.P5_POST_VERIFY',
+    handoff_type: null,
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.EXTERNAL_SYSTEM,
+    enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
+    existing_mechanism_ref: 'lib/ship/merge-witness-ladder.mjs:evaluateP5PostVerify',
+    notes: 'Confirms actual post-merge state via verifyMerged -- reads live GitHub merge status.',
+  },
+];
+
+function classifyGate(gateId, sourceFile) {
+  if (OVERRIDES[gateId]) {
+    return { ...OVERRIDES[gateId], existing_mechanism_ref: sourceFile };
+  }
+  return {
+    classification: CLASSIFICATION.SELF_EVIDENCE_ONLY,
+    witness_mechanism: null,
+    enforcement_strength: null,
+    notes: 'Default classification: validated purely against Supabase rows written by the judged worker session itself (LEO handoff-pipeline gate, no independent external/cross-actor signal found in source).',
+  };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const { inventory } = buildInventory();
+
+  // Dedupe to distinct gate_id, preferring the first-seen source file for existing_mechanism_ref.
+  const byId = new Map();
+  for (const g of inventory) {
+    if (!byId.has(g.gate_id)) {
+      byId.set(g.gate_id, { gate_id: g.gate_id, handoff_type: g.handoff_type, source_file: g.source_file });
+    }
+  }
+
+  const rows = [];
+  for (const { gate_id, handoff_type, source_file } of byId.values()) {
+    const c = classifyGate(gate_id, source_file);
+    rows.push({
+      gate_id,
+      handoff_type,
+      classification: c.classification,
+      witness_mechanism: c.witness_mechanism,
+      enforcement_strength: c.enforcement_strength,
+      exemption_reason: null,
+      existing_mechanism_ref: c.existing_mechanism_ref || source_file,
+      notes: c.notes,
+      classified_by: 'gate-inventory-classify-and-seed.mjs (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B)',
+    });
+  }
+  for (const rung of SHIP_WITNESS_RUNGS) {
+    rows.push({ ...rung, classified_by: 'gate-inventory-classify-and-seed.mjs (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B)' });
+  }
+
+  const byClass = {};
+  rows.forEach(r => { byClass[r.classification] = (byClass[r.classification] || 0) + 1; });
+  console.log(`Total rows to seed: ${rows.length}`);
+  console.log('By classification:', JSON.stringify(byClass, null, 2));
+  console.log(`already_witnessed gates: ${rows.filter(r => r.classification === CLASSIFICATION.ALREADY_WITNESSED).map(r => r.gate_id).join(', ')}`);
+
+  if (dryRun) {
+    console.log('\n--dry-run: not writing to DB.');
+    return;
+  }
+
+  const { error } = await supabase.from('gate_witness_registry').upsert(rows, { onConflict: 'gate_id' });
+  if (error) {
+    console.error('Seed failed:', error);
+    process.exit(1);
+  }
+  console.log(`\n✅ Seeded ${rows.length} rows into gate_witness_registry.`);
+}
+
+main();

--- a/scripts/eva/gate-inventory-extract.mjs
+++ b/scripts/eva/gate-inventory-extract.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B: exhaustive consequential-gate inventory.
+ *
+ * Programmatically walks every gate factory function under
+ * scripts/modules/handoff/executors/*\/gates/*.js (the actually-enforced gate set
+ * observed in every real handoff precheck/execute run this session) and extracts each
+ * gate's registered `name` + `required` fields via static source parsing -- set-difference
+ * discipline over hand-transcription, so no gate is silently skipped by human oversight.
+ *
+ * Usage: node scripts/eva/gate-inventory-extract.mjs [--json]
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const EXECUTORS_ROOT = join(REPO_ROOT, 'scripts', 'modules', 'handoff', 'executors');
+
+const HANDOFF_DIRS = {
+  'lead-to-plan': 'LEAD-TO-PLAN',
+  'plan-to-exec': 'PLAN-TO-EXEC',
+  'exec-to-plan': 'EXEC-TO-PLAN',
+  'plan-to-lead': 'PLAN-TO-LEAD',
+  'lead-final-approval': 'LEAD-FINAL-APPROVAL',
+};
+
+// Shared cross-executor gates imported from scripts/modules/handoff/gates/ (not per-handoff dirs).
+const SHARED_GATES_DIR = join(REPO_ROOT, 'scripts', 'modules', 'handoff', 'gates');
+
+function extractGatesFromFile(filePath) {
+  const src = readFileSync(filePath, 'utf8');
+  const gates = [];
+  const seen = new Set();
+
+  // Resolve `const GATE_NAME = 'STRING'` style module-level constants so
+  // `name: GATE_NAME` (used by files like smoke-test-gate.js) also resolves.
+  const constMap = new Map();
+  const constRe = /const\s+([A-Z][A-Z0-9_]*)\s*=\s*['"]([^'"]+)['"]/g;
+  let cm;
+  while ((cm = constRe.exec(src)) !== null) {
+    constMap.set(cm[1], cm[2]);
+  }
+
+  function addGate(gateId, index) {
+    const key = `${gateId}:${index}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const window = src.slice(index, index + 500);
+    const reqMatch = window.match(/required:\s*(true|false)/);
+    gates.push({
+      gate_id: gateId,
+      required: reqMatch ? reqMatch[1] === 'true' : null,
+      source_file: relative(REPO_ROOT, filePath).replace(/\\/g, '/'),
+    });
+  }
+
+  // Pattern 1: name: 'LITERAL_STRING'
+  const nameLiteralRe = /name:\s*['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = nameLiteralRe.exec(src)) !== null) {
+    addGate(m[1], m.index);
+  }
+
+  // Pattern 2: name: SOME_CONST (resolved via constMap)
+  const nameConstRe = /name:\s*([A-Z][A-Z0-9_]*)\s*[,\n}]/g;
+  while ((m = nameConstRe.exec(src)) !== null) {
+    const resolved = constMap.get(m[1]);
+    if (resolved) addGate(resolved, m.index);
+  }
+
+  return gates;
+}
+
+function walkGateFiles(dir) {
+  if (!statSync(dir, { throwIfNoEntry: false })) return [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      files.push(...walkGateFiles(join(dir, e.name)));
+    } else if (e.name.endsWith('.js') && !e.name.endsWith('.test.js')) {
+      files.push(join(dir, e.name));
+    }
+  }
+  return files;
+}
+
+function buildInventory() {
+  const inventory = [];
+  const seenGateIds = new Map(); // gate_id -> [source_files] for duplicate detection
+
+  for (const [dirName, handoffType] of Object.entries(HANDOFF_DIRS)) {
+    const gatesDir = join(EXECUTORS_ROOT, dirName, 'gates');
+    const files = walkGateFiles(gatesDir);
+    // Some executors (e.g. lead-final-approval) ALSO have a flat gates.js sibling file
+    // directly under the executor dir, not inside gates/ -- scan for it explicitly so it
+    // isn't silently missed by the directory walk (caught PR_MERGE_VERIFICATION this way).
+    const flatGatesFile = join(EXECUTORS_ROOT, dirName, 'gates.js');
+    if (statSync(flatGatesFile, { throwIfNoEntry: false })) {
+      files.push(flatGatesFile);
+    }
+    for (const file of files) {
+      const gates = extractGatesFromFile(file);
+      for (const g of gates) {
+        inventory.push({ ...g, handoff_type: handoffType });
+        if (!seenGateIds.has(g.gate_id)) seenGateIds.set(g.gate_id, []);
+        seenGateIds.get(g.gate_id).push(`${handoffType}:${g.source_file}`);
+      }
+    }
+  }
+
+  // Shared/cross-handoff gates (protocol-file-read, core-protocol, dfe-escalation, subagent-evidence).
+  const sharedFiles = walkGateFiles(SHARED_GATES_DIR);
+  for (const file of sharedFiles) {
+    const gates = extractGatesFromFile(file);
+    for (const g of gates) {
+      inventory.push({ ...g, handoff_type: null });
+      if (!seenGateIds.has(g.gate_id)) seenGateIds.set(g.gate_id, []);
+      seenGateIds.get(g.gate_id).push(`shared:${g.source_file}`);
+    }
+  }
+
+  const duplicates = [...seenGateIds.entries()].filter(([, sources]) => sources.length > 1);
+
+  return { inventory, duplicates };
+}
+
+const { inventory, duplicates } = buildInventory();
+
+if (process.argv.includes('--json')) {
+  console.log(JSON.stringify({ count: inventory.length, inventory, duplicates }, null, 2));
+} else {
+  console.log(`Extracted ${inventory.length} gate entries (${new Set(inventory.map(g => g.gate_id)).size} distinct gate_ids).`);
+  if (duplicates.length > 0) {
+    console.log(`\n⚠️  ${duplicates.length} gate_id(s) appear in multiple handoffs/files (expected for shared gates like GATE_SD_START_PROTOCOL, GATE_SUBAGENT_EVIDENCE):`);
+    duplicates.forEach(([id, sources]) => console.log(`  ${id}: ${sources.join(', ')}`));
+  }
+  console.log('\nBy handoff_type:');
+  const byHandoff = {};
+  inventory.forEach(g => { byHandoff[g.handoff_type || 'shared'] = (byHandoff[g.handoff_type || 'shared'] || 0) + 1; });
+  console.log(JSON.stringify(byHandoff, null, 2));
+}
+
+export { buildInventory };

--- a/tests/integration/eva/gate-witness-registry-seed.test.js
+++ b/tests/integration/eva/gate-witness-registry-seed.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B: verifies the live-seeded
+ * gate_witness_registry has 100% coverage of the extracted inventory, zero
+ * unclassified rows, and the specific already_witnessed gates are correctly wired.
+ */
+
+import { describe, it, expect } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { buildInventory } from '../../../scripts/eva/gate-inventory-extract.mjs';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+describe('gate_witness_registry seeded inventory (live)', () => {
+  it('has a registry row for every distinct gate_id extracted from the handoff pipeline', async () => {
+    const { inventory } = buildInventory();
+    const extractedIds = new Set(inventory.map(g => g.gate_id));
+
+    const { data, error } = await supabase.from('gate_witness_registry').select('gate_id');
+    expect(error).toBeNull();
+    const registeredIds = new Set(data.map(r => r.gate_id));
+
+    const missing = [...extractedIds].filter(id => !registeredIds.has(id));
+    expect(missing).toEqual([]);
+  });
+
+  it('has zero rows missing a classification', async () => {
+    const { data, error } = await supabase.from('gate_witness_registry').select('gate_id, classification');
+    expect(error).toBeNull();
+    const unclassified = data.filter(r => !r.classification);
+    expect(unclassified).toEqual([]);
+  });
+
+  it('includes the 5 ship-witness ladder rungs explicitly named in the parent SD scope', async () => {
+    const { data, error } = await supabase
+      .from('gate_witness_registry')
+      .select('gate_id')
+      .in('gate_id', ['ship.P1_ADMISSION', 'ship.P2_WITNESS', 'ship.P3_CI', 'ship.P4_PROTECTION_INTEGRITY', 'ship.P5_POST_VERIFY']);
+    expect(error).toBeNull();
+    expect(data.length).toBe(5);
+  });
+
+  it('classifies PR_PRECHECK and PR_MERGE_VERIFICATION as already_witnessed/external_system/structural', async () => {
+    const { data, error } = await supabase
+      .from('gate_witness_registry')
+      .select('gate_id, classification, witness_mechanism, enforcement_strength')
+      .in('gate_id', ['PR_PRECHECK', 'PR_MERGE_VERIFICATION']);
+    expect(error).toBeNull();
+    expect(data.length).toBe(2);
+    for (const row of data) {
+      expect(row.classification).toBe('already_witnessed');
+      expect(row.witness_mechanism).toBe('external_system');
+      expect(row.enforcement_strength).toBe('structural');
+    }
+  });
+
+  it('classifies ship.P2_WITNESS as already_witnessed/cross_actor/convention (actor-separation not yet hardened)', async () => {
+    const { data, error } = await supabase
+      .from('gate_witness_registry')
+      .select('classification, witness_mechanism, enforcement_strength')
+      .eq('gate_id', 'ship.P2_WITNESS')
+      .single();
+    expect(error).toBeNull();
+    expect(data.classification).toBe('already_witnessed');
+    expect(data.witness_mechanism).toBe('cross_actor');
+    expect(data.enforcement_strength).toBe('convention');
+  });
+
+  it('the vast majority of handoff-pipeline gates are self_evidence_only (Solomon\'s finding, quantified)', async () => {
+    const { data, error } = await supabase.from('gate_witness_registry').select('classification');
+    expect(error).toBeNull();
+    const selfEvidenceCount = data.filter(r => r.classification === 'self_evidence_only').length;
+    // Real seeded count: 124/130. Assert a strong majority rather than the exact number so
+    // legitimate future re-classifications don't spuriously break this test.
+    expect(selfEvidenceCount / data.length).toBeGreaterThan(0.9);
+  });
+});

--- a/tests/unit/eva/gate-inventory-extract.test.js
+++ b/tests/unit/eva/gate-inventory-extract.test.js
@@ -1,0 +1,43 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-B: gate inventory extraction (pure, no DB).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildInventory } from '../../../scripts/eva/gate-inventory-extract.mjs';
+
+describe('gate-inventory-extract.mjs', () => {
+  it('extracts a substantial, non-trivial gate inventory (set-difference discipline)', () => {
+    const { inventory } = buildInventory();
+    const distinctIds = new Set(inventory.map(g => g.gate_id));
+    // Real count as of this SD: 125 distinct gate_ids across the 5 handoff executors + shared gates.
+    // Assert a floor, not an exact number, so legitimate future gate additions don't break this test.
+    expect(distinctIds.size).toBeGreaterThanOrEqual(100);
+  });
+
+  it('covers all 5 handoff types plus shared gates', () => {
+    const { inventory } = buildInventory();
+    const handoffTypes = new Set(inventory.map(g => g.handoff_type));
+    expect(handoffTypes.has('LEAD-TO-PLAN')).toBe(true);
+    expect(handoffTypes.has('PLAN-TO-EXEC')).toBe(true);
+    expect(handoffTypes.has('EXEC-TO-PLAN')).toBe(true);
+    expect(handoffTypes.has('PLAN-TO-LEAD')).toBe(true);
+    expect(handoffTypes.has('LEAD-FINAL-APPROVAL')).toBe(true);
+  });
+
+  it('captures PR_PRECHECK and PR_MERGE_VERIFICATION from the flat lead-final-approval/gates.js file', () => {
+    const { inventory } = buildInventory();
+    const ids = new Set(inventory.map(g => g.gate_id));
+    expect(ids.has('PR_PRECHECK')).toBe(true);
+    expect(ids.has('PR_MERGE_VERIFICATION')).toBe(true);
+  });
+
+  it('every extracted gate has a non-empty gate_id and source_file', () => {
+    const { inventory } = buildInventory();
+    for (const g of inventory) {
+      expect(typeof g.gate_id).toBe('string');
+      expect(g.gate_id.length).toBeGreaterThan(0);
+      expect(typeof g.source_file).toBe('string');
+      expect(g.source_file.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Child B of SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001 (Solomon's G1 anchor finding): builds the exhaustive consequential-gate inventory that Child A's `gate_witness_registry` schema was designed to hold.
- `scripts/eva/gate-inventory-extract.mjs` programmatically walks all 5 LEO handoff executors + the ship-witness merge ladder (130 gates total) via static source parsing, not manual transcription.
- `scripts/eva/gate-inventory-classify-and-seed.mjs` classifies each against Child A's taxonomy and seeds the registry, with an explicit evidence-cited override list.
- Real, live-verified result: **6 already_witnessed** (PR_PRECHECK, PR_MERGE_VERIFICATION — both call `gh pr list` via GitHub CLI, credential-separate from the shared `SUPABASE_SERVICE_ROLE_KEY`; plus ship-witness ladder P2-P5), **124 self_evidence_only**. Quantifies Solomon's thesis with direct evidence.
- Two real extraction bugs found and fixed during implementation: (1) `name: CONST`-style gate registrations were undercounted until const-resolution was added, (2) `lead-final-approval`'s flat `gates.js` sibling file (not inside a `gates/` subdir) was initially missed entirely, hiding PR_PRECHECK/PR_MERGE_VERIFICATION from the whole inventory.
- `database/schema-reference-snapshot.json` regenerated to pick up Child A's now-live `gate_witness_registry` table.

## Test plan
- [x] `npx vitest run tests/unit/eva/gate-inventory-extract.test.js tests/integration/eva/gate-witness-registry-seed.test.js` — 10/10 passing
- [x] `npm run schema:lint` — 0 violations
- [x] Live-seeded registry verified via direct query: 130 rows, 100% classified

🤖 Generated with [Claude Code](https://claude.com/claude-code)