### PR TITLE
docs(tiered-orchestration): document Fable-use-doctrine model-tier stamp as a third dispatch axis

### DIFF
--- a/docs/leo/tiered-orchestration-door-routing.md
+++ b/docs/leo/tiered-orchestration-door-routing.md
@@ -1,10 +1,10 @@
 ---
 category: Protocol
 status: Approved
-version: 1.0.0
-author: Bravo (FABLE-MAX) — SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001
-last_updated: 2026-07-05
-tags: [tiered-orchestration, door-routing, dispatch, economics]
+version: 1.1.0
+author: Bravo (FABLE-MAX) — SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001; extended by SD-LEO-INFRA-OPERATIONALIZE-FABLE-USE-001
+last_updated: 2026-07-07
+tags: [tiered-orchestration, door-routing, dispatch, economics, model-tier, fable-use-doctrine]
 ---
 
 # Tiered Orchestration — One-Way/Two-Way Door Routing
@@ -71,3 +71,56 @@ PR passes the identical pipeline a Fable PR does.
 The local/ollama rung: add its label to `DELEGATE_TIERS`, register the session
 tier in the ladder, and (optionally) wire the client-factory seam for in-process
 calls. The rubric, stamps, gate, and ledger admit it unchanged.
+
+## A third, orthogonal axis: content-tier (Fable-use doctrine)
+
+SD-LEO-INFRA-OPERATIONALIZE-FABLE-USE-001 operationalizes a separate chairman
+doctrine (`docs/design/fable-use-case-doctrine.md`) that answers a different
+question than `door_class` does. **Do not conflate the two axes:**
+
+| Axis | Question it answers | Classifier | Fail bias |
+|---|---|---|---|
+| `door_class` (above) | *Who is authorized to execute this?* (reversibility/execution-authority) | `lib/fleet/door-classifier.mjs` | fails **closed** toward `one_way` |
+| `model_recommendation` (this section) | *Does this work item's content warrant Fable's judgment at all?* (R1-R5 doctrine) | `lib/fleet/model-recommendation.cjs` | fails **open** toward `sonnet` |
+
+### Components
+
+1. **Classifier** — `lib/fleet/model-recommendation.cjs` `recommendModelTier(item)`
+   → `{tier, criterion, reason}`. Pure, no I/O. Scores title/description/scope/
+   key_changes text against 5 keyword-list rules (R1 compounding-constraint/
+   architecture, R2 negative-space/pre-mortem, R3 taste/UX-judgment, R4
+   cross-subsystem coupling ≥3, R5 reversal-stakes). A `door_class.door ===
+   'one_way'` stamp on the item is treated as an automatic R5 (reversal-stakes)
+   shortcut. Defaults to `sonnet` when nothing matches — the doctrine's own
+   standing rule ("Default: Sonnet. Escalate to Fable IFF R1-R5").
+2. **Stamper** — `stampModelRecommendation` in `lib/coordinator/dispatch.cjs`,
+   wired into `insertCoordinationRow` immediately after the existing
+   `stampEffortRecommendation` call (the same single dispatch choke point as
+   `door_class`). Stamps `model_recommendation` / `_criterion` / `_reason` onto
+   every `WORK_ASSIGNMENT` row; skips quick-fixes (`QF-*`) and any dispatch that
+   already carries a caller-preset value.
+3. **Evidence-first enforcement** — when the recommendation is `fable`, the
+   stamper checks for `payload.evidence_packet` or a `sub_agent_execution_results`
+   row for the SD within the last 24h; absent both, it stamps
+   `model_recommendation_evidence_missing=true` rather than acting on an
+   unsubstantiated Fable escalation. Fails open on a lookup fault (advisory,
+   never blocks dispatch).
+4. **Audit trail** — a fire-and-forget, FIFO-capped-at-20 append to
+   `strategic_directives_v2.metadata.model_tier_decisions[]` on every dispatch.
+5. **Economics** — the same `door_routing_ledger` table gains two additive,
+   nullable columns, `r_criterion` (which R1-R5 rule fired) and
+   `funnel_position` (`selection`|`design`|`detailing`, phase-derived via
+   `funnelPositionForPhase()` in `lib/fleet/door-routing-ledger.cjs` — LEAD→
+   selection, PLAN→design, else→detailing), added by
+   `database/migrations/20260707_door_routing_ledger_fable_criterion_funnel.sql`
+   (additive-only, idempotent; applied at the same door-routing cutover as the
+   base table). `scripts/fable-allocation-report.mjs` aggregates ledger rows by
+   both dimensions, turning the doctrine's own observed bias ("we over-allocate
+   Fable to detailing, under-allocate to selection/pre-mortems") into a
+   measured, trending number instead of folklore.
+
+Like `door_class`, everything here is inert until the target SD already carries
+data the stamps depend on — the ledger write specifically requires a classified
+`door_class.door` (the ledger's `door` column is `NOT NULL`), so an SD with no
+door classification yet simply has no ledger row written; the dispatch stamp
+itself is unconditional and always fires.


### PR DESCRIPTION
## Summary
- Post-completion `/document` follow-up for SD-LEO-INFRA-OPERATIONALIZE-FABLE-USE-001.
- Extends `docs/leo/tiered-orchestration-door-routing.md` (existing reference doc for the door-routing/tiered-orchestration system this SD hooks into) rather than creating a new doc.
- Adds a section making explicit that `model_recommendation` (content-tier, fails open toward `sonnet`) and `door_class` (execution-authority, fails closed toward `one_way`) are two separate, orthogonal dispatch-time axes sharing the same choke point and `door_routing_ledger` table — so future readers don't conflate them.

## Test plan
- [x] Docs-only change; DOCMON pre-push gate passed clean (no blacklisted words, no location violations)
- [x] Grepped for blacklisted words before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)