### PR TITLE
feat(SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001): Stage-0 traversability gate — live capability envelope, fail-closed

### DIFF
--- a/lib/eva/stage-zero/paths/discovery-mode-versions.js
+++ b/lib/eva/stage-zero/paths/discovery-mode-versions.js
@@ -13,7 +13,9 @@
  * and are unreadable in score history. A human-curated string bumps deliberately.
  */
 
-export const TREND_SCANNER_PROMPT_VERSION = '2026-04-28-v2';
+// v3 (SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001): prompt now emits
+// required_capabilities [{name, kind}] per candidate for the traversability gate.
+export const TREND_SCANNER_PROMPT_VERSION = '2026-07-10-v3';
 
 /**
  * Sentinel surfaced by the get_discovery_strategy_scores RPC's COALESCE default

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -24,6 +24,7 @@ import { TREND_SCANNER_PROMPT_VERSION } from './discovery-mode-versions.js';
 import { parseRevenuePotential } from '../utils/parse-revenue.js';
 import { computeStrategicFit } from '../utils/strategic-fit.js';
 import { resolveActivePosture } from '../profile-service.js';
+import { loadCapabilityEnvelope, checkTraversability, parkFailedCandidate } from '../traversability-gate.js';
 
 // ── Typed errors for silent-failure hardening (FR-7) ─────────────────────────
 // Surfaced by callLLMForCandidates / runTrendScanner; mapped to error_details.error_type
@@ -117,21 +118,59 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
   const ranked = rankCandidates(candidates, { weights: posture.criteria.weights, strategicContext });
   logger.log(`   Generated ${ranked.length} candidate(s) under ${posture.posture_version}, top: ${ranked[0].name} (score: ${ranked[0].score})`);
 
-  // Step 4: Select top candidate
-  const top = ranked[0];
+  // Step 3.5: TRAVERSABILITY GATE — hard, in the selection path, not advisory.
+  // SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001 (spec R6): a candidate requiring a
+  // capability absent from the LIVE delivered envelope fails regardless of rank/score.
+  // EnvelopeUnavailableError propagates — the run fails closed, never silently ungated.
+  const envelope = await loadCapabilityEnvelope({ supabase, logger });
+  const gate = checkTraversability(ranked, envelope);
+
+  // Envelope-failed candidates are never silently dropped: park each with a
+  // machine-readable resurfacing condition ('viable when capability X ships').
+  // A parking error is surfaced but does not un-exclude the candidate.
+  const parkingErrors = [];
+  for (const failure of gate.failed) {
+    try {
+      await parkFailedCandidate(failure, { posture_version: posture.posture_version, strategy }, { supabase, logger });
+    } catch (parkErr) {
+      logger.warn(`   Traversability gate: parking failed for '${failure.candidate.name}': ${parkErr.message}`);
+      parkingErrors.push({ candidate: failure.candidate.name, error: parkErr.message });
+    }
+  }
+
+  if (gate.failed.length > 0) {
+    logger.log(`   Traversability gate: ${gate.stats.failed}/${gate.stats.total} candidate(s) excluded (undelivered capability), ${gate.stats.undeclared} undeclared`);
+  }
+
+  if (gate.passed.length === 0) {
+    logger.log('   Traversability gate: no candidate survives the capability envelope. Failures parked to nursery.');
+    return null;
+  }
+
+  // Step 4: Select top candidate — highest-ranked PASSING candidate.
+  const gated = gate.passed;
+  const top = gated[0];
 
   return createPathOutput({
     origin_type: 'discovery',
     raw_material: {
       strategy: strategyConfig,
       constraints,
-      candidates: ranked,
+      candidates: gated,
       top_candidate: top,
       analyzed_at: new Date().toISOString(),
       // Spec R2: every selection run stamps the posture-version it applied, and the
       // governed criteria (hard criteria / anti-goals) ride to the chairman-review surface.
       posture_version: posture.posture_version,
       posture_criteria: posture.criteria,
+      // Spec R6: named envelope failures ride to the chairman-review surface.
+      traversability_failures: gate.failed.map(f => ({
+        name: f.candidate.name,
+        composite_score: f.candidate.composite_score ?? null,
+        missing: f.missing,
+        resurfacing_conditions: f.resurfacing_conditions,
+      })),
+      parking_errors: parkingErrors,
     },
     discovery_strategy: strategy,
     suggested_name: top.name || '',
@@ -154,6 +193,17 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
       // SD-LEO-INFRA-STAGE0-GOVERNED-POSTURE-001 (FR-3): posture-version applied.
       posture_version: posture.posture_version,
       posture_phase_key: posture.phase_key,
+      // SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: gate stats — undeclared is
+      // visible by design (strategies that don't emit requirements yet are never
+      // silently ungated).
+      traversability: {
+        checked: gate.stats.total,
+        passed: gate.stats.passed,
+        failed: gate.stats.failed,
+        undeclared: gate.stats.undeclared,
+        envelope_count: envelope.count,
+        envelope_loaded_at: envelope.loadedAt,
+      },
     },
   });
 }
@@ -256,9 +306,10 @@ For each candidate, provide:
 - monthly_revenue_potential: Estimated $/month
 - competition_level: low/medium/high
 - automation_feasibility: Score 1-10
+- required_capabilities: EVERY factory/external capability this venture depends on to launch, distribute, operate, and collect revenue — form factor/hosting, third-party integrations, distribution channels, ops surface. Each entry: { "name": "capability", "kind": "form_factor" | "integration" | "channel" | "ops" }. The factory hard-checks these against its delivered capability envelope: a venture requiring an undelivered capability is parked until that capability ships, so be complete and honest — where the venture relies on a capability listed in the internal-capabilities context above, use that capability's exact name.
 
 Return a JSON array:
-[{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "monthly_revenue_potential": "string", "competition_level": "string", "automation_feasibility": 8 }]`;
+[{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "monthly_revenue_potential": "string", "competition_level": "string", "automation_feasibility": 8, "required_capabilities": [{ "name": "string", "kind": "integration" }] }]`;
 
   const candidates = await callLLMForCandidates(client, prompt, {
     logger,

--- a/lib/eva/stage-zero/traversability-gate.js
+++ b/lib/eva/stage-zero/traversability-gate.js
@@ -1,0 +1,200 @@
+/**
+ * Stage-0 Traversability Gate
+ * SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001 (spec R6, deep-challenge commission)
+ *
+ * Post-generation HARD gate: every candidate's declared required capabilities are
+ * checked against the LIVE capability envelope (v_unified_capabilities). A candidate
+ * requiring a capability the factory has not delivered FAILS traversability regardless
+ * of rank/score — the stub class begins at selection, and this gate ends it there.
+ *
+ * Design invariants:
+ * - FAIL-CLOSED: an unreachable envelope throws EnvelopeUnavailableError; there is no
+ *   fallback envelope constant and no silent pass (twin of PostureResolutionError).
+ * - MECHANICAL: matching is normalized-name containment only — no fuzzy scoring, no
+ *   LLM judgment inside the gate. Auditability over cleverness.
+ * - HONEST: candidates that declare no requirements PASS but are stamped
+ *   `traversability: 'no_requirements_declared'` and counted — visible, never silent.
+ * - NOT SILENTLY DROPPED: failed candidates park into the LIVE venture_nursery schema
+ *   with machine-readable resurfacing conditions ('viable when capability X ships').
+ *   NOTE: venture-nursery.js parkVenture()/runNurseryReeval() are drifted against the
+ *   live table (flagged separately, feedback ecab6c51) — this module deliberately
+ *   writes the verified live columns and does not call them.
+ */
+
+/** Delivered = the ledger's own claim of what genuinely ships today (spec R6). */
+const DEFAULT_DELIVERED_MATURITY = ['production'];
+
+export class EnvelopeUnavailableError extends Error {
+  /** @param {string} reason - no_supabase_client | view_unavailable
+   *  @param {string} [detail] */
+  constructor(reason, detail) {
+    super(`Capability envelope unavailable (${reason})${detail ? `: ${detail}` : ''} — traversability gate fails closed; selection cannot proceed without the live envelope (spec R6)`);
+    this.name = 'EnvelopeUnavailableError';
+    this.reason = reason;
+  }
+}
+
+/** lowercase, collapse non-alphanumerics to single spaces, trim. */
+export function normalizeCapabilityName(s) {
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+/**
+ * Read the live capability envelope. Fail-closed.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.supabase - required
+ * @param {Object} [deps.logger]
+ * @param {string[]} [deps.deliveredMaturityLevels] - default ['production']
+ * @returns {Promise<{delivered: Object[], deliveredNames: string[], loadedAt: string, count: number}>}
+ * @throws {EnvelopeUnavailableError}
+ */
+export async function loadCapabilityEnvelope(deps = {}) {
+  const { supabase, logger = console, deliveredMaturityLevels = DEFAULT_DELIVERED_MATURITY } = deps;
+
+  if (!supabase) {
+    throw new EnvelopeUnavailableError('no_supabase_client');
+  }
+
+  const { data, error } = await supabase
+    .from('v_unified_capabilities')
+    .select('name, capability_type, maturity_level, scope')
+    .in('maturity_level', deliveredMaturityLevels);
+
+  if (error) {
+    throw new EnvelopeUnavailableError('view_unavailable', error.message);
+  }
+  if (data == null) {
+    throw new EnvelopeUnavailableError('view_unavailable', 'null result with no error');
+  }
+
+  const delivered = data;
+  const deliveredNames = delivered.map(r => normalizeCapabilityName(r.name)).filter(Boolean);
+  logger.log(`   Traversability gate: live envelope loaded — ${delivered.length} delivered capabilit${delivered.length === 1 ? 'y' : 'ies'}`);
+
+  // An EMPTY delivered envelope is an honest (thin) envelope, not an error.
+  return { delivered, deliveredNames, loadedAt: new Date().toISOString(), count: delivered.length };
+}
+
+/** A requirement matches iff a delivered name contains it, or it contains a delivered name. */
+function requirementMatches(reqNameNorm, deliveredNames) {
+  if (!reqNameNorm) return false;
+  return deliveredNames.some(cap => cap && (cap.includes(reqNameNorm) || reqNameNorm.includes(cap)));
+}
+
+/** Accept required_capabilities entries as {name, kind} objects or bare strings. */
+function toRequirement(entry) {
+  if (entry == null) return null;
+  if (typeof entry === 'string') return { name: entry, kind: 'unspecified' };
+  if (typeof entry === 'object' && entry.name) return { name: entry.name, kind: entry.kind || 'unspecified' };
+  return null;
+}
+
+/**
+ * Hard-check candidates against the delivered envelope. Pure and deterministic.
+ *
+ * @param {Object[]} candidates - ranked candidates (may carry required_capabilities)
+ * @param {{deliveredNames: string[]}} envelope - from loadCapabilityEnvelope()
+ * @returns {{passed: Object[], failed: Object[], stats: Object}}
+ */
+export function checkTraversability(candidates, envelope) {
+  if (!envelope || !Array.isArray(envelope.deliveredNames)) {
+    throw new EnvelopeUnavailableError('view_unavailable', 'checkTraversability called without a loaded envelope');
+  }
+
+  const passed = [];
+  const failed = [];
+  let undeclared = 0;
+
+  for (const candidate of candidates || []) {
+    const requirements = (Array.isArray(candidate.required_capabilities) ? candidate.required_capabilities : [])
+      .map(toRequirement)
+      .filter(Boolean);
+
+    if (requirements.length === 0) {
+      undeclared += 1;
+      passed.push({ ...candidate, traversability: 'no_requirements_declared' });
+      continue;
+    }
+
+    const missing = requirements.filter(r => !requirementMatches(normalizeCapabilityName(r.name), envelope.deliveredNames));
+
+    if (missing.length === 0) {
+      passed.push({ ...candidate, traversability: 'passed' });
+    } else {
+      failed.push({
+        candidate,
+        missing,
+        resurfacing_conditions: missing.map(m => ({
+          type: 'capability_ships',
+          capability: m.name,
+          kind: m.kind,
+          condition: `viable when capability ${m.name} ships`,
+        })),
+      });
+    }
+  }
+
+  return {
+    passed,
+    failed,
+    stats: {
+      total: (candidates || []).length,
+      passed: passed.length,
+      failed: failed.length,
+      undeclared,
+    },
+  };
+}
+
+/**
+ * Park an envelope-failed candidate into venture_nursery — the LIVE schema
+ * (name, description, maturity_level ∈ seed|sprout|ready, trigger_conditions jsonb,
+ * current_score, source_type ∈ ...|discovery_mode, source_ref jsonb).
+ *
+ * @param {Object} failure - one entry from checkTraversability().failed
+ * @param {Object} context - { posture_version?, strategy? }
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<Object>} inserted row
+ */
+export async function parkFailedCandidate(failure, context = {}, deps = {}) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+
+  const c = failure.candidate;
+  const missingNames = failure.missing.map(m => m.name).join(', ');
+
+  const { data, error } = await supabase
+    .from('venture_nursery')
+    .insert({
+      name: c.name,
+      description: `${c.problem_statement || ''} → ${c.solution || ''}`.trim() ||
+        `Parked by traversability gate (missing: ${missingNames})`,
+      maturity_level: 'seed',
+      trigger_conditions: failure.resurfacing_conditions,
+      current_score: Number.isFinite(c.composite_score) ? c.composite_score : null,
+      source_type: 'discovery_mode',
+      source_ref: {
+        gate: 'traversability',
+        sd: 'SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001',
+        missing: failure.missing,
+        posture_version: context.posture_version || null,
+        strategy: context.strategy || null,
+        candidate: {
+          name: c.name,
+          problem_statement: c.problem_statement || null,
+          solution: c.solution || null,
+          target_market: c.target_market || null,
+          composite_score: c.composite_score ?? null,
+          prompt_version: c.prompt_version ?? null,
+        },
+      },
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to park envelope-failed candidate '${c.name}': ${error.message}`);
+
+  logger.log(`   Traversability gate: parked '${c.name}' (missing: ${missingNames})`);
+  return data;
+}

--- a/tests/unit/discovery-mode.test.js
+++ b/tests/unit/discovery-mode.test.js
@@ -117,6 +117,12 @@ function createMockSupabase({ strategies = STRATEGY_CONFIGS, nurseryItems = DEFA
           }),
         };
       }
+      if (table === 'v_unified_capabilities') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({ data: TEST_ENVELOPE_ROWS, error: null }),
+        };
+      }
       if (table === 'selection_postures') {
         return {
           select: vi.fn().mockReturnValue({
@@ -154,6 +160,13 @@ const TEST_WEIGHTS = Object.freeze({
   strategic_fit: 0.15,
   competition_level: 0.10,
 });
+
+// SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: executeDiscoveryMode loads the live
+// capability envelope fail-closed; the mock serves delivered (production) rows.
+const TEST_ENVELOPE_ROWS = [
+  { name: 'venture web deploy', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+  { name: 'email delivery', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+];
 const TEST_POSTURE_ROW = {
   id: 'posture-1', phase_key: 'test_posture', version: 1, display_name: 'Test posture',
   criteria: { weights: TEST_WEIGHTS }, status: 'active',

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-failure.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-failure.test.js
@@ -35,6 +35,13 @@ const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
 // SD-LEO-INFRA-STAGE0-GOVERNED-POSTURE-001: executeDiscoveryMode resolves the governed
 // posture fail-closed before ranking; the mock serves an active posture row.
+
+// SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: executeDiscoveryMode loads the live
+// capability envelope fail-closed; the mock serves delivered (production) rows.
+const TEST_ENVELOPE_ROWS = [
+  { name: 'venture web deploy', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+  { name: 'email delivery', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+];
 const TEST_POSTURE_ROW = {
   id: 'posture-1', phase_key: 'test_posture', version: 1,
   criteria: {
@@ -53,6 +60,12 @@ function createSupabase(strategy = { strategy_key: 'trend_scanner', name: 'Trend
   // Each .from() call returns a fresh chainable; supports .select().eq().eq().single() and ranking-data .gte().order().limit()
   return {
     from: vi.fn((table) => {
+      if (table === 'v_unified_capabilities') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({ data: TEST_ENVELOPE_ROWS, error: null }),
+        };
+      }
       if (table === 'selection_postures') {
         return {
           select: vi.fn().mockReturnThis(),

--- a/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
@@ -38,6 +38,13 @@ const TEST_WEIGHTS = Object.freeze({
   strategic_fit: 0.15,
   competition_level: 0.10,
 });
+
+// SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: executeDiscoveryMode loads the live
+// capability envelope fail-closed; the mock serves delivered (production) rows.
+const TEST_ENVELOPE_ROWS = [
+  { name: 'venture web deploy', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+  { name: 'email delivery', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+];
 const TEST_POSTURE_ROW = {
   id: 'posture-1', phase_key: 'test_posture', version: 1, display_name: 'Test posture',
   criteria: { weights: TEST_WEIGHTS }, status: 'active',
@@ -56,7 +63,18 @@ function createMockSupabase(strategyData = null, nurseryItems = []) {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockResolvedValue({ data: [TEST_POSTURE_ROW], error: null }),
   };
-  return { from: vi.fn((table) => (table === 'selection_postures' ? postureChain : chain)), _chain: chain };
+  const envelopeChain = {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ data: TEST_ENVELOPE_ROWS, error: null }),
+  };
+  return {
+    from: vi.fn((table) => {
+      if (table === 'selection_postures') return postureChain;
+      if (table === 'v_unified_capabilities') return envelopeChain;
+      return chain;
+    }),
+    _chain: chain,
+  };
 }
 
 // SD-LEO-ENH-TREND-SCANNER-SCORING-001 (Checkpoint 2): mock now matches the

--- a/tests/unit/eva/stage-zero/traversability-gate.test.js
+++ b/tests/unit/eva/stage-zero/traversability-gate.test.js
@@ -1,0 +1,221 @@
+/**
+ * SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001 (spec R6): traversability gate proofs.
+ *
+ * The three commission success criteria, mechanically:
+ *  1. UNDELIVERABLE CANDIDATES CANNOT WIN — a top-ranked candidate requiring a
+ *     capability absent from the envelope is excluded with the missing capability named.
+ *  2. ENVELOPE IS READ LIVE — adding the capability to the envelope flips the outcome;
+ *     an unreachable view fails closed (EnvelopeUnavailableError, no silent pass).
+ *  3. NURSERY INTEGRATION — failed candidates park with machine-readable resurfacing
+ *     conditions into the LIVE venture_nursery schema, never silently dropped.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  loadCapabilityEnvelope,
+  checkTraversability,
+  parkFailedCandidate,
+  normalizeCapabilityName,
+  EnvelopeUnavailableError,
+} from '../../../../lib/eva/stage-zero/traversability-gate.js';
+import { executeDiscoveryMode } from '../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+const ENVELOPE_ROWS = [
+  { name: 'venture web deploy', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+  { name: 'domain_intelligence', capability_type: 'agent_capability', maturity_level: 'production', scope: 'platform' },
+  { name: 'email delivery', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+];
+
+function envelopeSupabase({ rows = ENVELOPE_ROWS, error = null } = {}) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: error ? null : rows, error }),
+    })),
+  };
+}
+
+function envelopeOf(rows) {
+  return { delivered: rows, deliveredNames: rows.map(r => normalizeCapabilityName(r.name)), loadedAt: 't', count: rows.length };
+}
+
+describe('loadCapabilityEnvelope — live, fail-closed (FR-1)', () => {
+  test('missing supabase client throws no_supabase_client', async () => {
+    await expect(loadCapabilityEnvelope({ logger: silentLogger })).rejects.toMatchObject({ name: 'EnvelopeUnavailableError', reason: 'no_supabase_client' });
+  });
+
+  test('view error throws view_unavailable — no fallback envelope', async () => {
+    const supabase = envelopeSupabase({ error: { message: 'relation missing' } });
+    await expect(loadCapabilityEnvelope({ supabase, logger: silentLogger })).rejects.toMatchObject({ reason: 'view_unavailable' });
+  });
+
+  test('loads delivered rows and normalized names; empty envelope is honest, not an error', async () => {
+    const full = await loadCapabilityEnvelope({ supabase: envelopeSupabase(), logger: silentLogger });
+    expect(full.count).toBe(3);
+    expect(full.deliveredNames).toContain('venture web deploy');
+    expect(full.deliveredNames).toContain('domain intelligence'); // underscore normalized
+
+    const empty = await loadCapabilityEnvelope({ supabase: envelopeSupabase({ rows: [] }), logger: silentLogger });
+    expect(empty.count).toBe(0);
+  });
+});
+
+describe('checkTraversability — hard mechanical check (FR-2)', () => {
+  const topRanked = {
+    name: 'ShopSync', composite_score: 95, problem_statement: 'p', solution: 's', target_market: 'm',
+    required_capabilities: [{ name: 'shopify integration', kind: 'integration' }, { name: 'venture web deploy', kind: 'form_factor' }],
+  };
+  const runnerUp = {
+    name: 'MailBot', composite_score: 80,
+    required_capabilities: [{ name: 'email delivery', kind: 'integration' }],
+  };
+  const undeclared = { name: 'MysteryCo', composite_score: 60 };
+
+  test('SUCCESS CRITERION 1: top-ranked candidate with absent capability is excluded, missing capability NAMED', () => {
+    const result = checkTraversability([topRanked, runnerUp, undeclared], envelopeOf(ENVELOPE_ROWS));
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].candidate.name).toBe('ShopSync');
+    expect(result.failed[0].missing).toEqual([{ name: 'shopify integration', kind: 'integration' }]);
+    expect(result.passed.map(c => c.name)).toEqual(['MailBot', 'MysteryCo']);
+  });
+
+  test('SUCCESS CRITERION 2: adding the capability to the envelope flips the outcome', () => {
+    const grown = envelopeOf([...ENVELOPE_ROWS, { name: 'Shopify integration adapter', maturity_level: 'production' }]);
+    const result = checkTraversability([topRanked], grown);
+    expect(result.failed).toHaveLength(0);
+    expect(result.passed[0].name).toBe('ShopSync');
+    expect(result.passed[0].traversability).toBe('passed');
+  });
+
+  test('no declared requirements passes STAMPED, never silently', () => {
+    const result = checkTraversability([undeclared], envelopeOf(ENVELOPE_ROWS));
+    expect(result.passed[0].traversability).toBe('no_requirements_declared');
+    expect(result.stats.undeclared).toBe(1);
+  });
+
+  test('string-form requirements and containment both directions', () => {
+    const c = { name: 'X', required_capabilities: ['web deploy'] }; // contained in 'venture web deploy'
+    const result = checkTraversability([c], envelopeOf(ENVELOPE_ROWS));
+    expect(result.passed).toHaveLength(1);
+  });
+
+  test('resurfacing conditions are machine-readable per missing capability', () => {
+    const result = checkTraversability([topRanked], envelopeOf(ENVELOPE_ROWS));
+    expect(result.failed[0].resurfacing_conditions).toEqual([
+      { type: 'capability_ships', capability: 'shopify integration', kind: 'integration', condition: 'viable when capability shopify integration ships' },
+    ]);
+  });
+
+  test('throws when called without a loaded envelope (no default)', () => {
+    expect(() => checkTraversability([topRanked], null)).toThrow(EnvelopeUnavailableError);
+  });
+});
+
+describe('parkFailedCandidate — LIVE venture_nursery schema (FR-3 / criterion 3)', () => {
+  test('insert uses live columns with machine-readable trigger_conditions', async () => {
+    const inserted = [];
+    const supabase = {
+      from: vi.fn((table) => ({
+        insert: vi.fn((row) => {
+          inserted.push({ table, row });
+          return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'n1', ...row }, error: null }) }) };
+        }),
+      })),
+    };
+    const failure = {
+      candidate: { name: 'ShopSync', problem_statement: 'p', solution: 's', target_market: 'm', composite_score: 95, prompt_version: 'v3' },
+      missing: [{ name: 'shopify integration', kind: 'integration' }],
+      resurfacing_conditions: [{ type: 'capability_ships', capability: 'shopify integration', kind: 'integration', condition: 'viable when capability shopify integration ships' }],
+    };
+    await parkFailedCandidate(failure, { posture_version: 'phase_1_process_proving@v1', strategy: 'trend_scanner' }, { supabase, logger: silentLogger });
+
+    expect(inserted[0].table).toBe('venture_nursery');
+    const row = inserted[0].row;
+    // Live schema columns only (the drifted parkVenture columns must NOT appear).
+    expect(Object.keys(row).sort()).toEqual(['current_score', 'description', 'maturity_level', 'name', 'source_ref', 'source_type', 'trigger_conditions']);
+    expect(row.maturity_level).toBe('seed');            // live CHECK: seed|sprout|ready
+    expect(row.source_type).toBe('discovery_mode');     // live CHECK includes discovery_mode
+    expect(row.trigger_conditions[0]).toMatchObject({ type: 'capability_ships', capability: 'shopify integration' });
+    expect(row.source_ref.gate).toBe('traversability');
+    expect(row.source_ref.posture_version).toBe('phase_1_process_proving@v1');
+  });
+});
+
+describe('executeDiscoveryMode integration — hard gate in the selection path', () => {
+  const POSTURE_ROW = {
+    id: 'p1', phase_key: 'test_posture', version: 1,
+    criteria: { weights: { automation_feasibility: 0.30, monthly_revenue_potential: 0.25, target_market_specificity: 0.20, strategic_fit: 0.15, competition_level: 0.10 } },
+    status: 'active', ratified_by: 'chairman', ratified_at: '2026-07-10T00:00:00Z',
+  };
+
+  function fullSupabase({ envelopeRows = ENVELOPE_ROWS, envelopeError = null, nurseryInserts = [] } = {}) {
+    const strategyChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { strategy_key: 'trend_scanner', name: 'Trend Scanner', is_active: true }, error: null }),
+      order: vi.fn().mockResolvedValue({ data: [{ strategy_key: 'trend_scanner', is_active: true }], error: null }),
+    };
+    return {
+      from: vi.fn((table) => {
+        if (table === 'selection_postures') {
+          return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockResolvedValue({ data: [POSTURE_ROW], error: null }) };
+        }
+        if (table === 'v_unified_capabilities') {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: envelopeError ? null : envelopeRows, error: envelopeError }) };
+        }
+        if (table === 'venture_nursery') {
+          return {
+            insert: vi.fn((row) => {
+              nurseryInserts.push(row);
+              return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'n1' }, error: null }) }) };
+            }),
+          };
+        }
+        return strategyChain;
+      }),
+    };
+  }
+
+  function llmWith(candidates) {
+    return { _model: 'test-model', complete: vi.fn().mockResolvedValue(JSON.stringify(candidates)) };
+  }
+
+  const CANDIDATES = [
+    // Ranks #1 (feasibility 10, low competition, big revenue) but requires an undelivered capability.
+    { name: 'Undeliverable', problem_statement: 'p', solution: 's', target_market: 'B2B SaaS startups with 50-200 employees', automation_feasibility: 10, competition_level: 'low', monthly_revenue_potential: '$100K/month', required_capabilities: [{ name: 'blockchain settlement', kind: 'integration' }] },
+    { name: 'Deliverable', problem_statement: 'p', solution: 's', target_market: 'B2B SaaS startups with 50-200 employees', automation_feasibility: 7, competition_level: 'medium', monthly_revenue_potential: '$5K/month', required_capabilities: [{ name: 'email delivery', kind: 'integration' }] },
+    { name: 'Quiet', problem_statement: 'p', solution: 's', target_market: 'm', automation_feasibility: 6, competition_level: 'medium', monthly_revenue_potential: '$3K/month' },
+  ];
+
+  test('top-ranked undeliverable candidate cannot win; passing runner-up selected; failure parked + stamped', async () => {
+    const nurseryInserts = [];
+    const supabase = fullSupabase({ nurseryInserts });
+    const result = await executeDiscoveryMode({ strategy: 'trend_scanner' }, { supabase, logger: silentLogger, llmClient: llmWith(CANDIDATES) });
+
+    expect(result.raw_material.top_candidate.name).toBe('Deliverable');
+    expect(result.raw_material.candidates.map(c => c.name)).not.toContain('Undeliverable');
+    expect(result.raw_material.traversability_failures[0]).toMatchObject({ name: 'Undeliverable' });
+    expect(result.raw_material.traversability_failures[0].missing[0].name).toBe('blockchain settlement');
+    expect(result.metadata.traversability).toMatchObject({ checked: 3, passed: 2, failed: 1, undeclared: 1, envelope_count: 3 });
+    expect(nurseryInserts).toHaveLength(1);
+    expect(nurseryInserts[0].name).toBe('Undeliverable');
+  });
+
+  test('FAIL-CLOSED: unreachable envelope aborts the run with no PathOutput', async () => {
+    const supabase = fullSupabase({ envelopeError: { message: 'view gone' } });
+    await expect(
+      executeDiscoveryMode({ strategy: 'trend_scanner' }, { supabase, logger: silentLogger, llmClient: llmWith(CANDIDATES) })
+    ).rejects.toMatchObject({ name: 'EnvelopeUnavailableError', reason: 'view_unavailable' });
+  });
+
+  test('all candidates failing the envelope → parked, run returns null', async () => {
+    const nurseryInserts = [];
+    const supabase = fullSupabase({ envelopeRows: [], nurseryInserts });
+    const allRequire = CANDIDATES.slice(0, 2).map(c => ({ ...c, required_capabilities: [{ name: 'anything at all', kind: 'ops' }] }));
+    const result = await executeDiscoveryMode({ strategy: 'trend_scanner' }, { supabase, logger: silentLogger, llmClient: llmWith([...allRequire, { ...CANDIDATES[2], required_capabilities: [{ name: 'more', kind: 'ops' }] }]) });
+    expect(result).toBeNull();
+    expect(nurseryInserts).toHaveLength(3);
+  });
+});

--- a/tests/unit/stage-zero.test.js
+++ b/tests/unit/stage-zero.test.js
@@ -96,6 +96,16 @@ function createMockSupabase(overrides = {}) {
       chain.insert = vi.fn().mockResolvedValue({ error: null });
     }
 
+    // SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: gate loads the live envelope.
+    if (table === 'v_unified_capabilities') {
+      chain.in = vi.fn().mockResolvedValue({
+        data: [
+          { name: 'venture web deploy', capability_type: 'service', maturity_level: 'production', scope: 'platform' },
+        ],
+        error: null,
+      });
+    }
+
     // SD-LEO-INFRA-STAGE0-GOVERNED-POSTURE-001: discovery ranking resolves the
     // governed posture fail-closed; serve an active posture row.
     if (table === 'selection_postures') {


### PR DESCRIPTION
## Summary
Commission fix (spec R6, Solomon-adjudicated): Stage-0 gains a **post-generation hard gate** — a candidate requiring a capability the factory has not delivered fails traversability **regardless of rank/score**. The stub class begins at selection; this ends it there.

- **traversability-gate.js**: `loadCapabilityEnvelope` reads `v_unified_capabilities` LIVE (delivered = production maturity; unreachable view throws `EnvelopeUnavailableError` — fail-closed, no silent pass, twin of the posture seam). `checkTraversability` is mechanical normalized-name matching — missing capabilities are NAMED per candidate. `parkFailedCandidate` writes the **live** `venture_nursery` schema with machine-readable resurfacing conditions (`viable when capability X ships`) — deliberately not the drifted `parkVenture` (flagged separately, ecab6c51).
- **executeDiscoveryMode**: gate wired between ranking and selection (hard, not advisory). Failures park then get excluded; all-fail → park + null; run record stamps traversability stats + named failures.
- **trend_scanner prompt** now emits `required_capabilities [{name, kind}]` (TREND_SCANNER_PROMPT_VERSION → 2026-07-10-v3). Strategies that don't emit yet pass **stamped** `no_requirements_declared` — visible, never silently ungated.

## Verification
- Gate suite proves all three commission success criteria: top-ranked undeliverable candidate excluded with capability named; envelope change flips the outcome; unreachable view fails closed; failed candidates park with machine-readable conditions into the live nursery schema.
- 645 stage-zero-area tests green (42 files); full unit project: zero new failures vs baseline (same 7 pre-existing, unrelated files).
- Live smoke: 25 delivered capabilities read from the real view.

LOC >100 justified: new gate module + six-scenario proof suite; core integration delta in discovery-mode.js is ~60 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)