### PR TITLE
fix(QF-20260705-165): wire handoff-rejection-rates.mjs (npm script + weekly cron)

### DIFF
--- a/.github/workflows/handoff-rejection-rates-cron.yml
+++ b/.github/workflows/handoff-rejection-rates-cron.yml
@@ -1,0 +1,48 @@
+name: "Handoff rejection-rate report (durable cron)"
+
+# QF-20260705-165 (adversarial sweep J1 REFUTED-DORMANT): scripts/analytics/handoff-rejection-rates.mjs
+# (QF-20260703-793) shipped with zero invocation paths -- no npm script, cron, workflow, hook, or
+# importer called it. FIX: wire it (npm script + a consumer). Adds `npm run analytics:handoff-rejections`
+# for discoverability plus this weekly cron so the report has a live, recurring caller.
+#
+# READ-ONLY / SAFE: queries sd_phase_handoffs + strategic_directives_v2 and prints a report
+# (console.log via --json). No writes, no side effects.
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Weekly handoff rejection-rate report (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run handoff rejection-rate report
+        run: npm run analytics:handoff-rejections -- --json

--- a/package.json
+++ b/package.json
@@ -437,6 +437,7 @@
     "oiv:validate": "node scripts/oiv-validate.js",
     "sd:preflight": "node scripts/child-sd-preflight.js",
     "sd:burnrate": "node scripts/sd-burnrate.js",
+    "analytics:handoff-rejections": "node scripts/analytics/handoff-rejection-rates.mjs",
     "sd:burnrate:auto": "node scripts/pipeline/burn-rate-worker.js",
     "baseline:version": "node scripts/pipeline/baseline-versioner.js",
     "baseline:insert": "node scripts/pipeline/baseline-insertion-hook.js",


### PR DESCRIPTION
## Summary
- **Root cause**: adversarial sweep J1 REFUTED-DORMANT — `scripts/analytics/handoff-rejection-rates.mjs` (QF-20260703-793) exists and is unit-plausible, but no npm script, cron, workflow, hook, or importer invokes it. Built-but-not-live.
- **Fix**: wires it per the QF's own instruction ("wire it: npm script plus a consumer"):
  - `npm run analytics:handoff-rejections` — discoverable manual invocation
  - `.github/workflows/handoff-rejection-rates-cron.yml` (weekly, Mondays 13:00 UTC) — a durable recurring caller, matching the retention/fleet-rollcall cron pattern established this session. Read-only (queries `sd_phase_handoffs` + `strategic_directives_v2`, no writes) — safe to schedule.
- Live-verified both text and `--json` output modes against the real DB: 39.6% lifetime rejection rate across 30,884 handoffs, per-handoff-type/per-SD-type breakdowns all render correctly.

## Test plan
- [x] `node scripts/check-workflow-yaml.mjs .github/workflows/handoff-rejection-rates-cron.yml` — parses OK
- [x] Live-ran `node scripts/analytics/handoff-rejection-rates.mjs` (text mode) and `--json` mode against the real DB — both correct
- [x] Existing `tests/unit/analytics/handoff-rejection-rates.test.js` (7 tests, pure helper functions) — unchanged, still green

Generated with Claude Code