### PR TITLE
fix(QF-20260705-104): mechanical conflict-marker guard for generated protocol files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -175,6 +175,31 @@ fi
 echo "✅ CLAUDE*.md protection check passed"
 
 # ============================================================================
+# STAGE 0.55: CLAUDE*.md Conflict-Marker Guard (BLOCKING)
+# ============================================================================
+# QF-20260705-104: mechanical guard against unresolved merge/stash conflict
+# markers surviving into a commit. A stash-pop corruption left conflict
+# markers in 16 generated CLAUDE*.md files for ~75min, caught only by an
+# incidental hash-probe (Solomon feedback cycle 11). Scans the working tree
+# (not just staged diffs) so corruption is caught regardless of stage state.
+# ============================================================================
+CONFLICTED_CLAUDE_FILES=$(grep -l '^<<<<<<< ' CLAUDE*.md 2>/dev/null || true)
+
+if [ ! -z "$CONFLICTED_CLAUDE_FILES" ]; then
+  echo ""
+  echo "❌ BLOCKED: Unresolved conflict markers found in CLAUDE*.md files!"
+  echo ""
+  echo "$CONFLICTED_CLAUDE_FILES" | sed 's/^/   - /'
+  echo ""
+  echo "   Resolve the conflict, then regenerate: node scripts/generate-claude-md-from-db.js"
+  echo "   Emergency bypass (logged): git commit --no-verify"
+  echo ""
+  exit 1
+fi
+
+echo "✅ CLAUDE*.md conflict-marker guard passed"
+
+# ============================================================================
 # STAGE 0.6: Script Reference Protection (BLOCKING)
 # ============================================================================
 # SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002: Prevent deletion of referenced scripts

--- a/scripts/generate-claude-md-from-db.js
+++ b/scripts/generate-claude-md-from-db.js
@@ -9,12 +9,40 @@
 
 import dotenv from 'dotenv';
 import path from 'path';
