### PR TITLE
fix(SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001): deploy un-applied claude_sessions.metadata merge fix

### DIFF
--- a/database/migrations/20260614_fix_create_or_replace_session_metadata_merge.sql
+++ b/database/migrations/20260614_fix_create_or_replace_session_metadata_merge.sql
@@ -30,7 +30,13 @@ CREATE OR REPLACE FUNCTION create_or_replace_session(
   p_hostname TEXT,
   p_codebase TEXT,
   p_metadata JSONB DEFAULT '{}'::JSONB
-) RETURNS JSONB AS $$
+) RETURNS JSONB
+-- SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001 amendment (Adam same-object coordination check, corr
+-- 580a91da): the LIVE function already carries this search_path hardening (added after
+-- 2026-06-14, post-dating this migration's original authoring). Preserving it here so
+-- applying this migration does not silently REVERT that hardening.
+SET search_path TO 'public', 'extensions'
+AS $$
 DECLARE
   v_terminal_identity TEXT;
   v_previous_session RECORD;
@@ -150,6 +156,24 @@ BEGIN
   RAISE NOTICE 'FIX-CREATE-REPLACE verify OK: re-init merged metadata, preserving is_coordinator + claim_flag and applying auto_proceed.';
 END
 $verify$;
+
+-- SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001 amendment verify: confirm this migration did not silently
+-- revert the post-2026-06-14 search_path hardening (the exact regression Adam's same-object
+-- coordination check caught, corr 580a91da).
+DO $verify_search_path$
+DECLARE
+  v_config TEXT[];
+BEGIN
+  SELECT proconfig INTO v_config
+  FROM pg_proc
+  WHERE proname = 'create_or_replace_session';
+
+  ASSERT v_config IS NOT NULL AND 'search_path=public, extensions' = ANY(v_config),
+    'FIX-CREATE-REPLACE amendment: search_path hardening (SET search_path TO public, extensions) is missing from the deployed function';
+
+  RAISE NOTICE 'FIX-CREATE-REPLACE amendment verify OK: search_path hardening preserved.';
+END
+$verify_search_path$;
 
 -- ROLLBACK: re-apply 20260509_layer1_claiming_session_id_release_parity.sql's definition, i.e. set
 --   metadata = EXCLUDED.metadata

--- a/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
+++ b/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
@@ -97,6 +97,15 @@ describeDb('create_or_replace_session metadata merge (SD-LEO-INFRA-FIX-CREATE-RE
     expect(sql).not.toMatch(/metadata\s*=\s*EXCLUDED\.metadata\s*,/);
   });
 
+  // SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001 amendment (Adam same-object coordination check, corr
+  // 580a91da): the LIVE function already carries a post-2026-06-14 search_path hardening
+  // (SET search_path TO 'public', 'extensions') that this migration's ORIGINAL text did not
+  // preserve — applying it as originally written would have silently REVERTED that hardening.
+  it('regression guard: the migration preserves the search_path hardening, does not revert it', () => {
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect(sql).toMatch(/SET\s+search_path\s+TO\s+'public',\s*'extensions'/i);
+  });
+
   // SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001 (FR-2): the two tests above only ever prove the
   // MIGRATION FILE's logic is correct — the first re-applies it inside a transaction it
   // always ROLLS BACK ("independent of whether prod has been upgraded yet", per its own
@@ -121,5 +130,8 @@ describeDb('create_or_replace_session metadata merge (SD-LEO-INFRA-FIX-CREATE-RE
       /metadata\s*=\s*COALESCE\(\s*claude_sessions\.metadata[\s\S]*\|\|[\s\S]*EXCLUDED\.metadata/
     );
     expect(deployedDef).not.toMatch(/metadata\s*=\s*EXCLUDED\.metadata\s*,/);
+    // Amendment guard: the deploy must not have regressed the pre-existing search_path
+    // hardening (the exact class of mistake Adam's coordination check caught pre-deploy).
+    expect(deployedDef).toMatch(/SET\s+search_path\s+TO\s+'public',\s*'extensions'/i);
   });
 });

