### PR TITLE
feat(SPINE-001-D): creative_assets migration (FR-1 foundation)

### DIFF
--- a/database/migrations/20260712_creative_assets.sql
+++ b/database/migrations/20260712_creative_assets.sql
@@ -1,0 +1,69 @@
+-- SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — creative engine satellite.
+--
+-- Creates the venture-scoped `creative_assets` table: the SSOT for generated creative
+-- production (layered hero images, brand assets, short-form video) that VP_GROWTH consumes
+-- for venture landing pages and demand-engine channel execution. Every row carries its
+-- generation provenance (generator + prompt + brand-source refs + cost) so an asset is
+-- always traceable to how it was made, and a nullable `consumed_at` that the FR-3
+-- artifact-theater guard keys on (an asset with no consuming channel action within its plan
+-- window is flagged, not counted — assets are execution inputs, never deliverables).
+--
+-- CHAIRMAN-GATED APPLY: this migration adds an RLS policy, so per the repo DDL-approval rule
+-- it is NOT self-applicable by an autonomous worker. The fleet AUTHORS + TESTS it here; it is
+-- applied to prod only via scripts/apply-migration.js --prod-deploy under the 3-factor guard
+-- (flag + pre-issued MIGRATION_APPLY_TOKEN + `-- @approved-by: <chairman-email>` matching
+-- git config user.email). metadata.requires_chairman_apply=true is set on the SD. Dependent
+-- FR-1 code (lib/creative/) must fail soft (to_regclass existence check, never a head-count
+-- probe) until this lands live. MERGED != LIVE — flag the apply step.
+--
+-- Additive + reversible: CREATE TABLE only; rollback = DROP TABLE creative_assets.
+-- venture_id FK is ON DELETE CASCADE by design — a venture's creative assets are owned by that
+-- venture and should not outlive it (unlike run/audit evidence, which is teardown-exempt).
+
+CREATE TABLE IF NOT EXISTS creative_assets (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id        UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  -- capability lane: image ships first; video is gated behind the FR-1 capability-envelope
+  -- flag (a plan step requiring video fails at PLAN time until the video path is registered
+  -- with delivery evidence) — the CHECK admits both, the flag governs which is drivable.
+  capability        TEXT NOT NULL CHECK (capability IN ('image', 'video')),
+  -- provenance (never trust the prompt's description of the pixels — the actual generator + inputs):
+  generator         TEXT NOT NULL,                         -- provider name, e.g. 'runwayml' | 'gemini'
+  prompt            TEXT,                                  -- the generation prompt actually sent
+  brand_source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,    -- refs into S17 design-system artifacts
+  cost              NUMERIC,                               -- per-asset cost, attributed to venture x role x activity
+  provenance        JSONB NOT NULL DEFAULT '{}'::jsonb,    -- full generation provenance (model, params, task id, provider recipe)
+  -- theater-guard seam (FR-3): set when a distribution_channel_config row references this asset
+  -- as an EXECUTED channel action; NULL past the plan window => flagged by the sweep.
+  consumed_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Theater-guard sweep reads unconsumed assets per venture within a plan window — index both.
+CREATE INDEX IF NOT EXISTS creative_assets_venture_idx      ON creative_assets (venture_id);
+CREATE INDEX IF NOT EXISTS creative_assets_unconsumed_idx   ON creative_assets (venture_id, created_at) WHERE consumed_at IS NULL;
+
+COMMENT ON TABLE  creative_assets                 IS 'SD-...-SPINE-001-D FR-1: venture-scoped generated creative assets (image/video) with generation provenance; consumed_at feeds the FR-3 artifact-theater guard.';
+COMMENT ON COLUMN creative_assets.consumed_at     IS 'When a channel action referenced this asset (reach). NULL past the plan window => artifact-theater finding (reference != reach).';
+COMMENT ON COLUMN creative_assets.brand_source_refs IS 'Refs into S17 design-system artifacts used as brand source (array of artifact ids/keys).';
+
+-- Venture-scoped RLS (this is what makes the migration chairman-gated). Mirrors the canonical
+-- venture-access pattern (20260704_marketlens_owned_audience_caps.sql vdc_venture_access):
+-- authenticated users see only assets for ventures in companies they can access; the FR-1
+-- generation service runs as service_role with full access.
+ALTER TABLE creative_assets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY creative_assets_venture_access ON creative_assets
+  FOR ALL TO authenticated
+  USING (
+    venture_id IN (
+      SELECT v.id FROM ventures v
+      WHERE v.company_id IN (
+        SELECT company_id FROM user_company_access WHERE user_id = auth.uid()
+      )
+    )
+  );
+
+CREATE POLICY creative_assets_service_role ON creative_assets
+  FOR ALL TO service_role
+  USING (true);

--- a/tests/unit/creative-assets-migration.test.js
+++ b/tests/unit/creative-assets-migration.test.js
@@ -1,0 +1,48 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — static, live-probe-free assertions on the
+// creative_assets migration. Pins the DDL shape (columns, provenance, theater-guard seam,
+// venture-scoped RLS) so an accidental edit that weakens scoping or drops provenance is caught
+// at CI without touching a live DB. Mirrors the OBSERVED-migration static-test convention.
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION = path.resolve(__dirname, '../../database/migrations/20260712_creative_assets.sql');
+
+describe('creative_assets migration (FR-1)', () => {
+  let sql;
+  beforeAll(() => { sql = fs.readFileSync(MIGRATION, 'utf8'); });
+
+  it('creates the venture-scoped creative_assets table', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS creative_assets/);
+    // venture ownership cascades on venture delete (assets are owned by the venture)
+    expect(sql).toMatch(/venture_id\s+UUID NOT NULL REFERENCES ventures\(id\) ON DELETE CASCADE/);
+  });
+
+  it('gates capability to image|video (video envelope-flagged in code)', () => {
+    expect(sql).toMatch(/capability\s+TEXT NOT NULL CHECK \(capability IN \('image', 'video'\)\)/);
+  });
+
+  it('carries generation provenance, cost, and the theater-guard consumed_at seam', () => {
+    expect(sql).toMatch(/generator\s+TEXT NOT NULL/);
+    expect(sql).toMatch(/brand_source_refs JSONB/);
+    expect(sql).toMatch(/provenance\s+JSONB/);
+    expect(sql).toMatch(/cost\s+NUMERIC/);
+    expect(sql).toMatch(/consumed_at\s+TIMESTAMPTZ/);
+  });
+
+  it('enables RLS with the canonical venture-access scoping (not a tautology)', () => {
+    expect(sql).toMatch(/ALTER TABLE creative_assets ENABLE ROW LEVEL SECURITY/);
+    // real scoping: authenticated users limited to ventures in their accessible companies
+    expect(sql).toMatch(/FOR ALL TO authenticated/);
+    expect(sql).toMatch(/SELECT company_id FROM user_company_access WHERE user_id = auth\.uid\(\)/);
+    // service role (the FR-1 generation service) gets full access
+    expect(sql).toMatch(/creative_assets_service_role[\s\S]*FOR ALL TO service_role[\s\S]*USING \(true\)/);
+  });
+
+  it('is documented as chairman-gated (RLS => not self-applicable)', () => {
+    expect(sql).toMatch(/CHAIRMAN-GATED APPLY/);
+    expect(sql).toMatch(/MERGED != LIVE/);
+  });
+});


