### PR TITLE
fix(SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001): scope P2 witness lookup by branch, close cross-repo pr_number collision

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -506,13 +506,16 @@ Promise.all([
   const result = await attemptAutoMerge({
     prNumber: <PR#>, repoOwner: owner, repoName: name,
     isTrustedRepo, witnessSupabase: supabase, workKey: '<SD-KEY or null>',
+    branch: '<branch-name>',
   });
   if (!result.ok) process.exit(result.exitCode || 1);
 });
 "
 ```
 
-SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B): `isTrustedRepo` here now also admits a venture repo whose `applications.trust_tier='trusted'` AND whose PR has independently passed the P1 admission + P2 witness + P3 CI subset of the mergeWork() ladder (`lib/ship/venture-trust-gate.mjs`) — platform repos (EHG/EHG_Engineer) are unaffected, still fast-pathed with zero DB lookup. `<SD-KEY or null>` is the same value passed to Step 5's `logFindings` call.
+SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B): `isTrustedRepo` here now also admits a venture repo whose `applications.trust_tier='trusted'` AND whose PR has independently passed the P1 admission + P2 witness + P3 CI subset of the mergeWork() ladder (`lib/ship/venture-trust-gate.mjs`) — platform repos (EHG/EHG_Engineer) are unaffected, still fast-pathed with zero DB lookup. `<SD-KEY or null>` and `<branch-name>` are the SAME values passed to Step 5's `logFindings` call.
+
+SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): `branch` is REQUIRED here — the P2 witness lookup (`ship_review_findings` has no repo column) is scoped by branch to avoid a cross-repo `pr_number` collision (confirmed live: two different trusted venture repos both had passing rows at the same PR number). Omitting `branch` fails the lookup CLOSED (P2 evaluates `not_evaluable`/`fail`, never a false pass) — it never falls back to the old unscoped match, so an omitted `branch` degrades safety toward refusing auto-merge, not toward a false pass.
 
 If the call exits non-zero, `/ship` MUST hard-fail and skip Step 6.3 / Step 6.5 / `/learn` / next-SD selection. Do NOT rescue the exit code.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -453,6 +453,8 @@ await logFindings({
 });
 ```
 
