### PR TITLE
feat(SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001): get_pending_chairman_items — canonical chairman-actionable RPC (chairman-gated apply)

### DIFF
--- a/database/migrations/20260710_create_get_pending_chairman_items.sql
+++ b/database/migrations/20260710_create_get_pending_chairman_items.sql
@@ -1,0 +1,106 @@
+-- SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001
+-- Create get_pending_chairman_items(): the CANONICAL chairman-actionable pending-items source.
+--
+-- WHY: the console's designed reader (src/hooks/useDecisionGateQueue.ts:61 in rickfelix/ehg)
+-- has called this function since UIUX-B, but it was never created — every /chairman and
+-- /chairman/decisions load 404s (PGRST202) and falls back to the raw chairman_pending_decisions
+-- view, which mixes machine telemetry into the chairman's queue (measured 2026-07-10:
+-- 77 rows = 75 flag_review telemetry + 2 real approvals — a ~20x actionable-load overstatement).
+--
+-- ============================================================================
+-- SHARED PREDICATE ARTIFACT (canonical home — do not re-derive elsewhere)
+-- Consumed by: SD-EHG-CONSOLE-QUEUE-POLLUTION-001 (view scope) and
+-- SD-EHG-CONSOLE-PENDING-COUNT-SSOT-001 (every pending-count gauge reads total from here).
+-- A row is CHAIRMAN-ACTIONABLE iff ALL of:
+--   1. status = 'pending'
+--   2. decision_type is in the ALLOWLIST:
+--        'chairman_approval', 'gate_decision'          -- always actionable (RPC-actionable set,
+--                                                      -- DecisionActions.tsx:38)
+--        'escalation', 'okr_acceptance'                -- only when blocking = true (human-routed)
+--      (allowlist, not blocklist: new/unknown decision_type values are EXCLUDED by default and
+--       must be deliberately admitted here. flag_review / flag_enablement — auto-filed
+--       harness telemetry — are intentionally NOT admitted.)
+--   3. NOT a fixture venture: venture_id IS NULL (holding-level) OR the linked venture has
+--      (is_demo IS DISTINCT FROM true) AND name NOT LIKE '\_\_%' AND name NOT ILIKE 'test venture%'
+--      AND name NOT ILIKE '%citest%' AND name NOT ILIKE 'canonical-source-test%'
+-- Ratified with SD-EHG-CONSOLE-QUEUE-POLLUTION-001 (coordinator thread cae7eb0d); any future
+-- change lands HERE first and siblings follow.
+-- ============================================================================
+--
+-- Envelope: jsonb { items: [...], total: <int>, page: <int>, page_size: <int> }
+-- Each item is the view row (to_jsonb) plus consumer aliases:
+--   deadline := response_deadline  (GateDecision reads .deadline; raw view rows leave it
+--                                   undefined — the queue's blanket "No SLA" artifact)
+--   summary  := recommendation
+--
+-- Security: SECURITY INVOKER (caller's RLS posture), STABLE, read-only. EXECUTE granted to
+-- authenticated + service_role. No table DDL, no writer surface.
+--
+-- APPLY (chairman-gated, requires_chairman_apply pre-flagged at sourcing):
+--   node scripts/apply-migration.js database/migrations/20260710_create_get_pending_chairman_items.sql --prod-deploy
+--   with the chairman @approved-by stamp per standing policy.
+--
+-- ROLLBACK:
+--   DROP FUNCTION IF EXISTS public.get_pending_chairman_items(text, integer, integer);
+--   (consumers transparently resume the existing view-fallback path, useDecisionGateQueue.ts:77)
+
+CREATE OR REPLACE FUNCTION public.get_pending_chairman_items(
+  p_decision_type text DEFAULT NULL,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+WITH actionable AS (
+  SELECT d.*
+  FROM public.chairman_pending_decisions d
+  LEFT JOIN public.ventures v ON v.id = d.venture_id
+  WHERE d.status = 'pending'
+    AND (
+      d.decision_type IN ('chairman_approval', 'gate_decision')
+      OR (d.decision_type IN ('escalation', 'okr_acceptance') AND d.blocking IS TRUE)
+    )
+    AND (
+      d.venture_id IS NULL
+      OR (
+        (v.is_demo IS DISTINCT FROM TRUE)
+        AND v.name NOT LIKE '\_\_%'
+        AND v.name NOT ILIKE 'test venture%'
+        AND v.name NOT ILIKE '%citest%'
+        AND v.name NOT ILIKE 'canonical-source-test%'
+      )
+    )
+    AND (p_decision_type IS NULL OR d.decision_type = p_decision_type)
+),
+page AS (
+  SELECT *
+  FROM actionable
+  ORDER BY
+    CASE effective_priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+    created_at ASC
+  LIMIT GREATEST(COALESCE(p_page_size, 50), 1)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1) - 1) * GREATEST(COALESCE(p_page_size, 50), 1)
+)
+SELECT jsonb_build_object(
+  'items', COALESCE(
+    (SELECT jsonb_agg(
+       to_jsonb(page.*)
+       || jsonb_build_object('deadline', page.response_deadline, 'summary', page.recommendation)
+     ) FROM page),
+    '[]'::jsonb
+  ),
+  'total', (SELECT count(*) FROM actionable),
+  'page', GREATEST(COALESCE(p_page, 1), 1),
+  'page_size', GREATEST(COALESCE(p_page_size, 50), 1)
+);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO service_role;
+
+COMMENT ON FUNCTION public.get_pending_chairman_items(text, integer, integer) IS
+'Canonical chairman-actionable pending-items source (SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001). Predicate is the shared artifact for QUEUE-POLLUTION-001 / PENDING-COUNT-SSOT-001 — change it here first. Envelope: {items,total,page,page_size}.';

--- a/database/migrations/20260710_create_get_pending_chairman_items.sql
+++ b/database/migrations/20260710_create_get_pending_chairman_items.sql
@@ -64,16 +64,17 @@ WITH actionable AS (
       d.decision_type IN ('chairman_approval', 'gate_decision')
       OR (d.decision_type IN ('escalation', 'okr_acceptance') AND d.blocking IS TRUE)
     )
-    AND (
-      d.venture_id IS NULL
-      OR (
-        (v.is_demo IS DISTINCT FROM TRUE)
-        AND v.name NOT LIKE '\_\_%'
-        AND v.name NOT ILIKE 'test venture%'
-        AND v.name NOT ILIKE '%citest%'
-        AND v.name NOT ILIKE 'canonical-source-test%'
-      )
-    )
+    -- Fixture exclusion: exclude only rows POSITIVELY identified as fixture-linked.
+    -- COALESCE(..., false) makes NULL venture name / dangling reference / RLS-invisible
+    -- venture resolve to INCLUDE — a real pending decision must never vanish because its
+    -- venture row is missing or unreadable (adversarial-review W2).
+    AND NOT COALESCE(
+      v.is_demo IS TRUE
+      OR v.name LIKE '\_\_%'
+      OR v.name ILIKE 'test venture%'
+      OR v.name ILIKE '%citest%'
+      OR v.name ILIKE 'canonical-source-test%'
+    , false)
     AND (p_decision_type IS NULL OR d.decision_type = p_decision_type)
 ),
 page AS (
@@ -81,9 +82,10 @@ page AS (
   FROM actionable
   ORDER BY
     CASE effective_priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
-    created_at ASC
-  LIMIT GREATEST(COALESCE(p_page_size, 50), 1)
-  OFFSET (GREATEST(COALESCE(p_page, 1), 1) - 1) * GREATEST(COALESCE(p_page_size, 50), 1)
+    created_at ASC,
+    id ASC -- unique tiebreaker: LIMIT/OFFSET pages must be deterministic (adversarial-review W1)
+  LIMIT LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1) - 1)::bigint * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
 )
 SELECT jsonb_build_object(
   'items', COALESCE(
@@ -95,7 +97,7 @@ SELECT jsonb_build_object(
   ),
   'total', (SELECT count(*) FROM actionable),
   'page', GREATEST(COALESCE(p_page, 1), 1),
-  'page_size', GREATEST(COALESCE(p_page_size, 50), 1)
+  'page_size', LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
 );
 $$;
 

--- a/database/migrations/20260710_create_get_pending_chairman_items.sql
+++ b/database/migrations/20260710_create_get_pending_chairman_items.sql
@@ -99,6 +99,8 @@ SELECT jsonb_build_object(
 );
 $$;
 
+-- Least-privilege: strip the Postgres default PUBLIC EXECUTE before granting (security-agent review).
+REVOKE EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO service_role;
 

--- a/tests/integration/get-pending-chairman-items.contract.test.js
+++ b/tests/integration/get-pending-chairman-items.contract.test.js
@@ -51,9 +51,11 @@ describe('get_pending_chairman_items — static migration contract', () => {
     expect(SQL).not.toMatch(/IN \([^)]*'flag_enablement'/);
   });
 
-  it('fixture exclusion + grants + rollback are declared', () => {
-    expect(SQL).toMatch(/is_demo IS DISTINCT FROM TRUE/);
-    expect(SQL).toMatch(/NOT LIKE '\\_\\_%'/);
+  it('fixture exclusion + grants + rollback are declared (positive-identification form, NULL-safe)', () => {
+    expect(SQL).toMatch(/NOT COALESCE\(/);
+    expect(SQL).toMatch(/is_demo IS TRUE/);
+    expect(SQL).toMatch(/LIKE '\\_\\_%'/);
+    expect(SQL).toMatch(/, false\)/); // NULL/dangling/RLS-invisible venture resolves to INCLUDE
     expect(SQL).toMatch(/GRANT EXECUTE ON FUNCTION public\.get_pending_chairman_items\(text, integer, integer\) TO authenticated/);
     expect(SQL).toMatch(/DROP FUNCTION IF EXISTS public\.get_pending_chairman_items\(text, integer, integer\)/);
   });
@@ -111,7 +113,8 @@ describe.skipIf(!POOLER)('get_pending_chairman_items — live BEGIN..ROLLBACK co
       expect(Object.keys(env).sort()).toEqual(['items', 'page', 'page_size', 'total']);
       expect(Array.isArray(env.items)).toBe(true);
       expect(typeof env.total).toBe('number');
-      expect(env.total).toBeGreaterThanOrEqual(env.items.length === 200 ? 200 : env.items.length);
+      expect(env.total).toBeGreaterThanOrEqual(1); // the seeded real approval guarantees >=1
+      expect(env.page_size).toBe(200); // requested size within the LEAST(...,200) cap is honored
 
       // TS-2: telemetry classes NEVER appear; fixture-venture specimen excluded
       for (const item of env.items) {

--- a/tests/integration/get-pending-chairman-items.contract.test.js
+++ b/tests/integration/get-pending-chairman-items.contract.test.js
@@ -1,0 +1,162 @@
+/**
+ * SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001 — get_pending_chairman_items contract test.
+ *
+ * Pins the RPC's envelope shape and the SHARED chairman-actionable predicate so consumer/DB
+ * drift fails CI (reader/writer contract pattern). Two halves, per the established recipe
+ * (initiative-backbone-a1a-migration.test.js):
+ *   1. STATIC assertions over the migration SQL — run everywhere, no DB needed.
+ *   2. LIVE BEGIN..ROLLBACK against the real DB (skipIf no SUPABASE_POOLER_URL): executes the
+ *      CREATE OR REPLACE inside a transaction (works identically BEFORE the chairman-gated
+ *      production apply and AFTER it — CREATE OR REPLACE is idempotent), seeds predicate
+ *      specimens, asserts, rolls back. No persistent DDL, no persistent rows.
+ *
+ * Consumer contract pinned here = what src/hooks/useDecisionGateQueue.ts:61 (rickfelix/ehg)
+ * actually parses: jsonb envelope with `items` (GateDecision-shaped, incl. `deadline` and
+ * `summary` aliases) and `total`.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../');
+const MIGRATION_PATH = resolve(REPO_ROOT, 'database/migrations/20260710_create_get_pending_chairman_items.sql');
+const SQL = readFileSync(MIGRATION_PATH, 'utf8');
+
+describe('get_pending_chairman_items — static migration contract', () => {
+  it('creates the exact consumer-called signature (text, integer, integer)', () => {
+    expect(SQL).toMatch(/CREATE OR REPLACE FUNCTION public\.get_pending_chairman_items\(/);
+    expect(SQL).toMatch(/p_decision_type text DEFAULT NULL/);
+    expect(SQL).toMatch(/p_page integer DEFAULT 1/);
+    expect(SQL).toMatch(/p_page_size integer DEFAULT 50/);
+  });
+
+  it('is read-only, STABLE, SECURITY INVOKER, with pinned search_path', () => {
+    expect(SQL).toMatch(/\bSTABLE\b/);
+    expect(SQL).toMatch(/SECURITY INVOKER/);
+    expect(SQL).toMatch(/SET search_path = public/);
+    expect(SQL).not.toMatch(/SECURITY DEFINER/);
+    // no writer surface (rollback DROP lives only in the comment header)
+    expect(SQL).not.toMatch(/INSERT INTO/i);
+    expect(SQL).not.toMatch(/UPDATE\s+\w+\s+SET/i);
+    expect(SQL).not.toMatch(/DELETE FROM/i);
+  });
+
+  it('predicate is an ALLOWLIST (unknown types excluded by default; telemetry never admitted)', () => {
+    expect(SQL).toMatch(/decision_type IN \('chairman_approval', 'gate_decision'\)/);
+    expect(SQL).toMatch(/decision_type IN \('escalation', 'okr_acceptance'\) AND d\.blocking IS TRUE/);
+    // telemetry classes must never appear as admitted values
+    expect(SQL).not.toMatch(/IN \([^)]*'flag_review'/);
+    expect(SQL).not.toMatch(/IN \([^)]*'flag_enablement'/);
+  });
+
+  it('fixture exclusion + grants + rollback are declared', () => {
+    expect(SQL).toMatch(/is_demo IS DISTINCT FROM TRUE/);
+    expect(SQL).toMatch(/NOT LIKE '\\_\\_%'/);
+    expect(SQL).toMatch(/GRANT EXECUTE ON FUNCTION public\.get_pending_chairman_items\(text, integer, integer\) TO authenticated/);
+    expect(SQL).toMatch(/DROP FUNCTION IF EXISTS public\.get_pending_chairman_items\(text, integer, integer\)/);
+  });
+});
+
+const POOLER = process.env.SUPABASE_POOLER_URL;
+
+describe.skipIf(!POOLER)('get_pending_chairman_items — live BEGIN..ROLLBACK contract', () => {
+  let client;
+
+  beforeAll(async () => {
+    const { Client } = await import('pg');
+    client = new Client({ connectionString: POOLER });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  const call = async (args = {}) => {
+    const { p_decision_type = null, p_page = 1, p_page_size = 50 } = args;
+    const { rows } = await client.query(
+      'SELECT public.get_pending_chairman_items($1, $2, $3) AS env',
+      [p_decision_type, p_page, p_page_size]
+    );
+    return rows[0].env;
+  };
+
+  it('envelope + predicate + aliases + pagination hold on live data plus seeded specimens (TS-1..TS-4)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query(SQL); // transactional self-apply (idempotent post-apply too)
+
+      // Seed specimens (rolled back): one real holding-level approval, one fixture-venture approval.
+      const seeded = await client.query(`
+        INSERT INTO public.chairman_decisions (lifecycle_stage, decision, decision_type, status, summary)
+        VALUES (0, 'pending', 'stage_gate', 'pending', 'contract-test real approval (rollback)')
+        RETURNING id`);
+      const realId = seeded.rows[0].id;
+
+      const fixtureVenture = await client.query(
+        'SELECT id FROM public.ventures WHERE name LIKE \'\\_\\_%\' LIMIT 1');
+      let fixtureDecisionId = null;
+      if (fixtureVenture.rows.length) {
+        const fx = await client.query(`
+          INSERT INTO public.chairman_decisions (lifecycle_stage, decision, decision_type, status, summary, venture_id)
+          VALUES (0, 'pending', 'stage_gate', 'pending', 'contract-test fixture approval (rollback)', $1)
+          RETURNING id`, [fixtureVenture.rows[0].id]);
+        fixtureDecisionId = fx.rows[0].id;
+      }
+
+      // TS-1: envelope shape
+      const env = await call({ p_page_size: 200 });
+      expect(Object.keys(env).sort()).toEqual(['items', 'page', 'page_size', 'total']);
+      expect(Array.isArray(env.items)).toBe(true);
+      expect(typeof env.total).toBe('number');
+      expect(env.total).toBeGreaterThanOrEqual(env.items.length === 200 ? 200 : env.items.length);
+
+      // TS-2: telemetry classes NEVER appear; fixture-venture specimen excluded
+      for (const item of env.items) {
+        expect(['flag_review', 'flag_enablement']).not.toContain(item.decision_type);
+        // consumer aliases present on every item
+        expect('deadline' in item).toBe(true);
+        expect('summary' in item).toBe(true);
+      }
+      if (fixtureDecisionId) {
+        expect(env.items.some((i) => i.id === fixtureDecisionId)).toBe(false);
+      }
+
+      // TS-3: seeded real approval included; type filter works
+      expect(env.items.some((i) => i.id === realId)).toBe(true);
+      const onlyApprovals = await call({ p_decision_type: 'chairman_approval', p_page_size: 200 });
+      expect(onlyApprovals.items.every((i) => i.decision_type === 'chairman_approval')).toBe(true);
+      expect(onlyApprovals.items.some((i) => i.id === realId)).toBe(true); // view stamps chairman_decisions rows as chairman_approval
+
+      // Predicate consistency: total never exceeds the raw pending view count (pollution removed, never added)
+      const raw = await client.query(
+        'SELECT count(*)::int AS n FROM public.chairman_pending_decisions WHERE status = \'pending\'');
+      expect(env.total).toBeLessThanOrEqual(raw.rows[0].n);
+
+      // TS-4: pagination — page_size 1 yields disjoint items with constant total
+      const p1 = await call({ p_page: 1, p_page_size: 1 });
+      const p2 = await call({ p_page: 2, p_page_size: 1 });
+      expect(p1.items.length).toBe(1);
+      expect(p1.total).toBe(p2.total);
+      if (p2.items.length === 1) expect(p1.items[0].id).not.toBe(p2.items[0].id);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('TS-5: shape drift fails loudly — a scratch copy with a renamed envelope key breaks the pinned keys', async () => {
+    await client.query('BEGIN');
+    try {
+      const drifted = SQL
+        .replace(/get_pending_chairman_items/g, '__drift_probe_gpci')
+        .replace("'items',", "'rows',");
+      await client.query(drifted);
+      const { rows } = await client.query('SELECT public.__drift_probe_gpci(NULL, 1, 5) AS env');
+      expect(Object.keys(rows[0].env).sort()).not.toEqual(['items', 'page', 'page_size', 'total']);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Ledger finding #10 (P1): the console's designed reader (`useDecisionGateQueue.ts:61`) has 404'd on every `/chairman` + `/chairman/decisions` load — the RPC was never created. This PR ships the migration + contract test; the **production apply is chairman-gated** (`requires_chairman_apply`): `node scripts/apply-migration.js database/migrations/20260710_create_get_pending_chairman_items.sql --prod-deploy` with the @approved-by stamp.

- **Canonical shared predicate** (QUEUE-POLLUTION-001 + PENDING-COUNT-SSOT-001 consume it from here; coordinator thread cae7eb0d): allowlist `chairman_approval`/`gate_decision` + blocking `escalation`/`okr_acceptance`; telemetry (`flag_review`/`flag_enablement`) never admitted; fixture ventures excluded. Live queue measured 77 = 75 telemetry + 2 real — this is the ~20× overstatement fix at the source.
- Envelope `{items,total,page,page_size}` with consumer aliases (`deadline`, `summary` — also fixes the queue's blanket "No SLA" artifact class). STABLE, SECURITY INVOKER, read-only, documented rollback (one DROP; consumers auto-fallback to the view).
- **Contract test** (static pinning + live BEGIN..ROLLBACK transactional self-apply): 6/6 green against the live DB pre-apply; idempotent post-apply; drift probe fails naming the drifted key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)