### PR TITLE
fix(QF-20260706-786): verify blocked_on_sd dependency status against live SD state

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -203,6 +203,12 @@ async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
     if (!k || k === 'none' || k === 'None') continue; // no SD ref / sentinel -> non-blocking
     refKeys.push(k);
   }
+  // QF-20260706-786: metadata.blocked_on_sd is an ad-hoc single-dependency hold (distinct
+  // from the `dependencies` array) that a boolean flag (requires_human_action) can be
+  // cleared without the referenced SD actually completing. Folding it into refKeys means
+  // this axis is re-derived from LIVE status every time, independent of that flag.
+  const blockedOn = sd.metadata && sd.metadata.blocked_on_sd;
+  if (typeof blockedOn === 'string' && blockedOn && blockedOn !== 'none') refKeys.push(blockedOn);
   if (!refKeys.length) return true;
   try {
     const { data, error } = await sb.from('strategic_directives_v2').select('sd_key, status').in('sd_key', refKeys);

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -181,6 +181,24 @@ function enforceHumanActionGate(sd, effectiveId) {
   process.exit(1);
 }
 
+// QF-20260706-786: metadata.blocked_on_sd is an ad-hoc single-dependency hold that a
+// worker's own claim-TTL-lapse self-heal can clear (requires_human_action=false) without
+// the referenced SD actually completing (live incident: Bravo self-cleared the fence on
+// LANDING-REBUILD-001 3min after FABLE-VENTURE-DESIGN-001 finished — safe by luck only).
+// This re-derives eligibility from LIVE status every claim, independent of any boolean flag.
+async function enforceBlockedOnSdGate(sd, effectiveId) {
+  const blockedOn = sd?.metadata?.blocked_on_sd;
+  if (typeof blockedOn !== 'string' || !blockedOn || blockedOn === 'none') return;
+  const { data, error } = await supabase.from('strategic_directives_v2').select('status').eq('sd_key', blockedOn).maybeSingle();
+  if (error || !data) return; // fail-open: can't verify -> don't strand the claim on a query fault
+  if (data.status !== 'completed') {
+    console.log(`\n${colors.red}❌ ${effectiveId} is BLOCKED_ON ${blockedOn} — cannot be claimed${colors.reset}`);
+    console.log(`   metadata.blocked_on_sd=${blockedOn} (status=${data.status}) — dependency not yet completed.`);
+    console.log(`\n${colors.bold}Action:${colors.reset} Wait for ${blockedOn} to complete, or pick a different SD with ${colors.cyan}npm run sd:next${colors.reset}`);
+    process.exit(1);
+  }
+}
+
 const MAX_FALLBACK_ATTEMPTS = 3;
 
 /**
@@ -828,6 +846,9 @@ async function main() {
   // 1.2. QF-20260703-295: reject direct claims on HELD SDs (metadata.requires_human_action).
   enforceHumanActionGate(sd, effectiveId);
 
+  // 1.3. QF-20260706-786: independently re-verify metadata.blocked_on_sd against live status.
+  await enforceBlockedOnSdGate(sd, effectiveId);
+
   // 1.4. SD-LEO-INFRA-PR-CADENCE-PRECLAIM-GATE-001: Pre-claim cadence gate.
   // Refuses claim if SD is in a stability window. Re-runs after orchestrator
   // leaf routing so a cadence-blocked leaf is not silently claimed via the parent.
@@ -972,6 +993,8 @@ async function main() {
       // (findUnclaimedChild) does not filter on requires_human_action, so a HELD
       // child routed to via the parent must still be refused here.
       enforceHumanActionGate(sd, effectiveId);
+      // QF-20260706-786: same re-check for a leaf's own metadata.blocked_on_sd.
+      await enforceBlockedOnSdGate(sd, effectiveId);
       } // close else (route-to-leaf)
     }
   }

--- a/tests/unit/claim-eligibility.test.js
+++ b/tests/unit/claim-eligibility.test.js
@@ -89,6 +89,24 @@ describe('draftDepsSatisfied', () => {
     const sb = makeSb({}, { errorOnIn: true });
     await expect(draftDepsSatisfied(sb, { dependencies: [{ sd_key: 'SD-A' }] }, { throwOnError: true })).rejects.toBeTruthy();
   });
+
+  // QF-20260706-786: metadata.blocked_on_sd re-derived from LIVE status, independent of
+  // requires_human_action / blocked_on_sd_resolved (live incident: Bravo self-cleared the
+  // rha fence on LANDING-REBUILD-001 without the referenced SD having actually completed).
+  it('false when metadata.blocked_on_sd references a not-yet-completed SD, even with requires_human_action already cleared', async () => {
+    const sb = makeSb({ 'SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001': { status: 'in_progress' } });
+    const sd = { dependencies: [], metadata: { requires_human_action: false, blocked_on_sd: 'SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(false);
+  });
+  it('true once the metadata.blocked_on_sd referenced SD is actually completed', async () => {
+    const sb = makeSb({ 'SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001': { status: 'completed' } });
+    const sd = { dependencies: [], metadata: { blocked_on_sd: 'SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(true);
+  });
+  it('treats metadata.blocked_on_sd="none" as non-blocking', async () => {
+    const sd = { dependencies: [], metadata: { blocked_on_sd: 'none' } };
+    expect(await draftDepsSatisfied(makeSb({}), sd)).toBe(true);
+  });
 });
 
 describe('evaluateDispatchEligibility (discriminated verdict; throws on query error)', () => {

--- a/tests/unit/sd-start-blocked-on-sd-gate.test.js
+++ b/tests/unit/sd-start-blocked-on-sd-gate.test.js
@@ -1,0 +1,50 @@
+/**
+ * QF-20260706-786 — a worker's own claim-TTL-lapse self-heal can clear
+ * metadata.requires_human_action (e.g. by re-resolving an EARLIER, unrelated hold) without
+ * verifying whether the SD's OWN metadata.blocked_on_sd dependency has actually completed
+ * (LIVE-HIT: Bravo self-cleared the fence on SD-LEO-FEAT-MARKETLENS-LANDING-REBUILD-001 at
+ * 16:44:51Z, three minutes after FABLE-VENTURE-DESIGN-001 finished — safe by luck only).
+ * Fix adds an independent, live-status re-check of metadata.blocked_on_sd, gated on the
+ * referenced SD's actual `status` column rather than any boolean flag a self-heal path
+ * could clear.
+ *
+ * Static-pin pattern (mocking-independent), per tests/unit/sd-start-human-action-gate.test.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '..', '..', 'scripts/sd-start.js'), 'utf8');
+
+describe('QF-20260706-786: sd-start.js metadata.blocked_on_sd claim gate', () => {
+  it('defines enforceBlockedOnSdGate, gated on a LIVE strategic_directives_v2 status lookup, that exits(1) when unresolved', () => {
+    const start = src.indexOf('async function enforceBlockedOnSdGate');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, start + 900);
+    expect(body).toMatch(/sd\?\.metadata\?\.blocked_on_sd/);
+    expect(body).toMatch(/strategic_directives_v2/);
+    expect(body).toMatch(/status.*!==.*'completed'/);
+    expect(body).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('fails open on a query error (never strands a claim on a transient fault)', () => {
+    const start = src.indexOf('async function enforceBlockedOnSdGate');
+    const body = src.slice(start, start + 900);
+    expect(body).toMatch(/if \(error \|\| !data\) return;/);
+  });
+
+  it('is called right after enforceHumanActionGate on the initial claim path', () => {
+    expect(src).toMatch(/enforceHumanActionGate\(sd, effectiveId\);[^]{0,200}enforceBlockedOnSdGate\(sd, effectiveId\)/);
+  });
+
+  it('re-calls the gate after orchestrator child routing reassigns sd to a leaf (parity with enforceHumanActionGate)', () => {
+    const idx = src.indexOf('Re-enforce cadence gate against the leaf');
+    expect(idx).toBeGreaterThan(0);
+    const region = src.slice(idx, idx + 800);
+    expect(region).toMatch(/enforceHumanActionGate\(sd, effectiveId\)/);
+    expect(region).toMatch(/enforceBlockedOnSdGate\(sd, effectiveId\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- A worker's own claim-TTL-lapse self-heal can clear `metadata.requires_human_action` without checking whether `metadata.blocked_on_sd`'s referenced SD has actually completed (live incident: Bravo self-cleared the fence on `SD-LEO-FEAT-MARKETLENS-LANDING-REBUILD-001` at 16:44:51Z — safe only because `FABLE-VENTURE-DESIGN-001` happened to finish 3 minutes earlier).
- Adds an independent, live-status re-check of `metadata.blocked_on_sd`, gated on the referenced SD's actual `status` column rather than any boolean flag a self-heal path could clear:
  - `scripts/sd-start.js`: new `enforceBlockedOnSdGate`, called at both claim-time checkpoints (initial claim + post orchestrator-leaf-routing), mirroring the existing `enforceHumanActionGate` pattern.
  - `lib/fleet/claim-eligibility.cjs`: `draftDepsSatisfied` folds `metadata.blocked_on_sd` into its `refKeys`, so the shared worker self-claim (`worker-checkin.cjs`) and coordinator sweep CLAIM_FIX (`stale-session-sweep.cjs`) paths are covered by the same fix.

## Test plan
- [x] New unit tests: `tests/unit/sd-start-blocked-on-sd-gate.test.js` (static-pin pattern, matching `sd-start-human-action-gate.test.js`)
- [x] New cases in `tests/unit/claim-eligibility.test.js` for `metadata.blocked_on_sd` (unresolved / resolved / "none" sentinel)
- [x] Full regression pass: `tests/unit/claim-eligibility.test.js`, `tests/unit/sd-start-blocked-on-sd-gate.test.js`, `tests/unit/sd-start-human-action-gate.test.js`, `tests/unit/fleet/hold-provenance.test.js`, `tests/dispatch-eligibility-convergence.test.js`, `scripts/worker-checkin.test.js`, `tests/unit/coordinator/charter-audit-detectors.test.js` — 200 tests, 0 failures

QF-20260706-786