### PR TITLE
fix(QF-20260710-103): chairman-sla-enforcer reads brief_data, not phantom metadata column

### DIFF
--- a/lib/eva/chairman-sla-enforcer.js
+++ b/lib/eva/chairman-sla-enforcer.js
@@ -50,7 +50,9 @@ export async function enforceDecisionSLAs(supabase, options = {}) {
   try {
     const { data: pendingDecisions, error } = await supabase
       .from('chairman_decisions')
-      .select('id, decision_type, created_at, blocking, venture_id, metadata')
+      // Quick-fix QF-20260710-103: chairman_decisions has no metadata column; the
+      // real JSONB field is brief_data (see lib/chairman/record-pending-decision.mjs).
+      .select('id, decision_type, created_at, blocking, venture_id, brief_data')
       .eq('status', 'pending');
 
     if (error) {
@@ -79,7 +81,7 @@ export async function enforceDecisionSLAs(supabase, options = {}) {
       }
 
       // Already escalated?
-      if (decision.metadata?.escalation) {
+      if (decision.brief_data?.escalation) {
         result.skipped++;
         continue;
       }
@@ -140,10 +142,10 @@ export async function escalateDecision(supabase, decision, context = {}) {
   };
 
   try {
-    // Update decision metadata with escalation flag (V02: set blocking when SLA violated)
+    // Update decision brief_data with escalation flag (V02: set blocking when SLA violated)
     const updatePayload = {
-      metadata: {
-        ...(decision.metadata || {}),
+      brief_data: {
+        ...(decision.brief_data || {}),
         escalation: escalationRecord,
         requires_urgent_review: true,
         sla_violated: true,
@@ -201,7 +203,7 @@ export async function escalateDecision(supabase, decision, context = {}) {
         severity: 'high',
         metadata: {
           gate_name: 'CHAIRMAN_SLA_ENFORCER',
-          sd_key: decision.metadata?.sd_key || null,
+          sd_key: decision.brief_data?.sd_key || null,
           decision_id: decision.id,
           decision_type: decision.decision_type,
           sla_hours: escalationRecord.sla_hours,

--- a/tests/unit/cron/chairman-decision-sla-sweep.test.js
+++ b/tests/unit/cron/chairman-decision-sla-sweep.test.js
@@ -102,7 +102,7 @@ describe('selectBlockingSweepRows (pure selection for the blocking pass)', () =>
 
 describe('main — sweep passes (TS-2/TS-3/TS-4)', () => {
   it('TS-3: a due blocking row is escalated via the seam exactly once; second run dedups', async () => {
-    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {}, metadata: {} }];
+    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {} }];
     const sb = makeSupabase({ decisions });
     const escalate = vi.fn(async (supabase, id) => {
       const row = decisions.find((d) => d.id === id);
@@ -125,8 +125,8 @@ describe('main — sweep passes (TS-2/TS-3/TS-4)', () => {
 
   it('TS-2: enforcer runs NOTIFY-ONLY (blockOnViolation:false) with the actionable filter', async () => {
     const decisions = [
-      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {}, metadata: {} },
-      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {}, metadata: {} },
+      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {} },
+      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: iso(30 * HOUR), venture_id: null, brief_data: {} },
     ];
     const sb = makeSupabase({ decisions });
     let enforceOpts;
@@ -145,8 +145,8 @@ describe('main — sweep passes (TS-2/TS-3/TS-4)', () => {
     // so created_at must be aged relative to actual now, not the test's fixed NOW fixture constant.
     const realAged = new Date(Date.now() - 30 * HOUR).toISOString(); // past the 24h fallback SLA
     const decisions = [
-      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {}, metadata: {} },
-      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {}, metadata: {} },
+      { id: 'noise', decision_type: 'flag_review', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {} },
+      { id: 'a1', decision_type: 'chairman_approval', status: 'pending', blocking: false, created_at: realAged, venture_id: null, brief_data: {} },
     ];
     const sb = makeSupabase({ decisions });
     // main()'s own cutoff/actionable-filter logic uses deps.nowMs — keep that aligned with real time.
@@ -157,15 +157,15 @@ describe('main — sweep passes (TS-2/TS-3/TS-4)', () => {
     const r = await main(['node', 's', '--once'], deps);
     expect(r.exitCode).toBe(0);
     const noise = decisions.find((d) => d.id === 'noise');
-    expect(noise.metadata.escalation).toBeUndefined(); // telemetry untouched
+    expect(noise.brief_data.escalation).toBeUndefined(); // telemetry untouched
     expect(noise.blocking).toBe(false);
     const a1 = decisions.find((d) => d.id === 'a1');
-    expect(a1.metadata.escalation).toBeTruthy();       // SLA notify action recorded
+    expect(a1.brief_data.escalation).toBeTruthy();       // SLA notify action recorded
     expect(a1.blocking).toBe(false);                    // NEVER mutated (blockOnViolation:false)
   });
 
   it('dry-run performs no escalation, no stamp, no enforcement', async () => {
-    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {}, metadata: {} }];
+    const decisions = [{ id: 'd1', decision_type: 'stage_gate', status: 'pending', blocking: true, created_at: iso(2 * HOUR), venture_id: null, brief_data: {} }];
     const sb = makeSupabase({ decisions });
     const escalate = vi.fn();
     const enforce = vi.fn();

--- a/tests/unit/eva/chairman-sla-enforcer.test.js
+++ b/tests/unit/eva/chairman-sla-enforcer.test.js
@@ -13,7 +13,7 @@ function makeDecision(overrides = {}) {
     created_at: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(), // 5h ago (overdue for gate_decision 4h SLA)
     blocking: false,
     venture_id: 'v-1',
-    metadata: {},
+    brief_data: {},
     ...overrides,
   };
 }
@@ -95,7 +95,7 @@ describe('chairman-sla-enforcer', () => {
 
     it('skips already-escalated decisions', async () => {
       const escalatedDecision = makeDecision({
-        metadata: { escalation: { escalated_at: '2026-01-01' } },
+        brief_data: { escalation: { escalated_at: '2026-01-01' } },
       });
       const supabase = mockSupabase({ selectData: [escalatedDecision] });
 

--- a/tests/unit/governance/chairman-sla-enforcer.test.js
+++ b/tests/unit/governance/chairman-sla-enforcer.test.js
@@ -54,7 +54,7 @@ describe('Chairman SLA Enforcer — enforceDecisionSLAs', () => {
 
   it('skips blocking decisions (chairman authority)', async () => {
     const supabase = createMockSupabase([
-      { id: 'dec-1', decision_type: 'gate_decision', created_at: '2020-01-01T00:00:00Z', blocking: true, metadata: {} },
+      { id: 'dec-1', decision_type: 'gate_decision', created_at: '2020-01-01T00:00:00Z', blocking: true, brief_data: {} },
     ]);
     const result = await enforceDecisionSLAs(supabase, { logger: { warn: vi.fn() } });
     expect(result.skipped).toBe(1);
@@ -63,7 +63,7 @@ describe('Chairman SLA Enforcer — enforceDecisionSLAs', () => {
 
   it('skips already-escalated decisions', async () => {
     const supabase = createMockSupabase([
-      { id: 'dec-2', decision_type: 'advisory', created_at: '2020-01-01T00:00:00Z', blocking: false, metadata: { escalation: { escalated_at: '2020-01-02T00:00:00Z' } } },
+      { id: 'dec-2', decision_type: 'advisory', created_at: '2020-01-01T00:00:00Z', blocking: false, brief_data: { escalation: { escalated_at: '2020-01-02T00:00:00Z' } } },
     ]);
     const result = await enforceDecisionSLAs(supabase, { logger: { warn: vi.fn() } });
     expect(result.skipped).toBe(1);
@@ -71,7 +71,7 @@ describe('Chairman SLA Enforcer — enforceDecisionSLAs', () => {
   });
 
   it('returns blocked count when blockOnViolation is true (V02: default)', async () => {
-    const overdue = { id: 'dec-3', decision_type: 'stakeholder_response', created_at: '2020-01-01T00:00:00Z', blocking: false, metadata: {} };
+    const overdue = { id: 'dec-3', decision_type: 'stakeholder_response', created_at: '2020-01-01T00:00:00Z', blocking: false, brief_data: {} };
     const supabase = createMockSupabase([overdue]);
     const result = await enforceDecisionSLAs(supabase, { logger: { warn: vi.fn() } });
     expect(result.escalated).toBe(1);
@@ -79,7 +79,7 @@ describe('Chairman SLA Enforcer — enforceDecisionSLAs', () => {
   });
 
   it('does not block when blockOnViolation is false', async () => {
-    const overdue = { id: 'dec-4', decision_type: 'advisory', created_at: '2020-01-01T00:00:00Z', blocking: false, metadata: {} };
+    const overdue = { id: 'dec-4', decision_type: 'advisory', created_at: '2020-01-01T00:00:00Z', blocking: false, brief_data: {} };
     const supabase = createMockSupabase([overdue]);
     const result = await enforceDecisionSLAs(supabase, { blockOnViolation: false, logger: { warn: vi.fn() } });
     expect(result.escalated).toBe(1);
@@ -90,7 +90,7 @@ describe('Chairman SLA Enforcer — enforceDecisionSLAs', () => {
 describe('Chairman SLA Enforcer — escalateDecision', () => {
   it('sets blocking=true in decision update when blockOnViolation=true', async () => {
     const supabase = createMockSupabase();
-    const decision = { id: 'dec-5', metadata: {}, venture_id: 'v1' };
+    const decision = { id: 'dec-5', brief_data: {}, venture_id: 'v1' };
 
     await escalateDecision(supabase, decision, {
       slaMs: 7200000,
@@ -103,13 +103,13 @@ describe('Chairman SLA Enforcer — escalateDecision', () => {
     expect(updateCall).toHaveBeenCalled();
     const payload = updateCall.mock.calls[0][0];
     expect(payload.blocking).toBe(true);
-    expect(payload.metadata.sla_violated).toBe(true);
-    expect(payload.metadata.escalation.strategy).toBe('block_and_escalate');
+    expect(payload.brief_data.sla_violated).toBe(true);
+    expect(payload.brief_data.escalation.strategy).toBe('block_and_escalate');
   });
 
   it('uses escalate_notify strategy when blockOnViolation=false', async () => {
     const supabase = createMockSupabase();
-    const decision = { id: 'dec-6', metadata: {}, venture_id: 'v1' };
+    const decision = { id: 'dec-6', brief_data: {}, venture_id: 'v1' };
 
     const result = await escalateDecision(supabase, decision, {
       slaMs: 7200000,
@@ -121,12 +121,12 @@ describe('Chairman SLA Enforcer — escalateDecision', () => {
     expect(result.blocked).toBe(false);
     const payload = supabase._chain.update.mock.calls[0][0];
     expect(payload.blocking).toBeUndefined();
-    expect(payload.metadata.escalation.strategy).toBe('escalate_notify');
+    expect(payload.brief_data.escalation.strategy).toBe('escalate_notify');
   });
 
   it('returns blocked=true when blocking mode active', async () => {
     const supabase = createMockSupabase();
-    const decision = { id: 'dec-7', metadata: {}, venture_id: 'v1' };
+    const decision = { id: 'dec-7', brief_data: {}, venture_id: 'v1' };
 
     const result = await escalateDecision(supabase, decision, {
       slaMs: 7200000,


### PR DESCRIPTION
## Summary
- `enforceDecisionSLAs` (lib/eva/chairman-sla-enforcer.js) queried a `metadata` column on `chairman_decisions` that doesn't exist — real JSONB field is `brief_data`
- Silently no-op'd the entire SLA-notify pass in production (query error swallowed, `checked` stayed 0 on every call)
- Discovered live while smoke-verifying SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001's new cron dispatcher — the first production call site this module has ever had
- Renamed all `chairman_decisions`-facing `metadata` references to `brief_data` (select, read, update, and the stale test fixtures that masked the bug by accepting any field name on a mocked row)

## Test plan
- [x] `npx vitest run tests/unit/eva/chairman-sla-enforcer.test.js tests/unit/governance/chairman-sla-enforcer.test.js tests/unit/cron/ tests/unit/chairman/` — 130/130 pass
- [x] Live verification: `node scripts/cron/chairman-decision-sla-sweep.mjs --once` against the real DB — before: `errors:["Query failed: column chairman_decisions.metadata does not exist"]`; after: `sla_checked:5, errors:[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)