### PR TITLE
fix(QF-20260712-972): writeScheduleRecord sets target_session, satisfying valid_target CHECK

### DIFF
--- a/lib/coordinator/singleton-relaunch-trigger.js
+++ b/lib/coordinator/singleton-relaunch-trigger.js
@@ -134,6 +134,11 @@ export async function writeScheduleRecord(supabase, { role, senderSession, fresh
       body: `Quiescent-window trigger fired for '${role}' — behind ${freshness.behind} commit(s), fleet quiescent, target loop_state=${targetLoopState}.`,
       payload,
       sender_session: senderSession || 'singleton-relaunch-scheduler',
+      // NEVER null — the session_coordination valid_target CHECK rejects null; default to the
+      // documented worker->coordinator sentinel (re-targeted on the next /coordinator start),
+      // matching lib/coordinator/canary-trigger.cjs. No real relaunch consumer exists yet
+      // (scope fence: this fixes the WRITE only), so there is no specific successor session.
+      target_session: 'broadcast-coordinator',
       sender_type: 'coordinator',
     })
     .select('id')

--- a/tests/unit/coordinator/singleton-relaunch-trigger.test.js
+++ b/tests/unit/coordinator/singleton-relaunch-trigger.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   decideRelaunchSchedule,
   evaluateSingletonRelaunch,
+  writeScheduleRecord,
   SAFE_LOOP_STATES,
 } from '../../../lib/coordinator/singleton-relaunch-trigger.js';
 
@@ -10,7 +11,7 @@ import {
 // evaluateSingletonRelaunch below; decideRelaunchSchedule covers the full pure decision matrix.
 
 function makeSupabaseStub({ pendingRows = [], insertResult = { data: { id: 'sched-1' }, error: null }, sessionRow = null } = {}) {
-  const calls = { findPending: 0, insert: 0 };
+  const calls = { findPending: 0, insert: 0, insertedRows: [] };
   return {
     from() {
       return {
@@ -30,8 +31,9 @@ function makeSupabaseStub({ pendingRows = [], insertResult = { data: { id: 'sche
           };
           return chain;
         },
-        insert() {
+        insert(row) {
           calls.insert += 1;
+          calls.insertedRows.push(row);
           return { select: () => ({ single: () => Promise.resolve(insertResult) }) };
         },
       };
@@ -156,5 +158,41 @@ describe('evaluateSingletonRelaunch (IO-orchestrated)', () => {
     expect(r.scheduled).toBe(false);
     expect(r.reason).toBe('write_failed');
     expect(r.error).toBe('insert failed');
+  });
+});
+
+// QF-20260712-972: writeScheduleRecord() previously omitted target_session, failing the
+// session_coordination valid_target CHECK ((target_session IS NOT NULL) OR (target_sd IS NOT
+// NULL)) on every insert (feedback d100a68f, confirmed live 2026-07-07). Fixed to default to
+// the documented 'broadcast-coordinator' sentinel, matching lib/coordinator/canary-trigger.cjs.
+describe('writeScheduleRecord — session_coordination valid_target CHECK', () => {
+  it('sets a non-null target_session on every insert (the CHECK-satisfying fix)', async () => {
+    const stub = makeSupabaseStub();
+    await writeScheduleRecord(stub, {
+      role: 'coordinator',
+      senderSession: 'some-session-id',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'exited',
+      reason: 'quiescent_window',
+    });
+    expect(stub._calls.insert).toBe(1);
+    const row = stub._calls.insertedRows[0];
+    expect(row.target_session).toBe('broadcast-coordinator');
+    expect(row.sender_session).toBe('some-session-id');
+  });
+
+  it('still sets target_session even when senderSession is omitted (default sender)', async () => {
+    const stub = makeSupabaseStub();
+    await writeScheduleRecord(stub, {
+      role: 'adam',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'awaiting_tick',
+      reason: 'quiescent_window',
+    });
+    const row = stub._calls.insertedRows[0];
+    expect(row.target_session).toBe('broadcast-coordinator');
+    expect(row.sender_session).toBe('singleton-relaunch-scheduler');
   });
 });


### PR DESCRIPTION
## Summary
- D7 (chairman-ratified build-vs-run 2026-07-12): `writeScheduleRecord()` in `lib/coordinator/singleton-relaunch-trigger.js` inserted a `session_coordination` SPAWN_REQUEST row with `sender_session` set but no `target_session`, failing the table's `valid_target` CHECK (`(target_session IS NOT NULL) OR (target_sd IS NOT NULL)`) on every write — confirmed live 2026-07-07 (feedback `d100a68f`). The scheduler could correctly *decide* to schedule a relaunch but never actually wrote the record.
- Fixed by defaulting `target_session` to the `'broadcast-coordinator'` sentinel, matching the existing `lib/coordinator/canary-trigger.cjs` precedent.
- **Scope fence (chairman-ratified):** this fixes the WRITE only. Autonomous relaunch stays on hold — no spawn consumer or orchestrator is built here.

## Test plan
- [x] 2 new unit tests asserting `target_session` is always set on the insert.
- [x] Full `tests/unit/coordinator/` suite (379 tests) — zero regressions.
- [x] Live-verified against the real `session_coordination` table: inserted the exact fixed row shape, confirmed it passes the CHECK, then deleted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)