### PR TITLE
fix(SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001): re-key ack-null false metrics on reply correlation

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001.json
@@ -1,0 +1,116 @@
+{
+  "executive_summary": "Closure map class C6 (chairman-ratified PR #5840): S5 found 422 'unacked' worker-signal rows with 0 confirmed breaches, and S2's 46 'breaches' were largely the same false-positive class plus dead addressees (already fixed by QF-20260710-750). Root cause: several consumers treat `acknowledged_at IS NULL` on a row as proof nobody replied, but a reply to a coordination message routinely arrives as a FRESH row carrying `payload.correlation_id`/`payload.reply_to`, never as an update to the original row's `acknowledged_at`. The correct 'was this answered' check already exists and is proven in three places in this codebase (`lib/adam/task-rehydrate.js`, `lib/adam/stall-alert.js::isCorrelationTerminal`, `lib/coordinator/relay-drop-gauge.cjs::satisfiesCorrelation`) but four consumers still use the bare ack-null predicate: `lib/adam/outbound-silence-watchdog.js` (chairman-escalating breach classifier), `lib/coordinator/detectors.cjs` (REPLY_STARVATION anomaly), `scripts/adam-quiet-tick.mjs` (hard-interrupt reprint), and 3 of 4 `scripts/fleet-dashboard.cjs` sections (unread-signal count, pending-acknowledgment count, Solomon pending-consult count). This SD adds one shared, tested correlation primitive and ports those four call sites onto it, leaves the two-stage read_at/acknowledged_at DRAIN semantics completely untouched (metric consumers only, not the inbox contract), and documents a full consumer census (9 sites found) with an explicit RE-KEY/RETAIN disposition for each — satisfying the SD's ALL-PATHS clause.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Shared, tested reply-correlation primitive",
+      "description": "New `lib/coordinator/reply-correlation.js` exporting `hasCorrelatedReply(row, allRows)`: returns true iff some other row in `allRows` has `payload.reply_to === row.id` OR `payload.correlation_id === (row.payload?.correlation_id || row.id)`. Generalizes the pattern already proven in `lib/adam/task-rehydrate.js`'s `repliedCorr` set and `lib/adam/stall-alert.js`'s `isCorrelationTerminal()`, but as a single reusable, independently-tested function rather than duplicated inline logic per consumer.",
+      "acceptance_criteria": [
+        "hasCorrelatedReply returns true when another row's payload.reply_to matches the row's id",
+        "hasCorrelatedReply returns true when another row's payload.correlation_id matches the row's own payload.correlation_id",
+        "hasCorrelatedReply returns false when no other row references this row by either key",
+        "hasCorrelatedReply returns false for a null/undefined row (no throw)"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "outbound-silence-watchdog.js — stop escalating a correlated-but-unacked row as a breach",
+      "description": "`isBreaching(row, nowMs)` currently declares a chairman-visible breach purely on `!row.acknowledged_at` past 60min post-read. Add a `hasCorrelatedReply` check (caller supplies the candidate row set already fetched for the sweep window) so a row with a matching correlated reply is never escalated, closing the exact live-incident class this SD targets (highest-impact consumer: writes a `feedback` row with `severity: 'high'` to the chairman on false breaches).",
+      "acceptance_criteria": [
+        "A row with acknowledged_at IS NULL but a correlated reply present does NOT trigger isBreaching",
+        "A row with acknowledged_at IS NULL and no correlated reply, past the 60min threshold, still triggers isBreaching (behavior preserved for genuine breaches)",
+        "Existing UNREAD_BREACH_MS / read_at-based branch is untouched"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "detectors.cjs — REPLY_STARVATION recognizes a correlated reply as 'answered'",
+      "description": "`detectReplyStarvation`'s `answered` check currently only looks at `acknowledged_at` or `payload.routed_to_feedback_id`. Extend it to also treat `hasCorrelatedReply(sig, allSignalsInWindow)` as answered, so the REPLY_STARVATION anomaly (persisted to `coordination_events`, surfaced by `stale-session-sweep.cjs`) stops false-flagging correlated-but-unacked rows.",
+      "acceptance_criteria": [
+        "A signal with a correlated reply is excluded from the starved list even if acknowledged_at is null and read_at is null",
+        "A genuinely-starved signal (no ack, no read, no correlated reply, past threshold) is still flagged"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "adam-quiet-tick.mjs — hard-interrupt reprint converges on correlated reply",
+      "description": "`surfaceInboxItems`'s directive-row hard-interrupt currently re-prints every tick 'until acknowledged_at converges them.' A reply arriving as a fresh correlated row never converges this loop today. Add a `hasCorrelatedReply` check so a directive row with a correlated reply stops re-printing even without an ack-stamp on the original row.",
+      "acceptance_criteria": [
+        "A directive row with a correlated reply is excluded from the hard-interrupt reprint set",
+        "A directive row with neither an ack nor a correlated reply still re-prints every tick (unchanged behavior)"
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "fleet-dashboard.cjs — 3 of 4 ack-null sections re-keyed on correlation",
+      "description": "`printInbox()` ('N unread signal(s)'), `printCoordination()` ('N pending acknowledgment'), and `printSolomonInbox()` ('N pending consult(s)') all count/filter on bare `acknowledged_at IS NULL`. Each is updated to exclude rows with a correlated reply from its headline count (same `hasCorrelatedReply` primitive, applied client-side against the already-fetched row set — no new queries). `printCoaching()`'s Acked/Read/Unread tally is explicitly OUT OF SCOPE (FR-6 disposition: per-message coaching ack is an intentional 1:1 semantic, not a reply-correlation scenario).",
+      "acceptance_criteria": [
+        "printInbox's 'unread signal(s)' count excludes rows with a correlated reply",
+        "printCoordination's 'pending acknowledgment' count excludes rows with a correlated reply",
+        "printSolomonInbox's 'pending consult(s)' count excludes rows with a correlated reply",
+        "printCoaching's Acked/Read/Unread tally is unchanged (documented exclusion, not a silent gap)"
+      ]
+    },
+    {
+      "id": "FR-6",
+      "title": "Consumer census with per-consumer disposition (PR body)",
+      "description": "The PR description enumerates all 9 consumer sites found by the census (outbound-silence-watchdog.js, detectors.cjs REPLY_STARVATION, fleet-dashboard.cjs x4 sections, adam-quiet-tick.mjs, canary-trigger.cjs, stale-session-sweep.cjs + dead-letter-planning.cjs drain-gating, coordinator-quiet-tick.mjs openSignalCount) with an explicit RE-KEY or RETAIN-AS-IS disposition and one-line rationale for each — satisfying the SD's ALL-PATHS clause. RETAIN dispositions: printCoaching (intentional per-message ack, not reply-correlation), canary-trigger.cjs (direct-action semantic, not a 'reply' scenario), sweep/drain gating in stale-session-sweep.cjs/dead-letter-planning.cjs (staleness gate for auto-cleanup, not a human-facing breach/SLA metric — different mechanism than the SD's stated scope), coordinator-quiet-tick.mjs openSignalCount (internal suppress/emit gate, not surfaced to a human as a breach count).",
+      "acceptance_criteria": [
+        "PR body contains a table with all 9 consumers, disposition, and one-line rationale",
+        "Every RE-KEY disposition maps to a concrete FR (2-5) in this PRD",
+        "Every RETAIN disposition has a rationale grounded in the SD's own scope language (SLA/breach/attention metric vs. a different mechanism)"
+      ]
+    }
+  ],
+  "implementation_approach": {
+    "strategy": "One new shared primitive (FR-1) plus four surgical call-site edits (FR-2 through FR-5) that each add a single hasCorrelatedReply guard without touching the two-stage read_at/acknowledged_at DRAIN contract anywhere. The consumer census (FR-6) is a documentation deliverable in the PR body, not a code change, covering the 5 RETAIN-AS-IS sites with rationale so the SD's ALL-PATHS clause is honestly satisfied without forcing an inapplicable fix onto mechanisms that aren't actually the false-metric class (staleness gates, direct-action canary requests, intentional per-message coaching acks).",
+    "steps": [
+      "Add lib/coordinator/reply-correlation.js with hasCorrelatedReply() + unit tests",
+      "Port outbound-silence-watchdog.js isBreaching() to consult the primitive",
+      "Port detectors.cjs detectReplyStarvation() to consult the primitive",
+      "Port adam-quiet-tick.mjs surfaceInboxItems() hard-interrupt logic to consult the primitive",
+      "Port fleet-dashboard.cjs printInbox/printCoordination/printSolomonInbox to exclude correlated-reply rows from headline counts",
+      "Write the consumer census table into the PR body covering all 9 found sites"
+    ],
+    "rollback": "Each of the 4 call-site edits is an additive guard (an extra false-return condition) — reverting the PR restores the pre-fix ack-null-only behavior with no data loss, since no schema or DRAIN semantics changed."
+  },
+  "system_architecture": {
+    "overview": "Application-layer metric-consumer fix only. No schema changes — payload.correlation_id/payload.reply_to already exist and are actively used by 3 other consumers this SD reuses the pattern from. The two-stage read_at/acknowledged_at inbox-processing contract (session_coordination table) is unchanged.",
+    "components": [
+      { "name": "lib/coordinator/reply-correlation.js (new)", "responsibility": "Single source of truth for 'was this row answered by a correlated reply row'" },
+      { "name": "lib/adam/outbound-silence-watchdog.js", "responsibility": "Chairman escalation — stops false-breaching correlated-but-unacked rows" },
+      { "name": "lib/coordinator/detectors.cjs", "responsibility": "REPLY_STARVATION anomaly — stops false-flagging correlated rows" },
+      { "name": "scripts/adam-quiet-tick.mjs", "responsibility": "Hard-interrupt reprint — converges on correlated reply, not just ack" },
+      { "name": "scripts/fleet-dashboard.cjs", "responsibility": "3 of 4 ack-null-derived headline counts re-keyed on correlation" }
+    ],
+    "data_flow": "Each consumer already fetches its row window from session_coordination/worker signals; hasCorrelatedReply is applied client-side against that same already-fetched set (no new queries, no new DB round-trips)."
+  },
+  "integration_operationalization": {
+    "consumers": [
+      "Chairman (outbound-silence-watchdog escalations)",
+      "Coordinator operators (fleet-dashboard.cjs board, REPLY_STARVATION anomaly)",
+      "Adam (adam-quiet-tick.mjs hard-interrupt surfacing)"
+    ],
+    "dependencies": [
+      "payload.correlation_id / payload.reply_to JSONB convention (already populated by scripts/worker-signal.cjs, scripts/adam-advisory.cjs, and others per the census)"
+    ],
+    "data_contracts": [
+      "hasCorrelatedReply(row, allRows): boolean — pure function, no I/O"
+    ],
+    "runtime_config": [
+      "None — no new env vars or flags"
+    ],
+    "observability_rollout": "Single PR in EHG_Engineer. No migration, no chairman-gate. Post-merge: the 4 re-keyed consumers stop producing the false-positive breach/pending/starvation signals the closure map's S2/S5 rows documented; the 5 RETAIN-AS-IS sites are explicitly documented as out of scope with rationale, closing the ALL-PATHS enumeration requirement without inventing an inapplicable fix."
+  },
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "hasCorrelatedReply core matching logic", "expected": "True for reply_to match, true for correlation_id match, false otherwise, no throw on null" },
+    { "id": "TS-2", "scenario": "outbound-silence-watchdog isBreaching with a correlated reply present", "expected": "Returns false (no false breach)" },
+    { "id": "TS-3", "scenario": "outbound-silence-watchdog isBreaching with no correlated reply, past threshold", "expected": "Returns true (genuine breach still caught)" },
+    { "id": "TS-4", "scenario": "detectReplyStarvation with a correlated-reply signal", "expected": "Excluded from starved list" },
+    { "id": "TS-5", "scenario": "fleet-dashboard headline counts with a mix of correlated and uncorrelated rows", "expected": "Counts exclude only the correlated-reply rows" }
+  ],
+  "risks": [
+    { "risk": "Over-broad RETAIN-AS-IS disposition could leave a real false-metric site unfixed", "mitigation": "Each RETAIN rationale is grounded in a semantic difference from the SD's own scope language (staleness/cleanup gate vs. human-facing SLA/breach metric; direct-action vs. reply-correlation scenario) rather than a blanket 'out of scope for time' — reviewable and reversible as a fast-follow if judged wrong" },
+    { "risk": "hasCorrelatedReply requires the caller to supply the right row window (allRows) — an undersized window could miss a genuine correlated reply that arrived just outside it", "mitigation": "Each call site reuses the window it already fetches for its existing logic — no new windowing decisions introduced by this SD" }
+  ]
+}

