### PR TITLE
fix(QF-20260710-406): re-derive tier_rank on SessionStart-observed model change

### DIFF
--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -18,6 +18,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { rankForModelEffort } = require('../../lib/fleet/tier-ladder.cjs');
 const { execSync } = require('child_process');
 
 // SD-FDBK-ENH-SESSIONSTART-HOOK-CAPTURE-001 (FR-7): self-load .env so process.env.SUPABASE_*
@@ -282,12 +283,36 @@ function findClaudeCodePid(entryPath = 'unknown') {
 // only to the local marker file, never the DB) as a secondary auto-source alongside the
 // worker-checkin.cjs --model self-report. get-then-merge (base spread first) means an
 // already-DB-stamped metadata.model is never clobbered by an absent/null model here.
+
+// QF-20260710-406: SessionStart's stdin `model` field carries Claude Code's own model
+// identifier (undocumented exact format, e.g. a versioned display name), not the short
+// {haiku,sonnet,opus,fable} ladder alias. Substring-match on family name so any cased/
+// versioned variant resolves; unrecognized strings pass through untouched and fall to
+// tier-ladder's own normalizeModel, which maps conservative-UP (never under-restricts).
+const MODEL_ALIAS_ORDER = ['fable', 'opus', 'sonnet', 'haiku'];
+function coarseModelAlias(raw) {
+  const s = typeof raw === 'string' ? raw.toLowerCase() : '';
+  return MODEL_ALIAS_ORDER.find((alias) => s.includes(alias)) || raw;
+}
+
 function buildSessionMetadata(existingMetadata, ccPid, source, model) {
   const base = (existingMetadata && typeof existingMetadata === 'object' && !Array.isArray(existingMetadata))
     ? existingMetadata
     : {};
   const merged = { ...base, cc_pid: ccPid, source: source || 'unknown' };
-  if (model) merged.model = model;
+  if (model) {
+    merged.model = model;
+    // QF-20260710-406: a genuine model CHANGE observed at a real SessionStart event
+    // (startup/resume/clear/compact — the only moments this field is populated) must
+    // re-derive tier_rank, so a mid-session /model switch self-heals on the next
+    // natural session-lifecycle boundary instead of staying stranded on a stale rank
+    // until a worker manually re-checks in with --model. No-op on the common case
+    // (model unchanged from the prior stamp).
+    if (base.model !== model) {
+      try { merged.tier_rank = rankForModelEffort(coarseModelAlias(model), base.effort); }
+      catch { /* fail-open: keep whatever tier_rank was already stamped */ }
+    }
+  }
   return merged;
 }
 

--- a/tests/unit/capture-session-id-metadata-merge.test.js
+++ b/tests/unit/capture-session-id-metadata-merge.test.js
@@ -60,4 +60,33 @@ describe('QF-20260627-531: buildSessionMetadata merge-preserves stamped fields',
     const merged = buildSessionMetadata(existing, '9', 'sessionstart', 'fable');
     expect(merged.model).toBe('fable');
   });
+
+  // QF-20260710-406: a SessionStart-observed model CHANGE must re-derive tier_rank so a
+  // mid-session /model switch self-heals at the next natural session-lifecycle boundary.
+  describe('QF-20260710-406: tier_rank re-derives on a genuine model change', () => {
+    it('demotes a stale fable/4 stamp when SessionStart reports a downgrade to sonnet', () => {
+      const existing = { model: 'fable', effort: 'high', tier_rank: 4 };
+      const merged = buildSessionMetadata(existing, '9', 'compact', 'sonnet');
+      expect(merged.model).toBe('sonnet');
+      expect(merged.tier_rank).toBe(2); // rankForModelEffort('sonnet', 'high')
+    });
+
+    it('does NOT touch tier_rank when the reported model is unchanged from the prior stamp', () => {
+      const existing = { model: 'fable', effort: 'high', tier_rank: 4 };
+      const merged = buildSessionMetadata(existing, '9', 'compact', 'fable');
+      expect(merged.tier_rank).toBe(4);
+    });
+
+    it('resolves a raw/versioned model identifier via family-substring match, not the fail-safe fallback', () => {
+      const existing = { model: 'fable', effort: 'high', tier_rank: 4 };
+      const merged = buildSessionMetadata(existing, '9', 'resume', 'claude-sonnet-5-20260601');
+      expect(merged.tier_rank).toBe(2); // resolved to 'sonnet', not conservative-up to fable's rank
+    });
+
+    it('derives tier_rank using the already-stamped effort, not a default', () => {
+      const existing = { model: 'fable', effort: 'low', tier_rank: 4 };
+      const merged = buildSessionMetadata(existing, '9', 'clear', 'sonnet');
+      expect(merged.tier_rank).toBe(1); // rankForModelEffort('sonnet', 'low')
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `worker-checkin.cjs`'s `--model` self-report is currently the only path that recomputes `tier_rank` from a model change — `capture-session-id.cjs`'s SessionStart hook already captures the live `model` field (fires on startup/resume/clear/compact) and persists it to `metadata.model`, but never re-derived `tier_rank` from it.
- Result: a mid-session `/model` switch left `tier_rank` stranded until a worker manually re-checked in with the matching flag. Coordinator observed 6/8 worker sessions still stamped `fable/tier_rank:4` after a fleet-wide Fable→Sonnet switch; the 2 that recovered had been explicitly nudged.
- Fix: re-derive `tier_rank` via the existing `rankForModelEffort` whenever SessionStart reports a `model` that differs from the prior stamp. A coarse family-substring resolver handles SessionStart's raw model identifier (not the short `{haiku,sonnet,opus,fable}` ladder alias) — unrecognized strings fall through to `normalizeModel`'s conservative-up fallback, never under-restricting a worker.
- **Scope note**: confirmed via research (no `CLAUDE_MODEL` env var exists; no hook payload besides SessionStart carries a `model` field) that no INSTANT mid-session auto-detection channel exists in the current Claude Code hook/env API — this closes the gap at the boundary the platform actually exposes (session-lifecycle events), not an invented one.

## Test plan
- `npx vitest run --project unit tests/unit/capture-session-id-metadata-merge.test.js` → 11/11 (7 pre-existing + 4 new, covering: demotion on model downgrade, no-op when model unchanged, raw/versioned identifier resolution, effort preserved from the existing stamp)
- Pre-existing suites unaffected (all assertions on exact-object equality still pass — new tier_rank field only appears when a model change is actually detected)
- `npx vitest run tests/smoke.test.js` → 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)