### PR TITLE
fix(QF-20260704-300): map enforcement_rollout_default (section 620) into CLAUDE_CORE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 3785f2688283f35d -->
+<!-- file_content_hash: 9571664728ad3f85 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-07-05 1:57:26 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-06 9:13:25 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: ecf241d2d5e65307 -->
+<!-- file_content_hash: 71845e63e26d81a3 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -283,6 +283,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 2d378e9dc50f6067 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: e425823e12ed99c9 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 895688667caf77c6 -->
+<!-- file_content_hash: de52fc0869dac0ed -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -81,6 +81,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 9521b984ea381323 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: 9f28b5e1650a8cc1 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 1ae975cf096cdb95 -->
+<!-- file_content_hash: 17fe42551dd53842 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -796,6 +796,10 @@ node scripts/child-sd-preflight.js SD-XXX-001
 
 **Key Principle**: If you can split it without creating incomplete/broken intermediate states, you should split it.
 
+## Observe-Only-First Default for New Enforcement
+
+Any NEW enforcement mechanism (gate, PreToolUse guard, hook block, witness rung, dispatch fence) ships OBSERVE-ONLY by default: it logs/flags violations without blocking, for a calibration window, before promotion to binding. Promotion to binding requires an evidenced review of the observe-window output (false-positive rate examined and either zero or each FP class fixed). Per-SD exception (ship binding immediately) requires documented justification in the SD scope. Rationale (2026-07-04 evidence): ENF-17 shipped binding and false-positive-blocked legitimate sibling-repo work (QF-20260704-121), while the observe-only DUTY-8 charter probe surfaced a real wedged worker with zero collateral — observe-first catches calibration errors harmlessly. Provenance: Solomon simulation-tiers sweep #5 proposal -> Adam proposed -> coordinator co-signed (protocol default, composes with CONST-013 freeze and the ratified observe->binding discipline).
+
 ## Critical Term Definitions
 
 ## 🚫 CRITICAL TERM DEFINITIONS (BINDING)
@@ -1583,11 +1587,11 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 | Pattern ID | Category | Severity | Count | Trend | Top Solution |
 |------------|----------|----------|-------|-------|--------------|
-| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-HF-PLANTOEXEC-3e540545 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-HF-PLANTOLEAD-e8842331 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOEXEC-SD-EVA-F | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-RETRO-PLANTOLEAD-2ddf38d5 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-HF-PLANTOEXEC-3e540545 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
 
 ### Prevention Checklists
 
