### PR TITLE
fix(QF-20260709-053): enforce typed ADAM_INBOX_KINDS at the producer choke point

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -26,6 +26,8 @@ const crypto = require('crypto');
 // SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 (FR-1): the shared SSOT dispatch-
 // ineligibility classifier, mirror-killed into assertSdDispatchable below.
 const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cjs');
+// QF-20260709-053: no circular-require risk (adam-identity.cjs has zero requires of its own).
+const { getActiveAdamId } = require('./adam-identity.cjs');
 
 // Documented non-UUID targets that are intentionally allowed. broadcast =
 // coordinator→all; broadcast-coordinator = worker→coordinator; broadcast-solomon =
@@ -547,6 +549,29 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     );
     e.code = 'DISPATCH_WORK_ASSIGNMENT_TYPE_MISMATCH';
     throw e;
+  }
+  // QF-20260709-053: an Adam-directed send whose payload.kind is untyped/unknown falls into the
+  // reader-side "orphan" class (scripts/adam-advisory.cjs isOrphanedAdamRow) — flagged but never
+  // drained, a silent-drop risk under 30-min throttled ticks. Refuse at send time instead of
+  // tolerating it reader-side, mirroring the work_assignment guard above. Fail-open on lookup
+  // error (never block a send on a transient Adam-identity-resolution fault).
+  try {
+    const activeAdamId = await getActiveAdamId(supabase, {});
+    if (activeAdamId && row.target_session === activeAdamId && row.payload && typeof row.payload === 'object') {
+      const { isReplyRow, isAdamInboxRow, EXCLUDED_KINDS } = require('../../scripts/adam-advisory.cjs');
+      const kind = row.payload.kind;
+      const isExcluded = kind != null && EXCLUDED_KINDS.includes(kind);
+      if (!isReplyRow(row) && !isAdamInboxRow(row) && !isExcluded) {
+        const e = new Error(
+          `[dispatch] Adam-directed send with untyped/unknown payload.kind='${kind}' refused — not in ADAM_INBOX_KINDS/EXCLUDED_KINDS and not a reply. Use a typed kind (see scripts/adam-advisory.cjs ADAM_INBOX_KINDS) or route via a handler-owned lane.`
+        );
+        e.code = 'DISPATCH_UNTYPED_ADAM_KIND';
+        throw e;
+      }
+    }
+  } catch (e) {
+    if (e && e.code === 'DISPATCH_UNTYPED_ADAM_KIND') throw e; // fail CLOSED on a confirmed violation
+    logger && logger.warn && logger.warn(`[dispatch] Adam-inbox-kind check skipped (fail-open): ${e.message}`);
   }
   await assertValidTarget(supabase, row.target_session, logger);
   // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the

