### PR TITLE
docs(SD-LEO-FEAT-PROVISION-VENTURE-EMAIL-001): venture email provisioning reference

### DIFF
--- a/docs/reference/schema/engineer/tables/venture_email_identities.md
+++ b/docs/reference/schema/engineer/tables/venture_email_identities.md
@@ -1,0 +1,74 @@
+# venture_email_identities Table
+
+**Application**: EHG_Engineer - LEO Protocol Management Dashboard - CONSOLIDATED DB
+**Database**: dedlbzhpgkmetvhbkyzq
+**Repository**: EHG_Engineer (this repository)
+**Purpose**: Strategic Directive management, PRD tracking, retrospectives, LEO Protocol configuration
+**Generated**: 2026-07-12T14:03:26.234Z
+**Rows**: 0
+**RLS**: Enabled (1 policy)
+
+⚠️ **This is a REFERENCE document** - Query database directly for validation
+
+⚠️ **CRITICAL**: This schema is for **EHG_Engineer** database. Implementations go in EHG_Engineer (this repository)
+
+---
+
+## Columns (12 total)
+
+| Column | Type | Nullable | Default | Description |
+|--------|------|----------|---------|-------------|
+| id | `uuid` | **NO** | `gen_random_uuid()` | - |
+| venture_id | `uuid` | YES | - | - |
+| domain | `text` | **NO** | - | - |
+| cf_zone_id | `text` | YES | - | - |
+| resend_domain_id | `text` | YES | - | - |
+| scoped_key_id | `text` | YES | - | - |
+| routes | `jsonb` | **NO** | `'{}'::jsonb` | - |
+| provision_state | `text` | **NO** | `'pending'::text` | - |
+| last_error | `text` | YES | - | - |
+| lock_version | `integer(32)` | **NO** | `0` | - |
+| created_at | `timestamp with time zone` | **NO** | `now()` | - |
+| updated_at | `timestamp with time zone` | **NO** | `now()` | - |
+
+## Constraints
+
+### Primary Key
+- `venture_email_identities_pkey`: PRIMARY KEY (id)
+
+### Unique Constraints
+- `venture_email_identities_domain_key`: UNIQUE (domain)
+
+### Check Constraints
+- `venture_email_identities_provision_state_check`: CHECK ((provision_state = ANY (ARRAY['pending'::text, 'registered'::text, 'domain_enrolled'::text, 'dns_written'::text, 'verified'::text, 'key_scoped'::text, 'routes_wired'::text, 'provisioned'::text, 'plan_mode'::text, 'failed'::text])))
+
+## Indexes
+
+- `idx_vei_active_state`
+  ```sql
+  CREATE INDEX idx_vei_active_state ON public.venture_email_identities USING btree (provision_state, updated_at) WHERE (provision_state <> ALL (ARRAY['provisioned'::text, 'plan_mode'::text, 'failed'::text]))
+  ```
+- `idx_vei_venture`
+  ```sql
+  CREATE INDEX idx_vei_venture ON public.venture_email_identities USING btree (venture_id) WHERE (venture_id IS NOT NULL)
+  ```
+- `venture_email_identities_domain_key`
+  ```sql
+  CREATE UNIQUE INDEX venture_email_identities_domain_key ON public.venture_email_identities USING btree (domain)
+  ```
+- `venture_email_identities_pkey`
+  ```sql
+  CREATE UNIQUE INDEX venture_email_identities_pkey ON public.venture_email_identities USING btree (id)
+  ```
+
+## RLS Policies
+
+### 1. service_role_all_venture_email_identities (ALL)
+
+- **Roles**: {service_role}
+- **Using**: `true`
+- **With Check**: `true`
+
+---
+
+[← Back to Schema Overview](../database-schema-overview.md)

--- a/docs/reference/venture-email-provisioning.md
+++ b/docs/reference/venture-email-provisioning.md
@@ -1,0 +1,61 @@
+# Venture Email Provisioning
+
+- **Category**: Reference
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: SD-LEO-FEAT-PROVISION-VENTURE-EMAIL-001
+- **Last Updated**: 2026-07-12
+- **Tags**: venture-email, resend, cloudflare, provisioning, secrets
+
+One-call per-venture email identity: `provisionVentureEmail(venture)` in
+`lib/venture-email/provision-venture-email.js`. Registers the domain (CF Registrar),
+enrolls it in Resend, writes DKIM/SPF/DMARC DNS records, verify-polls, mints a
+per-domain scoped sending key, and wires `hello@`/`support@` inbound routes to the
+central inbox — as a **resumable step machine** over
+`venture_email_identities.provision_state` (optimistic CAS on `lock_version`).
+
+## States
+
+`pending → registered → domain_enrolled → dns_written → verified → key_scoped →
+routes_wired → provisioned` (LAST-COMPLETED-step semantics — re-invocation runs the
+next incomplete step). Terminal branches: `plan_mode` (credentials absent; manual
+steps emitted in `result.planSteps`), `failed` (human needed; `last_error` set).
+Re-invoking a `provisioned` domain is a **no-op** (never re-mints a key).
+
+## Credentials (all optional — absence = plan-mode, never a throw)
+
+| Env var | Leg |
+|---------|-----|
+| CF Registrar tokens (see `lib/venture-acquisition/registrar-adapter.js`) | domain registration |
+| Cloudflare DNS tokens (see `lib/venture-acquisition/dns-wiring.js`) | zone + records |
+| `RESEND_API_KEY` | enrollment, verify, key mint |
+| `CF_EMAIL_ROUTING_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `VENTURE_EMAIL_CENTRAL_INBOX` | inbound routes |
+
+## Secret handling (pointer convention — IMPORTANT)
+
+`venture_channel_secrets` has **no value column**. The provisioner persists only a
+`secret_ref` pointer row (`channel_type = email:<domain>`, one row per
+venture+domain, via `lib/marketing/channel-secrets.js` `storeSecret()`). The minted
+Resend key VALUE is revealed exactly once and returned in **`result.revealedKey`**
+(`{secretRef, keyId, keyValue}`) — the caller/operator must inject it into the
+`VENTURE_CHANNEL_SECRET_STORE` keyring under `secretRef`. It never enters the DB,
+the mapping row, or journals. If lost before injection, revoke by the journaled
+key ID (`scoped_key_minted` evidence row) and re-mint.
+
+## Observability
+
+Every external call — success or failure — journals a `portfolio_evidence` row
+(`evidence_kind='venture_email_provision_call'`, `provenance='real_event'`); a run
+is reconstructable from journal rows alone. Capacity warning journals at 8+ Resend
+domains (Pro cap 10; SES re-evaluation at venture 11+). AUP witness:
+`guardSequenceSend({captureRecordId})` refuses sequence-sends without a
+capture-record reference (typed `AupWitnessError`).
+
+## Operational notes
+
+- DMARC ships `p=none`; graduation to `p=quarantine` is a scheduled follow-up after
+  send-reputation warmup.
+- A freshly created central-inbox routing destination is unverified until the inbox
+  owner confirms Cloudflare's email — surfaced as a MANUAL plan step.
+- Tests: `tests/unit/venture-email/provision-venture-email.test.mjs` (vitest unit
+  lane; registered in `tests/test-estate-mjs-allowlist.json`).


### PR DESCRIPTION
## Summary
- Operator reference for the one-call venture email provisioner (states, credentials, secret_ref pointer convention, revealedKey keyring injection, observability)
- Generated schema table doc for venture_email_identities

## Test plan
- Docs only; no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)