### PR TITLE
fix(QF-20260705-181): record PROD_ERROR_SWEEP_LOOP_ENABLE activation as a chairman decision, not a silent flip

### DIFF
--- a/scripts/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.mjs
+++ b/scripts/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.mjs
@@ -1,0 +1,38 @@
+// QF-20260705-181: PROD_ERROR_SWEEP_LOOP_ENABLE was never flipped after
+// SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001 + -WIRE-001 shipped. The WIRE completion flag
+// (2026-06-21) explicitly recorded ACTIVATION as an operator/chairman decision, not
+// code-decidable ("Cannot be set from code") -- so this QF does NOT flip the flag. Instead
+// it records the durable, queryable disposition the QF's own text asks for ("record an
+// explicit deferred-with-trigger disposition") in leo_feature_flags, which had no
+// PROD_ERROR row at all until now.
+//
+// Idempotent: upserts on flag_key so re-running never duplicates the row.
+export const FLAG_KEY = 'PROD_ERROR_SWEEP_LOOP_ENABLE';
+
+export const DISPOSITION_ROW = {
+  flag_key: FLAG_KEY,
+  display_name: 'Production-error sweep loop (hourly, sources DRAFT corrective SDs)',
+  description: 'Gates whether prod-error-sweep-loop.yml (cron 40 * * * *) actually sweeps system_alerts and sources DRAFT corrective SDs, or SKIPs as a clean no-op (SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001 + -WIRE-001). Shipped default-OFF by design: the WIRE completion flag (2026-06-21) explicitly recorded ACTIVATION as an operator/chairman action, not code-decidable.',
+  is_enabled: false,
+  lifecycle_state: 'disabled',
+  risk_tier: 'medium',
+  owner_type: 'team',
+  owner_id: 'chairman',
+  is_temporary: false,
+  enablement_criteria: 'QF-20260705-181 (adversarial sweep J1): activation is a chairman/operator decision, not silently flippable by a worker. Trigger: chairman/operator sets PROD_ERROR_SWEEP_LOOP_ENABLE=true via gh variable set once ready to let hourly prod-error scans auto-source DRAFT SDs. Low near-term blast radius (system_alerts currently has only 2 rows). Coordinator recommended batching this with the sibling ADAM_GOVERNANCE_HEARTBEAT_V1 (QF-083, already activated) and SOURCING_GAUGE_GAP_MINER_V1 (QF-030, still open) as ONE activation-decision surface.',
+};
+
+export async function main(supabase) {
+  const { error } = await supabase.from('leo_feature_flags').upsert(DISPOSITION_ROW, { onConflict: 'flag_key' });
+  if (error) throw error;
+  return { flag_key: FLAG_KEY, recorded: true };
+}
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectRun) {
+  const { createClient } = await import('@supabase/supabase-js');
+  const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  main(sb).then((r) => console.log('[qf-20260705-181]', JSON.stringify(r))).catch((e) => { console.error('[qf-20260705-181] error:', e.message); process.exit(1); });
+}

