### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C): test-mode overlay + config-diff auditor + pseudonymize-not-redact gate

### DIFF
--- a/lib/deploy/config-diff-auditor.mjs
+++ b/lib/deploy/config-diff-auditor.mjs
@@ -1,0 +1,51 @@
+/**
+ * Config-diff auditor (FR-2/FR-3/FR-5, SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C).
+ *
+ * Compares a preview instance's effective config against production and
+ * emits a structured TEST_MODE_DIVERGENCE finding for any key differing
+ * outside the 7-row enumeration (docs/design/deploy-pipeline-architecture.md
+ * §4). Never flags the enumerated keys themselves — they share the same
+ * allowlist as the overlay generator, so the two can never drift out of sync.
+ *
+ * @module lib/deploy/config-diff-auditor
+ */
+
+import { ALL_ENUMERATED_KEYS } from './test-mode-divergence-keys.mjs';
+
+const SECRET_KEY_PATTERN = /SECRET|KEY|TOKEN/i;
+
+function maskIfSecret(key, value) {
+  return SECRET_KEY_PATTERN.test(key) ? '***MASKED***' : value;
+}
+
+function valuesEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * @param {Record<string, unknown>} prodConfig
+ * @param {Record<string, unknown>} previewConfig
+ * @param {{now?: string}} [opts] detectedAt is caller-supplied (no wall-clock dependency, TR-1/FR-5)
+ * @returns {Array<{type: 'TEST_MODE_DIVERGENCE', key: string, prodValue: unknown, previewValue: unknown, severity: 'HIGH', detectedAt: string|undefined}>}
+ */
+export function auditConfigDiff(prodConfig, previewConfig, opts = {}) {
+  const prod = prodConfig || {};
+  const preview = previewConfig || {};
+  const allKeys = new Set([...Object.keys(prod), ...Object.keys(preview)]);
+  const findings = [];
+
+  for (const key of allKeys) {
+    if (ALL_ENUMERATED_KEYS.includes(key)) continue;
+    if (valuesEqual(prod[key], preview[key])) continue;
+    findings.push({
+      type: 'TEST_MODE_DIVERGENCE',
+      key,
+      prodValue: maskIfSecret(key, prod[key]),
+      previewValue: maskIfSecret(key, preview[key]),
+      severity: 'HIGH',
+      detectedAt: opts.now,
+    });
+  }
+
+  return findings;
+}

--- a/lib/deploy/pseudonymize-not-redact-gate.mjs
+++ b/lib/deploy/pseudonymize-not-redact-gate.mjs
@@ -1,0 +1,32 @@
+/**
+ * Pseudonymize-not-redact verification gate (FR-4, SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C).
+ *
+ * Binding rule (Adam co-reviewed, docs/design/deploy-pipeline-architecture.md
+ * §3): seeding a replay branch from captured production state MUST pass the
+ * APA §11.3 pseudonymize-not-redact contract before the branch is created —
+ * deterministic substitutes preserve replayability while raw PII never lands
+ * in an ephemeral branch. Callers (Child B's preview primitive, wired in
+ * Child D) MUST call this gate before requesting branch creation from
+ * captured state.
+ *
+ * @module lib/deploy/pseudonymize-not-redact-gate
+ */
+
+const RECOGNIZED_PSEUDONYMIZATION_METHODS = new Set(['deterministic-substitution', 'format-preserving-hash']);
+
+/**
+ * @param {{pseudonymized?: boolean, pseudonymization_method?: string}} snapshot captured-state snapshot metadata
+ * @returns {{allowed: boolean, reason: string}}
+ */
+export function verifyPseudonymized(snapshot) {
+  if (!snapshot || snapshot.pseudonymized !== true) {
+    return { allowed: false, reason: 'snapshot has not been pseudonymized (pseudonymized !== true) — raw PII may be present' };
+  }
+  if (!RECOGNIZED_PSEUDONYMIZATION_METHODS.has(snapshot.pseudonymization_method)) {
+    return {
+      allowed: false,
+      reason: `snapshot.pseudonymization_method "${snapshot.pseudonymization_method}" is not a recognized method`,
+    };
+  }
+  return { allowed: true, reason: 'snapshot passed pseudonymize-not-redact verification' };
+}

