### PR TITLE
fix(SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001): reaper honors self-claimed QF live claims, fails closed

### DIFF
--- a/lib/worktree-reaper/live-claim-guard.js
+++ b/lib/worktree-reaper/live-claim-guard.js
@@ -105,12 +105,17 @@ export async function liveClaimBlocksRemoval(supabase, wtPath, opts = {}) {
 
     // Half-write case: SD-side claim cleared but a LIVE session still points at the
     // key via its session row (the same case foreignClaimantBlocksSteal covers).
-    const col = parsed.kind === 'sd' ? 'sd_key' : 'qf_id';
-    const { data: sessions, error: vErr } = await supabase
-      .from('v_active_sessions')
-      .select(SESSION_FIELDS)
-      .eq(col, parsed.key)
-      .limit(1);
+    // SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001 (RCA 7c61d78f, DATABASE 302bb2c7): a
+    // SELF-CLAIMED QF records its live claim ONLY in claude_sessions.sd_key='QF-...'
+    // (quick_fixes.claiming_session_id NULL, so v_active_sessions.qf_id is NULL — it
+    // derives from the claiming_session_id join, NOT sd_key). Scanning qf_id alone
+    // returned no_live_claim and the reaper DESTROYED the live worktree. The scan must
+    // match a live session by EITHER representation: for a QF, sd_key OR qf_id.
+    let scan = supabase.from('v_active_sessions').select(SESSION_FIELDS);
+    scan = parsed.kind === 'sd'
+      ? scan.eq('sd_key', parsed.key)
+      : scan.or(`sd_key.eq.${parsed.key},qf_id.eq.${parsed.key}`);
+    const { data: sessions, error: vErr } = await scan.limit(1);
     if (vErr) {
       return { blocked: true, reason: 'unverifiable_session_scan_error', detail: { ...parsed, error: vErr.message } };
     }

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -298,10 +298,16 @@ function getSupabaseClient() {
 async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 1000, repoRoot = process.cwd() } = {}) {
   const map = new Map();
   if (!supabase) return map;
+  // SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001 (FR-4, DATABASE 302bb2c7): do NOT gate on
+  // computed_status='active'. computed_status flips to 'idle' the instant a live session's
+  // sd_key reads NULL (a claim clear→reset window) and to 'stale' at heartbeat>600s — both
+  // would DROP a still-live session's row from the claim map, un-protecting its worktree.
+  // Select every non-released session (the view already excludes released) and filter for
+  // liveness by the heartbeat threshold in the loop below.
   const { data, error } = await supabase
     .from('v_active_sessions')
     .select('session_id, sd_key, qf_id, current_branch, heartbeat_at, computed_status')
-    .eq('computed_status', 'active');
+    .or('sd_key.not.is.null,qf_id.not.is.null');
   if (error) {
     throw new Error(
       `[reaper] loadClaimMap query failed: ${error.message}` +
@@ -322,7 +328,8 @@ async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 100
     return m ? m[1] : null;
   }
   for (const row of data) {
-    if (row.computed_status && row.computed_status !== 'active') continue;
+    // FR-4: liveness is decided by heartbeat freshness ONLY (not computed_status), so a
+    // churning-but-live session (momentarily 'idle'/'stale') is retained and protected.
     if (row.heartbeat_at) {
       const hb = new Date(row.heartbeat_at).getTime();
       if (Number.isFinite(hb) && now - hb > heartbeatThresholdMs) continue;
@@ -333,7 +340,12 @@ async function loadClaimMap(supabase, { heartbeatThresholdMs = 2 * 60 * 60 * 100
       session_id: row.session_id,
       heartbeat_at: row.heartbeat_at,
     };
-    if (row.sd_key) addCandidate(path.join(worktreesDir, row.sd_key), info);
+    if (row.sd_key) {
+      // FR-2: a self-claimed QF lives in sd_key (qf_id NULL). Derive BOTH the flat
+      // .worktrees/<key> AND, for a QF-shaped key, the real typed .worktrees/qf/<key>.
+      addCandidate(path.join(worktreesDir, row.sd_key), info);
+      if (/^QF-/i.test(row.sd_key)) addCandidate(path.join(worktreesDir, 'qf', row.sd_key), info);
+    }
     if (row.qf_id) addCandidate(path.join(worktreesDir, 'qf', row.qf_id), info);
     const branchBase = branchToBasename(row.current_branch);
     if (branchBase) {
@@ -374,10 +386,12 @@ async function loadClaimedKeySet(supabase) {
   const set = new Set();
   if (!supabase) return set;
   try {
+    // FR-4: identity + non-released, not computed_status='active' (which drops a
+    // churning-but-live session whose sd_key momentarily reads NULL → 'idle').
     const { data } = await supabase
       .from('v_active_sessions')
       .select('sd_key, qf_id, computed_status')
-      .eq('computed_status', 'active');
+      .or('sd_key.not.is.null,qf_id.not.is.null');
     for (const r of data || []) {
       if (r.sd_key) set.add(r.sd_key);
       if (r.qf_id) set.add(r.qf_id);
@@ -981,9 +995,24 @@ function runPhantomOnlyMode({ repoRoot, worktrees }) {
  * @returns {Promise<object>} the runOrphanSweep result
  */
 async function runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execute }) {
-  const owners = supabase ? await loadClaimMap(supabase).catch(() => new Map()) : new Map();
+  // SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001 (FR-3, RCA 7c61d78f): loadClaimMap was
+  // hardened to THROW on query error (QF-20260510-WT-CLAIM-PROTECT-001), but the prior
+  // `.catch(() => new Map())` here swallowed that throw back into an EMPTY owner set —
+  // resurrecting the exact silent fail-open, so the sweep would reclaim EVERYTHING. Fail
+  // CLOSED: if the claim map cannot be built, force DRY-RUN (reclaim nothing), mirroring
+  // the Supabase-unavailable branch below. An unverifiable owner set must never widen removal.
+  let owners = new Map();
+  let claimMapFailed = false;
+  if (supabase) {
+    try {
+      owners = await loadClaimMap(supabase);
+    } catch (e) {
+      claimMapFailed = true;
+      console.log(`🧹 Orphan sweep: claim-map build FAILED (${e?.message || e}) — forcing DRY-RUN (cannot verify active-claim ownership; refusing to reclaim).`);
+    }
+  }
   const liveOwners = new Set([...owners.keys()]);
-  const effectiveExecute = execute && !!supabase;
+  const effectiveExecute = execute && !!supabase && !claimMapFailed;
   if (execute && !supabase) {
     console.log('🧹 Orphan sweep: Supabase unavailable — running DRY-RUN (cannot verify active-claim ownership).');
   }

--- a/tests/unit/worktree-reaper-qf-selfclaim-guard.test.js
+++ b/tests/unit/worktree-reaper-qf-selfclaim-guard.test.js
@@ -57,7 +57,11 @@ describe('liveClaimBlocksRemoval — self-claimed QF (QF-20260712-008 incident s
 
 describe('loadClaimMap — self-claimed QF path derivation (FR-2/FR-4)', () => {
   const repoRoot = 'C:/repo';
-  const sep = (p) => p.replace(/\\/g, '/').toLowerCase(); // match normalizePath (lowercased, fwd-slash)
+  // normalizePath does path.resolve → prefix is cwd-dependent on POSIX (CI) vs Windows.
+  // Assert on the platform-agnostic SUFFIX (lowercased, forward-slash).
+  const hasQfPath = (map) =>
+    [...map.keys()].map((k) => k.replace(/\\/g, '/').toLowerCase())
+      .some((k) => k.endsWith('/.worktrees/qf/qf-20260712-008'));
 
   /** Mock the v_active_sessions .or(...) select used by loadClaimMap. */
   function claimMapSupabase(rows) {
@@ -70,8 +74,8 @@ describe('loadClaimMap — self-claimed QF path derivation (FR-2/FR-4)', () => {
       { session_id: 's1', sd_key: 'QF-20260712-008', qf_id: null, current_branch: 'qf/QF-20260712-008', heartbeat_at: now, computed_status: 'active' },
     ]);
     const map = await loadClaimMap(supabase, { repoRoot });
-    const keys = [...map.keys()].map(sep);
-    expect(keys).toContain('c:/repo/.worktrees/qf/qf-20260712-008');
+    
+    expect(hasQfPath(map)).toBe(true);
   });
 
   it('FR-4: a churning session reported computed_status=idle is still mapped (heartbeat is fresh)', async () => {
@@ -80,7 +84,7 @@ describe('loadClaimMap — self-claimed QF path derivation (FR-2/FR-4)', () => {
       { session_id: 's2', sd_key: 'QF-20260712-008', qf_id: null, current_branch: null, heartbeat_at: now, computed_status: 'idle' },
     ]);
     const map = await loadClaimMap(supabase, { repoRoot });
-    const keys = [...map.keys()].map(sep);
-    expect(keys).toContain('c:/repo/.worktrees/qf/qf-20260712-008');
+    
+    expect(hasQfPath(map)).toBe(true);
   });
 });

--- a/tests/unit/worktree-reaper-qf-selfclaim-guard.test.js
+++ b/tests/unit/worktree-reaper-qf-selfclaim-guard.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001 — regression pins for the 3rd-recurrence
+ * DESTRUCTIVE reap of a live self-claimed QF worktree (.worktrees/qf/QF-20260712-008,
+ * Alpha-6). RCA 7c61d78f / DATABASE 302bb2c7: a self-claimed QF records its live claim
+ * ONLY in claude_sessions.sd_key='QF-...' (quick_fixes.claiming_session_id NULL, so
+ * v_active_sessions.qf_id is NULL). The guard scanned qf_id alone → no_live_claim →
+ * the reaper destroyed the live worktree. The fix reads BOTH representations and the
+ * claim map derives the typed qf/ path; both are pinned here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { liveClaimBlocksRemoval } from '../../lib/worktree-reaper/live-claim-guard.js';
+import { loadClaimMap } from '../../scripts/worktree-reaper.mjs';
+
+const alive = () => ({ alive: true });
+
+/**
+ * Mock supporting the FR-1 shape: quick_fixes.claiming_session_id lookup (maybeSingle)
+ * returns NULL (self-claim), then a v_active_sessions .or(sd_key|qf_id) scan (.limit).
+ * `orRows` is what the .or scan returns; `orError` injects a scan error (fail-closed test).
+ */
+function mockSupabase({ orRows = [], orError = null } = {}) {
+  return {
+    from: vi.fn((table) => ({
+      select: vi.fn().mockReturnThis(),
+      // quick_fixes.eq('id', key).maybeSingle() → no SD-side claim (self-claim)
+      eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { claiming_session_id: null }, error: null }) })),
+      // v_active_sessions.or(...).limit(1) → the live-session scan
+      or: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: orRows, error: orError }) })),
+    })),
+  };
+}
+
+describe('liveClaimBlocksRemoval — self-claimed QF (QF-20260712-008 incident shape)', () => {
+  const WT = 'c:/repo/.worktrees/qf/qf-20260712-008';
+
+  it('THE FIX: a QF whose only live signal is a session pointing via sd_key => BLOCKED (was destroyed before)', async () => {
+    const supabase = mockSupabase({ orRows: [{ session_id: 'sess-alpha6', sd_key: 'QF-20260712-008', qf_id: null }] });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: alive });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('live_session_pointing');
+  });
+
+  it('genuine orphan: no live session by sd_key OR qf_id => not blocked (no over-protection)', async () => {
+    const supabase = mockSupabase({ orRows: [] });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: alive });
+    expect(r.blocked).toBe(false);
+    expect(r.reason).toBe('no_live_claim');
+  });
+
+  it('FAIL-CLOSED: the sd_key/qf_id scan errors => BLOCKED', async () => {
+    const supabase = mockSupabase({ orError: { message: 'connection reset' } });
+    const r = await liveClaimBlocksRemoval(supabase, WT, { isSessionAliveFn: alive });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('unverifiable_session_scan_error');
+  });
+});
+
+describe('loadClaimMap — self-claimed QF path derivation (FR-2/FR-4)', () => {
+  const repoRoot = 'C:/repo';
+  const sep = (p) => p.replace(/\\/g, '/').toLowerCase(); // match normalizePath (lowercased, fwd-slash)
+
+  /** Mock the v_active_sessions .or(...) select used by loadClaimMap. */
+  function claimMapSupabase(rows) {
+    return { from: vi.fn(() => ({ select: vi.fn().mockReturnThis(), or: vi.fn().mockResolvedValue({ data: rows, error: null }) })) };
+  }
+
+  it('FR-2: a session with sd_key=QF-X (qf_id NULL) maps to .worktrees/qf/QF-X', async () => {
+    const now = new Date().toISOString();
+    const supabase = claimMapSupabase([
+      { session_id: 's1', sd_key: 'QF-20260712-008', qf_id: null, current_branch: 'qf/QF-20260712-008', heartbeat_at: now, computed_status: 'active' },
+    ]);
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const keys = [...map.keys()].map(sep);
+    expect(keys).toContain('c:/repo/.worktrees/qf/qf-20260712-008');
+  });
+
+  it('FR-4: a churning session reported computed_status=idle is still mapped (heartbeat is fresh)', async () => {
+    const now = new Date().toISOString();
+    const supabase = claimMapSupabase([
+      { session_id: 's2', sd_key: 'QF-20260712-008', qf_id: null, current_branch: null, heartbeat_at: now, computed_status: 'idle' },
+    ]);
+    const map = await loadClaimMap(supabase, { repoRoot });
+    const keys = [...map.keys()].map(sep);
+    expect(keys).toContain('c:/repo/.worktrees/qf/qf-20260712-008');
+  });
+});


### PR DESCRIPTION
## Summary
3rd-recurrence DESTRUCTIVE reap of a live mid-flight QF worktree. RCA 7c61d78f (DATABASE PASS 302bb2c7, confidence 96): writer/consumer asymmetry — a self-claimed QF's live claim lives ONLY in `claude_sessions.sd_key='QF-...'`, but the reaper's guards read `quick_fixes.claiming_session_id` / `v_active_sessions.qf_id` (both NULL), so `liveClaimBlocksRemoval` returned `no_live_claim` cleanly and destroyed the worktree.

- **FR-1** guard scans `sd_key` OR `qf_id` for QFs (the load-bearing fix)
- **FR-2** `loadClaimMap` derives the typed `.worktrees/qf/<key>` path for a QF-shaped `sd_key`
- **FR-3** orphan sweep fails CLOSED (removed `.catch(()=>new Map())`)
- **FR-4** active-claim reads keep churning-but-live sessions (identity+heartbeat, not `computed_status='active'`)
- **FR-5** regression pins: exact QF-20260712-008 shape, fail-closed, churn window

## Test plan
- `tests/unit/worktree-reaper-qf-selfclaim-guard.test.js` (5) + existing guard regressions (18) = 23 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)