### PR TITLE
feat(SD-LEO-INFRA-GOLDEN-REFERENCES-CANONICAL-001-F): feedback/error-capture-seam golden reference

### DIFF
--- a/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
+++ b/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
@@ -1,21 +1,21 @@
 // Structural acceptance LOCKS for the feedback/error-capture-seam reference —
 // pure predicates over the JS source, node-builtins-only. Textual locks are
-// NECESSARY BUT WEAK (the -C lesson); the behavioral suite (parameterized over
-// GOLDEN_REF_MODULE) CALLS captureBoundary with a planted failure — and with a
-// THROWING sink/logger — and is the primary enforcement (best-effort robustness
-// and the swallow/never-silent doctrines are things no grep can prove).
+// NECESSARY BUT WEAK (the -C lesson) and a "no throw keyword" check is a proxy for
+// throw-SAFETY (the -F adversarial lesson) — so the behavioral suite (parameterized
+// over GOLDEN_REF_MODULE) that CALLS captureBoundary with a hostile thrown value, a
+// throwing sink/logger/clock, and an async op is the PRIMARY enforcement.
 export const DEFAULT_MODULE = 'golden-references/feedback-error-capture-seam/capture-seam.mjs';
 
 function stripComments(src) {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
 }
-/** Code body of a named function (exported or not), comments stripped. */
+/** Code body of a named function (exported or not, sync or async), comments stripped. */
 function fnBody(src, name) {
-  const start = src.search(new RegExp('(export )?function ' + name + '\\b'));
+  const start = src.search(new RegExp('(export )?(async )?function ' + name + '\\b'));
   if (start === -1) return null;
   const rest = src.slice(start + 1);
   const jsdoc = rest.search(/\n\/\*\*/);
-  const nextFn = rest.search(/\n(export )?function /);
+  const nextFn = rest.search(/\n(export )?(async )?function /);
   const cut = [jsdoc, nextFn].filter((i) => i !== -1).sort((a, b) => a - b)[0];
   return stripComments('e' + (cut === undefined ? rest : rest.slice(0, cut)));
 }
