### PR TITLE
fix(QF-20260710-056): adam-quiet-tick now watches for silently-stalled ventures

### DIFF
--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -117,6 +117,50 @@ export async function readCriticalPathParents(sb) {
   }
 }
 
+// QF-20260710-056: the quiet-tick only watched Adam-PM-board nodes (task_ledger) —
+// a live venture stuck mid-traversal (orchestrator_state='blocked') went silently
+// undetected for ~50min because nothing else was watching it. Scoped to
+// status='active' + orchestrator_state='blocked' only (live-verified: adding a
+// workflow_status='pending' OR-clause, as the raw incident report suggested, pulled
+// in 25+ status='cancelled' dead/archived/e2e-fixture ventures whose workflow_status
+// field was simply never updated after termination — pure noise, not stalls). A
+// fresh stage_executions row means the venture is actively progressing, not
+// stalled — checked per-candidate so a venture mid-stage-transition is never
+// false-flagged. Escalates (escalated:true) only once a candidate has already been
+// seen on a prior tick, matching the codebase's default-to-NOT-escalating bias.
+const VENTURE_STALL_THRESHOLD_MS = 15 * 60 * 1000;
+
+export async function checkVentureTraversalStalls(sb, priorSnapshot = {}) {
+  const thresholdIso = new Date(Date.now() - VENTURE_STALL_THRESHOLD_MS).toISOString();
+  const snapshot = {};
+  const alerted = [];
+  try {
+    const { data: stuck } = await sb
+      .from('ventures')
+      .select('id, name, orchestrator_state, status, updated_at')
+      .eq('status', 'active')
+      .eq('orchestrator_state', 'blocked')
+      .lt('updated_at', thresholdIso);
+
+    for (const v of (stuck || [])) {
+      const { data: recent } = await sb
+        .from('stage_executions')
+        .select('id')
+        .eq('venture_id', v.id)
+        .gte('updated_at', thresholdIso)
+        .limit(1);
+      if (recent && recent.length > 0) continue; // actively executing, not stalled
+
+      const escalated = !!priorSnapshot[v.id];
+      snapshot[v.id] = priorSnapshot[v.id] || Date.now();
+      alerted.push({ id: v.id, name: v.name, orchestrator_state: v.orchestrator_state, escalated });
+    }
+  } catch (e) {
+    return { snapshot: priorSnapshot, alerted: [], error: e && e.message };
+  }
+  return { snapshot, alerted };
+}
+
 // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-3) — surface the Adam session's
 // unacked directed rows as FIRST-CLASS lines in the TICK'S OWN stdout (the act-on-flagged-
 // lines contract, same as QUIET_TICK_STALL_ALERT). Required because scriptCore truncates
