### PR TITLE
fix(QF-20260711-711): guard promote-retro-action-items.mjs against synthetic test-fixture retrospectives

### DIFF
--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -67,9 +67,21 @@ let promoted = 0;
 let skippedAlreadyPromoted = 0;
 let skippedNoHighPriority = 0;
 
+let skippedTestFixture = 0;
+
 for (const retro of retros || []) {
   if (retro.metadata?.action_items_promoted) {
     skippedAlreadyPromoted++;
+    continue;
+  }
+
+  // QF-20260711-711: tests/integration/harness-backlog-drain-policy.db.test.js seeds
+  // fixture rows straight into this same production table (no isolated test schema
+  // exists). A leaked, un-cleaned fixture was scanned by this script's daily --apply
+  // cron and promoted into a real QF from placeholder text. Reject known-synthetic
+  // rows defensively here so a future test-cleanup failure can't repeat that.
+  if (retro.metadata?.test_fixture || retro.title === 'Test retrospective') {
+    skippedTestFixture++;
     continue;
   }
 
@@ -115,4 +127,4 @@ for (const retro of retros || []) {
   }
 }
 
-console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedNoHighPriority} with no high-priority items.`);
+console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedTestFixture} test-fixture, ${skippedNoHighPriority} with no high-priority items.`);

--- a/tests/integration/harness-backlog-drain-policy.db.test.js
+++ b/tests/integration/harness-backlog-drain-policy.db.test.js
@@ -57,7 +57,11 @@ async function seedRetro(overrides = {}) {
       retro_type: overrides.retro_type || 'SD_COMPLETION',
       learning_category: overrides.learning_category || 'PROCESS_IMPROVEMENT',
       action_items: overrides.action_items || [],
-      metadata: overrides.metadata || {},
+      // QF-20260711-711: this seeds directly into the shared production table (no
+      // isolated test schema). Marking rows as test fixtures lets
+      // promote-retro-action-items.mjs defensively exclude them even if this
+      // teardown ever fails to clean up again.
+      metadata: { ...(overrides.metadata || {}), test_fixture: true },
       target_application: overrides.target_application || 'EHG_Engineer',
       status: 'DRAFT',
     })
