### PR TITLE
fix(QF-20260706-282): surface manual-completion invocation on gh rate-limit errors

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -357,6 +357,27 @@ export function fetchPRMetadata(prNumber, testDir) {
 }
 
 /**
+ * QF-20260706-282: on a gh GraphQL rate-limit error, build the exact manual-completion
+ * invocation pre-filled with locally-derivable values (commit sha, branch), instead of every
+ * worker re-deriving --commit-sha/--branch-name from first principles. Returns null for any
+ * other error class, or if the local git info can't be derived.
+ * @param {string} errorMessage
+ * @param {string} qfId
+ * @param {string} testDir
+ * @returns {string|null}
+ */
+export function buildRateLimitHint(errorMessage, qfId, testDir) {
+  if (!/rate limit/i.test(errorMessage || '')) return null;
+  try {
+    const sha = execSync('git rev-parse HEAD', { cwd: testDir, encoding: 'utf-8' }).trim();
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: testDir, encoding: 'utf-8' }).trim();
+    return `node scripts/complete-quick-fix.js ${qfId} --commit-sha ${sha} --branch-name ${branch} --force-complete --reason "gh rate-limited; verified independently via REST API"`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Auto-detect git information for a quick-fix completion.
  *
  * Priority order:

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -20,7 +20,7 @@ import os from 'os';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
-import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, canSkipTestGate, reconcileDeclaredTypeVsFiles, touchesFrontend, getScopedUnitTestFiles, isEmptyDiff } from './git-operations.js';
+import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, canSkipTestGate, reconcileDeclaredTypeVsFiles, touchesFrontend, getScopedUnitTestFiles, isEmptyDiff, buildRateLimitHint } from './git-operations.js';
 // SD-LEO-INFRA-QF-FALSE-COMPLETION-WITNESS-GAP-001: merge-verification witness so a
 // quick_fixes row cannot reach status=completed while its change is absent from origin/main.
 import { verifyQFMergeWitness } from './merge-witness.js';
@@ -195,6 +195,11 @@ export async function completeQuickFix(qfId, options = {}) {
     gitInfo = autoDetectGitInfo(testDir, options);
   } catch (e) {
     console.error(`\n❌ ${e.message}\n`);
+    // QF-20260706-282: on a gh GraphQL rate-limit failure, print the exact manual-completion
+    // invocation pre-filled with locally-derivable values, instead of every worker re-deriving
+    // --commit-sha/--branch-name from first principles.
+    const hint = buildRateLimitHint(e.message, qfId, testDir);
+    if (hint) console.error(`💡 gh rate-limited. Manual completion:\n   ${hint}\n`);
     process.exit(1);
   }
   let { commitSha, branchName, actualLoc, actualSourceLoc, actualTestLoc, sourceDeletionLoc } = gitInfo;

--- a/tests/unit/complete-quick-fix/autodetect-git-info.test.js
+++ b/tests/unit/complete-quick-fix/autodetect-git-info.test.js
@@ -21,6 +21,7 @@ const {
   extractPRNumber,
   isInQFWorktree,
   fetchPRMetadata,
+  buildRateLimitHint,
 } = await import('../../../scripts/modules/complete-quick-fix/git-operations.js');
 
 beforeEach(() => {
@@ -205,5 +206,25 @@ describe('fetchPRMetadata', () => {
   it('throws on JSON missing state field', () => {
     execSync.mockReturnValueOnce(JSON.stringify({ headRefName: 'x' }));
     expect(() => fetchPRMetadata(123, 'C:/repo')).toThrow(/malformed JSON/);
+  });
+});
+
+describe('buildRateLimitHint (QF-20260706-282)', () => {
+  it('returns null for a non-rate-limit error message', () => {
+    expect(buildRateLimitHint('gh: authentication required', 'QF-1', 'C:/repo')).toBeNull();
+  });
+  it('returns the pre-filled manual-completion command on a rate-limit message', () => {
+    execSync
+      .mockReturnValueOnce('abc1234\n')
+      .mockReturnValueOnce('qf/QF-1\n');
+    const hint = buildRateLimitHint('GraphQL: API rate limit already exceeded', 'QF-1', 'C:/repo');
+    expect(hint).toBe(
+      'node scripts/complete-quick-fix.js QF-1 --commit-sha abc1234 --branch-name qf/QF-1 ' +
+      '--force-complete --reason "gh rate-limited; verified independently via REST API"'
+    );
+  });
+  it('returns null (best-effort) if local git commands fail', () => {
+    execSync.mockImplementationOnce(() => { throw new Error('not a git repo'); });
+    expect(buildRateLimitHint('API rate limit exceeded', 'QF-1', 'C:/repo')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- When `complete-quick-fix.js`'s internal `gh pr view` hits the fleet-wide GitHub GraphQL rate limit, it previously just errored out — every worker had to re-derive the `--commit-sha/--branch-name/--force-complete` bypass invocation from first principles.
- Adds `buildRateLimitHint()` (`git-operations.js`): detects the rate-limit error class and prints the exact fallback invocation pre-filled with the locally-derivable commit sha and branch name.
- Read-path ergonomics complement to QF-20260706-632's write-path fences (worktree-only enforcement for complete-quick-fix.js).

## Test plan
- [x] `npx vitest run tests/unit/complete-quick-fix/autodetect-git-info.test.js` — 21/21 passing (3 new tests for `buildRateLimitHint`: non-rate-limit passthrough, correct pre-filled hint, best-effort null on local-git failure)
- [x] `npx vitest run tests/unit/complete-quick-fix/ tests/unit/complete-quick-fix-*.test.js` — 277/277 passing, no regressions

QF-20260706-282

🤖 Generated with [Claude Code](https://claude.com/claude-code)