### PR TITLE
fix(QF-20260710-243): e2e/simulated fixture ventures no longer create real chairman decisions

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -24,33 +24,41 @@ const REALTIME_CHANNEL = 'chairman-decisions';
 // end-to-end (its own root cause was the CI workflow running that suite unintentionally
 // against production, fixed separately in package.json's test:coverage script), so it must
 // still be able to create decisions when the suite is run intentionally.
-const FIXTURE_VENTURE_NAME_RE = /^(parity-test-|test-stub)/i;
+// QF-20260710-243: widened to also match the `__e2e_*__` e2e-fixture naming convention --
+// confirmed live specimens ('__e2e_product_review_gate_adv_...__', 'Test Venture for
+// Owned-Audience Loop') both surfaced real Stage-23 chairman gates + emails within an hour,
+// with is_demo=false (the known ventures.is_synthetic phantom-column gap means fixture
+// factories can't reliably set is_demo).
+const FIXTURE_VENTURE_NAME_RE = /^(parity-test-|test-stub|__e2e_)/i;
 
 /**
  * Pure: is this venture a test/CI fixture that must never reach the live chairman queue?
- * is_demo=true is the primary signal; the name pattern is defense-in-depth for fixture
- * factories that omit is_demo.
- * @param {{is_demo?: boolean, name?: string}|null|undefined} venture
+ * is_demo=true is the primary signal; launch_mode='simulated' (confirmed live on both
+ * QF-20260710-243 incident specimens, which had is_demo=false) is a second structural
+ * signal -- no real venture is ever launch_mode='simulated'; the name pattern remains
+ * defense-in-depth for fixture factories that omit both.
+ * @param {{is_demo?: boolean, name?: string, launch_mode?: string}|null|undefined} venture
  * @returns {boolean}
  */
 export function isFixtureVenture(venture) {
   if (!venture) return false;
   if (venture.is_demo === true) return true;
+  if (venture.launch_mode === 'simulated') return true;
   return typeof venture.name === 'string' && FIXTURE_VENTURE_NAME_RE.test(venture.name);
 }
 
 /**
- * I/O: fetches {is_demo, name} for the fixture-venture check. Fail-open (returns null, never
- * throws) — a lookup fault must never block a legitimate chairman decision, matching this
- * module's existing resolveDecisionHealth fail-open contract.
+ * I/O: fetches {is_demo, name, launch_mode} for the fixture-venture check. Fail-open (returns
+ * null, never throws) — a lookup fault must never block a legitimate chairman decision,
+ * matching this module's existing resolveDecisionHealth fail-open contract.
  * @param {Object} supabase
  * @param {string} ventureId
  * @param {Object} [logger]
- * @returns {Promise<{is_demo?: boolean, name?: string}|null>}
+ * @returns {Promise<{is_demo?: boolean, name?: string, launch_mode?: string}|null>}
  */
 export async function fetchVentureForFixtureCheck(supabase, ventureId, logger = console) {
   try {
-    const { data, error } = await supabase.from('ventures').select('is_demo, name').eq('id', ventureId).maybeSingle();
+    const { data, error } = await supabase.from('ventures').select('is_demo, name, launch_mode').eq('id', ventureId).maybeSingle();
     if (error) {
       logger.warn(`[FixtureVentureCheck] Lookup errored for venture ${ventureId}, proceeding as non-fixture: ${error.message}`);
       return null;

--- a/lib/marketing/autonomy-gate.js
+++ b/lib/marketing/autonomy-gate.js
@@ -16,6 +16,12 @@
  * deliberately does not auto-mark an outcome as part of a successful publish() call.
  */
 import { recordPendingDecision } from '../chairman/record-pending-decision.mjs';
+// QF-20260710-243: this fail-closed publish gate never checked for a fixture venture before
+// recordPendingDecision() -- confirmed live: 'Test Venture for Owned-Audience Loop'
+// (launch_mode='simulated', is_demo=false) surfaced a real outbound-publish-approval to the
+// chairman queue. The authorization DECISION (allowed/denied, ledger propose row) is
+// unaffected -- only the chairman-facing side effect is skipped for a fixture.
+import { isFixtureVenture, fetchVentureForFixtureCheck } from '../eva/chairman-decision-watcher.js';
 
 const DEFAULT_RATE_LIMIT_MAX_POSTS = 50;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
@@ -152,14 +158,18 @@ export async function checkPublishAuthorization({ supabase, ventureId, channelTy
 
     // FR-7: a pending outbound approval routes through the existing chairman_decisions
     // surface rather than a new UI. Non-blocking — the pending ledger row is the durable
-    // record regardless of whether this notification succeeds.
-    await recordPendingDecision(supabase, {
-      title: `Outbound publish pending approval (${channelType})`,
-      decisionType: 'outbound_publish_approval',
-      ventureId,
-      blocking: false,
-      context: { ledger_entry_id: inserted?.id, channel_type: channelType, content_ref: contentId, correlation_id: proposeCorrelationId },
-    }).catch(() => { /* fail-soft: the pending ledger row is the durable record */ });
+    // record regardless of whether this notification succeeds. Fixture ventures never
+    // reach the live chairman queue (QF-20260710-243).
+    const ventureForCheck = await fetchVentureForFixtureCheck(supabase, ventureId);
+    if (!isFixtureVenture(ventureForCheck)) {
+      await recordPendingDecision(supabase, {
+        title: `Outbound publish pending approval (${channelType})`,
+        decisionType: 'outbound_publish_approval',
+        ventureId,
+        blocking: false,
+        context: { ledger_entry_id: inserted?.id, channel_type: channelType, content_ref: contentId, correlation_id: proposeCorrelationId },
+      }).catch(() => { /* fail-soft: the pending ledger row is the durable record */ });
+    }
   }
 
   return { allowed: false, reason: 'AUTONOMY_APPROVAL_REQUIRED: no accepted approval record for this content on this channel — a pending approval has been recorded for review' };

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -589,6 +589,21 @@ describe('isFixtureVenture', () => {
     expect(isFixtureVenture(null)).toBe(false);
     expect(isFixtureVenture(undefined)).toBe(false);
   });
+
+  // QF-20260710-243: confirmed live incident specimens (is_demo=false, name doesn't
+  // match the old regex) -- __e2e_product_review_gate_adv_...__ (Stage-23) and
+  // 'Test Venture for Owned-Audience Loop' (outbound_publish_approval).
+  it('is true for an __e2e_-prefixed name even without is_demo', () => {
+    expect(isFixtureVenture({ name: '__e2e_product_review_gate_adv_1783723784384__', is_demo: false })).toBe(true);
+  });
+
+  it('is true for launch_mode:simulated regardless of name or is_demo', () => {
+    expect(isFixtureVenture({ name: 'Test Venture for Owned-Audience Loop', is_demo: false, launch_mode: 'simulated' })).toBe(true);
+  });
+
+  it('is false for a real venture with a non-simulated launch_mode', () => {
+    expect(isFixtureVenture({ name: 'Acme Real Venture', is_demo: false, launch_mode: 'live' })).toBe(false);
+  });
 });
 
 describe('createOrReusePendingDecision: fixture-venture guard (QF-20260703-236)', () => {

--- a/tests/unit/marketing/autonomy-gate.test.js
+++ b/tests/unit/marketing/autonomy-gate.test.js
@@ -124,7 +124,7 @@ describe('recordPublishOutcome', () => {
 });
 
 describe('checkPublishAuthorization — dedup + FR-7 chairman_decisions routing', () => {
-  function makeAuthSupabase({ autonomyState = null, autonomyError = null, acceptedRow = null, acceptedError = null, existingPending = null, existingPendingError = null, insertData = { id: 'ledger-new' }, insertError = null }) {
+  function makeAuthSupabase({ autonomyState = null, autonomyError = null, acceptedRow = null, acceptedError = null, existingPending = null, existingPendingError = null, insertData = { id: 'ledger-new' }, insertError = null, ventureRow = { is_demo: false, name: 'Real Venture', launch_mode: 'live' } }) {
     let ledgerMaybeSingleCallCount = 0;
     const autonomyChain = {
       select: vi.fn().mockReturnThis(),
@@ -143,7 +143,21 @@ describe('checkPublishAuthorization — dedup + FR-7 chairman_decisions routing'
         return Promise.resolve({ data: existingPending, error: existingPendingError });
       }),
     };
-    return { from: vi.fn((table) => (table === 'venture_channel_autonomy' ? autonomyChain : ledgerChain)), ledgerChain };
+    // QF-20260710-243: fetchVentureForFixtureCheck reads its own 'ventures' table -- a dedicated
+    // chain so it never shares (and corrupts) ledgerChain's call-count-based maybeSingle mock.
+    const venturesChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(() => Promise.resolve({ data: ventureRow, error: null })),
+    };
+    return {
+      from: vi.fn((table) => {
+        if (table === 'venture_channel_autonomy') return autonomyChain;
+        if (table === 'ventures') return venturesChain;
+        return ledgerChain;
+      }),
+      ledgerChain,
+    };
   }
 
   beforeEach(() => vi.clearAllMocks());
@@ -187,6 +201,18 @@ describe('checkPublishAuthorization — dedup + FR-7 chairman_decisions routing'
       supabase,
       expect.objectContaining({ decisionType: 'outbound_publish_approval', ventureId: 'v-1' })
     );
+  });
+
+  it('QF-20260710-243: skips the chairman_decisions notification for a fixture venture, but still writes the pending ledger row (authorization behavior unchanged)', async () => {
+    const supabase = makeAuthSupabase({
+      autonomyState: 'propose_and_approve', acceptedRow: null, existingPending: null,
+      ventureRow: { is_demo: false, name: 'Test Venture for Owned-Audience Loop', launch_mode: 'simulated' },
+    });
+    const result = await checkPublishAuthorization({ supabase, ventureId: 'v-1', channelType: 'x', contentId: 'c-1', correlationId: 'corr-1' });
+
+    expect(result.allowed).toBe(false);
+    expect(supabase.ledgerChain.insert).toHaveBeenCalledWith(expect.objectContaining({ correlation_id: 'corr-1', decision: 'pending' }));
+    expect(recordPendingDecision).not.toHaveBeenCalled();
   });
 
   it('on a RETRY of the same unapproved attempt, does not insert a duplicate row or re-notify (dedup)', async () => {


### PR DESCRIPTION
## Summary
- Chairman OK'd this fix. Confirmed live: `__e2e_product_review_gate_adv_...__` ventures surfaced real Stage-23 chairman gates + emails, and `Test Venture for Owned-Audience Loop` surfaced a real `outbound_publish_approval` — both within ~1 hour. Both specimens have `is_demo=false` (the known `ventures.is_synthetic` phantom-column gap) but `launch_mode='simulated'` — no real venture is ever `launch_mode='simulated'`.
- Widened the canonical `isFixtureVenture()` (`lib/eva/chairman-decision-watcher.js`) to also treat `launch_mode='simulated'` as fixture, and widened the name regex to match `__e2e_` (still deliberately excludes `__citest_`, which intentionally exercises the real write path per its own test).
- `chairman-product-review.js`'s Stage-23 product-review gate already called this shared helper before generating a packet, so it's fixed for free by the widened predicate — no changes needed there.
- `lib/marketing/autonomy-gate.js`'s `checkPublishAuthorization()` (the `outbound_publish_approval` producer) never checked for a fixture venture before calling `recordPendingDecision()` — wired it through the same shared helper. The authorization decision itself (allowed/denied, the ledger propose row) is unchanged; only the chairman-facing notification is skipped for a fixture venture.
- Left `lib/chairman/chairman-actionable.mjs`'s separate `isFixtureVenture` untouched — it's a deliberately distinct READ-side console-display predicate mirroring a SQL RPC (`get_pending_chairman_items`), already broader on name patterns, and out of scope for this write-side prevention fix.

## Test plan
- `npx vitest run tests/unit/marketing/autonomy-gate.test.js tests/unit/eva/chairman-decision-watcher.test.js tests/unit/eva/chairman-decision-watcher-force.test.js tests/unit/eva/chairman-product-review.test.js tests/unit/chairman/all-paths-producers.test.js` → 125/125 pass
- New tests pin both incident specimens: `isFixtureVenture` true for `__e2e_product_review_gate_adv_...__` and for `launch_mode:'simulated'`; `checkPublishAuthorization` skips `recordPendingDecision` for a fixture venture while still writing the pending ledger row (authorization behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)