### PR TITLE
fix(QF-20260709-881): block fable-tier downward self-claim during active Fable window

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -46,6 +46,7 @@ const { isSdExecutableHere } = require('./sd-executable-here.cjs');
 // downward-claim reservation branch below. lowerTierBacklog does NOT touch the DB itself — the
 // caller precomputes ctx.lower_tier_backlog_data once per tick (see tier-backlog.cjs docstring).
 const { lowerTierBacklog } = require('./tier-backlog.cjs');
+const { ladderTopRank } = require('./tier-ladder.cjs');
 
 /**
  * PURE, synchronous, DB-free dispatch-ineligibility classifier for the non-dependency axes.
@@ -67,8 +68,8 @@ const { lowerTierBacklog } = require('./tier-backlog.cjs');
  * min_tier_rank) FAIL CLOSED ('tier_stamp_missing') instead of silently skipping the whole axis.
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
- * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object }} [ctx]  when present, applies the claim-time fitness + tier axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'tier_stamp_missing' | 'above_worker_tier' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object, fable_window_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'tier_stamp_missing' | 'above_worker_tier' | 'fable_window_downward_claim_blocked' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
@@ -157,6 +158,17 @@ function classifyDispatchIneligibility(sdRow, ctx) {
     } else {
       const workerRank = Number(ctx.worker_tier_rank);
       if (Number.isFinite(minRank) && minRank > workerRank) return 'above_worker_tier';
+      // QF-20260709-881: a top-rung (fable) seat self-claiming BELOW-tier belt work during an
+      // active Fable-window burns expensive Fable wall-clock that should go to directed door/
+      // queued high-tier work instead (recurred 2x same-day: Golf-2 unstamped one-way SWEEP
+      // claim, Charlie/2d178139 arrival self-claim of Sonnet-lane Child B). This OVERRIDES the
+      // FR-6 backlog allowance below — a genuine lower-tier backlog does not excuse the burn-down
+      // while the window is active; only an explicit coordinator dispatch (which does not route
+      // through this classifier) may hand a top-rung seat downward work in that window.
+      if (ctx.fable_window_active === true && workerRank >= ladderTopRank()
+        && Number.isFinite(minRank) && minRank < workerRank) {
+        return 'fable_window_downward_claim_blocked';
+      }
       // FR-6 WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED: a worker claims AT its own rung
       // unconditionally (minRank === workerRank falls through unchanged); claiming a STRICTLY
       // LOWER rung is gated on that lower tier having a genuine backlog, reserving capability

--- a/lib/fleet/tier-backlog.cjs
+++ b/lib/fleet/tier-backlog.cjs
@@ -133,4 +133,25 @@ async function fetchLowerTierBacklogData(supabase) {
   }
 }
 
-module.exports = { idleWorkerCensusByTier, lowerTierBacklog, fetchLowerTierBacklogData };
+/**
+ * QF-20260709-881: is the chairman-toggled Fable-window burn-down guard currently active?
+ * Reads chairman_dashboard_config.metadata.fable_window_active (config_key='default'), the same
+ * JSONB flag-bag lib/claim-guard.mjs's fetchClaimTTL reads claim_ttl_minutes from. Fail-open to
+ * false — a config-fetch fault must never block a claim that would otherwise proceed.
+ * @param {object} supabase service-role client
+ * @returns {Promise<boolean>}
+ */
+async function fetchFableWindowActive(supabase) {
+  try {
+    const { data } = await supabase
+      .from('chairman_dashboard_config')
+      .select('metadata')
+      .eq('config_key', 'default')
+      .single();
+    return data?.metadata?.fable_window_active === true;
+  } catch {
+    return false; // fail-open: config unavailable, never block a claim over this
+  }
+}
+
+module.exports = { idleWorkerCensusByTier, lowerTierBacklog, fetchLowerTierBacklogData, fetchFableWindowActive };

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -49,13 +49,13 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
-const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort } = require('../lib/fleet/tier-ladder.cjs');
+const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
 const { claimableForTier } = require('../lib/fleet/tier-claimable.cjs');
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): backlog-gated downward claims. The fetcher is
 // SHARED with lib/coordinator/dispatch.cjs's assertWorkerTierAllowed so the pull path (here) and
 // the directed-dispatch path compute an IDENTICAL backlog verdict — never two re-derivations.
