### PR TITLE
feat(SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001): Solomon-lane periodic reconciliation + optional validated typed-kind at send

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -158,13 +158,20 @@ function extractEmbeddedPeerDirective(rawPeerArg, rawBody) {
   return { peerArg: null, body: rawBody };
 }
 
-function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass, replyWindowMs, now, addressee }) {
+// SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-2: the known-kinds allowlist a caller may
+// explicitly stamp via --kind. Sourced from the SAME shared constants every drain already
+// filters on (lib/fleet/worker-status.cjs) -- never a second hand-maintained list.
+const KNOWN_SEND_KINDS = new Set([...Object.values(PAYLOAD_KINDS), ...DIRECTIVE_KINDS]);
+
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass, replyWindowMs, now, addressee, kind }) {
   // request mode (expectsReply) is always live-handshake (synchronous, bounded-timeout await);
   // send mode defaults to fire-and-forget unless the sender opts into reply-needed via --reply-class
   // (SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C).
   const resolvedReplyClass = expectsReply ? 'live-handshake' : (replyClass || 'fire-and-forget');
   const payload = {
-    kind: PAYLOAD_KINDS.ADAM_ADVISORY,
+    // FR-2: an explicit, validated --kind overrides the default; omitting --kind is
+    // BYTE-IDENTICAL to pre-SD behavior (always adam_advisory, as it always has been).
+    kind: kind || PAYLOAD_KINDS.ADAM_ADVISORY,
     sender_callsign: senderCallsign || null,
     repo: repo || null,
     reply_class: resolvedReplyClass,
@@ -733,7 +740,7 @@ async function main() {
   const argv = process.argv.slice(2);
   const mode = argv[0];
   if (mode !== 'send' && mode !== 'request' && mode !== 'replies' && mode !== 'inbox' && mode !== 'status' && mode !== 'ack') {
-    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>] [--to solomon|<session_id>]  |  request "<question>" [--timeout <ms>] [--to solomon|<session_id>]  |  replies [--background]  |  inbox [--background] [--window <Nh|Nd>] [--sweep [--window 24h]]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
+    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>] [--to solomon|<session_id>] [--kind <recognized_kind>]  |  request "<question>" [--timeout <ms>] [--to solomon|<session_id>] [--kind <recognized_kind>]  |  replies [--background]  |  inbox [--background] [--window <Nh|Nd>] [--sweep [--window 24h]]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
     process.exit(2);
   }
 
@@ -820,6 +827,15 @@ async function main() {
     console.error(`ERROR: --reply-class must be one of ${REPLY_CLASSES.join(', ')} (got "${replyClassArg}").`);
     process.exit(2);
   }
+  // SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-2: --kind is OPTIONAL (omitting it is
+  // byte-identical to pre-SD behavior); an EXPLICITLY-supplied value must be a recognized
+  // kind or the send is rejected (never a silently-inserted garbage kind no drain matches).
+  const kIdx = argv.indexOf('--kind');
+  const kindArg = kIdx >= 0 ? argv[kIdx + 1] || null : null;
+  if (kindArg && !KNOWN_SEND_KINDS.has(kindArg)) {
+    console.error(`ERROR: --kind "${kindArg}" is not a recognized kind (see PAYLOAD_KINDS/DIRECTIVE_KINDS in lib/fleet/worker-status.cjs).`);
+    process.exit(2);
+  }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to solomon` — direct
   // 1-hop channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' kills it).
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
@@ -833,7 +849,7 @@ async function main() {
   const toArg = toIdx >= 0 ? (argv[toIdx + 1] || '').toLowerCase() || null : null;
   const directIdx = argv.indexOf('--direct');
   const rawPeerArg = toArg || (directIdx >= 0 ? 'solomon' : null);
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx].filter(i => i >= 0));
+  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx, kIdx, kIdx + 1].filter(i => i >= 0));
   const rawBody = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
   // QF-20260707-114: a caller (confirmed live: Adam) sometimes embeds `--to <peer>` / `--direct`
   // INSIDE the quoted body instead of passing it as a separate CLI arg (the whole message ends
@@ -915,7 +931,7 @@ async function main() {
   }
   // FR-1: scope-tag the advisory from the sending repo (reuse-first, fail-soft).
   const { scopeKey, reuseClass, appliesToScopes } = await resolveScopeForSend(supabase, process.cwd());
-  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass: replyClassArg, replyWindowMs, addressee });
+  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass: replyClassArg, replyWindowMs, addressee, kind: kindArg });
   // R1 (QF-20260703-964): the addressee-vs-target divergence WARN lives ONE place — the
   // insertCoordinationRow choke point (lib/coordinator/dispatch.cjs) — not duplicated here.
   // SD-REFILL-00XK256L: the 2-hypothesis-bar GATE. Block an UNATTESTED urgent model-availability
@@ -1014,7 +1030,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS, KNOWN_SEND_KINDS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -34,7 +34,11 @@ const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: resolve the LIVE Solomon session at fire time
 // (metadata.role='solomon', fresh heartbeat) via the canonical resolver — NO hardcoded UUID.
-const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+// SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-1: fetchAllSolomons + retargetStaleSolomonInbound
+// were already exported (FR-2 of a prior SD) but had no periodic caller -- retargeting only ever
+// happened on the NEXT Solomon registration event. Wiring them into this existing hourly tick
+// closes that gap without touching either function's signature.
+const { getActiveSolomonId, fetchAllSolomons, retargetStaleSolomonInbound } = require('../lib/coordinator/solomon-identity.cjs');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const ADAM_FRESH_S = Number(process.env.ADAM_FRESH_SECONDS || 600);
@@ -139,6 +143,55 @@ async function dispatchSolomonReminder(sb, { dryRun = DRY_RUN, resolveSolomon = 
   }
 }
 
+/**
+ * SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-1: periodic stale-identity reconciliation for the
+ * Solomon lane. Solomon's own MODE-B advisory (session_coordination 09189ed9) instance (1): role-mail
+ * retargeting was EVENT-driven only (a new Solomon registration), so a resolution fault or a gap
+ * between a Solomon's death and its successor's registration left rows silently stranded at a stale
+ * target for hours. This rides the SAME hourly cadence as dispatchSolomonReminder (no new scheduler):
+ * resolve the live Solomon, list every OTHER role=solomon session (fetchAllSolomons, unfiltered by
+ * freshness), and retarget each stale one's still-unread rows via the existing, unmodified
+ * retargetStaleSolomonInbound primitive. Fail-open / non-fatal, mirrors the sibling reminder leg.
+ * @returns {Promise<{reconciled:number, staleCount:number, reason?:string}>}
+ */
+async function reconcileStaleSolomonInbound(sb, { dryRun = DRY_RUN, resolveSolomon = getActiveSolomonId, fetchAll = fetchAllSolomons, retarget = retargetStaleSolomonInbound } = {}) {
+  try {
+    const liveSolomon = await resolveSolomon(sb);
+    if (!liveSolomon) {
+      return { reconciled: 0, staleCount: 0, reason: 'no_live_solomon' };
+    }
+    const allSolomons = await fetchAll(sb);
+    const staleIds = Array.from(new Set(
+      (allSolomons || [])
+        .map(function (s) { return s && s.session_id; })
+        .filter(function (id) { return id && id !== liveSolomon; })
+    ));
+    if (staleIds.length === 0) {
+      return { reconciled: 0, staleCount: 0 };
+    }
+    if (dryRun) {
+      console.log('\n[HOURLY-REVIEW] Solomon reconcile: would check ' + staleIds.length + ' stale identity(ies). [dry-run, not retargeted]');
+      return { reconciled: 0, staleCount: staleIds.length, reason: 'dry_run' };
+    }
+    let reconciled = 0;
+    for (const staleId of staleIds) {
+      const result = await retarget(sb, { staleOriginator: staleId, liveSolomon });
+      if (result && result.error) {
+        console.log('[HOURLY-REVIEW] Solomon reconcile: retarget error for ' + String(staleId).slice(0, 8) + ' (non-fatal): ' + result.error);
+        continue;
+      }
+      reconciled += (result && result.retargeted) || 0;
+    }
+    if (reconciled > 0) {
+      console.log('\n[HOURLY-REVIEW] Solomon reconcile: re-targeted ' + reconciled + ' stale-addressed row(s) to the live Solomon (' + String(liveSolomon).slice(0, 8) + ').');
+    }
+    return { reconciled: reconciled, staleCount: staleIds.length };
+  } catch (e) {
+    console.log('[HOURLY-REVIEW] Solomon reconcile skipped (non-fatal): ' + e.message);
+    return { reconciled: 0, staleCount: 0, reason: 'error' };
+  }
+}
+
 async function resolveLiveAdam(sb, freshS) {
   // Filter role=adam SERVER-SIDE + order by heartbeat — an unfiltered select hits
   // Supabase's 1000-row cap and can miss Adam's row entirely.
@@ -174,6 +227,8 @@ async function main() {
   // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: the Solomon leg runs BEFORE the Adam leg because the
   // Adam leg `return`s from main on no-Adam/dry-run; the cycle-down gate above already guards both legs.
   await dispatchSolomonReminder(sb);
+  // SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-1: periodic stale-identity reconciliation, same tick.
+  await reconcileStaleSolomonInbound(sb);
 
   // Adam leg
   try {
@@ -277,4 +332,4 @@ if (require.main === module) {
   main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
 }
 
-module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer };
+module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer, reconcileStaleSolomonInbound };

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -81,22 +81,29 @@ const SOLOMON_SWEEP_BUDGET = Object.freeze({
 const SOLOMON_PER_SD_MAX = Number(process.env.SOLOMON_PER_SD_MAX) || 2;   // answers per SD
 const SOLOMON_PER_DAY_MAX = Number(process.env.SOLOMON_PER_DAY_MAX) || 20; // answers per UTC day
 
+// SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-2: mirrors adam-advisory.cjs's KNOWN_SEND_KINDS
+// allowlist exactly -- same shared source (lib/fleet/worker-status.cjs), never a second list.
+const KNOWN_SEND_KINDS = new Set([...Object.values(PAYLOAD_KINDS), ...DIRECTIVE_KINDS]);
+
 /**
- * Build the Solomon advisory payload. INVARIANT: payload.kind=adam_advisory (reuses the
+ * Build the Solomon advisory payload. INVARIANT: payload.kind=adam_advisory by default (reuses the
  * advisory-inbox plumbing), payload.oracle=true (the Solomon marker), and NEVER signal_type /
  * intent_action. correlation_id makes the answer replyable; a reply_to (the consult's correlation)
  * is echoed under BOTH keys so the asking side's matcher pairs the answer to its consult. Exported.
  * QF-20260711-596: body sizing now goes through the shared capBody() hard-error helper (matches
  * adam-advisory.cjs/coordinator-reply.cjs/worker-signal.cjs since QF-20260710-560) instead of a
  * silent .slice() -- throws a BODY_TOO_LONG error (never silently clips) for an over-cap body.
+ * FR-2 (SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001): an explicit, validated --kind overrides the
+ * default; omitting --kind is BYTE-IDENTICAL to pre-SD behavior. An answer to a consult (replyTo
+ * set) ignores kind and always reuses the advisory lane.
  */
-function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, replyTo, via, replyClass, replyWindowMs, now }) {
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, replyTo, via, replyClass, replyWindowMs, now, kind }) {
   // An answer to a consult (replyTo set) is terminal -- always fire-and-forget. Otherwise: request
   // mode (expectsReply) is live-handshake; send mode defaults fire-and-forget unless the sender
   // opts into reply-needed via --reply-class (SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C).
   const resolvedReplyClass = replyTo ? 'fire-and-forget' : (expectsReply ? 'live-handshake' : (replyClass || 'fire-and-forget'));
   const payload = {
-    kind: PAYLOAD_KINDS.ADAM_ADVISORY, // reuse the advisory inbox lane
+    kind: replyTo ? PAYLOAD_KINDS.ADAM_ADVISORY : (kind || PAYLOAD_KINDS.ADAM_ADVISORY), // reuse the advisory inbox lane
     oracle: true,                       // Solomon marker (distinguishes an oracle answer from an Adam advisory)
     sender_callsign: senderCallsign || null,
     repo: repo || null,
@@ -585,7 +592,7 @@ async function main() {
   const argv = process.argv.slice(2);
   const mode = argv[0];
   if (mode !== 'send' && mode !== 'request' && mode !== 'inbox' && mode !== 'status' && mode !== 'ack') {
-    console.error('Usage: node scripts/solomon-advisory.cjs send "<body>" [--reply-to <id>] [--to adam]  |  request "<q>" [--timeout <ms>] [--to adam]  |  inbox [--quiet] [--background]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
+    console.error('Usage: node scripts/solomon-advisory.cjs send "<body>" [--reply-to <id>] [--to adam] [--kind <recognized_kind>]  |  request "<q>" [--timeout <ms>] [--to adam] [--kind <recognized_kind>]  |  inbox [--quiet] [--background]  |  ack <row-id...>  |  status [--working "<body>" [--eta <ms>]]');
     process.exit(2);
   }
   const sessionId = process.env.CLAUDE_SESSION_ID;
@@ -654,6 +661,15 @@ async function main() {
     console.error(`ERROR: --reply-class must be one of ${REPLY_CLASSES.join(', ')} (got "${replyClassArg}").`);
     process.exit(2);
   }
+  // SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-2: --kind is OPTIONAL (omitting it is
+  // byte-identical to pre-SD behavior); an EXPLICITLY-supplied value must be a recognized
+  // kind or the send is rejected. Mirrors adam-advisory.cjs exactly.
+  const kIdx = argv.indexOf('--kind');
+  const kindArg = kIdx >= 0 ? argv[kIdx + 1] || null : null;
+  if (kindArg && !KNOWN_SEND_KINDS.has(kindArg)) {
+    console.error(`ERROR: --kind "${kindArg}" is not a recognized kind (see PAYLOAD_KINDS/DIRECTIVE_KINDS in lib/fleet/worker-status.cjs).`);
+    process.exit(2);
+  }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to adam` — direct 1-hop
   // channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default ON since QF-20260705-488; 'off' kills it).
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
@@ -667,7 +683,7 @@ async function main() {
   const toArg = toIdx >= 0 ? (argv[toIdx + 1] || '').toLowerCase() || null : null;
   const directIdx = argv.indexOf('--direct');
   const peerArg = toArg || (directIdx >= 0 ? 'adam' : null);
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx].filter((i) => i >= 0));
+  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx, kIdx, kIdx + 1].filter((i) => i >= 0));
   const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
