### PR TITLE
feat(harness): S20-26 simulated-run RUNNER — Charlie slice (H3+H4+H6+H7)

### DIFF
--- a/lib/harness/run-journal.mjs
+++ b/lib/harness/run-journal.mjs
@@ -77,9 +77,21 @@ export class RunJournal {
     return row;
   }
 
-  /** Convenience: journal a first-class finding. */
+  /**
+   * Convenience: journal a first-class finding. `detail.o_requirements` is
+   * LIFTED to the top-level field so checkCoverage() counts the finding toward
+   * its requirement (§H3: a CANNOT_DRIVE finding IS coverage — Charlie-slice
+   * fix; previously findings carried the mapping only inside detail, invisible
+   * to the coverage matrix).
+   */
   finding(findingType, event, detail = {}) {
-    return this.append({ kind: 'finding', finding_type: findingType, event, detail });
+    return this.append({
+      kind: 'finding',
+      finding_type: findingType,
+      event,
+      o_requirements: detail.o_requirements || [],
+      detail,
+    });
   }
 
   /** Read the full journal back (array of events, seq order). */

--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * S20-26 SIMULATED FULL-LIFE RUN — the owning-seat runner (Charlie slice:
+ * §H3 instrumentation/coverage + §H4 synthetic drivers + §H6 containment sweep +
+ * §H7 checkpoint-resume band ladder), built on the Bravo slice (§H1 fixture,
+ * §H2/§H3 RunJournal, §H9 calibration). Spec:
+ * docs/design/s20-26-simulated-run-harness-spec.md; O-requirements:
+ * docs/design/s20-26-operations-greenfield-spec.md.
+ *
+ * INSTRUMENT-DON'T-MOCK (§H2): every band runs the REAL machinery —
+ * stage-execution-engine.executeStage() for the stage's analysis + artifact
+ * persistence, then artifact-persistence-service.advanceStage() so the REAL
+ * exit-gate enforcer + binding gate-debt checks fire. A gate BLOCK is an
+ * OBSERVATION (that is the machinery working), never an abort: per §H7 the run
+ * records the finding and CONTINUES from the next drivable point — the product
+ * is the band's drivability map, not a crash log of its first gap.
+ *
+ * §H4 DRIVERS: after the go-live band (S24), the runner attempts each synthetic
+ * driver (stranger visitor, conversion, test-rail payment + attribution,
+ * support ticket, incident, injected-clock review cadence). A driver whose
+ * machinery does not exist in this repo journals a first-class CANNOT_DRIVE
+ * finding mapped to its O-requirement — the honest form of coverage.
+ *
+ * §H5/§H6 FENCES: the enumerated allowed-divergence set below is the ONLY
+ * sanctioned test-mode surface; the runner journals every fence it exercises
+ * and ends with the scheduler-residue + touched-tables containment sweep
+ * (teardown itself is a separate explicit step: s20-fixture.mjs teardown).
+ *
+ * §H7 CHECKPOINT-RESUME: band completion is journaled; a re-run with the same
+ * --run-id SKIPS completed bands (the journal is the continuation point;
+ * ownership never transfers). Clock is injectable (--clock ISO) and advanced
+ * per band (--clock-step-hours) so cadence logic never wall-clock-waits.
+ *
+ * Usage:
+ *   node scripts/harness/s20-run.mjs run    --run-id <id> [--entry-stage 20] [--to-stage 26]
+ *                                           [--clock 2026-07-12T09:00:00Z] [--clock-step-hours 24]
+ *                                           [--create-fixture] [--sweep-only]
+ *   node scripts/harness/s20-run.mjs status --run-id <id>
+ */
+import 'dotenv/config';
+import { createRequire } from 'node:module';
+import { RunJournal } from '../../lib/harness/run-journal.mjs';
+import { createFixture, findFixtureVentureId, assertClean } from './s20-fixture.mjs';
+
+const require = createRequire(import.meta.url);
+const { createClient } = require('@supabase/supabase-js');
+
+/** §H2/§H5: the ONLY sanctioned divergences from production behavior. */
+export const ALLOWED_DIVERGENCES = Object.freeze([
+  'stripe_test_keys',          // H5.1 — test-rail payments only
+  'preview_only_deploy',       // H5.2 — preview() leg, never promote; plan-mode without adapters
+  'sandboxed_outreach',        // H5.3 — zero real sends; degraded-mode email redirect
+  'mock_registrar',            // H5.4 — no domain purchases
+  'no_marketlens_signups',     // H5.5 — live MarketLens untouched
+  'synthetic_fixture_venture', // H5.6 — is_demo/is_synthetic fixture, teardown-cascaded
+  'coordinator_routed_gate',   // H5.7 — demand execution_gate satisfied with explicit test provenance via coordinator
+  'injected_clock',            // H4 — clock advancement, never wall-clock waits
+]);
+
+/**
+ * §H3: per-band O-requirement mapping (what each stage's machinery, when it
+ * fires, is evidence OF). Coverage closes over this + the post-launch drivers.
+ */
+export const STAGE_O_MAP = Object.freeze({
+  20: ['O2'],             // build execution / code quality toward launch gate-crossing
+  21: ['O3'],             // demand PLAN (Stage-21 artifact-only by design)
+  22: ['O3', 'O9'],       // distribution setup (channel envelope honesty)
+  23: ['O2'],             // launch readiness = the gate-crossing precondition
+  24: ['O1', 'O2', 'O4'], // go-live (simulated mode, labeled) + external-observation gauges
+  25: ['O4', 'O7', 'O8'], // post-launch review: provenance-reached metrics, feedback loop, review cadence
+  26: ['O7', 'O8'],       // growth playbook: retention loop + scale-or-exit input
+});
+
+/** §H4 post-launch synthetic drivers, each mapped to its O-requirement. */
+export const POST_LAUNCH_DRIVERS = Object.freeze([
+  { key: 'stranger_visitor', o: ['O3'], desc: 'scripted stranger-visitor against the preview deploy' },
+  { key: 'conversion_event', o: ['O3', 'O7'], desc: 'synthetic conversion event' },
+  { key: 'test_rail_payment', o: ['O6'], desc: 'Stripe test-key payment -> attribution assertion' },
+  { key: 'support_ticket', o: ['O5'], desc: 'synthetic support ticket -> triage observation' },
+  { key: 'incident_probe', o: ['O5'], desc: 'synthetic incident (tripped health probe) -> remediation/escalation' },
+  { key: 'review_cadence', o: ['O8'], desc: 'injected-clock advancement -> post-launch review cadence fires' },
+]);
+
+export const ALL_O_REQUIREMENTS = Object.freeze(['O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7', 'O8', 'O9', 'O10']);
+
+/** Injectable stepping clock (§H4): starts at a fixed ISO, advances on demand. */
+export function makeSteppingClock(startIso, stepHours = 24) {
+  let t = Date.parse(startIso);
+  if (!Number.isFinite(t)) throw new Error(`invalid --clock '${startIso}'`);
+  return {
+    now: () => new Date(t).toISOString(),
+    step: () => { t += stepHours * 3600 * 1000; return new Date(t).toISOString(); },
+  };
+}
+
+/** §H7 resume: bands already journaled complete for this run id. */
+export function completedBands(journal) {
+  const done = new Set();
+  for (const e of journal.readAll()) {
+    if (e.kind === 'checkpoint' && e.detail?.band_complete) done.add(e.detail.band_complete);
+  }
+  return done;
+}
+
+function makeClient() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+/**
+ * Run one stage band through the REAL machinery: executeStage -> journal ->
+ * advanceStage (real exit gates). Returns { advanced } — a block is journaled
+ * as an observation of the live gate, never thrown past the band.
+ */
+export async function runBand({ supabase, journal, ventureId, stage, clock, logger = console, seams = {} }) {
+  const oReqs = STAGE_O_MAP[stage] || [];
+  const executeStage = seams.executeStage || (await import('../../lib/eva/stage-execution-engine.js')).executeStage;
+  const advanceStage = seams.advanceStage || (await import('../../lib/eva/artifact-persistence-service.js')).advanceStage;
+
+  // 1. The stage's own machinery (analysis step + artifact persistence).
+  let exec;
+  try {
+    exec = await executeStage({ stageNumber: stage, ventureId, supabase, logger });
+    journal.append({
+      kind: 'observation',
+      event: `S${stage} executeStage ran (template=${exec.template || 'n/a'}, valid=${exec.validation?.valid !== false})`,
+      o_requirements: oReqs,
+      touched_tables: ['venture_artifacts', 'system_events'],
+      detail: { artifact_id: exec.artifactId || null, policy_halt: exec.output?.policy_halt || false },
+    });
+  } catch (e) {
+    journal.finding('CANNOT_DRIVE', `S${stage} executeStage threw: ${String(e.message).slice(0, 300)}`, { o_requirements: oReqs, stage });
+    journal.append({ kind: 'checkpoint', event: `band S${stage} checkpoint (execute failed, continuing)`, detail: { band_complete: stage } });
+    return { advanced: false, executed: false };
+  }
+
+  // 2. The REAL advance path — exit-gate enforcer + binding gate-debt fire here.
+  try {
+    await advanceStage(supabase, { ventureId, fromStage: stage, toStage: stage + 1, handoffData: { harness: true } });
+    journal.append({
+      kind: 'observation',
+      event: `S${stage} -> S${stage + 1} advanced through the REAL gate path (exit-gate enforcer + gate debt)`,
+      o_requirements: oReqs,
+      touched_tables: ['ventures', 'venture_stage_work'],
+    });
+    journal.append({ kind: 'checkpoint', event: `band S${stage} complete`, detail: { band_complete: stage } });
+    return { advanced: true, executed: true };
+  } catch (e) {
+    // A live gate block IS machinery evidence (never an abort — §H7).
+    journal.append({
+      kind: 'observation',
+      event: `S${stage} advance BLOCKED by live gates: ${String(e.message).slice(0, 400)}`,
+      o_requirements: [...oReqs, 'O2'],
+      touched_tables: ['system_events'],
+      detail: { blocked: true, at_clock: clock.now() },
+    });
+    journal.append({ kind: 'checkpoint', event: `band S${stage} checkpoint (advance blocked — drivability edge)`, detail: { band_complete: stage } });
+    return { advanced: false, executed: true };
+  }
+}
+
+/**
+ * §H4 post-launch drivers. Each driver either exercises real machinery or
+ * journals an honest CANNOT_DRIVE with the reason the surface is undrivable
+ * from this repo today. `seams` lets tests (and future wiring) inject drivers.
+ */
+export async function runPostLaunchDrivers({ supabase, journal, ventureId, clock, seams = {} }) {
+  for (const driver of POST_LAUNCH_DRIVERS) {
+    const impl = seams[driver.key];
+    if (impl) {
+      try {
+        const detail = await impl({ supabase, ventureId, clock, journal });
+        journal.append({ kind: 'observation', event: `driver ${driver.key} fired: ${driver.desc}`, o_requirements: driver.o, touched_tables: detail?.touched_tables || [], detail: detail || {} });
+        continue;
+      } catch (e) {
+        journal.finding('CANNOT_DRIVE', `driver ${driver.key} threw: ${String(e.message).slice(0, 300)}`, { o_requirements: driver.o });
+        continue;
+      }
+    }
+    // No implementation seam yet — the honest default per §H7: first-class finding.
+    const reason = {
+      stranger_visitor: 'no preview deploy exists for the fixture (preview() runs plan-mode without adapters — blocked_on_credentials by design, H5.2)',
+      conversion_event: 'depends on stranger_visitor reaching a live preview surface',
+      test_rail_payment: 'no payment-attribution machinery found in EHG_Engineer lib/ (attribution rail lives with the venture app; O6 undrivable from the platform repo alone)',
+      support_ticket: 'no support-ticket/triage machinery found in lib/ (O5 loop not built)',
+      incident_probe: 'no health-probe/remediation loop callable for a fixture venture (O5 loop not built)',
+      review_cadence: 'post-launch review cadence has no pre-scheduled machinery to fire under an injected clock (O8 scheduler absent)',
+    }[driver.key] || 'no driver seam wired';
+    journal.finding('CANNOT_DRIVE', `driver ${driver.key}: ${reason}`, { o_requirements: driver.o, at_clock: clock.now() });
+  }
+}
+
+/** §H6 containment sweep (run-level; teardown is the separate explicit step). */
+export async function containmentSweep({ supabase, journal, runId, ventureId }) {
+  // Fence 6: ghost-venture scheduler residue must be zero DURING the run too.
+  for (const table of ['eva_scheduler_queue', 'eva_scheduler_metrics']) {
+    const { count, error } = await supabase.from(table).select('*', { count: 'exact', head: true }).eq('venture_id', ventureId);
+    if (error) {
+      journal.finding('NO_DATA_GAUGE', `containment: ${table} unverifiable: ${error.message}`, { table });
+    } else if ((count ?? 0) > 0) {
+      journal.finding('RESIDUE', `containment: ${count} ${table} row(s) reference the fixture MID-RUN (ghost-venture class)`, { table, count });
+    } else {
+      journal.append({ kind: 'fence_assertion', event: `containment: zero ${table} rows for fixture`, detail: { table } });
+    }
+  }
+  // Enumerated divergences the run exercises are journaled up-front for the diff auditor.
+  for (const d of ALLOWED_DIVERGENCES) journal.assertDivergenceAllowed(d, [...ALLOWED_DIVERGENCES], { declared_upfront: true });
+  journal.append({ kind: 'fence_assertion', event: 'containment sweep complete', detail: { run_id: runId } });
+}
+
+export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart, clockStepHours = 24, createFixtureFirst = false, sweepOnly = false, supabase: sb, seams = {}, baseDir } = {}) {
+  const supabase = sb || makeClient();
+  const clock = makeSteppingClock(clockStart || new Date().toISOString(), clockStepHours);
+  const journal = new RunJournal(runId, { clock: clock.now, ...(baseDir ? { baseDir } : {}) });
+
+  let ventureId = await findFixtureVentureId(supabase, runId);
+  if (!ventureId && createFixtureFirst) {
+    const created = await createFixture(supabase, runId, { entryStage, journal });
+    ventureId = created.ventureId;
+  }
+  if (!ventureId) throw new Error(`no fixture venture for run ${runId} — create one first (s20-fixture.mjs create --run-id ${runId} or pass --create-fixture)`);
+
+  journal.append({ kind: 'lifecycle', event: `run arc started (S${entryStage}..S${toStage})`, detail: { venture_id: ventureId, clock: clock.now() } });
+
+  if (!sweepOnly) {
+    const done = completedBands(journal);
+    for (let stage = entryStage; stage <= toStage; stage++) {
+      if (done.has(stage)) { journal.append({ kind: 'lifecycle', event: `band S${stage} already complete — resumed past it (§H7)` }); continue; }
+      await runBand({ supabase, journal, ventureId, stage, clock, seams });
+      clock.step(); // injected-clock advancement between bands (never wall-clock waits)
+    }
+    await runPostLaunchDrivers({ supabase, journal, ventureId, clock, seams });
+  }
+
+  await containmentSweep({ supabase, journal, runId, ventureId });
+
+  // §H3 coverage close-out: every O-requirement observed or first-class-found.
+  const coverage = journal.checkCoverage([...ALL_O_REQUIREMENTS]);
+  for (const f of coverage.findings) journal.append({ kind: 'finding', finding_type: f.finding_type, event: f.event, o_requirements: f.o_requirements, detail: {} });
+  journal.append({ kind: 'lifecycle', event: `run arc pass complete: covered=${coverage.covered.join(',') || 'none'} uncovered=${coverage.uncovered.join(',') || 'none'}`, detail: { coverage } });
+
+  return { runId, ventureId, coverage, journalPath: journal.path };
+}
+
+async function main() {
+  const [mode, ...args] = process.argv.slice(2);
+  const flag = (name, dflt) => { const i = args.indexOf(`--${name}`); return i >= 0 ? args[i + 1] : dflt; };
+  const runId = flag('run-id', null);
+  if (!runId) { console.error('--run-id required'); process.exit(2); }
+
+  if (mode === 'run') {
+    const res = await runArc({
+      runId,
+      entryStage: Number(flag('entry-stage', 20)),
+      toStage: Number(flag('to-stage', 26)),
+      clockStart: flag('clock', undefined),
+      clockStepHours: Number(flag('clock-step-hours', 24)),
+      createFixtureFirst: args.includes('--create-fixture'),
+      sweepOnly: args.includes('--sweep-only'),
+    });
+    console.log(`HARNESS_RUN_PASS run=${res.runId} venture=${res.ventureId} covered=${res.coverage.covered.length}/${ALL_O_REQUIREMENTS.length} journal=${res.journalPath}`);
+    process.exit(0);
+  } else if (mode === 'status') {
+    const journal = new RunJournal(runId);
+    const events = journal.readAll();
+    const findings = events.filter((e) => e.kind === 'finding');
+    console.log(`HARNESS_RUN_STATUS run=${runId} events=${events.length} findings=${findings.length} bands_complete=${[...completedBands(journal)].join(',') || 'none'}`);
+    for (const f of findings) console.log(`  FINDING ${f.finding_type}: ${f.event}`);
+    process.exit(0);
+  } else {
+    console.error('Usage: s20-run.mjs run --run-id <id> [...] | status --run-id <id>');
+    process.exit(2);
+  }
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop())) {
+  main().catch((e) => { console.error('HARNESS_RUN_ERROR', e.message); process.exit(1); });
+}

