### PR TITLE
fix(QF-20260705-574): teach @wire-check-exempt remedy in the earlier advisory gate

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/wire-check-advisory.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/wire-check-advisory.js
@@ -47,10 +47,17 @@ const GATE_NAME = 'WIRE_CHECK_ADVISORY';
 
 /**
  * Remediation message appended to every unreachable-file advisory warning.
+ *
+ * QF-20260705-574: this pattern recurred 3+ times in one session with the IDENTICAL fix each
+ * time (Child C, Child E, Solomon guardrail SD) — workers rediscovered it from scratch because
+ * this EARLIER (advisory) message only named ONE of the two sanctioned remedies the LEAD-FINAL
+ * blocking gate already teaches. Both are now enumerated inline with one-line examples.
  */
 const REMEDIATION =
-  'Wire each file into package.json scripts (e.g. "audit:x": "node scripts/x.js") ' +
-  'or import it from a statically-reachable caller — in the SAME PR. Otherwise the ' +
+  'If intentional, pick the matching remedy in the SAME PR — either: ' +
+  '(a) wire it into package.json scripts (e.g. "audit:x": "node scripts/x.js") or import it from a ' +
+  'statically-reachable caller; OR (b) if it is a one-off probe/validation script with no permanent ' +
+  'entry point, add a `// @wire-check-exempt: <reason>` comment in its first 2KB. Otherwise the ' +
   'blocking WIRE_CHECK_GATE will fail this SD at LEAD-FINAL and force a 2nd PR.';
 
 /**

--- a/tests/unit/gates/wire-check-advisory.test.js
+++ b/tests/unit/gates/wire-check-advisory.test.js
@@ -83,4 +83,13 @@ describe('wire-check-advisory gate (SD-FDBK-ENH-WIRE-CHECK-GATE-002)', () => {
     const source = fs.readFileSync(ADVISORY_FILE, 'utf8');
     expect(source).toMatch(/required:\s*false/);
   });
+
+  // QF-20260705-574: this earlier (advisory) message previously named only ONE of the two
+  // sanctioned remedies the blocking LEAD-FINAL gate already teaches — workers rediscovered the
+  // @wire-check-exempt option from scratch each time. Both remedies must now be inline.
+  it('teaches BOTH sanctioned remedies inline (package.json wiring AND @wire-check-exempt)', () => {
+    const source = fs.readFileSync(ADVISORY_FILE, 'utf8');
+    expect(source).toMatch(/package\.json scripts/);
+    expect(source).toMatch(/@wire-check-exempt/);
+  });
 });


### PR DESCRIPTION
## Summary
- The unreachable-new-library-file WIRE_CHECK pattern recurred 3+ times in one session (Child C, Child E, Solomon guardrail SD) with the identical fix each time — workers rediscovered it per-SD.
- Root cause: the EXEC-TO-PLAN `WIRE_CHECK_ADVISORY` gate — the FIRST wire-check touchpoint a worker sees — only named ONE of the two sanctioned remedies (package.json wiring / static import). The blocking LEAD-FINAL gate already teaches both, but a worker hits the advisory message first.
- Fix: extend the advisory gate's `REMEDIATION` message to also teach the `@wire-check-exempt` comment option inline, mirroring the more complete LEAD-FINAL message.

## Test plan
- [x] `npx vitest run tests/unit/gates/wire-check-advisory.test.js tests/unit/gates/consumer-impact-gate.test.js` — 12/12 passing (existing) + 1 new assertion pinning both remedies are now present, 7/7 in the advisory test file
- [x] `npm run schema:lint` (diff) — 0 violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>