### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E): stateless-process check in venture stack-CI (reduced-scope Child E)

### DIFF
--- a/lib/eva/bridge/templates/venture-stack-scan.js
+++ b/lib/eva/bridge/templates/venture-stack-scan.js
@@ -21,6 +21,33 @@ export const REQUIRED = [
   { id: 'clerk', test: (s) => /['"]@clerk\//.test(s), why: 'Clerk (@clerk/*) is the canonical venture auth' },
   { id: 'replit_postgres', test: (s) => /\bDATABASE_URL\b/.test(s) || /(?:from|import|require\()\s*['"](?:pg|drizzle-orm)/.test(s), why: 'Replit Postgres (DATABASE_URL / pg / drizzle)' },
 ];
+// Stateless-process factory rule (SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E, deploy
+// design §7 risk 6): venture app processes are STATELESS — durable state lives in the
+// venture DB or an explicit external store. In-memory rate-limit/session/user stores
+// silently evaporate under scale-to-zero and multi-instance fan-out (MarketLens shipped
+// this class). WARN-class (observe-only-first, protocol default): results land in the
+// scan's additive `warnings` array, never `violations` — PROMOTION CRITERION: treat as
+// blocking only after calibration on the first fresh venture with zero false positives.
+// Patterns target STORE shapes specifically (store: option absent; module-scope bindings
+// NAMED like durable stores), not all in-memory structures.
+export const STATELESS_PROCESS_CHECKS = [
+  {
+    id: 'rate_limit_memory_store',
+    test: (s) => /(?:from|import|require\()\s*['"]express-rate-limit['"]/.test(s) && !/\bstore\s*:/.test(s),
+    why: 'express-rate-limit without a store: option — default MemoryStore resets on cold start / diverges across instances',
+  },
+  {
+    id: 'session_memory_store',
+    test: (s) => /(?:from|import|require\()\s*['"]express-session['"]/.test(s) && !/\bstore\s*:/.test(s),
+    why: 'express-session without an external store: — default MemoryStore evaporates sessions on cold start',
+  },
+  {
+    id: 'module_scope_user_store',
+    test: (s) => /^(?:export\s+)?(?:const|let|var)\s+(?:users?|sessions?|accounts?)\w*\s*=\s*(?:new\s+Map\s*\(|new\s+Set\s*\(|\{\s*\}|\[\s*\])/m.test(s),
+    why: 'module-scope in-memory user/session/account store — durable state must live in the venture DB or an explicit store',
+  },
+];
+
 const SRC_EXT = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
 
 /** Default real-fs IO: lists src-relative file paths (forward-slash) + reads them. */
@@ -41,11 +68,16 @@ export function realIo(root) {
 
 /**
  * Pure scan. `ioOrFactory` is either an io object { files: string[], read(rel)->string }
- * or a factory (root)->io. Returns { violations:[{file,why}], requiredPresent:Set, missing:string[] }.
+ * or a factory (root)->io. Returns { violations:[{file,why}], requiredPresent:Set,
+ * missing:string[], warnings:[{file,why,class}] } — `warnings` is ADDITIVE
+ * (SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E): observe-only stateless-process
+ * findings that must never fail the vendored test wrapper; existing consumers
+ * destructure the original keys unchanged.
  */
 export function scanForStackViolations(root, ioOrFactory = realIo) {
   const io = typeof ioOrFactory === 'function' ? ioOrFactory(root) : ioOrFactory;
   const violations = [];
+  const warnings = [];
   const requiredPresent = new Set();
   for (const file of io.files) {
     if (FORBIDDEN_FILE_RE.test(file)) {
@@ -55,9 +87,10 @@ export function scanForStackViolations(root, ioOrFactory = realIo) {
     try { src = io.read(file); } catch { continue; }
     for (const f of FORBIDDEN_IMPORTS) if (f.re.test(src)) violations.push({ file, why: f.why });
     for (const r of REQUIRED) if (!requiredPresent.has(r.id) && r.test(src)) requiredPresent.add(r.id);
+    for (const c of STATELESS_PROCESS_CHECKS) if (c.test(src)) warnings.push({ file, why: c.why, class: 'stateless_process' });
   }
   const missing = REQUIRED.filter((r) => !requiredPresent.has(r.id)).map((r) => r.why);
-  return { violations, requiredPresent, missing };
+  return { violations, requiredPresent, missing, warnings };
 }
 
-export default { FORBIDDEN_IMPORTS, FORBIDDEN_FILE_RE, REQUIRED, realIo, scanForStackViolations };
+export default { FORBIDDEN_IMPORTS, FORBIDDEN_FILE_RE, REQUIRED, STATELESS_PROCESS_CHECKS, realIo, scanForStackViolations };

--- a/tests/unit/venture-stack-scan-stateless.test.js
+++ b/tests/unit/venture-stack-scan-stateless.test.js
@@ -1,0 +1,85 @@
+/**
+ * SD-LEO-INFRA-VENTURE-DEPLOY-PIPELINE-001-E — stateless-process factory rule in the
+ * vendored venture stack-CI scanner (deploy design §7 risk 6). Observe-only-first:
+ * findings land in the ADDITIVE warnings array, never violations.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  scanForStackViolations, STATELESS_PROCESS_CHECKS,
+} from '../../lib/eva/bridge/templates/venture-stack-scan.js';
+
+const COMPLIANT_BASE = `
+import { ClerkExpressWithAuth } from '@clerk/express';
+const dbUrl = process.env.DATABASE_URL;
+`;
+
+function io(files) {
+  return { files: Object.keys(files), read: (f) => files[f] };
+}
+
+describe('STATELESS_PROCESS_CHECKS (observe-only warnings)', () => {
+  it('flags express-rate-limit without a store: option (default MemoryStore)', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/app.js': COMPLIANT_BASE + 'import rateLimit from \'express-rate-limit\';\napp.use(rateLimit({ windowMs: 60000, max: 100 }));',
+    }));
+    expect(r.warnings.map((w) => w.class)).toContain('stateless_process');
+    expect(r.warnings[0].why).toMatch(/express-rate-limit without a store/);
+    expect(r.violations).toHaveLength(0); // WARN class, never a violation
+  });
+
+  it('does NOT flag rate-limit wired to an external store', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/app.js': COMPLIANT_BASE + 'import rateLimit from \'express-rate-limit\';\napp.use(rateLimit({ windowMs: 60000, store: new RedisStore({ client }) }));',
+    }));
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it('flags express-session without an external store', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/session.js': COMPLIANT_BASE + 'import session from \'express-session\';\napp.use(session({ secret: process.env.SESSION_SECRET }));',
+    }));
+    expect(r.warnings.some((w) => w.why.match(/express-session without an external store/))).toBe(true);
+  });
+
+  it('flags a module-scope in-memory user store (the MarketLens class)', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/users.js': COMPLIANT_BASE + 'const users = new Map();\nexport function addUser(u) { users.set(u.id, u); }',
+    }));
+    expect(r.warnings.some((w) => w.why.match(/module-scope in-memory user\/session\/account store/))).toBe(true);
+  });
+
+  it('compliant DB-backed venture produces zero stateless-process warnings', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/app.js': COMPLIANT_BASE + 'import rateLimit from \'express-rate-limit\';\napp.use(rateLimit({ store: new PgStore(pool) }));\nimport session from \'express-session\';\napp.use(session({ store: new PgSession(pool), secret: s }));',
+      'src/users.js': COMPLIANT_BASE + 'export async function addUser(db, u) { await db.insert(usersTable).values(u); }',
+    }));
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it('does NOT flag non-store-named module Maps (bounded false-positive surface)', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/cache.js': COMPLIANT_BASE + 'const routeCache = new Map();\nconst memo = {};',
+    }));
+    expect(r.warnings).toHaveLength(0);
+  });
+});
+
+describe('additive return shape (existing consumers untouched)', () => {
+  it('violations/requiredPresent/missing semantics unchanged on legacy fixtures', () => {
+    const r = scanForStackViolations('/x', io({
+      'src/bad.js': 'import { createClient } from \'@supabase/supabase-js\';',
+      'src/auth/oidc.server.ts': 'export const oidc = 1;',
+    }));
+    expect(r.violations.length).toBeGreaterThanOrEqual(2); // supabase import + forbidden path
+    expect(r.missing.length).toBe(2); // clerk + replit_postgres absent
+    expect(Array.isArray(r.warnings)).toBe(true); // additive key present
+  });
+
+  it('every check has the {id, test, why} contract shape', () => {
+    for (const c of STATELESS_PROCESS_CHECKS) {
+      expect(typeof c.id).toBe('string');
+      expect(typeof c.test).toBe('function');
+      expect(typeof c.why).toBe('string');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `STATELESS_PROCESS_CHECKS` to the vendored venture stack scanner: express-rate-limit default MemoryStore, express-session default store, module-scope in-memory user/session/account stores (design §7 risk 6 — the account-evaporation class MarketLens shipped)
- Findings land in an **additive `warnings[]`** (observe-only-first; in-code promotion criterion); existing `violations`/`requiredPresent`/`missing` semantics untouched
- LEAD reduced Child E's scope 70% on validation evidence (design phasing premise unmet: deploy path unproven live, zero multi-target demand); deferred items carry named premises, domain automation carved to its chartered SD

## Test plan
- [x] 8 new tests (3 violation classes, 2 compliant fixtures, false-positive bound, legacy-shape regression, check contract)
- [x] 15 green across both scanner suites (incl. pre-existing venture-stack-ci-mandate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)