### PR TITLE
fix(QF-20260712-610): harden splitDiffByFile against in-hunk +++ header spoof

### DIFF
--- a/lib/ship/review-gate.js
+++ b/lib/ship/review-gate.js
@@ -60,14 +60,21 @@ function isTestFixturePath(path) {
 function splitDiffByFile(diffContent) {
   const segments = [];
   let current = { path: null, body: [] };
+  // QF-20260712-610 hardening (adversarial-review finding): real `+++ b/` / `--- a/`
+  // headers only appear BEFORE a file's first `@@` hunk. Inside a hunk, an added line
+  // whose content starts `++ b/tests/...` renders as `+++ b/tests/...` and would spoof
+  // the segment path onto a test file, leaking the test-fixture exemption to the rest
+  // of a non-test file. Only honor headers outside hunks.
+  let inHunk = false;
   const flush = () => { if (current.body.length) segments.push({ path: current.path, body: current.body.join('\n') }); };
 
   for (const line of diffContent.split('\n')) {
     const gitHeader = line.match(/^diff --git a\/.+ b\/(.+)$/);
-    if (gitHeader) { flush(); current = { path: gitHeader[1], body: [] }; continue; }
-    const plusHeader = line.match(/^\+\+\+ b\/(.+)$/);
+    if (gitHeader) { flush(); current = { path: gitHeader[1], body: [] }; inHunk = false; continue; }
+    if (/^@@ /.test(line)) inHunk = true;
+    const plusHeader = !inHunk && line.match(/^\+\+\+ b\/(.+)$/);
     if (plusHeader) { current.path = plusHeader[1]; continue; }
-    if (/^--- a\//.test(line)) continue; // diff metadata, not content
+    if (!inHunk && /^--- a\//.test(line)) continue; // diff metadata, not content
     current.body.push(line);
   }
   flush();

--- a/tests/unit/review-gate-closed-enum-fp.test.js
+++ b/tests/unit/review-gate-closed-enum-fp.test.js
@@ -108,4 +108,19 @@ describe('review-gate closed-enum false-positive fixes (a78478f9 + 03ccc4d4)', (
       '+ ALTER TABLE feedback DISABLE ROW LEVEL SECURITY;')))
       .toContain('auth_bypass');
   });
+
+  // splitDiffByFile header-spoof hardening — QF-20260712-610 (adversarial-review finding).
+  // In-hunk added content rendering as `+++ b/tests/...` must NOT reassign the segment
+  // path (which would leak the test-fixture exemption to the rest of a non-test file).
+  it('does NOT let in-hunk `+++ b/tests/...` content spoof a test path for later lines', () => {
+    const spoof = [
+      'diff --git a/lib/db/policy.js b/lib/db/policy.js',
+      '--- a/lib/db/policy.js',
+      '+++ b/lib/db/policy.js',
+      '@@ -1,0 +1,2 @@',
+      '+++ b/tests/evil.test.js', // added content line `++ b/tests/evil.test.js`
+      '+ await run("ALTER TABLE t DISABLE ROW LEVEL SECURITY");',
+    ].join('\n');
+    expect(names(spoof)).toContain('auth_bypass');
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up to #6031 (adversarial-review finding on the CRIT-003 exemption): an added content line rendering as `+++ b/tests/...` inside a hunk could reassign the diff segment path to a test file, leaking the test-fixture exemption to the rest of a non-test file. Headers are now honored only outside `@@` hunks; the spoof shape is pinned by a regression test.

## Test plan
- tests/unit/review-gate-closed-enum-fp.test.js — 20 tests incl. the new spoof pin (all existing exemption/still-fires directions re-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)