### PR TITLE
feat(SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D): staged chairman cash/burn write RPC + attributed-revenue feeder rewire

### DIFF
--- a/database/migrations/20260711120000_upsert_operator_cash_burn_chairman_editable.sql
+++ b/database/migrations/20260711120000_upsert_operator_cash_burn_chairman_editable.sql
@@ -1,0 +1,83 @@
+-- upsert_operator_cash_burn: chairman-editable write path for operator_cash_burn_monthly.
+-- SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D (FR-5/H10).
+--
+-- operator_cash_burn_monthly's RLS policies grant SELECT to `authenticated` and ALL to
+-- `service_role` only (verified live, 2026-07-11) -- the browser-side chairman client has
+-- no write path at all today. This SECURITY DEFINER RPC, gated by fn_is_chairman() (the
+-- same canonical role check used by kill_venture / approve_chairman_decision), is the
+-- established pattern in this codebase for exactly this class of problem: a chairman-only
+-- write against an RLS-locked table, without opening broad `authenticated` write access.
+--
+-- Only non-null parameters are applied (partial update) -- omitting a field leaves the
+-- existing value/freshness timestamp untouched. Every field the chairman DOES set gets its
+-- *_last_synced_at stamped to now() (a manual entry is "live" as of the moment it's saved,
+-- until superseded by the next automated feeder run). ai_burn_is_lower_bound is set to
+-- false when the chairman explicitly sets ai_burn_usd -- a manually-entered exact figure is
+-- not a lower-bound estimate. revenue_livemode is set to true when the chairman explicitly
+-- sets revenue_usd -- treats a chairman-asserted override/forecast with the same honesty
+-- weight as a live attributed figure, per FR-5's "override/forecast" framing.
+--
+-- Always targets the CURRENT period_month (date_trunc('month', now())) -- mirrors
+-- currentPeriodMonth() in src/hooks/useOperatorCashBurn.ts (ehg repo).
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. Application code (the new chairman-editable
+-- cash/burn form) calls this RPC and surfaces a clear "not yet enabled" error toast if
+-- it 404s (function does not exist) -- it degrades safely until the chairman applies
+-- this migration, matching this codebase's established staged-DDL convention.
+--
+-- requires-chairman-apply
+
+CREATE OR REPLACE FUNCTION public.upsert_operator_cash_burn(
+  p_cash_usd numeric DEFAULT NULL,
+  p_ai_burn_usd numeric DEFAULT NULL,
+  p_other_burn_usd numeric DEFAULT NULL,
+  p_revenue_usd numeric DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_period_month date := date_trunc('month', now())::date;
+  v_row public.operator_cash_burn_monthly;
+BEGIN
+  IF NOT public.fn_is_chairman() THEN
+    RAISE EXCEPTION 'Only the chairman can edit the cash/burn model'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  INSERT INTO public.operator_cash_burn_monthly (
+    period_month, cash_usd, cash_last_synced_at,
+    ai_burn_usd, ai_burn_last_synced_at, ai_burn_is_lower_bound,
+    other_burn_usd, other_burn_last_synced_at,
+    revenue_usd, revenue_last_synced_at, revenue_livemode
+  )
+  VALUES (
+    v_period_month, p_cash_usd, CASE WHEN p_cash_usd IS NOT NULL THEN now() END,
+    p_ai_burn_usd, CASE WHEN p_ai_burn_usd IS NOT NULL THEN now() END, CASE WHEN p_ai_burn_usd IS NOT NULL THEN false ELSE true END,
+    p_other_burn_usd, CASE WHEN p_other_burn_usd IS NOT NULL THEN now() END,
+    p_revenue_usd, CASE WHEN p_revenue_usd IS NOT NULL THEN now() END, CASE WHEN p_revenue_usd IS NOT NULL THEN true ELSE NULL END
+  )
+  ON CONFLICT (period_month) DO UPDATE SET
+    cash_usd = COALESCE(EXCLUDED.cash_usd, public.operator_cash_burn_monthly.cash_usd),
+    cash_last_synced_at = COALESCE(EXCLUDED.cash_last_synced_at, public.operator_cash_burn_monthly.cash_last_synced_at),
+    ai_burn_usd = COALESCE(EXCLUDED.ai_burn_usd, public.operator_cash_burn_monthly.ai_burn_usd),
+    ai_burn_last_synced_at = COALESCE(EXCLUDED.ai_burn_last_synced_at, public.operator_cash_burn_monthly.ai_burn_last_synced_at),
+    ai_burn_is_lower_bound = CASE WHEN p_ai_burn_usd IS NOT NULL THEN false ELSE public.operator_cash_burn_monthly.ai_burn_is_lower_bound END,
+    other_burn_usd = COALESCE(EXCLUDED.other_burn_usd, public.operator_cash_burn_monthly.other_burn_usd),
+    other_burn_last_synced_at = COALESCE(EXCLUDED.other_burn_last_synced_at, public.operator_cash_burn_monthly.other_burn_last_synced_at),
+    revenue_usd = COALESCE(EXCLUDED.revenue_usd, public.operator_cash_burn_monthly.revenue_usd),
+    revenue_last_synced_at = COALESCE(EXCLUDED.revenue_last_synced_at, public.operator_cash_burn_monthly.revenue_last_synced_at),
+    revenue_livemode = CASE WHEN p_revenue_usd IS NOT NULL THEN true ELSE public.operator_cash_burn_monthly.revenue_livemode END,
+    updated_at = now()
+  RETURNING * INTO v_row;
+
+  RETURN to_jsonb(v_row);
+END;
+$function$;
+
+COMMENT ON FUNCTION public.upsert_operator_cash_burn IS
+  'Chairman-only (fn_is_chairman-gated) partial upsert into operator_cash_burn_monthly for the current period_month. SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D FR-5.';
+
+GRANT EXECUTE ON FUNCTION public.upsert_operator_cash_burn(numeric, numeric, numeric, numeric) TO authenticated;

--- a/scripts/operator/feed-operator-cash-burn.mjs
+++ b/scripts/operator/feed-operator-cash-burn.mjs
@@ -8,8 +8,11 @@
  *         --days 30 --json) and write it to income_capture_monthly.business_expenses AND the
  *         substrate ai_burn input, ALWAYS labeled a lower bound (main-session Opus tokens are
  *         structurally uncaptured).
