### PR TITLE
feat(SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C): witness integrity check -- RLS + self-judge structural proofs

### DIFF
--- a/database/migrations/20260705_create_gate_witness_events.sql
+++ b/database/migrations/20260705_create_gate_witness_events.sql
@@ -1,0 +1,61 @@
+-- SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C
+-- G1-C: Witness Integrity Check -- RLS/Permission Proof, Not Convention
+--
+-- Child A's gate_witness_registry classifies which gates ALREADY have a witness
+-- mechanism. This table gives the fleet a real MECHANISM to record a witness event
+-- for those gates (and any future gate promoted to already_witnessed), with two
+-- structural proofs rather than an unenforced convention:
+--
+-- 1. RLS proof: only the service-role connection can write. The anon role has a
+--    SELECT-only policy -- no INSERT/UPDATE policy exists for it, so RLS
+--    default-denies any anon-key write attempt. Verified live by
+--    tests/integration/eva/gate-witness-events-rls.test.js.
+--
+-- 2. Self-judge rejection proof: a CHECK constraint rejects any row where
+--    witness_session_id = judged_session_id. Under the shared-service-role-key
+--    architecture (documented in Child A's migration), this is the one thing a DB
+--    constraint CAN structurally enforce today -- it cannot verify that two
+--    DIFFERENT session-id strings represent genuinely independent actors (that
+--    would need per-actor-scoped credentials or signed attestations, tracked as a
+--    known limitation, not silently assumed solved), but it DOES structurally
+--    prevent the literal self-attestation case that TEST-MASKING/ghost-completion
+--    incidents actually exploited. Verified live by
+--    tests/integration/eva/gate-witness-events-self-judge.test.js.
+--
+-- ADDITIVE ONLY: new table, no existing objects touched.
+CREATE TABLE IF NOT EXISTS gate_witness_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gate_id text NOT NULL,
+  witness_session_id text NOT NULL,
+  judged_session_id text NOT NULL,
+  verdict text NOT NULL CHECK (verdict IN ('witnessed', 'rejected')),
+  notes text,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_witness_not_self_judged CHECK (witness_session_id <> judged_session_id)
+);
+
+COMMENT ON TABLE gate_witness_events IS
+  'Log of recorded witness events for gates classified already_witnessed in '
+  'gate_witness_registry (Child A/B), per SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C. '
+  'Structural proof, not convention: RLS denies non-service-role writes (see the anon '
+  'SELECT-only policy below), and chk_witness_not_self_judged rejects the literal '
+  'self-attestation case at the DB layer.';
+COMMENT ON COLUMN gate_witness_events.witness_session_id IS
+  'The session/actor recording the witness verdict. Must differ from judged_session_id '
+  '(enforced by chk_witness_not_self_judged) -- this is a necessary, not sufficient, '
+  'condition for independence given the shared SUPABASE_SERVICE_ROLE_KEY architecture.';
+COMMENT ON COLUMN gate_witness_events.judged_session_id IS
+  'The session/actor whose work is being judged by this witness event.';
+
+ALTER TABLE gate_witness_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anon can read gate_witness_events" ON gate_witness_events;
+CREATE POLICY "Anon can read gate_witness_events"
+  ON gate_witness_events FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Service role full access to gate_witness_events" ON gate_witness_events;
+CREATE POLICY "Service role full access to gate_witness_events"
+  ON gate_witness_events FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-05T16:12:13.674Z",
+ "generated_at": "2026-07-05T16:49:40.289Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
- "table_count": 772,
+ "table_count": 773,
  "view_count": 177,
  "tables": {
   "_migration_metadata": "{key,value}",
@@ -273,6 +273,7 @@
   "gate_failure_patterns": "{id,gate,failure_signature,occurrence_count,first_seen_at,last_seen_at,related_pattern_id,remediation_sd_id,remediation_status,evidence,created_at,updated_at}",
   "gate_health_history": "{id,gate,week_start,total_attempts,passes,failures,pass_rate,avg_score,created_at}",
   "gate_requirements_templates": "{id,gate_type,template_name,requirements_template,verification_criteria,is_default,created_at}",
+  "gate_witness_events": "{id,gate_id,witness_session_id,judged_session_id,verdict,notes,recorded_at}",
   "gate_witness_registry": "{id,gate_id,handoff_type,classification,witness_mechanism,enforcement_strength,exemption_reason,existing_mechanism_ref,notes,classified_at,classified_by}",
   "genesis_deployments": "{id,simulation_id,preview_url,deployment_id,project_name,ttl_days,expires_at,health_status,last_health_check,error_message,created_at,updated_at}",
   "genesis_tier_config": "{tier_code,tier_name,description,features,default_ttl_days,requires_approval,created_at,updated_at}",

--- a/lib/eva/record-witness-event.js
+++ b/lib/eva/record-witness-event.js
@@ -1,0 +1,32 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C: records a gate_witness_events row via
+ * the service-role client, rejecting self-judged events at the application layer
+ * before the DB CHECK constraint (chk_witness_not_self_judged) is even reached.
+ */
+export async function recordWitnessEvent(supabase, { gateId, witnessSessionId, judgedSessionId, verdict, notes }) {
+  if (witnessSessionId === judgedSessionId) {
+    throw new Error(
+      `recordWitnessEvent: witness_session_id and judged_session_id must differ (both were "${witnessSessionId}") -- a session cannot witness its own work`
+    );
+  }
+  if (!['witnessed', 'rejected'].includes(verdict)) {
+    throw new Error(`recordWitnessEvent: verdict must be 'witnessed' or 'rejected', got "${verdict}"`);
+  }
+
+  const { data, error } = await supabase
+    .from('gate_witness_events')
+    .insert({
+      gate_id: gateId,
+      witness_session_id: witnessSessionId,
+      judged_session_id: judgedSessionId,
+      verdict,
+      notes: notes || null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`recordWitnessEvent: insert failed: ${error.message}`);
+  }
+  return data;
+}

--- a/tests/integration/eva/gate-witness-events-rls.test.js
+++ b/tests/integration/eva/gate-witness-events-rls.test.js
@@ -1,0 +1,58 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C: proves gate_witness_events writes are
+ * RLS-restricted to the service-role connection -- a real permission proof, not a
+ * convention. An anon-key client has only a SELECT policy; no INSERT policy exists for
+ * it, so RLS default-denies the write.
+ */
+
+import { describe, it, expect } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceClient = createClient(SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const anonClient = createClient(
+  SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+describe('gate_witness_events RLS permission proof (live)', () => {
+  it('rejects an INSERT from an anon-key connection', async () => {
+    const { data, error } = await anonClient.from('gate_witness_events').insert({
+      gate_id: 'TEST_RLS_PROOF_GATE',
+      witness_session_id: 'anon-attempt-witness',
+      judged_session_id: 'anon-attempt-judged',
+      verdict: 'witnessed',
+    });
+
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+  });
+
+  it('allows an INSERT from the service-role connection (control case)', async () => {
+    const witnessSessionId = `rls-proof-witness-${Date.now()}`;
+    const judgedSessionId = `rls-proof-judged-${Date.now()}`;
+
+    const { data, error } = await serviceClient
+      .from('gate_witness_events')
+      .insert({
+        gate_id: 'TEST_RLS_PROOF_GATE',
+        witness_session_id: witnessSessionId,
+        judged_session_id: judgedSessionId,
+        verdict: 'witnessed',
+      })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data.gate_id).toBe('TEST_RLS_PROOF_GATE');
+
+    // Cleanup
+    await serviceClient.from('gate_witness_events').delete().eq('id', data.id);
+  });
+
+  it('allows anon-key SELECT (read policy is intentionally permissive)', async () => {
+    const { error } = await anonClient.from('gate_witness_events').select('id').limit(1);
+    expect(error).toBeNull();
+  });
+});

--- a/tests/integration/eva/gate-witness-events-self-judge.test.js
+++ b/tests/integration/eva/gate-witness-events-self-judge.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C: proves the self-judge rejection is a
+ * real DB-enforced constraint, not a convention -- a same-session insert is rejected
+ * at both the application layer (recordWitnessEvent) and the DB layer (raw insert
+ * bypassing the helper), while a distinct-session insert succeeds.
+ */
+
+import { describe, it, expect } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { recordWitnessEvent } from '../../../lib/eva/record-witness-event.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+describe('gate_witness_events self-judge rejection proof (live)', () => {
+  it('recordWitnessEvent() rejects witness_session_id === judged_session_id at the application layer', async () => {
+    const sessionId = `self-judge-app-${Date.now()}`;
+    await expect(
+      recordWitnessEvent(supabase, {
+        gateId: 'TEST_SELF_JUDGE_GATE',
+        witnessSessionId: sessionId,
+        judgedSessionId: sessionId,
+        verdict: 'witnessed',
+      })
+    ).rejects.toThrow(/cannot witness its own work/);
+  });
+
+  it('a raw same-session INSERT (bypassing the helper) is rejected by the DB CHECK constraint', async () => {
+    const sessionId = `self-judge-db-${Date.now()}`;
+    const { data, error } = await supabase.from('gate_witness_events').insert({
+      gate_id: 'TEST_SELF_JUDGE_GATE',
+      witness_session_id: sessionId,
+      judged_session_id: sessionId,
+      verdict: 'witnessed',
+    });
+
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/chk_witness_not_self_judged|constraint/i);
+  });
+
+  it('recordWitnessEvent() succeeds when witness_session_id !== judged_session_id', async () => {
+    const row = await recordWitnessEvent(supabase, {
+      gateId: 'TEST_SELF_JUDGE_GATE',
+      witnessSessionId: `self-judge-witness-${Date.now()}`,
+      judgedSessionId: `self-judge-judged-${Date.now()}`,
+      verdict: 'witnessed',
+    });
+
+    expect(row.gate_id).toBe('TEST_SELF_JUDGE_GATE');
+    expect(row.witness_session_id).not.toBe(row.judged_session_id);
+
+    // Cleanup
+    await supabase.from('gate_witness_events').delete().eq('id', row.id);
+  });
+
+  it('recordWitnessEvent() rejects an invalid verdict', async () => {
+    await expect(
+      recordWitnessEvent(supabase, {
+        gateId: 'TEST_SELF_JUDGE_GATE',
+        witnessSessionId: 'v-witness',
+        judgedSessionId: 'v-judged',
+        verdict: 'maybe',
+      })
+    ).rejects.toThrow(/verdict must be/);
+  });
+});


