### PR TITLE
test(QF-20260711-722): pin classifyInboxMessage delivered_at-not-read_at for DIRECTIVE_KINDS

### DIFF
--- a/tests/unit/coordination-inbox-read-ack-split.test.js
+++ b/tests/unit/coordination-inbox-read-ack-split.test.js
@@ -15,6 +15,17 @@ describe('classifyInboxMessage', () => {
     expect(v).toEqual({ skip: false, markRead: false, markAck: false });
   });
 
+  // Retro action item (SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001, retrospective
+  // 887c2da7-f966-45d3-a7af-98110844cfb1): pin the core incident-fix invariant directly —
+  // a DIRECTIVE_KINDS row (payload.kind in the shared allowlist) must stamp delivered_at
+  // (transport receipt) on first poll, NEVER read_at, so the coordinator's hard-wake check
+  // (which gates on read_at IS NULL) is never defeated by a poll that merely saw the row
+  // exist. This is what caused the 2026-07-09 25-minute chairman-directive silence.
+  it('a DIRECTIVE_KINDS row (payload.kind=coordinator_request) stamps delivered_at, never read_at, on first poll', () => {
+    const v = classifyInboxMessage({ message_type: 'INFO', payload: { kind: 'coordinator_request' } }, { isIdle: true });
+    expect(v).toEqual({ skip: false, markRead: false, markDelivered: true, markAck: false });
+  });
+
   it('a plain INFO notification is now READ-ONLY drained on poll (read_at only; ack withheld for /checkin)', () => {
     // SD-LEO-INFRA-WORKER-INBOX-PUSH-DELIVERY-001: coordinator INFO push is delivered by the worker
     // /checkin loop (coordinator_messages[], filters acknowledged_at IS NULL), so the poll must NOT


### PR DESCRIPTION
## Summary
Retro action item (SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001, retrospective `887c2da7-f966-45d3-a7af-98110844cfb1`, priority=high). Existing coverage in `tests/unit/coordination-inbox-read-ack-split.test.js` exercised `classifyInboxMessage` broadly but no test case constructed `payload.kind` as an actual `DIRECTIVE_KINDS` value (e.g. `coordinator_request`) — missing the exact branch this incident-fix invariant lives in (`coordination-inbox.cjs` line ~191). Adds one direct test asserting `markDelivered:true` / `markRead:false` for a real `DIRECTIVE_KINDS` value, closing the literal gap the retro flagged.

A second high-priority item from the same retro (audit other unactioned-detection logic for the broadcast-vs-session-targeted lane gap, owner=PLAN) is broader audit-class work beyond a quick-fix LOC budget — left in the source retrospective for a dedicated follow-up, not attempted here.

## Test plan
- [x] `npx vitest run tests/unit/coordination-inbox-read-ack-split.test.js` — 14/14 passing (13 pre-existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)