### PR TITLE
fix(SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001): Adam inbox surfaces-not-stamps — delivered_at background drains, universal ack-recovery, first-class tick lines

### DIFF
--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-10T04:32:39.640Z",
+ "generated_at": "2026-07-10T12:36:05.555Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
  "table_count": 784,
  "view_count": 180,
@@ -596,7 +596,7 @@
   "service_tasks": "{id,venture_id,service_id,task_type,status,priority,artifacts,confidence_score,input_params,claimed_at,completed_at,error_message,metadata,created_at,updated_at}",
   "service_telemetry": "{id,task_id,venture_id,service_id,pr_url,pr_status,outcomes,venture_agent_version,reported_at,outcome,agent_version,processing_time_ms,feedback,service_key,event_type,confidence_score,routing_decision,metadata,created_at}",
   "service_versions": "{id,service_id,version,artifact_schema,changelog,deprecated_at,created_at}",
-  "session_coordination": "{id,target_session,target_sd,message_type,subject,body,payload,sender_session,sender_type,created_at,expires_at,read_at,acknowledged_at,correlation_id}",
+  "session_coordination": "{id,target_session,target_sd,message_type,subject,body,payload,sender_session,sender_type,created_at,expires_at,read_at,acknowledged_at,correlation_id,delivered_at}",
   "session_lifecycle_events": "{id,event_type,session_id,machine_id,terminal_id,pid,reason,latency_ms,metadata,created_at}",
   "ship_review_findings": "{id,pr_number,review_tier,risk_score,finding_count,finding_categories,verdict,sd_key,branch,multi_agent,reviewed_at,created_at,synthesized_at}",
   "shipping_decisions": "{id,sd_id,handoff_type,decision_type,decision,confidence,confidence_score,reasoning,context_snapshot,executed_at,execution_result,execution_duration_ms,escalated_to_human,human_decision,human_decision_at,human_notes,model,tokens_used,cost_usd,created_at,updated_at}",

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -98,6 +98,15 @@ const DIRECTIVE_KINDS = Object.freeze([
   'chairman_directive',
 ]);
 
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: handler-owned / terminal kinds the Adam
+// lane surfaces must NEVER drain, list, or count in the acknowledged_at IS NULL recovery
+// tier — each either has a dedicated responder that owns the row (canary_request,
+// comms_check) or is a terminal acknowledgement nobody ever acks (ack, coordinator_ack),
+// which would pollute an unacked-tier forever. Canonical home here (kinds module) so
+// adam-advisory.cjs, read-adam-directives.cjs and adam-quiet-tick.mjs share one list
+// without a require cycle (adam-advisory already requires read-adam-directives).
+const ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack']);
+
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;
 
 /**
@@ -163,6 +172,7 @@ module.exports = {
   CLAUDE_SESSIONS_COLUMNS,
   PAYLOAD_KINDS,
   DIRECTIVE_KINDS,
+  ADAM_EXCLUDED_KINDS,
   FLEET_ACTIVE_WINDOW_MS,
   getServiceClient,
   getReadClient,

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -51,7 +51,7 @@ const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version
 const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
-const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const { REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies } = require('../lib/coordinator/reply-class.cjs');
 // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: reuse the canonical Adam-session resolver for the unattended
@@ -295,33 +295,96 @@ function isReplyRow(r) {
   return p.kind === 'coordinator_reply' || (p.reply_to != null && p.reply_to !== '');
 }
 
-async function drainReplies(supabase, sessionId) {
+async function drainReplies(supabase, sessionId, { background = false, windowMs = DEFAULT_DRAIN_WINDOW_MS } = {}) {
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): the recoverable filter is
+  // acknowledged_at IS NULL (never read_at IS NULL) — a reply a background/legacy pass
+  // stamped read_at on stays surfaced until genuinely actioned. Window-scoped as a
+  // backlog guard (default 7d); older unacked rows are counted loudly, never silent.
+  const cutoffIso = new Date(Date.now() - windowMs).toISOString();
   const { data: allRows, error } = await supabase
     .from('session_coordination')
-    .select('id, sender_session, subject, body, payload, created_at')
+    .select('id, sender_session, subject, body, payload, created_at, read_at')
     .eq('target_session', sessionId)
-    .is('read_at', null)
+    .is('acknowledged_at', null)
+    .gte('created_at', cutoffIso)
     .order('created_at', { ascending: true })
     .limit(100);
   if (error) { console.error('ERROR: replies query failed:', error.message); process.exit(1); }
   const rows = (allRows || []).filter(isReplyRow);
-  if (rows.length === 0) { console.log('(no unread directed replies)'); return; }
+  if (rows.length === 0) { console.log('(no unacked directed replies)'); return; }
 
-  console.log(`${rows.length} directed repl${rows.length === 1 ? 'y' : 'ies'}:`);
+  console.log(`${rows.length} unacked directed repl${rows.length === 1 ? 'y' : 'ies'} (ack via adam-advisory.cjs ack <id> once actioned):`);
   const ids = [];
   for (const r of rows) {
     const replyTo = (r.payload && r.payload.reply_to) || '?';
     const text = (r.payload && r.payload.body) || r.body || '(empty)';
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
-    console.log(`  • [${String(replyTo).slice(0, 8)}] (${ageMin}m) ${text}`);
+    console.log(`  • [${String(replyTo).slice(0, 8)}] id=${r.id} (${ageMin}m) ${text}`);
     ids.push(r.id);
   }
-  // Consume: stamp read_at only on rows still NULL (idempotent; mirrors the await consume).
-  await supabase
-    .from('session_coordination')
-    .update({ read_at: new Date().toISOString() })
-    .in('id', ids)
-    .is('read_at', null);
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-1): stamp routing by context.
+  // Background/cron context: delivered_at only — read_at is reserved for a surface whose
+  // content lands in an operator-visible turn. Interactive: read_at (this render IS the
+  // operator-visible surface). Neither path ever stamps acknowledged_at (action-time only).
+  await stampSurfaced(supabase, ids, { background });
+}
+
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: interactive drain backlog-guard window.
+const DEFAULT_DRAIN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-1) — the single stamp-routing seam for
+ * both drain lanes. background=true: stamp delivered_at (only where NULL; column added by
+ * database/migrations/20260710_session_coordination_delivered_at.sql) and leave read_at
+ * untouched. background=false (interactive): stamp read_at (only where NULL). Idempotent
+ * either way; acknowledged_at is NEVER written here (see the `ack` subcommand).
+ */
+async function stampSurfaced(supabase, ids, { background = false } = {}) {
+  if (!ids || ids.length === 0) return;
+  const now = new Date().toISOString();
+  if (background) {
+    await supabase
+      .from('session_coordination')
+      .update({ delivered_at: now })
+      .in('id', ids)
+      .is('delivered_at', null);
+  } else {
+    await supabase
+      .from('session_coordination')
+      .update({ read_at: now })
+      .in('id', ids)
+      .is('read_at', null);
+  }
+}
+
+/**
+ * SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4) — `ack <id...>`: the single
+ * sanctioned action-time stamp for the Adam lane (chairman directives keep
+ * scripts/ack-chairman-directive.cjs). Stamps acknowledged_at (only where NULL) and
+ * backfills read_at where NULL (an actioned row was necessarily seen). Idempotent.
+ */
+async function ackRows(supabase, ids) {
+  const now = new Date().toISOString();
+  let acked = 0;
+  for (const id of ids) {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: now })
+      .eq('id', id)
+      .is('acknowledged_at', null)
+      .select('id, read_at');
+    if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
+    if (data && data.length > 0) {
+      acked += 1;
+      if (data[0].read_at == null) {
+        await supabase.from('session_coordination').update({ read_at: now }).eq('id', id).is('read_at', null);
+      }
+      console.log(`  ✓ acked ${id}`);
+    } else {
+      console.log(`  • ${id} already acked (or not found) — no-op`);
+    }
+  }
+  console.log(`${acked}/${ids.length} row(s) newly acknowledged.`);
 }
 
 /**
@@ -399,7 +462,10 @@ function isAdamInboxRow(r) {
  * consume (each has a dedicated responder that owns the row; the Adam inbox marking it read first
  * would break that handler). Mirrors the "DELIBERATELY EXCLUDED" list in the ADAM_INBOX_KINDS doc.
  */
