### PR TITLE
feat(SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001): roadmap fold-in seam — mandatory wave disposition + scheduled refresher + orphan backfill

### DIFF
--- a/.github/workflows/wave-progress-refresher.yml
+++ b/.github/workflows/wave-progress-refresher.yml
@@ -1,0 +1,49 @@
+name: "Wave progress refresher"
+
+# SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-3) — waves-as-gates model: wave gate
+# progress derives from the belt/gauge automatically instead of freezing until
+# someone runs the rollup by hand (strategic_roadmaps sat un-refreshed for a
+# month while nine ratified workstreams accumulated — plan-gap audit
+# 2026-07-11). Runs the existing rung rollup with --apply on a schedule,
+# independent of any coordinator session (mirrors backlog-rank-cron.yml). The
+# CLI self-registers in periodic_process_registry and stamps last_fired_at, so
+# the periodic-liveness watcher owns detecting a dead refresher.
+
+on:
+  schedule:
+    # Every 6 hours, minute offset to dodge the ~15min cron cluster.
+    - cron: '37 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Roll up wave progress from the belt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Apply rung/wave progress rollup
+        run: node scripts/vision/rung-progress-rollup.mjs --apply

--- a/lib/decision-binding/disposition.js
+++ b/lib/decision-binding/disposition.js
@@ -13,12 +13,17 @@
 // dual_domain_governance trigger takes its no-governance-required default path.
 
 import { createHash } from 'node:crypto';
+import { validateWaveDisposition, applyWaveDisposition } from '../roadmap/wave-disposition.js';
 
 const EVENT_TYPE = 'DECISION_DISPOSITION';
 
 // domain_acquisition added by SD-LEO-FEAT-VENTURE-DOMAIN-ACQUISITION-001 FR-4
 // (consumed-exactly-once purchase binding, subject {venture_id, domain}).
