### PR TITLE
fix(QF-20260711-607): parkFailedCandidate persists required_capabilities

### DIFF
--- a/lib/eva/stage-zero/traversability-gate.js
+++ b/lib/eva/stage-zero/traversability-gate.js
@@ -187,6 +187,10 @@ export async function parkFailedCandidate(failure, context = {}, deps = {}) {
           target_market: c.target_market || null,
           composite_score: c.composite_score ?? null,
           prompt_version: c.prompt_version ?? null,
+          // QF-20260711-607: without this, nursery re-eval reconstructs a candidate
+          // with no declared requirements and trivially auto-passes via the
+          // no_requirements_declared path, regardless of the original envelope gap.
+          required_capabilities: Array.isArray(c.required_capabilities) ? c.required_capabilities : [],
         },
       },
     })

--- a/tests/unit/eva/stage-zero/traversability-gate.test.js
+++ b/tests/unit/eva/stage-zero/traversability-gate.test.js
@@ -125,7 +125,10 @@ describe('parkFailedCandidate — LIVE venture_nursery schema (FR-3 / criterion 
       })),
     };
     const failure = {
-      candidate: { name: 'ShopSync', problem_statement: 'p', solution: 's', target_market: 'm', composite_score: 95, prompt_version: 'v3' },
+      candidate: {
+        name: 'ShopSync', problem_statement: 'p', solution: 's', target_market: 'm', composite_score: 95, prompt_version: 'v3',
+        required_capabilities: [{ name: 'shopify integration', kind: 'integration' }, { name: 'venture web deploy', kind: 'form_factor' }],
+      },
       missing: [{ name: 'shopify integration', kind: 'integration' }],
       resurfacing_conditions: [{ type: 'capability_ships', capability: 'shopify integration', kind: 'integration', condition: 'viable when capability shopify integration ships' }],
     };
@@ -140,6 +143,51 @@ describe('parkFailedCandidate — LIVE venture_nursery schema (FR-3 / criterion 
     expect(row.trigger_conditions[0]).toMatchObject({ type: 'capability_ships', capability: 'shopify integration' });
     expect(row.source_ref.gate).toBe('traversability');
     expect(row.source_ref.posture_version).toBe('phase_1_process_proving@v1');
+  });
+
+  // QF-20260711-607: parkFailedCandidate's persisted candidate snapshot previously
+  // omitted required_capabilities, so a nursery re-eval's carry-forward reconstruction
+  // always found zero requirements and trivially auto-passed via no_requirements_declared
+  // regardless of whether the original envelope gap was ever fixed.
+  test('persists required_capabilities in source_ref.candidate so re-eval carry-forward can reconstruct the original requirements', async () => {
+    const inserted = [];
+    const supabase = {
+      from: vi.fn((table) => ({
+        insert: vi.fn((row) => {
+          inserted.push({ table, row });
+          return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'n1', ...row }, error: null }) }) };
+        }),
+      })),
+    };
+    const requiredCapabilities = [{ name: 'shopify integration', kind: 'integration' }];
+    const failure = {
+      candidate: { name: 'ShopSync', composite_score: 95, required_capabilities: requiredCapabilities },
+      missing: [{ name: 'shopify integration', kind: 'integration' }],
+      resurfacing_conditions: [],
+    };
+    await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger });
+
+    expect(inserted[0].row.source_ref.candidate.required_capabilities).toEqual(requiredCapabilities);
+  });
+
+  test('defaults required_capabilities to an empty array when the candidate declares none', async () => {
+    const inserted = [];
+    const supabase = {
+      from: vi.fn((table) => ({
+        insert: vi.fn((row) => {
+          inserted.push({ table, row });
+          return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'n1', ...row }, error: null }) }) };
+        }),
+      })),
+    };
+    const failure = {
+      candidate: { name: 'MysteryCo', composite_score: 60 },
+      missing: [],
+      resurfacing_conditions: [],
+    };
+    await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger });
+
+    expect(inserted[0].row.source_ref.candidate.required_capabilities).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Auto-promoted from SD-LEO-INFRA-STAGE0-ENVELOPE-REGISTRATION-001's retrospective (high-priority action item #2).
- `parkFailedCandidate`'s persisted `source_ref.candidate` snapshot whitelisted 6 fields but omitted `required_capabilities`, so a nursery re-eval's carry-forward reconstruction always found zero declared requirements and trivially auto-passed via the `no_requirements_declared` path — regardless of whether the original envelope gap was ever actually fixed.
- Fix: add `required_capabilities` (defaulting to `[]`) to the persisted candidate snapshot.
- Retro action item #1 ("scope a capability provenance classification SD") is a LEAD-owned scoping task, not a code fix — out of scope for this QF, tracked separately.

## Test plan
- 2 new tests added to `tests/unit/eva/stage-zero/traversability-gate.test.js` pinning the fix (required_capabilities round-trips into `source_ref.candidate`; defaults to `[]` when absent).
- Full `tests/unit/eva/stage-zero/` suite: 52 files / 771 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)