### PR TITLE
fix(QF-20260711-804): migration classifier no longer over-counts semicolons in string literals

### DIFF
--- a/scripts/lib/migration-tier-classifier.mjs
+++ b/scripts/lib/migration-tier-classifier.mjs
@@ -38,7 +38,10 @@ const MAX_SQL_BYTES = 200_000;
 
 // Top-level destructive / permission-altering / non-additive verbs. If any of these
 // survive in the body-stripped, allow-head-stripped residue, the migration is TIER-2.
-const FORBIDDEN_TOPLEVEL = /\b(DROP|TRUNCATE|DELETE|UPDATE|RENAME|GRANT|REVOKE|CLUSTER|REINDEX|REFRESH|VACUUM|ANALYZE|COMMENT|COPY|CALL|LISTEN|NOTIFY|IMPORT|MERGE|LOCK|DO)\b/i;
+// COMMENT is deliberately EXCLUDED (QF-20260711-804): it now has its own narrow,
+// literal-value-only allow-rule (matchCommentOnColumn) — same treatment as CREATE/ALTER,
+// which are also absent here and gated by their own RULES instead of a blanket ban.
+const FORBIDDEN_TOPLEVEL = /\b(DROP|TRUNCATE|DELETE|UPDATE|RENAME|GRANT|REVOKE|CLUSTER|REINDEX|REFRESH|VACUUM|ANALYZE|COPY|CALL|LISTEN|NOTIFY|IMPORT|MERGE|LOCK|DO)\b/i;
 
 // Destructive tokens inside a CREATE FUNCTION / VIEW body (Rule E deep-scan).
 const BODY_DESTRUCTIVE = /\b(DROP|TRUNCATE|DELETE\s+FROM|UPDATE\b[\s\S]*?\bSET\b|ALTER\s+(TABLE|VIEW|MATERIALIZED|SEQUENCE|TYPE|SCHEMA|POLICY)|GRANT|REVOKE|CALL|COPY|EXECUTE|\bDO\b|INSERT\s+INTO|MERGE)\b/i;
@@ -100,9 +103,34 @@ function dollarQuotesBalanced(sql) {
   return Object.values(counts).every((n) => n % 2 === 0);
 }
 
-/** Count top-level (not inside a string/comment/dollar body) semicolons in a residue. */
-function countTopLevelSemicolons(residue) {
-  return (residue.match(/;/g) || []).length;
+/**
+ * Count semicolons OUTSIDE any single-quoted string literal in `s`. A quoted string —
+ * e.g. a COMMENT ON COLUMN ... IS '...' value — can legitimately contain semicolons as
+ * prose punctuation; those are NOT statement boundaries and must not be miscounted as
+ * one (QF-20260711-804: a chairman-facing COMMENT string with semicolons in its prose
+ * false-triggered the under-split/embedded-semicolon checks on an otherwise provably-
+ * additive migration). Dollar-quoted bodies are already removed by stripNonDdl() before
+ * this runs, so only '...'-style literals need handling here. Escaped '' inside a
+ * string (the SQL-standard doubled-quote escape) is honored.
+ */
+function countTopLevelSemicolons(s) {
+  let count = 0;
+  let inString = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "'") {
+      if (inString && s[i + 1] === "'") { i++; continue; } // escaped '' inside a string
+      inString = !inString;
+      continue;
+    }
+    if (ch === ';' && !inString) count++;
+  }
+  return count;
+}
+
+/** True iff `s` contains a semicolon OUTSIDE any single-quoted string literal. */
+function hasTopLevelSemicolon(s) {
+  return countTopLevelSemicolons(s) > 0;
 }
 
 /** Remove balanced parenthesized groups (iteratively, innermost-first) — bounded. */
@@ -252,7 +280,22 @@ function matchSafeCreateFnView(head, rawStmt) {
   return { token: 'create_function' };
 }
 
