### PR TITLE
fix(QF-20260710-435): fixture-residue sweep — fixture ventures cannot sit live+undeleted

### DIFF
--- a/scripts/sweep-fixture-residue.mjs
+++ b/scripts/sweep-fixture-residue.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Fixture-venture residue sweep
+ * QF-20260710-435 (coordinator gauge delta e580c3e0; §H5 fence-6 residue class)
+ *
+ * Test/e2e fixture ventures must never sit LIVE (active/paused) and undeleted in prod
+ * tables — that is exactly the residue the simulated-run harness fence 6 asserts zero
+ * of post-run. This sweep is the standing assertion:
+ *
+ *   node scripts/sweep-fixture-residue.mjs          # assert: exit 1 + FIXTURE_RESIDUE lines on residue
+ *   node scripts/sweep-fixture-residue.mjs --fix    # sanctioned teardown: soft-delete (deleted_at + cancelled)
+ *
+ * Predicate (the QF-named classes, superset of the canonical isFixtureVenture):
+ *   is_demo=true | metadata.is_fixture=true | name ^__e2e_ | ^TEST- | ^parity-test- |
+ *   ^test-stub | ^Test Venture for
+ * The permanently-flagged canary venture is EXCLUDED — it is designed to cycle live
+ * briefly during probes (net-zero per run) and is not residue.
+ */
+
+import 'dotenv/config';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createClient } = require('@supabase/supabase-js');
+
+/** Canary exclusion — the one sanctioned permanently-flagged is_demo venture. */
+export const CANARY_NAME = 'Canary Venture Probe';
+
+export const FIXTURE_CLASS_RE = /^(__e2e_|TEST-|parity-test-|test-stub|Test Venture for )/i;
+
+/** Pure: is this row a fixture-class venture (QF-435 predicate)? */
+export function isFixtureClassVenture(v) {
+  if (!v) return false;
+  if (v.name === CANARY_NAME) return false;
+  if (v.is_demo === true) return true;
+  if (v.metadata && v.metadata.is_fixture === true) return true;
+  return typeof v.name === 'string' && FIXTURE_CLASS_RE.test(v.name);
+}
+
+/** Pure: is this fixture-class row LIVE residue (the fence-6 class)? */
+export function isLiveResidue(v) {
+  return isFixtureClassVenture(v)
+    && v.deleted_at == null
+    && (v.status === 'active' || v.status === 'paused');
+}
+
+/**
+ * Sweep prod ventures for fixture residue.
+ * @returns {Promise<{residue: Object[], fixed: number}>}
+ */
+export async function sweepFixtureResidue(supabase, { fix = false, logger = console } = {}) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('id, name, status, is_demo, deleted_at, metadata')
+    .is('deleted_at', null)
+    .in('status', ['active', 'paused']);
+  if (error) throw new Error(`sweep query failed: ${error.message}`);
+
+  const residue = (data || []).filter(isLiveResidue);
+
+  for (const v of residue) {
+    logger.log(`FIXTURE_RESIDUE id=${v.id} name="${v.name}" status=${v.status} ⚠`);
+  }
+
+  let fixed = 0;
+  if (fix && residue.length > 0) {
+    for (const v of residue) {
+      // Sanctioned teardown: soft-delete — deleted_at stamped, status terminal.
+      const { error: updErr } = await supabase
+        .from('ventures')
+        .update({ status: 'cancelled', deleted_at: new Date().toISOString() })
+        .eq('id', v.id);
+      if (updErr) {
+        logger.warn(`FIXTURE_RESIDUE_FIX_FAILED id=${v.id}: ${updErr.message}`);
+      } else {
+        fixed += 1;
+        logger.log(`FIXTURE_RESIDUE_FIXED id=${v.id} name="${v.name}" (soft-deleted)`);
+      }
+    }
+  }
+
+  logger.log(`FIXTURE_RESIDUE_CLEAN=${residue.length - fixed === 0} residue=${residue.length} fixed=${fixed}`);
+  return { residue, fixed };
+}
+
+async function main() {
+  const fix = process.argv.includes('--fix');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+  const supabase = createClient(url, key);
+  const { residue, fixed } = await sweepFixtureResidue(supabase, { fix });
+  // exitCode (not process.exit): hard-exiting with live supabase handles trips a libuv
+  // teardown assert on Windows (exit 127 AFTER printing CLEAN=true) — an assertion tool
+  // must have a trustworthy exit code.
+  process.exitCode = residue.length - fixed === 0 ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop())) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/tests/unit/sweep-fixture-residue.test.js
+++ b/tests/unit/sweep-fixture-residue.test.js
@@ -1,0 +1,83 @@
+/**
+ * QF-20260710-435: fixture ventures cannot sit active+undeleted (fence-6 residue class).
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  isFixtureClassVenture,
+  isLiveResidue,
+  sweepFixtureResidue,
+  CANARY_NAME,
+} from '../../scripts/sweep-fixture-residue.mjs';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('fixture-class predicate (QF-435 named classes)', () => {
+  test.each([
+    ['is_demo flag', { name: 'Anything', is_demo: true }],
+    ['metadata.is_fixture', { name: 'Anything', metadata: { is_fixture: true } }],
+    ['__e2e_ prefix', { name: '__e2e_product_review_gate_adv_123__' }],
+    ['TEST- key prefix', { name: 'TEST-HARNESS-S20-run42' }],
+    ['parity-test- prefix', { name: 'parity-test-foo' }],
+    ['test-stub prefix', { name: 'test-stub-bar' }],
+    ['Test Venture for prefix', { name: 'Test Venture for Owned-Audience Loop' }],
+  ])('matches %s', (_label, row) => {
+    expect(isFixtureClassVenture(row)).toBe(true);
+  });
+
+  test('real ventures and the canary are excluded', () => {
+    expect(isFixtureClassVenture({ name: 'MarketLens', is_demo: false })).toBe(false);
+    expect(isFixtureClassVenture({ name: CANARY_NAME, is_demo: true })).toBe(false);
+  });
+});
+
+describe('live-residue predicate (fence-6 class: live + undeleted)', () => {
+  test('active/paused undeleted fixtures are residue; cancelled or soft-deleted are not', () => {
+    expect(isLiveResidue({ name: '__e2e_x__', status: 'active', deleted_at: null })).toBe(true);
+    expect(isLiveResidue({ name: '__e2e_x__', status: 'paused', deleted_at: null })).toBe(true);
+    expect(isLiveResidue({ name: '__e2e_x__', status: 'cancelled', deleted_at: null })).toBe(false);
+    expect(isLiveResidue({ name: '__e2e_x__', status: 'active', deleted_at: '2026-07-10T00:00:00Z' })).toBe(false);
+    expect(isLiveResidue({ name: 'RealCo', status: 'active', deleted_at: null })).toBe(false);
+  });
+});
+
+describe('sweep: assert and fix modes', () => {
+  function mockSupabase(rows, updates = []) {
+    return {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({ data: rows, error: null }),
+        update: vi.fn((payload) => ({
+          eq: vi.fn((col, id) => {
+            updates.push({ id, payload });
+            return Promise.resolve({ error: null });
+          }),
+        })),
+      })),
+    };
+  }
+
+  test('assert mode reports residue without touching rows', async () => {
+    const rows = [{ id: 'v1', name: '__e2e_x__', status: 'paused', deleted_at: null }];
+    const updates = [];
+    const { residue, fixed } = await sweepFixtureResidue(mockSupabase(rows, updates), { logger: silentLogger });
+    expect(residue).toHaveLength(1);
+    expect(fixed).toBe(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  test('--fix soft-deletes residue (deleted_at + cancelled) — the sanctioned teardown', async () => {
+    const rows = [
+      { id: 'v1', name: '__e2e_x__', status: 'paused', deleted_at: null },
+      { id: 'v2', name: 'RealCo', status: 'active', deleted_at: null }, // not residue
+    ];
+    const updates = [];
+    const { residue, fixed } = await sweepFixtureResidue(mockSupabase(rows, updates), { fix: true, logger: silentLogger });
+    expect(residue).toHaveLength(1);
+    expect(fixed).toBe(1);
+    expect(updates).toEqual([
+      { id: 'v1', payload: expect.objectContaining({ status: 'cancelled', deleted_at: expect.any(String) }) },
+    ]);
+  });
+});


### PR DESCRIPTION
Coordinator gauge delta e580c3e0 (cohort: pre-Saturday fence hygiene): two e2e fixture ventures sat active+undeleted — the exact residue class fence 6 asserts zero of post-run.

- **scripts/sweep-fixture-residue.mjs**: standing assertion (exit 1 on residue) + `--fix` sanctioned soft-delete teardown. Predicate = is_demo / metadata.is_fixture / `__e2e_`-,TEST-,parity-test-,test-stub,'Test Venture for' prefixes; the permanently-flagged canary venture excluded by design.
- **Live teardown executed**: paused `__e2e_product_review_gate_adv` soft-deleted via --fix; named Owned-Audience + remaining undeleted e2e rows stamped `deleted_at`. Assert mode verified clean (trustworthy exit code — `process.exitCode`, avoiding the Windows libuv teardown abort).
- 11 unit tests pin the predicate, the live-residue class, and both sweep modes.

Pre-cleans the Saturday simulated run's zero-residue fences so pre-existing dirt cannot false-fail them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)