### PR TITLE
fix(QF-20260705-043): classifyDispatchIneligibility excludes venture-targeted remediation SDs

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -17,6 +17,10 @@
  *   - metadata.requires_human_action is truthy (a POSTGRES-001-class SD that a human must action), OR
  *   - metadata.not_before is a future timestamp (a time-gated SD-level hold; QF-20260705-585), OR
  *   - metadata.door_class_note === 'one_way' (Fable-tier-supervised re-architecture; QF-20260705-585), OR
+ *   - sd_key matches SD-LEO-FIX-REMEDIATION-* AND target_application is a venture (not
+ *     'EHG_Engineer') — an auto-filed Stage-20 quality-loop finding no EHG_Engineer worker can
+ *     action (QF-20260705-043; mirrors the coordinator belt exclusion isUnactionableRemediationSd,
+ *     lib/coordinator/sd-exclusion.mjs, SD-REFILL-00306WTS), OR
  *   - any referenced dependency is not status='completed' (dep-blocked).
  *
  * The first three axes are DB-FREE (decidable from an already-loaded SD row), so they live in the pure
@@ -64,7 +68,7 @@ const { lowerTierBacklog } = require('./tier-backlog.cjs');
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
  * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object }} [ctx]  when present, applies the claim-time fitness + tier axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'sd_deferred' | 'sd_terminal' | 'tier_stamp_missing' | 'above_worker_tier' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'tier_stamp_missing' | 'above_worker_tier' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
@@ -112,6 +116,22 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // exclude it. The clone determination happens ONCE at bridge creation (where the ventures query
   // already runs); a venture->clone JOIN deliberately stays OUT of this pure/synchronous/DB-free predicate.
   if (row.metadata && row.metadata.test_clone_build_tree === true) return 'test_clone_build_tree';
+  // QF-20260705-043: an auto-filed Stage-20 quality-loop remediation SD (fr-c-prime-generator)
+  // targeting a VENTURE (target_application e.g. 'EHG') rather than the fleet's own checkout
+  // (EHG_Engineer) cannot be actioned by a worker here — mirrors the coordinator's belt exclusion
+  // (isUnactionableRemediationSd, lib/coordinator/sd-exclusion.mjs, SD-REFILL-00306WTS), which
+  // excluded these from ranking but left them claimable via self-claim. Live incident: worker
+  // self-claimed SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005 (a fr-c-generator.test.js real-DB fixture
+  // row, fc000000- sentinel venture_id) within 0.5s of its creation; the test's own cleanup
+  // cancelled+deleted the row 2s later and sd-start.js crashed on the vanished row. CONSERVATIVE:
+  // requires BOTH the canonical key prefix AND a non-EHG_Engineer target — a remediation SD
+  // genuinely targeting EHG_Engineer (or with no target) is unaffected.
+  if (typeof row.sd_key === 'string' && /^SD-LEO-FIX-REMEDIATION-/.test(row.sd_key)) {
+    const target = row.target_application || (row.metadata && row.metadata.target_application);
+    if (typeof target === 'string' && target !== '' && target !== 'EHG_Engineer') {
+      return 'unactionable_venture_remediation';
+    }
+  }
   // SD-FDBK-INFRA-STALE-SESSION-SWEEP-001: a DEFERRED SD is parked off the belt (coordinator/Adam
   // deferral) and must NEVER be re-dispatched — without this the sweep CLAIM_FIX re-asserted a
   // deferred SD's claim onto a worker with a live worktree every tick, defeating the deferral and

