### PR TITLE
docs(SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C): document coordinator reservation fence

### DIFF
--- a/docs/reference/dispatch-authorization-audit.md
+++ b/docs/reference/dispatch-authorization-audit.md
@@ -4,7 +4,7 @@
 **Status**: Approved
 **Version**: 1.0.0
 **Author**: Claude (EXEC, SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001)
-**Last Updated**: 2026-07-10
+**Last Updated**: 2026-07-10 (added `coordinatorReservation` row, SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C)
 **Tags**: dispatch-authorization, claim-eligibility, kind-a, kind-b, fail-open, fail-closed
 
 ## Purpose
@@ -60,6 +60,7 @@ FR-1 mirror-kill already covers is explicitly out of scope — see that SD's TR-
 | tier axes (`min_tier_rank`, `worker_tier_rank`, lower-tier-backlog) | claim-eligibility.cjs | B | fail-open when `ctx` absent | Capability/fit, not approval; explicitly no-op when `ctx` is undefined (directed-assign's FR-1 call always passes `ctx=undefined`). |
 | `metadata.fleet_critical === true` | worker-checkin.cjs | B (promotion) | n/a | Lifts an SD *into* the visible pool; still routes back through the classifier afterward (a fleet_critical + review-pending SD is correctly excluded — "the hold wins"). |
 | `metadata.self_claim === false`, `metadata.availability === 'idle_only'`, `metadata.coordinator_stand_down === true` | worker-checkin.cjs (self-claim gate predicate) | **out of scope** | fail-toward-active | **Worker-session** availability — a different axis entirely from SD-dispatch approval (governs whether a *worker* self-claims, not whether an *SD* is authorized). Documented here for completeness; not part of this audit's Kind-A/B scope. |
+| `coordinatorReservation(row, ctx)` — `ctx.reservations[row.sd_key]` active fence (NEW, SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C) | claim-eligibility.cjs | **not a `metadata.<flag>` predicate** | fail-open (`ctx.reservations` absent ⇒ eligible) | Reads a `ctx`-threaded fence sourced from a `session_coordination` row (`payload.kind='coordinator_reservation'`), not from `row.metadata` — outside this audit's literal metadata-flag scope, listed here for completeness since it lives in the SAME `INELIGIBILITY_AXES` table. Closer to Kind-A in spirit (a coordinator directive IS the boundary) but deliberately fail-open per-row on read/auth failure (TR-3) rather than fail-closed, since the fence is advisory-turned-block only while an active, coordinator-authenticated row exists. See [Fleet Coordination — Coordinator Reservation Fence](./fleet-coordination.md#coordinator-reservation-fence). |
 
 ## Findings
 

--- a/docs/reference/fleet-coordination.md
+++ b/docs/reference/fleet-coordination.md
@@ -1,10 +1,10 @@
 ---
 category: Reference
 status: Draft
-version: 1.1.0
+version: 1.2.0
 author: Claude Code
-last_updated: 2026-04-16
-tags: [fleet, coordinator, workers, sessions, coordination, monte-carlo, liveness]
+last_updated: 2026-07-10
+tags: [fleet, coordinator, workers, sessions, coordination, monte-carlo, liveness, reservation-fence]
 ---
 
 # Fleet Coordination System
@@ -215,6 +215,49 @@ Claims are tracked via `claude_sessions.sd_id`. A partial unique index enforces 
 | Release claim | `UPDATE claude_sessions SET sd_id = NULL, released_at = NOW()` |
 | Check claims | `SELECT * FROM claude_sessions WHERE sd_id IS NOT NULL AND status != 'terminated'` |
 | Fix stuck | `UPDATE claude_sessions SET sd_id=NULL, status='idle', released_at=NOW() WHERE session_id='...'` |
+
+## Coordinator Reservation Fence
+
+SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C: a coordinator can fence a specific
+SD to a specific session or worker tier for a time window, so the belt self-claim
+loop cannot grab it out from under an intended claimant. Fixes a live incident where
+a Fable-reserved worker seat belt-claimed a Sonnet-lane SD before a directed
+assignment could land.
+
+**Payload convention** — `payload.kind='coordinator_reservation'` on a
+`session_coordination` row with `message_type='INFO'`, `target_sd` set to the
+fenced SD key, `target_session=NULL` (broadcast — every candidate session must be
+able to read it, and it must never be auto-consumed by the first reader), and the
+native `expires_at` column for the window (default 1h). `payload` carries
+`reserved_for_session` and/or `reserved_for_tier` (the exemption). Registered in
+`PAYLOAD_KINDS` (`lib/fleet/worker-status.cjs`) — deliberately **not** in
+`DIRECTIVE_KINDS`, since a fence is a standing state row, not an action-required
+directive.
+
+**Read path** — `lib/checkin/steps/drain-reservations.cjs`, a checkin pipeline step
+positioned strictly after `adopt-orphan.cjs` and before `self-claim-gates.cjs` (so
+directed `WORK_ASSIGNMENT` dispatch, stranded/orphan recovery, and own-claim resume
+are structurally unaffected — they all run earlier). Read-only: never stamps
+`read_at`/`acknowledged_at` on the row it reads. Only honors rows whose
+`sender_session` matches the live active coordinator (`ctx.coordinatorId`) —
+defense-in-depth against a buggy (not malicious) worker self-fencing a claim
+monopoly. Fails open on any read error (never blocks the rest of self-claim).
+
+**Enforcement** — `coordinatorReservation(row, ctx)`, an axis in
+`lib/fleet/claim-eligibility.cjs`'s `INELIGIBILITY_AXES`, positioned before the
+tier axes (a reservation is more specific than the general worker-tier ladder).
+Self-compares `expires_at > now()` rather than trusting the row's continued
+existence — `cleanup_expired_coordination()` GC lags to the next
+stale-session-sweep tick, so an expired-but-not-yet-GC'd row must not still fence.
+Ctx-gated: absent `ctx.reservations` is byte-identical to pre-SD behavior for every
+other classifier caller (sweep, sd-start, directed-assign).
+
+**Worker breadcrumb** — when a tick actually skips a candidate due to an active
+fence, `worker-checkin.cjs`'s JSON output gains a `reservation_fences_skipped[]`
+array and the top-level `message` gets an explicit "deliberate, working as
+intended, no action needed" note, so an autonomous worker doesn't mistake a fence
+for a stuck belt and file a false RCA/`/signal stuck`. Purely additive — no new
+`action` enum value.
 
 ## Probabilistic Liveness (Monte Carlo)
 


### PR DESCRIPTION
## Summary
- Documents the `coordinator_reservation` payload.kind primitive shipped in PR #5812 in `docs/reference/fleet-coordination.md` (new "Coordinator Reservation Fence" section) and `docs/reference/dispatch-authorization-audit.md` (new classification-table row, cross-referenced).

## Test plan
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)