--- a/lib/adam/outbound-silence-watchdog.js
+++ b/lib/adam/outbound-silence-watchdog.js
@@ -25,6 +25,7 @@
  */
 
 import { emitFeedback } from '../governance/emit-feedback.js';
+import { hasCorrelatedReply } from '../coordinator/reply-correlation.cjs';
 
 export const REPLY_EXPECTED_KINDS = new Set(['coordinator_request', 'solomon_consult']);
 export const UNREAD_BREACH_MS = 30 * 60 * 1000;
@@ -45,11 +46,17 @@ export function isReplyExpected(row) {
     !!(row && row.payload && row.payload.expects_reply === true);
 }
 
-/** Pure: unread >30m, or read-but-unacknowledged >60m. Never true for the watchdog's own probe rows. */
-export function isBreaching(row, nowMs) {
+/**
+ * Pure: unread >30m, or read-but-unacknowledged >60m. Never true for the watchdog's
+ * own probe rows. `allRows` (optional, SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001):
+ * a row answered by a correlated reply (payload.reply_to/correlation_id on another
+ * row) never breaches, even with acknowledged_at still null — closure map class C6.
+ */
+export function isBreaching(row, nowMs, allRows) {
   if (!row || (row.payload && row.payload.kind === PROBE_KIND)) return false;
   if (!row.read_at) return (nowMs - toMs(row.created_at)) >= UNREAD_BREACH_MS;
   if (row.acknowledged_at) return false;
+  if (hasCorrelatedReply(row, allRows)) return false;
   return (nowMs - toMs(row.read_at)) >= UNACKED_BREACH_MS;
 }
 
@@ -57,7 +64,7 @@ export function isBreaching(row, nowMs) {
 export function classifyBreaches(outboundRows, liveSessionIds, nowMs) {
   const byTarget = new Map();
   for (const r of (outboundRows || [])) {
-    if (!r || !liveSessionIds.has(r.target_session) || !isReplyExpected(r) || !isBreaching(r, nowMs)) continue;
+    if (!r || !liveSessionIds.has(r.target_session) || !isReplyExpected(r) || !isBreaching(r, nowMs, outboundRows)) continue;
     const cur = byTarget.get(r.target_session);
     if (!cur || toMs(r.created_at) < toMs(cur.created_at)) byTarget.set(r.target_session, r);
   }

--- a/lib/adam/outbound-silence-watchdog.js
+++ b/lib/adam/outbound-silence-watchdog.js
@@ -54,17 +54,27 @@ export function isReplyExpected(row) {
  */
 export function isBreaching(row, nowMs, allRows) {
   if (!row || (row.payload && row.payload.kind === PROBE_KIND)) return false;
+  // Checked BEFORE either time-based branch: a reply can arrive as a fresh correlated row
+  // even when the original was never read_at-stamped — the reply IS the answer regardless
+  // of whether the original row's own delivery markers were ever touched.
+  if (hasCorrelatedReply(row, allRows)) return false;
   if (!row.read_at) return (nowMs - toMs(row.created_at)) >= UNREAD_BREACH_MS;
   if (row.acknowledged_at) return false;
-  if (hasCorrelatedReply(row, allRows)) return false;
   return (nowMs - toMs(row.read_at)) >= UNACKED_BREACH_MS;
 }
 
-/** Pure: oldest breaching reply-expected row per live target_session. */
-export function classifyBreaches(outboundRows, liveSessionIds, nowMs) {
+/**
+ * Pure: oldest breaching reply-expected row per live target_session. `correlationRows`
+ * (optional, SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001) is the row set checked for a
+ * correlated reply — defaults to `outboundRows` for backward compatibility, but a REAL
+ * reply is sent BY the target (sender_type != 'adam'), so callers with cross-actor reply
+ * data available should pass a broader set explicitly (see runOutboundSilenceWatchdog).
+ */
+export function classifyBreaches(outboundRows, liveSessionIds, nowMs, correlationRows) {
   const byTarget = new Map();
+  const correlationSet = correlationRows || outboundRows;
   for (const r of (outboundRows || [])) {
-    if (!r || !liveSessionIds.has(r.target_session) || !isReplyExpected(r) || !isBreaching(r, nowMs, outboundRows)) continue;
+    if (!r || !liveSessionIds.has(r.target_session) || !isReplyExpected(r) || !isBreaching(r, nowMs, correlationSet)) continue;
     const cur = byTarget.get(r.target_session);
     if (!cur || toMs(r.created_at) < toMs(cur.created_at)) byTarget.set(r.target_session, r);
   }
@@ -100,8 +110,26 @@ export async function runOutboundSilenceWatchdog(supabase, opts = {}) {
       .limit(200);
     const liveIds = new Set((sessions || []).map((s) => s.session_id));
 
+    // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6, adversarial review
+    // finding): a real reply is sent BY the target (sender_session = the row's own
+    // target_session, e.g. sender_type='coordinator'/'solomon'), never sender_type='adam'
+    // — so `outbound` alone (filtered to sender_type='adam') can never contain it. Fetch
+    // the counterparty-sent rows separately, keyed on the same target_session set.
+    const targetSessions = [...new Set((outbound || []).map((r) => r.target_session).filter(Boolean))];
+    let replyCandidates = [];
+    if (targetSessions.length > 0) {
+      const { data } = await supabase
+        .from('session_coordination')
+        .select('id, payload, sender_session, created_at')
+        .in('sender_session', targetSessions)
+        .gte('created_at', since)
+        .limit(400);
+      replyCandidates = data || [];
+    }
+    const correlationRows = [...(outbound || []), ...replyCandidates];
+
     result.laneHealth = laneHealthAggregate(outbound, liveIds, now);
-    const breaches = classifyBreaches(outbound, liveIds, now);
+    const breaches = classifyBreaches(outbound, liveIds, now, correlationRows);
 
     for (const [target, row] of breaches) {
       if (result.probed.length >= MAX_PROBES_PER_TICK) break; // C1: absolute per-tick cap

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -30,6 +30,8 @@
 
 'use strict';
 
+const { hasCorrelatedReply } = require('./reply-correlation.cjs');
+
 /** Default freshness window (ms) for "is this session a live coordinator". */
 const DEFAULT_COORDINATOR_FRESH_MS = 10 * 60 * 1000;
 /** Default REPLY_STARVATION threshold (ms) — unanswered worker signal age. */
@@ -120,9 +122,13 @@ function detectReplyStarvation(data) {
   const now = (data && data.now) ?? Date.now();
   const thresholdMs = (data && data.thresholdMs) ?? DEFAULT_REPLY_STARVATION_MS;
   const starved = [];
-  for (const sig of ((data && data.signals) || [])) {
+  const allSignals = (data && data.signals) || [];
+  for (const sig of allSignals) {
     if ((sig && sig.sender_type) !== 'worker') continue;
-    const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id);
+    // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply
+    // routinely arrives as a fresh correlated row, not an update to acknowledged_at.
+    const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id)
+      || hasCorrelatedReply(sig, allSignals);
     if (answered) continue;
     if (sig.read_at) continue; // read counts as a soft answer here (no separate reply table)
     const ageMs = now - toMs(sig.created_at);

--- a/lib/coordinator/reply-correlation.cjs
+++ b/lib/coordinator/reply-correlation.cjs
@@ -1,0 +1,24 @@
+/**
+ * Reply-correlation primitive — SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001.
+ *
+ * Closure map class C6: `acknowledged_at IS NULL` is not a reliable "unreplied"
+ * signal — a reply routinely arrives as a FRESH row carrying payload.reply_to /
+ * payload.correlation_id rather than an update to the original row's
+ * acknowledged_at. Generalizes the correlation check already proven in
+ * lib/adam/task-rehydrate.js's repliedCorr set and
+ * lib/adam/stall-alert.js's isCorrelationTerminal() into one reusable primitive.
+ *
+ * Pure function, no I/O — callers supply the row window they already fetched.
+ */
+
+function hasCorrelatedReply(row, allRows) {
+  if (!row || !Array.isArray(allRows)) return false;
+  const ownCorrelationId = row.payload?.correlation_id || row.id;
+  return allRows.some((other) => {
+    if (!other || other.id === row.id) return false;
+    const otherPayload = other.payload || {};
+    return otherPayload.reply_to === row.id || otherPayload.correlation_id === ownCorrelationId;
+  });
+}
+
+module.exports = { hasCorrelatedReply };

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -174,6 +174,7 @@ export async function surfaceInboxItems(sb) {
   try {
     const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
     const { DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
+    const { hasCorrelatedReply } = require('../lib/coordinator/reply-correlation.cjs');
     const adamId = await resolveAdamSessionId(sb);
     if (!adamId) return { items: [], directives: 0 };
 
@@ -188,17 +189,27 @@ export async function surfaceInboxItems(sb) {
       .limit(50);
     if (error) return { items: [], directives: 0, error: error.message };
 
+    // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a directive's
+    // reply is Adam's own outbound row correlated by payload.reply_to/correlation_id, not
+    // an update to THIS row's acknowledged_at — fetch the correlation window once.
+    const { data: correlationWindow } = await sb
+      .from('session_coordination')
+      .select('id, payload, sender_session, target_session')
+      .or(`sender_session.eq.${adamId},target_session.eq.${adamId}`)
+      .gte('created_at', cutoffIso)
+      .limit(400);
+
     const isDirectiveRow = (r) =>
       (r.payload && (DIRECTIVE_KINDS.includes(r.payload.kind) || r.payload.reply_needed || r.payload.reply_to)) || false;
 
     // Print-once dedup applies to the ITEM class only. DIRECTIVE-class rows are HARD
-    // interrupts: they re-print EVERY tick until acknowledged_at converges them —
-    // deduping a directive would let a single missed turn hide it forever (the exact
-    // failure class this SD closes; adversarial review of PR #5802).
+    // interrupts: they re-print EVERY tick until acknowledged_at converges them OR a
+    // correlated reply is found — deduping a directive would let a single missed turn
+    // hide it forever (the exact failure class this SD closes; adversarial review of PR #5802).
     const eligible = (rows || []).filter((r) => {
       const k = r.payload && r.payload.kind;
       if (k != null && ADAM_EXCLUDED_KINDS.includes(k)) return false;
-      if (isDirectiveRow(r)) return true;
+      if (isDirectiveRow(r)) return !hasCorrelatedReply(r, correlationWindow || []);
       return !(r.payload && r.payload.tick_surfaced_at);
     });
     const capHit = (rows || []).length === 50;

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1283,9 +1283,6 @@ async function printInbox() {
   // more than 20 even when the true unacknowledged backlog is larger — the label read "20
   // unread signal(s)" indefinitely regardless of triage progress. Query the true set (same
   // filters, no limit) so the display reflects real unread rows, not the window cap.
-  // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply to a worker
-  // signal routinely arrives as a fresh row targeting this SAME coordinatorId, so it is
-  // visible in this same query — exclude correlated-reply rows from the true-unread count.
   const { data: allUnreadRows, error: countError } = await supabase
     .from('session_coordination')
     .select('id, payload')
@@ -1294,7 +1291,18 @@ async function printInbox() {
     .is('acknowledged_at', null)
     .gte('created_at', signalSince);
 
-  const uncorrelatedUnread = (allUnreadRows || []).filter((r) => !hasCorrelatedReply(r, allUnreadRows));
+  // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply to a worker
+  // signal is sent BY the coordinator (sender_session=coordinatorId), targeting the
+  // ORIGINAL SENDER (never coordinatorId) and carrying no signal_type — it can never appear
+  // in the query above, so the correlation window must be fetched separately.
+  const { data: coordinatorReplies } = await supabase
+    .from('session_coordination')
+    .select('id, payload')
+    .eq('sender_session', coordinatorId)
+    .gte('created_at', signalSince)
+    .limit(400);
+  const correlationRows = [...(allUnreadRows || []), ...(coordinatorReplies || [])];
+  const uncorrelatedUnread = (allUnreadRows || []).filter((r) => !hasCorrelatedReply(r, correlationRows));
   const trueCount = countError || allUnreadRows == null ? signals.length : uncorrelatedUnread.length;
   console.log('  ' + trueCount + ' unread signal(s)' +
     (trueCount > signals.length ? ' (showing newest ' + signals.length + ')' : ''));
@@ -1536,6 +1544,7 @@ async function printSolomonInbox() {
       .from('session_coordination')
       .select('id, payload')
       .in('sender_session', targets)
+      .order('created_at', { ascending: false })
       .limit(200);
     rows = rows.filter((r) => !hasCorrelatedReply(r, [...rows, ...(solomonReplies || [])]));
   } catch { /* fail-open: correlation lookup unavailable → fall back to uncorrelated rows */ }

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -149,7 +149,9 @@ async function loadData() {
       .order('sd_key', { ascending: true }),
     supabase
       .from('session_coordination')
-      .select('id, target_session, target_sd, message_type, subject, read_at, acknowledged_at, created_at')
+      // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: + payload so printCoordination can
+      // exclude rows answered by a correlated reply from its pending-acknowledgment count.
+      .select('id, target_session, target_sd, message_type, subject, payload, read_at, acknowledged_at, created_at')
       .is('acknowledged_at', null)
       .order('created_at', { ascending: false })
       .limit(20),
@@ -691,7 +693,10 @@ function printCoordination(d) {
   }
 
   const unread = d.coordMessages.filter(m => !m.read_at).length;
-  const pending = d.coordMessages.filter(m => m.read_at && !m.acknowledged_at).length;
+  // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply to a
+  // coordination message routinely arrives as a fresh row (also ack-null, also in this
+  // same query) rather than an update to the original's acknowledged_at — exclude it.
+  const pending = d.coordMessages.filter(m => m.read_at && !m.acknowledged_at && !hasCorrelatedReply(m, d.coordMessages)).length;
   console.log('  ' + unread + ' unread, ' + pending + ' pending acknowledgment');
   console.log('');
 
@@ -1218,6 +1223,9 @@ const parseDeps = parseSdDependencies;
 // wire-check call-graph builder (lib/static-analysis/call-graph-builder.js)
 // can statically resolve the dependency on lib/coordinator/resolve.cjs.
 const { getActiveCoordinatorId: _getActiveCoordinatorIdForInbox } = require('../lib/coordinator/resolve.cjs');
+// SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): excludes rows
+// answered by a correlated reply from ack-null-derived headline counts.
+const { hasCorrelatedReply } = require('../lib/coordinator/reply-correlation.cjs');
 
 // ── Section: Worker-Signal Inbox (FR-3a) ──
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001
@@ -1273,17 +1281,21 @@ async function printInbox() {
 
   // QF-20260704-877: signals.length is capped by .limit(20) above, so it can never report
   // more than 20 even when the true unacknowledged backlog is larger — the label read "20
-  // unread signal(s)" indefinitely regardless of triage progress. Query the true count
-  // (same filters, no limit) so the display reflects real unread rows, not the window cap.
-  const { count: totalUnread, error: countError } = await supabase
+  // unread signal(s)" indefinitely regardless of triage progress. Query the true set (same
+  // filters, no limit) so the display reflects real unread rows, not the window cap.
+  // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply to a worker
+  // signal routinely arrives as a fresh row targeting this SAME coordinatorId, so it is
+  // visible in this same query — exclude correlated-reply rows from the true-unread count.
+  const { data: allUnreadRows, error: countError } = await supabase
     .from('session_coordination')
-    .select('id', { count: 'exact', head: true })
+    .select('id, payload')
     .eq('target_session', coordinatorId)
     .not('payload->>signal_type', 'is', null)
     .is('acknowledged_at', null)
     .gte('created_at', signalSince);
 
-  const trueCount = countError || totalUnread == null ? signals.length : totalUnread;
+  const uncorrelatedUnread = (allUnreadRows || []).filter((r) => !hasCorrelatedReply(r, allUnreadRows));
+  const trueCount = countError || allUnreadRows == null ? signals.length : uncorrelatedUnread.length;
   console.log('  ' + trueCount + ' unread signal(s)' +
     (trueCount > signals.length ? ' (showing newest ' + signals.length + ')' : ''));
   if (trueCount > 0) {
@@ -1508,6 +1520,25 @@ async function printSolomonInbox() {
     console.log('');
     return;
   }
+
+  if (rows.length === 0) {
+    console.log('  (no pending Solomon consults)');
+    console.log('');
+    return;
+  }
+
+  // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a consult's reply
+  // is Solomon's own outbound row (sender_session in targets) correlated by payload.reply_to
+  // /correlation_id, targeting the ORIGINAL REQUESTER — never visible in the targets-scoped
+  // `rows` query above, so a separate read of Solomon's own sends is required. PURE READ.
+  try {
+    const { data: solomonReplies } = await supabase
+      .from('session_coordination')
+      .select('id, payload')
+      .in('sender_session', targets)
+      .limit(200);
+    rows = rows.filter((r) => !hasCorrelatedReply(r, [...rows, ...(solomonReplies || [])]));
+  } catch { /* fail-open: correlation lookup unavailable → fall back to uncorrelated rows */ }
 
   if (rows.length === 0) {
     console.log('  (no pending Solomon consults)');

--- a/tests/unit/adam-inbox-surface-not-stamp.test.js
+++ b/tests/unit/adam-inbox-surface-not-stamp.test.js
@@ -196,7 +196,7 @@ describe('FR-1/FR-3: quiet tick', () => {
         select: () => c,
         update: (p) => { state.op = 'update'; state.payload = p; return c; },
         eq: (col, v) => { state.filters.push([col, v]); return c; },
-        is: () => c, gte: () => c, order: () => c, limit: () => c,
+        is: () => c, gte: () => c, order: () => c, limit: () => c, or: () => c,
         single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
         then: (res) => {
           if (state.op === 'update') { updates.push(state); return Promise.resolve({ data: [], error: null }).then(res); }
@@ -234,6 +234,59 @@ describe('FR-1/FR-3: quiet tick', () => {
     const sb = { from: () => { throw new Error('db down'); } };
     const out = await surfaceInboxItems(sb);
     expect(out.items).toEqual([]);
+  });
+
+  it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a directive with a correlated reply stops re-printing', async () => {
+    const directive = row({ payload: { kind: DIRECTIVE_KINDS[0] } });
+    const correlatedReply = { id: 'reply-1', payload: { reply_to: directive.id }, sender_session: ADAM, target_session: 'someone-else' };
+    const sb = { from: (table) => {
+      const state = { table, filters: [], payload: null, op: 'select', usedOr: false };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; state.payload = p; return c; },
+        eq: (col, v) => { state.filters.push([col, v]); return c; },
+        is: () => c, gte: () => c, order: () => c, limit: () => c,
+        or: () => { state.usedOr = true; return c; },
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          // The correlation-window query (identified by .or()) sees the reply; the
+          // primary ack-null query does not (the reply targets someone-else, not Adam).
+          if (state.usedOr) return Promise.resolve({ data: [directive, correlatedReply], error: null }).then(res);
+          return Promise.resolve({ data: [directive], error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items.map((i) => i.id)).not.toContain(directive.id);
+    expect(out.directives).toBe(0);
+  });
+
+  it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a directive with no correlated reply still hard-interrupts', async () => {
+    const directive = row({ payload: { kind: DIRECTIVE_KINDS[0] } });
+    const sb = { from: (table) => {
+      const state = { table, filters: [], payload: null, op: 'select', usedOr: false };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; state.payload = p; return c; },
+        eq: (col, v) => { state.filters.push([col, v]); return c; },
+        is: () => c, gte: () => c, order: () => c, limit: () => c,
+        or: () => { state.usedOr = true; return c; },
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          if (state.usedOr) return Promise.resolve({ data: [directive], error: null }).then(res);
+          return Promise.resolve({ data: [directive], error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items.map((i) => i.id)).toContain(directive.id);
+    expect(out.directives).toBe(1);
   });
 });
 

--- a/tests/unit/adam/outbound-silence-watchdog.test.js
+++ b/tests/unit/adam/outbound-silence-watchdog.test.js
@@ -22,7 +22,7 @@ const LIVE = 'target-live-1';
 
 /** Stub supabase: dispatches by table; session_coordination select() branches by whether
  *  .eq('payload->>kind', ...) is chained (prior-probe lookup) vs not (outbound fetch). */
-function makeStub({ outboundRows = [], sessionRows = [{ session_id: LIVE, heartbeat_at: new Date(NOW).toISOString() }], priorProbeRows = [] } = {}) {
+function makeStub({ outboundRows = [], sessionRows = [{ session_id: LIVE, heartbeat_at: new Date(NOW).toISOString() }], priorProbeRows = [], replyRows = [] } = {}) {
   const inserts = [];
   const priorProbeFilters = [];
   return {
@@ -44,6 +44,9 @@ function makeStub({ outboundRows = [], sessionRows = [{ session_id: LIVE, heartb
                 },
               }),
             }),
+            // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: counterparty-reply correlation fetch
+            // (.select().in('sender_session', targets).gte().limit()).
+            in: () => ({ gte: () => ({ limit: async () => ({ data: replyRows }) }) }),
           }),
           insert: async (row) => { inserts.push(row); return { data: null, error: null }; },
         };
@@ -182,6 +185,18 @@ describe('outbound-silence-watchdog: tick wiring (TS-2..TS-5)', () => {
     expect(inserted.payload.correlation_id).toBeUndefined();
     expect(inserted.payload.request_ack).toBeUndefined();
     expect(Date.parse(inserted.expires_at) - NOW).toBe(PROBE_EXPIRES_MS);
+  });
+
+  it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a counterparty reply (sender_type != adam) suppresses the false breach', async () => {
+    // The real reply is sent BY the target (sender_type='coordinator'/'solomon'), never
+    // sender_type='adam' — so it can only be found via the separate replyRows fetch, not
+    // the outboundRows fetch. This is the adversarial-review-caught direction bug.
+    const reply = { id: 'reply-1', payload: { reply_to: breachingRow.id }, sender_session: LIVE, created_at: new Date(NOW - 40 * 60_000).toISOString() };
+    const sb = makeStub({ outboundRows: [breachingRow], priorProbeRows: [], replyRows: [reply] });
+    const result = await runOutboundSilenceWatchdog(sb, { now: NOW });
+    expect(result.probed).toHaveLength(0);
+    expect(result.escalated).toHaveLength(0);
+    expect(emitFeedback).not.toHaveBeenCalled();
   });
 
   it('MAX_PROBES_PER_TICK: more breaching live targets than the cap -> only the cap is probed', async () => {

--- a/tests/unit/adam/outbound-silence-watchdog.test.js
+++ b/tests/unit/adam/outbound-silence-watchdog.test.js
@@ -73,6 +73,17 @@ describe('outbound-silence-watchdog: pure classification (TS-1)', () => {
     expect(isBreaching({ created_at: created30, read_at: null, payload: { kind: PROBE_KIND } }, NOW)).toBe(false);
   });
 
+  it('isBreaching: SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 — a correlated reply prevents a false breach', () => {
+    const read60 = new Date(NOW - UNACKED_BREACH_MS).toISOString();
+    const created30 = new Date(NOW - UNREAD_BREACH_MS).toISOString();
+    const original = { id: 'req-1', created_at: created30, read_at: read60, acknowledged_at: null, payload: {} };
+    const reply = { id: 'reply-1', payload: { reply_to: 'req-1' } };
+    // Without a correlated reply present: still a genuine breach.
+    expect(isBreaching(original, NOW, [original])).toBe(true);
+    // With a correlated reply present in the row window: no false breach.
+    expect(isBreaching(original, NOW, [original, reply])).toBe(false);
+  });
+
   it('classifyBreaches: live-target-only, oldest-per-target', () => {
     const older = { id: 'r1', target_session: LIVE, payload: { kind: 'coordinator_request' }, created_at: new Date(NOW - 40 * 60_000).toISOString(), read_at: null };
     const newer = { id: 'r2', target_session: LIVE, payload: { kind: 'coordinator_request' }, created_at: new Date(NOW - 35 * 60_000).toISOString(), read_at: null };
@@ -80,6 +91,15 @@ describe('outbound-silence-watchdog: pure classification (TS-1)', () => {
     const breaches = classifyBreaches([older, newer, deadTarget], new Set([LIVE]), NOW);
     expect(breaches.size).toBe(1);
     expect(breaches.get(LIVE).id).toBe('r1');
+  });
+
+  it('classifyBreaches: SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 — a correlated reply in the row set excludes that target entirely', () => {
+    const read60 = new Date(NOW - UNACKED_BREACH_MS).toISOString();
+    const created30 = new Date(NOW - UNREAD_BREACH_MS).toISOString();
+    const req = { id: 'r-corr', target_session: LIVE, payload: { kind: 'coordinator_request' }, created_at: created30, read_at: read60, acknowledged_at: null };
+    const reply = { id: 'reply-corr', target_session: 'someone-else', payload: { reply_to: 'r-corr' }, created_at: created30, read_at: null, acknowledged_at: null };
+    const breaches = classifyBreaches([req, reply], new Set([LIVE, 'someone-else']), NOW);
+    expect(breaches.has(LIVE)).toBe(false);
   });
 
   it('laneHealthAggregate: counts unread fire-and-forget at live targets, excludes probes', () => {

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -73,6 +73,20 @@ describe('detectReplyStarvation', () => {
     ];
     expect(detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
   });
+
+  it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a correlated reply row excludes the original from starvation', () => {
+    const original = { id: 'req-1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const reply = { id: 'reply-1', sender_type: 'coordinator', sender_session: 'c1', created_at: minsAgo(10), acknowledged_at: null, read_at: null, payload: { reply_to: 'req-1' } };
+    expect(detectReplyStarvation({ signals: [original, reply], now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
+  });
+
+  it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: no correlated reply present still starves (genuine case preserved)', () => {
+    const original = { id: 'req-2', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const unrelated = { id: 'other', sender_type: 'coordinator', sender_session: 'c1', created_at: minsAgo(10), acknowledged_at: null, read_at: null, payload: { reply_to: 'not-req-2' } };
+    const r = detectReplyStarvation({ signals: [original, unrelated], now: NOW, thresholdMs: 30 * 60_000 });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.samples.some((s) => s.id === 'req-2')).toBe(true);
+  });
 });
 
 describe('detectStuckWorker', () => {

--- a/tests/unit/coordinator/reply-correlation.test.js
+++ b/tests/unit/coordinator/reply-correlation.test.js
@@ -1,0 +1,50 @@
+/**
+ * SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 — reply-correlation primitive.
+ *
+ * Closure map class C6: `acknowledged_at IS NULL` is not a reliable "unreplied"
+ * signal — a reply routinely arrives as a fresh row carrying payload.reply_to /
+ * payload.correlation_id, never as an update to the original row's acknowledged_at.
+ */
+import { describe, it, expect } from 'vitest';
+import { hasCorrelatedReply } from '../../../lib/coordinator/reply-correlation.cjs';
+
+describe('hasCorrelatedReply', () => {
+  it('returns true when another row targets this row via payload.reply_to', () => {
+    const original = { id: 'req-1', payload: {} };
+    const reply = { id: 'reply-1', payload: { reply_to: 'req-1' } };
+    expect(hasCorrelatedReply(original, [original, reply])).toBe(true);
+  });
+
+  it('returns true when another row shares the same payload.correlation_id', () => {
+    const original = { id: 'req-2', payload: { correlation_id: 'corr-x' } };
+    const reply = { id: 'reply-2', payload: { correlation_id: 'corr-x' } };
+    expect(hasCorrelatedReply(original, [original, reply])).toBe(true);
+  });
+
+  it('returns false when no other row references this row', () => {
+    const original = { id: 'req-3', payload: {} };
+    const unrelated = { id: 'other', payload: { reply_to: 'someone-else' } };
+    expect(hasCorrelatedReply(original, [original, unrelated])).toBe(false);
+  });
+
+  it('returns false for a null/undefined row, no throw', () => {
+    expect(hasCorrelatedReply(null, [])).toBe(false);
+    expect(hasCorrelatedReply(undefined, [{ id: 'x', payload: {} }])).toBe(false);
+  });
+
+  it('returns false when allRows is not an array, no throw', () => {
+    expect(hasCorrelatedReply({ id: 'req-4', payload: {} }, null)).toBe(false);
+    expect(hasCorrelatedReply({ id: 'req-4', payload: {} }, undefined)).toBe(false);
+  });
+
+  it('does not match a row against itself', () => {
+    const row = { id: 'req-5', payload: { correlation_id: 'req-5' } };
+    expect(hasCorrelatedReply(row, [row])).toBe(false);
+  });
+
+  it('ignores rows with no payload', () => {
+    const original = { id: 'req-6', payload: {} };
+    const bare = { id: 'other-2' };
+    expect(hasCorrelatedReply(original, [original, bare])).toBe(false);
+  });
+});

--- a/tests/unit/fleet-dashboard-ackstamp-false-metrics.test.js
+++ b/tests/unit/fleet-dashboard-ackstamp-false-metrics.test.js
@@ -1,0 +1,75 @@
+/**
+ * SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 — fleet-dashboard.cjs re-keyed sections.
+ *
+ * Source-level pins (network-free, no supabase client), mirroring the existing
+ * fleet-dashboard-solomon-inbox.test.js pattern: printInbox, printCoordination, and
+ * printSolomonInbox now consult hasCorrelatedReply before reporting their headline
+ * ack-null-derived counts. printCoaching is explicitly untouched (RETAIN-AS-IS: an
+ * intentional per-message ack, not a reply-correlation scenario).
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, '../../scripts/fleet-dashboard.cjs'), 'utf8');
+
+function functionBody(startMarker) {
+  const start = SRC.indexOf(startMarker);
+  expect(start).toBeGreaterThan(-1);
+  const rest = SRC.slice(start + 1);
+  const nextFn = rest.search(/\n(?:async function|function) /);
+  return nextFn === -1 ? rest : rest.slice(0, nextFn);
+}
+
+describe('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 — reply-correlation primitive is wired in', () => {
+  it('top-level require of hasCorrelatedReply exists', () => {
+    expect(SRC).toMatch(/require\(['"]\.\.\/lib\/coordinator\/reply-correlation\.cjs['"]\)/);
+  });
+});
+
+describe('printInbox — headline unread count excludes correlated-reply rows', () => {
+  it('references hasCorrelatedReply in its true-unread computation', () => {
+    const body = functionBody('async function printInbox(');
+    expect(body).toMatch(/hasCorrelatedReply/);
+  });
+
+  it('no longer uses a head-only count query for the true-unread total (needs row data to correlate)', () => {
+    const body = functionBody('async function printInbox(');
+    expect(body).not.toMatch(/count:\s*['"]exact['"]\s*,\s*head:\s*true/);
+  });
+});
+
+describe('printCoordination — pending-acknowledgment count excludes correlated-reply rows', () => {
+  it('references hasCorrelatedReply in its pending computation', () => {
+    const body = functionBody('function printCoordination(');
+    expect(body).toMatch(/hasCorrelatedReply/);
+  });
+});
+
+describe('printSolomonInbox — pending-consult count excludes correlated-reply rows', () => {
+  it('references hasCorrelatedReply after fetching Solomon\'s own outbound replies', () => {
+    const body = functionBody('async function printSolomonInbox(');
+    expect(body).toMatch(/hasCorrelatedReply/);
+    expect(body).toMatch(/sender_session/);
+  });
+
+  it('remains PURE-READ — the new correlation lookup is a .select() only, no write', () => {
+    const body = functionBody('async function printSolomonInbox(');
+    expect(body).not.toMatch(/\.update\(\s*\{[^}]*read_at/);
+    expect(body).not.toMatch(/\.update\(\s*\{[^}]*acknowledged_at/);
+    expect(body).not.toMatch(/\.upsert\(/);
+    expect(body).not.toMatch(/\.rpc\(/);
+    expect(body).not.toMatch(/\.update\(/);
+  });
+});
+
+describe('printCoaching — RETAIN-AS-IS disposition (untouched)', () => {
+  it('Acked/Read/Unread tally is unchanged — no correlation logic added', () => {
+    const body = functionBody('async function printCoaching(');
+    expect(body).not.toMatch(/hasCorrelatedReply/);
+    expect(body).toContain('Acked:');
+    expect(body).toMatch(/const acked = coaching\.filter/);
+  });
+});


### PR DESCRIPTION
## Summary
Closure map class C6 (chairman-ratified PR #5840): `acknowledged_at IS NULL` is not a reliable "unreplied" signal — a reply routinely arrives as a fresh row carrying `payload.reply_to`/`correlation_id`, never as an update to the original row's `acknowledged_at`. S5 found 422 "unacked" rows with 0 confirmed breaches; S2's 46 "breaches" were largely the same false-positive class plus dead addressees (already fixed by QF-20260710-750, this SD's metric-layer complement).

New `lib/coordinator/reply-correlation.cjs` `hasCorrelatedReply(row, allRows)`, generalizing the pattern already proven in `lib/adam/task-rehydrate.js` and `lib/adam/stall-alert.js`. Ports 4 consumers onto it:
- `lib/adam/outbound-silence-watchdog.js`'s `isBreaching()` — the chairman-escalating breach classifier (highest-impact: writes a `feedback` row with `severity: 'high'` to the chairman on false breaches)
- `lib/coordinator/detectors.cjs`'s `detectReplyStarvation` — the `coordination_events` REPLY_STARVATION anomaly
- `scripts/adam-quiet-tick.mjs`'s directive hard-interrupt reprint — now converges on a correlated reply, not just an ack stamp
- `scripts/fleet-dashboard.cjs`'s 3 of 4 ack-null sections (`printInbox`'s "N unread signal(s)", `printCoordination`'s "N pending acknowledgment", `printSolomonInbox`'s "N pending consult(s)")

The two-stage `read_at`/`acknowledged_at` DRAIN semantics are untouched everywhere — this SD changes metric consumers only.

## Consumer census (ALL-PATHS clause) — 9 sites found, disposition per site

| # | Consumer | Disposition | Rationale |
|---|----------|--------------|-----------|
| 1 | `lib/adam/outbound-silence-watchdog.js` `isBreaching` | **RE-KEY** | Chairman-facing escalation — highest real-world false-positive impact |
| 2 | `lib/coordinator/detectors.cjs` `detectReplyStarvation` | **RE-KEY** | `coordination_events` anomaly stream, surfaced by `stale-session-sweep.cjs` |
| 3 | `scripts/adam-quiet-tick.mjs` directive hard-interrupt reprint | **RE-KEY** | Never converges today if the reply arrives as a fresh correlated row |
| 4 | `scripts/fleet-dashboard.cjs` `printInbox` "unread signal(s)" | **RE-KEY** | The exact Surface 5 / 422-row incident, live on the coordinator board |
| 5 | `scripts/fleet-dashboard.cjs` `printCoordination` "pending acknowledgment" | **RE-KEY** | Same class, coordinator board |
| 6 | `scripts/fleet-dashboard.cjs` `printSolomonInbox` "pending consult(s)" | **RE-KEY** | Same class, coordinator board |
| 7 | `scripts/fleet-dashboard.cjs` `printCoaching` Acked/Read/Unread tally | RETAIN-AS-IS | Per-message coaching ack is an intentional 1:1 semantic, not a reply-correlation scenario |
| 8 | `lib/coordinator/canary-trigger.cjs` `findUnactionedCanaryRequests` | RETAIN-AS-IS | Direct-action semantic ("did anyone act on this"), not a reply-correlation scenario |
| 9 | `scripts/stale-session-sweep.cjs` / `lib/sweep/passes/dead-letter-planning.cjs` drain-gating; `scripts/coordinator-quiet-tick.mjs` `openSignalCount` | RETAIN-AS-IS | Staleness gate for auto-cleanup / internal suppress-emit gate — not a human-facing SLA/breach metric, a different mechanism than this SD's scope |

## Test plan
- [x] New `tests/unit/coordinator/reply-correlation.test.js` — 7/7 (core primitive: reply_to match, correlation_id match, no-match, null-safety, self-exclusion)
- [x] New behavior tests added to existing suites: `outbound-silence-watchdog.test.js` (+2), `detectors.test.js` (+2), `adam-inbox-surface-not-stamp.test.js` (+2, including the `.or()` mock support the new query needs)
- [x] New `tests/unit/fleet-dashboard-ackstamp-false-metrics.test.js` — source-level pins (matches the existing `fleet-dashboard-solomon-inbox.test.js` pattern) confirming all 3 re-keyed sections reference `hasCorrelatedReply`, `printSolomonInbox` remains PURE-READ, and `printCoaching` is untouched
- [x] All 6 new/modified test files: 99/99 passing
- [x] Full unit tier: 26200/26205 passing (5 pre-existing failures in `enforcement-worktree-hygiene.test.js` and `witness-emitter-acceptance.test.js` — confirmed unrelated to this SD's files, environment-sensitive worktree/doctrine-judge tests)
- [x] Smoke suite 15/15
- [x] Confirmed ESM↔CJS interop: `outbound-silence-watchdog.js`/`adam-quiet-tick.mjs` (ESM) import named exports from `reply-correlation.cjs` (CJS) — an already-established pattern in this codebase (`grep 'from .*\.cjs'` across `scripts/*.mjs` confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)