### PR TITLE
feat(SPINE-001-D): quality gate + artifact-theater guard (FR-2, FR-3)

### DIFF
--- a/lib/creative/quality-gate.js
+++ b/lib/creative/quality-gate.js
@@ -1,0 +1,65 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-2) — quality + anti-fabrication gate on
+// generated assets. Two stages per the PRD: (1) brand-genome conformance, (2) anti-fabrication
+// screening. Judged on the asset's actual output, never on the generation prompt's description
+// of it (an asset judged by its own prompt is the decorative-computation class with a paintbrush).
+//
+// HONEST-GAUGE NOTE: full brand-genome pixel/palette conformance and claims-registry
+// text-in-image screening both need infrastructure this repo does not have yet (no
+// claims_registry table — confirmed absent, lib/apa/standing-assessment-round.mjs:30; no
+// pixel-level brand-token comparator). Rather than fabricate a pass for checks that can't
+// actually run, both stages FAIL CLOSED with a distinct, honest reason when their deeper
+// check is unwired — an asset is NOT usable until it genuinely passes, never silently
+// approved by an unimplemented judge (S-4 gauge substrate: NO-DATA over fabricated success).
+// What IS real and mechanical now: rejecting stub/test-mode output outright (AC-1) and
+// verifying brand-source provenance is present and non-empty before deeper conformance can
+// even be attempted.
+
+/**
+ * Stage 1: brand-genome conformance. Structural check now (brand_source_refs present and
+ * non-empty, referencing real S17 design-system artifacts); the deeper palette/typography/tone
+ * pixel comparison is NOT yet implemented — fails closed with a distinct reason rather than a
+ * fabricated pass.
+ * @param {{brand_source_refs?: any[], provenance?: object}} asset
+ * @returns {{pass: boolean, reason: string}}
+ */
+export function assessBrandGenomeConformance(asset) {
+  const refs = asset?.brand_source_refs;
+  if (!Array.isArray(refs) || refs.length === 0) {
+    return { pass: false, reason: 'NO_BRAND_SOURCE_REFS' };
+  }
+  // Structural check passes; the pixel-level palette/typography/tone comparison against S17
+  // artifacts is genuinely unimplemented — honest fail-closed, not a fabricated pass.
+  return { pass: false, reason: 'PIXEL_CONFORMANCE_CHECK_NOT_IMPLEMENTED' };
+}
+
+/**
+ * Stage 2: anti-fabrication screening. A stubbed/placeholder provider response (test-mode
+ * output — generateAsset() defaults there) is rejected mechanically, always (AC-1): a stub is
+ * never a real generation and can never be judged authentic. Real generated output cannot yet
+ * be screened against a claims registry (unwired) — fails closed with a distinct reason.
+ * @param {{provenance?: {testMode?: boolean}, asset?: {kind?: string}}} generationResult
+ * @returns {{pass: boolean, reason: string}}
+ */
+export function screenForFabrication(generationResult) {
+  const isStub = generationResult?.provenance?.testMode === true
+    || generationResult?.asset?.kind === 'watermarked-stub';
+  if (isStub) {
+    return { pass: false, reason: 'STUB_OUTPUT_REJECTED' };
+  }
+  // A real (non-stub) generation cannot yet be screened for synthesized social proof / fake
+  // testimonials / nonexistent-feature screenshots — claims_registry is unwired. Fail closed.
+  return { pass: false, reason: 'CLAIMS_REGISTRY_NOT_WIRED' };
+}
+
+/**
+ * Runs both quality-gate stages. Passes ONLY if both stages genuinely pass — an asset failing
+ * either stage is not usable (referenceable by a channel step), matching AC-1/AC-2.
+ * @param {object} generationResult — the {asset, provenance, cost} shape from generateAsset()
+ * @param {object} storedAsset — the creative_assets row shape (brand_source_refs etc.)
+ * @returns {{pass: boolean, stages: {brandGenome: object, antiFabrication: object}}}
+ */
+export function runQualityGate(generationResult, storedAsset) {
+  const brandGenome = assessBrandGenomeConformance(storedAsset);
+  const antiFabrication = screenForFabrication(generationResult);
+  return { pass: brandGenome.pass && antiFabrication.pass, stages: { brandGenome, antiFabrication } };
+}

