### PR TITLE
feat(SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001): decision-binding disposition primitive

### DIFF
--- a/lib/decision-binding/disposition.js
+++ b/lib/decision-binding/disposition.js
@@ -1,0 +1,234 @@
+// Decision-binding disposition primitive (SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001).
+//
+// Binds any gating decision (chairman ratification, Solomon/Adam consult answer,
+// future dispatch-auth) to the state it unblocks, keyed on a session-stable,
+// CONTENT-derived question_key -- never on correlation_id/message_id, which
+// rotate per session and are exactly why a re-asked question was invisible to
+// dedup.
+//
+// Storage: system_events (non-DDL Phase-1). idempotency_key = question_key gives
+// a DATABASE-ENFORCED unique constraint for dedup, stronger than app-level
+// checking alone. event_type='DECISION_DISPOSITION' distinguishes rows from
+// every other system_events consumer. actor_role is left null so the
+// dual_domain_governance trigger takes its no-governance-required default path.
+
+import { createHash } from 'node:crypto';
+
+const EVENT_TYPE = 'DECISION_DISPOSITION';
+
+const VALID_DECISION_TYPES = ['ratification', 'consult_answer', 'dispatch_auth'];
+const VALID_STATUSES = ['awaiting_disposition', 'dispositioned', 'consumed'];
+
+/**
+ * Canonicalize a subject payload into a stable string for hashing: sorted
+ * keys, JSON-stringified. Order-independent so {a:1,b:2} and {b:2,a:1} hash
+ * identically.
+ */
+function canonicalize(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(value[k])}`).join(',')}}`;
+}
+
+/**
+ * Derive a session-stable, content-derived question_key. NEVER reads
+ * correlation_id or message_id -- those rotate per session, which is the
+ * exact bug this primitive fixes.
+ *
+ * @param {'ratification'|'consult_answer'|'dispatch_auth'} decisionType
+ * @param {object} subject - decision-type-specific identifying content:
+ *   ratification: { fixture_set_id, fixture_id }
+ *   consult_answer: { question_text }
+ *   dispatch_auth: { subject_id, gate_type }
+ * @returns {string} a stable "dq_<sha256-hex>" key
+ */
+export function computeQuestionKey(decisionType, subject) {
+  if (!VALID_DECISION_TYPES.includes(decisionType)) {
+    throw new Error(`computeQuestionKey: invalid decisionType "${decisionType}"`);
+  }
+  if (!subject || typeof subject !== 'object') {
+    throw new Error('computeQuestionKey: subject must be an object');
+  }
+  const canonical = `${decisionType}::${canonicalize(subject)}`;
+  const hash = createHash('sha256').update(canonical, 'utf8').digest('hex');
+  return `dq_${hash}`;
+}
+
+function assertSupabase(supabase) {
+  if (!supabase || typeof supabase.from !== 'function') {
+    throw new Error('disposition.js: a Supabase client instance is required');
+  }
+}
+
+/**
+ * Record a disposition. If a row already exists for this question_key
+ * (dedup), the EXISTING row is returned unchanged -- recordDisposition never
+ * silently overwrites a prior decision. To transition an existing row's
+ * status, use updateDispositionStatus().
+ *
+ * @param {object} supabase - Supabase client (service-role)
+ * @param {object} params
+ * @param {'ratification'|'consult_answer'|'dispatch_auth'} params.decisionType
+ * @param {object} params.subject - identifying content, see computeQuestionKey
+ * @param {string} params.decisionKey - human-readable (subject_id, decision_type) label
+ * @param {string} [params.authority] - who decided (chairman|coordinator|session id)
+ * @param {object} [params.answerPayload] - polymorphic decision payload
+ * @param {'awaiting_disposition'|'dispositioned'} [params.status] - defaults to
+ *   'awaiting_disposition' unless answerPayload is provided, in which case
+ *   defaults to 'dispositioned' (a decision recorded WITH an answer is already decided).
+ * @returns {Promise<{row: object, created: boolean}>}
+ */
+export async function recordDisposition(supabase, {
+  decisionType,
+  subject,
+  decisionKey,
+  authority = null,
+  answerPayload = null,
+  status,
+}) {
+  assertSupabase(supabase);
+  const questionKey = computeQuestionKey(decisionType, subject);
+  const resolvedStatus = status || (answerPayload ? 'dispositioned' : 'awaiting_disposition');
+  if (!VALID_STATUSES.includes(resolvedStatus)) {
+    throw new Error(`recordDisposition: invalid status "${resolvedStatus}"`);
+  }
+
+  const existing = await getDisposition(supabase, questionKey);
+  if (existing) {
+    return { row: existing, created: false };
+  }
+
+  const nowIso = new Date().toISOString();
+  const insertRow = {
+    event_type: EVENT_TYPE,
+    idempotency_key: questionKey,
+    payload: {
+      question_key: questionKey,
+      decision_type: decisionType,
+      decision_key: decisionKey ?? null,
+      subject,
+      status: resolvedStatus,
+      authority,
+      decided_at: resolvedStatus === 'awaiting_disposition' ? null : nowIso,
+      answer_payload: answerPayload,
+    },
+  };
+
+  const { data, error } = await supabase
+    .from('system_events')
+    .insert(insertRow)
+    .select()
+    .single();
+
+  if (error) {
+    // Unique-violation race: another writer inserted the same question_key
+    // between our getDisposition() check and this insert. Read back and
+    // return the winner instead of surfacing a spurious failure.
+    if (error.code === '23505') {
+      const winner = await getDisposition(supabase, questionKey);
+      if (winner) return { row: winner, created: false };
+    }
+    throw new Error(`recordDisposition: insert failed: ${error.message}`);
+  }
+
+  return { row: data, created: true };
+}
+
+/**
+ * Read back a disposition by question_key. Returns null (never throws) when
+ * no row exists -- fail-closed: absence of a row is never authorized-by-default.
+ *
+ * @param {object} supabase
+ * @param {string} questionKey
+ * @returns {Promise<object|null>}
+ */
+export async function getDisposition(supabase, questionKey) {
+  assertSupabase(supabase);
+  const { data, error } = await supabase
+    .from('system_events')
+    .select('*')
+    .eq('event_type', EVENT_TYPE)
+    .eq('idempotency_key', questionKey)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getDisposition: query failed: ${error.message}`);
+  }
+  return data ?? null;
+}
+
+/**
+ * Look up a disposition by decisionType + subject content (computes the
+ * question_key internally). Convenience wrapper over getDisposition().
+ */
+export async function getDispositionBySubject(supabase, decisionType, subject) {
+  return getDisposition(supabase, computeQuestionKey(decisionType, subject));
+}
+
+/**
+ * Transition an existing disposition's status (e.g. dispositioned -> consumed
+ * once the bound blocked-state has acted on the decision).
+ *
+ * @returns {Promise<object>} the updated row
+ */
+export async function updateDispositionStatus(supabase, questionKey, newStatus, { answerPayload, authority } = {}) {
+  assertSupabase(supabase);
+  if (!VALID_STATUSES.includes(newStatus)) {
+    throw new Error(`updateDispositionStatus: invalid status "${newStatus}"`);
+  }
+  const existing = await getDisposition(supabase, questionKey);
+  if (!existing) {
+    throw new Error(`updateDispositionStatus: no disposition found for question_key ${questionKey}`);
+  }
+
+  const nowIso = new Date().toISOString();
+  const nextPayload = {
+    ...existing.payload,
+    status: newStatus,
+    decided_at: existing.payload.decided_at ?? (newStatus === 'awaiting_disposition' ? null : nowIso),
+    answer_payload: answerPayload !== undefined ? answerPayload : existing.payload.answer_payload,
+    authority: authority !== undefined ? authority : existing.payload.authority,
+  };
+
+  const { data, error } = await supabase
+    .from('system_events')
+    .update({ payload: nextPayload })
+    .eq('id', existing.id)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`updateDispositionStatus: update failed: ${error.message}`);
+  }
+  return data;
+}
+
+/**
+ * List all disposition rows in status=awaiting_disposition for a given
+ * decision_type, sorted oldest-first. Returns raw data only -- no
+ * rendering/formatting logic lives here; each consumer owns its own
+ * presentation.
+ *
+ * @param {object} supabase
+ * @param {'ratification'|'consult_answer'|'dispatch_auth'} decisionType
+ * @returns {Promise<object[]>}
+ */
+export async function listAwaitingDisposition(supabase, decisionType) {
+  assertSupabase(supabase);
+  if (!VALID_DECISION_TYPES.includes(decisionType)) {
+    return [];
+  }
+  const { data, error } = await supabase
+    .from('system_events')
+    .select('*')
+    .eq('event_type', EVENT_TYPE)
+    .eq('payload->>decision_type', decisionType)
+    .eq('payload->>status', 'awaiting_disposition')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`listAwaitingDisposition: query failed: ${error.message}`);
+  }
+  return data ?? [];
+}

--- a/scripts/apa-fixture-ratification-capture.mjs
+++ b/scripts/apa-fixture-ratification-capture.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001 FR-3: ratification-capture consumer.
+//
+// review-packet.html's Confirm/Flag-for-swap buttons are visual-only and CANNOT
+// reach a network endpoint -- the Artifact publishing surface enforces a strict
+// CSP that blocks all fetch/XHR. This script is the actual capture path: run it
+// after the chairman states his ratification decisions in conversation (the
+// established pattern for chairman-stated decisions in this codebase — see
+// coordinator-ack-adam.cjs --disposition), and it persists each decision as a
+// disposition_row keyed on (fixture_set_id, fixture_id) via the shared
+// decision-binding primitive.
+//
+// Usage:
+//   node scripts/apa-fixture-ratification-capture.mjs \
+//     --fixture-set apa-calibration-2026-07-08 \
+//     --confirmed G1,G2,G4,D1,D2,D3,D4,D6,B1,B2,I1,I2 \
+//     --flagged G3,D5,B3,I3 \
+//     --authority chairman
+//
+// Idempotent: re-running with the same fixture-set + fixture_id dedups against
+// the existing disposition row (question_key is content-derived, not
+// correlation-derived) instead of creating a duplicate.
+
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+import { recordDisposition } from '../lib/decision-binding/disposition.js';
+
+function parseArgs(argv) {
+  const out = { fixtureSet: null, confirmed: [], flagged: [], authority: 'chairman' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--fixture-set') out.fixtureSet = argv[++i];
+    else if (a === '--confirmed') out.confirmed = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (a === '--flagged') out.flagged = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (a === '--authority') out.authority = argv[++i];
+  }
+  if (!out.fixtureSet) throw new Error('--fixture-set is required');
+  return out;
+}
+
+export async function captureRatifications(supabase, { fixtureSet, confirmed, flagged, authority }) {
+  const results = [];
+  for (const fixtureId of confirmed) {
+    const { row, created } = await recordDisposition(supabase, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: fixtureSet, fixture_id: fixtureId },
+      decisionKey: `${fixtureSet}:${fixtureId}:ratification`,
+      authority,
+      answerPayload: { confirmed: true, flagged: false },
+    });
+    results.push({ fixtureId, verdict: 'confirmed', created, questionKey: row.payload.question_key });
+  }
+  for (const fixtureId of flagged) {
+    const { row, created } = await recordDisposition(supabase, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: fixtureSet, fixture_id: fixtureId },
+      decisionKey: `${fixtureSet}:${fixtureId}:ratification`,
+      authority,
+      answerPayload: { confirmed: false, flagged: true },
+    });
+    results.push({ fixtureId, verdict: 'flagged', created, questionKey: row.payload.question_key });
+  }
+  return results;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const results = await captureRatifications(supabase, args);
+  for (const r of results) {
+    console.log(`${r.fixtureId}: ${r.verdict} -> ${r.created ? 'NEW' : 'DEDUPED (already recorded)'} disposition row (question_key=${r.questionKey})`);
+  }
+  console.log(`\n${results.length} ratification(s) captured for fixture-set "${args.fixtureSet}".`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('apa-fixture-ratification-capture: FAILED:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/apa-fixture-ratification-capture.mjs
+++ b/scripts/apa-fixture-ratification-capture.mjs
@@ -38,6 +38,19 @@ function parseArgs(argv) {
   return out;
 }
 
+// recordDisposition() never overwrites an existing row (dedup returns the
+// PRIOR row unchanged), so on dedup the actually-stored verdict can differ
+// from what this call intended (e.g. a fixture previously flagged, now
+// re-run as confirmed). Always report the row's actual stored
+// answer_payload, never the caller's intended verdict, so the console output
+// can never silently misreport a contradicted decision.
+function storedVerdict(row) {
+  const payload = row.payload.answer_payload || {};
+  if (payload.confirmed) return 'confirmed';
+  if (payload.flagged) return 'flagged';
+  return 'unknown';
+}
+
 export async function captureRatifications(supabase, { fixtureSet, confirmed, flagged, authority }) {
   const results = [];
   for (const fixtureId of confirmed) {
@@ -48,7 +61,8 @@ export async function captureRatifications(supabase, { fixtureSet, confirmed, fl
       authority,
       answerPayload: { confirmed: true, flagged: false },
     });
-    results.push({ fixtureId, verdict: 'confirmed', created, questionKey: row.payload.question_key });
+    const verdict = storedVerdict(row);
+    results.push({ fixtureId, verdict, created, contradicted: !created && verdict !== 'confirmed', questionKey: row.payload.question_key });
   }
   for (const fixtureId of flagged) {
     const { row, created } = await recordDisposition(supabase, {
@@ -58,7 +72,8 @@ export async function captureRatifications(supabase, { fixtureSet, confirmed, fl
       authority,
       answerPayload: { confirmed: false, flagged: true },
     });
-    results.push({ fixtureId, verdict: 'flagged', created, questionKey: row.payload.question_key });
+    const verdict = storedVerdict(row);
+    results.push({ fixtureId, verdict, created, contradicted: !created && verdict !== 'flagged', questionKey: row.payload.question_key });
   }
   return results;
 }
@@ -70,7 +85,10 @@ async function main() {
   const supabase = createClient(supabaseUrl, serviceRoleKey);
   const results = await captureRatifications(supabase, args);
   for (const r of results) {
-    console.log(`${r.fixtureId}: ${r.verdict} -> ${r.created ? 'NEW' : 'DEDUPED (already recorded)'} disposition row (question_key=${r.questionKey})`);
+    const note = r.contradicted
+      ? `⚠ CONTRADICTS a prior disposition -- stored verdict is "${r.verdict}", not overwritten (re-run with an explicit override if this is intentional)`
+      : `${r.created ? 'NEW' : 'DEDUPED (already recorded)'} disposition row`;
+    console.log(`${r.fixtureId}: ${r.verdict} -> ${note} (question_key=${r.questionKey})`);
   }
   console.log(`\n${results.length} ratification(s) captured for fixture-set "${args.fixtureSet}".`);
 }

--- a/scripts/apa-fixture-ratification-capture.mjs
+++ b/scripts/apa-fixture-ratification-capture.mjs
@@ -65,7 +65,9 @@ export async function captureRatifications(supabase, { fixtureSet, confirmed, fl
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
   const results = await captureRatifications(supabase, args);
   for (const r of results) {
     console.log(`${r.fixtureId}: ${r.verdict} -> ${r.created ? 'NEW' : 'DEDUPED (already recorded)'} disposition row (question_key=${r.questionKey})`);

--- a/scripts/consult-answer-bind.mjs
+++ b/scripts/consult-answer-bind.mjs
@@ -8,9 +8,12 @@
 // transitioned in the same call -- so "answered" and "unblocked" can no longer
 // silently diverge.
 //
-// question_key is derived purely from the question TEXT content (never from
-// correlation_id), so a re-asked question in a brand-new session dedups
-// against the same disposition row instead of creating a phantom duplicate.
+// question_key is derived from the question TEXT content scoped to
+// (sdKey, blockedStateKey) -- never from correlation_id -- so a re-asked
+// question in a brand-new session dedups against the same disposition row
+// instead of creating a phantom duplicate. Scoping by sdKey/blockedStateKey
+// (not just raw question text) prevents two unrelated SDs that happen to ask
+// an identically-worded question from colliding onto the same disposition row.
 
 import { createClient } from '@supabase/supabase-js';
 import 'dotenv/config';
@@ -37,7 +40,7 @@ export async function bindConsultAnswer(supabase, { sdKey, blockedStateKey, ques
 
   const { row } = await recordDisposition(supabase, {
     decisionType: 'consult_answer',
-    subject: { question_text: questionText },
+    subject: { sd_key: sdKey, blocked_state_key: blockedStateKey, question_text: questionText },
     decisionKey: `${sdKey}:${blockedStateKey}`,
     authority,
     answerPayload: { answer },
@@ -59,12 +62,19 @@ export async function bindConsultAnswer(supabase, { sdKey, blockedStateKey, ques
     [`${blockedStateKey}_unblocked_at`]: new Date().toISOString(),
   };
 
-  const { error: updateError } = await supabase
+  // .select() + affected-row check: a bare .update() can silently no-op on
+  // zero matched rows (stale/mismatched sd_key, RLS) and still report no
+  // error -- the known supabase-js false-success pattern in this codebase.
+  const { data: updatedRows, error: updateError } = await supabase
     .from('strategic_directives_v2')
     .update({ metadata: nextMetadata })
-    .eq('sd_key', sdKey);
+    .eq('sd_key', sdKey)
+    .select('sd_key');
   if (updateError) {
     throw new Error(`bindConsultAnswer: could not update SD "${sdKey}" metadata: ${updateError.message}`);
+  }
+  if (!updatedRows || updatedRows.length === 0) {
+    throw new Error(`bindConsultAnswer: update matched 0 rows for SD "${sdKey}" -- metadata was NOT cleared, blocked-state remains set`);
   }
 
   return { disposition: row, sdUpdated: true };

--- a/scripts/consult-answer-bind.mjs
+++ b/scripts/consult-answer-bind.mjs
@@ -85,7 +85,9 @@ function parseArgs(argv) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
   const result = await bindConsultAnswer(supabase, args);
   console.log(`Consult answer bound: question_key=${result.disposition.payload.question_key}, SD "${args.sdKey}".${args.blockedStateKey} unblocked.`);
 }

--- a/scripts/consult-answer-bind.mjs
+++ b/scripts/consult-answer-bind.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001 FR-4: consult-answer-binding consumer.
+//
+// Closes Solomon's Mode-B "ANSWER-DELIVERED-not-CONSUMER-UNBLOCKED" finding: a
+// consult answer delivered via the advisory lane (scripts/solomon-advisory.cjs,
+// scripts/adam-advisory.cjs) is recorded here as a disposition_row AND the
+// specific strategic_directives_v2.metadata field it was meant to unblock is
+// transitioned in the same call -- so "answered" and "unblocked" can no longer
+// silently diverge.
+//
+// question_key is derived purely from the question TEXT content (never from
+// correlation_id), so a re-asked question in a brand-new session dedups
+// against the same disposition row instead of creating a phantom duplicate.
+
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+import { recordDisposition } from '../lib/decision-binding/disposition.js';
+
+/**
+ * Bind a delivered consult answer to the SD-metadata blocked-state it
+ * unblocks, recording the disposition and flipping the named metadata field
+ * to unblocked in one call.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.sdKey - strategic_directives_v2.sd_key to update
+ * @param {string} params.blockedStateKey - dot-path metadata field to clear, e.g. "blocked_on_solomon_consult"
+ * @param {string} params.questionText - the consult question, verbatim (the dedup key content)
+ * @param {string} params.answer - the delivered answer
+ * @param {string} params.authority - who answered (e.g. "solomon", "adam", session id)
+ * @returns {Promise<{disposition: object, sdUpdated: boolean}>}
+ */
+export async function bindConsultAnswer(supabase, { sdKey, blockedStateKey, questionText, answer, authority }) {
+  if (!sdKey) throw new Error('bindConsultAnswer: sdKey is required');
+  if (!blockedStateKey) throw new Error('bindConsultAnswer: blockedStateKey is required');
+  if (!questionText) throw new Error('bindConsultAnswer: questionText is required');
+
+  const { row } = await recordDisposition(supabase, {
+    decisionType: 'consult_answer',
+    subject: { question_text: questionText },
+    decisionKey: `${sdKey}:${blockedStateKey}`,
+    authority,
+    answerPayload: { answer },
+  });
+
+  const { data: sdRow, error: fetchError } = await supabase
+    .from('strategic_directives_v2')
+    .select('metadata')
+    .eq('sd_key', sdKey)
+    .single();
+  if (fetchError) {
+    throw new Error(`bindConsultAnswer: could not read SD "${sdKey}": ${fetchError.message}`);
+  }
+
+  const nextMetadata = {
+    ...(sdRow.metadata || {}),
+    [blockedStateKey]: false,
+    [`${blockedStateKey}_disposition_question_key`]: row.payload.question_key,
+    [`${blockedStateKey}_unblocked_at`]: new Date().toISOString(),
+  };
+
+  const { error: updateError } = await supabase
+    .from('strategic_directives_v2')
+    .update({ metadata: nextMetadata })
+    .eq('sd_key', sdKey);
+  if (updateError) {
+    throw new Error(`bindConsultAnswer: could not update SD "${sdKey}" metadata: ${updateError.message}`);
+  }
+
+  return { disposition: row, sdUpdated: true };
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--sd-key') out.sdKey = argv[++i];
+    else if (a === '--blocked-state-key') out.blockedStateKey = argv[++i];
+    else if (a === '--question') out.questionText = argv[++i];
+    else if (a === '--answer') out.answer = argv[++i];
+    else if (a === '--authority') out.authority = argv[++i];
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const result = await bindConsultAnswer(supabase, args);
+  console.log(`Consult answer bound: question_key=${result.disposition.payload.question_key}, SD "${args.sdKey}".${args.blockedStateKey} unblocked.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('consult-answer-bind: FAILED:', err.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/apa-fixture-ratification-capture.test.js
+++ b/tests/unit/apa-fixture-ratification-capture.test.js
@@ -74,4 +74,23 @@ describe('captureRatifications (FR-3)', () => {
     await captureRatifications(sb, { fixtureSet: 'set-2', confirmed: ['G1'], flagged: [], authority: 'a' });
     expect(sb._rows).toHaveLength(2);
   });
+
+  it('reports the ACTUAL stored verdict (not the caller-intended one) when a re-run contradicts a prior disposition', async () => {
+    const sb = makeFakeSupabase();
+    await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: [], flagged: ['G3'], authority: 'chairman' });
+    // Chairman changes his mind: G3 is now re-run as confirmed. recordDisposition never
+    // overwrites, so the stored row is still the ORIGINAL flagged decision.
+    const second = await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G3'], flagged: [], authority: 'chairman' });
+    expect(sb._rows).toHaveLength(1); // no duplicate row
+    expect(second[0].verdict).toBe('flagged'); // reports the TRUE stored verdict, not "confirmed"
+    expect(second[0].contradicted).toBe(true);
+  });
+
+  it('does not flag contradicted when the re-run verdict matches the stored one', async () => {
+    const sb = makeFakeSupabase();
+    await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G1'], flagged: [], authority: 'chairman' });
+    const second = await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G1'], flagged: [], authority: 'chairman' });
+    expect(second[0].verdict).toBe('confirmed');
+    expect(second[0].contradicted).toBe(false);
+  });
 });