- *   FR-3  REVENUE: mirror income_capture_monthly.recurring_revenue into the substrate revenue input
- *         with its livemode (test-mode) flag.
+ *   FR-3  REVENUE: prefer lib/payments/attribution-resolver.js's computeAttributedRevenue()
+ *         (real Stripe attribution, SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002) when
+ *         ops_payment_events has any row fleet-wide; otherwise fall back to mirroring
+ *         income_capture_monthly.recurring_revenue (pre-attribution behavior). Updated by
+ *         SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D (FR-5/H10, spec refresh 2026-07-10).
  *   FR-5  BACKFILL: price venture_token_ledger.cost_usd from token counts via lib/cost/llm-pricing.js
  *         for rows whose model is resolvable — leave unpriceable (unknown-model) rows untouched.
  *
@@ -28,6 +31,7 @@ import path from 'node:path';
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { priceFor } from '../../lib/cost/llm-pricing.js';
 import { periodMonthOf, upsertSubstrateInputs, AI_BURN_LOWER_BOUND_LABEL } from '../../lib/operator/cash-burn-substrate.js';
+import { computeAttributedRevenue } from '../../lib/payments/attribution-resolver.js';
 import { readStripeCashSlice } from '../../lib/operator/cash-sources/stripe-balance.js';
 import { readBankCashSlice } from '../../lib/operator/cash-sources/bank-read-service.js';
 import { loadTellerCertPair } from '../../lib/operator/cash-sources/token-vault.js';
@@ -176,25 +180,59 @@ async function main() {
   } catch (e) { warn('FR-2', `failed (fail-soft): ${e.message}`); result.ai_burn = { written: false, error: e.message }; }
 
   // ---- FR-3: revenue mirror ----
