### PR TITLE
fix(SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001): parent-lifecycle guard on orphan adoption

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -998,7 +998,9 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       // resume message (advisory — sd-start reads the live phase authoritatively on attach).
       // target_application added for the SD-LEO-INFRA-WORKER-CLAIM-TIME-001 claim-time repo-match
       // axis so a repo-mismatched orphan is not adopted into the wrong checkout.
-      .select('sd_key, sd_type, status, current_phase, metadata, updated_at, target_application')
+      // parent_sd_id added (SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001): feeds the parentLeadPending
+      // guard below so a CHILD orphan whose orchestrator parent is still pre-LEAD is not adopted.
+      .select('sd_key, sd_type, status, current_phase, metadata, updated_at, target_application, parent_sd_id')
       .eq('status', 'in_progress')
       .is('claiming_session_id', null)
       .neq('sd_type', 'orchestrator')         // parents are in_progress/no-claim BY DESIGN while children run
@@ -1011,6 +1013,13 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       // metadata.requires_human_action all skip. SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): {cwd}
       // adds the claim-time fitness axes so a repo-mismatched orphan is not adopted here.
       if (classifyDispatchIneligibility(sd, { cwd: process.cwd() }) !== null) continue;
+      // SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001: parent-lifecycle guard. classifyDispatchIneligibility
+      // excludes orchestrator-parents/test-fixtures/human-action/live-held but NOT a CHILD whose
+      // orchestrator parent is still pre-LEAD — adopting one only burns PLAN cycles before the hard
+      // 'child cannot enter EXEC until parent completes LEAD' block, then re-orphans (witnessed:
+      // ...ASSESSMENT-001-A re-adopted twice under a draft/LEAD parent). Reuse the same shared
+      // predicate the self-claim + draft tiers apply (evaluateDispatchEligibility). Fails open.
+      if (await parentLeadPending(sb, sd)) continue;
       // Live-foreign-holder probe (the half-write case: SD-side claim cleared but a LIVE session
       // still points at it via claude_sessions.sd_key). SD-LEO-INFRA-RECLAIM-STEAL-LIVE-CLAIMANT-
       // WIP-GUARD-001 (FR-3): the raw is_alive flag alone under-protects (it FREEZES stale between

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -35,6 +35,9 @@ function makeStub(cfg) {
       eq(k, v) { state.filters[k] = v; return chain; },
       in(k, v) { state.filters[k] = v; return chain; },
       neq(k, v) { state.filters['neq_' + k] = v; return chain; },
+      // parentLeadPending (SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001) looks the parent up via
+      // .or('id.eq.<ref>,sd_key.eq.<ref>'); capture the ref so resolveSingle can return the parent row.
+      or(expr) { const m = /(?:id|sd_key)\.eq\.([^,]+)/.exec(String(expr || '')); if (m) state.filters.or_ref = m[1]; return chain; },
       lt(k, v) { state.filters['lt_' + k] = v; return chain; },
       gte() { return chain; },
       is() { return chain; },
@@ -51,7 +54,10 @@ function makeStub(cfg) {
       // isSdInFlight (a): SELECT current_phase ... WHERE sd_key=? .maybeSingle()
       if (table === 'strategic_directives_v2') {
         if (cfg.inFlightThrow) return Promise.reject(new Error('isSdInFlight query failed'));
-        return Promise.resolve({ data: (cfg.sdRows && cfg.sdRows[state.filters.sd_key]) || null, error: null });
+        // or_ref => parentLeadPending's parent lookup (keyed by parent id/sd_key); else the
+        // isSdInFlight / resume-path lookup keyed by sd_key. Both read from cfg.sdRows.
+        const key = state.filters.or_ref || state.filters.sd_key;
+        return Promise.resolve({ data: (cfg.sdRows && cfg.sdRows[key]) || null, error: null });
       }
       // SD-LEO-INFRA-WORKER-CHECKIN-TEST-REGRESSION-001: the resume path (and confirmRowGone) reads
       // quick_fixes.status by id .maybeSingle() to verify a claimed QF is still resumable. Seed it via
@@ -693,6 +699,48 @@ describe('ORPHAN-ADOPTION: adopt zero-claim in_progress SDs (resume_orphan)', ()
     });
     const r = await runCheckin(sb, 'sess-1', noCoord);
     expect(r.action).toBe('idle'); // both classifier-skipped despite being claimable
+  });
+
+  // SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001: parent-lifecycle guard on orphan adoption. A CHILD
+  // orphan whose orchestrator parent has not yet passed LEAD cannot enter EXEC, so adopting it
+  // only burns PLAN cycles and re-orphans. parentLeadPending (the same predicate the self-claim +
+  // draft tiers use) now gates the orphan-adopt path too. (The real fix also adds parent_sd_id to
+  // the orphan query .select(...) so the guard sees the link; the stub returns full rows, so these
+  // tests exercise the guard logic — the select projection is covered by PRD FR-2 + code review.)
+  it('excludes a CHILD orphan whose orchestrator parent is still pre-LEAD (draft/LEAD)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-CHILD-PRELEAD-001', { parent_sd_id: 'SD-PARENT-PRELEAD-001' })],
+      sdRows: { 'SD-PARENT-PRELEAD-001': { status: 'draft', current_phase: 'LEAD' } },
+      candidates: [],
+      claimResults: { 'SD-CHILD-PRELEAD-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle'); // parentLeadPending skips it despite being otherwise claimable
+  });
+
+  it('adopts a CHILD orphan whose parent has COMPLETED (parentLeadPending → false)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-CHILD-DONE-001', { parent_sd_id: 'SD-PARENT-DONE-001' })],
+      sdRows: { 'SD-PARENT-DONE-001': { status: 'completed', current_phase: 'COMPLETED' } },
+      candidates: [],
+      claimResults: { 'SD-CHILD-DONE-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
+    expect(r.sd).toBe('SD-CHILD-DONE-001');
+  });
+
+  it('still adopts a NON-child orphan (no parent_sd_id — the guard no-ops, no regression)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-STANDALONE-ORPHAN-001')], // no parent_sd_id
+      candidates: [],
+      claimResults: { 'SD-STANDALONE-ORPHAN-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
   });
 
   // SD-LEO-INFRA-RECLAIM-STEAL-LIVE-CLAIMANT-WIP-GUARD-001 (FR-3): a lapsed/half-write claim's


