### PR TITLE
fix(QF-20260711-815): promote-retro-action-items.mjs actionText/owner field mismatch

### DIFF
--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -36,12 +36,12 @@ const supabase = createClient(
 const cutoff = new Date(Date.now() - LOOKBACK_DAYS * 24 * 3600 * 1000).toISOString();
 
 // Two shapes exist in the wild: the retro-agent's prompt-driven output uses
-// { item, owner, priority }; lib/sub-agents/retro/action-items.js's programmatic
-// generateSmartActionItems() uses { action, owner, deadline, success_criteria,
-// priority, source }. Support both rather than picking one and silently dropping
-// the other's text.
+// { item, owner, priority }; the real retrospectives.action_items schema (both
+// lib/sub-agents/retro/action-items.js's generateSmartActionItems() and hand-authored
+// retro rows) uses { title, description, owner_role, priority }. Support all three
+// rather than picking one and silently dropping the other's text.
 function actionText(item) {
-  return item.item || item.action || '(no text)';
+  return item.title || item.item || item.action || item.description || '(no text)';
 }
 
 const { data: retros, error } = await supabase
@@ -84,7 +84,7 @@ for (const retro of retros || []) {
   const title = `[Retro action items] ${retro.sd_id || retro.title || retro.id}`.slice(0, 100);
   const description = [
     `Auto-promoted from ${highPriority.length} high-priority action item(s) in retrospective ${retro.id} (SD ${retro.sd_id || 'n/a'}).`,
-    ...highPriority.map((i, idx) => `${idx + 1}. ${actionText(i)} (owner: ${i.owner || 'unassigned'}, success criteria: ${i.success_criteria || 'n/a'})`)
+    ...highPriority.map((i, idx) => `${idx + 1}. ${actionText(i)} (owner: ${i.owner_role || i.owner || 'unassigned'}, success criteria: ${i.success_criteria || 'n/a'})`)
   ].join('\n');
 
   try {


### PR DESCRIPTION
## Summary
- `actionText(item)` only checked `item.item`/`item.action`, but the real `retrospectives.action_items` schema uses `item.title`/`item.description`, so every auto-promoted QF description showed a literal "(no text)".
- The description-builder referenced `i.owner` only; now falls back through `i.owner_role` (the real schema's field) first.

## Evidence
- QF-20260711-607 was auto-promoted from a real-schema retro (`e652fcf8-c0f0-4519-9082-b573f16ede97`) and both its action items rendered as "(no text) (owner: unassigned, success criteria: n/a)" — confirmed via `node scripts/read-quick-fix.js QF-20260711-607`.
- Manually verified the fixed `actionText()` against all three known `action_items` shapes (prompt-driven `{item, owner}`, programmatic `{action, owner, success_criteria}`, real schema `{title, description, owner_role}`) plus the true-empty case (still honestly falls back to "(no text)").

## Test plan
- [x] Manual verification of `actionText()` logic against all 3 known shapes + empty case
- [x] Pre-commit smoke suite passed (15/15)
- [x] Tier 1 QF (12 LOC changed), compliance auto-approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)