### PR TITLE
fix(QF-20260710-236): agentic-fit complete() call-signature mismatch mangled every request to 'Hello'

### DIFF
--- a/lib/eva/stage-zero/synthesis/agentic-fit.js
+++ b/lib/eva/stage-zero/synthesis/agentic-fit.js
@@ -256,7 +256,7 @@ And flag any structural disadvantages (array of: capital_heavy, human_trust_depe
 Return JSON ONLY: {"agent_leverage":N,"compounding":N,"kill_speed":N,"attention_economy":N,"machine_improvement":N,"disadvantage_flags":[...],"confidence":0-1,"summary":"..."}`;
 
   try {
-    const response = await client.complete({ prompt, temperature: 0.2, maxTokens: 600 });
+    const response = await client.complete('', prompt, { temperature: 0.2, maxTokens: 600 });
     const text = typeof response === 'string' ? response : (response?.text ?? response?.content ?? '');
     const match = text.match(/\{[\s\S]*\}/);
     const analysis = match ? JSON.parse(match[0]) : {};

--- a/tests/eva/stage-zero/synthesis/agentic-fit.test.js
+++ b/tests/eva/stage-zero/synthesis/agentic-fit.test.js
@@ -9,7 +9,7 @@
  * FR-5 transparency: scoreAgenticFit records sub-scores + flags + multiplier
  * FR-6 config-SSOT: weights/params overridable
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   AF_WEIGHTS,
   AGENT_LEVERAGE_FLOOR,
@@ -18,6 +18,7 @@ import {
   classifyDisadvantages,
   scoreAgenticFit,
   buildAgenticFitAdvisory,
+  analyzeAgenticFit,
 } from '../../../../lib/eva/stage-zero/synthesis/agentic-fit.js';
 import { calculateWeightedScore } from '../../../../lib/eva/stage-zero/profile-service.js';
 import { evaluateKillGate } from '../../../../lib/eva/stage-templates/stage-03.js';
@@ -163,5 +164,51 @@ describe('FR-5 transparency + FR-6 config', () => {
     );
     expect(r.fit_composite).toBe(50);
     expect(r.machine_improvement_bonus).toBe(0); // multiplier disabled via config
+  });
+});
+
+describe('QF-20260710-236: analyzeAgenticFit calls client.complete with the correct signature', () => {
+  const mockPathOutput = {
+    suggested_name: 'AutoOps Scheduler',
+    suggested_problem: 'Ops teams manually triage recurring infra alerts',
+    suggested_solution: 'Agent fleet triages + resolves recurring alert classes',
+    target_market: 'Mid-market SaaS ops teams',
+  };
+
+  const mockLLMAnalysis = {
+    agent_leverage: 85,
+    compounding: 70,
+    kill_speed: 60,
+    attention_economy: 75,
+    machine_improvement: 40,
+    disadvantage_flags: [],
+    confidence: 0.8,
+    summary: 'Strong agentic fit.',
+  };
+
+  it('invokes complete(systemPrompt, userPrompt, options) — NOT complete(singleObject)', async () => {
+    const complete = vi.fn().mockResolvedValue({ content: JSON.stringify(mockLLMAnalysis) });
+    await analyzeAgenticFit(mockPathOutput, { llmClient: { complete }, logger: { log: vi.fn(), warn: vi.fn() } });
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    const args = complete.mock.calls[0];
+    // Regression guard: the historical bug passed a single object as arg 1, leaving
+    // userPrompt undefined so the adapter fell back to a literal 'Hello' turn.
+    expect(args).toHaveLength(3);
+    expect(typeof args[0]).toBe('string'); // systemPrompt
+    expect(typeof args[1]).toBe('string'); // userPrompt — must be a real prompt string, not undefined
+    expect(args[1]).toContain('AutoOps Scheduler');
+    expect(args[1].length).toBeGreaterThan(20);
+    expect(typeof args[2]).toBe('object'); // options (temperature/maxTokens)
+  });
+
+  it('produces a real scored result from the mocked LLM response (happy path)', async () => {
+    const complete = vi.fn().mockResolvedValue({ content: JSON.stringify(mockLLMAnalysis) });
+    const result = await analyzeAgenticFit(mockPathOutput, { llmClient: { complete }, logger: { log: vi.fn(), warn: vi.fn() } });
+
+    expect(result.component).toBe('agentic_fit');
+    expect(result.dimension_scores).toEqual({ agent_leverage: 85, compounding: 70, kill_speed: 60, attention_economy: 75 });
+    expect(result.agentic_fit_score).toBeGreaterThan(0);
+    expect(result.confidence).toBeCloseTo(0.8);
   });
 });


### PR DESCRIPTION
## Summary
- `analyzeAgenticFit()` in `lib/eva/stage-zero/synthesis/agentic-fit.js` called `client.complete({ prompt, temperature, maxTokens })` — a single object — instead of the real `(systemPrompt, userPrompt, options)` signature.
- `userPrompt` landed `undefined`, so `GoogleAdapter`'s fallback (`lib/sub-agents/vetting/provider-adapters.js:568`) silently substituted the literal string `'Hello'` for every production request. This explains the component's chronic zero-fit fail-soft firing (Solomon 41a2e6da H3, Delta ledger).
- Fixed the call to match the `(systemPrompt, userPrompt, options)` contract already used correctly by the sibling `analyzeAttentionCapital()`.
- Added a signature-shape regression test — mocks `client.complete`, asserts the 3-arg call shape and that `userPrompt` is a real, non-empty string containing the venture data. Verified it fails against the pre-fix code and passes against the fix.

## Test plan
- [x] `npx vitest run tests/eva/stage-zero/synthesis/agentic-fit.test.js` — 20/20 passing
- [x] Confirmed new regression test fails when the buggy single-object call is restored, passes with the fix
- [x] LOC threshold gate passed (51 lines, below cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)