### PR TITLE
fix(harness): fixture uses live ventures columns — is_synthetic does not exist

### DIFF
--- a/scripts/harness/s20-fixture.mjs
+++ b/scripts/harness/s20-fixture.mjs
@@ -7,7 +7,9 @@
  * fixture conventions so every exclusion guard refuses to route it:
  *   - ventures.is_demo = true            (the canonical isFixtureVenture discriminant —
  *                                         lib/eva/chairman-decision-watcher.js:36)
- *   - ventures.is_synthetic = true       (synthetic-venture-factory convention)
+ *   - metadata.synthetic = true          (live ventures table has NO is_synthetic column —
+ *                                         smoke-run finding 2026-07-10: pipeline-runner files
+ *                                         still write/filter that phantom column; ledger item)
  *   - name 'TEST-HARNESS-S20-<run-id>'   (TEST- fixture family key)
  *   - metadata.is_fixture / metadata.synthetic = true (spec §H1/§H5-6 markers)
  *
@@ -62,7 +64,12 @@ export function buildFixtureVentureRow(runId, { entryStage = 20 } = {}) {
     current_lifecycle_stage: entryStage,
     status: 'active',
     is_demo: true,        // canonical isFixtureVenture discriminant
-    is_synthetic: true,   // synthetic-venture-factory convention
+    // NOTE (smoke-run finding 2026-07-10): the LIVE ventures table has NO
+    // is_synthetic column (only is_demo + is_scaffolding) — the insert failed
+    // with a PostgREST schema error. metadata.synthetic below carries the
+    // synthetic marker instead. Separately ledgered: pipeline-runner files
+    // (synthetic-venture-factory.js:190, pipeline-executor.js:101,
+    // circuit-breaker.js:82) still write/filter the phantom column.
     metadata: {
       is_fixture: true,
       synthetic: true,

--- a/tests/unit/harness/s20-harness-slice.test.js
+++ b/tests/unit/harness/s20-harness-slice.test.js
@@ -24,8 +24,8 @@ describe('§H1: fixture venture row contract', () => {
     expect(row.is_demo).toBe(true);
   });
 
-  it('carries every exclusion marker: is_synthetic, TEST- family name, metadata.is_fixture/synthetic', () => {
-    expect(row.is_synthetic).toBe(true);
+  it('carries every exclusion marker: TEST- family name, metadata.is_fixture/synthetic (NO is_synthetic — live ventures table has no such column, smoke finding 2026-07-10)', () => {
+    expect(row.is_synthetic).toBeUndefined(); // phantom column — insert fails live if present
     expect(row.name.startsWith(FIXTURE_NAME_PREFIX)).toBe(true);
     expect(row.name.startsWith('TEST-')).toBe(true);
     expect(row.metadata.is_fixture).toBe(true);


### PR DESCRIPTION
## Summary
- First smoke-arc finding: the H1 fixture insert failed live — `ventures.is_synthetic` was never a column (live table has only `is_demo` + `is_scaffolding`). Dropped from the insert; `metadata.synthetic` (already present) carries the marker; `is_demo` remains the canonical `isFixtureVenture` discriminant.
- **Ledger-class side-catch**: production pipeline-runner files (`synthetic-venture-factory.js:190`, `pipeline-executor.js:101`, `circuit-breaker.js:82`) write/filter the same phantom column — the entire synthetic-venture insert path shares this live break (same class as ledger CH-1). Reported to the coordinator for adjudication fold.

## Test plan
- 22/22 harness tests green; node --check + eslint clean. Smoke arc re-runs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)