### PR TITLE
fix(QF-20260708-267): stop calendar-drift in claim-eligibility not_before test fixture

### DIFF
--- a/tests/unit/claim-eligibility-not-before-door-class.test.js
+++ b/tests/unit/claim-eligibility-not-before-door-class.test.js
@@ -49,7 +49,11 @@ describe('classifyDispatchIneligibility — hold-axis composition (QF-20260705-5
       .toBe('human_action_required');
   });
   it('the SD-ARCH-HOTSPOT-STAGE-WORKER-001 specimen (both fields set) is refused on not_before first', () => {
-    const specimen = { sd_key: 'SD-ARCH-HOTSPOT-STAGE-WORKER-001', metadata: { not_before: '2026-07-08T04:00:00Z', door_class_note: 'one_way' } };
+    // QF-20260708-267: was a hardcoded past-dated literal ('2026-07-08T04:00:00Z') that
+    // calendar-drifted stale (same class as QF-20260707-793) -- use a relative future date
+    // like the rest of this file (lines 14, 45) so the fixture never expires.
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const specimen = { sd_key: 'SD-ARCH-HOTSPOT-STAGE-WORKER-001', metadata: { not_before: future, door_class_note: 'one_way' } };
     expect(classifyDispatchIneligibility(specimen)).toBe('not_before_hold');
   });
 });


### PR DESCRIPTION
## Summary
- `tests/unit/claim-eligibility-not-before-door-class.test.js` hardcoded `not_before='2026-07-08T04:00:00Z'` for the `SD-ARCH-HOTSPOT-STAGE-WORKER-001` specimen. Once that timestamp passed, `classifyDispatchIneligibility` correctly returned `null` instead of the test's expected `'not_before_hold'` — the function is behaving correctly, the fixture date is what drifted stale.
- Same recurring bug class as `QF-20260707-793`. Was blocking `Run Unit Tier (quarantine-aware)` CI fleet-wide (discovered while shipping unrelated PR #5732).
- Fix: use a relative future date, matching the file's existing pattern at lines 14 and 45, so the fixture never expires again.

## Test plan
- [x] `npx vitest run tests/unit/claim-eligibility-not-before-door-class.test.js` — 9/9 pass
- [x] `npm run test:smoke` passes as part of the commit hook run

QF-20260708-267

🤖 Generated with [Claude Code](https://claude.com/claude-code)