### PR TITLE
fix(QF-20260707-848): content-pipeline checkBudget/recordSpend positional args

### DIFF
--- a/lib/marketing/content-pipeline.js
+++ b/lib/marketing/content-pipeline.js
@@ -13,7 +13,6 @@ import crypto from 'node:crypto';
 import { generateContent } from './content-generator.js';
 import { publish, getSupportedPlatforms } from './publisher/index.js';
 import { checkBudget, recordSpend } from './budget-governor.js';
-import { generateUTMParams } from './utm.js';
 
 // ── Pipeline Status Constants ───────────────────────────
 

--- a/lib/marketing/content-pipeline.js
+++ b/lib/marketing/content-pipeline.js
@@ -81,10 +81,10 @@ export async function executePipeline({
 
     try {
       // Step 1: Check budget
-      const budget = await checkBudget({ supabase, ventureId, channel: channel.id });
-      if (budget && budget.remaining <= 0) {
+      const budgetCheck = await checkBudget(supabase, ventureId, channel.platforms[0]);
+      if (!budgetCheck.allowed) {
         channelResult.status = PIPELINE_STATUS.FAILED;
-        channelResult.error = 'Budget exhausted for channel';
+        channelResult.error = budgetCheck.reason || 'Budget exhausted for channel';
         totalFailed++;
         results.push(channelResult);
         continue;
@@ -136,7 +136,7 @@ export async function executePipeline({
 
         if (pubResult.success) {
           totalPublished++;
-          await recordSpend({ supabase, ventureId, channel: channel.id, amount: 0 });
+          await recordSpend(supabase, ventureId, platform, 0);
         }
       }
 

--- a/tests/unit/marketing/content-pipeline-budget.test.js
+++ b/tests/unit/marketing/content-pipeline-budget.test.js
@@ -1,0 +1,70 @@
+/**
+ * QF-20260707-848: content-pipeline.js checkBudget()/recordSpend() call signature mismatch.
+ *
+ * Both checkBudget and recordSpend in budget-governor.js take POSITIONAL args
+ * (supabase, ventureId, platform, amount) but content-pipeline.js was calling them
+ * with an object, silently turning "Step 1: Check budget" into dead code and
+ * making spend-recording a silent no-op.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const checkBudget = vi.fn();
+const recordSpend = vi.fn();
+vi.mock('../../../lib/marketing/budget-governor.js', () => ({ checkBudget, recordSpend }));
+
+const generateContent = vi.fn();
+vi.mock('../../../lib/marketing/content-generator.js', () => ({ generateContent }));
+
+const publish = vi.fn();
+vi.mock('../../../lib/marketing/publisher/index.js', () => ({
+  publish,
+  getSupportedPlatforms: () => ['x', 'bluesky', 'email', 'google_ads'],
+}));
+
+vi.mock('../../../lib/marketing/utm.js', () => ({ generateUTMParams: () => ({}) }));
+
+const { executePipeline } = await import('../../../lib/marketing/content-pipeline.js');
+
+function fakeSupabase() {
+  return { from: () => ({ upsert: () => Promise.resolve({ error: null }) }) };
+}
+
+describe('content-pipeline.js budget call signatures (QF-20260707-848)', () => {
+  beforeEach(() => {
+    checkBudget.mockReset();
+    recordSpend.mockReset();
+    generateContent.mockReset();
+    publish.mockReset();
+  });
+
+  it('calls checkBudget with POSITIONAL args and halts the channel when disallowed', async () => {
+    checkBudget.mockResolvedValue({ allowed: false, reason: 'Monthly budget exceeded' });
+
+    const result = await executePipeline({
+      supabase: fakeSupabase(),
+      ventureId: 'v-1',
+      ventureContext: { name: 'Acme', description: 'desc' },
+      channelIds: ['email'],
+    });
+
+    expect(checkBudget).toHaveBeenCalledWith(expect.anything(), 'v-1', 'email');
+    expect(generateContent).not.toHaveBeenCalled();
+    expect(result.channels[0].status).toBe('failed');
+    expect(result.channels[0].error).toBe('Monthly budget exceeded');
+  });
+
+  it('calls recordSpend with POSITIONAL args after a successful publish', async () => {
+    checkBudget.mockResolvedValue({ allowed: true, budget: {} });
+    generateContent.mockResolvedValue({ contentId: 'c-1', variants: [{ body: 'b', headline: 'h', cta: 'go' }] });
+    publish.mockResolvedValue({ success: true });
+
+    await executePipeline({
+      supabase: fakeSupabase(),
+      ventureId: 'v-1',
+      ventureContext: { name: 'Acme', description: 'desc' },
+      channelIds: ['email'],
+    });
+
+    expect(recordSpend).toHaveBeenCalledWith(expect.anything(), 'v-1', 'email', 0);
+  });
+});


### PR DESCRIPTION
## Summary
- `checkBudget(supabase, ventureId, platform, cost)` and `recordSpend(supabase, ventureId, platform, amount)` in `budget-governor.js` take positional args, but `content-pipeline.js` called both with an object — silently making the budget-check step dead code and spend-recording a no-op.
- Fixed both call sites to use positional args and the real `.allowed`/`.reason` fields (there is no `.remaining` field).

## Test plan
- [x] New regression test `tests/unit/marketing/content-pipeline-budget.test.js` (2 tests) asserting positional call shape and that a disallowed budget halts the channel.
- [x] `npx vitest run tests/unit/marketing/content-pipeline-budget.test.js tests/unit/marketing/budget-governor.test.js tests/unit/eva/marketing-e2e.test.js` — 54/54 passed.
- [x] `npx tsc --noEmit` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)