### PR TITLE
fix(QF-20260709-797): phantom active ventures — fixture leak hardening + scrap-sweep assert-zero

### DIFF
--- a/scripts/venture-scrap-sweep-verify.mjs
+++ b/scripts/venture-scrap-sweep-verify.mjs
@@ -1,0 +1,42 @@
+// QF-20260709-797: assert-zero completion check for venture scrap sweeps.
+//
+// The 2026-07-08 scrap-all cancelled ventures by ENUMERATED ID (sequential updates), so a
+// venture missing from the enumeration (Proactora) stayed active SILENTLY — 35/36 looked done
+// and nobody re-queried. This verifier is the durable guard: run it as the LAST step of ANY
+// scrap sweep (scripted or ad-hoc). It re-queries the live table and exits non-zero listing
+// every still-active venture, so an enumeration miss can never go silent again.
+//
+// Usage:
+//   node scripts/venture-scrap-sweep-verify.mjs                    # assert ZERO active ventures
+//   node scripts/venture-scrap-sweep-verify.mjs --allow <id[,id]>  # scrap-all-except: listed venture ids may stay active
+//
+// Exit codes: 0 = assertion holds; 1 = unexpected active ventures remain (listed on stdout);
+//             2 = query error (verification could not run — treat as NOT verified).
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+
+const args = process.argv.slice(2);
+const allowIdx = args.indexOf('--allow');
+const allowed = new Set(allowIdx !== -1 && args[allowIdx + 1] ? args[allowIdx + 1].split(',').map((s) => s.trim()) : []);
+
+// Canonical env-walking client (QF-20260504-755): finds the parent worktree's .env, so this
+// verifier runs correctly from a manual `git worktree add` checkout too.
+const supabase = createSupabaseServiceClient();
+
+const { data, error } = await supabase.from('ventures').select('id, name, status, updated_at').eq('status', 'active');
+if (error) {
+  console.error(`SCRAP-SWEEP-VERIFY: query error — sweep NOT verified: ${error.message}`);
+  process.exit(2);
+}
+
+const unexpected = (data || []).filter((v) => !allowed.has(v.id));
+if (unexpected.length === 0) {
+  console.log(`SCRAP-SWEEP-VERIFY: PASS — 0 unexpected active ventures${allowed.size ? ` (${allowed.size} allowed exception(s))` : ''}.`);
+  process.exit(0);
+}
+
+console.error(`SCRAP-SWEEP-VERIFY: FAIL — ${unexpected.length} venture(s) STILL ACTIVE after the sweep:`);
+for (const v of unexpected) {
+  console.error(`  - ${v.id}  ${v.name}  (updated_at ${v.updated_at})`);
+}
+console.error('The sweep missed these (enumeration gap, fixture leak, or concurrent create). Cancel them and re-run this verifier.');
+process.exit(1);

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -22,6 +22,24 @@ function hash(seed) {
   return createHash('sha256').update(seed).digest('hex');
 }
 
+// QF-20260709-797: a run killed before afterAll orphans the fixture ventures into the
+// PRODUCTION venture list (witnessed 2026-07-08: two TS-fixture rows surfaced to the chairman
+// as phantom active ventures). Startup sweep: before creating fresh fixtures, delete any
+// stale TS-fixture-% rows older than STALE_FIXTURE_MS (and their feedback), so a prior
+// crashed run is self-healed by the next run instead of leaking forever. The 1h age guard
+// ensures a concurrently-running suite's live fixtures are never swept.
+const STALE_FIXTURE_MS = 60 * 60 * 1000;
+
+async function sweepStaleFixtures(client) {
+  const cutoff = new Date(Date.now() - STALE_FIXTURE_MS).toISOString();
+  const { data: stale } = await client.from('ventures')
+    .select('id').ilike('name', 'TS-fixture-%').lt('created_at', cutoff);
+  const ids = (stale || []).map((v) => v.id);
+  if (!ids.length) return;
+  await client.from('feedback').delete().in('venture_id', ids);
+  await client.from('ventures').delete().in('id', ids);
+}
+
 beforeAll(async () => {
   if (!HAS_REAL_DB) return;
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -29,17 +47,26 @@ beforeAll(async () => {
   const anonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   anon = createClient(url, anonKey);
 
+  await sweepStaleFixtures(svc);
+
   const { data: v1, error: e1 } = await svc.from('ventures')
     .insert({ name: `TS-fixture-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js' })
     .select('id').single();
   if (e1) throw e1;
   ventureId = v1.id;
 
-  const { data: v2, error: e2 } = await svc.from('ventures')
-    .insert({ name: `TS-fixture-other-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js (revocation-isolation control)' })
-    .select('id').single();
-  if (e2) throw e2;
-  otherVentureId = v2.id;
+  // Guarded second insert (QF-20260709-797): if it fails, remove the first fixture before
+  // rethrowing so a half-created pair never persists into the venture list.
+  try {
+    const { data: v2, error: e2 } = await svc.from('ventures')
+      .insert({ name: `TS-fixture-other-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js (revocation-isolation control)' })
+      .select('id').single();
+    if (e2) throw e2;
+    otherVentureId = v2.id;
+  } catch (err) {
+    await svc.from('ventures').delete().eq('id', ventureId).then(() => {}, () => {});
+    throw err;
+  }
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Summary
**Chairman-reported 07-09:** venture list showed 3 phantom active ventures post scrap-all. DB remediation already applied and readback-verified (**0 active ventures now**): the 2 orphaned `TS-fixture-%` rows from the 07-08 16:22Z crashed test run deleted (incl. their feedback), and **Proactora** (`d540af4f`) cancelled in `ventures` + killed in `eva_ventures` per the scrap-all directive.

**Durable fixes in this PR:**
- `tests/integration/venture-error-aggregation.db.test.js` — **startup sweep**: before creating fresh fixtures, delete stale `TS-fixture-%` ventures older than 1h (+ feedback), so a run killed before `afterAll` is self-healed by the next run instead of leaking into the production venture list; the second fixture insert is **guarded** so a half-created pair never persists.
- `scripts/venture-scrap-sweep-verify.mjs` — **assert-zero completion check** for scrap sweeps: re-queries live `status='active'` ventures and exits 1 listing any that remain (`--allow` for scrap-all-except), so an enumeration miss can never go silent again. Uses the env-walking `createSupabaseServiceClient` so it runs from manual worktrees.

## Why the sweep missed Proactora
The 07-08 12:45Z sweep cancelled ventures **sequentially ~3s apart** — an enumerated-ID loop, not a bulk `status='active'` update. Proactora was live in **both** `ventures` and `eva_ventures` (no join gap), so the miss happened at **enumeration**: the ID list came from a snapshot that excluded it — most plausibly because Proactora's continuously ticking `updated_at` (the sentry poller stamps it every few minutes; its metadata carries a `sentry` key) excluded it from any staleness-filtered candidate query. The assert-zero verifier makes this entire failure class loud regardless of the specific cause.

## Test plan
- Hardened suite run **live against the real DB**: 4/4 passed (sweep + guarded creation + TS-3/4/5/7 + cleanup), leaving 0 fixtures behind.
- Verifier run live: `SCRAP-SWEEP-VERIFY: PASS — 0 unexpected active ventures` (exit 0).

Not in scope (per QF): durable fixture admission-at-birth architecture — already in the sourced Pool-C pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)