### PR TITLE
feat(SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001): E0-E3 evidence grading — ungrounded LLM numbers cannot dominate ranking

### DIFF
--- a/lib/eva/stage-zero/evidence-grading.js
+++ b/lib/eva/stage-zero/evidence-grading.js
@@ -1,0 +1,103 @@
+/**
+ * Stage-0 Evidence Grading
+ * SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (spec R4, deep-challenge commission)
+ *
+ * Every ranking input carries an E0-E3 evidence grade; composites inherit their
+ * weakest input's grade; ungrounded LLM market numerics (E0) can never dominate
+ * a ranking decision — not through the composite, not through a tie-break.
+ *
+ * Grade ladder:
+ *   E0 — ungrounded LLM output (the default for every LLM-emitted field)
+ *   E1 — externally sourced (at least one declared source)
+ *   E2 — corroborated (multiple sources / partial triangulation)
+ *   E3 — externally verified / fully triangulated
+ *
+ * HONEST AT THE SOURCE: a candidate may DECLARE higher grades per field via
+ *   candidate.evidence[field] = { grade, sources?: string[], triangulation?: string[] }
+ * but a declared >E0 grade with no sources and <2 triangulation refs is CLAMPED
+ * back to E0 with a clamp note — no LLM-only path can emit >E0.
+ *
+ * Pure functions only — zero I/O, deterministic, replayable.
+ */
+
+export const GRADE_ORDER = Object.freeze(['E0', 'E1', 'E2', 'E3']);
+
+/** The five posture-weighted ranking inputs (beta seam, PR #5806). */
+export const RANKED_FIELDS = Object.freeze([
+  'automation_feasibility',
+  'monthly_revenue_potential',
+  'target_market_specificity',
+  'strategic_fit',
+  'competition_level',
+]);
+
+/**
+ * Spec R4's hard-rule class: LLM market/revenue numerics with no external source
+ * are E0 by definition and CANNOT dominate a ranking. E0 members of this class are
+ * neutral-flattened in the composite and excluded from tie-breaking. (Judgment
+ * inputs carry the TRIANGULATION duty instead — see TR-1 in the PRD: flattening
+ * E0 judgments would nullify the chairman's ratified Phase-1 posture weights.)
+ */
+export const MARKET_NUMERIC_FIELDS = Object.freeze(['monthly_revenue_potential']);
+
+/** Constant contribution (per unit weight) for a neutral-flattened E0 market numeric. */
+export const E0_NEUTRAL = 0.5;
+
+export function gradeRank(grade) {
+  const i = GRADE_ORDER.indexOf(grade);
+  return i === -1 ? 0 : i;
+}
+
+export function gradeAtLeast(grade, floor) {
+  return gradeRank(grade) >= gradeRank(floor);
+}
+
+/**
+ * Resolve per-field evidence grades for a candidate, clamping unsupported claims.
+ *
+ * @param {Object} candidate - may carry candidate.evidence[field] declarations
+ * @returns {{grades: Object<string,string>, clamps: Array<{field, declared, reason}>}}
+ */
+export function resolveInputGrades(candidate = {}) {
+  const grades = {};
+  const clamps = [];
+  const declared = (candidate.evidence && typeof candidate.evidence === 'object') ? candidate.evidence : {};
+
+  for (const field of RANKED_FIELDS) {
+    const claim = declared[field];
+    if (!claim || typeof claim !== 'object' || !GRADE_ORDER.includes(claim.grade) || claim.grade === 'E0') {
+      grades[field] = 'E0';
+      continue;
+    }
+    const sources = Array.isArray(claim.sources) ? claim.sources.filter(Boolean) : [];
+    const triangulation = Array.isArray(claim.triangulation) ? claim.triangulation.filter(Boolean) : [];
+    if (sources.length > 0 || triangulation.length >= 2) {
+      grades[field] = claim.grade;
+    } else {
+      grades[field] = 'E0';
+      clamps.push({ field, declared: claim.grade, reason: 'unsupported_grade_declaration' });
+    }
+  }
+
+  return { grades, clamps };
+}
+
+/** Weakest-link: a composite judgment's grade is its weakest input's grade. */
+export function weakestLink(grades) {
+  let min = 'E3';
+  for (const field of RANKED_FIELDS) {
+    const g = grades[field] || 'E0';
+    if (gradeRank(g) < gradeRank(min)) min = g;
+  }
+  return min;
+}
+
+/** Distribution of composite grades across a ranked candidate list (for the run stamp). */
+export function gradeDistribution(candidates = []) {
+  const dist = { E0: 0, E1: 0, E2: 0, E3: 0 };
+  for (const c of candidates) {
+    const g = GRADE_ORDER.includes(c.composite_evidence_grade) ? c.composite_evidence_grade : 'E0';
+    dist[g] += 1;
+  }
+  return dist;
+}

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -25,6 +25,7 @@ import { parseRevenuePotential } from '../utils/parse-revenue.js';
 import { computeStrategicFit } from '../utils/strategic-fit.js';
 import { resolveActivePosture } from '../profile-service.js';
 import { loadCapabilityEnvelope, checkTraversability, parkFailedCandidate } from '../traversability-gate.js';
