### PR TITLE
fix(SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001): telemetry for silent PATCH failures + PID cross-check AND-gate for dormancy detection

### DIFF
--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -47,6 +47,17 @@ const PARENT_REDISCOVER_TIMEOUT_MS = 3000;
 const MAX_PARENT_MISSES = 2;
 let parentMissCount = 0;
 
+// SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 (FR-1): the tickOnce() try/catch previously swallowed
+// a persistent PATCH failure (AbortController timeout, network/auth error) with zero
+// telemetry — process_alive_at freezes while claude_sessions.status stays 'active', a live
+// freeze-while-active dormancy-watchdog false-positive source (RCA 0.9 confidence,
+// QF-20260711-407). Never changes the catch's fail-open continuation — only makes a
+// persistent failure observable.
+const PATCH_FAILURE_TELEMETRY_THRESHOLD = 3;
+const PATCH_FAILURE_HTTP_TIMEOUT_MS = 1000;
+const patchFailureNdjsonPath = path.resolve(__dirname, '../.claude/pids/spawn-errors.log');
+let consecutivePatchFailures = 0;
+
 // SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-4): early-exit telemetry threshold + sinks.
 // If cleanupAndExit fires within EARLY_EXIT_THRESHOLD_MS of process start, emit a
 // structured tick.early_exit event so operators can detect ancestor-discovery regressions.
@@ -285,8 +296,16 @@ async function tickOnce() {
         cleanupAndExit(0);
       }
     }
-  } catch {
-    // swallow — next tick will retry. Never crash the tick loop.
+    // FR-1: a successful tick (POST/PATCH completed without throwing) clears the streak.
+    consecutivePatchFailures = 0;
+  } catch (err) {
+    // Never crash the tick loop — next tick will retry. FR-1: make a PERSISTENT failure
+    // observable instead of silently swallowing it every time.
+    consecutivePatchFailures += 1;
+    console.error(`session-tick: write failed (consecutive=${consecutivePatchFailures}): ${err && err.message}`);
+    if (consecutivePatchFailures === PATCH_FAILURE_TELEMETRY_THRESHOLD) {
+      emitPatchFailureTelemetry(consecutivePatchFailures, err);
+    }
   } finally {
     for (const t of timers) clearTimeout(t);
   }
