### PR TITLE
feat(SD-LEO-INFRA-VENTURE-REPO-TRUST-001): born-trusted venture repos at fleet mint

### DIFF
--- a/docs/reference/ship-witness-venture-trust-tier.md
+++ b/docs/reference/ship-witness-venture-trust-tier.md
@@ -3,8 +3,8 @@
 **SD**: SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B)
 **Status**: Approved
 **Category**: Protocol
-**Version**: 1.0.0
-**Last Updated**: 2026-07-03
+**Version**: 1.1.0
+**Last Updated**: 2026-07-12
 
 ## What this is
 
@@ -33,9 +33,13 @@ SD.
 
 `applications.trust_tier` (existing column; `ck_applications_trust_tier`
 already permits `'platform' | 'trusted' | 'external'` — no migration was
-needed for this SD). As of this SD's delivery, **zero rows use `'trusted'`**
-— promoting a specific venture repo is a separate, deliberate, chairman-gated
-operational decision, not something this SD's code performs.
+needed for this SD). As of Ship-witness B's delivery, **zero rows used
+`'trusted'`** — promoting a specific venture repo was a separate, deliberate,
+chairman-gated operational decision, not something that SD's code performed.
+(SD-LEO-INFRA-VENTURE-REPO-TRUST-001 later automated the born-trusted case for
+genuinely fleet-minted repos under chairman ratification — see the section
+below. Hand-promotion of an already-existing repo remains a manual SQL
+decision, as described here.)
 
 To promote a venture repo, issue a direct, reviewed SQL statement (there is
 no self-service script by design — see "Why no promotion script" below):
@@ -73,6 +77,52 @@ that decision visible.
 P2's actor-separation dimension and P4 (branch protection, pre-P0) are never
 required for a pass — they aren't evaluable yet at all (see
 `lib/ship/merge-witness-ladder.mjs`).
+
+## Born-trusted: fleet-minted venture repos (SD-LEO-INFRA-VENTURE-REPO-TRUST-001)
+
+Venture `applications` rows are born `trust_tier='external'` at their insert
+sites (`scripts/reroute-venture-to-bridge.mjs`, `lib/sd-creation/pipeline.js`).
+That default meant the factory's OWN merge-ready output was blocked by VB-2 and
+had to be hand-elevated per venture (MarketLens, then ApexNiche PR #1) — a
+recurring `external`-was-a-default-not-a-decision paper cut. This SD elevates
+`external`→`trusted` **automatically, but only at genuine fleet mint**, in
+`lib/eva/bridge/venture-provisioner.js`'s `repo_created` step.
+
+**The narrow, fail-closed predicate** (`lib/eva/bridge/trust-elevation.js`
+`resolveTrustElevation`) elevates only when **all** hold:
+
+1. **`repoWasMinted === true`** — the *load-bearing* discriminator. Elevation
+   runs only on the provisioner's genuine-mint path (`repoExists === false` →
+   `gh repo create`). Imported/linked/external repos already exist on GitHub, so
+   they **never enter that branch** and can never be born trusted. (CronGenius /
+   DataDistill have chairman-approved arch plans yet stay `external` precisely
+   because they are imported repos that never mint.)
+2. **`venture_id` resolves** to a real venture, **and**
+3. a **chairman-approved** row exists in `eva_architecture_plans` **or**
+   `eva_vision_documents` for that `venture_id` (vision-alone counts — MarketLens
+   has an approved vision and no arch plan).
+
+Any missing signal, unresolved venture, or query error yields **no elevation**
+(fail-closed). Trust flows from **chairman ratification of the venture**, not
+coordinator self-grant — consistent with the "keep the weight of the decision
+visible" philosophy above: this is not a self-service flip of an arbitrary repo,
+it is the automatic consequence of a chairman-ratified fleet mint.
+
+**Why born-trusted is safe:** VB-2 is unchanged and still requires
+`trust_tier='trusted'` **AND** a passing per-PR witness (P1/P2/P3). `'trusted'`
+alone grants nothing — every PR is still adjudicated. Born-trusted only removes
+the `external`-tier pre-rejection so the factory's own witness-passing PRs can
+reach the same scrutiny every trusted repo gets.
+
+**Audit shape.** Each elevation stamps
+`applications.metadata.trust_tier_elevation = { at, to:'trusted', from:'external',
+basis, approved_via, venture_id, policy:'fleet_created_ratified_program',
+decided_by }`. Elevation is idempotent (guarded on `trust_tier='external'`) and
+survives a partial-mint retry (captured at create-time, before the fragile
+clone/register lines). `scripts/backfill-trust-tier-elevation.mjs` (dry-run
+default, `--apply` to write, enumerated by id — never a heuristic sweep)
+normalized the two already-hand-elevated rows (MarketLens `6823cd37` got the
+provenance written; ApexNiche `3c8efc56` was already canonical).
 
 ## Where it's wired in
 

