### PR TITLE
feat(SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001): durable repo-scoped P2 witness lookup

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -434,12 +434,31 @@ Review Gate: [TIER] tier (score: X.XX, keyword override: yes/no)
 - If unfixable CRITICAL: halt for chairman review
 - If Deep tier agent failure/timeout: hard-fail (do NOT degrade to Standard)
 
+**5.5. Resolve repo once (SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5):**
+
+Resolve the repo owner/name exactly once per `/ship` run, here, and persist it to a small state file so Step 6 reuses the *identical* string instead of re-invoking `gh repo view` — this eliminates any possibility of write/read drift between the audit row and the merge-time witness lookup:
+
+```bash
+node -e "
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const owner = execSync('gh repo view --json owner --jq .owner.login').toString().trim();
+const name = execSync('gh repo view --json name --jq .name').toString().trim();
+fs.mkdirSync('.claude-work', { recursive: true });
+fs.writeFileSync('.claude-work/ship-repo-resolved.json', JSON.stringify({ owner, name }));
+console.log(owner + '/' + name);
+"
+```
+
 **6. Log findings (MANDATORY):**
 
 After the review gate completes (regardless of verdict), log the findings for audit trail:
 
 ```javascript
 import { logFindings } from './lib/ship/review-findings-logger.js';
+import { readFileSync } from 'node:fs';
+
+const { owner, name } = JSON.parse(readFileSync('.claude-work/ship-repo-resolved.json', 'utf8'));
 
 await logFindings({
   prNumber: <PR#>,
@@ -449,7 +468,8 @@ await logFindings({
   verdict: finalVerdict, // 'pass' or 'block'
   sdKey: '<SD-KEY or null>',
   branch: '<branch-name>',
-  multiAgent: gateResult.multiAgent || false
+  multiAgent: gateResult.multiAgent || false,
+  repo: `${owner}/${name}`
 });
 ```
 
