### PR TITLE
fix(SD-LEO-INFRA-FLEET-WIDE-AUDIT-001): add wire-check npm script entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "audit:orphan-prs": "node scripts/audit-orphan-prs.mjs",
     "audit:shared-tables": "node scripts/audit-shared-tables-residue.cjs",
     "audit:ghost-completed": "node scripts/audit-ghost-completed-sds.mjs",
+    "audit:venture-design-pass": "node scripts/audit-venture-design-pass.mjs",
     "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
     "hook:rca-outcome": "node scripts/hooks/post-tool-rca-outcome.cjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",


### PR DESCRIPTION
Follow-up to merged PR #5704. sd-start.js's LEAD-FINAL-APPROVAL pre-check surfaced a WIRE_CHECK_GATE failure (score 0/100) after #5704 merged: scripts/audit-venture-design-pass.mjs had no package.json entry point.

Adds `audit:venture-design-pass` npm script, matching the existing `audit:*` convention.

Note: an earlier attempt (#5705) was opened from the same feature branch used for #5704, whose merge-base with main was stale after the squash-merge — that PR's diff incorrectly showed all 5 original files. Closed in favor of this PR, built on a fresh branch off origin/main containing only this 1-line fix.

SD-LEO-INFRA-FLEET-WIDE-AUDIT-001