### PR TITLE
docs: update chairman-decision-surfaces.md for the queue-pollution predicate fix

### DIFF
--- a/docs/governance/chairman-decision-surfaces.md
+++ b/docs/governance/chairman-decision-surfaces.md
@@ -1,6 +1,7 @@
 # Chairman Decision Surfaces — Inventory
 
 > SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001 · 2026-06-11
+> Updated by SD-EHG-CONSOLE-QUEUE-POLLUTION-001 · 2026-07-10 (chairman-actionable predicate)
 >
 > The 10 places a "the chairman needs to decide something" can live, and which
 > are covered by the unified queue (`chairman_unified_decisions` /
@@ -11,13 +12,29 @@
 > are display-only defaults; pending-too-long (>72h) escalates *visibility*
 > (sort order) only. Every decision is an explicit chairman act producing
 > exactly one source write (`scripts/chairman-decisions.mjs decide`).
+>
+> **Chairman-actionable predicate (SD-EHG-CONSOLE-QUEUE-POLLUTION-001, PR #744,
+> `ehg` repo)**: console assessment ledger findings #8/#16 found the queue
+> rendering machine-internal signals (session_question "PM stall" telemetry,
+> harness_backlog/fleet_dormancy/process_enforcement feedback rows) as Critical
+> chairman decisions, and test-fixture-linked rows on every consumer. Fixed by
+> splitting the live 7-branch UNION into an unfiltered base view
+> (`chairman_all_decision_signals`) that `chairman_unified_decisions` and a new
+> `chairman_excluded_signals` view both filter with one predicate and its
+> logical inverse — excluded rows remain reachable and labeled at
+> `/chairman/decisions/excluded`, never silently deleted. Scope note: this fix
+> covers the decision queue and its known consumers
+> (`useDecisionGateQueue.ts`, `useChairmanDashboardData.ts`'s decision stack)
+> specifically — it does NOT extend the new fixture name-pattern exclusion to
+> every venture-listing surface (e.g. the Attention Queue Sidebar still relies
+> on the pre-existing `is_demo`-only filter in `applyVentureVisibility`).
 
 | # | Surface | Mechanism | Writers | Pending shape | Queue coverage |
 |---|---------|-----------|---------|---------------|----------------|
-| 1 | `chairman_decisions` | Table; atomic decide via `fn_chairman_decide` RPC (the name `decide_chairman_decision` does not exist on the live DB) | Venture stage-gate machinery (stage_gate/review/promotion_gate rows), `lib/chairman/record-pending-decision.mjs` proxy (session_question rows) | `status='pending'` (`decision='pending'`) | **Covered** — branch 4 (`chairman_approval`) |
+| 1 | `chairman_decisions` | Table; atomic decide via `fn_chairman_decide` RPC (the name `decide_chairman_decision` does not exist on the live DB) | Venture stage-gate machinery (stage_gate/review/promotion_gate rows), `lib/chairman/record-pending-decision.mjs` proxy (session_question rows) | `status='pending'` (`decision='pending'`) | **Covered** — branch 4 (`chairman_approval`), **except session_question rows** — excluded from the queue since SD-EHG-CONSOLE-QUEUE-POLLUTION-001 (confirmed live: 100% of session_question rows are machine-internal PM-stall telemetry, not genuine chairman questions); reachable via `chairman_excluded_signals` |
 | 2 | `venture_decisions` | Table; gate decisions per venture stage | Venture gate flow | `decision IS NULL` | **Covered** — branches 2/3 (`gate_decision`) |
 | 3 | `agent_messages` escalations | Table; agent→chairman escalation messages | Agent fleet (`message_type='escalation'`) | `status='pending'` | **Covered** — branch 1 (`escalation`) |
-| 4 | `feedback` (critical/high) | Table; durable flag/issue channel | `/signal`, `log-harness-bug.js`, sub-agents, captures, retros | `severity IN ('critical','high') AND resolved_at IS NULL AND status NOT IN ('resolved','wont_fix')` | **Covered (new)** — branch 5 (`flag_review`) |
+| 4 | `feedback` (critical/high) | Table; durable flag/issue channel | `/signal`, `log-harness-bug.js`, sub-agents, captures, retros | `severity IN ('critical','high') AND resolved_at IS NULL AND status NOT IN ('resolved','wont_fix')` | **Covered (new)** — branch 5 (`flag_review`), **minus a machine-internal category denylist** (`harness_backlog`/`fleet_dormancy`/`process_enforcement`) since SD-EHG-CONSOLE-QUEUE-POLLUTION-001 — genuine categories still surface unchanged |
 | 5 | `okr_generation_log` | Table; monthly OKR generator parks generations for acceptance | `lib/eva/jobs/okr-monthly-generator.js` (with `OKR_REQUIRE_ACCEPTANCE`); accept path `lib/eva/jobs/okr-accept-generation.js` | `status='pending_chairman_acceptance'` | **Covered (new)** — branch 7 (`okr_acceptance`) |
 | 6 | `leo_feature_flags` | Table; flags shipped OFF awaiting an enable-or-kill call | SDs shipping gated features (`lifecycle_state='draft'`, `is_enabled=false`) | draft + disabled + idle > 7 days | **Covered (new)** — branch 6 (`flag_enablement`); the queue records the call only — toggling stays in the flag tooling |
 | 7 | CHAIRMAN-PENDING markers | Convention: feedback rows / memory flags / doc markers tagged "CHAIRMAN-PENDING" (e.g. DR entitlement flag 9715c003) | Workers/retros ad hoc | free-text marker, no uniform shape | **Uncovered** — no machine-readable pending predicate; severity-tagged ones surface via branch 5; full coverage needs a marker convention SD |


### PR DESCRIPTION
## Summary
- Updates `docs/governance/chairman-decision-surfaces.md` (the authoritative inventory of all 10 chairman decision-surface writers) to reflect SD-EHG-CONSOLE-QUEUE-POLLUTION-001's fix (`ehg` repo, PR #744): session_question rows and machine-internal feedback categories are now excluded from queue coverage, with a note on the new `chairman_all_decision_signals` → `chairman_unified_decisions`/`chairman_excluded_signals` split and an explicit scope boundary (attention rail not yet covered).

## Test plan
- Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)