### PR TITLE
fix(QF-20260707-793): worker-checkin critical-QF-jump test fixture no longer calendar-drifts stale [unblocks repo-wide CI]

### DIFF
--- a/tests/unit/worker-checkin-critical-qf-priority-jump.test.js
+++ b/tests/unit/worker-checkin-critical-qf-priority-jump.test.js
@@ -11,7 +11,10 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { resolveCheckin, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS } = require('../../scripts/worker-checkin.cjs');
 
-const NOW = Date.parse('2026-07-05T00:00:00Z');
+// QF-20260707-793: relative to real Date.now(), not a fixed calendar date -- resolveCheckin's
+// isCriticalQfJumpEligible/isAutoStartableQF check ageDays against a real STALE_QF_DAYS=3
+// ceiling using the wall clock, so a hardcoded NOW drifts past that ceiling as real time passes.
+const NOW = Date.now();
 const OLD_ENOUGH = new Date(NOW - CRITICAL_QF_JUMP_GRACE_MS - 60_000).toISOString(); // just past grace
 const TOO_FRESH = new Date(NOW - 60_000).toISOString(); // 1 minute ago
 


### PR DESCRIPTION
## Summary
- **Currently blocking CI on every open PR** (Run Unit Tier quarantine-aware job) — root-caused while merging an unrelated QF (#5727) and hit the same red check.
- `tests/unit/worker-checkin-critical-qf-priority-jump.test.js` hardcoded `NOW = Date.parse('2026-07-05T00:00:00Z')` to derive its `OLD_ENOUGH`/`TOO_FRESH` fixture timestamps.
- `resolveCheckin`'s critical-QF-jump path calls `isCriticalQfJumpEligible` → `isAutoStartableQF`, which checks a real `STALE_QF_DAYS=3` ceiling against the wall clock (`Date.now()`), not the test's fixed `NOW`.
- As real calendar time passed 3+ days beyond 2026-07-05 (today is 2026-07-08), the fixture's `OLD_ENOUGH` QF started reading as stale (`ageDays > 3`), breaking both `resolveCheckin` integration tests (`idle` instead of `self_claimed_qf`).
- **Root cause is test-fixture calendar drift, not a production defect** — `STALE_QF_DAYS` is working exactly as designed; the pure-predicate tests (which pass `NOW` explicitly as `nowMs`) were unaffected since they're internally self-consistent regardless of real time.
- Fix: derive `NOW` from `Date.now()` instead of a fixed calendar string, so the fixture's small (11-minute) offsets never approach the 3-day staleness boundary regardless of which real day the suite runs on.

## Test plan
- [x] `tests/unit/worker-checkin-critical-qf-priority-jump.test.js`: 8/8 pass (was 6/8)
- [x] Broader sweep `tests/unit/worker-checkin*.test.js`: 154/154 pass, 17 files
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)