### PR TITLE
fix(QF-20260705-788): suppress gate-2x auto-signal when the handoff subsequently accepts

### DIFF
--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -383,6 +383,9 @@ export class BaseExecutor {
       let gateResults;
       let currentRetryCount = options._retryCount || 0;
       const maxGateRetries = GATE_MAX_RETRIES;
+      // QF-20260705-788: captured at the retryCount===2 crossing, but only actually EMITTED after
+      // the loop exits and the FINAL gateResults.passed is known — see below.
+      let _pendingGateAutoSignalArgs = null;
 
       for (let attempt = 0; attempt <= maxGateRetries; attempt++) {
         gateResults = await this.validationOrchestrator.validateGates(gates, validationContext);
@@ -415,33 +418,50 @@ export class BaseExecutor {
             currentRetryCount++;
             console.log(`\n   🔄 Gate retry ${currentRetryCount}/${maxGateRetries}: ${skipCheck.reason}`);
             // SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001 (FR-1): auto-emit a /signal at the gate-2x
-            // crossing — enforcement-layer escalation mirroring the shipped RCA-2x wiring. Fire-and-forget
-            // (detached + unref), env-gated (LEO_AUTO_SIGNAL=off), wrapped fail-open: it can NEVER block,
-            // slow, or throw into the handoff. Removes worker discretion at the gate-recurrence threshold.
+            // crossing — enforcement-layer escalation mirroring the shipped RCA-2x wiring. Env-gated
+            // (LEO_AUTO_SIGNAL=off), wrapped fail-open: it can NEVER block, slow, or throw into the
+            // handoff. QF-20260705-788: only CAPTURED here (not spawned) — a 2x-fail crossing still
+            // has one gate re-evaluation left in this same loop (GATE_MAX_RETRIES=2), and that final
+            // attempt routinely passes (the known WIRE_CHECK_GATE transient-fail gotcha). Emitting
+            // immediately fired HIGH-severity noise for a self-healing condition; the actual spawn now
+            // happens AFTER the loop, gated on the FINAL gateResults.passed still being false.
             try {
               const _req = createRequire(import.meta.url);
               const { shouldEmitGateAutoSignal, buildGateAutoSignalArgs } =
                 _req(path.join(ENGINEER_ROOT, 'lib', 'hooks', 'auto-signal-threshold.cjs'));
               const _sessionId = process.env.CLAUDE_SESSION_ID;
               if (shouldEmitGateAutoSignal({ retryCount: currentRetryCount, sessionId: _sessionId, env: process.env })) {
-                const { spawn } = _req('child_process');
-                const _args = buildGateAutoSignalArgs({
-                  gateName: gateResults.failedGate,
-                  sdKey: sd?.sd_key || sd?.id,
-                  retryCount: currentRetryCount,
-                });
-                const _child = spawn(
-                  process.execPath,
-                  [path.join(ENGINEER_ROOT, 'scripts', 'worker-signal.cjs'), ..._args],
-                  { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _sessionId } }
-                );
-                _child.unref();
+                _pendingGateAutoSignalArgs = {
+                  args: buildGateAutoSignalArgs({
+                    gateName: gateResults.failedGate,
+                    sdKey: sd?.sd_key || sd?.id,
+                    retryCount: currentRetryCount,
+                  }),
+                  sessionId: _sessionId,
+                };
               }
             } catch { /* fail-open: auto-signal must never block the handoff */ }
             continue;
           }
         }
         break; // Not retry-eligible or max retries reached
+      }
+
+      // QF-20260705-788: emit the captured gate-2x auto-signal ONLY if the handoff's gates are
+      // STILL failing after the retry loop exhausted (genuine exhaustion) — a subsequent PASS
+      // within this same loop (the self-healing WIRE_CHECK_GATE case) suppresses it entirely.
+      // Fire-and-forget (detached + unref), same safety contract as before.
+      if (_pendingGateAutoSignalArgs && !gateResults.passed) {
+        try {
+          const _req = createRequire(import.meta.url);
+          const { spawn } = _req('child_process');
+          const _child = spawn(
+            process.execPath,
+            [path.join(ENGINEER_ROOT, 'scripts', 'worker-signal.cjs'), ..._pendingGateAutoSignalArgs.args],
+            { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _pendingGateAutoSignalArgs.sessionId } }
+          );
+          _child.unref();
+        } catch { /* fail-open: auto-signal must never block the handoff */ }
       }
 
       try { endSpan(step3Span, { result: gateResults.passed ? 'pass' : 'fail' }); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }

