### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B): distribution PLAN rebuild — thesis-derived channels, fail-partial, binding gate

### DIFF
--- a/lib/eva/eva-orchestrator-helpers.js
+++ b/lib/eva/eva-orchestrator-helpers.js
@@ -254,6 +254,21 @@ async function loadStageTemplate(supabase, stageId) {
             };
           }
 
+          // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B FR-6: policy-halt sentinels
+          // (_blocked/_skip) must ALSO surface at the top level. Burying them inside
+          // `payload` (legacy path below) makes classifyStepResult() fall through to
+          // 'fallback_persist', which writes the sentinel as requiredArtifacts[0]
+          // (e.g. distribution_channel_config) — accidentally SATISFYING the
+          // artifact-precondition gate the stage deliberately withheld. Same seam
+          // class as the typed-array hoist above (adversarial review, PR #5753).
+          if (result && typeof result === 'object' && (result._blocked === true || result._skip === true)) {
+            return {
+              ...result,
+              source: jsTemplate.id || `stage-${stageId}`,
+              usage: result?.usage,
+            };
+          }
+
           return {
             artifactType: null,
             payload: result,

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -96,6 +96,28 @@ const FILTER_PREFERENCE_KEYS = [
  * @param {Function} [deps.httpClient] - HTTP client for reality gates
  * @returns {Promise<Object>} Stage result
  */
+/**
+ * Pure. Classifies an analysis-step return value into exactly one handling kind.
+ * These ARE the step-result branch conditions in processStage — kept as one
+ * exported classifier so the routing is unit-testable (SD-LEO-INFRA-VENTURE-
+ * DEMAND-DISTRIBUTION-001-B FR-6):
+ * - 'typed_artifacts': `{artifacts:[...]}` non-empty — each entry persisted, no fallback
+ * - 'skip':            `_skip:true` — stage owns its skip marker; NO fallback persist
+ * - 'blocked':         `_blocked:true` — stage owns block marker + recorded chairman
+ *                      decision and deliberately withholds required artifacts so the
+ *                      artifact-precondition gate halts advancement; NO fallback persist
+ * - 'fallback_persist': anything else — generic fallback artifact persisted
+ *
+ * @param {Object|null|undefined} stepResult
+ * @returns {'typed_artifacts'|'skip'|'blocked'|'fallback_persist'}
+ */
+export function classifyStepResult(stepResult) {
+  if (Array.isArray(stepResult?.artifacts) && stepResult.artifacts.length > 0) return 'typed_artifacts';
+  if (stepResult?._skip === true) return 'skip';
+  if (stepResult?._blocked === true) return 'blocked';
+  return 'fallback_persist';
+}
+
 export async function processStage({ ventureId, stageId, options = {} }, deps = {}) {
   const {
     supabase, logger = console, httpClient,
@@ -342,7 +364,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   }
 
   // ── 3b. Cross-stage contract pre-validation (advisory, not blocking) ──
-  let contractPreErrors = [];
+  let _contractPreErrors = []; // eslint drive-by: assigned for future downstream visibility, never read
   const contract = getContract(resolvedStage);
   if (contract && contract.consumes.length > 0) {
     const preSpan = tracer.startSpan('contract_pre_validation');
@@ -361,7 +383,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         // stage-execution-worker.js) provides defense-in-depth if needed.
         logger.warn(`[Eva][Contract] Pre-stage ${resolvedStage} validation: ${preResult.errors.length} error(s) [advisory] { errors: ${JSON.stringify(preResult.errors)} }`);
         // Store errors for downstream visibility but don't block
-        contractPreErrors = preResult.errors.map(e => ({ code: 'CONTRACT_PRE_VALIDATION', message: e }));
+        _contractPreErrors = preResult.errors.map(e => ({ code: 'CONTRACT_PRE_VALIDATION', message: e }));
       }
     } catch (err) {
       tracer.endSpan(preSpan.spanId, { status: 'failed', metadata: { error: err.message } });
@@ -486,7 +508,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
           }, { supabase, logger });
         }
 
