### PR TITLE
feat(SD-LEO-INFRA-SESSION-COORDINATION-LANE-001): resolver-only role-addressing lint + corrected insert-site census

### DIFF
--- a/.github/workflows/session-coordination-insert-classguard-lint.yml
+++ b/.github/workflows/session-coordination-insert-classguard-lint.yml
@@ -7,6 +7,10 @@ name: Session-Coordination Raw-Insert Class-Guard Lint
 # A DB-level advisory trigger already covers existing raw producers (see database/migrations/
 # 20260702_session_coordination_insert_lint.sql) -- this lint's job is to stop NEW raw sites.
 #
+# SD-LEO-INFRA-SESSION-COORDINATION-LANE-001 (clause a): the same driver script also runs a
+# second rule, no-echoed-session-coordination-target, flagging a target_session sourced from
+# an echoed prior-row field instead of a fresh identity-resolver call.
+#
 # GENUINELY BLOCKING (no continue-on-error): this repo's `npm run lint` (eslint.config.js
 # flat-config run) is not invoked by any other CI workflow, so registering the rule only in
 # eslint.config.js would not actually enforce anything -- this dedicated workflow is the real
@@ -18,6 +22,7 @@ on:
       - 'scripts/**/*.{js,mjs,cjs}'
       - 'lib/**/*.{js,mjs,cjs}'
       - 'eslint-rules/no-raw-session-coordination-insert.js'
+      - 'eslint-rules/no-echoed-session-coordination-target.js'
       - 'scripts/lint/session-coordination-insert-classguard-lint.mjs'
       - '.github/workflows/session-coordination-insert-classguard-lint.yml'
 

