### PR TITLE
fix(QF-20260706-648): registry-wide target_application designation at QF filing

### DIFF
--- a/lib/fleet/qf-target-application.js
+++ b/lib/fleet/qf-target-application.js
@@ -1,38 +1,17 @@
-/**
- * qf-target-application.js — QF-20260706-648
- *
- * Rider 3 (2026-07-06) opened quick_fixes.target_application to every ACTIVE
- * applications-registry row (trigger fn_quick_fixes_validate_target_application),
- * not just EHG/EHG_Engineer. scripts/create-quick-fix.js still assumed a two-platform
- * world at filing time. These helpers close that gap:
- *   - validateTargetApplication mirrors the DB trigger's exact matching rule, so a
- *     bad --target-application fails fast at the CLI instead of surfacing as a raw
- *     Postgres constraint error.
- *   - detectMisdesignation catches the silent case: a title/description that names
- *     an active VENTURE differing from the resolved (often cwd-inferred) target,
- *     which would otherwise file against the wrong repo unnoticed.
- */
+// QF-20260706-648: quick_fixes.target_application now accepts any active
+// applications-registry row, not just EHG/EHG_Engineer — these helpers keep filing
+// in sync with that.
 
-/**
- * Fetch the active applications registry (name + normalized_name).
- * @param {import('@supabase/supabase-js').SupabaseClient} supabase
- * @returns {Promise<Array<{name: string, normalized_name: string}>>}
- */
+/** Active applications registry (name + normalized_name). */
 export async function loadActiveApplications(supabase) {
   const { data, error } = await supabase.from('applications').select('name, normalized_name').eq('status', 'active');
   if (error) throw new Error(`loadActiveApplications: ${error.message}`);
   return data || [];
 }
 
