### PR TITLE
fix(QF-20260710-941): stage-gates reader/writer shape drift left stage0Score silently undefined

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -637,15 +637,26 @@ async function resolveGateContext(supabase, ventureId, toStage, options = {}) {
       .limit(1)
       .maybeSingle();
     if (szData?.result) {
-      const rubricScores = szData.result.rubric_scores;
+      // QF-20260710-941 (Solomon H4, Delta ledger): the live writer
+      // (scripts/stage-zero-queue-processor.js -> executeStageZero) nests
+      // rubric_scores/confidence under result.brief.metadata.forecast and
+      // venture_score under result.brief.metadata — never at result's top
+      // level. Only archived one-time scripts ever wrote the flat shape.
+      // Read both so historical top-level rows and the live nested shape
+      // resolve identically.
+      const forecast = szData.result.brief?.metadata?.forecast;
+      const rubricScores = szData.result.rubric_scores ?? forecast?.rubric_scores;
       if (rubricScores) {
         // Compute stage-weighted score (e.g. Stage 5 emphasizes financial dimensions)
-        const confidence = szData.result.confidence ?? 30;
+        const confidence = szData.result.confidence ?? forecast?.confidence ?? 30;
         const weightedScore = calculateStageWeightedScore(rubricScores, confidence, toStage);
         stage0Score = Math.round((weightedScore / 10) * 10) / 10;
-      } else if (szData.result.venture_score != null) {
-        // Legacy fallback: convert 0-100 rubric scale to 0-10 filter engine scale
-        stage0Score = Math.round((szData.result.venture_score / 10) * 10) / 10;
+      } else {
+        const ventureScore = szData.result.venture_score ?? szData.result.brief?.metadata?.venture_score;
+        if (ventureScore != null) {
+          // Legacy fallback: convert 0-100 rubric scale to 0-10 filter engine scale
+          stage0Score = Math.round((ventureScore / 10) * 10) / 10;
+        }
       }
     }
   }

--- a/tests/unit/stage-gates-ext.test.js
+++ b/tests/unit/stage-gates-ext.test.js
@@ -647,6 +647,89 @@ describe('resolveGateContext', () => {
     expect(stageInput.constraints).toEqual({});
     expect(stageInput.approvedConstraints).toEqual({});
   });
