### PR TITLE
fix(QF-20260711-063): claim reconciliation steals only from inside the SD's own worktree

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -534,6 +534,20 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // without a trace). Fail-safe: any error in the WIP check falls through to the original
     // hard-fail — reconciliation only ever fires on a POSITIVE, verified WIP signal.
     try {
+      // QF-20260711-063: reconciliation may fire ONLY when the caller is working INSIDE this
+      // SD's registered worktree. hasWip(process.cwd()) from anywhere else — most acutely the
+      // chronically-dirty shared root during sd-start acquisition (allowMainRepoForAcquisition
+      // =true) — reads ambient dirt as "I am the builder" and CAS-steals a LIVE peer's claim,
+      // write-then-block: sd-start's evidence-of-life gate only runs later and cannot un-write
+      // it. Live incidents 2026-07-11: APA-PHASE-STANDING-001 14:44Z, OPERATIVE-AGENT-
+      // OWNERSHIP-001-B 16:2xZ (peer claim clobbered, manually restored). The genuine
+      // stolen-builder recovery this block exists for always runs from the SD's own worktree,
+      // so requiring cwd-containment preserves it exactly.
+      const wtRegistered = sd.worktree_path ? path.resolve(sd.worktree_path) : null;
+      const cwdResolved = path.resolve(process.cwd());
+      const callerInSdWorktree = !!wtRegistered
+        && (cwdResolved === wtRegistered || cwdResolved.startsWith(wtRegistered + path.sep));
+      if (!callerInSdWorktree) throw new Error('reconciliation caller outside SD worktree — no steal');
       const { hasWip } = _require('./claim/wip-detector.cjs');
       const myBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: process.cwd(), encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
       const wip = hasWip(process.cwd(), myBranch, null, { repoRoot: process.cwd() });

--- a/tests/unit/claim-validity-gate-foreign-claim-reconciliation.test.js
+++ b/tests/unit/claim-validity-gate-foreign-claim-reconciliation.test.js
@@ -68,12 +68,38 @@ describe('TS-4: foreign_claim reconciliation fires BEFORE the hard-fail throw', 
 
   it('is fail-safe: the whole reconciliation attempt is wrapped in try/catch so any error falls through to the original hard-fail', () => {
     const idx = src.indexOf('foreign_claim reconciliation');
-    const surrounding = src.slice(idx, idx + 3600);
+    // Window widened 3600->5600 for the QF-20260711-063 worktree-containment guard inserted
+    // inside the same try block; the catch it pins is unchanged.
+    const surrounding = src.slice(idx, idx + 5600);
     expect(surrounding).toMatch(/try\s*\{/);
     expect(surrounding).toMatch(/\}\s*catch\s*\{\s*\/\*\s*fail-safe/i);
   });
 
   it('the original hard-fail behavior for a genuinely stale attempt is unchanged (still throws ClaimIdentityError with reason foreign_claim)', () => {
     expect(src).toMatch(/throw new ClaimIdentityError\(\{\s*\n\s*reason:\s*['"]foreign_claim['"]/);
+  });
+});
+
+describe('QF-20260711-063: reconciliation requires caller cwd INSIDE the SD\'s registered worktree (check-then-write)', () => {
+  it('computes worktree containment from sd.worktree_path before any WIP read', () => {
+    const containIdx = src.indexOf('callerInSdWorktree');
+    const wipIdx = src.indexOf("_require('./claim/wip-detector.cjs')");
+    expect(containIdx).toBeGreaterThan(0);
+    expect(wipIdx).toBeGreaterThan(0);
+    expect(containIdx).toBeLessThan(wipIdx);
+    expect(src).toMatch(/sd\.worktree_path\s*\?\s*path\.resolve\(sd\.worktree_path\)\s*:\s*null/);
+  });
+
+  it('an outside-worktree caller throws (falls to the foreign_claim hard-fail) BEFORE the CAS claim write — never write-then-block', () => {
+    expect(src).toMatch(/if\s*\(!callerInSdWorktree\)\s*throw new Error\(['"]reconciliation caller outside SD worktree — no steal['"]\)/);
+    // The guard throw must precede the CAS update within the reconciliation block.
+    const guardIdx = src.indexOf('reconciliation caller outside SD worktree');
+    const casIdx = src.indexOf('claiming_session_id: mySessionId, is_working_on: true');
+    expect(guardIdx).toBeGreaterThan(0);
+    expect(guardIdx).toBeLessThan(casIdx);
+  });
+
+  it('containment accepts the worktree root itself and any subdirectory (path.sep suffix), nothing else', () => {
+    expect(src).toMatch(/cwdResolved === wtRegistered \|\| cwdResolved\.startsWith\(wtRegistered \+ path\.sep\)/);
   });
 });


### PR DESCRIPTION
## Summary
Closes **QF-20260711-063** (T1, high — QF-272 follow-up, coordinator evidence 4084f43b): the DIRECT sd-start path could clobber a LIVE peer's claim **before** its own evidence-of-life gate ran (write-then-block).

## Root cause
`assertValidClaim`'s foreign_claim reconciliation (`lib/claim-validity-gate.js`) measured WIP via `hasWip(process.cwd())`. sd-start acquisition legitimately runs from the shared root (`allowMainRepoForAcquisition=true`) — which is chronically dirty — so ambient uncommitted changes read as "caller is the SD's builder" and the CAS write displaced the live owner. sd-start's evidence-of-life gate runs LATER and cannot un-write it. Live incidents 2026-07-11: APA-PHASE-STANDING-001 14:44Z (displaced 36212dc9), OPERATIVE-AGENT-OWNERSHIP-001-B 16:2xZ (Charlie clobbered a live peer, manually restored).

## Fix (check-then-write)
Reconciliation now requires the caller's cwd to be **inside `sd.worktree_path`** (root or subdirectory) before any WIP read or claim write. The genuine stolen-builder recovery this block exists for always runs from the SD's own worktree — preserved exactly. Outside callers fall through to the original `foreign_claim` hard-fail with zero writes.

## Verification
- 3 new source-pin tests (guard precedes the WIP require AND the CAS write; containment semantics pinned); 53 tests green across all claim-validity-gate suites.
- **Live UAT**: ran patched sd-start against `SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001` (actively claimed by e828c687) from a foreign cwd → hard `foreign_claim` refusal, no RECONCILED line, owner's claim byte-identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)