### PR TITLE
fix(QF-20260708-516): unpin calendar-drifted not_before literal in door-class test

### DIFF
--- a/tests/unit/claim-eligibility-not-before-door-class.test.js
+++ b/tests/unit/claim-eligibility-not-before-door-class.test.js
@@ -49,7 +49,8 @@ describe('classifyDispatchIneligibility — hold-axis composition (QF-20260705-5
       .toBe('human_action_required');
   });
   it('the SD-ARCH-HOTSPOT-STAGE-WORKER-001 specimen (both fields set) is refused on not_before first', () => {
-    const specimen = { sd_key: 'SD-ARCH-HOTSPOT-STAGE-WORKER-001', metadata: { not_before: '2026-07-08T04:00:00Z', door_class_note: 'one_way' } };
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const specimen = { sd_key: 'SD-ARCH-HOTSPOT-STAGE-WORKER-001', metadata: { not_before: future, door_class_note: 'one_way' } };
     expect(classifyDispatchIneligibility(specimen)).toBe('not_before_hold');
   });
 });


### PR DESCRIPTION
## Summary
- Line 52's absolute `not_before` timestamp (`2026-07-08T04:00:00Z`) had drifted into the past, flipping the expected `not_before_hold` classification to `null` and blocking CI on two dependent cleanup PRs (APA fixture SD lifecycle-close, QF-20260708-650).
- Switched to the same relative future-date pattern (`new Date(Date.now() + 86400000).toISOString()`) already used by sibling assertions in this file.
- Scope confirmed precise: grepped the file for remaining absolute-date literals — none left.

## Test plan
- [x] `npx vitest run tests/unit/claim-eligibility-not-before-door-class.test.js` — 9/9 passed
- [x] `npx tsc --noEmit` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)