### PR TITLE
feat(SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001): PR-A — domain acquisition money-safety core (FR-1..FR-6)

### DIFF
--- a/lib/decision-binding/disposition.js
+++ b/lib/decision-binding/disposition.js
@@ -16,7 +16,9 @@ import { createHash } from 'node:crypto';
 
 const EVENT_TYPE = 'DECISION_DISPOSITION';
 
-const VALID_DECISION_TYPES = ['ratification', 'consult_answer', 'dispatch_auth'];
+// domain_acquisition added by SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 FR-4
+// (consumed-exactly-once purchase binding, subject {venture_id, domain}).
+const VALID_DECISION_TYPES = ['ratification', 'consult_answer', 'dispatch_auth', 'domain_acquisition'];
 const VALID_STATUSES = ['awaiting_disposition', 'dispositioned', 'consumed'];
 
 /**
@@ -36,11 +38,12 @@ function canonicalize(value) {
  * correlation_id or message_id -- those rotate per session, which is the
  * exact bug this primitive fixes.
  *
- * @param {'ratification'|'consult_answer'|'dispatch_auth'} decisionType
+ * @param {'ratification'|'consult_answer'|'dispatch_auth'|'domain_acquisition'} decisionType
  * @param {object} subject - decision-type-specific identifying content:
  *   ratification: { fixture_set_id, fixture_id }
  *   consult_answer: { question_text }
  *   dispatch_auth: { subject_id, gate_type }
+ *   domain_acquisition: { venture_id, domain }
  * @returns {string} a stable "dq_<sha256-hex>" key
  */
 export function computeQuestionKey(decisionType, subject) {

--- a/lib/venture-acquisition/acquire.js
+++ b/lib/venture-acquisition/acquire.js
@@ -51,14 +51,32 @@ export function planAcquisitionActions(domain) {
   ];
 }
 
