### PR TITLE
fix(QF-20260707-650): extractSdFromAssignment() recognize payload.qf field

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -258,6 +258,11 @@ function extractSdFromAssignment(msg) {
   // sd_key instead). claim_sd itself is already QF-aware (p_sd_id LIKE 'QF-%'); the
   // gap was purely in this extraction step.
   if (typeof p.qf_id === 'string' && p.qf_id) return p.qf_id;
+  // QF-20260707-650: same bug class, different field-name variant. A directed_dispatch payload
+  // sometimes carries the QF key as payload.qf instead of qf_id (confirmed live on
+  // QF-20260705-893's redispatch, session_coordination row 2a3cef4b) -- silently skipped this
+  // extraction, no ack, no claim attempt, until manually diagnosed.
+  if (typeof p.qf === 'string' && p.qf) return p.qf;
   if (Array.isArray(p.available_sds) && p.available_sds.length) return p.available_sds[0];
   // current_sd is what the worker is ALREADY on — only use it as a last resort
   // when nothing else names a target (an assignment can reference the same SD).

--- a/tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js
+++ b/tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js
@@ -77,6 +77,33 @@ describe('resolveCheckin — a qf_id-only directed assignment now reaches the cl
   });
 });
 
+// QF-20260707-650: same bug class as leg 1, a different field-name variant. A directed_dispatch
+// payload carrying the QF key as payload.qf (not qf_id) was silently skipped by extraction --
+// confirmed live on QF-20260705-893's redispatch (session_coordination row 2a3cef4b).
+describe('extractSdFromAssignment — recognizes payload.qf (QF-20260707-650)', () => {
+  it('returns qf when assigned_sd/sd_key/qf_id are all absent', () => {
+    expect(extractSdFromAssignment({ payload: { qf: 'QF-20260705-893' } })).toBe('QF-20260705-893');
+  });
+
+  it('qf_id still takes precedence over qf when both present', () => {
+    expect(extractSdFromAssignment({ payload: { qf_id: 'QF-1', qf: 'QF-2' } })).toBe('QF-1');
+  });
+
+  it('assigned_sd/sd_key still take precedence over qf when present', () => {
+    expect(extractSdFromAssignment({ payload: { assigned_sd: 'QF-1', qf: 'QF-2' } })).toBe('QF-1');
+    expect(extractSdFromAssignment({ payload: { sd_key: 'QF-1', qf: 'QF-2' } })).toBe('QF-1');
+  });
+
+  it('falls through to available_sds when qf is absent (unchanged prior behavior)', () => {
+    expect(extractSdFromAssignment({ payload: { available_sds: ['SD-X-001'] } })).toBe('SD-X-001');
+  });
+
+  it('returns null for a non-string/empty qf (defensive)', () => {
+    expect(extractSdFromAssignment({ payload: { qf: '' } })).toBeNull();
+    expect(extractSdFromAssignment({ payload: { qf: 123 } })).toBeNull();
+  });
+});
+
 describe('sortQfCandidatesBySeverity (leg 2)', () => {
   it('orders critical before high before medium before low', () => {
     const qfs = [


### PR DESCRIPTION
## Summary
- Same bug class as the already-fixed `qf_id` gap (QF-20260704-602), different field-name variant: `extractSdFromAssignment()` in `scripts/worker-checkin.cjs` checked `payload.assigned_sd`/`sd_key`/`qf_id` but not plain `payload.qf`.
- A directed_dispatch WORK_ASSIGNMENT carrying the QF key as `payload.qf` was silently skipped — no ack, no claim attempt — confirmed live on QF-20260705-893's redispatch (session_coordination row `2a3cef4b`).

## Test plan
- [x] 17 tests pass in `tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js` (5 new cases mirroring the existing `qf_id` precedent tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)