### PR TITLE
fix(SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001): ready mints a PENDING chairman decision and PAUSES

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -377,6 +377,13 @@ export async function createOrReusePendingDecision({
   // hardcoded 1 at the DB level (no caller in this codebase ever incremented it before now) --
   // omit this param to preserve that exact pre-existing behavior for every other caller.
   attemptNumber = null,
+  // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: stage 0 is deliberately ABSENT from
+  // stage_config (adding it would break the TS-7 decision-creating-set parity test and feed
+  // can_auto_advance/stage-execution machinery), so stage_creates_decision(0) returns false and
+  // this helper would self-skip. The Stage-0 ready path — the one caller that IS the gate — passes
+  // forceDecisionCreation:true to skip ONLY the stage predicate. The fixture-venture guard below
+  // still runs first and wins: test/demo ventures never mint even with this flag.
+  forceDecisionCreation = false,
   supabase,
   logger = console,
 }) {
@@ -395,10 +402,14 @@ export async function createOrReusePendingDecision({
   // SD-LEO-REFAC-GATE-DECISION-CREATION-001 FR-2: stage_config-derived gate check.
   // Predicate now lives in RPC stage_creates_decision (FALLBACK_DECISION_CREATING_STAGES
   // used only when RPC is unavailable). Existing observability log line preserved.
-  const gate = await isDecisionCreatingStage(stageNumber, supabase, { logger });
-  if (!gate.creates_decision) {
-    logger.log(`[Decision] Skipping decision creation for non-gate stage ${stageNumber}`);
-    return { id: null, isNew: false, skipped: true };
+  // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: skipped only under forceDecisionCreation
+  // (Stage-0 chairman gate — see the param doc above).
+  if (!forceDecisionCreation) {
+    const gate = await isDecisionCreatingStage(stageNumber, supabase, { logger });
+    if (!gate.creates_decision) {
+      logger.log(`[Decision] Skipping decision creation for non-gate stage ${stageNumber}`);
+      return { id: null, isNew: false, skipped: true };
+    }
   }
 
   // Only reuse PENDING decisions of the SAME decision_type — never reuse approved decisions from

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -11,7 +11,10 @@
 
 import { validateVentureBrief } from './interfaces.js';
 import { parkVenture } from './venture-nursery.js';
-import { createOrReusePendingDecision as _createOrReusePendingDecision } from '../chairman-decision-watcher.js';
+// SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: the real chairman gate, un-parked.
+// A 'ready' verdict mints a PENDING decision and pauses — the machine RANKS, the chairman PICKS
+// (spec R7; Delta-C1 / Solomon FIX-2 shape, advisory a8eafc72).
+import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { toDbArchetype } from './synthesis/archetype-mapping.js';
 
@@ -133,7 +136,10 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
         // for all other paths. current_lifecycle_stage stays 1 so the clone re-runs S0 fresh.
         seeded_from_venture_id: brief.seeded_from_venture_id || brief.metadata?.seeded_from_venture_id || null,
         current_lifecycle_stage: 1,
-        status: 'active',
+        // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: 'ready' PAUSES — the venture is
+        // born paused-awaiting and only the activation consumer (decision-activation.js) flips it
+        // active on an authentic chairman approval. Never insert active here.
+        status: 'paused',
         company_id: companyId,
         metadata: {
           // SD-LEO-INFRA-STAGE0-THESIS-CONTRACT-001: the thesis + pre-registered kill
@@ -144,6 +150,13 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
           kill_criteria: brief.kill_criteria || null,
           explicit_decisions: brief.explicit_decisions || null,
           stage_zero: {
+            // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: the pause contract the
+            // activation consumer (decision-activation.js) keys on — cleared on activation.
+            awaiting_chairman_decision: true,
+            pause_provenance: {
+              minted_by: 'stage0-chairman-gate',
+              paused_at: new Date().toISOString(),
+            },
             // SD-LEO-FIX-FIX-STAGE-QUEUE-001: durable request→venture link (idempotency anchor).
             stage_zero_request_id: requestId,
             solution: brief.solution,
@@ -191,35 +204,27 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
           .maybeSingle();
         if (existingVenture) {
           logger.warn(`   Venture "${brief.name}" already active (${existingVenture.id}); returning existing (idempotent stale-claim re-run).`);
+          // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: if the original run died between
+          // the venture insert and the gate mint, the paused-awaiting venture has no pending
+          // decision and would wedge forever. The mint is reuse-safe (createOrReusePendingDecision
+          // returns the existing PENDING row), so re-mint here for paused-awaiting ventures. No
+          // compensating cancel on this path — the venture pre-existed this run.
+          if (existingVenture.status === 'paused' && existingVenture.metadata?.stage_zero?.awaiting_chairman_decision === true) {
+            const reusedDecisionId = await mintStageZeroGate(existingVenture, brief, { supabase, logger, compensateOnFailure: false });
+            return { ...existingVenture, stage_zero_decision_id: reusedDecisionId };
+          }
           return existingVenture;
         }
       }
       throw new Error(`Failed to create venture: ${error.message}`);
     }
 
-    // SD-LEO-FIX-FIX-STAGE-VENTURE-001: Record chairman decision AFTER venture creation
-    try {
-      const decisionStatus = decision === 'ready' ? 'approved' : 'rejected';
-      await supabase
-        .from('chairman_decisions')
-        .insert({
-          venture_id: venture.id,
-          lifecycle_stage: 0,
-          status: decisionStatus,
-          decision: 'proceed',
-          summary: 'Stage 0: Venture approved for Stage 1',
-          brief_data: {
-            name: brief.name,
-            problem_statement: brief.problem_statement,
-            solution: brief.solution,
-            target_market: brief.target_market,
-            archetype: brief.archetype,
-          },
-          rationale: 'Venture meets readiness criteria',
-        });
-    } catch (err) {
-      logger.warn(`   Chairman decision record failed (non-fatal): ${err.message}`);
-    }
+    // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: mint the REAL chairman gate.
+    // This replaces the deleted machine-forged approval insert (status='approved' with a canned
+    // rationale — Delta-C1). The mint is FAIL-CLOSED (flaw H5 class): a ready venture without a
+    // pending decision must never exist, so a mint failure compensates the venture to cancelled
+    // and rethrows instead of warn-and-continue.
+    const decisionId = await mintStageZeroGate(venture, brief, { supabase, logger });
 
     // Persist Stage 0 artifact via Unified Persistence Service
     try {
@@ -240,9 +245,9 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
     await persistBriefRecord(brief, venture.id, deps);
 
     logger.log(`   Venture created: ${venture.id}`);
-    logger.log('   Status: Ready for Stage 1');
+    logger.log(`   Status: PAUSED awaiting chairman decision${decisionId ? ` (${decisionId})` : ''}`);
 
-    return venture;
+    return { ...venture, stage_zero_decision_id: decisionId };
   }
 
   // Park in Venture Nursery via parkVenture() for proper trigger/review tracking
@@ -259,6 +264,69 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
   logger.log(`   Maturity: ${brief.maturity}`);
 
   return nurseryEntry;
+}
+
+/**
+ * SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: mint the Stage-0 chairman gate.
+ *
+ * Creates (or reuses) a PENDING chairman_decisions row for the paused venture via the same
+ * machinery every other gate stage uses. forceDecisionCreation skips only the stage_creates_decision
+ * predicate — stage 0 is deliberately absent from stage_config (see chairman-decision-watcher.js).
+ * Fixture ventures (is_demo) still never mint; they stay paused as inert test data.
+ *
+ * Fail-closed: on mint failure the venture is compensated to status='cancelled' (fresh-create path
+ * only — compensateOnFailure:false on the idempotent re-run path where the venture pre-existed)
+ * and the error is rethrown so the request records 'failed' instead of silently succeeding.
+ *
+ * @param {Object} venture - The created (or existing) ventures row
+ * @param {Object} brief - The venture brief
+ * @param {Object} deps - { supabase, logger, compensateOnFailure }
+ * @returns {Promise<string|null>} The decision id (null when skipped for a fixture venture)
+ */
+async function mintStageZeroGate(venture, brief, { supabase, logger = console, compensateOnFailure = true }) {
+  try {
+    const minted = await createOrReusePendingDecision({
+      ventureId: venture.id,
+      stageNumber: 0,
+      decisionType: 'stage_gate',
+      summary: 'Stage 0: venture awaiting chairman approval',
+      briefData: {
+        name: brief.name,
+        problem_statement: brief.problem_statement,
+        solution: brief.solution,
+        target_market: brief.target_market,
+        archetype: brief.archetype,
+        venture_score: brief.metadata?.venture_score ?? null,
+        provenance: { minted_by: 'stage0-machine', chairman_action_required: true },
+      },
+      forceDecisionCreation: true,
+      supabase,
+      logger,
+    });
+    return minted?.id || null;
+  } catch (err) {
+    if (compensateOnFailure) {
+      try {
+        await supabase
+          .from('ventures')
+          .update({
+            status: 'cancelled',
+            metadata: {
+              ...(venture.metadata || {}),
+              stage_zero: {
+                ...(venture.metadata?.stage_zero || {}),
+                awaiting_chairman_decision: false,
+                cancellation_reason: 'stage0_decision_mint_failed',
+              },
+            },
+          })
+          .eq('id', venture.id);
+      } catch (compErr) {
+        logger.warn(`   Compensating cancel failed for venture ${venture.id}: ${compErr.message}`);
+      }
+    }
+    throw new Error(`Stage-0 chairman gate mint failed (fail-closed): ${err.message}`);
+  }
 }
 
 /**

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -307,20 +307,40 @@ async function mintStageZeroGate(venture, brief, { supabase, logger = console, c
   } catch (err) {
     if (compensateOnFailure) {
       try {
-        await supabase
-          .from('ventures')
-          .update({
-            status: 'cancelled',
-            metadata: {
-              ...(venture.metadata || {}),
-              stage_zero: {
-                ...(venture.metadata?.stage_zero || {}),
-                awaiting_chairman_decision: false,
-                cancellation_reason: 'stage0_decision_mint_failed',
+        // Adversarial-review round 1: NEVER cancel a venture that already has a live PENDING
+        // gate decision — a concurrent duplicate-name request (23505 re-mint path) may have
+        // minted one between our insert and our failed mint; cancelling would strand that live
+        // decision in the chairman queue (approving it later becomes a silent no-op). If this
+        // check itself fails, fail toward PAUSE (skip the cancel, retryable) — never toward
+        // losing a chairman-visible decision.
+        const { data: livePending } = await supabase
+          .from('chairman_decisions')
+          .select('id')
+          .eq('venture_id', venture.id)
+          .eq('lifecycle_stage', 0)
+          .eq('decision_type', 'stage_gate')
+          .eq('status', 'pending')
+          .limit(1)
+          .maybeSingle();
+        if (!livePending) {
+          await supabase
+            .from('ventures')
+            .update({
+              status: 'cancelled',
+              metadata: {
+                ...(venture.metadata || {}),
+                stage_zero: {
+                  ...(venture.metadata?.stage_zero || {}),
+                  awaiting_chairman_decision: false,
+                  cancellation_reason: 'stage0_decision_mint_failed',
+                },
               },
-            },
-          })
-          .eq('id', venture.id);
+            })
+            .eq('id', venture.id)
+            .eq('status', 'paused'); // guard: only cancel the still-paused holding state
+        } else {
+          logger.warn(`   Skipping compensating cancel for venture ${venture.id}: live pending decision ${livePending.id} exists`);
+        }
       } catch (compErr) {
         logger.warn(`   Compensating cancel failed for venture ${venture.id}: ${compErr.message}`);
       }

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -313,7 +313,7 @@ async function mintStageZeroGate(venture, brief, { supabase, logger = console, c
         // decision in the chairman queue (approving it later becomes a silent no-op). If this
         // check itself fails, fail toward PAUSE (skip the cancel, retryable) — never toward
         // losing a chairman-visible decision.
-        const { data: livePending } = await supabase
+        const { data: livePending, error: pendingCheckErr } = await supabase
           .from('chairman_decisions')
           .select('id')
           .eq('venture_id', venture.id)
@@ -322,7 +322,12 @@ async function mintStageZeroGate(venture, brief, { supabase, logger = console, c
           .eq('status', 'pending')
           .limit(1)
           .maybeSingle();
-        if (!livePending) {
+        // supabase-js returns { data: null, error } on PostgREST faults instead of throwing —
+        // a discarded error here would read as "no pending decision" and cancel anyway. A soft
+        // check failure must also fail toward PAUSE.
+        if (pendingCheckErr) {
+          logger.warn(`   Skipping compensating cancel for venture ${venture.id}: live-pending check failed (${pendingCheckErr.message})`);
+        } else if (!livePending) {
           await supabase
             .from('ventures')
             .update({

--- a/lib/eva/stage-zero/decision-activation.js
+++ b/lib/eva/stage-zero/decision-activation.js
@@ -13,16 +13,28 @@
  * Poll-side (not bolted into one approval CLI) so every approval surface is covered — Solomon's
  * reach-not-mechanism lesson: governance wired to ONE path while three run ungoverned.
  *
+ * Scan shape (adversarial-review round 1): the pass is anchored on PAUSED-AWAITING VENTURES,
+ * not on resolved decisions — the decision table accumulates history forever (including the
+ * pre-fix machine-forged lifecycle_stage=0 approved rows), so a decision-first scan would grow
+ * unbounded and silently truncate at the PostgREST row cap, wedging fresh approvals outside the
+ * window. The awaiting-venture set is small by construction (bounded by ventures actually
+ * paused at the gate), and each venture is re-read fresh immediately before its guarded update
+ * to shrink the lossy read-modify-write window on metadata.
+ *
  * Advisory rows are excluded by the decision_type filter: createAdvisoryNotification writes
  * status='approved' decision_type='advisory' rows and must NEVER activate a venture.
  *
  * Idempotent: only ventures still paused with metadata.stage_zero.awaiting_chairman_decision=true
- * are touched; a second tick over an activated/cancelled venture is a no-op.
+ * are touched; a second tick over an activated/cancelled venture is a no-op; a re-processed
+ * rejection reuses the existing un-promoted nursery row instead of parking a duplicate.
  *
  * Part of SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 (Delta-C1 / Solomon FIX-2).
  */
 
 import { parkVenture } from './venture-nursery.js';
+
+/** Safety bound on one pass — anything beyond carries to the next tick. */
+const MAX_PER_PASS = 200;
 
 /**
  * Rebuild a park-able brief from the paused venture's typed columns + stage_zero metadata.
@@ -52,6 +64,23 @@ export function briefFromVenture(venture) {
 }
 
 /**
+ * Re-read the venture immediately before applying a verdict so the guarded update writes the
+ * freshest metadata available (the whole-object metadata write is still last-writer-wins — a
+ * JSONB merge RPC is the full fix; this shrinks the window from tick-length to milliseconds).
+ * Returns null when the venture is no longer paused (someone else applied a transition).
+ */
+async function readPausedVenture(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('*')
+    .eq('id', ventureId)
+    .eq('status', 'paused')
+    .maybeSingle();
+  if (error) throw error;
+  return data || null;
+}
+
+/**
  * Apply resolved Stage-0 gate decisions to their paused-awaiting ventures.
  *
  * @param {Object} deps
@@ -63,46 +92,53 @@ export async function processStageZeroDecisions({ supabase, logger = console }) 
   const summary = { processed: 0, activated: 0, parked: 0, errors: 0 };
   if (!supabase) throw new Error('supabase client is required');
 
-  const { data: decisions, error } = await supabase
-    .from('chairman_decisions')
-    .select('id, venture_id, status, rationale')
-    .eq('lifecycle_stage', 0)
-    .eq('decision_type', 'stage_gate')
-    .in('status', ['approved', 'rejected']);
-
-  if (error) {
-    logger.warn(`[Stage0Activation] Decision scan failed (retry next tick): ${error.message}`);
-    summary.errors += 1;
-    return summary;
-  }
-  if (!decisions?.length) return summary;
-
-  const ventureIds = [...new Set(decisions.map(d => d.venture_id).filter(Boolean))];
+  // Anchor on the (small) paused-awaiting venture set — never on unbounded decision history.
   const { data: ventures, error: vErr } = await supabase
     .from('ventures')
     .select('*')
-    .in('id', ventureIds)
-    .eq('status', 'paused');
+    .eq('status', 'paused')
+    .eq('metadata->stage_zero->>awaiting_chairman_decision', 'true')
+    .limit(MAX_PER_PASS);
 
   if (vErr) {
     logger.warn(`[Stage0Activation] Venture scan failed (retry next tick): ${vErr.message}`);
     summary.errors += 1;
     return summary;
   }
+  if (!ventures?.length) return summary;
 
-  const awaiting = new Map(
-    (ventures || [])
-      .filter(v => v.metadata?.stage_zero?.awaiting_chairman_decision === true)
-      .map(v => [v.id, v])
-  );
-  if (!awaiting.size) return summary;
+  const awaiting = new Map(ventures.map(v => [v.id, v]));
+
+  const { data: decisions, error: dErr } = await supabase
+    .from('chairman_decisions')
+    .select('id, venture_id, status, rationale')
+    .in('venture_id', [...awaiting.keys()])
+    .eq('lifecycle_stage', 0)
+    .eq('decision_type', 'stage_gate')
+    .in('status', ['approved', 'rejected'])
+    .order('updated_at', { ascending: true })
+    .limit(MAX_PER_PASS);
+
+  if (dErr) {
+    logger.warn(`[Stage0Activation] Decision scan failed (retry next tick): ${dErr.message}`);
+    summary.errors += 1;
+    return summary;
+  }
+  if (!decisions?.length) return summary;
 
   for (const decision of decisions) {
-    const venture = awaiting.get(decision.venture_id);
-    if (!venture) continue; // already applied, or not a paused-awaiting venture — no-op
+    if (!awaiting.has(decision.venture_id)) continue;
     summary.processed += 1;
 
     try {
+      // Fresh read inside the pass: skip if the venture already transitioned (idempotency /
+      // concurrent-instance race — the loser sees no paused row and does nothing).
+      const venture = await readPausedVenture(supabase, decision.venture_id);
+      if (!venture || venture.metadata?.stage_zero?.awaiting_chairman_decision !== true) {
+        summary.processed -= 1;
+        continue;
+      }
+
       if (decision.status === 'approved') {
         const { error: upErr } = await supabase
           .from('ventures')
@@ -130,15 +166,31 @@ export async function processStageZeroDecisions({ supabase, logger = console }) 
         // rejected -> park first, cancel second. A park failure leaves the venture PAUSED
         // (retryable next tick) — never cancel a venture that has no nursery row, or the idea
         // is silently lost (the exact strand class the nursery exists to prevent).
-        await parkVenture(
-          briefFromVenture(venture),
-          {
-            reason: `Chairman rejected at Stage 0 gate${decision.rationale ? `: ${decision.rationale}` : ''}`,
-            triggerConditions: [],
-            reviewSchedule: '90d',
-          },
-          { supabase, logger }
-        );
+        // Park is DEDUPED: a prior tick (or concurrent instance) whose cancel failed after a
+        // successful park must reuse its un-promoted nursery row, not insert a duplicate.
+        const { data: existingPark, error: parkLookupErr } = await supabase
+          .from('venture_nursery')
+          .select('id')
+          .eq('name', venture.name)
+          .is('promoted_to_venture_id', null)
+          .limit(1)
+          .maybeSingle();
+        if (parkLookupErr) throw parkLookupErr;
+
+        if (existingPark) {
+          logger.log(`[Stage0Activation] Reusing existing nursery row ${existingPark.id} for ${venture.name} (park already applied)`);
+        } else {
+          await parkVenture(
+            briefFromVenture(venture),
+            {
+              reason: `Chairman rejected at Stage 0 gate${decision.rationale ? `: ${decision.rationale}` : ''}`,
+              triggerConditions: [],
+              reviewSchedule: '90d',
+            },
+            { supabase, logger }
+          );
+        }
+
         const { error: cancelErr } = await supabase
           .from('ventures')
           .update({
@@ -164,7 +216,7 @@ export async function processStageZeroDecisions({ supabase, logger = console }) 
       }
     } catch (err) {
       summary.errors += 1;
-      logger.warn(`[Stage0Activation] Failed applying decision ${decision.id} to venture ${venture.id} (retry next tick): ${err.message}`);
+      logger.warn(`[Stage0Activation] Failed applying decision ${decision.id} to venture ${decision.venture_id} (retry next tick): ${err.message}`);
     }
   }
 

--- a/lib/eva/stage-zero/decision-activation.js
+++ b/lib/eva/stage-zero/decision-activation.js
@@ -93,11 +93,14 @@ export async function processStageZeroDecisions({ supabase, logger = console }) 
   if (!supabase) throw new Error('supabase client is required');
 
   // Anchor on the (small) paused-awaiting venture set — never on unbounded decision history.
+  // Newest-first: permanently-wedged awaiting ventures (e.g. fixtures the mint deliberately
+  // skips) age out of the window instead of crowding fresh chairman verdicts past the cap.
   const { data: ventures, error: vErr } = await supabase
     .from('ventures')
     .select('*')
     .eq('status', 'paused')
     .eq('metadata->stage_zero->>awaiting_chairman_decision', 'true')
+    .order('created_at', { ascending: false })
     .limit(MAX_PER_PASS);
 
   if (vErr) {

--- a/lib/eva/stage-zero/decision-activation.js
+++ b/lib/eva/stage-zero/decision-activation.js
@@ -1,0 +1,172 @@
+/**
+ * Stage-0 Decision Activation Consumer
+ *
+ * The resume seam for the paused 'ready' flow: chairman-review.js persistVentureBrief creates
+ * ready ventures PAUSED with a PENDING chairman_decisions row (lifecycle_stage=0,
+ * decision_type='stage_gate'). The chairman resolves that decision on ANY surface
+ * (eva-decisions.js CLI, dashboard, API) — none of which carry venture-side effects — so this
+ * poll-side consumer applies the verdict on the queue processor's tick:
+ *
+ *   approved -> venture status 'active' + activation provenance (traceable to the decision id)
+ *   rejected -> parkVenture (nursery, per SD-LEO-INFRA-STAGE0-NURSERY-PARK-PATH-001) + 'cancelled'
+ *
+ * Poll-side (not bolted into one approval CLI) so every approval surface is covered — Solomon's
+ * reach-not-mechanism lesson: governance wired to ONE path while three run ungoverned.
+ *
+ * Advisory rows are excluded by the decision_type filter: createAdvisoryNotification writes
+ * status='approved' decision_type='advisory' rows and must NEVER activate a venture.
+ *
+ * Idempotent: only ventures still paused with metadata.stage_zero.awaiting_chairman_decision=true
+ * are touched; a second tick over an activated/cancelled venture is a no-op.
+ *
+ * Part of SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 (Delta-C1 / Solomon FIX-2).
+ */
+
+import { parkVenture } from './venture-nursery.js';
+
+/**
+ * Rebuild a park-able brief from the paused venture's typed columns + stage_zero metadata.
+ * @param {Object} venture - ventures row
+ * @returns {Object} brief shape parkVenture consumes
+ */
+export function briefFromVenture(venture) {
+  const sz = venture.metadata?.stage_zero || {};
+  return {
+    name: venture.name,
+    problem_statement: venture.problem_statement || venture.description,
+    solution: venture.solution || sz.solution,
+    target_market: venture.target_market,
+    origin_type: venture.origin_type,
+    raw_chairman_intent: venture.raw_chairman_intent || sz.raw_chairman_intent,
+    archetype: sz.synthesis_archetype || venture.archetype,
+    moat_strategy: venture.moat_strategy,
+    portfolio_synergy_score: venture.portfolio_synergy_score,
+    time_horizon_classification: venture.time_horizon_classification,
+    build_estimate: venture.build_estimate,
+    discovery_strategy: venture.discovery_strategy,
+    // Rejected at the ready gate -> parks at the weakest maturity (mirrors the sibling SD's
+    // blocked/nursery -> 'seed' mapping).
+    maturity: 'seed',
+    metadata: venture.metadata,
+  };
+}
+
+/**
+ * Apply resolved Stage-0 gate decisions to their paused-awaiting ventures.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client (service role)
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<{processed: number, activated: number, parked: number, errors: number}>}
+ */
+export async function processStageZeroDecisions({ supabase, logger = console }) {
+  const summary = { processed: 0, activated: 0, parked: 0, errors: 0 };
+  if (!supabase) throw new Error('supabase client is required');
+
+  const { data: decisions, error } = await supabase
+    .from('chairman_decisions')
+    .select('id, venture_id, status, rationale')
+    .eq('lifecycle_stage', 0)
+    .eq('decision_type', 'stage_gate')
+    .in('status', ['approved', 'rejected']);
+
+  if (error) {
+    logger.warn(`[Stage0Activation] Decision scan failed (retry next tick): ${error.message}`);
+    summary.errors += 1;
+    return summary;
+  }
+  if (!decisions?.length) return summary;
+
+  const ventureIds = [...new Set(decisions.map(d => d.venture_id).filter(Boolean))];
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('*')
+    .in('id', ventureIds)
+    .eq('status', 'paused');
+
+  if (vErr) {
+    logger.warn(`[Stage0Activation] Venture scan failed (retry next tick): ${vErr.message}`);
+    summary.errors += 1;
+    return summary;
+  }
+
+  const awaiting = new Map(
+    (ventures || [])
+      .filter(v => v.metadata?.stage_zero?.awaiting_chairman_decision === true)
+      .map(v => [v.id, v])
+  );
+  if (!awaiting.size) return summary;
+
+  for (const decision of decisions) {
+    const venture = awaiting.get(decision.venture_id);
+    if (!venture) continue; // already applied, or not a paused-awaiting venture — no-op
+    summary.processed += 1;
+
+    try {
+      if (decision.status === 'approved') {
+        const { error: upErr } = await supabase
+          .from('ventures')
+          .update({
+            status: 'active',
+            metadata: {
+              ...(venture.metadata || {}),
+              stage_zero: {
+                ...(venture.metadata?.stage_zero || {}),
+                awaiting_chairman_decision: false,
+                activation: {
+                  decision_id: decision.id,
+                  activated_at: new Date().toISOString(),
+                  activated_by: 'chairman-approval',
+                },
+              },
+            },
+          })
+          .eq('id', venture.id)
+          .eq('status', 'paused'); // guard: never flip a venture something else already moved
+        if (upErr) throw upErr;
+        summary.activated += 1;
+        logger.log(`[Stage0Activation] Venture ${venture.id} ACTIVATED by chairman decision ${decision.id}`);
+      } else {
+        // rejected -> park first, cancel second. A park failure leaves the venture PAUSED
+        // (retryable next tick) — never cancel a venture that has no nursery row, or the idea
+        // is silently lost (the exact strand class the nursery exists to prevent).
+        await parkVenture(
+          briefFromVenture(venture),
+          {
+            reason: `Chairman rejected at Stage 0 gate${decision.rationale ? `: ${decision.rationale}` : ''}`,
+            triggerConditions: [],
+            reviewSchedule: '90d',
+          },
+          { supabase, logger }
+        );
+        const { error: cancelErr } = await supabase
+          .from('ventures')
+          .update({
+            status: 'cancelled',
+            metadata: {
+              ...(venture.metadata || {}),
+              stage_zero: {
+                ...(venture.metadata?.stage_zero || {}),
+                awaiting_chairman_decision: false,
+                cancellation: {
+                  decision_id: decision.id,
+                  reason: 'chairman_rejected',
+                  cancelled_at: new Date().toISOString(),
+                },
+              },
+            },
+          })
+          .eq('id', venture.id)
+          .eq('status', 'paused');
+        if (cancelErr) throw cancelErr;
+        summary.parked += 1;
+        logger.log(`[Stage0Activation] Venture ${venture.id} PARKED+CANCELLED by chairman decision ${decision.id}`);
+      }
+    } catch (err) {
+      summary.errors += 1;
+      logger.warn(`[Stage0Activation] Failed applying decision ${decision.id} to venture ${venture.id} (retry next tick): ${err.message}`);
+    }
+  }
+
+  return summary;
+}

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -163,10 +163,17 @@ export async function executeStageZero(params, deps = {}) {
   // Step 4: Persist
   const record = await persistVentureBrief(reviewResult, enrichedDeps);
 
-  // Step 5: Hand off to Stage 1 if ready
+  // Step 5: Pause for the chairman gate if ready
+  // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: 'ready' no longer means active — the
+  // venture is paused behind a PENDING chairman decision; activation happens on his approval
+  // (decision-activation.js consumer). The old "Run: eva venture stage 1" instruction was false
+  // the moment ready stopped self-approving.
   if (reviewResult.decision === 'ready') {
-    logger.log(`\n   Venture ready for Stage 1: ${record.id}`);
-    logger.log('   Run: eva venture stage 1 --venture ' + record.id);
+    logger.log(`\n   Venture paused awaiting chairman decision: ${record.id}`);
+    if (record.stage_zero_decision_id) {
+      logger.log(`   Pending decision: ${record.stage_zero_decision_id}`);
+      logger.log(`   Resolve via: node scripts/eva-decisions.js approve ${record.stage_zero_decision_id} --rationale "..."`);
+    }
   } else {
     logger.log(`\n   Venture parked in nursery (${reviewResult.decision}): ${record.id}`);
   }
@@ -185,6 +192,12 @@ export async function executeStageZero(params, deps = {}) {
     decision: reviewResult.decision,
     record_id: record.id,
     record_type: reviewResult.decision === 'ready' ? 'venture' : 'nursery_entry',
+    // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: downstream entry-path callers
+    // (venture-intake-gates, clean-clone launch, discovery-mode-versions) surface the pause
+    // instead of treating a non-active venture as failed.
+    ...(reviewResult.decision === 'ready'
+      ? { awaiting_chairman_decision: true, decision_id: record.stage_zero_decision_id || null }
+      : {}),
     brief: reviewResult.brief,
     validation: reviewResult.validation,
     experiment: experimentContext,

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -26,6 +26,7 @@ dotenv.config();
 
 import { createClient } from '@supabase/supabase-js';
 import { executeStageZero } from '../lib/eva/stage-zero/stage-zero-orchestrator.js';
+import { processStageZeroDecisions } from '../lib/eva/stage-zero/decision-activation.js';
 import { randomUUID } from 'crypto';
 
 // ── Configuration ──────────────────────────────────────────────────
@@ -443,6 +444,15 @@ let running = true;
 async function pollOnce(supabase) {
   // Release stale claims first
   await releaseStaleClaims(supabase);
+
+  // SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001: resume seam for the paused 'ready' flow —
+  // apply chairman verdicts (activate / park+cancel) before claiming new synthesis work. Fail-soft:
+  // an activation-pass fault must never block request processing; it retries next tick.
+  try {
+    await processStageZeroDecisions({ supabase, logger: log });
+  } catch (err) {
+    log.warn(`Stage-0 decision activation pass failed (retry next tick): ${err.message}`);
+  }
 
   // Fetch next pending
   const request = await fetchNextPending(supabase);

--- a/tests/unit/eva/chairman-decision-watcher-force.test.js
+++ b/tests/unit/eva/chairman-decision-watcher-force.test.js
@@ -1,0 +1,101 @@
+/**
+ * Unit Tests: createOrReusePendingDecision forceDecisionCreation option
+ * SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 (TS-5, TS-7)
+ *
+ * Stage 0 is deliberately absent from stage_config, so stage_creates_decision(0) returns
+ * creates_decision=false and the helper self-skips. The Stage-0 chairman gate passes
+ * forceDecisionCreation:true to skip ONLY that predicate; the fixture-venture guard still wins.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/eva/forward-gate.js', () => ({
+  recordForwardGateScore: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createOrReusePendingDecision } from '../../../lib/eva/chairman-decision-watcher.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+/**
+ * Fake supabase covering the helper's paths:
+ *  ventures (fixture check): select().eq().maybeSingle()
+ *  rpc('stage_creates_decision'): recorded, returns creates_decision=false for stage 0
+ *  chairman_decisions existing-pending lookup: select().eq()x4.single() -> none
+ *  venture_stage_work (health resolution): select().eq().eq().maybeSingle() -> none
+ *  chairman_decisions insert: insert().select().single() -> created row
+ */
+function makeSupabase({ venture = { is_demo: false, name: 'RealVenture' } } = {}) {
+  const inserted = [];
+  const rpc = vi.fn().mockResolvedValue({ data: [{ creates_decision: false, gate_type: null, review_mode: null }], error: null });
+
+  function chainFor(table) {
+    if (table === 'ventures') {
+      return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: venture, error: null }) }) }) };
+    }
+    if (table === 'venture_stage_work') {
+      const c = { select: () => c, eq: () => c, maybeSingle: () => Promise.resolve({ data: null, error: null }) };
+      return c;
+    }
+    // chairman_decisions
+    return {
+      select: () => {
+        const c = { eq: () => c, single: () => Promise.resolve({ data: null, error: { code: 'PGRST116' } }) };
+        return c;
+      },
+      insert: (payload) => {
+        inserted.push(payload);
+        return { select: () => ({ single: () => Promise.resolve({ data: { id: 'd-new' }, error: null }) }) };
+      },
+    };
+  }
+
+  return { from: vi.fn(chainFor), rpc, _inserted: inserted };
+}
+
+describe('createOrReusePendingDecision — forceDecisionCreation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('default (no flag): consults the stage predicate and SKIPS at stage 0', async () => {
+    const supabase = makeSupabase();
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v-1', stageNumber: 0, supabase, logger: silentLogger,
+    });
+    expect(supabase.rpc).toHaveBeenCalledWith('stage_creates_decision', { p_stage_number: 0 });
+    expect(result.skipped).toBe(true);
+    expect(supabase._inserted).toHaveLength(0);
+  });
+
+  it('forceDecisionCreation:true mints a real PENDING row at stage 0 without consulting the predicate', async () => {
+    const supabase = makeSupabase();
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v-1',
+      stageNumber: 0,
+      decisionType: 'stage_gate',
+      summary: 'Stage 0: venture awaiting chairman approval',
+      briefData: { provenance: { minted_by: 'stage0-machine' } },
+      forceDecisionCreation: true,
+      supabase,
+      logger: silentLogger,
+    });
+    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: 'd-new', isNew: true });
+    // TS-7 provenance pin: the mint is PENDING — the machine can never write approved here.
+    const row = supabase._inserted[0];
+    expect(row.status).toBe('pending');
+    expect(row.decision).toBe('pending');
+    expect(row.decision_type).toBe('stage_gate');
+    expect(row.lifecycle_stage).toBe(0);
+    expect(row.brief_data.provenance.minted_by).toBe('stage0-machine');
+  });
+
+  it('fixture-venture guard WINS over forceDecisionCreation — test/demo ventures never mint', async () => {
+    const supabase = makeSupabase({ venture: { is_demo: true, name: 'parity-test-thing' } });
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v-fixture', stageNumber: 0, forceDecisionCreation: true, supabase, logger: silentLogger,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('fixture_venture');
+    expect(supabase._inserted).toHaveLength(0);
+  });
+});

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -288,6 +288,26 @@ describe('ChairmanReview', () => {
       expect(cancelCall).toBeUndefined();
     });
 
