### PR TITLE
fix(SD-LEO-FIX-RETRO-ACTION-ITEMS-001): reserve stage 16 from auto-approve, stop silent chairman-gate error swallowing

### DIFF
--- a/lib/eva/autonomy-model.js
+++ b/lib/eva/autonomy-model.js
@@ -49,7 +49,12 @@ export const GATE_BEHAVIOR_MATRIX = {
 // has RESERVED as always-manual. A reserved stage must NEVER auto-approve regardless of autonomy
 // level (L0-L4), gate-type classification, or chairman autonomy override. This set is the durable,
 // classification-INDEPENDENT backstop — FR-3's gate-type correction is defense-in-depth behind it.
-export const RESERVED_CHAIRMAN_STAGES = new Set([3, 5, 10, 17, 18, 19]);
+// SD-LEO-FIX-RETRO-ACTION-ITEMS-001: added 16 (Blueprint->Build) — the DB trigger
+// reject_s16_programmatic_approval already unconditionally rejects a stage-16 programmatic
+// approval; this set was the one place that fact wasn't reflected, letting autonomy classify
+// stage 16 as auto_approve-able only for the RPC call to then fail (silently, at the two call
+// sites fixed alongside this — see eva-orchestrator.js and stage-execution-worker.js).
+export const RESERVED_CHAIRMAN_STAGES = new Set([3, 5, 10, 16, 17, 18, 19]);
 
 /**
  * Check autonomy level for a venture and determine gate action.

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -673,25 +673,39 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       // SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001: resolve via the canonical path
       // (fn_chairman_decide) so all paths write the identical (status, decision, blocking) triple.
       // p_force_stale=true — fresh same-pass autonomous resolve.
-      await supabase.rpc('fn_chairman_decide', {
+      const { error: approveError } = await supabase.rpc('fn_chairman_decide', {
         p_decision_id: hookContext.chairmanDecisionId,
         p_action: 'approved',
         p_decided_by: `auto-orchestrator-${autonomy.level}`,
         p_rationale: `Auto-approved (${autonomy.level} autonomy)`,
         p_force_stale: true,
       });
-      stageOutput.chairmanGate = {
-        status: 'approved',
-        rationale: `Auto-approved (${autonomy.level} autonomy)`,
-        decision_id: hookContext.chairmanDecisionId,
-      };
-      // Also patch into artifact payloads
-      for (const art of artifacts) {
-        if (art.payload && typeof art.payload === 'object') {
-          art.payload.chairmanGate = stageOutput.chairmanGate;
+      // SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-2): the RPC's error was previously never checked, so
+      // a DB-side rejection (e.g. reject_s16_programmatic_approval) was silently swallowed and the
+      // gate was marked approved anyway -- a code/DB state divergence. Only mark approved when the
+      // RPC actually succeeded.
+      if (approveError) {
+        logger.warn(`   Chairman gate auto-approve RPC failed: ${approveError.message}`);
+        stageOutput.chairmanGate = { status: 'pending', decision_id: hookContext.chairmanDecisionId, error: approveError.message };
+        for (const art of artifacts) {
+          if (art.payload && typeof art.payload === 'object') {
+            art.payload.chairmanGate = stageOutput.chairmanGate;
+          }
         }
+      } else {
+        stageOutput.chairmanGate = {
+          status: 'approved',
+          rationale: `Auto-approved (${autonomy.level} autonomy)`,
+          decision_id: hookContext.chairmanDecisionId,
+        };
+        // Also patch into artifact payloads
+        for (const art of artifacts) {
+          if (art.payload && typeof art.payload === 'object') {
+            art.payload.chairmanGate = stageOutput.chairmanGate;
+          }
+        }
+        logger.log(`   Chairman gate auto-approved (${autonomy.level})`);
       }
-      logger.log(`   Chairman gate auto-approved (${autonomy.level})`);
     } else {
       try {
         // CronPulse RCA #6: Single DB check instead of 5s polling (reduces noisy timeouts)

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -937,9 +937,13 @@ export class StageExecutionWorker {
                 p_force_stale: true,
               });
               if (_approveErr) {
-                this._logger.warn(`[Worker] Stage ${currentStage} canonical auto-approve failed (non-fatal): ${_approveErr.message}`);
-              }
-
+                // SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-3): previously this only logged and still
+                // advanced the stage as though approved -- a code/DB state divergence when the RPC
+                // (e.g. reject_s16_programmatic_approval) rejected it. Do NOT advance; fall through
+                // to the same still-pending handling used when shouldAutoApprove is false, so the
+                // decision is retried on the next poll instead of the worker believing it advanced.
+                this._logger.warn(`[Worker] Stage ${currentStage} canonical auto-approve failed — NOT advancing (will retry as pending): ${_approveErr.message}`);
+              } else {
               // Enrich existing artifact with promotion_gate if missing (build-loop stages).
               // The pending-decision shortcut skips processStage(), so promotion_gate
               // may not have been computed. evaluatePromotionGate is pure/algorithmic.
@@ -983,6 +987,7 @@ export class StageExecutionWorker {
               }
               currentStage = nextStage;
               continue;
+              }
             }
 
             // SD-REPLIT-PIPELINE-S20S26-REDESIGN-ORCH-001-B-A: Backfill advisory_data

--- a/tests/unit/eva/autonomy-reserved-gates.test.js
+++ b/tests/unit/eva/autonomy-reserved-gates.test.js
@@ -27,11 +27,19 @@ function mockSb(level) {
   };
 }
 
-const RESERVED = [3, 5, 10, 17, 18, 19];
+const RESERVED = [3, 5, 10, 16, 17, 18, 19];
 
 describe('RESERVED_CHAIRMAN_STAGES (FR-1)', () => {
-  it('contains exactly the chairman-reserved stages 3,5,10,17,18,19', () => {
+  it('contains exactly the chairman-reserved stages 3,5,10,16,17,18,19', () => {
     expect([...RESERVED_CHAIRMAN_STAGES].sort((a, b) => a - b)).toEqual(RESERVED);
+  });
+
+  // SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-1): stage 16 (Blueprint->Build) is reserved because the
+  // DB trigger reject_s16_programmatic_approval already unconditionally rejects a stage-16
+  // programmatic approval -- the reserved set previously didn't reflect that, letting autonomy
+  // classify stage 16 as auto_approve-able only for the RPC to then fail.
+  it('stage 16 is reserved', () => {
+    expect(RESERVED_CHAIRMAN_STAGES.has(16)).toBe(true);
   });
 });
 
@@ -52,8 +60,8 @@ describe('checkAutonomy reserved-stage backstop (FR-1)', () => {
     }
   });
 
-  it('non-reserved stage 16 at L4 is unaffected (normal matrix → auto_approve)', async () => {
-    const r = await checkAutonomy('v1', 'stage_gate', { supabase: mockSb('L4') }, 16);
+  it('non-reserved stage 20 at L4 is unaffected (normal matrix → auto_approve)', async () => {
+    const r = await checkAutonomy('v1', 'stage_gate', { supabase: mockSb('L4') }, 20);
     expect(r.action).toBe('auto_approve');
     expect(r.reserved).toBeUndefined();
   });
@@ -80,7 +88,7 @@ describe('autonomyPreCheck reserved beats chairman override (FR-1)', () => {
   });
 
   it('a non-reserved stage still honors the chairman override', async () => {
-    const r = await autonomyPreCheck('v1', 'stage_gate', overrideDeps, 16);
+    const r = await autonomyPreCheck('v1', 'stage_gate', overrideDeps, 20);
     expect(r.action).toBe('auto_approve'); // L4 override → stage_gate auto_approve
     expect(r.overridden).toBe(true);
   });
@@ -131,7 +139,10 @@ describe('stage-governance gate-type resolution (FR-2b / FR-3)', () => {
     _resetCacheForTest();
     const gov = await getStageGovernance(mockGovSb(ROWS));
     expect(gov.isReserved(18)).toBe(true);
-    expect(gov.isReserved(16)).toBe(false);
-    expect([...gov.reservedStages].sort((a, b) => a - b)).toEqual([3, 5, 10, 17, 18, 19]);
+    // SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-1): 16 is now reserved (see autonomy-reserved-gates
+    // describe block above) — stage-governance derives reservedStages/isReserved directly from
+    // RESERVED_CHAIRMAN_STAGES, so this must move in lockstep with that fix.
+    expect(gov.isReserved(16)).toBe(true);
+    expect([...gov.reservedStages].sort((a, b) => a - b)).toEqual([3, 5, 10, 16, 17, 18, 19]);
   });
 });

--- a/tests/unit/eva/eva-orchestrator-chairman-gate-rpc-error.test.js
+++ b/tests/unit/eva/eva-orchestrator-chairman-gate-rpc-error.test.js
@@ -1,0 +1,174 @@
+/**
+ * SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-2) — chairman-gate auto-approve RPC error handling
+ * in eva-orchestrator.js processStage().
+ *
+ * Bug: the `if (autonomy.action === 'auto_approve')` branch called
+ * `supabase.rpc('fn_chairman_decide', {...})` WITHOUT capturing the return value, then
+ * unconditionally marked `stageOutput.chairmanGate = { status: 'approved', ... }` (and patched
+ * it into every artifact payload). When the DB trigger reject_s16_programmatic_approval (or any
+ * other DB-side rejection) returned an error, it was silently swallowed and the gate was marked
+ * approved anyway — a code/DB state divergence (code believes "approved", DB row stays "pending").
+ *
+ * Fix: destructure `{ error: approveError }`; on a truthy error, log a warning and set
+ * chairmanGate to `{ status: 'pending', decision_id, error }` instead of approved. The success
+ * path (no error) is unchanged.
+ *
+ * These tests drive the REAL processStage() with the chairman gate armed (onBeforeAnalysis returns
+ * a chairmanDecisionId + autonomyPreCheck → auto_approve) and assert the two RPC outcomes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mirror the mocks from tests/unit/eva/eva-orchestrator.test.js so the same minimal harness works.
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+
+vi.mock('../../../lib/eva/dependency-manager.js', () => ({
+  checkDependencies: vi.fn().mockResolvedValue([]),
+  getDependencyGraph: vi.fn().mockResolvedValue({ dependsOn: [], providesTo: [] }),
+  wouldCreateCycle: vi.fn().mockResolvedValue(false),
+  addDependency: vi.fn(),
+  resolveDependency: vi.fn(),
+  removeDependency: vi.fn(),
+  MODULE_VERSION: '1.0.0',
+}));
+
+vi.mock('../../../lib/eva/shared-services.js', async () => {
+  const actual = await vi.importActual('../../../lib/eva/shared-services.js');
+  return { ...actual, emit: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../../lib/eva/devils-advocate.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDevilsAdvocateGate: vi.fn().mockReturnValue({ isGate: false, gateType: null }),
+  getDevilsAdvocateReview: vi.fn(),
+  buildArtifactRecord: vi.fn().mockReturnValue({}),
+}));
+
+// getTemplate supplies the onBeforeAnalysis hook that arms the chairman gate (returns a decision id).
+vi.mock('../../../lib/eva/stage-templates/index.js', () => ({
+  getTemplate: vi.fn(),
+}));
+
+// autonomyPreCheck → auto_approve so the chairman gate (and the downstream stage/reality gates)
+// take the auto-approve path. Spread importOriginal so other consumers keep the real exports.
+vi.mock('../../../lib/eva/autonomy-model.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  autonomyPreCheck: vi.fn(),
+}));
+
+import { processStage, _internal } from '../../../lib/eva/eva-orchestrator.js';
+import { getTemplate } from '../../../lib/eva/stage-templates/index.js';
+import { autonomyPreCheck } from '../../../lib/eva/autonomy-model.js';
+
+const { STATUS } = _internal;
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+
+function createMockSupabase(rpcResult) {
+  const ventureRow = {
+    id: 'v-1', name: 'Test Venture', status: 'active',
+    current_lifecycle_stage: 1, archetype: 'saas',
+    created_at: '2026-01-01', autonomy_level: 'L0',
+  };
+  const mockFrom = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+  };
+  return {
+    from: vi.fn(() => ({ ...mockFrom })),
+    // Only fn_chairman_decide is invoked in the reachable path; return the configured result.
+    rpc: vi.fn(async (fn) => (fn === 'fn_chairman_decide' ? rpcResult : { data: null, error: null })),
+  };
+}
+
+// A single analysis step that yields one artifact with an object payload, so the chairman gate's
+// artifact-patch loop has something to patch and we can assert on result.artifacts[0].payload.
+const artifactStep = {
+  id: 'produce-artifact',
+  artifactType: 'test_output',
+  execute: async () => ({ artifactType: 'test_output', payload: { score: 7, cost: 100 }, source: 'test-step' }),
+};
+
+function runChairmanGateStage(mockSupabase) {
+  return processStage(
+    { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [artifactStep] } } },
+    {
+      supabase: mockSupabase,
+      logger: silentLogger,
+      evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+      evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true, status: 'PASS' }),
+      validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+    },
+  );
+}
+
+describe('processStage chairman-gate auto-approve RPC error handling (FR-2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Arm the chairman gate: onBeforeAnalysis returns a decision id.
+    getTemplate.mockReturnValue({
+      onBeforeAnalysis: async () => ({ chairmanDecisionId: 'dec-1' }),
+    });
+    autonomyPreCheck.mockResolvedValue({ action: 'auto_approve', level: 'L3' });
+  });
+
+  it('RPC error → chairmanGate is pending (NOT approved) and carries the error', async () => {
+    const supabase = createMockSupabase({ data: null, error: { message: 'reject_s16_programmatic_approval' } });
+
+    const result = await runChairmanGateStage(supabase);
+
+    // The auto-approve RPC was attempted via the canonical path.
+    expect(supabase.rpc).toHaveBeenCalledWith('fn_chairman_decide', expect.objectContaining({
+      p_decision_id: 'dec-1',
+      p_action: 'approved',
+    }));
+
+    // The gate divergence is closed: a rejected RPC must NOT mark the gate approved.
+    const gate = result.artifacts[0].payload.chairmanGate;
+    expect(gate.status).toBe('pending');
+    expect(gate.status).not.toBe('approved');
+    expect(gate.decision_id).toBe('dec-1');
+    expect(gate.error).toBe('reject_s16_programmatic_approval');
+  });
+
+  it('RPC success → chairmanGate is approved (regression pin, unchanged behavior)', async () => {
+    const supabase = createMockSupabase({ data: { ok: true }, error: null });
+
+    const result = await runChairmanGateStage(supabase);
+
+    expect(supabase.rpc).toHaveBeenCalledWith('fn_chairman_decide', expect.objectContaining({
+      p_decision_id: 'dec-1',
+      p_action: 'approved',
+    }));
+
+    const gate = result.artifacts[0].payload.chairmanGate;
+    expect(gate.status).toBe('approved');
+    expect(gate.decision_id).toBe('dec-1');
+    expect(gate.rationale).toContain('Auto-approved');
+    // Success path never sets an error field.
+    expect(gate.error).toBeUndefined();
+  });
+
+  it('either way the overall stage still COMPLETES (chairman gate does not itself block)', async () => {
+    const errSb = createMockSupabase({ data: null, error: { message: 'reject_s16_programmatic_approval' } });
+    const okSb = createMockSupabase({ data: { ok: true }, error: null });
+
+    const errResult = await runChairmanGateStage(errSb);
+    const okResult = await runChairmanGateStage(okSb);
+
+    expect(errResult.status).toBe(STATUS.COMPLETED);
+    expect(okResult.status).toBe(STATUS.COMPLETED);
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-chairman-gate-rpc-error.test.js
+++ b/tests/unit/eva/stage-execution-worker-chairman-gate-rpc-error.test.js
@@ -1,0 +1,152 @@
+/**
+ * SD-LEO-FIX-RETRO-ACTION-ITEMS-001 (FR-3) — pending-decision auto-approve RPC error handling
+ * in stage-execution-worker.js _processVenture() poll loop.
+ *
+ * Bug: inside the pending-decision auto-approve shortcut, the worker captured
+ * `const { error: _approveErr } = await this._supabase.rpc('fn_chairman_decide', {...})` but only
+ * logged it as a non-fatal warning — execution unconditionally proceeded to `_advanceStage()` and
+ * `continue`d to the next stage regardless of the RPC outcome. When the DB trigger
+ * reject_s16_programmatic_approval (or any other DB-side rejection) rejected the approval, the
+ * worker advanced the venture as though the decision were approved — a code/DB state divergence.
+ *
+ * Fix: the artifact-enrichment + `_advanceStage()` + `continue` logic now runs only in an `else`
+ * branch when `_approveErr` is falsy. On a truthy `_approveErr` the worker logs and falls through
+ * (no `_advanceStage`, no `continue`), landing in the existing still-pending handling so the
+ * decision is retried on the next poll instead of a false advance.
+ *
+ * These tests drive the REAL _processVenture() loop (via processOneStage) for a single stage that
+ * has a pending decision and is eligible for auto-approve, and assert whether _advanceStage runs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn().mockResolvedValue({ acquired: true, lockId: 'lock-1', error: null }),
+  releaseProcessingLock: vi.fn().mockResolvedValue({ released: true }),
+  markCompleted: vi.fn().mockResolvedValue({ completed: true }),
+  getOrchestratorState: vi.fn().mockResolvedValue({ state: 'processing' }),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', COMPLETED: 'completed', KILLED_AT_REALITY_GATE: 'killed_at_reality_gate' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+  createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn(),
+  isFixtureVenture: vi.fn().mockReturnValue(false),
+  fetchVentureForFixtureCheck: vi.fn().mockResolvedValue({ id: 'v-7', name: 'Real Venture', is_demo: false }),
+}));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue({}) }));
+vi.mock('../../../lib/eva/autonomy-model.js', () => ({ checkAutonomy: vi.fn().mockResolvedValue({ action: 'block', level: 'L0' }) }));
+// Force the current stage to be treated as a pre-execution (review) gate so the pending-decision
+// shortcut is reachable — isReview()=true short-circuits the isPreExecGate check.
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn().mockResolvedValue({ isReview: () => true, isBlocking: () => false }),
+}));
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+const STAGE = 7; // non-special stage (not 19/20), STRATEGY mode — avoids the stage-specific guards.
+const PENDING = { id: 'dec-7', status: 'pending' };
+
+/**
+ * Per-table supabase fake. chairman_decisions distinguishes the "already approved?" universal check
+ * (status='approved' → none) from the "pending decision?" shortcut lookup (status='pending' → PENDING).
+ */
+function makeSupabase(rpcResult) {
+  const from = (table) => {
+    if (table === 'ventures') {
+      const chain = {
+        select: () => chain, eq: () => chain, update: () => chain,
+        single: async () => ({ data: { current_lifecycle_stage: STAGE, name: 'V' }, error: null }),
+        maybeSingle: async () => ({ data: { current_lifecycle_stage: STAGE, name: 'V' }, error: null }),
+      };
+      return chain;
+    }
+    if (table === 'chairman_decisions') {
+      let statusFilter = null;
+      const chain = {
+        select: () => chain,
+        eq: (col, val) => { if (col === 'status') statusFilter = val; return chain; },
+        neq: () => chain, limit: () => chain, order: () => chain,
+        maybeSingle: async () => ({ data: statusFilter === 'pending' ? PENDING : null, error: null }),
+        single: async () => ({ data: null, error: null }),
+      };
+      return chain;
+    }
+    if (table === 'venture_stage_work') {
+      // Non-empty advisory_data → the error-path advisory backfill is a no-op (skips _syncStageWork).
+      const chain = {
+        select: () => chain, eq: () => chain, update: () => chain,
+        upsert: async () => ({ data: null, error: null }),
+        maybeSingle: async () => ({ data: { advisory_data: { seeded: true } }, error: null }),
+      };
+      return chain;
+    }
+    const chain = {
+      select: () => chain, eq: () => chain, neq: () => chain, in: () => chain,
+      gt: () => chain, lt: () => chain, order: () => chain, limit: () => chain,
+      update: () => chain,
+      insert: async () => ({ data: null, error: null }),
+      upsert: async () => ({ data: null, error: null }),
+      maybeSingle: async () => ({ data: null, error: null }),
+      single: async () => ({ data: null, error: null }),
+    };
+    return chain;
+  };
+  return {
+    from: vi.fn(from),
+    rpc: vi.fn(async (fn) => (fn === 'fn_chairman_decide' ? rpcResult : { data: null, error: null })),
+  };
+}
+
+function makeWorker(supabase, { advanceStops = false } = {}) {
+  const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999, maxRetries: 0, retryDelayMs: 1 });
+  // Stub the surrounding machinery so the test isolates the pending-decision shortcut branch.
+  worker._checkGovernanceOverride = vi.fn().mockResolvedValue(null);
+  worker._canAutoAdvance = vi.fn().mockResolvedValue(true); // eligible for auto-approve
+  worker._isInHardGateStages = vi.fn().mockResolvedValue(false);
+  worker._syncStageWork = vi.fn().mockResolvedValue(undefined);
+  worker._advanceStage = vi.fn().mockImplementation(async () => {
+    // On the success path, stop the loop after the single advance so it does not cascade.
+    if (advanceStops) worker._running = false;
+    return {}; // not blocked
+  });
+  return worker;
+}
+
+describe('_processVenture pending-decision auto-approve RPC error handling (FR-3)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('RPC error → does NOT call _advanceStage and stays blocked at the same stage', async () => {
+    const supabase = makeSupabase({ data: null, error: { message: 'reject_s16_programmatic_approval' } });
+    const worker = makeWorker(supabase);
+
+    const result = await worker.processOneStage('v-7');
+
+    // The canonical auto-approve RPC was attempted...
+    expect(supabase.rpc).toHaveBeenCalledWith('fn_chairman_decide', expect.objectContaining({
+      p_decision_id: 'dec-7', p_action: 'approved', p_decided_by: 'auto-proceed-worker',
+    }));
+    // ...but the rejection means the venture must NOT advance.
+    expect(worker._advanceStage).not.toHaveBeenCalled();
+    // It falls through to the existing still-pending handling → blocked at the same stage.
+    expect(result.status).toBe('blocked');
+    expect(result.stageId).toBe(STAGE);
+    expect(result.pendingDecisionId).toBe('dec-7');
+  });
+
+  it('RPC success → advances the stage (regression pin, unchanged behavior)', async () => {
+    const supabase = makeSupabase({ data: { ok: true }, error: null });
+    const worker = makeWorker(supabase, { advanceStops: true });
+
+    await worker.processOneStage('v-7');
+
+    expect(supabase.rpc).toHaveBeenCalledWith('fn_chairman_decide', expect.objectContaining({
+      p_decision_id: 'dec-7', p_action: 'approved', p_decided_by: 'auto-proceed-worker',
+    }));
+    // Success → the pending-decision shortcut advances from STAGE to STAGE+1.
+    expect(worker._advanceStage).toHaveBeenCalledTimes(1);
+    expect(worker._advanceStage).toHaveBeenCalledWith(
+      'v-7', STAGE, STAGE + 1, expect.objectContaining({ advancementType: 'auto_approved' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Retro action item (from SD-LEO-FIX-EVA-DECISIONS-CANNOT-001) claimed two files silently omit `decided_by`/`context` on `chairman_decisions` writes. A LEAD-phase RISK sub-agent investigation (evidence `fe8c9f77-fd10-4878-9054-b3bf50acd8c3`, CONDITIONAL_PASS, confidence 88) found the real defect and rejected the literal remedy: widening the `fn_chairman_decide` RPC + `reject_s16_programmatic_approval` trigger allowlist would let autonomous code satisfy the stage-16 (Blueprint→Build) manual-chairman-approval security gate — a regression, not a fix.
- **Root cause**: `lib/eva/autonomy-model.js`'s `RESERVED_CHAIRMAN_STAGES` omitted 16, so autonomy could classify stage 16 as `auto_approve`-able even though the DB trigger always rejects it — and both RPC call sites then silently swallowed the resulting error, leaving code believing the stage was approved while the DB row stayed pending.
- **Fix (Direction A, security-preserving)**: reserve stage 16 (closes root cause) + stop marking `chairmanGate` approved when the RPC errors, at both `eva-orchestrator.js` and `stage-execution-worker.js` (defense in depth).
- **Explicit non-goal**: no database/migration changes — Direction B (RPC/trigger widening) was evaluated and rejected.

## Test plan
- [x] `tests/unit/eva/autonomy-reserved-gates.test.js` updated (16 now reserved; non-reserved-stage tests moved off 16)
- [x] New `tests/unit/eva/eva-orchestrator-chairman-gate-rpc-error.test.js` (RPC error → pending, not approved; RPC success unchanged)
- [x] New `tests/unit/eva/stage-execution-worker-chairman-gate-rpc-error.test.js` (RPC error → no stage advance; RPC success unchanged)
- [x] Full `tests/unit/eva/` suite: 487 files / 6421 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)