### PR TITLE
feat(SD-LEO-INFRA-APA-BOUNDARY-MATERIAL-001): boundary-material shelf schema + assembler guard (PART A)

### DIFF
--- a/docs/design/apa-boundary-material-shelf/manifest.json
+++ b/docs/design/apa-boundary-material-shelf/manifest.json
@@ -1,0 +1,5 @@
+{
+  "$schema_note": "APA Boundary-Material Shelf — durable, versioned source of floor-edge (sub-award) calibration fixtures. Each entry is a live-site capture (format='capture_png', consumed by SD-LEO-INFRA-APA-FIXTURE-HARNESS-001) BANDED relative to the ~4.0 pass/fail floor: 'above' (~4.1, just-above), 'on_line' (~4.0), 'below' (~3.8, just-below). The assembler is FORBIDDEN from drawing an all-same-side selection (see lib/apa/boundary-material-shelf.mjs assertBandDiversity). Each entry MUST carry craft_justification + a11y_notes (anti-reputation-confabulation discipline). entries[] is intentionally EMPTY at v1: PART A of SD-LEO-INFRA-APA-BOUNDARY-MATERIAL-001 ships the durable versioned container + schema + selection guard; populating it (live-site capture + design-banding + the pixel-level brand-strip scan) is the fenced curation follow-up.",
+  "shelf_version": 1,
+  "entries": []
+}

