### PR TITLE
fix(QF-20260705-609): rehydrateCallsign checks self-consistency vs already-current metadata

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -450,6 +450,18 @@ async function rehydrateCallsign(sb, sessionId, currentMeta) {
       .maybeSingle();
     const cs = data && data.payload && data.payload.callsign;
     if (!cs) return null;
+    // QF-20260705-609: refuse to resurrect `cs` when THIS session's own already-read
+    // claude_sessions.metadata.fleet_identity.callsign already disagrees with it -- a re-band
+    // self-heal (assignFleetIdentityAtCheckin) can write the NEW callsign to claude_sessions
+    // successfully while its own SET_IDENTITY dispatch fails silently (fail-open, "cron
+    // re-emits within 5 min"). Until that re-emit lands, this stale session_coordination row
+    // still names the OLD, already-vacated callsign; rehydrating it here would silently revert
+    // the session to a label it already gave up (chairman-observed live 2026-07-05 morning,
+    // operationally remedied via assign-fleet-identities --force). This is a self-consistency
+    // check (does MY canonical record still agree with `cs`), distinct from QF-20260703-665's
+    // fleet-wide uniqueness check below (does someone ELSE hold `cs`).
+    const myCurrentCallsign = currentMeta && currentMeta.fleet_identity && currentMeta.fleet_identity.callsign;
+    if (myCurrentCallsign && myCurrentCallsign !== cs) return null;
     // QF-20260703-665 (a): refuse to resurrect a callsign a DIFFERENT live session currently
     // holds -- a stale SET_IDENTITY row can name an identity long since reassigned elsewhere
     // (live-repro: Echo ccdd0c1c resurrected while another session already held it). Fail-open

--- a/tests/unit/worker-checkin-callsign-collision-fix.test.js
+++ b/tests/unit/worker-checkin-callsign-collision-fix.test.js
@@ -5,6 +5,14 @@
  *     matches the worker's tier band) freed the OLD label instantly, with no grace window,
  *     so another session's next roll_call could claim it right away.
  *
+ * QF-20260705-609: a follow-on gap in the SAME rehydrate path -- a re-band self-heal
+ * (assignFleetIdentityAtCheckin) can write the NEW callsign to claude_sessions.metadata
+ * successfully while its own SET_IDENTITY dispatch insert fails silently. Until the 5-min
+ * cron re-emits, rehydrateCallsign's fleet-wide uniqueness check (QF-665 (a)) does not catch
+ * this, because no OTHER session holds the stale label -- this session itself already
+ * vacated it. Adds a self-consistency check: does this session's OWN already-read
+ * claude_sessions.metadata.fleet_identity.callsign still agree with the stale label.
+ *
  * Deliberately a fresh, minimal file rather than extending
  * tests/unit/worker-checkin-fleet-identity.test.js, which is quarantined for an unrelated,
  * pre-existing reason (stale tier-encoding assumption, SD-LEO-INFRA-BASELINE-QUARANTINE-
@@ -129,5 +137,35 @@ describe('rehydrateCallsign — QF-20260703-665 (a) fleet-wide uniqueness before
     const sb = rehydrateStub({ history: null });
     const out = await rehydrateCallsign(sb, 'sess-1', {});
     expect(out).toBeNull();
+  });
+});
+
+describe('rehydrateCallsign — QF-20260705-609 self-consistency vs already-current claude_sessions metadata', () => {
+  it('refuses to resurrect a stale callsign when THIS session\'s own current metadata already moved on', async () => {
+    const sb = rehydrateStub({
+      history: { payload: { callsign: 'Charlie', color: 'blue' }, created_at: '2026-07-03T00:00:00Z' },
+      holder: null, // no OTHER session holds it either -- QF-665's check alone would let this through
+    });
+    const out = await rehydrateCallsign(sb, 'sess-1', { fleet_identity: { callsign: 'Foxtrot', color: 'red' } });
+    expect(out).toBeNull();
+    expect(sb.rec.update).toBeNull(); // never persisted a reversion to the vacated identity
+  });
+
+  it('still rehydrates normally when currentMeta has no fleet_identity yet (first-time / unknown)', async () => {
+    const sb = rehydrateStub({
+      history: { payload: { callsign: 'Charlie', color: 'blue' }, created_at: '2026-07-03T00:00:00Z' },
+      holder: null,
+    });
+    const out = await rehydrateCallsign(sb, 'sess-1', {});
+    expect(out).toBe('Charlie');
+  });
+
+  it('still rehydrates normally when currentMeta.fleet_identity.callsign already agrees with the stale row', async () => {
+    const sb = rehydrateStub({
+      history: { payload: { callsign: 'Charlie', color: 'blue' }, created_at: '2026-07-03T00:00:00Z' },
+      holder: null,
+    });
+    const out = await rehydrateCallsign(sb, 'sess-1', { fleet_identity: { callsign: 'Charlie', color: 'blue' } });
+    expect(out).toBe('Charlie');
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/worker-checkin.cjs`'s `rehydrateCallsign` gains a self-consistency check: if this session's own already-read `claude_sessions.metadata.fleet_identity.callsign` disagrees with the stale `session_coordination` SET_IDENTITY row's callsign, refuse to rehydrate and await a fresh SET_IDENTITY instead.
- QF-20260703-665 (a) added a fleet-wide uniqueness check (does a *different* live session currently hold this callsign) but missed a distinct race: a re-band self-heal (`assignFleetIdentityAtCheckin`) can write a NEW callsign to `claude_sessions.metadata` successfully while its own SET_IDENTITY dispatch insert fails silently (fail-open, "cron re-emits within 5 min"). Until that re-emit lands, the stale `session_coordination` row still names the OLD, already-vacated callsign — and since no *other* session holds it yet, QF-665's check alone lets `rehydrateCallsign` resurrect it, silently reverting this session to an identity it already gave up. Chairman-observed live 2026-07-05 morning, operationally remedied via `assign-fleet-identities --force`.

## Test plan
- [x] `tests/unit/worker-checkin-callsign-collision-fix.test.js` — 10/10 passing (3 new tests: refuses resurrection when own metadata disagrees, still rehydrates normally with no fleet_identity yet, still rehydrates normally when metadata already agrees)
- [x] Full `tests/unit/worker-checkin*.test.js` suite (18 files, 155 tests) — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)