### PR TITLE
fix(QF-20260711-967): grade O10 at run level, exclude from per-loop coverage matrix

### DIFF
--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -84,6 +84,14 @@ export const POST_LAUNCH_DRIVERS = Object.freeze([
 export const ALL_O_REQUIREMENTS = Object.freeze(['O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7', 'O8', 'O9', 'O10']);
 
 /**
+ * O10 is the run-META acceptance criterion (all per-loop O-reqs mapped AND containment
+ * clean AND journal durable) — no band or driver maps to it BY DESIGN, so feeding it into
+ * the per-loop coverage matrix guarantees a noise DEAD_LOOP finding on every single run
+ * (QF-20260711-967 / Solomon F4). Graded once, at run level, in runArc()'s close-out below.
+ */
+export const LOOP_O_REQUIREMENTS = Object.freeze(ALL_O_REQUIREMENTS.filter((r) => r !== 'O10'));
+
+/**
  * Per-band advance policy (smoke-run decode 2026-07-10):
  * - 'real-gates' (DEFAULT): the band advances only through the live gate path;
  *   a block is a drivability edge and the venture stays put (stage-mismatch
@@ -286,12 +294,25 @@ export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart,
 
   await containmentSweep({ supabase, journal, runId, ventureId, advancePolicy });
 
-  // §H3 coverage close-out: every O-requirement observed or first-class-found.
-  const coverage = journal.checkCoverage([...ALL_O_REQUIREMENTS]);
+  // §H3 coverage close-out: every PER-LOOP O-requirement observed or first-class-found.
+  // O10 is excluded here — it is not a loop, it is graded once below (QF-20260711-967).
+  const coverage = journal.checkCoverage([...LOOP_O_REQUIREMENTS]);
   for (const f of coverage.findings) journal.append({ kind: 'finding', finding_type: f.finding_type, event: f.event, o_requirements: f.o_requirements, detail: {} });
   journal.append({ kind: 'lifecycle', event: `run arc pass complete: covered=${coverage.covered.join(',') || 'none'} uncovered=${coverage.uncovered.join(',') || 'none'}`, detail: { coverage } });
 
-  return { runId, ventureId, coverage, journalPath: journal.path };
+  // O10 run-meta verdict, graded ONCE at run level: every per-loop O-req mapped (not dead)
+  // AND the containment sweep found no residue AND the journal is non-empty/durable.
+  const o10AllMapped = coverage.uncovered.length === 0;
+  const o10ResidueClean = !journal.readAll().some((e) => e.kind === 'finding' && e.finding_type === 'RESIDUE');
+  const o10JournalDurable = journal.readAll().length > 0;
+  const o10Pass = o10AllMapped && o10ResidueClean && o10JournalDurable;
+  if (o10Pass) {
+    journal.append({ kind: 'observation', event: 'O10 run-meta verdict: all loops mapped, containment clean, journal durable', o_requirements: ['O10'] });
+  } else {
+    journal.finding('DEAD_LOOP', `O10 run-meta verdict FAILED: all_mapped=${o10AllMapped} residue_clean=${o10ResidueClean} journal_durable=${o10JournalDurable}`, { o_requirements: ['O10'] });
+  }
+
+  return { runId, ventureId, coverage, o10: { pass: o10Pass, allMapped: o10AllMapped, residueClean: o10ResidueClean, journalDurable: o10JournalDurable }, journalPath: journal.path };
 }
 
 async function main() {
@@ -312,7 +333,7 @@ async function main() {
       advancePolicy: flag('advance-policy', 'real-gates'),
     });
     const { coverage } = res;
-    console.log(`HARNESS_RUN_PASS run=${res.runId} venture=${res.ventureId} positive=${coverage.positive.length}/${ALL_O_REQUIREMENTS.length} mapping_covered=${coverage.covered.length}/${ALL_O_REQUIREMENTS.length} journal=${res.journalPath}`);
+    console.log(`HARNESS_RUN_PASS run=${res.runId} venture=${res.ventureId} positive=${coverage.positive.length}/${LOOP_O_REQUIREMENTS.length} mapping_covered=${coverage.covered.length}/${LOOP_O_REQUIREMENTS.length} O10=${res.o10.pass ? 'pass' : 'FAILED'} journal=${res.journalPath}`);
     if (coverage.blocked.length) console.log(`  BLOCKED: ${coverage.blocked.join(',')}`);
     if (coverage.cannotDrive.length) console.log(`  CANNOT_DRIVE: ${coverage.cannotDrive.join(',')}`);
     if (coverage.uncovered.length) console.log(`  DEAD_LOOP: ${coverage.uncovered.join(',')}`);

--- a/tests/unit/harness/s20-runner.test.js
+++ b/tests/unit/harness/s20-runner.test.js
@@ -139,10 +139,34 @@ describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
     expect(executeStage.mock.calls.map((c) => c[0].stageNumber)).toEqual([21, 22]);
     // Coverage close-out ran: uncovered requirements landed as findings (drivers were default CANNOT_DRIVE, which COUNTS as covered).
     expect(res.coverage.covered).toEqual(expect.arrayContaining(['O3', 'O5', 'O6', 'O8']));
-    // O10 (acceptance) has no band/driver — must end as a DEAD_LOOP coverage finding, proving the matrix bites.
-    expect(res.coverage.uncovered).toContain('O10');
+    // O10 (QF-20260711-967): excluded from the per-loop matrix entirely — never a DEAD_LOOP
+    // noise finding for O10 ITSELF — and graded once at run level instead. In this scenario
+    // S20 was resumed/skipped so its O2 mapping never actually fires -> the composite
+    // honestly reports NOT all-mapped (this is real signal, not the old guaranteed-noise bug).
+    expect(res.coverage.uncovered).not.toContain('O10');
+    expect(res.coverage.uncovered).toContain('O2');
+    expect(res.o10.allMapped).toBe(false);
+    expect(res.o10.residueClean).toBe(true);
+    expect(res.o10.pass).toBe(false);
     const journal = new RunJournal(runId, { baseDir: BASE, clock: fixedClock });
-    expect(journal.readAll().some((e) => e.kind === 'finding' && (e.detail.o_requirements || e.o_requirements || []).includes('O10'))).toBe(true);
+    const o10Event = journal.readAll().find((e) => (e.o_requirements || []).includes('O10'));
+    expect(o10Event.kind).toBe('finding');
+    expect(o10Event.finding_type).toBe('DEAD_LOOP');
+  });
+
+  it('O10 passes when every band S20..S26 actually drives its O-mapping and containment is clean', async () => {
+    const runId = 't-arc-o10-pass';
+    const executeStage = vi.fn(async ({ stageNumber }) => ({ template: `stage-${stageNumber}`, artifactId: 'a', validation: { valid: true }, output: {} }));
+    const advanceStage = vi.fn(async () => ({}));
+    const res = await runArc({
+      runId, entryStage: 20, toStage: 26, clockStart: '2026-07-12T09:00:00Z',
+      supabase: fakeSupabase(), seams: { executeStage, advanceStage }, baseDir: BASE,
+    });
+    expect(res.coverage.uncovered).toEqual([]);
+    expect(res.o10).toEqual({ pass: true, allMapped: true, residueClean: true, journalDurable: true });
+    const journal = new RunJournal(runId, { baseDir: BASE, clock: fixedClock });
+    const o10Event = journal.readAll().find((e) => (e.o_requirements || []).includes('O10'));
+    expect(o10Event.kind).toBe('observation');
   });
 
   it('containment sweep journals scheduler residue as a RESIDUE finding when rows exist mid-run', async () => {
@@ -154,6 +178,9 @@ describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
     const journal = new RunJournal('t-arc-residue', { baseDir: BASE, clock: fixedClock });
     const residue = journal.readAll().filter((e) => e.finding_type === 'RESIDUE');
     expect(residue.length).toBeGreaterThanOrEqual(1);
+    // O10 must fail when the run's own containment sweep found residue mid-run.
+    expect(res.o10.residueClean).toBe(false);
+    expect(res.o10.pass).toBe(false);
     expect(residue[0].event).toMatch(/ghost-venture class/);
     expect(res.ventureId).toBe('v-fixture');
   });


### PR DESCRIPTION
## Summary
- O10 is the S20-26 harness's run-META acceptance criterion (all per-loop O-reqs mapped AND containment clean AND journal durable) — no band or driver maps to it by design, so feeding it into `checkCoverage()`'s per-loop matrix guaranteed a noise DEAD_LOOP finding on every single run (Solomon adjudication F4, run `s2026-bravo-0711`).
- Adds `LOOP_O_REQUIREMENTS` (ALL_O_REQUIREMENTS minus O10) and uses it for the per-loop matrix in `runArc()`'s coverage close-out.
- Grades O10 once, at run level, as a composite: all per-loop requirements mapped + the mid-run containment sweep found no residue + the journal is non-empty. A failing composite still journals honestly as a DEAD_LOOP finding scoped to O10 — it just no longer fires unconditionally.
- CLI `run` output now reports `O10=pass`/`O10=FAILED` alongside the (QF-20260711-114-fixed) positive/mapping_covered gauges, denominator corrected to `LOOP_O_REQUIREMENTS.length` (9) since O10 is no longer part of that matrix.

## Test plan
- [x] `npx vitest run tests/unit/harness/` — 141/141 passed (16 files)
- [x] `node scripts/harness/calibration.mjs` — GO
- [x] New test: full S20-26 run with every band actually driven → `O10.pass === true`
- [x] Updated existing resume test: since band S20 is skipped/resumed (its O2 mapping never fires), O10 honestly reports `allMapped: false` / `pass: false` — this is real signal, not the old guaranteed-noise bug
- [x] Residue test: mid-run scheduler residue → `O10.residueClean: false` / `pass: false`

QF-20260711-967

🤖 Generated with [Claude Code](https://claude.com/claude-code)