### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D): gate wiring — verifier dual-read + live-probe, launch_mode precondition, S19 check (PR 2/2)

### DIFF
--- a/lib/eva/launch-mode.js
+++ b/lib/eva/launch-mode.js
@@ -144,6 +144,35 @@ export async function setLaunchMode({ supabase, ventureId, toMode, decision } = 
     return { flipped: false, reason: 'decision_venture_mismatch' };
   }
 
+  // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-5): live requires a production
+  // deploy — 'launch_mode=live becomes meaningful only when a production deploy
+  // exists' (design SSOT). Additive AND on top of the decision/audit semantics
+  // (untouched). OBSERVE-ONLY-FIRST per the protocol default:
+  // LAUNCH_MODE_DEPLOY_PRECONDITION defaults to 'observe' (violation logged
+  // loudly, flip proceeds); set 'enforce' to block after the calibration review.
+  // Flips to 'simulated' (incl. emergency rollbacks) are never gated here.
+  if (toMode === LIVE) {
+    const gateMode = process.env.LAUNCH_MODE_DEPLOY_PRECONDITION || 'observe';
+    const { data: routed, error: depErr } = await supabase
+      .from('venture_deployments')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('status', 'routed')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    // Query fault (incl. unapplied migration) counts as no-deploy-visible: in
+    // observe mode that is a logged violation; in enforce mode it fails closed.
+    const hasDeploy = !depErr && !!routed;
+    if (!hasDeploy) {
+      const detail = depErr ? `deploy record read failed: ${depErr.message}` : 'no venture_deployments row with status=routed';
+      if (gateMode === 'enforce') {
+        return { flipped: false, reason: `no_production_deploy: ${detail}` };
+      }
+      console.error(`[launch-mode] DEPLOY-PRECONDITION VIOLATION (observe mode — flip proceeds): venture ${ventureId} flipping to live with ${detail}`);
+    }
+  }
+
   // W6: strict read — a degraded mode read must ABORT the write path (a LIVE
   // venture must never read as simulated here; that both blocks emergency
   // rollbacks and records a false from_mode in the audit).

