### PR TITLE
feat(SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-I1): ground new ventures in the operating-model SSOT

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -28,6 +28,8 @@ import { buildLeoBridgeClaudeMd, buildLeoBridgeBuildTasks } from './leo-bridge-s
 import { buildReplitConfig } from './replit-config-writer.js';
 // SD-LEO-INFRA-VENTURE-REPO-TRUST-001: born-trusted elevation at genuine repo mint.
 import { elevateVentureRepoTrust } from './trust-elevation.js';
+// SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-I1: inherit the operating-model SSOT at provisioning time.
+import OPERATING_MODEL from '../standards/operating-model.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
@@ -318,6 +320,57 @@ export const DEFAULT_STEPS = [
         }
       } catch (dbErr) {
         ctx.log(`[registry_updated] WARN: applications.local_path write-through error: ${dbErr.message}`);
+      }
+    },
+  },
+  {
+    // SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-I1: ground newly provisioned ventures in the
+    // operating-model SSOT (lib/eva/standards/operating-model.js) instead of leaving Stage-5/
+    // Stage-16 to re-derive generic-SaaS cost assumptions independently. Mirrors the
+    // monitoring_baseline check/execute/fail-soft pattern below.
+    name: 'operating_model_grounded',
+    check: async (ctx) => {
+      if (ctx.stepsCompleted.includes('operating_model_grounded')) return true;
+      if (!ctx.venture) return false;
+      const sb = createSupabaseServiceClient();
+      const { data } = await sb
+        .from('ventures')
+        .select('metadata')
+        .eq('id', ctx.ventureId)
+        .single();
+      return data?.metadata?.operating_model?.version === OPERATING_MODEL.version;
+    },
+    execute: async (ctx) => {
+      if (!ctx.venture) {
+        ctx.venture = await resolveVentureMetadata(ctx.ventureId);
+      }
+      if (!ctx.venture) {
+        ctx.log(`[operating_model_grounded] No venture metadata for ${ctx.ventureId} — skipping`);
+        return;
+      }
+
+      const sb = createSupabaseServiceClient();
+      const { data: current } = await sb
+        .from('ventures')
+        .select('metadata')
+        .eq('id', ctx.ventureId)
+        .single();
+
+      const existingMetadata = current?.metadata || {};
+      const merged = {
+        ...existingMetadata,
+        operating_model: { version: OPERATING_MODEL.version, grounded_at: new Date().toISOString() },
+      };
+
+      const { error: groundErr } = await sb
+        .from('ventures')
+        .update({ metadata: merged })
+        .eq('id', ctx.ventureId);
+
+      if (groundErr) {
+        ctx.log(`[operating_model_grounded] WARN: failed to stamp operating-model reference: ${groundErr.message}`);
+      } else {
+        ctx.log(`[operating_model_grounded] Stamped operating-model v${OPERATING_MODEL.version} reference`);
       }
     },
   },