@@ -343,6 +362,56 @@ function emitEarlyExitTelemetry(exitCode, lifetimeMs) {
         reason: 'ancestor_pid_exited',
         latency_ms: lifetimeMs,
         metadata: { cc_parent_pid: parentPid, exit_code: exitCode, hostname: event.hostname },
+      }),
+      signal: controller.signal,
+    }).catch(() => { /* best-effort */ });
+  } catch {
+    /* best-effort */
+  }
+}
+
+// SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 (FR-1): emit tick.patch_failure telemetry once a
+// write failure streak crosses PATCH_FAILURE_TELEMETRY_THRESHOLD. Same two-sink shape as
+// emitEarlyExitTelemetry above (durable NDJSON + best-effort DB event) — never awaited,
+// never blocks the tick loop.
+function emitPatchFailureTelemetry(streak, err) {
+  const event = {
+    timestamp: new Date().toISOString(),
+    event: 'tick.patch_failure',
+    session_id: sessionId,
+    tick_pid: process.pid,
+    consecutive_failures: streak,
+    error_message: (err && err.message) || String(err),
+    hostname: require('os').hostname(),
+  };
+  try {
+    fs.mkdirSync(path.dirname(patchFailureNdjsonPath), { recursive: true });
+    fs.appendFileSync(patchFailureNdjsonPath, JSON.stringify(event) + '\n');
+  } catch {
+    // file write failures are non-fatal — DB sink may still capture the event
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) return;
+  try {
+    const url = `${supabaseUrl.replace(/\/$/, '')}/rest/v1/session_lifecycle_events`;
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), PATCH_FAILURE_HTTP_TIMEOUT_MS);
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        event_type: 'tick.patch_failure',
+        session_id: sessionId,
+        pid: process.pid,
+        reason: 'consecutive_write_failures',
+        metadata: { consecutive_failures: streak, error_message: event.error_message, hostname: event.hostname },
       }),
       signal: controller.signal,
     }).catch(() => { /* best-effort */ });

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -42,11 +42,30 @@ const { assertSdDispatchable, isFullUuid } = require('../lib/coordinator/dispatc
 const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('../lib/claim/holding-statuses.cjs');
 const { SILENCE_HARD_CAP_MS } = require('../lib/fleet/silence-cap.cjs'); // FR-4: shared writer<=reader cap
 const { detectDormantWorkers } = require('../lib/fleet/dormancy-watchdog.cjs'); // QF-20260703-076
+const { getMarkerSessionIds } = require('../lib/fleet/cc-pid-liveness.cjs'); // SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 FR-2/FR-3
 // SD-FDBK-ENH-CONFIRMED-LIVE-TODAY-001: pure, exported so the gate can be unit-tested without a
 // live claude_sessions table. Mirrors MASKED_STALL_DETECT_ON (coordinator-capacity-forecast.mjs) --
 // DORMANT BY DEFAULT until process_alive_at is trustworthy again (see call site below for full RCA).
 function isDormancyWatchdogEnabled(env = process.env) {
   return env.LEO_DORMANCY_WATCHDOG_ENABLED === 'on';
+}
+
+// SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 (FR-2/FR-3, risk-agent evidence
+// 4d1be256-dbc4-4e37-a661-72ffb6453bc0): pure, exported AND-gate so the join can be
+// unit-tested without a live claude_sessions table or real pid-*.json marker files.
+// dormancyMarkers is the raw shape returned by lib/fleet/cc-pid-liveness.cjs's
+// getMarkerSessionIds() -- { [marker.session_id]: { claude_session_id, pid, alive } }.
+// CRITICAL: joins on each marker's claude_session_id field (the CLAUDE_SESSION_ID UUID
+// that claude_sessions.session_id also is), NEVER the marker's own session_id (the
+// map's OWN key, a DIFFERENT identifier) -- a naive join on the wrong key silently
+// fails open (matches nothing), making this AND-gate inert while looking shipped.
+function filterDormantByPidLiveness(dormantCandidates, dormancyMarkers) {
+  const aliveClaudeSessionIds = new Set(
+    Object.values(dormancyMarkers || {})
+      .filter((m) => m && m.alive && m.claude_session_id)
+      .map((m) => m.claude_session_id)
+  );
+  return (dormantCandidates || []).filter((d) => !aliveClaudeSessionIds.has(d.session_id));
 }
 
 const HEADLESS_ZOMBIE_MIN_MS = 15 * 60 * 1000;
@@ -1624,7 +1643,16 @@ async function main() {
         .from('claude_sessions')
         .select('session_id, loop_state, expected_silence_until, process_alive_at')
         .eq('status', 'active');
-      const dormant = detectDormantWorkers(allTracked || [], now.getTime());
+      const dormantCandidates = detectDormantWorkers(allTracked || [], now.getTime());
+      // FR-2/FR-3: AND-gate against an orthogonal failure-domain signal (OS-level PID
+      // liveness) before trusting process_alive_at alone -- process_alive_at is written
+      // ONLY by session-tick.cjs's detached daemon, which can die independently of the
+      // session itself. Computed fresh here (not reusing aliveCcPids, which is built
+      // later at this function's line ~1664 from detectIdentityCollisions() -- this
+      // block runs before that and before the no-sessions early-return, so it cannot
+      // depend on either). See filterDormantByPidLiveness's own doc for the keyspace
+      // join detail.
+      const dormant = filterDormantByPidLiveness(dormantCandidates, getMarkerSessionIds());
       const DORMANCY_ALERT_THRESHOLD = 2;
       if (dormant.length >= DORMANCY_ALERT_THRESHOLD) {
         const { emitFeedback } = await import('../lib/governance/emit-feedback.js');
@@ -3122,6 +3150,7 @@ module.exports.anyClaudeProcessRunning = anyClaudeProcessRunning;
 // does — no production behavior change.
 module.exports.isSweepResetAllowed = isSweepResetAllowed;
 module.exports.isDormancyWatchdogEnabled = isDormancyWatchdogEnabled; // SD-FDBK-ENH-CONFIRMED-LIVE-TODAY-001
+module.exports.filterDormantByPidLiveness = filterDormantByPidLiveness; // SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001
 module.exports.isHeadlessZombie = isHeadlessZombie; // QF-20260704-081
 module.exports.HEADLESS_ZOMBIE_MIN_MS = HEADLESS_ZOMBIE_MIN_MS; // QF-20260704-081
 // SD-ARCH-HOTSPOT-SWEEP-001 (PRD FR-2 / TS-3): promoted classification-time helper —

--- a/tests/unit/session-tick-patch-failure-telemetry.test.mjs
+++ b/tests/unit/session-tick-patch-failure-telemetry.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for scripts/session-tick.cjs — FR-1 of
+ * SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 (RCA 0.9 confidence, QF-20260711-407).
+ *
+ * The tickOnce() try/catch previously swallowed a persistent PATCH failure
+ * (AbortController timeout, network/auth error) with zero telemetry —
+ * process_alive_at freezes while claude_sessions.status stays 'active', a live
+ * freeze-while-active dormancy-watchdog false-positive source. This must be made
+ * observable WITHOUT changing the catch's fail-open continuation (the tick loop
+ * must keep retrying, never crash the daemon on a transient write error).
+ *
+ * Source-pinned (readFileSync + regex), same pattern as the sibling
+ * session-tick-*.test.mjs files — session-tick.cjs has no module.exports
+ * (a standalone detached daemon), so behavior is asserted against the source
+ * rather than invoked directly.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '../..');
+const tickPath = resolve(repoRoot, 'scripts/session-tick.cjs');
+const tickSrc = readFileSync(tickPath, 'utf8');
+
+test('FR-1: a consecutive-failure counter exists and starts at 0', () => {
+  assert.match(tickSrc, /let\s+consecutivePatchFailures\s*=\s*0;/);
+});
+
+test('FR-1: the catch block increments the counter and logs it (no longer a bare/empty catch)', () => {
+  const catchBlock = tickSrc.match(/consecutivePatchFailures \+= 1;[\s\S]+?\n\s*\}\s*finally\s*\{/);
+  assert.ok(catchBlock, 'tickOnce() catch block should exist and bind the caught error');
+  assert.match(catchBlock[0], /consecutivePatchFailures\s*\+=\s*1;/);
+  assert.match(catchBlock[0], /console\.error\(/);
+});
+
+test('FR-1: the catch block still never throws/rethrows — fail-open continuation preserved', () => {
+  const catchBlock = tickSrc.match(/consecutivePatchFailures \+= 1;[\s\S]+?\n\s*\}\s*finally\s*\{/);
+  assert.ok(catchBlock);
+  assert.doesNotMatch(catchBlock[0], /\bthrow\b/, 'catch must remain fail-open — never re-throw and crash the tick loop');
+});
+
+test('FR-1: a successful tick resets the failure streak to 0', () => {
+  // Must appear inside tickOnce()'s try block, after the steady-state PATCH logic,
+  // before the catch — i.e. only a completed-without-throwing tick clears the streak.
+  assert.match(tickSrc, /consecutivePatchFailures\s*=\s*0;\s*\n\s*\}\s*catch/);
+});
+
+test('FR-1: emitPatchFailureTelemetry helper is defined', () => {
+  assert.match(tickSrc, /function\s+emitPatchFailureTelemetry\s*\(\s*streak\s*,\s*err\s*\)/);
+});
+
+test('FR-1: telemetry only fires once the streak reaches the threshold (not on every single failure)', () => {
+  const catchBlock = tickSrc.match(/consecutivePatchFailures \+= 1;[\s\S]+?\n\s*\}\s*finally\s*\{/);
+  assert.ok(catchBlock);
+  assert.match(catchBlock[0], /consecutivePatchFailures\s*===\s*PATCH_FAILURE_TELEMETRY_THRESHOLD/);
+  assert.match(catchBlock[0], /emitPatchFailureTelemetry\(consecutivePatchFailures,\s*err\)/);
+});
+
+test('FR-1: emitPatchFailureTelemetry writes a durable NDJSON sink (survives even if the DB POST never resolves)', () => {
+  const fnBlock = tickSrc.match(/function\s+emitPatchFailureTelemetry[\s\S]+?\n\}/);
+  assert.ok(fnBlock);
+  assert.match(fnBlock[0], /appendFileSync\(patchFailureNdjsonPath/);
+});
+
+test('FR-1: emitPatchFailureTelemetry POSTs to session_lifecycle_events best-effort (mirrors emitEarlyExitTelemetry sink 2)', () => {
+  const fnBlock = tickSrc.match(/function\s+emitPatchFailureTelemetry[\s\S]+?\n\}/);
+  assert.ok(fnBlock);
+  assert.match(fnBlock[0], /session_lifecycle_events/);
+  assert.match(fnBlock[0], /event_type:\s*'tick\.patch_failure'/);
+});

