### PR TITLE
docs(QF-20260712-720): document worktree-verification-after-edit practice

### DIFF
--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 4163c8ec7ed6fc9c -->
+<!-- file_content_hash: c63173bf15a11251 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-11 4:07:57 AM
+**Generated**: 2026-07-12 6:15:19 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -640,6 +640,20 @@ git worktree remove C:/Users/rickf/Projects/_EHG/ehg/.worktrees/${SD_ID}
 | `git checkout` to different SD branch | Switches shared directory | Use worktrees |
 | Working in `C:/Users/rickf/Projects/_EHG/ehg` during parallel execution | Shared state conflicts | Use worktree path |
 | Branch switching mid-operation | Interrupts other instance | Complete or stash first |
+
+### Verify After Every Edit (When In Doubt)
+
+If there is ANY ambiguity about which working tree an Edit landed in — multi-session
+fleet, worktree-per-SD convention, a prior command that may have changed `cwd` — run
+`git status` (or `git diff --stat`) immediately after the Edit, not after a downstream
+symptom surfaces. Checking proactively is cheap; discovering a stray shared-root edit
+indirectly (e.g. via an unexpected test result loading stale worktree code) costs far
+more time to trace back.
+
+**Evidence**: SD-LEO-INFRA-FIX-SESSION-REGISTER-001 retrospective — all 3 fix files were
+initially edited at the shared root instead of the SD's worktree, caught only indirectly
+when a require-time test loaded the (still-unedited) worktree copy and produced
+unexpected results.
 
 ### Quick Reference
 
