### PR TITLE
fix(SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001): stall classifier held-state awareness

### DIFF
--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -19,6 +19,10 @@ const STALL_DIGEST_PREFIX = 'Adam PM stall:';
 // QF-20260710-818: dismissing a stall digest (status moved off 'pending') must not immediately
 // respawn a fresh escalation email on the same still-stale nodes the very next tick.
 const DISMISS_COOLDOWN_MS = 15 * 60_000;
+// SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-2): an SD claimed and moving within this
+// window is being actively driven, not stalled. Sized the same order of magnitude as
+// DISMISS_COOLDOWN_MS above.
+const PROGRESS_WINDOW_MS = 30 * 60_000;
 
 /**
  * QF-20260703-860: find an already-open stall digest (if any) so a subsequent tick can refresh
@@ -117,6 +121,43 @@ async function isCorrelationTerminal(supabase, correlationId) {
 }
 
 /**
+ * SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-2): a sourced_sd board node backed by an SD
+ * that is CLAIMED and moving (fresh claim or a fresh phase handoff within PROGRESS_WINDOW_MS) is
+ * being actively driven, not stalled -- live specimen: a claimed SD escalated at
+ * ticks_since_movement=8 (the minimum stale threshold) while it was actively driving to
+ * LEAD-FINAL. Checks BOTH claim_history and sd_phase_handoffs (either signal is sufficient) since
+ * a long EXEC step can move the SD without a fresh re-claim. Fail-soft (a query error is NOT
+ * terminal -- never silently swallow a possibly-real stall).
+ */
+async function isSdActivelyProgressing(supabase, sdKey) {
+  try {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, claiming_session_id, metadata')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (!sd || !sd.claiming_session_id) return false;
+
+    const claimHistory = Array.isArray(sd.metadata?.claim_history) ? sd.metadata.claim_history : [];
+    const lastClaim = claimHistory[claimHistory.length - 1];
+    if (lastClaim?.claimed_at && Date.now() - new Date(lastClaim.claimed_at).getTime() < PROGRESS_WINDOW_MS) {
+      return true;
+    }
+
+    const { data: handoffs } = await supabase
+      .from('sd_phase_handoffs')
+      .select('created_at')
+      .eq('sd_id', sd.id)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    const lastHandoff = handoffs?.[0];
+    return !!lastHandoff && Date.now() - new Date(lastHandoff.created_at).getTime() < PROGRESS_WINDOW_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * QF-20260710-818: find the most recently dismissed (non-pending) stall digest, if it covers
  * at least one of the currently-stalled node_ids and was dismissed within the cooldown window.
  * A chairman dismissal is a deliberate "not now" on those specific nodes — re-escalating them
@@ -199,19 +240,28 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
       console.log(`[Adam PM] Suppressing stall alert for intended-hold SD ${node.source_ref} (node ${node.id})`);
       continue;
     }
+    // SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-2): a claimed-and-progressing SD is
+    // being actively driven -- never a stall, regardless of ticks_since_movement.
+    if (node.source_kind === 'sourced_sd' && node.source_ref && await isSdActivelyProgressing(supabase, node.source_ref)) {
+      console.log(`[Adam PM] Suppressing stall alert for actively-claimed-and-progressing SD ${node.source_ref} (node ${node.id})`);
+      continue;
+    }
     // QF-20260704-319: same self-heal for an advisory_thread node whose correlation already
     // got a reply or a ratified decision — the board row is stale, not a genuine stall.
     if (node.source_kind === 'advisory_thread' && node.source_ref && await isCorrelationTerminal(supabase, node.source_ref)) {
       await setStatus(supabase, node.id, 'done').catch(() => {});
       continue;
     }
-    // QF-20260710-818: a manual node routed to another actor (Solomon consult, sourced fleet
-    // work, an external gate) is an intended hold, not a genuine stall. Unlike sourced_sd/
-    // advisory_thread, a manual node has no linked row to re-check -- board status='blocked' is
-    // the existing zero-migration signal for "don't escalate", set explicitly by whoever routed
-    // the work elsewhere (never set by default rehydrate, so this is opt-in, not silent).
-    if (node.source_kind === 'manual' && node.status === 'blocked') {
-      console.log(`[Adam PM] Suppressing stall alert for held manual node ${node.id}`);
+    // SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-1): board status='blocked' is ALREADY an
+    // explicit, board-visible held-by-design disposition (set directly, or rolled up from a
+    // genuinely blocked child via task-ledger.js rollupParentStatus) -- respect it for every
+    // source_kind, not just 'manual'. Generalizes the former manual-only QF-20260710-818 branch;
+    // live specimens showed sourced_sd/advisory_thread nodes with status='blocked' (a Solomon-gated
+    // design-queue child, a snoozed belt QF, a Fable-window gate) escalating with no suppression
+    // path at all. Runs AFTER the terminal/held-metadata/progressing checks above so a node that
+    // can self-heal (finished SD, resolved correlation) still closes instead of merely suppressing.
+    if (node.status === 'blocked') {
+      console.log(`[Adam PM] Suppressing stall alert for held node ${node.id} (status=blocked, source_kind=${node.source_kind || 'unknown'})`);
       continue;
     }
     stalls.push({ ...node, ticks });
@@ -232,25 +282,56 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
     };
 
     const existing = await findPendingStallDigest(supabase);
-    let decisionId;
-    let escalated;
+    // Per-node escalated outcome, defaulted below per-branch — lets a partial-dismissal delta
+    // (FR-3) report the previously-dismissed members as escalated=false alongside the genuinely
+    // new members' real outcome, instead of a single flag applied uniformly to every node.
+    const escalatedById = new Map();
     if (existing) {
       const briefData = { ...(existing.brief_data || {}), title, context, recorded_via: 'record-pending-decision' };
       await supabase.from('chairman_decisions')
         .update({ summary: title, brief_data: briefData, updated_at: new Date().toISOString() })
         .eq('id', existing.id);
-      decisionId = existing.id;
       // escalateChairmanDecision dedups on brief_data.escalation_email_sent_at, already stamped
       // by the digest's original insert — this call is therefore a no-op on every refresh tick,
       // which is exactly how "at most one escalation email" holds across many stale ticks.
-      const res = await escalateChairmanDecision(supabase, decisionId);
-      escalated = res.escalated === true;
+      const res = await escalateChairmanDecision(supabase, existing.id);
+      for (const n of stalls) escalatedById.set(n.id, res.escalated === true);
     } else {
       const dismissed = await findRecentlyDismissedStallDigest(supabase, context.node_ids);
-      if (dismissed) {
+      const dismissedIds = new Set(dismissed?.brief_data?.context?.node_ids || []);
+      // SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-3): a dismissal covers whichever
+      // specific node_ids it named, not "the current stall set" as a whole -- so membership
+      // drift (a node dropping off, or a genuinely new node joining) must not swing the outcome
+      // from "fully suppressed" to "fully re-escalated". Only nodes NOT covered by the
+      // dismissal are candidates to surface.
+      const newStalls = dismissed ? stalls.filter((n) => !dismissedIds.has(n.id)) : stalls;
+
+      if (dismissed && newStalls.length === 0) {
+        // Fully covered by a recent dismissal — the dismissed set stays dismissed for the
+        // cooldown window regardless of exact set-identity match (fixes the 9-min-refile shape:
+        // an identical or subset re-check must reuse the dismissal, never re-file).
         console.log(`[Adam PM] Suppressing re-escalation — digest ${dismissed.id} covering these nodes was dismissed within the last ${Math.round(DISMISS_COOLDOWN_MS / 60_000)}m`);
-        decisionId = dismissed.id;
-        escalated = false;
+        for (const n of stalls) escalatedById.set(n.id, false);
+      } else if (dismissed) {
+        // Partial overlap: only the genuinely NEW nodes (not covered by the dismissal) surface,
+        // as a delta digest — the previously-dismissed members do not re-file alongside them,
+        // and are reported as escalated=false rather than dropped from the tick log.
+        const deltaTitle = newStalls.length === 1
+          ? `Adam PM stall: ${newStalls[0].title || newStalls[0].id}`
+          : `Adam PM stall: ${newStalls.length} threads stalled`;
+        const deltaContext = {
+          node_ids: newStalls.map((n) => n.id),
+          ticks_since_movement: Object.fromEntries(newStalls.map((n) => [n.id, n.ticks])),
+        };
+        const res = await recordPendingDecision(supabase, {
+          title: deltaTitle,
+          decisionType: 'session_question',
+          context: deltaContext,
+          blocking: true,
+          raisedBy: 'adam',
+        });
+        const newlyEscalated = res.escalated === true;
+        for (const n of stalls) escalatedById.set(n.id, newStalls.includes(n) && newlyEscalated);
       } else {
         const res = await recordPendingDecision(supabase, {
           title,
@@ -259,11 +340,10 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
           blocking: true,
           raisedBy: 'adam',
         });
-        decisionId = res.id;
-        escalated = res.escalated === true;
+        for (const n of stalls) escalatedById.set(n.id, res.escalated === true);
       }
     }
-    for (const n of stalls) alerted.push({ id: n.id, title: n.title || n.id, escalated });
+    for (const n of stalls) alerted.push({ id: n.id, title: n.title || n.id, escalated: escalatedById.get(n.id) === true });
   }
   return { snapshot, alerted };
 }

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -393,6 +393,205 @@ describe('QF-20260710-818: dismissed stall digest cooldown (no immediate respawn
   });
 });
 
