### PR TITLE
feat(SPINE-001-D): generateAsset() provider-abstraction primitive (FR-1)

### DIFF
--- a/lib/creative/errors.js
+++ b/lib/creative/errors.js
@@ -1,0 +1,27 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — typed generation-failure contract.
+// Async provider task handling is first-class: a failure is always this shape, never a
+// silent empty/placeholder asset (the fail-toward-flattery ban, per the design spec §2).
+
+export class TaskFailedError extends Error {
+  constructor(message, { provider, capability, code, cause } = {}) {
+    super(message);
+    this.name = 'TaskFailedError';
+    this.provider = provider;
+    this.capability = capability;
+    this.code = code || 'TASK_FAILED';
+    if (cause) this.cause = cause;
+  }
+}
+
+// Thrown when a capability/provider pairing is registered but has no usable credential yet
+// (e.g. RunwayML before the chairman's account+API-key walkthrough) — distinct from a
+// runtime TaskFailedError so callers can distinguish "not configured" from "attempted and failed".
+export class ProviderNotConfiguredError extends Error {
+  constructor(provider, capability) {
+    super(`Provider "${provider}" for capability "${capability}" is registered but has no configured credential`);
+    this.name = 'ProviderNotConfiguredError';
+    this.provider = provider;
+    this.capability = capability;
+    this.code = 'PROVIDER_NOT_CONFIGURED';
+  }
+}

--- a/lib/creative/generate-asset.js
+++ b/lib/creative/generate-asset.js
@@ -1,0 +1,63 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — the generateAsset() provider-abstraction
+// primitive. ONE seam every creative-generation call site goes through (TR-2: no hardcoded
+// provider call sites) — provider-per-capability routing lives HERE, in routing config, never
+// inlined at callers, so the provider decision (chairman-ratified RunwayML-primary / Gemini-
+// fallback, design spec §2) stays swappable without touching consumers.
+//
+// Image lane: RunwayML primary, Gemini fallback (registered but honest about not-yet-configured
+// credentials). Video lane: RunwayML only — no Gemini fallback exists for video, so an unconfigured
+// Runway credential means video genuinely cannot be driven yet. That IS the capability-envelope
+// gate in effect for this primitive: a video request fails with a typed, distinguishable error
+// rather than silently degrading to image or fabricating an asset (O9 / fail-toward-flattery ban).
+
+import { generateWithRunway, isRunwayConfigured } from './providers/runway.js';
+import { generateWithGemini, isGeminiConfigured } from './providers/gemini.js';
+import { TaskFailedError, ProviderNotConfiguredError } from './errors.js';
+
+// Provider-per-capability routing table (TR-2). Order = fallback priority.
+const ROUTES = Object.freeze({
+  image: [
+    { name: 'runway', generate: generateWithRunway, isConfigured: isRunwayConfigured },
+    { name: 'gemini', generate: generateWithGemini, isConfigured: isGeminiConfigured },
+  ],
+  video: [
+    { name: 'runway', generate: generateWithRunway, isConfigured: isRunwayConfigured },
+  ],
+});
+
+/**
+ * @param {'image'|'video'} capability
+ * @param {{prompt: string}} spec
+ * @param {object} [constraints]
+ * @returns {Promise<{asset: object, provenance: object, cost: number|null}>}
+ * @throws {TaskFailedError} every configured provider attempt failed
+ * @throws {ProviderNotConfiguredError} no provider for this capability has a usable credential
+ */
+export async function generateAsset(capability, spec, constraints = {}) {
+  const route = ROUTES[capability];
+  if (!route) {
+    throw new TaskFailedError(`Unknown capability "${capability}"`, { capability, code: 'UNKNOWN_CAPABILITY' });
+  }
+
+  const attempted = [];
+  let lastConfiguredFailure = null;
+
+  for (const provider of route) {
+    if (!provider.isConfigured()) continue;
+    attempted.push(provider.name);
+    try {
+      return await provider.generate({ capability, spec, constraints }, {});
+    } catch (err) {
+      if (err instanceof ProviderNotConfiguredError) continue; // race with isConfigured(); try next
+      lastConfiguredFailure = err;
+      // typed failure, never a silent empty asset — but DO try the next provider in the fallback chain
+    }
+  }
+
+  if (lastConfiguredFailure) throw lastConfiguredFailure;
+
+  // No provider in this capability's route has a usable credential.
+  throw new ProviderNotConfiguredError(route.map((p) => p.name).join('|') || 'none', capability);
+}
+
+export { ROUTES as CREATIVE_PROVIDER_ROUTES };

