### PR TITLE
fix(QF-20260705-030): refute the flag-off premise; backfill stale pre-translation gauge-gap rows

### DIFF
--- a/scripts/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.mjs
+++ b/scripts/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.mjs
@@ -1,0 +1,62 @@
+// QF-20260705-030: adversarial sweep flagged SOURCING_GAUGE_GAP_MINER_V1 as "absent" and the
+// translateGapToBuildable layer as never having produced output. Investigation found the premise
+// was WRONG on both counts: the flag is hardcoded 'on' in
+// .github/workflows/sourcing-gauge-gap-miner-cron.yml (chairman-authorized go-live 2026-06-20,
+// docs/sourcing-engine-activation-runbook.md FR-3), and buildStagedRoadmapItem() already calls
+// translateGapToBuildable() unconditionally (lib/sourcing-engine/gauge-gap-miner.js:157).
+//
+// Real state: all 5 currently-weak VDR capabilities were staged on 2026-06-20 -- BEFORE the
+// TRANSLATEGAPTOBUILDABLE SD shipped (2026-06-22) -- so they predate metadata.translated and carry
+// raw capability labels. All 5 are already promoted_to_sd_key (SD-REFILL-00*), so the "0 translated
+// wave items" symptom has zero functional effect (nothing is stuck behind the RAW_LABEL_SOURCE
+// gate) -- but the metadata is historically inaccurate. mineGaugeGaps' idempotency (skip
+// already-staged capabilities) means these 5 rows will NEVER self-heal on a future cron tick, and
+// no NEW gap has appeared since (confirmed via a live dry-run: gaps=5 skipped_existing=5).
+//
+// This backfills the 5 stale rows with the buildable translation for provenance accuracy (same
+// shape as QF-20260705-478's LFA backfill) and leaves a durable audit_log verification record so a
+// future sweep does not re-flag this as dormant.
+import { translateGapToBuildable } from '../../lib/sourcing-engine/gauge-gap-miner.js';
+
+export async function main(supabase) {
+  const { data: rows, error } = await supabase
+    .from('roadmap_wave_items').select('id, metadata').eq('source_type', 'vdr_gauge');
+  if (error) throw error;
+
+  let backfilled = 0;
+  for (const row of rows || []) {
+    const md = row.metadata || {};
+    if (md.translated === true) continue; // already translated -- idempotent
+    const t = translateGapToBuildable({ capability: md.capability, status: md.gauge_status, nature: md.nature });
+    const { error: updErr } = await supabase.from('roadmap_wave_items')
+      .update({ title: t.title, metadata: { ...md, translated: true, description: t.scope } })
+      .eq('id', row.id);
+    if (updErr) throw updErr;
+    backfilled++;
+  }
+
+  const { error: evErr } = await supabase.from('audit_log').insert({
+    event_type: 'gauge_gap_translation_verification',
+    entity_type: 'script_run',
+    entity_id: 'qf-20260705-030-backfill-and-verify-gauge-gap-translation',
+    metadata: {
+      script: 'qf-20260705-030-backfill-and-verify-gauge-gap-translation.mjs',
+      backfilled, total_vdr_gauge_rows: (rows || []).length,
+      finding: 'SOURCING_GAUGE_GAP_MINER_V1 is ON (hardcoded in sourcing-gauge-gap-miner-cron.yml); translateGapToBuildable is correctly wired into buildStagedRoadmapItem. Zero NEW translated rows since ship is explained by zero new capability gaps (all 5 known gaps pre-date the translation SD and are already promoted_to_sd_key) -- not a dormancy bug.',
+    },
+    severity: 'info',
+    created_by: 'qf-20260705-030-backfill-and-verify-gauge-gap-translation.mjs',
+  });
+  if (evErr) console.warn('[qf-20260705-030] run-evidence write skipped (non-fatal):', evErr.message);
+
+  return { backfilled, total: (rows || []).length };
+}
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectRun) {
+  const { createClient } = await import('@supabase/supabase-js');
+  const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  main(sb).then((r) => console.log('[qf-20260705-030]', JSON.stringify(r))).catch((e) => { console.error('[qf-20260705-030] error:', e.message); process.exit(1); });
+}