--- a/eslint-rules/no-echoed-session-coordination-target.js
+++ b/eslint-rules/no-echoed-session-coordination-target.js
@@ -1,0 +1,145 @@
+/**
+ * ESLint Rule: no-echoed-session-coordination-target
+ *
+ * Flags a `target_session:` object property whose VALUE is an echoed field from a prior
+ * session_coordination row (e.g. `row.target_session`, `msg.target_session`,
+ * `row.sender_session`) rather than a fresh call to one of the identity resolvers
+ * (getActiveAdamId / getActiveSolomonId / getActiveCoordinatorId / resolvePeerTarget /
+ * resolveCoordinatorId / resolveCoordinatorIdSafe).
+ *
+ * SD-LEO-INFRA-SESSION-COORDINATION-LANE-001 (clause (a) of the Solomon session_coordination
+ * delivery-contract advisory, session_coordination row 09189ed9): "role-addressed sends
+ * resolve ONLY through the identity resolvers — raw session-id targeting for role mail
+ * becomes a lint error, never session-guessed." An echoed row field is a specific,
+ * mechanically-detectable instance of session-guessing: the ORIGINAL row's target may have
+ * gone stale (the role holder re-registered under a new session) by the time a later insert
+ * echoes that field back as its own target.
+ *
+ * This rule is intentionally narrow (AST pattern match on known echo property names, not a
+ * general data-flow analysis) — mirrors no-raw-session-coordination-insert.js's own pragmatic
+ * approach. It accepts false negatives (a differently-shaped echo it doesn't recognize) over
+ * false positives (flagging a legitimate resolver-sourced or worker-addressed value).
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-echoed-session-coordination-target -- <REASON>
+ *   await insertCoordinationRow(supabase, { target_session: row.target_session, ... });
+ *
+ * @module eslint-rules/no-echoed-session-coordination-target
+ */
+
+const RULE_NAME = 'no-echoed-session-coordination-target';
+const TARGET_PROPERTY = 'target_session';
+const ECHO_PROPERTY_NAMES = new Set(['target_session', 'sender_session']);
+
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/**
+ * Is `node` a `target_session: <value>` Property in an ObjectExpression, where <value> is a
+ * MemberExpression echoing a known session_coordination target/sender field?
+ * @param {import('estree').Node} node
+ */
+function isEchoedTargetProperty(node) {
+  if (!node || node.type !== 'Property') return false;
+  const key = node.key;
+  const keyName = key && (key.type === 'Identifier' ? key.name : key.type === 'Literal' ? key.value : null);
+  if (keyName !== TARGET_PROPERTY) return false;
+
+  const value = node.value;
+  if (!value || value.type !== 'MemberExpression' || value.computed) return false;
+  const prop = value.property;
+  if (!prop || prop.type !== 'Identifier') return false;
+  return ECHO_PROPERTY_NAMES.has(prop.name);
+}
+
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) return { targets: true, hasMarker: false, reason: '' };
+  const reason = suffix.slice(markerIdx + 2).trim();
+  return { targets: true, hasMarker: true, reason };
+}
+
+const STATEMENT_TYPES = new Set([
+  'ExpressionStatement', 'VariableDeclaration', 'IfStatement', 'ReturnStatement',
+  'AwaitExpression', 'BlockStatement',
+]);
+
+function getDisablePragmaCommentAbove(sourceCode, node) {
+  let stmt = node;
+  while (stmt && stmt.parent && !STATEMENT_TYPES.has(stmt.type)) stmt = stmt.parent;
+  for (const candidate of [node, stmt]) {
+    const comments = sourceCode.getCommentsBefore(candidate);
+    if (!comments || comments.length === 0) continue;
+    const last = comments[comments.length - 1];
+    if (!last || (last.type !== 'Line' && last.type !== 'Block')) continue;
+    if (last.loc && candidate.loc && last.loc.end.line < candidate.loc.start.line - 1) continue;
+    const verdict = classifyPragma(last.value);
+    if (verdict.targets) return last;
+  }
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a target_session: value echoed from a prior session_coordination row field instead of a fresh identity-resolver call',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-echoed-session-coordination-target.js',
+    },
+    messages: {
+      noEchoedTarget:
+        'target_session sourced from an echoed row field ({{propName}}) may be stale by the time this insert fires — re-resolve via getActiveAdamId/getActiveSolomonId/getActiveCoordinatorId instead of echoing a prior row. ' +
+        'To override: // eslint-disable-next-line no-echoed-session-coordination-target -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-echoed-session-coordination-target requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-echoed-session-coordination-target -- worker-addressed, not role mail',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const pragmaHandled = new Set();
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        for (const comment of comments) {
+          if (comment.type !== 'Line' && comment.type !== 'Block') continue;
+          const verdict = classifyPragma(comment.value);
+          if (!verdict.targets) continue;
+          pragmaHandled.add(comment.range && comment.range[0]);
+          if (!verdict.hasMarker) {
+            context.report({ loc: comment.loc, messageId: 'noEchoedTarget', data: { propName: '' } });
+          } else if (verdict.reason.length === 0) {
+            context.report({ loc: comment.loc, messageId: 'pragmaMissingReason' });
+          }
+        }
+      },
+
+      Property(node) {
+        if (!isEchoedTargetProperty(node)) return;
+
+        const above = getDisablePragmaCommentAbove(sourceCode, node);
+        if (above && pragmaHandled.has(above.range && above.range[0])) return;
+
+        context.report({
+          node,
+          messageId: 'noEchoedTarget',
+          data: { propName: node.value.property.name },
+        });
+      },
+    };
+  },
+};

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -535,6 +535,42 @@ async function assertDoorRoutingAllowed(supabase, row, logger = console) {
  * still insert raw and therefore call assertSdDispatchable directly. Validates
  * row.target_session, refuses terminal/non-existent targets, then performs the insert.
  *
+ * SD-LEO-INFRA-SESSION-COORDINATION-LANE-001 (corrected census, superseding any prior
+ * "92 raw sites" estimate): a full call-site census found 34 PRODUCTION raw insert sites
+ * (i.e. NOT routed through this function) — 7 already on-contract (target_session
+ * resolver-sourced despite bypassing this choke point), 27 migratable (nearly all
+ * worker-addressed or broadcast sends, which is OUTSIDE the Solomon-advisory clause-(a)
+ * "role-addressed sends resolve only through the identity resolvers" scope — workers are
+ * not singleton roles), 8 exempt (test fixtures / archived dead code under
+ * scripts/archive/one-time/). This function itself does NOT enforce that row.target_session
+ * came from a resolver — it only validates the target EXISTS (assertValidTarget /
+ * assertSdDispatchable). The genuine remaining clause-(a) risk class is a CALLER sourcing
+ * row.target_session from an ECHOED row field (row.target_session / msg.target_session /
+ * row.sender_session) rather than a fresh getActiveAdamId/getActiveSolomonId/
+ * getActiveCoordinatorId call. The new no-echoed-session-coordination-target lint (added by
+ * this SD) is a narrow AST pattern match — it catches a DIRECT `target_session: row.xxx`
+ * member-expression in the object literal, not an indirect echo through an intermediate
+ * variable. Verified sites: lib/coordinator/relay-queue.cjs and
+ * scripts/hooks/coordination-inbox.cjs both had a direct echo (target_session:
+ * row.sender_session / msg.sender_session) and are now cited via eslint-disable-next-line
+ * no-echoed-session-coordination-target, pending a follow-up investigation into their
+ * interaction with the already-shipped periodic stale-identity reconciliation sweep before a
+ * runtime fix is safe. lib/coordinator/reply-class.cjs:151 and
+ * lib/coordinator/adam-action-ack.cjs:288 echo the SAME underlying field but through an
+ * intermediate variable (`const target = row.target_session; ... target_session: target`) —
+ * a real instance of the same bug class that the new lint does NOT catch by design (accepts
+ * false negatives over false positives, mirroring no-raw-session-coordination-insert.js's own
+ * pragmatic approach); both are documented here as a known, uncited gap for a future lint
+ * enhancement or manual fix. One census finding was itself
+ * corrected on manual review: coordinator-self-review.mjs's adamParticipants loop is an
+ * intentional multi-recipient broadcast solicitation (poll every live Adam-role-shaped
+ * session for feedback), not a single-role-targeting bug — collapsing it to one
+ * getActiveAdamId() call would break the intended multi-participant behavior, so it is NOT
+ * treated as a clause-(a) violation. Clause (e) (unified read_at/acknowledged_at
+ * consumption semantics across every role inbox) was deferred to a follow-on SD — see
+ * docs/protocol/coordinator-adam-comms.md lines ~115-129 for the current, only-partially-
+ * unified state.
+ *
  * @param {object} supabase - Supabase client
  * @param {object} row - session_coordination row (must include target_session)
  * @param {object} [opts]

--- a/lib/coordinator/relay-queue.cjs
+++ b/lib/coordinator/relay-queue.cjs
@@ -265,6 +265,7 @@ async function drainOne(supabase, row, sendRelay, now = Date.now()) {
       .insert({
         sender_session: liveCoordinatorId || row.target_session,
         sender_type: 'coordinator',
+        // eslint-disable-next-line no-echoed-session-coordination-target -- reply-to-original-asker pattern; flagged by SD-LEO-INFRA-SESSION-COORDINATION-LANE-001's census as a stale-target risk, deferred to that SD's follow-on investigation
         target_session: row.sender_session,
         message_type: 'INFO',
         subject: `[RELAY_CONFIRM] relayed to ${row.payload.relay_to}`,

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -454,6 +454,7 @@ async function insertDeliveredRowIfRequested(supabase, sessionId, msg) {
       .from('session_coordination')
       .insert({
         sender_session: sessionId,
+        // eslint-disable-next-line no-echoed-session-coordination-target -- transport-ack replies to msg's original sender; flagged by SD-LEO-INFRA-SESSION-COORDINATION-LANE-001's census as a stale-target risk, deferred to that SD's follow-on investigation
         target_session: msg.sender_session,
         message_type: 'INFO',
         subject: deliveredSubject,

--- a/scripts/lint/session-coordination-insert-classguard-lint.mjs
+++ b/scripts/lint/session-coordination-insert-classguard-lint.mjs
@@ -32,6 +32,10 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { Linter } from 'eslint';
 import rule from '../../eslint-rules/no-raw-session-coordination-insert.js';
+// SD-LEO-INFRA-SESSION-COORDINATION-LANE-001 (clause a): a second, narrower class-guard
+// sharing this driver's diff/all/exclusion machinery — flags target_session sourced from an
+// echoed row field instead of a fresh identity-resolver call.
+import echoedTargetRule from '../../eslint-rules/no-echoed-session-coordination-target.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -44,6 +48,8 @@ const EXCLUDE_PATHS = new Set(['lib/coordinator/dispatch.cjs']);
 const EXCLUDE_DIR_PREFIXES = ['tests/'];
 
 const RULE_ID = 'session-coordination-insert-classguard/no-raw-session-coordination-insert';
+const ECHOED_TARGET_RULE_ID = 'session-coordination-insert-classguard/no-echoed-session-coordination-target';
+const CLASSGUARD_RULE_IDS = new Set([RULE_ID, ECHOED_TARGET_RULE_ID]);
 
 const FLAT_CONFIG = {
   languageOptions: {
@@ -56,10 +62,16 @@ const FLAT_CONFIG = {
     },
   },
   plugins: {
-    'session-coordination-insert-classguard': { rules: { 'no-raw-session-coordination-insert': rule } },
+    'session-coordination-insert-classguard': {
+      rules: {
+        'no-raw-session-coordination-insert': rule,
+        'no-echoed-session-coordination-target': echoedTargetRule,
+      },
+    },
   },
   rules: {
     [RULE_ID]: 'error',
+    [ECHOED_TARGET_RULE_ID]: 'error',
   },
 };
 
@@ -118,7 +130,7 @@ function lintFile(linter, absPath) {
     return [{ filePath: relPath, line: 0, column: 0, message: `Parse error: ${err.message}` }];
   }
   return messages
-    .filter((m) => m.ruleId === RULE_ID)
+    .filter((m) => CLASSGUARD_RULE_IDS.has(m.ruleId))
     .map((m) => ({ filePath: relPath, line: m.line, column: m.column, message: m.message }));
 }
 

--- a/tests/unit/eslint-rules/no-echoed-session-coordination-target.test.js
+++ b/tests/unit/eslint-rules/no-echoed-session-coordination-target.test.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for ESLint rule `no-echoed-session-coordination-target`.
+ *
+ * SD-LEO-INFRA-SESSION-COORDINATION-LANE-001 (clause (a): resolver-only role-addressing).
+ *
+ * Covers: the anti-pattern (target_session echoed from a prior row's field), the correct
+ * pattern (resolver-sourced or worker-loop-sourced target_session), and the escape-hatch
+ * pragma contract (mirrors no-raw-session-coordination-insert.js's identical shape).
+ *
+ * @module tests/unit/eslint-rules/no-echoed-session-coordination-target.test.js
+ */
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../eslint-rules/no-echoed-session-coordination-target.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const RULE_ID = 'rule-to-test/no-echoed-session-coordination-target';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-echoed-session-coordination-target', rule, {
+  valid: [
+    // TS-1: resolver-sourced target (a CallExpression, not an echoed MemberExpression).
+    {
+      code: 'await insertCoordinationRow(supabase, { target_session: await getActiveAdamId(supabase, {}), subject: \'x\' });',
+    },
+    // TS-2: worker-addressed, loop-sourced target (a MemberExpression, but not one of the
+    // echo property names -- worker addressing is out of clause (a)'s role-addressing scope).
+    {
+      code: 'for (const w of workers) { await insertCoordinationRow(supabase, { target_session: w.session_id }); }',
+    },
+    // TS-3: a plain identifier (already-resolved local variable), not a member expression at all.
+    {
+      code: 'await insertCoordinationRow(supabase, { target_session: coordinatorId, subject: \'x\' });',
+    },
+    // TS-4: escape-hatch pragma with a non-empty reason.
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID} -- worker-addressed, not role mail
+        await insertCoordinationRow(supabase, { target_session: row.target_session });
+      `,
+    },
+  ],
+  invalid: [
+    // TS-5: the echoed-target anti-pattern this rule exists to catch.
+    {
+      code: 'await insertCoordinationRow(supabase, { target_session: row.target_session, subject: \'x\' });',
+      errors: [{ messageId: 'noEchoedTarget' }],
+    },
+    // TS-6: echoed sender_session field (relay-confirm-to-asker pattern).
+    {
+      code: 'await insertCoordinationRow(supabase, { target_session: row.sender_session, subject: \'x\' });',
+      errors: [{ messageId: 'noEchoedTarget' }],
+    },
+    // TS-7: same anti-pattern on a raw insert (not just the choke point) via a differently-named object.
+    {
+      code: 'await supabase.from(\'session_coordination\').insert({ target_session: msg.target_session });',
+      errors: [{ messageId: 'noEchoedTarget' }],
+    },
+    // TS-8: pragma present but missing the `--` REASON marker entirely.
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID}
+        await insertCoordinationRow(supabase, { target_session: row.target_session });
+      `,
+      errors: [{ messageId: 'noEchoedTarget' }],
+    },
+    // TS-9: pragma present with the `--` marker but a whitespace-only (effectively empty) reason.
+    {
+      code: `// eslint-disable-next-line ${RULE_ID} --   \nawait insertCoordinationRow(supabase, { target_session: row.target_session });`,
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
Deferred clause (a) + census from the Solomon session_coordination delivery-contract advisory (session_coordination row 09189ed9), carried via SD-LEO-INFRA-COMMS-DELIVERY-CONTRACT-001. The mandated PLAN-phase census corrected the assumed "92 raw sites" down to 34 verified production sites (7 on-contract, 27 migratable — mostly worker/broadcast, outside clause (a)'s role-addressing scope — 8 exempt).

- `lib/coordinator/dispatch.cjs`: durable comment block documenting the corrected census
- **New lint** `eslint-rules/no-echoed-session-coordination-target.js`: flags a `target_session` sourced from an echoed prior-row field (`row.target_session`, `msg.target_session`, `row.sender_session`) instead of a fresh identity-resolver call
- Wired into the existing `scripts/lint/session-coordination-insert-classguard-lint.mjs` driver + `.github/workflows/session-coordination-insert-classguard-lint.yml` CI trigger
- 2 verified direct-echo sites cited with `eslint-disable-next-line` + reason: `lib/coordinator/relay-queue.cjs`, `scripts/hooks/coordination-inbox.cjs`. 2 sites with the same underlying bug via an indirect variable (`reply-class.cjs`, `adam-action-ack.cjs`) are NOT caught by the narrow direct-pattern lint — documented as a known limitation, not silently missed.
- One census-agent finding was manually corrected: `coordinator-self-review.mjs`'s `adamParticipants` loop is intentional multi-recipient broadcast, not a role-targeting violation.
- Clause (e) (unified read_at/acknowledged_at consumption semantics) filed as a real, content-populated follow-on SD (`SD-LEO-INFRA-SESSION-COORDINATION-LANE-002`), not silently dropped.

## Test plan
- [x] `npx vitest run tests/unit/eslint-rules/no-echoed-session-coordination-target.test.js tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js` — 17/17 passing
- [x] `node scripts/lint/session-coordination-insert-classguard-lint.mjs --all` — 0 echoed-target violations (2 cited, rest pre-existing unrelated backlog)
- [x] Independently re-verified by a fresh TESTING sub-agent, including confirming the indirect-echo-site claim and the broadcast-not-violation correction by direct code reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)