### PR TITLE
feat(SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001): activate design-fidelity gate (observe-only-first)

### DIFF
--- a/lib/eva/bridge/customer-facing-design-detector.js
+++ b/lib/eva/bridge/customer-facing-design-detector.js
@@ -12,11 +12,13 @@
  * landing is ALWAYS in-scope for design fidelity; these predicates let the gate observe that.
  */
 
-// Customer-facing landing signal: a user-facing marketing/landing surface. Word-boundaried so
-// "onboarding"/"branding" do not false-trip via "landing"/"brand". Exported (like
+// Customer-facing landing signal: a user-facing marketing/landing PAGE surface. Requires a
+// page-noun (not a bare "landing"/"hero") so a backend worker that merely mentions "hero-image"
+// or a "landing zone" does not false-trip — false-positives pollute the observe corpus that the
+// observe->bind decision reads (adversarial re-verify FR-1). Exported (like
 // backend-leaf-detection.js UI_SURFACE_RE) so the keyword set is reviewable/auditable.
 export const CUSTOMER_FACING_LANDING_RE =
-  /\b(landing[-\s]?page|landing|customer[-\s]?facing|marketing[-\s]?(?:page|site|landing)|hero[-\s]?(?:section|banner)?|home[-\s]?page|homepage|public[-\s]?(?:page|site)|splash[-\s]?page|go[-\s]?to[-\s]?market\s+page)\b/i;
+  /\b(landing[-\s]?page|customer[-\s]?facing|marketing[-\s]?(?:page|site|landing)|hero[-\s]?(?:section|banner)|home[-\s]?page|homepage|front[-\s]?page|product[-\s]?page|public[-\s]?(?:page|site)|splash[-\s]?page|go[-\s]?to[-\s]?market\s+page)\b/i;
 
 /** true when target_application names a VENTURE app (not the EHG_Engineer harness, not empty). */
 export function isVentureAppTarget(target) {

--- a/lib/eva/bridge/customer-facing-design-detector.js
+++ b/lib/eva/bridge/customer-facing-design-detector.js
@@ -1,0 +1,87 @@
+/**
+ * Customer-facing landing detector + design-pass check + gate-mode resolver.
+ * SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001 (the GATE HALF of the MarketLens landing-seam fix).
+ *
+ * Pure, synchronous, NEVER throws — same convention as backend-leaf-detection.js, so callers
+ * invoke these inside their existing flow without a try/catch and a malformed input can never
+ * turn a working gate evaluation into a thrown error.
+ *
+ * WHY: the thin MarketLens landing shipped as a backend/API child and slipped through
+ * backend-leaf-detection.js classifyBackendLeaf() (which exempts on !hasUISurface), while
+ * design-fidelity-scorer.js returned null (no stitchData) as a silent PASS. A customer-facing
+ * landing is ALWAYS in-scope for design fidelity; these predicates let the gate observe that.
+ */
+
+// Customer-facing landing signal: a user-facing marketing/landing surface. Word-boundaried so
+// "onboarding"/"branding" do not false-trip via "landing"/"brand". Exported (like
+// backend-leaf-detection.js UI_SURFACE_RE) so the keyword set is reviewable/auditable.
+export const CUSTOMER_FACING_LANDING_RE =
+  /\b(landing[-\s]?page|landing|customer[-\s]?facing|marketing[-\s]?(?:page|site|landing)|hero[-\s]?(?:section|banner)?|home[-\s]?page|homepage|public[-\s]?(?:page|site)|splash[-\s]?page|go[-\s]?to[-\s]?market\s+page)\b/i;
+
+/** true when target_application names a VENTURE app (not the EHG_Engineer harness, not empty). */
+export function isVentureAppTarget(target) {
+  const t = String(target || '').trim().toLowerCase();
+  if (!t) return false;                 // no target -> not a known venture surface
+  if (t === 'ehg_engineer') return false; // the backend-only harness repo
+  return true;
+}
+
+/**
+ * true when the SD is a CUSTOMER-FACING LANDING: it targets a venture app AND its scope/title
+ * carries a landing / customer-facing / marketing-page signal. FENCED so a genuine backend
+ * leaf (a venture engine/worker with no landing surface) never trips it — the venture-target
+ * AND landing-signal conjunction is required, so "DataDistill distillation engine" (venture
+ * target, no landing signal) is NOT a customer-facing landing.
+ *
+ * @param {{target_application?: string}} sd
+ * @param {string} scopeText - flattened scope.included text
+ * @param {string} titleText - sd.title
+ * @returns {boolean}
+ */
+export function isCustomerFacingLanding(sd, scopeText, titleText) {
+  if (!isVentureAppTarget(sd?.target_application)) return false;
+  const text = `${String(scopeText || '')} ${String(titleText || '')}`;
+  return CUSTOMER_FACING_LANDING_RE.test(text);
+}
+
+/**
+ * true when a customer-facing landing HAS a design pass by ANY path: a Stitch/S17 design
+ * artifact is present, OR a completed design / page-quality child SD exists. PURE — the caller
+ * injects the already-fetched artifacts + child SDs (dependency injection keeps this testable
+ * and non-throwing). A missing/malformed input reads as "no design pass".
+ *
+ * @param {{ designArtifacts?: Array, childSds?: Array }} deps
+ * @returns {boolean}
+ */
+export function hasDesignPass(deps = {}) {
+  const artifacts = Array.isArray(deps?.designArtifacts) ? deps.designArtifacts : [];
+  const children = Array.isArray(deps?.childSds) ? deps.childSds : [];
+
+  const hasStitchOrS17 = artifacts.some((a) => {
+    const kind = `${String(a?.artifact_type || a?.kind || a?.type || '')} ${String(a?.stage || a?.stage_number || '')} ${String(a?.name || '')}`.toLowerCase();
+    // substring for stitch/design (matches 'stitch_export', 'design_tokens'); S17 covers 's17' and a
+    // standalone stage number 17.
+    return kind.includes('stitch') || kind.includes('design') || kind.includes('s17') || /(^|\D)17(\D|$)/.test(kind);
+  });
+  if (hasStitchOrS17) return true;
+
+  return children.some((c) => {
+    const status = String(c?.status || '').toLowerCase();
+    if (status !== 'completed') return false;
+    const label = `${String(c?.sd_type || '')} ${String(c?.title || '')}`.toLowerCase();
+    return /\bdesign\b/.test(label) || /page[-\s]?quality/.test(label) || /\bui\b/.test(label);
+  });
+}
+
+/**
+ * Resolve DESIGN_FIDELITY_GATE_MODE as an explicit ALLOWLIST: ONLY the exact string 'bind'
+ * opts into blocking; every other value (unset, '', 'BIND ', 'binding', 'Bind', garbage)
+ * resolves to 'observe'. This FAILS SAFE — a misspelled/unset value can never fail-open into
+ * binding and block the MarketLens flagship (which has no design pass at S24).
+ *
+ * @param {object} env - process.env (or a test double)
+ * @returns {'observe'|'bind'}
+ */
+export function resolveDesignFidelityGateMode(env = {}) {
+  return (env && env.DESIGN_FIDELITY_GATE_MODE) === 'bind' ? 'bind' : 'observe';
+}

--- a/lib/eva/bridge/design-fidelity-observe.js
+++ b/lib/eva/bridge/design-fidelity-observe.js
@@ -1,0 +1,127 @@
+/**
+ * Observe-only design-fidelity would-reject recorder + dormant-scorer dispatch.
+ * SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001 (GATE HALF of the MarketLens landing-seam fix).
+ *
+ * OBSERVE-ONLY-FIRST: these functions RECORD a would-reject observation (durably, countably)
+ * so the observe->bind criterion (>=25 evals / >=48h / zero false-rejects / named flipper) is
+ * measurable — they NEVER block. Blocking is gated on DESIGN_FIDELITY_GATE_MODE === 'bind',
+ * which this SD does not set. Every write is SWALLOW-ALL (mirrors lib/eva/observe-gate-witness.js
+ * observeGateWitness): a witness-recording failure must never affect the caller's real behavior.
+ *
+ * Sink: the existing gate_witness_events table via recordWitnessEvent (NO new DDL). Would-rejects
+ * are recorded with verdict='rejected' under a fixed 'gate-harness' witness identity.
+ */
+import { isCustomerFacingLanding, hasDesignPass, resolveDesignFidelityGateMode } from './customer-facing-design-detector.js';
+
+export const DESIGN_FIDELITY_GATE_ID = 'DESIGN_FIDELITY_LANDING';
+const WITNESS_SESSION_ID = 'gate-harness'; // fixed, code-controlled observer identity (same as observe-gate-witness.js)
+const DEFAULT_SCORE_THRESHOLD = 50;
+
+async function resolveDeps(deps) {
+  const d = deps || {};
+  const recordWitnessEvent = d.recordWitnessEvent
+    || (await import('../record-witness-event.js')).recordWitnessEvent;
+  let supabase = d.supabase;
+  if (!supabase) {
+    const { createClient } = await import('@supabase/supabase-js');
+    supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  }
+  return { recordWitnessEvent, supabase };
+}
+
+/**
+ * Record a design_fidelity_would_reject observation. OBSERVE-ONLY + SWALLOW-ALL: never throws,
+ * never blocks. Skips (does not record) when there is no judged session or the judged session
+ * IS the witness identity (a session cannot witness its own work — recordWitnessEvent would
+ * throw on that, so we guard first, exactly like observeGateWitness).
+ *
+ * @param {{ judgedSessionId?: string, reason: string, gateId?: string }} params
+ * @param {object} [deps] - { recordWitnessEvent, supabase } injectable for tests
+ * @returns {Promise<{recorded: boolean, skipped: boolean, reason?: string}>}
+ */
+export async function observeDesignFidelityWouldReject({ judgedSessionId, reason, gateId } = {}, deps) {
+  try {
+    if (!judgedSessionId || judgedSessionId === WITNESS_SESSION_ID) {
+      return { recorded: false, skipped: true, reason: 'no judged session (or self-witness)' };
+    }
+    const { recordWitnessEvent, supabase } = await resolveDeps(deps);
+    await recordWitnessEvent(supabase, {
+      gateId: gateId || DESIGN_FIDELITY_GATE_ID,
+      witnessSessionId: WITNESS_SESSION_ID,
+      judgedSessionId,
+      verdict: 'rejected',
+      notes: `design-fidelity observe-only would-reject (SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001) -- not yet blocking: ${reason || 'customer-facing landing with no design pass'}`,
+    });
+    return { recorded: true, skipped: false };
+  } catch {
+    // OBSERVE-ONLY: a witness-recording failure must NEVER affect the caller (swallow-all).
+    return { recorded: false, skipped: false, reason: 'witness write failed (swallowed)' };
+  }
+}
+
+/**
+ * FR-1/FR-2 — the dormant design-fidelity scorer's FIRST live dispatch, fenced behind
+ * isCustomerFacingLanding. Runs scoreDesignFidelity(); a null result (no stitchData / no design
+ * data) OR a below-threshold score on a customer-facing landing is a WOULD-REJECT (observed),
+ * NOT a silent pass. NEVER throws, NEVER blocks (observe-only). Non-customer-facing SDs are a
+ * no-op (near-zero fleet cost). Returns the observation for the caller/tests.
+ *
+ * @param {{target_application?: string, title?: string}} sd
+ * @param {{ stitchData?: object, repoAnalysis?: object, scopeText?: string, titleText?: string, judgedSessionId?: string, threshold?: number }} ctx
+ * @param {object} [deps] - { scoreDesignFidelity, recordWitnessEvent, supabase } injectable for tests/spies
+ * @returns {Promise<{dispatched: boolean, wouldReject: boolean, score: number|null, mode: string}>}
+ */
+export async function dispatchDesignFidelityScorer(sd, ctx = {}, deps) {
+  const mode = resolveDesignFidelityGateMode((deps && deps.env) || process.env);
+  if (!isCustomerFacingLanding(sd, ctx.scopeText ?? '', ctx.titleText ?? sd?.title ?? '')) {
+    return { dispatched: false, wouldReject: false, score: null, mode }; // fenced: not a customer-facing landing
+  }
+  let result = null;
+  try {
+    const scoreFn = (deps && deps.scoreDesignFidelity)
+      || (await import('./design-fidelity-scorer.js')).scoreDesignFidelity;
+    result = scoreFn(ctx.stitchData ?? null, ctx.repoAnalysis ?? null); // <-- the live dispatch (was dormant)
+  } catch {
+    result = null; // a scorer error is treated as "no design signal" -> would-reject, never a throw
+  }
+  const threshold = Number.isFinite(ctx.threshold) ? ctx.threshold : DEFAULT_SCORE_THRESHOLD;
+  const score = result && Number.isFinite(result.score) ? result.score : null;
+  const wouldReject = score === null || score < threshold; // FR-2: null (no stitchData) is NOT a silent pass
+  // deps.observe === false -> dispatch the (formerly dormant) scorer for its LIVE call site only,
+  // WITHOUT recording (the caller owns recording, e.g. gated on hasDesignPass to avoid false-rejects).
+  const shouldObserve = !(deps && deps.observe === false);
+  if (wouldReject && shouldObserve) {
+    await observeDesignFidelityWouldReject({
+      judgedSessionId: ctx.judgedSessionId,
+      reason: score === null
+        ? 'customer-facing landing scored with NO design data (null) -- not a silent pass'
+        : `customer-facing landing design fidelity ${score} < ${threshold}`,
+    }, deps);
+  }
+  return { dispatched: true, wouldReject, score, mode };
+}
+
+/**
+ * FR-4 — venture-completion exit check for a customer-facing landing. If the landing has NO
+ * design pass by any path (no Stitch/S17 artifact AND no completed design/page-quality child),
+ * record a would-reject (observe-only). PURE inputs (injected artifacts + child SDs). NEVER
+ * throws, NEVER blocks.
+ *
+ * @param {{target_application?: string, title?: string}} sd
+ * @param {{ designArtifacts?: Array, childSds?: Array, scopeText?: string, titleText?: string, judgedSessionId?: string }} ctx
+ * @param {object} [deps]
+ * @returns {Promise<{applicable: boolean, wouldReject: boolean}>}
+ */
+export async function observeVentureCompletionDesignPass(sd, ctx = {}, deps) {
+  if (!isCustomerFacingLanding(sd, ctx.scopeText ?? '', ctx.titleText ?? sd?.title ?? '')) {
+    return { applicable: false, wouldReject: false }; // fenced: not a customer-facing landing
+  }
+  const passed = hasDesignPass({ designArtifacts: ctx.designArtifacts, childSds: ctx.childSds });
+  if (!passed) {
+    await observeDesignFidelityWouldReject({
+      judgedSessionId: ctx.judgedSessionId,
+      reason: 'venture completed a customer-facing landing with NO design pass (no Stitch/S17 artifact, no completed design child)',
+    }, deps);
+  }
+  return { applicable: true, wouldReject: !passed };
+}

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -116,22 +116,25 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
         // observe-only WOULD-REJECT. hasDesignPass gates it so a designed landing records nothing
         // (zero false-rejects — required for the observe->bind criterion). SWALLOW-ALL; never blocks.
         let childSds = [];
-        try {
-          if (sdResolved?.id) {
-            const { data: kids } = await supabase
+        let childLookupOk = false; // only record a would-reject when we could actually determine
+        try {                      // the design-pass state — a transient child-lookup failure must
+          if (sdResolved?.id) {    // not manufacture a spurious observe metric (re-verify FR-3).
+            const { data: kids, error: kidsErr } = await supabase
               .from('strategic_directives_v2')
               .select('sd_type,title,status')
               .eq('parent_sd_id', sdResolved.id);
-            childSds = kids || [];
+            if (!kidsErr) { childSds = kids || []; childLookupOk = true; }
           }
         } catch { /* observe-only: a child lookup failure must never affect the gate */ }
-        await observeVentureCompletionDesignPass(landingSd, {
-          designArtifacts: [], // Stitch/Lovable design-token source deprecated (SD out-of-scope note)
-          childSds,
-          scopeText: scopeToCheck,
-          titleText: sd?.title,
-          judgedSessionId,
-        }, { supabase });
+        if (childLookupOk) {
+          await observeVentureCompletionDesignPass(landingSd, {
+            designArtifacts: [], // Stitch/Lovable design-token source deprecated (SD out-of-scope note)
+            childSds,
+            scopeText: scopeToCheck,
+            titleText: sd?.title,
+            judgedSessionId,
+          }, { supabase });
+        }
         // OBSERVE-ONLY: intentionally do NOT return/block here — the existing exemption logic
         // still runs and still awards its 25/25. Binding is a separate, hand-verified step.
       }

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -92,6 +92,51 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
 
     const hasUIScope = /component|ui\s|frontend|form|page|view|dashboard/i.test(scopeToCheck);
 
+    // FR-3 (SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001): a CUSTOMER-FACING LANDING must NOT
+    // silently auto-exempt to 25/25 just because it is backend/API-classified (the seam that let
+    // the thin MarketLens landing ship ungated). OBSERVE-ONLY-FIRST: record a would-reject BEFORE
+    // any backend exemption fires; never change validation.score/pass while
+    // DESIGN_FIDELITY_GATE_MODE !== 'bind'. SWALLOW-ALL (mirrors observeGateWitness) so a witness
+    // write failure can never affect this gate's real result. Fenced by isCustomerFacingLanding
+    // so a genuine backend leaf is untouched (near-zero fleet cost).
+    try {
+      const { isCustomerFacingLanding } = await import('../../../lib/eva/bridge/customer-facing-design-detector.js');
+      const targetAppCFL = validation.details.target_application || sdResolved?.target_application || null;
+      const landingSd = { target_application: targetAppCFL, title: sd?.title };
+      if (isCustomerFacingLanding(landingSd, scopeToCheck, sd?.title)) {
+        const { dispatchDesignFidelityScorer, observeVentureCompletionDesignPass } = await import('../../../lib/eva/bridge/design-fidelity-observe.js');
+        const judgedSessionId = sdResolved?.claiming_session_id || null;
+        const scorerCtx = { scopeText: scopeToCheck, titleText: sd?.title, judgedSessionId, stitchData: null, repoAnalysis: null };
+        // FR-1/FR-2: give the DORMANT design-fidelity scorer its FIRST live dispatch (observe:false
+        // -> live call site only; the recording is owned below, gated on hasDesignPass, so a
+        // landing that HAS a design pass is never a false-reject). Stitch is deprecated -> null.
+        await dispatchDesignFidelityScorer(landingSd, scorerCtx, { supabase, observe: false });
+        // FR-3/FR-4: a customer-facing landing about to auto-exempt via a backend/API
+        // classification AND lacking a design pass (no completed design/page-quality child) is an
+        // observe-only WOULD-REJECT. hasDesignPass gates it so a designed landing records nothing
+        // (zero false-rejects — required for the observe->bind criterion). SWALLOW-ALL; never blocks.
+        let childSds = [];
+        try {
+          if (sdResolved?.id) {
+            const { data: kids } = await supabase
+              .from('strategic_directives_v2')
+              .select('sd_type,title,status')
+              .eq('parent_sd_id', sdResolved.id);
+            childSds = kids || [];
+          }
+        } catch { /* observe-only: a child lookup failure must never affect the gate */ }
+        await observeVentureCompletionDesignPass(landingSd, {
+          designArtifacts: [], // Stitch/Lovable design-token source deprecated (SD out-of-scope note)
+          childSds,
+          scopeText: scopeToCheck,
+          titleText: sd?.title,
+          judgedSessionId,
+        }, { supabase });
+        // OBSERVE-ONLY: intentionally do NOT return/block here — the existing exemption logic
+        // still runs and still awards its 25/25. Binding is a separate, hand-verified step.
+      }
+    } catch { /* observe-only: a detector/witness failure must never affect the gate */ }
+
     // SD types that never require UI component validation
     const noUITypes = ['database', 'infrastructure', 'documentation'];
     if (noUITypes.includes(sd?.sd_type) && !hasUIScope) {

--- a/tests/unit/eva/bridge/design-fidelity-observe.test.js
+++ b/tests/unit/eva/bridge/design-fidelity-observe.test.js
@@ -1,0 +1,221 @@
+// Unit tests for the design-fidelity activation (SD-LEO-INFRA-ACTIVATE-DESIGN-FIDELITY-001).
+// OBSERVE-ONLY-FIRST: the gate observes/logs would-rejects and NEVER blocks. These cover the
+// pure detector, the swallow-all witness recorder, the dormant-scorer live dispatch (spy-proven),
+// the no-false-reject fence, and the DESIGN_FIDELITY_GATE_MODE fail-safe allowlist.
+// NOTE: vitest.config.js excludes **/.worktrees/**, so run this from inside the worktree by file
+// path: npx vitest run tests/unit/eva/bridge/design-fidelity-observe.test.js
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isCustomerFacingLanding, isVentureAppTarget, hasDesignPass, resolveDesignFidelityGateMode,
+  CUSTOMER_FACING_LANDING_RE,
+} from '../../../../lib/eva/bridge/customer-facing-design-detector.js';
+import {
+  observeDesignFidelityWouldReject, dispatchDesignFidelityScorer, observeVentureCompletionDesignPass,
+  DESIGN_FIDELITY_GATE_ID,
+} from '../../../../lib/eva/bridge/design-fidelity-observe.js';
+
+// ---- (1) isCustomerFacingLanding: TRUE on a MarketLens-style landing, FALSE on a backend leaf ----
+describe('isCustomerFacingLanding — detects venture landings, fences backend leaves (no false-reject)', () => {
+  it('TRUE: MarketLens landing (venture target + landing signal)', () => {
+    expect(isCustomerFacingLanding(
+      { target_application: 'marketlens' },
+      'rebuild the MarketLens landing page hero and marketing sections',
+      'MarketLens Landing Rebuild',
+    )).toBe(true);
+  });
+  it('TRUE: customer-facing / homepage / marketing-site wording', () => {
+    expect(isCustomerFacingLanding({ target_application: 'venturex' }, 'the customer-facing homepage', 'x')).toBe(true);
+    expect(isCustomerFacingLanding({ target_application: 'venturex' }, 'public marketing site', 'x')).toBe(true);
+  });
+  it('FALSE: a genuine backend leaf on a venture app (no landing signal) — the no-false-reject fence', () => {
+    expect(isCustomerFacingLanding(
+      { target_application: 'datadistill' },
+      'the D1 distillation engine / worker that processes the ingest queue',
+      'DataDistill D1 distillation engine',
+    )).toBe(false);
+  });
+  it('FALSE: EHG_Engineer harness target is never a customer-facing landing', () => {
+    expect(isCustomerFacingLanding({ target_application: 'EHG_Engineer' }, 'a landing page', 'landing')).toBe(false);
+  });
+  it('FALSE: no target application (unknown surface)', () => {
+    expect(isCustomerFacingLanding({ target_application: null }, 'landing page', 'landing')).toBe(false);
+  });
+  it('isVentureAppTarget: venture yes, EHG_Engineer/empty no (case-insensitive)', () => {
+    expect(isVentureAppTarget('MarketLens')).toBe(true);
+    expect(isVentureAppTarget('ehg_engineer')).toBe(false);
+    expect(isVentureAppTarget('EHG_ENGINEER')).toBe(false);
+    expect(isVentureAppTarget('')).toBe(false);
+    expect(isVentureAppTarget(null)).toBe(false);
+  });
+  it('CUSTOMER_FACING_LANDING_RE is exported for review', () => {
+    expect(CUSTOMER_FACING_LANDING_RE).toBeInstanceOf(RegExp);
+  });
+});
+
+// ---- (6) DESIGN_FIDELITY_GATE_MODE ALLOWLIST TABLE — only exact 'bind' blocks (fail-open guard) ----
+describe('resolveDesignFidelityGateMode — allowlist, fails SAFE to observe (release-blocking guard)', () => {
+  const cases = [
+    ['bind', 'bind'],
+    ['observe', 'observe'],
+    [undefined, 'observe'],
+    ['', 'observe'],
+    ['BIND ', 'observe'],   // trailing space -> not exact
+    ['binding', 'observe'], // superstring -> not exact
+    ['Bind', 'observe'],    // case -> not exact
+    ['BIND', 'observe'],
+    ['1', 'observe'],
+    ['true', 'observe'],
+    ['garbage', 'observe'],
+  ];
+  for (const [input, expected] of cases) {
+    it(`DESIGN_FIDELITY_GATE_MODE=${JSON.stringify(input)} -> ${expected}`, () => {
+      expect(resolveDesignFidelityGateMode({ DESIGN_FIDELITY_GATE_MODE: input })).toBe(expected);
+    });
+  }
+  it('missing env object -> observe (fail-safe)', () => {
+    expect(resolveDesignFidelityGateMode()).toBe('observe');
+    expect(resolveDesignFidelityGateMode({})).toBe('observe');
+  });
+});
+
+// ---- (2)+(FR-4) hasDesignPass permutations ----
+describe('hasDesignPass — Stitch/S17 artifact OR completed design child, each path independent', () => {
+  it('Stitch artifact alone -> true', () => {
+    expect(hasDesignPass({ designArtifacts: [{ artifact_type: 'stitch_export' }], childSds: [] })).toBe(true);
+  });
+  it('S17 design stage artifact alone -> true', () => {
+    expect(hasDesignPass({ designArtifacts: [{ stage: 'S17', name: 'design tokens' }], childSds: [] })).toBe(true);
+  });
+  it('completed design child alone -> true', () => {
+    expect(hasDesignPass({ designArtifacts: [], childSds: [{ sd_type: 'feature', title: 'landing design pass', status: 'completed' }] })).toBe(true);
+  });
+  it('both paths present -> true', () => {
+    expect(hasDesignPass({ designArtifacts: [{ artifact_type: 'design' }], childSds: [{ title: 'page-quality', status: 'completed' }] })).toBe(true);
+  });
+  it('a design child that is NOT completed -> false', () => {
+    expect(hasDesignPass({ designArtifacts: [], childSds: [{ title: 'design', status: 'in_progress' }] })).toBe(false);
+  });
+  it('no artifact and no design child -> false (the MarketLens case)', () => {
+    expect(hasDesignPass({ designArtifacts: [], childSds: [{ sd_type: 'feature', title: 'backend api', status: 'completed' }] })).toBe(false);
+  });
+});
+
+// ---- (3) observeDesignFidelityWouldReject — records, skips, SWALLOW-ALL ----
+describe('observeDesignFidelityWouldReject — records via witness sink; skips safely; swallow-all', () => {
+  it('records a verdict=rejected witness event for a real judged session', async () => {
+    const rec = vi.fn().mockResolvedValue({ id: 'w1' });
+    const r = await observeDesignFidelityWouldReject(
+      { judgedSessionId: 'sess-A', reason: 'no design pass' },
+      { recordWitnessEvent: rec, supabase: {} },
+    );
+    expect(r).toEqual({ recorded: true, skipped: false });
+    expect(rec).toHaveBeenCalledTimes(1);
+    const arg = rec.mock.calls[0][1];
+    expect(arg.gateId).toBe(DESIGN_FIDELITY_GATE_ID);
+    expect(arg.verdict).toBe('rejected');
+    expect(arg.witnessSessionId).toBe('gate-harness');
+    expect(arg.judgedSessionId).toBe('sess-A');
+  });
+  it('SKIPS (no record) when there is no judged session', async () => {
+    const rec = vi.fn();
+    const r = await observeDesignFidelityWouldReject({ judgedSessionId: null, reason: 'x' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r.skipped).toBe(true);
+    expect(rec).not.toHaveBeenCalled();
+  });
+  it('SKIPS when judged session IS the witness identity (a session cannot witness itself)', async () => {
+    const rec = vi.fn();
+    const r = await observeDesignFidelityWouldReject({ judgedSessionId: 'gate-harness', reason: 'x' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r.skipped).toBe(true);
+    expect(rec).not.toHaveBeenCalled();
+  });
+  it('SWALLOW-ALL: a throwing witness write returns recorded=false and does NOT throw', async () => {
+    const rec = vi.fn().mockRejectedValue(new Error('insert failed / RLS denial'));
+    const r = await observeDesignFidelityWouldReject({ judgedSessionId: 'sess-A', reason: 'x' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r.recorded).toBe(false);
+    expect(r.skipped).toBe(false); // it attempted, but the failure was swallowed
+  });
+});
+
+// ---- (4) dispatchDesignFidelityScorer — spy-proven LIVE dispatch, fence, null->would-reject, observe toggle ----
+describe('dispatchDesignFidelityScorer — the dormant scorer gets a LIVE call site (spy-proven)', () => {
+  const landing = { target_application: 'marketlens', title: 'MarketLens Landing Rebuild' };
+  const landingCtx = { scopeText: 'the MarketLens landing page', titleText: 'MarketLens Landing Rebuild', judgedSessionId: 'sess-A' };
+
+  it('FENCED: a non-customer-facing SD does not dispatch the scorer', async () => {
+    const scorer = vi.fn();
+    const r = await dispatchDesignFidelityScorer({ target_application: 'ehg_engineer' }, { scopeText: 'backend', judgedSessionId: 'sess-A' }, { scoreDesignFidelity: scorer });
+    expect(r.dispatched).toBe(false);
+    expect(scorer).not.toHaveBeenCalled();
+  });
+  it('LIVE DISPATCH: the scorer function IS invoked for a customer-facing landing (spy)', async () => {
+    const scorer = vi.fn().mockReturnValue(null); // Stitch deprecated -> null
+    const rec = vi.fn().mockResolvedValue({ id: 'w' });
+    const r = await dispatchDesignFidelityScorer(landing, landingCtx, { scoreDesignFidelity: scorer, recordWitnessEvent: rec, supabase: {} });
+    expect(scorer).toHaveBeenCalledTimes(1); // <-- proves the scorer is no longer dormant
+    expect(r.dispatched).toBe(true);
+    expect(r.wouldReject).toBe(true); // FR-2: null is NOT a silent pass
+    expect(rec).toHaveBeenCalledTimes(1);
+  });
+  it('null result -> would-reject; a high score -> NOT a would-reject', async () => {
+    const rec = vi.fn().mockResolvedValue({});
+    const low = await dispatchDesignFidelityScorer(landing, landingCtx, { scoreDesignFidelity: () => ({ score: 20 }), recordWitnessEvent: rec, supabase: {} });
+    expect(low.wouldReject).toBe(true);
+    const high = await dispatchDesignFidelityScorer(landing, landingCtx, { scoreDesignFidelity: () => ({ score: 90 }), recordWitnessEvent: rec, supabase: {} });
+    expect(high.wouldReject).toBe(false);
+  });
+  it('observe:false -> live dispatch WITHOUT recording (caller owns recording)', async () => {
+    const scorer = vi.fn().mockReturnValue(null);
+    const rec = vi.fn();
+    const r = await dispatchDesignFidelityScorer(landing, landingCtx, { scoreDesignFidelity: scorer, recordWitnessEvent: rec, supabase: {}, observe: false });
+    expect(scorer).toHaveBeenCalledTimes(1); // still a live call site
+    expect(r.wouldReject).toBe(true);
+    expect(rec).not.toHaveBeenCalled();      // but no recording
+  });
+  it('a throwing scorer is treated as null (would-reject), never propagates', async () => {
+    const rec = vi.fn().mockResolvedValue({});
+    const r = await dispatchDesignFidelityScorer(landing, landingCtx, { scoreDesignFidelity: () => { throw new Error('boom'); }, recordWitnessEvent: rec, supabase: {} });
+    expect(r.wouldReject).toBe(true);
+    expect(r.score).toBeNull();
+  });
+});
+
+// ---- (FR-4) observeVentureCompletionDesignPass — exit check, gated on hasDesignPass (no false-reject) ----
+describe('observeVentureCompletionDesignPass — records only when a landing lacks a design pass', () => {
+  const landing = { target_application: 'marketlens', title: 'MarketLens Landing' };
+  it('landing with NO design pass -> would-reject recorded', async () => {
+    const rec = vi.fn().mockResolvedValue({});
+    const r = await observeVentureCompletionDesignPass(landing, { designArtifacts: [], childSds: [], scopeText: 'landing page', judgedSessionId: 'sess-A' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r).toEqual({ applicable: true, wouldReject: true });
+    expect(rec).toHaveBeenCalledTimes(1);
+  });
+  it('landing WITH a completed design child -> NO would-reject (no false-reject)', async () => {
+    const rec = vi.fn();
+    const r = await observeVentureCompletionDesignPass(landing, { designArtifacts: [], childSds: [{ title: 'design pass', status: 'completed' }], scopeText: 'landing page', judgedSessionId: 'sess-A' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r.wouldReject).toBe(false);
+    expect(rec).not.toHaveBeenCalled();
+  });
+  it('a non-landing SD is not applicable (fenced)', async () => {
+    const rec = vi.fn();
+    const r = await observeVentureCompletionDesignPass({ target_application: 'ehg_engineer' }, { scopeText: 'backend', judgedSessionId: 'sess-A' }, { recordWitnessEvent: rec, supabase: {} });
+    expect(r.applicable).toBe(false);
+    expect(rec).not.toHaveBeenCalled();
+  });
+});
+
+// ---- (7) pure/never-throws contract on malformed/null input (mirrors classifyBackendLeaf) ----
+describe('detector functions are pure and NEVER throw on malformed input', () => {
+  it('isCustomerFacingLanding survives null/undefined/non-string input', () => {
+    expect(() => isCustomerFacingLanding(null, null, null)).not.toThrow();
+    expect(() => isCustomerFacingLanding(undefined, 123, {})).not.toThrow();
+    expect(isCustomerFacingLanding({}, undefined, undefined)).toBe(false);
+  });
+  it('hasDesignPass survives null/undefined/non-array input', () => {
+    expect(() => hasDesignPass(null)).not.toThrow();
+    expect(() => hasDesignPass({ designArtifacts: 'nope', childSds: 42 })).not.toThrow();
+    expect(hasDesignPass()).toBe(false);
+  });
+  it('resolveDesignFidelityGateMode survives null/undefined', () => {
+    expect(() => resolveDesignFidelityGateMode(null)).not.toThrow();
+    expect(resolveDesignFidelityGateMode(null)).toBe('observe');
+  });
+});

--- a/tests/unit/eva/bridge/design-fidelity-observe.test.js
+++ b/tests/unit/eva/bridge/design-fidelity-observe.test.js
@@ -34,6 +34,17 @@ describe('isCustomerFacingLanding — detects venture landings, fences backend l
       'DataDistill D1 distillation engine',
     )).toBe(false);
   });
+  it('FALSE: a backend worker mentioning hero-image / landing zone (FR-1 — page-noun required, not bare hero/landing)', () => {
+    expect(isCustomerFacingLanding(
+      { target_application: 'datadistill' },
+      'the hero-image worker that warms the landing thumbnail cache in the landing zone',
+      'DataDistill hero-image worker',
+    )).toBe(false);
+  });
+  it('TRUE: front page / product page (FR-4 recall)', () => {
+    expect(isCustomerFacingLanding({ target_application: 'venturex' }, 'rebuild the product page', 'x')).toBe(true);
+    expect(isCustomerFacingLanding({ target_application: 'venturex' }, 'the front page redesign', 'x')).toBe(true);
+  });
   it('FALSE: EHG_Engineer harness target is never a customer-facing landing', () => {
     expect(isCustomerFacingLanding({ target_application: 'EHG_Engineer' }, 'a landing page', 'landing')).toBe(false);
   });


### PR DESCRIPTION
## Summary
The GATE HALF of the MarketLens landing-seam fix. A customer-facing landing shipped as a backend/API child slipped through Section A's `classifyBackendLeaf` exemption (`!hasUISurface`), while `design-fidelity-scorer.js` returned `null` (no stitchData) as a silent PASS and was dormant. This activates the design-fidelity gate **observe-only-first** — it LOGS would-rejects, never blocks (MarketLens @S24 has no design pass; binding would block the flagship).

- **NEW** `lib/eva/bridge/customer-facing-design-detector.js` — pure/never-throws: `isCustomerFacingLanding` (venture target + landing signal, fenced so a backend leaf never trips it), `hasDesignPass` (Stitch/S17 artifact OR completed design child), `resolveDesignFidelityGateMode` (**allowlist**: `=== 'bind'` else `'observe'` — fails SAFE).
- **NEW** `lib/eva/bridge/design-fidelity-observe.js` — `observeDesignFidelityWouldReject` (swallow-all witness write), `dispatchDesignFidelityScorer` (the dormant scorer's **first live call site**; null/Stitch-deprecated → would-reject, not a silent pass), `observeVentureCompletionDesignPass` (FR-4 exit).
- **CHANGED** `scripts/modules/implementation-fidelity/sections/design-fidelity.js` Section A — before the 8 backend exemptions, a customer-facing landing dispatches the scorer (live call site) and records a would-reject **IFF `!hasDesignPass`** (gated → zero false-rejects). Observe-only (never changes score/pass while mode ≠ bind), swallow-all, reuses `gate_witness_events` (no new DDL), does NOT flip to bind.

Key discovery: **Stitch/Lovable are deprecated** — that's why the scorer was dormant, so `null` is now the normal case and must be a would-reject, not a silent pass.

## Test plan
- 40 new unit tests (allowlist table / fail-open guard, spy-proven live dispatch, no-false-reject fence, swallow-all, pure/never-throws contract, FR-4 both-paths).
- 83 existing tests green (scorer + implementation-fidelity) — no regression.
- Gates: LEAD-TO-PLAN 93, PLAN-TO-EXEC 97, EXEC-TO-PLAN 94, PLAN-TO-LEAD 96. RISK LOW-MEDIUM, TESTING PASS, SECURITY PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)