--- a/lib/apa/boundary-material-shelf.mjs
+++ b/lib/apa/boundary-material-shelf.mjs
@@ -1,0 +1,102 @@
+// APA Boundary-Material Shelf — durable versioned floor-edge fixture source.
+// SD-LEO-INFRA-APA-BOUNDARY-MATERIAL-001 (PART A: dependency-free schema + assembler guard).
+//
+// The APA calibration set needs BOUNDARY fixtures: real-world, sub-award screens sitting right
+// at the pass/fail line. This module is the durable, versioned CONTAINER + the selection GUARD.
+// It consumes the `capture_png` fixture format from SD-LEO-INFRA-APA-FIXTURE-HARNESS-001.
+//
+// SCOPE NOTE (PART A only): this ships the schema (data contract), the shelf loader/validator, and
+// the assembler "forbidden all-same-side" band-diversity guard — the piece that prevents the exact
+// failure the first swap-round set hit. FENCED as follow-ups (see the SD): the pixel-level
+// baked-in-raster brand-strip SCANNER (needs an OCR dependency decision) and the actual curation /
+// live-site capture / design-banding of real floor-edge screens (APA-cluster, taste-gated).
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/** The three floor-edge bands, ordered above→line→below. */
+export const SHELF_BANDS = Object.freeze(['above', 'on_line', 'below']);
+
+/** Bands on the "pass" side vs the "fail" side of the ~4.0 floor. `on_line` is the line itself. */
+const ABOVE_SIDE = new Set(['above']);
+const BELOW_SIDE = new Set(['below']);
+
+/** Canonical on-disk location of the versioned shelf manifest. */
+export const SHELF_MANIFEST_PATH = path.resolve('docs/design/apa-boundary-material-shelf/manifest.json');
+
+/**
+ * Validate a single shelf entry against the boundary-material data contract.
+ * Throws with a descriptive message on the first violation; returns true when valid.
+ */
+export function validateShelfEntry(entry, index = 0) {
+  const where = `shelf entry [${index}]${entry && entry.id ? ` (${entry.id})` : ''}`;
+  if (!entry || typeof entry !== 'object') throw new Error(`${where}: not an object`);
+  if (!entry.id || typeof entry.id !== 'string') throw new Error(`${where}: missing string 'id'`);
+  // Boundary material is always a live-site capture — no hand-authored HTML wrapper.
+  if (entry.format !== 'capture_png') throw new Error(`${where}: format must be 'capture_png' (got '${entry.format}')`);
+  if (!SHELF_BANDS.includes(entry.band)) {
+    throw new Error(`${where}: band must be one of ${SHELF_BANDS.join('|')} (got '${entry.band}')`);
+  }
+  // Per-band craft justification + a11y notes are MANDATORY (the anti-reputation-confabulation
+  // discipline: every floor-edge pick must carry why it sits at its band, and its a11y read).
+  if (!entry.craft_justification || !String(entry.craft_justification).trim()) {
+    throw new Error(`${where}: missing non-empty 'craft_justification'`);
+  }
+  if (entry.a11y_notes === undefined || entry.a11y_notes === null || !String(entry.a11y_notes).trim()) {
+    throw new Error(`${where}: missing non-empty 'a11y_notes'`);
+  }
+  return true;
+}
+
+/**
+ * Validate the whole shelf manifest shape: a versioned container with an entries[] array.
+ * Every entry must pass validateShelfEntry. Returns the parsed shelf on success.
+ */
+export function validateShelf(shelf) {
+  if (!shelf || typeof shelf !== 'object') throw new Error('shelf: not an object');
+  if (typeof shelf.shelf_version !== 'number' || shelf.shelf_version < 1) {
+    throw new Error(`shelf: 'shelf_version' must be a positive number (got ${JSON.stringify(shelf.shelf_version)})`);
+  }
+  if (!Array.isArray(shelf.entries)) throw new Error("shelf: 'entries' must be an array");
+  shelf.entries.forEach((e, i) => validateShelfEntry(e, i));
+  return shelf;
+}
+
+/** Load + validate the versioned shelf manifest from disk (default: SHELF_MANIFEST_PATH). */
+export async function loadShelf(manifestPath = SHELF_MANIFEST_PATH) {
+  const raw = await readFile(manifestPath, 'utf8');
+  return validateShelf(JSON.parse(raw));
+}
+
+/**
+ * The assembler's "FORBIDDEN all-same-side" guard.
+ *
+ * A boundary selection that sits entirely on one side of the floor (all `above`, or all `below`)
+ * does NOT test the floor edge — it was the exact failure the first swap-round set hit. A valid
+ * selection must (a) be non-empty, (b) span at least 2 distinct bands, and (c) NOT be all-on-one-
+ * side (not exclusively `above` and not exclusively `below`; an `on_line` fixture straddles). Throws
+ * on violation; returns { bands, warnings } on success (warns when fewer than all 3 bands present).
+ */
+export function assertBandDiversity(selection) {
+  if (!Array.isArray(selection) || selection.length === 0) {
+    throw new Error('boundary selection: must be a non-empty array of shelf entries');
+  }
+  const bands = selection.map((e, i) => {
+    if (!SHELF_BANDS.includes(e && e.band)) throw new Error(`boundary selection [${i}]: invalid band '${e && e.band}'`);
+    return e.band;
+  });
+  const distinct = new Set(bands);
+  if (distinct.size < 2) {
+    throw new Error(`FORBIDDEN all-same-side selection: only band '${[...distinct][0]}' present — a floor-edge test must span >=2 bands (${SHELF_BANDS.join('|')})`);
+  }
+  const allAbove = bands.every((b) => ABOVE_SIDE.has(b));
+  const allBelow = bands.every((b) => BELOW_SIDE.has(b));
+  if (allAbove || allBelow) {
+    throw new Error(`FORBIDDEN all-same-side selection: every fixture is on the '${allAbove ? 'above' : 'below'}' side of the floor — include an on_line and/or opposite-side pick`);
+  }
+  const warnings = [];
+  if (distinct.size < SHELF_BANDS.length) {
+    warnings.push(`selection spans ${distinct.size}/${SHELF_BANDS.length} bands (${[...distinct].join(',')}) — one-per-band (above,on_line,below) is the recommended minimum`);
+  }
+  return { bands: [...distinct], warnings };
+}

--- a/tests/unit/apa-boundary-material-shelf.test.js
+++ b/tests/unit/apa-boundary-material-shelf.test.js
@@ -6,6 +6,7 @@ import {
   validateShelfEntry,
   validateShelf,
   assertBandDiversity,
+  loadShelf,
 } from '../../lib/apa/boundary-material-shelf.mjs';
 
 // SD-LEO-INFRA-APA-BOUNDARY-MATERIAL-001 (PART A): schema + assembler band-diversity guard.
