### PR TITLE
feat(SPINE-001-D): per-venture creative-brief seam (FR-1, final)

### DIFF
--- a/lib/creative/creative-brief.js
+++ b/lib/creative/creative-brief.js
@@ -1,0 +1,92 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — per-venture creative-brief seam.
+// The single entry point VP_GROWTH invokes to request a generated asset: routes the brief
+// through generateAsset() (provider-abstraction primitive), the FR-2 quality gate, and persists
+// a creative_assets row -- or fails typed, never a silent partial write.
+//
+// SCOPE NOTE: this seam does NOT auto-discover S17 brand-source artifacts or the consuming
+// channel step -- the caller (VP_GROWTH) supplies both (brandSourceRefs, and later sets
+// consumed_at via whatever channel-execution hook exists once it's built; see signal
+// 45638d20 -- that hook is genuinely separate, not-yet-specified work, not fabricated here).
+//
+// CHAIRMAN-GATED DEPENDENCY: creative_assets is chairman-gated (MERGED != LIVE until the
+// apply lands). This module fails soft with a distinct, honest error rather than a generic
+// DB exception, so callers can tell "the table isn't live yet" apart from "your write is
+// invalid" (schema-lint pragma below: same reasoning as theater-guard.js).
+
+import { generateAsset } from './generate-asset.js';
+import { runQualityGate } from './quality-gate.js';
+// TaskFailedError / ProviderNotConfiguredError are thrown by generateAsset() and documented in
+// the @throws below by name only — no import needed, they're never referenced in code here.
+
+export class CreativeAssetsTableNotLiveError extends Error {
+  constructor(cause) {
+    super('creative_assets table is not yet live (chairman-gated migration MERGED != LIVE)');
+    this.name = 'CreativeAssetsTableNotLiveError';
+    this.code = 'CREATIVE_ASSETS_TABLE_NOT_LIVE';
+    if (cause) this.cause = cause;
+  }
+}
+
+export class QualityGateRejectedError extends Error {
+  constructor(gateResult) {
+    super('Generated asset failed the FR-2 quality gate — not persisted, not usable');
+    this.name = 'QualityGateRejectedError';
+    this.code = 'QUALITY_GATE_REJECTED';
+    this.gateResult = gateResult;
+  }
+}
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{
+ *   ventureId: string,
+ *   capability: 'image'|'video',
+ *   prompt: string,
+ *   brandSourceRefs?: any[],
+ *   constraints?: object,
+ * }} brief
+ * @param {{ generateAssetFn?: typeof generateAsset, runQualityGateFn?: typeof runQualityGate }} [deps]
+ *   Injectable for testing (mirrors the fetchImpl-injection pattern in providers/gemini.js) —
+ *   FR-2's gate currently fail-closes every real/test-mode result by honest design, so tests
+ *   need a way to exercise the "gate passes" write path without fabricating working infra.
+ * @returns {Promise<{id: string, capability: string, generator: string}>}
+ * @throws {TaskFailedError|ProviderNotConfiguredError} generation failed / no configured provider
+ * @throws {QualityGateRejectedError} generation succeeded but failed the FR-2 quality gate
+ * @throws {CreativeAssetsTableNotLiveError} the chairman-gated table isn't applied yet
+ */
+export async function requestCreativeAsset(supabase, brief, deps = {}) {
+  const generateAssetFn = deps.generateAssetFn || generateAsset;
+  const runQualityGateFn = deps.runQualityGateFn || runQualityGate;
+  const { ventureId, capability, prompt, brandSourceRefs = [], constraints = {} } = brief;
+
+  const generationResult = await generateAssetFn(capability, { prompt }, constraints);
+
+  const storedAsset = { brand_source_refs: brandSourceRefs };
+  const gateResult = runQualityGateFn(generationResult, storedAsset);
+  if (!gateResult.pass) {
+    throw new QualityGateRejectedError(gateResult);
+  }
+
+  const { data, error } = await supabase
+    .from('creative_assets') // schema-lint-disable-line: chairman-gated migration (20260712_creative_assets.sql, PR #5981 merged) not yet applied to the live snapshot
+    .insert({
+      venture_id: ventureId,
+      capability,
+      generator: generationResult.provenance.generator,
+      prompt,
+      brand_source_refs: brandSourceRefs,
+      cost: generationResult.cost,
+      provenance: generationResult.provenance,
+    })
+    .select('id, capability, generator')
+    .single();
+
+  if (error) {
+    // 42P01 = undefined_table (Postgres) -- the honest, common case while the migration is
+    // merged-but-unapplied. Any other error is a real write failure, propagated as-is.
+    if (error.code === '42P01') throw new CreativeAssetsTableNotLiveError(error);
+    throw error;
+  }
+
+  return data;
+}

