### PR TITLE
fix(QF-20260711-977): s1-backlog-sweep retro action-item text extraction was un-synced with an already-fixed sibling

### DIFF
--- a/scripts/one-off/s1-backlog-sweep.mjs
+++ b/scripts/one-off/s1-backlog-sweep.mjs
@@ -231,6 +231,24 @@ function promoteGroup(group) {
   return { title, sourceIds };
 }
 
+// QF-20260711-977: three action_items shapes exist in the wild -- the retro-agent's
+// prompt-driven output uses { item, owner, priority }; generateSmartActionItems() uses
+// { action, owner, deadline, success_criteria, priority, source }; a manually-authored
+// SD_COMPLETION retrospective uses { title, description, owner_role, priority }. The
+// original inline `i.item || i.action || '(no text)'` never checked the third shape's
+// `.title`, so every manually-authored retro's action items promoted as literal
+// "(no text)" / "(owner: unassigned)" text. Mirrors the already-fixed
+// scripts/promote-retro-action-items.mjs actionText()/actionOwner() (QF-20260711-253)
+// -- that script has no exports (plain top-level script, not a module), so ported here
+// rather than refactored across files.
+export function actionText(item) {
+  return item.item || item.action || item.title || '(no text)';
+}
+
+export function actionOwner(item) {
+  return item.owner || item.owner_role || 'unassigned';
+}
+
 /** FR-4(a) — retro action-item fold-in: promote-retro-action-items.mjs's shape, unwindowed. */
 export async function foldInRetroActionItems(supabase, { dryRun = true } = {}) {
   const { data: retros, error } = await supabase
@@ -251,7 +269,7 @@ export async function foldInRetroActionItems(supabase, { dryRun = true } = {}) {
     const title = `[Retro action items] ${retro.sd_id || retro.title || retro.id}`.slice(0, 100);
     const description = [
       `Auto-promoted by S1 sweep from ${highPriority.length} high-priority action item(s) in retrospective ${retro.id} (SD ${retro.sd_id || 'n/a'}).`,
-      ...highPriority.map((i, idx) => `${idx + 1}. ${i.item || i.action || '(no text)'} (owner: ${i.owner || 'unassigned'})`),
+      ...highPriority.map((i, idx) => `${idx + 1}. ${actionText(i)} (owner: ${actionOwner(i)})`),
     ].join('\n');
     const cliArgs = ['scripts/create-quick-fix.js', '--title', title, '--type', 'bug', '--severity', 'medium', '--description', description];
     if (retro.target_application) cliArgs.push('--target-application', retro.target_application);

--- a/tests/unit/one-off/s1-backlog-sweep.test.js
+++ b/tests/unit/one-off/s1-backlog-sweep.test.js
@@ -23,6 +23,8 @@ import {
   runSweep,
   SIBLING_CLAIMED_IDS,
   PROMOTION_THRESHOLD,
+  actionText,
+  actionOwner,
 } from '../../../scripts/one-off/s1-backlog-sweep.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -342,6 +344,30 @@ describe('TS-10: retro action-item and flag_review fold-ins', () => {
     expect(result.promoted).toBe(0); // dry-run never increments promoted
     expect(result.noHighPriority).toBe(1);
     expect(result.skipped).toBe(1);
+  });
+
+  // QF-20260711-977: three action_items shapes exist in the wild. The original inline
+  // `i.item || i.action || '(no text)'` never checked the third (manually-authored
+  // SD_COMPLETION retro) shape's `.title`, so every such retro's action items promoted
+  // as literal "(no text)" / "(owner: unassigned)". Mirrors the already-fixed
+  // scripts/promote-retro-action-items.mjs (QF-20260711-253).
+  describe('actionText / actionOwner — all three known action_items shapes', () => {
+    it('retro-agent prompt-driven shape { item, owner }', () => {
+      expect(actionText({ item: 'do the thing', owner: 'a', priority: 'high' })).toBe('do the thing');
+      expect(actionOwner({ item: 'do the thing', owner: 'a', priority: 'high' })).toBe('a');
+    });
+    it('generateSmartActionItems shape { action, owner }', () => {
+      expect(actionText({ action: 'do the other thing', owner: 'b', priority: 'high' })).toBe('do the other thing');
+      expect(actionOwner({ action: 'do the other thing', owner: 'b', priority: 'high' })).toBe('b');
+    });
+    it('manually-authored SD_COMPLETION shape { title, owner_role } — the previously-broken case', () => {
+      expect(actionText({ title: 'Read source before finalizing scope', owner_role: 'PLAN', priority: 'high' })).toBe('Read source before finalizing scope');
+      expect(actionOwner({ title: 'Read source before finalizing scope', owner_role: 'PLAN', priority: 'high' })).toBe('PLAN');
+    });
+    it('falls back to the literal placeholders only when NO known field is present', () => {
+      expect(actionText({ priority: 'high' })).toBe('(no text)');
+      expect(actionOwner({ priority: 'high' })).toBe('unassigned');
+    });
   });
 
   it('foldInFlagReviewRows only ever calls defer (never approve/reject) and only on corroborated matches', async () => {


### PR DESCRIPTION
## Summary
- `s1-backlog-sweep.mjs`'s `foldInRetroActionItems()` had an inline `i.item || i.action || '(no text)'` text extractor that never checked the third known `action_items` shape's `.title` field (manually-authored `SD_COMPLETION` retros use `{title, description, owner_role, priority}`) — so every such retro's high-priority action items promoted into a QF with literal `"(no text)"` / `"(owner: unassigned)"` text.
- This is precisely what happened to this QF's own creation (QF-20260711-977, promoted from the S1-sweep's own retrospective).
- The sibling script `scripts/promote-retro-action-items.mjs` already fixed this exact bug (per QF-20260711-253, via `actionText()`/`actionOwner()` helpers checking all three known shapes), but `s1-backlog-sweep.mjs`'s duplicate inline implementation was never synced to match.
- Ported the same two helpers (the sibling script has no exports to import from — it's a plain top-level script) and exported them from `s1-backlog-sweep.mjs` for direct unit testing.
- This QF's own malformed title/description was separately corrected via a direct data update citing the real retrospective content, so it's actually usable if anyone reviews it later.

## Test plan
- `npx vitest run tests/unit/one-off/s1-backlog-sweep.test.js` → 23/23 pass (19 original + 4 new)
- New tests pin all three known `action_items` shapes (`{item,owner}`, `{action,owner}`, `{title,owner_role}` — the previously-broken case) plus the no-known-field fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)