### PR TITLE
feat(SD-FDBK-ENH-ADD-MARKETING-STANDARD-001): add VP_MARKETING as a standard 5th VP

### DIFF
--- a/lib/agents/venture-ceo-factory.js
+++ b/lib/agents/venture-ceo-factory.js
@@ -6,8 +6,13 @@
  *
  * Creates complete organizational structure from template:
  * - 1 CEO agent (hierarchy_level=2, parent=EVA)
- * - 4 VP agents (VP_STRATEGY, VP_PRODUCT, VP_TECH, VP_GROWTH)
- * - 14 crew agents distributed across VPs
+ * - 5 VP agents (VP_STRATEGY, VP_PRODUCT, VP_TECH, VP_GROWTH, VP_MARKETING)
+ * - 18 crew agents distributed across VPs
+ *
+ * SD-FDBK-ENH-ADD-MARKETING-STANDARD-001: VP_MARKETING added as a STANDARD
+ * (unconditionally instantiated) role per chairman ruling 2026-07-12, covering
+ * continuous post-launch brand/content/SEO/demand-gen/lifecycle marketing —
+ * a mandate that does not terminate at Stage 26, unlike VP_GROWTH's.
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
@@ -29,7 +34,7 @@ const WELL_KNOWN_IDS = {
 const STANDARD_VENTURE_TEMPLATE = {
   id: 'standard',
   name: 'Standard Venture Template',
-  description: 'Standard 19-agent organizational structure',
+  description: 'Standard 24-agent organizational structure',
 
   ceo: {
     agent_role: 'venture_ceo',
@@ -80,6 +85,17 @@ const STANDARD_VENTURE_TEMPLATE = {
       tools: ['web_search', 'sentiment_analyzer'],
       stage_ownership: [22, 23, 24, 25, 26],
       token_budget: 25000
+    },
+    {
+      // SD-FDBK-ENH-ADD-MARKETING-STANDARD-001: continuous post-launch mandate —
+      // stage_ownership is intentionally [] (no BUILD-pipeline stage binding),
+      // unlike VP_GROWTH's [22-26] which terminates at launch.
+      agent_role: 'VP_MARKETING',
+      display_name_template: '{venture_name} VP Marketing',
+      capabilities: ['brand_strategy', 'content_marketing', 'seo', 'demand_generation', 'lifecycle_marketing'],
+      tools: ['web_search', 'document_writer', 'sentiment_analyzer', 'email_sender', 'image_generator'],
+      stage_ownership: [],
+      token_budget: 25000
     }
   ],
 
@@ -104,7 +120,13 @@ const STANDARD_VENTURE_TEMPLATE = {
     // VP_GROWTH crews (3)
     { agent_role: 'Launch_Crew', executive_parent: 'VP_GROWTH', capabilities: ['launch_planning'], token_budget: 5000 },
     { agent_role: 'Analytics_Crew', executive_parent: 'VP_GROWTH', capabilities: ['analytics'], token_budget: 5000 },
-    { agent_role: 'Growth_Crew', executive_parent: 'VP_GROWTH', capabilities: ['optimization'], token_budget: 5000 }
+    { agent_role: 'Growth_Crew', executive_parent: 'VP_GROWTH', capabilities: ['optimization'], token_budget: 5000 },
+
+    // VP_MARKETING crews (4)
+    { agent_role: 'Brand_Content_Crew', executive_parent: 'VP_MARKETING', capabilities: ['brand_strategy', 'content_marketing'], token_budget: 5000 },
+    { agent_role: 'SEO_Crew', executive_parent: 'VP_MARKETING', capabilities: ['seo'], token_budget: 5000 },
+    { agent_role: 'Demand_Gen_Crew', executive_parent: 'VP_MARKETING', capabilities: ['demand_generation'], token_budget: 5000 },
+    { agent_role: 'Lifecycle_Crew', executive_parent: 'VP_MARKETING', capabilities: ['lifecycle_marketing'], token_budget: 5000 }
   ],
 
   budget_distribution: {

--- a/tests/unit/venture-ceo-factory.test.js
+++ b/tests/unit/venture-ceo-factory.test.js
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { VentureFactory, STANDARD_VENTURE_TEMPLATE } from '../../../lib/agents/venture-ceo-factory.js';
+import { VentureFactory, STANDARD_VENTURE_TEMPLATE } from '../../lib/agents/venture-ceo-factory.js';
 
 vi.mock('uuid', () => ({
   v4: () => `mock-uuid-${Math.random().toString(36).slice(2)}`

--- a/tests/unit/venture-ceo-factory.test.js
+++ b/tests/unit/venture-ceo-factory.test.js
@@ -1,0 +1,124 @@
+/**
+ * Unit Tests: VentureFactory / STANDARD_VENTURE_TEMPLATE
+ * SD-FDBK-ENH-ADD-MARKETING-STANDARD-001: VP_MARKETING added as a STANDARD
+ * (unconditionally instantiated) 5th VP role.
+ *
+ * No pre-existing test file covered this module before this SD — coverage
+ * added here spans both the template's static shape and a mocked full
+ * instantiateVenture() run, plus explicit zero-regression assertions on the
+ * pre-existing 4 VPs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VentureFactory, STANDARD_VENTURE_TEMPLATE } from '../../../lib/agents/venture-ceo-factory.js';
+
+vi.mock('uuid', () => ({
+  v4: () => `mock-uuid-${Math.random().toString(36).slice(2)}`
+}));
+
+describe('STANDARD_VENTURE_TEMPLATE shape', () => {
+  it('has 5 executives (was 4)', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.executives).toHaveLength(5);
+  });
+
+  it('includes VP_MARKETING with the expected capabilities/tools/stage_ownership', () => {
+    const vpMarketing = STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_MARKETING');
+    expect(vpMarketing).toBeDefined();
+    expect(vpMarketing.capabilities).toEqual(
+      expect.arrayContaining(['brand_strategy', 'content_marketing', 'seo', 'demand_generation', 'lifecycle_marketing'])
+    );
+    // Only tools that exist in tool_registry — verified directly against the live table.
+    expect(vpMarketing.tools).toEqual(
+      expect.arrayContaining(['web_search', 'document_writer', 'sentiment_analyzer', 'email_sender', 'image_generator'])
+    );
+    // Continuous mandate: NOT bound to any BUILD-pipeline stage, unlike VP_GROWTH.
+    expect(vpMarketing.stage_ownership).toEqual([]);
+  });
+
+  it('is unconditionally present — no flag/threshold field gates its inclusion', () => {
+    const vpMarketing = STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_MARKETING');
+    expect(vpMarketing).not.toHaveProperty('lazy');
+    expect(vpMarketing).not.toHaveProperty('instantiate_flag');
+    expect(vpMarketing).not.toHaveProperty('enabled');
+  });
+
+  it('has 18 crews (was 14), 4 of which report to VP_MARKETING', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.crews).toHaveLength(18);
+    const marketingCrews = STANDARD_VENTURE_TEMPLATE.crews.filter(c => c.executive_parent === 'VP_MARKETING');
+    expect(marketingCrews).toHaveLength(4);
+    expect(marketingCrews.map(c => c.agent_role)).toEqual(
+      expect.arrayContaining(['Brand_Content_Crew', 'SEO_Crew', 'Demand_Gen_Crew', 'Lifecycle_Crew'])
+    );
+    // Each crew has a distinct, non-empty capability list.
+    const capSets = marketingCrews.map(c => JSON.stringify(c.capabilities));
+    expect(new Set(capSets).size).toBe(marketingCrews.length);
+  });
+
+  it('leaves the other 4 VPs byte-identical to their pre-change shape (zero regression)', () => {
+    const expected = {
+      VP_STRATEGY: { capabilities: ['market_research', 'competitive_analysis', 'financial_modeling', 'tam_calculation'], stage_ownership: [1, 2, 3, 4, 5, 6, 7, 8, 9], token_budget: 30000 },
+      VP_PRODUCT: { capabilities: ['product_definition', 'user_research', 'narrative_development', 'naming'], stage_ownership: [10, 11, 12], token_budget: 25000 },
+      VP_TECH: { capabilities: ['tech_architecture', 'data_modeling', 'code_generation', 'qa_testing'], stage_ownership: [13, 14, 15, 16, 17, 18, 19, 20, 21], token_budget: 40000 },
+      VP_GROWTH: { capabilities: ['launch_planning', 'analytics', 'optimization', 'user_acquisition'], stage_ownership: [22, 23, 24, 25, 26], token_budget: 25000 }
+    };
+
+    for (const [role, exp] of Object.entries(expected)) {
+      const vp = STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === role);
+      expect(vp).toBeDefined();
+      expect(vp.capabilities).toEqual(exp.capabilities);
+      expect(vp.stage_ownership).toEqual(exp.stage_ownership);
+      expect(vp.token_budget).toBe(exp.token_budget);
+    }
+  });
+
+  it('description reflects the 24-agent total (1 CEO + 5 VP + 18 crew)', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.description).toContain('24-agent');
+  });
+});
+
+describe('VentureFactory.instantiateVenture with mocked Supabase', () => {
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn(() => mockSupabase),
+      // insert()/upsert() are chainable (agent_registry chains .select().single());
+      // call sites that await insert()/upsert() directly (agent_relationships,
+      // tool_access_grants, agent_memory_stores, agent_messages, org_agent_roles)
+      // destructure {error} off the returned object, which is undefined here —
+      // undefined is falsy, matching the "no error" success path.
+      insert: vi.fn(() => mockSupabase),
+      upsert: vi.fn(() => mockSupabase),
+      select: vi.fn(() => mockSupabase),
+      eq: vi.fn(() => mockSupabase),
+      // Terminal resolvers: every chained call site awaits one of these.
+      single: vi.fn(async () => ({ data: { id: `mock-agent-${Math.random().toString(36).slice(2)}` }, error: null })),
+      maybeSingle: vi.fn(async () => ({ data: null, error: null }))
+    };
+  });
+
+  it('creates 5 executive agents (was 4), including VP_MARKETING', async () => {
+    const factory = new VentureFactory(mockSupabase);
+    const result = await factory.instantiateVenture({
+      ventureName: 'Test Venture',
+      ventureId: 'test-venture-id-123'
+    });
+
+    expect(Object.keys(result.executive_agent_ids)).toHaveLength(5);
+    expect(result.executive_agent_ids).toHaveProperty('VP_MARKETING');
+    expect(result.executive_agent_ids).toHaveProperty('VP_STRATEGY');
+    expect(result.executive_agent_ids).toHaveProperty('VP_PRODUCT');
+    expect(result.executive_agent_ids).toHaveProperty('VP_TECH');
+    expect(result.executive_agent_ids).toHaveProperty('VP_GROWTH');
+  });
+
+  it('total_agents_created reflects 1 CEO + 5 VP + 18 crew = 24', async () => {
+    const factory = new VentureFactory(mockSupabase);
+    const result = await factory.instantiateVenture({
+      ventureName: 'Test Venture 2',
+      ventureId: 'test-venture-id-456'
+    });
+
+    expect(result.total_agents_created).toBe(24);
+  });
+});


### PR DESCRIPTION
## Summary
- Add VP_MARKETING to `STANDARD_VENTURE_TEMPLATE.executives` in `lib/agents/venture-ceo-factory.js`, unconditionally (STANDARD, not lazy) per chairman ruling 2026-07-12 -- overrides Solomon's default recommendation of instantiate-lazily.
- Scoped to continuous post-launch brand/content/SEO/demand-gen/lifecycle marketing; `stage_ownership=[]` since it is not bound to any BUILD-pipeline stage, unlike VP_GROWTH's `[22-26]` which terminates at launch.
- Adds 4 matching crews (Brand_Content_Crew, SEO_Crew, Demand_Gen_Crew, Lifecycle_Crew) and updates the stale 19-agent -> 24-agent template metadata/header comment.
- Root cause: 2026-07-12 EHG SaaS Operations Gap Audit found marketing has no post-launch owner because VP_GROWTH's mandate ends at Stage 26. `instantiateVenture()` is currently reachable only via a dead entry point (0 live callers), so this template-definition change carries near-zero runtime blast radius today -- its value is being correct/complete before the separate substrate SD (SD-FDBK-ENH-EHG-OPERATING-COMPANY-001) wires up real instantiation.
- New test file `tests/unit/venture-ceo-factory.test.js` (8 tests: template-shape assertions + mocked-Supabase `instantiateVenture()` integration test), covering PRD FR-1 through FR-4, including explicit zero-regression assertions on the pre-existing 4 VPs.

## Test plan
- [x] `npx vitest run tests/unit/venture-ceo-factory.test.js` -- 8/8 pass
- [x] `tests/unit/audits/venture-ceo-factory-reachability.test.js` -- 10/10 pass (zero regression)
- [x] `tests/unit/spine-verify-first-teardown.test.js` -- 5/5 pass (zero regression)
- [x] TESTING sub-agent validation: PASS (confidence 96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)