### PR TITLE
feat(SD-LEO-INFRA-GOLDEN-REFERENCES-CANONICAL-001-G): idempotent composite-key upsert seam (FINAL golden reference)

### DIFF
--- a/golden-references/idempotent-composite-upsert/acceptance-locks.mjs
+++ b/golden-references/idempotent-composite-upsert/acceptance-locks.mjs
@@ -1,0 +1,108 @@
+// Structural acceptance LOCKS for the idempotent-composite-upsert reference — pure
+// predicates over the JS source, node-builtins-only. Textual locks are NECESSARY BUT
+// WEAK (the -C lesson); the behavioral suite (parameterized over GOLDEN_REF_MODULE) that
+// RUNS the seam against a store adapter — two identical writes converge to one row, a
+// silent-drop store makes the seam FAIL LOUD, a partial key collapses distinct rows — is
+// the primary enforcement (the -F lesson: a "no bad keyword" textual check is a weak proxy
+// for the real behavior).
+export const DEFAULT_MODULE = 'golden-references/idempotent-composite-upsert/upsert-seam.mjs';
+
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+/** Code body of a named function (exported or not), comments stripped. */
+function fnBody(src, name) {
+  const start = src.search(new RegExp('(export )?(async )?function ' + name + '\\b'));
+  if (start === -1) return null;
+  const rest = src.slice(start + 1);
+  const jsdoc = rest.search(/\n\/\*\*/);
+  const nextFn = rest.search(/\n(export )?(async )?function /);
+  const cut = [jsdoc, nextFn].filter((i) => i !== -1).sort((a, b) => a - b)[0];
+  return stripComments('e' + (cut === undefined ? rest : rest.slice(0, cut)));
+}
+
+export function buildLocks() {
+  return {
+    reference_only_header: (s) => /REFERENCE ONLY/.test(s),
+
+    // D1: the key is computed from the FULL keyCols (keyOf maps every column) and the write
+    // is store.upsert(key,row) (converge), not an insert.
+    upsert_full_composite_key: (s) => {
+      const u = fnBody(s, 'upsertByKey');
+      const k = fnBody(s, 'keyOf');
+      if (!u || !k) return false;
+      return /keyOf\(keyCols,\s*record\)/.test(u) && /keyCols\.map\(/.test(k) && /store\.upsert\(\s*key,\s*row\s*\)/.test(u);
+    },
+
+    // D2: the new value is the EXTERNAL record; the verify read-back happens AFTER the write
+    // (never a read-before-write to derive the row = a racy read-modify-write).
+    inputs_not_from_mutated_row: (s) => {
+      const u = fnBody(s, 'upsertByKey');
+      if (!u) return false;
+      const fromRecord = /row\s*=\s*\{\s*\.\.\.record/.test(u);
+      const upsertIdx = u.indexOf('store.upsert(');
+      const getIdx = u.indexOf('store.getByKey(');
+      return fromRecord && upsertIdx !== -1 && getIdx !== -1 && getIdx > upsertIdx;
+    },
+
+    // D2 carve-out: bumpVersion does a DB-atomic increment (store.atomicIncrement), NEVER an
+    // app-side read-then-write (no getByKey inside bumpVersion).
+    version_counter_carveout: (s) => {
+      const b = fnBody(s, 'bumpVersion');
+      if (!b) return false;
+      return /store\.atomicIncrement\(/.test(b) && !/getByKey\(/.test(b);
+    },
+
+    // D3: readBack reads BY THE FULL composite key (getByKey on the JSON-encoded tuple), never
+    // an unordered scan / find / limit.
+    deterministic_readback: (s) => {
+      const r = fnBody(s, 'readBack');
+      if (!r) return false;
+      return /store\.getByKey\(\s*JSON\.stringify\(keyVals\)/.test(r) && !/store\.all\(|\.limit\(|\.find\(/.test(r);
+    },
+
+    // D4: verify the write landed by read-back and THROW if not (fail loud on a silent no-op).
+    verify_write_landed_fail_loud: (s) => {
+      const u = fnBody(s, 'upsertByKey');
+      if (!u) return false;
+      return /const landed\s*=\s*store\.getByKey\(/.test(u) && /if\s*\(\s*!landed[\s\S]*?throw new Error/.test(u);
+    },
+
+    // D4/h2: updated_at is stamped explicitly from the injected clock on every write.
+    explicit_updated_at: (s) => {
+      const u = fnBody(s, 'upsertByKey');
+      return !!u && /updated_at:\s*clock\.now\(\)/.test(u);
+    },
+
+    // D4/h1-null: a null/undefined key component FAILS LOUD (NULL is distinct from NULL).
+    null_key_fail_loud: (s) => {
+      const k = fnBody(s, 'keyOf');
+      if (!k) return false;
+      return /===\s*null\s*\|\|\s*v\s*===\s*undefined/.test(k) && /throw new Error/.test(k);
+    },
+
+    // store + clock are INJECTED parameters, never module singletons.
+    injected_store_clock: (s) => {
+      const takes = /export function upsertByKey\(store,\s*keyCols,\s*record,\s*opts/.test(s);
+      const noSingleton = !/^(const|let|var)\s+store\s*=/m.test(s);
+      return takes && noSingleton;
+    },
+
+    builtins_only_import: (s) => {
+      const spec = [
+        ...[...s.matchAll(/^\s*import\s+(?:[^'"]*?\sfrom\s+)?['"]([^'"]+)['"]/gm)].map((m) => m[1]),
+        ...[...s.matchAll(/^\s*export\s+[^'"]*?\sfrom\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]),
+        ...[...s.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g)].map((m) => m[1]),
+      ];
+      const hasRequire = /\brequire\s*\(/.test(s);
+      return !hasRequire && spec.every((i) => i.startsWith('node:'));
+    },
+  };
+}
+
+/** Evaluate every lock over a module's source; returns { ok, failed: [] }. */
+export function judgeSource(src) {
+  const locks = buildLocks();
+  const failed = Object.entries(locks).filter(([, check]) => !check(src)).map(([name]) => name);
+  return { ok: failed.length === 0, failed };
+}

--- a/golden-references/idempotent-composite-upsert/acceptance-locks.mjs
+++ b/golden-references/idempotent-composite-upsert/acceptance-locks.mjs
@@ -2,9 +2,9 @@
 // predicates over the JS source, node-builtins-only. Textual locks are NECESSARY BUT
 // WEAK (the -C lesson); the behavioral suite (parameterized over GOLDEN_REF_MODULE) that
 // RUNS the seam against a store adapter — two identical writes converge to one row, a
-// silent-drop store makes the seam FAIL LOUD, a partial key collapses distinct rows — is
-// the primary enforcement (the -F lesson: a "no bad keyword" textual check is a weak proxy
-// for the real behavior).
+// silent-drop store makes the seam FAIL LOUD, a partial key collapses distinct rows, a
+// drop-on-UPDATE with a colliding timestamp still fails loud — is the primary enforcement
+// (the -F lesson: a "no bad keyword" textual check is a weak proxy for the real behavior).
 export const DEFAULT_MODULE = 'golden-references/idempotent-composite-upsert/upsert-seam.mjs';
 
 function stripComments(src) {
@@ -61,11 +61,16 @@ export function buildLocks() {
       return /store\.getByKey\(\s*JSON\.stringify\(keyVals\)/.test(r) && !/store\.all\(|\.limit\(|\.find\(/.test(r);
     },
 
-    // D4: verify the write landed by read-back and THROW if not (fail loud on a silent no-op).
+    // D4: verify the write landed by read-back AND by write-IDENTITY (the payload), then THROW
+    // if not — an updated_at-equality-only check false-passes a drop-on-UPDATE with a colliding
+    // timestamp, so the verify MUST compare the intended payload (Object.keys(expected)).
     verify_write_landed_fail_loud: (s) => {
       const u = fnBody(s, 'upsertByKey');
-      if (!u) return false;
-      return /const landed\s*=\s*store\.getByKey\(/.test(u) && /if\s*\(\s*!landed[\s\S]*?throw new Error/.test(u);
+      const a = fnBody(s, 'assertLanded');
+      if (!u || !a) return false;
+      const readsBackAndVerifies = /const landed\s*=\s*store\.getByKey\(/.test(u) && /assertLanded\(\s*landed/.test(u);
+      const payloadIdentity = /Object\.keys\(\s*expected\s*\)/.test(a) && /throw new Error/.test(a);
+      return readsBackAndVerifies && payloadIdentity;
     },
 
     // D4/h2: updated_at is stamped explicitly from the injected clock on every write.
@@ -74,11 +79,32 @@ export function buildLocks() {
       return !!u && /updated_at:\s*clock\.now\(\)/.test(u);
     },
 
-    // D4/h1-null: a null/undefined key component FAILS LOUD (NULL is distinct from NULL).
+    // D4/h1-null: a null/undefined key component FAILS LOUD (NULL is distinct from NULL). The
+    // guard is centralized in assertKeyComponent and actually APPLIED by keyOf.
     null_key_fail_loud: (s) => {
+      const g = fnBody(s, 'assertKeyComponent');
       const k = fnBody(s, 'keyOf');
-      if (!k) return false;
-      return /===\s*null\s*\|\|\s*v\s*===\s*undefined/.test(k) && /throw new Error/.test(k);
+      if (!g || !k) return false;
+      const nullGuard = /v\s*===\s*null\s*\|\|\s*v\s*===\s*undefined/.test(g) && /throw new Error/.test(g);
+      const applied = /assertKeyComponent\(/.test(k);
+      return nullGuard && applied;
+    },
+
+    // D4/h1-nonfinite: a NaN/Infinity key component FAILS LOUD (it serializes to "null" and
+    // forges the exact colliding key the null guard exists to reject).
+    nonfinite_key_fail_loud: (s) => {
+      const g = fnBody(s, 'assertKeyComponent');
+      if (!g) return false;
+      return /Number\.isFinite\(/.test(g) && /throw new Error/.test(g);
+    },
+
+    // D1/degenerate: a zero-column keyCols FAILS LOUD (it cannot discriminate rows -> over-merge).
+    nonempty_keycols_fail_loud: (s) => {
+      const a = fnBody(s, 'assertKeyCols');
+      const k = fnBody(s, 'keyOf');
+      if (!a || !k) return false;
+      const guard = /keyCols\.length\s*===\s*0|!Array\.isArray\(\s*keyCols\s*\)/.test(a) && /throw new Error/.test(a);
+      return guard && /assertKeyCols\(/.test(k);
     },
 
     // store + clock are INJECTED parameters, never module singletons.

--- a/golden-references/idempotent-composite-upsert/application-guide.md
+++ b/golden-references/idempotent-composite-upsert/application-guide.md
@@ -39,14 +39,30 @@ These are never legal adaptations — each has a WHY in the reference:
 - **Inputs not from the mutated row (version-counter carve-out)** — the new value is a pure
   function of external inputs. The ONLY legitimate monotonic counter is a DB-atomic increment
   / optimistic-lock (`... WHERE version = $expected`) / `RETURNING` — never an app-side
-  `read → +1 → write` off the mutated row (it loses increments under interleaving).
+  `read → +1 → write` off the mutated row (it loses increments under interleaving). NOTE: the
+  acceptance harness can only check this at the `bumpVersion` body layer (it forbids a
+  `getByKey` there); it CANNOT see inside your DB adapter's `atomicIncrement`. Independently
+  audit that your `atomicIncrement` is a single atomic statement, not a get-then-set hidden in
+  the adapter — a racy counter buried in the adapter passes every automated check.
+- **keyCols is an ORDERED tuple = the index definition** — the seam keys positionally, so
+  `keyCols` must match your UNIQUE index's column order and be a FIXED per-table constant.
+  Reordering it produces a distinct positional key (the demo store does not model an
+  order-independent set-wise index).
 - **Deterministic read-back** — read BY THE FULL COMPOSITE KEY (or an explicit `ORDER BY`);
   an unordered `limit 1` returns a nondeterministic/stale row (h1).
-- **Verify the write landed + explicit `updated_at`, FAIL LOUD** — confirm the write affected
-  the expected row by reading it back by full key and THROW if it did not (h4's silent no-op);
-  stamp `updated_at` explicitly from the clock (h2); and FAIL LOUD on a null/undefined key
-  component (NULL is distinct from NULL in a composite index, so a null key part silently
-  duplicates). Contrast -F: this seam fails loud; it does not swallow.
+- **Verify the write landed (write-IDENTITY) + explicit `updated_at`, FAIL LOUD** — after the
+  write, read the row back by the FULL key and confirm the INTENDED PAYLOAD is what landed;
+  THROW on any mismatch (h4's silent no-op). Verify by the *payload*, NOT by `updated_at`
+  equality alone: a silent drop-on-UPDATE can leave a stale row whose `updated_at` happens to
+  equal this clock tick (h4 hiding under an h2 timestamp collision — real clocks collide at ms
+  resolution under load), and an equality check FALSE-PASSES on it. Stamp `updated_at`
+  explicitly from the clock (h2). (If your real table has an `updated_at` TRIGGER that owns the
+  column, verify a per-write token / a `RETURNING` id instead of the stamped `updated_at`.)
+  FAIL LOUD on an ILLEGAL key component — null/undefined (NULL is distinct from NULL, so a null
+  part silently duplicates), a NON-FINITE number (NaN/Infinity JSON-serialize to `"null"` and
+  forge a colliding key), a NON-SCALAR (serializes to a structure, not an index value), or a
+  ZERO-COLUMN key (cannot discriminate rows -> over-merges every record into one). Contrast -F:
+  this seam fails loud; it does not swallow.
 
 ### Estate-anchor mapping (positive vs cautionary — the estate is mixed)
 
@@ -74,7 +90,9 @@ npx vitest run tests/unit/golden-references/upsert-seam-acceptance.test.js
   component throws; distinct full keys stay distinct (structural keying); read-back by full
   key is exact and a miss returns null; an atomic version counter advances; `updated_at`
   advances with the clock.
-- **Miss**: a silent-drop store makes the seam THROW; and the portable `upsertContract`
-  ACCEPTS the golden seam (positive control) while REJECTING every broken copy — DO-NOTHING,
-  SELF-READ, PARTIAL-KEY, NO-VERIFY, STALE-UPDATED-AT, NULL-KEY-UNSAFE — so a broken delegate
-  copy is caught.
+- **Miss**: a silent-drop store makes the seam THROW; a drop-on-UPDATE store (INSERT lands, the
+  UPDATE silently no-ops) with a COLLIDING timestamp still THROWS (write-identity, not
+  updated_at-equality); a payload-dropped store THROWS; NaN/Infinity/empty-keyCols THROW; and
+  the portable `upsertContract` ACCEPTS the golden seam (positive control) while REJECTING every
+  broken copy — DO-NOTHING, SELF-READ, PARTIAL-KEY, NO-VERIFY, STALE-UPDATED-AT, NULL-KEY-UNSAFE,
+  WEAK-VERIFY (updated_at-equality only), NAN-KEY-UNSAFE — so a broken delegate copy is caught.

--- a/golden-references/idempotent-composite-upsert/application-guide.md
+++ b/golden-references/idempotent-composite-upsert/application-guide.md
@@ -1,0 +1,80 @@
+# Application guide — idempotent composite-key upsert/write seam
+
+Template-shaped for a delegate-tier session. You adapt `upsert-seam.mjs` to write a
+composite-keyed row idempotently for your own venture/build; you do not need estate
+context beyond this folder.
+
+## Inputs
+
+- **store** — the injected table adapter: `upsert(key, row)` (converge-to-latest on the
+  full key), `getByKey(key)` (exact lookup), `atomicIncrement(key, field)` (a DB-atomic
+  increment), `size()`, `all()`, `seed()`. In an application this is your DB client; here
+  it is an in-memory demo. Replace it — do NOT model your table's unique index by
+  string-joining key columns (that collides), key STRUCTURALLY on the tuple.
+- **keyCols** — the FULL composite key columns (the exact columns of the table's unique
+  index). A partial subset collapses distinct rows (data loss).
+- **record** — the keyCols + payload; the new value comes from THIS external input, never
+  from the row being mutated.
+- **clock** — the injected time source; `updated_at` is stamped from it explicitly.
+
+## Adaptation points
+
+1. Replace `keyCols` with YOUR table's full composite-key columns (matching a real UNIQUE
+   index); the seam's `onConflict` must match that index exactly.
+2. Map `store` onto your DB adapter: `upsert` must DO UPDATE (converge), not `DO NOTHING`;
+   `getByKey` must be an exact full-key lookup; `atomicIncrement` a DB-side increment /
+   `RETURNING` / optimistic-lock — never an app-side read-then-write.
+3. Keep the new value derived from `record` (external input); never read the mutated row to
+   compute it.
+4. Keep `updated_at` stamped explicitly from the clock — do NOT assume a DB trigger.
+
+## Invariants
+
+These are never legal adaptations — each has a WHY in the reference:
+
+- **Idempotent upsert on the FULL composite key** — two identical writes converge to ONE row
+  and a later differing write converges to the LATEST value. A partial/wrong conflict key
+  collapses distinct rows (data loss); insert-only duplicates; `ON CONFLICT DO NOTHING`
+  silently drops updates.
+- **Inputs not from the mutated row (version-counter carve-out)** — the new value is a pure
+  function of external inputs. The ONLY legitimate monotonic counter is a DB-atomic increment
+  / optimistic-lock (`... WHERE version = $expected`) / `RETURNING` — never an app-side
+  `read → +1 → write` off the mutated row (it loses increments under interleaving).
+- **Deterministic read-back** — read BY THE FULL COMPOSITE KEY (or an explicit `ORDER BY`);
+  an unordered `limit 1` returns a nondeterministic/stale row (h1).
+- **Verify the write landed + explicit `updated_at`, FAIL LOUD** — confirm the write affected
+  the expected row by reading it back by full key and THROW if it did not (h4's silent no-op);
+  stamp `updated_at` explicitly from the clock (h2); and FAIL LOUD on a null/undefined key
+  component (NULL is distinct from NULL in a composite index, so a null key part silently
+  duplicates). Contrast -F: this seam fails loud; it does not swallow.
+
+### Estate-anchor mapping (positive vs cautionary — the estate is mixed)
+
+| reference behavior                         | estate anchor                                                             |
+|--------------------------------------------|---------------------------------------------------------------------------|
+| full-key onConflict + explicit updated_at + verify | **POSITIVE** `post-build-verdict-engine.js` `upsertVerdict`        |
+| no verify + no explicit updated_at         | **CAUTION** `convergence-ledger.js` `upsertStage` (misses h4)             |
+| verify present, but no explicit updated_at | **CAUTION** `task-ledger.js`                                              |
+| `version = existing.version + 1` (racy RMW)| **CAUTION** `archplan-upsert.js` — h3 in the wild                         |
+| verify = read-back-by-full-key (identity)  | **strengthening** over the estate baseline `select().single()` (cardinality) |
+
+## Acceptance (both directions)
+
+Textual locks (`judgeSource` from `acceptance-locks.mjs`) are necessary but WEAK. The
+behavioral contract is the real enforcement — especially the convergence, silent-drop
+fail-loud, and partial-key checks no grep can prove — and it runs against YOUR module:
+
+```
+GOLDEN_REF_MODULE=<abs path to your upsert-seam.mjs> \
+GOLDEN_REF_SRC=<abs path to your source> \
+npx vitest run tests/unit/golden-references/upsert-seam-acceptance.test.js
+```
+
+- **Pass**: two identical writes leave one row; a later differing write wins; a null key
+  component throws; distinct full keys stay distinct (structural keying); read-back by full
+  key is exact and a miss returns null; an atomic version counter advances; `updated_at`
+  advances with the clock.
+- **Miss**: a silent-drop store makes the seam THROW; and the portable `upsertContract`
+  ACCEPTS the golden seam (positive control) while REJECTING every broken copy — DO-NOTHING,
+  SELF-READ, PARTIAL-KEY, NO-VERIFY, STALE-UPDATED-AT, NULL-KEY-UNSAFE — so a broken delegate
+  copy is caught.

--- a/golden-references/idempotent-composite-upsert/problem-prompt.md
+++ b/golden-references/idempotent-composite-upsert/problem-prompt.md
@@ -29,8 +29,11 @@ read it as a uniform pattern):
 **VERIFY mechanism** — the estate BASELINE is a *cardinality* check (`select().single()` throws
 on 0/many rows; the client sets an error on a real constraint violation). This reference
 STRENGTHENS that (an improvement, labeled — not an estate description): it reads the row back BY
-THE FULL COMPOSITE KEY and fails loud if the write did not land — which is what catches h4's
-SILENT no-op that the error/cardinality check alone does not.
+THE FULL COMPOSITE KEY and confirms the INTENDED PAYLOAD is what landed (write-IDENTITY),
+failing loud on any mismatch — which is what catches h4's SILENT no-op that the error/cardinality
+check alone does not. Crucially it verifies the *payload*, not `updated_at` equality alone: a
+silent drop-on-UPDATE can leave a stale row whose `updated_at` already equals this clock tick
+(h4 hiding under an h2 timestamp collision), and an equality check would FALSE-PASS on it.
 
 **Contrast with the -F capture seam**: that seam is best-effort and NEVER throws; THIS seam must
 **fail loud** on a vanished write. Idempotency here means repeat identical writes CONVERGE to one

--- a/golden-references/idempotent-composite-upsert/problem-prompt.md
+++ b/golden-references/idempotent-composite-upsert/problem-prompt.md
@@ -1,0 +1,43 @@
+# Problem — idempotent composite-key upsert/write seam
+
+**Domain**: you must write a row keyed on a COMPOSITE key so that repeating the write is
+safe (idempotent) and the write is never silently lost. This is a documented recurring bug
+CLASS, not a one-off. Four hazards recur:
+
+- **h1 — unordered "limit 1" read**: reading a row back with an unordered `limit 1` returns a
+  nondeterministic/stale row when more than one matches.
+- **h2 — `updated_at` without a trigger**: relying on `updated_at` to reflect a write when the
+  table has no trigger to set it (many do not).
+- **h3 — read-modify-write off the mutated row**: computing the new value by reading the same
+  row you are about to write (racy; loses updates under interleaving).
+- **h4 — the silent no-op**: the client swallows a CHECK/enum violation (or a
+  where-matches-nothing) as *no error, no row change* — a write that VANISHES.
+
+**Reuse evidence** — and the estate is INTENTIONALLY MIXED; that mix IS the bug class (do not
+read it as a uniform pattern):
+
+- **POSITIVE exemplar** — `lib/eva/post-build-verdict-engine.js` `upsertVerdict`: a full-key
+  `onConflict` (`venture_id,artifact_type,claim_ref`) + an EXPLICIT `updated_at` + a verify read
+  (`select('id').single()`). This is the shape the doctrines prescribe.
+- **CAUTIONARY exemplars** (real estate the doctrines harden AGAINST):
+  - `lib/coordinator/convergence-ledger.js` `upsertStage` — upserts on `run_id,stage` but does
+    NOT verify and does NOT set `updated_at` explicitly (only inspects the error object → misses h4).
+  - `lib/adam/task-ledger.js` — verifies, but does not stamp `updated_at` explicitly.
+  - `lib/eva/archplan-upsert.js` — `version = existing.version + 1`, read off the SAME `plan_key`
+    row it then upserts: **h3 in the wild** (a racy read-modify-write).
+
+**VERIFY mechanism** — the estate BASELINE is a *cardinality* check (`select().single()` throws
+on 0/many rows; the client sets an error on a real constraint violation). This reference
+STRENGTHENS that (an improvement, labeled — not an estate description): it reads the row back BY
+THE FULL COMPOSITE KEY and fails loud if the write did not land — which is what catches h4's
+SILENT no-op that the error/cardinality check alone does not.
+
+**Contrast with the -F capture seam**: that seam is best-effort and NEVER throws; THIS seam must
+**fail loud** on a vanished write. Idempotency here means repeat identical writes CONVERGE to one
+row (and a later differing write converges to the LATEST) — not that errors are swallowed, and
+not `ON CONFLICT DO NOTHING`.
+
+**Task shape a delegate will face**: write a row keyed on a composite key so two identical writes
+leave one row, a later differing write wins, a null key component is refused, the write is read
+back by the full key and fails loud if it did not land, and a monotonic counter (if any) uses a
+DB-atomic increment rather than a read-modify-write.

--- a/golden-references/idempotent-composite-upsert/upsert-seam.mjs
+++ b/golden-references/idempotent-composite-upsert/upsert-seam.mjs
@@ -1,0 +1,139 @@
+// Golden reference — idempotent composite-key upsert/write seam (REFERENCE ONLY, never wired).
+// Source SD: SD-LEO-INFRA-GOLDEN-REFERENCES-CANONICAL-001-G (the LAST family child).
+//
+// An idempotent write keyed on a COMPOSITE key is a documented recurring bug CLASS.
+// Four hazards this reference hardens against:
+//   h1  an unordered "limit 1" read returns a nondeterministic/stale row.
+//   h2  updated_at relied on without a DB trigger (do NOT assume a trigger exists).
+//   h3  the new value read FROM the row you are about to mutate (a racy read-modify-write).
+//   h4  the client SILENTLY no-ops on a CHECK/enum violation (or a where-matches-nothing):
+//       no error, no row change — a write that VANISHES.
+//
+// The estate is INTENTIONALLY MIXED — that mix IS the bug class (do not read it as a
+// uniform pattern):
+//   POSITIVE  lib/eva/post-build-verdict-engine.js upsertVerdict — full-key onConflict
+//             (venture_id,artifact_type,claim_ref) + EXPLICIT updated_at + a verify read.
+//   CAUTION   lib/coordinator/convergence-ledger.js upsertStage — no verify + no explicit
+//             updated_at (only checks the error object -> misses h4).
+//   CAUTION   lib/adam/task-ledger.js — verifies, but does not set updated_at explicitly.
+//   CAUTION   lib/eva/archplan-upsert.js — version = existing.version + 1 read off the SAME
+//             row it then upserts: h3 (racy read-modify-write) in the wild.
+//
+// CONTRAST with the -F capture seam (best-effort NEVER-throws): THIS seam must FAIL LOUD
+// on a vanished write — the bug it fights is a write that disappears without an error.
+//
+// VERIFY mechanism: the estate BASELINE is a cardinality check (select().single() throws
+// on 0/many rows; the client sets an error on a real constraint violation). This reference
+// STRENGTHENS that (an improvement, not an estate description): it reads the row back BY THE
+// FULL COMPOSITE KEY and fails loud if the write did not land — which is what catches h4's
+// SILENT no-op, that the error/cardinality check alone does not.
+//
+// Four doctrines (each modeled + textual-lock + BEHAVIORALLY enforced):
+//  1. IDEMPOTENT UPSERT ON THE FULL COMPOSITE KEY — two identical writes converge to ONE
+//     row, and a later differing write converges to the LATEST value (not DO NOTHING). A
+//     partial/wrong conflict key collapses distinct rows (data loss); insert-only duplicates.
+//  2. INPUTS NOT DERIVED FROM THE MUTATED ROW (version-counter CARVE-OUT) — the new value is
+//     a pure function of EXTERNAL inputs; never a racy read-modify-write off the mutated row.
+//     An intentional monotonic counter is legitimate ONLY via a DB-atomic increment /
+//     optimistic-lock / returning clause (modeled by store.atomicIncrement + bumpVersion),
+//     never an app-side read-then-write.
+//  3. DETERMINISTIC READ-BACK — read BY THE FULL COMPOSITE KEY (never an unordered scan/limit-1).
+//  4. VERIFY THE WRITE LANDED + EXPLICIT updated_at, FAIL LOUD — confirm the write affected
+//     the expected row (read back by full key) and THROW if it did not (h4); stamp updated_at
+//     explicitly from the injected clock (h2). Also FAIL LOUD on a NULL/undefined key
+//     component (NULL is distinct from NULL in a composite unique index, so a null key part
+//     silently duplicates).
+
+/** Structural composite key from the FULL keyCols — delimiter-safe (a JSON encoding so
+ *  ["a|b","c"] and ["a","b|c"] never collide, unlike a string-join). FAILS LOUD on a
+ *  null/undefined component (a null key part does not collide -> duplicate rows). */
+function keyOf(keyCols, source) {
+  const vals = keyCols.map((c) => {
+    const v = source[c];
+    if (v === null || v === undefined) {
+      throw new Error(`[upsert-seam] composite key column "${c}" is ${String(v)} — a NULL/undefined key component does not collide (NULL is distinct from NULL) and silently duplicates; refuse to key on it`);
+    }
+    return v;
+  });
+  return JSON.stringify(vals); // structural, delimiter-safe
+}
+
+/**
+ * Idempotent upsert on the FULL composite key. `record` carries the keyCols + payload; the
+ * new value IS `record` (external input) — never read from the mutated row (h3). Stamps
+ * updated_at from the injected clock (h2), upserts (converge-to-latest), then reads the row
+ * back BY FULL KEY and FAILS LOUD if the write did not land (h4).
+ *
+ * @param {{ upsert: Function, getByKey: Function }} store  injected table adapter.
+ * @param {string[]} keyCols  the FULL composite key columns.
+ * @param {object} record  keyCols + payload (external input).
+ * @param {{ clock: { now: () => number } }} opts  injected clock.
+ * @returns {object} the row that landed.
+ */
+export function upsertByKey(store, keyCols, record, opts = {}) {
+  const clock = (opts && opts.clock) || { now: () => 0 };
+  const key = keyOf(keyCols, record);                 // fail-loud on null-in-key
+  const row = { ...record, updated_at: clock.now() };  // explicit updated_at (h2); value = external input (h3)
+  store.upsert(key, row);                              // converge-to-latest on the full key (DO UPDATE)
+  const landed = store.getByKey(key);                 // VERIFY by read-back on the full key (h4)
+  if (!landed || landed.updated_at !== row.updated_at) {
+    throw new Error(`[upsert-seam] write did not land for key ${key} — a silent no-op (CHECK/enum violation or where-matches-nothing) must FAIL LOUD, never be trusted`);
+  }
+  return landed;
+}
+
+/** Deterministic read-back BY THE FULL composite key (never an unordered scan). Returns null
+ *  for a non-existent key (deterministically; does NOT throw — over-eager fail-loud would
+ *  break legitimate misses). FAILS LOUD only on a null/undefined key component. */
+export function readBack(store, keyCols, keyVals) {
+  if (keyVals.length !== keyCols.length) {
+    throw new Error('[upsert-seam] readBack requires a value for every key column (the FULL key)');
+  }
+  keyVals.forEach((v, i) => {
+    if (v === null || v === undefined) {
+      throw new Error(`[upsert-seam] readBack key column "${keyCols[i]}" is ${String(v)} — read by the FULL non-null composite key`);
+    }
+  });
+  return store.getByKey(JSON.stringify(keyVals));
+}
+
+/** The version-counter CARVE-OUT (doctrine 2): a monotonic counter done RIGHT — a DB-atomic
+ *  increment, NOT an app-side read-modify-write off the mutated row. Survives interleaving. */
+export function bumpVersion(store, keyCols, keyVals, field, opts = {}) {
+  const clock = (opts && opts.clock) || { now: () => 0 };
+  const key = JSON.stringify(keyVals);
+  return store.atomicIncrement(key, field, { updated_at: clock.now() }); // atomic; never read-then-write
+}
+
+/**
+ * A DEMO in-memory store adapter modeling a real table with a UNIQUE INDEX over the full
+ * composite key (delegates replace this with their DB adapter). Modes let the acceptance
+ * suite make each hazard REAL:
+ *   silentDrop: upsert returns success-looking but writes NOTHING (models h4).
+ *   insertOnly: a second write to an existing key raises a unique-index violation (models a
+ *               seam using insert instead of upsert).
+ */
+export function makeStore(opts = {}) {
+  const { silentDrop = false, insertOnly = false } = opts;
+  const rows = new Map(); // structural key -> row
+  return {
+    upsert(key, row) {
+      if (silentDrop) return { landed: false };                 // h4: silent no-op
+      if (insertOnly && rows.has(key)) {
+        throw new Error('[store] unique-index violation: insert on an existing composite key (use upsert)');
+      }
+      rows.set(key, { ...row });                                 // DO UPDATE: converge to latest
+      return { landed: true };
+    },
+    getByKey(key) { return rows.has(key) ? { ...rows.get(key) } : null; },
+    atomicIncrement(key, field, extra = {}) {                    // models a DB-side atomic increment / returning
+      const cur = rows.get(key) || {};
+      const next = { ...cur, ...extra, [field]: (cur[field] || 0) + 1 };
+      rows.set(key, next);
+      return { ...next };
+    },
+    all() { return [...rows.values()].map((r) => ({ ...r })); }, // an UNORDERED scan (a limit-1 misuse target)
+    size() { return rows.size; },
+    seed(key, row) { rows.set(key, { ...row }); },               // test seeding (poison-row, adversarial ordering)
+  };
+}

--- a/golden-references/idempotent-composite-upsert/upsert-seam.mjs
+++ b/golden-references/idempotent-composite-upsert/upsert-seam.mjs
@@ -24,83 +24,147 @@
 //
 // VERIFY mechanism: the estate BASELINE is a cardinality check (select().single() throws
 // on 0/many rows; the client sets an error on a real constraint violation). This reference
-// STRENGTHENS that (an improvement, not an estate description): it reads the row back BY THE
-// FULL COMPOSITE KEY and fails loud if the write did not land — which is what catches h4's
-// SILENT no-op, that the error/cardinality check alone does not.
+// STRENGTHENS that (an improvement, not an estate description): after the write it reads the
+// row back BY THE FULL COMPOSITE KEY and confirms the INTENDED PAYLOAD is what landed
+// (write-IDENTITY), failing loud on any mismatch — which is what catches h4's SILENT no-op
+// that the error/cardinality check alone does not.
+//   Why identity, not just updated_at: verifying only `landed.updated_at === row.updated_at`
+//   FALSE-PASSES a silent drop-on-UPDATE whenever the stale row already bears this clock tick
+//   (h4 hiding under an h2 timestamp collision — real clocks collide at ms resolution under
+//   load). The verify therefore compares the payload, not a single timestamp field. (If your
+//   real table has an updated_at TRIGGER that owns the column, the seam's explicit stamp does
+//   not apply — verify a per-write token / a RETURNING id instead of the payload's updated_at.)
 //
 // Four doctrines (each modeled + textual-lock + BEHAVIORALLY enforced):
 //  1. IDEMPOTENT UPSERT ON THE FULL COMPOSITE KEY — two identical writes converge to ONE
 //     row, and a later differing write converges to the LATEST value (not DO NOTHING). A
 //     partial/wrong conflict key collapses distinct rows (data loss); insert-only duplicates.
+//     keyCols is an ORDERED tuple matching the table's UNIQUE index definition (a fixed
+//     per-table constant) — reordering it produces a distinct positional key.
 //  2. INPUTS NOT DERIVED FROM THE MUTATED ROW (version-counter CARVE-OUT) — the new value is
 //     a pure function of EXTERNAL inputs; never a racy read-modify-write off the mutated row.
 //     An intentional monotonic counter is legitimate ONLY via a DB-atomic increment /
 //     optimistic-lock / returning clause (modeled by store.atomicIncrement + bumpVersion),
-//     never an app-side read-then-write.
+//     never an app-side read-then-write. NOTE: the harness can only enforce this at the
+//     bumpVersion body layer — it cannot see INSIDE your DB adapter's atomicIncrement, so you
+//     must independently audit that it is a single atomic statement (UPDATE ... SET n=n+1
+//     RETURNING, or WHERE version=$expected), not a get-then-set hidden in the adapter.
 //  3. DETERMINISTIC READ-BACK — read BY THE FULL COMPOSITE KEY (never an unordered scan/limit-1).
-//  4. VERIFY THE WRITE LANDED + EXPLICIT updated_at, FAIL LOUD — confirm the write affected
-//     the expected row (read back by full key) and THROW if it did not (h4); stamp updated_at
-//     explicitly from the injected clock (h2). Also FAIL LOUD on a NULL/undefined key
-//     component (NULL is distinct from NULL in a composite unique index, so a null key part
-//     silently duplicates).
+//  4. VERIFY THE WRITE LANDED (write-identity) + EXPLICIT updated_at, FAIL LOUD — read the row
+//     back by full key and confirm the INTENDED PAYLOAD is what landed; THROW if it did not
+//     (h4); stamp updated_at explicitly from the injected clock (h2). Also FAIL LOUD on an
+//     ILLEGAL key component: NULL/undefined (NULL is distinct from NULL in a composite unique
+//     index, so a null key part silently duplicates), a NON-FINITE number (NaN/Infinity
+//     JSON-serialize to "null" and forge a colliding key), a NON-SCALAR (an object/array
+//     serializes to a structure, not a real index value), or a ZERO-COLUMN key (cannot
+//     discriminate rows -> over-merges every record into one).
+
+/** Deep-ish equality for a read-back payload field. Scalars compare by ===; nested values by
+ *  a stable JSON encoding (both operands come from the same shaped record, so key order is
+ *  consistent). Sufficient for the reference; a production verify would use the DB's own
+ *  RETURNING row or a per-write token. */
+function deepEq(a, b) {
+  return a === b || JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Guard a single composite-key component. FAILS LOUD on every value that cannot be a real
+ *  scalar unique-index key: null/undefined, a non-finite number, or a non-scalar. Centralized
+ *  so keyOf, readBack and bumpVersion all key through the SAME guard (no hole in one path). */
+function assertKeyComponent(v, label) {
+  if (v === null || v === undefined) {
+    throw new Error(`[upsert-seam] ${label} is ${String(v)} — a NULL/undefined key component does not collide (NULL is distinct from NULL) and silently duplicates; refuse to key on it`);
+  }
+  const t = typeof v;
+  if (t === 'number' && !Number.isFinite(v)) {
+    throw new Error(`[upsert-seam] ${label} is ${String(v)} — a non-finite number serializes to "null" and forges a colliding key; refuse to key on it`);
+  }
+  if (t !== 'string' && t !== 'number' && t !== 'boolean' && t !== 'bigint') {
+    throw new Error(`[upsert-seam] ${label} is a ${t} — a composite key component must be a scalar (string/number/boolean/bigint); a non-scalar serializes to a structure and silently mis-keys`);
+  }
+}
+
+/** Assert the FULL keyCols is a usable ordered tuple (a zero-column key cannot discriminate
+ *  rows and silently over-merges every record into one). */
+function assertKeyCols(keyCols) {
+  if (!Array.isArray(keyCols) || keyCols.length === 0) {
+    throw new Error('[upsert-seam] keyCols must be a NON-EMPTY ordered tuple (the table\'s FULL composite unique-index columns) — a zero-column key cannot discriminate rows and silently over-merges every record into one');
+  }
+}
 
 /** Structural composite key from the FULL keyCols — delimiter-safe (a JSON encoding so
- *  ["a|b","c"] and ["a","b|c"] never collide, unlike a string-join). FAILS LOUD on a
- *  null/undefined component (a null key part does not collide -> duplicate rows). */
+ *  ["a|b","c"] and ["a","b|c"] never collide, unlike a string-join). FAILS LOUD on an illegal
+ *  key component (see assertKeyComponent) or a zero-column key. */
 function keyOf(keyCols, source) {
+  assertKeyCols(keyCols);
   const vals = keyCols.map((c) => {
     const v = source[c];
-    if (v === null || v === undefined) {
-      throw new Error(`[upsert-seam] composite key column "${c}" is ${String(v)} — a NULL/undefined key component does not collide (NULL is distinct from NULL) and silently duplicates; refuse to key on it`);
-    }
+    assertKeyComponent(v, `composite key column "${c}"`);
     return v;
   });
   return JSON.stringify(vals); // structural, delimiter-safe
+}
+
+/** VERIFY the write landed by write-IDENTITY: `landed` must exist AND every field of the
+ *  intended `expected` row must be present and equal in it (a superset is fine — a DB may add
+ *  generated columns like id). Comparing the PAYLOAD, not merely updated_at, is load-bearing:
+ *  a silent drop-on-UPDATE can leave a stale row whose updated_at collides with this clock
+ *  tick and false-pass an equality check (h4 hiding under h2). FAILS LOUD on any mismatch. */
+function assertLanded(landed, expected, key) {
+  if (!landed) {
+    throw new Error(`[upsert-seam] write did not land for key ${key} — a silent no-op (CHECK/enum violation or where-matches-nothing) must FAIL LOUD, never be trusted`);
+  }
+  for (const c of Object.keys(expected)) {
+    if (!deepEq(landed[c], expected[c])) {
+      throw new Error(`[upsert-seam] write did not land for key ${key}: column "${c}" read back as ${JSON.stringify(landed[c])}, expected ${JSON.stringify(expected[c])} — a silent no-op / partial write (h4) must FAIL LOUD (verify write-IDENTITY, not just updated_at equality)`);
+    }
+  }
 }
 
 /**
  * Idempotent upsert on the FULL composite key. `record` carries the keyCols + payload; the
  * new value IS `record` (external input) — never read from the mutated row (h3). Stamps
  * updated_at from the injected clock (h2), upserts (converge-to-latest), then reads the row
- * back BY FULL KEY and FAILS LOUD if the write did not land (h4).
+ * back BY FULL KEY and FAILS LOUD unless the intended payload is what landed (h4).
  *
  * @param {{ upsert: Function, getByKey: Function }} store  injected table adapter.
- * @param {string[]} keyCols  the FULL composite key columns.
+ * @param {string[]} keyCols  the FULL composite key columns (ordered tuple = index definition).
  * @param {object} record  keyCols + payload (external input).
  * @param {{ clock: { now: () => number } }} opts  injected clock.
  * @returns {object} the row that landed.
  */
 export function upsertByKey(store, keyCols, record, opts = {}) {
   const clock = (opts && opts.clock) || { now: () => 0 };
-  const key = keyOf(keyCols, record);                 // fail-loud on null-in-key
+  const key = keyOf(keyCols, record);                 // fail-loud on illegal key component
   const row = { ...record, updated_at: clock.now() };  // explicit updated_at (h2); value = external input (h3)
   store.upsert(key, row);                              // converge-to-latest on the full key (DO UPDATE)
   const landed = store.getByKey(key);                 // VERIFY by read-back on the full key (h4)
-  if (!landed || landed.updated_at !== row.updated_at) {
-    throw new Error(`[upsert-seam] write did not land for key ${key} — a silent no-op (CHECK/enum violation or where-matches-nothing) must FAIL LOUD, never be trusted`);
-  }
+  assertLanded(landed, row, key);                     // fail loud unless the INTENDED payload landed (write-identity)
   return landed;
 }
 
 /** Deterministic read-back BY THE FULL composite key (never an unordered scan). Returns null
  *  for a non-existent key (deterministically; does NOT throw — over-eager fail-loud would
- *  break legitimate misses). FAILS LOUD only on a null/undefined key component. */
+ *  break legitimate misses). FAILS LOUD only on an illegal key component. */
 export function readBack(store, keyCols, keyVals) {
+  assertKeyCols(keyCols);
   if (keyVals.length !== keyCols.length) {
     throw new Error('[upsert-seam] readBack requires a value for every key column (the FULL key)');
   }
-  keyVals.forEach((v, i) => {
-    if (v === null || v === undefined) {
-      throw new Error(`[upsert-seam] readBack key column "${keyCols[i]}" is ${String(v)} — read by the FULL non-null composite key`);
-    }
-  });
+  keyVals.forEach((v, i) => assertKeyComponent(v, `readBack key column "${keyCols[i]}"`));
   return store.getByKey(JSON.stringify(keyVals));
 }
 
 /** The version-counter CARVE-OUT (doctrine 2): a monotonic counter done RIGHT — a DB-atomic
- *  increment, NOT an app-side read-modify-write off the mutated row. Survives interleaving. */
+ *  increment, NOT an app-side read-modify-write off the mutated row. Survives interleaving.
+ *  (The harness cannot verify atomicity INSIDE your adapter — audit atomicIncrement is a
+ *  single atomic DB statement, not a get-then-set.) */
 export function bumpVersion(store, keyCols, keyVals, field, opts = {}) {
   const clock = (opts && opts.clock) || { now: () => 0 };
+  assertKeyCols(keyCols);
+  if (keyVals.length !== keyCols.length) {
+    throw new Error('[upsert-seam] bumpVersion requires a value for every key column (the FULL key)');
+  }
+  keyVals.forEach((v, i) => assertKeyComponent(v, `bumpVersion key column "${keyCols[i]}"`));
   const key = JSON.stringify(keyVals);
   return store.atomicIncrement(key, field, { updated_at: clock.now() }); // atomic; never read-then-write
 }
@@ -109,20 +173,25 @@ export function bumpVersion(store, keyCols, keyVals, field, opts = {}) {
  * A DEMO in-memory store adapter modeling a real table with a UNIQUE INDEX over the full
  * composite key (delegates replace this with their DB adapter). Modes let the acceptance
  * suite make each hazard REAL:
- *   silentDrop: upsert returns success-looking but writes NOTHING (models h4).
- *   insertOnly: a second write to an existing key raises a unique-index violation (models a
- *               seam using insert instead of upsert).
+ *   silentDrop:    upsert returns success-looking but writes NOTHING, always (models h4).
+ *   dropUpdates:   INSERT (new key) lands, but any UPDATE (existing key) silently no-ops —
+ *                  h4 on the UPDATE path only (the realistic case: a CHECK/enum on the new
+ *                  value, a partial index, or a where-matches-nothing on an existing row).
+ *   timestampOnly: writes ONLY updated_at, dropping the payload — a PARTIAL silent write (h4).
+ *   insertOnly:    a second write to an existing key raises a unique-index violation (models a
+ *                  seam using insert instead of upsert).
  */
 export function makeStore(opts = {}) {
-  const { silentDrop = false, insertOnly = false } = opts;
+  const { silentDrop = false, insertOnly = false, dropUpdates = false, timestampOnly = false } = opts;
   const rows = new Map(); // structural key -> row
   return {
     upsert(key, row) {
-      if (silentDrop) return { landed: false };                 // h4: silent no-op
+      if (silentDrop) return { landed: false };                 // h4: silent no-op (always)
       if (insertOnly && rows.has(key)) {
         throw new Error('[store] unique-index violation: insert on an existing composite key (use upsert)');
       }
-      rows.set(key, { ...row });                                 // DO UPDATE: converge to latest
+      if (dropUpdates && rows.has(key)) return { landed: false }; // h4: silent no-op on UPDATE only
+      rows.set(key, timestampOnly ? { updated_at: row.updated_at } : { ...row }); // DO UPDATE: converge to latest
       return { landed: true };
     },
     getByKey(key) { return rows.has(key) ? { ...rows.get(key) } : null; },

--- a/golden-references/idempotent-composite-upsert/upsert-seam.mjs
+++ b/golden-references/idempotent-composite-upsert/upsert-seam.mjs
@@ -62,7 +62,10 @@
 /** Deep-ish equality for a read-back payload field. Scalars compare by ===; nested values by
  *  a stable JSON encoding (both operands come from the same shaped record, so key order is
  *  consistent). Sufficient for the reference; a production verify would use the DB's own
- *  RETURNING row or a per-write token. */
+ *  RETURNING row or a per-write token. CAVEAT for a real table: this is order-sensitive and
+ *  exact, so a column the DB TRANSFORMS on read-back — jsonb re-sorted by key, undefined->null,
+ *  a numeric returned as a string, a timestamptz normalized — would false-throw on a LEGITIMATE
+ *  write. For such columns verify a per-write token / RETURNING id, not a payload deep-equal. */
 function deepEq(a, b) {
   if (a === b) return true;
   try { return JSON.stringify(a) === JSON.stringify(b); } catch { return false; } // e.g. a BigInt payload -> fall back to !== (fail loud)

--- a/golden-references/idempotent-composite-upsert/upsert-seam.mjs
+++ b/golden-references/idempotent-composite-upsert/upsert-seam.mjs
@@ -64,7 +64,8 @@
  *  consistent). Sufficient for the reference; a production verify would use the DB's own
  *  RETURNING row or a per-write token. */
 function deepEq(a, b) {
-  return a === b || JSON.stringify(a) === JSON.stringify(b);
+  if (a === b) return true;
+  try { return JSON.stringify(a) === JSON.stringify(b); } catch { return false; } // e.g. a BigInt payload -> fall back to !== (fail loud)
 }
 
 /** Guard a single composite-key component. FAILS LOUD on every value that cannot be a real
@@ -78,8 +79,11 @@ function assertKeyComponent(v, label) {
   if (t === 'number' && !Number.isFinite(v)) {
     throw new Error(`[upsert-seam] ${label} is ${String(v)} — a non-finite number serializes to "null" and forges a colliding key; refuse to key on it`);
   }
-  if (t !== 'string' && t !== 'number' && t !== 'boolean' && t !== 'bigint') {
-    throw new Error(`[upsert-seam] ${label} is a ${t} — a composite key component must be a scalar (string/number/boolean/bigint); a non-scalar serializes to a structure and silently mis-keys`);
+  if (t !== 'string' && t !== 'number' && t !== 'boolean') {
+    // bigint is a scalar but JSON.stringify throws on it (an opaque failure) — a delegate with a
+    // bigint id must stringify it first; reject here with the guided message rather than let the
+    // key encoder throw a bare TypeError.
+    throw new Error(`[upsert-seam] ${label} is a ${t} — a composite key component must be a JSON-encodable scalar (string/number/boolean); a non-scalar (or a BigInt) serializes to a structure / throws and silently mis-keys`);
   }
 }
 

--- a/golden-references/registry.json
+++ b/golden-references/registry.json
@@ -73,6 +73,21 @@
         "source_commit": "de44b5d368694634072e7849db2b78b302806a00"
       },
       "created_at": "2026-07-06T11:19:52.727Z"
+    },
+    {
+      "domain": "idempotent-composite-upsert",
+      "path": "golden-references/idempotent-composite-upsert/",
+      "guide": "application-guide.md — idempotent composite-key upsert/write seam: full-key upsert (converge-to-latest), inputs-not-from-mutated-row (version-counter carve-out), deterministic read-back, verify-landed + explicit updated_at FAIL LOUD (four doctrines vs the composite-upsert bug class)",
+      "door_class_of_application": "two_way",
+      "provenance": {
+        "source_files": [
+          "lib/eva/post-build-verdict-engine.js upsertVerdict (POSITIVE: full-key onConflict venture_id,artifact_type,claim_ref + explicit updated_at + select().single() verify)",
+          "lib/coordinator/convergence-ledger.js upsertStage (CAUTION: no verify + no explicit updated_at) + lib/adam/task-ledger.js (CAUTION: no explicit updated_at) + lib/eva/archplan-upsert.js (CAUTION: version=existing.version+1 racy read-modify-write)",
+          "the composite-key upsert bug class: unordered-limit1 stale read; updated_at-no-trigger; input-from-mutated-row; supabase-js silent CHECK/enum no-op"
+        ],
+        "source_commit": "88d858239ff90560a28118eaa754c9e4b9114863"
+      },
+      "created_at": "2026-07-06T13:42:27.056Z"
     }
   ]
 }

--- a/tests/unit/golden-references/upsert-seam-acceptance.test.js
+++ b/tests/unit/golden-references/upsert-seam-acceptance.test.js
@@ -1,0 +1,209 @@
+// Acceptance for the idempotent-composite-upsert golden reference. Behavioral-first
+// and PARAMETERIZED over GOLDEN_REF_MODULE from line 1 (the -C fix) so a delegate's
+// adapted COPY gets the same calling-enforcement. The load-bearing tests are the ones a
+// grep cannot prove: two identical writes converge to ONE row AND a later differing write
+// converges to the LATEST (falsifying ON CONFLICT DO NOTHING); a silent-drop store makes
+// the seam FAIL LOUD; a partial key collapses distinct rows; and the upsertContract must
+// ACCEPT the golden seam (positive control) while REJECTING every broken copy.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { judgeSource, buildLocks } from '../../../golden-references/idempotent-composite-upsert/acceptance-locks.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const abs = (p, d) => (p ? (isAbsolute(p) ? p : join(REPO_ROOT, p)) : d);
+const CANON_PATH = join(REPO_ROOT, 'golden-references', 'idempotent-composite-upsert', 'upsert-seam.mjs');
+const MODULE_PATH = abs(process.env.GOLDEN_REF_MODULE, CANON_PATH);
+const SRC_PATH = abs(process.env.GOLDEN_REF_SRC, MODULE_PATH);
+const SRC = readFileSync(SRC_PATH, 'utf8');
+
+let upsertByKey, readBack, bumpVersion, makeStore;
+beforeAll(async () => {
+  const m = await import(pathToFileURL(MODULE_PATH).href);
+  upsertByKey = m.upsertByKey; readBack = m.readBack; bumpVersion = m.bumpVersion; makeStore = m.makeStore;
+});
+
+const KEY = ['venture_id', 'artifact_type', 'claim_ref'];
+const rec = (over = {}) => ({ venture_id: 'v1', artifact_type: 'bp', claim_ref: 'c1', disposition: 'BUILT', ...over });
+const keyStr = (over = {}) => { const r = rec(over); return JSON.stringify(KEY.map((c) => r[c])); };
+
+// A PORTABLE upsert-contract checker — the teeth a delegate runs against their own seam.
+// It RUNS the candidate (not a source grep) against configured store scenarios. Returns
+// contract VIOLATIONS (empty === compliant). Includes a POSITIVE control (below) so a
+// vacuously over-strict candidate cannot pass by rejecting everything.
+function upsertContractViolations(seam, store = makeStore) {
+  const v = [];
+  const clock = (t) => ({ now: () => t });
+  // idempotency + convergence-to-latest (falsifies ON CONFLICT DO NOTHING)
+  try {
+    const s = store();
+    seam.upsertByKey(s, KEY, rec(), { clock: clock(1) });
+    seam.upsertByKey(s, KEY, rec(), { clock: clock(1) });
+    if (s.size() !== 1) v.push('not-idempotent');
+    seam.upsertByKey(s, KEY, rec({ disposition: 'MISSING' }), { clock: clock(2) });
+    const landed = s.getByKey(keyStr());
+    if (s.size() !== 1) v.push('not-idempotent');
+    if (!landed || landed.disposition !== 'MISSING') v.push('do-nothing-not-converged');
+  } catch { v.push('threw-on-happy-path'); }
+  // fail loud on a silent-drop store
+  { const s = store({ silentDrop: true }); let threw = false; try { seam.upsertByKey(s, KEY, rec(), { clock: clock(1) }); } catch { threw = true; } if (!threw) v.push('no-fail-loud-on-silent-drop'); }
+  // explicit updated_at advances with the clock
+  try { const s = store(); const a = seam.upsertByKey(s, KEY, rec(), { clock: clock(10) }); const b = seam.upsertByKey(s, KEY, rec({ disposition: 'X' }), { clock: clock(20) }); if (!(a && a.updated_at === 10) || !(b && b.updated_at === 20)) v.push('stale-updated-at'); } catch {}
+  // inputs not from the mutated row: seed a sentinel; the correct seam writes the external value
+  try { const s = store(); s.seed(keyStr(), rec({ disposition: 'SENTINEL', updated_at: 0 })); seam.upsertByKey(s, KEY, rec({ disposition: 'EXTERNAL' }), { clock: clock(1) }); const landed = s.getByKey(keyStr()); if (!landed || landed.disposition !== 'EXTERNAL') v.push('self-read-from-mutated-row'); } catch {}
+  // full composite key: distinct claim_ref must stay TWO rows (a partial key would collapse)
+  try { const s = store(); seam.upsertByKey(s, KEY, rec({ claim_ref: 'c1' }), { clock: clock(1) }); seam.upsertByKey(s, KEY, rec({ claim_ref: 'c2' }), { clock: clock(1) }); if (s.size() !== 2) v.push('partial-key-collapse'); } catch {}
+  // null-in-key must fail loud
+  { const s = store(); let threw = false; try { seam.upsertByKey(s, KEY, rec({ claim_ref: null }), { clock: clock(1) }); } catch { threw = true; } if (!threw) v.push('null-in-key-not-fail-loud'); }
+  return v;
+}
+
+// Broken delegate seams (inline). Each fails a DIFFERENT contract clause.
+const key = (over) => keyStr(over);
+const DO_NOTHING = { upsertByKey(s, keyCols, r, o) { const k = key(r); if (!s.getByKey(k)) s.upsert(k, { ...r, updated_at: o.clock.now() }); return s.getByKey(k); } };
+const SELF_READ = { upsertByKey(s, keyCols, r, o) { const k = key(r); const cur = s.getByKey(k); const row = { ...r, disposition: cur ? cur.disposition : r.disposition, updated_at: o.clock.now() }; s.upsert(k, row); return s.getByKey(k); } };
+const PARTIAL_KEY = { upsertByKey(s, keyCols, r, o) { const k = JSON.stringify([r.venture_id]); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); return s.getByKey(k); } };
+const NO_VERIFY = { upsertByKey(s, keyCols, r, o) { const k = key(r); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); return row; } }; // trusts the write, no read-back
+const STALE_UPDATED_AT = { upsertByKey(s, keyCols, r, o) { const k = key(r); s.upsert(k, { ...r }); const landed = s.getByKey(k); if (!landed) throw new Error('nope'); return landed; } };
+const NULL_KEY_UNSAFE = { upsertByKey(s, keyCols, r, o) { const k = JSON.stringify(keyCols.map((c) => r[c])); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); const landed = s.getByKey(k); if (!landed) throw new Error('nope'); return landed; } };
+
+describe('behavioral contract (the real enforcement — runs against the ADAPTED copy too)', () => {
+  it('IDEMPOTENCY + CONVERGENCE-TO-LATEST: identical writes -> 1 row; a differing write -> latest value (not DO NOTHING)', () => {
+    const s = makeStore();
+    upsertByKey(s, KEY, rec(), { clock: { now: () => 1 } });
+    upsertByKey(s, KEY, rec(), { clock: { now: () => 1 } });
+    expect(s.size()).toBe(1);
+    upsertByKey(s, KEY, rec({ disposition: 'MISSING' }), { clock: { now: () => 2 } });
+    expect(s.size()).toBe(1);
+    expect(s.getByKey(keyStr()).disposition).toBe('MISSING'); // converged to latest
+  });
+
+  it('SILENT-DROP FAIL-LOUD: a store that silently no-ops -> upsertByKey THROWS (contrast -F never-throw)', () => {
+    const s = makeStore({ silentDrop: true });
+    expect(() => upsertByKey(s, KEY, rec(), { clock: { now: () => 1 } })).toThrow(/did not land|FAIL LOUD|silent/i);
+  });
+
+  it('HAPPY-PATH lands + verifies: returns the stored row with the stamped updated_at', () => {
+    const s = makeStore();
+    const r = upsertByKey(s, KEY, rec(), { clock: { now: () => 42 } });
+    expect(r).toMatchObject({ venture_id: 'v1', artifact_type: 'bp', claim_ref: 'c1', disposition: 'BUILT', updated_at: 42 });
+  });
+
+  it('NULL-IN-KEY FAIL-LOUD: a null/undefined key component throws (NULL is distinct from NULL -> duplicates)', () => {
+    const s = makeStore();
+    expect(() => upsertByKey(s, KEY, rec({ claim_ref: null }), { clock: { now: () => 1 } })).toThrow(/NULL|null|undefined|key/i);
+    expect(() => upsertByKey(s, KEY, rec({ artifact_type: undefined }), { clock: { now: () => 1 } })).toThrow();
+  });
+
+  it('DELIMITER-COLLISION: ["a|b","c"] and ["a","b|c"] are DISTINCT rows (structural, not string-join keying)', () => {
+    const s = makeStore();
+    upsertByKey(s, ['a', 'b'], { a: 'a|b', b: 'c', v: 1 }, { clock: { now: () => 1 } });
+    upsertByKey(s, ['a', 'b'], { a: 'a', b: 'b|c', v: 2 }, { clock: { now: () => 1 } });
+    expect(s.size()).toBe(2);
+  });
+
+  it('DETERMINISTIC READ-BACK by full key; a non-existent key returns null (does NOT throw)', () => {
+    const s = makeStore();
+    upsertByKey(s, KEY, rec(), { clock: { now: () => 1 } });
+    expect(readBack(s, KEY, ['v1', 'bp', 'c1']).disposition).toBe('BUILT');
+    expect(readBack(s, KEY, ['v1', 'bp', 'nope'])).toBeNull(); // deterministic miss, no throw
+  });
+
+  it('VERSION-COUNTER CARVE-OUT (positive): an atomic bumpVersion survives repeats -> count advances', () => {
+    const s = makeStore();
+    s.seed(JSON.stringify(['v1', 'bp', 'c1']), rec({ count: 0 }));
+    bumpVersion(s, KEY, ['v1', 'bp', 'c1'], 'count', { clock: { now: () => 1 } });
+    const r = bumpVersion(s, KEY, ['v1', 'bp', 'c1'], 'count', { clock: { now: () => 2 } });
+    expect(r.count).toBe(2); // atomic increment, not a racy read-modify-write
+  });
+
+  it('VERSION-COUNTER (negative demonstration): a racy read-modify-write LOSES an increment under interleaving', () => {
+    const s = makeStore();
+    s.seed(JSON.stringify(['v1', 'bp', 'c1']), rec({ count: 0 }));
+    // simulate two interleaved sessions: both READ count=0, then both WRITE count=1
+    const k = JSON.stringify(['v1', 'bp', 'c1']);
+    const readA = s.getByKey(k).count;
+    const readB = s.getByKey(k).count;
+    s.upsert(k, { ...s.getByKey(k), count: readA + 1 });
+    s.upsert(k, { ...s.getByKey(k), count: readB + 1 });
+    expect(s.getByKey(k).count).toBe(1); // lost B's increment — WHY the atomic carve-out is required
+  });
+});
+
+describe('the upsert CONTRACT has TEETH (positive control + rejects every broken copy)', () => {
+  it('POSITIVE CONTROL: the canonical seam is ACCEPTED (contract is not vacuously over-strict)', () => {
+    expect(upsertContractViolations({ upsertByKey, readBack, bumpVersion })).toEqual([]);
+  });
+  it('NEGATIVE: DO-NOTHING (insert-if-absent) is REJECTED (does not converge to latest)', () => {
+    expect(upsertContractViolations(DO_NOTHING)).toContain('do-nothing-not-converged');
+  });
+  it('NEGATIVE: SELF-READ (value derived from the mutated row) is REJECTED', () => {
+    expect(upsertContractViolations(SELF_READ)).toContain('self-read-from-mutated-row');
+  });
+  it('NEGATIVE: PARTIAL-KEY (upsert on a partial key) is REJECTED (data-loss collapse)', () => {
+    expect(upsertContractViolations(PARTIAL_KEY)).toContain('partial-key-collapse');
+  });
+  it('NEGATIVE: NO-VERIFY (trusts the write) is REJECTED (reports success on a silent drop)', () => {
+    expect(upsertContractViolations(NO_VERIFY)).toContain('no-fail-loud-on-silent-drop');
+  });
+  it('NEGATIVE: STALE-UPDATED-AT (does not stamp updated_at) is REJECTED', () => {
+    expect(upsertContractViolations(STALE_UPDATED_AT)).toContain('stale-updated-at');
+  });
+  it('NEGATIVE: NULL-KEY-UNSAFE (keys on a null component) is REJECTED (no fail-loud)', () => {
+    expect(upsertContractViolations(NULL_KEY_UNSAFE)).toContain('null-in-key-not-fail-loud');
+  });
+});
+
+describe('textual locks pass on the source', () => {
+  const LOCKS = buildLocks();
+  for (const name of Object.keys(LOCKS)) {
+    it(`lock: ${name}`, () => {
+      expect(LOCKS[name](SRC), `lock '${name}' must hold`).toBe(true);
+    });
+  }
+  it('judgeSource aggregates to ok', () => {
+    expect(judgeSource(SRC)).toEqual({ ok: true, failed: [] });
+  });
+});
+
+describe('doctrine mutations fail named checks (miss direction)', () => {
+  const CANON = readFileSync(CANON_PATH, 'utf8');
+
+  it('upserting on a partial key fails upsert_full_composite_key', () => {
+    const m = CANON.replace('const key = keyOf(keyCols, record);', 'const key = keyOf([keyCols[0]], record);');
+    expect(judgeSource(m).failed).toContain('upsert_full_composite_key');
+  });
+  it('deriving the row from a read-before-write fails inputs_not_from_mutated_row', () => {
+    const m = CANON.replace('const row = { ...record, updated_at: clock.now() };', 'const prior = store.getByKey(key); const row = { ...record, updated_at: clock.now() };');
+    expect(judgeSource(m).failed).toContain('inputs_not_from_mutated_row');
+  });
+  it('a read-modify-write bumpVersion fails version_counter_carveout', () => {
+    const m = CANON.replace('return store.atomicIncrement(key, field, { updated_at: clock.now() });', 'const cur = store.getByKey(key); store.upsert(key, { ...cur, [field]: (cur[field]||0)+1 }); return store.getByKey(key);');
+    expect(judgeSource(m).failed).toContain('version_counter_carveout');
+  });
+  it('an unordered scan read-back fails deterministic_readback', () => {
+    const m = CANON.replace('return store.getByKey(JSON.stringify(keyVals));', 'return store.all().find((r) => r[keyCols[0]] === keyVals[0]);');
+    expect(judgeSource(m).failed).toContain('deterministic_readback');
+  });
+  it('dropping the verify read-back fails verify_write_landed_fail_loud', () => {
+    const m = CANON.replace(/const landed = store\.getByKey\(key\);[\s\S]*?\n  \}\n  return landed;/, 'return { ...row };');
+    expect(judgeSource(m).failed).toContain('verify_write_landed_fail_loud');
+  });
+  it('dropping the explicit updated_at fails explicit_updated_at', () => {
+    const m = CANON.replace('const row = { ...record, updated_at: clock.now() };', 'const row = { ...record };');
+    expect(judgeSource(m).failed).toContain('explicit_updated_at');
+  });
+  it('removing the null-key guard fails null_key_fail_loud', () => {
+    const m = CANON.replace('if (v === null || v === undefined) {', 'if (false) {');
+    expect(judgeSource(m).failed).toContain('null_key_fail_loud');
+  });
+  it('a module-level singleton store fails injected_store_clock', () => {
+    const m = CANON.replace('function keyOf(', 'const store = {};\nfunction keyOf(');
+    expect(judgeSource(m).failed).toContain('injected_store_clock');
+  });
+  it('a repo-relative import fails builtins_only_import', () => {
+    const m = "import { x } from '../../lib/eva/post-build-verdict-engine.js';\n" + CANON;
+    expect(judgeSource(m).failed).toContain('builtins_only_import');
+  });
+});

--- a/tests/unit/golden-references/upsert-seam-acceptance.test.js
+++ b/tests/unit/golden-references/upsert-seam-acceptance.test.js
@@ -56,6 +56,12 @@ function upsertContractViolations(seam, store = makeStore) {
   try { const s = store(); seam.upsertByKey(s, KEY, rec({ claim_ref: 'c1' }), { clock: clock(1) }); seam.upsertByKey(s, KEY, rec({ claim_ref: 'c2' }), { clock: clock(1) }); if (s.size() !== 2) v.push('partial-key-collapse'); } catch {}
   // null-in-key must fail loud
   { const s = store(); let threw = false; try { seam.upsertByKey(s, KEY, rec({ claim_ref: null }), { clock: clock(1) }); } catch { threw = true; } if (!threw) v.push('null-in-key-not-fail-loud'); }
+  // non-finite key must fail loud (NaN/Infinity serialize to "null" and forge a colliding key)
+  { const s = store(); let threw = false; try { seam.upsertByKey(s, KEY, rec({ claim_ref: NaN }), { clock: clock(1) }); } catch { threw = true; } if (!threw) v.push('non-finite-key-not-fail-loud'); }
+  // WRITE-IDENTITY verify: a silent drop-on-UPDATE (INSERT lands) must FAIL LOUD even when the
+  // stale row's updated_at collides with this clock tick — an updated_at-equality-only verify
+  // FALSE-PASSES here (h4 hiding under h2); a payload-identity verify does not.
+  { const s = store({ dropUpdates: true }); seam.upsertByKey(s, KEY, rec(), { clock: clock(5) }); let threw = false; try { seam.upsertByKey(s, KEY, rec({ disposition: 'MISSING' }), { clock: clock(5) }); } catch { threw = true; } if (!threw) v.push('weak-verify-false-pass-on-drop-update'); }
   return v;
 }
 
@@ -67,6 +73,10 @@ const PARTIAL_KEY = { upsertByKey(s, keyCols, r, o) { const k = JSON.stringify([
 const NO_VERIFY = { upsertByKey(s, keyCols, r, o) { const k = key(r); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); return row; } }; // trusts the write, no read-back
 const STALE_UPDATED_AT = { upsertByKey(s, keyCols, r, o) { const k = key(r); s.upsert(k, { ...r }); const landed = s.getByKey(k); if (!landed) throw new Error('nope'); return landed; } };
 const NULL_KEY_UNSAFE = { upsertByKey(s, keyCols, r, o) { const k = JSON.stringify(keyCols.map((c) => r[c])); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); const landed = s.getByKey(k); if (!landed) throw new Error('nope'); return landed; } };
+// verifies updated_at value-equality ONLY (the pre-hardening shape) -> FALSE-PASSES a silent
+// drop-on-UPDATE whenever the stale row's updated_at collides with this clock tick.
+const WEAK_VERIFY = { upsertByKey(s, keyCols, r, o) { const k = key(r); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); const landed = s.getByKey(k); if (!landed || landed.updated_at !== row.updated_at) throw new Error('nope'); return landed; } };
+const NAN_KEY_UNSAFE = { upsertByKey(s, keyCols, r, o) { const k = JSON.stringify(keyCols.map((c) => r[c])); const row = { ...r, updated_at: o.clock.now() }; s.upsert(k, row); const landed = s.getByKey(k); if (!landed) throw new Error('nope'); return landed; } };
 
 describe('behavioral contract (the real enforcement — runs against the ADAPTED copy too)', () => {
   it('IDEMPOTENCY + CONVERGENCE-TO-LATEST: identical writes -> 1 row; a differing write -> latest value (not DO NOTHING)', () => {
@@ -88,6 +98,30 @@ describe('behavioral contract (the real enforcement — runs against the ADAPTED
     const s = makeStore();
     const r = upsertByKey(s, KEY, rec(), { clock: { now: () => 42 } });
     expect(r).toMatchObject({ venture_id: 'v1', artifact_type: 'bp', claim_ref: 'c1', disposition: 'BUILT', updated_at: 42 });
+  });
+
+  it('DROP-ON-UPDATE + COLLIDING TIMESTAMP FAIL-LOUD: a silent no-op on UPDATE (INSERT lands) still THROWS even when the stale updated_at equals this clock tick', () => {
+    const s = makeStore({ dropUpdates: true });
+    upsertByKey(s, KEY, rec({ disposition: 'BUILT' }), { clock: { now: () => 5 } }); // INSERT lands
+    // the UPDATE silently drops; the stale row bears updated_at=5, SAME tick -> an updated_at-equality
+    // verify would FALSE-PASS. The payload-identity verify must still fail loud (disposition differs).
+    expect(() => upsertByKey(s, KEY, rec({ disposition: 'MISSING' }), { clock: { now: () => 5 } })).toThrow(/did not land|FAIL LOUD|column/i);
+  });
+
+  it('PAYLOAD-DROPPED write FAIL-LOUD: a store that keeps updated_at but drops the payload does not pass verification', () => {
+    const s = makeStore({ timestampOnly: true });
+    expect(() => upsertByKey(s, KEY, rec({ disposition: 'IMPORTANT' }), { clock: { now: () => 9 } })).toThrow(/did not land|column|FAIL LOUD/i);
+  });
+
+  it('NON-FINITE KEY FAIL-LOUD: NaN/Infinity key components throw (they serialize to "null" and forge a colliding key)', () => {
+    const s = makeStore();
+    expect(() => upsertByKey(s, ['a'], { a: NaN, v: 1 }, { clock: { now: () => 1 } })).toThrow(/non-finite|null|scalar|key/i);
+    expect(() => upsertByKey(s, ['a'], { a: Infinity, v: 1 }, { clock: { now: () => 1 } })).toThrow();
+  });
+
+  it('EMPTY KEYCOLS FAIL-LOUD: a zero-column composite key throws (it cannot discriminate rows -> over-merge)', () => {
+    const s = makeStore();
+    expect(() => upsertByKey(s, [], { a: 1, v: 1 }, { clock: { now: () => 1 } })).toThrow(/non-empty|discriminate|keyCols/i);
   });
 
   it('NULL-IN-KEY FAIL-LOUD: a null/undefined key component throws (NULL is distinct from NULL -> duplicates)', () => {
@@ -153,6 +187,12 @@ describe('the upsert CONTRACT has TEETH (positive control + rejects every broken
   it('NEGATIVE: NULL-KEY-UNSAFE (keys on a null component) is REJECTED (no fail-loud)', () => {
     expect(upsertContractViolations(NULL_KEY_UNSAFE)).toContain('null-in-key-not-fail-loud');
   });
+  it('NEGATIVE: WEAK-VERIFY (updated_at-equality only) is REJECTED (false-passes a drop-on-UPDATE under a timestamp collision)', () => {
+    expect(upsertContractViolations(WEAK_VERIFY)).toContain('weak-verify-false-pass-on-drop-update');
+  });
+  it('NEGATIVE: NAN-KEY-UNSAFE (keys on a non-finite component) is REJECTED (no fail-loud)', () => {
+    expect(upsertContractViolations(NAN_KEY_UNSAFE)).toContain('non-finite-key-not-fail-loud');
+  });
 });
 
 describe('textual locks pass on the source', () => {
@@ -187,8 +227,20 @@ describe('doctrine mutations fail named checks (miss direction)', () => {
     expect(judgeSource(m).failed).toContain('deterministic_readback');
   });
   it('dropping the verify read-back fails verify_write_landed_fail_loud', () => {
-    const m = CANON.replace(/const landed = store\.getByKey\(key\);[\s\S]*?\n  \}\n  return landed;/, 'return { ...row };');
+    const m = CANON.replace(/const landed = store\.getByKey\(key\);[\s\S]*?return landed;/, 'return { ...row };');
     expect(judgeSource(m).failed).toContain('verify_write_landed_fail_loud');
+  });
+  it('reverting to an updated_at-equality verify fails verify_write_landed_fail_loud', () => {
+    const m = CANON.replace('assertLanded(landed, row, key);', 'if (!landed || landed.updated_at !== row.updated_at) throw new Error("nope");');
+    expect(judgeSource(m).failed).toContain('verify_write_landed_fail_loud');
+  });
+  it('removing the non-finite key guard fails nonfinite_key_fail_loud', () => {
+    const m = CANON.replace("if (t === 'number' && !Number.isFinite(v)) {", 'if (false) {');
+    expect(judgeSource(m).failed).toContain('nonfinite_key_fail_loud');
+  });
+  it('removing the empty-keyCols guard fails nonempty_keycols_fail_loud', () => {
+    const m = CANON.replace('if (!Array.isArray(keyCols) || keyCols.length === 0) {', 'if (false) {');
+    expect(judgeSource(m).failed).toContain('nonempty_keycols_fail_loud');
   });
   it('dropping the explicit updated_at fails explicit_updated_at', () => {
     const m = CANON.replace('const row = { ...record, updated_at: clock.now() };', 'const row = { ...record };');


### PR DESCRIPTION
## Summary
The **7th and final** child of the golden-references family (6/7 → 7/7). A portable, node-builtins-only teaching reference for the **idempotent composite-key upsert/write seam** — hardening against a documented recurring bug class.

### Four hazards it fights
h1 unordered `limit 1` stale read · h2 `updated_at` without a trigger · h3 read-modify-write off the mutated row · h4 supabase-js silent CHECK/enum no-op (a write that vanishes).

### Four doctrines
1. **Idempotent upsert on the full composite key** — 2 identical writes → 1 row; a differing write → **latest** (not `ON CONFLICT DO NOTHING`).
2. **Inputs not from the mutated row (version-counter carve-out)** — external inputs only; a monotonic counter is legitimate *only* via a DB-atomic increment / optimistic-lock / `RETURNING`.
3. **Deterministic read-back** — by the full composite key, never an unordered `limit 1`.
4. **Verify the write landed + explicit `updated_at`, FAIL LOUD** — read back by full key and throw if it didn't land (h4); contrast -F's never-throw. Plus null-in-key fail-loud + structural (delimiter-safe) tuple keying.

### Estate honesty (RISK `ab37e04c`)
The estate is **mixed** — doctrines are *prescriptive*, anchors split **POSITIVE** (`upsertVerdict`) vs **CAUTIONARY** (`upsertStage` no-verify, `archplan-upsert` racy version RMW). Verify = the estate cardinality baseline *strengthened* to read-back-by-full-key (labeled).

### Verification (TESTING `a0b1098` must-adds folded)
The injected store is a **store adapter** (not a raw Map) with a silent-drop hook so fail-loud is genuinely testable. `upsertContract` is **behavioral** with a **positive control** + 6 negatives (convergence-vs-DO-NOTHING, version-counter pos/neg, null-in-key, delimiter-collision). **35 acceptance + 9 isolation green**; a broken copy fails **14/35** (enforcement reaches copies). Registry row 6 + idempotent mirror at **N=6**. Zero new DDL.

## Test plan
- `npx vitest run tests/unit/golden-references/upsert-seam-acceptance.test.js` → 35 passed
- `npx vitest run tests/unit/golden-references/isolation.test.js` → 9 passed
- `node scripts/golden-references/mirror-registry.mjs` ×2 → 1-then-0 at N=6

🤖 Generated with [Claude Code](https://claude.com/claude-code)