### PR TITLE
fix(QF-20260711-047): CRIT-002 sql_injection false-positives on diff-marker + and test-fixture exemption

### DIFF
--- a/config/review-critical-findings.json
+++ b/config/review-critical-findings.json
@@ -21,10 +21,10 @@
       "id": "CRIT-002",
       "name": "sql_injection",
       "description": "String concatenation in SQL queries without parameterization",
-      "_note": "SD-LEO-INFRA-FIX-WINDOWS-SESSION-001: added a negative lookbehind to pattern 1 excluding a match immediately preceded by a URL query-string separator character, so a PostgREST REST query-string parameter whose name happens to spell one of these keywords (a pervasive, safe convention across this Supabase-REST-heavy codebase, e.g. scripts/hooks/capture-session-id.cjs line 320) is no longer treated as SQL injection. The pattern's original intended shape -- an interpolation followed later on the line by a hardcoded, standalone SQL keyword -- still matches; verified with a small standalone script (case-by-case, deleted after use, not committed).",
+      "_note": "SD-LEO-INFRA-FIX-WINDOWS-SESSION-001: added a negative lookbehind to pattern 1 excluding a match immediately preceded by a URL query-string separator character, so a PostgREST REST query-string parameter whose name happens to spell one of these keywords (a pervasive, safe convention across this Supabase-REST-heavy codebase, e.g. scripts/hooks/capture-session-id.cjs line 320) is no longer treated as SQL injection. The pattern's original intended shape -- an interpolation followed later on the line by a hardcoded, standalone SQL keyword -- still matches; verified with a small standalone script (case-by-case, deleted after use, not committed). QF-20260711-047: pattern 2 (string-concat SQL) was matching the unified-diff added-line '+' marker itself -- when scanned raw diff text, a diff-added line whose FIRST non-marker content is a quoted SQL keyword (e.g. multi-line parameterized queries like '+    \"SELECT * FROM users WHERE id = %s\",') satisfied '\\\\+\\\\s*[quote]SELECT' because the diff '+' character sits immediately before the quote. Added a positive lookbehind requiring a same-line, non-newline character before the '+' -- the diff-marker '+' is always preceded by start-of-string or a newline, while a genuine concatenation operator ('x + \"SELECT...') is always preceded by other same-line content, so this discriminates cleanly without narrowing genuine detection.",
       "patterns": [
         "\\$\\{.*\\}.*(?<![?&])\\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\\b",
-        "\\+\\s*['\"]\\s*\\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\\b",
+        "(?<=[^\\r\\n])\\+\\s*['\"]\\s*\\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\\b",
         "\\.query\\s*\\(\\s*`[^`]*\\$\\{"
       ],
       "severity": "critical",

