### PR TITLE
fix(SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001): enforce LEAD-FINAL + SD_COMPLETION retro on all 4 orchestrator auto-complete paths

### DIFF
--- a/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
+++ b/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
@@ -1,0 +1,187 @@
+-- Migration: Orchestrator ghost-complete fix — enforce LEAD-FINAL + SD_COMPLETION retro
+-- SD: SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001
+-- Date: 2026-07-12
+--
+-- ⚠️  STAGED — NOT YET APPROVED FOR APPLY. CHAIRMAN APPLY REQUIRED. ⚠️
+-- TIER-2 (non-delegatable): CREATE OR REPLACE of a SECURITY DEFINER function
+-- per migration-tier-classifier.mjs. Apply via apply-migration.js --prod-deploy.
+-- Rollback companion: 20260712_orchestrator_ghost_complete_lead_final_rollback.sql
+-- Applied-vs-staged state observable via scripts/orchestrator-rpc-enforcement-status.mjs
+--
+-- The Problem (ghost-complete, caught live on SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001):
+-- complete_orchestrator_sd() set status='completed' directly once all children
+-- finished, FABRICATED an accepted PLAN-TO-LEAD handoff row
+-- (created_by='ORCHESTRATOR_AUTO_COMPLETE', whitelisted in check_handoff_bypass),
+-- and its retrospective check accepted ANY retro row regardless of retro_type —
+-- a mere HANDOFF retro satisfied completion.
+--
+-- The Fix:
+-- 1. Retro check filters retro_type='SD_COMPLETION' + freshness after the SD's
+--    accepted LEAD-TO-PLAN handoff (mirrors scripts/modules/handoff/retro-filters.js).
+-- 2. Completion requires a genuine accepted LEAD-FINAL-APPROVAL handoff row —
+--    otherwise the function stages the SD at status='pending_approval' and returns
+--    the exact command to run. No handoff row is ever fabricated.
+-- 3. check_handoff_bypass() no longer whitelists ORCHESTRATOR_AUTO_COMPLETE
+--    (the function no longer inserts handoffs; the whitelist was the bypass seam).
+
+-- ============================================================================
+-- FUNCTION: Complete Orchestrator SD (LEAD-FINAL enforced)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION complete_orchestrator_sd(sd_id_param VARCHAR)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sd RECORD;
+  is_orch BOOLEAN;
+  total_children INT;
+  completed_children INT;
+  lead_to_plan_accepted_at TIMESTAMPTZ;
+  retro_exists BOOLEAN;
+  lfa_exists BOOLEAN;
+BEGIN
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'SD not found: ' || sd_id_param);
+  END IF;
+
+  IF sd.status = 'completed' THEN
+    RETURN jsonb_build_object('success', true, 'message', 'SD already completed', 'sd_id', sd_id_param);
+  END IF;
+
+  is_orch := is_orchestrator_sd(sd_id_param);
+  IF NOT is_orch THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Not an orchestrator SD (has no children)', 'sd_id', sd_id_param);
+  END IF;
+
+  SELECT COUNT(*), COUNT(*) FILTER (WHERE status = 'completed')
+  INTO total_children, completed_children
+  FROM strategic_directives_v2
+  WHERE parent_sd_id = sd_id_param;
+
+  IF completed_children <> total_children THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Not all children completed: %s/%s', completed_children, total_children),
+      'completed_children', completed_children,
+      'total_children', total_children
+    );
+  END IF;
+
+  -- Canonical completion-retro check (mirrors scripts/modules/handoff/retro-filters.js):
+  -- retro_type='SD_COMPLETION', not tagged as a handoff-time retro, created after
+  -- LEAD-TO-PLAN acceptance (fallback: SD creation time).
+  SELECT COALESCE(
+    (SELECT accepted_at FROM sd_phase_handoffs
+     WHERE sd_id = sd_id_param AND from_phase = 'LEAD' AND to_phase = 'PLAN' AND status = 'accepted'
+     ORDER BY accepted_at DESC LIMIT 1),
+    sd.created_at,
+    to_timestamp(0)
+  ) INTO lead_to_plan_accepted_at;
+
+  SELECT EXISTS (
+    SELECT 1 FROM retrospectives
+    WHERE sd_id = sd_id_param
+      AND retro_type = 'SD_COMPLETION'
+      AND (retrospective_type IS NULL OR retrospective_type = 'SD_COMPLETION')
+      AND created_at > lead_to_plan_accepted_at
+  ) INTO retro_exists;
+
+  IF NOT retro_exists THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'SD-completion retrospective required (retro_type=SD_COMPLETION, created after LEAD-TO-PLAN acceptance)',
+      'hint', 'Run the RETRO sub-agent to generate a retro_type=SD_COMPLETION retrospective, then re-run'
+    );
+  END IF;
+
+  -- Completion witness: a genuine accepted LEAD-FINAL-APPROVAL handoff row.
+  SELECT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+      AND handoff_type = 'LEAD-FINAL-APPROVAL'
+      AND status = 'accepted'
+  ) INTO lfa_exists;
+
+  IF NOT lfa_exists THEN
+    -- Stage for the real executor instead of fabricating completion.
+    UPDATE strategic_directives_v2
+    SET status = 'pending_approval', is_working_on = false, updated_at = now()
+    WHERE id = sd_id_param AND status <> 'completed';
+
+    RETURN jsonb_build_object(
+      'success', false,
+      'staged', true,
+      'error', 'LEAD-FINAL-APPROVAL required before completion — SD staged at pending_approval',
+      'hint', format('Run: node scripts/handoff.js execute LEAD-FINAL-APPROVAL %s', COALESCE(sd.sd_key, sd_id_param)),
+      'sd_id', sd_id_param
+    );
+  END IF;
+
+  -- Genuine LEAD-FINAL evidence exists — completion is legitimate.
+  UPDATE strategic_directives_v2
+  SET status = 'completed', current_phase = 'COMPLETED', is_working_on = false, updated_at = now()
+  WHERE id = sd_id_param;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('Orchestrator completed: %s/%s children done, LEAD-FINAL-APPROVAL verified', completed_children, total_children),
+    'sd_id', sd_id_param,
+    'completed_children', completed_children
+  );
+END;
+$$;
+
+-- ============================================================================
+-- check_handoff_bypass: remove the ORCHESTRATOR_AUTO_COMPLETE whitelist
+-- (no code path inserts handoffs with that created_by anymore)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION check_handoff_bypass()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Allow known system creators
+  IF NEW.created_by IN ('HANDOFF_SYSTEM', 'LEO_EXECUTOR', 'UNIFIED_HANDOFF_SYSTEM') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Block unknown direct creation attempts
+  IF NEW.created_by IS NULL OR NEW.created_by = 'LEO_AGENT' THEN
+    RAISE EXCEPTION 'HANDOFF_BYPASS_BLOCKED: Direct handoff creation is not allowed.
+
+To create a handoff, run:
+  node scripts/handoff.js execute <TYPE> <SD-ID>
+
+Where TYPE is one of:
+  - LEAD-TO-PLAN
+  - PLAN-TO-EXEC
+  - EXEC-TO-PLAN
+  - PLAN-TO-LEAD
+
+Example:
+  node scripts/handoff.js execute PLAN-TO-EXEC SD-EXAMPLE-001
+
+Attempted created_by: %', COALESCE(NEW.created_by, 'NULL');
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================================
+-- VALIDATION
+-- ============================================================================
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Orchestrator ghost-complete fix installed:';
+  RAISE NOTICE '  - complete_orchestrator_sd(): SD_COMPLETION retro + accepted LEAD-FINAL-APPROVAL required';
+  RAISE NOTICE '  - no fabricated PLAN-TO-LEAD rows; stages at pending_approval instead';
+  RAISE NOTICE '  - check_handoff_bypass(): ORCHESTRATOR_AUTO_COMPLETE whitelist removed';
+END $$;

--- a/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
+++ b/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
@@ -8,43 +8,62 @@
 -- Rollback companion: 20260712_orchestrator_ghost_complete_lead_final_rollback.sql
 -- Applied-vs-staged state observable via scripts/orchestrator-rpc-enforcement-status.mjs
 --
+-- ORDERING: this migration SUPERSEDES section (c) (complete_orchestrator_sd) of the
+-- also-staged 20260711_orchestrator_terminal_status_sql_parity.sql and INCORPORATES its
+-- logic verbatim (cancelled-as-terminal child counting, PCVP handoff-evidence check,
+-- honest completion narrative). Sections (a),(b),(d),(e) of 20260711 are untouched and
+-- must still be applied. Apply 20260711 first, then this file (date order).
+--
 -- The Problem (ghost-complete, caught live on SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001):
 -- complete_orchestrator_sd() set status='completed' directly once all children
 -- finished, FABRICATED an accepted PLAN-TO-LEAD handoff row
--- (created_by='ORCHESTRATOR_AUTO_COMPLETE', whitelisted in check_handoff_bypass),
--- and its retrospective check accepted ANY retro row regardless of retro_type —
--- a mere HANDOFF retro satisfied completion.
+-- (created_by='ORCHESTRATOR_AUTO_COMPLETE'), and its retrospective check accepted
+-- ANY retro row regardless of retro_type — a mere HANDOFF retro satisfied completion.
 --
 -- The Fix:
 -- 1. Retro check filters retro_type='SD_COMPLETION' + freshness after the SD's
 --    accepted LEAD-TO-PLAN handoff (mirrors scripts/modules/handoff/retro-filters.js).
