### PR TITLE
fix(QF-20260711-114): honest-gauge coverage disposition, positive-path headline

### DIFF
--- a/lib/harness/run-journal.mjs
+++ b/lib/harness/run-journal.mjs
@@ -118,25 +118,58 @@ export class RunJournal {
    * observation OR a first-class finding referencing it. Unmapped = a finding ABOUT the
    * harness (returned here; §H9 calibration asserts a deliberately-dead loop lands here).
    *
+   * covered/uncovered/findings are the MAPPING-COMPLETENESS gauge (did anything reference
+   * this requirement at all — observation or finding) and stay exactly as before; calibration
+   * (§H9) asserts against this shape. positive/blocked/cannotDrive/disposition are a SEPARATE,
+   * honest-gauge fix (QF-20260711-114 / Solomon F2): a blocked or cannot-drive requirement is
+   * NOT a success — the headline gauge counts positive-path completions only, never conflating
+   * "mapped" with "succeeded".
+   *
    * @param {string[]} plannedRequirements - e.g. ['O1','O2',...,'O10']
-   * @returns {{covered: string[], uncovered: string[], findings: object[]}}
+   * @returns {{covered: string[], uncovered: string[], findings: object[], disposition: object,
+   *            positive: string[], blocked: string[], cannotDrive: string[],
+   *            headline: {positive: number, total: number}}}
    */
   checkCoverage(plannedRequirements) {
     const events = this.readAll();
-    const seen = new Set();
+    const seenAny = new Set();
+    const seenPositive = new Set();
+    const seenCannotDrive = new Set();
+    const seenBlocked = new Set();
     for (const e of events) {
-      if (e.kind === 'observation' || e.kind === 'finding') {
-        for (const o of e.o_requirements || []) seen.add(o);
+      if (e.kind === 'observation') {
+        for (const o of e.o_requirements || []) { seenAny.add(o); seenPositive.add(o); }
+      } else if (e.kind === 'finding') {
+        for (const o of e.o_requirements || []) {
+          seenAny.add(o);
+          if (e.finding_type === 'CANNOT_DRIVE') seenCannotDrive.add(o);
+          else seenBlocked.add(o);
+        }
       }
     }
-    const covered = plannedRequirements.filter((r) => seen.has(r));
-    const uncovered = plannedRequirements.filter((r) => !seen.has(r));
+    const covered = plannedRequirements.filter((r) => seenAny.has(r));
+    const uncovered = plannedRequirements.filter((r) => !seenAny.has(r));
     const findings = uncovered.map((r) => ({
       finding_type: 'DEAD_LOOP',
       event: `coverage: requirement ${r} ended the run with zero observations and no CANNOT_DRIVE finding — dead loop or un-driven surface`,
       o_requirements: [r],
     }));
-    return { covered, uncovered, findings };
+
+    const disposition = {};
+    for (const r of plannedRequirements) {
+      disposition[r] = seenPositive.has(r) ? 'positive'
+        : seenCannotDrive.has(r) ? 'cannot_drive'
+        : seenBlocked.has(r) ? 'blocked'
+        : 'dead_loop';
+    }
+    const positive = plannedRequirements.filter((r) => disposition[r] === 'positive');
+    const blocked = plannedRequirements.filter((r) => disposition[r] === 'blocked');
+    const cannotDrive = plannedRequirements.filter((r) => disposition[r] === 'cannot_drive');
+
+    return {
+      covered, uncovered, findings, disposition, positive, blocked, cannotDrive,
+      headline: { positive: positive.length, total: plannedRequirements.length },
+    };
   }
 
   /**

--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -311,7 +311,11 @@ async function main() {
       sweepOnly: args.includes('--sweep-only'),
       advancePolicy: flag('advance-policy', 'real-gates'),
     });
-    console.log(`HARNESS_RUN_PASS run=${res.runId} venture=${res.ventureId} covered=${res.coverage.covered.length}/${ALL_O_REQUIREMENTS.length} journal=${res.journalPath}`);
+    const { coverage } = res;
+    console.log(`HARNESS_RUN_PASS run=${res.runId} venture=${res.ventureId} positive=${coverage.positive.length}/${ALL_O_REQUIREMENTS.length} mapping_covered=${coverage.covered.length}/${ALL_O_REQUIREMENTS.length} journal=${res.journalPath}`);
+    if (coverage.blocked.length) console.log(`  BLOCKED: ${coverage.blocked.join(',')}`);
+    if (coverage.cannotDrive.length) console.log(`  CANNOT_DRIVE: ${coverage.cannotDrive.join(',')}`);
+    if (coverage.uncovered.length) console.log(`  DEAD_LOOP: ${coverage.uncovered.join(',')}`);
     process.exit(0);
   } else if (mode === 'status') {
     const journal = new RunJournal(runId);

--- a/tests/unit/harness/s20-harness-slice.test.js
+++ b/tests/unit/harness/s20-harness-slice.test.js
@@ -97,6 +97,22 @@ describe('§H2/§H3: run journal seam', () => {
     expect(cov.findings[0].finding_type).toBe('DEAD_LOOP');
   });
 
+  it('honest-gauge fix (QF-20260711-114): blocked/cannot-drive requirements are NOT counted as positive-path success', () => {
+    const j = new RunJournal('honest-gauge-run', { baseDir: TMP, clock: fixedClock });
+    j.append({ kind: 'observation', event: 'real completion', o_requirements: ['O1'] });
+    j.append({ kind: 'finding', finding_type: 'CANNOT_DRIVE', event: 'no driver exists', o_requirements: ['O2'] });
+    j.append({ kind: 'finding', finding_type: 'FENCE_BREACH', event: 'gate blocked it', o_requirements: ['O3'] });
+    // O4 gets zero events at all -> dead loop.
+    const cov = j.checkCoverage(['O1', 'O2', 'O3', 'O4']);
+    expect(cov.disposition).toEqual({ O1: 'positive', O2: 'cannot_drive', O3: 'blocked', O4: 'dead_loop' });
+    expect(cov.positive).toEqual(['O1']);
+    expect(cov.cannotDrive).toEqual(['O2']);
+    expect(cov.blocked).toEqual(['O3']);
+    expect(cov.headline).toEqual({ positive: 1, total: 4 });
+    // Mapping-completeness (unchanged contract) still counts O1-O3 as "covered".
+    expect(cov.covered.sort()).toEqual(['O1', 'O2', 'O3']);
+  });
+
   it('unenumerated divergence journals as TEST_MODE_DIVERGENCE; enumerated ones as observations', () => {
     const j = new RunJournal('div-run', { baseDir: TMP, clock: fixedClock });
     const allowed = j.assertDivergenceAllowed('stripe_test_keys', ['stripe_test_keys']);


### PR DESCRIPTION
## Summary
- `checkCoverage()` in `lib/harness/run-journal.mjs` counted blocked/CANNOT_DRIVE findings the same as a genuine positive-path observation, so the S20-26 harness run headline reported e.g. "9/10 covered" with zero real completions (honest-gauge violation, Solomon adjudication F2, run `s2026-bravo-0711`).
- Adds a per-requirement `disposition` (`positive`|`blocked`|`cannot_drive`|`dead_loop`) and a `headline: {positive, total}` gauge counting positive-path completions only.
- Mapping-completeness (`covered`/`uncovered`/`findings`) is kept exactly as before as a separately-named gauge — §H9 calibration and existing tests assert against that exact shape, so it is untouched.
- `scripts/harness/s20-run.mjs`'s CLI `run` output now itemizes `positive=`, `mapping_covered=`, and any `BLOCKED`/`CANNOT_DRIVE`/`DEAD_LOOP` requirements, instead of a single `covered=` line that reads as success.

## Test plan
- [x] `npx vitest run tests/unit/harness/` — 140/140 passed (16 files)
- [x] `node scripts/harness/calibration.mjs` — GO (all 5 seeded-defect checks still pass, confirming the coverage-shape contract calibration depends on is unchanged)
- [x] New unit test asserts disposition/positive/blocked/cannotDrive/headline for a mixed positive+blocked+cannot_drive+dead_loop scenario

QF-20260711-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)