--- a/tests/unit/handoff/base-executor-gate-autosignal-defer.test.js
+++ b/tests/unit/handoff/base-executor-gate-autosignal-defer.test.js
@@ -1,0 +1,45 @@
+/**
+ * QF-20260705-788: WIRE_CHECK_GATE auto-emit fired on the 2x-fail crossing even when the
+ * SAME handoff subsequently passed on its final retry within the same loop (GATE_MAX_RETRIES=2)
+ * — two benign HIGH stuck signals landed (2026-07-05, -C 04:40Z / -E 06:44Z) for a self-healing
+ * gate, drowning genuine signals.
+ *
+ * Fix: capture the shouldEmitGateAutoSignal() crossing decision, but only actually spawn
+ * worker-signal.cjs AFTER the retry loop exits, gated on the FINAL gateResults.passed still
+ * being false. Source-shape test (mirrors the marker-race-retry precedent) — full integration
+ * is covered by the handoff system tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readSource(rel) {
+  return fs.readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+}
+
+describe('BaseExecutor gate-2x auto-signal deferred emission (QF-20260705-788)', () => {
+  const src = readSource('scripts/modules/handoff/executors/BaseExecutor.js');
+
+  it('captures the crossing decision into a pending variable instead of spawning inline', () => {
+    expect(src).toMatch(/_pendingGateAutoSignalArgs\s*=\s*\{/);
+  });
+
+  it('the retry-loop crossing site no longer spawns worker-signal.cjs directly', () => {
+    const loopStart = src.indexOf('Retry eligible — increment and loop');
+    const loopSection = src.slice(loopStart, loopStart + 1500);
+    expect(loopSection).not.toMatch(/spawn\(/);
+  });
+
+  it('the actual spawn happens after the loop, gated on the final gate outcome', () => {
+    const afterLoopIdx = src.indexOf('_pendingGateAutoSignalArgs && !gateResults.passed');
+    expect(afterLoopIdx).toBeGreaterThan(-1);
+    const afterLoopSection = src.slice(afterLoopIdx, afterLoopIdx + 600);
+    expect(afterLoopSection).toMatch(/spawn\(/);
+    expect(afterLoopSection).toContain('worker-signal.cjs');
+  });
+
+  it('references the QF for traceability', () => {
+    expect(src).toContain('QF-20260705-788');
+  });
+});


### PR DESCRIPTION
## Summary
- The gate-2x SIGNAL-THRESHOLD-AUTO-EMIT path fired HIGH-severity stuck signals synchronously at the `retryCount===2` crossing, INSIDE the gate retry loop, before the final retry attempt (`GATE_MAX_RETRIES=2`) even ran.
- `WIRE_CHECK_GATE` routinely false-fails 1-2x then passes on the next attempt within the same loop — two identical benign HIGH signals landed on 2026-07-05 (`-C` 04:40Z, `-E` 06:44Z) while the same handoff was accepted within ~60s.
- Fix: capture the crossing decision instead of spawning inline; only actually emit the signal AFTER the retry loop exits, gated on the FINAL `gateResults.passed` still being false. Genuine exhaustion (3x fail, no accept) still emits HIGH exactly as before.

## Test plan
- [x] `npx vitest run tests/unit/handoff/base-executor-gate-autosignal-defer.test.js tests/unit/handoff/base-executor-marker-race-retry.test.js tests/unit/auto-signal-threshold.test.js` — 42/42 passing
- [x] `node --check scripts/modules/handoff/executors/BaseExecutor.js` — syntax valid
- [x] `npm run schema:lint` (diff) — 0 violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>