### PR TITLE
fix(QF-20260709-968): CLAIM_FIX must not overwrite an authoritative live claim

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2274,12 +2274,38 @@ async function main() {
       if (!_coordMutationAllowed) {
         warnings.push('CLAIM_FIX: re-assert SKIPPED for ' + s.sd_key + ' — not the canonical coordinator (rogue double-act guard)');
       } else if (sd.claiming_session_id !== s.session_id) {
-        await supabase
-          .from('strategic_directives_v2')
-          .update({ claiming_session_id: s.session_id, is_working_on: true })
-          .eq('sd_key', s.sd_key)
-          .select();
-        actions.push('CLAIM_FIX: set claiming_session_id on ' + s.sd_key + ' → ' + s.session_id.substring(0, 20));
+        // QF-20260709-968: sd.claiming_session_id is the AUTHORITATIVE claim (coordinator-directed,
+        // fail-closed gate enforced); s.sd_key is a worker SELF-REPORT re-stamped every checkin. When
+        // they disagree AND the current claim-holder is still alive, the claim wins — clear the
+        // stale self-report binding instead of silently reverting a directed reassignment. Only
+        // backfill claiming_session_id from a binding when the SD claim is genuinely unheld (NULL
+        // or the holder is dead).
+        const holder = sd.claiming_session_id ? classified.find(c => c.session_id === sd.claiming_session_id) : null;
+        if (holder && CLAIM_HOLDING_STATUSES.has(holder.status)) {
+          // QF-20260508-230 invariant: every claude_sessions release UPDATE must null
+          // worktree_branch (mirrors the fixture/non-uuid/terminal bilateral-release branches above).
+          await supabase
+            .from('claude_sessions')
+            .update({
+              sd_key: null,
+              status: s.status === 'ACTIVE' ? 'idle' : 'released',
+              released_at: now.toISOString(),
+              released_reason: 'SWEEP_STALE_BINDING_CLAIM_FIX',
+              worktree_path: null,
+              worktree_branch: null,
+              current_branch: null,
+            })
+            .eq('session_id', s.session_id)
+            .eq('sd_key', s.sd_key); // race guard: only clear if still pointing at this SD
+          actions.push('CLAIM_FIX: cleared stale sd_key binding on session ' + s.session_id.substring(0, 20) + ' (SD ' + s.sd_key + ' authoritatively claimed by live session ' + sd.claiming_session_id.substring(0, 20) + ')');
+        } else {
+          await supabase
+            .from('strategic_directives_v2')
+            .update({ claiming_session_id: s.session_id, is_working_on: true })
+            .eq('sd_key', s.sd_key)
+            .select();
+          actions.push('CLAIM_FIX: set claiming_session_id on ' + s.sd_key + ' → ' + s.session_id.substring(0, 20));
+        }
       } else if (!sd.is_working_on) {
         // Fix incomplete claim: claiming_session_id matches but is_working_on is false
         await supabase

--- a/tests/unit/scripts/sweep-claim-fix-authoritative-claim-wins.test.js
+++ b/tests/unit/scripts/sweep-claim-fix-authoritative-claim-wins.test.js
@@ -1,0 +1,39 @@
+/**
+ * QF-20260709-968: CLAIM_FIX must not overwrite an authoritative (coordinator-directed,
+ * still-alive) claiming_session_id with a stale worker self-report sd_key binding.
+ *
+ * Prior behavior: CLAIM_FIX unconditionally re-asserted claiming_session_id = s.session_id
+ * whenever it differed from the SD's current claim, silently reverting any directed
+ * reassignment while the displaced worker was still heartbeating. Fix: when the current
+ * claim-holder is alive (per CLAIM_HOLDING_STATUSES), clear the stale self-report binding
+ * instead of overwriting the claim.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SOURCE = readFileSync(resolve(REPO_ROOT, 'scripts/stale-session-sweep.cjs'), 'utf8');
+
+describe('QF-20260709-968 — CLAIM_FIX authoritative-claim-wins', () => {
+  it('checks CLAIM_HOLDING_STATUSES on the current claim-holder before re-asserting', () => {
+    const fnStart = SOURCE.indexOf('QF-20260709-968');
+    expect(fnStart, 'QF-20260709-968 branch not found').toBeGreaterThan(-1);
+    const window = SOURCE.slice(fnStart, fnStart + 1500);
+    expect(window).toMatch(/classified\.find\(c => c\.session_id === sd\.claiming_session_id\)/);
+    expect(window).toMatch(/CLAIM_HOLDING_STATUSES\.has\(holder\.status\)/);
+  });
+
+  it('the new stale-binding release reason is wired', () => {
+    expect(SOURCE).toContain('SWEEP_STALE_BINDING_CLAIM_FIX');
+  });
+
+  it('the stale-binding release only clears claude_sessions, never touches strategic_directives_v2', () => {
+    const anchor = SOURCE.indexOf('SWEEP_STALE_BINDING_CLAIM_FIX');
+    const window = SOURCE.slice(anchor - 400, anchor + 50);
+    expect(window).toMatch(/\.from\(\s*['"]claude_sessions['"]\s*\)/);
+    expect(window).not.toMatch(/\.from\(\s*['"]strategic_directives_v2['"]\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Third live firing 2026-07-09 (19:37Z, then 20:29Z on SD-ARCH-HOTSPOT-SWEEP-001): `CLAIM_FIX` treated `claiming_session_id` (authoritative, coordinator-directed, fail-closed-gate-enforced) as subordinate to `claude_sessions.sd_key` (a worker self-report re-stamped every checkin) -- any directed reassignment got silently reverted on the next sweep cycle while the displaced worker was still heartbeating.
- Fix: when the SD's `claiming_session_id` disagrees with the sweeping session's self-reported `sd_key` AND the current claim-holder is still alive (per `CLAIM_HOLDING_STATUSES`), the claim wins -- clear the stale self-report binding instead of overwriting the claim. Backfill still happens when the claim is genuinely unheld.
- Release payload matches the pre-existing `QF-20260508-230` invariant (`worktree_branch:null` etc.) -- the existing generic invariant test caught this on first pass, fixed before commit.

## Test plan
- [x] New unit test `tests/unit/scripts/sweep-claim-fix-authoritative-claim-wins.test.js` -- 3/3 pass
- [x] `npx vitest run tests/unit/scripts` -- 39 files, 436 tests, 0 failures
- [x] Broader claim/sweep regression sweep (34 files, 362 tests) -- 0 failures
- [x] `node --check` + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)