### PR TITLE
fix(QF-20260711-503): persist rollup status so a claimable-belt child never false-stalls its parent

### DIFF
--- a/lib/adam/task-ledger.js
+++ b/lib/adam/task-ledger.js
@@ -104,6 +104,65 @@ export function rollupParentStatus(children) {
 }
 
 /**
+ * QF-20260711-503: persist each parent's rolled-up status onto its OWN row. rollupParentStatus()
+ * was previously used ONLY for the board VIEW (adam-pm-board.mjs buildBoardView) — nothing wrote
+ * its result back onto the parent's persisted status column, so a parent could sit at a STALE
+ * status (e.g. 'blocked' from an earlier tick) even once its remaining child was unblocked and
+ * simply claimable on the belt. readCriticalPathParents() (adam-quiet-tick.mjs) derives
+ * inFlightNextStep from that stored column, so the stall-alert escalated a non-stall (live
+ * specimen: node with 6/7 children done, 7th open/claimable, parent still stored 'blocked').
+ * Fail-soft per parent — one row's read/write error must never abort the sync for the rest or
+ * the caller's tick.
+ * @param {object} supabase
+ * @returns {Promise<{checked: number, updated: number, errors: string[]}>}
+ */
+export async function syncParentRollupStatus(supabase) {
+  const result = { checked: 0, updated: 0, errors: [] };
+  try {
+    const { data: parents, error: pErr } = await supabase
+      .from(TABLE)
+      .select('id, status')
+      .eq('tier', 'parent')
+      .in('status', ['open', 'in_progress', 'blocked']);
+    if (pErr) throw pErr;
+    const parentIds = (parents || []).map((p) => p.id);
+    if (!parentIds.length) return result;
+
+    const { data: children, error: cErr } = await supabase
+      .from(TABLE)
+      .select('id, parent_id, status')
+      .eq('tier', 'child')
+      .in('parent_id', parentIds);
+    if (cErr) throw cErr;
+
+    const childrenByParent = new Map();
+    for (const c of children || []) {
+      if (!c.parent_id) continue;
+      if (!childrenByParent.has(c.parent_id)) childrenByParent.set(c.parent_id, []);
+      childrenByParent.get(c.parent_id).push(c);
+    }
+
+    for (const parent of parents) {
+      result.checked++;
+      const kids = childrenByParent.get(parent.id) || [];
+      if (!kids.length) continue; // no children yet -> nothing to roll up, leave status as-is
+      const computed = rollupParentStatus(kids);
+      if (computed !== parent.status) {
+        try {
+          await setStatus(supabase, parent.id, computed);
+          result.updated++;
+        } catch (e) {
+          result.errors.push(`parent ${parent.id}: ${e && e.message}`);
+        }
+      }
+    }
+  } catch (e) {
+    result.errors.push(`sync failed: ${e && e.message}`);
+  }
+  return result;
+}
+
+/**
  * Surface child blockers onto the parent for the chairman-curated view. Returns the ACTIVE child
  * blockers (a truthy blocker on a child that is not done/cancelled). PURE.
  * @param {Array<{id?:string,title?:string,status?:string,blocker?:string}>} children
@@ -133,5 +192,5 @@ export function sumTokenCost(children) {
 export default {
   TABLE, STATUSES, TIERS, SOURCE_KINDS,
   createOrUpsertNode, setStatus, setBlocker,
-  rollupParentStatus, bubbleBlockers, sumTokenCost,
+  rollupParentStatus, bubbleBlockers, sumTokenCost, syncParentRollupStatus,
 };

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -25,7 +25,7 @@ import 'dotenv/config';
 import { rehydrateBoard } from '../lib/adam/task-rehydrate.js';
 import { checkAndAlertStalls } from '../lib/adam/stall-alert.js';
 import { runOutboundSilenceWatchdog } from '../lib/adam/outbound-silence-watchdog.js';
-import { TABLE as TASK_LEDGER_TABLE } from '../lib/adam/task-ledger.js';
+import { TABLE as TASK_LEDGER_TABLE, syncParentRollupStatus } from '../lib/adam/task-ledger.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
@@ -94,14 +94,20 @@ export async function reconcileBoard(sb) {
 
 // FR-2/FR-3 (Child B): critical-path (chairman-parent) task_ledger rows, fail-soft — a read
 // error must never abort the tick. inFlightNextStep is derived from the row's OWN rolled-up
-// status (lib/adam/task-ledger.js rollupParentStatus already writes 'in_progress' onto a parent
-// while any child is still moving): status==='in_progress' -> treated as an intended hold (a
-// known next step is itself progressing) so it never escalates even if this exact row's
-// updated_at hasn't changed this tick; status==='blocked' (or anything else) is a genuine-stall
-// candidate, matching the locked scope's noise-avoidance bias (default to NOT escalating when
-// ambiguous, per stall-detector.js's classifyStaleness contract).
+// status: status==='in_progress' -> treated as an intended hold (a known next step is itself
+// progressing) so it never escalates even if this exact row's updated_at hasn't changed this
+// tick; status==='blocked' (or anything else) is a genuine-stall candidate, matching the locked
+// scope's noise-avoidance bias (default to NOT escalating when ambiguous, per stall-detector.js's
+// classifyStaleness contract).
+// QF-20260711-503: rollupParentStatus() (lib/adam/task-ledger.js) is PURE and was previously
+// used only for the board VIEW (adam-pm-board.mjs) — nothing wrote its result back onto the
+// parent's OWN persisted status column, so this read could see a STALE status (e.g. still
+// 'blocked' from an earlier tick) even once the remaining child was unblocked and simply
+// claimable on the belt, causing a false stall escalation. syncParentRollupStatus() persists
+// the fresh rollup first so this read always reflects current children state.
 export async function readCriticalPathParents(sb) {
   try {
+    await syncParentRollupStatus(sb).catch(() => {}); // fail-soft: a sync error falls through to the pre-fix (possibly stale) read rather than aborting the tick
     // QF-20260703-229: pre-filter to OPEN nodes at the query — a done/cancelled parent has
     // stopped moving BY DEFINITION and is never a stall candidate. source_kind/source_ref are
     // read here too so checkAndAlertStalls can self-heal a sourced_sd node whose linked SD

--- a/tests/unit/adam/adam-quiet-tick-reconcile.test.js
+++ b/tests/unit/adam/adam-quiet-tick-reconcile.test.js
@@ -115,4 +115,40 @@ describe('readCriticalPathParents', () => {
     const sb = { from: () => { throw new Error('boom'); } };
     await expect(readCriticalPathParents(sb)).resolves.toEqual([]);
   });
+
+  it('QF-20260711-503: self-heals a STALE parent status before reading it — 6/7 children done + 1 open no longer false-escalates', async () => {
+    const ledger = [
+      { id: 'p1', title: 'UX remediation', updated_at: 'x', tier: 'parent', status: 'blocked' }, // stale
+      ...Array.from({ length: 6 }, (_, i) => ({ id: `c${i}`, tier: 'child', parent_id: 'p1', status: 'done' })),
+      { id: 'c6', tier: 'child', parent_id: 'p1', status: 'open' }, // remaining child, claimable on the belt
+    ];
+    function filteredSelect() {
+      const filters = [];
+      const b = {
+        select: () => b,
+        eq(col, val) { filters.push((r) => r[col] === val); return b; },
+        in(col, vals) { filters.push((r) => vals.includes(r[col])); return b; },
+        then: (resolve, reject) => Promise.resolve({ data: ledger.filter((r) => filters.every((f) => f(r))), error: null }).then(resolve, reject),
+      };
+      return b;
+    }
+    const sb = {
+      from: (table) => {
+        if (table !== 'adam_task_ledger') throw new Error(`unexpected table: ${table}`);
+        return {
+          ...filteredSelect(),
+          update(patch) {
+            return { eq: (_c, id) => ({ select: () => ({ maybeSingle: async () => {
+              const row = ledger.find((r) => r.id === id);
+              if (row) Object.assign(row, patch);
+              return { data: row ?? null, error: null };
+            } }) }) };
+          },
+        };
+      },
+    };
+    const parents = await readCriticalPathParents(sb);
+    expect(ledger.find((r) => r.id === 'p1').status).toBe('in_progress'); // persisted, not just read
+    expect(parents.find((p) => p.id === 'p1').inFlightNextStep).toBe(true); // stall-alert now sees an intended hold
+  });
 });

--- a/tests/unit/adam/task-ledger.test.js
+++ b/tests/unit/adam/task-ledger.test.js
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createOrUpsertNode, setStatus, setBlocker,
-  rollupParentStatus, bubbleBlockers, sumTokenCost,
+  rollupParentStatus, bubbleBlockers, sumTokenCost, syncParentRollupStatus,
   STATUSES, TIERS, SOURCE_KINDS,
 } from '../../../lib/adam/task-ledger.js';
 
@@ -157,5 +157,94 @@ describe('sumTokenCost (PURE) — coarse per-parent rollup', () => {
     expect(sumTokenCost([{ token_cost: 100 }, { token_cost: 250 }, { token_cost: null }])).toBe(350);
     expect(sumTokenCost([{ token_cost: 100 }, { token_cost: 999, status: 'cancelled' }])).toBe(100);
     expect(sumTokenCost([])).toBe(0);
+  });
+});
+
+/** In-memory adam_task_ledger stub supporting select().eq().in() filter chains + the update path. */
+function makeSyncSupabase(rows) {
+  const ledger = [...rows];
+  function from(table) {
+    if (table !== 'adam_task_ledger') throw new Error(`unexpected table: ${table}`);
+    return {
+      select() {
+        const filters = [];
+        const builder = {
+          eq(col, val) { filters.push((r) => r[col] === val); return builder; },
+          in(col, vals) { filters.push((r) => vals.includes(r[col])); return builder; },
+          then(resolve, reject) {
+            const data = ledger.filter((r) => filters.every((f) => f(r)));
+            return Promise.resolve({ data, error: null }).then(resolve, reject);
+          },
+        };
+        return builder;
+      },
+      update(patch) {
+        return {
+          eq(_col, id) {
+            return {
+              select() {
+                return {
+                  maybeSingle: async () => {
+                    const row = ledger.find((r) => r.id === id);
+                    if (row) Object.assign(row, patch);
+                    return { data: row ?? null, error: null };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+  return { from, _ledger: ledger };
+}
+
+describe('syncParentRollupStatus (QF-20260711-503) — persists the rollup onto the parent row', () => {
+  it('updates a STALE parent status to match its children\'s rollup (6/7 done + 1 open -> in_progress)', async () => {
+    const sb = makeSyncSupabase([
+      { id: 'p1', tier: 'parent', status: 'blocked' }, // stale: should now be in_progress
+      ...Array.from({ length: 6 }, (_, i) => ({ id: `c${i}`, tier: 'child', parent_id: 'p1', status: 'done' })),
+      { id: 'c6', tier: 'child', parent_id: 'p1', status: 'open' }, // remaining child, claimable on the belt
+    ]);
+    const result = await syncParentRollupStatus(sb);
+    expect(result).toMatchObject({ checked: 1, updated: 1, errors: [] });
+    expect(sb._ledger.find((r) => r.id === 'p1').status).toBe('in_progress');
+  });
+
+  it('leaves an already-correct parent status untouched (no spurious update)', async () => {
+    const sb = makeSyncSupabase([
+      { id: 'p1', tier: 'parent', status: 'in_progress' },
+      { id: 'c1', tier: 'child', parent_id: 'p1', status: 'done' },
+      { id: 'c2', tier: 'child', parent_id: 'p1', status: 'open' },
+    ]);
+    const result = await syncParentRollupStatus(sb);
+    expect(result).toMatchObject({ checked: 1, updated: 0, errors: [] });
+    expect(sb._ledger.find((r) => r.id === 'p1').status).toBe('in_progress');
+  });
+
+  it('marks a parent done once every non-cancelled child is done', async () => {
+    const sb = makeSyncSupabase([
+      { id: 'p1', tier: 'parent', status: 'in_progress' },
+      { id: 'c1', tier: 'child', parent_id: 'p1', status: 'done' },
+      { id: 'c2', tier: 'child', parent_id: 'p1', status: 'done' },
+    ]);
+    const result = await syncParentRollupStatus(sb);
+    expect(result.updated).toBe(1);
+    expect(sb._ledger.find((r) => r.id === 'p1').status).toBe('done');
+  });
+
+  it('skips a parent with no children (nothing to roll up, status left as-is)', async () => {
+    const sb = makeSyncSupabase([{ id: 'p1', tier: 'parent', status: 'open' }]);
+    const result = await syncParentRollupStatus(sb);
+    expect(result).toMatchObject({ checked: 1, updated: 0, errors: [] });
+  });
+
+  it('is fail-soft: a throwing client returns a zeroed result, never throws', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    const result = await syncParentRollupStatus(sb);
+    expect(result.checked).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- `rollupParentStatus()` (`lib/adam/task-ledger.js`) is a pure derivation used only by the board VIEW (`adam-pm-board.mjs` `buildBoardView`) — nothing ever wrote its computed status back onto the parent's own `adam_task_ledger` row.
- `readCriticalPathParents()` (`scripts/adam-quiet-tick.mjs`) reads that persisted column directly to derive `inFlightNextStep`, so a parent could sit at a **stale** status (e.g. still `'blocked'` from an earlier tick) even once its remaining child was unblocked and simply claimable on the belt — causing the stall-alert to escalate a non-stall. Live specimen: node 92d34a13, 6/7 children done, 7th open/claimable, parent still stored `'blocked'` → paged the chairman twice in one day for the same non-stall.
- Adds `syncParentRollupStatus()`: re-derives and persists each non-terminal parent's rollup from its current children before the stall check reads it. Fail-soft per parent and at the call site — a sync error falls through to the pre-fix (possibly stale) read rather than aborting the tick.

## Scope boundary (documented, not silently dropped)
The QF also asked for a disposition-feedback dismiss-suppression that re-arms only on material change (status/blocker delta), replacing the current fixed 15-minute cooldown (`findRecentlyDismissedStallDigest` in `lib/adam/stall-alert.js`). **Not attempted here** — this fix addresses the concrete, root-cause bug the reported incident traces to (structurally prevents recurrence for this exact class, since the parent's `inFlightNextStep` will now correctly read `true` going forward), while the cooldown redesign is a separate, distinct hardening deserving its own pass.

## Test plan
- [x] `npx vitest run tests/unit/adam/task-ledger.test.js` — 19/19 passed (5 new `syncParentRollupStatus` cases: stale-parent-corrected, already-correct-untouched, all-done, no-children-skip, fail-soft)
- [x] `npx vitest run tests/unit/adam/adam-quiet-tick-reconcile.test.js` — 6/6 passed (new end-to-end test reproduces the exact 6/7-done+1-open specimen and proves the parent status is persisted, not just read, before the stall check)
- [x] `npx vitest run tests/unit/adam/` — full module suite, 301/301 passed, no regressions

QF-20260711-503

🤖 Generated with [Claude Code](https://claude.com/claude-code)