--- a/lib/creative/generate-asset.test.js
+++ b/lib/creative/generate-asset.test.js
@@ -1,0 +1,93 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — generateAsset() primitive tests.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { generateAsset } from './generate-asset.js';
+import { generateWithGemini, isGeminiConfigured } from './providers/gemini.js';
+import { generateWithRunway, isRunwayConfigured } from './providers/runway.js';
+import { TaskFailedError, ProviderNotConfiguredError } from './errors.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('generateAsset() provider-abstraction primitive', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('routes image requests to Gemini fallback when Runway is unconfigured (test-mode, no live call)', async () => {
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    const result = await generateAsset('image', { prompt: 'a hero image' });
+    expect(result.provenance.generator).toBe('gemini');
+    expect(result.provenance.testMode).toBe(true); // safe default — no live API call fired
+    expect(result.cost).toBe(0);
+  });
+
+  it('throws ProviderNotConfiguredError for video when Runway is unconfigured (no fallback for video)', async () => {
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+    process.env.GEMINI_API_KEY = 'test-key'; // present but irrelevant — video has no Gemini route
+
+    await expect(generateAsset('video', { prompt: 'a demo video' })).rejects.toThrow(ProviderNotConfiguredError);
+  });
+
+  it('throws ProviderNotConfiguredError when no provider for the capability is configured at all', async () => {
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+
+    await expect(generateAsset('image', { prompt: 'x' })).rejects.toThrow(ProviderNotConfiguredError);
+  });
+
+  it('throws TaskFailedError (never a silent empty asset) on unknown capability', async () => {
+    await expect(generateAsset('audio', { prompt: 'x' })).rejects.toThrow(TaskFailedError);
+  });
+
+  it('never fabricates a success result on a typed provider failure — propagates the error', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+
+    // Force Gemini out of test-mode via a direct call to confirm the live-path error contract
+    // (generateAsset() itself always test-mode-defaults; this exercises the adapter directly).
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'));
+    await expect(
+      generateWithGemini({ capability: 'image', spec: { prompt: 'x' } }, { fetchImpl, testMode: false })
+    ).rejects.toThrow(TaskFailedError);
+  });
+});
+
+describe('gemini adapter', () => {
+  afterEach(() => { process.env = { ...ORIGINAL_ENV }; vi.restoreAllMocks(); });
+
+  it('rejects video (image-lane fallback only, no Gemini video path)', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    await expect(generateWithGemini({ capability: 'video', spec: { prompt: 'x' } })).rejects.toThrow(TaskFailedError);
+  });
+
+  it('reports configured based on GEMINI_API_KEY or GOOGLE_AI_API_KEY', () => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    expect(isGeminiConfigured()).toBe(false);
+    process.env.GOOGLE_AI_API_KEY = 'x';
+    expect(isGeminiConfigured()).toBe(true);
+  });
+});
+
+describe('runway adapter (not yet configured — honest, not fabricated)', () => {
+  afterEach(() => { process.env = { ...ORIGINAL_ENV }; });
+
+  it('reports unconfigured with no credential present', () => {
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+    expect(isRunwayConfigured()).toBe(false);
+  });
+
+  it('throws ProviderNotConfiguredError rather than a fabricated success', async () => {
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+    await expect(generateWithRunway({ capability: 'image' })).rejects.toThrow(ProviderNotConfiguredError);
+  });
+});

