### PR TITLE
fix(QF-20260710-818): manual pm-board nodes get intended-hold suppression; dismissed digests don't respawn immediately

### DIFF
--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -16,6 +16,9 @@ import { setStatus } from './task-ledger.js';
 
 const SD_TERMINAL_STATUSES = ['completed', 'cancelled'];
 const STALL_DIGEST_PREFIX = 'Adam PM stall:';
+// QF-20260710-818: dismissing a stall digest (status moved off 'pending') must not immediately
+// respawn a fresh escalation email on the same still-stale nodes the very next tick.
+const DISMISS_COOLDOWN_MS = 15 * 60_000;
 
 /**
  * QF-20260703-860: find an already-open stall digest (if any) so a subsequent tick can refresh
@@ -114,6 +117,33 @@ async function isCorrelationTerminal(supabase, correlationId) {
 }
 
 /**
+ * QF-20260710-818: find the most recently dismissed (non-pending) stall digest, if it covers
+ * at least one of the currently-stalled node_ids and was dismissed within the cooldown window.
+ * A chairman dismissal is a deliberate "not now" on those specific nodes — re-escalating them
+ * on the very next tick defeats the dismissal. Fail-soft (a query error is NOT terminal — never
+ * silently swallow a possibly-real stall by treating an error as "recently dismissed").
+ */
+async function findRecentlyDismissedStallDigest(supabase, nodeIds) {
+  try {
+    const { data } = await supabase
+      .from('chairman_decisions')
+      .select('id, brief_data, updated_at')
+      .neq('status', 'pending')
+      .like('summary', `${STALL_DIGEST_PREFIX}%`)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!data) return null;
+    const dismissedIds = new Set(data.brief_data?.context?.node_ids || []);
+    const overlaps = nodeIds.some((id) => dismissedIds.has(id));
+    const withinCooldown = Date.now() - new Date(data.updated_at).getTime() < DISMISS_COOLDOWN_MS;
+    return overlaps && withinCooldown ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Pure: bump (or reset) the ticks-since-movement counter for a node given its current
  * updated_at and the previous tick's snapshot for that node. No movement recorded yet
  * (or the timestamp changed) resets the counter to 0; an unchanged timestamp increments it.
@@ -175,6 +205,15 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
       await setStatus(supabase, node.id, 'done').catch(() => {});
       continue;
     }
+    // QF-20260710-818: a manual node routed to another actor (Solomon consult, sourced fleet
+    // work, an external gate) is an intended hold, not a genuine stall. Unlike sourced_sd/
+    // advisory_thread, a manual node has no linked row to re-check -- board status='blocked' is
+    // the existing zero-migration signal for "don't escalate", set explicitly by whoever routed
+    // the work elsewhere (never set by default rehydrate, so this is opt-in, not silent).
+    if (node.source_kind === 'manual' && node.status === 'blocked') {
+      console.log(`[Adam PM] Suppressing stall alert for held manual node ${node.id}`);
+      continue;
+    }
     stalls.push({ ...node, ticks });
   }
 
@@ -207,15 +246,22 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
       const res = await escalateChairmanDecision(supabase, decisionId);
       escalated = res.escalated === true;
     } else {
-      const res = await recordPendingDecision(supabase, {
-        title,
-        decisionType: 'session_question',
-        context,
-        blocking: true,
-        raisedBy: 'adam',
-      });
-      decisionId = res.id;
-      escalated = res.escalated === true;
+      const dismissed = await findRecentlyDismissedStallDigest(supabase, context.node_ids);
+      if (dismissed) {
+        console.log(`[Adam PM] Suppressing re-escalation — digest ${dismissed.id} covering these nodes was dismissed within the last ${Math.round(DISMISS_COOLDOWN_MS / 60_000)}m`);
+        decisionId = dismissed.id;
+        escalated = false;
+      } else {
+        const res = await recordPendingDecision(supabase, {
+          title,
+          decisionType: 'session_question',
+          context,
+          blocking: true,
+          raisedBy: 'adam',
+        });
+        decisionId = res.id;
+        escalated = res.escalated === true;
+      }
     }
     for (const n of stalls) alerted.push({ id: n.id, title: n.title || n.id, escalated });
   }

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -308,6 +308,91 @@ describe('QF-20260704-319: advisory_thread correlation-terminal self-heal', () =
   });
 });
 