-/**
- * Mirrors fn_quick_fixes_validate_target_application exactly: a value is valid
- * when it equals an active app's `name` (case-sensitive) OR lower(value) equals
- * that app's `normalized_name`. Keeping this byte-identical to the trigger means a
- * value that passes here can never be rejected by the DB, and vice versa.
- * @param {string} value
- * @param {Array<{name: string, normalized_name: string}>} activeApps
- * @returns {{valid: boolean, allowedNames: string[]}}
- */
+// Mirrors fn_quick_fixes_validate_target_application exactly (name match OR
+// lower(value) === normalized_name) so a value accepted here can never be
+// rejected by the DB trigger, and vice versa.
 export function validateTargetApplication(value, activeApps) {
   const allowedNames = activeApps.map((a) => a.name);
   const lowerValue = String(value || '').toLowerCase();
@@ -40,24 +19,16 @@ export function validateTargetApplication(value, activeApps) {
   return { valid, allowedNames };
 }
 
-/** Platform repos are never subject to the mis-designation heuristic below — only
- *  ventures, since "EHG"/"EHG_Engineer" are common incidental words in QF prose. */
+// Platform names are excluded: they're common incidental words in QF prose and
+// would false-positive on nearly every platform-targeted QF.
 const PLATFORM_NAMES = new Set(['EHG', 'EHG_Engineer']);
 
-/**
- * Does this QF's title/description reference an active VENTURE (non-platform)
- * registry name that differs from the resolved target? Case-insensitive whole-name
- * substring match against the combined text.
- * @param {string} text - title + description (or any combined free text)
- * @param {string} resolvedTarget - the target_application about to be filed
- * @param {Array<{name: string, normalized_name: string}>} activeApps
- * @returns {string|null} the mismatched app name, or null when none found
- */
+/** Does title/description name an active venture that differs from the resolved
+ *  (often cwd-inferred) target? Returns the mismatched app name, or null. */
 export function detectMisdesignation(text, resolvedTarget, activeApps) {
   const haystack = String(text || '').toLowerCase();
   for (const app of activeApps) {
-    if (PLATFORM_NAMES.has(app.name)) continue;
-    if (app.name === resolvedTarget) continue;
+    if (PLATFORM_NAMES.has(app.name) || app.name === resolvedTarget) continue;
     if (haystack.includes(app.name.toLowerCase())) return app.name;
   }
   return null;

--- a/lib/fleet/qf-target-application.js
+++ b/lib/fleet/qf-target-application.js
@@ -1,0 +1,64 @@
+/**
+ * qf-target-application.js — QF-20260706-648
+ *
+ * Rider 3 (2026-07-06) opened quick_fixes.target_application to every ACTIVE
+ * applications-registry row (trigger fn_quick_fixes_validate_target_application),
+ * not just EHG/EHG_Engineer. scripts/create-quick-fix.js still assumed a two-platform
+ * world at filing time. These helpers close that gap:
+ *   - validateTargetApplication mirrors the DB trigger's exact matching rule, so a
+ *     bad --target-application fails fast at the CLI instead of surfacing as a raw
+ *     Postgres constraint error.
+ *   - detectMisdesignation catches the silent case: a title/description that names
+ *     an active VENTURE differing from the resolved (often cwd-inferred) target,
+ *     which would otherwise file against the wrong repo unnoticed.
+ */
+
+/**
+ * Fetch the active applications registry (name + normalized_name).
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Array<{name: string, normalized_name: string}>>}
+ */
+export async function loadActiveApplications(supabase) {
+  const { data, error } = await supabase.from('applications').select('name, normalized_name').eq('status', 'active');
+  if (error) throw new Error(`loadActiveApplications: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Mirrors fn_quick_fixes_validate_target_application exactly: a value is valid
+ * when it equals an active app's `name` (case-sensitive) OR lower(value) equals
+ * that app's `normalized_name`. Keeping this byte-identical to the trigger means a
+ * value that passes here can never be rejected by the DB, and vice versa.
+ * @param {string} value
+ * @param {Array<{name: string, normalized_name: string}>} activeApps
+ * @returns {{valid: boolean, allowedNames: string[]}}
+ */
+export function validateTargetApplication(value, activeApps) {
+  const allowedNames = activeApps.map((a) => a.name);
+  const lowerValue = String(value || '').toLowerCase();
+  const valid = activeApps.some((a) => a.name === value || a.normalized_name === lowerValue);
+  return { valid, allowedNames };
+}
+
+/** Platform repos are never subject to the mis-designation heuristic below — only
+ *  ventures, since "EHG"/"EHG_Engineer" are common incidental words in QF prose. */
+const PLATFORM_NAMES = new Set(['EHG', 'EHG_Engineer']);
+
+/**
+ * Does this QF's title/description reference an active VENTURE (non-platform)
+ * registry name that differs from the resolved target? Case-insensitive whole-name
+ * substring match against the combined text.
+ * @param {string} text - title + description (or any combined free text)
+ * @param {string} resolvedTarget - the target_application about to be filed
+ * @param {Array<{name: string, normalized_name: string}>} activeApps
+ * @returns {string|null} the mismatched app name, or null when none found
+ */
+export function detectMisdesignation(text, resolvedTarget, activeApps) {
+  const haystack = String(text || '').toLowerCase();
+  for (const app of activeApps) {
+    if (PLATFORM_NAMES.has(app.name)) continue;
+    if (app.name === resolvedTarget) continue;
+    if (haystack.includes(app.name.toLowerCase())) return app.name;
+  }
+  return null;
+}

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -131,12 +131,7 @@ async function createQuickFix(options = {}) {
     estimatedLoc = options.estimatedLoc || 10;
   }
 
-  // QF-20260706-648: registry-wide target_application designation. When an explicit
-  // --target-application was given, validate it against the active registry (mirrors
-  // the fn_quick_fixes_validate_target_application DB trigger — fail fast here with
-  // the allowed list instead of surfacing a raw constraint error). When relying on
-  // cwd auto-detect, refuse a QF whose title/description names a different active
-  // venture instead of silently filing against the wrong repo.
+  // QF-20260706-648: registry-wide target_application designation.
   const activeApps = await loadActiveApplications(supabase);
   if (options.targetApplication) {
     const { valid, allowedNames } = validateTargetApplication(options.targetApplication, activeApps);

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -28,6 +28,7 @@ import { preclaimFeedbackRows, resolveFeedbackIds, findFeedbackRefConflicts } fr
 import { releasePreclaim } from '../lib/feedback/release-preclaim.js';
 import { armCliTeardown } from '../lib/cli-graceful-exit.js';
 import { checkFeedbackPremiseLiveness, logForceLivenessOverride } from '../lib/eva/feedback-premise-adapter.js';
+import { loadActiveApplications, validateTargetApplication, detectMisdesignation } from '../lib/fleet/qf-target-application.js';
 
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
@@ -98,7 +99,7 @@ async function createQuickFix(options = {}) {
   // Auto-detect or use provided target application
   targetApplication = options.targetApplication || detectTargetApplication();
   console.log(`🎯 Target Application: ${targetApplication}`);
-  console.log(`   (Run from ${targetApplication === 'EHG' ? 'EHG app' : 'EHG_Engineer'} directory or use --target-application)\n`);
+  console.log('   (Auto-detected from cwd, or pass --target-application <name>)\n');
 
   if (options.interactive || !options.title) {
     console.log('📝 Interactive Mode - Please provide details:\n');
@@ -128,6 +129,29 @@ async function createQuickFix(options = {}) {
     expected = options.expected || '';
     actual = options.actual || '';
     estimatedLoc = options.estimatedLoc || 10;
+  }
+
+  // QF-20260706-648: registry-wide target_application designation. When an explicit
+  // --target-application was given, validate it against the active registry (mirrors
+  // the fn_quick_fixes_validate_target_application DB trigger — fail fast here with
+  // the allowed list instead of surfacing a raw constraint error). When relying on
+  // cwd auto-detect, refuse a QF whose title/description names a different active
+  // venture instead of silently filing against the wrong repo.
+  const activeApps = await loadActiveApplications(supabase);
+  if (options.targetApplication) {
+    const { valid, allowedNames } = validateTargetApplication(options.targetApplication, activeApps);
+    if (!valid) {
+      console.log(`❌ Invalid target application: ${options.targetApplication}`);
+      console.log(`   Allowed (active registry): ${allowedNames.join(', ')}`);
+      process.exit(1);
+    }
+  } else {
+    const misdesignated = detectMisdesignation(`${title} ${description}`, targetApplication, activeApps);
+    if (misdesignated) {
+      console.log(`❌ [TARGET_MISDESIGNATION] title/description references "${misdesignated}" but the inferred target is "${targetApplication}" (from cwd).`);
+      console.log(`   Pass --target-application ${misdesignated} if that's the real target, or --target-application ${targetApplication} to confirm the cwd default.`);
+      process.exit(1);
+    }
   }
 
   // Validate type
@@ -661,12 +685,10 @@ for (let i = 0; i < args.length; i++) {
   } else if (arg === '--estimated-loc') {
     options.estimatedLoc = parseInt(args[++i]);
   } else if (arg === '--target-application' || arg === '--target-app') {
-    const val = args[++i];
-    if (!['EHG', 'EHG_Engineer'].includes(val)) {
-      console.error(`❌ Invalid target application: ${val}. Must be 'EHG' or 'EHG_Engineer'`);
-      process.exit(1);
-    }
-    options.targetApplication = val;
+    // QF-20260706-648: any active registry name is accepted here; the async,
+    // DB-backed check against the live applications registry happens inside
+    // createQuickFix() (this parsing loop has no supabase client to query with).
+    options.targetApplication = args[++i];
   } else if (arg === '--feedback-id') {
     options.feedbackId = args[++i];
   } else if (arg === '--force-claim') {
@@ -705,7 +727,7 @@ Options:
   --expected             Expected behavior
   --actual               Actual behavior
   --estimated-loc        Estimated lines of code (default: 10)
-  --target-application   Target repo: 'EHG' or 'EHG_Engineer' (auto-detected from cwd)
+  --target-application   Target repo: any active applications-registry name (auto-detected from cwd)
   --allow-duplicate      Audited override for dedup gate; requires non-empty <reason>
   --force-liveness       Audited override for STALE_PREMISE gate; requires non-empty <reason>
   --help, -h             Show this help

--- a/tests/unit/fleet/qf-target-application.test.js
+++ b/tests/unit/fleet/qf-target-application.test.js
@@ -1,0 +1,51 @@
+// QF-20260706-648 — registry-wide target_application designation at QF filing time.
+// Hermetic pure-function tests: no live DB.
+import { describe, it, expect } from 'vitest';
+import { validateTargetApplication, detectMisdesignation } from '../../../lib/fleet/qf-target-application.js';
+
+const ACTIVE_APPS = [
+  { name: 'EHG', normalized_name: 'ehg' },
+  { name: 'EHG_Engineer', normalized_name: 'ehg_engineer' },
+  { name: 'MarketLens', normalized_name: 'marketlens' },
+  { name: 'Cron Canary', normalized_name: 'cron_canary' },
+];
+
+describe('validateTargetApplication (mirrors fn_quick_fixes_validate_target_application)', () => {
+  it('accepts an exact name match', () => {
+    expect(validateTargetApplication('MarketLens', ACTIVE_APPS).valid).toBe(true);
+  });
+
+  it('accepts the normalized_name form (lowercase, matches DB lower() compare)', () => {
+    expect(validateTargetApplication('cron_canary', ACTIVE_APPS).valid).toBe(true);
+  });
+
+  it('rejects a value matching neither name nor normalized_name', () => {
+    const v = validateTargetApplication('cron canary', ACTIVE_APPS); // space, not underscore
+    expect(v.valid).toBe(false);
+    expect(v.allowedNames).toEqual(['EHG', 'EHG_Engineer', 'MarketLens', 'Cron Canary']);
+  });
+
+  it('rejects an unregistered/unknown app', () => {
+    expect(validateTargetApplication('SomeUnregisteredVenture', ACTIVE_APPS).valid).toBe(false);
+  });
+});
+
+describe('detectMisdesignation', () => {
+  it('flags a venture name in the text that differs from the resolved (cwd) target', () => {
+    const hit = detectMisdesignation('Fix the MarketLens onboarding flow', 'EHG_Engineer', ACTIVE_APPS);
+    expect(hit).toBe('MarketLens');
+  });
+
+  it('does not flag when the resolved target already matches the mentioned venture', () => {
+    expect(detectMisdesignation('Fix the MarketLens onboarding flow', 'MarketLens', ACTIVE_APPS)).toBeNull();
+  });
+
+  it('never flags platform names (EHG/EHG_Engineer) — only ventures', () => {
+    expect(detectMisdesignation('Fix an EHG_Engineer CLI script', 'EHG_Engineer', ACTIVE_APPS)).toBeNull();
+    expect(detectMisdesignation('Fix an EHG dashboard bug', 'EHG_Engineer', ACTIVE_APPS)).toBeNull();
+  });
+
+  it('returns null for plain platform text mentioning no venture', () => {
+    expect(detectMisdesignation('Fix a CLI parsing bug in create-quick-fix.js', 'EHG_Engineer', ACTIVE_APPS)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman directive (2026-07-06 sitting, verbatim: "we need to make sure though that the quick fix process includes the proper designation of what the target application is"). Rider 3 opened `quick_fixes.target_application` to every ACTIVE `applications`-registry row, but `scripts/create-quick-fix.js` still assumed a two-platform world.
- `--target-application` now validates against the live `applications` registry (a new `lib/fleet/qf-target-application.js::validateTargetApplication` helper that mirrors the `fn_quick_fixes_validate_target_application` DB trigger exactly — a value passing here can never be rejected by the DB, and vice versa), instead of hardcoding `EHG`/`EHG_Engineer`.
- Added a mis-designation heuristic (`detectMisdesignation`): filing WITHOUT `--target-application` now refuses when the title/description names a different active *venture* than the cwd-inferred target, so a venture-titled QF can't silently land on the wrong repo.
- Help text updated to reflect the registry-wide flag.

## Sweep of other QF writers (requirement #4)
- `scripts/ci/red-merge-detector.mjs` already files QFs by invoking `scripts/create-quick-fix.js` as a subprocess with no `--target-application` override — it inherits this fix automatically, no separate change needed.
- `lib/eva/convergence-remediation-writers.js` hardcodes `target_application: 'EHG'` in a direct `quick_fixes` insert, but its own header comment documents that it deliberately bypasses this CLI (avoids a side-effecting git-worktree creation from an automated gate call site) for a platform-scoped convergence-gate use case. Left unchanged — no test coverage here, and changing an unrelated writer's behavior without it risks a real regression.

## Test plan
- [x] `npx vitest run tests/unit/fleet/qf-target-application.test.js` — 8/8 pass (exact-name match, normalized_name match, rejection + allowed-list, mis-designation detection, no-false-positive on platform names, no-false-positive on plain platform text)
- [x] Live-verified both directions against the real `applications` table: `--target-application MarketLens` validates true; a title mentioning "MarketLens" with target `EHG_Engineer` is flagged as a mis-designation; a plain CI-fix title with no venture mention is not flagged
- [x] `--help` output shows the updated flag description
- [x] `node --check` on both changed/new files

QF-20260706-648