### PR TITLE
feat(SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001): activate dormant venture ops-actuals layer

### DIFF
--- a/.github/workflows/venture-ops-actuals-cron.yml
+++ b/.github/workflows/venture-ops-actuals-cron.yml
@@ -1,0 +1,49 @@
+name: "Venture ops-actuals sweep (cron)"
+
+# SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 — ops_product_health and ops_revenue_metrics had
+# full schemas and fully-built collectors but ZERO rows: nothing scheduled/invoked them
+# (dormant-machinery class). This workflow is the named dispatcher for all three ops
+# jobs (product-health collector, revenue-metrics collector, external uptime probe on
+# deployed venture URLs) — see scripts/cron/venture-ops-actuals-sweep.mjs for the full
+# per-job breakdown and the G3 ARMED/ACTIVATED registration each job performs.
+
+on:
+  schedule:
+    # Every 6 hours — collectors compute a per-day (venture_id, metric_date) upsert, so
+    # more than daily cadence isn't required for the metrics; the uptime probe benefits
+    # from the tighter cadence (2-consecutive-failure threshold resolves faster).
+    - cron: '20 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: Product-health + revenue-metrics collectors, uptime probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run sweep (--once)
+        run: node scripts/cron/venture-ops-actuals-sweep.mjs --once

--- a/lib/fleet/exec-email-ops-actuals.mjs
+++ b/lib/fleet/exec-email-ops-actuals.mjs
@@ -1,0 +1,81 @@
+// exec-email-ops-actuals.mjs
+// SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 (FR-5): one actuals-vs-targets line per live venture
+// in the chairman exec-summary email, combining cost (venture_token_ledger) with health
+// (ops_product_health). Extends the EXISTING exec-email pipeline (no new report) — mirrors
+// the computeAlignmentLines fail-soft pattern in lib/fleet/exec-email-alignment.mjs.
+//
+// "Live venture" selection matches the rest of the SD: ventures WHERE deployment_url IS NOT
+// NULL (status is unreliable post-pivot — see lib/ops/venture-uptime-probe.js header).
+
+const WINDOW_DAYS = 30;
+
+/**
+ * PURE: format one venture's actuals line from its cost + health inputs.
+ * @param {{ name: string }} venture
+ * @param {{ costUsd: number|null, uptimePct: number|null, hasHealthRow: boolean }} actuals
+ * @returns {string}
+ */
+export function formatVentureActualsLine(venture, actuals) {
+  const name = venture?.name || 'Unknown venture';
+  const costPart = Number.isFinite(actuals?.costUsd)
+    ? `$${actuals.costUsd.toFixed(2)} cost (${WINDOW_DAYS}d)`
+    : `$0.00 cost (${WINDOW_DAYS}d)`;
+  const healthPart = actuals?.hasHealthRow && Number.isFinite(actuals?.uptimePct)
+    ? `${actuals.uptimePct.toFixed(1)}% uptime`
+    : 'health: no data yet';
+  return `${name}: ${costPart} · ${healthPart}`;
+}
+
+/**
+ * Compute the per-venture actuals lines for the exec email. Fail-soft: any error yields
+ * an empty array (the caller renders nothing for this section) rather than throwing.
+ * @param {{ supabase: object }} io
+ * @param {{ nowMs?: number }} [opts]
+ * @returns {Promise<string[]>}
+ */
+export async function computeOpsActualsLines(io, opts = {}) {
+  const db = io && io.supabase;
+  if (!db) return [];
+
+  try {
+    const { data: ventures, error: vErr } = await db
+      .from('ventures')
+      .select('id, name, deployment_url')
+      .not('deployment_url', 'is', null)
+      .neq('deployment_url', '');
+    if (vErr || !ventures || ventures.length === 0) return [];
+
+    const nowMs = typeof opts.nowMs === 'number' ? opts.nowMs : Date.now();
+    const sinceIso = new Date(nowMs - WINDOW_DAYS * 24 * 3600 * 1000).toISOString();
+    const todayDate = new Date(nowMs).toISOString().split('T')[0];
+
+    const lines = [];
+    for (const venture of ventures) {
+      let costUsd = 0;
+      try {
+        const { data: ledgerRows } = await db
+          .from('venture_token_ledger')
+          .select('cost_usd')
+          .eq('venture_id', venture.id)
+          .gte('created_at', sinceIso);
+        costUsd = (ledgerRows || []).reduce((sum, r) => sum + (Number(r.cost_usd) || 0), 0);
+      } catch { /* fail-soft per venture: cost defaults to 0 */ }
+
+      let uptimePct = null, hasHealthRow = false;
+      try {
+        const { data: health } = await db
+          .from('ops_product_health')
+          .select('uptime_pct')
+          .eq('venture_id', venture.id)
+          .eq('metric_date', todayDate)
+          .maybeSingle();
+        if (health) { hasHealthRow = true; uptimePct = health.uptime_pct; }
+      } catch { /* fail-soft per venture: health omitted */ }
+
+      lines.push(formatVentureActualsLine(venture, { costUsd, uptimePct, hasHealthRow }));
+    }
+    return lines;
+  } catch {
+    return [];
+  }
+}

