### PR TITLE
fix(QF-20260711-253): promote-retro-action-items.mjs missed a 3rd action_items shape

### DIFF
--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -35,13 +35,20 @@ const supabase = createClient(
 
 const cutoff = new Date(Date.now() - LOOKBACK_DAYS * 24 * 3600 * 1000).toISOString();
 
-// Two shapes exist in the wild: the retro-agent's prompt-driven output uses
+// Three shapes exist in the wild: the retro-agent's prompt-driven output uses
 // { item, owner, priority }; lib/sub-agents/retro/action-items.js's programmatic
 // generateSmartActionItems() uses { action, owner, deadline, success_criteria,
-// priority, source }. Support both rather than picking one and silently dropping
-// the other's text.
+// priority, source }; a manually-authored SD_COMPLETION retrospective (e.g. via
+// scripts/one-off/insert-retro-*.cjs) uses { title, description, owner_role,
+// priority } (QF-20260711-253: '(no text)'/'unassigned' auto-promoted because
+// this third shape wasn't covered). Support all three rather than silently
+// dropping text/owner for whichever shape isn't checked.
 function actionText(item) {
-  return item.item || item.action || '(no text)';
+  return item.item || item.action || item.title || '(no text)';
+}
+
+function actionOwner(item) {
+  return item.owner || item.owner_role || 'unassigned';
 }
 
 const { data: retros, error } = await supabase
@@ -84,7 +91,7 @@ for (const retro of retros || []) {
   const title = `[Retro action items] ${retro.sd_id || retro.title || retro.id}`.slice(0, 100);
   const description = [
     `Auto-promoted from ${highPriority.length} high-priority action item(s) in retrospective ${retro.id} (SD ${retro.sd_id || 'n/a'}).`,
-    ...highPriority.map((i, idx) => `${idx + 1}. ${actionText(i)} (owner: ${i.owner || 'unassigned'}, success criteria: ${i.success_criteria || 'n/a'})`)
+    ...highPriority.map((i, idx) => `${idx + 1}. ${actionText(i)} (owner: ${actionOwner(i)}, success criteria: ${i.success_criteria || 'n/a'})`)
   ].join('\n');
 
   try {

--- a/tests/unit/promote-retro-action-items-field-fallback.test.js
+++ b/tests/unit/promote-retro-action-items-field-fallback.test.js
@@ -1,0 +1,68 @@
+/**
+ * QF-20260711-253 — promote-retro-action-items.mjs's actionText()/actionOwner()
+ * silently dropped a third retrospectives.action_items shape ({title, description,
+ * owner_role, priority}, used by manually-authored SD_COMPLETION retrospectives),
+ * producing '(no text)' / 'unassigned' auto-promoted quick-fixes with no real content.
+ *
+ * The script is a top-level-executing CLI (queries Supabase on import), so this is a
+ * network-free source-level pin (matches the fleet-dashboard-*.test.js pattern) rather
+ * than an executed unit test — it asserts the fallback chains are present in source.
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, '../../scripts/promote-retro-action-items.mjs'), 'utf8');
+
+function functionBody(startMarker) {
+  const start = SRC.indexOf(startMarker);
+  expect(start).toBeGreaterThan(-1);
+  const rest = SRC.slice(start + 1);
+  const nextFn = rest.search(/\nfunction /);
+  return nextFn === -1 ? rest : rest.slice(0, nextFn);
+}
+
+// Re-implement the exact fallback logic inline (the script has no exports to import
+// without triggering its top-level Supabase query) to assert behavior, not just text.
+function actionText(item) {
+  return item.item || item.action || item.title || '(no text)';
+}
+function actionOwner(item) {
+  return item.owner || item.owner_role || 'unassigned';
+}
+
+describe('QF-20260711-253: actionText/actionOwner cover all 3 known action_items shapes', () => {
+  it('source references item.title as a fallback (the third shape)', () => {
+    const body = functionBody('function actionText(');
+    expect(body).toMatch(/item\.title/);
+  });
+
+  it('source references item.owner_role as a fallback for owner display', () => {
+    expect(SRC).toMatch(/owner_role/);
+  });
+
+  it('shape 1 (retro-agent prompt-driven: item/owner) resolves correctly', () => {
+    const row = { item: 'Do the thing', owner: 'PLAN', priority: 'high' };
+    expect(actionText(row)).toBe('Do the thing');
+    expect(actionOwner(row)).toBe('PLAN');
+  });
+
+  it('shape 2 (generateSmartActionItems: action/owner) resolves correctly', () => {
+    const row = { action: 'Fix the widget', owner: 'EXEC', priority: 'high' };
+    expect(actionText(row)).toBe('Fix the widget');
+    expect(actionOwner(row)).toBe('EXEC');
+  });
+
+  it('shape 3 (manually-authored SD_COMPLETION: title/owner_role) resolves correctly — the QF-20260711-253 bug', () => {
+    const row = { title: 'Enumerate producers explicitly', owner_role: 'PLAN', priority: 'high' };
+    expect(actionText(row)).toBe('Enumerate producers explicitly');
+    expect(actionOwner(row)).toBe('PLAN');
+  });
+
+  it('no shape matched falls back to the placeholder, not a throw', () => {
+    expect(actionText({ priority: 'high' })).toBe('(no text)');
+    expect(actionOwner({ priority: 'high' })).toBe('unassigned');
+  });
+});


### PR DESCRIPTION
## Summary
- `actionText()`/`actionOwner()` in `scripts/promote-retro-action-items.mjs` only handled 2 of 3 known `retrospectives.action_items` shapes, silently producing `(no text)`/`unassigned` placeholders in auto-promoted quick-fixes when the retrospective used `{title, description, owner_role}` instead of `{item, owner}` or `{action, owner}`.
- This is the exact bug that produced QF-20260711-253's own garbled description. Fixed the fallback chains; QF-20260711-253's own stored description has been corrected directly in the DB to reflect the real action items.

## Test plan
- [x] New `tests/unit/promote-retro-action-items-field-fallback.test.js` — 6/6 passing (source-level pins + inline re-implementation covering all 3 known shapes, plus a no-match-falls-back-safely case)
- [x] Smoke suite 15/15
- [x] Dry-run smoke test of the actual script confirms no syntax errors / crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)