### PR TITLE
fix(QF-20260711-176): clear quick_fixes.claiming_session_id on completion + sweep terminal pass

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -67,7 +67,11 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
     tests_passing: true,
     force_completed: true,
     verification_notes,
-    completed_at: qf.completed_at || nowIso
+    completed_at: qf.completed_at || nowIso,
+    // QF-20260711-176: a completed QF has no holder. Leaving claiming_session_id set made the
+    // live-claim-guard permanently block worktree reaping (claimed_claimant_not_verifiably_alive)
+    // until the pool drained to WORKTREE_CREATE_FAILED (coordinator evidence 5655cb68).
+    claiming_session_id: null
   };
 }
 
@@ -649,7 +653,10 @@ export async function completeQuickFix(qfId, options = {}) {
       verified_by: options.forceComplete ? 'FORCE_COMPLETE' : 'UAT_AGENT',
       verification_notes: finalVerificationNotes,
       files_changed: filesChanged.length > 0 ? filesChanged : null,
-      completed_at: new Date().toISOString()
+      completed_at: new Date().toISOString(),
+      // QF-20260711-176: completed QFs must not retain a holder — a lingering
+      // claiming_session_id blocks worktree reaping via the live-claim-guard.
+      claiming_session_id: null
     })
     .eq('id', qfId);
 

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1036,6 +1036,33 @@ async function cancelStaleTestFixtures(supabase, now, actions, warnings) {
 
 async function clearStaleQfClaims(supabase, now, actions, warnings) {
   const veryStaleSeconds = STALE_THRESHOLD_SECONDS * 3; // 15min = definitely dead
+
+  // QF-20260711-176 (guard-on-every-path): TERMINAL QFs have no legitimate holder — clear
+  // claiming_session_id unconditionally (no liveness check needed). The writer-side fix
+  // (complete-quick-fix orchestrator now clears it in the completion UPDATE) covers new
+  // completions; this sweep pass reaps the historical residue class that drained the worktree
+  // pool to 20/20 WORKTREE_CREATE_FAILED (live-claim-guard blocked reaping with
+  // claimed_claimant_not_verifiably_alive — coordinator evidence 5655cb68).
+  try {
+    const { data: terminalClaimed } = await supabase
+      .from('quick_fixes')
+      .select('id, status, claiming_session_id')
+      .in('status', ['completed', 'cancelled', 'escalated'])
+      .not('claiming_session_id', 'is', null);
+    for (const qf of (terminalClaimed || [])) {
+      const { error } = await supabase
+        .from('quick_fixes')
+        .update({ claiming_session_id: null })
+        .eq('id', qf.id)
+        .eq('claiming_session_id', qf.claiming_session_id); // race guard
+      if (!error) {
+        actions.push('QF: cleared claiming_session_id on TERMINAL ' + qf.status + ' ' + qf.id + ' (no legitimate holder; unblocks worktree reaping)');
+      }
+    }
+  } catch (termErr) {
+    warnings.push('QF_TERMINAL_CLAIM_SWEEP: ' + termErr.message);
+  }
+
   try {
     const { data: claimedQfs } = await supabase
       .from('quick_fixes')

--- a/tests/unit/scripts/sweep-residuals.test.js
+++ b/tests/unit/scripts/sweep-residuals.test.js
@@ -49,9 +49,21 @@ describe('FR-2: QF-aware orphan path + claim-age grace', () => {
   const fr2 = block('a QF-claiming session carries sd_key', 'const orphanedClaims');
   it('builds a quick_fixes existence set with a non-colliding column tuple (R11)', () => {
     expect(fr2).toMatch(/from\('quick_fixes'\)\.select\('id'\)/);
-    // R11: must NOT add a second select of the (id, status, claiming_session_id) tuple
+    // R11 intent: the FR-2 existence set must NOT collide with the claim-clear tuple selects.
+    // Two tuple selects are sanctioned — BOTH live inside clearStaleQfClaims (the QF-211
+    // open/in_progress pass + the QF-20260711-176 TERMINAL pass); none in the FR-2 block.
     const colliding = (SRC.match(/select\('id, status, claiming_session_id'\)/g) || []).length;
-    expect(colliding).toBe(1);
+    expect(colliding).toBe(2);
+    expect(fr2).not.toMatch(/select\('id, status, claiming_session_id'\)/);
+    const helperIdx = SRC.indexOf('async function clearStaleQfClaims');
+    const helperEnd = SRC.indexOf('\n}', SRC.indexOf('QF_CLAIM_SWEEP', helperIdx));
+    let searchFrom = 0;
+    for (let i = 0; i < colliding; i++) {
+      const at = SRC.indexOf("select('id, status, claiming_session_id')", searchFrom);
+      expect(at).toBeGreaterThan(helperIdx);
+      expect(at).toBeLessThan(helperEnd);
+      searchFrom = at + 1;
+    }
   });
   it('holds a QF claim when the QF exists OR was claimed within the grace window', () => {
     expect(fr2).toMatch(/QF_CLAIM_GRACE_SECONDS/);

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -125,19 +125,38 @@ describe('QF-20260525-211 (early-exit gap): QF claim clear runs before the early
   });
 
   it('does NOT double-run: the inline QF clear block was removed from main()', () => {
-    // exactly one definition site (the helper), and the old inline VERY_STALE_SECONDS gate is gone
-    expect(src.match(/from\(['"]quick_fixes['"]\)\s*\n\s*\.select\(['"]id, status, claiming_session_id['"]\)/g) || []).toHaveLength(1);
+    // Two select sites now, BOTH inside the clearStaleQfClaims helper (QF-20260711-176 added a
+    // TERMINAL-status pass alongside the QF-211 open/in_progress pass); the old inline
+    // VERY_STALE_SECONDS gate in main() stays gone.
+    const selects = src.match(/from\(['"]quick_fixes['"]\)\s*\n\s*\.select\(['"]id, status, claiming_session_id['"]\)/g) || [];
+    expect(selects).toHaveLength(2);
+    const helperIdx = src.indexOf('async function clearStaleQfClaims');
+    const helperEnd = src.indexOf('\n}', src.indexOf('QF_CLAIM_SWEEP', helperIdx));
+    let searchFrom = 0;
+    for (const m of selects) {
+      const at = src.indexOf(m, searchFrom);
+      expect(at).toBeGreaterThan(helperIdx);
+      expect(at).toBeLessThan(helperEnd);
+      searchFrom = at + m.length;
+    }
     expect(src).not.toMatch(/if\s*\(ageSec <= VERY_STALE_SECONDS\)/);
   });
 
   it('preserves QF-836 safety: race guard + conservative staleness bar', () => {
     const idx = src.indexOf('async function clearStaleQfClaims');
-    const fn = src.slice(idx, idx + 1600);
+    const fn = src.slice(idx, idx + 3600); // widened: the QF-176 terminal pass precedes the open/in_progress pass
     // only clear if still held by the same (dead) session
     expect(fn).toMatch(/\.eq\(['"]claiming_session_id['"],\s*qf\.claiming_session_id\)/);
     // leave alive/recent holders alone
     expect(fn).toMatch(/if\s*\(ageSec <= veryStaleSeconds\)\s*continue;/);
-    // only open/in_progress QFs are candidates
+    // open/in_progress QFs remain liveness-gated candidates
     expect(fn).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]open['"]\s*,\s*['"]in_progress['"]\s*\]/);
+  });
+
+  it('QF-20260711-176: terminal QFs are cleared unconditionally (no legitimate holder)', () => {
+    const idx = src.indexOf('async function clearStaleQfClaims');
+    const fn = src.slice(idx, idx + 3600);
+    expect(fn).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]completed['"]\s*,\s*['"]cancelled['"]\s*,\s*['"]escalated['"]\s*\]/);
+    expect(fn).toMatch(/TERMINAL/);
   });
 });


### PR DESCRIPTION
## Summary
Completed QFs retained `claiming_session_id`, so the live-claim-guard blocked worktree reaping forever and the pool drained to 20/20 `WORKTREE_CREATE_FAILED` (coordinator evidence 5655cb68 — this worker hit the same wall today and needed manual cleanup).

Guard-on-every-path:
- Both completion writers in `scripts/modules/complete-quick-fix/orchestrator.js` (main UPDATE + `buildMergedReconcileUpdate`) now null `claiming_session_id`
- `clearStaleQfClaims` (stale-session-sweep) gains a TERMINAL pass: completed/cancelled/escalated QFs with a holder are cleared unconditionally (no legitimate holder exists), with the still-held race guard
- Source-pin tests updated (two passes both inside the helper; new terminal pin)

## Verification
294/294 across complete-quick-fix, qf211 claim-guard, and pass-registry suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)