### PR TITLE
fix(QF-20260711-937): fence the claimGuard acquire lane (6th fence-bypass call site — orchestrator-children/handoff claims)

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -35,6 +35,12 @@ import os from 'os';
 // stampBranch keeps current_branch fresh on heartbeat writes — see
 // lib/session-writer.cjs and SD-LEO-INFRA-SESSION-CURRENT-BRANCH-001.
 const { stampBranch } = createRequire(import.meta.url)('./session-writer.cjs');
+// QF-20260711-937: coordinator-authority fence at THIS claim-write boundary too. claimGuard is
+// the acquire path for handoff.js (BaseExecutor._claimSDForSession) — the orchestrator-children
+// lane: a worker running the handoff chain on a child key claims it here without ever passing
+// belt/checkin/sd-start eligibility. Sixth fence-bypass call site (after QF-272's three,
+// displacement, sd-start-identity).
+const { liveClaimWriteFenceReason } = createRequire(import.meta.url)('./fleet/claim-eligibility.cjs');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -609,6 +615,18 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
   }
 
   // Case 3: No active claim (or stale claims released) → Acquire
+  // QF-20260711-937: live fence re-check at THIS write boundary (same predicate as QF-272's
+  // three lanes). Binds only the ACQUIRE — an existing self-owned claim above proceeds
+  // unchanged. FAIL-CLOSED: 'eligibility_check_error' refuses the claim.
+  const fenceReason = await liveClaimWriteFenceReason(supabase, sdKey);
+  if (fenceReason) {
+    return {
+      success: false,
+      error: `claim_write_fence:${fenceReason}`,
+      fence: fenceReason
+    };
+  }
+
   const { data: sdData } = await supabase
     .from('sd_baseline_items')
     .select('track')
@@ -688,6 +706,22 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
  */
 export function formatClaimFailure(result) {
   if (result.success) return '';
+
+  // QF-20260711-937: coordinator-authority fence refusal — name the fence, not a claim conflict.
+  if (result.fence || /^claim_write_fence:/.test(result.error || '')) {
+    const fence = result.fence || String(result.error).replace(/^claim_write_fence:/, '');
+    return [
+      '╔══════════════════════════════════════════════════════════╗',
+      '║  CLAIM GUARD: COORDINATOR-AUTHORITY FENCE — CANNOT CLAIM ║',
+      '╚══════════════════════════════════════════════════════════╝',
+      `  Fence:     ${fence}`,
+      '',
+      '  This SD is fenced at the claim-write boundary. Only coordinator/human',
+      '  authority clears it (e.g. clear-coordinator-review, flag removal,',
+      '  not_before expiry). Do NOT work this SD; pick another.',
+      '',
+    ].join('\n');
+  }
 
   // FR-1 (SD-LEO-INFRA-SHIP-UNMERGED-LAYERS-001): distinct banner for a cancelled-SD
   // refusal — this is NOT a foreign-claim conflict, so the message must differ.

--- a/tests/unit/claim-write-fence.test.js
+++ b/tests/unit/claim-write-fence.test.js
@@ -13,8 +13,12 @@
  */
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const {
   liveClaimWriteFenceReason,
   CLAIM_WRITE_FENCE_AXES,
@@ -71,5 +75,29 @@ describe('liveClaimWriteFenceReason (QF-20260711-272)', () => {
   it('fails CLOSED on a thrown fault', async () => {
     const sb = { from: () => { throw new Error('boom'); } };
     expect(await liveClaimWriteFenceReason(sb, 'SD-THROW-001')).toBe('eligibility_check_error');
+  });
+});
+
+describe('claimGuard acquire lane consults the fence (QF-20260711-937 — orchestrator-children / handoff lane)', () => {
+  const src = readFileSync(path.resolve(__dirname, '../../lib/claim-guard.mjs'), 'utf8');
+
+  it('imports the shared predicate (no hand-rolled fence re-implementation)', () => {
+    expect(src).toContain("liveClaimWriteFenceReason");
+    expect(src).toContain("./fleet/claim-eligibility.cjs");
+  });
+
+  it('consults the fence BEFORE the acquire claim_sd RPC (Case 3), refusing with the fence named', () => {
+    const caseThree = src.indexOf('// Case 3: No active claim');
+    expect(caseThree).toBeGreaterThan(-1);
+    const fenceCall = src.indexOf('await liveClaimWriteFenceReason(supabase, sdKey)', caseThree);
+    const acquireRpc = src.indexOf("rpc('claim_sd'", caseThree);
+    expect(fenceCall).toBeGreaterThan(-1);
+    expect(acquireRpc).toBeGreaterThan(-1);
+    expect(fenceCall).toBeLessThan(acquireRpc);
+    expect(src).toContain('claim_write_fence:${fenceReason}');
+  });
+
+  it('formatClaimFailure names the fence instead of reporting a claim conflict', () => {
+    expect(src).toContain('COORDINATOR-AUTHORITY FENCE');
   });
 });


### PR DESCRIPTION
## Summary
QF-20260711-937 (coordinator-sourced, high). SPINE children B and D were claimed at LEAD despite `needs_coordinator_review=true`.

**Lane located (ground-truthed against live claims)**: `handoff.js execute` → `BaseExecutor._claimSDForSession` Step 2 (no existing claim) → `claimGuard` → `claim_sd` RPC. Neither `claimGuard` nor `canClaimSd` consults any eligibility fence — so a worker driving an orchestrator child's handoff chain directly (the child-dispatch pattern) claims a fenced child at the write boundary. Sixth distinct call site in the fence-bypass family after QF-272's three (checkin resume_final, belt self-claim race, sd-start fallback), displacement, and sd-start-identity.

## Fix
- `claimGuard` Case 3 (acquire) consults the **shared** `liveClaimWriteFenceReason` predicate (QF-272) immediately before the `claim_sd` RPC. Refusal: `claim_write_fence:<reason>` with `fence` field; fail-closed on `eligibility_check_error`. Case 1/2 (existing self-owned claim) proceed unchanged — the fence binds claim WRITES only, per QF-272 semantics.
- `formatClaimFailure` names the fence with a distinct COORDINATOR-AUTHORITY FENCE banner (not a claim-conflict message).
- `tests/unit/claim-write-fence.test.js` extends with a lane pin: shared-predicate import (no hand-rolled re-implementation), fence consult ordered BEFORE the acquire RPC, named refusal string, banner present.

Interim coordinator mitigation (PLAN→EXEC boundary-hold) becomes defense-in-depth rather than the only line.

## Verification
- `claim-write-fence` + `claim-guard-gate-version-stamp` + `qf-claim-routing`: 20/20 pass
- `claim-eligibility` / `needs-coordinator-review-hold` / `claim-eligibility-all-match`: 46/46 pass
- `lib/claim-guard.mjs` smoke-imports cleanly (ESM↔CJS via createRequire, same pattern as session-writer)

62 LOC (34 impl incl. comments, 28 test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)