--- a/lib/creative/quality-gate.test.js
+++ b/lib/creative/quality-gate.test.js
@@ -1,0 +1,56 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-2) — quality gate tests.
+import { describe, it, expect } from 'vitest';
+import { assessBrandGenomeConformance, screenForFabrication, runQualityGate } from './quality-gate.js';
+
+describe('assessBrandGenomeConformance', () => {
+  it('rejects an asset with no brand_source_refs (real, mechanical check)', () => {
+    const result = assessBrandGenomeConformance({ brand_source_refs: [] });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('NO_BRAND_SOURCE_REFS');
+  });
+
+  it('rejects even with brand_source_refs present — pixel-level conformance is honestly unimplemented, never a fabricated pass', () => {
+    const result = assessBrandGenomeConformance({ brand_source_refs: ['s17-artifact-1'] });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('PIXEL_CONFORMANCE_CHECK_NOT_IMPLEMENTED');
+  });
+});
+
+describe('screenForFabrication (AC-1)', () => {
+  it('rejects stub/test-mode output mechanically — the acceptance-criterion case', () => {
+    const stub = { provenance: { testMode: true }, asset: { kind: 'watermarked-stub' } };
+    const result = screenForFabrication(stub);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('STUB_OUTPUT_REJECTED');
+  });
+
+  it('rejects a real (non-stub) generation too — claims_registry is honestly unwired, never a fabricated pass', () => {
+    const real = { provenance: { testMode: false }, asset: { kind: 'generated' } };
+    const result = screenForFabrication(real);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe('CLAIMS_REGISTRY_NOT_WIRED');
+  });
+});
+
+describe('runQualityGate', () => {
+  it('AC-1: a stubbed/placeholder provider response fails the gate mechanically, not silently accepted', () => {
+    const stubGenerationResult = { provenance: { testMode: true }, asset: { kind: 'watermarked-stub' } };
+    const storedAsset = { brand_source_refs: [] };
+    const result = runQualityGate(stubGenerationResult, storedAsset);
+    expect(result.pass).toBe(false);
+    expect(result.stages.antiFabrication.reason).toBe('STUB_OUTPUT_REJECTED');
+  });
+
+  it('currently blocks ALL assets by honest design (both stages fail-closed pending real infra) — never a false-pass', () => {
+    // This is the explicit, documented current state: neither judge is fully implemented, so
+    // nothing is falsely marked quality-approved. A future PR wiring the pixel comparator and
+    // claims_registry should change these reasons/results, at which point this test's intent
+    // shifts to "genuinely good assets pass, bad ones don't" — but until then, fail-closed.
+    const wellFormedGenerationResult = { provenance: { testMode: false }, asset: { kind: 'generated' } };
+    const wellFormedStoredAsset = { brand_source_refs: ['s17-artifact-1', 's17-artifact-2'] };
+    const result = runQualityGate(wellFormedGenerationResult, wellFormedStoredAsset);
+    expect(result.pass).toBe(false);
+    expect(result.stages.brandGenome.reason).toBe('PIXEL_CONFORMANCE_CHECK_NOT_IMPLEMENTED');
+    expect(result.stages.antiFabrication.reason).toBe('CLAIMS_REGISTRY_NOT_WIRED');
+  });
+});

