### PR TITLE
feat(SD-LEO-INFRA-ADVERSARIAL-VERIFICATION-SWEEP-001): adversarial verification sweep tool + first full run

### DIFF
--- a/scripts/adversarial-verification-sweep.mjs
+++ b/scripts/adversarial-verification-sweep.mjs
@@ -62,6 +62,25 @@ const LEDGER_CATEGORY = 'verification_ledger';
 // flags it loudly rather than under-reporting the auditable total.
 const PAGE_LIMIT = 5000;
 
+/**
+ * Fetch EVERY row of a query by paginating in PAGE_SIZE chunks — complete by construction,
+ * so consumers need no truncation heuristics. Used for the reads whose COMPLETENESS is
+ * load-bearing (witnessed-merge set; ledger set-difference), where a silently short read
+ * flips verdicts rather than just under-counting.
+ */
+const PAGE_SIZE = 1000;
+export async function fetchAllRows(supabase, table, columns, applyFilters) {
+  const rows = [];
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    let q = supabase.from(table).select(columns).range(offset, offset + PAGE_SIZE - 1);
+    if (applyFilters) q = applyFilters(q);
+    const { data, error } = await q;
+    if (error) throw new Error(`${table} paginated query failed: ${error.message}`);
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE_SIZE) return rows;
+  }
+}
+
 // Machinery-class filter: title/description must smell like an automated moving part (something
 // that RUNS and has an observable side effect), because those are exactly the items whose "done"
 // status a green build cannot substantiate. Docs/CHANGELOG-only completions are excluded — they
@@ -223,10 +242,11 @@ async function assemble(outPath) {
   const merges = PLATFORM_REPOS.flatMap((r) =>
     defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, ghRunner),
   );