-const VALID_DECISION_TYPES = ['ratification', 'consult_answer', 'dispatch_auth', 'domain_acquisition'];
+// plan_ratification added by SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001: chairman
+// PLAN-affecting ratifications (subject {workstream}) REQUIRE a wave
+// disposition — distinct from 'ratification', which is the artifact/fixture
+// class (value-authenticity, APA fixtures) and stays wave-exempt.
+const VALID_DECISION_TYPES = ['ratification', 'consult_answer', 'dispatch_auth', 'domain_acquisition', 'plan_ratification'];
 const VALID_STATUSES = ['awaiting_disposition', 'dispositioned', 'consumed'];
 
 /**
@@ -44,6 +49,7 @@ function canonicalize(value) {
  *   consult_answer: { question_text }
  *   dispatch_auth: { subject_id, gate_type }
  *   domain_acquisition: { venture_id, domain }
+ *   plan_ratification: { workstream }
  * @returns {string} a stable "dq_<sha256-hex>" key
  */
 export function computeQuestionKey(decisionType, subject) {
@@ -89,6 +95,7 @@ export async function recordDisposition(supabase, {
   authority = null,
   answerPayload = null,
   status,
+  waveDisposition = null,
 }) {
   assertSupabase(supabase);
   const questionKey = computeQuestionKey(decisionType, subject);
@@ -96,6 +103,13 @@ export async function recordDisposition(supabase, {
   if (!VALID_STATUSES.includes(resolvedStatus)) {
     throw new Error(`recordDisposition: invalid status "${resolvedStatus}"`);
   }
+
+  // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001: a plan ratification without an explicit
+  // wave disposition is unrecordable — validated BEFORE any row is written so
+  // the negative path leaves no partial state. Throws with usage guidance.
+  const waveVerdict = decisionType === 'plan_ratification'
+    ? validateWaveDisposition(waveDisposition)
+    : null;
 
   const existing = await getDisposition(supabase, questionKey);
   if (existing) {
@@ -115,6 +129,7 @@ export async function recordDisposition(supabase, {
       authority,
       decided_at: resolvedStatus === 'awaiting_disposition' ? null : nowIso,
       answer_payload: answerPayload,
+      ...(waveVerdict ? { wave_disposition: waveVerdict } : {}),
     },
   };
 
@@ -133,6 +148,18 @@ export async function recordDisposition(supabase, {
       if (winner) return { row: winner, created: false };
     }
     throw new Error(`recordDisposition: insert failed: ${error.message}`);
+  }
+
+  if (waveVerdict) {
+    // Durable effects: wave item (when a wave was chosen) + roadmap freshness
+    // stamp. The disposition row above is the source of truth; applyWaveDisposition
+    // is idempotent, so a failure here is loudly retryable without re-deciding.
+    await applyWaveDisposition(supabase, {
+      waveDisposition,
+      sourceKey: questionKey,
+      title: decisionKey ?? subject.workstream ?? questionKey,
+      dispositionSource: 'plan_ratification',
+    });
   }
 
   return { row: data, created: true };

--- a/lib/decision-binding/disposition.js
+++ b/lib/decision-binding/disposition.js
@@ -113,6 +113,20 @@ export async function recordDisposition(supabase, {
 
   const existing = await getDisposition(supabase, questionKey);
   if (existing) {
+    if (waveVerdict) {
+      // Repair path (adversarial review, SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001):
+      // a prior call may have committed the disposition row and then failed
+      // applying the durable wave effect. applyWaveDisposition is idempotent
+      // (dup insert resolves to the existing item; the stamp is harmless), so
+      // re-applying on the dedup path makes retry actually heal instead of
+      // short-circuiting the effect away forever.
+      await applyWaveDisposition(supabase, {
+        waveDisposition,
+        sourceKey: subject.workstream ?? questionKey,
+        title: decisionKey ?? subject.workstream ?? questionKey,
+        dispositionSource: 'plan_ratification',
+      });
+    }
     return { row: existing, created: false };
   }
 
@@ -153,10 +167,13 @@ export async function recordDisposition(supabase, {
   if (waveVerdict) {
     // Durable effects: wave item (when a wave was chosen) + roadmap freshness
     // stamp. The disposition row above is the source of truth; applyWaveDisposition
-    // is idempotent, so a failure here is loudly retryable without re-deciding.
+    // is idempotent AND re-runs on the dedup path above, so a failure here is
+    // genuinely retryable — call recordDisposition again with the same args.
+    // sourceKey uses the WORKSTREAM (not question_key) so the orchestrator
+    // creation path and this path share one item identity per workstream/sd_key.
     await applyWaveDisposition(supabase, {
       waveDisposition,
-      sourceKey: questionKey,
+      sourceKey: subject.workstream ?? questionKey,
       title: decisionKey ?? subject.workstream ?? questionKey,
       dispositionSource: 'plan_ratification',
     });

--- a/lib/roadmap/wave-disposition.js
+++ b/lib/roadmap/wave-disposition.js
@@ -1,0 +1,129 @@
+// Wave-disposition contract (SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001).
+//
+// Under the chairman-ratified WAVES-AS-GATES model, every plan-affecting event
+// (chairman plan ratification, orchestrator-parent SD creation) must record an
+// explicit wave disposition — a roadmap_wave_items insert OR an explicit
+// no_wave verdict — and stamp roadmap freshness either way. A missing
+// disposition is an ERROR on gated paths, never silently defaulted: the defect
+// this closes is exactly silent non-disposition (strategic_roadmaps.updated_at
+// frozen for a month while nine ratified workstreams accumulated waveless —
+// plan-gap audit 2026-07-11, verdict cd261597).
+
+import { createHash } from 'node:crypto';
+
+/**
+ * roadmap_wave_items.source_id is UUID NOT NULL and participates in
+ * UNIQUE(wave_id, source_type, source_id). Deriving the UUID deterministically
+ * from the caller's stable key (question_key / sd_key) makes the unique
+ * constraint double as the idempotency guarantee — re-recording the same
+ * disposition can never insert a second item.
+ */
+export function deterministicSourceId(key) {
+  const hex = createHash('sha256').update(String(key), 'utf8').digest('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Validate a wave disposition: exactly one of { waveId } or { noWave: reason }.
+ * Throws on anything else — explicit-never-default (TR-2).
+ *
+ * @returns {{kind:'wave', waveId:string} | {kind:'no_wave', reason:string}}
+ */
+export function validateWaveDisposition(wd) {
+  if (!wd || typeof wd !== 'object') {
+    throw new Error(
+      'wave_disposition required: pass { waveId: "<roadmap_waves.id>" } or { noWave: "<reason>" } — ' +
+      'plan-affecting events must record an explicit wave disposition (waves-as-gates model, SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001)'
+    );
+  }
+  const hasWave = typeof wd.waveId === 'string' && wd.waveId.trim().length > 0;
+  const hasNoWave = typeof wd.noWave === 'string' && wd.noWave.trim().length > 0;
+  if (hasWave === hasNoWave) {
+    throw new Error(
+      hasWave
+        ? 'wave_disposition must be exactly one of { waveId } or { noWave } — not both'
+        : 'wave_disposition must be exactly one of { waveId } or { noWave: "<non-empty reason>" }'
+    );
+  }
+  return hasWave
+    ? { kind: 'wave', waveId: wd.waveId.trim() }
+    : { kind: 'no_wave', reason: wd.noWave.trim() };
+}
+
+async function stampRoadmapFreshness(supabase, roadmapIds, nowIso) {
+  const ids = [...new Set(roadmapIds)].filter(Boolean);
+  if (ids.length === 0) return;
+  // strategic_roadmaps has no updated_at trigger — the stamp must be explicit.
+  const { error } = await supabase
+    .from('strategic_roadmaps')
+    .update({ updated_at: nowIso })
+    .in('id', ids);
+  if (error) throw new Error(`wave-disposition: roadmap freshness stamp failed: ${error.message}`);
+}
+
+/**
+ * Apply a validated disposition's durable effects.
+ *  - kind 'wave': insert a roadmap_wave_items row (source_type 'adam_direct' —
+ *    existing CHECK vocabulary; this SD is no-schema-change) keyed on a
+ *    deterministic source_id, then stamp the wave's parent roadmap.
+ *  - kind 'no_wave': stamp all active roadmaps — the explicit verdict itself
+ *    is the freshness event.
+ * Idempotent: a duplicate wave insert (23505) resolves to the existing row.
+ *
+ * @param {object} supabase - service-role client
+ * @param {object} params
+ * @param {object} params.waveDisposition - raw { waveId } | { noWave } shape
+ * @param {string} params.sourceKey - stable key (question_key / sd_key) for source_id derivation
+ * @param {string} params.title - wave-item title when a wave is chosen
+ * @param {string} params.dispositionSource - provenance label (e.g. 'plan_ratification', 'orchestrator_sd_creation')
+ * @returns {Promise<{verdict: object, itemId: string|null}>}
+ */
+export async function applyWaveDisposition(supabase, { waveDisposition, sourceKey, title, dispositionSource }) {
+  const verdict = validateWaveDisposition(waveDisposition);
+  const nowIso = new Date().toISOString();
+
+  if (verdict.kind === 'no_wave') {
+    const { data: actives, error } = await supabase
+      .from('strategic_roadmaps').select('id').eq('status', 'active');
+    if (error) throw new Error(`wave-disposition: active roadmap lookup failed: ${error.message}`);
+    await stampRoadmapFreshness(supabase, (actives ?? []).map((r) => r.id), nowIso);
+    return { verdict, itemId: null };
+  }
+
+  const sourceId = deterministicSourceId(sourceKey);
+  let itemId = null;
+  const { data, error } = await supabase
+    .from('roadmap_wave_items')
+    .insert({
+      wave_id: verdict.waveId,
+      source_type: 'adam_direct',
+      source_id: sourceId,
+      title,
+      item_disposition: 'pending',
+      metadata: { disposition_source: dispositionSource, source_key: sourceKey, wave_disposition: verdict },
+    })
+    .select('id')
+    .single();
+  if (error) {
+    if (error.code === '23505') {
+      const { data: existing } = await supabase
+        .from('roadmap_wave_items').select('id')
+        .eq('wave_id', verdict.waveId).eq('source_type', 'adam_direct').eq('source_id', sourceId)
+        .maybeSingle();
+      itemId = existing?.id ?? null;
+    } else {
+      throw new Error(`wave-disposition: wave item insert failed: ${error.message}`);
+    }
+  } else {
+    itemId = data.id;
+  }
+
+  const { data: wave, error: wErr } = await supabase
+    .from('roadmap_waves').select('roadmap_id').eq('id', verdict.waveId).single();
+  if (wErr) throw new Error(`wave-disposition: wave ${verdict.waveId} not found: ${wErr.message}`);
+  await stampRoadmapFreshness(supabase, [wave.roadmap_id], nowIso);
+
+  return { verdict, itemId };
+}
+
+export default { validateWaveDisposition, applyWaveDisposition, deterministicSourceId };

--- a/lib/sd-creation/pipeline.js
+++ b/lib/sd-creation/pipeline.js
@@ -29,6 +29,7 @@ import { trackWriteSource } from '../eva/cli-write-gate.js';
 // resolver so engineering/governance work never inherits a spurious venture prefix.
 import { isLegitimateNoVenture } from '../eva/bridge/sd-router.js';
 import { deriveSdFunctionalRequirements } from '../sd/derive-functional-requirements.js';
+import { validateWaveDisposition, applyWaveDisposition } from '../roadmap/wave-disposition.js';
 import { validateSDFields } from '../../scripts/modules/validate-sd-fields.js';
 // SD-LEO-INFRA-SOURCING-ENGINE-REGISTER-FIRST-001: pure register-first helpers (FR-2 warn-only decision).
 import { shouldWarnRegisterFirst } from '../sourcing-engine/register-first.js';
@@ -613,6 +614,10 @@ async function createSD(options) {
     // could not be populated by ANY caller. Default null preserves behavior for the
     // direct/--from-feedback/--child callers that omit it.
     dependencies = null,
+    // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001: orchestrator parents are plan-affecting
+    // events — creation requires an explicit wave disposition ({ waveId } or
+    // { noWave: reason }); enforced below once dbType resolves.
+    wave_disposition = null,
   } = options;
 
   // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-1/FR-2/FR-3): resolve the effective sd_type. An explicit
@@ -670,6 +675,19 @@ async function createSD(options) {
 
   // Map user-friendly type to valid database sd_type
   const dbType = mapToDbType(type);
+
+  // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): an orchestrator parent is a
+  // plan-affecting event — it MUST carry an explicit wave disposition
+  // (--wave <id> | --no-wave "<reason>" on the CLI; wave_disposition option
+  // programmatically). Validated before any insert; the verdict rides
+  // metadata.wave_disposition. Explicit-never-default: silent non-disposition
+  // is the defect this closes (roadmap frozen 26 days, nine waveless
+  // ratified workstreams). Children/non-orchestrators are unchanged.
+  let waveVerdict = null;
+  if (dbType === 'orchestrator') {
+    waveVerdict = validateWaveDisposition(wave_disposition);
+    metadata.wave_disposition = waveVerdict;
+  }
 
   // PREVENTIVE CONTROL: Validate sd_type/category alignment (RCA from SD-LEO-ENH-AUTO-PROCEED-001-12)
   // sd_type controls validation profiles, category controls gate overrides - misalignment causes issues
@@ -1226,6 +1244,26 @@ async function createSD(options) {
     visionKey: metadata?.vision_key,
     archKey: metadata?.arch_key
   }).catch(err => console.log(`\n   ⚠️  Vision pre-screen failed (non-blocking): ${err.message}`));
+
+  // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): durable disposition effects —
+  // wave item (when a wave was chosen) + roadmap freshness stamp. The SD row's
+  // metadata.wave_disposition (written pre-insert) is the source of truth;
+  // applyWaveDisposition is idempotent, so a failure here is loudly surfaced
+  // with remediation rather than rolling back the created SD.
+  if (waveVerdict) {
+    try {
+      await applyWaveDisposition(supabase, {
+        waveDisposition: wave_disposition,
+        sourceKey: data.sd_key,
+        title: data.title,
+        dispositionSource: 'orchestrator_sd_creation',
+      });
+      console.log(`   🌊 wave disposition recorded: ${waveVerdict.kind === 'wave' ? `wave ${waveVerdict.waveId}` : `no_wave (${waveVerdict.reason})`} — roadmap freshness stamped`);
+    } catch (wdErr) {
+      console.error(`   ❌ wave disposition apply FAILED (SD created, metadata.wave_disposition recorded): ${wdErr.message}`);
+      console.error('      Remediation: re-run node scripts/record-plan-ratification.mjs --workstream ' + JSON.stringify(data.sd_key) + ' with the same disposition (idempotent).');
+    }
+  }
 
   // Scope complexity advisory for orchestrator SDs (SD-MAN-ORCH-SCOPE-COMPLEXITY-ANALYSIS-001-A)
   if (dbType === 'orchestrator') {

--- a/lib/sd-creation/pipeline.js
+++ b/lib/sd-creation/pipeline.js
@@ -1261,7 +1261,12 @@ async function createSD(options) {
       console.log(`   🌊 wave disposition recorded: ${waveVerdict.kind === 'wave' ? `wave ${waveVerdict.waveId}` : `no_wave (${waveVerdict.reason})`} — roadmap freshness stamped`);
     } catch (wdErr) {
       console.error(`   ❌ wave disposition apply FAILED (SD created, metadata.wave_disposition recorded): ${wdErr.message}`);
-      console.error('      Remediation: re-run node scripts/record-plan-ratification.mjs --workstream ' + JSON.stringify(data.sd_key) + ' with the same disposition (idempotent).');
+      // The recorder CLI heals this exactly: it applies with sourceKey =
+      // workstream, and this path applies with sourceKey = sd_key — pass the
+      // sd_key as the workstream and the idempotent apply converges on the
+      // same roadmap_wave_items identity.
+      const flag = waveVerdict.kind === 'wave' ? `--wave ${waveVerdict.waveId}` : `--no-wave ${JSON.stringify(waveVerdict.reason)}`;
+      console.error(`      Remediation (idempotent): node scripts/record-plan-ratification.mjs --workstream ${JSON.stringify(data.sd_key)} ${flag}`);
     }
   }
 

--- a/lib/sd-creation/source-adapters/plan.js
+++ b/lib/sd-creation/source-adapters/plan.js
@@ -297,6 +297,10 @@ export async function createFromPlan(planPath = null, skipConfirmation = false, 
     }
   };
   if (parsed.priority) createOptions.priority = parsed.priority;
+  // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): thread --wave/--no-wave through to
+  // createSD's orchestrator gate (which throws when an orchestrator parent
+  // arrives without a disposition).
+  if (overrides.waveDisposition) createOptions.wave_disposition = overrides.waveDisposition;
   // 7f0a4f54: explicit `## Target Application` plan header takes precedence
   // over detectFromKeyChanges file-path inference. Without this, plans that
   // literally name the target still landed under the path-detector's default.

--- a/scripts/backfill-roadmap-fold-seam.mjs
+++ b/scripts/backfill-roadmap-fold-seam.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// One-time backfill — SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-4).
+//
+// Records gate-tag wave dispositions for the nine ratified-but-waveless
+// workstreams named in the plan-gap audit (Solomon verdict cd261597,
+// 2026-07-11), and archives the superseded EVA Intake Roadmap row (ed12bf74 —
+// standing 2026-06-13 chairman order that was never executed). Idempotent:
+// applyWaveDisposition derives a deterministic source_id per workstream, so
+// UNIQUE(wave_id, source_type, source_id) makes a second run a no-op; the
+// archive is a status flip guarded by its current value.
+//
+// Placements are Solomon-PROPOSED gate tags flagged with provenance
+// (disposition_source below) — reversible row-level edits the chairman can
+// re-disposition at any time.
+//
+// Usage: node scripts/backfill-roadmap-fold-seam.mjs [--dry-run]
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { applyWaveDisposition } from '../lib/roadmap/wave-disposition.js';
+
+const WAVE_1 = '8990e54c-9e0c-48ab-b488-917d523bdd9b'; // Wave 1: EHG Foundation
+const WAVE_2 = 'e7585d66-b995-430a-a9e9-2d38976aada1'; // Wave 2: Revenue rails ready
+const EVA_INTAKE_ROADMAP = 'ed12bf74-57c9-4ee0-a1b3-273bef11705c';
+const DISPOSITION_SOURCE = 'plan-gap-backfill-20260711';
+
+// The nine orphans, per the plan-gap audit's proposed placements.
+const ORPHANS = [
+  { key: 'operating-company-spine-core', title: 'Operating-company spine core (incl. sec-8 pipeline/CRM fold-in, ratified 07-10)', wave: WAVE_1 },
+  { key: 'deep-challenge-26-stage-commission', title: '26-stage DEEP CHALLENGE commission (Stage-0 first, 07-10)', wave: WAVE_1 },
+  { key: 's20-26-simulated-run-harness', title: 'S20-26 simulated-run harness (built + smoke-verified; run pending GO)', wave: WAVE_1 },
+  { key: 'kill-gate-teeth-proof-regime', title: 'Kill-gate teeth-proof regime (designed 07-11; ALPHA on GO, BETA post seam fix)', wave: WAVE_1 },
+  { key: 'apa-cluster', title: 'APA cluster (children A-D complete; E draft; chairman-fenced)', wave: WAVE_1 },
+  { key: 'chairman-console-eva-meetings', title: 'Chairman console / EVA-run meetings / venture AI-CEO org vision (07-10)', wave: WAVE_1 },
+  { key: 'deploy-pipeline', title: 'Venture deploy pipeline (parent completed; MarketLens live) — W3 entry-gate enabler', wave: WAVE_2 },
+  { key: 'demand-distribution-engine', title: 'Demand/distribution engine (A-D complete; E gated on live venture)', wave: WAVE_2 },
+  { key: 'venture-selection-fresh-start', title: 'Venture-selection method + 07-08 fresh-start pivot (produces the W3 gate candidate)', wave: WAVE_2 },
+];
+
+const dryRun = process.argv.includes('--dry-run');
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+let inserted = 0, existing = 0;
+for (const o of ORPHANS) {
+  if (dryRun) { console.log(`  [dry-run] would disposition "${o.title}" -> wave ${o.wave}`); continue; }
+  const before = await supabase.from('roadmap_wave_items').select('id')
+    .eq('wave_id', o.wave).eq('source_type', 'adam_direct')
+    .contains('metadata', { source_key: o.key }).maybeSingle();
+  const res = await applyWaveDisposition(supabase, {
+    waveDisposition: { waveId: o.wave },
+    sourceKey: o.key,
+    title: o.title,
+    dispositionSource: DISPOSITION_SOURCE,
+  });
+  if (before.data) existing += 1; else inserted += 1;
+  console.log(`  ✓ ${before.data ? 'exists' : 'dispositioned'}: ${o.key} -> item ${res.itemId}`);
+}
+
+// Archive the superseded EVA Intake Roadmap (status flip, never a delete).
+if (!dryRun) {
+  const { data: row } = await supabase.from('strategic_roadmaps')
+    .select('id,status').eq('id', EVA_INTAKE_ROADMAP).maybeSingle();
+  if (!row) {
+    console.log(`  ⚠ EVA Intake Roadmap ${EVA_INTAKE_ROADMAP} not found — skipping archive`);
+  } else if (row.status === 'archived') {
+    console.log('  ✓ EVA Intake Roadmap already archived (idempotent)');
+  } else {
+    const { error } = await supabase.from('strategic_roadmaps')
+      .update({ status: 'archived', updated_at: new Date().toISOString() })
+      .eq('id', EVA_INTAKE_ROADMAP);
+    if (error) { console.error(`  ❌ archive failed: ${error.message}`); process.exit(1); }
+    console.log('  ✓ EVA Intake Roadmap archived (status flip; content retained)');
+  }
+}
+
+console.log(`\nBackfill ${dryRun ? 'DRY-RUN' : 'complete'}: ${inserted} inserted, ${existing} already present, ${ORPHANS.length} total.`);
+
+// Enumeration proof (paste into the PR): every orphan has a disposition row.
+if (!dryRun) {
+  const { data: proof } = await supabase.from('roadmap_wave_items')
+    .select('title,wave_id,metadata')
+    .eq('source_type', 'adam_direct')
+    .filter('metadata->>disposition_source', 'eq', DISPOSITION_SOURCE);
+  console.log(`\nEnumeration (${(proof ?? []).length}/9 expected):`);
+  for (const p of proof ?? []) console.log(`  - [${p.wave_id === WAVE_1 ? 'W1' : 'W2'}] ${p.title.slice(0, 90)}`);
+}

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -353,6 +353,13 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // SD-LEO-INFRA-LEO-CREATE-CROSS-001: --target-repos for cross-repo SDs
       const targetReposIdxPlan = args.indexOf('--target-repos');
       const targetReposPlan = targetReposIdxPlan !== -1 ? parseTargetReposArg(args[targetReposIdxPlan + 1]) : null;
+      // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): --wave <roadmap_waves.id> | --no-wave "<reason>".
+      // Required when the plan produces an orchestrator parent (createSD's gate throws otherwise).
+      const waveIdxPlan = args.indexOf('--wave');
+      const noWaveIdxPlan = args.indexOf('--no-wave');
+      const waveDispositionPlan = waveIdxPlan !== -1
+        ? { waveId: args[waveIdxPlan + 1] }
+        : (noWaveIdxPlan !== -1 ? { noWave: args[noWaveIdxPlan + 1] } : null);
       // Path is any arg that isn't a flag or a flag's value
       const flagValuePositions = new Set(
         [
@@ -362,12 +369,14 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           visionKeyIdx !== -1 ? visionKeyIdx + 1 : -1,
           archKeyIdx !== -1 ? archKeyIdx + 1 : -1,
           targetReposIdxPlan !== -1 ? targetReposIdxPlan + 1 : -1,
+          waveIdxPlan !== -1 ? waveIdxPlan + 1 : -1,
+          noWaveIdxPlan !== -1 ? noWaveIdxPlan + 1 : -1,
         ].filter(i => i > 0)
       );
       const knownPlanFlags = new Set([
         '--yes', '-y', '--type', '--title', '--priority', '--from-plan',
         '--vision-key', '--arch-key', '--migration-reviewed', '--security-reviewed',
-        '--target-repos', '--force-create'
+        '--target-repos', '--force-create', '--wave', '--no-wave'
       ]);
       const planPath = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !flagValuePositions.has(i) && !knownPlanFlags.has(arg)
@@ -382,6 +391,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         securityReviewed,
         targetRepos: targetReposPlan,
         forceCreate,
+        waveDisposition: waveDispositionPlan,
       });
       exitFromResult(planRes);
     } else if (args[0] === '--child') {

--- a/scripts/modules/leo-create-sd/direct-lane.js
+++ b/scripts/modules/leo-create-sd/direct-lane.js
@@ -35,7 +35,10 @@ export async function runDirectCreation(args) {
   // are now valid in direct-args mode (closes 8a640d32 sibling-parity gap with --from-plan).
   const knownDirectFlags = new Set([
     '--venture', '--vision-key', '--arch-key', '--target-repos',
-    '--migration-reviewed', '--security-reviewed', '--yes', '-y'
+    '--migration-reviewed', '--security-reviewed', '--yes', '-y',
+    // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): wave disposition flags,
+    // required when the direct lane creates an orchestrator parent.
+    '--wave', '--no-wave'
   ]);
   const unknownFlags = args.filter(a => a.startsWith('-') && !knownDirectFlags.has(a));
   if (unknownFlags.length > 0) {
@@ -346,11 +349,19 @@ export async function runDirectCreation(args) {
   const directMigrationReviewed = args.includes('--migration-reviewed');
   const directSecurityReviewed = args.includes('--security-reviewed');
 
+  // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): --wave/--no-wave for orchestrator parents.
+  const directWaveIdx = args.indexOf('--wave');
+  const directNoWaveIdx = args.indexOf('--no-wave');
+  const directWaveDisposition = directWaveIdx !== -1
+    ? { waveId: args[directWaveIdx + 1] }
+    : (directNoWaveIdx !== -1 ? { noWave: args[directNoWaveIdx + 1] } : null);
+
   const createRes = await createSD({
     sdKey,
     title,
     description: enriched?.description || title,
     type,
+    wave_disposition: directWaveDisposition,
     rationale: enriched?.rationale || 'Created via /leo create',
     success_criteria: enriched?.success_criteria || null,
     key_changes: enriched?.key_changes || null,

--- a/scripts/record-plan-ratification.mjs
+++ b/scripts/record-plan-ratification.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Governed path for recording a chairman PLAN ratification
+// (SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001, FR-1).
+//
+// Every plan ratification MUST carry an explicit wave disposition — the
+// disposition primitive (lib/decision-binding/disposition.js, decision type
+// 'plan_ratification') throws without one, so a disposition-less ratification
+// is unrecordable on this path. Both disposition kinds stamp roadmap
+// freshness; idempotent (same workstream twice returns the existing row).
+//
+// Usage:
+//   node scripts/record-plan-ratification.mjs --workstream "<name>" \
+//     (--wave <roadmap_waves.id> | --no-wave "<reason>") \
+//     [--authority chairman] [--key "<decision label>"]
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { recordDisposition } from '../lib/decision-binding/disposition.js';
+
+function usage(msg) {
+  if (msg) console.error(`\n❌ ${msg}`);
+  console.error('\nUsage: node scripts/record-plan-ratification.mjs --workstream "<name>" (--wave <wave-id> | --no-wave "<reason>") [--authority chairman] [--key "<label>"]');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const val = (flag) => {
+  const i = args.indexOf(flag);
+  return i !== -1 ? args[i + 1] : null;
+};
+
+const workstream = val('--workstream');
+if (!workstream) usage('--workstream is required');
+
+const waveId = val('--wave');
+const noWave = val('--no-wave');
+const waveDisposition = waveId ? { waveId } : (noWave ? { noWave } : null);
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+try {
+  const { row, created } = await recordDisposition(supabase, {
+    decisionType: 'plan_ratification',
+    subject: { workstream },
+    decisionKey: val('--key') || workstream,
+    authority: val('--authority') || 'chairman',
+    answerPayload: { ratified: true },
+    waveDisposition,
+  });
+  console.log(`✓ plan ratification ${created ? 'recorded' : 'already recorded (idempotent)'}`);
+  console.log(`  question_key: ${row.payload.question_key}`);
+  console.log(`  workstream:   ${workstream}`);
+  console.log(`  disposition:  ${waveId ? `wave ${waveId}` : `no_wave (${noWave})`}`);
+  process.exit(0);
+} catch (err) {
+  usage(err.message);
+}

--- a/scripts/vision/rung-progress-rollup.mjs
+++ b/scripts/vision/rung-progress-rollup.mjs
@@ -15,6 +15,37 @@ import { computeBuildGauge } from '../../lib/vision/vdr-registry.js';
 import { makeDefaultGrepSeam } from '../../lib/vision/vdr-grep-seam.js';
 import { runRollup } from '../../lib/vision/rung-progress-rollup.mjs';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+
+// SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-3): applied runs are a registered,
+// owned periodic process (P6 regime) — self-register the registry row and
+// stamp last_fired_at each run so the liveness watcher sees it and the
+// refresher can never go dormant invisibly. Idempotent upsert.
+const PROCESS_KEY = 'wave-progress-refresher';
+const EXPECTED_INTERVAL_SECONDS = 6 * 60 * 60; // 6h cadence (wave-progress-refresher.yml)
+
+async function ensureRegistryAndStamp(supabase) {
+  try {
+    const { error } = await supabase.from('periodic_process_registry').upsert({
+      process_key: PROCESS_KEY,
+      display_name: 'Wave progress refresher (rung rollup --apply)',
+      owner: 'vision-rollup',
+      process_type: 'standalone_cron',
+      expected_interval_seconds: EXPECTED_INTERVAL_SECONDS,
+      liveness_source: 'self_stamped',
+      liveness_source_ref: { workflow: '.github/workflows/wave-progress-refresher.yml', sd_key: 'SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001' },
+      session_bound: false,
+      currently_expected_active: true,
+    }, { onConflict: 'process_key' });
+    if (error) throw new Error(error.message);
+    await stampLastFired(supabase, PROCESS_KEY);
+    console.log(`  [liveness] ${PROCESS_KEY} registered + last_fired_at stamped`);
+  } catch (err) {
+    // Loud but non-fatal: the rollup itself succeeded; a missing stamp surfaces
+    // as UNVERIFIED/OVERDUE on the liveness watcher rather than a lost run.
+    console.error(`  [liveness] WARN: registry stamp failed for ${PROCESS_KEY}: ${err.message}`);
+  }
+}
 
 async function main() {
   const apply = process.argv.includes('--apply');
@@ -27,6 +58,8 @@ async function main() {
 
   const res = await runRollup({ supabase, computeGaugeFn, apply });
   if (!res.ok) { console.error('[rung-rollup] ERROR:', res.error); process.exit(1); }
+
+  if (apply) await ensureRegistryAndStamp(supabase);
 
   console.log(`\n  Active build rung: ${res.activeRungKey} | build gauge: ${res.gaugeBuildPct}%`);
   console.log(`  ${apply ? 'APPLIED' : 'DRY-RUN (pass --apply to persist)'} — wrote ${res.written} row(s)\n`);

--- a/tests/unit/wave-disposition.test.js
+++ b/tests/unit/wave-disposition.test.js
@@ -143,6 +143,41 @@ describe('recordDisposition plan_ratification gate (TS-1 / TS-6)', () => {
     expect(from).not.toHaveBeenCalled(); // negative path leaves no partial state
   });
 
+  it('repair path: plan_ratification dedup RE-APPLIES the wave effect (partial-failure heal)', async () => {
+    // Simulates: disposition row committed on a prior call, wave effect lost.
+    // The dedup path must re-run applyWaveDisposition (idempotent), not
+    // short-circuit it away forever (adversarial review CRITICAL).
+    const existingRow = { id: 'e1', payload: { question_key: 'dq_y', status: 'dispositioned' } };
+    const stamped = [];
+    const inserted = [];
+    const supabase = {
+      from: (table) => ({
+        system_events: {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: existingRow, error: null }) }) }) }),
+        },
+        roadmap_wave_items: {
+          insert: (row) => { inserted.push(row); return { select: () => ({ single: () => Promise.resolve({ data: { id: 'item-2' }, error: null }) }) }; },
+        },
+        roadmap_waves: {
+          select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { roadmap_id: 'r1' }, error: null }) }) }),
+        },
+        strategic_roadmaps: {
+          update: () => ({ in: (_c, ids) => { stamped.push(...ids); return Promise.resolve({ error: null }); } }),
+        },
+      })[table],
+    };
+    const { created } = await recordDisposition(supabase, {
+      decisionType: 'plan_ratification',
+      subject: { workstream: 'spine-core' },
+      decisionKey: 'spine-core',
+      waveDisposition: { waveId: WAVE_ID },
+    });
+    expect(created).toBe(false);
+    expect(inserted).toHaveLength(1); // effect re-applied on the dedup path
+    expect(inserted[0].source_id).toBe(deterministicSourceId('spine-core')); // workstream identity, not question_key
+    expect(stamped).toEqual(['r1']);
+  });
+
   it('TS-6 control: artifact ratification (fixture class) records without a wave disposition', async () => {
     // Existing-row dedup path exercises the full pre-insert flow without a DB.
     const existingRow = { id: 'e1', payload: { question_key: 'dq_x', status: 'dispositioned' } };

--- a/tests/unit/wave-disposition.test.js
+++ b/tests/unit/wave-disposition.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the wave-disposition contract
+ * SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001
+ *
+ * Covers TS-1 (ratification without disposition rejected), TS-3 unit half
+ * (orchestrator creation gate semantics via validateWaveDisposition), TS-6
+ * control (exempt decision types unchanged), plus the idempotent apply path
+ * and freshness stamping.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validateWaveDisposition,
+  applyWaveDisposition,
+  deterministicSourceId,
+} from '../../lib/roadmap/wave-disposition.js';
+import { recordDisposition } from '../../lib/decision-binding/disposition.js';
+
+const WAVE_ID = '512c7478-c5df-4a5c-be00-49aa4d101e5c';
+
+describe('validateWaveDisposition (TS-1 / TS-3 gate semantics)', () => {
+  it('rejects a missing disposition with usage guidance', () => {
+    expect(() => validateWaveDisposition(null)).toThrow(/wave_disposition required/);
+    expect(() => validateWaveDisposition(undefined)).toThrow(/wave_disposition required/);
+  });
+
+  it('rejects both waveId and noWave supplied', () => {
+    expect(() => validateWaveDisposition({ waveId: WAVE_ID, noWave: 'x' })).toThrow(/not both/);
+  });
+
+  it('rejects an empty no_wave reason (explicit-never-default)', () => {
+    expect(() => validateWaveDisposition({ noWave: '   ' })).toThrow(/non-empty reason/);
+    expect(() => validateWaveDisposition({})).toThrow(/non-empty reason/);
+  });
+
+  it('accepts a wave choice and returns the verdict', () => {
+    expect(validateWaveDisposition({ waveId: WAVE_ID })).toEqual({ kind: 'wave', waveId: WAVE_ID });
+  });
+
+  it('accepts an explicit no_wave verdict with reason', () => {
+    expect(validateWaveDisposition({ noWave: 'operational-only, no gate impact' }))
+      .toEqual({ kind: 'no_wave', reason: 'operational-only, no gate impact' });
+  });
+});
+
+describe('deterministicSourceId', () => {
+  it('is stable and uuid-shaped (idempotency via UNIQUE constraint)', () => {
+    const a = deterministicSourceId('SD-X-001');
+    expect(a).toBe(deterministicSourceId('SD-X-001'));
+    expect(a).not.toBe(deterministicSourceId('SD-X-002'));
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+/** Minimal supabase mock: routes .from(table) chains onto canned handlers. */
+function mockSupabase(handlers) {
+  return {
+    from: (table) => handlers[table](),
+  };
+}
+
+describe('applyWaveDisposition', () => {
+  it('no_wave stamps all active roadmaps and inserts no item', async () => {
+    const stamped = [];
+    const supabase = mockSupabase({
+      strategic_roadmaps: () => ({
+        select: () => ({ eq: () => Promise.resolve({ data: [{ id: 'r1' }, { id: 'r2' }], error: null }) }),
+        update: (patch) => ({ in: (_c, ids) => { stamped.push(...ids); return Promise.resolve({ error: null }); } }),
+      }),
+    });
+    const res = await applyWaveDisposition(supabase, {
+      waveDisposition: { noWave: 'reason' },
+      sourceKey: 'k1',
+      title: 't',
+      dispositionSource: 'test',
+    });
+    expect(res.itemId).toBeNull();
+    expect(res.verdict.kind).toBe('no_wave');
+    expect(stamped).toEqual(['r1', 'r2']);
+  });
+
+  it('wave choice inserts the item and stamps the parent roadmap', async () => {
+    const inserted = [];
+    const stamped = [];
+    const supabase = mockSupabase({
+      roadmap_wave_items: () => ({
+        insert: (row) => { inserted.push(row); return { select: () => ({ single: () => Promise.resolve({ data: { id: 'item-1' }, error: null }) }) }; },
+      }),
+      roadmap_waves: () => ({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { roadmap_id: 'r1' }, error: null }) }) }),
+      }),
+      strategic_roadmaps: () => ({
+        update: () => ({ in: (_c, ids) => { stamped.push(...ids); return Promise.resolve({ error: null }); } }),
+      }),
+    });
+    const res = await applyWaveDisposition(supabase, {
+      waveDisposition: { waveId: WAVE_ID },
+      sourceKey: 'SD-ORCH-001',
+      title: 'Orch parent',
+      dispositionSource: 'orchestrator_sd_creation',
+    });
+    expect(res.itemId).toBe('item-1');
+    expect(inserted[0]).toMatchObject({
+      wave_id: WAVE_ID,
+      source_type: 'adam_direct',
+      item_disposition: 'pending',
+    });
+    expect(inserted[0].source_id).toBe(deterministicSourceId('SD-ORCH-001'));
+    expect(stamped).toEqual(['r1']);
+  });
+
+  it('duplicate insert (23505) resolves to the existing item — idempotent', async () => {
+    const supabase = mockSupabase({
+      roadmap_wave_items: () => ({
+        insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { code: '23505', message: 'dup' } }) }) }),
+        select: () => ({ eq: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { id: 'existing-1' }, error: null }) }) }) }) }),
+      }),
+      roadmap_waves: () => ({
+        select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { roadmap_id: 'r1' }, error: null }) }) }),
+      }),
+      strategic_roadmaps: () => ({
+        update: () => ({ in: () => Promise.resolve({ error: null }) }),
+      }),
+    });
+    const res = await applyWaveDisposition(supabase, {
+      waveDisposition: { waveId: WAVE_ID },
+      sourceKey: 'SD-ORCH-001',
+      title: 'Orch parent',
+      dispositionSource: 'orchestrator_sd_creation',
+    });
+    expect(res.itemId).toBe('existing-1');
+  });
+});
+
+describe('recordDisposition plan_ratification gate (TS-1 / TS-6)', () => {
+  it('TS-1: plan_ratification without waveDisposition throws BEFORE any write', async () => {
+    const from = vi.fn();
+    await expect(recordDisposition({ from }, {
+      decisionType: 'plan_ratification',
+      subject: { workstream: 'spine-core' },
+      decisionKey: 'spine-core',
+    })).rejects.toThrow(/wave_disposition required/);
+    expect(from).not.toHaveBeenCalled(); // negative path leaves no partial state
+  });
+
+  it('TS-6 control: artifact ratification (fixture class) records without a wave disposition', async () => {
+    // Existing-row dedup path exercises the full pre-insert flow without a DB.
+    const existingRow = { id: 'e1', payload: { question_key: 'dq_x', status: 'dispositioned' } };
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: existingRow, error: null }) }) }),
+        }),
+      }),
+    };
+    const { row, created } = await recordDisposition(supabase, {
+      decisionType: 'ratification',
+      subject: { fixture_set_id: 'fs1', fixture_id: 'f1' },
+      decisionKey: 'fixture f1',
+    });
+    expect(created).toBe(false);
+    expect(row).toBe(existingRow);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the process defect that froze the LEO Roadmap for a month while nine chairman-ratified workstreams accumulated with no wave home (plan-gap audit, Solomon verdict cd261597). Under the chairman-ratified **waves-as-gates** model:

- **FR-1** — `plan_ratification` decision type in `lib/decision-binding/disposition.js` REQUIRES an explicit wave disposition (`{ waveId }` XOR `{ noWave: reason }`), validated before any write. Artifact/fixture `ratification` class stays exempt (control-tested). Governed CLI: `scripts/record-plan-ratification.mjs`.
- **FR-2** — `createSD` rejects an orchestrator parent without a disposition **pre-insert** (verified live: 0 rows created). `--wave`/`--no-wave` threaded through `--from-plan` + direct lane. Both disposition kinds stamp `strategic_roadmaps.updated_at` — freshness can never silently freeze again.
- **FR-3** — `wave-progress-refresher.yml` runs the existing rung rollup `--apply` every 6h; the CLI self-registers in `periodic_process_registry` + stamps `last_fired_at` (P6 ownership regime).
- **FR-4** — one-time backfill executed: **9/9 orphan dispositions recorded** (W1: spine core, deep-challenge, S20-26 harness, kill-gate teeth regime, APA, chairman console; W2: deploy pipeline, demand engine, venture-selection/fresh-start), EVA Intake Roadmap archived (status flip), second run proven no-op. LEO Roadmap `updated_at` advanced 2026-06-15 → 2026-07-11.

## Verification
- 11 new unit tests (negative gate, both-kinds validation, idempotent apply, deterministic source_id, exempt-class control) — green.
- 138 tests green across the 12 suites touching modified modules.
- Live negative test: orchestrator creation without disposition rejected pre-insert, 0 rows.
- Backfill enumeration + idempotency output in the commit body.

## Known residual (flagged, out of LOC budget)
`lib/eva/create-orchestrator-from-plan.js` inserts orchestrator SDs directly (self-documented createSD bypass) and is NOT gated here — follow-up filed via completion flags.

## LOC justification (>100)
Three cohesive FRs sharing one invariant (every plan-affecting event stamps roadmap freshness): ~250 source LOC + 164 test LOC. Splitting would orphan the invariant across PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)