--- a/lib/ship/review-gate.js
+++ b/lib/ship/review-gate.js
@@ -24,20 +24,70 @@ try {
 }
 
 /**
+ * CRIT ids exempted for test/fixture paths. Hostile-input test fixtures
+ * legitimately embed SQL-injection and destructive-schema strings as test DATA
+ * (e.g. sqlite_master probes, DROP-TABLE assertions), so scanning them yields
+ * structural false positives on every venture PR. (QF-20260711-047)
+ */
+const TEST_FIXTURE_EXEMPT_IDS = new Set(['CRIT-002', 'CRIT-004']);
+
+/**
+ * True when a diff file path is a test/fixture path eligible for the exemption.
+ * Matches a `tests/` (or `test/`, `__tests__/`) directory anywhere in the path,
+ * or a `.test.`/`.spec.` filename. A null path (bare snippet with no diff header)
+ * is never exempt.
+ * @param {string | null} path
+ * @returns {boolean}
+ */
+function isTestFixturePath(path) {
+  if (!path) return false;
+  return /(^|\/)(tests?|__tests__)\//i.test(path) || /\.(test|spec)\.[a-z]+$/i.test(path);
+}
+
+/**
+ * Split a unified diff into per-file segments so path-scoped exemptions apply.
+ * A segment inherits its file path from the `diff --git … b/<path>` / `+++ b/<path>`
+ * headers. Content before any header (e.g. a bare snippet passed by a unit test)
+ * has a null path and is scanned as one non-exempt segment.
+ * @param {string} diffContent
+ * @returns {Array<{ path: string | null, body: string }>}
+ */
+function splitDiffByFile(diffContent) {
+  const segments = [];
+  let current = { path: null, body: [] };
+  const flush = () => { if (current.body.length) segments.push({ path: current.path, body: current.body.join('\n') }); };
+
+  for (const line of diffContent.split('\n')) {
+    const gitHeader = line.match(/^diff --git a\/.+ b\/(.+)$/);
+    if (gitHeader) { flush(); current = { path: gitHeader[1], body: [] }; continue; }
+    const plusHeader = line.match(/^\+\+\+ b\/(.+)$/);
+    if (plusHeader) { current.path = plusHeader[1]; continue; }
+    if (/^--- a\//.test(line)) continue; // diff metadata, not content
+    current.body.push(line);
+  }
+  flush();
+  return segments.length ? segments : [{ path: null, body: diffContent }];
+}
+
+/**
  * Check diff content against CRITICAL enumeration patterns
  * @param {string} diffContent - The PR diff text
  * @returns {{ found: boolean, findings: Array<{ id: string, name: string, matches: string[] }> }}
  */
 export function checkCriticalFindings(diffContent) {
   const findings = [];
+  const segments = splitDiffByFile(diffContent);
 
   for (const pattern of criticalConfig.critical_patterns) {
     const matches = [];
     for (const regexStr of pattern.patterns) {
-      const regex = new RegExp(regexStr, 'gi');
-      while (regex.exec(diffContent) !== null) {
-        // Log category, not the actual code excerpt (CISO requirement)
-        matches.push(`Line match: ${pattern.name} pattern detected`);
+      for (const segment of segments) {
+        if (TEST_FIXTURE_EXEMPT_IDS.has(pattern.id) && isTestFixturePath(segment.path)) continue;
+        const regex = new RegExp(regexStr, 'gi');
+        while (regex.exec(segment.body) !== null) {
+          // Log category, not the actual code excerpt (CISO requirement)
+          matches.push(`Line match: ${pattern.name} pattern detected`);
+        }
       }
     }
     if (matches.length > 0) {

--- a/tests/unit/review-gate-closed-enum-fp.test.js
+++ b/tests/unit/review-gate-closed-enum-fp.test.js
@@ -53,4 +53,44 @@ describe('review-gate closed-enum false-positive fixes (a78478f9 + 03ccc4d4)', (
   it('STILL flags an interpolated SQL keyword immediately preceded by a non-separator character', () => {
     expect(names('+ const sql = `${schema}.DELETE FROM t`;')).toContain('sql_injection');
   });
+
+  // CRIT-002 sql_injection pattern 2 (string-concat) — QF-20260711-047.
+  // The unified-diff added-line '+' marker sits at column 0 immediately before the
+  // quoted keyword on parameterized-SQL lines, so `\+\s*['"]\bSELECT` matched the diff
+  // markup itself. A positive lookbehind now requires a non-newline char before the '+',
+  // which the column-0 diff marker never has, while a genuine concat operator always does.
+  it('does NOT flag a diff-added parameterized-SQL line whose content starts with a quoted keyword', () => {
+    expect(names('+    "SELECT * FROM users WHERE id = %s",')).not.toContain('sql_injection');
+  });
+  it('does NOT flag a diff-added line with a leading-quote INSERT (parameterized)', () => {
+    expect(names('+  "INSERT INTO t (a) VALUES (?)"')).not.toContain('sql_injection');
+  });
+  it('STILL flags a genuine mid-line string-concat SQL (real injection shape)', () => {
+    expect(names('+ const q = base + "SELECT * FROM users WHERE id = " + id;')).toContain('sql_injection');
+  });
+  it('STILL flags concat SQL even when the concat operator is space-padded', () => {
+    expect(names('+ query = prefix + "DELETE FROM sessions";')).toContain('sql_injection');
+  });
+
+  // CRIT-002 / CRIT-004 test-fixture path exemption — QF-20260711-047.
+  // Hostile-input fixtures legitimately embed injection/destructive-schema strings as
+  // test DATA; a per-file diff header under tests/ exempts those two enumerations only.
+  const diffFor = (path, line) =>
+    `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,0 +1,1 @@\n${line}`;
+  it('does NOT flag CRIT-002 on a genuine concat inside a tests/ fixture file', () => {
+    expect(names(diffFor('tests/fixtures/hostile-sql.test.js', '+ const q = base + "SELECT * FROM users";')))
+      .not.toContain('sql_injection');
+  });
+  it('does NOT flag CRIT-004 (DROP TABLE) inside a .test. fixture file', () => {
+    expect(names(diffFor('apps/venture/src/db.test.ts', '+ await run("DROP TABLE users");')))
+      .not.toContain('schema_corruption');
+  });
+  it('STILL flags CRIT-002 on the SAME concat when the file is NOT a test path', () => {
+    expect(names(diffFor('src/db/query-builder.js', '+ const q = base + "SELECT * FROM users";')))
+      .toContain('sql_injection');
+  });
+  it('STILL flags CRIT-001 (hardcoded secret) even inside a test file (not exempt)', () => {
+    expect(names(diffFor('tests/setup.test.js', '+ const key = "sk-live-abc123def456ghi789jkl012mno345";')))
+      .toContain('hardcoded_secret');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes two structural false-positives in the `/ship` deep-tier review gate's CRIT-002 (`sql_injection`) closed-enumeration pattern, adversarially adjudicated from 2 witnessed false-positive PRs (apexniche-ai PR #1 `sqlite_master` `.prepare` lines; PR #2 with 0 real findings).

**Root cause 1 — diff-marker match.** CRIT-002 pattern 2 (string-concat SQL, `\+\s*['"]\bSELECT`) matched the unified-diff added-line `+` marker itself. On a parameterized-SQL line whose content starts with a quoted keyword (e.g. a multi-line `.prepare(\n  "SELECT ...")`), the column-0 diff `+` satisfied the pattern. Fixed with a positive lookbehind `(?<=[^\r\n])` requiring a non-newline char before the `+` — the column-0 diff marker never has one; a genuine concat operator (`base + "SELECT…"`) always does (even when space-padded). Chose `[^\r\n]` over `\S` deliberately: `(?<=\S)` would wrongly miss the common `x + "SELECT"` formatting.

**Root cause 2 — test fixtures.** `checkCriticalFindings` scanned the whole diff blob with no path awareness, so hostile-input test fixtures (which legitimately embed injection/destructive-schema strings as test DATA) flagged CRIT-002/CRIT-004 on every venture PR. Made it diff-path-aware via a per-file segmenter; CRIT-002 and CRIT-004 (only) are now exempt on `tests/`/`.test.`/`.spec.` paths. CRIT-001/003/005/006/007 and all non-test paths are unaffected — a hardcoded secret in a test still flags.

## Test plan
- [x] 8 new regression tests in `tests/unit/review-gate-closed-enum-fp.test.js` pin both fixes in both directions (FP no longer fires AND genuine signatures still fire; test-path exempt AND non-test path still flags AND CRIT-001 still fires in test files).
- [x] All 68 review-gate consumers green: `tests/review-gate.test.js` (34), `tests/review-risk-scorer.test.js` (17), `tests/unit/review-gate-closed-enum-fp.test.js` (17).
- [x] Verified against a realistic multi-file `gh pr diff` blob: parameterized `.prepare` SQL → clean, `tests/` fixtures → exempt, genuine mid-line concat in non-test src → still flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)