### PR TITLE
feat(SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001): FR-6 lane-lint observability gauge

### DIFF
--- a/lib/coordination/lane-lint-gauge.cjs
+++ b/lib/coordination/lane-lint-gauge.cjs
@@ -1,0 +1,203 @@
+/**
+ * session_coordination lane-lint observability gauge — FR-6.
+ *
+ * SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001.
+ *
+ * READ-ONLY: queries session_coordination directly, no new table, no new RLS surface (RLS on
+ * session_coordination is currently permissive). Reports SEPARATE counts per violation class
+ * (not one aggregate number) so a regression in any single class is individually visible, per
+ * PLAN correction #6 (extend the existing 20260702_session_coordination_insert_lint.sql advisory
+ * trigger's INTENT -- that trigger is NOTICE-only and not queryable/testable, so this gauge is a
+ * separate module rather than parsing Postgres log output).
+ *
+ * Mirrors the pure-core + IO-loader + tick-entrypoint SHAPE of
+ * lib/coordinator/relay-drop-gauge.cjs, with one structural delta: this gauge only reads and
+ * counts -- it performs zero writes (relay-drop-gauge's gaugeEnabled/recordFlags write-side has
+ * no equivalent here).
+ *
+ * Four violation classes (instances 2, 4, 1/6, 9 from this SD's evidence):
+ *   untyped_row            — payload.kind missing/null/empty (instance 2: silently skipped)
+ *   bodyless_row            — readCanonicalBody() returns '' on a non-mechanical, non-fence kind
+ *                              (instance 4: coordinator_request body-drop class)
+ *   empty_sender_row        — sender_session null/empty on a non-sweep-authored row
+ *                              (instance 1/6: provenance-loss class)
+ *   resurface_dedup_drift   — >1 concurrently-UNACKNOWLEDGED solomon_ledger_pending_resurface
+ *                              rows for the same ledger_id (instance 9: the daily payload->>
+ *                              dedup_key only prevents a SAME-DAY dupe, not a stale unacked
+ *                              reminder from an earlier day coexisting with today's fresh one)
+ *
+ * @module lib/coordination/lane-lint-gauge
+ */
+
+'use strict';
+
+const { ADAM_EXCLUDED_KINDS } = require('../fleet/worker-status.cjs');
+const { readCanonicalBody } = require('./lane-contract.cjs');
+
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000; // untyped/bodyless/empty-sender lookback
+const DEFAULT_RESURFACE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // drift needs a wider lookback — it's inherently a cross-day pattern
+
+// Kinds that are LEGITIMATELY bodyless by design (fences/reservations/roll-call — the axis
+// check or the row's mere existence IS the payload, per lib/fleet/worker-status.cjs's own
+// documentation of these kinds). Union'd with ADAM_EXCLUDED_KINDS (mechanical/handler-owned
+// rows) when deciding whether a bodyless row is a genuine contract violation.
+const LEGITIMATELY_BODYLESS_KINDS = Object.freeze([
+  'coordinator_reservation', 'seat_busy_reservation', 'fence_notice', 'roll_call',
+]);
+
+// sender_type values that legitimately omit sender_session (system/sweep-authored rows —
+// e.g. resurfaceStalePending in scripts/solomon-ledger-pending-resurface.cjs deliberately
+// writes sender_session:null). Without this exclusion the gauge would permanently over-count
+// a KNOWN, intentional pattern rather than the actual provenance-loss defect class (instance
+// 1/6: a re-target operation ERASING a previously-real sender_session).
+const LEGITIMATE_EMPTY_SENDER_TYPES = Object.freeze(['sweep', 'system']);
+
+const RESURFACE_KIND = 'solomon_ledger_pending_resurface';
+
+/** Pure: is payload.kind missing/null/empty? */
+function isUntypedRow(row) {
+  const kind = row && row.payload && typeof row.payload === 'object' ? row.payload.kind : undefined;
+  return kind === undefined || kind === null || kind === '';
+}
+
+/** Pure: does this row violate the canonical-body contract (non-mechanical, non-fence, no body)? */
+function isBodylessRow(row) {
+  if (isUntypedRow(row)) return false; // counted under untyped_row instead — no double-count
+  const kind = row.payload.kind;
+  if (ADAM_EXCLUDED_KINDS.includes(kind) || LEGITIMATELY_BODYLESS_KINDS.includes(kind)) return false;
+  return readCanonicalBody(row) === '';
+}
+
+/** Pure: does this row have a missing sender_session with no legitimate reason? */
+function isEmptySenderRow(row) {
+  if (row && row.sender_session) return false;
+  const senderType = row && row.sender_type;
+  return !LEGITIMATE_EMPTY_SENDER_TYPES.includes(senderType);
+}
+
+/**
+ * CORE — pure, zero IO. Counts the three row-level violation classes over an already-fetched
+ * window. Callers supply the row window (see loadWindowRows for the live-DB loader).
+ * @param {Array<object>} rows
+ * @returns {{untyped_row:number, bodyless_row:number, empty_sender_row:number}}
+ */
+function computeRowViolationCounts(rows) {
+  let untyped_row = 0;
+  let bodyless_row = 0;
+  let empty_sender_row = 0;
+  for (const row of (rows || [])) {
+    if (isUntypedRow(row)) untyped_row++;
+    if (isBodylessRow(row)) bodyless_row++;
+    if (isEmptySenderRow(row)) empty_sender_row++;
+  }
+  return { untyped_row, bodyless_row, empty_sender_row };
+}
+
+/**
+ * CORE — pure, zero IO. Instance 9: counts ledger_ids that currently have MORE THAN ONE
+ * concurrently-unacknowledged solomon_ledger_pending_resurface row — the daily dedup_key only
+ * blocks a SAME-DAY repeat, so a stale unacked reminder from an earlier day plus today's fresh
+ * one can coexist unacknowledged, which is exactly the "resurface duplicates when acked-state
+ * drifts" defect this counts.
+ * @param {Array<object>} resurfaceRows - rows already filtered/known to be resurface rows
+ * @returns {number}
+ */
+function computeResurfaceDedupDrift(resurfaceRows) {
+  const unackedCountByLedgerId = new Map();
+  for (const row of (resurfaceRows || [])) {
+    if (row && row.acknowledged_at) continue; // only concurrently-UNACKED rows count as drift
+    const ledgerId = row && row.payload && row.payload.ledger_id;
+    if (!ledgerId) continue;
+    unackedCountByLedgerId.set(ledgerId, (unackedCountByLedgerId.get(ledgerId) || 0) + 1);
+  }
+  let drift = 0;
+  for (const count of unackedCountByLedgerId.values()) {
+    if (count > 1) drift++;
+  }
+  return drift;
+}
+
+/**
+ * IO: load the row window for the 3 row-level classes. FAIL-SOFT: [] on error.
+ * @param {object} supabase
+ * @param {{windowMs?:number, now?:number}} [opts]
+ * @returns {Promise<Array<object>>}
+ */
+async function loadWindowRows(supabase, opts = {}) {
+  const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : DEFAULT_WINDOW_MS;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const since = new Date(now - windowMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, sender_type, payload, body, acknowledged_at, created_at')
+      .gte('created_at', since)
+      .limit(2000);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * IO: load candidate resurface rows over the wider drift-detection window. FAIL-SOFT: [] on
+ * error. Server-side kind filter — no need to fetch the whole table for this narrow class.
+ * @param {object} supabase
+ * @param {{resurfaceWindowMs?:number, now?:number}} [opts]
+ * @returns {Promise<Array<object>>}
+ */
+async function loadResurfaceRows(supabase, opts = {}) {
+  const windowMs = Number.isFinite(opts.resurfaceWindowMs) ? opts.resurfaceWindowMs : DEFAULT_RESURFACE_WINDOW_MS;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const since = new Date(now - windowMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload, acknowledged_at, created_at')
+      .eq('payload->>kind', RESURFACE_KIND)
+      .gte('created_at', since)
+      .limit(2000);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Tick entry point. FAIL-OPEN end to end — never throws; read-only, no writes ever.
+ * @param {object} supabase
+ * @param {{windowMs?:number, resurfaceWindowMs?:number, now?:number}} [opts]
+ * @returns {Promise<{untyped_row:number, bodyless_row:number, empty_sender_row:number, resurface_dedup_drift:number, windowRows:number, error?:string}>}
+ */
+async function runLaneLintGauge(supabase, opts = {}) {
+  try {
+    const [rows, resurfaceRows] = await Promise.all([
+      loadWindowRows(supabase, opts),
+      loadResurfaceRows(supabase, opts),
+    ]);
+    const rowCounts = computeRowViolationCounts(rows);
+    const resurface_dedup_drift = computeResurfaceDedupDrift(resurfaceRows);
+    return { ...rowCounts, resurface_dedup_drift, windowRows: rows.length };
+  } catch (e) {
+    return {
+      untyped_row: 0, bodyless_row: 0, empty_sender_row: 0, resurface_dedup_drift: 0,
+      windowRows: 0, error: String((e && e.message) || e),
+    };
+  }
+}
+
+module.exports = {
+  isUntypedRow,
+  isBodylessRow,
+  isEmptySenderRow,
+  computeRowViolationCounts,
+  computeResurfaceDedupDrift,
+  loadWindowRows,
+  loadResurfaceRows,
+  runLaneLintGauge,
+  LEGITIMATELY_BODYLESS_KINDS,
+  LEGITIMATE_EMPTY_SENDER_TYPES,
+  RESURFACE_KIND,
+  DEFAULT_WINDOW_MS,
+  DEFAULT_RESURFACE_WINDOW_MS,
+};

--- a/scripts/coordinator-lane-lint-gauge.cjs
+++ b/scripts/coordinator-lane-lint-gauge.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * session_coordination lane-lint gauge tick — FR-6.
+ *
+ * SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001.
+ *
+ * READ-ONLY (per lib/coordination/lane-lint-gauge.cjs) — prints per-violation-class counts.
+ * No writes, no feedback rows, no kill-switch: unlike scripts/coordinator-relay-drop-gauge.cjs
+ * this gauge has no write side to gate.
+ *
+ * Usage: node scripts/coordinator-lane-lint-gauge.cjs [--window-hours 24] [--resurface-window-days 30]
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const { runLaneLintGauge } = require('../lib/coordination/lane-lint-gauge.cjs');
+
+function parseHours(argv, flag, fallbackHours) {
+  const idx = argv.indexOf(flag);
+  const n = idx >= 0 ? Number(argv[idx + 1]) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallbackHours;
+}
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+  return createClient(url, key);
+}
+
+async function main() {
+  const windowHours = parseHours(process.argv, '--window-hours', 24);
+  const resurfaceWindowDays = parseHours(process.argv, '--resurface-window-days', 30);
+  const supabase = getSupabase();
+  const result = await runLaneLintGauge(supabase, {
+    windowMs: windowHours * 60 * 60 * 1000,
+    resurfaceWindowMs: resurfaceWindowDays * 24 * 60 * 60 * 1000,
+  });
+  console.log(
+    `LANE_LINT_GAUGE window=${windowHours}h rows=${result.windowRows} ` +
+    `untyped_row=${result.untyped_row} bodyless_row=${result.bodyless_row} ` +
+    `empty_sender_row=${result.empty_sender_row} resurface_dedup_drift=${result.resurface_dedup_drift}` +
+    `${result.error ? ' error=' + result.error : ''}`
+  );
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('coordinator-lane-lint-gauge failed:', (e && e.message) || e);
+    process.exit(1);
+  });
+}

--- a/tests/unit/coordination/lane-lint-gauge.test.js
+++ b/tests/unit/coordination/lane-lint-gauge.test.js
@@ -1,0 +1,171 @@
+/**
+ * SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-6 — lane-lint observability gauge.
+ *
+ * lib/coordination/lane-lint-gauge.cjs — read-only, four independent violation-class counts.
+ * No live DB calls in these tests (rows/resurfaceRows injected directly into the pure core).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  isUntypedRow,
+  isBodylessRow,
+  isEmptySenderRow,
+  computeRowViolationCounts,
+  computeResurfaceDedupDrift,
+  runLaneLintGauge,
+  RESURFACE_KIND,
+} = require('../../../lib/coordination/lane-lint-gauge.cjs');
+
+function cleanRow(overrides = {}) {
+  return {
+    id: 'row-' + Math.random().toString(36).slice(2),
+    sender_session: '11111111-1111-4111-8111-111111111111',
+    sender_type: 'worker',
+    payload: { kind: 'adam_advisory', body: 'a real authored message' },
+    body: null,
+    acknowledged_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('isUntypedRow / isBodylessRow / isEmptySenderRow — pure detectors', () => {
+  it('isUntypedRow: true for missing/null/empty payload.kind', () => {
+    expect(isUntypedRow({ payload: {} })).toBe(true);
+    expect(isUntypedRow({ payload: { kind: null } })).toBe(true);
+    expect(isUntypedRow({ payload: { kind: '' } })).toBe(true);
+    expect(isUntypedRow({ payload: null })).toBe(true);
+    expect(isUntypedRow({ payload: { kind: 'adam_advisory' } })).toBe(false);
+  });
+
+  it('isBodylessRow: true only for a TYPED, non-mechanical, non-fence row with no canonical body', () => {
+    expect(isBodylessRow({ payload: { kind: 'adam_advisory' }, body: null })).toBe(true);
+    expect(isBodylessRow({ payload: { kind: 'adam_advisory', body: 'x' } })).toBe(false);
+    expect(isBodylessRow({ payload: { kind: 'adam_advisory' }, body: 'x' })).toBe(false); // column fallback
+    expect(isBodylessRow({ payload: {} })).toBe(false); // untyped -- counted separately, no double-count
+    expect(isBodylessRow({ payload: { kind: 'canary_request' } })).toBe(false); // mechanical, legitimately bodyless
+    expect(isBodylessRow({ payload: { kind: 'fence_notice' } })).toBe(false); // legitimately bodyless
+  });
+
+  it('isEmptySenderRow: true for a missing sender_session UNLESS sender_type is legitimately senderless', () => {
+    expect(isEmptySenderRow({ sender_session: null, sender_type: 'worker' })).toBe(true);
+    expect(isEmptySenderRow({ sender_session: '', sender_type: 'coordinator' })).toBe(true);
+    expect(isEmptySenderRow({ sender_session: null, sender_type: 'sweep' })).toBe(false); // resurfaceStalePending's own legitimate pattern
+    expect(isEmptySenderRow({ sender_session: 's1', sender_type: 'worker' })).toBe(false);
+  });
+});
+
+describe('computeRowViolationCounts — AC-1: independent per-class counts', () => {
+  it('reports zero for a clean window (AC-2)', () => {
+    const rows = [cleanRow(), cleanRow(), cleanRow()];
+    expect(computeRowViolationCounts(rows)).toEqual({ untyped_row: 0, bodyless_row: 0, empty_sender_row: 0 });
+  });
+
+  it('counts each class independently, not conflated into one number', () => {
+    const rows = [
+      cleanRow(),
+      cleanRow({ payload: {} }), // untyped
+      cleanRow({ payload: { kind: 'adam_advisory' }, body: null }), // bodyless
+      cleanRow({ sender_session: null, sender_type: 'worker' }), // empty sender
+      cleanRow({ sender_session: null, sender_type: 'worker' }), // empty sender (2nd)
+    ];
+    expect(computeRowViolationCounts(rows)).toEqual({ untyped_row: 1, bodyless_row: 1, empty_sender_row: 2 });
+  });
+
+  it('AC-3: a fixture reproducing ONLY the untyped-row class reports non-zero for that class only', () => {
+    const rows = [cleanRow(), cleanRow(), cleanRow({ payload: { kind: '' } })];
+    expect(computeRowViolationCounts(rows)).toEqual({ untyped_row: 1, bodyless_row: 0, empty_sender_row: 0 });
+  });
+
+  it('AC-3: a fixture reproducing ONLY the bodyless-row class reports non-zero for that class only', () => {
+    const rows = [cleanRow(), cleanRow(), cleanRow({ payload: { kind: 'coordinator_request' }, body: null })];
+    expect(computeRowViolationCounts(rows)).toEqual({ untyped_row: 0, bodyless_row: 1, empty_sender_row: 0 });
+  });
+
+  it('AC-3: a fixture reproducing ONLY the empty-sender-row class reports non-zero for that class only', () => {
+    const rows = [cleanRow(), cleanRow(), cleanRow({ sender_session: '', sender_type: 'coordinator' })];
+    expect(computeRowViolationCounts(rows)).toEqual({ untyped_row: 0, bodyless_row: 0, empty_sender_row: 1 });
+  });
+});
+
+describe('computeResurfaceDedupDrift — instance 9', () => {
+  function resurfaceRow(ledgerId, acknowledged) {
+    return {
+      id: 'r-' + Math.random().toString(36).slice(2),
+      payload: { kind: RESURFACE_KIND, ledger_id: ledgerId },
+      acknowledged_at: acknowledged ? new Date().toISOString() : null,
+    };
+  }
+
+  it('reports zero when every ledger item has at most one unacked resurface (AC-2 clean window)', () => {
+    const rows = [resurfaceRow('l1', false), resurfaceRow('l2', false), resurfaceRow('l3', true)];
+    expect(computeResurfaceDedupDrift(rows)).toBe(0);
+  });
+
+  it('AC-3: a fixture reproducing ONLY the resurface-dedup-drift class reports non-zero for that class only', () => {
+    // l1 has TWO concurrently-unacked resurfaces (yesterday's stale one + today's fresh one) — drift.
+    const rows = [resurfaceRow('l1', false), resurfaceRow('l1', false), resurfaceRow('l2', false)];
+    expect(computeResurfaceDedupDrift(rows)).toBe(1);
+  });
+
+  it('an acknowledged prior resurface does not count toward drift for its ledger item', () => {
+    const rows = [resurfaceRow('l1', true), resurfaceRow('l1', false)]; // only 1 concurrently-unacked
+    expect(computeResurfaceDedupDrift(rows)).toBe(0);
+  });
+
+  it('rows of a different kind are ignored (server-side kind filter is trusted, but pure core is defensive)', () => {
+    const rows = [
+      { id: 'x', payload: { kind: 'adam_advisory' }, acknowledged_at: null },
+      resurfaceRow('l1', false),
+    ];
+    expect(computeResurfaceDedupDrift(rows)).toBe(0);
+  });
+});
+
+describe('runLaneLintGauge — tick entry point, fail-open, read-only', () => {
+  function makeSupabase({ windowRows = [], resurfaceRows = [] } = {}) {
+    return {
+      from(table) {
+        return {
+          select() {
+            return {
+              gte() {
+                return {
+                  limit: () => Promise.resolve({ data: windowRows, error: null }),
+                  eq: () => ({
+                    gte: () => ({ limit: () => Promise.resolve({ data: resurfaceRows, error: null }) }),
+                  }),
+                };
+              },
+              eq() {
+                return { gte: () => ({ limit: () => Promise.resolve({ data: resurfaceRows, error: null }) }) };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  it('never throws even if the supabase client itself throws (fail-soft at the loader layer, matching relay-drop-gauge.cjs precedent)', async () => {
+    const throwingSupabase = { from() { throw new Error('DB unavailable'); } };
+    const result = await runLaneLintGauge(throwingSupabase);
+    expect(result).toEqual({ untyped_row: 0, bodyless_row: 0, empty_sender_row: 0, resurface_dedup_drift: 0, windowRows: 0 });
+  });
+
+  it('composes the row-level counts and the resurface-drift count into one report', async () => {
+    const windowRows = [cleanRow(), cleanRow({ payload: {} })]; // 1 untyped
+    const resurfaceRows = [
+      { payload: { kind: RESURFACE_KIND, ledger_id: 'l1' }, acknowledged_at: null },
+      { payload: { kind: RESURFACE_KIND, ledger_id: 'l1' }, acknowledged_at: null },
+    ]; // drift=1
+    const supabase = makeSupabase({ windowRows, resurfaceRows });
+    const result = await runLaneLintGauge(supabase);
+    expect(result.untyped_row).toBe(1);
+    expect(result.resurface_dedup_drift).toBe(1);
+    expect(result.windowRows).toBe(2);
+    expect(result.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
New `lib/coordination/lane-lint-gauge.cjs` — a READ-ONLY gauge querying `session_coordination` directly (no new table, no new RLS surface). Reports SEPARATE counts per violation class so a regression in any single class is individually visible:

- `untyped_row` — `payload.kind` missing/null/empty (instance 2)
- `bodyless_row` — `readCanonicalBody()` returns `''` on a non-mechanical, non-fence-kind row (instance 4 class)
- `empty_sender_row` — `sender_session` null/empty on a non-sweep-authored row (instance 1/6 class)
- `resurface_dedup_drift` — >1 concurrently-unacknowledged `solomon_ledger_pending_resurface` rows for the same `ledger_id` (instance 9 — the daily `payload->>dedup_key` only prevents a same-day repeat, not a stale unacked reminder from an earlier day coexisting with today's fresh one)

Mirrors the pure-core + IO-loader + tick-entrypoint shape of `lib/coordinator/relay-drop-gauge.cjs`, with one structural delta: zero writes (read/report only). CLI wrapper: `scripts/coordinator-lane-lint-gauge.cjs`.

Final PR of SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 (FR-6 of 6, following #6016 FR-3, #6018 FR-1/FR-2, #6020 FR-4/FR-5). Depends on FR-2's `readCanonicalBody` (merged in #6018).

## Test plan
- [x] `tests/unit/coordination/lane-lint-gauge.test.js` — 14 tests: independent per-class counting, clean-window zero, per-instance-class isolated synthetic fixtures, tick entrypoint fail-open
- [x] Live sanity check against the real DB (`node scripts/coordinator-lane-lint-gauge.cjs`) — ran successfully, produced plausible non-crashing counts
- [x] Custom classguard ESLint rules pass (read-only module, zero raw inserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)