+describe('SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-1): board status=blocked is an intended hold for every source_kind', () => {
+  const sb = {};
+
+  it('TS-1: a sourced_sd node with status=blocked and no held metadata never escalates', async () => {
+    const parents = [{
+      id: 'sd5', title: 'Solomon-gated design queue item', updated_at: 'fixed', status: 'blocked',
+      source_kind: 'sourced_sd', source_ref: 'SD-GATED-001', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { sd5: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('TS-2: an advisory_thread node with status=blocked never escalates and is not closed', async () => {
+    const parents = [{
+      id: 'at1', title: 'Belt QF held', updated_at: 'fixed', status: 'blocked',
+      source_kind: 'advisory_thread', source_ref: 'some-correlation', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { at1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const stubSb = sbWithCorrelationState({ hasReply: false, hasRatifiedDecision: false });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('a node with no source_kind at all (bare status=blocked) is still suppressed', async () => {
+    const parents = [{ id: 'x1', title: 'Fable-gated item', updated_at: 'fixed', status: 'blocked', inFlightNextStep: false }];
+    const prevSnapshot = { x1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('regression: the retired literal suppression string is gone from the source', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(new URL('../../../lib/adam/stall-alert.js', import.meta.url), 'utf8');
+    expect(src).not.toContain('Suppressing stall alert for held manual node');
+  });
+});
+
+describe('SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-2): claimed-and-progressing SD never stalls', () => {
+  function sbWithSdProgress({ claimingSessionId, claimHistory = [], handoffs = [] } = {}) {
+    return {
+      from(table) {
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({
+                  data: { id: 'sd-uuid-1', claiming_session_id: claimingSessionId, metadata: { claim_history: claimHistory } },
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'sd_phase_handoffs') {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: async () => ({ data: handoffs }),
+                }),
+              }),
+            }),
+          };
+        }
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+      },
+    };
+  }
+
+  const prevSnapshot = { sdp1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+  const parents = [{
+    id: 'sdp1', title: 'Dispatch-auth phase-2 build', updated_at: 'fixed',
+    source_kind: 'sourced_sd', source_ref: 'SD-PROGRESSING-001', inFlightNextStep: false,
+  }];
+
+  it('TS-4: a fresh claim_history entry suppresses the stall even at the exact stale threshold', async () => {
+    const stubSb = sbWithSdProgress({
+      claimingSessionId: 'sess-live',
+      claimHistory: [{ claimed_at: new Date().toISOString(), session_id: 'sess-live' }],
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('TS-5: a fresh sd_phase_handoffs row (no recent claim_history) also suppresses the stall', async () => {
+    const stubSb = sbWithSdProgress({
+      claimingSessionId: 'sess-live',
+      claimHistory: [{ claimed_at: new Date(Date.now() - 60 * 60_000).toISOString(), session_id: 'sess-live' }],
+      handoffs: [{ created_at: new Date().toISOString() }],
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('an SD with no active claim is unaffected and still escalates', async () => {
+    const stubSb = sbWithSdProgress({ claimingSessionId: null });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'sdp1', title: 'Dispatch-auth phase-2 build', escalated: true }]);
+  });
+
+  it('a claim/handoff outside the progress window does not suppress — still escalates', async () => {
+    const stubSb = sbWithSdProgress({
+      claimingSessionId: 'sess-stale',
+      claimHistory: [{ claimed_at: new Date(Date.now() - 60 * 60_000).toISOString(), session_id: 'sess-stale' }],
+      handoffs: [{ created_at: new Date(Date.now() - 60 * 60_000).toISOString() }],
+    });
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'sdp1', title: 'Dispatch-auth phase-2 build', escalated: true }]);
+  });
+
+  it('TS-6: a DB error inside the progress check degrades to "not progressing" — never silently swallows a real stall', async () => {
+    const throwingSb = {
+      from(table) {
+        if (table === 'strategic_directives_v2') {
+          return { select: () => ({ eq: () => ({ maybeSingle: async () => { throw new Error('boom'); } }) }) };
+        }
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+      },
+    };
+    const { alerted } = await checkAndAlertStalls(throwingSb, parents, prevSnapshot);
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'sdp1', title: 'Dispatch-auth phase-2 build', escalated: true }]);
+  });
+});
+
+describe('SD-LEO-INFRA-STALL-CLASSIFIER-HELD-STATE-001 (FR-3): dismissal cooloff survives set-membership drift', () => {
+  function sbWithDismissedDigest(dismissedDigest) {
+    return {
+      from(table) {
+        if (table !== 'chairman_decisions') return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+        return {
+          select: () => ({
+            eq: () => ({ like: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null }) }) }) }) }),
+            neq: () => ({ like: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: dismissedDigest }) }) }) }) }),
+          }),
+        };
+      },
+    };
+  }
+
+  it('TS-7 (reproduces 12fe548f -> b4c46dc9 verbatim): an identical re-check of a dismissed 6-node set files nothing new', async () => {
+    const nodeIds = ['e945b024', 'b9e14859', 'ec603e38', '3e170e0e', '142cd353', '1dba6cf3'];
+    const stubSb = sbWithDismissedDigest({
+      id: 'dec-12fe548f', brief_data: { context: { node_ids: nodeIds } }, updated_at: new Date().toISOString(),
+    });
+    const parents = nodeIds.map((id) => ({ id, title: `Thread ${id}`, updated_at: 'fixed', inFlightNextStep: false }));
+    const prevSnapshot = Object.fromEntries(nodeIds.map((id) => [id, { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 }]));
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toHaveLength(6);
+    expect(alerted.every((a) => a.escalated === false)).toBe(true);
+  });
+
+  it('TS-8: dismissed set [A,B,C] plus new node D inside cooloff -- only D surfaces as a delta', async () => {
+    const stubSb = sbWithDismissedDigest({
+      id: 'dec-old', brief_data: { context: { node_ids: ['A', 'B', 'C'] } }, updated_at: new Date().toISOString(),
+    });
+    const parents = ['A', 'B', 'C', 'D'].map((id) => ({ id, title: `Thread ${id}`, updated_at: 'fixed', inFlightNextStep: false }));
+    const prevSnapshot = Object.fromEntries(['A', 'B', 'C', 'D'].map((id) => [id, { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 }]));
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    const call = recordPendingDecision.mock.calls[0][1];
+    expect(call.context.node_ids).toEqual(['D']);
+
+    const byId = Object.fromEntries(alerted.map((a) => [a.id, a.escalated]));
+    expect(byId).toEqual({ A: false, B: false, C: false, D: true });
+  });
+
+  it('TS-9: no prior dismissal at all -- full escalation is unchanged from today', async () => {
+    const stubSb = sbWithDismissedDigest(null);
+    const parents = [{ id: 'p9', title: 'Stuck thread', updated_at: 'fixed', inFlightNextStep: false }];
+    const prevSnapshot = { p9: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'p9', title: 'Stuck thread', escalated: true }]);
+  });
+});
+
 describe('QF-20260703-860: supersede the open stall digest instead of inserting per tick', () => {
   it('3 ticks against a persistent stale thread: exactly ONE recordPendingDecision insert, later ticks refresh the same row via update+re-attempted escalation (which dedupes)', async () => {
     const stubSb = makeStallDigestSupabase();


### PR DESCRIPTION
## Summary
- FR-1: generalizes the manual-only "board status='blocked' is an intended hold" suppression in `checkAndAlertStalls()` to every `source_kind` (sourced_sd, advisory_thread, manual) — a held-by-design node no longer needs a bespoke per-kind lookup to be respected.
- FR-2: adds `isSdActivelyProgressing()` — a sourced_sd node backed by a claimed SD with recent `claim_history`/`sd_phase_handoffs` movement (30min window) never classifies as a stall, fail-soft on DB error.
- FR-3: rewrites the dismissal cooloff so a dismissed node set stays dismissed regardless of membership drift; only genuinely new nodes surface as a delta digest instead of the whole set re-filing.
- Retires the hard-coded `[Adam PM] Suppressing stall alert for held manual node` stop-gap in favor of disposition-driven suppression.

Grounded in three verbatim rejected `chairman_decisions` rows from the overnight incident window (2026-07-10 23:47 → 2026-07-11 00:42 ET): `12fe548f`/`b4c46dc9` (identical 6-node held-by-design set, refiled 82s after dismissal) and `6bdd8d6c` (a claimed SD actively driving to LEAD-FINAL, flagged at the minimum stale-tick threshold).

## Test plan
- [x] 12 new unit tests (TS-1/TS-2 for FR-1, TS-4/TS-5/TS-6 for FR-2, TS-7/TS-8/TS-9 for FR-3) — `tests/unit/adam/stall-alert.test.js`: 35/35 passing
- [x] Full `tests/unit/adam/` suite: 313/313 passing (all 23 pre-existing tests unmodified and green)
- [x] TESTING sub-agent independently verified source + tests (not tautological), verdict PASS 95% confidence
- [x] Regression guard confirms the retired suppression string is fully removed from source

🤖 Generated with [Claude Code](https://claude.com/claude-code)