### PR TITLE
fix(QF-20260712-805): scope GATE2 sub-validator 2A to UI-layer children only

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -58,12 +58,48 @@ async function getGate2Result(context) {
 }
 
 /**
+ * QF-20260712-805: 2A:uiComponentsImplemented is registered OUTSIDE the aggregate scoring and
+ * hard-blocks architecture-decomposed children that never had UI components to begin with (API/
+ * data/test-layer children) -- live specimen: SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-A2 burned
+ * both retries before shipping via a verified --force. A non-UI child's metadata.architecture_layer
+ * is set explicitly by the decomposition bridge (lib/eva/lifecycle-sd-bridge.js, keys data/api/ui/
+ * tests) -- only skip when it's explicitly a non-UI layer, never on an unset/legacy SD (that would
+ * silently exempt every pre-decomposition SD and mask a real gap).
+ * @param {object} context - Validator context
+ * @returns {Promise<{skip:boolean, layer?:string}>}
+ */
+async function getNonUiLayerSkip(context) {
+  const { sd_id, supabase } = context;
+  try {
+    const { resolveSdInputOrNull } = await import('../../../../../lib/sd-id-resolver.js');
+    const { sd: sdData } = await resolveSdInputOrNull(sd_id, supabase);
+    const layer = sdData?.metadata?.architecture_layer;
+    if (layer && layer !== 'ui') return { skip: true, layer };
+  } catch { /* fail-open to the existing (pre-QF) hard-check behavior */ }
+  return { skip: false };
+}
+
+/**
  * Register Gate 2 validators
  * @param {import('../core.js').ValidatorRegistry} registry
  */
 export function registerGate2Validators(registry) {
   // Section A: UI Components Implementation
   registry.register('uiComponentsImplemented', async (context) => {
+    // QF-20260712-805: API/data/test-layer architecture-decomposed children never had UI
+    // components -- skip with a logged reason instead of hard-blocking; aggregate scoring unchanged.
+    const layerSkip = await getNonUiLayerSkip(context);
+    if (layerSkip.skip) {
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: [`2A skipped: architecture_layer='${layerSkip.layer}' (non-UI child)`],
+        details: { skipped: true, architecture_layer: layerSkip.layer }
+      };
+    }
+
     const result = await getGate2Result(context);
 
     // SD-LEO-FIX-FIX-GATE-SUB-001: Check sub-validator exemption before score extraction

--- a/tests/unit/implementation-fidelity/gate2-section-a-non-ui-skip.test.js
+++ b/tests/unit/implementation-fidelity/gate2-section-a-non-ui-skip.test.js
@@ -1,0 +1,111 @@
+/**
+ * QF-20260712-805 — GATE2 sub-validator 2A:uiComponentsImplemented hard-blocked
+ * API-only/data/test-layer architecture-decomposed children even when the aggregate
+ * GATE2 score was high (specimen: SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-A2 burned
+ * both retries before shipping via a verified --force).
+ *
+ * Fix: scope 2A to children whose metadata.architecture_layer indicates a UI layer.
+ * Non-UI layers (api/data/tests) skip with a logged reason instead of hard-blocking;
+ * an UNSET layer (legacy/pre-decomposition SDs) must NOT be silently exempted — only
+ * an EXPLICIT non-UI layer skips.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ sd: null, throwOnResolve: false }));
+
+vi.mock('../../../scripts/lib/sd-id-resolver.js', () => ({
+  resolveSdInputOrNull: async () => {
+    if (h.throwOnResolve) throw new Error('simulated resolver failure');
+    return { sd: h.sd };
+  },
+}));
+
+const gate2Result = vi.hoisted(() => ({ value: null }));
+vi.mock('../../../scripts/modules/implementation-fidelity-validation.js', () => ({
+  validateGate2ExecToPlan: async () => gate2Result.value,
+}));
+
+const { registerGate2Validators } = await import(
+  '../../../scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js'
+);
+const { ValidatorRegistry } = await import(
+  '../../../scripts/modules/handoff/validation/validator-registry/core.js'
+);
+
+function makeRegistry() {
+  const registry = new ValidatorRegistry();
+  registerGate2Validators(registry);
+  return registry;
+}
+
+function makeContext(sdId = 'SD-X') {
+  return { sd_id: sdId, supabase: {}, gateContext: {} };
+}
+
+describe('QF-20260712-805: 2A:uiComponentsImplemented non-UI-layer skip', () => {
+  beforeEach(() => {
+    h.sd = null;
+    h.throwOnResolve = false;
+    // A low aggregate Section A score -- if the skip did NOT fire, this would hard-fail.
+    gate2Result.value = { sections: { A: { score: 0, issues: ['no UI found'] } } };
+  });
+
+  it('skips (passes) an api-layer child without touching the aggregate result', async () => {
+    h.sd = { metadata: { architecture_layer: 'api' } };
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.warnings[0]).toMatch(/2A skipped/i);
+    expect(result.details.architecture_layer).toBe('api');
+  });
+
+  it('skips a data-layer child', async () => {
+    h.sd = { metadata: { architecture_layer: 'data' } };
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(true);
+    expect(result.details.architecture_layer).toBe('data');
+  });
+
+  it('skips a tests-layer child', async () => {
+    h.sd = { metadata: { architecture_layer: 'tests' } };
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(true);
+    expect(result.details.architecture_layer).toBe('tests');
+  });
+
+  it('does NOT skip a ui-layer child -- falls through to the normal aggregate check (and fails on a genuine gap)', async () => {
+    h.sd = { metadata: { architecture_layer: 'ui' } };
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(false); // aggregate Section A score is 0 -- a real UI gap must still block
+    expect(result.score).toBe(0);
+  });
+
+  it('does NOT skip when architecture_layer is unset (legacy/pre-decomposition SD) -- never silently exempts', async () => {
+    h.sd = { metadata: {} };
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('fails open to the pre-QF hard-check behavior if the resolver throws', async () => {
+    h.throwOnResolve = true;
+    const registry = makeRegistry();
+    const result = await registry.get('uiComponentsImplemented')(makeContext());
+    expect(result.passed).toBe(false); // resolver failure never silently passes a real gap
+    expect(result.score).toBe(0);
+  });
+
+  it('userWorkflowsImplemented and userActionsSupported inherit the same skip (they delegate to 2A)', async () => {
+    h.sd = { metadata: { architecture_layer: 'api' } };
+    const registry = makeRegistry();
+    const workflows = await registry.get('userWorkflowsImplemented')(makeContext());
+    const actions = await registry.get('userActionsSupported')(makeContext());
+    expect(workflows.passed).toBe(true);
+    expect(actions.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `2A:uiComponentsImplemented` (registered outside the aggregate GATE2 scoring) hard-blocked API/data/test-layer architecture-decomposed children even when the aggregate score was high (specimen: SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-A2 burned both retries before shipping via a verified `--force`).
- Fix: non-UI children (`metadata.architecture_layer` explicitly `api`/`data`/`tests`) now skip 2A with a logged reason instead of a hard block. An **unset** `architecture_layer` (legacy/pre-decomposition SDs) still runs the full check — nothing is silently exempted.
- Aggregate scoring is unchanged.

## Test plan
- [x] New unit test file (7 tests): api/data/tests layers skip; ui-layer and unset-layer children still run the real check and fail on a genuine gap; resolver failure fails open (never silently passes); userWorkflowsImplemented/userActionsSupported inherit the skip via delegation
- [x] Full `tests/unit/implementation-fidelity/` regression suite (80 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)