+`<branch-name>` here MUST be resolved programmatically, not assumed — run `gh pr view <PR#> --json headRefName --jq .headRefName` (or `git branch --show-current` if already checked out on the PR's branch) and substitute the literal result. Do not hand-type a remembered branch name — the P2 witness lookup this feeds (Step 6 below) is scoped by this exact string, so a stale/guessed value silently degrades the lookup to `not_evaluable` (fails closed, refuses auto-merge — not a false pass, but an avoidable refusal).
+
 This creates an audit record in `ship_review_findings` for every PR shipped through the gate.
 
 ---
@@ -506,7 +508,7 @@ Promise.all([
   const result = await attemptAutoMerge({
     prNumber: <PR#>, repoOwner: owner, repoName: name,
     isTrustedRepo, witnessSupabase: supabase, workKey: '<SD-KEY or null>',
-    branch: '<branch-name>',
+    branch: '<branch-name>', // resolve via gh pr view --json headRefName, same value as Step 5.5 above
   });
   if (!result.ok) process.exit(result.exitCode || 1);
 });
@@ -516,6 +518,8 @@ Promise.all([
 SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B): `isTrustedRepo` here now also admits a venture repo whose `applications.trust_tier='trusted'` AND whose PR has independently passed the P1 admission + P2 witness + P3 CI subset of the mergeWork() ladder (`lib/ship/venture-trust-gate.mjs`) — platform repos (EHG/EHG_Engineer) are unaffected, still fast-pathed with zero DB lookup. `<SD-KEY or null>` and `<branch-name>` are the SAME values passed to Step 5's `logFindings` call.
 
 SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): `branch` is REQUIRED here — the P2 witness lookup (`ship_review_findings` has no repo column) is scoped by branch to avoid a cross-repo `pr_number` collision (confirmed live: two different trusted venture repos both had passing rows at the same PR number). Omitting `branch` fails the lookup CLOSED (P2 evaluates `not_evaluable`/`fail`, never a false pass) — it never falls back to the old unscoped match, so an omitted `branch` degrades safety toward refusing auto-merge, not toward a false pass.
+
+KNOWN RESIDUAL LIMITATION (tracked, not silent): `branch` narrows the collision surface but is not itself a repo-unique key — two trusted repos could in principle share both a `pr_number` and a non-SD-scoped branch name (e.g. `main`). This is the exact reason `ship_review_findings` needs a real `repo` column; that durable fix is fast-follow `SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001` (chairman-gated migration + repo-scoped reads), explicitly authorized as a separate SD by the original LEAD RISK sub-agent so this fail-closed interim fix could ship without waiting on a schema migration.
 
 If the call exits non-zero, `/ship` MUST hard-fail and skip Step 6.3 / Step 6.5 / `/learn` / next-SD selection. Do NOT rescue the exit code.
 

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -269,6 +269,11 @@ export async function observeMergeWorkLadder({
   // SD-LEO-INFRA-SHIP-WITNESS-TRIO-001 (FR-3): optional, additive. Omitted by
   // every pre-existing caller — byte-identical behavior to before FR-3 (TR-3).
   adminOverride = false,
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: optional, additive — forwarded to
+  // P2's fetchReviewFinding so a live implementation can scope its lookup by
+  // branch and avoid a cross-repo pr_number collision. Callers that don't
+  // inject fetchReviewFinding (P2 already not_evaluable) are unaffected.
+  branch,
 }) {
   try {
     // FR-3: best-effort dual-key audit write for an admin-override merge, BEFORE
@@ -305,6 +310,7 @@ export async function observeMergeWorkLadder({
       // caller/merge leaves P4's escapeAuth sub-field absent (TR-3).
       adminOverride,
       checkEscapeAudit: adminOverride && supabase ? createEscapeAuditChecker(supabase) : undefined,
+      branch,
     });
     if (supabase) {
       await writeMergeWitnessTelemetry(supabase, verdict, {
@@ -367,6 +373,12 @@ export async function attemptAutoMerge({
   // (itself gated on SHIP_WITNESS_ENFORCE_MODE=enforce AND independently-computed readiness)
   // can ever cause a real pre-merge refusal here.
   enforcementDecision,
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): the PR's own head branch,
+  // forwarded through isTrustedRepo -> ...  -> P2's fetchReviewFinding so a live
+  // implementation can scope its ship_review_findings lookup and avoid a
+  // cross-repo pr_number collision (confirmed live: apexniche-ai/marketlens PR
+  // #2 and #5). Optional/additive — isPlatformRepo (the default) ignores it.
+  branch,
 }) {
   if (!prNumber) {
     return { ok: false, reason: 'prNumber required', exitCode: 2 };
@@ -381,7 +393,7 @@ export async function attemptAutoMerge({
   // through so an injected predicate can evaluate a per-PR witness (not just a
   // repo-level allowlist check). isPlatformRepo (the default) ignores the
   // extra args, so this is additive — existing 2-arg predicates are unaffected.
-  const trusted = await isTrustedRepo(repoOwner, repoName, prNumber, { workKey, tier });
+  const trusted = await isTrustedRepo(repoOwner, repoName, prNumber, { workKey, tier, branch });
   if (!allowExternalMerge && !trusted) {
     logger.warn(
       `⛔ Auto-merge refused for PR #${prNumber}: ${repoOwner || '?'}/${repoName || '?'} is not a platform repo. `
@@ -407,6 +419,7 @@ export async function attemptAutoMerge({
       repoOwner,
       repoName,
       checkProtection: (ro, rn) => detectBranchProtectionEnabled(ro, rn, 'main', runner),
+      branch,
     });
     const decision = await enforcementDecision({ verdict });
     if (decision?.action === 'block') {
@@ -462,7 +475,7 @@ export async function attemptAutoMerge({
       await observeMergeWorkLadder({
         prNumber, repoOwner, repoName, workKey, tier, runner, merged: true, verifyResult: { ok: true },
         lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
-        adminOverride: enforceAdmins,
+        adminOverride: enforceAdmins, branch,
       });
       return { ok: true, action: 'merged', adminUsed: enforceAdmins };
     }
@@ -489,7 +502,7 @@ export async function attemptAutoMerge({
     await observeMergeWorkLadder({
       prNumber, repoOwner, repoName, workKey, tier, runner, merged: true, verifyResult: { ok: true },
       lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
-      adminOverride: enforceAdmins,
+      adminOverride: enforceAdmins, branch,
     });
     return { ok: true, action: 'already-merged', adminUsed: enforceAdmins };
   }
@@ -508,7 +521,7 @@ export async function attemptAutoMerge({
   );
   await observeMergeWorkLadder({
     prNumber, repoOwner, repoName, workKey, tier, runner, merged: false, verifyResult: { ok: false },
-    lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
+    lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger, branch,
   });
   return {
     ok: false,

--- a/lib/ship/merge-witness-ladder.mjs
+++ b/lib/ship/merge-witness-ladder.mjs
@@ -99,15 +99,22 @@ function evaluateActorSeparation(finding, tier) {
  * — P2's own top-level pass/fail remains verdict-only, unchanged from before
  * FR-2, so existing evaluateEnforcementDecision() behavior on the /ship lane
  * does not regress (TR-3).
- * fetchReviewFinding(prNumber) => Promise<{verdict, metadata?}|null>.
+ * fetchReviewFinding(prNumber, {branch}) => Promise<{verdict, metadata?}|null>.
+ * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: branch is forwarded to
+ * fetchReviewFinding as an options object (additive — a legacy 1-arg
+ * fetchReviewFinding simply ignores it) so a live implementation can scope
+ * its lookup and avoid a cross-repo pr_number collision. This function does
+ * NOT itself enforce scoping — that is fetchReviewFinding's contract; see
+ * defaultFetchReviewFinding in venture-trust-gate.mjs for the fail-closed
+ * default.
  */
-export async function evaluateP2Witness({ prNumber, tier, fetchReviewFinding }) {
+export async function evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch }) {
   if (typeof fetchReviewFinding !== 'function') {
     return rung('P2', RUNG_STATUS.NOT_EVALUABLE, 'no fetchReviewFinding injected');
   }
   let finding;
   try {
-    finding = await fetchReviewFinding(prNumber);
+    finding = await fetchReviewFinding(prNumber, { branch });
   } catch (e) {
     return rung('P2', RUNG_STATUS.NOT_EVALUABLE, `lookup threw: ${e?.message || e}`);
   }
@@ -240,9 +247,13 @@ export async function evaluateMergeWorkLadder({
   // (byte-identical behavior to before FR-3, TR-3).
   adminOverride = false,
   checkEscapeAudit,
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: optional, additive — the PR's own
+  // head branch, forwarded to P2 so a live fetchReviewFinding can scope its
+  // ship_review_findings lookup and avoid a cross-repo pr_number collision.
+  branch,
 }) {
   const p1 = await evaluateP1Admission({ workKey, lookupWorkKeyReal });
-  const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding });
+  const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch });
   const p3 = evaluateP3CI({ statusCheckRollup });
   const p4 = await evaluateP4ProtectionIntegrity({ repoOwner, repoName, checkProtection, adminOverride, prNumber, checkEscapeAudit });
   const p5 = evaluateP5PostVerify({ merged, verifyResult });

--- a/lib/ship/venture-trust-gate.mjs
+++ b/lib/ship/venture-trust-gate.mjs
@@ -70,16 +70,33 @@ export async function defaultLookupWorkKeyReal(workKey, supabase) {
 }
 
 /**
- * P2 witness default: most recent ship_review_findings row for this PR.
- * Returns { verdict } or null (no row / query error).
+ * P2 witness default: most recent ship_review_findings row for this PR,
+ * scoped to the PR's own branch.
+ *
+ * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): the pre-fix version of
+ * this function matched by pr_number ALONE — small integers collide
+ * constantly across repos (confirmed live: apexniche-ai PR #2/#5 collided
+ * with MARKETLENS's passing rows at the same PR numbers), letting one
+ * venture repo's passing review witness-pass an ENTIRELY DIFFERENT repo's
+ * unreviewed PR through the VB-2 auto-merge trust gate. ship_review_findings
+ * has no repo column (see the chairman-gated Layer-2 migration for that),
+ * so this is scoped by branch instead — branch is 100% populated on every
+ * ship_review_findings row from the two live trusted-venture repos (verified
+ * against production data), unlike sd_key/workKey, which is a hand-filled
+ * ship.md placeholder ('<SD-KEY or null>') prone to write/read drift.
+ *
+ * FAIL-CLOSED (the core invariant): when branch is absent, this returns null
+ * (not_evaluable) — it NEVER falls back to the old pr_number-only match.
+ * Returns { verdict } or null (no row / query error / no branch supplied).
  */
-export async function defaultFetchReviewFinding(prNumber, supabase) {
-  if (!supabase || !prNumber) return null;
+export async function defaultFetchReviewFinding(prNumber, supabase, { branch } = {}) {
+  if (!supabase || !prNumber || !branch) return null;
   try {
     const { data, error } = await supabase
       .from('ship_review_findings')
       .select('verdict')
       .eq('pr_number', prNumber)
+      .eq('branch', branch)
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -96,11 +113,11 @@ export async function defaultFetchReviewFinding(prNumber, supabase) {
  * 'pass'. Never throws; any internal failure degrades to false (fail-closed).
  */
 export async function evaluateVenturePrWitness({
-  prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+  prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch,
 }) {
   try {
     const verdict = await evaluateMergeWorkLadder({
-      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch,
     });
     const byId = Object.fromEntries(verdict.rungs.map((r) => [r.id, r.status]));
     return byId.P1 === RUNG_STATUS.PASS && byId.P2 === RUNG_STATUS.PASS && byId.P3 === RUNG_STATUS.PASS;
@@ -124,9 +141,9 @@ export function createVentureTrustGate({
   fetchReviewFinding,
 } = {}) {
   const lookupWork = lookupWorkKeyReal || ((workKey) => defaultLookupWorkKeyReal(workKey, supabase));
-  const fetchFinding = fetchReviewFinding || ((prNumber) => defaultFetchReviewFinding(prNumber, supabase));
+  const fetchFinding = fetchReviewFinding || ((prNumber, opts) => defaultFetchReviewFinding(prNumber, supabase, opts));
 
-  return async function isTrustedRepoOrWitnessPassed(repoOwner, repoName, prNumber, { workKey, tier } = {}) {
+  return async function isTrustedRepoOrWitnessPassed(repoOwner, repoName, prNumber, { workKey, tier, branch } = {}) {
     if (isPlatformRepo(repoOwner, repoName)) return true;
     if (!prNumber) return false;
 
@@ -141,6 +158,7 @@ export function createVentureTrustGate({
       lookupWorkKeyReal: lookupWork,
       fetchReviewFinding: fetchFinding,
       statusCheckRollup,
+      branch,
     });
   };
 }

--- a/scripts/audit-borrowed-witness-rows.mjs
+++ b/scripts/audit-borrowed-witness-rows.mjs
@@ -30,7 +30,10 @@ function listMergedPRs(repo) {
 }
 
 export async function runAudit({ supabase } = {}) {
-  const sb = supabase || createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const sb = supabase || createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
 
   const { data: apps, error: appsErr } = await sb.from('applications').select('github_repo').eq('trust_tier', 'trusted').not('github_repo', 'is', null);
   if (appsErr) throw new Error(`applications query failed: ${appsErr.message}`);

--- a/scripts/audit-borrowed-witness-rows.mjs
+++ b/scripts/audit-borrowed-witness-rows.mjs
@@ -5,11 +5,14 @@
  * Read-only. Scoped to trust_tier='trusted' repos only (the only repos where
  * P2's witness result could have gated a real auto-merge decision via
  * lib/ship/venture-trust-gate.mjs). For every merged PR in a trusted repo,
- * checks whether ship_review_findings has a row for that PR's OWN branch. A
- * merged PR whose own branch has no row, but whose pr_number exists in the
- * table under a DIFFERENT branch with verdict='pass', is a "borrowed-row"
- * candidate — evidence the pre-fix pr_number-only lookup could have
- * witness-passed it off another repo's review.
+ * replicates the PRE-FIX query exactly (most-recent row for that pr_number,
+ * across ALL branches -- NOT "own branch wins if it exists": a PR whose own
+ * row is verdict='block'/'fail' could still have been borrow-passed if a
+ * NEWER same-pr_number row from a different branch existed, since the pre-fix
+ * lookup was order-by-created_at-desc-limit-1). If that most-recent row's
+ * branch differs from the PR's own branch AND its verdict is 'pass', it's a
+ * "borrowed-row" candidate — evidence the pre-fix pr_number-only lookup could
+ * have witness-passed it off another repo's (or branch's) review.
  *
  * This audit reports findings; it does NOT auto-remediate anything.
  *
@@ -49,15 +52,22 @@ export async function runAudit({ supabase } = {}) {
     if (prs === null) { report.skippedRepos.push(repo); continue; }
     for (const pr of prs) {
       report.checkedPRs++;
-      const ownRow = (findings || []).find((f) => f.pr_number === pr.number && f.branch === pr.headRefName);
-      if (ownRow) continue; // has its own row -- not a borrowed-row candidate.
-      const donorRow = (findings || [])
-        .filter((f) => f.pr_number === pr.number && f.branch !== pr.headRefName && f.verdict === 'pass')
+      // Replicate the PRE-FIX query exactly: .eq('pr_number', prNumber).order('created_at', desc).limit(1)
+      // -- most-recent-row-wins, across ALL branches, not "own branch wins if it exists". A PR whose own
+      // row is verdict='block' can still have been borrow-passed if a NEWER same-pr_number row from a
+      // different branch existed -- skipping on "has an own row" (regardless of its verdict/recency)
+      // missed exactly that case.
+      const mostRecentRow = (findings || [])
+        .filter((f) => f.pr_number === pr.number)
         .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
-      if (donorRow) {
+      if (!mostRecentRow) continue; // pre-fix lookup would have returned null too -- nothing to borrow.
+      if (mostRecentRow.branch === pr.headRefName) continue; // pre-fix lookup would have returned this PR's own row.
+      if (mostRecentRow.verdict === 'pass') {
+        const ownRow = (findings || []).find((f) => f.pr_number === pr.number && f.branch === pr.headRefName);
         report.borrowedRowCandidates.push({
           repo, prNumber: pr.number, ownBranch: pr.headRefName,
-          donorBranch: donorRow.branch, donorSdKey: donorRow.sd_key, donorCreatedAt: donorRow.created_at,
+          hasOwnRow: Boolean(ownRow), ownVerdict: ownRow?.verdict ?? null,
+          donorBranch: mostRecentRow.branch, donorSdKey: mostRecentRow.sd_key, donorCreatedAt: mostRecentRow.created_at,
         });
       }
     }
@@ -77,8 +87,11 @@ function printReport(report) {
   } else {
     console.log(`[audit] RESULT: ${report.borrowedRowCandidates.length} borrowed-row candidate(s) found:`);
     for (const c of report.borrowedRowCandidates) {
-      console.log(`  - ${c.repo} PR#${c.prNumber} (branch ${c.ownBranch}) has NO own ship_review_findings row, `
-        + `but pr_number=${c.prNumber} has a verdict=pass row on branch ${c.donorBranch} (sd_key=${c.donorSdKey}, ${c.donorCreatedAt}).`);
+      const ownDesc = c.hasOwnRow
+        ? `has its OWN row (verdict=${c.ownVerdict}) but it was NOT the most recent`
+        : 'has NO own ship_review_findings row';
+      console.log(`  - ${c.repo} PR#${c.prNumber} (branch ${c.ownBranch}) ${ownDesc}, `
+        + `so the pre-fix query would have returned pr_number=${c.prNumber}'s NEWER verdict=pass row on branch ${c.donorBranch} instead (sd_key=${c.donorSdKey}, ${c.donorCreatedAt}).`);
     }
   }
 }

--- a/scripts/audit-borrowed-witness-rows.mjs
+++ b/scripts/audit-borrowed-witness-rows.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Bounded retroactive audit (SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001, FR-3).
+ *
+ * Read-only. Scoped to trust_tier='trusted' repos only (the only repos where
+ * P2's witness result could have gated a real auto-merge decision via
+ * lib/ship/venture-trust-gate.mjs). For every merged PR in a trusted repo,
+ * checks whether ship_review_findings has a row for that PR's OWN branch. A
+ * merged PR whose own branch has no row, but whose pr_number exists in the
+ * table under a DIFFERENT branch with verdict='pass', is a "borrowed-row"
+ * candidate — evidence the pre-fix pr_number-only lookup could have
+ * witness-passed it off another repo's review.
+ *
+ * This audit reports findings; it does NOT auto-remediate anything.
+ *
+ * Usage: node scripts/audit-borrowed-witness-rows.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { execFileSync } from 'node:child_process';
+
+function listMergedPRs(repo) {
+  try {
+    const out = execFileSync('gh', ['pr', 'list', '-R', repo, '--state', 'merged', '--limit', '200', '--json', 'number,headRefName'], { encoding: 'utf-8' });
+    return JSON.parse(out);
+  } catch (e) {
+    console.warn(`[audit] gh pr list failed for ${repo} (non-fatal, skipping): ${e?.message || e}`);
+    return null;
+  }
+}
+
+export async function runAudit({ supabase } = {}) {
+  const sb = supabase || createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: apps, error: appsErr } = await sb.from('applications').select('github_repo').eq('trust_tier', 'trusted').not('github_repo', 'is', null);
+  if (appsErr) throw new Error(`applications query failed: ${appsErr.message}`);
+  const trustedRepos = (apps || []).map((r) => r.github_repo.replace(/\.git$/i, ''));
+
+  const { data: findings, error: findErr } = await sb.from('ship_review_findings').select('pr_number, branch, verdict, sd_key, created_at');
+  if (findErr) throw new Error(`ship_review_findings query failed: ${findErr.message}`);
+
+  const report = { trustedRepos, checkedPRs: 0, borrowedRowCandidates: [], skippedRepos: [] };
+
+  for (const repo of trustedRepos) {
+    const prs = listMergedPRs(repo);
+    if (prs === null) { report.skippedRepos.push(repo); continue; }
+    for (const pr of prs) {
+      report.checkedPRs++;
+      const ownRow = (findings || []).find((f) => f.pr_number === pr.number && f.branch === pr.headRefName);
+      if (ownRow) continue; // has its own row -- not a borrowed-row candidate.
+      const donorRow = (findings || [])
+        .filter((f) => f.pr_number === pr.number && f.branch !== pr.headRefName && f.verdict === 'pass')
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+      if (donorRow) {
+        report.borrowedRowCandidates.push({
+          repo, prNumber: pr.number, ownBranch: pr.headRefName,
+          donorBranch: donorRow.branch, donorSdKey: donorRow.sd_key, donorCreatedAt: donorRow.created_at,
+        });
+      }
+    }
+  }
+
+  return report;
+}
+
+function printReport(report) {
+  console.log(`[audit] trusted repos: ${report.trustedRepos.join(', ') || '(none)'}`);
+  if (report.skippedRepos.length > 0) {
+    console.log(`[audit] SKIPPED (gh pr list failed): ${report.skippedRepos.join(', ')}`);
+  }
+  console.log(`[audit] merged PRs checked: ${report.checkedPRs}`);
+  if (report.borrowedRowCandidates.length === 0) {
+    console.log('[audit] RESULT: 0 borrowed-row candidates found.');
+  } else {
+    console.log(`[audit] RESULT: ${report.borrowedRowCandidates.length} borrowed-row candidate(s) found:`);
+    for (const c of report.borrowedRowCandidates) {
+      console.log(`  - ${c.repo} PR#${c.prNumber} (branch ${c.ownBranch}) has NO own ship_review_findings row, `
+        + `but pr_number=${c.prNumber} has a verdict=pass row on branch ${c.donorBranch} (sd_key=${c.donorSdKey}, ${c.donorCreatedAt}).`);
+    }
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('audit-borrowed-witness-rows.mjs')) {
+  runAudit().then(printReport).catch((e) => { console.error('[audit] FATAL', e); process.exit(1); });
+}

--- a/scripts/ship-witness-retroactive.mjs
+++ b/scripts/ship-witness-retroactive.mjs
@@ -23,6 +23,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'node:url';
+import { execFileSync } from 'node:child_process';
 import { evaluateMergeWorkLadder } from '../lib/ship/merge-witness-ladder.mjs';
 import { writeMergeWitnessTelemetry } from '../lib/ship/merge-witness-telemetry.mjs';
 import { verifyMerged, fetchStatusCheckRollup, detectBranchProtectionEnabled } from '../lib/ship/auto-merge.mjs';
@@ -41,6 +42,20 @@ function parseArgs(argv) {
   return out;
 }
 
+/**
+ * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: resolve the PR's own head branch so
+ * the P2 witness lookup can be scoped by it (see defaultFetchReviewFinding's
+ * fail-closed contract) — a merged PR's branch may already be deleted, so a
+ * lookup failure here is expected/non-fatal, not an error.
+ */
+export function resolvePrBranch(prNumber, repoOwner, repoName) {
+  try {
+    return execFileSync('gh', ['pr', 'view', String(prNumber), '-R', `${repoOwner}/${repoName}`, '--json', 'headRefName', '--jq', '.headRefName'], { encoding: 'utf-8' }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function runRetroactiveEvaluation({ repo, pr, workKey, tier, reason, supabase }) {
   const [repoOwner, repoName] = repo.split('/');
   const prNumber = Number(pr);
@@ -48,13 +63,14 @@ export async function runRetroactiveEvaluation({ repo, pr, workKey, tier, reason
   const merged = verifyMerged(prNumber, repoOwner, repoName);
   const verifyResult = { ok: merged };
   const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName);
+  const branch = resolvePrBranch(prNumber, repoOwner, repoName);
 
   const verdict = await evaluateMergeWorkLadder({
     prNumber,
     workKey: workKey ?? null,
     tier: tier || 'standard',
     lookupWorkKeyReal: (wk) => defaultLookupWorkKeyReal(wk, supabase),
-    fetchReviewFinding: (n) => defaultFetchReviewFinding(n, supabase),
+    fetchReviewFinding: (n, opts) => defaultFetchReviewFinding(n, supabase, opts),
     statusCheckRollup,
     merged,
     verifyResult,
@@ -63,6 +79,7 @@ export async function runRetroactiveEvaluation({ repo, pr, workKey, tier, reason
     repoOwner,
     repoName,
     checkProtection: detectBranchProtectionEnabled,
+    branch,
   });
 
   verdict.rungs = [

--- a/tests/unit/ship/audit-borrowed-witness-rows.test.js
+++ b/tests/unit/ship/audit-borrowed-witness-rows.test.js
@@ -1,0 +1,68 @@
+/**
+ * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (FR-3): bounded retroactive audit.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const H = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock('node:child_process', () => ({ execFileSync: H.execFileSyncMock }));
+
+const { runAudit } = await import('../../../scripts/audit-borrowed-witness-rows.mjs');
+
+function makeSupabase({ applications, findings }) {
+  return {
+    from: (table) => {
+      if (table === 'applications') {
+        return { select: () => ({ eq: () => ({ not: () => Promise.resolve({ data: applications, error: null }) }) }) };
+      }
+      if (table === 'ship_review_findings') {
+        return { select: () => Promise.resolve({ data: findings, error: null }) };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+describe('runAudit', () => {
+  it('finds zero candidates when every merged PR has its own branch-matching row', async () => {
+    H.execFileSyncMock.mockReturnValue(JSON.stringify([{ number: 9, headRefName: 'feat/apex-D1' }]));
+    const supabase = makeSupabase({
+      applications: [{ github_repo: 'rickfelix/apexniche-ai' }],
+      findings: [{ pr_number: 9, branch: 'feat/apex-D1', verdict: 'pass', sd_key: 'SD-A', created_at: '2026-07-01' }],
+    });
+    const report = await runAudit({ supabase });
+    expect(report.borrowedRowCandidates).toEqual([]);
+    expect(report.checkedPRs).toBe(1);
+  });
+
+  it('flags a borrowed-row candidate: merged PR has no own-branch row but pr_number matches another branch pass row', async () => {
+    H.execFileSyncMock.mockImplementation((cmd, args) => {
+      const repo = args[args.indexOf('-R') + 1];
+      if (repo === 'rickfelix/apexniche-ai') return JSON.stringify([{ number: 9, headRefName: 'feat/apex-D1' }]);
+      return JSON.stringify([]);
+    });
+    const supabase = makeSupabase({
+      applications: [{ github_repo: 'rickfelix/apexniche-ai' }, { github_repo: 'rickfelix/marketlens' }],
+      findings: [{ pr_number: 9, branch: 'feat/ml-I1', verdict: 'pass', sd_key: 'SD-MARKETLENS-I1', created_at: '2026-07-03' }],
+    });
+    const report = await runAudit({ supabase });
+    expect(report.borrowedRowCandidates).toHaveLength(1);
+    expect(report.borrowedRowCandidates[0]).toMatchObject({
+      repo: 'rickfelix/apexniche-ai', prNumber: 9, ownBranch: 'feat/apex-D1', donorBranch: 'feat/ml-I1', donorSdKey: 'SD-MARKETLENS-I1',
+    });
+  });
+
+  it('does NOT flag a merged PR with no own row when no donor (pass) row exists either', async () => {
+    H.execFileSyncMock.mockReturnValue(JSON.stringify([{ number: 42, headRefName: 'feat/unreviewed' }]));
+    const supabase = makeSupabase({ applications: [{ github_repo: 'rickfelix/apexniche-ai' }], findings: [] });
+    const report = await runAudit({ supabase });
+    expect(report.borrowedRowCandidates).toEqual([]);
+  });
+
+  it('skips (not crashes) a repo whose gh pr list call fails', async () => {
+    H.execFileSyncMock.mockImplementation(() => { throw new Error('gh auth error'); });
+    const supabase = makeSupabase({ applications: [{ github_repo: 'rickfelix/apexniche-ai' }], findings: [] });
+    const report = await runAudit({ supabase });
+    expect(report.skippedRepos).toEqual(['rickfelix/apexniche-ai']);
+    expect(report.checkedPRs).toBe(0);
+  });
+});

--- a/tests/unit/ship/audit-borrowed-witness-rows.test.js
+++ b/tests/unit/ship/audit-borrowed-witness-rows.test.js
@@ -47,7 +47,8 @@ describe('runAudit', () => {
     const report = await runAudit({ supabase });
     expect(report.borrowedRowCandidates).toHaveLength(1);
     expect(report.borrowedRowCandidates[0]).toMatchObject({
-      repo: 'rickfelix/apexniche-ai', prNumber: 9, ownBranch: 'feat/apex-D1', donorBranch: 'feat/ml-I1', donorSdKey: 'SD-MARKETLENS-I1',
+      repo: 'rickfelix/apexniche-ai', prNumber: 9, ownBranch: 'feat/apex-D1', hasOwnRow: false,
+      donorBranch: 'feat/ml-I1', donorSdKey: 'SD-MARKETLENS-I1',
     });
   });
 
@@ -64,5 +65,35 @@ describe('runAudit', () => {
     const report = await runAudit({ supabase });
     expect(report.skippedRepos).toEqual(['rickfelix/apexniche-ai']);
     expect(report.checkedPRs).toBe(0);
+  });
+
+  it('flags a borrowed-row candidate EVEN WHEN the PR has its own row, if a NEWER cross-branch pass row exists (replicates pre-fix most-recent-wins query)', async () => {
+    H.execFileSyncMock.mockReturnValue(JSON.stringify([{ number: 9, headRefName: 'feat/apex-D1' }]));
+    const supabase = makeSupabase({
+      applications: [{ github_repo: 'rickfelix/apexniche-ai' }],
+      findings: [
+        { pr_number: 9, branch: 'feat/apex-D1', verdict: 'block', sd_key: 'SD-APEX-D1', created_at: '2026-07-01T00:00:00Z' },
+        { pr_number: 9, branch: 'feat/ml-I1', verdict: 'pass', sd_key: 'SD-MARKETLENS-I1', created_at: '2026-07-03T00:00:00Z' },
+      ],
+    });
+    const report = await runAudit({ supabase });
+    expect(report.borrowedRowCandidates).toHaveLength(1);
+    expect(report.borrowedRowCandidates[0]).toMatchObject({
+      prNumber: 9, ownBranch: 'feat/apex-D1', hasOwnRow: true, ownVerdict: 'block',
+      donorBranch: 'feat/ml-I1', donorSdKey: 'SD-MARKETLENS-I1',
+    });
+  });
+
+  it('does NOT flag when the own-branch row IS the most recent row, even if older cross-branch pass rows exist', async () => {
+    H.execFileSyncMock.mockReturnValue(JSON.stringify([{ number: 9, headRefName: 'feat/apex-D1' }]));
+    const supabase = makeSupabase({
+      applications: [{ github_repo: 'rickfelix/apexniche-ai' }],
+      findings: [
+        { pr_number: 9, branch: 'feat/ml-I1', verdict: 'pass', sd_key: 'SD-MARKETLENS-I1', created_at: '2026-07-01T00:00:00Z' },
+        { pr_number: 9, branch: 'feat/apex-D1', verdict: 'pass', sd_key: 'SD-APEX-D1', created_at: '2026-07-03T00:00:00Z' },
+      ],
+    });
+    const report = await runAudit({ supabase });
+    expect(report.borrowedRowCandidates).toEqual([]);
   });
 });

--- a/tests/unit/ship/merge-witness-ladder.test.js
+++ b/tests/unit/ship/merge-witness-ladder.test.js
@@ -102,6 +102,26 @@ describe('evaluateP2Witness', () => {
     expect(r.status).toBe(RUNG_STATUS.FAIL);
     expect(r.actorSeparation.status).toBe(RUNG_STATUS.PASS);
   });
+
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: branch is forwarded to
+  // fetchReviewFinding as an options object (additive, non-breaking) so a
+  // live implementation can scope its lookup.
+  it('forwards branch to fetchReviewFinding as {branch}', async () => {
+    let seen;
+    await evaluateP2Witness({
+      prNumber: 123, tier: 'standard', branch: 'feat/foo',
+      fetchReviewFinding: async (prNumber, opts) => { seen = { prNumber, opts }; return { verdict: 'pass' }; },
+    });
+    expect(seen).toEqual({ prNumber: 123, opts: { branch: 'feat/foo' } });
+  });
+
+  it('a legacy 1-arg fetchReviewFinding (ignores the second param) is unaffected', async () => {
+    const r = await evaluateP2Witness({
+      prNumber: 123, tier: 'standard', branch: 'feat/foo',
+      fetchReviewFinding: async (prNumber) => (prNumber === 123 ? { verdict: 'pass' } : null),
+    });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+  });
 });
 
 describe('evaluateP3CI', () => {

--- a/tests/unit/ship/ship-witness-retroactive-branch-scoping.test.js
+++ b/tests/unit/ship/ship-witness-retroactive-branch-scoping.test.js
@@ -1,0 +1,83 @@
+/**
+ * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (FR-2): scripts/ship-witness-retroactive.mjs
+ * is a SECOND consumer that independently wires defaultFetchReviewFinding — it must
+ * inherit the same branch-scoping fix as the live-gating venture-trust-gate.mjs path,
+ * not just the CLI's original behavior.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const H = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  spawnSyncMock: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: H.execFileSyncMock,
+  spawnSync: H.spawnSyncMock,
+}));
+
+const { resolvePrBranch, runRetroactiveEvaluation } = await import('../../../scripts/ship-witness-retroactive.mjs');
+
+describe('resolvePrBranch', () => {
+  it('resolves the head branch via gh pr view -R <repo>', () => {
+    H.execFileSyncMock.mockReturnValueOnce('feat/apex-D1\n');
+    const branch = resolvePrBranch(9, 'rickfelix', 'apexniche-ai');
+    expect(branch).toBe('feat/apex-D1');
+    expect(H.execFileSyncMock).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'view', '9', '-R', 'rickfelix/apexniche-ai', '--json', 'headRefName', '--jq', '.headRefName'],
+      expect.any(Object),
+    );
+  });
+
+  it('returns null (not a fabricated value) when the gh call fails — e.g. branch already deleted post-merge', () => {
+    H.execFileSyncMock.mockImplementationOnce(() => { throw new Error('gh: not found'); });
+    expect(resolvePrBranch(9, 'rickfelix', 'apexniche-ai')).toBeNull();
+  });
+
+  it('returns null on an empty result', () => {
+    H.execFileSyncMock.mockReturnValueOnce('\n');
+    expect(resolvePrBranch(9, 'rickfelix', 'apexniche-ai')).toBeNull();
+  });
+});
+
+describe('runRetroactiveEvaluation — branch threading (FR-2)', () => {
+  it('threads the resolved branch into evaluateMergeWorkLadder so P2 is scoped, not pr_number-only', async () => {
+    // Branch resolution goes through execFileSync (resolvePrBranch); verifyMerged
+    // and fetchStatusCheckRollup go through spawnSync (auto-merge.mjs's defaultRunner)
+    // — the hoisted spawnSync mock's default {status:0, stdout:''} stub degrades both
+    // to their safe empty-result paths (merged=false, statusCheckRollup=[]).
+    H.execFileSyncMock.mockReturnValueOnce('feat/apex-D1\n');
+
+    let seenBranch;
+    const findingsRows = [
+      { pr_number: 9, branch: 'feat/ml-I1', verdict: 'pass' },
+      { pr_number: 9, branch: 'feat/apex-D1', verdict: 'block' },
+    ];
+    const supabase = {
+      from: (table) => {
+        if (table !== 'ship_review_findings') throw new Error(`unexpected table ${table}`);
+        const builder = {
+          select: () => builder,
+          eq: (col, val) => { builder._f = { ...(builder._f || {}), [col]: val }; if (col === 'branch') seenBranch = val; return builder; },
+          order: () => builder,
+          limit: () => builder,
+          maybeSingle: () => {
+            const f = builder._f || {};
+            const row = findingsRows.find((r) => Object.entries(f).every(([k, v]) => r[k] === v));
+            return Promise.resolve({ data: row ?? null, error: null });
+          },
+        };
+        return builder;
+      },
+    };
+
+    const result = await runRetroactiveEvaluation({
+      repo: 'rickfelix/apexniche-ai', pr: '9', workKey: null, tier: 'standard', reason: 'test', supabase,
+    });
+
+    expect(seenBranch).toBe('feat/apex-D1');
+    // apex's OWN row is verdict='block' -- must not witness-pass off marketlens's row.
+    expect(result.witnessPass).toBe(false);
+  });
+});

--- a/tests/unit/ship/venture-trust-gate.test.js
+++ b/tests/unit/ship/venture-trust-gate.test.js
@@ -112,38 +112,85 @@ describe('defaultLookupWorkKeyReal', () => {
 });
 
 describe('defaultFetchReviewFinding', () => {
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: the mock builder tracks every
+  // .eq() call so tests can assert the query is scoped by BOTH pr_number and
+  // branch, not pr_number alone (the pre-fix vulnerability).
   function makeFindingSupabase(row) {
-    return {
+    const eqCalls = [];
+    const supabase = {
       from: (table) => {
         expect(table).toBe('ship_review_findings');
-        return {
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  maybeSingle: () => Promise.resolve({ data: row, error: null }),
-                }),
-              }),
-            }),
-          }),
+        const builder = {
+          select: () => builder,
+          eq: (col, val) => { eqCalls.push([col, val]); return builder; },
+          order: () => builder,
+          limit: () => builder,
+          maybeSingle: () => Promise.resolve({ data: row, error: null }),
         };
+        return builder;
       },
     };
+    return { supabase, eqCalls };
   }
 
-  it('returns the most recent verdict', async () => {
-    const supabase = makeFindingSupabase({ verdict: 'pass' });
-    expect(await defaultFetchReviewFinding(42, supabase)).toEqual({ verdict: 'pass' });
+  it('returns the most recent verdict when branch matches', async () => {
+    const { supabase, eqCalls } = makeFindingSupabase({ verdict: 'pass' });
+    expect(await defaultFetchReviewFinding(42, supabase, { branch: 'feat/foo' })).toEqual({ verdict: 'pass' });
+    expect(eqCalls).toEqual([['pr_number', 42], ['branch', 'feat/foo']]);
   });
 
   it('returns null when no row found', async () => {
-    const supabase = makeFindingSupabase(null);
-    expect(await defaultFetchReviewFinding(42, supabase)).toBeNull();
+    const { supabase } = makeFindingSupabase(null);
+    expect(await defaultFetchReviewFinding(42, supabase, { branch: 'feat/foo' })).toBeNull();
   });
 
   it('returns null on query error', async () => {
-    const supabase = { from: () => ({ select: () => ({ eq: () => ({ order: () => ({ limit: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) }) }) };
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) }) }) }) };
+    expect(await defaultFetchReviewFinding(42, supabase, { branch: 'feat/foo' })).toBeNull();
+  });
+
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): the core fail-closed
+  // invariant — branch absent/undefined must NEVER fall back to the old
+  // pr_number-only match, regardless of what the DB would have returned.
+  it('FAIL-CLOSED: returns null when branch is omitted, even if a row would match on pr_number alone', async () => {
+    const { supabase } = makeFindingSupabase({ verdict: 'pass' });
     expect(await defaultFetchReviewFinding(42, supabase)).toBeNull();
+    expect(await defaultFetchReviewFinding(42, supabase, {})).toBeNull();
+    expect(await defaultFetchReviewFinding(42, supabase, { branch: null })).toBeNull();
+  });
+
+  // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: the live witness case from Adam's
+  // adjudication — two different repos both had a pr_number=9 (and #2, #5)
+  // passing row. Confirms branch scoping prevents the cross-repo match.
+  it('cross-repo collision: a differently-branched row at the same pr_number never matches', async () => {
+    // Simulate: apexniche-ai PR#9 on branch feat/apex-D1 queries for its own
+    // finding, but the DB's most-recent row for pr_number=9 is MARKETLENS's
+    // (branch feat/ml-I1). A real Supabase .eq('branch', ...) filter would
+    // exclude it; assert our mock reflects that filtering intent.
+    const eqCalls = [];
+    const supabase = {
+      from: () => {
+        const builder = {
+          select: () => builder,
+          eq: (col, val) => {
+            eqCalls.push([col, val]);
+            // Simulate a real branch-scoped query: only the matching row is returned.
+            return builder;
+          },
+          order: () => builder,
+          limit: () => builder,
+          maybeSingle: () => {
+            const branchFilter = eqCalls.find(([c]) => c === 'branch')?.[1];
+            const row = branchFilter === 'feat/apex-D1' ? { verdict: 'fail' } : null; // apex's OWN row never passed
+            return Promise.resolve({ data: row, error: null });
+          },
+        };
+        return builder;
+      },
+    };
+    const result = await defaultFetchReviewFinding(9, supabase, { branch: 'feat/apex-D1' });
+    expect(result).toEqual({ verdict: 'fail' }); // apex's own (failing) row, NEVER marketlens's passing row
+    expect(eqCalls).toContainEqual(['branch', 'feat/apex-D1']);
   });
 });
 
@@ -264,6 +311,86 @@ describe('createVentureTrustGate', () => {
     const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' }]);
     const gate = createVentureTrustGate({ supabase });
     const result = await gate('rickfelix', 'marketlens', undefined, {});
+    expect(result).toBe(false);
+  });
+});
+
+// SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY, TS-1): reproduces the
+// LIVE cross-repo collision from Adam's adjudication (coordinator corr
+// cf4f94a9) end-to-end through createVentureTrustGate's OWN default
+// fetchReviewFinding (defaultFetchReviewFinding) — not an injected stub —
+// against a single shared Supabase mock holding rows from BOTH trust_tier=
+// 'trusted' venture repos (apexniche-ai, marketlens), matching production
+// where both live under the same consolidated Supabase project.
+describe('live cross-repo collision — apexniche-ai vs marketlens (TS-1)', () => {
+  /** One shared "DB" backing both applications and ship_review_findings. */
+  function makeSharedVentureDb({ applications, findings }) {
+    return {
+      from: (table) => {
+        if (table === 'applications') {
+          return { select: () => ({ not: () => Promise.resolve({ data: applications, error: null }) }) };
+        }
+        if (table === 'ship_review_findings') {
+          const builder = {
+            select: () => builder,
+            eq: (col, val) => { builder._filters = { ...(builder._filters || {}), [col]: val }; return builder; },
+            order: () => builder,
+            limit: () => builder,
+            maybeSingle: () => {
+              const f = builder._filters || {};
+              // Most-recent-first among rows matching ALL applied .eq() filters.
+              const matches = findings
+                .filter((r) => Object.entries(f).every(([k, v]) => r[k] === v))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              return Promise.resolve({ data: matches[0] ?? null, error: null });
+            },
+          };
+          return builder;
+        }
+        throw new Error(`unexpected table ${table}`);
+      },
+    };
+  }
+
+  // The exact live shape: two trusted repos, colliding pr_number=9 (also
+  // reproduced at #2/#5 per RISK's live finding — #9 suffices to prove the
+  // fix; the query logic is identical for any colliding number).
+  const APPLICATIONS = [
+    { trust_tier: 'trusted', github_repo: 'rickfelix/apexniche-ai' },
+    { trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' },
+  ];
+  const FINDINGS = [
+    { pr_number: 9, branch: 'feat/ml-I1', sd_key: 'SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-I1', verdict: 'pass', created_at: '2026-07-03T00:00:00Z' },
+    { pr_number: 9, branch: 'feat/apex-D1', sd_key: 'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-D1', verdict: 'block', created_at: '2026-07-11T00:00:00Z' },
+  ];
+
+  it('BEFORE the fix would have been exploitable: apexniche-ai PR#9 (own review=block) never inherits marketlens PR#9 (verdict=pass)', async () => {
+    const supabase = makeSharedVentureDb({ applications: APPLICATIONS, findings: FINDINGS });
+    const gate = createVentureTrustGate({ supabase, fetchStatusCheckRollup: async () => GREEN_ROLLUP, lookupWorkKeyReal: async () => true });
+    const result = await gate('rickfelix', 'apexniche-ai', 9, {
+      workKey: 'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-D1', tier: 'standard', branch: 'feat/apex-D1',
+    });
+    // apex's OWN row is verdict='block' -- a correctly-scoped lookup must
+    // return false, not fall through to marketlens's unrelated passing row.
+    expect(result).toBe(false);
+  });
+
+  it('marketlens PR#9 (own review=pass) correctly witness-passes on its own row', async () => {
+    const supabase = makeSharedVentureDb({ applications: APPLICATIONS, findings: FINDINGS });
+    const gate = createVentureTrustGate({ supabase, fetchStatusCheckRollup: async () => GREEN_ROLLUP, lookupWorkKeyReal: async () => true });
+    const result = await gate('rickfelix', 'marketlens', 9, {
+      workKey: 'SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-I1', tier: 'standard', branch: 'feat/ml-I1',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('FAIL-CLOSED: omitting branch on a trusted-tier venture repo never witness-passes, even though a same-numbered pass row exists in the shared DB', async () => {
+    const supabase = makeSharedVentureDb({ applications: APPLICATIONS, findings: FINDINGS });
+    const gate = createVentureTrustGate({ supabase, fetchStatusCheckRollup: async () => GREEN_ROLLUP, lookupWorkKeyReal: async () => true });
+    const result = await gate('rickfelix', 'apexniche-ai', 9, {
+      workKey: 'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-D1', tier: 'standard',
+      // branch omitted entirely -- this is the pre-fix vulnerable call shape.
+    });
     expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- **SECURITY**: `ship_review_findings` has no `repo` column, so the P2 witness lookup (`defaultFetchReviewFinding`) matched a PR's review verdict by `pr_number` alone. Confirmed live: `rickfelix/apexniche-ai` and `rickfelix/marketlens` (both `trust_tier='trusted'`) each had PRs at the same number (#2, #5), letting one repo's review verdict pass off as another's.
- Fix is fail-closed: the lookup now requires `branch` and scopes by `pr_number` AND `branch`; omitting `branch` returns `null` — it never falls back to the old unscoped match.
- Threaded `branch` (additive options-object param) through `lib/ship/merge-witness-ladder.mjs`, `lib/ship/venture-trust-gate.mjs`, `lib/ship/auto-merge.mjs`, `.claude/commands/ship.md` Step 6, and the second independent consumer `scripts/ship-witness-retroactive.mjs` (new `resolvePrBranch` via `gh pr view`).
- Added `scripts/audit-borrowed-witness-rows.mjs`, a bounded read-only retroactive audit. Run against production: found 5 real "borrowed-row" candidates (apexniche-ai PR#3/#4, marketlens PR#1/#6/#7) — reported to the coordinator separately.
- FR-4/5/6 (chairman-gated `repo` column migration, `ship.md` hoist, repo-scoped reads) descoped to fast-follow `SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001` per LEAD sub-agent guidance — Layer 1 (this fix) must not be gated behind Layer 2's migration.

## Test plan
- [x] `npx vitest run tests/unit/ship/` — 224/224 pass, including new fail-closed and live-collision-reproduction tests
- [x] Full `tests/unit/` regression — 23284 passed, 3 pre-existing failures unrelated to this change (different subsystem)
- [x] PLAN_VERIFICATION VALIDATION + REGRESSION sub-agents independently confirmed no bypass path and no signature regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)