-const EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack']);
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: canonical home moved to
+// lib/fleet/worker-status.cjs (ADAM_EXCLUDED_KINDS) so read-adam-directives.cjs and
+// adam-quiet-tick.mjs share the list without a require cycle. Export name preserved.
+const EXCLUDED_KINDS = ADAM_EXCLUDED_KINDS;
 
 /**
  * SD-FDBK-INFRA-ADAM-INBOX-ADAM-001 — is this an ORPHANED Adam-directed row? A row targeting the
@@ -456,15 +522,36 @@ async function renderChairmanDirectives(supabase, role, { quiet = false } = {}) 
  * DELIVERED-but-unacked directive stays recoverable via scripts/read-adam-directives.cjs (the
  * acknowledged_at IS NULL tier) until Adam genuinely acts.
  */
-async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
+async function drainInbox(supabase, sessionId, { quiet = false, background = false, windowMs = DEFAULT_DRAIN_WINDOW_MS } = {}) {
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): recoverable filter is
+  // acknowledged_at IS NULL — a row any background/legacy pass read-stamped still surfaces
+  // until actioned (the read-stamped-not-processed class, chairman-caught 2026-07-10, is
+  // structurally unreachable). Window-scoped (default 7d) as a backlog guard; older
+  // unacked rows are COUNTED below, never silently invisible.
+  const cutoffIso = new Date(Date.now() - windowMs).toISOString();
   const { data: allRows, error } = await supabase
     .from('session_coordination')
-    .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at')
+    .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at, read_at')
     .eq('target_session', sessionId)
-    .is('read_at', null)
+    .is('acknowledged_at', null)
+    .gte('created_at', cutoffIso)
     .order('created_at', { ascending: true })
     .limit(100);
   if (error) { console.error('ERROR: inbox query failed:', error.message); process.exit(1); }
+
+  // Backlog-guard visibility: unacked rows OLDER than the window are reported by count so
+  // they cannot rot invisibly; recover them via `--window <Nd>` or the stampless `--sweep`.
+  try {
+    const { count: olderCount } = await supabase
+      .from('session_coordination')
+      .select('id', { count: 'exact', head: true })
+      .eq('target_session', sessionId)
+      .is('acknowledged_at', null)
+      .lt('created_at', cutoffIso);
+    if (olderCount > 0) {
+      console.warn(`⚠ ${olderCount} unacked directed row(s) OLDER than the ${Math.round(windowMs / 86_400_000)}d drain window — widen with --window <Nd> or inspect via --sweep.`);
+    }
+  } catch { /* count is advisory — never blocks the drain */ }
 
   // SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001: widen the drain to ALL directed Adam classes
   // (isAdamInboxRow ⊇ DIRECTIVE_KINDS) — responder-owned + untyped rows stay untouched.
@@ -501,9 +588,9 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
   // chairman-attached work. With --quiet (the recurring tick), stay SILENT on a fully-empty lane
   // (mirrors the belt-countdown/offer-help silence-by-default). Manual `inbox` keeps the
   // confirmation line. Orphaned-row WARNINGs above are NEVER suppressed (real unread deliveries).
-  if (rows.length === 0) { if (!quiet) console.log('(no unread directed inbox rows — replies or directed classes)'); return; }
+  if (rows.length === 0) { if (!quiet) console.log('(no unacked directed inbox rows — replies or directed classes)'); return; }
 
-  console.log(`${rows.length} inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + all directed classes):`);
+  console.log(`${rows.length} unacked inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + all directed classes; ack via adam-advisory.cjs ack <id> once actioned):`);
   const ids = [];
   for (const r of rows) {
     const lane = isReplyRow(r) ? 'reply' : (isDirectiveRow(r) ? 'directive' : 'adam-directed');
@@ -514,17 +601,13 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
     // instead of silently misreading the row — surfaced, not consumed-differently (still drained).
     const skew = detectVersionSkew(r.payload);
     if (skew) console.warn(`  ⚠ PROTOCOL VERSION SKEW: sender v${skew.senderVersion}, receiver v${skew.receiverVersion} (id=${r.id})`);
-    console.log(`  • [${lane}/${kind}] (${ageMin}m) ${text}`);
+    console.log(`  • [${lane}/${kind}] id=${r.id} (${ageMin}m) ${text}`);
     ids.push(r.id);
   }
-  // Consume: stamp read_at = DELIVERED on surfaced rows still NULL (idempotent). Deliberately do NOT
-  // set acknowledged_at / payload.actioned_at — directives stay in the read-but-unacked tier
-  // (read-adam-directives.cjs) until genuinely actioned (two-stage ACK).
-  await supabase
-    .from('session_coordination')
-    .update({ read_at: new Date().toISOString() })
-    .in('id', ids)
-    .is('read_at', null);
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-1): stamp routing by context —
+  // background/cron passes stamp delivered_at only; interactive render stamps read_at.
+  // acknowledged_at / payload.actioned_at are NEVER set here (action-time only, `ack`).
+  await stampSurfaced(supabase, ids, { background });
 }
 
 const DEFAULT_SWEEP_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -636,8 +719,8 @@ async function main() {
   warnIfCheckoutStale('adam-advisory.cjs');
   const argv = process.argv.slice(2);
   const mode = argv[0];
-  if (mode !== 'send' && mode !== 'request' && mode !== 'replies' && mode !== 'inbox' && mode !== 'status') {
-    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>] [--to solomon|<session_id>]  |  request "<question>" [--timeout <ms>] [--to solomon|<session_id>]  |  replies  |  inbox [--sweep [--window 24h]]  |  status [--working "<body>" [--eta <ms>]]');
+  if (mode !== 'send' && mode !== 'request' && mode !== 'replies' && mode !== 'inbox' && mode !== 'status' && mode !== 'ack') {
+    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>] [--to solomon|<session_id>]  |  request "<question>" [--timeout <ms>] [--to solomon|<session_id>]  |  replies [--background]  |  inbox [--background] [--window <Nh|Nd>] [--sweep [--window 24h]]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
     process.exit(2);
   }
 
@@ -648,9 +731,22 @@ async function main() {
   try { supabase = createSupabaseServiceClient(); }
   catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
 
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: --background marks a cron/monitor
+  // context whose stdout no reasoning turn sees — such passes stamp delivered_at only.
+  const isBackground = argv.includes('--background');
+
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): `ack <id...>` — the action-time
+  // acknowledged_at stamp. Ids are positional args (flags filtered out).
+  if (mode === 'ack') {
+    const ids = argv.slice(1).filter((a) => !a.startsWith('--'));
+    if (ids.length === 0) { console.error('Usage: node scripts/adam-advisory.cjs ack <row-id...>'); process.exit(2); }
+    await ackRows(supabase, ids);
+    return;
+  }
+
   // FR-4 — durable reply reader (reply lane only; kept for back-compat).
   if (mode === 'replies') {
-    await drainReplies(supabase, sessionId);
+    await drainReplies(supabase, sessionId, { background: isBackground });
     return;
   }
 
