### PR TITLE
fix(QF-20260706-356): reject a QF claim whose target has no usable repo

### DIFF
--- a/lib/fleet/qf-repo-fitness.js
+++ b/lib/fleet/qf-repo-fitness.js
@@ -1,0 +1,32 @@
+/**
+ * qf-repo-fitness.js — QF-20260706-356
+ *
+ * Rider 3 (2026-07-06) opened quick_fixes.target_application to every ACTIVE
+ * applications-registry row, not just EHG/EHG_Engineer. 8 of 11 registered ventures
+ * have applications.github_repo IS NULL (scaffolded but never pushed to GitHub) — a
+ * QF filed against one is DB-valid but unworkable; a claiming worker would wedge
+ * hunting a repo that does not exist. This predicate runs at claim time (qf-start.js,
+ * BEFORE the claim_sd RPC) so that class of QF routes back with a clear reason
+ * instead of being claimed.
+ *
+ * Fails open (returns null) for: platform targets (EHG/EHG_Engineer), an unset
+ * target, and a target that doesn't match any registered application — only a
+ * POSITIVELY-confirmed missing github_repo/local_path blocks the claim.
+ */
+import { isVentureRepo, normalizeAppName } from '../repo-paths.js';
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} qfId
+ * @returns {Promise<string|null>} a human-readable block reason, or null when fit to claim
+ */
+export async function repoUnfitReason(supabase, qfId) {
+  const { data: qf } = await supabase.from('quick_fixes').select('target_application').eq('id', qfId).maybeSingle();
+  const targetApp = qf?.target_application;
+  if (!isVentureRepo(targetApp)) return null;
+  const { data: apps } = await supabase.from('applications')
+    .select('name, github_repo, local_path').eq('status', 'active').is('deleted_at', null);
+  const app = (apps || []).find((a) => normalizeAppName(a.name) === normalizeAppName(targetApp));
+  if (!app || (app.github_repo && app.local_path)) return null;
+  return `target '${targetApp}' has no usable repo (github_repo=${app.github_repo || 'null'}, local_path=${app.local_path || 'null'}) — needs repo registration, or route via a venture-SD lane instead of a worker QF claim.`;
+}

--- a/scripts/qf-start.js
+++ b/scripts/qf-start.js
@@ -18,6 +18,7 @@
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { spawnSync } from 'node:child_process';
 import dotenv from 'dotenv';
+import { repoUnfitReason } from '../lib/fleet/qf-repo-fitness.js';
 
 dotenv.config();
 
@@ -48,6 +49,13 @@ async function main() {
   }
 
   const supabase = createSupabaseServiceClient();
+
+  const unfitReason = await repoUnfitReason(supabase, qfId);
+  if (unfitReason) {
+    console.error(`✗ Quick-fix ${qfId} NOT claimed: ${unfitReason}`);
+    await safeExit(3);
+  }
+
   const { data, error } = await supabase.rpc('claim_sd', {
     p_sd_id: qfId,
     p_session_id: sessionId,

--- a/tests/unit/fleet/qf-repo-fitness.test.js
+++ b/tests/unit/fleet/qf-repo-fitness.test.js
@@ -1,0 +1,65 @@
+// QF-20260706-356 — claim-time repo-fitness guard for the venture-wide quick_fixes lane.
+// Hermetic: a hand-rolled fake supabase client, no live DB.
+import { describe, it, expect } from 'vitest';
+import { repoUnfitReason } from '../../../lib/fleet/qf-repo-fitness.js';
+
+const APPS = [
+  { name: 'EHG', github_repo: 'rickfelix/ehg.git', local_path: '/repos/ehg' },
+  { name: 'EHG_Engineer', github_repo: 'rickfelix/EHG_Engineer.git', local_path: '/repos/EHG_Engineer' },
+  { name: 'MarketLens', github_repo: 'rickfelix/marketlens', local_path: '/repos/marketlens' },
+  { name: 'Cron Canary', github_repo: null, local_path: '/repos/cron-canary' },
+];
+
+function fakeSupabase({ targetApplication }) {
+  return {
+    from(table) {
+      if (table === 'quick_fixes') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { target_application: targetApplication } }) }) }),
+        };
+      }
+      if (table === 'applications') {
+        return {
+          select: () => ({ eq: () => ({ is: async () => ({ data: APPS }) }) }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+describe('repoUnfitReason', () => {
+  it('fails open for a platform target (EHG_Engineer)', async () => {
+    const sb = fakeSupabase({ targetApplication: 'EHG_Engineer' });
+    expect(await repoUnfitReason(sb, 'QF-1')).toBeNull();
+  });
+
+  it('fails open when no target_application is set', async () => {
+    const sb = fakeSupabase({ targetApplication: null });
+    expect(await repoUnfitReason(sb, 'QF-1')).toBeNull();
+  });
+
+  it('MarketLens (github_repo + local_path both set) is claimable', async () => {
+    const sb = fakeSupabase({ targetApplication: 'MarketLens' });
+    expect(await repoUnfitReason(sb, 'QF-1')).toBeNull();
+  });
+
+  it('Cron Canary (github_repo NULL) routes back with a named reason', async () => {
+    const sb = fakeSupabase({ targetApplication: 'Cron Canary' });
+    const reason = await repoUnfitReason(sb, 'QF-1');
+    expect(reason).toMatch(/Cron Canary/);
+    expect(reason).toMatch(/github_repo=null/);
+    expect(reason).toMatch(/venture-SD lane/);
+  });
+
+  it('fails open for a target that matches no registered application', async () => {
+    const sb = fakeSupabase({ targetApplication: 'SomeUnregisteredVenture' });
+    expect(await repoUnfitReason(sb, 'QF-1')).toBeNull();
+  });
+
+  it('name matching is separator/case-insensitive', async () => {
+    const sb = fakeSupabase({ targetApplication: 'cron-canary' });
+    const reason = await repoUnfitReason(sb, 'QF-1');
+    expect(reason).toMatch(/no usable repo/);
+  });
+});


### PR DESCRIPTION
## Summary
- Rider 3 (2026-07-06) opened `quick_fixes.target_application` to every ACTIVE `applications`-registry row, but 8 of 11 registered ventures have `github_repo IS NULL` — a QF filed against one is DB-valid but unworkable, wedging a claiming worker hunting a repo that doesn't exist.
- `scripts/qf-start.js` now checks the target's `applications` row (via a new pure predicate, `lib/fleet/qf-repo-fitness.js`) BEFORE calling `claim_sd`, and routes the claim back with a named reason instead of letting a worker claim it.
- Fails open for platform targets (EHG/EHG_Engineer), unset targets, and targets that don't match any registered application — only a positively-confirmed missing `github_repo`/`local_path` blocks the claim.

## Test plan
- [x] `npx vitest run tests/unit/fleet/qf-repo-fitness.test.js` — 6/6 pass (platform passthrough, MarketLens claimable, Cron Canary routed back with named reason, unregistered-target fail-open, separator/case-insensitive matching)
- [x] `node --check` on both changed/new files
- [x] Verified live `applications` table data: MarketLens has both `github_repo`+`local_path`; Cron Canary/PrivacyPatrol AI/CommitCraft AI/CronRead/CodeGuardian CI/DataDistill all have `github_repo IS NULL`

QF-20260706-356