### PR TITLE
fix(QF-20260711-895): promote-retro-action-items.mjs drops a 4th action_items text shape

### DIFF
--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -35,16 +35,19 @@ const supabase = createClient(
 
 const cutoff = new Date(Date.now() - LOOKBACK_DAYS * 24 * 3600 * 1000).toISOString();
 
-// Three shapes exist in the wild: the retro-agent's prompt-driven output uses
+// Four shapes exist in the wild: the retro-agent's prompt-driven output uses
 // { item, owner, priority }; lib/sub-agents/retro/action-items.js's programmatic
 // generateSmartActionItems() uses { action, owner, deadline, success_criteria,
 // priority, source }; a manually-authored SD_COMPLETION retrospective (e.g. via
 // scripts/one-off/insert-retro-*.cjs) uses { title, description, owner_role,
 // priority } (QF-20260711-253: '(no text)'/'unassigned' auto-promoted because
-// this third shape wasn't covered). Support all three rather than silently
-// dropping text/owner for whichever shape isn't checked.
+// this third shape wasn't covered); a fourth shape, { text, category, priority }
+// (e.g. PLAN_VERIFICATION retrospectives), also promoted as '(no text)' until
+// QF-20260711-895 added it here. Support all four rather than silently dropping
+// text/owner for whichever shape isn't checked -- if a fifth shape appears,
+// add it here too, not a one-off patch on the promoted QF.
 function actionText(item) {
-  return item.item || item.action || item.title || '(no text)';
+  return item.item || item.action || item.title || item.text || '(no text)';
 }
 
 function actionOwner(item) {

--- a/tests/unit/promote-retro-action-items-field-fallback.test.js
+++ b/tests/unit/promote-retro-action-items-field-fallback.test.js
@@ -27,13 +27,13 @@ function functionBody(startMarker) {
 // Re-implement the exact fallback logic inline (the script has no exports to import
 // without triggering its top-level Supabase query) to assert behavior, not just text.
 function actionText(item) {
-  return item.item || item.action || item.title || '(no text)';
+  return item.item || item.action || item.title || item.text || '(no text)';
 }
 function actionOwner(item) {
   return item.owner || item.owner_role || 'unassigned';
 }
 
-describe('QF-20260711-253: actionText/actionOwner cover all 3 known action_items shapes', () => {
+describe('QF-20260711-253 / QF-20260711-895: actionText/actionOwner cover all 4 known action_items shapes', () => {
   it('source references item.title as a fallback (the third shape)', () => {
     const body = functionBody('function actionText(');
     expect(body).toMatch(/item\.title/);
@@ -59,6 +59,17 @@ describe('QF-20260711-253: actionText/actionOwner cover all 3 known action_items
     const row = { title: 'Enumerate producers explicitly', owner_role: 'PLAN', priority: 'high' };
     expect(actionText(row)).toBe('Enumerate producers explicitly');
     expect(actionOwner(row)).toBe('PLAN');
+  });
+
+  it('shape 4 (PLAN_VERIFICATION retrospective: text/category) resolves correctly — the QF-20260711-895 bug', () => {
+    const row = { text: 'Run schema-reference-lint as a pre-push habit', category: 'PROCESS', priority: 'high' };
+    expect(actionText(row)).toBe('Run schema-reference-lint as a pre-push habit');
+    expect(actionOwner(row)).toBe('unassigned'); // shape 4 carries no owner field at all — correct fallback
+  });
+
+  it('source references item.text as a fallback (the fourth shape)', () => {
+    const body = functionBody('function actionText(');
+    expect(body).toMatch(/item\.text/);
   });
 
   it('no shape matched falls back to the placeholder, not a throw', () => {


### PR DESCRIPTION
## Summary
This QF was itself auto-promoted with both action items showing `(no text)` — a live repro of the exact bug it fixes.

- The source retrospective (`2aa7c579-e2b3-4e35-89ea-cf779e7fd107`, SD-LEO-INFRA-OPERATOR-RUNWAY-TRUTHFULNESS-001) uses a 4th `action_items` shape not covered by `actionText()`'s fallback chain: `{ text, category, priority }` (PLAN_VERIFICATION retrospectives), alongside the 3 shapes already covered by QF-20260711-253's fix.
- Added `item.text` to the fallback chain and a regression test.
- Signaled to the coordinator: this is the 3rd recurrence of this exact bug class on this file (QF-20260711-253, QF-20260711-711, this one) — worth a schema-level fix (normalize `action_items` shape at write time) rather than continuing to patch the reader reactively.

## Test plan
- [x] `npx vitest run tests/unit/promote-retro-action-items-field-fallback.test.js tests/unit/promote-retro-action-items-synthetic-guard.test.js` — 13/13 passing
- [x] Verified the new test fails without the fix (reverted `item.text`, confirmed red), passes with it
- [x] LOC threshold gate passed (26 lines, below cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)