### PR TITLE
feat(SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001): computed plan-drift gauge (stamp-coverage + dispatch-mix)

### DIFF
--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -218,4 +218,33 @@ export const GAUGE_REGISTRY = [
     enabled: true,
     tracesToLayer: null,
   },
+  // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001: Layer A (stamp-coverage, the starvation detector) ships
+  // enabled now -- SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (the wave-linkage substrate) already shipped
+  // (PR #5925) before this SD reached LEAD, so there is no external gate to wait on.
+  {
+    id: 'plan-drift-coverage',
+    name: 'Roadmap wave-linkage stamp coverage (starvation detector)',
+    detectorFn: 'plan-drift-coverage',
+    thresholdConfig: { tripWhen: (result) => Boolean(result?.starved) },
+    ownerRole: 'coordinator',
+    remediation: 'Coverage of claimable leaf SDs carrying roadmap wave linkage has fallen below the 80% floor -- run node scripts/coordinator-backlog-rank.mjs and check roadmap_wave_items for a starved promotion channel (mirrors the frozen-roadmap incident this gauge was built to detect).',
+    prevent: 'SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 restores the promotion channel; this gauge is the durable, mechanical detection that it stays fed.',
+    enabled: true,
+    tracesToLayer: null,
+  },
+  // Layer B (dispatch-mix drift) ships as a STUB-ROW ADOPTION CONTRACT entry: detectorFn is wired
+  // (not null) but the detector itself self-gates on LIVE coverage (reads Layer A) before computing
+  // any drift -- a self-gating precondition rather than a manually-timed enabled flip, so it never
+  // needs re-litigating if roadmap linkage starves again in the future.
+  {
+    id: 'plan-drift-mix',
+    name: 'Dispatch-mix drift vs active-wave demand (self-gated on live coverage)',
+    detectorFn: 'plan-drift-mix',
+    thresholdConfig: { tripWhen: (result) => Boolean(result?.sustainedBreach) },
+    ownerRole: 'coordinator',
+    remediation: 'Sustained dispatch-mix drift from the active wave\'s demand across 2+ consecutive gauge-runner cycles -- review recent dispatch/claim history against the active wave\'s expected rung distribution.',
+    prevent: 'Sustained discipline in dispatch ordering (coordinator-backlog-rank.mjs\'s active-rung-first ranking); this gauge is the durable, mechanical detection that dispatch is actually following the plan, not just capable of it.',
+    enabled: true,
+    tracesToLayer: null,
+  },
 ];

