### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A): add explicit gated_on_attribution paid-gauge state

### DIFF
--- a/lib/telemetry/funnel-gauge.mjs
+++ b/lib/telemetry/funnel-gauge.mjs
@@ -62,4 +62,22 @@ export function isGaugeWriterAlive(opts) {
   return computeGaugeState(opts).state === 'live';
 }
 
-export default { DEFAULT_CADENCE_HOURS, computeGaugeState, isGaugeWriterAlive };
+/**
+ * The gauge's "paid" stage, per coordinator ruling on FR-3 descope
+ * (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A): a per-venture paid-KPI
+ * reader is structurally impossible today — ops_payment_events.venture_id is
+ * unconditionally null at capture time (api/webhooks/stripe.js,
+ * PAT-PORT-ISOL-001), and venture-payment attribution is Phase-2-deferred
+ * scope with no sourcing SD (routed to Adam). Rather than silently omitting
+ * the "paid" stage or showing a fabricated value, the funnel exposes this as
+ * an explicit, visible GATED_ON_ATTRIBUTION state — never a fake number.
+ * @returns {{state: 'gated_on_attribution', reason: string}}
+ */
+export function computePaidGaugeState() {
+  return {
+    state: 'gated_on_attribution',
+    reason: 'per-venture paid KPI is gated on Stripe-payment-to-venture attribution, which does not exist yet (Phase-2-deferred, no sourcing SD) — never a fabricated number',
+  };
+}
+
+export default { DEFAULT_CADENCE_HOURS, computeGaugeState, isGaugeWriterAlive, computePaidGaugeState };

--- a/tests/unit/telemetry/funnel-gauge.test.js
+++ b/tests/unit/telemetry/funnel-gauge.test.js
@@ -1,6 +1,6 @@
 // SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A (FR-2)
 import { describe, it, expect } from 'vitest';
-import { computeGaugeState, isGaugeWriterAlive, DEFAULT_CADENCE_HOURS } from '../../../lib/telemetry/funnel-gauge.mjs';
+import { computeGaugeState, isGaugeWriterAlive, computePaidGaugeState, DEFAULT_CADENCE_HOURS } from '../../../lib/telemetry/funnel-gauge.mjs';
 
 const NOW = new Date('2026-07-10T12:00:00.000Z');
 
@@ -85,5 +85,16 @@ describe('isGaugeWriterAlive (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A FR-
   it('false for stale', () => {
     const pulledAt = new Date(NOW.getTime() - 40 * 3600 * 1000);
     expect(isGaugeWriterAlive({ telemetryRow: { kpis: { signups: 1 }, pulled_at: pulledAt.toISOString(), ingest_status: 'ok' }, now: NOW })).toBe(false);
+  });
+});
+
+// Coordinator ruling on FR-3 descope (SD-LEO-INFRA-VENTURE-DEMAND-DISTRIBUTION-001-A):
+// the "paid" stage is never fabricated -- it's an explicit, visible gated state until
+// venture-payment attribution exists.
+describe('computePaidGaugeState (coordinator-ruled FR-3 descope)', () => {
+  it('always reports gated_on_attribution — never a fabricated paid value', () => {
+    const result = computePaidGaugeState();
+    expect(result.state).toBe('gated_on_attribution');
+    expect(result.reason).toMatch(/attribution/);
   });
 });


### PR DESCRIPTION
## Summary
- Coordinator ruling follow-up on the FR-3 descope (per-venture paid-KPI reader, already recorded via record-fr-descope.js).
- Adds `computePaidGaugeState()` to lib/telemetry/funnel-gauge.mjs: the funnel's "paid" stage is now an explicit, visible `gated_on_attribution` state rather than silently omitted — `ops_payment_events.venture_id` is unconditionally null at capture time and venture-payment attribution is Phase-2-deferred scope with no sourcing SD yet. Never a fabricated number.

## Test plan
- [x] 12/12 tests passing in tests/unit/telemetry/funnel-gauge.test.js (1 new test added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)