### PR TITLE
fix(SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001): chairman decision surfacing — no raiser bypass, SLA machinery dispatched

### DIFF
--- a/.github/workflows/chairman-decision-sla-cron.yml
+++ b/.github/workflows/chairman-decision-sla-cron.yml
@@ -1,0 +1,55 @@
+name: "Chairman decision SLA sweep (cron)"
+
+# SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 — chairman-decision-timeout.js and
+# chairman-sla-enforcer.js had ZERO production call sites (registered-verifier-never-
+# dispatched class): the 24h SLA backstop everyone assumed had never run once, and
+# blocking pending decisions from non-adam producers had no machine path to the
+# chairman. This workflow is the named dispatcher: it runs the sweep, which invokes
+# enforceDecisionSLAs in NOTIFY-ONLY mode plus a blocking-row escalation pass through
+# the rate-capped decision-email seam. Static wiring pinned by
+# tests/unit/cron/chairman-decision-sla-wiring.test.js — renaming this file, the sweep
+# script, or the enforcer import fails CI.
+
+on:
+  schedule:
+    # Hourly at :15, EXCLUDING 03:00-09:59 UTC — the chairman quiet window is
+    # 23:00-05:00 America/New_York (03:00-09:00 UTC in EDT, 04:00-10:00 UTC in EST);
+    # skipping 03-09 UTC keeps every firing outside the window year-round. The
+    # escalation seam ALSO guards the quiet window in-process (FR-3), so this
+    # schedule is belt-and-suspenders, not the only protection.
+    - cron: '15 0-2,10-23 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: SLA notify + blocking-row escalation sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      ESCALATION_GO_LIVE_CUTOFF: ${{ vars.ESCALATION_GO_LIVE_CUTOFF }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run sweep (--once)
+        run: node scripts/cron/chairman-decision-sla-sweep.mjs --once

--- a/lib/chairman/chairman-actionable.mjs
+++ b/lib/chairman/chairman-actionable.mjs
@@ -1,0 +1,71 @@
+/**
+ * Chairman-actionable predicate — JS mirror of the canonical SQL allowlist.
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-5.
+ *
+ * CANONICAL SOURCE: database/migrations/20260710_create_get_pending_chairman_items.sql
+ * (get_pending_chairman_items RPC, SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001). Change the
+ * predicate THERE first; this module mirrors it for JS callers that cannot call the RPC
+ * per-row (the scheduled SLA sweep). Keep the two in lockstep.
+ *
+ * SUPERSET INTENT (documented, deliberate): the console queue admits only the allowlist
+ * below, while the ESCALATION path additionally admits ANY blocking pending decision that
+ * is not machine telemetry — the SD's contract is "escalation fires for EVERY blocking
+ * pending decision regardless of raiser" (e.g. blocking stage_gate and session_question
+ * rows escalate by email even though the console RPC does not list those types). The two
+ * predicates therefore intentionally differ ONLY by the blocking-row clause; the telemetry
+ * and fixture exclusions are shared, so the C7 noise class can flood neither surface.
+ */
+
+/** Types the console allowlist admits unconditionally (status='pending'). */
+export const CONSOLE_ACTIONABLE_TYPES = Object.freeze(['chairman_approval', 'gate_decision']);
+
+/** Types the console allowlist admits only when the row is blocking. */
+export const CONSOLE_BLOCKING_ONLY_TYPES = Object.freeze(['escalation', 'okr_acceptance']);
+
+/** Machine-telemetry decision types deliberately NOT chairman-actionable (never escalate/email). */
+export const TELEMETRY_DECISION_TYPES = Object.freeze(['flag_review', 'flag_enablement']);
+
+/** Fixture-venture name patterns (mirrors the SQL: is_demo, '__%', 'test venture%', '%citest%', 'canonical-source-test%'). */
+const FIXTURE_NAME_PATTERNS = [
+  /^__/i,
+  /^test venture/i,
+  /citest/i,
+  /^canonical-source-test/i,
+];
+
+/**
+ * Is this venture a fixture (demo/test) venture? NULL/unreadable venture resolves to
+ * NOT-fixture (include), matching the SQL's fail-include behavior.
+ * @param {{ name?: string, is_demo?: boolean }|null|undefined} venture
+ * @returns {boolean}
+ */
+export function isFixtureVenture(venture) {
+  if (!venture) return false;
+  if (venture.is_demo === true) return true;
+  const name = venture.name || '';
+  return FIXTURE_NAME_PATTERNS.some((re) => re.test(name));
+}
+
+/**
+ * Console-queue predicate — exact mirror of the get_pending_chairman_items row filter
+ * (venture exclusion handled separately via isFixtureVenture, as the SQL does via join).
+ * @param {{ status?: string, decision_type?: string, blocking?: boolean }} row
+ * @returns {boolean}
+ */
+export function isConsoleActionable(row = {}) {
+  if (row.status !== 'pending') return false;
+  if (CONSOLE_ACTIONABLE_TYPES.includes(row.decision_type)) return true;
+  return CONSOLE_BLOCKING_ONLY_TYPES.includes(row.decision_type) && row.blocking === true;
+}
+
+/**
+ * Escalation predicate — console-actionable OR any blocking pending non-telemetry row
+ * (the documented superset; see header). Telemetry types never escalate, blocking or not.
+ * @param {{ status?: string, decision_type?: string, blocking?: boolean }} row
+ * @returns {boolean}
+ */
+export function isEscalationActionable(row = {}) {
+  if (row.status !== 'pending') return false;
+  if (TELEMETRY_DECISION_TYPES.includes(row.decision_type)) return false;
+  return isConsoleActionable(row) || row.blocking === true;
+}

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -22,6 +22,7 @@
 import { spawn as nodeSpawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { isWithinChairmanQuietWindow } from '../notifications/resend-adapter.js';
 
 const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'pause']);
 
@@ -32,17 +33,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ADAM_DECISION_EMAIL = resolve(__dirname, '../../scripts/adam-decision-email.mjs');
 
 /**
- * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 FR-1 — PURE, deterministic predicate: should recording
- * this decision IMMEDIATELY fire the standout chairman-escalation email? True only for a genuine Adam
- * escalation: raisedBy==='adam' AND (a routed stuck-question OR an Adam-flagged blocking decision).
+ * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 FR-1, widened by
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-1 — PURE, deterministic predicate: should recording
+ * this decision IMMEDIATELY fire the standout chairman-escalation email?
+ *
+ * ANY blocking pending decision escalates on creation REGARDLESS of raiser — the old
+ * raisedBy==='adam' gate meant stage-gate/coordinator/eva producers of blocking decisions
+ * structurally bypassed escalation, so a ready venture's pause never reached the chairman.
+ * The adam+session_question path (a routed stuck-question) is preserved.
  * Deliberately structural — there is NO 'is the chairman in-session' input, so the email no longer
  * depends on in-session judgment or the hourly cron. Exported for unit testing.
  * @param {{decisionType?:string, blocking?:boolean, raisedBy?:string}} o
  * @returns {boolean}
  */
 export function shouldAutoEscalate({ decisionType, blocking, raisedBy } = {}) {
-  if (raisedBy !== 'adam') return false;
-  return decisionType === 'session_question' || blocking === true;
+  if (blocking === true) return true;
+  return raisedBy === 'adam' && decisionType === 'session_question';
 }
 
 /**
@@ -92,9 +98,18 @@ async function getEscalationWindowCounts(supabase) {
  * @param {{spawn?:Function}} [opts] - inject spawn for tests
  * @returns {Promise<{escalated:boolean, deduped?:boolean, digest?:boolean, suppressed?:string, error?:string}>}
  */
