### PR TITLE
fix(SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001): honest runway headline, live-only revenue, real bank cash

### DIFF
--- a/lib/operator/cash-burn-substrate.js
+++ b/lib/operator/cash-burn-substrate.js
@@ -18,14 +18,21 @@
 import { createSupabaseServiceClient } from '../supabase-client.js';
 
 const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 /**
  * Per-input liveness windows (ms). An input refreshed more than this long ago is stale.
  * AI-burn + revenue are fed hourly (generous 3h window absorbs GitHub cron drops).
- * Cash is fed by a separate, lower-cadence sibling SD (36h window). Other-burn is optional.
+ * Cash's window matches its attestation CADENCE (a monthly manual attestation), not the
+ * feed cadence of the other inputs — a 36h window on a monthly attestation restaled the
+ * chairman's own July figure within two days (SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001
+ * FR-2). 31 days safely covers any calendar month attested on day 1. A live bank read
+ * (FR-1) supersedes manual attestation freshness once wired. MUST match
+ * DTB_LIVENESS_WINDOWS_MS.cash in the ehg repo's survivability-logic.ts exactly (TR-1).
+ * Other-burn is optional.
  */
 export const LIVENESS_WINDOWS_MS = Object.freeze({
-  cash: 36 * HOUR_MS,
+  cash: 31 * DAY_MS,
   ai_burn: 3 * HOUR_MS,
   other_burn: 36 * HOUR_MS,
   revenue: 3 * HOUR_MS,
@@ -100,6 +107,7 @@ export function computeRunway(row, opts = {}) {
   if (!row) {
     return {
       months_of_runway: null,
+      state: 'awaiting_cash',
       headline: 'awaiting cash source',
       partials: {
         cash: { value_usd: null, status: 'unattested', label: 'not yet measured', last_synced_at: null, age_ms: null },
@@ -122,34 +130,66 @@ export function computeRunway(row, opts = {}) {
     test_mode: row.revenue_livemode === false,
   });
 
-  // net-burn is live iff ai_burn is live (dominant required term). Absent other_burn/revenue
-  // contribute 0 (conservative: never understates burn).
+  // net-burn is live iff ai_burn is live (dominant required term). Absent other_burn contributes 0
+  // (conservative: never UNDERSTATES burn is the intent, but see FR-4 guard below for the case
+  // where a real other_burn cost is masked by staleness, which risks the opposite).
+  // FR-3: revenue only nets against burn when explicitly LIVE-mode. An explicit
+  // revenue_livemode===false (Stripe test-mode) contributes $0 — missing/undefined is
+  // conservatively treated as live (never silently excludes real revenue).
   let netBurn;
   if (aiBurn.status === 'live') {
     const ai = aiBurn.value_usd ?? 0;
     const other = otherBurn.status === 'live' ? (otherBurn.value_usd ?? 0) : 0;
-    const rev = revenue.status === 'live' ? (revenue.value_usd ?? 0) : 0;
+    const rev = revenue.status === 'live' && !revenue.test_mode ? (revenue.value_usd ?? 0) : 0;
     netBurn = { value_usd: Number((ai + other - rev).toFixed(2)), status: 'live', label: null };
   } else {
     netBurn = { value_usd: null, status: aiBurn.status, label: aiBurn.label };
   }
 
   let months_of_runway = null;
+  let state;
   let headline;
   if (cash.status !== 'live') {
+    state = 'awaiting_cash';
     headline = 'awaiting cash source';
   } else if (netBurn.status !== 'live') {
+    state = 'awaiting_burn';
     headline = 'awaiting burn data';
   } else if (netBurn.value_usd <= 0) {
-    // Net positive (revenue >= burn) — not burning down; runway is not "broke"-bounded.
-    months_of_runway = null;
-    headline = 'net cash-positive (no burn-down)';
+    // FR-4 truth-guard: a net<=0 verdict built on an ai_burn LOWER BOUND (the structurally-always
+    // -true fleet case — main-session Opus tokens are not captured) or a genuinely stale other_burn
+    // (a real cost masked by non-freshness, not merely absent) cannot honestly claim cash-positive
+    // — the true burn could be higher than what was measured. Refuse the optimistic claim instead.
+    // Scoped ONLY to this net<=0 branch — a lower-bound burn with net>0 still renders a real number.
+    const inputsIncomplete = aiBurn.is_lower_bound === true || otherBurn.status === 'stale';
+    if (inputsIncomplete) {
+      state = 'inputs_incomplete';
+      headline = 'inputs incomplete — runway unknown';
+    } else {
+      state = 'cash_positive';
+      headline = 'net cash-positive (no burn-down)';
+    }
   } else {
     months_of_runway = Number((cash.value_usd / netBurn.value_usd).toFixed(1));
+    state = 'runway_measured';
     headline = `${months_of_runway} months of runway`;
   }
 
-  return { months_of_runway, headline, partials: { cash, ai_burn: aiBurn, other_burn: otherBurn, revenue, net_burn: netBurn } };
+  return { months_of_runway, state, headline, partials: { cash, ai_burn: aiBurn, other_burn: otherBurn, revenue, net_burn: netBurn } };
+}
+
+/**
+ * Pure verdict for the operator-cash-attestation-missing gauge (FR-4). Trips on the
+ * pre-existing cash-not-live condition, PLUS the truth-guard state (inputs_incomplete) so a
+ * lower-bound-burn false-cash-positive is machine-checked, not just coded — reads the explicit
+ * state field, never a headline string-match. Does NOT trip on any other state (awaiting_burn,
+ * cash_positive, runway_measured), so a genuinely healthy month never false-positives.
+ * @param {{months_of_runway: number|null, state: string, headline: string, partials: object}} verdict - a computeRunway() return value
+ * @returns {{count: 0|1, cash_status: string, state: string}}
+ */
+export function cashAttestationMissingResult(verdict) {
+  const tripped = verdict.partials.cash.status !== 'live' || verdict.state === 'inputs_incomplete';
+  return { count: tripped ? 1 : 0, cash_status: verdict.partials.cash.status, state: verdict.state };
 }
 
 /** Read the substrate row for a period (defaults to current month). */

--- a/lib/operator/cash-sources/teller-client.js
+++ b/lib/operator/cash-sources/teller-client.js
@@ -1,0 +1,94 @@
+/**
+ * lib/operator/cash-sources/teller-client.js
+ *
+ * SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001 — FR-1/TR-4: a minimal, READ-ONLY
+ * Teller.io API client, hand-rolled over Node's built-in `https` module rather than
+ * an external "Teller SDK" package. No verified, trustworthy first-party Teller SDK
+ * exists on npm to add as a dependency without fabricating one; a small first-party
+ * module implementing exactly the two READ endpoints this feature needs has a
+ * smaller supply-chain surface than an unaudited third-party package, and is fully
+ * unit-testable via dependency injection (the same tellerClientFactory seam
+ * bank-read-service.js already exposes).
+ *
+ * HARD CONTRACT (TR-2, TS-6b):
+ *   - This module implements ONLY listAccounts() and getBalance() — Teller's REST
+ *     API also exposes transfer/payment endpoints, but no code path to them exists
+ *     anywhere in this file, by construction (the static + behavioral guards in
+ *     tests/unit/operator/cash-bank-feed.test.js assert this).
+ *   - Teller auth is mutual TLS (a chairman-enrolled client cert + private key)
+ *     PLUS HTTP Basic Auth (the access token as username, blank password) — both
+ *     credentials come from the caller; this module never reads a vault directly.
+ *   - The token/cert/key never appear in a log line or thrown error message.
+ */
+
+import https from 'node:https';
+
+const TELLER_API_HOST = 'api.teller.io';
+const REQUEST_TIMEOUT_MS = 15000;
+
+function tellerGet({ certPem, keyPem, token, path }) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: TELLER_API_HOST,
+        path,
+        method: 'GET',
+        cert: certPem,
+        key: keyPem,
+        auth: `${token}:`, // HTTP Basic Auth: access token as username, blank password
+        headers: { Accept: 'application/json' },
+        timeout: REQUEST_TIMEOUT_MS,
+        // Explicit defense-in-depth (SECURITY finding, adversarial review): a process-global
+        // NODE_TLS_REJECT_UNAUTHORIZED=0 would otherwise silently disable certificate
+        // verification for this bank-credential client. Setting it here overrides that env var.
+        rejectUnauthorized: true,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => {
+          if (res.statusCode == null || res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`Teller API ${path} returned status ${res.statusCode}`));
+            return;
+          }
+          try {
+            resolve(body ? JSON.parse(body) : null);
+          } catch {
+            reject(new Error(`Teller API ${path} returned unparseable JSON`));
+          }
+        });
+      }
+    );
+    req.on('error', (err) => reject(new Error(`Teller API ${path} request failed: ${err.message}`)));
+    req.on('timeout', () => req.destroy(new Error(`Teller API ${path} request timed out`)));
+    req.end();
+  });
+}
+
+/**
+ * A READ-ONLY Teller.io API client. Exposes exactly two methods, matching
+ * bank-read-service.js's tellerClientFactory contract:
+ *   - listAccounts()          -> GET /accounts
+ *   - getBalance(accountId)   -> GET /accounts/:id/balances, normalized to
+ *                                { currency: 'USD', available: number } (Teller
+ *                                only supports US bank accounts).
+ * @param {{token: string, certPem: string, keyPem: string}} creds
+ */
+export function createTellerClient({ token, certPem, keyPem }) {
+  if (!token || typeof token !== 'string') throw new Error('createTellerClient requires a non-empty token');
+  if (!certPem || typeof certPem !== 'string') throw new Error('createTellerClient requires a non-empty certPem');
+  if (!keyPem || typeof keyPem !== 'string') throw new Error('createTellerClient requires a non-empty keyPem');
+
+  return {
+    async listAccounts() {
+      const accounts = await tellerGet({ certPem, keyPem, token, path: '/accounts' });
+      return Array.isArray(accounts) ? accounts : [];
+    },
+    async getBalance(accountId) {
+      const balance = await tellerGet({ certPem, keyPem, token, path: `/accounts/${encodeURIComponent(accountId)}/balances` });
+      return { currency: 'USD', available: Number(balance?.available ?? 0) };
+    },
+  };
+}
+
+export default { createTellerClient };

