### PR TITLE
fix(QF-20260704-403): add a grace window to the ship-witness-unwitnessed-merge gauge

### DIFF
--- a/lib/ship/witness-adoption.mjs
+++ b/lib/ship/witness-adoption.mjs
@@ -62,10 +62,18 @@ export function classifyMerges(merges, telemetryRows) {
   }));
 }
 
+// QF-20260704-403: witness rows land within ~a minute of merge (a normal write race, not a
+// gap) — without a grace window, the gauge counted merges caught mid-race as unwitnessed and
+// false-tripped (evidence 2026-07-04: tripped twice, both times the unwitnessed array read []
+// on immediate re-query). Excludes merges younger than graceMs from the count/unwitnessed
+// array; `total` stays the full classified count (informational, not grace-filtered).
+export const DEFAULT_GRACE_MS = 5 * 60 * 1000;
+
 /** Pure: WATCH-HOLE detector shaped for gauge-registry's {count,...} convention. */
-export function detectUnwitnessedMerges(merges, telemetryRows) {
+export function detectUnwitnessedMerges(merges, telemetryRows, { graceMs = DEFAULT_GRACE_MS, now = Date.now() } = {}) {
   const classified = classifyMerges(merges, telemetryRows);
-  const unwitnessed = classified.filter((m) => !m.witnessed);
+  const cutoff = now - graceMs;
+  const unwitnessed = classified.filter((m) => !m.witnessed && Date.parse(m.mergedAt) < cutoff);
   return { count: unwitnessed.length, total: classified.length, unwitnessed };
 }
 

--- a/tests/unit/ship/witness-adoption.test.js
+++ b/tests/unit/ship/witness-adoption.test.js
@@ -85,6 +85,45 @@ describe('classifyMerges / detectUnwitnessedMerges (identity matching)', () => {
   });
 });
 
+describe('detectUnwitnessedMerges grace window (QF-20260704-403)', () => {
+  const now = Date.parse('2026-07-04T12:00:00Z');
+
+  it('a merge inside the grace window (< 5 min old) is NOT counted as unwitnessed', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:57:00Z' }]; // 3 min ago
+    const result = detectUnwitnessedMerges(merges, [], { now });
+    expect(result.count).toBe(0);
+    expect(result.unwitnessed).toEqual([]);
+  });
+
+  it('a merge older than the grace window IS counted as unwitnessed', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:50:00Z' }]; // 10 min ago
+    const result = detectUnwitnessedMerges(merges, [], { now });
+    expect(result.count).toBe(1);
+  });
+
+  it('total stays the full classified count regardless of the grace window', () => {
+    const merges = [
+      { repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:57:00Z' }, // grace-window, excluded from count
+      { repo: 'rickfelix/ehg', prNumber: 2, mergedAt: '2026-07-04T11:50:00Z' }, // older, counted
+    ];
+    const result = detectUnwitnessedMerges(merges, [], { now });
+    expect(result.total).toBe(2);
+    expect(result.count).toBe(1);
+  });
+
+  it('a custom graceMs is respected', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:59:00Z' }]; // 1 min ago
+    expect(detectUnwitnessedMerges(merges, [], { now, graceMs: 0 }).count).toBe(1);
+    expect(detectUnwitnessedMerges(merges, [], { now, graceMs: 2 * 60 * 1000 }).count).toBe(0);
+  });
+
+  it('defaults to Date.now() when now is not injected (still excludes fresh merges)', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: new Date().toISOString() }];
+    const result = detectUnwitnessedMerges(merges, []);
+    expect(result.count).toBe(0);
+  });
+});
+
 describe('isInvalidated (QF-20260703-979)', () => {
   it('true for a row carrying a synthetic INVALIDATED rung', () => {
     const row = { repo: 'rickfelix/marketlens', pr_number: 2, rungs: [{ id: 'P5', status: 'pass' }, { id: 'INVALIDATED', status: 'fail', reason: 'false specimen' }] };


### PR DESCRIPTION
## Summary
- **Root cause**: evidence 2026-07-04 evening — the `ship-witness-unwitnessed-merge` gauge tripped `count=2` twice (23:0xZ and 00:0xZ), and both times the `unwitnessed` array read `[]` on immediate re-query. Witness rows land within ~a minute of merge; the gauge counted merges caught inside that normal write race as unwitnessed, training alert fatigue on a gauge that guards a real invariant (SHIP-WITNESS-ENFORCE lane).
- **Fix**: `detectUnwitnessedMerges` (`lib/ship/witness-adoption.mjs`) now accepts an optional `{graceMs, now}` and excludes merges younger than `graceMs` (default 5 minutes) from the `count`/`unwitnessed` array. `total` stays the full classified count (informational context, not grace-filtered) — same `{count, total, unwitnessed}` shape `gauge-runner.mjs`'s registry convention expects, so no caller changes needed.

## Test plan
- [x] New tests (5): a merge inside the grace window is not counted, a merge older than the window is counted, `total` stays unaffected by the window, a custom `graceMs` is respected, the real `Date.now()` default still excludes a genuinely-fresh merge
- [x] Existing `tests/unit/ship/witness-adoption.test.js` (18 tests) — unchanged, still green (all use fixed mock timestamps well outside any grace window relative to the real clock)
- [x] Sibling `tests/unit/ship/ship-witness-reconcile.test.js` (6 tests) — no regression

Generated with Claude Code