--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -1,0 +1,138 @@
+/**
+ * Plan-drift gauge detectors (SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001).
+ *
+ * Layer A: STAMP-COVERAGE — percent of claimable leaf SDs carrying roadmap wave linkage
+ * (the starvation detector; floor = the >=80% acceptance criterion from
+ * SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001, which has already shipped as of this SD's LEAD phase).
+ *
+ * Layer B: DISPATCH-MIX drift — last-N dispatched/claimed SDs bucketed by wave-linked rung vs
+ * the active wave's demand. Self-gates on live coverage (reads Layer A itself) rather than
+ * coupling to any sibling SD's completion status — more robust against a future roadmap freeze
+ * recurrence than a time-based sequencing gate would be.
+ *
+ * Reuses (does not re-derive): scripts/coordinator-backlog-rank.mjs::computeClaimableLeaves,
+ * lib/vision/needle-priority.mjs::buildSdRungMap, lib/fleet/exec-email-alignment.mjs::isMetaSd
+ * (the exclusion-class classifier — QF-/SD-LEO-/SD-LEARN-FIX-/SD-MAN-INFRA- prefixed items are
+ * non-wave-eligible by the same convention the taper gauge already uses).
+ *
+ * @module lib/governance/plan-drift-detectors
+ */
+
+import { computeClaimableLeaves } from '../../scripts/coordinator-backlog-rank.mjs';
+import { buildSdRungMap } from '../vision/needle-priority.mjs';
+import { isMetaSd } from '../fleet/exec-email-alignment.mjs';
+
+/** Coverage floor: SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001's own acceptance criterion. */
+export const COVERAGE_FLOOR_PCT = 80;
+
+/**
+ * Pure: is this SD key excluded from the dispatch-mix denominator? QFs and harness/meta SDs
+ * (same prefix convention as the taper gauge's isMetaSd) are not wave-eligible work.
+ * @param {string} sdKey
+ * @returns {boolean}
+ */
+export function isWaveExclusionClass(sdKey) {
+  return isMetaSd(sdKey);
+}
+
+/**
+ * Pure: coverage = claimable leaves with a wave-linked rung / all claimable leaves.
+ * Honest-gauge rule: a zero denominator is STARVED, never coverage=1 by default (mirrors
+ * lib/governance/recursion-governor.js's isBandBreach product===0 convention).
+ * @param {object[]} claimable - claimable leaf SD rows ({ sd_key, ... })
+ * @param {Record<string, object>} sdRungMap - sd_key -> rung info (buildSdRungMap output)
+ * @param {{ floorPct?: number }} [opts]
+ * @returns {{ total: number, linked: number, coveragePct: (number|null), starved: boolean }}
+ */
+export function computeCoverage(claimable, sdRungMap, { floorPct = COVERAGE_FLOOR_PCT } = {}) {
+  const rows = Array.isArray(claimable) ? claimable : [];
+  const total = rows.length;
+  if (total === 0) return { total: 0, linked: 0, coveragePct: null, starved: true, value: 'STARVED (no claimable leaves)' };
+  const linked = rows.filter((d) => Boolean(sdRungMap && sdRungMap[d.sd_key])).length;
+  const coveragePct = (linked / total) * 100;
+  const starved = coveragePct < floorPct;
+  return { total, linked, coveragePct, starved, value: `${coveragePct.toFixed(1)}%${starved ? ' (STARVED)' : ''}` };
+}
+
+/**
+ * I/O: reads the live claimable-leaf set + wave-linkage map (reused, not re-derived) and computes
+ * Layer A coverage.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{ total: number, linked: number, coveragePct: (number|null), starved: boolean }>}
+ */
+export async function computeStampCoverage(supabase) {
+  const { error, claimable } = await computeClaimableLeaves(supabase, { quiet: true });
+  if (error) throw new Error('computeStampCoverage: computeClaimableLeaves failed: ' + error.message);
+  const [{ data: waveItems }, { data: waves }] = await Promise.all([
+    supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null),
+    supabase.from('roadmap_waves').select('id, time_horizon, metadata'),
+  ]);
+  const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
+  const sdRungMap = buildSdRungMap(waveItems, wavesById);
+  return computeCoverage(claimable, sdRungMap);
+}
+
+/**
+ * Pure: bucket the last-N dispatched SD keys by wave-linked rung, and compare against the active
+ * wave's demand distribution. Non-wave-eligible classes are excluded from the denominator by
+ * class (FR-3) -- if exclusion leaves zero denominator, report STARVED (same honesty convention
+ * as coverage), never a false pass.
+ * @param {string[]} dispatchedKeys - last-N dispatched/claimed SD keys, newest first
+ * @param {Record<string, object>} sdRungMap - sd_key -> rung info
+ * @param {string|null} activeRungKey - the active wave's rung key
+ * @returns {{ total: number, excluded: number, mix: Record<string, number>, activeRungCount: number, activeRungPct: (number|null), starved: boolean }}
+ */
+export function computeDispatchMix(dispatchedKeys, sdRungMap, activeRungKey) {
+  const keys = Array.isArray(dispatchedKeys) ? dispatchedKeys : [];
+  const excluded = keys.filter(isWaveExclusionClass).length;
+  const included = keys.filter((k) => !isWaveExclusionClass(k));
+  const total = included.length;
+  if (total === 0) return { total: 0, excluded, mix: {}, activeRungCount: 0, activeRungPct: null, starved: true };
+  const mix = {};
+  for (const k of included) {
+    // buildSdRungMap's values are plain rung-key STRINGS (see lib/vision/rung-progress-rollup.mjs
+    // mapWaveToRung) -- not objects.
+    const rung = (sdRungMap && sdRungMap[k]) || 'unlinked';
+    mix[rung] = (mix[rung] || 0) + 1;
+  }
+  const activeRungCount = activeRungKey ? (mix[activeRungKey] || 0) : 0;
+  const activeRungPct = (activeRungCount / total) * 100;
+  return { total, excluded, mix, activeRungCount, activeRungPct, starved: false };
+}
+
+/**
+ * I/O: the last `limit` dispatch/claim events (newest first) across all SDs, read from
+ * strategic_directives_v2.metadata.claim_history (there is no top-level dispatch_rank column --
+ * verified live; mirrors lib/governance/work-boundary-gauges.js::fetchSdBoundaryRows's JSONB read
+ * pattern). Each claim event is one dispatch signal, so a re-claimed SD contributes multiple
+ * entries -- this reflects actual dispatch activity volume, not just unique SDs touched.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ limit?: number }} [opts]
+ * @returns {Promise<string[]>} sd_keys, newest-claimed first
+ */
+export async function fetchLastNDispatchedKeys(supabase, { limit = 20 } = {}) {
+  const { data, error } = await supabase.from('strategic_directives_v2').select('sd_key, metadata');
+  if (error) throw new Error('fetchLastNDispatchedKeys failed: ' + error.message);
+  const events = [];
+  for (const row of data || []) {
+    const history = Array.isArray(row?.metadata?.claim_history) ? row.metadata.claim_history : [];
+    for (const entry of history) {
+      if (entry && entry.claimed_at) events.push({ sd_key: row.sd_key, claimed_at: entry.claimed_at });
+    }
+  }
+  events.sort((a, b) => new Date(b.claimed_at).getTime() - new Date(a.claimed_at).getTime());
+  return events.slice(0, limit).map((e) => e.sd_key);
+}
+
+/**
+ * Pure: does the dispatch mix drift past threshold relative to the active wave's demand? A wave
+ * is "aligned" when the active rung's share of dispatched work is at least `minActiveRungPct` of
+ * the mix; anything below is drift. Starved input is never "aligned" (honest-gauge rule).
+ * @param {{ starved: boolean, activeRungPct: (number|null) }} mixResult
+ * @param {{ minActiveRungPct?: number }} [opts]
+ * @returns {boolean}
+ */
+export function isDriftBreach(mixResult, { minActiveRungPct = 25 } = {}) {
+  if (!mixResult || mixResult.starved) return true;
+  return typeof mixResult.activeRungPct === 'number' && mixResult.activeRungPct < minActiveRungPct;
+}

