### PR TITLE
feat(SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001): retarget DR restore-rehearsal Drill B to synthetic fixtures

### DIFF
--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -51,6 +51,12 @@ export const RETENTION_POLICIES = [
  * management_reviews_quarantine_20260610 is the reversibility backup from the
  * SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 purge — eligible for a manual
  * chairman-reviewed drop after its verification soak window.
+ *
+ * SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001: when this table is eventually
+ * DROPped (still a separate, chairman-gated migration — NOT this SD), remove
+ * this entry in the same PR. See scripts/dr/restore-rehearsal.mjs (Drill B no
+ * longer reads this table), scripts/probe-purge-migration.mjs, and
+ * scripts/sentinels/audit-security-linter.mjs for the other 3 breadcrumbed sites.
  */
 export const SOAK_ENTRIES = [
   {
@@ -58,6 +64,7 @@ export const SOAK_ENTRIES = [
     mode: 'soak_until',
     eligibleAfter: '2026-06-24',
     action: 'manual chairman-reviewed drop after the purge verification window (45,015 backup rows)',
+    status: 'dr_drill_decoupled',
   },
 ];
 

--- a/scripts/dr/restore-rehearsal.mjs
+++ b/scripts/dr/restore-rehearsal.mjs
@@ -10,9 +10,14 @@
  *   from the LIVE table's column shape (jsonb_populate_record), read back via
  *   to_jsonb and assert field-level fidelity.
  *
- * Drill B — quarantine-table copy:
- *   copy a sample from management_reviews_quarantine_20260610 into scratch and
- *   assert row identity via per-row md5(row::text).
+ * Drill B — quarantine-table copy (synthetic fixture, SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001):
+ *   build a synthetic source fixture inside the scratch schema (hard-coded
+ *   23-column shape mirroring the management_reviews table — see
+ *   QUARANTINE_FIXTURE_COLUMNS), copy a deterministic sample into a second
+ *   scratch table, and assert row identity via per-row md5(row::text).
+ *   Retargeted off the real quarantine backup table this drill previously read
+ *   from directly, which is eligible for a future chairman-gated drop — this
+ *   drill no longer depends on it existing.
  *
  * Safety contract (asserted, not promised):
  *   - every statement passes through the audited executor; a whitelist
@@ -41,8 +46,71 @@ import {
 
 // Fixed targets — deliberately constants, never user input (identifier safety).
 const DRILL_A_ARCHIVED_TABLE = 'workflow_trace_log';
-const DRILL_B_QUARANTINE_TABLE = 'management_reviews_quarantine_20260610';
 const SAFE_IDENT = /^[a-z0-9_]+$/;
+
+// Drill B synthetic fixture — hard-coded to mirror the management_reviews table's live
+// 23-column shape (docs/reference/schema/engineer/tables/management_reviews.md, captured
+// 2026-07-02). Deliberately NOT derived from any live/backup table: this is what makes
+// Drill B independent of the real quarantine backup table's eventual chairman-gated drop.
+const QUARANTINE_FIXTURE_COLUMNS = [
+  { col: 'id', type: 'uuid' },
+  { col: 'review_date', type: 'date' },
+  { col: 'review_type', type: 'text' },
+  { col: 'baseline_version_from', type: 'integer' },
+  { col: 'baseline_version_to', type: 'integer' },
+  { col: 'planned_capabilities', type: 'integer' },
+  { col: 'actual_capabilities', type: 'integer' },
+  { col: 'planned_ventures', type: 'integer' },
+  { col: 'actual_ventures', type: 'integer' },
+  { col: 'planned_sds', type: 'integer' },
+  { col: 'actual_sds', type: 'integer' },
+  { col: 'okr_snapshot', type: 'jsonb' },
+  { col: 'risk_snapshot', type: 'jsonb' },
+  { col: 'strategy_health', type: 'jsonb' },
+  { col: 'decisions', type: 'jsonb' },
+  { col: 'actions', type: 'jsonb' },
+  { col: 'pipeline_snapshot', type: 'jsonb' },
+  { col: 'eva_narrative', type: 'text' },
+  { col: 'eva_proposals', type: 'jsonb' },
+  { col: 'chairman_notes', type: 'text' },
+  { col: 'chairman_approved_proposals', type: 'jsonb' },
+  { col: 'overall_score', type: 'integer' },
+  { col: 'created_at', type: 'timestamptz' },
+];
+
+/** Deterministic synthetic rows matching QUARANTINE_FIXTURE_COLUMNS — no live data read. */
+function buildSyntheticQuarantineRows(count) {
+  const reviewTypes = ['weekly', 'monthly', 'ad_hoc'];
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+      review_date: `2026-01-${String((i % 28) + 1).padStart(2, '0')}`,
+      review_type: reviewTypes[i % reviewTypes.length],
+      baseline_version_from: i,
+      baseline_version_to: i + 1,
+      planned_capabilities: i * 2,
+      actual_capabilities: i,
+      planned_ventures: i * 3,
+      actual_ventures: i,
+      planned_sds: i * 5,
+      actual_sds: i,
+      okr_snapshot: { fixture: true, index: i },
+      risk_snapshot: { fixture: true, index: i },
+      strategy_health: { fixture: true, index: i },
+      decisions: [],
+      actions: [],
+      pipeline_snapshot: { fixture: true, index: i },
+      eva_narrative: `synthetic fixture row ${i}`,
+      eva_proposals: [],
+      chairman_notes: null,
+      chairman_approved_proposals: [],
+      overall_score: i % 101,
+      created_at: '2026-01-01T00:00:00+00:00',
+    });
+  }
+  return rows;
+}
 
 function parseArgs(argv) {
   const args = { sample: 500, out: '' };
@@ -134,19 +202,28 @@ async function drillA(execute, scratch, sampleSize) {
   };
 }
 
