### PR TITLE
fix(SD-LEO-FIX-REGISTER-STAGE-REFINED-001): register stage_17_refined artifact_type + stage chairman-gated CHECK migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,10 @@ database/*.json
 # … but the schema-reference lint snapshot is a COMMITTED artifact the CI lint
 # reads offline (SD-LEO-INFRA-SCHEMA-REFERENCE-LINT-001)
 !database/schema-reference-snapshot.json
+# … and the pending-chairman-gate allowlist is a COMMITTED, reason-required
+# exemption config the artifact-type parity test reads offline
+# (SD-LEO-FIX-REGISTER-STAGE-REFINED-001)
+!database/artifact-type-parity-pending-chairman-gate.json
 
 # One-off root level scripts
 audit_rls.js

--- a/database/artifact-type-parity-pending-chairman-gate.json
+++ b/database/artifact-type-parity-pending-chairman-gate.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "ARTIFACT_TYPES registry values (lib/eva/artifact-types.js) that are registered in code but NOT YET allowed by the live venture_artifacts_artifact_type_check CHECK constraint, because the widening migration is chairman-gated and staged (not yet applied) -- mirrors the requires_chairman_apply convention used by scripts/check-migration-readiness.mjs. Every entry MUST cite the staged migration file and a reason. tests/unit/eva/artifact-type-db-parity.test.js enforces two things: (1) every drifted value not covered here still fails CI (real drift keeps failing), and (2) any entry here that IS already present in the live constraint snapshot fails CI too (a stale exemption that should have been removed once the migration was applied and the schema snapshot regenerated via `npm run schema:snapshot:lint`).",
+  "allow": {
+    "stage_17_refined": {
+      "reason": "SD-LEO-FIX-REGISTER-STAGE-REFINED-001: lib/eva/stage-17/refinement.js's live Pass-1-selection refinement path needs this type; CHECK-widening migration staged pending chairman apply (metadata.requires_chairman_apply=true).",
+      "migration": "database/migrations/20260711_add_stage_17_refined_artifact_type.sql"
+    }
+  }
+}

--- a/database/migrations/20260711_add_stage_17_refined_artifact_type.sql
+++ b/database/migrations/20260711_add_stage_17_refined_artifact_type.sql
@@ -1,0 +1,35 @@
+-- @chairman-gated: staged, not yet applied — see database/migrations/README or
+-- SD-LEO-FIX-REGISTER-STAGE-REFINED-001 metadata.requires_chairman_apply=true.
+-- =============================================================================
+-- Migration: venture_artifacts_artifact_type_check — ADD 'stage_17_refined'
+-- Fix: SD-LEO-FIX-REGISTER-STAGE-REFINED-001 (escalated from QF-20260711-926) —
+--      lib/eva/stage-17/refinement.js generateRefinedVariants() (the LIVE
+--      Pass-1-selection refinement path invoked by selection-flow.js
+--      submitPass1Selection()) writes artifactType 'stage_17_refined', which is
+--      not allowed by the live CHECK constraint. Confirmed live: writeArtifact
+--      throws a CHECK constraint violation on every invocation — this path has
+--      never successfully persisted a refined variant in production.
+-- Scope: LIVE table public.venture_artifacts ONLY. The same-named constraint on
+--      venture_artifacts_storm_quarantine_20260704 is deliberately untouched.
+-- Change class: CHECK-WIDENING by one value — cannot invalidate existing rows.
+-- Rollback: re-create the constraint without 'stage_17_refined' (prior
+--      definition = this list minus that one value).
+--
+-- After a chairman applies this migration:
+--   1. Run `npm run schema:snapshot:lint` to regenerate
+--      database/schema-reference-snapshot.json from the live schema.
+--   2. Remove the 'stage_17_refined' entry from
+--      database/artifact-type-parity-pending-chairman-gate.json (its
+--      pending-chairman-gate exemption is no longer needed once the value is
+--      live — tests/unit/eva/artifact-type-db-parity.test.js enforces this).
+-- =============================================================================
+
+ALTER TABLE public.venture_artifacts DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+ALTER TABLE public.venture_artifacts ADD CONSTRAINT venture_artifacts_artifact_type_check
+CHECK (((artifact_type)::text = ANY (ARRAY['blueprint_api_contract'::text, 'blueprint_data_model'::text, 'blueprint_erd_diagram'::text, 'blueprint_financial_projection'::text, 'blueprint_launch_readiness'::text, 'blueprint_positioning_brief'::text, 'blueprint_product_roadmap'::text, 'blueprint_project_plan'::text, 'blueprint_promotion_gate'::text, 'blueprint_review_summary'::text, 'blueprint_risk_register'::text, 'blueprint_schema_spec'::text, 'blueprint_sprint_plan'::text, 'blueprint_technical_architecture'::text, 'blueprint_token_manifest'::text, 'blueprint_user_journey'::text, 'blueprint_user_story_pack'::text, 'blueprint_wireframes'::text, 'build_cicd_config'::text, 'build_deviation_record'::text, 'build_mvp_build'::text, 'build_security_audit'::text, 'build_system_prompt'::text, 'build_test_coverage_report'::text, 'code_quality_report'::text, 'design_token_manifest'::text, 'distribution_ad_copy'::text, 'distribution_channel_config'::text, 'distribution_skip_marker'::text, 'economic_lens'::text, 'engine_business_model_canvas'::text, 'engine_exit_strategy'::text, 'engine_pricing_model'::text, 'engine_revenue_model'::text, 'engine_risk_assessment'::text, 'engine_risk_matrix'::text, 'growth_optimization_roadmap'::text, 'growth_playbook'::text, 'identity_brand_guidelines'::text, 'identity_brand_name'::text, 'identity_gtm_sales_strategy'::text, 'identity_logo_image'::text, 'identity_naming_visual'::text, 'identity_persona_brand'::text, 'intake_venture_analysis'::text, 'launch_analytics_dashboard'::text, 'launch_assumptions_vs_reality'::text, 'launch_churn_triggers'::text, 'launch_deployment_runbook'::text, 'launch_health_scoring'::text, 'launch_launch_metrics'::text, 'launch_marketing_checklist'::text, 'launch_metrics'::text, 'launch_optimization_roadmap'::text, 'launch_production_app'::text, 'launch_readiness_checklist'::text, 'launch_retention_playbook'::text, 'launch_test_plan'::text, 'launch_uat_report'::text, 'launch_user_feedback_summary'::text, 'lifecycle_sd_bridge'::text, 'marketing_app_store_desc'::text, 'marketing_blog_draft'::text, 'marketing_email_onboarding'::text, 'marketing_email_reengagement'::text, 'marketing_email_welcome'::text, 'marketing_landing_hero'::text, 'marketing_seo_meta'::text, 'marketing_social_posts'::text, 'marketing_tagline'::text, 'post_lifecycle_decision'::text, 'postlaunch_analytics_dashboard'::text, 'postlaunch_assumptions_vs_reality'::text, 'postlaunch_user_feedback_summary'::text, 's17_approved'::text, 's17_approved_png'::text, 's17_archetypes'::text, 's17_design_system'::text, 's17_fill_screen'::text, 's17_preview'::text, 's17_qa_report'::text, 's17_session_state'::text, 's17_strategy_recommendation'::text, 's17_strategy_stats'::text, 's17_variant_scores'::text, 's17_variant_wip'::text, 'stage_0_analysis'::text, 'stage_10_analysis'::text, 'stage_11_analysis'::text, 'stage_12_analysis'::text, 'stage_13_analysis'::text, 'stage_14_analysis'::text, 'stage_15_analysis'::text, 'stage_16_analysis'::text, 'stage_17_analysis'::text, 'stage_17_refined'::text, 'stage_18_analysis'::text, 'stage_19_analysis'::text, 'stage_1_analysis'::text, 'stage_20_analysis'::text, 'stage_21_analysis'::text, 'stage_22_analysis'::text, 'stage_23_analysis'::text, 'stage_24_analysis'::text, 'stage_25_analysis'::text, 'stage_26_analysis'::text, 'stage_2_analysis'::text, 'stage_3_analysis'::text, 'stage_4_analysis'::text, 'stage_5_analysis'::text, 'stage_6_analysis'::text, 'stage_7_analysis'::text, 'stage_8_analysis'::text, 'stage_9_analysis'::text, 'stitch_budget'::text, 'stitch_curation'::text, 'stitch_design_export'::text, 'stitch_project'::text, 'stitch_qa_report'::text, 'system_devils_advocate_review'::text, 'truth_ai_critique'::text, 'truth_competitive_analysis'::text, 'truth_financial_model'::text, 'truth_idea_brief'::text, 'truth_problem_statement'::text, 'truth_target_market_analysis'::text, 'truth_validation_decision'::text, 'truth_value_proposition'::text, 'value_multiplier_assessment'::text, 'visual_assets_skipped'::text, 'visual_device_screenshots'::text, 'visual_final_assets'::text, 'visual_social_graphics'::text, 'wireframe_screens'::text])));
+
+-- ROLLBACK block (restore constraint without 'stage_17_refined'):
+--   ALTER TABLE public.venture_artifacts DROP CONSTRAINT venture_artifacts_artifact_type_check;
+--   ALTER TABLE public.venture_artifacts ADD CONSTRAINT venture_artifacts_artifact_type_check
+--     CHECK (((artifact_type)::text = ANY (ARRAY[... this list minus 'stage_17_refined' ...])));

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -204,6 +204,15 @@ export const ARTIFACT_TYPES = Object.freeze({
   BLUEPRINT_S17_DESIGN_SYSTEM: 's17_design_system',
   /** S17 strategy usage statistics (feedback loop) — SD-S17-WORKER-STRATEGY-GATE-ORCH-001-A */
   BLUEPRINT_S17_STRATEGY_STATS: 's17_strategy_stats',
