### PR TITLE
feat(SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001): hard-block reaping resident worktrees; reap out-of-band

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -34,6 +34,8 @@ import os from 'os';
 import { enforceWorktreeQuota } from './worktree-quota.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-2): shared reapability guard.
 import { isReapable, logReapDecision } from './worktree-reapability.js';
+import { cwdResidencyBlocks } from './worktree-reaper/residency-guard.js';
+import { writeReapEligibleMarker } from './worktree-reaper/reap-eligible-marker.js';
 
 const WORKTREES_DIR = '.worktrees';
 
@@ -1464,6 +1466,19 @@ export function safeRecursiveCp(srcPath, destPath, options = {}) {
  */
 export function removeWorktreeViaGit(wtPath, repoRoot, options = {}) {
   const { allowFail = false, guard = false, liveOwner = false, logger = console.warn } = options;
+  // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-1): DEFAULT-ON cwd residency
+  // hard-block at the delete chokepoint. Every production delete path funnels
+  // here, so this one check covers all writers: a process may never delete the
+  // worktree it is standing in (the self-reap vector — deleting the cwd
+  // corrupts the resident shell and loses in-flight work). Fail-closed; the
+  // WORKTREE_RESIDENCY_GUARD=off kill-switch inside the guard is the only
+  // bypass. `blocked:true` (alongside skipped) tells callers with fs-rm
+  // fallbacks (post-merge cleanup :313) NOT to force-delete around the block.
+  const residency = cwdResidencyBlocks(wtPath, { logger });
+  if (residency.blocked) {
+    logReapDecision({ worktree: wtPath, decision: 'skip', reason: residency.reason }, logger);
+    return { ok: false, error: null, skipped: true, blocked: true, reason: residency.reason };
+  }
   if (guard) {
     const verdict = isReapable(wtPath, { liveOwner });
     if (!verdict.reapable) {
@@ -1637,16 +1652,19 @@ export function removeWorktree(sdKey) {
     }
   }
 
-  try {
-    // QF-20260523-697: unlink node_modules first so git can't follow the
-    // junction and wipe the shared main-repo node_modules.
-    preUnlinkWorktreeNodeModules(worktreePath);
-    execSync(`git worktree remove --force "${worktreePath}"`, {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
-  } catch {
+  // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-2): route through the guarded
+  // chokepoint instead of a direct execSync — this path is invoked by
+  // cleanupWorktree from LEAD-FINAL-APPROVAL / /ship Step 6.5, often with the
+  // acting process still standing INSIDE the worktree. On a residency block,
+  // mark reap-eligible (out-of-band handoff to the scheduled reaper) instead of
+  // deleting under the resident session.
+  const viaGit = removeWorktreeViaGit(worktreePath, repoRoot, { allowFail: true });
+  if (viaGit.blocked) {
+    const marker = writeReapEligibleMarker(worktreePath, { sd_key: sdKey });
+    console.warn(`[worktree-manager] BLOCKED removal of ${sdKey}: ${viaGit.reason} — marked reap-eligible (${marker.written ? 'marker written' : 'marker write failed: ' + marker.error})`);
+    return { removed: false, reason: viaGit.reason, marked: marker.written };
+  }
+  if (!viaGit.ok) {
     // SD-LEO-INFRA-WORKTREE-CLEANUP-WINDOWS-001 (FR-1 site #2):
     // git worktree remove failed — fall back to retry-with-backoff. On exhaustion,
     // mark the owning released session as cleanup_pending (FR-2 writer) so the
@@ -2095,15 +2113,15 @@ export async function cleanupStaleWorktrees({ dryRun = false, maxAgeMs, supabase
         }
       }
 
-      // Remove worktree
-      try {
-        // QF-20260523-697: unlink node_modules first so git can't follow the
-        // junction and wipe the shared main-repo node_modules.
-        preUnlinkWorktreeNodeModules(item.path);
-        execSync(`git worktree remove --force "${item.path}"`, {
-          cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-        });
-      } catch {
+      // Remove worktree — through the guarded chokepoint (SD-LEO-INFRA-
+      // WORKTREE-REAPER-RESIDENT-001 FR-2): a cwd-resident orphan is skipped,
+      // never force-deleted around the block.
+      const orphanRm = removeWorktreeViaGit(item.path, repoRoot, { allowFail: true });
+      if (orphanRm.blocked) {
+        result.skipped.push(`${item.key}: ${orphanRm.reason}`);
+        continue;
+      }
+      if (!orphanRm.ok) {
         // SD-LEO-INFRA-WORKTREE-CLEANUP-WINDOWS-001 (FR-1 site #4):
         // cleanupOrphans inner-loop manual fallback. Route through retry helper
         // so a stale Windows lock doesn't pin orphans across consecutive sweeps.

--- a/lib/worktree-reaper/reap-eligible-marker.js
+++ b/lib/worktree-reaper/reap-eligible-marker.js
@@ -1,0 +1,61 @@
+/**
+ * Reap-eligible marker (SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001, FR-3).
+ *
+ * The out-of-band reap handoff: instead of a post-merge flow deleting the
+ * worktree its own process is standing in (the self-reap vector), it writes
+ * this durable filesystem marker and exits with the worktree intact. The
+ * SCHEDULED reaper collects marker-bearing worktrees once residency clears.
+ *
+ * Filesystem-level by design (no DDL): mirrors the proven cleanup_pending
+ * deferred-delete pattern without a migration dependency. Marker writes are
+ * best-effort — a failure must never fail the merge (the reaper's normal
+ * age-based classification still collects the worktree later).
+ */
+import fs from 'fs';
+import path from 'path';
+
+export const MARKER_FILENAME = '.reap-eligible.json';
+
+/**
+ * Write the reap-eligible marker at the worktree root. Best-effort.
+ * @param {string} wtPath - worktree root
+ * @param {{ sd_key?: string, merged_pr?: number|string|null, marked_by_session?: string|null }} [fields]
+ * @returns {{ written: boolean, markerPath: string|null, error: string|null }}
+ */
+export function writeReapEligibleMarker(wtPath, fields = {}) {
+  const markerPath = path.join(wtPath, MARKER_FILENAME);
+  try {
+    const payload = {
+      sd_key: fields.sd_key ?? null,
+      merged_pr: fields.merged_pr ?? null,
+      marked_by_session: fields.marked_by_session ?? process.env.CLAUDE_SESSION_ID ?? null,
+      marked_at: new Date().toISOString(),
+    };
+    fs.writeFileSync(markerPath, JSON.stringify(payload, null, 2), 'utf8');
+    return { written: true, markerPath, error: null };
+  } catch (e) {
+    return { written: false, markerPath: null, error: e?.message || String(e) };
+  }
+}
+
+/**
+ * Read the marker if present and parseable.
+ * @param {string} wtPath - worktree root
+ * @returns {object|null} marker payload, or null when absent/corrupt
+ */
+export function readReapEligibleMarker(wtPath) {
+  try {
+    const raw = fs.readFileSync(path.join(wtPath, MARKER_FILENAME), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} wtPath @returns {boolean} */
+export function hasReapEligibleMarker(wtPath) {
+  return fs.existsSync(path.join(wtPath, MARKER_FILENAME));
+}
+
+export default { MARKER_FILENAME, writeReapEligibleMarker, readReapEligibleMarker, hasReapEligibleMarker };

--- a/lib/worktree-reaper/residency-guard.js
+++ b/lib/worktree-reaper/residency-guard.js
@@ -1,0 +1,124 @@
+/**
+ * Worktree residency guard (SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001).
+ *
+ * A worktree is RESIDENT when a live session is standing in it:
+ *   (a) the acting process cwd is inside the target path (pure path math), or
+ *   (b) any claude_sessions row with a FRESH heartbeat has worktree_path
+ *       equal to / containing the target (one indexed read).
+ * Deleting a resident worktree corrupts the resident session's shell and
+ * loses in-flight work — the twice-recurred self-reap class (Charlie ~16:05Z
+ * and Golf-4 20:09Z on 2026-07-11; prior P0 PAT-LEO-INFRA-WRITER-CONSUMER-
+ * ASYMMETRY-001, PRs #3670-#3674, recurred via #4316/#4657/#4669/#5853).
+ *
+ * Polarity: FAIL-CLOSED. An error answering the residency question blocks the
+ * reap (REAP_RESIDENCY_UNKNOWN) — mirrors liveClaimBlocksRemoval's contract.
+ * Freshness reuses the session-liveness SSOT (hasFreshHeartbeat, 300s); no
+ * second liveness predicate.
+ *
+ * Kill-switch: WORKTREE_RESIDENCY_GUARD=off restores pre-guard behavior
+ * (loudly) for emergency rollback without a revert — the guard sits on every
+ * delete path, so a false-positive storm must be operationally recoverable.
+ */
+import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { hasFreshHeartbeat } = require('../fleet/session-liveness.cjs');
+
+export const REAP_BLOCKED_RESIDENT = 'REAP_BLOCKED_RESIDENT';
+export const REAP_RESIDENCY_UNKNOWN = 'REAP_RESIDENCY_UNKNOWN';
+
+function killSwitchOff() {
+  const v = String(process.env.WORKTREE_RESIDENCY_GUARD || '').toLowerCase();
+  return v === 'off' || v === '0' || v === 'false';
+}
+
+function norm(p) {
+  return path.resolve(String(p)).replace(/[\\/]+$/, '');
+}
+
+/** Is `inner` the same directory as `outer`, or contained inside it? */
+function pathInside(inner, outer) {
+  const a = norm(inner);
+  const b = norm(outer);
+  if (process.platform === 'win32') {
+    const al = a.toLowerCase();
+    const bl = b.toLowerCase();
+    return al === bl || al.startsWith(bl + path.sep);
+  }
+  return a === b || a.startsWith(b + path.sep);
+}
+
+/**
+ * SYNC residency check: is the acting process standing inside the target?
+ * This is the exact in-process self-reap vector (post-merge cleanup running
+ * from inside the worktree it deletes) and needs no I/O, so it binds inside
+ * the synchronous delete chokepoint (removeWorktreeViaGit).
+ *
+ * @param {string} wtPath - worktree path targeted for deletion
+ * @param {{ cwd?: string, logger?: function }} [options] - cwd override for tests
+ * @returns {{ blocked: boolean, reason: string|null, bypassed?: boolean }}
+ */
+export function cwdResidencyBlocks(wtPath, options = {}) {
+  const { cwd = process.cwd(), logger = console.warn } = options;
+  if (killSwitchOff()) {
+    logger(`[residency-guard] WORKTREE_RESIDENCY_GUARD=off — BYPASSING cwd residency check for ${wtPath}`);
+    return { blocked: false, reason: null, bypassed: true };
+  }
+  try {
+    if (pathInside(cwd, wtPath)) {
+      return { blocked: true, reason: REAP_BLOCKED_RESIDENT };
+    }
+    return { blocked: false, reason: null };
+  } catch (e) {
+    // Path math should never throw, but the contract is fail-closed.
+    logger(`[residency-guard] cwd residency check failed (${e?.message}) — failing CLOSED`);
+    return { blocked: true, reason: REAP_RESIDENCY_UNKNOWN };
+  }
+}
+
+/**
+ * ASYNC residency check: does any FRESH-heartbeat session's worktree_path
+ * reference the target? Queries claude_sessions directly — v_active_sessions
+ * does not project worktree_path (QF-20260510-WT-CLAIM-PROTECT-001).
+ * For async removers only (scheduled reaper, cleanup-pending sweep); the sync
+ * chokepoint cannot await this.
+ *
+ * @param {object} supabase - service-role client
+ * @param {string} wtPath - worktree path targeted for deletion
+ * @param {{ nowMs?: number, logger?: function }} [options]
+ * @returns {Promise<{ blocked: boolean, reason: string|null, detail?: string }>}
+ */
+export async function heartbeatResidencyBlocksRemoval(supabase, wtPath, options = {}) {
+  const { nowMs = Date.now(), logger = console.warn } = options;
+  if (killSwitchOff()) {
+    logger(`[residency-guard] WORKTREE_RESIDENCY_GUARD=off — BYPASSING heartbeat residency check for ${wtPath}`);
+    return { blocked: false, reason: null };
+  }
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at, worktree_path')
+      .not('worktree_path', 'is', null);
+    if (error) throw error;
+    for (const row of data || []) {
+      if (!row.worktree_path) continue;
+      // Resident when the session's registered worktree IS the target, or sits
+      // inside it (nested fixture worktrees) — either way deletion is unsafe.
+      const references = pathInside(row.worktree_path, wtPath) || pathInside(wtPath, row.worktree_path);
+      if (references && hasFreshHeartbeat(row, nowMs)) {
+        return {
+          blocked: true,
+          reason: REAP_BLOCKED_RESIDENT,
+          detail: `fresh-heartbeat session ${row.session_id} resident at ${row.worktree_path}`,
+        };
+      }
+    }
+    return { blocked: false, reason: null };
+  } catch (e) {
+    logger(`[residency-guard] heartbeat residency check failed for ${wtPath} (${e?.message}) — failing CLOSED`);
+    return { blocked: true, reason: REAP_RESIDENCY_UNKNOWN, detail: e?.message };
+  }
+}
+
+export default { cwdResidencyBlocks, heartbeatResidencyBlocksRemoval, REAP_BLOCKED_RESIDENT, REAP_RESIDENCY_UNKNOWN };

--- a/scripts/cleanup-pending-sweep.mjs
+++ b/scripts/cleanup-pending-sweep.mjs
@@ -249,6 +249,18 @@ export async function processCleanupPendingQueue(supabase, opts = {}) {
       continue;
     }
 
+    // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-2): residency guard — this
+    // sweep deletes via fs (bypassing the git chokepoint), so it must ask the
+    // residency question itself. cwd + fresh-heartbeat worktree_path, fail-closed.
+    const { cwdResidencyBlocks, heartbeatResidencyBlocksRemoval } = await import('../lib/worktree-reaper/residency-guard.js');
+    const cwdRes = cwdResidencyBlocks(row.worktree_path);
+    const hbRes = cwdRes.blocked ? cwdRes : await heartbeatResidencyBlocksRemoval(supabase, row.worktree_path);
+    if (cwdRes.blocked || hbRes.blocked) {
+      summary.skippedUnsafe = (summary.skippedUnsafe || 0) + 1;
+      log(`${tag} SKIPPED_RESIDENT: ${(cwdRes.blocked ? cwdRes : hbRes).reason} — leaving cleanup_pending for a later sweep`);
+      continue;
+    }
+
     // FR-3: retry rm via the canonical helper (FR-1 retry layer).
     if (dryRun) {
       log(`${tag} DRY_RUN: would retry rm ${row.worktree_path}`);

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { createClient } from '@supabase/supabase-js';
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../../../lib/worktree-manager.js';
+import { writeReapEligibleMarker } from '../../../lib/worktree-reaper/reap-eligible-marker.js';
 import { detectOrphanWorktreeFromMerge } from '../../../lib/exec-context-guard.mjs';
 
 // Quick-fix QF-20260211-111: Post-merge worktree cleanup for /ship
@@ -237,14 +238,23 @@ function getMainRepoPath(meta, wtPath) {
 async function cleanupCurrentWorktree(options = {}) {
   if (!isInsideWorktree()) return { cleaned: false, reason: 'not_in_worktree' };
   const wtPath = gitExec('git rev-parse --show-toplevel');
-  // QF-20260404-445: Warn if CWD is inside the worktree about to be deleted.
-  // On Windows, deleting the CWD directory corrupts the shell — subsequent
-  // commands (handoffs, node module resolution) fail with ERR_MODULE_NOT_FOUND.
+  // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-2/FR-3): the former
+  // QF-20260404-445 warn-and-proceed branch here DELETED the resident
+  // worktree anyway (Golf-4 self-reap, 2026-07-11 20:09Z). Cwd-inside-target
+  // is now a HARD refusal: mark reap-eligible and hand off to the scheduled
+  // reaper, which collects once residency clears. Deleting the CWD corrupts
+  // the resident shell (ERR_MODULE_NOT_FOUND on every subsequent command).
   const cwd = process.cwd().replace(/\\/g, '/');
   const normalized = wtPath.replace(/\\/g, '/');
-  if (cwd.startsWith(normalized)) {
-    const result = await cleanupWorktreeByPath(wtPath, options);
-    return { ...result, warning: 'CWD_INSIDE_TARGET', hint: 'cd to main repo BEFORE running cleanup to avoid shell corruption' };
+  if (cwd === normalized || cwd.startsWith(normalized + '/')) {
+    const meta = getWorktreeMetadata(wtPath);
+    const marker = writeReapEligibleMarker(wtPath, { sd_key: meta?.workKey || meta?.sdKey || path.basename(wtPath) });
+    return {
+      cleaned: false,
+      reason: 'REAP_BLOCKED_RESIDENT',
+      marked: marker.written,
+      hint: 'worktree marked reap-eligible; the scheduled reaper collects it once no session is resident',
+    };
   }
   return cleanupWorktreeByPath(wtPath, options);
 }
@@ -310,6 +320,12 @@ async function cleanupWorktreeByPath(wtPath, options = {}) {
   // QF-20260511-446: pre-unlink node_modules symlink so git doesn't follow it
   // and wipe main repo's node_modules (MSYS-symlink-on-Windows wipe vector).
   const gitRemove = removeWorktreeViaGit(wtPath, mainRepoPath, { allowFail: true });
+  // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001: a residency BLOCK must never be
+  // force-deleted around via the fs fallback — mark reap-eligible instead.
+  if (gitRemove.blocked) {
+    const marker = writeReapEligibleMarker(wtPath, { sd_key: sdKey });
+    return { cleaned: false, reason: gitRemove.reason, marked: marker.written, mainRepoPath, workKey: sdKey };
+  }
   if (!gitRemove.ok && fs.existsSync(wtPath)) {
     safeRecursiveRm(wtPath);
     execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });

--- a/scripts/modules/shipping/worktree-merge.js
+++ b/scripts/modules/shipping/worktree-merge.js
@@ -14,7 +14,7 @@ import { execSync } from 'child_process';
 import { existsSync, realpathSync } from 'fs';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { removeWorktreeViaGit } from '../../../lib/worktree-manager.js';
+import { writeReapEligibleMarker } from '../../../lib/worktree-reaper/reap-eligible-marker.js';
 import { observeMergeWorkLadder } from '../../../lib/ship/auto-merge.mjs';
 
 function run(cmd, opts = {}) {
@@ -95,12 +95,13 @@ async function main() {
     console.log('   🧹 Pruning worktree references...');
     run('git worktree prune', { cwd: mainRepoPath });
 
-    // Try to remove the worktree directory if it still exists.
-    // QF-20260511-446: route through removeWorktreeViaGit so the node_modules
-    // symlink is unlinked first — bare `git worktree remove --force` follows
-    // MSYS bash symlinks on Windows and wipes the main repo's node_modules.
+    // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-3): this flow runs IN-PROCESS
+    // from inside the worktree right after the merge — deleting it here is the
+    // exact post-merge self-reap vector. Mark reap-eligible instead; the
+    // scheduled reaper collects it out-of-band once residency clears.
     if (existsSync(worktreePath)) {
-      removeWorktreeViaGit(worktreePath, mainRepoPath, { allowFail: true });
+      const marker = writeReapEligibleMarker(worktreePath, { sd_key: worktreeRelative, merged_pr: prNumber });
+      console.log(`   🏷️  Worktree marked reap-eligible${marker.written ? '' : ' (marker write failed: ' + marker.error + ')'} — scheduled reaper collects it out-of-band`);
     }
 
     // Delete local branch reference
@@ -111,7 +112,8 @@ async function main() {
       merged: true,
       pr: parseInt(prNumber),
       branch,
-      worktreeCleaned: true,
+      worktreeCleaned: false,
+      worktreeMarkedReapEligible: true,
       mainRepoPath,
       action: 'cd_to_main'
     }));

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -63,6 +63,8 @@ import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
 // QF-20260710-432: last-line live-claim guard — a live-claimed worktree is never
 // reaped regardless of commit count (Alpha-2 incident: zero-commit mid-PLAN reap).
 import { liveClaimBlocksRemoval } from '../lib/worktree-reaper/live-claim-guard.js';
+import { heartbeatResidencyBlocksRemoval } from '../lib/worktree-reaper/residency-guard.js';
+import { hasReapEligibleMarker, readReapEligibleMarker } from '../lib/worktree-reaper/reap-eligible-marker.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
 // These three used to be defined locally below; the canonical home is now
 // lib/worktree-reapability.js so every removal path shares one implementation.
@@ -590,6 +592,15 @@ async function classifyWorktree(wt, ctx) {
   const categories = [];
   const reasons = {};
 
+  // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-4): a .reap-eligible.json
+  // marker is the out-of-band handoff from a post-merge flow that refused to
+  // self-delete — collect it promptly, ahead of age-based classification. The
+  // removal gate (live-claim + residency guards) still decides WHEN it is safe.
+  if (hasReapEligibleMarker(wt.path)) {
+    categories.push('reap-eligible');
+    reasons['reap-eligible'] = { matched: true, reason: 'marker', evidence: readReapEligibleMarker(wt.path) || {} };
+  }
+
   const nested = isNested(wt);
   if (nested.matched) { categories.push('nested'); reasons.nested = nested; }
 
@@ -646,7 +657,8 @@ async function classifyWorktree(wt, ctx) {
 
 function stageForCategories(categories) {
   if (categories.length === 0) return { stage: null, verdict: 'keep' };
-  const hasStage1 = categories.includes('nested') || categories.includes('shipped-stale');
+  const hasStage1 = categories.includes('nested') || categories.includes('shipped-stale') ||
+                    categories.includes('reap-eligible');
   const hasStage2 = categories.includes('zombie-on-main') ||
                     categories.includes('orphan-sd') ||
                     categories.includes('idle');
@@ -1334,6 +1346,27 @@ export async function main(argv = process.argv) {
           worktree_path: wtPath,
           reason: claimGuard.reason,
           detail: claimGuard.detail || null,
+        });
+        aborted++;
+        continue;
+      }
+
+      // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-4): residency guard —
+      // a FRESH-heartbeat session whose worktree_path references this target
+      // is standing in it (claim-independent: idle/parked sessions hold no
+      // claim yet still resident). Fail-closed, same as the claim guard.
+      const residency = await heartbeatResidencyBlocksRemoval(supabase, wtPath, {
+        logger: (m) => process.stderr.write(`  ${m}\n`),
+      });
+      if (residency.blocked) {
+        console.log(`  ⛔ ${path.basename(wtPath)} residency guard: ${residency.reason} — skipping`);
+        emitJsonLine({
+          schema_version: SCHEMA_VERSION,
+          timestamp: new Date().toISOString(),
+          event: 'removal_blocked_resident',
+          worktree_path: wtPath,
+          reason: residency.reason,
+          detail: residency.detail || null,
         });
         aborted++;
         continue;

--- a/tests/unit/worktree-delete-primitive-static-guard.test.js
+++ b/tests/unit/worktree-delete-primitive-static-guard.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-5) — static delete-primitive guard.
+ *
+ * Per-site patching is why the self-reap class recurred (#3670-#3674 -> #4316,
+ * #4657, #4669, #5853, twice on 2026-07-11): each fix hardened one writer while
+ * new/unlisted writers kept executing `git worktree remove` directly, bypassing
+ * every guard. This scan fails CI when a non-allowlisted file executes the
+ * delete primitive — all deletes must route through the guarded chokepoint
+ * (removeWorktreeViaGit in lib/worktree-manager.js).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Files allowed to contain the execution string.
+const ALLOWLIST = new Set([
+  // The chokepoint itself (primary path + rollbackWorktreeFilesystemSync, a
+  // creation-failure rollback of a just-created worktree — not a reap).
+  'lib/worktree-manager.js',
+  // Stale CONCURRENT-session worktrees (hook context, PowerShell git): guarded
+  // by fs-marker + active-claim + dirty + unpushed + merged-to-main checks and
+  // structurally unable to import ESM chokepoint from a sync CJS hook.
+  'scripts/hooks/concurrent-session-worktree.cjs',
+  // Ephemeral temp BUILD worktree created and removed inside one function call
+  // (finally-block); never a session workspace.
+  'lib/gates/cross-repo-build-check.js',
+]);
+
+const SCAN_DIRS = ['lib', 'scripts'];
+const EXT_RE = /\.(m?c?js)$/;
+const PRIMITIVE_RE = /git\s+worktree\s+remove/;
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fp = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      yield* walk(fp);
+    } else if (EXT_RE.test(entry.name) && !/\.test\.|\.spec\./.test(entry.name)) {
+      // Test/spec files may reference the primitive in mocks and assertions.
+      yield fp;
+    }
+  }
+}
+
+describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
+  it('no non-allowlisted file executes `git worktree remove` directly', () => {
+    const violations = [];
+    for (const dir of SCAN_DIRS) {
+      for (const fp of walk(path.join(repoRoot, dir))) {
+        const rel = path.relative(repoRoot, fp).replace(/\\/g, '/');
+        if (ALLOWLIST.has(rel)) continue;
+        const src = fs.readFileSync(fp, 'utf8');
+        if (!PRIMITIVE_RE.test(src)) continue;
+        // Only flag EXECUTION contexts (exec/spawn/run/PowerShell), not comments
+        // or log strings mentioning the command.
+        for (const [i, line] of src.split('\n').entries()) {
+          if (!PRIMITIVE_RE.test(line)) continue;
+          const trimmed = line.trim();
+          if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('#')) continue;
+          if (/\b(execSync|exec|spawnSync|spawn|run|runGit|gitViaPowerShell)\s*\(/.test(line)) {
+            violations.push(`${rel}:${i + 1}`);
+          }
+        }
+      }
+    }
+    expect(violations, `direct 'git worktree remove' outside the guarded chokepoint:\n  ${violations.join('\n  ')}`).toEqual([]);
+  });
+
+  it('the warn-and-proceed CWD branch is gone from post-merge cleanup (FR-2)', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts/modules/shipping/post-merge-worktree-cleanup.js'), 'utf8');
+    // The old branch returned a warning AND still deleted; the refusal path
+    // must not call cleanupWorktreeByPath after detecting cwd containment.
+    expect(src).not.toMatch(/warning:\s*['"]CWD_INSIDE_TARGET['"]/);
+    expect(src).toMatch(/REAP_BLOCKED_RESIDENT/);
+  });
+});

--- a/tests/unit/worktree-residency-guard.test.js
+++ b/tests/unit/worktree-residency-guard.test.js
@@ -1,0 +1,165 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 — residency guard + marker + chokepoint.
+ *
+ * TS-1 cwd containment blocks at the chokepoint; TS-2 fresh-vs-stale heartbeat
+ * residency; TS-3 fail-closed on query error; TS-7 kill-switch bypass (loud);
+ * marker roundtrip; FR-6 e2e composition: block while fresh, collect after stale.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  cwdResidencyBlocks,
+  heartbeatResidencyBlocksRemoval,
+  REAP_BLOCKED_RESIDENT,
+  REAP_RESIDENCY_UNKNOWN,
+} from '../../lib/worktree-reaper/residency-guard.js';
+import {
+  writeReapEligibleMarker,
+  readReapEligibleMarker,
+  hasReapEligibleMarker,
+  MARKER_FILENAME,
+} from '../../lib/worktree-reaper/reap-eligible-marker.js';
+import { removeWorktreeViaGit } from '../../lib/worktree-manager.js';
+
+const noop = () => {};
+
+function sbReturning(result) {
+  const chain = { select: () => chain, not: () => Promise.resolve(result) };
+  return { from: () => chain };
+}
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wt-residency-'));
+}
+
+afterEach(() => {
+  delete process.env.WORKTREE_RESIDENCY_GUARD;
+});
+
+describe('cwdResidencyBlocks (TS-1, TS-7)', () => {
+  it('blocks when cwd IS the target', () => {
+    const d = tmpDir();
+    expect(cwdResidencyBlocks(d, { cwd: d, logger: noop })).toEqual({ blocked: true, reason: REAP_BLOCKED_RESIDENT });
+  });
+
+  it('blocks when cwd is a subdirectory of the target', () => {
+    const d = tmpDir();
+    const sub = path.join(d, 'a', 'b');
+    expect(cwdResidencyBlocks(d, { cwd: sub, logger: noop }).blocked).toBe(true);
+  });
+
+  it('does NOT block a sibling path sharing a prefix (no substring false-positive)', () => {
+    const d = tmpDir();
+    expect(cwdResidencyBlocks(d, { cwd: d + '-sibling', logger: noop }).blocked).toBe(false);
+  });
+
+  it('does NOT block when cwd is outside the target', () => {
+    const d = tmpDir();
+    expect(cwdResidencyBlocks(d, { cwd: os.tmpdir(), logger: noop }).blocked).toBe(false);
+  });
+
+  it('kill-switch bypasses LOUDLY (TS-7)', () => {
+    process.env.WORKTREE_RESIDENCY_GUARD = 'off';
+    const d = tmpDir();
+    const lines = [];
+    const res = cwdResidencyBlocks(d, { cwd: d, logger: (m) => lines.push(m) });
+    expect(res.blocked).toBe(false);
+    expect(res.bypassed).toBe(true);
+    expect(lines.join(' ')).toMatch(/BYPASSING/);
+  });
+});
+
+describe('heartbeatResidencyBlocksRemoval (TS-2, TS-3)', () => {
+  it('a FRESH-heartbeat session whose worktree_path is the target blocks', async () => {
+    const d = tmpDir();
+    const sb = sbReturning({ data: [{ session_id: 's1', heartbeat_at: new Date().toISOString(), worktree_path: d }], error: null });
+    const res = await heartbeatResidencyBlocksRemoval(sb, d, { logger: noop });
+    expect(res.blocked).toBe(true);
+    expect(res.reason).toBe(REAP_BLOCKED_RESIDENT);
+    expect(res.detail).toContain('s1');
+  });
+
+  it('a STALE-heartbeat session does not block', async () => {
+    const d = tmpDir();
+    const stale = new Date(Date.now() - 3600_000).toISOString();
+    const sb = sbReturning({ data: [{ session_id: 's1', heartbeat_at: stale, worktree_path: d }], error: null });
+    expect((await heartbeatResidencyBlocksRemoval(sb, d, { logger: noop })).blocked).toBe(false);
+  });
+
+  it('a fresh session on a DIFFERENT worktree does not block', async () => {
+    const d = tmpDir();
+    const other = tmpDir();
+    const sb = sbReturning({ data: [{ session_id: 's1', heartbeat_at: new Date().toISOString(), worktree_path: other }], error: null });
+    expect((await heartbeatResidencyBlocksRemoval(sb, d, { logger: noop })).blocked).toBe(false);
+  });
+
+  it('fails CLOSED on a query error (TS-3)', async () => {
+    const d = tmpDir();
+    const sb = sbReturning({ data: null, error: new Error('connection reset') });
+    const res = await heartbeatResidencyBlocksRemoval(sb, d, { logger: noop });
+    expect(res.blocked).toBe(true);
+    expect(res.reason).toBe(REAP_RESIDENCY_UNKNOWN);
+  });
+});
+
+describe('chokepoint integration (TS-1): removeWorktreeViaGit refuses a cwd-resident delete', () => {
+  it('returns blocked+skipped without executing the delete when the process stands inside the target', () => {
+    const d = tmpDir();
+    const prev = process.cwd();
+    try {
+      process.chdir(d);
+      const res = removeWorktreeViaGit(d, os.tmpdir(), { allowFail: true, logger: noop });
+      expect(res.blocked).toBe(true);
+      expect(res.skipped).toBe(true);
+      expect(res.reason).toBe(REAP_BLOCKED_RESIDENT);
+      expect(fs.existsSync(d)).toBe(true); // nothing was deleted
+    } finally {
+      process.chdir(prev);
+    }
+  });
+});
+
+describe('reap-eligible marker (FR-3)', () => {
+  it('write/read roundtrip carries sd_key, merged_pr, marked_at', () => {
+    const d = tmpDir();
+    const w = writeReapEligibleMarker(d, { sd_key: 'SD-X-001', merged_pr: 123 });
+    expect(w.written).toBe(true);
+    expect(hasReapEligibleMarker(d)).toBe(true);
+    const m = readReapEligibleMarker(d);
+    expect(m.sd_key).toBe('SD-X-001');
+    expect(m.merged_pr).toBe(123);
+    expect(typeof m.marked_at).toBe('string');
+  });
+
+  it('a corrupt marker reads as null; a missing dir write is non-fatal', () => {
+    const d = tmpDir();
+    fs.writeFileSync(path.join(d, MARKER_FILENAME), '{not json', 'utf8');
+    expect(readReapEligibleMarker(d)).toBeNull();
+    const w = writeReapEligibleMarker(path.join(d, 'no-such-dir', 'x'));
+    expect(w.written).toBe(false);
+    expect(w.error).toBeTruthy();
+  });
+});
+
+describe('FR-6 e2e composition: block while resident, collectable after residency clears', () => {
+  it('the same marked worktree is blocked fresh and clear after the heartbeat stales', async () => {
+    const d = tmpDir();
+    writeReapEligibleMarker(d, { sd_key: 'SD-E2E-001' });
+    expect(hasReapEligibleMarker(d)).toBe(true);
+
+    const freshRow = { session_id: 'resident', heartbeat_at: new Date().toISOString(), worktree_path: d };
+    const fresh = await heartbeatResidencyBlocksRemoval(sbReturning({ data: [freshRow], error: null }), d, { logger: noop });
+    expect(fresh.blocked).toBe(true);
+
+    const staleRow = { ...freshRow, heartbeat_at: new Date(Date.now() - 3600_000).toISOString() };
+    const cleared = await heartbeatResidencyBlocksRemoval(sbReturning({ data: [staleRow], error: null }), d, { logger: noop });
+    expect(cleared.blocked).toBe(false);
+
+    // Residency clear -> the chokepoint (called from outside the worktree) proceeds
+    // past the residency guard; actual git removal is exercised by reaper e2e suites.
+    const res = cwdResidencyBlocks(d, { cwd: os.tmpdir(), logger: noop });
+    expect(res.blocked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Implements **SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001** (coordinator-sourced from two live self-reap incidents on 2026-07-11 — Charlie ~16:05Z, Golf-4 20:09Z; recurrence of prior-P0 PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001, PRs #3670–#3674).

### The fix shape (chokepoint, not per-site patches)
- **FR-1** `lib/worktree-reaper/residency-guard.js`: residency = acting-process **cwd containment** (sync — binds DEFAULT-ON inside `removeWorktreeViaGit`, the chokepoint every production delete funnels through) OR **fresh-heartbeat `claude_sessions.worktree_path` match** (async, for the scheduled removers). Fail-closed (`REAP_RESIDENCY_UNKNOWN`); freshness reuses the session-liveness SSOT (300s); `WORKTREE_RESIDENCY_GUARD=off` kill-switch for emergency rollback.
- **FR-2** warn-and-proceed is gone: `cleanupCurrentWorktree`'s CWD_INSIDE_TARGET warning branch (which still deleted!) is now a hard refusal; `removeWorktree` (LEAD-FINAL Step 6.5 — previously **zero** residency guard), `cleanupOrphans`, and the cleanup-pending sweep all enforce residency; `blocked` results are never force-deleted around via fs fallbacks.
- **FR-3** out-of-band reap: post-merge flows (`post-merge-worktree-cleanup`, `worktree-merge`) write a durable `.reap-eligible.json` marker (filesystem — **no DDL**, mirroring the proven `cleanup_pending` pattern) instead of deleting in-process.
- **FR-4** the scheduled reaper collects marker-bearing worktrees (stage 1) and its removal gate composes the heartbeat-residency guard beside the existing fail-closed `liveClaimBlocksRemoval`.
- **FR-5** static guard test: any new direct `git worktree remove` execution outside the chokepoint allowlist fails CI — the reason the 2024-era fixes regressed (4+ recurrences) was per-site patching.
- **FR-6** e2e composition test: blocked while a fresh-heartbeat session is resident; collectable after residency clears.

### Verification
- 15 new tests (`worktree-residency-guard.test.js`, `worktree-delete-primitive-static-guard.test.js`), including a real-process `process.chdir` chokepoint block test.
- **350 tests green** across all 32 worktree/reaper/post-merge/shipping consumer suites.
- **Live dry-run** of the patched reaper against the real fleet state: classification intact, active claims protected, no errors.

### Size justification (>100 LOC)
544 insertions across 9 files — a guard-on-every-path safety fix per the SD's explicit enumerate-all-writers scope; splitting writers from the guard would ship windows where some paths remain unguarded (the exact recurrence mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)