### PR TITLE
fix(QF-20260712-023): test-estate .test.mjs reachability guard — dead verifiers fail at PR time

### DIFF
--- a/tests/test-estate-mjs-allowlist.json
+++ b/tests/test-estate-mjs-allowlist.json
@@ -1,0 +1,31 @@
+{
+  "_doc": "QF-20260712-023 (retro dc41e083 / SPINE-001-B action item): every tracked *.test.mjs file must be reachable by a named runner lane, or it is a DEAD VERIFIER — green in the editor, never executed. Vitest's unit project only includes tests/unit/org/**/*.test.mjs (node:test files are not vitest-compatible), so each .test.mjs needs an entry here naming its lane. tests/unit/test-estate-mjs-reachability.test.js enforces this: a NEW .test.mjs with no lane fails the unit suite at PR time. Do NOT add to legacy_unaudited — give new files a real runner.",
+  "lanes": {
+    "tests/unit/session-tick-heartbeat.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)",
+    "tests/unit/session-tick-release-on-exit.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)",
+    "tests/unit/session-tick-spawn-observe.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)"
+  },
+  "legacy_unaudited": {
+    "_doc": "DEBT REGISTER (pre-QF-20260712-023 files with no verified CI runner at seeding time — audit each: wire a lane and move it to lanes{}, or archive the file). Adding NEW entries here defeats the check's purpose.",
+    "files": [
+      "__tests__/scripts/b1-tri-tier-validator.test.mjs",
+      "__tests__/scripts/b2-testability-heuristic.test.mjs",
+      "tests/sd-start-dependency-gate.test.mjs",
+      "tests/unit/adam-doc-drift-review.test.mjs",
+      "tests/unit/adam-github-assessment.test.mjs",
+      "tests/unit/adam-sourcing-state-probe.test.mjs",
+      "tests/unit/adam-startup-check.test.mjs",
+      "tests/unit/calculate-sd-progress.test.mjs",
+      "tests/unit/coordinator-startup-check.test.mjs",
+      "tests/unit/db-size-monitor.test.mjs",
+      "tests/unit/pocock/weekly-deepening-report.test.mjs",
+      "tests/unit/protocol-lint/engine.test.mjs",
+      "tests/unit/sd-key-generator-ci-bypass.test.mjs",
+      "tests/unit/sd-key-generator-coverage.test.mjs",
+      "tests/unit/session-tick-patch-failure-telemetry.test.mjs",
+      "tests/unit/v-sd-next-candidates-fixture-exclusion.test.mjs",
+      "tests/unit/vision/rung-progress-rollup.test.mjs",
+      "tests/unit/worktree-stale-base-guard.test.mjs"
+    ]
+  }
+}

--- a/tests/unit/test-estate-mjs-reachability.test.js
+++ b/tests/unit/test-estate-mjs-reachability.test.js
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * QF-20260712-023 — test-estate reachability guard (retro dc41e083, SPINE-001-B).
+ *
+ * DEFECT CLASS: a *.test.mjs file lands green in the editor but is run by NO
+ * lane — vitest's unit include only covers tests/unit/org/ .test.mjs (the rest
+ * are node:test-based and vitest-incompatible), so a new .test.mjs silently
+ * becomes a dead verifier (witnessed: the SPINE-001-B org suites, and the 18
+ * legacy files in the allowlist's debt register).
+ *
+ * This test lives in the ALWAYS-REACHABLE .test.js unit lane and fails the PR
+ * when a tracked .test.mjs is neither (a) inside a vitest include, nor
+ * (b) registered in tests/test-estate-mjs-allowlist.json with a named lane,
+ * nor (c) already in the seeded legacy debt register (no new entries).
+ */
+
+const VITEST_MJS_INCLUDE_PREFIX = 'tests/unit/org/'; // mirrors vitest.config.js unit include
+
+function trackedMjsTests() {
+  const out = execFileSync('git', ['ls-files', '*.test.mjs'], { encoding: 'utf8' });
+  return out.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+describe('test-estate .test.mjs reachability (QF-20260712-023)', () => {
+  const allowlist = JSON.parse(
+    readFileSync(join(process.cwd(), 'tests/test-estate-mjs-allowlist.json'), 'utf8')
+  );
+  const laned = new Set(Object.keys(allowlist.lanes));
+  const legacy = new Set(allowlist.legacy_unaudited.files);
+
+  it('every tracked .test.mjs file has a runner lane (or is pre-existing registered debt)', () => {
+    const dead = trackedMjsTests().filter(
+      (f) => !f.startsWith(VITEST_MJS_INCLUDE_PREFIX) && !laned.has(f) && !legacy.has(f)
+    );
+    expect(
+      dead,
+      `Dead verifier(s): ${dead.join(', ')} — a .test.mjs outside vitest's unit include ` +
+        `(${VITEST_MJS_INCLUDE_PREFIX}) runs NOWHERE by default. Wire a lane (npm script + ` +
+        `workflow, or a vitest include) and register it in tests/test-estate-mjs-allowlist.json ` +
+        `lanes{}. Do not add to legacy_unaudited.`
+    ).toEqual([]);
+  });
+
+  it('allowlist entries reference files that still exist (no stale debt rows)', () => {
+    const tracked = new Set(trackedMjsTests());
+    const stale = [...laned, ...legacy].filter((f) => !tracked.has(f));
+    expect(
+      stale,
+      `Allowlist entries for deleted files: ${stale.join(', ')} — remove them from ` +
+        `tests/test-estate-mjs-allowlist.json so the register stays honest.`
+    ).toEqual([]);
+  });
+
+  it('the vitest-included org prefix still exists in the config (guard against silent include removal)', () => {
+    const config = readFileSync(join(process.cwd(), 'vitest.config.js'), 'utf8');
+    expect(config).toContain('**/tests/unit/org/**/*.test.mjs');
+  });
+});


### PR DESCRIPTION
## Summary
Systemic recurrence-blocker from retro dc41e083 (SPINE-001-B): any tracked `.test.mjs` outside vitest's narrow org include silently runs **nowhere** (node:test files are vitest-incompatible) — a dead verifier. This adds an always-reachable unit test asserting every `.test.mjs` has a named runner lane, an allowlist that doubles as the debt register (18 legacy files with no verified CI runner, called out for audit), and a guard against silent include removal.

**Teeth verified**: a rogue tracked `.test.mjs` fails with an actionable message; 3/3 green otherwise.

## Test plan
- `npx vitest run tests/unit/test-estate-mjs-reachability.test.js` — 3/3
- Negative probe: add a tracked rogue `.test.mjs` → guard fails naming it

🤖 Generated with [Claude Code](https://claude.com/claude-code)