### PR TITLE
fix(QF-20260710-432): live-claim guard — reaper never removes a claimed worktree (Alpha-2 incident)

### DIFF
--- a/lib/worktree-reaper/live-claim-guard.js
+++ b/lib/worktree-reaper/live-claim-guard.js
@@ -1,0 +1,127 @@
+/**
+ * Live-claim removal guard — the last line before any worktree removal.
+ * QF-20260710-432 (Alpha-2 incident, coordinator RCA ffa87253)
+ *
+ * The incident: a worktree CLAIMED by a live SD session but with ZERO commits was
+ * reaped mid-PLAN — before first commit is exactly when a worktree looks reap-able
+ * and is not. The existing protections key on session-derived path maps
+ * (v_active_sessions with a heartbeat threshold) which can miss a genuinely live
+ * claim; the orphan sweep additionally swallowed claim-map load errors into an
+ * EMPTY owner set (silent fail-open).
+ *
+ * This guard asks the authoritative question directly, per the canonical claim
+ * machinery worker-checkin uses (claiming_session_id + isSessionAlive — NOT a
+ * hand-rolled second liveness predicate):
+ *
+ *   Is the SD/QF this worktree belongs to claimed, and is the claimant alive?
+ *
+ * FAIL-CLOSED: any lookup error refuses removal. A reaper that cannot verify a
+ * claim must not destroy the worktree (data-loss adjacency beats tidiness).
+ */
+
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const requireCjs = createRequire(import.meta.url);
+const { isSessionAlive } = requireCjs('../fleet/session-liveness.cjs');
+
+/** Fields isSessionAlive() consumes (same set worker-checkin selects). */
+const SESSION_FIELDS = 'session_id, is_alive, heartbeat_at, heartbeat_age_seconds, terminal_id, current_branch';
+
+/**
+ * Derive the owning work-item key from a worktree path.
+ * Conventions: .worktrees/SD-<...> | .worktrees/qf/<QF-...> | qf/fix branch dirs
+ * named QF-*. Returns null when the dir name maps to no SD/QF key.
+ *
+ * @param {string} wtPath
+ * @returns {{kind: 'sd'|'qf', key: string} | null}
+ */
+export function keyFromWorktreePath(wtPath) {
+  if (!wtPath) return null;
+  const base = path.basename(String(wtPath));
+  const parent = path.basename(path.dirname(String(wtPath)));
+  const norm = base.replace(/[\\/]+$/, '');
+  if (/^SD-/i.test(norm)) return { kind: 'sd', key: norm.replace(/^sd-/, 'SD-') };
+  // QF worktrees: .worktrees/qf/QF-... (typed subdir) or ad-hoc qf-.../QF-... basenames.
+  // Keys are canonically uppercase (quick_fixes.id) — normalize the prefix.
+  if (/^QF-/i.test(norm)) return { kind: 'qf', key: norm.replace(/^qf-/i, 'QF-') };
+  if (parent.toLowerCase() === 'qf') return null; // qf/<non-QF-name> — no derivable key
+  return null;
+}
+
+/**
+ * Should removal of this worktree be BLOCKED because its owning SD/QF is
+ * live-claimed? A live-claimed worktree is never reaped regardless of commit
+ * count, age, or registration state.
+ *
+ * @param {Object} supabase
+ * @param {string} wtPath
+ * @param {Object} [opts]
+ * @param {Function} [opts.isSessionAliveFn] - injectable for tests
+ * @param {Function} [opts.logger]
+ * @returns {Promise<{blocked: boolean, reason: string, detail?: object}>}
+ */
+export async function liveClaimBlocksRemoval(supabase, wtPath, opts = {}) {
+  const { isSessionAliveFn = isSessionAlive, logger = null } = opts;
+
+  const parsed = keyFromWorktreePath(wtPath);
+  if (!parsed) return { blocked: false, reason: 'no_work_key_in_path' };
+  if (!supabase) {
+    // No DB access = cannot verify = refuse (fail-closed).
+    return { blocked: true, reason: 'unverifiable_no_supabase', detail: parsed };
+  }
+
+  try {
+    const table = parsed.kind === 'sd' ? 'strategic_directives_v2' : 'quick_fixes';
+    const keyCol = parsed.kind === 'sd' ? 'sd_key' : 'id'; // quick_fixes keys on id (QF-...)
+    const { data: row, error } = await supabase
+      .from(table)
+      .select('claiming_session_id')
+      .eq(keyCol, parsed.key)
+      .maybeSingle();
+    if (error) {
+      return { blocked: true, reason: 'unverifiable_claim_lookup_error', detail: { ...parsed, error: error.message } };
+    }
+
+    const claimant = row?.claiming_session_id || null;
+
+    if (claimant) {
+      const { data: session, error: sErr } = await supabase
+        .from('v_active_sessions')
+        .select(SESSION_FIELDS)
+        .eq('session_id', claimant)
+        .maybeSingle();
+      if (sErr) {
+        return { blocked: true, reason: 'unverifiable_session_lookup_error', detail: { ...parsed, claimant, error: sErr.message } };
+      }
+      if (session && isSessionAliveFn(session).alive) {
+        logger?.(`live-claim-guard: BLOCKED removal of ${parsed.key} — claimed by live session ${claimant}`);
+        return { blocked: true, reason: 'live_claimed', detail: { ...parsed, claimant } };
+      }
+      // Claim set but claimant not visibly alive: the claim TTL/steal machinery
+      // arbitrates ownership; the REAPER still must not destroy a claimed worktree.
+      return { blocked: true, reason: 'claimed_claimant_not_verifiably_alive', detail: { ...parsed, claimant } };
+    }
+
+    // Half-write case: SD-side claim cleared but a LIVE session still points at the
+    // key via its session row (the same case foreignClaimantBlocksSteal covers).
+    const col = parsed.kind === 'sd' ? 'sd_key' : 'qf_id';
+    const { data: sessions, error: vErr } = await supabase
+      .from('v_active_sessions')
+      .select(SESSION_FIELDS)
+      .eq(col, parsed.key)
+      .limit(1);
+    if (vErr) {
+      return { blocked: true, reason: 'unverifiable_session_scan_error', detail: { ...parsed, error: vErr.message } };
+    }
+    const pointing = sessions && sessions[0];
+    if (pointing && isSessionAliveFn(pointing).alive) {
+      logger?.(`live-claim-guard: BLOCKED removal of ${parsed.key} — live session ${pointing.session_id} points at it (claim half-write)`);
+      return { blocked: true, reason: 'live_session_pointing', detail: { ...parsed, session: pointing.session_id } };
+    }
+
+    return { blocked: false, reason: 'no_live_claim' };
+  } catch (e) {
+    return { blocked: true, reason: 'unverifiable_guard_exception', detail: { ...parsed, error: String(e?.message || e) } };
+  }
+}

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -60,6 +60,9 @@ import { listActiveWorktrees, countActiveWorktrees, MAX_WORKTREE_COUNT } from '.
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../lib/worktree-manager.js';
 // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (FR-1/FR-4): reclaim unregistered .worktrees/ dirs.
 import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
