### PR TITLE
fix(QF-20260710-257): declared cadences for known scheduler rounds in periodic-registry seeder

### DIFF
--- a/scripts/seed-periodic-process-registry.mjs
+++ b/scripts/seed-periodic-process-registry.mjs
@@ -31,8 +31,22 @@ const supabase = createClient(
 
 const ROLE_SESSION_INTERVAL_SECONDS = 1800; // 30-min tick, matches the fleet's own ScheduleWakeup idle-tick convention
 
+// QF-20260710-257: known rounds map to their DECLARED cadence — prefix inference put
+// gap_analysis / vision_rescore / corrective_generation (registered 'weekly' in
+// lib/eva/eva-master-scheduler.js _registerDefaultRounds) on the 86400 default, and
+// okr-mid-month-review (registerJob cadenceDays: 15) on 86400, producing standing false
+// OVERDUE flags that the liveness watcher's seeder re-invocation re-asserted every run.
+// New scheduler rounds/jobs MUST be added here; prefix inference is fallback only.
+const DECLARED_ROUND_INTERVALS = {
+  vision_rescore: 604800,
+  gap_analysis: 604800,
+  corrective_generation: 604800,
+  'okr-mid-month-review': 1296000, // cadenceDays: 15 (NOT monthly — ground truth over advisory)
+};
+
 function intervalForRoundKey(key) {
-  if (key.startsWith('daily_') || key.startsWith('okr-mid-month')) return 86400;
+  if (DECLARED_ROUND_INTERVALS[key]) return DECLARED_ROUND_INTERVALS[key];
+  if (key.startsWith('daily_')) return 86400;
   if (key.startsWith('weekly_') || key.startsWith('friday_')) return 604800;
   if (key.startsWith('okr-monthly') || key.startsWith('monthly_')) return 2592000;
   return 86400; // conservative default for unrecognized prefixes


### PR DESCRIPTION
## Summary
`intervalForRoundKey()` inferred cadence from key prefixes, so `vision_rescore` / `gap_analysis` / `corrective_generation` (registered **weekly** in `lib/eva/eva-master-scheduler.js`) and `okr-mid-month-review` (**cadenceDays: 15**) all fell to the 86400 default — 4 standing false OVERDUE flags, re-asserted on every seeder run so in-place registry corrections could not stick (coordinator advisory 00ab9b9d).

- Explicit `DECLARED_ROUND_INTERVALS` map takes precedence; prefix inference remains only as fallback, with a comment that new rounds must be mapped.
- **Ground-truth divergence from the QF text**: okr-mid-month-review maps to **1296000** (15 days, per its own `cadenceDays: 15` declaration) — not the 2592000 the QF proposed.
- **Acceptance verified live**: fixed seeder run → `periodic-liveness-watcher` twice consecutively → **19/19 OK** both runs; registry rows confirmed 604800×3 + 1296000. Idempotency integration test passes.
- Note: no in-repo code path has the watcher re-invoking the seeder — the ~15-min reverter is whatever external invoker runs the shared-root seeder copy; it picks up this fix on merge.

15+/1−. Cohort: coordinator advisory 00ab9b9d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)