### PR TITLE
feat(SD-ARCH-HOTSPOT-SD-START-001): dispatch-auth born-un-authorized polarity, observe-first (PR-B of 2)

### DIFF
--- a/lib/claim/gates/dispatch-authorization.cjs
+++ b/lib/claim/gates/dispatch-authorization.cjs
@@ -1,0 +1,145 @@
+/**
+ * Dispatch-authorization gate — the SD-2 phase-1 POLARITY FLIP, shipped safe.
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-7 (coupling rule Adam d56fa60a: fold the flip
+ * INTO this door; no separate SD-2 build).
+ *
+ * WHAT FLIPS: SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 shipped
+ * isDispatchAuthorized as OPT-IN (only SDs stamped metadata.dispatch_auth_required
+ * === true are checked — everything else is born CLAIMABLE, fail-open). This gate
+ * inverts that polarity when active: EVERY SD is born UN-authorized until a
+ * dispatch_auth disposition grant exists (fail-closed), per the deferred
+ * "separately-scoped coordinated cutover" SD-2's LEAD explicitly carved out.
+ *
+ * WHY IT CANNOT FREEZE THE BELT (the exact risk SD-2 deferred over):
+ *   1. MODE LADDER, off by default. leo_feature_flags has no variant/metadata
+ *      column, so the three modes ride TWO boolean flags (strictly more
+ *      auditable than a metadata field; prospective-testing D7 adapted):
+ *        dispatch_auth_born_denied          absent/disabled  → mode 'off'   (byte-identical behavior)
+ *        dispatch_auth_born_denied  enabled, enforce flag off → mode 'observe'
+ *        + dispatch_auth_born_denied_enforce enabled          → mode 'enforce'
+ *      Any evaluator error → 'off' (fail-soft, coordinator-backlog-rank precedent).
+ *   2. OBSERVE NEVER BLOCKS: it returns {authorized:true, would_deny:true} and
+ *      the callers log ONE structured WOULD-DENY line — the observe-window
+ *      evidence for the later enforce flip.
+ *   3. ENFORCE is implemented + tested but DORMANT: flipping it on is a later
+ *      data-only cutover gated on the backfill verification (zero un-granted
+ *      claimables — scripts/backfill-dispatch-auth-grants.mjs).
+ *
+ * AUTHORITY ALLOWLIST (implements the claim-eligibility.cjs L421-425 TODO —
+ * specified by SD-2's adversarial review, never built): a disposition row only
+ * authorizes when payload.authority ∈ {chairman, coordinator, backfill-cutover}.
+ * Any other authority (e.g. a worker session granting itself) is treated as
+ * UN-granted — never trust a recorded grant regardless of who recorded it.
+ *
+ * HOOK PLACEMENT (prospective-testing D8): callers wire this AFTER every other
+ * eligibility gate and IMMEDIATELY BEFORE the claim write (checkin: between
+ * parentLeadPending and tryClaim; sd-start: just before claim_sd) so the
+ * observe-mode WOULD-DENY set equals exactly the set enforce would block.
+ * PHASE-1 LANES: the two SELF-CLAIM lanes only. Checkin's orphan-adopt and
+ * directed WORK_ASSIGNMENT lanes are deliberate exemptions — coordinator-
+ * initiated lanes carry their own authorization semantics (the directed_assign
+ * IS the authorization); they are the enumerated phase-2 enforcement surface.
+ *
+ * @module lib/claim/gates/dispatch-authorization
+ */
+'use strict';
+
+/** Who may grant dispatch authorization (claim-eligibility L421-425 spec). */
+const DISPATCH_AUTH_AUTHORITY_ALLOWLIST = Object.freeze(['chairman', 'coordinator', 'backfill-cutover']);
+
+const BASE_FLAG = 'dispatch_auth_born_denied';
+const ENFORCE_FLAG = 'dispatch_auth_born_denied_enforce';
+
+/**
+ * Resolve the gate mode from the two-flag ladder. Resolve ONCE per CLI pass
+ * (the evaluator's 30s per-process cache makes repeat calls cheap but the
+ * single resolve keeps a pass internally consistent).
+ * @param {{isEnabledFn?: (flagKey: string) => Promise<boolean>}} [opts] test seam
+ * @returns {Promise<'off'|'observe'|'enforce'>}
+ */
+async function resolveDispatchAuthMode({ isEnabledFn } = {}) {
+  try {
+    let isEnabled = isEnabledFn;
+    if (typeof isEnabled !== 'function') {
+      ({ isEnabled } = await import('../../feature-flags/evaluator.js'));
+    }
+    if (!(await isEnabled(BASE_FLAG))) return 'off';
+    return (await isEnabled(ENFORCE_FLAG)) ? 'enforce' : 'observe';
+  } catch {
+    return 'off'; // fail-soft: a flag-infrastructure fault never changes claim behavior
+  }
+}
+
+/**
+ * Evaluate born-un-authorized dispatch authorization for an SD.
+ *
+ * @param {object} sd - SD row (needs sd_key)
+ * @param {object} supabase - service client
+ * @param {object} opts
+ * @param {'off'|'observe'|'enforce'} opts.mode - from resolveDispatchAuthMode (caller-resolved)
+ * @param {Function} [opts.getDispositionBySubjectFn] - test seam over lib/decision-binding/disposition.js
+ * @returns {Promise<{authorized: boolean, mode: string, would_deny?: boolean, reason?: string, authority?: string}>}
+ *   off     → {authorized:true, mode:'off'} with ZERO lookups
+ *   observe → granted: {authorized:true, mode}; un-granted: {authorized:true, would_deny:true, reason}
+ *   enforce → granted: {authorized:true, mode}; un-granted: {authorized:false, reason:'dispatch_auth_pending'}
+ */
+async function evaluateDispatchAuthorization(sd, supabase, { mode = 'off', getDispositionBySubjectFn } = {}) {
+  if (mode !== 'observe' && mode !== 'enforce') {
+    return { authorized: true, mode: 'off' };
+  }
+  const sdKey = sd && sd.sd_key;
+  if (!sdKey) {
+    // No subject identity to check a grant against — surface it, never crash a claim.
+    const reason = 'dispatch_auth_unresolvable_subject';
+    return mode === 'observe'
+      ? { authorized: true, mode, would_deny: true, reason }
+      : { authorized: false, mode, reason };
+  }
+
+  let grant = null;
+  let readError = null;
+  try {
+    let getBySubject = getDispositionBySubjectFn;
+    if (typeof getBySubject !== 'function') {
+      ({ getDispositionBySubject: getBySubject } = await import('../../decision-binding/disposition.js'));
+    }
+    grant = await getBySubject(supabase, 'dispatch_auth', { subject_id: sdKey, gate_type: 'dispatch' });
+  } catch (e) {
+    readError = (e && e.message) || String(e);
+  }
+
+  const payload = grant && grant.payload;
+  const statusOk = payload && (payload.status === 'dispositioned' || payload.status === 'consumed');
+  const authorityOk = payload && DISPATCH_AUTH_AUTHORITY_ALLOWLIST.includes(payload.authority);
+
+  if (statusOk && authorityOk) {
+    return { authorized: true, mode, authority: payload.authority };
+  }
+
+  // Un-granted (absent, pending, read error, or non-allowlisted authority).
+  // Fail-closed semantics per the decision-binding principle: absence never
+  // authorizes — but observe mode converts the denial into evidence only.
+  const reason = readError
+    ? `dispatch_auth_read_error: ${readError}`
+    : statusOk && !authorityOk
+      ? `dispatch_auth_authority_not_allowlisted: ${payload.authority}`
+      : 'dispatch_auth_pending';
+
+  return mode === 'observe'
+    ? { authorized: true, mode, would_deny: true, reason }
+    : { authorized: false, mode, reason };
+}
+
+/** One consistent WOULD-DENY line for both CLIs (the observe-window evidence). */
+function formatWouldDenyLine(sdKey, verdict, lane) {
+  return `DISPATCH_AUTH_WOULD_DENY sd=${sdKey} lane=${lane} reason=${verdict.reason} (observe mode — claim proceeds; SD-ARCH-HOTSPOT-SD-START-001 FR-7)`;
+}
+
+module.exports = {
+  resolveDispatchAuthMode,
+  evaluateDispatchAuthorization,
+  formatWouldDenyLine,
+  DISPATCH_AUTH_AUTHORITY_ALLOWLIST,
+  BASE_FLAG,
+  ENFORCE_FLAG,
+};

