### PR TITLE
fix(SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001): exit-gate enforcer fails closed on unresolvable binding verifiers + missing stage rows

### DIFF
--- a/lib/eva/lifecycle/exit-gate-enforcer.js
+++ b/lib/eva/lifecycle/exit-gate-enforcer.js
@@ -51,6 +51,32 @@ const FLAG_VALUE = (() => {
  */
 
 /**
+ * SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (FR-3): best-effort
+ * EXIT_GATE_ANOMALY system_events write, mirroring logObserveOnlyEvent's proven
+ * fail-soft shape. Never throws — a logging failure must never affect the
+ * (already fail-closed) blocking verdict itself.
+ *
+ * @param {Object} args
+ * @param {'unresolvable_binding_verifier'|'stage_config_row_missing'} args.anomalyKind
+ */
+async function logAnomalyEvent({ supabase, ventureId, stageNumber, anomalyKind, gateString = null, reason }) {
+  try {
+    const stamp = new Date().toISOString();
+    await supabase.from('system_events').insert({
+      event_type: 'EXIT_GATE_ANOMALY',
+      venture_id: ventureId,
+      stage_id: stageNumber,
+      idempotency_key: `EXIT_GATE_ANOMALY:${ventureId}:${stageNumber}:${anomalyKind}:${gateString ?? ''}:${Date.parse(stamp)}`,
+      payload: { anomaly_kind: anomalyKind, venture_id: ventureId, stage_number: stageNumber, gate_string: gateString, reason },
+      details: { anomaly_kind: anomalyKind, venture_id: ventureId, stage_number: stageNumber, gate_string: gateString, reason },
+      created_at: stamp,
+    });
+  } catch (err) {
+    console.warn(`[exit-gate-enforcer] anomaly event log failed (non-fatal): ${err.message}`);
+  }
+}
+
+/**
  * SD-LEO-INFRA-ACTIVATE-DORMANT-EXIT-001 (FR-2): best-effort system_events write for one
  * observe-only gate evaluation. Never throws — a logging failure must not affect the
  * (already non-blocking) observe-only evaluation itself.
@@ -76,9 +102,11 @@ async function logObserveOnlyEvent({ supabase, eventType, ventureId, stageNumber
  * Evaluate whether a venture is allowed to advance from `fromStage`. Caller is
  * responsible for invoking the actual advance RPC when allowed===true.
  *
- * Empty / missing gates.exit → allowed (no gates to check).
- * Unknown gate strings (no verifier registered) → logged and skipped (allow),
- * matching the staged-rollout philosophy of TR-3.
+ * Row present, empty / missing gates.exit → allowed (no gates to check).
+ * MISSING venture_stages row → BLOCK + EXIT_GATE_ANOMALY (fail-closed —
+ * SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 HP-2).
+ * Unknown gate strings on BINDING gates.exit → BLOCK + EXIT_GATE_ANOMALY
+ * (fail-closed — HP-1); log-and-allow remains ONLY for gates.exit_observe.
  *
  * @param {Object} args
  * @param {import('@supabase/supabase-js').SupabaseClient} args.supabase
@@ -113,6 +141,25 @@ export async function checkExitGates({ supabase, ventureId, fromStage }) {
     return {
       allowed: false,
       blocked_by: [`venture_stages read failed: ${cfgError.message}`],
+      gates_checked: [],
+      would_block_by: [],
+      stage_number: fromStage,
+      flag_enforced: true,
+    };
+  }
+
+  // SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (HP-2/FR-2): a MISSING
+  // venture_stages row is not a cfgError (maybeSingle returns data:null,
+  // error:null) and previously null-chained through gates?.exit -> undefined
+  // -> silent allow. Advancing FROM a stage the config table does not know is
+  // itself anomalous: block loudly. Row PRESENT with empty/absent gates keeps
+  // the intended allow path below.
+  if (!stageConfig) {
+    const reason = `venture_stages row missing for stage ${fromStage} (fail-closed): advancing FROM an unknown stage is anomalous`;
+    await logAnomalyEvent({ supabase, ventureId, stageNumber: fromStage, anomalyKind: 'stage_config_row_missing', reason });
+    return {
+      allowed: false,
+      blocked_by: [reason],
       gates_checked: [],
       would_block_by: [],
       stage_number: fromStage,
@@ -163,7 +210,14 @@ export async function checkExitGates({ supabase, ventureId, fromStage }) {
     gates_checked.push(gateString);
     const verifier = resolveVerifier(gateString);
     if (!verifier) {
-      console.warn(`[exit-gate-enforcer] No verifier registered for gate "${gateString}" at stage ${fromStage} — skipping (allow).`);
+      // SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (HP-1/FR-1): a
+      // declared-but-unresolvable verifier on a BINDING gate is fail-CLOSED —
+      // the author declared a gate the runtime cannot check, and allowing
+      // through an uncheckable gate is a silent bypass. Unknown-string
+      // log-and-allow remains correct ONLY for gates.exit_observe above.
+      const reason = `${gateString}: no verifier registered for a BINDING gate (fail-closed)`;
+      blocked_by.push(reason);
+      await logAnomalyEvent({ supabase, ventureId, stageNumber: fromStage, anomalyKind: 'unresolvable_binding_verifier', gateString, reason });
       continue;
     }
     const { satisfied, reason } = await verifier({ supabase, ventureId, fromStage });

--- a/tests/unit/eva/artifact-persistence-advance-reset.test.js
+++ b/tests/unit/eva/artifact-persistence-advance-reset.test.js
@@ -46,6 +46,17 @@ const lexiguardVentureRow = {
 function createMockSupabase({ stageWorkRow, ventureRow, rpcResult = { success: true } }) {
   const updates = { venture_stage_work: [], ventures: [] };
   const fromHandlers = {
+    // SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (HP-2): the enforcer now
+    // fails CLOSED on a MISSING venture_stages row, so healthy-config fixtures
+    // must model row-present-with-empty-gates (the intended allow path) instead
+    // of riding the old row-absent silent allow through the chainable fallback.
+    venture_stages: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+        }),
+      }),
+    }),
     venture_stage_work: () => ({
       select: () => ({
         eq: () => ({

--- a/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
+++ b/tests/unit/eva/lifecycle/exit-gate-enforcer.test.js
@@ -10,7 +10,10 @@
  *   - block when venture_resources.deployment_url is null
  *   - flag OFF skips enforcement (legacy behavior)
  *   - empty gates.exit array → allow
- *   - missing verifier for prose gate string → skip with WARN, allow
+ *   - unresolvable verifier on BINDING gates.exit → BLOCK + EXIT_GATE_ANOMALY
+ *     (SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 HP-1 — inverted from the
+ *     original skip-with-WARN-allow pin; observe lane keeps log-and-allow)
+ *   - missing venture_stages row → BLOCK + EXIT_GATE_ANOMALY (HP-2)
  *   - lifecycle_stage_config read failure → block with structured reason
  */
 
@@ -197,15 +200,102 @@ describe('exit-gate-enforcer', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('skips unknown gate strings (no verifier registered) with a WARN, still allows', async () => {
+    // SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (HP-1/FR-1) — INTENTIONAL
+    // POLARITY INVERSION of the original "skips unknown gate strings ... still
+    // allows" pin (VALIDATION 209181ef carry-forward a): a declared-but-
+    // unresolvable verifier on a BINDING gates.exit entry now fails CLOSED.
+    // Log-and-allow remains correct ONLY for gates.exit_observe (pinned below).
+    it('BLOCKS unknown gate strings on BINDING gates.exit (fail-closed) and writes an EXIT_GATE_ANOMALY', async () => {
       const { checkExitGates } = await importEnforcerWithFlag('on');
+      const insertedEvents = [];
       const supabase = buildSupabaseMock({
         stageConfig: { exit: ['Frobnicate the widget cache'] },
+        insertedEvents,
+      });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.gates_checked).toEqual(['Frobnicate the widget cache']);
+      expect(result.blocked_by[0]).toMatch(/Frobnicate the widget cache: no verifier registered for a BINDING gate \(fail-closed\)/);
+      const anomaly = insertedEvents.find((e) => e.event_type === 'EXIT_GATE_ANOMALY');
+      expect(anomaly).toBeTruthy();
+      expect(anomaly.payload.anomaly_kind).toBe('unresolvable_binding_verifier');
+      expect(anomaly.payload.gate_string).toBe('Frobnicate the widget cache');
+    });
+
+    // FR-1 regression fixture per SD success criterion: the S19 spend-guardrail
+    // gate shape — a real resolvable gate stays subject to its verifier while an
+    // unresolvable sibling blocks.
+    it('mixed binding gates: resolvable gate evaluated, unresolvable sibling blocks (S19 fixture shape)', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({
+        stageConfig: { exit: ['Application deployed', 'Totally unknown gate prose'] },
+        buildArtifactPresent: true,
+      });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by).toHaveLength(1); // only the unresolvable one
+      expect(result.blocked_by[0]).toMatch(/Totally unknown gate prose/);
+    });
+
+    // SD-LEO-INFRA-EXIT-GATE-FAIL-CLOSED-POLARITY-001 (HP-2/FR-2): row-absent
+    // (data:null, error:null from maybeSingle) is DISTINCT from row-present-
+    // empty-gates and must block loudly.
+    it('BLOCKS when the venture_stages row is missing entirely, with an EXIT_GATE_ANOMALY', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const insertedEvents = [];
+      const supabase = buildSupabaseMock({ insertedEvents });
+      supabase.from = vi.fn((table) => {
+        if (table === 'venture_stages') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === 'system_events') {
+          return { insert: vi.fn((row) => { insertedEvents.push(row); return Promise.resolve({ data: null, error: null }); }) };
+        }
+        return { select: vi.fn() };
+      });
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by[0]).toMatch(/venture_stages row missing for stage 19 \(fail-closed\)/);
+      const anomaly = insertedEvents.find((e) => e.event_type === 'EXIT_GATE_ANOMALY');
+      expect(anomaly).toBeTruthy();
+      expect(anomaly.payload.anomaly_kind).toBe('stage_config_row_missing');
+    });
+
+    // FR-3: a failing anomaly insert must never change the blocking verdict.
+    it('anomaly insert failure is fail-soft: verdict stays allowed=false, no throw', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({ stageConfig: { exit: ['Frobnicate the widget cache'] } });
+      const origFrom = supabase.from;
+      supabase.from = vi.fn((table) => {
+        if (table === 'system_events') {
+          return { insert: vi.fn(() => Promise.reject(new Error('insert exploded'))) };
+        }
+        return origFrom(table);
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
+      expect(result.allowed).toBe(false);
+      expect(result.blocked_by[0]).toMatch(/no verifier registered for a BINDING gate/);
+      warnSpy.mockRestore();
+    });
+
+    // FR-1 AC: unknown strings under gates.exit_observe keep log-and-allow.
+    it('unknown gate strings under gates.exit_observe still log-and-allow (observe lane untouched)', async () => {
+      const { checkExitGates } = await importEnforcerWithFlag('on');
+      const supabase = buildSupabaseMock({
+        stageConfig: { exit: [], exit_observe: ['Some unknown observe prose'] },
       });
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const result = await checkExitGates({ supabase, ventureId: VENTURE_ID, fromStage: 19 });
       expect(result.allowed).toBe(true);
-      expect(result.gates_checked).toEqual(['Frobnicate the widget cache']);
+      expect(result.would_block_by).toEqual([]);
+      expect(result.blocked_by).toEqual([]);
       expect(warnSpy).toHaveBeenCalled();
       warnSpy.mockRestore();
     });


### PR DESCRIPTION
## Summary
- **HP-1**: a declared-but-unresolvable verifier on a BINDING `gates.exit` entry now **blocks** (was warn-and-allow — a silent bypass through an uncheckable gate) and writes an `EXIT_GATE_ANOMALY` system_events row. Log-and-allow remains only for `gates.exit_observe`.
- **HP-2**: a **missing `venture_stages` row** (maybeSingle `data:null/error:null` — not a cfgError, previously null-chained to silent allow) now blocks loudly, explicitly distinguished from row-present-with-empty-gates (intended allow, unchanged).
- `logAnomalyEvent` mirrors the proven fail-soft observe-writer shape — a logging failure never changes the verdict. No DDL (new event_type value only).
- The original skip-unknown-strings pin is **inverted with a documented polarity-flip comment** (VALIDATION 209181ef carry-forward); 5 new pins incl. the S19 mixed-gates fixture, row-absent anomaly, fail-soft, and observe-lane preservation.
- The flip immediately caught a real instance of the defect class: the advance-reset caller fixture rode the row-absent silent allow and never mocked `venture_stages` — fixed to model healthy config explicitly.

## Operational note for the wiring SD
Live `venture_stages` has rows for stages 1–26 only; **stages 27–40 are absent**, so once the reachability SD wires `checkExitGates` onto the live advance path, advances FROM stages 27–40 will block loudly per HP-2 (by design). Seed those rows (or accept the block) as part of that SD — flagged in completion flags.

## Test plan
- Enforcer suite 37/37 (5 new/inverted pins; flag-polarity, cfgError-block, empty-gates exemplars untouched).
- Full `tests/unit/eva/` sweep: 6198 passed / 24 skipped / 0 failed.
- eslint + node --check clean. Hardening-ahead-of-wiring: the enforcer is not yet on the live daemon path (Golf-4 RCA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)