-export async function escalateChairmanDecision(supabase, decisionId, { spawn = defaultSpawnEscalationEmail } = {}) {
+export async function escalateChairmanDecision(supabase, decisionId, { spawn = defaultSpawnEscalationEmail, quietWindow = isWithinChairmanQuietWindow } = {}) {
   if (!supabase || !decisionId) return { escalated: false, error: 'supabase and decisionId required' };
   try {
+    // SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-3 — quiet-window check BEFORE any stamp/spawn.
+    // Previously the marker was stamped at spawn while adam-decision-email.mjs exited inside the
+    // 23:00-05:00 ET window without sending: the item was permanently marked sent but never delivered.
+    // Inside the window we record NOTHING, leaving the row eligible so the scheduled SLA sweep
+    // (scripts/cron/chairman-decision-sla-sweep.mjs) retries after the window opens.
+    if (quietWindow()) {
+      return { escalated: false, suppressed: 'quiet_window' };
+    }
+
     // Dedup: one email per decision. Re-read the live marker before sending.
     const { data: live } = await supabase
       .from('chairman_decisions')
@@ -141,8 +156,9 @@ export async function escalateChairmanDecision(supabase, decisionId, { spawn = d
  * @param {boolean} [opts.blocking=false]
  * @param {string} [opts.ventureId] - optional; session questions are ventureless
  * @param {number} [opts.lifecycleStage=0] - 0 = not a venture lifecycle decision
- * @param {string} [opts.raisedBy] - who raised it; 'adam' triggers the deterministic escalation email
+ * @param {string} [opts.raisedBy] - who raised it; any blocking decision (and adam session questions) escalates
  * @param {Function} [opts._spawnEscalation] - test seam: inject the email-spawn
+ * @param {Function} [opts._quietWindow] - test seam: inject the quiet-window predicate
  * @returns {Promise<{recorded: boolean, id?: string, error?: string, escalated?: boolean}>}
  */
 export async function recordPendingDecision(supabase, {
@@ -155,6 +171,7 @@ export async function recordPendingDecision(supabase, {
   lifecycleStage = 0,
   raisedBy = null,
   _spawnEscalation,
+  _quietWindow,
 } = {}) {
   if (!supabase) return { recorded: false, error: 'supabase client is required' };
   if (!title) return { recorded: false, error: 'title is required' };
@@ -187,12 +204,15 @@ export async function recordPendingDecision(supabase, {
   }
   const id = res.data?.[0]?.id;
 
-  // FR-2: DETERMINISTIC escalation — an Adam session_question/blocking decision fires the standout
-  // [ACTION NEEDED - ADAM] email IMMEDIATELY on creation, no in-session/availability gate and no
-  // waiting for the hourly cron. Fail-soft: an escalation error never fails the durable record.
+  // FR-2: DETERMINISTIC escalation — any blocking decision (or an Adam session_question) fires the
+  // standout email IMMEDIATELY on creation, no in-session/availability gate and no waiting for the
+  // hourly cron. Fail-soft: an escalation error never fails the durable record.
   let escalated = false;
   if (id && shouldAutoEscalate({ decisionType, blocking, raisedBy })) {
-    const r = await escalateChairmanDecision(supabase, id, _spawnEscalation ? { spawn: _spawnEscalation } : {});
+    const escOpts = {};
+    if (_spawnEscalation) escOpts.spawn = _spawnEscalation;
+    if (_quietWindow) escOpts.quietWindow = _quietWindow;
+    const r = await escalateChairmanDecision(supabase, id, escOpts);
     escalated = r.escalated === true;
   }
   return { recorded: true, id, escalated };

--- a/lib/eva/chairman-decision-timeout.js
+++ b/lib/eva/chairman-decision-timeout.js
@@ -1,6 +1,13 @@
 /**
  * Chairman Decision Timeout Manager
  *
+ * ⚠️ SUPERSEDED — DO NOT ARM: lib/eva/chairman-sla-enforcer.js is the consolidated
+ * successor and is the module dispatched in production (scripts/cron/
+ * chairman-decision-sla-sweep.mjs via .github/workflows/chairman-decision-sla-cron.yml,
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001). Scheduling this module alongside the
+ * enforcer double-escalates the same rows with a split audit trail. Kept for its
+ * exported SLA reference (DECISION_TYPE_SLA) and historical tests only.
+ *
  * Monitors pending decisions and escalates after a configurable
  * timeout threshold. Escalation NEVER auto-approves — it only
  * flags decisions for urgent Chairman review. Blocking decisions

--- a/lib/eva/chairman-sla-enforcer.js
+++ b/lib/eva/chairman-sla-enforcer.js
@@ -14,6 +14,7 @@ import { randomUUID } from 'crypto';
 // Default SLA matrix (configurable via constructor)
 export const DEFAULT_SLA_MATRIX = Object.freeze({
   gate_decision: 4 * 60 * 60 * 1000,      // 4 hours
+  stage_gate: 4 * 60 * 60 * 1000,          // 4 hours — stage-gate class (SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001, feedback 3acb9cdd)
   guardrail_override: 8 * 60 * 60 * 1000,  // 8 hours
   cascade_override: 8 * 60 * 60 * 1000,    // 8 hours
   advisory: 24 * 60 * 60 * 1000,           // 24 hours
@@ -31,11 +32,14 @@ const DEFAULT_FALLBACK_SLA_MS = 24 * 60 * 60 * 1000;
  * @param {Object} [options]
  * @param {Object} [options.slaMatrix] - Custom SLA matrix (overrides defaults)
  * @param {boolean} [options.blockOnViolation=true] - V02: blocking mode — SLA violations block downstream SD progression
+ * @param {Function} [options.filter] - optional per-row predicate; rows it rejects are counted skipped
+ *   (SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001: the production sweep passes the chairman-actionable
+ *   predicate + go-live cutoff here so machine telemetry and historical backlog are never processed)
  * @param {Object} [options.logger] - Logger instance
  * @returns {Promise<{ checked: number, escalated: number, blocked: number, skipped: number, errors: string[] }>}
  */
 export async function enforceDecisionSLAs(supabase, options = {}) {
-  const { slaMatrix = DEFAULT_SLA_MATRIX, blockOnViolation = true, logger = console } = options;
+  const { slaMatrix = DEFAULT_SLA_MATRIX, blockOnViolation = true, filter, logger = console } = options;
   const result = { checked: 0, escalated: 0, blocked: 0, skipped: 0, errors: [] };
 
   if (!supabase) {
@@ -62,6 +66,11 @@ export async function enforceDecisionSLAs(supabase, options = {}) {
 
     for (const decision of pendingDecisions) {
       result.checked++;
+
+      if (typeof filter === 'function' && !filter(decision)) {
+        result.skipped++;
+        continue;
+      }
 
       // Blocking decisions are exempt — Chairman has absolute authority
       if (decision.blocking) {

--- a/scripts/cron/chairman-decision-sla-sweep.mjs
+++ b/scripts/cron/chairman-decision-sla-sweep.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Chairman-decision SLA sweep — the scheduled production runner for the previously
+ * never-dispatched SLA machinery (registered-verifier-never-dispatched class).
+ *
+ * SD: SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 (FR-2/FR-5)
+ *
+ * Two passes per invocation, both producer-agnostic (the ALL-PATHS backstop — most of the
+ * ~16 chairman_decisions producers insert directly, bypassing recordPendingDecision's
+ * on-creation escalation):
+ *
+ *   1. SLA notify pass — enforceDecisionSLAs (lib/eva/chairman-sla-enforcer.js) in
+ *      NOTIFY-ONLY mode (blockOnViolation:false — this sweep NEVER mutates a decision's
+ *      blocking/status columns), scan filtered to the chairman-actionable predicate and a
+ *      go-live cutoff so machine telemetry and historical backlog are never processed.
+ *      chairman-decision-timeout.js is NOT wired here — the enforcer is its documented
+ *      consolidation; arming both would double-escalate (LEAD scope reduction).
+ *
+ *   2. Blocking-row pass — the enforcer deliberately exempts blocking rows ("Chairman has
+ *      absolute authority" = no auto-resolution), so a ready venture's PAUSE would never
+ *      surface through pass 1 alone. This pass NOTIFIES (never resolves): pending blocking
+ *      chairman-actionable rows past a grace period whose escalation email has not been
+ *      confirmed-sent are escalated through the single escalateChairmanDecision seam, which
+ *      owns dedup, the 3/hr rate cap + digest fold, and the quiet-window guard (FR-3: the
+ *      marker is only stamped outside the 23:00-05:00 ET window, so quiet-window skips are
+ *      retried by the next sweep).
+ *
+ * Liveness: registers ARMED machinery once (periodic_process_registry, named activation
+ * trigger = the cron workflow) and stamps last_fired_at on every real run. The static
+ * wiring is pinned by tests/unit/cron/chairman-decision-sla-wiring.test.js.
+ *
+ * Usage:
+ *   node scripts/cron/chairman-decision-sla-sweep.mjs --once      # one pass (canonical cron)
+ *   node scripts/cron/chairman-decision-sla-sweep.mjs --once --dry-run  # report intent, no writes
+ *
+ * Env:
+ *   ESCALATION_GO_LIVE_CUTOFF   ISO date; rows created before it are ignored (default 2026-07-10)
+ *   CHAIRMAN_BLOCKING_GRACE_MS  blocking-row grace period before sweep escalation (default 30 min)
+ *   SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (required)
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { createClient } from '@supabase/supabase-js';
+import { enforceDecisionSLAs } from '../../lib/eva/chairman-sla-enforcer.js';
+import { escalateChairmanDecision } from '../../lib/chairman/record-pending-decision.mjs';
+import { isEscalationActionable, isFixtureVenture } from '../../lib/chairman/chairman-actionable.mjs';
+import { registerArmedMachinery, armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+
+export const SD_KEY = 'SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001';
+export const ACTIVATION_TRIGGER = '.github/workflows/chairman-decision-sla-cron.yml';
+export const DEFAULT_GO_LIVE_CUTOFF = '2026-07-10T00:00:00Z';
+export const DEFAULT_BLOCKING_GRACE_MS = 30 * 60 * 1000;
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+function cutoffFromEnv(env) {
+  const raw = env.ESCALATION_GO_LIVE_CUTOFF;
+  return raw && !Number.isNaN(Date.parse(raw)) ? raw : DEFAULT_GO_LIVE_CUTOFF;
+}
+
+function graceMsFromEnv(env) {
+  const raw = parseInt(env.CHAIRMAN_BLOCKING_GRACE_MS || '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_BLOCKING_GRACE_MS;
+}
+
+/**
+ * PURE selection for the blocking-row pass (exported for the ALL-PATHS producer tests):
+ * pending + blocking + chairman-actionable (telemetry/fixture excluded) + created after the
+ * go-live cutoff + older than the grace period + escalation email not confirmed-sent.
+ * @param {Array<object>} rows - chairman_decisions rows (id, decision_type, status, blocking, created_at, venture_id, brief_data)
+ * @param {{ fixtureVentureIds?: Set<string>, cutoffIso: string, graceMs: number, nowMs?: number }} opts
+ * @returns {Array<object>} rows due for sweep escalation
+ */
+export function selectBlockingSweepRows(rows, { fixtureVentureIds = new Set(), cutoffIso, graceMs, nowMs = Date.now() } = {}) {
+  const cutoffMs = Date.parse(cutoffIso);
+  return (rows || []).filter((row) => {
+    if (row.blocking !== true) return false;
+    if (!isEscalationActionable(row)) return false;
+    if (row.venture_id && fixtureVentureIds.has(row.venture_id)) return false;
+    const createdMs = Date.parse(row.created_at);
+    if (!Number.isFinite(createdMs) || createdMs < cutoffMs) return false;
+    if (nowMs - createdMs < graceMs) return false;
+    if (row.brief_data?.escalation_email_sent_at) return false;
+    return true;
+  });
+}
+
+/** Resolve which of the given venture ids are fixture ventures (demo/test), fail-include on error. */
+async function fetchFixtureVentureIds(supabase, ventureIds, logger) {
+  const ids = [...new Set(ventureIds.filter(Boolean))];
+  if (ids.length === 0) return new Set();
+  try {
+    const { data, error } = await supabase.from('ventures').select('id, name, is_demo').in('id', ids);
+    if (error) {
+      logger.warn?.(`[sla-sweep] venture lookup failed (${error.message}) — fixture exclusion degraded to include-all`);
+      return new Set();
+    }
+    return new Set((data || []).filter((v) => isFixtureVenture(v)).map((v) => v.id));
+  } catch (err) {
+    logger.warn?.(`[sla-sweep] venture lookup threw (${err.message}) — fixture exclusion degraded to include-all`);
+    return new Set();
+  }
+}
+
+/** Ensure the ARMED registration exists WITHOUT wiping last_fired_at (registerArmedMachinery upserts null). */
+async function ensureArmedRegistration(supabase, logger) {
+  const processKey = armedProcessKey(SD_KEY);
+  try {
+    const { data } = await supabase
+      .from('periodic_process_registry')
+      .select('process_key')
+      .eq('process_key', processKey)
+      .maybeSingle();
+    if (!data) {
+      const reg = await registerArmedMachinery(supabase, { sd_key: SD_KEY }, {
+        activationTrigger: ACTIVATION_TRIGGER,
+        expectedIntervalSeconds: 2 * 60 * 60, // hourly cron with headroom
+        owner: 'chairman-decision-sla-sweep',
+      });
+      if (!reg.ok) logger.warn?.(`[sla-sweep] ARMED registration failed (non-fatal): ${reg.error}`);
+    }
+  } catch (err) {
+    logger.warn?.(`[sla-sweep] ARMED registration check failed (non-fatal): ${err.message}`);
+  }
+  return processKey;
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('chairman-decision-sla-sweep --once [--dry-run]');
+    return { exitCode: 0, action: 'help' };
+  }
+
+  const logger = deps.logger || console;
+  const env = deps.env || process.env;
+  const nowMs = deps.nowMs ?? Date.now();
+  const enforce = deps.enforce || enforceDecisionSLAs;
+  const escalate = deps.escalate || escalateChairmanDecision;
+  const cutoffIso = cutoffFromEnv(env);
+  const graceMs = graceMsFromEnv(env);
+
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) {
+    logger.error?.(`[sla-sweep] supabase client unavailable: ${err.message}`);
+    return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  // Liveness first — a genuine invocation is always recorded even if the sweep errors below.
+  if (!args.dryRun) {
+    const processKey = await ensureArmedRegistration(supabase, logger);
+    try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
+    catch (err) { logger.warn?.(`[sla-sweep] liveness stamp failed (non-fatal): ${err.message}`); }
+  }
+
+  // One shared read of the pending set powers both the enforcer filter and the blocking pass.
+  const { data: pending, error: readError } = await supabase
+    .from('chairman_decisions')
+    .select('id, decision_type, status, blocking, created_at, venture_id, brief_data')
+    .eq('status', 'pending');
+  if (readError) {
+    logger.error?.(`[sla-sweep] pending read failed: ${readError.message}`);
+    return { exitCode: 1, action: 'db_error' };
+  }
+  const rows = pending || [];
+  const fixtureVentureIds = await fetchFixtureVentureIds(supabase, rows.map((r) => r.venture_id), logger);
+  const cutoffMs = Date.parse(cutoffIso);
+  const actionableIds = new Set(
+    rows
+      .filter((r) => isEscalationActionable(r))
+      .filter((r) => !(r.venture_id && fixtureVentureIds.has(r.venture_id)))
+      .filter((r) => Date.parse(r.created_at) >= cutoffMs)
+      .map((r) => r.id)
+  );
+
+  // Pass 1 — SLA notify (non-blocking rows; the enforcer additionally skips blocking rows itself).
+  let slaResult = { checked: 0, escalated: 0, blocked: 0, skipped: 0, errors: [] };
+  if (!args.dryRun) {
+    slaResult = await enforce(supabase, {
+      blockOnViolation: false, // notify-only invariant — never mutate blocking (TR-2)
+      filter: (decision) => actionableIds.has(decision.id),
+      logger,
+    });
+  }
+
+  // Pass 2 — blocking-row notify sweep through the single delivery seam.
+  const due = selectBlockingSweepRows(rows, { fixtureVentureIds, cutoffIso, graceMs, nowMs });
+  const blockingResult = { due: due.length, escalated: 0, deduped: 0, suppressed: 0, errors: [] };
+  for (const row of due) {
+    if (args.dryRun) continue;
+    const r = await escalate(supabase, row.id);
+    if (r.escalated) blockingResult.escalated++;
+    else if (r.deduped) blockingResult.deduped++;
+    else if (r.suppressed) blockingResult.suppressed++;
+    else if (r.error) blockingResult.errors.push(`${row.id}: ${r.error}`);
+  }
+
+  const summary = {
+    ts: new Date(nowMs).toISOString(),
+    dry_run: args.dryRun,
+    cutoff: cutoffIso,
+    grace_ms: graceMs,
+    pending_scanned: rows.length,
+    actionable: actionableIds.size,
+    sla_checked: slaResult.checked,
+    sla_escalated: slaResult.escalated,
+    sla_skipped: slaResult.skipped,
+    blocking_due: blockingResult.due,
+    blocking_escalated: blockingResult.escalated,
+    blocking_deduped: blockingResult.deduped,
+    blocking_suppressed: blockingResult.suppressed,
+    errors: [...slaResult.errors, ...blockingResult.errors],
+  };
+  logger.log?.(`[sla-sweep] ${JSON.stringify(summary)}`);
+  return { exitCode: summary.errors.length > 0 ? 1 : 0, action: args.dryRun ? 'dry_run' : 'swept', summary };
+}
+
+/**
+ * Windows-safe termination (mirrors scripts/cron/eva-scheduler-watcher.mjs::gracefulExit —
+ * synchronous process.exit after a Supabase/undici query aborts on Windows with a libuv
+ * UV_HANDLE_CLOSING assertion; set exitCode, drain undici, unref'd backstop only).
+ */
+export async function gracefulExit(exitCode, { backstopMs = 4000 } = {}) {
+  process.exitCode = exitCode;
+  try {
+    const undici = await import('undici');
+    await undici.getGlobalDispatcher?.()?.close?.();
+  } catch { /* undici absent — natural drain still applies */ }
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  main().then(({ exitCode }) => gracefulExit(exitCode))
+        .catch((err) => { console.error('chairman-decision-sla-sweep fatal:', err.message); return gracefulExit(2); });
+}

--- a/tests/unit/chairman/all-paths-producers.test.js
+++ b/tests/unit/chairman/all-paths-producers.test.js
@@ -1,0 +1,100 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-6 — ALL-PATHS producer enumeration.
+ *
+ * Every producer that inserts pending chairman decisions is enumerated in PRODUCERS below
+ * with the row shape it mints. The invariant: a pending BLOCKING row from EVERY producer
+ * reaches escalation via at least one of the two paths —
+ *   creation-path: routed through recordPendingDecision → widened shouldAutoEscalate
+ *   sweep-path:    direct insert → scheduled sweep's selectBlockingSweepRows selection
+ * The Stage-0 ready-venture pause (blocking stage_gate row, paused venture) is the pinned
+ * regression fixture: with escalation formerly gated on raisedBy==='adam' and the SLA
+ * machinery never dispatched, exactly this shape died silently.
+ *
+ * Adding a new producer that inserts into chairman_decisions? Add it to PRODUCERS — the
+ * count pin below makes an unenumerated producer visible in review.
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldAutoEscalate } from '../../../lib/chairman/record-pending-decision.mjs';
+import { selectBlockingSweepRows } from '../../../scripts/cron/chairman-decision-sla-sweep.mjs';
+import { isEscalationActionable, isConsoleActionable, TELEMETRY_DECISION_TYPES } from '../../../lib/chairman/chairman-actionable.mjs';
+
+const NOW = Date.parse('2026-07-11T15:00:00Z');
+const AGED = new Date(NOW - 2 * 60 * 60 * 1000).toISOString(); // 2h old — past any grace period
+const CUTOFF = '2026-07-10T00:00:00Z';
+const GRACE = 30 * 60 * 1000;
+
+/** One entry per producer class that mints pending chairman_decisions rows (enumerated 2026-07-10). */
+const PRODUCERS = [
+  // —— routed through recordPendingDecision (creation-path escalation) ——
+  { producer: 'lib/adam/stall-alert.js', path: 'creation', shape: { decision_type: 'session_question', blocking: true, raised_by: 'adam' } },
+  { producer: 'scripts/coordinator-escalate-question.mjs (critical)', path: 'creation', shape: { decision_type: 'session_question', blocking: true, raised_by: undefined } },
+  // —— direct inserts into chairman_decisions (sweep-path escalation) ——
+  { producer: 'lib/eva/event-bus/handlers/budget-exceeded.js', path: 'sweep', shape: { decision_type: 'budget_override', blocking: true } },
+  { producer: 'lib/eva/event-bus/handlers/stage-failed.js', path: 'sweep', shape: { decision_type: 'stage_failure_review', blocking: true } },
+  { producer: 'lib/eva/gate-failure-recovery.js', path: 'sweep', shape: { decision_type: 'gate_failure_escalation', blocking: true } },
+  { producer: 'lib/eva/dfe-gate-escalation-router.js', path: 'sweep', shape: { decision_type: 'gate_escalation', blocking: true } },
+  { producer: 'lib/eva/guardrail-enforcement-engine.js', path: 'sweep', shape: { decision_type: 'guardrail_override', blocking: true } },
+  { producer: 'lib/eva/venture-monitor.js', path: 'sweep', shape: { decision_type: 'gate', blocking: true } },
+  { producer: 'lib/eva/stage-execution-worker.js (review path)', path: 'sweep', shape: { decision_type: 'review', blocking: true } },
+  { producer: 'lib/eva/stage-execution-worker.js (product review)', path: 'sweep', shape: { decision_type: 'product_review', blocking: true } },
+  { producer: 'lib/governance/chairman-escalation.js', path: 'sweep', shape: { decision_type: 'DFE_ESCALATION', blocking: true } },
+  { producer: 'lib/venture-acquisition/decision-packet.js', path: 'sweep', shape: { decision_type: 'chairman_approval', blocking: true } },
+  { producer: 'lib/integrations/okr-wave-linker.js', path: 'sweep', shape: { decision_type: 'roadmap_approval', blocking: true } },
+  { producer: 'scripts/modules/governance/cascade-validator.js', path: 'sweep', shape: { decision_type: 'cascade_override', blocking: true } },
+  { producer: 'scripts/modules/guardrails/guardrail-validator.js', path: 'sweep', shape: { decision_type: 'guardrail_override', blocking: true } },
+  // —— pinned regression fixture: the Stage-0 ready-venture pause ——
+  { producer: 'stage-zero review gate (ready-venture pause, PINNED FIXTURE)', path: 'sweep', shape: { decision_type: 'stage_gate', blocking: true } },
+];
+
+describe('ALL-PATHS: a blocking pending row from EVERY enumerated producer reaches escalation (FR-6)', () => {
+  it('enumeration pin: 16 producer shapes (update deliberately when adding a producer)', () => {
+    expect(PRODUCERS.length).toBe(16);
+  });
+
+  for (const { producer, path: escalationPath, shape } of PRODUCERS) {
+    it(`${escalationPath}-path: ${producer}`, () => {
+      if (escalationPath === 'creation') {
+        expect(
+          shouldAutoEscalate({ decisionType: shape.decision_type, blocking: shape.blocking, raisedBy: shape.raised_by }),
+          `${producer}: creation-path predicate must fire for its blocking shape`
+        ).toBe(true);
+      } else {
+        const row = { id: 'r1', status: 'pending', created_at: AGED, venture_id: null, brief_data: {}, ...shape };
+        const due = selectBlockingSweepRows([row], { cutoffIso: CUTOFF, graceMs: GRACE, nowMs: NOW });
+        expect(due.length, `${producer}: sweep selection must pick up its blocking shape`).toBe(1);
+      }
+    });
+  }
+
+  it('creation-path shapes are ALSO sweep-selectable (belt-and-suspenders when the on-creation email fails soft)', () => {
+    for (const { shape } of PRODUCERS.filter((p) => p.path === 'creation')) {
+      const row = { id: 'r1', status: 'pending', created_at: AGED, venture_id: null, brief_data: {}, ...shape };
+      expect(selectBlockingSweepRows([row], { cutoffIso: CUTOFF, graceMs: GRACE, nowMs: NOW }).length).toBe(1);
+    }
+  });
+});
+
+describe('chairman-actionable mirror (FR-5)', () => {
+  it('console predicate mirrors the RPC allowlist exactly', () => {
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'chairman_approval' })).toBe(true);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'gate_decision' })).toBe(true);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'escalation', blocking: true })).toBe(true);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'escalation', blocking: false })).toBe(false);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'okr_acceptance', blocking: true })).toBe(true);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'stage_gate', blocking: true })).toBe(false); // console does NOT admit stage_gate
+    expect(isConsoleActionable({ status: 'resolved', decision_type: 'chairman_approval' })).toBe(false);
+  });
+
+  it('escalation predicate = console set PLUS any blocking non-telemetry row (documented superset)', () => {
+    expect(isEscalationActionable({ status: 'pending', decision_type: 'stage_gate', blocking: true })).toBe(true);
+    expect(isEscalationActionable({ status: 'pending', decision_type: 'session_question', blocking: true })).toBe(true);
+    expect(isEscalationActionable({ status: 'pending', decision_type: 'stage_gate', blocking: false })).toBe(false);
+  });
+
+  it('telemetry types never escalate, blocking or not (the C7 noise guard)', () => {
+    for (const t of TELEMETRY_DECISION_TYPES) {
+      expect(isEscalationActionable({ status: 'pending', decision_type: t, blocking: true })).toBe(false);
+      expect(isEscalationActionable({ status: 'pending', decision_type: t, blocking: false })).toBe(false);
+    }
+  });
+});

