### PR TITLE
fix(SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001): enforce chairman review of S5 kill-gate verdicts

### DIFF
--- a/lib/eva/kill-override-guard.js
+++ b/lib/eva/kill-override-guard.js
@@ -1,0 +1,41 @@
+/**
+ * Guard against silently approving a chairman_decisions row whose underlying kill-gate
+ * verdict was computed as 'kill'. Without this, approveDecision() has no visibility into
+ * the S5 financial kill-gate's verdict and approves unconditionally.
+ *
+ * SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001 (Solomon consult finding: "queryable != consulted"
+ * pull-vs-push class -- the computed kill verdict is stored but nothing enforced it downstream).
+ */
+
+/**
+ * @param {Object} args
+ * @param {Object|null|undefined} args.briefData - chairman_decisions.brief_data
+ * @param {boolean} [args.overrideKill] - explicit operator override flag
+ * @returns {boolean} true if approval should be BLOCKED
+ */
+export function shouldBlockKillApproval({ briefData, overrideKill }) {
+  if (overrideKill) return false;
+  if (!briefData || typeof briefData !== 'object') return false;
+  return briefData.decision === 'kill';
+}
+
+/**
+ * Extract the kill-gate verdict fields from a persisted truth_financial_model artifact
+ * payload, for merging into a chairman_decisions.brief_data blob. Returns {} (no keys)
+ * when the payload has no 'decision' field, so callers can safely spread the result
+ * without polluting brief_data with undefined keys.
+ *
+ * @param {Object|null|undefined} artifactPayload - venture_artifacts.artifact_data
+ * @returns {{decision?: any, blockProgression?: any, reasons?: any, remediationRoute?: any}}
+ */
+export function extractKillGateVerdict(artifactPayload) {
+  if (!artifactPayload || typeof artifactPayload !== 'object' || !('decision' in artifactPayload)) {
+    return {};
+  }
+  return {
+    decision: artifactPayload.decision,
+    blockProgression: artifactPayload.blockProgression,
+    reasons: artifactPayload.reasons,
+    remediationRoute: artifactPayload.remediationRoute,
+  };
+}

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -39,6 +39,7 @@ import { hostname } from 'os';
 import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
+import { extractKillGateVerdict } from './kill-override-guard.js';
 // SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: the venture_stage_work write-through
 // + hard-gate check were extracted to a shared module so run-stage/executeStage
 // produce the SAME stage-completion records as this daemon (single source of truth).
@@ -2230,10 +2231,31 @@ export class StageExecutionWorker {
         gateQuality = extractGateQuality(stageWork?.advisory_data);
       } catch (_) { /* non-fatal */ }
 
