### PR TITLE
fix(QF-20260705-614): deviation-documentation sweep for MarketLens's 14 strategy-layer verdicts (CL-7)

### DIFF
--- a/scripts/one-off/qf-20260705-614-record-marketlens-strategy-deviations.mjs
+++ b/scripts/one-off/qf-20260705-614-record-marketlens-strategy-deviations.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * QF-20260705-614 — deviation-documentation sweep for MarketLens's 14 strategy-layer
+ * verdicts (cluster CL-7, SD-LEO-INFRA-MARKETLENS-REMEDIATION-TRIAGE-001).
+ *
+ * Every listed post_build_verdicts row is a keyword-heuristic false positive: the
+ * underlying artifact exists in venture_artifacts with substantial content, is out of
+ * adherence-rubric scope, and its PARTIAL/MISSING label came from a single-token
+ * comment/fixture collision (e.g. engine_exit_strategy matched process.exit()).
+ *
+ * Per the coordinator's pack amendment (2026-07-05T16:56Z, Bravo HIGH finding): the
+ * verdict engine short-circuits WEAK evidence to PARTIAL before its deviation branch
+ * (post-build-verdict-engine.js:317-325 — deviation lookup only fires at
+ * evidenceConfidence=NONE), so a deviation record can never flip a PARTIAL back. The
+ * deliverable is therefore the ledger row itself (recordDeviation, deviation-ledger.js),
+ * NOT deviation_artifact_id linkage on the verdict row — dispositions legally stay
+ * PARTIAL/MISSING. Zero product-repo (EHG venture) changes.
+ */
+import { recordDeviation } from '../../lib/eva/deviation-ledger.js';
+
+export const VENTURE_ID = 'ecbba50e-3c98-4493-9e77-1719cf6b6f00';
+export const WHY = 'strategy/launch-layer artifact, not product-wired by design — keyword-heuristic false positive (verdict engine short-circuits WEAK evidence to PARTIAL before its deviation branch; ledger row is the documented-deviation deliverable, not a disposition flip). SD-LEO-INFRA-MARKETLENS-REMEDIATION-TRIAGE-001 cluster CL-7.';
+
+// claim_ref -> optional per-artifact "instead" note. marketing_tagline gets a
+// content-refresh note per the ticket ("genuinely minimal at 99 chars") — a note only,
+// no product-repo content edit (zero product-repo changes is a hard constraint).
+export const CLAIM_REFS = [
+  'truth_idea_brief',
+  'truth_ai_critique',
+  'truth_competitive_analysis',
+  'truth_financial_model',
+  'engine_business_model_canvas',
+  'engine_exit_strategy',
+  'identity_gtm_sales_strategy',
+  'blueprint_financial_projection',
+  'system_devils_advocate_review',
+  'build_mvp_build',
+  'wireframe_screens',
+  'marketing_blog_draft',
+  'marketing_social_posts',
+  'marketing_tagline',
+];
+
+export const INSTEAD_NOTES = {
+  marketing_tagline: 'Content-refresh note: tagline artifact content is genuinely minimal (99 chars, "Uncover Market Truths. Price with Precision."). Flagged for a future content pass — not a product-wired gap.',
+};
+
+export async function main(supabase) {
+  const results = [];
+  for (const claimRef of CLAIM_REFS) {
+    const id = await recordDeviation(supabase, {
+      ventureId: VENTURE_ID,
+      artifactRef: claimRef,
+      instead: INSTEAD_NOTES[claimRef] ?? null,
+      why: WHY,
+      decidedBy: 'QF-20260705-614',
+      weight: 'declared-descope',
+    });
+    results.push({ claimRef, deviationRowId: id });
+    console.log(`recorded: ${claimRef} -> ${id}`);
+  }
+  console.log(`\nDone. ${results.length}/${CLAIM_REFS.length} deviation ledger rows recorded.`);
+  return results;
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`;
+if (isDirectRun) {
+  const { default: dotenv } = await import('dotenv');
+  dotenv.config();
+  const { createClient } = await import('@supabase/supabase-js');
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+  main(supabase).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/one-off/qf-20260705-614-record-marketlens-strategy-deviations.test.js
+++ b/tests/unit/one-off/qf-20260705-614-record-marketlens-strategy-deviations.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit test for the QF-20260705-614 remediation script (deviation-documentation sweep
+ * for MarketLens's 14 strategy-layer verdicts, cluster CL-7). Mocked supabase — no live
+ * DB writes; the actual 14 rows were already recorded via a one-time live run
+ * (verified via LEFT JOIN in the QF completion notes).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main, VENTURE_ID, CLAIM_REFS, WHY, INSTEAD_NOTES } from '../../../scripts/one-off/qf-20260705-614-record-marketlens-strategy-deviations.mjs';
+import { ARTIFACT_TYPES } from '../../../lib/eva/artifact-types.js';
+
+function createMockSupabase() {
+  const insertedRows = [];
+  const fromMock = vi.fn().mockImplementation(() => ({
+    insert: vi.fn().mockImplementation((row) => {
+      insertedRows.push(row);
+      return {
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { id: `deviation-${insertedRows.length}` }, error: null }),
+        }),
+      };
+    }),
+  }));
+  return { from: fromMock, _insertedRows: insertedRows };
+}
+
+describe('QF-20260705-614: CLAIM_REFS / constants', () => {
+  it('has exactly 14 unique claim_refs (cluster CL-7)', () => {
+    expect(CLAIM_REFS).toHaveLength(14);
+    expect(new Set(CLAIM_REFS).size).toBe(14);
+  });
+  it('WHY names the design intent, not a bug', () => {
+    expect(WHY).toMatch(/not product-wired by design/);
+  });
+  it('only marketing_tagline carries a content-refresh instead-note', () => {
+    expect(Object.keys(INSTEAD_NOTES)).toEqual(['marketing_tagline']);
+    expect(INSTEAD_NOTES.marketing_tagline).toMatch(/99 chars/);
+  });
+});
+
+describe('QF-20260705-614: main() (mocked supabase)', () => {
+  it('records one declared-descope deviation per claim_ref for the target venture', async () => {
+    const supabase = createMockSupabase();
+    const results = await main(supabase);
+
+    expect(results).toHaveLength(14);
+    expect(supabase._insertedRows).toHaveLength(14);
+    supabase._insertedRows.forEach((row, i) => {
+      expect(row.venture_id).toBe(VENTURE_ID);
+      expect(row.artifact_type).toBe(ARTIFACT_TYPES.BUILD_DEVIATION_RECORD);
+      expect(row.artifact_data.artifact_ref).toBe(CLAIM_REFS[i]);
+      expect(row.artifact_data.weight).toBe('declared-descope');
+      expect(row.artifact_data.why).toBe(WHY);
+      expect(row.is_current).toBe(false);
+    });
+  });
+
+  it('attaches the content-refresh note only to the marketing_tagline row', async () => {
+    const supabase = createMockSupabase();
+    await main(supabase);
+    const taglineRow = supabase._insertedRows.find((r) => r.artifact_data.artifact_ref === 'marketing_tagline');
+    const otherRow = supabase._insertedRows.find((r) => r.artifact_data.artifact_ref === 'truth_idea_brief');
+    expect(taglineRow.artifact_data.instead).toMatch(/99 chars/);
+    expect(otherRow.artifact_data.instead).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- All 14 `post_build_verdicts` rows in cluster CL-7 (venture `ecbba50e-3c98-4493-9e77-1719cf6b6f00`) are keyword-heuristic false positives -- the underlying artifact exists in `venture_artifacts` with substantial content, is out of adherence-rubric scope, and its PARTIAL/MISSING label came from a single-token comment/fixture collision (e.g. `engine_exit_strategy` matched `process.exit()`).
- Per the coordinator's pack amendment (Bravo HIGH finding, empirically reproduced): the verdict engine short-circuits WEAK evidence to PARTIAL *before* its deviation branch (`post-build-verdict-engine.js:317-325` -- deviation lookup only fires at `evidenceConfidence=NONE`), so a deviation record can never flip a PARTIAL back. The deliverable is therefore the ledger row itself (`recordDeviation`, `deviation-ledger.js`), NOT `deviation_artifact_id` linkage on the verdict row -- dispositions legally stay PARTIAL/MISSING.
- Ran `scripts/one-off/qf-20260705-614-record-marketlens-strategy-deviations.mjs` live against production: all 14 `declared-descope` deviation records written. `marketing_tagline` additionally carries a content-refresh note per the ticket ("genuinely minimal at 99 chars") -- a note only, zero product-repo (EHG venture) content edit.

## Test plan
- [x] Verified via LEFT JOIN (post-write): 14/14 target verdicts now have a matching `build_deviation_record` row in `venture_artifacts`
- [x] Total venture deviation-row count is exactly 15 (1 pre-existing, unrelated + 14 new) -- confirms the CL-1..CL-5 genuine-gap verdicts were not touched
- [x] Dispositions on all 14 verdicts remain PARTIAL/MISSING (unchanged), matching the pack amendment's explicit acceptance criteria
- [x] New `tests/unit/one-off/qf-20260705-614-record-marketlens-strategy-deviations.test.js` -- 5 tests (mocked supabase, no live DB access): CLAIM_REFS shape, WHY wording, instead-notes scoped to `marketing_tagline` only, insert-row shape per claim_ref
- [x] `npx vitest run` -- 21/21 passing (5 new + 16 pre-existing `deviation-ledger.test.js`, zero regressions)
- [x] `npx eslint` on both changed files -- no errors
- [x] Zero product-repo (EHG venture) changes

Generated with Claude Code