--- a/lib/deploy/test-mode-divergence-keys.mjs
+++ b/lib/deploy/test-mode-divergence-keys.mjs
@@ -1,0 +1,33 @@
+/**
+ * Shared allowlist of the 7 enumerated test-mode config divergences
+ * (docs/design/deploy-pipeline-architecture.md §4, SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C).
+ *
+ * Single source of truth imported by both test-mode-overlay.mjs (FR-1) and
+ * config-diff-auditor.mjs (FR-2/FR-3) so the two can never drift out of sync
+ * with each other — the allowlist that generates the overlay IS the allowlist
+ * the auditor exempts from findings.
+ *
+ * @module lib/deploy/test-mode-divergence-keys
+ */
+
+export const TEST_MODE_OVERLAY_VALUES = Object.freeze({
+  EMAIL_TRANSPORT: 'capture',
+  PAYMENTS_MODE: 'test',
+  CLOCK_SOURCE: 'injected',
+  DATABASE_URL: '<ephemeral>',
+  SEED_HOOKS: 'enabled',
+  TELEMETRY_SINK: 'test',
+  THIRD_PARTY_PROXY: 'record-replay',
+});
+
+// THIRD_PARTY_PROXY is optional/per-venture-declared (design §4 row 7) — it is
+// excluded from the always-applied set and added conditionally by the overlay
+// generator, and excluded from the auditor's mandatory allowlist so its
+// absence never itself produces a finding either way.
+export const ALWAYS_APPLIED_KEYS = Object.freeze(
+  Object.keys(TEST_MODE_OVERLAY_VALUES).filter((key) => key !== 'THIRD_PARTY_PROXY')
+);
+
+export const OPTIONAL_DECLARED_KEY = 'THIRD_PARTY_PROXY';
+
+export const ALL_ENUMERATED_KEYS = Object.freeze(Object.keys(TEST_MODE_OVERLAY_VALUES));

--- a/lib/deploy/test-mode-overlay.mjs
+++ b/lib/deploy/test-mode-overlay.mjs
@@ -1,0 +1,30 @@
+/**
+ * Test-mode config overlay generator (FR-1, SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C).
+ *
+ * Generates a preview instance's effective config from production config plus
+ * the 7-row divergence enumeration — ALWAYS generated, never hand-edited, so
+ * it stays in lockstep with production config drift. DATABASE_URL is an
+ * opaque placeholder here; the real ephemeral URL is injected by Child B's
+ * preview(sha, fixture) primitive at deploy time (TR-2 — out of this
+ * module's scope).
+ *
+ * @module lib/deploy/test-mode-overlay
+ */
+
+import { TEST_MODE_OVERLAY_VALUES, ALWAYS_APPLIED_KEYS, OPTIONAL_DECLARED_KEY } from './test-mode-divergence-keys.mjs';
+
+/**
+ * @param {Record<string, unknown>} prodConfig production config to overlay
+ * @param {{thirdPartyProxyDeclared?: boolean}} [opts]
+ * @returns {Record<string, unknown>} a new config object — prodConfig plus the enumerated divergences
+ */
+export function generateTestModeOverlay(prodConfig, opts = {}) {
+  const overlay = { ...prodConfig };
+  for (const key of ALWAYS_APPLIED_KEYS) {
+    overlay[key] = TEST_MODE_OVERLAY_VALUES[key];
+  }
+  if (opts.thirdPartyProxyDeclared === true) {
+    overlay[OPTIONAL_DECLARED_KEY] = TEST_MODE_OVERLAY_VALUES[OPTIONAL_DECLARED_KEY];
+  }
+  return overlay;
+}

