### PR TITLE
feat(SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001): token-burn autopilot — quiet-tick cutover + role-aware compaction + burn feed

### DIFF
--- a/.claude/compaction-thresholds.cjs
+++ b/.claude/compaction-thresholds.cjs
@@ -53,22 +53,40 @@ function defaultReadCoordFile() {
   } catch (_) { return null; }
 }
 
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the Adam role tag source (peer of active-coordinator.json),
+// written by scripts/adam-startup-check.mjs writeAdamMarker() at Adam startup. Same file-only,
+// fail-safe read discipline — no DB/network in the render hot path.
+function defaultReadAdamFile() {
+  try {
+    const fp = path.resolve(__dirname, 'active-adam.json');
+    return fs.existsSync(fp) ? JSON.parse(fs.readFileSync(fp, 'utf8')) : null;
+  } catch (_) { return null; }
+}
+
 // File-only role detection — NO database, NO network in the render hot path.
-// Returns 'coordinator' | 'worker' | 'solo'. Fail-safe to 'worker' (the conservative,
-// current-behavior profile) on ANY error. `reader` is injectable for tests.
-function detectRoleFromFile(sessionId, reader) {
+// Returns 'coordinator' | 'adam' | 'worker' | 'solo'. Fail-safe to 'worker' (the conservative,
+// current-behavior profile) on ANY error. `reader`/`adamReader` are injectable for tests.
+// Adam is checked AFTER coordinator (a session somehow tagged both counts as coordinator) and
+// only ever widens detection — a missing/mismatched adam marker preserves prior behavior exactly.
+function detectRoleFromFile(sessionId, reader, adamReader) {
   const read = typeof reader === 'function' ? reader : defaultReadCoordFile;
+  const readAdam = typeof adamReader === 'function' ? adamReader : defaultReadAdamFile;
   let coord = null;
   try { coord = read(); } catch (_) { return 'worker'; }
+  if (sessionId && coord && coord.session_id === sessionId) return 'coordinator';
+  let adam = null;
+  try { adam = readAdam(); } catch (_) { adam = null; }
+  if (sessionId && adam && adam.session_id === sessionId) return 'adam';
   if (!coord || !coord.session_id) return 'solo';
-  if (sessionId && coord.session_id === sessionId) return 'coordinator';
   return 'worker';
 }
 
 // Select advisory thresholds by role + flag. Flag OFF => GLOBAL for every role.
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: 'adam' joins 'coordinator' on the earlier profile —
+// both are long-lived role sessions whose burn the earlier CRITICAL/EMERGENCY nudges manage.
 function selectThresholds(role, flagEnabled) {
   if (!flagEnabled) return GLOBAL_THRESHOLDS;
-  if (role === 'coordinator') return COORDINATOR_THRESHOLDS;
+  if (role === 'coordinator' || role === 'adam') return COORDINATOR_THRESHOLDS;
   return GLOBAL_THRESHOLDS;
 }
 

--- a/.claude/context-usage-feed.cjs
+++ b/.claude/context-usage-feed.cjs
@@ -1,0 +1,43 @@
+// ============================================================================
+// Context-usage burn feed — pure helpers for the statusline JSONL append
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001 (FR-4)
+// ============================================================================
+// The queryable burn sink (context_usage_log table + scripts/sync-context-usage.js +
+// get_context_usage_summary RPC) already exists but was STARVED: the active
+// .claude/statusline.cjs never appended the .claude/logs/context-usage.jsonl feed the
+// sync script ingests (only the retired shell tracker did). These pure helpers build
+// contract-shaped entries (sync-context-usage transformEntry field parity) and throttle
+// appends to meaningful changes so the statusline hot path stays cheap.
+//
+// Turns/hour then falls out as row cadence per session — "which session is the burner"
+// becomes a query, not an investigation.
+'use strict';
+
+// Append only when the reading is meaningful: first sample, a percent change, or a
+// status transition. A repaint with identical percent+status is throttled (no append).
+function shouldAppendUsage(prevState, next) {
+  if (!next || typeof next.usage_percent !== 'number') return false;
+  if (!prevState) return true;
+  return prevState.last_percent !== next.usage_percent || prevState.last_status !== next.status;
+}
+
+// Build a JSONL entry matching scripts/sync-context-usage.js transformEntry field shape.
+function buildUsageEntry({ sessionId, modelId, contextUsed, contextSize, usagePercent, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, status, cwd, now }) {
+  return {
+    session_id: sessionId || 'unknown',
+    timestamp: (now instanceof Date ? now : new Date()).toISOString(),
+    model_id: modelId || 'unknown',
+    context_used: contextUsed | 0,
+    context_size: contextSize | 0,
+    usage_percent: usagePercent | 0,
+    input_tokens: inputTokens | 0,
+    output_tokens: outputTokens | 0,
+    cache_creation_tokens: cacheCreationTokens | 0,
+    cache_read_tokens: cacheReadTokens | 0,
+    status: status || 'HEALTHY',
+    compaction_detected: false,
+    working_directory: cwd || '',
+  };
+}
+
+module.exports = { shouldAppendUsage, buildUsageEntry };

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
     "COORD_ADAM_ACTION_ACK_V1": "on",
     "ADAM_GOVERNANCE_HEARTBEAT_V1": "on",
     "COORD_QUESTION_AUTO_PROCEED_V1": "on",
-    "LEO_LOOP_WAKEUP_REMINDER": "on"
+    "LEO_LOOP_WAKEUP_REMINDER": "on",
+    "COORD_COMPACTION_THRESHOLD_V2": "on"
   },
   "statusLine": {
     "type": "command",

--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -112,9 +112,11 @@ try {
 } catch (_) { /* intentionally silent: keep inline global thresholds, never crash the status line */ }
 
 // Status level (shifted: old-red→yellow, old-yellow→hidden)
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: EMERGENCY must be UNMISTAKABLE — the chairman's only
+// job is pressing /compact when told, never tracking meters. A subtle ' !' was missable.
 let status = 'HEALTHY';
 let icon = '';
-if (percentUsed >= thresholds.emergency) { status = 'EMERGENCY'; icon = ' !'; }
+if (percentUsed >= thresholds.emergency) { status = 'EMERGENCY'; icon = ' ‼ EMERGENCY — /compact NOW'; }
 else if (percentUsed >= thresholds.critical) { status = 'CRITICAL'; icon = ' *'; }
 
 // Progress bar
@@ -259,6 +261,28 @@ const progressSection = status === 'HEALTHY'
 
 // Build output
 const output = `${activitySignal}${projectInfo}${autoProceedInfo}${progressSection} (${modelShort})`;
+
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001 (FR-4): feed the burn-observability pipeline.
+// context_usage_log (table + sync + RPC) already existed but was starved — this statusline never
+// appended the context-usage.jsonl it ingests. Append a contract-shaped line, throttled to
+// percent/status changes (shouldAppendUsage reads the PRE-overwrite state file). Fail-soft:
+// nothing here may ever break the statusline render.
+try {
+  const feed = require('./context-usage-feed.cjs');
+  let prevState = null;
+  try { prevState = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')); } catch (_) { prevState = null; }
+  const entry = feed.buildUsageEntry({
+    sessionId, modelId: model, contextUsed, contextSize, usagePercent: percentUsed,
+    inputTokens: totalInputTokens, outputTokens: totalOutputTokens,
+    cacheCreationTokens: cacheCreation, cacheReadTokens: cacheRead,
+    status, cwd: process.cwd(),
+  });
+  if (feed.shouldAppendUsage(prevState, entry)) {
+    const logDir = path.join(__dirname, 'logs');
+    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    fs.appendFileSync(path.join(logDir, 'context-usage.jsonl'), JSON.stringify(entry) + '\n', 'utf8');
+  }
+} catch (_) { /* intentionally silent: the burn feed is best-effort */ }
 
 // Update state file
 try {

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -36,6 +36,9 @@ const FLAG = 'COORD_TEARDOWN_SAFETY_V2';
 // drift. The inbox loop is the critical one (re_asserts_pointer:true).
 const COORDINATOR_CRONS = [
   { key: 'sweep',     cadence: '*/5 * * * *',                                command: 'node scripts/stale-session-sweep.cjs',     re_asserts_pointer: false },
+  // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the quiet-tick consolidation cron (folds inbox/audit/
+  // charter-audit/capacity-forecast/backlog-rank) — teardown must remove it like any other loop.
+  { key: 'quiet-tick', cadence: '0,15,30,45 * * * *',                        command: 'node scripts/coordinator-quiet-tick.mjs',  re_asserts_pointer: false },
   { key: 'dashboard', cadence: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *',  command: 'node scripts/fleet-dashboard.cjs all',     re_asserts_pointer: false },
   { key: 'identity',  cadence: '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',  command: 'node scripts/assign-fleet-identities.cjs', re_asserts_pointer: false },
   { key: 'inbox',     cadence: '*/2 * * * *',                                command: 'node scripts/fleet-dashboard.cjs inbox',  re_asserts_pointer: true },
@@ -58,6 +61,7 @@ const COORDINATOR_CRONS = [
 // exact prompt string. The email loop is a separate script (coordinator-confirmed).
 const COORD_SCRIPT_MARKERS = [
   'stale-session-sweep.cjs',
+  'coordinator-quiet-tick.mjs', // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001
   'fleet-dashboard.cjs',
   'assign-fleet-identities.cjs',
   'coordinator-email-summary.mjs',

--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -36,7 +36,9 @@ describe('teardown-coordinator: inventory + matcher', () => {
   // QF-20260611-101: the cron inventory grows ~weekly and the magic-number pin
   // broke main twice in one day (7->8 #4626, 8->9 #4645). The key LIST is the
   // single pin now; the count derives from it. Adding a cron = add ONE key here.
-  const EXPECTED_CRON_KEYS = ['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention'];
+  // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: 'quiet-tick' joined the inventory (the consolidation
+  // cron the cutover arms — teardown must remove it like any other coordinator loop).
+  const EXPECTED_CRON_KEYS = ['sweep', 'quiet-tick', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention'];
 
   it('listCoordinatorCrons enumerates exactly the expected coordinator crons incl the pointer-re-asserting inbox loop', () => {
     const crons = listCoordinatorCrons();

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -137,6 +137,11 @@ export const ADAM_LOOPS = [
     // every recurring tick (scripts/adam-quiet-tick.mjs's reconcileBoard()), not only at /adam cold
     // start — closing the same "durable but session-fragile" gap the belt-countdown duty closed.
     key: 'board-reconcile',
+    // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: folded — this loop ran the SAME adam-quiet-tick.mjs
+    // at 12×/hour, duplicating the consolidated quiet-tick loop above (which composes
+    // reconcileBoard() on every tick at 4×/hour + self-paced wakeups). Keeping both would
+    // defeat the burn reduction the cutover exists for.
+    folded: true,
     label: 'Board<->reality reconcile every tick (adam_task_ledger via rehydrateBoard)',
     script: 'adam-quiet-tick.mjs',
     cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *',

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -19,7 +19,7 @@
 // Fail-open: always exits 0; a hiccup never blocks /adam startup.
 
 import 'dotenv/config';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
@@ -46,6 +46,18 @@ export const RESPONSIBILITIES = [
 //   - offer-help:      an agent-judgment tick (no script) — propose-only, silence-by-default.
 export const ADAM_LOOPS = [
   {
+    // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the quiet-tick cutover (docs/protocol/
+    // fleet-hibernation-quiet-tick.md). ONE self-pacing LLM tick composes the folded loops
+    // (inbox-monitor, belt-countdown, offer-help — marked folded:true, kept in this registry
+    // for the loop-parity guard). Cron minutes offset from the coordinator quiet-tick
+    // (0,15,30,45) so the two parties never co-fire; the tick parks 180–900s via ScheduleWakeup.
+    key: 'quiet-tick',
+    label: 'Adam quiet-tick (folds inbox-monitor + belt-countdown + offer-help)',
+    script: 'adam-quiet-tick.mjs',
+    cron: '7,22,37,52 * * * *',
+    prompt: 'Run `node scripts/adam-quiet-tick.mjs`. It prints ONE QUIET_TICK summary line and self-paces. If the output contains NO QUIET_TICK_PING / QUIET_TICK_STALL_ALERT / QUIET_TICK_OUTBOUND_PROBE / QUIET_TICK_ERROR lines, this turn is a NO-OP: arm ScheduleWakeup(nextWakeSeconds from the output) and emit nothing else. Otherwise act on the flagged lines, then arm the wakeup.',
+  },
+  {
     key: 'governance-scan',
     label: 'Daily governance opportunity-scan (gated on ADAM_GOVERNANCE_HEARTBEAT_V1)',
     script: 'adam-opportunity-scan.cjs',
@@ -56,6 +68,7 @@ export const ADAM_LOOPS = [
     // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: drain ALL coordinator-directed kinds (replies +
     // coordinator directives), not reply-only — closes the reply-only blindspot.
     key: 'inbox-monitor',
+    folded: true, // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: composed by adam-quiet-tick — never armed standalone
     label: 'Adam inbox — drain ALL coordinator-directed kinds (full-lane reader)',
     script: 'adam-advisory.cjs',
     // QF-20260701-062: chairman-directed 15min -> 5min durable baseline (tighter comms
@@ -68,6 +81,7 @@ export const ADAM_LOOPS = [
   },
   {
     key: 'offer-help',
+    folded: true, // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: composed by adam-quiet-tick — never armed standalone
     label: 'Offer coordinator help (agent judgment, propose-only, silence-by-default)',
     script: null, // agent-prompt tick — no script to run
     cron: '0 */2 * * *',
@@ -89,6 +103,7 @@ export const ADAM_LOOPS = [
     // crons and DIED with every Adam session (2026-06-11 handoff drill). Arming it here makes it
     // survive session restarts — closing the contract↔tooling gap the duty-marker parity test enforces.
     key: 'belt-countdown',
+    folded: true, // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: composed by adam-quiet-tick — never armed standalone
     label: 'Belt-countdown one-liner (ET 12h, rolling ETA to belt-dry) while the fleet is active',
     script: null, // agent-prompt tick — depth/burn come from DB rows via fleet-dashboard, never hand-converted ET↔UTC
     cron: '*/15 * * * *',
@@ -219,12 +234,27 @@ export function renderLoops(armed) {
     lines.push('  (no --armed set supplied — run CronList and re-invoke with --armed "<loop-key>,…" (e.g. "governance-scan,inbox-monitor") for an armed|MISSING verdict; emitting full spec below)');
   }
   const toArm = [];
+  const toTearDown = [];
   for (const loop of ADAM_LOOPS) {
+    // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: folded loops stay registered (quiet-tick cores +
+    // the loop-parity guard reference them) but are NEVER armed standalone — the quiet-tick
+    // composes them. A live cron still matching a folded loop must be torn down.
+    if (loop.folded) {
+      const live = loopStatus(loop, armed) === 'armed';
+      lines.push(`  [⏸ folded ] ${loop.key.padEnd(16)} ${loop.label} — composed by adam-quiet-tick; do NOT arm standalone${live ? ' (LIVE cron found — tear down below)' : ''}`);
+      if (live) toTearDown.push(loop);
+      continue;
+    }
     const status = loopStatus(loop, armed);
     const badge = status === 'armed' ? '✅ armed' : status === 'MISSING' ? '❌ MISSING' : '… unverified';
     lines.push(`  [${badge}] ${loop.key.padEnd(16)} ${loop.label}`);
     lines.push(`              cron: ${loop.cron}`);
     if (status !== 'armed') toArm.push(loop);
+  }
+  if (toTearDown.length) {
+    lines.push('');
+    lines.push(`  → TEAR DOWN ${toTearDown.length} standalone cron(s) now folded into the quiet-tick (CronDelete the CronList entry whose prompt matches):`);
+    for (const loop of toTearDown) lines.push(`     CronDelete <prompt: ${JSON.stringify(loop.prompt)}>`);
   }
   lines.push('');
   if (toArm.length === 0 && armed.provided) {
@@ -432,9 +462,22 @@ export async function renderBoardRehydrate({ supabase = null, env = process.env 
   }
 }
 
+// SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the Adam role tag source for role-aware compaction
+// thresholds (.claude/compaction-thresholds.cjs detectRoleFromFile). Peer of the coordinator's
+// .claude/active-coordinator.json. Fail-open: a write error never blocks startup.
+export function writeAdamMarker(env = process.env, repoRoot = REPO_ROOT) {
+  try {
+    if (!env.CLAUDE_SESSION_ID) return false;
+    writeFileSync(resolve(repoRoot, '.claude', 'active-adam.json'),
+      JSON.stringify({ session_id: env.CLAUDE_SESSION_ID, updated_at: new Date().toISOString() }, null, 2));
+    return true;
+  } catch { return false; }
+}
+
 async function main() {
   try {
     console.log('[ADAM-STARTUP] ' + (process.env.CLAUDE_SESSION_ID ? 'session=' + process.env.CLAUDE_SESSION_ID : 'session=unknown'));
+    if (writeAdamMarker()) console.log('[ADAM-STARTUP] role marker written: .claude/active-adam.json');
     console.log(buildReport(process.argv.slice(2), process.env));
     // FR-2: the read-only Sourcing SSOT state probe (DB-backed, fail-open).
     console.log('');

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -49,18 +49,25 @@ export const RESPONSIBILITIES = [
 export const STANDARD_LOOPS = [
   { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
     prompt: 'node scripts/stale-session-sweep.cjs' },
+  // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the quiet-tick cutover (docs/protocol/
+  // fleet-hibernation-quiet-tick.md). ONE self-pacing LLM tick composes the folded loops below
+  // (inbox, audit, charter-audit, capacity-forecast, backlog-rank — marked folded:true, kept in
+  // this registry for the loop-parity guard). Cron minutes offset from Adam's quiet-tick so the
+  // two parties never co-fire. The tick itself parks 180–900s via ScheduleWakeup between fires.
+  { key: 'quiet-tick', label: 'Coordinator quiet-tick (folds inbox+audit+charter-audit+capacity-forecast+backlog-rank)', script: 'coordinator-quiet-tick.mjs', cron: '0,15,30,45 * * * *',
+    prompt: 'Run `node scripts/coordinator-quiet-tick.mjs`. It prints ONE QUIET_TICK summary line and self-paces. If the output contains NO QUIET_TICK_PING / QUIET_TICK_STALL_ALERT / QUIET_TICK_OUTBOUND_PROBE / QUIET_TICK_ERROR lines, this turn is a NO-OP: arm ScheduleWakeup(nextWakeSeconds from the output) and emit nothing else. Otherwise act on the flagged lines, then arm the wakeup.' },
   { key: 'dashboard',   label: 'Fleet dashboard',      script: 'fleet-dashboard.cjs',       cron: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *',
     prompt: 'node scripts/fleet-dashboard.cjs all' },
   { key: 'identity',    label: 'Fleet identity refresh', script: 'assign-fleet-identities.cjs', cron: '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',
     prompt: 'node scripts/assign-fleet-identities.cjs' },
-  { key: 'inbox',       label: 'Coordinator inbox',    script: 'fleet-dashboard.cjs',       cron: '*/2 * * * *',
+  { key: 'inbox', folded: true,       label: 'Coordinator inbox',    script: 'fleet-dashboard.cjs',       cron: '*/2 * * * *',
     prompt: 'node scripts/fleet-dashboard.cjs inbox' },
-  { key: 'audit',       label: 'Coordinator 3-source audit', script: 'coordinator-audit.mjs', cron: '*/15 * * * *',
+  { key: 'audit', folded: true,       label: 'Coordinator 3-source audit', script: 'coordinator-audit.mjs', cron: '*/15 * * * *',
     prompt: 'node scripts/coordinator-audit.mjs' },
   // SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001: durable charter-compliance self-audit (replaces the
   // lost session-only CronCreate). READ-ONLY detection; authoritative PID/armed-silence liveness; fail-loud
   // on a foundational query error; names a remediation per violation. The prompt compels REMEDIATE-THEN-VERIFY.
-  { key: 'charter-audit', label: 'Coordinator charter-compliance self-audit (durable, remediate-then-verify)', script: 'coordinator-charter-audit.mjs', cron: '8,23,38,53 * * * *',
+  { key: 'charter-audit', folded: true, label: 'Coordinator charter-compliance self-audit (durable, remediate-then-verify)', script: 'coordinator-charter-audit.mjs', cron: '8,23,38,53 * * * *',
     prompt: 'Run `node scripts/coordinator-charter-audit.mjs` (READ-ONLY). For EACH reported violation perform the named remediation ACTION, then RE-RUN and confirm the output ends with CHARTER_AUDIT_VIOLATIONS=0 — never observe-only.' },
   // RETIRED (chairman email cutover, advisory b7b73b86 / QF-20260609-024, 2026-06-10): the
   // coordinator fleet email (coordinator-email-summary.mjs) is no longer a standard loop. The ONE
@@ -82,13 +89,13 @@ export const STANDARD_LOOPS = [
   // PROACTIVE capacity forecaster (operator directive 2026-06-10): tracks per-worker busy-state +
   // ETA-to-free and belt-depth-vs-demand; on a FORECAST deficit (workers about to run out of work) it
   // reaches Adam for sourcing BEFORE the belt empties (30m cooldown). --dispatch enables the auto-reach.
-  { key: 'capacity-forecast', label: 'Worker-utilization + belt dry-out forecaster (predictive Adam reach-out)', script: 'coordinator-capacity-forecast.mjs', cron: '3,13,23,33,43,53 * * * *',
+  { key: 'capacity-forecast', folded: true, label: 'Worker-utilization + belt dry-out forecaster (predictive Adam reach-out)', script: 'coordinator-capacity-forecast.mjs', cron: '3,13,23,33,43,53 * * * *',
     prompt: 'node scripts/coordinator-capacity-forecast.mjs --dispatch' },
   // Backlog-ordering pass (operator directive 2026-06-10, SRE duty 6): ranks the claimable belt
   // critical-path-first (unlock-count → priority → age) and persists metadata.dispatch_rank, which
   // worker-checkin's self-claim tiers honor when fresh — "what gets done first" is coordinator-driven
   // by default, not correction-by-dispatch.
-  { key: 'backlog-rank', label: 'Backlog prioritization pass (dispatch_rank for self-claim ordering)', script: 'coordinator-backlog-rank.mjs', cron: '6,21,36,51 * * * *',
+  { key: 'backlog-rank', folded: true, label: 'Backlog prioritization pass (dispatch_rank for self-claim ordering)', script: 'coordinator-backlog-rank.mjs', cron: '6,21,36,51 * * * *',
     prompt: 'node scripts/coordinator-backlog-rank.mjs' },
   // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D: the observability leg for the belt-and-suspenders
   // above (rank-on-transition + this cron + the worker-checkin pool-window fix) — counts claimable leaf
@@ -276,12 +283,27 @@ export function renderLoops(armed) {
     lines.push('  (no --armed set supplied — run CronList and re-invoke with --armed "<script1>,<script2>,…" to get armed|MISSING; emitting full spec below)');
   }
   const toArm = [];
+  const toTearDown = [];
   for (const loop of STANDARD_LOOPS) {
+    // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: folded loops stay in the registry (the quiet-tick
+    // cores + loop-parity guard reference their scripts) but are NEVER armed as standalone crons —
+    // the quiet-tick composes them. A live cron still matching a folded loop must be torn down.
+    if (loop.folded) {
+      const live = loopStatus(loop, armed) === 'armed';
+      lines.push(`  [⏸ folded ] ${loop.key.padEnd(10)} ${loop.label} — composed by quiet-tick; do NOT arm standalone${live ? ' (LIVE cron found — tear down below)' : ''}`);
+      if (live) toTearDown.push(loop);
+      continue;
+    }
     const status = loopStatus(loop, armed);
     const badge = status === 'armed' ? '✅ armed' : status === 'MISSING' ? '❌ MISSING' : '… unverified';
     lines.push(`  [${badge}] ${loop.key.padEnd(10)} ${loop.label}`);
     lines.push(`              cron: ${loop.cron}   prompt: ${loop.prompt}`);
     if (status !== 'armed') toArm.push(loop);
+  }
+  if (toTearDown.length) {
+    lines.push('');
+    lines.push(`  → TEAR DOWN ${toTearDown.length} standalone cron(s) now folded into the quiet-tick (CronDelete the CronList entry whose prompt matches):`);
+    for (const loop of toTearDown) lines.push(`     CronDelete <prompt: ${JSON.stringify(loop.prompt)}>`);
   }
   lines.push('');
   if (toArm.length === 0 && armed.provided) {

--- a/tests/unit/statusline-role-thresholds.test.js
+++ b/tests/unit/statusline-role-thresholds.test.js
@@ -104,3 +104,62 @@ describe('compaction-thresholds: TS-6 no database in the render path', () => {
     expect(called).toBe(1); // only the injected file reader is invoked
   });
 });
+
+// ── SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: adam role + burn-feed helpers ──
+describe('compaction-thresholds: TS-7 adam role detection + earlier thresholds', () => {
+  const coordNull = () => null;
+  const adamMatch = () => ({ session_id: 'adam-1' });
+  const adamNull = () => null;
+
+  it('matching active-adam.json session_id => adam (no coordinator file)', () => {
+    expect(ct.detectRoleFromFile('adam-1', coordNull, adamMatch)).toBe('adam');
+  });
+  it('coordinator match WINS over an adam match (double-tagged session)', () => {
+    const coordMatch = () => ({ session_id: 'both-1' });
+    const adamAlso = () => ({ session_id: 'both-1' });
+    expect(ct.detectRoleFromFile('both-1', coordMatch, adamAlso)).toBe('coordinator');
+  });
+  it('non-matching adam marker preserves prior behavior exactly (worker/solo)', () => {
+    const coordOther = () => ({ session_id: 'someone-else' });
+    const adamOther = () => ({ session_id: 'not-me' });
+    expect(ct.detectRoleFromFile('me', coordOther, adamOther)).toBe('worker');
+    expect(ct.detectRoleFromFile('me', coordNull, adamOther)).toBe('solo');
+  });
+  it('adam reader throwing falls back safely (never crashes, prior semantics)', () => {
+    const boom = () => { throw new Error('fs boom'); };
+    expect(ct.detectRoleFromFile('me', coordNull, boom)).toBe('solo');
+  });
+  it('flag ON: adam gets the earlier (coordinator-grade) thresholds; flag OFF: global', () => {
+    expect(ct.selectThresholds('adam', true)).toEqual(ct.COORDINATOR_THRESHOLDS);
+    expect(ct.selectThresholds('adam', false)).toEqual(ct.GLOBAL_THRESHOLDS);
+  });
+});
+
+describe('context-usage-feed: TS-8 burn-feed entry shape + throttle (SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001)', () => {
+  const feed = require('../../.claude/context-usage-feed.cjs');
+  const sample = { sessionId: 's1', modelId: 'claude-x', contextUsed: 1000, contextSize: 2000, usagePercent: 50, inputTokens: 400, outputTokens: 100, cacheCreationTokens: 300, cacheReadTokens: 200, status: 'HEALTHY', cwd: 'C:/x', now: new Date('2026-07-09T00:00:00Z') };
+
+  it('buildUsageEntry matches the sync-context-usage transformEntry field shape', () => {
+    const e = feed.buildUsageEntry(sample);
+    expect(Object.keys(e).sort()).toEqual([
+      'cache_creation_tokens', 'cache_read_tokens', 'compaction_detected', 'context_size', 'context_used',
+      'input_tokens', 'model_id', 'output_tokens', 'session_id', 'status', 'timestamp', 'usage_percent', 'working_directory',
+    ].sort());
+    expect(e.session_id).toBe('s1');
+    expect(e.usage_percent).toBe(50);
+    expect(e.timestamp).toBe('2026-07-09T00:00:00.000Z');
+  });
+  it('throttles an unchanged percent+status repaint (no append)', () => {
+    const e = feed.buildUsageEntry(sample);
+    expect(feed.shouldAppendUsage({ last_percent: 50, last_status: 'HEALTHY' }, e)).toBe(false);
+  });
+  it('appends on first sample, percent change, or status change', () => {
+    const e = feed.buildUsageEntry(sample);
+    expect(feed.shouldAppendUsage(null, e)).toBe(true);
+    expect(feed.shouldAppendUsage({ last_percent: 49, last_status: 'HEALTHY' }, e)).toBe(true);
+    expect(feed.shouldAppendUsage({ last_percent: 50, last_status: 'CRITICAL' }, e)).toBe(true);
+  });
+  it('rejects a malformed next entry (no percent) — never appends garbage', () => {
+    expect(feed.shouldAppendUsage(null, { status: 'HEALTHY' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
**Chairman directive 2026-07-09:** session-limit token burn handled automatically — no manual /compact tracking. The burn comes from long-lived role sessions (Adam, coordinator) whose crons wake the LLM every 2–15 min for mostly no-op polls. Key discovery: the consolidation machinery **already existed and shipped inert** (`docs/protocol/fleet-hibernation-quiet-tick.md`) — this PR executes its documented cutover plus the compaction/observability legs.

**1. Quiet-tick cron cutover** (the big lever, ~37–45 LLM ticks/hr → ≤6/hr in quiescence per the design doc):
- `STANDARD_LOOPS`: single self-pacing `coordinator-quiet-tick` (cron 0,15,30,45) folds inbox/audit/charter-audit/capacity-forecast/backlog-rank (kept registered, `folded: true` — parity guard intact; render skips arming + emits CronDelete teardown for live standalone crons).
- `ADAM_LOOPS`: single `adam-quiet-tick` (cron 7,22,37,52 — offset so parties never co-fire) folds inbox-monitor/belt-countdown/offer-help **and** the pre-existing `board-reconcile` loop, which ran the same aggregator at 12×/hr and would have defeated the reduction.
- Teardown registry mirrors the coordinator quiet-tick.

**2. Role-aware proactive compaction ON + Adam:** `COORD_COMPACTION_THRESHOLD_V2=on` in settings env; `detectRoleFromFile` learns `adam` via new `.claude/active-adam.json` (written by adam-startup-check at Adam startup; coordinator wins a double tag; missing marker = prior behavior); adam gets the earlier 85/92 profile.

**3. Unmistakable EMERGENCY:** statusline renders `‼ EMERGENCY — /compact NOW` (was a missable `!`).

**4. Burn-observability feed repaired:** `context_usage_log` + sync + RPC existed but were starved (the active statusline never appended the JSONL feed). statusline now appends contract-shaped entries via pure `.claude/context-usage-feed.cjs` helpers, throttled to percent/status changes, fail-soft. Turns/hour = row cadence: 'which session is the burner' is a query.

## Test plan
31/31 green: quiet-tick **loop-parity guard** (6 — enforces no folded core is lost), role-thresholds suite (25, incl. 9 new: adam detection/priority/fail-safe/thresholds + feed entry shape/throttle). Live: both quiet-tick `--dry-run`s compose the folded cores; both startup-check renders show folded-skip + teardown guidance; statusline parses.

## Rollout
New schedules arm when Adam/coordinator next run their startup-check (documented cutover step 3); old standalone crons are torn down via the emitted CronDelete guidance. Out of scope (per SD): the harness 80% auto-compact trigger, per-account quota tracking, model right-sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)