+  // SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D (FR-5/H10, spec refresh 2026-07-10): prefer
+  // computeAttributedRevenue's real Stripe attribution (lib/payments/attribution-resolver.js,
+  // SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002) over the pre-pivot income_capture_monthly
+  // mirror. Distinguishing "attribution wired but $0 this period" (a genuine live reading)
+  // from "attribution never wired" (fall back) requires checking whether ops_payment_events
+  // has ANY row at all, not just rows in the current period.
   try {
-    // Prefer the LIVE row; fall back to the TEST-mode row, surfacing the livemode flag honestly.
-    const { data: rows, error } = await supabase
-      .from('income_capture_monthly')
-      .select('recurring_revenue, livemode')
-      .eq('period_month', periodMonth);
-    if (error) throw new Error(error.message);
-    const live = (rows || []).find((r) => r.livemode === true);
-    const test = (rows || []).find((r) => r.livemode === false);
-    const pick = live || test || null;
-    if (!pick) {
-      result.revenue = { written: false, reason: 'no income_capture_monthly row yet (left stale)' };
-    } else {
-      const revUsd = pick.recurring_revenue == null ? null : Number(pick.recurring_revenue);
-      log('FR-3', `revenue = $${revUsd} (livemode=${pick.livemode})`);
-      if (!DRY_RUN && revUsd != null) {
-        await upsertSubstrateInputs(periodMonth, { revenue_usd: revUsd, revenue_livemode: pick.livemode === true }, supabase, nowIso);
+    const { count: anyEventCount, error: anyEventErr } = await supabase
+      .from('ops_payment_events')
+      .select('id', { count: 'exact', head: true });
+    if (anyEventErr) throw new Error(anyEventErr.message);
+
+    if ((anyEventCount ?? 0) > 0) {
+      // Attribution is live fleet-wide — use it as the primary source, even if this
+      // specific period has zero matching rows (a genuine $0, not a missing source).
+      const periodStart = `${periodMonth}T00:00:00.000Z`;
+      const periodEnd = new Date(new Date(periodStart).getTime());
+      periodEnd.setUTCMonth(periodEnd.getUTCMonth() + 1);
+      const { data: periodRows, error: periodErr } = await supabase
+        .from('ops_payment_events')
+        .select('amount_cents, currency, event_type, payment_intent_id, stripe_charge_id, id')
+        .eq('livemode', true)
+        .gte('event_ts', periodStart)
+        .lt('event_ts', periodEnd.toISOString());
+      if (periodErr) throw new Error(periodErr.message);
+      const { totalCents } = computeAttributedRevenue(periodRows || []);
+      const revUsd = Number((totalCents / 100).toFixed(2));
+      log('FR-3', `revenue (attributed) = $${revUsd} (livemode=true, ${(periodRows || []).length} events)`);
+      if (!DRY_RUN) {
+        await upsertSubstrateInputs(periodMonth, { revenue_usd: revUsd, revenue_livemode: true }, supabase, nowIso);
       }
-      result.revenue = { written: !DRY_RUN && revUsd != null, value_usd: revUsd, livemode: pick.livemode === true };
+      result.revenue = { written: !DRY_RUN, value_usd: revUsd, livemode: true, source: 'attribution_resolver' };
+    } else {
+      // Attribution never wired for this fleet yet — fall back to the pre-pivot mirror.
+      // Prefer the LIVE row; fall back to the TEST-mode row, surfacing livemode honestly.
+      const { data: rows, error } = await supabase
+        .from('income_capture_monthly')
+        .select('recurring_revenue, livemode')
+        .eq('period_month', periodMonth);
+      if (error) throw new Error(error.message);
+      const live = (rows || []).find((r) => r.livemode === true);
+      const test = (rows || []).find((r) => r.livemode === false);
+      const pick = live || test || null;
+      if (!pick) {
+        result.revenue = { written: false, reason: 'no income_capture_monthly row yet (left stale)', source: 'income_capture_monthly' };
+      } else {
+        const revUsd = pick.recurring_revenue == null ? null : Number(pick.recurring_revenue);
+        log('FR-3', `revenue (fallback) = $${revUsd} (livemode=${pick.livemode})`);
+        if (!DRY_RUN && revUsd != null) {
+          await upsertSubstrateInputs(periodMonth, { revenue_usd: revUsd, revenue_livemode: pick.livemode === true }, supabase, nowIso);
+        }
+        result.revenue = { written: !DRY_RUN && revUsd != null, value_usd: revUsd, livemode: pick.livemode === true, source: 'income_capture_monthly' };
+      }
     }
   } catch (e) { warn('FR-3', `failed (fail-soft): ${e.message}`); result.revenue = { written: false, error: e.message }; }
 

--- a/tests/unit/operator/feed-operator-cash-burn-fr3.test.js
+++ b/tests/unit/operator/feed-operator-cash-burn-fr3.test.js
@@ -1,0 +1,188 @@
+/**
+ * FR-3 revenue-mirror rewire tests for scripts/operator/feed-operator-cash-burn.mjs
+ * SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D (FR-5/H10, spec refresh 2026-07-10).
+ *
+ * The existing operator tests (parse-cash-flag.test.js, cash-burn-substrate.test.js)
+ * are pure-function suites and never drive main(). No established main()-level
+ * Supabase mock exists, so this focused suite builds the minimal graph mock needed
+ * to exercise ONLY the FR-3 branch:
+ *
+ *   attribution live (ops_payment_events has any row)  → computeAttributedRevenue
+ *      drives revenue_usd, revenue_livemode:true, source:'attribution_resolver'
+ *      — even when THIS period has zero matching rows (a genuine live $0).
+ *   attribution never wired (count 0)                  → fall back to the old
+ *      income_capture_monthly mirror, source:'income_capture_monthly'.
+ *
+ * The other steps are neutralized (not tested): FR-cash goes inert (bank/teller
+ * mocks return null, no --cash flag), FR-2's cost-report spawnSync is stubbed to
+ * fail-soft (returns null), FR-5's ledger query returns []. computeAttributedRevenue
+ * and periodMonthOf run for real so the assertions are meaningful.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted shared state: per-test Supabase responses + spies, referenced from the
+// (hoisted) vi.mock factories below.
+const H = vi.hoisted(() => ({
+  state: { responses: {}, tablesQueried: [] },
+  upsertSpy: vi.fn(async () => {}),
+  spawnSyncMock: vi.fn(() => ({ status: 1, stdout: '', signal: null })),
+}));
+
+// --- Supabase service client: a table-routed, chainable, thenable query builder ---
+vi.mock('../../../lib/supabase-client.js', () => {
+  function tableBuilder(table) {
+    const st = { opts: undefined };
+    const resolveResult = () => {
+      const r = H.state.responses[table] || {};
+      // head-count query (select('id', { count:'exact', head:true }))
+      if (st.opts && (st.opts.head || st.opts.count)) {
+        return { count: r.count ?? 0, error: r.countError ?? null, data: null };
+      }
+      return { data: r.data ?? [], error: r.error ?? null, count: r.count ?? null };
+    };
+    const builder = {
+      select: (_cols, opts) => { st.opts = opts; return builder; },
+      eq: () => builder,
+      gte: () => builder,
+      lt: () => builder,
+      or: () => builder,
+      limit: () => builder,
+      then: (res, rej) => Promise.resolve().then(resolveResult).then(res, rej),
+    };
+    return builder;
+  }
+  return {
+    createSupabaseServiceClient: () => ({
+      from: (table) => {
+        H.state.tablesQueried.push(table);
+        return tableBuilder(table);
+      },
+    }),
+  };
+});
+
+// --- Substrate lib: keep periodMonthOf/labels real, spy the write ---
+vi.mock('../../../lib/operator/cash-burn-substrate.js', async (importActual) => {
+  const actual = await importActual();
+  return { ...actual, upsertSubstrateInputs: H.upsertSpy };
+});
+
+// --- Cash sources: keep FR-cash inert (no network/credentials) ---
+vi.mock('../../../lib/operator/cash-sources/bank-read-service.js', () => ({
+  readBankCashSlice: async () => null,
+}));
+vi.mock('../../../lib/operator/cash-sources/stripe-balance.js', () => ({
+  readStripeCashSlice: async () => null,
+}));
+vi.mock('../../../lib/operator/cash-sources/token-vault.js', () => ({
+  loadTellerCertPair: async () => ({ certPem: null, keyPem: null }),
+}));
+vi.mock('../../../lib/operator/cash-sources/teller-client.js', () => ({
+  createTellerClient: () => ({}),
+}));
+
+// --- FR-2 cost report: fail-soft (spawnSync returns non-zero → ai_burn stays stale) ---
+vi.mock('node:child_process', () => ({ spawnSync: H.spawnSyncMock }));
+
+// computeAttributedRevenue + periodMonthOf are intentionally NOT mocked (real).
+import { main } from '../../../scripts/operator/feed-operator-cash-burn.mjs';
+
+function upsertCallWith(key) {
+  return H.upsertSpy.mock.calls.find((c) => c[1] && key in c[1]);
+}
+
+describe('feed-operator-cash-burn FR-3 revenue-mirror rewire', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    H.state.responses = {};
+    H.state.tablesQueried = [];
+    // FR-5 backfill: empty ledger so that step is a no-op.
+    H.state.responses.venture_token_ledger = { data: [] };
+  });
+
+  it('(a) attribution live: computeAttributedRevenue drives revenue_usd, livemode:true, source:attribution_resolver', async () => {
+    H.state.responses.ops_payment_events = {
+      count: 2, // any row fleet-wide → attribution is live
+      data: [
+        {
+          event_type: 'charge.succeeded',
+          amount_cents: 12300,
+          currency: 'usd',
+          payment_intent_id: 'pi_1',
+          stripe_charge_id: 'ch_1',
+          id: 'e1',
+        },
+      ],
+    };
+
+    const result = await main();
+
+    expect(result.revenue).toMatchObject({
+      written: true,
+      value_usd: 123, // 12300 cents / 100, via the real computeAttributedRevenue
+      livemode: true,
+      source: 'attribution_resolver',
+    });
+    const call = upsertCallWith('revenue_usd');
+    expect(call).toBeTruthy();
+    expect(call[1]).toMatchObject({ revenue_usd: 123, revenue_livemode: true });
+    // fallback source must NOT have been consulted
+    expect(H.state.tablesQueried).not.toContain('income_capture_monthly');
+  });
+
+  it('(b) attribution live but ZERO rows this period: genuine live $0, NOT a fallback', async () => {
+    H.state.responses.ops_payment_events = {
+      count: 1, // attribution wired fleet-wide...
+      data: [], // ...but no events in the current period
+    };
+
+    const result = await main();
+
+    expect(result.revenue).toMatchObject({
+      written: true,
+      value_usd: 0,
+      livemode: true,
+      source: 'attribution_resolver',
+    });
+    const call = upsertCallWith('revenue_usd');
+    expect(call[1]).toMatchObject({ revenue_usd: 0, revenue_livemode: true });
+    // must NOT fall back to income_capture_monthly on a live $0 reading
+    expect(H.state.tablesQueried).not.toContain('income_capture_monthly');
+  });
+
+  it('(c) attribution never wired (count 0): falls back to income_capture_monthly (live row)', async () => {
+    H.state.responses.ops_payment_events = { count: 0 };
+    H.state.responses.income_capture_monthly = {
+      data: [{ recurring_revenue: 4500, livemode: true }],
+    };
+
+    const result = await main();
+
+    expect(result.revenue).toMatchObject({
+      written: true,
+      value_usd: 4500,
+      livemode: true,
+      source: 'income_capture_monthly',
+    });
+    const call = upsertCallWith('revenue_usd');
+    expect(call[1]).toMatchObject({ revenue_usd: 4500, revenue_livemode: true });
+    expect(H.state.tablesQueried).toContain('income_capture_monthly');
+  });
+
+  it('(c2) fallback surfaces test-mode livemode honestly (income row livemode:false)', async () => {
+    H.state.responses.ops_payment_events = { count: 0 };
+    H.state.responses.income_capture_monthly = {
+      data: [{ recurring_revenue: 200, livemode: false }],
+    };
+
+    const result = await main();
+
+    expect(result.revenue).toMatchObject({
+      value_usd: 200,
+      livemode: false,
+      source: 'income_capture_monthly',
+    });
+    const call = upsertCallWith('revenue_usd');
+    expect(call[1]).toMatchObject({ revenue_usd: 200, revenue_livemode: false });
+  });
+});


### PR DESCRIPTION
## Summary
- New migration `20260711120000_upsert_operator_cash_burn_chairman_editable.sql`: `SECURITY DEFINER` `upsert_operator_cash_burn` RPC, `fn_is_chairman()`-gated partial upsert into `operator_cash_burn_monthly` (the table has no authenticated-role write RLS policy). **Staged, chairman-apply-gated DDL** (`-- requires-chairman-apply` marker); `metadata.requires_chairman_apply` set on the SD. Backs the new CashBurnEditor in the EHG app, which degrades honestly until applied.
- `scripts/operator/feed-operator-cash-burn.mjs` FR-3 revenue mirror: prefers `computeAttributedRevenue()` over `ops_payment_events` (livemode, period-scoped) once any attribution event exists fleet-wide; falls back to `income_capture_monthly` only when attribution was never wired.

## Test plan
- `tests/unit/operator/feed-operator-cash-burn-fr3.test.js`: 4 tests (attribution-live, attribution-live-zero-rows, attribution-never-wired, test-mode fallback honesty) — all green
- Full `tests/unit/operator/` suite green (59 tests)

Cross-repo counterpart: ehg PR carrying the chairman-v3 UI changes (SD-EHG-PRODUCT-UIUX-REMEDIATION-001-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)