+  /**
+   * S17 refined design variants (Pass-1-selection refinement path) — written by
+   * lib/eva/stage-17/refinement.js generateRefinedVariants(), the LIVE refinement
+   * step invoked by selection-flow.js submitPass1Selection(). Registered here (and
+   * in the venture_artifacts_artifact_type_check CHECK constraint) by
+   * SD-LEO-FIX-REGISTER-STAGE-REFINED-001 — previously an unregistered literal that
+   * had never successfully persisted in production (CHECK constraint violation).
+   */
+  BLUEPRINT_S17_REFINED: 'stage_17_refined',
 
   // Stage 15 — Wireframe screen data (replaces Stitch provisioning)
   BLUEPRINT_WIREFRAME_SCREENS: 'wireframe_screens',
@@ -362,6 +371,7 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
     ARTIFACT_TYPES.BLUEPRINT_S17_PREVIEW,
     ARTIFACT_TYPES.BLUEPRINT_S17_DESIGN_SYSTEM,
     ARTIFACT_TYPES.BLUEPRINT_S17_STRATEGY_STATS,
+    ARTIFACT_TYPES.BLUEPRINT_S17_REFINED,
   ],
   // Stage 18 = "Marketing Copy Studio" — outputs 9 persona-targeted copy sections,
   // one marketing_<section> artifact each. Was missing from the registry (gap