--- a/lib/operator/cash-sources/token-vault.js
+++ b/lib/operator/cash-sources/token-vault.js
@@ -25,6 +25,19 @@ export const BANK_READ_APP_ID = 'operator-bank-read';
 const TOKEN_KEY = 'bank_read_token';
 
 /**
+ * SEPARATE app namespace for the Teller mTLS client certificate + private key
+ * (SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001 FR-1/TR-2). Kept apart from
+ * BANK_READ_APP_ID deliberately -- encryptAppCredentials() overwrites its target
+ * file wholesale, so storing the token and the cert pair under the SAME app id via
+ * two separate calls would silently clobber whichever was written first. A second
+ * long-lived secret, so it goes through the SAME encrypted-vault mechanism, never
+ * argv/logs/repo.
+ */
+export const TELLER_MTLS_APP_ID = 'operator-bank-read-mtls';
+const CERT_KEY = 'teller_cert_pem';
+const KEY_KEY = 'teller_key_pem';
+
+/**
  * Encrypt a bank-read token in memory. Returns the AES-256-GCM blob
  * ({ encrypted, metadata }) — never the plaintext.
  */
@@ -76,5 +89,35 @@ export async function loadBankReadToken({ enc = credentialEncryption } = {}) {
       console.warn(`[bank-read-vault] WARN bank-read vault present but UNREADABLE (tamper/corruption/key-rotation?) — staying inert: ${msg}`);
     }
     return null;
+  }
+}
+
+/**
+ * Persist the Teller mTLS client certificate + private key together, under the
+ * SEPARATE TELLER_MTLS_APP_ID namespace (never the token's app id — see the
+ * constant's comment). Part of the same chairman ENROLLMENT action as the token.
+ */
+export async function storeTellerCertPair({ certPem, keyPem }, { enc = credentialEncryption } = {}) {
+  if (!certPem || typeof certPem !== 'string') throw new Error('Teller cert (certPem) must be a non-empty string');
+  if (!keyPem || typeof keyPem !== 'string') throw new Error('Teller private key (keyPem) must be a non-empty string');
+  return enc.encryptAppCredentials(TELLER_MTLS_APP_ID, { [CERT_KEY]: certPem, [KEY_KEY]: keyPem });
+}
+
+/**
+ * Load the decrypted Teller mTLS cert pair. INERT until enrollment: returns
+ * { certPem: null, keyPem: null } (never throws) when no vault exists, mirroring
+ * loadBankReadToken()'s fail-soft contract.
+ */
+export async function loadTellerCertPair({ enc = credentialEncryption } = {}) {
+  try {
+    const creds = await enc.decryptAppCredentials(TELLER_MTLS_APP_ID);
+    return { certPem: creds?.[CERT_KEY] ?? null, keyPem: creds?.[KEY_KEY] ?? null };
+  } catch (err) {
+    const msg = String(err?.message || err);
+    const missing = err?.code === 'ENOENT' || /ENOENT|no such file|not found/i.test(msg);
+    if (!missing) {
+      console.warn(`[bank-read-vault] WARN Teller mTLS vault present but UNREADABLE (tamper/corruption/key-rotation?) — staying inert: ${msg}`);
+    }
+    return { certPem: null, keyPem: null };
   }
 }

