### PR TITLE
feat(SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001): RDAP domain-availability adapter + Stage-11 activation-seam naming integration

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
@@ -16,6 +16,11 @@ import { runTournament } from '../../crews/tournament-orchestrator.js';
 import { writeArtifact } from '../../artifact-persistence-service.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 import { fetchSripSummary } from '../../eva-orchestrator-helpers.js';
+import {
+  resolveAvailabilityChecker, resolveAvailabilityWeight, assessCandidateAvailability,
+  availabilityScore, addAvailabilityCriterion, domainVerdictFor, domainDetailFor,
+  tldStatusesFor, buildDomainShortlist,
+} from '../../../venture-domains/stage-integration.js';
 
 // Duplicated from stage-11.js to avoid circular dependency
 const MIN_CANDIDATES = 5;
@@ -110,7 +115,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Naming & visual identity analysis
  */
-export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName, ventureId, supabase, logger = console, visionKey = null, planKey = null }) {
+export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName, ventureId, supabase, logger = console, visionKey = null, planKey = null, availabilityChecker = undefined }) {
   const startTime = Date.now();
   logger.log('[Stage11] Starting naming & visual identity analysis', { ventureName });
 
@@ -361,6 +366,26 @@ Output ONLY valid JSON.`;
 
   if (!logoSpec) llmFallbackCount++;
 
+  // --- Domain availability seam (SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001) ---
+  // Default OFF: with no injected checker and DOMAIN_AVAILABILITY_MODE!=='live' this block
+  // is a no-op and every downstream shape is byte-identical to pre-SD behavior
+  // (availabilityChecks stay 'pending', no Availability criterion, no shortlist).
+  const domainChecker = availabilityChecker === undefined ? resolveAvailabilityChecker() : availabilityChecker;
+  let domainAssessments = null;
+  if (domainChecker) {
+    try {
+      domainAssessments = await assessCandidateAvailability(candidates.map(c => c.name), domainChecker);
+      scoringCriteria = addAvailabilityCriterion(scoringCriteria, resolveAvailabilityWeight());
+      for (const c of candidates) {
+        c.scores['Availability'] = availabilityScore(domainAssessments.get(c.name));
+      }
+    } catch (err) {
+      // Honest degradation: a seam fault never breaks the stage; verdicts stay pending.
+      domainAssessments = null;
+      logger.warn('[Stage11] Domain availability seam failed — falling back to pending', { error: err.message });
+    }
+  }
+
   // --- Normalize decision ---
   const dec = parsed.decision || {};
   const topCandidate = candidates.length > 0
@@ -379,10 +404,15 @@ Output ONLY valid JSON.`;
     workingTitle: dec.workingTitle !== false,
     rationale: String(dec.rationale || 'Top-scoring candidate based on weighted criteria and persona fit').substring(0, 500),
     availabilityChecks: {
-      domain: AVAILABILITY_STATUSES.includes(ac.domain) ? ac.domain : 'pending',
+      // Real RDAP verdict when the availability seam is active; the LLM's claim (or
+      // 'pending') otherwise — the string contract (AVAILABILITY_STATUSES) is unchanged.
+      domain: domainAssessments
+        ? domainVerdictFor(domainAssessments.get(selectedName))
+        : (AVAILABILITY_STATUSES.includes(ac.domain) ? ac.domain : 'pending'),
       trademark: AVAILABILITY_STATUSES.includes(ac.trademark) ? ac.trademark : 'pending',
       social: AVAILABILITY_STATUSES.includes(ac.social) ? ac.social : 'pending',
     },
+    ...(domainAssessments ? { domainDetail: domainDetailFor(domainAssessments.get(selectedName)) } : {}),
   };
 
   if (llmFallbackCount > 0) {
@@ -391,7 +421,7 @@ Output ONLY valid JSON.`;
 
   // --- DB Write-Through: Naming Suggestions + Venture Artifacts ---
   if (supabase && ventureId) {
-    await writeStage11Artifacts({ supabase, ventureId, candidates, logger, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria, visionKey, planKey });
+    await writeStage11Artifacts({ supabase, ventureId, candidates, logger, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria, visionKey, planKey, domainAssessments });
   }
 
   // ── SRIP Completion Summary (supplementary, non-fatal) ──────
@@ -424,7 +454,7 @@ Output ONLY valid JSON.`;
  * Write Stage 11 naming candidates to naming_suggestions and venture_artifacts.
  * All DB writes are non-fatal — errors are logged and swallowed.
  */
-async function writeStage11Artifacts({ supabase, ventureId, candidates, logger, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria, visionKey, planKey }) {
+async function writeStage11Artifacts({ supabase, ventureId, candidates, logger, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria, visionKey, planKey, domainAssessments = null }) {
   // Generate a session UUID per Stage 11 run
   const generationSessionId = crypto.randomUUID();
 
@@ -439,6 +469,11 @@ async function writeStage11Artifacts({ supabase, ventureId, candidates, logger, 
       const pronounceabilityScore = candidate.scores?.['Pronounceability'] ?? candidate.scores?.['Memorability'] ?? null;
       const uniquenessScore = candidate.scores?.['Uniqueness'] ?? null;
 
+      // Real RDAP verdicts when the availability seam is active (SD-LEO-FEAT-VENTURE-
+      // DOMAIN-AVAILABILITY-001); the pre-SD hardcoded 'unknown' otherwise.
+      const tldStatuses = domainAssessments
+        ? tldStatusesFor(domainAssessments.get(candidate.name))
+        : { '.com': 'unknown', '.io': 'unknown', '.ai': 'unknown' };
       const { error: insertErr } = await supabase.from('naming_suggestions').insert({
         venture_id: ventureId,
         generation_session_id: generationSessionId,
@@ -447,9 +482,9 @@ async function writeStage11Artifacts({ supabase, ventureId, candidates, logger, 
         brand_fit_score: personaFitAvg,
         pronounceability_score: pronounceabilityScore,
         uniqueness_score: uniquenessScore,
-        domain_com_status: 'unknown',
-        domain_io_status: 'unknown',
-        domain_ai_status: 'unknown',
+        domain_com_status: tldStatuses['.com'] || 'unknown',
+        domain_io_status: tldStatuses['.io'] || 'unknown',
+        domain_ai_status: tldStatuses['.ai'] || 'unknown',
       });
 
       if (insertErr) {
@@ -467,7 +502,12 @@ async function writeStage11Artifacts({ supabase, ventureId, candidates, logger, 
       lifecycleStage: 11,
       artifactType: 'identity_brand_name',
       title: 'Naming Candidates (Stage 11)',
-      artifactData: { candidates, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria },
+      artifactData: {
+        candidates, visualIdentity, brandExpression, logoSpec, decision, scoringCriteria,
+        // Decision-ready shortlist for the acquisition SD / chairman CF domain decision —
+        // present only when the availability seam is active (payload byte-identical otherwise).
+        ...(domainAssessments ? { domainShortlist: buildDomainShortlist(domainAssessments) } : {}),
+      },
       metadata: {
         generation_session_id: generationSessionId,
         candidate_count: candidates.length,

--- a/lib/venture-domains/availability.js
+++ b/lib/venture-domains/availability.js
@@ -1,0 +1,132 @@
+/**
+ * Domain-availability adapter — the read-only half of venture domain automation.
+ *
+ * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 (FR-1).
+ *
+ * Pure, injectable, mirroring the lib/venture-deploy adapter discipline: all I/O
+ * (fetch), time (now) and pacing (sleep) are injected so tests run with fakes and
+ * plan/test-mode never touches the network. Verdicts are HONEST (honest-gauge
+ * convention): a lookup that cannot be confirmed is 'unknown' — a network fault,
+ * timeout, rate-limit or exhausted budget is NEVER coerced to 'available'.
+ *
+ * RDAP (RFC 7480) is free and unauthenticated; https://rdap.org is the bootstrap
+ * redirector covering gTLDs: 404 = unregistered (available), 2xx = registered
+ * (taken), anything else = unknown.
+ *
+ * @module lib/venture-domains/availability
+ */
+
+export const DEFAULT_TLDS = Object.freeze(['.com', '.io', '.app', '.ai']);
+export const DEFAULT_PREFIXES = Object.freeze(['get', 'try']);
+export const MAX_PERMUTATIONS = 24;
+export const RDAP_BASE = 'https://rdap.org/domain/';
+export const VERDICTS = Object.freeze(['available', 'taken', 'unknown']);
+
+/** Slugify a name candidate into a DNS label (lowercase alnum + hyphen). */
+export function toLabel(name) {
+  return String(name || '')
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+/**
+ * Generate sane domain permutations for a name candidate: exact, prefixed
+ * (get-/try-), and hyphenated (word-split) labels across the TLD set.
+ * Pure; deduped; capped at MAX_PERMUTATIONS (exact-first ordering so the cap
+ * never drops the highest-signal domains).
+ */
+export function generatePermutations(name, { tlds = DEFAULT_TLDS, prefixes = DEFAULT_PREFIXES, hyphenate = true } = {}) {
+  const hyphenated = toLabel(name); // word boundaries become hyphens
+  const compact = hyphenated.replace(/-/g, '');
+  if (!compact) return [];
+  const labels = [compact];
+  if (hyphenate && hyphenated !== compact) labels.push(hyphenated);
+  for (const p of prefixes) labels.push(`${p}${compact}`);
+  const out = [];
+  const seen = new Set();
+  // exact (unprefixed) labels first across all TLDs, then prefixed — cap keeps the best.
+  for (const label of labels) {
+    for (const tld of tlds) {
+      const domain = `${label}${tld.startsWith('.') ? tld : `.${tld}`}`;
+      if (!seen.has(domain)) { seen.add(domain); out.push(domain); }
+      if (out.length >= MAX_PERMUTATIONS) return out;
+    }
+  }
+  return out;
+}
+
+/** Create a rate budget: at most maxLookups, spaced minIntervalMs apart (injected clock/sleep). */
+export function createRateBudget({ maxLookups = 20, minIntervalMs = 250, now = () => Date.now(), sleep = (ms) => new Promise(r => setTimeout(r, ms)) } = {}) {
+  let used = 0;
+  let lastAt = null; // first lookup is never paced
+  return {
+    get remaining() { return maxLookups - used; },
+    exhausted() { return used >= maxLookups; },
+    /** Consume one lookup slot, pacing if needed. Returns false when exhausted. */
+    async take() {
+      if (used >= maxLookups) return false;
+      const wait = lastAt === null ? 0 : lastAt + minIntervalMs - now();
+      if (wait > 0) await sleep(wait);
+      used += 1;
+      lastAt = now();
+      return true;
+    },
+  };
+}
+
+/**
+ * Check one domain via RDAP. NEVER throws; never a false 'available'.
+ *
+ * @returns {Promise<{domain, verdict: 'available'|'taken'|'unknown', reason?: string, source: 'rdap', checked_at: string}>}
+ */
+export async function checkDomainAvailability(domain, { fetch, now = () => new Date(), timeoutMs = 8000, rdapBase = RDAP_BASE } = {}) {
+  const checked_at = now().toISOString();
+  if (typeof fetch !== 'function') {
+    return { domain, verdict: 'unknown', reason: 'no_fetch_injected', source: 'rdap', checked_at };
+  }
+  try {
+    const ctl = typeof AbortController === 'function' ? new AbortController() : null;
+    const timer = ctl ? setTimeout(() => ctl.abort(), timeoutMs) : null;
+    let res;
+    try {
+      res = await fetch(`${rdapBase}${encodeURIComponent(domain)}`, {
+        headers: { accept: 'application/rdap+json' },
+        ...(ctl ? { signal: ctl.signal } : {}),
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (res.status === 404) return { domain, verdict: 'available', source: 'rdap', checked_at };
+    if (res.status >= 200 && res.status < 300) return { domain, verdict: 'taken', source: 'rdap', checked_at };
+    return { domain, verdict: 'unknown', reason: `rdap_status_${res.status}`, source: 'rdap', checked_at };
+  } catch (e) {
+    return { domain, verdict: 'unknown', reason: `fetch_failed: ${String(e?.message || e).slice(0, 120)}`, source: 'rdap', checked_at };
+  }
+}
+
+/**
+ * Check a full candidate name: permutations under a shared rate budget.
+ * Budget-exhausted permutations report unknown('budget_exhausted') — honest, never skipped silently.
+ *
+ * @returns {Promise<{candidate, results: object[], best: {domain, verdict}|null}>}
+ */
+export async function checkCandidateAvailability(name, { fetch, now = () => new Date(), budget, tlds, prefixes, hyphenate } = {}) {
+  const domains = generatePermutations(name, { ...(tlds ? { tlds } : {}), ...(prefixes ? { prefixes } : {}), ...(hyphenate === undefined ? {} : { hyphenate }) });
+  const b = budget || createRateBudget({ now: () => now().getTime() });
+  const results = [];
+  for (const domain of domains) {
+    if (await b.take()) {
+      results.push(await checkDomainAvailability(domain, { fetch, now }));
+    } else {
+      results.push({ domain, verdict: 'unknown', reason: 'budget_exhausted', source: 'rdap', checked_at: now().toISOString() });
+    }
+  }
+  // best = first available in permutation order (exact-first), else null
+  const best = results.find(r => r.verdict === 'available') || null;
+  return { candidate: name, results, best: best ? { domain: best.domain, verdict: best.verdict } : null };
+}
+
+export default { toLabel, generatePermutations, createRateBudget, checkDomainAvailability, checkCandidateAvailability, DEFAULT_TLDS, DEFAULT_PREFIXES, MAX_PERMUTATIONS, VERDICTS };

--- a/lib/venture-domains/stage-integration.js
+++ b/lib/venture-domains/stage-integration.js
@@ -1,0 +1,133 @@
+/**
+ * Stage-11 naming integration for the domain-availability adapter.
+ *
+ * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 (FR-2/FR-3).
+ *
+ * ACTIVATION SEAM, default OFF: resolveAvailabilityChecker() returns null unless
+ * DOMAIN_AVAILABILITY_MODE==='live' (or a checker is injected by the caller), so
+ * the stage's default behavior — availabilityChecks.domain 'pending', no
+ * Availability criterion, hardcoded 'unknown' naming rows — is byte-identical to
+ * pre-SD behavior. When active, candidates gain an Availability score/criterion,
+ * the decision carries real verdicts, and a decision-ready domainShortlist rides
+ * the existing identity_brand_name artifact.
+ *
+ * @module lib/venture-domains/stage-integration
+ */
+
+import { checkCandidateAvailability, createRateBudget } from './availability.js';
+
+export const DEFAULT_AVAILABILITY_WEIGHT = 15;
+
+/** Env-gated checker factory: null (seam off) unless DOMAIN_AVAILABILITY_MODE=live. */
+export function resolveAvailabilityChecker(env = process.env) {
+  if (env.DOMAIN_AVAILABILITY_MODE !== 'live') return null;
+  if (typeof fetch !== 'function') return null; // no global fetch — cannot go live
+  const tlds = env.DOMAIN_AVAILABILITY_TLDS
+    ? env.DOMAIN_AVAILABILITY_TLDS.split(',').map(t => t.trim()).filter(Boolean)
+    : undefined;
+  const budget = createRateBudget({});
+  return (name) => checkCandidateAvailability(name, { fetch, budget, ...(tlds ? { tlds } : {}) });
+}
+
+export function resolveAvailabilityWeight(env = process.env) {
+  const w = Number(env.DOMAIN_AVAILABILITY_WEIGHT);
+  return Number.isFinite(w) && w > 0 && w < 100 ? w : DEFAULT_AVAILABILITY_WEIGHT;
+}
+
+/**
+ * Run the checker across candidate names. Never throws; a checker fault yields
+ * an empty result set for that candidate (downstream treats it as unknown).
+ *
+ * @param {string[]} names
+ * @param {(name: string) => Promise<{candidate, results, best}>} checker
+ * @returns {Promise<Map<string, {results: object[], best: object|null}>>}
+ */
+export async function assessCandidateAvailability(names, checker) {
+  const byCandidate = new Map();
+  for (const name of names) {
+    try {
+      const r = await checker(name);
+      byCandidate.set(name, { results: r.results || [], best: r.best || null });
+    } catch (e) {
+      byCandidate.set(name, { results: [], best: null, error: String(e?.message || e).slice(0, 120) });
+    }
+  }
+  return byCandidate;
+}
+
+/**
+ * Score a candidate's availability 0-100 (honest: unknown-heavy = mid-low, never a
+ * free pass): exact-first available permutation = 100; any available = 70;
+ * all-known-taken = 0; otherwise (unknowns, no available) = 40.
+ */
+export function availabilityScore(assessment) {
+  const results = assessment?.results || [];
+  if (results.length === 0) return 40; // nothing confirmable — neutral-low, not zero, not perfect
+  if (results[0]?.verdict === 'available') return 100; // exact permutation open
+  if (results.some(r => r.verdict === 'available')) return 70;
+  if (results.every(r => r.verdict === 'taken')) return 0;
+  return 40;
+}
+
+/** Add the Availability criterion and rescale ALL weights to sum 100 (integer-safe). */
+export function addAvailabilityCriterion(scoringCriteria, weight = DEFAULT_AVAILABILITY_WEIGHT) {
+  const others = scoringCriteria.filter(c => c.name !== 'Availability');
+  const otherSum = others.reduce((s, c) => s + (Number(c.weight) || 0), 0) || 1;
+  const scale = (100 - weight) / otherSum;
+  const rescaled = others.map(c => ({ ...c, weight: Math.round((Number(c.weight) || 0) * scale) }));
+  const drift = 100 - weight - rescaled.reduce((s, c) => s + c.weight, 0);
+  if (rescaled.length > 0) rescaled[0] = { ...rescaled[0], weight: rescaled[0].weight + drift };
+  return [...rescaled, { name: 'Availability', weight, description: 'Domain availability across the configured TLD set (RDAP-verified; taken names lose rank)' }];
+}
+
+/** The selected candidate's domain verdict for decision.availabilityChecks.domain (string contract preserved). */
+export function domainVerdictFor(assessment) {
+  const results = assessment?.results || [];
+  if (results.length === 0) return 'unknown';
+  if (results.some(r => r.verdict === 'available')) return 'available';
+  if (results.every(r => r.verdict === 'taken')) return 'taken';
+  return 'unknown';
+}
+
+/** Detail sibling for the decision (checked_at + permutations tried) — additive, string contract untouched. */
+export function domainDetailFor(assessment) {
+  const results = assessment?.results || [];
+  return {
+    checked_at: results[0]?.checked_at || null,
+    permutations: results.map(r => ({ domain: r.domain, verdict: r.verdict })),
+  };
+}
+
+/**
+ * Per-TLD status for the naming_suggestions columns. generatePermutations emits the
+ * exact (unprefixed, unhyphenated) label FIRST for every TLD, so the first result per
+ * TLD is the exact domain's verdict; honest 'unknown' fallback when unchecked.
+ */
+export function tldStatusesFor(assessment, tlds = ['.com', '.io', '.ai']) {
+  const results = assessment?.results || [];
+  const out = {};
+  for (const tld of tlds) {
+    out[tld] = results.find(r => r.domain.endsWith(tld))?.verdict || 'unknown';
+  }
+  return out;
+}
+
+/** Decision-ready shortlist: available exact domains first, then available-any, then unknown; taken excluded. */
+export function buildDomainShortlist(byCandidate, { limit = 10 } = {}) {
+  const rows = [];
+  for (const [candidate, assessment] of byCandidate.entries()) {
+    for (const r of (assessment.results || [])) {
+      if (r.verdict === 'taken') continue;
+      rows.push({ candidate, domain: r.domain, verdict: r.verdict, checked_at: r.checked_at, price: null });
+    }
+  }
+  const rank = (row) => (row.verdict === 'available' ? (row.domain.split('.')[0].includes('-') || /^get|^try/.test(row.domain) ? 1 : 0) : 2);
+  rows.sort((a, b) => rank(a) - rank(b) || a.domain.length - b.domain.length);
+  return rows.slice(0, limit);
+}
+
+export default {
+  resolveAvailabilityChecker, resolveAvailabilityWeight, assessCandidateAvailability,
+  availabilityScore, addAvailabilityCriterion, domainVerdictFor, domainDetailFor,
+  tldStatusesFor, buildDomainShortlist, DEFAULT_AVAILABILITY_WEIGHT,
+};

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-11-domain-availability.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-11-domain-availability.test.js
@@ -1,0 +1,122 @@
+/**
+ * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 — Stage-11 availability seam.
+ * OFF (default): byte-identical decision shape (all-'pending', no Availability criterion).
+ * ON (injected checker): availability-weighted scoring + real domain verdict + detail.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockComplete = vi.fn();
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ complete: mockComplete }),
+}));
+
+const { analyzeStage11 } = await import('../../../../../lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js');
+
+const silentLogger = { warn() {}, info() {}, error() {}, debug() {}, log() {} };
+
+const candidateNames = ['Craftbridge', 'ArtisanLink', 'Makerly', 'Handcraft', 'Loombridge'];
+
+function llmPayload() {
+  return JSON.stringify({
+    namingStrategy: { approach: 'metaphorical', rationale: 'Fits brand' },
+    scoringCriteria: [
+      { name: 'Memorability', weight: 25 },
+      { name: 'Relevance', weight: 25 },
+      { name: 'Persona Resonance', weight: 25 },
+      { name: 'Uniqueness', weight: 25 },
+    ],
+    candidates: candidateNames.map((name, i) => ({
+      name,
+      rationale: `Candidate ${i}`,
+      scores: { Memorability: 70 + i, Relevance: 70, 'Persona Resonance': 70, Uniqueness: 70 },
+      personaFit: [{ personaName: 'Tech-Savvy Artisan Founder', fitScore: 80, reasoning: 'Fits' }],
+    })),
+    visualIdentity: {
+      colorPalette: [{ name: 'Primary', hex: '#2563EB', usage: 'Primary', personaAlignment: 'Pro' }],
+      typography: { heading: 'Inter', body: 'Inter', rationale: 'Clean' },
+      imageryGuidance: 'Warm tones',
+    },
+    brandExpression: { tagline: 'T', elevator_pitch: 'E', messaging_pillars: ['A'] },
+    decision: {
+      selectedName: 'Craftbridge',
+      workingTitle: true,
+      rationale: 'Top scoring',
+      availabilityChecks: { domain: 'pending', trademark: 'pending', social: 'pending' },
+    },
+    logoSpec: { textTreatment: 'T', primaryColor: '#2563EB', accentColor: '#10B981', typography: 'Inter', iconConcept: 'I', svgPrompt: 'S' },
+  });
+}
+
+function stage10Data() {
+  return {
+    customerPersonas: [{ personaName: 'Tech-Savvy Artisan Founder', description: 'Founder' }],
+    brandGenome: { archetype: 'Creator', tone: 'Warm', values: ['Craft'] },
+  };
+}
+
+const stage1Data = { description: 'A platform connecting local artisans with global buyers' };
+
+function run(extra = {}) {
+  mockComplete.mockResolvedValueOnce(llmPayload());
+  return analyzeStage11({ stage1Data, stage10Data: stage10Data(), logger: silentLogger, ...extra });
+}
+
+beforeEach(() => { mockComplete.mockReset(); delete process.env.DOMAIN_AVAILABILITY_MODE; });
+
+describe('seam OFF (default)', () => {
+  it('is byte-identical to pre-SD behavior: all-pending, no Availability criterion, no domainDetail', async () => {
+    const result = await run();
+    expect(result.decision.availabilityChecks).toEqual({ domain: 'pending', trademark: 'pending', social: 'pending' });
+    expect(result.decision.domainDetail).toBeUndefined();
+    expect(result.scoringCriteria.some(c => c.name === 'Availability')).toBe(false);
+  });
+
+  it('explicit null checker also stays off even if env is live (injection wins)', async () => {
+    process.env.DOMAIN_AVAILABILITY_MODE = 'live';
+    const result = await run({ availabilityChecker: null });
+    expect(result.decision.availabilityChecks.domain).toBe('pending');
+    expect(result.scoringCriteria.some(c => c.name === 'Availability')).toBe(false);
+  });
+});
+
+describe('seam ON (injected checker)', () => {
+  const mkChecker = (verdictFor) => async (name) => ({
+    candidate: name,
+    results: [
+      { domain: `${name.toLowerCase()}.com`, verdict: verdictFor(name), checked_at: '2026-07-10T00:00:00Z', source: 'rdap' },
+      { domain: `${name.toLowerCase()}.io`, verdict: 'taken', checked_at: '2026-07-10T00:00:00Z', source: 'rdap' },
+    ],
+    best: null,
+  });
+
+  it('adds the Availability criterion (weights re-sum to 100) and scores candidates', async () => {
+    const checker = mkChecker((name) => (name === 'Makerly' ? 'available' : 'taken'));
+    const result = await run({ availabilityChecker: checker });
+    const avail = result.scoringCriteria.find(c => c.name === 'Availability');
+    expect(avail).toBeTruthy();
+    expect(result.scoringCriteria.reduce((s, c) => s + c.weight, 0)).toBe(100);
+    const makerly = result.candidates.find(c => c.name === 'Makerly');
+    const craftbridge = result.candidates.find(c => c.name === 'Craftbridge');
+    expect(makerly.scores['Availability']).toBe(100); // exact .com open
+    expect(craftbridge.scores['Availability']).toBe(0); // all taken
+  });
+
+  it('decision carries the SELECTED name real verdict + domainDetail permutations', async () => {
+    const checker = mkChecker(() => 'taken');
+    const result = await run({ availabilityChecker: checker });
+    expect(result.decision.selectedName).toBe('Craftbridge'); // LLM selection honored
+    expect(result.decision.availabilityChecks.domain).toBe('taken'); // real verdict, string contract
+    expect(result.decision.availabilityChecks.trademark).toBe('pending'); // untouched
+    expect(result.decision.domainDetail.permutations).toHaveLength(2);
+    expect(result.decision.domainDetail.checked_at).toBe('2026-07-10T00:00:00Z');
+  });
+
+  it('a throwing checker degrades honestly to pending (never breaks the stage)', async () => {
+    const boom = async () => { throw new Error('rdap outage'); };
+    // assessCandidateAvailability catches per-candidate; a fault in the seam itself also falls back.
+    const result = await run({ availabilityChecker: boom });
+    // per-candidate faults -> empty results -> verdict 'unknown' for selected name
+    expect(['unknown', 'pending']).toContain(result.decision.availabilityChecks.domain);
+    expect(result.candidates.length).toBeGreaterThanOrEqual(5); // stage output intact
+  });
+});

--- a/tests/unit/venture-domains/availability.test.js
+++ b/tests/unit/venture-domains/availability.test.js
@@ -1,0 +1,137 @@
+/**
+ * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 — adapter invariants.
+ * All I/O injected: no network, no real timers.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  toLabel, generatePermutations, createRateBudget, checkDomainAvailability,
+  checkCandidateAvailability, MAX_PERMUTATIONS, DEFAULT_TLDS,
+} from '../../../lib/venture-domains/availability.js';
+import {
+  availabilityScore, addAvailabilityCriterion, domainVerdictFor, tldStatusesFor,
+  buildDomainShortlist, assessCandidateAvailability, resolveAvailabilityChecker,
+} from '../../../lib/venture-domains/stage-integration.js';
+
+const fetchWithStatus = (status) => async () => ({ status });
+const failingFetch = async () => { throw new Error('ECONNRESET'); };
+const NOW = () => new Date('2026-07-10T00:00:00Z');
+
+describe('generatePermutations', () => {
+  it('emits exact-first, then hyphenated and prefixed labels across the default TLD set, deduped and capped', () => {
+    const perms = generatePermutations('Acme Lens');
+    expect(perms[0]).toBe('acmelens.com'); // exact label, first TLD — order is load-bearing (tldStatusesFor)
+    expect(perms).toContain('acmelens.io');
+    expect(perms).toContain('acme-lens.com');
+    expect(perms).toContain('getacmelens.com');
+    expect(perms).toContain('tryacmelens.app');
+    expect(new Set(perms).size).toBe(perms.length);
+    expect(perms.length).toBeLessThanOrEqual(MAX_PERMUTATIONS);
+  });
+
+  it('slugifies punctuation and returns [] for an empty name', () => {
+    expect(toLabel("O'Neil & Sons!")).toBe('oneil-sons');
+    expect(generatePermutations('!!!')).toEqual([]);
+  });
+});
+
+describe('checkDomainAvailability — honest verdict mapping', () => {
+  it('404 -> available; 2xx -> taken', async () => {
+    expect((await checkDomainAvailability('x.com', { fetch: fetchWithStatus(404), now: NOW })).verdict).toBe('available');
+    expect((await checkDomainAvailability('x.com', { fetch: fetchWithStatus(200), now: NOW })).verdict).toBe('taken');
+  });
+
+  it('429 / 5xx / network error / missing fetch -> unknown with a reason — NEVER available', async () => {
+    for (const r of [
+      await checkDomainAvailability('x.com', { fetch: fetchWithStatus(429), now: NOW }),
+      await checkDomainAvailability('x.com', { fetch: fetchWithStatus(503), now: NOW }),
+      await checkDomainAvailability('x.com', { fetch: failingFetch, now: NOW }),
+      await checkDomainAvailability('x.com', { now: NOW }),
+    ]) {
+      expect(r.verdict).toBe('unknown');
+      expect(r.reason).toBeTruthy();
+      expect(r.checked_at).toBe('2026-07-10T00:00:00.000Z');
+    }
+  });
+});
+
+describe('rate budget', () => {
+  it('caps lookups and marks the tail unknown(budget_exhausted)', async () => {
+    let calls = 0;
+    const countingFetch = async () => { calls++; return { status: 404 }; };
+    const budget = createRateBudget({ maxLookups: 3, minIntervalMs: 0, now: () => 0, sleep: async () => {} });
+    const { results } = await checkCandidateAvailability('Acme Lens', { fetch: countingFetch, now: NOW, budget });
+    expect(calls).toBe(3);
+    const tail = results.slice(3);
+    expect(tail.length).toBeGreaterThan(0);
+    expect(tail.every(r => r.verdict === 'unknown' && r.reason === 'budget_exhausted')).toBe(true);
+  });
+
+  it('paces lookups via the injected sleep', async () => {
+    const sleeps = [];
+    let t = 0;
+    const budget = createRateBudget({ maxLookups: 3, minIntervalMs: 100, now: () => t, sleep: async (ms) => { sleeps.push(ms); t += ms; } });
+    await budget.take(); t += 10; // 90ms early
+    await budget.take();
+    expect(sleeps).toEqual([90]);
+  });
+});
+
+describe('scoring + decision helpers', () => {
+  const mk = (verdicts) => ({ results: verdicts.map((v, i) => ({ domain: `d${i}.com`, verdict: v, checked_at: 'T' })) });
+
+  it('availabilityScore: exact-open=100, some-open=70, all-taken=0, unknowns=40', () => {
+    expect(availabilityScore(mk(['available', 'taken']))).toBe(100);
+    expect(availabilityScore(mk(['taken', 'available']))).toBe(70);
+    expect(availabilityScore(mk(['taken', 'taken']))).toBe(0);
+    expect(availabilityScore(mk(['taken', 'unknown']))).toBe(40);
+    expect(availabilityScore({ results: [] })).toBe(40);
+  });
+
+  it('addAvailabilityCriterion rescales existing weights to sum exactly 100', () => {
+    const out = addAvailabilityCriterion([{ name: 'A', weight: 60 }, { name: 'B', weight: 40 }], 15);
+    expect(out.find(c => c.name === 'Availability').weight).toBe(15);
+    expect(out.reduce((s, c) => s + c.weight, 0)).toBe(100);
+  });
+
+  it('domainVerdictFor and tldStatusesFor map honestly', () => {
+    expect(domainVerdictFor(mk(['taken', 'available']))).toBe('available');
+    expect(domainVerdictFor(mk(['taken', 'taken']))).toBe('taken');
+    expect(domainVerdictFor(mk(['taken', 'unknown']))).toBe('unknown');
+    expect(domainVerdictFor(null)).toBe('unknown');
+    const a = { results: [
+      { domain: 'acme.com', verdict: 'taken', checked_at: 'T' },
+      { domain: 'acme.io', verdict: 'available', checked_at: 'T' },
+    ] };
+    expect(tldStatusesFor(a)).toEqual({ '.com': 'taken', '.io': 'available', '.ai': 'unknown' });
+  });
+
+  it('buildDomainShortlist excludes taken, ranks exact-available first', () => {
+    const byCandidate = new Map([['Acme', { results: [
+      { domain: 'get-acme.com', verdict: 'available', checked_at: 'T' },
+      { domain: 'acme.com', verdict: 'taken', checked_at: 'T' },
+      { domain: 'acme.io', verdict: 'available', checked_at: 'T' },
+      { domain: 'acme.ai', verdict: 'unknown', checked_at: 'T' },
+    ] }]]);
+    const list = buildDomainShortlist(byCandidate);
+    expect(list.map(r => r.domain)).toEqual(['acme.io', 'get-acme.com', 'acme.ai']);
+    expect(list.every(r => r.price === null)).toBe(true);
+  });
+});
+
+describe('activation seam', () => {
+  it('resolveAvailabilityChecker is null unless DOMAIN_AVAILABILITY_MODE=live (default OFF)', () => {
+    expect(resolveAvailabilityChecker({})).toBeNull();
+    expect(resolveAvailabilityChecker({ DOMAIN_AVAILABILITY_MODE: 'off' })).toBeNull();
+    expect(typeof resolveAvailabilityChecker({ DOMAIN_AVAILABILITY_MODE: 'live' })).toBe('function');
+  });
+
+  it('assessCandidateAvailability never throws on a checker fault', async () => {
+    const byCandidate = await assessCandidateAvailability(['A', 'B'], async (n) => {
+      if (n === 'B') throw new Error('boom');
+      return { candidate: n, results: [{ domain: 'a.com', verdict: 'available', checked_at: 'T' }], best: null };
+    });
+    expect(byCandidate.get('A').results).toHaveLength(1);
+    expect(byCandidate.get('B').results).toEqual([]);
+    expect(byCandidate.get('B').error).toContain('boom');
+  });
+});


### PR DESCRIPTION
## Venture domain automation A — the read-only availability half

Coordinator-directed BUILD (rank-1 high; feeds the chairman CF domain decision).

- **`lib/venture-domains/availability.js`** — pure adapter: `generatePermutations` (exact-FIRST ordering, get-/try- prefixes, hyphenation, .com/.io/.app/.ai default, deduped/capped), `checkDomainAvailability` via **injected fetch** against RDAP (`404=available, 2xx=taken, everything else=unknown` with reason — the honest-gauge invariant: a fault is NEVER coerced to 'available'), `createRateBudget` (max lookups + pacing via injected clock/sleep; exhausted tail reports `unknown('budget_exhausted')`).
- **`lib/venture-domains/stage-integration.js`** — activation seam + helpers: `resolveAvailabilityChecker` returns null unless `DOMAIN_AVAILABILITY_MODE=live`; availability scoring (exact-open=100 / any-open=70 / all-taken=0 / unknowns=40) with the criterion weight renormalized to sum 100; decision verdict (string contract) + `domainDetail` sibling; per-TLD naming statuses; `buildDomainShortlist` (taken excluded, exact-available first, `price: null` until a registrar adapter exists).
- **`stage-11-visual-identity.js`** — the persisted-decision home (the SD's nominal "Stage-10": Stage 10's parallel decision block is never written to `identity_brand_name`; Stage 11's is, and it is what S11 name-promotion + chairman-product-review consume). Seam is **DEFAULT OFF → byte-identical**: the four pinned all-`'pending'` assertions (brand-stage-wiring:92, analysis-steps:166/704/765) pass UNMODIFIED. Active: candidates gain an Availability criterion + scores, `decision.availabilityChecks.domain` carries the real verdict for the selected name, `naming_suggestions.domain_*_status` get real values (were hardcoded 'unknown'), and `domainShortlist` rides the existing `identity_brand_name` artifactData (no new artifact type, no migration).

**Tests:** 17 new (adapter invariants incl. never-false-available + budget exhaustion + pacing; seam OFF byte-identity incl. injection-wins-over-env; seam ON scoring/verdict/detail/throwing-checker degradation). Existing stage-10/11, brand-wiring, and S11-brand-grounded suites green unmodified. The 2 failures in `analysis-steps.test.js` are **pre-existing on clean main** (Stage-14 house-stack fixture drift — logged to harness backlog), db-project, untouched by this diff.

**Activation:** one env var on the stage worker (`DOMAIN_AVAILABILITY_MODE=live`, optional `DOMAIN_AVAILABILITY_WEIGHT`/`_TLDS`) — documented follow-on. Fenced: registrar pricing (credentials), purchase/DNS (acquisition SD), trademark/social (stay pending).

LOC justification (>100): adapter + seam + tests are one contract (adapter alone would ship unverifiable, wiring alone unactivatable); ~240 impl + ~230 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)