### PR TITLE
fix(QF-20260705-478): run the LFA canonical backfill for real + leave run-evidence

### DIFF
--- a/scripts/backfill-canonical-lfa-from-executions.mjs
+++ b/scripts/backfill-canonical-lfa-from-executions.mjs
@@ -121,6 +121,20 @@ async function main() {
     else { written++; }
   }
   console.log(`[backfill-canonical-lfa] APPLIED: written=${written} skipped=${skipped} failed=${failed}`);
+
+  // QF-20260705-478: leave a durable run-evidence row so "did it run, and with what result" is
+  // answerable next time without re-deriving it from git blame — best-effort, never fails the run.
+  try {
+    const { error: evErr } = await sb.from('audit_log').insert({
+      event_type: 'backfill_run',
+      entity_type: 'script_run',
+      entity_id: 'backfill-canonical-lfa-from-executions',
+      metadata: { script: 'backfill-canonical-lfa-from-executions.mjs', corroborated: targets.length, cross_repo: crossRepo, written, skipped, failed },
+      severity: failed > 0 ? 'warning' : 'info',
+      created_by: 'backfill-canonical-lfa-from-executions.mjs',
+    });
+    if (evErr) console.warn('[backfill-canonical-lfa] run-evidence write skipped (non-fatal):', evErr.message);
+  } catch (e) { console.warn('[backfill-canonical-lfa] run-evidence write skipped (non-fatal):', e.message); }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary
- **Root cause**: adversarial sweep J1 REFUTED-DORMANT `SD-REFILL-00LTDQZ5` — the backfill CLI (`backfill-canonical-lfa-from-executions.mjs`, merged #5062) existed and was correct, but had apparently never been run for real: its own motivating case (`SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-E`) was still `is_ghost_completed=true`, and the tracked ghost population was 269.
- **Action**: ran the CLI for real. `--apply` wrote all 123 corroborated canonical LFA rows (`written=123 skipped=0 failed=0`). Re-verified the named target: `is_ghost_completed` flipped `true` → `false`.
- **Honest accounting**: the tracked ghost count (`v_sd_completion_integrity`) only moved `269` → `268`. Of the 123 rows written, 122 are `orchestrator`/`documentation`/`docs`-type SDs, which the ghost view **structurally exempts** by design (they have alternate completion paths, e.g. `complete_orchestrator_sd()`) — they were real historical LFA-canonical-record gaps worth reconciling, but were never counted in the 269 tally. Only the 1 `infrastructure`-type row (the named target) moves the tracked total. Both numbers — 123 historical records reconciled, 1 tracked ghost resolved — are true and non-contradictory; this PR reports both rather than picking whichever sounds better.
- **Run evidence**: adds a best-effort `audit_log` write (`event_type=backfill_run`) at the end of `--apply` so "did it run, and with what result" is answerable next time without git-blame archaeology.
- **Bug caught + fixed while wiring the evidence write**: the first attempt used `entity_id: null`, which silently violated `audit_log`'s `NOT NULL` constraint — `supabase-js` does not throw on this, and the original code never checked the returned `error`, so it would have failed silently forever. Fixed by checking `error` explicitly and using a self-describing `entity_id` (`'backfill-canonical-lfa-from-executions'`). Live-verified: the corrected write lands (row confirmed via direct query); a retroactive evidence row was also manually inserted for the real 123-write run (which predates this code existing).

## Test plan
- [x] Existing `tests/unit/backfill-canonical-lfa.test.js` (6 tests, pure `buildCanonicalLfaRow`/`isBackfillable` functions) — unchanged, still green
- [x] Live dry-run before: 123 corroborated ghosts (cross-repo: 90)
- [x] Live `--apply`: written=123 skipped=0 failed=0
- [x] Re-queried `v_sd_completion_integrity` for the named target: `is_ghost_completed` confirmed `false`
- [x] Re-ran `--apply` again: `corroborated ghosts: 0` (idempotent, nothing left to backfill)
- [x] Confirmed the `audit_log` run-evidence row lands (after fixing the NOT NULL bug)
- Note: `main()`'s DB-touching apply path is intentionally NOT unit-mocked (matches the script's pre-existing `@wire-check-exempt` design — "dry-run by default, --apply run manually under human/coordinator review, no production caller by design"); this PR instead live-verified the evidence-write behavior directly against the real DB, which is stronger evidence than a mock for this specific gap (a silent-failure bug a mock would not have caught unless it asserted on the `error` field, which the original code never checked).

Generated with Claude Code