### PR TITLE
fix(QF-20260710-291): park_venture_decision terminates parks as cancelled, not approved

### DIFF
--- a/database/migrations/20260710_park_venture_decision_park_semantic_status.sql
+++ b/database/migrations/20260710_park_venture_decision_park_semantic_status.sql
@@ -1,3 +1,9 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Approval provenance: chairman approved in-session 2026-07-10 ~13:5x ET (verbatim "approved"),
+-- relayed by Adam (session def9008c) via advisory corr 61b0fd23-bf63-4d03-824e-13c5f8ada540,
+-- relayed to Alpha-4 by coordinator directive 361c53e1. Chain verified against the live
+-- session_coordination row before stamping.
+--
 -- QF-20260710-291: Stage-0 park round-trip persisted parked candidates as status='approved'
 -- (decision='pause') — semantically corrupt authority state, parked-path sibling of the
 -- Delta-C1 forged-approval class removed from the ready path by

--- a/database/migrations/20260710_park_venture_decision_park_semantic_status.sql
+++ b/database/migrations/20260710_park_venture_decision_park_semantic_status.sql
@@ -1,0 +1,91 @@
+-- QF-20260710-291: Stage-0 park round-trip persisted parked candidates as status='approved'
+-- (decision='pause') — semantically corrupt authority state, parked-path sibling of the
+-- Delta-C1 forged-approval class removed from the ready path by
+-- SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 (PR #5825).
+--
+-- Why it matters concretely: the Stage-0 activation consumer
+-- (lib/eva/stage-zero/decision-activation.js) treats status='approved' on a
+-- lifecycle_stage=0 stage_gate decision as an authentic chairman approval and ACTIVATES the
+-- paused venture — a chairman clicking "Park" would have activated the venture he parked.
+-- Downstream counts/filters that treat approved as decided-yes are likewise poisoned.
+--
+-- Fix: a park terminates the decision as status='cancelled' (decision stays 'pause',
+-- rationale preserved) — the only park-semantic value in the existing
+-- chairman_decisions_status_check (pending|approved|rejected|cancelled); no DDL, no
+-- constraint change. Consumers keying on approved (activation, decided-yes counts) no
+-- longer match; consumers keying on "not pending" (waitForDecision) resolve to a
+-- non-approved verdict, the safe polarity for a park.
+--
+-- SOLOMON RULING 28f557f7 binding clause (2): backfill rows already written
+-- parked-as-approved, not just the write path. Clause (1): this fix (or its backfill)
+-- MUST land before nursery RESURFACING goes live.
+
+CREATE OR REPLACE FUNCTION public.park_venture_decision(p_decision_id uuid, p_park_type text, p_reason text, p_decided_by text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'auth'
+AS $function$
+DECLARE
+  v_cd RECORD; v_vd RECORD;
+  v_venture_id UUID; v_source TEXT;
+BEGIN
+  -- SD-FDBK-INFRA-DEFENSE-DEPTH-CHAIRMAN-001: chairman/service_role authz guard (defense-in-depth;
+  -- closes the live authenticated-EXECUTE hole). Returns this function's standard {success:false}
+  -- soft-fail shape (it has no EXCEPTION handler to convert a RAISE); mirrors delete_venture.
+  IF NOT (public.fn_is_chairman() OR auth.role() = 'service_role') THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'insufficient_privilege: chairman or service role required',
+      'detail', '42501'
+    );
+  END IF;
+  SELECT * INTO v_cd FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending' FOR UPDATE;
+  IF FOUND THEN
+    v_source := 'chairman_decisions';
+    v_venture_id := v_cd.venture_id;
+    -- QF-20260710-291: a park is NOT an approval — terminate as cancelled (park-semantic
+    -- within the existing status CHECK). decision='pause' + rationale carry the park intent.
+    UPDATE chairman_decisions SET
+      decision = 'pause', status = 'cancelled',
+      rationale = p_reason,
+      decided_by = COALESCE(p_decided_by, COALESCE(auth.uid()::text, 'chairman')),
+      blocking = false, updated_at = now()
+    WHERE id = p_decision_id;
+  ELSE
+    SELECT * INTO v_vd FROM venture_decisions
+    WHERE id = p_decision_id AND decision IS NULL FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Decision not found or already resolved');
+    END IF;
+    v_source := 'venture_decisions';
+    v_venture_id := v_vd.venture_id;
+    UPDATE venture_decisions SET
+      decision = 'pause',
+      decided_by = COALESCE(p_decided_by::uuid, auth.uid()),
+      decided_at = now(), notes = p_reason, updated_at = now()
+    WHERE id = p_decision_id;
+  END IF;
+  UPDATE ventures SET
+    status = CASE WHEN p_park_type = 'blocked' THEN 'paused' ELSE status END,
+    workflow_status = 'paused',
+    updated_at = now()
+  WHERE id = v_venture_id;
+  RETURN jsonb_build_object(
+    'success', true, 'decision_id', p_decision_id,
+    'venture_id', v_venture_id, 'park_type', p_park_type,
+    'review_date', CASE
+      WHEN p_park_type = 'blocked' THEN (now() + interval '30 days')::date
+      WHEN p_park_type = 'nursery' THEN (now() + interval '90 days')::date
+    END, 'source', v_source
+  );
+END;
+$function$;
+
+-- Backfill (Solomon clause 2): rows already terminalized parked-as-approved become cancelled.
+-- decision='pause' + status='approved' is exactly and only the corrupt park shape (verified:
+-- 1 live row at authoring time — the assessment's authorized Park probe on a test fixture).
+UPDATE chairman_decisions
+SET status = 'cancelled', updated_at = now()
+WHERE decision = 'pause' AND status = 'approved';

--- a/tests/integration/eva/park-decision-status-realdb.test.js
+++ b/tests/integration/eva/park-decision-status-realdb.test.js
@@ -1,0 +1,106 @@
+/**
+ * REAL, DB-backed regression test for the park_venture_decision RPC.
+ *
+ * QF-20260710-291 (console-assessment finding #2, Alpha-3 ledger PR #5828; Solomon
+ * ruling 28f557f7): parking a pending chairman decision terminalized it as
+ * status='approved' (decision='pause') — semantically corrupt authority state, the
+ * parked-path sibling of the Delta-C1 forged-approval class removed from the ready
+ * path by SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001. Concretely dangerous:
+ * the Stage-0 activation consumer treats status='approved' on a lifecycle_stage=0
+ * stage_gate row as an authentic approval — a chairman clicking "Park" would have
+ * ACTIVATED the venture he parked.
+ *
+ * The fixed RPC terminates a park as status='cancelled' (decision='pause', rationale
+ * preserved). This test proves the round-trip against the REAL function: a parked
+ * pending decision never yields status='approved'. A mocked unit test cannot catch
+ * this — the defect lives in the SQL function body, not in JS.
+ *
+ * Uses real Supabase service-role connection (requires .env). Skipped if no real DB.
+ * Creates a disposable venture + decision; all rows cleaned up in afterAll.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { resolve } from 'path';
+import { describeDb } from '../../helpers/db-available.js';
+
+dotenv.config({ path: resolve(process.cwd(), '.env') });
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);
+
+const ts = Date.now();
+let ventureId;
+let decisionId;
+
+describeDb('park_venture_decision RPC (real DB) — QF-20260710-291', () => {
+  beforeAll(async () => {
+    const { data: venture, error: vErr } = await supabase
+      .from('ventures')
+      .insert({
+        name: `__e2e_park_status_${ts}__`,
+        problem_statement: 'Disposable venture for QF-20260710-291 park-status regression',
+        current_lifecycle_stage: 1,
+        is_demo: true,
+        status: 'paused',
+      })
+      .select('id')
+      .single();
+    if (vErr) throw new Error(`Failed to create venture: ${vErr.message}`);
+    ventureId = venture.id;
+
+    const { data: decision, error: dErr } = await supabase
+      .from('chairman_decisions')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: 0,
+        status: 'pending',
+        decision: 'pending',
+        decision_type: 'stage_gate',
+        summary: 'QF-20260710-291 regression fixture',
+      })
+      .select('id')
+      .single();
+    if (dErr) throw new Error(`Failed to create decision: ${dErr.message}`);
+    decisionId = decision.id;
+  });
+
+  afterAll(async () => {
+    if (decisionId) await supabase.from('chairman_decisions').delete().eq('id', decisionId);
+    if (ventureId) await supabase.from('ventures').delete().eq('id', ventureId);
+  });
+
+  it('a parked pending decision terminates as cancelled — NEVER approved', async () => {
+    const { data, error } = await supabase.rpc('park_venture_decision', {
+      p_decision_id: decisionId,
+      p_park_type: 'nursery',
+      p_reason: 'QF-20260710-291 regression park',
+    });
+    expect(error).toBeNull();
+    expect(data?.success).toBe(true);
+
+    const { data: row } = await supabase
+      .from('chairman_decisions')
+      .select('status, decision, rationale')
+      .eq('id', decisionId)
+      .single();
+    expect(row.status).not.toBe('approved'); // the corrupt-authority shape, pinned out
+    expect(row.status).toBe('cancelled');
+    expect(row.decision).toBe('pause');
+    expect(row.rationale).toBe('QF-20260710-291 regression park');
+  });
+
+  it('no parked-as-approved rows remain anywhere (Solomon clause 2 backfill holds)', async () => {
+    const { count, error } = await supabase
+      .from('chairman_decisions')
+      .select('id', { count: 'exact', head: true })
+      .eq('decision', 'pause')
+      .eq('status', 'approved');
+    expect(error).toBeNull();
+    expect(count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **QF-20260710-291** (console-assessment finding #2, Alpha-3 ledger PR #5828; Solomon ruling 28f557f7 — POST-RUN FIXABLE, sequence-coupled with nursery resurfacing): the `park_venture_decision` RPC terminalized parked chairman decisions as `status='approved', decision='pause'` — corrupt authority state, the parked-path sibling of the Delta-C1 forged-approval class removed from the ready path by SD-LEO-INFRA-STAGE0-CHAIRMAN-DECISION-AUTHORITY-001 (PR #5825).
- Concrete blast radius: the stage-0 activation consumer treats `status='approved'` on a `lifecycle_stage=0 stage_gate` row as an authentic approval — a chairman clicking **Park** would have **activated** the venture he parked. Decided-yes counts/filters were likewise poisoned.
- Fix: park terminates as `status='cancelled'` (the only park-semantic value in the existing `chairman_decisions_status_check`; `decision='pause'` + rationale preserved — no DDL, no constraint change).
- Solomon clause (2): backfill `UPDATE` for rows already written parked-as-approved (1 live row at authoring — the assessment's authorized test-fixture probe).
- Realdb regression test: a parked pending decision never yields `status='approved'`; zero parked-as-approved rows remain. Guarded by `describeDb` (skips without DB env).

## Apply status
The live apply is chairman-gated (`apply-migration.js --prod-deploy` requires an `@approved-by` header). Requested via coordinator signal (subtype `gated-ddl-apply`, sha256 `5453086016307e76c5feb6d3e3b07eefa0ca05185419b5c100ba262398aa2de6`). The realdb test passes once the migration is applied.

## Test plan
- [x] Migration dry-run clean (`[MIGRATION_APPLY_DRY_RUN]`, 1 declared object)
- [ ] Gated apply by chairman/Adam (requested)
- [ ] Realdb regression green post-apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)
