### PR TITLE
feat(SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001): FR-1/FR-2 lane delivery contract module

### DIFF
--- a/lib/coordination/lane-contract.cjs
+++ b/lib/coordination/lane-contract.cjs
@@ -1,0 +1,124 @@
+/**
+ * session_coordination lane delivery contract — SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001.
+ *
+ * ONE module for SEND validation and canonical DRAIN reads, closing the architecture gap
+ * behind nine first-hand defect instances (untyped rows silently skipped, dual body
+ * locations splitting readers, courtesy-ACKs blocking canonical answers, re-target
+ * provenance loss, mechanical rows rendered as authored messages).
+ *
+ * FR-1 — validateOnSend: typed payload.kind enforcement staged OFF/OBSERVE/ENFORCE,
+ * reusing lib/claim/gates/dispatch-authorization.cjs's proven two-flag-ladder shape
+ * VERBATIM. A universally-required validator would break the live fleet today (payload-less
+ * rows are deliberate in places; ~34 raw insert sites bypass the existing partial choke
+ * point at lib/coordinator/dispatch.cjs:587) -- OFF by default, ENFORCE only after an
+ * observe-window confirms near-zero unexpected violations on the named seams.
+ *
+ * FR-2 — readCanonicalBody: dual-read (payload.body primary, body column fallback).
+ * Three divergent read orders exist live today (payload-first, column-first,
+ * subject-first); one reader never checks the body column at all (the coordinator_request
+ * body-drop, instance 4). Canonical = payload.body; fallback preserves legacy rows written
+ * before this SD with no historical backfill required.
+ */
+'use strict';
+
+const BASE_FLAG = 'session_coordination_lane_contract_born_denied';
+const ENFORCE_FLAG = 'session_coordination_lane_contract_enforce';
+
+/**
+ * Resolve the SEND-validation mode from the two-flag ladder. Any evaluator fault resolves
+ * to 'off' -- a flag-infrastructure error must never change delivery behavior on live
+ * fleet coordination.
+ * @param {{isEnabledFn?: (flagKey: string) => Promise<boolean>}} [opts] test seam
+ * @returns {Promise<'off'|'observe'|'enforce'>}
+ */
+async function resolveLaneContractMode({ isEnabledFn } = {}) {
+  try {
+    let isEnabled = isEnabledFn;
+    if (typeof isEnabled !== 'function') {
+      ({ isEnabled } = await import('../feature-flags/evaluator.js'));
+    }
+    if (!(await isEnabled(BASE_FLAG))) return 'off';
+    return (await isEnabled(ENFORCE_FLAG)) ? 'enforce' : 'observe';
+  } catch {
+    return 'off'; // fail-soft, matches dispatch-authorization.cjs precedent
+  }
+}
+
+/**
+ * Validate a session_coordination row against the SEND contract (payload.kind required).
+ * off     -> {valid:true, mode:'off'} with zero checks
+ * observe -> valid row: {valid:true, mode}; invalid row: {valid:true, would_deny:true, reason}
+ * enforce -> valid row: {valid:true, mode}; invalid row: {valid:false, reason}
+ *
+ * @param {object} row - the row about to be inserted (must have .payload)
+ * @param {{mode: 'off'|'observe'|'enforce'}} opts - caller-resolved mode (see resolveLaneContractMode)
+ * @returns {{valid: boolean, mode: string, would_deny?: boolean, reason?: string}}
+ */
+function validateOnSend(row, { mode = 'off' } = {}) {
+  if (mode !== 'observe' && mode !== 'enforce') {
+    return { valid: true, mode: 'off' };
+  }
+  const kind = row && row.payload && typeof row.payload === 'object' ? row.payload.kind : undefined;
+  if (kind !== undefined && kind !== null && kind !== '') {
+    return { valid: true, mode };
+  }
+  const reason = 'lane_contract_untyped_payload_kind';
+  return mode === 'observe'
+    ? { valid: true, mode, would_deny: true, reason }
+    : { valid: false, mode, reason };
+}
+
+/** One consistent WOULD-DENY line for the observe-window evidence trail. */
+function formatWouldDenyLine(row, verdict) {
+  const id = (row && row.id) || '(pre-insert)';
+  return `LANE_CONTRACT_WOULD_DENY row=${id} reason=${verdict.reason} (observe mode — send proceeds; SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001)`;
+}
+
+const WOULD_DENY_EVENT_TYPE = 'LANE_CONTRACT_WOULD_DENY';
+
+/**
+ * Durable observe-window evidence, fail-soft (a write failure never blocks or alters the
+ * send that observe mode already guarantees never blocks). Mirrors
+ * dispatch-authorization.cjs's recordWouldDenyEvidence exactly.
+ * @param {object} supabase - service-role client
+ * @param {object} row
+ * @param {{reason?: string}} verdict
+ * @returns {Promise<void>}
+ */
+async function recordWouldDenyEvidence(supabase, row, verdict) {
+  try {
+    await supabase.from('system_events').insert({
+      event_type: WOULD_DENY_EVENT_TYPE,
+      payload: { reason: verdict.reason, row_subject: row && row.subject, target_session: row && row.target_session },
+    });
+  } catch {
+    // fail-soft by design
+  }
+}
+
+/**
+ * Canonical body read (FR-2). payload.body is the canonical location; the body column is
+ * a fallback for legacy rows written before this SD (no backfill). Returns '' (never
+ * null/undefined) when neither location has content, so callers doing string operations
+ * never need a null-check.
+ * @param {{ body?: string, payload?: { body?: string } }} row
+ * @returns {string}
+ */
+function readCanonicalBody(row) {
+  if (!row) return '';
+  const payloadBody = row.payload && typeof row.payload === 'object' ? row.payload.body : undefined;
+  if (typeof payloadBody === 'string' && payloadBody.length > 0) return payloadBody;
+  if (typeof row.body === 'string') return row.body;
+  return '';
+}
+
+module.exports = {
+  resolveLaneContractMode,
+  validateOnSend,
+  formatWouldDenyLine,
+  recordWouldDenyEvidence,
+  readCanonicalBody,
+  WOULD_DENY_EVENT_TYPE,
+  BASE_FLAG,
+  ENFORCE_FLAG,
+};

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -52,6 +52,9 @@ const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.c
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
+// SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-2: canonical body read (payload.body
+// primary, body-column fallback) — closes instance 4, the coordinator_request body-drop below.
+const { readCanonicalBody } = require('../lib/coordination/lane-contract.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const { REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies } = require('../lib/coordinator/reply-class.cjs');
 // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: reuse the canonical Adam-session resolver for the unattended
@@ -688,7 +691,12 @@ async function windowSweep(supabase, sessionId, { windowMs = DEFAULT_SWEEP_WINDO
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
     const readStamp = r.read_at ? 'read' : 'UNREAD';
     const ackStamp = r.acknowledged_at ? 'acked' : 'UNACKED';
-    const text = (r.payload && r.payload.body) || r.subject || '(empty)';
+    // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-2 (instance 4): this print path
+    // previously checked payload.body only, never the body COLUMN -- a coordinator_request row
+    // with an 858-char body in the column printed as if empty. readCanonicalBody() dual-reads
+    // (payload.body primary, body-column fallback) before falling back to subject/'(empty)'.
+    const canonicalBody = readCanonicalBody(r);
+    const text = canonicalBody || r.subject || '(empty)';
     console.log(`  • [${kind}] (${ageMin}m) ${readStamp}/${ackStamp} id=${r.id} ${text}`);
   }
 }

--- a/tests/unit/adam-inbox-window-sweep.test.js
+++ b/tests/unit/adam-inbox-window-sweep.test.js
@@ -54,6 +54,26 @@ describe('Adam inbox window sweep (QF-20260703-946)', () => {
     expect(out).toContain('1 unacked');
   });
 
+  // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-2 (instance 4, coordinator-verified
+  // 2026-07-12): a coordinator_request row with an 858-char body in the COLUMN (not payload.body)
+  // previously printed as if empty -- this line never checked the body column at all. Migrated
+  // to readCanonicalBody(); this pins the fallback path against a real body-only-in-column row.
+  it('instance 4: a coordinator_request row with body ONLY in the body column no longer prints as empty', async () => {
+    const bodyText = 'x'.repeat(858);
+    const rows = [{
+      id: 'row-2', message_type: 'INFO', subject: 'coordinator_request subject',
+      payload: { kind: 'coordinator_request' }, // no payload.body — the instance-4 shape
+      body: bodyText, // real content lives in the column instead
+      created_at: new Date().toISOString(),
+      read_at: null,
+      acknowledged_at: null,
+    }];
+    await windowSweep(makeSupabase(rows), 'adam-sid', { windowMs: 3_600_000 });
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain(bodyText);
+    expect(out).not.toContain('(empty)');
+  });
+
   it('quiet: empty window prints nothing', async () => {
     await windowSweep(makeSupabase([]), 'adam-sid', { quiet: true });
     expect(logSpy).not.toHaveBeenCalled();

--- a/tests/unit/coordination/lane-contract.test.js
+++ b/tests/unit/coordination/lane-contract.test.js
@@ -1,0 +1,152 @@
+/**
+ * SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-1/FR-2 — session_coordination lane
+ * delivery contract: SEND validation (staged off/observe/enforce) + canonical body read.
+ *
+ * No live DB calls — isEnabledFn / supabase are injected stubs throughout.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  resolveLaneContractMode,
+  validateOnSend,
+  formatWouldDenyLine,
+  recordWouldDenyEvidence,
+  readCanonicalBody,
+  WOULD_DENY_EVENT_TYPE,
+  BASE_FLAG,
+  ENFORCE_FLAG,
+} = require('../../../lib/coordination/lane-contract.cjs');
+
+describe('resolveLaneContractMode — staged off/observe/enforce ladder (FR-1)', () => {
+  it('resolves off when the base flag is disabled', async () => {
+    const isEnabledFn = vi.fn().mockResolvedValue(false);
+    const mode = await resolveLaneContractMode({ isEnabledFn });
+    expect(mode).toBe('off');
+    expect(isEnabledFn).toHaveBeenCalledWith(BASE_FLAG);
+  });
+
+  it('resolves observe when base is on but enforce is off', async () => {
+    const isEnabledFn = vi.fn((flag) => Promise.resolve(flag === BASE_FLAG));
+    const mode = await resolveLaneContractMode({ isEnabledFn });
+    expect(mode).toBe('observe');
+  });
+
+  it('resolves enforce when both flags are on', async () => {
+    const isEnabledFn = vi.fn().mockResolvedValue(true);
+    const mode = await resolveLaneContractMode({ isEnabledFn });
+    expect(mode).toBe('enforce');
+    expect(isEnabledFn).toHaveBeenCalledWith(ENFORCE_FLAG);
+  });
+
+  it('fail-soft: resolves off when the evaluator throws (a flag-infrastructure error must never change delivery behavior)', async () => {
+    const isEnabledFn = vi.fn().mockRejectedValue(new Error('flag service down'));
+    const mode = await resolveLaneContractMode({ isEnabledFn });
+    expect(mode).toBe('off');
+  });
+});
+
+describe('validateOnSend — off/observe/enforce verdicts (FR-1)', () => {
+  const typedRow = { payload: { kind: 'adam_advisory' } };
+  const untypedRow = { payload: {} };
+  const noPayloadRow = {};
+
+  it('off mode: always valid, zero checks performed (even on an untyped row)', () => {
+    expect(validateOnSend(untypedRow, { mode: 'off' })).toEqual({ valid: true, mode: 'off' });
+    expect(validateOnSend(undefined, { mode: 'off' })).toEqual({ valid: true, mode: 'off' });
+  });
+
+  it('observe mode: a typed row is valid with no would-deny', () => {
+    expect(validateOnSend(typedRow, { mode: 'observe' })).toEqual({ valid: true, mode: 'observe' });
+  });
+
+  it('observe mode: an untyped row is NOT blocked (valid:true) but flags would_deny', () => {
+    const v = validateOnSend(untypedRow, { mode: 'observe' });
+    expect(v.valid).toBe(true);
+    expect(v.would_deny).toBe(true);
+    expect(v.reason).toBe('lane_contract_untyped_payload_kind');
+  });
+
+  it('observe mode: a row with no payload at all is also flagged (untyped) without blocking', () => {
+    const v = validateOnSend(noPayloadRow, { mode: 'observe' });
+    expect(v.valid).toBe(true);
+    expect(v.would_deny).toBe(true);
+  });
+
+  it('enforce mode: a typed row is valid', () => {
+    expect(validateOnSend(typedRow, { mode: 'enforce' })).toEqual({ valid: true, mode: 'enforce' });
+  });
+
+  it('enforce mode: an untyped row is REJECTED (the SAME row that observe mode let through)', () => {
+    const v = validateOnSend(untypedRow, { mode: 'enforce' });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('lane_contract_untyped_payload_kind');
+  });
+
+  it('an empty-string kind is treated as untyped in both observe and enforce', () => {
+    const row = { payload: { kind: '' } };
+    expect(validateOnSend(row, { mode: 'observe' }).would_deny).toBe(true);
+    expect(validateOnSend(row, { mode: 'enforce' }).valid).toBe(false);
+  });
+});
+
+describe('formatWouldDenyLine', () => {
+  it('names the row id and the reason', () => {
+    const line = formatWouldDenyLine({ id: 'row-1' }, { reason: 'lane_contract_untyped_payload_kind' });
+    expect(line).toContain('row-1');
+    expect(line).toContain('lane_contract_untyped_payload_kind');
+    expect(line).toContain('observe mode');
+  });
+
+  it('falls back to a pre-insert marker when the row has no id yet', () => {
+    const line = formatWouldDenyLine({}, { reason: 'x' });
+    expect(line).toContain('(pre-insert)');
+  });
+});
+
+describe('recordWouldDenyEvidence — fail-soft durable observe-window evidence', () => {
+  it('inserts a system_events row with the reason and row subject/target', async () => {
+    const inserted = [];
+    const supabase = { from: (table) => ({ insert: (row) => { inserted.push({ table, row }); return Promise.resolve({ error: null }); } }) };
+    await recordWouldDenyEvidence(supabase, { subject: 'subj', target_session: 't1' }, { reason: 'lane_contract_untyped_payload_kind' });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].table).toBe('system_events');
+    expect(inserted[0].row.event_type).toBe(WOULD_DENY_EVENT_TYPE);
+    expect(inserted[0].row.payload).toEqual({ reason: 'lane_contract_untyped_payload_kind', row_subject: 'subj', target_session: 't1' });
+  });
+
+  it('never throws even if the insert fails (fail-soft — never blocks or alters the send)', async () => {
+    const supabase = { from: () => ({ insert: () => Promise.reject(new Error('db down')) }) };
+    await expect(recordWouldDenyEvidence(supabase, { subject: 'x' }, { reason: 'y' })).resolves.toBeUndefined();
+  });
+});
+
+describe('readCanonicalBody — dual-read, payload.body primary / body-column fallback (FR-2)', () => {
+  it('returns the correct text for a row with body only in payload.body', () => {
+    expect(readCanonicalBody({ payload: { body: 'from payload' }, body: null })).toBe('from payload');
+  });
+
+  it('returns the correct text for a legacy row with body only in the body column (fallback path)', () => {
+    expect(readCanonicalBody({ payload: {}, body: 'legacy column body' })).toBe('legacy column body');
+  });
+
+  it('prefers payload.body over the body column when both are present', () => {
+    expect(readCanonicalBody({ payload: { body: 'canonical' }, body: 'legacy' })).toBe('canonical');
+  });
+
+  it('falls back to the body column when payload.body is an empty string', () => {
+    expect(readCanonicalBody({ payload: { body: '' }, body: 'legacy fallback' })).toBe('legacy fallback');
+  });
+
+  it('returns "" (never null/undefined) when neither location has content', () => {
+    expect(readCanonicalBody({ payload: {}, body: null })).toBe('');
+    expect(readCanonicalBody({ payload: null, body: undefined })).toBe('');
+    expect(readCanonicalBody(null)).toBe('');
+    expect(readCanonicalBody(undefined)).toBe('');
+  });
+
+  it('ignores a non-string body column value', () => {
+    expect(readCanonicalBody({ payload: {}, body: 12345 })).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- New `lib/coordination/lane-contract.cjs` — ONE module for the `session_coordination` lane's SEND validation and canonical DRAIN reads.
- **FR-1** `validateOnSend`: typed `payload.kind` enforcement staged OFF/OBSERVE/ENFORCE, reusing `lib/claim/gates/dispatch-authorization.cjs`'s proven two-flag-ladder shape verbatim. Ships OFF by default — RISK found a universally-required validator would break the live fleet today (payload-less rows are deliberate in places; ~34 raw insert sites bypass the existing partial choke point).
- **FR-2** `readCanonicalBody`: dual-read (`payload.body` primary, `body` column fallback). Migrated `adam-advisory.cjs`'s window-sweep print path (instance 4, coordinator-verified 2026-07-12) — a `coordinator_request` row with an 858-char body in the column previously printed as if empty because that read site never checked the body column at all.

Part of SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 (FR-1/FR-2 of 6, following #6016 which shipped FR-3). Shipping as a separate PR per this SD's own architecture-grounding note that the ~1150 LOC total across all 6 FRs exceeds the single-PR LOC ceiling.

## Test plan
- [x] `tests/unit/coordination/lane-contract.test.js` — 21 new tests: off/observe/enforce mode resolution + verdicts, would-deny evidence recording, canonical-body dual-read + fallback
- [x] `tests/unit/adam-inbox-window-sweep.test.js` — new instance-4 regression pin (body-only-in-column row no longer prints as empty), existing tests unaffected
- [x] Full regression sweep green

🤖 Generated with [Claude Code](https://claude.com/claude-code)