--- a/lib/eva/launch-mode.js
+++ b/lib/eva/launch-mode.js
@@ -152,20 +152,36 @@ export async function setLaunchMode({ supabase, ventureId, toMode, decision } = 
   // loudly, flip proceeds); set 'enforce' to block after the calibration review.
   // Flips to 'simulated' (incl. emergency rollbacks) are never gated here.
   if (toMode === LIVE) {
-    const gateMode = process.env.LAUNCH_MODE_DEPLOY_PRECONDITION || 'observe';
-    const { data: routed, error: depErr } = await supabase
-      .from('venture_deployments')
-      .select('id')
-      .eq('venture_id', ventureId)
-      .eq('status', 'routed')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+    const rawGateMode = process.env.LAUNCH_MODE_DEPLOY_PRECONDITION;
+    const gateMode = (rawGateMode || 'observe').trim().toLowerCase();
+    if (rawGateMode && gateMode !== 'enforce' && gateMode !== 'observe') {
+      // Never let a typo'd 'enforce' silently observe — the misconfigured-promotion
+      // case is the highest-stakes moment for this footgun (adversarial review PR #5769).
+      console.error(`[launch-mode] LAUNCH_MODE_DEPLOY_PRECONDITION has unrecognized value '${rawGateMode}' — treating as observe.`);
+    }
+    // Throws (nonstandard client, network layer) convert like every sibling DB
+    // access in this function — this write path never escapes as an unhandled
+    // rejection. A throw counts as no-deploy-visible, same as a query error.
+    let routed = null;
+    let depFault = null;
+    try {
+      const { data, error } = await supabase
+        .from('venture_deployments')
+        .select('id')
+        .eq('venture_id', ventureId)
+        .eq('status', 'routed')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      routed = data;
+      depFault = error ? error.message : null;
+    } catch (e) {
+      depFault = (e && e.message) || String(e);
+    }
     // Query fault (incl. unapplied migration) counts as no-deploy-visible: in
     // observe mode that is a logged violation; in enforce mode it fails closed.
-    const hasDeploy = !depErr && !!routed;
-    if (!hasDeploy) {
-      const detail = depErr ? `deploy record read failed: ${depErr.message}` : 'no venture_deployments row with status=routed';
+    if (!routed) {
+      const detail = depFault ? `deploy record read failed: ${depFault}` : 'no venture_deployments row with status=routed';
       if (gateMode === 'enforce') {
         return { flipped: false, reason: `no_production_deploy: ${detail}` };
       }

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -22,6 +22,9 @@ import { normalizeBuildTaskCompletion } from '../bridge/repo-readiness.js';
 import { GUARDRAIL_NAMES } from '../../venture-deploy/spend-guardrails.js';
 // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B FR-3: stack-descriptor validation.
 import { validateStackDescriptor } from '../../venture-deploy/stack-descriptor.js';
+// SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D FR-3: ONE off-host semantics shared with
+// promote.js's pre-route health gate (two hand-rolled probes diverged once already).
+import { safeHost } from '../../venture-deploy/promote.js';
 // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D FR-3: post-publish verifiers read
 // the publish record written by lib/venture-deploy/publish.js into
 // ventures.stack_descriptor.publish. (No extra import needed — read inline.)
@@ -411,8 +414,10 @@ async function latestRoutedDeployment(supabase, ventureId) {
 }
 
 /** Live HTTP probe (design R3 rule: PagesUrlLive must LIVE-PROBE, never trust the
- * row alone). Short timeout + one retry; final 2xx/3xx-free — a recorded URL that
- * does not actually serve is fail-closed. Injectable via ctx.fetchImpl for tests. */
+ * row alone). Short timeout + one retry; requires a FINAL 2xx on the SAME HOST —
+ * a lapsed/parked domain that cross-origin-redirects to some healthy 200 page must
+ * not satisfy the gate (same semantics as promote.js's pre-route health gate, via
+ * the shared safeHost). Injectable via ctx.fetchImpl for tests. */
 async function probeUrlAlive(url, fetchImpl = fetch, timeoutMs = 5000, retries = 1) {
   let lastErr = null;
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -420,8 +425,11 @@ async function probeUrlAlive(url, fetchImpl = fetch, timeoutMs = 5000, retries =
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
       const res = await fetchImpl(url, { signal: ctrl.signal, redirect: 'follow' });
-      if (res.status >= 200 && res.status < 300) return { alive: true };
-      lastErr = `HTTP ${res.status}`;
+      // res.url absent (bare test mocks) = same-host; unparseable = off-host (fail-closed).
+      const sameHost = !res.url || safeHost(res.url) === safeHost(url);
+      if (!sameHost) lastErr = `redirected off-host to ${safeHost(res.url)}`;
+      else if (res.status >= 200 && res.status < 300) return { alive: true };
+      else lastErr = `HTTP ${res.status}`;
     } catch (e) {
       lastErr = e?.name === 'AbortError' ? `timeout>${timeoutMs}ms` : String(e?.message || e);
     } finally {

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -381,26 +381,90 @@ async function verifyDeploymentTargetProvisioned({ supabase, ventureId }) {
  * publish record yields satisfied:false. Gate strings are distinct from B/C.
  */
 
-/** Verifier: a deployment URL was recorded by publish(). Backs 'pages url live'. */
-async function verifyPagesUrlLive({ supabase, ventureId }) {
-  const { data, error } = await supabase
-    .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
-  if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
-  const url = data?.stack_descriptor?.publish?.deploymentUrl;
+/**
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-3): DUAL-READ transition.
+ * The canonical deploy record is now venture_deployments (written by promote(),
+ * design R3/R4/R5 binding rule); the legacy stack_descriptor.publish read is the
+ * transition path for ventures whose deploys predate the table.
+ * RETIREMENT CRITERION (DORMANT-EXIT-001 discipline): retire the legacy read only
+ * after >=25 verifier evaluations over 48h with ZERO false-rejects on the
+ * record-only path, flipped by a named operator — until then both paths satisfy.
+ */
+async function latestRoutedDeployment(supabase, ventureId) {
+  // Missing table (migration not yet applied), query fault, or a client that
+  // cannot express this query: report null so the caller falls through to the
+  // legacy read — the dual-read transition exists exactly for these cases.
+  try {
+    const { data, error } = await supabase
+      .from('venture_deployments')
+      .select('id, url, sha')
+      .eq('venture_id', ventureId)
+      .eq('status', 'routed')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) return null;
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Live HTTP probe (design R3 rule: PagesUrlLive must LIVE-PROBE, never trust the
+ * row alone). Short timeout + one retry; final 2xx/3xx-free — a recorded URL that
+ * does not actually serve is fail-closed. Injectable via ctx.fetchImpl for tests. */
+async function probeUrlAlive(url, fetchImpl = fetch, timeoutMs = 5000, retries = 1) {
+  let lastErr = null;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, { signal: ctrl.signal, redirect: 'follow' });
+      if (res.status >= 200 && res.status < 300) return { alive: true };
+      lastErr = `HTTP ${res.status}`;
+    } catch (e) {
+      lastErr = e?.name === 'AbortError' ? `timeout>${timeoutMs}ms` : String(e?.message || e);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return { alive: false, reason: lastErr };
+}
+
+/** Verifier: a deployment URL is recorded AND live-probes successfully.
+ * Backs 'pages url live'. Dual-read: venture_deployments routed row (canonical)
+ * OR legacy publish record; EITHER way the URL must actually serve (R3). */
+async function verifyPagesUrlLive({ supabase, ventureId, fetchImpl }) {
+  const routed = await latestRoutedDeployment(supabase, ventureId);
+  let url = routed?.url;
+  if (!url) {
+    const { data, error } = await supabase
+      .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
+    if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+    url = data?.stack_descriptor?.publish?.deploymentUrl;
+  }
   if (typeof url !== 'string' || url.length === 0) {
-    return { satisfied: false, reason: 'no deployment URL recorded by publish() → fail-closed' };
+    return { satisfied: false, reason: 'no deployment URL recorded (venture_deployments or publish()) → fail-closed' };
+  }
+  const probe = await probeUrlAlive(url, fetchImpl);
+  if (!probe.alive) {
+    return { satisfied: false, reason: `deployment URL recorded but not serving (${probe.reason}) → fail-closed (R3: never trust the row alone)` };
   }
   return { satisfied: true, reason: '' };
 }
 
-/** Verifier: publish() reported status 'published'. Backs 'compute deployed'. */
+/** Verifier: a production deploy is recorded. Backs 'compute deployed'.
+ * Dual-read: venture_deployments status='routed' (canonical, written by promote())
+ * OR legacy publish() status 'published' (transition — see retirement criterion above). */
 async function verifyComputeDeployed({ supabase, ventureId }) {
+  const routed = await latestRoutedDeployment(supabase, ventureId);
+  if (routed) return { satisfied: true, reason: '' };
   const { data, error } = await supabase
     .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
   if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
   const status = data?.stack_descriptor?.publish?.status;
   if (status !== 'published') {
-    return { satisfied: false, reason: `publish status is '${status ?? 'none'}' (not 'published') → fail-closed` };
+    return { satisfied: false, reason: `no routed venture_deployments row and publish status is '${status ?? 'none'}' → fail-closed` };
   }
   return { satisfied: true, reason: '' };
 }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -747,33 +747,6 @@ export class StageExecutionWorker {
           }
         }
 
-        // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-6): S19-entry deploy-target
-        // provisioning check (design §5 — provisioning executes at S19 entry beside the
-        // spend/stack gates; production deploy is an S19 exit requirement).
-        // OBSERVE-ONLY by default per the protocol default for new enforcement:
-        // S19_DEPLOY_PROVISIONING=observe logs the would-block; 'enforce' (post-
-        // calibration-review promotion) blocks like the scaffold gate above.
-        if (currentStage === 19) {
-          try {
-            const { checkDeployTargetProvisioned } = await import('../venture-deploy/provisioning-check.js');
-            const prov = await checkDeployTargetProvisioned(this._supabase, ventureId);
-            if (!prov.provisioned) {
-              const gateMode = process.env.S19_DEPLOY_PROVISIONING || 'observe';
-              if (gateMode === 'enforce') {
-                this._logger.error(`[Worker] S19 DEPLOY-PROVISIONING gate: venture ${ventureId} — ${prov.reason} — blocking S19 advance.`);
-                releaseState = ORCHESTRATOR_STATES.BLOCKED;
-                lastResult = { ventureId, stageId: 19, status: 'blocked', gate: 'deploy_target_unprovisioned', reason: prov.reason };
-                break;
-              }
-              this._logger.warn(`[Worker] S19 DEPLOY-PROVISIONING (observe-only — would block under enforce): venture ${ventureId} — ${prov.reason}`);
-            }
-          } catch (e) {
-            // The check itself failing is not this gate's enforcement to invent —
-            // fail-open with a loud log, same posture as the scaffold gate's catch.
-            this._logger.warn(`[Worker] S19 deploy-provisioning check failed (non-fatal, fail-open): ${e.message}`);
-          }
-        }
-
         // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-2): DECISION-STATE-INDEPENDENT hard pre-advance S19
         // invariant gate. A leo_bridge venture MUST NOT pass Stage 19 until its orchestrator + all
         // child SDs are complete. Predecessor SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 only blocked
@@ -1707,6 +1680,56 @@ export class StageExecutionWorker {
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'vision_acceptance_pending' };
             break;
+          }
+        }
+
+        // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-6): S19 deploy-target provisioning
+        // check (design §5 — provisioning executes at S19 entry beside the spend/stack gates;
+        // production deploy is an S19 exit requirement). PLACEMENT IS LOAD-BEARING: this runs
+        // AFTER the bridge/provisioning blocks above (_runS19Bridge → _verifyAndProvisionVenture
+        // is the only writer of stack_descriptor.connection) — checking before them would be the
+        // block-before-remediate deadlock class the scaffold gate's comment documents (an
+        // enforce-blocked venture whose only fix runs later in the same tick, adversarial
+        // review of PR #5769). OBSERVE-ONLY by default per the protocol default:
+        // S19_DEPLOY_PROVISIONING=observe logs the would-block; 'enforce' (post-calibration
+        // promotion) blocks like the sibling scaffold gate, with the same durable
+        // venture_stage_work record so chairman surfaces show WHY the venture is held.
+        if (currentStage === 19) {
+          try {
+            const { checkDeployTargetProvisioned } = await import('../venture-deploy/provisioning-check.js');
+            const prov = await checkDeployTargetProvisioned(this._supabase, ventureId);
+            if (!prov.provisioned) {
+              const rawGateMode = process.env.S19_DEPLOY_PROVISIONING;
+              const gateMode = (rawGateMode || 'observe').trim().toLowerCase();
+              if (rawGateMode && gateMode !== 'enforce' && gateMode !== 'observe') {
+                // Misconfigured promotion is the highest-stakes moment for this footgun:
+                // never let a typo'd 'enforce' silently observe without saying so.
+                this._logger.warn(`[Worker] S19_DEPLOY_PROVISIONING has unrecognized value '${rawGateMode}' — treating as observe.`);
+              }
+              if (gateMode === 'enforce') {
+                this._logger.error(`[Worker] S19 DEPLOY-PROVISIONING gate: venture ${ventureId} — ${prov.reason} — blocking S19 advance.`);
+                // Merge, not replace — sibling gates write chairman-facing data into this row.
+                const { data: existingRow } = await this._supabase
+                  .from('venture_stage_work')
+                  .select('advisory_data')
+                  .eq('venture_id', ventureId).eq('lifecycle_stage', 19).maybeSingle();
+                await this._supabase.from('venture_stage_work').upsert({
+                  venture_id: ventureId,
+                  lifecycle_stage: 19,
+                  stage_status: 'blocked',
+                  work_type: 'sd_required',
+                  advisory_data: { ...(existingRow?.advisory_data || {}), reason: 'deploy_target_unprovisioned', detail: prov.reason },
+                }, { onConflict: 'venture_id,lifecycle_stage' });
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: 19, status: 'blocked', gate: 'deploy_target_unprovisioned', reason: prov.reason };
+                break;
+              }
+              this._logger.warn(`[Worker] S19 DEPLOY-PROVISIONING (observe-only — would block under enforce): venture ${ventureId} — ${prov.reason}`);
+            }
+          } catch (e) {
+            // The check itself failing is not this gate's enforcement to invent —
+            // fail-open with a loud log, same posture as the scaffold gate's catch.
+            this._logger.warn(`[Worker] S19 deploy-provisioning check failed (non-fatal, fail-open): ${e.message}`);
           }
         }
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -747,6 +747,33 @@ export class StageExecutionWorker {
           }
         }
 
+        // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-6): S19-entry deploy-target
+        // provisioning check (design §5 — provisioning executes at S19 entry beside the
+        // spend/stack gates; production deploy is an S19 exit requirement).
+        // OBSERVE-ONLY by default per the protocol default for new enforcement:
+        // S19_DEPLOY_PROVISIONING=observe logs the would-block; 'enforce' (post-
+        // calibration-review promotion) blocks like the scaffold gate above.
+        if (currentStage === 19) {
+          try {
+            const { checkDeployTargetProvisioned } = await import('../venture-deploy/provisioning-check.js');
+            const prov = await checkDeployTargetProvisioned(this._supabase, ventureId);
+            if (!prov.provisioned) {
+              const gateMode = process.env.S19_DEPLOY_PROVISIONING || 'observe';
+              if (gateMode === 'enforce') {
+                this._logger.error(`[Worker] S19 DEPLOY-PROVISIONING gate: venture ${ventureId} — ${prov.reason} — blocking S19 advance.`);
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: 19, status: 'blocked', gate: 'deploy_target_unprovisioned', reason: prov.reason };
+                break;
+              }
+              this._logger.warn(`[Worker] S19 DEPLOY-PROVISIONING (observe-only — would block under enforce): venture ${ventureId} — ${prov.reason}`);
+            }
+          } catch (e) {
+            // The check itself failing is not this gate's enforcement to invent —
+            // fail-open with a loud log, same posture as the scaffold gate's catch.
+            this._logger.warn(`[Worker] S19 deploy-provisioning check failed (non-fatal, fail-open): ${e.message}`);
+          }
+        }
+
         // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-2): DECISION-STATE-INDEPENDENT hard pre-advance S19
         // invariant gate. A leo_bridge venture MUST NOT pass Stage 19 until its orchestrator + all
         // child SDs are complete. Predecessor SD-LEO-INFRA-ENFORCE-S19-COMPLETION-001 only blocked

--- a/lib/venture-deploy/promote.js
+++ b/lib/venture-deploy/promote.js
@@ -126,8 +126,10 @@ export async function emitDeployUnreproducible(supabase, { ventureId, sha, stage
  * @param {{ fetchImpl?: typeof fetch, timeoutMs?: number, retries?: number }} [opts]
  * @returns {Promise<{ok: boolean, failures: string[]}>}
  */
-/** Hostname of a URL, or null when unparseable (treated as off-host, fail-closed). */
-function safeHost(url) {
+/** Hostname of a URL, or null when unparseable (treated as off-host, fail-closed).
+ * Exported so other probes (exit-gate verifiers) share ONE off-host semantics —
+ * two hand-rolled copies already diverged once (adversarial review, PR #5769). */
+export function safeHost(url) {
   try { return new URL(url).host; } catch { return null; }
 }
 

--- a/lib/venture-deploy/provisioning-check.js
+++ b/lib/venture-deploy/provisioning-check.js
@@ -1,0 +1,38 @@
+/**
+ * S19-entry deploy-target provisioning check (deploy-pipeline-architecture.md §5:
+ * "Provisioning executes at S19 entry, where the spend-guardrail + stack gates
+ * already live"; production deploy is an S19 exit requirement).
+ *
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-6).
+ *
+ * Uses the SAME predicate as verifyDeploymentTargetProvisioned (exit-gate
+ * verifiers): stack_descriptor.connection carries {provider, secret_ref} — the
+ * record sibling-B provisioning writes. Pure read, no side effects; the stage
+ * worker consumes it OBSERVE-ONLY by default (S19_DEPLOY_PROVISIONING=observe),
+ * promoting to 'enforce' only after the calibration review per the
+ * observe-only-first protocol default.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} ventureId
+ * @returns {Promise<{provisioned: boolean, reason: string}>}
+ */
+export async function checkDeployTargetProvisioned(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('stack_descriptor')
+    .eq('id', ventureId)
+    .maybeSingle();
+  if (error) {
+    return { provisioned: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+  }
+  const conn = data?.stack_descriptor?.connection;
+  if (!conn || typeof conn !== 'object' || !conn.provider || !conn.secret_ref) {
+    return {
+      provisioned: false,
+      reason: 'stack_descriptor.connection not provisioned (missing provider/secret_ref) — run the provisioning path before S19 exit',
+    };
+  }
+  return { provisioned: true, reason: '' };
+}
+
+export default { checkDeployTargetProvisioned };

--- a/lib/venture-deploy/provisioning-check.js
+++ b/lib/venture-deploy/provisioning-check.js
@@ -5,10 +5,12 @@
  *
  * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (FR-6).
  *
- * Uses the SAME predicate as verifyDeploymentTargetProvisioned (exit-gate
- * verifiers): stack_descriptor.connection carries {provider, secret_ref} — the
- * record sibling-B provisioning writes. Pure read, no side effects; the stage
- * worker consumes it OBSERVE-ONLY by default (S19_DEPLOY_PROVISIONING=observe),
+ * DELEGATES to the registered 'deployment target provisioned' exit-gate verifier
+ * (verifyDeploymentTargetProvisioned) rather than copying its predicate — the
+ * S19-entry check and the S19-exit gate must be the SAME question, and a copied
+ * predicate silently diverges when the provisioning record shape changes
+ * (adversarial review, PR #5769). Pure read, no side effects; the stage worker
+ * consumes it OBSERVE-ONLY by default (S19_DEPLOY_PROVISIONING=observe),
  * promoting to 'enforce' only after the calibration review per the
  * observe-only-first protocol default.
  *
@@ -16,23 +18,17 @@
  * @param {string} ventureId
  * @returns {Promise<{provisioned: boolean, reason: string}>}
  */
+import { resolveVerifier } from '../eva/lifecycle/exit-gate-verifiers.js';
+
 export async function checkDeployTargetProvisioned(supabase, ventureId) {
-  const { data, error } = await supabase
-    .from('ventures')
-    .select('stack_descriptor')
-    .eq('id', ventureId)
-    .maybeSingle();
-  if (error) {
-    return { provisioned: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+  const verifier = resolveVerifier('deployment target provisioned');
+  if (!verifier) {
+    // Registry drift (the gate string disappeared) is a fail-closed condition —
+    // an unanswerable provisioning question must never read as provisioned.
+    return { provisioned: false, reason: "no verifier registered for 'deployment target provisioned' (fail-closed)" };
   }
-  const conn = data?.stack_descriptor?.connection;
-  if (!conn || typeof conn !== 'object' || !conn.provider || !conn.secret_ref) {
-    return {
-      provisioned: false,
-      reason: 'stack_descriptor.connection not provisioned (missing provider/secret_ref) — run the provisioning path before S19 exit',
-    };
-  }
-  return { provisioned: true, reason: '' };
+  const result = await verifier({ supabase, ventureId });
+  return { provisioned: result.satisfied === true, reason: result.reason || '' };
 }
 
 export default { checkDeployTargetProvisioned };

--- a/tests/unit/eva/launch-mode-residual.test.js
+++ b/tests/unit/eva/launch-mode-residual.test.js
@@ -65,6 +65,17 @@ function flipFakeSb({
           update: (patch) => ({ eq: (col, val) => { log.confirms.push({ patch, id: val }); return Promise.resolve({ error: null }); } }),
         };
       }
+      if (table === 'venture_deployments') {
+        // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D FR-5: the deploy precondition
+        // reads the latest routed row. These residual tests predate the table; no
+        // routed row + default observe mode preserves every prior expectation
+        // (violation logged, flip semantics unchanged).
+        const chain = {
+          select: () => chain, eq: () => chain, order: () => chain, limit: () => chain,
+          maybeSingle: () => Promise.resolve({ data: null, error: null }),
+        };
+        return chain;
+      }
       throw new Error('unexpected table ' + table);
     },
   };

--- a/tests/unit/venture-deploy-gate-wiring.test.js
+++ b/tests/unit/venture-deploy-gate-wiring.test.js
@@ -1,0 +1,212 @@
+/**
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (PR 2/2) — gate wiring:
+ * verifier dual-read + live-probe (FR-3), launch_mode deploy precondition (FR-5),
+ * S19 deploy-provisioning check (FR-6). Mocks confined to the DB/HTTP boundary.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolveVerifier } from '../../lib/eva/lifecycle/exit-gate-verifiers.js';
+import { setLaunchMode } from '../../lib/eva/launch-mode.js';
+import { checkDeployTargetProvisioned } from '../../lib/venture-deploy/provisioning-check.js';
+
+const verifyPagesUrlLive = resolveVerifier('pages url live');
+const verifyComputeDeployed = resolveVerifier('compute deployed');
+
+/** Multi-table chainable mock: ventures / venture_deployments / chairman_decisions / launch_mode_audit. */
+function mockSupabase({
+  stackDescriptor = null,
+  launchMode = 'simulated',
+  routedRows = [],
+  deploymentsError = null,
+  decision = null,
+} = {}) {
+  const state = { auditRows: [], ventureUpdates: [] };
+  const api = {
+    state,
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select: (cols) => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: cols.includes('launch_mode')
+                  ? { id: 'v1', launch_mode: launchMode }
+                  : { stack_descriptor: stackDescriptor },
+                error: null,
+              }),
+            }),
+          }),
+          update(patch) {
+            const chain = {
+              eq: () => chain,
+              select: async () => { state.ventureUpdates.push(patch); return { data: [{ id: 'v1' }], error: null }; },
+            };
+            return chain;
+          },
+        };
+      }
+      if (table === 'venture_deployments') {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          order: () => chain,
+          limit: () => chain,
+          maybeSingle: async () => deploymentsError
+            ? { data: null, error: { message: deploymentsError } }
+            : { data: routedRows[routedRows.length - 1] ?? null, error: null },
+        };
+        return chain;
+      }
+      if (table === 'chairman_decisions') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: decision, error: null }) }) }),
+        };
+      }
+      if (table === 'launch_mode_audit') {
+        return {
+          insert(row) {
+            return {
+              select: () => ({
+                single: async () => {
+                  const rec = { id: `audit-${state.auditRows.length + 1}`, ...row };
+                  state.auditRows.push(rec);
+                  return { data: { id: rec.id }, error: null };
+                },
+              }),
+            };
+          },
+          update: () => ({ eq: async () => ({ data: null, error: null }) }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+  return api;
+}
+
+const APPROVED_DECISION = { id: 'dec-1', decided_by: 'chairman', venture_id: 'v1', status: 'approved' };
+const LEGACY_PUBLISHED = { publish: { status: 'published', deploymentUrl: 'https://legacy.example' } };
+
+afterEach(() => { delete process.env.LAUNCH_MODE_DEPLOY_PRECONDITION; });
+
+describe('FR-3: verifyComputeDeployed dual-read (TS-5)', () => {
+  it('passes on a routed venture_deployments row with no legacy publish record', async () => {
+    const supabase = mockSupabase({ routedRows: [{ id: 'dep-1', url: 'https://live.example' }] });
+    expect((await verifyComputeDeployed({ supabase, ventureId: 'v1' })).satisfied).toBe(true);
+  });
+
+  it('passes on legacy publish record only (transition path, retirement criterion documented)', async () => {
+    const supabase = mockSupabase({ stackDescriptor: LEGACY_PUBLISHED });
+    expect((await verifyComputeDeployed({ supabase, ventureId: 'v1' })).satisfied).toBe(true);
+  });
+
+  it('fails closed with neither', async () => {
+    const supabase = mockSupabase({ stackDescriptor: {} });
+    const r = await verifyComputeDeployed({ supabase, ventureId: 'v1' });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/fail-closed/);
+  });
+
+  it('deployments query fault falls through to the legacy read (dual-read exists for this)', async () => {
+    const supabase = mockSupabase({ deploymentsError: 'relation does not exist', stackDescriptor: LEGACY_PUBLISHED });
+    expect((await verifyComputeDeployed({ supabase, ventureId: 'v1' })).satisfied).toBe(true);
+  });
+});
+
+describe('FR-3: verifyPagesUrlLive live-probe (TS-4)', () => {
+  it('recorded URL that does not serve is fail-closed — the probe is load-bearing (R3)', async () => {
+    const supabase = mockSupabase({ routedRows: [{ id: 'dep-1', url: 'https://dead.example' }] });
+    const fetchImpl = vi.fn(async () => ({ status: 503 }));
+    const r = await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/not serving/);
+  });
+
+  it('routed row URL that serves 2xx passes', async () => {
+    const supabase = mockSupabase({ routedRows: [{ id: 'dep-1', url: 'https://live.example' }] });
+    const fetchImpl = vi.fn(async () => ({ status: 200 }));
+    expect((await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl })).satisfied).toBe(true);
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('legacy publish URL is also live-probed (probe applies to BOTH sources)', async () => {
+    const supabase = mockSupabase({ stackDescriptor: LEGACY_PUBLISHED });
+    const fetchImpl = vi.fn(async () => ({ status: 200 }));
+    expect((await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl })).satisfied).toBe(true);
+  });
+
+  it('no URL anywhere is fail-closed without probing', async () => {
+    const supabase = mockSupabase({ stackDescriptor: {} });
+    const fetchImpl = vi.fn();
+    const r = await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl });
+    expect(r.satisfied).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('FR-5: launch_mode deploy precondition (TS-6)', () => {
+  it('observe mode (default): live-flip without a routed deploy PROCEEDS with a logged violation', async () => {
+    const supabase = mockSupabase({ decision: APPROVED_DECISION, launchMode: 'simulated' });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const r = await setLaunchMode({ supabase, ventureId: 'v1', toMode: 'live', decision: { id: 'dec-1' } });
+      expect(r.flipped).toBe(true);
+      expect(spy.mock.calls.map((c) => c.join(' ')).join('\n')).toMatch(/DEPLOY-PRECONDITION VIOLATION/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('enforce mode: live-flip without a routed deploy is BLOCKED citing no_production_deploy', async () => {
+    process.env.LAUNCH_MODE_DEPLOY_PRECONDITION = 'enforce';
+    const supabase = mockSupabase({ decision: APPROVED_DECISION, launchMode: 'simulated' });
+    const r = await setLaunchMode({ supabase, ventureId: 'v1', toMode: 'live', decision: { id: 'dec-1' } });
+    expect(r.flipped).toBe(false);
+    expect(r.reason).toMatch(/no_production_deploy/);
+    expect(supabase.state.auditRows).toHaveLength(0); // blocked before audit write
+  });
+
+  it('enforce mode: live-flip WITH a routed deploy proceeds', async () => {
+    process.env.LAUNCH_MODE_DEPLOY_PRECONDITION = 'enforce';
+    const supabase = mockSupabase({
+      decision: APPROVED_DECISION, launchMode: 'simulated',
+      routedRows: [{ id: 'dep-1' }],
+    });
+    const r = await setLaunchMode({ supabase, ventureId: 'v1', toMode: 'live', decision: { id: 'dec-1' } });
+    expect(r.flipped).toBe(true);
+  });
+
+  it('flips to simulated are never gated (emergency rollback path untouched)', async () => {
+    process.env.LAUNCH_MODE_DEPLOY_PRECONDITION = 'enforce';
+    const supabase = mockSupabase({ decision: APPROVED_DECISION, launchMode: 'live' });
+    const r = await setLaunchMode({ supabase, ventureId: 'v1', toMode: 'simulated', decision: { id: 'dec-1' } });
+    expect(r.flipped).toBe(true);
+  });
+
+  it('existing decision semantics unchanged: non-approved decision still blocks (regression)', async () => {
+    const supabase = mockSupabase({ decision: { ...APPROVED_DECISION, status: 'rejected' } });
+    const r = await setLaunchMode({ supabase, ventureId: 'v1', toMode: 'live', decision: { id: 'dec-1' } });
+    expect(r.flipped).toBe(false);
+    expect(r.reason).toMatch(/decision_not_approved/);
+  });
+});
+
+describe('FR-6: checkDeployTargetProvisioned (TS-7)', () => {
+  it('provisioned when stack_descriptor.connection carries provider + secret_ref', async () => {
+    const supabase = mockSupabase({ stackDescriptor: { connection: { provider: 'neon', secret_ref: 'sm://x' } } });
+    expect((await checkDeployTargetProvisioned(supabase, 'v1')).provisioned).toBe(true);
+  });
+
+  it('unprovisioned (missing connection) reports the honest cause', async () => {
+    const supabase = mockSupabase({ stackDescriptor: {} });
+    const r = await checkDeployTargetProvisioned(supabase, 'v1');
+    expect(r.provisioned).toBe(false);
+    expect(r.reason).toMatch(/not provisioned/);
+  });
+
+  it('query error is fail-closed with the true cause (never a silent pass)', async () => {
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: { message: 'boom' } }) }) }) }) };
+    const r = await checkDeployTargetProvisioned(supabase, 'v1');
+    expect(r.provisioned).toBe(false);
+    expect(r.reason).toMatch(/boom/);
+  });
+});

