### PR TITLE
fix(QF-20260706-630): governor verdict CLI 3 pilot-found defects

### DIFF
--- a/lib/eva/capacity-governor.js
+++ b/lib/eva/capacity-governor.js
@@ -11,6 +11,23 @@ const DEFAULT_BUDGET_SESSION_HOURS = 32 * 0.7; // 22.4 -- used only when the led
 const REFERENCE_BURN_PER_SESSION_PER_HOUR = 8; // initial estimate: ~8 session_coordination sends/session/hour under typical LEO cadence
 const MIN_CONFIDENT_EVENT_COUNT = 5;
 
+// QF-20260706-630 (defect 3): per-model burn weight relative to a sonnet baseline (1x) --
+// fable seats run heavier reasoning per tick (~2x), opus is heavier than sonnet, haiku lighter.
+// Used both to weight the core-size survival math and to order parking so heavier seats stay
+// up longest (the chairman fable-stays-up doctrine): a frozen Fable seat loses more than a
+// parked light seat, so light seats park first.
+const MODEL_WEIGHTS = { fable: 2, opus: 1.3, sonnet: 1, haiku: 0.7 };
+
+/** Resolve a session's model to its burn weight. Unknown/unset models default to the sonnet
+ *  baseline (1) -- never NaN, never throws. */
+export function resolveModelWeight(model) {
+  const m = String(model || '').toLowerCase();
+  if (m.includes('fable')) return MODEL_WEIGHTS.fable;
+  if (m.includes('opus')) return MODEL_WEIGHTS.opus;
+  if (m.includes('haiku')) return MODEL_WEIGHTS.haiku;
+  return MODEL_WEIGHTS.sonnet;
+}
+
 /**
  * Pure function -- no DB access. hoursToWall = adjustedBudget / fleetSize, where
  * adjustedBudget shrinks as burn rises above the reference rate (burn-reactive,
@@ -91,9 +108,14 @@ export async function getCurrentBurnRate(supabase, { windowHours = 1, fleetSize 
 }
 
 /**
- * Live fleet roster: active, fleet (non-Solomon/non-Adam) sessions, tagged with
- * a coarse seat tier derived from the self-reported model. Never throws --
- * empty array on failure.
+ * Live fleet roster: active, fleet (non-Solomon/non-Adam/non-coordinator) sessions, tagged
+ * with a per-seat burn weight derived from the self-reported model. Never throws -- empty
+ * array on failure.
+ *
+ * QF-20260706-630 (defect 2): the coordinator's own session was never excluded (only
+ * non_fleet/adam/solomon were), so it could appear in its own park_list. Reuses the shared
+ * isDispatchableFleetMember predicate (lib/fleet/session-predicates.mjs) -- the same SSOT
+ * fleet-rollcall.cjs uses -- rather than a hand-rolled subset of the exclusion rules.
  */
 export async function getFleetRoster(supabase) {
   try {
@@ -104,29 +126,28 @@ export async function getFleetRoster(supabase) {
 
     if (error || !data) return [];
 
+    const { isDispatchableFleetMember } = await import('../fleet/session-predicates.mjs');
+    const { getActiveCoordinatorId } = await import('../coordinator/resolve.cjs');
+    const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+
     return data
-      .filter(row => !row.metadata?.non_fleet && row.metadata?.role !== 'solomon' && row.metadata?.role !== 'adam')
+      .filter(row => row.metadata?.role !== 'solomon' && isDispatchableFleetMember(row, coordinatorId))
       .map(row => ({
         sessionId: row.session_id,
         callsign: row.metadata?.fleet_identity?.callsign || row.session_id,
         model: row.metadata?.model || 'unknown',
-        seatTier: isBurstTierModel(row.metadata?.model) ? 'burst' : 'standard',
+        weight: resolveModelWeight(row.metadata?.model),
       }));
   } catch {
     return [];
   }
 }
 
-function isBurstTierModel(model) {
-  if (!model) return false;
-  return /fable/i.test(model);
-}
-
 /**
  * Combines projection + live roster into the single queryable verdict the SD's
  * own success criteria names: { core_size, park_list, park_at, resume_at, confidence }.
- * Burst/premium-tier seats park first, per the SD's explicit park-order requirement
- * ("a frozen Fable seat loses more than a parked one").
+ * Light seats park first, heaviest (fable) seats stay up longest, per the SD's explicit
+ * park-order requirement ("a frozen Fable seat loses more than a parked one").
  */
 export function computeVerdict({
   fleetRoster,
@@ -137,20 +158,29 @@ export function computeVerdict({
   parkLeadMinutes = 30,
   resumeAtIso = null,
 }) {
-  const windowEntry = windowEntryIso ? new Date(windowEntryIso) : defaultWindowEntry();
+  // QF-20260706-630 (defect 1): anchor to NOW when no explicit --window-entry is given, not a
+  // fixed clock target -- a 6h-window ask must span the next 6h from now, not "6h starting at
+  // the next 23:00 boundary" (which produced ~26h plans for a 6h ask when run mid-day/night).
+  const windowEntry = windowEntryIso ? new Date(windowEntryIso) : new Date();
   const roster = [...fleetRoster];
-  // Burst-tier first, so it is parked before any standard-tier seat.
-  roster.sort((a, b) => (a.seatTier === 'burst' ? -1 : 0) - (b.seatTier === 'burst' ? -1 : 0));
+  // QF-20260706-630 (defect 3): heaviest (fable) seats first, so they remain in the surviving
+  // core longest -- the park loop below parks from the light/END of the array first, per the
+  // chairman fable-stays-up doctrine (a frozen Fable seat loses more than a parked light one).
+  roster.sort((a, b) => (b.weight ?? 1) - (a.weight ?? 1));
 
   const parkList = [];
   let coreSize = roster.length;
+  // Sum of burn weights for the N heaviest-first seats -- the WEIGHTED effective fleet size,
+  // not a raw headcount, so 1 fable + 1 sonnet (weight 3) burns like ~3 standard seats, not 2.
+  const weightOf = (n) => roster.slice(0, n).reduce((sum, r) => sum + (r.weight ?? 1), 0);
 
   // If the fleet's current size can't survive the whole unattended window at the
-  // projected burn, shrink from the burst end until it (roughly) can.
+  // projected burn, shrink from the light end until it (roughly) can.
   for (let candidateSize = roster.length; candidateSize >= 1; candidateSize--) {
+    const effectiveSize = weightOf(candidateSize);
     const { hoursToWall } = projectTimeToWall({
-      budgetSessionHours: (projectedHoursToWall || 0) * candidateSize,
-      fleetSize: candidateSize,
+      budgetSessionHours: (projectedHoursToWall || 0) * effectiveSize,
+      fleetSize: effectiveSize,
       burnRatePerSessionPerHour: REFERENCE_BURN_PER_SESSION_PER_HOUR,
       referenceBurnRatePerSessionPerHour: REFERENCE_BURN_PER_SESSION_PER_HOUR,
     });
@@ -176,23 +206,16 @@ export function computeVerdict({
 
   return {
     core_size: coreSize,
-    park_list: parkList.map(s => ({ sessionId: s.sessionId, callsign: s.callsign, seatTier: s.seatTier })),
+    park_list: parkList.map(s => ({ sessionId: s.sessionId, callsign: s.callsign, model: s.model, weight: s.weight })),
     park_at: parkAt,
     resume_at: resumeAt,
     confidence: eventCount >= MIN_CONFIDENT_EVENT_COUNT ? 'medium' : 'low',
   };
 }
 
-/** Default unattended-window entry: today (or tomorrow, if already past) at 23:00 local. */
-function defaultWindowEntry() {
-  const d = new Date();
-  d.setHours(23, 0, 0, 0);
-  if (d.getTime() < Date.now()) d.setDate(d.getDate() + 1);
-  return d;
-}
-
 export const CONSTANTS = {
   DEFAULT_BUDGET_SESSION_HOURS,
   REFERENCE_BURN_PER_SESSION_PER_HOUR,
   MIN_CONFIDENT_EVENT_COUNT,
+  MODEL_WEIGHTS,
 };

--- a/tests/unit/eva/capacity-governor.test.js
+++ b/tests/unit/eva/capacity-governor.test.js
@@ -8,6 +8,7 @@ import {
   projectTimeToWall,
   getCalibratedBudget,
   computeVerdict,
+  resolveModelWeight,
   CONSTANTS,
 } from '../../../lib/eva/capacity-governor.js';
 
@@ -95,18 +96,32 @@ describe('getCalibratedBudget()', () => {
   });
 });
 
+describe('resolveModelWeight() (QF-20260706-630 defect 3)', () => {
+  it('weights fable ~2x the sonnet baseline, opus heavier than sonnet, haiku lighter', () => {
+    expect(resolveModelWeight('fable')).toBe(2);
+    expect(resolveModelWeight('claude-opus-4-8')).toBeGreaterThan(resolveModelWeight('claude-sonnet-5'));
+    expect(resolveModelWeight('sonnet')).toBe(1);
+    expect(resolveModelWeight('haiku')).toBeLessThan(1);
+  });
+  it('defaults unknown/missing models to the sonnet baseline (never NaN)', () => {
+    expect(resolveModelWeight(undefined)).toBe(1);
+    expect(resolveModelWeight('qwen3-coder:30b')).toBe(1);
+  });
+});
+
 describe('computeVerdict()', () => {
-  it('parks burst/fable-tier sessions before any standard-tier session (TS-4)', () => {
-    const fleetRoster = [
-      { sessionId: 's1', callsign: 'Alpha', model: 'sonnet', seatTier: 'standard' },
-      { sessionId: 's2', callsign: 'Bravo', model: 'fable', seatTier: 'burst' },
-      { sessionId: 's3', callsign: 'Charlie', model: 'sonnet', seatTier: 'standard' },
-      { sessionId: 's4', callsign: 'Delta', model: 'sonnet', seatTier: 'standard' },
-      { sessionId: 's5', callsign: 'Echo', model: 'sonnet', seatTier: 'standard' },
-      { sessionId: 's6', callsign: 'Foxtrot', model: 'fable', seatTier: 'burst' },
-      { sessionId: 's7', callsign: 'Golf', model: 'sonnet', seatTier: 'standard' },
-      { sessionId: 's8', callsign: 'Hotel', model: 'sonnet', seatTier: 'standard' },
-    ];
+  const fleetRoster = [
+    { sessionId: 's1', callsign: 'Alpha', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+    { sessionId: 's2', callsign: 'Bravo', model: 'fable', weight: resolveModelWeight('fable') },
+    { sessionId: 's3', callsign: 'Charlie', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+    { sessionId: 's4', callsign: 'Delta', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+    { sessionId: 's5', callsign: 'Echo', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+    { sessionId: 's6', callsign: 'Foxtrot', model: 'fable', weight: resolveModelWeight('fable') },
+    { sessionId: 's7', callsign: 'Golf', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+    { sessionId: 's8', callsign: 'Hotel', model: 'sonnet', weight: resolveModelWeight('sonnet') },
+  ];
+
+  it('parks light (sonnet) seats before any fable seat -- fable-stays-up doctrine (TS-4)', () => {
     const result = computeVerdict({
       fleetRoster,
       projectedHoursToWall: 3, // shorter than the window -> must shrink
@@ -117,21 +132,51 @@ describe('computeVerdict()', () => {
 
     expect(result.core_size).toBeLessThan(fleetRoster.length);
     expect(result.park_list.length).toBe(fleetRoster.length - result.core_size);
-    // Every burst-tier seat that got parked must appear before considering any
-    // standard-tier seat is parked -- i.e. no standard-tier park without both
-    // burst seats already parked.
-    const parkedTiers = result.park_list.map(s => s.seatTier);
-    const firstStandardIdx = parkedTiers.indexOf('standard');
-    if (firstStandardIdx !== -1) {
-      const burstCount = fleetRoster.filter(s => s.seatTier === 'burst').length;
-      const burstParkedBeforeStandard = parkedTiers.slice(0, firstStandardIdx).filter(t => t === 'burst').length;
-      expect(burstParkedBeforeStandard).toBe(Math.min(burstCount, firstStandardIdx));
+    // No fable seat may be parked while any sonnet seat remains unparked.
+    const parkedModels = result.park_list.map(s => s.model);
+    const firstFableIdx = parkedModels.indexOf('fable');
+    if (firstFableIdx !== -1) {
+      expect(parkedModels.slice(0, firstFableIdx).every(m => m !== 'fable')).toBe(true);
     }
+  });
+
+  it('shrinking to keep both fable seats forces parking ALL sonnet seats first (weighted core-size)', () => {
+    // 2 fable (weight 2 each = 4) + enough headroom that surviving both fable seats alone
+    // still satisfies the window -- core_size should retain the fable seats over sonnet.
+    const result = computeVerdict({
+      fleetRoster,
+      projectedHoursToWall: 1.5,
+      unattendedWindowHours: 6,
+      eventCount: 2,
+      windowEntryIso: '2026-07-05T23:00:00-04:00',
+    });
+    const coreModels = fleetRoster
+      .slice() // computeVerdict sorts internally; re-derive from the roster's own weight order
+      .sort((a, b) => b.weight - a.weight)
+      .slice(0, result.core_size)
+      .map(s => s.model);
+    expect(coreModels.filter(m => m === 'fable').length).toBe(Math.min(2, result.core_size));
+  });
+
+  it('anchors the window to NOW when no windowEntryIso is given, not a fixed clock target (QF-20260706-630 defect 1)', () => {
+    const before = Date.now();
+    const result = computeVerdict({
+      fleetRoster: [{ sessionId: 's1', callsign: 'Alpha', model: 'sonnet', weight: 1 }],
+      projectedHoursToWall: 10,
+      unattendedWindowHours: 6,
+      eventCount: 6,
+    });
+    const after = Date.now();
+    const resumeAtMs = Date.parse(result.resume_at);
+    // resume_at must be ~6h from NOW (+/- the time this test took to run), never pinned to a
+    // fixed clock boundary hours away (the ~26h-window-for-a-6h-ask bug).
+    expect(resumeAtMs).toBeGreaterThanOrEqual(before + 6 * 3600_000 - 5000);
+    expect(resumeAtMs).toBeLessThanOrEqual(after + 6 * 3600_000 + 5000);
   });
 
   it('reports low confidence with fewer than 5 calibration events', () => {
     const result = computeVerdict({
-      fleetRoster: [{ sessionId: 's1', callsign: 'Alpha', model: 'sonnet', seatTier: 'standard' }],
+      fleetRoster: [{ sessionId: 's1', callsign: 'Alpha', model: 'sonnet', weight: 1 }],
       projectedHoursToWall: 10,
       unattendedWindowHours: 6,
       eventCount: 2,
@@ -141,7 +186,7 @@ describe('computeVerdict()', () => {
 
   it('returns all 4 required verdict fields', () => {
     const result = computeVerdict({
-      fleetRoster: [{ sessionId: 's1', callsign: 'Alpha', model: 'sonnet', seatTier: 'standard' }],
+      fleetRoster: [{ sessionId: 's1', callsign: 'Alpha', model: 'sonnet', weight: 1 }],
       projectedHoursToWall: 10,
       unattendedWindowHours: 6,
       eventCount: 6,


### PR DESCRIPTION
## Summary
- Fixes 3 defects found during overnight-capacity-governor pilot use: window anchored to a fixed clock target instead of NOW (produced ~26h plans for a 6h ask), the coordinator's own session was never excluded from its own roster/park_list, and burst/standard tier was binary with no proportional weighting.
- Replaces the binary tier with per-model `MODEL_WEIGHTS` (fable 2x, opus 1.3x, sonnet 1x, haiku 0.7x) feeding a weighted core-size survival calculation so heavier seats correctly stay up longest (fable-stays-up doctrine).
- `getFleetRoster` now reuses the shared `isDispatchableFleetMember` SSOT predicate instead of a hand-rolled exclusion subset.

## Test plan
- [x] `npx vitest run tests/unit/eva/capacity-governor.test.js` — 13/13 passing
- [x] Live-verified `verdict --window-hours 6` against real DB: coordinator absent from roster, fable seat (Bravo) weighted 2x, `resume_at` anchored ~6h from invocation time (not a fixed clock boundary)

QF-20260706-630

🤖 Generated with [Claude Code](https://claude.com/claude-code)