### PR TITLE
fix(QF-20260710-850): ground Stage-0 competitor-teardown in fetched page content (Solomon C11)

### DIFF
--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -29,6 +29,26 @@ import { persistTeardownAnalyses } from '../../../competitive-intelligence/index
 import { runDifferentiationBoard } from '../../../competitive-intelligence/differentiation-board.js';
 import { projectBoardResultToStageZero } from '../../../competitive-intelligence/board-result-projection.js';
 
+// QF-20260710-850 (Solomon C11): fetchUrl was declared but never called — analyses must be
+// grounded in the fetched page; prior recall survives only as a labeled E0 fallback.
+async function defaultFetchUrl(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal, redirect: 'follow',
+      headers: { 'User-Agent': 'ehg-stage0-teardown/1.0 (+competitor-analysis)' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.text())
+      .replace(/<(script|style)[\s\S]*?<\/\1>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ').trim().slice(0, 6000);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * Execute the competitor teardown path.
  *
@@ -37,7 +57,7 @@ import { projectBoardResultToStageZero } from '../../../competitive-intelligence
  * @param {Object} deps - Injected dependencies
  * @param {Object} deps.supabase - Supabase client
  * @param {Object} [deps.logger] - Logger
- * @param {Function} [deps.fetchUrl] - URL fetcher (for testing)
+ * @param {Function} [deps.fetchUrl] - URL fetcher override; defaults to a real page fetch (QF-20260710-850)
  * @param {Object} [deps.llmClient] - LLM client override (for testing)
  * @returns {Promise<Object>} PathOutput
  */
@@ -54,7 +74,7 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
   const analyses = [];
   for (const url of urls) {
     logger.log(`   Analyzing: ${url}`);
-    const analysis = await analyzeCompetitor(url, { supabase, logger, llmClient });
+    const analysis = await analyzeCompetitor(url, { supabase, logger, llmClient, fetchUrl: deps.fetchUrl });
     analyses.push(analysis);
     logger.log(`   Completed: ${analysis.company_name || url}`);
   }
@@ -138,6 +158,10 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
       url_count: urls.length,
       companies_analyzed: analyses.map(a => a.company_name).filter(Boolean),
       canonical_ci_record_ids: seededRecordIds,
+      grounding: {
+        fetched: analyses.filter(a => a.grounding === 'fetched').length,
+        unfetched: analyses.filter(a => a.grounding === 'unfetched').length,
+      },
     },
     // FR-2: surface the projected board output so executeStageZero spreads it into
     // stage_zero_requests.result (the exact shape the ehg Stage-0 UI reads). Omitted
@@ -154,8 +178,14 @@ export async function executeCompetitorTeardown({ urls }, deps = {}) {
  * @returns {Promise<Object>} Competitor analysis
  */
 async function analyzeCompetitor(url, deps = {}) {
-  const { supabase, logger = console, llmClient } = deps;
+  const { supabase, logger = console, llmClient, fetchUrl } = deps;
   const client = llmClient || getValidationClient();
+
+  // QF-20260710-850: fetch the page first — the fetched content is the primary source.
+  const fetcher = fetchUrl || defaultFetchUrl;
+  let fetchedContent = null;
+  try { fetchedContent = (await fetcher(url)) || null; }
+  catch (err) { logger.warn(`   Warning: fetch failed for ${url} — falling back to model-knowledge profile (E0): ${err.message}`); }
 
   // SD-LEO-FEAT-AUTOMATED-RANKING-DATA-001 (US-005): Cross-reference URL with ranking data
   let marketPositionBlock = '';
@@ -204,11 +234,18 @@ async function analyzeCompetitor(url, deps = {}) {
     { stage: 0, path: 'competitor_teardown' }, { supabase }
   ).catch(() => '');
 
+  const fetchedBlock = fetchedContent
+    ? `\n## Fetched Site Content (primary source — ground the analysis in this)\n${fetchedContent}\n`
+    : '';
+  const groundingInstruction = fetchedContent
+    ? 'Ground the analysis in the Fetched Site Content above (primary source), supplemented by what you know. Provide a structured analysis:'
+    : 'No site content could be fetched. Based only on what you know about this URL/company, provide a structured analysis (it will be labeled as an unfetched model-knowledge profile):';
+
   const prompt = `Analyze this competitor business for venture creation purposes.
 
 Competitor URL: ${url}
-${marketPositionBlock}${mentalModelBlock ? `\n${mentalModelBlock}\n` : ''}
-Based on what you know about this URL/company, provide a structured analysis:
+${fetchedBlock}${marketPositionBlock}${mentalModelBlock ? `\n${mentalModelBlock}\n` : ''}
+${groundingInstruction}
 
 1. **Company Name**: The company name
 2. **Business Model**: How they make money (SaaS, marketplace, service, etc.)
@@ -235,18 +272,23 @@ Return a JSON object with these fields:
   "differentiation_opportunities": ["string"]
 }`;
 
+  // QF-20260710-850: unfetched output is re-labeled per Solomon C11 and graded E0.
+  const groundingStamp = fetchedContent
+    ? { grounding: 'fetched', fetched_chars: fetchedContent.length }
+    : { grounding: 'unfetched', grounding_label: 'model-knowledge profile, UNFETCHED', evidence_grade: 'E0' };
+
   try {
     // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
     const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {
-      return { ...JSON.parse(jsonMatch[0]), url, analyzed_at: new Date().toISOString() };
+      return { ...JSON.parse(jsonMatch[0]), url, analyzed_at: new Date().toISOString(), ...groundingStamp };
     }
-    return { url, company_name: url, error: 'Could not parse analysis', raw_response: text.substring(0, 500) };
+    return { url, company_name: url, error: 'Could not parse analysis', raw_response: text.substring(0, 500), ...groundingStamp };
   } catch (err) {
     logger.warn(`   Warning: Analysis failed for ${url}: ${err.message}`);
-    return { url, company_name: url, error: err.message };
+    return { url, company_name: url, error: err.message, ...groundingStamp };
   }
 }
 

--- a/tests/unit/competitor-teardown.test.js
+++ b/tests/unit/competitor-teardown.test.js
@@ -94,19 +94,21 @@ function createMockLLMClient(responses = {}) {
 }
 
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+// QF-20260710-850: unit tests must never hit the network — inject the fetch seam.
+const mockFetchUrl = vi.fn().mockResolvedValue('MOCK FETCHED SITE CONTENT for grounding');
 
 // ── Core Functionality Tests ──────────────────────────────────
 
 describe('Competitor Teardown - executeCompetitorTeardown', () => {
   test('requires at least one URL', async () => {
     await expect(
-      executeCompetitorTeardown({ urls: [] }, { logger: silentLogger })
+      executeCompetitorTeardown({ urls: [] }, { logger: silentLogger, fetchUrl: mockFetchUrl })
     ).rejects.toThrow('At least one competitor URL is required');
   });
 
   test('requires urls parameter', async () => {
     await expect(
-      executeCompetitorTeardown({}, { logger: silentLogger })
+      executeCompetitorTeardown({}, { logger: silentLogger, fetchUrl: mockFetchUrl })
     ).rejects.toThrow('At least one competitor URL is required');
   });
 
@@ -115,7 +117,7 @@ describe('Competitor Teardown - executeCompetitorTeardown', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://testcorp.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     // Verify PathOutput structure
@@ -143,7 +145,7 @@ describe('Competitor Teardown - executeCompetitorTeardown', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://comp-a.com', 'https://comp-b.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     // LLM should be called: 2 analyses + 1 deconstruction + 1 gap analysis = 4
@@ -164,7 +166,7 @@ describe('Competitor Teardown - executeCompetitorTeardown', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://single.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     // LLM should be called: 1 analysis + 1 deconstruction = 2
@@ -195,7 +197,7 @@ describe('Competitor Teardown - analyzeCompetitor', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://testcorp.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     const analysis = result.raw_material.competitor_analyses[0];
@@ -212,7 +214,7 @@ describe('Competitor Teardown - analyzeCompetitor', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://bad-response.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     // Should still produce a result, even with error in analysis
@@ -268,7 +270,7 @@ describe('Competitor Teardown - First Principles', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://comp.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     expect(result.suggested_name).toBe('AutoPilot');
@@ -295,7 +297,7 @@ describe('Competitor Teardown - First Principles', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://test.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     // Should still return a result, with empty suggested fields
@@ -321,7 +323,7 @@ describe('Competitor Teardown - Gap Analysis', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://comp1.com', 'https://comp2.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     const gap = result.raw_material.gap_analysis;
@@ -355,7 +357,7 @@ describe('Competitor Teardown - Gap Analysis', () => {
 
     const result = await executeCompetitorTeardown(
       { urls: ['https://comp1.com', 'https://comp2.com'] },
-      { logger: silentLogger, llmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient }
     );
 
     expect(result.raw_material.gap_analysis.error).toBe('Gap analysis failed');

--- a/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
+++ b/tests/unit/eva/stage-zero/paths/competitor-teardown.test.js
@@ -24,6 +24,8 @@ vi.mock('../../../../../scripts/modules/sd-key-generator.js', () => ({
 import { executeCompetitorTeardown } from '../../../../../lib/eva/stage-zero/paths/competitor-teardown.js';
 
 const silentLogger = { log: vi.fn(), warn: vi.fn() };
+// QF-20260710-850: unit tests must never hit the network — inject the fetch seam.
+const mockFetchUrl = vi.fn().mockResolvedValue('MOCK FETCHED SITE CONTENT for grounding');
 
 let mockLlmClient;
 
@@ -88,19 +90,19 @@ beforeEach(() => {
 
 describe('executeCompetitorTeardown', () => {
   test('throws when no URLs provided', async () => {
-    await expect(executeCompetitorTeardown({ urls: [] }, { logger: silentLogger }))
+    await expect(executeCompetitorTeardown({ urls: [] }, { logger: silentLogger, fetchUrl: mockFetchUrl }))
       .rejects.toThrow('At least one competitor URL is required');
   });
 
   test('throws when urls is undefined', async () => {
-    await expect(executeCompetitorTeardown({}, { logger: silentLogger }))
+    await expect(executeCompetitorTeardown({}, { logger: silentLogger, fetchUrl: mockFetchUrl }))
       .rejects.toThrow('At least one competitor URL is required');
   });
 
   test('analyzes single URL and returns PathOutput', async () => {
     const result = await executeCompetitorTeardown(
       { urls: ['http://competitor.com'] },
-      { logger: silentLogger, llmClient: mockLlmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
     );
 
     expect(result).not.toBeNull();
@@ -114,7 +116,7 @@ describe('executeCompetitorTeardown', () => {
   test('analyzes multiple URLs', async () => {
     const result = await executeCompetitorTeardown(
       { urls: ['http://a.com', 'http://b.com'] },
-      { logger: silentLogger, llmClient: mockLlmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
     );
 
     expect(result.competitor_urls).toEqual(['http://a.com', 'http://b.com']);
@@ -126,7 +128,7 @@ describe('executeCompetitorTeardown', () => {
   test('single competitor does not run gap analysis', async () => {
     const result = await executeCompetitorTeardown(
       { urls: ['http://single.com'] },
-      { logger: silentLogger, llmClient: mockLlmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
     );
 
     expect(result.raw_material.gap_analysis).toBeNull();
@@ -135,7 +137,7 @@ describe('executeCompetitorTeardown', () => {
   test('uses injected llmClient', async () => {
     await executeCompetitorTeardown(
       { urls: ['http://test.com'] },
-      { logger: silentLogger, llmClient: mockLlmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
     );
 
     expect(mockLlmClient.complete).toHaveBeenCalled();
@@ -144,7 +146,7 @@ describe('executeCompetitorTeardown', () => {
   test('returns valid PathOutput with suggested fields from deconstruction', async () => {
     const result = await executeCompetitorTeardown(
       { urls: ['http://test.com'] },
-      { logger: silentLogger, llmClient: mockLlmClient }
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
     );
 
     // The suggested fields come from the deconstruction response
@@ -152,6 +154,54 @@ describe('executeCompetitorTeardown', () => {
     expect(result.suggested_problem).toBeDefined();
     expect(result.suggested_solution).toBeDefined();
     expect(result.target_market).toBeDefined();
+  });
+});
+
+describe('executeCompetitorTeardown — fetch grounding (QF-20260710-850, Solomon C11)', () => {
+  test('calls the injected fetchUrl for each URL and grounds the analysis prompt in the fetched content', async () => {
+    await executeCompetitorTeardown(
+      { urls: ['http://a.com', 'http://b.com'] },
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
+    );
+
+    expect(mockFetchUrl).toHaveBeenCalledTimes(2);
+    expect(mockFetchUrl).toHaveBeenCalledWith('http://a.com');
+    // The first analysis prompt must embed the fetched content as primary source
+    const firstPrompt = mockLlmClient.complete.mock.calls[0][1];
+    expect(firstPrompt).toContain('Fetched Site Content');
+    expect(firstPrompt).toContain('MOCK FETCHED SITE CONTENT for grounding');
+    expect(firstPrompt).not.toContain('Based only on what you know');
+  });
+
+  test('stamps fetched analyses with grounding provenance and a metadata rollup', async () => {
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://a.com'] },
+      { logger: silentLogger, fetchUrl: mockFetchUrl, llmClient: mockLlmClient }
+    );
+
+    const analysis = result.raw_material.competitor_analyses[0];
+    expect(analysis.grounding).toBe('fetched');
+    expect(analysis.fetched_chars).toBeGreaterThan(0);
+    expect(analysis.evidence_grade).toBeUndefined();
+    expect(result.metadata.grounding).toEqual({ fetched: 1, unfetched: 0 });
+  });
+
+  test('fetch failure falls back to a labeled UNFETCHED model-knowledge profile graded E0', async () => {
+    const failingFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await executeCompetitorTeardown(
+      { urls: ['http://unreachable.example'] },
+      { logger: silentLogger, fetchUrl: failingFetch, llmClient: mockLlmClient }
+    );
+
+    const analysis = result.raw_material.competitor_analyses[0];
+    expect(analysis.grounding).toBe('unfetched');
+    expect(analysis.grounding_label).toBe('model-knowledge profile, UNFETCHED');
+    expect(analysis.evidence_grade).toBe('E0');
+    expect(result.metadata.grounding).toEqual({ fetched: 0, unfetched: 1 });
+    // The fallback prompt must declare itself, not masquerade as grounded analysis
+    const prompt = mockLlmClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('No site content could be fetched');
+    expect(prompt).not.toContain('Fetched Site Content');
   });
 });
 
@@ -184,7 +234,7 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     const result = await executeCompetitorTeardown(
       { urls: ['http://competitor.com'] },
       {
-        logger: silentLogger,
+        logger: silentLogger, fetchUrl: mockFetchUrl,
         llmClient: mockLlmClient,
         supabase: {}, // present, but persist disabled
         persistTeardownAnalyses: persistSpy,
@@ -205,7 +255,7 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     const result = await executeCompetitorTeardown(
       { urls: ['http://a.com', 'http://b.com'] },
       {
-        logger: silentLogger,
+        logger: silentLogger, fetchUrl: mockFetchUrl,
         llmClient: mockLlmClient,
         supabase: {},
         persistToCanonical: true,
@@ -268,7 +318,7 @@ describe('executeCompetitorTeardown — differentiation board wiring (SD-LEO-INF
     const result = await executeCompetitorTeardown(
       { urls: ['http://competitor.com'] },
       {
-        logger: silentLogger,
+        logger: silentLogger, fetchUrl: mockFetchUrl,
         llmClient: mockLlmClient,
         supabase: {},
         persistToCanonical: true,


### PR DESCRIPTION
## Summary
The teardown path declared `deps.fetchUrl` but never called it — every competitor analysis was LLM prior recall presented as grounded analysis (Solomon adjudication 41a2e6da C11, Delta ledger; reachable via path-router today).

- Wire the fetch: injectable `fetchUrl` seam, defaulting to a real page fetch (15s timeout, HTML-stripped, 6k cap); the analysis prompt now embeds the fetched content as primary source.
- Labeled fallback: when the fetch fails, output is re-labeled `model-knowledge profile, UNFETCHED` with `evidence_grade: 'E0'` (per the Stage-0 evidence-grading contract) instead of masquerading as analysis.
- `metadata.grounding` rollup (fetched/unfetched counts) for downstream consumers.
- Tests: 3 new cases (prompt grounding, provenance stamps, E0 fallback); all existing suites updated to inject the fetch seam so unit tests never hit the network. 38/38 pass locally.

Source LOC: 50+/8− (net 42). Cohort stage0-fixset-20260710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)