### PR TITLE
feat(SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001): value-authenticity spec-time gate + criteria library

### DIFF
--- a/database/migrations/20260709_value_authenticity_criteria_library.sql
+++ b/database/migrations/20260709_value_authenticity_criteria_library.sql
@@ -1,0 +1,99 @@
+-- SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001 (FR-1, FR-6)
+-- Canonical criteria library: the anti-mock assertion forms (T0-T4) that spec authors
+-- SELECT + PARAMETERIZE from, and that pair-half B (APA runtime, SD-LEO-INFRA-VALUE-
+-- AUTHENTICITY-APA-001) reads + runs at runtime by criterion_id (round-trip SSOT,
+-- docs/design/value-authenticity-system-design.md §4.3).
+--
+-- Contract version 1 (FR-6 exit criterion): criterion_id format is 'VA-<T_FORM>-<slug>'
+-- (e.g. VA-T1-source-reached-market-research). This format is frozen as of this
+-- migration; a future breaking change to the ID scheme requires a documented contract
+-- version bump (add a `contract_version` value, never silently reshape existing rows).
+
+CREATE TABLE IF NOT EXISTS value_authenticity_criteria_library (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  criterion_id TEXT NOT NULL UNIQUE,
+  contract_version INTEGER NOT NULL DEFAULT 1,
+  t_form TEXT NOT NULL CHECK (t_form IN ('T0', 'T1', 'T2', 'T3', 'T4')),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  -- What a spec author fills in when selecting this form for a leaf (FR-1).
+  -- Shape varies per T-form; documented per-row in parameter_schema_notes.
+  parameter_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+  parameter_schema_notes TEXT,
+  -- E0-E3 weakest-link evidence grade (§2 primitive #2). This table defines the FIELD;
+  -- the propagation engine across domain-claim -> spec-criterion -> runtime-verdict is
+  -- L3's job (a future SD), not this one.
+  evidence_grade TEXT CHECK (evidence_grade IN ('E0', 'E1', 'E2', 'E3')),
+  -- true for T0/T1/T2 (hard catchers, can gate); false for T3/T4 (soft corroborators,
+  -- can never hard-fail a leaf per SSOT §1-L1 fail-closed bar).
+  hard_catcher BOOLEAN NOT NULL,
+  -- Free-text provenance of why this form is proven mock-distinguishing (the FR-1
+  -- meta-gate: v1 is manual-review-with-checklist, not an automated prover).
+  mock_distinguishing_proof TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_value_authenticity_criteria_library_t_form
+  ON value_authenticity_criteria_library (t_form);
+
+-- Seed the 5 T0-T4 forms (FR-1 acceptance criterion), each mapped to the MarketLens
+-- persona-generation origin incident per docs/design/value-authenticity-system-design.md
+-- §4.1 (the gate's own acceptance test / TS-1).
+INSERT INTO value_authenticity_criteria_library
+  (criterion_id, t_form, title, description, parameter_schema, parameter_schema_notes, hard_catcher, mock_distinguishing_proof)
+VALUES
+  (
+    'VA-T0-source-exists',
+    'T0',
+    'Source-EXISTS static check',
+    'AST/grep the value engine for ANY external dependency (model call / data corpus / external fetch). A pure-function-of-user-input implementation is an automatic finding. Catches the honest stub.',
+    '{"target_module": "string (path to the value-engine module)", "expected_external_dependency_pattern": "string (e.g. an API call, a corpus file read, an LLM invocation)"}'::jsonb,
+    'Author supplies the module path and what external dependency SHOULD be present; the check fails if grep/AST finds none.',
+    true,
+    'MarketLens''s FNV-1a hash stub has NO external dependency (pure function of input text) — T0 catches it trivially. Any real research/generation engine has a real dependency; a stub by definition does not.'
+  ),
+  (
+    'VA-T1-source-reached',
+    'T1',
+    'Source-REACHED runtime instrumentation assertion (PRIMARY hard catcher)',
+    'During the walkthrough, APA''s own instrumentation (instrument-don''t-mock; author != adjudicator, never the build''s own test suite) asserts the declared source was ACTUALLY consulted at runtime. Catches the dishonest stub that deleted the honesty comment. Keys on the PRODUCT-LEVEL claim (numbers presented as real research), never an in-code string.',
+    '{"instrumented_call_site": "string (the exact function/API call APA must observe being invoked)", "product_level_claim": "string (the user-facing claim this call site backs, e.g. \"WTP derived from real market research\")"}'::jsonb,
+    'Author names the exact call site APA instruments and the user-facing claim it substantiates — never an in-code string match (defeatable by renaming).',
+    true,
+    'A hash stub never reaches any external call site — T1 observes zero invocations at runtime regardless of what the code comments claim, closing the "deleted the honesty comment" loophole T0 alone cannot catch.'
+  ),
+  (
+    'VA-T2-metamorphic-monotonicity',
+    'T2',
+    'Metamorphic-MONOTONICITY (deterministic, low false-positive)',
+    'A CONTROLLED DIRECTED perturbation (e.g. budget up, segment shift; template-generated, no LLM) must produce the CORRESPONDING directed output change — checking direction/ordering, not absolute values. Rule: input-sensitivity != input-responsiveness. A hash stub moves outputs randomly on ANY input change; its sensitivity is uncorrelated with meaning.',
+    '{"perturbation": "string (the directed input change, e.g. \"increase stated budget by 2x\")", "expected_direction": "string (the expected directional output change, e.g. \"WTP band should shift upward\")"}'::jsonb,
+    'The probe BACKEND that executes this check is pair-half B''s (APA runtime) build cost — this row only defines the form/parameter shape a spec author selects at spec-time.',
+    true,
+    'MarketLens''s hash stub is input-sensitive (any input change moves the hash) but NOT input-responsive in a meaningful direction — a 2x budget increase does not reliably shift its WTP band upward. T2 is the form specifically designed to catch "differs per input" as insufficient.'
+  ),
+  (
+    'VA-T3-paraphrase-invariance',
+    'T3',
+    'Paraphrase-INVARIANCE (SOFT corroborator only)',
+    'Stability under meaning-preserving edits. FP-prone versus real LLM variance, so under the fail-closed bar it must NEVER hard-fail a leaf. Keys only on absolute-value product-sensitivity, wide tolerance, biased toward false-negatives (i.e. biased to NOT flag).',
+    '{"paraphrase_pairs": "array of {original, paraphrased} input pairs", "tolerance": "number (wide tolerance band for output similarity)"}'::jsonb,
+    'Soft-only: findings from this form can corroborate a T1/T2 finding but can never independently block a leaf.',
+    false,
+    'Corroborator only — proof of mock-distinguishing-ness is inherited from T1/T2, not independently required for a soft form.'
+  ),
+  (
+    'VA-T4-plausibility-as-persona',
+    'T4',
+    'Plausibility-as-persona (model-tier, SOFT)',
+    'An agent walks the flow AS the persona and judges "specific to my input vs canned boilerplate." Routed through the design SSOT §5 two-stage funnel; corroborates, never blocks.',
+    '{"persona_definition": "string (the persona the judging agent adopts)", "plausibility_rubric": "string (what counts as specific-vs-canned for this leaf)"}'::jsonb,
+    'Soft-only, same non-blocking constraint as T3. Judge-integrity constraints (SSOT §1-L5: brand-stripped, multimodal, triangulated) apply when this form is actually executed at runtime (pair-half B / APA Child E), not at spec-time.',
+    false,
+    'Corroborator only — same rationale as T3.'
+  )
+ON CONFLICT (criterion_id) DO NOTHING;
+
+COMMENT ON TABLE value_authenticity_criteria_library IS
+  'SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001: canonical anti-mock criteria library (T0-T4 forms). Spec-time gate (this SD) writes selections here; APA runtime (pair-half B, SD-LEO-INFRA-VALUE-AUTHENTICITY-APA-001) reads+runs by criterion_id. Contract version 1 — see migration header comment before changing the ID format.';

--- a/database/migrations/20260709_value_authenticity_criteria_library.sql
+++ b/database/migrations/20260709_value_authenticity_criteria_library.sql
@@ -97,3 +97,19 @@ ON CONFLICT (criterion_id) DO NOTHING;
 
 COMMENT ON TABLE value_authenticity_criteria_library IS
   'SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001: canonical anti-mock criteria library (T0-T4 forms). Spec-time gate (this SD) writes selections here; APA runtime (pair-half B, SD-LEO-INFRA-VALUE-AUTHENTICITY-APA-001) reads+runs by criterion_id. Contract version 1 — see migration header comment before changing the ID format.';
+
+-- Adversarial-review finding (PR #5761): this table shipped with no RLS, unlike
+-- every sibling internal-reference-table migration from the same week
+-- (20260706_create_capacity_limit_events.sql, 20260706_venture_design_pass_ledger.sql).
+-- Matches the established pattern: service_role has full access (writes come from the
+-- gate/database-agent, never end-user code), authenticated reads are allowed (the
+-- library is reference data, not sensitive).
+ALTER TABLE value_authenticity_criteria_library ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all" ON value_authenticity_criteria_library;
+CREATE POLICY "service_role_all" ON value_authenticity_criteria_library
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "authenticated_select" ON value_authenticity_criteria_library;
+CREATE POLICY "authenticated_select" ON value_authenticity_criteria_library
+  FOR SELECT TO authenticated USING (true);

--- a/scripts/modules/handoff/validation/validator-registry/gates/index.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/index.js
@@ -10,3 +10,5 @@ export { registerGate3Validators } from './gate-3-traceability.js';
 export { registerGate4Validators } from './gate-4-strategic-value.js';
 export { registerGateQValidators } from './gate-q-quality.js';
 export { registerAdditionalValidators } from './additional-validators.js';
+// SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001: observe-only spec-time anti-mock gate.
+export { registerValueAuthenticityGate } from './value-authenticity-spec-gate.js';

--- a/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
@@ -1,0 +1,259 @@
+/**
+ * Value-authenticity spec-time gate (SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001).
+ *
+ * Rejects PRD acceptance criteria on value-bearing ("derived result") leaves that a
+ * mock/stub could satisfy — forcing authors to SELECT + PARAMETERIZE a criterion_id
+ * from the canonical criteria library (value_authenticity_criteria_library, see
+ * database/migrations/20260709_value_authenticity_criteria_library.sql) instead of
+ * writing free-text prose. See docs/design/value-authenticity-system-design.md §1-L2.
+ *
+ * Ships OBSERVE-ONLY (FR-5, CLAUDE_CORE.md "Observe-Only-First Default for New
+ * Enforcement"): findings are logged/flagged, never blocking, unless
+ * VALUE_AUTHENTICITY_GATE_BINDING=true is explicitly set.
+ *
+ * All classification/check functions below are PURE (no I/O) so they are directly
+ * unit-testable without a database or PRD row.
+ */
+
+// Contract version 1 ID scheme (FR-6): 'VA-<T_FORM>-<slug>'. A criterion is considered
+// "selected from the library" if its text contains a matching ID token — this is how
+// the spec-time selection (this SD) and the runtime execution (pair-half B) round-trip
+// by ID without either side re-deriving the other's shape (SSOT §4.3).
+const LIBRARY_CRITERION_ID_PATTERN = /\bVA-T[0-4]-[a-z0-9-]+\b/i;
+
+// Trigger predicate (SSOT §1-L2): only leaves whose output the product presents as a
+// DERIVED RESULT a user relies on — never CRUD/nav (universal friction gets gates
+// gamed). Keyword-heuristic classifier; false-negatives (missing a real derived-result
+// leaf) are safer than false-positives (gating CRUD) given this ships observe-only.
+const DERIVED_RESULT_KEYWORDS = [
+  'analysis', 'analyze', 'recommend', 'generat', 'score', 'pricing', 'price',
+  'persona', 'insight', 'predict', 'forecast', 'valuation', 'rating', 'assessment',
+  'evaluat', 'classif', 'summar', 'derive', 'research', 'estimate'
+];
+const CRUD_NAV_KEYWORDS = [
+  'create a', 'create an', 'delete', 'navigate', 'display the', 'list the',
+  'render', 'view the', 'record', 'save the', 'store the', 'load the', 'fetch the',
+  'log in', 'sign up', 'button', 'form field', 'page load', 'redirect'
+];
+
+/**
+ * Does this leaf (FR title + description) present a claim a user relies on as a
+ * derived result (analysis/recommendation/generated content/score/price), as opposed
+ * to CRUD/nav? Pure function — no I/O.
+ * @param {string} leafText
+ * @returns {boolean} true if the leaf is in scope for the gate
+ */
+function classifyTriggerPredicate(leafText) {
+  const text = (leafText || '').toLowerCase();
+  if (!text.trim()) return false;
+
+  const hasDerivedResultSignal = DERIVED_RESULT_KEYWORDS.some(kw => text.includes(kw));
+  if (!hasDerivedResultSignal) return false;
+
+  // A leaf can mention a derived-result word in passing while still being pure CRUD
+  // (e.g. "user can view their score history" — a display leaf, not a computation
+  // leaf). Require the derived-result signal WITHOUT being dominated by CRUD/nav
+  // phrasing to reduce false positives on such leaves.
+  const crudNavHits = CRUD_NAV_KEYWORDS.filter(kw => text.includes(kw)).length;
+  const derivedHits = DERIVED_RESULT_KEYWORDS.filter(kw => text.includes(kw)).length;
+  return derivedHits > crudNavHits;
+}
+
+/**
+ * Is this acceptance-criterion text mock-satisfiable — i.e. free-text prose rather
+ * than a selection+parameterization from the canonical criteria library by ID? Pure
+ * function — no I/O, no DB lookup (library existence is NOT verified here; that is
+ * the caller's job when it has access to the live library rows).
+ * @param {string} criterionText
+ * @returns {boolean} true if the criterion is mock-satisfiable (missing a library ID)
+ */
+function isMockSatisfiable(criterionText) {
+  const text = (criterionText || '').trim();
+  if (!text) return true;
+  return !LIBRARY_CRITERION_ID_PATTERN.test(text);
+}
+
+/**
+ * Extract the library criterion_id referenced by an acceptance-criterion string, if
+ * any. Pure function.
+ * @param {string} criterionText
+ * @returns {string|null}
+ */
+function extractCriterionId(criterionText) {
+  const match = LIBRARY_CRITERION_ID_PATTERN.exec(criterionText || '');
+  return match ? match[0].toUpperCase() : null;
+}
+
+/**
+ * Deferred-stub trap (SSOT §1-L2, two teeth). A phased stub on an in-scope leaf is
+ * legal ONLY if BOTH teeth are present:
+ *   (i) the deferral names a blocking-predecessor SD (a real SD key gating launch)
+ *   (ii) the product claim demotes while stubbed (cannot advertise as real)
+ * Pure function.
+ * @param {{ namedBlockingSdKey?: string|null, claimDemoted?: boolean }} deferral
+ * @returns {{ passed: boolean, missingTeeth: string[] }}
+ */
+function checkDeferredStubTrap(deferral) {
+  const missingTeeth = [];
+  const hasNamedBlockingSd = !!(deferral && deferral.namedBlockingSdKey && /^SD-/.test(deferral.namedBlockingSdKey));
+  const claimDemoted = !!(deferral && deferral.claimDemoted === true);
+
+  if (!hasNamedBlockingSd) missingTeeth.push('NAMED_BLOCKING_PREDECESSOR_SD');
+  if (!claimDemoted) missingTeeth.push('CLAIM_DEMOTION');
+
+  return { passed: missingTeeth.length === 0, missingTeeth };
+}
+
+/**
+ * No-silent-pass (FR-4): an in-scope leaf with no library-expressible criterion must
+ * either (a) have a criterion selected from the library, or (b) carry an explicit
+ * authenticity-unspecifiable waiver with a named owner (recorded via SD-1's decision-
+ * binding disposition rows — this function does not read that table; the caller
+ * supplies whether a waiver was found). Pure function.
+ * @param {{ hasLibraryCriterion: boolean, waiver?: { ownerName?: string } | null }} params
+ * @returns {{ passed: boolean, reason: string }}
+ */
+function checkNoSilentPass({ hasLibraryCriterion, waiver }) {
+  if (hasLibraryCriterion) return { passed: true, reason: 'LIBRARY_CRITERION_PRESENT' };
+  const hasNamedWaiver = !!(waiver && typeof waiver.ownerName === 'string' && waiver.ownerName.trim().length > 0);
+  if (hasNamedWaiver) return { passed: true, reason: 'WAIVER_WITH_NAMED_OWNER' };
+  return { passed: false, reason: 'NO_CRITERION_NO_WAIVER' };
+}
+
+/**
+ * Evaluate a single PRD functional requirement against FR-2/FR-3/FR-4. Pure function
+ * (no I/O) — the caller supplies libraryCriterionIds (from a live DB read) and any
+ * known waivers so this stays testable without a database.
+ * @param {object} fr - a PRD functional_requirements[] entry
+ * @param {{ libraryCriterionIds: Set<string>, waiversByFrId?: Map<string, {ownerName: string}> }} ctx
+ * @returns {Array<{fr_id: string, criterion: string, issue: string, message: string}>}
+ */
+function evaluateFunctionalRequirement(fr, ctx) {
+  const findings = [];
+  const leafText = `${fr?.title || ''} ${fr?.description || ''}`;
+  if (!classifyTriggerPredicate(leafText)) return findings; // out of scope (CRUD/nav)
+
+  const criteria = Array.isArray(fr?.acceptance_criteria) ? fr.acceptance_criteria : [];
+  const libraryCriterionIds = ctx?.libraryCriterionIds || new Set();
+  let anyLibraryCriterion = false;
+
+  for (const criterion of criteria) {
+    if (isMockSatisfiable(criterion)) {
+      findings.push({
+        fr_id: fr.id || '(no id)',
+        criterion,
+        issue: 'MOCK_SATISFIABLE',
+        message: `FR ${fr.id || '(no id)'}: acceptance criterion "${String(criterion).slice(0, 120)}" is free-text and mock-satisfiable — select+parameterize a criterion_id from value_authenticity_criteria_library instead.`
+      });
+      continue;
+    }
+    const criterionId = extractCriterionId(criterion);
+    if (libraryCriterionIds.size > 0 && criterionId && !libraryCriterionIds.has(criterionId)) {
+      findings.push({
+        fr_id: fr.id || '(no id)',
+        criterion,
+        issue: 'UNKNOWN_CRITERION_ID',
+        message: `FR ${fr.id || '(no id)'}: references criterion_id "${criterionId}" which is not in the current criteria library — round-trip contract broken.`
+      });
+      continue;
+    }
+    anyLibraryCriterion = true;
+  }
+
+  if (!anyLibraryCriterion) {
+    const waiver = ctx?.waiversByFrId?.get(fr.id);
+    const silentPass = checkNoSilentPass({ hasLibraryCriterion: false, waiver });
+    if (!silentPass.passed) {
+      findings.push({
+        fr_id: fr.id || '(no id)',
+        criterion: null,
+        issue: 'NO_SILENT_PASS_VIOLATION',
+        message: `FR ${fr.id || '(no id)'}: derived-result leaf has no library-expressible criterion and no authenticity-unspecifiable waiver with a named owner — cannot silently pass.`
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Main gate evaluation across a full PRD. Pure function given its inputs — the
+ * ValidatorRegistry wrapper (registerValueAuthenticityGate below) is the only piece
+ * that performs I/O (reading the live library table, the binding-mode env var).
+ * @param {object} prd - PRD row (functional_requirements field consumed)
+ * @param {{ bindingEnabled?: boolean, libraryCriterionIds?: Set<string>, waiversByFrId?: Map<string, {ownerName: string}> }} options
+ * @returns {{ passed: boolean, score: number, max_score: number, issues: string[], warnings: string[], findings: Array }}
+ */
+function evaluateValueAuthenticitySpecGate(prd, options = {}) {
+  const bindingEnabled = options.bindingEnabled === true;
+  const frs = Array.isArray(prd?.functional_requirements) ? prd.functional_requirements : [];
+
+  const allFindings = frs.flatMap(fr => evaluateFunctionalRequirement(fr, options));
+  const messages = allFindings.map(f => f.message);
+
+  // Observe-only (default): never fails the gate, findings surface as warnings only,
+  // so the calibration window has real data without blocking any handoff (FR-5).
+  if (!bindingEnabled) {
+    return {
+      passed: true,
+      score: allFindings.length === 0 ? 100 : 70,
+      max_score: 100,
+      issues: [],
+      warnings: messages,
+      findings: allFindings
+    };
+  }
+
+  return {
+    passed: allFindings.length === 0,
+    score: allFindings.length === 0 ? 100 : 0,
+    max_score: 100,
+    issues: messages,
+    warnings: [],
+    findings: allFindings
+  };
+}
+
+/**
+ * Register this gate into the ValidatorRegistry, following the established
+ * `registry.register(name, async (context) => result, description)` pattern (see
+ * scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js).
+ * @param {import('../core.js').ValidatorRegistry} registry
+ */
+function registerValueAuthenticityGate(registry) {
+  registry.register('valueAuthenticitySpecGate', async (context) => {
+    const { prd, supabase } = context;
+
+    if (!prd) {
+      return { passed: true, score: 100, max_score: 100, warnings: ['No PRD available yet — gate not applicable at this handoff'] };
+    }
+
+    let libraryCriterionIds = new Set();
+    try {
+      if (supabase) {
+        const { data } = await supabase.from('value_authenticity_criteria_library').select('criterion_id');
+        libraryCriterionIds = new Set((data || []).map(r => r.criterion_id.toUpperCase()));
+      }
+    } catch {
+      // Fail-open on a library-read error: observe-mode already never blocks, and a
+      // transient DB error should not manufacture MOCK_SATISFIABLE findings for
+      // criteria that legitimately reference valid (but unverifiable-right-now) IDs.
+      libraryCriterionIds = new Set();
+    }
+
+    const bindingEnabled = process.env.VALUE_AUTHENTICITY_GATE_BINDING === 'true';
+    return evaluateValueAuthenticitySpecGate(prd, { bindingEnabled, libraryCriterionIds });
+  }, 'Value-authenticity spec-time gate (FR-2/FR-3/FR-4; observe-only unless VALUE_AUTHENTICITY_GATE_BINDING=true)');
+}
+
+export {
+  classifyTriggerPredicate,
+  isMockSatisfiable,
+  extractCriterionId,
+  checkDeferredStubTrap,
+  checkNoSilentPass,
+  evaluateFunctionalRequirement,
+  evaluateValueAuthenticitySpecGate,
+  registerValueAuthenticityGate,
+  LIBRARY_CRITERION_ID_PATTERN
+};

--- a/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
@@ -133,6 +133,23 @@ function evaluateFunctionalRequirement(fr, ctx) {
   const leafText = `${fr?.title || ''} ${fr?.description || ''}`;
   if (!classifyTriggerPredicate(leafText)) return findings; // out of scope (CRUD/nav)
 
+  // FR-3 deferred-stub trap: an FR MAY declare `fr.deferral = { namedBlockingSdKey,
+  // claimDemoted }` to mark itself as a phased/stubbed capability. When declared, BOTH
+  // teeth must be present (checkDeferredStubTrap) — an untracked deferral (the exact
+  // MarketLens TR-2 defect: "deferred the real engine to an untracked follow-up") is
+  // flagged independent of whether the FR also has a library-selected criterion.
+  if (fr && Object.prototype.hasOwnProperty.call(fr, 'deferral')) {
+    const stubTrap = checkDeferredStubTrap(fr.deferral || {});
+    if (!stubTrap.passed) {
+      findings.push({
+        fr_id: fr.id || '(no id)',
+        criterion: null,
+        issue: 'DEFERRED_STUB_TRAP_VIOLATION',
+        message: `FR ${fr.id || '(no id)'}: declares a deferral missing required teeth (${stubTrap.missingTeeth.join(', ')}) — an untracked/undemoted deferred stub is not compliant.`
+      });
+    }
+  }
+
   const criteria = Array.isArray(fr?.acceptance_criteria) ? fr.acceptance_criteria : [];
   const libraryCriterionIds = ctx?.libraryCriterionIds || new Set();
   let anyLibraryCriterion = false;

--- a/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
@@ -64,23 +64,31 @@ function classifyTriggerPredicate(leafText) {
  * than a selection+parameterization from the canonical criteria library by ID? Pure
  * function — no I/O, no DB lookup (library existence is NOT verified here; that is
  * the caller's job when it has access to the live library rows).
- * @param {string} criterionText
+ *
+ * Coerces via String() rather than relying on the input already being a string:
+ * PRD acceptance_criteria is author-supplied JSONB and a non-string entry (a number,
+ * object, or array slipped in by a malformed PRD) must never throw here — this
+ * function runs inside a fleet-wide handoff gate where an uncaught exception gets
+ * converted to a hard FAIL by ValidationOrchestrator, regardless of the observe-only
+ * binding flag (the exact fail-open guarantee FR-5 promises).
+ * @param {*} criterionText
  * @returns {boolean} true if the criterion is mock-satisfiable (missing a library ID)
  */
 function isMockSatisfiable(criterionText) {
-  const text = (criterionText || '').trim();
+  const text = criterionText == null ? '' : String(criterionText).trim();
   if (!text) return true;
   return !LIBRARY_CRITERION_ID_PATTERN.test(text);
 }
 
 /**
  * Extract the library criterion_id referenced by an acceptance-criterion string, if
- * any. Pure function.
- * @param {string} criterionText
+ * any. Pure function. Coerces via String() for the same reason as isMockSatisfiable.
+ * @param {*} criterionText
  * @returns {string|null}
  */
 function extractCriterionId(criterionText) {
-  const match = LIBRARY_CRITERION_ID_PATTERN.exec(criterionText || '');
+  const text = criterionText == null ? '' : String(criterionText);
+  const match = LIBRARY_CRITERION_ID_PATTERN.exec(text);
   return match ? match[0].toUpperCase() : null;
 }
 
@@ -208,12 +216,20 @@ function evaluateValueAuthenticitySpecGate(prd, options = {}) {
   const allFindings = frs.flatMap(fr => evaluateFunctionalRequirement(fr, options));
   const messages = allFindings.map(f => f.message);
 
-  // Observe-only (default): never fails the gate, findings surface as warnings only,
-  // so the calibration window has real data without blocking any handoff (FR-5).
+  // Observe-only (default): score is ALWAYS 100, never just "passed: true" with a
+  // lower score. Adversarial-review finding (PR #5761): ValidationOrchestrator
+  // computes a WEIGHTED-AVERAGE composite score across all gates
+  // (weightedScoreSum / totalWeight) that feeds the SD-type pass threshold — a
+  // rule row with weight:0 is treated as weight:1.0 by `gate.weight || 1.0`
+  // (falsy-zero fallback), so a lower score here would NOT be blocking by itself
+  // (`passed` gates that) but WOULD drag down other gates' composite average,
+  // indirectly failing an otherwise-healthy handoff. True observe-only neutrality
+  // requires score:100 always, with findings surfaced ONLY via warnings — the
+  // calibration window still gets real data without touching any handoff's score.
   if (!bindingEnabled) {
     return {
       passed: true,
-      score: allFindings.length === 0 ? 100 : 70,
+      score: 100,
       max_score: 100,
       issues: [],
       warnings: messages,
@@ -259,7 +275,22 @@ function registerValueAuthenticityGate(registry) {
     }
 
     const bindingEnabled = process.env.VALUE_AUTHENTICITY_GATE_BINDING === 'true';
-    return evaluateValueAuthenticitySpecGate(prd, { bindingEnabled, libraryCriterionIds });
+    try {
+      return evaluateValueAuthenticitySpecGate(prd, { bindingEnabled, libraryCriterionIds });
+    } catch (evalErr) {
+      // Defense-in-depth: this gate must NEVER be the thing that hard-fails a handoff.
+      // ValidationOrchestrator converts an uncaught validator exception into a hard
+      // FAIL regardless of the binding flag — a single malformed PRD field (e.g. a
+      // non-string acceptance_criteria entry future code adds without updating this
+      // gate) would otherwise silently violate FR-5's fail-open guarantee for every
+      // SD in the fleet. Fail open here too, with the error surfaced as a warning.
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        warnings: [`valueAuthenticitySpecGate evaluation error (failed open): ${evalErr && evalErr.message ? evalErr.message : String(evalErr)}`]
+      };
+    }
   }, 'Value-authenticity spec-time gate (FR-2/FR-3/FR-4; observe-only unless VALUE_AUTHENTICITY_GATE_BINDING=true)');
 }
 

--- a/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
@@ -160,7 +160,7 @@ function evaluateFunctionalRequirement(fr, ctx) {
         fr_id: fr.id || '(no id)',
         criterion,
         issue: 'MOCK_SATISFIABLE',
-        message: `FR ${fr.id || '(no id)'}: acceptance criterion "${String(criterion).slice(0, 120)}" is free-text and mock-satisfiable — select+parameterize a criterion_id from value_authenticity_criteria_library instead.`
+        message: `FR ${fr.id || '(no id)'}: acceptance criterion "${String(criterion).slice(0, 120)}" is free-text and mock-satisfiable — reference a parameterized criterion_id from value_authenticity_criteria_library instead.`
       });
       continue;
     }

--- a/scripts/modules/handoff/validation/validator-registry/index.js
+++ b/scripts/modules/handoff/validation/validator-registry/index.js
@@ -23,7 +23,8 @@ import {
   registerGate3Validators,
   registerGate4Validators,
   registerGateQValidators,
-  registerAdditionalValidators
+  registerAdditionalValidators,
+  registerValueAuthenticityGate
 } from './gates/index.js';
 
 /**
@@ -41,6 +42,7 @@ export function createValidatorRegistry() {
   registerGate4Validators(registry);
   registerGateQValidators(registry);
   registerAdditionalValidators(registry);
+  registerValueAuthenticityGate(registry);
 
   console.log(`ValidatorRegistry: Registered ${registry.validators.size} validators`);
 
@@ -61,7 +63,8 @@ export {
   registerGate3Validators,
   registerGate4Validators,
   registerGateQValidators,
-  registerAdditionalValidators
+  registerAdditionalValidators,
+  registerValueAuthenticityGate
 } from './gates/index.js';
 
 // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Gate context preloader

--- a/tests/unit/value-authenticity-spec-gate.test.js
+++ b/tests/unit/value-authenticity-spec-gate.test.js
@@ -52,6 +52,16 @@ describe('isMockSatisfiable + extractCriterionId (FR-2)', () => {
     expect(isMockSatisfiable('')).toBe(true);
     expect(isMockSatisfiable(null)).toBe(true);
   });
+
+  it('crash-safety: a non-string criterion entry (malformed PRD JSONB) never throws — adversarial-review finding', () => {
+    expect(() => isMockSatisfiable(42)).not.toThrow();
+    expect(() => isMockSatisfiable({ not: 'a string' })).not.toThrow();
+    expect(() => isMockSatisfiable(['array', 'entry'])).not.toThrow();
+    expect(() => isMockSatisfiable(true)).not.toThrow();
+    expect(isMockSatisfiable(42)).toBe(true); // coerced to "42", no library ID → mock-satisfiable
+    expect(() => extractCriterionId(42)).not.toThrow();
+    expect(() => extractCriterionId({ not: 'a string' })).not.toThrow();
+  });
 });
 
 describe('checkDeferredStubTrap (FR-3, two teeth)', () => {
@@ -188,6 +198,16 @@ describe('evaluateFunctionalRequirement — integration of the checks above', ()
     expect(findings.some(f => f.issue === 'UNKNOWN_CRITERION_ID')).toBe(true);
   });
 
+  it('crash-safety: a malformed PRD with non-string acceptance_criteria entries never throws — adversarial-review finding', () => {
+    const fr = {
+      id: 'FR-9',
+      title: 'Generate market analysis',
+      description: 'System shall produce a market analysis score',
+      acceptance_criteria: [42, { malformed: true }, null, 'VA-T1-source-reached: x']
+    };
+    expect(() => evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(['VA-T1-SOURCE-REACHED']) })).not.toThrow();
+  });
+
   it('FR-4 no-silent-pass: derived-result leaf with zero criteria and no waiver is flagged, not silently passed', () => {
     const fr = {
       id: 'FR-5',
@@ -229,6 +249,16 @@ describe('evaluateValueAuthenticitySpecGate — TS-4 observe-only vs binding mod
     expect(result.passed).toBe(true);
     expect(result.warnings.length).toBeGreaterThan(0);
     expect(result.issues).toEqual([]);
+  });
+
+  it('adversarial-review finding: observe-only score is ALWAYS 100 regardless of findings — a real ValidationOrchestrator quirk (gate.weight || 1.0) means a lower score here would drag down OTHER gates composite average even though passed=true never blocks by itself', () => {
+    const result = evaluateValueAuthenticitySpecGate(nonConformingPrd, { bindingEnabled: false });
+    expect(result.score).toBe(100);
+    expect(result.max_score).toBe(100);
+    // Sanity: a conforming PRD also scores 100, so the invariant is score-independent
+    // of findings, not just "happens to be 100 when findings exist".
+    const cleanResult = evaluateValueAuthenticitySpecGate({ functional_requirements: [] }, { bindingEnabled: false });
+    expect(cleanResult.score).toBe(100);
   });
 
   it('binding mode: the SAME non-conforming PRD FAILS the gate', () => {

--- a/tests/unit/value-authenticity-spec-gate.test.js
+++ b/tests/unit/value-authenticity-spec-gate.test.js
@@ -116,6 +116,45 @@ describe('evaluateFunctionalRequirement — integration of the checks above', ()
     expect(findings[0].issue).toBe('MOCK_SATISFIABLE');
   });
 
+  it('TS-1: MarketLens replay fails on BOTH grounds when the FR also declares an untracked deferral (SSOT §4.1)', () => {
+    const fr = {
+      id: 'TR-2',
+      title: 'Generate persona recommendations',
+      description: 'System shall generate a persona and WTP pricing analysis from user input',
+      acceptance_criteria: ['Output differs per input'],
+      // The real engine was deferred to an UNTRACKED follow-up — no named blocking SD,
+      // no claim-demotion. This is the exact MarketLens TR-2 defect.
+      deferral: {}
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set() });
+    const issues = findings.map(f => f.issue);
+    expect(issues).toContain('MOCK_SATISFIABLE');
+    expect(issues).toContain('DEFERRED_STUB_TRAP_VIOLATION');
+  });
+
+  it('FR-3 wired: a tracked deferral (both teeth present) does not raise DEFERRED_STUB_TRAP_VIOLATION', () => {
+    const fr = {
+      id: 'FR-7',
+      title: 'Generate persona recommendations',
+      description: 'System shall generate a persona and WTP pricing analysis from user input',
+      acceptance_criteria: ['VA-T1-source-reached: instrumented_call_site=x, product_level_claim=y'],
+      deferral: { namedBlockingSdKey: 'SD-REAL-ENGINE-001', claimDemoted: true }
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(['VA-T1-SOURCE-REACHED']) });
+    expect(findings.some(f => f.issue === 'DEFERRED_STUB_TRAP_VIOLATION')).toBe(false);
+  });
+
+  it('FR-3 wired: an FR with no `deferral` field at all is never flagged for the stub trap', () => {
+    const fr = {
+      id: 'FR-8',
+      title: 'Generate market analysis',
+      description: 'System shall produce a market analysis score',
+      acceptance_criteria: ['VA-T1-source-reached: instrumented_call_site=x, product_level_claim=y']
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(['VA-T1-SOURCE-REACHED']) });
+    expect(findings.some(f => f.issue === 'DEFERRED_STUB_TRAP_VIOLATION')).toBe(false);
+  });
+
   it('TS-5: a CRUD/nav FR is never gated, even with a vague criterion', () => {
     const fr = {
       id: 'FR-2',

--- a/tests/unit/value-authenticity-spec-gate.test.js
+++ b/tests/unit/value-authenticity-spec-gate.test.js
@@ -1,0 +1,222 @@
+// SD-LEO-INFRA-VALUE-AUTHENTICITY-SPEC-001: tests for the spec-time anti-mock gate
+// (FR-2 mock-satisfiability, FR-3 deferred-stub trap, FR-4 no-silent-pass, FR-5
+// observe-only mode). Covers PRD test scenarios TS-1 through TS-5.
+import { describe, it, expect } from 'vitest';
+import {
+  classifyTriggerPredicate,
+  isMockSatisfiable,
+  extractCriterionId,
+  checkDeferredStubTrap,
+  checkNoSilentPass,
+  evaluateFunctionalRequirement,
+  evaluateValueAuthenticitySpecGate
+} from '../../scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js';
+
+describe('classifyTriggerPredicate (trigger predicate — derived-result vs CRUD/nav)', () => {
+  it('flags a derived-result leaf (analysis/recommendation) as in scope', () => {
+    expect(classifyTriggerPredicate('System shall generate a persona recommendation with WTP pricing analysis based on user input')).toBe(true);
+  });
+
+  it('does NOT flag a CRUD/nav leaf — TS-5', () => {
+    expect(classifyTriggerPredicate('User can create a venture record and navigate to the detail page')).toBe(false);
+  });
+
+  it('does NOT flag a pure display leaf even if it mentions a derived-result noun in passing', () => {
+    expect(classifyTriggerPredicate('User can view the score history list and navigate back')).toBe(false);
+  });
+
+  it('returns false for empty/missing text', () => {
+    expect(classifyTriggerPredicate('')).toBe(false);
+    expect(classifyTriggerPredicate(undefined)).toBe(false);
+  });
+});
+
+describe('isMockSatisfiable + extractCriterionId (FR-2)', () => {
+  it('flags free-text "differs per input" as mock-satisfiable — the exact MarketLens TR-2 defect', () => {
+    expect(isMockSatisfiable('Output differs per input, proving the engine is responsive')).toBe(true);
+  });
+
+  it('does NOT flag a criterion that selects a library form by ID', () => {
+    expect(isMockSatisfiable('VA-T1-source-reached: instrumented_call_site=persona-gen-api, product_level_claim="WTP derives from real research"')).toBe(false);
+  });
+
+  it('extracts the criterion_id from a valid selection', () => {
+    expect(extractCriterionId('Use VA-T2-metamorphic-monotonicity: perturbation=budget-2x')).toBe('VA-T2-METAMORPHIC-MONOTONICITY');
+  });
+
+  it('extractCriterionId returns null when no library ID is present', () => {
+    expect(extractCriterionId('The output should be reasonable')).toBeNull();
+  });
+
+  it('empty criterion text is mock-satisfiable', () => {
+    expect(isMockSatisfiable('')).toBe(true);
+    expect(isMockSatisfiable(null)).toBe(true);
+  });
+});
+
+describe('checkDeferredStubTrap (FR-3, two teeth)', () => {
+  it('rejects a deferral with only a named blocking SD (missing claim-demotion tooth)', () => {
+    const result = checkDeferredStubTrap({ namedBlockingSdKey: 'SD-FOLLOWUP-001', claimDemoted: false });
+    expect(result.passed).toBe(false);
+    expect(result.missingTeeth).toContain('CLAIM_DEMOTION');
+  });
+
+  it('rejects a deferral with only claim-demotion (missing named-SD tooth) — an untracked deferral', () => {
+    const result = checkDeferredStubTrap({ namedBlockingSdKey: null, claimDemoted: true });
+    expect(result.passed).toBe(false);
+    expect(result.missingTeeth).toContain('NAMED_BLOCKING_PREDECESSOR_SD');
+  });
+
+  it('rejects the MarketLens TR-2-style untracked deferral (both teeth missing)', () => {
+    const result = checkDeferredStubTrap({});
+    expect(result.passed).toBe(false);
+    expect(result.missingTeeth).toEqual(['NAMED_BLOCKING_PREDECESSOR_SD', 'CLAIM_DEMOTION']);
+  });
+
+  it('accepts a deferral with both teeth present', () => {
+    const result = checkDeferredStubTrap({ namedBlockingSdKey: 'SD-REAL-ENGINE-001', claimDemoted: true });
+    expect(result.passed).toBe(true);
+    expect(result.missingTeeth).toEqual([]);
+  });
+});
+
+describe('checkNoSilentPass (FR-4)', () => {
+  it('passes when a library criterion is present', () => {
+    expect(checkNoSilentPass({ hasLibraryCriterion: true }).passed).toBe(true);
+  });
+
+  it('fails (does not silently pass) when there is no criterion and no waiver', () => {
+    const result = checkNoSilentPass({ hasLibraryCriterion: false, waiver: null });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toBe('NO_CRITERION_NO_WAIVER');
+  });
+
+  it('fails when a waiver exists but has no named owner', () => {
+    const result = checkNoSilentPass({ hasLibraryCriterion: false, waiver: { ownerName: '' } });
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes with a waiver that has a named owner', () => {
+    const result = checkNoSilentPass({ hasLibraryCriterion: false, waiver: { ownerName: 'Adam' } });
+    expect(result.passed).toBe(true);
+    expect(result.reason).toBe('WAIVER_WITH_NAMED_OWNER');
+  });
+});
+
+describe('evaluateFunctionalRequirement — integration of the checks above', () => {
+  it('TS-1: MarketLens replay — free-text "differs per input" on a derived-result leaf is flagged', () => {
+    const fr = {
+      id: 'FR-1',
+      title: 'Generate persona recommendations',
+      description: 'System shall generate a persona and WTP pricing analysis from user input',
+      acceptance_criteria: ['Output differs per input']
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set() });
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0].issue).toBe('MOCK_SATISFIABLE');
+  });
+
+  it('TS-5: a CRUD/nav FR is never gated, even with a vague criterion', () => {
+    const fr = {
+      id: 'FR-2',
+      title: 'Create venture record',
+      description: 'User can create a venture record via a form',
+      acceptance_criteria: ['Form submits successfully']
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set() });
+    expect(findings).toEqual([]);
+  });
+
+  it('a library-selected criterion on a derived-result leaf produces no findings', () => {
+    const fr = {
+      id: 'FR-3',
+      title: 'Generate market analysis',
+      description: 'System shall produce a market analysis score',
+      acceptance_criteria: ['VA-T1-source-reached: instrumented_call_site=market-api, product_level_claim="score derives from real market data"']
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(['VA-T1-SOURCE-REACHED']) });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags UNKNOWN_CRITERION_ID when the referenced ID is not in the live library', () => {
+    const fr = {
+      id: 'FR-4',
+      title: 'Generate market analysis',
+      description: 'System shall produce a market analysis score',
+      acceptance_criteria: ['VA-T1-nonexistent-form: some params']
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(['VA-T1-SOURCE-REACHED']) });
+    expect(findings.some(f => f.issue === 'UNKNOWN_CRITERION_ID')).toBe(true);
+  });
+
+  it('FR-4 no-silent-pass: derived-result leaf with zero criteria and no waiver is flagged, not silently passed', () => {
+    const fr = {
+      id: 'FR-5',
+      title: 'Generate persona recommendations',
+      description: 'System shall generate persona recommendations',
+      acceptance_criteria: []
+    };
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set() });
+    expect(findings.some(f => f.issue === 'NO_SILENT_PASS_VIOLATION')).toBe(true);
+  });
+
+  it('FR-4 waiver path: a named-owner waiver silences the no-silent-pass finding', () => {
+    const fr = {
+      id: 'FR-6',
+      title: 'Generate persona recommendations',
+      description: 'System shall generate persona recommendations',
+      acceptance_criteria: []
+    };
+    const waiversByFrId = new Map([['FR-6', { ownerName: 'Adam' }]]);
+    const findings = evaluateFunctionalRequirement(fr, { libraryCriterionIds: new Set(), waiversByFrId });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('evaluateValueAuthenticitySpecGate — TS-4 observe-only vs binding mode', () => {
+  const nonConformingPrd = {
+    functional_requirements: [
+      {
+        id: 'FR-1',
+        title: 'Generate persona recommendations',
+        description: 'System shall generate a persona and WTP pricing analysis',
+        acceptance_criteria: ['Output differs per input']
+      }
+    ]
+  };
+
+  it('observe-only (default): gate PASSES with warnings, never blocks a non-conforming PRD', () => {
+    const result = evaluateValueAuthenticitySpecGate(nonConformingPrd, { bindingEnabled: false });
+    expect(result.passed).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('binding mode: the SAME non-conforming PRD FAILS the gate', () => {
+    const result = evaluateValueAuthenticitySpecGate(nonConformingPrd, { bindingEnabled: true });
+    expect(result.passed).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+
+  it('a conforming PRD passes in BOTH modes', () => {
+    const conformingPrd = {
+      functional_requirements: [
+        {
+          id: 'FR-1',
+          title: 'Generate persona recommendations',
+          description: 'System shall generate a persona and WTP pricing analysis',
+          acceptance_criteria: ['VA-T1-source-reached: instrumented_call_site=x, product_level_claim=y']
+        }
+      ]
+    };
+    const libraryCriterionIds = new Set(['VA-T1-SOURCE-REACHED']);
+    expect(evaluateValueAuthenticitySpecGate(conformingPrd, { bindingEnabled: false, libraryCriterionIds }).passed).toBe(true);
+    expect(evaluateValueAuthenticitySpecGate(conformingPrd, { bindingEnabled: true, libraryCriterionIds }).passed).toBe(true);
+  });
+
+  it('handles a PRD with no functional_requirements gracefully', () => {
+    const result = evaluateValueAuthenticitySpecGate({}, { bindingEnabled: true });
+    expect(result.passed).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Pair-half A of the value-authenticity coupled pair (docs/design/value-authenticity-system-design.md §1-L2/§2/§3): a canonical criteria library of anti-mock assertion forms (T0-T4) seeded against the MarketLens hash-stub origin incident, plus a spec-time gate that rejects mock-satisfiable free-text PRD acceptance criteria on derived-result leaves.
- Ships **observe-only** by default (`VALUE_AUTHENTICITY_GATE_BINDING`, default off) per CLAUDE_CORE.md's Observe-Only-First policy — never blocks a handoff until an evidenced false-positive review promotes it to binding (a LEAD-imposed condition, out of this SD's scope).
- The library's `criterion_id` scheme (contract_version 1) is frozen as this SD's exit criterion — this is what unblocks pair-half B (SD-LEO-INFRA-VALUE-AUTHENTICITY-APA-001) to round-trip real criteria IDs at runtime.
- A real integration gap (deferred-stub-trap check defined but never wired into the eval path) was caught by the VALIDATION sub-agent during PLAN_VERIFICATION and fixed in a follow-up commit.

## Test plan
- [x] 30 new unit tests covering all 5 PRD test scenarios (TS-1 MarketLens replay on both grounds, TS-2 round-trip ID matching, TS-3 no-silent-pass ± named-owner waiver, TS-4 observe-only vs binding mode divergence on the same input, TS-5 CRUD/nav never gated)
- [x] 144 tests across the broader ValidatorRegistry-touching suite, zero regressions
- [x] DATABASE sub-agent executed the migration and verified 5 seeded rows
- [x] TESTING, VALIDATION, and REGRESSION sub-agents all PASS at their respective gates
- [x] Retrospective quality-gated (85 vs 55 threshold, infrastructure SD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)