--- a/tests/unit/chairman/record-pending-decision-escalation.test.js
+++ b/tests/unit/chairman/record-pending-decision-escalation.test.js
@@ -66,16 +66,22 @@ function makeSupabase({ briefData = null } = {}) {
   return sb;
 }
 
-describe('shouldAutoEscalate (FR-1)', () => {
+describe('shouldAutoEscalate (FR-1, widened by SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001)', () => {
   it('adam + session_question => true', () => {
     expect(shouldAutoEscalate({ decisionType: 'session_question', raisedBy: 'adam' })).toBe(true);
   });
   it('adam + blocking => true', () => {
     expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: true, raisedBy: 'adam' })).toBe(true);
   });
-  it('non-adam => false regardless of type/blocking', () => {
+  it('blocking => true for ANY raiser — no raiser bypass', () => {
+    expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: true, raisedBy: 'stage_gate' })).toBe(true);
+    expect(shouldAutoEscalate({ decisionType: 'gate_decision', blocking: true, raisedBy: 'coordinator' })).toBe(true);
+    expect(shouldAutoEscalate({ blocking: true, raisedBy: null })).toBe(true);
+    expect(shouldAutoEscalate({ blocking: true })).toBe(true); // raisedBy omitted entirely
+  });
+  it('non-adam non-blocking => false (non-blocking rows escalate only via the adam session_question path)', () => {
     expect(shouldAutoEscalate({ decisionType: 'session_question', raisedBy: 'coordinator' })).toBe(false);
-    expect(shouldAutoEscalate({ blocking: true, raisedBy: null })).toBe(false);
+    expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: false, raisedBy: 'stage_gate' })).toBe(false);
   });
   it('adam but neither session_question nor blocking => false', () => {
     expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: false, raisedBy: 'adam' })).toBe(false);
