### PR TITLE
polish(QF-20260711-236): Adam delegated-apply marker on distillation-queue migration

### DIFF
--- a/database/migrations/20260623_eva_consultant_recommendations_distillation_queue.sql
+++ b/database/migrations/20260623_eva_consultant_recommendations_distillation_queue.sql
@@ -2,6 +2,8 @@
 -- Child idx 0 (dependency root) of the Brainstorm Distillation Pipeline orchestrator
 -- (SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001).
 -- ADDITIVE, nullable, REVERSIBLE, idempotent. No drops/renames.
+-- @approved-by: codestreetlabs@gmail.com
+-- (additive-DDL class chairman-ratified 2026-06-16 b917c3e1; applied by Adam as scribe under the 2026-07-11 verbal-approval policy)
 --
 -- Adds the chairman review-queue substrate to eva_consultant_recommendations so a distilled
 -- brainstorm candidate can be recorded as a chairman-reviewable recommendation row that LINKS


### PR DESCRIPTION
## Summary
- One-line routing marker (`-- @approved-by: codestreetlabs@gmail.com`) plus a rationale comment on the additive `20260623_eva_consultant_recommendations_distillation_queue.sql` migration, so the chairman-ratified delegated-apply path (2026-06-16, b917c3e1) can apply it under the 2026-07-11 verbal-approval policy.
- Marker is routing-only; actual authority is the delegation token + kill-switch, not the marker itself.
- Unblocks QF-20260705-893.

## Test plan
- N/A (comment-only addition to an unapplied migration file; no code/behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)