### PR TITLE
fix(QF-20260706-632): CRITICAL - fence complete-quick-fix.js working-tree fallback to isolated worktrees

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -569,17 +569,34 @@ export function analyzeGitDiff(testDir, qfDescription = '') {
     // commitAndPushChanges no-ops (nothing committed → no branch commits → --auto-pr
     // can't open a PR). Fall back to the working tree (tracked changes vs HEAD +
     // untracked) so scope/test-coverage checks and the auto-PR body see real files.
+    //
+    // QF-20260706-632: live near-miss — run from the SHARED main repo root (not an
+    // isolated QF worktree) with no QF commit yet, this fallback previously attributed
+    // ANOTHER session's entire dirty baseline (~264 files) to this QF and attempted to
+    // git-add + commit all of it onto main; only the OS command-line length limit on the
+    // auto-generated commit message stopped it. Fence the fallback to isolated QF
+    // worktrees only (isInQFWorktree already exists for this exact guard class), plus a
+    // sanity cap — a single QF should never legitimately touch this many uncommitted files.
+    const WORKING_TREE_FALLBACK_FILE_CAP = 30;
     let diffRange = 'origin/main...HEAD';
     if (files.length === 0) {
-      const tracked = execSync('git diff HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
-        .trim().split('\n').filter(f => f);
-      const untracked = execSync('git ls-files --others --exclude-standard', { encoding: 'utf-8', cwd: testDir })
-        .trim().split('\n').filter(f => f);
-      const working = [...new Set([...tracked, ...untracked])];
-      if (working.length > 0) {
-        files = working;
-        diffRange = 'HEAD';
-        console.log('   ℹ️  No committed diff vs origin/main; using working-tree changes (uncommitted QF).');
+      if (!isInQFWorktree(testDir)) {
+        console.log(`   ⚠️  Refusing working-tree fallback: ${testDir} is not an isolated QF worktree.`);
+        console.log('   ⚠️  Commit the QF changes first, or run completion from the QF worktree (.worktrees/qf/<QF-ID>).');
+      } else {
+        const tracked = execSync('git diff HEAD --name-only', { encoding: 'utf-8', cwd: testDir })
+          .trim().split('\n').filter(f => f);
+        const untracked = execSync('git ls-files --others --exclude-standard', { encoding: 'utf-8', cwd: testDir })
+          .trim().split('\n').filter(f => f);
+        const working = [...new Set([...tracked, ...untracked])];
+        if (working.length > WORKING_TREE_FALLBACK_FILE_CAP) {
+          console.log(`   ⚠️  Refusing working-tree fallback: ${working.length} dirty file(s) exceeds the ${WORKING_TREE_FALLBACK_FILE_CAP}-file sanity cap.`);
+          console.log('   ⚠️  Commit the QF changes explicitly, or pass an explicit file list.');
+        } else if (working.length > 0) {
+          files = working;
+          diffRange = 'HEAD';
+          console.log('   ℹ️  No committed diff vs origin/main; using working-tree changes (uncommitted QF).');
+        }
       }
     }
     filesChanged = files;

--- a/scripts/modules/complete-quick-fix/working-tree-fallback-fence.test.js
+++ b/scripts/modules/complete-quick-fix/working-tree-fallback-fence.test.js
@@ -1,0 +1,84 @@
+/**
+ * Regression test for QF-20260706-632.
+ *
+ * Live near-miss (Golf-2, QF-880 completion): running complete-quick-fix.js from the
+ * shared main repo root with no QF-specific commit fell back to working-tree diff
+ * analysis, attributed the entire pre-existing dirty baseline of ANOTHER session
+ * (~264 files) to this QF, and attempted to git-add + commit all of it onto main. Only
+ * the OS command-line length limit on the auto-generated commit message stopped it.
+ *
+ * analyzeGitDiff()'s working-tree fallback must now:
+ *   1. REFUSE when testDir is not an isolated QF worktree (isInQFWorktree() false).
+ *   2. Still work normally when testDir IS an isolated QF worktree (no regression).
+ *   3. REFUSE even inside a QF worktree if the dirty file count exceeds a sanity cap.
+ *
+ * Uses REAL temporary git repos (git init / git worktree add) rather than mocking
+ * execSync, so the fix is proven against actual git behavior.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { analyzeGitDiff, isInQFWorktree } from './git-operations.js';
+
+function git(cwd, cmd) {
+  return execSync(`git ${cmd}`, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+describe('analyzeGitDiff working-tree fallback fence (QF-20260706-632)', () => {
+  let repoDir;
+  let qfWorktreeDir;
+
+  beforeAll(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'qf632-repo-'));
+    git(repoDir, 'init -q -b main');
+    git(repoDir, 'config user.email "test@test.local"');
+    git(repoDir, 'config user.name "Test"');
+    writeFileSync(join(repoDir, 'README.md'), 'initial\n');
+    git(repoDir, 'add README.md');
+    git(repoDir, 'commit -q -m "initial"');
+    const headSha = git(repoDir, 'rev-parse HEAD').trim();
+    // Fake an origin/main remote-tracking ref pointing at HEAD (no real remote needed)
+    // so `git diff origin/main...HEAD` succeeds and returns empty — the exact precondition
+    // that triggers the working-tree fallback.
+    git(repoDir, `update-ref refs/remotes/origin/main ${headSha}`);
+
+    qfWorktreeDir = join(repoDir, '.worktrees', 'qf', 'QF-20260706-632-fixture');
+    git(repoDir, `worktree add -q -B qf-fixture-branch "${qfWorktreeDir}" main`);
+  });
+
+  afterAll(() => {
+    try { git(repoDir, `worktree remove --force "${qfWorktreeDir}"`); } catch { /* best-effort */ }
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('isInQFWorktree correctly distinguishes the two fixture dirs', () => {
+    expect(isInQFWorktree(repoDir)).toBe(false);
+    expect(isInQFWorktree(qfWorktreeDir)).toBe(true);
+  });
+
+  it('REFUSES the working-tree fallback from the shared main root (not a QF worktree)', () => {
+    // Simulate another session's dirty baseline sitting in the shared repo root.
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(repoDir, `unrelated-${i}.txt`), 'peer session work\n');
+    }
+    const { filesChanged } = analyzeGitDiff(repoDir, 'some QF description');
+    expect(filesChanged).toEqual([]);
+  });
+
+  it('still works normally from an isolated QF worktree (no regression)', () => {
+    writeFileSync(join(qfWorktreeDir, 'my-qf-fix.txt'), 'the actual QF change\n');
+    const { filesChanged } = analyzeGitDiff(qfWorktreeDir, 'some QF description');
+    expect(filesChanged).toContain('my-qf-fix.txt');
+  });
+
+  it('REFUSES even inside a QF worktree once the dirty count exceeds the sanity cap', () => {
+    for (let i = 0; i < 35; i++) {
+      writeFileSync(join(qfWorktreeDir, `bulk-${i}.txt`), 'x\n');
+    }
+    const { filesChanged } = analyzeGitDiff(qfWorktreeDir, 'some QF description');
+    expect(filesChanged).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- **Live near-miss** (Golf-2, QF-880 completion): running `complete-quick-fix.js` from the shared main repo root with no QF-specific commit vs origin/main fell back to working-tree diff analysis, attributed ANOTHER session's entire pre-existing dirty baseline (~264 files) to this QF, and attempted `git add` + `git commit` of all of it onto main. Only the OS command-line length limit on the auto-generated commit message stopped it.
- Root cause: `analyzeGitDiff()`'s working-tree fallback (tracked+untracked files vs HEAD) never checked whether it was running in an isolated QF worktree before treating the entire dirty tree as "this QF's files."
- Fix: fence the fallback behind `isInQFWorktree()` (an existing guard built for exactly this bug class, but never consulted at this call site) plus a 30-file sanity cap. From the shared main root — or when the dirty count is implausibly large even inside a QF worktree — the fallback now refuses and directs the operator to commit explicitly or run from the QF worktree.
- `commitAndPushChanges()`'s existing scoped-`git add` logic (harness 62327062) already only stages files intersecting `filesChanged` — but that scoping is defeated when `filesChanged` itself is poisoned upstream, which is exactly what this closes.

## Test plan
- [x] New regression test (`working-tree-fallback-fence.test.js`) uses REAL temporary git repos (`git init` / `git worktree add`) to reproduce the near-miss directly: refuses from a non-worktree root, works normally from an isolated QF worktree (no regression), and refuses again once the dirty count exceeds the sanity cap even inside a worktree — 4/4 passing
- [x] Existing `empty-diff-guard.test.js` + `test-runner-summary.test.js` — 11/11 passing, no regressions
- [x] `npm run schema:lint` (diff) — 0 violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>