@@ -90,7 +96,7 @@ describe('escalateChairmanDecision (FR-2/FR-3)', () => {
   it('fires the email once and stamps escalation_email_sent_at', async () => {
     const sb = makeSupabase({ briefData: { title: 'q' } });
     const spawn = vi.fn();
-    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
     expect(r.escalated).toBe(true);
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(sb.rows[0].brief_data.escalation_email_sent_at).toBeTruthy();
@@ -99,7 +105,7 @@ describe('escalateChairmanDecision (FR-2/FR-3)', () => {
   it('dedup: a row already stamped does NOT spawn again', async () => {
     const sb = makeSupabase({ briefData: { title: 'q', escalation_email_sent_at: '2026-06-28T00:00:00Z' } });
     const spawn = vi.fn();
-    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
     expect(r.deduped).toBe(true);
     expect(spawn).not.toHaveBeenCalled();
   });
@@ -107,7 +113,7 @@ describe('escalateChairmanDecision (FR-2/FR-3)', () => {
   it('fail-soft: a spawn throw is swallowed (escalated:false, no throw)', async () => {
     const sb = makeSupabase({ briefData: { title: 'q' } });
     const spawn = vi.fn(() => { throw new Error('spawn boom'); });
-    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
     expect(r.escalated).toBe(false);
     expect(r.error).toMatch(/boom/);
   });
@@ -122,7 +128,7 @@ describe('escalateChairmanDecision — rate cap (QF-20260703-905)', () => {
     }
     sb.rows.push({ id: 'dec-4', created_at: new Date().toISOString(), brief_data: { title: 'q4' } });
 
-    const r = await escalateChairmanDecision(sb, 'dec-4', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-4', { spawn, quietWindow: () => false });
     expect(r.escalated).toBe(true);
     expect(r.digest).toBe(true);
     expect(spawn).toHaveBeenCalledTimes(1);
@@ -136,10 +142,10 @@ describe('escalateChairmanDecision — rate cap (QF-20260703-905)', () => {
       sb.rows.push({ id: `seed-${i}`, created_at: new Date().toISOString(), brief_data: { escalation_email_sent_at: new Date().toISOString() } });
     }
     sb.rows.push({ id: 'dec-4', created_at: new Date().toISOString(), brief_data: {} });
-    await escalateChairmanDecision(sb, 'dec-4', { spawn }); // sends the ONE digest
+    await escalateChairmanDecision(sb, 'dec-4', { spawn, quietWindow: () => false }); // sends the ONE digest
 
     sb.rows.push({ id: 'dec-5', created_at: new Date().toISOString(), brief_data: { title: 'q5' } });
-    const r = await escalateChairmanDecision(sb, 'dec-5', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-5', { spawn, quietWindow: () => false });
     expect(r.escalated).toBe(false);
     expect(r.suppressed).toBe('rate_cap');
     expect(spawn).toHaveBeenCalledTimes(1); // still just the one digest — never a 2nd
@@ -150,10 +156,43 @@ describe('escalateChairmanDecision — rate cap (QF-20260703-905)', () => {
     const spawn = vi.fn();
     sb.rows.push({ id: 'seed-0', created_at: new Date().toISOString(), brief_data: { escalation_email_sent_at: new Date().toISOString() } });
     sb.rows.push({ id: 'dec-2', created_at: new Date().toISOString(), brief_data: { title: 'q2' } });
-    const r = await escalateChairmanDecision(sb, 'dec-2', { spawn });
+    const r = await escalateChairmanDecision(sb, 'dec-2', { spawn, quietWindow: () => false });
     expect(r.escalated).toBe(true);
     expect(r.digest).toBeUndefined();
     expect(sb.rows.find(row => row.id === 'dec-2').brief_data.escalation_email_sent_at).toBeTruthy();
+  });
+});
+
+describe('escalateChairmanDecision — quiet-window race fix (SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-3)', () => {
+  it('inside the quiet window: neither stamps escalation_email_sent_at nor spawns', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const spawn = vi.fn();
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => true });
+    expect(r.escalated).toBe(false);
+    expect(r.suppressed).toBe('quiet_window');
+    expect(spawn).not.toHaveBeenCalled();
+    expect(sb.rows[0].brief_data.escalation_email_sent_at).toBeUndefined(); // row stays eligible for the sweep retry
+  });
+
+  it('outside the quiet window: stamps + spawns exactly once; a second call is deduped', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const spawn = vi.fn();
+    const r1 = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
+    expect(r1.escalated).toBe(true);
+    expect(sb.rows[0].brief_data.escalation_email_sent_at).toBeTruthy();
+    const r2 = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
+    expect(r2.deduped).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('quiet-window suppression happens BEFORE the rate-cap read, so it never counts against the cap', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const spawn = vi.fn();
+    await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => true });
+    // Marker absent => a later out-of-window escalation still sends the standout email.
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn, quietWindow: () => false });
+    expect(r.escalated).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -161,24 +200,35 @@ describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)'
   it('an adam session_question record fires exactly one email spawn, no in-session gate', async () => {
     const sb = makeFakeTable();
     const spawn = vi.fn();
-    const r = await recordPendingDecision(sb, { title: 'Adam needs a call', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: spawn });
+    const r = await recordPendingDecision(sb, { title: 'Adam needs a call', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: spawn, _quietWindow: () => false });
     expect(r.recorded).toBe(true);
     expect(r.escalated).toBe(true);
     expect(spawn).toHaveBeenCalledTimes(1);
   });
 
-  it('a non-adam record does NOT fire the email', async () => {
+  it('a non-adam NON-BLOCKING record does NOT fire the email', async () => {
     const sb = makeFakeTable();
     const spawn = vi.fn();
-    const r = await recordPendingDecision(sb, { title: 'routine', raisedBy: 'coordinator', decisionType: 'session_question', _spawnEscalation: spawn });
+    const r = await recordPendingDecision(sb, { title: 'routine', raisedBy: 'coordinator', decisionType: 'session_question', _spawnEscalation: spawn, _quietWindow: () => false });
     expect(r.recorded).toBe(true);
     expect(r.escalated).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it('a BLOCKING record fires the email regardless of raiser — no raiser bypass (SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-1)', async () => {
+    for (const raisedBy of ['stage_gate', 'coordinator', undefined]) {
+      const sb = makeFakeTable();
+      const spawn = vi.fn();
+      const r = await recordPendingDecision(sb, { title: 'venture paused behind gate', raisedBy, decisionType: 'stage_gate', blocking: true, _spawnEscalation: spawn, _quietWindow: () => false });
+      expect(r.recorded).toBe(true);
+      expect(r.escalated).toBe(true);
+      expect(spawn).toHaveBeenCalledTimes(1);
+    }
+  });
+
   it('persists raised_by in brief_data for escalation provenance', async () => {
     const sb = makeFakeTable();
-    const r = await recordPendingDecision(sb, { title: 'q', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: vi.fn() });
+    const r = await recordPendingDecision(sb, { title: 'q', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: vi.fn(), _quietWindow: () => false });
     expect(r.recorded).toBe(true);
   });
 
@@ -192,6 +242,7 @@ describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)'
         decisionType: 'stage_gate',
         blocking: true,
         _spawnEscalation: spawn,
+        _quietWindow: () => false,
       });
       expect(r.recorded).toBe(true);
     }

--- a/tests/unit/cron/chairman-decision-sla-sweep.test.js
+++ b/tests/unit/cron/chairman-decision-sla-sweep.test.js
@@ -1,0 +1,186 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 — chairman-decision SLA sweep (TS-2/TS-3/TS-4).
+ *
+ * The sweep is the producer-agnostic backstop: most chairman_decisions producers insert
+ * directly (bypassing recordPendingDecision), so only a scheduled scan can guarantee a
+ * blocking pending decision reaches the chairman. These tests pin: notify-only invariant
+ * (blocking column never mutated), blocking-row grace escalation with dedup, telemetry +
+ * fixture exclusion, and the go-live cutoff.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  main,
+  parseArgs,
+  selectBlockingSweepRows,
+  DEFAULT_GO_LIVE_CUTOFF,
+} from '../../../scripts/cron/chairman-decision-sla-sweep.mjs';
+import { enforceDecisionSLAs, DEFAULT_SLA_MATRIX } from '../../../lib/eva/chairman-sla-enforcer.js';
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-11T15:00:00Z');
+const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
+
+/** Minimal fake supabase covering the sweep's reads (+ the enforcer's own pending read/update paths). */
+function makeSupabase({ decisions = [], ventures = [] } = {}) {
+  const updates = [];
+  function table(name) {
+    const rows = name === 'chairman_decisions' ? decisions : name === 'ventures' ? ventures : [];
+    const ctx = { filters: [], op: 'select' };
+    const api = {
+      select() { return api; },
+      eq(col, val) { ctx.filters.push((r) => r[col] === val); return api; },
+      in(col, vals) { ctx.filters.push((r) => vals.includes(r[col])); return api; },
+      update(vals) { ctx.op = 'update'; ctx.vals = vals; return api; },
+      insert(vals) { ctx.op = 'insert'; ctx.vals = vals; return api; },
+      upsert(vals) { ctx.op = 'upsert'; ctx.vals = vals; return api; },
+      maybeSingle: async () => ({ data: rows.filter((r) => ctx.filters.every((f) => f(r)))[0] || null, error: null }),
+      then(resolve) {
+        if (ctx.op === 'update') {
+          const hit = rows.filter((r) => ctx.filters.every((f) => f(r)));
+          hit.forEach((r) => { updates.push({ table: name, id: r.id, vals: ctx.vals }); Object.assign(r, ctx.vals); });
+          resolve({ data: null, error: null });
+        } else if (ctx.op === 'insert' || ctx.op === 'upsert') {
+          resolve({ data: null, error: null });
+        } else {
+          resolve({ data: rows.filter((r) => ctx.filters.every((f) => f(r))), error: null });
+        }
+      },
+    };
+    return api;
+  }
+  return { from: table, _updates: updates };
+}
+
+const baseEnv = { ESCALATION_GO_LIVE_CUTOFF: '2026-07-10T00:00:00Z' };
+
+describe('parseArgs', () => {
+  it('parses --once and --dry-run', () => {
+    expect(parseArgs(['node', 's', '--once', '--dry-run'])).toEqual({ once: true, dryRun: true, help: false });
+  });
+});
+
+describe('selectBlockingSweepRows (pure selection for the blocking pass)', () => {
+  const base = { status: 'pending', blocking: true, venture_id: null, brief_data: {} };
+
+  it('selects a blocking stage_gate row past the grace period (the ready-venture pause shape)', () => {
+    const rows = [{ ...base, id: 'd1', decision_type: 'stage_gate', created_at: iso(2 * HOUR) }];
+    const due = selectBlockingSweepRows(rows, { cutoffIso: baseEnv.ESCALATION_GO_LIVE_CUTOFF, graceMs: 30 * 60 * 1000, nowMs: NOW });
+    expect(due.map((r) => r.id)).toEqual(['d1']);
+  });
+
+  it('respects the grace period (fresh blocking rows are left to the on-creation path)', () => {
+    const rows = [{ ...base, id: 'd1', decision_type: 'stage_gate', created_at: iso(5 * 60 * 1000) }];
+    expect(selectBlockingSweepRows(rows, { cutoffIso: baseEnv.ESCALATION_GO_LIVE_CUTOFF, graceMs: 30 * 60 * 1000, nowMs: NOW })).toEqual([]);
+  });
+
+  it('excludes telemetry types even when blocking (TS-4 core)', () => {
+    const rows = [
+      { ...base, id: 't1', decision_type: 'flag_review', created_at: iso(2 * HOUR) },
+      { ...base, id: 't2', decision_type: 'flag_enablement', created_at: iso(2 * HOUR) },
+    ];
+    expect(selectBlockingSweepRows(rows, { cutoffIso: baseEnv.ESCALATION_GO_LIVE_CUTOFF, graceMs: 0, nowMs: NOW })).toEqual([]);
+  });
+
+  it('excludes rows created before the go-live cutoff (no backlog flood)', () => {
+    const rows = [{ ...base, id: 'old', decision_type: 'stage_gate', created_at: '2026-07-01T00:00:00Z' }];
+    expect(selectBlockingSweepRows(rows, { cutoffIso: baseEnv.ESCALATION_GO_LIVE_CUTOFF, graceMs: 0, nowMs: NOW })).toEqual([]);
+  });
+
+  it('excludes fixture ventures and already-emailed rows', () => {
+    const rows = [
+      { ...base, id: 'fix', decision_type: 'stage_gate', created_at: iso(2 * HOUR), venture_id: 'v-fixture' },
+      { ...base, id: 'sent', decision_type: 'stage_gate', created_at: iso(2 * HOUR), brief_data: { escalation_email_sent_at: iso(HOUR) } },
+    ];
+    const due = selectBlockingSweepRows(rows, { fixtureVentureIds: new Set(['v-fixture']), cutoffIso: baseEnv.ESCALATION_GO_LIVE_CUTOFF, graceMs: 0, nowMs: NOW });
+    expect(due).toEqual([]);
+  });
+
+  it('default cutoff constant is the SD go-live date', () => {
+    expect(DEFAULT_GO_LIVE_CUTOFF).toBe('2026-07-10T00:00:00Z');
+  });
+});
+
+describe('main — sweep passes (TS-2/TS-3/TS-4)', () => {
+  it('TS-3: a due blocking row is escalated via the seam exactly once; second run dedups', async () => {
+    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {}, metadata: {} }];
+    const sb = makeSupabase({ decisions });
+    const escalate = vi.fn(async (supabase, id) => {
+      const row = decisions.find((d) => d.id === id);
+      if (row.brief_data.escalation_email_sent_at) return { escalated: false, deduped: true };
+      row.brief_data = { ...row.brief_data, escalation_email_sent_at: new Date(NOW).toISOString() };
+      return { escalated: true };
+    });
+    const enforce = vi.fn(async () => ({ checked: 0, escalated: 0, blocked: 0, skipped: 0, errors: [] }));
+    const deps = { supabase: sb, escalate, enforce, env: baseEnv, nowMs: NOW, stampLastFired: vi.fn(), logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } };
+
+    const r1 = await main(['node', 's', '--once'], deps);
+    expect(r1.exitCode).toBe(0);
+    expect(r1.summary.blocking_escalated).toBe(1);
+    expect(escalate).toHaveBeenCalledTimes(1);
+
+    const r2 = await main(['node', 's', '--once'], deps);
+    expect(r2.summary.blocking_due).toBe(0); // marker now present — not even selected
+    expect(escalate).toHaveBeenCalledTimes(1);
+  });
+
+  it('TS-2: enforcer runs NOTIFY-ONLY (blockOnViolation:false) with the actionable filter', async () => {
+    const decisions = [
+      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {}, metadata: {} },
+      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {}, metadata: {} },
+    ];
+    const sb = makeSupabase({ decisions });
+    let enforceOpts;
+    const enforce = vi.fn(async (supabase, opts) => { enforceOpts = opts; return { checked: 2, escalated: 1, blocked: 0, skipped: 1, errors: [] }; });
+    const deps = { supabase: sb, escalate: vi.fn(), enforce, env: baseEnv, nowMs: NOW, stampLastFired: vi.fn(), logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } };
+
+    const r = await main(['node', 's', '--once'], deps);
+    expect(r.exitCode).toBe(0);
+    expect(enforceOpts.blockOnViolation).toBe(false); // notify-only invariant (TR-2)
+    expect(enforceOpts.filter({ id: 'a1' })).toBe(true);      // actionable row admitted
+    expect(enforceOpts.filter({ id: 'noise' })).toBe(false);  // telemetry row rejected (TS-4)
+  });
+
+  it('TS-4: real enforcer + filter never mutates blocking and skips telemetry (integration of the two modules)', async () => {
+    // enforceDecisionSLAs computes age against the REAL wall clock (Date.now(), not injectable) —
+    // so created_at must be aged relative to actual now, not the test's fixed NOW fixture constant.
+    const realAged = new Date(Date.now() - 30 * HOUR).toISOString(); // past the 24h fallback SLA
+    const decisions = [
+      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {}, metadata: {} },
+      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {}, metadata: {} },
+    ];
+    const sb = makeSupabase({ decisions });
+    // main()'s own cutoff/actionable-filter logic uses deps.nowMs — keep that aligned with real time.
+    // Cutoff pinned far in the past so a real-clock-aged fixture always clears it regardless of
+    // when this suite actually runs.
+    const deps = { supabase: sb, escalate: vi.fn(async () => ({ escalated: true })), enforce: enforceDecisionSLAs, env: { ESCALATION_GO_LIVE_CUTOFF: '2000-01-01T00:00:00Z' }, nowMs: Date.now(), stampLastFired: vi.fn(), logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } };
+
+    const r = await main(['node', 's', '--once'], deps);
+    expect(r.exitCode).toBe(0);
+    const noise = decisions.find((d) => d.id === 'noise');
+    expect(noise.metadata.escalation).toBeUndefined(); // telemetry untouched
+    expect(noise.blocking).toBe(false);
+    const a1 = decisions.find((d) => d.id === 'a1');
+    expect(a1.metadata.escalation).toBeTruthy();       // SLA notify action recorded
+    expect(a1.blocking).toBe(false);                    // NEVER mutated (blockOnViolation:false)
+  });
+
+  it('dry-run performs no escalation, no stamp, no enforcement', async () => {
+    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {}, metadata: {} }];
+    const sb = makeSupabase({ decisions });
+    const escalate = vi.fn();
+    const enforce = vi.fn();
+    const stamp = vi.fn();
+    const r = await main(['node', 's', '--once', '--dry-run'], { supabase: sb, escalate, enforce, env: baseEnv, nowMs: NOW, stampLastFired: stamp, logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } });
+    expect(r.action).toBe('dry_run');
+    expect(r.summary.blocking_due).toBe(1); // reports intent
+    expect(escalate).not.toHaveBeenCalled();
+    expect(enforce).not.toHaveBeenCalled();
+    expect(stamp).not.toHaveBeenCalled();
+  });
+});
+
+describe('SLA matrix (feedback 3acb9cdd)', () => {
+  it('DEFAULT_SLA_MATRIX carries the stage_gate key', () => {
+    expect(DEFAULT_SLA_MATRIX.stage_gate).toBe(4 * HOUR);
+  });
+});

