### PR TITLE
feat(SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D): observe-only witness rung on top-3 highest-blast-radius gates

### DIFF
--- a/lib/eva/observe-gate-witness.js
+++ b/lib/eva/observe-gate-witness.js
@@ -1,0 +1,73 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D: observe-only enforcement rung.
+ *
+ * Wraps a handoff gate's validator so every evaluation ALSO records a
+ * gate_witness_events row (Child C) via the 'gate-harness' witness identity --
+ * without blocking, retrying, or altering the gate's own pass/fail result in
+ * any way. This is deliberately OBSERVE-ONLY (leo_protocol_sections id=620):
+ * it starts collecting real signal on the 3 highest-blast-radius
+ * self_evidence_only gates identified by Child B before any enforcement is
+ * promoted, so a clean observation window can be established first.
+ *
+ * Known limitation (same one documented in Child C): 'gate-harness' is a
+ * fixed, code-controlled identity, not a cryptographically distinct actor --
+ * under the shared SUPABASE_SERVICE_ROLE_KEY architecture this is
+ * convention-strength, not structural. It is still strictly better than no
+ * witness event at all for these 3 gates.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { recordWitnessEvent } from './record-witness-event.js';
+
+const WITNESS_SESSION_ID = 'gate-harness';
+
+function resolveJudgedSessionId(ctx) {
+  return ctx?.sd?.claiming_session_id || ctx?.sessionId || null;
+}
+
+function resolveVerdict(result) {
+  const passed = 'passed' in (result || {}) ? result.passed : result?.pass;
+  return passed ? 'witnessed' : 'rejected';
+}
+
+/**
+ * Best-effort, non-blocking witness observation. Never throws; a failure to
+ * record (missing session id, network error, RLS denial) is swallowed so the
+ * wrapped gate's real behavior is completely unaffected.
+ */
+export async function observeGateWitness(gateId, ctx, result, supabaseOverride) {
+  try {
+    const judgedSessionId = resolveJudgedSessionId(ctx);
+    if (!judgedSessionId || judgedSessionId === WITNESS_SESSION_ID) return;
+
+    const supabase = supabaseOverride
+      || createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+    await recordWitnessEvent(supabase, {
+      gateId,
+      witnessSessionId: WITNESS_SESSION_ID,
+      judgedSessionId,
+      verdict: resolveVerdict(result),
+      notes: 'observe-only enforcement rung (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D) -- not yet blocking',
+    });
+  } catch {
+    // Observe-only: a witness-recording failure must never affect the gate itself.
+  }
+}
+
+/**
+ * Wraps a gate object's validator with observe-only witness recording.
+ * @param {string} gateId - stable gate_id, matches Child B's inventory (e.g. 'RETROSPECTIVE_EXISTS')
+ * @param {Object} gate - the gate object as returned by a createXGate() factory
+ * @returns {Object} the same gate object with validator wrapped
+ */
+export function withObserveOnlyWitness(gateId, gate) {
+  const originalValidator = gate.validator;
+  return {
+    ...gate,
+    validator: async (ctx) => {
+      const result = await originalValidator(ctx);
+      await observeGateWitness(gateId, ctx, result);
+      return result;
+    },
+  };
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -19,6 +19,9 @@ import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from 
 // Pipeline Flow Verifier (SD-LEO-INFRA-INTEGRATION-AWARE-PRD-001 FR-5)
 import { verifyPipelineFlow, requiresPipelineFlowVerification } from '../../../../../lib/pipeline-flow-verifier.js';
 
+// Observe-only witness rung (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D)
+import { withObserveOnlyWitness } from '../../../../../lib/eva/observe-gate-witness.js';
+
 // Orchestrator Completion Validation Gates (SD-ORCHESTRATOR-COMPLETION-VALIDATION-GATES-ORCH-001)
 import { createSmokeTestGate } from './gates/smoke-test-gate.js';
 export { createSmokeTestGate };
@@ -379,7 +382,7 @@ export function createUserStoriesCompleteGate(supabase, prdRepo) {
  * @returns {Object} Gate definition
  */
 export function createRetrospectiveExistsGate(supabase) {
-  return {
+  return withObserveOnlyWitness('RETROSPECTIVE_EXISTS', {
     name: 'RETROSPECTIVE_EXISTS',
     validator: async (ctx) => {
       console.log('\n🔒 GATE 3: Retrospective Verification');
@@ -473,7 +476,7 @@ export function createRetrospectiveExistsGate(supabase) {
       };
     },
     required: true
-  };
+  });
 }
 
 /**

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js
@@ -6,6 +6,8 @@
  */
 
 import { isInfrastructureSDSync } from '../../../../sd-type-checker.js';
+// Observe-only witness rung (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D)
+import { withObserveOnlyWitness } from '../../../../../../lib/eva/observe-gate-witness.js';
 
 /**
  * Create the GATE5_GIT_COMMIT_ENFORCEMENT gate validator
@@ -25,7 +27,7 @@ export function createGitCommitEnforcementGate(supabase, sd, appPath) {
   // this is type-agnostic and covers refactor/database/security/etc. on EHG target.
   if (isNonCodeSD || isBugfixSD) {
     const sdTypeLabel = isBugfixSD ? 'Bugfix' : 'Documentation/Infrastructure';
-    return {
+    return withObserveOnlyWitness('GATE5_GIT_COMMIT_ENFORCEMENT', {
       name: 'GATE5_GIT_COMMIT_ENFORCEMENT',
       validator: async () => {
         console.log('\n🔒 GATE 5: Git Commit Enforcement');
@@ -48,11 +50,11 @@ export function createGitCommitEnforcementGate(supabase, sd, appPath) {
         };
       },
       required: true
-    };
+    });
   }
 
   // Standard SDs get full commit enforcement, UNLESS the target repo has no usable git.
-  return {
+  return withObserveOnlyWitness('GATE5_GIT_COMMIT_ENFORCEMENT', {
     name: 'GATE5_GIT_COMMIT_ENFORCEMENT',
     validator: async (ctx) => {
       // Self-skip when the target repo has no usable git (e.g. EHG consolidated repo).
@@ -167,5 +169,5 @@ export function createGitCommitEnforcementGate(supabase, sd, appPath) {
       };
     },
     required: true
-  };
+  });
 }

--- a/scripts/modules/handoff/gates/scope-completion-gate.js
+++ b/scripts/modules/handoff/gates/scope-completion-gate.js
@@ -13,6 +13,8 @@ import fs from 'fs';
 import path from 'path';
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 import { isParentOrchestrator } from '../../../../lib/handoff/parent-detection.js';
+// Observe-only witness rung (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D)
+import { withObserveOnlyWitness } from '../../../../lib/eva/observe-gate-witness.js';
 
 import { execSync } from 'child_process';
 // PROJECT_ROOT prefers `git rev-parse --show-toplevel` (worktree-aware) over
@@ -436,7 +438,7 @@ export async function validateScopeCompletion(sdKey) {
  * Create the Scope Completion Verification Gate for use in handoff system.
  */
 export function createScopeCompletionGate() {
-  return {
+  return withObserveOnlyWitness('SCOPE_COMPLETION_VERIFICATION', {
     name: 'SCOPE_COMPLETION_VERIFICATION',
     validator: async (ctx) => {
       const sdKey = ctx.sdKey || ctx.sdId;
@@ -445,7 +447,7 @@ export function createScopeCompletionGate() {
     required: true,
     blocking: false, // Advisory by default — warns but doesn't block
     remediation: 'Review missing deliverables and implement them before marking SD complete.'
-  };
+  });
 }
 
 export { extractDeliverables, checkDeliverable, grepRecursive, filterBySlice, globToRegExp, isInheritedWithoutSlice };

--- a/tests/integration/eva/gate-witness-observe-only.test.js
+++ b/tests/integration/eva/gate-witness-observe-only.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D: proves the observe-only
+ * enforcement rung actually records a live gate_witness_events row (Child C)
+ * for a wrapped gate, using the fixed 'gate-harness' witness identity, without
+ * altering the gate's own pass/fail result.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { withObserveOnlyWitness } from '../../../lib/eva/observe-gate-witness.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const insertedIds = [];
+
+afterEach(async () => {
+  if (insertedIds.length) {
+    await supabase.from('gate_witness_events').delete().in('id', insertedIds);
+    insertedIds.length = 0;
+  }
+});
+
+describe('observe-only enforcement rung (live)', () => {
+  it('records a witnessed verdict for a passing gate, without altering the result', async () => {
+    const judgedSessionId = `observe-only-pass-${Date.now()}`;
+    const gate = {
+      name: 'TEST_OBSERVE_ONLY_GATE',
+      validator: async () => ({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] }),
+      required: true,
+    };
+    const wrapped = withObserveOnlyWitness('TEST_OBSERVE_ONLY_GATE', gate);
+
+    const result = await wrapped.validator({ sd: { claiming_session_id: judgedSessionId } });
+    expect(result).toEqual({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] });
+
+    const { data, error } = await supabase
+      .from('gate_witness_events')
+      .select('*')
+      .eq('gate_id', 'TEST_OBSERVE_ONLY_GATE')
+      .eq('judged_session_id', judgedSessionId)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data.witness_session_id).toBe('gate-harness');
+    expect(data.verdict).toBe('witnessed');
+    insertedIds.push(data.id);
+  });
+
+  it('records a rejected verdict for a failing gate ("pass" shape, not "passed")', async () => {
+    const judgedSessionId = `observe-only-fail-${Date.now()}`;
+    const gate = {
+      name: 'TEST_OBSERVE_ONLY_GATE',
+      validator: async () => ({ pass: false, score: 0, issues: ['missing deliverable'], warnings: [] }),
+      required: true,
+    };
+    const wrapped = withObserveOnlyWitness('TEST_OBSERVE_ONLY_GATE', gate);
+
+    const result = await wrapped.validator({ sd: { claiming_session_id: judgedSessionId } });
+    expect(result.pass).toBe(false);
+
+    const { data, error } = await supabase
+      .from('gate_witness_events')
+      .select('*')
+      .eq('gate_id', 'TEST_OBSERVE_ONLY_GATE')
+      .eq('judged_session_id', judgedSessionId)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data.witness_session_id).toBe('gate-harness');
+    expect(data.verdict).toBe('rejected');
+    insertedIds.push(data.id);
+  });
+
+  it('silently records nothing (no throw) when ctx.sd.claiming_session_id is absent', async () => {
+    const gate = {
+      name: 'TEST_OBSERVE_ONLY_GATE',
+      validator: async () => ({ passed: true }),
+      required: true,
+    };
+    const wrapped = withObserveOnlyWitness('TEST_OBSERVE_ONLY_GATE', gate);
+
+    await expect(wrapped.validator({})).resolves.toEqual({ passed: true });
+  });
+});

