### PR TITLE
fix(QF-20260705-359): durable cron for fleet-rollcall; leave worker-spawn-executor un-wired (chairman/host-only)

### DIFF
--- a/.github/workflows/fleet-rollcall-cron.yml
+++ b/.github/workflows/fleet-rollcall-cron.yml
@@ -1,0 +1,60 @@
+name: "Fleet roll-call (durable cron)"
+
+# QF-20260705-359 (adversarial sweep J1 REFUTED-DORMANT SD-LEO-FIX-POST-CRASH-FLEET-001)
+#
+# fleet-rollcall.cjs (multi-signal role/worker liveness probe, QF-20260703-958) shipped with
+# zero scheduled invoker -- it only ran if a human remembered to run it after a crash, which
+# defeats the point of crash-recovery visibility. This durable cron gives a periodic,
+# queryable liveness report without relying on human memory.
+#
+# READ-ONLY / SAFE: this script only queries claude_sessions + session_coordination and
+# prints a report (console.log) -- no writes, no process spawning, no side effects. Safe to
+# run on a cadence with no operator gate.
+#
+# The SIBLING finding in this QF (SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001,
+# scripts/fleet/worker-spawn-executor.cjs) is DELIBERATELY NOT wired here: that script's own
+# header says "OPERATOR GATE (Stage 2, do NOT enable autonomously)" -- its live spawn path
+# requires a chairman/operator to host-validate the exact `claude` CLI invocation on THEIR
+# OWN machine and register a LOCAL Windows Task Scheduler entry (the SD's own converged
+# design explicitly rules out GitHub Actions as a host: "GHA cannot launch interactive bg
+# workers against the local FS"). That is outside any fleet worker's technical reach and
+# outside this QF's scope -- see the PR description for the full disposition.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rollcall:
+    name: Fleet roll-call liveness probe (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run fleet roll-call (read-only report)
+        run: node scripts/fleet-rollcall.cjs


### PR DESCRIPTION
## Summary
- Adversarial sweep filed two sibling findings under one QF (shared fix venue: scheduler registration): `SD-LEO-FIX-POST-CRASH-FLEET-001` (`fleet-rollcall.cjs`, multi-signal liveness probe) and `SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001` (`worker-spawn-executor.cjs`, the spawn-execution daemon). Investigated both before wiring anything — they have fundamentally different actionability, so this PR splits them.

### `fleet-rollcall.cjs` — wired (safe)
Read-only: queries `claude_sessions` + `session_coordination`, prints a multi-signal liveness report. No writes, no process spawning, no side effects. Adds `.github/workflows/fleet-rollcall-cron.yml` (every 30 min + `workflow_dispatch`) so a post-crash liveness report exists without relying on a human to remember to run it. Live-verified against the real DB (correct role-singleton + worker verdicts, `getMarkerSessionIds()` fails open to `{}` on a machine with no local PID markers — confirmed safe on a GH Actions runner).

### `worker-spawn-executor.cjs` — deliberately NOT wired
This script's own header is explicit: **"OPERATOR GATE (Stage 2, do NOT enable autonomously)."** The live spawn path (`WORKER_SPAWN_EXECUTOR_LIVE=true`) launches OS processes that spawn fresh `claude` CLI sessions using the operator's own authenticated session — and requires a human to (1) host-validate the exact spawn invocation (`buildSpawnInvocation()`) for their specific machine, and (2) register a **local** Windows Task Scheduler entry. The SD's own converged design (`SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001` metadata, `architecture_lock.host`) explicitly rules out GitHub Actions as the host: *"the fleet runs LOCALLY so GHA cannot launch interactive workers... CronCreate cannot cold-spawn... GH-Actions cannot reach the checkout."* A worktree-isolated fleet-worker session has no access to the chairman's physical machine, no way to host-validate the spawn command, and no way to register a local scheduled task. This is not a code fix — it requires an explicit chairman/operator action outside this repository. Left fully untouched (script unchanged, still default dry-run/inert).

## Test plan
- [x] `node scripts/check-workflow-yaml.mjs .github/workflows/fleet-rollcall-cron.yml` — parses OK
- [x] Live-ran `fleet-rollcall.cjs` against the real DB — clean multi-signal report, no errors
- [x] Existing `tests/unit/fleet/fleet-rollcall.test.js` (14 tests) — unchanged, still green
- [x] `worker-spawn-executor.cjs` untouched — still default dry-run (`WORKER_SPAWN_EXECUTOR_LIVE` unset), no behavior change

Generated with Claude Code