@@ -727,7 +743,7 @@ async function main() {
   // worker-signal.cjs already uses -- never a silent clip, never a crash-shaped stack trace.
   let payload;
   try {
-    payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, replyTo, via, replyClass: replyClassArg, replyWindowMs });
+    payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, replyTo, via, replyClass: replyClassArg, replyWindowMs, kind: kindArg });
   } catch (e) {
     if (e && e.code === 'BODY_TOO_LONG') { console.error('ERROR:', e.message); process.exit(2); }
     throw e;
@@ -808,7 +824,7 @@ module.exports = {
   computeConsultSignature, enforceSweepBudget, SOLOMON_SWEEP_BUDGET, alreadyAnswered, checkConsultQuota,
   drainInbox, resolveReplyToCorrelation, drainSolomonOutbound, captureLedgerRow,
   checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator, ensureOriginatorCc,
-  stampSurfaced, ackRows,
+  stampSurfaced, ackRows, KNOWN_SEND_KINDS,
 };
 
 if (require.main === module) {

--- a/tests/unit/comms-delivery-contract-typed-kind.test.js
+++ b/tests/unit/comms-delivery-contract-typed-kind.test.js
@@ -1,0 +1,51 @@
+/**
+ * SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-2 — typed kind, explicitly settable + validated at send.
+ *
+ * Re-scoped mid-EXEC from Solomon's original clause (c) ("untyped send REJECTED"): both
+ * adam-advisory.cjs and solomon-advisory.cjs already unconditionally hardcode payload.kind on every
+ * send today, so no row from either CLI is ever literally untyped — rejecting the ABSENCE of --kind
+ * would have broken every existing production caller (none pass --kind today). The corrected design:
+ * --kind is OPTIONAL (omitting it is byte-identical to pre-SD behavior); an EXPLICITLY-supplied value
+ * must be a recognized kind (KNOWN_SEND_KINDS, sourced from lib/fleet/worker-status.cjs's
+ * PAYLOAD_KINDS + DIRECTIVE_KINDS) or buildAdvisoryPayload's caller rejects the send.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const adam = require('../../scripts/adam-advisory.cjs');
+const solomon = require('../../scripts/solomon-advisory.cjs');
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../../lib/fleet/worker-status.cjs');
+
+describe('adam-advisory.cjs buildAdvisoryPayload — FR-2 typed kind', () => {
+  it('omitting kind is byte-identical to pre-SD behavior (defaults to adam_advisory)', () => {
+    const p = adam.buildAdvisoryPayload({ body: 'hi', correlationId: 'c1' });
+    expect(p.kind).toBe(PAYLOAD_KINDS.ADAM_ADVISORY);
+  });
+  it('an explicit recognized kind overrides the default', () => {
+    const p = adam.buildAdvisoryPayload({ body: 'hi', correlationId: 'c1', kind: PAYLOAD_KINDS.COORDINATOR_REQUEST });
+    expect(p.kind).toBe(PAYLOAD_KINDS.COORDINATOR_REQUEST);
+  });
+  it('KNOWN_SEND_KINDS is sourced from the shared PAYLOAD_KINDS + DIRECTIVE_KINDS constants (single SSOT)', () => {
+    Object.values(PAYLOAD_KINDS).forEach((k) => expect(adam.KNOWN_SEND_KINDS.has(k)).toBe(true));
+    DIRECTIVE_KINDS.forEach((k) => expect(adam.KNOWN_SEND_KINDS.has(k)).toBe(true));
+    expect(adam.KNOWN_SEND_KINDS.has('totally_made_up_kind')).toBe(false);
+  });
+});
+
+describe('solomon-advisory.cjs buildAdvisoryPayload — FR-2 typed kind (mirrors the Adam lane)', () => {
+  it('omitting kind is byte-identical to pre-SD behavior (defaults to adam_advisory, reuses the advisory lane)', () => {
+    const p = solomon.buildAdvisoryPayload({ body: 'hi', correlationId: 'c1' });
+    expect(p.kind).toBe(PAYLOAD_KINDS.ADAM_ADVISORY);
+  });
+  it('an explicit recognized kind overrides the default', () => {
+    const p = solomon.buildAdvisoryPayload({ body: 'hi', correlationId: 'c1', kind: PAYLOAD_KINDS.SOLOMON_CONSULT });
+    expect(p.kind).toBe(PAYLOAD_KINDS.SOLOMON_CONSULT);
+  });
+  it('an ANSWER to a consult (replyTo set) always reuses the advisory lane, ignoring any supplied kind', () => {
+    const p = solomon.buildAdvisoryPayload({ body: 'answer', correlationId: 'self', replyTo: 'consult-corr', kind: PAYLOAD_KINDS.SOLOMON_CONSULT });
+    expect(p.kind).toBe(PAYLOAD_KINDS.ADAM_ADVISORY); // never solomon_consult for an answer -- terminal, not a new consult
+  });
+  it('KNOWN_SEND_KINDS matches adam-advisory.cjs exactly (same shared source, not a second hand-maintained list)', () => {
+    expect(Array.from(solomon.KNOWN_SEND_KINDS).sort()).toEqual(Array.from(adam.KNOWN_SEND_KINDS).sort());
+  });
+});

--- a/tests/unit/coordinator-hourly-review-solomon-leg.test.js
+++ b/tests/unit/coordinator-hourly-review-solomon-leg.test.js
@@ -14,7 +14,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer } = require('../../scripts/coordinator-hourly-review.cjs');
+const { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer, reconcileStaleSolomonInbound } = require('../../scripts/coordinator-hourly-review.cjs');
 
 const sb = {};
 
@@ -65,6 +65,71 @@ describe('dispatchSolomonReminder — the Solomon hourly leg', () => {
     expect(SOLOMON_REMINDER).toMatch(/CONST-002/);
     expect(SOLOMON_REMINDER).toMatch(/consult triage gate/i);
     expect(SOLOMON_REMINDER).toMatch(/task_budget/);
+  });
+});
+
+describe('reconcileStaleSolomonInbound — SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001 / FR-1 (periodic reconciliation)', () => {
+  it('retargets unread rows at every stale (non-live) Solomon identity to the live Solomon, on this hourly tick — not only on a new registration event', async () => {
+    const retarget = vi.fn(async (_sb, { staleOriginator }) => ({ retargeted: staleOriginator === 'stale-1' ? 2 : 1, error: null }));
+    const fetchAll = vi.fn(async () => ([
+      { session_id: 'live-solomon' },
+      { session_id: 'stale-1' },
+      { session_id: 'stale-2' },
+    ]));
+    const r = await reconcileStaleSolomonInbound(sb, {
+      dryRun: false, resolveSolomon: async () => 'live-solomon', fetchAll, retarget,
+    });
+    expect(r.staleCount).toBe(2);
+    expect(r.reconciled).toBe(3); // 2 + 1
+    expect(retarget).toHaveBeenCalledWith(sb, { staleOriginator: 'stale-1', liveSolomon: 'live-solomon' });
+    expect(retarget).toHaveBeenCalledWith(sb, { staleOriginator: 'stale-2', liveSolomon: 'live-solomon' });
+  });
+
+  it('no-op when there is no other Solomon identity besides the live one', async () => {
+    const retarget = vi.fn();
+    const fetchAll = vi.fn(async () => ([{ session_id: 'live-solomon' }]));
+    const r = await reconcileStaleSolomonInbound(sb, { dryRun: false, resolveSolomon: async () => 'live-solomon', fetchAll, retarget });
+    expect(r.staleCount).toBe(0);
+    expect(r.reconciled).toBe(0);
+    expect(retarget).not.toHaveBeenCalled();
+  });
+
+  it('skips (no reconcile) when there is no live Solomon — itself a cycle-down', async () => {
+    const retarget = vi.fn();
+    const fetchAll = vi.fn();
+    const r = await reconcileStaleSolomonInbound(sb, { dryRun: false, resolveSolomon: async () => null, fetchAll, retarget });
+    expect(r.reason).toBe('no_live_solomon');
+    expect(fetchAll).not.toHaveBeenCalled();
+    expect(retarget).not.toHaveBeenCalled();
+  });
+
+  it('dry-run: reports the stale count but does NOT retarget', async () => {
+    const retarget = vi.fn();
+    const fetchAll = vi.fn(async () => ([{ session_id: 'live-solomon' }, { session_id: 'stale-1' }]));
+    const r = await reconcileStaleSolomonInbound(sb, { dryRun: true, resolveSolomon: async () => 'live-solomon', fetchAll, retarget });
+    expect(r.reason).toBe('dry_run');
+    expect(r.staleCount).toBe(1);
+    expect(retarget).not.toHaveBeenCalled();
+  });
+
+  it('a per-identity retarget error is surfaced (non-fatal) and does not block reconciling the remaining stale identities', async () => {
+    const retarget = vi.fn(async (_sb, { staleOriginator }) => (
+      staleOriginator === 'stale-bad'
+        ? { retargeted: 0, error: 'db error' }
+        : { retargeted: 5, error: null }
+    ));
+    const fetchAll = vi.fn(async () => ([{ session_id: 'live-solomon' }, { session_id: 'stale-bad' }, { session_id: 'stale-ok' }]));
+    const r = await reconcileStaleSolomonInbound(sb, { dryRun: false, resolveSolomon: async () => 'live-solomon', fetchAll, retarget });
+    expect(r.reconciled).toBe(5); // only stale-ok's count, stale-bad's error is skipped not thrown
+    expect(retarget).toHaveBeenCalledTimes(2);
+  });
+
+  it('fail-open: an unexpected error (e.g. fetchAll throws) returns a non-reconciled verdict, never throws', async () => {
+    const r = await reconcileStaleSolomonInbound(sb, {
+      dryRun: false, resolveSolomon: async () => 'live-solomon', fetchAll: async () => { throw new Error('db down'); }, retarget: vi.fn(),
+    });
+    expect(r.reconciled).toBe(0);
+    expect(r.reason).toBe('error');
   });
 });
 


### PR DESCRIPTION
## Summary
Narrowed at LEAD (risk-agent CONDITIONAL_PASS, evidence `63af3314-75a7-40bd-972a-4f0505e0586c`) from Solomon's original 5-clause "unified delivery contract" advisory (session_coordination row `09189ed9`) down to two clauses, per Solomon's own stated counterfactual — both his trigger conditions were empirically confirmed true (no existing reconciliation pass; blast radius = 92 raw `session_coordination` insert call sites, not the ~5 he estimated).

- **FR-1 (clause b — periodic stale-identity reconciliation):** wires the already-exported, previously-dormant `retargetStaleSolomonInbound` primitive (`lib/coordinator/solomon-identity.cjs`) into the existing `coordinator-hourly-review.cjs` sweep tick via a new `reconcileStaleSolomonInbound()`. Role-mail addressed to a stale Solomon identity now re-resolves on the next hourly tick instead of only on the next Solomon registration event. Additive-only — no exported-signature changes, Solomon-lane only, preserves the deliberate fail-open on `resolveSolomonReplyTarget` and the unread/unsettled-only invariant.
- **FR-2 (clause c — typed kind, re-scoped mid-EXEC):** EXEC-phase investigation found both `adam-advisory.cjs` and `solomon-advisory.cjs` already unconditionally hardcode `payload.kind` on every send — no row was ever literally untyped, so rejecting the *absence* of `--kind` (as originally scoped) would have broken every existing production caller. Corrected design: `--kind` is optional (omitting it is byte-identical to pre-SD behavior); an explicitly-supplied kind is validated against `KNOWN_SEND_KINDS` (sourced from `lib/fleet/worker-status.cjs`'s `PAYLOAD_KINDS` + `DIRECTIVE_KINDS`, the same allowlist every drain already filters on) and an unrecognized value is rejected at send time.

**Deferred** (per Solomon's own counterfactual): clause (a) resolver-only role-addressing lint and clause (e) cross-lane consumption-semantics census — filed as `SD-LEO-INFRA-SESSION-COORDINATION-LANE-001` (92-site raw-insert census as its PLAN-phase deliverable).

**Separately fixed** (not part of this SD): `solomon-advisory.cjs`'s own silent-4096-truncation gap, found during LEAD investigation, missed by QF-20260710-560 — shipped as QF-20260711-596 (PR #5890, merged).

## Send-entrypoint census (FR-3, reduced ALL-PATHS)

Every CLI/script entrypoint that emits an `adam_advisory`-kind or `solomon_consult`-kind `session_coordination` row, and its status against the FR-2 typed-kind contract:

| Entrypoint | On-contract? | Notes |
|---|---|---|
| `scripts/adam-advisory.cjs` `send`/`request` | ✅ On-contract | Gained `--kind` (optional, validated against `KNOWN_SEND_KINDS`) this PR |
| `scripts/solomon-advisory.cjs` `send`/`request` | ✅ On-contract | Mirrors adam-advisory.cjs exactly; reply/answer sends (`--reply-to`) are exempt by design (always reuse the advisory-lane kind, ignore `--kind`) |
| `scripts/coordinator-reply.cjs` | ✅ Exempt by construction | Hardcodes `payload.kind = 'coordinator_reply'`, a recognized `PAYLOAD_KINDS` value; has no `--kind` flag and needs none — it only ever sends one kind, by design, so there is no untyped/mistyped-kind risk to guard against |

No entrypoint in this set bypasses the typed-kind contract. The full 92-site raw-`session_coordination`-insert census (clauses a/e, every OTHER writer in the codebase) is explicitly out of scope here — tracked by `SD-LEO-INFRA-SESSION-COORDINATION-LANE-001`.

## Test plan
- [x] `tests/unit/coordinator-hourly-review-solomon-leg.test.js` — 6 new tests for `reconcileStaleSolomonInbound` (retarget-on-tick, no-op-when-none-stale, no-live-Solomon skip, dry-run, per-identity error isolation, fail-open)
- [x] `tests/unit/comms-delivery-contract-typed-kind.test.js` (new) — 7 tests for FR-2 typed-kind behavior on both CLIs (default preserved, explicit override, shared-allowlist SSOT, reply-exemption)
- [x] Full regression sweep: `npx vitest run tests/unit/ -t "adam"` — 106/106 passing, zero regressions
- [x] `node -c` syntax check on all three modified scripts
- [x] VALIDATION sub-agent (PLAN_VERIFICATION): CONDITIONAL_PASS 88% — code/PRD-lockstep confirmed; the one condition (this census) addressed in this update
- [x] REGRESSION sub-agent (PLAN_VERIFICATION): PASS 98% — flagValueIdxs off-by-one risk checked and clear, byte-identical defaults confirmed, 106/106 broad sweep, no other callers affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
