### PR TITLE
fix(QF-20260710-743): resurface-pump paginates past its limit-50 window instead of starving the tail

### DIFF
--- a/scripts/solomon-ledger-pending-resurface.cjs
+++ b/scripts/solomon-ledger-pending-resurface.cjs
@@ -15,6 +15,10 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
 
 const DEFAULT_THRESHOLD_HOURS = 24;
+const DEFAULT_PAGE_SIZE = 50;
+// Safety cap on pages per invocation (10 * 50 = 500 rows/run) -- bounds worst-case query
+// volume for a sweep script without reintroducing the head-of-queue starvation this fixes.
+const DEFAULT_MAX_PAGES = 10;
 
 function parseThresholdHours(argv) {
   const idx = argv.indexOf('--threshold-hours');
@@ -27,18 +31,30 @@ function dedupKeyFor(ledgerId, nowMs) {
   return `solomon_ledger_pending:${ledgerId}:${new Date(nowMs).toISOString().slice(0, 10)}`;
 }
 
-/** Fetches ledger rows still pending past the threshold (primary-state check — no caching). */
-async function planStalePending(supabase, { thresholdHours = DEFAULT_THRESHOLD_HOURS, nowMs = Date.now() } = {}) {
+/**
+ * Fetches ALL ledger rows still pending past the threshold (primary-state check — no
+ * caching). QF-20260710-743: the original single .limit(50) query starved rows 51+ forever
+ * whenever the oldest 50 stale-pending rows never resolved -- pages via .range() past that
+ * window (bounded by maxPages) so the whole backlog surfaces over successive/single runs.
+ */
+async function planStalePending(supabase, { thresholdHours = DEFAULT_THRESHOLD_HOURS, nowMs = Date.now(), pageSize = DEFAULT_PAGE_SIZE, maxPages = DEFAULT_MAX_PAGES } = {}) {
   const cutoff = new Date(nowMs - thresholdHours * 60 * 60 * 1000).toISOString();
-  const { data, error } = await supabase
-    .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
-    .select('id, correlation_id, sd_key, proposal_summary, created_at')
-    .eq('decision', 'pending')
-    .lte('created_at', cutoff)
-    .order('created_at', { ascending: true })
-    .limit(50);
-  if (error) throw new Error(`planStalePending query failed: ${error.message}`);
-  return data || [];
+  const all = [];
+  for (let page = 0; page < maxPages; page++) {
+    const from = page * pageSize;
+    const { data, error } = await supabase
+      .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
+      .select('id, correlation_id, sd_key, proposal_summary, created_at')
+      .eq('decision', 'pending')
+      .lte('created_at', cutoff)
+      .order('created_at', { ascending: true })
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(`planStalePending query failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < pageSize) break; // last page
+  }
+  return all;
 }
 
 /** Rate-limited, deduped daily resurface: at most one inbox row per stale ledger item per day. */

--- a/tests/unit/solomon-ledger-pending-resurface.test.js
+++ b/tests/unit/solomon-ledger-pending-resurface.test.js
@@ -26,10 +26,12 @@ function createMockSupabase({ ledgerRows = [], inboxRows = [] } = {}) {
             eq: (col, val) => ({
               lte: (col2, val2) => ({
                 order: () => ({
-                  limit: async () => ({
-                    data: ledger.filter((r) => r[col] === val && r[col2] <= val2),
-                    error: null,
-                  }),
+                  range: async (from, to) => {
+                    const filtered = ledger
+                      .filter((r) => r[col] === val && r[col2] <= val2)
+                      .sort((a, b) => (a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0));
+                    return { data: filtered.slice(from, to + 1), error: null };
+                  },
                 }),
               }),
             }),
@@ -78,6 +80,35 @@ describe('planStalePending()', () => {
     });
     const rows = await planStalePending(supabase, { thresholdHours: 24, nowMs });
     expect(rows.map((r) => r.id)).toEqual(['l1']);
+  });
+
+  // QF-20260710-743: the original .limit(50) query starved every row past the oldest 50
+  // whenever the head of the queue never resolved. Pins the fix with a small pageSize so
+  // the fixture doesn't need 51+ rows to prove pagination past a single page.
+  it('pages past a single-page window so rows beyond it are not starved (QF-20260710-743)', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const ledgerRows = Array.from({ length: 5 }, (_, i) => ({
+      id: `l${i + 1}`,
+      decision: 'pending',
+      created_at: new Date(nowMs - (5 - i) * 48 * 60 * 60 * 1000).toISOString(), // all stale, oldest first
+    }));
+    const supabase = createMockSupabase({ ledgerRows });
+
+    const rows = await planStalePending(supabase, { thresholdHours: 24, nowMs, pageSize: 2, maxPages: 5 });
+    expect(rows.map((r) => r.id)).toEqual(['l1', 'l2', 'l3', 'l4', 'l5']);
+  });
+
+  it('respects maxPages as a bounded safety cap rather than looping forever', async () => {
+    const nowMs = new Date('2026-07-05T12:00:00Z').getTime();
+    const ledgerRows = Array.from({ length: 10 }, (_, i) => ({
+      id: `l${i + 1}`,
+      decision: 'pending',
+      created_at: new Date(nowMs - (10 - i) * 48 * 60 * 60 * 1000).toISOString(),
+    }));
+    const supabase = createMockSupabase({ ledgerRows });
+
+    const rows = await planStalePending(supabase, { thresholdHours: 24, nowMs, pageSize: 2, maxPages: 3 });
+    expect(rows).toHaveLength(6); // 3 pages * 2 per page, not the full 10
   });
 });
 


### PR DESCRIPTION
## Summary
- `scripts/solomon-ledger-pending-resurface.cjs`'s `planStalePending()` fetched `.order(created_at asc).limit(50)` with no cursor/offset. If more than 50 `solomon_advice_outcome_ledger` rows were stale-pending and the head-of-queue oldest 50 never resolved, rows 51+ were never fetched — perpetual tail starvation.
- Fix: page via `.range()` up to a bounded 10-page (500-row) safety cap per invocation, so the whole backlog surfaces instead of just the oldest 50.
- The one-resurface-per-row-per-day dedup (`resurfaceStalePending()`) is untouched — a row already resurfaced today is still skipped on a re-run.
- Ratified closure-map intake item (resurface-pump limit-50 cursor QF).

## Test plan
- `npx vitest run tests/unit/solomon-ledger-pending-resurface.test.js` → 7/7 pass
- New tests pin: pagination surfaces all stale rows past a single page (5 rows, pageSize=2); the maxPages safety cap bounds a run rather than looping unbounded (10 rows, maxPages=3 → 6 returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)