### PR TITLE
fix(SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001): scope feedback authenticated SELECT (RLS gap)

### DIFF
--- a/database/migrations/20260712_feedback_authenticated_select_scope.sql
+++ b/database/migrations/20260712_feedback_authenticated_select_scope.sql
@@ -15,7 +15,12 @@
 -- user-feedback set).
 --
 -- THE FIX: mirror the already-scoped anon policy venture_user_select_feedback
--- exactly. Harness/machine rows are excluded by BOTH clauses independently
+-- exactly. NOTE (cross-SD coherence): that anon policy is itself STAGED for drop
+-- by the sibling cross-tenant SD (20260712_drop_venture_user_select_feedback_
+-- STAGED.sql) — once that applies, this policy is the sole instance of the
+-- type-scoped-but-not-caller-scoped predicate. The accepted residual (no
+-- per-venture ownership binding) is tracked for a follow-up SD at apply time.
+-- Harness/machine rows are excluded by BOTH clauses independently
 -- (defense-in-depth): machine feedback_type values don't match 'user_%', and
 -- lib/governance/emit-feedback.js exposes no venture_id parameter so every
 -- harness row has venture_id NULL.

--- a/database/migrations/20260712_feedback_authenticated_select_scope.sql
+++ b/database/migrations/20260712_feedback_authenticated_select_scope.sql
@@ -1,0 +1,39 @@
+-- Migration: 20260712_feedback_authenticated_select_scope
+-- SD: SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 (security / RLS, Tier 3)
+--
+-- TIER-2 (NON-ADDITIVE: DROP POLICY) — CHAIRMAN-GATED APPLY. Do NOT auto-apply.
+-- Apply only via the 3-factor ceremony (--issue-token -> MIGRATION_APPLY_TOKEN
+-- + the chairman's @approved-by attestation line, inserted by the scribe upon
+-- verbal approval, directly below this block). An apply without the attestation
+-- line MUST refuse.
+--
+-- THE GAP (verified live via pg_policies 2026-07-12, twice — Adam corr ab9559a9,
+-- re-verified at claim): select_feedback_policy = {authenticated} SELECT USING (true).
+-- Any logged-in user of any venture could read EVERY feedback row cross-venture,
+-- including harness-internal rows (chairman commissions, security findings —
+-- 7,909 rows visible; the scoped predicate reduces this to the genuine
+-- user-feedback set).
+--
+-- THE FIX: mirror the already-scoped anon policy venture_user_select_feedback
+-- exactly. Harness/machine rows are excluded by BOTH clauses independently
+-- (defense-in-depth): machine feedback_type values don't match 'user_%', and
+-- lib/governance/emit-feedback.js exposes no venture_id parameter so every
+-- harness row has venture_id NULL.
+--
+-- SCOPE ISOLATION: touches ONLY select_feedback_policy. The anon policies
+-- (owned by in-flight SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001) and the
+-- service-role-only write policies are deliberately not referenced. The service
+-- role bypasses RLS, so harness tooling is unaffected.
+--
+-- Fail-closed: RLS stays enabled throughout; DROP+CREATE in one transaction
+-- means no observable window, and any fault yields default-deny, never qual=true.
+
+BEGIN;
+
+DROP POLICY IF EXISTS select_feedback_policy ON public.feedback;
+
+CREATE POLICY select_feedback_policy ON public.feedback
+  FOR SELECT TO authenticated
+  USING (((feedback_type)::text LIKE 'user_%') AND (venture_id IS NOT NULL));
+
+COMMIT;

--- a/tests/unit/feedback-select-policy-migration.test.js
+++ b/tests/unit/feedback-select-policy-migration.test.js
@@ -26,11 +26,13 @@ describe('feedback authenticated-SELECT scope migration (SD-FDBK-FIX-FEEDBACK-SE
     expect(SQL).toMatch(/CREATE POLICY select_feedback_policy ON public\.feedback\s+FOR SELECT TO authenticated/);
   });
 
-  it('TS-2: scoped USING predicate carries BOTH clauses; no USING (true) survives', () => {
+  it('TS-2: scoped USING predicate pinned VERBATIM (adversarial mutant check: OR-for-AND passes clause-presence pins)', () => {
     const using = SQL.match(/USING \(([\s\S]*?)\);/);
     expect(using).toBeTruthy();
-    expect(using[1]).toContain("(feedback_type)::text LIKE 'user_%'");
-    expect(using[1]).toContain('venture_id IS NOT NULL');
+    // Full-string pin: an AND->OR mutant materially broadens the policy (every
+    // venture_id IS NOT NULL row becomes readable) while containing both clauses.
+    expect(using[1].replace(/\s+/g, ' ').trim())
+      .toBe("((feedback_type)::text LIKE 'user_%') AND (venture_id IS NOT NULL)");
     expect(SQL).not.toMatch(/USING\s*\(\s*true\s*\)/i);
   });
 
@@ -46,8 +48,11 @@ describe('feedback authenticated-SELECT scope migration (SD-FDBK-FIX-FEEDBACK-SE
     ]) {
       expect(SQL, `${foreign} belongs to another owner`).not.toContain(foreign);
     }
-    // No role broadening: only the authenticated SELECT is (re)created.
-    expect(SQL).not.toMatch(/TO (anon|public)\b/);
+    // No role broadening: the TO clause must be EXACTLY 'authenticated' (adversarial
+    // mutant check: 'TO authenticated, anon' evades a /TO (anon|public)/ pin).
+    const grantees = SQL.match(/FOR SELECT TO ([^\n]+)/i);
+    expect(grantees).toBeTruthy();
+    expect(grantees[1].trim().toLowerCase()).toBe('authenticated');
     expect(SQL.match(/CREATE POLICY/g)).toHaveLength(1);
   });
 