--- a/lib/eva/bridge/trust-elevation.js
+++ b/lib/eva/bridge/trust-elevation.js
@@ -1,0 +1,165 @@
+/**
+ * Born-trusted trust-tier elevation for fleet-minted venture repos.
+ * SD-LEO-INFRA-VENTURE-REPO-TRUST-001
+ *
+ * Venture `applications` rows are born trust_tier='external' at their insert sites
+ * (scripts/reroute-venture-to-bridge.mjs, lib/sd-creation/pipeline.js). The VB-2
+ * human-merge gate (lib/ship/venture-trust-gate.mjs) refuses auto-merge for external
+ * repos — so the factory's OWN merge-ready output was being blocked, requiring a
+ * per-venture hand elevation. This module elevates external->trusted ONLY when the
+ * fleet genuinely mints the repo AND the venture carries chairman ratification.
+ *
+ * SECURITY (why this is safe):
+ *  - The LOAD-BEARING discriminator is `repoWasMinted` — true ONLY on the venture
+ *    provisioner's genuine-mint path (repoExists===false -> `gh repo create`).
+ *    Imported/linked/external repos already exist on GitHub, so they never enter
+ *    that branch and can never be elevated here.
+ *  - `chairman_approved` (eva_architecture_plans OR eva_vision_documents for the
+ *    venture_id) is a secondary AND-guard. It alone is NOT sufficient: CronGenius /
+ *    DataDistill have chairman-approved arch plans yet are imported external repos,
+ *    so they never mint and never elevate.
+ *  - FAIL-CLOSED: any missing signal, unresolved venture_id, or query error yields
+ *    elevate=false. Trust is only ever granted on a positive, ratified, fleet mint.
+ *  - VB-2 keeps full teeth: it requires trust_tier==='trusted' AND an independent
+ *    per-PR witness pass, so 'trusted' grants nothing by itself.
+ *
+ * The elevation predicate is a PURE function of injectable inputs (no `gh`, no
+ * side-effect writes) so the negative pin is unit-testable without a repo or a merge.
+ */
+
+import { createSupabaseServiceClient } from '../../supabase-client.js';
+import { normalizeAppName } from '../../repo-paths.js';
+
+/**
+ * Decide whether a venture repo may be born trusted. Pure w.r.t. side effects — it
+ * performs read-only queries via the injected supabase client and NEVER writes or
+ * shells out to `gh`. Fail-closed on every uncertain branch.
+ *
+ * @param {object} args
+ * @param {string} args.ventureId
+ * @param {boolean} args.repoWasMinted - true ONLY on the genuine-mint path (repoExists===false)
+ * @param {import('@supabase/supabase-js').SupabaseClient} [args.supabase]
+ * @returns {Promise<{elevate:boolean, reason:string, basis?:string, provenance?:object}>}
+ */
+export async function resolveTrustElevation({ ventureId, repoWasMinted, supabase } = {}) {
+  // FR-2: the mint gate is load-bearing — imported/external repos never reach here.
+  if (repoWasMinted !== true) return { elevate: false, reason: 'not_fleet_minted' };
+  if (!ventureId) return { elevate: false, reason: 'venture_id_unresolved' };
+
+  const sb = supabase || createSupabaseServiceClient();
+
+  // Chairman ratification: a chairman_approved arch plan OR (vision-alone counts —
+  // MarketLens has a chairman_approved vision and no arch plan).
+  let archApproved = false;
+  let visionApproved = false;
+  try {
+    const { data: arch, error } = await sb
+      .from('eva_architecture_plans')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('chairman_approved', true)
+      .limit(1);
+    if (error) throw error;
+    archApproved = Array.isArray(arch) && arch.length > 0;
+  } catch {
+    // fail-closed: an unreadable ratification signal is treated as NOT approved.
+    archApproved = false;
+  }
+  if (!archApproved) {
+    try {
+      const { data: vis, error } = await sb
+        .from('eva_vision_documents')
+        .select('id')
+        .eq('venture_id', ventureId)
+        .eq('chairman_approved', true)
+        .limit(1);
+      if (error) throw error;
+      visionApproved = Array.isArray(vis) && vis.length > 0;
+    } catch {
+      visionApproved = false;
+    }
+  }
+
+  if (!archApproved && !visionApproved) {
+    return { elevate: false, reason: 'no_chairman_approval' };
+  }
+
+  const approvedVia = archApproved ? 'architecture plan' : 'vision document';
+  const basis = `fleet_created_ratified_program: repo minted by fleet provisioner; chairman_approved ${approvedVia} for venture ${ventureId}`;
+  return {
+    elevate: true,
+    reason: 'ratified_fleet_mint',
+    basis,
+    provenance: {
+      to: 'trusted',
+      from: 'external',
+      basis,
+      approved_via: approvedVia,
+      venture_id: ventureId,
+      policy: 'fleet_created_ratified_program',
+      decided_by: 'venture_provisioner_born_trusted_policy',
+    },
+  };
+}
+
+/**
+ * Elevate the venture's `applications` row external->trusted when
+ * {@link resolveTrustElevation} approves it. Idempotent + concurrency-safe: the UPDATE
+ * is guarded on `trust_tier='external'`, so a row already trusted is a no-op and the
+ * elevation can be safely re-attempted (which is exactly what a partial-mint retry
+ * does — FR-3). NON-FATAL: any failure logs and returns without throwing, so trust
+ * elevation never breaks provisioning.
+ *
+ * @param {object} args
+ * @param {string} args.ventureId
+ * @param {string} args.ventureName - matched against applications.name (normalizeAppName)
+ * @param {boolean} args.repoWasMinted
+ * @param {import('@supabase/supabase-js').SupabaseClient} [args.supabase]
+ * @param {(msg:string)=>void} [args.log]
+ * @param {string} [args.stampedAt] - ISO timestamp for the elevation record (injectable for tests)
+ * @returns {Promise<{elevated:boolean, reason:string, applicationId?:string}>}
+ */
+export async function elevateVentureRepoTrust({ ventureId, ventureName, repoWasMinted, supabase, log = () => {}, stampedAt } = {}) {
+  const sb = supabase || createSupabaseServiceClient();
+  const decision = await resolveTrustElevation({ ventureId, repoWasMinted, supabase: sb });
+  if (!decision.elevate) {
+    log(`[trust-elevation] not elevating (${decision.reason})`);
+    return { elevated: false, reason: decision.reason };
+  }
+
+  try {
+    const { data: appRows, error: selErr } = await sb
+      .from('applications')
+      .select('id, name, trust_tier, metadata')
+      .eq('status', 'active');
+    if (selErr) throw selErr;
+
+    const needle = normalizeAppName(ventureName);
+    const match = (appRows || []).find((a) => normalizeAppName(a.name) === needle);
+    if (!match) {
+      log(`[trust-elevation] no active applications row matches "${ventureName}" — skipped`);
+      return { elevated: false, reason: 'no_app_row' };
+    }
+    if (match.trust_tier !== 'external') {
+      log(`[trust-elevation] applications ${match.id} already trust_tier=${match.trust_tier} — no-op`);
+      return { elevated: false, reason: `already_${match.trust_tier}`, applicationId: match.id };
+    }
+
+    const provenance = { at: stampedAt || new Date().toISOString(), ...decision.provenance };
+    const nextMetadata = { ...(match.metadata || {}), trust_tier_elevation: provenance };
+
+    // Concurrency-safe idempotency: only flip a row that is STILL external.
+    const { error: upErr } = await sb
+      .from('applications')
+      .update({ trust_tier: 'trusted', metadata: nextMetadata })
+      .eq('id', match.id)
+      .eq('trust_tier', 'external');
+    if (upErr) throw upErr;
+
+    log(`[trust-elevation] applications ${match.id} ("${ventureName}") elevated external->trusted (${decision.basis})`);
+    return { elevated: true, reason: 'elevated', applicationId: match.id };
+  } catch (err) {
+    log(`[trust-elevation] WARN non-fatal: ${err.message}`);
+    return { elevated: false, reason: 'error' };
+  }
+}

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -26,6 +26,8 @@ import { routeDbProvider } from '../../venture-deploy/stakes-router.js';
 // shared with claude-md-writer.js / build-tasks-writer.js).
 import { buildLeoBridgeClaudeMd, buildLeoBridgeBuildTasks } from './leo-bridge-scaffold-writer.js';
 import { buildReplitConfig } from './replit-config-writer.js';
