### PR TITLE
fix(QF-20260711-772): venture_deployments seed insert violates NOT-NULL sha + status CHECK constraint

### DIFF
--- a/lib/ops/venture-uptime-probe.js
+++ b/lib/ops/venture-uptime-probe.js
@@ -122,9 +122,16 @@ export async function ensureDeploymentRows(supabase) {
       continue;
     }
 
+    // QF-20260711-772: sha is NOT NULL with no column default (inherited from the
+    // table's original deploy-log schema); these seed rows aren't real deploy events,
+    // so 'unknown' documents that honestly rather than fabricating a fake commit hash.
+    // status has a CHECK constraint (planned|deployed_no_traffic|routed|failed|rolled_back)
+    // -- 'seeded' isn't a member. 'routed' is the accurate value: we only seed a row for a
+    // venture that already has ventures.deployment_url set, i.e. a URL presumed to be
+    // receiving traffic (the exact thing this probe verifies).
     const { data: created, error: insErr } = await supabase
       .from('venture_deployments')
-      .insert({ venture_id: v.id, url: v.deployment_url, actor: 'venture-ops-actuals-sweep', status: 'seeded', metadata: {} })
+      .insert({ venture_id: v.id, url: v.deployment_url, sha: 'unknown', actor: 'venture-ops-actuals-sweep', status: 'routed', metadata: {} })
       .select('id, venture_id, url, metadata')
       .single();
     if (insErr) {

--- a/tests/unit/ops/venture-uptime-probe.test.js
+++ b/tests/unit/ops/venture-uptime-probe.test.js
@@ -143,4 +143,17 @@ describe('ensureDeploymentRows / runVentureUptimeProbe (adversarial-review fix: 
     expect(summary.reachable).toBe(1);
     expect(summary.errors).toHaveLength(0);
   });
+
+  // QF-20260711-772: live-verified against the real venture_deployments schema —
+  // sha is NOT NULL (no default) and status has a CHECK constraint that does not
+  // include 'seeded'. The mock supabase above doesn't enforce constraints, so these
+  // assertions pin the exact insert payload rather than relying on the mock to fail.
+  it('seeds a deployment row with sha populated and status within the CHECK constraint allow-list', async () => {
+    const supabase = makeSupabase({ ventures: [{ id: 'v1', deployment_url: 'https://x' }] });
+    const { rows, errors } = await ensureDeploymentRows(supabase);
+    expect(errors).toHaveLength(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sha).toBeTruthy();
+    expect(['planned', 'deployed_no_traffic', 'routed', 'failed', 'rolled_back']).toContain(rows[0].status);
+  });
 });


### PR DESCRIPTION
## Summary
- `ensureDeploymentRows()` (lib/ops/venture-uptime-probe.js, from SD-LEO-INFRA-VENTURE-OPS-ACTUALS-001) inserted `venture_deployments` rows missing `sha` (NOT NULL, no default) and with `status='seeded'` (not in the CHECK constraint allow-list).
- Caught live on the first real production run via the NC-7 escalation this same SD added — loud failure, not a silent pass.
- Fix: `sha='unknown'` (synthetic tracking row, not a real deploy event), `status='routed'` (accurate: only seeded for ventures with a known deployment_url).

## Test plan
- [x] 25 unit tests passing (incl. new assertion pinning sha + status against the CHECK constraint allow-list)
- [x] Live-verified against production DB: both MarketLens (200) and CronGenius (404, still reachable) now seed and probe correctly; ops_product_health/ops_revenue_metrics rows confirmed written

🤖 Generated with [Claude Code](https://claude.com/claude-code)