--- a/tests/unit/feedback-select-policy-migration.test.js
+++ b/tests/unit/feedback-select-policy-migration.test.js
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Migration-pin — SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001.
+ *
+ * Pins the RLS fix for the live cross-venture read gap on public.feedback
+ * (select_feedback_policy was {authenticated} SELECT USING (true)). The unit
+ * lane has no DB, so this pins the migration FILE: the scoped predicate must
+ * survive verbatim, no unpredicated authenticated SELECT may reappear, and the
+ * file must stay isolated from the sibling SD's anon policies.
+ */
+
+const RAW = readFileSync(
+  join(process.cwd(), 'database/migrations/20260712_feedback_authenticated_select_scope.sql'),
+  'utf8'
+);
+// Executable statements only — the header narrates the gap (quoting qual=true and
+// the sibling policy names), so negative pins must ignore `--` comment lines.
+const SQL = RAW.split('\n').filter((l) => !l.trim().startsWith('--')).join('\n');
+
+describe('feedback authenticated-SELECT scope migration (SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001)', () => {
+  it('TS-1: drops and recreates select_feedback_policy FOR SELECT TO authenticated', () => {
+    expect(SQL).toMatch(/DROP POLICY IF EXISTS select_feedback_policy ON public\.feedback/);
+    expect(SQL).toMatch(/CREATE POLICY select_feedback_policy ON public\.feedback\s+FOR SELECT TO authenticated/);
+  });
+
+  it('TS-2: scoped USING predicate carries BOTH clauses; no USING (true) survives', () => {
+    const using = SQL.match(/USING \(([\s\S]*?)\);/);
+    expect(using).toBeTruthy();
+    expect(using[1]).toContain("(feedback_type)::text LIKE 'user_%'");
+    expect(using[1]).toContain('venture_id IS NOT NULL');
+    expect(SQL).not.toMatch(/USING\s*\(\s*true\s*\)/i);
+  });
+
+  it('TS-3: sibling-scope isolation — anon and service_role policies never referenced', () => {
+    for (const foreign of [
+      'venture_user_select_feedback',
+      'telegram_bot_select_feedback',
+      'venture_user_insert_feedback',
+      'telegram_bot_insert_feedback',
+      'insert_feedback_policy',
+      'update_feedback_policy',
+      'delete_feedback_policy',
+    ]) {
+      expect(SQL, `${foreign} belongs to another owner`).not.toContain(foreign);
+    }
+    // No role broadening: only the authenticated SELECT is (re)created.
+    expect(SQL).not.toMatch(/TO (anon|public)\b/);
+    expect(SQL.match(/CREATE POLICY/g)).toHaveLength(1);
+  });
+
+  it('TS-4: tier-2 chairman-gate markers present; RLS never disabled; single transaction', () => {
+    expect(RAW).toMatch(/TIER-2 \(NON-ADDITIVE: DROP POLICY\) — CHAIRMAN-GATED APPLY/);
+    expect(RAW).toMatch(/@approved-by/); // ceremony documented; scribe fills the attestation at approval
+    expect(SQL).not.toMatch(/DISABLE ROW LEVEL SECURITY/i);
+    expect(SQL).toMatch(/^BEGIN;$/m);
+    expect(SQL).toMatch(/^COMMIT;$/m);
+  });
+
+  it('TS-2b: no WITH CHECK added (SELECT policies carry none)', () => {
+    expect(SQL).not.toMatch(/WITH CHECK/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces `select_feedback_policy` (authenticated, `USING (true)` — live cross-venture read gap incl. harness-internal rows) with the venture-scoped predicate mirroring `venture_user_select_feedback`
- Migration is TIER-2 chairman-gated: inert until the `@approved-by` scribe ceremony; apply + pg_policies readback happen post-approval
- Migration-pin unit test: predicate clauses, no `USING (true)`, sibling-scope isolation (anon/service_role policies untouched), gate markers

## Test plan
- `npx vitest run --project unit tests/unit/feedback-select-policy-migration.test.js` (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)