--- a/lib/operator/runway-parity-fixture.json
+++ b/lib/operator/runway-parity-fixture.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "Canonical shared fixture (TR-1) proving computeRunway() (EHG_Engineer) and distanceToBroke() (ehg) reach an identical verdict for the same row. Consumed by both repos' test suites plus scripts/operator/verify-runway-parity.mjs. nowIso is the fixed instant every case is evaluated against.",
+  "nowIso": "2026-06-19T22:00:00Z",
+  "cases": [
+    {
+      "name": "TS-2: complete live inputs render a real runway figure",
+      "row": {
+        "cash_usd": 5000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 800, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": 200, "other_burn_last_synced_at": "2026-06-19T21:00:00Z",
+        "revenue_usd": 0, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": true
+      },
+      "expected": { "headline": "5 months of runway", "months": 5.0 }
+    },
+    {
+      "name": "TS-2b: lower-bound burn WITH net>0 still renders a real runway (guard does not over-fire)",
+      "row": {
+        "cash_usd": 1200, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": true,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": null, "revenue_last_synced_at": null, "revenue_livemode": null
+      },
+      "expected": { "headline": "12 months of runway", "months": 12.0 }
+    },
+    {
+      "name": "TS-1a: FR-4 truth-guard refuses cash-positive when net<=0 is built on a lower-bound burn",
+      "row": {
+        "cash_usd": 1000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": true,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": 200, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": true
+      },
+      "expected": { "headline": "inputs incomplete — runway unknown", "months": null }
+    },
+    {
+      "name": "TS-1b: FR-4 truth-guard also refuses on a genuinely stale other_burn",
+      "row": {
+        "cash_usd": 1000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": 400, "other_burn_last_synced_at": "2026-06-18T00:00:00Z",
+        "revenue_usd": 200, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": true
+      },
+      "expected": { "headline": "inputs incomplete — runway unknown", "months": null }
+    },
+    {
+      "name": "genuine cash-positive: non-lower-bound burn, fresh inputs, net<=0 -- guard does not over-fire",
+      "row": {
+        "cash_usd": 1000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": 200, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": true
+      },
+      "expected": { "headline": "net cash-positive (no burn-down)", "months": null }
+    },
+    {
+      "name": "TS-4: Stripe test-mode revenue contributes $0 to net-burn",
+      "row": {
+        "cash_usd": 1000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": 50, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": false
+      },
+      "expected": { "headline": "10 months of runway", "months": 10.0 }
+    },
+    {
+      "name": "TS-4 (live counterpart): live revenue nets against burn normally",
+      "row": {
+        "cash_usd": 1000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": 50, "revenue_last_synced_at": "2026-06-19T21:00:00Z", "revenue_livemode": true
+      },
+      "expected": { "headline": "20 months of runway", "months": 20.0 }
+    },
+    {
+      "name": "TS-3: manual cash attestation stays live at 20 days (past the old 36h)",
+      "row": {
+        "cash_usd": 5000, "cash_last_synced_at": "2026-05-30T22:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": null, "revenue_last_synced_at": null, "revenue_livemode": null
+      },
+      "expected": { "headline": "50 months of runway", "months": 50.0 }
+    },
+    {
+      "name": "TS-3b: an attestation beyond the monthly window still fails closed",
+      "row": {
+        "cash_usd": 5000, "cash_last_synced_at": "2026-05-01T00:00:00Z",
+        "ai_burn_usd": 100, "ai_burn_last_synced_at": "2026-06-19T21:00:00Z", "ai_burn_is_lower_bound": false,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": null, "revenue_last_synced_at": null, "revenue_livemode": null
+      },
+      "expected": { "headline": "awaiting cash source", "months": null }
+    },
+    {
+      "name": "awaiting_burn: cash live but ai_burn unattested",
+      "row": {
+        "cash_usd": 5000, "cash_last_synced_at": "2026-06-19T21:00:00Z",
+        "ai_burn_usd": null, "ai_burn_last_synced_at": null, "ai_burn_is_lower_bound": null,
+        "other_burn_usd": null, "other_burn_last_synced_at": null,
+        "revenue_usd": null, "revenue_last_synced_at": null, "revenue_livemode": null
+      },
+      "expected": { "headline": "awaiting burn data", "months": null }
+    },
+    {
+      "name": "null row: awaiting cash source",
+      "row": null,
+      "expected": { "headline": "awaiting cash source", "months": null }
+    }
+  ]
+}

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -55,7 +55,7 @@ import {
 import { getCaptureCompleteness } from '../lib/eva/venture-capture-forward.js';
 import { resolveMinExtractStage } from '../lib/eva/template-extractor.js';
 import { detectExpiredPremises } from '../lib/governance/revisit-tags.js';
-import { readSubstrateRow, computeRunway, periodMonthOf } from '../lib/operator/cash-burn-substrate.js';
+import { readSubstrateRow, computeRunway, periodMonthOf, cashAttestationMissingResult } from '../lib/operator/cash-burn-substrate.js';
 
 const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
 
@@ -209,8 +209,8 @@ function buildDetectorResolvers(supabase) {
     'operator-cash-attestation-missing': async () => {
       const periodMonth = periodMonthOf(Date.now());
       const row = await readSubstrateRow(periodMonth, supabase);
-      const { partials } = computeRunway(row);
-      return { count: partials.cash.status === 'live' ? 0 : 1, period_month: periodMonth, cash_status: partials.cash.status };
+      const verdict = computeRunway(row);
+      return { ...cashAttestationMissingResult(verdict), period_month: periodMonth };
     },
     'recursion-governor-ratio': async () => {
       const items = await fetchThroughputItems(supabase);

--- a/scripts/operator/enroll-bank-read.mjs
+++ b/scripts/operator/enroll-bank-read.mjs
@@ -104,8 +104,12 @@ async function main() {
   try {
     const supabase = createSupabaseServiceClient();
     await supabase.from('audit_log').insert({
-      action: 'BANK_READ_ENROLLMENT',
-      details: { actor: os.userInfo().username, at: new Date().toISOString(), reenroll: REENROLL },
+      event_type: 'BANK_READ_ENROLLMENT',
+      entity_type: 'operator_cash_source',
+      entity_id: 'bank_read',
+      severity: 'info',
+      created_by: os.userInfo().username,
+      metadata: { at: new Date().toISOString(), reenroll: REENROLL },
     });
   } catch (err) {
     console.warn(`[enroll-bank-read] WARN audit_log write failed (enrollment still succeeded, non-blocking): ${err.message}`);

--- a/scripts/operator/enroll-bank-read.mjs
+++ b/scripts/operator/enroll-bank-read.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * scripts/operator/enroll-bank-read.mjs
+ *
+ * SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001 — FR-1: the chairman enrollment CLI
+ * for the bank-read token + Teller mTLS client certificate. Ships the MECHANISM;
+ * does NOT self-enroll a live token — running this IS the chairman's own enrollment
+ * action.
+ *
+ * SECURITY CONTRACT (row d3074dd7, TR-6 — all fail-closed):
+ *   1. Refuses to run in a CI/fleet/automated context (isCIContext(), reused from
+ *      lib/payments/stripe-client.js) UNLESS BANK_READ_ENROLL_CONFIRM=true is ALSO
+ *      set — an explicit, positive, human-set confirmation, not just "not detected
+ *      as CI".
+ *   2. Reads the ENTIRE credential payload (token + Teller cert PEM + Teller key
+ *      PEM) as ONE JSON object from STDIN ONLY — never process.argv (argv is
+ *      visible in `ps`/shell history/process listings).
+ *   3. Never echoes, logs, or includes the token/cert/key in any output or thrown
+ *      error message.
+ *   4. Refuses to overwrite an existing vault entry unless --reenroll is passed.
+ *   5. Emits a best-effort audit_log row (who/when/reenroll flag) — NEVER the
+ *      secret values.
+ *
+ * Usage:
+ *   echo '{"token":"...","certPem":"-----BEGIN CERTIFICATE-----\n...","keyPem":"-----BEGIN PRIVATE KEY-----\n..."}' \
+ *     | BANK_READ_ENROLL_CONFIRM=true node scripts/operator/enroll-bank-read.mjs [--reenroll]
+ */
+
+import 'dotenv/config';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import os from 'node:os';
+import { isCIContext } from '../../lib/payments/stripe-client.js';
+import { storeBankReadToken, loadBankReadToken, storeTellerCertPair, loadTellerCertPair } from '../../lib/operator/cash-sources/token-vault.js';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+const REENROLL = process.argv.includes('--reenroll');
+
+/** Read the full stdin stream to completion (no size assumption; credentials are small). */
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+    // No TTY means stdin is piped (the only supported invocation shape); a TTY with
+    // no piped input would hang forever waiting for EOF the user never sends.
+    if (process.stdin.isTTY) {
+      reject(new Error('enroll-bank-read requires the credential JSON piped via stdin (no TTY input supported) — see the file header for usage'));
+    }
+  });
+}
+
+async function main() {
+  // MUST 1: fail-closed CI/fleet gate, requires an EXPLICIT positive override.
+  // (Explicit `return` after every process.exit() below: in production exit() never
+  // returns, but a test harness mocking it as a no-op must not fall through to the
+  // next gate/stdin-read as if the refusal never happened.)
+  if (isCIContext() && process.env.BANK_READ_ENROLL_CONFIRM !== 'true') {
+    console.error(
+      '[enroll-bank-read] REFUSED: detected a CI/fleet/automated context. ' +
+      'This is a one-time chairman enrollment action, never an autonomous one. ' +
+      'Set BANK_READ_ENROLL_CONFIRM=true only if a human is deliberately running this.'
+    );
+    process.exit(1);
+    return;
+  }
+
+  // MUST 4: overwrite guard.
+  const existingToken = await loadBankReadToken();
+  const { certPem: existingCert } = await loadTellerCertPair();
+  if ((existingToken || existingCert) && !REENROLL) {
+    console.error('[enroll-bank-read] REFUSED: a bank-read credential is already enrolled. Pass --reenroll to intentionally replace it.');
+    process.exit(1);
+    return;
+  }
+
+  // MUST 2: stdin only, never argv.
+  let payload;
+  try {
+    const raw = await readStdin();
+    payload = JSON.parse(raw);
+  } catch {
+    // Deliberately generic — V8's JSON.parse SyntaxError embeds a fragment of the offending
+    // input in err.message (e.g. a chairman mistakenly piping a raw token instead of the JSON
+    // envelope would leak its first ~10 chars into this log line otherwise). Never interpolate
+    // the caught error here (SECURITY finding, adversarial review).
+    console.error('[enroll-bank-read] REFUSED: could not read/parse the credential JSON from stdin — expected {"token":"...","certPem":"...","keyPem":"..."}.');
+    process.exit(1);
+    return;
+  }
+
+  const { token, certPem, keyPem } = payload || {};
+  if (!token || !certPem || !keyPem) {
+    console.error('[enroll-bank-read] REFUSED: stdin payload must be JSON with non-empty "token", "certPem", and "keyPem" fields.');
+    process.exit(1);
+    return;
+  }
+
+  await storeBankReadToken(token);
+  await storeTellerCertPair({ certPem, keyPem });
+
+  // MUST 5: best-effort audit event — never the secret values.
+  try {
+    const supabase = createSupabaseServiceClient();
+    await supabase.from('audit_log').insert({
+      action: 'BANK_READ_ENROLLMENT',
+      details: { actor: os.userInfo().username, at: new Date().toISOString(), reenroll: REENROLL },
+    });
+  } catch (err) {
+    console.warn(`[enroll-bank-read] WARN audit_log write failed (enrollment still succeeded, non-blocking): ${err.message}`);
+  }
+
+  console.log(`[enroll-bank-read] Bank-read token + Teller mTLS cert pair enrolled successfully${REENROLL ? ' (re-enrollment)' : ''}. Nothing was logged or echoed.`);
+}
+
+// Entrypoint guard: only run main() as a CLI, never on static import.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().then(() => process.exit(0)).catch((e) => { console.error('[enroll-bank-read] FATAL', e.message); process.exit(1); });
+}
+
+export { main, readStdin };

--- a/scripts/operator/feed-operator-cash-burn.mjs
+++ b/scripts/operator/feed-operator-cash-burn.mjs
@@ -30,6 +30,8 @@ import { priceFor } from '../../lib/cost/llm-pricing.js';
 import { periodMonthOf, upsertSubstrateInputs, AI_BURN_LOWER_BOUND_LABEL } from '../../lib/operator/cash-burn-substrate.js';
 import { readStripeCashSlice } from '../../lib/operator/cash-sources/stripe-balance.js';
 import { readBankCashSlice } from '../../lib/operator/cash-sources/bank-read-service.js';
+import { loadTellerCertPair } from '../../lib/operator/cash-sources/token-vault.js';
+import { createTellerClient } from '../../lib/operator/cash-sources/teller-client.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -113,7 +115,15 @@ async function main() {
       if (!DRY_RUN) await upsertSubstrateInputs(periodMonth, { cash_usd: cashUsd }, supabase, nowIso);
       result.cash = { written: !DRY_RUN, value_usd: cashUsd, sources: ['chairman_attested'] };
     } else {
-    const bankSlice = await readBankCashSlice();
+    // FR-1: the Teller client factory must stay SYNCHRONOUS (bank-read-service.js calls it
+    // without awaiting) -- pre-load the mTLS cert pair here (async) and close over it, rather
+    // than making the factory itself async. Absent an enrolled cert pair, the factory stays
+    // undefined and readBankCashSlice() falls through to its existing inert-by-default path.
+    const { certPem, keyPem } = await loadTellerCertPair();
+    const tellerClientFactory = certPem && keyPem
+      ? (token) => createTellerClient({ token, certPem, keyPem })
+      : undefined;
+    const bankSlice = await readBankCashSlice({ tellerClientFactory });
     if (!bankSlice) {
       // Inert: no primary cash source yet. Peek Stripe for logging only; do NOT write cash.
       const stripePeek = await readStripeCashSlice();

--- a/scripts/operator/verify-runway-parity.mjs
+++ b/scripts/operator/verify-runway-parity.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * scripts/operator/verify-runway-parity.mjs
+ *
+ * TR-1 anti-drift oracle: proves computeRunway() (EHG_Engineer, lib/operator/cash-burn-substrate.js)
+ * and distanceToBroke() (ehg, src/components/chairman-v3/survivability/survivability-logic.ts)
+ * reach an IDENTICAL verdict (headline + months) for every row in the shared canonical fixture
+ * (lib/operator/runway-parity-fixture.json), and that their per-input liveness-window constants
+ * are pinned equal across repos.
+ *
+ * distanceToBroke() has ZERO runtime dependencies -- its only import is `import type { NorthStar }`,
+ * which is erased entirely by TypeScript's type-stripping. This lets us load it directly via
+ * esbuild's TS transform + a temp-file dynamic import, with no ehg build step and no `@/` alias
+ * resolution needed.
+ *
+ * Exit code 0 = full parity. Non-zero = at least one mismatch (printed to stderr).
+ */
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import * as esbuild from 'esbuild';
+import { computeRunway, LIVENESS_WINDOWS_MS } from '../../lib/operator/cash-burn-substrate.js';
+import { resolveRepoPath } from '../../lib/repo-paths.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.resolve(__dirname, '../../lib/operator/runway-parity-fixture.json');
+const EHG_SURVIVABILITY_REL_PATH = 'src/components/chairman-v3/survivability/survivability-logic.ts';
+
+/**
+ * Transpile + dynamically import the ehg survivability-logic module (zero runtime deps).
+ * Resolves the canonical ehg root via resolveRepoPath() by default (the correct target for a
+ * production drift check); EHG_REPO_PATH_OVERRIDE lets a session working in an isolated ehg
+ * worktree (e.g. mid-EXEC, before merge) point this at that worktree instead.
+ */
+async function loadEhgSurvivabilityModule() {
+  const ehgRoot = process.env.EHG_REPO_PATH_OVERRIDE || resolveRepoPath('ehg');
+  const srcPath = path.join(ehgRoot, EHG_SURVIVABILITY_REL_PATH);
+  const source = readFileSync(srcPath, 'utf8');
+  const { code } = await esbuild.transform(source, { loader: 'ts', format: 'esm' });
+  const tmpFile = path.join(__dirname, `.tmp-survivability-logic-${process.pid}-${Date.now()}.mjs`);
+  writeFileSync(tmpFile, code);
+  try {
+    return await import(`file://${tmpFile.replace(/\\/g, '/')}`);
+  } finally {
+    unlinkSync(tmpFile);
+  }
+}
+
+async function main() {
+  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+  const nowMs = Date.parse(fixture.nowIso);
+  const ehgMod = await loadEhgSurvivabilityModule();
+  const { distanceToBroke, DTB_LIVENESS_WINDOWS_MS } = ehgMod;
+
+  let failures = 0;
+
+  // TR-1 cross-repo constant equality.
+  for (const key of Object.keys(LIVENESS_WINDOWS_MS)) {
+    if (LIVENESS_WINDOWS_MS[key] !== DTB_LIVENESS_WINDOWS_MS[key]) {
+      failures++;
+      console.error(
+        `MISMATCH [constant:${key}]: LIVENESS_WINDOWS_MS.${key}=${LIVENESS_WINDOWS_MS[key]} !== DTB_LIVENESS_WINDOWS_MS.${key}=${DTB_LIVENESS_WINDOWS_MS[key]}`
+      );
+    }
+  }
+
+  for (const c of fixture.cases) {
+    const eng = computeRunway(c.row, { nowMs });
+    const ehg = distanceToBroke(c.row, nowMs);
+    const engMonths = eng.months_of_runway;
+    const ehgMonths = ehg.runwayMonths;
+
+    const headlineMatchesEachOther = eng.headline === ehg.headline;
+    const monthsMatchesEachOther = engMonths === ehgMonths;
+    const headlineMatchesExpected = eng.headline === c.expected.headline && ehg.headline === c.expected.headline;
+    const monthsMatchesExpected = engMonths === c.expected.months && ehgMonths === c.expected.months;
+
+    if (!headlineMatchesEachOther || !monthsMatchesEachOther || !headlineMatchesExpected || !monthsMatchesExpected) {
+      failures++;
+      console.error(`MISMATCH [${c.name}]:`);
+      console.error(`  expected:     headline=${JSON.stringify(c.expected.headline)} months=${c.expected.months}`);
+      console.error(`  EHG_Engineer: headline=${JSON.stringify(eng.headline)} months=${engMonths}`);
+      console.error(`  ehg:          headline=${JSON.stringify(ehg.headline)} months=${ehgMonths}`);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`\n❌ verify-runway-parity: ${failures} mismatch(es) across ${fixture.cases.length} cases`);
+    process.exit(1);
+  }
+  console.log(`✅ verify-runway-parity: ${fixture.cases.length} cases + liveness-window constants all match across repos`);
+}
+
+main().catch((err) => {
+  console.error('verify-runway-parity failed:', err);
+  process.exit(1);
+});

--- a/tests/unit/operator/cash-bank-feed.test.js
+++ b/tests/unit/operator/cash-bank-feed.test.js
@@ -13,8 +13,13 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { readStripeCashSlice } from '../../../lib/operator/cash-sources/stripe-balance.js';
-import { encryptBankReadToken, decryptBankReadToken, loadBankReadToken } from '../../../lib/operator/cash-sources/token-vault.js';
+import {
+  encryptBankReadToken, decryptBankReadToken, loadBankReadToken,
+  storeTellerCertPair, loadTellerCertPair,
+} from '../../../lib/operator/cash-sources/token-vault.js';
 import { readBankCashSlice } from '../../../lib/operator/cash-sources/bank-read-service.js';
+import { createTellerClient } from '../../../lib/operator/cash-sources/teller-client.js';
+import { computeRunway } from '../../../lib/operator/cash-burn-substrate.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '../../..');
@@ -109,5 +114,153 @@ describe('contract: bank token never in the gauge code path', () => {
     expect(gauge).not.toMatch(/cash-sources/);
     expect(gauge).not.toMatch(/token-vault|bank-read-service/);
     expect(gauge).not.toMatch(/bank_read_token/);
+  });
+});
+
+// SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001 FR-1
+describe('FR-1: Teller mTLS cert-pair vault (separate namespace from the token vault)', () => {
+  const fakeEnc = {
+    encryptAppCredentials: vi.fn(async (appId, creds) => ({ appId, creds })),
+    decryptAppCredentials: vi.fn(async () => ({ teller_cert_pem: 'CERT', teller_key_pem: 'KEY' })),
+  };
+
+  it('round-trips a cert pair via storeTellerCertPair/loadTellerCertPair', async () => {
+    await storeTellerCertPair({ certPem: 'CERT', keyPem: 'KEY' }, { enc: fakeEnc });
+    expect(fakeEnc.encryptAppCredentials).toHaveBeenCalledWith('operator-bank-read-mtls', { teller_cert_pem: 'CERT', teller_key_pem: 'KEY' });
+    const loaded = await loadTellerCertPair({ enc: fakeEnc });
+    expect(loaded).toEqual({ certPem: 'CERT', keyPem: 'KEY' });
+  });
+
+  it('rejects an empty cert or key', async () => {
+    await expect(storeTellerCertPair({ certPem: '', keyPem: 'KEY' }, { enc: fakeEnc })).rejects.toThrow(/certPem/);
+    await expect(storeTellerCertPair({ certPem: 'CERT', keyPem: '' }, { enc: fakeEnc })).rejects.toThrow(/keyPem/);
+  });
+
+  it('loadTellerCertPair is silently inert ({certPem:null,keyPem:null}) when nothing is enrolled', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const enc = { decryptAppCredentials: vi.fn(async () => { const e = new Error('ENOENT: no such file'); e.code = 'ENOENT'; throw e; }) };
+    expect(await loadTellerCertPair({ enc })).toEqual({ certPem: null, keyPem: null });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+// TS-6b(a): static guard, extended from the Stripe pattern above to Teller verbs.
+describe('TS-6b(a): static guard -- no transfer/payment verb anywhere in the bank-read surface', () => {
+  const FORBIDDEN_VERBS = /\.(transfer|payment|payee|zelle|ach|wire|payout)s?\b/i;
+
+  it('bank-read-service.js contains no transfer/payment/payee/zelle/ach/wire/payout verb', () => {
+    const src = readFileSync(join(REPO_ROOT, 'lib/operator/cash-sources/bank-read-service.js'), 'utf8');
+    expect(src).not.toMatch(FORBIDDEN_VERBS);
+  });
+
+  it('teller-client.js contains no transfer/payment/payee/zelle/ach/wire/payout verb', () => {
+    const src = readFileSync(join(REPO_ROOT, 'lib/operator/cash-sources/teller-client.js'), 'utf8');
+    expect(src).not.toMatch(FORBIDDEN_VERBS);
+    // Only the two read endpoints exist.
+    expect(src).toMatch(/listAccounts/);
+    expect(src).toMatch(/getBalance/);
+  });
+
+  it('enroll-bank-read.mjs contains no transfer/payment/payee/zelle/ach/wire/payout verb', () => {
+    const src = readFileSync(join(REPO_ROOT, 'scripts/operator/enroll-bank-read.mjs'), 'utf8');
+    expect(src).not.toMatch(FORBIDDEN_VERBS);
+  });
+});
+
+// TS-6b(b): mocked-client behavioral negative -- a client exposing transfer/payment spies
+// alongside the read methods must have ONLY the read methods invoked.
+describe('TS-6b(b): behavioral negative -- readBankCashSlice never calls a transfer/payment method', () => {
+  it('only listAccounts/getBalance are ever invoked, even when the client also exposes transfer/payment', async () => {
+    const transfer = vi.fn();
+    const payment = vi.fn();
+    const client = {
+      listAccounts: vi.fn(async () => [{ id: 'a1' }]),
+      getBalance: vi.fn(async () => ({ currency: 'USD', available: 100 })),
+      transfer,
+      payment,
+    };
+    const slice = await readBankCashSlice({ loadToken: async () => 'tok', tellerClientFactory: () => client });
+    expect(slice).toEqual({ usd: 100, other_burn_usd: null, source: 'bank' });
+    expect(client.listAccounts).toHaveBeenCalledOnce();
+    expect(client.getBalance).toHaveBeenCalledOnce();
+    expect(transfer).not.toHaveBeenCalled();
+    expect(payment).not.toHaveBeenCalled();
+  });
+});
+
+// TS-6a: FR-1 bank-read fallthrough on failure -- the actual END-TO-END chain
+// (read failure -> stale cash -> honest headline via computeRunway()), not just the
+// low-level function returning null in isolation.
+describe('TS-6a: FR-1 bank-read failure falls through to the honest headline end-to-end', () => {
+  const NOW = Date.parse('2026-06-19T22:00:00Z');
+  const staleRow = {
+    // Cash was manually attested a while ago and is now stale -- a failed bank read
+    // must NOT refresh it, so the substrate correctly withholds the runway.
+    cash_usd: 5000, cash_last_synced_at: new Date(NOW - 60 * 24 * 60 * 60 * 1000).toISOString(),
+    ai_burn_usd: 100, ai_burn_last_synced_at: new Date(NOW - 60 * 60 * 1000).toISOString(), ai_burn_is_lower_bound: false,
+    other_burn_usd: null, other_burn_last_synced_at: null,
+    revenue_usd: null, revenue_last_synced_at: null,
+  };
+
+  it('a throwing tellerClientFactory leaves cash un-refreshed, flowing through to "awaiting cash source"', async () => {
+    const throwingFactory = () => { throw new Error('Teller API unreachable'); };
+    const slice = await readBankCashSlice({ loadToken: async () => 'tok', tellerClientFactory: throwingFactory });
+    expect(slice).toBeNull(); // the read failed -- no fresh cash_usd is ever written by the caller
+
+    // The substrate never saw a write, so it still evaluates the pre-existing (stale) row honestly.
+    const verdict = computeRunway(staleRow, { nowMs: NOW });
+    expect(verdict.partials.cash.status).toBe('stale');
+    expect(verdict.headline).toBe('awaiting cash source');
+  });
+
+  it('no tellerClientFactory configured (chairman not enrolled) behaves identically', async () => {
+    const slice = await readBankCashSlice({ loadToken: async () => 'tok' }); // no factory
+    expect(slice).toBeNull();
+    const verdict = computeRunway(staleRow, { nowMs: NOW });
+    expect(verdict.headline).toBe('awaiting cash source');
+  });
+});
+
+// TS-6b(c)/(d): enroll-bank-read.mjs's fail-closed security gates.
+describe('TS-6b(c)(d): enroll-bank-read.mjs security gates', () => {
+  it('refuses under a CI/GITHUB_ACTIONS/fleet marker without the explicit confirm flag', async () => {
+    const originalEnv = { ...process.env };
+    const originalExit = process.exit;
+    const originalArgv1 = process.argv[1];
+    class ExitCalled extends Error {}
+    const exitSpy = vi.fn(() => { throw new ExitCalled(); }); // guarantees main() cannot fall through
+    process.exit = exitSpy;
+    process.env.GITHUB_ACTIONS = 'true';
+    delete process.env.BANK_READ_ENROLL_CONFIRM;
+    process.argv[1] = 'not-this-module'; // suppress the entrypoint auto-run guard
+    try {
+      const mod = await import('../../../scripts/operator/enroll-bank-read.mjs?fresh1');
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(mod.main()).rejects.toThrow(ExitCalled);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      errSpy.mockRestore();
+    } finally {
+      process.env = originalEnv;
+      process.exit = originalExit;
+      process.argv[1] = originalArgv1;
+    }
+  });
+
+  it('createTellerClient requires token, certPem, and keyPem (never silently proceeds with a partial credential set)', () => {
+    expect(() => createTellerClient({ token: '', certPem: 'C', keyPem: 'K' })).toThrow(/token/);
+    expect(() => createTellerClient({ token: 'T', certPem: '', keyPem: 'K' })).toThrow(/certPem/);
+    expect(() => createTellerClient({ token: 'T', certPem: 'C', keyPem: '' })).toThrow(/keyPem/);
+  });
+
+  it('readStdin rejects immediately when stdin is a TTY (no piped input) rather than hanging', async () => {
+    const mod = await import('../../../scripts/operator/enroll-bank-read.mjs?fresh2');
+    const originalIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+    try {
+      await expect(mod.readStdin()).rejects.toThrow(/stdin/);
+    } finally {
+      process.stdin.isTTY = originalIsTTY;
+    }
   });
 });

--- a/tests/unit/operator/cash-burn-substrate.test.js
+++ b/tests/unit/operator/cash-burn-substrate.test.js
@@ -9,6 +9,7 @@ import {
   computeRunway,
   LIVENESS_WINDOWS_MS,
   AI_BURN_LOWER_BOUND_LABEL,
+  cashAttestationMissingResult,
 } from '../../../lib/operator/cash-burn-substrate.js';
 
 const HOUR = 60 * 60 * 1000;
@@ -59,7 +60,9 @@ describe('computeRunway — honest degrade', () => {
     expect(v.months_of_runway).toBeNull();
     expect(v.headline).toBe('awaiting cash source');
     expect(v.partials.net_burn.status).toBe('live');
-    expect(v.partials.net_burn.value_usd).toBe(500); // 600 + 0 - 100
+    // FR-3: this fixture's revenue is explicitly test-mode (revenue_livemode: false), so it now
+    // correctly contributes $0 (was 600 + 0 - 100 = 500 under the pre-fix test-mode-counts bug).
+    expect(v.partials.net_burn.value_usd).toBe(600); // 600 + 0 - 0(test-mode revenue excluded)
   });
 
   it('cash + ai_burn fresh: months-of-runway renders (cash / net-burn)', () => {
@@ -115,7 +118,12 @@ describe('computeRunway — honest degrade', () => {
     expect(v.partials.revenue.livemode).toBe(false);
   });
 
-  it('net cash-positive (revenue >= burn) withholds runway rather than reporting infinite', () => {
+  // SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001 FR-4 (TS-1a): a net<=0 verdict built on a
+  // LOWER-BOUND ai_burn (the structurally-always-true fleet case, since main-session Opus
+  // tokens are not captured) cannot honestly claim cash-positive -- refuse the optimistic
+  // claim. This is the ACTUAL July trigger this SD exists to fix; it replaces the pre-fix
+  // test that asserted the old (incorrect) 'net cash-positive' headline for this exact input.
+  it('TS-1a: FR-4 truth-guard refuses cash-positive when net<=0 is built on a lower-bound burn', () => {
     const row = {
       cash_usd: 5000, cash_last_synced_at: fresh(1),
       ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
@@ -125,7 +133,107 @@ describe('computeRunway — honest degrade', () => {
     const v = computeRunway(row, { nowMs: NOW });
     expect(v.partials.net_burn.value_usd).toBe(-400); // 100 + 0 - 500
     expect(v.months_of_runway).toBeNull();
+    expect(v.state).toBe('inputs_incomplete');
+    expect(v.headline).toBe('inputs incomplete — runway unknown');
+  });
+
+  it('TS-1b: FR-4 truth-guard also refuses on a genuinely stale other_burn (not just the lower-bound flag)', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false, // NOT a lower bound
+      other_burn_usd: 400, other_burn_last_synced_at: fresh(48), // stale (>36h window) -- a real cost masked
+      revenue_usd: 500, revenue_last_synced_at: fresh(1), revenue_livemode: true,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.other_burn.status).toBe('stale');
+    expect(v.partials.net_burn.value_usd).toBe(-400); // 100 + 0(stale other_burn suppressed) - 500
+    expect(v.state).toBe('inputs_incomplete');
+    expect(v.headline).toBe('inputs incomplete — runway unknown');
+  });
+
+  it('genuine cash-positive: a non-lower-bound burn with fresh inputs still reaches cash_positive (guard does not over-fire)', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 500, revenue_last_synced_at: fresh(1), revenue_livemode: true,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.net_burn.value_usd).toBe(-400);
+    expect(v.months_of_runway).toBeNull();
+    expect(v.state).toBe('cash_positive');
     expect(v.headline).toBe('net cash-positive (no burn-down)');
+  });
+
+  // TS-2b: the normal production case (ai_burn is structurally always a lower bound) with net>0
+  // must still render a real runway number -- the guard is scoped to the netBurn<=0 branch only.
+  it('TS-2b: lower-bound burn WITH net>0 still renders a real runway (guard does not over-fire outside net<=0)', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(2),
+      ai_burn_usd: 800, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: 200, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 0, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.net_burn.value_usd).toBe(1000);
+    expect(v.state).toBe('runway_measured');
+    expect(v.months_of_runway).toBe(5.0);
+  });
+
+  // TS-4: live-only revenue -- FR-3.
+  it('TS-4: Stripe test-mode revenue contributes $0 to net-burn; live/undefined revenue is unaffected', () => {
+    const testMode = computeRunway({
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 50, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    }, { nowMs: NOW });
+    expect(testMode.partials.net_burn.value_usd).toBe(100); // 50 test-mode contributes $0
+
+    const liveMode = computeRunway({
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 50, revenue_last_synced_at: fresh(1), revenue_livemode: true,
+    }, { nowMs: NOW });
+    expect(liveMode.partials.net_burn.value_usd).toBe(50); // 100 - 50 live revenue
+
+    const undefinedMode = computeRunway({
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 50, revenue_last_synced_at: fresh(1),
+    }, { nowMs: NOW });
+    expect(undefinedMode.partials.net_burn.value_usd).toBe(50); // conservative default: undefined=live
+  });
+
+  // TS-3 / TS-3b: FR-2 monthly attestation freshness.
+  it('TS-3: a manual cash attestation stays live for the new monthly window (e.g. 20 days, past the old 36h)', () => {
+    const daysAgo = (d) => new Date(NOW - d * 24 * HOUR).toISOString();
+    const row = {
+      cash_usd: 10000, cash_last_synced_at: daysAgo(20),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 0, revenue_last_synced_at: fresh(1),
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.cash.status).toBe('live');
+  });
+
+  it('TS-3b: an attestation beyond the monthly window still fails closed (stale)', () => {
+    const daysAgo = (d) => new Date(NOW - d * 24 * HOUR).toISOString();
+    const row = {
+      cash_usd: 10000, cash_last_synced_at: daysAgo(40),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 0, revenue_last_synced_at: fresh(1),
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.cash.status).toBe('stale');
+  });
+
+  it('FR-2: the cash liveness window is a real bound (31 days), not effectively infinite', () => {
+    expect(LIVENESS_WINDOWS_MS.cash).toBe(31 * 24 * HOUR);
   });
 
   it('NULL-not-zero: a 0-valued cash input is distinct from an absent one and never fabricated', () => {
@@ -159,5 +267,41 @@ describe('computeRunway — honest degrade', () => {
   it('exposes per-input liveness windows (ai_burn/revenue hourly-tight, cash generous)', () => {
     expect(LIVENESS_WINDOWS_MS.ai_burn).toBeLessThan(LIVENESS_WINDOWS_MS.cash);
     expect(LIVENESS_WINDOWS_MS.revenue).toBe(LIVENESS_WINDOWS_MS.ai_burn);
+  });
+});
+
+describe('cashAttestationMissingResult — the operator-cash-attestation-missing gauge (FR-4)', () => {
+  it('TS-5a: trips (count:1) via the explicit inputs_incomplete state, cash itself still live', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 500, revenue_last_synced_at: fresh(1), revenue_livemode: true,
+    };
+    const verdict = computeRunway(row, { nowMs: NOW });
+    expect(verdict.partials.cash.status).toBe('live'); // cash itself is fine
+    expect(verdict.state).toBe('inputs_incomplete');
+    const result = cashAttestationMissingResult(verdict);
+    expect(result.count).toBe(1);
+  });
+
+  it('TS-5b: does NOT trip (count:0) on a real, complete, healthy runway (negative case)', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(2),
+      ai_burn_usd: 800, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: false,
+      other_burn_usd: 200, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 0, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    };
+    const verdict = computeRunway(row, { nowMs: NOW });
+    expect(verdict.state).toBe('runway_measured');
+    const result = cashAttestationMissingResult(verdict);
+    expect(result.count).toBe(0);
+  });
+
+  it('still trips on the pre-existing cash-not-live condition (regression)', () => {
+    const verdict = computeRunway(null, { nowMs: NOW });
+    const result = cashAttestationMissingResult(verdict);
+    expect(result.count).toBe(1);
+    expect(result.cash_status).toBe('unattested');
   });
 });


### PR DESCRIPTION
## Summary
Chairman's July $10,000 cash attestation exposed the operator runway headline as untrustworthy — it rendered "net cash-positive, no burn-down" (effectively infinite runway) because of three compounding gaps: a 36h freshness window on a monthly manual attestation, Stripe test-mode revenue counted as real, and no guard against a lower-bound AI-burn figure producing a false "not burning" claim.

- **FR-2**: cash's liveness window is now a pinned 31-day monthly window (was 36h), mirrored exactly in the `ehg` repo.
- **FR-3**: revenue only nets against burn when explicitly `livemode=true` or undefined/missing; explicit `livemode=false` (test-mode) contributes $0.
- **FR-4**: a new fail-closed truth-guard — a net<=0 verdict built on a lower-bound AI-burn or a genuinely stale other_burn now yields an explicit `inputs_incomplete` state instead of the optimistic claim. Verified against the real live July row: now shows **346.4 months of runway** (a real number), not a false claim.
- **TR-1**: `scripts/operator/verify-runway-parity.mjs` + a shared fixture proving `computeRunway()` and the `ehg` repo's `distanceToBroke()` reach identical verdicts.
- **FR-1**: wires the bank-read scaffold with a real, hand-rolled read-only Teller.io client (no external SDK — none verified/trustworthy exists on npm), a chairman enrollment CLI (stdin-only, CI-fail-closed, `--reenroll` guard, audited), and a separate encrypted vault namespace for the mTLS cert pair.

Two adversarial sub-agent passes (TESTING + SECURITY) reviewed the actual implementation; both PASSED with two minor hardening fixes applied inline (generic stdin-parse error to avoid leaking a token fragment; explicit `rejectUnauthorized:true`). A confirmed sibling defect in `ehg`'s `deriveNetIncome()` is out of this SD's literal scope and was routed to the coordinator as a fast-follow.

Companion `ehg` repo PR mirrors FR-2/FR-3/FR-4/TR-1.

## Test plan
- `npx vitest run tests/unit/operator/` — 55/55 pass
- `node scripts/operator/verify-runway-parity.mjs` (with the companion ehg branch) — 11/11 cases + constant equality pass
- ESLint clean on all touched files
- Verified against the real live `operator_cash_burn_monthly` row (not just fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)