+import { resolveInputGrades, weakestLink, gradeDistribution, gradeAtLeast, E0_NEUTRAL } from '../evidence-grading.js';
 
 // ── Typed errors for silent-failure hardening (FR-7) ─────────────────────────
 // Surfaced by callLLMForCandidates / runTrendScanner; mapped to error_details.error_type
@@ -118,6 +119,19 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
   const ranked = rankCandidates(candidates, { weights: posture.criteria.weights, strategicContext });
   logger.log(`   Generated ${ranked.length} candidate(s) under ${posture.posture_version}, top: ${ranked[0].name} (score: ${ranked[0].score})`);
 
+  // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (FR-3): does the pick ride on ungrounded
+  // margins? Score every candidate with EVERY E0 contribution flattened to neutral; the
+  // run is E0-sensitive when the real winner no longer beats the real runner-up on
+  // grounded (E1+) contributions alone (a tie counts as sensitive — the pick cannot be
+  // justified on evidence). Stamped for the chairman-review surface, not enforced
+  // (enforcement beyond market numerics is the follow-on triangulation machinery).
+  const flatScores = new Map(
+    rankCandidates(candidates, { weights: posture.criteria.weights, strategicContext, flattenAllE0: true })
+      .map(c => [c.name, c.composite_score])
+  );
+  const e0Sensitivity = ranked.length > 1
+    && !(flatScores.get(ranked[0].name) > flatScores.get(ranked[1].name));
+
   // Step 3.5: TRAVERSABILITY GATE — hard, in the selection path, not advisory.
   // SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001 (spec R6): a candidate requiring a
   // capability absent from the LIVE delivered envelope fails regardless of rank/score.
@@ -203,6 +217,13 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
         undeclared: gate.stats.undeclared,
         envelope_count: envelope.count,
         envelope_loaded_at: envelope.loadedAt,
+      },
+      // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (FR-3): evidence-grading stamp.
+      evidence_grading: {
+        policy: 'llm_emitted_defaults_E0',
+        top_composite_grade: top.composite_evidence_grade || 'E0',
+        grade_distribution: gradeDistribution(gated),
+        e0_sensitivity: e0Sensitivity,
       },
     },
   });
@@ -744,23 +765,43 @@ export function rankCandidates(candidates, opts = {}) {
         score, // compat alias preserves callers reading top.score
         parsed_revenue_high: 0,
         score_attribution: ['legacy_v1_formula', 'automation_feasibility', 'competition_level'],
+        // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001: historical rows keep their v1
+        // formula, honestly labeled — both inputs are ungrounded LLM output.
+        evidence_grades: { automation_feasibility: 'E0', competition_level: 'E0' },
+        composite_evidence_grade: 'E0',
+        evidence_clamps: [],
       };
     }
+
+    // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (spec R4): grade every ranking input.
+    // All LLM-emitted fields default E0; declared >E0 grades require sources or
+    // triangulation (else clamped). Weakest link becomes the candidate's composite grade.
+    const { grades, clamps } = resolveInputGrades(c);
 
     const automationFeasibility01 = clamp01(Number(c.automation_feasibility) / 10 || 0);
     const revenue = parseRevenuePotential(c.monthly_revenue_potential);
     const revenueHighRaw = revenue ? revenue.high : 0;
-    const revenue01 = revenueHighRaw > 0 ? clamp01(Math.log10(revenueHighRaw + 1) / 6) : 0; // log10($1M) ≈ 6
+    const revenue01Raw = revenueHighRaw > 0 ? clamp01(Math.log10(revenueHighRaw + 1) / 6) : 0; // log10($1M) ≈ 6
+    // UNGROUNDED-CANNOT-DOMINATE: an E0 market numeric contributes a CONSTANT neutral
+    // value — identical for every candidate — so a hallucinated revenue number can never
+    // differentiate candidates. Grounded (E1+) revenue contributes its real value.
+    const revenue01 = gradeAtLeast(grades.monthly_revenue_potential, 'E1') ? revenue01Raw : E0_NEUTRAL;
     const targetSpec01 = clamp01(scoreTargetMarketSpecificity(c.target_market) / 100);
     const strategicFit01 = clamp01(computeStrategicFit(c, strategicContext) / 100);
     const competition01 = c.competition_level === 'low' ? 1 : c.competition_level === 'medium' ? 0.5 : c.competition_level === 'high' ? 0 : 0.5;
 