+import { readdirSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
 import { createClient } from '@supabase/supabase-js';
 import { fileURLToPath } from 'url';
 
 import { CLAUDEMDGeneratorV3, KNOWN_GENERATED_FILES } from './modules/claude-md-generator/index.js';
 import { getActiveProtocol } from './modules/claude-md-generator/db-queries.js';
 import { runRegenLintHook } from './protocol-lint/regen-hook.mjs';
+
+// QF-20260705-104 (seam 2): refuse to regenerate OVER a conflicted working tree instead
+// of silently overwriting it — a prior stash-pop corruption left conflict markers in 16
+// generated CLAUDE*.md files undetected for ~75min (Solomon feedback cycle 11). Checks
+// both the marker itself and git's own unmerged-file signal (UU), so a conflict without
+// markers already burned into a CLAUDE*.md file still blocks. Fail-open on git errors —
+// this is a defense-in-depth guard, not the primary gate (that's the pre-commit hook).
+export function detectConflictedState(baseDir) {
+  const markered = readdirSync(baseDir)
+    .filter((f) => /^CLAUDE.*\.md$/.test(f))
+    .filter((f) => {
+      try {
+        return /^<<<<<<< /m.test(readFileSync(path.join(baseDir, f), 'utf8'));
+      } catch {
+        return false;
+      }
+    });
+  let unmerged = [];
+  try {
+    const porcelain = execSync('git status --porcelain', { cwd: baseDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    unmerged = porcelain.split('\n').filter((l) => l.startsWith('UU ')).map((l) => l.slice(3).trim());
+  } catch {
+    // fail-open
+  }
+  return (markered.length || unmerged.length) ? { markered, unmerged } : null;
+}
 
 // SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-4): parse --only <FILE[,FILE...]>
 // into a validated file list. Unknown names fail loud listing valid targets. Exported
@@ -59,6 +87,16 @@ if (import.meta.url === `file:///${normalizedArgv}`) {
   async function main() {
     const baseDir = path.join(__dirname, '..');
     const mappingPath = path.join(__dirname, 'section-file-mapping.json');
+
+    // QF-20260705-104 (seam 2): refuse to regenerate over a conflicted working tree.
+    const conflict = detectConflictedState(baseDir);
+    if (conflict) {
+      console.error('Refusing to regenerate: working tree is in a conflicted state.');
+      if (conflict.markered.length) console.error('  Conflict markers in: ' + conflict.markered.join(', '));
+      if (conflict.unmerged.length) console.error('  Unmerged (UU) files: ' + conflict.unmerged.join(', '));
+      console.error('Resolve the conflict before regenerating.');
+      process.exit(1);
+    }
 
     // Pre-regen lint hook (SD-PROTOCOL-LINTER-001). Aborts before file
     // writes when a severity=block violation is detected. All current seed

--- a/tests/unit/protocol-publication-pipeline.test.js
+++ b/tests/unit/protocol-publication-pipeline.test.js
@@ -11,7 +11,7 @@ import crypto from 'crypto';
 import { createRequire } from 'node:module';
 
 import { CLAUDEMDGeneratorV3, KNOWN_GENERATED_FILES, verifyFileContentHash } from '../../scripts/modules/claude-md-generator/index.js';
-import { parseOnlyFlag } from '../../scripts/generate-claude-md-from-db.js';
+import { parseOnlyFlag, detectConflictedState } from '../../scripts/generate-claude-md-from-db.js';
 
 const require = createRequire(import.meta.url);
 const { evaluatePublicationInvariants } = require('../../scripts/protocol-publication-audit.cjs');
@@ -143,5 +143,53 @@ describe('FR-4: --only scoped regeneration', () => {
     expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_COORDINATOR_DIGEST.md');
     expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_SOLOMON.md');
     expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_SOLOMON_DIGEST.md');
+  });
+});
+
+describe('QF-20260705-104: detectConflictedState (generator entry guard, seam 2)', () => {
+  it('clean CLAUDE*.md files, no git repo => null (no false positive)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-guard-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# Clean file\nno markers here\n');
+      expect(detectConflictedState(dir)).toBeNull();
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('a CLAUDE*.md file with a conflict marker is reported', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-guard-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'CLAUDE_CORE.md'), '# Body\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n');
+      const result = detectConflictedState(dir);
+      expect(result).not.toBeNull();
+      expect(result.markered).toEqual(['CLAUDE_CORE.md']);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('multiple markered files are all reported', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-guard-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '<<<<<<< HEAD\nx\n');
+      fs.writeFileSync(path.join(dir, 'CLAUDE_LEAD.md'), '<<<<<<< HEAD\ny\n');
+      fs.writeFileSync(path.join(dir, 'CLAUDE_PLAN.md'), '# clean\n');
+      const result = detectConflictedState(dir);
+      expect(result.markered.sort()).toEqual(['CLAUDE.md', 'CLAUDE_LEAD.md']);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('non-CLAUDE*.md files are ignored even with markers', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-guard-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'README.md'), '<<<<<<< HEAD\nx\n');
+      expect(detectConflictedState(dir)).toBeNull();
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('fails open on a git status error (no git repo) rather than throwing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-guard-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# clean, no markers\n');
+      expect(() => detectConflictedState(dir)).not.toThrow();
+      expect(detectConflictedState(dir)).toBeNull();
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
## Summary
- Adds a pre-commit STAGE 0.55 that blocks any commit while a `CLAUDE*.md` file carries an unresolved `^<<<<<<< ` conflict marker (working-tree scan, not just staged diff).
- Adds a `detectConflictedState(baseDir)` entry guard to `scripts/generate-claude-md-from-db.js` so the generator refuses to regenerate over a conflicted working tree (markers present, or `git status --porcelain` shows `UU` unmerged files) instead of silently overwriting it.
- Root cause: a stash-pop corruption left conflict markers in 16 generated `CLAUDE*.md` files for ~75 minutes, caught only by an incidental hash-probe (Solomon feedback cycle 11). Hooks don't decay across session generations; behavioral lessons do.
- Seam 3 from the ticket ("add a coverage-matrix cell") is deferred: `lib/governance/coverage-matrix.js` enumerates exactly 6 fixed surface classes mechanically regenerated from real sources; adding a 7th (`protocol_file`) is a materially larger, separately-scoped change (new enumerator + migration + tests) than this QF's ~30 LOC budget. Recommending it as its own follow-up QF/SD once scoped.

## Test plan
- [x] `npx vitest run tests/unit/protocol-publication-pipeline.test.js` — 20/20 passing (5 new tests covering `detectConflictedState`: clean tree, single marker, multiple markers, non-CLAUDE files ignored, fail-open on git errors)
- [x] `bash -n .husky/pre-commit` — syntax check passes
- [x] Manual smoke test: synthetic `CLAUDE_CORE.md` with real conflict markers correctly detected by the exact `grep -l '^<<<<<<< ' CLAUDE*.md` line used in the hook
- [x] Committed on this branch — the new pre-commit stage itself ran clean (no markers present in this repo's actual CLAUDE*.md files)
- [x] `npx eslint` on both changed JS files — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)