### PR TITLE
feat(SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001): tag gate_witness_events with enforcement_strength, correct registry for D-wired gates

### DIFF
--- a/database/migrations/20260706_gate_witness_events_strength_tagging.sql
+++ b/database/migrations/20260706_gate_witness_events_strength_tagging.sql
@@ -1,0 +1,28 @@
+-- SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001
+-- Fast-follow to the G1 orchestrator (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001): tags
+-- every gate_witness_events row with the enforcement_strength/witness_mechanism it
+-- actually ran at, matching Child A's gate_witness_registry vocabulary exactly, and
+-- surfaces convention-tier ("downgrade") events as first-class, queryable evidence
+-- rather than something inferred by cross-referencing the registry separately.
+--
+-- ADDITIVE ONLY: 3 new nullable/defaulted columns on an existing table. No existing
+-- column, constraint, policy, or row is touched.
+ALTER TABLE gate_witness_events
+  ADD COLUMN IF NOT EXISTS enforcement_strength text CHECK (enforcement_strength IN ('structural', 'convention')),
+  ADD COLUMN IF NOT EXISTS witness_mechanism text CHECK (witness_mechanism IN ('cross_actor', 'external_system', 'replay')),
+  ADD COLUMN IF NOT EXISTS is_downgrade boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN gate_witness_events.enforcement_strength IS
+  'The enforcement_strength this specific event actually ran at, looked up from '
+  'gate_witness_registry.gate_id at recording time (lib/eva/record-witness-event.js). '
+  'Null when the gate_id has no registry row yet -- never blocks recording.';
+COMMENT ON COLUMN gate_witness_events.witness_mechanism IS
+  'The witness_mechanism this specific event actually ran at, mirroring '
+  'gate_witness_registry.witness_mechanism. Null when the gate_id has no registry row yet.';
+COMMENT ON COLUMN gate_witness_events.is_downgrade IS
+  'true when enforcement_strength=convention -- i.e. this gate ran at convention-strength '
+  'because no structural witness mechanism exists for it today. First-class, queryable '
+  'evidence of how often convention-level enforcement is load-bearing, per the coordinator '
+  'relay (a6fa69a9-ea69-43e4-9bce-fb129196a7c7) that named this as a missed G1 fold-in: '
+  '"never silent". Defaults false so pre-existing rows (recorded before this migration) '
+  'read as non-downgrade rather than NULL-ambiguous.';

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-05T16:49:40.289Z",
+ "generated_at": "2026-07-05T23:26:45.116Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
  "table_count": 773,
  "view_count": 177,
@@ -273,7 +273,7 @@
   "gate_failure_patterns": "{id,gate,failure_signature,occurrence_count,first_seen_at,last_seen_at,related_pattern_id,remediation_sd_id,remediation_status,evidence,created_at,updated_at}",
   "gate_health_history": "{id,gate,week_start,total_attempts,passes,failures,pass_rate,avg_score,created_at}",
   "gate_requirements_templates": "{id,gate_type,template_name,requirements_template,verification_criteria,is_default,created_at}",
-  "gate_witness_events": "{id,gate_id,witness_session_id,judged_session_id,verdict,notes,recorded_at}",
+  "gate_witness_events": "{id,gate_id,witness_session_id,judged_session_id,verdict,notes,recorded_at,enforcement_strength,witness_mechanism,is_downgrade}",
   "gate_witness_registry": "{id,gate_id,handoff_type,classification,witness_mechanism,enforcement_strength,exemption_reason,existing_mechanism_ref,notes,classified_at,classified_by}",
   "genesis_deployments": "{id,simulation_id,preview_url,deployment_id,project_name,ttl_days,expires_at,health_status,last_health_check,error_message,created_at,updated_at}",
   "genesis_tier_config": "{tier_code,tier_name,description,features,default_ttl_days,requires_approval,created_at,updated_at}",

--- a/lib/eva/record-witness-event.js
+++ b/lib/eva/record-witness-event.js
@@ -2,7 +2,33 @@
  * SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-C: records a gate_witness_events row via
  * the service-role client, rejecting self-judged events at the application layer
  * before the DB CHECK constraint (chk_witness_not_self_judged) is even reached.