-  const { data: telemetryRows, error: telErr } = await supabase
-    .from('merge_witness_telemetry')
-    .select('repo, pr_number');
-  if (telErr) throw new Error('merge_witness_telemetry query failed: ' + telErr.message);
+  // Adversarial review of this very tool (PR #5666): this read was the one UNGUARDED query —
+  // a truncated witnessed-set silently reclassifies witnessed merges as unwitnessed (false
+  // REFUTE injections), the exact silent-truncation class this file guards against. Paginate
+  // to completeness instead of trusting any single-page cap.
+  const telemetryRows = await fetchAllRows(supabase, 'merge_witness_telemetry', 'repo, pr_number');
   const unwitnessed = detectUnwitnessedMerges(merges, telemetryRows).unwitnessed;
   const unwitnessedItems = unwitnessed.map((m) => ({
     work_key: `${m.repo}#${m.prNumber}`,
@@ -429,8 +449,11 @@ async function writeLedger(dispositionsPath) {
 
     if (existing && existing.length > 0) {
       const id = existing[0].id;
+      // Re-runs refresh the VERDICT fields but never clobber human triage state
+      // (PR #5666 review): status/severity are set only on first insert.
+      const { status: _s, severity: _sev, ...verdictOnly } = row;
       // eslint-disable-next-line no-await-in-loop
-      const { error: updErr } = await supabase.from('feedback').update(row).eq('id', id);
+      const { error: updErr } = await supabase.from('feedback').update(verdictOnly).eq('id', id);
       if (updErr) throw new Error(`ledger update failed for ${workKey}: ${updErr.message}`);
     } else {
       // eslint-disable-next-line no-await-in-loop
@@ -457,12 +480,12 @@ async function writeLedger(dispositionsPath) {
     }
   }
 
-  // Set-difference invariant: every backlog key must now have a ledger row.
-  const { data: ledgerRows, error: allErr } = await supabase
-    .from('feedback')
-    .select('metadata')
-    .eq('category', LEDGER_CATEGORY);
-  if (allErr) throw new Error('ledger set-difference read failed: ' + allErr.message);
+  // Set-difference invariant: every backlog key must now have a ledger row. Paginated
+  // (PR #5666 review): a single-page read would FALSE-FAIL this invariant once the ledger
+  // outgrows PostgREST's page cap across sweeps — fails closed, but loudly wrong.
+  const ledgerRows = await fetchAllRows(supabase, 'feedback', 'metadata', (q) =>
+    q.eq('category', LEDGER_CATEGORY),
+  );
   const ledgerKeys = new Set((ledgerRows || []).map((r) => r.metadata?.work_key).filter(Boolean));
   const missing = [...backlogKeys].filter((k) => !ledgerKeys.has(k));
 

--- a/scripts/adversarial-verification-sweep.mjs
+++ b/scripts/adversarial-verification-sweep.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+/**
+ * adversarial-verification-sweep.mjs — SD-LEO-INFRA-ADVERSARIAL-VERIFICATION-SWEEP-001.
+ *
+ * A three-phase adversarial sweep that takes a REFUTE stance toward "machinery-class" work that
+ * claims to be done: assemble a backlog of things-that-assert-they-work, classify each against
+ * real reachability/side-effect evidence (default to REFUTED when uncertain — a green checkmark is
+ * not evidence), then write a durable per-item verdict to a verification ledger.
+ *
+ *   PHASE ASSEMBLE  (--assemble --out <path>)  — read-only. Enumerate the denominator.
+ *   PHASE CLASSIFY  (exported pure classifyItem) — no I/O; the decision table.
+ *   PHASE LEDGER    (--write-ledger <dispositions.json>) — one durable feedback row per item.
+ *
+ * ── RUN LOCATION (hard requirement) ─────────────────────────────────────────────────────────────
+ * MUST be invoked with cwd = the EHG_Engineer repo ROOT. `import 'dotenv/config'` resolves `.env`
+ * from process.cwd(), and the assemble/ledger phases need SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
+ * plus the `gh` CLI on PATH. Running the worktree copy is fine (ESM relative imports resolve against
+ * the script's own location), but cwd must be the root, e.g.:
+ *   node .worktrees/SD-.../scripts/adversarial-verification-sweep.mjs --assemble --out sweep.json
+ *
+ * ── CONSUMING QUERY (coverage-matrix "sign-of-life" cells) ──────────────────────────────────────
+ * The coverage matrix reads back each item's live verdict from the ledger with:
+ *   SELECT metadata->>'work_key', metadata->>'disposition', metadata->>'evidence_pointer', updated_at
+ *   FROM feedback WHERE category='verification_ledger';
+ *
+ * ── WHY feedback, NOT coverage_matrix ───────────────────────────────────────────────────────────
+ * coverage_matrix carries CHECK constraints on BOTH `status` and `surface_class` that reject this
+ * ledger's vocabulary (disposition values like 'refuted_dormant'/'unverifiable' are not in its
+ * allowed sets) — verified against pg_constraint on 2026-07-05. The feedback table is the durable,
+ * queryable home whose category column is unconstrained, so category='verification_ledger' is a
+ * clean namespace that the consuming query above filters on.
+ *
+ * ── DEVIATIONS from the SD spec, forced by feedback CHECK/NOT-NULL constraints (verified 2026-07-05)
+ *   1. source_type: the spec asks for 'adversarial_sweep', but feedback_source_type_check REJECTS
+ *      that value (allowed set: manual_feedback|auto_capture|uat_failure|error_capture|
+ *      uncaught_exception|unhandled_rejection|manual_capture|todoist_intake|youtube_intake|
+ *      claude_code_intake|telegram|user_feedback). We write source_type='auto_capture' (closest
+ *      allowed value — this is automated tooling capture) and PRESERVE the intended provenance in
+ *      metadata.sweep_source_type='adversarial_sweep' so nothing is lost.
+ *   2. type: feedback.type is NOT NULL with no default and the spec omitted it → we set 'issue'.
+ *   3. source_application: NOT NULL with no default, spec omitted it → we set 'EHG_Engineer'.
+ * These are the minimum changes required for the ledger writer to actually succeed; the row's
+ * category/status/severity and the full metadata block match the spec exactly.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import {
+  PLATFORM_REPOS,
+  WITNESS_CUTOVER_ISO,
+  defaultFetchMergedPlatformPRs,
+  detectUnwitnessedMerges,
+} from '../lib/ship/witness-adoption.mjs';
+
+export const SWEPT_BY_SD = 'SD-LEO-INFRA-ADVERSARIAL-VERIFICATION-SWEEP-001';
+const WINDOW_DAYS = 30;
+const LEDGER_CATEGORY = 'verification_ledger';
+// Explicit high bound so the denominator is never SILENTLY truncated at PostgREST's default page
+// cap (~1000). If a query returns exactly this many rows the denominator is suspect — assemble
+// flags it loudly rather than under-reporting the auditable total.
+const PAGE_LIMIT = 5000;
+
+// Machinery-class filter: title/description must smell like an automated moving part (something
+// that RUNS and has an observable side effect), because those are exactly the items whose "done"
+// status a green build cannot substantiate. Docs/CHANGELOG-only completions are excluded — they
+// have no runtime to refute.
+export const MACHINERY_PATTERNS =
+  /watcher|writer|recorder|router|cron|hook|daemon|scheduler|sweep|gauge|detector|enforc|monitor|reconcil|listener|trigger|heartbeat|resurface|escalat/i;
+
+/** Pure: does this item's text describe an automated moving part? (RECALL stage) */
+export function isMachinery(title, description) {
+  return MACHINERY_PATTERNS.test(`${title || ''}\n${description || ''}`);
+}
+
+// PRECISION stage (added after the first real assemble run): the recall regex matched 67% of ALL
+// completed SDs (design passes, UI cosmetics, contract builds) because LEO prose is saturated with
+// verbs like "monitor"/"trigger"/"enforce". Machinery-CLASS means the COMPLETION SHIPPED an
+// unattended-execution artifact — something that runs on a schedule/event with an observable side
+// effect. Precision requires an artifact NOUN in the TITLE (not incidental prose) or file-path
+// evidence of a hook/cron/watcher artifact. Both recall and precision counts are emitted so the
+// denominator narrowing is auditable, never silent.
+const STRONG_TITLE_PATTERNS =
+  /\b(cron|daemon|watchdog|watcher|poller|listener|scheduler|sweeper?|sweep\b|heartbeat|liveness|reconciler?|resurfacer?|gauge|stop[- ]hook|(pre|post)tool(use)?[- ]?hook|sessionstart[- ]?hook|auto[- ]?(file[rs]?|refill|escalat\w*|resurface\w*|remediat\w*|merge[rs]?|validat\w*|purge[rs]?|reaper)|detector|enforcer|recorder|router|writer[s]?\b)\b/i;
+const FILE_EVIDENCE_PATTERNS =
+  /(scripts\/hooks\/|-cron\.|cron-|-watcher|watcher-|-daemon|daemon-|-sweep|sweep-|gauge-runner|scheduler|-reaper|heartbeat|stale-session|resurface)/i;
+const PRECISION_EXCLUDE_TITLE = /\b(design pass|design-pass|cosmetic|wireframe|walkthrough|changelog|readme)\b/i;
+
+/** Pure: PRECISION — did this completion ship an unattended-execution artifact? */
+export function isStrongMachinery(title, description, files) {
+  const t = title || '';
+  if (PRECISION_EXCLUDE_TITLE.test(t)) return false;
+  if (STRONG_TITLE_PATTERNS.test(t)) return true;
+  const fileText = Array.isArray(files) ? files.join('\n') : (files || '');
+  return FILE_EVIDENCE_PATTERNS.test(fileText);
+}
+
+/** Pure: docs/CHANGELOG-only completion — excluded from the machinery denominator (no runtime). */
+export function isDocsOnly(title, description) {
+  const t = title || '';
+  if (/^\s*docs?\s*(\(|:|\b)/i.test(t)) return true; // conventional-commit `docs(...)` / `docs:`
+  if (/^\s*changelog\b/i.test(t)) return true;
+  const text = `${t}\n${description || ''}`;
+  return /\b(changelog entry|documentation only|docs only|doc-only|docs-only)\b/i.test(text);
+}
+
+/**
+ * PHASE CLASSIFY — PURE. REFUTE stance: default to refuted/unverifiable whenever the evidence does
+ * not affirmatively prove a working side effect. A pass (`verified_working`) is only ever returned
+ * when reachability AND an observed side effect are both explicitly true.
+ *
+ * @param {{
+ *   reachable: true|false|null,
+ *   triggerFired: true|false|null,
+ *   sideEffectObserved: true|false|null,
+ *   safetyBar: 'read_only'|'fixture_safe'|'unsafe',
+ *   notes?: string,
+ *   reachabilityTraceComplete?: boolean   // discriminator for the reachable===null row of the table:
+ *                                         //   true  → trace ran and found no live path (dormant)
+ *                                         //   false/absent → trace never completed (unverifiable)
+ * }} checkResults
+ * @returns {{ disposition: string, reason?: string, evidence: object }}
+ */
+export function classifyItem(checkResults) {
+  const cr = checkResults || {};
+  const reachable = cr.reachable ?? null;
+  const triggerFired = cr.triggerFired ?? null;
+  const sideEffectObserved = cr.sideEffectObserved ?? null;
+  const safetyBar = cr.safetyBar ?? null;
+  const evidence = {
+    reachable,
+    triggerFired,
+    sideEffectObserved,
+    safetyBar,
+    notes: cr.notes ?? null,
+  };
+
+  // reachable === false → refuted_dormant
+  if (reachable === false) {
+    return { disposition: 'refuted_dormant', evidence };
+  }
+
+  // reachable === true && sideEffectObserved === false && triggerFired === true → refuted_broken
+  if (reachable === true && sideEffectObserved === false && triggerFired === true) {
+    return { disposition: 'refuted_broken', evidence };
+  }
+
+  // reachable === true && sideEffectObserved === true → verified_working (the ONLY pass)
+  if (reachable === true && sideEffectObserved === true) {
+    return { disposition: 'verified_working', evidence };
+  }
+
+  // reachable === true && (triggerFired===null || sideEffectObserved===null) && safetyBar==='unsafe'
+  //   → unverifiable (trigger unsafe to fire; instrumentation needed)
+  if (
+    reachable === true &&
+    (triggerFired === null || sideEffectObserved === null) &&
+    safetyBar === 'unsafe'
+  ) {
+    return {
+      disposition: 'unverifiable',
+      reason: 'trigger unsafe to fire; instrumentation needed',
+      evidence,
+    };
+  }
+
+  // reachable === null → refuted_dormant IF the reachability trace completed and found nothing,
+  //   else unverifiable with reason 'reachability trace incomplete'
+  if (reachable === null) {
+    if (cr.reachabilityTraceComplete === true) {
+      return { disposition: 'refuted_dormant', evidence };
+    }
+    return {
+      disposition: 'unverifiable',
+      reason: 'reachability trace incomplete',
+      evidence,
+    };
+  }
+
+  // Any remaining uncertain combination (REFUTE stance: never fall through to a pass).
+  return {
+    disposition: 'unverifiable',
+    reason: 'insufficient evidence to classify; defaulting to unverifiable under REFUTE stance',
+    evidence,
+  };
+}
+
+// ─── shared helpers ─────────────────────────────────────────────────────────────────────────────
+
+function requireSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error(
+      '[adversarial-sweep] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required — run from the EHG_Engineer ROOT so dotenv loads .env',
+    );
+    process.exit(1);
+  }
+  return createClient(url, key);
+}
+
+function cutoffIso(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+
+// ─── PHASE ASSEMBLE ─────────────────────────────────────────────────────────────────────────────
+
+async function assemble(outPath) {
+  const supabase = requireSupabase();
+
+  // Source (a): unwitnessed merges — REUSE the exact machinery gauge-runner.mjs's
+  // 'ship-witness-unwitnessed-merge' detector uses. NO reconcile call (assembly is side-effect-free).
+  const ghRunner = (args) => {
+    const r = spawnSync('gh', args, { encoding: 'utf8' });
+    return { code: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+  };
+  const merges = PLATFORM_REPOS.flatMap((r) =>
+    defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, ghRunner),
+  );
+  const { data: telemetryRows, error: telErr } = await supabase
+    .from('merge_witness_telemetry')
+    .select('repo, pr_number');
+  if (telErr) throw new Error('merge_witness_telemetry query failed: ' + telErr.message);
+  const unwitnessed = detectUnwitnessedMerges(merges, telemetryRows).unwitnessed;
+  const unwitnessedItems = unwitnessed.map((m) => ({
+    work_key: `${m.repo}#${m.prNumber}`,
+    backlog_source: 'unwitnessed_merge',
+    title: `Unwitnessed merge ${m.repo}#${m.prNumber}`,
+    description: `Platform merge ${m.repo}#${m.prNumber} (mergedAt ${m.mergedAt}) has ZERO merge_witness_telemetry row since the witness cutover (${WITNESS_CUTOVER_ISO}).`,
+    merged_at: m.mergedAt,
+  }));
+
+  // Source (b): machinery-class completions from SDs and QFs in the last WINDOW_DAYS.
+  const since = cutoffIso(WINDOW_DAYS);
+
+  const { data: sdRows, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, description, status, updated_at, sd_type, metadata')
+    .eq('status', 'completed')
+    .gte('updated_at', since)
+    .limit(PAGE_LIMIT);
+  if (sdErr) throw new Error('strategic_directives_v2 query failed: ' + sdErr.message);
+
+  const { data: qfRows, error: qfErr } = await supabase
+    .from('quick_fixes')
+    .select('id, title, description, status, completed_at')
+    .eq('status', 'completed')
+    .gte('completed_at', since)
+    .limit(PAGE_LIMIT);
+  if (qfErr) throw new Error('quick_fixes query failed: ' + qfErr.message);
+
+  if ((sdRows || []).length === PAGE_LIMIT || (qfRows || []).length === PAGE_LIMIT) {
+    console.error(
+      `[adversarial-sweep] WARNING: a source query returned exactly PAGE_LIMIT (${PAGE_LIMIT}) rows — ` +
+        'the denominator may be TRUNCATED. Paginate before trusting these counts.',
+    );
+  }
+
+  // Two-stage filter: RECALL (broad regex over title+description) narrows to candidates;
+  // PRECISION (artifact noun in TITLE, or hook/cron/watcher FILE evidence, minus doc/design
+  // classes) narrows to the sweep denominator. Both stage counts are emitted — the narrowing
+  // is auditable, never silent.
+  let sdRejectedRecall = 0;
+  let sdRejectedPrecision = 0;
+  const machinerySds = [];
+  for (const sd of sdRows || []) {
+    if (!(isMachinery(sd.title, sd.description) && !isDocsOnly(sd.title, sd.description))) {
+      sdRejectedRecall += 1;
+      continue;
+    }
+    const sdType = (sd.sd_type || '').toLowerCase();
+    const files = sd.metadata?.files_to_modify || sd.metadata?.files || null;
+    if (sdType === 'documentation' || sdType === 'docs' || !isStrongMachinery(sd.title, sd.description, files)) {
+      sdRejectedPrecision += 1;
+      continue;
+    }
+    machinerySds.push({
+      work_key: sd.sd_key || sd.id,
+      backlog_source: 'machinery_sd',
+      title: sd.title,
+      description: sd.description || null,
+      sd_id: sd.id,
+      completed_at: sd.updated_at,
+    });
+  }
+
+  let qfRejectedRecall = 0;
+  let qfRejectedPrecision = 0;
+  const machineryQfs = [];
+  for (const qf of qfRows || []) {
+    if (!(isMachinery(qf.title, qf.description) && !isDocsOnly(qf.title, qf.description))) {
+      qfRejectedRecall += 1;
+      continue;
+    }
+    if (!isStrongMachinery(qf.title, qf.description, null)) {
+      qfRejectedPrecision += 1;
+      continue;
+    }
+    machineryQfs.push({
+      work_key: qf.id,
+      backlog_source: 'machinery_qf',
+      title: qf.title,
+      description: qf.description || null,
+      completed_at: qf.completed_at,
+    });
+  }
+  const sdRejected = sdRejectedRecall + sdRejectedPrecision;
+  const qfRejected = qfRejectedRecall + qfRejectedPrecision;
+
+  const backlog = [...unwitnessedItems, ...machinerySds, ...machineryQfs];
+  const report = {
+    generated_at: new Date().toISOString(),
+    swept_by_sd: SWEPT_BY_SD,
+    window_days: WINDOW_DAYS,
+    window_since: since,
+    sources: {
+      unwitnessed_merges: { count: unwitnessedItems.length, items: unwitnessedItems },
+      machinery_sds: { count: machinerySds.length, items: machinerySds },
+      machinery_qfs: { count: machineryQfs.length, items: machineryQfs },
+    },
+    machinery_filter: {
+      sd_considered: (sdRows || []).length,
+      sd_accepted: machinerySds.length,
+      sd_rejected: sdRejected,
+      sd_rejected_recall: sdRejectedRecall,
+      sd_rejected_precision: sdRejectedPrecision,
+      qf_considered: (qfRows || []).length,
+      qf_accepted: machineryQfs.length,
+      qf_rejected: qfRejected,
+      qf_rejected_recall: qfRejectedRecall,
+      qf_rejected_precision: qfRejectedPrecision,
+      total_rejected: sdRejected + qfRejected,
+      possibly_truncated:
+        (sdRows || []).length === PAGE_LIMIT || (qfRows || []).length === PAGE_LIMIT,
+      page_limit: PAGE_LIMIT,
+    },
+    total_backlog: backlog.length,
+    backlog,
+  };
+
+  const json = JSON.stringify(report, null, 2);
+  if (outPath) writeFileSync(outPath, json);
+  process.stdout.write(json + '\n');
+
+  console.error(
+    `[adversarial-sweep] ASSEMBLE — unwitnessed merges: ${unwitnessedItems.length}, ` +
+      `machinery SDs: ${machinerySds.length}, machinery QFs: ${machineryQfs.length}, ` +
+      `filter rejections: ${sdRejected + qfRejected}, total backlog: ${backlog.length}` +
+      (outPath ? ` → ${outPath}` : ''),
+  );
+  return report;
+}
+
+// ─── PHASE LEDGER ───────────────────────────────────────────────────────────────────────────────
+
+/** Pure: build a durable feedback row from one dispositioned backlog item. */
+export function buildLedgerRow(item, nowIso = new Date().toISOString()) {
+  const workKey = item.work_key;
+  const disposition = item.disposition;
+  const evidence = item.evidence ?? null;
+  const evidenceSummary =
+    (evidence && (evidence.notes || JSON.stringify(evidence))) ||
+    item.unverifiable_reason ||
+    '(no evidence captured)';
+  return {
+    category: LEDGER_CATEGORY,
+    // DEVIATIONS (see header): type + source_application are NOT-NULL/no-default; source_type
+    // 'adversarial_sweep' is rejected by feedback_source_type_check → 'auto_capture' + metadata tag.
+    type: 'issue',
+    source_application: 'EHG_Engineer',
+    source_type: 'auto_capture',
+    title: `${workKey}: ${disposition}`,
+    description: `[${disposition}] ${workKey} — ${evidenceSummary}`,
+    status: 'new',
+    severity: 'low',
+    updated_at: nowIso,
+    metadata: {
+      disposition,
+      work_key: workKey,
+      evidence,
+      evidence_pointer: item.evidence_pointer ?? null,
+      filed_qf: item.filed_qf ?? null,
+      unverifiable_reason: item.unverifiable_reason ?? null,
+      backlog_source: item.backlog_source ?? null,
+      swept_by_sd: SWEPT_BY_SD,
+      sweep_source_type: 'adversarial_sweep', // preserved intended provenance (see header deviation #1)
+    },
+  };
+}
+
+async function writeLedger(dispositionsPath) {
+  const supabase = requireSupabase();
+  const raw = readFileSync(dispositionsPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const items = Array.isArray(parsed) ? parsed : parsed.items || parsed.backlog || [];
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error(`no dispositioned items found in ${dispositionsPath}`);
+  }
+  for (const it of items) {
+    if (!it.work_key) throw new Error('every dispositioned item requires a work_key');
+    if (!it.disposition) throw new Error(`item ${it.work_key} is missing a disposition`);
+  }
+
+  const nowIso = new Date().toISOString();
+  const histogram = {};
+  const backlogKeys = new Set();
+
+  for (const item of items) {
+    const workKey = item.work_key;
+    backlogKeys.add(workKey);
+    histogram[item.disposition] = (histogram[item.disposition] || 0) + 1;
+    const row = buildLedgerRow(item, nowIso);
+
+    // Idempotent: match an existing ledger row by category + metadata->>work_key, UPDATE not INSERT.
+    // eslint-disable-next-line no-await-in-loop -- sequential is intentional (small N, ordered logs)
+    const { data: existing, error: selErr } = await supabase
+      .from('feedback')
+      .select('id')
+      .eq('category', LEDGER_CATEGORY)
+      .filter('metadata->>work_key', 'eq', workKey)
+      .limit(1);
+    if (selErr) throw new Error(`ledger pre-select failed for ${workKey}: ${selErr.message}`);
+
+    if (existing && existing.length > 0) {
+      const id = existing[0].id;
+      // eslint-disable-next-line no-await-in-loop
+      const { error: updErr } = await supabase.from('feedback').update(row).eq('id', id);
+      if (updErr) throw new Error(`ledger update failed for ${workKey}: ${updErr.message}`);
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      const { error: insErr } = await supabase.from('feedback').insert(row);
+      if (insErr) throw new Error(`ledger insert failed for ${workKey}: ${insErr.message}`);
+    }
+
+    // Select-back verify (supabase-js silent-failure rule): the row must exist with our disposition.
+    // eslint-disable-next-line no-await-in-loop
+    const { data: verify, error: verErr } = await supabase
+      .from('feedback')
+      .select('id, metadata')
+      .eq('category', LEDGER_CATEGORY)
+      .filter('metadata->>work_key', 'eq', workKey)
+      .limit(1);
+    if (verErr) throw new Error(`ledger select-back failed for ${workKey}: ${verErr.message}`);
+    if (!verify || verify.length === 0) {
+      throw new Error(`ledger select-back found NO row for ${workKey} — write silently failed`);
+    }
+    if (verify[0].metadata?.disposition !== item.disposition) {
+      throw new Error(
+        `ledger select-back mismatch for ${workKey}: expected ${item.disposition}, got ${verify[0].metadata?.disposition}`,
+      );
+    }
+  }
+
+  // Set-difference invariant: every backlog key must now have a ledger row.
+  const { data: ledgerRows, error: allErr } = await supabase
+    .from('feedback')
+    .select('metadata')
+    .eq('category', LEDGER_CATEGORY);
+  if (allErr) throw new Error('ledger set-difference read failed: ' + allErr.message);
+  const ledgerKeys = new Set((ledgerRows || []).map((r) => r.metadata?.work_key).filter(Boolean));
+  const missing = [...backlogKeys].filter((k) => !ledgerKeys.has(k));
+
+  console.error('[adversarial-sweep] LEDGER disposition histogram:');
+  for (const [disp, n] of Object.entries(histogram).sort((a, b) => b[1] - a[1])) {
+    console.error(`  ${disp}: ${n}`);
+  }
+  console.error(
+    `[adversarial-sweep] set-difference check (backlog keys minus ledger keys): ${missing.length === 0 ? 'EMPTY (OK)' : 'NON-EMPTY: ' + missing.join(', ')}`,
+  );
+  if (missing.length > 0) {
+    throw new Error(`set-difference invariant violated: ${missing.length} backlog key(s) have no ledger row`);
+  }
+  return { histogram, written: items.length };
+}
+
+// ─── entrypoint ─────────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (process.argv.includes('--assemble')) {
+    await assemble(argValue('--out'));
+    return;
+  }
+  const ledgerPath = argValue('--write-ledger');
+  if (ledgerPath) {
+    await writeLedger(ledgerPath);
+    return;
+  }
+  console.error(
+    'Usage:\n' +
+      '  node scripts/adversarial-verification-sweep.mjs --assemble --out <backlog.json>\n' +
+      '  node scripts/adversarial-verification-sweep.mjs --write-ledger <dispositions.json>\n' +
+      '(run with cwd = EHG_Engineer ROOT so dotenv loads .env; gh CLI required for --assemble)',
+  );
+  process.exit(2);
+}
+
+// Only run when invoked directly, not when imported by the test suite.
+// argv[1] is undefined under `node --input-type=module -e "import(...)"` — guard it, or the
+// module CRASHES ON IMPORT for exactly the consumers the pure classifyItem export exists for.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    console.error('[adversarial-sweep] FAILED:', e?.message || e);
+    process.exit(1);
+  });
+}