-async function drillB(execute, scratch, sampleSize) {
-  const t = DRILL_B_QUARANTINE_TABLE;
-  if (!SAFE_IDENT.test(t)) throw new Error(`unsafe identifier: ${t}`);
-  const scratchTable = `${scratch}."restored_quarantine"`;
+export async function drillB(execute, scratch, sampleSize) {
+  const fixtureTable = `${scratch}."quarantine_fixture"`;
+  const restoredTable = `${scratch}."restored_quarantine"`;
 
-  // 1. Scratch copy with the exact live shape (LIKE keeps column order/types,
-  //    which row::text rendering depends on).
-  await execute(`CREATE TABLE ${scratchTable} (LIKE public.${t})`, [], 'create-quarantine-copy');
+  // 1. Synthetic source fixture — hard-coded shape, no live table read.
+  const colDefs = QUARANTINE_FIXTURE_COLUMNS.map((c) => `"${c.col}" ${c.type}`).join(', ');
+  await execute(`CREATE TABLE ${fixtureTable} (${colDefs})`, [], 'create-quarantine-fixture');
 
-  // 2. Copy deterministic sample.
+  const syntheticRows = buildSyntheticQuarantineRows(sampleSize);
   await execute(
-    `INSERT INTO ${scratchTable}
-       SELECT * FROM (SELECT * FROM public.${t} ORDER BY id LIMIT $1) s`,
+    `INSERT INTO ${fixtureTable}
+       SELECT (jsonb_populate_record(NULL::${fixtureTable}, e)).*
+         FROM jsonb_array_elements($1::jsonb) AS e`,
+    [JSON.stringify(syntheticRows)],
+    'insert-quarantine-fixture'
+  );
+
+  // 2. "Restore" copy — same shape, scratch-to-scratch (no public schema involved).
+  await execute(`CREATE TABLE ${restoredTable} (LIKE ${fixtureTable})`, [], 'create-quarantine-copy');
+  await execute(
+    `INSERT INTO ${restoredTable}
+       SELECT * FROM (SELECT * FROM ${fixtureTable} ORDER BY id LIMIT $1) s`,
     [sampleSize],
     'copy-quarantine-sample'
   );
@@ -154,20 +231,20 @@ async function drillB(execute, scratch, sampleSize) {
   // 3. Row-identity: per-row md5(row::text) on the same deterministic sample.
   const { rows: src } = await execute(
     `SELECT md5(s::text) AS h
-       FROM (SELECT * FROM public.${t} ORDER BY id LIMIT $1) s`,
+       FROM (SELECT * FROM ${fixtureTable} ORDER BY id LIMIT $1) s`,
     [sampleSize],
     'md5-source-sample'
   );
   const { rows: dst } = await execute(
-    `SELECT md5(t::text) AS h FROM ${scratchTable} t`,
+    `SELECT md5(t::text) AS h FROM ${restoredTable} t`,
     [],
     'md5-scratch-copy'
   );
 
   const cmp = md5ListsMatch(src.map((r) => r.h), dst.map((r) => r.h));
   return {
-    name: 'quarantine-table copy (md5 row identity)',
-    quarantineTable: t,
+    name: 'quarantine-table copy (md5 row identity, synthetic fixture)',
+    fixtureSchema: 'synthetic:management_reviews-shape',
     sampled: cmp.sourceCount,
     copied: cmp.scratchCount,
     md5Match: cmp.match,

--- a/scripts/probe-purge-migration.mjs
+++ b/scripts/probe-purge-migration.mjs
@@ -25,44 +25,64 @@ const fingerprintQ = `
 
 const client = await createDatabaseClient('ehg');
 let ok = false;
+let skipped = false;
 try {
-  await client.query('BEGIN');
+  // SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001: this is a one-shot pre-flight probe for a
+  // migration that has already shipped to production (management_reviews_quarantine_20260610
+  // is live). upSql's own 0a guard aborts on a pre-existing quarantine table, so re-running the
+  // full probe against today's already-migrated state would always fail confusingly inside the
+  // migration SQL. When this table is eventually DROPped (chairman-gated, separate migration —
+  // see the breadcrumb in lib/retention/policies.js and scripts/sentinels/audit-security-linter.mjs),
+  // this script becomes fully dead and should be deleted in that same PR.
+  const existing = await client.query(
+    "SELECT to_regclass('public.management_reviews_quarantine_20260610') AS t"
+  );
 
-  const before = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
-  const fpBefore = await client.query(fingerprintQ);
-  console.log('live count before (in-tx):', before.rows[0].n);
+  if (existing.rows[0].t !== null) {
+    skipped = true;
+    ok = true;
+    console.log('ℹ️  management_reviews_quarantine_20260610 already exists — the 20260610 migration this probes has already shipped. Nothing further to verify; this script is historical.');
+  } else {
+    await client.query('BEGIN');
 
-  // --- UP: run the whole migration as one multi-statement query (matches apply-migration.js model) ---
-  await client.query(upSql);
+    const before = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+    const fpBefore = await client.query(fingerprintQ);
+    console.log('live count before (in-tx):', before.rows[0].n);
 
-  const after = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
-  const quar = await client.query('SELECT count(*)::bigint AS n FROM management_reviews_quarantine_20260610');
-  const conUp = await client.query(constraintQ);
-  console.log('after UP  — live:', after.rows[0].n, '(expect 0) | quarantine:', quar.rows[0].n, '(expect == before) | UNIQUE present:', conUp.rowCount === 1 ? 'YES' : 'NO');
+    // --- UP: run the whole migration as one multi-statement query (matches apply-migration.js model) ---
+    await client.query(upSql);
 
-  // --- DOWN: roll the purge back inside the same tx and prove byte-identical restoration ---
-  await client.query(downSql);
+    const after = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+    const quar = await client.query('SELECT count(*)::bigint AS n FROM management_reviews_quarantine_20260610');
+    const conUp = await client.query(constraintQ);
+    console.log('after UP  — live:', after.rows[0].n, '(expect 0) | quarantine:', quar.rows[0].n, '(expect == before) | UNIQUE present:', conUp.rowCount === 1 ? 'YES' : 'NO');
 
-  const restored = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
-  const fpAfter = await client.query(fingerprintQ);
-  const conDown = await client.query(constraintQ);
-  console.log('after DOWN — live:', restored.rows[0].n, '(expect == before) | UNIQUE present:', conDown.rowCount === 1 ? 'YES' : 'NO', '(expect NO) | fingerprint match:', fpBefore.rows[0].fp === fpAfter.rows[0].fp ? 'YES' : 'NO');
+    // --- DOWN: roll the purge back inside the same tx and prove byte-identical restoration ---
+    await client.query(downSql);
 
-  const pass =
-    after.rows[0].n === '0' &&
-    quar.rows[0].n === before.rows[0].n &&
-    conUp.rowCount === 1 &&
-    restored.rows[0].n === before.rows[0].n &&
-    conDown.rowCount === 0 &&
-    fpBefore.rows[0].fp === fpAfter.rows[0].fp;
+    const restored = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+    const fpAfter = await client.query(fingerprintQ);
+    const conDown = await client.query(constraintQ);
+    console.log('after DOWN — live:', restored.rows[0].n, '(expect == before) | UNIQUE present:', conDown.rowCount === 1 ? 'YES' : 'NO', '(expect NO) | fingerprint match:', fpBefore.rows[0].fp === fpAfter.rows[0].fp ? 'YES' : 'NO');
 
-  if (!pass) throw new Error('PROBE ASSERTIONS FAILED');
-  ok = true;
-  console.log('\n✅ PROBE PASS — UP purges + constrains, DOWN restores byte-identical (fingerprint match), all rolled back.');
+    const pass =
+      after.rows[0].n === '0' &&
+      quar.rows[0].n === before.rows[0].n &&
+      conUp.rowCount === 1 &&
+      restored.rows[0].n === before.rows[0].n &&
+      conDown.rowCount === 0 &&
+      fpBefore.rows[0].fp === fpAfter.rows[0].fp;
+
+    if (!pass) throw new Error('PROBE ASSERTIONS FAILED');
+    ok = true;
+    console.log('\n✅ PROBE PASS — UP purges + constrains, DOWN restores byte-identical (fingerprint match), all rolled back.');
+  }
 } catch (e) {
   console.error('\n❌ PROBE FAIL:', e.message);
 } finally {
-  try { await client.query('ROLLBACK'); console.log('rolled back — no committed change'); } catch {}
+  if (!skipped) {
+    try { await client.query('ROLLBACK'); console.log('rolled back — no committed change'); } catch {}
+  }
   await client.end();
   process.exitCode = ok ? 0 : 1;
 }

--- a/scripts/sentinels/audit-security-linter.mjs
+++ b/scripts/sentinels/audit-security-linter.mjs
@@ -46,6 +46,10 @@ const EXEMPTED_TABLES = new Set([
   'schema_migrations',
   'spatial_ref_sys',
   // SD-MAN purge/quarantine campaign copies (2026-06-09/10) — non-`_qparity` suffix.
+  // management_reviews_quarantine_20260610 is still LIVE in production (SD-LEO-INFRA-RETARGET-
+  // RESTORE-REHEARSAL-001 decoupled the DR restore-rehearsal drill from reading it, but did NOT
+  // drop it — that remains a separate, chairman-gated migration). Remove this entry in the same
+  // PR as that eventual drop.
   'management_reviews_quarantine_20260610',
   'venture_artifacts_storm_quarantine_20260610',
   'sd_baseline_items_purge_backup_20260609',

--- a/tests/unit/dr-restore-rehearsal.test.js
+++ b/tests/unit/dr-restore-rehearsal.test.js
@@ -270,7 +270,7 @@ describe('drillB — synthetic fixture (retargeted off the real quarantine table
 
   function buildMockExecute({ srcHashes, dstHashes }) {
     const audit = [];
-    const execute = vi.fn(async (sql, params = [], label = '') => {
+    const execute = vi.fn(async (sql, _params = [], label = '') => {
       audit.push(sql);
       if (label === 'md5-source-sample') return { rows: srcHashes.map((h) => ({ h })) };
       if (label === 'md5-scratch-copy') return { rows: dstHashes.map((h) => ({ h })) };

--- a/tests/unit/dr-restore-rehearsal.test.js
+++ b/tests/unit/dr-restore-rehearsal.test.js
@@ -18,6 +18,11 @@ import {
   buildReport,
   MAX_SAMPLE,
 } from '../../scripts/dr/restore-rehearsal-core.mjs';
+// SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001 — unlike the rest of this file, drillB is
+// imported live from restore-rehearsal.mjs (not core.mjs) to exercise the actual retargeted
+// SQL it generates. Still offline: drillB is only ever invoked below against a mock executor
+// that never reaches a real client, so no DB connection is made during this test run.
+import { drillB } from '../../scripts/dr/restore-rehearsal.mjs';
 
 const SCHEMA = 'dr_rehearsal_20260610_2300';
 
@@ -255,5 +260,55 @@ describe('buildReport', () => {
     const r = buildReport({ ...base, error: 'boom' });
     expect(r.overall).toBe('FAIL');
     expect(r.statementAudit).toMatchObject({ total: 2, reads: 1, scratchWrites: 1, forbidden: 0 });
+  });
+});
+
+// SD-LEO-INFRA-RETARGET-RESTORE-REHEARSAL-001 — Drill B retargeted off the real
+// management_reviews_quarantine_20260610 table onto a synthetic, scratch-only fixture.
+describe('drillB — synthetic fixture (retargeted off the real quarantine table)', () => {
+  const QUOTED_SCHEMA = `"${SCHEMA}"`; // drillB is always called with the pre-quoted schema (see main())
+
+  function buildMockExecute({ srcHashes, dstHashes }) {
+    const audit = [];
+    const execute = vi.fn(async (sql, params = [], label = '') => {
+      audit.push(sql);
+      if (label === 'md5-source-sample') return { rows: srcHashes.map((h) => ({ h })) };
+      if (label === 'md5-scratch-copy') return { rows: dstHashes.map((h) => ({ h })) };
+      return { rows: [] };
+    });
+    return { execute, audit };
+  }
+
+  it('never references the real quarantine table', async () => {
+    const { execute, audit } = buildMockExecute({ srcHashes: ['a', 'b'], dstHashes: ['a', 'b'] });
+    await drillB(execute, QUOTED_SCHEMA, 5);
+    for (const sql of audit) {
+      expect(sql).not.toMatch(/management_reviews_quarantine_20260610/i);
+    }
+  });
+
+  it('every generated statement classifies as read or scratch-write, never forbidden', async () => {
+    const { execute, audit } = buildMockExecute({ srcHashes: ['a', 'b'], dstHashes: ['a', 'b'] });
+    await drillB(execute, QUOTED_SCHEMA, 5);
+    for (const sql of audit) {
+      const kind = classifyStatement(sql, SCHEMA);
+      expect(kind, `unexpected kind for: ${sql}`).not.toBe('forbidden');
+    }
+  });
+
+  it('PASSes when the two scratch tables agree', async () => {
+    const { execute } = buildMockExecute({ srcHashes: ['a', 'b', 'c'], dstHashes: ['c', 'b', 'a'] });
+    const result = await drillB(execute, QUOTED_SCHEMA, 3);
+    expect(result.status).toBe('PASS');
+    expect(result.md5Match).toBe(true);
+  });
+
+  it('FAILs when the two scratch tables diverge', async () => {
+    const { execute } = buildMockExecute({ srcHashes: ['a', 'b'], dstHashes: ['a', 'x'] });
+    const result = await drillB(execute, QUOTED_SCHEMA, 2);
+    expect(result.status).toBe('FAIL');
+    expect(result.md5Match).toBe(false);
+    expect(result.onlySource).toEqual(['b']);
+    expect(result.onlyScratch).toEqual(['x']);
   });
 });


### PR DESCRIPTION
## Summary
- Drill B of the DR restore-rehearsal (`scripts/dr/restore-rehearsal.mjs`) previously copied from the real `management_reviews_quarantine_20260610` table, which is eligible for a future chairman-gated drop. Retargeted it onto a self-contained synthetic fixture (hard-coded 23-column shape mirroring `management_reviews`) built entirely inside the drill's own scratch schema, so the DR resilience drill no longer depends on that table's continued existence.
- Decoupled the 3 remaining references to the table with additive-only, breadcrumbed changes (the table is still live in production — its actual `DROP` remains a separate, chairman-gated migration, out of scope here):
  - `lib/retention/policies.js` — `SOAK_ENTRIES[0]` gains a `status: 'dr_drill_decoupled'` marker; `table`/`mode`/`eligibleAfter` untouched.
  - `scripts/probe-purge-migration.mjs` — guarded with a `to_regclass` existence check so it degrades to a clear informational message instead of crashing when re-run against today's (or a future post-drop) state.
  - `scripts/sentinels/audit-security-linter.mjs` — `EXEMPTED_TABLES` entry left in place with a breadcrumb comment (removing it now would false-flag a still-live table).
- Added unit coverage (`tests/unit/dr-restore-rehearsal.test.js`) proving Drill B never references the real table and every generated SQL statement classifies as read/scratch-write (never forbidden) via the real safety classifier.

## Test plan
- [x] `tests/unit/dr-restore-rehearsal.test.js` — 36/36 passing (includes new drillB coverage)
- [x] `tests/unit/retention/retention-policy.test.js` — unchanged, still passing
- [x] `tests/unit/security-hygiene-rls-searchpath.test.js` — unchanged, still passing
- [x] Live smoke test: `node scripts/dr/restore-rehearsal.mjs` against the real database — `drillA=PASS drillB=PASS`, 0 forbidden statements, scratch schema cleanly dropped
- [x] `grep -rn "management_reviews_quarantine_20260610" lib/ scripts/` returns exactly the 3 breadcrumbed sites, zero inside `restore-rehearsal.mjs`
- [x] The actual `DROP TABLE management_reviews_quarantine_20260610` is explicitly out of scope for this SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)