+describe('QF-20260710-818: manual node intended-hold suppression (status=blocked)', () => {
+  const sb = {};
+
+  it('suppresses a manual node held via status=blocked — no filing, no false-done', async () => {
+    const parents = [{
+      id: 'm1', title: 'Routed to Solomon consult', updated_at: 'fixed', status: 'blocked',
+      source_kind: 'manual', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { m1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled(); // held, not finished — must not be marked done
+    expect(alerted).toEqual([]);
+  });
+
+  it('still alerts a manual node that is genuinely stale (status is open, not blocked)', async () => {
+    const parents = [{
+      id: 'm2', title: 'Genuinely stuck manual task', updated_at: 'fixed', status: 'open',
+      source_kind: 'manual', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { m2: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'm2', title: 'Genuinely stuck manual task', escalated: true }]);
+  });
+});
+
+describe('QF-20260710-818: dismissed stall digest cooldown (no immediate respawn)', () => {
+  const parents = [{ id: 'p1', title: 'Stuck thread', updated_at: 'fixed', inFlightNextStep: false }];
+  const prevSnapshot = { p1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+  function sbWithDismissedDigest(dismissedDigest) {
+    return {
+      from(table) {
+        if (table !== 'chairman_decisions') return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+        return {
+          select: () => ({
+            eq: () => ({ like: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null }) }) }) }) }),
+            neq: () => ({ like: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: dismissedDigest }) }) }) }) }),
+          }),
+        };
+      },
+    };
+  }
+
+  it('suppresses re-escalation when a recently-dismissed digest covers the same node', async () => {
+    const stubSb = sbWithDismissedDigest({
+      id: 'dec-old', brief_data: { context: { node_ids: ['p1'] } }, updated_at: new Date().toISOString(),
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([{ id: 'p1', title: 'Stuck thread', escalated: false }]);
+  });
+
+  it('still escalates when the dismissed digest does not overlap the current node_ids', async () => {
+    const stubSb = sbWithDismissedDigest({
+      id: 'dec-old', brief_data: { context: { node_ids: ['unrelated-node'] } }, updated_at: new Date().toISOString(),
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'p1', title: 'Stuck thread', escalated: true }]);
+  });
+
+  it('still escalates once the dismissed digest is outside the cooldown window', async () => {
+    const stubSb = sbWithDismissedDigest({
+      id: 'dec-old', brief_data: { context: { node_ids: ['p1'] } },
+      updated_at: new Date(Date.now() - 60 * 60_000).toISOString(), // 1h ago, past the 15m cooldown
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'p1', title: 'Stuck thread', escalated: true }]);
+  });
+
+  it('escalates normally when no dismissed digest exists at all', async () => {
+    const stubSb = sbWithDismissedDigest(null);
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'p1', title: 'Stuck thread', escalated: true }]);
+  });
+});
+
 describe('QF-20260703-860: supersede the open stall digest instead of inserting per tick', () => {
   it('3 ticks against a persistent stale thread: exactly ONE recordPendingDecision insert, later ticks refresh the same row via update+re-attempted escalation (which dedupes)', async () => {
     const stubSb = makeStallDigestSupabase();


### PR DESCRIPTION
## Summary
- `source_kind='manual'` pm-board nodes had no hold-detection path (unlike `sourced_sd`/`advisory_thread`), so a manual node whose work was routed to another actor (Solomon consult, sourced fleet QF/SD, external time window) always re-escalated to the chairman once stale — hit the chairman 3x in ~1h on the same 6 node_ids per the incident report.
- Adds a `status='blocked'` suppression branch mirroring the existing `isSdIntentionallyHeld` pattern — zero migration, reuses the `status` column `adam-quiet-tick.mjs` already fetches and filters on.
- Also fixes the dismiss→re-detect→re-email loop: dismissing a stall digest (status moved off `'pending'`) let the very next reconcile tick immediately insert a fresh escalation on the same `node_ids`. Adds a 15-minute cooldown keyed on the dismissed digest's `node_ids` overlap + `updated_at` recency.
- `rollupParentStatus`'s childless-parent-forced-to-`'open'` behavior (also named in the QF description) was researched and confirmed **not currently wired to any writer** — its output isn't persisted anywhere today, so there's nothing live to fix there; noted for awareness if a future change ever wires it into a reconcile write.

## Test plan
- [x] `tests/unit/adam/stall-alert.test.js` — added coverage for manual-node `status=blocked` suppression (+ a contrast case confirming a genuinely-stale open manual node still escalates), and for the dismissed-digest cooldown (suppresses on overlap+recency, still escalates on no-overlap or past-cooldown) — 23/23 passing
- [x] Mutation-verified: stashed the fix, confirmed the 2 new suppression assertions genuinely fail against the pre-fix code, restored the fix, confirmed all 23 pass again
- [x] Regression sweep on adjacent Adam PM-board test files (`adam-quiet-tick-reconcile`, `task-ledger`, `adam-pm-board`) — 24/24 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)