### PR TITLE
feat(SD-LEO-INFRA-STAGE0-THESIS-PRICING-KEY-001): structured thesis price_point

### DIFF
--- a/lib/eva/stage-zero/thesis-contract.js
+++ b/lib/eva/stage-zero/thesis-contract.js
@@ -23,6 +23,27 @@ export const THESIS_FIELDS = Object.freeze(['who_pays', 'pays_for_what', 'reache
 // would have nursery-parked every competitor-teardown/blueprint venture).
 export const THESIS_CORE_FIELDS = Object.freeze(['who_pays', 'pays_for_what', 'demand_test_plan']);
 export const KILL_COMPARATORS = Object.freeze(['lt', 'lte', 'gt', 'gte', 'eq']);
+// SD-LEO-INFRA-STAGE0-THESIS-PRICING-KEY-001: price_point's payment model, so
+// demand-test-plan/kill-criteria/downstream consumers can branch on one-time vs
+// recurring instead of parsing prose. 'unknown' when the source text names no model.
+export const PRICE_MODELS = Object.freeze(['one_time', 'recurring', 'unknown']);
+
+const RECURRING_MODEL_HINTS = /subscription|recurring|\bmrr\b|\bmonthly\b|per\s+month|\/\s*mo(nth)?\b|\barr\b/i;
+const ONE_TIME_MODEL_HINTS = /one[-\s]?time|one[-\s]?off|single\s+purchase|flat\s+fee|license\s+fee/i;
+
+/**
+ * Infer the payment model from free-text revenue-model prose. Never guesses beyond the
+ * text's own hints — 'unknown' is an honest answer, not a failure.
+ * @param {string} [revenueModelText]
+ * @returns {'one_time'|'recurring'|'unknown'}
+ */
+function inferPriceModel(revenueModelText) {
+  if (!revenueModelText) return 'unknown';
+  const s = String(revenueModelText);
+  if (RECURRING_MODEL_HINTS.test(s)) return 'recurring';
+  if (ONE_TIME_MODEL_HINTS.test(s)) return 'one_time';
+  return 'unknown';
+}
 
 /**
  * Validate a venture thesis. A valid thesis answers: who pays, for what, how they are
@@ -38,8 +59,32 @@ export function validateVentureThesis(thesis) {
     return { valid: false, errors: ['thesis must be a non-null object (a bare score is not a Stage-Zero output)'] };
   }
   for (const f of THESIS_FIELDS) {
+    if (f === 'price_point') continue; // validated below as a structured object, not a string
     if (!thesis[f] || typeof thesis[f] !== 'string' || !thesis[f].trim()) {
       errors.push(`thesis.${f} is required (non-empty string)`);
+    }
+  }
+  // price_point (SD-LEO-INFRA-STAGE0-THESIS-PRICING-KEY-001): the registry's second
+  // first-class key — structured data, not prose, so downstream consumers (economics
+  // kill criteria, demand-test plan threshold, O6 revenue arming) read a key, not text.
+  const pricePoint = thesis.price_point;
+  if (!pricePoint || typeof pricePoint !== 'object' || Array.isArray(pricePoint)) {
+    errors.push('thesis.price_point is required (structured object: {amount_low, amount_high, currency, model, raw_text})');
+  } else {
+    if (pricePoint.amount_low != null && typeof pricePoint.amount_low !== 'number') {
+      errors.push('thesis.price_point.amount_low must be a number or null');
+    }
+    if (pricePoint.amount_high != null && typeof pricePoint.amount_high !== 'number') {
+      errors.push('thesis.price_point.amount_high must be a number or null');
+    }
+    if (!pricePoint.currency || typeof pricePoint.currency !== 'string') {
+      errors.push('thesis.price_point.currency is required (string)');
+    }
+    if (!PRICE_MODELS.includes(pricePoint.model)) {
+      errors.push(`thesis.price_point.model must be one of ${PRICE_MODELS.join('|')}`);
+    }
+    if (!pricePoint.raw_text || typeof pricePoint.raw_text !== 'string' || !pricePoint.raw_text.trim()) {
+      errors.push('thesis.price_point.raw_text is required (non-empty string, human-readable)');
     }
   }
   const plan = thesis.demand_test_plan;
@@ -155,12 +200,27 @@ export function buildThesisFromSynthesis(pathOutput = {}, synthesisResults = {},
   const revenueModel = candidate.revenue_model;
   const parsed = parseRevenuePotential(candidate.monthly_revenue_potential);
   if (revenueModel && String(revenueModel).trim()) {
-    thesis.price_point = parsed
-      ? `${String(revenueModel).trim()} (candidate estimate $${parsed.low}-$${parsed.high}/mo, E0 ungraded)`
-      : String(revenueModel).trim();
+    const revenueModelText = String(revenueModel).trim();
+    thesis.price_point = {
+      amount_low: parsed ? parsed.low : null,
+      amount_high: parsed ? parsed.high : null,
+      currency: parsed ? parsed.currency : 'USD',
+      model: inferPriceModel(revenueModelText),
+      raw_text: parsed
+        ? `${revenueModelText} (candidate estimate $${parsed.low}-$${parsed.high}/mo, E0 ungraded)`
+        : revenueModelText,
+      ...(parsed ? { grade: parsed.grade } : {}),
+    };
     provenance.price_point = { source_field: parsed ? 'candidate.revenue_model + monthly_revenue_potential' : 'candidate.revenue_model', derived: true };
   } else if (parsed) {
-    thesis.price_point = `candidate estimate $${parsed.low}-$${parsed.high}/mo (E0 ungraded — no external source)`;
+    thesis.price_point = {
+      amount_low: parsed.low,
+      amount_high: parsed.high,
+      currency: parsed.currency,
+      model: 'unknown', // no revenue_model text to infer one_time vs recurring from
+      raw_text: `candidate estimate $${parsed.low}-$${parsed.high}/mo (E0 ungraded — no external source)`,
+      grade: parsed.grade,
+    };
     provenance.price_point = { source_field: 'candidate.monthly_revenue_potential', derived: true, weak: true };
   } else incomplete.push('price_point');
 
@@ -221,7 +281,7 @@ export function deriveDefaultKillCriteria(thesis = {}) {
       comparator: 'lt',
       threshold: 1,
       stage_by: 24,
-      description: `Dies if zero real revenue events have occurred by stage 24 (${thesis?.price_point ? `price point: ${truncate(thesis.price_point, 80)}` : 'price point pending'}).`,
+      description: `Dies if zero real revenue events have occurred by stage 24 (${thesis?.price_point?.raw_text ? `price point: ${truncate(thesis.price_point.raw_text, 80)}` : 'price point pending'}).`,
       source: 'derived_default',
     },
   ];
@@ -303,6 +363,7 @@ export default {
   THESIS_FIELDS,
   THESIS_CORE_FIELDS,
   KILL_COMPARATORS,
+  PRICE_MODELS,
   validateVentureThesis,
   validateKillCriteria,
   evaluateKillCriterion,

--- a/tests/unit/eva/stage-zero/interfaces.test.js
+++ b/tests/unit/eva/stage-zero/interfaces.test.js
@@ -153,7 +153,7 @@ describe('validateVentureBrief', () => {
       who_pays: 'SMB owners',
       pays_for_what: 'an automated solution',
       reached_how: 'SEO + communities',
-      price_point: 'subscription $29/mo',
+      price_point: { amount_low: 29, amount_high: 29, currency: 'USD', model: 'recurring', raw_text: 'subscription $29/mo' },
       demand_test_plan: [
         { step: 1, instruction: 'landing page probe', success_signal: '>=10 signups' },
         { step: 2, instruction: 'pre-order ask', success_signal: '>=3 pre-commitments' },

--- a/tests/unit/eva/stage-zero/thesis-contract.test.js
+++ b/tests/unit/eva/stage-zero/thesis-contract.test.js
@@ -13,6 +13,7 @@ import {
   EXPLICIT_DECISIONS,
   buildExplicitDecisions,
   validateExplicitDecisions,
+  PRICE_MODELS,
 } from '../../../../lib/eva/stage-zero/thesis-contract.js';
 import { validateVentureBrief } from '../../../../lib/eva/stage-zero/interfaces.js';
 import { scanTextForStackCompliance, ruleApplies } from '../../../../lib/eva/standards/venture-stack-compliance.js';
@@ -22,7 +23,7 @@ const FULL_THESIS = {
   who_pays: 'B2B SaaS founders with 5-50 employees',
   pays_for_what: 'automated churn-risk digests from their existing billing data',
   reached_how: 'founder communities; SEO on churn keywords',
-  price_point: 'subscription $49/mo',
+  price_point: { amount_low: 49, amount_high: 49, currency: 'USD', model: 'recurring', raw_text: 'subscription $49/mo' },
   demand_test_plan: [
     { step: 1, instruction: 'Landing page with request-access CTA', success_signal: '>=10 qualified signups' },
     { step: 2, instruction: 'Pre-order ask at $49/mo', success_signal: '>=3 pre-commitments' },
@@ -124,9 +125,15 @@ describe('FR-1: buildThesisFromSynthesis derivation with provenance', () => {
     expect(t.provenance.who_pays.assumption).toBe('payer_assumed_equal_to_target_market');
     expect(t.provenance.pays_for_what.source_field).toBe('suggested_solution');
     expect(t.provenance.price_point.source_field).toContain('revenue_model');
-    expect(t.price_point).toContain('E0 ungraded'); // LLM estimate honestly labeled
+    expect(t.price_point.raw_text).toContain('E0 ungraded'); // LLM estimate honestly labeled
+    expect(t.price_point.amount_low).toBe(5000);
+    expect(t.price_point.amount_high).toBe(5000);
+    expect(t.price_point.currency).toBe('USD');
+    expect(t.price_point.model).toBe('recurring'); // 'subscription' revenue_model
+    expect(t.price_point.grade).toBe('E0');
     expect(t.incomplete_fields).toEqual([]);
     expect(t.demand_test_plan.length).toBeGreaterThanOrEqual(2);
+    expect(validateVentureThesis(t).valid).toBe(true);
   });
 
   it('prefers synthesis virality channels for reached_how when present', () => {
@@ -140,7 +147,90 @@ describe('FR-1: buildThesisFromSynthesis derivation with provenance', () => {
     expect(t.incomplete_fields).toContain('who_pays');
     expect(t.incomplete_fields).toContain('price_point');
     expect(t.incomplete_fields).toContain('demand_test_plan');
+    expect(t.price_point).toBeUndefined(); // absent, not a half-built structure
     expect(validateVentureThesis(t).valid).toBe(false); // incomplete thesis does not masquerade as valid
+  });
+});
+
+describe('FR-1b: price_point is a structured field (SD-LEO-INFRA-STAGE0-THESIS-PRICING-KEY-001)', () => {
+  it('validateVentureThesis rejects a string price_point (the old prose shape)', () => {
+    const r = validateVentureThesis({ ...FULL_THESIS, price_point: 'subscription $49/mo' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toContain('thesis.price_point is required (structured object');
+  });
+
+  it('validateVentureThesis rejects a structured price_point missing required sub-fields', () => {
+    const r = validateVentureThesis({ ...FULL_THESIS, price_point: { amount_low: 10 } });
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toContain('thesis.price_point.currency is required');
+    expect(r.errors.join(' ')).toContain('thesis.price_point.model must be one of');
+    expect(r.errors.join(' ')).toContain('thesis.price_point.raw_text is required');
+  });
+
+  it('validateVentureThesis rejects a non-numeric amount and an unlisted model', () => {
+    const r1 = validateVentureThesis({ ...FULL_THESIS, price_point: { ...FULL_THESIS.price_point, amount_low: '49' } });
+    expect(r1.errors.join(' ')).toContain('thesis.price_point.amount_low must be a number or null');
+    const r2 = validateVentureThesis({ ...FULL_THESIS, price_point: { ...FULL_THESIS.price_point, model: 'freemium' } });
+    expect(r2.errors.join(' ')).toContain(`thesis.price_point.model must be one of ${PRICE_MODELS.join('|')}`);
+  });
+
+  it('accepts null amounts (price genuinely unknown yet, refined by the demand test)', () => {
+    const r = validateVentureThesis({
+      ...FULL_THESIS,
+      price_point: { amount_low: null, amount_high: null, currency: 'USD', model: 'unknown', raw_text: 'price TBD via WTP probe' },
+    });
+    expect(r.valid).toBe(true);
+  });
+
+  it('buildThesisFromSynthesis infers model=recurring/one_time/unknown from revenue_model text', () => {
+    const pathOutput = { target_market: 'x', suggested_solution: 'y' };
+    const recurring = buildThesisFromSynthesis(pathOutput, {}, { revenue_model: 'monthly subscription', monthly_revenue_potential: '$10/month' });
+    expect(recurring.price_point.model).toBe('recurring');
+
+    const oneTime = buildThesisFromSynthesis(pathOutput, {}, { revenue_model: 'one-time license fee', monthly_revenue_potential: null });
+    expect(oneTime.price_point.model).toBe('one_time');
+    expect(oneTime.price_point.amount_low).toBeNull();
+    expect(oneTime.price_point.amount_high).toBeNull();
+    expect(oneTime.price_point.currency).toBe('USD');
+
+    const unknownModel = buildThesisFromSynthesis(pathOutput, {}, { revenue_model: 'ads', monthly_revenue_potential: null });
+    expect(unknownModel.price_point.model).toBe('unknown');
+  });
+
+  it('a parsed monthly_revenue_potential with NO revenue_model text still produces a valid structured price_point (model=unknown)', () => {
+    const pathOutput = { target_market: 'x', suggested_solution: 'y' };
+    const t = buildThesisFromSynthesis(pathOutput, {}, { monthly_revenue_potential: '$2K-$5K/month', automation_approach: 'cold outreach' });
+    expect(t.price_point.amount_low).toBe(2000);
+    expect(t.price_point.amount_high).toBe(5000);
+    expect(t.price_point.model).toBe('unknown');
+    expect(t.price_point.grade).toBe('E0');
+    expect(validateVentureThesis(t).valid).toBe(true);
+  });
+
+  it("deriveDefaultKillCriteria's kill-first-revenue description reads price_point.raw_text, not the object itself", () => {
+    const kills = deriveDefaultKillCriteria(FULL_THESIS);
+    const killFirstRevenue = kills.find((k) => k.id === 'kill-first-revenue');
+    expect(killFirstRevenue.description).toContain('subscription $49/mo');
+    expect(killFirstRevenue.description).not.toContain('[object Object]');
+
+    const noPriceKills = deriveDefaultKillCriteria({});
+    expect(noPriceKills.find((k) => k.id === 'kill-first-revenue').description).toContain('price point pending');
+  });
+
+  it('ALL-PATHS: the single production writer (buildThesisFromSynthesis) always emits a schema-valid structured price_point when any revenue signal exists', () => {
+    const pathOutput = { target_market: 'x', suggested_solution: 'y' };
+    const cases = [
+      { revenue_model: 'subscription', monthly_revenue_potential: '$5K/month' },
+      { revenue_model: 'one-time purchase', monthly_revenue_potential: null },
+      { monthly_revenue_potential: '$500/month' },
+    ];
+    for (const candidate of cases) {
+      const t = buildThesisFromSynthesis(pathOutput, {}, candidate);
+      expect(typeof t.price_point).toBe('object');
+      expect(PRICE_MODELS).toContain(t.price_point.model);
+      expect(typeof t.price_point.raw_text).toBe('string');
+      expect(t.price_point.raw_text.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/tests/unit/stage-zero.test.js
+++ b/tests/unit/stage-zero.test.js
@@ -216,7 +216,7 @@ describe('Stage 0 Interfaces', () => {
         who_pays: 'SMB owners',
         pays_for_what: 'a solution',
         reached_how: 'communities',
-        price_point: 'subscription $29/mo',
+        price_point: { amount_low: 29, amount_high: 29, currency: 'USD', model: 'recurring', raw_text: 'subscription $29/mo' },
         demand_test_plan: [
           { step: 1, instruction: 'landing page probe', success_signal: '>=10 signups' },
           { step: 2, instruction: 'pre-order ask', success_signal: '>=3 pre-commitments' },


### PR DESCRIPTION
## Summary
- `thesis.price_point` becomes a structured object (`amount_low`/`amount_high`, `currency`, `model`, `raw_text`) instead of free-text prose, in `lib/eva/stage-zero/thesis-contract.js`'s sole production thesis writer (`buildThesisFromSynthesis`)
- New `PRICE_MODELS` export (`one_time`/`recurring`/`unknown`) + `inferPriceModel()` helper, inferred from `revenue_model` text hints, never guessed beyond the text
- `validateVentureThesis` validates the structured shape and rejects the old string shape with a clear error
- `deriveDefaultKillCriteria`'s `kill-first-revenue` description now reads `price_point.raw_text` instead of stringifying the object
- SOFT-field-incomplete behavior (price_point absent → declared in `incomplete_fields`, doesn't demote maturity) is unchanged, matching the parent SD's PR #5809 adversarial-round-1 finding

Confirmed via LEAD-phase exploration (parallel Explore sweep + direct file reads, not guessed): exactly one production writer of a thesis object exists — all 4 Stage-0 entry paths funnel through `buildThesisFromSynthesis` — so the SD's ALL-PATHS clause is satisfied by this one constructor. The "economics kill criterion" has zero live consumers today (pre-existing gap, `docs/audit/stage-zero-flaw-ledger-charlie.md` CH-5) — wiring an actual consuming gate is separately-scoped future work, out of this SD's "single-repo, interfaces seam" framing.

## Test plan
- [x] New test coverage: structured-shape validation (valid/invalid sub-fields, null amounts), model inference (recurring/one_time/unknown), kill-criterion description fix, ALL-PATHS regression across 3 revenue-signal shapes
- [x] 3 existing fixture files updated from string to structured `price_point` (`thesis-contract.test.js`, `interfaces.test.js`, `stage-zero.test.js`)
- [x] Full `tests/unit/eva/stage-zero/` directory (43 files) + `tests/unit/stage-zero.test.js`: 643/643 passing, zero regressions
- [x] Repo-wide grep confirmed no other production code reads `thesis.price_point` (2 unrelated same-named fields exist elsewhere, neither touches this one)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>