### PR TITLE
fix(QF-20260711-538): pin LEO_WORKTREE_GUARD on in worktree-hygiene test harness

### DIFF
--- a/tests/unit/enforcement-worktree-hygiene.test.js
+++ b/tests/unit/enforcement-worktree-hygiene.test.js
@@ -29,6 +29,14 @@ function runHook(toolName, toolInput, env = {}) {
     // hold the event loop until network timeout).
     SUPABASE_URL: '',
     SUPABASE_SERVICE_ROLE_KEY: '',
+    // Pin the guard-under-test ON regardless of the host's .env: dev machines
+    // may carry LEO_WORKTREE_GUARD=off globally (inherited via ...process.env
+    // above), which silently disabled this whole suite locally while CI stayed
+    // green (QF-20260711-538). Strand recovery is pinned off so the block path
+    // is deterministic (no DB-dependent detectStrandedClaim branch). The
+    // off-switch test still works: its own env param lands after these.
+    LEO_WORKTREE_GUARD: 'on',
+    LEO_WORKTREE_STRAND_RECOVERY: 'off',
     CLAUDE_SESSION_ID: 'test-session-' + Math.random().toString(36).slice(2, 10),
     ...env,
   };


### PR DESCRIPTION
## Summary
The worktree-hygiene suite spreads `...process.env`, so any dev host with `LEO_WORKTREE_GUARD=off` in its `.env` silently disabled all four guard-behavior cases — 4/10 red locally on clean main while CI (no .env) stayed green, blocking every QF's `complete-quick-fix` local suite gate (coordinator sourcing-radar 36d07efd).

Fix (8 LOC, test-harness only): pin `LEO_WORKTREE_GUARD: 'on'` and `LEO_WORKTREE_STRAND_RECOVERY: 'off'` in `runHook`'s merged env, ahead of the per-test override — the off-switch case still exercises 'off' via its own env param.

## Verification
- 10/10 pass locally WITH the host var set (previously 6/10)
- CI behavior unchanged (guard was already on there)
- tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)