### PR DESCRIPTION
## Summary
First EXEC slice of the creative engine satellite (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D), unblocked now that spine core (child B) completed and the coordinator cleared the satellite fences.

- **`database/migrations/20260712_creative_assets.sql`** — venture-scoped `creative_assets` table: SSOT for generated creative production (image/video) with generation provenance (generator/prompt/brand_source_refs/cost) and a `consumed_at` seam the FR-3 artifact-theater guard keys on (reference ≠ reach). `capability` CHECK admits `image|video` (video gated behind the FR-1 capability-envelope flag in code). Venture-scoped RLS mirrors the canonical `user_company_access` pattern (from `20260704_marketlens_owned_audience_caps.sql`) + a service-role policy for the generation service.
- **`tests/unit/creative-assets-migration.test.js`** — static, live-probe-free assertions pinning the DDL shape (columns, provenance, theater-guard seam, real venture-scoped RLS — guards against an accidental tautology).

## Chairman-gated
RLS present ⇒ per the repo DDL-approval rule this migration is **NOT self-applied**. Authored + tested here; applied via `apply-migration.js --prod-deploy` under the 3-factor guard. `metadata.requires_chairman_apply=true` set on the SD. **MERGED ≠ LIVE** — FR-1 code will fail soft (to_regclass check) until it lands.

## Scope
FR-1 foundation only. Follow-on slices: `lib/creative/` `generateAsset()` primitive + RunwayML/Gemini adapters, the quality/anti-fabrication gate (FR-2), and the theater-guard gauge (FR-3).

## Test plan
- [x] `npx vitest run tests/unit/creative-assets-migration.test.js` — 5/5 pass
- [x] Pre-commit smoke suite — 15/15 pass
- [ ] Live schema verification deferred to chairman-gated apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)