### PR TITLE
fix(QF-20260705-757): DESIGN workflow validator no longer graph-checks meta-deliverable stories as UI journeys

### DIFF
--- a/lib/sub-agents/design/workflow-detection.js
+++ b/lib/sub-agents/design/workflow-detection.js
@@ -196,28 +196,39 @@ export function detectWorkflowIssues(interactionGraph, currentWorkflow, analysis
     analysis_depth: maxDepth
   };
 
-  // Detect dead ends (nodes with no outgoing edges except goal states)
-  interactionGraph.nodes.forEach(node => {
-    const outgoingEdges = interactionGraph.edges.filter(e => e.from === node.id);
-    if (outgoingEdges.length === 0 && node.type !== 'goal') {
-      const label = node.label.toLowerCase();
-      // Don't flag common landing page patterns as dead ends
-      const isLandingPage = /dashboard|home|overview|landing|main view|briefing|index|welcome/i.test(label);
-      const isAppPage = /\/[\w/-]+/.test(label);
+  // QF-20260705-757: meta-deliverable stories (deviation-ledger records, copy edits,
+  // roadmap notes, contracts) have no genuine UI-interaction pattern in their
+  // implementation_context, so every story chain graph-checks as a dead end even
+  // though there is no real UI journey to traverse. Skip topology checks (dead
+  // ends / circular flows) when no story in the set shows a real UI signal.
+  issues.is_ui_journey = userStories.some(
+    story => story.implementation_context && extractInteractionsFromContext(story.implementation_context).length > 0
+  );
 
-      if (!isLandingPage && !isAppPage) {
-        issues.deadEnds.push({
-          node_id: node.id,
-          label: node.label,
-          severity: 'HIGH',
-          description: `User reaches "${node.label}" but has no way to proceed or return`
-        });
+  if (issues.is_ui_journey) {
+    // Detect dead ends (nodes with no outgoing edges except goal states)
+    interactionGraph.nodes.forEach(node => {
+      const outgoingEdges = interactionGraph.edges.filter(e => e.from === node.id);
+      if (outgoingEdges.length === 0 && node.type !== 'goal') {
+        const label = node.label.toLowerCase();
+        // Don't flag common landing page patterns as dead ends
+        const isLandingPage = /dashboard|home|overview|landing|main view|briefing|index|welcome/i.test(label);
+        const isAppPage = /\/[\w/-]+/.test(label);
+
+        if (!isLandingPage && !isAppPage) {
+          issues.deadEnds.push({
+            node_id: node.id,
+            label: node.label,
+            severity: 'HIGH',
+            description: `User reaches "${node.label}" but has no way to proceed or return`
+          });
+        }
       }
-    }
-  });
+    });
+  }
 
   // Detect circular flows (cycles in graph)
-  const cycles = detectCycles(interactionGraph);
+  const cycles = issues.is_ui_journey ? detectCycles(interactionGraph) : [];
   issues.circularFlows = cycles.map(cycle => ({
     path: cycle,
     severity: cycle.length > 3 ? 'HIGH' : 'MEDIUM',

--- a/tests/unit/sub-agents/design-workflow-meta-deliverable.test.js
+++ b/tests/unit/sub-agents/design-workflow-meta-deliverable.test.js
@@ -1,0 +1,68 @@
+/**
+ * QF-20260705-757: DESIGN workflow validator graph-checks meta-deliverable stories
+ * (deviation-ledger records, copy edits, roadmap notes, contracts) as UI journeys,
+ * producing a false dead-end/circular-flow FAIL even when no story has any real
+ * UI-interaction pattern. Fix: detectWorkflowIssues skips topology checks when no
+ * story's implementation_context contains a Navigate/Click/Fill/Submit signal.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractWorkflowFromStories,
+  buildInteractionGraph,
+  detectWorkflowIssues
+} from '../../../lib/sub-agents/design/workflow-detection.js';
+
+describe('detectWorkflowIssues: meta-deliverable vs UI-journey discrimination', () => {
+  it('does NOT flag dead ends for a meta-deliverable story set with no UI-interaction signal', async () => {
+    const userStories = [
+      { id: 'US-1', user_role: 'planner', user_want: 'update the deviation ledger', user_benefit: 'record the drift', implementation_context: 'Append a row to the deviation ledger with the reason.' },
+      { id: 'US-2', user_role: 'planner', user_want: 'revise the roadmap note', user_benefit: 'reflect the new sequencing', implementation_context: 'Edit the roadmap note text and re-save the contract.' }
+    ];
+
+    const workflow = await extractWorkflowFromStories(userStories);
+    const graph = buildInteractionGraph(workflow);
+    const issues = detectWorkflowIssues(graph, { steps: [], routes: [] }, [], userStories);
+
+    expect(issues.is_ui_journey).toBe(false);
+    expect(issues.deadEnds).toHaveLength(0);
+    expect(issues.circularFlows).toHaveLength(0);
+  });
+
+  it('STILL flags a real dead end for a genuine UI-journey story set (regression guard)', async () => {
+    const userStories = [
+      {
+        id: 'US-1',
+        user_role: 'user',
+        user_want: 'reach the settings page',
+        user_benefit: 'change preferences',
+        implementation_context: 'Navigate to /settings then Click #save-orphan-panel'
+      }
+    ];
+
+    const workflow = await extractWorkflowFromStories(userStories);
+    const graph = buildInteractionGraph(workflow);
+    const issues = detectWorkflowIssues(graph, { steps: [], routes: [] }, [], userStories);
+
+    expect(issues.is_ui_journey).toBe(true);
+    expect(issues.deadEnds.length).toBeGreaterThan(0);
+  });
+
+  it('treats a mixed set (at least one real UI story) as a UI journey — topology checks still run', async () => {
+    const userStories = [
+      { id: 'US-1', user_role: 'planner', user_want: 'update the contract', user_benefit: 'stay current', implementation_context: 'Amend the contract text.' },
+      {
+        id: 'US-2',
+        user_role: 'user',
+        user_want: 'reach the review panel',
+        user_benefit: 'inspect the change',
+        implementation_context: 'Navigate to /review then Click #orphan-widget'
+      }
+    ];
+
+    const workflow = await extractWorkflowFromStories(userStories);
+    const graph = buildInteractionGraph(workflow);
+    const issues = detectWorkflowIssues(graph, { steps: [], routes: [] }, [], userStories);
+
+    expect(issues.is_ui_journey).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `detectWorkflowIssues()` ran dead-end/circular-flow topology checks unconditionally, so meta-deliverable story sets (deviation-ledger records, copy edits, roadmap notes, contracts) graph-checked as a linear chain that definitionally dead-ends — a category error producing false `Workflow validation FAIL -> DESIGN BLOCKED`.
- Live specimen: `SD-VENTURE-MARKETLENS-REMED-5-001` EXEC-TO-PLAN blocked 3x while a fresh substantive CONDITIONAL_PASS design-evidence row already existed.
- Adds a cheap discriminator reusing the already-exported `extractInteractionsFromContext`: if no story's `implementation_context` contains a real Navigate/Click/Fill/Submit signal, the set has no genuine UI journey to traverse, and dead-end/circular-flow detection is skipped. The decision is recorded on `issues.is_ui_journey`, not silent.
- Regression guard: any story with a real UI-interaction pattern still triggers full topology checking — a genuine dead end in a real UI journey is still flagged.

## Test plan
- [x] `npx vitest run tests/unit/sub-agents/design-workflow-meta-deliverable.test.js` — 3/3 new tests passing (meta-only set produces zero dead-ends, genuine UI-journey set still flags a real dead end, mixed set still classified as UI journey)
- [x] Full design sub-agent suite (8 files, 50 tests) — all passing, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)