+      // SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001 FR-1: the mandatory manual review at a
+      // kill_gate stage must surface the underlying computed kill-gate verdict by name --
+      // without this, the chairman brief only carried quality_score/completeness_pct/
+      // critical_gaps/gate_rationale and a 'kill' verdict was invisible to the reviewer.
+      // Scoped to stage 5 (the only stage currently persisting a truth_financial_model
+      // verdict artifact); fail-open on lookup error, never blocks the gate.
+      let killGateVerdict = {};
+      if (gateType === 'kill_gate' && stageNumber === 5) {
+        try {
+          const { data: artifact } = await this._supabase
+            .from('venture_artifacts')
+            .select('artifact_data')
+            .eq('venture_id', ventureId)
+            .eq('lifecycle_stage', stageNumber)
+            .eq('artifact_type', 'truth_financial_model')
+            .eq('is_current', true)
+            .maybeSingle();
+          killGateVerdict = extractKillGateVerdict(artifact?.artifact_data);
+        } catch (_) { /* non-fatal */ }
+      }
+
       const { id: decisionId, isNew, reason: skipReason } = await createOrReusePendingDecision({
         ventureId,
         stageNumber,
-        briefData: { stage: stageNumber, ventureName: venture?.name, ...gateQuality },
+        briefData: { stage: stageNumber, ventureName: venture?.name, ...gateQuality, ...killGateVerdict },
         summary: `Chairman gate: Stage ${stageNumber} review for ${venture?.name || ventureId}`,
         supabase: this._supabase,
         logger: this._logger,

--- a/scripts/eva-decisions.js
+++ b/scripts/eva-decisions.js
@@ -13,6 +13,8 @@
  *   --status <pending|approved|rejected|cancelled>   Filter by status
  *   --stage <0|10|22|25>                             Filter by stage
  *   --rationale "reason"                             Required for approve/reject
+ *   --override-kill                                  Required to approve a decision whose brief_data.decision='kill'
+ *   --override-reason "reason"                       Required (min 10 chars) with --override-kill
  *   --limit <n>                                      Max results (default 50)
  *   --json                                           Output as JSON
  *
@@ -21,6 +23,7 @@
  *   node scripts/eva-decisions.js list --status approved
  *   node scripts/eva-decisions.js view abc-123
  *   node scripts/eva-decisions.js approve abc-123 --rationale "Strong market fit"
+ *   node scripts/eva-decisions.js approve abc-123 --rationale "..." --override-kill --override-reason "chairman accepts the risk"
  *   node scripts/eva-decisions.js reject abc-123 --rationale "Insufficient traction"
  *
  * Part of SD-EVA-FEAT-CHAIRMAN-API-001
@@ -29,6 +32,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { shouldBlockKillApproval } from '../lib/eva/kill-override-guard.js';
 
 // ── Argument Parsing ──────────────────────────────────────────
 
@@ -230,6 +234,8 @@ async function viewDecision(supabase, decisionId) {
 
 async function approveDecision(supabase, decisionId) {
   const rationale = getArg('rationale');
+  const overrideKill = hasFlag('override-kill');
+  const overrideReason = getArg('override-reason');
 
   if (!decisionId) {
     console.error('Usage: eva decisions approve <decision-id> --rationale "reason"');
@@ -239,11 +245,15 @@ async function approveDecision(supabase, decisionId) {
     console.error('Error: --rationale is required for approval');
     process.exit(1);
   }
+  if (overrideKill && (!overrideReason || overrideReason.trim().length < 10)) {
+    console.error('Error: --override-reason (min 10 chars) is required when using --override-kill');
+    process.exit(1);
+  }
 
   // Check current status
   const { data: existing, error: fetchErr } = await supabase
     .from('chairman_decisions')
-    .select('id, status, venture_id, lifecycle_stage')
+    .select('id, status, venture_id, lifecycle_stage, brief_data')
     .eq('id', decisionId)
     .single();
 
@@ -257,14 +267,28 @@ async function approveDecision(supabase, decisionId) {
     process.exit(1);
   }
 
+  // SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001: a computed 'kill' verdict must never be
+  // approved silently — require an explicit, recorded override.
+  if (shouldBlockKillApproval({ briefData: existing.brief_data, overrideKill })) {
+    console.error(`\n  ❌ REFUSED: Decision ${decisionId} carries a computed 'kill' verdict (brief_data.decision='kill').`);
+    console.error('  Approving a kill verdict requires an explicit, recorded override:');
+    console.error(`    eva decisions approve ${decisionId} --rationale "..." --override-kill --override-reason "why you are overriding the kill verdict"\n`);
+    process.exit(1);
+  }
+
+  const updatePayload = {
+    status: 'approved',
+    decision: 'proceed',
+    rationale,
+    updated_at: new Date().toISOString(),
+  };
+  if (overrideKill) {
+    updatePayload.override_reason = overrideReason;
+  }
+
   const { error } = await supabase
     .from('chairman_decisions')
-    .update({
-      status: 'approved',
-      decision: 'proceed',
-      rationale,
-      updated_at: new Date().toISOString(),
-    })
+    .update(updatePayload)
     .eq('id', decisionId);
 
   if (error) {
@@ -274,6 +298,9 @@ async function approveDecision(supabase, decisionId) {
 
   console.log(`\n  ✅ Decision APPROVED: ${decisionId}`);
   console.log(`  Rationale: ${rationale}`);
+  if (overrideKill) {
+    console.log(`  ⚠️  Kill-verdict override: ${overrideReason}`);
+  }
   console.log(`  Venture: ${existing.venture_id}`);
   console.log(`  Stage: ${existing.lifecycle_stage}\n`);
 }

--- a/tests/unit/eva/kill-override-guard.test.js
+++ b/tests/unit/eva/kill-override-guard.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { shouldBlockKillApproval, extractKillGateVerdict } from '../../../lib/eva/kill-override-guard.js';
+
+describe('shouldBlockKillApproval (SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001)', () => {
+  it('blocks approval of a computed-kill verdict without override (TS-1)', () => {
+    expect(shouldBlockKillApproval({ briefData: { decision: 'kill' }, overrideKill: false })).toBe(true);
+  });
+
+  it('allows approval of a computed-kill verdict with explicit override (TS-2)', () => {
+    expect(shouldBlockKillApproval({ briefData: { decision: 'kill' }, overrideKill: true })).toBe(false);
+  });
+
+  it('allows approval when the verdict is not kill (TS-3)', () => {
+    expect(shouldBlockKillApproval({ briefData: { decision: 'pass' }, overrideKill: false })).toBe(false);
+  });
+
+  it('allows approval when brief_data has no decision field (TS-4)', () => {
+    expect(shouldBlockKillApproval({ briefData: { quality_score: 80 }, overrideKill: false })).toBe(false);
+  });
+
+  it('allows approval when briefData is null/undefined (TS-5)', () => {
+    expect(shouldBlockKillApproval({ briefData: null, overrideKill: false })).toBe(false);
+    expect(shouldBlockKillApproval({ briefData: undefined, overrideKill: false })).toBe(false);
+  });
+});
+
+describe('extractKillGateVerdict', () => {
+  it('extracts the 4 verdict fields when decision is present', () => {
+    const payload = { decision: 'kill', blockProgression: true, reasons: [{ message: 'x' }], remediationRoute: 'pivot', otherField: 'ignored' };
+    expect(extractKillGateVerdict(payload)).toEqual({
+      decision: 'kill',
+      blockProgression: true,
+      reasons: [{ message: 'x' }],
+      remediationRoute: 'pivot',
+    });
+  });
+
+  it('returns {} when payload has no decision field', () => {
+    expect(extractKillGateVerdict({ quality_score: 80 })).toEqual({});
+  });
+
+  it('returns {} for null/undefined payload', () => {
+    expect(extractKillGateVerdict(null)).toEqual({});
+    expect(extractKillGateVerdict(undefined)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Solomon (Fable-tier oracle) proposed a demand-thesis adjudication stage design; self-corrected to one clean residual question: is the S5 financial kill-gate's computed verdict actually enforced end-to-end, or computed-but-ignored?
- Ground-truth code trace (this session): MIXED. `conditional_pass` is enforced (routes to HOLD). But `kill` vs `pass` are undifferentiated -- S5 is a mandatory-manual-review stage regardless, and the chairman brief never surfaced the computed decision/blockProgression, while `approveDecision()` approved unconditionally with zero check against it.
- Fix: `lib/eva/kill-override-guard.js` (new, pure + unit-tested), `_handleChairmanGate` now merges the S5 verdict into `brief_data` (fail-open), `approveDecision()` refuses a computed-kill approval unless `--override-kill --override-reason` is explicitly supplied (persisted to the existing `override_reason` column).
- Solomon's remaining proposed workstreams (demand-thesis artifact, adjudication protocol wiring, E2 probe kit, discovery/provenance) are explicitly deferred, not spawned as draft children -- the belt already carries 28 draft SDs against a 10-item guardrail.

## Test plan
- [x] `npx vitest run tests/unit/eva/kill-override-guard.test.js` -- 8/8 pass
- [x] Full `tests/unit/eva/` regression suite (479 files, 6259 tests) -- 0 failures
- [x] `node --check` + ESLint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)