### PR TITLE
fix(SD-LEO-INFRA-FIX-SESSION-REGISTER-001): stop cross-session identity smear in session-register.cjs

### DIFF
--- a/lib/claim/build-forbidden-session.cjs
+++ b/lib/claim/build-forbidden-session.cjs
@@ -27,6 +27,16 @@
  */
 function isBuildForbiddenSession(metadata) {
   const md = metadata || {};
+  // SD-LEO-INFRA-FIX-SESSION-REGISTER-001 (RCA 2026-07-12): every legitimate
+  // non_fleet writer (adam-register.cjs, solomon-register.cjs) co-writes a
+  // `role` key. A bare non_fleet:true with no role is the exact fingerprint
+  // of the ad-hoc metadata-REPLACE clobber this SD investigated — log it as
+  // an anomaly so it's visible, but still honor the fail-closed block (do
+  // not hard-flip to ignoring it; that would trade an availability bug for
+  // a possible authorization gap).
+  if (md.non_fleet === true && !md.role) {
+    console.warn('[isBuildForbiddenSession] ANOMALY: non_fleet:true with no role key -- likely a corrupted/mis-targeted metadata write. Still honoring fail-closed block. See SD-LEO-INFRA-FIX-SESSION-REGISTER-001.');
+  }
   return md.non_fleet === true || md.role === 'adam' || md.is_coordinator === true;
 }
 

--- a/lib/session-writer.cjs
+++ b/lib/session-writer.cjs
@@ -82,8 +82,64 @@ function stampBranch(payload, cwd) {
   return base;
 }
 