--- a/tests/unit/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.test.js
+++ b/tests/unit/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.test.js
@@ -1,0 +1,75 @@
+/**
+ * Unit test for the QF-20260705-030 backfill script. Mocked supabase — no live DB writes.
+ * QF-20260705-030 found the adversarial sweep's premise wrong (the flag is ON, the translator is
+ * wired correctly) and instead backfills stale pre-translation rows for provenance accuracy.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main } from '../../../scripts/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.mjs';
+
+function createMockSupabase({ rows, updateError = null, auditError = null }) {
+  const updates = [];
+  const audits = [];
+  const fromMock = vi.fn().mockImplementation((table) => {
+    if (table === 'roadmap_wave_items') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: rows, error: null }),
+        }),
+        update: vi.fn().mockImplementation((patch) => {
+          updates.push(patch);
+          return { eq: vi.fn().mockResolvedValue({ error: updateError }) };
+        }),
+      };
+    }
+    if (table === 'audit_log') {
+      return {
+        insert: vi.fn().mockImplementation((row) => {
+          audits.push(row);
+          return Promise.resolve({ error: auditError });
+        }),
+      };
+    }
+    throw new Error(`unexpected table: ${table}`);
+  });
+  return { from: fromMock, _updates: updates, _audits: audits };
+}
+
+describe('QF-20260705-030: main() (mocked supabase)', () => {
+  it('backfills only rows missing metadata.translated, skips already-translated ones', async () => {
+    const rows = [
+      { id: 'a', metadata: { capability: 'X', gauge_status: 'unbuilt', nature: 'operational' } },
+      { id: 'b', metadata: { capability: 'Y', gauge_status: 'partial', nature: 'buildable', translated: true } },
+    ];
+    const supabase = createMockSupabase({ rows });
+    const result = await main(supabase);
+
+    expect(result).toEqual({ backfilled: 1, total: 2 });
+    expect(supabase._updates).toHaveLength(1);
+    expect(supabase._updates[0].metadata.translated).toBe(true);
+    expect(supabase._updates[0].metadata.capability).toBe('X'); // original metadata preserved
+    expect(supabase._updates[0].title).toMatch(/^Realize VDR capability: X/);
+  });
+
+  it('leaves a run-evidence audit_log row', async () => {
+    const rows = [{ id: 'a', metadata: { capability: 'X', gauge_status: 'unbuilt', nature: 'operational' } }];
+    const supabase = createMockSupabase({ rows });
+    await main(supabase);
+    expect(supabase._audits).toHaveLength(1);
+    expect(supabase._audits[0].event_type).toBe('gauge_gap_translation_verification');
+    expect(supabase._audits[0].metadata.backfilled).toBe(1);
+  });
+
+  it('is a no-op (0 backfilled) when all rows are already translated', async () => {
+    const rows = [{ id: 'a', metadata: { capability: 'X', translated: true } }];
+    const supabase = createMockSupabase({ rows });
+    const result = await main(supabase);
+    expect(result).toEqual({ backfilled: 0, total: 1 });
+    expect(supabase._updates).toHaveLength(0);
+  });
+
+  it('throws on an update error instead of silently swallowing it', async () => {
+    const rows = [{ id: 'a', metadata: { capability: 'X' } }];
+    const supabase = createMockSupabase({ rows, updateError: { message: 'boom' } });
+    await expect(main(supabase)).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- **Adversarial sweep's stated premise**: `SOURCING_GAUGE_GAP_MINER_V1` flag absent, `translateGapToBuildable` layer never produced output — implied fix: "set the flag or record deferral."
- **Investigated first, premise found WRONG on both counts**:
  - `SOURCING_GAUGE_GAP_MINER_V1` is hardcoded `'on'` directly in `.github/workflows/sourcing-gauge-gap-miner-cron.yml`'s `env:` block — part of the chairman-authorized sourcing-engine go-live (2026-06-20, see `docs/sourcing-engine-activation-runbook.md` FR-3). It was never meant to be a GitHub repo variable, which is why `gh variable list` reported it "absent" — that was the wrong signal to check.
  - `translateGapToBuildable` **is** correctly wired: `buildStagedRoadmapItem()` (`lib/sourcing-engine/gauge-gap-miner.js:157`) calls it unconditionally and always stamps `metadata.translated=true` on newly staged rows.
- **Real, narrower finding**: all 5 currently-weak VDR capabilities were staged on 2026-06-20 — 2 days *before* the translation SD shipped (2026-06-22) — so they predate `metadata.translated` and carry raw capability-label titles. All 5 already have `promoted_to_sd_key` set (`SD-REFILL-00*`), so this has **zero functional effect** (nothing is stuck behind the `RAW_LABEL_SOURCE` funnel gate) — but the metadata was historically inaccurate, and `mineGaugeGaps`'s idempotency (skip already-staged capabilities) means these rows would never self-heal on their own. Live-verified via dry-run: `gaps=5 skipped_existing=5` — zero new capability gaps have appeared since ship, which fully explains "zero output ever" without any code defect.
- **Action**: backfills the 5 stale rows with the buildable translation (title + `metadata.translated=true` + `metadata.description`), same shape as `QF-20260705-478`'s LFA backfill, and leaves a durable `audit_log` verification record documenting the refuted premise so a future adversarial sweep doesn't re-flag this as dormant.

## Test plan
- [x] New `tests/unit/one-off/qf-20260705-030-backfill-and-verify-gauge-gap-translation.test.js` (4 tests, mocked supabase): backfills only untranslated rows, leaves run-evidence, no-op when already translated, DB error propagates
- [x] Live-verified: ran the script for real, backfilled 5/5 rows, confirmed titles/metadata updated correctly via direct query
- [x] Live-verified the `audit_log` verification row lands with the refuted-premise finding
- [x] Confirmed via a live dry-run of `gauge-gap-miner-sweep.mjs` that the miner is alive and correctly reports `gaps=5 skipped_existing=5` (no new gaps, not a dormancy bug)

Generated with Claude Code