### PR TITLE
fix(SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001): close feedback authenticated-SELECT caller-venture residual

### DIFF
--- a/database/migrations/20260712_feedback_authenticated_select_caller_venture_STAGED.sql
+++ b/database/migrations/20260712_feedback_authenticated_select_caller_venture_STAGED.sql
@@ -1,0 +1,83 @@
+-- Migration: 20260712_feedback_authenticated_select_caller_venture_STAGED
+-- SD: SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001 (security / RLS residual)
+--
+-- ================================================================
+-- STAGED -- NOT APPLIED BY THIS SD. See "Apply runbook" below.
+-- ================================================================
+--
+-- TIER-2 (NON-ADDITIVE: DROP POLICY) — CHAIRMAN-GATED APPLY. Do NOT auto-apply.
+-- Apply only via the 3-factor ceremony (--issue-token -> MIGRATION_APPLY_TOKEN
+-- + the chairman's @approved-by attestation line, inserted by the scribe upon
+-- verbal approval, directly below this block). An apply without the attestation
+-- line MUST refuse.
+--
+-- THE RESIDUAL: SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 (shipped, PR #6029)
+-- scoped select_feedback_policy from an unconditional USING(true) leak to
+-- USING (feedback_type LIKE 'user_%' AND venture_id IS NOT NULL) -- this closed
+-- the critical cross-venture leak, but that fix's own migration comment
+-- explicitly named the remaining gap: no per-venture CALLER binding. Any
+-- authenticated user can still read any OTHER venture's user_% feedback rows
+-- (title/description/metadata) -- just not ALL feedback unconditionally
+-- anymore. That migration's comment: "The accepted residual (no per-venture
+-- ownership binding) is tracked for a follow-up SD at apply time." This SD is
+-- that follow-up.
+--
+-- THE FIX: add fn_user_has_venture_access(venture_id) as an additional
+-- conjunct. This is the established local idiom (see product_requirements_v2,
+-- sd_phase_handoffs) -- a SECURITY DEFINER helper that returns true
+-- unconditionally for chairman/admin/owner roles (preserving cross-venture
+-- oversight by design on this internal operating-company platform), and
+-- otherwise resolves the venture's company_id and checks user_company_access.
+-- Unlike the anon-role case (structurally inexpressible -- a shared
+-- unauthenticated key can't carry per-caller identity), authenticated callers
+-- DO carry a resolvable auth.uid(), so genuine scoping is expressible here --
+-- this is a predicate addition, not a policy removal.
+--
+-- WHY STAGED, NOT APPLIED HERE: same risk class as the sibling anon-role
+-- DROP (20260712_drop_venture_user_select_feedback_STAGED.sql) -- a live RLS
+-- change on a shared production table. Grounding (SECURITY sub-agent,
+-- 2026-07-12) found zero current authenticated consumers of cross-venture
+-- feedback reads (all EHG_Engineer feedback reads use service_role, which
+-- bypasses RLS; no src/client/app .from('feedback') call sites exist), and
+-- only 3 rows are exposed under current auth population (3 accounts, all
+-- internal). Low practical risk, but a chairman checkpoint on an irreversible
+-- -in-spirit RLS DROP+CREATE stays the appropriately humble default for this
+-- risk class, matching this repo's established precedent.
+--
+-- SCOPE ISOLATION: touches ONLY select_feedback_policy. Does not touch
+-- venture_user_select_feedback (owned by the sibling anon-role SD's own
+-- staged drop) or the service-role-only write policies.
+--
+-- Fail-closed: RLS stays enabled throughout; DROP+CREATE in one transaction
+-- means no observable window, and any fault yields default-deny.
+--
+-- APPLY RUNBOOK (for whoever applies this):
+--   1. Re-confirm (via pg_policies) the live predicate still matches the
+--      SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 post-fix state
+--      (feedback_type LIKE 'user_%' AND venture_id IS NOT NULL) -- if it has
+--      drifted, stop and re-ground before applying.
+--   2. Re-confirm no new authenticated cross-venture consumer of feedback
+--      SELECT has appeared since grounding (grep src/, client/, app/ in both
+--      EHG_Engineer and the ehg repo for .from('feedback') calls using an
+--      authenticated, not service_role, client).
+--   3. Apply this file via the standard apply-migration.js --prod-deploy flow
+--      (git-committed + token + @approved-by guards already satisfied by this
+--      file's own header -- issue a fresh token; tokens are single-use/1h-TTL).
+--   4. Re-verify: with a non-chairman authenticated JWT scoped to venture A's
+--      company, GET /rest/v1/feedback?feedback_type=like.user_* returns only
+--      venture A's rows; with a chairman-role JWT, all matching rows are
+--      still visible (bypass preserved).
+
+BEGIN;
+
+DROP POLICY IF EXISTS select_feedback_policy ON public.feedback;
+
+CREATE POLICY select_feedback_policy ON public.feedback
+  FOR SELECT TO authenticated
+  USING (
+    ((feedback_type)::text LIKE 'user_%')
+    AND (venture_id IS NOT NULL)
+    AND fn_user_has_venture_access(venture_id)
+  );
+
+COMMIT;

--- a/scripts/lint/rls-anon-tenant-predicate-lint.mjs
+++ b/scripts/lint/rls-anon-tenant-predicate-lint.mjs
@@ -121,10 +121,28 @@ function extractParenBlock(text, keywordRe) {
   return null;
 }
 
-const BLANKET_TRUE_RE = /^\s*true\s*$/i;
+// Matches a USING clause that reduces to literal `true`, tolerating any
+// number of redundant wrapping parens (USING (true), USING ((true)), ...) --
+// extractParenBlock only strips the outermost USING(...) paren, so a
+// double-wrapped literal would otherwise slip past a bare /^true$/ match.
+const BLANKET_TRUE_RE = /^\s*\(*\s*true\s*\)*\s*$/i;
 
 /**
- * PURE: classify a SELECT/anon-or-authenticated policy's violation, or null
+ * A policy is in the lint's scope if its role list is anon, authenticated,
+ * PUBLIC (explicit), or PUBLIC-by-omission (Postgres default when a
+ * CREATE POLICY has no TO clause at all -- the broadest, most dangerous
+ * shape, strictly wider than anon or authenticated alone since it also
+ * covers anon+authenticated+every other role).
+ * @param {string[]} roles
+ * @returns {boolean}
+ */
+function isInScopeRoles(roles) {
+  if (!Array.isArray(roles) || roles.length === 0) return true; // implicit PUBLIC
+  return roles.some((r) => SCOPED_ROLES.includes(r) || r === 'public');
+}
+
+/**
+ * PURE: classify a SELECT-or-ALL, in-scope-role policy's violation, or null
  * if clean. Two distinct shapes, both real historical instances:
  *   'unconditional_anon_select' -- USING (true), zero predicate at all (the
  *      companies-table incident, SD-LEO-GEN-SCOPE-ANON-KEY-001, and the
@@ -139,19 +157,29 @@ const BLANKET_TRUE_RE = /^\s*true\s*$/i;
  *      instances, venture_user_select_feedback [anon] and
  *      select_feedback_policy [authenticated]) -- partially scoped but not
  *      by CALLER, so still admits every tenant's rows.
+ * Scope note: FOR ALL grants SELECT (in addition to INSERT/UPDATE/DELETE),
+ * so it carries the same read-confidentiality risk as an explicit FOR SELECT
+ * and is checked identically -- a future policy written as `FOR ALL` instead
+ * of `FOR SELECT` must not silently evade this lint.
  * @param {{cmd:string, roles:string[], using:string|null}} policy
  * @returns {string|null}
  */
 export function classifyViolation(policy) {
-  if (policy.cmd !== 'SELECT') return null;
-  if (!policy.roles.some((r) => SCOPED_ROLES.includes(r))) return null;
+  if (policy.cmd !== 'SELECT' && policy.cmd !== 'ALL') return null;
+  if (!isInScopeRoles(policy.roles)) return null;
   if (!policy.using) return null;
   if (BLANKET_TRUE_RE.test(policy.using)) return 'unconditional_anon_select';
   if (TENANT_COLUMN_RE.test(policy.using) && !IDENTITY_BOUND_RE.test(policy.using)) return 'unbound_tenant_predicate';
   return null;
 }
 
-const scopedRoleLabel = (p) => p.roles.filter((r) => SCOPED_ROLES.includes(r)).join('/');
+// PUBLIC-by-omission (empty roles, no TO clause) and explicit `TO PUBLIC`
+// both label as 'PUBLIC' -- the broadest possible grant, worth naming
+// distinctly from a plain anon/authenticated list in the reported message.
+const scopedRoleLabel = (p) => {
+  if (!Array.isArray(p.roles) || p.roles.length === 0 || p.roles.includes('public')) return 'PUBLIC';
+  return p.roles.filter((r) => SCOPED_ROLES.includes(r)).join('/');
+};
 
 const VIOLATION_MESSAGES = {
   unconditional_anon_select: (p) =>

--- a/scripts/lint/rls-anon-tenant-predicate-lint.mjs
+++ b/scripts/lint/rls-anon-tenant-predicate-lint.mjs
@@ -1,23 +1,28 @@
 #!/usr/bin/env node
 /**
- * RLS anon-role tenant-predicate-sufficiency lint.
+ * RLS anon/authenticated-role tenant-predicate-sufficiency lint.
  *
  * SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001 FR-4.
+ * Extended to the authenticated role by SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001 FR-3.
  *
- * This exact bug class -- an anon-role SELECT RLS policy referencing a
- * tenant-shaped column (venture_id/tenant_id/etc.) without binding it to the
- * caller's own identity -- already recurred once (companies table,
- * SD-LEO-GEN-SCOPE-ANON-KEY-001) before this SD's feedback-table instance
- * (venture_user_select_feedback). That lesson never became a
- * recurrence-preventing lint. This one scans migration SQL text for the
+ * This exact bug class -- a SELECT RLS policy referencing a tenant-shaped
+ * column (venture_id/tenant_id/etc.) without binding it to the caller's own
+ * identity -- has now recurred three times: companies table (anon,
+ * SD-LEO-GEN-SCOPE-ANON-KEY-001), feedback table anon policy
+ * (venture_user_select_feedback, SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001),
+ * and feedback table authenticated policy (select_feedback_policy,
+ * SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001). The first extension of this
+ * lint covered only anon; that scope gap is exactly why the authenticated
+ * instance shipped undetected. This one scans migration SQL text for the
  * pattern directly, rather than the live DB, so it can run in CI on a PR
  * diff before a bad policy is ever applied.
  *
- * Scope: SELECT-cmd, anon-role policies ONLY. An INSERT/UPDATE/DELETE policy
- * referencing a tenant column (e.g. venture_user_insert_feedback's WITH CHECK
- * venture_id IS NOT NULL AND ...) is a DIFFERENT risk class (write-integrity/
- * spam, not read-confidentiality leakage) and is deliberately not flagged --
- * neither of this lint's two motivating real instances is an INSERT policy.
+ * Scope: SELECT-cmd, anon OR authenticated-role policies. An INSERT/UPDATE/
+ * DELETE policy referencing a tenant column (e.g. venture_user_insert_feedback's
+ * WITH CHECK venture_id IS NOT NULL AND ...) is a DIFFERENT risk class
+ * (write-integrity/spam, not read-confidentiality leakage) and is
+ * deliberately not flagged -- none of this lint's motivating real instances
+ * is an INSERT policy.
  *
  * Detection is a pragmatic regex/paren-balance extractor on CREATE POLICY
  * statements, not a full SQL parser -- mirrors this repo's own established
@@ -45,7 +50,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 const TENANT_COLUMN_RE = /\b(venture_id|tenant_id|org_id|company_id|portfolio_id|account_id)\b/i;
-const IDENTITY_BOUND_RE = /\bauth\.(uid|jwt)\s*\(/i;
+// auth.uid()/auth.jwt() (raw caller-identity primitives) AND the established
+// SECURITY DEFINER caller-binding helpers used elsewhere in this schema
+// (product_requirements_v2, sd_phase_handoffs): fn_user_has_venture_access,
+// fn_user_has_company_access. A predicate calling any of these is
+// caller-bound even though it doesn't reference auth.*() directly itself.
+const IDENTITY_BOUND_RE = /\bauth\.(uid|jwt)\s*\(|\bfn_user_has_(venture|company)_access\s*\(/i;
+const SCOPED_ROLES = ['anon', 'authenticated'];
 
 /**
  * PURE: extract CREATE POLICY statements from SQL text as {name, table, cmd,
@@ -113,34 +124,40 @@ function extractParenBlock(text, keywordRe) {
 const BLANKET_TRUE_RE = /^\s*true\s*$/i;
 
 /**
- * PURE: classify a SELECT/anon policy's violation, or null if clean. Two
- * distinct shapes, both real historical instances:
+ * PURE: classify a SELECT/anon-or-authenticated policy's violation, or null
+ * if clean. Two distinct shapes, both real historical instances:
  *   'unconditional_anon_select' -- USING (true), zero predicate at all (the
- *      companies-table incident, SD-LEO-GEN-SCOPE-ANON-KEY-001) -- flagged
- *      regardless of whether the table has any tenant-shaped column, since
- *      blanket anon SELECT access is inherently risky on its own.
+ *      companies-table incident, SD-LEO-GEN-SCOPE-ANON-KEY-001, and the
+ *      feedback-table authenticated-role instance pre-fix,
+ *      SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001) -- flagged regardless of
+ *      whether the table has any tenant-shaped column, since blanket
+ *      unauthenticated-or-any-logged-in-user SELECT access is inherently
+ *      risky on its own. Name kept for stability even though it now also
+ *      fires for authenticated -- it describes the SHAPE, not the role.
  *   'unbound_tenant_predicate' -- USING references a tenant-shaped column
  *      without binding it to the caller's identity (the feedback-table
- *      instance, venture_user_select_feedback, this SD) -- partially scoped
- *      but not by CALLER, so still admits every tenant's rows.
+ *      instances, venture_user_select_feedback [anon] and
+ *      select_feedback_policy [authenticated]) -- partially scoped but not
+ *      by CALLER, so still admits every tenant's rows.
  * @param {{cmd:string, roles:string[], using:string|null}} policy
  * @returns {string|null}
  */
 export function classifyViolation(policy) {
   if (policy.cmd !== 'SELECT') return null;
-  if (!policy.roles.includes('anon')) return null;
+  if (!policy.roles.some((r) => SCOPED_ROLES.includes(r))) return null;
   if (!policy.using) return null;
   if (BLANKET_TRUE_RE.test(policy.using)) return 'unconditional_anon_select';
   if (TENANT_COLUMN_RE.test(policy.using) && !IDENTITY_BOUND_RE.test(policy.using)) return 'unbound_tenant_predicate';
   return null;
 }
 
+const scopedRoleLabel = (p) => p.roles.filter((r) => SCOPED_ROLES.includes(r)).join('/');
 
 const VIOLATION_MESSAGES = {
   unconditional_anon_select: (p) =>
-    `Anon-role SELECT policy '${p.name}' ON ${p.table} has an unconditional USING (true) -- any anon-key holder can read ALL rows. See SD-LEO-GEN-SCOPE-ANON-KEY-001 (companies table) for the prior real instance of this class.`,
+    `${scopedRoleLabel(p)}-role SELECT policy '${p.name}' ON ${p.table} has an unconditional USING (true) -- any ${scopedRoleLabel(p) === 'anon' ? 'anon-key holder' : 'matching-role caller'} can read ALL rows. See SD-LEO-GEN-SCOPE-ANON-KEY-001 (companies table) and SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 (feedback table, authenticated) for prior real instances of this class.`,
   unbound_tenant_predicate: (p) =>
-    `Anon-role SELECT policy '${p.name}' ON ${p.table} references tenant column '${TENANT_COLUMN_RE.exec(p.using)[1]}' in USING without binding it to auth.uid()/auth.jwt() -- any anon-key holder can read every tenant's rows. See SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001 (feedback table) for the prior real instance of this class.`,
+    `${scopedRoleLabel(p)}-role SELECT policy '${p.name}' ON ${p.table} references tenant column '${TENANT_COLUMN_RE.exec(p.using)[1]}' in USING without binding it to auth.uid()/auth.jwt()/fn_user_has_venture_access()/fn_user_has_company_access() -- any ${scopedRoleLabel(p) === 'anon' ? 'anon-key holder' : 'matching-role caller'} can read every tenant's rows. See SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001 (feedback table, anon) and SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001 (feedback table, authenticated) for prior real instances of this class.`,
 };
 
 /**

--- a/tests/unit/lint/feedback-authenticated-select-caller-venture-migration.test.js
+++ b/tests/unit/lint/feedback-authenticated-select-caller-venture-migration.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001 US-004/US-005 — regression
+ * tests for the staged migration's policy definition. The migration is
+ * deliberately STAGED (not auto-applied -- chairman-gated, same risk class
+ * as the sibling anon-role DROP), so these are structural/SQL-text tests of
+ * the committed policy definition, not live-DB behavioral tests. Live
+ * behavioral verification (chairman sees all ventures; a scoped user sees
+ * only their own) is deferred to the migration's own Apply Runbook step 4,
+ * executed at apply time -- see the migration file's header comment.
+ */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import { extractPolicies, classifyViolation } from '../../../scripts/lint/rls-anon-tenant-predicate-lint.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = path.resolve(
+  __dirname,
+  '../../../database/migrations/20260712_feedback_authenticated_select_caller_venture_STAGED.sql'
+);
+
+function loadPolicy() {
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+  const policies = extractPolicies(sql);
+  const policy = policies.find((p) => p.name === 'select_feedback_policy');
+  if (!policy) throw new Error('select_feedback_policy not found in migration SQL');
+  return policy;
+}
+
+describe('US-001/US-002: migration ships the caller-venture predicate, staged', () => {
+  it('the migration is explicitly marked STAGED / NOT APPLIED in its header', () => {
+    const sql = readFileSync(MIGRATION_PATH, 'utf8');
+    expect(sql).toMatch(/STAGED\s*--\s*NOT APPLIED/i);
+    expect(sql).toMatch(/CHAIRMAN-GATED APPLY/i);
+    expect(sql).toMatch(/APPLY RUNBOOK/i);
+  });
+
+  it('the policy targets the authenticated role for SELECT on public.feedback', () => {
+    const p = loadPolicy();
+    expect(p.table).toBe('feedback');
+    expect(p.cmd).toBe('SELECT');
+    expect(p.roles).toEqual(['authenticated']);
+  });
+
+  it('the existing feedback_type/venture_id guard is preserved (no widening)', () => {
+    const p = loadPolicy();
+    expect(p.using).toMatch(/feedback_type.*LIKE.*'user_%'/i);
+    expect(p.using).toMatch(/venture_id IS NOT NULL/i);
+  });
+});
+
+describe('US-004: chairman/oversight bypass is preserved', () => {
+  it('the predicate calls fn_user_has_venture_access(venture_id), which returns true unconditionally for chairman/admin/owner', () => {
+    const p = loadPolicy();
+    expect(p.using).toMatch(/fn_user_has_venture_access\s*\(\s*venture_id\s*\)/i);
+  });
+});
+
+describe('US-005: cross-venture read is blocked for scoped (non-chairman) users', () => {
+  it('the policy no longer classifies as an unbound_tenant_predicate violation under the (now authenticated-aware) lint', () => {
+    const p = loadPolicy();
+    expect(classifyViolation(p)).toBeNull();
+  });
+
+  it('control: the migration this SD supersedes (pre-caller-venture-binding shape) WOULD have been flagged', () => {
+    const [p] = extractPolicies(
+      "CREATE POLICY select_feedback_policy ON public.feedback FOR SELECT TO authenticated USING (((feedback_type)::text LIKE 'user_%') AND (venture_id IS NOT NULL));"
+    );
+    expect(classifyViolation(p)).toBe('unbound_tenant_predicate');
+  });
+});

--- a/tests/unit/lint/rls-anon-tenant-predicate-lint.test.js
+++ b/tests/unit/lint/rls-anon-tenant-predicate-lint.test.js
@@ -148,6 +148,41 @@ describe('classifyViolation — the two real historical instance shapes', () => 
     expect(classifyViolation(p)).toBeNull();
   });
 
+  it('CRITICAL-fix: flags a FOR ALL policy (ALL grants SELECT too, same read-confidentiality class)', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY leaky ON public.feedback FOR ALL TO authenticated USING (venture_id IS NOT NULL);'
+    );
+    expect(classifyViolation(p)).toBe('unbound_tenant_predicate');
+  });
+
+  it('CRITICAL-fix: flags a FOR ALL, unconditional USING (true) policy', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY leaky2 ON public.feedback FOR ALL TO authenticated USING (true);'
+    );
+    expect(classifyViolation(p)).toBe('unconditional_anon_select');
+  });
+
+  it('CRITICAL-fix: flags a policy with NO TO clause (implicit PUBLIC -- broader than anon or authenticated alone)', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY leaky3 ON public.feedback FOR SELECT USING (true);'
+    );
+    expect(classifyViolation(p)).toBe('unconditional_anon_select');
+  });
+
+  it('CRITICAL-fix: flags a policy with explicit TO PUBLIC', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY leaky4 ON public.feedback FOR SELECT TO PUBLIC USING (venture_id IS NOT NULL);'
+    );
+    expect(classifyViolation(p)).toBe('unbound_tenant_predicate');
+  });
+
+  it('WARNING-fix: flags a double-parenthesized unconditional USING ((true))', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY leaky5 ON public.feedback FOR SELECT TO authenticated USING ((true));'
+    );
+    expect(classifyViolation(p)).toBe('unconditional_anon_select');
+  });
+
   it('does not flag an INSERT/UPDATE/DELETE policy referencing a tenant column (different risk class)', () => {
     const [p] = extractPolicies(
       'CREATE POLICY venture_user_insert_feedback ON public.feedback FOR INSERT TO anon WITH CHECK (venture_id IS NOT NULL);'

--- a/tests/unit/lint/rls-anon-tenant-predicate-lint.test.js
+++ b/tests/unit/lint/rls-anon-tenant-predicate-lint.test.js
@@ -1,13 +1,24 @@
 /**
  * SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001 FR-4 — RLS anon-role
  * tenant-predicate-sufficiency lint.
+ * Extended to the authenticated role by SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001 FR-3.
  *
- * Pins detection of BOTH real historical instances of this bug class:
+ * Pins detection of all real historical instances of this bug class:
  *   - companies table (SD-LEO-GEN-SCOPE-ANON-KEY-001): USING (true), a
  *     blanket unconditional anon SELECT.
- *   - feedback table (this SD): USING references venture_id but never binds
- *     it to the caller's identity.
- * And confirms a properly-scoped policy passes clean.
+ *   - feedback table anon policy (SD-APEXNICHE-AI-MAN-FIX-FIX-CROSS-TENANT-001):
+ *     USING references venture_id but never binds it to the caller's identity.
+ *   - feedback table authenticated policy, pre-fix shape
+ *     (SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001): USING (true), unconditional
+ *     for any logged-in user -- the lint's anon-only scope originally missed
+ *     this class entirely.
+ *   - feedback table authenticated policy, post-first-fix shape
+ *     (SD-LEO-FIX-FINGERPRINT-CRITICAL-SECURITY-001): venture_id referenced
+ *     but not caller-bound -- same unbound_tenant_predicate shape as the anon
+ *     instance, just on the authenticated role.
+ * And confirms properly-scoped policies (auth.uid(), auth.jwt(), and the
+ * fn_user_has_venture_access/fn_user_has_company_access SECURITY DEFINER
+ * helper idiom) pass clean.
  */
 import { describe, it, expect } from 'vitest';
 import { extractPolicies, classifyViolation, lintSql } from '../../../scripts/lint/rls-anon-tenant-predicate-lint.mjs';
@@ -95,9 +106,44 @@ describe('classifyViolation — the two real historical instance shapes', () => 
     expect(classifyViolation(p)).toBeNull();
   });
 
-  it('does not flag a non-anon-role policy (e.g. authenticated qual=true)', () => {
+  it('AC (FR-3): flags an authenticated-role unconditional USING (true) (the feedback-table pre-fix shape, SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001)', () => {
     const [p] = extractPolicies(
       'CREATE POLICY select_feedback_policy ON public.feedback FOR SELECT TO authenticated USING (true);'
+    );
+    expect(classifyViolation(p)).toBe('unconditional_anon_select');
+  });
+
+  it('AC (FR-3): flags an authenticated-role policy referencing a tenant column without caller-binding (this SD\'s own finding)', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY select_feedback_policy ON public.feedback FOR SELECT TO authenticated USING (feedback_type LIKE \'user_%\' AND venture_id IS NOT NULL);'
+    );
+    expect(classifyViolation(p)).toBe('unbound_tenant_predicate');
+  });
+
+  it('AC (FR-3): does NOT flag an authenticated-role policy bound via fn_user_has_venture_access (this SD\'s own fix)', () => {
+    const [p] = extractPolicies(
+      "CREATE POLICY select_feedback_policy ON public.feedback FOR SELECT TO authenticated USING (feedback_type LIKE 'user_%' AND venture_id IS NOT NULL AND fn_user_has_venture_access(venture_id));"
+    );
+    expect(classifyViolation(p)).toBeNull();
+  });
+
+  it('AC (FR-3): does NOT flag a policy bound via a user_company_access join subquery referencing auth.uid()', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY good ON public.modeling_requests FOR SELECT TO authenticated USING (company_id IN (SELECT company_id FROM user_company_access WHERE user_id = auth.uid() AND is_active));'
+    );
+    expect(classifyViolation(p)).toBeNull();
+  });
+
+  it('AC (FR-3): does NOT flag a policy bound via the JWT venture_id claim idiom', () => {
+    const [p] = extractPolicies(
+      "CREATE POLICY good ON public.ops_table FOR SELECT TO authenticated USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);"
+    );
+    expect(classifyViolation(p)).toBeNull();
+  });
+
+  it('does not flag a role not in the scoped set (e.g. service_role)', () => {
+    const [p] = extractPolicies(
+      'CREATE POLICY svc ON public.feedback FOR SELECT TO service_role USING (true);'
     );
     expect(classifyViolation(p)).toBeNull();
   });


### PR DESCRIPTION
## Summary
- `select_feedback_policy` (authenticated role) was already scoped from an unconditional cross-venture leak to `feedback_type LIKE 'user_%' AND venture_id IS NOT NULL` by SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 (shipped, PR #6029) -- that critical leak is closed.
- This SD closes the residual that fix explicitly deferred: no caller-venture binding, so any authenticated user could still read any OTHER venture's user_% feedback. Adds `fn_user_has_venture_access(venture_id)` -- the established local idiom (product_requirements_v2, sd_phase_handoffs) that preserves the chairman/admin/owner cross-venture oversight bypass.
- Migration ships **STAGED** (chairman-gated, not auto-applied), matching the sibling anon-role fix's precedent for live RLS changes on a shared production table.
- Extends `scripts/lint/rls-anon-tenant-predicate-lint.mjs` (previously anon-role-only) to also cover authenticated-role policies -- the exact scope gap that let this residual ship undetected in the first place.

## Test plan
- [x] 25 unit tests pass (`tests/unit/lint/rls-anon-tenant-predicate-lint.test.js` + new `tests/unit/lint/feedback-authenticated-select-caller-venture-migration.test.js`), including true-positive/true-negative cases for all 3 local caller-binding idioms (`fn_user_has_venture_access`, `user_company_access` join, JWT `venture_id` claim)
- [x] Lint `--diff` mode confirms zero violations on this branch's actual changes; `--all` advisory sweep confirms the new migration itself is clean
- [x] Independently verified `fn_user_has_venture_access`/`fn_is_chairman`/`fn_user_has_company_access` exist live via `pg_proc` before writing the migration
- [x] Live behavioral verification (chairman bypass preserved, cross-venture read blocked) deferred to the migration's own Apply Runbook -- staged migrations can't be behaviorally tested pre-apply by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)