--- a/tests/unit/venture-deploy-gate-wiring.test.js
+++ b/tests/unit/venture-deploy-gate-wiring.test.js
@@ -132,6 +132,25 @@ describe('FR-3: verifyPagesUrlLive live-probe (TS-4)', () => {
     const supabase = mockSupabase({ stackDescriptor: LEGACY_PUBLISHED });
     const fetchImpl = vi.fn(async () => ({ status: 200 }));
     expect((await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl })).satisfied).toBe(true);
+    // The probe must actually run on the legacy path — a skipped probe would
+    // also return satisfied:true and make this test's name a lie.
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('legacy publish URL that is DEAD is fail-closed (the transition path gets no probe exemption)', async () => {
+    const supabase = mockSupabase({ stackDescriptor: LEGACY_PUBLISHED });
+    const fetchImpl = vi.fn(async () => ({ status: 503 }));
+    const r = await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/not serving/);
+  });
+
+  it('a cross-origin redirect to a healthy 200 is fail-closed (off-host, shared safeHost semantics)', async () => {
+    const supabase = mockSupabase({ routedRows: [{ id: 'dep-1', url: 'https://live.example' }] });
+    const fetchImpl = vi.fn(async () => ({ status: 200, url: 'https://parked.other.example/' }));
+    const r = await verifyPagesUrlLive({ supabase, ventureId: 'v1', fetchImpl });
+    expect(r.satisfied).toBe(false);
+    expect(r.reason).toMatch(/off-host/);
   });
 
   it('no URL anywhere is fail-closed without probing', async () => {

--- a/tests/unit/venture-publish.test.js
+++ b/tests/unit/venture-publish.test.js
@@ -143,11 +143,16 @@ describe('FR-3: fail-closed post-publish verifiers', () => {
     expect(resolveVerifier('compute deployed')).not.toBe(resolveVerifier('application deployed'));
   });
 
-  it('pages-url-live: PASS when recorded, fail-closed when absent / on error', async () => {
+  it('pages-url-live: PASS when recorded AND serving, fail-closed when absent / on error', async () => {
     const v = resolveVerifier('pages url live');
-    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: PUBLISHED } }), ventureId: VENTURE })).satisfied).toBe(true);
-    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: VENTURE })).satisfied).toBe(false);
-    expect((await v({ supabase: fakeSupabase({ ventureError: { message: 'boom' } }), ventureId: VENTURE })).satisfied).toBe(false);
+    // SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D FR-3 (design R3): the row alone is no
+    // longer sufficient — the URL must also live-probe. fetchImpl injected here so this
+    // stays a unit test; the recorded-but-dead case is covered in
+    // venture-deploy-gate-wiring.test.js.
+    const alive = async () => ({ status: 200 });
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: PUBLISHED } }), ventureId: VENTURE, fetchImpl: alive })).satisfied).toBe(true);
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: VENTURE, fetchImpl: alive })).satisfied).toBe(false);
+    expect((await v({ supabase: fakeSupabase({ ventureError: { message: 'boom' } }), ventureId: VENTURE, fetchImpl: alive })).satisfied).toBe(false);
   });
 
   it('compute-deployed: PASS only when status published, fail-closed otherwise', async () => {


### PR DESCRIPTION
## Summary
Completes SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-D (PR 1/2 was #5763: promote() + venture_deployments + findings). Wires the deploy record into the gates:
- **FR-3**: `verifyComputeDeployed`/`verifyPagesUrlLive` dual-read — canonical `venture_deployments` routed row OR legacy `stack_descriptor.publish` (transition; retirement criterion in-code per DORMANT-EXIT-001). **`verifyPagesUrlLive` now actually live-probes** (design R3 — the prior code trusted the recorded URL alone).
- **FR-5**: `setLaunchMode(live)` deployment-record precondition behind `LAUNCH_MODE_DEPLOY_PRECONDITION` (default **observe** — loud violation, flip proceeds; `enforce` blocks pre-audit). Decision/audit semantics untouched.
- **FR-6**: S19-entry deploy-provisioning check, observe-only via `S19_DEPLOY_PROVISIONING` (default observe), enforce path mirrors the sibling scaffold gate.

All new enforcement ships observe-only-first per the protocol default.

## Test plan
- [x] 16 new wiring tests (dual-read matrix, live-probe load-bearing, observe/enforce/simulated-ungated launch-mode matrix, provisioning check fail-closed)
- [x] 123 green across affected families (launch-mode, launch-mode-residual, eva/lifecycle, venture-deploy promote/preview/publish)
- [x] Pre-existing suites migrated not loosened (residual mock extended for the new table read; publish pages-url-live test injects a serving probe per the new R3 contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)