### PR TITLE
fix(QF-20260706-549): marketing budget-governor fails CLOSED on missing channel_budgets row

### DIFF
--- a/lib/marketing/budget-governor.js
+++ b/lib/marketing/budget-governor.js
@@ -23,8 +23,8 @@ export async function checkBudget(supabase, ventureId, platform, estimatedCostCe
     .single();
 
   if (error || !budget) {
-    // No budget configured = no restrictions
-    return { allowed: true, budget: null };
+    // Fail CLOSED: no budget row means spend is unbounded/untracked, not unrestricted.
+    return { allowed: false, reason: 'No budget configured for this venture/platform', budget: null };
   }
 
   // Check if budget month needs reset

--- a/lib/marketing/publisher/index.js
+++ b/lib/marketing/publisher/index.js
@@ -116,7 +116,8 @@ async function checkBudget(supabase, ventureId, platform) {
     .single();
 
   if (!budget) {
-    return { allowed: true }; // No budget configured = no restrictions
+    // Fail CLOSED: no budget row means spend is unbounded/untracked, not unrestricted.
+    return { allowed: false, reason: 'No budget configured for this venture/platform' };
   }
 
   if (budget.status === 'exceeded') {

--- a/tests/unit/marketing/budget-governor.test.js
+++ b/tests/unit/marketing/budget-governor.test.js
@@ -21,13 +21,17 @@ function createMockSupabase(overrides = {}) {
 }
 
 describe('checkBudget', () => {
-  it('should allow when no budget configured', async () => {
+  // QF-20260706-549: checkBudget previously FAILED OPEN (allowed:true) when no
+  // channel_budgets row existed, making the spend brake a no-op and leaving spend
+  // untracked. Regression: a missing budget row must BLOCK, not grant unlimited spend.
+  it('should BLOCK (fail closed) when no budget configured', async () => {
     const supabase = createMockSupabase();
     supabase.single.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
 
     const result = await checkBudget(supabase, 'v-1', 'x');
 
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('No budget configured');
     expect(result.budget).toBeNull();
   });
 

--- a/tests/unit/marketing/publisher.test.js
+++ b/tests/unit/marketing/publisher.test.js
@@ -29,7 +29,13 @@ function createMockSupabase() {
     upsert: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     limit: vi.fn().mockResolvedValue({ data: [] }),
-    single: vi.fn().mockResolvedValue({ data: null, error: null })
+    // Default: a funded budget row, so "should publish" tests exercise the real
+    // configured-budget path (QF-20260706-549: checkBudget now fails CLOSED when
+    // no row exists, so a null default would block every publish here).
+    single: vi.fn().mockResolvedValue({
+      data: { status: 'active', current_month_spend_cents: 0, monthly_budget_cents: 10000, daily_limit_cents: null },
+      error: null
+    })
   };
   mock.from.mockReturnValue(mock);
   return mock;
@@ -99,6 +105,24 @@ describe('Publisher', () => {
 
     // Verify marketing_attribution insert was called
     expect(mockSupabase.from).toHaveBeenCalledWith('marketing_attribution');
+  });
+
+  it('should BLOCK publish (fail closed) when no budget row exists', async () => {
+    // QF-20260706-549: publisher/index.js has its own local checkBudget() (separate
+    // from lib/marketing/budget-governor.js) that also failed open on a missing row.
+    const noBudgetSupabase = createMockSupabase();
+    noBudgetSupabase.single = vi.fn().mockResolvedValue({ data: null, error: null });
+    noBudgetSupabase.from.mockReturnValue(noBudgetSupabase);
+
+    const result = await publish({
+      supabase: noBudgetSupabase,
+      content: { id: 'c-1', body: 'Test' },
+      platform: 'x',
+      ventureId: 'v-1'
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No budget configured');
   });
 
   it('should deduplicate existing dispatches', async () => {


### PR DESCRIPTION
## Summary
- checkBudget() failed OPEN (allowed:true) when no channel_budgets row existed, in BOTH lib/marketing/budget-governor.js and a separate duplicate local checkBudget() in lib/marketing/publisher/index.js (the live call path). channel_budgets has 0 rows platform-wide, so the spend brake was a complete no-op.
- Both call sites now fail CLOSED: a missing budget row blocks the dispatch rather than granting unlimited spend.
- Updated the existing test that encoded the old fail-open behavior as expected; added explicit regression tests for the missing-row path at both call sites.
- Descope: seeding a default channel_budgets row at venture provisioning is a separate product decision (default budget amounts) beyond this QF's scope — the fail-closed fix alone fully closes the unbounded-spend exposure.

## Test plan
- [x] `npx vitest run tests/unit/marketing/budget-governor.test.js tests/unit/marketing/publisher.test.js` — 20/20 pass
- [x] `npx vitest run tests/unit/marketing/` (full suite) — 62/62 pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)