--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -125,6 +125,27 @@ export async function fetchLastNDispatchedKeys(supabase, { limit = 20 } = {}) {
 }
 
 /**
+ * I/O: re-surface-once dedup check (FR-5) -- is there already an OPEN invariant_gauge_finding for
+ * this gauge_id? routeFinding() in scripts/gauge-runner.mjs always inserts unconditionally
+ * otherwise (verified: 903 existing duplicate rows, no gauge dedups today), so this is genuinely
+ * new logic, not a reuse of existing framework behavior.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} gaugeId
+ * @returns {Promise<boolean>} true when an OPEN finding already exists (caller should skip insert)
+ */
+export async function hasOpenFinding(supabase, gaugeId) {
+  const { data, error } = await supabase
+    .from('feedback')
+    .select('id')
+    .eq('category', 'invariant_gauge_finding')
+    .eq('metadata->>gauge_id', gaugeId)
+    .in('status', ['new', 'backlog', 'in_progress'])
+    .limit(1);
+  if (error) throw new Error('hasOpenFinding failed: ' + error.message);
+  return Array.isArray(data) && data.length > 0;
+}
+
+/**
  * Pure: does the dispatch mix drift past threshold relative to the active wave's demand? A wave
  * is "aligned" when the active rung's share of dispatched work is at least `minActiveRungPct` of
  * the mix; anything below is drift. Starved input is never "aligned" (honest-gauge rule).

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -56,8 +56,19 @@ import { getCaptureCompleteness } from '../lib/eva/venture-capture-forward.js';
 import { resolveMinExtractStage } from '../lib/eva/template-extractor.js';
 import { detectExpiredPremises } from '../lib/governance/revisit-tags.js';
 import { readSubstrateRow, computeRunway, periodMonthOf, cashAttestationMissingResult } from '../lib/operator/cash-burn-substrate.js';
+import { runRollup } from '../lib/vision/rung-progress-rollup.mjs';
+import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
+import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
+import { buildSdRungMap } from '../lib/vision/needle-priority.mjs';
+import {
+  computeStampCoverage,
+  computeDispatchMix,
+  isDriftBreach,
+  fetchLastNDispatchedKeys,
+} from '../lib/governance/plan-drift-detectors.js';
 
 const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
+const PLAN_DRIFT_MIX_DIMENSION = 'plan-drift-mix';
 
 // relay-drop-gauge.cjs, adam-identity.cjs, solomon-identity.cjs are CommonJS -- createRequire is
 // this codebase's established ESM-import-CJS seam (mirrors gauge-unranked-claimable-leaves.mjs's
@@ -221,7 +232,107 @@ function buildDetectorResolvers(supabase) {
       const { sustained, streak } = detectSustainedBreach(recent);
       return { count: sustained ? 1 : 0, ...ratioResult, breach, streak };
     },
+    // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 Layer A: stamp-coverage (starvation detector).
+    'plan-drift-coverage': async () => computeStampCoverage(supabase),
+    // Layer B: dispatch-mix drift. Self-gates on LIVE coverage (re-reads Layer A) rather than
+    // coupling to any sibling SD's completion status. Sustained-breach trip reuses the
+    // recursion-governor.js cycle-tracking pattern (same codebase_health_snapshots table, a
+    // dimension key ('plan-drift-mix') that does not collide with 'recursion-governor-ratio').
+    // Re-surface-once dedup: skips the feedback-table insert (skipRoute) when an OPEN
+    // invariant_gauge_finding already exists for this gauge_id -- routeFinding() always inserts
+    // unconditionally otherwise, and 903 existing duplicate rows confirmed no gauge dedups today.
+    'plan-drift-mix': async () => {
+      const coverage = await computeStampCoverage(supabase);
+      if (coverage.starved) {
+        return { sustainedBreach: false, starved: true, coverage, skipRoute: true, value: 'STARVED (self-gated on Layer A coverage)' };
+      }
+      let activeRungKey = null;
+      let sdRungMap = {};
+      try {
+        const grep = makeDefaultGrepSeam();
+        const computeGaugeFn = () => computeBuildGauge({ io: { supabase, grep }, visionSource: true });
+        const roll = await runRollup({ supabase, computeGaugeFn, apply: false, log: () => {} });
+        if (roll && roll.ok) activeRungKey = roll.activeRungKey || null;
+        const [{ data: waveItems }, { data: waves }] = await Promise.all([
+          supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null),
+          supabase.from('roadmap_waves').select('id, time_horizon, metadata'),
+        ]);
+        const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
+        sdRungMap = buildSdRungMap(waveItems, wavesById);
+      } catch (e) {
+        console.error(`[gauge-runner] plan-drift-mix: active-rung context unavailable (fail-soft): ${e?.message || e}`);
+      }
+      const dispatchedKeys = await fetchLastNDispatchedKeys(supabase, { limit: 20 });
+      const mixResult = computeDispatchMix(dispatchedKeys, sdRungMap, activeRungKey);
+      const breach = isDriftBreach(mixResult);
+      await writeThroughputSnapshot(supabase, { dimension: PLAN_DRIFT_MIX_DIMENSION, ratioResult: mixResult, breach });
+      const recent = await fetchRecentSnapshots(supabase, { dimension: PLAN_DRIFT_MIX_DIMENSION, limit: 2 });
+      const { sustained, streak } = detectSustainedBreach(recent, { requiredConsecutive: 2 });
+      let skipRoute = false;
+      if (sustained) {
+        const { data: openFindings } = await supabase
+          .from('feedback')
+          .select('id')
+          .eq('category', 'invariant_gauge_finding')
+          .eq('metadata->>gauge_id', 'plan-drift-mix')
+          .in('status', ['new', 'backlog', 'in_progress'])
+          .limit(1);
+        skipRoute = Array.isArray(openFindings) && openFindings.length > 0;
+      }
+      const mixPctStr = typeof mixResult.activeRungPct === 'number' ? `${mixResult.activeRungPct.toFixed(1)}%` : 'n/a';
+      return {
+        sustainedBreach: sustained,
+        starved: false,
+        coverage,
+        mix: mixResult,
+        activeRungKey,
+        streak,
+        skipRoute,
+        value: `active-rung=${mixPctStr}${sustained ? ` (SUSTAINED BREACH x${streak})` : ''}`,
+      };
+    },
   };
+}
+
+/**
+ * SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-6: dual-recipient advisory (coordinator + Adam), fired only
+ * on a genuine sustained-breach trip that passed the re-surface-once dedup (never an unconditional
+ * per-run insert -- no existing gauge pushes to session_coordination today per design-agent's
+ * finding, so this push is deliberately narrow and gauge-specific rather than a generalized
+ * mechanism no other gauge has asked for yet).
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {object} result - the plan-drift-mix detector's result
+ */
+async function pushPlanDriftAdvisory(supabase, result) {
+  const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+  const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
+  const mixPct = typeof result?.mix?.activeRungPct === 'number' ? result.mix.activeRungPct.toFixed(1) : 'n/a';
+  const subject = `[PLAN-DRIFT] Dispatch mix drifted from active-wave demand (active-rung share ${mixPct}%)`;
+  const body = `Sustained dispatch-mix drift detected across ${result?.streak ?? '?'} consecutive gauge-runner cycles. Active-rung share of last-N dispatched work: ${mixPct}% (mix: ${JSON.stringify(result?.mix?.mix || {})}). Coverage floor is currently clear (not starved), so this is a genuine mix drift, not a linkage-starvation false trip.`;
+
+  const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+  const { error: coordErr } = await supabase.from('session_coordination').insert({
+    message_type: 'INFO',
+    target_session: coordinatorId || 'broadcast-coordinator',
+    subject,
+    sender_type: 'gauge-runner',
+    payload: { kind: 'coordinator_advisory', gauge_id: 'plan-drift-mix', body, mix: result?.mix, streak: result?.streak },
+  });
+  if (coordErr) console.error(`[gauge-runner] plan-drift advisory (coordinator) failed (non-fatal): ${coordErr.message}`);
+
+  const adamId = await resolveAdamSessionId(supabase).catch(() => null);
+  if (adamId) {
+    const { error: adamErr } = await supabase.from('session_coordination').insert({
+      message_type: 'INFO',
+      target_session: adamId,
+      subject,
+      sender_type: 'gauge-runner',
+      payload: { kind: 'coordinator_advisory', gauge_id: 'plan-drift-mix', body, mix: result?.mix, streak: result?.streak },
+    });
+    if (adamErr) console.error(`[gauge-runner] plan-drift advisory (Adam) failed (non-fatal): ${adamErr.message}`);
+  } else {
+    console.error('[gauge-runner] plan-drift advisory: no live Adam session resolved -- coordinator leg still sent');
+  }
 }
 
 /**
@@ -272,6 +383,14 @@ export function buildFindingRow(entry, result) {
 }
 
 async function routeFinding(supabase, entry, result) {
+  // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-5 (re-surface-once dedup): a detector may set
+  // result.skipRoute=true when an OPEN finding for its gauge_id already exists (or the trip is a
+  // self-gated starved short-circuit that isn't a genuine drift finding) -- skip the duplicate
+  // insert. Generic extension point: any future detector can opt in the same way.
+  if (result?.skipRoute) {
+    console.log(`[gauge-runner] ${entry.id}: routing skipped (skipRoute -- already-open finding or starved short-circuit)`);
+    return;
+  }
   const { error } = await supabase.from('feedback').insert(buildFindingRow(entry, result));
   if (error) console.error(`[gauge-runner] finding-route failed for ${entry.id} (non-fatal): ${error.message}`);
 }
@@ -310,7 +429,15 @@ async function main() {
       const value = typeof result?.count === 'number' ? result.count : (result?.value ?? 'n/a');
       console.log(`GAUGE ${entry.id}=${value}`);
       results.push({ id: entry.id, value, tripped, result });
-      if (tripped) await routeFinding(supabase, entry, result);
+      if (tripped) {
+        await routeFinding(supabase, entry, result);
+        // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-6: dual-recipient push, gauge-specific (narrow by
+        // design -- no other gauge pushes to session_coordination yet) and dedup-gated (skipRoute
+        // means either a starved short-circuit or an already-open finding -- never re-push).
+        if (entry.id === 'plan-drift-mix' && !result.skipRoute) {
+          await pushPlanDriftAdvisory(supabase, result);
+        }
+      }
     } catch (e) {
       console.error(`[gauge-runner] detector "${entry.id}" threw (non-fatal, advisory-only): ${e?.message || e}`);
       results.push({ id: entry.id, error: e?.message || String(e) });

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -65,6 +65,7 @@ import {
   computeDispatchMix,
   isDriftBreach,
   fetchLastNDispatchedKeys,
+  hasOpenFinding,
 } from '../lib/governance/plan-drift-detectors.js';
 
 const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
@@ -268,17 +269,7 @@ function buildDetectorResolvers(supabase) {
       await writeThroughputSnapshot(supabase, { dimension: PLAN_DRIFT_MIX_DIMENSION, ratioResult: mixResult, breach });
       const recent = await fetchRecentSnapshots(supabase, { dimension: PLAN_DRIFT_MIX_DIMENSION, limit: 2 });
       const { sustained, streak } = detectSustainedBreach(recent, { requiredConsecutive: 2 });
-      let skipRoute = false;
-      if (sustained) {
-        const { data: openFindings } = await supabase
-          .from('feedback')
-          .select('id')
-          .eq('category', 'invariant_gauge_finding')
-          .eq('metadata->>gauge_id', 'plan-drift-mix')
-          .in('status', ['new', 'backlog', 'in_progress'])
-          .limit(1);
-        skipRoute = Array.isArray(openFindings) && openFindings.length > 0;
-      }
+      const skipRoute = sustained ? await hasOpenFinding(supabase, 'plan-drift-mix') : false;
       const mixPctStr = typeof mixResult.activeRungPct === 'number' ? `${mixResult.activeRungPct.toFixed(1)}%` : 'n/a';
       return {
         sustainedBreach: sustained,
@@ -295,40 +286,43 @@ function buildDetectorResolvers(supabase) {
 }
 
 /**
+ * Pure-ish: builds the two session_coordination insert rows (coordinator + Adam) for a
+ * plan-drift-mix advisory. Extracted from pushPlanDriftAdvisory so the row SHAPE is unit-testable
+ * without faking coordinator/Adam session resolution.
+ * @param {object} result - the plan-drift-mix detector's result
+ * @param {{ coordinatorId: (string|null), adamId: (string|null) }} recipients
+ * @returns {{ coordinatorRow: object, adamRow: (object|null) }}
+ */
+export function buildPlanDriftAdvisoryRows(result, { coordinatorId, adamId }) {
+  const mixPct = typeof result?.mix?.activeRungPct === 'number' ? result.mix.activeRungPct.toFixed(1) : 'n/a';
+  const subject = `[PLAN-DRIFT] Dispatch mix drifted from active-wave demand (active-rung share ${mixPct}%)`;
+  const body = `Sustained dispatch-mix drift detected across ${result?.streak ?? '?'} consecutive gauge-runner cycles. Active-rung share of last-N dispatched work: ${mixPct}% (mix: ${JSON.stringify(result?.mix?.mix || {})}). Coverage floor is currently clear (not starved), so this is a genuine mix drift, not a linkage-starvation false trip.`;
+  const payload = { kind: 'coordinator_advisory', gauge_id: 'plan-drift-mix', body, mix: result?.mix, streak: result?.streak };
+  const coordinatorRow = { message_type: 'INFO', target_session: coordinatorId || 'broadcast-coordinator', subject, sender_type: 'gauge-runner', payload };
+  const adamRow = adamId ? { message_type: 'INFO', target_session: adamId, subject, sender_type: 'gauge-runner', payload } : null;
+  return { coordinatorRow, adamRow };
+}
+
+/**
  * SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-6: dual-recipient advisory (coordinator + Adam), fired only
  * on a genuine sustained-breach trip that passed the re-surface-once dedup (never an unconditional
  * per-run insert -- no existing gauge pushes to session_coordination today per design-agent's
  * finding, so this push is deliberately narrow and gauge-specific rather than a generalized
- * mechanism no other gauge has asked for yet).
+ * mechanism no other gauge has asked for yet). Session-id resolution is injected (not resolved
+ * internally) so buildPlanDriftAdvisoryRows/the insert calls are testable without faking the
+ * coordinator/Adam session-resolution machinery (those helpers have their own test suites).
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {object} result - the plan-drift-mix detector's result
+ * @param {{ coordinatorId: (string|null), adamId: (string|null) }} recipients
  */