@@ -1613,18 +1617,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001: Symmetric + idempotent missing_protocol_improvements quality-warning lifecycle (PR #4285) [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 6/6/2026 | **Score**: 100
-
-**Key Improvements**:
-- The two quality_issues-writing triggers should arguably be unified so a single function owns quality...
-- A missing_protocol_improvements warning still does not survive a content-change INSERT because auto_...
-
-**Action Items**:
-- [ ] Add a lint/static check that flags any trigger reading or writing a column that ...
-- [ ] Open a follow-up SD to unify retrospectives quality_issues ownership into a sing...
-
-### 2. SD-LEO-FIX-SHOW-WHICH-STAGE-001: Show which stage is being viewed when browsing venture stage history — SD Completion Retrospective [QUALITY]
+### 1. SD-LEO-FIX-SHOW-WHICH-STAGE-001: Show which stage is being viewed when browsing venture stage history — SD Completion Retrospective [QUALITY]
 **Category**: USER_EXPERIENCE | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
@@ -1635,18 +1628,18 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] Update the testing-agent so that when it maps a passing test to a user story it ...
 - [ ] Document the add-prd --content integration_operationalization key whitelist (the...
 
-### 3. SD-LEO-INFRA-ATOMIC-FLEET-WORK-001: Atomic fleet work-leasing — the swept-twice bug was a deploy gap, not a code gap [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 6/5/2026 | **Score**: 100
+### 2. SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 SD Completion Retrospective [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- Migration deploy automation and auditing: committed does not equal applied, and there is currently n...
-- The "completed" definition for migration-bearing SDs should require a deploy gate; otherwise a write...
+- {"area":"EHG app listVentures() applies neither an is_demo nor a deleted_at predicate","prevention":...
+- {"area":"The pre-existing chairman_decisions parity assertion fails on the unmodified baseline","pre...
 
 **Action Items**:
-- [ ] In a fresh session, apply 20260605_atomic_lease_sweep_respect_inflight.sql via s...
-- [ ] Fix the false "check-readiness CI applies it" comment across migration templates...
+- [ ] Open a follow-up QF to add is_demo=false and deleted_at IS NULL predicates to th...
+- [ ] Track and fix the pre-existing chairman_decisions parity assertion that fails on...
 
-### 4. SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 Retrospective [QUALITY]
+### 3. SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 Retrospective [QUALITY]
 **Category**: DATABASE_SCHEMA | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
@@ -1657,16 +1650,27 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] DEPLOY: update the main checkout's .claude/settings.json (or reload settings) so...
 - [ ] POST-DEPLOY VERIFY: confirm the fleet-wide claim-sweep-mid-sub-agent dormancy is...
 
-### 5. SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 SD Completion Retrospective [QUALITY]
+### 4. SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001: Symmetric + idempotent missing_protocol_improvements quality-warning lifecycle (PR #4285) [QUALITY]
 **Category**: PROCESS_IMPROVEMENT | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- {"area":"EHG app listVentures() applies neither an is_demo nor a deleted_at predicate","prevention":...
-- {"area":"The pre-existing chairman_decisions parity assertion fails on the unmodified baseline","pre...
+- The two quality_issues-writing triggers should arguably be unified so a single function owns quality...
+- A missing_protocol_improvements warning still does not survive a content-change INSERT because auto_...
 
 **Action Items**:
-- [ ] Open a follow-up QF to add is_demo=false and deleted_at IS NULL predicates to th...
-- [ ] Track and fix the pre-existing chairman_decisions parity assertion that fails on...
+- [ ] Add a lint/static check that flags any trigger reading or writing a column that ...
+- [ ] Open a follow-up SD to unify retrospectives quality_issues ownership into a sing...
+
+### 5. SD_COMPLETION Retrospective: issue_patterns completion-side closure-loop (SD-FDBK-ENH-ISSUE-PATTERNS-CLOSURE-001) [QUALITY]
+**Category**: DATABASE_SCHEMA | **Date**: 6/6/2026 | **Score**: 100
+
+**Key Improvements**:
+- CLAIM-SWEEP + WORKTREE-REAP harness bug bit hard during a ~2.5h idle gap (operator stepped away, no ...
+- Observed ~4h clock skew between the node env (reporting 19:08Z) and the system clock (15:06Z), which...
+
+**Action Items**:
+- [ ] Investigate idle-gap claim-sweep coverage + node/system clock skew. The claim-sw...
+- [ ] Consider a detector that alerts if assigned-on-completed or NULL-assigned issue_...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1733,7 +1737,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 80ef34364eaa3ede -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: e066a1000e9ff21e -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-07-05 1:57:26 PM*
+*DIGEST generated: 2026-07-06 9:13:25 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 1f55a3f76347c554 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: f77ab37a7b337426 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-07-05 1:57:26 PM*
+*DIGEST generated: 2026-07-06 9:13:25 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: fb59efc526ceb88b -->
+<!-- file_content_hash: 3dbaebf9777e6b5b -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2120,6 +2120,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 6aee90e19be86489 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: 607300cae1368e0e -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-05 1:57:27 PM*
+*DIGEST generated: 2026-07-06 9:13:25 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e94932218eae07c8 -->
+<!-- file_content_hash: 9811730d2a3c8ae5 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1586,6 +1586,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 1d75e5d237d8c102 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: 7866355edfc87243 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-07-05 1:57:26 PM*
+*DIGEST generated: 2026-07-06 9:13:25 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 850f6828f535140a -->
+<!-- file_content_hash: 05d8a0e0a344139e -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2445,6 +2445,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 8b8cda16f271e9f8 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: 5fd09518b76f2988 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-07-05 1:57:26 PM*
+*DIGEST generated: 2026-07-06 9:13:25 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 075d839ce1952a87 -->
+<!-- file_content_hash: 94539b2c18c7e703 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-07-05 1:57:26 PM
+**Generated**: 2026-07-06 9:13:25 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -265,6 +265,6 @@ Solomon operates under the canonical crew-comms routing protocol: `docs/protocol
 
 ---
 
-*Generated from database: 2026-07-05*
+*Generated from database: 2026-07-06*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-05T17:57:26.553Z -->
-<!-- git_commit: b85ddb7e -->
-<!-- db_snapshot_hash: 3f05fd7b8de08edd -->
-<!-- file_content_hash: 73f3e57a7626f140 -->
+<!-- generated_at: 2026-07-06T01:13:25.434Z -->
+<!-- git_commit: 1d213d23 -->
+<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
+<!-- file_content_hash: f5a72988d560d314 -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,119 +1,119 @@
 {
-  "generated_at": "2026-07-05T17:57:26.553Z",
-  "git_commit": "b85ddb7e",
-  "db_snapshot_hash": "3f05fd7b8de08edd",
+  "generated_at": "2026-07-06T01:13:25.434Z",
+  "git_commit": "1d213d23",
+  "db_snapshot_hash": "7ac3577c8642ff48",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "3c1cca60f37ea3bb",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE.md"
+      "content_hash": "b5230dbdc4033cf8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 90152,
-      "estimated_tokens": 22538,
-      "content_hash": "4600e82c2bcf67a1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_CORE.md"
+      "chars": 91143,
+      "estimated_tokens": 22786,
+      "content_hash": "a9eb569cafdd6fcf",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65998,
       "estimated_tokens": 16500,
-      "content_hash": "f5dcb7d5e9f5d44f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_LEAD.md"
+      "content_hash": "116cefd0af84bf45",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 91700,
       "estimated_tokens": 22925,
-      "content_hash": "e02db0d23cf7b84b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_PLAN.md"
+      "content_hash": "a087c847286af85b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 86566,
       "estimated_tokens": 21642,
-      "content_hash": "fa30cd59ad12f97e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_EXEC.md"
+      "content_hash": "c2422666633309a1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
       "chars": 54280,
       "estimated_tokens": 13570,
-      "content_hash": "80d1550afca88060",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_ADAM.md"
+      "content_hash": "a5e8a547ef579632",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
       "chars": 22134,
       "estimated_tokens": 5534,
-      "content_hash": "461c117ab372f4d2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_COORDINATOR.md"
+      "content_hash": "01762753500f1025",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
       "chars": 45828,
       "estimated_tokens": 11457,
-      "content_hash": "c16db9e02ae6b99c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_SOLOMON.md"
+      "content_hash": "aa235e7a669bf5e7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "3dead13a1b8514c9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_DIGEST.md"
+      "content_hash": "d71aa773cb80e749",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11664,
       "estimated_tokens": 2916,
-      "content_hash": "da0cfdb4b49e426e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "6ed1a940fbf5ba54",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5551,
       "estimated_tokens": 1388,
-      "content_hash": "bfc4dd58bd36c706",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "a3ecf621e36de64d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8541,
       "estimated_tokens": 2136,
-      "content_hash": "4da8fb48f6f2bbee",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "c11e451ac8b1bbc2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10964,
       "estimated_tokens": 2741,
-      "content_hash": "b201e88a3ee386c8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "8a1086097289920a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 13068,
       "estimated_tokens": 3267,
-      "content_hash": "624e778964fd5659",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "76f706328c9f00bb",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 6076,
       "estimated_tokens": 1519,
-      "content_hash": "55818ea0c7f8b80e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "666a0062d7d79028",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 4705,
       "estimated_tokens": 1177,
-      "content_hash": "e561d72baa122500",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001-pr2\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "b92ba101e2fdd105",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260704-300\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -33,6 +33,7 @@
       "git_commit_guidelines",
       "pr_size_guidelines",
       "database_first_enforcement_expanded",
+      "enforcement_rollout_default",
       "supabase_operations",
       "database_column_reference",
       "pattern_search_guide",


### PR DESCRIPTION
## Summary
- DB section id=620 (`section_type=enforcement_rollout_default`, "Observe-Only-First Default for New Enforcement") was co-signed by the coordinator (Solomon sweep-5 via Adam, 2026-07-04) but never wired into `scripts/section-file-mapping.json` -- until this line landed, any regen would silently drop section 620 from rendered `CLAUDE_CORE.md`.
- Added the one mapping line under `CLAUDE_CORE.md` sections (right after `database_first_enforcement_expanded`) and ran a full regeneration so the generated markdown + manifest stay internally consistent.
- Note: the stale `qf/QF-20260704-300` branch that existed from the original claim (30+ hours old, 0 unique commits vs origin/main, zero unrelated diff other than being far behind) was deleted and recreated fresh off current `origin/main` before making this change.

## Test plan
- [x] `grep 'Observe-Only-First' CLAUDE_CORE.md` renders post-regen (line 799)
- [x] `node scripts/check-claude-md-drift.cjs` -- "OK no drift — generated CLAUDE_*.md match leo_protocol_sections (section digests aligned)"
- [x] Full regen (`node scripts/generate-claude-md-from-db.js`, all 16 files) so the manifest reflects a complete, consistent snapshot rather than a partial `--only` run
- [x] Confirmed `enforcement_rollout_default` is intentionally absent from `scripts/section-file-mapping-digest.json` too (its sibling `database_first_enforcement_expanded` isn't listed there either -- the DIGEST variant already excludes this family, no digest change needed)

Generated with Claude Code