### PR TITLE
fix(SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001): FR-4 courtesy-ACK dedup narrowing + FR-5 mechanical-row marking/INBOX_CAP fix

### DIFF
--- a/lib/coordinator/reply-correlation.cjs
+++ b/lib/coordinator/reply-correlation.cjs
@@ -11,12 +11,28 @@
  * Pure function, no I/O — callers supply the row window they already fetched.
  */
 
-function hasCorrelatedReply(row, allRows) {
+/**
+ * @param {object} row
+ * @param {object[]} allRows
+ * @param {{ excludeKinds?: string[] }} [opts] - SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001
+ *   FR-4: optional, additive, backward-compatible. When supplied, a candidate `other` row
+ *   whose payload.kind is in excludeKinds is NOT counted as a correlated reply -- so a
+ *   mechanical courtesy-ACK (e.g. kind='ack'/'coordinator_ack', per
+ *   lib/fleet/worker-status.cjs's ADAM_EXCLUDED_KINDS) echoing the same correlation_id can
+ *   never suppress the eventual genuine reply/verdict. Omitting opts (or excludeKinds)
+ *   leaves behavior byte-identical to before this SD -- existing callers (fleet-dashboard,
+ *   outbound-silence-watchdog, detectors) that intentionally want the broad "ANY reply"
+ *   semantics are unaffected. Deliberately NOT a lane-wide dedup rewrite -- narrowly scoped
+ *   per RISK sub-agent finding (no per-lane equivalence proof exists for a broader collapse).
+ */
+function hasCorrelatedReply(row, allRows, opts = {}) {
   if (!row || !Array.isArray(allRows)) return false;
   const ownCorrelationId = row.payload?.correlation_id || row.id;
+  const excludeKinds = opts.excludeKinds;
   return allRows.some((other) => {
     if (!other || other.id === row.id) return false;
     const otherPayload = other.payload || {};
+    if (excludeKinds && excludeKinds.includes(otherPayload.kind)) return false;
     return otherPayload.reply_to === row.id || otherPayload.correlation_id === ownCorrelationId;
   });
 }

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -70,6 +70,7 @@ const PAYLOAD_KINDS = Object.freeze({
   COORDINATOR_RESERVATION: 'coordinator_reservation', // SD-LEO-INFRA-DISPATCH-AUTH-AUTO-AUTHORIZE-001-C: a coordinator-authored, non-consuming fence (target_session=NULL, target_sd set, self-compared expires_at) that suppresses belt self-claim of a specific SD for every session except the one it names. Drained read-only by lib/checkin/steps/drain-reservations.cjs into ctx.reservations — never stamped read_at/acknowledged_at, so it is intentionally NOT a DIRECTIVE_KIND (no agent ever "acts" on it; the axis check IS the action).
   SEAT_BUSY_RESERVATION: 'seat_busy_reservation', // SD-LEO-INFRA-NON-SD-WORK-CLAIM-FENCE-001: a coordinator-authored, non-consuming fence (target_session=<worker>, target_sd=NULL, self-compared expires_at) that suppresses ALL self-claim-of-new-work tiers for the ONE seat it names, for directed non-SD work (console assessment, audit sweep, open-loop gather) that is structurally invisible to COORDINATOR_RESERVATION above (which is keyed on target_sd). Drained read-only by lib/checkin/steps/seat-busy-fence.cjs into ctx.seatBusy — intentionally NOT a DIRECTIVE_KIND, same rationale as COORDINATOR_RESERVATION (the fence check IS the action).
   FENCE_NOTICE: 'fence_notice', // SD-LEO-INFRA-MID-FLIGHT-DIRECTIVE-001 / FR-2: a hard-stop/sequencing-fence notice (e.g. "do not run PLAN-TO-EXEC until sibling X passes") that a busy worker must see PROMPTLY, not just eventually. A DIRECTIVE_KIND (below) for deliver-not-consume semantics AND priority-exempt from coordination-inbox.cjs's oldest-N row cap (FR-1) — an older low-priority directive must never starve a newer fence notice out of the surfaced window.
+  CROSS_PARTY_PING: 'cross_party_ping', // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 (instance 5): the subject-only STUB row Adam/coordinator quiet-tick sends the other party on a real salient-state delta (QUIET_TICK_PING log line). Mechanical, never authored content — reserved kind so it is excluded from the Adam inbox drain (ADAM_EXCLUDED_KINDS below) same as canary_request/comms_check, instead of rendering as an authored request.
 });
 
 // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): payload.kind values that are
@@ -120,7 +121,9 @@ const PRIORITY_EXEMPT_DIRECTIVE_KINDS = Object.freeze(['fence_notice']);
 // which would pollute an unacked-tier forever. Canonical home here (kinds module) so
 // adam-advisory.cjs, read-adam-directives.cjs and adam-quiet-tick.mjs share one list
 // without a require cycle (adam-advisory already requires read-adam-directives).
-const ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack']);
+// SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5: cross_party_ping added —
+// the same "mechanical, never authored" rationale as canary_request/comms_check.
+const ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack', 'cross_party_ping']);
 
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;
 

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -176,6 +176,16 @@ export async function checkVentureTraversalStalls(sb, priorSnapshot = {}) {
 // NEVER read_at/acknowledged_at). Fail-soft: any error returns items:[] without aborting.
 const TICK_SURFACE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
+// SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 (instance 6, INBOX_CAP overflow):
+// the raw fetch and the DISPLAY budget were previously the SAME number (50) — a burst of
+// mechanical rows (ADAM_EXCLUDED_KINDS) consumed the entire raw fetch before the mechanical
+// filter ever ran client-side, starving genuinely authored items out of the window all day.
+// Split them: fetch a generous raw window (matches correlationWindow's existing .limit(400)
+// precedent a few lines below), filter mechanical rows out FIRST, THEN cap the display at 50 —
+// so mechanical noise can no longer crowd out authored content regardless of burst size.
+const INBOX_RAW_FETCH_LIMIT = 400;
+const INBOX_DISPLAY_CAP = 50;
+
 export async function surfaceInboxItems(sb) {
   try {
     const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
@@ -192,7 +202,7 @@ export async function surfaceInboxItems(sb) {
       .is('acknowledged_at', null)
       .gte('created_at', cutoffIso)
       .order('created_at', { ascending: true })
-      .limit(50);
+      .limit(INBOX_RAW_FETCH_LIMIT);
     if (error) return { items: [], directives: 0, error: error.message };
 
     // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a directive's
@@ -215,13 +225,21 @@ export async function surfaceInboxItems(sb) {
     const eligible = (rows || []).filter((r) => {
       const k = r.payload && r.payload.kind;
       if (k != null && ADAM_EXCLUDED_KINDS.includes(k)) return false;
-      if (isDirectiveRow(r)) return !hasCorrelatedReply(r, correlationWindow || []);
+      // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-4 (instance 3): a courtesy-ACK
+      // (kind='ack'/'coordinator_ack', already excluded from Adam's own inbox above) echoing
+      // this directive's correlation_id must never suppress the eventual genuine reply/verdict.
+      if (isDirectiveRow(r)) return !hasCorrelatedReply(r, correlationWindow || [], { excludeKinds: ADAM_EXCLUDED_KINDS });
       return !(r.payload && r.payload.tick_surfaced_at);
     });
-    const capHit = (rows || []).length === 50;
+    // FR-5: capHit now reflects a genuine authored-item backlog exceeding the display budget
+    // (eligible.length > cap) OR the raw fetch itself being truncated (rows.length hit its own
+    // higher ceiling) -- NOT "the raw window happened to contain 50 rows," which previously gave
+    // a false CAP signal even when every one of those 50 rows was mechanical noise (eligible:[]).
+    const capHit = eligible.length > INBOX_DISPLAY_CAP || (rows || []).length === INBOX_RAW_FETCH_LIMIT;
     if (eligible.length === 0) return { items: [], directives: 0, capHit };
 
-    const items = eligible.map((r) => {
+    const surfaced = eligible.slice(0, INBOX_DISPLAY_CAP);
+    const items = surfaced.map((r) => {
       const k = (r.payload && r.payload.kind) || '(untyped)';
       const isDirective = isDirectiveRow(r);
       const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
@@ -232,7 +250,7 @@ export async function surfaceInboxItems(sb) {
     // Stamp the dedup marker on ITEM-class rows only (visibility marker — the row stays
     // unread/unacked-recoverable; directives are deliberately never marked).
     const seenAt = new Date().toISOString();
-    for (const r of eligible.filter((x) => !isDirectiveRow(x) && !(x.payload && x.payload.tick_surfaced_at))) {
+    for (const r of surfaced.filter((x) => !isDirectiveRow(x) && !(x.payload && x.payload.tick_surfaced_at))) {
       await sb.from('session_coordination').update({ payload: { ...(r.payload || {}), tick_surfaced_at: seenAt } }).eq('id', r.id);
     }
     return { items, directives: items.filter((i) => i.isDirective).length, capHit };
@@ -364,7 +382,7 @@ async function main() {
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
     if (delta.changed) {
-      console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing)`);
+      console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing; if sending a subject-only stub ping, stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -278,7 +278,7 @@ async function main() {
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
     if (delta.changed) {
-      console.log(`QUIET_TICK_PING=coordinator->adam reason=${delta.fields.join(',')} (real delta — emit a prompt cross-party ping)`);
+      console.log(`QUIET_TICK_PING=coordinator->adam reason=${delta.fields.join(',')} (real delta — emit a prompt cross-party ping; stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
     }
   }
   return result;

--- a/tests/unit/adam-inbox-surface-not-stamp.test.js
+++ b/tests/unit/adam-inbox-surface-not-stamp.test.js
@@ -222,6 +222,85 @@ describe('FR-1/FR-3: quiet tick', () => {
     }
   });
 
+  // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 (instance 6, INBOX_CAP overflow):
+  // a burst of mechanical rows must never starve genuinely authored items out of the raw fetch.
+  it('a burst of cross_party_ping/mechanical rows does NOT starve a real authored item out of the window', async () => {
+    const mechanicalBurst = Array.from({ length: 60 }, (_, i) =>
+      row({ payload: { kind: 'cross_party_ping' }, created_at: new Date(Date.now() - (60 - i) * 60_000).toISOString() })
+    );
+    const authored = row({ payload: { kind: 'adam_advisory' }, created_at: new Date().toISOString() });
+    const allRows = [...mechanicalBurst, authored]; // 61 raw rows — would have overflowed the OLD .limit(50) raw fetch
+    const sb = { from: (table) => {
+      const state = { table, filters: [], payload: null, op: 'select' };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; state.payload = p; return c; },
+        eq: (col, v) => { state.filters.push([col, v]); return c; },
+        is: () => c, gte: () => c, order: () => c, limit: () => c, or: () => c,
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          return Promise.resolve({ data: allRows, error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    // the mechanical burst is excluded (ADAM_EXCLUDED_KINDS now includes cross_party_ping);
+    // the single authored item survives instead of being crowded out by the noise.
+    expect(out.items.map((i) => i.id)).toEqual([authored.id]);
+    expect(out.items.every((i) => i.kind !== 'cross_party_ping')).toBe(true);
+  });
+
+  it('capHit reflects a genuine eligible-item backlog, not a mechanical-noise-filled raw window', async () => {
+    // 55 mechanical rows only (all excluded) -- old logic: rows.length===50-ish -> capHit:true
+    // with ZERO eligible items (misleading). New logic: capHit must be false here.
+    const mechanicalOnly = Array.from({ length: 55 }, () => row({ payload: { kind: 'cross_party_ping' } }));
+    const sb = { from: (table) => {
+      const state = { table, op: 'select' };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; return c; },
+        eq: () => c, is: () => c, gte: () => c, order: () => c, limit: () => c, or: () => c,
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          return Promise.resolve({ data: mechanicalOnly, error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items).toEqual([]);
+    expect(out.capHit).toBe(false);
+  });
+
+  it('capHit is true when authored eligible items genuinely exceed the 50-item display budget', async () => {
+    const manyAuthored = Array.from({ length: 60 }, (_, i) =>
+      row({ payload: { kind: 'adam_advisory' }, created_at: new Date(Date.now() - (60 - i) * 60_000).toISOString() })
+    );
+    const sb = { from: (table) => {
+      const state = { table, op: 'select' };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; return c; },
+        eq: () => c, is: () => c, gte: () => c, order: () => c, limit: () => c, or: () => c,
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          return Promise.resolve({ data: manyAuthored, error: null }).then(res);
+        },
+      };
+      return c;
+    } };
+    const out = await surfaceInboxItems(sb);
+    expect(out.items).toHaveLength(50); // display cap still 50
+    expect(out.capHit).toBe(true); // but the signal now correctly reflects real overflow
+  });
+
   it('the cron prompt allowlist includes both INBOX tokens (no-op gate cannot swallow a directive)', async () => {
     const { readFileSync } = await import('node:fs');
     const src = readFileSync(new URL('../../scripts/adam-startup-check.mjs', import.meta.url), 'utf8');
@@ -262,6 +341,47 @@ describe('FR-1/FR-3: quiet tick', () => {
     const out = await surfaceInboxItems(sb);
     expect(out.items.map((i) => i.id)).not.toContain(directive.id);
     expect(out.directives).toBe(0);
+  });
+
+  // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-4 (instance 3): the exact courtesy-
+  // ACK-vs-canonical-verdict fixture from the PRD AC — a mechanical ack echoing the consult
+  // correlation must never suppress the directive, and the genuine reply still delivers once it
+  // arrives. Exercises the REAL surfaceInboxItems wiring (isDirectiveRow + hasCorrelatedReply +
+  // ADAM_EXCLUDED_KINDS), not just the standalone reply-correlation.cjs unit.
+  it('FR-4: a courtesy-ACK echoing the consult correlation does NOT suppress the directive; the real verdict does', async () => {
+    const directive = row({ payload: { kind: DIRECTIVE_KINDS[0], correlation_id: 'corr-fr4' } });
+    const courtesyAck = { id: 'ack-fr4', payload: { correlation_id: 'corr-fr4', kind: 'ack' }, sender_session: ADAM, target_session: 'someone-else' };
+    const buildSb = (correlationRows) => ({ from: (table) => {
+      const state = { table, filters: [], payload: null, op: 'select', usedOr: false };
+      const c = {
+        select: () => c,
+        update: (p) => { state.op = 'update'; state.payload = p; return c; },
+        eq: (col, v) => { state.filters.push([col, v]); return c; },
+        is: () => c, gte: () => c, order: () => c, limit: () => c,
+        or: () => { state.usedOr = true; return c; },
+        single: async () => ({ data: { session_id: ADAM, metadata: { role: 'adam' } }, error: null }),
+        then: (res) => {
+          if (state.op === 'update') return Promise.resolve({ data: [], error: null }).then(res);
+          if (state.table === 'claude_sessions') return Promise.resolve({ data: [{ session_id: ADAM }], error: null }).then(res);
+          if (state.usedOr) return Promise.resolve({ data: [directive, ...correlationRows], error: null }).then(res);
+          return Promise.resolve({ data: [directive], error: null }).then(res);
+        },
+      };
+      return c;
+    } });
+
+    // Only the courtesy-ACK exists so far — the directive must STILL surface (hard interrupt).
+    const beforeVerdict = await surfaceInboxItems(buildSb([courtesyAck]));
+    expect(beforeVerdict.items.map((i) => i.id)).toContain(directive.id);
+    expect(beforeVerdict.directives).toBe(1);
+
+    // The real verdict has now also arrived, correlated to the SAME id — the directive is
+    // suppressed (a genuine, non-excluded-kind reply exists), matching the C6 suppression test
+    // above. Both the courtesy-ACK and the genuine verdict were correctly classified in turn.
+    const verdict = { id: 'verdict-fr4', payload: { correlation_id: 'corr-fr4', kind: 'adam_advisory' }, sender_session: ADAM, target_session: 'someone-else' };
+    const afterVerdict = await surfaceInboxItems(buildSb([courtesyAck, verdict]));
+    expect(afterVerdict.items.map((i) => i.id)).not.toContain(directive.id);
+    expect(afterVerdict.directives).toBe(0);
   });
 
   it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a directive with no correlated reply still hard-interrupts', async () => {

--- a/tests/unit/coordinator/reply-correlation.test.js
+++ b/tests/unit/coordinator/reply-correlation.test.js
@@ -48,3 +48,35 @@ describe('hasCorrelatedReply', () => {
     expect(hasCorrelatedReply(original, [original, bare])).toBe(false);
   });
 });
+
+// SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-4 (instance 3): opts.excludeKinds —
+// a mechanical courtesy-ACK echoing a consult correlation_id must never suppress the eventual
+// genuine oracle-verdict/reply row.
+describe('hasCorrelatedReply — opts.excludeKinds (FR-4)', () => {
+  it('WITHOUT excludeKinds (default, byte-identical to pre-FR-4): a courtesy-ACK still counts as a correlated reply', () => {
+    const consult = { id: 'consult-1', payload: { correlation_id: 'corr-x' } };
+    const courtesyAck = { id: 'ack-1', payload: { correlation_id: 'corr-x', kind: 'ack' } };
+    expect(hasCorrelatedReply(consult, [consult, courtesyAck])).toBe(true);
+  });
+
+  it('WITH excludeKinds: a courtesy-ACK matching an excluded kind is ignored — the directive is NOT suppressed', () => {
+    const consult = { id: 'consult-2', payload: { correlation_id: 'corr-y' } };
+    const courtesyAck = { id: 'ack-2', payload: { correlation_id: 'corr-y', kind: 'ack' } };
+    expect(hasCorrelatedReply(consult, [consult, courtesyAck], { excludeKinds: ['ack', 'coordinator_ack'] })).toBe(false);
+  });
+
+  it('WITH excludeKinds: the genuine oracle-verdict reply (a non-excluded kind) still correlates', () => {
+    const consult = { id: 'consult-3', payload: { correlation_id: 'corr-z' } };
+    const courtesyAck = { id: 'ack-3', payload: { correlation_id: 'corr-z', kind: 'ack' } };
+    const verdict = { id: 'verdict-3', payload: { correlation_id: 'corr-z', kind: 'adam_advisory' } };
+    // Both a mechanical ack AND the real verdict exist — excludeKinds filters the ack out but
+    // the verdict still satisfies the correlation.
+    expect(hasCorrelatedReply(consult, [consult, courtesyAck, verdict], { excludeKinds: ['ack'] })).toBe(true);
+  });
+
+  it('excludeKinds only filters by kind, not by which field matched (reply_to path also respects it)', () => {
+    const req = { id: 'req-7', payload: {} };
+    const courtesyAck = { id: 'ack-4', payload: { reply_to: 'req-7', kind: 'coordinator_ack' } };
+    expect(hasCorrelatedReply(req, [req, courtesyAck], { excludeKinds: ['coordinator_ack'] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **FR-4** (instance 3): `lib/coordinator/reply-correlation.cjs`'s `hasCorrelatedReply` matched on `correlation_id` for ANY row, not restricted to oracle-verdict/reply rows — a courtesy-ACK echoing a consult correlation could suppress the canonical directive in `adam-quiet-tick.mjs`'s `surfaceInboxItems`. Adds an optional, backward-compatible `opts.excludeKinds` parameter and wires it at the one affected call site with `ADAM_EXCLUDED_KINDS`. Narrowly scoped, not a lane-wide dedup rewrite — 4 disjoint dedup schemes coexist deliberately (one, QF-20260709-800's key, was already narrowed once before for exactly this reason).
- **FR-5** (instances 5/6): subject-only STUB rows (quiet-tick cross-party pings) rendered as authored requests, and a burst of mechanical rows could clog Adam's 50-row inbox window all day (INBOX_CAP overflow) because the raw fetch and the display budget were the same number — mechanical noise consumed the entire fetch before the exclusion filter ever ran client-side. Adds a reserved `cross_party_ping` payload.kind to `ADAM_EXCLUDED_KINDS`, and splits `surfaceInboxItems`'s raw fetch (400, matching this file's own `correlationWindow` precedent) from the 50-item display cap so a mechanical burst of any size can no longer starve authored content out of the window.

Part of SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 (FR-4/FR-5 of 6, following #6016 FR-3 and #6018 FR-1/FR-2). Shipping as a separate PR per this SD's own architecture-grounding note that the ~1150 LOC total across all 6 FRs exceeds the single-PR LOC ceiling.

## Test plan
- [x] `tests/unit/coordinator/reply-correlation.test.js` — new `opts.excludeKinds` unit coverage
- [x] `tests/unit/adam-inbox-surface-not-stamp.test.js` — new FR-4 integration fixture (courtesy-ACK doesn't suppress, real verdict does) + FR-5 burst-starvation / capHit-semantics tests
- [x] `tests/unit/lint/quiet-tick-token-parity-lint.test.js` — confirms the updated `QUIET_TICK_PING` guidance text doesn't break token-parity lint
- [x] Full regression sweep green

🤖 Generated with [Claude Code](https://claude.com/claude-code)