--- a/tests/unit/stale-session-sweep-dormancy-gate.test.js
+++ b/tests/unit/stale-session-sweep-dormancy-gate.test.js
@@ -16,7 +16,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { isDormancyWatchdogEnabled } = require('../../scripts/stale-session-sweep.cjs');
+const { isDormancyWatchdogEnabled, filterDormantByPidLiveness } = require('../../scripts/stale-session-sweep.cjs');
 
 describe('isDormancyWatchdogEnabled', () => {
   it('defaults to disabled when the env var is unset', () => {
@@ -45,5 +45,54 @@ describe('isDormancyWatchdogEnabled', () => {
       if (prior === undefined) delete process.env.LEO_DORMANCY_WATCHDOG_ENABLED;
       else process.env.LEO_DORMANCY_WATCHDOG_ENABLED = prior;
     }
+  });
+});
+
+// SD-LEO-INFRA-FIX-RESIDUAL-PROCESS-001 (FR-2/FR-3, risk-agent evidence
+// 4d1be256-dbc4-4e37-a661-72ffb6453bc0): process_alive_at can freeze while a session is
+// genuinely live (session-tick.cjs's daemon dies independently of the CC session). The
+// AND-gate cross-checks an orthogonal signal (OS-level PID liveness from pid-*.json
+// markers) before trusting process_alive_at-derived dormancy alone.
+describe('filterDormantByPidLiveness — the FR-2/FR-3 AND-gate', () => {
+  it('drops a dormant candidate whose CLAUDE_SESSION_ID matches an ALIVE marker (process_alive_at lied)', () => {
+    const candidates = [{ session_id: 'live-session-uuid' }];
+    const markers = { 'marker-own-id-1': { claude_session_id: 'live-session-uuid', pid: 4242, alive: true } };
+    expect(filterDormantByPidLiveness(candidates, markers)).toEqual([]);
+  });
+
+  it('keeps a dormant candidate whose CLAUDE_SESSION_ID matches a DEAD marker (both signals agree: genuinely dormant)', () => {
+    const candidates = [{ session_id: 'dead-session-uuid' }];
+    const markers = { 'marker-own-id-2': { claude_session_id: 'dead-session-uuid', pid: 9999, alive: false } };
+    expect(filterDormantByPidLiveness(candidates, markers)).toEqual(candidates);
+  });
+
+  it('keeps a dormant candidate with NO matching marker at all (no PID evidence either way -- process_alive_at stands)', () => {
+    const candidates = [{ session_id: 'orphan-session-uuid' }];
+    expect(filterDormantByPidLiveness(candidates, {})).toEqual(candidates);
+  });
+
+  it('CRITICAL: joins on marker.claude_session_id, never the map key (marker.session_id) -- proves the fix is not silently inert on the keyspace mismatch', () => {
+    const candidates = [{ session_id: 'live-session-uuid' }];
+    // The map KEY ('live-session-uuid') deliberately does NOT equal the candidate's
+    // session_id here in a way that would pass a naive Object.keys()-based join --
+    // only the VALUE's claude_session_id field does. If the implementation ever
+    // regresses to keying off the map key instead of the value's claude_session_id,
+    // this still passes ONLY if the join correctly reads .claude_session_id.
+    const markers = { 'totally-different-marker-key': { claude_session_id: 'live-session-uuid', pid: 1, alive: true } };
+    expect(filterDormantByPidLiveness(candidates, markers)).toEqual([]);
+  });
+
+  it('a marker with alive=false is never treated as live evidence, even if present', () => {
+    const candidates = [{ session_id: 's1' }, { session_id: 's2' }];
+    const markers = {
+      m1: { claude_session_id: 's1', pid: 1, alive: false },
+      m2: { claude_session_id: 's2', pid: 2, alive: true },
+    };
+    expect(filterDormantByPidLiveness(candidates, markers)).toEqual([{ session_id: 's1' }]);
+  });
+
+  it('handles null/undefined dormancyMarkers and empty candidates without throwing', () => {
+    expect(filterDormantByPidLiveness([], null)).toEqual([]);
+    expect(filterDormantByPidLiveness(undefined, undefined)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
RCA (0.9 confidence, database-agent corroborated, QF-20260711-407) found `SD-LEO-INFRA-FIX-WINDOWS-SESSION-001` (2026-07-04) fixed only one `process_alive_at` freeze path, and `LEO_DORMANCY_WATCHDOG_ENABLED` was flipped on post-merge without the required canary-verify ever being confirmed clean — 25+ `fleet_dormancy` false-positive rows fired 2026-07-04 through 2026-07-10.

LEAD-phase risk-agent investigation (evidence `4d1be256-dbc4-4e37-a661-72ffb6453bc0`, CONDITIONAL_PASS) confirmed one real live defect and caught two scoping errors in the original RCA before any code was written:

- **FR-1 (confirmed real defect):** `session-tick.cjs`'s tick-write `catch` block silently swallowed a persistent PATCH failure (timeout/network/auth) with zero telemetry. Added a consecutive-failure counter + `emitPatchFailureTelemetry` (mirrors the existing `emitEarlyExitTelemetry` two-sink pattern). Fail-open continuation is unchanged.
- **FR-2/FR-3:** `stale-session-sweep.cjs`'s dormancy block now cross-checks OS-level PID liveness (`lib/fleet/cc-pid-liveness.cjs`) before trusting `process_alive_at` alone. Extracted as a pure, exported `filterDormantByPidLiveness()` — **correctly joins on each marker's `claude_session_id` field, never the marker map's own key** (a different identifier per `cc-pid-liveness.cjs`'s own JSDoc; a naive join on the wrong key would have silently failed open, leaving the fix inert while looking shipped).
- **Deferred (risk-agent-flagged over-scope in the original RCA):** `session-tick.cjs`'s parent-PID-ESRCH/uncaughtException exit paths already correctly release the row (invisible to the dormancy query) — not touched here, would need dedicated Windows spawn-and-observe test infra if revisited.
- **Corrected (risk-agent caught a defect in the RCA's own spec):** the RCA's originally-worded regression test would have **reverted** the existing `QF-20260703-076` anti-masking invariant if implemented literally. Corrected to add PID-aware coverage additively, with an explicit regression check that the pre-existing anti-masking test case is untouched.

`LEO_DORMANCY_WATCHDOG_ENABLED` stays OFF — re-enabling it is explicitly human/chairman-gated on a genuine clean canary window, out of this SD's autonomous scope.

**All FR-4 deferred/non-goal items (for completeness):** (a) `session-tick.cjs` exit-path edits — deferred per risk-agent, see above; (b) `LEO_DORMANCY_WATCHDOG_ENABLED` re-enable — human/chairman-gated, see above; (c) collapsing all fleet-liveness signals into one SSOT computed verdict — a separate, larger follow-up, not attempted here.

## Test plan
- [x] `node --test tests/unit/session-tick-patch-failure-telemetry.test.mjs` — 8/8 new tests passing
- [x] `node --test tests/unit/session-tick-heartbeat.test.mjs tests/unit/session-tick-release-on-exit.test.mjs` — 25/25 passing, zero regressions
- [x] `npx vitest run tests/unit/stale-session-sweep-dormancy-gate.test.js` — 10/10 (4 pre-existing + 6 new)
- [x] `npx vitest run tests/unit/fleet/dormancy-watchdog.test.js` — pre-existing anti-masking test case unmodified and passing
- [x] Full regression sweep across all `stale-session-sweep*` + `dormancy*` test files — 69/69 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
