### PR TITLE
fix(QF-20260709-800): Solomon drain-visibility silent-drop + dedup-ledger false-success

### DIFF
--- a/lib/coordinator/reply-class.cjs
+++ b/lib/coordinator/reply-class.cjs
@@ -18,6 +18,14 @@ const REPLY_CLASS_SET = new Set(REPLY_CLASSES);
 
 const DEFAULT_REPLY_WINDOW_MS = 2 * 60 * 60_000; // 2h
 
+// QF-20260709-800: alreadyAnswered/resolveAnsweredSet must only count a GENUINE
+// answer row (adam_advisory/oracle lane), not a ping_on_silence reminder — a
+// ping row also carries payload.reply_to (it threads back to the original
+// consult), so without this exclusion a pinged-but-never-answered consult
+// falsely dedups as "already answered" and the real answer never gets sent.
+const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+const ANSWER_KIND = PAYLOAD_KINDS.ADAM_ADVISORY;
+
 /** Pure: true iff v is one of the 3 canonical reply-class values. */
 function isValidReplyClass(v) {
   return REPLY_CLASS_SET.has(v);
@@ -71,6 +79,7 @@ async function alreadyAnswered(supabase, correlationId) {
       .from('session_coordination')
       .select('id')
       .eq('payload->>reply_to', correlationId)
+      .eq('payload->>kind', ANSWER_KIND) // QF-20260709-800: exclude ping_on_silence rows
       .limit(1);
     if (error) return false;
     return Array.isArray(data) && data.length > 0;
@@ -92,6 +101,7 @@ async function resolveAnsweredSet(supabase, candidateCorrelationIds) {
       .from('session_coordination')
       .select('payload')
       .in('payload->>reply_to', ids)
+      .eq('payload->>kind', ANSWER_KIND) // QF-20260709-800: exclude ping_on_silence rows
       .limit(1000);
     if (error) return new Set();
     return new Set((data || []).map((r) => r.payload && r.payload.reply_to).filter(Boolean));

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -110,7 +110,7 @@ try {
 //     read_at IS NULL SELECT) until actioned.
 // Pure + synchronous; no DB calls (amCoordinator/amAdam/twoWayOn/isIdle resolved once by caller).
 function classifyInboxMessage(msg, opts = {}) {
-  const { twoWayOn = false, amAdam = false, isIdle = false } = opts;
+  const { twoWayOn = false, amAdam = false, amSolomon = false, isIdle = false } = opts;
   const p = (msg && msg.payload) || {};
   const isInfo = msg && msg.message_type === 'INFO';
   // Coordinator-exclusive INFO rows — SKIP for EVERY session (the coordinator surfaces them via
@@ -139,6 +139,16 @@ function classifyInboxMessage(msg, opts = {}) {
   // notifications re-surface until acked — acceptable for an advisory session whose duty is
   // never missing a directive. Non-Adam (worker/coordinator) drain behavior is untouched.
   if (amAdam) {
+    return { skip: false, markRead: false, markAck: false };
+  }
+  // QF-20260709-800: mirror the amAdam carve-out for Solomon. Without this, a
+  // solomon_consult row (INFO, kind not in DIRECTIVE_KINDS by design) falls
+  // through to the default drain below and gets read_at stamped on the FIRST
+  // tool-call poll — before scripts/solomon-advisory.cjs's specialized
+  // drainInbox() (which queries read_at IS NULL) ever sees it. That drain has
+  // its own closure path (it answers, then stamps read_at itself), so it must
+  // own the stamping, not this generic hook.
+  if (amSolomon) {
     return { skip: false, markRead: false, markAck: false };
   }
   // Actionable directed rows — surface but do NOT mark read/ack on poll; re-surface until the
@@ -527,6 +537,7 @@ async function main() {
   // so the inbox classifier can avoid draining coordinator directives in an Adam session.
   let isIdle = false;
   let amAdam = false;
+  let amSolomon = false;
   try {
     const { data: sessionData } = await supabase
       .from('claude_sessions')
@@ -535,7 +546,8 @@ async function main() {
       .single();
     isIdle = !sessionData?.sd_id; // NOTE: pre-existing bug — column is sd_key, so this is ~always true (flagged, out of scope)
     amAdam = sessionData?.metadata?.role === 'adam';
-  } catch { /* assume not idle / not adam if query fails */ }
+    amSolomon = sessionData?.metadata?.role === 'solomon'; // QF-20260709-800
+  } catch { /* assume not idle / not adam / not solomon if query fails */ }
 
   // Read unread coordination messages for this session
   const { data: messages, error: tableErr } = await supabase
@@ -571,7 +583,7 @@ async function main() {
       // SD-LEO-FIX-FIX-COORDINATION-INBOX-001: single pure decision replaces the three inline
       // skip guards (which were wrongly gated on amCoordinator, letting Adam/workers drain
       // coordinator-exclusive rows) and the read_at/ack stamping below.
-      const verdict = classifyInboxMessage(msg, { isIdle, twoWayOn, amAdam });
+      const verdict = classifyInboxMessage(msg, { isIdle, twoWayOn, amAdam, amSolomon });
       if (verdict.skip) {
         continue;
       }

--- a/tests/unit/coordination-inbox-read-ack-split.test.js
+++ b/tests/unit/coordination-inbox-read-ack-split.test.js
@@ -85,6 +85,17 @@ describe('classifyInboxMessage', () => {
     expect(classifyInboxMessage(coaching, { amAdam: false })).toEqual({ skip: false, markRead: true, markAck: false });
   });
 
+  // QF-20260709-800: a solomon_consult row (INFO, kind not in DIRECTIVE_KINDS by design) previously
+  // fell through to the default drain (markRead:true) on Solomon's OWN first poll, before
+  // scripts/solomon-advisory.cjs's specialized drainInbox() (read_at IS NULL) ever saw it — a silent
+  // drop. amSolomon must mirror amAdam's surface-not-drain carve-out.
+  it('QF-800: a solomon_consult INFO row stays UNREAD for Solomon (mirrors amAdam)', () => {
+    const consult = { message_type: 'INFO', payload: { kind: 'solomon_consult' }, sender_type: 'worker' };
+    expect(classifyInboxMessage(consult, { amSolomon: true })).toEqual({ skip: false, markRead: false, markAck: false });
+    // non-Solomon session keeps the pre-existing default drain (unaffected by this fix)
+    expect(classifyInboxMessage(consult, { amSolomon: false })).toEqual({ skip: false, markRead: true, markAck: false });
+  });
+
   // QF-20260610-545: residual after QF-623 — the carve-out kept a sender_type ALLOWLIST
   // (orchestrator|coordinator), so sender_type=chairman directives fell through to the default
   // drain and 5 chairman messages were auto-acked unseen (harness-bug 43c2dee2). The fix replaces

--- a/tests/unit/solomon-advisory.test.js
+++ b/tests/unit/solomon-advisory.test.js
@@ -95,11 +95,20 @@ describe('FR-E1: NET-NEW guards', () => {
   });
 
   it('alreadyAnswered is true when an advisory already echoes the consult correlation (durable dedup)', async () => {
-    const answered = { from: () => ({ select: () => ({ eq: () => ({ limit: async () => ({ data: [{ id: 'x' }], error: null }) }) }) }) };
-    const fresh = { from: () => ({ select: () => ({ eq: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) };
+    // QF-20260709-800: alreadyAnswered now chains a second .eq() (payload->>kind = adam_advisory)
+    // to exclude ping_on_silence reminder rows from the dedup check — the mock chain reflects that.
+    const answered = { from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ limit: async () => ({ data: [{ id: 'x' }], error: null }) }) }) }) }) };
+    const fresh = { from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) }) };
     expect(await m.alreadyAnswered(answered, 'c1')).toBe(true);
     expect(await m.alreadyAnswered(fresh, 'c1')).toBe(false);
     expect(await m.alreadyAnswered(fresh, null)).toBe(false); // no correlation → not answered
+  });
+
+  it('alreadyAnswered is false when only a ping_on_silence reminder echoes the correlation (QF-20260709-800)', async () => {
+    // A ping row also carries payload.reply_to (threads back to the original consult), but is
+    // NOT a genuine answer — the kind filter must exclude it, so dedup never false-positives.
+    const pingOnly = { from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) }) };
+    expect(await m.alreadyAnswered(pingOnly, 'c1')).toBe(false);
   });
 
   it('checkConsultQuota blocks at the per-day and per-SD ceilings, fails OPEN on error', async () => {


### PR DESCRIPTION
## Summary
- `scripts/hooks/coordination-inbox.cjs`: added an `amSolomon` carve-out mirroring `amAdam` — a `solomon_consult` row no longer gets `read_at` stamped by the generic per-tool-call hook before Solomon's specialized `drainInbox()` (read_at IS NULL) sees it. Fixes the silent-drop instance where a consult reached `read_at=true` without ever surfacing.
- `lib/coordinator/reply-class.cjs`: `alreadyAnswered`/`resolveAnsweredSet` now filter to `payload->>kind = adam_advisory`, excluding `ping_on_silence` reminder rows (which also echo `payload.reply_to` but aren't genuine answers) from the dedup check. Fixes the false-success instance where Solomon's ledger recorded "already answered" with zero delivered answer rows.

**Deliberately out of scope**: assert-at-send typed-kind validation for untyped Adam-directed sends (the third defect in this QF's description). It already has a warn-only visibility safety net (flagged, not silently dropped) and would touch the canonical `insertCoordinationRow()` choke point used by every producer — higher blast radius, warrants its own scoped follow-up.

## Test plan
- [x] 36 unit tests across 3 files (`tests/unit/coordination-inbox-fr3a-defer.test.js`, `tests/unit/coordination-inbox-read-ack-split.test.js`, `tests/unit/solomon-advisory.test.js`) — 2 new tests added, 1 pre-existing test's mock updated to reflect the new query shape
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)