--- a/tests/unit/apa-fixture-ratification-capture.test.js
+++ b/tests/unit/apa-fixture-ratification-capture.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001 FR-3 — apa-fixture-ratification-capture.mjs
+ */
+import { describe, it, expect } from 'vitest';
+import { captureRatifications } from '../../scripts/apa-fixture-ratification-capture.mjs';
+
+function makeFakeSupabase() {
+  const rows = [];
+  let nextId = 1;
+  return {
+    _rows: rows,
+    from(table) {
+      if (table !== 'system_events') throw new Error(`unexpected table ${table}`);
+      return {
+        insert(row) {
+          return {
+            select: () => ({
+              single: () => {
+                if (rows.some((r) => r.idempotency_key === row.idempotency_key)) {
+                  return Promise.resolve({ data: null, error: { code: '23505', message: 'dup' } });
+                }
+                const stored = { id: `evt-${nextId++}`, created_at: new Date().toISOString(), ...row };
+                rows.push(stored);
+                return Promise.resolve({ data: stored, error: null });
+              },
+            }),
+          };
+        },
+        select() {
+          let filtered = [...rows];
+          const builder = {
+            eq(col, val) {
+              filtered = filtered.filter((r) => r[col] === val);
+              return builder;
+            },
+            maybeSingle: () => Promise.resolve({ data: filtered[0] ?? null, error: null }),
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+describe('captureRatifications (FR-3)', () => {
+  it('records a dispositioned row per confirmed and per flagged fixture', async () => {
+    const sb = makeFakeSupabase();
+    const results = await captureRatifications(sb, {
+      fixtureSet: 'apa-calibration-2026-07-08',
+      confirmed: ['G1', 'G2'],
+      flagged: ['G3'],
+      authority: 'chairman',
+    });
+    expect(results).toHaveLength(3);
+    expect(sb._rows).toHaveLength(3);
+    const g3 = sb._rows.find((r) => r.payload.subject.fixture_id === 'G3');
+    expect(g3.payload.answer_payload).toEqual({ confirmed: false, flagged: true });
+    const g1 = sb._rows.find((r) => r.payload.subject.fixture_id === 'G1');
+    expect(g1.payload.answer_payload).toEqual({ confirmed: true, flagged: false });
+    expect(g1.payload.status).toBe('dispositioned');
+  });
+
+  it('is idempotent: re-running with the same fixture-set + fixture_id dedups instead of duplicating', async () => {
+    const sb = makeFakeSupabase();
+    await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G1'], flagged: [], authority: 'chairman' });
+    const second = await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G1'], flagged: [], authority: 'chairman' });
+    expect(sb._rows).toHaveLength(1);
+    expect(second[0].created).toBe(false);
+  });
+
+  it('keys distinct fixture-sets independently (no cross-set collision)', async () => {
+    const sb = makeFakeSupabase();
+    await captureRatifications(sb, { fixtureSet: 'set-1', confirmed: ['G1'], flagged: [], authority: 'a' });
+    await captureRatifications(sb, { fixtureSet: 'set-2', confirmed: ['G1'], flagged: [], authority: 'a' });
+    expect(sb._rows).toHaveLength(2);
+  });
+});

--- a/tests/unit/consult-answer-bind.test.js
+++ b/tests/unit/consult-answer-bind.test.js
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001 FR-4 — consult-answer-bind.mjs
+ */
+import { describe, it, expect } from 'vitest';
+import { bindConsultAnswer } from '../../scripts/consult-answer-bind.mjs';
+
+function makeFakeSupabase({ initialSdMetadata = {} } = {}) {
+  const events = [];
+  let sdMetadata = { ...initialSdMetadata };
+  let nextId = 1;
+  return {
+    _events: events,
+    _sdMetadata: () => sdMetadata,
+    from(table) {
+      if (table === 'system_events') {
+        return {
+          insert(row) {
+            return {
+              select: () => ({
+                single: () => {
+                  if (events.some((r) => r.idempotency_key === row.idempotency_key)) {
+                    return Promise.resolve({ data: null, error: { code: '23505', message: 'dup' } });
+                  }
+                  const stored = { id: `evt-${nextId++}`, created_at: new Date().toISOString(), ...row };
+                  events.push(stored);
+                  return Promise.resolve({ data: stored, error: null });
+                },
+              }),
+            };
+          },
+          select() {
+            let filtered = [...events];
+            const builder = {
+              eq(col, val) {
+                filtered = filtered.filter((r) => r[col] === val);
+                return builder;
+              },
+              maybeSingle: () => Promise.resolve({ data: filtered[0] ?? null, error: null }),
+            };
+            return builder;
+          },
+        };
+      }
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { metadata: sdMetadata }, error: null }),
+            }),
+          }),
+          update: (patch) => ({
+            eq: () => {
+              sdMetadata = patch.metadata;
+              return Promise.resolve({ error: null });
+            },
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+describe('bindConsultAnswer (FR-4)', () => {
+  it('records a disposition AND flips the named SD-metadata blocked-state field in one call', async () => {
+    const sb = makeFakeSupabase({ initialSdMetadata: { blocked_on_solomon_consult: true, unrelated: 'x' } });
+    const result = await bindConsultAnswer(sb, {
+      sdKey: 'SD-TEST-001',
+      blockedStateKey: 'blocked_on_solomon_consult',
+      questionText: 'Should Solomon own the belt-tiering rollback?',
+      answer: 'Yes, Solomon owns it.',
+      authority: 'solomon',
+    });
+    expect(result.sdUpdated).toBe(true);
+    expect(sb._sdMetadata().blocked_on_solomon_consult).toBe(false);
+    expect(sb._sdMetadata().unrelated).toBe('x'); // untouched fields preserved
+    expect(sb._sdMetadata().blocked_on_solomon_consult_disposition_question_key).toBe(result.disposition.payload.question_key);
+  });
+
+  it('TS-2-style REGRESSION: re-asking the identical question in a fresh call dedups against the same disposition', async () => {
+    const sb = makeFakeSupabase({ initialSdMetadata: { blocked_on_x: true } });
+    const first = await bindConsultAnswer(sb, {
+      sdKey: 'SD-TEST-001', blockedStateKey: 'blocked_on_x',
+      questionText: 'Ship it?', answer: 'Yes', authority: 'session-A',
+    });
+    const second = await bindConsultAnswer(sb, {
+      sdKey: 'SD-TEST-001', blockedStateKey: 'blocked_on_x',
+      questionText: 'Ship it?', answer: 'Yes (re-delivered)', authority: 'session-B',
+    });
+    expect(sb._events).toHaveLength(1);
+    expect(second.disposition.id).toBe(first.disposition.id);
+  });
+
+  it('throws when required args are missing', async () => {
+    const sb = makeFakeSupabase();
+    await expect(bindConsultAnswer(sb, { sdKey: 'SD-TEST-001' })).rejects.toThrow(/blockedStateKey/);
+  });
+});

--- a/tests/unit/consult-answer-bind.test.js
+++ b/tests/unit/consult-answer-bind.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import { bindConsultAnswer } from '../../scripts/consult-answer-bind.mjs';
 
-function makeFakeSupabase({ initialSdMetadata = {} } = {}) {
+function makeFakeSupabase({ initialSdMetadata = {}, knownSdKeys = ['SD-TEST-001'] } = {}) {
   const events = [];
   let sdMetadata = { ...initialSdMetadata };
   let nextId = 1;
@@ -49,10 +49,15 @@ function makeFakeSupabase({ initialSdMetadata = {} } = {}) {
             }),
           }),
           update: (patch) => ({
-            eq: () => {
-              sdMetadata = patch.metadata;
-              return Promise.resolve({ error: null });
-            },
+            eq: (col, val) => ({
+              select: () => {
+                if (!knownSdKeys.includes(val)) {
+                  return Promise.resolve({ data: [], error: null }); // zero-row-match simulation
+                }
+                sdMetadata = patch.metadata;
+                return Promise.resolve({ data: [{ sd_key: val }], error: null });
+              },
+            }),
           }),
         };
       }
@@ -94,5 +99,29 @@ describe('bindConsultAnswer (FR-4)', () => {
   it('throws when required args are missing', async () => {
     const sb = makeFakeSupabase();
     await expect(bindConsultAnswer(sb, { sdKey: 'SD-TEST-001' })).rejects.toThrow(/blockedStateKey/);
+  });
+
+  it('throws instead of silently succeeding when the metadata update matches 0 rows (stale/mismatched sd_key)', async () => {
+    const sb = makeFakeSupabase({ knownSdKeys: [] }); // no SD matches -- simulates a stale sd_key
+    await expect(bindConsultAnswer(sb, {
+      sdKey: 'SD-DOES-NOT-EXIST-001', blockedStateKey: 'blocked_on_x',
+      questionText: 'Ship it?', answer: 'Yes', authority: 'session-A',
+    })).rejects.toThrow(/matched 0 rows/);
+  });
+
+  it('scopes question_key by (sdKey, blockedStateKey) so two DIFFERENT SDs asking an identically-worded question do NOT collide', async () => {
+    const sb = makeFakeSupabase({ knownSdKeys: ['SD-A-001', 'SD-B-001'] });
+    const forA = await bindConsultAnswer(sb, {
+      sdKey: 'SD-A-001', blockedStateKey: 'blocked_on_x',
+      questionText: 'Should we proceed?', answer: 'Yes for A', authority: 'solomon',
+    });
+    const forB = await bindConsultAnswer(sb, {
+      sdKey: 'SD-B-001', blockedStateKey: 'blocked_on_x',
+      questionText: 'Should we proceed?', answer: 'Yes for B', authority: 'solomon',
+    });
+    expect(sb._events).toHaveLength(2); // two DISTINCT disposition rows, not deduped
+    expect(forA.disposition.id).not.toBe(forB.disposition.id);
+    expect(forA.disposition.payload.answer_payload.answer).toBe('Yes for A');
+    expect(forB.disposition.payload.answer_payload.answer).toBe('Yes for B');
   });
 });

--- a/tests/unit/decision-binding-disposition.test.js
+++ b/tests/unit/decision-binding-disposition.test.js
@@ -1,0 +1,222 @@
+/**
+ * SD-LEO-INFRA-DECISION-BINDING-PRIMITIVE-001 — lib/decision-binding/disposition.js
+ * Injected-stub coverage (no real DB). Covers FR-1/FR-2/FR-5 and the TS-2
+ * regression: a re-asked question (same content, new correlation_id/session)
+ * must dedup against the existing disposition row.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeQuestionKey,
+  recordDisposition,
+  getDisposition,
+  getDispositionBySubject,
+  updateDispositionStatus,
+  listAwaitingDisposition,
+} from '../../lib/decision-binding/disposition.js';
+
+/** In-memory fake of the system_events surface this module touches. */
+function makeFakeSupabase() {
+  const rows = [];
+  let nextId = 1;
+
+  function insert(row) {
+    if (rows.some((r) => r.idempotency_key === row.idempotency_key)) {
+      return { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint' } };
+    }
+    const stored = { id: `evt-${nextId++}`, created_at: new Date().toISOString(), ...row };
+    rows.push(stored);
+    return { data: stored, error: null };
+  }
+
+  return {
+    _rows: rows,
+    from(table) {
+      if (table !== 'system_events') throw new Error(`unexpected table ${table}`);
+      return {
+        insert(row) {
+          const result = insert(row);
+          return {
+            select: () => ({
+              single: () => Promise.resolve(result),
+            }),
+          };
+        },
+        select() {
+          let filtered = [...rows];
+          const builder = {
+            eq(col, val) {
+              filtered = filtered.filter((r) => {
+                if (col === 'payload->>decision_type') return r.payload?.decision_type === val;
+                if (col === 'payload->>status') return r.payload?.status === val;
+                return r[col] === val;
+              });
+              return builder;
+            },
+            order() {
+              filtered.sort((a, b) => a.created_at.localeCompare(b.created_at));
+              return Promise.resolve({ data: filtered, error: null });
+            },
+            maybeSingle() {
+              return Promise.resolve({ data: filtered[0] ?? null, error: null });
+            },
+          };
+          return builder;
+        },
+        update(patch) {
+          return {
+            eq: (col, val) => ({
+              select: () => ({
+                single: () => {
+                  const idx = rows.findIndex((r) => r[col] === val);
+                  if (idx === -1) return Promise.resolve({ data: null, error: { message: 'not found' } });
+                  rows[idx] = { ...rows[idx], ...patch };
+                  return Promise.resolve({ data: rows[idx], error: null });
+                },
+              }),
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('computeQuestionKey (FR-2)', () => {
+  it('is stable across different key ORDER in the subject object', () => {
+    const k1 = computeQuestionKey('ratification', { fixture_set_id: 'set-1', fixture_id: 'G1' });
+    const k2 = computeQuestionKey('ratification', { fixture_id: 'G1', fixture_set_id: 'set-1' });
+    expect(k1).toBe(k2);
+  });
+
+  it('never reads correlation_id or message_id even if present on the subject', () => {
+    const withCorr = computeQuestionKey('consult_answer', { question_text: 'ship it?', correlation_id: 'aaa' });
+    const withDiffCorr = computeQuestionKey('consult_answer', { question_text: 'ship it?', correlation_id: 'bbb' });
+    // Different correlation_id embedded in subject still changes the hash (it's just data) —
+    // the real invariant under test is that the SD's own call sites never pass correlation_id
+    // as part of the identifying subject in the first place (see recordDisposition tests below).
+    expect(typeof withCorr).toBe('string');
+    expect(withCorr.startsWith('dq_')).toBe(true);
+    expect(withCorr).not.toBe(withDiffCorr); // sanity: hash responds to subject content
+  });
+
+  it('produces DISTINCT keys for distinct subject content (no false collision)', () => {
+    const k1 = computeQuestionKey('ratification', { fixture_set_id: 'set-1', fixture_id: 'G1' });
+    const k2 = computeQuestionKey('ratification', { fixture_set_id: 'set-1', fixture_id: 'G2' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('rejects an invalid decisionType', () => {
+    expect(() => computeQuestionKey('bogus', {})).toThrow(/invalid decisionType/);
+  });
+});
+
+describe('recordDisposition + getDisposition (FR-1)', () => {
+  it('creates a new row with status=awaiting_disposition when none exists', async () => {
+    const sb = makeFakeSupabase();
+    const { row, created } = await recordDisposition(sb, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: 'set-1', fixture_id: 'G1' },
+      decisionKey: 'set-1:G1:ratification',
+    });
+    expect(created).toBe(true);
+    expect(row.payload.status).toBe('awaiting_disposition');
+    expect(row.payload.decided_at).toBeNull();
+  });
+
+  it('defaults to status=dispositioned when an answerPayload is provided at creation', async () => {
+    const sb = makeFakeSupabase();
+    const { row } = await recordDisposition(sb, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: 'set-1', fixture_id: 'G1' },
+      answerPayload: { confirmed: true },
+      authority: 'chairman',
+    });
+    expect(row.payload.status).toBe('dispositioned');
+    expect(row.payload.decided_at).not.toBeNull();
+    expect(row.payload.answer_payload).toEqual({ confirmed: true });
+  });
+
+  it('getDisposition returns null (not throw) for a question_key with no row — fail-closed', async () => {
+    const sb = makeFakeSupabase();
+    const result = await getDisposition(sb, 'dq_nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('TS-2 REGRESSION: a re-asked question (same content, new correlation_id/session) dedups against the existing row', async () => {
+    const sb = makeFakeSupabase();
+
+    // Session A asks the question, keyed purely on content.
+    const first = await recordDisposition(sb, {
+      decisionType: 'consult_answer',
+      subject: { question_text: 'Should Solomon own the belt-tiering rollback?' },
+      authority: 'session-A-correlation-111',
+    });
+    expect(first.created).toBe(true);
+
+    // A brand-new "session" re-asks the IDENTICAL question — simulated by a
+    // fresh recordDisposition call carrying a totally different authority/
+    // correlation identity, but the SAME subject content.
+    const second = await recordDisposition(sb, {
+      decisionType: 'consult_answer',
+      subject: { question_text: 'Should Solomon own the belt-tiering rollback?' },
+      authority: 'session-B-correlation-999',
+    });
+
+    expect(second.created).toBe(false); // dedup: no new row
+    expect(second.row.id).toBe(first.row.id);
+    expect(sb._rows).toHaveLength(1); // exactly one disposition row total
+  });
+
+  it('does not collide across genuinely distinct questions', async () => {
+    const sb = makeFakeSupabase();
+    await recordDisposition(sb, { decisionType: 'consult_answer', subject: { question_text: 'Question A?' } });
+    await recordDisposition(sb, { decisionType: 'consult_answer', subject: { question_text: 'Question B?' } });
+    expect(sb._rows).toHaveLength(2);
+  });
+
+  it('getDispositionBySubject finds the row without the caller precomputing the key', async () => {
+    const sb = makeFakeSupabase();
+    const subject = { fixture_set_id: 'set-1', fixture_id: 'B3' };
+    await recordDisposition(sb, { decisionType: 'ratification', subject });
+    const found = await getDispositionBySubject(sb, 'ratification', subject);
+    expect(found).not.toBeNull();
+  });
+});
+
+describe('updateDispositionStatus', () => {
+  it('transitions dispositioned -> consumed and preserves prior answer_payload when not overridden', async () => {
+    const sb = makeFakeSupabase();
+    const { row } = await recordDisposition(sb, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: 'set-1', fixture_id: 'G1' },
+      answerPayload: { confirmed: true },
+    });
+    const updated = await updateDispositionStatus(sb, row.payload.question_key, 'consumed');
+    expect(updated.payload.status).toBe('consumed');
+    expect(updated.payload.answer_payload).toEqual({ confirmed: true });
+  });
+
+  it('throws for an unknown question_key', async () => {
+    const sb = makeFakeSupabase();
+    await expect(updateDispositionStatus(sb, 'dq_missing', 'consumed')).rejects.toThrow(/no disposition found/);
+  });
+});
+
+describe('listAwaitingDisposition (FR-5)', () => {
+  it('returns only awaiting rows for the requested decision_type, no rendering logic', async () => {
+    const sb = makeFakeSupabase();
+    await recordDisposition(sb, { decisionType: 'ratification', subject: { fixture_set_id: 's', fixture_id: 'G1' } });
+    await recordDisposition(sb, { decisionType: 'ratification', subject: { fixture_set_id: 's', fixture_id: 'G2' }, answerPayload: { confirmed: true } });
+    await recordDisposition(sb, { decisionType: 'consult_answer', subject: { question_text: 'unrelated?' } });
+
+    const awaiting = await listAwaitingDisposition(sb, 'ratification');
+    expect(awaiting).toHaveLength(1);
+    expect(awaiting[0].payload.subject.fixture_id).toBe('G1');
+  });
+
+  it('returns an empty array for an unknown decision_type instead of throwing', async () => {
+    const sb = makeFakeSupabase();
+    const result = await listAwaitingDisposition(sb, 'not_a_real_type');
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a durable decision-binding disposition primitive (`lib/decision-binding/disposition.js`), keyed on a session-stable, content-derived `question_key` (never `correlation_id`, which rotates per session and is why re-asked questions were invisible to dedup).
- Storage: existing `system_events` table (non-DDL Phase-1 constraint honored) — reuses its pre-existing `idempotency_key` UNIQUE constraint for DB-enforced dedup.
- Consumer 1 (FR-3): `scripts/apa-fixture-ratification-capture.mjs` closes the APA fixture review packet's visual-only Confirm/Flag-for-swap button gap (persists ratification decisions).
- Consumer 2 (FR-4): `scripts/consult-answer-bind.mjs` closes Solomon's Mode-B ANSWER-DELIVERED-not-CONSUMER-UNBLOCKED finding — binds a consult answer AND flips the named `strategic_directives_v2.metadata` blocked-state field in one call.
- 20 unit tests, including a regression test proving a re-asked question (same content, new correlation_id/session) dedups against the existing row instead of creating a duplicate.
- Live-DB smoke test confirmed cross-process durability and dedup against the real `system_events` table (not committed; cleaned up).

## Test plan
- [x] 20/20 new unit tests pass (`tests/unit/decision-binding-disposition.test.js`, `tests/unit/apa-fixture-ratification-capture.test.js`, `tests/unit/consult-answer-bind.test.js`)
- [x] Live-DB smoke test: record → readback from fresh process → re-ask dedup → cleanup, all verified against real `system_events`
- [x] VALIDATION sub-agent PASS (95% confidence) — all 5 FRs trace to working code, non-DDL constraint honored
- [x] REGRESSION sub-agent PASS (96% confidence) — purely additive (810 insertions, 0 deletions), no event_type/idempotency_key collision with existing consumers
- [x] 3 pre-existing unrelated unit-test failures identified, confirmed untouched by this commit, logged as harness-backlog (feedback rows `0f7acda1` and `f5bbeb06`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)