### PR TITLE
fix(QF-20260705-115): directed WA purge covers completed/terminal QF assignments

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1519,13 +1519,21 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // ~2.6h before its gate). Deferral is TRANSIENT: on gate, do NOT ack — the assignment
       // stays live and succeeds once not_before passes. Read error = FAIL CLOSED via
       // assignedSdFetchFailed, mirroring the QF-20260703-151 semantics above.
+      // QF-20260705-115: same query also carries `status`, so a directed assignment whose QF
+      // already reached a terminal status is purged HERE instead of relying on claim_sd's RPC
+      // rejection to land in TERMINAL_CLAIM_ERRORS (it doesn't always -- live specimen:
+      // QF-20260705-436 resurfaced 5+ checkins post-completion). Reuses `terminalStatus` so it
+      // takes the SAME ack+stale_assignment_purged branch as the SD terminal case below.
+      // Terminal set mirrors the existing quick_fixes staleness check at line ~1386.
       let qfDeferredUntil = null;
       if (!assignedSdFetchFailed && /^QF-/.test(sdKey)) {
         try {
           const { data: qfRow, error: qfErr } = await sb.from('quick_fixes')
-            .select('not_before').eq('id', sdKey).maybeSingle();
+            .select('status, not_before').eq('id', sdKey).maybeSingle();
           if (qfErr) {
             assignedSdFetchFailed = true;
+          } else if (qfRow && ['completed', 'cancelled', 'escalated'].includes(qfRow.status)) {
+            terminalStatus = qfRow.status;
           } else {
             const nb = qfRow && qfRow.not_before ? Date.parse(qfRow.not_before) : NaN;
             if (Number.isFinite(nb) && nb > Date.now()) qfDeferredUntil = qfRow.not_before;

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -59,7 +59,7 @@ describe('extractDirectedSd — structured directed fields only (finding #2)', (
 
 // resolveCheckin seam 1 — fake sb: session holds mySd; an unread WORK_ASSIGNMENT targets a
 // different SD. The assignment must surface on the resume result without dropping the claim.
-function fakeSb({ heldSd, assignmentSd, windDown, sdRow }) {
+function fakeSb({ heldSd, assignmentSd, windDown, sdRow, qfRow }) {
   return {
     rpc: () => Promise.resolve({ data: { success: true }, error: null }),
     from(table) {
@@ -71,6 +71,8 @@ function fakeSb({ heldSd, assignmentSd, windDown, sdRow }) {
           // QF-20260703-780: sdRow === null must mean "genuinely no row" (a QF-keyed or
           // phantom/typo'd-SD-keyed lookup), distinct from sdRow left unspecified (undefined).
           if (table === 'strategic_directives_v2') return Promise.resolve({ data: sdRow === undefined ? { status: 'in_progress' } : sdRow, error: null });
+          // QF-20260705-115: quick_fixes.status/not_before for the directed-QF terminal check.
+          if (table === 'quick_fixes') return Promise.resolve({ data: qfRow === undefined ? null : qfRow, error: null });
           return Promise.resolve({ data: null, error: null });
         },
         insert() { return Promise.resolve({ error: null }); },
@@ -486,6 +488,97 @@ describe('resolveCheckin — QF-20260703-780: terminal-class claim rejection ack
       expect(res.action).not.toBe('claimed_assignment');
       expect(res.assignment_claim_error).toBe('claimed_by_live_peer');
       expect(res.assignment_claim_terminal_purged).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});
+
+// QF-20260705-115: the SD-only lookup above (strategic_directives_v2) always misses for a
+// QF- key by design (QF-20260704-602), so a directed assignment whose QF already reached a
+// terminal status previously fell through to tryClaim() every checkin instead of being purged
+// directly -- live specimen: QF-20260705-436 resurfaced 5+ checkins post-completion. Fixed by
+// reading quick_fixes.status alongside the existing not_before query and reusing the SAME
+// stale_assignment_purged branch as the SD terminal case (no RPC round-trip needed).
+describe('resolveCheckin — QF-20260705-115: directed QF assignment purges on quick_fixes.status terminal', () => {
+  it('a QF-keyed assignment whose quick_fixes.status is completed is purged via stale_assignment_purged (no RPC call)', async () => {
+    const assignmentSd = 'QF-20260705-436';
+    const sb = fakeSb({ heldSd: null, sdRow: null, qfRow: { status: 'completed', not_before: null } });
+    let rpcCalled = false;
+    sb.rpc = () => { rpcCalled = true; return Promise.resolve({ data: { success: true }, error: null }); };
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-completed', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.stale_assignment_purged).toEqual({ sd: assignmentSd, status: 'completed' });
+      expect(res.assignment_claim_terminal_purged).toBeUndefined();
+      expect(rpcCalled).toBe(false);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it.each(['cancelled', 'escalated'])('a QF-keyed assignment whose quick_fixes.status is %s is also purged', async (status) => {
+    const assignmentSd = 'QF-20260705-999';
+    const sb = fakeSb({ heldSd: null, sdRow: null, qfRow: { status, not_before: null } });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-terminal-2', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.stale_assignment_purged).toEqual({ sd: assignmentSd, status });
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a QF-keyed assignment with a NON-terminal status (open/in_progress) still claims normally', async () => {
+    const assignmentSd = 'QF-20260705-222';
+    const sb = fakeSb({ heldSd: null, sdRow: null, qfRow: { status: 'open', not_before: null } });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-open', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('claimed_assignment');
+      expect(res.sd).toBe(assignmentSd);
+      expect(res.stale_assignment_purged).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a QF-keyed assignment with a future not_before still defers (unaffected by the status check)', async () => {
+    const assignmentSd = 'QF-20260705-333';
+    const future = new Date(Date.now() + 3600000).toISOString();
+    const sb = fakeSb({ heldSd: null, sdRow: null, qfRow: { status: 'open', not_before: future } });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-deferred', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.assignment_deferred_not_before).toEqual({ qf: assignmentSd, not_before: future });
+      expect(res.stale_assignment_purged).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a QF-keyed assignment with no quick_fixes row (null) falls through unchanged (byte-identical to before)', async () => {
+    const assignmentSd = 'QF-20260703-197';
+    const sb = fakeSb({ heldSd: null, sdRow: null, qfRow: null });
+    sb.rpc = () => Promise.resolve({ data: { success: false, error: 'sd_terminal_status' }, error: null });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-no-row', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.assignment_claim_terminal_purged).toEqual({ sd: assignmentSd, error: 'sd_terminal_status' });
+      expect(res.stale_assignment_purged).toBeUndefined();
     } finally {
       ws.getMessagesForSession = orig;
     }


### PR DESCRIPTION
## Summary
- worker-checkin.cjs's directed-assignment path fetches `strategic_directives_v2` only (intentional, QF-20260704-602 -- a `QF-` key always misses there), so a directed WORK_ASSIGNMENT whose QF already reached a terminal status fell through to `tryClaim()` every checkin instead of being purged directly. Live specimen: the QF-20260705-436 return-pin WA resurfaced 5+ times post-completion.
- Fix: the existing `quick_fixes.not_before` query (already run for `QF-` keys) now also reads `status`. When status is `completed`/`cancelled`/`escalated` (mirroring the terminal set already used elsewhere in the same file at the resume-path staleness check), it sets the same `terminalStatus` variable the SD branch uses -- so the assignment is ACKed and purged via the identical `stale_assignment_purged` breadcrumb, with no extra DB round-trip and no RPC call needed.
- Belt+braces verified empirically (not a code change, just confirmation): `claim_sd`'s live RPC (`database/migrations/20260704_claim_sd_client_gate_version.sql`) already returns `error=sd_terminal_status` for a terminal QF, which IS in `TERMINAL_CLAIM_ERRORS` -- confirmed via a direct RPC call against a real completed QF (`QF-20260705-104`). This JS-side fix adds a faster, defense-in-depth purge that does not depend on that RPC path being reached at all.

## Test plan
- [x] Empirical RPC check: `supabase.rpc('claim_sd', {p_sd_id: 'QF-20260705-104', ...})` against a real completed QF returns `error: 'sd_terminal_status'` (already covered by `TERMINAL_CLAIM_ERRORS`)
- [x] New tests in `tests/unit/worker-checkin-assignment-surfacing.test.js` (5 new, extending `fakeSb` with an optional `qfRow` param): completed/cancelled/escalated status all purge via `stale_assignment_purged` with NO RPC call; a non-terminal status (`open`) still claims normally; a future `not_before` still defers unaffected; a null `quick_fixes` row falls through byte-identical to the pre-existing behavior
- [x] `npx vitest run` on the assignment-surfacing + terminal-status-guard test files -- 45/45 passing, zero regressions
- [x] Broader worker-checkin test files (ranked/newest/fleet-critical window, callsign-collision) -- 27/27 passing, zero regressions
- [x] `npx eslint scripts/worker-checkin.cjs` -- no errors (the test file has one PRE-EXISTING unrelated unused-var lint error, confirmed via `git stash` before my change -- not introduced by this PR, and non-blocking since the pre-commit hook's eslint step is best-effort)

Generated with Claude Code