--- a/tests/unit/coordinator-dispatch-adam-untyped-kind-guard.test.js
+++ b/tests/unit/coordinator-dispatch-adam-untyped-kind-guard.test.js
@@ -1,0 +1,93 @@
+/**
+ * QF-20260709-053 — insertCoordinationRow (the choke point) must refuse an Adam-directed
+ * send whose payload.kind is neither a typed ADAM_INBOX_KINDS/EXCLUDED_KINDS entry nor a
+ * reply. Untyped/unknown kinds targeting Adam fell into scripts/adam-advisory.cjs's
+ * reader-side "orphan" class (flagged, never drained) — a silent-drop risk under 30-min
+ * throttled ticks. This guard kills the orphan class mechanically at send time.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../../lib/coordinator/dispatch.cjs');
+
+const ADAM_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const OTHER_TARGET = '11111111-2222-3333-4444-555555555555';
+const silentLog = { warn() {}, error() {}, log() {} };
+
+function stubSupabase({ adamSessionId } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        _mode: null,
+        select() { return chain; },
+        eq(_col, val) { chain._eq = val; return chain; },
+        gte() { chain._mode = 'adam-lookup'; return chain; },
+        filter() { return chain; },
+        limit() { return chain; },
+        maybeSingle() {
+          if (table === 'claude_sessions') {
+            const known = new Set([ADAM_TARGET, OTHER_TARGET]);
+            return Promise.resolve({ data: known.has(chain._eq) ? { session_id: chain._eq, status: 'active' } : null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(r) { chain._inserted = r; return chain; },
+        then(res, rej) {
+          if (table === 'claude_sessions' && chain._mode === 'adam-lookup') {
+            const rows = adamSessionId
+              ? [{ session_id: adamSessionId, heartbeat_at: new Date().toISOString(), metadata: { role: 'adam', adam_since: '2026-01-01T00:00:00Z' } }]
+              : [];
+            return Promise.resolve({ data: rows, error: null }).then(res, rej);
+          }
+          return Promise.resolve({ data: chain._inserted || null, error: null }).then(res, rej);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('insertCoordinationRow: Adam-directed untyped-kind guard (QF-20260709-053)', () => {
+  it('refuses an Adam-directed row with an unknown/untyped payload.kind (the orphan class)', async () => {
+    const sb = stubSupabase({ adamSessionId: ADAM_TARGET });
+    const row = { message_type: 'INFO', target_session: ADAM_TARGET, payload: { kind: 'coordinator_notice', body: 'fyi' } };
+    await expect(insertCoordinationRow(sb, row, { logger: silentLog })).rejects.toMatchObject({
+      code: 'DISPATCH_UNTYPED_ADAM_KIND',
+    });
+  });
+
+  it('allows an Adam-directed row with a typed ADAM_INBOX_KINDS kind', async () => {
+    const sb = stubSupabase({ adamSessionId: ADAM_TARGET });
+    const row = { message_type: 'INFO', target_session: ADAM_TARGET, payload: { kind: 'chairman_heads_up', body: 'fyi' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('chairman_heads_up');
+  });
+
+  it('allows an Adam-directed row with a handler-owned EXCLUDED_KINDS kind', async () => {
+    const sb = stubSupabase({ adamSessionId: ADAM_TARGET });
+    const row = { message_type: 'INFO', target_session: ADAM_TARGET, payload: { kind: 'comms_check' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('comms_check');
+  });
+
+  it('allows an Adam-directed reply row even with an untyped kind (reply_to echo)', async () => {
+    const sb = stubSupabase({ adamSessionId: ADAM_TARGET });
+    const row = { message_type: 'INFO', target_session: ADAM_TARGET, payload: { reply_to: 'corr-1', body: 'answer' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.reply_to).toBe('corr-1');
+  });
+
+  it('does not touch a non-Adam-targeted row with an untyped kind', async () => {
+    const sb = stubSupabase({ adamSessionId: ADAM_TARGET });
+    const row = { message_type: 'INFO', target_session: OTHER_TARGET, payload: { kind: 'coordinator_notice', body: 'fyi' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('coordinator_notice');
+  });
+
+  it('fails open (allows the send) when no live Adam resolves', async () => {
+    const sb = stubSupabase({ adamSessionId: null });
+    const row = { message_type: 'INFO', target_session: ADAM_TARGET, payload: { kind: 'coordinator_notice', body: 'fyi' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('coordinator_notice');
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/coordinator/dispatch.cjs` `insertCoordinationRow`: refuses an Adam-directed send whose `payload.kind` is neither a typed `ADAM_INBOX_KINDS`/`EXCLUDED_KINDS` entry nor a reply — mirrors the existing `work_assignment` type-mismatch guard.
- Untyped/unknown kinds targeting Adam previously fell into `scripts/adam-advisory.cjs`'s reader-side "orphan" class (flagged but never drained, a silent-drop risk under 30-min throttled ticks). This kills the orphan class mechanically at send time.
- Fail-open on the Adam-identity lookup (never blocks a send on a transient DB fault).

Companion to QF-20260709-800, which fixed the two sibling silent-failure defects in Solomon's comms lane (drain-visibility silent-drop, dedup-ledger false-success). That QF deliberately scoped this fix out since it's architecturally distinct (producer-side assert vs reader-side fix) — it's now its own dedicated QF per Adam's follow-up ask.

## Test plan
- [x] 6 new unit tests in `tests/unit/coordinator-dispatch-adam-untyped-kind-guard.test.js`: refusal, typed-kind pass, excluded-kind pass, reply pass, non-Adam-target unaffected, fail-open on no live Adam
- [x] 91/91 tests pass across the full dispatch-related regression suite (no existing tests broken)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)