### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A): funnel gauge STALE semantics, /v1/metrics stack-CI check, gauge liveness canary, launch_mode precondition

### DIFF
--- a/database/migrations/20260710_venture_metrics_cadence_hours.sql
+++ b/database/migrations/20260710_venture_metrics_cadence_hours.sql
@@ -1,0 +1,16 @@
+-- Migration: 20260710_venture_metrics_cadence_hours.sql
+-- SD: SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-2)
+-- Purpose: per-venture override for the funnel gauge's declared-writer expected
+--          cadence (lib/telemetry/funnel-gauge.mjs). NULL = use the module's
+--          DEFAULT_CADENCE_HOURS (30h, buffered over the daily pull cron).
+--          Additive, nullable — zero-risk to existing consumers of applications.
+-- @approved-by: codestreetlabs@gmail.com
+
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS metrics_cadence_hours INTEGER;
+
+COMMENT ON COLUMN applications.metrics_cadence_hours IS 'Declared expected /v1/metrics pull cadence in hours for the funnel gauge STALE check (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A). NULL = use lib/telemetry/funnel-gauge.mjs DEFAULT_CADENCE_HOURS.';
+
+-- ============================================================================
+-- ROLLBACK (manual):
+--   ALTER TABLE applications DROP COLUMN IF EXISTS metrics_cadence_hours;
+-- ============================================================================

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-10T01:07:31.197Z",
+ "generated_at": "2026-07-10T01:22:31.386Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
  "table_count": 780,
  "view_count": 177,
@@ -734,7 +734,6 @@
   "venture_market_analysis": "{id,venture_id,tam_estimate,sam_estimate,som_estimate,market_trends,methodology,confidence_score,metadata,created_at,updated_at}",
   "venture_milestones": "{id,venture_id,stage_number,milestone_name,start_date,end_date,status,dependencies,metadata,created_at,updated_at}",
   "venture_nursery": "{id,brief_id,name,description,maturity_level,trigger_conditions,current_score,score_history,last_evaluated_at,next_evaluation_at,evaluation_interval_days,promoted_to_venture_id,promoted_at,source_type,source_ref,created_at,updated_at}",
-  "venture_deployments": "{id,venture_id,sha,revision,url,actor,status,error,metadata,created_at}",
   "venture_persona_mapping": "{id,venture_id,persona_id,relevance_score,notes,created_by,created_at,updated_at}",
   "venture_phase_budgets": "{id,venture_id,phase_name,budget_allocated,budget_remaining,phase_started_at,phase_completed_at,created_at,updated_at}",
   "venture_postmortems": "{id,venture_id,venture_name,venture_start_date,failure_date,why_1,why_1_evidence,why_2,why_2_evidence,why_3,why_3_evidence,why_4,why_4_evidence,why_5,why_5_evidence,root_cause_summary,contributing_factors,linked_sd_ids,linked_pattern_ids,status,assigned_to,reviewed_by,review_date,created_by,updated_by,created_at,updated_at}",

--- a/lib/eva/bridge/templates/venture-stack-compliance.test.template.js
+++ b/lib/eva/bridge/templates/venture-stack-compliance.test.template.js
@@ -25,7 +25,7 @@ test('venture uses NO forbidden stack (@supabase / Replit Auth / OIDC)', () => {
   );
 });
 