@@ -663,7 +759,12 @@ async function main() {
     // FR-1: surface broadcast chairman directives FIRST-CLASS (above normal advisories) with Adam's
     // per-directive ack status, BEFORE the normal target_session-scoped drain.
     await renderChairmanDirectives(supabase, 'adam', { quiet: argv.includes('--quiet') });
-    await drainInbox(supabase, adamId, { quiet: argv.includes('--quiet') });
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: --window (when given without --sweep)
+    // widens/narrows the interactive drain's backlog-guard window; default 7d.
+    const drainWindowMs = argv.includes('--window') && !argv.includes('--sweep')
+      ? parseSweepWindowMs(argv)
+      : DEFAULT_DRAIN_WINDOW_MS;
+    await drainInbox(supabase, adamId, { quiet: argv.includes('--quiet'), background: isBackground, windowMs: drainWindowMs });
     // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: PING-ON-SILENCE — check MY OWN sent
     // reply-needed advisories for ones left unanswered past their window. Never suppressed by
     // --quiet (a real overdue reply is a genuine delivery, not routine tick noise).
@@ -898,7 +999,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -363,16 +363,20 @@ async function stampSurfaced(supabase, ids, { background = false } = {}) {
  * scripts/ack-chairman-directive.cjs). Stamps acknowledged_at (only where NULL) and
  * backfills read_at where NULL (an actioned row was necessarily seen). Idempotent.
  */
-async function ackRows(supabase, ids) {
+async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
   const now = new Date().toISOString();
   let acked = 0;
   for (const id of ids) {
-    const { data, error } = await supabase
+    // Ownership guard (adversarial review of PR #5802): only rows targeting THIS Adam
+    // session may be acked — a mistyped foreign UUID must not drop another session's row
+    // out of ITS acknowledged_at-IS-NULL recovery tier.
+    let q = supabase
       .from('session_coordination')
       .update({ acknowledged_at: now })
       .eq('id', id)
-      .is('acknowledged_at', null)
-      .select('id, read_at');
+      .is('acknowledged_at', null);
+    if (expectedTarget) q = q.eq('target_session', expectedTarget);
+    const { data, error } = await q.select('id, read_at');
     if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
     if (data && data.length > 0) {
       acked += 1;
@@ -381,7 +385,7 @@ async function ackRows(supabase, ids) {
       }
       console.log(`  ✓ acked ${id}`);
     } else {
-      console.log(`  • ${id} already acked (or not found) — no-op`);
+      console.log(`  • ${id} already acked, not found, or not targeted at this Adam session — no-op`);
     }
   }
   console.log(`${acked}/${ids.length} row(s) newly acknowledged.`);
@@ -538,6 +542,13 @@ async function drainInbox(supabase, sessionId, { quiet = false, background = fal
     .order('created_at', { ascending: true })
     .limit(100);
   if (error) { console.error('ERROR: inbox query failed:', error.message); process.exit(1); }
+
+  // Within-window overflow visibility (adversarial review of PR #5802): oldest-first +
+  // limit(100) + never-auto-ack means >100 unacked rows would re-surface the same oldest
+  // 100 every pass — say so loudly instead of silently starving newer rows.
+  if ((allRows || []).length === 100) {
+    console.warn('⚠ inbox fetch cap hit (100, oldest-first) — newer unacked rows exist beyond this page; ack surfaced rows or use --sweep to see the full window.');
+  }
 
   // Backlog-guard visibility: unacked rows OLDER than the window are reported by count so
   // they cannot rot invisibly; recover them via `--window <Nd>` or the stampless `--sweep`.
@@ -740,7 +751,9 @@ async function main() {
   if (mode === 'ack') {
     const ids = argv.slice(1).filter((a) => !a.startsWith('--'));
     if (ids.length === 0) { console.error('Usage: node scripts/adam-advisory.cjs ack <row-id...>'); process.exit(2); }
-    await ackRows(supabase, ids);
+    // Ownership guard: acks are scoped to rows targeting the canonical Adam session.
+    const adamTarget = (await resolveAdamSessionId(supabase)) || sessionId;
+    await ackRows(supabase, ids, { expectedTarget: adamTarget });
     return;
   }
 

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -55,7 +55,10 @@ const DRY_RUN = process.argv.includes('--dry-run');
  * delta-gated rather than dropped.
  */
 export const COMPOSED_CORES = [
-  { key: 'inbox-monitor', script: 'adam-advisory.cjs', args: ['scripts/adam-advisory.cjs', 'inbox', '--quiet'], quiescentSkip: false, safety: true },
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-1): --background — this cron core's
+  // stdout is truncated to one line (scriptCore below), so it must NEVER consume (read_at);
+  // it stamps delivered_at only. Operator-visible surfacing is FR-3's surfaceInboxItems.
+  { key: 'inbox-monitor', script: 'adam-advisory.cjs', args: ['scripts/adam-advisory.cjs', 'inbox', '--quiet', '--background'], quiescentSkip: false, safety: true },
 ];
 export const DELTA_GATED_LOOPS = ['belt-countdown', 'offer-help'];
 
@@ -111,6 +114,59 @@ export async function readCriticalPathParents(sb) {
     return (data || []).map((row) => ({ ...row, inFlightNextStep: row.status === 'in_progress' }));
   } catch {
     return [];
+  }
+}
+
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-3) — surface the Adam session's
+// unacked directed rows as FIRST-CLASS lines in the TICK'S OWN stdout (the act-on-flagged-
+// lines contract, same as QUIET_TICK_STALL_ALERT). Required because scriptCore truncates
+// the child drain's stdout to its last line — content printed by the child is structurally
+// invisible to the operator turn, so the tick itself must surface. Print-once dedup via
+// payload.tick_surfaced_at (QF-20260702-414 orphan_seen_at pattern — a visibility marker,
+// NEVER read_at/acknowledged_at). Fail-soft: any error returns items:[] without aborting.
+const TICK_SURFACE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function surfaceInboxItems(sb) {
+  try {
+    const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
+    const { DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
+    const adamId = await resolveAdamSessionId(sb);
+    if (!adamId) return { items: [], directives: 0 };
+
+    const cutoffIso = new Date(Date.now() - TICK_SURFACE_WINDOW_MS).toISOString();
+    const { data: rows, error } = await sb
+      .from('session_coordination')
+      .select('id, subject, body, payload, sender_type, created_at')
+      .eq('target_session', adamId)
+      .is('acknowledged_at', null)
+      .gte('created_at', cutoffIso)
+      .order('created_at', { ascending: true })
+      .limit(50);
+    if (error) return { items: [], directives: 0, error: error.message };
+
+    const eligible = (rows || []).filter((r) => {
+      const k = r.payload && r.payload.kind;
+      if (k != null && ADAM_EXCLUDED_KINDS.includes(k)) return false;
+      return !(r.payload && r.payload.tick_surfaced_at); // print-once dedup
+    });
+    if (eligible.length === 0) return { items: [], directives: 0 };
+
+    const items = eligible.map((r) => {
+      const k = (r.payload && r.payload.kind) || '(untyped)';
+      const isDirective = (r.payload && (DIRECTIVE_KINDS.includes(r.payload.kind) || r.payload.reply_needed || r.payload.reply_to)) || false;
+      const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+      const subject = String(r.subject || (r.payload && r.payload.body) || r.body || '(empty)').replace(/\s+/g, ' ').slice(0, 140);
+      return { id: r.id, kind: k, isDirective, ageMin, subject };
+    });
+
+    // Stamp the dedup marker (visibility only — the row stays unread/unacked-recoverable).
+    const seenAt = new Date().toISOString();
+    for (const r of eligible) {
+      await sb.from('session_coordination').update({ payload: { ...(r.payload || {}), tick_surfaced_at: seenAt } }).eq('id', r.id);
+    }
+    return { items, directives: items.filter((i) => i.isDirective).length };
+  } catch (e) {
+    return { items: [], directives: 0, error: e && e.message };
   }
 }
 
@@ -183,6 +239,10 @@ async function main() {
     outboundSilence = { probed: [], escalated: [], laneHealth: { unactionedCount: 0, maxAgeMs: 0 }, error: e && e.message };
   }
 
+  // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-3): surface unacked directed rows
+  // as first-class tick output (the child drain above ran --background and consumed nothing).
+  const inboxSurface = await surfaceInboxItems(sb);
+
   // FR-4: belt-countdown + offer-help collapse to a salient-delta check — Adam only
   // reaches the coordinator on a real belt/venture delta, never a "still idle" status.
   const salient = await readSalientState(sb);
@@ -199,6 +259,8 @@ async function main() {
     failedCount: tick.failedCount,
     boardReconcile,
     stallAlerted: stall.alerted,
+    inboxSurfaced: inboxSurface.items.length,
+    inboxDirectives: inboxSurface.directives,
     outboundSilence,
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
@@ -222,6 +284,12 @@ async function main() {
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);
+    }
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-3): first-class inbox surfacing —
+    // directive/reply-needed rows carry the distinct hard-interrupt token.
+    for (const i of inboxSurface.items) {
+      const token = i.isDirective ? 'QUIET_TICK_INBOX_DIRECTIVE' : 'QUIET_TICK_INBOX_ITEM';
+      console.log(`${token}=adam id=${i.id} kind=${i.kind} age=${i.ageMin}m subject="${i.subject}"`);
     }
     for (const p of outboundSilence.probed) {
       console.log(`QUIET_TICK_OUTBOUND_PROBE=adam target=${p.target} row=${p.rowId}`);

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -144,27 +144,37 @@ export async function surfaceInboxItems(sb) {
       .limit(50);
     if (error) return { items: [], directives: 0, error: error.message };
 
+    const isDirectiveRow = (r) =>
+      (r.payload && (DIRECTIVE_KINDS.includes(r.payload.kind) || r.payload.reply_needed || r.payload.reply_to)) || false;
+
+    // Print-once dedup applies to the ITEM class only. DIRECTIVE-class rows are HARD
+    // interrupts: they re-print EVERY tick until acknowledged_at converges them —
+    // deduping a directive would let a single missed turn hide it forever (the exact
+    // failure class this SD closes; adversarial review of PR #5802).
     const eligible = (rows || []).filter((r) => {
       const k = r.payload && r.payload.kind;
       if (k != null && ADAM_EXCLUDED_KINDS.includes(k)) return false;
-      return !(r.payload && r.payload.tick_surfaced_at); // print-once dedup
+      if (isDirectiveRow(r)) return true;
+      return !(r.payload && r.payload.tick_surfaced_at);
     });
-    if (eligible.length === 0) return { items: [], directives: 0 };
+    const capHit = (rows || []).length === 50;
+    if (eligible.length === 0) return { items: [], directives: 0, capHit };
 
     const items = eligible.map((r) => {
       const k = (r.payload && r.payload.kind) || '(untyped)';
-      const isDirective = (r.payload && (DIRECTIVE_KINDS.includes(r.payload.kind) || r.payload.reply_needed || r.payload.reply_to)) || false;
+      const isDirective = isDirectiveRow(r);
       const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
       const subject = String(r.subject || (r.payload && r.payload.body) || r.body || '(empty)').replace(/\s+/g, ' ').slice(0, 140);
       return { id: r.id, kind: k, isDirective, ageMin, subject };
     });
 
-    // Stamp the dedup marker (visibility only — the row stays unread/unacked-recoverable).
+    // Stamp the dedup marker on ITEM-class rows only (visibility marker — the row stays
+    // unread/unacked-recoverable; directives are deliberately never marked).
     const seenAt = new Date().toISOString();
-    for (const r of eligible) {
+    for (const r of eligible.filter((x) => !isDirectiveRow(x) && !(x.payload && x.payload.tick_surfaced_at))) {
       await sb.from('session_coordination').update({ payload: { ...(r.payload || {}), tick_surfaced_at: seenAt } }).eq('id', r.id);
     }
-    return { items, directives: items.filter((i) => i.isDirective).length };
+    return { items, directives: items.filter((i) => i.isDirective).length, capHit };
   } catch (e) {
     return { items: [], directives: 0, error: e && e.message };
   }
@@ -275,6 +285,7 @@ async function main() {
       `fail=${tick.failedCount} ` +
       `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
       `stalls=${stall.alerted.length} ` +
+      `inbox=${inboxSurface.items.length}(dir:${inboxSurface.directives}) ` +
       `probes=${outboundSilence.probed.length} esc=${outboundSilence.escalated.length} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
@@ -290,6 +301,9 @@ async function main() {
     for (const i of inboxSurface.items) {
       const token = i.isDirective ? 'QUIET_TICK_INBOX_DIRECTIVE' : 'QUIET_TICK_INBOX_ITEM';
       console.log(`${token}=adam id=${i.id} kind=${i.kind} age=${i.ageMin}m subject="${i.subject}"`);
+    }
+    if (inboxSurface.capHit) {
+      console.log('QUIET_TICK_INBOX_CAP=adam fetched=50 oldest-first — within-window overflow; ack surfaced rows to reach newer ones');
     }
     for (const p of outboundSilence.probed) {
       console.log(`QUIET_TICK_OUTBOUND_PROBE=adam target=${p.target} row=${p.rowId}`);

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -55,7 +55,11 @@ export const ADAM_LOOPS = [
     label: 'Adam quiet-tick (folds inbox-monitor + belt-countdown + offer-help)',
     script: 'adam-quiet-tick.mjs',
     cron: '7,22,37,52 * * * *',
-    prompt: 'Run `node scripts/adam-quiet-tick.mjs`. It prints ONE QUIET_TICK summary line and self-paces. If the output contains NO QUIET_TICK_PING / QUIET_TICK_STALL_ALERT / QUIET_TICK_OUTBOUND_PROBE / QUIET_TICK_ERROR lines, this turn is a NO-OP: arm ScheduleWakeup(nextWakeSeconds from the output) and emit nothing else. Otherwise act on the flagged lines, then arm the wakeup.',
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: QUIET_TICK_INBOX_DIRECTIVE /
+    // QUIET_TICK_INBOX_ITEM are actionable tokens — omitting them from this allowlist
+    // would make an isolated directive arrival read as a NO-OP tick (the read-stamped-
+    // not-processed class rebuilt at the tick layer; caught by adversarial review of PR #5802).
+    prompt: 'Run `node scripts/adam-quiet-tick.mjs`. It prints ONE QUIET_TICK summary line and self-paces. If the output contains NO QUIET_TICK_PING / QUIET_TICK_STALL_ALERT / QUIET_TICK_OUTBOUND_PROBE / QUIET_TICK_INBOX_DIRECTIVE / QUIET_TICK_INBOX_ITEM / QUIET_TICK_ERROR lines, this turn is a NO-OP: arm ScheduleWakeup(nextWakeSeconds from the output) and emit nothing else. Otherwise act on the flagged lines (QUIET_TICK_INBOX_DIRECTIVE lines are HARD interrupts — process the directed row, then `node scripts/adam-advisory.cjs ack <id>`; QUIET_TICK_INBOX_ITEM lines are directed inbox rows to action or deliberately leave pending), then arm the wakeup.',
   },
   {
     key: 'governance-scan',

--- a/scripts/read-adam-directives.cjs
+++ b/scripts/read-adam-directives.cjs
@@ -18,11 +18,21 @@
 require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 
-// SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: include 'chairman'. The full-lane inbox drain stamps
-// read_at=DELIVERED on directive-kind rows of ANY sender; this acked-NULL safety net must cover
-// chairman too, or a chairman directive is DELIVERED-then-dropped (harness-bug 43c2dee2: 5 chairman
-// messages auto-acked unseen — the exact blindspot this SD lineage closes). Sender-agnostic by intent.
+// SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: include 'chairman'. (Kept exported for back-compat.)
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-2): the query NO LONGER filters by this
+// list — the recoverable tier is UNIVERSAL across sender lanes (Solomon adam_advisory,
+// coordinator_reply, untyped rows included; the 2026-07-10 incident rows 9370edf1/06843d14/
+// 7bd9f12b were exactly the lanes the old sender allowlist hid). Only the handler-owned /
+// terminal ADAM_EXCLUDED_KINDS are excluded (never acked by design — they would pollute an
+// unacked tier forever).
 const DIRECTIVE_SENDERS = ['coordinator', 'orchestrator', 'chairman'];
+const { ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
+
+/** FR-2 — tier membership: any directed row except handler-owned/terminal kinds. PURE. */
+function isRecoverableTierRow(r) {
+  const k = r && r.payload && r.payload.kind;
+  return !(k != null && ADAM_EXCLUDED_KINDS.includes(k));
+}
 
 // Resolve the Adam session id: prefer CLAUDE_SESSION_ID when it is the Adam session, else fall
 // back to the most-recent active session tagged metadata.role='adam'. Returns null if none.
@@ -50,36 +60,41 @@ async function main() {
   const adamId = await resolveAdamSessionId(supabase);
   if (!adamId) { console.log('ADAM DIRECTIVE PEEK: no active Adam session found — nothing to surface.'); return; }
 
-  const { data: rows, error } = await supabase
+  // FR-2 (SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001): UNIVERSAL tier — no sender_type
+  // filter. Fetch wide (excluded kinds are filtered in JS since payload.kind is jsonb),
+  // render the oldest 20, and report the TRUE total so accumulation is always visible.
+  const { data: allRows, error } = await supabase
     .from('session_coordination')
-    .select('id, message_type, subject, body, payload, sender_type, sender_session, created_at, read_at, acknowledged_at')
+    .select('id, message_type, subject, body, payload, sender_type, sender_session, created_at, read_at, delivered_at, acknowledged_at')
     .eq('target_session', adamId)
-    .in('sender_type', DIRECTIVE_SENDERS)
     .is('acknowledged_at', null)
     .order('created_at', { ascending: true })
-    .limit(20);
+    .limit(200);
   if (error) { console.error('ERROR: directive query failed:', error.message); process.exit(1); }
+  const tier = (allRows || []).filter(isRecoverableTierRow);
+  const rows = tier.slice(0, 20);
 
-  console.log('ADAM DIRECTIVE PEEK — read-but-unacknowledged (read-only — stamps nothing)');
+  console.log('ADAM RECOVERY PEEK — unacknowledged directed rows, ALL sender lanes (read-only — stamps nothing)');
   console.log('─'.repeat(60));
-  if (!rows || !rows.length) { console.log('  (no unacknowledged coordinator/orchestrator directives to Adam)'); return; }
+  if (!rows.length) { console.log('  (no unacknowledged directed rows to Adam)'); return; }
 
-  console.log(`  ${rows.length} unacknowledged directive(s):`);
+  console.log(`  ${tier.length} unacknowledged row(s) total${tier.length > rows.length ? ` — showing oldest ${rows.length}` : ''}${(allRows || []).length === 200 ? ' (fetch cap hit — true total may be higher)' : ''}:`);
   for (const r of rows) {
-    const stage = r.read_at ? 'READ-unacked' : 'unread';
+    const kind = (r.payload && r.payload.kind) || '(untyped)';
+    const stage = r.read_at ? 'READ-unacked' : (r.delivered_at ? 'DELIVERED-unacked' : 'unread');
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
     const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
     const body = (r.body || (r.payload && r.payload.body) || r.subject || '').replace(/\n/g, ' ');
     console.log(`  • ${r.id}`);
-    console.log(`      ${r.sender_type} | ${r.message_type} | ${stage} | ${ageStr} ago`);
+    console.log(`      ${r.sender_type || '?'} | ${kind} | ${r.message_type} | ${stage} | ${ageStr} ago`);
     console.log(`      ${body}`);
   }
   console.log('');
-  console.log('  These rows stay visible until acknowledged_at is stamped (genuine Adam action).');
+  console.log('  These rows stay visible until acknowledged_at is stamped (adam-advisory.cjs ack <id> at genuine action time).');
 }
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
 }
 
-module.exports = { resolveAdamSessionId, DIRECTIVE_SENDERS };
+module.exports = { resolveAdamSessionId, DIRECTIVE_SENDERS, isRecoverableTierRow };

--- a/tests/unit/adam-inbox-quiet-suppression.test.js
+++ b/tests/unit/adam-inbox-quiet-suppression.test.js
@@ -12,10 +12,13 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { drainInbox } = require('../../scripts/adam-advisory.cjs');
 
-// Minimal chainable supabase mock: from().select().eq().is().order().limit() -> {data, error}
+// Minimal chainable supabase mock: from().select().eq().is().gte().order().limit() -> {data, error}
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: gte (window scope) + terminal lt (older-rows
+// head-count) added; the empty-lane wording changed 'no unread' -> 'no unacked'.
 function makeSupabase(rows) {
   const q = {
-    select: () => q, eq: () => q, is: () => q, order: () => q,
+    select: () => q, eq: () => q, is: () => q, gte: () => q, order: () => q,
+    lt: () => Promise.resolve({ count: 0, error: null }),
     limit: () => Promise.resolve({ data: rows, error: null }),
   };
   return { from: () => q };
@@ -31,19 +34,19 @@ describe('Adam inbox --quiet no-op suppression (SD-REFILL-00YJS6VB)', () => {
 
   it('quiet: empty lane prints NOTHING (silent no-op tick)', async () => {
     await drainInbox(makeSupabase([]), 'adam-sid', { quiet: true });
-    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
-    expect(noUnread).toBe(false);
+    const emptyLine = logSpy.mock.calls.flat().some((a) => String(a).includes('no unacked'));
+    expect(emptyLine).toBe(false);
   });
 
   it('non-quiet (manual): empty lane prints the confirmation line', async () => {
     await drainInbox(makeSupabase([]), 'adam-sid', { quiet: false });
-    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
-    expect(noUnread).toBe(true);
+    const emptyLine = logSpy.mock.calls.flat().some((a) => String(a).includes('no unacked'));
+    expect(emptyLine).toBe(true);
   });
 
   it('default (no opts) behaves like non-quiet — backward compatible', async () => {
     await drainInbox(makeSupabase([]), 'adam-sid');
-    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
-    expect(noUnread).toBe(true);
+    const emptyLine = logSpy.mock.calls.flat().some((a) => String(a).includes('no unacked'));
+    expect(emptyLine).toBe(true);
   });
 });

--- a/tests/unit/adam-inbox-surface-not-stamp.test.js
+++ b/tests/unit/adam-inbox-surface-not-stamp.test.js
@@ -1,0 +1,215 @@
+/**
+ * SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 — the read-stamped-not-processed permanent fix.
+ *
+ * FR-1: background drains stamp delivered_at only (read_at reserved for operator-visible turns)
+ * FR-2: acknowledged_at IS NULL recovery tier is universal across sender lanes
+ * FR-3: quiet tick emits unacked directed rows as first-class QUIET_TICK_INBOX_ITEM= /
+ *        QUIET_TICK_INBOX_DIRECTIVE= lines with payload.tick_surfaced_at print-once dedup
+ * FR-4: interactive drain filters acknowledged_at IS NULL; ack subcommand is the only
+ *        action-time acknowledged_at stamp
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { drainInbox, drainReplies, stampSurfaced, ackRows, EXCLUDED_KINDS, DEFAULT_DRAIN_WINDOW_MS } = require('../../scripts/adam-advisory.cjs');
+const { isRecoverableTierRow } = require('../../scripts/read-adam-directives.cjs');
+const { ADAM_EXCLUDED_KINDS, DIRECTIVE_KINDS } = require('../../lib/fleet/worker-status.cjs');
+const { COMPOSED_CORES, surfaceInboxItems } = await import('../../scripts/adam-quiet-tick.mjs');
+
+const ADAM = 'adam-session-uuid';
+
+/**
+ * Recording supabase mock: query-filter capture + FIFO responses per table, plus a log of
+ * every update payload/filters so stamp semantics are assertable.
+ */
+function makeMock(selectRows = []) {
+  const updates = [];
+  const selects = [];
+  function chain(table) {
+    const state = { table, op: 'select', filters: [], updatePayload: null, head: false };
+    const c = {
+      select: (cols, opts) => { if (opts && opts.head) { state.head = true; } return c; },
+      update: (payload) => { state.op = 'update'; state.updatePayload = payload; return c; },
+      eq: (col, v) => { state.filters.push(['eq', col, v]); return c; },
+      in: (col, v) => { state.filters.push(['in', col, v]); return c; },
+      is: (col, v) => { state.filters.push(['is', col, v]); return c; },
+      gte: (col, v) => { state.filters.push(['gte', col, v]); return c; },
+      lt: (col, v) => { state.filters.push(['lt', col, v]); return c; },
+      order: () => c,
+      limit: () => c,
+      single: () => finish(),
+      maybeSingle: () => finish(),
+      then: (res, rej) => finish().then(res, rej),
+    };
+    async function finish() {
+      if (state.op === 'update') { updates.push(state); return { data: [], error: null }; }
+      selects.push(state);
+      if (state.head) return { count: 0, error: null };
+      return { data: selectRows, error: null };
+    }
+    return c;
+  }
+  return { supabase: { from: chain }, updates, selects };
+}
+
+function row(overrides = {}) {
+  return {
+    id: 'row-' + Math.abs(JSON.stringify(overrides).split('').reduce((a, ch) => a + ch.charCodeAt(0), 0)),
+    sender_session: 's1', sender_type: 'agent', message_type: 'INFO',
+    subject: 'subj', body: 'body', payload: { kind: 'adam_advisory' },
+    created_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+    read_at: null,
+    ...overrides,
+  };
+}
+
+describe('FR-1/FR-4: stamp routing (stampSurfaced)', () => {
+  it('background=true stamps delivered_at only-where-NULL and never touches read_at', async () => {
+    const { supabase, updates } = makeMock();
+    await stampSurfaced(supabase, ['a', 'b'], { background: true });
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].updatePayload)).toEqual(['delivered_at']);
+    expect(updates[0].filters).toContainEqual(['is', 'delivered_at', null]);
+    expect(JSON.stringify(updates[0])).not.toContain('read_at');
+  });
+
+  it('interactive (default) stamps read_at only-where-NULL and never delivered_at/acknowledged_at', async () => {
+    const { supabase, updates } = makeMock();
+    await stampSurfaced(supabase, ['a']);
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].updatePayload)).toEqual(['read_at']);
+    expect(updates[0].filters).toContainEqual(['is', 'read_at', null]);
+    expect(JSON.stringify(updates[0])).not.toContain('acknowledged_at');
+  });
+
+  it('empty id list is a no-op', async () => {
+    const { supabase, updates } = makeMock();
+    await stampSurfaced(supabase, [], { background: true });
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe('FR-4: interactive drainInbox filters acknowledged_at IS NULL (recoverable until actioned)', () => {
+  it('queries ack-IS-NULL (not read_at) with a created_at window — read-stamped rows resurface', async () => {
+    const r = row({ read_at: new Date().toISOString() }); // the incident class: read=Y ack=N
+    const { supabase, selects, updates } = makeMock([r]);
+    await drainInbox(supabase, ADAM, { quiet: true });
+    const mainSelect = selects.find(s => !s.head);
+    expect(mainSelect.filters).toContainEqual(['is', 'acknowledged_at', null]);
+    expect(mainSelect.filters.some(f => f[0] === 'is' && f[1] === 'read_at')).toBe(false);
+    expect(mainSelect.filters.some(f => f[0] === 'gte' && f[1] === 'created_at')).toBe(true);
+    // surfaced interactively -> read_at stamp attempted (idempotent only-where-NULL)
+    const stamp = updates.find(u => u.updatePayload && 'read_at' in u.updatePayload);
+    expect(stamp).toBeTruthy();
+  });
+
+  it('background drainInbox stamps delivered_at instead of read_at', async () => {
+    const { supabase, updates } = makeMock([row()]);
+    await drainInbox(supabase, ADAM, { quiet: true, background: true });
+    const stamp = updates.find(u => u.updatePayload && 'delivered_at' in u.updatePayload);
+    expect(stamp).toBeTruthy();
+    expect(updates.some(u => u.updatePayload && 'read_at' in u.updatePayload)).toBe(false);
+  });
+
+  it('drainReplies uses the same ack-IS-NULL filter and stamp routing', async () => {
+    const r = row({ payload: { kind: 'coordinator_reply', reply_to: 'corr-1', body: 'answer' } });
+    const { supabase, selects, updates } = makeMock([r]);
+    await drainReplies(supabase, ADAM, { background: true });
+    expect(selects[0].filters).toContainEqual(['is', 'acknowledged_at', null]);
+    expect(updates.find(u => 'delivered_at' in (u.updatePayload || {}))).toBeTruthy();
+    expect(updates.some(u => 'read_at' in (u.updatePayload || {}))).toBe(false);
+  });
+});
+
+describe('FR-4: ack subcommand is the action-time stamp', () => {
+  it('stamps acknowledged_at only-where-NULL (idempotent)', async () => {
+    const updates = [];
+    const supabase = { from: () => ({
+      update: (payload) => ({
+        eq: (c, v) => ({ is: (c2, v2) => ({ select: async () => {
+          updates.push({ payload, guards: [[c, v], [c2, v2]] });
+          return { data: [{ id: v, read_at: '2026-07-10T00:00:00Z' }], error: null };
+        } }) }),
+        // read_at backfill path (guarded .is with no select)
+        in: () => ({ is: async () => ({ data: [], error: null }) }),
+      }),
+    }) };
+    await ackRows(supabase, ['id-1']);
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].payload)).toEqual(['acknowledged_at']);
+    expect(updates[0].guards).toContainEqual(['acknowledged_at', null]);
+  });
+});
+
+describe('FR-2: universal recovery tier membership', () => {
+  it('admits every sender lane: adam_advisory, coordinator_reply, untyped', () => {
+    expect(isRecoverableTierRow(row({ payload: { kind: 'adam_advisory' } }))).toBe(true);
+    expect(isRecoverableTierRow(row({ payload: { kind: 'coordinator_reply' } }))).toBe(true);
+    expect(isRecoverableTierRow(row({ payload: {} }))).toBe(true);
+    expect(isRecoverableTierRow(row({ payload: null }))).toBe(true);
+  });
+
+  it('excludes exactly the handler-owned/terminal kinds (single canonical list)', () => {
+    for (const k of ADAM_EXCLUDED_KINDS) {
+      expect(isRecoverableTierRow(row({ payload: { kind: k } }))).toBe(false);
+    }
+    expect(EXCLUDED_KINDS).toBe(ADAM_EXCLUDED_KINDS); // one list, no drift
+  });
+});
+
+describe('FR-1/FR-3: quiet tick', () => {
+  it('COMPOSED_CORES inbox-monitor runs the drain with --background (cron may never consume)', () => {
+    const core = COMPOSED_CORES.find(c => c.key === 'inbox-monitor');
+    expect(core.args).toContain('--background');
+    expect(core.args).toContain('--quiet');
+  });
+
+  it('surfaceInboxItems emits items once and stamps only payload.tick_surfaced_at', async () => {
+    const fresh = row({ payload: { kind: 'adam_advisory' } });
+    const directive = row({ payload: { kind: DIRECTIVE_KINDS[0] } });
+    const alreadySurfaced = row({ payload: { kind: 'adam_advisory', tick_surfaced_at: '2026-07-10T00:00:00Z' } });
+    const excluded = row({ payload: { kind: 'canary_request' } });
+    const updates = [];
+    const sb = { from: (table) => {
+      const state = { table, filters: [], payload: null, op: 'select' };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; state.payload = p; return c; },
+        eq: (col, v) => { state.filters.push([col, v]); return c; },
+        is: () => c, gte: () => c, order: () => c, limit: () => c,
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') { updates.push(state); return Promise.resolve({ data: [], error: null }).then(res); }
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          return Promise.resolve({ data: [fresh, directive, alreadySurfaced, excluded], error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items.map(i => i.id).sort()).toEqual([directive.id, fresh.id].sort());
+    expect(out.directives).toBe(1);
+    expect(out.items.find(i => i.id === directive.id).isDirective).toBe(true);
+    // dedup marker stamped on exactly the two surfaced rows; only payload written
+    expect(updates).toHaveLength(2);
+    for (const u of updates) {
+      expect(Object.keys(u.payload)).toEqual(['payload']);
+      expect(u.payload.payload.tick_surfaced_at).toBeTruthy();
+      expect(JSON.stringify(u.payload)).not.toContain('read_at');
+      expect(JSON.stringify(u.payload)).not.toContain('acknowledged_at');
+    }
+  });
+
+  it('surfaceInboxItems is fail-soft on query error', async () => {
+    const sb = { from: () => { throw new Error('db down'); } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items).toEqual([]);
+  });
+});
+
+describe('constants', () => {
+  it('interactive drain window defaults to 7 days', () => {
+    expect(DEFAULT_DRAIN_WINDOW_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/tests/unit/adam-inbox-surface-not-stamp.test.js
+++ b/tests/unit/adam-inbox-surface-not-stamp.test.js
@@ -123,22 +123,39 @@ describe('FR-4: interactive drainInbox filters acknowledged_at IS NULL (recovera
 });
 
 describe('FR-4: ack subcommand is the action-time stamp', () => {
-  it('stamps acknowledged_at only-where-NULL (idempotent)', async () => {
+  function ackMock() {
     const updates = [];
-    const supabase = { from: () => ({
-      update: (payload) => ({
-        eq: (c, v) => ({ is: (c2, v2) => ({ select: async () => {
-          updates.push({ payload, guards: [[c, v], [c2, v2]] });
-          return { data: [{ id: v, read_at: '2026-07-10T00:00:00Z' }], error: null };
-        } }) }),
-        // read_at backfill path (guarded .is with no select)
-        in: () => ({ is: async () => ({ data: [], error: null }) }),
-      }),
-    }) };
+    const supabase = { from: () => {
+      const state = { payload: null, guards: [] };
+      const c = {
+        update: (payload) => { state.payload = payload; return c; },
+        eq: (col, v) => { state.guards.push([col, v]); return c; },
+        is: (col, v) => { state.guards.push([col, v]); return c; },
+        in: () => c,
+        select: async () => {
+          updates.push(state);
+          return { data: [{ id: 'id-1', read_at: '2026-07-10T00:00:00Z' }], error: null };
+        },
+        then: (res) => Promise.resolve({ data: [], error: null }).then(res),
+      };
+      return c;
+    } };
+    return { supabase, updates };
+  }
+
+  it('stamps acknowledged_at only-where-NULL (idempotent)', async () => {
+    const { supabase, updates } = ackMock();
     await ackRows(supabase, ['id-1']);
     expect(updates).toHaveLength(1);
     expect(Object.keys(updates[0].payload)).toEqual(['acknowledged_at']);
     expect(updates[0].guards).toContainEqual(['acknowledged_at', null]);
+  });
+
+  it('ownership guard: with expectedTarget the update is scoped to target_session', async () => {
+    const { supabase, updates } = ackMock();
+    await ackRows(supabase, ['id-1'], { expectedTarget: ADAM });
+    expect(updates).toHaveLength(1);
+    expect(updates[0].guards).toContainEqual(['target_session', ADAM]);
   });
 });
 
@@ -165,9 +182,11 @@ describe('FR-1/FR-3: quiet tick', () => {
     expect(core.args).toContain('--quiet');
   });
 
-  it('surfaceInboxItems emits items once and stamps only payload.tick_surfaced_at', async () => {
+  it('surfaceInboxItems: ITEMs dedup via tick_surfaced_at; DIRECTIVEs re-print every tick until acked', async () => {
     const fresh = row({ payload: { kind: 'adam_advisory' } });
     const directive = row({ payload: { kind: DIRECTIVE_KINDS[0] } });
+    // an already-tick-surfaced DIRECTIVE must STILL surface (hard interrupt — dedup never applies)
+    const surfacedDirective = row({ payload: { kind: DIRECTIVE_KINDS[0], tick_surfaced_at: '2026-07-10T00:00:00Z', reply_needed: true } });
     const alreadySurfaced = row({ payload: { kind: 'adam_advisory', tick_surfaced_at: '2026-07-10T00:00:00Z' } });
     const excluded = row({ payload: { kind: 'canary_request' } });
     const updates = [];
@@ -182,23 +201,33 @@ describe('FR-1/FR-3: quiet tick', () => {
         then: (res) => {
           if (state.op === 'update') { updates.push(state); return Promise.resolve({ data: [], error: null }).then(res); }
           if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
-          return Promise.resolve({ data: [fresh, directive, alreadySurfaced, excluded], error: null }).then(res);
+          return Promise.resolve({ data: [fresh, directive, surfacedDirective, alreadySurfaced, excluded], error: null }).then(res);
         },
       };
       return c;
     } };
     const out = await surfaceInboxItems(sb);
-    expect(out.items.map(i => i.id).sort()).toEqual([directive.id, fresh.id].sort());
-    expect(out.directives).toBe(1);
+    expect(out.items.map(i => i.id).sort()).toEqual([directive.id, fresh.id, surfacedDirective.id].sort());
+    expect(out.directives).toBe(2);
     expect(out.items.find(i => i.id === directive.id).isDirective).toBe(true);
-    // dedup marker stamped on exactly the two surfaced rows; only payload written
-    expect(updates).toHaveLength(2);
+    // dedup marker stamped ONLY on the fresh ITEM-class row (directives never marked —
+    // they must re-print every tick until acknowledged); only payload written
+    expect(updates).toHaveLength(1);
     for (const u of updates) {
       expect(Object.keys(u.payload)).toEqual(['payload']);
       expect(u.payload.payload.tick_surfaced_at).toBeTruthy();
+      expect(u.payload.payload.kind).toBe('adam_advisory');
       expect(JSON.stringify(u.payload)).not.toContain('read_at');
       expect(JSON.stringify(u.payload)).not.toContain('acknowledged_at');
     }
+  });
+
+  it('the cron prompt allowlist includes both INBOX tokens (no-op gate cannot swallow a directive)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(new URL('../../scripts/adam-startup-check.mjs', import.meta.url), 'utf8');
+    const quietTickPrompt = src.slice(src.indexOf("key: 'quiet-tick'"), src.indexOf("key: 'governance-scan'"));
+    expect(quietTickPrompt).toContain('QUIET_TICK_INBOX_DIRECTIVE');
+    expect(quietTickPrompt).toContain('QUIET_TICK_INBOX_ITEM');
   });
 
   it('surfaceInboxItems is fail-soft on query error', async () => {

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -401,26 +401,29 @@ describe('full-lane: isDirectiveRow / isReplyRow lane classification', () => {
 });
 
 describe('full-lane: drainInbox surfaces BOTH lanes + two-stage ACK', () => {
-  // AND-only server query (.eq target_session + .is read_at null), then a consume update; the mock
-  // returns the seeded rows on the 1st .from() and captures the read_at update on the 2nd.
+  // AND-only server query (.eq target_session + .is acknowledged_at null), then a surface-stamp
+  // update. SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: drainInbox added a window scope (gte)
+  // and an advisory older-rows head-count (terminal .lt), so the mock routes by verb instead of
+  // by call order.
   function mockInboxSb(rows, captured) {
-    let callIdx = 0;
     return {
       from() {
-        callIdx += 1;
-        if (callIdx === 1) {
-          const q = {
-            select() { return q; }, eq() { return q; }, is() { return q; }, order() { return q; },
-            limit() { return Promise.resolve({ data: rows, error: null }); },
-          };
-          return q;
-        }
-        const u = {
-          update(patch) { captured.update = patch; return u; },
-          in(_k, ids) { captured.ids = ids; return u; },
-          is() { return Promise.resolve({}); },
+        const q = {
+          select() { return q; },
+          update(patch) { captured.update = patch; return q; },
+          eq() { return q; },
+          in(_k, ids) { captured.ids = ids; return q; },
+          is() { return q; },
+          gte() { return q; },
+          lt() { return Promise.resolve({ count: 0, error: null }); },
+          order() { return q; },
+          limit() { return Promise.resolve({ data: rows, error: null }); },
+          then(res, rej) {
+            // awaited chain terminal: the surface-stamp update resolves here
+            return Promise.resolve({ data: [], error: null }).then(res, rej);
+          },
         };
-        return u;
+        return q;
       },
     };
   }

--- a/tests/unit/coordination/adam-advisory-full-lane.test.js
+++ b/tests/unit/coordination/adam-advisory-full-lane.test.js
@@ -27,17 +27,19 @@ describe('isReplyRow (FR-4 reply-lane predicate)', () => {
 // Stub the supabase query/update chain. The SELECT uses AND-only filters (NO .or()), and the
 // chain captures the eq/is filters so we can PROVE lane scoping is applied, plus the consumed ids.
 function stub(rows) {
-  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false };
+  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false, updatePayloads: [] };
   const selectChain = {
     select() { return selectChain; },
     eq(col, val) { captured.eq[col] = val; return selectChain; },
     or() { captured.usedOr = true; return selectChain; },
     is(col) { captured.isNull.push(col); return selectChain; },
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: window scoping added to the lane query.
+    gte() { return selectChain; },
     order() { return selectChain; },
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };
   const updateChain = {
-    update() { return updateChain; },
+    update(payload) { captured.updatePayloads.push(payload); return updateChain; },
     in(_col, ids) { captured.updatedIds = ids; return updateChain; },
     is() { return Promise.resolve({ error: null }); },
   };
@@ -56,7 +58,7 @@ function stub(rows) {
 }
 
 describe('drainReplies (FR-4 full-lane, AND-only query + JS filter)', () => {
-  it('scopes to target_session + read_at IS NULL, surfaces only reply rows, consumes them once', async () => {
+  it('scopes to target_session + acknowledged_at IS NULL, surfaces only reply rows, stamps read_at interactively', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const rows = [
       { id: 'r1', payload: { kind: 'coordinator_reply', reply_to: 'corr-1', body: 'classic reply' }, created_at: new Date().toISOString() },
@@ -66,18 +68,24 @@ describe('drainReplies (FR-4 full-lane, AND-only query + JS filter)', () => {
     const { supabase, captured } = stub(rows);
     await drainReplies(supabase, 'adam-session');
     expect(captured.eq.target_session).toBe('adam-session'); // lane scoped by the AND-only query
-    expect(captured.isNull).toContain('read_at');
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): recoverable filter is
+    // acknowledged_at IS NULL — read_at is only a stamp, never a hiding filter.
+    expect(captured.isNull).toContain('acknowledged_at');
+    expect(captured.isNull).not.toContain('read_at');
     expect(captured.usedOr).toBe(false);                      // no brittle PostgREST .or()
-    expect(captured.updatedIds).toEqual(['r1', 'r2']);        // only the two reply rows consumed; r3 left alone
+    expect(captured.updatedIds).toEqual(['r1', 'r2']);        // only the two reply rows stamped; r3 left alone
+    // Interactive surfacing stamps read_at; acknowledged_at is NEVER written by the drain.
+    expect(captured.updatePayloads.some(p => 'read_at' in p)).toBe(true);
+    expect(captured.updatePayloads.some(p => 'acknowledged_at' in p)).toBe(false);
     logSpy.mockRestore();
   });
 
-  it('reports cleanly when there are no unread directed replies', async () => {
+  it('reports cleanly when there are no unacked directed replies', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { supabase, captured } = stub([{ id: 'x', payload: { kind: 'work_assignment' }, created_at: new Date().toISOString() }]);
     await drainReplies(supabase, 'adam-session');
-    expect(captured.updatedIds).toBeNull(); // nothing reply-shaped -> nothing consumed
-    expect(logSpy).toHaveBeenCalledWith('(no unread directed replies)');
+    expect(captured.updatedIds).toBeNull(); // nothing reply-shaped -> nothing stamped
+    expect(logSpy).toHaveBeenCalledWith('(no unacked directed replies)');
     logSpy.mockRestore();
   });
 });

--- a/tests/unit/coordination/adam-inbox-all-classes.test.js
+++ b/tests/unit/coordination/adam-inbox-all-classes.test.js
@@ -46,18 +46,23 @@ describe('isAdamInboxRow predicate', () => {
 });
 
 // AND-only fetch + JS-filter stub (mirrors adam-advisory-full-lane.test.js).
+// SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: drainInbox now window-scopes (gte), runs an
+// advisory older-rows head-count (terminal .lt), and records the UPDATE payload so the stamp
+// matrix (read_at interactive / delivered_at background / acknowledged_at never) is pinned.
 function stub(rows) {
-  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false };
+  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false, updatePayloads: [] };
   const selectChain = {
     select() { return selectChain; },
     eq(col, val) { captured.eq[col] = val; return selectChain; },
     or() { captured.usedOr = true; return selectChain; },
     is(col) { captured.isNull.push(col); return selectChain; },
+    gte() { return selectChain; },
+    lt() { return Promise.resolve({ count: 0, error: null }); },
     order() { return selectChain; },
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };
   const updateChain = {
-    update() { return updateChain; },
+    update(payload) { captured.updatePayloads.push(payload); return updateChain; },
     in(_col, ids) { captured.updatedIds = ids; return updateChain; },
     is() { return Promise.resolve({ error: null }); },
     eq() { return Promise.resolve({ error: null }); }, // QF-20260702-414: orphan_seen_at per-row stamp
@@ -88,11 +93,19 @@ describe('drainInbox (all-classes drain)', () => {
     const { supabase, captured } = stub(rows);
     await drainInbox(supabase, 'adam-session');
     expect(captured.eq.target_session).toBe('adam-session');
-    expect(captured.isNull).toContain('read_at');
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): the recoverable filter is
+    // acknowledged_at IS NULL — read_at is a stamp, never a server filter, so a
+    // read-stamped-but-unactioned row can never be hidden.
+    expect(captured.isNull).toContain('acknowledged_at');
+    expect(captured.isNull).not.toContain('read_at');
     expect(captured.usedOr).toBe(false); // AND-only — no PostgREST .or() trap
     expect(captured.updatedIds).toEqual(['reply', 'directive', 'heads_up', 'handoff', 'advisory', 'adam_fb', 'assist', 'reconcile']);
     // none of the excluded/untyped ids consumed
     for (const bad of ['canary', 'comms', 'ack', 'untyped']) expect(captured.updatedIds).not.toContain(bad);
+    // Stamp matrix: interactive surfacing stamps read_at; acknowledged_at is NEVER written by a drain.
+    const surfaceStamp = captured.updatePayloads.find(p => 'read_at' in p);
+    expect(surfaceStamp).toBeTruthy();
+    expect(captured.updatePayloads.some(p => 'acknowledged_at' in p)).toBe(false);
     logSpy.mockRestore();
   });
 

--- a/tests/unit/coordination/adam-inbox-orphan-warn.test.js
+++ b/tests/unit/coordination/adam-inbox-orphan-warn.test.js
@@ -15,6 +15,10 @@ function stub(rows) {
     eq(col, val) { captured.eq[col] = val; return selectChain; },
     or() { captured.usedOr = true; return selectChain; },
     is(col) { captured.isNull.push(col); return selectChain; },
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: window scope (gte) + advisory
+    // older-rows head-count (terminal .lt) added to drainInbox.
+    gte() { return selectChain; },
+    lt() { return Promise.resolve({ count: 0, error: null }); },
     order() { return selectChain; },
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };

--- a/tests/unit/coordination/protocol-version-skew-surfacing.test.js
+++ b/tests/unit/coordination/protocol-version-skew-surfacing.test.js
@@ -17,6 +17,10 @@ function stub(rows) {
     select() { return selectChain; },
     eq() { return selectChain; },
     is() { return selectChain; },
+    // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: drainInbox now window-scopes (gte)
+    // and runs an advisory older-rows head-count (terminal .lt).
+    gte() { return selectChain; },
+    lt() { return Promise.resolve({ count: 0, error: null }); },
     order() { return selectChain; },
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };


### PR DESCRIPTION
## Summary
- **FR-1**: `--background` flag on `adam-advisory.cjs` (wired into the quiet-tick cron core) routes both drain lanes to stamp `delivered_at` only — `read_at` is reserved for operator-visible surfacing; the cron can never consume content whose stdout is truncated to one line
- **FR-2**: `read-adam-directives.cjs` recovery tier is universal — no sender allowlist; Solomon `adam_advisory` / `coordinator_reply` / untyped rows stay ack-recoverable; handler-owned kinds excluded via the new canonical `ADAM_EXCLUDED_KINDS` in `lib/fleet/worker-status.cjs`
- **FR-3**: `adam-quiet-tick.mjs` emits each unacked directed row as first-class `QUIET_TICK_INBOX_ITEM=` / `QUIET_TICK_INBOX_DIRECTIVE=` lines with `payload.tick_surfaced_at` print-once dedup (QF-20260702-414 pattern)
- **FR-4**: interactive drain filters `acknowledged_at IS NULL` (7d window, `--window` override, loud older-rows count); new `ack <id...>` subcommand is the single action-time stamp; `--sweep` unchanged

Closes the chairman-caught 2026-07-10 live incident class (rows 9370edf1/06843d14/7bd9f12b: read=Y/ack=N invisible 15–75 min).

## Test plan
- New `tests/unit/adam-inbox-surface-not-stamp.test.js` (13 tests): stamp matrix, tier membership, tick emission/dedup, ack idempotency
- 5 existing pinned suites migrated equal-or-stronger (ack-IS-NULL filter + stamp-payload assertions added)
- Full pinned sweep: **60 files / 638 tests green**; `delivered_at` column verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)