### PR TITLE
fix(SD-LEO-INFRA-CHAIRMAN-GAUGE-FABRICATIONS-FIX4-001): C6 -- exec-summary email no longer fabricates all-clear on decision-read failure

### DIFF
--- a/lib/chairman/actions-status-label.mjs
+++ b/lib/chairman/actions-status-label.mjs
@@ -1,0 +1,36 @@
+/**
+ * Gauge-trust map C6 (SD-LEO-INFRA-CHAIRMAN-GAUGE-FABRICATIONS-FIX4-001).
+ *
+ * A single source of truth for the "all clear" claim in scripts/adam-exec-summary.mjs's
+ * subject/plaintext/HTML renders. nActions===0 is genuinely ambiguous -- it means "the
+ * chairman_pending_decisions read returned zero rows" OR "the read failed and rows fell back
+ * to []" -- and the two must never render identically. Rendering "all clear" on a read failure
+ * is exactly the FABRICATED-on-failure class this audit exists to close.
+ */
+
+/**
+ * @param {{nActions: number, decisionsReadFailed: boolean}} params
+ * @returns {{subject: string, plaintext: string, html: string}}
+ */
+export function resolveActionsStatusLabel({ nActions, decisionsReadFailed }) {
+  if (nActions) {
+    const word = nActions === 1 ? 'action' : 'actions';
+    return {
+      subject: `${nActions} ${word} for you`,
+      plaintext: `${nActions} ${word} for you`,
+      html: `${nActions} ${word} for you`,
+    };
+  }
+  if (decisionsReadFailed) {
+    return {
+      subject: 'decisions status unknown',
+      plaintext: 'Decisions status unknown (read failed this run — will retry).',
+      html: 'Decisions status unknown (read failed this run — will retry).',
+    };
+  }
+  return {
+    subject: 'all clear',
+    plaintext: 'No decisions need you right now.',
+    html: 'No decisions need you right now.',
+  };
+}

--- a/lib/chairman/actions-status-label.mjs
+++ b/lib/chairman/actions-status-label.mjs
@@ -2,10 +2,10 @@
  * Gauge-trust map C6 (SD-LEO-INFRA-CHAIRMAN-GAUGE-FABRICATIONS-FIX4-001).
  *
  * A single source of truth for the "all clear" claim in scripts/adam-exec-summary.mjs's