+ *
+ * SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001: also looks up gate_witness_registry by
+ * gate_id and stamps enforcement_strength/witness_mechanism/is_downgrade onto the
+ * event -- first-class, queryable evidence of what strength this gate actually ran
+ * at, rather than something inferred by a separate cross-reference. A lookup miss
+ * (unregistered gate_id) or lookup error stamps all 3 as null/false rather than
+ * failing the insert -- this must never turn a working witness-recording call into
+ * a thrown error for a gate not yet classified in the registry.
  */
+async function lookupGateStrength(supabase, gateId) {
+  try {
+    const { data } = await supabase
+      .from('gate_witness_registry')
+      .select('enforcement_strength, witness_mechanism')
+      .eq('gate_id', gateId)
+      .single();
+    const enforcementStrength = data?.enforcement_strength ?? null;
+    return {
+      enforcementStrength,
+      witnessMechanism: data?.witness_mechanism ?? null,
+      isDowngrade: enforcementStrength === 'convention',
+    };
+  } catch {
+    return { enforcementStrength: null, witnessMechanism: null, isDowngrade: false };
+  }
+}
+
 export async function recordWitnessEvent(supabase, { gateId, witnessSessionId, judgedSessionId, verdict, notes }) {
   if (witnessSessionId === judgedSessionId) {
     throw new Error(
@@ -13,6 +39,8 @@ export async function recordWitnessEvent(supabase, { gateId, witnessSessionId, j
     throw new Error(`recordWitnessEvent: verdict must be 'witnessed' or 'rejected', got "${verdict}"`);
   }
 
+  const { enforcementStrength, witnessMechanism, isDowngrade } = await lookupGateStrength(supabase, gateId);
+
   const { data, error } = await supabase
     .from('gate_witness_events')
     .insert({
@@ -21,6 +49,9 @@ export async function recordWitnessEvent(supabase, { gateId, witnessSessionId, j
       judged_session_id: judgedSessionId,
       verdict,
       notes: notes || null,
+      enforcement_strength: enforcementStrength,
+      witness_mechanism: witnessMechanism,
+      is_downgrade: isDowngrade,
     })
     .select()
     .single();

--- a/scripts/eva/gate-inventory-classify-and-seed.mjs
+++ b/scripts/eva/gate-inventory-classify-and-seed.mjs
@@ -60,6 +60,29 @@ const OVERRIDES = {
     enforcement_strength: ENFORCEMENT_STRENGTH.STRUCTURAL,
     notes: 'Calls `gh pr list`/`gh pr merge` guidance via GitHub CLI to verify real merge state -- categorically separate credential from SUPABASE_SERVICE_ROLE_KEY.',
   },
+  // SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001: Child D (observe-only enforcement rung) wired
+  // these 3 gates to observeGateWitness's fixed 'gate-harness' identity, which genuinely
+  // records a witness event on every evaluation -- but this registry was never re-seeded
+  // after Child D shipped, so it still read self_evidence_only/null for all 3. Corrected here
+  // so the registry and the real (weak) witness mechanism agree.
+  RETROSPECTIVE_EXISTS: {
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.CROSS_ACTOR,
+    enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+    notes: "Wired to observeGateWitness's fixed 'gate-harness' identity (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D) -- a code-controlled identity, not a cryptographically distinct actor, so convention-strength under the shared SUPABASE_SERVICE_ROLE_KEY architecture, same limitation Child C/D already document.",
+  },
+  GATE5_GIT_COMMIT_ENFORCEMENT: {
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.CROSS_ACTOR,
+    enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+    notes: "Wired to observeGateWitness's fixed 'gate-harness' identity (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D) -- convention-strength, same limitation as RETROSPECTIVE_EXISTS above.",
+  },
+  SCOPE_COMPLETION_VERIFICATION: {
+    classification: CLASSIFICATION.ALREADY_WITNESSED,
+    witness_mechanism: WITNESS_MECHANISM.CROSS_ACTOR,
+    enforcement_strength: ENFORCEMENT_STRENGTH.CONVENTION,
+    notes: "Wired to observeGateWitness's fixed 'gate-harness' identity (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001-D) -- convention-strength, same limitation as RETROSPECTIVE_EXISTS above.",
+  },
 };
 
 // Ship-witness ladder rungs -- not part of the 5 handoff executors, added explicitly

--- a/tests/integration/eva/gate-witness-observe-only.test.js
+++ b/tests/integration/eva/gate-witness-observe-only.test.js
@@ -84,4 +84,33 @@ describe('observe-only enforcement rung (live)', () => {
 
     await expect(wrapped.validator({})).resolves.toEqual({ passed: true });
   });
+
+  // SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001 FR-4/TS-5: prove the registry lookup-and-stamp
+  // change reaches the D-wrapper path for a REAL wired gate_id (registry-corrected to
+  // already_witnessed/cross_actor/convention by this SD) without any change to
+  // observe-gate-witness.js itself.
+  it('stamps enforcement_strength=convention and is_downgrade=true for the real RETROSPECTIVE_EXISTS gate_id', async () => {
+    const judgedSessionId = `observe-only-strength-${Date.now()}`;
+    const gate = {
+      name: 'RETROSPECTIVE_EXISTS',
+      validator: async () => ({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] }),
+      required: true,
+    };
+    const wrapped = withObserveOnlyWitness('RETROSPECTIVE_EXISTS', gate);
+
+    await wrapped.validator({ sd: { claiming_session_id: judgedSessionId } });
+
+    const { data, error } = await supabase
+      .from('gate_witness_events')
+      .select('*')
+      .eq('gate_id', 'RETROSPECTIVE_EXISTS')
+      .eq('judged_session_id', judgedSessionId)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data.enforcement_strength).toBe('convention');
+    expect(data.witness_mechanism).toBe('cross_actor');
+    expect(data.is_downgrade).toBe(true);
+    insertedIds.push(data.id);
+  });
 });

--- a/tests/unit/eva/record-witness-event-strength-tagging.test.js
+++ b/tests/unit/eva/record-witness-event-strength-tagging.test.js
@@ -1,0 +1,105 @@
+/**
+ * SD-LEO-INFRA-GATE-WITNESS-STRENGTH-001: unit tests for the gate_witness_registry
+ * lookup-and-stamp behavior added to recordWitnessEvent(). Mocked supabase client --
+ * no DB access (that's covered by the live integration test).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { recordWitnessEvent } from '../../../lib/eva/record-witness-event.js';
+
+function makeSupabase({ registryRow, registryError, insertedRow }) {
+  const registryChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: registryRow ?? null, error: registryError ?? null }),
+  };
+  const eventsChain = {
+    insert: vi.fn().mockImplementation((payload) => ({
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: insertedRow ?? { id: 'evt-1', ...payload }, error: null }),
+    })),
+  };
+  return {
+    from: vi.fn().mockImplementation((table) => {
+      if (table === 'gate_witness_registry') return registryChain;
+      if (table === 'gate_witness_events') return eventsChain;
+      throw new Error(`unexpected table: ${table}`);
+    }),
+    _eventsChain: eventsChain,
+  };
+}
+
+describe('recordWitnessEvent() -- strength tagging', () => {
+  it('stamps enforcement_strength=convention/witness_mechanism=cross_actor/is_downgrade=true for a convention-tier gate', async () => {
+    const supabase = makeSupabase({
+      registryRow: { enforcement_strength: 'convention', witness_mechanism: 'cross_actor' },
+    });
+
+    await recordWitnessEvent(supabase, {
+      gateId: 'RETROSPECTIVE_EXISTS',
+      witnessSessionId: 'gate-harness',
+      judgedSessionId: 'session-a',
+      verdict: 'witnessed',
+    });
+
+    const insertCall = supabase._eventsChain.insert.mock.calls[0][0];
+    expect(insertCall.enforcement_strength).toBe('convention');
+    expect(insertCall.witness_mechanism).toBe('cross_actor');
+    expect(insertCall.is_downgrade).toBe(true);
+  });
+
+  it('stamps enforcement_strength=structural/is_downgrade=false for a structural-tier gate', async () => {
+    const supabase = makeSupabase({
+      registryRow: { enforcement_strength: 'structural', witness_mechanism: 'external_system' },
+    });
+
+    await recordWitnessEvent(supabase, {
+      gateId: 'PR_PRECHECK',
+      witnessSessionId: 'gate-harness',
+      judgedSessionId: 'session-a',
+      verdict: 'witnessed',
+    });
+
+    const insertCall = supabase._eventsChain.insert.mock.calls[0][0];
+    expect(insertCall.enforcement_strength).toBe('structural');
+    expect(insertCall.witness_mechanism).toBe('external_system');
+    expect(insertCall.is_downgrade).toBe(false);
+  });
+
+  it('stamps all 3 fields null/false for an unregistered gate_id, without throwing', async () => {
+    const supabase = makeSupabase({ registryRow: null, registryError: { message: 'not found' } });
+
+    await recordWitnessEvent(supabase, {
+      gateId: 'SOME_UNREGISTERED_GATE',
+      witnessSessionId: 'gate-harness',
+      judgedSessionId: 'session-a',
+      verdict: 'witnessed',
+    });
+
+    const insertCall = supabase._eventsChain.insert.mock.calls[0][0];
+    expect(insertCall.enforcement_strength).toBeNull();
+    expect(insertCall.witness_mechanism).toBeNull();
+    expect(insertCall.is_downgrade).toBe(false);
+  });
+
+  it('still throws on the pre-existing self-judge guard, before any registry lookup matters', async () => {
+    const supabase = makeSupabase({ registryRow: { enforcement_strength: 'convention', witness_mechanism: 'cross_actor' } });
+
+    await expect(recordWitnessEvent(supabase, {
+      gateId: 'RETROSPECTIVE_EXISTS',
+      witnessSessionId: 'same-session',
+      judgedSessionId: 'same-session',
+      verdict: 'witnessed',
+    })).rejects.toThrow('must differ');
+  });
+
+  it('still throws on the pre-existing verdict validation guard', async () => {
+    const supabase = makeSupabase({ registryRow: { enforcement_strength: 'convention', witness_mechanism: 'cross_actor' } });
+
+    await expect(recordWitnessEvent(supabase, {
+      gateId: 'RETROSPECTIVE_EXISTS',
+      witnessSessionId: 'gate-harness',
+      judgedSessionId: 'session-a',
+      verdict: 'maybe',
+    })).rejects.toThrow("must be 'witnessed' or 'rejected'");
+  });
+});


### PR DESCRIPTION
## Summary
- Fast-follow to G1 (SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001): adds `enforcement_strength`/`witness_mechanism`/`is_downgrade` columns to `gate_witness_events` (additive migration) and stamps them on every recorded event via a `gate_witness_registry` lookup in `recordWitnessEvent()`.
- Corrects a registry gap found during this SD's own PLAN phase: `RETROSPECTIVE_EXISTS`/`GATE5_GIT_COMMIT_ENFORCEMENT`/`SCOPE_COMPLETION_VERIFICATION` were still classified `self_evidence_only`/null even though Child D already wired all 3 to a real (convention-strength) witness mechanism — the registry was never re-seeded after Child D shipped.
- `observe-gate-witness.js` needed zero changes — it already threads `gateId` through, verified end-to-end with a new live integration test.

## Test plan
- 5 new unit tests (mocked supabase) for the lookup-and-stamp behavior (convention/structural/unregistered-fallback/pre-existing guards unchanged)
- 1 new live integration test proving a real `RETROSPECTIVE_EXISTS` witness event now carries `enforcement_strength=convention`/`is_downgrade=true`
- All 3 pre-existing `gate_witness_events`/`gate_witness_registry` test files re-run green (24 tests), zero regression
- LEAD-TO-PLAN (93%), PLAN-TO-EXEC (92%), PLAN-TO-LEAD (93%) handoffs accepted (infrastructure type skips EXEC-TO-PLAN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)