### PR TITLE
feat(SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001): env-first claim identity — mismatch guard + audited pointer fallback

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -654,7 +654,7 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
   }
 
   // Fail-soft boundary instrumentation (SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3)
-  await stampClaim(supabase, sdKey, sessionId);
+  await stampClaim(supabase, sdKey, sessionId, process.env.CLAUDE_SESSION_ID === sessionId ? 'env' : 'pointer_fallback'); // SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001: provenance stamped on every claim_sd path
 
   // Post-acquisition verification: read back to confirm we actually own the claim
   const verification = await verifyClaimOwnership(sdKey, sessionId);

--- a/lib/claim/claim-identity.js
+++ b/lib/claim/claim-identity.js
@@ -1,0 +1,65 @@
+// Claim-identity resolver — SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001 (FR-1).
+//
+// Claim identity is the spine of fleet accounting (liveness, displacement,
+// revival targeting, the fence predicate all key on claiming_session_id), so a
+// claim must ALWAYS carry the acting session's env identity when one exists.
+// The live defect: under 8+ concurrent sessions in the shared root, the shared
+// pointer file is last-writer-wins — identity derived from it attributed one
+// session's claim to a DIFFERENT live session (coordinator ask 5655cb68;
+// witnessed twice more while building this fix).
+//
+// Precedence (explicit-never-silent):
+//   1. CLAUDE_SESSION_ID env — per-process, race-free. source: 'env'.
+//   2. Shared pointer (.claude/session-identity/current) ONLY when env is
+//      absent — LOUD (console.warn) and audited: callers must stamp
+//      identity_source on the claim so misattribution is queryable.
+//      source: 'pointer_fallback'.
+//   3. Neither -> { sessionId: null, source: 'none' } — the caller decides
+//      whether to fail or register a fresh identity; this module never guesses.
+
+import { readCurrentPointer } from '../session-identity-sot.js';
+
+/**
+ * @param {object} [env=process.env]
+ * @param {{repoRoot?: string, warn?: (msg: string) => void}} [opts]
+ * @returns {{sessionId: string|null, source: 'env'|'pointer_fallback'|'none'}}
+ */
+export function resolveClaimIdentity(env = process.env, opts = {}) {
+  const warn = opts.warn ?? console.warn;
+  const envId = typeof env?.CLAUDE_SESSION_ID === 'string' && env.CLAUDE_SESSION_ID.trim().length > 0
+    ? env.CLAUDE_SESSION_ID.trim()
+    : null;
+  if (envId) return { sessionId: envId, source: 'env' };
+
+  let pointerId = null;
+  try {
+    pointerId = readCurrentPointer(opts.repoRoot) || null;
+  } catch {
+    pointerId = null;
+  }
+  if (pointerId) {
+    warn(`[claim-identity] CLAUDE_SESSION_ID absent — falling back to the SHARED pointer (${pointerId}). ` +
+      'This is last-writer-wins under concurrency; the claim will be stamped identity_source=pointer_fallback.');
+    return { sessionId: pointerId, source: 'pointer_fallback' };
+  }
+  return { sessionId: null, source: 'none' };
+}
+
+/**
+ * FR-2 guard predicate: does an adopted session row CONTRADICT the caller's
+ * env identity? Contradiction only — absence of env identity is not a
+ * conflict (pointer/registered flows stay valid for env-less human runs).
+ *
+ * @param {{session_id?: string}|null} sessionRow
+ * @param {{sessionId: string|null, source: string}} identity - resolveClaimIdentity() result
+ * @returns {{mismatch: boolean, envId?: string, adoptedId?: string}}
+ */
+export function checkIdentityMismatch(sessionRow, identity) {
+  if (!sessionRow?.session_id || identity.source !== 'env' || !identity.sessionId) {
+    return { mismatch: false };
+  }
+  if (sessionRow.session_id === identity.sessionId) return { mismatch: false };
+  return { mismatch: true, envId: identity.sessionId, adoptedId: sessionRow.session_id };
+}
+
+export default { resolveClaimIdentity, checkIdentityMismatch };

