### PR TITLE
feat(SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B): durable mint-path-segmented would_deny evidence

### DIFF
--- a/lib/claim/gates/dispatch-authorization.cjs
+++ b/lib/claim/gates/dispatch-authorization.cjs
@@ -135,10 +135,41 @@ function formatWouldDenyLine(sdKey, verdict, lane) {
   return `DISPATCH_AUTH_WOULD_DENY sd=${sdKey} lane=${lane} reason=${verdict.reason} (observe mode — claim proceeds; SD-ARCH-HOTSPOT-SD-START-001 FR-7)`;
 }
 
+const WOULD_DENY_EVENT_TYPE = 'DISPATCH_AUTH_WOULD_DENY';
+
+/**
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-1/FR-2: durable, mint-path-segmented
+ * evidence alongside formatWouldDenyLine's console.log — the observe window's would_deny
+ * signal was log-only before this. Reuses system_events (event_type/sd_id/payload columns
+ * already generic; sd_id is `text`, so the sd_key string is written directly, no UUID lookup).
+ * Fail-soft by design (TR-2): a write failure never blocks or alters the claim outcome that
+ * observe mode already guarantees never blocks.
+ * @param {object} supabase - service-role client
+ * @param {string} sdKey
+ * @param {{reason?: string}} verdict - the would_deny verdict from evaluateDispatchAuthorization
+ * @param {string} lane - which caller/CLI attempted the claim (independent of mint path)
+ * @param {object} [sd] - the SD row already in hand at the call site, if available
+ * @returns {Promise<void>}
+ */
+async function recordWouldDenyEvidence(supabase, sdKey, verdict, lane, sd) {
+  try {
+    const mintPath = (sd && sd.metadata && sd.metadata.sourced_by) || 'unknown';
+    await supabase.from('system_events').insert({
+      event_type: WOULD_DENY_EVENT_TYPE,
+      sd_id: sdKey,
+      payload: { reason: verdict.reason, lane, mint_path: mintPath },
+    });
+  } catch {
+    // fail-soft: evidence recording never affects the claim path (TR-2)
+  }
+}
+
 module.exports = {
   resolveDispatchAuthMode,
   evaluateDispatchAuthorization,
   formatWouldDenyLine,
+  recordWouldDenyEvidence,
+  WOULD_DENY_EVENT_TYPE,
   DISPATCH_AUTH_AUTHORITY_ALLOWLIST,
   BASE_FLAG,
   ENFORCE_FLAG,

--- a/lib/eva/convergence-remediation-writers.js
+++ b/lib/eva/convergence-remediation-writers.js
@@ -69,7 +69,7 @@ export function createSdWriter() {
       type: 'bugfix',
       priority: 'high',
       rationale: `Filed by the post-build adherence-scorer convergence loop for a below-floor dimension (${dimension}) that requires more than a quick-fix scope.`,
-      metadata: { source: 'convergence_gate_remediation', dimension },
+      metadata: { source: 'convergence_gate_remediation', dimension, sourced_by: 'convergence-remediation' },
     });
     return sd.sd_key || sdKey;
   };

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -447,6 +447,12 @@ function buildProvenance(ventureId) {
  * @returns {Promise<{ created: boolean, error: Object|null }>}
  */
 async function insertSDIdempotent(supabase, row) {
+  // SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-4: stamp the mint-path
+  // provenance signal here, in the one shared insert helper, so every call site
+  // in this file is covered uniformly rather than patched piecemeal.
+  if (row.metadata && row.metadata.sourced_by === undefined) {
+    row.metadata.sourced_by = 'lifecycle-sd-bridge';
+  }
   const { error } = await supabase
     .from('strategic_directives_v2')
     .insert(row);
@@ -1402,6 +1408,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       metadata: {
         ...provenance,
         created_via: 'lifecycle-sd-bridge-expand',
+        sourced_by: 'lifecycle-sd-bridge',
         parent_venture_id: parentVentureId,
         parent_venture_name: parentVentureName,
         expansion_type: expansionType,

--- a/scripts/dispatch-auth-would-deny-report.mjs
+++ b/scripts/dispatch-auth-would-deny-report.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Per-mint-path would_deny evidence report.
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-5.
+ *
+ * Reads the durable evidence written by recordWouldDenyEvidence()
+ * (lib/claim/gates/dispatch-authorization.cjs, reusing system_events) and
+ * groups it by mint path (payload.mint_path — the SD's own creation
+ * provenance, distinct from claim lane) and by claim lane. This is the
+ * concrete deliverable a future, separately-scoped SD would consume as its
+ * empirical input for deriving an auto-authorize allowlist — deriving or
+ * shipping that allowlist is explicitly OUT OF SCOPE here.
+ *
+ * Usage:
+ *   node scripts/dispatch-auth-would-deny-report.mjs
+ */
+
+import 'dotenv/config';
+import { createSupabaseServiceClient } from './lib/supabase-connection.js';
+import { WOULD_DENY_EVENT_TYPE } from '../lib/claim/gates/dispatch-authorization.cjs';
+
+/**
+ * @param {object} supabase
+ * @returns {Promise<{total: number, byMintPath: Record<string, number>, byLane: Record<string, number>}>}
+ */
+export async function buildWouldDenyProfile(supabase) {
+  const { data, error } = await supabase
+    .from('system_events')
+    .select('payload')
+    .eq('event_type', WOULD_DENY_EVENT_TYPE);
+  if (error) throw new Error(`would_deny evidence read failed: ${error.message}`);
+
+  const rows = data || [];
+  const byMintPath = {};
+  const byLane = {};
+  for (const row of rows) {
+    const payload = row.payload || {};
+    const mintPath = payload.mint_path || 'unknown';
+    const lane = payload.lane || 'unknown';
+    byMintPath[mintPath] = (byMintPath[mintPath] || 0) + 1;
+    byLane[lane] = (byLane[lane] || 0) + 1;
+  }
+  return { total: rows.length, byMintPath, byLane };
+}
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+  const profile = await buildWouldDenyProfile(supabase);
+
+  console.log('\nDISPATCH-AUTH WOULD-DENY EVIDENCE PROFILE');
+  console.log('='.repeat(60));
+  console.log(`Total evidence rows: ${profile.total}`);
+
+  console.log('\nBy mint path (SD creation provenance):');
+  if (Object.keys(profile.byMintPath).length === 0) {
+    console.log('  (none yet)');
+  } else {
+    for (const [mintPath, count] of Object.entries(profile.byMintPath).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${mintPath.padEnd(30)} ${count}`);
+    }
+  }
+
+  console.log('\nBy claim lane (which CLI attempted the claim):');
+  if (Object.keys(profile.byLane).length === 0) {
+    console.log('  (none yet)');
+  } else {
+    for (const [lane, count] of Object.entries(profile.byLane).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${lane.padEnd(30)} ${count}`);
+    }
+  }
+  console.log('='.repeat(60));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -917,6 +917,7 @@ async function main() {
     const authVerdict = await dispatchAuthGate.evaluateDispatchAuthorization(sd, supabase, { mode: authMode });
     if (authVerdict.would_deny) {
       console.log(`${colors.yellow}${dispatchAuthGate.formatWouldDenyLine(effectiveId, authVerdict, 'sd_start_direct_claim')}${colors.reset}`);
+      await dispatchAuthGate.recordWouldDenyEvidence(supabase, effectiveId, authVerdict, 'sd_start_direct_claim', sd);
     }
     if (!authVerdict.authorized) {
       console.log(`\n${colors.red}${colors.bold}🚫 ${effectiveId} is not dispatch-authorized (born-un-authorized polarity, enforce mode)${colors.reset}`);
@@ -1148,6 +1149,7 @@ async function main() {
           const fbVerdict = await dispatchAuthGate.evaluateDispatchAuthorization({ sd_key: nextSD.sdKey }, supabase, { mode: fbAuthMode });
           if (fbVerdict.would_deny) {
             console.log(`${colors.yellow}${dispatchAuthGate.formatWouldDenyLine(nextSD.sdKey, fbVerdict, 'sd_start_fallback_claim')}${colors.reset}`);
+            await dispatchAuthGate.recordWouldDenyEvidence(supabase, nextSD.sdKey, fbVerdict, 'sd_start_fallback_claim', null);
           }
           if (!fbVerdict.authorized) {
             skippedSDs.push({ sdKey: nextSD.sdKey, reason: `dispatch_auth: ${fbVerdict.reason}` });

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -856,7 +856,10 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   // enforce mode would block. Observe NEVER blocks; enforce refuses (dormant until the
   // backfill-verified cutover flips the enforce flag).
   const authVerdict = await dispatchAuth.evaluateDispatchAuthorization(d, sb, { mode: await getDispatchAuthMode() });
-  if (authVerdict.would_deny) console.log(dispatchAuth.formatWouldDenyLine(d.sd_key, authVerdict, 'checkin_self_claim'));
+  if (authVerdict.would_deny) {
+    console.log(dispatchAuth.formatWouldDenyLine(d.sd_key, authVerdict, 'checkin_self_claim'));
+    await dispatchAuth.recordWouldDenyEvidence(sb, d.sd_key, authVerdict, 'checkin_self_claim', d);
+  }
   if (!authVerdict.authorized) return null; // enforce mode: born-un-authorized SD skipped
   const claimed = await tryClaim(sb, d.sd_key, sessionId);
   if (claimed.ok) {

--- a/tests/unit/claim/gates/dispatch-authorization.test.js
+++ b/tests/unit/claim/gates/dispatch-authorization.test.js
@@ -16,6 +16,8 @@ const {
   resolveDispatchAuthMode,
   evaluateDispatchAuthorization,
   formatWouldDenyLine,
+  recordWouldDenyEvidence,
+  WOULD_DENY_EVENT_TYPE,
   DISPATCH_AUTH_AUTHORITY_ALLOWLIST,
 } = require('../../../../lib/claim/gates/dispatch-authorization.cjs');
 
@@ -92,6 +94,39 @@ describe('evaluateDispatchAuthorization — TS-7/TS-8/TS-9', () => {
   });
 });
 
+describe('recordWouldDenyEvidence — SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-1/FR-2', () => {
+  it('writes a system_events row with sd_id, event_type, and a payload segmented by lane + mint_path', async () => {
+    const inserted = [];
+    const supabase = { from: (table) => ({ insert: async (row) => { inserted.push({ table, row }); return { error: null }; } }) };
+    const sd = { sd_key: 'SD-X-001', metadata: { sourced_by: 'auto-refill' } };
+    await recordWouldDenyEvidence(supabase, 'SD-X-001', { reason: 'dispatch_auth_pending' }, 'checkin_self_claim', sd);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].table).toBe('system_events');
+    expect(inserted[0].row).toMatchObject({
+      event_type: WOULD_DENY_EVENT_TYPE,
+      sd_id: 'SD-X-001',
+      payload: { reason: 'dispatch_auth_pending', lane: 'checkin_self_claim', mint_path: 'auto-refill' },
+    });
+  });
+
+  it('falls back to mint_path="unknown" when the sd/metadata is unavailable (the sd-start fallback-claim lane)', async () => {
+    const inserted = [];
+    const supabase = { from: () => ({ insert: async (row) => { inserted.push(row); return { error: null }; } }) };
+    await recordWouldDenyEvidence(supabase, 'SD-Y-001', { reason: 'dispatch_auth_pending' }, 'sd_start_fallback_claim', null);
+    expect(inserted[0].payload.mint_path).toBe('unknown');
+  });
+
+  it('is fail-soft: a Supabase insert failure never throws (TR-2 — evidence recording must not affect the claim path)', async () => {
+    const supabase = { from: () => ({ insert: async () => { throw new Error('connection reset'); } }) };
+    await expect(recordWouldDenyEvidence(supabase, 'SD-Z-001', { reason: 'x' }, 'checkin_self_claim', null)).resolves.toBeUndefined();
+  });
+
+  it('is fail-soft on a returned (non-thrown) Supabase error too', async () => {
+    const supabase = { from: () => ({ insert: async () => ({ error: { message: 'boom' } }) }) };
+    await expect(recordWouldDenyEvidence(supabase, 'SD-Z-002', { reason: 'x' }, 'checkin_self_claim', null)).resolves.toBeUndefined();
+  });
+});
+
 describe('WIRING PINS (D8 placement + lane exemptions)', () => {
   const checkin = readFileSync(resolve(repoRoot, 'scripts/worker-checkin.cjs'), 'utf8');
   const sdStart = readFileSync(resolve(repoRoot, 'scripts/sd-start.js'), 'utf8');
@@ -143,6 +178,17 @@ describe('WIRING PINS (D8 placement + lane exemptions)', () => {
     // And exactly two in sd-start (direct claim + fallback lane).
     const sdStartHooks = (sdStart.match(/evaluateDispatchAuthorization\(/g) || []).length;
     expect(sdStartHooks).toBe(2);
+  });
+
+  it('SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B: recordWouldDenyEvidence is wired at all 3 would_deny call sites', () => {
+    expect(checkin).toMatch(/recordWouldDenyEvidence\(sb, d\.sd_key, authVerdict, 'checkin_self_claim', d\)/);
+    expect(sdStart).toMatch(/recordWouldDenyEvidence\(supabase, effectiveId, authVerdict, 'sd_start_direct_claim', sd\)/);
+    expect(sdStart).toMatch(/recordWouldDenyEvidence\(supabase, nextSD\.sdKey, fbVerdict, 'sd_start_fallback_claim', null\)/);
+    // Every recordWouldDenyEvidence call must be gated behind the same `would_deny` check as its
+    // sibling formatWouldDenyLine call (never fires on an authorized/off-mode verdict).
+    const recordCount = (checkin.match(/recordWouldDenyEvidence\(/g) || []).length
+      + (sdStart.match(/recordWouldDenyEvidence\(/g) || []).length;
+    expect(recordCount).toBe(3);
   });
 });
 

--- a/tests/unit/dispatch-auth-would-deny-report.test.js
+++ b/tests/unit/dispatch-auth-would-deny-report.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-5 — per-mint-path
+ * would_deny evidence report.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWouldDenyProfile } from '../../scripts/dispatch-auth-would-deny-report.mjs';
+import { WOULD_DENY_EVENT_TYPE } from '../../lib/claim/gates/dispatch-authorization.cjs';
+
+function fakeSupabase(rows) {
+  return {
+    from(table) {
+      return {
+        select() { return this; },
+        eq(col, val) {
+          if (col === 'event_type' && val !== WOULD_DENY_EVENT_TYPE) return Promise.resolve({ data: [], error: null });
+          return Promise.resolve({ data: rows, error: null });
+        },
+      };
+    },
+  };
+}
+
+describe('buildWouldDenyProfile', () => {
+  it('groups evidence rows by mint_path and by lane, independently', async () => {
+    const supabase = fakeSupabase([
+      { payload: { reason: 'x', lane: 'checkin_self_claim', mint_path: 'auto-refill' } },
+      { payload: { reason: 'x', lane: 'checkin_self_claim', mint_path: 'convergence-remediation' } },
+      { payload: { reason: 'x', lane: 'sd_start_direct_claim', mint_path: 'auto-refill' } },
+      { payload: { reason: 'x', lane: 'sd_start_fallback_claim', mint_path: 'unknown' } },
+    ]);
+    const profile = await buildWouldDenyProfile(supabase);
+    expect(profile.total).toBe(4);
+    expect(profile.byMintPath).toEqual({ 'auto-refill': 2, 'convergence-remediation': 1, unknown: 1 });
+    expect(profile.byLane).toEqual({ checkin_self_claim: 2, sd_start_direct_claim: 1, sd_start_fallback_claim: 1 });
+  });
+
+  it('handles the zero-evidence (fresh observe window) case without throwing', async () => {
+    const profile = await buildWouldDenyProfile(fakeSupabase([]));
+    expect(profile.total).toBe(0);
+    expect(profile.byMintPath).toEqual({});
+    expect(profile.byLane).toEqual({});
+  });
+
+  it('falls back to "unknown" for a row missing mint_path or lane in its payload', async () => {
+    const supabase = fakeSupabase([{ payload: { reason: 'x' } }]);
+    const profile = await buildWouldDenyProfile(supabase);
+    expect(profile.byMintPath).toEqual({ unknown: 1 });
+    expect(profile.byLane).toEqual({ unknown: 1 });
+  });
+
+  it('surfaces a read error rather than silently returning an empty profile', async () => {
+    const supabase = { from: () => ({ select() { return this; }, eq: () => Promise.resolve({ data: null, error: { message: 'connection reset' } }) }) };
+    await expect(buildWouldDenyProfile(supabase)).rejects.toThrow(/would_deny evidence read failed/);
+  });
+});

--- a/tests/unit/eva/convergence-remediation-writers.test.js
+++ b/tests/unit/eva/convergence-remediation-writers.test.js
@@ -83,4 +83,16 @@ describe('createSdWriter', () => {
     expect(callArg.type).toBe('bugfix');
     expect(callArg.metadata).toMatchObject({ source: 'convergence_gate_remediation', dimension: 'persona-surface-coverage' });
   });
+
+  it('SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-3: stamps metadata.sourced_by so the SD is attributable to this mint path', async () => {
+    resolveVenturePrefix.mockResolvedValue(null);
+    generateSDKey.mockResolvedValue('SD-LEO-FIX-EXAMPLE-002');
+    createSD.mockResolvedValue({ sd_key: 'SD-LEO-FIX-EXAMPLE-002' });
+
+    const writer = createSdWriter();
+    await writer({ title: 'Another gap', dimension: 'data-model-fidelity' });
+
+    const callArg = createSD.mock.calls[0][0];
+    expect(callArg.metadata.sourced_by).toBe('convergence-remediation');
+  });
 });

--- a/tests/unit/lifecycle-sd-bridge-sourced-by-stamping.test.js
+++ b/tests/unit/lifecycle-sd-bridge-sourced-by-stamping.test.js
@@ -1,0 +1,57 @@
+/**
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-B FR-4: insertSDIdempotent
+ * (lib/eva/lifecycle-sd-bridge.js) is the single shared insert helper every
+ * SD-creation call site in this file routes through — stamping sourced_by
+ * here covers all of them uniformly rather than patching each call site.
+ */
+import { describe, it, expect } from 'vitest';
+import { _internal } from '../../lib/eva/lifecycle-sd-bridge.js';
+
+const { insertSDIdempotent } = _internal;
+
+function fakeSupabase(insertResult = { error: null }) {
+  const calls = [];
+  return {
+    calls,
+    client: {
+      from: () => ({
+        insert: async (row) => {
+          calls.push(row);
+          return insertResult;
+        },
+      }),
+    },
+  };
+}
+
+describe('insertSDIdempotent — sourced_by stamping', () => {
+  it('stamps metadata.sourced_by = "lifecycle-sd-bridge" when the row does not already set it', async () => {
+    const { client, calls } = fakeSupabase();
+    const row = { sd_key: 'SD-X-001', id: 'uuid-1', metadata: { created_via: 'lifecycle-sd-bridge' } };
+    await insertSDIdempotent(client, row);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].metadata.sourced_by).toBe('lifecycle-sd-bridge');
+  });
+
+  it('does not overwrite an explicit sourced_by already set by the caller', async () => {
+    const { client, calls } = fakeSupabase();
+    const row = { sd_key: 'SD-X-002', id: 'uuid-2', metadata: { sourced_by: 'some-other-writer' } };
+    await insertSDIdempotent(client, row);
+    expect(calls[0].metadata.sourced_by).toBe('some-other-writer');
+  });
+
+  it('applies across every call (all 3 insertSDIdempotent call sites share this one function)', async () => {
+    const { client, calls } = fakeSupabase();
+    await insertSDIdempotent(client, { sd_key: 'SD-ORCH-001', id: 'u1', metadata: {} });
+    await insertSDIdempotent(client, { sd_key: 'SD-ORCH-001-1', id: 'u2', metadata: {} });
+    await insertSDIdempotent(client, { sd_key: 'SD-ORCH-001-1-1', id: 'u3', metadata: {} });
+    expect(calls.every((r) => r.metadata.sourced_by === 'lifecycle-sd-bridge')).toBe(true);
+  });
+
+  it('still treats a 23505 duplicate-key error as reuse, unaffected by the stamping change', async () => {
+    const { client } = fakeSupabase({ error: { code: '23505', message: 'duplicate key value violates unique constraint "strategic_directives_v2_sd_key_key"' } });
+    const result = await insertSDIdempotent(client, { sd_key: 'SD-DUP-001', id: 'u4', metadata: {} });
+    expect(result.created).toBe(false);
+    expect(result.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a durable would_deny evidence write (reuses `system_events`, `event_type='DISPATCH_AUTH_WOULD_DENY'`) alongside the existing `formatWouldDenyLine` console.log at all 3 dispatch-auth call sites (checkin self-claim, sd-start direct claim, sd-start fallback claim), fail-soft so it never affects the claim path
- Extends `metadata.sourced_by` stamping to the two SD-creation writers that lacked it: `lib/eva/convergence-remediation-writers.js` and `lib/eva/lifecycle-sd-bridge.js` (stamped once in the shared `insertSDIdempotent` helper, covering all its call sites)
- Adds `scripts/dispatch-auth-would-deny-report.mjs`, a per-mint-path would-deny profile report

Out of scope (explicitly deferred to a future SD per the parent's release decision): deriving/shipping an auto-authorize allowlist from this evidence, flipping enforce mode, and the directive-aware self-claim axis (sibling child SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C).

## Test plan
- [x] Existing pinned `tests/unit/claim/gates/dispatch-authorization.test.js` suite (15 tests) passes unmodified — call-site contract and wiring pins preserved
- [x] New unit tests for `recordWouldDenyEvidence` (payload shape, mint-path fallback, fail-soft on throw and on returned error)
- [x] New unit tests for `buildWouldDenyProfile` report (segmentation, zero-evidence case, read-error surfacing)
- [x] New unit tests for `sourced_by` stamping in both writers (including non-overwrite of an explicit value, and the 23505-duplicate-key path)
- [x] Full worker-checkin + sd-start regression sweep: 27 files / 226 tests, zero regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>