--- a/tests/unit/eva/observe-gate-witness.test.js
+++ b/tests/unit/eva/observe-gate-witness.test.js
@@ -1,0 +1,54 @@
+/**
+ * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D: pure logic tests for the
+ * observe-only wrapper -- no DB access (that's covered by the live
+ * integration test).
+ */
+import { describe, it, expect } from 'vitest';
+import { withObserveOnlyWitness } from '../../../lib/eva/observe-gate-witness.js';
+
+describe('withObserveOnlyWitness()', () => {
+  it('returns the original validator result completely unchanged (passing case)', async () => {
+    const originalResult = { passed: true, score: 100, max_score: 100, issues: [], warnings: [] };
+    const gate = { name: 'TEST_GATE', validator: async () => originalResult, required: true };
+    const wrapped = withObserveOnlyWitness('TEST_GATE', gate);
+
+    // No ctx.sd.claiming_session_id -> observeGateWitness no-ops silently, never throws.
+    const result = await wrapped.validator({});
+    expect(result).toEqual(originalResult);
+  });
+
+  it('returns the original validator result completely unchanged (failing case)', async () => {
+    const originalResult = { passed: false, score: 0, max_score: 100, issues: ['nope'], warnings: [] };
+    const gate = { name: 'TEST_GATE', validator: async () => originalResult, required: true };
+    const wrapped = withObserveOnlyWitness('TEST_GATE', gate);
+
+    const result = await wrapped.validator({});
+    expect(result).toEqual(originalResult);
+  });
+
+  it('preserves all other gate properties (name, required, blocking, etc.)', () => {
+    const gate = { name: 'TEST_GATE', validator: async () => ({}), required: true, blocking: false, remediation: 'fix it' };
+    const wrapped = withObserveOnlyWitness('TEST_GATE', gate);
+
+    expect(wrapped.name).toBe('TEST_GATE');
+    expect(wrapped.required).toBe(true);
+    expect(wrapped.blocking).toBe(false);
+    expect(wrapped.remediation).toBe('fix it');
+  });
+
+  it('never throws even when ctx is missing entirely', async () => {
+    const gate = { name: 'TEST_GATE', validator: async () => ({ passed: true }), required: true };
+    const wrapped = withObserveOnlyWitness('TEST_GATE', gate);
+
+    await expect(wrapped.validator(undefined)).resolves.toEqual({ passed: true });
+  });
+
+  it('never throws even when the original validator itself throws', async () => {
+    const gate = { name: 'TEST_GATE', validator: async () => { throw new Error('boom'); }, required: true };
+    const wrapped = withObserveOnlyWitness('TEST_GATE', gate);
+
+    // The observe-only wrapper does not swallow the ORIGINAL validator's own errors --
+    // only witness-recording failures are swallowed. A genuinely broken gate must still fail loudly.
+    await expect(wrapped.validator({})).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- Final child (D) of SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001 (Solomon's G1 anchor finding): wires Child C's `gate_witness_events` recording mechanism onto the 3 highest-blast-radius `self_evidence_only` gates identified by Child B's inventory — the terminal per-phase checkpoints that gate an SD's own progression toward `completed`:
  - `RETROSPECTIVE_EXISTS` (LEAD-FINAL-APPROVAL)
  - `GATE5_GIT_COMMIT_ENFORCEMENT` (PLAN-TO-LEAD)
  - `SCOPE_COMPLETION_VERIFICATION` (shared EXEC-TO-PLAN gate)
- New `lib/eva/observe-gate-witness.js` exports `withObserveOnlyWitness(gateId, gate)`, a higher-order wrapper: calls the original validator unchanged, best-effort records a witness event (fixed `gate-harness` identity), returns the original result verbatim. A witness-recording failure never blocks or alters the gate.
- **Strictly observe-only** — no gate becomes blocking here. Promoting any of the 3 to enforcement is an explicit future decision after reviewing the observation window this starts collecting, per `leo_protocol_sections` id=620's observe-only-first default.
- With all 4 children (A/B/C/D) shipped, the G1 orchestrator parent's own `PLAN-TO-LEAD` can now resolve past `WAIT`.

## Test plan
- [x] `npx vitest run tests/unit/eva/observe-gate-witness.test.js tests/integration/eva/gate-witness-observe-only.test.js` — 8/8 passing (live, against production)
- [x] `npx vitest run scripts/modules/handoff/executors/lead-final-approval/gates/retrospective-exists.test.js tests/scope-completion-gate.test.js` — 21/21 passing, zero regression
- [x] `npm run schema:lint` — 0 violations
- [x] `node scripts/audit-db-test-guards.mjs` — 0 new unguarded DB-touching unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)