### PR TITLE
fix(QF-20260705-915): surface the missing operator cash attestation via the gauge registry

### DIFF
--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -207,4 +207,15 @@ export const GAUGE_REGISTRY = [
     enabled: false,
     tracesToLayer: null,
   },
+  {
+    id: 'operator-cash-attestation-missing',
+    name: 'Distance-to-broke gauge dark for lack of a cash attestation (QF-20260705-915)',
+    detectorFn: 'operator-cash-attestation-missing',
+    thresholdConfig: { tripWhen: (result) => (result?.count || 0) > 0 },
+    ownerRole: 'chairman',
+    remediation: 'Run node scripts/operator/feed-operator-cash-burn.mjs --cash <current-cash-usd> to attest the current month\'s cash-on-hand; the distance-to-broke gauge lights up on the next read once cash_usd is live.',
+    prevent: 'A one-time operator attestation; the substrate (lib/operator/cash-burn-substrate.js) and CLI are already built (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001) -- this gauge itself is the durable "ask" so the activation is never silently forgotten again.',
+    enabled: true,
+    tracesToLayer: null,
+  },
 ];

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -55,6 +55,7 @@ import {
 import { getCaptureCompleteness } from '../lib/eva/venture-capture-forward.js';
 import { resolveMinExtractStage } from '../lib/eva/template-extractor.js';
 import { detectExpiredPremises } from '../lib/governance/revisit-tags.js';
+import { readSubstrateRow, computeRunway, periodMonthOf } from '../lib/operator/cash-burn-substrate.js';
 
 const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
 
@@ -204,6 +205,12 @@ function buildDetectorResolvers(supabase) {
         perVenture.push({ name: venture.name, ...reading });
       }
       return { count: totalMissing, perVenture };
+    },
+    'operator-cash-attestation-missing': async () => {
+      const periodMonth = periodMonthOf(Date.now());
+      const row = await readSubstrateRow(periodMonth, supabase);
+      const { partials } = computeRunway(row);
+      return { count: partials.cash.status === 'live' ? 0 : 1, period_month: periodMonth, cash_status: partials.cash.status };
     },
     'recursion-governor-ratio': async () => {
       const items = await fetchThroughputItems(supabase);

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -20,14 +20,14 @@ import {
 const VALID_FEEDBACK_TYPES = ['issue', 'enhancement'];
 
 describe('GAUGE_REGISTRY shape', () => {
-  it('exports exactly 19 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001)', () => {
-    expect(GAUGE_REGISTRY).toHaveLength(19);
+  it('exports exactly 20 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001 + operator-cash-attestation-missing, QF-20260705-915)', () => {
+    expect(GAUGE_REGISTRY).toHaveLength(20);
   });
 
-  it('16 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
+  it('17 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
     const live = GAUGE_REGISTRY.filter((e) => e.enabled === true);
     const stubs = GAUGE_REGISTRY.filter((e) => e.enabled === false);
-    expect(live).toHaveLength(16);
+    expect(live).toHaveLength(17);
     expect(stubs.map((e) => e.id).sort()).toEqual(['adam_self_score_age', 'coordinator_self_score_age', 'solomon_self_score_age']);
   });
 
@@ -101,9 +101,9 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
     expect(selectEnabledEntries(undefined)).toEqual([]);
   });
 
-  it('the real GAUGE_REGISTRY selects all 16 enabled entries', () => {
+  it('the real GAUGE_REGISTRY selects all 17 enabled entries', () => {
     const selected = selectEnabledEntries(GAUGE_REGISTRY);
-    expect(selected).toHaveLength(16);
+    expect(selected).toHaveLength(17);
     expect(selected.map((e) => e.id).sort()).toEqual([
       'adam-claimed-or-built-sd',
       'coordinator-sourced-sd',
@@ -114,6 +114,7 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
       'loop-health-D_convergence_clone',
       'loop-health-E_role_self_review',
       'loop-health-F_pat_registry',
+      'operator-cash-attestation-missing',
       'recursion-governor-ratio',
       'relay-drop',
       'ship-witness-unwitnessed-merge',
@@ -122,6 +123,15 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
       'unranked-claimable-leaves',
       'venture-capture-completeness',
     ]);
+  });
+
+  it('QF-20260705-915: operator-cash-attestation-missing has a resolvable detectorFn, ownerRole chairman, and the >0-count tripWhen convention', () => {
+    const entry = GAUGE_REGISTRY.find((e) => e.id === 'operator-cash-attestation-missing');
+    expect(entry).toBeTruthy();
+    expect(entry.detectorFn).toBe('operator-cash-attestation-missing');
+    expect(entry.ownerRole).toBe('chairman');
+    expect(entry.thresholdConfig.tripWhen({ count: 1 })).toBe(true);
+    expect(entry.thresholdConfig.tripWhen({ count: 0 })).toBe(false);
   });
 
   it('SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001: the new entry has a resolvable detectorFn and the >0-count tripWhen convention', () => {


### PR DESCRIPTION
## Summary
- Adds one `GAUGE_REGISTRY` entry (`operator-cash-attestation-missing`, ownerRole: chairman) that trips whenever the current month's `operator_cash_burn_monthly.cash_usd` isn't live, reusing the existing gauge-runner surface.
- No new table, no new notification framework — the substrate/CLI (`SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001`) already exist; only the "ask" was missing.

## Test plan
- [x] Live-verified against the real DB: `cash_status: "unattested"`, gauge trips (`count: 1`) — matches the QF's repro exactly
- [x] `tests/unit/governance/gauge-registry.test.js` updated (20 total / 17 enabled) + new dedicated assertion for the entry
- [x] Full `tests/unit/governance/` + `tests/unit/operator/` suite: 38 files / 590 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)