### PR TITLE
fix(QF-20260711-215): route eva insertCascade through the wave-disposition gate

### DIFF
--- a/lib/eva/create-orchestrator-from-plan.js
+++ b/lib/eva/create-orchestrator-from-plan.js
@@ -36,6 +36,13 @@ import { inheritStrategicFields, inferSDType } from '../../scripts/modules/child
 // metadata.min_tier_rank — a tier-idle starvation leak (unstamped => the 6cf5c558 undefined-tier bug).
 // Gap-fill stamp each record before insert (never overwrite an explicit stamp; mirrors leo-create-sd.js).
 import { stampPayload } from '../fleet/sd-tier-rank.mjs';
+// QF-20260711-215: this direct-INSERT path bypassed the mandatory wave-disposition gate that
+// SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 added to the canonical creation seam (lib/sd-creation/
+// pipeline.js) — the authored-but-bypassable class. Every orchestrator creation must record a
+// disposition (wave item or explicit no_wave verdict) and stamp roadmap freshness. The
+// auto-cascade has no human chooser, so absent an explicit waveDisposition it records a
+// documented no_wave verdict — an EXPLICIT recorded choice, not a silent default.
+import { validateWaveDisposition, applyWaveDisposition } from '../roadmap/wave-disposition.js';
 
 /**
  * Gap-fill metadata.min_tier_rank on a strategic_directives_v2-shaped record about to be inserted.
@@ -394,11 +401,25 @@ export function buildChildSD({ phase, orchestratorRecord, orchestratorKey, orche
  * @param {boolean} [args.dryRun=false]
  * @param {Object} [args.logger=console]
  */