-async function pushPlanDriftAdvisory(supabase, result) {
-  const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
-  const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
-  const mixPct = typeof result?.mix?.activeRungPct === 'number' ? result.mix.activeRungPct.toFixed(1) : 'n/a';
-  const subject = `[PLAN-DRIFT] Dispatch mix drifted from active-wave demand (active-rung share ${mixPct}%)`;
-  const body = `Sustained dispatch-mix drift detected across ${result?.streak ?? '?'} consecutive gauge-runner cycles. Active-rung share of last-N dispatched work: ${mixPct}% (mix: ${JSON.stringify(result?.mix?.mix || {})}). Coverage floor is currently clear (not starved), so this is a genuine mix drift, not a linkage-starvation false trip.`;
+export async function pushPlanDriftAdvisory(supabase, result, recipients) {
+  const { coordinatorRow, adamRow } = buildPlanDriftAdvisoryRows(result, recipients);
 
-  const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
-  const { error: coordErr } = await supabase.from('session_coordination').insert({
-    message_type: 'INFO',
-    target_session: coordinatorId || 'broadcast-coordinator',
-    subject,
-    sender_type: 'gauge-runner',
-    payload: { kind: 'coordinator_advisory', gauge_id: 'plan-drift-mix', body, mix: result?.mix, streak: result?.streak },
-  });
+  const { error: coordErr } = await supabase.from('session_coordination').insert(coordinatorRow);
   if (coordErr) console.error(`[gauge-runner] plan-drift advisory (coordinator) failed (non-fatal): ${coordErr.message}`);
 
-  const adamId = await resolveAdamSessionId(supabase).catch(() => null);
-  if (adamId) {
-    const { error: adamErr } = await supabase.from('session_coordination').insert({
-      message_type: 'INFO',
-      target_session: adamId,
-      subject,
-      sender_type: 'gauge-runner',
-      payload: { kind: 'coordinator_advisory', gauge_id: 'plan-drift-mix', body, mix: result?.mix, streak: result?.streak },
-    });
+  if (adamRow) {
+    const { error: adamErr } = await supabase.from('session_coordination').insert(adamRow);
     if (adamErr) console.error(`[gauge-runner] plan-drift advisory (Adam) failed (non-fatal): ${adamErr.message}`);
   } else {
     console.error('[gauge-runner] plan-drift advisory: no live Adam session resolved -- coordinator leg still sent');
@@ -435,7 +429,13 @@ async function main() {
         // design -- no other gauge pushes to session_coordination yet) and dedup-gated (skipRoute
         // means either a starved short-circuit or an already-open finding -- never re-push).
         if (entry.id === 'plan-drift-mix' && !result.skipRoute) {
-          await pushPlanDriftAdvisory(supabase, result);
+          const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+          const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
+          const [coordinatorId, adamId] = await Promise.all([
+            getActiveCoordinatorId(supabase).catch(() => null),
+            resolveAdamSessionId(supabase).catch(() => null),
+          ]);
+          await pushPlanDriftAdvisory(supabase, result, { coordinatorId, adamId });
         }
       }
     } catch (e) {

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -20,14 +20,14 @@ import {
 const VALID_FEEDBACK_TYPES = ['issue', 'enhancement'];
 
 describe('GAUGE_REGISTRY shape', () => {
-  it('exports exactly 20 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001 + operator-cash-attestation-missing, QF-20260705-915)', () => {
-    expect(GAUGE_REGISTRY).toHaveLength(20);
+  it('exports exactly 22 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001 + operator-cash-attestation-missing, QF-20260705-915 + plan-drift-coverage/plan-drift-mix, SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001)', () => {
+    expect(GAUGE_REGISTRY).toHaveLength(22);
   });
 
-  it('17 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
+  it('19 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
     const live = GAUGE_REGISTRY.filter((e) => e.enabled === true);
     const stubs = GAUGE_REGISTRY.filter((e) => e.enabled === false);
-    expect(live).toHaveLength(17);
+    expect(live).toHaveLength(19);
     expect(stubs.map((e) => e.id).sort()).toEqual(['adam_self_score_age', 'coordinator_self_score_age', 'solomon_self_score_age']);
   });
 
@@ -101,9 +101,9 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
     expect(selectEnabledEntries(undefined)).toEqual([]);
   });
 
-  it('the real GAUGE_REGISTRY selects all 17 enabled entries', () => {
+  it('the real GAUGE_REGISTRY selects all 19 enabled entries', () => {
     const selected = selectEnabledEntries(GAUGE_REGISTRY);
-    expect(selected).toHaveLength(17);
+    expect(selected).toHaveLength(19);
     expect(selected.map((e) => e.id).sort()).toEqual([
       'adam-claimed-or-built-sd',
       'coordinator-sourced-sd',
@@ -115,6 +115,8 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
       'loop-health-E_role_self_review',
       'loop-health-F_pat_registry',
       'operator-cash-attestation-missing',
+      'plan-drift-coverage',
+      'plan-drift-mix',
       'recursion-governor-ratio',
       'relay-drop',
       'ship-witness-unwitnessed-merge',
@@ -123,6 +125,21 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
       'unranked-claimable-leaves',
       'venture-capture-completeness',
     ]);
+  });
+
+  it('SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001: the two new entries have resolvable detectorFns, ownerRole coordinator, and honest-gauge tripWhen conventions', () => {
+    const coverage = GAUGE_REGISTRY.find((e) => e.id === 'plan-drift-coverage');
+    const mix = GAUGE_REGISTRY.find((e) => e.id === 'plan-drift-mix');
+    expect(coverage).toBeTruthy();
+    expect(coverage.detectorFn).toBe('plan-drift-coverage');
+    expect(coverage.ownerRole).toBe('coordinator');
+    expect(coverage.thresholdConfig.tripWhen({ starved: true })).toBe(true);
+    expect(coverage.thresholdConfig.tripWhen({ starved: false })).toBe(false);
+    expect(mix).toBeTruthy();
+    expect(mix.detectorFn).toBe('plan-drift-mix');
+    expect(mix.ownerRole).toBe('coordinator');
+    expect(mix.thresholdConfig.tripWhen({ sustainedBreach: true })).toBe(true);
+    expect(mix.thresholdConfig.tripWhen({ sustainedBreach: false })).toBe(false);
   });
 
   it('QF-20260705-915: operator-cash-attestation-missing has a resolvable detectorFn, ownerRole chairman, and the >0-count tripWhen convention', () => {

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -12,6 +12,7 @@ import {
   selectEnabledEntries, tripsThreshold, buildFindingRow,
   shapeRelayDropResult, shapeStaleTreeResult,
   staleSelfScoreDetector, DEFAULT_SELF_SCORE_STALE_HOURS,
+  buildPlanDriftAdvisoryRows, pushPlanDriftAdvisory,
 } from '../../../scripts/gauge-runner.mjs';
 
 // feedback.type is constrained by feedback_type_check (database/migrations/391_quality_lifecycle_schema.sql)
@@ -329,6 +330,58 @@ describe('the 3 self-score-age registry entries (FR-4)', () => {
       expect(entry.thresholdConfig.tripWhen({ count: 0 })).toBe(false);
       expect(entry.enabled).toBe(false); // ships alongside the writers' default-OFF cadence flags
     });
+  });
+});
+
+describe('buildPlanDriftAdvisoryRows / pushPlanDriftAdvisory (SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-6, TS-5)', () => {
+  const sampleResult = { streak: 2, mix: { activeRungPct: 12.5, mix: { now: 1, next: 7 } } };
+
+  it('builds a coordinator row targeting the resolved coordinator id', () => {
+    const { coordinatorRow } = buildPlanDriftAdvisoryRows(sampleResult, { coordinatorId: 'coord-123', adamId: null });
+    expect(coordinatorRow.target_session).toBe('coord-123');
+    expect(coordinatorRow.payload.kind).toBe('coordinator_advisory');
+    expect(coordinatorRow.payload.gauge_id).toBe('plan-drift-mix');
+    expect(coordinatorRow.subject).toContain('[PLAN-DRIFT]');
+  });
+
+  it('falls back to the broadcast-coordinator sentinel when no coordinator is resolved', () => {
+    const { coordinatorRow } = buildPlanDriftAdvisoryRows(sampleResult, { coordinatorId: null, adamId: null });
+    expect(coordinatorRow.target_session).toBe('broadcast-coordinator');
+  });
+
+  it('builds an Adam row only when an Adam session id is resolved (TS-8 typed-kind contract)', () => {
+    const withAdam = buildPlanDriftAdvisoryRows(sampleResult, { coordinatorId: 'coord-1', adamId: 'adam-1' });
+    expect(withAdam.adamRow).not.toBeNull();
+    expect(withAdam.adamRow.target_session).toBe('adam-1');
+    expect(withAdam.adamRow.payload.kind).toBe('coordinator_advisory'); // registered ADAM_INBOX_KINDS entry -- never orphaned
+
+    const withoutAdam = buildPlanDriftAdvisoryRows(sampleResult, { coordinatorId: 'coord-1', adamId: null });
+    expect(withoutAdam.adamRow).toBeNull();
+  });
+
+  it('pushPlanDriftAdvisory inserts exactly one coordinator row and one Adam row when both are resolved', async () => {
+    const inserted = [];
+    const fakeSupabase = {
+      from: () => ({
+        insert: (row) => { inserted.push(row); return Promise.resolve({ error: null }); },
+      }),
+    };
+    await pushPlanDriftAdvisory(fakeSupabase, sampleResult, { coordinatorId: 'coord-1', adamId: 'adam-1' });
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].target_session).toBe('coord-1');
+    expect(inserted[1].target_session).toBe('adam-1');
+  });
+
+  it('pushPlanDriftAdvisory inserts only the coordinator row when no Adam session resolves (never blocks on it)', async () => {
+    const inserted = [];
+    const fakeSupabase = {
+      from: () => ({
+        insert: (row) => { inserted.push(row); return Promise.resolve({ error: null }); },
+      }),
+    };
+    await pushPlanDriftAdvisory(fakeSupabase, sampleResult, { coordinatorId: 'coord-1', adamId: null });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].target_session).toBe('coord-1');
   });
 });
 

--- a/tests/unit/plan-drift-detectors.test.js
+++ b/tests/unit/plan-drift-detectors.test.js
@@ -4,6 +4,7 @@ import {
   computeCoverage,
   computeDispatchMix,
   isDriftBreach,
+  hasOpenFinding,
   COVERAGE_FLOOR_PCT,
 } from '../../lib/governance/plan-drift-detectors.js';
 
@@ -108,5 +109,35 @@ describe('plan-drift-detectors', () => {
 
   it('COVERAGE_FLOOR_PCT matches the fold-seam SD acceptance floor', () => {
     expect(COVERAGE_FLOOR_PCT).toBe(80);
+  });
+
+  describe('hasOpenFinding (FR-5 re-surface-once dedup, TS-6)', () => {
+    const fakeSupabase = (rows, err = null) => ({
+      from: (table) => ({
+        select: () => ({
+          eq: (col1, val1) => ({
+            eq: (col2, val2) => ({
+              in: () => ({
+                limit: () => Promise.resolve({ data: rows, error: err }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+
+    it('returns true when an OPEN finding already exists for the gauge_id', async () => {
+      const result = await hasOpenFinding(fakeSupabase([{ id: 'existing-row' }]), 'plan-drift-mix');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no OPEN finding exists (sustained breach not yet recorded, or prior one resolved)', async () => {
+      const result = await hasOpenFinding(fakeSupabase([]), 'plan-drift-mix');
+      expect(result).toBe(false);
+    });
+
+    it('throws on a query error (caught non-fatally by the caller, not swallowed here)', async () => {
+      await expect(hasOpenFinding(fakeSupabase(null, { message: 'boom' }), 'plan-drift-mix')).rejects.toThrow(/boom/);
+    });
   });
 });

--- a/tests/unit/plan-drift-detectors.test.js
+++ b/tests/unit/plan-drift-detectors.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWaveExclusionClass,
+  computeCoverage,
+  computeDispatchMix,
+  isDriftBreach,
+  COVERAGE_FLOOR_PCT,
+} from '../../lib/governance/plan-drift-detectors.js';
+
+describe('plan-drift-detectors', () => {
+  describe('isWaveExclusionClass', () => {
+    it('excludes QF keys', () => {
+      expect(isWaveExclusionClass('QF-20260711-001')).toBe(true);
+    });
+    it('excludes harness/meta SD prefixes', () => {
+      expect(isWaveExclusionClass('SD-LEO-INFRA-FOO-001')).toBe(true);
+      expect(isWaveExclusionClass('SD-LEARN-FIX-BAR-001')).toBe(true);
+      expect(isWaveExclusionClass('SD-MAN-INFRA-BAZ-001')).toBe(true);
+    });
+    it('does not exclude product SD keys', () => {
+      expect(isWaveExclusionClass('SD-EHG-PRODUCT-FOO-001')).toBe(false);
+    });
+  });
+
+  describe('computeCoverage (honest-gauge rule)', () => {
+    it('reports STARVED on zero claimable leaves (divide-by-zero edge, TS-3)', () => {
+      const result = computeCoverage([], {});
+      expect(result.starved).toBe(true);
+      expect(result.coveragePct).toBeNull();
+      expect(result.total).toBe(0);
+    });
+
+    it('reports STARVED when coverage is below the floor (TS-2)', () => {
+      const claimable = [{ sd_key: 'SD-A-001' }, { sd_key: 'SD-B-001' }, { sd_key: 'SD-C-001' }, { sd_key: 'SD-D-001' }, { sd_key: 'SD-E-001' }];
+      // 3/5 = 60% < 80% floor
+      const sdRungMap = { 'SD-A-001': 'now', 'SD-B-001': 'next', 'SD-C-001': 'now' };
+      const result = computeCoverage(claimable, sdRungMap);
+      expect(result.coveragePct).toBe(60);
+      expect(result.starved).toBe(true);
+    });
+
+    it('reports aligned when coverage is at/above the floor (TS-1)', () => {
+      const claimable = [{ sd_key: 'SD-A-001' }, { sd_key: 'SD-B-001' }, { sd_key: 'SD-C-001' }, { sd_key: 'SD-D-001' }, { sd_key: 'SD-E-001' }];
+      // 4/5 = 80% >= 80% floor
+      const sdRungMap = { 'SD-A-001': 'now', 'SD-B-001': 'next', 'SD-C-001': 'now', 'SD-D-001': 'later' };
+      const result = computeCoverage(claimable, sdRungMap);
+      expect(result.coveragePct).toBe(80);
+      expect(result.starved).toBe(false);
+    });
+
+    it('respects a custom floor', () => {
+      const claimable = [{ sd_key: 'SD-A-001' }, { sd_key: 'SD-B-001' }];
+      const sdRungMap = { 'SD-A-001': 'now' };
+      const result = computeCoverage(claimable, sdRungMap, { floorPct: 40 });
+      expect(result.coveragePct).toBe(50);
+      expect(result.starved).toBe(false);
+    });
+  });
+
+  describe('computeDispatchMix', () => {
+    it('reports STARVED on a zero post-exclusion denominator (all excluded)', () => {
+      const result = computeDispatchMix(['QF-20260711-001', 'SD-LEO-INFRA-FOO-001'], {}, 'now');
+      expect(result.starved).toBe(true);
+      expect(result.total).toBe(0);
+      expect(result.excluded).toBe(2);
+    });
+
+    it('excludes QF/harness classes from the denominator (TS-7)', () => {
+      const dispatched = ['SD-EHG-PRODUCT-A-001', 'QF-20260711-001', 'SD-EHG-PRODUCT-B-001'];
+      const sdRungMap = { 'SD-EHG-PRODUCT-A-001': 'now', 'SD-EHG-PRODUCT-B-001': 'now' };
+      const withExclusion = computeDispatchMix(dispatched, sdRungMap, 'now');
+      expect(withExclusion.total).toBe(2);
+      expect(withExclusion.excluded).toBe(1);
+
+      const withoutExclusionSd = ['SD-EHG-PRODUCT-A-001', 'SD-EHG-PRODUCT-B-001'];
+      const noExclusionPresent = computeDispatchMix(withoutExclusionSd, sdRungMap, 'now');
+      expect(noExclusionPresent.total).toBe(2);
+      expect(noExclusionPresent.excluded).toBe(0);
+    });
+
+    it('buckets by rung and computes active-rung share', () => {
+      const dispatched = ['SD-A-001', 'SD-B-001', 'SD-C-001', 'SD-D-001'];
+      // SD-D-001 is intentionally absent from sdRungMap -- exercises the 'unlinked' fallback.
+      const sdRungMap = { 'SD-A-001': 'now', 'SD-B-001': 'now', 'SD-C-001': 'next' };
+      const result = computeDispatchMix(dispatched, sdRungMap, 'now');
+      expect(result.total).toBe(4);
+      expect(result.mix.now).toBe(2);
+      expect(result.mix.next).toBe(1);
+      expect(result.mix.unlinked).toBe(1);
+      expect(result.activeRungCount).toBe(2);
+      expect(result.activeRungPct).toBe(50);
+    });
+  });
+
+  describe('isDriftBreach', () => {
+    it('treats STARVED as a breach (never a false pass)', () => {
+      expect(isDriftBreach({ starved: true, activeRungPct: 100 })).toBe(true);
+    });
+
+    it('is a breach when active-rung share is below the minimum', () => {
+      expect(isDriftBreach({ starved: false, activeRungPct: 10 }, { minActiveRungPct: 25 })).toBe(true);
+    });
+
+    it('is not a breach when active-rung share meets the minimum', () => {
+      expect(isDriftBreach({ starved: false, activeRungPct: 40 }, { minActiveRungPct: 25 })).toBe(false);
+    });
+  });
+
+  it('COVERAGE_FLOOR_PCT matches the fold-seam SD acceptance floor', () => {
+    expect(COVERAGE_FLOOR_PCT).toBe(80);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new advisory-only invariant gauge to the existing gauge-runner registry framework, detecting when fleet dispatch/claim activity drifts away from the chairman-ratified roadmap wave demand.
- **Layer A (stamp-coverage)**: percent of claimable leaf SDs carrying roadmap wave linkage; honest-gauge rule reports STARVED (never a false "aligned") on zero claimable leaves or coverage below the 80% floor.
- **Layer B (dispatch-mix drift)**: buckets the last-20 dispatched SD keys by wave-linked rung vs the active wave's demand, excluding QF-/SD-LEO-/SD-LEARN-FIX-/SD-MAN-INFRA- classes; self-gates on live Layer A coverage; sustained breach (2 consecutive cycles) triggers a dual advisory push (coordinator + Adam session) with a re-surface-once dedup check.

## Test plan
- [x] `npx vitest run tests/unit/plan-drift-detectors.test.js tests/unit/governance/gauge-registry.test.js` — 17 + updated gauge-registry tests, all green
- [x] Regression suite (137 tests / 8 files across governance, vision, and gauge-runner areas) — all green
- [x] Live gauge-runner smoke run against production data — correctly detected genuine starvation (0/2 claimable leaves wave-linked)
- [x] VALIDATION sub-agent PASS (confidence 95%)
- [x] REGRESSION sub-agent PASS (confidence 93%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)