-/** Persist a sanitized refusal/error onto the decision record (fail-soft recorder — never masks the primary result). */
+/**
+ * Persist a sanitized refusal/error/result onto the decision record.
+ * Fresh-read-merge-write (adversarial finding: a start-of-run snapshot merge
+ * silently clobbers concurrent brief_data writes AND earlier persists in the
+ * same run), and the supabase error result is CHECKED — a failed persist is
+ * reported in the return value, never swallowed (FR-6 fail-loud). Still
+ * fail-soft overall: a recorder fault never masks the executor's own result.
+ * @returns {Promise<{persisted: boolean, error?: string}>}
+ */
 async function persistOnDecision(supabase, decision, key, payload) {
   try {
-    await supabase
+    const { data: fresh, error: rErr } = await supabase
       .from('chairman_decisions')
-      .update({ brief_data: { ...(decision.brief_data || {}), [key]: payload } })
+      .select('brief_data')
+      .eq('id', decision.id)
+      .maybeSingle();
+    if (rErr) return { persisted: false, error: rErr.message };
+    const { error } = await supabase
+      .from('chairman_decisions')
+      .update({ brief_data: { ...((fresh && fresh.brief_data) || decision.brief_data || {}), [key]: payload } })
       .eq('id', decision.id);
-  } catch { /* recorder fault never masks the executor's own result */ }
+    if (error) return { persisted: false, error: error.message };
+    return { persisted: true };
+  } catch (e) {
+    return { persisted: false, error: String(e?.message || e).slice(0, 200) };
+  }
 }
 
 /**
@@ -86,7 +104,9 @@ export async function executeAcquisition(supabase, decisionId, deps = {}) {
   if (decision.status === 'rejected') return { status: 'refused', reason: 'decision_rejected' };
   if (decision.status !== 'approved') return { status: 'refused', reason: `decision_not_approved: ${decision.status}` };
 
-  const domain = brief.recommended;
+  // Lowercase-normalize: the idempotency subject must treat Lumina.com and
+  // lumina.com as the SAME purchase (adversarial finding).
+  const domain = typeof brief.recommended === 'string' ? brief.recommended.toLowerCase() : null;
   const ventureId = decision.venture_id;
   if (!domain || !ventureId) return { status: 'refused', reason: 'packet_missing_domain_or_venture' };
 
@@ -108,7 +128,14 @@ export async function executeAcquisition(supabase, decisionId, deps = {}) {
   }
 
   // ── FR-5 fail-closed ceiling against the LIVE quote (never the packet's) ──
-  const ceilingUsd = resolvePurchaseCeilingUsd(env);
+  // Ceiling provenance (adversarial finding): the bound the chairman APPROVED
+  // (brief_data.ceiling_usd) must not be loosenable by a later env change —
+  // enforce the MINIMUM of the approved ceiling and the current env ceiling.
+  const envCeiling = resolvePurchaseCeilingUsd(env);
+  const approvedCeiling = typeof brief.ceiling_usd === 'number' && Number.isFinite(brief.ceiling_usd) && brief.ceiling_usd > 0
+    ? brief.ceiling_usd
+    : envCeiling;
+  const ceilingUsd = Math.min(envCeiling, approvedCeiling);
   let live;
   try {
     live = normalizeQuote(await registrar.checkDomain(domain));
@@ -131,7 +158,7 @@ export async function executeAcquisition(supabase, decisionId, deps = {}) {
   }
 
   // ── FR-4 registry-first: durable record BEFORE the money call ──
-  const { row } = await recordDisposition(supabase, {
+  const { row, created } = await recordDisposition(supabase, {
     decisionType: 'domain_acquisition',
     subject,
     decisionKey: `domain_acquisition:${ventureId}:${domain}`,
@@ -141,6 +168,18 @@ export async function executeAcquisition(supabase, decisionId, deps = {}) {
   if (row?.payload?.status === 'consumed') {
     return { status: 'already_acquired', domain, disposition: row.payload.question_key };
   }
+  // DOUBLE-BUY GUARD (adversarial finding): a PRE-EXISTING awaiting row means
+  // another executor is in flight OR a prior run registered and died before
+  // the consume transition — the purchase outcome is UNKNOWN. Proceeding here
+  // is the double-register window; refuse and demand operator resolution.
+  if (!created) {
+    return {
+      status: 'refused',
+      reason: 'in_flight_or_unknown_outcome',
+      domain,
+      unblock: 'A prior acquisition attempt for this venture+domain is unresolved. Verify with the registrar whether the purchase completed, then transition the disposition to consumed (purchase happened) or delete it (it did not) before retrying.',
+    };
+  }
   const questionKey = computeQuestionKey('domain_acquisition', subject);
 
   // ── The register call: last, narrowest, most-audited. No rollback exists. ──
@@ -149,15 +188,21 @@ export async function executeAcquisition(supabase, decisionId, deps = {}) {
     registrarResponse = await registrar.registerDomain(domain, { years: 1, autoRenew: false });
   } catch (e) {
     const msg = String(e?.message || e).slice(0, 500);
-    await persistOnDecision(supabase, decision, 'acquisition_error', { step: 'register', reason: msg, at: now().toISOString() });
-    // Disposition stays un-consumed: retry-able once the cause clears (FR-6).
-    return { status: 'failed', reason: 'register_failed', error: msg };
+    const persist = await persistOnDecision(supabase, decision, 'acquisition_error', { step: 'register', reason: msg, at: now().toISOString() });
+    // Disposition stays un-consumed: the outcome is unknown until an operator
+    // resolves it (the in_flight guard above makes blind retries refuse).
+    return { status: 'failed', reason: 'register_failed', error: msg, errorPersisted: persist.persisted };
   }
 
+  // Forensics BEFORE the consume transition (adversarial finding: a consume
+  // crash must not lose the registrar response — no rollback exists).
+  const resultPersist = await persistOnDecision(supabase, decision, 'acquisition_result', {
+    registrar_response: registrarResponse, registered_at: now().toISOString(), live_price_usd: live.priceUsd,
+  });
   await updateDispositionStatus(supabase, questionKey, 'consumed', {
     answerPayload: { registrar_response: registrarResponse, registered_at: now().toISOString(), live_price_usd: live.priceUsd },
   });
-  return { status: 'registered', domain, registrarResponse };
+  return { status: 'registered', domain, registrarResponse, resultPersisted: resultPersist.persisted };
 }
 
 export default { executeAcquisition, planAcquisitionActions, PACKET_QUOTE_TTL_MS };

--- a/lib/venture-acquisition/acquire.js
+++ b/lib/venture-acquisition/acquire.js
@@ -1,0 +1,163 @@
+/**
+ * Purchase executor — approval-enforced, idempotent, ceiling-guarded, plan-first.
+ *
+ * SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 FR-3 / FR-4 / FR-5 / FR-6.
+ *
+ * THE AUTHORIZATION BOUNDARY IS THIS CODE PATH, not convention (RISK evidence
+ * 5d4f0fe5 gate #1): the executor consumes ONLY a linked chairman_decisions row
+ * with status='approved'. Refusal matrix (each with a named reason, zero
+ * registrar calls): decision absent / not an acquisition packet / pending /
+ * rejected-or-other-nonapproved / stale quote / already consumed.
+ *
+ * PLAN-MODE DEFAULT (mirrors lib/venture-deploy/promote.js): without
+ * deps.registrar AND deps.execute===true the result is the ordered action plan
+ * + status 'blocked_on_credentials' — no registrar HTTP is reachable. This is
+ * what lets the real-money surface merge dormant before the chairman
+ * provisions the token.
+ *
+ * EXECUTE ORDER (registry-first, register last):
+ *   1. live re-quote (Check) -> FR-5 fail-closed ceiling guardrail — the
+ *      packet's quote is ADVISORY; money decisions use the live number only.
+ *   2. recordDisposition(domain_acquisition, {venture_id, domain}) BEFORE the
+ *      register call (awaiting) — the durable check-before-register record;
+ *      a prior 'consumed' row short-circuits to already_acquired (FR-4).
+ *   3. registerDomain — the LAST, narrowest, most-audited step. No rollback
+ *      exists; the full registrar response is persisted for forensics.
+ *   4. disposition -> consumed with the registrar response in answer_payload.
+ * Failures persist a sanitized error onto the decision record
+ * (brief_data.acquisition_error) and LEAVE the disposition un-consumed so a
+ * retry is possible once the cause clears (FR-6, fail-loud never fail-silent).
+ *
+ * @module lib/venture-acquisition/acquire
+ */
+
+import { REGISTRAR_PRICE_CEILING } from '../venture-deploy/spend-guardrails.js';
+import { normalizeQuote } from './registrar-adapter.js';
+import { PACKET_KIND, resolvePurchaseCeilingUsd } from './decision-packet.js';
+import { recordDisposition, updateDispositionStatus, getDispositionBySubject, computeQuestionKey } from '../decision-binding/disposition.js';
+
+/** Quote freshness bound: an approval on week-old prices must re-compose (FR-3 stale state). */
+export const PACKET_QUOTE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** The ordered action plan (plan mode emits this; execute mode walks it). */
+export function planAcquisitionActions(domain) {
+  return [
+    { kind: 'live_quote', desc: `registrar Check ${domain} — live registrability + price (packet quote is advisory only)` },
+    { kind: 'ceiling_guardrail', desc: 'registrar-price-ceiling fail-closed check against the live quote (blocks even WITH approval)' },
+    { kind: 'idempotency_record', desc: `disposition domain_acquisition {venture, ${domain}} written BEFORE the register call (registry-first)` },
+    { kind: 'register', desc: `registrar Register ${domain} — the real-money, irreversible, most-audited step` },
+    { kind: 'dns_wiring', desc: 'zone + minimal record set for the deploy handoff (FR-7, PR-B)' },
+    { kind: 'deploy_handoff', desc: 'stamp ventures.deployment_url once routed (FR-8, PR-B)' },
+  ];
+}
+
+/** Persist a sanitized refusal/error onto the decision record (fail-soft recorder — never masks the primary result). */
+async function persistOnDecision(supabase, decision, key, payload) {
+  try {
+    await supabase
+      .from('chairman_decisions')
+      .update({ brief_data: { ...(decision.brief_data || {}), [key]: payload } })
+      .eq('id', decision.id);
+  } catch { /* recorder fault never masks the executor's own result */ }
+}
+
+/**
+ * Execute (or plan) the acquisition for an approved decision.
+ *
+ * @param {object} supabase - service-role client
+ * @param {string} decisionId - chairman_decisions.id
+ * @param {{registrar?: object|null, execute?: boolean, env?: object, now?: () => Date}} [deps]
+ * @returns {Promise<{status: string, reason?: string, domain?: string, plan?: object[], registrarResponse?: object, error?: string}>}
+ */
+export async function executeAcquisition(supabase, decisionId, deps = {}) {
+  const { registrar = null, execute = false, env = process.env, now = () => new Date() } = deps;
+
+  // ── FR-3 refusal matrix: every state below refuses BEFORE any registrar call ──
+  const { data: decision, error: dErr } = await supabase
+    .from('chairman_decisions')
+    .select('*')
+    .eq('id', decisionId)
+    .maybeSingle();
+  if (dErr) return { status: 'refused', reason: `decision_read_error: ${dErr.message}` };
+  if (!decision) return { status: 'refused', reason: 'decision_not_found' };
+  const brief = decision.brief_data || {};
+  if (brief.packet_kind !== PACKET_KIND) return { status: 'refused', reason: 'not_an_acquisition_packet' };
+  if (decision.status === 'pending') return { status: 'refused', reason: 'approval_pending' };
+  if (decision.status === 'rejected') return { status: 'refused', reason: 'decision_rejected' };
+  if (decision.status !== 'approved') return { status: 'refused', reason: `decision_not_approved: ${decision.status}` };
+
+  const domain = brief.recommended;
+  const ventureId = decision.venture_id;
+  if (!domain || !ventureId) return { status: 'refused', reason: 'packet_missing_domain_or_venture' };
+
+  const quotedAt = Date.parse(brief.quoted_at || '');
+  if (!Number.isFinite(quotedAt) || now().getTime() - quotedAt > PACKET_QUOTE_TTL_MS) {
+    return { status: 'refused', reason: 'stale_packet_quote', unblock: 're-compose the packet (composeAcquisitionPacket) for fresh quotes and a fresh approval' };
+  }
+
+  // ── FR-4 check-before-register: a consumed disposition means this purchase already happened ──
+  const subject = { venture_id: ventureId, domain };
+  const prior = await getDispositionBySubject(supabase, 'domain_acquisition', subject);
+  if (prior?.payload?.status === 'consumed') {
+    return { status: 'already_acquired', domain, disposition: prior.payload.question_key };
+  }
+
+  // ── TR-1 plan-mode default: no adapter or execute!==true => ordered plan, zero live calls ──
+  if (!registrar || execute !== true) {
+    return { status: 'blocked_on_credentials', domain, plan: planAcquisitionActions(domain) };
+  }
+
+  // ── FR-5 fail-closed ceiling against the LIVE quote (never the packet's) ──
+  const ceilingUsd = resolvePurchaseCeilingUsd(env);
+  let live;
+  try {
+    live = normalizeQuote(await registrar.checkDomain(domain));
+  } catch (e) {
+    const msg = String(e?.message || e).slice(0, 500);
+    await persistOnDecision(supabase, decision, 'acquisition_error', { step: 'live_quote', reason: msg, at: now().toISOString() });
+    return { status: 'failed', reason: 'live_quote_failed', error: msg };
+  }
+  const verdict = REGISTRAR_PRICE_CEILING.enforce({ quote: { priceUsd: live.priceUsd ?? undefined }, limits: { registrarPriceCeilingUsd: ceilingUsd } });
+  if (verdict.decision !== 'allow' || live.registrable !== true) {
+    const refusal = {
+      step: 'ceiling_guardrail',
+      reason: live.registrable !== true ? 'domain_not_registrable_at_execute' : verdict.reason,
+      live_price_usd: live.priceUsd,
+      ceiling_usd: ceilingUsd,
+      at: now().toISOString(),
+    };
+    await persistOnDecision(supabase, decision, 'acquisition_refusal', refusal);
+    return { status: 'refused', reason: refusal.reason };
+  }
+
+  // ── FR-4 registry-first: durable record BEFORE the money call ──
+  const { row } = await recordDisposition(supabase, {
+    decisionType: 'domain_acquisition',
+    subject,
+    decisionKey: `domain_acquisition:${ventureId}:${domain}`,
+    authority: 'chairman',
+    status: 'awaiting_disposition',
+  });
+  if (row?.payload?.status === 'consumed') {
+    return { status: 'already_acquired', domain, disposition: row.payload.question_key };
+  }
+  const questionKey = computeQuestionKey('domain_acquisition', subject);
+
+  // ── The register call: last, narrowest, most-audited. No rollback exists. ──
+  let registrarResponse;
+  try {
+    registrarResponse = await registrar.registerDomain(domain, { years: 1, autoRenew: false });
+  } catch (e) {
+    const msg = String(e?.message || e).slice(0, 500);
+    await persistOnDecision(supabase, decision, 'acquisition_error', { step: 'register', reason: msg, at: now().toISOString() });
+    // Disposition stays un-consumed: retry-able once the cause clears (FR-6).
+    return { status: 'failed', reason: 'register_failed', error: msg };
+  }
+
+  await updateDispositionStatus(supabase, questionKey, 'consumed', {
+    answerPayload: { registrar_response: registrarResponse, registered_at: now().toISOString(), live_price_usd: live.priceUsd },
+  });
+  return { status: 'registered', domain, registrarResponse };
+}
+
+export default { executeAcquisition, planAcquisitionActions, PACKET_QUOTE_TTL_MS };

