### PR TITLE
fix(QF-20260710-467): persist posture fields in chairman-review metadata

### DIFF
--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -156,6 +156,16 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
             build_estimate: brief.build_estimate,
             cross_references: brief.cross_references,
             chairman_constraint_scores: brief.chairman_constraint_scores,
+            // CH-7 (QF-20260710-467, Solomon adjudication a8eafc72, Charlie R1-R10 ledger
+            // #5815): posture_version rides the run through synthesis but was dropped here —
+            // the R9 reproducibility/provenance chain broke at the record with the longest
+            // retention. Null-coalesced: posture is only resolved for the discovery_mode
+            // strategy (other origin paths never had one to lose).
+            posture: {
+              posture_version: brief.metadata?.posture_version ?? null,
+              posture_phase_key: brief.metadata?.posture_phase_key ?? null,
+              weights_used: brief.metadata?.posture_criteria?.weights ?? null,
+            },
             origin_metadata: {
               competitor_urls: brief.competitor_ref,
               blueprint_id: brief.blueprint_id,

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -207,6 +207,10 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
       // SD-LEO-INFRA-STAGE0-GOVERNED-POSTURE-001 (FR-3): posture-version applied.
       posture_version: posture.posture_version,
       posture_phase_key: posture.phase_key,
+      // CH-7 (QF-20260710-467): the governed criteria/weights this run applied, so the
+      // chairman-review write site can persist them alongside posture_version instead of
+      // dropping them at venture creation (mirrors raw_material.posture_criteria above).
+      posture_criteria: posture.criteria,
       // SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001: gate stats — undeclared is
       // visible by design (strategies that don't emit requirements yet are never
       // silently ungated).

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -213,6 +213,45 @@ describe('ChairmanReview', () => {
       expect(insertArg.seeded_from_venture_id).toBeNull();
     });
 
+    // CH-7 (QF-20260710-467): posture_version + weights_used must survive to the venture
+    // record instead of dying at creation — the R9 reproducibility chain's longest-retention
+    // stop.
+    it('persists posture_version/posture_phase_key/weights_used when the brief carries a posture stamp', async () => {
+      const mockSupabase = createMockSupabase();
+      const briefWithPosture = {
+        ...validBrief,
+        metadata: {
+          posture_version: 'discovery@v3',
+          posture_phase_key: 'discovery',
+          posture_criteria: { weights: { moat: 0.4, market: 0.6 } },
+        },
+      };
+      await persistVentureBrief(
+        { decision: 'ready', brief: briefWithPosture, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      const insertArg = mockSupabase._mockChain.insert.mock.calls[0][0];
+      expect(insertArg.metadata.stage_zero.posture).toEqual({
+        posture_version: 'discovery@v3',
+        posture_phase_key: 'discovery',
+        weights_used: { moat: 0.4, market: 0.6 },
+      });
+    });
+
+    it('null-coalesces posture fields for a brief with no posture stamp (non-discovery paths)', async () => {
+      const mockSupabase = createMockSupabase();
+      await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      const insertArg = mockSupabase._mockChain.insert.mock.calls[0][0];
+      expect(insertArg.metadata.stage_zero.posture).toEqual({
+        posture_version: null,
+        posture_phase_key: null,
+        weights_used: null,
+      });
+    });
+
     it('should throw on DB error when inserting venture', async () => {
       const mockSupabase = createMockSupabase({
         single: vi.fn().mockResolvedValue({

--- a/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
@@ -188,6 +188,9 @@ describe('executeDiscoveryMode', () => {
     // Governed-posture stamp (spec R2): the run records the posture-version it applied.
     expect(result.metadata.posture_version).toBe('test_posture@v1');
     expect(result.raw_material.posture_version).toBe('test_posture@v1');
+    // CH-7 (QF-20260710-467): the applied weights must also reach metadata (not just
+    // raw_material, which is discarded before the chairman-review write site).
+    expect(result.metadata.posture_criteria).toEqual(result.raw_material.posture_criteria);
   });
 });
 


### PR DESCRIPTION
## Summary
- CH-7 fix: `posture_version`/`posture_phase_key`/weights now survive to the venture record's `metadata.stage_zero.posture` block instead of dying at venture creation.
- Threads `posture_criteria` through `discovery-mode.js`'s PathOutput metadata (posture_version/posture_phase_key were already there) so it reaches `chairman-review.js`'s write site one hop away, matching the existing `origin_metadata.prompt_version` null-coalesce convention.

## Test plan
- [x] `npx vitest run tests/unit/eva/stage-zero/chairman-review.test.js tests/unit/eva/stage-zero/paths/discovery-mode.test.js tests/unit/eva/stage-zero/selection-posture.test.js tests/unit/eva/stage-zero/traversability-gate.test.js` — 46/46 passing, including 2 new regression tests (posture-present + posture-absent/null-coalesced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)