### PR TITLE
feat(SD-LEO-INFRA-AUTOMATED-PRODUCT-ASSESSMENT-001-D): APA stage-ladder orchestrator (persona coverage + fix-loops)

### DIFF
--- a/lib/apa/stage-ladder-orchestrator.mjs
+++ b/lib/apa/stage-ladder-orchestrator.mjs
@@ -1,0 +1,190 @@
+/**
+ * APA Stage-Ladder Orchestrator (SD-LEO-INFRA-AUTOMATED-PRODUCT-ASSESSMENT-001-D).
+ *
+ * Design doc §8.5: APA executes as a staged, iterative pipeline — cheap
+ * deterministic stages (S0-S2) gate expensive judgment stages (S4), each
+ * stage is a fix-loop, and the chairman stamp requires ONE full clean
+ * S0-S4 re-run (S5) — never a stitched-together set of partial greens.
+ *
+ * This module is the scheduling/gating layer only. Stage runners,
+ * fix-functions, and dimension-checkers are all injected — it never
+ * directly calls Child A (sandbox), Child B (assertions), or Child C
+ * (browser executor); a future orchestration entrypoint wires those in.
+ *
+ * Persona provenance (design doc §10, line 258): personas MUST come from
+ * the venture's real artifact corpus, never be invented at assessment
+ * time. resolvePersonas is the only I/O in this module for exactly that
+ * reason — everything else stays pure and injectable.
+ *
+ * @module lib/apa/stage-ladder-orchestrator
+ */
+
+const DEFAULT_PERSONA_ARTIFACT_TYPES = Object.freeze(['identity_persona_brand']);
+const DEFAULT_MAX_RETRIES = 3;
+
+/**
+ * FR-1: run an ordered stage list, halting the moment a stage fails.
+ * @param {Array<{id: string, run: (ctx: object) => Promise<{pass: boolean, findings?: Array}>}>} stages
+ * @param {object} [ctx]
+ * @returns {Promise<{completedStages: string[], haltedAt: string|null, results: object}>}
+ */
+export async function runStageLadder(stages, ctx = {}) {
+  const completedStages = [];
+  const results = {};
+  for (const stage of stages || []) {
+    const result = await stage.run(ctx);
+    results[stage.id] = result;
+    if (!result.pass) {
+      return { completedStages, haltedAt: stage.id, results };
+    }
+    completedStages.push(stage.id);
+  }
+  return { completedStages, haltedAt: null, results };
+}
+
+/**
+ * Order-independent fingerprint of a findings array, so re-ordered-but-
+ * identical findings are correctly recognized as a plateau (TR-3).
+ */
+function fingerprintFindings(findings) {
+  const normalized = (findings || []).map((f) => JSON.stringify(f, Object.keys(f || {}).sort()));
+  normalized.sort();
+  return normalized.join('|');
+}
+
+/**
+ * FR-2: run a single stage's inner fix-loop (run -> findings -> fix ->
+ * re-run), bounded by a retry cap, with plateau detection that escalates
+ * when the same findings recur with zero improvement.
+ * @param {{id: string, run: (ctx: object) => Promise<{pass: boolean, findings?: Array}>}} stage
+ * @param {object} ctx
+ * @param {{maxRetries?: number, fixFn?: (findings: Array, ctx: object) => Promise<void>}} [opts]
+ * @returns {Promise<{clean: boolean, plateaued: boolean, capped: boolean, attempts: number, lastResult: object}>}
+ */
+export async function runStageWithFixLoop(stage, ctx, opts = {}) {
+  const { maxRetries = DEFAULT_MAX_RETRIES, fixFn = async () => {} } = opts;
+  let lastResult = await stage.run(ctx);
+  let lastFingerprint = fingerprintFindings(lastResult.findings);
+  let attempts = 1;
+
+  if (lastResult.pass) {
+    return { clean: true, plateaued: false, capped: false, attempts, lastResult };
+  }
+
+  while (attempts <= maxRetries) {
+    await fixFn(lastResult.findings || [], ctx);
+    const nextResult = await stage.run(ctx);
+    attempts += 1;
+    if (nextResult.pass) {
+      return { clean: true, plateaued: false, capped: false, attempts, lastResult: nextResult };
+    }
+    const nextFingerprint = fingerprintFindings(nextResult.findings);
+    if (nextFingerprint === lastFingerprint) {
+      return { clean: false, plateaued: true, capped: false, attempts, lastResult: nextResult };
+    }
+    lastResult = nextResult;
+    lastFingerprint = nextFingerprint;
+  }
+
+  return { clean: false, plateaued: false, capped: true, attempts, lastResult };
+}
+
+/**
+ * FR-3: resolve REAL personas from a venture's artifact corpus. Never
+ * fabricates a default — absence is itself the finding.
+ * @param {string} ventureId
+ * @param {object} supabase injected Supabase client
+ * @param {{artifactTypes?: string[]}} [opts]
+ * @returns {Promise<{personas: Array<object>, findings: Array<object>}>}
+ */
+export async function resolvePersonas(ventureId, supabase, opts = {}) {
+  const artifactTypes = opts.artifactTypes || DEFAULT_PERSONA_ARTIFACT_TYPES;
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('content, created_at')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', artifactTypes)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (error || !Array.isArray(data) || data.length === 0) {
+    return {
+      personas: [],
+      findings: [{
+        type: 'PERSONA_PROVENANCE_MISSING',
+        ventureId,
+        artifactTypes,
+        reason: error ? `query error: ${error.message}` : 'no matching persona artifact found',
+      }],
+    };
+  }
+
+  let parsed;
+  try {
+    const row = data[0];
+    parsed = typeof row.content === 'string' ? JSON.parse(row.content) : row.content;
+  } catch (e) {
+    return {
+      personas: [],
+      findings: [{ type: 'PERSONA_PROVENANCE_MISSING', ventureId, artifactTypes, reason: `unparseable artifact content: ${e.message}` }],
+    };
+  }
+
+  const personas = Array.isArray(parsed && parsed.personas) ? parsed.personas : [];
+  if (personas.length === 0) {
+    return {
+      personas: [],
+      findings: [{ type: 'PERSONA_PROVENANCE_MISSING', ventureId, artifactTypes, reason: 'artifact found but personas array is empty' }],
+    };
+  }
+
+  return { personas, findings: [] };
+}
+
+/**
+ * FR-4: S3 persona matrix — a true cross-product of dimension-checkers x
+ * personas, tagged per (checkerId, personaName) pair.
+ * @param {Array<{id: string, check: (persona: object, evidence: object) => {pass: boolean, findings?: Array}}>} dimensionCheckers
+ * @param {Array<object>} personas
+ * @param {object} evidence
+ * @returns {Array<{checkerId: string, personaName: string, pass: boolean, findings: Array}>}
+ */
+export function runPersonaMatrix(dimensionCheckers, personas, evidence) {
+  const results = [];
+  for (const checker of dimensionCheckers || []) {
+    for (const persona of personas || []) {
+      const verdict = checker.check(persona, evidence);
+      results.push({
+        checkerId: checker.id,
+        personaName: persona.name,
+        pass: verdict.pass,
+        findings: verdict.findings || [],
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * FR-5: S5 regression guard. The chairman stamp requires exactly one full,
+ * uninterrupted, zero-finding S0-S4 re-run — never a stitched-together set
+ * of partial greens (design doc §8.5).
+ * @param {{completedStages: string[], results: object}} s5Result
+ * @param {string[]} [requiredStages] defaults to the canonical S0-S4 ladder
+ * @returns {{eligible: boolean, reason: string}}
+ */
+export function assertChairmanStampEligible(s5Result, requiredStages = ['S0', 'S1', 'S2', 'S3', 'S4']) {
+  const completed = new Set(s5Result.completedStages || []);
+  for (const stageId of requiredStages) {
+    if (!completed.has(stageId)) {
+      return { eligible: false, reason: `stage ${stageId} did not complete — chairman stamp requires the full S0-S4 ladder in one pass` };
+    }
+  }
+  for (const stageId of requiredStages) {
+    const findings = (s5Result.results && s5Result.results[stageId] && s5Result.results[stageId].findings) || [];
+    if (findings.length > 0) {
+      return { eligible: false, reason: `stage ${stageId} carries ${findings.length} finding(s) — chairman stamp requires zero findings across the full pass` };
+    }
+  }
+  return { eligible: true, reason: 'full S0-S4 pass, zero findings on every stage' };
+}

--- a/tests/unit/apa/stage-ladder-orchestrator.test.js
+++ b/tests/unit/apa/stage-ladder-orchestrator.test.js
@@ -1,0 +1,186 @@
+/**
+ * lib/apa/stage-ladder-orchestrator unit tests
+ * SD-LEO-INFRA-AUTOMATED-PRODUCT-ASSESSMENT-001-D
+ *
+ * Covers PRD test scenarios TS-1 through TS-10.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runStageLadder,
+  runStageWithFixLoop,
+  resolvePersonas,
+  runPersonaMatrix,
+  assertChairmanStampEligible,
+} from '../../../lib/apa/stage-ladder-orchestrator.mjs';
+
+describe('TS-1/TS-2: runStageLadder gating', () => {
+  it('TS-1: halts on first failure, never runs downstream stages', async () => {
+    const calls = [];
+    const stages = ['S0', 'S1', 'S2'].map((id) => ({
+      id,
+      run: async () => { calls.push(id); return { pass: id !== 'S0' }; },
+    }));
+    const result = await runStageLadder(stages);
+    expect(calls).toEqual(['S0']);
+    expect(result.haltedAt).toBe('S0');
+    expect(result.completedStages).toEqual([]);
+  });
+
+  it('TS-2: completes fully when every stage passes', async () => {
+    const stages = ['S0', 'S1', 'S2'].map((id) => ({ id, run: async () => ({ pass: true }) }));
+    const result = await runStageLadder(stages);
+    expect(result.completedStages).toEqual(['S0', 'S1', 'S2']);
+    expect(result.haltedAt).toBeNull();
+  });
+});
+
+describe('TS-3/TS-4/TS-5: runStageWithFixLoop', () => {
+  it('TS-3: plateaus within 2 re-runs on identical recurring findings', async () => {
+    const stage = { id: 'S1', run: async () => ({ pass: false, findings: [{ key: 'same' }] }) };
+    const result = await runStageWithFixLoop(stage, {}, { maxRetries: 5 });
+    expect(result.plateaued).toBe(true);
+    expect(result.capped).toBe(false);
+    expect(result.attempts).toBeLessThanOrEqual(3);
+  });
+
+  it('TS-4: does not falsely plateau on genuinely improving findings', async () => {
+    let remaining = 3;
+    const stage = {
+      id: 'S1',
+      run: async () => {
+        if (remaining === 0) return { pass: true, findings: [] };
+        const findings = Array.from({ length: remaining }, (_, i) => ({ key: `f${i}` }));
+        remaining -= 1;
+        return { pass: false, findings };
+      },
+    };
+    const result = await runStageWithFixLoop(stage, {}, { maxRetries: 10 });
+    expect(result.clean).toBe(true);
+    expect(result.plateaued).toBe(false);
+  });
+
+  it('TS-5: hits the retry cap (capped:true) on non-plateauing, never-clearing findings', async () => {
+    let counter = 0;
+    const stage = {
+      id: 'S1',
+      run: async () => {
+        counter += 1;
+        return { pass: false, findings: [{ key: `f${counter}` }] };
+      },
+    };
+    const result = await runStageWithFixLoop(stage, {}, { maxRetries: 3 });
+    expect(result.capped).toBe(true);
+    expect(result.plateaued).toBe(false);
+    expect(result.attempts).toBe(4);
+  });
+
+  it('a stage that passes immediately returns clean:true on the first attempt', async () => {
+    const stage = { id: 'S0', run: async () => ({ pass: true }) };
+    const result = await runStageWithFixLoop(stage, {});
+    expect(result).toMatchObject({ clean: true, attempts: 1 });
+  });
+});
+
+describe('TS-6/TS-7: resolvePersonas', () => {
+  const makeSupabase = (rows, error = null) => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          in: () => ({
+            order: () => ({
+              limit: async () => ({ data: rows, error }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  });
+
+  it('TS-6: returns the real parsed persona list, unmodified', async () => {
+    const personas = [{ name: 'Chloe' }, { name: 'Mark' }];
+    const sb = makeSupabase([{ content: { personas }, created_at: '2026-01-01' }]);
+    const result = await resolvePersonas('venture-1', sb);
+    expect(result.personas).toEqual(personas);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('handles content stored as a JSON string, not just an object', async () => {
+    const personas = [{ name: 'Chloe' }];
+    const sb = makeSupabase([{ content: JSON.stringify({ personas }), created_at: '2026-01-01' }]);
+    const result = await resolvePersonas('venture-1', sb);
+    expect(result.personas).toEqual(personas);
+  });
+
+  it('TS-7: no matching artifact resolves to empty array + a structured finding, never a default', async () => {
+    const sb = makeSupabase([]);
+    const result = await resolvePersonas('venture-2', sb);
+    expect(result.personas).toEqual([]);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].type).toBe('PERSONA_PROVENANCE_MISSING');
+  });
+
+  it('a query error also resolves to empty + finding, never throws', async () => {
+    const sb = makeSupabase(null, { message: 'boom' });
+    const result = await resolvePersonas('venture-3', sb);
+    expect(result.personas).toEqual([]);
+    expect(result.findings[0].reason).toContain('boom');
+  });
+
+  it('an artifact with an empty personas array is also a provenance-missing finding', async () => {
+    const sb = makeSupabase([{ content: { personas: [] }, created_at: '2026-01-01' }]);
+    const result = await resolvePersonas('venture-4', sb);
+    expect(result.personas).toEqual([]);
+    expect(result.findings[0].type).toBe('PERSONA_PROVENANCE_MISSING');
+  });
+});
+
+describe('TS-8: runPersonaMatrix cross-product', () => {
+  it('produces exactly N*M tagged results', () => {
+    const checkers = [
+      { id: 'sideEffectHonesty', check: () => ({ pass: true }) },
+      { id: 'recoveryPath', check: () => ({ pass: false, findings: [{ key: 'x' }] }) },
+    ];
+    const personas = [{ name: 'A' }, { name: 'B' }, { name: 'C' }];
+    const results = runPersonaMatrix(checkers, personas, {});
+    expect(results).toHaveLength(6);
+    expect(results.filter((r) => r.checkerId === 'recoveryPath')).toHaveLength(3);
+    expect(results.filter((r) => r.personaName === 'A')).toHaveLength(2);
+  });
+
+  it('zero personas produces zero results', () => {
+    const checkers = [{ id: 'c1', check: () => ({ pass: true }) }];
+    expect(runPersonaMatrix(checkers, [], {})).toEqual([]);
+  });
+});
+
+describe('TS-9/TS-10: assertChairmanStampEligible', () => {
+  it('TS-9: refuses a partial ladder, naming the missing stage', () => {
+    const s5Result = { completedStages: ['S0', 'S1', 'S2'], results: {} };
+    const verdict = assertChairmanStampEligible(s5Result);
+    expect(verdict.eligible).toBe(false);
+    expect(verdict.reason).toContain('S3');
+  });
+
+  it('TS-10: grants eligibility for a full, zero-finding S0-S4 pass', () => {
+    const s5Result = {
+      completedStages: ['S0', 'S1', 'S2', 'S3', 'S4'],
+      results: {
+        S0: { findings: [] }, S1: { findings: [] }, S2: { findings: [] }, S3: { findings: [] }, S4: { findings: [] },
+      },
+    };
+    expect(assertChairmanStampEligible(s5Result).eligible).toBe(true);
+  });
+
+  it('refuses when any stage carries findings, even if the ladder completed', () => {
+    const s5Result = {
+      completedStages: ['S0', 'S1', 'S2', 'S3', 'S4'],
+      results: {
+        S0: { findings: [] }, S1: { findings: [] }, S2: { findings: [{ key: 'x' }] }, S3: { findings: [] }, S4: { findings: [] },
+      },
+    };
+    const verdict = assertChairmanStampEligible(s5Result);
+    expect(verdict.eligible).toBe(false);
+    expect(verdict.reason).toContain('S2');
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/apa/stage-ladder-orchestrator.mjs`: implements design doc §8.5's staged S0-S5 execution model
- `runStageLadder()`: gated sequential stage execution, halts immediately on the first failing stage
- `runStageWithFixLoop()`: per-stage inner loop with a retry cap + order-independent plateau detection (escalates instead of looping forever)
- `resolvePersonas()`: reads REAL `identity_persona_brand` venture_artifacts — never fabricates a default persona list; absence is itself a structured finding (design doc §10 line 258 provenance rule)
- `runPersonaMatrix()`: the S3 cross-product of dimension-checkers × resolved personas
- `assertChairmanStampEligible()`: the S5 regression guard — the chairman stamp requires one full, zero-finding S0-S4 pass, never stitched-together partial greens

This is the scheduling/gating layer only; Child A (sandbox), Child B (assertions), and Child C (browser executor) — all already completed and merged — are consumed as injected stage-runner functions, never called directly.

## Test plan
- [x] 16 unit tests in `tests/unit/apa/stage-ladder-orchestrator.test.js` covering PRD TS-1 through TS-10
- [x] `npx vitest run --project unit tests/unit/apa/stage-ladder-orchestrator.test.js` — 16/16 passed
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)