@@ -496,13 +516,16 @@ The bare `gh pr merge <PR#> --merge --delete-branch` call silently failed for mo
 ```bash
 node -e "
 require('dotenv').config();
+const fs = require('node:fs');
 Promise.all([
   import('./lib/ship/auto-merge.mjs'),
   import('./lib/ship/venture-trust-gate.mjs'),
   import('@supabase/supabase-js'),
 ]).then(async ([{ attemptAutoMerge, fetchStatusCheckRollup }, { createVentureTrustGate }, { createClient }]) => {
-  const owner = (await import('node:child_process')).execSync('gh repo view --json owner --jq .owner.login').toString().trim();
-  const name = (await import('node:child_process')).execSync('gh repo view --json name --jq .name').toString().trim();
+  // Reuse the SAME owner/name resolved once at Step 5.5 -- never re-invoke
+  // gh repo view here, so the audit row and the merge-time witness lookup
+  // can never drift (SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5).
+  const { owner, name } = JSON.parse(fs.readFileSync('.claude-work/ship-repo-resolved.json', 'utf8'));
   const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
   const isTrustedRepo = createVentureTrustGate({ supabase, fetchStatusCheckRollup });
   const result = await attemptAutoMerge({

--- a/database/migrations/20260712_ship_review_findings_repo_column.sql
+++ b/database/migrations/20260712_ship_review_findings_repo_column.sql
@@ -1,0 +1,60 @@
+-- SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-4)
+-- Add ship_review_findings.repo (nullable text) so P2's witness-evaluation
+-- rung (evaluateP2Witness(), lib/ship/merge-witness-ladder.mjs) can scope
+-- its lookup by the exact owner/name repo string instead of the interim
+-- branch-only scoping shipped by the parent SD.
+--
+-- requires-chairman-apply
+--
+-- WHY: the parent SD (SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001) closed a live
+-- cross-repo pr_number collision (apexniche-ai PR#2/#5 colliding with
+-- marketlens's rows at the same PR numbers, letting an unrelated repo's
+-- passing review witness-pass an unreviewed venture PR) with an URGENT,
+-- fail-closed interim fix: scoping the P2 lookup by `branch` instead, since
+-- ship_review_findings had no repo column at the time and branch was already
+-- 100% populated on every live row. Branch is a weaker discriminant than
+-- repo (branch names like `main` can collide across repos too, and SD/QF-
+-- derived branch names are usually but not guaranteed unique), so this
+-- column is the durable Layer 2: once populated, repo becomes the PRIMARY
+-- scope and branch-only matching is restricted to legacy (repo IS NULL) rows
+-- only -- see lib/ship/venture-trust-gate.mjs defaultFetchReviewFinding
+-- (FR-6) for the exact fail-closed read logic. This is additive and
+-- non-blocking: FR-5's writers and FR-6's reader both probe for this
+-- column's existence at runtime and degrade to today's exact branch-only
+-- behavior when it is absent, so this migration may ship un-applied for an
+-- indefinite period (as sibling chairman-gated migrations on this same
+-- table already have) without affecting the auto-merge trust gate.
+--
+-- Data shape written by future callers (documented, not enforced by a CHECK
+-- -- keeps the column forward-compatible): 'owner/name', all-lowercase, no
+-- '.git' suffix -- matches the shape already used by merge_witness_telemetry
+-- and ship_escape_audit (lib/ship/auto-merge.mjs `${repoOwner}/${repoName}`),
+-- normalized via the shared normalizeGithubRepo() helper
+-- (lib/ship/repo-column-probe.mjs) on every write and read path.
+--
+-- APPLY (chairman-gated, requires_chairman_apply pre-flagged at sourcing):
+--   This migration is committed WITHOUT the @approved-by stamp (deliberate
+--   deviation from the 20260711_ship_review_findings_actor_metadata.sql
+--   template, which mirrors a migration that was pre-approved at sourcing
+--   time). The chairman must add the stamp below before running:
+--     node scripts/apply-migration.js database/migrations/20260712_ship_review_findings_repo_column.sql --prod-deploy
+--
+-- ROLLBACK:
+--   ALTER TABLE public.ship_review_findings DROP COLUMN IF EXISTS repo;
+--
+-- @approved-by: <pending chairman sign-off>
+
+BEGIN;
+
+ALTER TABLE public.ship_review_findings
+  ADD COLUMN IF NOT EXISTS repo text;
+
+COMMENT ON COLUMN public.ship_review_findings.repo IS
+  'SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-4: optional repo '
+  'scope (''owner/name'', lowercase, no .git suffix) for the P2 witness '
+  'lookup (evaluateP2Witness()). NULL means no repo captured for this row '
+  '(legacy rows, or rows written before this column was chairman-applied) '
+  '-- defaultFetchReviewFinding() falls back to branch-scoped matching '
+  'restricted to repo IS NULL rows for those, never widening the match.';
+
+COMMIT;

--- a/docs/reference/ship-witness-venture-trust-tier.md
+++ b/docs/reference/ship-witness-venture-trust-tier.md
@@ -157,6 +157,45 @@ reads) is fast-follow `SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001`,
 explicitly split out so this fail-closed interim fix could ship without
 waiting on a schema migration.
 
+## P2's durable repo scoping (SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001, SECURITY fast-follow)
+
+Layer 2 on top of the branch-scoping fix above. `ship_review_findings.repo`
+is a new **chairman-gated, additive, nullable** column
+(`database/migrations/20260712_ship_review_findings_repo_column.sql`) —
+committed but **not applied**; it may sit un-applied for an indeterminate
+period (two sibling chairman-gated migrations on this same table have sat
+un-applied for months). Every writer and the reader therefore probe column
+existence at runtime (`lib/ship/repo-column-probe.mjs::probeRepoColumnExists`,
+cached per-process) and degrade to the pre-this-SD branch-only behavior
+exactly when the column is absent — the migration landing or not landing is
+never observable as a functional regression.
+
+Once the column is populated, `defaultFetchReviewFinding` in
+`lib/ship/venture-trust-gate.mjs` scopes **primarily by `repo`**
+(`'owner/name'`, lowercase, no `.git` suffix, normalized via the shared
+`normalizeGithubRepo()` helper) — strictly stronger than `branch`, since
+branch names like `main` can collide across repos too. The legacy `branch`
+fallback (for rows written before the column existed) is additionally
+restricted to `repo IS NULL` rows: without that guard, a populated-but-
+different-repo row that merely shares the query's branch name would
+re-open the exact cross-repo collision the branch-scoping fix closed. Never
+OR'd together — primary is repo-only, fallback is branch-only-AND-repo-
+IS-NULL, and a non-null repo differing from the query's repo never matches
+under any path (verified by a dedicated regression test in
+`tests/unit/ship/venture-trust-gate.test.js`).
+
+`repo` is resolved exactly **once** per `/ship` run (`.claude/commands/ship.md`
+Step 5.5, persisted to `.claude-work/ship-repo-resolved.json`) and reused
+verbatim at Step 6's merge call — never re-resolved via a second `gh repo
+view`, so the audit row and the merge-time witness lookup can never drift.
+The same `repo` value is threaded into all 4 `ship_review_findings` insert
+sites: `lib/ship/review-findings-logger.js` (`logFindings`), the
+LEAD-FINAL-APPROVAL populator hook, `scripts/backfill-pr-tracking.js`, and
+`scripts/audit-phantom-completions.js` (whose inventory previously stored a
+bare repo name like `EHG_Engineer` — now normalized to `rickfelix/<repo>`
+before writing, closing an avoidable shape-drift the LEAD security review
+flagged).
+
 ## Where it's wired in
 
 - `lib/ship/venture-trust-gate.mjs` — the predicate + default lookups (new).
@@ -181,3 +220,8 @@ waiting on a schema migration.
   adoption-readiness gauge + gated enforce-flip capability. See
   `docs/reference/ship-witness-enforce-flip-readiness.md` for the readiness
   bar and what D deliberately did NOT activate.
+- SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (completed): P2's branch-scoped
+  fail-closed fix (urgent, interim — see section above).
+- SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001: P2's durable
+  repo-scoped fix (Layer 2 fast-follow, chairman-gated migration —
+  see section above).

--- a/lib/ship/merge-witness-ladder.mjs
+++ b/lib/ship/merge-witness-ladder.mjs
@@ -99,7 +99,7 @@ function evaluateActorSeparation(finding, tier) {
  * — P2's own top-level pass/fail remains verdict-only, unchanged from before
  * FR-2, so existing evaluateEnforcementDecision() behavior on the /ship lane
  * does not regress (TR-3).
- * fetchReviewFinding(prNumber, {branch}) => Promise<{verdict, metadata?}|null>.
+ * fetchReviewFinding(prNumber, {branch, repo}) => Promise<{verdict, metadata?}|null>.
  * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: branch is forwarded to
  * fetchReviewFinding as an options object (additive — a legacy 1-arg
  * fetchReviewFinding simply ignores it) so a live implementation can scope
@@ -107,14 +107,17 @@ function evaluateActorSeparation(finding, tier) {
  * NOT itself enforce scoping — that is fetchReviewFinding's contract; see
  * defaultFetchReviewFinding in venture-trust-gate.mjs for the fail-closed
  * default.
+ * SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): repo is
+ * forwarded alongside branch, same additive contract -- a legacy
+ * fetchReviewFinding that only destructures {branch} simply ignores it.
  */
-export async function evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch }) {
+export async function evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch, repo }) {
   if (typeof fetchReviewFinding !== 'function') {
     return rung('P2', RUNG_STATUS.NOT_EVALUABLE, 'no fetchReviewFinding injected');
   }
   let finding;
   try {
-    finding = await fetchReviewFinding(prNumber, { branch });
+    finding = await fetchReviewFinding(prNumber, { branch, repo });
   } catch (e) {
     return rung('P2', RUNG_STATUS.NOT_EVALUABLE, `lookup threw: ${e?.message || e}`);
   }
@@ -251,9 +254,14 @@ export async function evaluateMergeWorkLadder({
   // head branch, forwarded to P2 so a live fetchReviewFinding can scope its
   // ship_review_findings lookup and avoid a cross-repo pr_number collision.
   branch,
+  // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): optional,
+  // additive — the PR's own repo ('owner/name'), forwarded to P2 so a live
+  // fetchReviewFinding can scope by repo (primary) once the durable column
+  // exists, instead of only branch (interim fallback).
+  repo,
 }) {
   const p1 = await evaluateP1Admission({ workKey, lookupWorkKeyReal });
-  const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch });
+  const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding, branch, repo });
   const p3 = evaluateP3CI({ statusCheckRollup });
   const p4 = await evaluateP4ProtectionIntegrity({ repoOwner, repoName, checkProtection, adminOverride, prNumber, checkEscapeAudit });
   const p5 = evaluateP5PostVerify({ merged, verifyResult });

--- a/lib/ship/repo-column-probe.mjs
+++ b/lib/ship/repo-column-probe.mjs
@@ -30,7 +30,9 @@ const COLUMN_ABSENT_CODES = new Set(['42703', 'PGRST204']);
 export async function probeRepoColumnExists(supabase) {
   if (repoColumnExists !== null) return repoColumnExists;
   if (!supabase) return false;
-  const { error } = await supabase.from('ship_review_findings').select('repo').limit(1);
+  // Intentional existence probe for a column the static schema snapshot doesn't
+  // know about yet -- it only exists once the chairman applies the FR-4 migration.
+  const { error } = await supabase.from('ship_review_findings').select('repo').limit(1); // schema-lint-disable-line
   if (!error) {
     repoColumnExists = true;
     return true;

--- a/lib/ship/repo-column-probe.mjs
+++ b/lib/ship/repo-column-probe.mjs
@@ -1,0 +1,56 @@
+/**
+ * Capability probe + normalizer for ship_review_findings.repo.
+ *
+ * SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-4/5/6). The repo
+ * column is added by a chairman-gated migration
+ * (database/migrations/20260712_ship_review_findings_repo_column.sql) that
+ * may ship un-applied for an indeterminate period -- two sibling
+ * chairman-gated migrations on this same table have sat un-applied for
+ * months (confirmed live via security-agent LEAD review). Every writer
+ * (FR-5) and the FR-6 reader must therefore probe for the column's
+ * existence at runtime and degrade to today's exact pre-repo-column
+ * behavior when it is absent, rather than erroring the whole insert/read.
+ *
+ * The probe result is cached for the lifetime of the process ONLY once
+ * confirmed either way by a recognized "column does not exist" error code
+ * (42703 = Postgres undefined_column; PGRST204 = PostgREST schema-cache
+ * miss for the same condition) -- an unrelated transient error (network,
+ * auth) is never cached, so a real outage doesn't permanently wedge every
+ * future call into the "absent" branch for the rest of the process.
+ */
+
+let repoColumnExists = null; // null = unknown, true = confirmed present, false = confirmed absent
+
+const COLUMN_ABSENT_CODES = new Set(['42703', 'PGRST204']);
+
+/**
+ * @param {object} supabase - Supabase service-role client.
+ * @returns {Promise<boolean>}
+ */
+export async function probeRepoColumnExists(supabase) {
+  if (repoColumnExists !== null) return repoColumnExists;
+  if (!supabase) return false;
+  const { error } = await supabase.from('ship_review_findings').select('repo').limit(1);
+  if (!error) {
+    repoColumnExists = true;
+    return true;
+  }
+  if (COLUMN_ABSENT_CODES.has(error.code)) {
+    repoColumnExists = false;
+    return false;
+  }
+  // Unrecognized error (network/auth/etc.) -- don't cache; degrade for this
+  // call only, retry fresh next time.
+  return false;
+}
+
+/** Test-only: reset the process-lifetime cache between test cases. */
+export function __resetRepoColumnProbeForTests() {
+  repoColumnExists = null;
+}
+
+/** Normalize a github_repo field ('owner/name.git' or 'owner/name') to 'owner/name' lowercase. */
+export function normalizeGithubRepo(githubRepo) {
+  if (!githubRepo) return null;
+  return githubRepo.replace(/\.git$/i, '').toLowerCase();
+}

--- a/lib/ship/review-findings-logger.js
+++ b/lib/ship/review-findings-logger.js
@@ -7,6 +7,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import { probeRepoColumnExists, normalizeGithubRepo } from './repo-column-probe.mjs';
 
 dotenv.config();
 
@@ -29,11 +30,12 @@ function getSupabase() {
  * @param {string} [params.sdKey] - SD key if available
  * @param {string} [params.branch] - Branch name
  * @param {boolean} [params.multiAgent] - Whether multi-agent review was used
+ * @param {string} [params.repo] - Repo ('owner/name'), SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5
  * @returns {Promise<{ success: boolean, id?: string, error?: string }>}
  */
 export async function logFindings({
   prNumber, reviewTier, riskScore, findings = [], verdict,
-  sdKey = null, branch = null, multiAgent = false
+  sdKey = null, branch = null, multiAgent = false, repo = null
 }) {
   const supabase = getSupabase();
 
@@ -43,20 +45,28 @@ export async function logFindings({
     findingCategories[type] = (findingCategories[type] || 0) + 1;
   }
 
+  const row = {
+    pr_number: prNumber,
+    review_tier: reviewTier,
+    risk_score: riskScore,
+    finding_count: findings.length,
+    finding_categories: findingCategories,
+    verdict,
+    sd_key: sdKey,
+    branch,
+    multi_agent: multiAgent,
+    reviewed_at: new Date().toISOString()
+  };
+  // FR-5: capability-gated -- only write repo once the chairman-gated
+  // column exists (probeRepoColumnExists), so this insert never breaks
+  // while the migration is pending apply.
+  if (repo && await probeRepoColumnExists(supabase)) {
+    row.repo = normalizeGithubRepo(repo);
+  }
+
   const { data, error } = await supabase
     .from('ship_review_findings')
-    .insert({
-      pr_number: prNumber,
-      review_tier: reviewTier,
-      risk_score: riskScore,
-      finding_count: findings.length,
-      finding_categories: findingCategories,
-      verdict,
-      sd_key: sdKey,
-      branch,
-      multi_agent: multiAgent,
-      reviewed_at: new Date().toISOString()
-    })
+    .insert(row)
     .select('id')
     .single();
 

--- a/lib/ship/venture-trust-gate.mjs
+++ b/lib/ship/venture-trust-gate.mjs
@@ -23,12 +23,9 @@
 
 import { evaluateMergeWorkLadder, RUNG_STATUS } from './merge-witness-ladder.mjs';
 import { isPlatformRepo } from './auto-merge.mjs';
+import { probeRepoColumnExists, normalizeGithubRepo } from './repo-column-probe.mjs';
 
-/** Normalize a github_repo field ('owner/name.git' or 'owner/name') to 'owner/name' lowercase. */
-export function normalizeGithubRepo(githubRepo) {
-  if (!githubRepo) return null;
-  return githubRepo.replace(/\.git$/i, '').toLowerCase();
-}
+export { normalizeGithubRepo };
 
 /**
  * Look up applications.trust_tier for a repoOwner/repoName pair by matching
@@ -71,32 +68,64 @@ export async function defaultLookupWorkKeyReal(workKey, supabase) {
 
 /**
  * P2 witness default: most recent ship_review_findings row for this PR,
- * scoped to the PR's own branch.
+ * scoped to the PR's own repo (primary, once the column exists) or branch
+ * (fallback).
  *
  * SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY): the pre-fix version of
  * this function matched by pr_number ALONE — small integers collide
  * constantly across repos (confirmed live: apexniche-ai PR #2/#5 collided
  * with MARKETLENS's passing rows at the same PR numbers), letting one
  * venture repo's passing review witness-pass an ENTIRELY DIFFERENT repo's
- * unreviewed PR through the VB-2 auto-merge trust gate. ship_review_findings
- * has no repo column (see the chairman-gated Layer-2 migration for that),
- * so this is scoped by branch instead — branch is 100% populated on every
- * ship_review_findings row from the two live trusted-venture repos (verified
- * against production data), unlike sd_key/workKey, which is a hand-filled
- * ship.md placeholder ('<SD-KEY or null>') prone to write/read drift.
+ * unreviewed PR through the VB-2 auto-merge trust gate. The urgent interim
+ * fix scoped by branch instead — 100% populated on every live row, unlike
+ * sd_key/workKey.
  *
- * FAIL-CLOSED (the core invariant): when branch is absent, this returns null
- * (not_evaluable) — it NEVER falls back to the old pr_number-only match.
- * Returns { verdict } or null (no row / query error / no branch supplied).
+ * SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): once the
+ * chairman-gated repo column exists (probed at runtime, never assumed) and
+ * a repo is supplied, repo becomes the PRIMARY scope — strictly stronger
+ * than branch (branch names like `main` can collide across repos too).
+ * The branch fallback is now ADDITIONALLY restricted to `repo IS NULL`
+ * rows: without that guard, a populated-but-different-repo row that
+ * happens to share a branch name would re-open the exact cross-repo
+ * fail-open this SD's parent closed. Never OR the two scopes together.
+ *
+ * FAIL-CLOSED (the core invariant, unchanged): no repo AND no branch
+ * returns null (not_evaluable) — this NEVER falls back to the old
+ * pr_number-only match. Returns { verdict } or null (no row / query error).
  */
-export async function defaultFetchReviewFinding(prNumber, supabase, { branch } = {}) {
-  if (!supabase || !prNumber || !branch) return null;
+export async function defaultFetchReviewFinding(prNumber, supabase, { branch, repo } = {}) {
+  if (!supabase || !prNumber || (!branch && !repo)) return null;
   try {
-    const { data, error } = await supabase
+    const hasRepoColumn = await probeRepoColumnExists(supabase);
+
+    if (hasRepoColumn && repo) {
+      const { data, error } = await supabase
+        .from('ship_review_findings')
+        .select('verdict')
+        .eq('pr_number', prNumber)
+        .eq('repo', normalizeGithubRepo(repo))
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error || !data) return null;
+      return { verdict: data.verdict };
+    }
+
+    if (!branch) return null;
+    let query = supabase
       .from('ship_review_findings')
       .select('verdict')
       .eq('pr_number', prNumber)
-      .eq('branch', branch)
+      .eq('branch', branch);
+    // Restrict the legacy branch fallback to repo IS NULL rows once the
+    // column exists -- a populated repo that merely shares this branch
+    // name must never match (see FR-6 doc above). Only applied when the
+    // column exists; `.is('repo', null)` against an absent column would
+    // itself error.
+    if (hasRepoColumn) {
+      query = query.is('repo', null);
+    }
+    const { data, error } = await query
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -113,11 +142,11 @@ export async function defaultFetchReviewFinding(prNumber, supabase, { branch } =
  * 'pass'. Never throws; any internal failure degrades to false (fail-closed).
  */
 export async function evaluateVenturePrWitness({
-  prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch,
+  prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch, repo,
 }) {
   try {
     const verdict = await evaluateMergeWorkLadder({
-      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch,
+      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, branch, repo,
     });
     const byId = Object.fromEntries(verdict.rungs.map((r) => [r.id, r.status]));
     return byId.P1 === RUNG_STATUS.PASS && byId.P2 === RUNG_STATUS.PASS && byId.P3 === RUNG_STATUS.PASS;
@@ -159,6 +188,7 @@ export function createVentureTrustGate({
       fetchReviewFinding: fetchFinding,
       statusCheckRollup,
       branch,
+      repo: `${repoOwner}/${repoName}`,
     });
   };
 }

--- a/scripts/audit-phantom-completions.js
+++ b/scripts/audit-phantom-completions.js
@@ -27,6 +27,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { execSync } from 'node:child_process';
 import { lookupSdIdForFk } from './modules/auto-trigger-stories.mjs';
+import { probeRepoColumnExists, normalizeGithubRepo } from '../lib/ship/repo-column-probe.mjs';
 
 const args = process.argv.slice(2);
 const APPLY = args.includes('--apply');
@@ -252,11 +253,19 @@ async function main() {
       finding_count: 0,
       finding_categories: {},
       sd_key: item.sd.sd_key,
-      branch: prInfo?.branch || (isOrch ? `<orchestrator-summary>` : null),
+      branch: prInfo?.branch || (isOrch ? '<orchestrator-summary>' : null),
       multi_agent: false,
       synthesized_at: new Date().toISOString(),
       reviewed_at: prInfo?.mergedAt || new Date().toISOString(),
     };
+    // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5: inv.repo is a
+    // BARE name ('EHG_Engineer'/'ehg'), not 'owner/name' -- normalize with
+    // the same 'rickfelix/<repo>' prefix fetchPRMergeInfo() already assumes,
+    // so this write never drifts from the canonical owner/name shape used
+    // by every other insert site (security review blocker #3).
+    if (!isOrch && inv?.repo && await probeRepoColumnExists(supabase)) {
+      row.repo = normalizeGithubRepo(`rickfelix/${inv.repo}`);
+    }
 
     const { error: insErr } = await supabase
       .from('ship_review_findings')

--- a/scripts/backfill-pr-tracking.js
+++ b/scripts/backfill-pr-tracking.js
@@ -35,6 +35,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createSupabaseServiceClient } from './lib/supabase-connection.js';
 import { extractKey } from './lib/branch-key-extractor.js';
+import { probeRepoColumnExists, normalizeGithubRepo } from '../lib/ship/repo-column-probe.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -186,6 +187,12 @@ async function processRepo(repo, opts, supabase, auditPath, resumeMarks) {
       reviewed_at: cls.mergedAt || new Date().toISOString(),
       multi_agent: false,
     };
+    // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5: repo is
+    // already 'owner/name' (the loop var), thread it in once the
+    // chairman-gated column exists.
+    if (repo && await probeRepoColumnExists(supabase)) {
+      row.repo = normalizeGithubRepo(repo);
+    }
     const { error } = await supabase.from('ship_review_findings').insert(row);
     if (error) {
       if (error.code === '23505') {

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/ship-review-findings-populator.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/ship-review-findings-populator.js
@@ -12,6 +12,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { probeRepoColumnExists, normalizeGithubRepo } from '../../../../../../lib/ship/repo-column-probe.mjs';
 
 const KILL_SWITCH = 'LEO_SHIP_REVIEW_POPULATOR_OFF';
 
@@ -94,6 +95,12 @@ export async function runShipReviewFindingsPopulator(sd, supabase) {
     reviewed_at: prInfo.mergedAt || new Date().toISOString(),
     multi_agent: false,
   };
+  // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 FR-5: prInfo.repo is
+  // already resolved by fetchLatestMergedPR; thread it in once the
+  // chairman-gated column exists (never breaks the insert if not).
+  if (prInfo.repo && await probeRepoColumnExists(supabase)) {
+    row.repo = normalizeGithubRepo(prInfo.repo);
+  }
   try {
     const { error } = await supabase.from('ship_review_findings').insert(row);
     if (error) {

--- a/tests/unit/ship/merge-witness-ladder.test.js
+++ b/tests/unit/ship/merge-witness-ladder.test.js
@@ -122,6 +122,17 @@ describe('evaluateP2Witness', () => {
     });
     expect(r.status).toBe(RUNG_STATUS.PASS);
   });
+
+  // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): repo is
+  // forwarded alongside branch, same additive contract.
+  it('forwards repo to fetchReviewFinding as {branch, repo}', async () => {
+    let seen;
+    await evaluateP2Witness({
+      prNumber: 123, tier: 'standard', branch: 'feat/foo', repo: 'rickfelix/apexniche-ai',
+      fetchReviewFinding: async (prNumber, opts) => { seen = { prNumber, opts }; return { verdict: 'pass' }; },
+    });
+    expect(seen).toEqual({ prNumber: 123, opts: { branch: 'feat/foo', repo: 'rickfelix/apexniche-ai' } });
+  });
 });
 
 describe('evaluateP3CI', () => {

--- a/tests/unit/ship/repo-column-probe.test.js
+++ b/tests/unit/ship/repo-column-probe.test.js
@@ -1,0 +1,68 @@
+/**
+ * SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-4/5/6)
+ * repo-column-probe.mjs — capability probe for the chairman-gated
+ * ship_review_findings.repo column, which may ship un-applied for an
+ * indeterminate period (confirmed live for two sibling migrations on this
+ * same table). Every writer/reader must degrade gracefully, never error.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  probeRepoColumnExists,
+  __resetRepoColumnProbeForTests,
+  normalizeGithubRepo,
+} from '../../../lib/ship/repo-column-probe.mjs';
+
+beforeEach(() => {
+  __resetRepoColumnProbeForTests();
+});
+
+function makeSupabase(error) {
+  return {
+    from: () => ({ select: () => ({ limit: () => Promise.resolve({ data: error ? null : [], error }) }) }),
+  };
+}
+
+describe('probeRepoColumnExists', () => {
+  it('returns true when the select succeeds (column present)', async () => {
+    expect(await probeRepoColumnExists(makeSupabase(null))).toBe(true);
+  });
+
+  it('returns false on 42703 (Postgres undefined_column)', async () => {
+    expect(await probeRepoColumnExists(makeSupabase({ code: '42703', message: 'column "repo" does not exist' }))).toBe(false);
+  });
+
+  it('returns false on PGRST204 (PostgREST schema-cache miss)', async () => {
+    expect(await probeRepoColumnExists(makeSupabase({ code: 'PGRST204', message: 'schema cache' }))).toBe(false);
+  });
+
+  it('returns false (uncached) on an unrelated error, and retries fresh next call', async () => {
+    const flaky = makeSupabase({ code: 'ECONNRESET', message: 'network blip' });
+    expect(await probeRepoColumnExists(flaky)).toBe(false);
+    // Not cached -- a subsequent healthy call should flip to true.
+    expect(await probeRepoColumnExists(makeSupabase(null))).toBe(true);
+  });
+
+  it('caches a confirmed "absent" result across calls, even if supabase would now say present', async () => {
+    await probeRepoColumnExists(makeSupabase({ code: '42703', message: 'nope' }));
+    // Cached false wins even though this call would otherwise succeed.
+    expect(await probeRepoColumnExists(makeSupabase(null))).toBe(false);
+  });
+
+  it('caches a confirmed "present" result across calls', async () => {
+    await probeRepoColumnExists(makeSupabase(null));
+    expect(await probeRepoColumnExists(makeSupabase({ code: '42703' }))).toBe(true);
+  });
+
+  it('returns false when supabase is missing', async () => {
+    expect(await probeRepoColumnExists(null)).toBe(false);
+  });
+});
+
+describe('normalizeGithubRepo', () => {
+  it('strips .git suffix and lowercases', () => {
+    expect(normalizeGithubRepo('rickfelix/MarketLens.GIT')).toBe('rickfelix/marketlens');
+  });
+  it('null in, null out', () => {
+    expect(normalizeGithubRepo(null)).toBeNull();
+  });
+});

--- a/tests/unit/ship/review-findings-logger-repo.test.js
+++ b/tests/unit/ship/review-findings-logger-repo.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-5)
+ * logFindings()'s capability-gated repo write: only included once the
+ * chairman-gated ship_review_findings.repo column exists (probed at
+ * runtime), and always normalized ('owner/name', lowercase, no .git).
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { __resetRepoColumnProbeForTests } from '../../../lib/ship/repo-column-probe.mjs';
+import { logFindings } from '../../../lib/ship/review-findings-logger.js';
+
+const state = vi.hoisted(() => ({ insertedRows: [], probeError: null }));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: (cols) => {
+        // probeRepoColumnExists shape: select('repo').limit(1), awaited directly.
+        if (cols === 'repo') {
+          const p = Promise.resolve({ data: state.probeError ? null : [], error: state.probeError });
+          p.limit = () => p;
+          return p;
+        }
+        return {};
+      },
+      insert: (row) => {
+        state.insertedRows.push(row);
+        return { select: () => ({ single: () => Promise.resolve({ data: { id: 'row-1' }, error: null }) }) };
+      },
+    }),
+  }),
+}));
+
+beforeEach(() => {
+  state.insertedRows.length = 0;
+  state.probeError = null;
+  __resetRepoColumnProbeForTests();
+});
+
+const BASE = { prNumber: 1, reviewTier: 'light', riskScore: 0, verdict: 'pass' };
+
+describe('logFindings — repo (FR-5)', () => {
+  it('includes normalized repo when the column exists and repo is supplied', async () => {
+    await logFindings({ ...BASE, repo: 'rickfelix/ApexNiche-AI.git' });
+    expect(state.insertedRows[0].repo).toBe('rickfelix/apexniche-ai');
+  });
+
+  it('omits the repo key entirely when not supplied (byte-identical to pre-FR-5 insert shape)', async () => {
+    await logFindings({ ...BASE });
+    expect('repo' in state.insertedRows[0]).toBe(false);
+  });
+
+  it('omits the repo key when the column is absent (probe 42703), even though repo was supplied', async () => {
+    state.probeError = { code: '42703' };
+    await logFindings({ ...BASE, repo: 'rickfelix/apexniche-ai' });
+    expect('repo' in state.insertedRows[0]).toBe(false);
+    // Every other field still writes normally -- the insert is not blocked.
+    expect(state.insertedRows[0].pr_number).toBe(1);
+  });
+});

--- a/tests/unit/ship/venture-trust-gate.test.js
+++ b/tests/unit/ship/venture-trust-gate.test.js
@@ -4,7 +4,7 @@
  * pre-merge witness evaluator. Pure unit tests against fake Supabase/runner
  * stubs — no live DB.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   normalizeGithubRepo,
   fetchTrustTier,
@@ -13,6 +13,14 @@ import {
   evaluateVenturePrWitness,
   createVentureTrustGate,
 } from '../../../lib/ship/venture-trust-gate.mjs';
+import { __resetRepoColumnProbeForTests } from '../../../lib/ship/repo-column-probe.mjs';
+
+// FR-6's probeRepoColumnExists() caches its result for the process lifetime
+// (by design -- see repo-column-probe.mjs). Reset before every test in this
+// file so one test's cached probe result never leaks into the next.
+beforeEach(() => {
+  __resetRepoColumnProbeForTests();
+});
 
 const GREEN_ROLLUP = [{ status: 'COMPLETED', conclusion: 'SUCCESS' }];
 
@@ -115,13 +123,24 @@ describe('defaultFetchReviewFinding', () => {
   // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001: the mock builder tracks every
   // .eq() call so tests can assert the query is scoped by BOTH pr_number and
   // branch, not pr_number alone (the pre-fix vulnerability).
+  // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): these tests
+  // predate the repo column's existence, so select('repo') (the probe's
+  // shape) reports "absent" (42703) -- defaultFetchReviewFinding then
+  // degrades to the exact pre-FR-6 branch-only path these tests assert.
   function makeFindingSupabase(row) {
     const eqCalls = [];
     const supabase = {
       from: (table) => {
         expect(table).toBe('ship_review_findings');
         const builder = {
-          select: () => builder,
+          select: (cols) => {
+            if (cols === 'repo') {
+              const p = Promise.resolve({ data: null, error: { code: '42703' } });
+              p.limit = () => p;
+              return p;
+            }
+            return builder;
+          },
           eq: (col, val) => { eqCalls.push([col, val]); return builder; },
           order: () => builder,
           limit: () => builder,
@@ -171,7 +190,14 @@ describe('defaultFetchReviewFinding', () => {
     const supabase = {
       from: () => {
         const builder = {
-          select: () => builder,
+          select: (cols) => {
+            if (cols === 'repo') {
+              const p = Promise.resolve({ data: null, error: { code: '42703' } });
+              p.limit = () => p;
+              return p;
+            }
+            return builder;
+          },
           eq: (col, val) => {
             eqCalls.push([col, val]);
             // Simulate a real branch-scoped query: only the matching row is returned.
@@ -191,6 +217,111 @@ describe('defaultFetchReviewFinding', () => {
     const result = await defaultFetchReviewFinding(9, supabase, { branch: 'feat/apex-D1' });
     expect(result).toEqual({ verdict: 'fail' }); // apex's own (failing) row, NEVER marketlens's passing row
     expect(eqCalls).toContainEqual(['branch', 'feat/apex-D1']);
+  });
+});
+
+// SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): the durable
+// Layer 2 on top of FR-1's branch scoping. Once the chairman-gated repo
+// column exists, repo becomes the PRIMARY scope; the branch fallback is
+// additionally restricted to repo IS NULL rows so it never re-opens the
+// cross-repo collision FR-1 closed.
+describe('defaultFetchReviewFinding — repo-scoped (FR-6)', () => {
+  beforeEach(() => {
+    __resetRepoColumnProbeForTests();
+  });
+
+  function makeRepoAwareSupabase({ probeError = null, row = null } = {}) {
+    const eqCalls = [];
+    const isCalls = [];
+    const supabase = {
+      from: (table) => {
+        expect(table).toBe('ship_review_findings');
+        const builder = {
+          select: () => builder,
+          eq: (col, val) => { eqCalls.push([col, val]); return builder; },
+          is: (col, val) => { isCalls.push([col, val]); return builder; },
+          order: () => builder,
+          limit: () => {
+            const p = Promise.resolve({ data: probeError ? null : [], error: probeError });
+            p.maybeSingle = () => Promise.resolve({ data: row, error: null });
+            return p;
+          },
+        };
+        return builder;
+      },
+    };
+    return { supabase, eqCalls, isCalls };
+  }
+
+  it('column present + repo supplied: scopes PRIMARILY by (normalized) repo, not branch', async () => {
+    const { supabase, eqCalls } = makeRepoAwareSupabase({ row: { verdict: 'pass' } });
+    const result = await defaultFetchReviewFinding(9, supabase, {
+      branch: 'feat/apex-D1', repo: 'rickfelix/ApexNiche-AI.git',
+    });
+    expect(result).toEqual({ verdict: 'pass' });
+    expect(eqCalls).toEqual([['pr_number', 9], ['repo', 'rickfelix/apexniche-ai']]);
+  });
+
+  it('column present, no row for this repo: returns null (never falls through to branch)', async () => {
+    const { supabase } = makeRepoAwareSupabase({ row: null });
+    const result = await defaultFetchReviewFinding(9, supabase, { branch: 'feat/apex-D1', repo: 'rickfelix/apexniche-ai' });
+    expect(result).toBeNull();
+  });
+
+  it('column present, no repo supplied: falls back to branch, scoped to repo IS NULL', async () => {
+    const { supabase, eqCalls, isCalls } = makeRepoAwareSupabase({ row: { verdict: 'fail' } });
+    const result = await defaultFetchReviewFinding(9, supabase, { branch: 'feat/apex-D1' });
+    expect(result).toEqual({ verdict: 'fail' });
+    expect(eqCalls).toEqual([['pr_number', 9], ['branch', 'feat/apex-D1']]);
+    expect(isCalls).toEqual([['repo', null]]);
+  });
+
+  it('column absent (probe reports 42703): degrades to pre-FR-6 exact branch-only behavior, no repo eq/is calls', async () => {
+    const { supabase, eqCalls, isCalls } = makeRepoAwareSupabase({ probeError: { code: '42703' }, row: { verdict: 'pass' } });
+    const result = await defaultFetchReviewFinding(9, supabase, { branch: 'feat/apex-D1', repo: 'rickfelix/apexniche-ai' });
+    expect(result).toEqual({ verdict: 'pass' });
+    expect(eqCalls).toEqual([['pr_number', 9], ['branch', 'feat/apex-D1']]);
+    expect(isCalls).toEqual([]);
+  });
+
+  it('no repo AND no branch: returns null without querying at all (fail-closed)', async () => {
+    const { supabase, eqCalls } = makeRepoAwareSupabase({});
+    const result = await defaultFetchReviewFinding(9, supabase, {});
+    expect(result).toBeNull();
+    expect(eqCalls).toEqual([]);
+  });
+
+  // SECURITY (blocker #2 from LEAD security review): the fallback's repo IS
+  // NULL guard is the load-bearing fix -- without it, a populated-but-
+  // different-repo row that merely shares this branch name would re-open
+  // the exact cross-repo fail-open FR-1 closed.
+  it('SECURITY fail-closed: a populated-but-different-repo row sharing this branch name never matches via the fallback', async () => {
+    const isCalls = [];
+    const OTHER_REPO_ROW = { verdict: 'pass', repo: 'rickfelix/marketlens', branch: 'main' };
+    const supabase = {
+      from: () => {
+        const builder = {
+          select: () => builder,
+          eq: (col, val) => { builder._eq = builder._eq || []; builder._eq.push([col, val]); return builder; },
+          is: (col, val) => { isCalls.push([col, val]); return builder; },
+          order: () => builder,
+          limit: () => {
+            const p = Promise.resolve({ data: [], error: null }); // probe: column present
+            p.maybeSingle = () => {
+              const guardApplied = isCalls.some(([c, v]) => c === 'repo' && v === null);
+              // A real `.is('repo', null)` filter excludes OTHER_REPO_ROW
+              // (its repo is non-null) -- mirror that filtering intent.
+              return Promise.resolve({ data: guardApplied ? null : OTHER_REPO_ROW, error: null });
+            };
+            return p;
+          },
+        };
+        return builder;
+      },
+    };
+    const result = await defaultFetchReviewFinding(9, supabase, { branch: 'main' });
+    expect(result).toBeNull(); // guard applied -> excluded -> null, never OTHER_REPO_ROW's verdict
+    expect(isCalls).toEqual([['repo', null]]);
   });
 });
 
@@ -313,6 +444,22 @@ describe('createVentureTrustGate', () => {
     const result = await gate('rickfelix', 'marketlens', undefined, {});
     expect(result).toBe(false);
   });
+
+  // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6): the gate
+  // forwards `${repoOwner}/${repoName}` down to fetchReviewFinding so a
+  // live default can scope by repo once the durable column exists.
+  it('forwards repo ("owner/name") to fetchReviewFinding', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' }]);
+    let seenOpts;
+    const gate = createVentureTrustGate({
+      supabase,
+      fetchStatusCheckRollup: async () => GREEN_ROLLUP,
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async (prNumber, opts) => { seenOpts = opts; return { verdict: 'pass' }; },
+    });
+    await gate('rickfelix', 'marketlens', 99, { workKey: 'SD-XXX-001', tier: 'standard', branch: 'feat/x' });
+    expect(seenOpts).toEqual({ branch: 'feat/x', repo: 'rickfelix/marketlens' });
+  });
 });
 
 // SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001 (SECURITY, TS-1): reproduces the
@@ -332,7 +479,19 @@ describe('live cross-repo collision — apexniche-ai vs marketlens (TS-1)', () =
         }
         if (table === 'ship_review_findings') {
           const builder = {
-            select: () => builder,
+            // SD-APEXNICHE-AI-LEO-GEN-WITNESS-LOOKUP-DURABLE-001 (FR-6):
+            // FINDINGS rows below have no `repo` field -- this shared mock
+            // predates the repo column, so the probe reports "absent" and
+            // defaultFetchReviewFinding degrades to its pre-FR-6 branch-only
+            // path (which these tests exercise via the real implementation).
+            select: (cols) => {
+              if (cols === 'repo') {
+                const p = Promise.resolve({ data: null, error: { code: '42703' } });
+                p.limit = () => p;
+                return p;
+              }
+              return builder;
+            },
             eq: (col, val) => { builder._filters = { ...(builder._filters || {}), [col]: val }; return builder; },
             order: () => builder,
             limit: () => builder,


### PR DESCRIPTION
## Summary
- FR-4: chairman-gated additive `ship_review_findings.repo` migration (staged, not applied)
- FR-5: hoist `gh repo view` resolution in `.claude/commands/ship.md` to a single Step 5.5, thread `repo` into all 4 insert call sites via a shared capability-gated probe (`lib/ship/repo-column-probe.mjs`)
- FR-6: `defaultFetchReviewFinding` scopes primarily by `repo` once the column exists; the legacy branch fallback is restricted to `repo IS NULL` rows so it can never re-open the cross-repo collision the parent SD (`SD-FDBK-FIX-WITNESS-LOOKUP-MATCHES-001`) closed
- LEAD security review (CONDITIONAL-PASS) requirements incorporated: capability-gated degradation, repo-IS-NULL fallback guard, normalized `owner/name` shape across all 4 writers (`audit-phantom-completions.js` previously wrote a bare repo name)
- Docs: new FR-4/5/6 section in `docs/reference/ship-witness-venture-trust-tier.md`

## Test plan
- [x] `npx vitest run --project unit tests/unit/ship/` — 246/246 pass
- [x] `npx vitest run --project unit tests/unit/ship-review-findings-populator.test.js tests/unit/backfill-pr-tracking.test.js` — 15/15 pass
- [x] TESTING sub-agent (EXEC): CONDITIONAL-PASS, 261/261 total
- [x] VALIDATION sub-agent (VERIFY): CONDITIONAL-PASS, all 15 PRD acceptance criteria confirmed
- [x] REGRESSION sub-agent (VERIFY): PASS (confidence 92), full-repo caller sweep, zero regressions
- [x] Migration confirmed NOT applied to live schema (probe returns 42703)

🤖 Generated with [Claude Code](https://claude.com/claude-code)