--- 2. Completion requires a genuine accepted LEAD-FINAL-APPROVAL handoff row —
---    otherwise the function stages the SD at status='pending_approval' and returns
---    the exact command to run. No handoff row is ever fabricated.
--- 3. check_handoff_bypass() no longer whitelists ORCHESTRATOR_AUTO_COMPLETE
---    (the function no longer inserts handoffs; the whitelist was the bypass seam).
+-- 2. Completion requires a GENUINE accepted LEAD-FINAL-APPROVAL handoff row written by
+--    the executor (created_by IN ('UNIFIED-HANDOFF-SYSTEM','unified-handoff-system')) —
+--    NOT rows forged via privileged actors (live data shows 807 ADMIN_OVERRIDE-created
+--    accepted LFA rows; handoff_actor_policy() still authorizes ADMIN_OVERRIDE inserts
+--    that skip claim checks, so created_by is the discriminating witness). Absent the
+--    witness, the function stages the SD at status='pending_approval' and returns the
+--    exact command to run. No handoff row is ever fabricated.
+-- 3. NOTE (adversarial review 2026-07-12): the previously-drafted check_handoff_bypass()
+--    replacement was REMOVED from this migration — that function is a dead third copy
+--    already DROPped by the 20260530 handoff-actor-policy SSOT migration; re-creating it
+--    would resurrect dead code without touching the live gates
+--    (enforce_handoff_system / enforce_is_working_on_for_handoffs via
+--    handoff_actor_policy()). Narrowing handoff_actor_policy() itself is out of scope
+--    here (it has its own SSOT invariant tests) — the created_by witness allow-list in
+--    (2) is the enforcement seam instead.
 
 -- ============================================================================
--- FUNCTION: Complete Orchestrator SD (LEAD-FINAL enforced)
+-- FUNCTION: Complete Orchestrator SD (LEAD-FINAL enforced; supersedes 20260711 (c))
 -- ============================================================================
 
-CREATE OR REPLACE FUNCTION complete_orchestrator_sd(sd_id_param VARCHAR)
-RETURNS JSONB
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
+CREATE OR REPLACE FUNCTION public.complete_orchestrator_sd(sd_id_param character varying)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
 DECLARE
   sd RECORD;
   is_orch BOOLEAN;
+  children_done BOOLEAN;
   total_children INT;
   completed_children INT;
+  cancelled_children INT;
+  children_without_handoffs INT;
+  child_quality_issues JSONB;
   lead_to_plan_accepted_at TIMESTAMPTZ;
   retro_exists BOOLEAN;
-  lfa_exists BOOLEAN;
+  lfa_witness_exists BOOLEAN;
+  completion_narrative TEXT;
 BEGIN
   SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
-
   IF NOT FOUND THEN
     RETURN jsonb_build_object('success', false, 'error', 'SD not found: ' || sd_id_param);
   END IF;
@@ -58,12 +77,18 @@ BEGIN
     RETURN jsonb_build_object('success', false, 'error', 'Not an orchestrator SD (has no children)', 'sd_id', sd_id_param);
   END IF;
 
-  SELECT COUNT(*), COUNT(*) FILTER (WHERE status = 'completed')
-  INTO total_children, completed_children
+  -- SD-LEO-FIX-ORCHESTRATOR-LEAF-ROUTER-001 (incorporated from 20260711 (c)):
+  -- cancelled is a terminal disposition, same as completed.
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status IN ('completed', 'cancelled')),
+    COUNT(*) FILTER (WHERE status = 'cancelled')
+  INTO total_children, completed_children, cancelled_children
   FROM strategic_directives_v2
   WHERE parent_sd_id = sd_id_param;
 
-  IF completed_children <> total_children THEN
+  children_done := (completed_children = total_children);
+  IF NOT children_done THEN
     RETURN jsonb_build_object(
       'success', false,
       'error', format('Not all children completed: %s/%s', completed_children, total_children),
@@ -72,9 +97,42 @@ BEGIN
     );
   END IF;
 
-  -- Canonical completion-retro check (mirrors scripts/modules/handoff/retro-filters.js):
-  -- retro_type='SD_COMPLETION', not tagged as a handoff-time retro, created after
-  -- LEAD-TO-PLAN acceptance (fallback: SD creation time).
+  -- PCVP (incorporated from 20260711 (c)): only 'completed' children (never 'cancelled')
+  -- are required to have handoff evidence.
+  SELECT COUNT(*) INTO children_without_handoffs
+  FROM strategic_directives_v2 child
+  WHERE child.parent_sd_id = sd_id_param
+    AND child.status = 'completed'
+    AND NOT EXISTS (
+      SELECT 1 FROM sd_phase_handoffs h
+      WHERE h.sd_id = child.id AND h.status = 'accepted'
+    );
+  IF children_without_handoffs > 0 THEN
+    SELECT jsonb_agg(jsonb_build_object(
+      'sd_key', child.sd_key, 'title', child.title,
+      'issue', 'No accepted handoff records found'
+    ))
+    INTO child_quality_issues
+    FROM strategic_directives_v2 child
+    WHERE child.parent_sd_id = sd_id_param
+      AND child.status = 'completed'
+      AND NOT EXISTS (
+        SELECT 1 FROM sd_phase_handoffs h
+        WHERE h.sd_id = child.id AND h.status = 'accepted'
+      );
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('PCVP: %s child(ren) completed without handoff evidence', children_without_handoffs),
+      'children_without_handoffs', children_without_handoffs,
+      'quality_issues', child_quality_issues,
+      'hint', 'Each child SD must have at least one accepted handoff in sd_phase_handoffs'
+    );
+  END IF;
+
+  -- SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: canonical completion-retro check
+  -- (mirrors scripts/modules/handoff/retro-filters.js): retro_type='SD_COMPLETION',
+  -- not tagged as a handoff-time retro, created after LEAD-TO-PLAN acceptance
+  -- (fallback: SD creation time).
   SELECT COALESCE(
     (SELECT accepted_at FROM sd_phase_handoffs
      WHERE sd_id = sd_id_param AND from_phase = 'LEAD' AND to_phase = 'PLAN' AND status = 'accepted'
@@ -99,18 +157,26 @@ BEGIN
     );
   END IF;
 
-  -- Completion witness: a genuine accepted LEAD-FINAL-APPROVAL handoff row.
+  -- Completion witness: a genuine accepted LEAD-FINAL-APPROVAL handoff row WRITTEN BY
+  -- THE EXECUTOR. created_by is the discriminator: privileged actors (ADMIN_OVERRIDE,
+  -- ORCHESTRATOR_AUTO_COMPLETE) can insert accepted rows via handoff_actor_policy(),
+  -- so an unqualified EXISTS would be forgeable with a single INSERT.
   SELECT EXISTS (
     SELECT 1 FROM sd_phase_handoffs
     WHERE sd_id = sd_id_param
       AND handoff_type = 'LEAD-FINAL-APPROVAL'
       AND status = 'accepted'
-  ) INTO lfa_exists;
+      AND created_by IN ('UNIFIED-HANDOFF-SYSTEM', 'unified-handoff-system')
+  ) INTO lfa_witness_exists;
 
-  IF NOT lfa_exists THEN
+  IF NOT lfa_witness_exists THEN
     -- Stage for the real executor instead of fabricating completion.