--- a/lib/fleet/exec-email-ops-actuals.test.js
+++ b/lib/fleet/exec-email-ops-actuals.test.js
@@ -1,0 +1,93 @@
+// SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 (FR-5): unit tests for the per-venture exec-email
+// actuals line (cost from venture_token_ledger + health from ops_product_health).
+import { describe, it, expect } from 'vitest';
+import { formatVentureActualsLine, computeOpsActualsLines } from './exec-email-ops-actuals.mjs';
+
+describe('formatVentureActualsLine (pure formatter)', () => {
+  it('formats cost + uptime when both are present', () => {
+    const line = formatVentureActualsLine({ name: 'MarketLens' }, { costUsd: 12.5, uptimePct: 99.4, hasHealthRow: true });
+    expect(line).toBe('MarketLens: $12.50 cost (30d) · 99.4% uptime');
+  });
+
+  it('shows $0.00 cost when no ledger rows exist yet', () => {
+    const line = formatVentureActualsLine({ name: 'MarketLens' }, { costUsd: 0, uptimePct: null, hasHealthRow: false });
+    expect(line).toContain('$0.00 cost (30d)');
+  });
+
+  it('shows "no data yet" for health when no ops_product_health row exists (not a fabricated 0%)', () => {
+    const line = formatVentureActualsLine({ name: 'MarketLens' }, { costUsd: 5, uptimePct: null, hasHealthRow: false });
+    expect(line).toContain('health: no data yet');
+    expect(line).not.toContain('0.0% uptime');
+  });
+
+  it('falls back to a placeholder name when venture is missing a name', () => {
+    const line = formatVentureActualsLine({}, { costUsd: 0, uptimePct: null, hasHealthRow: false });
+    expect(line).toContain('Unknown venture');
+  });
+});
+
+/** Minimal fake supabase for computeOpsActualsLines. */
+function makeSupabase({ ventures = [], ledgerByVenture = {}, healthByVenture = {} } = {}) {
+  return {
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select() { return this; }, not() { return this; }, neq() { return this; },
+          then: (resolve) => resolve({ data: ventures, error: null }),
+        };
+      }
+      if (table === 'venture_token_ledger') {
+        const ctx = {};
+        return {
+          select() { return this; },
+          eq(col, val) { ctx.venture_id = val; return this; },
+          gte() { return this; },
+          then: (resolve) => resolve({ data: ledgerByVenture[ctx.venture_id] || [], error: null }),
+        };
+      }
+      if (table === 'ops_product_health') {
+        const ctx = {};
+        return {
+          select() { return this; },
+          eq(col, val) { if (col === 'venture_id') ctx.venture_id = val; return this; },
+          maybeSingle: async () => ({ data: healthByVenture[ctx.venture_id] || null, error: null }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('computeOpsActualsLines', () => {
+  it('returns one line per live-deployment venture, summing ledger cost and reading today\'s health', async () => {
+    const ventures = [{ id: 'v1', name: 'MarketLens', deployment_url: 'https://x' }];
+    const ledgerByVenture = { v1: [{ cost_usd: 1.5 }, { cost_usd: 2.25 }] };
+    const healthByVenture = { v1: { uptime_pct: 99.9 } };
+
+    const lines = await computeOpsActualsLines({ supabase: makeSupabase({ ventures, ledgerByVenture, healthByVenture }) });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe('MarketLens: $3.75 cost (30d) · 99.9% uptime');
+  });
+
+  it('returns an empty array (fail-soft) when there are no live-deployment ventures', async () => {
+    const lines = await computeOpsActualsLines({ supabase: makeSupabase({ ventures: [] }) });
+    expect(lines).toEqual([]);
+  });
+
+  it('never throws when supabase is missing (fail-soft)', async () => {
+    await expect(computeOpsActualsLines({})).resolves.toEqual([]);
+  });
+
+  it('degrades a single venture to $0/no-data on a per-table query error without dropping other ventures', async () => {
+    const ventures = [
+      { id: 'v1', name: 'MarketLens', deployment_url: 'https://x' },
+      { id: 'v2', name: 'CronGenius', deployment_url: 'https://y' },
+    ];
+    const supabase = makeSupabase({ ventures, ledgerByVenture: { v2: [{ cost_usd: 4 }] }, healthByVenture: { v2: { uptime_pct: 80 } } });
+    const lines = await computeOpsActualsLines({ supabase });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('$0.00 cost');
+    expect(lines[1]).toContain('$4.00 cost');
+  });
+});

--- a/lib/ops/venture-uptime-probe.js
+++ b/lib/ops/venture-uptime-probe.js
@@ -85,7 +85,13 @@ export function computeNextProbeState(priorProbe, checkResult, nowIso) {
 /**
  * Ensure a venture_deployments row exists for every venture with a deployment_url.
  * Idempotent: upserts on (venture_id, url) so a re-run never duplicates rows.
- * @returns {Promise<Array<{ id: string, venture_id: string, url: string, metadata: object }>>}
+ * Adversarial-review fix: lookup/insert failures used to be console.warn'd and silently
+ * dropped — a venture whose seed row could never be created was indistinguishable from a
+ * venture that legitimately has no deployment_url, which would let runVentureUptimeProbe
+ * report checked=0/errors=[] (a silent green pass) even when every venture failed to seed.
+ * Errors are now returned alongside rows so the caller can fold them into its own summary.
+ *
+ * @returns {Promise<{ rows: Array<{ id: string, venture_id: string, url: string, metadata: object }>, errors: string[] }>}
  */
 export async function ensureDeploymentRows(supabase) {
   const { data: ventures, error: vErr } = await supabase
@@ -96,6 +102,7 @@ export async function ensureDeploymentRows(supabase) {
   if (vErr) throw new Error(`ensureDeploymentRows: ventures query failed: ${vErr.message}`);
 
   const rows = [];
+  const errors = [];
   for (const v of ventures || []) {
     const { data: existing, error: findErr } = await supabase
       .from('venture_deployments')
@@ -103,7 +110,12 @@ export async function ensureDeploymentRows(supabase) {
       .eq('venture_id', v.id)
       .eq('url', v.deployment_url)
       .maybeSingle();
-    if (findErr) { console.warn(`[uptime-probe] lookup failed for venture ${v.id}: ${findErr.message}`); continue; }
+    if (findErr) {
+      const msg = `${v.id}: lookup failed: ${findErr.message}`;
+      console.warn(`[uptime-probe] ${msg}`);
+      errors.push(msg);
+      continue;
+    }
 
     if (existing) {
       rows.push(existing);
@@ -115,10 +127,15 @@ export async function ensureDeploymentRows(supabase) {
       .insert({ venture_id: v.id, url: v.deployment_url, actor: 'venture-ops-actuals-sweep', status: 'seeded', metadata: {} })
       .select('id, venture_id, url, metadata')
       .single();
-    if (insErr) { console.warn(`[uptime-probe] seed insert failed for venture ${v.id}: ${insErr.message}`); continue; }
+    if (insErr) {
+      const msg = `${v.id}: seed insert failed: ${insErr.message}`;
+      console.warn(`[uptime-probe] ${msg}`);
+      errors.push(msg);
+      continue;
+    }
     rows.push(created);
   }
-  return rows;
+  return { rows, errors };
 }
 
 /**
@@ -148,14 +165,16 @@ export async function surfaceUnreachableToProductHealth(supabase, ventureId, met
 /**
  * Run one probe cycle across all deployed ventures.
  * @param {{ supabase: object, fetchFn?: typeof fetch, timeoutMs?: number, nowIso?: string }} params
- * @returns {Promise<{ checked: number, reachable: number, unreachable: number, newly_surfaced: number, errors: string[] }>}
+ * @returns {Promise<{ ventures_seedable: number, checked: number, reachable: number, unreachable: number, newly_surfaced: number, errors: string[] }>}
  */
 export async function runVentureUptimeProbe({ supabase, fetchFn, timeoutMs, nowIso } = {}) {
   const now = nowIso || new Date().toISOString();
   const metricDate = now.split('T')[0];
-  const summary = { checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
+  const summary = { ventures_seedable: 0, checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
 
-  const rows = await ensureDeploymentRows(supabase);
+  const { rows, errors: seedErrors } = await ensureDeploymentRows(supabase);
+  summary.ventures_seedable = rows.length + seedErrors.length;
+  summary.errors.push(...seedErrors);
 
   for (const row of rows) {
     summary.checked++;

--- a/lib/ops/venture-uptime-probe.js
+++ b/lib/ops/venture-uptime-probe.js
@@ -1,0 +1,182 @@
+/**
+ * Venture Uptime Probe
+ * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-4
+ *
+ * External reachability probe for deployed venture URLs. Writes results into
+ * venture_deployments.metadata.probe (2-consecutive-failure threshold before surfacing
+ * unreachable, per SD risk mitigation — avoids false alarms on transient network blips)
+ * and, once unreachable is CONFIRMED, drags today's ops_product_health.uptime_pct down
+ * to reflect the outage regardless of what internal service_telemetry reported.
+ *
+ * GROUND-TRUTH CORRECTION (documented, not silently patched): the SD scope names
+ * `venture_deployments.url` as the probe target, but venture_deployments is an empty,
+ * never-populated table (0 rows, live-verified 2026-07-11) — the real live URLs (e.g.
+ * MarketLens) live in `ventures.deployment_url`. `ensureDeploymentRows()` below seeds
+ * venture_deployments from ventures.deployment_url (idempotent upsert on venture_id+url)
+ * so the probe target table matches the SD's literal wording AND the actual data.
+ * `ventures.status` is NOT used to filter "live" — both known deployment_url rows
+ * (MarketLens, CronGenius) currently carry status='cancelled' post-pivot (2026-07-08),
+ * so a status filter would silently probe nothing and contradict the SD's own smoke
+ * test ("point the probe at the live MarketLens URL").
+ */
+
+const CONSECUTIVE_FAILURE_THRESHOLD = 2;
+const DEFAULT_TIMEOUT_MS = 8000;
+
+/**
+ * Perform a single reachability check against a URL.
+ * @param {string} url
+ * @param {{ fetchFn?: typeof fetch, timeoutMs?: number }} [opts]
+ * @returns {Promise<{ reachable: boolean, statusCode: number|null, error: string|null }>}
+ */
+export async function checkReachability(url, opts = {}) {
+  const fetchFn = opts.fetchFn || globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  if (!fetchFn) {
+    return { reachable: false, statusCode: null, error: 'no_fetch_implementation' };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(url, { method: 'GET', signal: controller.signal });
+    const statusCode = res.status;
+    return { reachable: statusCode >= 200 && statusCode < 500, statusCode, error: null };
+  } catch (err) {
+    return { reachable: false, statusCode: null, error: (err && err.message) || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * PURE: compute the next probe state given prior metadata.probe state + this check's result.
+ * Exported for unit testing without any network/DB dependency.
+ *
+ * @param {{ consecutive_failures?: number }|null} priorProbe - prior metadata.probe (or null/undefined for first check)
+ * @param {{ reachable: boolean, statusCode: number|null, error: string|null }} checkResult
+ * @param {string} nowIso
+ * @returns {{ probe: object, justSurfacedUnreachable: boolean }}
+ *   justSurfacedUnreachable is true only on the exact check that crosses the threshold
+ *   (i.e. the transition into "surfaced", not every check while already surfaced) —
+ *   callers use this to decide whether to escalate/log, not just to persist state.
+ */
+export function computeNextProbeState(priorProbe, checkResult, nowIso) {
+  const priorConsecutiveFailures = Number.isFinite(priorProbe?.consecutive_failures) ? priorProbe.consecutive_failures : 0;
+  const wasSurfaced = priorConsecutiveFailures >= CONSECUTIVE_FAILURE_THRESHOLD;
+
+  const consecutive_failures = checkResult.reachable ? 0 : priorConsecutiveFailures + 1;
+  const surfaced = consecutive_failures >= CONSECUTIVE_FAILURE_THRESHOLD;
+
+  return {
+    probe: {
+      reachable: checkResult.reachable,
+      status_code: checkResult.statusCode,
+      last_error: checkResult.error,
+      consecutive_failures,
+      surfaced,
+      last_checked_at: nowIso,
+    },
+    justSurfacedUnreachable: surfaced && !wasSurfaced,
+  };
+}
+
+/**
+ * Ensure a venture_deployments row exists for every venture with a deployment_url.
+ * Idempotent: upserts on (venture_id, url) so a re-run never duplicates rows.
+ * @returns {Promise<Array<{ id: string, venture_id: string, url: string, metadata: object }>>}
+ */
+export async function ensureDeploymentRows(supabase) {
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, deployment_url')
+    .not('deployment_url', 'is', null)
+    .neq('deployment_url', '');
+  if (vErr) throw new Error(`ensureDeploymentRows: ventures query failed: ${vErr.message}`);
+
+  const rows = [];
+  for (const v of ventures || []) {
+    const { data: existing, error: findErr } = await supabase
+      .from('venture_deployments')
+      .select('id, venture_id, url, metadata')
+      .eq('venture_id', v.id)
+      .eq('url', v.deployment_url)
+      .maybeSingle();
+    if (findErr) { console.warn(`[uptime-probe] lookup failed for venture ${v.id}: ${findErr.message}`); continue; }
+
+    if (existing) {
+      rows.push(existing);
+      continue;
+    }
+
+    const { data: created, error: insErr } = await supabase
+      .from('venture_deployments')
+      .insert({ venture_id: v.id, url: v.deployment_url, actor: 'venture-ops-actuals-sweep', status: 'seeded', metadata: {} })
+      .select('id, venture_id, url, metadata')
+      .single();
+    if (insErr) { console.warn(`[uptime-probe] seed insert failed for venture ${v.id}: ${insErr.message}`); continue; }
+    rows.push(created);
+  }
+  return rows;
+}
+
+/**
+ * Merge a confirmed-unreachable probe result into today's ops_product_health row.
+ * Never inflates uptime (takes the min of any existing value and 0); never touches
+ * error_rate/p95/request-count fields owned by the telemetry-derived collector.
+ */
+export async function surfaceUnreachableToProductHealth(supabase, ventureId, metricDate) {
+  const { data: existing } = await supabase
+    .from('ops_product_health')
+    .select('uptime_pct')
+    .eq('venture_id', ventureId)
+    .eq('metric_date', metricDate)
+    .maybeSingle();
+
+  const nextUptime = existing?.uptime_pct != null ? Math.min(existing.uptime_pct, 0) : 0;
+
+  const { error } = await supabase
+    .from('ops_product_health')
+    .upsert(
+      { venture_id: ventureId, metric_date: metricDate, uptime_pct: nextUptime, computed_at: new Date().toISOString() },
+      { onConflict: 'venture_id,metric_date' }
+    );
+  if (error) console.warn(`[uptime-probe] failed to surface unreachable to ops_product_health for ${ventureId}: ${error.message}`);
+}
+
+/**
+ * Run one probe cycle across all deployed ventures.
+ * @param {{ supabase: object, fetchFn?: typeof fetch, timeoutMs?: number, nowIso?: string }} params
+ * @returns {Promise<{ checked: number, reachable: number, unreachable: number, newly_surfaced: number, errors: string[] }>}
+ */
+export async function runVentureUptimeProbe({ supabase, fetchFn, timeoutMs, nowIso } = {}) {
+  const now = nowIso || new Date().toISOString();
+  const metricDate = now.split('T')[0];
+  const summary = { checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
+
+  const rows = await ensureDeploymentRows(supabase);
+
+  for (const row of rows) {
+    summary.checked++;
+    const checkResult = await checkReachability(row.url, { fetchFn, timeoutMs });
+    const { probe, justSurfacedUnreachable } = computeNextProbeState(row.metadata?.probe, checkResult, now);
+
+    if (probe.reachable) summary.reachable++; else summary.unreachable++;
+    if (justSurfacedUnreachable) summary.newly_surfaced++;
+
+    const { error } = await supabase
+      .from('venture_deployments')
+      .update({ metadata: { ...(row.metadata || {}), probe } })
+      .eq('id', row.id);
+    if (error) summary.errors.push(`${row.venture_id}: ${error.message}`);
+
+    if (probe.surfaced) {
+      await surfaceUnreachableToProductHealth(supabase, row.venture_id, metricDate);
+    }
+  }
+
+  return summary;
+}
+
+export const CONSTANTS = { CONSECUTIVE_FAILURE_THRESHOLD, DEFAULT_TIMEOUT_MS };

--- a/lib/services/branding-service.js
+++ b/lib/services/branding-service.js
@@ -162,15 +162,24 @@ export class BrandingService {
   /**
    * Report task outcomes to service_telemetry.
    *
+   * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-1: also writes `outcome` and `processing_time_ms`
+   * (in addition to the existing `outcomes` jsonb blob) — these are the two scalar columns the
+   * ops_product_health collector (lib/eva/services/ops-health-monitor.js computeProductHealth)
+   * actually SELECTs. Prior to this fix they were never populated, so every completed branding
+   * task was invisible to the collector (read back as null, not "success"). Additive only — the
+   * existing `outcomes` jsonb write is unchanged for any other consumer of that column.
+   *
    * @param {object} params
    * @param {string} params.taskId - UUID of the completed service_task
    * @param {string} params.ventureId - UUID of the venture
    * @param {object} params.outcomes - Structured outcome metrics
+   * @param {string} [params.outcome='success'] - Scalar outcome for the ops_product_health collector.
+   * @param {number} [params.processingTimeMs] - Duration in ms for the collector's p95 latency calc.
    * @param {string} [params.prUrl] - PR URL if applicable
    * @param {string} [params.prStatus] - PR status
    * @param {string} [params.agentVersion] - Venture agent version
    */
-  async reportTelemetry({ taskId, ventureId, outcomes, prUrl, prStatus, agentVersion }) {
+  async reportTelemetry({ taskId, ventureId, outcomes, outcome, processingTimeMs, prUrl, prStatus, agentVersion }) {
     const serviceId = await this.resolveServiceId();
 
     const { error } = await this.supabase
@@ -182,6 +191,8 @@ export class BrandingService {
         pr_url: prUrl || null,
         pr_status: prStatus || null,
         outcomes: outcomes || {},
+        outcome: outcome || 'success',
+        processing_time_ms: processingTimeMs ?? null,
         venture_agent_version: agentVersion || '1.0.0',
       });
 
@@ -201,7 +212,7 @@ export class BrandingService {
   async completeTask(taskId, outcomes = {}) {
     const { data: task, error: fetchError } = await this.supabase
       .from('service_tasks')
-      .select('venture_id, service_id, artifacts, confidence_score')
+      .select('venture_id, service_id, artifacts, confidence_score, created_at')
       .eq('id', taskId)
       .single();
 
@@ -209,17 +220,24 @@ export class BrandingService {
       throw new Error(`Task not found: ${fetchError?.message || 'no data'}`);
     }
 
+    const completedAt = new Date();
     const { error: updateError } = await this.supabase
       .from('service_tasks')
       .update({
         status: 'completed',
-        completed_at: new Date().toISOString(),
+        completed_at: completedAt.toISOString(),
       })
       .eq('id', taskId);
 
     if (updateError) {
       throw new Error(`Failed to complete task: ${updateError.message}`);
     }
+
+    // processing_time_ms: wall-clock from task creation to completion. task.created_at is
+    // always set (NOT NULL default now() at insert in createTask); a missing/unparseable
+    // value degrades to null rather than a misleading 0ms duration.
+    const createdMs = task.created_at ? Date.parse(task.created_at) : NaN;
+    const processingTimeMs = Number.isFinite(createdMs) ? Math.max(0, completedAt.getTime() - createdMs) : null;
 
     await this.reportTelemetry({
       taskId,
@@ -229,6 +247,8 @@ export class BrandingService {
         confidence_score: task.confidence_score,
         artifacts_generated: true,
       },
+      outcome: 'success',
+      processingTimeMs,
     });
 
     return { success: true };
@@ -286,8 +306,8 @@ export class BrandingService {
       `Style: ${input.style || 'Modern'}`,
       `Primary Font: ${logoSpec.typography.primary}`,
       `Primary Color: ${colorPalette[0]}`,
-      `Use the logo mark at minimum 32px height.`,
-      `Maintain clear space equal to the height of the logo icon around the mark.`,
+      'Use the logo mark at minimum 32px height.',
+      'Maintain clear space equal to the height of the logo icon around the mark.',
     ].join('\n');
   }
 }

--- a/lib/services/telemetry.js
+++ b/lib/services/telemetry.js
@@ -70,9 +70,18 @@ export async function reportTelemetry(supabase, event) {
  * Resolve a service_key to its ehg_services.id (NOT NULL FK on service_telemetry).
  * Mirrors BrandingService.resolveServiceId; kept local (no shared cache) since this
  * function has no per-instance state to cache across calls.
- * @returns {Promise<string|null>} service_id, or null if unresolvable (fail-open —
- *   telemetry is non-blocking, a missing/unknown service_key should not throw here;
- *   the insert itself will surface a clear DB error if service_id is truly required).
+ *
+ * Adversarial-review fix: an unresolvable service_key fails open to null (telemetry is
+ * non-blocking by design — a missing/unknown service_key should not throw here), but the
+ * subsequent NOT-NULL insert then fails too, reproducing the exact "0 rows written"
+ * silent-failure class this SD's producer-contract fix exists to close — just triggered
+ * by a mis-keyed/unregistered service_key instead of missing task_id/service_id. This
+ * function now logs its OWN warning at the point of failure (distinct from the generic
+ * insert-error warning below) so an unresolvable service_key is diagnosable from logs
+ * alone, without having to correlate it to a downstream constraint-violation message.
+ *
+ * @returns {Promise<string|null>} service_id, or null if unresolvable (fail-open — the
+ *   caller's insert will still surface a DB error if service_id is truly required).
  */
 async function resolveServiceId(supabase, serviceKey) {
   if (!serviceKey) return null;
@@ -83,9 +92,13 @@ async function resolveServiceId(supabase, serviceKey) {
       .eq('service_key', serviceKey)
       .eq('status', 'active')
       .maybeSingle();
-    if (error || !data) return null;
+    if (error || !data) {
+      console.warn(`[telemetry] service_key "${serviceKey}" did not resolve to an active ehg_services row${error ? ` (${error.message})` : ''} — the insert will fail its NOT-NULL service_id constraint`);
+      return null;
+    }
     return data.id;
-  } catch {
+  } catch (err) {
+    console.warn(`[telemetry] resolveServiceId("${serviceKey}") threw: ${err.message}`);
     return null;
   }
 }

--- a/lib/services/telemetry.js
+++ b/lib/services/telemetry.js
@@ -1,30 +1,59 @@
+import { randomUUID } from 'crypto';
+
 /**
  * Service Telemetry — EHG Venture Factory
  * SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
  *
  * Reports service outcomes to service_telemetry table for cross-venture intelligence.
- */
-
-/**
- * Report a telemetry event to the service_telemetry table.
+ *
+ * PRODUCER CONTRACT (SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-1): service_telemetry has
+ * TWO independent NOT-NULL columns (task_id, service_id) inherited from an earlier
+ * task/PR-scoped schema, plus `outcome` (text) and `processing_time_ms` (int) added later
+ * specifically for the ops_product_health collector (lib/eva/services/ops-health-monitor.js
+ * computeProductHealth, which SELECTs outcome/processing_time_ms filtered on venture_id +
+ * reported_at). Before this fix, this function omitted task_id/service_id entirely — every
+ * insert violated the NOT-NULL constraints and silently failed (caught, logged, swallowed
+ * below), which is why service_telemetry had 0 rows despite this function existing. It also
+ * never wrote outcome/processing_time_ms, so even a successful insert would have produced
+ * collector-visible nulls (uptime computed as a false 0%, not "no data"). This is the ONE
+ * canonical service_telemetry writer for non-task-scoped shared-service events; the single
+ * contract test asserting producer/consumer field alignment lives at
+ * tests/unit/services/service-telemetry-contract.test.js.
+ *
  * @param {object} supabase - Supabase client
  * @param {object} event
- * @param {string} event.service_key - Service identifier (e.g., 'branding')
+ * @param {string} event.service_key - Service identifier (e.g., 'branding'); resolved to
+ *   service_id via the ehg_services registry (same pattern as BrandingService.resolveServiceId).
  * @param {string} event.venture_id - UUID of the venture
  * @param {string} event.event_type - Type of event (e.g., 'artifact_generated', 'routing_decision')
+ * @param {string} [event.outcome] - 'success' | 'error' | 'failure' — read by the ops_product_health
+ *   collector to compute uptime_pct/error_rate. Omit only for events with no pass/fail outcome.
+ * @param {number} [event.processing_time_ms] - Duration in ms — read by the collector for p95 latency.
+ * @param {string} [event.task_id] - UUID of an associated service_tasks row, if this event is
+ *   task-scoped. Generic (non-task) events get a fresh UUID so the NOT-NULL constraint is satisfied
+ *   without forcing every caller to invent a task record.
  * @param {number} [event.confidence_score] - Confidence score (0.0-1.0)
  * @param {string} [event.routing_decision] - Routing outcome (auto_approve/review_flagged/draft_only)
  * @param {object} [event.metadata] - Additional event data
  */
 export async function reportTelemetry(supabase, event) {
-  const { service_key, venture_id, event_type, confidence_score, routing_decision, metadata } = event;
+  const {
+    service_key, venture_id, event_type, confidence_score, routing_decision, metadata,
+    outcome, processing_time_ms, task_id,
+  } = event;
+
+  const service_id = await resolveServiceId(supabase, service_key);
 
   const { error } = await supabase
     .from('service_telemetry')
     .insert({
+      task_id: task_id || randomUUID(),
+      service_id,
       service_key,
       venture_id,
       event_type,
+      outcome: outcome ?? null,
+      processing_time_ms: processing_time_ms ?? null,
       confidence_score: confidence_score ?? null,
       routing_decision: routing_decision ?? null,
       metadata: metadata ?? {},
@@ -34,6 +63,30 @@ export async function reportTelemetry(supabase, event) {
   if (error) {
     // Telemetry is non-blocking — log but don't throw
     console.warn(`[telemetry] Failed to record event: ${error.message}`);
+  }
+}
+
+/**
+ * Resolve a service_key to its ehg_services.id (NOT NULL FK on service_telemetry).
+ * Mirrors BrandingService.resolveServiceId; kept local (no shared cache) since this
+ * function has no per-instance state to cache across calls.
+ * @returns {Promise<string|null>} service_id, or null if unresolvable (fail-open —
+ *   telemetry is non-blocking, a missing/unknown service_key should not throw here;
+ *   the insert itself will surface a clear DB error if service_id is truly required).
+ */
+async function resolveServiceId(supabase, serviceKey) {
+  if (!serviceKey) return null;
+  try {
+    const { data, error } = await supabase
+      .from('ehg_services')
+      .select('id')
+      .eq('service_key', serviceKey)
+      .eq('status', 'active')
+      .maybeSingle();
+    if (error || !data) return null;
+    return data.id;
+  } catch {
+    return null;
   }
 }
 

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -30,6 +30,8 @@ import { formatRungRollupLine } from '../lib/fleet/exec-email-rung-rollup.js';
 // SD-LEO-INFRA-EXEC-EMAIL-STRATEGY-ALIGNED-001 (FR-2): the ALIGNMENT section — meta-to-product ratio
 // (taper gauge) + dormant-until-revenue distance-to-quit (mission needle), both required by CLAUDE_ADAM.md.
 import { computeAlignmentLines } from '../lib/fleet/exec-email-alignment.mjs';
+// SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 (FR-5): per-venture actuals line (cost + health).
+import { computeOpsActualsLines } from '../lib/fleet/exec-email-ops-actuals.mjs';
 // SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: the shared code-grep seam so the 5 code_grep probes resolve
 // (the chairman-visible gauge measures all 11 capabilities, not just the 6 DB/KR-backed ones).
 import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
@@ -274,6 +276,16 @@ try {
   console.warn('[adam-email] alignment lines skipped (fail-soft): ' + (e?.message || e));
 }
 
+// ── 2e. OPS ACTUALS (SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-5) ──
+// One actuals-vs-targets line per live venture (cost from venture_token_ledger + health
+// from ops_product_health). Fail-soft: computeOpsActualsLines never throws, degrades to [].
+let opsActualsLines = [];
+try {
+  opsActualsLines = await computeOpsActualsLines({ supabase: db }, { nowMs: t });
+} catch (e) {
+  console.warn('[adam-email] ops-actuals lines skipped (fail-soft): ' + (e?.message || e));
+}
+
 // ── 3. ACTIONS FOR YOU: render the pending decisions (fetched above) as a copy-paste block ──
 const LEAD_IN = "I have received the following executive decisions via email and I'm ready to address them:";
 const numbered = lines.map((l, i) => `${i + 1}. ${l}`);
@@ -352,6 +364,7 @@ const text = [
   ...(metaLine ? ['   ' + metaLine] : []),
   ...(distanceToQuitLine ? ['   ' + distanceToQuitLine] : []),
   ...(watchdogLine ? ['   ' + watchdogLine] : []),
+  ...(opsActualsLines.length ? ['', 'Venture actuals:', ...opsActualsLines.map((l) => '   ' + l)] : []),
   ...(recentText ? ['', recentText] : []),
   ...(decisionsLine ? [decisionsLine] : []),
   '',
@@ -381,6 +394,10 @@ const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px
   (metaLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(metaLine)}</div>` : '') +
   (distanceToQuitLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(distanceToQuitLine)}</div>` : '') +
   (watchdogLine ? `<div style="font-size:12px;color:#b54708;margin:2px 0 0">${esc(watchdogLine)}</div>` : '') +
+  (opsActualsLines.length
+    ? `<p style="font-size:13px;font-weight:600;margin:8px 0 0">Venture actuals:</p>` +
+      opsActualsLines.map((l) => `<div style="font-size:12px;color:#444;margin:2px 0 0">${esc(l)}</div>`).join('')
+    : '') +
   recentHtml + decisionsHtml +
   '<hr style="border:none;border-top:1px solid #e1e4e8;margin:14px 0">' +
   actionsHtml +

--- a/scripts/cron/venture-ops-actuals-sweep.mjs
+++ b/scripts/cron/venture-ops-actuals-sweep.mjs
@@ -167,7 +167,7 @@ export async function main(argv = process.argv, deps = {}) {
   // Job 3: uptime probe
   {
     const processKey = args.dryRun ? null : await ensureArmedRegistration(supabase, JOBS[2], logger);
-    let probeSummary = { checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
+    let probeSummary = { ventures_seedable: 0, checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
     if (!args.dryRun) {
       probeSummary = await (deps.runVentureUptimeProbe || runVentureUptimeProbe)({ supabase });
       try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
@@ -176,6 +176,12 @@ export async function main(argv = process.argv, deps = {}) {
     summary.jobs[JOBS[2].key] = probeSummary;
     if (probeSummary.newly_surfaced > 0) {
       logger.warn?.(`[ops-actuals-sweep] ${probeSummary.newly_surfaced} venture(s) newly surfaced UNREACHABLE this cycle.`);
+    }
+    // NC-7 parity with jobs 1/2 (adversarial-review finding): ensureDeploymentRows failures
+    // used to be swallowed with no signal the caller could act on, which would let this job
+    // report checked=0/errors=[] — a silent green pass — even if every venture failed to seed.
+    if (!args.dryRun && ventures.length > 0 && probeSummary.checked === 0) {
+      logger.error?.(`[ops-actuals-sweep] NC-7 ESCALATION: ${JOBS[2].key} checked 0 deployments across ${ventures.length} venture(s) — investigate before trusting future silent passes.`);
     }
   }
 

--- a/scripts/cron/venture-ops-actuals-sweep.mjs
+++ b/scripts/cron/venture-ops-actuals-sweep.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Venture ops-actuals sweep — the scheduled production runner that activates the
+ * previously dormant ops_product_health / ops_revenue_metrics collectors + the
+ * external uptime probe (dormant-machinery class: schemas + collectors fully BUILT,
+ * zero rows, nothing invoked them).
+ *
+ * SD: SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 (FR-2, FR-3, FR-4, FR-6)
+ *
+ * Three jobs per invocation, each independently registered in periodic_process_registry
+ * with its own owner-agent (TR-3: distinct owner-agent per collector, not a shared/
+ * anonymous cron) and its own liveness stamp — one job failing never blocks the others:
+ *
+ *   1. ops-product-health-collector  — collectProductHealth() for every venture with a
+ *      live deployment (deployment_url set). Depends on the FR-1 producer-contract fix
+ *      (lib/services/telemetry.js, lib/services/branding-service.js) already landing.
+ *   2. ops-revenue-metrics-collector — collectRevenueMetrics() for the same venture set.
+ *      Independent of the service_telemetry contract (reads capital_transactions).
+ *   3. venture-uptime-probe          — runVentureUptimeProbe() (lib/ops/venture-uptime-probe.js).
+ *
+ * FR-6 (verify-then-schedule, NC-7): the first live cycle after the contract fix is not
+ * silently trusted — this script logs a per-job row-count summary every run so a
+ * zero-rows-written result is visible in the cron log, not swallowed as a normal pass.
+ *
+ * "Live venture deployment" selection (all three jobs, consistent set): ventures WHERE
+ * deployment_url IS NOT NULL. ventures.status is deliberately NOT used as a filter — both
+ * currently-deployed ventures (MarketLens, CronGenius) carry status='cancelled' post the
+ * 2026-07-08 pivot, so a status filter would silently probe/collect nothing (see
+ * lib/ops/venture-uptime-probe.js header for the full ground-truth note).
+ *
+ * Usage:
+ *   node scripts/cron/venture-ops-actuals-sweep.mjs --once
+ *   node scripts/cron/venture-ops-actuals-sweep.mjs --once --dry-run
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { createClient } from '@supabase/supabase-js';
+import { collectProductHealth } from '../../lib/eva/services/ops-health-monitor.js';
+import { collectRevenueMetrics } from '../../lib/eva/services/ops-revenue-collector.js';
+import { runVentureUptimeProbe } from '../../lib/ops/venture-uptime-probe.js';
+import { registerArmedMachinery, armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+
+export const SD_KEY = 'SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001';
+export const ACTIVATION_TRIGGER = '.github/workflows/venture-ops-actuals-cron.yml';
+
+const JOBS = [
+  { key: 'ops-product-health-collector', owner: 'ops-product-health-collector' },
+  { key: 'ops-revenue-metrics-collector', owner: 'ops-revenue-metrics-collector' },
+  { key: 'venture-uptime-probe', owner: 'venture-uptime-probe' },
+];
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+/** Ensure ARMED registration exists for a job WITHOUT wiping last_fired_at on re-run. */
+async function ensureArmedRegistration(supabase, job, logger) {
+  const processKey = armedProcessKey(`${SD_KEY}-${job.key}`);
+  try {
+    const { data } = await supabase
+      .from('periodic_process_registry')
+      .select('process_key')
+      .eq('process_key', processKey)
+      .maybeSingle();
+    if (!data) {
+      const reg = await registerArmedMachinery(supabase, { sd_key: `${SD_KEY}-${job.key}` }, {
+        activationTrigger: ACTIVATION_TRIGGER,
+        expectedIntervalSeconds: 6 * 60 * 60, // 6h cadence with headroom
+        owner: job.owner,
+      });
+      if (!reg.ok) logger.warn?.(`[ops-actuals-sweep] ARMED registration failed for ${job.key} (non-fatal): ${reg.error}`);
+    }
+  } catch (err) {
+    logger.warn?.(`[ops-actuals-sweep] ARMED registration check failed for ${job.key} (non-fatal): ${err.message}`);
+  }
+  return processKey;
+}
+
+/** Ventures with a live deployment — the shared selection set for all three jobs. */
+async function fetchLiveDeploymentVentures(supabase) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('id, deployment_url')
+    .not('deployment_url', 'is', null)
+    .neq('deployment_url', '');
+  if (error) throw new Error(`ventures query failed: ${error.message}`);
+  return data || [];
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('venture-ops-actuals-sweep --once [--dry-run]');
+    return { exitCode: 0, action: 'help' };
+  }
+
+  const logger = deps.logger || console;
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) {
+    logger.error?.(`[ops-actuals-sweep] supabase client unavailable: ${err.message}`);
+    return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  const ventures = await fetchLiveDeploymentVentures(supabase);
+  const summary = { ts: new Date().toISOString(), dry_run: args.dryRun, ventures_scanned: ventures.length, jobs: {} };
+
+  // Job 1: ops_product_health collector
+  {
+    const processKey = args.dryRun ? null : await ensureArmedRegistration(supabase, JOBS[0], logger);
+    let written = 0;
+    const errors = [];
+    if (!args.dryRun) {
+      for (const v of ventures) {
+        try {
+          const row = await (deps.collectProductHealth || collectProductHealth)({ ventureId: v.id, supabase });
+          if (row) written++;
+        } catch (err) { errors.push(`${v.id}: ${err.message}`); }
+      }
+      try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
+      catch (err) { logger.warn?.(`[ops-actuals-sweep] liveness stamp failed for ${JOBS[0].key} (non-fatal): ${err.message}`); }
+    }
+    summary.jobs[JOBS[0].key] = { attempted: ventures.length, written, errors };
+    // FR-6 / NC-7: a live cycle over a non-empty venture set that writes zero rows is an
+    // escalation-worthy signal (collector code never ran live before this SD), not a quiet pass.
+    if (!args.dryRun && ventures.length > 0 && written === 0) {
+      logger.error?.(`[ops-actuals-sweep] NC-7 ESCALATION: ${JOBS[0].key} wrote 0 rows across ${ventures.length} venture(s) — investigate before trusting future silent passes.`);
+    }
+  }
+
+  // Job 2: ops_revenue_metrics collector
+  {
+    const processKey = args.dryRun ? null : await ensureArmedRegistration(supabase, JOBS[1], logger);
+    let written = 0;
+    const errors = [];
+    if (!args.dryRun) {
+      for (const v of ventures) {
+        try {
+          const row = await (deps.collectRevenueMetrics || collectRevenueMetrics)({ ventureId: v.id, supabase });
+          if (row) written++;
+        } catch (err) { errors.push(`${v.id}: ${err.message}`); }
+      }
+      try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
+      catch (err) { logger.warn?.(`[ops-actuals-sweep] liveness stamp failed for ${JOBS[1].key} (non-fatal): ${err.message}`); }
+    }
+    summary.jobs[JOBS[1].key] = { attempted: ventures.length, written, errors };
+    if (!args.dryRun && ventures.length > 0 && written === 0) {
+      logger.error?.(`[ops-actuals-sweep] NC-7 ESCALATION: ${JOBS[1].key} wrote 0 rows across ${ventures.length} venture(s) — investigate before trusting future silent passes.`);
+    }
+  }
+
+  // Job 3: uptime probe
+  {
+    const processKey = args.dryRun ? null : await ensureArmedRegistration(supabase, JOBS[2], logger);
+    let probeSummary = { checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: [] };
+    if (!args.dryRun) {
+      probeSummary = await (deps.runVentureUptimeProbe || runVentureUptimeProbe)({ supabase });
+      try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
+      catch (err) { logger.warn?.(`[ops-actuals-sweep] liveness stamp failed for ${JOBS[2].key} (non-fatal): ${err.message}`); }
+    }
+    summary.jobs[JOBS[2].key] = probeSummary;
+    if (probeSummary.newly_surfaced > 0) {
+      logger.warn?.(`[ops-actuals-sweep] ${probeSummary.newly_surfaced} venture(s) newly surfaced UNREACHABLE this cycle.`);
+    }
+  }
+
+  logger.log?.(`[ops-actuals-sweep] ${JSON.stringify(summary)}`);
+  const anyErrors = Object.values(summary.jobs).some((j) => (j.errors || []).length > 0);
+  return { exitCode: anyErrors ? 1 : 0, action: args.dryRun ? 'dry_run' : 'swept', summary };
+}
+
+/** Windows-safe termination (mirrors scripts/cron/chairman-decision-sla-sweep.mjs). */
+export async function gracefulExit(exitCode, { backstopMs = 4000 } = {}) {
+  process.exitCode = exitCode;
+  try {
+    const undici = await import('undici');
+    await undici.getGlobalDispatcher?.()?.close?.();
+  } catch { /* undici absent — natural drain still applies */ }
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  main().then(({ exitCode }) => gracefulExit(exitCode))
+        .catch((err) => { console.error('venture-ops-actuals-sweep fatal:', err.message); return gracefulExit(2); });
+}

--- a/tests/unit/cron/venture-ops-actuals-sweep.test.js
+++ b/tests/unit/cron/venture-ops-actuals-sweep.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 — venture ops-actuals sweep (TS-1/TS-5).
+ *
+ * Pins: --dry-run performs zero writes, all three jobs run per venture with a live
+ * deployment, per-job error isolation (one job's failure doesn't block the others),
+ * and the NC-7 zero-rows escalation log when a non-empty venture set writes nothing.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main, parseArgs, SD_KEY, ACTIVATION_TRIGGER } from '../../../scripts/cron/venture-ops-actuals-sweep.mjs';
+
+const VENTURES = [
+  { id: 'v1', deployment_url: 'https://marketlens.example' },
+  { id: 'v2', deployment_url: 'https://crongenius.example' },
+];
+
+/** Minimal fake supabase covering the sweep's own reads (ventures, periodic_process_registry). */
+function makeSupabase({ ventures = VENTURES } = {}) {
+  return {
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select() { return this; },
+          not() { return this; },
+          neq() { return this; },
+          then: (resolve) => resolve({ data: ventures, error: null }),
+        };
+      }
+      if (table === 'periodic_process_registry') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: async () => ({ data: { process_key: 'existing' }, error: null }),
+          upsert: async () => ({ error: null }),
+        };
+      }
+      throw new Error(`unexpected table in test fake: ${table}`);
+    },
+  };
+}
+
+describe('parseArgs', () => {
+  it('parses --once and --dry-run', () => {
+    expect(parseArgs(['node', 's', '--once', '--dry-run'])).toEqual({ once: true, dryRun: true, help: false });
+  });
+});
+
+describe('venture-ops-actuals-sweep main()', () => {
+  it('static wiring: SD_KEY and ACTIVATION_TRIGGER are exported for the workflow-wiring pin', () => {
+    expect(SD_KEY).toBe('SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001');
+    expect(ACTIVATION_TRIGGER).toBe('.github/workflows/venture-ops-actuals-cron.yml');
+  });
+
+  it('--dry-run performs zero collector/probe/stamp calls', async () => {
+    const collectProductHealth = vi.fn();
+    const collectRevenueMetrics = vi.fn();
+    const runVentureUptimeProbe = vi.fn();
+    const stampLastFired = vi.fn();
+
+    const result = await main(['node', 's', '--once', '--dry-run'], {
+      supabase: makeSupabase(),
+      collectProductHealth, collectRevenueMetrics, runVentureUptimeProbe, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(result.action).toBe('dry_run');
+    expect(collectProductHealth).not.toHaveBeenCalled();
+    expect(collectRevenueMetrics).not.toHaveBeenCalled();
+    expect(runVentureUptimeProbe).not.toHaveBeenCalled();
+    expect(stampLastFired).not.toHaveBeenCalled();
+  });
+
+  it('runs all three jobs once per live-deployment venture and stamps liveness for each', async () => {
+    const collectProductHealth = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    const collectRevenueMetrics = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    const runVentureUptimeProbe = vi.fn().mockResolvedValue({ checked: 2, reachable: 2, unreachable: 0, newly_surfaced: 0, errors: [] });
+    const stampLastFired = vi.fn().mockResolvedValue(undefined);
+
+    const result = await main(['node', 's', '--once'], {
+      supabase: makeSupabase(),
+      collectProductHealth, collectRevenueMetrics, runVentureUptimeProbe, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(collectProductHealth).toHaveBeenCalledTimes(2);
+    expect(collectRevenueMetrics).toHaveBeenCalledTimes(2);
+    expect(runVentureUptimeProbe).toHaveBeenCalledTimes(1);
+    expect(stampLastFired).toHaveBeenCalledTimes(3); // one per job
+    expect(result.summary.jobs['ops-product-health-collector'].written).toBe(2);
+    expect(result.summary.jobs['ops-revenue-metrics-collector'].written).toBe(2);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('isolates a single failing venture: one collector error does not stop the others', async () => {
+    const collectProductHealth = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ venture_id: 'v2' });
+    const collectRevenueMetrics = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    const runVentureUptimeProbe = vi.fn().mockResolvedValue({ checked: 2, reachable: 2, unreachable: 0, newly_surfaced: 0, errors: [] });
+    const stampLastFired = vi.fn().mockResolvedValue(undefined);
+
+    const result = await main(['node', 's', '--once'], {
+      supabase: makeSupabase(),
+      collectProductHealth, collectRevenueMetrics, runVentureUptimeProbe, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(result.summary.jobs['ops-product-health-collector'].written).toBe(1);
+    expect(result.summary.jobs['ops-product-health-collector'].errors).toHaveLength(1);
+    expect(result.exitCode).toBe(1); // errors present -> non-zero exit for cron visibility
+    // the other two jobs still ran fully despite job 1's per-venture error
+    expect(collectRevenueMetrics).toHaveBeenCalledTimes(2);
+    expect(runVentureUptimeProbe).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs an NC-7 escalation when a non-empty venture set writes zero rows', async () => {
+    const errorLog = vi.fn();
+    const collectProductHealth = vi.fn().mockResolvedValue(null); // simulates storeProductHealth's null-on-error return
+    const collectRevenueMetrics = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    const runVentureUptimeProbe = vi.fn().mockResolvedValue({ checked: 2, reachable: 2, unreachable: 0, newly_surfaced: 0, errors: [] });
+    const stampLastFired = vi.fn().mockResolvedValue(undefined);
+
+    await main(['node', 's', '--once'], {
+      supabase: makeSupabase(),
+      collectProductHealth, collectRevenueMetrics, runVentureUptimeProbe, stampLastFired,
+      logger: { log() {}, warn() {}, error: errorLog },
+    });
+
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining('NC-7 ESCALATION'));
+  });
+});

--- a/tests/unit/cron/venture-ops-actuals-sweep.test.js
+++ b/tests/unit/cron/venture-ops-actuals-sweep.test.js
@@ -127,4 +127,23 @@ describe('venture-ops-actuals-sweep main()', () => {
 
     expect(errorLog).toHaveBeenCalledWith(expect.stringContaining('NC-7 ESCALATION'));
   });
+
+  it('logs an NC-7 escalation for the uptime-probe job too when it checks 0 deployments (adversarial-review fix: parity with jobs 1/2)', async () => {
+    const errorLog = vi.fn();
+    const collectProductHealth = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    const collectRevenueMetrics = vi.fn().mockResolvedValue({ venture_id: 'x' });
+    // Simulates ensureDeploymentRows failing to seed every venture (e.g. RLS/permissions
+    // drift) — pre-fix, this returned checked=0/errors=[] and passed silently.
+    const runVentureUptimeProbe = vi.fn().mockResolvedValue({ ventures_seedable: 2, checked: 0, reachable: 0, unreachable: 0, newly_surfaced: 0, errors: ['v1: seed insert failed', 'v2: seed insert failed'] });
+    const stampLastFired = vi.fn().mockResolvedValue(undefined);
+
+    const result = await main(['node', 's', '--once'], {
+      supabase: makeSupabase(),
+      collectProductHealth, collectRevenueMetrics, runVentureUptimeProbe, stampLastFired,
+      logger: { log() {}, warn() {}, error: errorLog },
+    });
+
+    expect(errorLog).toHaveBeenCalledWith(expect.stringMatching(/NC-7 ESCALATION.*venture-uptime-probe/));
+    expect(result.exitCode).toBe(1); // the folded seed errors also flip anyErrors
+  });
 });

--- a/tests/unit/cron/venture-ops-actuals-wiring.test.js
+++ b/tests/unit/cron/venture-ops-actuals-wiring.test.js
@@ -1,0 +1,62 @@
+/**
+ * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-2/FR-3/FR-4 — registered machinery must name its
+ * dispatcher (pattern PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001, exemplar
+ * tests/unit/cron/chairman-decision-sla-wiring.test.js).
+ *
+ * The defect class this SD retires: ops_product_health / ops_revenue_metrics collectors
+ * (lib/eva/services/ops-health-monitor.js, ops-revenue-collector.js) sat fully BUILT with
+ * ZERO production call sites — no scheduler ever invoked them, hence 0 rows. These static
+ * assertions fail CI the moment any edge of the wiring decays: workflow → sweep script →
+ * collectors/probe → armed-registration. No network or DB required.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const WORKFLOW = path.join(repoRoot, '.github', 'workflows', 'venture-ops-actuals-cron.yml');
+const SWEEP = path.join(repoRoot, 'scripts', 'cron', 'venture-ops-actuals-sweep.mjs');
+
+describe('venture ops-actuals machinery names its dispatcher', () => {
+  it('the cron workflow exists and its run step invokes the sweep script', () => {
+    expect(fs.existsSync(WORKFLOW), `missing dispatcher workflow: ${WORKFLOW}`).toBe(true);
+    const yml = fs.readFileSync(WORKFLOW, 'utf8');
+    expect(yml, 'workflow no longer references scripts/cron/venture-ops-actuals-sweep.mjs').toMatch(
+      /node\s+scripts\/cron\/venture-ops-actuals-sweep\.mjs\s+--once/
+    );
+    expect(yml, 'workflow lost its schedule trigger').toMatch(/schedule:/);
+  });
+
+  it('the sweep script imports both collectors and the uptime probe', () => {
+    expect(fs.existsSync(SWEEP), `missing sweep script: ${SWEEP}`).toBe(true);
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src, 'sweep no longer imports collectProductHealth').toMatch(
+      /import\s*\{[^}]*collectProductHealth[^}]*\}\s*from\s*['"][./]*\.\.\/\.\.\/lib\/eva\/services\/ops-health-monitor\.js['"]/
+    );
+    expect(src, 'sweep no longer imports collectRevenueMetrics').toMatch(
+      /import\s*\{[^}]*collectRevenueMetrics[^}]*\}\s*from\s*['"][./]*\.\.\/\.\.\/lib\/eva\/services\/ops-revenue-collector\.js['"]/
+    );
+    expect(src, 'sweep no longer imports runVentureUptimeProbe').toMatch(
+      /import\s*\{[^}]*runVentureUptimeProbe[^}]*\}\s*from\s*['"][./]*\.\.\/\.\.\/lib\/ops\/venture-uptime-probe\.js['"]/
+    );
+  });
+
+  it('the sweep registers ARMED machinery per job with an activation trigger naming the workflow file', () => {
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src, 'sweep no longer calls registerArmedMachinery').toMatch(/registerArmedMachinery/);
+    expect(src, 'ACTIVATION_TRIGGER no longer names the cron workflow').toMatch(
+      /ACTIVATION_TRIGGER\s*=\s*['"]\.github\/workflows\/venture-ops-actuals-cron\.yml['"]/
+    );
+    expect(src, 'each job no longer stamps liveness via stampLastFired').toMatch(/stampLastFired/);
+  });
+
+  it('each of the three jobs has a distinct owner-agent (TR-3: not a shared/anonymous cron)', () => {
+    const src = fs.readFileSync(SWEEP, 'utf8');
+    expect(src).toMatch(/ops-product-health-collector/);
+    expect(src).toMatch(/ops-revenue-metrics-collector/);
+    expect(src).toMatch(/venture-uptime-probe/);
+  });
+});

--- a/tests/unit/ops/venture-uptime-probe.test.js
+++ b/tests/unit/ops/venture-uptime-probe.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-4
+ * Pure-logic tests for the uptime probe's threshold state machine (no network/DB).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { checkReachability, computeNextProbeState, CONSTANTS } from '../../../lib/ops/venture-uptime-probe.js';
+
+describe('computeNextProbeState (pure state machine)', () => {
+  it('starts at 0 consecutive failures on a first successful check with no prior state', () => {
+    const { probe, justSurfacedUnreachable } = computeNextProbeState(null, { reachable: true, statusCode: 200, error: null }, '2026-07-11T00:00:00Z');
+    expect(probe.consecutive_failures).toBe(0);
+    expect(probe.surfaced).toBe(false);
+    expect(justSurfacedUnreachable).toBe(false);
+  });
+
+  it('does NOT surface unreachable after a single failed check (avoids transient-blip false positives)', () => {
+    const { probe, justSurfacedUnreachable } = computeNextProbeState(null, { reachable: false, statusCode: null, error: 'ECONNREFUSED' }, '2026-07-11T00:00:00Z');
+    expect(probe.consecutive_failures).toBe(1);
+    expect(probe.surfaced).toBe(false);
+    expect(justSurfacedUnreachable).toBe(false);
+  });
+
+  it('surfaces unreachable on the 2nd consecutive failure (threshold)', () => {
+    const first = computeNextProbeState(null, { reachable: false, statusCode: null, error: 'timeout' }, '2026-07-11T00:00:00Z');
+    const second = computeNextProbeState(first.probe, { reachable: false, statusCode: null, error: 'timeout' }, '2026-07-11T00:05:00Z');
+    expect(second.probe.consecutive_failures).toBe(2);
+    expect(second.probe.surfaced).toBe(true);
+    expect(second.justSurfacedUnreachable).toBe(true);
+  });
+
+  it('only reports justSurfacedUnreachable on the crossing check, not on subsequent still-down checks', () => {
+    const c1 = computeNextProbeState(null, { reachable: false, statusCode: null, error: 'e' }, 't1');
+    const c2 = computeNextProbeState(c1.probe, { reachable: false, statusCode: null, error: 'e' }, 't2');
+    const c3 = computeNextProbeState(c2.probe, { reachable: false, statusCode: null, error: 'e' }, 't3');
+    expect(c2.justSurfacedUnreachable).toBe(true);
+    expect(c3.probe.surfaced).toBe(true);
+    expect(c3.justSurfacedUnreachable).toBe(false);
+  });
+
+  it('resets consecutive_failures to 0 immediately on a successful check after failures', () => {
+    const c1 = computeNextProbeState(null, { reachable: false, statusCode: null, error: 'e' }, 't1');
+    const c2 = computeNextProbeState(c1.probe, { reachable: false, statusCode: null, error: 'e' }, 't2');
+    expect(c2.probe.surfaced).toBe(true);
+    const c3 = computeNextProbeState(c2.probe, { reachable: true, statusCode: 200, error: null }, 't3');
+    expect(c3.probe.consecutive_failures).toBe(0);
+    expect(c3.probe.surfaced).toBe(false);
+  });
+});
+
+describe('checkReachability', () => {
+  it('reports reachable=true for a 2xx response', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ status: 200 });
+    const result = await checkReachability('https://example.test', { fetchFn });
+    expect(result.reachable).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('reports reachable=true for a 4xx response (server is up, just rejecting the request)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ status: 404 });
+    const result = await checkReachability('https://example.test', { fetchFn });
+    expect(result.reachable).toBe(true);
+  });
+
+  it('reports reachable=false for a 5xx response', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ status: 503 });
+    const result = await checkReachability('https://example.test', { fetchFn });
+    expect(result.reachable).toBe(false);
+  });
+
+  it('reports reachable=false and captures the error when fetch rejects (network failure)', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await checkReachability('https://dead.test', { fetchFn });
+    expect(result.reachable).toBe(false);
+    expect(result.error).toBe('ECONNREFUSED');
+  });
+
+  it('exposes the 2-consecutive-failure threshold as a named constant (matches SD risk mitigation)', () => {
+    expect(CONSTANTS.CONSECUTIVE_FAILURE_THRESHOLD).toBe(2);
+  });
+});

--- a/tests/unit/ops/venture-uptime-probe.test.js
+++ b/tests/unit/ops/venture-uptime-probe.test.js
@@ -3,7 +3,7 @@
  * Pure-logic tests for the uptime probe's threshold state machine (no network/DB).
  */
 import { describe, it, expect, vi } from 'vitest';
-import { checkReachability, computeNextProbeState, CONSTANTS } from '../../../lib/ops/venture-uptime-probe.js';
+import { checkReachability, computeNextProbeState, CONSTANTS, ensureDeploymentRows, runVentureUptimeProbe } from '../../../lib/ops/venture-uptime-probe.js';
 
 describe('computeNextProbeState (pure state machine)', () => {
   it('starts at 0 consecutive failures on a first successful check with no prior state', () => {
@@ -76,5 +76,71 @@ describe('checkReachability', () => {
 
   it('exposes the 2-consecutive-failure threshold as a named constant (matches SD risk mitigation)', () => {
     expect(CONSTANTS.CONSECUTIVE_FAILURE_THRESHOLD).toBe(2);
+  });
+});
+
+/** Minimal fake supabase for ensureDeploymentRows / runVentureUptimeProbe. */
+function makeSupabase({ ventures = [], seedInsertFails = false } = {}) {
+  const deploymentRows = [];
+  return {
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select() { return this; }, not() { return this; }, neq() { return this; },
+          then: (resolve) => resolve({ data: ventures, error: null }),
+        };
+      }
+      if (table === 'venture_deployments') {
+        const ctx = {};
+        return {
+          select() { return this; },
+          eq(col, val) { ctx[col] = val; return this; },
+          maybeSingle: async () => ({ data: deploymentRows.find((r) => r.venture_id === ctx.venture_id) || null, error: null }),
+          insert(vals) {
+            return {
+              select() { return this; },
+              single: async () => {
+                if (seedInsertFails) return { data: null, error: { message: 'permission denied for table venture_deployments' } };
+                const row = { id: `dep-${vals.venture_id}`, ...vals };
+                deploymentRows.push(row);
+                return { data: row, error: null };
+              },
+            };
+          },
+          update() { return { eq: async () => ({ error: null }) }; },
+        };
+      }
+      if (table === 'ops_product_health') {
+        return { select() { return this; }, eq() { return this; }, maybeSingle: async () => ({ data: null, error: null }), upsert: async () => ({ error: null }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('ensureDeploymentRows / runVentureUptimeProbe (adversarial-review fix: no silent seed-failure swallowing)', () => {
+  it('ensureDeploymentRows returns errors alongside rows instead of swallowing them', async () => {
+    const supabase = makeSupabase({ ventures: [{ id: 'v1', deployment_url: 'https://x' }], seedInsertFails: true });
+    const { rows, errors } = await ensureDeploymentRows(supabase);
+    expect(rows).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('seed insert failed');
+  });
+
+  it('runVentureUptimeProbe folds seed errors into its own errors array (visible to the sweep\'s anyErrors check)', async () => {
+    const supabase = makeSupabase({ ventures: [{ id: 'v1', deployment_url: 'https://x' }], seedInsertFails: true });
+    const summary = await runVentureUptimeProbe({ supabase, fetchFn: vi.fn() });
+    expect(summary.checked).toBe(0);
+    expect(summary.errors).toHaveLength(1); // pre-fix this was [] -> a silent green pass
+    expect(summary.ventures_seedable).toBe(1);
+  });
+
+  it('checks every successfully-seeded venture even when unrelated ventures fail to seed', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ status: 200 });
+    const supabase = makeSupabase({ ventures: [{ id: 'v1', deployment_url: 'https://x' }] });
+    const summary = await runVentureUptimeProbe({ supabase, fetchFn });
+    expect(summary.checked).toBe(1);
+    expect(summary.reachable).toBe(1);
+    expect(summary.errors).toHaveLength(0);
   });
 });

--- a/tests/unit/services/service-telemetry-contract.test.js
+++ b/tests/unit/services/service-telemetry-contract.test.js
@@ -1,0 +1,159 @@
+/**
+ * service_telemetry producer/consumer contract test
+ * SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001 FR-1
+ *
+ * Consumer enumeration (grep-verified 2026-07-11, single consumer):
+ *   lib/eva/services/ops-health-monitor.js :: computeProductHealth() selects
+ *   `outcome, processing_time_ms` filtered on venture_id + reported_at.
+ *
+ * Producers (grep-verified, two writers):
+ *   lib/services/telemetry.js :: reportTelemetry(supabase, event)  — generic/shared
+ *   lib/services/branding-service.js :: BrandingService#reportTelemetry()  — task-scoped
+ *
+ * This test asserts both producers write a row shape the consumer can read: `outcome`
+ * and `processing_time_ms` populated (not silently null), and — for the shared writer —
+ * that the previously-fatal NOT-NULL columns (task_id, service_id) are always populated
+ * so the insert does not silently fail (the pre-fix state: 0 rows in service_telemetry
+ * despite both writers "succeeding" from the caller's perspective).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reportTelemetry as reportGenericTelemetry } from '../../../lib/services/telemetry.js';
+import { BrandingService } from '../../../lib/services/branding-service.js';
+
+function createMockSupabase(overrides = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnValue({ error: null }),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'svc-id-123' }, error: null }),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    ...overrides,
+  };
+  const fromFn = vi.fn().mockReturnValue(chainable);
+  return { from: fromFn, _chainable: chainable };
+}
+
+const MOCK_VENTURE_ID = '72efb937-981c-495c-b12c-1f006aee50d0';
+
+describe('service_telemetry producer/consumer contract', () => {
+  describe('lib/services/telemetry.js reportTelemetry (generic producer)', () => {
+    let supabase;
+    beforeEach(() => { supabase = createMockSupabase(); });
+
+    it('writes outcome and processing_time_ms when the caller supplies them', async () => {
+      await reportGenericTelemetry(supabase, {
+        service_key: 'branding',
+        venture_id: MOCK_VENTURE_ID,
+        event_type: 'artifact_generated',
+        outcome: 'success',
+        processing_time_ms: 842,
+      });
+
+      const insertCall = supabase._chainable.insert.mock.calls[0][0];
+      expect(insertCall.outcome).toBe('success');
+      expect(insertCall.processing_time_ms).toBe(842);
+    });
+
+    it('always populates task_id and service_id (NOT NULL columns) even when the caller omits task_id', async () => {
+      await reportGenericTelemetry(supabase, {
+        service_key: 'branding',
+        venture_id: MOCK_VENTURE_ID,
+        event_type: 'routing_decision',
+      });
+
+      const insertCall = supabase._chainable.insert.mock.calls[0][0];
+      expect(insertCall.task_id).toBeTruthy();
+      expect(typeof insertCall.task_id).toBe('string');
+      expect(insertCall.service_id).toBe('svc-id-123');
+    });
+
+    it('is non-blocking (never throws) when service_key does not resolve', async () => {
+      const failingSupabase = createMockSupabase({
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+        insert: vi.fn().mockReturnValue({ error: { message: 'null value in column "service_id"' } }),
+      });
+
+      await expect(reportGenericTelemetry(failingSupabase, {
+        service_key: 'unknown-service',
+        venture_id: MOCK_VENTURE_ID,
+        event_type: 'artifact_generated',
+      })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('lib/services/branding-service.js BrandingService#reportTelemetry (task-scoped producer)', () => {
+    it('writes outcome (default success) alongside the existing outcomes jsonb blob', async () => {
+      const supabase = createMockSupabase();
+      const service = new BrandingService({ supabaseClient: supabase, serviceId: 'svc-id-123' });
+
+      await service.reportTelemetry({
+        taskId: 'task-001',
+        ventureId: MOCK_VENTURE_ID,
+        outcomes: { artifacts_generated: true },
+      });
+
+      const insertCall = supabase._chainable.insert.mock.calls[0][0];
+      expect(insertCall.outcome).toBe('success');
+      expect(insertCall.outcomes).toEqual({ artifacts_generated: true });
+    });
+
+    it('completeTask computes processing_time_ms from task creation to completion', async () => {
+      const createdAt = new Date(Date.now() - 5000).toISOString();
+      const fetchChainable = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { venture_id: MOCK_VENTURE_ID, service_id: 'svc-id-123', confidence_score: 0.9, created_at: createdAt },
+          error: null,
+        }),
+      };
+      const updateChainable = { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ error: null }) };
+      const telemetryChainable = { insert: vi.fn().mockReturnValue({ error: null }) };
+
+      let callCount = 0;
+      const supabase = {
+        from: vi.fn().mockImplementation((table) => {
+          if (table === 'service_telemetry') return telemetryChainable;
+          callCount++;
+          return callCount === 1 ? fetchChainable : updateChainable;
+        }),
+      };
+      const service = new BrandingService({ supabaseClient: supabase, serviceId: 'svc-id-123' });
+
+      const result = await service.completeTask('task-001', {});
+
+      expect(result.success).toBe(true);
+      const insertCall = telemetryChainable.insert.mock.calls[0][0];
+      expect(insertCall.outcome).toBe('success');
+      expect(insertCall.processing_time_ms).toBeGreaterThanOrEqual(5000);
+    });
+
+    it('degrades processing_time_ms to null when task.created_at is missing (no misleading 0ms)', async () => {
+      const fetchChainable = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { venture_id: MOCK_VENTURE_ID, service_id: 'svc-id-123', confidence_score: 0.9 },
+          error: null,
+        }),
+      };
+      const updateChainable = { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ error: null }) };
+      const telemetryChainable = { insert: vi.fn().mockReturnValue({ error: null }) };
+      let callCount = 0;
+      const supabase = {
+        from: vi.fn().mockImplementation((table) => {
+          if (table === 'service_telemetry') return telemetryChainable;
+          callCount++;
+          return callCount === 1 ? fetchChainable : updateChainable;
+        }),
+      };
+      const service = new BrandingService({ supabaseClient: supabase, serviceId: 'svc-id-123' });
+
+      await service.completeTask('task-001', {});
+
+      const insertCall = telemetryChainable.insert.mock.calls[0][0];
+      expect(insertCall.processing_time_ms).toBeNull();
+    });
+  });
+});

--- a/tests/unit/services/service-telemetry-contract.test.js
+++ b/tests/unit/services/service-telemetry-contract.test.js
@@ -68,17 +68,23 @@ describe('service_telemetry producer/consumer contract', () => {
       expect(insertCall.service_id).toBe('svc-id-123');
     });
 
-    it('is non-blocking (never throws) when service_key does not resolve', async () => {
+    it('is non-blocking (never throws) when service_key does not resolve, and logs a distinct warning (adversarial-review fix)', async () => {
       const failingSupabase = createMockSupabase({
         maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
         insert: vi.fn().mockReturnValue({ error: { message: 'null value in column "service_id"' } }),
       });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       await expect(reportGenericTelemetry(failingSupabase, {
         service_key: 'unknown-service',
         venture_id: MOCK_VENTURE_ID,
         event_type: 'artifact_generated',
       })).resolves.toBeUndefined();
+
+      // The unresolvable service_key gets its OWN warning, distinct from the generic
+      // insert-failure warning, so the failure is diagnosable without correlating logs.
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('did not resolve to an active ehg_services row'));
+      warnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes the service_telemetry producer/consumer field contract (FR-1): both writers now populate task_id/service_id (previously-silent NOT-NULL failures) and outcome/processing_time_ms (the fields the ops_product_health collector reads).
- Adds a durable scheduler (scripts/cron/venture-ops-actuals-sweep.mjs) that activates the ops_product_health and ops_revenue_metrics collectors plus a new external uptime probe, each registered in periodic_process_registry with a distinct owner-agent (FR-2/FR-3/FR-4/FR-6).
- Extends the existing chairman exec-email pipeline with a per-venture actuals-vs-targets line (FR-5).
- 200 tests passing across 12 new/modified test files; all pre-existing tests in touched files still pass.

## Test plan
- [x] `npx vitest run` across all new/modified test files (200/200 passing)
- [x] Static wiring test pins workflow → sweep script → collector/probe import chain
- [ ] Post-merge: verify service_telemetry / ops_product_health / ops_revenue_metrics row counts advance after the first live cron cycle (per the SD's own smoke_test_steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)