### PR TITLE
fix(QF-20260705-797): schedule solomon-ledger-pending-resurface

### DIFF
--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -75,6 +75,13 @@ export const COMPOSED_CORES = [
   { key: 'relay-drain', script: 'coordinator-relay-drain.cjs', args: ['scripts/coordinator-relay-drain.cjs'], quiescentSkip: false },
   // FR-3: cheap read + fail-open write; valuable exactly when quiet for the same reason.
   { key: 'relay-drop-gauge', script: 'coordinator-relay-drop-gauge.cjs', args: ['scripts/coordinator-relay-drop-gauge.cjs'], quiescentSkip: false },
+  // QF-20260705-797: solomon-ledger-pending-resurface.cjs shipped with no scheduled invoker
+  // anywhere (npm script only) -- 0 session_coordination rows ever emitted. Cheap (single SELECT
+  // + per-row dedup check), fail-open (no active Adam -> no-op), and self-rate-limits to once per
+  // stale ledger row per day via its own payload.dedup_key, so running it every tick is safe. NOT
+  // quiescentSkip: an aged pending recommendation is exactly as stale-and-worth-surfacing during a
+  // quiet fleet window as during an active one.
+  { key: 'solomon-ledger-resurface', script: 'solomon-ledger-pending-resurface.cjs', args: ['scripts/solomon-ledger-pending-resurface.cjs'], quiescentSkip: false },
 ];
 
 /** Build the fail-soft core list for the current mode (quiescent skips the expensive cores). */

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -191,6 +191,15 @@ export const STANDARD_LOOPS = [
   // Twice-hourly off-minute cadence (cheap single registry scan; idempotent re-run).
   { key: 'liveness-watcher', label: 'Periodic-process liveness watcher-of-watchers (twice-hourly, durable)', script: 'periodic-liveness-watcher.mjs', cron: '17,47 * * * *',
     prompt: 'node scripts/periodic-liveness-watcher.mjs' },
+  // QF-20260705-797 (J1 adversarial sweep REFUTED-DORMANT, scoped to FR-1 of
+  // SD-LEO-FIX-SOLOMON-RECOMMENDATION-GUARDRAIL-001): solomon-ledger-pending-resurface.cjs
+  // shipped with an npm script only — no scheduled invoker anywhere — so aged
+  // solomon_advice_outcome_ledger rows never resurfaced into Adam's inbox. Cheap (single SELECT
+  // + per-row dedup check), fail-open (no active Adam session -> no-op), and self-rate-limits
+  // to once per stale ledger row per day via its own payload.dedup_key, so a frequent tick is
+  // safe. Also composed into scripts/coordinator-quiet-tick.mjs's COMPOSED_CORES.
+  { key: 'solomon-ledger-resurface', label: 'Solomon ledger-pending resurface (aged advice-outcome rows -> Adam inbox)', script: 'solomon-ledger-pending-resurface.cjs', cron: '13,43 * * * *',
+    prompt: 'node scripts/solomon-ledger-pending-resurface.cjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.


### PR DESCRIPTION
## Summary
- `solomon-ledger-pending-resurface.cjs` shipped with an npm alias only — no scheduled invoker anywhere (grep of STANDARD_LOOPS/coordinator-quiet-tick/.github found none). 0 `session_coordination` rows with `payload.kind=solomon_ledger_pending_resurface` since the source SD completed.
- Wires it into `STANDARD_LOOPS` (`scripts/coordinator-startup-check.mjs`) and `COMPOSED_CORES` (`scripts/coordinator-quiet-tick.mjs`), matching the exact pattern used for QF-20260705-533's periodic-liveness-watcher fix.
- Live-verified: running it now resurfaced 50 genuinely stale (80-87h old) `solomon_advice_outcome_ledger` rows into Adam's inbox — confirmed via direct `session_coordination` count query.

## Test plan
- [x] `npx vitest run tests/unit/coordinator/quiet-tick-loop-parity.test.js tests/unit/solomon-ledger-pending-resurface.test.js` — 11/11 passing
- [x] `node scripts/coordinator-quiet-tick.mjs --dry-run` — new core composes cleanly (`solomon-ledger-resurface:ok`)
- [x] Live run of the script confirmed 50 rows landed in `session_coordination`
- [x] `npm run schema:lint` (diff) — 0 violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>