+    // Adversarial-review round 2: supabase-js returns { data: null, error } on PostgREST faults
+    // instead of throwing — a discarded error would read as "no pending decision" and cancel
+    // anyway. A soft check failure must also fail toward PAUSE.
+    it('mint failure with a FAILED live-pending check also SKIPS the compensating cancel', async () => {
+      createOrReusePendingDecision.mockRejectedValueOnce(new Error('mint exploded'));
+      const mockSupabase = createMockSupabase({
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'transient 5xx' } }),
+      });
+      await expect(
+        persistVentureBrief(
+          { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+          { supabase: mockSupabase, logger: silentLogger },
+        ),
+      ).rejects.toThrow(/fail-closed/);
+      const cancelCall = mockSupabase._mockChain.update.mock.calls.find(
+        (c) => c[0]?.status === 'cancelled',
+      );
+      expect(cancelCall).toBeUndefined();
+    });
+
     // Idempotent re-run wedge closure: original run died between venture insert and mint —
     // the 23505 path re-mints (reuse-safe) for a paused-awaiting existing venture.
     it('23505 re-run with a paused-awaiting venture re-mints the pending gate', async () => {

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -250,7 +250,11 @@ describe('ChairmanReview', () => {
     // never exist — mint failure compensates the venture to cancelled and rethrows.
     it('mint failure throws fail-closed and compensates the venture to cancelled', async () => {
       createOrReusePendingDecision.mockRejectedValueOnce(new Error('mint exploded'));
-      const mockSupabase = createMockSupabase();
+      // maybeSingle serves the live-pending check inside the compensating path — no pending
+      // decision exists, so the cancel proceeds.
+      const mockSupabase = createMockSupabase({
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      });
       await expect(
         persistVentureBrief(
           { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
@@ -262,6 +266,26 @@ describe('ChairmanReview', () => {
       );
       expect(updateArg).toBeDefined();
       expect(updateArg[0].metadata.stage_zero.cancellation_reason).toBe('stage0_decision_mint_failed');
+    });
+
+    // Adversarial-review round 1: never cancel a venture that already carries a live PENDING
+    // gate decision (concurrent duplicate-name 23505 re-mint race) — cancelling would strand
+    // a chairman-visible decision whose later approval becomes a silent no-op.
+    it('mint failure with a live pending decision SKIPS the compensating cancel', async () => {
+      createOrReusePendingDecision.mockRejectedValueOnce(new Error('mint exploded'));
+      const mockSupabase = createMockSupabase({
+        maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'd-live' }, error: null }),
+      });
+      await expect(
+        persistVentureBrief(
+          { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+          { supabase: mockSupabase, logger: silentLogger },
+        ),
+      ).rejects.toThrow(/fail-closed/);
+      const cancelCall = mockSupabase._mockChain.update.mock.calls.find(
+        (c) => c[0]?.status === 'cancelled',
+      );
+      expect(cancelCall).toBeUndefined();
     });
 
     // Idempotent re-run wedge closure: original run died between venture insert and mint —

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -37,6 +37,7 @@ vi.mock('../../../../lib/eva/chairman-decision-watcher.js', () => ({
 
 import { conductChairmanReview, persistVentureBrief } from '../../../../lib/eva/stage-zero/chairman-review.js';
 import { parkVenture } from '../../../../lib/eva/stage-zero/venture-nursery.js';
+import { createOrReusePendingDecision } from '../../../../lib/eva/chairman-decision-watcher.js';
 
 const silentLogger = {
   log: vi.fn(),
@@ -188,6 +189,101 @@ describe('ChairmanReview', () => {
 
       expect(result.id).toBe('v-1');
       expect(mockSupabase.from).toHaveBeenCalledWith('ventures');
+    });
+
+    // ── SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 acceptance canaries ──
+
+    // Canary 1: READY NEVER SELF-APPROVES.
+    it('ready path inserts a PAUSED venture awaiting the chairman — never active', async () => {
+      const mockSupabase = createMockSupabase();
+      await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      const insertArg = mockSupabase._mockChain.insert.mock.calls[0][0];
+      expect(insertArg.status).toBe('paused');
+      expect(insertArg.metadata.stage_zero.awaiting_chairman_decision).toBe(true);
+      expect(insertArg.metadata.stage_zero.pause_provenance.minted_by).toBe('stage0-chairman-gate');
+      expect(insertArg.current_lifecycle_stage).toBe(1);
+    });
+
+    it('ready path mints the REAL pending gate at stage 0 and returns its id', async () => {
+      const mockSupabase = createMockSupabase();
+      const result = await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      expect(createOrReusePendingDecision).toHaveBeenCalledTimes(1);
+      const mintArg = createOrReusePendingDecision.mock.calls[0][0];
+      expect(mintArg.stageNumber).toBe(0);
+      expect(mintArg.decisionType).toBe('stage_gate');
+      expect(mintArg.forceDecisionCreation).toBe(true);
+      expect(mintArg.briefData.provenance.minted_by).toBe('stage0-machine');
+      expect(result.stage_zero_decision_id).toBe('decision-1');
+    });
+
+    it('never writes chairman_decisions directly — no machine-forged approval row exists', async () => {
+      const mockSupabase = createMockSupabase();
+      await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      // The ONLY decision writer on this path is the mocked real gate helper; chairman-review
+      // itself must not touch the table (the forged status='approved' insert is deleted).
+      expect(mockSupabase.from).not.toHaveBeenCalledWith('chairman_decisions');
+    });
+
+    it('the machine-forged approval insert is gone from the source (grep pin)', async () => {
+      const fs = await import('node:fs');
+      const url = await import('node:url');
+      const path = await import('node:path');
+      const here = path.dirname(url.fileURLToPath(import.meta.url));
+      const src = fs.readFileSync(
+        path.resolve(here, '../../../../lib/eva/stage-zero/chairman-review.js'),
+        'utf8',
+      );
+      expect(src).not.toContain('Venture meets readiness criteria');
+      expect(src).not.toContain("status: 'active'");
+    });
+
+    // Fail-closed mint (flaw H5 class closed): a ready venture without a pending decision must
+    // never exist — mint failure compensates the venture to cancelled and rethrows.
+    it('mint failure throws fail-closed and compensates the venture to cancelled', async () => {
+      createOrReusePendingDecision.mockRejectedValueOnce(new Error('mint exploded'));
+      const mockSupabase = createMockSupabase();
+      await expect(
+        persistVentureBrief(
+          { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+          { supabase: mockSupabase, logger: silentLogger },
+        ),
+      ).rejects.toThrow(/fail-closed.*mint exploded/);
+      const updateArg = mockSupabase._mockChain.update.mock.calls.find(
+        (c) => c[0]?.status === 'cancelled',
+      );
+      expect(updateArg).toBeDefined();
+      expect(updateArg[0].metadata.stage_zero.cancellation_reason).toBe('stage0_decision_mint_failed');
+    });
+
+    // Idempotent re-run wedge closure: original run died between venture insert and mint —
+    // the 23505 path re-mints (reuse-safe) for a paused-awaiting existing venture.
+    it('23505 re-run with a paused-awaiting venture re-mints the pending gate', async () => {
+      const existingVenture = {
+        id: 'v-existing',
+        name: 'TestVenture',
+        status: 'paused',
+        metadata: { stage_zero: { awaiting_chairman_decision: true } },
+      };
+      const mockSupabase = makeGuardSupabase({
+        insertError: { code: '23505', message: 'duplicate key value violates unique constraint "idx_ventures_unique_active_name"' },
+        existingVenture,
+      });
+      const result = await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger, company_id: 'co-1' },
+      );
+      expect(createOrReusePendingDecision).toHaveBeenCalledTimes(1);
+      expect(result.stage_zero_decision_id).toBe('decision-1');
+      expect(result.id).toBe('v-existing');
     });
 
     // SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-A (FR-3): a reseeded brief stamps provenance

--- a/tests/unit/eva/stage-zero/decision-activation.test.js
+++ b/tests/unit/eva/stage-zero/decision-activation.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit Tests: Stage-0 Decision Activation Consumer
+ * SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001
+ *
+ * Acceptance canary 2 ("Real approval activates") + rejection-parks + the
+ * no-machine-approver filters (advisory rows never activate).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../lib/eva/stage-zero/venture-nursery.js', () => ({
+  parkVenture: vi.fn().mockResolvedValue({ id: 'nursery-1' }),
+}));
+
+import { processStageZeroDecisions, briefFromVenture } from '../../../../lib/eva/stage-zero/decision-activation.js';
+import { parkVenture } from '../../../../lib/eva/stage-zero/venture-nursery.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+/**
+ * Fake supabase for the consumer's three query shapes:
+ *  - chairman_decisions: select().eq().eq().in() -> { data: decisions } (filters recorded)
+ *  - ventures select:    select().in().eq()      -> { data: ventures }
+ *  - ventures update:    update(payload).eq().eq() -> { error } (payloads recorded)
+ */
+function makeSupabase({ decisions = [], ventures = [], updateError = null } = {}) {
+  const recorded = { decisionFilters: [], ventureUpdates: [] };
+
+  function decisionsChain() {
+    const filters = [];
+    recorded.decisionFilters.push(filters);
+    const chain = {
+      select: () => chain,
+      eq: (col, val) => { filters.push(['eq', col, val]); return chain; },
+      in: (col, vals) => {
+        filters.push(['in', col, vals]);
+        return Promise.resolve({ data: decisions, error: null });
+      },
+    };
+    return chain;
+  }
+
+  function venturesChain() {
+    const chain = {
+      select: () => chain,
+      in: () => chain,
+      eq: () => Promise.resolve({ data: ventures, error: null }),
+      // consumer shape: update(payload).eq('id', ..).eq('status', 'paused') then awaited
+      update: (payload) => {
+        recorded.ventureUpdates.push(payload);
+        return { eq: () => ({ eq: () => Promise.resolve({ error: updateError }) }) };
+      },
+    };
+    return chain;
+  }
+
+  return {
+    from: vi.fn((table) => (table === 'chairman_decisions' ? decisionsChain() : venturesChain())),
+    _recorded: recorded,
+  };
+}
+
+const pausedAwaitingVenture = {
+  id: 'v-1',
+  name: 'TestVenture',
+  status: 'paused',
+  problem_statement: 'Test problem',
+  solution: 'Test solution',
+  target_market: 'SMBs',
+  origin_type: 'discovery',
+  raw_chairman_intent: 'Test problem',
+  metadata: { stage_zero: { awaiting_chairman_decision: true, synthesis_archetype: 'saas' } },
+};
+
+describe('processStageZeroDecisions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('queries ONLY stage-0 stage_gate decisions — advisory rows are excluded at the filter', async () => {
+    const supabase = makeSupabase({ decisions: [], ventures: [] });
+    await processStageZeroDecisions({ supabase, logger: silentLogger });
+    const filters = supabase._recorded.decisionFilters[0];
+    expect(filters).toContainEqual(['eq', 'lifecycle_stage', 0]);
+    expect(filters).toContainEqual(['eq', 'decision_type', 'stage_gate']);
+    expect(filters).toContainEqual(['in', 'status', ['approved', 'rejected']]);
+  });
+
+  // Acceptance canary 2: real approval activates.
+  it('activates a paused-awaiting venture on an approved decision, with decision-id provenance', async () => {
+    const supabase = makeSupabase({
+      decisions: [{ id: 'd-1', venture_id: 'v-1', status: 'approved', rationale: 'looks good' }],
+      ventures: [pausedAwaitingVenture],
+    });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary.activated).toBe(1);
+    expect(summary.parked).toBe(0);
+    const update = supabase._recorded.ventureUpdates[0];
+    expect(update.status).toBe('active');
+    expect(update.metadata.stage_zero.awaiting_chairman_decision).toBe(false);
+    expect(update.metadata.stage_zero.activation.decision_id).toBe('d-1');
+    expect(update.metadata.stage_zero.activation.activated_by).toBe('chairman-approval');
+  });
+
+  it('rejection parks the brief (nursery) THEN cancels the venture', async () => {
+    const supabase = makeSupabase({
+      decisions: [{ id: 'd-2', venture_id: 'v-1', status: 'rejected', rationale: 'not now' }],
+      ventures: [pausedAwaitingVenture],
+    });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary.parked).toBe(1);
+    expect(parkVenture).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'TestVenture', maturity: 'seed' }),
+      expect.objectContaining({ reason: expect.stringContaining('not now') }),
+      expect.objectContaining({ supabase }),
+    );
+    const update = supabase._recorded.ventureUpdates[0];
+    expect(update.status).toBe('cancelled');
+    expect(update.metadata.stage_zero.cancellation.decision_id).toBe('d-2');
+  });
+
+  it('park failure leaves the venture PAUSED (retryable) — never cancels without a nursery row', async () => {
+    parkVenture.mockRejectedValueOnce(new Error('nursery schema drift'));
+    const supabase = makeSupabase({
+      decisions: [{ id: 'd-3', venture_id: 'v-1', status: 'rejected', rationale: null }],
+      ventures: [pausedAwaitingVenture],
+    });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary.parked).toBe(0);
+    expect(summary.errors).toBe(1);
+    expect(supabase._recorded.ventureUpdates).toHaveLength(0); // no cancel write
+  });
+
+  it('is idempotent: a venture no longer paused-awaiting is a no-op', async () => {
+    const activatedVenture = {
+      ...pausedAwaitingVenture,
+      metadata: { stage_zero: { awaiting_chairman_decision: false } },
+    };
+    const supabase = makeSupabase({
+      decisions: [{ id: 'd-1', venture_id: 'v-1', status: 'approved', rationale: null }],
+      ventures: [activatedVenture],
+    });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary.processed).toBe(0);
+    expect(supabase._recorded.ventureUpdates).toHaveLength(0);
+  });
+
+  it('returns early with zero work when no resolved decisions exist', async () => {
+    const supabase = makeSupabase({ decisions: [], ventures: [] });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary).toEqual({ processed: 0, activated: 0, parked: 0, errors: 0 });
+  });
+});
+
+describe('briefFromVenture', () => {
+  it('rebuilds a park-able brief from venture columns + stage_zero metadata', () => {
+    const brief = briefFromVenture(pausedAwaitingVenture);
+    expect(brief.name).toBe('TestVenture');
+    expect(brief.problem_statement).toBe('Test problem');
+    expect(brief.archetype).toBe('saas');
+    expect(brief.maturity).toBe('seed');
+  });
+});

