### PR TITLE
fix(QF-20260710-593): Solomon-leg comms surface-not-stamp — mirror ADAM-INBOX-SURFACE-NOT-STAMP-001

### DIFF
--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -255,12 +255,16 @@ async function renderChairmanDirectives(supabase, { quiet = false } = {}) {
   }
 }
 
-async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
+async function drainInbox(supabase, sessionId, { quiet = false, background = false } = {}) {
+  // QF-20260710-593 (mirrors adam-advisory drainInbox / SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001):
+  // recoverable filter is acknowledged_at IS NULL, never read_at IS NULL — a row this drain surfaces but
+  // the reasoning turn doesn't genuinely act on must stay recoverable on the NEXT drain instead of
+  // silently vanishing the moment it's first read-stamped.
   const { data: allRows, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at')
     .eq('target_session', sessionId)
-    .is('read_at', null)
+    .is('acknowledged_at', null)
     .order('created_at', { ascending: true })
     .limit(100);
   if (error) { console.error('ERROR: solomon inbox query failed:', error.message); process.exit(1); }
@@ -293,12 +297,56 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
     console.log(`  • [${lane}/${kind}] (${ageMin}m) ${text}`);
     ids.push(r.id);
   }
-  // Two-stage ACK: stamp read_at = DELIVERED only; withhold acknowledged_at (recoverable until actioned).
-  await supabase
-    .from('session_coordination')
-    .update({ read_at: new Date().toISOString() })
-    .in('id', ids)
-    .is('read_at', null);
+  // QF-20260710-593: stamp routing by context — background/cron passes (no reasoning turn sees
+  // stdout) stamp delivered_at only; interactive render stamps read_at. acknowledged_at is NEVER
+  // set here (action-time only, see ackRows below).
+  await stampSurfaced(supabase, ids, { background });
+}
+
+/**
+ * QF-20260710-593 (mirrors adam-advisory.stampSurfaced) — the single stamp-routing seam for
+ * drainInbox. background=true: stamp delivered_at (only where NULL). background=false
+ * (interactive): stamp read_at (only where NULL). Idempotent either way; acknowledged_at is
+ * NEVER written here (see ackRows).
+ */
+async function stampSurfaced(supabase, ids, { background = false } = {}) {
+  if (!ids || ids.length === 0) return;
+  const now = new Date().toISOString();
+  if (background) {
+    await supabase.from('session_coordination').update({ delivered_at: now }).in('id', ids).is('delivered_at', null);
+  } else {
+    await supabase.from('session_coordination').update({ read_at: now }).in('id', ids).is('read_at', null);
+  }
+}
+
+/**
+ * QF-20260710-593 (mirrors adam-advisory.ackRows) — the single sanctioned action-time stamp for
+ * the Solomon lane. Stamps acknowledged_at (only where NULL) and backfills read_at where NULL (an
+ * actioned row was necessarily seen). Ownership-scoped when expectedTarget is given. Idempotent.
+ */
+async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
+  const now = new Date().toISOString();
+  let acked = 0;
+  for (const id of ids) {
+    let q = supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: now })
+      .eq('id', id)
+      .is('acknowledged_at', null);
+    if (expectedTarget) q = q.eq('target_session', expectedTarget);
+    const { data, error } = await q.select('id, read_at');
+    if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
+    if (data && data.length > 0) {
+      acked += 1;
+      if (data[0].read_at == null) {
+        await supabase.from('session_coordination').update({ read_at: now }).eq('id', id).is('read_at', null);
+      }
+      console.log(`  ✓ acked ${id}`);
+    } else {
+      console.log(`  • ${id} already acked, not found, or not targeted at this Solomon session — no-op`);
+    }
+  }
+  console.log(`${acked}/${ids.length} row(s) newly acknowledged.`);
 }
 
 async function snapshotSender(supabase, sessionId) {
@@ -533,8 +581,8 @@ async function main() {
   warnIfCheckoutStale('solomon-advisory.cjs');
   const argv = process.argv.slice(2);
   const mode = argv[0];
-  if (mode !== 'send' && mode !== 'request' && mode !== 'inbox' && mode !== 'status') {
-    console.error('Usage: node scripts/solomon-advisory.cjs send "<body>" [--reply-to <id>] [--to adam]  |  request "<q>" [--timeout <ms>] [--to adam]  |  inbox [--quiet]  |  status [--working "<body>" [--eta <ms>]]');
+  if (mode !== 'send' && mode !== 'request' && mode !== 'inbox' && mode !== 'status' && mode !== 'ack') {
+    console.error('Usage: node scripts/solomon-advisory.cjs send "<body>" [--reply-to <id>] [--to adam]  |  request "<q>" [--timeout <ms>] [--to adam]  |  inbox [--quiet] [--background]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
     process.exit(2);
   }
   const sessionId = process.env.CLAUDE_SESSION_ID;
@@ -543,6 +591,20 @@ async function main() {
   let supabase;
   try { supabase = createSupabaseServiceClient(); }
   catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+
+  // QF-20260710-593: --background marks a cron/monitor context whose stdout no reasoning turn
+  // sees — such passes stamp delivered_at only (mirrors adam-advisory).
+  const isBackground = argv.includes('--background');
+
+  // QF-20260710-593 — `ack <id...>`: the action-time acknowledged_at stamp. Ids are positional
+  // args (flags filtered out).
+  if (mode === 'ack') {
+    const ids = argv.slice(1).filter((a) => !a.startsWith('--'));
+    if (ids.length === 0) { console.error('Usage: node scripts/solomon-advisory.cjs ack <row-id...>'); process.exit(2); }
+    const solomonTarget = (await getActiveSolomonId(supabase)) || sessionId;
+    await ackRows(supabase, ids, { expectedTarget: solomonTarget });
+    return;
+  }
 
   if (mode === 'inbox') {
     // Resolve the CANONICAL Solomon session (env var may not propagate to a cron subprocess).
@@ -557,7 +619,7 @@ async function main() {
     // FR-1: surface broadcast chairman directives FIRST-CLASS (above consults) with Solomon's per-directive
     // ack status, BEFORE the normal target_session-scoped drain — the Solomon-last-hop compliance fix.
     await renderChairmanDirectives(supabase, { quiet: argv.includes('--quiet') });
-    await drainInbox(supabase, solomonId, { quiet: argv.includes('--quiet') });
+    await drainInbox(supabase, solomonId, { quiet: argv.includes('--quiet'), background: isBackground });
     // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: PING-ON-SILENCE — check MY OWN sent
     // reply-needed advisories for ones left unanswered past their window. Never suppressed by
     // --quiet (a real overdue reply is a genuine delivery, not routine tick noise).
@@ -733,6 +795,7 @@ module.exports = {
   computeConsultSignature, enforceSweepBudget, SOLOMON_SWEEP_BUDGET, alreadyAnswered, checkConsultQuota,
   drainInbox, resolveReplyToCorrelation, drainSolomonOutbound, captureLedgerRow,
   checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator, ensureOriginatorCc,
+  stampSurfaced, ackRows,
 };
 
 if (require.main === module) {

--- a/tests/unit/solomon-advisory.test.js
+++ b/tests/unit/solomon-advisory.test.js
@@ -143,27 +143,118 @@ describe('FR-E1: drainSolomonOutbound (re-target on handoff — register depende
   });
 });
 
-describe('FR-E1: drainInbox consumes consults via two-stage ACK (read_at only)', () => {
-  it('surfaces consults/directives, warns on orphans, stamps read_at but NOT acknowledged_at', async () => {
-    const seen = { update: null };
+// QF-20260710-593 — migrated (not loosened): the old assertions locked in the read_at-only
+// filter/stamp, the exact bug this QF fixes (a row stamped read_at by one drain silently vanished
+// from every later drain even when never genuinely actioned). Mirrors
+// tests/unit/adam-inbox-surface-not-stamp.test.js's recording-mock pattern.
+function makeRecordingMock(selectRows = []) {
+  const updates = [];
+  const selects = [];
+  function chain() {
+    const state = { op: 'select', filters: [], updatePayload: null };
+    const c = {
+      select: () => c,
+      update: (payload) => { state.op = 'update'; state.updatePayload = payload; return c; },
+      eq: (col, v) => { state.filters.push(['eq', col, v]); return c; },
+      in: (col, v) => { state.filters.push(['in', col, v]); return c; },
+      is: (col, v) => { state.filters.push(['is', col, v]); return c; },
+      order: () => c,
+      limit: () => c,
+      then: (res, rej) => finish().then(res, rej),
+    };
+    async function finish() {
+      if (state.op === 'update') { updates.push(state); return { data: [], error: null }; }
+      selects.push(state);
+      return { data: selectRows, error: null };
+    }
+    return c;
+  }
+  return { supabase: { from: chain }, updates, selects };
+}
+
+describe('QF-20260710-593: drainInbox filters acknowledged_at IS NULL (recoverable until actioned)', () => {
+  it('queries ack-IS-NULL (not read_at) — a row a prior drain read-stamped still resurfaces', async () => {
     const unread = [
-      { id: 'a', payload: { kind: 'solomon_consult', body: 'q1' }, created_at: new Date().toISOString() },
+      { id: 'a', payload: { kind: 'solomon_consult', body: 'q1' }, created_at: new Date().toISOString(), read_at: new Date().toISOString() },
       { id: 'b', payload: { kind: 'coordinator_alert', body: 'orphan' }, created_at: new Date().toISOString() }, // orphan
     ];
-    const sb = {
-      from: () => ({
-        select: () => ({ eq: () => ({ is: () => ({ order: () => ({ limit: async () => ({ data: unread, error: null }) }) }) }) }),
-        update(p) { seen.update = p; return { in: () => ({ is: async () => ({ data: null, error: null }) }) }; },
-      }),
-    };
+    const { supabase, selects, updates } = makeRecordingMock(unread);
     const logs = []; const warns = [];
     const log = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
     const warn = vi.spyOn(console, 'warn').mockImplementation((...a) => warns.push(a.join(' ')));
-    await m.drainInbox(sb, 'solomon-sess', { quiet: false });
+    await m.drainInbox(supabase, 'solomon-sess', { quiet: false });
     log.mockRestore(); warn.mockRestore();
-    expect(seen.update).toHaveProperty('read_at');
-    expect(seen.update).not.toHaveProperty('acknowledged_at'); // two-stage ACK
-    expect(warns.join(' ')).toMatch(/orphan/i);                // orphan surfaced, not consumed
+    expect(selects[0].filters).toContainEqual(['is', 'acknowledged_at', null]);
+    expect(selects[0].filters.some((f) => f[0] === 'is' && f[1] === 'read_at')).toBe(false);
+    expect(warns.join(' ')).toMatch(/orphan/i); // orphan surfaced, not consumed
     expect(logs.join(' ')).toMatch(/consult/);
+    // interactive (default): surfaced rows stamp read_at, never acknowledged_at
+    const stamp = updates.find((u) => u.updatePayload && 'read_at' in u.updatePayload);
+    expect(stamp).toBeTruthy();
+    expect(updates.some((u) => u.updatePayload && 'acknowledged_at' in u.updatePayload)).toBe(false);
+  });
+
+  it('background=true stamps delivered_at instead of read_at', async () => {
+    const row = { id: 'a', payload: { kind: 'solomon_consult', body: 'q1' }, created_at: new Date().toISOString() };
+    const { supabase, updates } = makeRecordingMock([row]);
+    await m.drainInbox(supabase, 'solomon-sess', { quiet: true, background: true });
+    expect(updates.find((u) => u.updatePayload && 'delivered_at' in u.updatePayload)).toBeTruthy();
+    expect(updates.some((u) => u.updatePayload && 'read_at' in u.updatePayload)).toBe(false);
+  });
+});
+
+describe('QF-20260710-593: stampSurfaced', () => {
+  it('background=true stamps delivered_at only-where-NULL, never read_at', async () => {
+    const { supabase, updates } = makeRecordingMock();
+    await m.stampSurfaced(supabase, ['a', 'b'], { background: true });
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].updatePayload)).toEqual(['delivered_at']);
+    expect(updates[0].filters).toContainEqual(['is', 'delivered_at', null]);
+  });
+
+  it('interactive (default) stamps read_at only-where-NULL, never delivered_at/acknowledged_at', async () => {
+    const { supabase, updates } = makeRecordingMock();
+    await m.stampSurfaced(supabase, ['a']);
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].updatePayload)).toEqual(['read_at']);
+    expect(updates[0].filters).toContainEqual(['is', 'read_at', null]);
+  });
+
+  it('empty id list is a no-op', async () => {
+    const { supabase, updates } = makeRecordingMock();
+    await m.stampSurfaced(supabase, [], { background: true });
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe('QF-20260710-593: ackRows — the action-time stamp', () => {
+  function ackMock() {
+    const updates = [];
+    const supabase = { from: () => {
+      const state = { payload: null, guards: [] };
+      const c = {
+        update: (payload) => { state.payload = payload; return c; },
+        eq: (col, v) => { state.guards.push(['eq', col, v]); return c; },
+        is: (col, v) => { state.guards.push(['is', col, v]); return c; },
+        select: async () => { updates.push(state); return { data: [{ id: 'id-1', read_at: '2026-07-10T00:00:00Z' }], error: null }; },
+      };
+      return c;
+    } };
+    return { supabase, updates };
+  }
+
+  it('stamps acknowledged_at only-where-NULL (idempotent)', async () => {
+    const { supabase, updates } = ackMock();
+    await m.ackRows(supabase, ['id-1']);
+    expect(updates).toHaveLength(1);
+    expect(Object.keys(updates[0].payload)).toEqual(['acknowledged_at']);
+    expect(updates[0].guards).toContainEqual(['is', 'acknowledged_at', null]);
+  });
+
+  it('ownership guard: with expectedTarget the update is scoped to target_session', async () => {
+    const { supabase, updates } = ackMock();
+    await m.ackRows(supabase, ['id-1'], { expectedTarget: 'solomon-sess' });
+    expect(updates).toHaveLength(1);
+    expect(updates[0].guards).toContainEqual(['eq', 'target_session', 'solomon-sess']);
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/solomon-advisory.cjs`'s `drainInbox` filtered/consumed on `read_at IS NULL` and unconditionally stamped `read_at` on every drain, so a consult surfaced but not genuinely actioned silently vanished from every later drain (the same class of bug ADAM-INBOX-SURFACE-NOT-STAMP-001 fixed on the Adam side).
- Mirrors `scripts/adam-advisory.cjs`'s `stampSurfaced`/`ackRows` split: recoverable filter is now `acknowledged_at IS NULL`, stamp routing is background-aware (`delivered_at` for cron/monitor passes, `read_at` for interactive renders), and a new `ack <row-id...>` CLI subcommand + `--background` flag are the only sanctioned action-time `acknowledged_at` stamp.
- `drainSolomonOutbound` and the `request`-mode reply consume are intentionally untouched (already correct per research).

## Test plan
- [x] `tests/unit/solomon-advisory.test.js` — migrated the old test that locked in the buggy `read_at`-only behavior, added coverage for `stampSurfaced` background/interactive routing and `ackRows` ownership guard (24/24 passing)
- [x] Mutation-verified: stashed the fix, confirmed the new/changed assertions genuinely fail against the pre-fix code (7 failures), restored the fix, confirmed all 24 pass again
- [x] Broader coordination-lane regression sweep (`fleet-dashboard-solomon-inbox`, `read-solomon-directives`, `coordination-inbox-read-ack-split`, `protocol-version-skew-surfacing`, `solomon-consult-originator-cc`, `solomon-advisory-ledger-capture`, `adam-solomon-lane-probe`, `adam-solomon-direct-channel`) — 83/83 passing
- [x] `adam-inbox-surface-not-stamp.test.js` (reference pattern) unaffected — 15/15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)