--- a/lib/venture-acquisition/decision-packet.js
+++ b/lib/venture-acquisition/decision-packet.js
@@ -1,0 +1,146 @@
+/**
+ * Acquisition decision packet — shortlist -> ONE pending chairman decision.
+ *
+ * SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 FR-1.
+ *
+ * Consumes the Stage-11 domainShortlist riding the identity_brand_name
+ * venture_artifacts row (producer contract:
+ * lib/venture-domains/stage-integration.js buildDomainShortlist —
+ * [{candidate, domain, verdict, checked_at, price:null}]; price is null BY
+ * DESIGN there, so this module quotes LIVE via the registrar adapter's Check
+ * endpoint; unquotable domains carry price 'unknown', never a fabricated
+ * number).
+ *
+ * ROUTED THROUGH THE EXISTING QUEUE ONLY: a plain chairman_decisions insert
+ * (writer pattern: lib/eva/stage-zero/chairman-review.js) with status
+ * 'pending' — surfaced by chairman_pending_decisions / CLI / email for free,
+ * resolved exclusively via fn_chairman_decide. Never a bespoke channel or UI.
+ *
+ * DEGRADE, DON'T FABRICATE: the availability seam is default-OFF
+ * (DOMAIN_AVAILABILITY_MODE), so the shortlist may be ABSENT — that returns
+ * {status:'no_shortlist'} with the re-run hint and inserts NOTHING.
+ *
+ * IDEMPOTENT: an existing pending acquisition packet for the venture is
+ * returned as-is (no duplicate pending rows). Packets are identified by
+ * brief_data.packet_kind === 'domain_acquisition'.
+ *
+ * @module lib/venture-acquisition/decision-packet
+ */
+
+import { normalizeQuote } from './registrar-adapter.js';
+
+export const PACKET_KIND = 'domain_acquisition';
+export const PACKET_VERSION = 1;
+export const DEFAULT_DOMAIN_PURCHASE_CEILING_USD = 50;
+
+/** Resolve the configured per-purchase ceiling (env-driven; FR-5 default 50). */
+export function resolvePurchaseCeilingUsd(env = process.env) {
+  const v = Number(env.DOMAIN_PURCHASE_CEILING_USD);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_DOMAIN_PURCHASE_CEILING_USD;
+}
+
+/** Read the venture's latest identity_brand_name artifact's domainShortlist (or null). */
+export async function readDomainShortlist(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_data, created_at')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', 'identity_brand_name')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(`readDomainShortlist: ${error.message}`);
+  const shortlist = data?.[0]?.artifact_data?.domainShortlist;
+  return Array.isArray(shortlist) && shortlist.length > 0 ? shortlist : null;
+}
+
+/**
+ * Quote the shortlist via the registrar adapter (live Check per domain).
+ * Adapter null or a per-domain fault => price 'unknown' (honest, fail-soft for
+ * QUOTING only — the executor's ceiling re-quote is the fail-closed layer).
+ */
+export async function quoteShortlist(shortlist, registrar) {
+  const ranked = [];
+  for (const row of shortlist) {
+    let quotedPriceUsd = 'unknown';
+    let registrable = null;
+    if (registrar) {
+      try {
+        const q = normalizeQuote(await registrar.checkDomain(row.domain));
+        registrable = q.registrable;
+        quotedPriceUsd = q.priceUsd === null ? 'unknown' : q.priceUsd;
+      } catch { /* honest unknown — never fabricate a price */ }
+    }
+    ranked.push({ domain: row.domain, candidate: row.candidate, verdict: row.verdict, registrable, quoted_price_usd: quotedPriceUsd });
+  }
+  return ranked;
+}
+
+/** Pick the recommended default: first registrable-and-within-ceiling, else first row. */
+export function pickRecommended(ranked, ceilingUsd) {
+  const affordable = ranked.find((r) => r.registrable === true && typeof r.quoted_price_usd === 'number' && r.quoted_price_usd <= ceilingUsd);
+  return (affordable || ranked[0])?.domain ?? null;
+}
+
+/**
+ * Compose the packet: ONE pending chairman_decisions row for the venture.
+ *
+ * @param {object} supabase - service-role client
+ * @param {string} ventureId
+ * @param {{registrar?: object|null, env?: object, lifecycleStage?: number, selectedName?: string}} [deps]
+ * @returns {Promise<{status: 'created'|'existing'|'no_shortlist', decision?: object, unblock?: string}>}
+ */
+export async function composeAcquisitionPacket(supabase, ventureId, deps = {}) {
+  const { registrar = null, env = process.env, lifecycleStage = 11, selectedName = null } = deps;
+
+  // Idempotency first: one pending acquisition packet per venture, ever.
+  const { data: existing, error: exErr } = await supabase
+    .from('chairman_decisions')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .eq('status', 'pending')
+    .eq('brief_data->>packet_kind', PACKET_KIND)
+    .limit(1);
+  if (exErr) throw new Error(`composeAcquisitionPacket: pending lookup failed: ${exErr.message}`);
+  if (existing && existing.length > 0) return { status: 'existing', decision: existing[0] };
+
+  const shortlist = await readDomainShortlist(supabase, ventureId);
+  if (!shortlist) {
+    return {
+      status: 'no_shortlist',
+      unblock: 'No domainShortlist on the identity_brand_name artifact — re-run Stage-11 naming with DOMAIN_AVAILABILITY_MODE=live (lib/venture-domains/stage-integration.js seam) to produce one.',
+    };
+  }
+
+  const ceilingUsd = resolvePurchaseCeilingUsd(env);
+  const ranked = await quoteShortlist(shortlist, registrar);
+  const recommended = pickRecommended(ranked, ceilingUsd);
+  const name = selectedName || shortlist[0]?.candidate || null;
+
+  const { data: decision, error } = await supabase
+    .from('chairman_decisions')
+    .insert({
+      venture_id: ventureId,
+      lifecycle_stage: lifecycleStage,
+      status: 'pending',
+      decision: 'pending',
+      blocking: false,
+      decision_type: 'chairman_approval',
+      summary: `Domain acquisition: register "${recommended}" for venture name "${name}" (${ranked.length} candidate domain(s), ceiling $${ceilingUsd}/yr)`,
+      rationale: 'One-touch purchase gate (SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001): approve to register the recommended domain via Cloudflare Registrar, auto-wire DNS, and hand to the deploy pipeline. Purchase is real money and irreversible — the executor refuses without this approval.',
+      brief_data: {
+        packet_kind: PACKET_KIND,
+        packet_version: PACKET_VERSION,
+        selected_name: name,
+        ranked_domains: ranked,
+        recommended,
+        ceiling_usd: ceilingUsd,
+        quoted_at: new Date().toISOString(),
+      },
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`composeAcquisitionPacket: insert failed: ${error.message}`);
+  return { status: 'created', decision };
+}
+
+export default { composeAcquisitionPacket, readDomainShortlist, quoteShortlist, pickRecommended, resolvePurchaseCeilingUsd, PACKET_KIND, PACKET_VERSION, DEFAULT_DOMAIN_PURCHASE_CEILING_USD };

--- a/lib/venture-acquisition/decision-packet.js
+++ b/lib/venture-acquisition/decision-packet.js
@@ -139,7 +139,28 @@ export async function composeAcquisitionPacket(supabase, ventureId, deps = {}) {
     })
     .select()
     .single();
