### PR TITLE
fix(QF-20260704-545): stale-session-sweep auto-cancels leaked SD-TEST-* fixtures unclaimed >24h

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -811,6 +811,51 @@ function checkNpmInstallLock() {
  * Conservative bar (holder gone or heartbeat > VERY_STALE) avoids yanking a live worker's claim.
  * Degrade-safe: query failure warns, never blocks the sweep.
  */
+// QF-20260704-545: harness test runs that die mid-flight leave SD-TEST-* fixtures
+// (draft/in_progress/active, never claimed) polluting the non-terminal queue and
+// coordinator-audit stuck-count indefinitely. Auto-cancel any SD-TEST-* row that's
+// been sitting unclaimed for >24h -- real SDs never use the SD-TEST- prefix
+// (isTestFixtureSdKey), so this can never touch production work.
+const TEST_FIXTURE_STALE_MS = 24 * 60 * 60 * 1000;
+async function cancelStaleTestFixtures(supabase, now, actions, warnings) {
+  try {
+    const cutoff = new Date(now.getTime() - TEST_FIXTURE_STALE_MS).toISOString();
+    const { data: staleFixtures, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status')
+      .ilike('sd_key', TEST_FIXTURE_SD_KEY_LIKE)
+      .in('status', ['draft', 'in_progress', 'active'])
+      .is('claiming_session_id', null)
+      .lt('updated_at', cutoff);
+
+    if (error) {
+      warnings.push('TEST_FIXTURE_SWEEP: ' + error.message);
+      return;
+    }
+
+    for (const fixture of (staleFixtures || [])) {
+      // Canonical cancellation shape (matches scripts/cancel-sd.js): top-level
+      // cancellation_reason column, not metadata -- never overwrite metadata here.
+      const { error: updateErr } = await supabase
+        .from('strategic_directives_v2')
+        .update({
+          status: 'cancelled',
+          current_phase: 'CANCELLED',
+          cancellation_reason: 'QF-20260704-545: auto-cancelled leaked SD-TEST-* fixture, unclaimed >24h',
+          claiming_session_id: null,
+          is_working_on: false,
+        })
+        .eq('id', fixture.id)
+        .is('claiming_session_id', null); // race guard: only if still unclaimed
+      if (!updateErr) {
+        actions.push('TEST_FIXTURE: auto-cancelled leaked ' + fixture.sd_key + ' (' + fixture.status + ', unclaimed >24h)');
+      }
+    }
+  } catch (fixtureErr) {
+    warnings.push('TEST_FIXTURE_SWEEP: ' + fixtureErr.message);
+  }
+}
+
 async function clearStaleQfClaims(supabase, now, actions, warnings) {
   const veryStaleSeconds = STALE_THRESHOLD_SECONDS * 3; // 15min = definitely dead
   try {
@@ -935,6 +980,10 @@ async function main() {
   // QF-20260525-211 (early-exit gap): reap orphaned QF claims BEFORE the early-return below,
   // so a stale QF claim is cleared even when zero SD-claiming sessions remain (fleet wound down).
   await clearStaleQfClaims(supabase, now, actions, warnings);
+
+  // QF-20260704-545: same early-exit-gap discipline -- cancel leaked SD-TEST-* fixtures
+  // before the early-return below, so they're reaped even with zero active sessions.
+  await cancelStaleTestFixtures(supabase, now, actions, warnings);
 
   // QF-20260703-076: session-independent dormancy watchdog -- prior backstops run INSIDE
   // a turn and can't observe a worker whose armed wakeup never fired. Detector-only.
@@ -2920,6 +2969,9 @@ module.exports.INTENT_PAYLOAD_KEYS = INTENT_PAYLOAD_KEYS;
 // FR-3 predicate (pure): the reserved SD-TEST- fixture namespace check.
 module.exports.isTestFixtureSdKey = isTestFixtureSdKey;
 module.exports.TEST_FIXTURE_SD_KEY_LIKE = TEST_FIXTURE_SD_KEY_LIKE;
+// QF-20260704-545: auto-cancel leaked SD-TEST-* fixtures (test seam).
+module.exports.cancelStaleTestFixtures = cancelStaleTestFixtures;
+module.exports.TEST_FIXTURE_STALE_MS = TEST_FIXTURE_STALE_MS;
 // SD-REFILL-00NFWJ6M: hard-cap pid-alive OS-truth fallback helpers (test seam).
 module.exports.isProcessRunning = isProcessRunning;
 module.exports.anyClaudeProcessRunning = anyClaudeProcessRunning;

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -819,12 +819,16 @@ function checkNpmInstallLock() {
 const TEST_FIXTURE_STALE_MS = 24 * 60 * 60 * 1000;
 async function cancelStaleTestFixtures(supabase, now, actions, warnings) {
   try {
+    // active-sd-predicate-parity: use the shared predicate rather than an inline
+    // .in('status', [...]) literal (PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001).
+    const { getActiveSDFilter } = await import('../lib/sd/active-sd-predicate.js');
     const cutoff = new Date(now.getTime() - TEST_FIXTURE_STALE_MS).toISOString();
-    const { data: staleFixtures, error } = await supabase
+    let query = supabase
       .from('strategic_directives_v2')
       .select('id, sd_key, status')
-      .ilike('sd_key', TEST_FIXTURE_SD_KEY_LIKE)
-      .in('status', ['draft', 'in_progress', 'active'])
+      .ilike('sd_key', TEST_FIXTURE_SD_KEY_LIKE);
+    query = getActiveSDFilter(query);
+    const { data: staleFixtures, error } = await query
       .is('claiming_session_id', null)
       .lt('updated_at', cutoff);
 
@@ -836,6 +840,8 @@ async function cancelStaleTestFixtures(supabase, now, actions, warnings) {
     for (const fixture of (staleFixtures || [])) {
       // Canonical cancellation shape (matches scripts/cancel-sd.js): top-level
       // cancellation_reason column, not metadata -- never overwrite metadata here.
+      // active_session_id:null co-clears alongside claiming_session_id:null, per the
+      // FR-1 release-site invariant (claim-lifecycle-hardening).
       const { error: updateErr } = await supabase
         .from('strategic_directives_v2')
         .update({
@@ -843,6 +849,7 @@ async function cancelStaleTestFixtures(supabase, now, actions, warnings) {
           current_phase: 'CANCELLED',
           cancellation_reason: 'QF-20260704-545: auto-cancelled leaked SD-TEST-* fixture, unclaimed >24h',
           claiming_session_id: null,
+          active_session_id: null,
           is_working_on: false,
         })
         .eq('id', fixture.id)

--- a/tests/unit/scripts/stale-session-sweep-test-fixture-cancel.test.js
+++ b/tests/unit/scripts/stale-session-sweep-test-fixture-cancel.test.js
@@ -14,39 +14,41 @@ const SOURCE_PATH = resolve(__dirname, '../../../scripts/stale-session-sweep.cjs
 const require = createRequire(import.meta.url);
 const sweep = require(SOURCE_PATH);
 
+// Chainable + thenable query-builder mock: select/ilike/in/or/is/lt (used by both the
+// SELECT path and getActiveSDFilter's real .in()/.or()/.is() calls) all return the SAME
+// chain object, which also resolves like a promise -- so it doesn't matter how many
+// chain calls the real production code makes before awaiting.
+function makeSelectChain(result) {
+  const chain = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.ilike = vi.fn().mockReturnValue(chain);
+  chain.in = vi.fn().mockReturnValue(chain);
+  chain.or = vi.fn().mockReturnValue(chain);
+  chain.is = vi.fn().mockReturnValue(chain);
+  chain.lt = vi.fn().mockReturnValue(chain);
+  chain.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+function makeUpdateChain(result) {
+  const chain = {};
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.is = vi.fn().mockReturnValue(chain);
+  chain.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
 function makeSupabase({ selectResult, updateResults = [] }) {
   let updateCallIndex = 0;
   return {
     from: vi.fn().mockImplementation((table) => {
       if (table !== 'strategic_directives_v2') throw new Error(`unexpected table: ${table}`);
       return {
-        select: vi.fn().mockReturnThis(),
-        ilike: vi.fn().mockReturnThis(),
-        in: vi.fn().mockReturnThis(),
-        is: vi.fn().mockImplementation(function () {
-          // First .is() call is part of the SELECT chain (claiming_session_id null filter);
-          // subsequent calls belong to per-row UPDATE chains.
-          if (this._isUpdateChain) {
-            const result = updateResults[updateCallIndex] ?? { error: null };
-            updateCallIndex++;
-            return Promise.resolve(result);
-          }
-          return this;
-        }),
-        lt: vi.fn().mockImplementation(function () {
-          return Promise.resolve(selectResult);
-        }),
-        update: vi.fn().mockImplementation(function (payload) {
-          this._lastUpdatePayload = payload;
-          const chain = {
-            eq: vi.fn().mockReturnThis(),
-            is: vi.fn().mockImplementation(() => {
-              const result = updateResults[updateCallIndex] ?? { error: null };
-              updateCallIndex++;
-              return Promise.resolve(result);
-            }),
-          };
-          return chain;
+        select: vi.fn().mockReturnValue(makeSelectChain(selectResult)),
+        update: vi.fn().mockImplementation(() => {
+          const result = updateResults[updateCallIndex] ?? { error: null };
+          updateCallIndex++;
+          return makeUpdateChain(result);
         }),
       };
     }),
@@ -74,21 +76,21 @@ describe('cancelStaleTestFixtures()', () => {
   });
 
   it('never queries by anything but the SD-TEST-% prefix', async () => {
+    let ilikeCol, ilikePattern;
     const fromSpy = vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnThis(),
-      ilike: vi.fn().mockImplementation((col, pattern) => {
-        expect(col).toBe('sd_key');
-        expect(pattern).toBe(sweep.TEST_FIXTURE_SD_KEY_LIKE);
-        return {
-          in: vi.fn().mockReturnThis(),
-          is: vi.fn().mockReturnThis(),
-          lt: vi.fn().mockResolvedValue({ data: [], error: null }),
-        };
+      select: vi.fn().mockReturnValue({
+        ilike: vi.fn().mockImplementation((col, pattern) => {
+          ilikeCol = col;
+          ilikePattern = pattern;
+          return makeSelectChain({ data: [], error: null });
+        }),
       }),
     });
     const supabase = { from: fromSpy };
     await sweep.cancelStaleTestFixtures(supabase, now, [], []);
     expect(fromSpy).toHaveBeenCalledWith('strategic_directives_v2');
+    expect(ilikeCol).toBe('sd_key');
+    expect(ilikePattern).toBe(sweep.TEST_FIXTURE_SD_KEY_LIKE);
   });
 
   it('does nothing (no throw, no actions) when zero stale fixtures are found', async () => {

--- a/tests/unit/scripts/stale-session-sweep-test-fixture-cancel.test.js
+++ b/tests/unit/scripts/stale-session-sweep-test-fixture-cancel.test.js
@@ -1,0 +1,122 @@
+/**
+ * QF-20260704-545: auto-cancel leaked SD-TEST-* fixtures (draft/in_progress/active,
+ * unclaimed) that a harness test run left behind mid-flight, once they've sat stale
+ * for >24h. Guard: only ever touches sd_key ilike 'SD-TEST-%' -- real SDs never use
+ * that prefix (isTestFixtureSdKey), so production work is structurally unreachable.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = resolve(__dirname, '../../../scripts/stale-session-sweep.cjs');
+const require = createRequire(import.meta.url);
+const sweep = require(SOURCE_PATH);
+
+function makeSupabase({ selectResult, updateResults = [] }) {
+  let updateCallIndex = 0;
+  return {
+    from: vi.fn().mockImplementation((table) => {
+      if (table !== 'strategic_directives_v2') throw new Error(`unexpected table: ${table}`);
+      return {
+        select: vi.fn().mockReturnThis(),
+        ilike: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        is: vi.fn().mockImplementation(function () {
+          // First .is() call is part of the SELECT chain (claiming_session_id null filter);
+          // subsequent calls belong to per-row UPDATE chains.
+          if (this._isUpdateChain) {
+            const result = updateResults[updateCallIndex] ?? { error: null };
+            updateCallIndex++;
+            return Promise.resolve(result);
+          }
+          return this;
+        }),
+        lt: vi.fn().mockImplementation(function () {
+          return Promise.resolve(selectResult);
+        }),
+        update: vi.fn().mockImplementation(function (payload) {
+          this._lastUpdatePayload = payload;
+          const chain = {
+            eq: vi.fn().mockReturnThis(),
+            is: vi.fn().mockImplementation(() => {
+              const result = updateResults[updateCallIndex] ?? { error: null };
+              updateCallIndex++;
+              return Promise.resolve(result);
+            }),
+          };
+          return chain;
+        }),
+      };
+    }),
+  };
+}
+
+describe('cancelStaleTestFixtures()', () => {
+  const now = new Date('2026-07-06T00:00:00Z');
+
+  it('auto-cancels a leaked SD-TEST-* fixture unclaimed >24h', async () => {
+    const supabase = makeSupabase({
+      selectResult: {
+        data: [{ id: 'fixture-1', sd_key: 'SD-TEST-ABC123-ORCH-001', status: 'in_progress' }],
+        error: null,
+      },
+      updateResults: [{ error: null }],
+    });
+    const actions = [];
+    const warnings = [];
+
+    await sweep.cancelStaleTestFixtures(supabase, now, actions, warnings);
+
+    expect(warnings).toEqual([]);
+    expect(actions.some(a => a.includes('SD-TEST-ABC123-ORCH-001') && a.includes('unclaimed >24h'))).toBe(true);
+  });
+
+  it('never queries by anything but the SD-TEST-% prefix', async () => {
+    const fromSpy = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockImplementation((col, pattern) => {
+        expect(col).toBe('sd_key');
+        expect(pattern).toBe(sweep.TEST_FIXTURE_SD_KEY_LIKE);
+        return {
+          in: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          lt: vi.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }),
+    });
+    const supabase = { from: fromSpy };
+    await sweep.cancelStaleTestFixtures(supabase, now, [], []);
+    expect(fromSpy).toHaveBeenCalledWith('strategic_directives_v2');
+  });
+
+  it('does nothing (no throw, no actions) when zero stale fixtures are found', async () => {
+    const supabase = makeSupabase({ selectResult: { data: [], error: null } });
+    const actions = [];
+    const warnings = [];
+    await sweep.cancelStaleTestFixtures(supabase, now, actions, warnings);
+    expect(actions).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('degrades safely (warns, does not throw) on a query error', async () => {
+    const supabase = makeSupabase({ selectResult: { data: null, error: { message: 'boom' } } });
+    const actions = [];
+    const warnings = [];
+    await expect(sweep.cancelStaleTestFixtures(supabase, now, actions, warnings)).resolves.toBeUndefined();
+    expect(warnings.some(w => w.includes('TEST_FIXTURE_SWEEP'))).toBe(true);
+  });
+
+  it('degrades safely (warns, does not throw) when supabase itself throws', async () => {
+    const supabase = { from: vi.fn().mockImplementation(() => { throw new Error('connection lost'); }) };
+    const actions = [];
+    const warnings = [];
+    await expect(sweep.cancelStaleTestFixtures(supabase, now, actions, warnings)).resolves.toBeUndefined();
+    expect(warnings.some(w => w.includes('TEST_FIXTURE_SWEEP'))).toBe(true);
+  });
+
+  it('exposes the 24h stale threshold as a named constant', () => {
+    expect(sweep.TEST_FIXTURE_STALE_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary
- Harness test runs that die mid-flight leave SD-TEST-* fixtures (draft/in_progress/active, never claimed) polluting the non-terminal queue and coordinator-audit stuck-count indefinitely. Evidence 2026-07-04: SD-TEST-MR2O0CTA-ORCH-001 + children sat unclaimed 1-2 days, requiring manual coordinator cancellation.
- New `cancelStaleTestFixtures()` step in `stale-session-sweep.cjs`, called alongside the existing `clearStaleQfClaims()` early-exit-gap reap. Only ever touches `sd_key ilike 'SD-TEST-%'` -- real SDs never use that prefix (`isTestFixtureSdKey`), so production work is structurally unreachable.
- Cancellation shape matches the canonical `scripts/cancel-sd.js` pattern (top-level `cancellation_reason` column, `current_phase='CANCELLED'`, clears `claiming_session_id`/`is_working_on`) -- never touches `metadata`.

## Test plan
- 6 new unit tests: real cancellation, SD-TEST-% query guard, no-op on zero stale fixtures, degrade-safe on query error, degrade-safe when supabase throws, threshold constant exposed.
- All 39 pre-existing `stale-session-sweep` tests re-run green, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)