### PR TITLE
feat(SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H): kill-gate to exit-execution wiring

### DIFF
--- a/lib/eva/lifecycle/exit-capability-harvest.js
+++ b/lib/eva/lifecycle/exit-capability-harvest.js
@@ -1,0 +1,48 @@
+/**
+ * Capability-harvest interface stub — SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H FR-3.
+ *
+ * Stable interface for depositing a harvested-capability record at venture exit
+ * certification, targeting sibling Child E's venture-scoped `venture_capability_ledger`
+ * table (in PLAN_PRD as of this SD's build, not yet landed — coordinated via /signal
+ * ddab108e, not blocked on). This is deliberately an interface/stub, not a new table
+ * (TR-2): once Child E ships the real table, only WRITE_TARGET below needs updating.
+ *
+ * Does NOT write to the existing sd_capabilities table (lib/capabilities/) — that is
+ * a different, already-shipped SD-scoped ledger, not the venture-scoped one this
+ * harvest step targets (RISK sub-agent, row a08f9f05).
+ */
+
+/** Flip to 'venture_capability_ledger' once Child E ships the real table. */
+export const WRITE_TARGET = null;
+
+export class CapabilityHarvestNotReadyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CapabilityHarvestNotReadyError';
+  }
+}
+
+/**
+ * @param {{ ventureId: string, capability: string, evidence: string, sourceDecisionId: string }} input
+ * @returns {{ accepted: boolean, ventureId: string, capability: string, reason?: string }}
+ */
+export function harvestCapabilityAtExit({ ventureId, capability, evidence, sourceDecisionId }) {
+  if (!ventureId || !capability || !evidence || !sourceDecisionId) {
+    throw new Error('harvestCapabilityAtExit requires ventureId, capability, evidence, and sourceDecisionId');
+  }
+
+  // Interface proven now; the real persistent writer is intentionally deferred until
+  // Child E's venture_capability_ledger lands (WRITE_TARGET above documents the seam).
+  if (!WRITE_TARGET) {
+    return {
+      accepted: false,
+      ventureId,
+      capability,
+      reason: 'venture_capability_ledger not yet landed (Child E, PLAN_PRD) — interface proven, write deferred',
+    };
+  }
+
+  throw new CapabilityHarvestNotReadyError(
+    `WRITE_TARGET is set to '${WRITE_TARGET}' but the real writer has not been implemented yet`,
+  );
+}

