### PR TITLE
fix(QF-20260711-272): bind coordinator-authority fences at every claim-write site

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -587,4 +587,42 @@ async function isDispatchAuthorized(sd, supabase) {
   return { authorized: false, reason: 'dispatch_auth_pending' };
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized };
+// QF-20260711-272: coordinator-authority fences that BIND at the claim-WRITE boundary. Three
+// claim paths bypassed dispatch fences (worker-checkin resume_final, belt self-claim racing a
+// just-stamped needs_coordinator_review flag, sd-start auto-fallback) because eligibility ran
+// only at candidate-LIST time (stale row) or not at all on that path. This subset — NOT the full
+// axis table — binds at the write boundary: these reasons are clearable only by coordinator/human
+// authority (clear-coordinator-review.mjs, flag removal, not_before expiry), so no claim path may
+// cross them, including directed dispatch (a coordinator must CLEAR the fence, not dispatch over
+// it). Deliberately excluded: tier/fitness/reservation axes (ctx-dependent, path-specific) and
+// one_way door (documented directed-assign exemption in the oneWayDoor axis comment above).
+const CLAIM_WRITE_FENCE_AXES = new Set(['human_action_required', 'needs_coordinator_review', 'not_before_hold']);
+
+/**
+ * Live fence re-check at the claim-WRITE boundary (QF-20260711-272). Re-fetches the SD row so a
+ * fence stamped AFTER a candidate list was assembled still blocks (closes the read-then-claim
+ * race: KILL-GATE-TIER-001 was claimed 13:41Z against a pre-review snapshot). FAIL-CLOSED: a
+ * query error refuses the claim ('eligibility_check_error') — never claim on uncertainty.
+ * A missing row returns null (non-SD ids — QF keys — pass through; the claim_sd RPC arbitrates
+ * those), keeping the QF self-claim lane byte-identical.
+ * @param {object} sb  service-role client
+ * @param {string} sdKey
+ * @returns {Promise<string|null>} fence reason, 'eligibility_check_error', or null (no fence)
+ */
+async function liveClaimWriteFenceReason(sb, sdKey) {
+  try {
+    const { data, error } = await sb
+      .from('strategic_directives_v2')
+      .select('sd_key, sd_type, metadata, status, target_application')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null; // not an SD row (e.g. a QF id) — nothing to fence here
+    return classifyAllDispatchIneligibility(data).find((r) => CLAIM_WRITE_FENCE_AXES.has(r)) || null;
+  } catch (e) {
+    console.warn(`[claim-eligibility] live claim-write fence check failed for ${sdKey} — failing CLOSED: ${e && e.message}`);
+    return 'eligibility_check_error';
+  }
+}
+
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES };

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -100,7 +100,7 @@ const { evaluateClaimDependencyGate } = cjsRequire('../lib/claim/gates/dependenc
 const { verifyHandoffIntegrity: verifyHandoffIntegrityGate } = cjsRequire('../lib/claim/gates/handoff-integrity.cjs');
 const { evaluateCadenceGate } = cjsRequire('../lib/claim/gates/cadence-gate.cjs');
 const queueResolver = cjsRequire('../lib/claim/queue-resolver.cjs');
-const { classifyAllDispatchIneligibility } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
+const { classifyAllDispatchIneligibility, liveClaimWriteFenceReason } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
 // SD-ARCH-HOTSPOT-SD-START-001 FR-7: dispatch-authorization polarity gate (flag-gated, observe-first).
 const dispatchAuthGate = cjsRequire('../lib/claim/gates/dispatch-authorization.cjs');
 
@@ -1155,6 +1155,21 @@ async function main() {
             skippedSDs.push({ sdKey: nextSD.sdKey, reason: `dispatch_auth: ${fbVerdict.reason}` });
             excludeKeys.push(nextSD.sdKey);
             console.log(`${colors.yellow}   ⚠️  ${nextSD.sdKey} not dispatch-authorized (enforce mode) — skipping${colors.reset}`);
+            continue;
+          }
+        }
+
+        // QF-20260711-272: the fallback lane must enforce the same coordinator-authority fences
+        // (requires_human_action / needs_coordinator_review / not_before) the direct path enforces
+        // at 2.9 — live-fetched, so a fence stamped after queue assembly still blocks. Skip-polarity
+        // (iterate to the next candidate), matching the dispatch-auth block above. Fail-closed:
+        // 'eligibility_check_error' also skips.
+        {
+          const fbFence = await liveClaimWriteFenceReason(supabase, nextSD.sdKey);
+          if (fbFence) {
+            skippedSDs.push({ sdKey: nextSD.sdKey, reason: `claim_fenced:${fbFence}` });
+            excludeKeys.push(nextSD.sdKey);
+            console.log(`${colors.yellow}   ⚠️  ${nextSD.sdKey} fenced (${fbFence}) — skipping${colors.reset}`);
             continue;
           }
         }

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -46,7 +46,7 @@ const { isBuildForbiddenSession } = require('../lib/claim/build-forbidden-sessio
 const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cjs');
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
-const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
+const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, liveClaimWriteFenceReason } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-ARCH-HOTSPOT-SD-START-001 FR-2: the CONVERGED dependency gate shared with scripts/sd-start.js
 // (one resolution truth — deps array shapes + blocked_on_sd fold + sd_key-OR-id lookup). This
 // consumer applies its native FAIL-CLOSED polarity via depsSatisfiedFromVerdict: skip on