@@ -71,10 +75,19 @@ async function seedRetro(overrides = {}) {
 describeDb('Harness-backlog drain policy (live DB)', () => {
   afterEach(async () => {
     if (seededIds.length > 0) {
-      await db.from('feedback').delete().in('id', seededIds.splice(0, seededIds.length));
+      const { error } = await db.from('feedback').delete().in('id', seededIds.splice(0, seededIds.length));
+      if (error) throw new Error(`teardown: feedback cleanup failed: ${JSON.stringify(error)}`);
     }
     if (seededRetroIds.length > 0) {
-      await db.from('retrospectives').delete().in('id', seededRetroIds.splice(0, seededRetroIds.length));
+      const ids = seededRetroIds.splice(0, seededRetroIds.length);
+      // retrospectives_audit has an AFTER INSERT trigger + an ON DELETE NO ACTION FK
+      // back to retrospectives (unlike its CASCADE sibling FKs), so the parent delete
+      // below 23503s unless its own audit children are cleared first (QF-20260711-711
+      // RCA: this is exactly why 14 fixture rows silently survived 7 prior runs).
+      const { error: auditError } = await db.from('retrospectives_audit').delete().in('retrospective_id', ids);
+      if (auditError) throw new Error(`teardown: retrospectives_audit cleanup failed: ${JSON.stringify(auditError)}`);
+      const { error } = await db.from('retrospectives').delete().in('id', ids);
+      if (error) throw new Error(`teardown: retrospectives cleanup failed: ${JSON.stringify(error)}`);
     }
   });
 

--- a/tests/unit/promote-retro-action-items-synthetic-guard.test.js
+++ b/tests/unit/promote-retro-action-items-synthetic-guard.test.js
@@ -1,0 +1,44 @@
+/**
+ * QF-20260711-711 — promote-retro-action-items.mjs's daily --apply cron scanned the
+ * live retrospectives table with no guard against synthetic/test rows. An integration
+ * test's leaked "Test retrospective" fixture (tests/integration/harness-backlog-drain-policy.db.test.js
+ * seeds directly into the shared production table) was promoted into a real QF built
+ * from placeholder action-item text ("Do the important thing").
+ *
+ * Same network-free source-pin approach as promote-retro-action-items-field-fallback.test.js
+ * (the script top-level-queries Supabase on import, so it has no importable exports).
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, '../../scripts/promote-retro-action-items.mjs'), 'utf8');
+
+// Re-implement the exact guard predicate inline to assert behavior, not just text.
+function isSyntheticFixture(retro) {
+  return Boolean(retro.metadata?.test_fixture || retro.title === 'Test retrospective');
+}
+
+describe('QF-20260711-711: promoter rejects synthetic/test-fixture retro rows', () => {
+  it('source checks metadata.test_fixture before promoting', () => {
+    expect(SRC).toMatch(/metadata\?\.test_fixture/);
+  });
+
+  it('source checks the exact leaked fixture title as a belt-and-suspenders guard', () => {
+    expect(SRC).toMatch(/title === 'Test retrospective'/);
+  });
+
+  it('a row with metadata.test_fixture=true is rejected', () => {
+    expect(isSyntheticFixture({ title: 'Anything', metadata: { test_fixture: true } })).toBe(true);
+  });
+
+  it('a row titled exactly "Test retrospective" is rejected even without the metadata marker', () => {
+    expect(isSyntheticFixture({ title: 'Test retrospective', metadata: {} })).toBe(true);
+  });
+
+  it('a real retrospective row is not rejected', () => {
+    expect(isSyntheticFixture({ title: 'LEAD_TO_PLAN Handoff Retrospective: real work', metadata: {} })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- RCA: an integration test's retrospectives fixture (`tests/integration/harness-backlog-drain-policy.db.test.js`) leaks directly into the shared production table because its `afterEach` teardown silently swallows a Postgres FK error (`retrospectives_audit`'s `ON DELETE NO ACTION` FK + an `AFTER DELETE` audit trigger that self-violates it). A leaked fixture was scanned by the daily `promote-retro-action-items.mjs --apply` cron 8 hours later and promoted into a real quick-fix built from placeholder text ("Do the important thing").
- `scripts/promote-retro-action-items.mjs` now rejects rows carrying `metadata.test_fixture` or the exact leaked title `"Test retrospective"` before promoting — the load-bearing guard.
- `seedRetro()` now stamps `metadata.test_fixture=true`; `afterEach` now checks delete errors (fail-loud) and clears `retrospectives_audit` children before deleting the parent row.
- New `tests/unit/promote-retro-action-items-synthetic-guard.test.js`, mutation-verified against pre-fix source.
- Operationally: quarantined the 14 already-leaked prod rows via the same `metadata.test_fixture=true` marker (data-only, no schema change) and corrected `QF-20260711-711`'s own auto-generated placeholder title/description to describe the real fix.
- Deferred to harness-backlog (schema-scoped, out of QF tier): the underlying `retrospectives_audit` FK should be `ON DELETE CASCADE` so `retrospectives` rows are deletable again — that needs a real migration SD, not attempted here.

## Test plan
- [x] `npx vitest run tests/unit/promote-retro-action-items-synthetic-guard.test.js tests/unit/promote-retro-action-items-field-fallback.test.js` — 11/11 passing
- [x] Mutation-verified: stashing the guard fails 2/5 new tests against pre-fix source, confirming the tests actually pin the new behavior
- [x] Live dry-run of `node scripts/promote-retro-action-items.mjs` confirms the 6 remaining quarantined fixtures are now skipped (`6 test-fixture` in the summary line) while real retro items still surface correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)