--- a/lib/eva/lifecycle/exit-wiring.js
+++ b/lib/eva/lifecycle/exit-wiring.js
@@ -1,0 +1,94 @@
+/**
+ * Kill-to-exit wiring — SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H FR-1/FR-5.
+ *
+ * Thin orchestration layer connecting an APPROVED thesis-kill chairman decision
+ * to the existing exit-execution engine (supabase/functions/execute-exit) — WITHOUT
+ * ever calling it. This module creates a PENDING exit-init marker only: it never
+ * approves, advances, or calls execute-exit/kill_venture itself. A chairman still
+ * manually drives the existing, unmodified execute-exit flow to actually run the
+ * exit. See docs/design/spine-system-architecture-review.md §4/§5 and the SD's
+ * corrected description for the ground-truth investigation behind this scope.
+ *
+ * SECURITY (RISK sub-agent, row a08f9f05, security domain 7/10): this module MUST
+ * NEVER construct a payload containing chairman_approval, an 'advance' action, or
+ * any call into execute-exit or kill_venture. That invariant is enforced by
+ * construction (no such calls exist in this file) and pinned by a structural test
+ * (tests/unit/exit-wiring.test.js) that greps this file for those forbidden tokens.
+ *
+ * Persistence: no new table (TR-1/TR-2) — the PENDING exit-init marker is a
+ * system_events row, mirroring thesis-kill-gate.js's own logging pattern exactly.
+ */
+
+export const EXIT_INIT_EVENT_TYPE = 'exit_init_pending';
+export const THESIS_KILL_DECISION_TYPE = 'thesis_kill_tier_b';
+
+/**
+ * Best-effort, never-throwing system_events write — mirrors thesis-kill-gate.js's
+ * logThesisKillEvent shape exactly. A logging failure must never propagate to the
+ * caller (an approval CLI command must still succeed even if this wiring fails).
+ */
+export async function createPendingExitInit({ supabase, ventureId, decisionId, rationale, logger = console }) {
+  try {
+    if (!supabase || !ventureId || !decisionId) {
+      throw new Error('createPendingExitInit requires supabase, ventureId, and decisionId');
+    }
+    const stamp = new Date().toISOString();
+    const { error } = await supabase.from('system_events').insert({
+      event_type: EXIT_INIT_EVENT_TYPE,
+      venture_id: ventureId,
+      idempotency_key: `${EXIT_INIT_EVENT_TYPE}:${ventureId}:${decisionId}`,
+      payload: { venture_id: ventureId, decision_id: decisionId, decision_type: THESIS_KILL_DECISION_TYPE, rationale: rationale ?? null },
+      details: { venture_id: ventureId, decision_id: decisionId, decision_type: THESIS_KILL_DECISION_TYPE, rationale: rationale ?? null },
+      created_at: stamp,
+    });
+    if (error) {
+      logger.warn(`[exit-wiring] system_events write failed (non-fatal): ${error.message}`);
+      return { created: false, reason: error.message };
+    }
+    logger.log(`[exit-wiring] PENDING exit-init created for venture ${ventureId} (decision ${decisionId})`);
+    return { created: true };
+  } catch (err) {
+    logger.warn(`[exit-wiring] system_events write failed (non-fatal): ${err.message}`);
+    return { created: false, reason: err.message };
+  }
+}
+
+/**
+ * Queryable status check for FR-5 (a chairman can see a kill-approved venture has
+ * an exit ready to be manually driven). Read-only; never mutates.
+ */
+export async function getPendingExitInit({ supabase, ventureId }) {
+  if (!supabase || !ventureId) {
+    throw new Error('getPendingExitInit requires supabase and ventureId');
+  }
+  const { data, error } = await supabase
+    .from('system_events')
+    .select('id, venture_id, payload, created_at')
+    .eq('event_type', EXIT_INIT_EVENT_TYPE)
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data ?? null;
+}
+
+/**
+ * Called from scripts/eva-decisions.js's approveDecision() after a successful
+ * approval write. Only acts on thesis_kill_tier_b decisions; every other
+ * decision_type is a no-op. Never throws — a wiring failure must not affect the
+ * (already-committed) approval.
+ */
+export async function onDecisionApproved({ supabase, decision, logger = console }) {
+  if (!decision || decision.decision_type !== THESIS_KILL_DECISION_TYPE) {
+    return { acted: false };
+  }
+  const result = await createPendingExitInit({
+    supabase,
+    ventureId: decision.venture_id,
+    decisionId: decision.id,
+    rationale: decision.rationale,
+    logger,
+  });
+  return { acted: true, ...result };
+}

--- a/scripts/eva-decisions.js
+++ b/scripts/eva-decisions.js
@@ -35,6 +35,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 import { shouldBlockKillApproval } from '../lib/eva/kill-override-guard.js';
+import { onDecisionApproved } from '../lib/eva/lifecycle/exit-wiring.js';
 
 // ── Argument Parsing ──────────────────────────────────────────
 
