### PR TITLE
fix(QF-20260711-569): fence needs_coordinator_review on sd-start DIRECT path + handoff boundary (confirmed root cause of tonight's fenced-child claims)

### DIFF
--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -254,6 +254,31 @@ export class BaseExecutor {
         }, claimConflict.issues[0] || 'SD is claimed by another active session. Pick a different SD.');
       }
 
+      // Step 1.9: QF-20260711-569 (scope-widened leg) — coordinator-authority fence at the
+      // HANDOFF boundary. SPINE-001-C executed PLAN->EXEC THROUGH a needs_coordinator_review
+      // fence because handoff gates never consulted it. Same ONE shared predicate as the
+      // claim-write fences (QF-272 / QF-937 / sd-start direct path): live row re-fetch,
+      // fail-closed, binds human_action_required / needs_coordinator_review / not_before_hold
+      // at every handoff type. options.bypassValidation remains the documented (rate-limited,
+      // reason-required) emergency hatch.
+      {
+        const { liveClaimWriteFenceReason } = createRequire(import.meta.url)('../../../../lib/fleet/claim-eligibility.cjs');
+        const fenceReason = await liveClaimWriteFenceReason(this.supabase, sd?.sd_key || sdId);
+        if (fenceReason) {
+          if (options.bypassValidation) {
+            console.log(`\n⚠️  BYPASS ACTIVE: coordinator-authority fence (${fenceReason}) overridden — emergency path, audited.`);
+          } else {
+            try { endSpan(rootSpan, { result: 'authority_fence' }); persist(traceCtx, { supabase: this.supabase }); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }
+            return ResultBuilder.gateFailure('GATE_COORDINATOR_AUTHORITY_FENCE', {
+              issues: [`SD is fenced at the authority boundary: ${fenceReason}`, 'Only coordinator/human authority clears this fence (clear-coordinator-review, flag removal, not_before expiry).'],
+              score: 0,
+              max_score: 100,
+              warnings: ['Do NOT work this SD until the fence clears; pick another via npm run sd:next']
+            }, `GATE_COORDINATOR_AUTHORITY_FENCE: ${fenceReason} — handoff refused`);
+          }
+        }
+      }
+
       // Step 2: Pre-execution setup (optional, override in subclass)
       let step2Span;
       try { step2Span = startSpan('step.setup', { span_type: 'phase', step_name: 'setup', sd_key: sdId }, traceCtx, rootSpan); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -101,7 +101,7 @@ const { evaluateClaimDependencyGate } = cjsRequire('../lib/claim/gates/dependenc
 const { verifyHandoffIntegrity: verifyHandoffIntegrityGate } = cjsRequire('../lib/claim/gates/handoff-integrity.cjs');
 const { evaluateCadenceGate } = cjsRequire('../lib/claim/gates/cadence-gate.cjs');
 const queueResolver = cjsRequire('../lib/claim/queue-resolver.cjs');
-const { classifyAllDispatchIneligibility, liveClaimWriteFenceReason } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
+const { classifyAllDispatchIneligibility, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES } = cjsRequire('../lib/fleet/claim-eligibility.cjs');
 // SD-ARCH-HOTSPOT-SD-START-001 FR-7: dispatch-authorization polarity gate (flag-gated, observe-first).
 const dispatchAuthGate = cjsRequire('../lib/claim/gates/dispatch-authorization.cjs');
 
@@ -179,9 +179,21 @@ function enforceHumanActionGate(sd, effectiveId) {
   // hold (the reason the old first-match classifier was avoided) while a
   // multi-axis orchestrator SD without the hold does NOT trip this gate.
   const axes = classifyAllDispatchIneligibility(sd || {});
-  if (!axes.includes('human_action_required')) return;
-  console.log(`\n${colors.red}❌ ${effectiveId} requires HUMAN ACTION — cannot be claimed${colors.reset}`);
-  console.log('   metadata.requires_human_action=true — held for chairman/coordinator review.');
+  // QF-20260711-569 (root cause CONFIRMED by live repro on SPINE-001-E): this DIRECT-path
+  // gate keyed ONLY on human_action_required, so a needs_coordinator_review fence was
+  // claimable straight through sd-start. Key on the full coordinator-authority fence set
+  // (CLAIM_WRITE_FENCE_AXES — same shared authority as QF-272/QF-937's write-boundary
+  // fences), naming whichever axis matched.
+  const fence = axes.find((a) => CLAIM_WRITE_FENCE_AXES.has(a));
+  if (!fence) return;
+  const detail = {
+    human_action_required: 'metadata.requires_human_action=true — held for chairman/coordinator action.',
+    needs_coordinator_review: 'metadata.needs_coordinator_review=true — review-HELD by the coordinator.',
+    not_before_hold: 'metadata.not_before is in the future — sequencing hold.',
+  }[fence] || fence;
+  console.log(`\n${colors.red}❌ ${effectiveId} is FENCED (${fence}) — cannot be claimed${colors.reset}`);
+  console.log(`   ${detail}`);
+  console.log('   Only coordinator/human authority clears this fence — do not work this SD.');
   console.log(`\n${colors.bold}Action:${colors.reset} Pick a different SD with ${colors.cyan}npm run sd:next${colors.reset}`);
   process.exit(1);
 }

--- a/tests/unit/claim-eligibility-all-match.test.js
+++ b/tests/unit/claim-eligibility-all-match.test.js
@@ -78,14 +78,15 @@ describe('classifyAllDispatchIneligibility (FR-1 / TS-1)', () => {
     expect(classifyAllDispatchIneligibility(tierGated)).toEqual([]);
   });
 
-  it('WIRING PINS (D6 + FR-6/FR-2): sd-start keys its human-action gate on axes.includes, and both CLIs consume the shared lib/claim gates', () => {
+  it('WIRING PINS (D6 + FR-6/FR-2): sd-start keys its gate on the coordinator-authority fence set, and both CLIs consume the shared lib/claim gates', () => {
     // Same static-pin style as tests/dispatch-eligibility-convergence.test.js (C):
     // cheap, deterministic proof the call sites exist — moving them requires
     // updating these pins in the same commit (TR-5).
     const sdStart = readFileSync(resolve(repoRoot, 'scripts/sd-start.js'), 'utf8');
-    // D6: the SPECIFIC-axis check — .includes('human_action_required'), never length>0.
+    // D6 + QF-20260711-569: SPECIFIC-axes check via CLAIM_WRITE_FENCE_AXES
+    // (human_action_required + needs_coordinator_review + not_before_hold), never length>0.
     expect(sdStart).toMatch(/classifyAllDispatchIneligibility\(sd \|\| \{\}\)/);
-    expect(sdStart).toMatch(/axes\.includes\('human_action_required'\)/);
+    expect(sdStart).toMatch(/CLAIM_WRITE_FENCE_AXES\.has\(a\)/);
     expect(sdStart).not.toMatch(/axes\.length\s*>\s*0/);
     // FR-6: sd-start consumes the shared gate/queue modules.
     expect(sdStart).toMatch(/lib\/claim\/gates\/dependency-gate\.cjs/);

--- a/tests/unit/claim-write-fence.test.js
+++ b/tests/unit/claim-write-fence.test.js
@@ -101,3 +101,31 @@ describe('claimGuard acquire lane consults the fence (QF-20260711-937 — orches
     expect(src).toContain('COORDINATOR-AUTHORITY FENCE');
   });
 });
+
+describe('handoff boundary consults the fence (QF-20260711-569 scope-widened leg — SPINE-001-C ran PLAN->EXEC through the fence)', () => {
+  const execSrc = readFileSync(path.resolve(__dirname, '../../scripts/modules/handoff/executors/BaseExecutor.js'), 'utf8');
+
+  it('BaseExecutor.execute consults the SHARED predicate before setup/claim and refuses with a named gate', () => {
+    const fenceIdx = execSrc.indexOf('liveClaimWriteFenceReason(this.supabase');
+    const setupIdx = execSrc.indexOf('// Step 2: Pre-execution setup');
+    const claimIdx = execSrc.indexOf('_claimSDForSession(sdId, sd)');
+    expect(fenceIdx).toBeGreaterThan(-1);
+    expect(setupIdx).toBeGreaterThan(-1);
+    expect(fenceIdx).toBeLessThan(setupIdx);
+    expect(fenceIdx).toBeLessThan(claimIdx);
+    expect(execSrc).toContain('GATE_COORDINATOR_AUTHORITY_FENCE');
+    expect(execSrc).toContain('../../../../lib/fleet/claim-eligibility.cjs');
+  });
+
+  it('a fenced SD refuses the handoff naming the fence (message embeds the live reason)', () => {
+    expect(execSrc).toMatch(/GATE_COORDINATOR_AUTHORITY_FENCE: \$\{fenceReason\} — handoff refused/);
+  });
+
+  it('only the documented bypassValidation emergency hatch crosses it, loudly', () => {
+    const fenceIdx = execSrc.indexOf('Step 1.9: QF-20260711-569');
+    expect(fenceIdx).toBeGreaterThan(-1);
+    const block = execSrc.slice(fenceIdx, fenceIdx + 2200);
+    expect(block).toContain('options.bypassValidation');
+    expect(block).toContain('BYPASS ACTIVE');
+  });
+});

--- a/tests/unit/sd-start-human-action-gate.test.js
+++ b/tests/unit/sd-start-human-action-gate.test.js
@@ -22,17 +22,30 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(__dirname, '../..', 'scripts/sd-start.js'), 'utf8');
 
 describe('QF-20260703-295: sd-start.js HELD-SD (requires_human_action) claim gate', () => {
-  it('defines enforceHumanActionGate, keyed on the SPECIFIC human_action_required axis, that exits(1)', () => {
-    // SD-ARCH-HOTSPOT-SD-START-001 FR-6/D6: the gate now routes through the shared
-    // ALL-MATCH classifier (classifyAllDispatchIneligibility) and keys on
-    // .includes('human_action_required') — the same never-miss-a-HELD-orchestrator
-    // guarantee the old direct metadata check provided, now via one axis table.
+  it('defines enforceHumanActionGate, keyed on the coordinator-authority fence set, that exits(1)', () => {
+    // SD-ARCH-HOTSPOT-SD-START-001 FR-6/D6: the gate routes through the shared
+    // ALL-MATCH classifier (classifyAllDispatchIneligibility). QF-20260711-569
+    // (root cause confirmed on SPINE-001-E): it now keys on the FULL
+    // CLAIM_WRITE_FENCE_AXES set — human_action_required AND needs_coordinator_review
+    // AND not_before_hold — not the single human-action axis, naming the matched fence.
     const start = src.indexOf('function enforceHumanActionGate');
     expect(start).toBeGreaterThan(0);
-    const body = src.slice(start, start + 1800);
+    const body = src.slice(start, start + 2600);
     expect(body).toMatch(/classifyAllDispatchIneligibility\(sd \|\| \{\}\)/);
-    expect(body).toMatch(/axes\.includes\('human_action_required'\)/);
+    expect(body).toMatch(/CLAIM_WRITE_FENCE_AXES\.has\(a\)/);
+    expect(body).toMatch(/needs_coordinator_review/);
     expect(body).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('QF-20260711-569 regression pin: a needs_coordinator_review SD is refused by the DIRECT path gate predicate', async () => {
+    // Live repro: worker 52e6c8b2 cleanly claimed fenced SPINE-001-E through this gap.
+    const { createRequire } = await import('node:module');
+    const cjsRequire = createRequire(import.meta.url);
+    const { classifyAllDispatchIneligibility, CLAIM_WRITE_FENCE_AXES } =
+      cjsRequire('../../lib/fleet/claim-eligibility.cjs');
+    const reviewHeld = { sd_type: 'infrastructure', status: 'draft', metadata: { needs_coordinator_review: true } };
+    const axes = classifyAllDispatchIneligibility(reviewHeld);
+    expect(axes.find((a) => CLAIM_WRITE_FENCE_AXES.has(a))).toBe('needs_coordinator_review');
   });
 
   it('does NOT gate via the FIRST-MATCH classifier return value or a length>0 blanket (axis-precedence-masking regression, D6)', () => {


### PR DESCRIPTION
## Summary
QF-20260711-569 (coordinator-sourced, high; root cause CONFIRMED by live repro on SPINE-001-E). Two legs:

**Leg 1 — sd-start DIRECT path (the confirmed root cause).** `enforceHumanActionGate` keyed only on the `human_action_required` axis, so `needs_coordinator_review` SDs were claimable straight through `sd-start.js` — this explains every fenced SPINE child claim tonight (B/C/D/E). The gate now keys on the full `CLAIM_WRITE_FENCE_AXES` set (human_action_required / needs_coordinator_review / not_before_hold) via the shared ALL-MATCH classifier, naming the matched fence in the refusal. Both call sites (direct claim + post-orchestrator-routing leaf re-check) inherit it.

**Leg 2 — handoff boundary (scope widened by live breach).** SPINE-001-C executed its PLAN→EXEC handoff THROUGH the fence. `BaseExecutor.execute` gains Step 1.9: a live fence re-check via the ONE shared predicate (`liveClaimWriteFenceReason` — same as QF-272 / QF-937 / leg 1) before setup/claim on EVERY handoff type, refusing with `GATE_COORDINATOR_AUTHORITY_FENCE: <reason>`. `options.bypassValidation` (`--bypass-validation --bypass-reason`, rate-limited) remains the documented emergency hatch, loudly logged.

Together with QF-937 (claimGuard acquire lane, merged as #5965), all authority boundaries — belt, checkin, sd-start fallback, sd-start direct, claimGuard acquire, handoff execution — now route through the same fence predicate. The coordinator's interim PLAN→EXEC boundary-hold becomes defense-in-depth.

## Tests
- `claim-write-fence.test.js` extended: handoff-boundary pins (fence consulted before setup/claim, named gate, bypass-hatch containment)
- `sd-start-human-action-gate.test.js` updated to the fence-set keying + new QF-569 regression pin (review-held SD refused by the direct-path predicate)
- 60/60 pass across claim-write-fence, sd-start-human-action-gate, claim-eligibility, needs-coordinator-review-hold
- BaseExecutor smoke-imports; sd-start syntax-checked

89 insertions / 11 deletions (45 impl incl. comments, rest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)