-        if (Array.isArray(stepResult.artifacts) && stepResult.artifacts.length > 0) {
+        const stepKind = classifyStepResult(stepResult);
+        if (stepKind === 'typed_artifacts') {
           stepProvidedTypedArtifacts = true;
           for (const a of stepResult.artifacts) {
             artifacts.push({
@@ -498,7 +521,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
               ...(a.gaps ? { gaps: a.gaps } : {}),
             });
           }
-        } else if (stepResult._skip === true) {
+        } else if (stepKind === 'skip') {
           // SD-LEO-FIX-FIX-STAGE-SKIP-001: a precondition-skip is OWNED by the stage's
           // own skip-marker writer (e.g. persistSkipMarker → `<stage>_skipped`). Do NOT
           // persist a generic fallback artifact here: the fallback resolves artifactType
@@ -509,6 +532,14 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
           // venture over 6.6 days). Suppressing the generic persist for `_skip` payloads
           // applies to every stage that returns a skip; normal (non-skip) writes unaffected.
           logger.info?.(`[Eva] Stage ${resolvedStage} step returned _skip (reason=${stepResult.skip_reason || 'unknown'}); skip marker owned by the stage — no generic fallback artifact persisted.`);
+        } else if (stepKind === 'blocked') {
+          // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B FR-6: a policy BLOCK is
+          // owned by the stage (block marker + recorded chairman decision). The stage
+          // deliberately withholds its required artifacts so the artifact-precondition
+          // gate halts advancement — persisting the generic fallback here (typed
+          // requiredArtifacts[0]) would accidentally SATISFY that gate and defeat the
+          // binding block. Suppress it, exactly like the _skip branch above.
+          logger.warn?.(`[Eva] Stage ${resolvedStage} step returned _blocked (reason=${stepResult.block_reason || 'unknown'}); block marker + decision owned by the stage — no generic fallback artifact persisted.`);
         } else {
           const fallbackType = stepResult.artifactType || step.artifactType || requiredArtifacts[0] || (ARTIFACT_TYPE_BY_STAGE[resolvedStage]?.[0]);
           if (!fallbackType) {
@@ -1405,6 +1436,7 @@ export async function run({ ventureId, options = {} }, deps = {}) {
 
 export const _internal = {
   buildResult,
+  classifyStepResult,
   computeActionPreview,
   assertActionPreviewConsistent,
   mergeArtifactOutputs,

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -313,6 +313,23 @@ export function validateOutput(output, template) {
 }
 
 /**
+ * Pure. True when an analysisStep output is a POLICY HALT sentinel — a stage-owned
+ * block (`_blocked:true`, e.g. the Distribution binding gate) or skip (`_skip:true`).
+ * Such outputs must NEVER be persisted as stage artifacts: persistArtifact would
+ * write the sentinel as the stage's canonical artifact type
+ * (ARTIFACT_TYPE_BY_STAGE[stage][0]) and accidentally satisfy the
+ * artifact-precondition gate the stage is deliberately withholding.
+ * SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B FR-6 (executeStage path).
+ *
+ * @param {Object|null|undefined} output - analysisStep return value
+ * @returns {boolean}
+ */
+export function isPolicyHaltOutput(output) {
+  return Boolean(output) && typeof output === 'object'
+    && (output._blocked === true || output._skip === true);
+}
+
+/**
  * Persist stage artifact to venture_artifacts.
  * Marks previous versions as is_current=false.
  *
@@ -593,6 +610,32 @@ export async function executeStage(options = {}) {
         output.chairmanGate = { status: 'pending', rationale: null, decision_id: beforeAnalysisContext.chairmanDecisionId };
       }
     }
+  }
+
+  // 4.55. Stage-owned policy halt (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B FR-6):
+  // a _blocked/_skip sentinel is a deliberate stage decision (block marker + recorded
+  // chairman decision already written by the stage), not stage output. Return it
+  // FAITHFULLY before post-stage contract validation — otherwise the contract check
+  // mislabels the policy block as a contract violation ('post-stage-blocked',
+  // output discarded) and operators debug contracts instead of reading the block
+  // marker. Nothing is persisted: the stage withholds its required artifacts so the
+  // artifact-precondition gate halts advancement.
+  if (isPolicyHaltOutput(output)) {
+    const haltKind = output._blocked === true ? '_blocked' : '_skip';
+    logger.log(`   Persist skipped: step returned ${haltKind} (${output.block_reason || output.skip_reason || 'no reason given'}) — marker/decision owned by the stage`);
+    return {
+      stageNumber,
+      ventureId,
+      template: template.id || `stage-${stageNumber}`,
+      hasAnalysisStep,
+      output,
+      validation: { valid: true, errors: [] },
+      artifactId: null,
+      dryRun,
+      latencyMs: Date.now() - startTime,
+      persisted: false,
+      policyHalt: haltKind,
+    };
   }
 
   // 4.6. Post-stage contract validation (SD-MAN-INFRA-STAGE-DATA-FLOW-001: FR-001)

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -1,17 +1,29 @@
 /**
- * Stage 22 Analysis Step — Distribution Setup
+ * Stage 22 Analysis Step — Distribution Setup (thesis-derived rebuild)
  * Phase: BUILD & MARKET (Stages 18-22)
- * SD: SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001 (refactor of SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-D)
+ * SD: SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B (design D1, parent PRD FR-2;
+ *     rebuild of SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001)
  *
- * Configures distribution channels from GTM strategy (S12) and persona
- * demographics (S10). Generates platform-specific ad copy with targeting.
+ * NOTE: file is named stage-22 but runs as the Distribution stage (stage_number 21)
+ * after the 21/22 content swap (migration 20260607_swap_stage_21_22_full_content.sql).
+ * All artifact writes pin lifecycle_stage 21.
  *
- * FR-1: emits two canonical venture_artifacts rows (distribution_channel_config
- *       + distribution_ad_copy) instead of one bundled launch_deployment_runbook.
- *       Dual-emits the legacy row while LEO_S22_GATES_ENABLED=false (backward compat).
- * FR-3: refuses to run when upstream preconditions absent; emits SKIP marker
- *       artifact noting which precondition is missing.
- * FR-4: validates all 6 spec'd channels with explicit enabled+skip_reason.
+ * Semantics (inverted from the fixed-six/skip-and-advance original):
+ * - Channels DERIVE from the venture's demand-thesis CHANNEL claim
+ *   (truth_demand_thesis artifact). Open taxonomy — integration/marketplace/
+ *   partnership/referral are first-class; there is NO fixed channel universe.
+ * - Persona×channel JOIN: every channel maps to a persona named in the WHO
+ *   claim, or that channel is invalidated with COHERENCE_JOIN_GAP.
+ * - Fail-PARTIAL: one malformed channel invalidates only that channel's
+ *   experiment, never the stage.
+ * - BINDING gate: total failure (no thesis / no joinable channels / all
+ *   experiments invalid / generation failure) records a blocking
+ *   chairman_decisions row + a distribution_block_marker artifact, withholds
+ *   the canonical pair (so the artifact-precondition gate blocks advancement),
+ *   and returns {_blocked:true}. There is NO _skip:true and NO fabricated
+ *   fallback portfolio on this path.
+ * - The ONLY skip path is an approved chairman 'distribution_skip' decision,
+ *   honored via BUILD_DEVIATION_RECORD rows (the existing artifact-gate valve).
  *
  * @module lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup
  */
@@ -23,96 +35,80 @@ import { getOperatingModelPromptBlock } from '../../standards/operating-model.js
 // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D (FR-004): pre-launch Growth Playbook co-output.
 import { runPrelaunchGrowthCoOutput } from './prelaunch-growth-playbook.js';
 import { describeArtifactGap } from '../../contracts/describe-artifact-gap.js';
+import { recordPendingDecision } from '../../../chairman/record-pending-decision.mjs';
+import { recordDeviation } from '../../deviation-ledger.js';
 
-const CHANNELS = ['app_store', 'google_ads', 'facebook_instagram', 'twitter_x', 'email', 'blog_seo'];
+/** Consumption contract: the demand-thesis artifact this step reads.
+ *  Producer is design-only today (docs/design/venture-selection-demand-thesis-design.md);
+ *  validateThesisChannelClaim below is the written, tested contract it must satisfy. */
+const THESIS_ARTIFACT_TYPE = 'truth_demand_thesis';
 
+const BLOCK_DECISION_TYPE = 'distribution_block';
+const SKIP_DECISION_TYPE = 'distribution_skip';
+/** Same approved-decision vocabulary advance_venture_stage matches at chairman gates. */
+const APPROVED_DECISIONS = ['pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release'];
+
+const LIFECYCLE_STAGE = 21;
+const ARTIFACT_SOURCE = 'worker_sd_leo_infra_venture_demand_distribution_001_b';
+const CANONICAL_PAIR_TYPES = ['distribution_channel_config', 'distribution_ad_copy'];
+const EXECUTION_TIERS = ['T0', 'T1', 'T2'];
+
+/**
+ * Value-domain normalization for the legacy consumer allowlist.
+ * selectOrganicChannel (lib/marketing/organic-channel-provisioning.js) filters
+ * channels[].channel against a CLOSED set (blog_seo|twitter_x|email|
+ * facebook_instagram). Thesis-derived names that cleanly map onto a legacy
+ * platform are normalized so that consumer keeps working; unmappable
+ * open-taxonomy names (community, integration, marketplace, partnership,
+ * referral, ...) pass through unchanged — selectOrganicChannel returning null
+ * for those is documented acceptable (it fail-softs with a reason; the Child C
+ * execution rail consumes the portfolio directly).
+ */
+const LEGACY_CHANNEL_NAME_MAP = {
+  x: 'twitter_x',
+  twitter: 'twitter_x',
+  twitter_x: 'twitter_x',
+  build_in_public: 'twitter_x',
+  seo: 'blog_seo',
+  blog: 'blog_seo',
+  blog_seo: 'blog_seo',
+  content_seo: 'blog_seo',
+  email: 'email',
+  newsletter: 'email',
+  facebook: 'facebook_instagram',
+  instagram: 'facebook_instagram',
+  facebook_instagram: 'facebook_instagram',
+};
+
+/** Pure. Normalizes a thesis channel name onto the legacy platform taxonomy
+ *  where a clean mapping exists; open-taxonomy names pass through unchanged. */
+export function normalizeChannelName(name) {
+  const key = String(name || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+  return LEGACY_CHANNEL_NAME_MAP[key] || key;
+}
+
+/** Legacy upstream context (S7 pricing / S10 persona / S12 GTM). These are
+ *  OPTIONAL LLM context — no longer skip-triggering preconditions (the old
+ *  precondition-skip path was the second silent-skip source). The param_key
+ *  convention (stage{N}Data) is pinned by
+ *  stage-precondition-whole-stage-key-invariant.test.js. */
 const REQUIRED_UPSTREAM = [
-  { artifact_type: 'engine_pricing_model',          source_stage: 7,  param_key: 'stage7Data' },
-  { artifact_type: 'identity_persona_brand',        source_stage: 10, param_key: 'stage10Data' },
-  { artifact_type: 'identity_gtm_sales_strategy',   source_stage: 12, param_key: 'stage12Data' },
-  // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A (PRD FR-003, option-ii): Distribution now runs
-  // BEFORE Visual Assets (Distribution at stage 21, Visual at 22), so it no longer consumes
-  // visual_social_graphics / visual_device_screenshots as upstream — that was a FORWARD
-  // dependency contradicting the resequence (it caused precondition_missing). Visual now
-  // consumes Distribution downstream, not vice-versa. Distribution's real preconditions are
-  // pricing(7) / persona(10) / GTM(12).
+  { artifact_type: 'engine_pricing_model', source_stage: 7, param_key: 'stage7Data' },
+  { artifact_type: 'identity_persona_brand', source_stage: 10, param_key: 'stage10Data' },
+  { artifact_type: 'identity_gtm_sales_strategy', source_stage: 12, param_key: 'stage12Data' },
 ];
 
 const FEATURE_FLAG_KEY = 'LEO_S22_GATES_ENABLED';
 
-const SYSTEM_PROMPT = `You are EVA's Distribution Planner. Configure marketing distribution channels and generate ad copy based on GTM strategy and target personas.
-
-Output valid JSON:
-{
-  "channels": [
-    {
-      "channel": "app_store|google_ads|facebook_instagram|twitter_x|email|blog_seo",
-      "status": "active|pending|skipped",
-      "reason": "Why this channel is active or skipped",
-      "ad_copy": {
-        "headline": "Ad headline for this channel",
-        "body": "Ad body text (channel-appropriate length)",
-        "cta": "Call to action text"
-      },
-      "targeting": {
-        "audience": "Target audience description",
-        "demographics": "Age, location, interests",
-        "keywords": ["keyword1", "keyword2"]
-      }
-    }
-  ],
-  "email_sequences": [
-    {
-      "sequence_name": "welcome|onboarding|reengagement",
-      "emails_count": 3,
-      "cadence": "Day 0, Day 3, Day 7",
-      "preview": "Brief description of the sequence"
-    }
-  ],
-  "budget_allocation": {
-    "total_monthly": "Recommended monthly budget",
-    "by_channel": { "google_ads": "40%", "facebook_instagram": "35%", "twitter_x": "15%", "blog_seo": "10%" }
-  }
-}
-
-Rules:
-- Configure at least 3 channels as active
-- Each active channel must have ad copy and targeting
-- Email sequences should reference the S18 copy (welcome, onboarding, re-engagement)
-- Targeting should use persona demographics (age, interests, pain points)
-
-${getOperatingModelPromptBlock()}
-
-DISTRIBUTION RULES (EHG operating model — organic-first GTM, solo + AI-agent):
-- ORGANIC channels (twitter_x/X, Bluesky, blog_seo + Stage-18 AI-generated copy, email) are the PRIMARY/default at launch.
-- PAID channels (google_ads, facebook_instagram) are SECONDARY — a later-stage opt-in, with $0 budget at launch.
-- budget_allocation at launch should be ~$0 paid: weight organic. Total monthly should reflect the operating-model marketing band ($0-200/mo), NOT a generic paid-ads budget.`;
-
 /**
- * Pure helper. Normalizes worker-provided upstream params into the bespoke
- * param_keys this producer's REQUIRED_UPSTREAM declares.
- *
- * The generic worker loader (lib/eva/stage-execution-engine.js fetchUpstreamArtifacts)
- * keys upstream data as `stage${N}Data` (merged-by-stage) with a `__byType` sub-map
- * keyed by artifact_type. Params whose param_key already follows the `stage${N}Data`
- * convention (stage7Data/stage10Data/stage12Data) arrive correctly. (Per
- * SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A the former bespoke S21 visual keys were removed —
- * Distribution no longer consumes Visual upstream — so all current REQUIRED_UPSTREAM
- * entries follow the stage{N}Data convention; the generic __byType derivation below is a
- * no-op for them and retained only for any future bespoke key.)
- *
- * Mirrors the `extractUpstreamByType` pattern in stage-18-marketing-copy.js, but
- * maps to this producer's declared param_keys via REQUIRED_UPSTREAM. Pure + DB-less:
- * operates only on the passed-in params, returns a shallow copy (does not mutate
- * input), and tolerates absent stages / missing __byType.
- *
+ * Pure helper (unchanged from the pre-rebuild module). Normalizes
+ * worker-provided upstream params into the param_keys REQUIRED_UPSTREAM
+ * declares. Tolerates absent stages / missing __byType; returns a shallow copy.
  * SD-LEO-FIX-FIX-POST-BUILD-001.
  */
 export function normalizeUpstreamParams(params) {
   const out = { ...(params || {}) };
   for (const req of REQUIRED_UPSTREAM) {
-    // Already populated under the declared param_key (e.g. stage7Data from the
-    // loader's stage{N}Data convention)? Leave it untouched.
     const existing = out[req.param_key];
     if (existing && typeof existing === 'object' && Object.keys(existing).length > 0) continue;
 
@@ -121,8 +117,6 @@ export function normalizeUpstreamParams(params) {
 
     const byTypeEntry = stageData.__byType && stageData.__byType[req.artifact_type];
     if (byTypeEntry && typeof byTypeEntry === 'object') {
-      // fetchUpstreamArtifacts stores the unwrapped artifact_data under __byType;
-      // tolerate a {artifact_data}/{content} wrapper defensively.
       const data = byTypeEntry.artifact_data || byTypeEntry.content || byTypeEntry;
       if (data && typeof data === 'object' && Object.keys(data).length > 0) {
         out[req.param_key] = data;
@@ -133,70 +127,181 @@ export function normalizeUpstreamParams(params) {
 }
 
 /**
- * Pure helper. Returns {ok, missing[]} where missing names which upstream
- * artifact_type is absent. Does not call the database.
+ * @typedef {Object} ThesisChannelEntry
+ * @property {string} channel - reachable-path name from the CHANNEL claim
+ *   (open taxonomy; e.g. 'community', 'integration', 'twitter_x', 'blog_seo')
+ * @property {string} [channel_type] - taxonomy hint (social|search|email|content|
+ *   integration|marketplace|partnership|referral|...)
+ * @property {string|string[]} [persona] - name(s) of the WHO-claim persona this
+ *   channel reaches (also accepted: persona_name, personas)
+ * @property {string} [cost_hypothesis] - cost-to-first-100-strangers hypothesis
+ *
+ * @typedef {Object} DemandThesis
+ * @property {Object|Array} claims - keyed (WHO/CHANNEL/...) object or array of
+ *   {claim_type|type|key, ...} entries. CHANNEL claim carries {channels:
+ *   ThesisChannelEntry[]}; WHO claim carries {personas: (string|{name})[]}.
+ *   Source: docs/design/venture-selection-demand-thesis-design.md (six claims;
+ *   persona×channel JOIN rule from docs/design/venture-demand-distribution-engine.md §1.1).
  */
-export function validateEntryPreconditions(params) {
-  const missing = [];
-  for (const req of REQUIRED_UPSTREAM) {
-    const data = params[req.param_key];
-    const present = data && typeof data === 'object' && Object.keys(data).length > 0;
-    if (!present) missing.push({ artifact_type: req.artifact_type, source_stage: req.source_stage });
+
+function extractClaim(claims, key) {
+  if (!claims) return null;
+  if (Array.isArray(claims)) {
+    return claims.find((c) => {
+      const t = String(c?.claim_type || c?.type || c?.key || '').toUpperCase();
+      return t === key;
+    }) || null;
   }
-  return { ok: missing.length === 0, missing };
+  if (typeof claims === 'object') {
+    return claims[key] || claims[key.toLowerCase()] || null;
+  }
+  return null;
+}
+
+function personaNamesOf(entry) {
+  const raw = entry?.persona ?? entry?.persona_name ?? entry?.personas;
+  if (!raw) return [];
+  const list = Array.isArray(raw) ? raw : [raw];
+  return list
+    .map((p) => (typeof p === 'string' ? p : p?.name))
+    .filter((n) => typeof n === 'string' && n.trim().length > 0)
+    .map((n) => n.trim());
 }
 
 /**
- * Pure helper. Validates that LLM output covers all 6 spec'd channels with
- * the required {enabled, skip_reason?, targeting?, ad_copy?} shape. Throws
- * a descriptive error on failure (caller catches and converts to SKIP).
+ * Pure. Parses + validates the demand-thesis CHANNEL/WHO claims this step
+ * consumes. Tolerates benign extra fields (additive-producer friendly).
+ * @param {DemandThesis|null|undefined} thesis - truth_demand_thesis artifact_data
+ * @returns {{ok:boolean, channels:ThesisChannelEntry[], personas:string[], problems:string[]}}
  */
-export function validateChannelCoverage(channels) {
-  if (!Array.isArray(channels)) {
-    throw new Error('validateChannelCoverage: channels is not an array');
+export function validateThesisChannelClaim(thesis) {
+  const problems = [];
+  if (!thesis || typeof thesis !== 'object') {
+    return { ok: false, channels: [], personas: [], problems: ['thesis artifact_data is missing or not an object'] };
   }
-  const seen = new Set();
-  for (const ch of channels) {
-    if (!ch || typeof ch !== 'object') {
-      throw new Error('validateChannelCoverage: non-object channel entry');
-    }
-    const name = ch.channel || ch.channel_name;
-    if (!name) throw new Error('validateChannelCoverage: channel entry missing channel name');
-    if (!CHANNELS.includes(name)) {
-      throw new Error(`validateChannelCoverage: unrecognized channel "${name}" (valid: ${CHANNELS.join(', ')})`);
-    }
-    seen.add(name);
-    const enabled = typeof ch.enabled === 'boolean'
-      ? ch.enabled
-      : (ch.status === 'active');
-    if (typeof enabled !== 'boolean') {
-      throw new Error(`validateChannelCoverage: channel "${name}" missing boolean enabled flag`);
-    }
-    if (!enabled) {
-      const reason = ch.skip_reason || ch.reason;
-      if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
-        throw new Error(`validateChannelCoverage: disabled channel "${name}" missing skip_reason`);
-      }
+  const claims = thesis.claims ?? thesis;
+  const channelClaim = extractClaim(claims, 'CHANNEL');
+  const whoClaim = extractClaim(claims, 'WHO');
+
+  const personas = [];
+  const whoPersonas = whoClaim?.personas ?? whoClaim?.persona ?? [];
+  for (const p of Array.isArray(whoPersonas) ? whoPersonas : [whoPersonas]) {
+    const name = typeof p === 'string' ? p : p?.name;
+    if (typeof name === 'string' && name.trim()) personas.push(name.trim());
+  }
+  if (personas.length === 0) problems.push('WHO claim names no personas');
+
+  let channels = [];
+  if (!channelClaim) {
+    problems.push('CHANNEL claim is missing');
+  } else {
+    const rawChannels = channelClaim.channels ?? (Array.isArray(channelClaim) ? channelClaim : null);
+    if (!Array.isArray(rawChannels) || rawChannels.length === 0) {
+      problems.push('CHANNEL claim has no channels[] entries');
     } else {
-      if (!ch.ad_copy || typeof ch.ad_copy !== 'object') {
-        throw new Error(`validateChannelCoverage: enabled channel "${name}" missing ad_copy object`);
-      }
-      if (!ch.targeting || typeof ch.targeting !== 'object') {
-        throw new Error(`validateChannelCoverage: enabled channel "${name}" missing targeting object`);
-      }
+      channels = rawChannels.filter((c) => {
+        const named = c && typeof c === 'object' && (c.channel || c.channel_type || c.name || c.type);
+        if (!named) problems.push('CHANNEL claim entry missing a channel name');
+        return named;
+      });
+      if (channels.length === 0) problems.push('CHANNEL claim entries are all unnamed');
     }
   }
-  for (const expected of CHANNELS) {
-    if (!seen.has(expected)) {
-      throw new Error(`validateChannelCoverage: missing channel "${expected}" (all 6 must appear)`);
+
+  return { ok: channels.length > 0 && personas.length > 0, channels, personas, problems };
+}
+
+/**
+ * Pure. Derives channel candidates from a parsed thesis, enforcing the
+ * persona×channel JOIN: every channel must reference a persona named in the
+ * WHO claim, or it is invalidated with COHERENCE_JOIN_GAP (fail-partial —
+ * only that channel is invalidated).
+ * @param {{channels:ThesisChannelEntry[], personas:string[]}} parsedThesis
+ * @returns {{channels:Array<{channel:string, source_channel:string, channel_type:string|null, persona:string, cost_hypothesis:string|null}>, invalid:Array<{entry:Object, invalid_reason:string}>}}
+ */
+export function deriveChannelsFromThesis(parsedThesis) {
+  const { channels = [], personas = [] } = parsedThesis || {};
+  const personaSet = new Set(personas.map((p) => p.toLowerCase()));
+  const valid = [];
+  const invalid = [];
+
+  for (const entry of channels) {
+    const sourceName = String(entry.channel || entry.name || entry.channel_type || entry.type).trim();
+    const entryPersonas = personaNamesOf(entry);
+    if (entryPersonas.length === 0) {
+      invalid.push({ entry, invalid_reason: 'COHERENCE_JOIN_GAP: channel names no persona' });
+      continue;
     }
+    const joined = entryPersonas.find((p) => personaSet.has(p.toLowerCase()));
+    if (!joined) {
+      invalid.push({ entry, invalid_reason: `COHERENCE_JOIN_GAP: persona(s) [${entryPersonas.join(', ')}] not named in WHO claim` });
+      continue;
+    }
+    valid.push({
+      channel: normalizeChannelName(sourceName),
+      source_channel: sourceName,
+      channel_type: entry.channel_type || entry.type || null,
+      persona: joined,
+      cost_hypothesis: entry.cost_hypothesis || entry.cost_to_signal || entry.cost || null,
+    });
   }
-  return true;
+
+  return { channels: valid, invalid };
+}
+
+/**
+ * Pure. Validates one channel experiment for portfolio completeness
+ * (fail-partial unit). Returns every failure reason, not just the first.
+ * @param {Object} exp
+ * @returns {{valid:boolean, reasons:string[]}}
+ */
+export function validateExperiment(exp) {
+  const reasons = [];
+  if (!exp || typeof exp !== 'object') return { valid: false, reasons: ['experiment is not an object'] };
+
+  const nonEmpty = (v) => (typeof v === 'string' && v.trim().length > 0)
+    || (typeof v === 'number' && Number.isFinite(v))
+    || (Array.isArray(v) && v.length > 0)
+    || (Boolean(v) && typeof v === 'object' && Object.keys(v).length > 0);
+
+  if (typeof exp.hypothesis !== 'string' || !exp.hypothesis.trim()) reasons.push('missing hypothesis');
+  if (typeof exp.persona_mapping !== 'string' || !exp.persona_mapping.trim()) reasons.push('missing persona_mapping');
+  if (!nonEmpty(exp.cost_to_signal_bound)) reasons.push('missing cost_to_signal_bound');
+  if (!nonEmpty(exp.success_criteria)) reasons.push('missing success_criteria');
+  if (!nonEmpty(exp.kill_criteria)) reasons.push('missing kill_criteria');
+  if (!EXECUTION_TIERS.includes(exp.execution_tier)) reasons.push(`execution_tier must be one of ${EXECUTION_TIERS.join('/')}`);
+
+  const variants = Array.isArray(exp.message_variants) ? exp.message_variants : [];
+  const wellFormed = variants.filter((v) => v && typeof v === 'object'
+    && typeof v.headline === 'string' && v.headline.trim()
+    && typeof v.body === 'string' && v.body.trim()
+    && typeof v.cta === 'string' && v.cta.trim());
+  if (wellFormed.length < 2) reasons.push(`requires >=2 well-formed message variants (headline/body/cta), got ${wellFormed.length}`);
+
+  const utm = exp.utm;
+  const utmOk = utm && typeof utm === 'object'
+    && ['utm_source', 'utm_medium', 'utm_campaign'].every((k) => typeof utm[k] === 'string' && utm[k].trim());
+  if (!utmOk) reasons.push('missing utm {utm_source, utm_medium, utm_campaign}');
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+/**
+ * Pure. Stable-ranks experiments (numeric exp.rank when the generator provided
+ * one, else original order) and stamps 1-based rank + first-touch attribution.
+ */
+export function rankExperiments(experiments) {
+  const indexed = (experiments || []).map((exp, i) => ({ exp, i }));
+  indexed.sort((a, b) => {
+    const ra = Number.isFinite(Number(a.exp?.rank)) ? Number(a.exp.rank) : Number.POSITIVE_INFINITY;
+    const rb = Number.isFinite(Number(b.exp?.rank)) ? Number(b.exp.rank) : Number.POSITIVE_INFINITY;
+    return ra === rb ? a.i - b.i : ra - rb;
+  });
+  return indexed.map(({ exp }, i) => ({ ...exp, rank: i + 1, attribution: 'first_touch' }));
 }
 
 // SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-1: flag (advisory, non-blocking) when
-// PAID channels (google_ads/facebook_instagram) exceed 20% of the budget allocation — EHG's GTM is
-// organic-first, so heavy paid spend at launch contradicts the operating model. Pure + exported.
+// PAID channels exceed 20% of the budget allocation — EHG's GTM is organic-first. Pure + exported.
 const PAID_CHANNELS = ['google_ads', 'facebook_instagram', 'paid_search', 'paid_social'];
 export function paidBudgetAdvisory(budgetAllocation) {
   const byChannel = (budgetAllocation && budgetAllocation.by_channel) || {};
@@ -211,34 +316,51 @@ export function paidBudgetAdvisory(budgetAllocation) {
 }
 
 /**
- * Pure helper. Splits the LLM result object into the canonical pair payloads.
+ * Pure. Splits the assembled portfolio into the canonical pair payloads.
+ * Back-compat contract (TR-3): channels[].{channel,status,enabled,skip_reason}
+ * with status pinned 'active' for valid experiments, plus total_channels /
+ * active_channels counts (stage-23 reads active_channels; selectOrganicChannel
+ * reads channels[].{channel,status}). Message variants live ONLY in the
+ * distribution_ad_copy artifact.
  */
-export function splitArtifacts(result) {
-  const channels = Array.isArray(result.channels) ? result.channels : [];
+export function splitArtifacts(portfolio) {
+  const experiments = Array.isArray(portfolio.experiments) ? portfolio.experiments : [];
+  const invalidExperiments = Array.isArray(portfolio.invalid_experiments) ? portfolio.invalid_experiments : [];
+
+  const backCompatChannels = [
+    ...experiments.map((exp) => ({ channel: exp.channel, status: 'active', enabled: true, skip_reason: null })),
+    ...invalidExperiments.map((inv) => ({
+      channel: normalizeChannelName(inv.channel || inv.entry?.channel || inv.entry?.name || 'unknown'),
+      status: 'skipped',
+      enabled: false,
+      skip_reason: inv.invalid_reason,
+    })),
+  ];
+
   const channelConfig = {
-    channels: channels.map(ch => {
-      const { ad_copy: _ac, ad_creative: _acr, ad_variants: _av, ...config } = ch;
-      const enabled = typeof ch.enabled === 'boolean' ? ch.enabled : (ch.status === 'active');
-      return { ...config, enabled, skip_reason: enabled ? null : (ch.skip_reason || ch.reason) };
-    }),
-    total_channels: channels.length,
-    active_channels: channels.filter(ch => (typeof ch.enabled === 'boolean' ? ch.enabled : ch.status === 'active')).length,
-    budget_allocation: result.budget_allocation || {},
-    // SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-1: advisory when paid spend exceeds
-    // the organic-first default. Non-blocking — surfaces over-reliance on paid acquisition at launch.
-    paid_budget_advisory: paidBudgetAdvisory(result.budget_allocation),
+    experiments: experiments.map(({ message_variants: variants, ...rest }) => ({
+      ...rest,
+      variant_count: Array.isArray(variants) ? variants.length : 0,
+    })),
+    invalid_experiments: invalidExperiments,
+    channels: backCompatChannels,
+    total_channels: backCompatChannels.length,
+    active_channels: experiments.length,
+    budget_allocation: portfolio.budget_allocation || {},
+    paid_budget_advisory: paidBudgetAdvisory(portfolio.budget_allocation),
+    attribution: 'first_touch',
+    thesis_version: portfolio.thesis_version || null,
   };
+
   const adCopy = {
-    channels_with_copy: channels
-      .filter(ch => (typeof ch.enabled === 'boolean' ? ch.enabled : ch.status === 'active'))
-      .map(ch => ({
-        channel: ch.channel || ch.channel_name,
-        ad_copy: ch.ad_copy || null,
-        ad_creative: ch.ad_creative || null,
-        ad_variants: ch.ad_variants || null,
-      })),
-    email_sequences: result.email_sequences || [],
+    channels_with_copy: experiments.map((exp) => ({
+      channel: exp.channel,
+      persona_mapping: exp.persona_mapping,
+      message_variants: exp.message_variants || [],
+    })),
+    email_sequences: portfolio.email_sequences || [],
   };
+
   return { channelConfig, adCopy };
 }
 
@@ -251,29 +373,234 @@ async function readFeatureFlag(supabase, logger) {
       .eq('flag_key', FEATURE_FLAG_KEY)
       .maybeSingle();
     if (error) {
-      logger?.warn?.(`[S22-Distribution] feature flag read error, defaulting OFF: ${error.message}`);
+      logger?.warn?.(`[S21-Distribution] feature flag read error, defaulting OFF: ${error.message}`);
       return false;
     }
     return Boolean(data?.is_enabled);
   } catch (err) {
-    logger?.warn?.(`[S22-Distribution] feature flag read threw, defaulting OFF: ${err.message}`);
+    logger?.warn?.(`[S21-Distribution] feature flag read threw, defaulting OFF: ${err.message}`);
     return false;
   }
 }
 
+async function readDemandThesis(supabase, ventureId, logger) {
+  if (!supabase || !ventureId) return null;
+  try {
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .select('id, artifact_data, created_at')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', THESIS_ARTIFACT_TYPE)
+      .eq('is_current', true)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) {
+      logger?.warn?.(`[S21-Distribution] demand-thesis read error: ${error.message}`);
+      return null;
+    }
+    return (data && data[0]) || null;
+  } catch (err) {
+    logger?.warn?.(`[S21-Distribution] demand-thesis read threw: ${err.message}`);
+    return null;
+  }
+}
+
+/** Latest approved chairman 'distribution_skip' decision for this venture, or null. */
+async function findApprovedSkipDecision(supabase, ventureId, logger) {
+  if (!supabase || !ventureId) return null;
+  try {
+    const { data, error } = await supabase
+      .from('chairman_decisions')
+      .select('id, decision, summary, status')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', LIFECYCLE_STAGE)
+      .eq('decision_type', SKIP_DECISION_TYPE)
+      .in('decision', APPROVED_DECISIONS)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) {
+      logger?.warn?.(`[S21-Distribution] skip-decision read error: ${error.message}`);
+      return null;
+    }
+    return (data && data[0]) || null;
+  } catch (err) {
+    logger?.warn?.(`[S21-Distribution] skip-decision read threw: ${err.message}`);
+    return null;
+  }
+}
+
+/** Existing PENDING distribution_block decision for dedup (FR-5b), or null. */
+async function findPendingBlockDecision(supabase, ventureId, logger) {
+  if (!supabase || !ventureId) return null;
+  try {
+    const { data, error } = await supabase
+      .from('chairman_decisions')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', LIFECYCLE_STAGE)
+      .eq('decision_type', BLOCK_DECISION_TYPE)
+      .eq('status', 'pending')
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) {
+      logger?.warn?.(`[S21-Distribution] pending-block read error: ${error.message}`);
+      return null;
+    }
+    return (data && data[0]) || null;
+  } catch (err) {
+    logger?.warn?.(`[S21-Distribution] pending-block read threw: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Persists the self-describing distribution_block_marker (title NOT NULL).
+ * Marks any prior current marker stale first — venture_artifacts has a partial
+ * unique index on (venture, stage, type) WHERE is_current=true, so repeated
+ * blocks must retire the previous marker.
+ */
+export async function persistBlockMarker(supabase, ventureId, detail, logger) {
+  if (!supabase || !ventureId) return { persisted: false };
+  try {
+    const { error: staleErr } = await supabase
+      .from('venture_artifacts')
+      .update({ is_current: false, updated_at: new Date().toISOString() })
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', LIFECYCLE_STAGE)
+      .eq('artifact_type', 'distribution_block_marker')
+      .eq('is_current', true);
+    if (staleErr) {
+      logger?.warn?.(`[S21-Distribution] block marker mark-stale error: ${staleErr.message}`);
+    }
+    const { error } = await supabase
+      .from('venture_artifacts')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: LIFECYCLE_STAGE,
+        artifact_type: 'distribution_block_marker',
+        title: 'Distribution blocked',
+        is_current: true,
+        source: ARTIFACT_SOURCE,
+        artifact_data: { ...detail, attempted_at: new Date().toISOString() },
+      });
+    if (error) {
+      logger?.warn?.(`[S21-Distribution] block marker persist error: ${error.message}`);
+      return { persisted: false, error: error.message };
+    }
+    return { persisted: true };
+  } catch (err) {
+    logger?.warn?.(`[S21-Distribution] block marker persist threw: ${err.message}`);
+    return { persisted: false, error: err.message };
+  }
+}
+
+/**
+ * FR-5 binding gate. Records (or reuses, dedup) a blocking pending chairman
+ * decision, persists the block marker, and returns the {_blocked:true}
+ * contract. NEVER emits _skip:true and NEVER persists the canonical pair —
+ * advancement stays blocked via the artifact-precondition gate.
+ */
+async function blockDistribution({ supabase, ventureId, ventureName, reason, detail, logger }) {
+  const label = ventureName || ventureId || 'unknown venture';
+  logger?.warn?.(`[S21-Distribution] BLOCKED (${reason}) for ${label}`);
+
+  if (!supabase || !ventureId) {
+    return { _blocked: true, block_reason: reason, block_detail: detail || null, decision_id: null, persisted: false };
+  }
+
+  let decisionId = null;
+  let decisionError = null;
+  const existing = await findPendingBlockDecision(supabase, ventureId, logger);
+  if (existing) {
+    decisionId = existing.id;
+    logger?.info?.(`[S21-Distribution] reusing pending ${BLOCK_DECISION_TYPE} decision ${decisionId}`);
+  } else {
+    // camelCase opts are the helper's real API (decisionType/lifecycleStage/title) —
+    // snake_case keys would silently default to session_question @ stage 0.
+    const res = await recordPendingDecision(supabase, {
+      title: `Distribution blocked for ${label}: ${reason}`,
+      decisionType: BLOCK_DECISION_TYPE,
+      lifecycleStage: LIFECYCLE_STAGE,
+      ventureId,
+      blocking: true,
+      context: { block_reason: reason, detail: detail || null },
+    });
+    if (res.recorded) {
+      decisionId = res.id;
+    } else {
+      // NC-7: a zero-row decision write must surface loudly, not vanish into a warn.
+      decisionError = res.error || 'unknown insert failure';
+      logger?.warn?.(`[S21-Distribution] chairman decision insert FAILED: ${decisionError} — venture stays blocked via withheld artifacts`);
+    }
+  }
+
+  await persistBlockMarker(supabase, ventureId, {
+    block_reason: reason,
+    detail: detail || null,
+    decision_id: decisionId,
+    ...(decisionError ? { decision_insert_error: decisionError } : {}),
+  }, logger);
+
+  return { _blocked: true, block_reason: reason, block_detail: detail || null, decision_id: decisionId };
+}
+
+/**
+ * FR-7 skip valve. An APPROVED chairman distribution_skip decision is honored
+ * by writing one BUILD_DEVIATION_RECORD per canonical type (the existing
+ * artifact-gate valve: the gate matches artifact_data->>artifact_ref and then
+ * reports deviated-not-blocking). recordDeviation THROWS unless weight + a
+ * non-empty why are supplied.
+ */
+async function applyApprovedSkip({ supabase, ventureId, decision, logger }) {
+  const deviationIds = [];
+  const errors = [];
+  for (const artifactRef of CANONICAL_PAIR_TYPES) {
+    try {
+      const id = await recordDeviation(supabase, {
+        ventureId,
+        artifactRef,
+        what: `${artifactRef} (Distribution stage canonical output)`,
+        instead: 'Distribution stage skipped by explicit chairman decision',
+        why: `Chairman-approved distribution skip (chairman_decisions ${decision.id}): ${decision.summary || 'no summary recorded'}`,
+        decidedBy: 'chairman',
+        weight: 'declared-descope',
+        lifecycleStage: LIFECYCLE_STAGE,
+      });
+      deviationIds.push(id);
+    } catch (err) {
+      errors.push(`${artifactRef}: ${err.message}`);
+      logger?.warn?.(`[S21-Distribution] deviation record failed for ${artifactRef}: ${err.message}`);
+    }
+  }
+
+  await persistBlockMarker(supabase, ventureId, {
+    block_reason: 'skipped_by_chairman_decision',
+    skipped_by_decision: true,
+    decision_id: decision.id,
+    deviation_ids: deviationIds,
+    ...(errors.length ? { deviation_errors: errors } : {}),
+  }, logger);
+
+  logger?.info?.(`[S21-Distribution] skip honored via chairman decision ${decision.id} (${deviationIds.length}/${CANONICAL_PAIR_TYPES.length} deviation records)`);
+  return {
+    _blocked: true,
+    skipped_by_decision: true,
+    decision_id: decision.id,
+    deviation_ids: deviationIds,
+    ...(errors.length ? { deviation_errors: errors } : {}),
+  };
+}
+
 export async function persistCanonicalPair(supabase, ventureId, channelConfig, adCopy, fullResult, options) {
   if (!supabase || !ventureId) {
-    options.logger?.warn?.('[S22-Distribution] persistCanonicalPair skipped: no supabase or ventureId');
+    options.logger?.warn?.('[S21-Distribution] persistCanonicalPair skipped: no supabase or ventureId');
     return { persisted: false, reason: 'no_supabase_or_ventureId' };
   }
 
-  // venture_artifacts.title is NOT NULL. Omitting it silently fails every insert
-  // (the constraint violation only surfaces as a logger.warn), so the chairman has
-  // no drafted channels/budget/copy to review at the S22 spend_approval gate.
-  // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B FR-4.
+  // venture_artifacts.title is NOT NULL (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-B FR-4).
   const writes = [
     { artifact_type: 'distribution_channel_config', title: 'Distribution channel config', artifact_data: channelConfig },
-    { artifact_type: 'distribution_ad_copy',        title: 'Distribution ad copy',        artifact_data: adCopy },
+    { artifact_type: 'distribution_ad_copy', title: 'Distribution ad copy', artifact_data: adCopy },
   ];
 
   if (options.dualEmit) {
@@ -290,26 +617,26 @@ export async function persistCanonicalPair(supabase, ventureId, channelConfig, a
       .from('venture_artifacts')
       .update({ is_current: false, updated_at: new Date().toISOString() })
       .eq('venture_id', ventureId)
-      .eq('lifecycle_stage', 21)
+      .eq('lifecycle_stage', LIFECYCLE_STAGE)
       .eq('artifact_type', w.artifact_type)
       .eq('is_current', true);
     if (e1) {
-      options.logger?.warn?.(`[S22-Distribution] mark-stale error on ${w.artifact_type}: ${e1.message}`);
+      options.logger?.warn?.(`[S21-Distribution] mark-stale error on ${w.artifact_type}: ${e1.message}`);
     }
 
     const { error: e2 } = await supabase
       .from('venture_artifacts')
       .insert({
         venture_id: ventureId,
-        lifecycle_stage: 21,
+        lifecycle_stage: LIFECYCLE_STAGE,
         artifact_type: w.artifact_type,
         title: w.title,
         is_current: true,
-        source: 'worker_sd_leo_feat_stage_distribution_setup_001',
+        source: ARTIFACT_SOURCE,
         artifact_data: w.artifact_data,
       });
     if (e2) {
-      options.logger?.warn?.(`[S22-Distribution] insert error on ${w.artifact_type}: ${e2.message}`);
+      options.logger?.warn?.(`[S21-Distribution] insert error on ${w.artifact_type}: ${e2.message}`);
     } else {
       persisted.push(w.artifact_type);
     }
@@ -317,160 +644,244 @@ export async function persistCanonicalPair(supabase, ventureId, channelConfig, a
   return { persisted: persisted.length > 0, types: persisted };
 }
 
-export async function persistSkipMarker(supabase, ventureId, missing, logger) {
-  if (!supabase || !ventureId) return { persisted: false };
-  try {
-    const artifactData = {
-      precondition_missing: missing.map(m => m.artifact_type),
-      attempted_at: new Date().toISOString(),
-      required_upstream: REQUIRED_UPSTREAM,
-    };
-    // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5: self-describing skip —
-    // record what the venture ACTUALLY has (+ nearest-match / rename diff)
-    // alongside what is missing. Fail-soft: diagnostics never block the marker.
-    try {
-      const gap = await describeArtifactGap({
-        supabase, ventureId, stage: 21,
-        requiredTypes: missing.map(m => m.artifact_type),
-        logger,
-      });
-      if (gap) {
-        artifactData.gap_detail = gap.rendered;
-        artifactData.gap_matches = gap.matches;
-        logger?.warn?.(`[S22-Distribution] artifact gap detail:\n${gap.rendered}`);
-      }
-    } catch { /* fail-soft */ }
-    const { error } = await supabase
-      .from('venture_artifacts')
-      .insert({
-        venture_id: ventureId,
-        lifecycle_stage: 21,
-        artifact_type: 'distribution_skip_marker',
-        title: 'Distribution skipped',  // venture_artifacts.title is NOT NULL (FR-4)
-        is_current: true,
-        source: 'worker_sd_leo_feat_stage_distribution_setup_001',
-        artifact_data: artifactData,
-      });
-    if (error) {
-      logger?.warn?.(`[S22-Distribution] SKIP marker persist error: ${error.message}`);
-      return { persisted: false, error: error.message };
+function buildGenerationPrompt(derivedChannels, ventureName) {
+  const channelLines = derivedChannels
+    .map((c) => `- channel: "${c.channel}" (thesis name: "${c.source_channel}"${c.channel_type ? `, type: ${c.channel_type}` : ''}) → persona: "${c.persona}"${c.cost_hypothesis ? ` | cost hypothesis: ${c.cost_hypothesis}` : ''}`)
+    .join('\n');
+
+  const system = `You are EVA's Distribution Planner. Design a ranked, budget-boxed channel-experiment portfolio for the channels DERIVED FROM THIS VENTURE'S DEMAND THESIS. Do not invent channels beyond the provided list; do not omit any provided channel.
+
+Output valid JSON:
+{
+  "experiments": [
+    {
+      "channel": "<exactly one of the provided channel names>",
+      "rank": 1,
+      "hypothesis": "Falsifiable statement of why this channel reaches the mapped persona",
+      "persona_mapping": "<the provided persona for this channel>",
+      "cost_to_signal_bound": "Budget box, e.g. '$50 or 10 hours to reach 100 relevant strangers'",
+      "success_criteria": "Measurable funnel target, e.g. '25 landing visits, 5 waitlist signups in 14 days'",
+      "kill_criteria": "Pre-set kill condition, e.g. '<1% CTR after 200 impressions'",
+      "execution_tier": "T0|T1|T2",
+      "message_variants": [
+        { "variant_id": "A", "headline": "...", "body": "...", "cta": "..." },
+        { "variant_id": "B", "headline": "...", "body": "...", "cta": "..." }
+      ],
+      "utm": { "utm_source": "<channel>", "utm_medium": "<taxonomy type>", "utm_campaign": "<venture>-launch" }
     }
-    return { persisted: true };
-  } catch (err) {
-    logger?.warn?.(`[S22-Distribution] SKIP marker persist threw: ${err.message}`);
-    return { persisted: false, error: err.message };
+  ],
+  "email_sequences": [
+    { "sequence_name": "welcome|onboarding|reengagement", "emails_count": 3, "cadence": "Day 0, Day 3, Day 7", "preview": "Brief description" }
+  ],
+  "budget_allocation": { "total_monthly": "...", "by_channel": { "<channel>": "N%" } }
+}
+
+Rules:
+- EXACTLY one experiment per provided channel; rank ALL experiments by expected cost-to-signal (cheapest signal first).
+- Every experiment carries AT LEAST 2 message variants (the message-test protocol: variants are compared by conversion).
+- Execution tiers: T0 = deterministic/template-level, T1/T2 = cheap-model content production per the D2 allocation matrix.
+- UTM discipline on every experiment; attribution is first-touch.
+
+${getOperatingModelPromptBlock()}
+
+DISTRIBUTION RULES (EHG operating model — organic-first GTM, solo + AI-agent):
+- ORGANIC channels are the PRIMARY/default at launch; PAID channels are a later-stage opt-in with $0 budget at launch.
+- budget_allocation at launch should be ~$0 paid: weight organic. Total monthly should reflect the operating-model marketing band ($0-200/mo).`;
+
+  const user = `Design the channel-experiment portfolio for: ${ventureName}\n\nTHESIS-DERIVED CHANNELS (persona×channel JOIN already enforced):\n${channelLines}`;
+  return { system, user };
+}
+
+/**
+ * Pure. Assembles per-channel experiments from the generator output against the
+ * derived channel set (fail-partial): every derived channel needs exactly one
+ * well-formed experiment; malformed/missing/off-thesis entries are invalidated
+ * individually.
+ */
+export function assembleExperiments(derivedChannels, generated) {
+  const rawExperiments = Array.isArray(generated?.experiments) ? generated.experiments : [];
+  const byChannel = new Map();
+  for (const exp of rawExperiments) {
+    const key = normalizeChannelName(exp?.channel);
+    if (!byChannel.has(key)) byChannel.set(key, exp);
   }
+
+  const valid = [];
+  const invalid = [];
+  const derivedKeys = new Set(derivedChannels.map((c) => c.channel));
+
+  for (const derived of derivedChannels) {
+    const exp = byChannel.get(derived.channel);
+    if (!exp) {
+      invalid.push({ channel: derived.channel, entry: derived, invalid_reason: 'not_generated: generator returned no experiment for this thesis channel' });
+      continue;
+    }
+    const candidate = {
+      ...exp,
+      channel: derived.channel,
+      source_channel: derived.source_channel,
+      channel_type: derived.channel_type,
+      persona_mapping: exp.persona_mapping || derived.persona,
+      cost_hypothesis: derived.cost_hypothesis,
+    };
+    const check = validateExperiment(candidate);
+    if (check.valid) {
+      valid.push(candidate);
+    } else {
+      invalid.push({ channel: derived.channel, entry: exp, invalid_reason: check.reasons.join('; ') });
+    }
+  }
+
+  for (const exp of rawExperiments) {
+    const key = normalizeChannelName(exp?.channel);
+    if (!derivedKeys.has(key)) {
+      invalid.push({ channel: key, entry: exp, invalid_reason: 'not_in_thesis: generator proposed a channel outside the thesis CHANNEL claim' });
+    }
+  }
+
+  return { valid, invalid };
 }
 
 export async function analyzeStage22Distribution(params) {
-  // SD-LEO-FIX-FIX-POST-BUILD-001: normalize worker-provided upstream params before gating.
-  // (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A removed the bespoke S21 visual keys — Distribution
-  // no longer consumes Visual upstream — so this is a no-op for the remaining stage{N}Data
-  // preconditions; retained for any future bespoke key.)
   const normalized = normalizeUpstreamParams(params);
   const {
-    stage12Data, stage10Data, stage18Data, stage7Data,
+    stage7Data, stage10Data, stage12Data, stage18Data,
     ventureName, ventureId, supabase,
     logger = console,
   } = normalized;
 
-  logger.info?.(`[S22-Distribution] Configuring channels for ${ventureName || 'unknown'}`);
+  logger.info?.(`[S21-Distribution] Planning thesis-derived distribution for ${ventureName || 'unknown'}`);
 
-  const preflight = validateEntryPreconditions(normalized);
-  if (!preflight.ok) {
-    logger.warn?.(
-      `[S22-Distribution] SKIP — missing preconditions: ${preflight.missing.map(m => m.artifact_type).join(', ')}`
-    );
-    await persistSkipMarker(supabase, ventureId, preflight.missing, logger);
-    return {
-      _skip: true,
-      precondition_missing: preflight.missing,
-      channels: [],
-      email_sequences: [],
-      budget_allocation: {},
-      total_channels: 0,
-      active_channels: 0,
-      channels_with_copy: 0,
-      usage: {},
-    };
+  // FR-7: the ONLY skip path — an approved chairman distribution_skip decision.
+  const skipDecision = await findApprovedSkipDecision(supabase, ventureId, logger);
+  if (skipDecision) {
+    return applyApprovedSkip({ supabase, ventureId, decision: skipDecision, logger });
   }
 
-  const flagEnabled = await readFeatureFlag(supabase, logger);
+  // FR-1/FR-5: the demand thesis is the hard input. Absent/invalid → binding block.
+  if (!supabase || !ventureId) {
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'no_supabase_or_ventureId',
+      detail: 'Distribution planning requires database access to read the demand thesis',
+    });
+  }
 
+  const thesisRow = await readDemandThesis(supabase, ventureId, logger);
+  if (!thesisRow) {
+    let gapDetail = null;
+    try {
+      const gap = await describeArtifactGap({
+        supabase, ventureId, stage: LIFECYCLE_STAGE,
+        requiredTypes: [THESIS_ARTIFACT_TYPE],
+        logger,
+      });
+      if (gap) gapDetail = gap.rendered;
+    } catch { /* fail-soft */ }
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'demand_thesis_missing',
+      detail: gapDetail || `No current ${THESIS_ARTIFACT_TYPE} artifact exists for this venture`,
+    });
+  }
+
+  const parsedThesis = validateThesisChannelClaim(thesisRow.artifact_data);
+  if (!parsedThesis.ok) {
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'demand_thesis_invalid',
+      detail: parsedThesis.problems.join('; '),
+    });
+  }
+
+  const derivation = deriveChannelsFromThesis(parsedThesis);
+  if (derivation.channels.length === 0) {
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'no_joinable_channels',
+      detail: derivation.invalid.map((i) => i.invalid_reason).join('; ') || 'CHANNEL claim yielded no persona-joinable channels',
+    });
+  }
+
+  // Portfolio generation: one retry, then binding block. NO fabricated fallback
+  // portfolio (TR-4) — a recorded block is strictly more honest than fake data.
+  const { system, user } = buildGenerationPrompt(derivation.channels, ventureName);
   const context = {
     gtm_strategy: stage12Data || {},
     personas: stage10Data || {},
     marketing_copy: stage18Data || {},
     pricing: stage7Data || {},
-    venture_name: ventureName,
+  };
+  let generated = null;
+  let usage = {};
+  let lastErr = null;
+  for (let attempt = 1; attempt <= 2 && !generated; attempt++) {
+    try {
+      const client = getLLMClient();
+      const response = await client.complete(system, `${user}\n\nOptional context:\n${JSON.stringify(context, null, 2)}`);
+      const parsed = parseJSON(response);
+      usage = extractUsage(response) || {};
+      if (parsed && Array.isArray(parsed.experiments)) {
+        generated = parsed;
+      } else {
+        lastErr = new Error('generator output missing experiments[]');
+      }
+    } catch (err) {
+      lastErr = err;
+      logger.warn?.(`[S21-Distribution] generation attempt ${attempt} failed: ${err.message}`);
+    }
+  }
+  if (!generated) {
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'generation_failed',
+      detail: lastErr?.message || 'portfolio generation failed after retry',
+    });
+  }
+
+  // FR-4 fail-partial: per-experiment validation; JOIN gaps merge in as invalid entries.
+  const assembly = assembleExperiments(derivation.channels, generated);
+  const invalidExperiments = [
+    ...derivation.invalid.map((i) => ({ channel: normalizeChannelName(i.entry?.channel || i.entry?.name || 'unknown'), entry: i.entry, invalid_reason: i.invalid_reason })),
+    ...assembly.invalid,
+  ];
+  if (assembly.valid.length === 0) {
+    return blockDistribution({
+      supabase, ventureId, ventureName, logger,
+      reason: 'all_experiments_invalid',
+      detail: invalidExperiments.map((i) => `${i.channel}: ${i.invalid_reason}`).join(' | '),
+    });
+  }
+  if (invalidExperiments.length > 0) {
+    logger.warn?.(`[S21-Distribution] fail-partial: ${invalidExperiments.length} invalidated entr${invalidExperiments.length === 1 ? 'y' : 'ies'} (${assembly.valid.length} valid persist)`);
+  }
+
+  const portfolio = {
+    experiments: rankExperiments(assembly.valid),
+    invalid_experiments: invalidExperiments,
+    email_sequences: generated.email_sequences || [],
+    budget_allocation: generated.budget_allocation || {},
+    thesis_version: thesisRow.id || null,
   };
 
-  let result;
-  let usage = {};
-
-  try {
-    const client = getLLMClient();
-    const response = await client.complete(SYSTEM_PROMPT, `Configure distribution for: ${ventureName}\n\nContext:\n${JSON.stringify(context, null, 2)}`);
-    const parsed = parseJSON(response);
-    usage = extractUsage(response) || {};
-    result = parsed?.channels ? parsed : buildFallback(ventureName);
-  } catch (err) {
-    logger.warn('[S22-Distribution] LLM error, using fallback:', err.message);
-    result = buildFallback(ventureName);
-  }
-
-  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #5): the LLM
-  // proposes off-spec channels despite the prompt enum (witnessed live: "linkedin"
-  // for a B2B DevOps venture — a *reasonable* suggestion), and validateChannelCoverage
-  // hard-throws on ANY unrecognized name, converting the whole stage to SKIP. An
-  // EXTRA channel must not kill coverage of the 6 spec'd ones: filter extras out
-  // (preserved under extra_channels for the calibration record) and validate the
-  // recognized set. Missing/malformed SPEC'D channels still throw → SKIP unchanged.
-  const rawChannels = Array.isArray(result.channels) ? result.channels : [];
-  const isOffSpec = (c) => c && typeof c === 'object' && (c.channel || c.channel_name) && !CHANNELS.includes(c.channel || c.channel_name);
-  const extraChannels = rawChannels.filter(isOffSpec);
-  if (extraChannels.length > 0) {
-    logger.warn?.(`[S22-Distribution] dropping ${extraChannels.length} off-spec channel(s): ${extraChannels.map(c => c.channel || c.channel_name).join(', ')} (kept under extra_channels)`);
-    result.extra_channels = extraChannels;
-  }
-  const channels = rawChannels.filter(c => !isOffSpec(c));
-  const activeChannels = channels.filter(c => (typeof c.enabled === 'boolean' ? c.enabled : c.status === 'active'));
-
+  const flagEnabled = await readFeatureFlag(supabase, logger);
+  const { channelConfig, adCopy } = splitArtifacts(portfolio);
   const fullResult = {
-    ...result,
-    channels,
-    email_sequences: result.email_sequences || [],
-    budget_allocation: result.budget_allocation || {},
-    total_channels: channels.length,
-    active_channels: activeChannels.length,
-    channels_with_copy: activeChannels.filter(c => c.ad_copy?.headline).length,
+    ...channelConfig,
+    experiments: portfolio.experiments,
+    email_sequences: portfolio.email_sequences,
+    channels_with_copy: adCopy.channels_with_copy.length,
     usage,
   };
 
-  try {
-    validateChannelCoverage(channels);
-  } catch (err) {
-    logger.warn?.(`[S22-Distribution] coverage validation failed: ${err.message}`);
-    await persistSkipMarker(
-      supabase, ventureId,
-      [{ artifact_type: 'channel_coverage_violation', source_stage: 21, detail: err.message }],
-      logger
-    );
-    return { ...fullResult, _skip: true, _validation_error: err.message };
-  }
-
-  const { channelConfig, adCopy } = splitArtifacts(fullResult);
   await persistCanonicalPair(
     supabase, ventureId,
     channelConfig, adCopy, fullResult,
-    { dualEmit: !flagEnabled, logger }
+    { dualEmit: !flagEnabled, logger },
   );
 
-  // FR-004 (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D): generate the pre-launch Growth
-  // Playbook as a null-safe, idempotent co-output so the S23 launch kill-gate (FR-005)
-  // can validate growth strategy BEFORE launch (the canonical playbook otherwise only
-  // exists at the terminal stage 26). This runs unconditionally (additive + reversible);
-  // it never blocks or alters the Distribution result — failures are swallowed below.
+  // FR-004 (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D): pre-launch Growth Playbook co-output.
+  // Runs unconditionally on the success path; failures are swallowed (non-blocking).
   let growthCoOutput;
   try {
     growthCoOutput = await runPrelaunchGrowthCoOutput({
@@ -485,7 +896,7 @@ export async function analyzeStage22Distribution(params) {
       logger,
     });
   } catch (err) {
-    logger.warn?.(`[S22-Distribution] pre-launch growth co-output failed (non-blocking): ${err.message}`);
+    logger.warn?.(`[S21-Distribution] pre-launch growth co-output failed (non-blocking): ${err.message}`);
     growthCoOutput = { status: 'skipped', reason: 'unexpected_error' };
   }
 
@@ -498,31 +909,12 @@ export async function analyzeStage22Distribution(params) {
   };
 }
 
-function buildFallback(ventureName) {
-  return {
-    channels: CHANNELS.map(ch => {
-      const isActive = ['app_store', 'google_ads', 'email'].includes(ch);
-      return {
-        channel: ch,
-        enabled: isActive,
-        status: isActive ? 'active' : 'skipped',
-        skip_reason: isActive ? null : 'Awaiting GTM data — fallback skip',
-        reason: ch === 'app_store' ? 'Primary distribution' : 'Awaiting GTM data',
-        ad_copy: isActive
-          ? { headline: `Try ${ventureName}`, body: '[Fallback — regenerate with GTM data]', cta: 'Get Started' }
-          : null,
-        targeting: isActive
-          ? { audience: 'Target audience', demographics: 'specified-by-EXEC from persona data', keywords: [ventureName?.toLowerCase() || 'product'] }
-          : null,
-      };
-    }),
-    email_sequences: [
-      { sequence_name: 'welcome', emails_count: 3, cadence: 'Day 0, Day 1, Day 3', preview: 'Welcome + quick start' },
-      { sequence_name: 'onboarding', emails_count: 3, cadence: 'Day 3, Day 5, Day 7', preview: 'Feature highlights' },
-      { sequence_name: 'reengagement', emails_count: 2, cadence: 'Day 14, Day 30', preview: 'Come back + incentive' },
-    ],
-    budget_allocation: { total_monthly: 'specified-by-EXEC', by_channel: { google_ads: '40%', facebook_instagram: '35%', email: '15%', blog_seo: '10%' } },
-  };
-}
-
-export { CHANNELS, REQUIRED_UPSTREAM, FEATURE_FLAG_KEY };
+export {
+  THESIS_ARTIFACT_TYPE,
+  BLOCK_DECISION_TYPE,
+  SKIP_DECISION_TYPE,
+  APPROVED_DECISIONS,
+  REQUIRED_UPSTREAM,
+  FEATURE_FLAG_KEY,
+  LEGACY_CHANNEL_NAME_MAP,
+};

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -36,7 +36,7 @@ import { getOperatingModelPromptBlock } from '../../standards/operating-model.js
 import { runPrelaunchGrowthCoOutput } from './prelaunch-growth-playbook.js';
 import { describeArtifactGap } from '../../contracts/describe-artifact-gap.js';
 import { recordPendingDecision } from '../../../chairman/record-pending-decision.mjs';
-import { recordDeviation } from '../../deviation-ledger.js';
+import { recordDeviation, readDeviations } from '../../deviation-ledger.js';
 
 /** Consumption contract: the demand-thesis artifact this step reads.
  *  Producer is design-only today (docs/design/venture-selection-demand-thesis-design.md);
@@ -224,6 +224,7 @@ export function deriveChannelsFromThesis(parsedThesis) {
   const personaSet = new Set(personas.map((p) => p.toLowerCase()));
   const valid = [];
   const invalid = [];
+  const seenNormalized = new Map(); // normalized name → source_channel of first claimant
 
   for (const entry of channels) {
     const sourceName = String(entry.channel || entry.name || entry.channel_type || entry.type).trim();
@@ -237,8 +238,18 @@ export function deriveChannelsFromThesis(parsedThesis) {
       invalid.push({ entry, invalid_reason: `COHERENCE_JOIN_GAP: persona(s) [${entryPersonas.join(', ')}] not named in WHO claim` });
       continue;
     }
+    const normalized = normalizeChannelName(sourceName);
+    // Two thesis entries normalizing to the same legacy channel (e.g. 'twitter'
+    // + 'build_in_public' → twitter_x) would duplicate the experiment and
+    // inflate active_channels (adversarial review, PR #5753). First claimant
+    // wins; later ones invalidate fail-partially with the collision named.
+    if (seenNormalized.has(normalized)) {
+      invalid.push({ entry, invalid_reason: `duplicate_channel: '${sourceName}' normalizes to '${normalized}', already claimed by thesis channel '${seenNormalized.get(normalized)}'` });
+      continue;
+    }
+    seenNormalized.set(normalized, sourceName);
     valid.push({
-      channel: normalizeChannelName(sourceName),
+      channel: normalized,
       source_channel: sourceName,
       channel_type: entry.channel_type || entry.type || null,
       persona: joined,
@@ -528,9 +539,19 @@ async function blockDistribution({ supabase, ventureId, ventureName, reason, det
     if (res.recorded) {
       decisionId = res.id;
     } else {
-      // NC-7: a zero-row decision write must surface loudly, not vanish into a warn.
-      decisionError = res.error || 'unknown insert failure';
-      logger?.warn?.(`[S21-Distribution] chairman decision insert FAILED: ${decisionError} — venture stays blocked via withheld artifacts`);
+      // Concurrent-run race: idx_chairman_decisions_unique_pending is per
+      // (venture, stage, decision_type) WHERE status='pending' — a 23505 here
+      // means a peer just inserted the same pending block decision. Re-query
+      // and reuse it instead of dropping the record.
+      const raced = await findPendingBlockDecision(supabase, ventureId, logger);
+      if (raced) {
+        decisionId = raced.id;
+        logger?.info?.(`[S21-Distribution] insert raced an existing pending decision — reusing ${decisionId}`);
+      } else {
+        // NC-7: a zero-row decision write must surface loudly, not vanish into a warn.
+        decisionError = res.error || 'unknown insert failure';
+        logger?.warn?.(`[S21-Distribution] chairman decision insert FAILED: ${decisionError} — venture stays blocked via withheld artifacts`);
+      }
     }
   }
 
@@ -556,6 +577,16 @@ async function applyApprovedSkip({ supabase, ventureId, decision, logger }) {
   const errors = [];
   for (const artifactRef of CANONICAL_PAIR_TYPES) {
     try {
+      // Idempotency: the deviation ledger is append-only, and this step can
+      // legitimately re-run after an approved skip (retry, manual run-stage).
+      // Reuse an existing record for this ref instead of appending duplicates
+      // that pollute the ledger's reason-quality scoring (adversarial review).
+      const existing = await readDeviations(supabase, { ventureId, artifactRef });
+      const priorSkip = existing.find((d) => d.decided_by === 'chairman' && String(d.why || '').includes(decision.id));
+      if (priorSkip) {
+        deviationIds.push(priorSkip.id);
+        continue;
+      }
       const id = await recordDeviation(supabase, {
         ventureId,
         artifactRef,
@@ -584,6 +615,9 @@ async function applyApprovedSkip({ supabase, ventureId, decision, logger }) {
   logger?.info?.(`[S21-Distribution] skip honored via chairman decision ${decision.id} (${deviationIds.length}/${CANONICAL_PAIR_TYPES.length} deviation records)`);
   return {
     _blocked: true,
+    // Labeled so orchestrator/engine halt logs show an honest reason for an
+    // approved SKIP (not an anonymous block).
+    block_reason: 'skipped_by_chairman_decision',
     skipped_by_decision: true,
     decision_id: decision.id,
     deviation_ids: deviationIds,

--- a/tests/unit/eva/stage-policy-halt-guards.test.js
+++ b/tests/unit/eva/stage-policy-halt-guards.test.js
@@ -135,6 +135,25 @@ function makeEngineFakeSupabase(seedRows = {}) {
   };
 }
 
+describe('CRITICAL fix (adversarial review PR #5753): loadStageTemplate JS-wrapper hoists policy-halt sentinels', () => {
+  it('surfaces the real Distribution step\'s _blocked at the TOP level so classifyStepResult routes it away from fallback_persist', async () => {
+    const { sb } = makeEngineFakeSupabase({}); // no thesis → real step blocks
+    const template = await _internal.loadStageTemplate(sb, 21);
+    expect(Array.isArray(template.analysisSteps)).toBe(true);
+
+    const stepResult = await template.analysisSteps[0].execute({
+      ventureContext: { id: '00000000-0000-0000-0000-000000000002', name: 'WrapperTest' },
+    });
+
+    // Without the hoist, the sentinel is buried as {artifactType:null, payload:{_blocked:true}}
+    // and classifyStepResult returns 'fallback_persist' — persisting the sentinel as
+    // requiredArtifacts[0] (distribution_channel_config) and defeating the binding gate.
+    expect(stepResult._blocked).toBe(true);
+    expect(stepResult.payload).toBeUndefined();
+    expect(classifyStepResult(stepResult)).toBe('blocked');
+  });
+});
+
 describe('TS-10: executeStage never persists a blocked step output (stage 21, real template)', () => {
   it('runs the real Distribution analysisStep, gets _blocked (no thesis), and performs no artifact persist', async () => {
     const { sb, calls } = makeEngineFakeSupabase({}); // no thesis, no decisions

--- a/tests/unit/eva/stage-policy-halt-guards.test.js
+++ b/tests/unit/eva/stage-policy-halt-guards.test.js
@@ -1,0 +1,171 @@
+/**
+ * Invocation-path guards for stage-owned policy halts (_blocked/_skip).
+ * SD: SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B FR-6 / TS-8 / TS-10.
+ *
+ * BOTH production step-invocation paths must refuse to persist a policy-halt
+ * sentinel as a stage artifact:
+ *  - eva-orchestrator processStage: classifyStepResult routes 'blocked'/'skip'
+ *    away from the generic fallback persist (which is typed requiredArtifacts[0]
+ *    and would accidentally satisfy the stage-21 any-of artifact gate).
+ *  - stage-execution-engine executeStage: isPolicyHaltOutput guards the
+ *    persistArtifact + syncStageWork block (CRITICAL-1 from the prospective
+ *    TESTING review: this second path would otherwise persist the sentinel as
+ *    canonical distribution_channel_config, defeating the binding gate).
+ *
+ * @module tests/unit/eva/stage-policy-halt-guards.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock transitive deps with shebangs that vitest can't transform (same as
+// orchestrator-persist-artifacts.test.js).
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+
+import { _internal, classifyStepResult } from '../../../lib/eva/eva-orchestrator.js';
+import { isPolicyHaltOutput, executeStage } from '../../../lib/eva/stage-execution-engine.js';
+
+describe('classifyStepResult — the orchestrator step-result routing (TS-8)', () => {
+  it("routes {_blocked:true} to 'blocked' (no generic fallback persist by construction)", () => {
+    expect(classifyStepResult({ _blocked: true, block_reason: 'no_thesis' })).toBe('blocked');
+  });
+
+  it("routes {_skip:true} to 'skip' (existing behavior unchanged)", () => {
+    expect(classifyStepResult({ _skip: true, skip_reason: 'precondition' })).toBe('skip');
+  });
+
+  it("routes non-empty typed artifacts to 'typed_artifacts' (existing behavior unchanged)", () => {
+    expect(classifyStepResult({ artifacts: [{ artifactType: 'x', payload: {} }] })).toBe('typed_artifacts');
+  });
+
+  it("routes everything else to 'fallback_persist' (existing behavior unchanged)", () => {
+    expect(classifyStepResult({ channels: [], total_channels: 0 })).toBe('fallback_persist');
+    expect(classifyStepResult({ artifacts: [] })).toBe('fallback_persist'); // empty array = legacy path
+    expect(classifyStepResult(null)).toBe('fallback_persist');
+    expect(classifyStepResult(undefined)).toBe('fallback_persist');
+  });
+
+  it('typed artifacts win over sentinel flags (a step should never mix them, but routing is deterministic)', () => {
+    expect(classifyStepResult({ artifacts: [{ artifactType: 'x' }], _blocked: true })).toBe('typed_artifacts');
+  });
+
+  it('is exported through _internal for downstream tooling', () => {
+    expect(_internal.classifyStepResult).toBe(classifyStepResult);
+  });
+});
+
+describe('isPolicyHaltOutput — the executeStage persist guard predicate', () => {
+  it('is true for _blocked and _skip sentinels', () => {
+    expect(isPolicyHaltOutput({ _blocked: true, block_reason: 'x' })).toBe(true);
+    expect(isPolicyHaltOutput({ _skip: true })).toBe(true);
+  });
+
+  it('is false for normal outputs, empty objects, and non-objects', () => {
+    expect(isPolicyHaltOutput({ channels: [], active_channels: 0 })).toBe(false);
+    expect(isPolicyHaltOutput({})).toBe(false);
+    expect(isPolicyHaltOutput(null)).toBe(false);
+    expect(isPolicyHaltOutput(undefined)).toBe(false);
+    expect(isPolicyHaltOutput({ _blocked: 'yes' })).toBe(false); // strict boolean
+  });
+});
+
+/**
+ * TS-10 — executeStage end-to-end with the REAL stage-21 template (whose
+ * analysisStep is the rebuilt Distribution step). With no truth_demand_thesis
+ * seeded, the step takes the binding-block path and returns {_blocked:true};
+ * the engine must then perform ZERO venture_artifacts persists of any
+ * distribution type (the sentinel must never become the canonical artifact).
+ */
+function makeEngineFakeSupabase(seedRows = {}) {
+  const calls = { inserts: [], updates: [], upserts: [] };
+  let insertSeq = 0;
+
+  function from(table) {
+    const q = { table, op: 'select', filters: [], limitN: null, wantSingle: false, wantMaybe: false, payload: null };
+
+    function applyFilters(rows) {
+      return rows.filter((row) => q.filters.every(([kind, col, val]) => {
+        if (kind === 'eq') return row[col] === val;
+        if (kind === 'in') return Array.isArray(val) && val.includes(row[col]);
+        return true; // other operators: pass-through
+      }));
+    }
+
+    function exec() {
+      if (q.op === 'insert') {
+        const id = `fake-${table}-${++insertSeq}`;
+        const data = q.wantSingle ? { ...q.payload, id } : [{ ...q.payload, id }];
+        return Promise.resolve({ data, error: null });
+      }
+      if (q.op === 'update' || q.op === 'upsert') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      let rows = applyFilters(seedRows[table] || []);
+      if (q.limitN != null) rows = rows.slice(0, q.limitN);
+      if (q.wantSingle || q.wantMaybe) return Promise.resolve({ data: rows[0] ?? null, error: null });
+      return Promise.resolve({ data: rows, error: null });
+    }
+
+    const chain = (fn) => (...args) => { if (fn) fn(...args); return builder; };
+    const builder = {
+      select: chain(),
+      insert(payload) { q.op = 'insert'; q.payload = payload; calls.inserts.push({ table, row: payload }); return builder; },
+      update(patch) { q.op = 'update'; q.payload = patch; calls.updates.push({ table, patch }); return builder; },
+      upsert(payload) { q.op = 'upsert'; q.payload = payload; calls.upserts.push({ table, row: payload }); return builder; },
+      eq: chain((col, val) => q.filters.push(['eq', col, val])),
+      neq: chain(), gt: chain(), gte: chain(), lt: chain(), lte: chain(), is: chain(), not: chain(),
+      in: chain((col, val) => q.filters.push(['in', col, val])),
+      contains: chain(), or: chain(), ilike: chain(), like: chain(),
+      order: chain(),
+      limit(n) { q.limitN = n; return builder; },
+      range: chain(),
+      maybeSingle() { q.wantMaybe = true; return exec(); },
+      single() { q.wantSingle = true; return exec(); },
+      then(res, rej) { return exec().then(res, rej); },
+    };
+    return builder;
+  }
+
+  return {
+    sb: { from, rpc: async () => ({ data: null, error: null }) },
+    calls,
+  };
+}
+
+describe('TS-10: executeStage never persists a blocked step output (stage 21, real template)', () => {
+  it('runs the real Distribution analysisStep, gets _blocked (no thesis), and performs no artifact persist', async () => {
+    const { sb, calls } = makeEngineFakeSupabase({}); // no thesis, no decisions
+    const logs = [];
+    const logger = { log: (m) => logs.push(String(m)), warn: (m) => logs.push(String(m)), error: (m) => logs.push(String(m)), info: (m) => logs.push(String(m)) };
+
+    const result = await executeStage({
+      supabase: sb,
+      ventureId: '00000000-0000-0000-0000-000000000001',
+      stageNumber: 21,
+      logger,
+    });
+
+    // The step blocked (binding gate) rather than skipping or fabricating output;
+    // the engine returned the sentinel faithfully as a policy halt.
+    expect(result.output?._blocked).toBe(true);
+    expect(result.output?._skip).toBeUndefined();
+    expect(result.policyHalt).toBe('_blocked');
+    expect(result.persisted).toBe(false);
+    expect(result.artifactId).toBeNull();
+
+    // The engine must not have persisted the sentinel as ANY distribution artifact.
+    const artifactInserts = calls.inserts.filter((i) => i.table === 'venture_artifacts');
+    const persistedTypes = artifactInserts.map((i) => i.row.artifact_type);
+    expect(persistedTypes).not.toContain('distribution_channel_config');
+    expect(persistedTypes).not.toContain('distribution_ad_copy');
+    expect(persistedTypes).not.toContain('launch_deployment_runbook');
+    // The stage-owned block evidence IS written (marker + chairman decision).
+    expect(persistedTypes).toContain('distribution_block_marker');
+    expect(calls.inserts.some((i) => i.table === 'chairman_decisions')).toBe(true);
+    // And the engine logged the persist suppression.
+    expect(logs.join('\n')).toMatch(/Persist skipped: step returned _blocked/);
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
@@ -1,16 +1,25 @@
 /**
- * Unit tests for Stage 22 Analysis Step — Distribution Setup
- * SD: SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001
+ * Unit tests for Stage 22 Analysis Step — Distribution Setup (thesis-derived rebuild)
+ * SD: SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B
  *
- * Covers:
- *   FR-1 split + idempotency + dual-emit (flag OFF emits 3, flag ON emits 2)
- *   FR-3 entry-precondition refusal + SKIP marker artifact
- *   FR-4 channel-coverage validation (4 negative cases + happy path)
+ * Covers (PRD FR-1..FR-8 / TS-1..TS-9):
+ *   FR-1 thesis-derived channels, open taxonomy, no fixed-six validator
+ *   FR-2 persona×channel JOIN → COHERENCE_JOIN_GAP (fail-partial)
+ *   FR-3 ranked budget-boxed portfolio, ≥2 message variants, UTM/first-touch,
+ *        back-compat channels[]/counts + value-domain normalization
+ *   FR-4 fail-partial per-experiment validation
+ *   FR-5 binding gate: recorded blocking chairman decision + block marker,
+ *        canonical pair withheld, dedup, zero _skip:true
+ *   FR-7 approved chairman skip → BUILD_DEVIATION_RECORD valve
+ *   TR-4 no fabricated fallback portfolio on LLM failure
  *
  * @module tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
 
 // Mock the LLM client BEFORE importing the module under test.
 vi.mock('../../../../../lib/llm/index.js', () => ({
@@ -18,472 +27,671 @@ vi.mock('../../../../../lib/llm/index.js', () => ({
     complete: vi.fn(),
   })),
 }));
+// Growth co-output + gap diagnostics are separately-owned modules with their own
+// suites — isolate them here so their DB/LLM traffic doesn't pollute call capture.
+vi.mock('../../../../../lib/eva/stage-templates/analysis-steps/prelaunch-growth-playbook.js', () => ({
+  runPrelaunchGrowthCoOutput: vi.fn(async () => ({ status: 'mocked' })),
+}));
+vi.mock('../../../../../lib/eva/contracts/describe-artifact-gap.js', () => ({
+  describeArtifactGap: vi.fn(async () => null),
+}));
 
 import {
   analyzeStage22Distribution,
-  validateEntryPreconditions,
-  validateChannelCoverage,
+  validateThesisChannelClaim,
+  deriveChannelsFromThesis,
+  validateExperiment,
+  rankExperiments,
+  assembleExperiments,
   splitArtifacts,
+  normalizeChannelName,
   normalizeUpstreamParams,
-  CHANNELS,
+  paidBudgetAdvisory,
+  THESIS_ARTIFACT_TYPE,
+  BLOCK_DECISION_TYPE,
+  SKIP_DECISION_TYPE,
   REQUIRED_UPSTREAM,
-  FEATURE_FLAG_KEY,
 } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
-import { CROSS_STAGE_DEPS } from '../../../../../lib/eva/contracts/stage-contracts.js';
 
-// Helper — full happy-path LLM response (all 6 channels, 3 active).
-function makeLLMResponse(overrides = {}) {
-  const channels = (overrides.channels || CHANNELS.map(ch => {
-    const isActive = ['app_store', 'google_ads', 'email'].includes(ch);
-    return {
-      channel: ch,
-      enabled: isActive,
-      status: isActive ? 'active' : 'skipped',
-      skip_reason: isActive ? null : `No ${ch} audience for B2B persona`,
-      ad_copy: isActive ? { headline: 'h', body: 'b', cta: 'c' } : null,
-      targeting: isActive ? { audience: 'a', demographics: 'd', keywords: ['k'] } : null,
+const silent = { info() {}, warn() {}, error() {}, log() {} };
+
+// ---------------------------------------------------------------------------
+// Fake supabase harness (extended for the rebuild — HIGH-6 finding):
+// - generic eq/in filter application against seeded per-table rows
+// - chainable insert().select('id')[.single()] (recordPendingDecision, recordDeviation)
+// - order()/limit()/maybeSingle()/single() and thenable awaiting
+// ---------------------------------------------------------------------------
+function makeFakeSupabase(seedRows = {}) {
+  const calls = { inserts: [], updates: [] };
+  let insertSeq = 0;
+
+  function from(table) {
+    const q = { table, op: 'select', filters: [], limitN: null, wantSingle: false, wantMaybe: false, payload: null };
+
+    function applyFilters(rows) {
+      return rows.filter((row) => q.filters.every(([kind, col, val]) => {
+        if (kind === 'eq') return row[col] === val;
+        if (kind === 'in') return Array.isArray(val) && val.includes(row[col]);
+        return true;
+      }));
+    }
+
+    function exec() {
+      if (q.op === 'insert') {
+        const id = `fake-${table}-${++insertSeq}`;
+        const data = q.wantSingle ? { ...q.payload, id } : [{ ...q.payload, id }];
+        return Promise.resolve({ data, error: null });
+      }
+      if (q.op === 'update') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      let rows = applyFilters(seedRows[table] || []);
+      if (q.limitN != null) rows = rows.slice(0, q.limitN);
+      if (q.wantSingle || q.wantMaybe) return Promise.resolve({ data: rows[0] ?? null, error: null });
+      return Promise.resolve({ data: rows, error: null });
+    }
+
+    const builder = {
+      select() { return builder; },
+      insert(payload) {
+        q.op = 'insert';
+        q.payload = payload;
+        calls.inserts.push({ table, row: payload });
+        return builder;
+      },
+      update(patch) {
+        q.op = 'update';
+        q.payload = patch;
+        calls.updates.push({ table, patch });
+        return builder;
+      },
+      eq(col, val) { q.filters.push(['eq', col, val]); return builder; },
+      in(col, val) { q.filters.push(['in', col, val]); return builder; },
+      contains(col, val) { q.filters.push(['contains', col, val]); return builder; },
+      gte() { return builder; },
+      order() { return builder; },
+      limit(n) { q.limitN = n; return builder; },
+      maybeSingle() { q.wantMaybe = true; return exec(); },
+      single() { q.wantSingle = true; return exec(); },
+      then(res, rej) { return exec().then(res, rej); },
     };
-  }));
-  return JSON.stringify({
-    channels,
-    email_sequences: [{ sequence_name: 'welcome', emails_count: 3, cadence: 'D0,D3,D7', preview: 'p' }],
-    budget_allocation: { total_monthly: '$5k', by_channel: { google_ads: '50%', email: '50%' } },
+    return builder;
+  }
+
+  return { sb: { from }, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const WEB_SAAS_THESIS = {
+  claims: {
+    WHO: { personas: ['consultant', 'indie builder'] },
+    CHANNEL: {
+      channels: [
+        { channel: 'community', channel_type: 'community', persona: 'consultant', cost_hypothesis: '10h to 100 strangers' },
+        { channel: 'twitter', channel_type: 'social', persona: 'indie builder' },
+        { channel: 'integration', channel_type: 'integration', persona: 'consultant' },
+      ],
+    },
+  },
+};
+
+function thesisRow(artifactData = WEB_SAAS_THESIS) {
+  return {
+    id: 'thesis-row-1',
+    venture_id: 'ven-1',
+    artifact_type: THESIS_ARTIFACT_TYPE,
+    is_current: true,
+    artifact_data: artifactData,
+    created_at: '2026-07-01T00:00:00Z',
+  };
+}
+
+function makeExperiment(channel, persona, overrides = {}) {
+  return {
+    channel,
+    hypothesis: `${persona} discovers via ${channel} because that is where they already look for tools`,
+    persona_mapping: persona,
+    cost_to_signal_bound: '$0 + 8 hours to reach 100 relevant strangers',
+    success_criteria: '25 landing visits, 5 waitlist signups in 14 days',
+    kill_criteria: '<1% CTR after 200 impressions',
+    execution_tier: 'T1',
+    message_variants: [
+      { variant_id: 'A', headline: 'hA', body: 'bA', cta: 'cA' },
+      { variant_id: 'B', headline: 'hB', body: 'bB', cta: 'cB' },
+    ],
+    utm: { utm_source: channel, utm_medium: 'organic', utm_campaign: 'launch' },
     ...overrides,
+  };
+}
+
+function llmResponse(experiments, extra = {}) {
+  return JSON.stringify({
+    experiments,
+    email_sequences: [{ sequence_name: 'welcome', emails_count: 3, cadence: 'D0,D3,D7', preview: 'p' }],
+    budget_allocation: { total_monthly: '$50', by_channel: { community: '60%', twitter_x: '30%', integration: '10%' } },
+    ...extra,
   });
 }
 
 function setupMockLLM(response) {
-  const mockComplete = vi.fn().mockResolvedValue(response);
+  const mockComplete = typeof response === 'function'
+    ? vi.fn().mockImplementation(response)
+    : vi.fn().mockResolvedValue(response);
   getLLMClient.mockReturnValue({ complete: mockComplete });
   return mockComplete;
 }
 
-// Factory — fake supabase client that records calls.
-function makeFakeSupabase({ flagEnabled = false, captureWrites = [] } = {}) {
-  const inserted = [];
-  const updated = [];
-  captureWrites.length = 0; // share array if caller wants to inspect
-  const sb = {
-    from(table) {
-      const ctx = { table };
-      const builder = {
-        select(_fields) {
-          ctx.op = 'select';
-          return builder;
-        },
-        eq(col, val) {
-          ctx.filters = ctx.filters || {};
-          ctx.filters[col] = val;
-          return builder;
-        },
-        maybeSingle() {
-          if (table === 'leo_feature_flags' && ctx.filters?.flag_key === FEATURE_FLAG_KEY) {
-            return Promise.resolve({ data: { is_enabled: flagEnabled }, error: null });
-          }
-          return Promise.resolve({ data: null, error: null });
-        },
-        update(payload) {
-          ctx.op = 'update';
-          ctx.payload = payload;
-          return {
-            eq(col, val) {
-              ctx.filters = ctx.filters || {};
-              ctx.filters[col] = val;
-              return this;
-            },
-          };
-        },
-        insert(payload) {
-          inserted.push({ table, payload });
-          captureWrites.push({ op: 'insert', table, payload });
-          return Promise.resolve({ data: payload, error: null });
-        },
-      };
-      // Mock update path so it returns a thenable when chained .eq().eq().eq().eq()
-      const origUpdate = builder.update.bind(builder);
-      builder.update = (payload) => {
-        const rec = { op: 'update', table, payload, filters: {} };
-        updated.push(rec);
-        captureWrites.push(rec);
-        const eqChain = {
-          eq(col, val) { rec.filters[col] = val; return eqChain; },
-          then(resolve) { resolve({ data: null, error: null }); return Promise.resolve({ data: null, error: null }); },
-        };
-        return eqChain;
-      };
-      return builder;
-    },
-  };
-  return { sb, inserted, updated };
-}
+const insertsOf = (calls, table, type = null) => calls.inserts
+  .filter((i) => i.table === table)
+  .filter((i) => (type ? i.row.artifact_type === type : true));
 
-// SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A (FR-003, option-ii): Distribution is now stage 21
-// and Visual Assets is stage 22. Distribution's REQUIRED_UPSTREAM is only 3 entries
-// (pricing/7, persona/10, GTM/12) — the former visual_social_graphics and
-// visual_device_screenshots (source_stage:21) were removed because Distribution now runs
-// BEFORE Visual (they were a forward-dependency contradiction).
-const VALID_UPSTREAM = {
-  stage7Data: { pricing: { tier: 'pro' } },
-  stage10Data: { persona: { name: 'Pragmatic Priya' } },
-  stage12Data: { gtm: { strategy: 'PLG' } },
-  stage18Data: { copy: 'tagline' },
-};
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-describe('stage-22-distribution-setup — pure helpers (FR-1/3/4)', () => {
-  describe('validateEntryPreconditions (FR-3)', () => {
-    it('passes when all 3 upstream artifacts present (pricing/7, persona/10, GTM/12)', () => {
-      const result = validateEntryPreconditions(VALID_UPSTREAM);
-      expect(result.ok).toBe(true);
-      expect(result.missing).toEqual([]);
-    });
-
-    it.each(REQUIRED_UPSTREAM)('fails when $artifact_type missing', (req) => {
-      const params = { ...VALID_UPSTREAM, [req.param_key]: null };
-      const result = validateEntryPreconditions(params);
-      expect(result.ok).toBe(false);
-      expect(result.missing).toContainEqual({ artifact_type: req.artifact_type, source_stage: req.source_stage });
-    });
-
-    it('treats empty-object data as missing', () => {
-      const result = validateEntryPreconditions({ ...VALID_UPSTREAM, stage7Data: {} });
-      expect(result.ok).toBe(false);
-      expect(result.missing[0].artifact_type).toBe('engine_pricing_model');
-    });
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+describe('normalizeChannelName — value-domain normalization (FR-3, CRITICAL-2)', () => {
+  it('maps legacy-platform synonyms onto the selectOrganicChannel allowlist', () => {
+    expect(normalizeChannelName('twitter')).toBe('twitter_x');
+    expect(normalizeChannelName('X')).toBe('twitter_x');
+    expect(normalizeChannelName('Build In Public')).toBe('twitter_x');
+    expect(normalizeChannelName('content_seo')).toBe('blog_seo');
+    expect(normalizeChannelName('newsletter')).toBe('email');
+    expect(normalizeChannelName('instagram')).toBe('facebook_instagram');
   });
 
-  describe('validateChannelCoverage (FR-4)', () => {
-    function makeChannel(overrides = {}) {
-      return {
-        channel: 'email',
-        enabled: true,
-        ad_copy: { headline: 'h', body: 'b', cta: 'c' },
-        targeting: { audience: 'a' },
-        ...overrides,
-      };
+  it('passes open-taxonomy names through unchanged (never a fixed list)', () => {
+    for (const open of ['community', 'integration', 'marketplace', 'partnership', 'referral']) {
+      expect(normalizeChannelName(open)).toBe(open);
     }
-    function makeAll6(overrides = {}) {
-      return CHANNELS.map(ch => {
-        const isActive = ['app_store', 'google_ads', 'email'].includes(ch);
-        return makeChannel({
-          channel: ch,
-          enabled: isActive,
-          skip_reason: isActive ? null : 'no audience',
-          ad_copy: isActive ? { headline: 'h', body: 'b', cta: 'c' } : null,
-          targeting: isActive ? { audience: 'a' } : null,
-          ...overrides,
-        });
-      });
-    }
-
-    it('passes when all 6 channels present and well-formed', () => {
-      expect(() => validateChannelCoverage(makeAll6())).not.toThrow();
-    });
-
-    it('throws when channels is not an array', () => {
-      expect(() => validateChannelCoverage(null)).toThrow(/not an array/);
-      expect(() => validateChannelCoverage('garbage')).toThrow(/not an array/);
-    });
-
-    it('throws when a channel is missing', () => {
-      const channels = makeAll6().filter(c => c.channel !== 'twitter_x');
-      expect(() => validateChannelCoverage(channels)).toThrow(/missing channel "twitter_x"/);
-    });
-
-    it('throws when an unrecognized channel is present', () => {
-      const channels = makeAll6().concat([makeChannel({ channel: 'tiktok' })]);
-      expect(() => validateChannelCoverage(channels)).toThrow(/unrecognized channel "tiktok"/);
-    });
-
-    it('throws when an enabled channel is missing ad_copy', () => {
-      const channels = makeAll6();
-      channels[0].ad_copy = null;
-      expect(() => validateChannelCoverage(channels)).toThrow(/missing ad_copy object/);
-    });
-
-    it('throws when a disabled channel is missing skip_reason', () => {
-      const channels = makeAll6();
-      const ix = channels.findIndex(c => !c.enabled);
-      channels[ix].skip_reason = '';
-      channels[ix].reason = '';
-      expect(() => validateChannelCoverage(channels)).toThrow(/missing skip_reason/);
-    });
-  });
-
-  describe('splitArtifacts (FR-1)', () => {
-    it('splits into channelConfig (no ad_copy) and adCopy (only enabled channels)', () => {
-      const llmResult = JSON.parse(makeLLMResponse());
-      const { channelConfig, adCopy } = splitArtifacts(llmResult);
-
-      expect(channelConfig.channels).toHaveLength(6);
-      expect(channelConfig.channels.every(c => c.ad_copy === undefined)).toBe(true);
-      expect(channelConfig.budget_allocation).toBeDefined();
-
-      expect(adCopy.channels_with_copy.length).toBe(3);
-      expect(adCopy.channels_with_copy.every(c => c.ad_copy)).toBe(true);
-      expect(adCopy.email_sequences).toHaveLength(1);
-    });
   });
 });
 
-describe('analyzeStage22Distribution — integration (FR-1/3/4)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe('validateThesisChannelClaim — consumption contract (FR-8)', () => {
+  it('accepts the design-shaped thesis and extracts channels + personas', () => {
+    const r = validateThesisChannelClaim(WEB_SAAS_THESIS);
+    expect(r.ok).toBe(true);
+    expect(r.channels).toHaveLength(3);
+    expect(r.personas).toEqual(['consultant', 'indie builder']);
+    expect(r.problems).toEqual([]);
   });
 
-  it('FR-3 — emits SKIP marker when engine_pricing_model (stage7) absent', async () => {
-    // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A: Distribution no longer requires Visual
-    // artifacts (they were a forward-dep contradiction). Verify that a genuinely
-    // required precondition (stage7/pricing) causes a SKIP.
-    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
-    const params = {
-      ...VALID_UPSTREAM,
-      stage7Data: null, // genuinely required upstream absent
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-1',
-      supabase: sb,
-      logger: { info: () => {}, warn: () => {} },
+  it('tolerates benign extra fields (additive-producer friendly)', () => {
+    const thesis = {
+      version: 3,
+      extra_top: true,
+      claims: {
+        ...WEB_SAAS_THESIS.claims,
+        WTP: { price_point: '$29/mo' },
+        CHANNEL: { ...WEB_SAAS_THESIS.claims.CHANNEL, evidence_grade: 'B' },
+      },
     };
-    const out = await analyzeStage22Distribution(params);
-
-    expect(out._skip).toBe(true);
-    expect(out.precondition_missing.find(m => m.artifact_type === 'engine_pricing_model')).toBeDefined();
-    expect(out.channels).toEqual([]);
-    // SKIP marker persisted
-    const skipInsert = inserted.find(i => i.payload.artifact_type === 'distribution_skip_marker');
-    expect(skipInsert).toBeDefined();
-    expect(skipInsert.payload.artifact_data.precondition_missing).toContain('engine_pricing_model');
-    // Canonical pair NOT emitted
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeUndefined();
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_ad_copy')).toBeUndefined();
+    expect(validateThesisChannelClaim(thesis).ok).toBe(true);
   });
 
-  it('FR-1 — emits BOTH canonical pair AND legacy launch_deployment_runbook when flag OFF (dual-emit)', async () => {
-    setupMockLLM(makeLLMResponse());
-    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
-    const params = {
-      ...VALID_UPSTREAM,
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-2',
-      supabase: sb,
-      logger: { info: () => {}, warn: () => {} },
+  it('accepts array-form claims keyed by claim_type', () => {
+    const thesis = {
+      claims: [
+        { claim_type: 'WHO', personas: [{ name: 'consultant' }] },
+        { claim_type: 'CHANNEL', channels: [{ channel: 'community', persona: 'consultant' }] },
+      ],
     };
-    const out = await analyzeStage22Distribution(params);
-
-    expect(out._skip).toBeUndefined();
-    expect(out._flag_enabled).toBe(false);
-    expect(out._dual_emitted).toBe(true);
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeDefined();
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_ad_copy')).toBeDefined();
-    expect(inserted.find(i => i.payload.artifact_type === 'launch_deployment_runbook')).toBeDefined();
+    const r = validateThesisChannelClaim(thesis);
+    expect(r.ok).toBe(true);
+    expect(r.personas).toEqual(['consultant']);
   });
 
-  it('FR-1 — emits ONLY canonical pair (no legacy) when flag ON (single-emit)', async () => {
-    setupMockLLM(makeLLMResponse());
-    const { sb, inserted } = makeFakeSupabase({ flagEnabled: true });
-    const params = {
-      ...VALID_UPSTREAM,
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-3',
-      supabase: sb,
-      logger: { info: () => {}, warn: () => {} },
+  it('reports a missing CHANNEL claim', () => {
+    const r = validateThesisChannelClaim({ claims: { WHO: { personas: ['consultant'] } } });
+    expect(r.ok).toBe(false);
+    expect(r.problems.join(' ')).toMatch(/CHANNEL claim is missing/);
+  });
+
+  it('reports empty channels[] and missing thesis', () => {
+    expect(validateThesisChannelClaim({ claims: { WHO: { personas: ['p'] }, CHANNEL: { channels: [] } } }).ok).toBe(false);
+    expect(validateThesisChannelClaim(null).ok).toBe(false);
+    expect(validateThesisChannelClaim(undefined).problems.length).toBeGreaterThan(0);
+  });
+});
+
+describe('deriveChannelsFromThesis — persona×channel JOIN (FR-2 / TS-4)', () => {
+  it('joins each channel to a WHO persona and normalizes names', () => {
+    const parsed = validateThesisChannelClaim(WEB_SAAS_THESIS);
+    const d = deriveChannelsFromThesis(parsed);
+    expect(d.channels.map((c) => c.channel)).toEqual(['community', 'twitter_x', 'integration']);
+    expect(d.channels[0].persona).toBe('consultant');
+    expect(d.channels[1].source_channel).toBe('twitter');
+    expect(d.invalid).toEqual([]);
+  });
+
+  it('raises COHERENCE_JOIN_GAP for a channel whose persona is not in the WHO claim — that entry only', () => {
+    const thesis = {
+      claims: {
+        WHO: { personas: ['consultant'] },
+        CHANNEL: {
+          channels: [
+            { channel: 'community', persona: 'consultant' },
+            { channel: 'app_store', persona: 'builder' }, // not in WHO
+          ],
+        },
+      },
     };
-    const out = await analyzeStage22Distribution(params);
-
-    expect(out._flag_enabled).toBe(true);
-    expect(out._dual_emitted).toBe(false);
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeDefined();
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_ad_copy')).toBeDefined();
-    expect(inserted.find(i => i.payload.artifact_type === 'launch_deployment_runbook')).toBeUndefined();
+    const d = deriveChannelsFromThesis(validateThesisChannelClaim(thesis));
+    expect(d.channels).toHaveLength(1);
+    expect(d.invalid).toHaveLength(1);
+    expect(d.invalid[0].invalid_reason).toMatch(/COHERENCE_JOIN_GAP/);
+    expect(d.invalid[0].invalid_reason).toMatch(/builder/);
   });
 
-  it('FR-1 — idempotent: marks prior is_current=true rows as is_current=false before insert', async () => {
-    setupMockLLM(makeLLMResponse());
-    const { sb, updated } = makeFakeSupabase({ flagEnabled: false });
-    const params = {
-      ...VALID_UPSTREAM,
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-4',
-      supabase: sb,
-      logger: { info: () => {}, warn: () => {} },
+  it('raises COHERENCE_JOIN_GAP for a channel naming no persona at all', () => {
+    const thesis = {
+      claims: {
+        WHO: { personas: ['consultant'] },
+        CHANNEL: { channels: [{ channel: 'community' }] },
+      },
     };
-    await analyzeStage22Distribution(params);
-    // 3 update calls (one per artifact_type written) when dual-emit ON
-    const channelConfigUpdates = updated.filter(u => u.filters.artifact_type === 'distribution_channel_config');
-    const adCopyUpdates = updated.filter(u => u.filters.artifact_type === 'distribution_ad_copy');
-    const legacyUpdates = updated.filter(u => u.filters.artifact_type === 'launch_deployment_runbook');
-    expect(channelConfigUpdates.length).toBe(1);
-    expect(adCopyUpdates.length).toBe(1);
-    expect(legacyUpdates.length).toBe(1);
-    // The update payload sets is_current=false
-    expect(channelConfigUpdates[0].payload.is_current).toBe(false);
+    const d = deriveChannelsFromThesis(validateThesisChannelClaim(thesis));
+    expect(d.channels).toHaveLength(0);
+    expect(d.invalid[0].invalid_reason).toMatch(/COHERENCE_JOIN_GAP: channel names no persona/);
+  });
+});
+
+describe('validateExperiment — fail-partial unit (FR-4)', () => {
+  it('passes a fully-formed experiment', () => {
+    expect(validateExperiment(makeExperiment('community', 'consultant')).valid).toBe(true);
   });
 
-  it('FR-4 — emits SKIP marker when LLM returns malformed coverage (missing channel)', async () => {
-    setupMockLLM(makeLLMResponse({
-      channels: CHANNELS.filter(c => c !== 'twitter_x').map(ch => ({
-        channel: ch, enabled: true, ad_copy: { headline: 'h', body: 'b', cta: 'c' }, targeting: { audience: 'a' },
-      })),
+  it('fails on missing kill_criteria (with the reason named)', () => {
+    const r = validateExperiment(makeExperiment('community', 'consultant', { kill_criteria: '' }));
+    expect(r.valid).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/kill_criteria/);
+  });
+
+  it('fails with fewer than 2 well-formed message variants — never pads (FR-3)', () => {
+    const r = validateExperiment(makeExperiment('community', 'consultant', {
+      message_variants: [{ variant_id: 'A', headline: 'h', body: 'b', cta: 'c' }],
     }));
-    const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
-    const params = {
-      ...VALID_UPSTREAM,
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-5',
-      supabase: sb,
-      logger: { info: () => {}, warn: () => {} },
-    };
-    const out = await analyzeStage22Distribution(params);
-
-    expect(out._skip).toBe(true);
-    expect(out._validation_error).toMatch(/missing channel "twitter_x"/);
-    const skipInsert = inserted.find(i => i.payload.artifact_type === 'distribution_skip_marker');
-    expect(skipInsert).toBeDefined();
-    expect(skipInsert.payload.artifact_data.precondition_missing).toContain('channel_coverage_violation');
-    // Canonical pair NOT emitted (validation failed)
-    expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeUndefined();
+    expect(r.valid).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/>=2 well-formed message variants/);
   });
 
-  it('returns gracefully when supabase absent (no persistence happens)', async () => {
-    setupMockLLM(makeLLMResponse());
-    const params = {
-      ...VALID_UPSTREAM,
-      ventureName: 'TestVenture',
-      ventureId: 'venture-uuid-6',
-      supabase: null,
-      logger: { info: () => {}, warn: () => {} },
-    };
-    const out = await analyzeStage22Distribution(params);
-    expect(out._canonical_pair).toBeDefined();
-    expect(out._flag_enabled).toBe(false); // defaults OFF when no supabase
+  it('fails on invalid execution_tier and missing utm fields', () => {
+    const r = validateExperiment(makeExperiment('community', 'consultant', {
+      execution_tier: 'T9',
+      utm: { utm_source: 'community' },
+    }));
+    expect(r.valid).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/execution_tier/);
+    expect(r.reasons.join(' ')).toMatch(/utm/);
   });
 });
 
-// SD-LEO-FIX-FIX-POST-BUILD-001 — the worker upstream-loading fix.
-// The generic worker (fetchUpstreamArtifacts) keys upstream data as stage{N}Data
-// merged-by-stage with a __byType sub-map keyed by artifact_type. Before this fix
-// (a) CROSS_STAGE_DEPS[22] omitted source stages 7/10/12 so stage7Data/stage10Data/
-// stage12Data never arrived, and (b) the per-artifact-type S21 keys were never derived.
-describe('SD-LEO-FIX-FIX-POST-BUILD-001 — worker upstream-loading fix', () => {
-  // Shape the loader actually produces: stage{N}Data with a __byType sub-map.
-  function makeWorkerShapeUpstream({ includeS21 = true } = {}) {
-    const upstream = {
-      stage7Data:  { tier: 'pro', __byType: { engine_pricing_model: { tier: 'pro' } } },
-      stage10Data: { name: 'Pragmatic Priya', __byType: { identity_persona_brand: { name: 'Pragmatic Priya' } } },
-      stage12Data: { strategy: 'PLG', __byType: { identity_gtm_sales_strategy: { strategy: 'PLG' } } },
-      stage18Data: { copy: 'tagline', __byType: { content_marketing_copy: { copy: 'tagline' } } },
-    };
-    if (includeS21) {
-      upstream.stage21Data = {
-        // merged top-level (one type wins) + lossless __byType for both visual types
-        url: 'social',
-        __byType: {
-          visual_social_graphics:    { social_url: 'https://cdn/social.png' },
-          visual_device_screenshots: { screenshot_url: 'https://cdn/shot.png' },
-        },
-      };
+describe('rankExperiments (FR-3)', () => {
+  it('orders by generator rank, re-stamps 1-based ranks, and stamps first-touch attribution', () => {
+    const ranked = rankExperiments([
+      makeExperiment('a', 'p', { rank: 7 }),
+      makeExperiment('b', 'p', { rank: 2 }),
+      makeExperiment('c', 'p', {}), // unranked → last, stable
+    ]);
+    expect(ranked.map((e) => e.channel)).toEqual(['b', 'a', 'c']);
+    expect(ranked.map((e) => e.rank)).toEqual([1, 2, 3]);
+    expect(ranked.every((e) => e.attribution === 'first_touch')).toBe(true);
+  });
+});
+
+describe('assembleExperiments (FR-4)', () => {
+  const derived = [
+    { channel: 'community', source_channel: 'community', channel_type: 'community', persona: 'consultant', cost_hypothesis: null },
+    { channel: 'twitter_x', source_channel: 'twitter', channel_type: 'social', persona: 'indie builder', cost_hypothesis: null },
+  ];
+
+  it('invalidates a thesis channel the generator omitted (not_generated)', () => {
+    const r = assembleExperiments(derived, { experiments: [makeExperiment('community', 'consultant')] });
+    expect(r.valid).toHaveLength(1);
+    expect(r.invalid).toHaveLength(1);
+    expect(r.invalid[0].invalid_reason).toMatch(/not_generated/);
+  });
+
+  it('invalidates generator channels outside the thesis (not_in_thesis) — never silently drops them', () => {
+    const r = assembleExperiments(derived, {
+      experiments: [
+        makeExperiment('community', 'consultant'),
+        makeExperiment('twitter', 'indie builder'), // normalizes onto derived twitter_x
+        makeExperiment('linkedin', 'consultant'),   // off-thesis
+      ],
+    });
+    expect(r.valid).toHaveLength(2);
+    expect(r.invalid.map((i) => i.invalid_reason).join(' ')).toMatch(/not_in_thesis/);
+  });
+
+  it('defaults persona_mapping from the derived persona when the generator omits it', () => {
+    const exp = makeExperiment('community', 'consultant');
+    delete exp.persona_mapping;
+    const r = assembleExperiments(derived.slice(0, 1), { experiments: [exp] });
+    expect(r.valid).toHaveLength(1);
+    expect(r.valid[0].persona_mapping).toBe('consultant');
+  });
+});
+
+describe('splitArtifacts — back-compat consumer contract (FR-3 / TS-9 shape half)', () => {
+  const portfolio = {
+    experiments: rankExperiments([
+      makeExperiment('twitter_x', 'indie builder'),
+      makeExperiment('community', 'consultant'),
+    ]),
+    invalid_experiments: [{ channel: 'app_store', entry: {}, invalid_reason: 'COHERENCE_JOIN_GAP: x' }],
+    email_sequences: [{ sequence_name: 'welcome' }],
+    budget_allocation: { total_monthly: '$50', by_channel: { community: '100%' } },
+    thesis_version: 'thesis-row-1',
+  };
+
+  it('keeps channels[].{channel,status,enabled,skip_reason} with status pinned active for valid experiments', () => {
+    const { channelConfig } = splitArtifacts(portfolio);
+    const active = channelConfig.channels.filter((c) => c.status === 'active');
+    expect(active).toHaveLength(2);
+    expect(active.every((c) => c.enabled === true && c.skip_reason === null)).toBe(true);
+    const skipped = channelConfig.channels.find((c) => c.status === 'skipped');
+    expect(skipped.channel).toBe('app_store');
+    expect(skipped.skip_reason).toMatch(/COHERENCE_JOIN_GAP/);
+  });
+
+  it('active_channels equals the valid-experiment count (stage-23 read)', () => {
+    const { channelConfig } = splitArtifacts(portfolio);
+    expect(channelConfig.active_channels).toBe(2);
+    expect(channelConfig.total_channels).toBe(3);
+  });
+
+  it('message variants live ONLY in the ad-copy artifact; config carries variant_count', () => {
+    const { channelConfig, adCopy } = splitArtifacts(portfolio);
+    expect(channelConfig.experiments.every((e) => !('message_variants' in e))).toBe(true);
+    expect(channelConfig.experiments.every((e) => e.variant_count === 2)).toBe(true);
+    expect(adCopy.channels_with_copy).toHaveLength(2);
+    expect(adCopy.channels_with_copy.every((c) => c.message_variants.length >= 2)).toBe(true);
+  });
+
+  it('config carries first-touch attribution + thesis_version + paid-budget advisory', () => {
+    const { channelConfig } = splitArtifacts(portfolio);
+    expect(channelConfig.attribution).toBe('first_touch');
+    expect(channelConfig.thesis_version).toBe('thesis-row-1');
+    expect(channelConfig.paid_budget_advisory.flagged).toBe(false);
+  });
+});
+
+describe('paidBudgetAdvisory (unchanged behavior)', () => {
+  it('flags paid spend above 20%', () => {
+    expect(paidBudgetAdvisory({ by_channel: { google_ads: '40%', community: '60%' } }).flagged).toBe(true);
+    expect(paidBudgetAdvisory({ by_channel: { community: '90%', google_ads: '10%' } }).flagged).toBe(false);
+  });
+});
+
+describe('normalizeUpstreamParams + REQUIRED_UPSTREAM (optional context, key convention pinned)', () => {
+  it('REQUIRED_UPSTREAM keeps whole-stage stage{N}Data keys (invariant test contract)', () => {
+    for (const req of REQUIRED_UPSTREAM) {
+      expect(req.param_key).toBe(`stage${req.source_stage}Data`);
     }
-    return upstream;
-  }
-
-  // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A: Distribution is now stage_number 21
-  // (not 22). CROSS_STAGE_DEPS[21] covers its deps; CROSS_STAGE_DEPS[22] is Visual Assets.
-  describe('FR-1 — CROSS_STAGE_DEPS[21] alignment (Distribution is now stage 21)', () => {
-    it('includes the producer-required source stages 7, 10 and 12', () => {
-      for (const stage of [7, 10, 12]) {
-        expect(CROSS_STAGE_DEPS[21]).toContain(stage);
-      }
-    });
-
-    it('retains the build-phase context stages 17-20 (additive change only, stage 21 is self)', () => {
-      // Distribution is stage 21, so CROSS_STAGE_DEPS[21] includes 17-20 as context;
-      // 21 itself is not a dependency of itself.
-      for (const stage of [17, 18, 19, 20]) {
-        expect(CROSS_STAGE_DEPS[21]).toContain(stage);
-      }
-    });
-
-    it('every REQUIRED_UPSTREAM source_stage is present in CROSS_STAGE_DEPS[21]', () => {
-      const deps = new Set(CROSS_STAGE_DEPS[21]);
-      for (const req of REQUIRED_UPSTREAM) {
-        expect(deps.has(req.source_stage)).toBe(true);
-      }
-    });
   });
 
-  describe('FR-2 — normalizeUpstreamParams (per-artifact-type S21 key derivation)', () => {
-    it('does NOT derive stage21SocialData / stage21ScreenshotData (visual removed from REQUIRED_UPSTREAM)', () => {
-      // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A: visual_social_graphics and
-      // visual_device_screenshots were removed from REQUIRED_UPSTREAM (forward-dep fix).
-      // normalizeUpstreamParams iterates REQUIRED_UPSTREAM generically; since those
-      // artifact_types are gone, neither key is produced even when stage21Data.__byType
-      // contains the visual entries.
-      const out = normalizeUpstreamParams(makeWorkerShapeUpstream());
-      expect(out.stage21SocialData).toBeUndefined();
-      expect(out.stage21ScreenshotData).toBeUndefined();
-    });
+  it('is pure and tolerates missing __byType', () => {
+    const params = { stage7Data: { pricing: true }, ventureId: 'v' };
+    const out = normalizeUpstreamParams(params);
+    expect(out.stage7Data).toEqual({ pricing: true });
+    expect(out).not.toBe(params);
+  });
+});
 
-    it('leaves already-populated stage{N}Data keys untouched (stage7/10/12)', () => {
-      const input = makeWorkerShapeUpstream();
-      const out = normalizeUpstreamParams(input);
-      expect(out.stage7Data).toBe(input.stage7Data);
-      expect(out.stage10Data).toBe(input.stage10Data);
-      expect(out.stage12Data).toBe(input.stage12Data);
-    });
+// ---------------------------------------------------------------------------
+// analyzeStage22Distribution — end-to-end paths (fake supabase + mocked LLM)
+// ---------------------------------------------------------------------------
+describe('TS-1: web-SaaS thesis without app_store → full portfolio, no skip, no block', () => {
+  it('persists the canonical pair with 3 ranked experiments and zero _skip/_blocked', async () => {
+    const { sb, calls } = makeFakeSupabase({ venture_artifacts: [thesisRow()] });
+    setupMockLLM(llmResponse([
+      makeExperiment('community', 'consultant', { rank: 1 }),
+      makeExperiment('twitter', 'indie builder', { rank: 2 }),
+      makeExperiment('integration', 'consultant', { rank: 3 }),
+    ]));
 
-    it('is pure — does not mutate the input params', () => {
-      const input = makeWorkerShapeUpstream();
-      normalizeUpstreamParams(input);
-      expect(input.stage21SocialData).toBeUndefined();
-      expect(input.stage21ScreenshotData).toBeUndefined();
-    });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'MarketLens', supabase: sb, logger: silent });
 
-    it('tolerates absent stage21Data / missing __byType without throwing', () => {
-      expect(() => normalizeUpstreamParams({})).not.toThrow();
-      expect(() => normalizeUpstreamParams({ stage21Data: {} })).not.toThrow();
-      expect(() => normalizeUpstreamParams(null)).not.toThrow();
-    });
+    expect('_skip' in result).toBe(false);
+    expect('_blocked' in result).toBe(false);
+    expect(result.active_channels).toBe(3);
+    expect(result.experiments.map((e) => e.channel)).toEqual(['community', 'twitter_x', 'integration']);
+
+    const configInsert = insertsOf(calls, 'venture_artifacts', 'distribution_channel_config');
+    const copyInsert = insertsOf(calls, 'venture_artifacts', 'distribution_ad_copy');
+    expect(configInsert).toHaveLength(1);
+    expect(copyInsert).toHaveLength(1);
+    expect(configInsert[0].row.lifecycle_stage).toBe(21);
+    expect(configInsert[0].row.title.length).toBeGreaterThan(0);
+    // No app_store anywhere — the fixed six is gone; open taxonomy is first-class.
+    expect(configInsert[0].row.artifact_data.channels.some((c) => c.channel === 'app_store')).toBe(false);
+    expect(configInsert[0].row.artifact_data.channels.some((c) => c.channel === 'integration')).toBe(true);
+    expect(configInsert[0].row.artifact_data.channels.some((c) => c.channel === 'community')).toBe(true);
+    // No block/skip markers, no chairman decisions on the happy path.
+    expect(insertsOf(calls, 'venture_artifacts', 'distribution_block_marker')).toHaveLength(0);
+    expect(insertsOf(calls, 'chairman_decisions')).toHaveLength(0);
   });
 
-  describe('FR-3 — producer runs / skips correctly on worker-loader shape', () => {
-    it('RUNS (preconditions ok) when all three required upstream artifacts (7/10/12) arrive in worker shape', () => {
-      const normalized = normalizeUpstreamParams(makeWorkerShapeUpstream());
-      const result = validateEntryPreconditions(normalized);
-      expect(result.ok).toBe(true);
-      expect(result.missing).toEqual([]);
-    });
+  it('dual-emits the legacy runbook while the gate flag is OFF, single-emits when ON', async () => {
+    const flagOff = makeFakeSupabase({ venture_artifacts: [thesisRow()] });
+    setupMockLLM(llmResponse([makeExperiment('community', 'consultant')]));
+    await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: flagOff.sb, logger: silent });
+    expect(insertsOf(flagOff.calls, 'venture_artifacts', 'launch_deployment_runbook')).toHaveLength(1);
 
-    it('does NOT skip end-to-end for a fully-built venture (worker shape)', async () => {
-      setupMockLLM(makeLLMResponse());
-      const { sb, inserted } = makeFakeSupabase({ flagEnabled: false });
-      const out = await analyzeStage22Distribution({
-        ...makeWorkerShapeUpstream(),
-        ventureName: 'DataDistill',
-        ventureId: 'venture-datadistill',
-        supabase: sb,
-        logger: { info: () => {}, warn: () => {} },
-      });
-      expect(out._skip).toBeUndefined();
-      expect(inserted.find(i => i.payload.artifact_type === 'distribution_channel_config')).toBeDefined();
+    const flagOn = makeFakeSupabase({
+      venture_artifacts: [thesisRow()],
+      leo_feature_flags: [{ flag_key: 'LEO_S22_GATES_ENABLED', is_enabled: true }],
     });
+    setupMockLLM(llmResponse([makeExperiment('community', 'consultant')]));
+    await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: flagOn.sb, logger: silent });
+    expect(insertsOf(flagOn.calls, 'venture_artifacts', 'launch_deployment_runbook')).toHaveLength(0);
+  });
+});
 
-    it('passes preconditions when S21 visual data absent — Distribution no longer requires Visual upstream', () => {
-      // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A: visual_social_graphics and
-      // visual_device_screenshots removed from REQUIRED_UPSTREAM (forward-dep fix).
-      // Distribution runs BEFORE Visual Assets, so requiring Visual was a contradiction.
-      // With S7/S10/S12 present and no stage21 visual data, preconditions are OK.
-      const normalized = normalizeUpstreamParams(makeWorkerShapeUpstream({ includeS21: false }));
-      const result = validateEntryPreconditions(normalized);
-      expect(result.ok).toBe(true);
-      expect(result.missing).toEqual([]);
-      // Visual artifact_types are not in the missing list (not required at all)
-      const missingTypes = result.missing.map(m => m.artifact_type);
-      expect(missingTypes).not.toContain('visual_social_graphics');
-      expect(missingTypes).not.toContain('visual_device_screenshots');
-      // S7/S10/S12 not falsely reported missing either
-      expect(missingTypes).not.toContain('engine_pricing_model');
-      expect(missingTypes).not.toContain('identity_persona_brand');
-      expect(missingTypes).not.toContain('identity_gtm_sales_strategy');
+describe('TS-2: fail-partial — one malformed channel invalidates only that experiment', () => {
+  it('persists the valid experiments and records the malformed one under invalid_experiments', async () => {
+    const { sb, calls } = makeFakeSupabase({ venture_artifacts: [thesisRow()] });
+    setupMockLLM(llmResponse([
+      makeExperiment('community', 'consultant'),
+      makeExperiment('twitter', 'indie builder', { kill_criteria: '' }), // malformed
+      makeExperiment('integration', 'consultant'),
+    ]));
+
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+
+    expect('_skip' in result).toBe(false);
+    expect('_blocked' in result).toBe(false);
+    expect(result.active_channels).toBe(2);
+    expect(result.invalid_experiments).toHaveLength(1);
+    expect(result.invalid_experiments[0].channel).toBe('twitter_x');
+    expect(result.invalid_experiments[0].invalid_reason).toMatch(/kill_criteria/);
+    expect(insertsOf(calls, 'venture_artifacts', 'distribution_channel_config')).toHaveLength(1);
+  });
+});
+
+describe('TS-3/FR-5: binding gate — missing thesis blocks with a recorded chairman decision', () => {
+  it('records a blocking pending distribution_block decision + block marker; withholds the pair; no _skip', async () => {
+    const { sb, calls } = makeFakeSupabase({}); // no thesis rows
+    setupMockLLM(llmResponse([]));
+
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+
+    expect(result._blocked).toBe(true);
+    expect('_skip' in result).toBe(false);
+    expect(result.block_reason).toBe('demand_thesis_missing');
+    expect(result.decision_id).toBeTruthy();
+
+    const decisions = insertsOf(calls, 'chairman_decisions');
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].row.decision_type).toBe(BLOCK_DECISION_TYPE);
+    expect(decisions[0].row.lifecycle_stage).toBe(21);
+    expect(decisions[0].row.blocking).toBe(true);
+    expect(decisions[0].row.status).toBe('pending');
+    expect(typeof decisions[0].row.summary).toBe('string');
+
+    const marker = insertsOf(calls, 'venture_artifacts', 'distribution_block_marker');
+    expect(marker).toHaveLength(1);
+    expect(marker[0].row.title).toBe('Distribution blocked');
+    expect(marker[0].row.lifecycle_stage).toBe(21);
+    expect(marker[0].row.artifact_data.decision_id).toBe(result.decision_id);
+
+    // The canonical pair is WITHHELD — that is what blocks advancement.
+    expect(insertsOf(calls, 'venture_artifacts', 'distribution_channel_config')).toHaveLength(0);
+    expect(insertsOf(calls, 'venture_artifacts', 'distribution_ad_copy')).toHaveLength(0);
+    // The LLM is never consulted without a thesis.
+    expect(getLLMClient).not.toHaveBeenCalled();
+  });
+
+  it('blocks with demand_thesis_invalid when the thesis has no CHANNEL claim', async () => {
+    const { sb, calls } = makeFakeSupabase({
+      venture_artifacts: [thesisRow({ claims: { WHO: { personas: ['consultant'] } } })],
     });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('demand_thesis_invalid');
+    expect(result.block_detail).toMatch(/CHANNEL claim is missing/);
+    expect(insertsOf(calls, 'chairman_decisions')).toHaveLength(1);
+  });
+
+  it('blocks with no_joinable_channels when every channel fails the persona JOIN (all COHERENCE_JOIN_GAP)', async () => {
+    const { sb } = makeFakeSupabase({
+      venture_artifacts: [thesisRow({
+        claims: {
+          WHO: { personas: ['consultant'] },
+          CHANNEL: { channels: [{ channel: 'community', persona: 'nobody' }] },
+        },
+      })],
+    });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('no_joinable_channels');
+    expect(result.block_detail).toMatch(/COHERENCE_JOIN_GAP/);
+  });
+
+  it('blocks with all_experiments_invalid when generation yields zero valid experiments', async () => {
+    const { sb } = makeFakeSupabase({ venture_artifacts: [thesisRow()] });
+    setupMockLLM(llmResponse([
+      makeExperiment('community', 'consultant', { message_variants: [] }),
+      makeExperiment('twitter', 'indie builder', { hypothesis: '' }),
+      makeExperiment('integration', 'consultant', { execution_tier: 'nope' }),
+    ]));
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('all_experiments_invalid');
+  });
+
+  it('returns a graceful non-persisting block without supabase (no throw)', async () => {
+    const result = await analyzeStage22Distribution({ ventureName: 'V', logger: silent });
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('no_supabase_or_ventureId');
+    expect(result.decision_id).toBeNull();
+  });
+});
+
+describe('TS-6/FR-5b: block-decision dedup', () => {
+  it('reuses an existing PENDING distribution_block decision instead of inserting a duplicate', async () => {
+    const { sb, calls } = makeFakeSupabase({
+      chairman_decisions: [{
+        id: 'existing-block-1',
+        venture_id: 'ven-1',
+        lifecycle_stage: 21,
+        decision_type: BLOCK_DECISION_TYPE,
+        decision: 'pending',
+        status: 'pending',
+      }],
+    });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result._blocked).toBe(true);
+    expect(result.decision_id).toBe('existing-block-1');
+    expect(insertsOf(calls, 'chairman_decisions')).toHaveLength(0);
+  });
+});
+
+describe('TS-5/TS-6/FR-7: the ONLY skip path is an APPROVED chairman decision', () => {
+  const approvedSkip = {
+    id: 'skip-dec-1',
+    venture_id: 'ven-1',
+    lifecycle_stage: 21,
+    decision_type: SKIP_DECISION_TYPE,
+    decision: 'approve',
+    status: 'approved',
+    summary: 'MarketLens: skip distribution for the probe window',
+  };
+
+  it('honors an approved skip via BUILD_DEVIATION_RECORD rows for BOTH canonical types', async () => {
+    const { sb, calls } = makeFakeSupabase({ chairman_decisions: [approvedSkip] });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+
+    expect(result._blocked).toBe(true);
+    expect(result.skipped_by_decision).toBe(true);
+    expect(result.decision_id).toBe('skip-dec-1');
+    expect('_skip' in result).toBe(false);
+
+    const deviations = insertsOf(calls, 'venture_artifacts', 'build_deviation_record');
+    expect(deviations).toHaveLength(2);
+    const refs = deviations.map((d) => d.row.artifact_data.artifact_ref).sort();
+    expect(refs).toEqual(['distribution_ad_copy', 'distribution_channel_config']);
+    expect(deviations.every((d) => d.row.artifact_data.weight === 'declared-descope')).toBe(true);
+    expect(deviations.every((d) => d.row.artifact_data.why.includes('skip-dec-1'))).toBe(true);
+
+    const marker = insertsOf(calls, 'venture_artifacts', 'distribution_block_marker');
+    expect(marker).toHaveLength(1);
+    expect(marker[0].row.artifact_data.skipped_by_decision).toBe(true);
+    // No NEW pending decision is created on the skip path.
+    expect(insertsOf(calls, 'chairman_decisions')).toHaveLength(0);
+  });
+
+  it('does NOT honor a PENDING (unapproved) skip decision — the block path fires instead', async () => {
+    const { sb, calls } = makeFakeSupabase({
+      chairman_decisions: [{ ...approvedSkip, id: 'skip-dec-2', decision: 'pending', status: 'pending' }],
+    });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result.skipped_by_decision).toBeUndefined();
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('demand_thesis_missing');
+    expect(insertsOf(calls, 'venture_artifacts', 'build_deviation_record')).toHaveLength(0);
+  });
+});
+
+describe('TS-7/TR-4: LLM failure → recorded block, never a fabricated fallback portfolio', () => {
+  it('retries once, then blocks with generation_failed and persists NO portfolio', async () => {
+    const { sb, calls } = makeFakeSupabase({ venture_artifacts: [thesisRow()] });
+    const mockComplete = vi.fn().mockRejectedValue(new Error('provider down'));
+    getLLMClient.mockReturnValue({ complete: mockComplete });
+
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+
+    expect(mockComplete).toHaveBeenCalledTimes(2); // one retry
+    expect(result._blocked).toBe(true);
+    expect(result.block_reason).toBe('generation_failed');
+    expect(insertsOf(calls, 'venture_artifacts', 'distribution_channel_config')).toHaveLength(0);
+    expect(insertsOf(calls, 'venture_artifacts', 'launch_deployment_runbook')).toHaveLength(0);
+  });
+});
+
+describe('module invariants (FR-1/FR-5 acceptance)', () => {
+  const raw = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js'),
+    'utf8',
+  );
+  // Strip block + line comments so doc references to the removed pattern don't false-positive.
+  const src = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('emits zero _skip:true anywhere in the module CODE (the silent-skip path is gone)', () => {
+    expect(src).not.toMatch(/_skip\s*:\s*true/);
+    expect(src).not.toMatch(/persistSkipMarker/);
+  });
+
+  it('contains no fixed channel-universe validator or fallback (fixed six removed)', () => {
+    expect(src).not.toMatch(/validateChannelCoverage/);
+    expect(src).not.toMatch(/all 6 must appear/);
+    expect(src).not.toMatch(/buildFallback/);
+    expect(src).not.toMatch(/'app_store',\s*'google_ads'/);
   });
 });

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-22-distribution-setup.test.js
@@ -288,6 +288,26 @@ describe('deriveChannelsFromThesis — persona×channel JOIN (FR-2 / TS-4)', () 
     expect(d.invalid[0].invalid_reason).toMatch(/builder/);
   });
 
+  it('invalidates a second channel normalizing to the same legacy name (no duplicate experiments / inflated counts)', () => {
+    const thesis = {
+      claims: {
+        WHO: { personas: ['consultant', 'indie builder'] },
+        CHANNEL: {
+          channels: [
+            { channel: 'twitter', persona: 'consultant' },
+            { channel: 'build_in_public', persona: 'indie builder' }, // also → twitter_x
+          ],
+        },
+      },
+    };
+    const d = deriveChannelsFromThesis(validateThesisChannelClaim(thesis));
+    expect(d.channels).toHaveLength(1);
+    expect(d.channels[0].channel).toBe('twitter_x');
+    expect(d.invalid).toHaveLength(1);
+    expect(d.invalid[0].invalid_reason).toMatch(/duplicate_channel/);
+    expect(d.invalid[0].invalid_reason).toMatch(/twitter/);
+  });
+
   it('raises COHERENCE_JOIN_GAP for a channel naming no persona at all', () => {
     const thesis = {
       claims: {
@@ -645,6 +665,32 @@ describe('TS-5/TS-6/FR-7: the ONLY skip path is an APPROVED chairman decision', 
     expect(marker[0].row.artifact_data.skipped_by_decision).toBe(true);
     // No NEW pending decision is created on the skip path.
     expect(insertsOf(calls, 'chairman_decisions')).toHaveLength(0);
+  });
+
+  it('is idempotent on re-run: existing chairman deviation records for this decision are reused, not duplicated', async () => {
+    const priorDeviation = (id) => ({
+      id,
+      venture_id: 'ven-1',
+      artifact_type: 'build_deviation_record',
+      is_current: false,
+      created_at: '2026-07-08T00:00:00Z',
+      artifact_data: {
+        artifact_ref: 'distribution_channel_config',
+        why: `Chairman-approved distribution skip (chairman_decisions ${approvedSkip.id}): prior run`,
+        decided_by: 'chairman',
+        weight: 'declared-descope',
+      },
+    });
+    const { sb, calls } = makeFakeSupabase({
+      chairman_decisions: [approvedSkip],
+      venture_artifacts: [priorDeviation('dev-prior-1')],
+    });
+    const result = await analyzeStage22Distribution({ ventureId: 'ven-1', ventureName: 'V', supabase: sb, logger: silent });
+    expect(result.skipped_by_decision).toBe(true);
+    expect(result.block_reason).toBe('skipped_by_chairman_decision'); // labeled, not anonymous
+    // No NEW deviation inserts — prior records reused.
+    expect(insertsOf(calls, 'venture_artifacts', 'build_deviation_record')).toHaveLength(0);
+    expect(result.deviation_ids).toContain('dev-prior-1');
   });
 
   it('does NOT honor a PENDING (unapproved) skip decision — the block path fires instead', async () => {

--- a/tests/unit/eva/stage-templates/stage-22-spend-approval.test.js
+++ b/tests/unit/eva/stage-templates/stage-22-spend-approval.test.js
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   persistCanonicalPair,
-  persistSkipMarker,
+  persistBlockMarker,
 } from '../../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js';
 import { FALLBACK_DECISION_CREATING_STAGES } from '../../../../lib/eva/chairman-decision-watcher.js';
 
@@ -77,20 +77,25 @@ describe('FR-4: persistCanonicalPair writes titled, allow-listed distribution ar
   });
 });
 
-describe('FR-4: persistSkipMarker writes a titled distribution_skip_marker', () => {
-  it('inserts artifact_type=distribution_skip_marker WITH a title (NOT NULL) at lifecycle_stage 21', async () => {
-    // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A: Distribution is now lifecycle_stage 21
+// SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-B: the silent skip marker is gone —
+// the binding gate writes a titled distribution_block_marker instead (same FR-4
+// NOT-NULL-title + lifecycle_stage-21 contract).
+describe('FR-4: persistBlockMarker writes a titled distribution_block_marker', () => {
+  it('inserts artifact_type=distribution_block_marker WITH a title (NOT NULL) at lifecycle_stage 21', async () => {
     const { sb, calls } = stub();
-    const r = await persistSkipMarker(sb, 'ven-3', [{ artifact_type: 'engine_pricing_model', source_stage: 7 }], silent);
+    const r = await persistBlockMarker(sb, 'ven-3', { block_reason: 'demand_thesis_missing', decision_id: 'dec-1' }, silent);
     expect(r.persisted).toBe(true);
     expect(calls.inserts).toHaveLength(1);
-    expect(calls.inserts[0].artifact_type).toBe('distribution_skip_marker');
-    expect(calls.inserts[0].title).toBe('Distribution skipped');
+    expect(calls.inserts[0].artifact_type).toBe('distribution_block_marker');
+    expect(calls.inserts[0].title).toBe('Distribution blocked');
     expect(calls.inserts[0].lifecycle_stage).toBe(21);
+    expect(calls.inserts[0].artifact_data.block_reason).toBe('demand_thesis_missing');
+    // Prior current marker retired first (partial unique index on is_current=true).
+    expect(calls.updates.some(u => u.is_current === false)).toBe(true);
   });
 
   it('fails open (no throw) without supabase/ventureId', async () => {
-    const r = await persistSkipMarker(null, null, []);
+    const r = await persistBlockMarker(null, null, {});
     expect(r.persisted).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Rebuilds `lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js` (runs as Distribution stage 21 post 21/22 swap): channels now DERIVE from the venture's `truth_demand_thesis` CHANNEL claim via an exported, tested consumption contract (`validateThesisChannelClaim`); the hardcoded six-channel list, the 'all 6 must appear' coverage throw, the off-spec drop filter, and the fabricated `buildFallback` portfolio are removed. Open channel taxonomy (integration/marketplace/partnership/referral first-class).
- **Persona×channel JOIN** (design §1.1): a channel without a WHO-claim persona is invalidated with `COHERENCE_JOIN_GAP` — fail-partial: one malformed channel invalidates only its own experiment, never the stage.
- **Portfolio artifact**: ranked, budget-boxed channel experiments (hypothesis, persona mapping, cost-to-signal bound, success/kill criteria, execution tier, ≥2 message variants, UTM + first-touch attribution). Back-compat preserved for `selectOrganicChannel` (legacy channel-name normalization + `channels[].{channel,status,enabled,skip_reason}`) and stage-23's `active_channels` read.
- **Binding gate** (inverts skip-and-advance): total failure records a blocking `chairman_decisions` row (`decision_type=distribution_block`, dedup-reused) + a self-describing `distribution_block_marker`, withholds the canonical pair so `advance_venture_stage`/`fn_stage_artifact_precondition` blocks advancement — zero `_skip:true` on the new path. The ONLY skip is an approved chairman `distribution_skip` decision, honored via `build_deviation_record` valve rows.
- **Both invocation paths guarded**: `eva-orchestrator` routes `_blocked` step returns away from the generic fallback persist (`classifyStepResult`); `stage-execution-engine` returns a faithful policy-halt result before post-stage contract validation (`isPolicyHaltOutput`) — closing the second persist path that would have written the sentinel as the canonical artifact and defeated the gate.

## Why (evidence)
The fixed-six validator caused 3-of-3 ventures to silently skip distribution (MarketLens skipped over `app_store` — irrelevant to a web SaaS). Design SSOT: `docs/design/venture-demand-distribution-engine.md` D1 + §5.5; parent PRD FR-2.

## PR size justification (401+ LOC prod)
Atomic inversion of stage failure semantics: derivation + fail-partial + binding gate must land together — any intermediate state reintroduces silent skips. No migrations; no schema changes. Tests are ~60% of the diff (full suite rewrite asserting the inverted semantics).

## Test plan
- [x] `npx vitest run tests/unit/eva/` — 6154 passed, 0 failed (full eva surface)
- [x] Rewritten suite: thesis-derived portfolio (no app_store, no violation), fail-partial, binding-gate block + decision dedup, approved-skip deviation valve, LLM-failure block (no fabricated fallback), consumer back-compat, zero `_skip:true` source invariant
- [x] New `stage-policy-halt-guards.test.js`: classifier routing + executeStage end-to-end with the REAL stage-21 template (blocked run persists nothing, returns faithful policy-halt result)
- [x] ESLint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)