+/**
+ * markSessionNonFleet — canonical, merge-preserving write path for marking a
+ * claude_sessions row non_fleet (propose-only / cannot hold a build claim).
+ *
+ * SD-LEO-INFRA-FIX-SESSION-REGISTER-001: prior ad-hoc remediation of rows
+ * judged to be phantom/duplicate entries has full-REPLACED the metadata
+ * column (`.update({ metadata: { non_fleet: true, released_reason: '...' } })`),
+ * destroying unrelated fields (fleet_identity, tier_rank, auto_proceed,
+ * chain_orchestrators) with no trace. This helper reads the existing
+ * metadata, merges in `non_fleet: true`, and writes the human-readable
+ * reason to the top-level released_reason COLUMN (not inside metadata) —
+ * every other field on the row survives.
+ *
+ * Throws on Supabase errors rather than swallowing them: this is the
+ * canonical write path, so a failure here should be visible to the caller
+ * rather than silently producing a no-op remediation.
+ *
+ * @param {string} sessionId
+ * @param {string} [reason] — human-readable note, stored in released_reason
+ * @param {object} [supabaseClient] — injectable client (tests); defaults to
+ *   createSupabaseServiceClient()
+ * @returns {Promise<{sessionId: string, metadata: object, released_reason: string|null}>}
+ */
+async function markSessionNonFleet(sessionId, reason, supabaseClient) {
+  if (!sessionId || typeof sessionId !== 'string') {
+    throw new Error('markSessionNonFleet: sessionId is required');
+  }
+
+  let supabase = supabaseClient;
+  if (!supabase) {
+    const { createSupabaseServiceClient } = require('./supabase-client.cjs');
+    supabase = createSupabaseServiceClient();
+  }
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('claude_sessions')
+    .select('metadata')
+    .eq('session_id', sessionId)
+    .maybeSingle();
+  if (fetchError) throw fetchError;
+
+  const priorMetadata = existing?.metadata && typeof existing.metadata === 'object' && !Array.isArray(existing.metadata)
+    ? existing.metadata
+    : {};
+  const mergedMetadata = { ...priorMetadata, non_fleet: true };
+
+  const { error: updateError } = await supabase
+    .from('claude_sessions')
+    .update({ metadata: mergedMetadata, released_reason: reason || null })
+    .eq('session_id', sessionId);
+  if (updateError) throw updateError;
+
+  return { sessionId, metadata: mergedMetadata, released_reason: reason || null };
+}
+
 module.exports = {
   resolveCurrentBranch,
   stampBranch,
+  markSessionNonFleet,
   BRANCH_RESOLUTION_TIMEOUT_MS,
 };

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { stampBranch } = require('../../lib/session-writer.cjs');
+const { resolveSessionId } = require('../../lib/hooks/session-id.cjs');
 
 /**
  * Detect the current repo context from CWD or CLAUDE_PROJECT_DIR.
@@ -37,44 +38,26 @@ function detectCurrentRepo() {
   return 'EHG_Engineer';
 }
 
-function getCurrentSessionId() {
-  // Resolution order (5f02d3c2):
-  //   1. CLAUDE_SESSION_ID env var (set by capture-session-id.cjs which runs
-  //      earlier in the SessionStart chain — most reliable when present)
-  //   2. .claude/session-identity/<uuid>.json — current marker scheme;
-  //      pick the most-recently-modified file. capture-session-id.cjs:383
-  //      writes one file per session here.
-  //   3. .claude/session-id.json — legacy single-file marker (predates the
-  //      session-identity dir, kept for backward compat)
-  //   4. ~/.claude-sessions/*.json — even-older fallback
-  if (process.env.CLAUDE_SESSION_ID) {
-    return process.env.CLAUDE_SESSION_ID;
-  }
+// SD-LEO-INFRA-FIX-SESSION-REGISTER-001: this hook previously carried its own
+// getCurrentSessionId() whose marker-file fallback picked the most-recently
+// -modified file under .claude/session-identity/*.json with NO hostname/pid
+// scoping. When CLAUDE_SESSION_ID was unset in-process (the normal case for
+// SessionStart:compact), that let one session's compact-hook read an
+// UNRELATED session's marker and upsert its own hostname/tty onto that
+// foreign session_id — see RCA 2026-07-12 (session de6e0bfb clobbered by an
+// ac499e67 compact-hook race). resolveSessionId() (lib/hooks/session-id.cjs,
+// QF-20260504-765/297/749) already solves this correctly: stdin session_id
+// (authoritative per-invocation truth from Claude Code itself) first, then
+// env, then a PID-scoped marker, and only a bare mtime-newest marker as a
+// last resort. Delegating to it here closes the smear at its source instead
+// of re-deriving a weaker local heuristic.
+async function getCurrentSessionId() {
+  const resolved = await resolveSessionId();
+  if (resolved) return resolved;
 
+  // Last-resort legacy fallback (pre-dates the shared resolver): scan
+  // ~/.claude-sessions for a file whose recorded pid matches this process.
   try {
-    const markerDir = path.resolve(__dirname, '../../.claude/session-identity');
-    if (fs.existsSync(markerDir)) {
-      const markers = fs.readdirSync(markerDir)
-        .filter(f => f.endsWith('.json'))
-        .map(f => {
-          const full = path.join(markerDir, f);
-          return { name: f, mtime: fs.statSync(full).mtimeMs };
-        })
-        .sort((a, b) => b.mtime - a.mtime);
-      if (markers.length > 0) {
-        const latest = JSON.parse(fs.readFileSync(path.join(markerDir, markers[0].name), 'utf8'));
-        if (latest.session_id) return latest.session_id;
-      }
-    }
-  } catch { /* fall through to legacy lookups */ }
-
-  try {
-    const sessionFile = path.resolve(__dirname, '../../.claude/session-id.json');
-    if (fs.existsSync(sessionFile)) {
-      const data = JSON.parse(fs.readFileSync(sessionFile, 'utf8'));
-      if (data.session_id) return data.session_id;
-    }
-
     const sessionDir = path.join(os.homedir(), '.claude-sessions');
     if (!fs.existsSync(sessionDir)) return null;
     const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
@@ -115,7 +98,7 @@ async function main() {
     return; // Supabase not available
   }
 
-  const sessionId = getCurrentSessionId();
+  const sessionId = await getCurrentSessionId();
   if (!sessionId) return;
 
   const now = new Date().toISOString();
@@ -197,9 +180,17 @@ async function main() {
   } catch { /* best-effort observability; never block SessionStart */ }
 }
 