--- a/lib/fleet/claim-stamp.cjs
+++ b/lib/fleet/claim-stamp.cjs
@@ -36,16 +36,22 @@ async function readSd(supabase, sdRef) {
 }
 
 /**
- * Append { session_id, claimed_at } to metadata.claim_history (FIFO cap 20)
- * after a successful claim_sd. Fail-soft: returns the appended entry or null.
+ * Append { session_id, claimed_at[, identity_source] } to metadata.claim_history
+ * (FIFO cap 20) after a successful claim_sd. Fail-soft: returns the appended
+ * entry or null. identity_source (SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001):
+ * 'env' | 'pointer_fallback' from lib/claim/claim-identity.js — makes
+ * pointer-derived (misattribution-prone) claims queryable, never silent.
  */
-async function stampClaim(supabase, sdRef, sessionId) {
+async function stampClaim(supabase, sdRef, sessionId, identitySource) {
   try {
     if (!supabase || !sdRef || !sessionId) return null;
     const row = await readSd(supabase, sdRef);
     if (!row) return null;
     const md = row.metadata && typeof row.metadata === 'object' ? row.metadata : {};
     const entry = { session_id: sessionId, claimed_at: new Date().toISOString() };
+    if (typeof identitySource === 'string' && identitySource.length > 0) {
+      entry.identity_source = identitySource;
+    }
     const history = Array.isArray(md.claim_history) ? md.claim_history : [];
     history.push(entry);
     md.claim_history = history.slice(-CLAIM_HISTORY_CAP);

--- a/lib/session-conflict-checker.mjs
+++ b/lib/session-conflict-checker.mjs
@@ -314,7 +314,7 @@ export async function claimSD(sdId, sessionId) {
 
   if (!data || data.success !== false) {
     // Fail-soft boundary instrumentation (SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3)
-    await stampClaim(supabase, sdId, sessionId);
+    await stampClaim(supabase, sdId, sessionId, process.env.CLAUDE_SESSION_ID === sessionId ? 'env' : 'pointer_fallback'); // SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001: provenance stamped on every claim_sd path
   }
 
   return {

--- a/scripts/audit-claim-attribution.mjs
+++ b/scripts/audit-claim-attribution.mjs
@@ -54,7 +54,7 @@ for (const sd of sds ?? []) {
     // A hand-off is plausible when the prior session is gone/released; two
     // sessions that BOTH remain known-live interleaving on one SD is the
     // anomaly class (misattribution or churn).
-    const prevGone = !prevSession || prevSession.status !== 'active';
+    const prevGone = !prevSession || !['active', 'idle'].includes(prevSession.status); // 'idle' is a LIVE status (adversarial review): treating it as gone silently zeroed the interleave-anomaly class
     transitions.push({
       at: cur.claimed_at,
       from: prev.session_id,
@@ -81,7 +81,7 @@ const summary = {
   anomaly_transitions: findings.reduce((n, f) => n + f.transitions.filter((t) => t.verdict === 'ANOMALY_live_interleave').length, 0),
   reroute_transitions: findings.reduce((n, f) => n + f.transitions.filter((t) => t.verdict === 'plausible_reroute').length, 0),
   cases: findings,
-  method: 'claim_history transitions cross-referenced against claude_sessions status; ANOMALY = distinct-session transition while the prior session row is still active',
+  method: 'claim_history transitions cross-referenced against claude_sessions status; ANOMALY = distinct-session transition while the prior session row is still live (active or idle)',
 };
 
 console.log(`Claim-attribution audit for ${DAY}:`);

--- a/scripts/audit-claim-attribution.mjs
+++ b/scripts/audit-claim-attribution.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Retro-audit of claim-attribution anomalies — SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001 (FR-5).
+//
+// Enumerates claim_history entries for a given UTC day across
+// strategic_directives_v2, groups multi-claim SDs, and classifies each
+// transition: same-session re-affirm | plausible re-route (prior session dead
+// at hand-off) | ANOMALY (two live sessions interleaving on one SD — the
+// misattribution / churn class this SD fixes). Findings are attached to this
+// SD's metadata.claim_attribution_audit for the coordinator.
+//
+// Usage: node scripts/audit-claim-attribution.mjs [--day 2026-07-11] [--dry-run]
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SELF_SD_KEY = 'SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001';
+const dayArgIdx = process.argv.indexOf('--day');
+const DAY = dayArgIdx !== -1 ? process.argv[dayArgIdx + 1] : new Date().toISOString().slice(0, 10);
+const dryRun = process.argv.includes('--dry-run');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const { data: sds, error } = await supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, metadata')
+  .not('metadata->claim_history', 'is', null);
+if (error) { console.error(`audit: SD query failed: ${error.message}`); process.exit(1); }
+
+const { data: sessions, error: sErr } = await supabase
+  .from('claude_sessions')
+  .select('session_id, terminal_id, status, heartbeat_at, released_reason');
+if (sErr) { console.error(`audit: sessions query failed: ${sErr.message}`); process.exit(1); }
+const sessionById = new Map((sessions ?? []).map((s) => [s.session_id, s]));
+
+const findings = [];
+for (const sd of sds ?? []) {
+  const dayEntries = (sd.metadata?.claim_history ?? [])
+    .filter((e) => typeof e?.claimed_at === 'string' && e.claimed_at.startsWith(DAY))
+    .sort((a, b) => a.claimed_at.localeCompare(b.claimed_at));
+  if (dayEntries.length < 2) continue;
+
+  const transitions = [];
+  for (let i = 1; i < dayEntries.length; i++) {
+    const prev = dayEntries[i - 1];
+    const cur = dayEntries[i];
+    if (prev.session_id === cur.session_id) {
+      transitions.push({ at: cur.claimed_at, verdict: 'same_session_reaffirm' });
+      continue;
+    }
+    const prevSession = sessionById.get(prev.session_id);
+    // A hand-off is plausible when the prior session is gone/released; two
+    // sessions that BOTH remain known-live interleaving on one SD is the
+    // anomaly class (misattribution or churn).
+    const prevGone = !prevSession || prevSession.status !== 'active';
+    transitions.push({
+      at: cur.claimed_at,
+      from: prev.session_id,
+      to: cur.session_id,
+      prior_session_state: prevSession ? `${prevSession.status}${prevSession.released_reason ? ':' + prevSession.released_reason : ''}` : 'unknown_row',
+      verdict: prevGone ? 'plausible_reroute' : 'ANOMALY_live_interleave',
+    });
+  }
+  const anomalies = transitions.filter((t) => t.verdict === 'ANOMALY_live_interleave');
+  const reroutes = transitions.filter((t) => t.verdict === 'plausible_reroute');
+  if (anomalies.length || reroutes.length >= 2) {
+    findings.push({
+      sd_key: sd.sd_key,
+      day_claims: dayEntries.length,
+      distinct_sessions: [...new Set(dayEntries.map((e) => e.session_id))].length,
+      transitions,
+    });
+  }
+}
+
+const summary = {
+  day: DAY,
+  sds_with_multi_claims: findings.length,
+  anomaly_transitions: findings.reduce((n, f) => n + f.transitions.filter((t) => t.verdict === 'ANOMALY_live_interleave').length, 0),
+  reroute_transitions: findings.reduce((n, f) => n + f.transitions.filter((t) => t.verdict === 'plausible_reroute').length, 0),
+  cases: findings,
+  method: 'claim_history transitions cross-referenced against claude_sessions status; ANOMALY = distinct-session transition while the prior session row is still active',
+};
+
+console.log(`Claim-attribution audit for ${DAY}:`);
+console.log(`  multi-claim SDs flagged: ${summary.sds_with_multi_claims}`);
+console.log(`  ANOMALY (live interleave) transitions: ${summary.anomaly_transitions}`);
+console.log(`  plausible re-routes: ${summary.reroute_transitions}`);
+for (const f of findings) {
+  console.log(`  - ${f.sd_key}: ${f.day_claims} claims / ${f.distinct_sessions} sessions`);
+  for (const t of f.transitions.filter((t) => t.verdict !== 'same_session_reaffirm')) {
+    console.log(`      ${t.at} ${t.from} -> ${t.to} [${t.verdict}] prior=${t.prior_session_state}`);
+  }
+}
+
+if (!dryRun) {
+  const { data: selfSd, error: selfErr } = await supabase
+    .from('strategic_directives_v2').select('id, metadata').eq('sd_key', SELF_SD_KEY).single();
+  if (selfErr || !selfSd?.id) { console.error(`audit: could not load ${SELF_SD_KEY} — findings not attached`); process.exit(1); }
+  const { error: wErr } = await supabase
+    .from('strategic_directives_v2')
+    .update({ metadata: { ...(selfSd.metadata ?? {}), claim_attribution_audit: summary } })
+    .eq('id', selfSd.id);
+  if (wErr) { console.error(`audit: attach failed: ${wErr.message}`); process.exit(1); }
+  console.log(`\nFindings attached to ${SELF_SD_KEY} (metadata.claim_attribution_audit).`);
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -33,6 +33,7 @@ import { assertValidClaim, ClaimIdentityError } from '../lib/claim-validity-gate
 import { hasRecentClaimReleased, formatClaimReleasedAbort, detectSdKeyDrift } from '../lib/claim-lifecycle-release.mjs';
 import sessionIdentitySot from '../lib/session-identity-sot.js';
 import { findClaudeCodePid } from '../lib/terminal-identity.js';
+import { resolveClaimIdentity, checkIdentityMismatch } from '../lib/claim/claim-identity.js';
 import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
 import { checkClaimGateFreshness } from '../lib/claim/gate-freshness-check.mjs';
 // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — pre-claim multi-signal evidence-of-life gate.
@@ -812,6 +813,25 @@ async function main() {
     session = await getOrCreateSession();
   }
 
+  // SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001 (FR-2): identity-mismatch guard.
+  // getOrCreateSession's findExistingSession matches by getTerminalId(), whose
+  // marker/pointer fallback is last-writer-wins under concurrency — it can adopt
+  // ANOTHER live session's identity and misattribute the claim (live-evidenced:
+  // env=e2f6eecc claimed as e828c687, coordinator ask 5655cb68). A session that
+  // CONTRADICTS the caller's env identity is never used for a claim — fail loud,
+  // never misattribute. Absence of env identity is NOT a conflict (human runs).
+  const claimIdentity = resolveClaimIdentity();
+  const idCheck = checkIdentityMismatch(session, claimIdentity);
+  if (idCheck.mismatch) {
+    console.error(`${colors.red}🚫 CLAIM-IDENTITY MISMATCH — refusing to claim under an adopted identity${colors.reset}`);
+    console.error(`   env CLAUDE_SESSION_ID: ${idCheck.envId}`);
+    console.error(`   adopted session row:   ${idCheck.adoptedId}`);
+    console.error('   The adopted row belongs to a DIFFERENT session (shared-pointer race).');
+    console.error('   Remediation: ensure this session has its own claude_sessions row');
+    console.error('   (SessionStart session-register hook), then re-run sd-start.');
+    process.exit(1);
+  }
+
   // 2.1 SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-B (FR-1, TR-1, TR-2):
   // Atomically reconcile the three identity sources so claim-validity-gate sees
   // all three in agreement. No-op when SESSION_IDENTITY_SOT_ENABLED is unset/false.
@@ -1444,6 +1464,16 @@ async function main() {
   } catch (e) {
     // Non-fatal: health check failure should not block claiming
     console.debug('[sd-start] Health check error:', e?.message || e);
+  }
+
+  // SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001 (FR-2): stamp identity provenance on
+  // the claim_history entry (fail-soft) — 'env' vs 'pointer_fallback' makes
+  // misattribution-prone claims queryable for the retro-audit / coordinator sweeps.
+  if (claimResult.claim.status === 'newly_acquired') {
+    try {
+      const { stampClaim } = await import('../lib/fleet/claim-stamp.cjs').then((m) => m.default || m);
+      await stampClaim(supabase, effectiveId, session.session_id, claimIdentity.source);
+    } catch { /* fail-soft: stamping must never break the claim path */ }
   }
 
   // 5. Display SD info

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -353,7 +353,7 @@ async function tryClaim(sb, sdKey, sessionId, track) {
     const { data, error } = await sb.rpc('claim_sd', { p_sd_id: sdKey, p_session_id: sessionId, p_track });
     if (error) return { ok: false, error: error.message };
     if (data && data.success === false) return { ok: false, error: data.error || 'claim_rejected', owner: data.claimed_by };
-    await stampClaim(sb, sdKey, sessionId); // fail-soft boundary instrumentation (SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3)
+    await stampClaim(sb, sdKey, sessionId, 'env'); // fail-soft boundary instrumentation (SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3); identity always env here (hard-required at entry) — SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e.message };

--- a/tests/unit/claim-identity.test.js
+++ b/tests/unit/claim-identity.test.js
@@ -1,0 +1,141 @@
+/**
+ * Claim-identity integrity — SD-LEO-INFRA-CLAIM-IDENTITY-INTEGRITY-001.
+ * TS-1 resolver precedence, TS-2 mismatch guard, TS-3 concurrency e2e
+ * (N pairs of child processes, distinct env, shared root + pointer churn),
+ * TS-4 identity_source stamping.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const RESOLVER_URL = pathToFileURL(path.resolve('lib/claim/claim-identity.js')).href;
+const fwd = (p) => p.replace(/\\/g, '/');
+import { resolveClaimIdentity, checkIdentityMismatch } from '../../lib/claim/claim-identity.js';
+import { stampClaim } from '../../lib/fleet/claim-stamp.cjs';
+
+const execFileP = promisify(execFile);
+
+/** Build a temp repo root carrying a pointer file with the given session id. */
+function tmpRootWithPointer(pointerId) {
+  const root = mkdtempSync(path.join(tmpdir(), 'claim-id-'));
+  const dir = path.join(root, '.claude', 'session-identity');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'current'), JSON.stringify({ session_id: pointerId }));
+  return root;
+}
+
+describe('resolveClaimIdentity (TS-1)', () => {
+  it('env wins with source env; pointer never consulted', () => {
+    const root = tmpRootWithPointer('pointer-session');
+    const r = resolveClaimIdentity({ CLAUDE_SESSION_ID: 'env-session' }, { repoRoot: root, warn: vi.fn() });
+    expect(r).toEqual({ sessionId: 'env-session', source: 'env' });
+  });
+
+  it('env absent falls back to pointer LOUDLY with source pointer_fallback', () => {
+    const root = tmpRootWithPointer('pointer-session');
+    const warn = vi.fn();
+    const r = resolveClaimIdentity({}, { repoRoot: root, warn });
+    expect(r.source).toBe('pointer_fallback');
+    expect(r.sessionId).toBe('pointer-session');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('neither -> null with source none', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'claim-id-empty-'));
+    const r = resolveClaimIdentity({}, { repoRoot: root, warn: vi.fn() });
+    expect(r).toEqual({ sessionId: null, source: 'none' });
+  });
+
+  it('whitespace-only env is treated as absent', () => {
+    const root = tmpRootWithPointer('pointer-session');
+    const r = resolveClaimIdentity({ CLAUDE_SESSION_ID: '   ' }, { repoRoot: root, warn: vi.fn() });
+    expect(r.source).toBe('pointer_fallback');
+  });
+});
+
+describe('checkIdentityMismatch (TS-2 guard predicate)', () => {
+  const envIdentity = { sessionId: 'env-a', source: 'env' };
+
+  it('contradiction -> mismatch with both identities named', () => {
+    expect(checkIdentityMismatch({ session_id: 'other-b' }, envIdentity))
+      .toEqual({ mismatch: true, envId: 'env-a', adoptedId: 'other-b' });
+  });
+
+  it('agreement -> no mismatch', () => {
+    expect(checkIdentityMismatch({ session_id: 'env-a' }, envIdentity).mismatch).toBe(false);
+  });
+
+  it('absence of env identity is NOT a conflict (human/pointer runs stay valid)', () => {
+    expect(checkIdentityMismatch({ session_id: 'x' }, { sessionId: 'p', source: 'pointer_fallback' }).mismatch).toBe(false);
+    expect(checkIdentityMismatch({ session_id: 'x' }, { sessionId: null, source: 'none' }).mismatch).toBe(false);
+    expect(checkIdentityMismatch(null, envIdentity).mismatch).toBe(false);
+  });
+});
+
+describe('stampClaim identity_source (TS-4)', () => {
+  function mockSupabase(store) {
+    return {
+      from: () => ({
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'u1', metadata: store.metadata }, error: null }) }) }),
+        update: (patch) => ({ eq: async () => { store.metadata = patch.metadata; return { error: null }; } }),
+      }),
+    };
+  }
+
+  it('stamps identity_source when provided and omits it when not', async () => {
+    const store = { metadata: {} };
+    await stampClaim(mockSupabase(store), 'SD-X-001', 'sess-1', 'pointer_fallback');
+    expect(store.metadata.claim_history.at(-1)).toMatchObject({ session_id: 'sess-1', identity_source: 'pointer_fallback' });
+    await stampClaim(mockSupabase(store), 'SD-X-001', 'sess-2');
+    expect(store.metadata.claim_history.at(-1).identity_source).toBeUndefined();
+  });
+});
+
+describe('concurrency e2e (TS-3 / FR-4): env always wins under shared-pointer churn', () => {
+  it('N=12 concurrent children with distinct env each resolve their OWN identity — zero cross-adoption', async () => {
+    const root = tmpRootWithPointer('initial-pointer');
+    const pointerPath = path.join(root, '.claude', 'session-identity', 'current');
+    // Child: churns the shared pointer (last-writer-wins simulation), then resolves.
+    const childScript = `
+      import { writeFileSync } from 'node:fs';
+      import { resolveClaimIdentity } from ${JSON.stringify(RESOLVER_URL)};
+      const me = process.env.CLAUDE_SESSION_ID;
+      for (let i = 0; i < 20; i++) writeFileSync(${JSON.stringify(fwd(pointerPath))}, JSON.stringify({ session_id: me + '-pointer-' + i }));
+      const r = resolveClaimIdentity(process.env, { repoRoot: ${JSON.stringify(fwd(root))}, warn: () => {} });
+      console.log(JSON.stringify(r));
+    `;
+    const runChild = (id) => execFileP(process.execPath, ['--input-type=module', '-e', childScript], {
+      cwd: root,
+      env: { ...process.env, CLAUDE_SESSION_ID: id },
+    }).then(({ stdout }) => JSON.parse(stdout.trim().split('\n').at(-1)));
+
+    const pairs = [];
+    for (let n = 0; n < 6; n++) pairs.push([`sess-A-${n}`, `sess-B-${n}`]);
+    const results = await Promise.all(pairs.flat().map((id) => runChild(id).then((r) => ({ id, r }))));
+
+    for (const { id, r } of results) {
+      expect(r.source).toBe('env');
+      expect(r.sessionId).toBe(id); // zero cross-adoption
+    }
+  }, 60_000);
+
+  it('negative: env-unset child resolves the pointer loudly', async () => {
+    const root = tmpRootWithPointer('shared-pointer-x');
+    const childScript = `
+      import { resolveClaimIdentity } from ${JSON.stringify(RESOLVER_URL)};
+      const r = resolveClaimIdentity(process.env, { repoRoot: ${JSON.stringify(fwd(root))} });
+      console.log(JSON.stringify(r));
+    `;
+    const env = { ...process.env };
+    delete env.CLAUDE_SESSION_ID;
+    const { stdout, stderr } = await execFileP(process.execPath, ['--input-type=module', '-e', childScript], { cwd: root, env });
+    const r = JSON.parse(stdout.trim().split('\n').at(-1));
+    expect(r).toEqual({ sessionId: 'shared-pointer-x', source: 'pointer_fallback' });
+    expect(stderr).toContain('pointer_fallback');
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
Fixes claim-identity misattribution under concurrent sessions (coordinator ask 5655cb68; the defect struck this SD itself 3× during its own build). Root cause: sd-start's `getOrCreateSession` fallback adopts identities via `getTerminalId()`'s shared marker/pointer — last-writer-wins under 8+ shared-root sessions.

- **`lib/claim/claim-identity.js`** (new): `resolveClaimIdentity` — env FIRST; shared pointer only as a **loud, stamped** fallback; `checkIdentityMismatch` guard predicate (contradiction-only — env-less human runs unaffected).
- **sd-start**: a session contradicting the caller's env identity can NEVER claim (hard error naming both identities + remediation); `claim_history` entries now carry `identity_source`.
- **Site map** (FR-3): worker-checkin = env hard-required (stamped); create-quick-fix & claim-orchestrator-for-rollup = already env-first; sd-start was the sole vulnerable writer — now guarded.
- **Retro-audit** (`scripts/audit-claim-attribution.mjs`) ran live for 2026-07-11: 2 multi-claim SDs, 6 cross-session transitions including the 5-claim dispatch-auth churn chain; findings attached to SD metadata. Known limitation noted: prior-session rows resolve `unknown_row` for conversation-UUID identities, so live-interleave verdicts are conservative.

## Test plan
- [x] 10 tests green, including the **concurrency e2e**: 12 concurrent child processes with distinct `CLAUDE_SESSION_ID` from one shared root under active pointer churn — **zero cross-adoptions**
- [x] Negative case: env-unset child resolves pointer with loud `pointer_fallback`
- [x] Mismatch guard unit-tested (contradiction blocks; agreement/absence pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)