### PR TITLE
fix(SD-LEO-FIX-RESOLVE-STAGE-ARCHETYPE-001): wire archetype generator into S17 docGen()

### DIFF
--- a/lib/eva/stage-handlers/s17.js
+++ b/lib/eva/stage-handlers/s17.js
@@ -121,11 +121,22 @@ export async function docGen(ctx, ventureId) {
   ctx.logger.log('[Worker] S17 post-stage hook: vision + architecture docs generated');
 
   // SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A: Strategy gate — block until chairman selects strategy.
-  // Required regardless of the design path: the GVOS composer renders S17 from
-  // venture_gvos_profile after strategy approval.
-  // SD-LEO-REFAC-EXTRACT-S17-ARCHETYPE-001: legacy archetype-generator invocation removed
-  // (GVOS composer is the live path; s17_use_gvos_composer is globally enabled).
   await ctx.ensureS17StrategySelected(ventureId);
+
+  // SD-LEO-FIX-RESOLVE-STAGE-ARCHETYPE-001: produce the Pass-1 archetype candidates
+  // selection-flow.js's submitPass1Selection fetches by id. The prior comment here
+  // claimed a "GVOS composer" superseded generation, but no such module exists in the
+  // codebase, and it referred to the OLD generateArchetypes() (deleted by
+  // SD-LEO-REFAC-EXTRACT-S17-ARCHETYPE-001), not the CURRENT restored producer below
+  // (SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001), which had zero live callers until this fix.
+  // Non-throwing: a generation failure must never block the S17 stage transition.
+  try {
+    const { generateArchetypesForAllScreens } = await import('../stage-17/archetype-generator.js');
+    await generateArchetypesForAllScreens(ventureId, ctx.supabase);
+    ctx.logger.log('[Worker] S17 post-stage hook: archetype candidates generated');
+  } catch (err) {
+    ctx.logger.warn(`[Worker] S17 archetype generation failed (non-fatal): ${err.message}`);
+  }
 }
 
 /**

--- a/scripts/one-off/smoke-s17-archetype-wiring.mjs
+++ b/scripts/one-off/smoke-s17-archetype-wiring.mjs
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { generateArchetypeVariants } from '../../lib/eva/stage-17/archetype-generator.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const ventureId = '510177ba-435f-4dd7-bfa5-6154cc8cf54b';
+
+const { data: wireframeArt } = await supabase
+  .from('venture_artifacts')
+  .select('artifact_data')
+  .eq('venture_id', ventureId)
+  .eq('artifact_type', 'wireframe_screens')
+  .eq('is_current', true)
+  .maybeSingle();
+
+const screen = wireframeArt.artifact_data.screens.find(
+  (s) => (s.name ?? s.screen_name ?? s.title) === 'Landing Page'
+);
+console.log('Screen found:', !!screen);
+
+const artifactIds = await generateArchetypeVariants(
+  ventureId,
+  'Landing Page',
+  'landing-smoke-test-0',
+  supabase,
+  { screen }
+);
+console.log('SMOKE_TEST_ARTIFACT_IDS=' + JSON.stringify(artifactIds));

--- a/scripts/one-off/smoke-s17-selection-flow-fetch.mjs
+++ b/scripts/one-off/smoke-s17-selection-flow-fetch.mjs
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { submitPass1Selection } from '../../lib/eva/stage-17/selection-flow.js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const ventureId = '510177ba-435f-4dd7-bfa5-6154cc8cf54b';
+const selectedIds = ['27f4ce96-b147-44c2-98d3-dc3bf7ccdb37', '7f8020a9-890d-436e-9518-a404d555a63a'];
+
+const result = await submitPass1Selection(ventureId, 'landing-smoke-test-0', selectedIds, supabase, { platform: 'mobile' });
+console.log('SELECTION_FLOW_RESOLVED_OK=true');
+console.log('REFINED_VARIANT_COUNT=' + (result?.artifactIds?.length ?? result?.length ?? 'unknown'));

--- a/tests/unit/eva/stage-handlers/s17-docgen-archetype.test.js
+++ b/tests/unit/eva/stage-handlers/s17-docgen-archetype.test.js
@@ -1,0 +1,84 @@
+/**
+ * SD-LEO-FIX-RESOLVE-STAGE-ARCHETYPE-001 (FR-1): docGen() must call
+ * generateArchetypesForAllScreens() exactly once, and a thrown error inside
+ * it must be caught and logged, never propagating to fail docGen() or block
+ * the S17 stage transition.
+ *
+ * The frozen-snapshot equivalence test (registry-equivalence.test.js) does
+ * NOT exercise this call site: its s17_docgen_default_path scenario throws
+ * inside generateDocs() (mock has no .like()) before execution ever reaches
+ * the archetype call. This file provides the dedicated coverage the PRD
+ * requires.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const generateDocsMock = vi.fn().mockResolvedValue(undefined);
+const generateArchetypesForAllScreensMock = vi.fn().mockResolvedValue([]);
+
+vi.mock('../../../../lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js', () => ({
+  generateDocs: (...args) => generateDocsMock(...args),
+}));
+
+vi.mock('../../../../lib/eva/stage-17/archetype-generator.js', () => ({
+  generateArchetypesForAllScreens: (...args) => generateArchetypesForAllScreensMock(...args),
+}));
+
+const V = '00000000-0000-4000-8000-000000000001';
+
+function makeCtx() {
+  const supabase = {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { name: 'Test Venture' }, error: null }),
+        }),
+      }),
+    }),
+  };
+  const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const ensureS17StrategySelected = vi.fn().mockResolvedValue(undefined);
+  return { supabase, logger, ensureS17StrategySelected };
+}
+
+describe('SD-LEO-FIX-RESOLVE-STAGE-ARCHETYPE-001: s17.docGen() archetype call site', () => {
+  beforeEach(() => {
+    generateDocsMock.mockClear();
+    generateArchetypesForAllScreensMock.mockClear();
+    generateArchetypesForAllScreensMock.mockResolvedValue([]);
+  });
+
+  it('calls generateArchetypesForAllScreens() exactly once with the correct ventureId/supabase args', async () => {
+    const { docGen } = await import('../../../../lib/eva/stage-handlers/s17.js');
+    const ctx = makeCtx();
+
+    await docGen(ctx, V);
+
+    expect(generateArchetypesForAllScreensMock).toHaveBeenCalledTimes(1);
+    expect(generateArchetypesForAllScreensMock).toHaveBeenCalledWith(V, ctx.supabase);
+    expect(ctx.ensureS17StrategySelected).toHaveBeenCalledWith(V);
+  });
+
+  it('a thrown error inside generateArchetypesForAllScreens() is caught, logged, and does not propagate', async () => {
+    generateArchetypesForAllScreensMock.mockRejectedValueOnce(new Error('archetype generation exploded'));
+    const { docGen } = await import('../../../../lib/eva/stage-handlers/s17.js');
+    const ctx = makeCtx();
+
+    await expect(docGen(ctx, V)).resolves.toBeUndefined();
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('archetype generation failed (non-fatal): archetype generation exploded'),
+    );
+  });
+
+  it('runs generateArchetypesForAllScreens() after the strategy gate (ordering)', async () => {
+    const order = [];
+    const ctx = makeCtx();
+    ctx.ensureS17StrategySelected = vi.fn().mockImplementation(async () => { order.push('strategyGate'); });
+    generateArchetypesForAllScreensMock.mockImplementation(async () => { order.push('archetypeGen'); return []; });
+
+    const { docGen } = await import('../../../../lib/eva/stage-handlers/s17.js');
+    await docGen(ctx, V);
+
+    expect(order).toEqual(['strategyGate', 'archetypeGen']);
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/eva/stage-handlers/s17.js` `docGen()` generated vision/architecture docs and gated on strategy selection, but never called the restored archetype producer (`generateArchetypesForAllScreens`, from SD-LEO-INFRA-FABLE-VENTURE-DESIGN-001) — it had zero live callers.
- Adds the call after the strategy gate, wrapped non-throwing (matches the existing `gvosLock`/`seedDraftVision` hook pattern) so a generation failure never blocks the S17 stage transition.
- Corrects a stale comment claiming a nonexistent "GVOS composer" module superseded generation — no such module exists anywhere in the codebase (verified via repo-wide grep); the comment referred to an already-deleted, unrelated function from an earlier SD.

## Test plan
- [x] New unit test (`tests/unit/eva/stage-handlers/s17-docgen-archetype.test.js`): asserts `generateArchetypesForAllScreens()` is called exactly once with correct `(ventureId, supabase)` args, asserts a thrown error is caught/logged and never propagates, asserts call ordering after the strategy gate — 3/3 passing.
- [x] Frozen-snapshot equivalence suite (`registry-equivalence.test.js`) — 13/13 passing, unaffected (its `s17_docgen_default_path` scenario short-circuits inside the pre-existing, untouched `generateDocs()` before reaching the new code).
- [x] Zero regressions across `archetype-generator.js`, `refinement.js`, `selection-flow.js`, and related consumer test suites — 85/85 passing.
- [x] Live smoke verification against a real scaffolding venture (`DataDistill`, `is_scaffolding=true`): `generateArchetypeVariants()` wrote 4 real `s17_archetypes` `venture_artifacts` rows; `selection-flow.js`'s `submitPass1Selection` successfully fetched 2 of them by id (proceeded to the refinement LLM call, which only fires after both fetches succeed) — confirms the producer/consumer artifact contract holds end-to-end.
- [x] Note: the downstream refinement-write failure hit during that verification (`stage_17_refined` missing from `ARTIFACT_TYPES`) is a separate, pre-existing bug in the unrelated refinement funnel — explicitly out of scope per this SD's PRD risk mitigation. Will be filed as a follow-on QF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)