### PR TITLE
refactor(SD-ARCH-HOTSPOT-SD-START-001): shared lib/claim gates + queue resolver (PR-A of 2, structural)

### DIFF
--- a/lib/claim/gates/cadence-gate.cjs
+++ b/lib/claim/gates/cadence-gate.cjs
@@ -1,0 +1,135 @@
+/**
+ * Shared cadence gate ADAPTER — SD-ARCH-HOTSPOT-SD-START-001 FR-4.
+ *
+ * lib/cadence/pre-claim-gate.mjs (computeGateState/formatRefusalMessage) stays the
+ * cadence SSOT — this module adapts it (plus the bypass-rubric override validation
+ * and the CADENCE_GATE_* audit contract that sd-start previously inlined at L649)
+ * into a pure-verdict gate. The audit writes ARE part of the gate's contract
+ * (refusals are recorded; an override that cannot be audit-logged is REFUSED —
+ * fail-closed, preserved verbatim), so they live here; console/colors/exit and
+ * argv parsing stay in the sd-start caller.
+ *
+ * Loaded from ESM (sd-start) via createRequire; ESM-only dependencies are pulled
+ * with await import() (a .cjs module cannot require() ESM synchronously).
+ *
+ * Verdict outcomes:
+ *   { allowed:true,  outcome:'inactive' }                                        gate not active
+ *   { allowed:false, outcome:'refused', state, refusalMessage, shortOverride,
+ *     auditRecorded, auditError? }                                               no/short override (refusal audit best-effort)
+ *   { allowed:false, outcome:'override_rejected', state, message }               bypass-rubric shape refused
+ *   { allowed:false, outcome:'audit_unavailable_fail_closed', state, auditError } override valid but unrecordable
+ *   { allowed:true,  outcome:'override_accepted', state, overrideReason,
+ *     patternRef }                                                               valid + audit-logged override
+ *
+ * @module lib/claim/gates/cadence-gate
+ */
+'use strict';
+
+/**
+ * @param {object} supabase - service client
+ * @param {object} sd - SD row carrying governance_metadata + metadata + id
+ * @param {object} [opts]
+ * @param {string} [opts.sdKey] - display key for messages/audit (defaults to sd.sd_key)
+ * @param {string|null} [opts.overrideReason] - the --override-cadence-gate value (caller-parsed)
+ * @param {string|null} [opts.patternId] - the --pattern-id value
+ * @param {string|null} [opts.followupSdKey] - the --followup-sd-key value
+ * @param {string|null} [opts.sessionId] - operator session id for audit rows (caller-supplied;
+ *   this module reads no env — prospective-testing hidden-coupling rule)
+ */
+async function evaluateCadenceGate(supabase, sd, {
+  sdKey = (sd && sd.sd_key) || null,
+  overrideReason = null,
+  patternId = null,
+  followupSdKey = null,
+  sessionId = null,
+} = {}) {
+  const { computeGateState, formatRefusalMessage } = await import('../../cadence/pre-claim-gate.mjs');
+  const gateState = computeGateState({
+    governance_metadata: sd.governance_metadata,
+    metadata: sd.metadata,
+  });
+
+  if (!gateState.active) return { allowed: true, outcome: 'inactive' };
+
+  if (!overrideReason || overrideReason.length < 20) {
+    // Refusal: audit best-effort (a failed refusal record is non-blocking, verbatim
+    // from the sd-start inline gate), then the caller prints + exits.
+    let auditRecorded = true;
+    let auditError = null;
+    try {
+      const { error } = await supabase.from('audit_log').insert({
+        event_type: 'CADENCE_GATE_REFUSED',
+        entity_type: 'strategic_directive',
+        entity_id: sd.id,
+        metadata: {
+          sd_key: sdKey,
+          gate_until: gateState.gate_until,
+          days_remaining: gateState.days_remaining,
+          source: gateState.source,
+          override_attempted: overrideReason !== null,
+          override_reason: overrideReason,
+          operator_session_id: sessionId,
+        },
+        severity: 'info',
+      });
+      if (error) { auditRecorded = false; auditError = error.message; }
+    } catch (auditErr) {
+      auditRecorded = false;
+      auditError = auditErr.message;
+    }
+    return {
+      allowed: false,
+      outcome: 'refused',
+      state: gateState,
+      refusalMessage: formatRefusalMessage({ sdKey, gateState }),
+      shortOverride: Boolean(overrideReason && overrideReason.length < 20),
+      overrideReasonLength: overrideReason ? overrideReason.length : 0,
+      auditRecorded,
+      ...(auditError ? { auditError } : {}),
+    };
+  }
+
+  const { validateBypassShape } = await import('../../../scripts/modules/handoff/bypass-rubric.js');
+  const shapeResult = await validateBypassShape({
+    patternId,
+    followupSdKey,
+    supabase,
+    bypassReason: overrideReason,
+    sdId: sd.id,
+    handoffType: 'sd_start_cadence_override',
+  });
+  if (!shapeResult.allowed) {
+    return { allowed: false, outcome: 'override_rejected', state: gateState, message: shapeResult.message };
+  }
+
+  const { error: auditErr } = await supabase.from('audit_log').insert({
+    event_type: 'CADENCE_GATE_OVERRIDE',
+    entity_type: 'strategic_directive',
+    entity_id: sd.id,
+    metadata: {
+      sd_key: sdKey,
+      gate_until: gateState.gate_until,
+      days_remaining: gateState.days_remaining,
+      source: gateState.source,
+      override_reason: overrideReason,
+      pattern_id: patternId,
+      followup_sd_key: followupSdKey,
+      operator_session_id: sessionId,
+    },
+    severity: 'warning',
+  });
+  if (auditErr) {
+    // Fail-closed, verbatim: an override that cannot be safely recorded is refused.
+    return { allowed: false, outcome: 'audit_unavailable_fail_closed', state: gateState, auditError: auditErr.message };
+  }
+
+  return {
+    allowed: true,
+    outcome: 'override_accepted',
+    state: gateState,
+    overrideReason,
+    patternRef: patternId || followupSdKey,
+  };
+}
+
+module.exports = { evaluateCadenceGate };