### PR DESCRIPTION
## Summary
`adoptOrphanInProgress` (worker-checkin) adopted orphaned in_progress SDs but did not check parent lifecycle for **child** SDs — it excluded orchestrator-parents/fixtures/human-action/live-held (via `classifyDispatchIneligibility`) but not a child whose orchestrator parent is still **pre-LEAD** (draft/LEAD). Such a child can't enter EXEC until the parent clears LEAD, so adoption burned PLAN cycles and re-orphaned (witnessed: …ASSESSMENT-001-A re-adopted twice under a draft parent).

**Fix (2 lines of behavior):**
- Apply the shared `parentLeadPending(sb, sd)` predicate — the same one the self-claim + draft tiers use — in the orphan-adopt loop.
- Add `parent_sd_id` to the orphan candidate query `.select(...)` so the guard can resolve the child→parent link (without it the guard would silently no-op).

Fails open: non-child orphans, completed-parent children, and parent-lookup errors all still adopt (no regression).

## Test plan
`npx vitest run scripts/worker-checkin.test.js` → **86 passed** (83 existing + 3 new): skip a pre-LEAD-parent child orphan; adopt a completed-parent child orphan; adopt a non-child orphan. Added `.or()` support to the test mock for the parent lookup.

Reporter: worker e2ef1d11 (signal 83995a34); instance stopgapped by Hotel-2 (requires_human_action=true on the child) — can be lifted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)