### PR TITLE
feat(SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001): Stage-0 thesis + explicit-decisions contract

### DIFF
--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -174,7 +174,21 @@ export async function checkVentureStackCompliance(supabase, ventureId) {
     // (still fail-closed/hold) rather than a silent, misleading over-block.
     return { compliant: false, unscannable: true, reason: `query_error: ${error.message}`, violations: [], missing: [] };
   }
-  return scanArtifactsForStackCompliance(artifacts || []);
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (FR-4): consume the venture's RECORDED
+  // explicit decisions (Stage-0 explicit_decisions on ventures.metadata) so appliesWhen-
+  // conditioned rules judge against the decided form factor, not an assumed default.
+  // Fail-soft: a read error leaves decisions null = the declared defaults govern
+  // (byte-identical pre-decision behavior).
+  let decisions = null;
+  try {
+    const { data: venture } = await supabase
+      .from('ventures')
+      .select('metadata')
+      .eq('id', ventureId)
+      .maybeSingle();
+    decisions = venture?.metadata?.explicit_decisions || null;
+  } catch { /* fail-soft — defaults govern */ }
+  return scanArtifactsForStackCompliance(artifacts || [], { decisions });
 }
 
 /** The TOP orchestrator (parent_sd_id IS NULL) for the venture. Read-only. */

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -136,6 +136,13 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
         status: 'active',
         company_id: companyId,
         metadata: {
+          // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the thesis + pre-registered kill
+          // criteria + explicit decisions live ON the venture record — downstream gates
+          // (S20-26 O2) arm kill_criteria as live gauges, and stack scans consume the
+          // form-factor decision instead of assuming web.
+          thesis: brief.thesis || null,
+          kill_criteria: brief.kill_criteria || null,
+          explicit_decisions: brief.explicit_decisions || null,
           stage_zero: {
             // SD-LEO-FIX-FIX-STAGE-QUEUE-001: durable request→venture link (idempotency anchor).
             stage_zero_request_id: requestId,

--- a/lib/eva/stage-zero/interfaces.js
+++ b/lib/eva/stage-zero/interfaces.js
@@ -9,7 +9,7 @@
  */
 
 // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the thesis/kills/decisions contract seam.
-import { validateVentureThesis, validateKillCriteria, validateExplicitDecisions } from './thesis-contract.js';
+import { validateVentureThesis, validateKillCriteria, validateExplicitDecisions, THESIS_CORE_FIELDS } from './thesis-contract.js';
 
 /**
  * Validate a PathOutput object.
@@ -122,14 +122,20 @@ export function validateVentureBrief(brief) {
   }
 
   // THESIS CONTRACT — an incomplete thesis is representable (incomplete_fields honesty)
-  // but its incompleteness must be DECLARED and the brief must not claim 'ready'.
+  // but its incompleteness must be DECLARED, and CORE-incomplete (cannot state who pays
+  // for what / no testable plan) must not claim maturity 'ready'. SOFT-incomplete
+  // (price_point/reached_how) stays 'ready'-eligible: the demand-test plan is the
+  // instrument that refines those fields (PR #5809 adversarial round-1).
   const thesisCheck = validateVentureThesis(brief.thesis);
   if (!thesisCheck.valid) {
     const declaredIncomplete = Array.isArray(brief.thesis?.incomplete_fields) && brief.thesis.incomplete_fields.length > 0;
     if (!declaredIncomplete) {
       errors.push(...thesisCheck.errors.map((e) => `thesis contract: ${e}`));
-    } else if (brief.maturity === 'ready') {
-      errors.push(`thesis contract: incomplete thesis (${brief.thesis.incomplete_fields.join(', ')}) cannot carry maturity 'ready' — demote to 'seed'`);
+    } else {
+      const coreIncomplete = brief.thesis.incomplete_fields.filter((f) => THESIS_CORE_FIELDS.includes(f));
+      if (coreIncomplete.length > 0 && brief.maturity === 'ready') {
+        errors.push(`thesis contract: core-incomplete thesis (${coreIncomplete.join(', ')}) cannot carry maturity 'ready' — demote to 'seed'`);
+      }
     }
   }
 

--- a/lib/eva/stage-zero/interfaces.js
+++ b/lib/eva/stage-zero/interfaces.js
@@ -8,6 +8,9 @@
  * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
  */
 
+// SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the thesis/kills/decisions contract seam.
+import { validateVentureThesis, validateKillCriteria, validateExplicitDecisions } from './thesis-contract.js';
+
 /**
  * Validate a PathOutput object.
  * Every path handler must produce output conforming to this shape.
@@ -84,6 +87,13 @@ export function validateSynthesisInput(input) {
 /**
  * Validate a VentureBrief — the Stage 0 output that feeds Stage 1.
  *
+ * SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (spec R3+R5): a brief is only a valid
+ * Stage-Zero output when it carries a falsifiable THESIS (who pays / for what / reached
+ * how / at what price + a pre-build demand-test plan), PRE-REGISTERED KILL CRITERIA as
+ * machine-consumable contracts, and the EXPLICIT-DECISIONS block (form factor first).
+ * A bare composite score with none of these is REJECTED here — while a scoreless brief
+ * with a full thesis remains representable (no score field is required).
+ *
  * @param {Object} brief - The venture brief to validate
  * @returns {{ valid: boolean, errors: string[] }}
  */
@@ -109,6 +119,28 @@ export function validateVentureBrief(brief) {
   const validMaturities = ['ready', 'seed', 'sprout', 'blocked', 'nursery'];
   if (brief.maturity && !validMaturities.includes(brief.maturity)) {
     errors.push(`maturity must be one of: ${validMaturities.join(', ')}`);
+  }
+
+  // THESIS CONTRACT — an incomplete thesis is representable (incomplete_fields honesty)
+  // but its incompleteness must be DECLARED and the brief must not claim 'ready'.
+  const thesisCheck = validateVentureThesis(brief.thesis);
+  if (!thesisCheck.valid) {
+    const declaredIncomplete = Array.isArray(brief.thesis?.incomplete_fields) && brief.thesis.incomplete_fields.length > 0;
+    if (!declaredIncomplete) {
+      errors.push(...thesisCheck.errors.map((e) => `thesis contract: ${e}`));
+    } else if (brief.maturity === 'ready') {
+      errors.push(`thesis contract: incomplete thesis (${brief.thesis.incomplete_fields.join(', ')}) cannot carry maturity 'ready' — demote to 'seed'`);
+    }
+  }
+
+  const killCheck = validateKillCriteria(brief.kill_criteria);
+  if (!killCheck.valid) {
+    errors.push(...killCheck.errors.map((e) => `kill contract: ${e}`));
+  }
+
+  const decisionCheck = validateExplicitDecisions(brief.explicit_decisions);
+  if (!decisionCheck.valid) {
+    errors.push(...decisionCheck.errors.map((e) => `decision contract: ${e}`));
   }
 
   return { valid: errors.length === 0, errors };

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -61,6 +61,8 @@ import { analyzeAttentionCapital } from './attention-capital.js';
 import { analyzeAgenticFit } from './agentic-fit.js';
 import { runMentalModelAnalysis } from './mental-model-analysis.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
+// SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: thesis/kills/decisions contract producers.
+import { buildThesisFromSynthesis, deriveDefaultKillCriteria, buildExplicitDecisions } from '../thesis-contract.js';
 
 /**
  * Run all 14 synthesis components on a PathOutput.
@@ -238,12 +240,32 @@ export async function runSynthesis(pathOutput, deps = {}) {
   const gatingComponents = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, agenticFit, constraints];
   const gatingFailedCount = gatingComponents.filter(c => c === null || c?._failed === true).length;
   const anyComponentFailed = gatingFailedCount > 0;
-  const maturity = constraints?.verdict === 'fail' ? 'blocked'
+
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (spec R3+R5): the brief is a falsifiable
+  // THESIS with pre-registered kills and named decisions, not a bare score. Derivation is
+  // deterministic from fields the candidate/synthesis already carries (per-field
+  // provenance; nothing invented — missing sources are DECLARED in incomplete_fields).
+  const candidate = pathOutput.raw_material?.candidate || pathOutput.metadata?.candidate || pathOutput;
+  const thesis = buildThesisFromSynthesis(pathOutput, synthesisResults, candidate);
+  const killCriteria = deriveDefaultKillCriteria(thesis);
+  const explicitDecisions = buildExplicitDecisions(pathOutput.metadata?.decision_overrides || {});
+
+  // Maturity: ENGINE-FAIL-CLOSED-001's weakest-link gate takes precedence (blocked on any
+  // failed gating component), then the pre-existing branches, then THESIS-CONTRACT-001's
+  // demotion — an incomplete thesis DEMOTES 'ready' to 'seed' (honesty over optimism).
+  const baseMaturity = constraints?.verdict === 'fail' ? 'blocked'
     : anyComponentFailed ? 'blocked'
     : timeHorizon?.position === 'park_and_build_later' ? 'nursery'
     : 'ready';
+  const maturity = baseMaturity === 'ready' && thesis.incomplete_fields.length > 0 ? 'seed' : baseMaturity;
+  if (thesis.incomplete_fields.length > 0) {
+    logger.log(`   Thesis incomplete (${thesis.incomplete_fields.join(', ')}) — maturity ${baseMaturity === 'ready' ? "demoted to 'seed'" : `stays '${maturity}'`}`);
+  }
 
   return {
+    thesis,
+    kill_criteria: killCriteria,
+    explicit_decisions: explicitDecisions,
     name: pathOutput.suggested_name,
     problem_statement: recommendedProblem,
     solution: pathOutput.suggested_solution,

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -62,7 +62,7 @@ import { analyzeAgenticFit } from './agentic-fit.js';
 import { runMentalModelAnalysis } from './mental-model-analysis.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: thesis/kills/decisions contract producers.
-import { buildThesisFromSynthesis, deriveDefaultKillCriteria, buildExplicitDecisions } from '../thesis-contract.js';
+import { buildThesisFromSynthesis, deriveDefaultKillCriteria, buildExplicitDecisions, THESIS_CORE_FIELDS } from '../thesis-contract.js';
 
 /**
  * Run all 14 synthesis components on a PathOutput.
@@ -245,21 +245,31 @@ export async function runSynthesis(pathOutput, deps = {}) {
   // THESIS with pre-registered kills and named decisions, not a bare score. Derivation is
   // deterministic from fields the candidate/synthesis already carries (per-field
   // provenance; nothing invented — missing sources are DECLARED in incomplete_fields).
-  const candidate = pathOutput.raw_material?.candidate || pathOutput.metadata?.candidate || pathOutput;
+  // Candidate resolution uses the PRODUCTION shapes: discovery-mode emits
+  // raw_material.top_candidate (paths/discovery-mode.js); competitor-teardown/blueprint
+  // paths carry no revenue-shaped candidate (their soft thesis fields stay honestly
+  // incomplete). NO pathOutput fallback — that shape never carries candidate fields and
+  // masked the real derivation gap (adversarial round-1 of PR #5809, CRITICAL).
+  const candidate = pathOutput.raw_material?.top_candidate || pathOutput.raw_material?.candidate || pathOutput.metadata?.candidate || {};
   const thesis = buildThesisFromSynthesis(pathOutput, synthesisResults, candidate);
   const killCriteria = deriveDefaultKillCriteria(thesis);
   const explicitDecisions = buildExplicitDecisions(pathOutput.metadata?.decision_overrides || {});
 
   // Maturity: ENGINE-FAIL-CLOSED-001's weakest-link gate takes precedence (blocked on any
   // failed gating component), then the pre-existing branches, then THESIS-CONTRACT-001's
-  // demotion — an incomplete thesis DEMOTES 'ready' to 'seed' (honesty over optimism).
+  // demotion. Only a CORE-incomplete thesis (cannot state who pays for what / no testable
+  // plan) demotes 'ready' -> 'seed'. SOFT fields (price_point, reached_how) missing are
+  // recorded honestly but do NOT park the venture — the demand-test plan is exactly the
+  // instrument that refines them (round-1 CRITICAL of PR #5809: demoting on soft fields
+  // would have nursery-parked every competitor-teardown/blueprint venture).
+  const coreIncomplete = thesis.incomplete_fields.filter((f) => THESIS_CORE_FIELDS.includes(f));
   const baseMaturity = constraints?.verdict === 'fail' ? 'blocked'
     : anyComponentFailed ? 'blocked'
     : timeHorizon?.position === 'park_and_build_later' ? 'nursery'
     : 'ready';
-  const maturity = baseMaturity === 'ready' && thesis.incomplete_fields.length > 0 ? 'seed' : baseMaturity;
+  const maturity = baseMaturity === 'ready' && coreIncomplete.length > 0 ? 'seed' : baseMaturity;
   if (thesis.incomplete_fields.length > 0) {
-    logger.log(`   Thesis incomplete (${thesis.incomplete_fields.join(', ')}) — maturity ${baseMaturity === 'ready' ? "demoted to 'seed'" : `stays '${maturity}'`}`);
+    logger.log(`   Thesis incomplete (${thesis.incomplete_fields.join(', ')}; core: ${coreIncomplete.length ? coreIncomplete.join(', ') : 'none'}) — maturity ${coreIncomplete.length && baseMaturity === 'ready' ? "demoted to 'seed'" : `'${maturity}'`}`);
   }
 
   return {

--- a/lib/eva/stage-zero/thesis-contract.js
+++ b/lib/eva/stage-zero/thesis-contract.js
@@ -1,0 +1,301 @@
+/**
+ * Stage-0 THESIS + EXPLICIT-DECISIONS CONTRACT — SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001.
+ *
+ * Provenance: deep-challenge commission (spec R3 + R5, Bravo flaw-ledger findings 4/6,
+ * Solomon adjudication 2026-07-10 12:21Z). Stage-0's output was a bare composite score;
+ * this module makes it a falsifiable THESIS (who pays, for what, reached how, at what
+ * price, testable before build), with PRE-REGISTERED KILL CRITERIA emitted as
+ * machine-consumable contracts (the S20-26 O2 launch gate arms them as live gauges),
+ * and NAMED EXPLICIT DECISIONS replacing silent factory assumptions (form factor first).
+ *
+ * Pure module: no DB / fs / network / LLM. Derivations pull ONLY from fields the
+ * candidate/synthesis already carries and record per-field provenance — a value with no
+ * source is listed in incomplete_fields, never invented (value-authenticity invariant).
+ */
+
+import { parseRevenuePotential } from './utils/parse-revenue.js';
+
+export const THESIS_FIELDS = Object.freeze(['who_pays', 'pays_for_what', 'reached_how', 'price_point']);
+export const KILL_COMPARATORS = Object.freeze(['lt', 'lte', 'gt', 'gte', 'eq']);
+
+/**
+ * Validate a venture thesis. A valid thesis answers: who pays, for what, how they are
+ * reached, at what price — plus a pre-build demand-test plan (>=2 concrete steps, each
+ * with an instruction and a success_signal). Independent of any score by construction.
+ *
+ * @param {Object} thesis
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateVentureThesis(thesis) {
+  const errors = [];
+  if (!thesis || typeof thesis !== 'object') {
+    return { valid: false, errors: ['thesis must be a non-null object (a bare score is not a Stage-Zero output)'] };
+  }
+  for (const f of THESIS_FIELDS) {
+    if (!thesis[f] || typeof thesis[f] !== 'string' || !thesis[f].trim()) {
+      errors.push(`thesis.${f} is required (non-empty string)`);
+    }
+  }
+  const plan = thesis.demand_test_plan;
+  if (!Array.isArray(plan) || plan.length < 2) {
+    errors.push('thesis.demand_test_plan requires >=2 steps (a demand test executable BEFORE build)');
+  } else {
+    plan.forEach((s, i) => {
+      if (!s || typeof s.instruction !== 'string' || !s.instruction.trim()) errors.push(`demand_test_plan[${i}].instruction is required`);
+      if (!s || typeof s.success_signal !== 'string' || !s.success_signal.trim()) errors.push(`demand_test_plan[${i}].success_signal is required`);
+    });
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate pre-registered kill criteria. Each criterion is a MACHINE-CONSUMABLE contract:
+ * numeric comparator math a downstream gate evaluates with zero free-text parsing.
+ *
+ * @param {Array} list
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateKillCriteria(list) {
+  const errors = [];
+  if (!Array.isArray(list) || list.length === 0) {
+    return { valid: false, errors: ['kill_criteria requires >=1 pre-registered criterion ("this venture dies if X by stage Y")'] };
+  }
+  list.forEach((c, i) => {
+    if (!c || typeof c !== 'object') { errors.push(`kill_criteria[${i}] must be an object`); return; }
+    if (!c.id || typeof c.id !== 'string') errors.push(`kill_criteria[${i}].id is required`);
+    if (!c.metric || typeof c.metric !== 'string') errors.push(`kill_criteria[${i}].metric is required`);
+    if (!KILL_COMPARATORS.includes(c.comparator)) errors.push(`kill_criteria[${i}].comparator must be one of ${KILL_COMPARATORS.join('|')}`);
+    if (typeof c.threshold !== 'number' || !Number.isFinite(c.threshold)) errors.push(`kill_criteria[${i}].threshold must be a finite number`);
+    if (!Number.isInteger(c.stage_by) || c.stage_by < 1 || c.stage_by > 26) errors.push(`kill_criteria[${i}].stage_by must be an integer stage 1-26`);
+    if (!c.description || typeof c.description !== 'string') errors.push(`kill_criteria[${i}].description is required`);
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Evaluate ONE kill criterion against an observed value. Pure comparator math — the
+ * O2-gate consumption seam. killed=true means the criterion FIRED (observed value is on
+ * the death side of the threshold: e.g. comparator 'lt' kills when observed < threshold).
+ *
+ * @param {Object} criterion - a validateKillCriteria-valid criterion
+ * @param {number} observedValue
+ * @returns {{ killed: boolean, criterionId: string, observed: number, threshold: number, comparator: string }}
+ */
+export function evaluateKillCriterion(criterion, observedValue) {
+  const v = Number(observedValue);
+  if (!Number.isFinite(v)) {
+    // Fail-closed for gauges: an unobservable metric cannot prove survival.
+    return { killed: true, criterionId: criterion.id, observed: NaN, threshold: criterion.threshold, comparator: criterion.comparator, reason: 'unobservable_metric_fail_closed' };
+  }
+  const t = criterion.threshold;
+  const killed =
+    criterion.comparator === 'lt' ? v < t :
+    criterion.comparator === 'lte' ? v <= t :
+    criterion.comparator === 'gt' ? v > t :
+    criterion.comparator === 'gte' ? v >= t :
+    v === t; // 'eq'
+  return { killed, criterionId: criterion.id, observed: v, threshold: t, comparator: criterion.comparator };
+}
+
+/**
+ * Derive the thesis DETERMINISTICALLY from fields the candidate/synthesis already carries.
+ * No LLM call, no invention: every populated field records its source in
+ * thesis.provenance[field] = { source_field, derived: true }; a field whose source is
+ * absent is listed in thesis.incomplete_fields (the caller demotes maturity — honesty
+ * over completeness).
+ *
+ * @param {Object} pathOutput - PathOutput (suggested_* fields, target_market, metadata)
+ * @param {Object} [synthesisResults] - keyed synthesis outputs (virality etc.)
+ * @param {Object} [candidate] - the LLM-emitted discovery candidate when available
+ *                               (revenue_model, monthly_revenue_potential)
+ * @returns {Object} thesis (possibly incomplete — check incomplete_fields)
+ */
+export function buildThesisFromSynthesis(pathOutput = {}, synthesisResults = {}, candidate = {}) {
+  const provenance = {};
+  const incomplete = [];
+  const thesis = { demand_test_plan: [], provenance, incomplete_fields: incomplete };
+
+  const market = pathOutput.target_market || candidate.target_market;
+  if (market && String(market).trim()) {
+    thesis.who_pays = String(market).trim();
+    provenance.who_pays = { source_field: 'target_market', derived: true };
+  } else incomplete.push('who_pays');
+
+  const solution = pathOutput.suggested_solution || candidate.solution;
+  if (solution && String(solution).trim()) {
+    thesis.pays_for_what = String(solution).trim();
+    provenance.pays_for_what = { source_field: 'suggested_solution', derived: true };
+  } else incomplete.push('pays_for_what');
+
+  // reached_how: prefer concrete viral channels the synthesis emitted; else the discovery
+  // path itself is an honest (weak) reach hypothesis source.
+  const channels = synthesisResults?.virality?.viral_channels;
+  if (Array.isArray(channels) && channels.length > 0) {
+    thesis.reached_how = channels.map((c) => (typeof c === 'string' ? c : c?.channel || JSON.stringify(c))).join('; ');
+    provenance.reached_how = { source_field: 'synthesis.virality.viral_channels', derived: true };
+  } else if (candidate.automation_approach || pathOutput.metadata?.path) {
+    thesis.reached_how = candidate.automation_approach
+      ? String(candidate.automation_approach).trim()
+      : `distribution hypothesis pending — origin path: ${pathOutput.metadata.path}`;
+    provenance.reached_how = { source_field: candidate.automation_approach ? 'candidate.automation_approach' : 'pathOutput.metadata.path', derived: true, weak: true };
+  } else incomplete.push('reached_how');
+
+  const revenueModel = candidate.revenue_model;
+  const parsed = parseRevenuePotential(candidate.monthly_revenue_potential);
+  if (revenueModel && String(revenueModel).trim()) {
+    thesis.price_point = parsed
+      ? `${String(revenueModel).trim()} (candidate estimate $${parsed.low}-$${parsed.high}/mo, E0 ungraded)`
+      : String(revenueModel).trim();
+    provenance.price_point = { source_field: parsed ? 'candidate.revenue_model + monthly_revenue_potential' : 'candidate.revenue_model', derived: true };
+  } else if (parsed) {
+    thesis.price_point = `candidate estimate $${parsed.low}-$${parsed.high}/mo (E0 ungraded — no external source)`;
+    provenance.price_point = { source_field: 'candidate.monthly_revenue_potential', derived: true, weak: true };
+  } else incomplete.push('price_point');
+
+  // Demand-test plan: pre-build probes phrased against the derived who_pays/pays_for_what.
+  // Templated STRUCTURE (the plan shape), grounded CONTENT (fields above) — provenance says so.
+  if (thesis.who_pays && thesis.pays_for_what) {
+    thesis.demand_test_plan = [
+      {
+        step: 1,
+        instruction: `Landing-page probe: state the offer ("${truncate(thesis.pays_for_what, 90)}") to ${truncate(thesis.who_pays, 60)} with a request-access CTA; drive the reach channel (${truncate(thesis.reached_how || 'channel TBD', 60)}).`,
+        success_signal: 'Unpaid visitor -> signup conversion >= 5% over the first 100 visitors, or >= 10 qualified signups',
+      },
+      {
+        step: 2,
+        instruction: 'Willingness-to-pay probe: present the price point to signups (pre-order / paid pilot ask) before any build.',
+        success_signal: '>= 3 explicit pre-commitments (pre-order, LOI, or paid pilot acceptance)',
+      },
+    ];
+    provenance.demand_test_plan = { source_field: 'derived_from(who_pays, pays_for_what, reached_how)', derived: true, template: 'landing_page+wtp_probe' };
+  } else {
+    incomplete.push('demand_test_plan');
+  }
+
+  return thesis;
+}
+
+/**
+ * Derive >=2 default pre-registered kill criteria tied to the demand-test plan. These are
+ * the venture's own falsifiers, registered at selection — downstream gates consume them
+ * as contracts instead of inventing generic thresholds later (spec R3 gate-realism).
+ *
+ * @param {Object} thesis - output of buildThesisFromSynthesis (plan may be present)
+ * @returns {Array} kill criteria (validateKillCriteria-valid)
+ */
+export function deriveDefaultKillCriteria(thesis = {}) {
+  return [
+    {
+      id: 'kill-demand-signals',
+      metric: 'demand_test_qualified_signups',
+      comparator: 'lt',
+      threshold: 10,
+      stage_by: 12,
+      description: 'Dies if the pre-build demand test produces fewer than 10 qualified signups by stage 12 (demand_test_plan step 1 unmet).',
+      source: 'derived_default',
+    },
+    {
+      id: 'kill-willingness-to-pay',
+      metric: 'pre_commitments',
+      comparator: 'lt',
+      threshold: 3,
+      stage_by: 16,
+      description: 'Dies if fewer than 3 explicit pre-commitments (pre-order/LOI/paid pilot) exist by stage 16 (demand_test_plan step 2 unmet).',
+      source: 'derived_default',
+    },
+    {
+      id: 'kill-first-revenue',
+      metric: 'real_revenue_events',
+      comparator: 'lt',
+      threshold: 1,
+      stage_by: 24,
+      description: `Dies if zero real revenue events have occurred by stage 24 (${thesis?.price_point ? `price point: ${truncate(thesis.price_point, 80)}` : 'price point pending'}).`,
+      source: 'derived_default',
+    },
+  ];
+}
+
+/**
+ * EXPLICIT-DECISION REGISTRY (spec R5): any dimension the factory currently builds only
+ * ONE way is a selection-time DECISION with a declared default — never a silent
+ * assumption discovered at Stage 14. form_factor is the first (chairman-surfaced)
+ * instance; pricing model and hosting follow the same pattern later.
+ */
+export const EXPLICIT_DECISIONS = Object.freeze({
+  form_factor: Object.freeze({
+    default: 'web',
+    allowed: Object.freeze(['web', 'pwa', 'native']),
+    phase1_anti_goal: 'native',
+    native_criterion:
+      'native only when an OS capability (push-critical UX, hardware sensor access, offline-first field use) is LOAD-BEARING for the core loop and a PWA demonstrably cannot deliver it',
+  }),
+});
+
+/**
+ * Build the explicit-decisions block for a brief. Defaults apply unless an override is
+ * provided (an override marks decided_by:'chairman' and must be an allowed value).
+ *
+ * @param {Object} [overrides] - e.g. { form_factor: { value: 'pwa', rationale: '...' } }
+ * @returns {Object} explicit_decisions
+ */
+export function buildExplicitDecisions(overrides = {}) {
+  const out = {};
+  for (const [key, spec] of Object.entries(EXPLICIT_DECISIONS)) {
+    const ov = overrides[key];
+    if (ov && spec.allowed.includes(ov.value)) {
+      out[key] = {
+        value: ov.value,
+        default: spec.default,
+        decided_by: 'chairman',
+        rationale: ov.rationale || '(chairman override — no rationale recorded)',
+        criterion_for_native: spec.native_criterion,
+      };
+    } else {
+      out[key] = {
+        value: spec.default,
+        default: spec.default,
+        decided_by: 'default',
+        rationale: `declared factory default (${spec.default}-first; ${spec.phase1_anti_goal} is a Phase-1 anti-goal)`,
+        criterion_for_native: spec.native_criterion,
+      };
+    }
+  }
+  return out;
+}
+
+/**
+ * Validate the explicit-decisions block: every registry key present with an allowed value.
+ * @param {Object} decisions
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateExplicitDecisions(decisions) {
+  const errors = [];
+  if (!decisions || typeof decisions !== 'object') {
+    return { valid: false, errors: ['explicit_decisions must be a non-null object (silent assumptions are not a valid output)'] };
+  }
+  for (const [key, spec] of Object.entries(EXPLICIT_DECISIONS)) {
+    const d = decisions[key];
+    if (!d || typeof d !== 'object') { errors.push(`explicit_decisions.${key} is required`); continue; }
+    if (!spec.allowed.includes(d.value)) errors.push(`explicit_decisions.${key}.value must be one of ${spec.allowed.join('|')}`);
+    if (!d.rationale || typeof d.rationale !== 'string') errors.push(`explicit_decisions.${key}.rationale is required`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+function truncate(s, n) {
+  const str = String(s);
+  return str.length <= n ? str : str.slice(0, n - 1) + '…';
+}
+
+export default {
+  THESIS_FIELDS,
+  KILL_COMPARATORS,
+  validateVentureThesis,
+  validateKillCriteria,
+  evaluateKillCriterion,
+  buildThesisFromSynthesis,
+  deriveDefaultKillCriteria,
+  EXPLICIT_DECISIONS,
+  buildExplicitDecisions,
+  validateExplicitDecisions,
+};

--- a/lib/eva/stage-zero/thesis-contract.js
+++ b/lib/eva/stage-zero/thesis-contract.js
@@ -16,6 +16,12 @@
 import { parseRevenuePotential } from './utils/parse-revenue.js';
 
 export const THESIS_FIELDS = Object.freeze(['who_pays', 'pays_for_what', 'reached_how', 'price_point']);
+// CORE fields: without these the thesis cannot be stated at all — their absence demotes
+// maturity. SOFT fields (price_point, reached_how) are refinable BY the demand-test plan
+// itself (the WTP probe discovers price), so their declared absence records honestly
+// without parking the venture (adversarial round-1 of PR #5809: demoting on soft fields
+// would have nursery-parked every competitor-teardown/blueprint venture).
+export const THESIS_CORE_FIELDS = Object.freeze(['who_pays', 'pays_for_what', 'demand_test_plan']);
 export const KILL_COMPARATORS = Object.freeze(['lt', 'lte', 'gt', 'gte', 'eq']);
 
 /**
@@ -84,8 +90,11 @@ export function validateKillCriteria(list) {
 export function evaluateKillCriterion(criterion, observedValue) {
   const v = Number(observedValue);
   if (!Number.isFinite(v)) {
-    // Fail-closed for gauges: an unobservable metric cannot prove survival.
-    return { killed: true, criterionId: criterion.id, observed: NaN, threshold: criterion.threshold, comparator: criterion.comparator, reason: 'unobservable_metric_fail_closed' };
+    // Fail-closed for gauges: an unobservable metric cannot prove survival. The
+    // `unobservable: true` flag lets a consuming gate distinguish HOLD-for-observability
+    // from a genuine kill — auto-kill machinery must never treat this as a fired
+    // falsifier (it is a missing gauge, not a failed test).
+    return { killed: true, unobservable: true, criterionId: criterion.id, observed: NaN, threshold: criterion.threshold, comparator: criterion.comparator, reason: 'unobservable_metric_fail_closed' };
   }
   const t = criterion.threshold;
   const killed =
@@ -118,7 +127,10 @@ export function buildThesisFromSynthesis(pathOutput = {}, synthesisResults = {},
   const market = pathOutput.target_market || candidate.target_market;
   if (market && String(market).trim()) {
     thesis.who_pays = String(market).trim();
-    provenance.who_pays = { source_field: 'target_market', derived: true };
+    // weak: the payer is ASSUMED to equal the target market — wrong for ad-funded /
+    // marketplace models where the payer differs from the user. The demand-test WTP
+    // probe is what falsifies this assumption pre-build.
+    provenance.who_pays = { source_field: 'target_market', derived: true, weak: true, assumption: 'payer_assumed_equal_to_target_market' };
   } else incomplete.push('who_pays');
 
   const solution = pathOutput.suggested_solution || candidate.solution;
@@ -289,6 +301,7 @@ function truncate(s, n) {
 
 export default {
   THESIS_FIELDS,
+  THESIS_CORE_FIELDS,
   KILL_COMPARATORS,
   validateVentureThesis,
   validateKillCriteria,

--- a/lib/eva/standards/venture-stack-compliance.js
+++ b/lib/eva/standards/venture-stack-compliance.js
@@ -33,13 +33,35 @@ function asGlobal(re) {
   return new RegExp(re.source, flags);
 }
 
-/** Scan a single text blob. Returns { violations:[{id,label,kind,token,why}], presentRequired:Set<id> }. */
-function scanOne(text) {
+/**
+ * SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (FR-4): does a FORBIDDEN rule apply to a
+ * venture given its recorded explicit decisions? Rules without appliesWhen always apply.
+ * With appliesWhen, the rule applies when NO decision is provided for the key (the
+ * declared default governs — back-compat) or the decision's value is in the rule's list.
+ * PURE. @param {object} rule @param {object|null} decisions e.g. {form_factor:{value:'native'}}
+ */
+export function ruleApplies(rule, decisions) {
+  if (!rule.appliesWhen) return true;
+  if (!decisions || typeof decisions !== 'object') return true;
+  for (const [key, allowedValues] of Object.entries(rule.appliesWhen)) {
+    const decided = decisions[key] && decisions[key].value;
+    if (decided && !allowedValues.includes(decided)) return false;
+  }
+  return true;
+}
+
+/** Scan a single text blob. Returns { violations:[{id,label,kind,token,why}], presentRequired:Set<id>, skippedRules:[{id,reason}] }. */
+function scanOne(text, decisions = null) {
   const violations = [];
   const presentRequired = new Set();
-  if (typeof text !== 'string' || !text) return { violations, presentRequired };
+  const skippedRules = [];
+  if (typeof text !== 'string' || !text) return { violations, presentRequired, skippedRules };
 
   for (const rule of FORBIDDEN) {
+    if (!ruleApplies(rule, decisions)) {
+      skippedRules.push({ id: rule.id, reason: `skipped: recorded explicit decision (${Object.keys(rule.appliesWhen).join(',')}) outside this rule's appliesWhen` });
+      continue;
+    }
     let flagged = false;
     for (const re of rule.patterns) {
       if (flagged) break;
@@ -66,14 +88,19 @@ function scanOne(text) {
     }
   }
 
-  return { violations, presentRequired };
+  return { violations, presentRequired, skippedRules };
 }
 
 /**
  * Core: scan an array of text blobs at the VENTURE level (all artifacts taken together). Returns
  * { compliant, unscannable, reason, violations, missing }.
  */
-export function scanTextForStackCompliance(texts) {
+export function scanTextForStackCompliance(texts, opts = {}) {
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (FR-4): opts.decisions = the venture's
+  // recorded explicit_decisions block; rules whose appliesWhen excludes the decided value
+  // are skipped (reported in skippedRules). Omitting opts.decisions is byte-identical to
+  // the pre-decision behavior (the declared defaults govern).
+  const { decisions = null } = opts;
   const blobs = (Array.isArray(texts) ? texts : [texts]).filter((t) => typeof t === 'string' && t.trim());
   if (blobs.length === 0) {
     return {
@@ -82,15 +109,18 @@ export function scanTextForStackCompliance(texts) {
       reason: 'unscannable',
       violations: [],
       missing: REQUIRED.map((r) => r.label),
+      skippedRules: [],
     };
   }
 
   const byId = new Map(); // dedupe violations by rule id across blobs
   const presentRequired = new Set();
+  const skippedById = new Map();
   for (const b of blobs) {
-    const { violations, presentRequired: pr } = scanOne(b);
+    const { violations, presentRequired: pr, skippedRules } = scanOne(b, decisions);
     for (const v of violations) if (!byId.has(v.id)) byId.set(v.id, v);
     for (const id of pr) presentRequired.add(id);
+    for (const s of skippedRules) if (!skippedById.has(s.id)) skippedById.set(s.id, s);
   }
 
   const violations = [...byId.values()];
@@ -102,6 +132,7 @@ export function scanTextForStackCompliance(texts) {
     reason: compliant ? 'compliant' : 'forbidden_stack_present',
     violations,
     missing,
+    skippedRules: [...skippedById.values()],
   };
 }
 
@@ -111,7 +142,7 @@ export function scanTextForStackCompliance(texts) {
  * AGAINST the concept and so mention forbidden approaches without the venture adopting them. Zero
  * SCANNABLE artifacts -> unscannable (fail-closed). Otherwise delegates to scanTextForStackCompliance.
  */
-export function scanArtifactsForStackCompliance(artifacts) {
+export function scanArtifactsForStackCompliance(artifacts, opts = {}) {
   const scannable = (Array.isArray(artifacts) ? artifacts : []).filter(
     (a) => a && !EXCLUDED_ARTIFACT_TYPES.has(a.artifact_type),
   );
@@ -122,6 +153,7 @@ export function scanArtifactsForStackCompliance(artifacts) {
       reason: 'unscannable',
       violations: [],
       missing: REQUIRED.map((r) => r.label),
+      skippedRules: [],
     };
   }
   const texts = [];
@@ -131,7 +163,7 @@ export function scanArtifactsForStackCompliance(artifacts) {
       try { texts.push(typeof a.artifact_data === 'string' ? a.artifact_data : JSON.stringify(a.artifact_data)); } catch { /* skip unserializable */ }
     }
   }
-  return scanTextForStackCompliance(texts);
+  return scanTextForStackCompliance(texts, opts);
 }
 
-export default { isNegated, scanTextForStackCompliance, scanArtifactsForStackCompliance };
+export default { isNegated, ruleApplies, scanTextForStackCompliance, scanArtifactsForStackCompliance };

--- a/lib/eva/standards/venture-stack-policy.js
+++ b/lib/eva/standards/venture-stack-policy.js
@@ -54,7 +54,13 @@ export const FORBIDDEN = Object.freeze([
     label: 'CLI-as-product framing',
     kind: 'framing',
     patterns: [/\bCLI\s+(tool|product|app|application)\b/i, /\bcommand[- ]line\s+(tool|product|app|interface|utility)\b/i, /\bnpm\s+install\s+(?:-g\s+)?[a-z0-9@/_-]+[\s\S]{0,60}\b[a-z0-9-]+\s+run\b/i],
-    why: 'Ventures are hosted SaaS web apps, not CLI products.',
+    // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 (spec R5): form factor is a recorded
+    // Stage-0 DECISION (web default -> PWA -> native criterion), not a policy assertion.
+    // appliesWhen conditions this rule on that decision: the scan enforces it only when
+    // the venture's recorded form_factor is in this list — or when no decision is passed
+    // at all (the declared web default governs; byte-identical back-compat).
+    appliesWhen: { form_factor: ['web', 'pwa'] },
+    why: 'The venture’s recorded form-factor decision (Stage-0 explicit_decisions; web-first default) is a hosted app, not a CLI product.',
   },
 ]);
 

--- a/tests/unit/eva/stage-zero/interfaces.test.js
+++ b/tests/unit/eva/stage-zero/interfaces.test.js
@@ -140,6 +140,8 @@ describe('createPathOutput', () => {
 });
 
 describe('validateVentureBrief', () => {
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: a COMPLETE brief now carries the thesis /
+  // kill-criteria / explicit-decisions contract — a bare score-shaped brief is rejected.
   const validBrief = {
     name: 'Test Venture',
     problem_statement: 'A problem',
@@ -147,12 +149,37 @@ describe('validateVentureBrief', () => {
     target_market: 'SMBs',
     origin_type: 'discovery',
     raw_chairman_intent: 'Make money with AI',
+    thesis: {
+      who_pays: 'SMB owners',
+      pays_for_what: 'an automated solution',
+      reached_how: 'SEO + communities',
+      price_point: 'subscription $29/mo',
+      demand_test_plan: [
+        { step: 1, instruction: 'landing page probe', success_signal: '>=10 signups' },
+        { step: 2, instruction: 'pre-order ask', success_signal: '>=3 pre-commitments' },
+      ],
+    },
+    kill_criteria: [
+      { id: 'k1', metric: 'signups', comparator: 'lt', threshold: 10, stage_by: 12, description: 'dies if <10 signups by S12', source: 'derived_default' },
+    ],
+    explicit_decisions: {
+      form_factor: { value: 'web', default: 'web', decided_by: 'default', rationale: 'declared factory default', criterion_for_native: 'OS capability load-bearing' },
+    },
   };
 
   test('returns valid for complete brief', () => {
     const result = validateVentureBrief(validBrief);
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  test('rejects a thesis-less score-shaped brief (SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001)', () => {
+    const { thesis, kill_criteria, explicit_decisions, ...bare } = validBrief;
+    const result = validateVentureBrief({ ...bare, composite_score: 91 });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/thesis contract/);
+    expect(result.errors.join(' ')).toMatch(/kill contract/);
+    expect(result.errors.join(' ')).toMatch(/decision contract/);
   });
 
   test('returns invalid for null', () => {

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -97,7 +97,10 @@ const silentLogger = { log: vi.fn(), warn: vi.fn() };
 
 const validPathOutput = {
   origin_type: 'discovery',
-  raw_material: { data: true },
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the candidate carries the thesis derivation
+  // sources (revenue_model/monthly_revenue_potential -> price_point). A candidate missing
+  // them yields a DECLARED-incomplete thesis and demotes maturity to 'seed' (tested below).
+  raw_material: { data: true, candidate: { revenue_model: 'subscription', monthly_revenue_potential: '$5K/month', automation_approach: 'communities + SEO' } },
   suggested_name: 'Test Venture',
   suggested_problem: 'A real problem',
   suggested_solution: 'An automated solution',
@@ -202,6 +205,24 @@ describe('runSynthesis', () => {
   test('determines maturity=ready when constraints pass and horizon is build_now', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
     expect(result.maturity).toBe('ready');
+  });
+
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the brief is a thesis, not a score.
+  test('emits thesis + kill_criteria + explicit_decisions on every brief', async () => {
+    const result = await runSynthesis(validPathOutput, { logger: silentLogger });
+    expect(result.thesis.who_pays).toBe('SMBs');
+    expect(result.thesis.provenance.who_pays.source_field).toBe('target_market');
+    expect(result.thesis.incomplete_fields).toEqual([]);
+    expect(result.kill_criteria.length).toBeGreaterThanOrEqual(2);
+    expect(result.explicit_decisions.form_factor.value).toBe('web');
+    expect(result.explicit_decisions.form_factor.decided_by).toBe('default');
+  });
+
+  test("an incomplete thesis DEMOTES maturity 'ready' -> 'seed' (honesty over optimism)", async () => {
+    const noRevenue = { ...validPathOutput, raw_material: { data: true } }; // no candidate sources
+    const result = await runSynthesis(noRevenue, { logger: silentLogger });
+    expect(result.thesis.incomplete_fields).toContain('price_point');
+    expect(result.maturity).toBe('seed');
   });
 
   test('determines maturity=blocked when constraints fail', async () => {

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -97,10 +97,10 @@ const silentLogger = { log: vi.fn(), warn: vi.fn() };
 
 const validPathOutput = {
   origin_type: 'discovery',
-  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the candidate carries the thesis derivation
-  // sources (revenue_model/monthly_revenue_potential -> price_point). A candidate missing
-  // them yields a DECLARED-incomplete thesis and demotes maturity to 'seed' (tested below).
-  raw_material: { data: true, candidate: { revenue_model: 'subscription', monthly_revenue_potential: '$5K/month', automation_approach: 'communities + SEO' } },
+  // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: PRODUCTION shape — discovery-mode emits the
+  // ranked winner at raw_material.top_candidate (paths/discovery-mode.js), which carries
+  // the thesis derivation sources (revenue_model/monthly_revenue_potential -> price_point).
+  raw_material: { data: true, top_candidate: { revenue_model: 'subscription', monthly_revenue_potential: '$5K/month', automation_approach: 'communities + SEO' } },
   suggested_name: 'Test Venture',
   suggested_problem: 'A real problem',
   suggested_solution: 'An automated solution',
@@ -218,10 +218,20 @@ describe('runSynthesis', () => {
     expect(result.explicit_decisions.form_factor.decided_by).toBe('default');
   });
 
-  test("an incomplete thesis DEMOTES maturity 'ready' -> 'seed' (honesty over optimism)", async () => {
-    const noRevenue = { ...validPathOutput, raw_material: { data: true } }; // no candidate sources
-    const result = await runSynthesis(noRevenue, { logger: silentLogger });
+  test("SOFT-incomplete thesis (no revenue candidate, e.g. competitor-teardown shape) stays 'ready' — declared, not parked", async () => {
+    // competitor-teardown/blueprint paths carry no revenue-shaped candidate at all;
+    // demoting on soft fields would nursery-park every such venture (PR #5809 round-1).
+    const noCandidate = { ...validPathOutput, raw_material: { data: true } };
+    const result = await runSynthesis(noCandidate, { logger: silentLogger });
     expect(result.thesis.incomplete_fields).toContain('price_point');
+    expect(result.thesis.incomplete_fields.every((f) => ['price_point', 'reached_how'].includes(f))).toBe(true);
+    expect(result.maturity).toBe('ready');
+  });
+
+  test("CORE-incomplete thesis (no target_market -> no who_pays/plan) DEMOTES 'ready' -> 'seed'", async () => {
+    const noMarket = { ...validPathOutput, target_market: '', raw_material: { data: true } };
+    const result = await runSynthesis(noMarket, { logger: silentLogger });
+    expect(result.thesis.incomplete_fields).toContain('who_pays');
     expect(result.maturity).toBe('seed');
   });
 

--- a/tests/unit/eva/stage-zero/thesis-contract.test.js
+++ b/tests/unit/eva/stage-zero/thesis-contract.test.js
@@ -91,13 +91,19 @@ describe('FR-1: validateVentureBrief enforcement (thesis-less score REJECTED)', 
     expect(validateVentureBrief(brief).valid).toBe(true);
   });
 
-  it("a declared-incomplete thesis is representable but cannot carry maturity 'ready'", () => {
-    const incompleteThesis = { ...FULL_THESIS, price_point: undefined, incomplete_fields: ['price_point'] };
-    const rejected = validateVentureBrief(fullBrief({ thesis: incompleteThesis, maturity: 'ready' }));
+  it("a CORE-incomplete thesis (who_pays) is representable but cannot carry maturity 'ready'", () => {
+    const coreIncomplete = { ...FULL_THESIS, who_pays: undefined, incomplete_fields: ['who_pays'] };
+    const rejected = validateVentureBrief(fullBrief({ thesis: coreIncomplete, maturity: 'ready' }));
     expect(rejected.valid).toBe(false);
     expect(rejected.errors.join(' ')).toContain("demote to 'seed'");
-    const accepted = validateVentureBrief(fullBrief({ thesis: incompleteThesis, maturity: 'seed' }));
+    const accepted = validateVentureBrief(fullBrief({ thesis: coreIncomplete, maturity: 'seed' }));
     expect(accepted.valid).toBe(true);
+  });
+
+  it("a SOFT-incomplete thesis (price_point) stays 'ready'-eligible — the demand test refines it (PR #5809 round-1)", () => {
+    const softIncomplete = { ...FULL_THESIS, price_point: undefined, incomplete_fields: ['price_point'] };
+    const r = validateVentureBrief(fullBrief({ thesis: softIncomplete, maturity: 'ready' }));
+    expect(r.valid).toBe(true);
   });
 });
 
@@ -113,6 +119,9 @@ describe('FR-1: buildThesisFromSynthesis derivation with provenance', () => {
     const t = buildThesisFromSynthesis(pathOutput, {}, candidate);
     expect(t.who_pays).toBe('indie game studios');
     expect(t.provenance.who_pays.source_field).toBe('target_market');
+    // payer-uncertainty honestly flagged: target_market != payer for ad/marketplace models
+    expect(t.provenance.who_pays.weak).toBe(true);
+    expect(t.provenance.who_pays.assumption).toBe('payer_assumed_equal_to_target_market');
     expect(t.provenance.pays_for_what.source_field).toBe('suggested_solution');
     expect(t.provenance.price_point.source_field).toContain('revenue_model');
     expect(t.price_point).toContain('E0 ungraded'); // LLM estimate honestly labeled
@@ -154,10 +163,13 @@ describe('FR-2: kill criteria — machine-consumable contracts', () => {
     expect(validateKillCriteria([]).valid).toBe(false);
   });
 
-  it('an unobservable metric fails CLOSED (cannot prove survival)', () => {
+  it('an unobservable metric fails CLOSED with the unobservable flag (HOLD, never auto-kill)', () => {
     const r = evaluateKillCriterion(VALID_KILLS[0], undefined);
     expect(r.killed).toBe(true);
+    expect(r.unobservable).toBe(true); // consuming gates must HOLD, not treat as a fired falsifier
     expect(r.reason).toBe('unobservable_metric_fail_closed');
+    // a genuinely observed value never carries the flag
+    expect(evaluateKillCriterion(VALID_KILLS[0], 7).unobservable).toBeUndefined();
   });
 
   it('all five comparators evaluate correctly', () => {
@@ -234,5 +246,31 @@ describe('FR-4: venture-stack-policy consumes the form-factor decision', () => {
     expect(ruleApplies(supabaseRule, { form_factor: { value: 'native' } })).toBe(true);
     const r = scanTextForStackCompliance(['uses @supabase/supabase-js for data'], { decisions: { form_factor: { value: 'native' } } });
     expect(r.violations.map((v) => v.id)).toContain('supabase_pkg');
+  });
+
+  it('LIVE consumer wired: checkVentureStackCompliance reads ventures.metadata.explicit_decisions and passes it through', async () => {
+    const { checkVentureStackCompliance } = await import('../../../../lib/eva/bridge/venture-build-consumer.js');
+    function mockSb({ decisions }) {
+      return { from: (table) => {
+        const c = {
+          select: () => c,
+          eq: () => c,
+          maybeSingle: async () => ({ data: { metadata: { explicit_decisions: decisions } }, error: null }),
+          then: (res) => Promise.resolve(
+            table === 'venture_artifacts'
+              ? { data: [{ artifact_type: 'spec', content: CLI_TEXT, artifact_data: null }], error: null }
+              : { data: null, error: null }
+          ).then(res),
+        };
+        return c;
+      } };
+    }
+    // recorded native decision -> cli_as_product skipped in the LIVE consumer path
+    const skipped = await checkVentureStackCompliance(mockSb({ decisions: { form_factor: { value: 'native' } } }), 'v-1');
+    expect(skipped.violations.map((v) => v.id)).not.toContain('cli_as_product');
+    expect(skipped.skippedRules.map((s) => s.id)).toContain('cli_as_product');
+    // no recorded decision -> defaults govern, rule fires
+    const fires = await checkVentureStackCompliance(mockSb({ decisions: undefined }), 'v-2');
+    expect(fires.violations.map((v) => v.id)).toContain('cli_as_product');
   });
 });

--- a/tests/unit/eva/stage-zero/thesis-contract.test.js
+++ b/tests/unit/eva/stage-zero/thesis-contract.test.js
@@ -1,0 +1,238 @@
+/**
+ * SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001 — Stage-0 thesis + explicit-decisions contract.
+ * Spec R3 (thesis-not-score, pre-registered kills as consumable contracts) + R5 (named
+ * decisions replace silent assumptions; form factor first). Bravo ledger findings 4/6.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateVentureThesis,
+  validateKillCriteria,
+  evaluateKillCriterion,
+  buildThesisFromSynthesis,
+  deriveDefaultKillCriteria,
+  EXPLICIT_DECISIONS,
+  buildExplicitDecisions,
+  validateExplicitDecisions,
+} from '../../../../lib/eva/stage-zero/thesis-contract.js';
+import { validateVentureBrief } from '../../../../lib/eva/stage-zero/interfaces.js';
+import { scanTextForStackCompliance, ruleApplies } from '../../../../lib/eva/standards/venture-stack-compliance.js';
+import { FORBIDDEN } from '../../../../lib/eva/standards/venture-stack-policy.js';
+
+const FULL_THESIS = {
+  who_pays: 'B2B SaaS founders with 5-50 employees',
+  pays_for_what: 'automated churn-risk digests from their existing billing data',
+  reached_how: 'founder communities; SEO on churn keywords',
+  price_point: 'subscription $49/mo',
+  demand_test_plan: [
+    { step: 1, instruction: 'Landing page with request-access CTA', success_signal: '>=10 qualified signups' },
+    { step: 2, instruction: 'Pre-order ask at $49/mo', success_signal: '>=3 pre-commitments' },
+  ],
+};
+
+const VALID_KILLS = [
+  { id: 'k1', metric: 'signups', comparator: 'lt', threshold: 10, stage_by: 12, description: 'dies if <10 signups by S12', source: 'derived_default' },
+];
+
+function fullBrief(overrides = {}) {
+  return {
+    name: 'ChurnLens',
+    problem_statement: 'Founders discover churn too late',
+    solution: 'Automated churn-risk digests',
+    target_market: 'B2B SaaS founders',
+    origin_type: 'discovery',
+    raw_chairman_intent: 'catch churn early',
+    maturity: 'ready',
+    thesis: FULL_THESIS,
+    kill_criteria: VALID_KILLS,
+    explicit_decisions: buildExplicitDecisions(),
+    ...overrides,
+  };
+}
+
+describe('FR-1: thesis validation', () => {
+  it('accepts a complete thesis', () => {
+    expect(validateVentureThesis(FULL_THESIS).valid).toBe(true);
+  });
+
+  it('rejects a missing/empty thesis and names every missing field', () => {
+    const r = validateVentureThesis(null);
+    expect(r.valid).toBe(false);
+    const r2 = validateVentureThesis({});
+    expect(r2.valid).toBe(false);
+    for (const f of ['who_pays', 'pays_for_what', 'reached_how', 'price_point']) {
+      expect(r2.errors.join(' ')).toContain(f);
+    }
+  });
+
+  it('requires a demand-test plan of >=2 concrete steps with success signals', () => {
+    const r = validateVentureThesis({ ...FULL_THESIS, demand_test_plan: [{ instruction: 'x' }] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toContain('demand_test_plan');
+  });
+});
+
+describe('FR-1: validateVentureBrief enforcement (thesis-less score REJECTED)', () => {
+  it('rejects a score-only brief with no thesis/kills/decisions', () => {
+    const r = validateVentureBrief({ ...fullBrief(), thesis: undefined, kill_criteria: undefined, explicit_decisions: undefined, composite_score: 87 });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toMatch(/thesis contract/);
+    expect(r.errors.join(' ')).toMatch(/kill contract/);
+    expect(r.errors.join(' ')).toMatch(/decision contract/);
+  });
+
+  it('accepts a complete contract-carrying brief', () => {
+    const r = validateVentureBrief(fullBrief());
+    expect(r.valid).toBe(true);
+  });
+
+  it('a SCORELESS brief with a full thesis validates (thesis independent of score)', () => {
+    const brief = fullBrief();
+    delete brief.composite_score;
+    expect(validateVentureBrief(brief).valid).toBe(true);
+  });
+
+  it("a declared-incomplete thesis is representable but cannot carry maturity 'ready'", () => {
+    const incompleteThesis = { ...FULL_THESIS, price_point: undefined, incomplete_fields: ['price_point'] };
+    const rejected = validateVentureBrief(fullBrief({ thesis: incompleteThesis, maturity: 'ready' }));
+    expect(rejected.valid).toBe(false);
+    expect(rejected.errors.join(' ')).toContain("demote to 'seed'");
+    const accepted = validateVentureBrief(fullBrief({ thesis: incompleteThesis, maturity: 'seed' }));
+    expect(accepted.valid).toBe(true);
+  });
+});
+
+describe('FR-1: buildThesisFromSynthesis derivation with provenance', () => {
+  const pathOutput = {
+    target_market: 'indie game studios',
+    suggested_solution: 'asset-pipeline automation',
+    metadata: { path: 'trend_scanner' },
+  };
+  const candidate = { revenue_model: 'subscription', monthly_revenue_potential: '$5K/month', automation_approach: 'discord communities' };
+
+  it('every derived field carries provenance naming its source; nothing invented', () => {
+    const t = buildThesisFromSynthesis(pathOutput, {}, candidate);
+    expect(t.who_pays).toBe('indie game studios');
+    expect(t.provenance.who_pays.source_field).toBe('target_market');
+    expect(t.provenance.pays_for_what.source_field).toBe('suggested_solution');
+    expect(t.provenance.price_point.source_field).toContain('revenue_model');
+    expect(t.price_point).toContain('E0 ungraded'); // LLM estimate honestly labeled
+    expect(t.incomplete_fields).toEqual([]);
+    expect(t.demand_test_plan.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('prefers synthesis virality channels for reached_how when present', () => {
+    const t = buildThesisFromSynthesis(pathOutput, { virality: { viral_channels: ['discord', 'itch.io devlogs'] } }, candidate);
+    expect(t.reached_how).toContain('discord');
+    expect(t.provenance.reached_how.source_field).toBe('synthesis.virality.viral_channels');
+  });
+
+  it('missing sources are DECLARED in incomplete_fields, never silently blanked', () => {
+    const t = buildThesisFromSynthesis({}, {}, {});
+    expect(t.incomplete_fields).toContain('who_pays');
+    expect(t.incomplete_fields).toContain('price_point');
+    expect(t.incomplete_fields).toContain('demand_test_plan');
+    expect(validateVentureThesis(t).valid).toBe(false); // incomplete thesis does not masquerade as valid
+  });
+});
+
+describe('FR-2: kill criteria — machine-consumable contracts', () => {
+  it('round-trip: derived defaults validate and evaluate with pure comparator math', () => {
+    const kills = deriveDefaultKillCriteria(FULL_THESIS);
+    expect(kills.length).toBeGreaterThanOrEqual(2);
+    expect(validateKillCriteria(kills).valid).toBe(true);
+    const demand = kills.find((k) => k.id === 'kill-demand-signals');
+    expect(evaluateKillCriterion(demand, 7)).toMatchObject({ killed: true, observed: 7, threshold: 10 });
+    expect(evaluateKillCriterion(demand, 12)).toMatchObject({ killed: false });
+    for (const k of kills) expect(k.source).toBe('derived_default');
+  });
+
+  it('rejects malformed criteria: bad comparator, non-numeric threshold, stage_by out of range', () => {
+    expect(validateKillCriteria([{ ...VALID_KILLS[0], comparator: 'below' }]).valid).toBe(false);
+    expect(validateKillCriteria([{ ...VALID_KILLS[0], threshold: 'ten' }]).valid).toBe(false);
+    expect(validateKillCriteria([{ ...VALID_KILLS[0], stage_by: 0 }]).valid).toBe(false);
+    expect(validateKillCriteria([{ ...VALID_KILLS[0], stage_by: 27 }]).valid).toBe(false);
+    expect(validateKillCriteria([]).valid).toBe(false);
+  });
+
+  it('an unobservable metric fails CLOSED (cannot prove survival)', () => {
+    const r = evaluateKillCriterion(VALID_KILLS[0], undefined);
+    expect(r.killed).toBe(true);
+    expect(r.reason).toBe('unobservable_metric_fail_closed');
+  });
+
+  it('all five comparators evaluate correctly', () => {
+    const base = { ...VALID_KILLS[0], threshold: 5 };
+    expect(evaluateKillCriterion({ ...base, comparator: 'lt' }, 4).killed).toBe(true);
+    expect(evaluateKillCriterion({ ...base, comparator: 'lte' }, 5).killed).toBe(true);
+    expect(evaluateKillCriterion({ ...base, comparator: 'gt' }, 6).killed).toBe(true);
+    expect(evaluateKillCriterion({ ...base, comparator: 'gte' }, 5).killed).toBe(true);
+    expect(evaluateKillCriterion({ ...base, comparator: 'eq' }, 5).killed).toBe(true);
+    expect(evaluateKillCriterion({ ...base, comparator: 'lt' }, 5).killed).toBe(false);
+  });
+});
+
+describe('FR-3: explicit-decision registry (form factor first)', () => {
+  it('registry pins form_factor: web default, native anti-goal, named native criterion', () => {
+    expect(Object.keys(EXPLICIT_DECISIONS)).toEqual(['form_factor']);
+    expect(EXPLICIT_DECISIONS.form_factor.default).toBe('web');
+    expect(EXPLICIT_DECISIONS.form_factor.allowed).toEqual(['web', 'pwa', 'native']);
+    expect(EXPLICIT_DECISIONS.form_factor.phase1_anti_goal).toBe('native');
+    expect(EXPLICIT_DECISIONS.form_factor.native_criterion).toContain('LOAD-BEARING');
+  });
+
+  it('default build records value, default, decided_by, rationale, and the native criterion', () => {
+    const d = buildExplicitDecisions();
+    expect(d.form_factor).toMatchObject({ value: 'web', default: 'web', decided_by: 'default' });
+    expect(d.form_factor.rationale).toContain('anti-goal');
+    expect(d.form_factor.criterion_for_native).toContain('PWA');
+    expect(validateExplicitDecisions(d).valid).toBe(true);
+  });
+
+  it('a chairman override with an allowed value is recorded as decided_by chairman', () => {
+    const d = buildExplicitDecisions({ form_factor: { value: 'pwa', rationale: 'offline field use, no native need' } });
+    expect(d.form_factor).toMatchObject({ value: 'pwa', decided_by: 'chairman' });
+  });
+
+  it('an invalid override falls back to the declared default (never an unallowed value)', () => {
+    const d = buildExplicitDecisions({ form_factor: { value: 'vr-headset' } });
+    expect(d.form_factor.value).toBe('web');
+    expect(d.form_factor.decided_by).toBe('default');
+  });
+
+  it('validateExplicitDecisions rejects missing keys and unallowed values', () => {
+    expect(validateExplicitDecisions(null).valid).toBe(false);
+    expect(validateExplicitDecisions({}).valid).toBe(false);
+    expect(validateExplicitDecisions({ form_factor: { value: 'desktop', rationale: 'x' } }).valid).toBe(false);
+  });
+});
+
+describe('FR-4: venture-stack-policy consumes the form-factor decision', () => {
+  const CLI_TEXT = 'The product is a CLI tool users install via npm.';
+
+  it('back-compat: no decisions passed -> cli_as_product still fires (declared default governs)', () => {
+    const r = scanTextForStackCompliance([CLI_TEXT]);
+    expect(r.compliant).toBe(false);
+    expect(r.violations.map((v) => v.id)).toContain('cli_as_product');
+    expect(r.skippedRules).toEqual([]);
+  });
+
+  it('an explicit non-web decision skips the rule and SAYS so', () => {
+    const decisions = { form_factor: { value: 'native', decided_by: 'chairman' } };
+    const r = scanTextForStackCompliance([CLI_TEXT], { decisions });
+    expect(r.violations.map((v) => v.id)).not.toContain('cli_as_product');
+    expect(r.skippedRules.map((s) => s.id)).toContain('cli_as_product');
+    expect(r.skippedRules[0].reason).toContain('explicit decision');
+  });
+
+  it('an explicit web/pwa decision keeps the rule active', () => {
+    const r = scanTextForStackCompliance([CLI_TEXT], { decisions: { form_factor: { value: 'pwa' } } });
+    expect(r.violations.map((v) => v.id)).toContain('cli_as_product');
+  });
+
+  it('rules without appliesWhen are unaffected by decisions', () => {
+    const supabaseRule = FORBIDDEN.find((f) => f.id === 'supabase_pkg');
+    expect(ruleApplies(supabaseRule, { form_factor: { value: 'native' } })).toBe(true);
+    const r = scanTextForStackCompliance(['uses @supabase/supabase-js for data'], { decisions: { form_factor: { value: 'native' } } });
+    expect(r.violations.map((v) => v.id)).toContain('supabase_pkg');
+  });
+});

--- a/tests/unit/stage-zero.test.js
+++ b/tests/unit/stage-zero.test.js
@@ -199,6 +199,27 @@ describe('Stage 0 Interfaces', () => {
   });
 
   describe('validateVentureBrief', () => {
+    // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: a valid brief carries the thesis /
+    // kill-criteria / explicit-decisions contract (a thesis-less score is rejected).
+    const CONTRACT = {
+      thesis: {
+        who_pays: 'SMB owners',
+        pays_for_what: 'a solution',
+        reached_how: 'communities',
+        price_point: 'subscription $29/mo',
+        demand_test_plan: [
+          { step: 1, instruction: 'landing page probe', success_signal: '>=10 signups' },
+          { step: 2, instruction: 'pre-order ask', success_signal: '>=3 pre-commitments' },
+        ],
+      },
+      kill_criteria: [
+        { id: 'k1', metric: 'signups', comparator: 'lt', threshold: 10, stage_by: 12, description: 'dies if <10 signups by S12', source: 'derived_default' },
+      ],
+      explicit_decisions: {
+        form_factor: { value: 'web', default: 'web', decided_by: 'default', rationale: 'declared factory default', criterion_for_native: 'OS capability load-bearing' },
+      },
+    };
+
     test('accepts valid brief', () => {
       const brief = {
         name: 'Test Venture',
@@ -208,6 +229,7 @@ describe('Stage 0 Interfaces', () => {
         origin_type: 'discovery',
         raw_chairman_intent: 'Build something great',
         maturity: 'ready',
+        ...CONTRACT,
       };
       const result = validateVentureBrief(brief);
       expect(result.valid).toBe(true);
@@ -216,6 +238,21 @@ describe('Stage 0 Interfaces', () => {
     test('rejects missing required fields', () => {
       const result = validateVentureBrief({ name: 'Test' });
       expect(result.valid).toBe(false);
+    });
+
+    test('rejects a thesis-less brief (SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001)', () => {
+      const brief = {
+        name: 'Test',
+        problem_statement: 'Test',
+        solution: 'Test',
+        target_market: 'Test',
+        origin_type: 'manual',
+        raw_chairman_intent: 'Test',
+        maturity: 'ready',
+      };
+      const result = validateVentureBrief(brief);
+      expect(result.valid).toBe(false);
+      expect(result.errors.join(' ')).toMatch(/thesis contract/);
     });
 
     test('rejects invalid maturity', () => {
@@ -227,6 +264,7 @@ describe('Stage 0 Interfaces', () => {
         origin_type: 'manual',
         raw_chairman_intent: 'Test',
         maturity: 'invalid',
+        ...CONTRACT,
       };
       const result = validateVentureBrief(brief);
       expect(result.valid).toBe(false);
@@ -241,6 +279,7 @@ describe('Stage 0 Interfaces', () => {
         origin_type: 'manual',
         raw_chairman_intent: 'Test',
         maturity: 'blocked',
+        ...CONTRACT,
       };
       expect(validateVentureBrief(brief).valid).toBe(true);
     });
@@ -254,6 +293,7 @@ describe('Stage 0 Interfaces', () => {
         origin_type: 'manual',
         raw_chairman_intent: 'Test',
         maturity: 'nursery',
+        ...CONTRACT,
       };
       expect(validateVentureBrief(brief).valid).toBe(true);
     });


### PR DESCRIPTION
## Summary
- **FR-1**: Stage-0 output is a falsifiable THESIS (who-pays / pays-for-what / reached-how / price + a >=2-step pre-build demand-test plan) — `validateVentureBrief` rejects a thesis-less score; derivation is deterministic from existing candidate/synthesis fields with per-field provenance (`E0 ungraded` labeling for LLM estimates); declared-incomplete theses demote maturity `ready`→`seed`
- **FR-2**: pre-registered kill criteria as machine-consumable contracts (`{metric, comparator, threshold, stage_by}`) with `evaluateKillCriterion` pure comparator math (fail-closed on unobservable metrics) — the S20-26 O2 launch-gate arming seam
- **FR-3**: `EXPLICIT_DECISIONS` registry (form factor first: web default → PWA → named native criterion; native = Phase-1 anti-goal); decisions persisted on the venture record at creation
- **FR-4**: `venture-stack-policy` `cli_as_product` conditioned on the recorded decision via `appliesWhen`/`opts.decisions` (skip-with-stated-reason); no-decision path byte-identical (pinned) — the silent web assumption at `venture-stack-policy.js:57` is retired
- Provenance: deep-challenge commission, Bravo flaw-ledger findings 4 (R3) + 6 (R5), Solomon adjudication 12:21Z; cohort `stage0-fixset-20260710`

## Test plan
- New `tests/unit/eva/stage-zero/thesis-contract.test.js` (23 tests): thesis validation/rejection, scoreless-thesis representability, provenance, kill round-trip + malformed rejection + all comparators + fail-closed, decision registry pin + override semantics, policy consumption + byte-identical back-compat pin
- Pins migrated equal-or-stronger: interfaces complete-brief fixture now carries the contract (+ new thesis-less rejection case); synthesis-engine gains contract-emission and seed-demotion cases
- Sweep: stage-zero + standards + venture-stack-scan **620/620 green**
- LOC justification (>400): single new pure contract module (thesis-contract.js) + its dedicated test suite dominate the count; wiring diffs are surgical

🤖 Generated with [Claude Code](https://claude.com/claude-code)