### PR TITLE
fix(QF-20260705-893): apply the never-applied brainstorm-distillation migration

### DIFF
--- a/database/migrations/20260623_eva_consultant_recommendations_distillation_queue.sql
+++ b/database/migrations/20260623_eva_consultant_recommendations_distillation_queue.sql
@@ -15,11 +15,12 @@
 --   * confidence_tier      -> ALREADY EXISTS (text). The ADD COLUMN IF NOT EXISTS is an explicit,
 --                             idempotent no-op kept here only to make the queue contract complete.
 --
--- DORMANT: the fleet AUTHORS and TESTS this migration; workers CANNOT self-apply prod. This is an
--- ADDITIVE, nullable change — Adam applies it via the database-agent under the chairman's additive-DDL
--- delegation. It is NOT chairman-gated (an additive nullable column needs no RLS policy). Until applied,
--- the queue writer cannot run (its insert surfaces the missing-column error rather than swallowing it) —
--- so the distiller child (idx 2) that calls the writer is sequenced AFTER this migration is applied.
+-- APPLIED 2026-07-11 (QF-20260705-893) via the chairman 3-factor --prod-deploy path (not the
+-- automated additive-DDL delegation — isDelegatableAdditive() classifies this file NOT delegatable
+-- because source_wave_item_id carries a REFERENCES clause; Rule C in
+-- scripts/lib/migration-tier-classifier.mjs deliberately excludes FK-bearing ADD COLUMN from the
+-- automated path by design). source_wave_item_id + distilled_sd_payload columns are now live —
+-- the distiller child (idx 2) writer can run.
 --
 -- Idempotent (IF NOT EXISTS) so a re-run is a no-op.
 


### PR DESCRIPTION
## Summary
- Applies the authored-but-never-applied `20260623_eva_consultant_recommendations_distillation_queue.sql` migration via the chairman 3-factor `--prod-deploy` path — `eva_consultant_recommendations` was missing `source_wave_item_id` + `distilled_sd_payload`, blocking the distillation queue substrate.
- Updated the migration's stale `DORMANT` header comment to reflect that it's now applied.

## Test plan
- [x] Live production verification: `source_wave_item_id`, `distilled_sd_payload`, `confidence_tier` all queryable on `eva_consultant_recommendations`
- [x] Idempotent (`IF NOT EXISTS`) — safe to re-run
- [x] No live distillation row yet (expected — the distiller child idx 2 writer hasn't run; that's separate downstream orchestrator work, out of this QF's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)