### PR TITLE
fix(QF-20260706-985): manual convergence rescore for MarketLens (chairman review gate)

### DIFF
--- a/scripts/one-off/qf-20260706-985-marketlens-convergence-rescore.mjs
+++ b/scripts/one-off/qf-20260706-985-marketlens-convergence-rescore.mjs
@@ -1,0 +1,25 @@
+// QF-20260706-985: manual convergence rescore for MarketLens (post-REMED). The S19->S20
+// automatic trigger (Child D) hasn't fired for this venture (mid-walk at S24), so the
+// retroactive rescore needs a manual invoke of the convergence loop (Child C,
+// lib/eva/convergence-loop.js runConvergenceLoop). Read-only against post_build_verdicts:
+// scoreVerdictTable/buildDeviationLedger (lib/eva/adherence-scorer.js) never write; no
+// backfillFn/createQuickFixFn/createSdFn are injected here, so any gap this run finds is
+// safely deferred (never silently remediated) rather than auto-filing new QFs/SDs
+// unsupervised -- this is a rescore + report, not a remediation run.
+import { runConvergenceLoop } from '../../lib/eva/convergence-loop.js';
+
+export const VENTURE_ID = 'ecbba50e-3c98-4493-9e77-1719cf6b6f00';
+
+export async function main(supabase) {
+  const result = await runConvergenceLoop(supabase, { ventureId: VENTURE_ID });
+  return result;
+}
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectRun) {
+  const { createClient } = await import('@supabase/supabase-js');
+  const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  main(sb).then((r) => console.log('[qf-20260706-985]', JSON.stringify(r, null, 2))).catch((e) => { console.error('[qf-20260706-985] error:', e.message); process.exit(1); });
+}

--- a/tests/unit/one-off/qf-20260706-985-marketlens-convergence-rescore.test.js
+++ b/tests/unit/one-off/qf-20260706-985-marketlens-convergence-rescore.test.js
@@ -1,0 +1,32 @@
+/**
+ * Unit test for the QF-20260706-985 manual convergence-rescore invoker. Mocked
+ * runConvergenceLoop — no live DB access. The actual live rescore already ran once
+ * (recorded in the QF completion notes / coordinator signal): status=ESCALATED,
+ * mean=3.5 vs mean_floor=4, zero routable per-dimension gaps (all at-or-above floor),
+ * ready for chairman disposition.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../lib/eva/convergence-loop.js', () => ({
+  runConvergenceLoop: vi.fn().mockResolvedValue({ status: 'ESCALATED', cycles: 2, scoreResult: { mean: 3.5, pass: false } }),
+}));
+
+import { main, VENTURE_ID } from '../../../scripts/one-off/qf-20260706-985-marketlens-convergence-rescore.mjs';
+import { runConvergenceLoop } from '../../../lib/eva/convergence-loop.js';
+
+describe('QF-20260706-985: main()', () => {
+  it('invokes runConvergenceLoop for the MarketLens venture and returns its result verbatim', async () => {
+    const supabase = {};
+    const result = await main(supabase);
+    expect(runConvergenceLoop).toHaveBeenCalledWith(supabase, { ventureId: VENTURE_ID });
+    expect(result).toEqual({ status: 'ESCALATED', cycles: 2, scoreResult: { mean: 3.5, pass: false } });
+  });
+
+  it('never injects backfillFn/createQuickFixFn/createSdFn (rescore-and-report only, no auto-remediation)', async () => {
+    await main({});
+    const callArgs = runConvergenceLoop.mock.calls.at(-1)[1];
+    expect(callArgs.backfillFn).toBeUndefined();
+    expect(callArgs.createQuickFixFn).toBeUndefined();
+    expect(callArgs.createSdFn).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **PRIORITY QF** (chairman Monday chain, gates Adam's chairman-review card walkthrough #2): REMED wave complete but MarketLens (venture `ecbba50e-3c98-4493-9e77-1719cf6b6f00`, S24 mid-walk) never got a retroactive convergence rescore — the S19->S20 auto-trigger (Child D) doesn't apply mid-walk, so this needed a manual invoke.
- **Live-ran the rescore** (`lib/eva/convergence-loop.js` `runConvergenceLoop`, no `backfillFn`/`createQuickFixFn`/`createSdFn` injected — rescore-and-report only, never auto-remediates unsupervised):
  - `status=ESCALATED`, `mean=3.5` vs `mean_floor=4`, 2 cycles run (stable non-passing state, no further routable gaps)
  - Dimension scores: `user_story_coverage=5`, `persona_surface_coverage=3`, `data_model_fidelity=3`, `architecture_conformance=3` — all four are **at-or-above** their individual floor (3)
  - This is a genuine mean-floor shortfall with **zero per-dimension gaps** (`classifyGaps` only flags below-floor dimensions; none are below floor) — not a bug in the invocation, a structural property of this score. Correctly escalates to the chairman's 3-way disposition (`descope-as-known-gap` / `pivot-the-artifact` / `hold-launch`) rather than looping forever.
  - Deviation ledger carries 1 entry (`wireframe_screens`, `declared-descope`, from this morning's `QF-20260705-614` backfill).
- **Signaled the coordinator** (severity high) with the full result immediately after running it, per the QF's own instructions ("signal coordinator + Adam with new counts"). Flagged that I could not confirm the exact source/scheme of the QF's referenced "before: 24/18/4" baseline (current `post_build_verdicts.disposition` totals `BUILT=33/PARTIAL=12/DEVIATED_WITH_DOCUMENTED_REASON=1`=46, which doesn't map directly) rather than guessing at a match.
- Committing the one-off invoker (read-only against `post_build_verdicts` — `adherence-scorer.js` never writes) for traceability/reproducibility.

## Test plan
- [x] Live-ran the rescore against the real DB — full result captured above and in the coordinator signal
- [x] New `tests/unit/one-off/qf-20260706-985-marketlens-convergence-rescore.test.js` (2 tests, mocked `runConvergenceLoop`): correct venture id passed, no remediation callbacks injected
- [x] Confirmed `scoreVerdictTable`/`buildDeviationLedger` (`lib/eva/adherence-scorer.js`) contain no `.insert`/`.update`/`.upsert` calls — the invocation is read-only

Generated with Claude Code