--- a/scripts/adversarial-verification-sweep.mjs
+++ b/scripts/adversarial-verification-sweep.mjs
@@ -72,7 +72,14 @@ const PAGE_SIZE = 1000;
 export async function fetchAllRows(supabase, table, columns, applyFilters) {
   const rows = [];
   for (let offset = 0; ; offset += PAGE_SIZE) {
-    let q = supabase.from(table).select(columns).range(offset, offset + PAGE_SIZE - 1);
+    // Stable unique ordering makes offset pagination provably complete — without it,
+    // PostgREST guarantees no default order and a concurrent write during a multi-page
+    // read could skip/duplicate a row across a page boundary (PR #5666 review INFO).
+    let q = supabase
+      .from(table)
+      .select(columns)
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1);
     if (applyFilters) q = applyFilters(q);
     const { data, error } = await q;
     if (error) throw new Error(`${table} paginated query failed: ${error.message}`);

--- a/tests/unit/adversarial-sweep-classifier.test.js
+++ b/tests/unit/adversarial-sweep-classifier.test.js
@@ -1,0 +1,174 @@
+/**
+ * SD-LEO-INFRA-ADVERSARIAL-VERIFICATION-SWEEP-001 — classifyItem decision-table tests.
+ *
+ * Exercises the REAL exported classifyItem (no mocks). The classifier encodes a REFUTE stance:
+ * a pass ('verified_working') is only ever returned when reachability AND an observed side effect
+ * are both explicitly true. Every branch of the decision table is hit at least once, and a
+ * property test proves no null in reachable/sideEffectObserved can ever yield a pass.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyItem } from '../../scripts/adversarial-verification-sweep.mjs';
+
+describe('classifyItem — planted fixtures (spec a–e)', () => {
+  it('(a) planted dormant item (reachable:false) → refuted_dormant', () => {
+    const r = classifyItem({
+      reachable: false,
+      triggerFired: null,
+      sideEffectObserved: null,
+      safetyBar: 'read_only',
+      notes: 'no live invocation path',
+    });
+    expect(r.disposition).toBe('refuted_dormant');
+    expect(r.evidence.notes).toBe('no live invocation path');
+  });
+
+  it('(b) known-working item (reachable+trigger+sideEffect all true) → verified_working', () => {
+    const r = classifyItem({
+      reachable: true,
+      triggerFired: true,
+      sideEffectObserved: true,
+      safetyBar: 'fixture_safe',
+      notes: 'row written and read back',
+    });
+    expect(r.disposition).toBe('verified_working');
+  });
+
+  it('(c) reachable but side-effect absent after a real fire → refuted_broken', () => {
+    const r = classifyItem({
+      reachable: true,
+      triggerFired: true,
+      sideEffectObserved: false,
+      safetyBar: 'fixture_safe',
+      notes: 'fired the trigger, no row appeared',
+    });
+    expect(r.disposition).toBe('refuted_broken');
+  });
+
+  it('(d) reachable but unsafe to fire → unverifiable with non-empty reason', () => {
+    const r = classifyItem({
+      reachable: true,
+      triggerFired: null,
+      sideEffectObserved: null,
+      safetyBar: 'unsafe',
+      notes: 'would send real chairman email',
+    });
+    expect(r.disposition).toBe('unverifiable');
+    expect(typeof r.reason).toBe('string');
+    expect(r.reason.length).toBeGreaterThan(0);
+  });
+
+  it('(e) incomplete reachability trace (reachable:null) → unverifiable with reason', () => {
+    const r = classifyItem({
+      reachable: null,
+      triggerFired: null,
+      sideEffectObserved: null,
+      safetyBar: 'read_only',
+      notes: 'grep timed out',
+    });
+    expect(r.disposition).toBe('unverifiable');
+    expect(r.reason).toBe('reachability trace incomplete');
+  });
+});
+
+describe('classifyItem — full decision-table branch coverage', () => {
+  it('reachable===null AND trace completed with no live path → refuted_dormant', () => {
+    const r = classifyItem({
+      reachable: null,
+      triggerFired: null,
+      sideEffectObserved: null,
+      safetyBar: 'read_only',
+      reachabilityTraceComplete: true,
+      notes: 'trace ran, no caller found',
+    });
+    expect(r.disposition).toBe('refuted_dormant');
+  });
+
+  it('reachable===true with unresolved trigger and non-unsafe bar → unverifiable fallthrough', () => {
+    // Not refuted_broken (sideEffectObserved is null, not false), not verified_working, and
+    // safetyBar is not 'unsafe' so it misses that branch too — the REFUTE default must catch it.
+    const r = classifyItem({
+      reachable: true,
+      triggerFired: false,
+      sideEffectObserved: null,
+      safetyBar: 'read_only',
+      notes: 'reachable but never exercised',
+    });
+    expect(r.disposition).toBe('unverifiable');
+    expect(r.reason.length).toBeGreaterThan(0);
+  });
+
+  it('every disposition is producible; evidence passes through on every branch', () => {
+    const cases = [
+      { reachable: false },
+      { reachable: true, triggerFired: true, sideEffectObserved: false },
+      { reachable: true, triggerFired: true, sideEffectObserved: true },
+      { reachable: true, triggerFired: null, sideEffectObserved: null, safetyBar: 'unsafe' },
+      { reachable: null, reachabilityTraceComplete: true },
+      { reachable: null },
+    ];
+    const seen = new Set();
+    for (const c of cases) {
+      const r = classifyItem(c);
+      seen.add(r.disposition);
+      expect(r).toHaveProperty('evidence'); // evidence passthrough on all
+      expect(r.evidence).toHaveProperty('reachable');
+    }
+    expect(seen).toEqual(
+      new Set(['refuted_dormant', 'refuted_broken', 'verified_working', 'unverifiable']),
+    );
+  });
+
+  it('unverifiable branches always carry a non-empty reason', () => {
+    const unverifiableCases = [
+      { reachable: true, triggerFired: null, sideEffectObserved: null, safetyBar: 'unsafe' },
+      { reachable: null },
+      { reachable: true, triggerFired: false, sideEffectObserved: null, safetyBar: 'read_only' },
+    ];
+    for (const c of unverifiableCases) {
+      const r = classifyItem(c);
+      expect(r.disposition).toBe('unverifiable');
+      expect(typeof r.reason).toBe('string');
+      expect(r.reason.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('classifyItem — REFUTE property: null uncertainty never passes', () => {
+  it('any null in reachable OR sideEffectObserved never yields verified_working', () => {
+    const triState = [true, false, null];
+    const bars = ['read_only', 'fixture_safe', 'unsafe'];
+    let checked = 0;
+    for (const reachable of triState) {
+      for (const triggerFired of triState) {
+        for (const sideEffectObserved of triState) {
+          for (const safetyBar of bars) {
+            for (const traceComplete of [true, false, undefined]) {
+              const r = classifyItem({
+                reachable,
+                triggerFired,
+                sideEffectObserved,
+                safetyBar,
+                reachabilityTraceComplete: traceComplete,
+              });
+              checked += 1;
+              if (reachable === null || sideEffectObserved === null) {
+                expect(r.disposition).not.toBe('verified_working');
+              }
+              // verified_working is only ever legal when both are explicitly true.
+              if (r.disposition === 'verified_working') {
+                expect(reachable).toBe(true);
+                expect(sideEffectObserved).toBe(true);
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(200);
+  });
+
+  it('empty / undefined input does not throw and defaults to unverifiable', () => {
+    expect(classifyItem({}).disposition).toBe('unverifiable');
+    expect(classifyItem(undefined).disposition).toBe('unverifiable');
+  });
+});


### PR DESCRIPTION
## Summary
- **Tool** (`scripts/adversarial-verification-sweep.mjs`): three-phase J1 sweep — ASSEMBLE (reuses the ship-witness unwitnessed-merge gauge machinery + trailing-30d machinery completions; two-stage recall→precision filter with both stage counts emitted so the denominator narrowing is auditable; page-cap truncation flag), CLASSIFY (pure REFUTE-stance `classifyItem`: a pass requires reachable AND observed side effect both explicitly true — nulls can never pass), LEDGER (feedback-table rows `category=verification_ledger`, idempotent per work_key, every write select-back verified, empty-set-difference invariant enforced). Header documents the consuming query and why the ledger lives in `feedback` (coverage_matrix CHECK constraints on both `status` and `surface_class` reject the vocabulary — verified via pg_constraint).
- **Tests**: 11 classifier tests through the real logic — every decision-table branch, MISS/PASS fixture directions, and a 200+-combination null-never-passes property sweep.
- **First real run (results already in the DB)**: denominator **199** (1 unwitnessed merge + 162 machinery SDs + 36 machinery QFs; 899 auditable rejections across both filter stages) → **44 verified_working / 139 unverifiable (named reasons) / 16 refuted_dormant**, 100% dispositioned, set-difference EMPTY, **13 fix QFs filed** with reproducible evidence (split-verb: framed, not fixed). Highlights: never-applied distillation migration; `ADAM_GOVERNANCE_HEARTBEAT_V1` + `PROD_ERROR_SWEEP_LOOP_ENABLE` + `SOURCING_GAUGE_GAP_MINER_V1` all absent (flag-gated dormant estate); cloud-cap feeder frozen 20 days; retention loop not converging; watcher-of-watchers itself had no invoker.

## Test plan
- `npx vitest run tests/unit/adversarial-sweep-classifier.test.js`: 11/11 through real `classifyItem`, zero mocks.
- MISS/PASS smoke: planted dormant fixture → `refuted_dormant`; planted working fixture → `verified_working` (both recorded in the run log).
- Ledger select-back: 199 rows in `feedback` where `category='verification_ledger'`; refuted-without-QF count = 0.
- Verification evidence spot-checked 6/6 across slices (pg_constraint, information_schema, merge_witness_telemetry, live grep traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)