--- a/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
+++ b/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
@@ -22,7 +22,7 @@ import { it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { describeDb, HAS_REAL_DB } from '../helpers/db-available.js';
+import { describeDb, itDb, HAS_REAL_DB } from '../helpers/db-available.js';
 import createDatabaseClient from '../../lib/supabase-connection.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -95,5 +95,31 @@ describeDb('create_or_replace_session metadata merge (SD-LEO-INFRA-FIX-CREATE-RE
     );
     // ... and must NOT contain the old replace assignment.
     expect(sql).not.toMatch(/metadata\s*=\s*EXCLUDED\.metadata\s*,/);
+  });
+
+  // SD-FDBK-FIX-FLEET-WIDE-CLAUDE-001 (FR-2): the two tests above only ever prove the
+  // MIGRATION FILE's logic is correct — the first re-applies it inside a transaction it
+  // always ROLLS BACK ("independent of whether prod has been upgraded yet", per its own
+  // top-of-file comment), and the second inspects the file's text, not the DB. Neither can
+  // detect a "migration written but never deployed" gap — which is exactly what caused the
+  // fleet-wide claude_sessions.metadata clobber incident this SD fixes: this migration
+  // (SD-LEO-INFRA-FIX-CREATE-REPLACE-001, dated 20260614) sat correct-but-undeployed for
+  // weeks while the LIVE create_or_replace_session function still ran the old
+  // `metadata = EXCLUDED.metadata` wholesale replace. This test queries the ACTUAL deployed
+  // function body (pg_get_functiondef, no transaction/rollback) so a future regression of
+  // "the fix exists in git but isn't live" is caught, not just "the fix's SQL text is
+  // correct".
+  itDb('live-deployed-state guard: the DEPLOYED create_or_replace_session actually merges metadata (not just the migration file)', async () => {
+    const { rows } = await client.query(
+      `SELECT pg_get_functiondef(oid) AS def
+         FROM pg_proc
+        WHERE proname = 'create_or_replace_session'`
+    );
+    expect(rows).toHaveLength(1);
+    const deployedDef = rows[0].def;
+    expect(deployedDef).toMatch(
+      /metadata\s*=\s*COALESCE\(\s*claude_sessions\.metadata[\s\S]*\|\|[\s\S]*EXCLUDED\.metadata/
+    );
+    expect(deployedDef).not.toMatch(/metadata\s*=\s*EXCLUDED\.metadata\s*,/);
   });
 });


### PR DESCRIPTION
## Summary
- Root-caused the ~17:00Z 2026-07-12 fleet-wide claude_sessions.metadata clobber: a prior SD (SD-LEO-INFRA-FIX-CREATE-REPLACE-001) already wrote the correct merge fix for `create_or_replace_session`'s ON CONFLICT branch weeks ago, but the migration was never actually deployed to production — live-verified via `pg_get_functiondef` that the deployed function still ran the old wholesale `metadata = EXCLUDED.metadata` replace.
- The migration's own existing test only validated the file's SQL logic inside a rolled-back transaction ("independent of whether prod has been upgraded yet"), so it structurally could not detect a "written but never deployed" gap.
- Added a companion test that queries the ACTUAL deployed function body (no transaction) and asserts the merge pattern is present — it correctly failed before deploy and now passes.
- Amended per Adam's same-object coordination check (corr 580a91da): the live function already carried a post-2026-06-14 `SET search_path TO 'public', 'extensions'` hardening the original migration text would have silently reverted — added it back plus an in-migration self-verifying assertion and a dedicated regression-guard test.
- Deployed via chairman-authorized `--prod-deploy` (this session never self-issued/self-consumed the token).

## Test plan
- [x] `tests/db-invariants/create-or-replace-session-metadata-merge.test.js` — 4/4 pass (metadata-merge rolled-back-txn check, file-content regression guard, search_path regression guard, live-deployed-state check)
- [x] Full `tests/db-invariants/` suite — 24/24 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)