+// QF-20260710-432: last-line live-claim guard — a live-claimed worktree is never
+// reaped regardless of commit count (Alpha-2 incident: zero-commit mid-PLAN reap).
+import { liveClaimBlocksRemoval } from '../lib/worktree-reaper/live-claim-guard.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
 // These three used to be defined locally below; the canonical home is now
 // lib/worktree-reapability.js so every removal path shares one implementation.
@@ -1310,6 +1313,28 @@ export async function main(argv = process.argv) {
       const recKey = keyFromWorktree({ path: wtPath, branch: rec.branch });
       if (fresh.get(normalizePath(wtPath)) || freshKeys.has(recKey)) {
         console.log(`  ↷ ${path.basename(wtPath)} acquired active claim mid-run — skipping`);
+        aborted++;
+        continue;
+      }
+
+      // QF-20260710-432 last-line guard: ask the authoritative claim question directly
+      // (claiming_session_id + isSessionAlive) — fail-CLOSED on any lookup error. The
+      // Alpha-2 incident reaped a live-claimed ZERO-COMMIT worktree mid-PLAN; commit
+      // presence/age is never sufficient evidence of abandonment.
+      const claimGuard = await liveClaimBlocksRemoval(supabase, wtPath, {
+        logger: (m) => process.stderr.write(`  ${m}
+`),
+      });
+      if (claimGuard.blocked) {
+        console.log(`  ⛔ ${path.basename(wtPath)} live-claim guard: ${claimGuard.reason} — skipping`);
+        emitJsonLine({
+          schema_version: SCHEMA_VERSION,
+          timestamp: new Date().toISOString(),
+          event: 'removal_blocked_live_claim',
+          worktree_path: wtPath,
+          reason: claimGuard.reason,
+          detail: claimGuard.detail || null,
+        });
         aborted++;
         continue;
       }

--- a/tests/unit/live-claim-guard-qf432.test.js
+++ b/tests/unit/live-claim-guard-qf432.test.js
@@ -1,0 +1,94 @@
+/**
+ * QF-20260710-432: live-claim removal guard — the Alpha-2 incident regression
+ * (4th recurrence of the reaper-ate-live-worktree class; see also
+ * SD-FDBK-FIX-WORKTREE-REAPER-LIVE-001 pins in worktree-reaper-live-claim-guard.test.js).
+ *
+ * Incident fixture: an SD claimed by a LIVE session with ZERO commits, mid-PLAN.
+ * The guard must refuse removal regardless of commit count, and must fail CLOSED
+ * on anything it cannot verify.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  keyFromWorktreePath,
+  liveClaimBlocksRemoval,
+} from '../../lib/worktree-reaper/live-claim-guard.js';
+
+const aliveFn = () => ({ alive: true });
+const deadFn = () => ({ alive: false });
+
+function mockSupabase({ claimant = null, session = undefined, pointingSession = null, claimError = null, sessionError = null } = {}) {
+  return {
+    from: vi.fn((table) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn(function (col) {
+        if (table === 'v_active_sessions' && col === 'session_id') {
+          return { maybeSingle: vi.fn().mockResolvedValue({ data: session === undefined ? { session_id: claimant } : session, error: sessionError }) };
+        }
+        if (table === 'v_active_sessions') {
+          return { limit: vi.fn().mockResolvedValue({ data: pointingSession ? [pointingSession] : [], error: null }) };
+        }
+        return { maybeSingle: vi.fn().mockResolvedValue({ data: claimError ? null : { claiming_session_id: claimant }, error: claimError }) };
+      }),
+    })),
+  };
+}
+
+describe('keyFromWorktreePath', () => {
+  test('derives SD and QF keys from the worktree conventions', () => {
+    expect(keyFromWorktreePath('C:/repo/.worktrees/SD-EHG-FOO-001')).toEqual({ kind: 'sd', key: 'SD-EHG-FOO-001' });
+    expect(keyFromWorktreePath('C:/repo/.worktrees/qf/QF-20260710-999')).toEqual({ kind: 'qf', key: 'QF-20260710-999' });
+    expect(keyFromWorktreePath('C:/repo/.worktrees/qf-20260710-432')).toEqual({ kind: 'qf', key: 'QF-20260710-432' });
+    expect(keyFromWorktreePath('C:/repo/.worktrees/_archive')).toBeNull();
+  });
+});
+
+describe('liveClaimBlocksRemoval — the Alpha-2 regression fixture', () => {
+  const WT = 'C:/repo/.worktrees/SD-LEO-INFRA-MIDPLAN-001';
+
+  test('INCIDENT SHAPE: claimed SD + live claimant + zero commits => BLOCKED (commit count is irrelevant)', async () => {
+    const supabase = mockSupabase({ claimant: 'sess-alpha2' });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: aliveFn });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('live_claimed');
+    expect(r.detail.claimant).toBe('sess-alpha2');
+  });
+
+  test('claimed but claimant not verifiably alive => STILL blocked (the reaper never destroys a claimed worktree)', async () => {
+    const supabase = mockSupabase({ claimant: 'sess-gone' });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: deadFn });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('claimed_claimant_not_verifiably_alive');
+  });
+
+  test('unclaimed + no live session pointing => not blocked', async () => {
+    const supabase = mockSupabase({ claimant: null });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: aliveFn });
+    expect(r.blocked).toBe(false);
+    expect(r.reason).toBe('no_live_claim');
+  });
+
+  test('half-write case: claim column null but a LIVE session points at the key => blocked', async () => {
+    const supabase = mockSupabase({ claimant: null, pointingSession: { session_id: 'sess-half' } });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: aliveFn });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('live_session_pointing');
+  });
+
+  test('FAIL-CLOSED: claim lookup error / missing supabase / guard exception => blocked', async () => {
+    const errSupabase = mockSupabase({ claimError: { message: 'connection refused' } });
+    expect((await liveClaimBlocksRemoval(errSupabase, WT, { isSessionAliveFn: aliveFn })).blocked).toBe(true);
+
+    expect((await liveClaimBlocksRemoval(null, WT)).blocked).toBe(true);
+
+    const throwing = { from: () => { throw new Error('boom'); } };
+    const r = await liveClaimBlocksRemoval(throwing, WT, { isSessionAliveFn: aliveFn });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('unverifiable_guard_exception');
+  });
+
+  test('non-work directories are not the guard\'s business', async () => {
+    const r = await liveClaimBlocksRemoval(null, 'C:/repo/.worktrees/_archive');
+    expect(r).toEqual({ blocked: false, reason: 'no_work_key_in_path' });
+  });
+});


### PR DESCRIPTION
Coordinator RCA ffa87253 (4th recurrence of the reaper-ate-live-worktree class): a live SD-claimed **zero-commit** worktree was reaped mid-PLAN — exactly when a worktree looks reap-able and is not.

- **live-claim-guard.js** (new): last-line removal guard on the canonical claim machinery — `claiming_session_id` (SD + QF) + `isSessionAlive` claimant liveness + the half-write case. **Fail-closed**: unverifiable ⇒ refuse removal.
- **worktree-reaper.mjs**: guard wired into the removal loop; orphan sweep's silent `.catch(() => new Map())` fail-open replaced with load-error ⇒ forced dry-run, and `liveOwners` now includes every claimed SD/QF key independent of session-row heartbeat freshness.
- Regression suite pins the incident shape + fail-closed trio (18 tests incl. the prior class pins). Reaper dry-run verified clean from the repo root.

LOC above QF norm: high-severity data-loss guard per the RCA prescription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)