### PR TITLE
fix(QF-20260707-432): stop EvaMasterScheduler registries from silently expiring 24h after start

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -13,7 +13,6 @@
 import { randomUUID } from 'crypto';
 import { execSync } from 'child_process';
 import { ServiceRegistry } from './service-registry.js';
-import { TTLMap } from '../utils/ttl-map.js';
 
 // SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B (FR-1): build provenance, computed ONCE at
 // construction and merged into every heartbeat metadata write. The 2026-06-10 OKR
@@ -173,8 +172,14 @@ export class EvaMasterScheduler {
     // Periodic vision scoring configuration (US-001)
     this.visionScoringIntervalMs = cfg.visionScoringIntervalMs || DEFAULT_VISION_SCORING_INTERVAL_MS;
 
-    // Round registry — bounded to prevent unbounded growth (FR-1, FR-3, FR-4)
-    this._roundRegistry = new TTLMap({ defaultTTLMs: 24 * 60 * 60 * 1000, maxEntries: 500 }); // 24h TTL, max 500
+    // Round registry — QF-20260707-432: registerRound() is only ever called once per
+    // round type at process-startup (module-import time), never at runtime, so a TTLMap's
+    // maxEntries bound was never load-bearing here — its 24h TTL was, and it silently
+    // expired every constructor-registered round 24h after daemon start while the poll
+    // loop and heartbeat stayed healthy, masking a full scheduler outage. A plain Map has
+    // no expiry, matching the actual "registered once, needed for the process lifetime"
+    // semantics.
+    this._roundRegistry = new Map();
     this._lastRoundRun = new Map();
     this._totalRoundExecutions = 0;
     this._totalRoundErrors = 0;
@@ -189,8 +194,9 @@ export class EvaMasterScheduler {
     this._metricsWriteFailures = 0;
     this._lastVisionScoringAt = null;
 
-    // Job Registry — bounded (US-002: pluggable periodic tasks)
-    this._jobRegistry = new TTLMap({ defaultTTLMs: 24 * 60 * 60 * 1000, maxEntries: 1000 }); // 24h TTL, max 1000
+    // Job Registry — QF-20260707-432: same fix as _roundRegistry above; registerJob()
+    // only fires once per job at startup, so a plain Map (no expiry) is correct.
+    this._jobRegistry = new Map();
     this._jobLastRunAt = new Map();
 
     // Register built-in jobs

--- a/tests/unit/eva-master-scheduler.test.js
+++ b/tests/unit/eva-master-scheduler.test.js
@@ -1446,6 +1446,30 @@ describe('EvaMasterScheduler', () => {
       expect(() => scheduler.registerRound('valid', {})).toThrow();
     });
 
+    test('registered rounds and jobs survive past 24h (QF-20260707-432 regression)', () => {
+      // Registries used to be TTLMaps with a 24h TTL and no refresh-on-read, so every
+      // constructor-registered round/job silently vanished 24h after daemon start while
+      // the poll loop stayed healthy. registerRound/registerJob only ever fire once at
+      // startup, so entries must live for the full process lifetime.
+      vi.useFakeTimers();
+      try {
+        scheduler.registerRound('long_lived_round', {
+          description: 'Should not expire',
+          handler: async () => ({ ok: true }),
+          cadence: 'hourly',
+        });
+        scheduler.registerJob({ name: 'long_lived_job', handler: async () => {}, cadenceDays: 1 });
+
+        vi.advanceTimersByTime(25 * 60 * 60 * 1000); // 25h — past the old 24h TTL
+
+        const roundTypes = scheduler.listRounds().map(r => r.type);
+        expect(roundTypes).toContain('long_lived_round');
+        expect(scheduler.getRegisteredJobs().map(j => j.name)).toContain('long_lived_job');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     test('runRound should execute the handler and return result', async () => {
       scheduler.registerRound('quick_test', {
         description: 'Quick',


### PR DESCRIPTION
## Summary
- `EvaMasterScheduler._roundRegistry`/`_jobRegistry` were `TTLMap`s with a 24h TTL and no refresh-on-read, populated once at construction but needed for the full process lifetime.
- `registerRound()`/`registerJob()` only ever fire once per entry at process-startup (module-import time) — confirmed via `grep` across all call sites — so `TTLMap`'s `maxEntries` FIFO bound was never load-bearing here; only the TTL was active, and it silently dropped every constructor-registered round/job 24h after daemon start.
- The independent poll loop kept heartbeating normally, so the only external watcher (`eva-scheduler-watcher-cron.yml`, which checks `last_poll_at`) reported "scheduler alive" throughout, masking a full outage of 9/11 daily/weekly rounds for ~73h in production (confirmed live against daemon `scheduler-7f77838a`).
- Fix: swap both registries to plain `Map`s — interface-compatible with the only methods actually used (`set`/`get`/`values`/iteration), no expiry for entries that live for the process lifetime.

## Test plan
- [x] New regression test: registers a round + job, advances fake timers 25h (past the old 24h TTL), asserts both are still listed
- [x] Full `tests/unit/eva-master-scheduler.test.js` suite: 80/82 pass — the 2 failures are the exact pre-existing quarantined `assertion-drift` signature (`tests/quarantine-manifest.json`, quarantined 2026-06-11, unrelated `processStage` mock-argument issue)
- [x] `lib/utils/ttl-map.test.js` (the general-purpose TTLMap module itself, untouched) — 3/3 pass
- [x] ESLint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)