--- a/lib/creative/theater-guard.js
+++ b/lib/creative/theater-guard.js
@@ -1,0 +1,62 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-3) — artifact-theater guard gauge (O3).
+// Flags any creative_assets row with no EXECUTED consuming channel action within its plan
+// window -- reference alone does not count as reach. Schema-independent of child C's
+// distribution_channel_config rebuild shape: this sweep reads ONLY creative_assets.consumed_at,
+// the abstraction boundary the FR-1 migration deliberately added for this purpose. Whatever
+// process marks an asset consumed (the creative-brief seam, or a future demand-engine execution
+// hook) is responsible for setting consumed_at; this module never queries channel tables
+// directly, so it cannot be broken by C landing a different distribution_channel_config shape.
+//
+// PLAN-WINDOW NOTE (PRD open item, not yet numerically fixed at PLAN time): the PRD explicitly
+// left the plan-window duration and sweep cadence unpinned. DEFAULT_PLAN_WINDOW_MS below is a
+// documented placeholder (24h), not a ratified operational value -- callers should override via
+// the planWindowMs param once the coordinator/chairman pins the real number. Presenting this as
+// anything other than a placeholder would be exactly the fabricated-precision anti-pattern this
+// program's gauges are built to avoid.
+
+export const DEFAULT_PLAN_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h placeholder — see note above.
+
+/**
+ * Pure sweep logic — no I/O, so it's trivially unit-testable (mirrors the
+ * lib/worktree-reaper/pools.js computePoolUtilization pattern used elsewhere in this repo).
+ *
+ * A row is flagged when it has never been consumed (consumed_at IS NULL) AND its creation is
+ * older than the plan window. An asset actively referenced (consumed_at set, even if that
+ * timestamp itself is old — "actively referenced" means the seam re-touches consumed_at on
+ * every live reference, not just the first) is never flagged (AC-2: reused/pre-staged library
+ * assets under active reference are excluded from false-positive flagging).
+ *
+ * @param {Array<{id: string, created_at: string, consumed_at: string|null}>} rows
+ * @param {{ now?: Date, planWindowMs?: number }} [options]
+ * @returns {{ flagged: Array<{id: string, reason: string}>, checked: number, planWindowMs: number }}
+ */
+export function sweepArtifactTheater(rows, { now = new Date(), planWindowMs = DEFAULT_PLAN_WINDOW_MS } = {}) {
+  const nowMs = now.getTime();
+  const flagged = [];
+
+  for (const row of rows || []) {
+    if (row.consumed_at) continue; // actively referenced — never flagged, regardless of age (AC-2)
+    const createdMs = new Date(row.created_at).getTime();
+    if (Number.isFinite(createdMs) && nowMs - createdMs > planWindowMs) {
+      flagged.push({ id: row.id, reason: 'NO_CONSUMING_CHANNEL_ACTION_WITHIN_PLAN_WINDOW' });
+    }
+  }
+
+  return { flagged, checked: (rows || []).length, planWindowMs };
+}
+
+/**
+ * DB-facing wrapper: fetches unconsumed creative_assets rows and runs the sweep. Only fetches
+ * consumed_at IS NULL rows (cheap query — never needs the full table), matching AC-1 (a row
+ * with no consuming channel action trips the guard within one sweep).
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ now?: Date, planWindowMs?: number }} [options]
+ */
+export async function runArtifactTheaterSweep(supabase, options = {}) {
+  const { data, error } = await supabase
+    .from('creative_assets')
+    .select('id, created_at, consumed_at')
+    .is('consumed_at', null);
+  if (error) throw error;
+  return sweepArtifactTheater(data || [], options);
+}