--- a/tests/unit/harness/s20-runner.test.js
+++ b/tests/unit/harness/s20-runner.test.js
@@ -1,0 +1,159 @@
+/**
+ * S20-26 harness RUNNER (Charlie slice — §H3/§H4/§H6/§H7) unit pins.
+ * Pure-local: injected seams + fake supabase + fixed clock; no DB, no LLM.
+ *
+ * @module tests/unit/harness/s20-runner.test
+ */
+import { describe, it, expect, vi, afterAll } from 'vitest';
+import { rmSync } from 'node:fs';
+import {
+  ALLOWED_DIVERGENCES, STAGE_O_MAP, POST_LAUNCH_DRIVERS, ALL_O_REQUIREMENTS,
+  makeSteppingClock, completedBands, runBand, runPostLaunchDrivers, runArc,
+} from '../../../scripts/harness/s20-run.mjs';
+import { RunJournal } from '../../../lib/harness/run-journal.mjs';
+
+const BASE = '.harness-runs-test';
+afterAll(() => { try { rmSync(BASE, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+const fixedClock = () => '2026-07-12T09:00:00.000Z';
+
+function fakeSupabase({ ventureExists = true, schedulerRows = 0 } = {}) {
+  return {
+    from: (table) => ({
+      select: () => ({
+        eq: (col, _val) => {
+          if (table === 'ventures' && col === 'name') {
+            return { maybeSingle: async () => ({ data: ventureExists ? { id: 'v-fixture' } : null }) };
+          }
+          // count-head queries (scheduler residue)
+          return Promise.resolve({ count: table.startsWith('eva_scheduler') ? schedulerRows : 0, error: null });
+        },
+      }),
+    }),
+  };
+}
+
+describe('runner constants (§H2/§H3 shape pins)', () => {
+  it('the allowed-divergence set is exactly the enumerated H5 fences + injected clock', () => {
+    expect([...ALLOWED_DIVERGENCES].sort()).toEqual([
+      'coordinator_routed_gate', 'injected_clock', 'mock_registrar', 'no_marketlens_signups',
+      'preview_only_deploy', 'sandboxed_outreach', 'stripe_test_keys', 'synthetic_fixture_venture',
+    ]);
+  });
+
+  it('every band S20..S26 maps to >=1 O-requirement, and band+driver maps reach every O except O10', () => {
+    for (let s = 20; s <= 26; s++) expect((STAGE_O_MAP[s] || []).length, `S${s}`).toBeGreaterThan(0);
+    const reachable = new Set();
+    for (const os of Object.values(STAGE_O_MAP)) for (const o of os) reachable.add(o);
+    for (const d of POST_LAUNCH_DRIVERS) for (const o of d.o) reachable.add(o);
+    const missing = ALL_O_REQUIREMENTS.filter((o) => !reachable.has(o));
+    // O10 is the acceptance requirement — satisfied by the run itself (coverage close-out),
+    // so it is the only one allowed to be unreachable from bands/drivers.
+    expect(missing).toEqual(['O10']);
+  });
+
+  it('stepping clock: fixed start, deterministic step, never wall-clock', () => {
+    const c = makeSteppingClock('2026-07-12T09:00:00Z', 24);
+    expect(c.now()).toBe('2026-07-12T09:00:00.000Z');
+    c.step();
+    expect(c.now()).toBe('2026-07-13T09:00:00.000Z');
+  });
+});
+
+describe('runBand (§H2 instrument-don\'t-mock, §H7 never-abort)', () => {
+  it('executes the real seams, journals the observation with O-mapping, advances, checkpoints the band', async () => {
+    const journal = new RunJournal('t-band-ok', { baseDir: BASE, clock: fixedClock });
+    const executeStage = vi.fn(async () => ({ template: 'stage-20', artifactId: 'a1', validation: { valid: true }, output: {} }));
+    const advanceStage = vi.fn(async () => ({}));
+    const r = await runBand({ supabase: {}, journal, ventureId: 'v1', stage: 20, clock: { now: fixedClock }, seams: { executeStage, advanceStage } });
+    expect(r).toEqual({ advanced: true, executed: true });
+    expect(executeStage).toHaveBeenCalledWith(expect.objectContaining({ stageNumber: 20, ventureId: 'v1' }));
+    expect(advanceStage).toHaveBeenCalledWith({}, expect.objectContaining({ fromStage: 20, toStage: 21 }));
+    const events = journal.readAll();
+    expect(events.find((e) => e.kind === 'observation' && e.event.includes('S20 executeStage')).o_requirements).toEqual(['O2']);
+    expect(events.find((e) => e.kind === 'checkpoint').detail.band_complete).toBe(20);
+  });
+
+  it('a live gate BLOCK is journaled as an OBSERVATION and the band checkpoints — never throws (§H7)', async () => {
+    const journal = new RunJournal('t-band-blocked', { baseDir: BASE, clock: fixedClock });
+    const executeStage = vi.fn(async () => ({ artifactId: 'a1', validation: { valid: true }, output: {} }));
+    const advanceStage = vi.fn(async () => { throw new Error('advanceStage blocked by exit-gate enforcer. Blocked by: demand_gate'); });
+    const r = await runBand({ supabase: {}, journal, ventureId: 'v1', stage: 22, clock: { now: fixedClock }, seams: { executeStage, advanceStage } });
+    expect(r).toEqual({ advanced: false, executed: true });
+    const blockedObs = journal.readAll().find((e) => e.event.includes('BLOCKED by live gates'));
+    expect(blockedObs.kind).toBe('observation');
+    expect(blockedObs.detail.blocked).toBe(true);
+  });
+
+  it('an executeStage crash lands as CANNOT_DRIVE and the run continues (checkpoint written)', async () => {
+    const journal = new RunJournal('t-band-crash', { baseDir: BASE, clock: fixedClock });
+    const executeStage = vi.fn(async () => { throw new Error('template missing'); });
+    const r = await runBand({ supabase: {}, journal, ventureId: 'v1', stage: 25, clock: { now: fixedClock }, seams: { executeStage, advanceStage: vi.fn() } });
+    expect(r).toEqual({ advanced: false, executed: false });
+    const finding = journal.readAll().find((e) => e.kind === 'finding');
+    expect(finding.finding_type).toBe('CANNOT_DRIVE');
+    expect(journal.readAll().some((e) => e.kind === 'checkpoint')).toBe(true);
+  });
+});
+
+describe('post-launch drivers (§H4 honest defaults)', () => {
+  it('unwired drivers journal first-class CANNOT_DRIVE findings mapped to their O-requirements', async () => {
+    const journal = new RunJournal('t-drivers-default', { baseDir: BASE, clock: fixedClock });
+    await runPostLaunchDrivers({ supabase: {}, journal, ventureId: 'v1', clock: { now: fixedClock } });
+    const findings = journal.readAll().filter((e) => e.kind === 'finding');
+    expect(findings).toHaveLength(POST_LAUNCH_DRIVERS.length);
+    const o6 = findings.find((f) => f.event.includes('test_rail_payment'));
+    expect(o6.finding_type).toBe('CANNOT_DRIVE');
+    expect(o6.detail.o_requirements).toEqual(['O6']);
+  });
+
+  it('a wired driver seam runs and journals an observation; a throwing seam lands as CANNOT_DRIVE', async () => {
+    const journal = new RunJournal('t-drivers-wired', { baseDir: BASE, clock: fixedClock });
+    const seams = {
+      stranger_visitor: vi.fn(async () => ({ touched_tables: ['preview_hits'] })),
+      conversion_event: vi.fn(async () => { throw new Error('no conversion endpoint'); }),
+    };
+    await runPostLaunchDrivers({ supabase: {}, journal, ventureId: 'v1', clock: { now: fixedClock }, seams });
+    const events = journal.readAll();
+    expect(events.find((e) => e.event.includes('driver stranger_visitor fired')).kind).toBe('observation');
+    expect(events.find((e) => e.event.includes('conversion_event threw')).finding_type).toBe('CANNOT_DRIVE');
+    expect(journal.touchedTables()).toContain('preview_hits');
+  });
+});
+
+describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
+  it('resumes past completed bands (journal is the continuation point) and closes coverage over O1..O10', async () => {
+    const runId = 't-arc-resume';
+    const pre = new RunJournal(runId, { baseDir: BASE, clock: fixedClock });
+    pre.append({ kind: 'checkpoint', event: 'band S20 complete', detail: { band_complete: 20 } });
+    expect(completedBands(pre).has(20)).toBe(true);
+
+    const executeStage = vi.fn(async ({ stageNumber }) => ({ template: `stage-${stageNumber}`, artifactId: 'a', validation: { valid: true }, output: {} }));
+    const advanceStage = vi.fn(async () => ({}));
+    const res = await runArc({
+      runId, entryStage: 20, toStage: 22, clockStart: '2026-07-12T09:00:00Z',
+      supabase: fakeSupabase(), seams: { executeStage, advanceStage }, baseDir: BASE,
+    });
+    // S20 skipped (resumed), S21+S22 executed.
+    expect(executeStage.mock.calls.map((c) => c[0].stageNumber)).toEqual([21, 22]);
+    // Coverage close-out ran: uncovered requirements landed as findings (drivers were default CANNOT_DRIVE, which COUNTS as covered).
+    expect(res.coverage.covered).toEqual(expect.arrayContaining(['O3', 'O5', 'O6', 'O8']));
+    // O10 (acceptance) has no band/driver — must end as a DEAD_LOOP coverage finding, proving the matrix bites.
+    expect(res.coverage.uncovered).toContain('O10');
+    const journal = new RunJournal(runId, { baseDir: BASE, clock: fixedClock });
+    expect(journal.readAll().some((e) => e.kind === 'finding' && (e.detail.o_requirements || e.o_requirements || []).includes('O10'))).toBe(true);
+  });
+
+  it('containment sweep journals scheduler residue as a RESIDUE finding when rows exist mid-run', async () => {
+    const executeStage = vi.fn(async () => ({ artifactId: 'a', validation: { valid: true }, output: {} }));
+    const res = await runArc({
+      runId: 't-arc-residue', entryStage: 21, toStage: 21, clockStart: '2026-07-12T09:00:00Z',
+      supabase: fakeSupabase({ schedulerRows: 3 }), seams: { executeStage, advanceStage: vi.fn(async () => ({})) }, baseDir: BASE,
+    });
+    const journal = new RunJournal('t-arc-residue', { baseDir: BASE, clock: fixedClock });
+    const residue = journal.readAll().filter((e) => e.finding_type === 'RESIDUE');
+    expect(residue.length).toBeGreaterThanOrEqual(1);
+    expect(residue[0].event).toMatch(/ghost-venture class/);
+    expect(res.ventureId).toBe('v-fixture');
+  });
+});


### PR DESCRIPTION
## Summary
The owning-seat run arc (spec §H7: one seat owns spec-consume → build → Saturday run → ledger) built on Bravo's substrate (#5816: H1 fixture, H2/H3 journal, H9 calibration):
- **Band ladder S20..S26 through REAL machinery** (§H2): `executeStage()` per stage, then `advanceStage()` so the live exit-gate enforcer + binding gate-debt checks fire. A live gate BLOCK is journaled as an **observation** and the band checkpoints — never an abort; the weekend's product is the drivability map (§H7).
- **§H4 drivers** (stranger visitor / conversion / test-rail payment / support ticket / incident / injected-clock review cadence) with injectable seams; the honest default journals a first-class **CANNOT_DRIVE** finding mapped to its O-requirement (e.g. O6 payment attribution has no platform-repo machinery — that finding IS the audit data).
- **§H7 checkpoint-resume**: band completion journaled; re-running the same `--run-id` skips completed bands. **Injected stepping clock** — never wall-clock waits.
- **§H5/§H6**: the enumerated allowed-divergence set (7 fences + injected clock) declared through the config-diff seam; mid-run containment sweep asserts zero scheduler ghost-venture residue.
- **§H3 coverage close-out** over O1..O10; uncovered requirements land as DEAD_LOOP findings.
- **Journal fix (additive)**: `finding()` lifts `detail.o_requirements` to the top level so `checkCoverage()` counts findings as coverage — previously CANNOT_DRIVE findings were invisible to the matrix they exist to feed.

## Test plan
- 10 new runner pins (never-abort on block/crash, resume-skips-bands, honest driver defaults + wired-seam path, containment RESIDUE finding, allowed-divergence shape, O-map completeness incl. the deliberate O10 coverage-bite check) — 22/22 across `tests/unit/harness/` with Bravo's suite green unmodified.
- §H9 calibration: **GO** (seeded dead-loop + broken-gauge + unenumerated-divergence all detected).
- eslint + node --check clean. NOTE: `tests/unit/harness/leo-create-flags-parity.test.js` has 1 pre-existing failure reproducing on unmodified main (unrelated pin, another seat's regression — reported separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)