### PR TITLE
fix(QF-20260705-347): durable PARK marker honored by fleet predicates

### DIFF
--- a/lib/fleet/session-predicates.mjs
+++ b/lib/fleet/session-predicates.mjs
@@ -87,7 +87,7 @@ export function isGenuineCountableWorker(session, coordinatorId) {
  * @param {string} coordinatorId - the active coordinator's session_id (excluded)
  * @returns {boolean}
  */
-export function isDispatchableFleetMember(session, coordinatorId) {
+export function isDispatchableFleetMember(session, coordinatorId, nowMs = Date.now()) {
   try {
     if (!session || typeof session !== 'object') return false;
     if (session.session_id && coordinatorId && session.session_id === coordinatorId) return false;
@@ -102,6 +102,13 @@ export function isDispatchableFleetMember(session, coordinatorId) {
     // restores the session to capacity. Applied HERE (the SSOT predicate) so the audit,
     // capacity forecaster, dashboard and rollcall all agree.
     if (session.metadata?.quarantined_at) return false;
+    // QF-20260705-347: durable PARK marker — a session parked-by-plan (coordinator stamps
+    // metadata.parked_until at park time, clears it at resume) must not count as dispatchable
+    // idle capacity while still parked. Prose park-order WAs are message-deaf (a parked session
+    // isn't reading anything); this durable field is the enforcement axis charter-audit
+    // DUTY-3 (which already imports this predicate) was missing.
+    const parkedUntil = session.metadata?.parked_until ? Date.parse(session.metadata.parked_until) : NaN;
+    if (Number.isFinite(parkedUntil) && parkedUntil > nowMs) return false;
     if (isFixtureSession(session)) return false;
     return true;
   } catch {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -169,13 +169,24 @@ function isSelfClaimDisabled(metadata) {
   return metadata.self_claim === false
     || metadata.availability === 'idle_only'
     || metadata.coordinator_stand_down === true
-    || isQuarantined(metadata);
+    || isQuarantined(metadata)
+    || isParked(metadata);
 }
 
 // SD-LEO-INFRA-CLAIM-BOUNDARY-PRE-001 FR-4: pure — uncleared probe quarantine present?
 function isQuarantined(metadata) {
   const q = metadata && typeof metadata === 'object' ? metadata.quarantine : null;
   return !!(q && typeof q === 'object' && !q.cleared_at);
+}
+
+// QF-20260705-347: durable PARK marker — the coordinator stamps metadata.parked_until (ISO)
+// at park time and clears it at resume; a prose park-order WA alone is message-deaf (a parked
+// session isn't reading anything). Availability control only — roll_call, resume and directed
+// WORK_ASSIGNMENTs stay honored, same contract as the other isSelfClaimDisabled sub-checks.
+function isParked(metadata) {
+  const until = metadata && typeof metadata === 'object' && metadata.parked_until
+    ? Date.parse(metadata.parked_until) : NaN;
+  return Number.isFinite(until) && until > Date.now();
 }
 
 /**
@@ -1900,7 +1911,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isQuarantined, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/fleet/self-claim-standdown.test.js
+++ b/tests/unit/fleet/self-claim-standdown.test.js
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import mod from '../../../scripts/worker-checkin.cjs';
 
-const { isSelfClaimDisabled, isGlobalStandDownActive, orderByFleetCriticalThenRank } = mod;
+const { isSelfClaimDisabled, isParked, isGlobalStandDownActive, orderByFleetCriticalThenRank } = mod;
 
 // Mock supabase: from('system_settings').select(...).in('key', keys) -> Promise<{data,error}>.
 function mockSettingsSb(result) {
@@ -34,6 +34,24 @@ describe('FR-2 global/fleet stand-down (system_settings)', () => {
   it('global HARD_HALT_STATUS enabled (superset) disables self_claim', async () => {
     const sb = mockSettingsSb({ data: [{ key: 'HARD_HALT_STATUS', value_json: { enabled: true } }], error: null });
     expect(await isGlobalStandDownActive(sb)).toBe(true);
+  });
+});
+
+describe('QF-20260705-347 durable PARK marker', () => {
+  it('metadata.parked_until in the future disables self_claim', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    expect(isParked({ parked_until: future })).toBe(true);
+    expect(isSelfClaimDisabled({ parked_until: future })).toBe(true);
+  });
+  it('a PAST parked_until re-enables self_claim (park is self-expiring)', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    expect(isParked({ parked_until: past })).toBe(false);
+    expect(isSelfClaimDisabled({ parked_until: past })).toBe(false);
+  });
+  it('absent/garbage parked_until leaves self_claim ENABLED (fail-toward-active)', () => {
+    expect(isParked({})).toBe(false);
+    expect(isParked({ parked_until: 'not-a-date' })).toBe(false);
+    expect(isParked(null)).toBe(false);
   });
 });
 

--- a/tests/unit/session-predicates.test.js
+++ b/tests/unit/session-predicates.test.js
@@ -137,6 +137,26 @@ describe('isDispatchableFleetMember — idle/capacity panel role guard (no everC
     expect(isDispatchableFleetMember({ session_id: 'e4c2b7aa-0000-4000-8000-000000000000', metadata: { quarantined_at: null }, sd_key: null }, coordId)).toBe(true);
     expect(isDispatchableFleetMember({ session_id: 'e4c2b7aa-0000-4000-8000-000000000000', metadata: {}, sd_key: null }, coordId)).toBe(true);
   });
+
+  // QF-20260705-347: durable PARK marker — a parked-by-plan session (e.g. an overnight-cycle-down
+  // seat) must not false-flag charter-audit DUTY-3 idle-with-work while metadata.parked_until is
+  // still in the future.
+  it('EXCLUDES a session parked_until a future timestamp', () => {
+    const now = Date.parse('2026-07-06T04:00:00Z');
+    const parked = { session_id: 'f1a2b3c4-0000-4000-8000-000000000000', metadata: { parked_until: '2026-07-06T05:00:00Z' }, sd_key: null };
+    expect(isDispatchableFleetMember(parked, coordId, now)).toBe(false);
+  });
+
+  it('counts a session again once parked_until has passed — park is reversible/self-expiring', () => {
+    const now = Date.parse('2026-07-06T06:00:00Z');
+    const expired = { session_id: 'f1a2b3c4-0000-4000-8000-000000000000', metadata: { parked_until: '2026-07-06T05:00:00Z' }, sd_key: null };
+    expect(isDispatchableFleetMember(expired, coordId, now)).toBe(true);
+  });
+
+  it('ignores a garbage/unparseable parked_until (fail toward member)', () => {
+    const garbage = { session_id: 'f1a2b3c4-0000-4000-8000-000000000000', metadata: { parked_until: 'not-a-date' }, sd_key: null };
+    expect(isDispatchableFleetMember(garbage, coordId)).toBe(true);
+  });
 });
 
 describe('production wiring guard (catch idle-filter call-site deletion)', () => {


### PR DESCRIPTION
## Summary
- Park orders were prose WAs — message-deaf sessions never read them, and neither `isDispatchableFleetMember` (charter-audit DUTY-3's idle/capacity predicate) nor worker-checkin's self-claim gate had a park axis.
- `lib/fleet/session-predicates.mjs`: `isDispatchableFleetMember` now excludes a session while `metadata.parked_until` is in the future (mirrors the existing `quarantined_at` pattern; adds an optional `nowMs` param for testability, default `Date.now()`).
- `scripts/worker-checkin.cjs`: `isSelfClaimDisabled` gains `isParked()` on the same `metadata.parked_until` field — self-claim only; resume/directed WAs still honored, matching `isQuarantined`'s existing contract.
- Coordinator sets/clears `metadata.parked_until` at park/resume as a behavioral convention on the existing `metadata` JSONB column — no new field or migration needed.

## Test plan
- [x] `npx vitest run tests/unit/session-predicates.test.js tests/unit/fleet/self-claim-standdown.test.js` — 33/33 passing (new park cases + all existing quarantine/standdown cases)
- [x] `npx vitest run tests/unit/worker-checkin-self-claim-availability.test.js tests/unit/coordinator/charter-audit-detectors.test.js tests/unit/coordinator/charter-audit-mirror-detectors.test.js` — 77/77 passing (no regressions)
- [x] `npm run schema:lint` (diff) — 0 violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>