+    // e0_sensitivity support (FR-3): same formula with EVERY E0 input flattened to
+    // neutral — used by executeDiscoveryMode to gauge whether the pick rides on
+    // ungrounded margins. Same pathway, no second scoring implementation.
+    const flattenAll = opts.flattenAllE0 === true;
+    const v = (field, value01) => (flattenAll && !gradeAtLeast(grades[field], 'E1') ? E0_NEUTRAL : value01);
+
     const composite =
-      w.automation_feasibility * automationFeasibility01 +
-      w.monthly_revenue_potential * revenue01 +
-      w.target_market_specificity * targetSpec01 +
-      w.strategic_fit * strategicFit01 +
-      w.competition_level * competition01;
+      w.automation_feasibility * v('automation_feasibility', automationFeasibility01) +
+      w.monthly_revenue_potential * v('monthly_revenue_potential', revenue01) +
+      w.target_market_specificity * v('target_market_specificity', targetSpec01) +
+      w.strategic_fit * v('strategic_fit', strategicFit01) +
+      w.competition_level * v('competition_level', competition01);
 
     const composite_score = Math.round(composite * 100); // 0-100 scale
 
@@ -777,12 +818,20 @@ export function rankCandidates(candidates, opts = {}) {
       score: composite_score, // compat alias
       parsed_revenue_high: revenueHighRaw,
       score_attribution: attribution,
+      evidence_grades: grades,
+      composite_evidence_grade: weakestLink(grades),
+      evidence_clamps: clamps,
     };
   });
 
   return enriched.sort((a, b) => {
     if (b.composite_score !== a.composite_score) return b.composite_score - a.composite_score;
-    if (b.parsed_revenue_high !== a.parsed_revenue_high) return b.parsed_revenue_high - a.parsed_revenue_high;
+    // Spec R4: an E0 revenue estimate cannot be the deciding factor — even in a
+    // tie-break. The chairman's Phase-1 'revenue = tiebreaker' semantics operate on
+    // GROUNDED (E1+) revenue only.
+    const revenueGraded = gradeAtLeast(a.evidence_grades?.monthly_revenue_potential || 'E0', 'E1')
+      && gradeAtLeast(b.evidence_grades?.monthly_revenue_potential || 'E0', 'E1');
+    if (revenueGraded && b.parsed_revenue_high !== a.parsed_revenue_high) return b.parsed_revenue_high - a.parsed_revenue_high;
     const aFeas = Number(a.automation_feasibility) || 0;
     const bFeas = Number(b.automation_feasibility) || 0;
     if (bFeas !== aFeas) return bFeas - aFeas;

--- a/lib/eva/stage-zero/utils/parse-revenue.js
+++ b/lib/eva/stage-zero/utils/parse-revenue.js
@@ -67,5 +67,9 @@ export function parseRevenuePotential(input) {
     high = Math.round(high / 12);
   }
 
-  return { low, high, currency: 'USD' };
+  // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (spec R4): an LLM-emitted market numeric
+  // is ungrounded at origin BY DEFINITION — stamped E0 here so no downstream path can
+  // treat a parsed hallucination as evidence. Only a declared external source or
+  // triangulation (candidate.evidence) lifts the grade, never parsing.
+  return { low, high, currency: 'USD', grade: 'E0' };
 }

--- a/tests/unit/eva/stage-zero/evidence-grading.test.js
+++ b/tests/unit/eva/stage-zero/evidence-grading.test.js
@@ -1,0 +1,185 @@
+/**
+ * SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 (spec R4): evidence-grading proofs.
+ *
+ * The three commission success criteria, mechanically:
+ *  1. GRADES END-TO-END — ranking output exposes per-input grades + the
+ *     weakest-link composite grade per candidate.
+ *  2. E0 CANNOT DOMINATE — two candidates differing ONLY in an E0 revenue
+ *     estimate are indistinguishable (identical composite AND no revenue tie-break).
+ *  3. HONEST AT THE SOURCE — parseRevenuePotential stamps E0 at origin; a declared
+ *     >E0 grade with no sources/triangulation is clamped; no LLM-only path emits >E0.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  resolveInputGrades,
+  weakestLink,
+  gradeDistribution,
+  gradeAtLeast,
+  GRADE_ORDER,
+  E0_NEUTRAL,
+} from '../../../../lib/eva/stage-zero/evidence-grading.js';
+import { parseRevenuePotential } from '../../../../lib/eva/stage-zero/utils/parse-revenue.js';
+import { rankCandidates, executeDiscoveryMode } from '../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const v2 = '2026-07-10-v3';
+
+const WEIGHTS_P2 = { // revenue-weighted (Phase-2 shape) — where E0 revenue would bite
+  monthly_revenue_potential: 0.40,
+  automation_feasibility: 0.20,
+  target_market_specificity: 0.15,
+  strategic_fit: 0.15,
+  competition_level: 0.10,
+};
+
+function cand(overrides = {}) {
+  return {
+    name: 'Base', prompt_version: v2,
+    problem_statement: 'p', solution: 's',
+    target_market: 'B2B SaaS startups with 50-200 employees',
+    automation_feasibility: 7, competition_level: 'medium',
+    monthly_revenue_potential: '$5K/month',
+    ...overrides,
+  };
+}
+
+describe('resolveInputGrades — clamp validation (FR-1 / criterion 3)', () => {
+  test('all fields default E0 with no declarations', () => {
+    const { grades, clamps } = resolveInputGrades(cand());
+    expect(Object.values(grades).every(g => g === 'E0')).toBe(true);
+    expect(clamps).toHaveLength(0);
+  });
+
+  test('declared E2 with no sources/triangulation is CLAMPED to E0 with a note', () => {
+    const { grades, clamps } = resolveInputGrades(cand({ evidence: { monthly_revenue_potential: { grade: 'E2' } } }));
+    expect(grades.monthly_revenue_potential).toBe('E0');
+    expect(clamps).toEqual([{ field: 'monthly_revenue_potential', declared: 'E2', reason: 'unsupported_grade_declaration' }]);
+  });
+
+  test('declared E1 with a source lifts; triangulation (>=2 refs) also lifts', () => {
+    const { grades: g1 } = resolveInputGrades(cand({ evidence: { monthly_revenue_potential: { grade: 'E1', sources: ['https://report'] } } }));
+    expect(g1.monthly_revenue_potential).toBe('E1');
+    const { grades: g2 } = resolveInputGrades(cand({ evidence: { automation_feasibility: { grade: 'E2', triangulation: ['lens-a', 'lens-b'] } } }));
+    expect(g2.automation_feasibility).toBe('E2');
+    // Single triangulation ref is NOT enough
+    const { grades: g3, clamps } = resolveInputGrades(cand({ evidence: { automation_feasibility: { grade: 'E2', triangulation: ['lens-a'] } } }));
+    expect(g3.automation_feasibility).toBe('E0');
+    expect(clamps).toHaveLength(1);
+  });
+
+  test('invalid grade strings resolve to E0 without clamp-note noise', () => {
+    const { grades } = resolveInputGrades(cand({ evidence: { competition_level: { grade: 'E9', sources: ['x'] } } }));
+    expect(grades.competition_level).toBe('E0');
+  });
+});
+
+describe('weakest-link propagation (criterion 1)', () => {
+  test('one E0 input among E2s → composite grade E0', () => {
+    expect(weakestLink({
+      automation_feasibility: 'E2', monthly_revenue_potential: 'E2',
+      target_market_specificity: 'E2', strategic_fit: 'E0', competition_level: 'E2',
+    })).toBe('E0');
+  });
+
+  test('all E1 → E1; grade order sane', () => {
+    expect(weakestLink({
+      automation_feasibility: 'E1', monthly_revenue_potential: 'E1',
+      target_market_specificity: 'E1', strategic_fit: 'E1', competition_level: 'E1',
+    })).toBe('E1');
+    expect(GRADE_ORDER).toEqual(['E0', 'E1', 'E2', 'E3']);
+    expect(gradeAtLeast('E2', 'E1')).toBe(true);
+    expect(gradeAtLeast('E0', 'E1')).toBe(false);
+  });
+
+  test('ranked output exposes grades end-to-end', () => {
+    const ranked = rankCandidates([cand()], { weights: WEIGHTS_P2 });
+    expect(ranked[0].evidence_grades).toBeDefined();
+    expect(ranked[0].evidence_grades.monthly_revenue_potential).toBe('E0');
+    expect(ranked[0].composite_evidence_grade).toBe('E0');
+    expect(ranked[0].evidence_clamps).toEqual([]);
+  });
+});
+
+describe('E0 cannot dominate (criterion 2)', () => {
+  test('THE INDISTINGUISHABILITY PROOF: identical except E0 revenue → identical composite, no revenue tie-break', () => {
+    const a = cand({ name: 'Alpha', monthly_revenue_potential: '$500K/month' });
+    const b = cand({ name: 'Beta', monthly_revenue_potential: '$1K/month' });
+    const ranked = rankCandidates([a, b], { weights: WEIGHTS_P2 });
+    // Identical composites — the E0 revenue difference is neutral-flattened.
+    expect(ranked[0].composite_score).toBe(ranked[1].composite_score);
+    // The revenue tie-break did NOT separate them: parsed_revenue_high differs wildly,
+    // yet order fell through to feasibility (equal) then name ASC.
+    expect(ranked[0].parsed_revenue_high).not.toBe(ranked[1].parsed_revenue_high);
+    expect(ranked[0].name).toBe('Alpha'); // name ASC, not HighRev-first
+  });
+
+  test('grounded E1 revenue genuinely differentiates the same pair', () => {
+    const src = { grade: 'E1', sources: ['https://market-report'] };
+    const a = cand({ name: 'Alpha', monthly_revenue_potential: '$500K/month', evidence: { monthly_revenue_potential: src } });
+    const b = cand({ name: 'Beta', monthly_revenue_potential: '$1K/month', evidence: { monthly_revenue_potential: src } });
+    const ranked = rankCandidates([a, b], { weights: WEIGHTS_P2 });
+    expect(ranked[0].composite_score).toBeGreaterThan(ranked[1].composite_score);
+    expect(ranked[0].name).toBe('Alpha');
+    expect(ranked[0].composite_evidence_grade).toBe('E0'); // weakest link: other inputs still E0
+    expect(ranked[0].evidence_grades.monthly_revenue_potential).toBe('E1');
+  });
+
+  test('E0 revenue contributes the neutral constant regardless of magnitude', () => {
+    // Weight everything to revenue: E0 candidates all score round(0.5*100)=50.
+    const w = { monthly_revenue_potential: 1.0, automation_feasibility: 0, target_market_specificity: 0, strategic_fit: 0, competition_level: 0 };
+    const ranked = rankCandidates([cand({ name: 'A', monthly_revenue_potential: '$900K/month' }), cand({ name: 'B', monthly_revenue_potential: '$10/month' })], { weights: w });
+    expect(ranked[0].composite_score).toBe(Math.round(E0_NEUTRAL * 100));
+    expect(ranked[1].composite_score).toBe(Math.round(E0_NEUTRAL * 100));
+  });
+});
+
+describe('honest at the source (criterion 3)', () => {
+  test('parseRevenuePotential stamps grade E0 at origin', () => {
+    expect(parseRevenuePotential('$10K/month')).toEqual({ low: 10000, high: 10000, currency: 'USD', grade: 'E0' });
+    expect(parseRevenuePotential('garbage')).toBeNull();
+  });
+});
+
+describe('run-record stamp + e0_sensitivity (FR-3)', () => {
+  const POSTURE_ROW = {
+    id: 'p1', phase_key: 'test_posture', version: 1,
+    criteria: { weights: WEIGHTS_P2 },
+    status: 'active', ratified_by: 'chairman', ratified_at: '2026-07-10T00:00:00Z',
+  };
+  const ENVELOPE_ROWS = [{ name: 'email delivery', capability_type: 'service', maturity_level: 'production', scope: 'platform' }];
+
+  function fullSupabase() {
+    const strategyChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { strategy_key: 'trend_scanner', name: 'Trend Scanner', is_active: true }, error: null }),
+      order: vi.fn().mockResolvedValue({ data: [{ strategy_key: 'trend_scanner', is_active: true }], error: null }),
+    };
+    return {
+      from: vi.fn((table) => {
+        if (table === 'selection_postures') return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockResolvedValue({ data: [POSTURE_ROW], error: null }) };
+        if (table === 'v_unified_capabilities') return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: ENVELOPE_ROWS, error: null }) };
+        return strategyChain;
+      }),
+    };
+  }
+
+  test('metadata.evidence_grading carries policy, distribution, and e0_sensitivity', async () => {
+    // Winner rides an E0 feasibility margin → flattening all E0 would tie/change the top → sensitive.
+    const candidates = [
+      cand({ name: 'FeasWinner', automation_feasibility: 10, competition_level: 'low' }),
+      cand({ name: 'Runner', automation_feasibility: 4, competition_level: 'high' }),
+      cand({ name: 'Third', automation_feasibility: 5, competition_level: 'high' }),
+    ];
+    const llmClient = { _model: 'test-model', complete: vi.fn().mockResolvedValue(JSON.stringify(candidates)) };
+    const result = await executeDiscoveryMode({ strategy: 'trend_scanner' }, { supabase: fullSupabase(), logger: silentLogger, llmClient });
+
+    const eg = result.metadata.evidence_grading;
+    expect(eg.policy).toBe('llm_emitted_defaults_E0');
+    expect(eg.top_composite_grade).toBe('E0');
+    expect(eg.grade_distribution.E0).toBe(3);
+    expect(eg.e0_sensitivity).toBe(true);
+    expect(gradeDistribution(result.raw_material.candidates).E0).toBe(3);
+  });
+});

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-rank.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-rank.test.js
@@ -113,13 +113,35 @@ describe('rankCandidates - tie-break order', () => {
     };
     // Without strategicContext, fit=50 (neutral) for both; composites will tie.
     // Tie-break should then look at parsed_revenue_high.
+    // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001: the revenue tie-break only fires on
+    // GROUNDED (E1+) revenue — these fixtures declare sourced evidence to exercise it.
+    const E1_REV = { monthly_revenue_potential: { grade: 'E1', sources: ['fixture://market-report'] } };
     const cands = [
-      v2Candidate({ name: 'LowRev', monthly_revenue_potential: '$1K', automation_feasibility: 8 }),
-      v2Candidate({ name: 'HighRev', monthly_revenue_potential: '$50K', automation_feasibility: 4 }),
+      v2Candidate({ name: 'LowRev', monthly_revenue_potential: '$1K', automation_feasibility: 8, evidence: E1_REV }),
+      v2Candidate({ name: 'HighRev', monthly_revenue_potential: '$50K', automation_feasibility: 4, evidence: E1_REV }),
     ];
     const ranked = rankCandidates(cands, { weights: w });
     expect(ranked[0].composite_score).toBe(ranked[1].composite_score); // confirm tie
     expect(ranked[0].name).toBe('HighRev');
+  });
+
+  test('E0 (ungrounded) revenue is EXCLUDED from tie-breaking — feasibility decides instead (spec R4)', () => {
+    const w = {
+      automation_feasibility: 0.0,
+      monthly_revenue_potential: 0.0,
+      target_market_specificity: 0.0,
+      strategic_fit: 1.0,
+      competition_level: 0.0,
+    };
+    // No declared evidence → revenue grade E0 → a hallucinated $50K cannot decide the tie.
+    const cands = [
+      v2Candidate({ name: 'LowRevHighFeas', monthly_revenue_potential: '$1K', automation_feasibility: 8 }),
+      v2Candidate({ name: 'HighRevLowFeas', monthly_revenue_potential: '$50K', automation_feasibility: 4 }),
+    ];
+    const ranked = rankCandidates(cands, { weights: w });
+    expect(ranked[0].composite_score).toBe(ranked[1].composite_score); // tie
+    expect(ranked[0].name).toBe('LowRevHighFeas'); // feasibility tie-break, NOT E0 revenue
+    expect(ranked[0].evidence_grades.monthly_revenue_potential).toBe('E0');
   });
 
   test('automation_feasibility DESC fires when composite + revenue both tie', () => {

--- a/tests/unit/eva/stage-zero/selection-posture.test.js
+++ b/tests/unit/eva/stage-zero/selection-posture.test.js
@@ -102,12 +102,15 @@ describe('resolveActivePosture — fail-closed (FR-2)', () => {
 describe('posture consumption (FR-3)', () => {
   const v2 = '2025-12-trend-scanner-v2';
   const candidates = [
-    // Revenue monster: high revenue, middling automation, vague market.
-    { name: 'RevenueMonster', prompt_version: v2, automation_feasibility: 5, monthly_revenue_potential: '$500K/month', target_market: 'everyone', competition_level: 'medium' },
-    // Simple bot: highly automatable, specific market, no revenue estimate at all
-    // (revenue01=0 — under Phase-2's 0.40 revenue weight this must lose; under
-    // Phase-1's 0.0 revenue weight it must win on simplicity).
-    { name: 'SimpleBot', prompt_version: v2, automation_feasibility: 10, target_market: 'B2B SaaS startups with 50-200 employees in fintech', competition_level: 'low' },
+    // Revenue monster: huge GROUNDED revenue (declared E1 with a source, since
+    // SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001 flattens ungrounded E0 revenue),
+    // middling automation, vague market, low competition.
+    { name: 'RevenueMonster', prompt_version: v2, automation_feasibility: 5, monthly_revenue_potential: '$500K/month', target_market: 'everyone', competition_level: 'low', evidence: { monthly_revenue_potential: { grade: 'E1', sources: ['fixture://market-sizing-report'] } } },
+    // Simple bot: highly automatable, specific market, tiny GROUNDED revenue
+    // (process-proving scale — under Phase-2's 0.40 revenue weight this must lose
+    // to the grounded revenue monster; under Phase-1's 0.0 revenue weight it must
+    // win on simplicity).
+    { name: 'SimpleBot', prompt_version: v2, automation_feasibility: 10, monthly_revenue_potential: '$100/month', target_market: 'B2B SaaS startups with 50-200 employees in fintech', competition_level: 'low', evidence: { monthly_revenue_potential: { grade: 'E1', sources: ['fixture://pilot-invoice'] } } },
   ];
 
   test('rankCandidates without weights throws (no hardcoded posture constants)', () => {

--- a/tests/unit/eva/stage-zero/utils/parse-revenue.test.js
+++ b/tests/unit/eva/stage-zero/utils/parse-revenue.test.js
@@ -8,16 +8,19 @@
 import { describe, test, expect } from 'vitest';
 import { parseRevenuePotential } from '../../../../../lib/eva/stage-zero/utils/parse-revenue.js';
 
+// SD-LEO-INFRA-STAGE0-EVIDENCE-GRADING-001: parsed LLM market numerics are stamped
+// E0 at origin (spec R4) — every expected shape carries grade:'E0'.
+
 describe('parseRevenuePotential — documented input forms (AC-6)', () => {
   const cases = [
-    { input: '$5K/month',          expected: { low: 5000,    high: 5000,    currency: 'USD' } },
-    { input: '$5,000-$50,000/mo',  expected: { low: 5000,    high: 50000,   currency: 'USD' } },
-    { input: '$1K+/month',         expected: { low: 1000,    high: 1000,    currency: 'USD' } },
-    { input: '$500-$2000 monthly', expected: { low: 500,     high: 2000,    currency: 'USD' } },
-    { input: '~$10K MRR',          expected: { low: 10000,   high: 10000,   currency: 'USD' } },
-    { input: '$2K+',               expected: { low: 2000,    high: 2000,    currency: 'USD' } },
-    { input: '$60K/year',          expected: { low: 5000,    high: 5000,    currency: 'USD' } },
-    { input: '$10M/year',          expected: { low: 833333,  high: 833333,  currency: 'USD' } },
+    { input: '$5K/month',          expected: { low: 5000,    high: 5000,    currency: 'USD', grade: 'E0' } },
+    { input: '$5,000-$50,000/mo',  expected: { low: 5000,    high: 50000,   currency: 'USD', grade: 'E0' } },
+    { input: '$1K+/month',         expected: { low: 1000,    high: 1000,    currency: 'USD', grade: 'E0' } },
+    { input: '$500-$2000 monthly', expected: { low: 500,     high: 2000,    currency: 'USD', grade: 'E0' } },
+    { input: '~$10K MRR',          expected: { low: 10000,   high: 10000,   currency: 'USD', grade: 'E0' } },
+    { input: '$2K+',               expected: { low: 2000,    high: 2000,    currency: 'USD', grade: 'E0' } },
+    { input: '$60K/year',          expected: { low: 5000,    high: 5000,    currency: 'USD', grade: 'E0' } },
+    { input: '$10M/year',          expected: { low: 833333,  high: 833333,  currency: 'USD', grade: 'E0' } },
   ];
 
   test.each(cases)('parses "$input" → low/high', ({ input, expected }) => {
@@ -49,46 +52,46 @@ describe('parseRevenuePotential — null fallback (no throws)', () => {
   test('does not throw on weird unicode', () => {
     expect(() => parseRevenuePotential('💰 $5K')).not.toThrow();
     // The regex still extracts $5K → 5000
-    expect(parseRevenuePotential('💰 $5K')).toEqual({ low: 5000, high: 5000, currency: 'USD' });
+    expect(parseRevenuePotential('💰 $5K')).toEqual({ low: 5000, high: 5000, currency: 'USD', grade: 'E0' });
   });
 });
 
 describe('parseRevenuePotential — yearly normalization', () => {
   test('yearly is divided by 12', () => {
-    expect(parseRevenuePotential('$120K/year')).toEqual({ low: 10000, high: 10000, currency: 'USD' });
+    expect(parseRevenuePotential('$120K/year')).toEqual({ low: 10000, high: 10000, currency: 'USD', grade: 'E0' });
   });
 
   test('annual is divided by 12', () => {
-    expect(parseRevenuePotential('$60K annually')).toEqual({ low: 5000, high: 5000, currency: 'USD' });
+    expect(parseRevenuePotential('$60K annually')).toEqual({ low: 5000, high: 5000, currency: 'USD', grade: 'E0' });
   });
 
   test('p.a. is treated as yearly', () => {
-    expect(parseRevenuePotential('$24K p.a.')).toEqual({ low: 2000, high: 2000, currency: 'USD' });
+    expect(parseRevenuePotential('$24K p.a.')).toEqual({ low: 2000, high: 2000, currency: 'USD', grade: 'E0' });
   });
 
   test('default is monthly when ambiguous', () => {
-    expect(parseRevenuePotential('$10K')).toEqual({ low: 10000, high: 10000, currency: 'USD' });
+    expect(parseRevenuePotential('$10K')).toEqual({ low: 10000, high: 10000, currency: 'USD', grade: 'E0' });
   });
 });
 
 describe('parseRevenuePotential — range detection', () => {
   test('hyphen-separated range', () => {
-    expect(parseRevenuePotential('$1K-$5K')).toEqual({ low: 1000, high: 5000, currency: 'USD' });
+    expect(parseRevenuePotential('$1K-$5K')).toEqual({ low: 1000, high: 5000, currency: 'USD', grade: 'E0' });
   });
 
   test('"to" separated range', () => {
-    expect(parseRevenuePotential('$1,000 to $5,000')).toEqual({ low: 1000, high: 5000, currency: 'USD' });
+    expect(parseRevenuePotential('$1,000 to $5,000')).toEqual({ low: 1000, high: 5000, currency: 'USD', grade: 'E0' });
   });
 
   test('comma-numeric ranges parsed correctly', () => {
-    expect(parseRevenuePotential('$5,000-$50,000/mo')).toEqual({ low: 5000, high: 50000, currency: 'USD' });
+    expect(parseRevenuePotential('$5,000-$50,000/mo')).toEqual({ low: 5000, high: 50000, currency: 'USD', grade: 'E0' });
   });
 
   test('decimal shorthand: $5.5K', () => {
-    expect(parseRevenuePotential('$5.5K/month')).toEqual({ low: 5500, high: 5500, currency: 'USD' });
+    expect(parseRevenuePotential('$5.5K/month')).toEqual({ low: 5500, high: 5500, currency: 'USD', grade: 'E0' });
   });
 
   test('billion shorthand: $2B/year', () => {
-    expect(parseRevenuePotential('$2B/year')).toEqual({ low: 166666667, high: 166666667, currency: 'USD' });
+    expect(parseRevenuePotential('$2B/year')).toEqual({ low: 166666667, high: 166666667, currency: 'USD', grade: 'E0' });
   });
 });


### PR DESCRIPTION
## Summary
CRITICAL commission fix (spec R4, Solomon-adjudicated): Stage-0 ranking gains **evidence grading** on the beta posture seam.

- **E0-E3 grades** on every ranking input; LLM-emitted fields default **E0**; declared higher grades require sources or ≥2 triangulation refs else **clamped** — no LLM-only path emits >E0.
- **Weakest-link propagation**: each candidate exposes `evidence_grades` + `composite_evidence_grade` (= weakest input).
- **Ungrounded cannot dominate**: E0 revenue is neutral-flattened in the composite (identical constant for every candidate) **and** excluded from the `parsed_revenue_high` tie-break — two candidates differing only in an E0 revenue estimate are literally indistinguishable. Grounded (E1+) revenue contributes its real value and may tie-break, so the chairman's Phase-1 'revenue = tiebreaker' semantics operate on grounded revenue.
- `parseRevenuePotential` stamps **E0 at origin**; runs stamp `metadata.evidence_grading` incl. `grade_distribution` and an `e0_sensitivity` gauge (winner can't beat runner-up on grounded contributions alone).
- Judgment inputs (feasibility/fit/competition) are graded + visible but not flattened — spec R4 assigns them the **triangulation** duty (follow-on executor), and flattening them would nullify the ratified Phase-1 posture weights (TR-1 in the PRD).

## Verification
- New suite: indistinguishability proof, clamp validation, weakest-link, origin stamp, E0 tie-break exclusion, run stamp + sensitivity.
- 662 stage-zero tests green (44 files); sanctioned fixture-evidence diffs in 3 suites (posture switch-proof now rides grounded E1 revenue — a stronger proof).
- Full unit project: zero new failures vs the 7-failure pre-existing baseline.
- Live behavior today is numerically unchanged (active Phase-1 posture has revenue weight 0.0); the flatten bites exactly where sanctioned — revenue-weighted postures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)