-const RULES = [matchCreateTableINE, matchCreateIndex, matchAdditiveAddColumn, matchPolicyOrEnableRls];
+// Rule F — COMMENT ON COLUMN <table>.<col> IS <literal-or-NULL> (QF-20260711-804). Pure
+// catalog metadata (pg_description) on an EXISTING column — no query execution, no data
+// mutation, no object coupling beyond referencing the column. The value MUST be a plain
+// constant string literal or NULL (clears the comment) — never a sub-expression/function
+// call, which could not be proven side-effect-free. COMMENT ON <anything else> (TABLE,
+// FUNCTION, ...) is intentionally NOT covered — fails closed to TIER-2 (unrecognized).
+function matchCommentOnColumn(head) {
+  const m = head.match(/^comment\s+on\s+column\s+([a-z0-9_."]+)\s+is\s+(.+)$/);
+  if (!m) return null;
+  const value = m[2].trim();
+  if (value === 'null') return { token: `comment_on_column:${m[1]}` };
+  if (!/^'(?:[^']|'')*'$/.test(value)) return null; // must be a plain string literal
+  return { token: `comment_on_column:${m[1]}` };
+}
+
+const RULES = [matchCreateTableINE, matchCreateIndex, matchAdditiveAddColumn, matchPolicyOrEnableRls, matchCommentOnColumn];
 
 /**
  * Classify a migration's risk tier. PURE; never throws; default-deny to TIER-2.
@@ -289,7 +332,7 @@ export function classifyMigration(sql) {
     for (const raw of stmts) {
       const head = normalizeHead(raw);
       if (!head) continue; // comment/whitespace-only fragment between statements
-      if (head.includes(';')) return T2('embedded_semicolon_ambiguity'); // FC-3
+      if (hasTopLevelSemicolon(head)) return T2('embedded_semicolon_ambiguity'); // FC-3
       // FC-3 (under-split): a single statement must carry exactly one command verb.
       // Catches the no-semicolon blob (two CREATEs) that a prefix-only head match
       // would false-pass, and any destructive command concatenated to an additive one.

--- a/tests/unit/migration-tier-classifier.test.js
+++ b/tests/unit/migration-tier-classifier.test.js
@@ -8,6 +8,7 @@
  * so every case is an integration assertion, not a string-shape mock).
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { classifyMigration } from '../../scripts/lib/migration-tier-classifier.mjs';
 
 // ── Adversarial corpus: every one of these MUST classify TIER-2 (never auto-applied) ──
@@ -70,6 +71,13 @@ const TIER2_CORPUS = [
   ['EXTERNAL SECURITY DEFINER comment split (FC-15)', 'CREATE FUNCTION esc() RETURNS void LANGUAGE sql EXTERNAL SECURITY/*c*/DEFINER AS $b$ SELECT 1 $b$;'],
   ['weaponized SECURITY DEFINER auth.users exfil', 'CREATE FUNCTION all_secrets() RETURNS SETOF auth.users LANGUAGE sql SECURITY/*x*/DEFINER AS $b$ SELECT * FROM auth.users $b$;'],
   ['camouflage: additive ADD COLUMN + CTAS-kill', 'ALTER TABLE foo ADD COLUMN note text;\nCREATE TABLE IF NOT EXISTS k AS SELECT pg_terminate_backend(pid) FROM pg_stat_activity;'],
+  // ── QF-20260711-804: the new COMMENT ON COLUMN rule is narrow — every unsupported
+  //    COMMENT shape must still fail closed to TIER-2. ──
+  ['COMMENT ON TABLE (unsupported form)', "COMMENT ON TABLE users IS 'the users table';"],
+  ['COMMENT ON FUNCTION (unsupported form)', "COMMENT ON FUNCTION add_two(int,int) IS 'adds two ints';"],
+  ['COMMENT ON COLUMN with a function-call value (not a literal)', 'COMMENT ON COLUMN foo.bar IS current_user;'],
+  ['COMMENT ON COLUMN with a subquery value', 'COMMENT ON COLUMN foo.bar IS (SELECT description FROM meta LIMIT 1);'],
+  ['COMMENT ON COLUMN concatenating two literals (not a single plain literal)', "COMMENT ON COLUMN foo.bar IS 'a' || 'b';"],
 ];
 
 // ── Provably-additive: every one of these MUST classify TIER-1 (auto-apply eligible) ──
@@ -84,6 +92,19 @@ const TIER1_CORPUS = [
   //    genuinely-additive forms (proves the fix is precise, not a blanket ban). ──
   ['bare CREATE FUNCTION (definition stored, not executed at apply)', 'CREATE FUNCTION add_two(a int, b int) RETURNS int LANGUAGE sql AS $$ SELECT a + b $$;'],
   ['CREATE TABLE IF NOT EXISTS with in-table volatile DEFAULT (fires on INSERT, not apply)', 'CREATE TABLE IF NOT EXISTS evt (id uuid DEFAULT gen_random_uuid(), at timestamptz DEFAULT now());'],
+  // ── QF-20260711-804: COMMENT ON COLUMN allow-rule (pure catalog metadata) ──
+  ['COMMENT ON COLUMN with a plain string literal', "COMMENT ON COLUMN users.email IS 'primary contact address';\n"],
+  ['COMMENT ON COLUMN IS NULL (clears an existing comment)', 'COMMENT ON COLUMN users.email IS NULL;'],
+  // ── QF-20260711-804 regression: a COMMENT string containing prose semicolons must
+  //    NOT be miscounted as extra statement boundaries (the exact false-reject this
+  //    QF fixes — Solomon/harness specimen: 20260623_eva_consultant_recommendations_
+  //    distillation_queue.sql's chairman-facing column comments). ──
+  ['multi-statement additive migration with a semicolon-bearing COMMENT value', `
+ALTER TABLE eva_consultant_recommendations ADD COLUMN IF NOT EXISTS distilled_sd_payload jsonb;
+ALTER TABLE eva_consultant_recommendations ADD COLUMN IF NOT EXISTS confidence_tier text;
+CREATE INDEX IF NOT EXISTS idx_ecr_conf ON eva_consultant_recommendations(confidence_tier);
+COMMENT ON COLUMN eva_consultant_recommendations.distilled_sd_payload IS 'the distilled SD JSON payload (distiller writes; chairman reviews; disposition-gate checks).';
+`],
 ];
 
 describe('classifyMigration — TIER-2 (must never auto-apply)', () => {
@@ -139,5 +160,19 @@ describe('classifyMigration — invariants', () => {
       const sql = `CREATE FUNCTION esc() RETURNS void LANGUAGE sql SECURITY${zw}DEFINER AS $b$ SELECT 1 $b$;`;
       expect(classifyMigration(sql).tier, `U+${cp.toString(16)} split must be TIER-2`).toBe(2);
     }
+  });
+
+  it('QF-20260711-804 regression: the real specimen no longer false-rejects on under-split/embedded-semicolon ambiguity', () => {
+    // Live specimen (b917c3e1): this migration's chairman-facing COMMENT ON COLUMN
+    // prose contains semicolons, which used to inflate the residue semicolon count past
+    // stmts.length (under_split_ambiguity) and separately trip the per-statement
+    // embedded-semicolon check (embedded_semicolon_ambiguity) -- both now fixed.
+    // The file still classifies TIER-2 overall for a SEPARATE, correctly-conservative
+    // reason: one ADD COLUMN carries an inline REFERENCES (FK) clause, which Rule C
+    // deliberately excludes (out of scope for this fix -- FK support is its own decision).
+    const sql = readFileSync('database/migrations/20260623_eva_consultant_recommendations_distillation_queue.sql', 'utf8');
+    const r = classifyMigration(sql);
+    expect(r.reason).not.toBe('under_split_ambiguity');
+    expect(r.reason).not.toBe('embedded_semicolon_ambiguity');
   });
 });