--- a/tests/unit/claim-eligibility-venture-remediation.test.js
+++ b/tests/unit/claim-eligibility-venture-remediation.test.js
@@ -1,0 +1,49 @@
+// QF-20260705-043 — port the coordinator's venture-remediation belt exclusion
+// (isUnactionableRemediationSd, lib/coordinator/sd-exclusion.mjs, SD-REFILL-00306WTS) into
+// classifyDispatchIneligibility, the shared SSOT for worker self-claim + coordinator/sweep-PUSH.
+// Harness gap (live incident 2026-07-06): worker-checkin.cjs self-claimed
+// SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005 (a fr-c-generator.test.js real-DB fixture row,
+// target_application='EHG', fc000000- sentinel venture_id) within 0.5s of its creation; the
+// test's own afterEach cancelled+hard-deleted the row 2s later and sd-start.js crashed on the
+// vanished row (PostgREST .single() 0-row coercion error).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { classifyDispatchIneligibility } = require('../../lib/fleet/claim-eligibility.cjs');
+
+describe('classifyDispatchIneligibility — venture-remediation axis (QF-20260705-043)', () => {
+  it('a REMEDIATION SD targeting a venture (EHG) is NOT self-claimable', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005', target_application: 'EHG' }))
+      .toBe('unactionable_venture_remediation');
+  });
+  it('reads target_application from metadata when the top-level column is absent', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-UNIT-TEST-005', metadata: { target_application: 'EHG' } }))
+      .toBe('unactionable_venture_remediation');
+  });
+  it('a REMEDIATION SD genuinely targeting EHG_Engineer stays claimable', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', target_application: 'EHG_Engineer' })).toBeNull();
+  });
+  it('a REMEDIATION SD with no target_application falls through unchanged (fail-open)', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001' })).toBeNull();
+  });
+  it('a non-REMEDIATION key is unaffected regardless of target_application', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X-001', target_application: 'EHG' })).toBeNull();
+  });
+  it('the live incident specimen (SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005) is refused', () => {
+    const specimen = {
+      sd_key: 'SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005',
+      target_application: 'EHG',
+      metadata: { venture_id: 'fc000000-0000-4000-8000-b3f778cfb649', generated_by: 'fr-c-prime-generator' },
+    };
+    expect(classifyDispatchIneligibility(specimen)).toBe('unactionable_venture_remediation');
+  });
+});
+
+describe('classifyDispatchIneligibility — venture-remediation axis composition (QF-20260705-043)', () => {
+  it('prior axes (orchestrator/fixture/human-action) still win over the new venture-remediation check', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', sd_type: 'orchestrator', target_application: 'EHG' }))
+      .toBe('orchestrator_parent');
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', target_application: 'EHG', metadata: { requires_human_action: true } }))
+      .toBe('human_action_required');
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: the shared worker self-claim SSOT (`lib/fleet/claim-eligibility.cjs` `classifyDispatchIneligibility`) never ported the coordinator's `isUnactionableRemediationSd` belt exclusion (`lib/coordinator/sd-exclusion.mjs`, `SD-REFILL-00306WTS`): an auto-filed `SD-LEO-FIX-REMEDIATION-*` SD targeting a VENTURE (`target_application` != `EHG_Engineer`) was excluded from the coordinator's ranked/claimable count, but a worker's `self_claim` path could still claim it directly.
- **Live incident** (this session, 2026-07-06 ~02:56 UTC): `worker-checkin.cjs` self-claimed `SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005` (`target_application='EHG'`, `fc000000-...` sentinel `venture_id`, `generated_by='fr-c-prime-generator'`) within 0.5s of its creation. The row was a real-DB integration-test fixture from `tests/unit/lib/eva/quality-findings/fr-c-generator.test.js` (gated on `HAS_REAL_DB`, which is true whenever real Supabase creds are loaded — i.e. every fleet worker session). The test's own `afterEach` cancelled+hard-deleted the row ~2s later, and `node scripts/sd-start.js SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-005` then crashed (`Cannot coerce the result to a single JSON object` — PostgREST `.single()` on 0 rows) on the vanished row.
- **Fix**: add the same venture-remediation exclusion as a new `classifyDispatchIneligibility` axis (`unactionable_venture_remediation`) — CONSERVATIVE (requires both the canonical `SD-LEO-FIX-REMEDIATION-` key prefix AND a non-`EHG_Engineer` target), FAIL-OPEN, same shape as the existing `not_before_hold`/`one_way_door_requires_supervision` axes added in QF-20260705-585.
- This closes the self-claim side of a PAT-WRITER-CONSUMER-ASYMMETRY the file's own header already names as a recurring class (previously fixed once for orchestrator-parent exclusion, `SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001`).
- **Deliberately NOT done here**: the deeper test-isolation risk (a real-DB-touching test file able to inject/delete live rows in `strategic_directives_v2` against production, ambient-triggered by `.env` credential presence rather than an explicit opt-in) is a bigger architectural question flagged separately to the coordinator (`/signal harness-bug`) rather than redesigned inline — this QF closes the concrete claim-eligibility gap the incident exposed, not the test-harness's real-DB opt-in policy.

## Test plan
- [x] New `tests/unit/claim-eligibility-venture-remediation.test.js` (6 tests): venture-target excluded (top-level + metadata-sourced), EHG_Engineer-target stays claimable, no-target fails open, non-REMEDIATION key unaffected, live-incident specimen reproduced, prior-axis precedence (orchestrator/human-action still win)
- [x] Existing `tests/unit/claim-eligibility-not-before-door-class.test.js` (10 tests) — no regression
- [x] `tests/unit/worker-checkin-assignment-surfacing.test.js` + `tests/unit/coordinator-sd-exclusion.test.js` (74 tests) — no regression
- [x] Pre-commit hooks (smoke tests, DOCMON, LOC threshold, secret scan) all passed

Generated with Claude Code