### PR TITLE
fix(QF-20260708-650): allowlist frozen APA-fixture base64 image data in secret-scan hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -271,7 +271,15 @@ echo "🔐 Running secret detection scan..."
 
 # Get all staged file contents (excluding pre-commit hook itself to avoid false positives)
 # The hook contains regex patterns that would otherwise trigger detection
-STAGED_CONTENT=$(git diff --cached --diff-filter=ACM -U0 -- ':!.husky/pre-commit' ':!.githooks/*' 2>/dev/null || true)
+STAGED_CONTENT=$(git diff --cached --diff-filter=ACM -U0 -- ':!.husky/pre-commit' ':!.githooks/*' ':!docs/design/apa-calibration-fixtures/*' 2>/dev/null || true)
+
+# QF-20260708-650: frozen design fixtures under docs/design/apa-calibration-fixtures/**
+# inline-embed base64 PNG screenshots that false-positive-match the AKIA pattern.
+# Narrowly scoped allowlist: strip ONLY base64 image-data-URI lines from that path's
+# diff -- any other content in those files (e.g. a real secret) is still scanned.
+FIXTURE_CONTENT=$(git diff --cached --diff-filter=ACM -U0 -- 'docs/design/apa-calibration-fixtures/*' 2>/dev/null | grep -viE '^\+.*data:image/(png|jpe?g|gif);base64,' || true)
+STAGED_CONTENT="${STAGED_CONTENT}
+${FIXTURE_CONTENT}"
 
 # Define secret patterns (regex)
 # These patterns match common API key and credential formats


### PR DESCRIPTION
## Summary
- Base64-embedded PNG screenshots in `docs/design/apa-calibration-fixtures/**` false-positive-matched the AKIA-key pattern in the pre-commit secret-scan hook, blocking commits for frozen-fixture SD deliverables (first hit: SD-FDBK-ENH-APA-CALIBRATION-FIXTURE-001, Golf-3 parked at EXEC).
- Fix is narrowly scoped: only strip base64 image-data-URI lines from that specific fixtures path's diff before scanning. A real secret anywhere else — including elsewhere in the same fixture file, or in any other path — is still scanned and blocked. Not a blanket base64 bypass.

## Test plan
- [x] `bash -n .husky/pre-commit` — syntax valid
- [x] Synthetic fixture file with a false-positive AKIA-shaped base64 image-data URI under `docs/design/apa-calibration-fixtures/` → commit succeeds
- [x] Real secret (`AKIA...`) in a normal (non-fixture) file → commit still blocked
- [x] Real secret hidden in a fixture file OUTSIDE a `data:image` line → commit still blocked (guardrail intact)
- [x] `npm run test:smoke` passes as part of the commit hook run

QF-20260708-650

🤖 Generated with [Claude Code](https://claude.com/claude-code)