+
+  // QF-20260710-941 (Solomon H4, Delta ledger): reader/writer shape contract.
+  // The live writer (scripts/stage-zero-queue-processor.js -> executeStageZero)
+  // nests rubric_scores/confidence under result.brief.metadata.forecast and
+  // venture_score under result.brief.metadata — never at result's top level.
+  describe('stage0Score fallback (SHAPE-DRIFT class)', () => {
+    const RUBRIC_SCORES = {
+      market_opportunity: { score: 4, rationale: 'Strong' },
+      revenue_viability: { score: 3, rationale: 'Moderate' },
+      unit_economics: { score: 3, rationale: 'Moderate' },
+      execution_feasibility: { score: 4, rationale: 'Strong' },
+      competitive_defensibility: { score: 2, rationale: 'Weak' },
+    };
+
+    function mockStageZeroRequests(resultRow) {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: resultRow ? { result: resultRow } : null, error: null }),
+      };
+    }
+
+    it('reads rubric_scores from the LIVE nested shape (result.brief.metadata.forecast)', async () => {
+      const supabase = createMockSupabase({
+        stage_zero_requests: mockStageZeroRequests({
+          brief: { metadata: { forecast: { rubric_scores: RUBRIC_SCORES, confidence: 70 }, venture_score: 55 } },
+        }),
+      });
+
+      const { stageInput } = await resolveGateContext(supabase, 'v1', 5, { stageOutput: {} });
+
+      expect(stageInput.score).toBeGreaterThan(0);
+      expect(stageInput.score).not.toBeUndefined();
+    });
+
+    it('falls back to venture_score from the LIVE nested shape when no rubric_scores present', async () => {
+      const supabase = createMockSupabase({
+        stage_zero_requests: mockStageZeroRequests({
+          brief: { metadata: { venture_score: 80 } },
+        }),
+      });
+
+      const { stageInput } = await resolveGateContext(supabase, 'v1', 5, { stageOutput: {} });
+
+      expect(stageInput.score).toBe(8); // 80/10
+    });
+
+    it('still reads the legacy flat top-level shape (backward compatibility)', async () => {
+      const supabase = createMockSupabase({
+        stage_zero_requests: mockStageZeroRequests({
+          rubric_scores: RUBRIC_SCORES,
+          confidence: 70,
+        }),
+      });
+
+      const { stageInput } = await resolveGateContext(supabase, 'v1', 5, { stageOutput: {} });
+
+      expect(stageInput.score).toBeGreaterThan(0);
+      expect(stageInput.score).not.toBeUndefined();
+    });
+
+    it('leaves stage0Score undefined when neither shape has a score (no silent wrong value)', async () => {
+      const supabase = createMockSupabase({
+        stage_zero_requests: mockStageZeroRequests({ brief: { metadata: {} } }),
+      });
+
+      const { stageInput } = await resolveGateContext(supabase, 'v1', 5, { stageOutput: {} });
+
+      expect(stageInput.score).toBeUndefined();
+    });
+
+    it('does not query stage_zero_requests when stageOutput.score is already provided', async () => {
+      const stageZeroTable = mockStageZeroRequests({ brief: { metadata: { venture_score: 80 } } });
+      const supabase = createMockSupabase({ stage_zero_requests: stageZeroTable });
+
+      const { stageInput } = await resolveGateContext(supabase, 'v1', 5, { stageOutput: { score: 6 } });
+
+      expect(stageInput.score).toBe(6);
+      expect(stageZeroTable.maybeSingle).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // ── Existing Gate Preservation (FR-4) ───────────────────────────────


### PR DESCRIPTION
## Summary
- `resolveGateContext()` in `lib/agents/modules/venture-state-machine/stage-gates.js` read the Stage-0 rubric fallback (`rubric_scores`/`venture_score`) at the top level of `stage_zero_requests.result`.
- The live writer (`scripts/stage-zero-queue-processor.js` → `executeStageZero` → `conductChairmanReview`) actually nests these under `result.brief.metadata.forecast.rubric_scores` and `result.brief.metadata.venture_score` — only archived one-time scripts ever wrote the flat shape. `stage0Score` was silently `undefined` on every live path (Solomon 41a2e6da H4, Delta ledger).
- Fixed the reader to check the live nested shape first, falling back to the legacy flat shape for backward compatibility with any historical rows.
- Added a reader/writer contract test suite (SHAPE-DRIFT class): nested rubric_scores, nested venture_score fallback, legacy flat shape still works, neither-shape leaves score `undefined` (no silent wrong value), and the query is skipped when `stageOutput.score` is already provided.

## Note on test quarantine
`tests/unit/stage-gates-ext.test.js` is already quarantined (`tests/quarantine-manifest.json`) for unrelated pre-existing issues (a TASTE-gate assertion-drift + a `createMockSupabase` mock-chain gap missing `.order()`/`.limit()`/`.maybeSingle()` on its default chain). Verified by running the file under a bypass filename outside the quarantine glob: the new tests pass and the fix introduces **zero new failures** — same 8/54 pre-existing failures before and after this change.

## Test plan
- [x] Ran the quarantined file directly (bypassing the exclude glob) — 5/5 new tests pass, 8 pre-existing unrelated failures unchanged
- [x] LOC threshold gate passed (104 lines, below cap)
- [x] Traced the actual live writer chain (`stage-zero-orchestrator.js` → `chairman-review.js` → `stage-zero-queue-processor.js`) to confirm the real nested shape before writing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)