+// SD-LEO-INFRA-VENTURE-REPO-TRUST-001: born-trusted elevation at genuine repo mint.
+import { elevateVentureRepoTrust } from './trust-elevation.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
@@ -205,6 +207,20 @@ export const DEFAULT_STEPS = [
         ctx.log(`[repo_created] Creating GitHub repo: rickfelix/${repoName}`);
         execFileSync('gh', ['repo', 'create', `rickfelix/${repoName}`, REPO_VISIBILITY, '--description', `EHG Venture: ${ctx.venture.name}`], {
           stdio: 'pipe', encoding: 'utf8', timeout: 30000
+        });
+        // SD-LEO-INFRA-VENTURE-REPO-TRUST-001 (FR-1/FR-3): the fleet genuinely minted this
+        // repo (repoExists===false path). Elevate its applications row external->trusted so
+        // VB-2 stops blocking the factory's own output — but ONLY when the venture carries
+        // chairman ratification (resolveTrustElevation is fail-closed). Done HERE, immediately
+        // after create, because mint-ness is ephemeral: if a later line (clone/register) throws
+        // and executeStepWithRetry re-enters, repoExists is now true and this branch is skipped.
+        // Idempotent (guarded on trust_tier='external') + NON-FATAL, so a retry never
+        // double-elevates and an elevation fault never breaks provisioning.
+        await elevateVentureRepoTrust({
+          ventureId: ctx.ventureId,
+          ventureName: ctx.venture.name,
+          repoWasMinted: true,
+          log: (m) => ctx.log(m),
         });
       }
 