@@ -31,6 +32,11 @@ describe('boundary-material shelf: entry schema', () => {
     expect(() => validateShelfEntry(entry({ craft_justification: '' }))).toThrow(/craft_justification/);
     expect(() => validateShelfEntry(entry({ a11y_notes: '  ' }))).toThrow(/a11y_notes/);
   });
+  it('rejects a non-object entry and a missing/non-string id', () => {
+    expect(() => validateShelfEntry(null)).toThrow(/not an object/);
+    expect(() => validateShelfEntry(entry({ id: undefined }))).toThrow(/id/);
+    expect(() => validateShelfEntry(entry({ id: 42 }))).toThrow(/id/);
+  });
 });
 
 describe('boundary-material shelf: manifest shape', () => {
@@ -48,6 +54,12 @@ describe('boundary-material shelf: manifest shape', () => {
     expect(shelf.shelf_version).toBe(1);
     expect(shelf.entries).toEqual([]);
   });
+  it('loadShelf() reads + validates the committed manifest via its own async path', async () => {
+    const shelf = await loadShelf();
+    expect(shelf.shelf_version).toBe(1);
+    expect(shelf.entries).toEqual([]);
+    await expect(loadShelf(path.resolve('docs/design/apa-boundary-material-shelf/nope.json'))).rejects.toThrow();
+  });
 });
 
 describe('boundary-material shelf: assembler FORBIDDEN all-same-side guard', () => {
@@ -62,6 +74,9 @@ describe('boundary-material shelf: assembler FORBIDDEN all-same-side guard', () 
   });
   it('rejects an empty selection', () => {
     expect(() => assertBandDiversity([])).toThrow(/non-empty/);
+  });
+  it('rejects a selection containing an invalid band', () => {
+    expect(() => assertBandDiversity([entry({ band: 'above' }), entry({ band: 'nope' })])).toThrow(/invalid band/);
   });
   it('accepts an above+below selection (straddles the floor)', () => {
     const r = assertBandDiversity([entry({ band: 'above' }), entry({ band: 'below' })]);

--- a/tests/unit/apa-boundary-material-shelf.test.js
+++ b/tests/unit/apa-boundary-material-shelf.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  SHELF_BANDS,
+  validateShelfEntry,
+  validateShelf,
+  assertBandDiversity,
+} from '../../lib/apa/boundary-material-shelf.mjs';
+
+// SD-LEO-INFRA-APA-BOUNDARY-MATERIAL-001 (PART A): schema + assembler band-diversity guard.
+const entry = (over = {}) => ({
+  id: 'B-example', format: 'capture_png', band: 'on_line',
+  craft_justification: 'ordinary SaaS landing, competent but unremarkable hierarchy',
+  a11y_notes: 'contrast ~4.5:1, visible focus rings', ...over,
+});
+
+describe('boundary-material shelf: entry schema', () => {
+  it('accepts a well-formed capture_png entry in each band', () => {
+    for (const band of SHELF_BANDS) {
+      expect(() => validateShelfEntry(entry({ band }))).not.toThrow();
+    }
+  });
+  it('rejects a non-capture_png format (boundary material is always a live capture)', () => {
+    expect(() => validateShelfEntry(entry({ format: 'html_native' }))).toThrow(/capture_png/);
+  });
+  it('rejects an unknown band', () => {
+    expect(() => validateShelfEntry(entry({ band: 'way_below' }))).toThrow(/band must be one of/);
+  });
+  it('requires craft_justification and a11y_notes (anti-confabulation discipline)', () => {
+    expect(() => validateShelfEntry(entry({ craft_justification: '' }))).toThrow(/craft_justification/);
+    expect(() => validateShelfEntry(entry({ a11y_notes: '  ' }))).toThrow(/a11y_notes/);
+  });
+});
+
+describe('boundary-material shelf: manifest shape', () => {
+  it('accepts a versioned container with a valid (possibly empty) entries array', () => {
+    expect(() => validateShelf({ shelf_version: 1, entries: [] })).not.toThrow();
+    expect(() => validateShelf({ shelf_version: 2, entries: [entry(), entry({ band: 'above' })] })).not.toThrow();
+  });
+  it('requires a positive shelf_version and an entries array', () => {
+    expect(() => validateShelf({ entries: [] })).toThrow(/shelf_version/);
+    expect(() => validateShelf({ shelf_version: 1 })).toThrow(/entries/);
+  });
+  it('the committed shelf manifest is valid and starts empty at v1', () => {
+    const shelf = JSON.parse(readFileSync(path.resolve('docs/design/apa-boundary-material-shelf/manifest.json'), 'utf8'));
+    expect(() => validateShelf(shelf)).not.toThrow();
+    expect(shelf.shelf_version).toBe(1);
+    expect(shelf.entries).toEqual([]);
+  });
+});
+
+describe('boundary-material shelf: assembler FORBIDDEN all-same-side guard', () => {
+  it('rejects an all-above selection (no floor-edge test)', () => {
+    expect(() => assertBandDiversity([entry({ band: 'above' }), entry({ band: 'above' })])).toThrow(/all-same-side/);
+  });
+  it('rejects an all-below selection', () => {
+    expect(() => assertBandDiversity([entry({ band: 'below' }), entry({ band: 'below' })])).toThrow(/all-same-side/);
+  });
+  it('rejects a single-band selection (must span >=2 bands)', () => {
+    expect(() => assertBandDiversity([entry({ band: 'on_line' })])).toThrow(/>=2 bands|all-same-side/);
+  });
+  it('rejects an empty selection', () => {
+    expect(() => assertBandDiversity([])).toThrow(/non-empty/);
+  });
+  it('accepts an above+below selection (straddles the floor)', () => {
+    const r = assertBandDiversity([entry({ band: 'above' }), entry({ band: 'below' })]);
+    expect(r.bands.sort()).toEqual(['above', 'below']);
+  });
+  it('accepts a full above+on_line+below selection with no warnings', () => {
+    const r = assertBandDiversity([entry({ band: 'above' }), entry({ band: 'on_line' }), entry({ band: 'below' })]);
+    expect(r.warnings).toHaveLength(0);
+    expect(r.bands.sort()).toEqual(['above', 'below', 'on_line']);
+  });
+  it('warns (but passes) when a 2-band selection includes on_line + one side', () => {
+    const r = assertBandDiversity([entry({ band: 'on_line' }), entry({ band: 'above' })]);
+    expect(r.warnings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Durable, **versioned boundary-material shelf** for APA calibration — the floor-edge (sub-award) fixture source the calibration set lacked:
- `lib/apa/boundary-material-shelf.mjs` — the shelf **schema** (`validateShelfEntry`/`validateShelf`: capture_png entries banded `above`~4.1 / `on_line`~4.0 / `below`~3.8, mandatory `craft_justification` + `a11y_notes`), a versioned-shelf `loadShelf()`, and the assembler **`assertBandDiversity()` guard** that REFUSES a FORBIDDEN all-same-side selection (must span ≥2 bands) — the exact failure the first swap-round set hit.
- `docs/design/apa-boundary-material-shelf/manifest.json` — the versioned container (`shelf_version: 1`, `entries: []`), consuming the `capture_png` format shipped by SD-LEO-INFRA-APA-FIXTURE-HARNESS-001 (#5736).
- 14 unit tests.

## Test plan
`npx vitest run tests/unit/apa-boundary-material-shelf.test.js` → **14 passed**: schema acceptance per band; format/band/justification/a11y rejections; manifest-shape + committed-manifest validation; all-above/all-below/single-band/empty rejections; above+below straddle and full-band acceptance; 2-band warning.

## Scope (PART A)
Fenced follow-ups, documented in the SD + completion flags: the **pixel-level baked-in-raster brand-strip scanner** (requires an OCR dependency decision — repo has sharp + playwright but no tesseract/OCR) and the **live-site capture + design-banding curation** that populates the shelf (APA-cluster, taste-gated). The v1 container + schema + guard make both a pure additive population step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)