### PR TITLE
fix(QF-20260711-316): author the coordinator_reservation write-side utility (fence was inert)

### DIFF
--- a/lib/coordinator/reserve-sd.cjs
+++ b/lib/coordinator/reserve-sd.cjs
@@ -1,0 +1,108 @@
+/**
+ * Coordinator-side writer for a COORDINATOR_RESERVATION fence row.
+ *
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C shipped the payload.kind convention
+ * plus the read/enforcement/observability side (lib/checkin/steps/drain-reservations.cjs,
+ * lib/checkin/steps/self-claim-gates.cjs) but no code inserted a real
+ * coordinator_reservation row -- the fence was inert in production until this writer
+ * existed (retro action item, e537e872).
+ *
+ * Storage: a session_coordination row, message_type='INFO', target_session=NULL
+ * (broadcast -- drain-reservations.cjs never stamps read_at/acknowledged_at, so it must
+ * stay visible to every session), target_sd=<the fenced SD>,
+ * payload.kind=PAYLOAD_KINDS.COORDINATOR_RESERVATION. Mirrors lib/coordinator/relay-queue.cjs's
+ * pure-builder + IO-wrapper split.
+ *
+ * @module lib/coordinator/reserve-sd
+ */
+
+'use strict';
+
+const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+const { getActiveCoordinatorId } = require('./resolve.cjs');
+
+/**
+ * FAIL-SOFT wrapper matching relay-queue.cjs's resolveCoordinatorIdSafe: an unresolved
+ * coordinator is a real, actionable failure for THIS writer (unlike relay-queue's
+ * advisory-precision use), so callers must check the returned error rather than get a
+ * reservation silently authored under a null identity.
+ *
+ * `resolveFn` is injectable (defaults to the real getActiveCoordinatorId) so tests can
+ * exercise reserveSd's own logic without depending on resolve.cjs's pointer-file/DB
+ * election internals — same DI shape as relay-queue.cjs's drainOne(supabase, row, sendRelay).
+ * @param {object} supabase
+ * @param {(supabase: object) => Promise<string|null>} [resolveFn]
+ * @returns {Promise<string|null>}
+ */
+async function resolveCoordinatorIdSafe(supabase, resolveFn = getActiveCoordinatorId) {
+  try {
+    return await resolveFn(supabase);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * PURE: build the payload for a new coordinator_reservation row.
+ * @param {{ reservedForSession?: string, reservedForTier?: string, lanePattern?: string }} opts
+ * @returns {object}
+ */
+function buildCoordinatorReservationPayload({ reservedForSession, reservedForTier, lanePattern } = {}) {
+  return {
+    kind: PAYLOAD_KINDS.COORDINATOR_RESERVATION,
+    reserved_for_session: reservedForSession || null,
+    reserved_for_tier: reservedForTier || null,
+    lane_pattern: lanePattern || null,
+  };
+}
+
+/**
+ * IO: write a coordinator_reservation fence row for targetSd.
+ *
+ * sender_session MUST resolve to the LIVE active coordinator -- drain-reservations.cjs's
+ * FR-2 SECURITY MUST only honors rows where row.sender_session === the coordinator it
+ * resolves at drain time (defense-in-depth against a buggy worker writing a self-serving
+ * fence). Refusing to write when no coordinator resolves (rather than falling back to a
+ * caller-supplied identity) keeps that guarantee intact at the source: a reservation
+ * authored under any other identity would just be a dead row nobody ever honors, which is
+ * a worse failure mode than a loud upfront error.
+ *
+ * @param {object} supabase
+ * @param {{ targetSd: string, reservedForSession?: string, reservedForTier?: string,
+ *   lanePattern?: string, expiresAt: string, resolveCoordinatorId?: (supabase: object) =>
+ *   Promise<string|null> }} opts - expiresAt is an ISO-8601 string; the caller decides
+ *   the reservation's lifetime, this writer never invents a default. resolveCoordinatorId
+ *   defaults to the real getActiveCoordinatorId; override only for tests.
+ * @returns {Promise<{ data: object|null, error: string|null }>}
+ */
+async function reserveSd(supabase, { targetSd, reservedForSession, reservedForTier, lanePattern, expiresAt, resolveCoordinatorId } = {}) {
+  if (!targetSd) return { data: null, error: 'targetSd is required' };
+  if (!expiresAt) return { data: null, error: 'expiresAt is required' };
+  const coordinatorId = await resolveCoordinatorIdSafe(supabase, resolveCoordinatorId);
+  if (!coordinatorId) {
+    return { data: null, error: 'no live active coordinator resolved -- refusing to write an unenforceable reservation' };
+  }
+  const payload = buildCoordinatorReservationPayload({ reservedForSession, reservedForTier, lanePattern });
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .insert({
+        sender_session: coordinatorId,
+        sender_type: 'coordinator',
+        target_session: null,
+        target_sd: targetSd,
+        message_type: 'INFO',
+        subject: `[COORDINATOR_RESERVATION] ${targetSd}`,
+        payload,
+        expires_at: expiresAt,
+      })
+      .select('id, created_at')
+      .single();
+    if (error) return { data: null, error: error.message };
+    return { data, error: null };
+  } catch (e) {
+    return { data: null, error: String((e && e.message) || e) };
+  }
+}
+
+module.exports = { buildCoordinatorReservationPayload, reserveSd };

--- a/tests/unit/coordinator/reserve-sd.test.js
+++ b/tests/unit/coordinator/reserve-sd.test.js
@@ -1,0 +1,125 @@
+/**
+ * SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C retro action item (e537e872) —
+ * lib/coordinator/reserve-sd.cjs, the coordinator_reservation write-side utility that
+ * did not exist before this fix. No live git/gh/DB calls (all injected). The coordinator
+ * resolver is injected via opts.resolveCoordinatorId (same DI shape as relay-queue.cjs's
+ * drainOne(supabase, row, sendRelay)) rather than mocked, since resolve.cjs's real
+ * getActiveCoordinatorId reads a local pointer file / queries claude_sessions and isn't a
+ * clean unit-test seam.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildCoordinatorReservationPayload, reserveSd } from '../../../lib/coordinator/reserve-sd.cjs';
+import { PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+describe('buildCoordinatorReservationPayload — pure builder', () => {
+  it('builds a coordinator_reservation payload with the correct kind', () => {
+    const payload = buildCoordinatorReservationPayload({ reservedForSession: 's1', reservedForTier: 'sonnet', lanePattern: 'SD-LEO-*' });
+    expect(payload.kind).toBe(PAYLOAD_KINDS.COORDINATOR_RESERVATION);
+    expect(payload.reserved_for_session).toBe('s1');
+    expect(payload.reserved_for_tier).toBe('sonnet');
+    expect(payload.lane_pattern).toBe('SD-LEO-*');
+  });
+
+  it('defaults unset fields to null rather than undefined', () => {
+    const payload = buildCoordinatorReservationPayload();
+    expect(payload.reserved_for_session).toBeNull();
+    expect(payload.reserved_for_tier).toBeNull();
+    expect(payload.lane_pattern).toBeNull();
+  });
+});
+
+function makeInsertStub() {
+  const calls = { inserts: [] };
+  return {
+    calls,
+    from(table) {
+      return {
+        insert(row) {
+          calls.inserts.push({ table, row });
+          return { select: () => ({ single: () => Promise.resolve({ data: { id: 'res-1', created_at: '2026-07-11T00:00:00Z' }, error: null }) }) };
+        },
+      };
+    },
+  };
+}
+
+const resolveToLiveCoordinator = async () => 'live-coord-id';
+const resolveToNull = async () => null;
+const resolveThatThrows = async () => { throw new Error('resolve exploded'); };
+
+describe('reserveSd — FR-2 SECURITY MUST: sender_session is the live coordinator, never a caller-supplied identity', () => {
+  it('stamps sender_session from the resolved live coordinator, not any caller input', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, {
+      targetSd: 'SD-EXAMPLE-001', reservedForSession: 'worker-1', expiresAt: '2026-07-12T00:00:00Z',
+      resolveCoordinatorId: resolveToLiveCoordinator,
+    });
+    expect(result.error).toBeNull();
+    expect(supabase.calls.inserts[0].row.sender_session).toBe('live-coord-id');
+    expect(supabase.calls.inserts[0].row.target_session).toBeNull();
+    expect(supabase.calls.inserts[0].row.target_sd).toBe('SD-EXAMPLE-001');
+    expect(supabase.calls.inserts[0].row.payload.kind).toBe(PAYLOAD_KINDS.COORDINATOR_RESERVATION);
+  });
+
+  it('refuses to write when no live coordinator resolves, rather than authoring an unenforceable row', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, {
+      targetSd: 'SD-EXAMPLE-001', expiresAt: '2026-07-12T00:00:00Z',
+      resolveCoordinatorId: resolveToNull,
+    });
+    expect(result.data).toBeNull();
+    expect(result.error).toMatch(/no live active coordinator/);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+
+  it('refuses to write when the resolver throws (fail-soft resolution, fail-loud write refusal)', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, {
+      targetSd: 'SD-EXAMPLE-001', expiresAt: '2026-07-12T00:00:00Z',
+      resolveCoordinatorId: resolveThatThrows,
+    });
+    expect(result.error).toMatch(/no live active coordinator/);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+});
+
+describe('reserveSd — required-field validation', () => {
+  it('rejects a missing targetSd before ever resolving a coordinator', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, { expiresAt: '2026-07-12T00:00:00Z', resolveCoordinatorId: resolveToLiveCoordinator });
+    expect(result.error).toMatch(/targetSd is required/);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+
+  it('rejects a missing expiresAt -- this writer never invents a default lifetime', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, { targetSd: 'SD-EXAMPLE-001', resolveCoordinatorId: resolveToLiveCoordinator });
+    expect(result.error).toMatch(/expiresAt is required/);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+});
+
+describe('reserveSd — insert-error propagation', () => {
+  it('returns the Supabase error message rather than throwing', async () => {
+    const supabase = {
+      from() {
+        return { insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'insert failed' } }) }) }) };
+      },
+    };
+    const result = await reserveSd(supabase, {
+      targetSd: 'SD-EXAMPLE-001', expiresAt: '2026-07-12T00:00:00Z',
+      resolveCoordinatorId: resolveToLiveCoordinator,
+    });
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('insert failed');
+  });
+});
+
+describe('reserveSd — default resolver (no injection)', () => {
+  it('falls back to the real resolve.cjs when resolveCoordinatorId is omitted, and still fails safe (no live coordinator in this test environment)', async () => {
+    const supabase = makeInsertStub();
+    const result = await reserveSd(supabase, { targetSd: 'SD-EXAMPLE-001', expiresAt: '2026-07-12T00:00:00Z' });
+    // No assertion on the specific outcome (environment-dependent) -- only that it never throws.
+    expect(result).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
- SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C shipped the payload.kind convention plus the read/enforcement/observability side (`lib/checkin/steps/drain-reservations.cjs`), but no code ever inserted a `coordinator_reservation` `session_coordination` row -- the fence mechanism was inert in production (retro action item, SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C retrospective).
- Adds `lib/coordinator/reserve-sd.cjs`: a small writer utility (`buildCoordinatorReservationPayload` + `reserveSd`) matching the exact row shape `drain-reservations.cjs` already reads, mirroring `lib/coordinator/relay-queue.cjs`'s pure-builder + IO-wrapper split.
- FR-2 SECURITY MUST preserved: `sender_session` is always the resolved LIVE active coordinator (never a caller-supplied identity) -- the writer refuses to write (rather than falling back to an unenforceable identity) when no live coordinator resolves.
- The coordinator resolver is injectable (`opts.resolveCoordinatorId`, defaults to the real `getActiveCoordinatorId`) -- same DI shape as `relay-queue.cjs`'s `drainOne(supabase, row, sendRelay)` -- since `resolve.cjs`'s real resolution reads a local pointer file / queries `claude_sessions` and isn't a clean unit-test seam.

## Test plan
- [x] `npx vitest run tests/unit/coordinator/reserve-sd.test.js` -- 9/9 passing
- [x] Mutation-verified: swapping the implementation for a no-op stub fails 8/9 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)