@@ -269,7 +270,7 @@ async function approveDecision(supabase, decisionId) {
   // Check current status
   const { data: existing, error: fetchErr } = await supabase
     .from('chairman_decisions')
-    .select('id, status, venture_id, lifecycle_stage, brief_data')
+    .select('id, status, venture_id, lifecycle_stage, brief_data, decision_type')
     .eq('id', decisionId)
     .single();
 
@@ -320,6 +321,17 @@ async function approveDecision(supabase, decisionId) {
   }
   console.log(`  Venture: ${existing.venture_id}`);
   console.log(`  Stage: ${existing.lifecycle_stage}\n`);
+
+  // SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H: on approval of a thesis-kill decision,
+  // create a PENDING exit-init marker only — never approves/advances execute-exit itself.
+  const wiring = await onDecisionApproved({ supabase, decision: { ...existing, rationale } });
+  if (wiring.acted) {
+    console.log(
+      wiring.created
+        ? `  ➡️  Exit-init marker created (venture ${existing.venture_id} ready for manual chairman exit execution)\n`
+        : `  ⚠️  Exit-init marker write failed (non-fatal, approval still stands): ${wiring.reason}\n`,
+    );
+  }
 }
 
 async function rejectDecision(supabase, decisionId) {

--- a/tests/unit/eva-decisions-exit-wiring.test.js
+++ b/tests/unit/eva-decisions-exit-wiring.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H — end-to-end proof that approving a
+ * thesis_kill_tier_b decision through the real CLI approval path (scripts/
+ * eva-decisions.js approveDecision) triggers the exit-init wiring, and that
+ * approving any OTHER decision_type does not.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { approveDecision } from '../../scripts/eva-decisions.js';
+
+const ORIGINAL_ARGV = [...process.argv];
+
+function setArgv(...extraFlags) {
+  process.argv = [...ORIGINAL_ARGV.slice(0, 2), ...extraFlags];
+}
+
+beforeEach(() => setArgv('--rationale', 'test rationale, long enough'));
+afterEach(() => {
+  process.argv = [...ORIGINAL_ARGV];
+  vi.restoreAllMocks();
+});
+
+function makeSupabaseStub(existingRow) {
+  const inserted = [];
+  const updated = [];
+  return {
+    inserted,
+    updated,
+    from(table) {
+      if (table === 'chairman_decisions') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: existingRow, error: null }),
+            }),
+          }),
+          update: (payload) => ({
+            eq: async () => {
+              updated.push({ table, payload });
+              return { error: null };
+            },
+          }),
+        };
+      }
+      if (table === 'system_events') {
+        return {
+          insert: async (row) => {
+            inserted.push({ table, row });
+            return { error: null };
+          },
+        };
+      }
+      throw new Error(`unexpected table in test stub: ${table}`);
+    },
+  };
+}
+
+describe('approveDecision — kill-to-exit wiring integration', () => {
+  it('approving a thesis_kill_tier_b decision creates a PENDING exit-init marker', async () => {
+    const supabase = makeSupabaseStub({
+      id: 'decision-1',
+      status: 'pending',
+      venture_id: 'venture-1',
+      lifecycle_stage: 16,
+      brief_data: {},
+      decision_type: 'thesis_kill_tier_b',
+    });
+    const exitSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await approveDecision(supabase, 'decision-1');
+
+    expect(supabase.updated).toHaveLength(1);
+    expect(supabase.updated[0].payload.status).toBe('approved');
+    expect(supabase.inserted).toHaveLength(1);
+    expect(supabase.inserted[0].table).toBe('system_events');
+    expect(supabase.inserted[0].row.event_type).toBe('exit_init_pending');
+    expect(supabase.inserted[0].row.venture_id).toBe('venture-1');
+
+    exitSpy.mockRestore();
+  });
+
+  it('approving a non-kill decision_type does NOT create an exit-init marker', async () => {
+    const supabase = makeSupabaseStub({
+      id: 'decision-2',
+      status: 'pending',
+      venture_id: 'venture-2',
+      lifecycle_stage: 22,
+      brief_data: {},
+      decision_type: 'stage_gate',
+    });
+    const exitSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await approveDecision(supabase, 'decision-2');
+
+    expect(supabase.updated).toHaveLength(1);
+    expect(supabase.inserted).toHaveLength(0);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/tests/unit/exit-capability-harvest.test.js
+++ b/tests/unit/exit-capability-harvest.test.js
@@ -1,0 +1,49 @@
+/**
+ * SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H — capability-harvest interface stub tests
+ * (PRD FR-3, TS-5). Proves the interface is callable now and correctly defers the
+ * real write until Child E's venture_capability_ledger lands, without creating a
+ * competing table (TS-6) or writing to the unrelated SD-scoped sd_capabilities store.
+ */
+import { describe, it, expect } from 'vitest';
+import { harvestCapabilityAtExit, WRITE_TARGET } from '../../lib/eva/lifecycle/exit-capability-harvest.js';
+
+describe('harvestCapabilityAtExit', () => {
+  it('accepts a well-formed payload without throwing (TS-5)', () => {
+    const result = harvestCapabilityAtExit({
+      ventureId: 'venture-1',
+      capability: 'clerk-registration-api-pattern',
+      evidence: 'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-B2',
+      sourceDecisionId: 'decision-1',
+    });
+    expect(result.ventureId).toBe('venture-1');
+    expect(result.capability).toBe('clerk-registration-api-pattern');
+  });
+
+  it('defers the real write until Child E lands (WRITE_TARGET unset) — interface proven, not faked', () => {
+    expect(WRITE_TARGET).toBeNull();
+    const result = harvestCapabilityAtExit({
+      ventureId: 'v1',
+      capability: 'c1',
+      evidence: 'e1',
+      sourceDecisionId: 'd1',
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toMatch(/venture_capability_ledger not yet landed/);
+  });
+
+  it('requires all four fields', () => {
+    expect(() => harvestCapabilityAtExit({ ventureId: 'v1' })).toThrow();
+    expect(() => harvestCapabilityAtExit({})).toThrow();
+  });
+
+  it('TS-6/RISK a08f9f05: the executable code never writes to sd_capabilities (a different, SD-scoped ledger)', async () => {
+    const rawSource = (await import('node:fs')).readFileSync(
+      new URL('../../lib/eva/lifecycle/exit-capability-harvest.js', import.meta.url),
+      'utf8',
+    );
+    // Strip comments — the file's own doc comment names sd_capabilities to explain
+    // why it's NOT the write target, which would otherwise trip a naive substring search.
+    const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(codeOnly.includes('sd_capabilities')).toBe(false);
+  });
+});

--- a/tests/unit/exit-wiring.test.js
+++ b/tests/unit/exit-wiring.test.js
@@ -1,0 +1,179 @@
+/**
+ * SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-H — kill-to-exit wiring tests.
+ * Covers PRD TS-1 (PENDING-only marker) and TS-2/TS-3 (structural proof the
+ * wiring can never bypass execute-exit's or kill_venture's chairman gates).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  createPendingExitInit,
+  getPendingExitInit,
+  onDecisionApproved,
+  EXIT_INIT_EVENT_TYPE,
+  THESIS_KILL_DECISION_TYPE,
+} from '../../lib/eva/lifecycle/exit-wiring.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function makeSupabaseStub({ insertError = null, selectData = null, selectError = null } = {}) {
+  const inserted = [];
+  return {
+    inserted,
+    from(table) {
+      return {
+        insert: async (row) => {
+          inserted.push({ table, row });
+          return { error: insertError };
+        },
+        select() {
+          return this;
+        },
+        eq() {
+          return this;
+        },
+        order() {
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        maybeSingle: async () => ({ data: selectData, error: selectError }),
+      };
+    },
+  };
+}
+
+describe('createPendingExitInit — TS-1', () => {
+  it('writes exactly one system_events row with the expected shape', async () => {
+    const supabase = makeSupabaseStub();
+    const result = await createPendingExitInit({
+      supabase,
+      ventureId: 'venture-1',
+      decisionId: 'decision-1',
+      rationale: 'test rationale',
+    });
+    expect(result.created).toBe(true);
+    expect(supabase.inserted).toHaveLength(1);
+    const { table, row } = supabase.inserted[0];
+    expect(table).toBe('system_events');
+    expect(row.event_type).toBe(EXIT_INIT_EVENT_TYPE);
+    expect(row.venture_id).toBe('venture-1');
+    expect(row.payload.decision_id).toBe('decision-1');
+    expect(row.payload.decision_type).toBe(THESIS_KILL_DECISION_TYPE);
+    expect(row.idempotency_key).toBe(`${EXIT_INIT_EVENT_TYPE}:venture-1:decision-1`);
+  });
+
+  it('never throws on a system_events write failure (fail-soft, mirrors thesis-kill-gate.js)', async () => {
+    const supabase = makeSupabaseStub({ insertError: { message: 'boom' } });
+    const result = await createPendingExitInit({ supabase, ventureId: 'v1', decisionId: 'd1' });
+    expect(result.created).toBe(false);
+    expect(result.reason).toBe('boom');
+  });
+
+  it('TESTING finding: malformed args fail SOFT (created:false), never throw/reject — a bad decision must not crash the approve CLI post-commit', async () => {
+    await expect(createPendingExitInit({ supabase: null, ventureId: 'v', decisionId: 'd' })).resolves.toEqual({
+      created: false,
+      reason: expect.stringContaining('requires supabase'),
+    });
+    await expect(createPendingExitInit({ supabase: {}, ventureId: null, decisionId: 'd' })).resolves.toEqual({
+      created: false,
+      reason: expect.stringContaining('requires supabase'),
+    });
+  });
+});
+
+describe('getPendingExitInit — FR-5 status visibility', () => {
+  it('is read-only: does not call insert/update/delete', async () => {
+    const supabase = makeSupabaseStub({ selectData: { id: '1', venture_id: 'v1', payload: {}, created_at: 'now' } });
+    const result = await getPendingExitInit({ supabase, ventureId: 'v1' });
+    expect(result.venture_id).toBe('v1');
+    expect(supabase.inserted).toHaveLength(0);
+  });
+
+  it('returns null when no exit-init marker exists', async () => {
+    const supabase = makeSupabaseStub({ selectData: null });
+    const result = await getPendingExitInit({ supabase, ventureId: 'v1' });
+    expect(result).toBeNull();
+  });
+});
+
+describe('onDecisionApproved — decision_type gating', () => {
+  it('acts only on thesis_kill_tier_b decisions', async () => {
+    const supabase = makeSupabaseStub();
+    const acted = await onDecisionApproved({
+      supabase,
+      decision: { id: 'd1', venture_id: 'v1', decision_type: THESIS_KILL_DECISION_TYPE, rationale: 'r' },
+    });
+    expect(acted.acted).toBe(true);
+    expect(supabase.inserted).toHaveLength(1);
+  });
+
+  it('is a no-op for every other decision_type', async () => {
+    const supabase = makeSupabaseStub();
+    for (const decision_type of ['stage_gate', 'product_review', undefined, null, 'thesis_kill_tier_a']) {
+      const acted = await onDecisionApproved({ supabase, decision: { id: 'd1', venture_id: 'v1', decision_type } });
+      expect(acted.acted).toBe(false);
+    }
+    expect(supabase.inserted).toHaveLength(0);
+  });
+
+  it('is a no-op when decision itself is missing', async () => {
+    const supabase = makeSupabaseStub();
+    const acted = await onDecisionApproved({ supabase, decision: null });
+    expect(acted.acted).toBe(false);
+  });
+
+  it('TESTING finding: a thesis_kill_tier_b decision with a null venture_id resolves fail-soft, never rejects (approve CLI must not crash post-commit)', async () => {
+    const supabase = makeSupabaseStub();
+    const acted = await onDecisionApproved({
+      supabase,
+      decision: { id: 'd1', venture_id: null, decision_type: THESIS_KILL_DECISION_TYPE, rationale: 'r' },
+    });
+    expect(acted.acted).toBe(true);
+    expect(acted.created).toBe(false);
+    expect(acted.reason).toMatch(/requires supabase/);
+    expect(supabase.inserted).toHaveLength(0);
+  });
+
+  it('TESTING finding: a thesis_kill_tier_b decision with a null id also resolves fail-soft', async () => {
+    const supabase = makeSupabaseStub();
+    const acted = await onDecisionApproved({
+      supabase,
+      decision: { id: null, venture_id: 'v1', decision_type: THESIS_KILL_DECISION_TYPE, rationale: 'r' },
+    });
+    expect(acted.created).toBe(false);
+    expect(supabase.inserted).toHaveLength(0);
+  });
+});
+
+describe('SECURITY — TS-2/TS-3: regression tripwires (NOT a formal proof — see caveat below)', () => {
+  // TESTING sub-agent finding (row 78786846): these are literal-substring/regex
+  // tripwires against accidental reintroduction of a bypass, not a formal proof —
+  // a determined future edit (string concatenation, an .rpc() call the table-regex
+  // below doesn't observe, a renamed action) could defeat them while still passing.
+  // The REAL invariant this SD relies on is minimalism (this file does almost
+  // nothing) plus the two downstream systems (execute-exit, kill_venture) staying
+  // independently chairman-gated at their own call sites regardless of what calls
+  // them. Treat a change to this file that touches any of the checks below as a
+  // mandatory manual security re-review, not something these tests alone clear.
+  const rawSource = readFileSync(join(__dirname, '../../lib/eva/lifecycle/exit-wiring.js'), 'utf8');
+  const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('the executable code never references execute-exit, an advance action, or a synthesized chairman_approval', () => {
+    const forbidden = ['execute-exit', 'chairman_approval', "action: 'advance'", 'kill_venture', 'advanceRound'];
+    for (const token of forbidden) {
+      expect(codeOnly.includes(token), `exit-wiring.js code must never reference "${token}"`).toBe(false);
+    }
+  });
+
+  it('makes no Supabase RPC calls at all (kill_venture is an RPC, not a .from() table — checked separately since the table-regex below cannot see it)', () => {
+    expect(codeOnly.includes('.rpc(')).toBe(false);
+  });
+
+  it('the only Supabase table touched is system_events (no new table, TR-1/TR-2)', () => {
+    const tableRefs = [...codeOnly.matchAll(/\.from\('([a-z_]+)'\)/g)].map((m) => m[1]);
+    expect(new Set(tableRefs)).toEqual(new Set(['system_events']));
+  });
+});


### PR DESCRIPTION
## Summary
- Thin orchestration/wiring layer for the operating-company spine's satellite #6 (wind-down/exit): connects an approved thesis-kill chairman decision to the existing exit-execution engine, without ever calling it.
- `lib/eva/lifecycle/exit-wiring.js` — on approval of a `thesis_kill_tier_b` decision (wired into `scripts/eva-decisions.js`'s `approveDecision`), creates a PENDING exit-init marker (a `system_events` row). Never approves, advances, or invokes `execute-exit`/`kill_venture` itself.
- `lib/eva/lifecycle/exit-capability-harvest.js` — capability-harvest interface stub (deferred real write until sibling Child E's `venture_capability_ledger` lands).

## LEAD scope correction
The architecture doc implied building venture-exit teardown machinery from scratch. Ground-truth investigation (VALIDATION row `fe1214ed`, RISK row `a08f9f05`) found kill-decision (`thesis-kill-gate.js`), kill-execution (`kill_venture` RPC, 23 ventures already killed), and exit-execution (`supabase/functions/execute-exit`, built by an unrelated completed SD) all already exist and are independently chairman-gated. The real, corrected gap was only the missing wiring between them.

## Security
Dominant risk (RISK sub-agent, security domain 7/10): this wiring could accidentally short-circuit one of the two independently-enforced chairman gates it connects. Mitigated by construction (this module never calls either downstream system) and pinned by regression tests. TESTING sub-agent (row `78786846`) caught a real fail-soft contract violation — an arg-validation guard threw outside its try/catch, risking a post-commit CLI crash on a malformed decision — fixed with regression tests, and the structural tests were reframed as regression tripwires rather than a formal security proof.

## Test plan
- [x] 26 unit tests pass (`npx vitest run tests/unit/exit-wiring.test.js tests/unit/exit-capability-harvest.test.js tests/unit/eva-decisions-exit-wiring.test.js tests/unit/eva-decisions-decided-by.test.js`)
- [x] `npx eslint` clean on all new/changed files
- [x] No new database table (system_events only)
- [x] `execute-exit`/`kill_venture` remain completely unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)