### PR TITLE
fix(QF-20260706-090): distinct screenId for each stage_17_refined variant

### DIFF
--- a/lib/eva/stage-17/refinement.js
+++ b/lib/eva/stage-17/refinement.js
@@ -121,7 +121,12 @@ Output ONLY the HTML — no explanation, no markdown fences.`;
       qualityScore: 85,
       validationStatus: 'pending',
       source: 'stage-17-archetype-generator',
-      metadata: { variantIndex: i + 1 },
+      // QF-20260706-090: writeArtifact() dedups is_current rows by (venture_id,
+      // lifecycle_stage, artifact_type, metadata.screenId) -- a bare shared screenName
+      // across all 4 variants would collapse all 4 into 1 (mirrors the archetype-generator.js
+      // fix). Suffix per variant so each survives as its own current row, while a re-run
+      // for the same screen still cleanly replaces its own 4 slots.
+      metadata: { variantIndex: i + 1, screenId: `${screenName}::refined-v${i + 1}` },
     });
 
     artifactIds.push(artifactId);

--- a/tests/unit/stage-17/refinement.test.js
+++ b/tests/unit/stage-17/refinement.test.js
@@ -20,6 +20,7 @@ vi.mock('../../../lib/llm/client-factory.js', () => ({
   }),
 }));
 
+import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
 import { generateRefinedVariants } from '../../../lib/eva/stage-17/refinement.js';
 
 describe('refinement', () => {
@@ -55,6 +56,57 @@ describe('refinement', () => {
       const prompt = mockComplete.mock.calls[0][1];
       const promptText = typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
       expect(promptText).toContain('MOBILE REFERENCE');
+    });
+
+    // QF-20260706-090: writeArtifact() dedups is_current rows by metadata.screenId --
+    // a bare shared value across all 4 variants collapses them to 1 survivor.
+    test('gives each of the 4 variants a distinct metadata.screenId (no dedup collision)', async () => {
+      await generateRefinedVariants(
+        'v-1', 'Home',
+        ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      const screenIds = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
+      expect(new Set(screenIds).size).toBe(4);
+    });
+
+    test('re-generating for the SAME screen reproduces the SAME 4 screenIds (clean re-dedup)', async () => {
+      await generateRefinedVariants(
+        'v-1', 'Home',
+        ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      const firstRun = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
+      writeArtifact.mockClear();
+      await generateRefinedVariants(
+        'v-1', 'Home',
+        ['<html>B1</html>', '<html>B2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      const secondRun = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
+      expect(secondRun).toEqual(firstRun);
+    });
+
+    test('a different screen gets different screenIds (no cross-screen collision)', async () => {
+      await generateRefinedVariants(
+        'v-1', 'Home',
+        ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      const homeIds = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
+      writeArtifact.mockClear();
+      await generateRefinedVariants(
+        'v-1', 'Pricing',
+        ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      const pricingIds = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
+      expect(pricingIds.some((id) => homeIds.includes(id))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `generateRefinedVariants` (lib/eva/stage-17/refinement.js) writes 4 `stage_17_refined` artifacts with no `screenId` in metadata. `artifact-persistence-service`'s dedup scopes `is_current` by `COALESCE(metadata->>screenId,'__no_screen__')`, so all 4 variants collide on the same key — only the last (variantIndex 4) survives `is_current=true`.
- Currently **LATENT** (a DB query for `artifact_type=stage_17_refined` returns zero rows fleet-wide — no venture has run this live GVOS Stage-17 refinement path yet), but a real defect that will manifest the moment the S17 refinement / Fable design-generation path produces variants.
- Same bug class already fixed in the sibling `lib/eva/stage-17/archetype-generator.js` (added a per-variant-suffixed `screenId`). This mirrors that fix using `screenName` — the identifier already threaded into this function — suffixed per variant index (`${screenName}::refined-v${i+1}`).

## Test plan
- [x] New tests: 4 variants get 4 distinct `screenId`s; re-generating the SAME screen reproduces the SAME 4 `screenId`s (clean re-dedup); a DIFFERENT screen gets non-overlapping `screenId`s (no cross-screen collision)
- [x] Full regression: `tests/unit/stage-17/refinement.test.js` + `tests/unit/stage-17/selection-flow.test.js` — 17 tests, 0 failures

QF-20260706-090