--- a/tests/unit/deploy/config-diff-auditor.test.js
+++ b/tests/unit/deploy/config-diff-auditor.test.js
@@ -1,0 +1,89 @@
+/**
+ * lib/deploy/config-diff-auditor unit tests
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C
+ */
+
+import { describe, it, expect } from 'vitest';
+import { auditConfigDiff } from '../../../lib/deploy/config-diff-auditor.mjs';
+import { generateTestModeOverlay } from '../../../lib/deploy/test-mode-overlay.mjs';
+
+const prodConfig = {
+  EMAIL_TRANSPORT: 'sendgrid',
+  PAYMENTS_MODE: 'live',
+  CLOCK_SOURCE: 'system',
+  DATABASE_URL: 'postgres://prod',
+  SEED_HOOKS: 'disabled',
+  TELEMETRY_SINK: 'production',
+  APP_NAME: 'marketlens',
+  REGION: 'us-east-1',
+};
+
+describe('TS-3: auditor happy path', () => {
+  it('preview built by the overlay generator produces zero findings', () => {
+    const previewConfig = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    const findings = auditConfigDiff(prodConfig, previewConfig);
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('TS-4: auditor flags a single out-of-budget divergence', () => {
+  it('produces exactly one TEST_MODE_DIVERGENCE finding naming the offending key', () => {
+    const previewConfig = { ...generateTestModeOverlay(prodConfig), REGION: 'us-west-2' };
+    const findings = auditConfigDiff(prodConfig, previewConfig);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ type: 'TEST_MODE_DIVERGENCE', key: 'REGION', prodValue: 'us-east-1', previewValue: 'us-west-2', severity: 'HIGH' });
+  });
+});
+
+describe('TS-5: auditor flags each of multiple out-of-budget divergences independently', () => {
+  it('produces exactly 3 findings, one per offending key', () => {
+    const previewConfig = {
+      ...generateTestModeOverlay(prodConfig),
+      REGION: 'us-west-2',
+      APP_NAME: 'renamed',
+      NEW_UNBUDGETED_KEY: 'surprise',
+    };
+    const findings = auditConfigDiff(prodConfig, previewConfig);
+    expect(findings).toHaveLength(3);
+    const keys = findings.map((f) => f.key).sort();
+    expect(keys).toEqual(['APP_NAME', 'NEW_UNBUDGETED_KEY', 'REGION']);
+  });
+});
+
+describe('TS-8: auditor never flags the 7 enumerated keys, even adversarially', () => {
+  it('produces zero findings when only the enumerated keys differ', () => {
+    const previewConfig = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    const findings = auditConfigDiff(prodConfig, previewConfig);
+    expect(findings.some((f) => f.key === 'THIRD_PARTY_PROXY')).toBe(false);
+    expect(findings).toEqual([]);
+  });
+
+  it('never flags an enumerated key even with an arbitrary adversarial value', () => {
+    const previewConfig = { ...prodConfig, EMAIL_TRANSPORT: 'something-totally-different' };
+    const findings = auditConfigDiff(prodConfig, previewConfig);
+    expect(findings.some((f) => f.key === 'EMAIL_TRANSPORT')).toBe(false);
+  });
+});
+
+describe('secret masking (FR-2 AC3)', () => {
+  it('masks values for keys matching SECRET/KEY/TOKEN', () => {
+    const prod = { ...prodConfig, API_SECRET: 'sk_live_abc123' };
+    const preview = { ...prod, API_SECRET: 'sk_live_xyz789' };
+    const findings = auditConfigDiff(prod, preview);
+    const finding = findings.find((f) => f.key === 'API_SECRET');
+    expect(finding.prodValue).toBe('***MASKED***');
+    expect(finding.previewValue).toBe('***MASKED***');
+  });
+});
+
+describe('FR-5: structured findings, no throw on well-formed input', () => {
+  it('always returns an array, empty when nothing diverges', () => {
+    expect(Array.isArray(auditConfigDiff(prodConfig, { ...prodConfig }))).toBe(true);
+  });
+
+  it('propagates caller-supplied detectedAt without computing wall-clock time', () => {
+    const previewConfig = { ...prodConfig, REGION: 'eu-west-1' };
+    const findings = auditConfigDiff(prodConfig, previewConfig, { now: '2026-07-09T00:00:00Z' });
+    expect(findings[0].detectedAt).toBe('2026-07-09T00:00:00Z');
+  });
+});

--- a/tests/unit/deploy/pseudonymize-not-redact-gate.test.js
+++ b/tests/unit/deploy/pseudonymize-not-redact-gate.test.js
@@ -1,0 +1,38 @@
+/**
+ * lib/deploy/pseudonymize-not-redact-gate unit tests
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C
+ */
+
+import { describe, it, expect } from 'vitest';
+import { verifyPseudonymized } from '../../../lib/deploy/pseudonymize-not-redact-gate.mjs';
+
+describe('TS-6: pseudonymize gate blocks an unpseudonymized snapshot', () => {
+  it('returns allowed:false with a specific reason when pseudonymized !== true', () => {
+    const result = verifyPseudonymized({ pseudonymized: false });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('not been pseudonymized');
+  });
+
+  it('returns allowed:false for a null/undefined snapshot', () => {
+    expect(verifyPseudonymized(null).allowed).toBe(false);
+    expect(verifyPseudonymized(undefined).allowed).toBe(false);
+  });
+
+  it('returns allowed:false when pseudonymized is true but the method is unrecognized', () => {
+    const result = verifyPseudonymized({ pseudonymized: true, pseudonymization_method: 'ad-hoc-find-replace' });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('not a recognized method');
+  });
+});
+
+describe('TS-7: pseudonymize gate permits a properly pseudonymized snapshot', () => {
+  it('returns allowed:true for a recognized pseudonymization method', () => {
+    const result = verifyPseudonymized({ pseudonymized: true, pseudonymization_method: 'deterministic-substitution' });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('accepts format-preserving-hash as a recognized method', () => {
+    const result = verifyPseudonymized({ pseudonymized: true, pseudonymization_method: 'format-preserving-hash' });
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/tests/unit/deploy/test-mode-overlay.test.js
+++ b/tests/unit/deploy/test-mode-overlay.test.js
@@ -1,0 +1,63 @@
+/**
+ * lib/deploy/test-mode-overlay unit tests
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-C
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateTestModeOverlay } from '../../../lib/deploy/test-mode-overlay.mjs';
+import { ALL_ENUMERATED_KEYS } from '../../../lib/deploy/test-mode-divergence-keys.mjs';
+
+const prodConfig = {
+  EMAIL_TRANSPORT: 'sendgrid',
+  PAYMENTS_MODE: 'live',
+  CLOCK_SOURCE: 'system',
+  DATABASE_URL: 'postgres://prod',
+  SEED_HOOKS: 'disabled',
+  TELEMETRY_SINK: 'production',
+  APP_NAME: 'marketlens',
+  REGION: 'us-east-1',
+};
+
+describe('TS-1: overlay generator happy path', () => {
+  it('produces exactly the 7 enumerated keys changed, all other keys byte-identical', () => {
+    const overlay = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    expect(overlay.EMAIL_TRANSPORT).toBe('capture');
+    expect(overlay.PAYMENTS_MODE).toBe('test');
+    expect(overlay.CLOCK_SOURCE).toBe('injected');
+    expect(overlay.DATABASE_URL).toBe('<ephemeral>');
+    expect(overlay.SEED_HOOKS).toBe('enabled');
+    expect(overlay.TELEMETRY_SINK).toBe('test');
+    expect(overlay.THIRD_PARTY_PROXY).toBe('record-replay');
+    expect(overlay.APP_NAME).toBe(prodConfig.APP_NAME);
+    expect(overlay.REGION).toBe(prodConfig.REGION);
+  });
+
+  it('is deterministic across repeated calls with the same inputs', () => {
+    const a = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    const b = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('TS-2: THIRD_PARTY_PROXY is optional / per-venture declared', () => {
+  it('omits THIRD_PARTY_PROXY when not declared', () => {
+    const overlay = generateTestModeOverlay(prodConfig);
+    expect('THIRD_PARTY_PROXY' in overlay).toBe(false);
+  });
+
+  it('omits THIRD_PARTY_PROXY when explicitly declared false', () => {
+    const overlay = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: false });
+    expect('THIRD_PARTY_PROXY' in overlay).toBe(false);
+  });
+
+  it('includes THIRD_PARTY_PROXY only when declared true', () => {
+    const overlay = generateTestModeOverlay(prodConfig, { thirdPartyProxyDeclared: true });
+    expect(overlay.THIRD_PARTY_PROXY).toBe('record-replay');
+  });
+});
+
+describe('shared allowlist', () => {
+  it('exports all 7 enumerated keys', () => {
+    expect(ALL_ENUMERATED_KEYS).toHaveLength(7);
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/deploy/test-mode-divergence-keys.mjs`: shared 7-row allowlist (docs/design/deploy-pipeline-architecture.md §4) — single source of truth for both the overlay generator and the auditor
- `lib/deploy/test-mode-overlay.mjs`: generates a preview's test-mode config overlay from production config, always generated, never hand-edited
- `lib/deploy/config-diff-auditor.mjs`: diffs a preview's effective config against production, emits structured `TEST_MODE_DIVERGENCE` findings for any out-of-budget key; masks secret-like values
- `lib/deploy/pseudonymize-not-redact-gate.mjs`: blocks captured-production-state replay seeding until the snapshot passes the binding pseudonymize-not-redact contract (Adam co-reviewed)

## Test plan
- [x] 19 unit tests in `tests/unit/deploy/` covering PRD TS-1 through TS-8
- [x] `npx vitest run --project unit tests/unit/deploy/` — 19/19 passed
- [x] ESLint clean
- [x] Pre-commit hooks passed (smoke tests, secret scan, Gate 0 SD status, LOC threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)