--- a/scripts/backfill-trust-tier-elevation.mjs
+++ b/scripts/backfill-trust-tier-elevation.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Backfill applications.metadata.trust_tier_elevation provenance for the venture repos
+ * that were hand-elevated to trust_tier='trusted' BEFORE the born-trusted policy shipped.
+ * SD-LEO-INFRA-VENTURE-REPO-TRUST-001 (FR-4).
+ *
+ * These rows are ALREADY trust_tier='trusted' (the hand elevations that motivated this SD);
+ * the backfill normalizes their audit metadata to the canonical policy shape produced by
+ * resolveTrustElevation(), so future audits read one schema. It does NOT flip any tier.
+ *
+ * SAFETY:
+ *  - Targets are ENUMERATED BY ID, never a heuristic sweep (a `WHERE trust_tier='external'
+ *    AND kind='venture'` sweep would misclassify imported venture repos as fleet-created).
+ *  - --dry-run is the DEFAULT. Writing requires the explicit --apply flag.
+ *  - Idempotent: a row that already carries metadata.trust_tier_elevation is a no-op.
+ *  - Fail-closed: a target whose venture lacks chairman ratification (resolveTrustElevation
+ *    returns elevate=false) is SKIPPED, not fabricated — we never invent provenance.
+ *
+ * Usage:
+ *   node scripts/backfill-trust-tier-elevation.mjs            # dry-run (default)
+ *   node scripts/backfill-trust-tier-elevation.mjs --apply    # write
+ */
+import { pathToFileURL } from 'url';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { resolveTrustElevation } from '../lib/eva/bridge/trust-elevation.js';
+
+// Enumerated targets — the two repos hand-elevated before this policy (validation-agent
+// 2026-07-12). MarketLens is trusted-but-unattributed; ApexNiche already carries canonical
+// provenance (will no-op).
+export const BACKFILL_TARGET_IDS = [
+  '6823cd37-552e-486d-99f3-98db739c9095', // MarketLens
+  '3c8efc56-ab13-49a6-bce5-2072d0c15ee7', // ApexNiche AI
+];
+
+/**
+ * Compute the backfill plan for one already-fetched applications row. Pure — no writes.
+ * @param {{id:string,name:string,trust_tier:string,venture_id:string,metadata:object}} row
+ * @param {{elevate:boolean, provenance?:object}} decision - resolveTrustElevation output
+ * @param {string} stampedAt
+ * @returns {{action:'write'|'skip', reason:string, nextMetadata?:object}}
+ */
+export function planBackfillForRow(row, decision, stampedAt) {
+  if (!row) return { action: 'skip', reason: 'row_not_found' };
+  if (row.metadata && row.metadata.trust_tier_elevation) {
+    return { action: 'skip', reason: 'already_has_provenance' };
+  }
+  if (!decision || !decision.elevate) {
+    return { action: 'skip', reason: `not_ratified (${decision ? decision.reason : 'no_decision'})` };
+  }
+  const provenance = { at: stampedAt, ...decision.provenance, backfilled: true };
+  const nextMetadata = { ...(row.metadata || {}), trust_tier_elevation: provenance };
+  return { action: 'write', reason: 'normalize_provenance', nextMetadata };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const mode = apply ? 'APPLY' : 'DRY-RUN (default — pass --apply to write)';
+  console.log(`\nbackfill-trust-tier-elevation — ${mode}`);
+  console.log('='.repeat(60));
+
+  const sb = createSupabaseServiceClient();
+  const stampedAt = new Date().toISOString();
+  let writes = 0;
+  let skips = 0;
+
+  for (const id of BACKFILL_TARGET_IDS) {
+    const { data: row, error } = await sb
+      .from('applications')
+      .select('id, name, trust_tier, venture_id, metadata')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) {
+      console.log(`  ! ${id} — fetch error: ${error.message} (skipped)`);
+      skips++;
+      continue;
+    }
+    if (!row) {
+      console.log(`  ! ${id} — not found (skipped)`);
+      skips++;
+      continue;
+    }
+
+    // Only compute a ratification decision when the row actually needs provenance —
+    // this avoids a needless query for the already-canonical row.
+    let decision = { elevate: false, reason: 'not_evaluated' };
+    if (!(row.metadata && row.metadata.trust_tier_elevation)) {
+      decision = await resolveTrustElevation({ ventureId: row.venture_id, repoWasMinted: true, supabase: sb });
+    }
+    const plan = planBackfillForRow(row, decision, stampedAt);
+
+    if (plan.action === 'skip') {
+      console.log(`  · ${row.name} (${id}) — skip: ${plan.reason}`);
+      skips++;
+      continue;
+    }
+
+    console.log(`  → ${row.name} (${id}) — write trust_tier_elevation:`);
+    console.log(`      basis: ${plan.nextMetadata.trust_tier_elevation.basis}`);
+    if (apply) {
+      // Guard on the row STILL lacking provenance is implicit (we re-read is not done here,
+      // but the metadata merge is idempotent and a second run no-ops via already_has_provenance).
+      const { error: upErr } = await sb
+        .from('applications')
+        .update({ metadata: plan.nextMetadata })
+        .eq('id', id);
+      if (upErr) {
+        console.log(`      ! write failed: ${upErr.message}`);
+        skips++;
+        continue;
+      }
+      console.log('      ✓ written');
+      writes++;
+    } else {
+      console.log('      (dry-run — not written)');
+      writes++;
+    }
+  }
+
+  console.log('='.repeat(60));
+  console.log(`  ${apply ? 'wrote' : 'would write'}: ${writes} | skipped: ${skips}`);
+  if (!apply && writes > 0) console.log('  Re-run with --apply to persist.');
+}
+
+// Only run main() when invoked directly (guard keeps the pure exports import-safe for tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/tests/unit/eva/bridge/venture-provisioner-trust-elevation.test.js
+++ b/tests/unit/eva/bridge/venture-provisioner-trust-elevation.test.js
@@ -1,0 +1,220 @@
+/**
+ * SD-LEO-INFRA-VENTURE-REPO-TRUST-001 — born-trusted trust-tier elevation.
+ * Pure unit tests against injected fake Supabase clients — no live DB, no gh.
+ *
+ * TS-1  resolveTrustElevation fail-closed truth table (incl. vision-only)
+ * TS-2  elevateVentureRepoTrust performs the conditional UPDATE only on external rows
+ * TS-3  negative pin: external-shaped row never elevates AND VB-2 still blocks it
+ * TS-5  planBackfillForRow: write vs skip (already-provenance / not-ratified)
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveTrustElevation, elevateVentureRepoTrust } from '../../../../lib/eva/bridge/trust-elevation.js';
+import { planBackfillForRow } from '../../../../scripts/backfill-trust-tier-elevation.mjs';
+import { fetchTrustTier, createVentureTrustGate } from '../../../../lib/ship/venture-trust-gate.mjs';
+
+// A minimal thenable query-builder fake. Each table maps to a handler returning {data,error}.
+// Supports the two shapes the code uses:
+//   .from(t).select(cols).eq().eq().limit()             (ratification reads)
+//   .from(t).select(cols).eq('status','active')         (applications lookup)
+//   .from(t).update(patch).eq().eq()                    (elevation write)
+function makeSupabase(handlers) {
+  return {
+    from(table) {
+      const h = handlers[table] || {};
+      const build = (op, payload) => {
+        const state = { table, op, payload, filters: {} };
+        const chain = {
+          select(cols) { state.cols = cols; return chain; },
+          eq(col, val) { state.filters[col] = val; return chain; },
+          limit(n) { state.limit = n; return Promise.resolve(h[op] ? h[op](state) : { data: [], error: null }); },
+          maybeSingle() { return Promise.resolve(h[op] ? h[op](state) : { data: null, error: null }); },
+          then(resolve, reject) {
+            return Promise.resolve(h[op] ? h[op](state) : { data: [], error: null }).then(resolve, reject);
+          },
+        };
+        return chain;
+      };
+      return {
+        select: (cols) => build('select', null).select(cols),
+        update: (patch) => build('update', patch),
+      };
+    },
+  };
+}
+
+const RATIFIED = {
+  eva_architecture_plans: { select: (s) => (s.filters.venture_id === 'v-arch' ? { data: [{ id: 'a1' }], error: null } : { data: [], error: null }) },
+  eva_vision_documents: { select: (s) => (s.filters.venture_id === 'v-vision' ? { data: [{ id: 'vd1' }], error: null } : { data: [], error: null }) },
+};
+
+describe('TS-1 resolveTrustElevation — fail-closed predicate', () => {
+  it('elevate=false when the repo was NOT fleet-minted (load-bearing mint gate)', async () => {
+    const r = await resolveTrustElevation({ ventureId: 'v-arch', repoWasMinted: false, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(false);
+    expect(r.reason).toBe('not_fleet_minted');
+  });
+
+  it('elevate=false when venture_id is unresolved', async () => {
+    const r = await resolveTrustElevation({ ventureId: null, repoWasMinted: true, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(false);
+    expect(r.reason).toBe('venture_id_unresolved');
+  });
+
+  it('elevate=false when there is no chairman_approved arch plan OR vision', async () => {
+    const r = await resolveTrustElevation({ ventureId: 'v-none', repoWasMinted: true, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(false);
+    expect(r.reason).toBe('no_chairman_approval');
+  });
+
+  it('elevate=true on a genuine mint with a chairman_approved ARCH plan', async () => {
+    const r = await resolveTrustElevation({ ventureId: 'v-arch', repoWasMinted: true, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(true);
+    expect(r.provenance.approved_via).toBe('architecture plan');
+    expect(r.provenance.to).toBe('trusted');
+  });
+
+  it('elevate=true on a genuine mint with VISION-ONLY approval (MarketLens case)', async () => {
+    const r = await resolveTrustElevation({ ventureId: 'v-vision', repoWasMinted: true, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(true);
+    expect(r.provenance.approved_via).toBe('vision document');
+  });
+
+  it('fail-closed on a query error (treated as not approved)', async () => {
+    const throwing = {
+      eva_architecture_plans: { select: () => ({ data: null, error: { message: 'boom' } }) },
+      eva_vision_documents: { select: () => ({ data: null, error: { message: 'boom' } }) },
+    };
+    const r = await resolveTrustElevation({ ventureId: 'v-arch', repoWasMinted: true, supabase: makeSupabase(throwing) });
+    expect(r.elevate).toBe(false);
+    expect(r.reason).toBe('no_chairman_approval');
+  });
+});
+
+describe('TS-2 elevateVentureRepoTrust — conditional UPDATE', () => {
+  it('elevates an external applications row and writes canonical provenance', async () => {
+    let updatePatch = null;
+    let updateFilters = null;
+    const supabase = makeSupabase({
+      ...RATIFIED,
+      applications: {
+        select: () => ({ data: [{ id: 'app1', name: 'ApexNiche AI', trust_tier: 'external', metadata: { existing: true } }], error: null }),
+        update: (s) => { updatePatch = s.payload; updateFilters = s.filters; return { data: null, error: null }; },
+      },
+    });
+    const res = await elevateVentureRepoTrust({ ventureId: 'v-arch', ventureName: 'ApexNiche AI', repoWasMinted: true, supabase, stampedAt: '2026-07-12T00:00:00Z' });
+    expect(res.elevated).toBe(true);
+    expect(updatePatch.trust_tier).toBe('trusted');
+    expect(updatePatch.metadata.existing).toBe(true); // merged, not overwritten
+    expect(updatePatch.metadata.trust_tier_elevation.at).toBe('2026-07-12T00:00:00Z');
+    expect(updateFilters.trust_tier).toBe('external'); // concurrency-safe idempotency guard
+  });
+
+  it('no-ops (no UPDATE) when the row is already trusted', async () => {
+    let updateCalled = false;
+    const supabase = makeSupabase({
+      ...RATIFIED,
+      applications: {
+        select: () => ({ data: [{ id: 'app1', name: 'ApexNiche AI', trust_tier: 'trusted', metadata: {} }], error: null }),
+        update: () => { updateCalled = true; return { data: null, error: null }; },
+      },
+    });
+    const res = await elevateVentureRepoTrust({ ventureId: 'v-arch', ventureName: 'ApexNiche AI', repoWasMinted: true, supabase });
+    expect(res.elevated).toBe(false);
+    expect(res.reason).toBe('already_trusted');
+    expect(updateCalled).toBe(false);
+  });
+
+  it('does not elevate an unratified venture even with an app row present', async () => {
+    let updateCalled = false;
+    const supabase = makeSupabase({
+      ...RATIFIED,
+      applications: {
+        select: () => ({ data: [{ id: 'app1', name: 'Imported Co', trust_tier: 'external', metadata: {} }], error: null }),
+        update: () => { updateCalled = true; return { data: null, error: null }; },
+      },
+    });
+    const res = await elevateVentureRepoTrust({ ventureId: 'v-none', ventureName: 'Imported Co', repoWasMinted: true, supabase });
+    expect(res.elevated).toBe(false);
+    expect(res.reason).toBe('no_chairman_approval');
+    expect(updateCalled).toBe(false);
+  });
+});
+
+describe('TS-4 retry-safety — a partial-mint retry converges to trusted, never double-elevates', () => {
+  it('first call (mint) elevates external->trusted; a second call (retry) is a harmless no-op', async () => {
+    // Stateful fake: the row starts external and flips to trusted once the guarded UPDATE fires,
+    // exactly as the live row would across an executeStepWithRetry re-entry.
+    const row = { id: 'app1', name: 'ApexNiche AI', trust_tier: 'external', metadata: {} };
+    let updateCount = 0;
+    const supabase = makeSupabase({
+      ...RATIFIED,
+      applications: {
+        select: () => ({ data: [{ ...row }], error: null }),
+        update: (s) => {
+          // honor the .eq('trust_tier','external') guard — a trusted row is not re-updated
+          if (s.filters.trust_tier === 'external' && row.trust_tier === 'external') {
+            row.trust_tier = 'trusted';
+            row.metadata = s.payload.metadata;
+            updateCount++;
+          }
+          return { data: null, error: null };
+        },
+      },
+    });
+
+    const first = await elevateVentureRepoTrust({ ventureId: 'v-arch', ventureName: 'ApexNiche AI', repoWasMinted: true, supabase });
+    expect(first.elevated).toBe(true);
+    expect(row.trust_tier).toBe('trusted');
+
+    const second = await elevateVentureRepoTrust({ ventureId: 'v-arch', ventureName: 'ApexNiche AI', repoWasMinted: true, supabase });
+    expect(second.elevated).toBe(false);
+    expect(second.reason).toBe('already_trusted');
+    expect(updateCount).toBe(1); // never double-applied
+  });
+});
+
+describe('TS-3 negative pin — external-shaped row never elevates AND VB-2 blocks it', () => {
+  it('an imported repo (repoWasMinted=false) is never elevated', async () => {
+    const r = await resolveTrustElevation({ ventureId: 'v-arch', repoWasMinted: false, supabase: makeSupabase(RATIFIED) });
+    expect(r.elevate).toBe(false);
+  });
+
+  it('VB-2 (createVentureTrustGate) refuses a repo whose applications.trust_tier is external', async () => {
+    // fetchTrustTier reads applications via .select().not() — mirror the gate's own test shape.
+    const externalAppsSupabase = {
+      from: (t) => {
+        if (t !== 'applications') throw new Error(`unexpected table ${t}`);
+        return { select: () => ({ not: () => Promise.resolve({ data: [{ trust_tier: 'external', github_repo: 'rickfelix/importedco' }], error: null }) }) };
+      },
+    };
+    const tier = await fetchTrustTier('rickfelix', 'importedco', externalAppsSupabase);
+    expect(tier).toBe('external');
+
+    const isTrusted = createVentureTrustGate({ supabase: externalAppsSupabase, fetchStatusCheckRollup: async () => [] });
+    const verdict = await isTrusted({ repoOwner: 'rickfelix', repoName: 'importedco', prNumber: 1, workKey: null });
+    expect(verdict).toBe(false); // external tier -> gate returns false BEFORE any witness need
+  });
+});
+
+describe('TS-5 planBackfillForRow — enumerated normalization', () => {
+  const stamp = '2026-07-12T00:00:00Z';
+  it('skips a row that already has trust_tier_elevation (idempotent)', () => {
+    const plan = planBackfillForRow({ id: 'x', name: 'ApexNiche AI', metadata: { trust_tier_elevation: { at: 'prev' } } }, { elevate: true }, stamp);
+    expect(plan.action).toBe('skip');
+    expect(plan.reason).toBe('already_has_provenance');
+  });
+
+  it('writes canonical provenance for a trusted-but-unattributed ratified row (MarketLens)', () => {
+    const decision = { elevate: true, provenance: { to: 'trusted', from: 'external', basis: 'b', approved_via: 'vision document', decided_by: 'venture_provisioner_born_trusted_policy' } };
+    const plan = planBackfillForRow({ id: 'm', name: 'MarketLens', metadata: {} }, decision, stamp);
+    expect(plan.action).toBe('write');
+    expect(plan.nextMetadata.trust_tier_elevation.at).toBe(stamp);
+    expect(plan.nextMetadata.trust_tier_elevation.backfilled).toBe(true);
+  });
+
+  it('skips (never fabricates) when the venture is not ratified', () => {
+    const plan = planBackfillForRow({ id: 'z', name: 'Imported', metadata: {} }, { elevate: false, reason: 'no_chairman_approval' }, stamp);
+    expect(plan.action).toBe('skip');
+    expect(plan.reason).toContain('not_ratified');
+  });
+});

--- a/tests/unit/eva/bridge/venture-provisioner-trust-wiring.test.js
+++ b/tests/unit/eva/bridge/venture-provisioner-trust-wiring.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-VENTURE-REPO-TRUST-001 — provisioner WIRING pin (TS-2 / TS-3, integration slice).
+ *
+ * The decision+write logic (resolveTrustElevation / elevateVentureRepoTrust) is exhaustively
+ * unit-tested in venture-provisioner-trust-elevation.test.js. This file pins the ONE fact those
+ * pure tests cannot: that the DEFAULT_STEPS `repo_created` step invokes elevateVentureRepoTrust
+ * ONLY on the genuine-mint branch (repoExists===false -> `gh repo create`) and passes
+ * repoWasMinted:true ONLY there — the load-bearing second layer of the "imported repos can NEVER
+ * be born trusted" negative pin. Without this test, a refactor that moved the elevation call out
+ * of the else-branch (or added a repoWasMinted:true call to the repo-exists branch) would ship
+ * green — the pure tests would still pass. (Ref memory: "test-masking: mock the gate ships green
+ * on dead code"; "RECURRED-family fix requires e2e acceptance in spec".)
+ *
+ * The gh CLI, the local clone, and resource registration are mocked; the elevation module is
+ * spied. No live DB, no network, no `gh`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  repoViewShouldThrow: true, // true => repo does NOT exist => genuine mint path
+  createCalled: false,
+  elevateSpy: vi.fn(),
+}));
+
+// gh CLI: `repo view` throws when the repo is absent (mint) or returns JSON when present
+// (imported/existing); `repo create` records that a real mint occurred.
+vi.mock('child_process', () => ({
+  execFileSync: (_file, args) => {
+    if (Array.isArray(args) && args.includes('view')) {
+      if (h.repoViewShouldThrow) throw new Error('gh: repo not found');
+      return JSON.stringify({ name: 'apexniche-ai' });
+    }
+    if (Array.isArray(args) && args.includes('create')) {
+      h.createCalled = true;
+      return '';
+    }
+    return '';
+  },
+}));
+
+vi.mock('../../../../lib/eva/bridge/ensure-venture-clone.js', () => ({
+  ensureVentureClone: () => ({ action: 'cloned', reason: 'test-fixture' }),
+}));
+
+vi.mock('../../../../lib/venture-resources.js', () => ({
+  registerVentureResource: async () => {},
+}));
+
+// The spied elevation module — the exact seam we are pinning.
+vi.mock('../../../../lib/eva/bridge/trust-elevation.js', () => ({
+  elevateVentureRepoTrust: h.elevateSpy,
+}));
+
+const { DEFAULT_STEPS } = await import('../../../../lib/eva/bridge/venture-provisioner.js');
+
+function repoCreatedStep() {
+  const step = DEFAULT_STEPS.find((s) => s.name === 'repo_created');
+  if (!step) throw new Error('repo_created step not found in DEFAULT_STEPS');
+  return step;
+}
+
+function makeCtx() {
+  return {
+    ventureId: 'v-arch',
+    venture: { name: 'ApexNiche AI', repoName: 'apexniche-ai', localPath: '/tmp/apexniche-ai' },
+    ventureRepoPath: null,
+    stepsCompleted: [],
+    log: () => {},
+  };
+}
+
+describe('venture-provisioner repo_created — trust-elevation WIRING pin', () => {
+  beforeEach(() => {
+    h.repoViewShouldThrow = true;
+    h.createCalled = false;
+    h.elevateSpy.mockReset();
+    h.elevateSpy.mockResolvedValue({ elevated: true, reason: 'elevated' });
+  });
+
+  it('GENUINE MINT (repo absent): mints the repo AND calls elevateVentureRepoTrust with repoWasMinted:true', async () => {
+    h.repoViewShouldThrow = true; // repo does not exist -> else-branch -> gh repo create
+    await repoCreatedStep().execute(makeCtx());
+
+    expect(h.createCalled).toBe(true); // the fleet genuinely minted the repo
+    expect(h.elevateSpy).toHaveBeenCalledTimes(1);
+    const arg = h.elevateSpy.mock.calls[0][0];
+    expect(arg.repoWasMinted).toBe(true);
+    expect(arg.ventureId).toBe('v-arch');
+    expect(arg.ventureName).toBe('ApexNiche AI');
+  });
+
+  it('IMPORTED/EXISTING repo (repo present): NEVER mints and NEVER calls elevateVentureRepoTrust (negative pin)', async () => {
+    h.repoViewShouldThrow = false; // repo already exists -> if(repoExists) branch, no create, no elevation
+    await repoCreatedStep().execute(makeCtx());
+
+    expect(h.createCalled).toBe(false); // no mint occurred
+    expect(h.elevateSpy).not.toHaveBeenCalled(); // imported repo can never be born trusted through this path
+  });
+});


### PR DESCRIPTION
## Summary
- Venture `applications` rows are born `trust_tier='external'` (a column DEFAULT), so the VB-2 human-merge gate refused auto-merge on the factory's OWN merge-ready output — forcing a per-venture hand elevation (MarketLens, then ApexNiche PR #1; recurring for every venture). This elevates `external`→`trusted` **automatically, but only at genuine fleet mint**.
- **Narrow, fail-closed predicate** (`lib/eva/bridge/trust-elevation.js::resolveTrustElevation`): elevate only when `repoWasMinted===true` (the load-bearing discriminator — imported repos already exist on GitHub and never enter the provisioner's `repoExists===false` mint branch) AND `venture_id` resolves AND a `chairman_approved` `eva_architecture_plans` OR `eva_vision_documents` row exists (vision-alone counts). Any missing signal → no elevation.
- Elevation is a **new second `applications` UPDATE** in the provisioner's mint else-branch (after `gh repo create`, before the fragile clone/register lines — so a partial-mint retry still converges), never folded into the `registry_updated` local_path UPDATE (which runs for all ventures). Idempotent + concurrency-guarded on `trust_tier='external'`, non-fatal.
- **VB-2 gate logic unchanged** — it still requires `trust_tier='trusted'` AND an independent per-PR witness pass, so born-trusted grants nothing by itself (this is the *producer* complement to completed `SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001`).
- Enumerated, dry-run-default backfill normalized the two already-hand-elevated rows' provenance (MarketLens `6823cd37` got the audit metadata; ApexNiche `3c8efc56` no-op). No migration (`ck_applications_trust_tier` already permits `'trusted'`).

## Test plan
- [x] 17 tests: predicate truth-table (incl. vision-only + fail-closed-on-error), mint-branch-only UPDATE, retry-safety convergence, VB-2 external-block negative pin, backfill idempotency, and a **wiring test** driving the real `repo_created` step (gh/clone mocked) pinning `repoWasMinted:true` only from the mint branch
- [x] Independent TESTING sub-agent verification — found + closed a test-masking gap (the wiring pin) itself
- [x] Independent VALIDATION sub-agent — 5/5 FRs delivered, live-DB backfill confirmed, VB-2 byte-identical, negative pin holds at all layers
- [x] Independent REGRESSION sub-agent — 6839 tests across `tests/unit/eva` + `tests/unit/ship`, 0 failures; no circular import; pre-existing eslint at venture-provisioner.js:655 confirmed from a 2026-04-01 commit (not this branch)
- [x] LEO gates: LEAD-TO-PLAN 100, PLAN-TO-EXEC 98, EXEC-TO-PLAN pass, PLAN-TO-LEAD 96

🤖 Generated with [Claude Code](https://claude.com/claude-code)