### PR TITLE
docs(SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001): document directive hard-wake + delivered_at/read_at split

### DIFF
--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -101,17 +101,30 @@ node scripts/coordinator-ack-adam.cjs --advisory <id> --reply "sourcing now" # r
 node scripts/adam-advisory.cjs inbox                                         # drains the full lane (replies + directives)
 ```
 
-## Receipt contract — ALL directive kinds (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001)
+## Receipt contract — ALL directive kinds (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001, revised by SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001)
 
 The two-stage ACK above is not advisory-specific. For **every** directive kind
 (`coordinator_request`, `work_assignment`, `adam_action_required`, `coordinator_reminder`,
 `coordinator_to_adam` — the canonical list is `DIRECTIVE_KINDS` in
-`lib/fleet/worker-status.cjs`, **import it, never duplicate it**), in **both** directions:
+`lib/fleet/worker-status.cjs`, **import it, never duplicate it**), in **both** directions,
+receipt is now a **three-stage** contract:
 
 | Marker | Meaning | Who stamps it |
 |--------|---------|---------------|
-| `read_at` | **DELIVERED** — a render/poll surfaced the row to the target | any poll/render (inbox hook, dashboard) |
+| `delivered_at` | **TRANSPORT RECEIPT** — a render/poll merely saw the row exist | any poll/render (inbox hook, dashboard) |
+| `read_at` | **SURFACED FOR ACTION** — the row was genuinely surfaced for action-required processing | worker check-in `ackMessage` on a real claim, Adam's action-required drill, `ack-chairman-directive.cjs`, etc. — never a plain poll/render |
 | `acknowledged_at` / `payload.actioned_at` | **ACTIONED** — the agent genuinely processed it | ONLY the agent that actioned the row |
+
+Prior to SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001, a plain poll/render stamped
+`read_at` directly (skipping the middle stage) — that let a directive row read as "delivered"
+to any consumer gating on `read_at IS NULL`, even though nothing had genuinely surfaced it for
+action yet. This is exactly the gap that caused a chairman burn-now directive stack to sit
+unactioned for 25+ minutes on 2026-07-09: `scripts/coordinator-quiet-tick.mjs`'s hard-wake
+check (see [fleet-hibernation-quiet-tick.md](fleet-hibernation-quiet-tick.md#directive-hard-wake-override-sd-leo-infra-coordinator-wake-on-directive-001))
+gates on `read_at IS NULL`, so a row already poll-stamped to `read_at` looked "handled" and
+never triggered the hard-wake. `scripts/hooks/coordination-inbox.cjs`'s `classifyInboxMessage`
+now stamps `delivered_at` on first poll instead, leaving `read_at` NULL (and the hard-wake
+live) until real action occurs.
 
 No poll/drain path may ever stamp `acknowledged_at` on a directive kind (FR-3 —
 the inbox hook's kind-allowlist enforces this; the sender-type allowlist that auto-acked

--- a/docs/protocol/fleet-hibernation-quiet-tick.md
+++ b/docs/protocol/fleet-hibernation-quiet-tick.md
@@ -45,6 +45,46 @@ When workers/signals are present the tick runs ACTIVE (180–270s), so latency i
 whenever anything is actually moving. Phasing (`partyOffsetS`: coordinator 0, Adam 420)
 keeps the two parties from co-firing and tapping each other awake.
 
+## Directive hard-wake override (SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001)
+
+The 900s quiescent park above assumed no pending work needed the coordinator's attention.
+That assumption broke on 2026-07-09: a chairman burn-now directive stack sat unactioned for
+25+ minutes because `decideCadence` had no awareness of pending directive-class inbox rows
+and could self-schedule a full 900s park immediately after a directive landed.
+
+`decideCadence` now takes an optional `hasUnactionedDirective` flag that, when true,
+overrides **both** the quiescent park and the normal active band with a short
+`DIRECTIVE_WAKE_MIN_S`–`DIRECTIVE_WAKE_MAX_S` (15–45s) hard-wake delay — checked *before* the
+quiescent branch. Omitting the flag is byte-identical to prior behavior.
+
+`scripts/coordinator-quiet-tick.mjs` computes the flag from **two independent, `Promise.all`
+branches** (each with its own error boundary, so one failing never suppresses the other):
+
+| Check | Covers | Mechanism |
+|-------|--------|-----------|
+| `hasUnactionedDirective(sb, coordinatorId)` | Session-targeted `DIRECTIVE_KINDS` rows (`target_session = <real session id>`) | `read_at IS NULL` |
+| `hasOutstandingChairmanDirective(sb)` | `chairman_directive` rows — issued with `target_session='broadcast'` (a literal sentinel, never a real session id, per `scripts/issue-chairman-directive.cjs`) | reuses `lib/coordinator/chairman-directive-gauge.cjs` `loadRoleDirectiveStatus('coordinator')`, since broadcast directives track compliance via a separate `chairman_directive_ack` mechanism, not `read_at` |
+
+The two-check split exists because a plain `target_session=coordinatorId` query structurally
+cannot see broadcast-lane `chairman_directive` rows — the exact flagship incident scenario —
+so a single check would have missed it.
+
+### `read_at` vs `delivered_at`
+
+`session_coordination.delivered_at` (additive migration, no backfill) now separates two
+meanings that used to be conflated under `read_at`:
+
+- **`delivered_at`** — a consumer's process merely *saw* this row (poll/list/render).
+- **`read_at`** — the row was genuinely surfaced for action-required processing (worker
+  check-in `ackMessage` on a real claim, Adam's action-required drill,
+  `ack-chairman-directive.cjs`, etc.).
+
+`scripts/hooks/coordination-inbox.cjs`'s `classifyInboxMessage` previously stamped `read_at`
+on a `DIRECTIVE_KINDS` row on its *first poll* — a stand-in "delivered" marker that hid the
+row from any consumer gating on `read_at IS NULL` (including `hasUnactionedDirective` above)
+before it was ever genuinely actioned. It now stamps `delivered_at` instead, leaving
+`read_at` NULL until real action occurs.
+
 ## Smoke test (safe — no side effects)
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents the directive hard-wake override (`hasUnactionedDirective`/`hasOutstandingChairmanDirective`) shipped in PR #5794 in `docs/protocol/fleet-hibernation-quiet-tick.md`
- Corrects a now-stale claim in `docs/protocol/coordinator-adam-comms.md` — it described a two-stage receipt contract (`read_at` = DELIVERED on poll/render) that PR #5794 changed to a three-stage model (`delivered_at` = transport receipt, `read_at` = surfaced for action, `acknowledged_at` = actioned)

## Test plan
- [x] Docs-only change, no code/behavior affected
- [x] Cross-references between the two updated docs verified (anchor link to the new section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)