### PR DESCRIPTION
## Summary
- Child C of SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001 (Solomon's G1 anchor finding): gives the fleet a real, structurally-enforced witness-recording mechanism instead of an unenforced convention.
- New additive `gate_witness_events` table (RLS enabled; anon gets SELECT-only, so RLS default-denies any anon-key write attempt; service_role gets ALL) + `chk_witness_not_self_judged` CHECK constraint rejecting `witness_session_id = judged_session_id`.
- `lib/eva/record-witness-event.js` enforces the same rule at the application layer, before any DB round-trip.
- **Both proofs verified live against production, not mocked** — a real anon-key client attempting to write is rejected; a raw same-session insert (bypassing the helper) is rejected by the DB constraint; a distinct-session insert succeeds.
- Explicitly documents a known limitation rather than glossing over it: under the shared `SUPABASE_SERVICE_ROLE_KEY` architecture (established in Child A), the constraint can only catch the literal self-judge case — not a maliciously-fabricated distinct session ID. Full cryptographic actor-attestation is out of scope for this child.

## Test plan
- [x] `npx vitest run tests/integration/eva/gate-witness-events-rls.test.js tests/integration/eva/gate-witness-events-self-judge.test.js` — 7/7 passing (live, against production)
- [x] `npm run schema:lint` — 0 violations after snapshot regeneration
- [x] `node scripts/audit-db-test-guards.mjs` — 0 new unguarded DB-touching unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)