+    -- is_working_on is deliberately NOT cleared: the LFA executor's canonical handoff
+    -- insert (created_by='UNIFIED-HANDOFF-SYSTEM') does not skip the claim check, and
+    -- enforce_is_working_on_for_handoffs rejects the insert when is_working_on is false
+    -- (parity with completeStandardSD's staging behavior).
     UPDATE strategic_directives_v2
-    SET status = 'pending_approval', is_working_on = false, updated_at = now()
+    SET status = 'pending_approval', updated_at = now()
     WHERE id = sd_id_param AND status <> 'completed';
 
     RETURN jsonb_build_object(
@@ -123,56 +189,26 @@ BEGIN
   END IF;
 
   -- Genuine LEAD-FINAL evidence exists — completion is legitimate.
+  completion_narrative := CASE WHEN cancelled_children = 0
+    THEN format('All %s child SDs completed with verified handoff evidence. Quality verified across all children.', total_children)
+    ELSE format('%s of %s child SDs completed with verified handoff evidence; %s cancelled (a terminal disposition, not a quality failure — cancelled children never require handoff evidence).', completed_children - cancelled_children, total_children, cancelled_children)
+  END;
+
   UPDATE strategic_directives_v2
   SET status = 'completed', current_phase = 'COMPLETED', is_working_on = false, updated_at = now()
   WHERE id = sd_id_param;
 
   RETURN jsonb_build_object(
     'success', true,
-    'message', format('Orchestrator completed: %s/%s children done, LEAD-FINAL-APPROVAL verified', completed_children, total_children),
+    'message', format('Orchestrator completed (LEAD-FINAL-APPROVAL verified): %s', completion_narrative),
     'sd_id', sd_id_param,
-    'completed_children', completed_children
+    'completed_children', completed_children - cancelled_children,
+    'cancelled_children', cancelled_children,
+    'quality_verified', cancelled_children = 0
   );
 END;
-$$;
-
--- ============================================================================
--- check_handoff_bypass: remove the ORCHESTRATOR_AUTO_COMPLETE whitelist
--- (no code path inserts handoffs with that created_by anymore)
--- ============================================================================
-
-CREATE OR REPLACE FUNCTION check_handoff_bypass()
-RETURNS TRIGGER
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  -- Allow known system creators
-  IF NEW.created_by IN ('HANDOFF_SYSTEM', 'LEO_EXECUTOR', 'UNIFIED_HANDOFF_SYSTEM') THEN
-    RETURN NEW;
-  END IF;
-
-  -- Block unknown direct creation attempts
-  IF NEW.created_by IS NULL OR NEW.created_by = 'LEO_AGENT' THEN
-    RAISE EXCEPTION 'HANDOFF_BYPASS_BLOCKED: Direct handoff creation is not allowed.
-
-To create a handoff, run:
-  node scripts/handoff.js execute <TYPE> <SD-ID>
-
-Where TYPE is one of:
-  - LEAD-TO-PLAN
-  - PLAN-TO-EXEC
-  - EXEC-TO-PLAN
-  - PLAN-TO-LEAD
-
-Example:
-  node scripts/handoff.js execute PLAN-TO-EXEC SD-EXAMPLE-001
-
-Attempted created_by: %', COALESCE(NEW.created_by, 'NULL');
-  END IF;
-
-  RETURN NEW;
-END;
-$$;
+$function$
+;
 
 -- ============================================================================
 -- VALIDATION
@@ -181,7 +217,7 @@ $$;
 DO $$
 BEGIN
   RAISE NOTICE 'Orchestrator ghost-complete fix installed:';
-  RAISE NOTICE '  - complete_orchestrator_sd(): SD_COMPLETION retro + accepted LEAD-FINAL-APPROVAL required';
+  RAISE NOTICE '  - complete_orchestrator_sd(): SD_COMPLETION retro + executor-written accepted LEAD-FINAL-APPROVAL required';
   RAISE NOTICE '  - no fabricated PLAN-TO-LEAD rows; stages at pending_approval instead';
-  RAISE NOTICE '  - check_handoff_bypass(): ORCHESTRATOR_AUTO_COMPLETE whitelist removed';
+  RAISE NOTICE '  - incorporates 20260711 cancelled-as-terminal + PCVP logic (supersedes its section (c))';
 END $$;

--- a/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
+++ b/database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
@@ -159,8 +159,10 @@ BEGIN
 
   -- Completion witness: a genuine accepted LEAD-FINAL-APPROVAL handoff row WRITTEN BY
   -- THE EXECUTOR. created_by is the discriminator: privileged actors (ADMIN_OVERRIDE,
-  -- ORCHESTRATOR_AUTO_COMPLETE) can insert accepted rows via handoff_actor_policy(),
+  -- the legacy auto-complete actor) can insert accepted rows via handoff_actor_policy(),
   -- so an unqualified EXISTS would be forgeable with a single INSERT.
+  -- (Actor names deliberately not spelled out here: this comment lives inside prosrc and
+  -- scripts/orchestrator-rpc-enforcement-status.mjs greps the live body for markers.)
   SELECT EXISTS (
     SELECT 1 FROM sd_phase_handoffs
     WHERE sd_id = sd_id_param

--- a/database/migrations/20260712_orchestrator_ghost_complete_lead_final_rollback.sql
+++ b/database/migrations/20260712_orchestrator_ghost_complete_lead_final_rollback.sql
@@ -1,14 +1,32 @@
 -- ROLLBACK for 20260712_orchestrator_ghost_complete_lead_final.sql
 -- SD: SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001
 --
--- ⚠️  CHAIRMAN APPLY ONLY. Restores the PRIOR (permissive, ghost-complete)
--- behavior from database/migrations/20251221_orchestrator_auto_complete.sql.
--- Only use if the enforcement migration causes fleet-wide orchestrator
--- completion failures that cannot be remediated forward.
+-- ⚠️  CHAIRMAN APPLY ONLY. Restores the PRIOR (permissive, ghost-complete-capable)
+-- complete_orchestrator_sd() behavior. Only use if the enforcement migration causes
+-- fleet-wide orchestrator completion failures that cannot be remediated forward.
 --
--- To roll back: re-apply database/migrations/20251221_orchestrator_auto_complete.sql
--- verbatim — it CREATE OR REPLACEs both complete_orchestrator_sd() and
--- check_handoff_bypass() with their prior bodies. This file exists so the
--- rollback path is explicit and reviewable next to the forward migration:
+-- This file is a DOCUMENTED PROCEDURE, not a self-contained script — the prior
+-- function body lives in an earlier migration file and psql \i meta-commands are
+-- not portable across apply-migration.js / MCP apply_migration / arbitrary CWDs
+-- (adversarial review finding, 2026-07-12).
+--
+-- PROCEDURE (pick ONE, depending on what was applied before this migration):
+--
+--   Case A — 20260711_orchestrator_terminal_status_sql_parity.sql WAS applied
+--   (check: live complete_orchestrator_sd body contains 'PCVP'):
+--     Re-apply section (c) of that file — the CREATE OR REPLACE FUNCTION
+--     public.complete_orchestrator_sd block — verbatim:
+--       node scripts/apply-migration.js database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql --prod-deploy
+--     (Re-applying the whole 20260711 file is idempotent for its other sections.)
+--
+--   Case B — 20260711 was NOT applied (live body has no 'PCVP' marker):
+--     Re-apply the original 20251221 definition:
+--       node scripts/apply-migration.js database/migrations/20251221_orchestrator_auto_complete.sql --prod-deploy
+--     NOTE: 20251221 also re-creates check_handoff_bypass(), a function the 20260530
+--     handoff-actor-policy SSOT migration dropped as dead — if you use Case B, drop it
+--     again afterwards: DROP FUNCTION IF EXISTS check_handoff_bypass();
+--
+-- Verify the rollback took effect (either case):
+--   node scripts/orchestrator-rpc-enforcement-status.mjs   → should report STAGED
 
-\i database/migrations/20251221_orchestrator_auto_complete.sql
+SELECT 'This rollback is a documented procedure — read the header of this file.' AS rollback_instructions;

--- a/database/migrations/20260712_orchestrator_ghost_complete_lead_final_rollback.sql
+++ b/database/migrations/20260712_orchestrator_ghost_complete_lead_final_rollback.sql
@@ -1,0 +1,14 @@
+-- ROLLBACK for 20260712_orchestrator_ghost_complete_lead_final.sql
+-- SD: SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001
+--
+-- ⚠️  CHAIRMAN APPLY ONLY. Restores the PRIOR (permissive, ghost-complete)
+-- behavior from database/migrations/20251221_orchestrator_auto_complete.sql.
+-- Only use if the enforcement migration causes fleet-wide orchestrator
+-- completion failures that cannot be remediated forward.
+--
+-- To roll back: re-apply database/migrations/20251221_orchestrator_auto_complete.sql
+-- verbatim — it CREATE OR REPLACEs both complete_orchestrator_sd() and
+-- check_handoff_bypass() with their prior bodies. This file exists so the
+-- rollback path is explicit and reviewable next to the forward migration:
+
+\i database/migrations/20251221_orchestrator_auto_complete.sql

--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -1135,9 +1135,23 @@ export async function handleExecuteWithContinuation(handoffType, sdId, args) {
       currentSdId
     );
 
-    // If all children complete, orchestrator-completion-hook already fired
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: when all children are complete the
+    // parent is STAGED at pending_approval (not completed) — the hook no longer fires
+    // from the child path. Run the parent's LEAD-FINAL-APPROVAL here so AUTO-PROCEED
+    // genuinely completes it instead of stranding it (that run fires the hook itself,
+    // and its own result carries any grandparent staging for the next iteration).
     if (allComplete) {
-      console.log('\n✅ All children complete - orchestrator completion hook triggered');
+      const chaining = currentResult?.result?.orchestratorChaining || currentResult?.orchestratorChaining;
+      const staged = chaining?.parentRoutedToLeadFinal;
+      if (staged) {
+        console.log('\n⏸  All children complete — parent staged at pending_approval');
+        console.log('   ➡️  AUTO-PROCEED: executing parent LEAD-FINAL-APPROVAL...');
+        currentSdId = completedSD.parent_sd_id;
+        currentHandoffType = 'LEAD-FINAL-APPROVAL';
+        currentResult = await handleExecuteCommand('LEAD-FINAL-APPROVAL', completedSD.parent_sd_id, args);
+        continue;
+      }
+      console.log('\n✅ All children complete - orchestrator completion handled');
       break;
     }
 

--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -8,7 +8,9 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { executeOrchestratorCompletionHook } from '../../orchestrator-completion-hook.js';
+// SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: the orchestrator completion hook no
+// longer fires from here — parents are staged (not completed) by the guardian, and the
+// hook fires at genuine completion inside the LFA executor (index.js).
 import { publishVisionEvent, VISION_EVENTS } from '../../../../../lib/eva/event-bus/vision-events.js';
 import { closeIssuePatterns } from '../../../../../lib/governance/pattern-closure.js';
 import { isTerminalChildStatus } from '../../../../../lib/orchestrator/child-terminal-status.js';
@@ -29,7 +31,7 @@ import { isTerminalChildStatus } from '../../../../../lib/orchestrator/child-ter
  * @param {Object} [options.shippingResults] - PR merge/cleanup results from auto-shipping (SD-LEO-INFRA-AUTO-CHAIN-MERGE-001)
  * @returns {Promise<{ orchestratorCompleted: boolean, chainContinue?: boolean, nextOrchestrator?: string }>}
  */
-export async function checkAndCompleteParentSD(sd, supabase, { shippingResults } = {}) {
+export async function checkAndCompleteParentSD(sd, supabase, { shippingResults: _shippingResults } = {}) {
   console.log('\n   Checking parent SD completion...');
 
   // Default return for non-completion cases
@@ -65,30 +67,25 @@ export async function checkAndCompleteParentSD(sd, supabase, { shippingResults }
 
         const report = await guardian.validate();
 
+        // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: guardian.complete() no longer
+        // completes — it STAGES the parent at pending_approval and returns
+        // { routedToLeadFinal, leadFinalCommand }. The parent completes only when its
+        // own LEAD-FINAL-APPROVAL executor runs. Do NOT fire the completion hook or
+        // report orchestratorCompleted here — the parent is not completed yet
+        // (adversarial review: the old shape stranded parents at pending_approval
+        // while chaining fired as if they had completed).
         if (report.canComplete) {
           const result = await guardian.complete();
-          if (result.success) {
-            console.log(`   ✅ Parent SD "${parentSD.title}" completed via Guardian`);
-
-            // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
-            // SD-LEO-ENH-AUTO-PROCEED-001-05: Returns chaining info if enabled
-            // SD-LEO-INFRA-ORCHESTRATOR-GATE-FIXES-ORCH-001-A: pass callerSessionId
-            // so the hook excludes the current session from active claim checks
-            const hookResult = await executeOrchestratorCompletionHook(
-              parentSD.id,
-              parentSD.title,
-              siblings.length,
-              { supabase, shippingResults, callerSessionId: sd.claiming_session_id }
-            );
-
+          if (result.success && result.routedToLeadFinal) {
+            console.log(`   ⏸  Parent SD "${parentSD.title}" staged at pending_approval — LEAD-FINAL-APPROVAL required:`);
+            console.log(`      ${result.leadFinalCommand}`);
             return {
-              orchestratorCompleted: true,
-              chainContinue: hookResult?.chainContinue || false,
-              nextOrchestrator: hookResult?.nextOrchestrator || null,
-              nextOrchestratorSdKey: hookResult?.nextOrchestratorSdKey || null
+              orchestratorCompleted: false,
+              parentRoutedToLeadFinal: true,
+              leadFinalCommand: result.leadFinalCommand
             };
-          } else {
-            console.log(`   ⚠️  Guardian completion failed: ${result.error}`);
+          } else if (!result.success) {
+            console.log(`   ⚠️  Guardian staging failed: ${result.error}`);
             await recordFailedCompletion(parentSD, result.error, null, supabase);
           }
         } else if (report.canAutoComplete) {
@@ -96,27 +93,16 @@ export async function checkAndCompleteParentSD(sd, supabase, { shippingResults }
           await guardian.autoCreateArtifacts();
 
           const result = await guardian.complete();
-          if (result.success) {
-            console.log(`   ✅ Parent SD "${parentSD.title}" completed (with auto-created artifacts)`);
-
-            // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
-            // SD-LEO-ENH-AUTO-PROCEED-001-05: Returns chaining info if enabled
-            // SD-LEO-INFRA-ORCHESTRATOR-GATE-FIXES-ORCH-001-A: pass callerSessionId
-            const hookResult = await executeOrchestratorCompletionHook(
-              parentSD.id,
-              parentSD.title,
-              siblings.length,
-              { supabase, shippingResults, callerSessionId: sd.claiming_session_id }
-            );
-
+          if (result.success && result.routedToLeadFinal) {
+            console.log(`   ⏸  Parent SD "${parentSD.title}" staged at pending_approval (artifacts auto-created) — LEAD-FINAL-APPROVAL required:`);
+            console.log(`      ${result.leadFinalCommand}`);
             return {
-              orchestratorCompleted: true,
-              chainContinue: hookResult?.chainContinue || false,
-              nextOrchestrator: hookResult?.nextOrchestrator || null,
-              nextOrchestratorSdKey: hookResult?.nextOrchestratorSdKey || null
+              orchestratorCompleted: false,
+              parentRoutedToLeadFinal: true,
+              leadFinalCommand: result.leadFinalCommand
             };
-          } else {
-            console.log(`   ⚠️  Completion failed after auto-fix: ${result.error}`);
+          } else if (!result.success) {
+            console.log(`   ⚠️  Staging failed after auto-fix: ${result.error}`);
             await recordFailedCompletion(parentSD, result.error, null, supabase);
           }
         } else {

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -736,15 +736,14 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     // run — so THIS is where the orchestrator completion hook (chaining, learn queue)
     // fires; the old direct-complete paths that used to fire it no longer complete.
     try {
-      const { data: childRows } = await this.supabase
+      const { count: childCount } = await this.supabase
         .from('strategic_directives_v2')
-        .select('id')
-        .eq('parent_sd_id', sd.id)
-        .limit(1);
-      if (childRows?.length) {
+        .select('id', { count: 'exact', head: true })
+        .eq('parent_sd_id', sd.id);
+      if (childCount > 0) {
         const { executeOrchestratorCompletionHook } = await import('../../orchestrator-completion-hook.js');
         const hookResult = await executeOrchestratorCompletionHook(
-          sd.id, sd.title, childRows.length,
+          sd.id, sd.title, childCount,
           { supabase: this.supabase, shippingResults, callerSessionId: sd.claiming_session_id }
         );
         orchestratorChainingInfo = {
@@ -814,11 +813,15 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       worktree_cleanup: worktreeCleanupResult,
       qualityScore: gateResults.normalizedScore ?? Math.round((gateResults.totalScore / gateResults.totalMaxScore) * 100),
       // SD-LEO-ENH-AUTO-PROCEED-001-05: Orchestrator chaining info
-      orchestratorChaining: orchestratorChainingInfo.orchestratorCompleted ? {
-        orchestratorCompleted: true,
+      // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: staged-parent info must reach the
+      // machine-readable result — console output alone loses the parent's LFA command.
+      orchestratorChaining: (orchestratorChainingInfo.orchestratorCompleted || orchestratorChainingInfo.parentRoutedToLeadFinal) ? {
+        orchestratorCompleted: orchestratorChainingInfo.orchestratorCompleted || false,
         chainContinue: orchestratorChainingInfo.chainContinue || false,
         nextOrchestrator: orchestratorChainingInfo.nextOrchestrator || null,
-        nextOrchestratorSdKey: orchestratorChainingInfo.nextOrchestratorSdKey || null
+        nextOrchestratorSdKey: orchestratorChainingInfo.nextOrchestratorSdKey || null,
+        parentRoutedToLeadFinal: orchestratorChainingInfo.parentRoutedToLeadFinal || false,
+        leadFinalCommand: orchestratorChainingInfo.leadFinalCommand || null
       } : null
     };
   }

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -730,8 +730,45 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
     // SD-LEO-ENH-AUTO-PROCEED-001-05: Capture chaining info for orchestrator continuation
     // SD-LEO-INFRA-AUTO-CHAIN-MERGE-001: Pass shippingResults so auto-chain can gate on merge
     let orchestratorChainingInfo = { orchestratorCompleted: false };
+
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: with the ghost-complete paths closed,
+    // an orchestrator parent now genuinely completes HERE, via its own LEAD-FINAL-APPROVAL
+    // run — so THIS is where the orchestrator completion hook (chaining, learn queue)
+    // fires; the old direct-complete paths that used to fire it no longer complete.
+    try {
+      const { data: childRows } = await this.supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sd.id)
+        .limit(1);
+      if (childRows?.length) {
+        const { executeOrchestratorCompletionHook } = await import('../../orchestrator-completion-hook.js');
+        const hookResult = await executeOrchestratorCompletionHook(
+          sd.id, sd.title, childRows.length,
+          { supabase: this.supabase, shippingResults, callerSessionId: sd.claiming_session_id }
+        );
+        orchestratorChainingInfo = {
+          orchestratorCompleted: true,
+          chainContinue: hookResult?.chainContinue || false,
+          nextOrchestrator: hookResult?.nextOrchestrator || null,
+          nextOrchestratorSdKey: hookResult?.nextOrchestratorSdKey || null
+        };
+      }
+    } catch (hookErr) {
+      console.warn(`   ⚠️  Orchestrator completion hook error (non-blocking): ${hookErr.message}`);
+    }
+
     if (sd.parent_sd_id) {
-      orchestratorChainingInfo = await checkAndCompleteParentSD(sd, this.supabase, { shippingResults });
+      const parentInfo = await checkAndCompleteParentSD(sd, this.supabase, { shippingResults });
+      if (orchestratorChainingInfo.orchestratorCompleted) {
+        // This SD's own orchestrator-completion chaining wins; parent staging info augments it.
+        if (parentInfo.parentRoutedToLeadFinal) {
+          orchestratorChainingInfo.parentRoutedToLeadFinal = true;
+          orchestratorChainingInfo.leadFinalCommand = parentInfo.leadFinalCommand;
+        }
+      } else {
+        orchestratorChainingInfo = parentInfo;
+      }
     }
 
     // SD-LEO-INFRA-INTEGRATE-WORKTREE-CREATION-001: Cleanup worktree on SD completion

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -397,14 +397,20 @@ export class PlanToLeadExecutor extends BaseExecutor {
       const result = await completeOrchestratorSD(this.supabase, sdId, children.length);
 
       if (!result.success) {
-        return ResultBuilder.rejected('ID_NORMALIZATION_FAILED', result.error);
+        const code = result.canonicalId ? 'ORCHESTRATOR_LEAD_FINAL_STAGING_FAILED' : 'ID_NORMALIZATION_FAILED';
+        return ResultBuilder.rejected(code, result.error);
       }
 
       // SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-E: Parent orchestrator completion
       // When all children complete, parent gets finalization commands
       // PAT-PRD-DUP-001: Import from source module (state-transitions.js doesn't re-export this)
+      // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: the SD is at pending_approval, not
+      // completed — LEAD-FINAL-APPROVAL must run before the finalization commands.
       const { getParentFinalizationCommands } = await import('../../../../../lib/utils/orchestrator-child-completion.js');
-      const parentCommands = getParentFinalizationCommands({ sd_key: sd.sd_key || sd.id });
+      const parentCommands = [
+        ...(result.leadFinalCommand ? [result.leadFinalCommand] : []),
+        ...getParentFinalizationCommands({ sd_key: sd.sd_key || sd.id })
+      ];
 
       return {
         success: true,

--- a/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
@@ -206,15 +206,12 @@ export async function checkAndCompleteParentSD(supabase, sd) {
       // Child commands first, then parent commands
       result.commandsToRun = [...result.childCommands, ...result.parentCommands];
 
-      // Recursively check grandparent — it stages at pending_approval at most;
-      // its own LEAD-FINAL-APPROVAL gates enforce genuine child completion.
-      if (parentSD.parent_sd_id) {
-        console.log('   📊 Checking grandparent SD...');
-        const grandparentResult = await checkAndCompleteParentSD(supabase, parentSD);
-        if (grandparentResult.parentCommands.length > 0) {
-          result.commandsToRun.push(...grandparentResult.parentCommands);
-        }
-      }
+      // No eager grandparent recursion: the parent is only staged at pending_approval,
+      // NOT completed, so the grandparent's children are not yet all terminal. The
+      // grandparent cascade fires when the parent GENUINELY completes via its
+      // LEAD-FINAL-APPROVAL (that executor's own parent-completion path handles it).
+      // Recursing here staged grandparents whose children were incomplete — the exact
+      // ghost-complete class this SD closes (adversarial review 2026-07-12).
     }
   } catch (error) {
     console.log(`   ⚠️  Parent completion check error: ${error.message}`);

--- a/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
@@ -17,6 +17,11 @@ import {
   getParentFinalizationCommands
 } from '../../../../../lib/utils/orchestrator-child-completion.js';
 
+// SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: orchestrator parents may no longer
+// be written to status='completed' here — they stage at pending_approval and the
+// LEAD-FINAL-APPROVAL executor is the only completion writer.
+import { routeOrchestratorToLeadFinal } from '../../lib/orchestrator-terminal-guard.js';
+
 /**
  * Finalize user stories to completed status
  *
@@ -173,40 +178,36 @@ export async function checkAndCompleteParentSD(supabase, sd) {
       return result;
     }
 
-    console.log(`   🎉 All ${siblings.length} children completed - auto-completing parent SD`);
+    console.log(`   🎉 All ${siblings.length} children completed - routing parent to LEAD-FINAL-APPROVAL`);
 
     // Satisfy template requirements before attempting completion
     // RCA: PAT-TEMPLATE-CODE-SYNC-001
     await satisfyOrchestratorTemplateRequirements(supabase, parentSD.id, parentSD.title);
 
-    // SD-LEO-FIX-COMPLETION-WORKFLOW-001: Also reset is_working_on when auto-completing
-    const { error: updateError } = await supabase
-      .from('strategic_directives_v2')
-      .update({
-        status: 'completed',
-        progress: 100,
-        current_phase: 'COMPLETED',
-        is_working_on: false,  // Critical: prevent stale "working on" status
-        updated_at: new Date().toISOString()
-      })
-      .eq('id', parentSD.id);
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: never write status='completed'
+    // here — stage at pending_approval; the LEAD-FINAL-APPROVAL executor (with the
+    // canonical SD_COMPLETION retro gate) is the only completion writer.
+    const routing = await routeOrchestratorToLeadFinal(supabase, parentSD, {
+      source: 'plan-to-lead:checkAndCompleteParentSD'
+    });
 
-    if (updateError) {
-      console.log(`   ⚠️  Could not complete parent SD: ${updateError.message}`);
+    if (!routing.routed) {
       result.commandsToRun = result.childCommands;
     } else {
-      console.log(`   ✅ Parent SD "${parentSD.title}" auto-completed!`);
-      result.parentCompleted = true;
+      // Completion is now pending LEAD-FINAL-APPROVAL — not yet completed.
+      result.parentCompleted = false;
+      result.parentRoutedToLeadFinal = true;
 
-      // Get parent finalization commands (document, leo next)
-      // SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-E
-      result.parentCommands = getParentFinalizationCommands(parentSD);
+      // LEAD-FINAL first, then finalization commands (document, leo next) which
+      // must only run after genuine completion.
+      result.parentCommands = [routing.command, ...getParentFinalizationCommands(parentSD)];
       console.log(`   📋 Parent finalization commands: ${result.parentCommands.join(', ')}`);
 
       // Child commands first, then parent commands
       result.commandsToRun = [...result.childCommands, ...result.parentCommands];
 
-      // Recursively check grandparent
+      // Recursively check grandparent — it stages at pending_approval at most;
+      // its own LEAD-FINAL-APPROVAL gates enforce genuine child completion.
       if (parentSD.parent_sd_id) {
         console.log('   📊 Checking grandparent SD...');
         const grandparentResult = await checkAndCompleteParentSD(supabase, parentSD);
@@ -312,7 +313,11 @@ export async function satisfyOrchestratorTemplateRequirements(supabase, sdId, sd
         .insert({
           sd_id: sdId,
           title: `Orchestrator Completion: ${sdTitle}`,
-          retro_type: 'orchestrator_completion',
+          // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: must be the canonical
+          // completion type — retro-filters.js and the LEAD-FINAL-APPROVAL gate
+          // filter on retro_type='SD_COMPLETION'; the previous value
+          // 'orchestrator_completion' made this row invisible to both.
+          retro_type: 'SD_COMPLETION',
           status: 'PUBLISHED',
           generated_by: 'SUB_AGENT',
           trigger_event: 'ORCHESTRATOR_TEMPLATE_SATISFACTION',
@@ -371,37 +376,40 @@ export async function completeOrchestratorSD(supabase, sdId, childrenCount) {
   // RCA: PAT-TEMPLATE-CODE-SYNC-001
   await satisfyOrchestratorTemplateRequirements(supabase, canonicalId, sdId);
 
-  // SD-LEO-FIX-COMPLETION-WORKFLOW-001: Also reset is_working_on when completing orchestrator
-  const { data: updateResult, error: sdError } = await supabase
+  // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: PLAN-TO-LEAD stages the
+  // orchestrator at pending_approval (same as standard SDs) — only the
+  // LEAD-FINAL-APPROVAL executor writes status='completed'.
+  const { data: sdRow } = await supabase
     .from('strategic_directives_v2')
-    .update({
-      status: 'completed',
-      current_phase: 'LEAD',
-      progress_percentage: 100,
-      is_working_on: false,  // Critical: prevent stale "working on" status
-      updated_at: new Date().toISOString()
-    })
+    .select('id, sd_key, created_at, status')
     .eq('id', canonicalId)
-    .select('id')
-    .single();
+    .maybeSingle();
 
-  if (sdError) {
-    console.log(`   ⚠️  SD update error: ${sdError.message}`);
-  } else if (!updateResult) {
-    console.log('   ⚠️  SD update returned no data - possible silent failure');
-  } else {
-    console.log('   ✅ Orchestrator SD status transitioned: → completed');
-    console.log('   ✅ Progress set to 100% (all children complete)');
+  const routing = await routeOrchestratorToLeadFinal(supabase, sdRow || { id: canonicalId }, {
+    source: 'plan-to-lead:completeOrchestratorSD'
+  });
+
+  if (!routing.routed) {
+    return {
+      success: false,
+      error: `Orchestrator could not be staged for LEAD-FINAL-APPROVAL (${routing.reason}). ` +
+        'A retro_type=\'SD_COMPLETION\' retrospective created after LEAD-TO-PLAN acceptance is required.',
+      handoffId,
+      childrenCount,
+      canonicalId
+    };
   }
 
-  console.log('\n🎉 ORCHESTRATOR COMPLETION: All children finished, parent SD marked complete');
+  console.log('\n⏸  ORCHESTRATOR PLAN-TO-LEAD complete: parent at pending_approval, LEAD-FINAL-APPROVAL required');
   console.log('📊 Handoff ID:', handoffId);
 
   return {
     success: true,
     handoffId,
     childrenCount,
-    canonicalId
+    canonicalId,
+    routedToLeadFinal: true,
+    leadFinalCommand: routing.command
   };
 }
 

--- a/scripts/modules/handoff/lib/orchestrator-terminal-guard.js
+++ b/scripts/modules/handoff/lib/orchestrator-terminal-guard.js
@@ -1,0 +1,81 @@
+/**
+ * Orchestrator terminal-transition guard (SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001)
+ *
+ * Orchestrator parents used to "ghost-complete": auto-complete paths wrote
+ * status='completed' directly once all children finished, skipping the
+ * LEAD-FINAL-APPROVAL executor entirely, and their retrospective checks
+ * accepted ANY retro row regardless of retro_type.
+ *
+ * This module is the single funnel those paths now route through:
+ *   1. Canonical retro check via retro-filters.js (retro_type='SD_COMPLETION',
+ *      freshness after LEAD-TO-PLAN acceptance) — the same contract the
+ *      LEAD-FINAL-APPROVAL RETROSPECTIVE_EXISTS gate enforces.
+ *   2. Stage the SD at status='pending_approval' (the entry state the
+ *      LEAD-FINAL-APPROVAL executor requires).
+ *   3. Surface the LEAD-FINAL-APPROVAL command — the executor is the ONLY
+ *      writer of status='completed'; no caller may fabricate completion.
+ */
+
+import { getFilteredRetrospective } from '../retro-filters.js';
+
+/**
+ * The command that genuinely completes an orchestrator parent.
+ *
+ * @param {string} sdRef - sd_key (preferred) or id
+ * @returns {string}
+ */
+export function leadFinalCommand(sdRef) {
+  return `node scripts/handoff.js execute LEAD-FINAL-APPROVAL ${sdRef}`;
+}
+
+/**
+ * Route an orchestrator parent toward genuine completion via LEAD-FINAL-APPROVAL.
+ *
+ * Never writes status='completed'. On success the SD sits at 'pending_approval'
+ * and the returned command drives the real executor (whose gates re-verify the
+ * retro and write the canonical accepted LEAD-FINAL handoff row).
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} sd - SD row; requires id, uses sd_key/created_at when present
+ * @param {Object} [opts]
+ * @param {string} [opts.source] - calling path, for log attribution
+ * @returns {Promise<{routed: boolean, reason: string|null, command: string|null}>}
+ */
+export async function routeOrchestratorToLeadFinal(supabase, sd, { source = 'orchestrator-completion' } = {}) {
+  const sdRef = sd.sd_key || sd.id;
+
+  const { retrospective, leadToPlanAcceptedAt, error: retroError } = await getFilteredRetrospective(
+    sd.id, sd.created_at || null, supabase, sd.sd_key || null
+  );
+
+  if (retroError) {
+    console.log(`   ⚠️  [${source}] Retro lookup failed for ${sdRef}: ${retroError.message}`);
+    return { routed: false, reason: 'RETRO_LOOKUP_FAILED', command: null };
+  }
+
+  if (!retrospective) {
+    console.log(`   ⛔ [${source}] ${sdRef}: no SD-completion retrospective (retro_type='SD_COMPLETION', created_at > ${leadToPlanAcceptedAt}) — refusing to advance toward completion.`);
+    console.log('      Remediation: run the RETRO sub-agent to generate a retro_type=\'SD_COMPLETION\' retrospective, then re-run the completion flow.');
+    return { routed: false, reason: 'RETRO_MISSING', command: null };
+  }
+
+  const { error: updateError } = await supabase
+    .from('strategic_directives_v2')
+    .update({
+      status: 'pending_approval',
+      is_working_on: false,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', sd.id)
+    .neq('status', 'completed');
+
+  if (updateError) {
+    console.log(`   ⚠️  [${source}] Could not stage ${sdRef} at pending_approval: ${updateError.message}`);
+    return { routed: false, reason: 'STAGE_UPDATE_FAILED', command: null };
+  }
+
+  const command = leadFinalCommand(sdRef);
+  console.log(`   ⏸  [${source}] ${sdRef} staged at pending_approval — completion requires LEAD-FINAL-APPROVAL:`);
+  console.log(`      ${command}`);
+  return { routed: true, reason: null, command };
+}

--- a/scripts/modules/handoff/lib/orchestrator-terminal-guard.js
+++ b/scripts/modules/handoff/lib/orchestrator-terminal-guard.js
@@ -44,6 +44,11 @@ export function leadFinalCommand(sdRef) {
 export async function routeOrchestratorToLeadFinal(supabase, sd, { source = 'orchestrator-completion' } = {}) {
   const sdRef = sd.sd_key || sd.id;
 
+  if (sd.status === 'completed') {
+    console.log(`   ℹ️  [${source}] ${sdRef} already completed — nothing to stage.`);
+    return { routed: false, reason: 'ALREADY_COMPLETED', command: null };
+  }
+
   const { retrospective, leadToPlanAcceptedAt, error: retroError } = await getFilteredRetrospective(
     sd.id, sd.created_at || null, supabase, sd.sd_key || null
   );
@@ -59,11 +64,14 @@ export async function routeOrchestratorToLeadFinal(supabase, sd, { source = 'orc
     return { routed: false, reason: 'RETRO_MISSING', command: null };
   }
 
+  // is_working_on is deliberately NOT cleared: the LFA executor's canonical handoff
+  // insert (created_by='UNIFIED-HANDOFF-SYSTEM') does not skip the claim check, and
+  // enforce_is_working_on_for_handoffs rejects it when is_working_on is false —
+  // parity with completeStandardSD's staging behavior (adversarial review 2026-07-12).
   const { error: updateError } = await supabase
     .from('strategic_directives_v2')
     .update({
       status: 'pending_approval',
-      is_working_on: false,
       updated_at: new Date().toISOString()
     })
     .eq('id', sd.id)

--- a/scripts/modules/handoff/lib/orchestrator-terminal-guard.test.js
+++ b/scripts/modules/handoff/lib/orchestrator-terminal-guard.test.js
@@ -90,8 +90,22 @@ describe('routeOrchestratorToLeadFinal', () => {
     expect(payload.status).toBe('pending_approval');
     expect(payload.status).not.toBe('completed');
     expect(payload.current_phase).toBeUndefined(); // terminal phase is written only by the LFA executor
+    // is_working_on must survive staging — the LFA canonical handoff insert requires it
+    expect(payload.is_working_on).toBeUndefined();
     // guard refuses to touch already-completed rows
     expect(sdChain.neq).toHaveBeenCalledWith('status', 'completed');
+  });
+
+  it('short-circuits with ALREADY_COMPLETED for a completed SD without touching the DB', async () => {
+    const supabase = { from: vi.fn(() => { throw new Error('no DB access expected'); }) };
+    const result = await routeOrchestratorToLeadFinal(
+      supabase,
+      { id: 'uuid-1', sd_key: 'SD-ORCH-001', status: 'completed' },
+      { source: 'test' }
+    );
+    expect(result.routed).toBe(false);
+    expect(result.reason).toBe('ALREADY_COMPLETED');
+    expect(supabase.from).not.toHaveBeenCalled();
   });
 
   it('returns STAGE_UPDATE_FAILED (no command) when the staging update errors', async () => {

--- a/scripts/modules/handoff/lib/orchestrator-terminal-guard.test.js
+++ b/scripts/modules/handoff/lib/orchestrator-terminal-guard.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for orchestrator-terminal-guard.js
+ * SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001
+ *
+ * Invariants:
+ *   1. No canonical SD_COMPLETION retro -> refuse (RETRO_MISSING), no SD write at all.
+ *   2. Canonical retro -> stage at status='pending_approval' and surface the
+ *      LEAD-FINAL-APPROVAL command. NEVER write status='completed'.
+ *   3. Staging update failure -> routed=false, no command.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { routeOrchestratorToLeadFinal, leadFinalCommand } from './orchestrator-terminal-guard.js';
+
+/**
+ * Chainable, thenable Supabase query mock. Every builder method returns the
+ * chain; awaiting the chain (or calling maybeSingle) resolves `result`.
+ */
+function makeChain(result) {
+  const c = {};
+  ['select', 'eq', 'neq', 'or', 'gt', 'order', 'limit', 'update', 'insert', 'in'].forEach(m => {
+    c[m] = vi.fn(() => c);
+  });
+  c.maybeSingle = vi.fn(async () => result);
+  c.single = vi.fn(async () => result);
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+}
+
+function makeSupabase(tables) {
+  return {
+    from: vi.fn((table) => {
+      if (!tables[table]) throw new Error(`unexpected table: ${table}`);
+      return tables[table];
+    })
+  };
+}
+
+describe('leadFinalCommand', () => {
+  it('names the LEAD-FINAL-APPROVAL executor for the SD', () => {
+    expect(leadFinalCommand('SD-X-001')).toBe('node scripts/handoff.js execute LEAD-FINAL-APPROVAL SD-X-001');
+  });
+});
+
+describe('routeOrchestratorToLeadFinal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses with RETRO_MISSING and performs NO SD write when no canonical retro exists', async () => {
+    const sdChain = makeChain({ data: null, error: null });
+    const supabase = makeSupabase({
+      strategic_directives_v2: sdChain,
+      sd_phase_handoffs: makeChain({ data: null, error: null }),
+      retrospectives: makeChain({ data: null, error: null }) // e.g. only HANDOFF retros -> filter matches nothing
+    });
+
+    const result = await routeOrchestratorToLeadFinal(
+      supabase,
+      { id: 'uuid-1', created_at: '2026-01-01T00:00:00Z' },
+      { source: 'test' }
+    );
+
+    expect(result.routed).toBe(false);
+    expect(result.reason).toBe('RETRO_MISSING');
+    expect(result.command).toBeNull();
+    expect(sdChain.update).not.toHaveBeenCalled();
+  });
+
+  it('stages at pending_approval (never completed) and surfaces the LEAD-FINAL command when the canonical retro exists', async () => {
+    const sdChain = makeChain({ data: { id: 'uuid-1' }, error: null });
+    const supabase = makeSupabase({
+      strategic_directives_v2: sdChain,
+      sd_phase_handoffs: makeChain({ data: { accepted_at: '2026-01-02T00:00:00Z' }, error: null }),
+      retrospectives: makeChain({
+        data: { id: 'r1', retro_type: 'SD_COMPLETION', created_at: '2026-01-03T00:00:00Z' },
+        error: null
+      })
+    });
+
+    const result = await routeOrchestratorToLeadFinal(
+      supabase,
+      { id: 'uuid-1', sd_key: 'SD-ORCH-001', created_at: '2026-01-01T00:00:00Z' },
+      { source: 'test' }
+    );
+
+    expect(result.routed).toBe(true);
+    expect(result.command).toBe('node scripts/handoff.js execute LEAD-FINAL-APPROVAL SD-ORCH-001');
+
+    expect(sdChain.update).toHaveBeenCalledOnce();
+    const payload = sdChain.update.mock.calls[0][0];
+    expect(payload.status).toBe('pending_approval');
+    expect(payload.status).not.toBe('completed');
+    expect(payload.current_phase).toBeUndefined(); // terminal phase is written only by the LFA executor
+    // guard refuses to touch already-completed rows
+    expect(sdChain.neq).toHaveBeenCalledWith('status', 'completed');
+  });
+
+  it('returns STAGE_UPDATE_FAILED (no command) when the staging update errors', async () => {
+    const sdChain = makeChain({ data: null, error: { message: 'trigger blocked' } });
+    const supabase = makeSupabase({
+      strategic_directives_v2: sdChain,
+      sd_phase_handoffs: makeChain({ data: null, error: null }),
+      retrospectives: makeChain({
+        data: { id: 'r1', retro_type: 'SD_COMPLETION', created_at: '2026-01-03T00:00:00Z' },
+        error: null
+      })
+    });
+
+    const result = await routeOrchestratorToLeadFinal(
+      supabase,
+      { id: 'uuid-1', created_at: '2026-01-01T00:00:00Z' },
+      { source: 'test' }
+    );
+
+    expect(result.routed).toBe(false);
+    expect(result.reason).toBe('STAGE_UPDATE_FAILED');
+    expect(result.command).toBeNull();
+  });
+});

--- a/scripts/modules/handoff/orchestrator-completion-guardian.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian.js
@@ -16,6 +16,10 @@
 import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
 import { extractContracts, detectMismatches } from './executors/exec-to-plan/gates/cross-child-integration-gate.js';
 import { isTerminalChildStatus } from '../../../lib/orchestrator/child-terminal-status.js';
+// SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: canonical completion-retro contract
+// + terminal-transition guard (guardian may no longer write status='completed').
+import { getFilteredRetrospective } from './retro-filters.js';
+import { routeOrchestratorToLeadFinal } from './lib/orchestrator-terminal-guard.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -366,17 +370,18 @@ export class OrchestratorCompletionGuardian {
    * Validate retrospective exists with sufficient quality
    */
   async validateRetrospective() {
-    const { data: retro, error } = await supabase
-      .from('retrospectives')
-      .select('id, quality_score, status, key_learnings')
-      .eq('sd_id', this.sdId)
-      .single();
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: use the canonical filter
+    // (retro_type='SD_COMPLETION', created after LEAD-TO-PLAN acceptance) instead
+    // of accepting ANY retro row — a HANDOFF retro must not satisfy completion.
+    const { retrospective: retro, error } = await getFilteredRetrospective(
+      this.sdId, this.parentData?.created_at || null, supabase, this.parentData?.sd_key || null
+    );
 
     if (error || !retro) {
       this.validationResults.push({
         check: 'RETROSPECTIVE',
         passed: false,
-        message: 'No retrospective found for orchestrator SD',
+        message: 'No SD-completion retrospective found (must be retro_type=SD_COMPLETION, created after LEAD-TO-PLAN acceptance)',
         canAutoFix: true,
         autoFixAction: 'CREATE_RETROSPECTIVE'
       });
@@ -730,38 +735,31 @@ export class OrchestratorCompletionGuardian {
    * Complete the orchestrator SD after all artifacts are in place
    */
   async complete() {
-    console.log('\n🎯 COMPLETING ORCHESTRATOR SD');
+    console.log('\n🎯 STAGING ORCHESTRATOR SD FOR LEAD-FINAL-APPROVAL');
     console.log('════════════════════════════════════════════════════════════');
 
-    // Use direct update (Supabase client should work now that artifacts exist)
-    const { data, error } = await supabase
-      .from('strategic_directives_v2')
-      .update({
-        status: 'completed',
-        progress: 100,
-        current_phase: 'COMPLETED',
-        completion_date: new Date().toISOString()
-      })
-      .eq('id', this.sdId)
-      .select('id, status, progress')
-      .single();
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: the guardian may not write
+    // status='completed'. It stages the SD at pending_approval; only the
+    // LEAD-FINAL-APPROVAL executor (with its retro + handoff gates) completes.
+    const routing = await routeOrchestratorToLeadFinal(
+      supabase,
+      this.parentData || { id: this.sdId },
+      { source: 'orchestrator-completion-guardian' }
+    );
 
-    if (error) {
-      console.log(`\n❌ COMPLETION FAILED: ${error.message}`);
-      console.log('\n💡 This may be a LEO Protocol trigger blocking the update.');
-      console.log(`   Run: node scripts/complete-orchestrator-direct.js ${this.sdId}`);
-      return { success: false, error: error.message };
+    if (!routing.routed) {
+      console.log(`\n❌ STAGING FAILED: ${routing.reason}`);
+      console.log('   A retro_type=\'SD_COMPLETION\' retrospective (created after LEAD-TO-PLAN acceptance) is required.');
+      return { success: false, error: routing.reason };
     }
 
-    console.log('\n🎉 ORCHESTRATOR COMPLETED SUCCESSFULLY');
-    console.log(`   ID: ${data.id}`);
-    console.log(`   Status: ${data.status}`);
-    console.log(`   Progress: ${data.progress}%`);
+    console.log('\n⏸  ORCHESTRATOR STAGED — run LEAD-FINAL-APPROVAL to complete:');
+    console.log(`   ${routing.command}`);
 
-    // Record pattern success
+    // Record pattern success (artifacts staged; genuine completion via LEAD-FINAL)
     await this.recordPatternSuccess();
 
-    return { success: true, data };
+    return { success: true, routedToLeadFinal: true, leadFinalCommand: routing.command };
   }
 
   /**

--- a/scripts/orchestrator-rpc-enforcement-status.mjs
+++ b/scripts/orchestrator-rpc-enforcement-status.mjs
@@ -18,7 +18,9 @@ const ENFORCEMENT_MARKERS = [
   { fn: 'complete_orchestrator_sd', marker: 'LEAD-FINAL-APPROVAL', meaning: 'requires accepted LEAD-FINAL-APPROVAL row' },
   { fn: 'complete_orchestrator_sd', marker: "retro_type = 'SD_COMPLETION'", meaning: 'canonical retro filter' },
   { fn: 'complete_orchestrator_sd', marker: 'UNIFIED-HANDOFF-SYSTEM', meaning: 'executor-written witness allow-list (forged ADMIN_OVERRIDE rows rejected)' },
-  { fn: 'complete_orchestrator_sd', marker: 'ORCHESTRATOR_AUTO_COMPLETE', meaning: 'fabricated PLAN-TO-LEAD insert (must be ABSENT)', mustBeAbsent: true }
+  // Executable pattern, not the actor name: the actor name appears in the new body's
+  // rationale comments (preserved in pg_proc.prosrc), which would false-positive forever.
+  { fn: 'complete_orchestrator_sd', marker: 'INSERT INTO sd_phase_handoffs', meaning: 'fabricated PLAN-TO-LEAD insert (must be ABSENT)', mustBeAbsent: true }
 ];
 
 async function main() {

--- a/scripts/orchestrator-rpc-enforcement-status.mjs
+++ b/scripts/orchestrator-rpc-enforcement-status.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * orchestrator-rpc-enforcement-status.mjs
+ * SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001 (FR-4 / TS-7)
+ *
+ * READ-ONLY check of whether the staged migration
+ * database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql
+ * has been applied to the live database. Migration files that exist and are
+ * git-tracked are NOT evidence they were applied (retro 8d83c6a2) — this
+ * script inspects the live function body.
+ *
+ * Exit 0 always (status report, not a gate). Prints APPLIED or STAGED.
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+const ENFORCEMENT_MARKERS = [
+  { fn: 'complete_orchestrator_sd', marker: 'LEAD-FINAL-APPROVAL', meaning: 'requires accepted LEAD-FINAL-APPROVAL row' },
+  { fn: 'complete_orchestrator_sd', marker: "retro_type = 'SD_COMPLETION'", meaning: 'canonical retro filter' },
+  { fn: 'check_handoff_bypass', marker: 'ORCHESTRATOR_AUTO_COMPLETE', meaning: 'fabrication whitelist (must be ABSENT)', mustBeAbsent: true }
+];
+
+async function main() {
+  const client = await createDatabaseClient('engineer', { verify: true });
+  try {
+    const { rows } = await client.query(
+      "SELECT proname, prosrc FROM pg_proc WHERE proname = ANY($1::text[])",
+      [[...new Set(ENFORCEMENT_MARKERS.map(m => m.fn))]]
+    );
+    const bodies = Object.fromEntries(rows.map(r => [r.proname, r.prosrc]));
+
+    let applied = true;
+    for (const check of ENFORCEMENT_MARKERS) {
+      const body = bodies[check.fn];
+      if (!body) {
+        console.log(`❌ ${check.fn}: function not found in live DB`);
+        applied = false;
+        continue;
+      }
+      const present = body.includes(check.marker);
+      const ok = check.mustBeAbsent ? !present : present;
+      console.log(`${ok ? '✅' : '⚠️ '} ${check.fn}: ${check.meaning} — ${check.mustBeAbsent ? (present ? 'STILL PRESENT' : 'absent (good)') : (present ? 'present' : 'MISSING')}`);
+      if (!ok) applied = false;
+    }
+
+    console.log('');
+    if (applied) {
+      console.log('STATUS: APPLIED — live RPC enforces LEAD-FINAL + SD_COMPLETION retro.');
+    } else {
+      console.log('STATUS: STAGED — live RPC still permissive (ghost-complete possible via SQL path).');
+      console.log('        JS-path enforcement is independent and already active once the PR merges.');
+      console.log('        Chairman apply: node scripts/apply-migration.js database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql --prod-deploy');
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch(err => {
+  console.error('Verification failed to run (this is a connectivity/read error, not an enforcement verdict):', err.message);
+  process.exit(0);
+});

--- a/scripts/orchestrator-rpc-enforcement-status.mjs
+++ b/scripts/orchestrator-rpc-enforcement-status.mjs
@@ -23,10 +23,8 @@ const ENFORCEMENT_MARKERS = [
 async function main() {
   const client = await createDatabaseClient('engineer', { verify: true });
   try {
-    const { rows } = await client.query(
-      "SELECT proname, prosrc FROM pg_proc WHERE proname = ANY($1::text[])",
-      [[...new Set(ENFORCEMENT_MARKERS.map(m => m.fn))]]
-    );
+    const functionBodyQuery = 'SELECT proname, prosrc FROM pg_proc WHERE proname = ANY($1::text[])';
+    const { rows } = await client.query(functionBodyQuery, [[...new Set(ENFORCEMENT_MARKERS.map(m => m.fn))]]);
     const bodies = Object.fromEntries(rows.map(r => [r.proname, r.prosrc]));
 
     let applied = true;

--- a/scripts/orchestrator-rpc-enforcement-status.mjs
+++ b/scripts/orchestrator-rpc-enforcement-status.mjs
@@ -17,7 +17,8 @@ import { createDatabaseClient } from './lib/supabase-connection.js';
 const ENFORCEMENT_MARKERS = [
   { fn: 'complete_orchestrator_sd', marker: 'LEAD-FINAL-APPROVAL', meaning: 'requires accepted LEAD-FINAL-APPROVAL row' },
   { fn: 'complete_orchestrator_sd', marker: "retro_type = 'SD_COMPLETION'", meaning: 'canonical retro filter' },
-  { fn: 'check_handoff_bypass', marker: 'ORCHESTRATOR_AUTO_COMPLETE', meaning: 'fabrication whitelist (must be ABSENT)', mustBeAbsent: true }
+  { fn: 'complete_orchestrator_sd', marker: 'UNIFIED-HANDOFF-SYSTEM', meaning: 'executor-written witness allow-list (forged ADMIN_OVERRIDE rows rejected)' },
+  { fn: 'complete_orchestrator_sd', marker: 'ORCHESTRATOR_AUTO_COMPLETE', meaning: 'fabricated PLAN-TO-LEAD insert (must be ABSENT)', mustBeAbsent: true }
 ];
 
 async function main() {

--- a/tests/unit/handoff/check-and-complete-parent-sd.test.js
+++ b/tests/unit/handoff/check-and-complete-parent-sd.test.js
@@ -48,9 +48,16 @@ function makeSupabase({ parentSD, siblings }) {
 }
 
 describe('checkAndCompleteParentSD — completed+cancelled sibling mix', () => {
-  it('proceeds to the Guardian completion path when siblings are a completed+cancelled mix (never blocks on a cancelled sibling)', async () => {
+  it('proceeds to the Guardian path when siblings are a completed+cancelled mix (never blocks on a cancelled sibling)', async () => {
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: guardian.complete() no longer
+    // completes — it stages the parent at pending_approval and surfaces the
+    // LEAD-FINAL-APPROVAL command; helpers must report that contract faithfully.
     validateMock.mockResolvedValue({ canComplete: true });
-    completeMock.mockResolvedValue({ success: true });
+    completeMock.mockResolvedValue({
+      success: true,
+      routedToLeadFinal: true,
+      leadFinalCommand: 'node scripts/handoff.js execute LEAD-FINAL-APPROVAL parent-1'
+    });
     const parentSD = { id: 'parent-1', title: 'Parent', status: 'in_progress', sd_type: 'orchestrator' };
     const siblings = [
       { id: 'c1', status: 'completed' },
@@ -62,7 +69,10 @@ describe('checkAndCompleteParentSD — completed+cancelled sibling mix', () => {
     const result = await checkAndCompleteParentSD(sd, makeSupabase({ parentSD, siblings }));
 
     expect(GuardianCtor).toHaveBeenCalledWith('parent-1');
-    expect(result.orchestratorCompleted).toBe(true);
+    // Parent is staged, NOT completed — completion happens via its own LFA run.
+    expect(result.orchestratorCompleted).toBe(false);
+    expect(result.parentRoutedToLeadFinal).toBe(true);
+    expect(result.leadFinalCommand).toContain('LEAD-FINAL-APPROVAL parent-1');
   });
 
   it('does NOT proceed when a sibling is still genuinely in-progress (not terminal)', async () => {

--- a/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
@@ -144,7 +144,10 @@ describe('satisfyOrchestratorTemplateRequirements', () => {
     expect(result.satisfied).toBe(true);
     expect(result.created).toContain('retrospective');
     expect(insertFn).toHaveBeenCalledOnce();
-    expect(insertFn.mock.calls[0][0].retro_type).toBe('orchestrator_completion');
+    // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: must be the canonical completion
+    // type — 'orchestrator_completion' was invisible to retro-filters.js and the
+    // LEAD-FINAL-APPROVAL RETROSPECTIVE_EXISTS gate.
+    expect(insertFn.mock.calls[0][0].retro_type).toBe('SD_COMPLETION');
   });
 
   it('should create both when both missing', async () => {

--- a/tests/unit/handoff/orchestrator-ghost-complete-guard.test.js
+++ b/tests/unit/handoff/orchestrator-ghost-complete-guard.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001 — FR-6 source-shape regression.
+ *
+ * Orchestrator auto-complete paths may not write strategic_directives_v2
+ * status='completed' directly; the LEAD-FINAL-APPROVAL executor is the only
+ * completion writer. This test fails if a direct completed-write reappears in
+ * any of the guarded files (the ghost-complete class regressed twice via
+ * per-site patches before this fix — see SD provenance).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const GUARDED_FILES = [
+  'scripts/modules/handoff/executors/plan-to-lead/state-transitions.js',
+  'scripts/modules/handoff/orchestrator-completion-guardian.js',
+  'scripts/modules/handoff/lib/orchestrator-terminal-guard.js'
+];
+
+/**
+ * Split the source at each .from('<table>') call; a chunk beginning with the
+ * strategic_directives_v2 table must not contain a status: 'completed' payload
+ * (PRD/user-story/deliverable chunks may — those are different tables).
+ */
+function sdChunksWithCompletedWrite(src) {
+  const chunks = src.split(/\.from\(/).slice(1);
+  return chunks
+    .map((chunk, i) => ({ chunk, i }))
+    .filter(({ chunk }) => chunk.startsWith("'strategic_directives_v2'"))
+    .filter(({ chunk }) => {
+      // Only inspect up to the next .from( boundary (already split) and only
+      // update payloads: a completed STRING COMPARISON (status === 'completed')
+      // is legitimate; a payload key is not.
+      return /status:\s*'completed'/.test(chunk);
+    });
+}
+
+describe('ghost-complete guard: no direct SD completed writes', () => {
+  for (const rel of GUARDED_FILES) {
+    it(`${rel} does not write strategic_directives_v2 status='completed'`, () => {
+      const src = readFileSync(join(repoRoot, rel), 'utf8');
+      const offenders = sdChunksWithCompletedWrite(src);
+      expect(offenders, `direct completed-write found in ${rel}`).toHaveLength(0);
+    });
+  }
+
+  it('the guarded paths route through the terminal guard', () => {
+    const stateTransitions = readFileSync(join(repoRoot, GUARDED_FILES[0]), 'utf8');
+    const guardian = readFileSync(join(repoRoot, GUARDED_FILES[1]), 'utf8');
+    expect(stateTransitions).toMatch(/routeOrchestratorToLeadFinal/);
+    expect(guardian).toMatch(/routeOrchestratorToLeadFinal/);
+    // guardian retro check uses the canonical filter, not a bare table query
+    expect(guardian).toMatch(/getFilteredRetrospective/);
+  });
+});


### PR DESCRIPTION
## Summary
Orchestrator parents could **ghost-complete**: four auto-complete paths wrote `status='completed'` directly once all children finished — skipping LEAD-FINAL-APPROVAL entirely — and their retrospective checks accepted ANY retro row regardless of `retro_type` (a HANDOFF retro satisfied completion). Caught live on SD-LEO-INFRA-INDEPENDENT-GATE-WITNESS-001.

**The invariant this PR enforces: `completed` ⟹ genuine accepted LEAD-FINAL-APPROVAL handoff row + canonical `retro_type='SD_COMPLETION'` retrospective.**

## Changes
- **New single funnel** `scripts/modules/handoff/lib/orchestrator-terminal-guard.js`: canonical retro check (reuses `retro-filters.js`) → stage at `pending_approval` → surface the LEAD-FINAL-APPROVAL command. Never writes `completed`.
- **Path 1+2** `plan-to-lead/state-transitions.js`: `checkAndCompleteParentSD` and `completeOrchestratorSD` route through the guard; the auto-created orchestrator retro now writes canonical `retro_type='SD_COMPLETION'` (was `'orchestrator_completion'` — invisible to the gate).
- **Path 3** `orchestrator-completion-guardian.js`: retro sufficiency uses the canonical filter; `complete()` stages instead of completing.
- **Path 4 (SQL, STAGED — chairman apply required)** `database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql`: `complete_orchestrator_sd()` requires the canonical retro + an accepted LEAD-FINAL-APPROVAL row (stages at `pending_approval` otherwise, no more fabricated PLAN-TO-LEAD rows); `check_handoff_bypass()` drops the `ORCHESTRATOR_AUTO_COMPLETE` whitelist. Rollback companion included. **TIER-2 (CREATE OR REPLACE + SECURITY DEFINER) — non-delegatable; apply via `apply-migration.js --prod-deploy`.** `scripts/orchestrator-rpc-enforcement-status.mjs` reports live APPLIED/STAGED (today: STAGED; note `check_handoff_bypass` is absent from the live DB entirely).
- **Anti-strand fast-path (RISK R1)**: the LEAD-FINAL-APPROVAL command is surfaced FIRST in `commandsToRun` so auto-proceed drivers complete parents genuinely; finalization commands run after.

## Tests
- 20 tests across guard unit tests + source-shape regression (fails if a direct `strategic_directives_v2` completed-write reappears in any guarded file — this class regressed twice before via per-site patches).
- Full handoff scope: 122 files / 1,240 tests green. Full unit suite: 26,583 passed; only pre-existing baseline failure (witness-emitter, fails identically on main) + one load-timeout flake (passes in isolation).

## LOC justification (>100)
610 insertions across 4 enforcement sites + tests + staged migration/rollback/verifier. Splitting would ship enforcement without the anti-strand fast-path or tests — exactly the partial-fix pattern that let this class regress before (per SD provenance). Within the 400-LOC-of-source tier: source changes are ~250 LOC; the remainder is tests + SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adversarial review (deep tier, 3 rounds — converged)

This PR passed a deep-tier multi-agent adversarial review with three rounds of fixes:

- **Round 1** found 3 CRITICAL + 3 warning + 2 info. All fixed: the migration now (a) requires an **executor-written** accepted LEAD-FINAL-APPROVAL row (`created_by IN ('UNIFIED-HANDOFF-SYSTEM',…)`) rather than any accepted row (807 live accepted LFA rows are `ADMIN_OVERRIDE`-created and forgeable); (b) **incorporates** the staged `20260711` cancelled-as-terminal + PCVP body verbatim instead of regressing it; and (c) the `lead-final-approval` executor was adapted to the guardian's new staged contract (no longer reports/chains parents as completed while they sit at `pending_approval`), with the orchestrator completion hook now firing at **genuine** completion.
- **Round 2** found 3 new (verifier marker false-positive, staged-parent info not reaching the machine-readable result / auto-proceed loop, `childCount=1`). All fixed.
- **Round 3** verified all closed, **no new issues**.

### Accepted-risk / follow-up (logged to `ship_review_findings`)
- **Follow-up recommended**: the `plan-to-lead` sibling predicate counts `pending_approval` as complete and LFA has no children-terminal gate for orchestrators. Pre-existing; this PR is strictly better than `main` (which fully *completed* the parent at that moment). Suggested follow-up: a `CHILDREN_TERMINAL` gate in LFA for orchestrators, or switch the predicate to `isTerminalChildStatus`.
- **Accepted risk**: `created_by` is client-asserted (SSOT `handoff_actor_policy()` narrowing is out of scope); auto-created `SD_COMPLETION` stub retro makes the orchestrator retro gate weaker than standard SDs by design (net enforcement still strictly increases).

## ⚠️ Chairman apply required
`database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql` is **STAGED, not applied** (TIER-2: CREATE OR REPLACE + SECURITY DEFINER). Until applied, the SQL RPC path stays permissive — JS-path enforcement is live on merge and independent. Apply order: `20260711` first, then this file. Live state: `node scripts/orchestrator-rpc-enforcement-status.mjs`.
