### PR TITLE
fix(QF-20260707-875): startup staleness WARN for routing-critical comms CLIs

### DIFF
--- a/lib/coordinator/checkout-staleness.cjs
+++ b/lib/coordinator/checkout-staleness.cjs
@@ -1,0 +1,27 @@
+// QF-20260707-875: preventive staleness WARN for routing-critical comms CLIs.
+// PREVENTIVE per Alpha's RCA on QF-20260707-652 (closed as stale-code artifact): a
+// routing-critical send silently re-ran pre-fix (already-fixed elsewhere) code for
+// 1h43m because the checkout was 18 commits behind origin/main, with no signal.
+// Deliberately: WARN only, never auto-pull (main checkout is chronically dirty —
+// mutating auto-pull is unsafe) and never a hard gate (too aggressive for a warn-class
+// issue). Non-fatal on any git error (detached HEAD, no upstream, git unavailable).
+const { execSync } = require('child_process');
+
+function warnIfCheckoutStale(label, execImpl = execSync) {
+  try {
+    const behind = execImpl('git rev-list --count HEAD..@{u}', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const count = parseInt(behind, 10);
+    if (count > 0) {
+      process.stderr.write(
+        `⚠️  WARN: ${label} checkout is ${count} commit(s) behind origin/main — this send may run pre-fix code. Consider a git pull before continuing.\n`
+      );
+    }
+  } catch {
+    // No upstream configured, detached HEAD, or git unavailable — never block the send.
+  }
+}
+
+module.exports = { warnIfCheckoutStale };

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -48,6 +48,7 @@ const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled 
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { insertCoordinationRow, isSentinelTarget } = require('../lib/coordinator/dispatch.cjs');
 const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
+const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
@@ -632,6 +633,7 @@ async function printStatus(supabase, sessionId, argv) {
 }
 
 async function main() {
+  warnIfCheckoutStale('adam-advisory.cjs');
   const argv = process.argv.slice(2);
   const mode = argv[0];
   if (mode !== 'send' && mode !== 'request' && mode !== 'replies' && mode !== 'inbox' && mode !== 'status') {

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -46,6 +46,7 @@ const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signa
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
+const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
@@ -529,6 +530,7 @@ async function printStatus(supabase, sessionId, argv) {
 }
 
 async function main() {
+  warnIfCheckoutStale('solomon-advisory.cjs');
   const argv = process.argv.slice(2);
   const mode = argv[0];
   if (mode !== 'send' && mode !== 'request' && mode !== 'inbox' && mode !== 'status') {

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -28,6 +28,7 @@ const { evaluateSolomonTriage } = require('../lib/coordinator/solomon-triage.cjs
 const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const { computeReplyExpectedBy } = require('../lib/coordinator/reply-class.cjs');
+const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-4): 'unfit' — a worker reporting an assignment it cannot
 // execute HERE/NOW (repo mismatch / closed premise / missing input precondition). Replaces the
@@ -604,6 +605,7 @@ async function solomonConsultMain(flags, positional) {
 }
 
 async function main() {
+  warnIfCheckoutStale('worker-signal.cjs');
   const { flags, positional } = parseArgs(process.argv);
 
   // FR-1: route the `intent` subcommand before the legacy signal path.

--- a/tests/unit/coordinator/checkout-staleness.test.js
+++ b/tests/unit/coordinator/checkout-staleness.test.js
@@ -1,0 +1,35 @@
+/**
+ * QF-20260707-875: preventive staleness WARN for routing-critical comms CLIs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { warnIfCheckoutStale } from '../../../lib/coordinator/checkout-staleness.cjs';
+
+describe('warnIfCheckoutStale', () => {
+  let stderrSpy;
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => stderrSpy.mockRestore());
+
+  it('does NOT warn when up to date (0 commits behind)', () => {
+    const fakeExec = vi.fn().mockReturnValue('0\n');
+    warnIfCheckoutStale('test-cli', fakeExec);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('WARNs with the commit count when behind origin', () => {
+    const fakeExec = vi.fn().mockReturnValue('18\n');
+    warnIfCheckoutStale('adam-advisory.cjs', fakeExec);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const message = stderrSpy.mock.calls[0][0];
+    expect(message).toContain('18');
+    expect(message).toContain('adam-advisory.cjs');
+    expect(message).toContain('WARN');
+  });
+
+  it('never throws and never warns when git errors (detached HEAD / no upstream)', () => {
+    const fakeExec = vi.fn().mockImplementation(() => { throw new Error('no upstream configured'); });
+    expect(() => warnIfCheckoutStale('worker-signal.cjs', fakeExec)).not.toThrow();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Preventive per Alpha's RCA on QF-20260707-652: a routing-critical send silently ran pre-fix code for 1h43m because the checkout was 18 commits behind origin/main, with no signal.
- Adds `lib/coordinator/checkout-staleness.cjs::warnIfCheckoutStale()`, called at the top of `main()` in `adam-advisory.cjs`, `solomon-advisory.cjs`, and `worker-signal.cjs` (the three routing-critical send CLIs).
- WARN only — no auto-pull (main checkout is chronically dirty, unsafe to mutate) and no hard gate (too aggressive for a warn-class issue). Non-fatal on any git error.

## Test plan
- [x] New unit test `tests/unit/coordinator/checkout-staleness.test.js` (3 tests, dependency-injected exec) — warns when behind, silent when current, never throws on git errors.
- [x] Manually smoke-tested all 3 CLIs still run their usage/help paths cleanly with no spurious WARN on an up-to-date checkout.
- [x] `node --check` + eslint clean on all 5 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)