--- a/lib/creative/providers/gemini.js
+++ b/lib/creative/providers/gemini.js
@@ -1,0 +1,81 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — Gemini image-generation adapter.
+// gemini-2.5-flash-image via raw fetch is the ratified image path (design spec §2). Registered
+// as the live FALLBACK behind generateAsset() — RunwayML is primary once configured, per the
+// chairman's ruling (2026-07-10) — never a hardcoded call site elsewhere in the codebase.
+//
+// Same env convention as lib/llm/client-factory.js (GEMINI_API_KEY || GOOGLE_AI_API_KEY) and the
+// same generativelanguage.googleapis.com host, so this adapter is not a new integration pattern.
+
+import { TaskFailedError, ProviderNotConfiguredError } from '../errors.js';
+
+const GEMINI_IMAGE_MODEL = 'gemini-2.5-flash-image';
+const GEMINI_HOST = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+export function isGeminiConfigured() {
+  return Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY);
+}
+
+/**
+ * @param {{capability: 'image'|'video', spec: {prompt: string}, constraints?: object}} params
+ * @param {{fetchImpl?: typeof fetch, testMode?: boolean}} [deps]
+ * @returns {Promise<{asset: object, provenance: object, cost: number}>}
+ */
+export async function generateWithGemini({ capability, spec, constraints = {} }, deps = {}) {
+  if (capability !== 'image') {
+    // Gemini is the image-lane fallback only; video has no Gemini fallback (Runway-only, envelope-flagged).
+    throw new TaskFailedError(`Gemini adapter does not support capability "${capability}"`, {
+      provider: 'gemini', capability, code: 'CAPABILITY_UNSUPPORTED',
+    });
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    throw new ProviderNotConfiguredError('gemini', capability);
+  }
+
+  const fetchImpl = deps.fetchImpl || fetch;
+  const testMode = deps.testMode ?? true; // fail-safe default: never fires a live call unless explicitly disabled
+
+  if (testMode) {
+    // Watermarked/sandboxed synthetic output (design spec §2) — the simulated run and APA
+    // fixtures never consume production quota silently.
+    return {
+      asset: { kind: 'watermarked-stub', capability: 'image', prompt: spec.prompt },
+      provenance: { generator: 'gemini', model: GEMINI_IMAGE_MODEL, testMode: true, prompt: spec.prompt },
+      cost: 0,
+    };
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(
+      `${GEMINI_HOST}/${GEMINI_IMAGE_MODEL}:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: spec.prompt }] }],
+          generationConfig: constraints.generationConfig || {},
+        }),
+      }
+    );
+  } catch (cause) {
+    throw new TaskFailedError('Gemini image generation request failed', {
+      provider: 'gemini', capability, code: 'NETWORK_ERROR', cause,
+    });
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new TaskFailedError(`Gemini image generation failed (${response.status})`, {
+      provider: 'gemini', capability, code: `HTTP_${response.status}`, cause: body,
+    });
+  }
+
+  const data = await response.json();
+  return {
+    asset: { kind: 'generated', capability: 'image', raw: data },
+    provenance: { generator: 'gemini', model: GEMINI_IMAGE_MODEL, testMode: false, prompt: spec.prompt },
+    cost: constraints.estimatedCost ?? null, // Gemini image pricing not yet wired to the spend-envelope model
+  };
+}

--- a/lib/creative/providers/runway.js
+++ b/lib/creative/providers/runway.js
@@ -1,0 +1,28 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — RunwayML adapter (PRIMARY, chairman
+// ruling 2026-07-10: "RunwayML is PRIMARY for BOTH image and video"). Registered now so the
+// routing table is complete and the provider decision never needs a call-site change later —
+// but no credential exists yet (RUNWAY_API_KEY unset; the chairman's account + API-key
+// walkthrough is a separate, not-yet-completed step per the design spec §2 provenance note).
+//
+// Deliberately NOT a fabricated/mocked client: rather than pretend to call an API this codebase
+// has never integrated, this adapter throws a typed ProviderNotConfiguredError so callers (and
+// the FR-1 routing layer) get an honest, distinguishable signal instead of a false success or a
+// guessed request shape that would need rewriting anyway once the real credential lands.
+
+import { ProviderNotConfiguredError } from '../errors.js';
+
+export function isRunwayConfigured() {
+  return Boolean(process.env.RUNWAY_API_KEY || process.env.RUNWAYML_API_KEY);
+}
+
+/**
+ * @param {{capability: 'image'|'video', spec: object, constraints?: object}} params
+ * @returns {Promise<{asset: object, provenance: object, cost: number}>}
+ */
+export async function generateWithRunway({ capability }) {
+  if (!isRunwayConfigured()) {
+    throw new ProviderNotConfiguredError('runway', capability);
+  }
+  // Real client implementation lands once RUNWAY_API_KEY is provisioned (chairman walkthrough).
+  throw new ProviderNotConfiguredError('runway', capability);
+}


### PR DESCRIPTION
## Summary
Second FR-1 slice of the creative engine satellite (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D), building on the `creative_assets` migration (#5981, merged).

- **`lib/creative/generate-asset.js`** — the `generateAsset(capability, spec, constraints)` primitive: the ONE seam every creative-generation call site goes through (TR-2, no hardcoded provider call sites). Provider-per-capability routing lives in config, not at callers.
- **`lib/creative/providers/{runway,gemini}.js`** — image lane: RunwayML primary (chairman ruling 2026-07-10), Gemini `gemini-2.5-flash-image` fallback via raw fetch (matches `lib/llm/client-factory.js`'s existing host/env convention). Video lane: RunwayML only, no fallback — since `RUNWAY_API_KEY` is unset until the chairman's account walkthrough, this **is** the capability-envelope gate in effect for video: a typed failure, never a silent degrade to image.
- **`lib/creative/errors.js`** — typed failure contract (`TaskFailedError`, `ProviderNotConfiguredError`) so async failures are never a silent empty asset (fail-toward-flattery ban).
- **Safety**: `generateAsset()` defaults to test-mode (watermarked/sandboxed synthetic output) — no automated run, including this one, ever fires a live paid API call. The Runway adapter is registered but honestly reports not-yet-configured rather than a fabricated/mocked client.

## Scope note
292 LOC — above the ≤100 target but under the documented 400 LOC ceiling and the pre-commit LOC gate's SD-required threshold. One cohesive unit (errors + 2 adapters + primitive + comprehensive test coverage); splitting further would fragment a single interface contract across PRs.

## Test plan
- [x] `npx vitest run lib/creative/generate-asset.test.js` — 9/9 pass (routing/fallback order, typed-failure propagation, test-mode-default safety, video no-fallback behavior, unconfigured-provider handling)
- [x] `npx eslint` on all new files — clean
- [x] Pre-commit smoke suite

## Follow-on (out of scope here)
Per-venture creative-brief seam (DB write to `creative_assets`), FR-2 quality/anti-fabrication gate, FR-3 theater-guard gauge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)