@@ -2133,6 +2147,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-07-11*
+*Generated from database: 2026-07-12*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-06T01:13:25.434Z -->
-<!-- git_commit: 1d213d23 -->
-<!-- db_snapshot_hash: 7ac3577c8642ff48 -->
-<!-- file_content_hash: 607300cae1368e0e -->
+<!-- generated_at: 2026-07-12T10:15:19.058Z -->
+<!-- git_commit: 8d2481ce -->
+<!-- db_snapshot_hash: 2dada35e85f2199f -->
+<!-- file_content_hash: cf0d65f2f582ef2a -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-06 9:13:25 PM*
+*DIGEST generated: 2026-07-12 6:15:19 AM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,18 +1,123 @@
 {
-  "generated_at": "2026-07-11T08:07:57.195Z",
-  "git_commit": "9e3557d9",
-  "db_snapshot_hash": "1443b957c10c2c85",
+  "generated_at": "2026-07-12T10:24:04.535Z",
+  "git_commit": "8744971f",
+  "db_snapshot_hash": "2dada35e85f2199f",
   "files": {
+    "CLAUDE.md": {
+      "type": "full",
+      "chars": 19368,
+      "estimated_tokens": 4842,
+      "content_hash": "66db69dd8f5a8040",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE.md"
+    },
+    "CLAUDE_CORE.md": {
+      "type": "full",
+      "chars": 91064,
+      "estimated_tokens": 22766,
+      "content_hash": "e78d984fd2a2f867",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_CORE.md"
+    },
+    "CLAUDE_LEAD.md": {
+      "type": "full",
+      "chars": 65998,
+      "estimated_tokens": 16500,
+      "content_hash": "0f5e31ff7aa6ed33",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_LEAD.md"
+    },
+    "CLAUDE_PLAN.md": {
+      "type": "full",
+      "chars": 91830,
+      "estimated_tokens": 22958,
+      "content_hash": "7d6f2da741fe89fa",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_PLAN.md"
+    },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 87631,
-      "estimated_tokens": 21908,
-      "content_hash": "363032dc192b93d4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-PAYMENT-RAIL-RETRO-001\\CLAUDE_EXEC.md"
+      "chars": 88410,
+      "estimated_tokens": 22103,
+      "content_hash": "ebb45be54134199c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_EXEC.md"
+    },
+    "CLAUDE_ADAM.md": {
+      "type": "full",
+      "chars": 56902,
+      "estimated_tokens": 14226,
+      "content_hash": "a187f739f97f3566",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_ADAM.md"
+    },
+    "CLAUDE_COORDINATOR.md": {
+      "type": "full",
+      "chars": 22134,
+      "estimated_tokens": 5534,
+      "content_hash": "2d1b68d02b11bc11",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_COORDINATOR.md"
+    },
+    "CLAUDE_SOLOMON.md": {
+      "type": "full",
+      "chars": 45828,
+      "estimated_tokens": 11457,
+      "content_hash": "985e8498471a6a7b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_SOLOMON.md"
+    },
+    "CLAUDE_DIGEST.md": {
+      "type": "digest",
+      "chars": 9611,
+      "estimated_tokens": 2403,
+      "content_hash": "92289ed46131ef6d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_DIGEST.md"
+    },
+    "CLAUDE_CORE_DIGEST.md": {
+      "type": "digest",
+      "chars": 11664,
+      "estimated_tokens": 2916,
+      "content_hash": "4cdbdae533bb1a79",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_CORE_DIGEST.md"
+    },
+    "CLAUDE_LEAD_DIGEST.md": {
+      "type": "digest",
+      "chars": 5551,
+      "estimated_tokens": 1388,
+      "content_hash": "a8cf00b7196a2099",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_LEAD_DIGEST.md"
+    },
+    "CLAUDE_PLAN_DIGEST.md": {
+      "type": "digest",
+      "chars": 8541,
+      "estimated_tokens": 2136,
+      "content_hash": "6f5ea4c29c826301",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_PLAN_DIGEST.md"
+    },
+    "CLAUDE_EXEC_DIGEST.md": {
+      "type": "digest",
+      "chars": 10964,
+      "estimated_tokens": 2741,
+      "content_hash": "357b35bc085fd7d2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_EXEC_DIGEST.md"
+    },
+    "CLAUDE_ADAM_DIGEST.md": {
+      "type": "digest",
+      "chars": 15690,
+      "estimated_tokens": 3923,
+      "content_hash": "8f92449978c51072",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_ADAM_DIGEST.md"
+    },
+    "CLAUDE_COORDINATOR_DIGEST.md": {
+      "type": "digest",
+      "chars": 6076,
+      "estimated_tokens": 1519,
+      "content_hash": "f0aee63948b57dde",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_COORDINATOR_DIGEST.md"
+    },
+    "CLAUDE_SOLOMON_DIGEST.md": {
+      "type": "digest",
+      "chars": 4705,
+      "estimated_tokens": 1177,
+      "content_hash": "4dd30ae70daa0b8e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260712-720\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "9951f23b5620b3ad",
+    "global": "5318357fe22c8a98",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -107,7 +212,7 @@
       "300": "87e4aa2892c00fd2",
       "301": "cec5f28b18b461a4",
       "303": "9ccb23f56cde7b93",
-      "305": "e1a835721684425e",
+      "305": "5628b194309b66b7",
       "306": "0c43eb6c7b16f82d",
       "307": "4a5e9b832ae9c14e",
       "308": "a02867048d9feb1f",
@@ -284,7 +389,8 @@
       "616": "cf03793e285951bf",
       "620": "3fd2f83a068a8381",
       "621": "5d93172c5c9c2138",
-      "622": "94a8df85a96ad041"
+      "622": "94a8df85a96ad041",
+      "624": "598aeea1e7124569"
     },
     "meta": {
       "94": {
@@ -1641,6 +1747,11 @@
         "section_type": "worktree_freshness_precheck",
         "target_file": "CLAUDE_EXEC.md",
         "title": "Worktree Freshness Pre-Check (Before Declaring Code Missing)"
+      },
+      "624": {
+        "section_type": "adam_role_contract",
+        "target_file": null,
+        "title": "PLAN CHECK — chairman status-report format (chairman-directed 2026-07-11)"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds a "Verify After Every Edit (When In Doubt)" subsection to CLAUDE_EXEC.md (section 305 in leo_protocol_sections), codifying a retro action item from SD-LEO-INFRA-FIX-SESSION-REGISTER-001: run `git status` immediately after any Edit when there's doubt about which working tree it landed in.

## Test plan
- [x] `node scripts/generate-claude-md-from-db.js` run against the updated DB section; only CLAUDE_EXEC.md/CLAUDE_EXEC_DIGEST.md content diffs kept (unrelated pre-existing drift in other CLAUDE*.md files reverted, out of scope for this QF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)