-main().catch((err) => {
-  // Never throw — SessionStart must not abort — but surface the error so it's
-  // no longer invisible (was previously swallowed with no trace, hiding schema
-  // drift like the started_at column removal from every session's boot).
-  process.stderr.write(`[session-register] main.failed error=${err?.message || String(err)}\n`);
-});
+// SD-LEO-INFRA-FIX-SESSION-REGISTER-001: only auto-invoke main() when this
+// file is run directly as the SessionStart hook (`node .../session-register.cjs`).
+// A test file requiring this module for getCurrentSessionId() must NOT
+// trigger a live Supabase call as a require-time side effect.
+if (require.main === module) {
+  main().catch((err) => {
+    // Never throw — SessionStart must not abort — but surface the error so it's
+    // no longer invisible (was previously swallowed with no trace, hiding schema
+    // drift like the started_at column removal from every session's boot).
+    process.stderr.write(`[session-register] main.failed error=${err?.message || String(err)}\n`);
+  });
+}
+
+module.exports = { getCurrentSessionId, main };

--- a/tests/unit/claim-self-only-authorization.test.js
+++ b/tests/unit/claim-self-only-authorization.test.js
@@ -47,6 +47,36 @@ describe('isBuildForbiddenSession (FR-1 predicate)', () => {
   });
 });
 
