### PR TITLE
fix(QF-20260705-533): arm the watcher-of-watchers (STANDARD_LOOPS twice-hourly + liveness:watch alias)

### DIFF
--- a/package.json
+++ b/package.json
@@ -590,6 +590,7 @@
     "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",
     "retention:check": "node scripts/retention-enforce.js",
     "retention:apply": "node scripts/retention-enforce.js --apply",
+    "liveness:watch": "node scripts/periodic-liveness-watcher.mjs",
     "dr:rehearse": "node scripts/dr/restore-rehearsal.mjs",
     "dr:dump": "node scripts/dr/governance-dump.mjs",
     "schema:lint": "node scripts/lint/schema-reference-lint.mjs --diff",

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -180,6 +180,17 @@ export const STANDARD_LOOPS = [
   // rate-limited/deduped per category per day (metadata.sla_key), so an extra run is a no-op.
   { key: 'feedback-sla', label: 'Feedback-consumption SLA breach reminder (daily)', script: 'coordinator-feedback-sla-gauge.cjs', cron: '45 9 * * *',
     prompt: 'node scripts/coordinator-feedback-sla-gauge.cjs' },
+  // QF-20260705-533 (J1 adversarial sweep REFUTED-DORMANT): the watcher-of-watchers
+  // (periodic-liveness-watcher.mjs, SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001) shipped with NO
+  // scheduled invoker anywhere — the meta-watcher meant to catch dead periodic processes was
+  // itself a dead periodic process. Venue is DELIBERATELY the dev host (not GHA): its 2+-signal
+  // role_session checks read PID/process_alive_at signals that only exist where sessions run;
+  // a CI venue would degrade to single-signal reads (the false-dead class the script's own
+  // header warns about). Its __watcher_self__ self-stamp makes missed ticks self-evident on the
+  // same dashboard it renders — the tick-evidence mitigation the retention loop lacked.
+  // Twice-hourly off-minute cadence (cheap single registry scan; idempotent re-run).
+  { key: 'liveness-watcher', label: 'Periodic-process liveness watcher-of-watchers (twice-hourly, durable)', script: 'periodic-liveness-watcher.mjs', cron: '17,47 * * * *',
+    prompt: 'node scripts/periodic-liveness-watcher.mjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.


### PR DESCRIPTION
## Summary
- J1 adversarial-sweep REFUTED-DORMANT finding: `periodic-liveness-watcher.mjs` — the watcher-of-watchers — shipped with **no scheduled invoker anywhere** (the meta-watcher for dead periodic processes was itself a dead periodic process).
- Registers it in the coordinator `STANDARD_LOOPS` (twice-hourly, off-minute `17,47 * * * *`) + adds the `liveness:watch` npm alias.
- Venue rationale (from the sweep's own venue-mismatch lesson): deliberately the **dev host**, not GHA — its 2+-signal role_session checks read PID/`process_alive_at` signals that only exist where sessions run; a CI venue would degrade to the single-signal false-dead class the script's own header warns about. Missed ticks are self-evident via its `__watcher_self__` self-stamp (the tick evidence the retention loop lacked).

## Test plan
- Live run: evaluated 19 registry processes (17 OK, **2 OVERDUE surfaced immediately** — scheduler_round:stage_health and the eva-scheduler watcher self-row); `__watcher_self__.last_fired_at` stamped (select-back verified).
- Pre-commit smoke suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)