### PR TITLE
fix(QF-20260710-750): dispatch guard checks heartbeat freshness, not just row existence

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -29,6 +29,15 @@ const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cj
 // QF-20260709-053: no circular-require risk (adam-identity.cjs has zero requires of its own).
 const { getActiveAdamId } = require('./adam-identity.cjs');
 
+// QF-20260710-750 (closure-map line 39): a claude_sessions ROW existing is not the same as the
+// session being LIVE -- a row persists long after its process ends. 10min mirrors the SAME
+// heartbeat-freshness cutoff stale-session-sweep.cjs already treats as canonical "alive"
+// elsewhere (its liveCutoff), not a new invention. Deliberately NOT is_alive (documented stale-
+// false-read trap) and NOT a wider window like 30min (coordinator-self-review.mjs's solicitation
+// query used exactly that laxer window, which is why review requests kept reaching sessions whose
+// median lifespan (~9min) had already elapsed by dispatch time).
+const LIVE_HEARTBEAT_CUTOFF_MS = 10 * 60_000;
+
 // Documented non-UUID targets that are intentionally allowed. broadcast =
 // coordinator→all; broadcast-coordinator = worker→coordinator; broadcast-solomon =
 // worker/Adam→Solomon consult lane (SD-LEO-INFRA-SOLOMON-CONSULT-001C — inert until
@@ -76,7 +85,7 @@ async function assertValidTarget(supabase, target, logger = console) {
   // Well-formed UUID — confirm it names a live session (FR-3, the dominant new check).
   const { data, error } = await supabase
     .from('claude_sessions')
-    .select('session_id')
+    .select('session_id, heartbeat_at')
     .eq('session_id', target)
     .limit(1)
     .maybeSingle();
@@ -91,6 +100,21 @@ async function assertValidTarget(supabase, target, logger = console) {
     logger && logger.error && logger.error(msg);
     const e = new Error(msg);
     e.code = 'DISPATCH_TARGET_UNKNOWN';
+    throw e;
+  }
+  // QF-20260710-750: the row EXISTS but may be a dead addressee (session ended, row never
+  // cleaned up) — check heartbeat freshness, not just row presence. A missing heartbeat_at
+  // (real rows always have one; only an incomplete lookup would lack it) fails OPEN — matching
+  // this module's established fail-open-on-unconfirmed / fail-closed-only-on-CONFIRMED-violation
+  // posture (see assertWorkerTierAllowed above) — rather than treating absence as certain death.
+  const hbAgeMs = data.heartbeat_at ? (Date.now() - Date.parse(data.heartbeat_at)) : null;
+  if (hbAgeMs !== null && hbAgeMs > LIVE_HEARTBEAT_CUTOFF_MS) {
+    const msg = `[dispatch] REFUSED insert: target_session ${target} exists but heartbeat is stale `
+      + `(${Math.round(hbAgeMs / 60000)}min old, cutoff ${Math.round(LIVE_HEARTBEAT_CUTOFF_MS / 60000)}min) `
+      + `— would dead-letter to a dead addressee. Re-target to a live worker UUID or a sentinel.`;
+    logger && logger.error && logger.error(msg);
+    const e = new Error(msg);
+    e.code = 'DISPATCH_TARGET_STALE';
     throw e;
   }
   return { ok: true, kind: 'live_session' };

--- a/lib/coordinator/dispatch.test.js
+++ b/lib/coordinator/dispatch.test.js
@@ -117,6 +117,29 @@ describe('insertCoordinationRow — accept/reject matrix (FR-2/3/4)', () => {
     expect(inserts).toHaveLength(1);
   });
 
+  // QF-20260710-750: a claude_sessions ROW existing is not the same as being LIVE.
+  it('REFUSES a live-row UUID whose heartbeat is stale (>10min) — no insert', async () => {
+    const staleHeartbeat = new Date(Date.now() - 15 * 60_000).toISOString();
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID, heartbeat_at: staleHeartbeat } });
+    await expect(
+      insertCoordinationRow(sb, { target_session: LIVE_UUID, message_type: 'COACHING' }, { logger: silent })
+    ).rejects.toMatchObject({ code: 'DISPATCH_TARGET_STALE' });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('ACCEPTS a live-row UUID with a fresh heartbeat (<10min)', async () => {
+    const freshHeartbeat = new Date(Date.now() - 2 * 60_000).toISOString();
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID, heartbeat_at: freshHeartbeat } });
+    await insertCoordinationRow(sb, { target_session: LIVE_UUID, message_type: 'COACHING' }, { logger: silent });
+    expect(inserts).toHaveLength(1);
+  });
+
+  it('ACCEPTS a live-row UUID with no heartbeat_at in the lookup (fail-open on unconfirmed, not certain-dead)', async () => {
+    const { sb, inserts } = makeFakeSupabase({ sessionRow: { session_id: LIVE_UUID } });
+    await insertCoordinationRow(sb, { target_session: LIVE_UUID, message_type: 'COACHING' }, { logger: silent });
+    expect(inserts).toHaveLength(1);
+  });
+
   it('fails CLOSED when the live-session lookup errors — no insert', async () => {
     const { sb, inserts } = makeFakeSupabase({ lookupError: { message: 'db down' } });
     await expect(


### PR DESCRIPTION
## Summary
- Closure-map line 39 (REAL-OPEN): "Review requests keep targeting dead addressees." `coordinator-self-review.mjs` fires periodic COACHING review-request messages to workers selected via a `heartbeat_at >= now-30min` query — but a worker session's median lifespan (~9min) is far shorter than that 30-minute window, so many candidates are already dead by dispatch time. A `claude_sessions` row existing is not the same as the session being live; the row persists long after its process ends.
- Fix lives in the shared choke point every sender already routes through: `assertValidTarget()` in `lib/coordinator/dispatch.cjs`'s `insertCoordinationRow`. It now also checks `heartbeat_at` freshness against the same 10-minute cutoff `stale-session-sweep.cjs` already treats as canonical "alive" elsewhere — refusing (`DISPATCH_TARGET_STALE`) a stale target instead of dead-lettering to it. Deliberately not `is_alive` (documented stale-false-read trap).
- A missing `heartbeat_at` fails OPEN (matches this module's own established fail-open-on-unconfirmed / fail-closed-only-on-CONFIRMED-violation posture, e.g. `assertWorkerTierAllowed`) rather than being treated as certain-dead — this meant no other dispatch test fixture needed updating.
- `coordinator-self-review.mjs`'s existing per-target `try/catch` around `insertCoordinationRow` (already logs `solicit skip <target>: <error>` and continues) picks up the new refusal for free — "fail loud to the sender" per the closure map's acceptable fix shape, no caller-side change needed.

## Test plan
- `npx vitest run lib/coordinator/dispatch.test.js` → 14/14 pass (3 new tests: stale-heartbeat refused, fresh-heartbeat accepted, missing-heartbeat fail-open)
- Full dispatch-adjacent sweep: `lib/coordinator/dispatch.test.js` + 10 other files that independently mock `claude_sessions` → 80/80 pass unchanged, confirming the fail-open design didn't require touching any of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)