--- a/lib/eva/stage-17/refinement.js
+++ b/lib/eva/stage-17/refinement.js
@@ -17,6 +17,7 @@
 
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { getClaudeModel } from '../../config/model-config.js';
+import { ARTIFACT_TYPES } from '../artifact-types.js';
 
 /**
  * Generate 4 refined variants from 2 selected archetype HTMLs.
@@ -110,7 +111,7 @@ Output ONLY the HTML — no explanation, no markdown fences.`;
     const artifactId = await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 17,
-      artifactType: 'stage_17_refined',
+      artifactType: ARTIFACT_TYPES.BLUEPRINT_S17_REFINED,
       title: `${screenName} — Refined ${i + 1}: ${refinementStyles[i].split(' ')[0]}`,
       content: refinedHtml,
       artifactData: {

--- a/lib/eva/stage-templates/artifact-type-parity.js
+++ b/lib/eva/stage-templates/artifact-type-parity.js
@@ -11,6 +11,7 @@
  * registered here but missing from the constraint). Pure/offline so it can
  * run in CI against the committed database/schema-reference-snapshot.json.
  */
+import { readFileSync } from 'node:fs';
 
 /**
  * Parse the allowed value set out of a Postgres CHECK constraint definition
@@ -30,4 +31,31 @@ export function parseCheckConstraintAllowedValues(definition) {
   if (!definition) return allowed;
   for (const match of definition.matchAll(/'([a-zA-Z0-9_]+)'::text/g)) allowed.add(match[1]);
   return allowed;
+}
+
+/**
+ * Load database/artifact-type-parity-pending-chairman-gate.json — the
+ * reason-required allowlist of ARTIFACT_TYPES values registered in code
+ * ahead of their chairman-gated widening migration being applied (mirrors
+ * scripts/check-migration-readiness.mjs's requires_chairman_apply
+ * convention). SD-LEO-FIX-REGISTER-STAGE-REFINED-001.
+ * @param {string} [path]
+ * @returns {Record<string, {reason: string, migration?: string}>}
+ */
+export function loadPendingChairmanGateAllowlist(path) {
+  const target = path ?? new URL('../../../database/artifact-type-parity-pending-chairman-gate.json', import.meta.url);
+  let raw;
+  try {
+    raw = readFileSync(target, 'utf8');
+  } catch {
+    return {};
+  }
+  const json = JSON.parse(raw);
+  const entries = json.allow || {};
+  for (const [value, entry] of Object.entries(entries)) {
+    if (!entry || typeof entry.reason !== 'string' || !entry.reason.trim()) {
+      throw new Error(`artifact-type-parity-pending-chairman-gate.json entry '${value}' must have a non-empty reason`);
+    }
+  }
+  return entries;
 }