+// SD-LEO-INFRA-FIX-SESSION-REGISTER-001 (Layer 3): a bare non_fleet:true with
+// no role key is the exact fingerprint of the ad-hoc metadata-REPLACE clobber
+// this SD's RCA investigated. The predicate must still fail-closed (block),
+// but should now surface an anomaly warning so the corrupted write is visible.
+//
+// console.warn is already a persistent vi.fn() (tests/setup.unit.js, never
+// auto-cleared between tests in this file) -- mockClear() it before each
+// assertion here instead of vi.spyOn'ing a fresh layer on top of it.
+describe('isBuildForbiddenSession anomaly flagging (Layer 3)', () => {
+  beforeEach(() => {
+    console.warn.mockClear();
+  });
+
+  it('warns and still blocks on a bare non_fleet:true with no role key', () => {
+    expect(isBuildForbiddenSession({ non_fleet: true })).toBe(true);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn.mock.calls[0][0]).toMatch(/ANOMALY/);
+  });
+
+  it('does not warn for a legitimate non_fleet session that carries a role', () => {
+    expect(isBuildForbiddenSession({ non_fleet: true, role: 'adam' })).toBe(true);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when non_fleet is not set at all', () => {
+    expect(isBuildForbiddenSession({ role: 'worker' })).toBe(false);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
 // claimVirtualSession self-only guard — mock the service client factory.
 const rows = new Map();
 function fakeClient() {

--- a/tests/unit/hooks/session-register-identity-scoping.test.js
+++ b/tests/unit/hooks/session-register-identity-scoping.test.js
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for scripts/hooks/session-register.cjs::getCurrentSessionId
+ * SD-LEO-INFRA-FIX-SESSION-REGISTER-001 (Layer 1)
+ *
+ * RCA 2026-07-12: getCurrentSessionId() previously picked the most-recently
+ * -modified file under .claude/session-identity/*.json with NO hostname/pid
+ * scoping whenever CLAUDE_SESSION_ID was unset (the normal case for
+ * SessionStart:compact). That let one session's compact-hook read an
+ * unrelated session's marker and smear its own identity onto that foreign
+ * session_id. The fix delegates to lib/hooks/session-id.cjs::resolveSessionId,
+ * which checks stdin, then env, then a PID-SCOPED marker (not mtime-newest)
+ * before ever falling back to the old unscoped heuristic.
+ *
+ * These tests exercise the REAL resolveSessionId (via its documented test
+ * override env vars, QF297_MARKER_DIR_OVERRIDE / QF297_CCPID_OVERRIDE)
+ * rather than mocking it: session-register.cjs and lib/hooks/session-id.cjs
+ * are both native CJS modules loaded via createRequire, so vi.mock cannot
+ * intercept the nested require() between them -- exercising the real
+ * resolution chain is both necessary and the stronger test.
+ *
+ * Requiring scripts/hooks/session-register.cjs must NOT trigger main()'s live
+ * Supabase call (guarded by `if (require.main === module)`); these tests rely
+ * on that guard to safely import getCurrentSessionId.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+describe('session-register.cjs require-time safety', () => {
+  it('does not export an empty object (main() must not have fired at require time)', () => {
+    const mod = require('../../../scripts/hooks/session-register.cjs');
+    expect(typeof mod.getCurrentSessionId).toBe('function');
+    expect(typeof mod.main).toBe('function');
+  });
+});
+
+describe('getCurrentSessionId (SD-LEO-INFRA-FIX-SESSION-REGISTER-001 FR-1)', () => {
+  const { getCurrentSessionId } = require('../../../scripts/hooks/session-register.cjs');
+
+  let tmpMarkerDir;
+  const savedEnv = {};
+  const ENV_KEYS = ['CLAUDE_SESSION_ID', 'QF297_MARKER_DIR_OVERRIDE', 'QF297_CCPID_OVERRIDE', 'QF749_DISABLE_NULL_LOG'];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    delete process.env.CLAUDE_SESSION_ID;
+    delete process.env.QF297_MARKER_DIR_OVERRIDE;
+    delete process.env.QF297_CCPID_OVERRIDE;
+    process.env.QF749_DISABLE_NULL_LOG = '1'; // silence the diagnostic canary during tests
+    tmpMarkerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-register-marker-test-'));
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (tmpMarkerDir && fs.existsSync(tmpMarkerDir)) {
+      try { fs.rmSync(tmpMarkerDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('returns CLAUDE_SESSION_ID when set, without touching any marker file', async () => {
+    process.env.CLAUDE_SESSION_ID = 'own-session-abc';
+    const result = await getCurrentSessionId();
+    expect(result).toBe('own-session-abc');
+  });
+
+  it('regression: a PID-scoped marker wins over a foreign most-recently-modified marker', async () => {
+    // This is the exact fixed scenario: a foreign session's marker is the
+    // newest by mtime, but this process's own pid-<ccPid>.json marker must
+    // still be the one returned -- proving recency alone can no longer win.
+    process.env.QF297_MARKER_DIR_OVERRIDE = tmpMarkerDir;
+    process.env.QF297_CCPID_OVERRIDE = 'own-pid-111';
+
+    fs.writeFileSync(
+      path.join(tmpMarkerDir, 'pid-own-pid-111.json'),
+      JSON.stringify({ session_id: 'own-session-id' })
+    );
+    // Written after the own-pid marker, so it is strictly newer by mtime.
+    fs.writeFileSync(
+      path.join(tmpMarkerDir, 'pid-foreign-pid-222.json'),
+      JSON.stringify({ session_id: 'foreign-session-id' })
+    );
+
+    const result = await getCurrentSessionId();
+    expect(result).toBe('own-session-id');
+    expect(result).not.toBe('foreign-session-id');
+  });
+
+  it('falls back to the mtime-newest marker only when this process has no marker of its own (documented residual tier, unaffected by this fix)', async () => {
+    process.env.QF297_MARKER_DIR_OVERRIDE = tmpMarkerDir;
+    process.env.QF297_CCPID_OVERRIDE = 'own-pid-with-no-marker';
+
+    fs.writeFileSync(
+      path.join(tmpMarkerDir, 'pid-someone-else.json'),
+      JSON.stringify({ session_id: 'only-marker-present' })
+    );
+
+    const result = await getCurrentSessionId();
+    expect(result).toBe('only-marker-present');
+  });
+});

--- a/tests/unit/session-writer/mark-session-non-fleet.test.js
+++ b/tests/unit/session-writer/mark-session-non-fleet.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for lib/session-writer.cjs::markSessionNonFleet
+ * SD-LEO-INFRA-FIX-SESSION-REGISTER-001 (Layer 2)
+ *
+ * RCA 2026-07-12: a prior ad-hoc remediation full-REPLACED claude_sessions.metadata
+ * when marking a row non_fleet, destroying fleet_identity/tier_rank/auto_proceed
+ * with no trace. markSessionNonFleet must MERGE instead of replace, and must write
+ * the human-readable reason to the top-level released_reason column, not inside
+ * metadata.
+ *
+ * The Supabase client is passed explicitly (dependency injection) rather than
+ * mocked via vi.mock, because markSessionNonFleet's internal require('./supabase-
+ * client.cjs') is a native Node CJS require (this module is loaded via
+ * createRequire), which Vitest's ESM-level module interception does not reach.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { markSessionNonFleet } = require('../../../lib/session-writer.cjs');
+
+const rows = new Map();
+function fakeClient() {
+  return {
+    from() {
+      return {
+        _id: null,
+        select() { return this; },
+        eq(col, val) { if (col === 'session_id') this._id = val; return this; },
+        maybeSingle: function () {
+          return Promise.resolve({ data: rows.get(this._id) || null, error: null });
+        },
+        update: function (patch) {
+          return {
+            eq(col, val) {
+              const existing = rows.get(val) || {};
+              rows.set(val, { ...existing, ...patch });
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('markSessionNonFleet (SD-LEO-INFRA-FIX-SESSION-REGISTER-001 FR-2)', () => {
+  beforeEach(() => {
+    rows.clear();
+  });
+
+  it('merges non_fleet:true into existing metadata rather than replacing it', async () => {
+    rows.set('victim-session', {
+      session_id: 'victim-session',
+      metadata: {
+        tier_rank: 4,
+        auto_proceed: true,
+        fleet_identity: { color: 'yellow', callsign: 'Alpha-4' },
+        chain_orchestrators: true,
+      },
+    });
+
+    await markSessionNonFleet('victim-session', 'test remediation reason', fakeClient());
+
+    const after = rows.get('victim-session');
+    expect(after.metadata.non_fleet).toBe(true);
+    // Every pre-existing field must survive the merge.
+    expect(after.metadata.tier_rank).toBe(4);
+    expect(after.metadata.auto_proceed).toBe(true);
+    expect(after.metadata.fleet_identity).toEqual({ color: 'yellow', callsign: 'Alpha-4' });
+    expect(after.metadata.chain_orchestrators).toBe(true);
+  });
+
+  it('writes the reason to the top-level released_reason column, not inside metadata', async () => {
+    rows.set('victim-session-2', { session_id: 'victim-session-2', metadata: { tier_rank: 2 } });
+
+    await markSessionNonFleet('victim-session-2', 'phantom row suspected', fakeClient());
+
+    const after = rows.get('victim-session-2');
+    expect(after.released_reason).toBe('phantom row suspected');
+    expect(after.metadata.released_reason).toBeUndefined();
+  });
+
+  it('handles a row with no prior metadata gracefully', async () => {
+    rows.set('fresh-session', { session_id: 'fresh-session', metadata: null });
+
+    await markSessionNonFleet('fresh-session', 'reason', fakeClient());
+
+    const after = rows.get('fresh-session');
+    expect(after.metadata).toEqual({ non_fleet: true });
+  });
+
+  it('throws when sessionId is missing', async () => {
+    await expect(markSessionNonFleet(undefined, 'reason', fakeClient())).rejects.toThrow(/sessionId is required/);
+  });
+});


### PR DESCRIPTION
## Summary
- RCA 2026-07-12: a live fleet-worker session's `claude_sessions.metadata` got fully replaced with `{non_fleet:true, released_reason:"..."}`, wiping `fleet_identity`/`auto_proceed`/`chain_orchestrators` and blocking a legitimate claim with `non_fleet_build_forbidden`.
- Root cause: `session-register.cjs`'s `getCurrentSessionId()` fell back to the most-recently-modified `.claude/session-identity/*.json` marker with no hostname/pid scoping whenever `CLAUDE_SESSION_ID` was unset (the normal case for `SessionStart:compact`) — letting one session's compact-hook read an unrelated session's marker and smear its identity onto that foreign session_id, which a downstream ad-hoc remediation then full-REPLACED as "phantom."
- Three-layer fix: (1) delegate to the already-existing, tested `resolveSessionId()` (stdin → env → pid-scoped marker → mtime fallback) instead of a weaker local heuristic; (2) add `markSessionNonFleet()` as the canonical merge-preserving write path; (3) log an anomaly warning (still fail-closed) when `isBuildForbiddenSession` sees a bare `non_fleet:true` with no role key.

## Test plan
- [x] 22 tests green across `tests/unit/hooks/session-register-identity-scoping.test.js` (new), `tests/unit/session-writer/mark-session-non-fleet.test.js` (new), `tests/unit/claim-self-only-authorization.test.js` (3 new Layer-3 tests + 11 existing)
- [x] Regression pin proving a PID-scoped marker now wins over a foreign most-recently-modified marker (the exact previously-vulnerable scenario)
- [x] VALIDATION sub-agent: PASS (88% confidence)
- [x] REGRESSION sub-agent: PASS — upsert payload byte-identical, `require.main` guard verified both directions, no external caller of the removed local heuristic

🤖 Generated with [Claude Code](https://claude.com/claude-code)