### PR TITLE
fix(QF-20260712-610): exempt CRIT-003 auth_bypass on test-path diff segments

### DIFF
--- a/lib/ship/review-gate.js
+++ b/lib/ship/review-gate.js
@@ -29,7 +29,12 @@ try {
  * (e.g. sqlite_master probes, DROP-TABLE assertions), so scanning them yields
  * structural false positives on every venture PR. (QF-20260711-047)
  */
-const TEST_FIXTURE_EXEMPT_IDS = new Set(['CRIT-002', 'CRIT-004']);
+// QF-20260712-610 extends the exemption to CRIT-003 (auth_bypass): test files
+// encode forbidden patterns as NEGATIVE guard assertions (e.g. a migration-pin
+// asserting `not.toMatch(/DISABLE ROW LEVEL SECURITY/i)`), which the
+// `disable.*(?:auth|rls|security)` pattern matched — CRITICAL-blocking the very
+// PR whose test forbids the behavior. Non-test segments are still scanned.
+const TEST_FIXTURE_EXEMPT_IDS = new Set(['CRIT-002', 'CRIT-003', 'CRIT-004']);
 
 /**
  * True when a diff file path is a test/fixture path eligible for the exemption.

--- a/tests/unit/review-gate-closed-enum-fp.test.js
+++ b/tests/unit/review-gate-closed-enum-fp.test.js
@@ -93,4 +93,19 @@ describe('review-gate closed-enum false-positive fixes (a78478f9 + 03ccc4d4)', (
     expect(names(diffFor('tests/setup.test.js', '+ const key = "sk-live-abc123def456ghi789jkl012mno345";')))
       .toContain('hardcoded_secret');
   });
+
+  // CRIT-003 auth_bypass test-fixture exemption — QF-20260712-610.
+  // Witnessed live on PR #6029: a migration-pin test's NEGATIVE guard assertion
+  // (`not.toMatch(/DISABLE ROW LEVEL SECURITY/i)`) matched `disable.*(?:auth|rls|security)`
+  // and CRITICAL-blocked the PR whose test FORBIDS disabling RLS.
+  it('does NOT flag CRIT-003 on a guard assertion inside a tests/ file', () => {
+    expect(names(diffFor('tests/unit/feedback-select-policy-migration.test.js',
+      '+    expect(SQL).not.toMatch(/DISABLE ROW LEVEL SECURITY/i);')))
+      .not.toContain('auth_bypass');
+  });
+  it('STILL flags CRIT-003 on the SAME string when the file is NOT a test path', () => {
+    expect(names(diffFor('database/migrations/20260712_bad.sql',
+      '+ ALTER TABLE feedback DISABLE ROW LEVEL SECURITY;')))
+      .toContain('auth_bypass');
+  });
 });


### PR DESCRIPTION
## Summary
Extends the QF-20260711-047 test-path exemption to **CRIT-003 (auth_bypass)**: test files encode forbidden patterns as *negative guard assertions* (witnessed live: a migration-pin test asserting `not.toMatch(/DISABLE ROW LEVEL SECURITY/i)` CRITICAL-blocked PR #6029 — the guard blocked the very PR whose test forbids the behavior). Non-test diff segments are still scanned and still block.

One-line set extension + both-direction regression tests (test-path guard not flagged; non-test disable-RLS still flagged) — 19/19 green.

Authored by Alpha-6 (session 2951cbe1); verified and shipped by Alpha-5 (orphaned-QF completion).

## Test plan
- `npx vitest run tests/unit/review-gate-closed-enum-fp.test.js` — 19/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)