@@ -227,6 +271,7 @@ async function main() {
   // {salient, stallSnapshot} — treat it as the salient half and start with no stall snapshot.
   const priorSalient = priorState.salient !== undefined ? priorState.salient : priorState;
   const priorStallSnapshot = priorState.stallSnapshot || {};
+  const priorVentureStallSnapshot = priorState.ventureStallSnapshot || {};
 
   // Child B FR-2/FR-3: intended-hold-vs-genuine-stall check on critical-path parents every
   // tick. Only a genuine stall (per stall-detector.js's classifier) ever calls
@@ -237,6 +282,15 @@ async function main() {
     stall = await checkAndAlertStalls(sb, parents, priorStallSnapshot, {});
   } catch (e) {
     stall = { snapshot: priorStallSnapshot, alerted: [], error: e && e.message };
+  }
+
+  // QF-20260710-056: a venture stuck mid-traversal is the thing that matters most —
+  // check it every tick, independent of the task_ledger stall watch above.
+  let ventureStall = { snapshot: priorVentureStallSnapshot, alerted: [] };
+  try {
+    ventureStall = await checkVentureTraversalStalls(sb, priorVentureStallSnapshot);
+  } catch (e) {
+    ventureStall = { snapshot: priorVentureStallSnapshot, alerted: [], error: e && e.message };
   }
 
   // SD-LEO-FIX-ADAM-OUTBOUND-SILENCE-001: watch Adam's own outbound rows at a live
@@ -257,7 +311,7 @@ async function main() {
   // reaches the coordinator on a real belt/venture delta, never a "still idle" status.
   const salient = await readSalientState(sb);
   const delta = detectSalientDelta(priorSalient, salient);
-  saveLastState({ salient, stallSnapshot: stall.snapshot });
+  saveLastState({ salient, stallSnapshot: stall.snapshot, ventureStallSnapshot: ventureStall.snapshot });
 
   const delaySeconds = decideCadence({ quiescent, partyOffsetS: ADAM_PARTY_OFFSET_S });
 
@@ -269,6 +323,7 @@ async function main() {
     failedCount: tick.failedCount,
     boardReconcile,
     stallAlerted: stall.alerted,
+    ventureStallAlerted: ventureStall.alerted,
     inboxSurfaced: inboxSurface.items.length,
     inboxDirectives: inboxSurface.directives,
     outboundSilence,
@@ -285,6 +340,7 @@ async function main() {
       `fail=${tick.failedCount} ` +
       `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
       `stalls=${stall.alerted.length} ` +
+      `ventureStalls=${ventureStall.alerted.length} ` +
       `inbox=${inboxSurface.items.length}(dir:${inboxSurface.directives}) ` +
       `probes=${outboundSilence.probed.length} esc=${outboundSilence.escalated.length} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
@@ -295,6 +351,9 @@ async function main() {
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);
+    }
+    for (const v of ventureStall.alerted) {
+      console.log(`QUIET_TICK_VENTURE_STALL_ALERT=adam venture=${v.id} name="${v.name}" state=${v.orchestrator_state} escalated=${v.escalated}`);
     }
     // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-3): first-class inbox surfacing —
     // directive/reply-needed rows carry the distinct hard-interrupt token.

--- a/tests/unit/adam/adam-quiet-tick-venture-stall.test.js
+++ b/tests/unit/adam/adam-quiet-tick-venture-stall.test.js
@@ -1,0 +1,99 @@
+/**
+ * QF-20260710-056: adam-quiet-tick was blind to a venture stuck mid-traversal —
+ * only the Adam-PM-board (task_ledger) watch existed. checkVentureTraversalStalls()
+ * closes that gap by checking ventures.orchestrator_state/workflow_status directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkVentureTraversalStalls } from '../../../scripts/adam-quiet-tick.mjs';
+
+function readBuilder(data) {
+  const b = {
+    select: () => b, eq: () => b, or: () => b, lt: () => b, gte: () => b, limit: () => b,
+    then: (resolve, reject) => Promise.resolve({ data, error: null }).then(resolve, reject),
+  };
+  return b;
+}
+
+/** Filter-applying ventures builder — proves the query itself excludes non-active/non-blocked rows,
+ *  not just that the caller happens to pre-filter its fixture (QF-20260710-056 noise-scope fix). */
+function ventureBuilder(rows) {
+  const filters = [];
+  const b = {
+    select: () => b,
+    eq: (col, val) => { filters.push((r) => r[col] === val); return b; },
+    lt: (col, val) => { filters.push((r) => r[col] < val); return b; },
+    then: (resolve, reject) => Promise.resolve({ data: rows.filter((r) => filters.every((f) => f(r))), error: null }).then(resolve, reject),
+  };
+  return b;
+}
+
+function makeSupabase({ ventures = [], staleStageExecutions = new Set() } = {}) {
+  return {
+    from(table) {
+      if (table === 'ventures') return ventureBuilder(ventures);
+      if (table === 'stage_executions') {
+        // Return a fresh row only for venture IDs NOT in staleStageExecutions —
+        // i.e. actively-executing ventures have a recent stage_executions row.
+        let lastVentureId = null;
+        const b = {
+          select: () => b,
+          eq: (col, val) => { if (col === 'venture_id') lastVentureId = val; return b; },
+          gte: () => b,
+          limit: () => b,
+          then: (resolve, reject) => {
+            const data = staleStageExecutions.has(lastVentureId) ? [] : [{ id: 'se-1' }];
+            return Promise.resolve({ data, error: null }).then(resolve, reject);
+          },
+        };
+        return b;
+      }
+      return readBuilder([]);
+    },
+  };
+}
+
+describe('checkVentureTraversalStalls', () => {
+  it('flags a status=active/orchestrator_state=blocked venture with no fresh stage_executions row, first-seen (not escalated)', async () => {
+    const sb = makeSupabase({
+      ventures: [{ id: 'v1', name: 'North Star', status: 'active', orchestrator_state: 'blocked', updated_at: '2020-01-01' }],
+      staleStageExecutions: new Set(['v1']),
+    });
+    const result = await checkVentureTraversalStalls(sb, {});
+    expect(result.alerted).toHaveLength(1);
+    expect(result.alerted[0]).toMatchObject({ id: 'v1', escalated: false });
+    expect(result.snapshot.v1).toBeTruthy();
+  });
+
+  it('escalates a venture already present in the prior snapshot', async () => {
+    const sb = makeSupabase({
+      ventures: [{ id: 'v1', name: 'North Star', status: 'active', orchestrator_state: 'blocked', updated_at: '2020-01-01' }],
+      staleStageExecutions: new Set(['v1']),
+    });
+    const result = await checkVentureTraversalStalls(sb, { v1: Date.now() - 60_000 });
+    expect(result.alerted[0].escalated).toBe(true);
+  });
+
+  it('does NOT flag a venture with a fresh stage_executions row (actively executing, not stalled)', async () => {
+    const sb = makeSupabase({
+      ventures: [{ id: 'v2', name: 'Active Venture', status: 'active', orchestrator_state: 'blocked', updated_at: '2020-01-01' }],
+      staleStageExecutions: new Set(), // v2 has a fresh row
+    });
+    const result = await checkVentureTraversalStalls(sb, {});
+    expect(result.alerted).toHaveLength(0);
+  });
+
+  it('does NOT flag a status=cancelled venture even if orchestrator_state is stuck at blocked (dead/archived venture noise — QF-20260710-056 live-verified regression)', async () => {
+    const sb = makeSupabase({
+      ventures: [{ id: 'v3', name: '__e2e_dead_fixture__', status: 'cancelled', orchestrator_state: 'blocked', updated_at: '2020-01-01' }],
+      staleStageExecutions: new Set(['v3']),
+    });
+    const result = await checkVentureTraversalStalls(sb, {});
+    expect(result.alerted).toHaveLength(0);
+  });
+
+  it('is fail-soft: a throwing/malformed client returns empty alerts and the prior snapshot, never throws', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    const prior = { v9: 123 };
+    await expect(checkVentureTraversalStalls(sb, prior)).resolves.toMatchObject({ alerted: [], snapshot: prior });
+  });
+});


### PR DESCRIPTION
## Summary
- The Adam quiet-tick only detected Adam-PM-board stalls (`task_ledger` nodes) — a live venture stuck mid-traversal went silently undetected for ~50min (venture `809ec7e7`, the process-proving north-star, sat `orchestrator_state=blocked` at stage 7; the chairman caught it, not the tick).
- Adds `checkVentureTraversalStalls()`: flags ventures with `status='active'` AND `orchestrator_state='blocked'` past a 15min threshold with no fresh `stage_executions` row (a venture still actively progressing mid-stage is never false-flagged), escalating only once a candidate has already been seen on a prior tick.
- **Scope note (live-verified before finalizing):** the incident report's literal suggested query (`orchestrator_state='blocked'` OR `workflow_status='pending'`) was tested against the real DB first and pulled in 25+ `status='cancelled'` dead/archived/e2e-test-fixture ventures whose `workflow_status` field was simply never updated after termination — pure noise, not stalls, which would have spammed every tick forever. Narrowed to `status='active'` AND `orchestrator_state='blocked'` only, which isolates the real incident venture with zero false positives against current live data (re-verified: 0 alerts right now, all current blocked-candidates are <2min old, well under the 15min threshold).

## Test plan
- New `tests/unit/adam/adam-quiet-tick-venture-stall.test.js`: 5 cases — flags a genuine stall, escalates on repeat, does not flag an actively-executing venture (fresh `stage_executions` row), does not flag a `status='cancelled'` dead venture (the noise-exclusion regression), fail-soft on a throwing client.
- Existing `tests/unit/adam/adam-quiet-tick-reconcile.test.js` (5 tests) still passes unmodified.
- Live-verified read-only against the actual database: the corrected query returns the real cited incident venture (`809ec7e7`) when the OR-clause noise is removed, and returns 0 alerts against current live data (nothing currently past the 15min threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)