@@ -344,6 +344,11 @@ async function resolveTrack(sb, sdKey, fallback) {
 /** Attempt a claim via the canonical claim_sd RPC. Never throws. */
 async function tryClaim(sb, sdKey, sessionId, track) {
   try {
+    // QF-20260711-272: live coordinator-authority fence check at the claim-WRITE boundary —
+    // covers EVERY checkin claim lane (resume_final, orphan-adopt, draft self-claim, directed
+    // assignment) with one re-fetch, closing the stale-candidate-row race. Fail-closed.
+    const fence = await liveClaimWriteFenceReason(sb, sdKey);
+    if (fence) return { ok: false, error: `claim_fenced:${fence}` };
     const p_track = await resolveTrack(sb, sdKey, track);
     const { data, error } = await sb.rpc('claim_sd', { p_sd_id: sdKey, p_session_id: sessionId, p_track });
     if (error) return { ok: false, error: error.message };

--- a/tests/unit/claim-write-fence.test.js
+++ b/tests/unit/claim-write-fence.test.js
@@ -1,0 +1,75 @@
+/**
+ * QF-20260711-272 — live coordinator-authority fence at the claim-WRITE boundary.
+ *
+ * Three claim paths bypassed dispatch fences (worker-checkin resume_final, belt self-claim
+ * racing a just-stamped needs_coordinator_review flag, sd-start auto-fallback) because
+ * eligibility ran only at candidate-LIST time or not at all. liveClaimWriteFenceReason
+ * re-fetches the LIVE row at the write boundary and binds ONLY the coordinator-authority
+ * axes (human_action_required / needs_coordinator_review / not_before_hold) — fail-CLOSED
+ * on query error, pass-through on a missing row (QF ids), and deliberately NOT binding
+ * axes with documented directed-dispatch exemptions (one_way door).
+ *
+ * @module tests/unit/claim-write-fence.test
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  liveClaimWriteFenceReason,
+  CLAIM_WRITE_FENCE_AXES,
+} = require('../../lib/fleet/claim-eligibility.cjs');
+
+/** Minimal chainable supabase stub resolving maybeSingle() to the given result. */
+function sbReturning(result) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: async () => result,
+  };
+  return { from: () => chain };
+}
+
+describe('liveClaimWriteFenceReason (QF-20260711-272)', () => {
+  it('fences a requires_human_action SD at the write boundary', async () => {
+    const sb = sbReturning({ data: { sd_key: 'SD-HELD-001', sd_type: 'infrastructure', status: 'draft', metadata: { requires_human_action: true } }, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-HELD-001')).toBe('human_action_required');
+  });
+
+  it('fences a needs_coordinator_review SD stamped AFTER candidate assembly (the read-then-claim race)', async () => {
+    const sb = sbReturning({ data: { sd_key: 'SD-REVIEW-001', sd_type: 'infrastructure', status: 'draft', metadata: { needs_coordinator_review: true } }, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-REVIEW-001')).toBe('needs_coordinator_review');
+  });
+
+  it('fences a future not_before hold', async () => {
+    const sb = sbReturning({ data: { sd_key: 'SD-GATED-001', sd_type: 'infrastructure', status: 'draft', metadata: { not_before: '2126-01-01T00:00:00Z' } }, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-GATED-001')).toBe('not_before_hold');
+  });
+
+  it('passes an unfenced SD (null)', async () => {
+    const sb = sbReturning({ data: { sd_key: 'SD-OPEN-001', sd_type: 'infrastructure', status: 'draft', metadata: {} }, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-OPEN-001')).toBeNull();
+  });
+
+  it('does NOT bind non-authority axes at the write boundary (one_way door keeps its directed-dispatch exemption; orchestrator/fixture stay path-specific)', async () => {
+    const sb = sbReturning({ data: { sd_key: 'SD-DOOR-001', sd_type: 'orchestrator', status: 'draft', metadata: { door_class_note: 'one_way' } }, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-DOOR-001')).toBeNull();
+    expect(CLAIM_WRITE_FENCE_AXES.has('one_way_door_requires_supervision')).toBe(false);
+    expect(CLAIM_WRITE_FENCE_AXES.has('orchestrator_parent')).toBe(false);
+  });
+
+  it('passes through a missing row (QF ids and other non-SD keys — claim_sd arbitrates those)', async () => {
+    const sb = sbReturning({ data: null, error: null });
+    expect(await liveClaimWriteFenceReason(sb, 'QF-20260711-999')).toBeNull();
+  });
+
+  it('fails CLOSED on a query error', async () => {
+    const sb = sbReturning({ data: null, error: new Error('connection reset') });
+    expect(await liveClaimWriteFenceReason(sb, 'SD-ERR-001')).toBe('eligibility_check_error');
+  });
+
+  it('fails CLOSED on a thrown fault', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    expect(await liveClaimWriteFenceReason(sb, 'SD-THROW-001')).toBe('eligibility_check_error');
+  });
+});


### PR DESCRIPTION
## Summary
Closes **QF-20260711-272** (Tier 2, high): three claim paths bypassed dispatch fences (coordinator evidence, 4+ occurrences 2026-07-11):
1. `worker-checkin.cjs` **resume_final** claimed stranded SDs with no eligibility check at all
2. **belt self-claim** raced a just-stamped `needs_coordinator_review` flag — eligibility ran against the stale candidate-list row (KILL-GATE-TIER-001 claimed 13:41Z pre-clearance)
3. `sd-start.js` **AUTO-FALLBACK** skipped the fences the direct path enforces (claimed UIUX parent with `requires_human_action=true` at 14:48Z after the direct path correctly blocked at 12:47Z)

## Fix (per coordinator's prescribed shape — one shared predicate, not per-path patches)
- New `liveClaimWriteFenceReason()` in `lib/fleet/claim-eligibility.cjs`: re-fetches the **live** SD row at the claim-WRITE boundary and binds the coordinator-authority axes (`human_action_required` / `needs_coordinator_review` / `not_before_hold`) from the existing SSOT axis table (`classifyAllDispatchIneligibility`) — no duplicated axis logic.
- **Fail-CLOSED** on query error (`eligibility_check_error` refuses the claim). Missing row passes through (QF ids — the `claim_sd` RPC arbitrates those). `one_way` door keeps its documented directed-dispatch exemption.
- Wired inside `tryClaim()` — one seam covers resume_final, orphan-adopt, draft self-claim, and directed assignment — and in the sd-start fallback lane (skip-polarity, fence named in the skip line).

## Verification
- 8 new unit tests (`tests/unit/claim-write-fence.test.js`): each fence axis binds, unfenced passes, non-authority axes excluded, missing-row pass-through, fail-closed on error + throw.
- Adjacent suites green: `claim-eligibility*.test.js`, `claim-fallback.test.js`, `worker-checkin*.test.js` — 167 tests passed.
- `node --check` clean on all three edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)