### PR TITLE
fix(QF-20260711-412): raise MAX_WORKTREE_COUNT 20 -> 28

### DIFF
--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -37,7 +37,7 @@ import { isReapable } from './worktree-reapability.js';
 // SSOT. No import cycle: worktree-provision.js does not import this module.
 import { getFreeDiskBytes } from './worktree-provision.js';
 
-export const MAX_WORKTREE_COUNT = 20;
+export const MAX_WORKTREE_COUNT = 28;
 
 // SD-FDBK-INFRA-DISK-FULL-RECURS-001: a free-space FLOOR enforced at worktree-creation time. The quota
 // only ever capped COUNT (20), so on a near-full disk a new `git worktree add` (+ a possibly isolated

--- a/lib/worktree-quota.test.js
+++ b/lib/worktree-quota.test.js
@@ -226,8 +226,8 @@ describe('lib/worktree-quota', () => {
   });
 
   describe('exports', () => {
-    it('re-exports MAX_WORKTREE_COUNT as 20 (plan constraint)', () => {
-      expect(MAX_WORKTREE_COUNT).toBe(20);
+    it('re-exports MAX_WORKTREE_COUNT as 28 (plan constraint)', () => {
+      expect(MAX_WORKTREE_COUNT).toBe(28);
     });
 
     it('re-exports WORKTREE_QUOTA_HELPERS with documented helper names', () => {

--- a/scripts/fleet/worktree-reaper-tick.cjs
+++ b/scripts/fleet/worktree-reaper-tick.cjs
@@ -29,7 +29,7 @@ const STATE_SCHEMA_VERSION = 1;
 // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-002): pool-utilization watchdog.
 // Mirrors lib/worktree-quota.js::MAX_WORKTREE_COUNT (kept in sync; the .cjs tick
 // cannot `require` the ESM quota module, so the cap is duplicated as a constant).
-const MAX_WORKTREE_COUNT = 20;
+const MAX_WORKTREE_COUNT = 28;
 const DEFAULT_POOL_THRESHOLD = 0.8;
 
 function readState(statePath) {

--- a/tests/unit/worktree-reaper/pool-watchdog.test.js
+++ b/tests/unit/worktree-reaper/pool-watchdog.test.js
@@ -217,8 +217,8 @@ describe('computePoolUtilization', () => {
     expect(computePoolUtilization(16, 20).percent).toBe(80);
     expect(computePoolUtilization(15, 20).percent).toBe(75);
   });
-  test('guards a zero/invalid cap (falls back to MAX_WORKTREE_COUNT=20)', () => {
-    expect(computePoolUtilization(10, 0).cap).toBe(20);
+  test('guards a zero/invalid cap (falls back to MAX_WORKTREE_COUNT=28)', () => {
+    expect(computePoolUtilization(10, 0).cap).toBe(28);
   });
 });
 


### PR DESCRIPTION
## Summary
- Coordinator-requested (reply d059f5e7): the 20-slot worktree pool cap in `lib/worktree-quota.js` predates multi-tree programs and was exhausted tonight by legitimate concurrent scale (spine 9 trees + apex sprint tree + QFs).
- Raises `MAX_WORKTREE_COUNT` 20 -> 28 in the ESM source, its documented `.cjs`-mirrored duplicate in `scripts/fleet/worktree-reaper-tick.cjs` (kept in sync per its own header comment), and both pin tests (`lib/worktree-quota.test.js`, `tests/unit/worktree-reaper/pool-watchdog.test.js`).
- Audited all other `MAX_WORKTREE_COUNT` consumers (`resolve-sd-workdir.js`, `coordinator-audit.mjs`, `coordinator-charter-audit.mjs`) — all import/derive the constant, no further hardcoded duplicates found.

## Test plan
- [x] `npx vitest run lib/worktree-quota.test.js tests/unit/worktree-reaper/pool-watchdog.test.js` — 39/39 passed
- [x] Manual grep audit across the repo for hardcoded `20` tied to `MAX_WORKTREE_COUNT` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)