-  if (error) throw new Error(`composeAcquisitionPacket: insert failed: ${error.message}`);
+  if (error) {
+    // Real-DB constraint the pre-check can't see (adversarial finding): a
+    // partial unique index allows ONE pending decision per (venture, stage) —
+    // ANY other pending stage-11 decision 23505s this insert. Surface it as a
+    // named conflict (fail-loud, retry after that decision resolves), and
+    // re-check for a concurrently-created acquisition packet first.
+    if (error.code === '23505') {
+      const { data: raced } = await supabase
+        .from('chairman_decisions')
+        .select('*')
+        .eq('venture_id', ventureId)
+        .eq('status', 'pending')
+        .eq('brief_data->>packet_kind', PACKET_KIND)
+        .limit(1);
+      if (raced && raced.length > 0) return { status: 'existing', decision: raced[0] };
+      return {
+        status: 'pending_conflict',
+        unblock: `Another pending stage-${lifecycleStage} chairman decision holds this venture's pending slot (partial unique index) — resolve it, then re-compose.`,
+      };
+    }
+    throw new Error(`composeAcquisitionPacket: insert failed: ${error.message}`);
+  }
   return { status: 'created', decision };
 }
 

--- a/lib/venture-acquisition/registrar-adapter.js
+++ b/lib/venture-acquisition/registrar-adapter.js
@@ -1,0 +1,81 @@
+/**
+ * Cloudflare Registrar adapter — thin, injectable, credential-hygienic.
+ *
+ * SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 FR-2.
+ *
+ * THIN by contract (mirrors lib/venture-deploy/cli-adapters.js): no business
+ * logic here — search/check/register are 1:1 HTTP wrappers over the Cloudflare
+ * Registrar API (beta 2026-04: /accounts/{id}/registrar domain-search + check +
+ * register; capability confirmed at PLAN). All orchestration (approval matrix,
+ * ceiling, idempotency) lives in acquire.js / decision-packet.js, which take
+ * this adapter via dependency injection so tests pass fakes and no unit test
+ * ever makes live HTTP.
+ *
+ * CREDENTIAL CONTRACT (TR-5): token read ONCE at construction from
+ * CLOUDFLARE_REGISTRAR_API_TOKEN (Registrar write + DNS edit scopes,
+ * least-privilege) + CLOUDFLARE_ACCOUNT_ID. The factory returns NULL when
+ * either is absent — null adapter IS the plan-mode activation gate downstream
+ * (blocked_on_credentials, zero live calls). The token value is captured in a
+ * closure and never logged, echoed, thrown, or persisted; error messages carry
+ * only sanitized registrar error text.
+ *
+ * PROVISIONING (chairman bootstrap step, NOT an EXEC blocker): create a CF API
+ * token scoped to Registrar:Edit + DNS:Edit on the platform account, then set
+ * both env vars in the platform secret store. Until then every consumer plans.
+ *
+ * @module lib/venture-acquisition/registrar-adapter
+ */
+
+const API_BASE = 'https://api.cloudflare.com/client/v4';
+
+/**
+ * Build the adapter, or null when credentials are absent (=> plan mode).
+ *
+ * @param {object} [env] - environment (injectable for tests)
+ * @param {{fetchImpl?: typeof fetch}} [opts] - fetch seam for tests
+ * @returns {{searchDomains: Function, checkDomain: Function, registerDomain: Function}|null}
+ */
+export function createRegistrarAdapter(env = process.env, { fetchImpl } = {}) {
+  const token = env.CLOUDFLARE_REGISTRAR_API_TOKEN;
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+  if (!token || !accountId) return null;
+  const f = fetchImpl || (typeof fetch === 'function' ? fetch : null);
+  if (!f) return null;
+  const base = `${API_BASE}/accounts/${encodeURIComponent(accountId)}/registrar`;
+
+  /** One HTTP call; throws a SANITIZED error (registrar text only, never the token). */
+  async function call(method, path, body) {
+    const res = await f(`${base}${path}`, {
+      method,
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    let json = null;
+    try { json = await res.json(); } catch { /* non-JSON error body — status carries the signal */ }
+    if (!res.ok || (json && json.success === false)) {
+      const detail = json?.errors?.map((e) => e.message).filter(Boolean).join('; ') || `HTTP ${res.status}`;
+      throw new Error(`registrar ${method} ${path}: ${detail}`);
+    }
+    return json?.result ?? json;
+  }
+
+  return {
+    /** Candidate-domain search from a keyword/phrase. */
+    searchDomains: (query) => call('POST', '/domain-search', { query }),
+    /** Registrability + live price for one domain. Returns the raw API result. */
+    checkDomain: (domain) => call('GET', `/domains/${encodeURIComponent(domain)}/check`),
+    /** Register a domain. THE real-money call — acquire.js makes this the last, most-audited step. */
+    registerDomain: (domain, { years = 1, autoRenew = false } = {}) =>
+      call('POST', `/domains/${encodeURIComponent(domain)}/register`, { years, auto_renew: autoRenew }),
+  };
+}
+
+/** Normalize a checkDomain result to {registrable, priceUsd} (unknown-safe). */
+export function normalizeQuote(checkResult) {
+  const registrable = checkResult?.available === true || checkResult?.registrable === true;
+  const raw = checkResult?.price ?? checkResult?.price_usd ?? checkResult?.fees?.registration;
+  const priceUsd = typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+  return { registrable, priceUsd };
+}
+
+export default { createRegistrarAdapter, normalizeQuote };

--- a/lib/venture-deploy/spend-guardrails.js
+++ b/lib/venture-deploy/spend-guardrails.js
@@ -103,6 +103,23 @@ export const GUARDRAILS = Object.freeze([
 export const GUARDRAIL_NAMES = Object.freeze(GUARDRAILS.map((g) => g.name));
 
 /**
+ * Registrar price-ceiling guardrail (SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001
+ * FR-5). Same fail-closed shape as the deploy set, but deliberately NOT
+ * appended to GUARDRAILS — the deploy gate verifier asserts exactly the 8
+ * names above, and this guardrail is invoked by the acquisition executor
+ * (lib/venture-acquisition/acquire.js) with its own ctx:
+ *   { quote: { priceUsd }, limits: { registrarPriceCeilingUsd } }
+ * Missing / non-finite quote or ceiling => BLOCK — an unpriced domain purchase
+ * never proceeds, even with chairman approval.
+ */
+export const REGISTRAR_PRICE_CEILING = makeGuardrail('registrar-price-ceiling', (ctx) => {
+  const quote = ctx.quote?.priceUsd;
+  const ceiling = ctx.limits?.registrarPriceCeilingUsd;
+  if (!isNum(quote) || !isNum(ceiling)) return { ok: false, detail: 'registrar quote/ceiling not measured → fail-closed' };
+  return { ok: quote <= ceiling, detail: `registrar quote $${quote} / ceiling $${ceiling}/yr` };
+});
+
+/**
  * Evaluate ALL 8 guardrails for a venture context.
  * @param {object} ctx — { ventureId, usage, limits, config, state }
  * @returns {{ satisfied: boolean, decisions: object[], blocked: object[], alerts: object[] }}

--- a/tests/unit/venture-acquisition/acquisition-core.test.js
+++ b/tests/unit/venture-acquisition/acquisition-core.test.js
@@ -291,3 +291,82 @@ describe('consumed-exactly-once + fail-loud (FR-4/FR-6, TS-5/TS-7)', () => {
     expect(() => computeQuestionKey('nonsense_type', { a: 1 })).toThrow(/invalid decisionType/);
   });
 });
+
+// ── Adversarial-review regression pins (findings a6c7549a) ──────────────────
+
+describe('adversarial-review fixes', () => {
+  it('DOUBLE-BUY GUARD: a pre-existing AWAITING disposition (in-flight or crashed-after-register) refuses — never proceeds to register', async () => {
+    const key = computeQuestionKey('domain_acquisition', { venture_id: 'v1', domain: 'lumina.com' });
+    const tables = {
+      chairman_decisions: [approvedPacket()],
+      venture_artifacts: [],
+      system_events: [{ id: 'se-1', event_type: 'DECISION_DISPOSITION', idempotency_key: key, payload: { question_key: key, status: 'awaiting_disposition', decision_type: 'domain_acquisition' } }],
+    };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar();
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('refused');
+    expect(r.reason).toBe('in_flight_or_unknown_outcome');
+    expect(r.unblock).toMatch(/Verify with the registrar/);
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+  });
+
+  it('CEILING PROVENANCE: the APPROVED ceiling binds — raising the env ceiling after approval cannot loosen the bound', async () => {
+    const packet = approvedPacket();
+    packet.brief_data.ceiling_usd = 20; // what the chairman saw and approved
+    const tables = { chairman_decisions: [packet], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar({ checkDomain: vi.fn(async () => ({ available: true, price: 30 })) });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: { DOMAIN_PURCHASE_CEILING_USD: '100' } });
+    expect(r.status).toBe('refused'); // 30 > min(100, 20)
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+    expect(tables.chairman_decisions[0].brief_data.acquisition_refusal.ceiling_usd).toBe(20);
+  });
+
+  it('CEILING PROVENANCE inverse: lowering the env ceiling below the approved one also binds (min of both)', async () => {
+    const packet = approvedPacket();
+    packet.brief_data.ceiling_usd = 100;
+    const sb = fakeSupabase({ chairman_decisions: [packet], system_events: [], venture_artifacts: [] });
+    const reg = fakeRegistrar({ checkDomain: vi.fn(async () => ({ available: true, price: 30 })) });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: { DOMAIN_PURCHASE_CEILING_USD: '25' } });
+    expect(r.status).toBe('refused'); // 30 > min(25, 100)
+  });
+
+  it('LOWERCASE NORMALIZE: Lumina.com and lumina.com are the SAME idempotency subject', async () => {
+    const packet = approvedPacket();
+    packet.brief_data.recommended = 'Lumina.com';
+    const tables = { chairman_decisions: [packet], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: fakeRegistrar(), execute: true, env: {} });
+    expect(r.status).toBe('registered');
+    expect(r.domain).toBe('lumina.com');
+    const dispo = tables.system_events.find((e) => e.event_type === 'DECISION_DISPOSITION');
+    expect(dispo.idempotency_key).toBe(computeQuestionKey('domain_acquisition', { venture_id: 'v1', domain: 'lumina.com' }));
+  });
+
+  it('FORENSICS BEFORE CONSUME: the registrar response lands on the decision record (survives a consume crash), and success reports resultPersisted', async () => {
+    const tables = { chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: fakeRegistrar(), execute: true, env: {} });
+    expect(r.status).toBe('registered');
+    expect(r.resultPersisted).toBe(true);
+    expect(tables.chairman_decisions[0].brief_data.acquisition_result.registrar_response).toMatchObject({ order_id: 'ord-1' });
+  });
+
+  it('COMPOSE 23505: the partial unique pending index surfaces as pending_conflict (or the raced packet), never an opaque throw', async () => {
+    const tables = tablesWithShortlist();
+    const sb = fakeSupabase(tables);
+    // Simulate the real-DB partial unique index: first insert 23505s.
+    const origFrom = sb.from.bind(sb);
+    sb.from = (table) => {
+      const chain = origFrom(table);
+      if (table === 'chairman_decisions') {
+        chain.insert = () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "idx_chairman_decisions_unique_pending"' } }) }) });
+      }
+      return chain;
+    };
+    const r = await composeAcquisitionPacket(sb, 'v1', { registrar: fakeRegistrar(), env: {} });
+    expect(r.status).toBe('pending_conflict');
+    expect(r.unblock).toMatch(/pending slot/);
+  });
+});

--- a/tests/unit/venture-acquisition/acquisition-core.test.js
+++ b/tests/unit/venture-acquisition/acquisition-core.test.js
@@ -1,0 +1,293 @@
+/**
+ * SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 PR-A (FR-1..FR-6, TS-1..TS-7):
+ * decision packet + registrar adapter + approval-enforced idempotent
+ * ceiling-guarded executor. All registrar/supabase interactions are injected
+ * fakes — zero live HTTP, zero live DB.
+ *
+ * @module tests/unit/venture-acquisition/acquisition-core.test
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRegistrarAdapter, normalizeQuote } from '../../../lib/venture-acquisition/registrar-adapter.js';
+import { composeAcquisitionPacket, pickRecommended, resolvePurchaseCeilingUsd, PACKET_KIND, DEFAULT_DOMAIN_PURCHASE_CEILING_USD } from '../../../lib/venture-acquisition/decision-packet.js';
+import { executeAcquisition, PACKET_QUOTE_TTL_MS } from '../../../lib/venture-acquisition/acquire.js';
+import { REGISTRAR_PRICE_CEILING } from '../../../lib/venture-deploy/spend-guardrails.js';
+import { computeQuestionKey } from '../../../lib/decision-binding/disposition.js';
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+/** Minimal chainable supabase fake over in-memory tables. */
+function fakeSupabase(tables) {
+  const calls = { inserts: [], updates: [] };
+  function from(table) {
+    const rows = tables[table] || [];
+    const state = { filters: [], order: null, limit: null };
+    const applyFilters = () => rows.filter((r) => state.filters.every(([k, v]) => {
+      if (k.includes('->>')) {
+        const [col, key] = k.split('->>');
+        return String((r[col] || {})[key]) === String(v);
+      }
+      return r[k] === v;
+    }));
+    const chain = {
+      select() { return chain; },
+      eq(k, v) { state.filters.push([k, v]); return chain; },
+      order() { return chain; },
+      limit() { return Promise.resolve({ data: applyFilters(), error: null }); },
+      maybeSingle() { const d = applyFilters(); return Promise.resolve({ data: d[0] ?? null, error: null }); },
+      single() { const d = applyFilters(); return Promise.resolve({ data: d[0] ?? null, error: d[0] ? null : { message: 'no row' } }); },
+      insert(row) {
+        calls.inserts.push({ table, row });
+        const stored = { id: `${table}-${rows.length + 1}`, ...row };
+        rows.push(stored); tables[table] = rows;
+        return {
+          select: () => ({ single: () => Promise.resolve({ data: stored, error: null }) }),
+        };
+      },
+      update(patch) {
+        calls.updates.push({ table, patch });
+        return {
+          eq(k, v) {
+            const target = rows.find((r) => r[k] === v);
+            if (target) Object.assign(target, patch);
+            return { select: () => ({ single: () => Promise.resolve({ data: target ?? null, error: null }) }), then: (res) => res({ data: target ?? null, error: null }) };
+          },
+        };
+      },
+    };
+    return chain;
+  }
+  return { from, _calls: calls, _tables: tables };
+}
+
+const SHORTLIST = [
+  { candidate: 'Lumina', domain: 'lumina.com', verdict: 'available', checked_at: 't', price: null },
+  { candidate: 'Lumina', domain: 'lumina.io', verdict: 'available', checked_at: 't', price: null },
+  { candidate: 'Lumina', domain: 'getlumina.com', verdict: 'unknown', checked_at: 't', price: null },
+];
+
+function tablesWithShortlist(extraDecisions = []) {
+  return {
+    venture_artifacts: [{ id: 'a1', venture_id: 'v1', artifact_type: 'identity_brand_name', created_at: '2026-07-10T00:00:00Z', artifact_data: { domainShortlist: SHORTLIST } }],
+    chairman_decisions: [...extraDecisions],
+    system_events: [],
+  };
+}
+
+const fakeRegistrar = (overrides = {}) => ({
+  checkDomain: vi.fn(async (d) => ({ available: true, price: d === 'lumina.com' ? 12.5 : 32 })),
+  registerDomain: vi.fn(async (d) => ({ domain: d, order_id: 'ord-1', status: 'registered' })),
+  searchDomains: vi.fn(async () => []),
+  ...overrides,
+});
+
+const approvedPacket = (over = {}) => ({
+  id: 'dec-1', venture_id: 'v1', status: 'approved',
+  brief_data: {
+    packet_kind: PACKET_KIND, recommended: 'lumina.com', ceiling_usd: 50,
+    quoted_at: new Date().toISOString(), ranked_domains: [],
+  },
+  ...over,
+});
+
+// ── FR-2 adapter + credential hygiene ────────────────────────────────────────
+
+describe('registrar adapter (FR-2)', () => {
+  it('factory returns null without both env vars — the plan-mode activation gate', () => {
+    expect(createRegistrarAdapter({}, { fetchImpl: vi.fn() })).toBeNull();
+    expect(createRegistrarAdapter({ CLOUDFLARE_REGISTRAR_API_TOKEN: 't' }, { fetchImpl: vi.fn() })).toBeNull();
+    expect(createRegistrarAdapter({ CLOUDFLARE_ACCOUNT_ID: 'a' }, { fetchImpl: vi.fn() })).toBeNull();
+    expect(createRegistrarAdapter({ CLOUDFLARE_REGISTRAR_API_TOKEN: 't', CLOUDFLARE_ACCOUNT_ID: 'a' }, { fetchImpl: vi.fn() })).not.toBeNull();
+  });
+
+  it('API error surfaces sanitized registrar text — NEVER the token value', async () => {
+    const secret = 'SUPER-SECRET-TOKEN-VALUE';
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 402, json: async () => ({ success: false, errors: [{ message: 'payment method required' }] }) }));
+    const adapter = createRegistrarAdapter({ CLOUDFLARE_REGISTRAR_API_TOKEN: secret, CLOUDFLARE_ACCOUNT_ID: 'acct' }, { fetchImpl });
+    await expect(adapter.checkDomain('x.com')).rejects.toThrow(/payment method required/);
+    try { await adapter.checkDomain('x.com'); } catch (e) { expect(String(e.message)).not.toContain(secret); }
+    // The token travels only in the auth header of the fetch call itself.
+    expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe(`Bearer ${secret}`);
+  });
+
+  it('normalizeQuote: honest unknown for missing price; registrable from available|registrable', () => {
+    expect(normalizeQuote({ available: true, price: 9.99 })).toEqual({ registrable: true, priceUsd: 9.99 });
+    expect(normalizeQuote({ registrable: true })).toEqual({ registrable: true, priceUsd: null });
+    expect(normalizeQuote(undefined)).toEqual({ registrable: false, priceUsd: null });
+  });
+});
+
+// ── FR-1 packet composer (TS-1, TS-2) ────────────────────────────────────────
+
+describe('decision packet composer (FR-1)', () => {
+  it('TS-1 happy path: one pending chairman_decisions row with live-quoted ranked domains + recommended default', async () => {
+    const sb = fakeSupabase(tablesWithShortlist());
+    const r = await composeAcquisitionPacket(sb, 'v1', { registrar: fakeRegistrar(), env: {} });
+    expect(r.status).toBe('created');
+    expect(r.decision.status).toBe('pending');
+    expect(r.decision.brief_data.packet_kind).toBe(PACKET_KIND);
+    expect(r.decision.brief_data.recommended).toBe('lumina.com'); // cheapest registrable within ceiling ranks first in shortlist order
+    expect(r.decision.brief_data.ranked_domains).toHaveLength(3);
+    expect(r.decision.brief_data.ranked_domains[0]).toMatchObject({ domain: 'lumina.com', quoted_price_usd: 12.5, registrable: true });
+    expect(r.decision.brief_data.ceiling_usd).toBe(DEFAULT_DOMAIN_PURCHASE_CEILING_USD);
+    expect(sb._calls.inserts).toHaveLength(1);
+  });
+
+  it('TS-2 degrade: absent shortlist -> no_shortlist + re-run hint + ZERO inserts (never fabricate)', async () => {
+    const sb = fakeSupabase({ venture_artifacts: [], chairman_decisions: [], system_events: [] });
+    const r = await composeAcquisitionPacket(sb, 'v1', { registrar: fakeRegistrar(), env: {} });
+    expect(r.status).toBe('no_shortlist');
+    expect(r.unblock).toMatch(/DOMAIN_AVAILABILITY_MODE=live/);
+    expect(sb._calls.inserts).toHaveLength(0);
+  });
+
+  it('TS-2 idempotency: an existing pending acquisition packet is returned, not duplicated', async () => {
+    const existing = { id: 'dec-0', venture_id: 'v1', status: 'pending', brief_data: { packet_kind: PACKET_KIND } };
+    const sb = fakeSupabase(tablesWithShortlist([existing]));
+    const r = await composeAcquisitionPacket(sb, 'v1', { registrar: fakeRegistrar(), env: {} });
+    expect(r.status).toBe('existing');
+    expect(r.decision.id).toBe('dec-0');
+    expect(sb._calls.inserts).toHaveLength(0);
+  });
+
+  it('unquotable domains carry price unknown (registrar fault is honest, not fabricated)', async () => {
+    const sb = fakeSupabase(tablesWithShortlist());
+    const reg = fakeRegistrar({ checkDomain: vi.fn(async () => { throw new Error('rate limited'); }) });
+    const r = await composeAcquisitionPacket(sb, 'v1', { registrar: reg, env: {} });
+    expect(r.decision.brief_data.ranked_domains.every((d) => d.quoted_price_usd === 'unknown')).toBe(true);
+  });
+
+  it('ceiling env: DOMAIN_PURCHASE_CEILING_USD respected, default 50 pinned', () => {
+    expect(resolvePurchaseCeilingUsd({})).toBe(50);
+    expect(resolvePurchaseCeilingUsd({ DOMAIN_PURCHASE_CEILING_USD: '25' })).toBe(25);
+    expect(resolvePurchaseCeilingUsd({ DOMAIN_PURCHASE_CEILING_USD: 'garbage' })).toBe(50);
+    expect(pickRecommended([{ domain: 'a.com', registrable: true, quoted_price_usd: 60 }, { domain: 'b.com', registrable: true, quoted_price_usd: 12 }], 50)).toBe('b.com');
+  });
+});
+
+// ── FR-3 refusal matrix (TS-3) + plan mode (TS-4) ────────────────────────────
+
+describe('executor refusal matrix (FR-3 / TS-3)', () => {
+  const cases = [
+    ['absent', [], 'nonexistent-id', 'decision_not_found'],
+    ['pending', [approvedPacket({ status: 'pending' })], 'dec-1', 'approval_pending'],
+    ['rejected', [approvedPacket({ status: 'rejected' })], 'dec-1', 'decision_rejected'],
+    ['other-status', [approvedPacket({ status: 'expired' })], 'dec-1', 'decision_not_approved: expired'],
+    ['not-a-packet', [approvedPacket({ brief_data: { packet_kind: 'something_else' } })], 'dec-1', 'not_an_acquisition_packet'],
+  ];
+  for (const [label, decisions, id, reason] of cases) {
+    it(`${label} decision refuses with ${reason} and performs ZERO registrar calls`, async () => {
+      const sb = fakeSupabase({ chairman_decisions: decisions, system_events: [], venture_artifacts: [] });
+      const reg = fakeRegistrar();
+      const r = await executeAcquisition(sb, id, { registrar: reg, execute: true, env: {} });
+      expect(r.status).toBe('refused');
+      expect(r.reason).toBe(reason);
+      expect(reg.checkDomain).not.toHaveBeenCalled();
+      expect(reg.registerDomain).not.toHaveBeenCalled();
+    });
+  }
+
+  it('stale packet quote (> TTL) refuses with re-compose unblock (TS-3 stale state)', async () => {
+    const stale = approvedPacket();
+    stale.brief_data.quoted_at = new Date(Date.now() - PACKET_QUOTE_TTL_MS - 1000).toISOString();
+    const sb = fakeSupabase({ chairman_decisions: [stale], system_events: [], venture_artifacts: [] });
+    const reg = fakeRegistrar();
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.reason).toBe('stale_packet_quote');
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+  });
+
+  it('TS-4 plan mode: approved decision, no adapter -> ordered plan + blocked_on_credentials, zero live calls', async () => {
+    const sb = fakeSupabase({ chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: null, execute: false, env: {} });
+    expect(r.status).toBe('blocked_on_credentials');
+    expect(r.plan.map((a) => a.kind)).toEqual(['live_quote', 'ceiling_guardrail', 'idempotency_record', 'register', 'dns_wiring', 'deploy_handoff']);
+  });
+
+  it('TS-4 execute:true without adapter still plans (both required — promote.js parity)', async () => {
+    const sb = fakeSupabase({ chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] });
+    const withAdapterNoExecute = await executeAcquisition(sb, 'dec-1', { registrar: fakeRegistrar(), execute: false, env: {} });
+    expect(withAdapterNoExecute.status).toBe('blocked_on_credentials');
+  });
+});
+
+// ── FR-5 ceiling (TS-6) ──────────────────────────────────────────────────────
+
+describe('registrar price ceiling (FR-5 / TS-6)', () => {
+  it('guardrail shape: fail-closed on missing quote or ceiling; allow only quote<=ceiling', () => {
+    expect(REGISTRAR_PRICE_CEILING.enforce({}).decision).toBe('block');
+    expect(REGISTRAR_PRICE_CEILING.enforce({ quote: { priceUsd: 10 } }).decision).toBe('block');
+    expect(REGISTRAR_PRICE_CEILING.enforce({ quote: { priceUsd: 51 }, limits: { registrarPriceCeilingUsd: 50 } }).decision).toBe('block');
+    expect(REGISTRAR_PRICE_CEILING.enforce({ quote: { priceUsd: 50 }, limits: { registrarPriceCeilingUsd: 50 } }).decision).toBe('allow');
+  });
+
+  it('above-ceiling LIVE quote refuses EVEN WITH approval; refusal persisted on the decision record', async () => {
+    const tables = { chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar({ checkDomain: vi.fn(async () => ({ available: true, price: 500 })) });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('refused');
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+    expect(tables.chairman_decisions[0].brief_data.acquisition_refusal).toMatchObject({ step: 'ceiling_guardrail', live_price_usd: 500, ceiling_usd: 50 });
+  });
+
+  it('unknown live price refuses (fail-closed) — packet quote is never used for the money decision', async () => {
+    const sb = fakeSupabase({ chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] });
+    const reg = fakeRegistrar({ checkDomain: vi.fn(async () => ({ available: true })) }); // no price
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('refused');
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+  });
+});
+
+// ── FR-4 idempotency (TS-5) + FR-6 fail-loud (TS-7) ─────────────────────────
+
+describe('consumed-exactly-once + fail-loud (FR-4/FR-6, TS-5/TS-7)', () => {
+  it('TS-5 happy execute: registry-first disposition BEFORE register, consumed after, full response persisted', async () => {
+    const tables = { chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar();
+    const order = [];
+    reg.registerDomain.mockImplementation(async (d) => { order.push('register'); return { domain: d, order_id: 'ord-1' }; });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('registered');
+    const dispo = tables.system_events.find((e) => e.event_type === 'DECISION_DISPOSITION');
+    expect(dispo).toBeTruthy();
+    expect(dispo.payload.status).toBe('consumed');
+    expect(dispo.payload.answer_payload.registrar_response).toMatchObject({ order_id: 'ord-1' });
+    expect(dispo.idempotency_key).toBe(computeQuestionKey('domain_acquisition', { venture_id: 'v1', domain: 'lumina.com' }));
+  });
+
+  it('TS-5 re-run after success: zero additional registrar writes, already_acquired (durable readback)', async () => {
+    const key = computeQuestionKey('domain_acquisition', { venture_id: 'v1', domain: 'lumina.com' });
+    const tables = {
+      chairman_decisions: [approvedPacket()],
+      venture_artifacts: [],
+      system_events: [{ id: 'se-1', event_type: 'DECISION_DISPOSITION', idempotency_key: key, payload: { question_key: key, status: 'consumed', decision_type: 'domain_acquisition' } }],
+    };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar();
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('already_acquired');
+    expect(reg.checkDomain).not.toHaveBeenCalled();
+    expect(reg.registerDomain).not.toHaveBeenCalled();
+  });
+
+  it('TS-7 register failure: sanitized error persisted to brief_data, disposition NOT consumed (retry-able), non-success status', async () => {
+    const tables = { chairman_decisions: [approvedPacket()], system_events: [], venture_artifacts: [] };
+    const sb = fakeSupabase(tables);
+    const reg = fakeRegistrar({ registerDomain: vi.fn(async () => { throw new Error('registrar POST /domains/lumina.com/register: insufficient funds'); }) });
+    const r = await executeAcquisition(sb, 'dec-1', { registrar: reg, execute: true, env: {} });
+    expect(r.status).toBe('failed');
+    expect(r.reason).toBe('register_failed');
+    expect(tables.chairman_decisions[0].brief_data.acquisition_error).toMatchObject({ step: 'register' });
+    expect(tables.chairman_decisions[0].brief_data.acquisition_error.reason).toMatch(/insufficient funds/);
+    const dispo = tables.system_events.find((e) => e.event_type === 'DECISION_DISPOSITION');
+    expect(dispo.payload.status).toBe('awaiting_disposition'); // retry-able, NOT consumed
+  });
+
+  it('disposition enum: domain_acquisition accepted, invalid type still throws (additive pin)', () => {
+    expect(() => computeQuestionKey('domain_acquisition', { venture_id: 'v', domain: 'd' })).not.toThrow();
+    expect(() => computeQuestionKey('ratification', { fixture_set_id: 1, fixture_id: 2 })).not.toThrow();
+    expect(() => computeQuestionKey('nonsense_type', { a: 1 })).toThrow(/invalid decisionType/);
+  });
+});


### PR DESCRIPTION
## Summary
- **Decision packet composer** (`lib/venture-acquisition/decision-packet.js`, FR-1): Stage-11 `domainShortlist` artifact -> ONE pending `chairman_decisions` row with live registrar quotes (unquotable = honest `unknown`) + recommended default. Degrades explicitly on absent shortlist (availability seam is default-OFF); idempotent per venture; routed through the EXISTING queue/`fn_chairman_decide` only — no new approval channel or UI.
- **CF Registrar adapter** (`registrar-adapter.js`, FR-2): thin injectable HTTP wrapper over the Registrar API beta (2026-04: domain-search / check / register). Null factory without `CLOUDFLARE_REGISTRAR_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` — credential presence IS the activation gate. Token read-once in closure, never logged/persisted; errors carry sanitized registrar text only.
- **Purchase executor** (`acquire.js`, FR-3/4/5/6): in-code 5-state refusal matrix (absent / not-a-packet / pending / rejected / stale-quote) + consumed-readback; plan-mode default (`blocked_on_credentials`, zero live calls — promote.js parity); live-quote fail-closed **price ceiling** via new `REGISTRAR_PRICE_CEILING` guardrail (deploy `GUARDRAILS` list untouched); **registry-first** `domain_acquisition` disposition (new additive enum value in `disposition.js`) written BEFORE the register call; register is last/most-audited; failures persist sanitized onto `brief_data` and leave the disposition retry-able.
- **Dormant by design**: zero `CLOUDFLARE_*` credentials exist in any environment — every path plans until the chairman provisions the Registrar-scoped token (documented in the adapter header).

RISK evidence 5d4f0fe5 gates #1-#4 + #6 land here; PR-B (FR-7..FR-9) adds DNS wiring + deploy handoff + single-touch E2E.

## Test plan
- 23 new tests (`tests/unit/venture-acquisition/acquisition-core.test.js`) covering TS-1..TS-7: packet happy/degrade/idempotent/unknown-price, adapter credential gate + sanitized errors, full refusal matrix with zero-registrar-call asserts, plan-mode, ceiling fail-closed (above-ceiling WITH approval refused + persisted), consumed-exactly-once re-run, register-failure fail-loud.
- Existing pins green unmodified: `decision-binding-disposition.test.js` + `venture-spend-guardrails.test.js` (60 tests).
- eslint + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)