--- a/lib/creative/theater-guard.js
+++ b/lib/creative/theater-guard.js
@@ -54,7 +54,7 @@ export function sweepArtifactTheater(rows, { now = new Date(), planWindowMs = DE
  */
 export async function runArtifactTheaterSweep(supabase, options = {}) {
   const { data, error } = await supabase
-    .from('creative_assets')
+    .from('creative_assets') // schema-lint-disable-line: chairman-gated migration (20260712_creative_assets.sql, PR #5981 merged, MERGED != LIVE) not yet applied to the live snapshot
     .select('id, created_at, consumed_at')
     .is('consumed_at', null);
   if (error) throw error;

--- a/lib/creative/theater-guard.test.js
+++ b/lib/creative/theater-guard.test.js
@@ -1,0 +1,61 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-3) — theater-guard sweep tests.
+import { describe, it, expect, vi } from 'vitest';
+import { sweepArtifactTheater, runArtifactTheaterSweep, DEFAULT_PLAN_WINDOW_MS } from './theater-guard.js';
+
+const NOW = new Date('2026-07-12T12:00:00Z');
+const OLD = new Date(NOW.getTime() - DEFAULT_PLAN_WINDOW_MS - 1000).toISOString(); // just past the window
+const RECENT = new Date(NOW.getTime() - 1000).toISOString(); // well within the window
+
+describe('sweepArtifactTheater (pure logic)', () => {
+  it('AC-1: flags an unconsumed row older than the plan window', () => {
+    const rows = [{ id: 'a1', created_at: OLD, consumed_at: null }];
+    const result = sweepArtifactTheater(rows, { now: NOW });
+    expect(result.flagged).toHaveLength(1);
+    expect(result.flagged[0]).toEqual({ id: 'a1', reason: 'NO_CONSUMING_CHANNEL_ACTION_WITHIN_PLAN_WINDOW' });
+    expect(result.checked).toBe(1);
+  });
+
+  it('does not flag an unconsumed row still within the plan window', () => {
+    const rows = [{ id: 'a2', created_at: RECENT, consumed_at: null }];
+    const result = sweepArtifactTheater(rows, { now: NOW });
+    expect(result.flagged).toHaveLength(0);
+  });
+
+  it('AC-2: an actively-consumed asset is never flagged, even if old (reference != false-positive)', () => {
+    const rows = [{ id: 'a3', created_at: OLD, consumed_at: RECENT }];
+    const result = sweepArtifactTheater(rows, { now: NOW });
+    expect(result.flagged).toHaveLength(0);
+  });
+
+  it('respects an overridden planWindowMs (the PRD-flagged unpinned value)', () => {
+    const rows = [{ id: 'a4', created_at: RECENT, consumed_at: null }];
+    const result = sweepArtifactTheater(rows, { now: NOW, planWindowMs: 500 }); // 500ms window, RECENT is 1000ms old
+    expect(result.flagged).toHaveLength(1);
+    expect(result.planWindowMs).toBe(500);
+  });
+
+  it('handles an empty row set without error', () => {
+    expect(sweepArtifactTheater([], { now: NOW })).toEqual({ flagged: [], checked: 0, planWindowMs: DEFAULT_PLAN_WINDOW_MS });
+  });
+});
+
+describe('runArtifactTheaterSweep (DB wrapper)', () => {
+  it('queries only unconsumed rows and delegates to the pure sweep', async () => {
+    const is = vi.fn().mockResolvedValue({ data: [{ id: 'a1', created_at: OLD, consumed_at: null }], error: null });
+    const select = vi.fn().mockReturnValue({ is });
+    const from = vi.fn().mockReturnValue({ select });
+    const supabase = { from };
+
+    const result = await runArtifactTheaterSweep(supabase, { now: NOW });
+    expect(from).toHaveBeenCalledWith('creative_assets');
+    expect(select).toHaveBeenCalledWith('id, created_at, consumed_at');
+    expect(is).toHaveBeenCalledWith('consumed_at', null);
+    expect(result.flagged).toHaveLength(1);
+  });
+
+  it('throws on a query error rather than silently returning an empty sweep', async () => {
+    const is = vi.fn().mockResolvedValue({ data: null, error: new Error('db down') });
+    const supabase = { from: () => ({ select: () => ({ is }) }) };
+    await expect(runArtifactTheaterSweep(supabase)).rejects.toThrow('db down');
+  });
+});


### PR DESCRIPTION
## Summary
Two related FR slices of the creative engine satellite (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D), both gauge-shaped, built on the migration (#5981) and `generateAsset()` primitive (#5982), both merged. Landed on one branch/PR since they're a natural pairing (quality gate + theater guard) and stayed well under the LOC threshold together.

### FR-2 — `lib/creative/quality-gate.js`
Two-stage gate: `assessBrandGenomeConformance` (palette/typography/tone vs S17 artifacts) and `screenForFabrication` (anti-fabrication / claims-registry screen), combined via `runQualityGate`.

**Honest-gauge design, not a bug**: full pixel-level brand-token comparison and `claims_registry` text-in-image screening both need infrastructure this repo does not have yet — confirmed `claims_registry` doesn't exist (`lib/apa/standing-assessment-round.mjs:30`), no pixel-level brand comparator anywhere in `lib/`. Both stages **fail closed** with a distinct, honest reason rather than fabricate a pass (S-4 gauge doctrine: NO-DATA over fabricated success). **Currently blocks 100% of assets by design** until the two follow-on infra pieces land — explicit and tested, not hidden.

What IS real and mechanical today: stub/test-mode output rejected unconditionally (AC-1 genuinely satisfied), `brand_source_refs` presence verified.

### FR-3 — `lib/creative/theater-guard.js`
Sweep-based gauge (O3): flags any `creative_assets` row with no EXECUTED consuming channel action within its plan window — reference alone doesn't count as reach (AC-1). An actively-consumed asset is never flagged regardless of age (AC-2).

**Schema-independent of child C's `distribution_channel_config` rebuild** (flagged as an open dependency question to the coordinator, signal `93b91185`) — this sweep reads only `creative_assets.consumed_at`, the abstraction boundary the FR-1 migration deliberately added; it never queries channel tables directly, so it can't be broken by C landing a different shape. Chosen for this slot specifically because it's independent.

Plan-window/cadence were left unpinned at PLAN time (PRD open item) — `DEFAULT_PLAN_WINDOW_MS` is an explicitly-documented 24h placeholder, not a fabricated ratified value.

## Test plan
- [x] `npx vitest run lib/creative/quality-gate.test.js lib/creative/theater-guard.test.js` — 13/13 pass
- [x] `npx eslint` — clean
- [x] Pre-commit smoke suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)