@@ -24,75 +24,81 @@ export function buildLocks() {
   return {
     reference_only_header: (s) => /REFERENCE ONLY/.test(s),
 
-    // D1: captureBoundary wraps op() in try/catch and routes failure to capture(),
-    // whose failure path appends a structured entry to the injected sink.
+    // D1: captureBoundary wraps op() in try/catch and routes failure through the
+    // last-ditch guard to record(), which appends a schema-shaped entry to the sink.
     capture_at_boundary: (s) => {
       const cb = fnBody(s, 'captureBoundary');
-      const cap = fnBody(s, 'capture');
-      if (!cb || !cap) return false;
-      const wrapsOp = /try\s*\{[\s\S]*?op\(\)[\s\S]*?\}\s*catch/.test(cb) && /return capture\(/.test(cb);
-      const appendsEntry = /sink\.append\(\s*\{[\s\S]*?symptom[\s\S]*?dedup_hash/.test(cap);
+      const rec = fnBody(s, 'record');
+      if (!cb || !rec) return false;
+      const wrapsOp = /try\s*\{[\s\S]*?op\(\)[\s\S]*?\}\s*catch/.test(cb) && /return guard\(/.test(cb);
+      const appendsEntry = /sink\.append\(\s*entry\s*\)/.test(rec) && /buildEntry\(/.test(rec);
       return wrapsOp && appendsEntry;
     },
 
-    // D2 (never-throws): the boundary catch RETURNS (never re-throws); the sink write
-    // is wrapped in try/catch; the logger goes through safeLog (which swallows a
-    // logger failure). No bare throw on the failure path — the seam must not become
-    // the swallow footgun it fights.
+    // D2 (never-throws — for ANY input): the boundary routes failure through guard()
+    // (a last-ditch try that returns a best-effort result rather than propagate); the
+    // pure prologue is throw-safe (symptomOf guards String(err); utcDayOf handles an
+    // invalid/NaN time); the sink write and the logger are each wrapped; no bare throw.
     never_throws_best_effort: (s) => {
       const cb = fnBody(s, 'captureBoundary');
-      const cap = fnBody(s, 'capture');
+      const g = fnBody(s, 'guard');
       const sl = fnBody(s, 'safeLog');
-      if (!cb || !cap || !sl) return false;
-      const catchReturns = /catch\s*\([^)]*\)\s*\{\s*return capture\(/.test(cb);
-      const sinkWrapped = /try\s*\{\s*sink\.append\([\s\S]*?\}\s*catch/.test(cap);
+      const sy = fnBody(s, 'symptomOf');
+      const ud = fnBody(s, 'utcDayOf');
+      const rec = fnBody(s, 'record');
+      if (!cb || !g || !sl || !sy || !ud || !rec) return false;
+      const catchGuards = /catch\s*\([^)]*\)\s*\{\s*return guard\(/.test(cb);
+      const guardCatchReturns = /catch\s*\([^)]*\)\s*\{[\s\S]*?return\s*\{\s*ok:\s*false/.test(g);
       const safeLoggerWrapped = /try\s*\{\s*logger\.error\([\s\S]*?\}\s*catch/.test(sl);
-      const noBareThrow = !/\bthrow\b/.test(cap);
-      return catchReturns && sinkWrapped && safeLoggerWrapped && noBareThrow;
+      const symptomGuarded = /try\s*\{[\s\S]*?String\(err\)[\s\S]*?\}\s*catch/.test(sy);
+      const clockGuarded = /Number\.isFinite/.test(ud);
+      const sinkWrapped = /try\s*\{\s*sink\.append\([\s\S]*?\}\s*catch/.test(rec);
+      const noBareThrow = !/\bthrow\b/.test(cb) && !/\bthrow\b/.test(rec);
+      return catchGuards && guardCatchReturns && safeLoggerWrapped && symptomGuarded && clockGuarded && sinkWrapped && noBareThrow;
     },
 
-    // D2 (never-silent): the FIRST-capture branch emits BOTH a durable row (sink.append)
-    // AND a stderr line (safeLog logger). Both present in the else branch.
+    // D2 (never-silent): the FIRST-capture path emits BOTH a durable row (sink.append)
+    // AND a stderr line (safeLog logger).
     never_silent_stderr_and_row: (s) => {
-      const cap = fnBody(s, 'capture');
-      if (!cap) return false;
-      return /sink\.append\(/.test(cap) && /safeLog\(\s*logger/.test(cap);
+      const rec = fnBody(s, 'record');
+      if (!rec) return false;
+      return /sink\.append\(/.test(rec) && /safeLog\(\s*logger/.test(rec);
     },
 
-    // D3: dedup_hash is composed of STABLE fields ONLY (utcDay + symptom + source);
-    // emitted_at (volatile) is NOT part of the hash but IS stored on the row.
+    // D3: dedup_hash is STABLE fields ONLY (utcDay + symptom + source); emitted_at
+    // (volatile) is stored on the entry but NOT part of the hash.
     dedup_stable_fields_only: (s) => {
       const dh = fnBody(s, 'dedupHash');
-      const cap = fnBody(s, 'capture');
-      if (!dh || !cap) return false;
-      const stableHash = /\$\{utcDay\}::\$\{symptom\}::\$\{source\}/.test(dh) && !/emitted_at/.test(dh);
-      const volatileStored = /emitted_at:\s*clock\.now\(\)/.test(cap);
+      const be = fnBody(s, 'buildEntry');
+      if (!dh || !be) return false;
+      const stableHash = /\$\{utcDay\}::\$\{symptom\}::\$\{String\(source\)\}/.test(dh) && !/emitted_at/.test(dh);
+      const volatileStored = /emitted_at:\s*safeNow\(clock\)/.test(be);
       return stableHash && volatileStored;
     },
 
-    // D3: dedup lookup is co-scoped by (category, dedup_hash) — same hash under a
-    // different category is a new row.
+    // D3: dedup lookup is co-scoped by (category, dedup_hash).
     category_scoped_dedup: (s) => {
-      const cap = fnBody(s, 'capture');
-      if (!cap) return false;
-      return /sink\.findByHash\(\s*\{\s*category,\s*dedup_hash\s*\}\s*\)/.test(cap);
+      const rec = fnBody(s, 'record');
+      if (!rec) return false;
+      return /findByHash\(\s*\{\s*category,\s*dedup_hash/.test(rec);
     },
 
-    // D4: the SUCCESS path writes nothing — captureBoundary's non-throwing return has
-    // no sink/logger/safeLog call (discrimination is throw-vs-return, not truthiness).
+    // D4: the SUCCESS path writes nothing (all writes live in record()); discrimination
+    // is throw-vs-return, not truthiness.
     healthy_path_silent: (s) => {
       const cb = fnBody(s, 'captureBoundary');
       if (!cb) return false;
       const returnsValue = /return\s*\{\s*ok:\s*true,\s*value\s*\}/.test(cb);
-      const noWriteOnSuccess = !/sink\.|logger\.|safeLog\(/.test(cb); // all writes live in capture()
+      const noWriteOnSuccess = !/sink\.|logger\.|safeLog\(/.test(cb);
       return returnsValue && noWriteOnSuccess;
     },
 
     // sink/logger/clock are INJECTED (destructured from deps), never module singletons.
     injected_deps: (s) => {
-      const cap = fnBody(s, 'capture');
-      if (!cap) return false;
-      const destructured = /const\s*\{\s*sink,\s*logger,\s*clock/.test(cap);
+      const rec = fnBody(s, 'record');
+      const be = fnBody(s, 'buildEntry');
+      if (!rec || !be) return false;
+      const destructured = /const\s*\{[^}]*\bsink\b[^}]*\}\s*=\s*deps/.test(rec) && /const\s*\{[^}]*\bclock\b[^}]*\}\s*=\s*deps/.test(be);
       const noSingleton = !/^(const|let|var)\s+(sink|logger|clock)\s*=/m.test(s);
       return destructured && noSingleton;
     },

--- a/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
+++ b/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
@@ -50,7 +50,7 @@ export function buildLocks() {
       const catchGuards = /catch\s*\([^)]*\)\s*\{\s*return guard\(/.test(cb);
       const depsCoerced = /deps\s*=\s*deps\s*\|\|\s*\{\}/.test(cb); // an explicit null must not slip the default
       const guardCatchReturns = /catch\s*\([^)]*\)\s*\{[\s\S]*?return\s*\{\s*ok:\s*false/.test(g);
-      const guardLogNullSafe = /safeLog\(\s*deps\s*&&\s*deps\.logger/.test(g); // catch handler must not deref null deps
+      const guardLogNullSafe = /safeLog\(\s*safeGet\(deps,\s*'logger'\)/.test(g); // catch handler read must survive a null deps AND a throwing getter/Proxy
       const safeLoggerWrapped = /try\s*\{\s*logger\.error\([\s\S]*?\}\s*catch/.test(sl);
       const symptomGuarded = /try\s*\{[\s\S]*?String\(err\)[\s\S]*?\}\s*catch/.test(sy);
       const clockGuarded = /Number\.isFinite/.test(ud);

--- a/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
+++ b/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
@@ -48,13 +48,15 @@ export function buildLocks() {
       const rec = fnBody(s, 'record');
       if (!cb || !g || !sl || !sy || !ud || !rec) return false;
       const catchGuards = /catch\s*\([^)]*\)\s*\{\s*return guard\(/.test(cb);
+      const depsCoerced = /deps\s*=\s*deps\s*\|\|\s*\{\}/.test(cb); // an explicit null must not slip the default
       const guardCatchReturns = /catch\s*\([^)]*\)\s*\{[\s\S]*?return\s*\{\s*ok:\s*false/.test(g);
+      const guardLogNullSafe = /safeLog\(\s*deps\s*&&\s*deps\.logger/.test(g); // catch handler must not deref null deps
       const safeLoggerWrapped = /try\s*\{\s*logger\.error\([\s\S]*?\}\s*catch/.test(sl);
       const symptomGuarded = /try\s*\{[\s\S]*?String\(err\)[\s\S]*?\}\s*catch/.test(sy);
       const clockGuarded = /Number\.isFinite/.test(ud);
       const sinkWrapped = /try\s*\{\s*sink\.append\([\s\S]*?\}\s*catch/.test(rec);
       const noBareThrow = !/\bthrow\b/.test(cb) && !/\bthrow\b/.test(rec);
-      return catchGuards && guardCatchReturns && safeLoggerWrapped && symptomGuarded && clockGuarded && sinkWrapped && noBareThrow;
+      return catchGuards && depsCoerced && guardCatchReturns && guardLogNullSafe && safeLoggerWrapped && symptomGuarded && clockGuarded && sinkWrapped && noBareThrow;
     },
 
     // D2 (never-silent): the FIRST-capture path emits BOTH a durable row (sink.append)

--- a/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
+++ b/golden-references/feedback-error-capture-seam/acceptance-locks.mjs
@@ -1,0 +1,117 @@
+// Structural acceptance LOCKS for the feedback/error-capture-seam reference —
+// pure predicates over the JS source, node-builtins-only. Textual locks are
+// NECESSARY BUT WEAK (the -C lesson); the behavioral suite (parameterized over
+// GOLDEN_REF_MODULE) CALLS captureBoundary with a planted failure — and with a
+// THROWING sink/logger — and is the primary enforcement (best-effort robustness
+// and the swallow/never-silent doctrines are things no grep can prove).
+export const DEFAULT_MODULE = 'golden-references/feedback-error-capture-seam/capture-seam.mjs';
+
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+/** Code body of a named function (exported or not), comments stripped. */
+function fnBody(src, name) {
+  const start = src.search(new RegExp('(export )?function ' + name + '\\b'));
+  if (start === -1) return null;
+  const rest = src.slice(start + 1);
+  const jsdoc = rest.search(/\n\/\*\*/);
+  const nextFn = rest.search(/\n(export )?function /);
+  const cut = [jsdoc, nextFn].filter((i) => i !== -1).sort((a, b) => a - b)[0];
+  return stripComments('e' + (cut === undefined ? rest : rest.slice(0, cut)));
+}
+
+export function buildLocks() {
+  return {
+    reference_only_header: (s) => /REFERENCE ONLY/.test(s),
+
+    // D1: captureBoundary wraps op() in try/catch and routes failure to capture(),
+    // whose failure path appends a structured entry to the injected sink.
+    capture_at_boundary: (s) => {
+      const cb = fnBody(s, 'captureBoundary');
+      const cap = fnBody(s, 'capture');
+      if (!cb || !cap) return false;
+      const wrapsOp = /try\s*\{[\s\S]*?op\(\)[\s\S]*?\}\s*catch/.test(cb) && /return capture\(/.test(cb);
+      const appendsEntry = /sink\.append\(\s*\{[\s\S]*?symptom[\s\S]*?dedup_hash/.test(cap);
+      return wrapsOp && appendsEntry;
+    },
+
+    // D2 (never-throws): the boundary catch RETURNS (never re-throws); the sink write
+    // is wrapped in try/catch; the logger goes through safeLog (which swallows a
+    // logger failure). No bare throw on the failure path — the seam must not become
+    // the swallow footgun it fights.
+    never_throws_best_effort: (s) => {
+      const cb = fnBody(s, 'captureBoundary');
+      const cap = fnBody(s, 'capture');
+      const sl = fnBody(s, 'safeLog');
+      if (!cb || !cap || !sl) return false;
+      const catchReturns = /catch\s*\([^)]*\)\s*\{\s*return capture\(/.test(cb);
+      const sinkWrapped = /try\s*\{\s*sink\.append\([\s\S]*?\}\s*catch/.test(cap);
+      const safeLoggerWrapped = /try\s*\{\s*logger\.error\([\s\S]*?\}\s*catch/.test(sl);
+      const noBareThrow = !/\bthrow\b/.test(cap);
+      return catchReturns && sinkWrapped && safeLoggerWrapped && noBareThrow;
+    },
+
+    // D2 (never-silent): the FIRST-capture branch emits BOTH a durable row (sink.append)
+    // AND a stderr line (safeLog logger). Both present in the else branch.
+    never_silent_stderr_and_row: (s) => {
+      const cap = fnBody(s, 'capture');
+      if (!cap) return false;
+      return /sink\.append\(/.test(cap) && /safeLog\(\s*logger/.test(cap);
+    },
+
+    // D3: dedup_hash is composed of STABLE fields ONLY (utcDay + symptom + source);
+    // emitted_at (volatile) is NOT part of the hash but IS stored on the row.
+    dedup_stable_fields_only: (s) => {
+      const dh = fnBody(s, 'dedupHash');
+      const cap = fnBody(s, 'capture');
+      if (!dh || !cap) return false;
+      const stableHash = /\$\{utcDay\}::\$\{symptom\}::\$\{source\}/.test(dh) && !/emitted_at/.test(dh);
+      const volatileStored = /emitted_at:\s*clock\.now\(\)/.test(cap);
+      return stableHash && volatileStored;
+    },
+
+    // D3: dedup lookup is co-scoped by (category, dedup_hash) — same hash under a
+    // different category is a new row.
+    category_scoped_dedup: (s) => {
+      const cap = fnBody(s, 'capture');
+      if (!cap) return false;
+      return /sink\.findByHash\(\s*\{\s*category,\s*dedup_hash\s*\}\s*\)/.test(cap);
+    },
+
+    // D4: the SUCCESS path writes nothing — captureBoundary's non-throwing return has
+    // no sink/logger/safeLog call (discrimination is throw-vs-return, not truthiness).
+    healthy_path_silent: (s) => {
+      const cb = fnBody(s, 'captureBoundary');
+      if (!cb) return false;
+      const returnsValue = /return\s*\{\s*ok:\s*true,\s*value\s*\}/.test(cb);
+      const noWriteOnSuccess = !/sink\.|logger\.|safeLog\(/.test(cb); // all writes live in capture()
+      return returnsValue && noWriteOnSuccess;
+    },
+
+    // sink/logger/clock are INJECTED (destructured from deps), never module singletons.
+    injected_deps: (s) => {
+      const cap = fnBody(s, 'capture');
+      if (!cap) return false;
+      const destructured = /const\s*\{\s*sink,\s*logger,\s*clock/.test(cap);
+      const noSingleton = !/^(const|let|var)\s+(sink|logger|clock)\s*=/m.test(s);
+      return destructured && noSingleton;
+    },
+
+    builtins_only_import: (s) => {
+      const spec = [
+        ...[...s.matchAll(/^\s*import\s+(?:[^'"]*?\sfrom\s+)?['"]([^'"]+)['"]/gm)].map((m) => m[1]),
+        ...[...s.matchAll(/^\s*export\s+[^'"]*?\sfrom\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]),
+        ...[...s.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g)].map((m) => m[1]),
+      ];
+      const hasRequire = /\brequire\s*\(/.test(s);
+      return !hasRequire && spec.every((i) => i.startsWith('node:'));
+    },
+  };
+}
+
+/** Evaluate every lock over a module's source; returns { ok, failed: [] }. */
+export function judgeSource(src) {
+  const locks = buildLocks();
+  const failed = Object.entries(locks).filter(([, check]) => !check(src)).map(([name]) => name);
+  return { ok: failed.length === 0, failed };
+}

--- a/golden-references/feedback-error-capture-seam/application-guide.md
+++ b/golden-references/feedback-error-capture-seam/application-guide.md
@@ -31,6 +31,20 @@ this folder.
    call site so recurrences dedup.
 5. Keep `symptom` derived safely from the thrown value (a non-`Error` throw must not
    break the coercion).
+6. Keep `source` a stable STRING per call site (an object `source` collapses under
+   `String()` to `[object Object]` and over-dedups distinct call sites).
+
+### Async ops (REQUIRED when `op` OR `sink.append` returns a Promise)
+
+`captureBoundary` is SYNCHRONOUS. If `op` is `async` (or returns a Promise), a rejection
+is NOT a synchronous throw — the sync seam returns `{ ok:true, value:<rejected promise> }`
+and captures NOTHING (the rejection later surfaces as an unhandledRejection outside the
+seam). This is the swallow class the reference exists to defeat, so it is a footgun on the
+teaching surface. **Use `captureBoundaryAsync` whenever `op` or your sink is async** — and
+the estate's real sink (`emit-feedback.js` `emitFeedback`) IS `async`, so an application
+adapter almost always needs the async variant. `captureBoundaryAsync` awaits `op()` (a
+rejection IS a captured failure) and awaits the sink (so an async write failure is caught).
+Both share every doctrine below and neither ever throws/rejects.
 
 ## Invariants
 

--- a/golden-references/feedback-error-capture-seam/application-guide.md
+++ b/golden-references/feedback-error-capture-seam/application-guide.md
@@ -1,0 +1,92 @@
+# Application guide — feedback/error capture seam
+
+Template-shaped for a delegate-tier session. You adapt `capture-seam.mjs` to wrap a
+risky operation for your own venture/build; you do not need estate context beyond
+this folder.
+
+## Inputs
+
+- **op** — the risky operation to run. If it RETURNS (even a falsy value), that is a
+  success. If it THROWS, that is a failure to capture.
+- **sink** — the injected durable ledger: `append(entry)` writes a row,
+  `findByHash({ category, dedup_hash })` returns an existing row or falsy. In an
+  application this is the `feedback` table via `emit-feedback.js`; here it is an
+  in-memory object.
+- **logger** — the injected stderr sink: `error(line)`. Kept separate from the row so
+  a failure is both durable (row) and immediately visible (stderr).
+- **clock** — the injected time source: `now()` returns epoch ms. Injected so the
+  per-UTC-day dedup boundary is deterministic (never `Date.now()` inside the seam).
+- **category / type / source / severity** — the routing + identity of the failure;
+  `source` and the error's `symptom` (message) form the stable dedup identity.
+
+## Adaptation points
+
+1. Replace `op` with your risky operation; keep the discrimination throw-vs-return
+   (do NOT test the return value for truthiness — a valid `0`/`''`/`false`/`null`
+   return is a success).
+2. Map `sink` onto your durable channel (`append` + a `findByHash` co-scoped by
+   `category` + `dedup_hash`); in the estate that is `emit-feedback.js` over `feedback`.
+3. Map `logger` onto your stderr writer.
+4. Choose `category`/`type`/`severity` for your routing; `source` should be stable per
+   call site so recurrences dedup.
+5. Keep `symptom` derived safely from the thrown value (a non-`Error` throw must not
+   break the coercion).
+
+## Invariants
+
+These are never legal adaptations — each has a WHY in the reference:
+
+- **Capture at the boundary, never swallow** — a failure records a structured,
+  schema-shaped entry to the sink. An empty `catch` that discards the error is the
+  anti-pattern; a guessed column that silently no-ops is its schema cousin.
+- **Best-effort but never silent** *(seam-design hardening — see the note below)* — the
+  seam NEVER throws (returns `{ ok:false, error }` so the caller is not broken) AND, on a
+  first capture, emits BOTH a durable row AND a stderr line. Critically, the capture
+  itself is best-effort: a throwing `sink.append` or `logger.error` is caught, so the
+  anti-swallow seam never becomes a swallow footgun. An UNGUARDED sink call is exactly
+  that footgun.
+- **Dedup on stable fields only, per-UTC-day, category-scoped** — `dedup_hash =
+  sha256(utcDay::symptom::source)` over STABLE fields; `emitted_at` is stored on the row
+  but MUST NOT join the hash, or identical failures flood. Dedup is per-UTC-day and
+  co-scoped by `category`; a recurrence across a UTC-day boundary, or under a different
+  category, is intentionally a fresh row. A deduped recurrence writes NO new row AND NO
+  new stderr — re-emitting is the flood.
+- **Healthy path is silent** — a success writes no row and emits no stderr.
+
+> **Hardening note (attribution honesty)**: the never-throw and the per-capture stderr
+> are deliberate seam-design choices, NOT distilled from `emit-feedback.js` (which throws
+> on insert/validation and is silent on success; `log-harness-bug.js` uses stdout). The
+> estate's `console.warn` enrichment paths and `console.error` dual-write path are the
+> "never fully silent" seed this reference composes into a per-capture guarantee.
+
+### Estate-anchor mapping
+
+| reference field / behavior            | estate anchor                                                              |
+|---------------------------------------|----------------------------------------------------------------------------|
+| `sink.append(entry)`                  | `lib/governance/emit-feedback.js` `emitFeedback` → `feedback` row           |
+| `symptom`                             | `feedback` *description* (the stable dedup component)                       |
+| `dedup_hash = sha256(utcDay::symptom::source)` | `sha256(today::description::dedup_key)`, `today` = UTC day        |
+| `findByHash({category, dedup_hash})`  | dedup CHECK co-scoped by `(category, metadata->>dedup_hash)`               |
+| `emitted_at` stored, excluded from hash | volatile row metadata; `source_id`/`status`/`notes` excluded from hash    |
+| never-throw + per-capture stderr      | **hardening** — cited from `_autoFillDeferredFromSdKey` + the dual-write catch/warn |
+
+## Acceptance (both directions)
+
+Textual locks (`judgeSource` from `acceptance-locks.mjs`) are necessary but WEAK. The
+behavioral contract is the real enforcement — especially the throwing-sink/logger and
+swallow checks no grep can prove — and it runs against YOUR module:
+
+```
+GOLDEN_REF_MODULE=<abs path to your capture-seam.mjs> \
+GOLDEN_REF_SRC=<abs path to your source> \
+npx vitest run tests/unit/golden-references/capture-seam-acceptance.test.js
+```
+
+- **Pass**: a planted throw yields `ok:false` + exactly one row + at least one stderr
+  line and does not throw; a falsy-but-valid return is a silent success; an identical
+  recurrence dedups (no new row, no new stderr); a day boundary or a new category makes
+  a fresh row.
+- **Miss**: a swallow (no row + no stderr), a throw-through, an always-write, a
+  dedup-break (volatile field in the hash), and an unguarded sink (propagates on
+  `sink.append` failure) are each REJECTED by the portable `captureContract` checker —
+  so a broken delegate copy is caught.

--- a/golden-references/feedback-error-capture-seam/capture-seam.mjs
+++ b/golden-references/feedback-error-capture-seam/capture-seam.mjs
@@ -1,0 +1,117 @@
+// Golden reference — feedback/error-capture seam (REFERENCE ONLY, never wired).
+// Source SD: SD-LEO-INFRA-GOLDEN-REFERENCES-CANONICAL-001-F
+//
+// A capture seam turns a risky operation into a CAPTURED failure instead of a
+// SWALLOWED one. The failure class it defeats: the empty catch that discards the
+// error (fail-silent), and the "session-register" class where a call returns
+// ok:true while the durable row it was supposed to write is missing. The seam
+// makes every failure leave TWO traces — a durable row and a stderr line — while
+// never throwing (so it does not break the caller) and never flooding (identical
+// recurrences dedup).
+//
+// Estate anchor (the shape this distills): lib/governance/emit-feedback.js
+//   (@canonical-writer-for:feedback) emitFeedback(...) with
+//   dedupHash = crypto.sha256(`${today}::${description}::${dedup_key}`), today =
+//   toISOString().slice(0,10) (per-UTC-day); the dedup CHECK is co-scoped by
+//   (category, metadata->>dedup_hash); source_id/status/priority/resolution_notes
+//   are EXCLUDED from the hash; emitted_at is volatile row metadata. Callers:
+//   scripts/log-harness-bug.js + scripts/capture-completion-flags.js.
+//
+// ATTRIBUTION HONESTY (do not miscopy as estate-distilled): TWO properties here
+// are deliberate SEAM-DESIGN HARDENING, not a mirror of emitFeedback:
+//   - "never throws" — emitFeedback DOES throw on its INSERT failure and on
+//     validation; only its enrichment (_autoFillDeferredFromSdKey) and its
+//     non-blocking dual-write catch are best-effort. A CAPTURE seam, though,
+//     must not throw — or it re-becomes the swallow class it fights.
+//   - "a stderr line on every first capture" — emitFeedback is SILENT on the
+//     successful row write and log-harness-bug.js logs to STDOUT on success. The
+//     estate's "never fully silent" seed is its console.warn enrichment paths and
+//     its console.error dual-write path; this seam COMPOSES those into a
+//     per-capture stderr guarantee. Labeled as hardening, not distillation.
+//
+// Four doctrines:
+//  1. CAPTURE-AT-BOUNDARY, NEVER SWALLOW — the risky op is wrapped; on failure a
+//     structured, schema-shaped entry is recorded to the INJECTED sink. An empty
+//     catch that discards the error is the anti-pattern.
+//  2. BEST-EFFORT BUT NEVER SILENT — the seam NEVER throws (returns a best-effort
+//     result so the caller is not broken) AND is never silent: a first capture
+//     writes BOTH a row AND a stderr line. Crucially, the capture ITSELF is
+//     best-effort: a throwing sink or logger is caught, so the anti-swallow seam
+//     never becomes a swallow footgun (an unguarded sink.append is exactly that).
+//  3. DEDUP ON STABLE FIELDS ONLY — dedup_hash = sha256(utcDay::symptom::source),
+//     STABLE fields only; emitted_at (volatile) is stored on the row but MUST NOT
+//     join the hash or identical failures flood. Dedup is per-UTC-day and
+//     co-scoped by category; a recurrence across a day boundary is intentionally
+//     a fresh row. A deduped recurrence writes NO new row AND NO new stderr — the
+//     first capture already made it visible; re-emitting IS the flood.
+//  4. HEALTHY PATH IS SILENT — success (op returns, even a FALSY value like 0/''/
+//     false/null) writes no row and emits no stderr. Discrimination is
+//     throw-vs-return, never truthiness.
+import { createHash } from 'node:crypto';
+
+/** Safe symptom text from ANY thrown value (Error, string, number, null, undefined). */
+function symptomOf(err) {
+  if (err && typeof err.message === 'string' && err.message) return err.message;
+  return String(err);
+}
+/** UTC day from the INJECTED clock (never Date.now() — injected for determinism). */
+function utcDayOf(clock) {
+  return new Date(clock.now()).toISOString().slice(0, 10);
+}
+/** Dedup hash over STABLE fields ONLY (utcDay::symptom::source); emitted_at excluded. */
+function dedupHash(utcDay, symptom, source) {
+  return createHash('sha256').update(`${utcDay}::${symptom}::${source}`).digest('hex');
+}
+/** Best-effort stderr — the logger itself failing must never break the seam (D2). */
+function safeLog(logger, line) {
+  try { logger.error(line); } catch { /* logger failed; nothing left to do — never re-throw */ }
+}
+
+/**
+ * Run `op` at a capture boundary.
+ *   SUCCESS (op returns, even a falsy value) -> { ok:true, value }; writes NOTHING.
+ *   FAILURE (op throws) -> NEVER throws; { ok:false, error, deduped }; for the FIRST
+ *   occurrence of this (category, dedup_hash) it appends a schema-shaped row to the
+ *   injected sink AND emits a stderr line; a recurrence dedups (no row, no stderr).
+ *
+ * @param {() => any} op
+ * @param {{ sink: { append: Function, findByHash: Function }, logger: { error: Function },
+ *           clock: { now: () => number }, category: string, type?: string,
+ *           source: string, severity?: string }} deps  All of sink/logger/clock are
+ *           INJECTED (never module singletons).
+ * @returns {{ ok: true, value: any } | { ok: false, error: any, deduped: boolean }}
+ */
+export function captureBoundary(op, deps) {
+  let value;
+  try {
+    value = op();                        // D4: throw-vs-return discrimination, NOT truthiness
+  } catch (err) {
+    return capture(err, deps);           // FAILURE path
+  }
+  return { ok: true, value };            // SUCCESS: falsy values are valid; write nothing
+}
+
+/** The failure path — best-effort capture (D1/D2/D3). Never throws. */
+function capture(err, deps) {
+  const { sink, logger, clock, category, type = 'error', source, severity = 'medium' } = deps;
+  const symptom = symptomOf(err);
+  const utcDay = utcDayOf(clock);
+  const dedup_hash = dedupHash(utcDay, symptom, source);
+  let deduped = false;
+  // First-occurrence guard — best-effort read; a broken read falls through to append.
+  let existing = null;
+  try { existing = sink.findByHash({ category, dedup_hash }); } catch { existing = null; }
+  if (existing) {
+    deduped = true;                      // D3: recurrence already visible — no row, no stderr
+  } else {
+    // D2: durable row + stderr, EACH best-effort so neither's failure throws NOR
+    // skips the other — the anti-swallow seam must not itself swallow.
+    try {
+      sink.append({ category, type, symptom, source, severity, dedup_hash, emitted_at: clock.now() });
+    } catch (sinkErr) {
+      safeLog(logger, `[capture-seam] sink append failed: ${symptomOf(sinkErr)}`); // still not fully silent
+    }
+    safeLog(logger, `[capture-seam] ${category}/${type}: ${symptom} (${source})`);
+  }
+  return { ok: false, error: err, deduped };
+}

--- a/golden-references/feedback-error-capture-seam/capture-seam.mjs
+++ b/golden-references/feedback-error-capture-seam/capture-seam.mjs
@@ -80,6 +80,11 @@ function dedupHash(utcDay, symptom, source) {
 function safeLog(logger, line) {
   try { logger.error(line); } catch { /* logger failed or absent; nothing left to do — never re-throw */ }
 }
+/** Read a property that may be a THROWING getter (or on a hostile Proxy) — never throws.
+ *  Used only where the read happens OUTSIDE any other try (the guard catch handlers). */
+function safeGet(obj, key) {
+  try { return obj == null ? undefined : obj[key]; } catch { return undefined; }
+}
 /** Build the schema-shaped entry from a thrown value + deps (pure; never throws). */
 function buildEntry(err, deps) {
   const { category, type = 'error', source, severity = 'medium', clock } = deps;
@@ -137,11 +142,11 @@ export async function captureBoundaryAsync(op, deps = {}) {
  *  than propagate — never re-becoming the swallow footgun. */
 function guard(err, deps, fn) {
   try { return fn(); }
-  catch (captureErr) { safeLog(deps && deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+  catch (captureErr) { safeLog(safeGet(deps, 'logger'), `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
 }
 async function guardAsync(err, deps, fn) {
   try { return await fn(); }
-  catch (captureErr) { safeLog(deps && deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+  catch (captureErr) { safeLog(safeGet(deps, 'logger'), `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
 }
 
 /** The sync failure path — best-effort capture (D1/D2/D3). */

--- a/golden-references/feedback-error-capture-seam/capture-seam.mjs
+++ b/golden-references/feedback-error-capture-seam/capture-seam.mjs
@@ -50,10 +50,16 @@ function symptomOf(err) {
   try { if (err && typeof err.message === 'string' && err.message) return err.message; } catch { /* throwing getter */ }
   if (err === null || err === undefined) return String(err);
   if (typeof err !== 'object') { try { return String(err); } catch { return 'unserializable-throw'; } }
-  try { const j = JSON.stringify(err); if (j && j !== '{}') return j; } catch { /* circular / throwing toJSON */ }
+  try { const j = JSON.stringify(err); if (j && j !== '{}') return j; } catch { /* circular / throwing toJSON / BigInt */ }
   try {
     const name = (err.constructor && err.constructor.name) || 'Object';
-    return `${name}{${Object.keys(err).slice(0, 12).sort().join(',')}}`;
+    // Include VALUES, not just key NAMES — else distinct non-JSON throws with the same
+    // key-shape ({code:1n} vs {code:2n}) collapse to one dedup row (a swallow of the 2nd).
+    const parts = Object.keys(err).slice(0, 12).sort().map((k) => {
+      let v; try { v = String(err[k]); } catch { v = '?'; }
+      return `${k}=${v.slice(0, 64)}`;
+    });
+    return `${name}{${parts.join(',')}}`;
   } catch { return 'unserializable-throw'; } // null-proto object
 }
 /** Epoch ms from the INJECTED clock — never throws; a hostile clock falls back to 0. */
@@ -97,6 +103,7 @@ function buildEntry(err, deps) {
  * @returns {{ ok: true, value: any } | { ok: false, error: any, deduped: boolean }}
  */
 export function captureBoundary(op, deps = {}) {
+  deps = deps || {};                     // an explicit `null` must not slip past the `= {}` default
   let value;
   try {
     value = op();                        // D4: throw-vs-return discrimination, NOT truthiness
@@ -115,6 +122,7 @@ export function captureBoundary(op, deps = {}) {
  * @returns {Promise<{ ok: true, value: any } | { ok: false, error: any, deduped: boolean }>}
  */
 export async function captureBoundaryAsync(op, deps = {}) {
+  deps = deps || {};                     // an explicit `null` must not slip past the `= {}` default
   let value;
   try {
     value = await op();
@@ -129,11 +137,11 @@ export async function captureBoundaryAsync(op, deps = {}) {
  *  than propagate — never re-becoming the swallow footgun. */
 function guard(err, deps, fn) {
   try { return fn(); }
-  catch (captureErr) { safeLog(deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+  catch (captureErr) { safeLog(deps && deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
 }
 async function guardAsync(err, deps, fn) {
   try { return await fn(); }
-  catch (captureErr) { safeLog(deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+  catch (captureErr) { safeLog(deps && deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
 }
 
 /** The sync failure path — best-effort capture (D1/D2/D3). */

--- a/golden-references/feedback-error-capture-seam/capture-seam.mjs
+++ b/golden-references/feedback-error-capture-seam/capture-seam.mjs
@@ -14,104 +14,147 @@
 //   dedupHash = crypto.sha256(`${today}::${description}::${dedup_key}`), today =
 //   toISOString().slice(0,10) (per-UTC-day); the dedup CHECK is co-scoped by
 //   (category, metadata->>dedup_hash); source_id/status/priority/resolution_notes
-//   are EXCLUDED from the hash; emitted_at is volatile row metadata. Callers:
-//   scripts/log-harness-bug.js + scripts/capture-completion-flags.js.
+//   are EXCLUDED from the hash; emitted_at is volatile row metadata.
 //
-// ATTRIBUTION HONESTY (do not miscopy as estate-distilled): TWO properties here
-// are deliberate SEAM-DESIGN HARDENING, not a mirror of emitFeedback:
-//   - "never throws" — emitFeedback DOES throw on its INSERT failure and on
-//     validation; only its enrichment (_autoFillDeferredFromSdKey) and its
-//     non-blocking dual-write catch are best-effort. A CAPTURE seam, though,
-//     must not throw — or it re-becomes the swallow class it fights.
-//   - "a stderr line on every first capture" — emitFeedback is SILENT on the
-//     successful row write and log-harness-bug.js logs to STDOUT on success. The
-//     estate's "never fully silent" seed is its console.warn enrichment paths and
-//     its console.error dual-write path; this seam COMPOSES those into a
-//     per-capture stderr guarantee. Labeled as hardening, not distillation.
+// ATTRIBUTION HONESTY (do not miscopy as estate-distilled): "never throws" and
+// "a stderr line on every first capture" are deliberate SEAM-DESIGN HARDENING, not
+// a mirror of emitFeedback (which DOES throw on insert/validation and is SILENT on
+// success; log-harness-bug.js uses stdout). The estate "never fully silent" seed is
+// emitFeedback's console.warn enrichment paths + its console.error dual-write catch.
+//
+// SYNC vs ASYNC (do not miscopy): captureBoundary is SYNCHRONOUS — a rejected
+// Promise from an async `op` is NOT a synchronous throw, so a sync seam would
+// SILENTLY pass a failing async op (itself a swallow). Use captureBoundaryAsync for
+// an async `op` and/or an async sink (the estate's emitFeedback returns a Promise).
 //
 // Four doctrines:
 //  1. CAPTURE-AT-BOUNDARY, NEVER SWALLOW — the risky op is wrapped; on failure a
-//     structured, schema-shaped entry is recorded to the INJECTED sink. An empty
-//     catch that discards the error is the anti-pattern.
-//  2. BEST-EFFORT BUT NEVER SILENT — the seam NEVER throws (returns a best-effort
-//     result so the caller is not broken) AND is never silent: a first capture
-//     writes BOTH a row AND a stderr line. Crucially, the capture ITSELF is
-//     best-effort: a throwing sink or logger is caught, so the anti-swallow seam
-//     never becomes a swallow footgun (an unguarded sink.append is exactly that).
+//     structured, schema-shaped entry is recorded to the INJECTED sink.
+//  2. BEST-EFFORT BUT NEVER SILENT — the seam NEVER throws (for ANY thrown value or
+//     hostile dependency — see symptomOf/utcDayOf/safeNow and the last-ditch guard)
+//     AND a first capture writes BOTH a row AND a stderr line. The capture itself is
+//     best-effort: a throwing sink/logger/clock is caught, so the anti-swallow seam
+//     never becomes a swallow footgun.
 //  3. DEDUP ON STABLE FIELDS ONLY — dedup_hash = sha256(utcDay::symptom::source),
-//     STABLE fields only; emitted_at (volatile) is stored on the row but MUST NOT
-//     join the hash or identical failures flood. Dedup is per-UTC-day and
-//     co-scoped by category; a recurrence across a day boundary is intentionally
-//     a fresh row. A deduped recurrence writes NO new row AND NO new stderr — the
-//     first capture already made it visible; re-emitting IS the flood.
-//  4. HEALTHY PATH IS SILENT — success (op returns, even a FALSY value like 0/''/
-//     false/null) writes no row and emits no stderr. Discrimination is
-//     throw-vs-return, never truthiness.
+//     stable fields only; emitted_at (volatile) is stored but MUST NOT join the hash.
+//     Per-UTC-day, co-scoped by category; a deduped recurrence writes no new row and
+//     no new stderr.
+//  4. HEALTHY PATH IS SILENT — success (op returns, even a FALSY value) writes
+//     nothing. Discrimination is throw-vs-return, never truthiness.
 import { createHash } from 'node:crypto';
 
-/** Safe symptom text from ANY thrown value (Error, string, number, null, undefined). */
+/** Safe symptom text from ANY thrown value — never throws, and keeps DISTINCT object
+ *  throws distinct (a bare String(obj) collapses every object to "[object Object]"
+ *  and over-dedups). Order: message string -> JSON -> constructor+keys -> fallback. */
 function symptomOf(err) {
-  if (err && typeof err.message === 'string' && err.message) return err.message;
-  return String(err);
+  try { if (err && typeof err.message === 'string' && err.message) return err.message; } catch { /* throwing getter */ }
+  if (err === null || err === undefined) return String(err);
+  if (typeof err !== 'object') { try { return String(err); } catch { return 'unserializable-throw'; } }
+  try { const j = JSON.stringify(err); if (j && j !== '{}') return j; } catch { /* circular / throwing toJSON */ }
+  try {
+    const name = (err.constructor && err.constructor.name) || 'Object';
+    return `${name}{${Object.keys(err).slice(0, 12).sort().join(',')}}`;
+  } catch { return 'unserializable-throw'; } // null-proto object
 }
-/** UTC day from the INJECTED clock (never Date.now() — injected for determinism). */
+/** Epoch ms from the INJECTED clock — never throws; a hostile clock falls back to 0. */
+function safeNow(clock) {
+  try { const n = clock.now(); return typeof n === 'number' && Number.isFinite(n) ? n : 0; } catch { return 0; }
+}
+/** UTC day from the injected clock — never throws; an invalid/NaN time falls back to epoch. */
 function utcDayOf(clock) {
-  return new Date(clock.now()).toISOString().slice(0, 10);
+  const d = new Date(safeNow(clock));
+  const iso = Number.isFinite(d.getTime()) ? d.toISOString() : '1970-01-01T00:00:00.000Z';
+  return iso.slice(0, 10);
 }
 /** Dedup hash over STABLE fields ONLY (utcDay::symptom::source); emitted_at excluded. */
 function dedupHash(utcDay, symptom, source) {
-  return createHash('sha256').update(`${utcDay}::${symptom}::${source}`).digest('hex');
+  return createHash('sha256').update(`${utcDay}::${symptom}::${String(source)}`).digest('hex');
 }
-/** Best-effort stderr — the logger itself failing must never break the seam (D2). */
+/** Best-effort stderr — the logger itself failing (or being absent) must never throw. */
 function safeLog(logger, line) {
-  try { logger.error(line); } catch { /* logger failed; nothing left to do — never re-throw */ }
+  try { logger.error(line); } catch { /* logger failed or absent; nothing left to do — never re-throw */ }
+}
+/** Build the schema-shaped entry from a thrown value + deps (pure; never throws). */
+function buildEntry(err, deps) {
+  const { category, type = 'error', source, severity = 'medium', clock } = deps;
+  const symptom = symptomOf(err);
+  const dedup_hash = dedupHash(utcDayOf(clock), symptom, source);
+  return { category, type, symptom, source, severity, dedup_hash, emitted_at: safeNow(clock) };
 }
 
 /**
- * Run `op` at a capture boundary.
+ * Run a SYNCHRONOUS `op` at a capture boundary.
  *   SUCCESS (op returns, even a falsy value) -> { ok:true, value }; writes NOTHING.
  *   FAILURE (op throws) -> NEVER throws; { ok:false, error, deduped }; for the FIRST
- *   occurrence of this (category, dedup_hash) it appends a schema-shaped row to the
- *   injected sink AND emits a stderr line; a recurrence dedups (no row, no stderr).
+ *   occurrence of this (category, dedup_hash) it appends a row + emits a stderr line;
+ *   a recurrence dedups (no row, no stderr).
+ * NOTE: sync-only. For an async op or async sink use captureBoundaryAsync.
  *
  * @param {() => any} op
- * @param {{ sink: { append: Function, findByHash: Function }, logger: { error: Function },
- *           clock: { now: () => number }, category: string, type?: string,
- *           source: string, severity?: string }} deps  All of sink/logger/clock are
- *           INJECTED (never module singletons).
+ * @param {{ sink?: { append: Function, findByHash: Function }, logger?: { error: Function },
+ *           clock?: { now: () => number }, category?: string, type?: string,
+ *           source?: string, severity?: string }} [deps]  sink/logger/clock are INJECTED.
  * @returns {{ ok: true, value: any } | { ok: false, error: any, deduped: boolean }}
  */
-export function captureBoundary(op, deps) {
+export function captureBoundary(op, deps = {}) {
   let value;
   try {
     value = op();                        // D4: throw-vs-return discrimination, NOT truthiness
   } catch (err) {
-    return capture(err, deps);           // FAILURE path
+    return guard(err, deps, () => record(err, deps)); // FAILURE path — never throws
   }
   return { ok: true, value };            // SUCCESS: falsy values are valid; write nothing
 }
 
-/** The failure path — best-effort capture (D1/D2/D3). Never throws. */
-function capture(err, deps) {
-  const { sink, logger, clock, category, type = 'error', source, severity = 'medium' } = deps;
-  const symptom = symptomOf(err);
-  const utcDay = utcDayOf(clock);
-  const dedup_hash = dedupHash(utcDay, symptom, source);
-  let deduped = false;
-  // First-occurrence guard — best-effort read; a broken read falls through to append.
-  let existing = null;
-  try { existing = sink.findByHash({ category, dedup_hash }); } catch { existing = null; }
-  if (existing) {
-    deduped = true;                      // D3: recurrence already visible — no row, no stderr
-  } else {
-    // D2: durable row + stderr, EACH best-effort so neither's failure throws NOR
-    // skips the other — the anti-swallow seam must not itself swallow.
-    try {
-      sink.append({ category, type, symptom, source, severity, dedup_hash, emitted_at: clock.now() });
-    } catch (sinkErr) {
-      safeLog(logger, `[capture-seam] sink append failed: ${symptomOf(sinkErr)}`); // still not fully silent
-    }
-    safeLog(logger, `[capture-seam] ${category}/${type}: ${symptom} (${source})`);
+/**
+ * Async variant — awaits `op()` (a rejected Promise IS a captured failure) and awaits
+ * the sink so an async writer (e.g. the estate's emitFeedback) reports its own failure.
+ * Same doctrines; never rejects.
+ * @param {() => (any|Promise<any>)} op
+ * @param {object} [deps]
+ * @returns {Promise<{ ok: true, value: any } | { ok: false, error: any, deduped: boolean }>}
+ */
+export async function captureBoundaryAsync(op, deps = {}) {
+  let value;
+  try {
+    value = await op();
+  } catch (err) {
+    return guardAsync(err, deps, () => recordAsync(err, deps));
   }
-  return { ok: false, error: err, deduped };
+  return { ok: true, value };
+}
+
+/** Last-ditch guard: run `fn` and return its result; if the CAPTURE itself throws
+ *  (a hostile dep slipped past the field guards) return a best-effort result rather
+ *  than propagate — never re-becoming the swallow footgun. */
+function guard(err, deps, fn) {
+  try { return fn(); }
+  catch (captureErr) { safeLog(deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+}
+async function guardAsync(err, deps, fn) {
+  try { return await fn(); }
+  catch (captureErr) { safeLog(deps.logger, `[capture-seam] capture failed: ${symptomOf(captureErr)}`); return { ok: false, error: err, deduped: false }; }
+}
+
+/** The sync failure path — best-effort capture (D1/D2/D3). */
+function record(err, deps) {
+  const { sink, logger, category } = deps;
+  const entry = buildEntry(err, deps);
+  let existing = null;
+  try { existing = sink.findByHash({ category, dedup_hash: entry.dedup_hash }); } catch { existing = null; }
+  if (existing) return { ok: false, error: err, deduped: true }; // D3: recurrence — no row, no stderr
+  try { sink.append(entry); } catch (sinkErr) { safeLog(logger, `[capture-seam] sink append failed: ${symptomOf(sinkErr)}`); }
+  safeLog(logger, `[capture-seam] ${entry.category}/${entry.type}: ${entry.symptom} (${entry.source})`); // D2: never silent
+  return { ok: false, error: err, deduped: false };
+}
+/** The async failure path — awaits an async sink. */
+async function recordAsync(err, deps) {
+  const { sink, logger, category } = deps;
+  const entry = buildEntry(err, deps);
+  let existing = null;
+  try { existing = await sink.findByHash({ category, dedup_hash: entry.dedup_hash }); } catch { existing = null; }
+  if (existing) return { ok: false, error: err, deduped: true };
+  try { await sink.append(entry); } catch (sinkErr) { safeLog(logger, `[capture-seam] sink append failed: ${symptomOf(sinkErr)}`); }
+  safeLog(logger, `[capture-seam] ${entry.category}/${entry.type}: ${entry.symptom} (${entry.source})`);
+  return { ok: false, error: err, deduped: false };
 }

--- a/golden-references/feedback-error-capture-seam/problem-prompt.md
+++ b/golden-references/feedback-error-capture-seam/problem-prompt.md
@@ -1,0 +1,46 @@
+# Problem — feedback/error capture seam
+
+**Domain**: a risky operation can fail. The wrong response is to SWALLOW the failure
+— an empty `catch` that discards the error, or (the "session-register" class) a call
+that returns `ok:true` while the durable row it was supposed to write is missing. Both
+leave a failure with no trace. The right response is to CAPTURE it: leave a durable
+record AND a visible signal, without breaking the caller and without flooding.
+
+**Reuse evidence** (why this domain earned a golden reference):
+
+- **The swallowed-error class is recurring and expensive**: a `catch {}` that returns
+  fail-silent hides the very failure you need to see. The estate funnels failures into
+  a single durable channel precisely so they cannot vanish.
+- **The estate's canonical capture writer** (`lib/governance/emit-feedback.js`,
+  `@canonical-writer-for: feedback`) shows the durable shape: `emitFeedback(...)` inserts
+  a `feedback` row and dedups via `dedupHash = sha256(today::description::dedup_key)`
+  where `today` is the UTC day (`toISOString().slice(0,10)`); the dedup CHECK is
+  co-scoped by `(category, metadata->>dedup_hash)`; `source_id`, `status`, `priority`,
+  and `resolution_notes` are EXCLUDED from the hash, and `emitted_at` is volatile row
+  metadata — dedup keys on STABLE fields only. Its CLI wrapper is
+  `scripts/log-harness-bug.js`; `scripts/capture-completion-flags.js` funnels
+  completion findings through the same channel; sub-agent failures land as error rows
+  in `sub_agent_execution_results`.
+
+**Attribution honesty** (do not miscopy as estate-distilled): two properties of this
+reference are deliberate **seam-design hardening**, not a mirror of `emitFeedback`:
+
+- **"never throws"** — `emitFeedback` actually DOES throw on its insert failure and on
+  validation; only its enrichment path (`_autoFillDeferredFromSdKey`) and its
+  non-blocking dual-write catch are best-effort. A *capture seam*, though, must not
+  throw — if it does, it re-becomes the swallow class it fights. So the seam-wide
+  never-throw is a composition, cited from those two partial precedents.
+- **"a stderr line on every first capture"** — `emitFeedback` is SILENT on the
+  successful row write, and `log-harness-bug.js` logs to STDOUT (not stderr) on success.
+  The estate's "never fully silent" seed is its `console.warn` enrichment-error paths and
+  its `console.error` dual-write path. This reference COMPOSES those into a per-capture
+  stderr guarantee — labeled hardening, not distillation.
+
+The entry shape here (`{category, type, symptom, source, severity, dedup_hash,
+emitted_at}`) is a DISTILLATION of the estate's `feedback` row + dedup shape — `symptom`
+maps to the `feedback` *description*, `dedup_hash` is composed of the same stable fields,
+`emitted_at` is stored but excluded from the hash.
+
+**Task shape a delegate will face**: wrap a risky operation so that a failure leaves a
+durable, deduped row and a visible stderr line, the caller is never broken by a throw
+(not even when the sink or logger itself fails), and a healthy operation stays silent.

--- a/golden-references/registry.json
+++ b/golden-references/registry.json
@@ -58,6 +58,21 @@
         "source_commit": "1041b7bf475b76dee7aac56cf6104b1421be6910"
       },
       "created_at": "2026-07-06T09:44:28.219Z"
+    },
+    {
+      "domain": "feedback-error-capture-seam",
+      "path": "golden-references/feedback-error-capture-seam/",
+      "guide": "application-guide.md — feedback/error capture seam: capture-at-boundary never swallow, best-effort but never silent (seam-design hardening), dedup on stable fields per-UTC-day category-scoped, healthy path silent (four doctrines vs swallowed errors)",
+      "door_class_of_application": "two_way",
+      "provenance": {
+        "source_files": [
+          "lib/governance/emit-feedback.js (@canonical-writer-for:feedback; emitFeedback sha256(today::description::dedup_key) per-UTC-day, stable-fields-only, category-scoped; _buildRowObject schema-shaping; MUST-NOT-throw sub-paths)",
+          "scripts/log-harness-bug.js (CLI wrapper, STDOUT-on-success) + scripts/capture-completion-flags.js (completion funnel)",
+          "feedback table + sub_agent_execution_results error rows; swallowed-error / session-register failure class; never-throw + stderr labeled as seam-design hardening"
+        ],
+        "source_commit": "de44b5d368694634072e7849db2b78b302806a00"
+      },
+      "created_at": "2026-07-06T11:19:52.727Z"
     }
   ]
 }

--- a/tests/unit/golden-references/capture-seam-acceptance.test.js
+++ b/tests/unit/golden-references/capture-seam-acceptance.test.js
@@ -64,6 +64,11 @@ function captureContractViolations(cb) {
     try { cb(() => { throw Object.create(null); }, DEPS(h)); } catch { threw = true; }
     if (threw) v.push('throws-on-hostile-input');
   }
+  { // null-deps: a hostile NULL deps bag + a throwing op must NOT make the seam throw (the re-verify blocker)
+    let threw = false;
+    try { cb(() => { throw new Error('n'); }, null); } catch { threw = true; }
+    if (threw) v.push('throws-on-null-deps');
+  }
   { // healthy-path-silent: success -> no row, no stderr, ok:true
     const h = makeHarness();
     const r = cb(() => 1, DEPS(h));
@@ -103,6 +108,12 @@ const DEDUP_BREAK = (op, d) => {
 const SINK_THROWS_PROPAGATES = (op, d) => {
   try { return { ok: true, value: op() }; } catch (e) {
     d.sink.append({ category: d.category, dedup_hash: 'h', symptom: 'x' }); d.logger.error('x'); // UNGUARDED
+    return { ok: false, error: e };
+  }
+};
+const NULL_DEPS_UNSAFE = (op, d) => { // no `d = d || {}` coercion -> derefs a null deps bag
+  try { return { ok: true, value: op() }; } catch (e) {
+    d.sink.append({ symptom: String(e && e.message) }); d.logger.error('x');
     return { ok: false, error: e };
   }
 };
@@ -180,6 +191,12 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     expect(r.ok).toBe(false);
   });
 
+  it('NEVER-THROWS when deps is explicitly NULL (the null-deps hole: `= {}` only defaults undefined): returns ok:false', () => {
+    let r;
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, null); }).not.toThrow();
+    expect(r.ok).toBe(false);
+  });
+
   it('NON-ERROR throw: a thrown string is captured safely with a stable hash (never throws)', () => {
     const h = makeHarness();
     let r;
@@ -197,6 +214,13 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     captureBoundary(() => { throw { code: 'E1', detail: 'disk full' }; }, DEPS(h));
     captureBoundary(() => { throw { code: 'E2', detail: 'network down' }; }, DEPS(h));
     expect(h.rows).toHaveLength(2); // bare String() would collapse both to "[object Object]"
+  });
+
+  it('NO OVER-DEDUP (non-serializable): two DISTINCT BigInt-bearing throws (JSON.stringify throws) are two rows', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw { code: 1n, detail: 'disk' }; }, DEPS(h)); // BigInt -> JSON path throws -> value fallback
+    captureBoundary(() => { throw { code: 2n, detail: 'net' }; }, DEPS(h));
+    expect(h.rows).toHaveLength(2); // the ctor+keys fallback must include VALUES, not just key names
   });
 
   it('BEST-EFFORT: a throwing sink.append does NOT propagate; a fallback stderr is still emitted', () => {
@@ -293,6 +317,20 @@ describe('async variant (captureBoundaryAsync — the estate sink is async)', ()
     r.value.catch(() => {});                 // swallow the rejection so it is not an unhandled rejection here
     expect(h.rows).toHaveLength(0);          // documented in the module header + guide
   });
+
+  it('NEVER-REJECTS when deps is explicitly NULL: an async rejection returns ok:false', async () => {
+    let r;
+    await expect((async () => { r = await captureBoundaryAsync(async () => { throw new Error('boom'); }, null); })()).resolves.not.toThrow();
+    expect(r.ok).toBe(false);
+  });
+
+  it('async teeth: a SWALLOW-async copy is OBSERVABLY broken (no row despite a rejection)', async () => {
+    const swallowAsync = async (op) => { try { return { ok: true, value: await op() }; } catch (e) { return { ok: false, error: e }; } };
+    const h = makeHarness();
+    const r = await swallowAsync(async () => { throw new Error('x'); });
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(0);          // a delegate can observe the async swallow — the async path IS checkable
+  });
 });
 
 describe('the capture CONTRACT has TEETH (proves enforcement reaches a delegate copy)', () => {
@@ -313,6 +351,9 @@ describe('the capture CONTRACT has TEETH (proves enforcement reaches a delegate 
   });
   it('NEGATIVE-COPY: a SINK-THROWS-PROPAGATES copy (unguarded sink) is REJECTED', () => {
     expect(captureContractViolations(SINK_THROWS_PROPAGATES)).toContain('sink-throws-propagates');
+  });
+  it('NEGATIVE-COPY: a NULL-DEPS-UNSAFE copy (derefs a null deps bag) is REJECTED', () => {
+    expect(captureContractViolations(NULL_DEPS_UNSAFE)).toContain('throws-on-null-deps');
   });
   it('NEGATIVE-COPY: a NOT-HARDENED copy (throws on a hostile input) is REJECTED', () => {
     const notHardened = (op, d) => {
@@ -347,6 +388,14 @@ describe('doctrine mutations fail named checks (miss direction)', () => {
   });
   it('re-throwing from the boundary catch fails never_throws_best_effort', () => {
     const m = CANON.replace('return guard(err, deps, () => record(err, deps));', 'throw err;');
+    expect(judgeSource(m).failed).toContain('never_throws_best_effort');
+  });
+  it('removing the deps null-coercion fails never_throws_best_effort', () => {
+    const m = CANON.replace('deps = deps || {};', 'deps = deps;'); // first occurrence = captureBoundary
+    expect(judgeSource(m).failed).toContain('never_throws_best_effort');
+  });
+  it('an unguarded null-deps deref in the guard catch fails never_throws_best_effort', () => {
+    const m = CANON.replace(/safeLog\(deps && deps\.logger/g, 'safeLog(deps.logger');
     expect(judgeSource(m).failed).toContain('never_throws_best_effort');
   });
   it('an unguarded logger fails never_throws_best_effort', () => {

--- a/tests/unit/golden-references/capture-seam-acceptance.test.js
+++ b/tests/unit/golden-references/capture-seam-acceptance.test.js
@@ -2,9 +2,10 @@
 // first and PARAMETERIZED over GOLDEN_REF_MODULE from line 1 (the -C fix) so a
 // delegate's adapted COPY gets the same calling-enforcement. The load-bearing
 // tests are the ones a grep cannot prove: a planted failure must leave a row AND
-// a stderr line; a THROWING sink/logger must NOT propagate (the anti-swallow seam
-// must not itself swallow); a falsy-but-valid return must NOT be miscaptured; and
-// the captureContract must REJECT four broken delegate copies.
+// a stderr line; a HOSTILE thrown value (null-proto, throwing getter) or a bad
+// clock must NOT make the seam throw (the -F adversarial lesson: "never throws"
+// is absolute); a THROWING sink/logger must not propagate; a falsy-but-valid
+// return must not be miscaptured; and the captureContract must REJECT broken copies.
 import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
@@ -18,15 +19,15 @@ const MODULE_PATH = abs(process.env.GOLDEN_REF_MODULE, CANON_PATH);
 const SRC_PATH = abs(process.env.GOLDEN_REF_SRC, MODULE_PATH);
 const SRC = readFileSync(SRC_PATH, 'utf8');
 
-let captureBoundary;
+let captureBoundary, captureBoundaryAsync;
 beforeAll(async () => {
   const mod = await import(pathToFileURL(MODULE_PATH).href);
   captureBoundary = mod.captureBoundary;
+  captureBoundaryAsync = mod.captureBoundaryAsync;
 });
 
 // Injected harness: an in-memory sink (append + findByHash), a stderr logger, and a
-// controllable clock — all injected, never singletons. Counters let tests assert
-// exact row/line counts.
+// controllable clock — all injected, never singletons.
 function makeHarness(startMs = 0) {
   const rows = [];
   const sink = {
@@ -42,13 +43,11 @@ function makeHarness(startMs = 0) {
 const DEPS = (h, over = {}) => ({ sink: h.sink, logger: h.logger, clock: h.clock, category: 'harness_backlog', type: 'error', source: 'demo', ...over });
 
 // A PORTABLE capture-contract checker — the teeth a delegate runs against their own
-// copy. Returns the list of contract VIOLATIONS (empty === compliant). It probes only
-// OBSERVABLE outcomes (row/line counts, throw, return shape) and shares NO hash helper
-// with the reference.
+// copy. Returns contract VIOLATIONS (empty === compliant). Probes only OBSERVABLE
+// outcomes (row/line counts, throw, return shape); shares NO hash helper.
 function captureContractViolations(cb) {
   const v = [];
-  // capture-on-failure: failing op -> ok:false, exactly 1 row, >=1 stderr, no throw
-  {
+  { // capture-on-failure: failing op -> ok:false, exactly 1 row, >=1 stderr, no throw
     const h = makeHarness();
     let threw = false, r;
     try { r = cb(() => { throw new Error('x'); }, DEPS(h)); } catch { threw = true; }
@@ -59,16 +58,19 @@ function captureContractViolations(cb) {
       if (h.lines.length < 1) v.push('silent-on-failure');
     }
   }
-  // healthy-path-silent: success -> no row, no stderr, ok:true
-  {
+  { // throw-safety: a HOSTILE thrown value must NOT make the seam throw (F1 class)
+    const h = makeHarness();
+    let threw = false;
+    try { cb(() => { throw Object.create(null); }, DEPS(h)); } catch { threw = true; }
+    if (threw) v.push('throws-on-hostile-input');
+  }
+  { // healthy-path-silent: success -> no row, no stderr, ok:true
     const h = makeHarness();
     const r = cb(() => 1, DEPS(h));
     if (!(r && r.ok === true)) v.push('success-not-ok-true');
     if (h.rows.length !== 0 || h.lines.length !== 0) v.push('writes-on-healthy-path');
   }
-  // dedup-break: identical failure twice (clock advanced) -> must stay 1 row.
-  // Guarded: a throw-through copy is already flagged by the first probe.
-  {
+  { // dedup-break: identical failure twice (clock advanced) -> must stay 1 row
     const h = makeHarness();
     try {
       cb(() => { throw new Error('dup'); }, DEPS(h));
@@ -77,8 +79,7 @@ function captureContractViolations(cb) {
       if (h.rows.length > 1) v.push('dedup-break');
     } catch { /* throw-through: flagged elsewhere */ }
   }
-  // best-effort: a THROWING sink.append must NOT propagate
-  {
+  { // best-effort: a THROWING sink.append must NOT propagate
     const badSink = { append: () => { throw new Error('sink down'); }, findByHash: () => null };
     let threw = false;
     try { cb(() => { throw new Error('y'); }, { sink: badSink, logger: { error: () => {} }, clock: { now: () => 0 }, category: 'c', source: 's' }); }
@@ -88,22 +89,20 @@ function captureContractViolations(cb) {
   return v;
 }
 
-// Four+one REAL broken delegate copies (inline implementations the contract rejects).
-const SWALLOW = (op) => { try { return { ok: true, value: op() }; } catch (e) { return { ok: false, error: e }; } }; // no row, no stderr
-const THROW_THROUGH = (op) => ({ ok: true, value: op() }); // no capture at all
+// REAL broken delegate copies (inline implementations the contract rejects).
+const SWALLOW = (op) => { try { return { ok: true, value: op() }; } catch (e) { return { ok: false, error: e }; } };
+const THROW_THROUGH = (op) => ({ ok: true, value: op() });
 const ALWAYS_WRITE = (op, d) => { d.sink.append({ note: 'always' }); try { return { ok: true, value: op() }; } catch (e) { return { ok: false, error: e }; } };
 const DEDUP_BREAK = (op, d) => {
   try { return { ok: true, value: op() }; } catch (e) {
     const sym = e && e.message ? e.message : String(e);
-    const hash = `${d.source}:${sym}:${d.clock.now()}`; // volatile now() in the key -> floods
-    d.sink.append({ category: d.category, dedup_hash: hash, symptom: sym }); d.logger.error('x');
+    d.sink.append({ category: d.category, dedup_hash: `${d.source}:${sym}:${d.clock.now()}`, symptom: sym }); d.logger.error('x');
     return { ok: false, error: e };
   }
 };
 const SINK_THROWS_PROPAGATES = (op, d) => {
   try { return { ok: true, value: op() }; } catch (e) {
-    d.sink.append({ category: d.category, dedup_hash: 'h', symptom: 'x' }); // UNGUARDED -> propagates if sink throws
-    d.logger.error('x');
+    d.sink.append({ category: d.category, dedup_hash: 'h', symptom: 'x' }); d.logger.error('x'); // UNGUARDED
     return { ok: false, error: e };
   }
 };
@@ -115,10 +114,9 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     let r;
     expect(() => { r = captureBoundary(() => { throw err; }, DEPS(h)); }).not.toThrow();
     expect(r.ok).toBe(false);
-    expect(r.error).toBe(err);            // failure return contract
+    expect(r.error).toBe(err);
     expect(h.rows).toHaveLength(1);
     expect(h.lines.length).toBeGreaterThanOrEqual(1);
-    // full schema, emitted_at sourced from the INJECTED clock
     expect(h.rows[0]).toMatchObject({ category: 'harness_backlog', type: 'error', symptom: 'boom', source: 'demo', severity: 'medium' });
     expect(h.rows[0].dedup_hash).toEqual(expect.any(String));
     expect(h.rows[0].emitted_at).toBe(1000);
@@ -143,26 +141,71 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     }
   });
 
-  it('NON-ERROR throw: a thrown string/number/null is captured safely with a stable hash (never throws)', () => {
+  it('NEVER-THROWS on a null-proto throw (String(err) would throw): captured, no propagation', () => {
+    const h = makeHarness();
+    let r;
+    expect(() => { r = captureBoundary(() => { throw Object.create(null); }, DEPS(h)); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1); // still captured
+  });
+
+  it('NEVER-THROWS on a throwing message getter: captured, no propagation', () => {
+    const h = makeHarness();
+    let r;
+    const hostile = { get message() { throw new Error('getter'); } };
+    expect(() => { r = captureBoundary(() => { throw hostile; }, DEPS(h)); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1);
+  });
+
+  it('NEVER-THROWS on a NaN / hostile clock (Date(NaN).toISOString() would throw): captured with an epoch-fallback day', () => {
+    const h = makeHarness();
+    let r;
+    const badClock = { now: () => NaN };
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), clock: badClock }); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1);
+    expect(h.rows[0].emitted_at).toBe(0); // safe fallback
+  });
+
+  it('NEVER-THROWS on a throwing clock: captured, no propagation', () => {
+    const h = makeHarness();
+    const throwingClock = { now: () => { throw new Error('clock down'); } };
+    expect(() => captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), clock: throwingClock })).not.toThrow();
+  });
+
+  it('NEVER-THROWS when deps are omitted (the deps-asymmetry footgun): a failure returns ok:false', () => {
+    let r;
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }); }).not.toThrow();
+    expect(r.ok).toBe(false);
+  });
+
+  it('NON-ERROR throw: a thrown string is captured safely with a stable hash (never throws)', () => {
     const h = makeHarness();
     let r;
     expect(() => { r = captureBoundary(() => { throw 'raw string boom'; }, DEPS(h)); }).not.toThrow();
     expect(r.ok).toBe(false);
-    expect(h.rows).toHaveLength(1);
     const firstHash = h.rows[0].dedup_hash;
     h.clock.advance(5);
-    captureBoundary(() => { throw 'raw string boom'; }, DEPS(h)); // identical non-Error -> deduped
+    captureBoundary(() => { throw 'raw string boom'; }, DEPS(h));
     expect(h.rows).toHaveLength(1);
-    expect(h.rows[0].dedup_hash).toBe(firstHash); // stable across repeats
+    expect(h.rows[0].dedup_hash).toBe(firstHash);
   });
 
-  it('BEST-EFFORT: a throwing sink.append does NOT propagate (the seam never becomes a swallow footgun)', () => {
+  it('NO OVER-DEDUP: two DISTINCT object throws (no .message) are two rows, not one', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw { code: 'E1', detail: 'disk full' }; }, DEPS(h));
+    captureBoundary(() => { throw { code: 'E2', detail: 'network down' }; }, DEPS(h));
+    expect(h.rows).toHaveLength(2); // bare String() would collapse both to "[object Object]"
+  });
+
+  it('BEST-EFFORT: a throwing sink.append does NOT propagate; a fallback stderr is still emitted', () => {
     const badSink = { append: () => { throw new Error('sink down'); }, findByHash: () => null };
     const h = makeHarness();
     let r;
     expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), sink: badSink }); }).not.toThrow();
     expect(r.ok).toBe(false);
-    expect(h.lines.length).toBeGreaterThanOrEqual(1); // still not fully silent (fallback stderr)
+    expect(h.lines.length).toBeGreaterThanOrEqual(1);
   });
 
   it('BEST-EFFORT: a throwing logger does NOT propagate AND the row is still written', () => {
@@ -171,58 +214,84 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     let r;
     expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), logger: badLogger }); }).not.toThrow();
     expect(r.ok).toBe(false);
-    expect(h.rows).toHaveLength(1); // sink write survives a logger failure
+    expect(h.rows).toHaveLength(1);
   });
 
   it('DEDUP same-stable, different-volatile: identical failure recurs -> 1 row, second deduped, NO new stderr', () => {
     const h = makeHarness();
     captureBoundary(() => { throw new Error('dup'); }, DEPS(h));
     const linesAfterFirst = h.lines.length;
-    h.clock.advance(1000); // volatile emitted_at differs, stable key identical
+    h.clock.advance(1000);
     const r2 = captureBoundary(() => { throw new Error('dup'); }, DEPS(h));
     expect(h.rows).toHaveLength(1);
     expect(r2.deduped).toBe(true);
-    expect(h.lines).toHaveLength(linesAfterFirst); // deduped recurrence is silent (no flood)
+    expect(h.lines).toHaveLength(linesAfterFirst);
   });
 
-  it('DEDUP different-stable: a different symptom is a new row', () => {
-    const h = makeHarness();
+  it('DEDUP different-stable / HASH excludes volatile / UTC-day boundary / CATEGORY co-scope / TYPE excluded', () => {
+    // different symptom -> new row
+    let h = makeHarness();
     captureBoundary(() => { throw new Error('one'); }, DEPS(h));
     captureBoundary(() => { throw new Error('two'); }, DEPS(h));
     expect(h.rows).toHaveLength(2);
-  });
-
-  it('HASH excludes volatile (direct): two rows differing only in emitted_at share a byte-identical dedup_hash', () => {
-    const h = makeHarness();
+    // two rows differing only in emitted_at share a byte-identical hash (diff category -> 2 rows)
+    h = makeHarness();
     captureBoundary(() => { throw new Error('same'); }, DEPS(h, { category: 'catA' }));
     h.clock.advance(1000);
-    captureBoundary(() => { throw new Error('same'); }, DEPS(h, { category: 'catB' })); // diff category -> 2 rows
-    expect(h.rows).toHaveLength(2);
-    expect(h.rows[0].dedup_hash).toBe(h.rows[1].dedup_hash); // emitted_at differs, hash identical
+    captureBoundary(() => { throw new Error('same'); }, DEPS(h, { category: 'catB' }));
+    expect(h.rows[0].dedup_hash).toBe(h.rows[1].dedup_hash);
     expect(h.rows[0].emitted_at).not.toBe(h.rows[1].emitted_at);
-  });
-
-  it('UTC-day boundary: the same failure on day D vs D+1 is two rows (per-UTC-day dedup)', () => {
-    const h = makeHarness(0); // 1970-01-01
+    // UTC-day boundary -> two rows
+    h = makeHarness(0);
     captureBoundary(() => { throw new Error('cross'); }, DEPS(h));
-    h.clock.advance(86400000); // +1 day -> 1970-01-02
+    h.clock.advance(86400000);
     captureBoundary(() => { throw new Error('cross'); }, DEPS(h));
     expect(h.rows).toHaveLength(2);
-    expect(h.rows[0].dedup_hash).not.toBe(h.rows[1].dedup_hash);
-  });
-
-  it('CATEGORY co-scopes dedup: the same hash inputs under two categories are two rows', () => {
-    const h = makeHarness();
+    // category co-scopes dedup -> two rows
+    h = makeHarness();
     captureBoundary(() => { throw new Error('shared'); }, DEPS(h, { category: 'catA' }));
     captureBoundary(() => { throw new Error('shared'); }, DEPS(h, { category: 'catB' }));
     expect(h.rows).toHaveLength(2);
-  });
-
-  it('TYPE is not part of the hash: same symptom/source/day, different type -> deduped', () => {
-    const h = makeHarness();
+    // type is NOT part of the hash -> deduped
+    h = makeHarness();
     captureBoundary(() => { throw new Error('sym'); }, DEPS(h, { type: 'error' }));
     captureBoundary(() => { throw new Error('sym'); }, DEPS(h, { type: 'warning' }));
-    expect(h.rows).toHaveLength(1); // type excluded from the stable key
+    expect(h.rows).toHaveLength(1);
+  });
+});
+
+describe('async variant (captureBoundaryAsync — the estate sink is async)', () => {
+  it('a rejected async op is a CAPTURED failure (row + stderr), not a swallow', async () => {
+    const h = makeHarness();
+    const r = await captureBoundaryAsync(async () => { throw new Error('async boom'); }, DEPS(h));
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1);
+    expect(h.lines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('an async success is silent and returns the resolved value', async () => {
+    const h = makeHarness();
+    const r = await captureBoundaryAsync(async () => 7, DEPS(h));
+    expect(r).toEqual({ ok: true, value: 7 });
+    expect(h.rows).toHaveLength(0);
+  });
+
+  it('awaits an ASYNC sink so its write failure is caught (never rejects)', async () => {
+    const asyncBadSink = { append: async () => { throw new Error('db down'); }, findByHash: async () => null };
+    const h = makeHarness();
+    let r;
+    await expect((async () => { r = await captureBoundaryAsync(async () => { throw new Error('boom'); }, { ...DEPS(h), sink: asyncBadSink }); })()).resolves.not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.lines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('KNOWN LIMITATION: sync captureBoundary does NOT catch an async rejection (use the async variant)', () => {
+    const h = makeHarness();
+    const r = captureBoundary(() => Promise.reject(new Error('x')), DEPS(h));
+    expect(r.ok).toBe(true);                 // sync seam sees a returned (rejected) promise as success
+    expect(r.value).toBeInstanceOf(Promise);
+    r.value.catch(() => {});                 // swallow the rejection so it is not an unhandled rejection here
+    expect(h.rows).toHaveLength(0);          // documented in the module header + guide
   });
 });
 
@@ -245,6 +314,16 @@ describe('the capture CONTRACT has TEETH (proves enforcement reaches a delegate 
   it('NEGATIVE-COPY: a SINK-THROWS-PROPAGATES copy (unguarded sink) is REJECTED', () => {
     expect(captureContractViolations(SINK_THROWS_PROPAGATES)).toContain('sink-throws-propagates');
   });
+  it('NEGATIVE-COPY: a NOT-HARDENED copy (throws on a hostile input) is REJECTED', () => {
+    const notHardened = (op, d) => {
+      try { return { ok: true, value: op() }; } catch (e) {
+        const sym = String(e && e.message ? e.message : e); // bare String -> throws on null-proto
+        d.sink.append({ category: d.category, dedup_hash: sym, symptom: sym }); d.logger.error('x');
+        return { ok: false, error: e };
+      }
+    };
+    expect(captureContractViolations(notHardened)).toContain('throws-on-hostile-input');
+  });
 });
 
 describe('textual locks pass on the source', () => {
@@ -263,23 +342,30 @@ describe('doctrine mutations fail named checks (miss direction)', () => {
   const CANON = readFileSync(CANON_PATH, 'utf8');
 
   it('routing the failure to a bare return (no sink append) fails capture_at_boundary', () => {
-    const m = CANON.replace('sink.append({ category, type, symptom, source, severity, dedup_hash, emitted_at: clock.now() });', 'void 0;');
+    const m = CANON.replace('return guard(err, deps, () => record(err, deps));', 'return { ok: false, error: err, deduped: false };');
     expect(judgeSource(m).failed).toContain('capture_at_boundary');
   });
   it('re-throwing from the boundary catch fails never_throws_best_effort', () => {
-    const m = CANON.replace('return capture(err, deps);', 'throw err;');
+    const m = CANON.replace('return guard(err, deps, () => record(err, deps));', 'throw err;');
     expect(judgeSource(m).failed).toContain('never_throws_best_effort');
   });
   it('an unguarded logger fails never_throws_best_effort', () => {
     const m = CANON.replace(/try \{ logger\.error\(line\); \} catch \{[^}]*\}/, 'logger.error(line);');
     expect(judgeSource(m).failed).toContain('never_throws_best_effort');
   });
+  it('an unguarded invalid-time (no Number.isFinite) fails never_throws_best_effort', () => {
+    // The behavioral null-proto / hostile-input tests carry SYMPTOM throw-safety (a
+    // textual lock is a weak proxy — the -F lesson); the lock reliably catches the
+    // structural clock guard, whose removal makes Date(NaN).toISOString() throw.
+    const m = CANON.replace('Number.isFinite(d.getTime())', 'true');
+    expect(judgeSource(m).failed).toContain('never_throws_best_effort');
+  });
   it('a volatile field in the dedup hash fails dedup_stable_fields_only', () => {
-    const m = CANON.replace('`${utcDay}::${symptom}::${source}`', '`${utcDay}::${symptom}::${source}::${emitted_at}`');
+    const m = CANON.replace('`${utcDay}::${symptom}::${String(source)}`', '`${utcDay}::${symptom}::${String(source)}::${emitted_at}`');
     expect(judgeSource(m).failed).toContain('dedup_stable_fields_only');
   });
   it('dropping the category from the dedup lookup fails category_scoped_dedup', () => {
-    const m = CANON.replace('sink.findByHash({ category, dedup_hash })', 'sink.findByHash({ dedup_hash })');
+    const m = CANON.replace('sink.findByHash({ category, dedup_hash: entry.dedup_hash })', 'sink.findByHash({ dedup_hash: entry.dedup_hash })');
     expect(judgeSource(m).failed).toContain('category_scoped_dedup');
   });
   it('writing on the success path fails healthy_path_silent', () => {

--- a/tests/unit/golden-references/capture-seam-acceptance.test.js
+++ b/tests/unit/golden-references/capture-seam-acceptance.test.js
@@ -69,6 +69,11 @@ function captureContractViolations(cb) {
     try { cb(() => { throw new Error('n'); }, null); } catch { threw = true; }
     if (threw) v.push('throws-on-null-deps');
   }
+  { // hostile-deps: a deps whose property access throws (throwing getter / Proxy) must NOT make the seam throw
+    let threw = false;
+    try { cb(() => { throw new Error('n'); }, new Proxy({}, { get() { throw new Error('trap'); } })); } catch { threw = true; }
+    if (threw) v.push('throws-on-hostile-deps');
+  }
   { // healthy-path-silent: success -> no row, no stderr, ok:true
     const h = makeHarness();
     const r = cb(() => 1, DEPS(h));
@@ -194,6 +199,20 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
   it('NEVER-THROWS when deps is explicitly NULL (the null-deps hole: `= {}` only defaults undefined): returns ok:false', () => {
     let r;
     expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, null); }).not.toThrow();
+    expect(r.ok).toBe(false);
+  });
+
+  it('NEVER-THROWS on a deps whose `logger` getter throws (the guard-catch deref hole): returns ok:false', () => {
+    let r;
+    const hostileDeps = { get logger() { throw new Error('logger-getter'); } };
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, hostileDeps); }).not.toThrow();
+    expect(r.ok).toBe(false);
+  });
+
+  it('NEVER-THROWS on a deps Proxy that throws on every get: returns ok:false', () => {
+    let r;
+    const proxyDeps = new Proxy({}, { get() { throw new Error('proxy-trap'); } });
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, proxyDeps); }).not.toThrow();
     expect(r.ok).toBe(false);
   });
 
@@ -394,8 +413,8 @@ describe('doctrine mutations fail named checks (miss direction)', () => {
     const m = CANON.replace('deps = deps || {};', 'deps = deps;'); // first occurrence = captureBoundary
     expect(judgeSource(m).failed).toContain('never_throws_best_effort');
   });
-  it('an unguarded null-deps deref in the guard catch fails never_throws_best_effort', () => {
-    const m = CANON.replace(/safeLog\(deps && deps\.logger/g, 'safeLog(deps.logger');
+  it('an unguarded deps.logger read in the guard catch fails never_throws_best_effort', () => {
+    const m = CANON.replace(/safeLog\(safeGet\(deps, 'logger'\)/g, 'safeLog(deps.logger');
     expect(judgeSource(m).failed).toContain('never_throws_best_effort');
   });
   it('an unguarded logger fails never_throws_best_effort', () => {

--- a/tests/unit/golden-references/capture-seam-acceptance.test.js
+++ b/tests/unit/golden-references/capture-seam-acceptance.test.js
@@ -1,0 +1,297 @@
+// Acceptance for the feedback/error-capture-seam golden reference. Behavioral-
+// first and PARAMETERIZED over GOLDEN_REF_MODULE from line 1 (the -C fix) so a
+// delegate's adapted COPY gets the same calling-enforcement. The load-bearing
+// tests are the ones a grep cannot prove: a planted failure must leave a row AND
+// a stderr line; a THROWING sink/logger must NOT propagate (the anti-swallow seam
+// must not itself swallow); a falsy-but-valid return must NOT be miscaptured; and
+// the captureContract must REJECT four broken delegate copies.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { judgeSource, buildLocks } from '../../../golden-references/feedback-error-capture-seam/acceptance-locks.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const abs = (p, d) => (p ? (isAbsolute(p) ? p : join(REPO_ROOT, p)) : d);
+const CANON_PATH = join(REPO_ROOT, 'golden-references', 'feedback-error-capture-seam', 'capture-seam.mjs');
+const MODULE_PATH = abs(process.env.GOLDEN_REF_MODULE, CANON_PATH);
+const SRC_PATH = abs(process.env.GOLDEN_REF_SRC, MODULE_PATH);
+const SRC = readFileSync(SRC_PATH, 'utf8');
+
+let captureBoundary;
+beforeAll(async () => {
+  const mod = await import(pathToFileURL(MODULE_PATH).href);
+  captureBoundary = mod.captureBoundary;
+});
+
+// Injected harness: an in-memory sink (append + findByHash), a stderr logger, and a
+// controllable clock — all injected, never singletons. Counters let tests assert
+// exact row/line counts.
+function makeHarness(startMs = 0) {
+  const rows = [];
+  const sink = {
+    append: (e) => rows.push(e),
+    findByHash: ({ category, dedup_hash }) => rows.find((r) => r.category === category && r.dedup_hash === dedup_hash),
+  };
+  const lines = [];
+  const logger = { error: (l) => lines.push(l) };
+  let t = startMs;
+  const clock = { now: () => t, advance: (ms) => { t += ms; } };
+  return { sink, logger, clock, rows, lines };
+}
+const DEPS = (h, over = {}) => ({ sink: h.sink, logger: h.logger, clock: h.clock, category: 'harness_backlog', type: 'error', source: 'demo', ...over });
+
+// A PORTABLE capture-contract checker — the teeth a delegate runs against their own
+// copy. Returns the list of contract VIOLATIONS (empty === compliant). It probes only
+// OBSERVABLE outcomes (row/line counts, throw, return shape) and shares NO hash helper
+// with the reference.
+function captureContractViolations(cb) {
+  const v = [];
+  // capture-on-failure: failing op -> ok:false, exactly 1 row, >=1 stderr, no throw
+  {
+    const h = makeHarness();
+    let threw = false, r;
+    try { r = cb(() => { throw new Error('x'); }, DEPS(h)); } catch { threw = true; }
+    if (threw) v.push('throws-through');
+    else {
+      if (!(r && r.ok === false)) v.push('failure-not-ok-false');
+      if (h.rows.length !== 1) v.push('no-row-on-failure');
+      if (h.lines.length < 1) v.push('silent-on-failure');
+    }
+  }
+  // healthy-path-silent: success -> no row, no stderr, ok:true
+  {
+    const h = makeHarness();
+    const r = cb(() => 1, DEPS(h));
+    if (!(r && r.ok === true)) v.push('success-not-ok-true');
+    if (h.rows.length !== 0 || h.lines.length !== 0) v.push('writes-on-healthy-path');
+  }
+  // dedup-break: identical failure twice (clock advanced) -> must stay 1 row.
+  // Guarded: a throw-through copy is already flagged by the first probe.
+  {
+    const h = makeHarness();
+    try {
+      cb(() => { throw new Error('dup'); }, DEPS(h));
+      h.clock.advance(1000);
+      cb(() => { throw new Error('dup'); }, DEPS(h));
+      if (h.rows.length > 1) v.push('dedup-break');
+    } catch { /* throw-through: flagged elsewhere */ }
+  }
+  // best-effort: a THROWING sink.append must NOT propagate
+  {
+    const badSink = { append: () => { throw new Error('sink down'); }, findByHash: () => null };
+    let threw = false;
+    try { cb(() => { throw new Error('y'); }, { sink: badSink, logger: { error: () => {} }, clock: { now: () => 0 }, category: 'c', source: 's' }); }
+    catch { threw = true; }
+    if (threw) v.push('sink-throws-propagates');
+  }
+  return v;
+}
+
+// Four+one REAL broken delegate copies (inline implementations the contract rejects).
+const SWALLOW = (op) => { try { return { ok: true, value: op() }; } catch (e) { return { ok: false, error: e }; } }; // no row, no stderr
+const THROW_THROUGH = (op) => ({ ok: true, value: op() }); // no capture at all
+const ALWAYS_WRITE = (op, d) => { d.sink.append({ note: 'always' }); try { return { ok: true, value: op() }; } catch (e) { return { ok: false, error: e }; } };
+const DEDUP_BREAK = (op, d) => {
+  try { return { ok: true, value: op() }; } catch (e) {
+    const sym = e && e.message ? e.message : String(e);
+    const hash = `${d.source}:${sym}:${d.clock.now()}`; // volatile now() in the key -> floods
+    d.sink.append({ category: d.category, dedup_hash: hash, symptom: sym }); d.logger.error('x');
+    return { ok: false, error: e };
+  }
+};
+const SINK_THROWS_PROPAGATES = (op, d) => {
+  try { return { ok: true, value: op() }; } catch (e) {
+    d.sink.append({ category: d.category, dedup_hash: 'h', symptom: 'x' }); // UNGUARDED -> propagates if sink throws
+    d.logger.error('x');
+    return { ok: false, error: e };
+  }
+};
+
+describe('behavioral contract (the real enforcement — runs against the ADAPTED copy too)', () => {
+  it('capture-on-failure: a planted throw yields ok:false + exactly 1 row + >=1 stderr, and does NOT throw', () => {
+    const h = makeHarness(1000);
+    const err = new Error('boom');
+    let r;
+    expect(() => { r = captureBoundary(() => { throw err; }, DEPS(h)); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe(err);            // failure return contract
+    expect(h.rows).toHaveLength(1);
+    expect(h.lines.length).toBeGreaterThanOrEqual(1);
+    // full schema, emitted_at sourced from the INJECTED clock
+    expect(h.rows[0]).toMatchObject({ category: 'harness_backlog', type: 'error', symptom: 'boom', source: 'demo', severity: 'medium' });
+    expect(h.rows[0].dedup_hash).toEqual(expect.any(String));
+    expect(h.rows[0].emitted_at).toBe(1000);
+  });
+
+  it('healthy-path-silent: a success writes NO row and NO stderr, returns ok:true + value', () => {
+    const h = makeHarness();
+    const r = captureBoundary(() => 42, DEPS(h));
+    expect(r).toEqual({ ok: true, value: 42 });
+    expect(h.rows).toHaveLength(0);
+    expect(h.lines).toHaveLength(0);
+  });
+
+  it('FALSY-BUT-VALID return: 0 / empty / false / null are successes, not failures (throw-vs-return)', () => {
+    for (const falsy of [0, '', false, null]) {
+      const h = makeHarness();
+      const r = captureBoundary(() => falsy, DEPS(h));
+      expect(r.ok).toBe(true);
+      expect(r.value).toBe(falsy);
+      expect(h.rows).toHaveLength(0);
+      expect(h.lines).toHaveLength(0);
+    }
+  });
+
+  it('NON-ERROR throw: a thrown string/number/null is captured safely with a stable hash (never throws)', () => {
+    const h = makeHarness();
+    let r;
+    expect(() => { r = captureBoundary(() => { throw 'raw string boom'; }, DEPS(h)); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1);
+    const firstHash = h.rows[0].dedup_hash;
+    h.clock.advance(5);
+    captureBoundary(() => { throw 'raw string boom'; }, DEPS(h)); // identical non-Error -> deduped
+    expect(h.rows).toHaveLength(1);
+    expect(h.rows[0].dedup_hash).toBe(firstHash); // stable across repeats
+  });
+
+  it('BEST-EFFORT: a throwing sink.append does NOT propagate (the seam never becomes a swallow footgun)', () => {
+    const badSink = { append: () => { throw new Error('sink down'); }, findByHash: () => null };
+    const h = makeHarness();
+    let r;
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), sink: badSink }); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.lines.length).toBeGreaterThanOrEqual(1); // still not fully silent (fallback stderr)
+  });
+
+  it('BEST-EFFORT: a throwing logger does NOT propagate AND the row is still written', () => {
+    const badLogger = { error: () => { throw new Error('logger down'); } };
+    const h = makeHarness();
+    let r;
+    expect(() => { r = captureBoundary(() => { throw new Error('boom'); }, { ...DEPS(h), logger: badLogger }); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(h.rows).toHaveLength(1); // sink write survives a logger failure
+  });
+
+  it('DEDUP same-stable, different-volatile: identical failure recurs -> 1 row, second deduped, NO new stderr', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw new Error('dup'); }, DEPS(h));
+    const linesAfterFirst = h.lines.length;
+    h.clock.advance(1000); // volatile emitted_at differs, stable key identical
+    const r2 = captureBoundary(() => { throw new Error('dup'); }, DEPS(h));
+    expect(h.rows).toHaveLength(1);
+    expect(r2.deduped).toBe(true);
+    expect(h.lines).toHaveLength(linesAfterFirst); // deduped recurrence is silent (no flood)
+  });
+
+  it('DEDUP different-stable: a different symptom is a new row', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw new Error('one'); }, DEPS(h));
+    captureBoundary(() => { throw new Error('two'); }, DEPS(h));
+    expect(h.rows).toHaveLength(2);
+  });
+
+  it('HASH excludes volatile (direct): two rows differing only in emitted_at share a byte-identical dedup_hash', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw new Error('same'); }, DEPS(h, { category: 'catA' }));
+    h.clock.advance(1000);
+    captureBoundary(() => { throw new Error('same'); }, DEPS(h, { category: 'catB' })); // diff category -> 2 rows
+    expect(h.rows).toHaveLength(2);
+    expect(h.rows[0].dedup_hash).toBe(h.rows[1].dedup_hash); // emitted_at differs, hash identical
+    expect(h.rows[0].emitted_at).not.toBe(h.rows[1].emitted_at);
+  });
+
+  it('UTC-day boundary: the same failure on day D vs D+1 is two rows (per-UTC-day dedup)', () => {
+    const h = makeHarness(0); // 1970-01-01
+    captureBoundary(() => { throw new Error('cross'); }, DEPS(h));
+    h.clock.advance(86400000); // +1 day -> 1970-01-02
+    captureBoundary(() => { throw new Error('cross'); }, DEPS(h));
+    expect(h.rows).toHaveLength(2);
+    expect(h.rows[0].dedup_hash).not.toBe(h.rows[1].dedup_hash);
+  });
+
+  it('CATEGORY co-scopes dedup: the same hash inputs under two categories are two rows', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw new Error('shared'); }, DEPS(h, { category: 'catA' }));
+    captureBoundary(() => { throw new Error('shared'); }, DEPS(h, { category: 'catB' }));
+    expect(h.rows).toHaveLength(2);
+  });
+
+  it('TYPE is not part of the hash: same symptom/source/day, different type -> deduped', () => {
+    const h = makeHarness();
+    captureBoundary(() => { throw new Error('sym'); }, DEPS(h, { type: 'error' }));
+    captureBoundary(() => { throw new Error('sym'); }, DEPS(h, { type: 'warning' }));
+    expect(h.rows).toHaveLength(1); // type excluded from the stable key
+  });
+});
+
+describe('the capture CONTRACT has TEETH (proves enforcement reaches a delegate copy)', () => {
+  it('the canonical seam passes the portable contract checker', () => {
+    expect(captureContractViolations(captureBoundary)).toEqual([]);
+  });
+  it('NEGATIVE-COPY: a SWALLOW copy (silent on failure) is REJECTED', () => {
+    expect(captureContractViolations(SWALLOW)).toEqual(expect.arrayContaining(['no-row-on-failure', 'silent-on-failure']));
+  });
+  it('NEGATIVE-COPY: a THROW-THROUGH copy (re-throws) is REJECTED', () => {
+    expect(captureContractViolations(THROW_THROUGH)).toContain('throws-through');
+  });
+  it('NEGATIVE-COPY: an ALWAYS-WRITE copy (writes on the healthy path) is REJECTED', () => {
+    expect(captureContractViolations(ALWAYS_WRITE)).toContain('writes-on-healthy-path');
+  });
+  it('NEGATIVE-COPY: a DEDUP-BREAK copy (volatile field in the hash) is REJECTED', () => {
+    expect(captureContractViolations(DEDUP_BREAK)).toContain('dedup-break');
+  });
+  it('NEGATIVE-COPY: a SINK-THROWS-PROPAGATES copy (unguarded sink) is REJECTED', () => {
+    expect(captureContractViolations(SINK_THROWS_PROPAGATES)).toContain('sink-throws-propagates');
+  });
+});
+
+describe('textual locks pass on the source', () => {
+  const LOCKS = buildLocks();
+  for (const name of Object.keys(LOCKS)) {
+    it(`lock: ${name}`, () => {
+      expect(LOCKS[name](SRC), `lock '${name}' must hold`).toBe(true);
+    });
+  }
+  it('judgeSource aggregates to ok', () => {
+    expect(judgeSource(SRC)).toEqual({ ok: true, failed: [] });
+  });
+});
+
+describe('doctrine mutations fail named checks (miss direction)', () => {
+  const CANON = readFileSync(CANON_PATH, 'utf8');
+
+  it('routing the failure to a bare return (no sink append) fails capture_at_boundary', () => {
+    const m = CANON.replace('sink.append({ category, type, symptom, source, severity, dedup_hash, emitted_at: clock.now() });', 'void 0;');
+    expect(judgeSource(m).failed).toContain('capture_at_boundary');
+  });
+  it('re-throwing from the boundary catch fails never_throws_best_effort', () => {
+    const m = CANON.replace('return capture(err, deps);', 'throw err;');
+    expect(judgeSource(m).failed).toContain('never_throws_best_effort');
+  });
+  it('an unguarded logger fails never_throws_best_effort', () => {
+    const m = CANON.replace(/try \{ logger\.error\(line\); \} catch \{[^}]*\}/, 'logger.error(line);');
+    expect(judgeSource(m).failed).toContain('never_throws_best_effort');
+  });
+  it('a volatile field in the dedup hash fails dedup_stable_fields_only', () => {
+    const m = CANON.replace('`${utcDay}::${symptom}::${source}`', '`${utcDay}::${symptom}::${source}::${emitted_at}`');
+    expect(judgeSource(m).failed).toContain('dedup_stable_fields_only');
+  });
+  it('dropping the category from the dedup lookup fails category_scoped_dedup', () => {
+    const m = CANON.replace('sink.findByHash({ category, dedup_hash })', 'sink.findByHash({ dedup_hash })');
+    expect(judgeSource(m).failed).toContain('category_scoped_dedup');
+  });
+  it('writing on the success path fails healthy_path_silent', () => {
+    const m = CANON.replace('return { ok: true, value };', "deps.logger.error('leak'); return { ok: true, value };");
+    expect(judgeSource(m).failed).toContain('healthy_path_silent');
+  });
+  it('a module-level singleton dep fails injected_deps', () => {
+    const m = CANON.replace('import { createHash }', 'const sink = {};\nimport { createHash }');
+    expect(judgeSource(m).failed).toContain('injected_deps');
+  });
+  it('a repo-relative import fails builtins_only_import', () => {
+    const m = "import { x } from '../../lib/governance/emit-feedback.js';\n" + CANON;
+    expect(judgeSource(m).failed).toContain('builtins_only_import');
+  });
+});


### PR DESCRIPTION
## Summary
Child -F of the golden-references family (5/7 → 6/7). A portable, node-builtins-only teaching reference for the **feedback/error-capture seam** — the anti-swallow control.

Distilled from the estate's real funnel: `lib/governance/emit-feedback.js` (`@canonical-writer-for:feedback`, sha256 dedup) + `log-harness-bug.js` + `capture-completion-flags.js` over the `feedback` table.

### Four doctrines
1. **Capture-at-boundary, never swallow** — failure records a schema-shaped entry to an injected sink.
2. **Best-effort but never silent** *(seam-design hardening, honestly labeled)* — never throws AND (first capture) writes a row + a stderr line. The capture itself is best-effort: a throwing `sink.append`/`logger` is caught, so the anti-swallow seam never becomes a swallow footgun.
3. **Dedup on stable fields only** — `sha256(utcDay::symptom::source)`, per-UTC-day, category-scoped; `emitted_at` stored but excluded (else it floods); a deduped recurrence writes no new row and no new stderr.
4. **Healthy path silent** — throw-vs-return discrimination (a falsy return like `0`/`''`/`false`/`null` is valid).

### Attribution honesty (RISK `ace9b9e2`, the -E F1 lesson)
The never-throw and per-capture stderr are labeled **seam-design hardening**, NOT distilled from `emitFeedback` (which throws on insert/validation and is silent on success). Over-attributing would generate folklore into copied content.

### Verification
- Behavioral-first, **parameterized over `GOLDEN_REF_MODULE`** — 36/36. Includes the TESTING-mandated **best-effort robustness** (throwing sink/logger), **falsy-but-valid return**, and **non-Error throw** tests.
- `captureContract` **rejects 5 real negative fixtures** (SWALLOW / THROW-THROUGH / ALWAYS-WRITE / DEDUP-BREAK / SINK-THROWS-PROPAGATES); a broken copy fails **20/36** (enforcement reaches delegate copies, the -C fix).
- Node-builtins + crypto only; isolation green (9/9); registry row 5 + idempotent mirror at **N=5**. Zero new DDL.

RISK `ace9b9e2` + TESTING `a73ff8b8` folded into the design pre-build.

## Test plan
- `npx vitest run tests/unit/golden-references/capture-seam-acceptance.test.js` → 36 passed
- `npx vitest run tests/unit/golden-references/isolation.test.js` → 9 passed
- `node scripts/golden-references/mirror-registry.mjs` ×2 → 1-then-0 at N=5

🤖 Generated with [Claude Code](https://claude.com/claude-code)