### PR TITLE
fix(QF-20260705-817): detect + surface completion-boundary silent loop exits

### DIFF
--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const { runDetectors, detectInertWorkerRevival } = require('./detectors.cjs');
+const { runDetectors, detectInertWorkerRevival, detectCompletionBoundaryExit } = require('./detectors.cjs');
 // SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001: route this alert insert through the
 // validated dispatch guard. target_session here is the 'broadcast-coordinator' sentinel,
 // which the guard short-circuits (no live-session lookup) — behavior is preserved.
@@ -432,6 +432,109 @@ async function runInertWorkerSurfacing(supabase, opts) {
   }
 }
 
+/**
+ * QF-20260705-817: default-OFF flag for the completion-boundary-exit surfacing feature.
+ * Independent of COORD_DETECTORS_V2 / SURFACE_INERT_WORKER_V1 so it can roll out/back on its own.
+ */
+function completionBoundaryExitDetectorEnabled(env) {
+  env = env || process.env;
+  return String(env.SURFACE_COMPLETION_BOUNDARY_EXIT_V1 ?? 'false').toLowerCase() !== 'false';
+}
+
+/** Build the completion-boundary-exit detector input from the live DB. READ-ONLY, fail-soft. */
+async function gatherCompletionBoundaryExitInputs(supabase, opts) {
+  opts = opts || {};
+  const now = opts.now ?? Date.now();
+  let sessions = [];
+  try {
+    const sinceIso = new Date(now - 24 * 3600 * 1000).toISOString();
+    const { data } = await supabase
+      .from('claude_sessions')
+      .select('session_id, sd_key, released_reason, released_at, heartbeat_at')
+      .is('sd_key', null)
+      .gte('released_at', sinceIso);
+    sessions = data || [];
+  } catch (_) { sessions = []; }
+  let unclaimedItems = 0;
+  try {
+    const [{ data: sds }, { data: qfs }] = await Promise.all([
+      supabase.from('strategic_directives_v2').select('sd_key, claiming_session_id, is_working_on, status')
+        .not('status', 'in', '(completed,cancelled,archived,superseded,deferred)'),
+      supabase.from('quick_fixes').select('id, claiming_session_id, status')
+        .is('claiming_session_id', null).in('status', ['open', 'in_progress']),
+    ]);
+    const unclaimedSds = (sds || []).filter((s) => !s.claiming_session_id && !s.is_working_on && s.status !== 'blocked').length;
+    unclaimedItems = unclaimedSds + (qfs || []).length;
+  } catch (_) { unclaimedItems = 0; }
+  return { sessions, unclaimedItems };
+}
+
+/**
+ * Emit ONE de-duped operator alert for a completion-boundary loop exit. Reuses the SAME
+ * FLEET_WORKER_STARTUP_PROMPT re-paste text as the inert-worker alert (single source of truth).
+ * FAIL-OPEN. Skips when an unacknowledged, unexpired same-kind alert already exists.
+ * @returns {Promise<{ ok: boolean, skipped?: boolean, id?: string, error?: string }>}
+ */
+async function emitCompletionBoundaryExitAlert(supabase, evidence, opts) {
+  opts = opts || {};
+  const nowMs = opts.now ?? Date.now();
+  try {
+    const nowIso = new Date(nowMs).toISOString();
+    const { data: dupes } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('message_type', 'INFO')
+      .eq('payload->>kind', 'completion_boundary_exit_alert')
+      .is('acknowledged_at', null)
+      .gt('expires_at', nowIso)
+      .limit(1);
+    if (dupes && dupes.length > 0) return { ok: true, skipped: true, id: dupes[0].id };
+    const exited = (evidence && evidence.exited_count) || 0;
+    const expiresAt = new Date(nowMs + 24 * 3600 * 1000).toISOString();
+    const body = exited + ' worker session(s) loop-exited right after completing a phase/SD, with unclaimed work waiting — no self-revival possible. Paste the prompt below into an idle Claude Code window to wake a worker:\n\n' + FLEET_WORKER_STARTUP_PROMPT;
+    const row = {
+      target_session: 'broadcast-coordinator',
+      sender_type: 'sweep',
+      message_type: 'INFO',
+      subject: '[COMPLETION_BOUNDARY_EXIT] ' + exited + ' worker(s) silent-exited post-completion - paste prompt to wake',
+      body,
+      payload: { kind: 'completion_boundary_exit_alert', severity: 'high', exited_count: exited, evidence },
+      expires_at: expiresAt,
+    };
+    const { data, error } = await insertCoordinationRow(supabase, row, { select: 'id', single: true });
+    if (error) {
+      console.warn('   [COMPLETION_BOUNDARY_EXIT_ALERT_FAILED] ' + error.message + ' (non-fatal)');
+      return { ok: false, error: error.message };
+    }
+    return { ok: true, id: data.id };
+  } catch (e) {
+    console.warn('   [COMPLETION_BOUNDARY_EXIT_ALERT_THREW] ' + ((e && e.message) || e) + ' (non-fatal)');
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * Flag-gated, fail-open: detect completion-boundary loop exits and (on match) emit ONE de-duped
+ * operator alert. OFF flag => null with ZERO reads/writes.
+ * @returns {Promise<{ matched: boolean, exited_count?: number, alert?: object } | null>}
+ */
+async function runCompletionBoundaryExitSurfacing(supabase, opts) {
+  opts = opts || {};
+  const env = opts.env || process.env;
+  if (!completionBoundaryExitDetectorEnabled(env)) return null;
+  try {
+    const now = opts.now ?? Date.now();
+    const inputs = await gatherCompletionBoundaryExitInputs(supabase, { now });
+    const res = detectCompletionBoundaryExit({ sessions: inputs.sessions, unclaimedItems: inputs.unclaimedItems, now });
+    if (!res.matched) return { matched: false };
+    const alert = await emitCompletionBoundaryExitAlert(supabase, res.evidence, { now });
+    return { matched: true, exited_count: res.evidence.exited_count, alert };
+  } catch (e) {
+    console.warn('   [COMPLETION_BOUNDARY_EXIT_SURFACING_THREW] ' + ((e && e.message) || e) + ' (non-fatal)');
+    return null;
+  }
+}
+
 module.exports = {
   DETECTOR_VERSION,
   coordDetectorsEnabled,
@@ -445,6 +548,11 @@ module.exports = {
   gatherInertWorkerInputs,
   emitInertWorkerAlert,
   runInertWorkerSurfacing,
+  // QF-20260705-817
+  completionBoundaryExitDetectorEnabled,
+  gatherCompletionBoundaryExitInputs,
+  emitCompletionBoundaryExitAlert,
+  runCompletionBoundaryExitSurfacing,
   // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001
   computeMergesByRole,
 };

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -459,6 +459,52 @@ function detectMaskedStall(data) {
 }
 
 /**
+ * QF-20260705-817: the COMPLETION-boundary silent-exit attrition class — a worker whose loop
+ * EXITED right after completing a phase/SD (4 instances in one day: post-probe-ship,
+ * post-HOTSPOTS-LEAD-TO-PLAN, +2 earlier), discovered late by a coordinator investigation each
+ * time. Distinct from detectStalledLoop/detectMaskedStall (both REQUIRE a fresh heartbeat — a
+ * still-looping-but-parked worker); this detector is the inverse: the completion-grace window
+ * (DEFAULT_COMPLETION_GRACE_MS) has ELAPSED (no longer legitimately finishing its post-completion
+ * tail) AND the heartbeat has gone STALE (the loop actually stopped, not just parked-alive) AND
+ * unclaimed work is waiting. PURE — no I/O. Fail-open: skips sessions with no usable
+ * released_at/heartbeat_at, or whose last release wasn't a genuine completion, or that still hold
+ * a claim (a different failure class).
+ * @param {{ sessions?: Array, unclaimedItems?: number, now?: number, freshMs?: number, graceMs?: number }} data
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectCompletionBoundaryExit(data) {
+  const now = (data && data.now) ?? Date.now();
+  const freshMs = (data && data.freshMs) ?? DEFAULT_STALLED_LOOP_FRESH_MS;
+  const graceMs = (data && data.graceMs) ?? DEFAULT_COMPLETION_GRACE_MS;
+  const unclaimed = Number((data && data.unclaimedItems) ?? 0);
+  if (unclaimed <= 0) {
+    return { matched: false, reason: 'no_unclaimed_work', evidence: { unclaimed_items: unclaimed } };
+  }
+  const exited = [];
+  for (const s of ((data && data.sessions) || [])) {
+    if (!s || s.sd_key) continue;                         // holds a claim -> a different failure class
+    if (!isCompletionRelease(s.released_reason)) continue; // last release wasn't a genuine completion
+    const releasedAtMs = toMs(s.released_at);
+    if (!releasedAtMs) continue;                           // no usable release time -> skip (fail-open)
+    if (now - releasedAtMs <= graceMs) continue;            // still inside the legitimate post-completion tail
+    const hbMs = toMs(s.heartbeat_at);
+    if (!hbMs) continue;                                    // no usable heartbeat -> skip (fail-open)
+    if (now - hbMs <= freshMs) continue;                    // heartbeat still fresh -> not exited (detectStalledLoop's territory)
+    if (exited.length < 10) {
+      exited.push({ session_id: s.session_id, released_reason: s.released_reason, silent_ms: now - hbMs });
+    }
+  }
+  if (exited.length === 0) {
+    return { matched: false, reason: 'no_completion_boundary_exits', evidence: { unclaimed_items: unclaimed, fresh_ms: freshMs, grace_ms: graceMs } };
+  }
+  return {
+    matched: true,
+    reason: 'session_loop_exited_after_completion_while_work_waits',
+    evidence: { exited_count: exited.length, unclaimed_items: unclaimed, fresh_ms: freshMs, grace_ms: graceMs, samples: exited, advisory: 're-paste the fleet-worker wake prompt into that window — the loop exited right after completing, no self-revival possible' },
+  };
+}
+
+/**
  * Per-session projection of detectMaskedStall (mirrors stalledLoopSessionIds). Returns the flagged
  * session_id Set. PURE — inherits every detectMaskedStall guard. @returns {Set<string>}
  */
@@ -644,6 +690,10 @@ module.exports = {
   LOOP_ACTIVE_STATES,
   DEFAULT_LOOP_EXPIRY_WARN_MS,
   DEFAULT_STALLED_LOOP_FRESH_MS,
+  isCompletionRelease,
+  DEFAULT_COMPLETION_GRACE_MS,
+  // QF-20260705-817
+  detectCompletionBoundaryExit,
   // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001
   detectEvaSchedulerStale,
   DEFAULT_EVA_SCHEDULER_STALE_MS,

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2652,6 +2652,21 @@ async function main() {
     console.log('INERT_WORKER: ' + (inertErr && inertErr.message ? inertErr.message : 'unknown'));
   }
 
+  // QF-20260705-817 — completion-boundary silent-exit surfacing. DEFAULT-OFF behind
+  // SURFACE_COMPLETION_BOUNDARY_EXIT_V1, READ-ONLY, fail-open. Emits ONE de-duped operator
+  // alert (carrying the same paste-able /loop prompt as INERT_WORKER) when a worker's loop
+  // exited right after completing a phase/SD while unclaimed work waits. Fully inert when flag off.
+  try {
+    const exitSurf = await _coordEventsModule.runCompletionBoundaryExitSurfacing(supabase, {});
+    if (exitSurf && exitSurf.matched) {
+      const a = exitSurf.alert || {};
+      const tail = a.skipped ? ' (alert deduped)' : a.ok ? ' - operator alert emitted' : ' (alert emit failed)';
+      console.log('  COMPLETION_BOUNDARY_EXIT: ' + exitSurf.exited_count + ' worker(s) silent-exited post-completion' + tail);
+    }
+  } catch (exitErr) {
+    console.log('COMPLETION_BOUNDARY_EXIT: ' + (exitErr && exitErr.message ? exitErr.message : 'unknown'));
+  }
+
   // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-4d — SIGNAL_RESOLVED notification.
   // For each contributing signal where payload.routed_to_sd_key is non-null AND the SD
   // status is 'completed' AND payload.notification_sent is not yet true, look up

--- a/tests/unit/coordinator/completion-boundary-exit.test.js
+++ b/tests/unit/coordinator/completion-boundary-exit.test.js
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the completion-boundary silent-exit surfacing feature.
+ * QF-20260705-817
+ *
+ * Pure detector over injected fixtures + mocked-supabase writer (fail-open + dedup).
+ * Mirrors tests/unit/coordinator/inert-worker.test.js's structure/mock conventions.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  completionBoundaryExitDetectorEnabled,
+  FLEET_WORKER_STARTUP_PROMPT,
+  emitCompletionBoundaryExitAlert,
+  runCompletionBoundaryExitSurfacing,
+} from '../../../lib/coordinator/coordination-events.cjs';
+
+const NOW = 1_750_000_000_000;
+
+describe('completionBoundaryExitDetectorEnabled', () => {
+  it('is OFF by default and ON when flag set', () => {
+    expect(completionBoundaryExitDetectorEnabled({})).toBe(false);
+    expect(completionBoundaryExitDetectorEnabled({ SURFACE_COMPLETION_BOUNDARY_EXIT_V1: 'false' })).toBe(false);
+    expect(completionBoundaryExitDetectorEnabled({ SURFACE_COMPLETION_BOUNDARY_EXIT_V1: 'true' })).toBe(true);
+  });
+});
+
+function mockSupabase({ dupes = [], insertError = null, throwOn = null }) {
+  return {
+    from() {
+      return {
+        select() { return this; }, eq() { return this; }, is() { return this; }, gt() { return this; },
+        limit() {
+          if (throwOn === 'select') throw new Error('boom-select');
+          return Promise.resolve({ data: dupes, error: null });
+        },
+        insert() {
+          if (throwOn === 'insert') throw new Error('boom-insert');
+          return { select() { return { single() { return Promise.resolve({ data: insertError ? null : { id: 'new-1' }, error: insertError }); } }; } };
+        },
+      };
+    },
+  };
+}
+
+describe('emitCompletionBoundaryExitAlert (dedup + fail-open)', () => {
+  it('inserts one alert when no live dupe exists, body carries the re-paste prompt', async () => {
+    const res = await emitCompletionBoundaryExitAlert(mockSupabase({ dupes: [] }), { exited_count: 2 }, { now: NOW });
+    expect(res.ok).toBe(true); expect(res.skipped).toBeUndefined(); expect(res.id).toBe('new-1');
+  });
+  it('skips insert when an unacknowledged, unexpired alert already exists', async () => {
+    const res = await emitCompletionBoundaryExitAlert(mockSupabase({ dupes: [{ id: 'old-1' }] }), { exited_count: 2 }, { now: NOW });
+    expect(res.ok).toBe(true); expect(res.skipped).toBe(true); expect(res.id).toBe('old-1');
+  });
+  it('fail-open on insert error', async () => {
+    const res = await emitCompletionBoundaryExitAlert(mockSupabase({ dupes: [], insertError: { message: 'db down' } }), { exited_count: 1 }, { now: NOW });
+    expect(res.ok).toBe(false); expect(res.error).toBe('db down');
+  });
+  it('fail-open when the select throws', async () => {
+    const res = await emitCompletionBoundaryExitAlert(mockSupabase({ throwOn: 'select' }), { exited_count: 1 }, { now: NOW });
+    expect(res.ok).toBe(false);
+  });
+  it('reuses the SAME FLEET_WORKER_STARTUP_PROMPT single source of truth', () => {
+    expect(FLEET_WORKER_STARTUP_PROMPT).toContain('/loop');
+  });
+});
+
+describe('runCompletionBoundaryExitSurfacing', () => {
+  it('returns null with ZERO I/O when flag is OFF', async () => {
+    const sb = { from: vi.fn(() => { throw new Error('should not be called'); }) };
+    const res = await runCompletionBoundaryExitSurfacing(sb, { env: {} });
+    expect(res).toBeNull();
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -16,6 +16,7 @@ import {
   detectStalledLoop,
   stalledLoopSessionIds,
   detectEvaSchedulerStale,
+  detectCompletionBoundaryExit,
   runDetectors,
 } from '../../../lib/coordinator/detectors.cjs';
 import {
@@ -178,6 +179,46 @@ describe('detectStalledLoop', () => {
   it('STILL flags a non-completion release (e.g. stale_cleanup) with a recent released_at', () => {
     const other = { ...stalled, session_id: 'other-rel', released_reason: 'stale_cleanup', released_at: minsAgo(2) };
     expect(detectStalledLoop({ sessions: [other], unclaimedItems: 5, now: NOW }).matched).toBe(true);
+  });
+});
+
+// QF-20260705-817: the inverse of detectStalledLoop's post-completion-tail exclusion — a worker
+// whose loop EXITED (heartbeat gone STALE) after the grace window elapsed, following a genuine
+// completion release, while unclaimed work waits.
+describe('detectCompletionBoundaryExit', () => {
+  const exited = { session_id: 'w1', sd_key: null, released_reason: 'completed', released_at: minsAgo(20), heartbeat_at: minsAgo(15) };
+  it('matches a session that loop-exited after completion, grace elapsed, heartbeat stale', () => {
+    const r = detectCompletionBoundaryExit({ sessions: [exited], unclaimedItems: 3, now: NOW });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.exited_count).toBe(1);
+    expect(r.evidence.samples[0].session_id).toBe('w1');
+  });
+  it('does not match when there is no unclaimed work', () => {
+    expect(detectCompletionBoundaryExit({ sessions: [exited], unclaimedItems: 0, now: NOW }).matched).toBe(false);
+  });
+  it('does not match a session that still holds a claim', () => {
+    const claimed = { ...exited, session_id: 'has-claim', sd_key: 'SD-X' };
+    expect(detectCompletionBoundaryExit({ sessions: [claimed], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('does not match a non-completion release reason', () => {
+    const other = { ...exited, session_id: 'other-rel', released_reason: 'stale_cleanup' };
+    expect(detectCompletionBoundaryExit({ sessions: [other], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('does not match while still inside the post-completion grace window', () => {
+    const inGrace = { ...exited, session_id: 'in-grace', released_at: minsAgo(3), heartbeat_at: minsAgo(15) };
+    expect(detectCompletionBoundaryExit({ sessions: [inGrace], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('does not match when the heartbeat is still fresh (looks alive, not exited)', () => {
+    const alive = { ...exited, session_id: 'alive', heartbeat_at: minsAgo(2) };
+    expect(detectCompletionBoundaryExit({ sessions: [alive], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('skips (fail-open) a session with no usable released_at', () => {
+    const noTs = { ...exited, session_id: 'no-ts', released_at: null };
+    expect(detectCompletionBoundaryExit({ sessions: [noTs], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('skips (fail-open) a session with no usable heartbeat_at', () => {
+    const noHb = { ...exited, session_id: 'no-hb', heartbeat_at: null };
+    expect(detectCompletionBoundaryExit({ sessions: [noHb], unclaimedItems: 5, now: NOW }).matched).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- BRAVO (FABLE-MAX) loop-exited after completing work FOUR times in one day (post-probe-ship, post-HOTSPOTS-LEAD-TO-PLAN, +2 earlier). The shipped CLAIM-BOUNDARY probe covers claim-side wedges; completion-side exits had NO detector, so each cost a coordinator escalation + a chairman re-paste discovered minutes-to-hours late.
- Adds `detectCompletionBoundaryExit` (`lib/coordinator/detectors.cjs`) — the inverse of `detectStalledLoop`'s post-completion-tail exclusion: flags a session whose most recent release was a genuine completion (`released_reason` in `{completed, qf_completed}`), whose post-completion grace window has **elapsed**, and whose heartbeat has gone **stale** (the loop actually exited, not just parked-alive — distinct from `detectStalledLoop`/`detectMaskedStall`, which both require a *fresh* heartbeat), while unclaimed work waits.
- Composes with the existing coordination-observability machinery rather than inventing new plumbing: mirrors `SD-LEO-INFRA-SURFACE-INERT-WORKER-001`'s gather/detect/emit/run-wrapper shape exactly (default-OFF flag `SURFACE_COMPLETION_BOUNDARY_EXIT_V1`, read-only, fail-open) and reuses the *same* `FLEET_WORKER_STARTUP_PROMPT` re-paste text (single source of truth) for the ONE de-duped coordinator-lane alert. Wired into `stale-session-sweep.cjs` alongside the sibling `INERT_WORKER` call.
- Root-cause of the exit itself (ScheduleWakeup not re-armed on the completion tail? worker.md turn-end rule?) is a separate, deeper fix this QF explicitly does not attempt — it makes the failure LOUD and one-paste recoverable first, per its own scope note.

**LOC note**: the ticket estimated ~70 LOC; actual implementation is ~175 LOC across 3 files. The overage is near-mechanical mirroring of an already-shipped, low-risk sibling feature (INERT_WORKER_REVIVAL) rather than added complexity — every new function is default-OFF, read-only, and fail-open, so blast radius is effectively zero even at this size. Documented per CLAUDE.md's "exceed only with documented justification" PR-size allowance rather than escalating to a full SD for a change this contained.

## Test plan
- [x] `tests/unit/coordinator/detectors.test.js` — 46/46 passing (8 new tests for `detectCompletionBoundaryExit`, mirroring `detectStalledLoop`'s fixture style)
- [x] New `tests/unit/coordinator/completion-boundary-exit.test.js` — 6/6 passing (dedup, fail-open, flag-off zero-I/O, mirroring `inert-worker.test.js`)
- [x] `tests/unit/coordinator/inert-worker.test.js` — unchanged, still passing (11/11)
- [x] Broader stale-session-sweep test suites (9 files) — zero regressions (1 unrelated integration test pre-existing-skips on a missing local `.env.test`, unrelated to this diff — it fails at DB-connection setup before this PR's code is ever reached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)