-test('venture HAS the required stack (Clerk + Replit Postgres)', () => {
+test('venture HAS the required stack (Clerk + Replit Postgres + GET /v1/metrics)', () => {
   const { missing } = scanForStackViolations(ROOT);
   assert.equal(missing.length, 0, `missing required stack: ${missing.join('; ')}`);
 });

--- a/lib/eva/bridge/templates/venture-stack-scan.js
+++ b/lib/eva/bridge/templates/venture-stack-scan.js
@@ -17,9 +17,15 @@ export const FORBIDDEN_IMPORTS = [
 // Hand-rolled Replit-Auth / OIDC artifacts, detectable by file path (the B1 class).
 export const FORBIDDEN_FILE_RE = /(?:^|[\\/])(?:auth[\\/]oidc\.|oidc\.server\.|session\.server\.|api\.auth\.)/i;
 // Required stack (at least one src file must evidence each).
+// SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-1): v1_metrics makes
+// docs/03_protocols_and_standards/venture-metrics-standard.md's GET /v1/metrics
+// endpoint a venture-template requirement, closing the "zero implementing
+// ventures" gap — matched by route-path literal, framework-agnostic (Express
+// `.get('/v1/metrics', ...)`, Next-style string routes, etc.).
 export const REQUIRED = [
   { id: 'clerk', test: (s) => /['"]@clerk\//.test(s), why: 'Clerk (@clerk/*) is the canonical venture auth' },
   { id: 'replit_postgres', test: (s) => /\bDATABASE_URL\b/.test(s) || /(?:from|import|require\()\s*['"](?:pg|drizzle-orm)/.test(s), why: 'Replit Postgres (DATABASE_URL / pg / drizzle)' },
+  { id: 'v1_metrics', test: (s) => /['"`]\/v1\/metrics['"`]/.test(s), why: 'GET /v1/metrics implementation (docs/03_protocols_and_standards/venture-metrics-standard.md) — no route/handler referencing "/v1/metrics" found in venture src' },
 ];
 // Stateless-process factory rule (SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E, deploy
 // design §7 risk 6): venture app processes are STATELESS — durable state lives in the

--- a/lib/eva/bridge/templates/venture-stack-scan.js
+++ b/lib/eva/bridge/templates/venture-stack-scan.js
@@ -20,12 +20,21 @@ export const FORBIDDEN_FILE_RE = /(?:^|[\\/])(?:auth[\\/]oidc\.|oidc\.server\.|s
 // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-1): v1_metrics makes
 // docs/03_protocols_and_standards/venture-metrics-standard.md's GET /v1/metrics
 // endpoint a venture-template requirement, closing the "zero implementing
-// ventures" gap — matched by route-path literal, framework-agnostic (Express
-// `.get('/v1/metrics', ...)`, Next-style string routes, etc.).
+// ventures" gap. Matched two ways: (a) a route-path literal in source (Express
+// `.get('/v1/metrics', ...)`, template-literal routes), OR (b) a file-based-
+// routing path (Next.js App Router `.../v1/metrics/route.ts`, Pages Router
+// `.../api/v1/metrics.ts`), since the URL there comes from the folder
+// structure and the literal string never appears in content. KNOWN LIMITATION
+// (adversarial review, PR #5774): a prefix-mounted-router split across two
+// files (e.g. `app.use('/v1', router)` in one file, `router.get('/metrics', ...)`
+// in another) is NOT detected — closing that would need cross-file mount
+// tracking, out of scope for this content/path-only scanner.
+const V1_METRICS_CONTENT_RE = /['"`]\/v1\/metrics['"`]/;
+const V1_METRICS_FILE_PATH_RE = /(?:^|\/)(?:api\/)?v1\/metrics(?:\/route)?\.[jt]sx?$/i;
 export const REQUIRED = [
   { id: 'clerk', test: (s) => /['"]@clerk\//.test(s), why: 'Clerk (@clerk/*) is the canonical venture auth' },
   { id: 'replit_postgres', test: (s) => /\bDATABASE_URL\b/.test(s) || /(?:from|import|require\()\s*['"](?:pg|drizzle-orm)/.test(s), why: 'Replit Postgres (DATABASE_URL / pg / drizzle)' },
-  { id: 'v1_metrics', test: (s) => /['"`]\/v1\/metrics['"`]/.test(s), why: 'GET /v1/metrics implementation (docs/03_protocols_and_standards/venture-metrics-standard.md) — no route/handler referencing "/v1/metrics" found in venture src' },
+  { id: 'v1_metrics', test: (s, file) => V1_METRICS_CONTENT_RE.test(s) || (file != null && V1_METRICS_FILE_PATH_RE.test(file)), why: 'GET /v1/metrics implementation (docs/03_protocols_and_standards/venture-metrics-standard.md) — no route/handler referencing "/v1/metrics" (by content or file-based route path) found in venture src' },
 ];
 // Stateless-process factory rule (SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E, deploy
 // design §7 risk 6): venture app processes are STATELESS — durable state lives in the
@@ -89,10 +98,13 @@ export function scanForStackViolations(root, ioOrFactory = realIo) {
     if (FORBIDDEN_FILE_RE.test(file)) {
       violations.push({ file, why: `forbidden auth/OIDC file path (Replit Auth class): ${file}` });
     }
+    // File-path-only REQUIRED checks (e.g. Next.js file-based routing) can be satisfied
+    // without reading content, so evaluate those even if the file read below fails.
+    for (const r of REQUIRED) if (!requiredPresent.has(r.id) && r.test('', file)) requiredPresent.add(r.id);
     let src;
     try { src = io.read(file); } catch { continue; }
     for (const f of FORBIDDEN_IMPORTS) if (f.re.test(src)) violations.push({ file, why: f.why });
-    for (const r of REQUIRED) if (!requiredPresent.has(r.id) && r.test(src)) requiredPresent.add(r.id);
+    for (const r of REQUIRED) if (!requiredPresent.has(r.id) && r.test(src, file)) requiredPresent.add(r.id);
     for (const c of STATELESS_PROCESS_CHECKS) if (c.test(src)) warnings.push({ file, why: c.why, class: 'stateless_process' });
   }
   const missing = REQUIRED.filter((r) => !requiredPresent.has(r.id)).map((r) => r.why);

--- a/lib/eva/external-observation.js
+++ b/lib/eva/external-observation.js
@@ -6,17 +6,30 @@
  * pure verifier (independently unit-testable, zero I/O) and an I/O collector
  * (the sole boundary that talks to the network/DB), matching this repo's
  * pure-logic/IO-boundary convention (e.g. lib/governance/*-gauges.js).
+ *
+ * SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-5): telemetryRowCount was a
+ * documented forward dependency, hardcoded null forever — which meant
+ * verifyExternalObservation().verified was structurally UNSATISFIABLE (checks.every()
+ * requires all 3, and telemetry_rows_arrive can never pass typeof-number+>0 against
+ * null), so launch_mode='live' has been permanently unreachable via this path since
+ * SD-LEO-INFRA-LAUNCH-MODE-POLICY-001 shipped. Now wired to the real
+ * venture_telemetry table (SD-LEO-INFRA-VENTURE-TELEMETRY-PULL-001-C). Also adds a
+ * NEW, distinct gaugeWriterAlive observation + check: telemetry_rows_arrive answers
+ * "has real data EVER landed" (historical), gauge_writer_alive answers "is the
+ * funnel gauge currently live within its declared cadence" (current) — see
+ * lib/telemetry/funnel-gauge.mjs.
  */
+import { computeGaugeState } from '../telemetry/funnel-gauge.mjs';
 
 const FETCH_TIMEOUT_MS = 5000;
 
 /**
  * Pure verifier. Any input that cannot be evaluated (null/undefined) fails
  * CLOSED with reason 'NO_DATA_SOURCE' — it never silently defaults to a pass.
- * @param {{endpointStatus?: number|null, billingProductId?: string|null, telemetryRowCount?: number|null}} observations
+ * @param {{endpointStatus?: number|null, billingProductId?: string|null, telemetryRowCount?: number|null, gaugeWriterAlive?: boolean|null}} observations
  * @returns {{verified: boolean, checks: Array<{name: string, verified: boolean, reason: string}>}}
  */
-export function verifyExternalObservation({ endpointStatus, billingProductId, telemetryRowCount } = {}) {
+export function verifyExternalObservation({ endpointStatus, billingProductId, telemetryRowCount, gaugeWriterAlive } = {}) {
   const checks = [
     {
       name: 'endpoint_200',
@@ -33,24 +46,27 @@ export function verifyExternalObservation({ endpointStatus, billingProductId, te
       verified: typeof telemetryRowCount === 'number' && telemetryRowCount > 0,
       reason: telemetryRowCount == null ? 'NO_DATA_SOURCE' : (telemetryRowCount > 0 ? '' : 'zero telemetry rows'),
     },
+    {
+      name: 'gauge_writer_alive',
+      verified: gaugeWriterAlive === true,
+      reason: gaugeWriterAlive == null ? 'NO_DATA_SOURCE' : (gaugeWriterAlive ? '' : 'funnel gauge writer is not currently live (no_writer_yet or stale)'),
+    },
   ];
   return { verified: checks.every((c) => c.verified), checks };
 }
 
 /**
  * I/O boundary: collects what THIS repo can ground today for a venture's
- * external observations. telemetryRowCount has no existing data source
- * (no telemetry/analytics table for ventures) — returned as null, a documented
- * forward dependency (see PRD risk), NOT stubbed to a passing value.
+ * external observations.
  * @param {{supabase: object, ventureId: string}} params
- * @returns {Promise<{endpointStatus: number|null, billingProductId: string|null, telemetryRowCount: number|null}>}
+ * @returns {Promise<{endpointStatus: number|null, billingProductId: string|null, telemetryRowCount: number|null, gaugeWriterAlive: boolean|null}>}
  */
 export async function collectExternalObservations({ supabase, ventureId }) {
   let application = null;
   try {
     const { data } = await supabase
       .from('applications')
-      .select('deployment_url, metadata')
+      .select('id, deployment_url, metadata, metrics_cadence_hours')
       .eq('venture_id', ventureId)
       .maybeSingle();
     application = data || null;
@@ -73,5 +89,25 @@ export async function collectExternalObservations({ supabase, ventureId }) {
 
   const billingProductId = application?.metadata?.billing_product_id || null;
 
-  return { endpointStatus, billingProductId, telemetryRowCount: null };
+  let telemetryRowCount = null;
+  let gaugeWriterAlive = null;
+  if (application?.id) {
+    try {
+      const { data: telemetryRow } = await supabase
+        .from('venture_telemetry')
+        .select('kpis, pulled_at, ingest_status')
+        .eq('application_id', application.id)
+        .maybeSingle();
+      const kpisEverLanded = !!telemetryRow?.kpis && typeof telemetryRow.kpis === 'object' && Object.keys(telemetryRow.kpis).length > 0;
+      telemetryRowCount = kpisEverLanded ? 1 : 0;
+      const gaugeOpts = { telemetryRow: telemetryRow || null };
+      if (typeof application.metrics_cadence_hours === 'number') gaugeOpts.cadenceHours = application.metrics_cadence_hours;
+      gaugeWriterAlive = computeGaugeState(gaugeOpts).state === 'live';
+    } catch {
+      telemetryRowCount = null;
+      gaugeWriterAlive = null;
+    }
+  }
+
+  return { endpointStatus, billingProductId, telemetryRowCount, gaugeWriterAlive };
 }

--- a/lib/telemetry/canary-gauge-liveness.mjs
+++ b/lib/telemetry/canary-gauge-liveness.mjs
@@ -1,0 +1,36 @@
+/**
+ * Synthetic-visit canary liveness proof — SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-4.
+ *
+ * Pure assertion: given the result of a real (or injected, for tests) /v1/metrics
+ * pull (scripts/venture-telemetry-pull.mjs pullVenture()) and the resulting funnel
+ * gauge state (lib/telemetry/funnel-gauge.mjs computeGaugeState()), decides whether
+ * the synthetic visit + signup genuinely registered end-to-end. A successful HTTP
+ * pull alone is NOT sufficient proof — the gauge must also read 'live', closing the
+ * loop between "the endpoint responded" and "the platform's gauge trusts it".
+ *
+ * @module lib/telemetry/canary-gauge-liveness
+ */
+
+/**
+ * @param {object} opts
+ * @param {{outcome: string}} opts.pullResult - the pullVenture() result for the canary run
+ * @param {{state: string}} opts.gaugeState - computeGaugeState() output AFTER persisting pullResult
+ * @returns {{passed: boolean, reason: string}}
+ */
+export function assertGaugeLivenessProof({ pullResult, gaugeState }) {
+  if (pullResult?.outcome !== 'ok') {
+    return {
+      passed: false,
+      reason: `synthetic pull did not succeed (outcome='${pullResult?.outcome ?? 'missing'}') — no real data reached the venture's /v1/metrics endpoint`,
+    };
+  }
+  if (gaugeState?.state !== 'live') {
+    return {
+      passed: false,
+      reason: `pull succeeded but the funnel gauge state is '${gaugeState?.state ?? 'missing'}', not 'live' — the canary visit did not register end-to-end`,
+    };
+  }
+  return { passed: true, reason: 'synthetic visit registered end-to-end: pull succeeded and the funnel gauge reads live' };
+}
+
+export default { assertGaugeLivenessProof };

--- a/lib/telemetry/funnel-gauge.mjs
+++ b/lib/telemetry/funnel-gauge.mjs
@@ -1,0 +1,65 @@
+/**
+ * Funnel gauge STALE / no-writer-yet semantics — SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-2.
+ *
+ * Layers a declared-writer + expected-cadence contract on TOP of the existing
+ * venture_telemetry table/writer (scripts/venture-telemetry-pull.mjs) — no new
+ * table, additive only. Three states, never a fabricated number:
+ *   - 'no_writer_yet': no venture_telemetry row, or the row has never carried a
+ *     validated kpis payload (a writer that always errors/skips never counts as
+ *     "having written" — kpis persists from the last GOOD pull, per
+ *     persistResult's metadata-only update on failure).
+ *   - 'live': the most recent pull was 'ok' and landed within the cadence window.
+ *   - 'stale': a writer existed before (kpis non-empty) but the current state is
+ *     not a fresh 'ok' pull — either the latest attempt failed/skipped, or the
+ *     cadence window has elapsed since the last successful pull.
+ *
+ * @module lib/telemetry/funnel-gauge
+ */
+
+/** Default expected pull cadence: the daily cron (scripts/venture-telemetry-pull.mjs
+ *  docstring: "daily PULL") plus a generous buffer for scheduling jitter. */
+export const DEFAULT_CADENCE_HOURS = 30;
+
+function hasEverWritten(telemetryRow) {
+  const kpis = telemetryRow?.kpis;
+  return !!kpis && typeof kpis === 'object' && Object.keys(kpis).length > 0;
+}
+
+/**
+ * Pure gauge-state computation. No I/O — caller supplies the venture_telemetry
+ * row (or null) and the declared cadence.
+ * @param {object} opts
+ * @param {object|null} opts.telemetryRow - a venture_telemetry row, or null if none exists
+ * @param {Date} [opts.now]
+ * @param {number} [opts.cadenceHours] - declared expected-pull cadence for this venture
+ * @returns {{state: 'no_writer_yet'|'live'|'stale', reason: string}}
+ */
+export function computeGaugeState({ telemetryRow, now = new Date(), cadenceHours = DEFAULT_CADENCE_HOURS }) {
+  if (!hasEverWritten(telemetryRow)) {
+    return { state: 'no_writer_yet', reason: telemetryRow ? 'no validated KPI payload has ever landed for this venture' : 'no venture_telemetry row exists for this venture' };
+  }
+
+  const pulledAt = telemetryRow.pulled_at ? new Date(telemetryRow.pulled_at) : null;
+  const ageHours = pulledAt ? (now.getTime() - pulledAt.getTime()) / (1000 * 60 * 60) : Infinity;
+
+  if (telemetryRow.ingest_status === 'ok' && ageHours <= cadenceHours) {
+    return { state: 'live', reason: `last successful pull ${ageHours.toFixed(1)}h ago, within the ${cadenceHours}h cadence window` };
+  }
+
+  if (telemetryRow.ingest_status !== 'ok') {
+    return { state: 'stale', reason: `writer has prior data but the latest pull attempt was '${telemetryRow.ingest_status}', not 'ok'` };
+  }
+  return { state: 'stale', reason: `last successful pull was ${ageHours.toFixed(1)}h ago, exceeding the ${cadenceHours}h cadence window` };
+}
+
+/**
+ * True only when the gauge is genuinely 'live' — the single boolean a caller
+ * (e.g. a launch_mode=live precondition) needs, without inspecting state internals.
+ * @param {object} opts - same shape as computeGaugeState
+ * @returns {boolean}
+ */
+export function isGaugeWriterAlive(opts) {
+  return computeGaugeState(opts).state === 'live';
+}
+
+export default { DEFAULT_CADENCE_HOURS, computeGaugeState, isGaugeWriterAlive };

--- a/scripts/canary/run-gauge-liveness-probe.mjs
+++ b/scripts/canary/run-gauge-liveness-probe.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Funnel-gauge synthetic-visit liveness probe — SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-4.
+ *
+ * Distinct from scripts/canary/run-canary-probe.mjs (which drives an isolated
+ * synthetic VENTURE through stage machinery). This probe targets a REAL,
+ * instrumented venture's /v1/metrics endpoint via the existing pull mechanism
+ * (scripts/venture-telemetry-pull.mjs pullVenture) and asserts the resulting
+ * funnel gauge reads 'live' — proving a synthetic visit registers end-to-end
+ * before the gauge is trusted, per docs/design/venture-demand-distribution-engine.md.
+ *
+ * Gated by leo_feature_flags FUNNEL_GAUGE_CANARY_V1 (ships OFF), mirroring the
+ * flag-gating convention in scripts/canary/canary-core.mjs.
+ *
+ * Usage: node scripts/canary/run-gauge-liveness-probe.mjs --application-id <uuid> [--force-local]
+ */
+import { createClient } from '@supabase/supabase-js';
+import { pathToFileURL } from 'node:url';
+import { config } from 'dotenv';
+import { pullVenture, persistResult } from '../venture-telemetry-pull.mjs';
+import { computeGaugeState } from '../../lib/telemetry/funnel-gauge.mjs';
+import { assertGaugeLivenessProof } from '../../lib/telemetry/canary-gauge-liveness.mjs';
+
+config();
+
+export const GAUGE_CANARY_FLAG = 'FUNNEL_GAUGE_CANARY_V1';
+
+const args = process.argv.slice(2);
+const argVal = (name) => { const i = args.indexOf(name); return i !== -1 && args[i + 1] ? args[i + 1] : null; };
+const FORCE_LOCAL = args.includes('--force-local');
+const APPLICATION_ID = argVal('--application-id');
+
+async function flagEnabled(supabase) {
+  const { data } = await supabase.from('leo_feature_flags').select('is_enabled').eq('flag_key', GAUGE_CANARY_FLAG).maybeSingle();
+  return data?.is_enabled === true;
+}
+
+/**
+ * Run the probe against one application row. Injectable deps for testing;
+ * defaults are the real pull mechanism + real gauge computation.
+ * @param {{supabase: object, application: object, now?: Date, cadenceHours?: number, fetchFn?: Function}} opts
+ * @returns {Promise<{passed: boolean, reason: string}>}
+ */
+export async function runGaugeLivenessProbe({ supabase, application, now = new Date(), cadenceHours, fetchFn }) {
+  const pullResult = await pullVenture(application, { fetchFn, now });
+  await persistResult(supabase, application, pullResult);
+
+  const { data: telemetryRow } = await supabase
+    .from('venture_telemetry').select('kpis, pulled_at, ingest_status').eq('application_id', application.id).maybeSingle();
+  const gaugeOpts = { telemetryRow: telemetryRow || null, now };
+  if (typeof cadenceHours === 'number') gaugeOpts.cadenceHours = cadenceHours;
+  const gaugeState = computeGaugeState(gaugeOpts);
+
+  return assertGaugeLivenessProof({ pullResult, gaugeState });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  (async () => {
+    if (!FORCE_LOCAL && !(await flagEnabled(supabase))) {
+      console.log(`[gauge-liveness-probe] flag ${GAUGE_CANARY_FLAG} is disabled — quiet refusal (enable it or pass --force-local)`);
+      process.exit(0);
+    }
+    if (!APPLICATION_ID) {
+      console.error('[gauge-liveness-probe] --application-id <uuid> is required');
+      process.exit(1);
+    }
+    const { data: application, error } = await supabase
+      .from('applications').select('id, name, venture_id, metrics_base_url, metrics_api_key_ref, metrics_cadence_hours').eq('id', APPLICATION_ID).maybeSingle();
+    if (error || !application) {
+      console.error(`[gauge-liveness-probe] application ${APPLICATION_ID} not found: ${error?.message ?? 'no row'}`);
+      process.exit(1);
+    }
+    const result = await runGaugeLivenessProbe({ supabase, application, cadenceHours: application.metrics_cadence_hours ?? undefined });
+    console.log(JSON.stringify(result));
+    process.exit(result.passed ? 0 : 1);
+  })();
+}
+
+export default { GAUGE_CANARY_FLAG, runGaugeLivenessProbe };

--- a/tests/unit/canary/run-gauge-liveness-probe.test.js
+++ b/tests/unit/canary/run-gauge-liveness-probe.test.js
@@ -1,0 +1,63 @@
+// SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-4)
+import { describe, it, expect, vi } from 'vitest';
+import { runGaugeLivenessProbe } from '../../../scripts/canary/run-gauge-liveness-probe.mjs';
+
+const APP = { id: 'app-1', name: 'TestVenture', venture_id: 'v-1', metrics_base_url: 'https://example.com', metrics_api_key_ref: 'TEST_KEY' };
+
+/** Records upserts/updates into venture_telemetry and answers the post-pull select. */
+function buildSupabase({ telemetryRowAfterPull }) {
+  const calls = [];
+  return {
+    calls,
+    from: (table) => {
+      if (table !== 'venture_telemetry') throw new Error(`unexpected table: ${table}`);
+      return {
+        upsert: (row) => { calls.push({ op: 'upsert', row }); return { error: null }; },
+        update: (row) => { calls.push({ op: 'update', row }); return { eq: () => ({ select: async () => ({ data: [{ id: 1 }], error: null }) }) }; },
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: telemetryRowAfterPull, error: null }) }) }),
+      };
+    },
+  };
+}
+
+describe('runGaugeLivenessProbe (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-4)', () => {
+  it('passes end-to-end: a successful synthetic pull + fresh telemetry row yields passed:true', async () => {
+    const now = new Date('2026-07-10T12:00:00Z');
+    const fetchFn = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ contract_version: '1.0', total: 1, kpis: { signups: 1 } }),
+    });
+    process.env.TEST_KEY = 'fake-key';
+    const supabase = buildSupabase({
+      telemetryRowAfterPull: { kpis: { signups: 1 }, pulled_at: now.toISOString(), ingest_status: 'ok' },
+    });
+    const result = await runGaugeLivenessProbe({ supabase, application: APP, now, fetchFn });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when the endpoint pull itself errors', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('unreachable'));
+    process.env.TEST_KEY = 'fake-key';
+    const supabase = buildSupabase({ telemetryRowAfterPull: null });
+    const result = await runGaugeLivenessProbe({ supabase, application: APP, fetchFn });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/did not succeed/);
+  });
+
+  it('fails when the pull succeeds but the persisted row reads stale against a tight cadence', async () => {
+    const now = new Date('2026-07-10T12:00:00Z');
+    const fetchFn = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ contract_version: '1.0', total: 1, kpis: { signups: 1 } }),
+    });
+    process.env.TEST_KEY = 'fake-key';
+    const supabase = buildSupabase({
+      telemetryRowAfterPull: { kpis: { signups: 1 }, pulled_at: new Date(now.getTime() - 5 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+    });
+    const result = await runGaugeLivenessProbe({ supabase, application: APP, now, fetchFn, cadenceHours: 1 });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/did not register end-to-end/);
+  });
+});