-const { fetchLowerTierBacklogData } = require('../lib/fleet/tier-backlog.cjs');
+const { fetchLowerTierBacklogData, fetchFableWindowActive } = require('../lib/fleet/tier-backlog.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId, tierRankOf, pickCallsignForTier, callsignInTierBand } = require('./assign-fleet-identities.cjs');
@@ -1790,6 +1790,11 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     if (tierCtx.tiering_active === true) {
       const backlogData = await fetchLowerTierBacklogData(sb);
       if (backlogData) tierCtx.lower_tier_backlog_data = backlogData;
+      // QF-20260709-881: only a top-rung (fable) worker's downward claims are gated on this, so
+      // only fetch when relevant — avoids a config round-trip for every sub-top-rung checkin.
+      if (Number(tierCtx.worker_tier_rank) >= ladderTopRank()) {
+        tierCtx.fable_window_active = await fetchFableWindowActive(sb);
+      }
     }
     // QF-20260630-761: snapshot whether tiering is active so the idle message (below, outside this
     // scope) only attributes a 0-claimable belt to TIER when tiering is actually on. With tiering off

--- a/tests/unit/fleet/fable-window-downward-claim-guard.test.js
+++ b/tests/unit/fleet/fable-window-downward-claim-guard.test.js
@@ -1,0 +1,51 @@
+/**
+ * QF-20260709-881 — Fable-window burn-down guard.
+ *
+ * A top-rung (fable) worker's downward self-claim (min_tier_rank < worker_tier_rank) must be
+ * blocked while ctx.fable_window_active is true, REGARDLESS of a genuine lower-tier backlog —
+ * this overrides FR-6's normal backlog-permits-downward-claim allowance for the duration of the
+ * window. Sub-top-rung workers and non-downward claims are unaffected.
+ */
+import { describe, it, expect } from 'vitest';
+import { ladderTopRank } from '../../../lib/fleet/tier-ladder.cjs';
+import { classifyDispatchIneligibility } from '../../../lib/fleet/claim-eligibility.cjs';
+
+const TOP = ladderTopRank();
+const backlogPresent = { claimableBreakdown: { cumulative: { 1: 5 } }, idleCensus: { cumulative: { 1: 1 } } };
+
+describe("classifyDispatchIneligibility 'fable_window_downward_claim_blocked' branch", () => {
+  it('blocks a top-rung downward claim during an active Fable window, even with a genuine backlog', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, {
+      worker_tier_rank: TOP, tiering_active: true, fable_window_active: true, lower_tier_backlog_data: backlogPresent,
+    })).toBe('fable_window_downward_claim_blocked');
+  });
+
+  it('admits the same downward claim when the Fable window is inactive (falls through to FR-6)', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, {
+      worker_tier_rank: TOP, tiering_active: true, fable_window_active: false, lower_tier_backlog_data: backlogPresent,
+    })).toBeNull();
+  });
+
+  it('does not block a sub-top-rung worker even during an active Fable window', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, {
+      worker_tier_rank: TOP - 1, tiering_active: true, fable_window_active: true, lower_tier_backlog_data: backlogPresent,
+    })).toBeNull();
+  });
+
+  it('does not block an AT-rung claim (min_tier_rank === worker_tier_rank) during an active window', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: TOP } };
+    expect(classifyDispatchIneligibility(sd, {
+      worker_tier_rank: TOP, tiering_active: true, fable_window_active: true,
+    })).toBeNull();
+  });
+
+  it('is byte-identical (null-safe) when fable_window_active is omitted', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, {
+      worker_tier_rank: TOP, tiering_active: true, lower_tier_backlog_data: backlogPresent,
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Recurred 2x same-day (Golf-2 unstamped one-way SWEEP claim; Charlie/2d178139 arrival self-claim of Sonnet-lane Child B). `min_tier_rank` is a FLOOR and cannot express LANES -- nothing stopped a tier-4/fable seat from silently self-claiming below-tier belt work while directed door/queued high-tier work was pending, burning expensive Fable wall-clock.
- Extends the existing FR-6 WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED axis in `classifyDispatchIneligibility` with a chairman-toggled override: when `chairman_dashboard_config.metadata.fable_window_active` is true, a top-rung worker's downward claim is blocked regardless of a genuine lower-tier backlog.
- Directed coordinator dispatch (which does not route through this classifier) is unaffected -- only silent arrival self-claim is refused.

## Test plan
- [x] `npx vitest run tests/unit/fleet/fable-window-downward-claim-guard.test.js` -- 5/5 pass
- [x] `npx vitest run tests/unit/fleet tests/unit/worker-checkin*.test.js` -- 59 files, 652 tests, 0 failures
- [x] `node --check` + ESLint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)