### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-B): preview/replay primitive + registry + TTL reaper

### DIFF
--- a/database/migrations/20260709_venture_preview_instances.sql
+++ b/database/migrations/20260709_venture_preview_instances.sql
@@ -1,0 +1,27 @@
+-- SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-B (FR-2)
+-- Durable registry for preview/replay instances created by lib/venture-deploy/preview.js.
+-- Every preview (plan-mode or live) is registered here with a TTL; the reaper
+-- (scripts/venture-preview-reaper.mjs) sweeps expired planned/live rows.
+-- Additive only: CREATE TABLE IF NOT EXISTS + index, no destructive DDL.
+
+CREATE TABLE IF NOT EXISTS venture_preview_instances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id uuid NOT NULL,
+  sha text NOT NULL,
+  fixture_id text,
+  status text NOT NULL DEFAULT 'planned'
+    CHECK (status IN ('planned', 'live', 'reaped', 'failed')),
+  url text,
+  expires_at timestamptz NOT NULL,
+  created_by text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Reaper sweep path: WHERE status IN ('planned','live') AND expires_at < now()
+CREATE INDEX IF NOT EXISTS idx_venture_preview_instances_reap
+  ON venture_preview_instances (status, expires_at);
+
+COMMENT ON TABLE venture_preview_instances IS
+  'SSOT registry of preview/replay instances (deploy-pipeline Child B). TTL enforced by scripts/venture-preview-reaper.mjs.';

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-08T23:04:36.894Z",
+ "generated_at": "2026-07-09T22:00:11.764Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
- "table_count": 776,
+ "table_count": 778,
  "view_count": 177,
  "tables": {
   "_migration_metadata": "{key,value}",
@@ -696,6 +696,7 @@
   "validation_audit_log": "{id,correlation_id,sd_id,sd_type,validator_name,failure_reason,artifact_id,failure_category,metadata,created_at,execution_context}",
   "validation_evidence": "{id,validation_id,evidence_type,file_path,file_name,file_size,mime_type,component_name,test_case,viewport_size,elements_found,elements_missing,accessibility_issues,performance_metrics,captured_at,created_at}",
   "validation_gate_registry": "{id,gate_key,sd_type,validation_profile,applicability,reason,created_at,updated_at}",
+  "value_authenticity_criteria_library": "{id,criterion_id,contract_version,t_form,title,description,parameter_schema,parameter_schema_notes,evidence_grade,hard_catcher,mock_distinguishing_proof,created_at,updated_at}",
   "venture_archetypes": "{id,name,description,visual_theme,is_default,icon,color,created_at,updated_at,archetype_key,detection_keywords,detection_patterns,total_ventures,graduated_count,killed_count,avg_completion_stages,common_kill_stages,common_kill_reasons,recommended_strategies,known_pitfalls,benchmark_metrics,is_active}",
   "venture_artifact_summaries": "{id,venture_id,artifact_id,artifact_type,lifecycle_stage,summary_text,tags,llm_model,token_count,source_updated_at,created_at,updated_at}",
   "venture_artifact_summaries_qparity20260610": "{id,venture_id,artifact_id,artifact_type,lifecycle_stage,summary_text,tags,llm_model,token_count,source_updated_at,created_at,updated_at}",
@@ -734,6 +735,7 @@
   "venture_persona_mapping": "{id,venture_id,persona_id,relevance_score,notes,created_by,created_at,updated_at}",
   "venture_phase_budgets": "{id,venture_id,phase_name,budget_allocated,budget_remaining,phase_started_at,phase_completed_at,created_at,updated_at}",
   "venture_postmortems": "{id,venture_id,venture_name,venture_start_date,failure_date,why_1,why_1_evidence,why_2,why_2_evidence,why_3,why_3_evidence,why_4,why_4_evidence,why_5,why_5_evidence,root_cause_summary,contributing_factors,linked_sd_ids,linked_pattern_ids,status,assigned_to,reviewed_by,review_date,created_by,updated_by,created_at,updated_at}",
+  "venture_preview_instances": "{id,venture_id,sha,fixture_id,status,url,expires_at,created_by,metadata,created_at,updated_at}",
   "venture_provisioning_state": "{venture_id,venture_name,status,state,current_step,steps_completed,error_details,retry_count,github_repo_url,registry_entry_id,conformance_score,conformance_threshold,conformance_passed,conformance_checks_total,conformance_checks_passing,conformance_failed_checks,conformance_checked_at,provisioned_at,completed_at,created_at,updated_at}",
   "venture_quality_findings": "{id,venture_id,stage_number,finding_category,severity,finding_hash,evidence_pointer,sd_key,created_at,resolved_at,status,sd_filed_at,resolved_at_v2,cancelled_at}",
   "venture_raid_summary": "{venture_id,risk_count,action_count,issue_count,decision_count,total_count,last_updated}",

--- a/lib/venture-deploy/preview.js
+++ b/lib/venture-deploy/preview.js
@@ -1,0 +1,177 @@
+/**
+ * preview(sha, fixture) — the preview/replay primitive (deploy-pipeline-architecture.md §1).
+ *
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-B (FR-1).
+ *
+ * PREVIEW = deployInstance(v, any_sha, test_mode_overlay, ephemeral_branch(seed)):
+ * a no-traffic tagged Cloud Run revision (or native CF preview) of an ALREADY-BUILT
+ * image for `sha` (Child A's image-per-SHA discipline), an ephemeral DB expressed as
+ * a NEUTRAL db_ref contract (D1-create vs Neon-branch adjudication pending — this
+ * module never chooses), a seed-hook step, and a durable row in the
+ * `venture_preview_instances` registry with a TTL the reaper enforces.
+ *
+ * SAFE BY DEFAULT, mirroring publish.js:
+ *   - Plan mode is the default: with no injected real adapters the result records
+ *     the ordered planned actions and status 'blocked_on_credentials' — no cloud
+ *     CLI is ever reached (the chairman bootstrap gate).
+ *   - Real execution differs ONLY by adapter injection (deps.adapters +
+ *     deps.execute:true); the plan is the contract either way.
+ *   - A missing registry table degrades to status 'registry_unavailable' (explicit,
+ *     never a silent success and never a crash).
+ *
+ * @module lib/venture-deploy/preview
+ */
+
+import { deployTargetFamily, validateStackDescriptor } from './stack-descriptor.js';
+
+export const PREVIEW_STATUSES = Object.freeze(['planned', 'live', 'reaped', 'failed']);
+export const DEFAULT_PREVIEW_TTL_MS = 4 * 60 * 60 * 1000; // 4h — preview instances are ephemeral by contract
+
+/**
+ * Neutral ephemeral-DB reference: names the candidate adapters WITHOUT selecting one.
+ * The Adam/Solomon stakes adjudication picks the adapter; the contract shape is stable.
+ */
+export function ephemeralDbRef(fixtureId) {
+  return Object.freeze({
+    kind: 'ephemeral_branch',
+    fixture_id: fixtureId ?? null,
+    candidates: Object.freeze(['ensureD1', 'ensureNeon']),
+    chosen: null,
+  });
+}
+
+/** Ordered preview actions for a deployment family (plan-first, adapters resolve later). */
+export function planPreviewActions(family, sha, fixtureId) {
+  const dbRef = ephemeralDbRef(fixtureId);
+  const actions = [];
+  if (family === 'cloud-run') {
+    actions.push({
+      adapter: 'deployCloudRun',
+      kind: 'no_traffic_revision',
+      desc: `gcloud run deploy --no-traffic --tag preview-${sha} (already-built image for ${sha})`,
+    });
+  } else if (family === 'cloudflare') {
+    actions.push({
+      adapter: 'deployWorkers',
+      kind: 'no_traffic_revision',
+      desc: `wrangler versions upload (native version preview URL for ${sha})`,
+    });
+  } else {
+    actions.push({ adapter: null, kind: 'no_traffic_revision', desc: 'replit family — no preview compute path; plan only' });
+  }
+  actions.push({ adapter: null, kind: 'ephemeral_db', desc: 'ephemeral DB per db_ref (adapter adjudication pending)', db_ref: dbRef });
+  actions.push({ adapter: null, kind: 'seed_hook', desc: `apply fixture seed '${fixtureId ?? 'none'}' via the venture's declared seed hook` });
+  actions.push({ adapter: null, kind: 'registry_register', desc: 'register instance in venture_preview_instances with TTL' });
+  return actions;
+}
+
+/**
+ * Create (plan) a preview instance for a venture at a given SHA + fixture.
+ *
+ * @param {string} ventureId
+ * @param {string} sha - commit SHA whose image Child A's CI already built
+ * @param {string|null} fixture - fixture/seed id for the ephemeral DB
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ adapters?: object, execute?: boolean, now?: () => Date, ttlMs?: number, createdBy?: string }} [deps]
+ * @returns {Promise<{instance_id: string|null, url: string|null, planned_actions: object[], status: string, teardown: () => Promise<{reaped: boolean, already?: boolean}>}>}
+ */
+export async function preview(ventureId, sha, fixture, supabase, deps = {}) {
+  if (!ventureId) throw new Error('preview: ventureId is required');
+  if (!sha) throw new Error('preview: sha is required');
+  if (!supabase) throw new Error('preview: supabase client is required');
+  const now = deps.now || (() => new Date());
+  const ttlMs = deps.ttlMs ?? DEFAULT_PREVIEW_TTL_MS;
+  const hasRealAdapters = !!deps.adapters && deps.execute === true;
+
+  const { data: vRow, error: vErr } = await supabase
+    .from('ventures')
+    .select('stack_descriptor')
+    .eq('id', ventureId)
+    .maybeSingle();
+  if (vErr) throw new Error(`preview: cannot read ventures.stack_descriptor: ${vErr.message}`);
+  const descriptor = vRow?.stack_descriptor;
+  const { valid, errors } = validateStackDescriptor(descriptor);
+  if (!valid) throw new Error(`preview: invalid/missing stack_descriptor — refusing: ${errors.join('; ')}`);
+
+  const family = deployTargetFamily(descriptor);
+  const plannedActions = planPreviewActions(family, sha, fixture ?? null);
+  const expiresAt = new Date(now().getTime() + ttlMs).toISOString();
+
+  // Register the instance FIRST — the registry is the SSOT even for plan-mode instances.
+  const row = {
+    venture_id: ventureId,
+    sha,
+    fixture_id: fixture ?? null,
+    status: 'planned',
+    url: null,
+    expires_at: expiresAt,
+    created_by: deps.createdBy ?? 'preview-primitive',
+    metadata: { family, planned_actions: plannedActions.map((a) => a.kind) },
+  };
+  const { data: inserted, error: insErr } = await supabase
+    .from('venture_preview_instances')
+    .insert(row)
+    .select('id')
+    .maybeSingle();
+  if (insErr) {
+    // Missing table (migration not yet applied) or any insert fault: explicit degradation.
+    return {
+      instance_id: null,
+      url: null,
+      planned_actions: plannedActions,
+      status: 'registry_unavailable',
+      teardown: async () => ({ reaped: false, already: true }),
+    };
+  }
+  const instanceId = inserted?.id ?? null;
+
+  const teardown = async () => {
+    const { data: cur, error: curErr } = await supabase
+      .from('venture_preview_instances')
+      .select('status')
+      .eq('id', instanceId)
+      .maybeSingle();
+    if (curErr || !cur) return { reaped: false, already: true };
+    if (cur.status === 'reaped' || cur.status === 'failed') return { reaped: false, already: true };
+    const { error: upErr } = await supabase
+      .from('venture_preview_instances')
+      .update({ status: 'reaped', metadata: { ...row.metadata, reaped_at: now().toISOString() } })
+      .eq('id', instanceId);
+    return { reaped: !upErr };
+  };
+
+  // Plan mode (no credentials/adapters): the ordered plan IS the deliverable.
+  if (!hasRealAdapters) {
+    return { instance_id: instanceId, url: null, planned_actions: plannedActions, status: 'blocked_on_credentials', teardown };
+  }
+
+  // Real execution: same plan, injected adapters. Any adapter fault marks the
+  // instance failed (never a false 'live').
+  let url = null;
+  for (const action of plannedActions) {
+    if (!action.adapter || typeof deps.adapters[action.adapter] !== 'function') continue;
+    try {
+      const result = await deps.adapters[action.adapter]([], { ventureId, sha, fixture: fixture ?? null });
+      if (!url && result && typeof result.previewUrl === 'string') url = result.previewUrl;
+    } catch (e) {
+      await supabase
+        .from('venture_preview_instances')
+        .update({ status: 'failed', metadata: { ...row.metadata, error: String(e?.message || e) } })
+        .eq('id', instanceId);
+      return { instance_id: instanceId, url: null, planned_actions: plannedActions, status: 'failed', teardown };
+    }
+  }
+  const { error: liveErr } = await supabase
+    .from('venture_preview_instances')
+    .update({ status: 'live', url })
+    .eq('id', instanceId);
+  return {
+    instance_id: instanceId,
+    url,
+    planned_actions: plannedActions,
+    status: liveErr ? 'registry_unavailable' : 'live',
+    teardown,
+  };
+}
+
+export default { preview, planPreviewActions, ephemeralDbRef, PREVIEW_STATUSES, DEFAULT_PREVIEW_TTL_MS };

--- a/scripts/venture-preview-reaper.mjs
+++ b/scripts/venture-preview-reaper.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * TTL reaper for venture_preview_instances (deploy-pipeline Child B, FR-3).
+ *
+ * Sweeps rows with expires_at < now() AND status IN ('planned','live'):
+ *   --dry-run  list reap-eligible instances, mutate NOTHING (default is real mode)
+ *   real mode  invoke teardown through the injected adapter seam (plan-mode teardown
+ *              until credentials exist — no cloud CLI reached) and mark rows
+ *              status='reaped' with metadata.reaped_at.
+ *
+ * Idempotent: reaped/failed rows are never re-processed; a second run over the
+ * same set reaps zero rows. Exit 0 on success (including zero eligible),
+ * exit 1 on query/update failure.
+ *
+ * Usage: node scripts/venture-preview-reaper.mjs [--dry-run]
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+
+export const REAP_ELIGIBLE_STATUSES = Object.freeze(['planned', 'live']);
+
+/** Pure eligibility predicate (unit-tested): expired AND still planned/live. */
+export function isReapEligible(row, nowIso) {
+  if (!row || !row.expires_at) return false;
+  if (!REAP_ELIGIBLE_STATUSES.includes(row.status)) return false;
+  return new Date(row.expires_at).getTime() < new Date(nowIso).getTime();
+}
+
+/**
+ * Run one reaper sweep.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ dryRun?: boolean, now?: () => Date, teardownAdapter?: (row: object) => Promise<void> }} [opts]
+ * @returns {Promise<{eligible: object[], reaped: string[], dryRun: boolean}>}
+ */
+export async function reapExpiredPreviews(supabase, opts = {}) {
+  const dryRun = opts.dryRun === true;
+  const now = opts.now || (() => new Date());
+  const nowIso = now().toISOString();
+
+  const { data, error } = await supabase
+    .from('venture_preview_instances')
+    .select('id, venture_id, sha, fixture_id, status, url, expires_at, metadata')
+    .in('status', [...REAP_ELIGIBLE_STATUSES])
+    .lt('expires_at', nowIso);
+  if (error) throw new Error(`reaper: eligibility query failed: ${error.message}`);
+
+  const eligible = (data || []).filter((r) => isReapEligible(r, nowIso));
+  if (dryRun) return { eligible, reaped: [], dryRun: true };
+
+  const reaped = [];
+  for (const row of eligible) {
+    if (opts.teardownAdapter) {
+      // Adapter seam: real cloud teardown when credentials land; plan-mode no-op today.
+      await opts.teardownAdapter(row);
+    }
+    const { error: upErr } = await supabase
+      .from('venture_preview_instances')
+      .update({ status: 'reaped', metadata: { ...(row.metadata || {}), reaped_at: nowIso, reaped_by: 'venture-preview-reaper' } })
+      .eq('id', row.id)
+      .in('status', [...REAP_ELIGIBLE_STATUSES]); // guard: never overwrite a concurrent reap/fail
+    if (upErr) throw new Error(`reaper: failed to mark ${row.id} reaped: ${upErr.message}`);
+    reaped.push(row.id);
+  }
+  return { eligible, reaped, dryRun: false };
+}
+
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (isDirectRun) {
+  const dryRun = process.argv.includes('--dry-run');
+  try {
+    const supabase = createSupabaseServiceClient();
+    const { eligible, reaped } = await reapExpiredPreviews(supabase, { dryRun });
+    for (const row of eligible) {
+      console.log(`${dryRun ? '[dry-run] reap-eligible' : 'reaped'}: ${row.id} venture=${row.venture_id} sha=${row.sha} status=${row.status} expired=${row.expires_at}`);
+    }
+    console.log(`${dryRun ? 'Would reap' : 'Reaped'} ${dryRun ? eligible.length : reaped.length} instance(s).`);
+    process.exit(0);
+  } catch (e) {
+    console.error(`venture-preview-reaper: ${e?.message || e}`);
+    process.exit(1);
+  }
+}

--- a/tests/unit/venture-deploy-preview.test.js
+++ b/tests/unit/venture-deploy-preview.test.js
@@ -1,0 +1,200 @@
+/**
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-B — preview primitive + TTL reaper.
+ * All cloud/DB access mocked: no CLI, no live table required.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  preview, planPreviewActions, ephemeralDbRef, DEFAULT_PREVIEW_TTL_MS,
+} from '../../lib/venture-deploy/preview.js';
+import { reapExpiredPreviews, isReapEligible } from '../../scripts/venture-preview-reaper.mjs';
+
+const DESCRIPTOR = {
+  deployment_target: 'cloud-run',
+  db_provider: 'neon',
+  storage: 'r2',
+  connection: { provider: 'neon', secret_ref: 'sm://x' },
+};
+
+/** Minimal chainable mock of the two tables preview()/reaper touch. */
+function mockSupabase({ descriptor = DESCRIPTOR, insertError = null, rows = [] } = {}) {
+  const state = { instances: [...rows], updates: [] };
+  const api = {
+    state,
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { stack_descriptor: descriptor }, error: null }) }) }),
+        };
+      }
+      if (table === 'venture_preview_instances') {
+        return {
+          insert(row) {
+            return {
+              select: () => ({
+                maybeSingle: async () => {
+                  if (insertError) return { data: null, error: { message: insertError } };
+                  const rec = { id: `inst-${state.instances.length + 1}`, ...row };
+                  state.instances.push(rec);
+                  return { data: { id: rec.id }, error: null };
+                },
+              }),
+            };
+          },
+          select() {
+            const chain = {
+              _filters: [],
+              eq(col, val) { chain._filters.push((r) => r[col] === val); return chain; },
+              in(col, vals) { chain._filters.push((r) => vals.includes(r[col])); return chain; },
+              lt(col, val) { chain._filters.push((r) => new Date(r[col]) < new Date(val)); return chain; },
+              async maybeSingle() {
+                const hit = state.instances.find((r) => chain._filters.every((f) => f(r)));
+                return { data: hit ? { ...hit } : null, error: null };
+              },
+              then(resolve) { // awaited as a list query
+                const hits = state.instances.filter((r) => chain._filters.every((f) => f(r)));
+                resolve({ data: hits.map((h) => ({ ...h })), error: null });
+              },
+            };
+            return chain;
+          },
+          update(patch) {
+            const chain = {
+              _filters: [],
+              eq(col, val) { chain._filters.push((r) => r[col] === val); return chain; },
+              in(col, vals) { chain._filters.push((r) => vals.includes(r[col])); return chain; },
+              then(resolve) {
+                const hits = state.instances.filter((r) => chain._filters.every((f) => f(r)));
+                hits.forEach((r) => Object.assign(r, patch));
+                state.updates.push({ patch, count: hits.length });
+                resolve({ data: null, error: null });
+              },
+            };
+            return chain;
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+  return api;
+}
+
+describe('planPreviewActions / ephemeralDbRef', () => {
+  it('cloud-run family plans a no-traffic tagged revision + neutral db + seed + registry', () => {
+    const actions = planPreviewActions('cloud-run', 'abc123', 'fx-1');
+    expect(actions.map((a) => a.kind)).toEqual(['no_traffic_revision', 'ephemeral_db', 'seed_hook', 'registry_register']);
+    expect(actions[0].adapter).toBe('deployCloudRun');
+    expect(actions[0].desc).toContain('--no-traffic --tag preview-abc123');
+    const dbRef = actions.find((a) => a.kind === 'ephemeral_db').db_ref;
+    expect(dbRef.candidates).toEqual(['ensureD1', 'ensureNeon']);
+    expect(dbRef.chosen).toBeNull(); // adjudication pending — NEVER chosen here
+  });
+
+  it('cloudflare family rides native version previews; replit family plans no compute', () => {
+    expect(planPreviewActions('cloudflare', 's', null)[0].adapter).toBe('deployWorkers');
+    expect(planPreviewActions('replit', 's', null)[0].adapter).toBeNull();
+  });
+
+  it('ephemeralDbRef is frozen and neutral', () => {
+    const ref = ephemeralDbRef('fx');
+    expect(ref.kind).toBe('ephemeral_branch');
+    expect(Object.isFrozen(ref)).toBe(true);
+  });
+});
+
+describe('preview() plan mode', () => {
+  it('registers a planned instance with TTL and returns blocked_on_credentials without touching any CLI', async () => {
+    const sb = mockSupabase();
+    const t0 = new Date('2026-07-09T12:00:00Z');
+    const res = await preview('v-1', 'abc123', 'fx-1', sb, { now: () => t0 });
+    expect(res.status).toBe('blocked_on_credentials');
+    expect(res.instance_id).toBe('inst-1');
+    expect(res.url).toBeNull();
+    expect(res.planned_actions).toHaveLength(4);
+    const row = sb.state.instances[0];
+    expect(row.status).toBe('planned');
+    expect(new Date(row.expires_at).getTime()).toBe(t0.getTime() + DEFAULT_PREVIEW_TTL_MS);
+  });
+
+  it('degrades to registry_unavailable when the table is missing (insert error), never throws', async () => {
+    const sb = mockSupabase({ insertError: 'relation "venture_preview_instances" does not exist' });
+    const res = await preview('v-1', 'abc123', null, sb);
+    expect(res.status).toBe('registry_unavailable');
+    expect(res.instance_id).toBeNull();
+    expect(res.planned_actions).toHaveLength(4); // the plan is still the contract
+  });
+
+  it('teardown marks the row reaped and is idempotent', async () => {
+    const sb = mockSupabase();
+    const res = await preview('v-1', 'abc123', 'fx', sb);
+    expect((await res.teardown()).reaped).toBe(true);
+    expect(sb.state.instances[0].status).toBe('reaped');
+    const second = await res.teardown();
+    expect(second.reaped).toBe(false);
+    expect(second.already).toBe(true);
+  });
+
+  it('refuses on an invalid stack descriptor (fail-loud, mirrors publish)', async () => {
+    const sb = mockSupabase({ descriptor: null });
+    await expect(preview('v-1', 'abc', null, sb)).rejects.toThrow(/stack_descriptor/);
+  });
+
+  it('real execution path marks failed (never live) when an adapter throws', async () => {
+    const sb = mockSupabase();
+    const adapters = { deployCloudRun: async () => { throw new Error('gcloud exploded'); } };
+    const res = await preview('v-1', 'abc', null, sb, { adapters, execute: true });
+    expect(res.status).toBe('failed');
+    expect(sb.state.instances[0].status).toBe('failed');
+  });
+
+  it('real execution path goes live and captures the preview URL', async () => {
+    const sb = mockSupabase();
+    const adapters = { deployCloudRun: async () => ({ previewUrl: 'https://preview-abc---svc.run.app' }) };
+    const res = await preview('v-1', 'abc', null, sb, { adapters, execute: true });
+    expect(res.status).toBe('live');
+    expect(res.url).toContain('preview-abc');
+    expect(sb.state.instances[0].status).toBe('live');
+  });
+});
+
+describe('reaper', () => {
+  const NOW = '2026-07-09T12:00:00Z';
+  const mk = (id, status, expiresAt) => ({ id, venture_id: 'v-1', sha: 's', fixture_id: null, status, url: null, expires_at: expiresAt, metadata: {} });
+
+  it('isReapEligible: expired planned/live only', () => {
+    expect(isReapEligible(mk('a', 'planned', '2026-07-09T11:00:00Z'), NOW)).toBe(true);
+    expect(isReapEligible(mk('b', 'live', '2026-07-09T11:00:00Z'), NOW)).toBe(true);
+    expect(isReapEligible(mk('c', 'planned', '2026-07-09T13:00:00Z'), NOW)).toBe(false); // unexpired
+    expect(isReapEligible(mk('d', 'reaped', '2026-07-09T11:00:00Z'), NOW)).toBe(false); // terminal
+    expect(isReapEligible(mk('e', 'failed', '2026-07-09T11:00:00Z'), NOW)).toBe(false);
+  });
+
+  it('dry-run lists eligible rows and mutates nothing', async () => {
+    const sb = mockSupabase({ rows: [mk('x', 'planned', '2026-07-09T11:00:00Z'), mk('y', 'live', '2026-07-09T13:00:00Z')] });
+    const res = await reapExpiredPreviews(sb, { dryRun: true, now: () => new Date(NOW) });
+    expect(res.eligible.map((r) => r.id)).toEqual(['x']);
+    expect(res.reaped).toEqual([]);
+    expect(sb.state.instances.find((r) => r.id === 'x').status).toBe('planned');
+  });
+
+  it('real mode reaps only expired planned/live, calls the teardown adapter, and is idempotent on re-run', async () => {
+    const sb = mockSupabase({
+      rows: [mk('x', 'planned', '2026-07-09T11:00:00Z'), mk('y', 'live', '2026-07-09T10:00:00Z'), mk('z', 'reaped', '2026-07-09T09:00:00Z')],
+    });
+    const torn = [];
+    const opts = { now: () => new Date(NOW), teardownAdapter: async (r) => torn.push(r.id) };
+    const first = await reapExpiredPreviews(sb, opts);
+    expect(first.reaped.sort()).toEqual(['x', 'y']);
+    expect(torn.sort()).toEqual(['x', 'y']);
+    expect(sb.state.instances.filter((r) => r.status === 'reaped')).toHaveLength(3);
+    const second = await reapExpiredPreviews(sb, opts);
+    expect(second.reaped).toEqual([]); // idempotent
+  });
+
+  it('throws (nonzero-exit contract) on a query failure', async () => {
+    const sb = {
+      from: () => ({ select: () => ({ in: () => ({ lt: () => ({ then: (resolve) => resolve({ data: null, error: { message: 'boom' } }) }) }) }) }),
+    };
+    await expect(reapExpiredPreviews(sb)).rejects.toThrow(/eligibility query failed/);
+  });
+});


### PR DESCRIPTION
## Deploy Child B — preview/replay primitive (APA's exit-from-interim)

Per the ratified design (`docs/design/deploy-pipeline-architecture.md` §1 + §6, Child B row; depends on Child A — shipped):

- **`lib/venture-deploy/preview.js`** — adapter-injected `preview(ventureId, sha, fixture, supabase, deps)` extending the `publish.js` planner discipline. Plan-mode default: with no injected adapters it registers the instance and returns `blocked_on_credentials` with the four ordered planned actions (`no_traffic_revision` — `gcloud run deploy --no-traffic --tag preview-<sha>` on Child A's per-SHA images, `ephemeral_db`, `seed_hook`, `registry_register`) — no cloud CLI reached. The ephemeral-DB ref is **neutral** (`candidates: [ensureD1, ensureNeon], chosen: null`) — the Adam/Solomon stakes adjudication picks the adapter, not this code. Real execution differs only by adapter injection; adapter faults mark `failed`, never a false `live`.
- **`database/migrations/20260709_venture_preview_instances.sql`** — additive registry (status CHECK planned|live|reaped|failed, `expires_at` TTL, reap index). Code degrades to explicit `registry_unavailable` until applied.
- **`scripts/venture-preview-reaper.mjs`** — `--dry-run`-capable TTL sweep of expired planned/live rows via the teardown adapter seam; idempotent (second run reaps zero); exit 0/1 contract.
- **13 unit tests** (all adapters/DB mocked) + neighboring venture-deploy suites still green (58 passed).

Fenced (documented, unbuilt): real cloud execution (chairman bootstrap gate, same as Child A) and the D1-vs-Neon choice (adjudication pending). Child C (test-mode overlay + diff auditor) is the next child.

~430 LOC incl. tests/migration — justification: primitive + registry + reaper are one contract (design §6 single Child B row); splitting would ship a registry no one writes to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)