--- a/lib/claim/gates/dependency-gate.cjs
+++ b/lib/claim/gates/dependency-gate.cjs
@@ -1,0 +1,132 @@
+/**
+ * Shared claim DEPENDENCY gate — ONE resolution, raw-axes verdict, TWO caller polarities.
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-2 (prospective-testing D3/D4/D5).
+ *
+ * WHY RAW AXES, NOT AN allow BOOLEAN: the two claim CLIs apply OPPOSITE polarities
+ * to the same facts —
+ *   - worker-checkin (draftDepsSatisfied heritage) fails CLOSED: an unresolved ref
+ *     or a query error means SKIP the candidate (never claim a maybe-blocked SD).
+ *   - sd-start (evaluateDependencyGate heritage) warns-never-blocks on unresolved
+ *     refs (blocking on a bad reference would strand the SD forever) and fails
+ *     OPEN on query errors, refusing only CONFIRMED-incomplete deps (--force
+ *     downgrades that refusal to a warning).
+ * A single `allowed` boolean cannot preserve both (prospective-testing CRITICAL
+ * D3/D4), so this gate returns the classified axes and each caller applies its
+ * native polarity: checkin via depsSatisfiedFromVerdict(); sd-start by feeding
+ * verdict.resolved into lib/sd-start/dependency-gate.mjs evaluateDependencyGate
+ * (which stays the pure refuse/warn SSOT).
+ *
+ * ONE RESOLUTION PATH (the convergence this SD exists for): dependency-shape
+ * handling from lib/fleet/claim-eligibility.cjs draftDepsSatisfied — plain text
+ * ("SD-X needs Y"), {sd_id}, {sd_key}, "none"/"None" sentinels, ref-less notes —
+ * PLUS the metadata.blocked_on_sd fold (QF-20260706-786: re-derived from LIVE
+ * status every call, independent of any boolean flag), PLUS sd-start's richer
+ * status lookup that matches referenced SDs by sd_key OR id (uuid refs resolve
+ * instead of dangling). NOTE for checkin: uuid refs that previously came back
+ * unresolved (sd_key-only lookup → fail-closed skip) now RESOLVE; a ref that
+ * resolves to a completed SD stops skipping (strictly more accurate — the skip
+ * was a resolution gap, not a policy), while non-completed resolutions still
+ * block. The fail-closed POLARITY itself is unchanged.
+ *
+ * NO audit writes here — DEPENDENCY_GATE_REFUSED stays in the sd-start caller
+ * (D5: checkin writes no dependency audit today and must not start). No console,
+ * no process.exit, no argv/env reads (grep-pinned by the unit suite).
+ *
+ * @module lib/claim/gates/dependency-gate
+ */
+'use strict';
+
+/** Extract referenced SD keys/ids from the heterogeneous dependencies array +
+ *  the metadata.blocked_on_sd fold. Pure. Mirrors draftDepsSatisfied exactly. */
+function extractDependencyRefs(sd) {
+  const row = sd || {};
+  const deps = Array.isArray(row.dependencies) ? row.dependencies : [];
+  const refs = [];
+  for (const e of deps) {
+    let k = null;
+    if (typeof e === 'string') k = e.split(/\s/)[0];
+    else if (e && typeof e === 'object') k = e.sd_id || e.sd_key || null;
+    if (!k || k === 'none' || k === 'None') continue; // no SD ref / sentinel -> non-blocking
+    refs.push(k);
+  }
+  const blockedOn = row.metadata && row.metadata.blocked_on_sd;
+  if (typeof blockedOn === 'string' && blockedOn && blockedOn !== 'none') refs.push(blockedOn);
+  return refs;
+}
+
+/**
+ * Resolve + classify an SD's declared dependencies.
+ *
+ * @param {object} supabase - service client
+ * @param {object} sd - SD row; needs `dependencies` (fetched when absent and
+ *   `id`/`sd_key` is present) and `metadata` (for the blocked_on_sd fold)
+ * @returns {Promise<{
+ *   blocking: Array<{sd_id: string, status: string}>,
+ *   unresolved: Array<{sd_id: string, status: null}>,
+ *   satisfied: Array<{sd_id: string, status: 'completed'}>,
+ *   resolved: Array<{sd_id: string, status: string|null}>,
+ *   queryError: string|null
+ * }>} raw axes; on queryError the axis arrays are empty and callers apply
+ *   their native error polarity (checkin: skip; sd-start: proceed-with-warning)
+ */
+async function evaluateClaimDependencyGate(supabase, sd) {
+  const empty = { blocking: [], unresolved: [], satisfied: [], resolved: [], queryError: null };
+  const row = sd || {};
+  let deps = row.dependencies;
+  try {
+    // sd-start's getSDDetails historically omitted `dependencies`; fetch it when
+    // the caller did not load it (undefined — an explicit [] / null is respected).
+    if (deps === undefined && (row.id || row.sd_key)) {
+      const { data, error } = await supabase
+        .from('strategic_directives_v2')
+        .select('dependencies')
+        .or(row.id ? `id.eq.${row.id}` : `sd_key.eq.${row.sd_key}`)
+        .maybeSingle();
+      if (error) throw error;
+      deps = data ? data.dependencies : null;
+    }
+    const refs = extractDependencyRefs({ ...row, dependencies: deps });
+    if (!refs.length) return empty;
+
+    // Richer lookup than draftDepsSatisfied's sd_key-only .in(): match by sd_key
+    // OR id so uuid-shaped refs resolve (sd-start heritage). Statuses keyed by
+    // BOTH columns so each ref finds its row regardless of which form it used.
+    const keyList = refs.map((k) => `"${String(k).replace(/"/g, '')}"`).join(',');
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status')
+      .or(`sd_key.in.(${keyList}),id.in.(${keyList})`);
+    if (error) throw error;
+
+    const statusByRef = {};
+    for (const r of data || []) {
+      if (r.sd_key) statusByRef[r.sd_key] = r.status;
+      if (r.id) statusByRef[r.id] = r.status;
+    }
+    const resolved = refs.map((k) => ({ sd_id: k, status: statusByRef[k] || null }));
+    return {
+      blocking: resolved.filter((d) => d.status && d.status !== 'completed'),
+      unresolved: resolved.filter((d) => !d.status),
+      satisfied: resolved.filter((d) => d.status === 'completed'),
+      resolved,
+      queryError: null,
+    };
+  } catch (e) {
+    return { ...empty, queryError: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * worker-checkin's native FAIL-CLOSED polarity over the raw axes — the drop-in
+ * for its draftDepsSatisfied call: true only when every ref resolved completed
+ * and the lookup succeeded. (Unresolved ref or query error => false => skip.)
+ * @param {Awaited<ReturnType<typeof evaluateClaimDependencyGate>>} verdict
+ * @returns {boolean}
+ */
+function depsSatisfiedFromVerdict(verdict) {
+  if (!verdict) return false;
+  if (verdict.queryError) return false;
+  return verdict.blocking.length === 0 && verdict.unresolved.length === 0;
+}
+
+module.exports = { evaluateClaimDependencyGate, depsSatisfiedFromVerdict, extractDependencyRefs };

--- a/lib/claim/gates/handoff-integrity.cjs
+++ b/lib/claim/gates/handoff-integrity.cjs
@@ -1,0 +1,99 @@
+/**
+ * Shared handoff-integrity gate — relocated verbatim from scripts/sd-start.js
+ * (SD-ARCH-HOTSPOT-SD-START-001 FR-3). Checks the LAST sd_phase_handoffs row for
+ * an SD before resume so a rejected-and-unresolved handoff surfaces instead of
+ * being silently built past.
+ *
+ * Pure verdict function: no console (prospective-testing D9 — the sd-start
+ * caller passes onWarn to keep its loud QF-20260609-564 error surfacing), no
+ * process.exit, no argv. Fail-OPEN on query error (the consumer hard-exits on
+ * valid:false without --force, so a transient DB hiccup must not block resume).
+ *
+ * Verdict shape varies by path (D9, documented):
+ *   query error   → { valid:true,  lastHandoff:null, message, recoveryOptions:[] }        (no `status`)
+ *   no handoffs   → { valid:false, lastHandoff:null, status:'missing', message, recoveryOptions }
+ *   accepted      → { valid:true,  lastHandoff, status, message, recoveryOptions:[] }
+ *   resolved      → { valid:true,  lastHandoff, status:'resolved', message, recoveryOptions:[] }
+ *   rejected      → { valid:false, lastHandoff, status, message, reason, recoveryOptions }  (adds `reason`)
+ *
+ * @module lib/claim/gates/handoff-integrity
+ */
+'use strict';
+
+/**
+ * @param {object} supabase - service client
+ * @param {string} sdUuid - the SD UUID (sd_phase_handoffs is keyed by sd_id — QF-20260609-564:
+ *   the prior sd-start query filtered a non-existent text-key column and silently disabled
+ *   this whole check; the sd_id keying here IS the fix, preserved verbatim)
+ * @param {{onWarn?: (msg: string) => void}} [opts]
+ */
+async function verifyHandoffIntegrity(supabase, sdUuid, { onWarn } = {}) {
+  const { data: handoffs, error } = await supabase
+    .from('sd_phase_handoffs')
+    .select('id, from_phase, to_phase, status, created_at, rejection_reason, resolved_at')
+    .eq('sd_id', sdUuid)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (error) {
+    // QF-20260609-564: surface the error instead of silently swallowing it. Stay fail-open,
+    // but report loudly (via the caller's onWarn) so a real/persistent query error can never
+    // hide again the way the dead-column bug did.
+    if (typeof onWarn === 'function') {
+      onWarn(`verifyHandoffIntegrity: handoff query failed (${error.code || 'error'}: ${error.message}) — proceeding without integrity check`);
+    }
+    return { valid: true, lastHandoff: null, message: `Could not query handoffs: ${error.message} (proceeding)`, recoveryOptions: [] };
+  }
+
+  if (!handoffs || handoffs.length === 0) {
+    return {
+      valid: false,
+      lastHandoff: null,
+      status: 'missing',
+      message: 'No prior handoff found',
+      recoveryOptions: [
+        'Run the appropriate handoff for this phase',
+        'Use --force flag to proceed without handoff verification',
+      ],
+    };
+  }
+
+  const last = handoffs[0];
+
+  if (last.status === 'accepted' || last.status === 'completed') {
+    return {
+      valid: true,
+      lastHandoff: last,
+      status: last.status,
+      message: `Last handoff: ${last.status} (${last.from_phase} → ${last.to_phase})`,
+      recoveryOptions: [],
+    };
+  }
+
+  // Handoff was rejected or failed — but check if it was already resolved
+  if (last.resolved_at) {
+    return {
+      valid: true,
+      lastHandoff: last,
+      status: 'resolved',
+      message: `Last handoff ${last.status} but resolved at ${new Date(last.resolved_at).toLocaleString()} (${last.from_phase} → ${last.to_phase})`,
+      recoveryOptions: [],
+    };
+  }
+
+  const reason = last.rejection_reason || 'No reason provided';
+  return {
+    valid: false,
+    lastHandoff: last,
+    status: last.status,
+    message: `Last handoff ${last.status}: ${last.from_phase} → ${last.to_phase}`,
+    reason,
+    recoveryOptions: [
+      `View handoff details: node -e "..." (handoff ID: ${last.id})`,
+      `Re-run the ${last.from_phase} → ${last.to_phase} handoff after addressing issues`,
+      'Use --force flag to override and continue (not recommended)',
+    ],
+  };
+}
+
+module.exports = { verifyHandoffIntegrity };

--- a/lib/claim/queue-resolver.cjs
+++ b/lib/claim/queue-resolver.cjs
@@ -1,0 +1,243 @@
+/**
+ * Shared claim queue resolver — SD-ARCH-HOTSPOT-SD-START-001 FR-5.
+ *
+ * Relocates sd-start's queue intelligence (getNextWorkableSD, findLeafWorkItem,
+ * findUnclaimedChild) plus the transitive helpers they cannot run without
+ * (getOrchestratorChildren, getActiveClaimSessionIds — prospective-testing D1)
+ * behind explicit `supabase` params (D2: the recursion threads it too) and an
+ * optional onTrace callback in place of console drilling messages.
+ *
+ * TWO ORCHESTRATOR PRIMITIVES, ON PURPOSE: worker-checkin EXCLUDES orchestrator
+ * parents from its candidate pools while sd-start DESCENDS into them to find a
+ * buildable leaf — opposite strategies over the same fact. isOrchestratorParent
+ * serves the exclude intent and is keyed on sd_type === 'orchestrator' (D10:
+ * matching checkin's .neq('sd_type','orchestrator') filters and the classifier's
+ * orchestrator_parent axis — NOT a structural has-children probe); resolveLeafWorkItem
+ * serves the descend intent.
+ *
+ * No console / process.exit / argv (callers own I/O and process control).
+ *
+ * @module lib/claim/queue-resolver
+ */
+'use strict';
+
+/** Exclude-intent predicate (checkin family). Keyed on sd_type, same as the
+ *  classifier's orchestrator_parent axis. */
+function isOrchestratorParent(sd) {
+  return Boolean(sd) && sd.sd_type === 'orchestrator';
+}
+
+/**
+ * Get the next workable SD from the queue, excluding specified SD keys.
+ * Returns { sdKey, title, phase } or null if no workable SDs remain.
+ * SD-LEO-INFRA-PRE-CLAIM-CHECK-001: used by sd-start's auto-fallback when claim
+ * conflicts occur. Relocated verbatim (ordering: priority asc, created_at asc;
+ * active-claim exclusion via claude_sessions).
+ */
+async function getNextWorkableSD(supabase, excludeKeys = []) {
+  // Get all active sessions to identify claimed SDs
+  const { data: activeSessions } = await supabase
+    .from('claude_sessions')
+    .select('sd_key')
+    .not('sd_key', 'is', null)
+    .in('status', ['active', 'idle']);
+
+  const claimedSdKeys = new Set((activeSessions || []).map(s => s.sd_key));
+
+  // Query for workable SDs: not completed, not cancelled, not blocked
+  const { data: candidates } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, current_phase, status, priority, progress_percentage')
+    .in('status', ['draft', 'active', 'planning', 'ready', 'in_progress'])
+    .not('sd_key', 'is', null)
+    .order('priority', { ascending: true })
+    .order('created_at', { ascending: true })
+    .limit(20);
+
+  if (!candidates || candidates.length === 0) return null;
+
+  // Filter: exclude specified keys, exclude claimed SDs
+  for (const sd of candidates) {
+    if (excludeKeys.includes(sd.sd_key)) continue;
+    if (claimedSdKeys.has(sd.sd_key)) continue;
+    return { sdKey: sd.sd_key, title: sd.title, phase: sd.current_phase };
+  }
+
+  return null;
+}
+
+/** Children of an orchestrator by parent ref (sd_key or UUID id, with the
+ *  sd_key→id resolve-and-retry fallback). Relocated verbatim from sd-start L458. */
+async function getOrchestratorChildren(supabase, sdKeyOrId) {
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, current_phase, priority, claiming_session_id, progress_percentage, sd_type')
+    .or(`parent_sd_id.eq.${sdKeyOrId}`);
+
+  if (error || !data || data.length === 0) {
+    // If sdKeyOrId was a sd_key, resolve its UUID id and retry
+    const { data: parent } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('sd_key', sdKeyOrId)
+      .single();
+
+    if (parent && parent.id !== sdKeyOrId) {
+      const { data: children, error: childErr } = await supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_key, title, status, current_phase, priority, claiming_session_id, progress_percentage, sd_type')
+        .eq('parent_sd_id', parent.id);
+
+      if (!childErr && children) return children;
+    }
+    return data || [];
+  }
+  return data;
+}
+
+/**
+ * Session IDs that currently hold an active claim in claude_sessions
+ * (status active/idle with an sd_key). Source of truth — the SD row's
+ * claiming_session_id can be stale. Relocated verbatim from sd-start L490.
+ */
+async function getActiveClaimSessionIds(supabase) {
+  const { data } = await supabase
+    .from('claude_sessions')
+    .select('session_id')
+    .not('sd_key', 'is', null)
+    .in('status', ['active', 'idle']);
+  return new Set((data || []).map(r => r.session_id));
+}
+
+/**
+ * Find the first unclaimed child SD that's ready to work on.
+ * Uses child-sd-selector for urgency-based sorting, then validates
+ * claiming_session_id against live claude_sessions rows (a stale/released
+ * claim is treated as unclaimed). Relocated verbatim from sd-start L566.
+ */
+async function findUnclaimedChild(supabase, parentSdKey, { selectNextReadyChild } = {}) {
+  // parent_sd_id stores UUID `id`, not sd_key — resolve so getNextReadyChild
+  // and getOrchestratorChildren query parent_sd_id correctly.
+  let parentId = parentSdKey;
+  const { data: parentRow } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('sd_key', parentSdKey)
+    .single();
+  if (parentRow) {
+    parentId = parentRow.id;
+  }
+
+  // getNextReadyChild handles urgency sorting and blocker filtering (ESM module —
+  // a .cjs cannot require() it synchronously). Injectable seam for unit tests.
+  let selector = selectNextReadyChild;
+  if (typeof selector !== 'function') {
+    ({ getNextReadyChild: selector } = await import('../../scripts/modules/handoff/child-sd-selector.js'));
+  }
+  const result = await selector(supabase, parentId);
+
+  if (!result.sd) {
+    return { child: null, allComplete: result.allComplete, reason: result.reason };
+  }
+
+  const activeSessionIds = await getActiveClaimSessionIds(supabase);
+
+  // A child is truly claimed only if its claiming_session_id maps to an active session
+  const isTrulyClaimed = (child) =>
+    child.claiming_session_id && activeSessionIds.has(child.claiming_session_id);
+
+  if (isTrulyClaimed(result.sd)) {
+    // The top-priority child is claimed — check all children for an unclaimed one
+    const children = await getOrchestratorChildren(supabase, parentSdKey);
+    const readyChildren = children.filter(c =>
+      !isTrulyClaimed(c) &&
+      c.status !== 'completed' &&
+      c.status !== 'blocked'
+    );
+
+    if (readyChildren.length > 0) {
+      return { child: readyChildren[0], allComplete: false, reason: 'First unclaimed child' };
+    }
+
+    // All children are either truly claimed or not ready
+    const allClaimed = children.filter(c => isTrulyClaimed(c) && c.status !== 'completed');
+    if (allClaimed.length > 0) {
+      return {
+        child: null,
+        allComplete: false,
+        reason: `No ready children: ${allClaimed.length} active`
+      };
+    }
+  }
+
+  return { child: result.sd, allComplete: false, reason: result.reason };
+}
+
+/**
+ * Descend-intent resolver (sd-start family): recursively find a leaf-level
+ * (non-orchestrator) work item from an orchestrator hierarchy, drilling
+ * orchestrator → sub-orchestrator → … → leaf. Relocated verbatim from
+ * sd-start L512; the drilling console message became onTrace.
+ *
+ * @param {object} supabase
+ * @param {string} parentSdKey
+ * @param {{depth?: number, routingPath?: string[], onTrace?: (msg: string) => void}} [opts]
+ * @returns {Promise<{child: object|null, allComplete: boolean, reason: string, routingPath: string[]}>}
+ */
+async function resolveLeafWorkItem(supabase, parentSdKey, { depth = 0, routingPath = [], onTrace, selectNextReadyChild } = {}) {
+  const MAX_DEPTH = 5; // Safety limit for deeply nested orchestrators
+
+  if (depth >= MAX_DEPTH) {
+    return {
+      child: null,
+      allComplete: false,
+      reason: `Max orchestrator nesting depth (${MAX_DEPTH}) exceeded`,
+      routingPath
+    };
+  }
+
+  const { child, allComplete, reason } = await findUnclaimedChild(supabase, parentSdKey, { selectNextReadyChild });
+
+  if (!child) {
+    return { child: null, allComplete, reason, routingPath };
+  }
+
+  const childKey = child.sd_key || child.id;
+  const updatedPath = [...routingPath, childKey];
+
+  // Check if this child is itself an orchestrator (has its own children)
+  const grandchildren = await getOrchestratorChildren(supabase, childKey);
+
+  if (grandchildren.length > 0) {
+    // Sub-orchestrator detected — check if all its children are done
+    const allGrandchildrenComplete = grandchildren.every(gc => gc.status === 'completed');
+
+    if (allGrandchildrenComplete) {
+      // Sub-orchestrator needs its own completion handoff — return it as the work item
+      return {
+        child,
+        allComplete: false,
+        reason: `Sub-orchestrator ${childKey}: all ${grandchildren.length} children completed — needs completion handoff`,
+        routingPath: updatedPath
+      };
+    }
+
+    // Recurse into the sub-orchestrator to find a leaf grandchild
+    if (typeof onTrace === 'function') {
+      onTrace(`${childKey} is a sub-orchestrator (${grandchildren.length} children) — drilling deeper...`);
+    }
+    return resolveLeafWorkItem(supabase, childKey, { depth: depth + 1, routingPath: updatedPath, onTrace, selectNextReadyChild });
+  }
+
+  // Leaf-level SD found
+  return { child, allComplete: false, reason, routingPath: updatedPath };
+}
+
+module.exports = {
+  isOrchestratorParent,
+  getNextWorkableSD,
+  getOrchestratorChildren,
+  getActiveClaimSessionIds,
+  findUnclaimedChild,
+  resolveLeafWorkItem,
+};

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -71,34 +71,53 @@ const { ladderTopRank } = require('./tier-ladder.cjs');
  * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object, fable_window_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
  * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'tier_stamp_missing' | 'above_worker_tier' | 'fable_window_downward_claim_blocked' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
-function classifyDispatchIneligibility(sdRow, ctx) {
-  const row = sdRow || {};
-  if (row.sd_type === 'orchestrator') return 'orchestrator_parent';
-  if (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) return 'test_fixture_key';
+// ── Ordered ineligibility axis table (SD-ARCH-HOTSPOT-SD-START-001 FR-1) ──
+// Each axis is a pure (row, ctx) => reason|null. BOTH classifiers below walk this ONE
+// table: classifyDispatchIneligibility (first-match — the long-standing string API,
+// precedence = array order, byte-compatible with the pre-table behavior) and
+// classifyAllDispatchIneligibility (all-match — the unlock for consumers that must see
+// a SPECIFIC axis even when an earlier axis also matches, e.g. sd-start's human-action
+// gate, which historically avoided the first-match form for exactly this reason).
+// Never fork axis logic between the two exports — extend THIS table.
+const INELIGIBILITY_AXES = [
+  function orchestratorParent(row) {
+    return row.sd_type === 'orchestrator' ? 'orchestrator_parent' : null;
+  },
+  function testFixtureKey(row) {
+    return (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) ? 'test_fixture_key' : null;
+  },
   // QF-20260704-193: the verdict stays a bare string (consumers string-compare it) —
   // callers that need the WHY resolve it via resolveHoldProvenance(row.metadata) below,
   // the SSOT coalescer for the ad-hoc hold-reason keys. Deliberate scope decision over
   // changing this return type (recorded in the QF completion notes).
-  if (row.metadata && row.metadata.requires_human_action) return 'human_action_required';
+  function humanActionRequired(row) {
+    return (row.metadata && row.metadata.requires_human_action) ? 'human_action_required' : null;
+  },
   // QF-20260705-585: metadata.not_before is a future-dated SD-level hold -- mirrors the
   // quick_fixes.not_before semantics already respected in worker-checkin.cjs (L511-515,
   // L1516-1534), generalized here so the self-claim path respects it too (feedback b0ac7ba1:
   // a Sonnet worker self-claimed a Fable-framed, pre-release-window hotspot SD). Auto-clears
   // once the timestamp passes -- no manual flag/clear needed.
-  const notBefore = row.metadata && Date.parse(row.metadata.not_before);
-  if (Number.isFinite(notBefore) && notBefore > Date.now()) return 'not_before_hold';
+  function notBeforeHold(row) {
+    const notBefore = row.metadata && Date.parse(row.metadata.not_before);
+    return (Number.isFinite(notBefore) && notBefore > Date.now()) ? 'not_before_hold' : null;
+  },
   // QF-20260705-585: a one_way door-class SD (metadata.door_class_note === 'one_way') is a
   // re-architecture requiring a Fable-tier session to execute or supervise -- never
   // self-claimable. Still reachable via DIRECTED-ASSIGN (which does not route through this
   // classifier), so the coordinator can hand it to a specific Fable session deliberately.
-  if (row.metadata && row.metadata.door_class_note === 'one_way') return 'one_way_door_requires_supervision';
+  function oneWayDoor(row) {
+    return (row.metadata && row.metadata.door_class_note === 'one_way') ? 'one_way_door_requires_supervision' : null;
+  },
   // SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored DRAFT SD is NON-CLAIMABLE
   // until co-author convergence — else a parked worker claims it and writes the PRD before the
   // co-author input lands, so the late co-author FRs never reach EXEC (the PRD-drift-after-co-author
   // race, [[reference-sd-scope-edits-after-prd-dont-reach-exec]]). Strict === true so a false/absent
   // flag (converged or non-co-authored) falls through unchanged. Shared SSOT: the self-claim (draft +
   // baselined) and stale-session-sweep paths all route through this predicate, so they exclude it too.
-  if (row.metadata && row.metadata.co_author_pending === true) return 'co_author_pending';
+  function coAuthorPending(row) {
+    return (row.metadata && row.metadata.co_author_pending === true) ? 'co_author_pending' : null;
+  },
   // SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001: a review-pending SD (metadata.needs_coordinator_review
   // === true) is NON-CLAIMABLE until the coordinator REVIEWS it — the coordinator clearing the flag
   // (set false / remove) IS the dispatch authorization (no separate approval artifact). This is the SHARED
@@ -110,7 +129,9 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // hand-mirroring a subset of axes.
   // Composition: the SELF-CLAIM-WINDOW fetchFleetCriticalCandidates union routes through this classifier,
   // so a fleet_critical-AND-review-pending SD is correctly surfaced-then-EXCLUDED (the hold wins).
-  if (row.metadata && row.metadata.needs_coordinator_review === true) return 'needs_coordinator_review';
+  function needsCoordinatorReview(row) {
+    return (row.metadata && row.metadata.needs_coordinator_review === true) ? 'needs_coordinator_review' : null;
+  },
   // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture's build-tree (orchestrator +
   // children + grandchildren, stamped metadata.test_clone_build_tree=true at creation by
   // lib/eva/lifecycle-sd-bridge.js convertSprintToSDs) is a throwaway test-clone MVP that must never
@@ -118,7 +139,9 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // DB-free marker (strict === true), read here so BOTH the self_claim and stale-session-sweep paths
   // exclude it. The clone determination happens ONCE at bridge creation (where the ventures query
   // already runs); a venture->clone JOIN deliberately stays OUT of this pure/synchronous/DB-free predicate.
-  if (row.metadata && row.metadata.test_clone_build_tree === true) return 'test_clone_build_tree';
+  function testCloneBuildTree(row) {
+    return (row.metadata && row.metadata.test_clone_build_tree === true) ? 'test_clone_build_tree' : null;
+  },
   // QF-20260705-043: an auto-filed Stage-20 quality-loop remediation SD (fr-c-prime-generator)
   // targeting a VENTURE (target_application e.g. 'EHG') rather than the fleet's own checkout
   // (EHG_Engineer) cannot be actioned by a worker here — mirrors the coordinator's belt exclusion
@@ -129,25 +152,35 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // cancelled+deleted the row 2s later and sd-start.js crashed on the vanished row. CONSERVATIVE:
   // requires BOTH the canonical key prefix AND a non-EHG_Engineer target — a remediation SD
   // genuinely targeting EHG_Engineer (or with no target) is unaffected.
-  if (typeof row.sd_key === 'string' && /^SD-LEO-FIX-REMEDIATION-/.test(row.sd_key)) {
-    const target = row.target_application || (row.metadata && row.metadata.target_application);
-    if (typeof target === 'string' && target !== '' && target !== 'EHG_Engineer') {
-      return 'unactionable_venture_remediation';
+  function unactionableVentureRemediation(row) {
+    if (typeof row.sd_key === 'string' && /^SD-LEO-FIX-REMEDIATION-/.test(row.sd_key)) {
+      const target = row.target_application || (row.metadata && row.metadata.target_application);
+      if (typeof target === 'string' && target !== '' && target !== 'EHG_Engineer') {
+        return 'unactionable_venture_remediation';
+      }
     }
-  }
+    return null;
+  },
   // SD-FDBK-INFRA-STALE-SESSION-SWEEP-001: a DEFERRED SD is parked off the belt (coordinator/Adam
   // deferral) and must NEVER be re-dispatched — without this the sweep CLAIM_FIX re-asserted a
   // deferred SD's claim onto a worker with a live worktree every tick, defeating the deferral and
   // re-trapping the worker. Terminal SDs (completed/cancelled) are likewise never claimable (the
   // sweep also terminal-guards these earlier; this is the shared-SSOT defense so the worker
   // self-claim path refuses them too). Active/claimable statuses fall through unchanged.
-  if (row.status === 'deferred') return 'sd_deferred';
-  if (row.status === 'completed' || row.status === 'cancelled') return 'sd_terminal';
+  function sdDeferred(row) {
+    return row.status === 'deferred' ? 'sd_deferred' : null;
+  },
+  function sdTerminal(row) {
+    return (row.status === 'completed' || row.status === 'cancelled') ? 'sd_terminal' : null;
+  },
   // FR-3 WORK-DOWN-NEVER-UP: a below-rung worker skips above-rung work, but ONLY when tiering is
   // active (>= 2 live workers, FR-5) and the caller supplied its rung. A higher rung may take lower
   // work (no block when worker_tier_rank >= min_tier_rank). Unscored SDs (no min_tier_rank) fall
   // through unchanged. ctx-gated => byte-identical for callers that omit the tier fields.
-  if (ctx && ctx.tiering_active === true) {
+  // The tier branches (stamp-missing / above-tier / fable-window / reserved) are mutually
+  // exclusive outcomes of ONE axis, so they stay one table entry.
+  function tierAxes(row, ctx) {
+    if (!(ctx && ctx.tiering_active === true)) return null;
     const minRank = Number(row.metadata && row.metadata.min_tier_rank);
     // QF-20260703-242: a missing/non-finite worker tier stamp must FAIL CLOSED on tier-gated SDs
     // (minRank finite) instead of silently skipping this whole axis — else an unstamped or
@@ -155,39 +188,72 @@ function classifyDispatchIneligibility(sdRow, ctx) {
     // min_tier_rank) are unaffected: there is nothing to gate against.
     if (!Number.isFinite(Number(ctx.worker_tier_rank))) {
       if (Number.isFinite(minRank)) return 'tier_stamp_missing';
-    } else {
-      const workerRank = Number(ctx.worker_tier_rank);
-      if (Number.isFinite(minRank) && minRank > workerRank) return 'above_worker_tier';
-      // QF-20260709-881: a top-rung (fable) seat self-claiming BELOW-tier belt work during an
-      // active Fable-window burns expensive Fable wall-clock that should go to directed door/
-      // queued high-tier work instead (recurred 2x same-day: Golf-2 unstamped one-way SWEEP
-      // claim, Charlie/2d178139 arrival self-claim of Sonnet-lane Child B). This OVERRIDES the
-      // FR-6 backlog allowance below — a genuine lower-tier backlog does not excuse the burn-down
-      // while the window is active; only an explicit coordinator dispatch (which does not route
-      // through this classifier) may hand a top-rung seat downward work in that window.
-      if (ctx.fable_window_active === true && workerRank >= ladderTopRank()
-        && Number.isFinite(minRank) && minRank < workerRank) {
-        return 'fable_window_downward_claim_blocked';
-      }
-      // FR-6 WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED: a worker claims AT its own rung
-      // unconditionally (minRank === workerRank falls through unchanged); claiming a STRICTLY
-      // LOWER rung is gated on that lower tier having a genuine backlog, reserving capability
-      // otherwise. ctx.lower_tier_backlog_data is OPTIONAL and precomputed by the caller once per
-      // tick (lowerTierBacklog's inputs are DB-dependent, so they cannot be computed inside this
-      // pure/sync classifier) — omitted => byte-identical pre-FR-6 WORK-DOWN-ALWAYS behavior for
-      // any caller that has not wired it yet.
-      if (Number.isFinite(minRank) && minRank < workerRank && ctx.lower_tier_backlog_data) {
-        if (!lowerTierBacklog(minRank, ctx.lower_tier_backlog_data)) return 'reserved_no_lower_backlog';
-      }
+      return null;
     }
-  }
-  if (ctx) {
+    const workerRank = Number(ctx.worker_tier_rank);
+    if (Number.isFinite(minRank) && minRank > workerRank) return 'above_worker_tier';
+    // QF-20260709-881: a top-rung (fable) seat self-claiming BELOW-tier belt work during an
+    // active Fable-window burns expensive Fable wall-clock that should go to directed door/
+    // queued high-tier work instead (recurred 2x same-day: Golf-2 unstamped one-way SWEEP
+    // claim, Charlie/2d178139 arrival self-claim of Sonnet-lane Child B). This OVERRIDES the
+    // FR-6 backlog allowance below — a genuine lower-tier backlog does not excuse the burn-down
+    // while the window is active; only an explicit coordinator dispatch (which does not route
+    // through this classifier) may hand a top-rung seat downward work in that window.
+    if (ctx.fable_window_active === true && workerRank >= ladderTopRank()
+      && Number.isFinite(minRank) && minRank < workerRank) {
+      return 'fable_window_downward_claim_blocked';
+    }
+    // FR-6 WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED: a worker claims AT its own rung
+    // unconditionally (minRank === workerRank falls through unchanged); claiming a STRICTLY
+    // LOWER rung is gated on that lower tier having a genuine backlog, reserving capability
+    // otherwise. ctx.lower_tier_backlog_data is OPTIONAL and precomputed by the caller once per
+    // tick (lowerTierBacklog's inputs are DB-dependent, so they cannot be computed inside this
+    // pure/sync classifier) — omitted => byte-identical pre-FR-6 WORK-DOWN-ALWAYS behavior for
+    // any caller that has not wired it yet.
+    if (Number.isFinite(minRank) && minRank < workerRank && ctx.lower_tier_backlog_data) {
+      if (!lowerTierBacklog(minRank, ctx.lower_tier_backlog_data)) return 'reserved_no_lower_backlog';
+    }
+    return null;
+  },
+  function fitnessAxes(row, ctx) {
+    if (!ctx) return null;
     try {
       const verdict = isSdExecutableHere(row, ctx);
       if (verdict && verdict.fit === false && verdict.blockClass) return `unfit_${verdict.blockClass}`;
     } catch { /* fail-open: a fitness fault never blocks dispatch */ }
+    return null;
+  },
+];
+
+function classifyDispatchIneligibility(sdRow, ctx) {
+  const row = sdRow || {};
+  for (const axis of INELIGIBILITY_AXES) {
+    const reason = axis(row, ctx);
+    if (reason) return reason;
   }
   return null;
+}
+
+/**
+ * All-match variant over the SAME axis table (SD-ARCH-HOTSPOT-SD-START-001 FR-1).
+ * Returns EVERY matching ineligibility reason in precedence order ([] when eligible).
+ * Use this when a consumer must detect a SPECIFIC axis regardless of what else matches
+ * (e.g. sd-start's human-action gate checks .includes('human_action_required') so a
+ * HELD SD that is also an orchestrator parent still surfaces the hold). Same purity
+ * contract as the first-match form: sync, DB-free, ctx-gated tier/fitness axes.
+ *
+ * @param {object} sdRow  same shape as classifyDispatchIneligibility
+ * @param {object} [ctx]  same shape as classifyDispatchIneligibility
+ * @returns {string[]} all matching reasons, [] when fully eligible
+ */
+function classifyAllDispatchIneligibility(sdRow, ctx) {
+  const row = sdRow || {};
+  const reasons = [];
+  for (const axis of INELIGIBILITY_AXES) {
+    const reason = axis(row, ctx);
+    if (reason) reasons.push(reason);
+  }
+  return reasons;
 }
 
 /**
@@ -443,4 +509,4 @@ async function isDispatchAuthorized(sd, supabase) {
   return { authorized: false, reason: 'dispatch_auth_pending' };
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized };

--- a/scripts/__tests__/sd-start-cadence-orchestrator-leaf.test.js
+++ b/scripts/__tests__/sd-start-cadence-orchestrator-leaf.test.js
@@ -56,9 +56,17 @@ describe('sd-start.js cadence gate wiring', () => {
     expect(afterReassign).toMatch(/await enforceCadenceGate\s*\(\s*sd\s*,\s*effectiveId\s*\)/);
   });
 
-  it('helper imports the canonical pre-claim-gate module', () => {
-    // Drift guard: helper must read computeGateState from
-    // lib/cadence/pre-claim-gate.mjs, not a local re-implementation.
-    expect(SOURCE).toMatch(/import\(['"]\.\.\/lib\/cadence\/pre-claim-gate\.mjs['"]\)/);
+  it('helper consumes the canonical pre-claim-gate module (via the shared cadence adapter)', () => {
+    // Drift guard: computeGateState must come from lib/cadence/pre-claim-gate.mjs,
+    // not a local re-implementation. SD-ARCH-HOTSPOT-SD-START-001 FR-4 moved the
+    // consumption one hop: sd-start → lib/claim/gates/cadence-gate.cjs (shared
+    // adapter, also usable by worker-checkin) → the cadence SSOT. Pin BOTH hops
+    // so neither link can silently fork the gate-state logic.
+    expect(SOURCE).toMatch(/lib\/claim\/gates\/cadence-gate\.cjs/);
+    const adapterSrc = fs.readFileSync(
+      path.resolve(__dirname, '..', '..', 'lib', 'claim', 'gates', 'cadence-gate.cjs'),
+      'utf8',
+    );
+    expect(adapterSrc).toMatch(/import\(['"]\.\.\/\.\.\/cadence\/pre-claim-gate\.mjs['"]\)/);
   });
 });

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -26,7 +26,7 @@ import { getRepoRoot, isInsideWorktree } from '../lib/repo-paths.js';
 import os from 'os';
 import path from 'node:path';
 import dotenv from 'dotenv';
-import { getOrCreateSession, updateHeartbeat } from '../lib/session-manager.mjs';
+import { getOrCreateSession } from '../lib/session-manager.mjs'; // (updateHeartbeat import was long-dead — dropped with the FR-5/FR-6 extraction lint pass)
 import { resolveOwnSession } from '../lib/resolve-own-session.js';
 import { assertValidClaim, ClaimIdentityError } from '../lib/claim-validity-gate.js';
 // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001: FR-3 inbox poll + FR-2 sd_key drift detector
@@ -60,7 +60,6 @@ import { decideOwnConflictReattach } from '../lib/exec-context-guard.mjs';
 // base is behind origin/main, so a worker never silently builds on a stale base (a merge-as-is would
 // revert sibling work that landed after the base commit). Fail-open; reuses checkout-freshness.
 import { runStaleBaseGuard } from '../lib/worktree/stale-base-guard.mjs';
-import { getNextReadyChild } from './modules/handoff/child-sd-selector.js';
 import { checkSDAge, handleTimelineViolation, formatBlockMessage } from './modules/governance/timeline-violation-handler.js';
 import {
   evaluateInstallDecision,
@@ -89,6 +88,20 @@ dotenv.config();
 
 const supabase = createSupabaseServiceClient();
 
+// SD-ARCH-HOTSPOT-SD-START-001: the claim gate/queue phases live in shared
+// lib/claim/*.cjs modules consumed by BOTH this CLI and worker-checkin.cjs
+// (one eligibility truth — kills the claim-drift bug family). CJS so checkin
+// can require() them; loaded here via the established createRequire interop
+// (same pattern as the npm-install-lock load below). This CLI keeps ALL
+// console/colors/process.exit/argv handling — the modules return pure verdicts.
+import { createRequire } from 'node:module';
+const cjsRequire = createRequire(import.meta.url);
+const { evaluateClaimDependencyGate } = cjsRequire('../lib/claim/gates/dependency-gate.cjs');
+const { verifyHandoffIntegrity: verifyHandoffIntegrityGate } = cjsRequire('../lib/claim/gates/handoff-integrity.cjs');
+const { evaluateCadenceGate } = cjsRequire('../lib/claim/gates/cadence-gate.cjs');
+const queueResolver = cjsRequire('../lib/claim/queue-resolver.cjs');
+const { classifyAllDispatchIneligibility } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
+
 // SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: pre-claim DEPENDENCY gate.
 // Dependency BLOCKS were advisory-only (computed by the sweep/dashboard but never
 // enforced), so workers repeatedly claimed dependency-blocked child SDs. This
@@ -97,40 +110,23 @@ const supabase = createSupabaseServiceClient();
 // warns and proceeds; any resolution error fails OPEN so a transient DB issue can
 // never block every claim. Pure decision logic lives in lib/sd-start/dependency-gate.mjs.
 async function enforceDependencyGate(sd, effectiveId) {
-  let resolved;
-  try {
-    // dependencies is not fetched by getSDDetails — read it for the effective SD.
-    const { data: row, error: depErr } = await supabase
-      .from('strategic_directives_v2')
-      .select('dependencies')
-      .eq('id', sd.id)
-      .maybeSingle();
-    if (depErr) throw depErr;
-
-    const deps = Array.isArray(row?.dependencies) ? row.dependencies : [];
-    const refs = deps
-      .map(d => (d && typeof d === 'object' ? d.sd_id : d))
-      .filter(v => typeof v === 'string' && v.length > 0);
-    if (refs.length === 0) return; // no declared dependencies — nothing to enforce
-
-    // Resolve each ref (sd_key OR uuid) to its current status in one query.
-    const { data: depRows, error: resErr } = await supabase
-      .from('strategic_directives_v2')
-      .select('id, sd_key, status')
-      .or(`sd_key.in.(${refs.join(',')}),id.in.(${refs.join(',')})`);
-    if (resErr) throw resErr;
-
-    const byRef = new Map();
-    for (const r of depRows || []) {
-      if (r.sd_key) byRef.set(r.sd_key, r.status);
-      if (r.id) byRef.set(r.id, r.status);
-    }
-    resolved = refs.map(ref => ({ sd_id: ref, status: byRef.has(ref) ? byRef.get(ref) : null }));
-  } catch (err) {
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-2: resolution moved to the SHARED gate
+  // (lib/claim/gates/dependency-gate.cjs — the same one worker-checkin consumes,
+  // one resolution truth). This CLI applies its native FAIL-OPEN polarity over
+  // the raw axes: proceed-with-warning on resolution errors and unresolved refs;
+  // refuse only CONFIRMED-incomplete deps (--force downgrades to warn-proceed).
+  const gate = await evaluateClaimDependencyGate(supabase, sd);
+  if (gate.queryError) {
     // Fail-open: a transient DB/resolution error must never block every claim.
-    console.warn(`${colors.dim}(dependency gate skipped — resolution error, fail-open: ${err.message})${colors.reset}`);
+    console.warn(`${colors.dim}(dependency gate skipped — resolution error, fail-open: ${gate.queryError})${colors.reset}`);
     return;
   }
+  // The blocked_on_sd fold (retired enforceBlockedOnSdGate) is enforced by the
+  // dedicated wrapper at its original pre-/post-route call sites; exclude it here
+  // so `dependencies`-array semantics (incl. --force) stay byte-identical.
+  const blockedOn = sd?.metadata?.blocked_on_sd;
+  const resolved = gate.resolved.filter(d => d.sd_id !== blockedOn);
+  if (resolved.length === 0) return; // no declared dependencies — nothing to enforce
 
   const force = process.argv.includes('--force');
   const result = evaluateDependencyGate(resolved, { force });
@@ -174,7 +170,13 @@ async function enforceDependencyGate(sd, effectiveId) {
 // so an == 'human_action_required' equality check would silently miss a HELD SD that is ALSO an
 // orchestrator parent or test-fixture key (adversarial review finding, ship-gate self-review).
 function enforceHumanActionGate(sd, effectiveId) {
-  if (!sd?.metadata?.requires_human_action) return;
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-6 (prospective-testing D6): route through the
+  // shared ALL-MATCH classifier and key on the SPECIFIC axis — .includes(), never
+  // length>0, so a HELD SD that is also an orchestrator/fixture still surfaces the
+  // hold (the reason the old first-match classifier was avoided) while a
+  // multi-axis orchestrator SD without the hold does NOT trip this gate.
+  const axes = classifyAllDispatchIneligibility(sd || {});
+  if (!axes.includes('human_action_required')) return;
   console.log(`\n${colors.red}❌ ${effectiveId} requires HUMAN ACTION — cannot be claimed${colors.reset}`);
   console.log('   metadata.requires_human_action=true — held for chairman/coordinator review.');
   console.log(`\n${colors.bold}Action:${colors.reset} Pick a different SD with ${colors.cyan}npm run sd:next${colors.reset}`);
@@ -187,13 +189,19 @@ function enforceHumanActionGate(sd, effectiveId) {
 // LANDING-REBUILD-001 3min after FABLE-VENTURE-DESIGN-001 finished — safe by luck only).
 // This re-derives eligibility from LIVE status every claim, independent of any boolean flag.
 async function enforceBlockedOnSdGate(sd, effectiveId) {
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-2: resolution now rides the SHARED dependency
+  // gate's blocked_on_sd fold (one resolution truth with worker-checkin). Parity
+  // preserved exactly: fail-open on query faults / unresolvable refs, HARD refuse
+  // (no --force override) when the referenced SD is live and not completed.
   const blockedOn = sd?.metadata?.blocked_on_sd;
   if (typeof blockedOn !== 'string' || !blockedOn || blockedOn === 'none') return;
-  const { data, error } = await supabase.from('strategic_directives_v2').select('status').eq('sd_key', blockedOn).maybeSingle();
-  if (error || !data) return; // fail-open: can't verify -> don't strand the claim on a query fault
-  if (data.status !== 'completed') {
+  // dependencies:[] → only the blocked_on_sd fold resolves (single-ref lookup).
+  const gate = await evaluateClaimDependencyGate(supabase, { ...sd, dependencies: [] });
+  if (gate.queryError) return; // fail-open: can't verify -> don't strand the claim on a query fault
+  const hit = gate.blocking.find(d => d.sd_id === blockedOn);
+  if (hit) {
     console.log(`\n${colors.red}❌ ${effectiveId} is BLOCKED_ON ${blockedOn} — cannot be claimed${colors.reset}`);
-    console.log(`   metadata.blocked_on_sd=${blockedOn} (status=${data.status}) — dependency not yet completed.`);
+    console.log(`   metadata.blocked_on_sd=${blockedOn} (status=${hit.status}) — dependency not yet completed.`);
     console.log(`\n${colors.bold}Action:${colors.reset} Wait for ${blockedOn} to complete, or pick a different SD with ${colors.cyan}npm run sd:next${colors.reset}`);
     process.exit(1);
   }
@@ -260,36 +268,10 @@ async function getSessionAutoProceed(sessionId) {
  *
  * SD-LEO-INFRA-PRE-CLAIM-CHECK-001: Used by auto-fallback when claim conflicts occur.
  */
-async function getNextWorkableSD(excludeKeys = []) {
-  // Get all active sessions to identify claimed SDs
-  const { data: activeSessions } = await supabase
-    .from('claude_sessions')
-    .select('sd_key')
-    .not('sd_key', 'is', null)
-    .in('status', ['active', 'idle']);
-
-  const claimedSdKeys = new Set((activeSessions || []).map(s => s.sd_key));
-
-  // Query for workable SDs: not completed, not cancelled, not blocked
-  const { data: candidates } = await supabase
-    .from('strategic_directives_v2')
-    .select('sd_key, title, current_phase, status, priority, progress_percentage')
-    .in('status', ['draft', 'active', 'planning', 'ready', 'in_progress'])
-    .not('sd_key', 'is', null)
-    .order('priority', { ascending: true })
-    .order('created_at', { ascending: true })
-    .limit(20);
-
-  if (!candidates || candidates.length === 0) return null;
-
-  // Filter: exclude specified keys, exclude claimed SDs, exclude blocked
-  for (const sd of candidates) {
-    if (excludeKeys.includes(sd.sd_key)) continue;
-    if (claimedSdKeys.has(sd.sd_key)) continue;
-    return { sdKey: sd.sd_key, title: sd.title, phase: sd.current_phase };
-  }
-
-  return null;
+// SD-ARCH-HOTSPOT-SD-START-001 FR-5: relocated to lib/claim/queue-resolver.cjs
+// (shared with worker-checkin). Thin delegate — behavior parity pinned there.
+function getNextWorkableSD(excludeKeys = []) {
+  return queueResolver.getNextWorkableSD(supabase, excludeKeys);
 }
 
 /**
@@ -310,77 +292,13 @@ function getPhaseContextFile(phase) {
  *
  * @returns {{ valid: boolean, lastHandoff: Object|null, message: string, recoveryOptions: string[] }}
  */
-async function verifyHandoffIntegrity(sdUuid) {
-  // QF-20260609-564: sd_phase_handoffs is keyed by sd_id (the SD UUID). The prior query
-  // filtered the wrong (non-existent) text-key column, so every call hit the error path and
-  // silently returned valid:true, disabling resume-integrity verification entirely (the
-  // accepted/rejected/missing-handoff checks below never ran). Correct pattern matches
-  // sd-start.js:~1465 and sd-recover.js:53.
-  const { data: handoffs, error } = await supabase
-    .from('sd_phase_handoffs')
-    .select('id, from_phase, to_phase, status, created_at, rejection_reason, resolved_at')
-    .eq('sd_id', sdUuid)
-    .order('created_at', { ascending: false })
-    .limit(1);
-
-  if (error) {
-    // QF-20260609-564: surface the error instead of silently swallowing it. Stay fail-open
-    // (the consumer hard-exits on valid:false without --force, so a transient DB hiccup must
-    // not block resume), but log loudly so a real/persistent query error can never hide again
-    // the way the dead-column bug did.
-    console.warn(`⚠️  verifyHandoffIntegrity: handoff query failed (${error.code || 'error'}: ${error.message}) — proceeding without integrity check`);
-    return { valid: true, lastHandoff: null, message: `Could not query handoffs: ${error.message} (proceeding)`, recoveryOptions: [] };
-  }
-
-  if (!handoffs || handoffs.length === 0) {
-    return {
-      valid: false,
-      lastHandoff: null,
-      status: 'missing',
-      message: 'No prior handoff found',
-      recoveryOptions: [
-        'Run the appropriate handoff for this phase',
-        'Use --force flag to proceed without handoff verification'
-      ]
-    };
-  }
-
-  const last = handoffs[0];
-
-  if (last.status === 'accepted' || last.status === 'completed') {
-    return {
-      valid: true,
-      lastHandoff: last,
-      status: last.status,
-      message: `Last handoff: ${last.status} (${last.from_phase} → ${last.to_phase})`,
-      recoveryOptions: []
-    };
-  }
-
-  // Handoff was rejected or failed — but check if it was already resolved
-  if (last.resolved_at) {
-    return {
-      valid: true,
-      lastHandoff: last,
-      status: 'resolved',
-      message: `Last handoff ${last.status} but resolved at ${new Date(last.resolved_at).toLocaleString()} (${last.from_phase} → ${last.to_phase})`,
-      recoveryOptions: []
-    };
-  }
-
-  const reason = last.rejection_reason || 'No reason provided';
-  return {
-    valid: false,
-    lastHandoff: last,
-    status: last.status,
-    message: `Last handoff ${last.status}: ${last.from_phase} → ${last.to_phase}`,
-    reason,
-    recoveryOptions: [
-      `View handoff details: node -e "..." (handoff ID: ${last.id})`,
-      `Re-run the ${last.from_phase} → ${last.to_phase} handoff after addressing issues`,
-      'Use --force flag to override and continue (not recommended)'
-    ]
-  };
+// SD-ARCH-HOTSPOT-SD-START-001 FR-3: relocated to lib/claim/gates/handoff-integrity.cjs
+// (QF-20260609-564 sd_id keying + fail-open semantics preserved there verbatim).
+// The CLI keeps the loud warning surface via onWarn.
+function verifyHandoffIntegrity(sdUuid) {
+  return verifyHandoffIntegrityGate(supabase, sdUuid, {
+    onWarn: (msg) => console.warn(`⚠️  ${msg}`),
+  });
 }
 
 // Colors for terminal output
@@ -455,168 +373,21 @@ async function hasParentNeedsOwnLeadToPlan(sd) {
   return !data || data.length === 0;
 }
 
-async function getOrchestratorChildren(sdKeyOrId) {
-  const { data, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, priority, claiming_session_id, progress_percentage, sd_type')
-    .or(`parent_sd_id.eq.${sdKeyOrId}`);
-
-  if (error || !data || data.length === 0) {
-    // If sdKeyOrId was a sd_key, resolve its UUID id and retry
-    const { data: parent } = await supabase
-      .from('strategic_directives_v2')
-      .select('id')
-      .eq('sd_key', sdKeyOrId)
-      .single();
-
-    if (parent && parent.id !== sdKeyOrId) {
-      const { data: children, error: childErr } = await supabase
-        .from('strategic_directives_v2')
-        .select('id, sd_key, title, status, current_phase, priority, claiming_session_id, progress_percentage, sd_type')
-        .eq('parent_sd_id', parent.id);
-
-      if (!childErr && children) return children;
-    }
-    return data || [];
-  }
-  return data;
+// SD-ARCH-HOTSPOT-SD-START-001 FR-5: relocated to lib/claim/queue-resolver.cjs
+// (shared with worker-checkin, incl. the sd_key→UUID resolve-and-retry fallback
+// and the live-claim source-of-truth read). Thin delegates.
+function getOrchestratorChildren(sdKeyOrId) {
+  return queueResolver.getOrchestratorChildren(supabase, sdKeyOrId);
 }
 
-/**
- * Get the set of session IDs that currently hold an active claim in claude_sessions.
- * A session is "active" if status is 'active' or 'idle' (not released/stale).
- * This is the source of truth — the claiming_session_id on the SD can be stale.
- */
-async function getActiveClaimSessionIds() {
-  const { data } = await supabase
-    .from('claude_sessions')
-    .select('session_id')
-    .not('sd_key', 'is', null)
-    .in('status', ['active', 'idle']);
-  return new Set((data || []).map(r => r.session_id));
-}
-
-/**
- * Recursively find a leaf-level (non-orchestrator) work item from an orchestrator hierarchy.
- * Traverses orchestrator → sub-orchestrator → ... → leaf SD.
- *
- * When a child is itself an orchestrator (sd_type === 'orchestrator' or has children),
- * recurse into it instead of claiming it directly. This ensures that `sd:start` on a
- * top-level orchestrator drills down to the actual grandchild that needs work.
- *
- * @param {string} parentSdKey - The orchestrator SD key to search from
- * @param {number} depth - Current recursion depth (safety limit)
- * @param {string[]} routingPath - Accumulated routing path for display
- * @returns {Promise<{child: object|null, allComplete: boolean, reason: string, routingPath: string[]}>}
- */
-async function findLeafWorkItem(parentSdKey, depth = 0, routingPath = []) {
-  const MAX_DEPTH = 5; // Safety limit for deeply nested orchestrators
-
-  if (depth >= MAX_DEPTH) {
-    return {
-      child: null,
-      allComplete: false,
-      reason: `Max orchestrator nesting depth (${MAX_DEPTH}) exceeded`,
-      routingPath
-    };
-  }
-
-  const { child, allComplete, reason } = await findUnclaimedChild(parentSdKey);
-
-  if (!child) {
-    return { child: null, allComplete, reason, routingPath };
-  }
-
-  const childKey = child.sd_key || child.id;
-  const updatedPath = [...routingPath, childKey];
-
-  // Check if this child is itself an orchestrator (has its own children)
-  const grandchildren = await getOrchestratorChildren(childKey);
-
-  if (grandchildren.length > 0) {
-    // Sub-orchestrator detected — check if all its children are done
-    const allGrandchildrenComplete = grandchildren.every(gc => gc.status === 'completed');
-
-    if (allGrandchildrenComplete) {
-      // Sub-orchestrator needs its own completion handoff — return it as the work item
-      return {
-        child,
-        allComplete: false,
-        reason: `Sub-orchestrator ${childKey}: all ${grandchildren.length} children completed — needs completion handoff`,
-        routingPath: updatedPath
-      };
-    }
-
-    // Recurse into the sub-orchestrator to find a leaf grandchild
-    console.log(`   ${colors.cyan}↳ ${childKey} is a sub-orchestrator (${grandchildren.length} children) — drilling deeper...${colors.reset}`);
-    return findLeafWorkItem(childKey, depth + 1, updatedPath);
-  }
-
-  // Leaf-level SD found
-  return { child, allComplete: false, reason, routingPath: updatedPath };
-}
-
-/**
- * Find the first unclaimed child SD that's ready to work on.
- * Uses child-sd-selector for urgency-based sorting, then filters out claimed children.
- *
- * FIX: validates claiming_session_id against active claude_sessions rows.
- * A child with a stale/released claiming_session_id is treated as unclaimed.
- */
-async function findUnclaimedChild(parentSdKey) {
-  // FIX: parent_sd_id stores UUID `id`, not sd_key.
-  // Resolve sd_key → UUID id so getNextReadyChild and getOrchestratorChildren
-  // can query parent_sd_id correctly.
-  let parentId = parentSdKey;
-  const { data: parentRow } = await supabase
-    .from('strategic_directives_v2')
-    .select('id')
-    .eq('sd_key', parentSdKey)
-    .single();
-  if (parentRow) {
-    parentId = parentRow.id;
-  }
-
-  // Use the existing getNextReadyChild which handles urgency sorting and blocker filtering
-  const result = await getNextReadyChild(supabase, parentId);
-
-  if (!result.sd) {
-    return { child: null, allComplete: result.allComplete, reason: result.reason };
-  }
-
-  // Get sessions that genuinely hold an active claim in claude_sessions
-  const activeSessionIds = await getActiveClaimSessionIds();
-
-  // A child is truly claimed only if its claiming_session_id maps to an active session
-  const isTrulyClaimed = (child) =>
-    child.claiming_session_id && activeSessionIds.has(child.claiming_session_id);
-
-  // Check if the selected child is already claimed by another active session
-  if (isTrulyClaimed(result.sd)) {
-    // The top-priority child is claimed — check all children for an unclaimed one
-    const children = await getOrchestratorChildren(parentSdKey);
-    const readyChildren = children.filter(c =>
-      !isTrulyClaimed(c) &&
-      c.status !== 'completed' &&
-      c.status !== 'blocked'
-    );
-
-    if (readyChildren.length > 0) {
-      return { child: readyChildren[0], allComplete: false, reason: 'First unclaimed child' };
-    }
-
-    // All children are either truly claimed or not ready
-    const allClaimed = children.filter(c => isTrulyClaimed(c) && c.status !== 'completed');
-    if (allClaimed.length > 0) {
-      return {
-        child: null,
-        allComplete: false,
-        reason: `No ready children: ${allClaimed.length} active`
-      };
-    }
-  }
-
-  return { child: result.sd, allComplete: false, reason: result.reason };
+// SD-ARCH-HOTSPOT-SD-START-001 FR-5: the leaf/child resolution lives in
+// lib/claim/queue-resolver.cjs (resolveLeafWorkItem composes findUnclaimedChild
+// internally — shared with worker-checkin; stale-claim validation + urgency
+// sorting intact). Thin delegate: the CLI supplies supabase + drilling trace.
+function findLeafWorkItem(parentSdKey) {
+  return queueResolver.resolveLeafWorkItem(supabase, parentSdKey, {
+    onTrace: (msg) => console.log(`   ${colors.cyan}↳ ${msg}${colors.reset}`),
+  });
 }
 
 async function getNextHandoff(sd) {
@@ -647,14 +418,10 @@ async function getNextHandoff(sd) {
  * plus either --pattern-id or --followup-sd-key, audit-logged fail-closed.
  */
 async function enforceCadenceGate(sd, effectiveId) {
-  const { computeGateState, formatRefusalMessage } = await import('../lib/cadence/pre-claim-gate.mjs');
-  const gateState = computeGateState({
-    governance_metadata: sd.governance_metadata,
-    metadata: sd.metadata,
-  });
-
-  if (!gateState.active) return;
-
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-4: gate logic + audit contract live in the
+  // shared lib/claim/gates/cadence-gate.cjs adapter (cadence SSOT untouched at
+  // lib/cadence/pre-claim-gate.mjs). This CLI keeps argv parsing + rendering +
+  // process.exit, applied over the adapter's pure verdict.
   const argv = process.argv;
   const overrideIdx = argv.findIndex(a => a === '--override-cadence-gate');
   const overrideReason = (overrideIdx !== -1 && argv[overrideIdx + 1]) ? argv[overrideIdx + 1] : null;
@@ -663,73 +430,44 @@ async function enforceCadenceGate(sd, effectiveId) {
   const patternId = (patternIdIdx !== -1 && argv[patternIdIdx + 1]) ? argv[patternIdIdx + 1] : null;
   const followupSdKey = (followupIdx !== -1 && argv[followupIdx + 1]) ? argv[followupIdx + 1] : null;
 
-  if (!overrideReason || overrideReason.length < 20) {
-    console.log(`\n${colors.red}${colors.bold}🚫 ${formatRefusalMessage({ sdKey: effectiveId, gateState })}${colors.reset}`);
-    if (overrideReason && overrideReason.length < 20) {
-      console.log(`${colors.red}   (override reason must be ≥20 chars; got ${overrideReason.length})${colors.reset}`);
-    }
-    try {
-      await supabase.from('audit_log').insert({
-        event_type: 'CADENCE_GATE_REFUSED',
-        entity_type: 'strategic_directive',
-        entity_id: sd.id,
-        metadata: {
-          sd_key: effectiveId,
-          gate_until: gateState.gate_until,
-          days_remaining: gateState.days_remaining,
-          source: gateState.source,
-          override_attempted: overrideReason !== null,
-          override_reason: overrideReason,
-          operator_session_id: process.env.CLAUDE_SESSION_ID || null,
-        },
-        severity: 'info',
-      });
-    } catch (auditErr) {
-      console.warn(`${colors.dim}(audit-log refusal record failed non-blocking: ${auditErr.message})${colors.reset}`);
-    }
-    process.exit(1);
-  }
-
-  const { validateBypassShape } = await import('./modules/handoff/bypass-rubric.js');
-  const shapeResult = await validateBypassShape({
+  const verdict = await evaluateCadenceGate(supabase, sd, {
+    sdKey: effectiveId,
+    overrideReason,
     patternId,
     followupSdKey,
-    supabase,
-    bypassReason: overrideReason,
-    sdId: sd.id,
-    handoffType: 'sd_start_cadence_override',
+    sessionId: process.env.CLAUDE_SESSION_ID || null,
   });
-  if (!shapeResult.allowed) {
-    console.log(`\n${colors.red}${colors.bold}🚫 Cadence override refused${colors.reset}`);
-    console.log(`   ${shapeResult.message}`);
+
+  if (verdict.allowed && verdict.outcome === 'inactive') return;
+
+  if (verdict.outcome === 'refused') {
+    console.log(`\n${colors.red}${colors.bold}🚫 ${verdict.refusalMessage}${colors.reset}`);
+    if (verdict.shortOverride) {
+      console.log(`${colors.red}   (override reason must be ≥20 chars; got ${verdict.overrideReasonLength})${colors.reset}`);
+    }
+    if (!verdict.auditRecorded) {
+      console.warn(`${colors.dim}(audit-log refusal record failed non-blocking: ${verdict.auditError})${colors.reset}`);
+    }
     process.exit(1);
   }
 
-  const { error: auditErr } = await supabase.from('audit_log').insert({
-    event_type: 'CADENCE_GATE_OVERRIDE',
-    entity_type: 'strategic_directive',
-    entity_id: sd.id,
-    metadata: {
-      sd_key: effectiveId,
-      gate_until: gateState.gate_until,
-      days_remaining: gateState.days_remaining,
-      source: gateState.source,
-      override_reason: overrideReason,
-      pattern_id: patternId,
-      followup_sd_key: followupSdKey,
-      operator_session_id: process.env.CLAUDE_SESSION_ID || null,
-    },
-    severity: 'warning',
-  });
-  if (auditErr) {
+  if (verdict.outcome === 'override_rejected') {
+    console.log(`\n${colors.red}${colors.bold}🚫 Cadence override refused${colors.reset}`);
+    console.log(`   ${verdict.message}`);
+    process.exit(1);
+  }
+
+  if (verdict.outcome === 'audit_unavailable_fail_closed') {
     console.log(`\n${colors.red}${colors.bold}🚫 audit-log unavailable; cadence override cannot be safely recorded${colors.reset}`);
-    console.log(`   audit_log error: ${auditErr.message}`);
+    console.log(`   audit_log error: ${verdict.auditError}`);
     console.log(`   ${colors.dim}fail-closed: claim refused${colors.reset}`);
     process.exit(1);
   }
+
+  // override_accepted
   console.log(`${colors.yellow}⚠ Cadence gate override accepted${colors.reset}`);
-  console.log(`   Reason:           "${overrideReason}"`);
-  console.log(`   Pattern/Followup: ${patternId || followupSdKey}`);
+  console.log(`   Reason:           "${verdict.overrideReason}"`);
+  console.log(`   Pattern/Followup: ${verdict.patternRef}`);
   console.log(`   Audit row:        event_type=CADENCE_GATE_OVERRIDE on entity_id=${sd.id}`);
 }
 

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -47,6 +47,12 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-ARCH-HOTSPOT-SD-START-001 FR-2: the CONVERGED dependency gate shared with scripts/sd-start.js
+// (one resolution truth — deps array shapes + blocked_on_sd fold + sd_key-OR-id lookup). This
+// consumer applies its native FAIL-CLOSED polarity via depsSatisfiedFromVerdict: skip on
+// blocking, unresolved, AND query error — the exact draftDepsSatisfied semantics it replaces
+// (with uuid-shaped refs now RESOLVING instead of dangling, a resolution-accuracy fix only).
+const { evaluateClaimDependencyGate, depsSatisfiedFromVerdict } = require('../lib/claim/gates/dependency-gate.cjs');
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
 const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank } = require('../lib/fleet/tier-ladder.cjs');
@@ -823,7 +829,8 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): tierCtx adds worker_tier_rank +
   // tiering_active so a below-rung worker skips above-rung drafts (WORK-DOWN-NEVER-UP).
   if (classifyDispatchIneligibility(d, { cwd: process.cwd(), ...tierCtx }) !== null) return null;
-  if (!(await draftDepsSatisfied(sb, d))) return null; // skip dependency-blocked
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-2: converged shared gate (fail-closed polarity preserved).
+  if (!depsSatisfiedFromVerdict(await evaluateClaimDependencyGate(sb, d))) return null; // skip dependency-blocked
   // SD-REFILL-00SO4HZY: skip an orchestrator child whose parent has not yet passed LEAD (a worker would
   // otherwise drive PLAN then hit the hard EXEC-transition block). Fail-open inside parentLeadPending.
   if (await parentLeadPending(sb, d)) return null;

--- a/tests/unit/claim-eligibility-all-match.test.js
+++ b/tests/unit/claim-eligibility-all-match.test.js
@@ -1,0 +1,115 @@
+/**
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-1 / TS-1 — all-match classifier variant.
+ *
+ * classifyAllDispatchIneligibility returns EVERY matching axis so consumers that
+ * key on a SPECIFIC axis (sd-start's human-action gate: .includes('human_action_required'))
+ * see it even when an earlier axis also matches — the exact gap that made sd-start
+ * avoid the first-match classifier (its historical L168-175 rationale).
+ * Both exports walk ONE axis table; this suite pins their consistency.
+ *
+ * @module tests/unit/claim-eligibility-all-match.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  classifyDispatchIneligibility,
+  classifyAllDispatchIneligibility,
+} = require('../../lib/fleet/claim-eligibility.cjs');
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('classifyAllDispatchIneligibility (FR-1 / TS-1)', () => {
+  it('returns ALL matching axes for a multi-fault SD, in precedence order', () => {
+    const sd = {
+      sd_key: 'SD-MULTI-001',
+      sd_type: 'orchestrator', // axis 1
+      status: 'deferred',      // sd_deferred axis
+      metadata: {
+        requires_human_action: true,                          // human_action_required
+        not_before: '2126-01-01T00:00:00Z',                   // not_before_hold (far future)
+        door_class_note: 'one_way',                           // one_way_door_requires_supervision
+      },
+    };
+    const all = classifyAllDispatchIneligibility(sd);
+    expect(all).toEqual([
+      'orchestrator_parent',
+      'human_action_required',
+      'not_before_hold',
+      'one_way_door_requires_supervision',
+      'sd_deferred',
+    ]);
+    // First-match export returns exactly the head of the all-match list (one table).
+    expect(classifyDispatchIneligibility(sd)).toBe(all[0]);
+  });
+
+  it('surfaces human_action_required even when an earlier axis also matches (the sd-start gate unlock)', () => {
+    const heldOrchestrator = {
+      sd_key: 'SD-HELD-ORCH-001',
+      sd_type: 'orchestrator',
+      status: 'draft',
+      metadata: { requires_human_action: true },
+    };
+    // First-match hides the hold behind orchestrator_parent…
+    expect(classifyDispatchIneligibility(heldOrchestrator)).toBe('orchestrator_parent');
+    // …all-match still surfaces it, which is what the human-action gate keys on.
+    expect(classifyAllDispatchIneligibility(heldOrchestrator)).toContain('human_action_required');
+  });
+
+  it('returns [] for a fully eligible SD and matches the first-match null', () => {
+    const clean = { sd_key: 'SD-CLEAN-001', sd_type: 'feature', status: 'draft', metadata: {} };
+    expect(classifyAllDispatchIneligibility(clean)).toEqual([]);
+    expect(classifyDispatchIneligibility(clean)).toBeNull();
+  });
+
+  it('applies ctx-gated tier axes identically to the first-match form', () => {
+    const tierGated = {
+      sd_key: 'SD-TIER-001', sd_type: 'feature', status: 'draft',
+      metadata: { min_tier_rank: 4 },
+    };
+    const ctx = { tiering_active: true, worker_tier_rank: 2 };
+    expect(classifyAllDispatchIneligibility(tierGated, ctx)).toEqual(['above_worker_tier']);
+    expect(classifyDispatchIneligibility(tierGated, ctx)).toBe('above_worker_tier');
+    // ctx omitted => tier axis inert in both forms.
+    expect(classifyAllDispatchIneligibility(tierGated)).toEqual([]);
+  });
+
+  it('WIRING PINS (D6 + FR-6/FR-2): sd-start keys its human-action gate on axes.includes, and both CLIs consume the shared lib/claim gates', () => {
+    // Same static-pin style as tests/dispatch-eligibility-convergence.test.js (C):
+    // cheap, deterministic proof the call sites exist — moving them requires
+    // updating these pins in the same commit (TR-5).
+    const sdStart = readFileSync(resolve(repoRoot, 'scripts/sd-start.js'), 'utf8');
+    // D6: the SPECIFIC-axis check — .includes('human_action_required'), never length>0.
+    expect(sdStart).toMatch(/classifyAllDispatchIneligibility\(sd \|\| \{\}\)/);
+    expect(sdStart).toMatch(/axes\.includes\('human_action_required'\)/);
+    expect(sdStart).not.toMatch(/axes\.length\s*>\s*0/);
+    // FR-6: sd-start consumes the shared gate/queue modules.
+    expect(sdStart).toMatch(/lib\/claim\/gates\/dependency-gate\.cjs/);
+    expect(sdStart).toMatch(/lib\/claim\/gates\/handoff-integrity\.cjs/);
+    expect(sdStart).toMatch(/lib\/claim\/gates\/cadence-gate\.cjs/);
+    expect(sdStart).toMatch(/lib\/claim\/queue-resolver\.cjs/);
+    // FR-2: worker-checkin consumes the converged dependency gate with fail-closed polarity.
+    const checkin = readFileSync(resolve(repoRoot, 'scripts/worker-checkin.cjs'), 'utf8');
+    expect(checkin).toMatch(/lib\/claim\/gates\/dependency-gate\.cjs/);
+    expect(checkin).toMatch(/depsSatisfiedFromVerdict\(await evaluateClaimDependencyGate\(sb, d\)\)/);
+  });
+
+  it('every first-match verdict equals element 0 of the all-match list (property pin across axis inputs)', () => {
+    const cases = [
+      { sd_key: 'SD-TEST-CLONE-001', metadata: { test_clone_build_tree: true } },
+      { sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', target_application: 'EHG', metadata: {} },
+      { sd_key: 'SD-CO-001', metadata: { co_author_pending: true } },
+      { sd_key: 'SD-REVIEW-001', metadata: { needs_coordinator_review: true } },
+      { sd_key: 'SD-DONE-001', status: 'completed', metadata: {} },
+    ];
+    for (const sd of cases) {
+      const all = classifyAllDispatchIneligibility(sd);
+      expect(all.length).toBeGreaterThan(0);
+      expect(classifyDispatchIneligibility(sd)).toBe(all[0]);
+    }
+  });
+});

--- a/tests/unit/claim/gates/dependency-gate.test.js
+++ b/tests/unit/claim/gates/dependency-gate.test.js
@@ -1,0 +1,151 @@
+/**
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-2 / TS-2 — converged dependency gate:
+ * one resolution, raw axes, BOTH caller polarities pinned.
+ *
+ * @module tests/unit/claim/gates/dependency-gate.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { createRequire } from 'module';
+import { evaluateDependencyGate } from '../../../../lib/sd-start/dependency-gate.mjs';
+
+const require = createRequire(import.meta.url);
+const {
+  evaluateClaimDependencyGate,
+  depsSatisfiedFromVerdict,
+  extractDependencyRefs,
+} = require('../../../../lib/claim/gates/dependency-gate.cjs');
+
+// Minimal fake supabase: .from().select().or().maybeSingle()/thenable with seeded rows.
+function makeSb({ rows = [], depsRow, failWith = null } = {}) {
+  return {
+    from() {
+      const q = { wantMaybe: false };
+      const builder = {
+        select() { return builder; },
+        or() { return builder; },
+        in() { return builder; },
+        maybeSingle() {
+          q.wantMaybe = true;
+          if (failWith) return Promise.resolve({ data: null, error: { message: failWith } });
+          return Promise.resolve({ data: depsRow !== undefined ? depsRow : null, error: null });
+        },
+        then(res, rej) {
+          if (failWith) return Promise.resolve({ data: null, error: { message: failWith } }).then(res, rej);
+          return Promise.resolve({ data: rows, error: null }).then(res, rej);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+const sdWith = (dependencies, metadata = {}) => ({ id: 'uuid-1', sd_key: 'SD-SELF-001', dependencies, metadata });
+
+describe('extractDependencyRefs — draftDepsSatisfied-heritage resolution (one path)', () => {
+  it('handles every fleet dependency shape + the blocked_on_sd fold', () => {
+    const refs = extractDependencyRefs(sdWith(
+      ['SD-A-001 needs finishing', { sd_id: 'SD-B-001' }, { sd_key: 'SD-C-001' }, { sd_key: 'none' }, { type: 'note', status: 'x', dependency: 'free-form' }, 'None'],
+      { blocked_on_sd: 'SD-D-001' },
+    ));
+    expect(refs).toEqual(['SD-A-001', 'SD-B-001', 'SD-C-001', 'SD-D-001']);
+  });
+});
+
+describe('evaluateClaimDependencyGate — TS-2 raw-axes matrix', () => {
+  it('classifies blocking / satisfied / unresolved and folds blocked_on_sd', async () => {
+    const sb = makeSb({ rows: [
+      { id: 'u-a', sd_key: 'SD-A-001', status: 'in_progress' },
+      { id: 'u-b', sd_key: 'SD-B-001', status: 'completed' },
+      { id: 'u-d', sd_key: 'SD-D-001', status: 'draft' },
+    ] });
+    const v = await evaluateClaimDependencyGate(sb, sdWith(
+      [{ sd_key: 'SD-A-001' }, { sd_key: 'SD-B-001' }, { sd_key: 'SD-GONE-001' }],
+      { blocked_on_sd: 'SD-D-001' },
+    ));
+    expect(v.queryError).toBeNull();
+    expect(v.blocking.map(d => d.sd_id)).toEqual(['SD-A-001', 'SD-D-001']);
+    expect(v.satisfied.map(d => d.sd_id)).toEqual(['SD-B-001']);
+    expect(v.unresolved.map(d => d.sd_id)).toEqual(['SD-GONE-001']);
+    expect(v.resolved).toHaveLength(4);
+  });
+
+  it('all-completed and empty deps both come back clean', async () => {
+    const clean = await evaluateClaimDependencyGate(
+      makeSb({ rows: [{ id: 'u', sd_key: 'SD-A-001', status: 'completed' }] }),
+      sdWith([{ sd_key: 'SD-A-001' }]),
+    );
+    expect(clean.blocking).toEqual([]);
+    expect(clean.unresolved).toEqual([]);
+    const empty = await evaluateClaimDependencyGate(makeSb({}), sdWith([]));
+    expect(empty.resolved).toEqual([]);
+  });
+
+  it('resolves uuid-shaped refs by id (the resolution gap the sd_key-only lookup had)', async () => {
+    const v = await evaluateClaimDependencyGate(
+      makeSb({ rows: [{ id: 'c6c645c6-2f94-41b6-8e80-2642d7fcdc23', sd_key: 'SD-PARENT-001', status: 'completed' }] }),
+      sdWith([{ sd_id: 'c6c645c6-2f94-41b6-8e80-2642d7fcdc23' }]),
+    );
+    expect(v.satisfied).toHaveLength(1);
+    expect(v.unresolved).toEqual([]);
+  });
+
+  it('fetches the dependencies column when the caller did not load it (sd-start heritage)', async () => {
+    const v = await evaluateClaimDependencyGate(
+      makeSb({ depsRow: { dependencies: [{ sd_key: 'SD-A-001' }] }, rows: [{ id: 'u', sd_key: 'SD-A-001', status: 'active' }] }),
+      { id: 'uuid-1', sd_key: 'SD-SELF-001', metadata: {} }, // dependencies undefined
+    );
+    expect(v.blocking.map(d => d.sd_id)).toEqual(['SD-A-001']);
+  });
+
+  it('query error → queryError set, axes empty (callers apply native polarity)', async () => {
+    const v = await evaluateClaimDependencyGate(makeSb({ failWith: 'boom' }), sdWith([{ sd_key: 'SD-A-001' }]));
+    expect(v.queryError).toMatch(/boom/);
+    expect(v.blocking).toEqual([]);
+    expect(v.unresolved).toEqual([]);
+  });
+});
+
+describe('TS-2 caller polarities — the D3/D4 parity pins', () => {
+  const blockingVerdict = { blocking: [{ sd_id: 'SD-A-001', status: 'draft' }], unresolved: [], satisfied: [], resolved: [], queryError: null };
+  const unresolvedVerdict = { blocking: [], unresolved: [{ sd_id: 'SD-GONE-001', status: null }], satisfied: [], resolved: [], queryError: null };
+  const errorVerdict = { blocking: [], unresolved: [], satisfied: [], resolved: [], queryError: 'boom' };
+  const cleanVerdict = { blocking: [], unresolved: [], satisfied: [{ sd_id: 'SD-B-001', status: 'completed' }], resolved: [], queryError: null };
+
+  it('checkin polarity (fail-CLOSED): skips on blocking, unresolved, AND query error — claims only on clean', () => {
+    expect(depsSatisfiedFromVerdict(blockingVerdict)).toBe(false);
+    expect(depsSatisfiedFromVerdict(unresolvedVerdict)).toBe(false); // unresolved ⇒ skip (current draftDepsSatisfied behavior)
+    expect(depsSatisfiedFromVerdict(errorVerdict)).toBe(false);      // query error ⇒ skip (conservative)
+    expect(depsSatisfiedFromVerdict(cleanVerdict)).toBe(true);
+  });
+
+  it('sd-start polarity (fail-OPEN, evaluateDependencyGate over verdict.resolved): unresolved warns-never-blocks; --force downgrades a refusal', () => {
+    // Unresolved-only: proceed with warning (never block on a bad reference).
+    const unresolved = evaluateDependencyGate([{ sd_id: 'SD-GONE-001', status: null }]);
+    expect(unresolved.verdict).toBe('proceed');
+    expect(unresolved.warn).toBe(true);
+    // Confirmed-incomplete: refuse without --force, warn-and-proceed with it.
+    const refusal = evaluateDependencyGate([{ sd_id: 'SD-A-001', status: 'draft' }]);
+    expect(refusal.verdict).toBe('refuse');
+    const forced = evaluateDependencyGate([{ sd_id: 'SD-A-001', status: 'draft' }], { force: true });
+    expect(forced.verdict).toBe('proceed');
+    expect(forced.warn).toBe(true);
+  });
+});
+
+describe('module purity (FR-2 AC — D5 audit ownership + no CLI side effects)', () => {
+  const raw = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../../../../lib/claim/gates/dependency-gate.cjs'),
+    'utf8',
+  );
+  // Strip comments so doc references to the forbidden patterns don't false-positive.
+  const src = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  it('contains no process.exit / console / argv / audit writes in CODE', () => {
+    expect(src).not.toMatch(/process\.exit/);
+    expect(src).not.toMatch(/console\./);
+    expect(src).not.toMatch(/process\.argv/);
+    expect(src).not.toMatch(/audit_log/); // DEPENDENCY_GATE_REFUSED stays in the sd-start caller
+  });
+});

--- a/tests/unit/claim/gates/handoff-and-cadence-gates.test.js
+++ b/tests/unit/claim/gates/handoff-and-cadence-gates.test.js
@@ -1,0 +1,175 @@
+/**
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-3/FR-4 (TS-3/TS-4) — relocated handoff-integrity
+ * gate parity + cadence-gate adapter parity (incl. the fail-closed audit contract,
+ * exercised via the D11 insert-capture/-failure fake this suite builds).
+ *
+ * @module tests/unit/claim/gates/handoff-and-cadence-gates.test
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { verifyHandoffIntegrity } = require('../../../../lib/claim/gates/handoff-integrity.cjs');
+const { evaluateCadenceGate } = require('../../../../lib/claim/gates/cadence-gate.cjs');
+
+// D11 harness: per-table seeded rows, INSERT capture, and per-table insert-failure injection —
+// the capability gap the prospective TESTING review flagged in the existing fakes.
+function makeFakeSupabase({ seed = {}, failInsertOn = null } = {}) {
+  const calls = { inserts: [] };
+  function from(table) {
+    const q = { filters: [] };
+    const builder = {
+      select() { return builder; },
+      insert(row) {
+        calls.inserts.push({ table, row });
+        const failed = failInsertOn === table;
+        const result = { data: null, error: failed ? { message: `insert failed on ${table}` } : null };
+        // Support both `await ...insert(...)` and `...insert(...).then(...)` chains.
+        return { then: (res, rej) => Promise.resolve(result).then(res, rej) };
+      },
+      eq(col, val) { q.filters.push([col, val]); return builder; },
+      order() { return builder; },
+      limit() { return builder; },
+      maybeSingle() {
+        const rows = (seed[table] || []).filter((r) => q.filters.every(([c, v]) => r[c] === v));
+        return Promise.resolve({ data: rows[0] ?? null, error: null });
+      },
+      then(res, rej) {
+        if (seed[table] === 'ERROR') return Promise.resolve({ data: null, error: { code: 'X', message: 'seeded query error' } }).then(res, rej);
+        const rows = (seed[table] || []).filter((r) => q.filters.every(([c, v]) => r[c] === v));
+        return Promise.resolve({ data: rows, error: null }).then(res, rej);
+      },
+    };
+    return builder;
+  }
+  return { sb: { from }, calls };
+}
+
+// ─────────────────────────── FR-3 / TS-3: handoff integrity ───────────────────────────
+describe('verifyHandoffIntegrity — relocated verdict parity (TS-3)', () => {
+  it('no handoffs → invalid with status missing + recovery options', async () => {
+    const { sb } = makeFakeSupabase({ seed: { sd_phase_handoffs: [] } });
+    const v = await verifyHandoffIntegrity(sb, 'uuid-1');
+    expect(v).toMatchObject({ valid: false, lastHandoff: null, status: 'missing' });
+    expect(v.recoveryOptions.length).toBeGreaterThan(0);
+  });
+
+  it('accepted latest → valid with status echoed', async () => {
+    const { sb } = makeFakeSupabase({ seed: { sd_phase_handoffs: [
+      { id: 'h1', sd_id: 'uuid-1', from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', created_at: '2026-07-01', resolved_at: null },
+    ] } });
+    const v = await verifyHandoffIntegrity(sb, 'uuid-1');
+    expect(v).toMatchObject({ valid: true, status: 'accepted' });
+    expect(v.message).toMatch(/LEAD → PLAN/);
+  });
+
+  it('rejected-unresolved latest → invalid with reason (the path the dead-column bug silently disabled)', async () => {
+    const { sb } = makeFakeSupabase({ seed: { sd_phase_handoffs: [
+      { id: 'h2', sd_id: 'uuid-1', from_phase: 'PLAN', to_phase: 'EXEC', status: 'rejected', rejection_reason: 'gate fail', created_at: '2026-07-02', resolved_at: null },
+    ] } });
+    const v = await verifyHandoffIntegrity(sb, 'uuid-1');
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('gate fail');
+    expect(v.recoveryOptions.join(' ')).toMatch(/--force/);
+  });
+
+  it('rejected-but-resolved latest → valid with status resolved', async () => {
+    const { sb } = makeFakeSupabase({ seed: { sd_phase_handoffs: [
+      { id: 'h3', sd_id: 'uuid-1', from_phase: 'PLAN', to_phase: 'EXEC', status: 'rejected', created_at: '2026-07-02', resolved_at: '2026-07-03T00:00:00Z' },
+    ] } });
+    const v = await verifyHandoffIntegrity(sb, 'uuid-1');
+    expect(v).toMatchObject({ valid: true, status: 'resolved' });
+  });
+
+  it('query error → fail-OPEN valid:true, warning surfaced via onWarn (D9), no status field', async () => {
+    const { sb } = makeFakeSupabase({ seed: { sd_phase_handoffs: 'ERROR' } });
+    const warnings = [];
+    const v = await verifyHandoffIntegrity(sb, 'uuid-1', { onWarn: (m) => warnings.push(m) });
+    expect(v.valid).toBe(true);
+    expect('status' in v).toBe(false); // documented per-path shape variance
+    expect(warnings.join(' ')).toMatch(/handoff query failed/);
+  });
+});
+
+// ─────────────────────────── FR-4 / TS-4: cadence gate adapter ───────────────────────────
+const FUTURE = '2126-01-01T00:00:00Z';
+const activeSd = (over = {}) => ({
+  id: 'uuid-cad-1',
+  sd_key: 'SD-CAD-001',
+  governance_metadata: { next_workable_after: FUTURE },
+  metadata: {},
+  ...over,
+});
+
+describe('evaluateCadenceGate — adapter parity over the cadence SSOT (TS-4)', () => {
+  it('gate inactive (no cadence metadata) → allowed, outcome inactive, zero audit writes', async () => {
+    const { sb, calls } = makeFakeSupabase({});
+    const v = await evaluateCadenceGate(sb, { id: 'u', sd_key: 'SD-X', governance_metadata: {}, metadata: {} });
+    expect(v).toEqual({ allowed: true, outcome: 'inactive' });
+    expect(calls.inserts).toHaveLength(0);
+  });
+
+  it('active gate, no override → refused with SSOT refusal message + CADENCE_GATE_REFUSED audit row', async () => {
+    const { sb, calls } = makeFakeSupabase({});
+    const v = await evaluateCadenceGate(sb, activeSd(), { sessionId: 'sess-1' });
+    expect(v.allowed).toBe(false);
+    expect(v.outcome).toBe('refused');
+    expect(v.refusalMessage).toMatch(/SD-CAD-001/);
+    expect(v.auditRecorded).toBe(true);
+    const audit = calls.inserts.find((i) => i.table === 'audit_log');
+    expect(audit.row.event_type).toBe('CADENCE_GATE_REFUSED');
+    expect(audit.row.metadata.operator_session_id).toBe('sess-1');
+  });
+
+  it('short override (<20 chars) → refused with shortOverride flagged (caller prints the length hint)', async () => {
+    const { sb } = makeFakeSupabase({});
+    const v = await evaluateCadenceGate(sb, activeSd(), { overrideReason: 'too short' });
+    expect(v.outcome).toBe('refused');
+    expect(v.shortOverride).toBe(true);
+    expect(v.overrideReasonLength).toBe(9);
+  });
+
+  it('valid override + known pattern-id → override_accepted with CADENCE_GATE_OVERRIDE audit row', async () => {
+    const { sb, calls } = makeFakeSupabase({ seed: {
+      issue_patterns: [{ pattern_id: 'PAT-TEST-001', status: 'active' }],
+    } });
+    const v = await evaluateCadenceGate(sb, activeSd(), {
+      overrideReason: 'coordinator-approved stability-window override for hotfix',
+      patternId: 'PAT-TEST-001',
+      sessionId: 'sess-1',
+    });
+    expect(v.allowed).toBe(true);
+    expect(v.outcome).toBe('override_accepted');
+    expect(v.patternRef).toBe('PAT-TEST-001');
+    const audit = calls.inserts.find((i) => i.table === 'audit_log' && i.row.event_type === 'CADENCE_GATE_OVERRIDE');
+    expect(audit.row.severity).toBe('warning');
+    expect(audit.row.metadata.pattern_id).toBe('PAT-TEST-001');
+  });
+
+  it('valid override but unknown pattern-id under warn-only rubric → still allowed (bypass-rubric parity), audit row written', async () => {
+    // ENFORCE_BYPASS_SHAPE is unset in tests → validateBypassShape is warn-only for
+    // a missing pattern row; the adapter must mirror the inline gate exactly.
+    const { sb } = makeFakeSupabase({ seed: { issue_patterns: [] } });
+    const v = await evaluateCadenceGate(sb, activeSd(), {
+      overrideReason: 'coordinator-approved stability-window override for hotfix',
+      patternId: 'PAT-MISSING-001',
+    });
+    expect(['override_accepted', 'override_rejected']).toContain(v.outcome);
+    // Parity is with validateBypassShape's live verdict: warn-only → allowed.
+    expect(v.allowed).toBe(v.outcome === 'override_accepted');
+  });
+
+  it('override valid but audit_log insert FAILS → fail-closed refusal (TS-4, the D11 harness case)', async () => {
+    const { sb } = makeFakeSupabase({
+      seed: { issue_patterns: [{ pattern_id: 'PAT-TEST-001', status: 'active' }] },
+      failInsertOn: 'audit_log',
+    });
+    const v = await evaluateCadenceGate(sb, activeSd(), {
+      overrideReason: 'coordinator-approved stability-window override for hotfix',
+      patternId: 'PAT-TEST-001',
+    });
+    expect(v.allowed).toBe(false);
+    expect(v.outcome).toBe('audit_unavailable_fail_closed');
+    expect(v.auditError).toMatch(/insert failed/);
+  });
+});

--- a/tests/unit/claim/queue-resolver.test.js
+++ b/tests/unit/claim/queue-resolver.test.js
@@ -1,0 +1,158 @@
+/**
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-5 / TS-5 — queue-resolver relocation parity.
+ *
+ * @module tests/unit/claim/queue-resolver.test
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+
+// The urgency-sorting selector is INJECTED via opts.selectNextReadyChild (the
+// resolver's test seam); the real child-sd-selector has its own suite.
+const getNextReadyChildMock = vi.fn();
+const seam = { selectNextReadyChild: (...args) => getNextReadyChildMock(...args) };
+
+const require = createRequire(import.meta.url);
+const {
+  isOrchestratorParent,
+  getNextWorkableSD,
+  resolveLeafWorkItem,
+  findUnclaimedChild,
+} = require('../../../lib/claim/queue-resolver.cjs');
+
+// Fake supabase: per-table seeded rows with eq/in/not/or filter support.
+function makeSb(seed = {}) {
+  function from(table) {
+    const q = { filters: [], wantSingle: false };
+    const builder = {
+      select() { return builder; },
+      not() { return builder; },
+      in(col, vals) { q.filters.push((r) => vals.includes(r[col])); return builder; },
+      eq(col, val) { q.filters.push((r) => r[col] === val); return builder; },
+      or(expr) {
+        // supports 'parent_sd_id.eq.X' single-clause or-expressions used by the resolver
+        const m = /^([a-z_]+)\.eq\.(.+)$/.exec(expr);
+        if (m) q.filters.push((r) => String(r[m[1]]) === m[2]);
+        return builder;
+      },
+      order() { return builder; },
+      limit() { return builder; },
+      single() {
+        q.wantSingle = true;
+        const rows = (seed[table] || []).filter((r) => q.filters.every((f) => f(r)));
+        return Promise.resolve({ data: rows[0] ?? null, error: rows[0] ? null : { code: 'PGRST116' } });
+      },
+      then(res, rej) {
+        const rows = (seed[table] || []).filter((r) => q.filters.every((f) => f(r)));
+        return Promise.resolve({ data: rows, error: null }).then(res, rej);
+      },
+    };
+    return builder;
+  }
+  return { from };
+}
+
+beforeEach(() => getNextReadyChildMock.mockReset());
+
+describe('isOrchestratorParent — exclude-intent predicate (D10: sd_type-keyed)', () => {
+  it('true only for sd_type orchestrator; structural has-children does NOT count', () => {
+    expect(isOrchestratorParent({ sd_type: 'orchestrator' })).toBe(true);
+    expect(isOrchestratorParent({ sd_type: 'feature' })).toBe(false);
+    expect(isOrchestratorParent({ sd_type: 'feature', has_children: true })).toBe(false);
+    expect(isOrchestratorParent(null)).toBe(false);
+  });
+});
+
+describe('getNextWorkableSD — relocation parity (ordering + claim exclusion)', () => {
+  const sessions = [{ session_id: 's1', sd_key: 'SD-CLAIMED-001', status: 'active' }];
+  const candidates = [
+    { sd_key: 'SD-CLAIMED-001', title: 'claimed', current_phase: 'EXEC', status: 'in_progress' },
+    { sd_key: 'SD-FREE-001', title: 'free', current_phase: 'LEAD', status: 'draft' },
+    { sd_key: 'SD-FREE-002', title: 'free2', current_phase: 'PLAN', status: 'draft' },
+  ];
+
+  it('skips claimed + excluded keys and returns the first remaining candidate', async () => {
+    const sb = makeSb({ claude_sessions: sessions, strategic_directives_v2: candidates });
+    const pick = await getNextWorkableSD(sb, ['SD-FREE-001']);
+    expect(pick).toEqual({ sdKey: 'SD-FREE-002', title: 'free2', phase: 'PLAN' });
+  });
+
+  it('returns null when nothing survives the filters', async () => {
+    const sb = makeSb({ claude_sessions: sessions, strategic_directives_v2: [candidates[0]] });
+    expect(await getNextWorkableSD(sb, [])).toBeNull();
+  });
+});
+
+describe('resolveLeafWorkItem / findUnclaimedChild — descend-intent parity (TS-5)', () => {
+  const parentRow = { id: 'uuid-parent', sd_key: 'SD-ORCH-001' };
+
+  it('unclaimed ready child → returned directly with routing path', async () => {
+    const leaf = { id: 'uuid-c1', sd_key: 'SD-ORCH-001-A', status: 'draft', claiming_session_id: null };
+    getNextReadyChildMock.mockResolvedValue({ sd: leaf, reason: 'urgency pick' });
+    const sb = makeSb({ strategic_directives_v2: [parentRow], claude_sessions: [] });
+    const r = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam });
+    expect(r.child.sd_key).toBe('SD-ORCH-001-A');
+    expect(r.routingPath).toEqual(['SD-ORCH-001-A']);
+    expect(r.allComplete).toBe(false);
+  });
+
+  it('claimed-top-child falls back to the first genuinely-unclaimed sibling (stale claims treated as unclaimed)', async () => {
+    const claimed = { id: 'uuid-c1', sd_key: 'SD-ORCH-001-A', status: 'in_progress', claiming_session_id: 'live-sess' };
+    const stale = { id: 'uuid-c2', sd_key: 'SD-ORCH-001-B', status: 'draft', claiming_session_id: 'dead-sess', parent_sd_id: 'uuid-parent' };
+    getNextReadyChildMock.mockResolvedValue({ sd: claimed, reason: 'urgency pick' });
+    const sb = makeSb({
+      strategic_directives_v2: [parentRow, { ...claimed, parent_sd_id: 'uuid-parent' }, stale],
+      claude_sessions: [{ session_id: 'live-sess', sd_key: 'SD-ORCH-001-A', status: 'active' }], // dead-sess absent → stale
+    });
+    const r = await findUnclaimedChild(sb, 'SD-ORCH-001', { ...seam });
+    expect(r.child.sd_key).toBe('SD-ORCH-001-B');
+    expect(r.reason).toBe('First unclaimed child');
+  });
+
+  it('nested orchestrator → drills to a leaf grandchild with the recursion threading supabase (D2) and onTrace firing', async () => {
+    const subOrch = { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB', status: 'draft', claiming_session_id: null };
+    const grandLeaf = { id: 'uuid-g1', sd_key: 'SD-ORCH-001-SUB-A', status: 'draft', claiming_session_id: null };
+    getNextReadyChildMock
+      .mockResolvedValueOnce({ sd: subOrch, reason: 'urgency pick' })
+      .mockResolvedValueOnce({ sd: grandLeaf, reason: 'urgency pick' });
+    const sb = makeSb({
+      strategic_directives_v2: [
+        parentRow,
+        { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB' },
+        { ...grandLeaf, parent_sd_id: 'uuid-sub' }, // sub-orch has a non-complete child → recurse
+      ],
+      claude_sessions: [],
+    });
+    const traces = [];
+    const r = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam, onTrace: (m) => traces.push(m) });
+    expect(r.child.sd_key).toBe('SD-ORCH-001-SUB-A');
+    expect(r.routingPath).toEqual(['SD-ORCH-001-SUB', 'SD-ORCH-001-SUB-A']);
+    expect(traces.join(' ')).toMatch(/drilling deeper/);
+  });
+
+  it('sub-orchestrator with ALL grandchildren complete → returned itself (needs completion handoff)', async () => {
+    const subOrch = { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB', status: 'in_progress', claiming_session_id: null };
+    getNextReadyChildMock.mockResolvedValue({ sd: subOrch, reason: 'urgency pick' });
+    const sb = makeSb({
+      strategic_directives_v2: [
+        parentRow,
+        { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB' },
+        { id: 'uuid-g1', sd_key: 'SD-ORCH-001-SUB-A', status: 'completed', parent_sd_id: 'uuid-sub' },
+      ],
+      claude_sessions: [],
+    });
+    const r = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam });
+    expect(r.child.sd_key).toBe('SD-ORCH-001-SUB');
+    expect(r.reason).toMatch(/needs completion handoff/);
+  });
+
+  it('all children complete → {child:null, allComplete:true} passthrough; depth cap honored', async () => {
+    getNextReadyChildMock.mockResolvedValue({ sd: null, allComplete: true, reason: 'All children completed' });
+    const sb = makeSb({ strategic_directives_v2: [parentRow], claude_sessions: [] });
+    const done = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam });
+    expect(done).toMatchObject({ child: null, allComplete: true });
+
+    const capped = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam, depth: 5 });
+    expect(capped.child).toBeNull();
+    expect(capped.reason).toMatch(/nesting depth/);
+  });
+});

--- a/tests/unit/sd-start-blocked-on-sd-gate.test.js
+++ b/tests/unit/sd-start-blocked-on-sd-gate.test.js
@@ -18,22 +18,29 @@ import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(__dirname, '..', '..', 'scripts/sd-start.js'), 'utf8');
+// SD-ARCH-HOTSPOT-SD-START-001 FR-2: the LIVE-status resolution moved into the
+// shared dependency gate (blocked_on_sd fold) — pin the invariant across both files.
+const gateSrc = readFileSync(resolve(__dirname, '..', '..', 'lib/claim/gates/dependency-gate.cjs'), 'utf8');
 
 describe('QF-20260706-786: sd-start.js metadata.blocked_on_sd claim gate', () => {
-  it('defines enforceBlockedOnSdGate, gated on a LIVE strategic_directives_v2 status lookup, that exits(1) when unresolved', () => {
+  it('defines enforceBlockedOnSdGate over the SHARED gate, refusing (exit 1) on a live non-completed dependency', () => {
     const start = src.indexOf('async function enforceBlockedOnSdGate');
     expect(start).toBeGreaterThan(0);
-    const body = src.slice(start, start + 900);
+    const body = src.slice(start, start + 1800);
     expect(body).toMatch(/sd\?\.metadata\?\.blocked_on_sd/);
-    expect(body).toMatch(/strategic_directives_v2/);
-    expect(body).toMatch(/status.*!==.*'completed'/);
+    expect(body).toMatch(/evaluateClaimDependencyGate/);          // shared resolution, no fork
+    expect(body).toMatch(/gate\.blocking\.find/);                 // gated on LIVE status axes
     expect(body).toMatch(/process\.exit\(1\)/);
+    // The LIVE strategic_directives_v2 status lookup + blocked_on_sd fold live in the shared gate.
+    expect(gateSrc).toMatch(/strategic_directives_v2/);
+    expect(gateSrc).toMatch(/blocked_on_sd/);
+    expect(gateSrc).toMatch(/status !== 'completed'|status && d\.status !== 'completed'|d\.status !== 'completed'/);
   });
 
   it('fails open on a query error (never strands a claim on a transient fault)', () => {
     const start = src.indexOf('async function enforceBlockedOnSdGate');
-    const body = src.slice(start, start + 900);
-    expect(body).toMatch(/if \(error \|\| !data\) return;/);
+    const body = src.slice(start, start + 1800);
+    expect(body).toMatch(/if \(gate\.queryError\) return;/);
   });
 
   it('is called right after enforceHumanActionGate on the initial claim path', () => {

--- a/tests/unit/sd-start-handoff-integrity-query.test.js
+++ b/tests/unit/sd-start-handoff-integrity-query.test.js
@@ -13,16 +13,23 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
 const src = fs.readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf-8');
+// SD-ARCH-HOTSPOT-SD-START-001 FR-3: verifyHandoffIntegrity relocated to the shared
+// gate module — the QF-20260609-564 sd_id-keying invariant is pinned there now.
+const gateSrc = fs.readFileSync(path.join(repoRoot, 'lib/claim/gates/handoff-integrity.cjs'), 'utf-8');
 
 describe('QF-20260609-564: sd-start.js handoff queries use sd_id, not sd_key', () => {
-  it('verifyHandoffIntegrity filters sd_phase_handoffs by sd_id (not the non-existent sd_key column)', () => {
-    const start = src.indexOf('async function verifyHandoffIntegrity');
+  it('verifyHandoffIntegrity (relocated shared gate) filters sd_phase_handoffs by sd_id, and the sd-start wrapper delegates to it', () => {
+    const start = gateSrc.indexOf('async function verifyHandoffIntegrity');
     expect(start).toBeGreaterThan(0);
-    const fnBlock = src.slice(start, start + 1200);
+    const fnBlock = gateSrc.slice(start, start + 1200);
     // The integrity query must filter by sd_id...
     expect(fnBlock).toMatch(/\.eq\(['"]sd_id['"],\s*sdUuid\)/);
     // ...and must NOT reference the non-existent sd_key column anywhere in the function.
     expect(fnBlock).not.toMatch(/sd_key/);
+    // sd-start delegates (keeps the loud warning surface via onWarn → console.warn).
+    const wrapper = src.indexOf('function verifyHandoffIntegrity(sdUuid)');
+    expect(wrapper).toBeGreaterThan(0);
+    expect(src.slice(wrapper, wrapper + 400)).toMatch(/verifyHandoffIntegrityGate\(supabase,\s*sdUuid/);
   });
 
   it('the PRIOR WORK (>=3 handoffs) warning filters sd_phase_handoffs by sd_id', () => {
@@ -42,12 +49,16 @@ describe('QF-20260609-564: sd-start.js handoff queries use sd_id, not sd_key', (
     // assert the dead pattern is absent entirely for this column on that table.
     const deadPattern = /sd_phase_handoffs[\s\S]{0,200}?\.eq\(['"]sd_key['"]/;
     expect(src).not.toMatch(deadPattern);
+    expect(gateSrc).not.toMatch(deadPattern); // and not reintroduced in the relocated gate
   });
 
-  it('verifyHandoffIntegrity surfaces (logs) a query error instead of silently swallowing it', () => {
-    const start = src.indexOf('async function verifyHandoffIntegrity');
-    const fnBlock = src.slice(start, start + 1200);
-    // The error branch must log the error (no longer a silent return).
-    expect(fnBlock).toMatch(/if \(error\) \{[\s\S]*?console\.(warn|error)\(/);
+  it('verifyHandoffIntegrity surfaces a query error instead of silently swallowing it (onWarn → console.warn in the CLI)', () => {
+    // The relocated gate reports through onWarn on its error branch…
+    const start = gateSrc.indexOf('async function verifyHandoffIntegrity');
+    const fnBlock = gateSrc.slice(start, start + 1600);
+    expect(fnBlock).toMatch(/if \(error\) \{[\s\S]*?onWarn\(/);
+    // …and the sd-start wrapper wires onWarn to a loud console.warn.
+    const wrapper = src.indexOf('function verifyHandoffIntegrity(sdUuid)');
+    expect(src.slice(wrapper, wrapper + 400)).toMatch(/onWarn:.*console\.warn/);
   });
 });

--- a/tests/unit/sd-start-human-action-gate.test.js
+++ b/tests/unit/sd-start-human-action-gate.test.js
@@ -22,18 +22,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(__dirname, '../..', 'scripts/sd-start.js'), 'utf8');
 
 describe('QF-20260703-295: sd-start.js HELD-SD (requires_human_action) claim gate', () => {
-  it('defines enforceHumanActionGate, gated directly on metadata.requires_human_action, that exits(1)', () => {
+  it('defines enforceHumanActionGate, keyed on the SPECIFIC human_action_required axis, that exits(1)', () => {
+    // SD-ARCH-HOTSPOT-SD-START-001 FR-6/D6: the gate now routes through the shared
+    // ALL-MATCH classifier (classifyAllDispatchIneligibility) and keys on
+    // .includes('human_action_required') — the same never-miss-a-HELD-orchestrator
+    // guarantee the old direct metadata check provided, now via one axis table.
     const start = src.indexOf('function enforceHumanActionGate');
     expect(start).toBeGreaterThan(0);
-    const body = src.slice(start, start + 500);
-    expect(body).toMatch(/sd\?\.metadata\?\.requires_human_action/);
+    const body = src.slice(start, start + 1800);
+    expect(body).toMatch(/classifyAllDispatchIneligibility\(sd \|\| \{\}\)/);
+    expect(body).toMatch(/axes\.includes\('human_action_required'\)/);
     expect(body).toMatch(/process\.exit\(1\)/);
   });
 
-  it('does NOT gate via classifyDispatchIneligibility\'s return value (axis-precedence-masking regression)', () => {
+  it('does NOT gate via the FIRST-MATCH classifier return value or a length>0 blanket (axis-precedence-masking regression, D6)', () => {
     const start = src.indexOf('function enforceHumanActionGate');
-    const body = src.slice(start, start + 500);
-    expect(body).not.toMatch(/classifyDispatchIneligibility/);
+    const body = src.slice(start, start + 1800);
+    // The first-match form short-circuits on orchestrator_parent/test_fixture_key
+    // before human_action_required; a blanket length>0 would over-block routing.
+    expect(body).not.toMatch(/classifyDispatchIneligibility\(/);
+    expect(body).not.toMatch(/axes\.length\s*>\s*0/);
   });
 
   it('calls the gate right after the 1.1 deferred-claim check (direct/parent claim path)', () => {
@@ -46,12 +54,17 @@ describe('QF-20260703-295: sd-start.js HELD-SD (requires_human_action) claim gat
     expect(src.slice(idx, idx + 600)).toMatch(/enforceHumanActionGate\(sd, effectiveId\)/);
   });
 
-  it('regression pin: a HELD sd that is ALSO an orchestrator parent must still be refused', () => {
-    // Guards the exact gap the review-gate found: classifyDispatchIneligibility({sd_type:
-    // 'orchestrator', metadata: {requires_human_action: true}}) returns 'orchestrator_parent'
-    // (checked first), NOT 'human_action_required' — so a gate keyed off that return value
-    // would silently let this combination through. The direct metadata check does not.
+  it('regression pin: a HELD sd that is ALSO an orchestrator parent must still be refused', async () => {
+    // Guards the exact gap the review-gate found: the FIRST-MATCH classifier returns
+    // 'orchestrator_parent' (checked first), NOT 'human_action_required' — so a gate
+    // keyed off that return value would silently let this combination through. The
+    // ALL-MATCH classifier the gate now uses surfaces the hold regardless.
+    const { createRequire } = await import('node:module');
+    const cjsRequire = createRequire(import.meta.url);
+    const { classifyDispatchIneligibility, classifyAllDispatchIneligibility } =
+      cjsRequire('../../lib/fleet/claim-eligibility.cjs');
     const heldOrchestrator = { sd_type: 'orchestrator', metadata: { requires_human_action: true } };
-    expect(Boolean(heldOrchestrator?.metadata?.requires_human_action)).toBe(true);
+    expect(classifyDispatchIneligibility(heldOrchestrator)).toBe('orchestrator_parent'); // the masking
+    expect(classifyAllDispatchIneligibility(heldOrchestrator)).toContain('human_action_required'); // the fix
   });
 });


### PR DESCRIPTION
## Summary
PR-A (structural half) of the SD-START hotspot door — one claim-eligibility truth for both fleet CLIs:
- **Axis-table classifier**: `classifyAllDispatchIneligibility` all-match variant over the SAME table as the first-match API (byte-compatible; 72 existing pins green unmodified). Unlocks specific-axis gates (a HELD orchestrator surfaces the hold).
- **Converged dependency gate** (`lib/claim/gates/dependency-gate.cjs`): one resolution (all fleet dep shapes + `blocked_on_sd` fold + sd_key-OR-id lookup), RAW-AXES verdict — each caller keeps its native polarity (checkin fail-closed skip; sd-start warn-proceed/--force). The prospective-testing review proved a single `allowed` boolean flips one caller's behavior (D3/D4).
- **Relocated handoff-integrity + cadence adapters** preserving QF-20260609-564 sd_id keying, fail-open, and the fail-closed audit contract.
- **Queue resolver** with both orchestrator intents as distinct primitives (checkin EXCLUDES via sd_type; sd-start DESCENDS via `resolveLeafWorkItem`), transitive helpers moved (D1), supabase threaded through recursion (D2).
- **sd-start** keeps CLI/colors/exit/argv over pure verdicts; 2147→1885 lines (documented deviation from the ~1200 aspiration: CLI/display/worktree stay per the SD's own target shape). **worker-checkin** consumes the converged gate (consumption 1 of ≥2; #2 in PR-B).
- Pins moved WITH the code in the same commit (TR-5); new wiring pins added.

PR-B (dispatch-auth born-un-authorized phase-1, flag-gated observe-first + backfill tooling) follows separately — risk mandate: structural and authorization axes never one merge.

## Test plan
- [x] Full unit surface: 21,521 passed; the 8 failures reproduce identically on unmodified main (pre-existing env-dependent)
- [x] All ~14 targeted claim/dispatch/sd-start pin suites green (136+ tests incl. new module matrices + dual-polarity parity pins)
- [x] Live claim cycle through the new gates (this SD's own re-affirm)
- [x] ESLint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)