### PR TITLE
fix(QF-20260710-491): cancelled children are terminal for orchestrator completion

### DIFF
--- a/lib/claim/queue-resolver.cjs
+++ b/lib/claim/queue-resolver.cjs
@@ -209,8 +209,10 @@ async function resolveLeafWorkItem(supabase, parentSdKey, { depth = 0, routingPa
   const grandchildren = await getOrchestratorChildren(supabase, childKey);
 
   if (grandchildren.length > 0) {
-    // Sub-orchestrator detected — check if all its children are done
-    const allGrandchildrenComplete = grandchildren.every(gc => gc.status === 'completed');
+    // Sub-orchestrator detected — check if all its children are terminal
+    // (completed or cancelled) — QF-20260710-491.
+    const { isTerminalChildStatus } = await import('../orchestrator/child-terminal-status.js');
+    const allGrandchildrenComplete = grandchildren.every(gc => isTerminalChildStatus(gc.status));
 
     if (allGrandchildrenComplete) {
       // Sub-orchestrator needs its own completion handoff — return it as the work item

--- a/lib/orchestrator/child-terminal-status.js
+++ b/lib/orchestrator/child-terminal-status.js
@@ -1,0 +1,16 @@
+/**
+ * Shared terminal-status predicate for orchestrator child SDs.
+ *
+ * A child is "terminal" — no longer something a worker or completion gate
+ * should wait on — when it is either completed or cancelled; both are final
+ * dispositions. QF-20260710-491: cancelled was excluded from every
+ * "are children done?" computation except plan-to-lead/gates/prerequisite-check.js,
+ * so any orchestrator with a cancelled child could never reach allComplete=true,
+ * permanently stranding it at claim/routing and (had claim been forced)
+ * re-stalling at LEAD-FINAL/completion-guardian.
+ */
+export const TERMINAL_CHILD_STATUSES = ['completed', 'cancelled'];
+
+export function isTerminalChildStatus(status) {
+  return TERMINAL_CHILD_STATUSES.includes(status);
+}

--- a/scripts/modules/handoff/child-sd-selector.js
+++ b/scripts/modules/handoff/child-sd-selector.js
@@ -15,6 +15,7 @@ import { sortByUrgency, scoreToBand } from '../auto-proceed/urgency-scorer.js';
 import { buildDependencyDAG, detectCycles, computeRunnableSet } from '../../../lib/orchestrator/dependency-dag.js';
 import { computeGateState } from '../../../lib/cadence/pre-claim-gate.mjs';
 import { isLeadDecisionPaused } from '../sd-next/status-helpers.js';
+import { isTerminalChildStatus } from '../../../lib/orchestrator/child-terminal-status.js';
 // SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001: route the child-path stale-claim reap through the SAME
 // gated helper the sd-next reaper uses, so a PARKED /loop worker on a CHILD SD (armed silence, PID dead
 // between ticks) is NOT reaped/phase-reset while its window is live. Reuses the ONE shared predicate.
@@ -181,13 +182,14 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
       return { sd: null, allComplete: true, reason: 'No children found' };
     }
 
-    // Check completion status
-    const completedCount = allChildren.filter(c => c.status === 'completed').length;
+    // Check completion status. Terminal (completed or cancelled) children
+    // never block orchestrator progression — QF-20260710-491.
+    const completedCount = allChildren.filter(c => isTerminalChildStatus(c.status)).length;
     const totalCount = allChildren.length;
     const allComplete = completedCount === totalCount;
 
     if (allComplete) {
-      return { sd: null, allComplete: true, reason: `All ${totalCount} children completed` };
+      return { sd: null, allComplete: true, reason: `All ${totalCount} children terminal (completed/cancelled)` };
     }
 
     // Some children exist but none are ready (blocked or in unexpected state)
@@ -196,14 +198,14 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
       return {
         sd: null,
         allComplete: false,
-        reason: `${blockedCount} children blocked, ${completedCount}/${totalCount} completed`
+        reason: `${blockedCount} children blocked, ${completedCount}/${totalCount} terminal`
       };
     }
 
     return {
       sd: null,
       allComplete: false,
-      reason: `No ready children: ${completedCount}/${totalCount} completed`
+      reason: `No ready children: ${completedCount}/${totalCount} terminal`
     };
   } catch (err) {
     console.warn(`   [child-sd-selector] Error: ${err.message}`);
@@ -252,10 +254,10 @@ export async function getReadyChildren(supabase, parentSdId, options = {}) {
       return { children: [], allComplete: true, dagErrors: [], reason: 'No children found' };
     }
 
-    // Check if all children are completed
-    const completedCount = allChildren.filter(c => c.status === 'completed').length;
+    // Check if all children are terminal (completed or cancelled) — QF-20260710-491.
+    const completedCount = allChildren.filter(c => isTerminalChildStatus(c.status)).length;
     if (completedCount === allChildren.length) {
-      return { children: [], allComplete: true, dagErrors: [], reason: `All ${allChildren.length} children completed` };
+      return { children: [], allComplete: true, dagErrors: [], reason: `All ${allChildren.length} children terminal (completed/cancelled)` };
     }
 
     // Build DAG from ALL children

--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -11,6 +11,7 @@ import path from 'path';
 import { executeOrchestratorCompletionHook } from '../../orchestrator-completion-hook.js';
 import { publishVisionEvent, VISION_EVENTS } from '../../../../../lib/eva/event-bus/vision-events.js';
 import { closeIssuePatterns } from '../../../../../lib/governance/pattern-closure.js';
+import { isTerminalChildStatus } from '../../../../../lib/orchestrator/child-terminal-status.js';
 
 /**
  * Check and complete parent SD when all children are done
@@ -51,7 +52,8 @@ export async function checkAndCompleteParentSD(sd, supabase, { shippingResults }
       .select('id, status')
       .eq('parent_sd_id', sd.parent_sd_id);
 
-    const allComplete = siblings.every(s => s.status === 'completed');
+    // Terminal (completed or cancelled) siblings never block parent completion — QF-20260710-491.
+    const allComplete = siblings.every(s => isTerminalChildStatus(s.status));
 
     if (allComplete) {
       console.log(`   🎉 All ${siblings.length} children completed - initiating parent completion`);

--- a/scripts/modules/handoff/orchestrator-completion-guardian.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian.js
@@ -15,6 +15,7 @@
 
 import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
 import { extractContracts, detectMismatches } from './executors/exec-to-plan/gates/cross-child-integration-gate.js';
+import { isTerminalChildStatus } from '../../../lib/orchestrator/child-terminal-status.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -134,7 +135,8 @@ export class OrchestratorCompletionGuardian {
     }
 
     this.childData = children || [];
-    const incomplete = children?.filter(c => c.status !== 'completed') || [];
+    // Terminal (completed or cancelled) children never block orchestrator completion — QF-20260710-491.
+    const incomplete = children?.filter(c => !isTerminalChildStatus(c.status)) || [];
 
     if (children?.length === 0) {
       this.validationResults.push({

--- a/tests/unit/claim/queue-resolver.test.js
+++ b/tests/unit/claim/queue-resolver.test.js
@@ -145,6 +145,23 @@ describe('resolveLeafWorkItem / findUnclaimedChild — descend-intent parity (TS
     expect(r.reason).toMatch(/needs completion handoff/);
   });
 
+  it('sub-orchestrator with a mix of completed + cancelled grandchildren → treated as all-terminal (QF-20260710-491)', async () => {
+    const subOrch = { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB', status: 'in_progress', claiming_session_id: null };
+    getNextReadyChildMock.mockResolvedValue({ sd: subOrch, reason: 'urgency pick' });
+    const sb = makeSb({
+      strategic_directives_v2: [
+        parentRow,
+        { id: 'uuid-sub', sd_key: 'SD-ORCH-001-SUB' },
+        { id: 'uuid-g1', sd_key: 'SD-ORCH-001-SUB-A', status: 'completed', parent_sd_id: 'uuid-sub' },
+        { id: 'uuid-g2', sd_key: 'SD-ORCH-001-SUB-B', status: 'cancelled', parent_sd_id: 'uuid-sub' },
+      ],
+      claude_sessions: [],
+    });
+    const r = await resolveLeafWorkItem(sb, 'SD-ORCH-001', { ...seam });
+    expect(r.child.sd_key).toBe('SD-ORCH-001-SUB');
+    expect(r.reason).toMatch(/needs completion handoff/);
+  });
+
   it('all children complete → {child:null, allComplete:true} passthrough; depth cap honored', async () => {
     getNextReadyChildMock.mockResolvedValue({ sd: null, allComplete: true, reason: 'All children completed' });
     const sb = makeSb({ strategic_directives_v2: [parentRow], claude_sessions: [] });

--- a/tests/unit/handoff/child-sd-selector.test.js
+++ b/tests/unit/handoff/child-sd-selector.test.js
@@ -135,6 +135,39 @@ describe('Child SD Selector', () => {
       expect(result.allComplete).toBe(true);
     });
 
+    it('should return allComplete=true when children are a mix of completed and cancelled (QF-20260710-491)', async () => {
+      let queryCount = 0;
+      const dualMock = {
+        from: () => ({
+          select: () => ({
+            eq: () => {
+              queryCount++;
+              if (queryCount === 1) {
+                return {
+                  in: () => Promise.resolve({ data: [], error: null })
+                };
+              } else {
+                return Promise.resolve({
+                  data: [
+                    { id: 'c1', status: 'completed' },
+                    { id: 'c2', status: 'cancelled' },
+                    { id: 'c3', status: 'completed' }
+                  ],
+                  error: null
+                });
+              }
+            }
+          })
+        })
+      };
+
+      const result = await getNextReadyChild(dualMock, 'parent-1');
+
+      expect(result.sd).toBe(null);
+      expect(result.allComplete).toBe(true);
+      expect(result.reason).toContain('terminal');
+    });
+
     it('should indicate blocked children when some are blocked', async () => {
       let queryCount = 0;
       const mockSupabase = {

--- a/tests/unit/orchestrator/child-terminal-status.test.js
+++ b/tests/unit/orchestrator/child-terminal-status.test.js
@@ -1,0 +1,24 @@
+/**
+ * QF-20260710-491 — shared terminal-status predicate for orchestrator children.
+ */
+import { describe, it, expect } from 'vitest';
+import { isTerminalChildStatus, TERMINAL_CHILD_STATUSES } from '../../../lib/orchestrator/child-terminal-status.js';
+
+describe('isTerminalChildStatus', () => {
+  it('treats completed and cancelled as terminal', () => {
+    expect(isTerminalChildStatus('completed')).toBe(true);
+    expect(isTerminalChildStatus('cancelled')).toBe(true);
+  });
+
+  it('treats draft/active/blocked/in_progress as non-terminal', () => {
+    expect(isTerminalChildStatus('draft')).toBe(false);
+    expect(isTerminalChildStatus('active')).toBe(false);
+    expect(isTerminalChildStatus('blocked')).toBe(false);
+    expect(isTerminalChildStatus('in_progress')).toBe(false);
+    expect(isTerminalChildStatus(undefined)).toBe(false);
+  });
+
+  it('TERMINAL_CHILD_STATUSES matches the plan-to-lead prerequisite-check reference implementation', () => {
+    expect(TERMINAL_CHILD_STATUSES).toEqual(['completed', 'cancelled']);
+  });
+});


### PR DESCRIPTION
## Summary
- RCA-confirmed: 5 of 6 code sites that compute "are all children done?" for an orchestrator SD only counted `status='completed'` as terminal, leaving `cancelled` (a deliberate final disposition) permanently non-terminal.
- Any orchestrator with ≥1 cancelled child could never reach `allComplete=true`, stranding it at claim/routing (`child-sd-selector.js` `getNextReadyChild`/`getReadyChildren`, `queue-resolver.cjs` `resolveLeafWorkItem`) and would have re-stalled at LEAD-FINAL completion (`helpers.js`, `orchestrator-completion-guardian.js`) had the claim been forced through by any other means.
- Adds a shared `isTerminalChildStatus()`/`TERMINAL_CHILD_STATUSES` helper (`lib/orchestrator/child-terminal-status.js`) matching the one site that was already correct (`plan-to-lead/gates/prerequisite-check.js:211`), and applies it at all 5 buggy sites — eliminating the divergence instead of patching one symptom.
- Confirmed live-stranded and now fixed: `SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001` (children `[completed, cancelled, completed]`, stuck ~3h+ despite an explicit coordinator adopt-orphan directive) — `resolveLeafWorkItem` now resolves `allComplete=true` for it.
- `git log -L` confirms this is a long-standing gap (shipped 2026-01-25), not a regression.

## Test plan
- New `tests/unit/orchestrator/child-terminal-status.test.js` — unit coverage for the shared predicate.
- New regression case in `tests/unit/handoff/child-sd-selector.test.js` — mix of completed+cancelled children now returns `allComplete=true`.
- New regression case in `tests/unit/claim/queue-resolver.test.js` — sub-orchestrator with a mix of completed+cancelled grandchildren is treated as all-terminal (previously would recurse/mis-route).
- All 27 tests in the 3 touched suites pass.
- Live-verified against the actual DB: `resolveLeafWorkItem(supabase, 'SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001')` now returns `{ allComplete: true, reason: 'All 3 children terminal (completed/cancelled)' }`, unblocking the documented parent-rollup recovery path in `sd-start.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)