--- a/scripts/backfill-dispatch-auth-grants.mjs
+++ b/scripts/backfill-dispatch-auth-grants.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Dispatch-authorization grant backfill + pre-flip verification.
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-8 — ships INERT (dry-run default, never auto-runs).
+ *
+ * PURPOSE: before the born-un-authorized polarity may flip to ENFORCE
+ * (dispatch_auth_born_denied_enforce flag), every currently belt-claimable SD
+ * must hold a dispatch_auth disposition grant — otherwise the flip freezes the
+ * whole belt (the exact risk SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001's
+ * LEAD deferred the flip over). This tool:
+ *   1. Enumerates the claimable set — the same status surface worker-checkin
+ *      claims from: draft / active / planning / ready / in_progress /
+ *      pending_approval (terminal statuses excluded).
+ *   2. Reports which already hold a grant (idempotent: recordDisposition
+ *      dedups on the content-derived question key, 23505-race safe).
+ *   3. DRY-RUN (default): prints the enumeration + the PRE-FLIP VERIFICATION
+ *      (un-granted claimable count — must be ZERO before enforce) and writes
+ *      NOTHING.
+ *   4. --apply: writes one grant per un-granted claimable via recordDisposition
+ *      (authority='backfill-cutover', on the gate's allowlist), then re-runs
+ *      the verification.
+ *
+ * Usage:
+ *   node scripts/backfill-dispatch-auth-grants.mjs            # dry-run (default)
+ *   node scripts/backfill-dispatch-auth-grants.mjs --apply    # write grants
+ *
+ * The enforce flip itself is NOT this tool's job — it is a later coordinated
+ * cutover (chairman/coordinator) gated on this tool's verification reading 0.
+ */
+
+import 'dotenv/config';
+import { createSupabaseServiceClient } from './lib/supabase-connection.js';
+import { recordDisposition, getDispositionBySubject } from '../lib/decision-binding/disposition.js';
+import { DISPATCH_AUTH_AUTHORITY_ALLOWLIST } from '../lib/claim/gates/dispatch-authorization.cjs';
+
+/** The worker-checkin claimable status surface (terminal statuses excluded). */
+export const CLAIMABLE_STATUSES = ['draft', 'active', 'planning', 'ready', 'in_progress', 'pending_approval'];
+const BACKFILL_AUTHORITY = 'backfill-cutover';
+
+export async function enumerateClaimables(supabase) {
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status')
+    .in('status', CLAIMABLE_STATUSES)
+    .not('sd_key', 'is', null);
+  if (error) throw new Error(`claimable enumeration failed: ${error.message}`);
+  return data || [];
+}
+
+/** Partition claimables into granted / unGranted by live disposition reads. */
+export async function verifyGrantCoverage(supabase, claimables) {
+  const granted = [];
+  const unGranted = [];
+  for (const sd of claimables) {
+    const row = await getDispositionBySubject(supabase, 'dispatch_auth', { subject_id: sd.sd_key, gate_type: 'dispatch' });
+    const p = row && row.payload;
+    const ok = p && (p.status === 'dispositioned' || p.status === 'consumed')
+      && DISPATCH_AUTH_AUTHORITY_ALLOWLIST.includes(p.authority);
+    (ok ? granted : unGranted).push(sd);
+  }
+  return { granted, unGranted };
+}
+
+export async function applyGrants(supabase, unGranted) {
+  const results = { created: 0, reused: 0, failed: [] };
+  for (const sd of unGranted) {
+    try {
+      const { created } = await recordDisposition(supabase, {
+        decisionType: 'dispatch_auth',
+        subject: { subject_id: sd.sd_key, gate_type: 'dispatch' },
+        decisionKey: 'backfill-cutover-grant',
+        authority: BACKFILL_AUTHORITY,
+        status: 'dispositioned',
+        answerPayload: {
+          granted_by: 'backfill-dispatch-auth-grants.mjs',
+          reason: 'pre-enforce cutover backfill (SD-ARCH-HOTSPOT-SD-START-001 FR-8)',
+          sd_status_at_grant: sd.status,
+        },
+      });
+      if (created) results.created += 1; else results.reused += 1;
+    } catch (e) {
+      results.failed.push({ sd_key: sd.sd_key, error: e.message });
+    }
+  }
+  return results;
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = createSupabaseServiceClient();
+
+  console.log(`dispatch-auth grant backfill — mode: ${apply ? 'APPLY' : 'DRY-RUN (pass --apply to write)'}`);
+  const claimables = await enumerateClaimables(supabase);
+  console.log(`claimable belt surface (${CLAIMABLE_STATUSES.join('/')}): ${claimables.length} SD(s)`);
+
+  const before = await verifyGrantCoverage(supabase, claimables);
+  console.log(`already granted: ${before.granted.length} | un-granted: ${before.unGranted.length}`);
+
+  if (!apply) {
+    for (const sd of before.unGranted.slice(0, 25)) console.log(`  would grant: ${sd.sd_key} (${sd.status})`);
+    if (before.unGranted.length > 25) console.log(`  … and ${before.unGranted.length - 25} more`);
+    console.log(`\nPRE-FLIP VERIFICATION: ${before.unGranted.length} claimable SD(s) lack a grant — must be 0 before dispatch_auth_born_denied_enforce may be enabled.`);
+    console.log('DRY-RUN complete — nothing written.');
+    return;
+  }
+
+  const results = await applyGrants(supabase, before.unGranted);
+  console.log(`grants written: ${results.created} created, ${results.reused} reused (idempotent), ${results.failed.length} failed`);
+  for (const f of results.failed) console.log(`  FAILED ${f.sd_key}: ${f.error}`);
+
+  const after = await verifyGrantCoverage(supabase, claimables);
+  console.log(`\nPRE-FLIP VERIFICATION (post-apply): ${after.unGranted.length} claimable SD(s) lack a grant — must be 0 before the enforce flip.`);
+  process.exitCode = after.unGranted.length === 0 && results.failed.length === 0 ? 0 : 1;
+}
+
+// Only run as a CLI (the exported helpers are unit-tested directly).
+if (process.argv[1] && process.argv[1].endsWith('backfill-dispatch-auth-grants.mjs')) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -101,6 +101,8 @@ const { verifyHandoffIntegrity: verifyHandoffIntegrityGate } = cjsRequire('../li
 const { evaluateCadenceGate } = cjsRequire('../lib/claim/gates/cadence-gate.cjs');
 const queueResolver = cjsRequire('../lib/claim/queue-resolver.cjs');
 const { classifyAllDispatchIneligibility } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
+// SD-ARCH-HOTSPOT-SD-START-001 FR-7: dispatch-authorization polarity gate (flag-gated, observe-first).
+const dispatchAuthGate = cjsRequire('../lib/claim/gates/dispatch-authorization.cjs');
 
 // SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: pre-claim DEPENDENCY gate.
 // Dependency BLOCKS were advisory-only (computed by the sweep/dashboard but never
@@ -903,6 +905,24 @@ async function main() {
       console.log(`\n${colors.yellow}Note: Session already working on ${effectiveId}, refreshing claim...${colors.reset}`);
     } else if (session.adopted_sd_id) {
       console.log(`\n${colors.yellow}Note: Session currently working on ${session.adopted_sd_id}, switching to ${effectiveId}${colors.reset}`);
+    }
+  }
+
+  // 2.9. SD-ARCH-HOTSPOT-SD-START-001 FR-7 (D8 placement): dispatch-authorization
+  // check AFTER every eligibility gate, immediately BEFORE the claim write — the
+  // observe-mode WOULD-DENY set equals exactly what enforce mode would block.
+  // Flag ladder absent => mode 'off' => zero lookups, byte-identical behavior.
+  {
+    const authMode = await dispatchAuthGate.resolveDispatchAuthMode();
+    const authVerdict = await dispatchAuthGate.evaluateDispatchAuthorization(sd, supabase, { mode: authMode });
+    if (authVerdict.would_deny) {
+      console.log(`${colors.yellow}${dispatchAuthGate.formatWouldDenyLine(effectiveId, authVerdict, 'sd_start_direct_claim')}${colors.reset}`);
+    }
+    if (!authVerdict.authorized) {
+      console.log(`\n${colors.red}${colors.bold}🚫 ${effectiveId} is not dispatch-authorized (born-un-authorized polarity, enforce mode)${colors.reset}`);
+      console.log(`   reason: ${authVerdict.reason}`);
+      console.log(`   ${colors.dim}Grant path: a chairman/coordinator dispatch_auth disposition (see scripts/backfill-dispatch-auth-grants.mjs for the cutover tool).${colors.reset}`);
+      process.exit(1);
     }
   }
 

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1137,6 +1137,26 @@ async function main() {
         }
 
         console.log(`${colors.dim}   Attempt ${fallbackAttempt}/${MAX_FALLBACK_ATTEMPTS}: Trying ${nextSD.sdKey} — ${nextSD.title}${colors.reset}`);
+
+        // SD-ARCH-HOTSPOT-SD-START-001 FR-7 (self-review gap fix): the fallback lane
+        // claims a DIFFERENT SD than the one gated at 2.9 — without this check the
+        // enforce mode would be bypassed (and observe would under-count) on exactly
+        // this lane. Skip-polarity here (iterate to the next candidate), matching
+        // checkin's self-claim semantics rather than sd-start's loud direct refusal.
+        {
+          const fbAuthMode = await dispatchAuthGate.resolveDispatchAuthMode();
+          const fbVerdict = await dispatchAuthGate.evaluateDispatchAuthorization({ sd_key: nextSD.sdKey }, supabase, { mode: fbAuthMode });
+          if (fbVerdict.would_deny) {
+            console.log(`${colors.yellow}${dispatchAuthGate.formatWouldDenyLine(nextSD.sdKey, fbVerdict, 'sd_start_fallback_claim')}${colors.reset}`);
+          }
+          if (!fbVerdict.authorized) {
+            skippedSDs.push({ sdKey: nextSD.sdKey, reason: `dispatch_auth: ${fbVerdict.reason}` });
+            excludeKeys.push(nextSD.sdKey);
+            console.log(`${colors.yellow}   ⚠️  ${nextSD.sdKey} not dispatch-authorized (enforce mode) — skipping${colors.reset}`);
+            continue;
+          }
+        }
+
         claimResult = await claimGuard(nextSD.sdKey, session.session_id, { autoFallback: true });
 
         if (claimResult.success) {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -53,6 +53,17 @@ const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligib
 // blocking, unresolved, AND query error — the exact draftDepsSatisfied semantics it replaces
 // (with uuid-shaped refs now RESOLVING instead of dangling, a resolution-accuracy fix only).
 const { evaluateClaimDependencyGate, depsSatisfiedFromVerdict } = require('../lib/claim/gates/dependency-gate.cjs');
+// SD-ARCH-HOTSPOT-SD-START-001 FR-7: the SD-2 phase-1 dispatch-authorization polarity flip,
+// flag-gated (two-flag ladder, absent=off=byte-identical) + OBSERVE-ONLY first. Wired on the
+// SELF-CLAIM lane only (orphan-adopt + directed WORK_ASSIGNMENT are documented exemptions —
+// coordinator-initiated lanes carry their own authorization; the phase-2 enforcement surface).
+const dispatchAuth = require('../lib/claim/gates/dispatch-authorization.cjs');
+// Resolve the mode ONCE per CLI pass (one-shot process) — prospective-testing D8.
+let _dispatchAuthModePromise = null;
+function getDispatchAuthMode() {
+  if (!_dispatchAuthModePromise) _dispatchAuthModePromise = dispatchAuth.resolveDispatchAuthMode();
+  return _dispatchAuthModePromise;
+}
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
 const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank } = require('../lib/fleet/tier-ladder.cjs');
@@ -840,6 +851,13 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   // otherwise drive PLAN then hit the hard EXEC-transition block). Fail-open inside parentLeadPending.
   if (await parentLeadPending(sb, d)) return null;
   if (await isSdInFlight(sb, d.sd_key, sessionId)) return null; // dedup: started or live-foreign-held
+  // SD-ARCH-HOTSPOT-SD-START-001 FR-7 (D8 placement): AFTER every other gate, immediately
+  // BEFORE the claim write — so the observe-mode WOULD-DENY set equals exactly the set
+  // enforce mode would block. Observe NEVER blocks; enforce refuses (dormant until the
+  // backfill-verified cutover flips the enforce flag).
+  const authVerdict = await dispatchAuth.evaluateDispatchAuthorization(d, sb, { mode: await getDispatchAuthMode() });
+  if (authVerdict.would_deny) console.log(dispatchAuth.formatWouldDenyLine(d.sd_key, authVerdict, 'checkin_self_claim'));
+  if (!authVerdict.authorized) return null; // enforce mode: born-un-authorized SD skipped
   const claimed = await tryClaim(sb, d.sd_key, sessionId);
   if (claimed.ok) {
     return {

--- a/tests/unit/claim/gates/dispatch-authorization.test.js
+++ b/tests/unit/claim/gates/dispatch-authorization.test.js
@@ -123,6 +123,27 @@ describe('WIRING PINS (D8 placement + lane exemptions)', () => {
     expect(claimIdx).toBeGreaterThan(authIdx);
     expect(sdStart.slice(authIdx, claimIdx)).toMatch(/process\.exit\(1\)/); // enforce refusal path
   });
+
+  it('sd-start: the auto-FALLBACK lane is ALSO gated (self-review gap fix) with skip-polarity before its claimGuard', () => {
+    const fbIdx = sdStart.indexOf('evaluateDispatchAuthorization({ sd_key: nextSD.sdKey }');
+    expect(fbIdx).toBeGreaterThan(0);
+    const fbClaimIdx = sdStart.indexOf('claimGuard(nextSD.sdKey, session.session_id, { autoFallback: true })');
+    expect(fbClaimIdx).toBeGreaterThan(fbIdx); // check precedes the fallback claim write
+    const between = sdStart.slice(fbIdx, fbClaimIdx);
+    expect(between).toMatch(/sd_start_fallback_claim/);      // observe logging on this lane
+    expect(between).toMatch(/continue;/);                    // skip-polarity, not process.exit
+    expect(between).not.toMatch(/process\.exit/);
+  });
+
+  it('documented lane exemptions hold: stranded-final recovery + orphan-adopt + QF claims carry NO auth hook (phase-2 surface)', () => {
+    // Exactly one evaluateDispatchAuthorization call site in checkin (the self-claim
+    // choke point) — recovery/adoption/QF lanes are deliberate phase-1 exemptions.
+    const checkinHooks = (checkin.match(/evaluateDispatchAuthorization\(/g) || []).length;
+    expect(checkinHooks).toBe(1);
+    // And exactly two in sd-start (direct claim + fallback lane).
+    const sdStartHooks = (sdStart.match(/evaluateDispatchAuthorization\(/g) || []).length;
+    expect(sdStartHooks).toBe(2);
+  });
 });
 
 describe('TS-10 — backfill tool (inert, idempotent) helpers', () => {

--- a/tests/unit/claim/gates/dispatch-authorization.test.js
+++ b/tests/unit/claim/gates/dispatch-authorization.test.js
@@ -1,0 +1,198 @@
+/**
+ * SD-ARCH-HOTSPOT-SD-START-001 FR-7/FR-8 (TS-7..TS-10) — dispatch-authorization
+ * polarity gate (flag-laddered, observe-first, authority-allowlisted) + the
+ * inert backfill tooling.
+ *
+ * @module tests/unit/claim/gates/dispatch-authorization.test
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  resolveDispatchAuthMode,
+  evaluateDispatchAuthorization,
+  formatWouldDenyLine,
+  DISPATCH_AUTH_AUTHORITY_ALLOWLIST,
+} = require('../../../../lib/claim/gates/dispatch-authorization.cjs');
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+const grantRow = (authority, status = 'dispositioned') => ({
+  payload: { decision_type: 'dispatch_auth', status, authority, subject: { subject_id: 'SD-X-001', gate_type: 'dispatch' } },
+});
+
+describe('resolveDispatchAuthMode — two-flag ladder (D7 adapted: no metadata column on leo_feature_flags)', () => {
+  it('base flag off/absent → off; base on → observe; base+enforce on → enforce', async () => {
+    expect(await resolveDispatchAuthMode({ isEnabledFn: async () => false })).toBe('off');
+    expect(await resolveDispatchAuthMode({ isEnabledFn: async (k) => k === 'dispatch_auth_born_denied' })).toBe('observe');
+    expect(await resolveDispatchAuthMode({ isEnabledFn: async () => true })).toBe('enforce');
+  });
+
+  it('evaluator error → off (fail-soft: flag infrastructure never changes claim behavior) — TS-9', async () => {
+    expect(await resolveDispatchAuthMode({ isEnabledFn: async () => { throw new Error('flag table gone'); } })).toBe('off');
+  });
+});
+
+describe('evaluateDispatchAuthorization — TS-7/TS-8/TS-9', () => {
+  const sd = { sd_key: 'SD-X-001' };
+
+  it('TS-9 mode=off: authorized with ZERO disposition lookups (byte-identical behavior)', async () => {
+    const spy = vi.fn();
+    const v = await evaluateDispatchAuthorization(sd, {}, { mode: 'off', getDispositionBySubjectFn: spy });
+    expect(v).toEqual({ authorized: true, mode: 'off' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('TS-7 observe + no grant: would_deny logged-not-blocked (claim proceeds)', async () => {
+    const v = await evaluateDispatchAuthorization(sd, {}, { mode: 'observe', getDispositionBySubjectFn: async () => null });
+    expect(v.authorized).toBe(true);
+    expect(v.would_deny).toBe(true);
+    expect(v.reason).toBe('dispatch_auth_pending');
+    expect(formatWouldDenyLine(sd.sd_key, v, 'checkin_self_claim')).toMatch(/DISPATCH_AUTH_WOULD_DENY sd=SD-X-001 lane=checkin_self_claim/);
+  });
+
+  it('TS-7 observe + allowlisted grant: authorized silently (no would_deny)', async () => {
+    for (const authority of DISPATCH_AUTH_AUTHORITY_ALLOWLIST) {
+      const v = await evaluateDispatchAuthorization(sd, {}, { mode: 'observe', getDispositionBySubjectFn: async () => grantRow(authority) });
+      expect(v.authorized).toBe(true);
+      expect(v.would_deny).toBeUndefined();
+      expect(v.authority).toBe(authority);
+    }
+  });
+
+  it('TS-8 authority allowlist (the specified-never-built claim-eligibility L421-425 check): a non-allowlisted authority NEVER authorizes', async () => {
+    const rogue = async () => grantRow('some-worker-session-id');
+    const obs = await evaluateDispatchAuthorization(sd, {}, { mode: 'observe', getDispositionBySubjectFn: rogue });
+    expect(obs.would_deny).toBe(true);
+    expect(obs.reason).toMatch(/authority_not_allowlisted: some-worker-session-id/);
+    const enf = await evaluateDispatchAuthorization(sd, {}, { mode: 'enforce', getDispositionBySubjectFn: rogue });
+    expect(enf.authorized).toBe(false);
+  });
+
+  it('enforce + no grant: refused with dispatch_auth_pending; awaiting_disposition status does not authorize', async () => {
+    const v = await evaluateDispatchAuthorization(sd, {}, { mode: 'enforce', getDispositionBySubjectFn: async () => null });
+    expect(v).toMatchObject({ authorized: false, reason: 'dispatch_auth_pending' });
+    const pending = await evaluateDispatchAuthorization(sd, {}, { mode: 'enforce', getDispositionBySubjectFn: async () => grantRow('chairman', 'awaiting_disposition') });
+    expect(pending.authorized).toBe(false);
+  });
+
+  it('consumed grants authorize (both load-bearing statuses); disposition read error surfaces in the reason and fails closed under enforce', async () => {
+    const consumed = await evaluateDispatchAuthorization(sd, {}, { mode: 'enforce', getDispositionBySubjectFn: async () => grantRow('coordinator', 'consumed') });
+    expect(consumed.authorized).toBe(true);
+    const err = await evaluateDispatchAuthorization(sd, {}, { mode: 'enforce', getDispositionBySubjectFn: async () => { throw new Error('boom'); } });
+    expect(err.authorized).toBe(false);
+    expect(err.reason).toMatch(/dispatch_auth_read_error: boom/);
+    const errObs = await evaluateDispatchAuthorization(sd, {}, { mode: 'observe', getDispositionBySubjectFn: async () => { throw new Error('boom'); } });
+    expect(errObs.authorized).toBe(true); // observe NEVER blocks, even on read errors
+    expect(errObs.would_deny).toBe(true);
+  });
+});
+
+describe('WIRING PINS (D8 placement + lane exemptions)', () => {
+  const checkin = readFileSync(resolve(repoRoot, 'scripts/worker-checkin.cjs'), 'utf8');
+  const sdStart = readFileSync(resolve(repoRoot, 'scripts/sd-start.js'), 'utf8');
+
+  it('checkin: the hook sits AFTER parentLeadPending/isSdInFlight and BEFORE tryClaim in tryClaimDraftCandidate', () => {
+    const fnStart = checkin.indexOf('async function tryClaimDraftCandidate');
+    const body = checkin.slice(fnStart, fnStart + 3500);
+    const parentIdx = body.indexOf('parentLeadPending(sb, d)');
+    const authIdx = body.indexOf('evaluateDispatchAuthorization(d, sb');
+    const claimIdx = body.indexOf('tryClaim(sb, d.sd_key, sessionId)');
+    expect(parentIdx).toBeGreaterThan(0);
+    expect(authIdx).toBeGreaterThan(parentIdx);
+    expect(claimIdx).toBeGreaterThan(authIdx);
+    // Observe logging + enforce skip both wired.
+    expect(body).toMatch(/formatWouldDenyLine\(d\.sd_key, authVerdict, 'checkin_self_claim'\)/);
+    expect(body).toMatch(/if \(!authVerdict\.authorized\) return null;/);
+  });
+
+  it('checkin: mode resolved once per pass (memoized promise), and ONLY the self-claim lane is hooked (orphan-adopt + WORK_ASSIGNMENT exempt)', () => {
+    expect(checkin).toMatch(/_dispatchAuthModePromise/);
+    const hookCount = (checkin.match(/evaluateDispatchAuthorization\(/g) || []).length;
+    expect(hookCount).toBe(1); // exactly the tryClaimDraftCandidate choke point
+  });
+
+  it('sd-start: the hook sits immediately before the claimGuard claim write and hard-refuses only under enforce', () => {
+    const authIdx = sdStart.indexOf('evaluateDispatchAuthorization(sd, supabase');
+    const claimIdx = sdStart.indexOf('claimGuard(effectiveId, session.session_id, { autoFallback');
+    expect(authIdx).toBeGreaterThan(0);
+    expect(claimIdx).toBeGreaterThan(authIdx);
+    expect(sdStart.slice(authIdx, claimIdx)).toMatch(/process\.exit\(1\)/); // enforce refusal path
+  });
+});
+
+describe('TS-10 — backfill tool (inert, idempotent) helpers', () => {
+  it('enumerates the exact worker-checkin claimable status surface and partitions grant coverage', async () => {
+    const backfill = await import('../../../../scripts/backfill-dispatch-auth-grants.mjs');
+    expect(backfill.CLAIMABLE_STATUSES).toEqual(['draft', 'active', 'planning', 'ready', 'in_progress', 'pending_approval']);
+
+    // verifyGrantCoverage over a mixed set (mocked disposition reads via a fake supabase
+    // the real getDispositionBySubject queries: system_events by idempotency_key).
+    const grants = {
+      // dq_ keys are content-derived; fake matches on the subject embedded in payload instead:
+    };
+    void grants;
+    const fakeSb = {
+      from(table) {
+        expect(table).toBe('system_events');
+        const q = {};
+        const b = {
+          select() { return b; },
+          eq(col, val) { q[col] = val; return b; },
+          maybeSingle() {
+            // Grant exists only for SD-GRANTED-001's question key: emulate by
+            // checking the key material embedded when computeQuestionKey ran.
+            // We can't reverse the hash here; instead seed by call order via the
+            // idempotency_key of a real computeQuestionKey call below.
+            return Promise.resolve({ data: q.idempotency_key === grantedKey ? { payload: { status: 'dispositioned', authority: 'backfill-cutover' } } : null, error: null });
+          },
+        };
+        return b;
+      },
+    };
+    const { computeQuestionKey } = await import('../../../../lib/decision-binding/disposition.js');
+    const grantedKey = computeQuestionKey('dispatch_auth', { subject_id: 'SD-GRANTED-001', gate_type: 'dispatch' });
+
+    const { granted, unGranted } = await backfill.verifyGrantCoverage(fakeSb, [
+      { sd_key: 'SD-GRANTED-001', status: 'draft' },
+      { sd_key: 'SD-BARE-001', status: 'ready' },
+    ]);
+    expect(granted.map(s => s.sd_key)).toEqual(['SD-GRANTED-001']);
+    expect(unGranted.map(s => s.sd_key)).toEqual(['SD-BARE-001']);
+  });
+
+  it('applyGrants writes via recordDisposition with the allowlisted backfill authority and is idempotent (created:false counted as reused)', async () => {
+    const backfill = await import('../../../../scripts/backfill-dispatch-auth-grants.mjs');
+    const inserts = [];
+    let call = 0;
+    const fakeSb = {
+      from() {
+        const b = {
+          select() { return b; },
+          eq() { return b; },
+          maybeSingle() {
+            // recordDisposition pre-checks existing: first SD absent, second SD already granted.
+            return Promise.resolve({ data: call === 0 ? null : { payload: { status: 'dispositioned', authority: 'backfill-cutover' } }, error: null });
+          },
+          insert(row) {
+            inserts.push(row);
+            return { select: () => ({ single: () => { call += 1; return Promise.resolve({ data: row, error: null }); } }) };
+          },
+        };
+        return b;
+      },
+    };
+    // First grant: created. Then simulate second run over an already-granted SD: reused.
+    const r1 = await backfill.applyGrants(fakeSb, [{ sd_key: 'SD-NEW-001', status: 'draft' }]);
+    expect(r1.created).toBe(1);
+    const r2 = await backfill.applyGrants(fakeSb, [{ sd_key: 'SD-NEW-001', status: 'draft' }]);
+    expect(r2.reused).toBe(1);
+    expect(r2.created).toBe(0);
+    expect(inserts[0].payload.authority).toBe('backfill-cutover');
+    expect(inserts[0].payload.decision_type).toBe('dispatch_auth');
+  });
+});


### PR DESCRIPTION
## Summary
PR-B (authorization half) — the SD-2 phase-1 polarity flip folded into this door per the coordinator coupling rule, shipped safe:
- **Born-un-authorized gate** behind a two-flag ladder (`dispatch_auth_born_denied` → observe; + `_enforce` → enforce; absent = off = byte-identical with zero lookups). Observe **never blocks** — it emits one structured `DISPATCH_AUTH_WOULD_DENY` line per would-blocked claim (the observe-window evidence for the later flip).
- **Authority allowlist** ({chairman, coordinator, backfill-cutover}) — implements the check SD-2's adversarial review specified at `claim-eligibility.cjs` L421-425 but never built; rogue-recorded grants never authorize.
- **Hooks at the exact enforce choke points** (after all other gates, immediately before the claim write) on the two SELF-CLAIM lanes; orphan-adopt + directed WORK_ASSIGNMENT documented exemptions (phase-2 surface).
- **Inert backfill tool** (dry-run default) + PRE-FLIP VERIFICATION over the exact checkin-claimable status surface; the enforce flip is a later coordinated data-only cutover gated on that verification reading zero.

Depends on PR-A (#5767, merged): consumes the shared lib/claim namespace; this is checkin's shared-module consumption #2 (SD acceptance ≥2 met).

## Test plan
- [x] 13 new tests (TS-7..TS-10): mode ladder incl. fail-soft, observe/enforce/allowlist matrices, read-error polarity (observe never blocks, enforce fails closed), D8 wiring-placement pins, backfill coverage partition + idempotency
- [x] Flag-off byte-identity: existing dispatch-auth-opt-in + convergence + claim/sd-start suites green unmodified (151 tests across 19 files)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)