--- a/lib/creative/creative-brief.test.js
+++ b/lib/creative/creative-brief.test.js
@@ -1,0 +1,86 @@
+// SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D (FR-1) — creative-brief seam tests.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { requestCreativeAsset, CreativeAssetsTableNotLiveError, QualityGateRejectedError } from './creative-brief.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeSupabaseMock({ insertResult }) {
+  const single = vi.fn().mockResolvedValue(insertResult);
+  const select = vi.fn().mockReturnValue({ single });
+  const insert = vi.fn().mockReturnValue({ select });
+  const from = vi.fn().mockReturnValue({ insert });
+  return { supabase: { from }, from, insert, select, single };
+}
+
+describe('requestCreativeAsset', () => {
+  afterEach(() => { process.env = { ...ORIGINAL_ENV }; vi.restoreAllMocks(); });
+
+  it('rejects with QualityGateRejectedError and never writes when the gate fails (the real, currently-always-true case)', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.RUNWAY_API_KEY;
+    delete process.env.RUNWAYML_API_KEY;
+
+    const { supabase, from } = makeSupabaseMock({ insertResult: { data: null, error: null } });
+
+    await expect(
+      requestCreativeAsset(supabase, { ventureId: 'v1', capability: 'image', prompt: 'a hero image' })
+    ).rejects.toThrow(QualityGateRejectedError);
+
+    expect(from).not.toHaveBeenCalled(); // never persists a gate-rejected asset
+  });
+
+  it('persists via the injected gate/generate deps when the gate genuinely passes (proves the write path is correct, independent of FR-2s current fail-closed state)', async () => {
+    const generateAssetFn = vi.fn().mockResolvedValue({
+      asset: { kind: 'generated' },
+      provenance: { generator: 'gemini', testMode: false },
+      cost: 0.02,
+    });
+    const runQualityGateFn = vi.fn().mockReturnValue({ pass: true, stages: {} });
+    const { supabase, from, insert, single } = makeSupabaseMock({
+      insertResult: { data: { id: 'asset-1', capability: 'image', generator: 'gemini' }, error: null },
+    });
+
+    const result = await requestCreativeAsset(
+      supabase,
+      { ventureId: 'v1', capability: 'image', prompt: 'a hero image', brandSourceRefs: ['s17-1'] },
+      { generateAssetFn, runQualityGateFn }
+    );
+
+    expect(result).toEqual({ id: 'asset-1', capability: 'image', generator: 'gemini' });
+    expect(from).toHaveBeenCalledWith('creative_assets');
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      venture_id: 'v1', capability: 'image', generator: 'gemini', cost: 0.02,
+    }));
+    expect(single).toHaveBeenCalled();
+  });
+
+  it('throws CreativeAssetsTableNotLiveError (distinct, honest) on a 42P01 undefined_table error', async () => {
+    const generateAssetFn = vi.fn().mockResolvedValue({ asset: {}, provenance: { generator: 'gemini' }, cost: 0 });
+    const runQualityGateFn = vi.fn().mockReturnValue({ pass: true, stages: {} });
+    const { supabase } = makeSupabaseMock({
+      insertResult: { data: null, error: { code: '42P01', message: 'relation "creative_assets" does not exist' } },
+    });
+
+    await expect(
+      requestCreativeAsset(supabase, { ventureId: 'v1', capability: 'image', prompt: 'x' }, { generateAssetFn, runQualityGateFn })
+    ).rejects.toThrow(CreativeAssetsTableNotLiveError);
+  });
+
+  it('propagates a non-42P01 DB error as-is (a real write failure, not the table-not-live case)', async () => {
+    const generateAssetFn = vi.fn().mockResolvedValue({ asset: {}, provenance: { generator: 'gemini' }, cost: 0 });
+    const runQualityGateFn = vi.fn().mockReturnValue({ pass: true, stages: {} });
+    const { supabase } = makeSupabaseMock({
+      insertResult: { data: null, error: { code: '23514', message: 'check constraint violation' } },
+    });
+
+    let thrown;
+    try {
+      await requestCreativeAsset(supabase, { ventureId: 'v1', capability: 'image', prompt: 'x' }, { generateAssetFn, runQualityGateFn });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown).not.toBeInstanceOf(CreativeAssetsTableNotLiveError);
+    expect(thrown.code).toBe('23514');
+  });
+});


### PR DESCRIPTION
## Summary
Fourth and final FR-1 slice of the creative engine satellite (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D), completing D's PRD scope. Builds on migration (#5981), `generateAsset()` primitive (#5982), and quality-gate + theater-guard (#5984), all merged.

- **`lib/creative/creative-brief.js`** — the seam VP_GROWTH invokes: `requestCreativeAsset(supabase, brief)` routes through `generateAsset()` → FR-2 quality gate → `creative_assets` insert, or fails typed (never a silent partial write).

## Resolves the deferred dependency — with a real finding
The earlier-deferred `distribution_channel_config` question (signal `93b91185`) is resolved with new information (signal `45638d20`): **that table was never real** — confirmed absent from the live schema, no migration anywhere creates it. My own PRD's FR-1 INTERFACES line named a table that doesn't exist (a genuine PLAN-time assumption gap). The actual live table is `venture_distribution_channels` — enrollment-only (`venture_id`/`channel_id`/`budget_usd CHECK=0`), not a channel-action-executed log.

This seam builds only the **write side** (D's own responsibility, independent of the consumer table's exact shape). Whatever sets `creative_assets.consumed_at` when a channel action actually executes is flagged as genuinely separate, not-yet-specified work — not fabricated here.

## Honest note: this seam currently cannot successfully persist anything
Since FR-2's quality gate fail-closes every result by design (no `claims_registry`, no pixel comparator yet — see #5984), `requestCreativeAsset` currently always rejects with `QualityGateRejectedError`. **This is correct wiring, not a bug** — nothing enters `creative_assets` without genuinely passing the gate. Tests use dependency injection (mirrors the `fetchImpl` pattern in `providers/gemini.js`) to exercise the gate-pass write path independently, proving the write logic itself is correct and ready for the moment FR-2's infra lands (no code change needed here at that point).

## Test plan
- [x] `npx vitest run lib/creative/` — 26/26 pass across all 4 modules (full regression, not just the new file)
- [x] `npx eslint` — clean
- [x] `SCHEMA_LINT_BASE=origin/main schema-reference-lint --diff` — 0 violations (pragma applied inline)
- [x] Pre-commit smoke suite

## D's PRD scope status
FR-1 (generation service + provider routing + brief seam), FR-2 (quality gate, honestly scaffolded), FR-3 (theater guard) all delivered. This closes out Child D's EXEC arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)