--- a/tests/unit/cron/chairman-decision-sla-wiring.test.js
+++ b/tests/unit/cron/chairman-decision-sla-wiring.test.js
@@ -1,0 +1,63 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 FR-4 — registered machinery must name its
+ * dispatcher (pattern PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001, exemplar
+ * tests/unit/adam/adam-machinery-consumer-invariant.test.js).
+ *
+ * The defect class this SD retires: chairman-decision-timeout.js + chairman-sla-enforcer.js
+ * sat with ZERO production call sites — armed logic, no dispatcher. These static assertions
+ * fail CI the moment any edge of the wiring decays: workflow → sweep script → enforcer →
+ * armed-registration. No network or DB required.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const WORKFLOW = path.join(repoRoot, '.github', 'workflows', 'chairman-decision-sla-cron.yml');
+const SWEEP = path.join(repoRoot, 'scripts', 'cron', 'chairman-decision-sla-sweep.mjs');
+
+describe('chairman-decision SLA machinery names its dispatcher (FR-4)', () => {
+  it('the cron workflow exists and its run step invokes the sweep script', () => {
+    expect(fs.existsSync(WORKFLOW), `missing dispatcher workflow: ${WORKFLOW}`).toBe(true);
+    const yml = fs.readFileSync(WORKFLOW, 'utf8');
+    expect(yml, 'workflow no longer references scripts/cron/chairman-decision-sla-sweep.mjs').toMatch(
+      /node\s+scripts\/cron\/chairman-decision-sla-sweep\.mjs\s+--once/
+    );
+    expect(yml, 'workflow lost its schedule trigger').toMatch(/schedule:/);
+  });
+
+  it('the sweep script exists and imports enforceDecisionSLAs from the SLA enforcer', () => {
+    expect(fs.existsSync(SWEEP), `missing sweep script: ${SWEEP}`).toBe(true);
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src, 'sweep no longer imports enforceDecisionSLAs from lib/eva/chairman-sla-enforcer.js').toMatch(
+      /import\s*\{[^}]*enforceDecisionSLAs[^}]*\}\s*from\s*['"][./]*\.\.\/\.\.\/lib\/eva\/chairman-sla-enforcer\.js['"]/
+    );
+    expect(src, 'sweep no longer delivers through the escalateChairmanDecision seam').toMatch(/escalateChairmanDecision/);
+  });
+
+  it('the sweep registers ARMED machinery with an activation trigger naming the workflow file', () => {
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src, 'sweep no longer calls registerArmedMachinery').toMatch(/registerArmedMachinery/);
+    expect(src, 'ACTIVATION_TRIGGER no longer names the cron workflow').toMatch(
+      /ACTIVATION_TRIGGER\s*=\s*['"]\.github\/workflows\/chairman-decision-sla-cron\.yml['"]/
+    );
+  });
+
+  it('the sweep pins notify-only mode (blockOnViolation:false) — the V02 mass-mutation guard', () => {
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src, 'sweep lost the blockOnViolation:false pin — first live run would mass-set blocking=true').toMatch(
+      /blockOnViolation:\s*false/
+    );
+  });
+
+  it('the superseded timeout module is NOT dispatched by the workflow or the sweep', () => {
+    const yml = fs.readFileSync(WORKFLOW, 'utf8');
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    // History comments may NAME the module; what must never exist is an invocation or import.
+    expect(/node\s+[^\n]*chairman-decision-timeout/.test(yml), 'workflow must not invoke the superseded timeout module').toBe(false);
+    expect(/from\s*['"][^'"]*chairman-decision-timeout/.test(src), 'sweep must not import the superseded timeout module').toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Widen `shouldAutoEscalate` so ANY blocking pending chairman decision escalates regardless of raiser (was gated on `raisedBy==='adam'`), closing the gap where stage-gate/coordinator/eva producers of blocking decisions never reached the chairman
- Dispatch the previously never-armed SLA machinery: new `scripts/cron/chairman-decision-sla-sweep.mjs` + `.github/workflows/chairman-decision-sla-cron.yml` run `enforceDecisionSLAs` notify-only (`blockOnViolation:false`) plus a blocking-row grace-period sweep through the existing rate-capped delivery seam — `chairman-decision-timeout.js` is deliberately NOT armed (superseded by the enforcer; arming both would double-escalate)
- Fix a quiet-window race where `escalateChairmanDecision` stamped "sent" before checking the 23:00-05:00 ET window, permanently marking undelivered items as sent
- Add `lib/chairman/chairman-actionable.mjs`, a pinned JS mirror of the canonical `get_pending_chairman_items` SQL allowlist, so the sweep can never escalate machine telemetry
- Add a static consumer-invariant test pinning the workflow → script → enforcer wiring, and an ALL-PATHS producer-enumeration test covering 16 producer classes (incl. the Stage-0 ready-venture pause regression fixture)

## Test plan
- [x] `npx vitest run tests/unit/chairman/ tests/unit/cron/` — 58/58 new/modified SD tests pass
- [x] `npx vitest run tests/unit` (full suite) — 1819 passed / 9 failed / 172 skipped; all 9 failures independently confirmed pre-existing/environmental and unrelated to this change (branch-detection, subprocess env-capture, golden-reference drift, source-pin regex, live-DB savepoint)
- [x] TESTING sub-agent PASS (evidence row e4dbdf6d)
- [x] VALIDATION sub-agent PASS at LEAD + PLAN_VERIFICATION (b4c7828f, 7675e7b2)
- [x] REGRESSION sub-agent PASS — confirmed backward compatible, no caller relies on old narrow escalation behavior (cf8f820b)
- [x] RISK sub-agent PASS_WITH_MITIGATIONS, all must-fixes folded into the implementation (cfaa0ab2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)