--- a/tests/unit/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.test.js
+++ b/tests/unit/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.test.js
@@ -1,0 +1,49 @@
+/**
+ * Unit test for the QF-20260705-181 disposition-recording script. Mocked supabase — no live
+ * DB writes; the actual leo_feature_flags row was already recorded via a one-time live run.
+ * QF-20260705-181 deliberately does NOT flip PROD_ERROR_SWEEP_LOOP_ENABLE — the WIRE
+ * completion flag (2026-06-21) explicitly recorded activation as a chairman/operator
+ * decision, not code-decidable. This script records that disposition durably instead.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main, FLAG_KEY, DISPOSITION_ROW } from '../../../scripts/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.mjs';
+
+function createMockSupabase({ error = null } = {}) {
+  const upsertCalls = [];
+  const fromMock = vi.fn().mockImplementation(() => ({
+    upsert: vi.fn().mockImplementation((row, opts) => {
+      upsertCalls.push({ row, opts });
+      return Promise.resolve({ data: error ? null : [row], error });
+    }),
+  }));
+  return { from: fromMock, _upsertCalls: upsertCalls };
+}
+
+describe('QF-20260705-181: DISPOSITION_ROW', () => {
+  it('records the flag as disabled, NOT flipped to enabled', () => {
+    expect(DISPOSITION_ROW.flag_key).toBe(FLAG_KEY);
+    expect(DISPOSITION_ROW.is_enabled).toBe(false);
+    expect(DISPOSITION_ROW.lifecycle_state).toBe('disabled');
+  });
+  it('names the chairman as owner and states the trigger for reactivation', () => {
+    expect(DISPOSITION_ROW.owner_type).toBe('team');
+    expect(DISPOSITION_ROW.owner_id).toBe('chairman');
+    expect(DISPOSITION_ROW.enablement_criteria).toMatch(/chairman\/operator sets PROD_ERROR_SWEEP_LOOP_ENABLE=true/);
+  });
+});
+
+describe('QF-20260705-181: main() (mocked supabase)', () => {
+  it('upserts the disposition row keyed on flag_key (idempotent)', async () => {
+    const supabase = createMockSupabase();
+    const result = await main(supabase);
+    expect(result).toEqual({ flag_key: FLAG_KEY, recorded: true });
+    expect(supabase._upsertCalls).toHaveLength(1);
+    expect(supabase._upsertCalls[0].opts).toEqual({ onConflict: 'flag_key' });
+    expect(supabase._upsertCalls[0].row.flag_key).toBe(FLAG_KEY);
+  });
+
+  it('throws on a DB error instead of silently swallowing it', async () => {
+    const supabase = createMockSupabase({ error: { message: 'constraint violation' } });
+    await expect(main(supabase)).rejects.toThrow('constraint violation');
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: adversarial sweep J1 REFUTED-DORMANT, two SDs one root (`SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001` + `-WIRE-001`) — `prod-error-sweep-loop.yml` runs hourly (`cron 40 * * * *`) but the run step SKIPs unless repo var `PROD_ERROR_SWEEP_LOOP_ENABLE=true`, which has been unset since ship (2026-06-20/21). 0 SDs sourced since.
- **This QF's own text explicitly cautions**: "The activation is chairman-gated... do NOT silently flip if the gate was intentional." I investigated first: the `-WIRE-001` SD's own completion flag (2026-06-21, `type=needs_decision`) already recorded *"ACTIVATION is an operator/chairman action... Cannot be set from code."* This is a deliberate, documented gate, not an oversight — so **this QF does not flip the GitHub repo variable**.
- **Action taken instead**: records the durable, queryable disposition the QF asks for. New `leo_feature_flags` row for `PROD_ERROR_SWEEP_LOOP_ENABLE` (`is_enabled=false`, `lifecycle_state='disabled'`, `owner_type='team'`/`owner_id='chairman'`, `enablement_criteria` naming the exact trigger for activation). This closes the "no PROD_ERROR row in `leo_feature_flags`" gap the verification-ledger evidence flagged, mirroring the existing `ADAM_GOVERNANCE_HEARTBEAT_V1` row's shape (same table, same tracked-pending-flag pattern).
- **Context checked before deciding**: `system_alerts` currently has only 2 rows — low near-term blast radius if/when activated, noted in the disposition record. Also notes the coordinator's own recommendation (fleet-retro, this session) to batch this activation decision with sibling flags `ADAM_GOVERNANCE_HEARTBEAT_V1` (QF-083, already activated earlier this session) and `SOURCING_GAUGE_GAP_MINER_V1` (QF-030, still open, not touched by this PR).

## Test plan
- [x] New `tests/unit/one-off/qf-20260705-181-record-prod-error-sweep-activation-decision.test.js` (4 tests, mocked supabase): disposition row is disabled not enabled, owner/trigger fields correct, idempotent upsert keyed on `flag_key`, DB error propagates (not silently swallowed)
- [x] Live-verified the actual `leo_feature_flags` row lands (ran the script for real against the DB; re-ran to confirm the upsert is idempotent)
- [x] Confirmed `PROD_ERROR_SWEEP_LOOP_ENABLE` GitHub repo variable is deliberately left untouched (still absent) — this PR is a disposition record, not an activation

Generated with Claude Code