--- a/tests/unit/eva/bridge/venture-stack-ci-mandate.test.js
+++ b/tests/unit/eva/bridge/venture-stack-ci-mandate.test.js
@@ -90,6 +90,26 @@ describe('FR-3 — the reusable scanner catches off-stack CODE (not just deps)',
     expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(false);
   });
 
+  // Adversarial review (PR #5774): the content-only regex missed Next.js file-based routing,
+  // where the URL comes from the folder structure and the literal string never appears in source.
+  it('PASSES v1/metrics detection for a Next.js App Router file-based route (no string literal in content)', () => {
+    const io = { files: ['src/app/api/v1/metrics/route.ts'], read: () => 'export async function GET() { return Response.json(kpis); }' };
+    const { missing } = scanForStackViolations('/x', io);
+    expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(false);
+  });
+
+  it('PASSES v1/metrics detection for a Next.js Pages Router API file (no string literal in content)', () => {
+    const io = { files: ['src/pages/api/v1/metrics.ts'], read: () => 'export default function handler(req, res) { res.json(kpis); }' };
+    const { missing } = scanForStackViolations('/x', io);
+    expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(false);
+  });
+
+  it('does not false-positive v1/metrics on an unrelated file path containing similar segments', () => {
+    const io = { files: ['src/pages/v1/metrics-summary.ts'], read: () => 'export default function() {}' };
+    const { missing } = scanForStackViolations('/x', io);
+    expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(true);
+  });
+
   it('the scanner encodes the standard (supabase + openid forbidden imports present)', () => {
     const ids = FORBIDDEN_IMPORTS.map((f) => f.id);
     expect(ids).toContain('supabase');

--- a/tests/unit/eva/bridge/venture-stack-ci-mandate.test.js
+++ b/tests/unit/eva/bridge/venture-stack-ci-mandate.test.js
@@ -51,12 +51,13 @@ describe('FR-3 — the reusable scanner catches off-stack CODE (not just deps)',
     expect(violations.some((v) => v.why.includes('Supabase'))).toBe(true);
   });
 
-  it('PASSES a Clerk + Replit-Postgres compliant venture (no false block)', () => {
+  it('PASSES a Clerk + Replit-Postgres + /v1/metrics compliant venture (no false block)', () => {
     const io = {
-      files: ['src/routes/__root.tsx', 'src/lib/db.ts'],
+      files: ['src/routes/__root.tsx', 'src/lib/db.ts', 'src/routes/api.v1.metrics.ts'],
       read: (rel) => ({
         'src/routes/__root.tsx': 'import { ClerkProvider } from "@clerk/tanstack-react-start";',
         'src/lib/db.ts': 'const url = process.env.DATABASE_URL; import pg from "pg";',
+        'src/routes/api.v1.metrics.ts': 'app.get("/v1/metrics", async (req, res) => { /* aggregates-only KPI response */ });',
       }[rel]),
     };
     const { violations, missing } = scanForStackViolations('/x', io);
@@ -64,10 +65,29 @@ describe('FR-3 — the reusable scanner catches off-stack CODE (not just deps)',
     expect(missing.length).toBe(0);
   });
 
-  it('reports MISSING required stack when Clerk/Postgres absent (advisory completeness)', () => {
+  it('reports MISSING required stack when Clerk/Postgres/v1-metrics all absent (advisory completeness)', () => {
     const io = { files: ['src/index.ts'], read: () => 'export const x = 1;' };
     const { missing } = scanForStackViolations('/x', io);
     expect(missing.length).toBe(REQUIRED.length);
+  });
+
+  // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-1)
+  it('FLAGS a venture missing GET /v1/metrics even when Clerk + Postgres are both present', () => {
+    const io = {
+      files: ['src/routes/__root.tsx', 'src/lib/db.ts'],
+      read: (rel) => ({
+        'src/routes/__root.tsx': 'import { ClerkProvider } from "@clerk/tanstack-react-start";',
+        'src/lib/db.ts': 'const url = process.env.DATABASE_URL; import pg from "pg";',
+      }[rel]),
+    };
+    const { missing } = scanForStackViolations('/x', io);
+    expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(true);
+  });
+
+  it('PASSES v1/metrics detection for a route registered as a template literal', () => {
+    const io = { files: ['src/server.ts'], read: () => 'router.get(`/v1/metrics`, handler);' };
+    const { missing } = scanForStackViolations('/x', io);
+    expect(missing.some((m) => /v1\/metrics/.test(m))).toBe(false);
   });
 
   it('the scanner encodes the standard (supabase + openid forbidden imports present)', () => {

--- a/tests/unit/eva/external-observation.test.js
+++ b/tests/unit/eva/external-observation.test.js
@@ -3,11 +3,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { verifyExternalObservation, collectExternalObservations } from '../../../lib/eva/external-observation.js';
 
 describe('verifyExternalObservation (pure, SD-LEO-INFRA-LAUNCH-MODE-POLICY-001 FR-2)', () => {
-  it('verified:true only when all 3 checks pass', () => {
-    const result = verifyExternalObservation({ endpointStatus: 200, billingProductId: 'prod_123', telemetryRowCount: 5 });
+  it('verified:true only when all 4 checks pass', () => {
+    const result = verifyExternalObservation({ endpointStatus: 200, billingProductId: 'prod_123', telemetryRowCount: 5, gaugeWriterAlive: true });
     expect(result.verified).toBe(true);
-    expect(result.checks).toHaveLength(3);
+    expect(result.checks).toHaveLength(4);
     expect(result.checks.every((c) => c.verified)).toBe(true);
+  });
+
+  it('fails (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-5) when gaugeWriterAlive is false even though the other 3 checks pass', () => {
+    const result = verifyExternalObservation({ endpointStatus: 200, billingProductId: 'prod_123', telemetryRowCount: 5, gaugeWriterAlive: false });
+    expect(result.verified).toBe(false);
+    const gaugeCheck = result.checks.find((c) => c.name === 'gauge_writer_alive');
+    expect(gaugeCheck.verified).toBe(false);
+    expect(gaugeCheck.reason).toMatch(/not currently live/);
   });
 
   it('fails closed (verified:false, reason NO_DATA_SOURCE) when inputs are missing — never silently passes', () => {
@@ -48,30 +56,41 @@ describe('collectExternalObservations (I/O boundary, SD-LEO-INFRA-LAUNCH-MODE-PO
   const originalFetch = global.fetch;
   afterEach(() => { global.fetch = originalFetch; });
 
-  function buildSupabase({ row, error = null } = {}) {
-    const chain = { eq: () => chain, maybeSingle: async () => ({ data: row, error }) };
-    return { from: () => ({ select: () => chain }) };
+  /** Routes by table name so applications + venture_telemetry can return distinct rows. */
+  function buildSupabase({ applicationRow, telemetryRow, applicationError = null, telemetryError = null } = {}) {
+    return {
+      from: (table) => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => (table === 'applications'
+              ? { data: applicationRow, error: applicationError }
+              : { data: telemetryRow, error: telemetryError }),
+          }),
+        }),
+      }),
+    };
   }
 
-  it('returns endpointStatus from a successful fetch and billingProductId from application.metadata', async () => {
+  it('returns endpointStatus from a successful fetch and billingProductId from application.metadata (no application.id — telemetry lookup skipped)', async () => {
     global.fetch = vi.fn().mockResolvedValue({ status: 200 });
-    const supabase = buildSupabase({ row: { deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' } } });
+    const supabase = buildSupabase({ applicationRow: { deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' } } });
     const result = await collectExternalObservations({ supabase, ventureId: 'venture-1' });
     expect(result.endpointStatus).toBe(200);
     expect(result.billingProductId).toBe('prod_123');
     expect(result.telemetryRowCount).toBeNull();
+    expect(result.gaugeWriterAlive).toBeNull();
   });
 
   it('returns endpointStatus=null on a fetch error rather than throwing', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('network unreachable'));
-    const supabase = buildSupabase({ row: { deployment_url: 'https://example.com', metadata: {} } });
+    const supabase = buildSupabase({ applicationRow: { deployment_url: 'https://example.com', metadata: {} } });
     const result = await collectExternalObservations({ supabase, ventureId: 'venture-1' });
     expect(result.endpointStatus).toBeNull();
   });
 
   it('returns endpointStatus=null and billingProductId=null when no application row exists', async () => {
     global.fetch = vi.fn();
-    const supabase = buildSupabase({ row: null });
+    const supabase = buildSupabase({ applicationRow: null });
     const result = await collectExternalObservations({ supabase, ventureId: 'venture-1' });
     expect(result.endpointStatus).toBeNull();
     expect(result.billingProductId).toBeNull();
@@ -84,6 +103,41 @@ describe('collectExternalObservations (I/O boundary, SD-LEO-INFRA-LAUNCH-MODE-PO
       endpointStatus: null,
       billingProductId: null,
       telemetryRowCount: null,
+      gaugeWriterAlive: null,
     });
+  });
+
+  it('SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-5: gaugeWriterAlive:true and telemetryRowCount:1 for a venture with a fresh ok pull', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    const now = new Date('2026-07-10T12:00:00Z');
+    const supabase = buildSupabase({
+      applicationRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: {}, metrics_cadence_hours: null },
+      telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(now.getTime() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+    });
+    const result = await collectExternalObservations({ supabase, ventureId: 'venture-1' });
+    expect(result.telemetryRowCount).toBe(1);
+    expect(result.gaugeWriterAlive).toBe(true);
+  });
+
+  it('SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-5: gaugeWriterAlive:false for a venture whose writer has never landed real data', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    const supabase = buildSupabase({
+      applicationRow: { id: 'app-2', deployment_url: 'https://example.com', metadata: {}, metrics_cadence_hours: null },
+      telemetryRow: null,
+    });
+    const result = await collectExternalObservations({ supabase, ventureId: 'venture-2' });
+    expect(result.telemetryRowCount).toBe(0);
+    expect(result.gaugeWriterAlive).toBe(false);
+  });
+
+  it('SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-5: honors a per-venture metrics_cadence_hours override', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    const supabase = buildSupabase({
+      applicationRow: { id: 'app-3', deployment_url: 'https://example.com', metadata: {}, metrics_cadence_hours: 1 },
+      telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 5 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+    });
+    const result = await collectExternalObservations({ supabase, ventureId: 'venture-3' });
+    // 5h stale against a 1h declared cadence -> not alive, even though the module default (30h) would have passed it.
+    expect(result.gaugeWriterAlive).toBe(false);
   });
 });

--- a/tests/unit/eva/launch-mode-residual.test.js
+++ b/tests/unit/eva/launch-mode-residual.test.js
@@ -188,8 +188,14 @@ describe('TS-4: sim work cannot masquerade as real (shared helper)', () => {
 describe('TS-5: live mode demands external observations (fail-closed)', () => {
   it('null/absent observations fail closed; verified observations pass', () => {
     expect(evaluateModeEvidence({ mode: LIVE, observations: null }).pass).toBe(false);
-    expect(evaluateModeEvidence({ mode: LIVE, observations: { endpointStatus: 200, billingProductId: 'prod_1', telemetryRowCount: 3 } }).pass).toBe(true);
-    expect(evaluateModeEvidence({ mode: LIVE, observations: { endpointStatus: 200, billingProductId: 'prod_1', telemetryRowCount: 0 } }).pass).toBe(false);
+    expect(evaluateModeEvidence({ mode: LIVE, observations: { endpointStatus: 200, billingProductId: 'prod_1', telemetryRowCount: 3, gaugeWriterAlive: true } }).pass).toBe(true);
+    expect(evaluateModeEvidence({ mode: LIVE, observations: { endpointStatus: 200, billingProductId: 'prod_1', telemetryRowCount: 0, gaugeWriterAlive: true } }).pass).toBe(false);
+  });
+
+  // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-5): new gauge_writer_alive check —
+  // endpoint + billing + telemetry all passing is no longer sufficient on its own.
+  it('fails when gaugeWriterAlive is false even though the other 3 checks pass', () => {
+    expect(evaluateModeEvidence({ mode: LIVE, observations: { endpointStatus: 200, billingProductId: 'prod_1', telemetryRowCount: 3, gaugeWriterAlive: false } }).pass).toBe(false);
   });
 });
 

--- a/tests/unit/eva/stage-24-go-live-launch-mode.test.js
+++ b/tests/unit/eva/stage-24-go-live-launch-mode.test.js
@@ -4,7 +4,7 @@ import { analyzeStage24GoLive } from '../../../lib/eva/stage-templates/analysis-
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
 
-function buildSupabase({ ventureRow, appRow } = {}) {
+function buildSupabase({ ventureRow, appRow, telemetryRow } = {}) {
   return {
     from: (table) => {
       if (table === 'ventures') {
@@ -13,6 +13,11 @@ function buildSupabase({ ventureRow, appRow } = {}) {
       }
       if (table === 'applications') {
         const chain = { eq: () => chain, maybeSingle: async () => ({ data: appRow || null, error: null }) };
+        return { select: () => chain };
+      }
+      if (table === 'venture_telemetry') {
+        // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-5): only reached when appRow.id is set.
+        const chain = { eq: () => chain, maybeSingle: async () => ({ data: telemetryRow || null, error: null }) };
         return { select: () => chain };
       }
       if (table === 'venture_artifacts') {
@@ -70,15 +75,14 @@ describe('analyzeStage24GoLive launch_mode branch (SD-LEO-INFRA-LAUNCH-MODE-POLI
     expect(result.artifacts[0].payload.labeled_simulation).toBe(true);
   });
 
-  it('live mode, all external checks pass: launches + attaches composable_evidence', async () => {
+  it('live mode, appRow has no id (no venture_telemetry lookup possible): HOLDs on missing telemetry/gauge data', async () => {
     global.fetch = vi.fn().mockResolvedValue({ status: 200 });
     const supabase = buildSupabase({
       ventureRow: { launch_mode: 'live' },
       appRow: { deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' } },
     });
-    // Monkeypatch: telemetryRowCount has no real data source yet, so this test verifies the
-    // fail-closed default UNLESS a future data source is wired — here we assert the current,
-    // honest behavior: telemetry has no source, so live mode HOLDs even with endpoint+billing OK.
+    // No appRow.id -> collectExternalObservations cannot look up venture_telemetry ->
+    // telemetryRowCount/gaugeWriterAlive stay null -> fails closed, even with endpoint+billing OK.
     const result = await analyzeStage24GoLive({
       stage23Data: { verdict: 'PASS' },
       stage22Data: { channels: [] },
@@ -94,6 +98,57 @@ describe('analyzeStage24GoLive launch_mode branch (SD-LEO-INFRA-LAUNCH-MODE-POLI
     expect(evidence.launch_mode).toBe('live');
     expect(evidence.external_observation.verified).toBe(false);
     expect(evidence.external_observation.checks.find((c) => c.name === 'telemetry_rows_arrive').reason).toBe('NO_DATA_SOURCE');
+  });
+
+  // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-5): before this SD, telemetryRowCount was
+  // hardcoded null FOREVER, so verifyExternalObservation().verified was structurally unsatisfiable —
+  // live-mode launches could never succeed via this path regardless of real venture state. This test
+  // proves the fix: a venture with real, fresh venture_telemetry data now genuinely launches.
+  it('live mode, real fresh venture_telemetry + endpoint/billing OK: launches (FR-5 fix — previously permanently unreachable)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    const supabase = buildSupabase({
+      ventureRow: { launch_mode: 'live' },
+      appRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: null },
+      telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+    });
+    const result = await analyzeStage24GoLive({
+      stage23Data: { verdict: 'PASS' },
+      stage22Data: { channels: [] },
+      ventureName: 'TestVenture',
+      logger: silentLogger,
+      launchedAt: '2026-07-03T00:00:00.000Z',
+      supabase,
+      ventureId: 'venture-1',
+    });
+    expect(result.launch_status).toBe('launched');
+    expect(result.launched_at).toBe('2026-07-03T00:00:00.000Z');
+    const evidence = result.artifacts[0].payload.composable_evidence;
+    expect(evidence.external_observation.verified).toBe(true);
+  });
+
+  // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-5): a venture with historical data whose
+  // gauge is now STALE (pull is older than its declared cadence) must still HOLD — a launch cannot
+  // proceed on a gauge writer that once worked but is no longer verifiably alive.
+  it('live mode, stale gauge (writer existed but exceeded cadence): HOLDs, never launched', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    const supabase = buildSupabase({
+      ventureRow: { launch_mode: 'live' },
+      appRow: { id: 'app-2', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: 1 },
+      telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 5 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+    });
+    const result = await analyzeStage24GoLive({
+      stage23Data: { verdict: 'PASS' },
+      stage22Data: { channels: [] },
+      ventureName: 'TestVenture',
+      logger: silentLogger,
+      launchedAt: '2026-07-03T00:00:00.000Z',
+      supabase,
+      ventureId: 'venture-1',
+    });
+    expect(result.launch_status).toBe('hold_external_observation_unverified');
+    expect(result.launched_at).toBeNull();
+    const evidence = result.artifacts[0].payload.composable_evidence;
+    expect(evidence.external_observation.checks.find((c) => c.name === 'gauge_writer_alive').verified).toBe(false);
   });
 
   it('live mode, no external evidence at all: HOLD with per-check reasons surfaced, never launched', async () => {

--- a/tests/unit/telemetry/canary-gauge-liveness.test.js
+++ b/tests/unit/telemetry/canary-gauge-liveness.test.js
@@ -1,0 +1,28 @@
+// SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-4)
+import { describe, it, expect } from 'vitest';
+import { assertGaugeLivenessProof } from '../../../lib/telemetry/canary-gauge-liveness.mjs';
+
+describe('assertGaugeLivenessProof (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-4)', () => {
+  it('passes when the pull succeeded AND the gauge reads live', () => {
+    const result = assertGaugeLivenessProof({ pullResult: { outcome: 'ok' }, gaugeState: { state: 'live' } });
+    expect(result.passed).toBe(true);
+    expect(result.reason).toMatch(/registered end-to-end/);
+  });
+
+  it('fails when the synthetic pull itself did not succeed', () => {
+    const result = assertGaugeLivenessProof({ pullResult: { outcome: 'error' }, gaugeState: { state: 'no_writer_yet' } });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/did not succeed/);
+  });
+
+  it('fails when the pull succeeded but the gauge did not register as live (FR-4 acceptance criterion 3)', () => {
+    const result = assertGaugeLivenessProof({ pullResult: { outcome: 'ok' }, gaugeState: { state: 'stale' } });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/did not register end-to-end/);
+  });
+
+  it('fails closed on missing inputs rather than throwing', () => {
+    expect(() => assertGaugeLivenessProof({})).not.toThrow();
+    expect(assertGaugeLivenessProof({}).passed).toBe(false);
+  });
+});

--- a/tests/unit/telemetry/funnel-gauge.test.js
+++ b/tests/unit/telemetry/funnel-gauge.test.js
@@ -1,0 +1,89 @@
+// SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-2)
+import { describe, it, expect } from 'vitest';
+import { computeGaugeState, isGaugeWriterAlive, DEFAULT_CADENCE_HOURS } from '../../../lib/telemetry/funnel-gauge.mjs';
+
+const NOW = new Date('2026-07-10T12:00:00.000Z');
+
+describe('computeGaugeState (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-2)', () => {
+  it('no_writer_yet when no venture_telemetry row exists', () => {
+    const result = computeGaugeState({ telemetryRow: null, now: NOW });
+    expect(result.state).toBe('no_writer_yet');
+    expect(result.reason).toMatch(/no venture_telemetry row/);
+  });
+
+  it('no_writer_yet when a row exists but kpis has never carried any validated field (e.g. always skipped/errored)', () => {
+    const result = computeGaugeState({
+      telemetryRow: { kpis: {}, pulled_at: NOW.toISOString(), ingest_status: 'skipped' },
+      now: NOW,
+    });
+    expect(result.state).toBe('no_writer_yet');
+    expect(result.reason).toMatch(/no validated KPI payload/);
+  });
+
+  it('no_writer_yet when kpis is null', () => {
+    const result = computeGaugeState({ telemetryRow: { kpis: null, pulled_at: NOW.toISOString(), ingest_status: 'error' }, now: NOW });
+    expect(result.state).toBe('no_writer_yet');
+  });
+
+  it('live when the latest pull is ok and within the cadence window', () => {
+    const pulledAt = new Date(NOW.getTime() - 5 * 3600 * 1000); // 5h ago
+    const result = computeGaugeState({
+      telemetryRow: { kpis: { signups: 10 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' },
+      now: NOW,
+      cadenceHours: DEFAULT_CADENCE_HOURS,
+    });
+    expect(result.state).toBe('live');
+    expect(result.reason).toMatch(/within the 30h cadence window/);
+  });
+
+  it('stale when the last successful pull exceeds the cadence window, even though ingest_status is ok', () => {
+    const pulledAt = new Date(NOW.getTime() - 40 * 3600 * 1000); // 40h ago, exceeds default 30h
+    const result = computeGaugeState({
+      telemetryRow: { kpis: { signups: 10 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' },
+      now: NOW,
+    });
+    expect(result.state).toBe('stale');
+    expect(result.reason).toMatch(/exceeding the 30h cadence window/);
+  });
+
+  it('stale when historical kpis exist but the LATEST attempt is not ok (writer regressed)', () => {
+    const pulledAt = new Date(NOW.getTime() - 1 * 3600 * 1000); // recent, but errored
+    const result = computeGaugeState({
+      telemetryRow: { kpis: { signups: 10 }, pulled_at: pulledAt.toISOString(), ingest_status: 'error' },
+      now: NOW,
+    });
+    expect(result.state).toBe('stale');
+    expect(result.reason).toMatch(/latest pull attempt was 'error'/);
+  });
+
+  it('honors a per-venture cadenceHours override tighter than the default', () => {
+    const pulledAt = new Date(NOW.getTime() - 2 * 3600 * 1000); // 2h ago
+    const result = computeGaugeState({
+      telemetryRow: { kpis: { signups: 10 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' },
+      now: NOW,
+      cadenceHours: 1, // 2h ago exceeds a 1h declared cadence
+    });
+    expect(result.state).toBe('stale');
+  });
+
+  it('never fabricates a number — the return shape never carries a metric value, only a state + reason', () => {
+    const result = computeGaugeState({ telemetryRow: null, now: NOW });
+    expect(Object.keys(result).sort()).toEqual(['reason', 'state']);
+  });
+});
+
+describe('isGaugeWriterAlive (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-2/FR-5)', () => {
+  it('true only for state live', () => {
+    const pulledAt = new Date(NOW.getTime() - 1 * 3600 * 1000);
+    expect(isGaugeWriterAlive({ telemetryRow: { kpis: { signups: 1 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' }, now: NOW })).toBe(true);
+  });
+
+  it('false for no_writer_yet', () => {
+    expect(isGaugeWriterAlive({ telemetryRow: null, now: NOW })).toBe(false);
+  });
+
+  it('false for stale', () => {
+    const pulledAt = new Date(NOW.getTime() - 40 * 3600 * 1000);
+    expect(isGaugeWriterAlive({ telemetryRow: { kpis: { signups: 1 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' }, now: NOW })).toBe(false);
+  });
+});

--- a/tests/unit/venture-stack-scan-stateless.test.js
+++ b/tests/unit/venture-stack-scan-stateless.test.js
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  scanForStackViolations, STATELESS_PROCESS_CHECKS,
+  scanForStackViolations, STATELESS_PROCESS_CHECKS, REQUIRED,
 } from '../../lib/eva/bridge/templates/venture-stack-scan.js';
 
 const COMPLIANT_BASE = `
@@ -71,7 +71,10 @@ describe('additive return shape (existing consumers untouched)', () => {
       'src/auth/oidc.server.ts': 'export const oidc = 1;',
     }));
     expect(r.violations.length).toBeGreaterThanOrEqual(2); // supabase import + forbidden path
-    expect(r.missing.length).toBe(2); // clerk + replit_postgres absent
+    // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A added a 3rd REQUIRED entry (v1_metrics)
+    // after this test was first written — assert against REQUIRED.length rather than a
+    // hardcoded count so future REQUIRED additions don't silently break this fixture.
+    expect(r.missing.length).toBe(REQUIRED.length); // clerk + replit_postgres + v1_metrics all absent
     expect(Array.isArray(r.warnings)).toBe(true); // additive key present
   });
 


### PR DESCRIPTION
## Summary

Demand engine Child A (funnel gauge) — the root of the venture-demand-distribution family's failure chain: without measurement, no distribution execution is verifiable ("measured or it didn't happen", design SSOT §1.5).

Delivers FR-1, FR-2, FR-4, FR-5 of the PRD:
- **FR-2** `lib/telemetry/funnel-gauge.mjs`: pure `computeGaugeState()` — `no_writer_yet` / `live` / `stale`, layered on the existing `venture_telemetry` table/writer, never a fabricated number. Additive `applications.metrics_cadence_hours` migration for per-venture cadence overrides.
- **FR-1** `lib/eva/bridge/templates/venture-stack-scan.js`: new `v1_metrics` REQUIRED check, vendored into every future venture's own CI. Corrected mid-EXEC from the PRD's original assumption — `venture_templates` is a strategy-pattern DB table (scoring/pricing/GTM), not a code scaffold; the real enforcement point is the per-venture stack-compliance scanner (SD-LEO-INFRA-REQUIRE-STACK-ENFORCING-001).
- **FR-5** `lib/eva/external-observation.js`: wires the previously-hardcoded-`null` `telemetryRowCount` to real `venture_telemetry` data and adds a `gauge_writer_alive` check. This closes a pre-existing defect: `verifyExternalObservation().verified` was structurally unsatisfiable (one of 3 required checks could never pass), meaning `launch_mode='live'` has been **permanently unreachable** via this path since SD-LEO-INFRA-LAUNCH-MODE-POLICY-001 shipped. Also implements the FR-5 gauge-writer-liveness precondition itself.
- **FR-4** `lib/telemetry/canary-gauge-liveness.mjs` + `scripts/canary/run-gauge-liveness-probe.mjs`: synthetic-visit liveness proof, flag-gated (`FUNNEL_GAUGE_CANARY_V1`) consistent with the existing canary pattern.

**Deferred (not built in this PR, both tracked, neither silent):**
- **FR-3** ("paid" KPI reader): `ops_payment_events.venture_id` is unconditionally `null` at capture time (`api/webhooks/stripe.js:130`) and venture-attribution is Phase-2 scope with no sourcing SD yet — building it now would be structurally dead code. Signaled via need-sweep (`9dccbb0a-a0fb-4290-93f8-aa60f65d8a09`).
- **visitors KPI_ALLOWLIST addition**: standard-governed (`docs/03_protocols_and_standards/venture-metrics-standard.md`), requires chairman data-minimization sign-off. Recorded as a durable, non-escalating pending decision (`chairman_decisions` row `241eaba4-801c-40b0-a0a9-b5276473bf62`).

## Test plan
- [x] 115+ unit tests passing across all touched/new files (`tests/unit/telemetry/`, `tests/unit/canary/`, `tests/unit/eva/external-observation.test.js`, `tests/unit/eva/stage-24-go-live-launch-mode.test.js`, `tests/unit/eva/bridge/venture-stack-ci-mandate.test.js`)
- [x] Confirmed no regression in `tests/unit/venture-telemetry-pull.test.js` (20/20, file untouched) and `tests/unit/eva/stage-templates/` (stage-23, 29/29)
- [x] PLAN-TO-LEAD handoff PASS (score 95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)