-export async function insertCascade({ supabase, orchestratorRecord, childRecords, archPlan, dryRun = false, logger = console } = {}) {
+export async function insertCascade({ supabase, orchestratorRecord, childRecords, archPlan, dryRun = false, logger = console, waveDisposition = null } = {}) {
   const result = { orchestrator: null, children: [], errors: [] };
 
   if (!supabase || !orchestratorRecord || !Array.isArray(childRecords)) {
     result.errors.push({ stage: 'preflight', error: 'insertCascade: supabase, orchestratorRecord, childRecords required' });
+    return result;
+  }
+
+  // QF-20260711-215: wave-disposition gate on this creation path. Validate BEFORE any insert
+  // (a malformed explicit disposition fails the whole cascade, matching pipeline.js semantics);
+  // absent an explicit one, record a documented no_wave verdict for the auto-cascade.
+  const effectiveWaveDisposition = waveDisposition ?? {
+    noWave: `auto-cascade orchestrator ${orchestratorRecord.sd_key} from vision ${orchestratorRecord.metadata?.vision_key ?? 'unknown'} — wave assignment deferred to roadmap fold-in`,
+  };
+  let waveVerdict;
+  try {
+    waveVerdict = validateWaveDisposition(effectiveWaveDisposition);
+  } catch (wdErr) {
+    result.errors.push({ stage: 'wave_disposition', error: wdErr.message });
     return result;
   }
 
@@ -437,6 +458,8 @@ export async function insertCascade({ supabase, orchestratorRecord, childRecords
 
   if (!orchestratorAlreadyExists) {
     gapFillMinTierRank(orchestratorRecord); // FR-2: stamp at creation (harmless for parents; matches SD scope)
+    // QF-20260711-215: the verdict rides metadata.wave_disposition (source of truth, mirrors pipeline.js).
+    orchestratorRecord.metadata = { ...orchestratorRecord.metadata, wave_disposition: waveVerdict };
     const { error: orchErr } = await supabase
       .from('strategic_directives_v2')
       .insert(orchestratorRecord);
@@ -445,6 +468,21 @@ export async function insertCascade({ supabase, orchestratorRecord, childRecords
       return result;
     }
     logger.log?.(`[insertCascade] Orchestrator created: ${orchestratorKey} (${orchestratorId})`);
+    // Durable disposition effects: wave item (when a wave was chosen) + roadmap freshness stamp.
+    // applyWaveDisposition is idempotent; a failure here is loudly surfaced (not rolled back),
+    // matching pipeline.js — the SD row already carries the recorded verdict.
+    try {
+      await applyWaveDisposition(supabase, {
+        waveDisposition: effectiveWaveDisposition,
+        sourceKey: orchestratorKey,
+        title: orchestratorRecord.title,
+        dispositionSource: 'orchestrator_sd_creation',
+      });
+      logger.log?.(`[insertCascade] wave disposition recorded: ${waveVerdict.kind === 'wave' ? `wave ${waveVerdict.waveId}` : `no_wave (${waveVerdict.reason})`} — roadmap freshness stamped`);
+    } catch (wdErr) {
+      result.waveDispositionError = wdErr.message;
+      logger.error?.(`[insertCascade] wave disposition apply FAILED (SD created, metadata.wave_disposition recorded): ${wdErr.message} — re-run applyWaveDisposition for ${orchestratorKey} to reconcile`);
+    }
   }
   result.orchestrator = { ...orchestratorRecord, id: orchestratorId };
 

--- a/tests/unit/eva/insert-cascade-wave-disposition.test.js
+++ b/tests/unit/eva/insert-cascade-wave-disposition.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { insertCascade } from '../../../lib/eva/create-orchestrator-from-plan.js';
+
+// QF-20260711-215: the eva auto-cascade direct-INSERT path must route through the
+// wave-disposition gate (SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001) — every orchestrator creation
+// records a disposition (wave item or explicit no_wave verdict) and stamps roadmap freshness.
+
+/** Minimal supabase fake covering the chains insertCascade + applyWaveDisposition use. */
+function fakeSupabase(calls) {
+  return {
+    from(table) {
+      const ctx = { table, op: null, payload: null };
+      const chain = {
+        select() { ctx.op = ctx.op || 'select'; return chain; },
+        insert(payload) { ctx.op = 'insert'; ctx.payload = payload; calls.push({ table, op: 'insert', payload }); return chain; },
+        update(payload) { ctx.op = 'update'; ctx.payload = payload; calls.push({ table, op: 'update', payload }); return chain; },
+        eq() { return chain; },
+        in() { calls.push({ table, op: 'update-in', payload: ctx.payload }); return Promise.resolve({ error: null }); },
+        maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        single() { return Promise.resolve({ data: { id: 'item-1', roadmap_id: 'rm-1' }, error: null }); },
+        then(resolve) { resolve({ data: [{ id: 'rm-active' }], error: null }); }, // awaited select-eq chains
+      };
+      return chain;
+    },
+  };
+}
+
+const orchestratorRecord = () => ({
+  id: 'orch-uuid-1',
+  sd_key: 'SD-TESTFAKE-ORCH-001',
+  title: 'Fake orchestrator',
+  sd_type: 'orchestrator',
+  metadata: { vision_key: 'VIS-1', arch_key: 'ARCH-1' },
+});
+
+describe('insertCascade wave-disposition gate (QF-20260711-215)', () => {
+  it('rejects a malformed explicit disposition BEFORE any insert', async () => {
+    const calls = [];
+    const result = await insertCascade({
+      supabase: fakeSupabase(calls),
+      orchestratorRecord: orchestratorRecord(),
+      childRecords: [],
+      logger: { log() {}, error() {} },
+      waveDisposition: { waveId: 'w-1', noWave: 'both set — invalid' },
+    });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].stage).toBe('wave_disposition');
+    expect(calls.filter((c) => c.op === 'insert')).toHaveLength(0);
+  });
+
+  it('auto-records an explicit no_wave verdict on the auto-cascade path (no silent non-disposition)', async () => {
+    const calls = [];
+    const result = await insertCascade({
+      supabase: fakeSupabase(calls),
+      orchestratorRecord: orchestratorRecord(),
+      childRecords: [],
+      logger: { log() {}, error() {} },
+    });
+    expect(result.errors).toHaveLength(0);
+    const sdInsert = calls.find((c) => c.table === 'strategic_directives_v2' && c.op === 'insert');
+    expect(sdInsert.payload.metadata.wave_disposition.kind).toBe('no_wave');
+    expect(sdInsert.payload.metadata.wave_disposition.reason).toContain('SD-TESTFAKE-ORCH-001');
+    // Freshness stamped on active roadmaps (the explicit verdict IS the freshness event).
+    const stamp = calls.find((c) => c.table === 'strategic_roadmaps' && c.op === 'update-in');
+    expect(stamp).toBeTruthy();
+    expect(stamp.payload.updated_at).toBeTruthy();
+  });
+
+  it('dry-run performs no disposition writes', async () => {
+    const calls = [];
+    const result = await insertCascade({
+      supabase: fakeSupabase(calls),
+      orchestratorRecord: orchestratorRecord(),
+      childRecords: [],
+      dryRun: true,
+      logger: { log() {}, error() {} },
+    });
+    expect(result.orchestrator._dry_run).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
`insertCascade` (eva auto-cascade orchestrator creation) direct-INSERTed orchestrator SDs, bypassing the mandatory wave-disposition gate from SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (PR #5925) — same authored-but-bypassable class as QF-20260711-272 (coordinator retro flag 69a98d6a).

- Explicit `waveDisposition` param validates **before any insert** (malformed ⇒ cascade fails at `stage: wave_disposition`)
- Auto-cascade default records a **documented no_wave verdict** — an explicit recorded choice, never a silent non-disposition (the QF's 'auto-records the disposition choice' option)
- Verdict rides `metadata.wave_disposition`; `applyWaveDisposition` stamps roadmap freshness post-insert (loud, non-rollback on failure — mirrors pipeline.js)
- Resumed orchestrators and dry-run unchanged

## Verification
3 new pin tests (malformed-rejected-pre-insert, no_wave-recorded+freshness-stamped, dry-run-clean) + existing wave-disposition (12) and consumer (orchestrator-target-repos) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)