- * subject/plaintext/HTML renders. nActions===0 is genuinely ambiguous -- it means "the
- * chairman_pending_decisions read returned zero rows" OR "the read failed and rows fell back
- * to []" -- and the two must never render identically. Rendering "all clear" on a read failure
- * is exactly the FABRICATED-on-failure class this audit exists to close.
+ * subject/plaintext/HTML renders. nActions===0 covers two distinct cases the caller must not
+ * conflate: "the chairman_pending_decisions read returned zero rows" versus "the read failed
+ * and rows fell back to []" -- the two must never render identically. Rendering "all clear" on
+ * a read failure is exactly the FABRICATED-on-failure class this audit exists to close.
  */
 
 /**

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -20,6 +20,7 @@ import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { liveFleetWorkers, isFleetWorker } from '../lib/fleet/genuine-worker.mjs';
 import { renderDecisionLines, prepareDecisions, DEAD_VENTURE_STATUSES } from '../lib/chairman/decision-layman.mjs';
+import { resolveActionsStatusLabel } from '../lib/chairman/actions-status-label.mjs';
 // SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
 // static .adam-vision-build.json number.
 import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-registry.js';
@@ -55,11 +56,22 @@ const DRY = !!process.env.ADAM_EMAIL_DRYRUN || process.argv.includes('--dry-run'
 const FORCE = process.argv.includes('--force');
 
 // ── ACTIONS FOR YOU: pending chairman decisions, fetched FIRST so the quiescence gate can see them ──
+// Gauge-trust map C6: a read failure here must never render as "0 pending" / "all clear" -- the
+// original code discarded `error` entirely, so a query failure was indistinguishable from a
+// genuinely empty queue (the exact FABRICATED-on-failure edge the audit flagged). Track the
+// failure so downstream renders can say "status unknown" instead of a false all-clear, and so
+// the quiescence gate below never fail-skips a send when the count itself is unknown.
 let rows = [];
+let decisionsReadFailed = false;
 try {
-  const { data } = await db.from('chairman_pending_decisions').select('*').limit(200);
+  const { data, error } = await db.from('chairman_pending_decisions').select('*').limit(200);
+  if (error) throw error;
   rows = data || [];
-} catch { rows = []; }
+} catch (e) {
+  rows = [];
+  decisionsReadFailed = true;
+  console.warn('[adam-email] chairman_pending_decisions read failed: ' + (e?.message || e));
+}
 // FR-4 (SD-LEO-INFRA-FIX-CHAIRMAN-HOURLY-001): drop stale chairman_approvals for DEAD ventures
 // (the view never joins venture status) and collapse the auto-generated "Corrective:" gap findings
 // into one advisory line — so the chairman's action count is real, not inflated by resolved/noise
@@ -82,7 +94,9 @@ const { count: nActions, lines } = renderDecisionLines(preparedRows, new Date(t)
 // Quiescence gate (QF-20260612-437): skip the hourly send when the fleet is fully OFF — UNLESS the
 // chairman has pending actions, which must surface regardless of fleet state (they are often the very
 // reason the fleet is idle). Fails open to ACTIVE so a query error never drops a real email.
-if (!DRY && !FORCE && nActions === 0) {
+// Gauge-trust map C6: also never quiesce-skip when the decisions read itself failed -- nActions===0
+// in that case means "unknown", not "genuinely zero", and skipping could silently drop a real send.
+if (!DRY && !FORCE && nActions === 0 && !decisionsReadFailed) {
   try {
     const { createRequire } = await import('module');
     const q = createRequire(import.meta.url)('../lib/coordinator/fleet-quiescence.cjs');
@@ -281,7 +295,10 @@ const visSubj = subjectNeedle
   : (subjPct != null ? `EHG rung ${subjPct}%` : 'EHG vision n/a');
 // '(hr avg)' tag only for a CONFIDENT (non-sparse) hourly average — keep the subject honest too.
 const workerSubj = pulseSource === 'unavailable' ? 'workers n/a' : `${avgActive} active${(pulseSource === 'hourly avg' && !wc.sparse) ? ' (hr avg)' : ''}`;
-const actionsSubj = nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'all clear';
+// Gauge-trust map C6: "all clear" is a claim about a successfully-read empty queue -- a read
+// failure must say so, never fabricate the same all-clear a genuinely empty queue would show.
+const actionsStatus = resolveActionsStatusLabel({ nActions, decisionsReadFailed });
+const actionsSubj = actionsStatus.subject;
 // QF-20260627-338: when an ADAM ESCALATION is present (an Adam-flagged blocking decision), the
 // SUBJECT must STAND OUT from the routine hourly digest so the chairman instantly distinguishes it.
 // FR-1 standout subject leading with a distinct token; FR-2 routine subject unchanged otherwise.
@@ -339,7 +356,7 @@ const text = [
   ...(decisionsLine ? [decisionsLine] : []),
   '',
   '──────────────────────────────────────────────',
-  nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'No decisions need you right now.',
+  actionsStatus.plaintext,
   ...(nActions ? ['   Press and hold the text below, Select All, Copy — then paste it into Claude Code.', '──────────────────────────────────────────────', '', copyBlock] : ['──────────────────────────────────────────────']),
   '',
   `as of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`,
@@ -353,7 +370,7 @@ const actionsHtml = nActions
   ? `<p style="font-size:14px;margin:0 0 2px"><b>${nActions} ${nActions === 1 ? 'action' : 'actions'} for you</b></p>` +
     `<p style="font-size:12px;color:#888;margin:0 0 6px">On your phone, press and hold the box below, tap "Select All", then "Copy" — then paste it into Claude Code.</p>` +
     `<pre style="font-size:13px;background:#f6f8fa;border:1px solid #e1e4e8;border-radius:4px;padding:12px;white-space:pre-wrap;margin:0;font-family:ui-monospace,Menlo,Consolas,monospace;-webkit-user-select:all;user-select:all">${esc(copyBlock)}</pre>`
-  : `<p style="font-size:14px;margin:0 0 6px"><b>No decisions need you right now.</b></p>`;
+  : `<p style="font-size:14px;margin:0 0 6px"><b>${esc(actionsStatus.html)}</b></p>`;
 const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
   `<p style="font-size:15px;margin:0 0 12px"><b>Workers:</b> ${esc(workerText)}</p>` +
   // SD-LEO-INFRA-EXEC-EMAIL-STRATEGY-ALIGNED-001: HTML↔plaintext parity for the new skeleton. Lead with

--- a/tests/unit/chairman-actions-status-label.test.js
+++ b/tests/unit/chairman-actions-status-label.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { resolveActionsStatusLabel } from '../../lib/chairman/actions-status-label.mjs';
+
+// Gauge-trust map C6 (SD-LEO-INFRA-CHAIRMAN-GAUGE-FABRICATIONS-FIX4-001): a chairman_pending_decisions
+// read failure must never render as the same "all clear" a genuinely empty queue renders.
+describe('resolveActionsStatusLabel', () => {
+  it('renders the action count when there are pending decisions, regardless of read-failed flag', () => {
+    const ok = resolveActionsStatusLabel({ nActions: 3, decisionsReadFailed: false });
+    expect(ok.subject).toBe('3 actions for you');
+    expect(ok.plaintext).toBe('3 actions for you');
+    expect(ok.html).toBe('3 actions for you');
+
+    const singular = resolveActionsStatusLabel({ nActions: 1, decisionsReadFailed: false });
+    expect(singular.subject).toBe('1 action for you');
+  });
+
+  it('renders honest "all clear" when the read genuinely succeeded with zero rows', () => {
+    const clear = resolveActionsStatusLabel({ nActions: 0, decisionsReadFailed: false });
+    expect(clear.subject).toBe('all clear');
+    expect(clear.plaintext).toBe('No decisions need you right now.');
+    expect(clear.html).toBe('No decisions need you right now.');
+  });
+
+  it('never renders "all clear" when the read failed -- the exact C6 fabrication this fixes', () => {
+    const failed = resolveActionsStatusLabel({ nActions: 0, decisionsReadFailed: true });
+    expect(failed.subject).not.toMatch(/all clear/i);
+    expect(failed.plaintext).not.toMatch(/no decisions need you/i);
+    expect(failed.html).not.toMatch(/no decisions need you/i);
+    expect(failed.subject).toBe('decisions status unknown');
+    expect(failed.plaintext).toMatch(/status unknown/i);
+    expect(failed.html).toMatch(/status unknown/i);
+  });
+});


### PR DESCRIPTION
## Summary
EHG_Engineer-side companion to the ehg-repo B3/B4/B5 fix ([PR #752](https://github.com/rickfelix/ehg/pull/752)) for the chairman-ratified [gauge-trust map](https://github.com/rickfelix/EHG_Engineer/pull/5847). Closes the clearest "email-report edge" in the map: **C6**.

`scripts/adam-exec-summary.mjs`'s `chairman_pending_decisions` read discarded `error` entirely (destructured only `data`), so a genuine query failure fell through to `rows=[]`, indistinguishable from a real empty queue — the subject/plaintext/HTML all rendered "all clear" either way, and the quiescence gate could silently skip the whole send on a read failure it never knew occurred.

Extracts the three duplicated render-site ternaries into one testable pure helper (`lib/chairman/actions-status-label.mjs`) that renders "decisions status unknown" instead of "all clear" when the read failed, and gates the quiescence check on `!decisionsReadFailed` so an unknown count can never be treated as "genuinely quiescent, safe to skip."

Currently **latent** (`ADAM_EMAIL_LIVE=false`, dry-run only per the audit) — fixes the all-clear-on-error path before this email is ever re-enabled, per the audit's own stated fix direction: *"If ever re-enabled: fix the all-clear-on-error path first."*

## Scope note (out of scope, with justification)
Per the SD's own success criteria ("no finding silently skipped"), the other Tier-C email/alert findings were reviewed and excluded:
- **A6** (decision escalation emails) is graded **REAL** with a silent-*send*-skip edge (not a fabricated *value*) — different bug class from this fix's target.
- **C2/C3** are console UI tiles, not email.
- **C5** (heartbeat) / **C8** (channel liveness) are graded **REAL** — no numeric claims to fabricate.
- **C7** (fleet-down alert) is a dead-man's-switch design gap (alert never fires) — not a rendered fabricated value, a different failure mode from "render real data or NO-DATA, never fabricate."

## Test plan
- [x] `tests/unit/chairman-actions-status-label.test.js` (new, 3 tests) — action-count render, honest "all clear" on genuine empty read, "status unknown" (never "all clear") on read failure
- [x] Mutation-verified: reintroduced the old bug in the helper, confirmed the "never all clear on failure" test fails, restored and re-confirmed green
- [x] `node --check` on both changed/new files — clean
- [x] Regression sweep: `chairman-decision-layman.test.js` + `chairman-decision-layman-stale-filter.test.js` (24 tests) — unaffected

## Related
- ehg-repo companion PR (findings B3/B4/B5): https://github.com/rickfelix/ehg/pull/752
- Gauge-trust map: #5847

🤖 Generated with [Claude Code](https://claude.com/claude-code)