--- a/tests/unit/eva/artifact-type-db-parity.test.js
+++ b/tests/unit/eva/artifact-type-db-parity.test.js
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { ARTIFACT_TYPES } from '../../../lib/eva/artifact-types.js';
 import { UPSTREAM_ARTIFACT_TYPES } from '../../../lib/eva/stage-templates/upstream-artifact-types.js';
-import { parseCheckConstraintAllowedValues } from '../../../lib/eva/stage-templates/artifact-type-parity.js';
+import { parseCheckConstraintAllowedValues, loadPendingChairmanGateAllowlist } from '../../../lib/eva/stage-templates/artifact-type-parity.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_PATH = join(__dirname, '../../../database/schema-reference-snapshot.json');
@@ -36,15 +36,26 @@ describe('parseCheckConstraintAllowedValues (pure)', () => {
 });
 
 describe('ARTIFACT_TYPES registry <-> venture_artifacts CHECK constraint parity', () => {
-  it('every canonical ARTIFACT_TYPES value is allowed by the live constraint (committed snapshot)', () => {
+  it('every canonical ARTIFACT_TYPES value is allowed by the live constraint, or has a reasoned pending-chairman-gate exemption', () => {
     const snapshot = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8'));
     const definition = snapshot.checks && snapshot.checks[CONSTRAINT_KEY];
     expect(definition, `${CONSTRAINT_KEY} missing from database/schema-reference-snapshot.json — regenerate via: npm run schema:snapshot:lint`).toBeTruthy();
 
     const allowed = parseCheckConstraintAllowedValues(definition);
-    const drifted = Object.values(ARTIFACT_TYPES).filter((v) => !allowed.has(v));
+    const pending = loadPendingChairmanGateAllowlist();
+    const drifted = Object.values(ARTIFACT_TYPES).filter((v) => !allowed.has(v) && !(v in pending));
 
-    expect(drifted, `ARTIFACT_TYPES values missing from the live constraint (add via a chairman-gated migration, then npm run schema:snapshot:lint): ${drifted.join(', ')}`).toEqual([]);
+    expect(drifted, `ARTIFACT_TYPES values missing from the live constraint (add via a chairman-gated migration, then either npm run schema:snapshot:lint after it's applied, or a reasoned entry in database/artifact-type-parity-pending-chairman-gate.json while it's pending): ${drifted.join(', ')}`).toEqual([]);
+  });
+
+  it('no pending-chairman-gate allowlist entry references a value ALREADY present in the live constraint (stale — remove it)', () => {
+    const snapshot = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8'));
+    const definition = snapshot.checks && snapshot.checks[CONSTRAINT_KEY];
+    const allowed = parseCheckConstraintAllowedValues(definition);
+    const pending = loadPendingChairmanGateAllowlist();
+    const stale = Object.keys(pending).filter((v) => allowed.has(v));
+
+    expect(stale, `these pending-chairman-gate allowlist entries are now live in the constraint — remove them from database/artifact-type-parity-pending-chairman-gate.json: ${stale.join(', ')}`).toEqual([]);
   });
 });
 

--- a/tests/unit/stage-17/refinement.test.js
+++ b/tests/unit/stage-17/refinement.test.js
@@ -22,6 +22,7 @@ vi.mock('../../../lib/llm/client-factory.js', () => ({
 
 import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
 import { generateRefinedVariants } from '../../../lib/eva/stage-17/refinement.js';
+import { ARTIFACT_TYPES } from '../../../lib/eva/artifact-types.js';
 
 describe('refinement', () => {
   beforeEach(() => {
@@ -107,6 +108,26 @@ describe('refinement', () => {
       );
       const pricingIds = writeArtifact.mock.calls.map((call) => call[1].metadata.screenId);
       expect(pricingIds.some((id) => homeIds.includes(id))).toBe(false);
+    });
+
+    // SD-LEO-FIX-REGISTER-STAGE-REFINED-001: the live Pass-1-selection refinement path
+    // wrote artifactType: 'stage_17_refined' as a hardcoded literal not registered in
+    // ARTIFACT_TYPES nor the venture_artifacts_artifact_type_check CHECK constraint --
+    // every writeArtifact() call threw, so this path had never successfully persisted
+    // a refined variant in production. Asserts the call now sources the type from the
+    // single-source-of-truth registry (matching artifact-types.js's own "no hardcoded
+    // artifact type strings" rule), catching a future re-drift between the two.
+    test('writes artifactType from the ARTIFACT_TYPES registry (not a hardcoded literal)', async () => {
+      await generateRefinedVariants(
+        'v-1', 'Home',
+        ['<html>A1</html>', '<html>A2</html>'],
+        { colors: ['#FF5733'], typeScale: { heading: 'Inter', body: 'Roboto' } },
+        {}
+      );
+      for (const call of writeArtifact.mock.calls) {
+        expect(call[1].artifactType).toBe(ARTIFACT_TYPES.BLUEPRINT_S17_REFINED);
+      }
+      expect(ARTIFACT_TYPES.BLUEPRINT_S17_REFINED).toBe('stage_17_refined');
     });
   });
 });


### PR DESCRIPTION
## Summary
- `lib/eva/stage-17/refinement.js`'s `generateRefinedVariants()` — the LIVE Pass-1-selection refinement path invoked by `selection-flow.js` `submitPass1Selection()` — writes `artifactType: 'stage_17_refined'`, which is not registered in `ARTIFACT_TYPES` nor allowed by the live `venture_artifacts_artifact_type_check` CHECK constraint. Confirmed live during SD-LEO-FIX-RESOLVE-STAGE-ARCHETYPE-001 smoke verification: every `writeArtifact` call on this path throws a CHECK constraint violation — this path has never successfully persisted a refined variant in production.
- Registers `ARTIFACT_TYPES.BLUEPRINT_S17_REFINED` and switches `refinement.js` to source the type from the registry instead of a hardcoded literal.
- Stages (but does **not** apply) a chairman-gated CHECK-widening migration, per `metadata.requires_chairman_apply=true` set at sourcing (escalated from QF-20260711-926) — DDL apply requires a separate chairman GO.
- Adds a small, reason-required, self-cleaning "pending chairman-gate" allowlist so the existing `ARTIFACT_TYPES`↔CHECK-constraint CI parity test (built after an identical `blueprint_user_journey` incident) stays honest and green while the migration awaits chairman apply, instead of either faking the live schema snapshot or breaking CI. A dedicated regression test fails if an allowlist entry goes stale (its value becomes live), so the exemption can't silently mask a future real drift.

## Chairman action required (post-merge)
1. Review and apply `database/migrations/20260711_add_stage_17_refined_artifact_type.sql`.
2. Run `npm run schema:snapshot:lint` to regenerate `database/schema-reference-snapshot.json`.
3. Remove the now-stale `stage_17_refined` entry from `database/artifact-type-parity-pending-chairman-gate.json` (a dedicated test will start failing until this is done).

## Test plan
- [x] `npx vitest run tests/unit/eva/artifact-type-db-parity.test.js tests/unit/eva/artifact-types.test.js tests/unit/stage-17/archetype-generator.test.js tests/unit/stage-17/refinement.test.js tests/database/s17-artifact-types.test.js` — 45/45 passing
- [x] `node scripts/lint/schema-reference-lint.mjs` — 0 violations
- [x] Verified `scripts/check-migration-readiness.mjs`'s `parseChairmanGatedMarker()` recognizes the new migration file's marker
- [x] Confirmed no live DB write occurs (migration staged only, `database/schema-reference-snapshot.json` untouched by this diff)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>