### PR TITLE
feat(SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001): default-on registrar-first domain check at naming decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Table of Contents
 
 - [2026-07-12](#2026-07-12)
+  - [Features](#features)
   - [Infrastructure](#infrastructure)
   - [Bugfix](#bugfix)
 - [2026-07-11](#2026-07-11)
@@ -86,6 +87,13 @@
   - [EHG (Venture App)](#ehg-venture-app)
 
 ## 2026-07-12
+
+### Features
+- **Domain-availability check for venture naming, now ON by default** - PR #6019 (SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001)
+  - **What shipped**: closes an opt-in trap where the Stage 11 naming decision's domain-availability check was OFF by default behind an env flag nobody set, which let a taken `.com` (`getalttext.com`) reach the Cloudflare purchase screen uncaught (chairman-reported incident). `resolveDomainAvailabilityChecker()` (`lib/venture-domains/stage-integration.js`) now runs by default with a registrar-first, RDAP-fallback resolution ladder: the Cloudflare Registrar API when credentials exist (authoritative, priced), a zero-credential RDAP check otherwise, and explicit `DOMAIN_AVAILABILITY_MODE=off` as the only opt-out. The naming decision now always carries a `domainAvailability` record (`domain`, `availability`, `price_usd`, `checked_at`, `method`) that never fabricates "available" — RDAP's `unknown` verdict maps to the honest `unverified` label.
+  - **PRD-vs-reachability correction**: the PRD named `stage-10-naming-brand.js` as the file to wire, but that file is dead/unreachable code — `stage-10.js`'s real `analysisStep` import resolves to `stage-10-customer-brand.js`. The actual naming-decision producer, verified by tracing the live `identity_brand_name` artifact writer, is `lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js`; wired there instead of the file literally named in the SD.
+  - **Live-credential safety check**: this repo's shared `.env` genuinely holds Cloudflare Registrar credentials, so an always-on-by-default checker risked firing live, paid API calls during automated test runs. Verified and fixed on two fronts: the `--project db` integration tests (`analysis-steps.test.js`, `stage-chain.test.js`), which load real `.env`, now explicitly inject `availabilityChecker: null` at the Stage 11 call site; and a genuine pre-existing `.env`-leak into the supposedly-hermetic "unit" vitest project (some transitive import of the stage-11 module self-loads `.env` as a side effect) is neutralized by explicitly clearing both Cloudflare env vars in the unit test's `beforeEach`.
+  - **Verification**: 16 new/rewritten unit tests across 2 files (all pass), TESTING sub-agent PASS 95% (backend-only SD, no dev server/UI — verification is the automated test suite). Also caught and logged (not fixed in-scope) a pre-existing, unrelated harness bug: `stage-chain.test.js`'s LLM mock never matches stage 11's real system prompt ("Naming & Visual Identity Engine" vs. the mock's stale "Go-To-Market Strategy Engine" check), cascading to 8/34 failures in that file — confirmed identical on `origin/main`, unrelated to this change.
 
 ### Infrastructure
 - **Creative engine satellite: provider-abstraction generation primitive, honest-by-design quality gate, artifact-theater guard** - PRs #5981, #5982, #5984, #5991 (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-D)

--- a/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
@@ -17,9 +17,9 @@ import { writeArtifact } from '../../artifact-persistence-service.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 import { fetchSripSummary } from '../../eva-orchestrator-helpers.js';
 import {
-  resolveAvailabilityChecker, resolveAvailabilityWeight, assessCandidateAvailability,
+  resolveAvailabilityWeight, assessCandidateAvailability,
   availabilityScore, addAvailabilityCriterion, domainVerdictFor, domainDetailFor,
-  tldStatusesFor, buildDomainShortlist,
+  tldStatusesFor, buildDomainShortlist, resolveDomainAvailabilityChecker, domainAvailabilityRecordFor,
 } from '../../../venture-domains/stage-integration.js';
 
 // Duplicated from stage-11.js to avoid circular dependency
@@ -366,11 +366,15 @@ Output ONLY valid JSON.`;
 
   if (!logoSpec) llmFallbackCount++;
 
-  // --- Domain availability seam (SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001) ---
-  // Default OFF: with no injected checker and DOMAIN_AVAILABILITY_MODE!=='live' this block
-  // is a no-op and every downstream shape is byte-identical to pre-SD behavior
-  // (availabilityChecks stay 'pending', no Availability criterion, no shortlist).
-  const domainChecker = availabilityChecker === undefined ? resolveAvailabilityChecker() : availabilityChecker;
+  // --- Domain availability seam (SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001, extended by
+  // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001) ---
+  // ON BY DEFAULT: resolveDomainAvailabilityChecker() checks the registrar API first (real
+  // price + authoritative availability) when credentials exist, falls back to the zero-
+  // credential RDAP checker otherwise, and only returns null on an explicit
+  // DOMAIN_AVAILABILITY_MODE='off' opt-out or when neither rung can run. Closes the chairman-
+  // reported incident where a taken .com reached the CF purchase screen uncaught because the
+  // prior opt-in flag was never set.
+  const domainChecker = availabilityChecker === undefined ? resolveDomainAvailabilityChecker() : availabilityChecker;
   let domainAssessments = null;
   if (domainChecker) {
     try {
@@ -413,6 +417,11 @@ Output ONLY valid JSON.`;
       social: AVAILABILITY_STATUSES.includes(ac.social) ? ac.social : 'pending',
     },
     ...(domainAssessments ? { domainDetail: domainDetailFor(domainAssessments.get(selectedName)) } : {}),
+    // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001 (FR-2/FR-3): the exact naming-input record
+    // -- {domain, availability, price_usd, checked_at, method} -- present even when the seam
+    // is off (domainAssessments null), reporting the honest 'unverified' floor rather than
+    // silently omitting the field.
+    domainAvailability: domainAvailabilityRecordFor(domainAssessments?.get(selectedName)),
   };
 
   if (llmFallbackCount > 0) {

--- a/lib/venture-domains/stage-integration.js
+++ b/lib/venture-domains/stage-integration.js
@@ -14,7 +14,8 @@
  * @module lib/venture-domains/stage-integration
  */
 
-import { checkCandidateAvailability, createRateBudget } from './availability.js';
+import { checkCandidateAvailability, createRateBudget, toLabel } from './availability.js';
+import { createRegistrarAdapter, normalizeQuote } from '../venture-acquisition/registrar-adapter.js';
 
 export const DEFAULT_AVAILABILITY_WEIGHT = 15;
 
@@ -32,6 +33,61 @@ export function resolveAvailabilityChecker(env = process.env) {
 export function resolveAvailabilityWeight(env = process.env) {
   const w = Number(env.DOMAIN_AVAILABILITY_WEIGHT);
   return Number.isFinite(w) && w > 0 && w < 100 ? w : DEFAULT_AVAILABILITY_WEIGHT;
+}
+
+/**
+ * SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001 (FR-1): registrar-first, RDAP-fallback
+ * checker, ON BY DEFAULT (closes the opt-in trap that let a taken .com reach the
+ * Cloudflare purchase screen uncaught — the chairman-reported incident). Resolution
+ * order: explicit opt-out -> registrar API (authoritative, priced) -> RDAP (zero-
+ * credential fallback) -> null (both rungs unavailable; caller reports 'unverified').
+ * Every result is shaped identically to the existing RDAP assessment
+ * ({candidate, results:[{domain, verdict, source, checked_at, priceUsd?}], best}) so
+ * assessCandidateAvailability/domainVerdictFor/tldStatusesFor/buildDomainShortlist/
+ * availabilityScore all keep working unmodified on registrar-sourced results too.
+ */
+export function resolveDomainAvailabilityChecker(env = process.env) {
+  if (env.DOMAIN_AVAILABILITY_MODE === 'off') return null; // explicit opt-out escape hatch
+  const adapter = createRegistrarAdapter(env);
+  if (adapter) return (name) => checkViaRegistrar(name, adapter);
+  return resolveAvailabilityChecker({ ...env, DOMAIN_AVAILABILITY_MODE: 'live' });
+}
+
+/** Check ONE candidate's primary .com via the registrar adapter. Never throws. */
+async function checkViaRegistrar(name, adapter) {
+  // Compact (no-hyphen) label, matching generatePermutations' own exact-first convention
+  // (the same form the existing 'acmelens.com'-first ordering relies on).
+  const domain = `${toLabel(name).replace(/-/g, '')}.com`;
+  const checked_at = new Date().toISOString();
+  try {
+    const raw = await adapter.checkDomain(domain);
+    const { registrable, priceUsd } = normalizeQuote(raw);
+    const result = { domain, verdict: registrable ? 'available' : 'taken', source: 'registrar_api', checked_at, priceUsd };
+    return { candidate: name, results: [result], best: registrable ? { domain, verdict: 'available' } : null };
+  } catch {
+    // A per-candidate registrar hiccup degrades to 'unknown' for THIS candidate only —
+    // never aborts the whole naming-stage run.
+    return { candidate: name, results: [{ domain, verdict: 'unknown', source: 'registrar_api', checked_at, reason: 'registrar_call_failed' }], best: null };
+  }
+}
+
+/**
+ * SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001 (FR-2): the exact naming-artifact
+ * decision shape the chairman's lesson-learned specifies. RDAP's 'unknown' verdict
+ * maps to 'unverified' here (PLAN-MODE / NO-DATA-over-fabrication honesty) — never
+ * silently reported as available.
+ * @returns {{domain: string|null, availability: 'available'|'taken'|'unverified', price_usd: number|null, checked_at: string|null, method: 'registrar_api'|'rdap'|'unverified'}}
+ */
+export function domainAvailabilityRecordFor(assessment) {
+  const primary = assessment?.results?.[0] || null;
+  if (!primary) return { domain: null, availability: 'unverified', price_usd: null, checked_at: null, method: 'unverified' };
+  return {
+    domain: primary.domain,
+    availability: primary.verdict === 'unknown' ? 'unverified' : primary.verdict,
+    price_usd: typeof primary.priceUsd === 'number' ? primary.priceUsd : null,
+    checked_at: primary.checked_at || null,
+    method: primary.source || 'unverified',
+  };
 }
 
 /**
@@ -118,7 +174,9 @@ export function buildDomainShortlist(byCandidate, { limit = 10 } = {}) {
   for (const [candidate, assessment] of byCandidate.entries()) {
     for (const r of (assessment.results || [])) {
       if (r.verdict === 'taken') continue;
-      rows.push({ candidate, domain: r.domain, verdict: r.verdict, checked_at: r.checked_at, price: null });
+      // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001: carry the registrar quote when present
+      // (RDAP-sourced rows have no price and stay null, as before).
+      rows.push({ candidate, domain: r.domain, verdict: r.verdict, checked_at: r.checked_at, price: typeof r.priceUsd === 'number' ? r.priceUsd : null });
     }
   }
   const rank = (row) => (row.verdict === 'available' ? (row.domain.split('.')[0].includes('-') || /^get|^try/.test(row.domain) ? 1 : 0) : 2);
@@ -130,4 +188,5 @@ export default {
   resolveAvailabilityChecker, resolveAvailabilityWeight, assessCandidateAvailability,
   availabilityScore, addAvailabilityCriterion, domainVerdictFor, domainDetailFor,
   tldStatusesFor, buildDomainShortlist, DEFAULT_AVAILABILITY_WEIGHT,
+  resolveDomainAvailabilityChecker, domainAvailabilityRecordFor,
 };

--- a/lib/venture-domains/stage-integration.js
+++ b/lib/venture-domains/stage-integration.js
@@ -49,16 +49,25 @@ export function resolveAvailabilityWeight(env = process.env) {
 export function resolveDomainAvailabilityChecker(env = process.env) {
   if (env.DOMAIN_AVAILABILITY_MODE === 'off') return null; // explicit opt-out escape hatch
   const adapter = createRegistrarAdapter(env);
-  if (adapter) return (name) => checkViaRegistrar(name, adapter);
+  if (adapter) {
+    // Same pacing discipline as the RDAP rung below — one shared budget per resolved
+    // checker (i.e. per Stage-11 run), so N candidates can't fire N un-throttled CF calls.
+    const budget = createRateBudget({});
+    return (name) => checkViaRegistrar(name, adapter, budget);
+  }
   return resolveAvailabilityChecker({ ...env, DOMAIN_AVAILABILITY_MODE: 'live' });
 }
 
 /** Check ONE candidate's primary .com via the registrar adapter. Never throws. */
-async function checkViaRegistrar(name, adapter) {
+async function checkViaRegistrar(name, adapter, budget) {
   // Compact (no-hyphen) label, matching generatePermutations' own exact-first convention
   // (the same form the existing 'acmelens.com'-first ordering relies on).
   const domain = `${toLabel(name).replace(/-/g, '')}.com`;
   const checked_at = new Date().toISOString();
+  const allowed = await budget.take();
+  if (!allowed) {
+    return { candidate: name, results: [{ domain, verdict: 'unknown', source: 'registrar_api', checked_at, reason: 'rate_budget_exhausted' }], best: null };
+  }
   try {
     const raw = await adapter.checkDomain(domain);
     const { registrable, priceUsd } = normalizeQuote(raw);

--- a/tests/integration/eva/analysis-steps.test.js
+++ b/tests/integration/eva/analysis-steps.test.js
@@ -779,6 +779,10 @@ describe('Stage 11: analyzeStage11', () => {
       stage5Data: genStage05(),
       stage10Data: genStage10(),
       logger: silentLogger,
+      // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001: the domain-availability seam now runs
+      // BY DEFAULT (registrar API when credentials exist -- this integration tier DOES load
+      // real .env). Explicitly disable so this test never fires a live Cloudflare API call.
+      availabilityChecker: null,
     });
 
     expect(result).toHaveProperty('namingStrategy');

--- a/tests/integration/eva/stage-chain.test.js
+++ b/tests/integration/eva/stage-chain.test.js
@@ -367,6 +367,10 @@ describe('Stage Chain: Full 1→25 Pipeline with Real Outputs', () => {
         stage10Data: stageOutputs[10],
         ventureName: VENTURE_NAME,
         logger: silentLogger,
+        // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001: the domain-availability seam now runs
+        // BY DEFAULT (registrar API when credentials exist -- this integration tier DOES load
+        // real .env). Explicitly disable so this test never fires a live Cloudflare API call.
+        availabilityChecker: null,
       });
 
       expect(stageOutputs[11]).toBeDefined();

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-11-domain-availability.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-11-domain-availability.test.js
@@ -1,9 +1,16 @@
 /**
- * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 — Stage-11 availability seam.
- * OFF (default): byte-identical decision shape (all-'pending', no Availability criterion).
- * ON (injected checker): availability-weighted scoring + real domain verdict + detail.
+ * SD-LEO-FEAT-VENTURE-DOMAIN-AVAILABILITY-001 — Stage-11 availability seam, extended by
+ * SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001.
+ *
+ * ON BY DEFAULT (chairman lesson-learned: a taken .com reached the CF purchase screen
+ * uncaught because the old opt-in flag was never set). With no registrar credentials in
+ * this test environment, the default now falls through to the RDAP checker -- global
+ * fetch is stubbed so this stays hermetic (no live network in a unit test).
+ * Explicit DOMAIN_AVAILABILITY_MODE='off' is the only way back to the pre-SD pending/
+ * no-criterion shape. ON (injected checker): availability-weighted scoring + real domain
+ * verdict + detail, unchanged from the original seam's behavior.
  */
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 const mockComplete = vi.fn();
 vi.mock('../../../../../lib/llm/index.js', () => ({
@@ -61,14 +68,39 @@ function run(extra = {}) {
   return analyzeStage11({ stage1Data, stage10Data: stage10Data(), logger: silentLogger, ...extra });
 }
 
-beforeEach(() => { mockComplete.mockReset(); delete process.env.DOMAIN_AVAILABILITY_MODE; });
+beforeEach(() => {
+  mockComplete.mockReset();
+  delete process.env.DOMAIN_AVAILABILITY_MODE;
+  // SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001: some transitively-imported module in this
+  // stage's dependency chain self-loads .env as a side effect (confirmed live -- a bare
+  // process.env check shows these unset, but importing analyzeStage11 fills them in from
+  // the real .env, even in the "unit" vitest project). Explicitly clear both so the
+  // "no registrar credentials" scenario below is deterministic regardless of that leak.
+  delete process.env.CLOUDFLARE_REGISTRAR_API_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
+});
+afterEach(() => { vi.unstubAllGlobals(); });
 
-describe('seam OFF (default)', () => {
-  it('is byte-identical to pre-SD behavior: all-pending, no Availability criterion, no domainDetail', async () => {
+describe('seam ON BY DEFAULT (SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001)', () => {
+  it('with no registrar credentials, the bare default falls through to the RDAP checker and adds Availability scoring', async () => {
+    // No registrar creds in this test env -> resolveDomainAvailabilityChecker() falls
+    // through to RDAP. Stub global fetch so this stays hermetic (no live network).
+    vi.stubGlobal('fetch', async () => ({ status: 404 })); // RDAP: 404 = available
+    const result = await run();
+    expect(result.decision.availabilityChecks.domain).toBe('available');
+    expect(result.decision.domainDetail).toBeDefined();
+    expect(result.scoringCriteria.some(c => c.name === 'Availability')).toBe(true);
+    // FR-2/FR-3: the new naming-input decision record is populated, never omitted.
+    expect(result.decision.domainAvailability).toMatchObject({ availability: 'available', method: 'rdap' });
+  });
+
+  it('explicit DOMAIN_AVAILABILITY_MODE=off is the only way back to the pre-SD pending/no-criterion shape', async () => {
+    process.env.DOMAIN_AVAILABILITY_MODE = 'off';
     const result = await run();
     expect(result.decision.availabilityChecks).toEqual({ domain: 'pending', trademark: 'pending', social: 'pending' });
     expect(result.decision.domainDetail).toBeUndefined();
     expect(result.scoringCriteria.some(c => c.name === 'Availability')).toBe(false);
+    expect(result.decision.domainAvailability).toEqual({ domain: null, availability: 'unverified', price_usd: null, checked_at: null, method: 'unverified' });
   });
 
   it('explicit null checker also stays off even if env is live (injection wins)', async () => {

--- a/tests/unit/venture-domains/domain-availability-resolver.test.js
+++ b/tests/unit/venture-domains/domain-availability-resolver.test.js
@@ -1,0 +1,100 @@
+/**
+ * SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001 — registrar-first, RDAP-fallback
+ * domain-availability resolver (FR-1) and the naming-artifact decision record (FR-2).
+ *
+ * Chairman lesson-learned: a taken .com (getalttext.com) reached the Cloudflare
+ * purchase screen uncaught because the pre-existing RDAP-only seam was OFF by
+ * default behind an opt-in flag nobody set. These tests lock: (1) the seam now
+ * runs BY DEFAULT, (2) registrar credentials take priority over RDAP when present,
+ * (3) a registrar failure degrades honestly rather than aborting, (4) the decision
+ * record never fabricates 'available'.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  resolveDomainAvailabilityChecker, domainAvailabilityRecordFor,
+} from '../../../lib/venture-domains/stage-integration.js';
+
+const REGISTRAR_ENV = { CLOUDFLARE_REGISTRAR_API_TOKEN: 'tok', CLOUDFLARE_ACCOUNT_ID: 'acct' };
+
+function jsonResponse(body, ok = true) {
+  return { ok, status: ok ? 200 : 500, json: async () => body };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('resolveDomainAvailabilityChecker — resolution order', () => {
+  it('runs BY DEFAULT with no env flags at all (closes the opt-in trap)', () => {
+    const checker = resolveDomainAvailabilityChecker({});
+    // No registrar creds and (in this Node test env) global fetch exists -> falls through
+    // to the RDAP rung, which is truthy (a function) rather than the old always-null default.
+    expect(typeof checker).toBe('function');
+  });
+
+  it('explicit DOMAIN_AVAILABILITY_MODE=off is the only way to fully disable the seam', () => {
+    expect(resolveDomainAvailabilityChecker({ DOMAIN_AVAILABILITY_MODE: 'off' })).toBeNull();
+  });
+
+  it('prefers the registrar adapter over RDAP when credentials are present', async () => {
+    vi.stubGlobal('fetch', async () => jsonResponse({ success: true, result: { available: true, price: 12 } }));
+    const checker = resolveDomainAvailabilityChecker(REGISTRAR_ENV);
+    const assessment = await checker('Acme Lens');
+    expect(assessment.results).toHaveLength(1); // registrar path checks ONE domain: the primary .com
+    expect(assessment.results[0]).toMatchObject({ domain: 'acmelens.com', verdict: 'available', source: 'registrar_api', priceUsd: 12 });
+  });
+
+  it('falls back to the RDAP checker with no registrar credentials', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 404 })); // RDAP: 404 = available
+    const checker = resolveDomainAvailabilityChecker({});
+    const assessment = await checker('Acme Lens');
+    expect(assessment.results[0].source).toBe('rdap');
+    expect(assessment.results[0].verdict).toBe('available');
+  });
+
+  it('a taken domain via the registrar adapter reports verdict=taken with the real price', async () => {
+    vi.stubGlobal('fetch', async () => jsonResponse({ success: true, result: { available: false, price: 0 } }));
+    const checker = resolveDomainAvailabilityChecker(REGISTRAR_ENV);
+    const assessment = await checker('Get Alt Text');
+    expect(assessment.results[0]).toMatchObject({ domain: 'getalttext.com', verdict: 'taken' });
+    expect(assessment.best).toBeNull();
+  });
+
+  it('a registrar-call failure degrades to unknown for that candidate — never throws, never fabricates available', async () => {
+    vi.stubGlobal('fetch', async () => jsonResponse({ success: false, errors: [{ message: 'rate limited' }] }, false));
+    const checker = resolveDomainAvailabilityChecker(REGISTRAR_ENV);
+    const assessment = await checker('Acme Lens');
+    expect(assessment.results[0].verdict).toBe('unknown');
+    expect(assessment.best).toBeNull();
+  });
+});
+
+describe('domainAvailabilityRecordFor — FR-2 naming-artifact decision shape', () => {
+  it('an available registrar result produces the full priced record', () => {
+    const assessment = { results: [{ domain: 'acmelens.com', verdict: 'available', source: 'registrar_api', checked_at: '2026-07-12T00:00:00Z', priceUsd: 12 }] };
+    expect(domainAvailabilityRecordFor(assessment)).toEqual({
+      domain: 'acmelens.com', availability: 'available', price_usd: 12, checked_at: '2026-07-12T00:00:00Z', method: 'registrar_api',
+    });
+  });
+
+  it('a taken .com produces availability=taken with no price fabricated when absent', () => {
+    const assessment = { results: [{ domain: 'getalttext.com', verdict: 'taken', source: 'registrar_api', checked_at: '2026-07-12T00:00:00Z' }] };
+    const record = domainAvailabilityRecordFor(assessment);
+    expect(record.availability).toBe('taken');
+    expect(record.price_usd).toBeNull();
+  });
+
+  it('an RDAP "unknown" verdict maps to the honest "unverified" label, never fabricated available', () => {
+    const assessment = { results: [{ domain: 'x.com', verdict: 'unknown', source: 'rdap', checked_at: '2026-07-12T00:00:00Z' }] };
+    expect(domainAvailabilityRecordFor(assessment).availability).toBe('unverified');
+  });
+
+  it('no assessment at all (seam fully off) produces the all-null unverified floor', () => {
+    expect(domainAvailabilityRecordFor(null)).toEqual({
+      domain: null, availability: 'unverified', price_usd: null, checked_at: null, method: 'unverified',
+    });
+    expect(domainAvailabilityRecordFor(undefined)).toEqual({
+      domain: null, availability: 'unverified', price_usd: null, checked_at: null, method: 'unverified',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the opt-in trap that let a taken .com reach the Cloudflare purchase screen uncaught (chairman-reported incident): `resolveDomainAvailabilityChecker()` now runs **by default** — registrar API when Cloudflare credentials exist, RDAP fallback otherwise, explicit `DOMAIN_AVAILABILITY_MODE=off` the only opt-out.
- The Stage 11 naming decision now always carries a `domainAvailability` record (`{domain, availability, price_usd, checked_at, method}`), never fabricating "available" — RDAP's `unknown` maps to `unverified`.
- Wired into `stage-11-visual-identity.js`, the actual reachable naming analysis step (verified via `stage-10.js`'s real import chain) — `stage-10-naming-brand.js`, named literally in the PRD, is dead/unreachable code.

## Test plan
- [x] `tests/unit/venture-domains/domain-availability-resolver.test.js` (new, 10 tests) — resolution ladder + decision-record shape
- [x] `tests/unit/eva/stage-templates/analysis-steps/stage-11-domain-availability.test.js` (6 tests) — default-on behavior, opt-out, injection-wins
- [x] `tests/integration/eva/analysis-steps.test.js` Stage 11 case verified passing under `--project db` (real `.env`); explicit `availabilityChecker: null` added to prevent live Cloudflare calls in CI
- [x] `tests/integration/eva/stage-chain.test.js` Stage 11 call site given the same CI-safety fix; confirmed the "no naming candidates" failure in this file is a **pre-existing, unrelated** mock/system-prompt mismatch (logged as harness bug, feedback id `0f2ed996-a068-4629-9f3e-7a3ba5298137`) — reproduces identically on `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)