### PR DESCRIPTION
## Summary
- `countTopLevelSemicolons()` and the per-statement embedded-semicolon check both counted every `;` character naively, including ones inside single-quoted string literals — e.g. a chairman-facing `COMMENT ON COLUMN ... IS '...text with semicolons...'` value. This inflated the residue semicolon count past the real statement count, false-triggering `under_split_ambiguity` / `embedded_semicolon_ambiguity` on otherwise provably-additive migrations (live specimen: `20260623_eva_consultant_recommendations_distillation_queue.sql`).
- Both checks are now string-literal-aware (honoring the SQL `''` escape). Zero change to genuine under-split detection — a real missed splitter boundary still has unmatched non-string-literal semicolons and is still caught (verified against the full 55-case adversarial corpus).
- Adds a narrow `COMMENT ON COLUMN` allow-rule (Rule F): pure catalog metadata (`pg_description`), no query execution at apply time. The value must be a plain string literal or `NULL` — a function call, subquery, or concatenation still fails closed to TIER-2. `COMMENT` is removed from `FORBIDDEN_TOPLEVEL` accordingly — same treatment CREATE/ALTER already get (gated by their own allow-rules instead of a blanket ban).

## Scope boundary (documented, not silently dropped)
The cited specimen migration (`20260623_...distillation_queue.sql`) still classifies TIER-2 overall for a **separate, correctly-conservative** reason: one `ADD COLUMN` carries an inline `REFERENCES` (FK) clause, which Rule C deliberately excludes. Extending FK support is a bigger, distinct security decision (it touches Rule C, `commandVerbCount`'s `ON DELETE`/`ON UPDATE` handling, and `FORBIDDEN_TOPLEVEL` simultaneously) that this fix does not attempt — it's out of scope for a Tier-1 quick fix and deserves its own dedicated review. The genuine splitter bugs this QF targets (`under_split_ambiguity`, `embedded_semicolon_ambiguity`) are fixed and regression-pinned against the real file.

## Test plan
- [x] `npx vitest run tests/unit/migration-tier-classifier.test.js tests/unit/migration-tier-gate.test.js` — 87/87 passed (9 new cases: 5 adversarial COMMENT-shape rejections, 4 positive cases including the semicolon-bearing-comment regression)
- [x] `npx vitest run tests/handoff/pending-migrations-check.test.js tests/unit/adam-delegated-apply.test.js` — 24/24 passed (both classifier consumers, no regressions)
- [x] Regression test reads the real specimen file and asserts its reason is neither `under_split_ambiguity` nor `embedded_semicolon_ambiguity` (still correctly TIER-2, but for the honest FK reason now)

QF-20260711-804

🤖 Generated with [Claude Code](https://claude.com/claude-code)