--- a/tests/unit/eva/stage-zero/decision-activation.test.js
+++ b/tests/unit/eva/stage-zero/decision-activation.test.js
@@ -52,6 +52,7 @@ function makeSupabase({
     const chain = {
       select: () => chain,
       eq: () => chain,
+      order: () => chain,
       limit: () => Promise.resolve({ data: pausedVentures, error: null }),
       maybeSingle: () =>
         Promise.resolve({

--- a/tests/unit/eva/stage-zero/decision-activation.test.js
+++ b/tests/unit/eva/stage-zero/decision-activation.test.js
@@ -3,7 +3,8 @@
  * SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001
  *
  * Acceptance canary 2 ("Real approval activates") + rejection-parks + the
- * no-machine-approver filters (advisory rows never activate).
+ * no-machine-approver filters (advisory rows never activate) + adversarial-review
+ * round-1 regressions (venture-anchored scan, park dedupe, fresh re-read).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,13 +19,21 @@ import { parkVenture } from '../../../../lib/eva/stage-zero/venture-nursery.js';
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
 /**
- * Fake supabase for the consumer's three query shapes:
- *  - chairman_decisions: select().eq().eq().in() -> { data: decisions } (filters recorded)
- *  - ventures select:    select().in().eq()      -> { data: ventures }
- *  - ventures update:    update(payload).eq().eq() -> { error } (payloads recorded)
+ * Fake supabase for the consumer's query shapes:
+ *  - ventures scan (list):   select('*').eq(status).eq(jsonpath).limit()      -> pausedVentures
+ *  - ventures fresh read:    select('*').eq(id).eq(status).maybeSingle()      -> freshVenture
+ *  - chairman_decisions:     select().in().eq().eq().in().order().limit()     -> decisions (filters recorded)
+ *  - venture_nursery dedupe: select('id').eq(name).is().limit().maybeSingle() -> existingPark
+ *  - ventures update:        update(payload).eq().eq()                        -> { error } (payloads recorded)
  */
-function makeSupabase({ decisions = [], ventures = [], updateError = null } = {}) {
-  const recorded = { decisionFilters: [], ventureUpdates: [] };
+function makeSupabase({
+  pausedVentures = [],
+  decisions = [],
+  freshVenture = undefined, // undefined => default to first paused venture; null => gone
+  existingPark = null,
+  updateError = null,
+} = {}) {
+  const recorded = { decisionFilters: [], ventureUpdates: [], nurseryLookups: 0 };
 
   function decisionsChain() {
     const filters = [];
@@ -32,10 +41,9 @@ function makeSupabase({ decisions = [], ventures = [], updateError = null } = {}
     const chain = {
       select: () => chain,
       eq: (col, val) => { filters.push(['eq', col, val]); return chain; },
-      in: (col, vals) => {
-        filters.push(['in', col, vals]);
-        return Promise.resolve({ data: decisions, error: null });
-      },
+      in: (col, vals) => { filters.push(['in', col, vals]); return chain; },
+      order: () => chain,
+      limit: () => Promise.resolve({ data: decisions, error: null }),
     };
     return chain;
   }
@@ -43,9 +51,13 @@ function makeSupabase({ decisions = [], ventures = [], updateError = null } = {}
   function venturesChain() {
     const chain = {
       select: () => chain,
-      in: () => chain,
-      eq: () => Promise.resolve({ data: ventures, error: null }),
-      // consumer shape: update(payload).eq('id', ..).eq('status', 'paused') then awaited
+      eq: () => chain,
+      limit: () => Promise.resolve({ data: pausedVentures, error: null }),
+      maybeSingle: () =>
+        Promise.resolve({
+          data: freshVenture === undefined ? (pausedVentures[0] || null) : freshVenture,
+          error: null,
+        }),
       update: (payload) => {
         recorded.ventureUpdates.push(payload);
         return { eq: () => ({ eq: () => Promise.resolve({ error: updateError }) }) };
@@ -54,8 +66,24 @@ function makeSupabase({ decisions = [], ventures = [], updateError = null } = {}
     return chain;
   }
 
+  function nurseryChain() {
+    recorded.nurseryLookups += 1;
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      limit: () => chain,
+      maybeSingle: () => Promise.resolve({ data: existingPark, error: null }),
+    };
+    return chain;
+  }
+
   return {
-    from: vi.fn((table) => (table === 'chairman_decisions' ? decisionsChain() : venturesChain())),
+    from: vi.fn((table) => {
+      if (table === 'chairman_decisions') return decisionsChain();
+      if (table === 'venture_nursery') return nurseryChain();
+      return venturesChain();
+    }),
     _recorded: recorded,
   };
 }
@@ -75,20 +103,31 @@ const pausedAwaitingVenture = {
 describe('processStageZeroDecisions', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('queries ONLY stage-0 stage_gate decisions — advisory rows are excluded at the filter', async () => {
-    const supabase = makeSupabase({ decisions: [], ventures: [] });
+  it('queries ONLY stage-0 stage_gate decisions for the awaiting ventures — advisory rows excluded at the filter', async () => {
+    const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
+      decisions: [],
+    });
     await processStageZeroDecisions({ supabase, logger: silentLogger });
     const filters = supabase._recorded.decisionFilters[0];
+    expect(filters).toContainEqual(['in', 'venture_id', ['v-1']]); // venture-anchored, not history-anchored
     expect(filters).toContainEqual(['eq', 'lifecycle_stage', 0]);
     expect(filters).toContainEqual(['eq', 'decision_type', 'stage_gate']);
     expect(filters).toContainEqual(['in', 'status', ['approved', 'rejected']]);
   });
 
+  it('does not scan decisions at all when no venture is paused-awaiting (bounded pass)', async () => {
+    const supabase = makeSupabase({ pausedVentures: [], decisions: [] });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(summary).toEqual({ processed: 0, activated: 0, parked: 0, errors: 0 });
+    expect(supabase._recorded.decisionFilters).toHaveLength(0);
+  });
+
   // Acceptance canary 2: real approval activates.
   it('activates a paused-awaiting venture on an approved decision, with decision-id provenance', async () => {
     const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
       decisions: [{ id: 'd-1', venture_id: 'v-1', status: 'approved', rationale: 'looks good' }],
-      ventures: [pausedAwaitingVenture],
     });
     const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
     expect(summary.activated).toBe(1);
@@ -102,8 +141,8 @@ describe('processStageZeroDecisions', () => {
 
   it('rejection parks the brief (nursery) THEN cancels the venture', async () => {
     const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
       decisions: [{ id: 'd-2', venture_id: 'v-1', status: 'rejected', rationale: 'not now' }],
-      ventures: [pausedAwaitingVenture],
     });
     const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
     expect(summary.parked).toBe(1);
@@ -117,11 +156,25 @@ describe('processStageZeroDecisions', () => {
     expect(update.metadata.stage_zero.cancellation.decision_id).toBe('d-2');
   });
 
+  // Adversarial-review round 1: a prior tick's successful park whose cancel failed must be
+  // REUSED — never a duplicate nursery insert.
+  it('re-processed rejection reuses the existing un-promoted nursery row (park dedupe)', async () => {
+    const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
+      decisions: [{ id: 'd-2', venture_id: 'v-1', status: 'rejected', rationale: 'not now' }],
+      existingPark: { id: 'nursery-existing' },
+    });
+    const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
+    expect(parkVenture).not.toHaveBeenCalled();
+    expect(summary.parked).toBe(1); // still cancels the venture
+    expect(supabase._recorded.ventureUpdates[0].status).toBe('cancelled');
+  });
+
   it('park failure leaves the venture PAUSED (retryable) — never cancels without a nursery row', async () => {
     parkVenture.mockRejectedValueOnce(new Error('nursery schema drift'));
     const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
       decisions: [{ id: 'd-3', venture_id: 'v-1', status: 'rejected', rationale: null }],
-      ventures: [pausedAwaitingVenture],
     });
     const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
     expect(summary.parked).toBe(0);
@@ -129,24 +182,30 @@ describe('processStageZeroDecisions', () => {
     expect(supabase._recorded.ventureUpdates).toHaveLength(0); // no cancel write
   });
 
-  it('is idempotent: a venture no longer paused-awaiting is a no-op', async () => {
-    const activatedVenture = {
-      ...pausedAwaitingVenture,
-      metadata: { stage_zero: { awaiting_chairman_decision: false } },
-    };
+  // Adversarial-review round 1: the fresh re-read makes a concurrent transition a no-op.
+  it('is idempotent: a venture that transitioned between scan and apply is a no-op', async () => {
     const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
       decisions: [{ id: 'd-1', venture_id: 'v-1', status: 'approved', rationale: null }],
-      ventures: [activatedVenture],
+      freshVenture: null, // gone by the time we re-read — another instance applied it
     });
     const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
     expect(summary.processed).toBe(0);
     expect(supabase._recorded.ventureUpdates).toHaveLength(0);
   });
 
-  it('returns early with zero work when no resolved decisions exist', async () => {
-    const supabase = makeSupabase({ decisions: [], ventures: [] });
+  it('is idempotent: awaiting flag already cleared on the fresh read is a no-op', async () => {
+    const supabase = makeSupabase({
+      pausedVentures: [pausedAwaitingVenture],
+      decisions: [{ id: 'd-1', venture_id: 'v-1', status: 'approved', rationale: null }],
+      freshVenture: {
+        ...pausedAwaitingVenture,
+        metadata: { stage_zero: { awaiting_chairman_decision: false } },
+      },
+    });
     const summary = await processStageZeroDecisions({ supabase, logger: silentLogger });
-    expect(summary).toEqual({ processed: 0, activated: 0, parked: 0, errors: 0 });
+    expect(summary.processed).toBe(0);
+    expect(supabase._recorded.ventureUpdates).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Delta-C1 / Solomon FIX-2 (advisory a8eafc72, selection-gating for the Discovery run):** `chairman-review.js`'s `'ready'` path auto-inserted the venture as ACTIVE and machine-forged a `chairman_decisions` row (`status='approved'`, rationale `'Venture meets readiness criteria'`) — the machine approving on the chairman's behalf, violating spec R7 (machine RANKS, chairman PICKS).
- Ready path now creates the venture `status='paused'` with `metadata.stage_zero.awaiting_chairman_decision`; the synthetic-approval insert is **deleted**; artifact + brief-record writes preserved.
- The real gate is un-parked: `createOrReusePendingDecision` mints the stage-0 PENDING row via a new scoped `forceDecisionCreation` option (stage 0 is deliberately absent from `stage_config` — a config row would break TS-7 parity and feed `can_auto_advance`; the fixture-venture guard still wins). The mint is FAIL-CLOSED with a compensating cancel; the 23505 idempotent re-run re-mints so a mid-run death can never wedge a venture.
- New poll-side activation consumer (`lib/eva/stage-zero/decision-activation.js`, wired into the queue-processor tick): approved -> active with decision-id provenance; rejected -> nursery park + cancel (park failure leaves the venture paused/retryable); `decision_type='advisory'` rows can never activate.
- Orchestrator result gains `awaiting_chairman_decision` + `decision_id`; the false "Run: eva venture stage 1" instruction is gone.

## Test plan
- [x] Canary 1 — ready never self-approves: pending decision + paused venture + zero machine-written approved rows; canned rationale grep-pinned absent
- [x] Canary 2 — real approval activates; rejection parks (park path per STAGE0-NURSERY-PARK-PATH-001)
- [x] Force-flag scoping: default callers byte-identical; fixture guard wins over the flag
- [x] Machine-approver reachability pins (engine can_auto_advance, advisory writer)
- [x] 148 tests green across affected suites; full unit suite 25801 passed — the 11 failures are the pre-existing Windows environment baseline (verified identical on clean main)

LOC over 100 justified: the activation consumer must ship in lockstep with the pause (risk-agent HIGH/HIGH: every ready venture wedges without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
