### PR TITLE
docs(SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001): CHANGELOG entry for witness-lookup security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Table of Contents
 
 - [2026-07-12](#2026-07-12)
+  - [Security](#security)
   - [Features](#features)
   - [Infrastructure](#infrastructure)
   - [Bugfix](#bugfix)
@@ -87,6 +88,13 @@
   - [EHG (Venture App)](#ehg-venture-app)
 
 ## 2026-07-12
+
+### Security
+- **Close cross-repo `pr_number` collision in the P2 auto-merge witness lookup** - PR #6030 (SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001)
+  - **What shipped**: `ship_review_findings` has no `repo` column, so `lib/ship/venture-trust-gate.mjs`'s `defaultFetchReviewFinding` matched a PR's review verdict by `pr_number` alone — confirmed live at PR#2/#5 between the two `trust_tier='trusted'` venture repos (`rickfelix/apexniche-ai`, `rickfelix/marketlens`), letting one repo's passing review witness-pass an entirely different repo's PR through the VB-2 auto-merge trust gate. Fixed fail-closed: the lookup now requires `branch` and scopes by `.eq('pr_number').eq('branch')`; an omitted `branch` returns `null` immediately rather than falling back to the old unscoped match. Threaded as an additive options-object parameter through `merge-witness-ladder.mjs`, `venture-trust-gate.mjs`, `auto-merge.mjs`, `.claude/commands/ship.md`'s Step 6 template, and the second independent consumer `scripts/ship-witness-retroactive.mjs` (new `resolvePrBranch` via `gh pr view`).
+  - **Retroactive audit, run against production, not just written**: `scripts/audit-borrowed-witness-rows.mjs` replicates the pre-fix `pr_number`-only-most-recent-row query exactly and cross-checks it against every merged PR in the two trusted repos. First pass found 5 candidates; an adversarial review round caught a false-negative in the audit's own own-branch-skip logic (it wrongly treated "has any own-branch row" as safe, missing the case where a newer cross-repo row would have been served instead) — corrected, re-run, and confirmed **9 real borrowed-row exposure candidates** across 29 merged PRs. Reported to the coordinator for visibility (does not itself prove auto-merge, vs. human-merge, occurred for those specific PRs).
+  - **Scope discipline**: a durable Layer-2 fix (a real `repo` column on `ship_review_findings`, chairman-gated migration + repo-scoped reads) was explicitly descoped to fast-follow `SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001`, per the original LEAD RISK sub-agent's own guidance that this fail-closed interim fix must not be gated behind a schema migration. The descope is formally recorded (`strategic_directives_v2.metadata.descoped_frs`, `user_stories` metadata) rather than silent.
+  - **Verification**: 226/226 `tests/unit/ship/` tests pass (including new fail-closed and live-collision-reproduction tests); full `tests/unit/` regression (23,284 passed, 3 pre-existing unrelated failures). Deep-tier adversarial PR review (2 rounds of genuine findings, both fixed, verified clean on round 3). LEAD VALIDATION + RISK, EXEC TESTING, PLAN_VERIFICATION VALIDATION + REGRESSION sub-agents all PASS. Handoffs EXEC-TO-PLAN 98, PLAN-TO-LEAD 97, LEAD-FINAL-APPROVAL 97.
 
 ### Features
 - **Domain-availability check for venture naming, now ON by default** - PR #6019 (SD-LEO-FEAT-NAMING-DOMAIN-AVAILABILITY-001)

--- a/docs/reference/ship-witness-venture-trust-tier.md
+++ b/docs/reference/ship-witness-venture-trust-tier.md
@@ -3,7 +3,7 @@
 **SD**: SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B)
 **Status**: Approved
 **Category**: Protocol
-**Version**: 1.1.0
+**Version**: 1.2.0
 **Last Updated**: 2026-07-12
 
 ## What this is
@@ -71,7 +71,7 @@ that decision visible.
 | Ratification term | Ladder rung | What it checks |
 |---|---|---|
 | "our-own-fleet-authored" | P1 admission | `workKey` resolves to a real `strategic_directives_v2`/`quick_fixes` row (not a synthetic/test key) |
-| "a second-session check" | P2 witness | A `ship_review_findings` row exists for the PR with `verdict='pass'` (produced by the review gate — actor-separation beyond that is `not_evaluable` today, per the ladder module's own docs) |
+| "a second-session check" | P2 witness | A `ship_review_findings` row exists for the PR **on its own branch** with `verdict='pass'` (produced by the review gate — actor-separation beyond that is `not_evaluable` today, per the ladder module's own docs). See "P2's branch scoping" below — `pr_number` alone is not a safe key. |
 | "CI-green" | P3 CI | `statusCheckRollup` shows all checks succeeded (pending/empty is `not_evaluable`, never a false pass) |
 
 P2's actor-separation dimension and P4 (branch protection, pre-P0) are never
@@ -123,6 +123,39 @@ clone/register lines). `scripts/backfill-trust-tier-elevation.mjs` (dry-run
 default, `--apply` to write, enumerated by id — never a heuristic sweep)
 normalized the two already-hand-elevated rows (MarketLens `6823cd37` got the
 provenance written; ApexNiche `3c8efc56` was already canonical).
+
+## P2's branch scoping (SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001, SECURITY)
+
+`ship_review_findings` has no `repo` column. The original P2 default lookup
+(`defaultFetchReviewFinding` in `lib/ship/venture-trust-gate.mjs`) matched a
+PR's review verdict by `pr_number` **alone** — small sequential integers
+collide constantly across repos. This was confirmed live: `rickfelix/
+apexniche-ai` and `rickfelix/marketlens` (the only two `trust_tier='trusted'`
+repos at the time) each had merged PRs at the same `pr_number` (#1, #2, #5,
+#6, #7, #8, #9), so one repo's passing review could witness-pass an entirely
+different repo's PR. A bounded, read-only retroactive audit
+(`scripts/audit-borrowed-witness-rows.mjs`) confirmed **9 real borrowed-row
+exposure candidates** across the two trusted repos' merge history.
+
+The fix scopes the lookup by `branch` (the PR's own head branch,
+`headRefName`) instead, and is **fail-closed by design**:
+`defaultFetchReviewFinding(prNumber, supabase, { branch })` returns `null`
+immediately if `branch` is omitted — it never falls back to the old
+unscoped `pr_number`-only match. `branch` is threaded as an additive
+options-object parameter through `evaluateP2Witness` /
+`evaluateMergeWorkLadder` (`lib/ship/merge-witness-ladder.mjs`),
+`evaluateVenturePrWitness` / `createVentureTrustGate`
+(`lib/ship/venture-trust-gate.mjs`), `attemptAutoMerge` /
+`observeMergeWorkLadder` (`lib/ship/auto-merge.mjs`), and both live callers
+(`.claude/commands/ship.md` Step 5.5/6, `scripts/ship-witness-retroactive.mjs`).
+
+**Known residual limitation.** `branch` narrows the collision surface but is
+not itself repo-unique — two trusted repos could in principle share both a
+`pr_number` and a non-SD-scoped branch name. The durable fix (a real `repo`
+column on `ship_review_findings`, chairman-gated migration + repo-scoped
+reads) is fast-follow `SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001`,
+explicitly split out so this fail-closed interim fix could ship without
+waiting on a schema migration.
 
 ## Where it's wired in
 


### PR DESCRIPTION
## Summary
- CHANGELOG entry for the merged security fix (#6030): P2 witness lookup branch-scoping, the live cross-repo collision, the retroactive audit (9 confirmed borrowed-row candidates), and the fast-follow SD descope.
- Updated `docs/reference/ship-witness-venture-trust-tier.md` with a new "P2's branch scoping" section documenting the fix, the fail-closed contract, and the known residual limitation.

## Test plan
- Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)