@@ -652,7 +705,7 @@ services:
           });
 
           if (createRes.ok) {
-            const project = await createRes.json();
+            await createRes.json();
             // Fetch DSN from project keys
             const keysRes = await fetch(`${sentryBaseUrl}/api/0/projects/${sentryOrg}/${projectSlug}/keys/`, {
               headers: { 'Authorization': `Bearer ${sentryToken}` },

--- a/tests/unit/eva/bridge/venture-provisioner-operating-model-grounding.test.js
+++ b/tests/unit/eva/bridge/venture-provisioner-operating-model-grounding.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-I1 (FR-3): the new 'operating_model_grounded'
+// DEFAULT_STEPS entry stamps a version+timestamp reference into ventures.metadata. Mock the
+// DB client with a mutable in-memory row so check()/execute()/check() can be chained like a
+// real idempotent re-run, following the venture-provisioner-scaffold-seeded.test.js pattern.
+let ventureRow = { metadata: {} };
+let updateShouldFail = false;
+
+vi.mock('../../../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: ventureRow, error: null }),
+        }),
+      }),
+      update: (patch) => ({
+        eq: async () => {
+          if (updateShouldFail) return { error: { message: 'simulated write failure' } };
+          ventureRow = { ...ventureRow, ...patch };
+          return { error: null };
+        },
+      }),
+    }),
+  }),
+}));
+
+const { DEFAULT_STEPS } = await import('../../../../lib/eva/bridge/venture-provisioner.js');
+const OPERATING_MODEL = (await import('../../../../lib/eva/standards/operating-model.js')).default;
+
+function groundingStep() {
+  const step = DEFAULT_STEPS.find((s) => s.name === 'operating_model_grounded');
+  if (!step) throw new Error('operating_model_grounded step not found in DEFAULT_STEPS');
+  return step;
+}
+
+describe('venture-provisioner DEFAULT_STEPS: operating_model_grounded', () => {
+  it('check() returns false when no operating_model stamp exists yet', async () => {
+    ventureRow = { metadata: {} };
+    updateShouldFail = false;
+    const ctx = { ventureId: 'v1', venture: { name: 'ApexNiche' }, stepsCompleted: [], log: () => {} };
+    expect(await groundingStep().check(ctx)).toBe(false);
+  });
+
+  it('execute() stamps metadata.operating_model.version to match OPERATING_MODEL.version', async () => {
+    ventureRow = { metadata: {} };
+    updateShouldFail = false;
+    const ctx = { ventureId: 'v1', venture: { name: 'ApexNiche' }, stepsCompleted: [], log: () => {} };
+    await groundingStep().execute(ctx);
+    expect(ventureRow.metadata.operating_model.version).toBe(OPERATING_MODEL.version);
+    expect(ventureRow.metadata.operating_model.grounded_at).toEqual(expect.any(String));
+  });
+
+  it('preserves pre-existing metadata keys (merge, not replace)', async () => {
+    ventureRow = { metadata: { sentry: { org: 'ehg-3v' } } };
+    updateShouldFail = false;
+    const ctx = { ventureId: 'v1', venture: { name: 'ApexNiche' }, stepsCompleted: [], log: () => {} };
+    await groundingStep().execute(ctx);
+    expect(ventureRow.metadata.sentry).toEqual({ org: 'ehg-3v' });
+    expect(ventureRow.metadata.operating_model.version).toBe(OPERATING_MODEL.version);
+  });
+
+  it('check() returns true (idempotent no-op) once already stamped with the current version', async () => {
+    ventureRow = { metadata: { operating_model: { version: OPERATING_MODEL.version, grounded_at: '2026-01-01T00:00:00.000Z' } } };
+    updateShouldFail = false;
+    const ctx = { ventureId: 'v1', venture: { name: 'ApexNiche' }, stepsCompleted: [], log: () => {} };
+    expect(await groundingStep().check(ctx)).toBe(true);
+  });
+
+  it('execute() logs a WARN and does not throw when the Supabase update errors (fail-soft)', async () => {
+    ventureRow = { metadata: {} };
+    updateShouldFail = true;
+    const logs = [];
+    const ctx = { ventureId: 'v1', venture: { name: 'ApexNiche' }, stepsCompleted: [], log: (msg) => logs.push(msg) };
+    await expect(groundingStep().execute(ctx)).resolves.not.toThrow();
+    expect(logs.some((l) => l.includes('WARN'))).toBe(true);
+  });
+
+  it('is positioned after registry_updated and before schema_created', () => {
+    const names = DEFAULT_STEPS.map((s) => s.name);
+    expect(names.indexOf('operating_model_grounded')).toBeGreaterThan(names.indexOf('registry_updated'));
+    expect(names.indexOf('operating_model_grounded')).toBeLessThan(names.indexOf('schema_created'));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an `operating_model_grounded` step to `lib/eva/bridge/venture-provisioner.js`'s `DEFAULT_STEPS` (positioned between `registry_updated` and `schema_created`)
- Stamps a version+timestamp reference to `lib/eva/standards/operating-model.js` into `ventures.metadata` at provisioning time, idempotent and fail-soft, following the existing `monitoring_baseline` pattern
- Closes the confirmed 0-reference gap between the operating-model SSOT and venture-provisioner.js, giving Stage-5/Stage-16 a persisted grounding marker instead of relying solely on independent re-derivation
- Also fixes a pre-existing unused-var lint error in `monitoring_baseline` (blocking the pre-commit hook on this file)

## Test plan
- [x] New `tests/unit/eva/bridge/venture-provisioner-operating-model-grounding.test.js` (6 tests: stamp write, idempotent skip, metadata merge preservation, fail-soft on write error, step ordering)
- [x] Full existing venture-provisioner test suites pass unmodified (445 tests / 34 files, 0 regressions)
- [x] `node --check` syntax verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)