### PR TITLE
fix(canary): raise probe batch 5->10 + jitter/backoff (D2 rate-limit-health, chairman-ratified)

### DIFF
--- a/scripts/continuity/cloud-cap-feeder.mjs
+++ b/scripts/continuity/cloud-cap-feeder.mjs
@@ -31,9 +31,24 @@ import { isMainModule } from '../../lib/utils/is-main-module.js';
 /** Error categories that count as a cloud-cap failure (vs operator/config errors like 401/400). */
 export const CAP_FAILURE_CATEGORIES = Object.freeze(new Set(['rate_limit', 'overloaded', 'server', 'timeout']));
 
-export const DEFAULT_PROBE_COUNT = 5;
+// Rolling error-rate denominator. Raised 5 -> 10 (D2 rate-limit-health, chairman-ratified): at 5 a single
+// transient blip is 1/5 = 20% > the 5% error_rate_threshold -> a false ROLLING (degraded) alert. A 10-probe
+// batch halves one blip's weight to 10%, and the per-probe retry-on-transient below lets a recovering blip
+// resolve to OK before it counts at all. DETECTION-TUNING ONLY: threshold/alerting unchanged.
+export const DEFAULT_PROBE_COUNT = 10;
 export const MAX_PROBE_COUNT = 20; // clamp the only real-spend surface against a fat-finger invocation
 export const SINGLETON_ID = 'singleton';
+
+// Jitter + exponential-backoff on the probe requests (D2). Jitter de-synchronizes the batch so the probes do
+// not themselves burst into a rate limit; the transient-error retry (with exponential backoff) lets a momentary
+// 429/5xx/overloaded/timeout recover instead of counting toward the rolling error rate. Sustained degradation
+// still surfaces: retries are bounded, so a real cap fails every attempt and is recorded as a failure.
+export const DEFAULT_MAX_RETRIES = 2;       // retries per probe on a TRANSIENT (cap) error before recording a failure
+export const DEFAULT_BACKOFF_BASE_MS = 250; // exponential backoff base: attempt 0 -> 250ms, attempt 1 -> 500ms, ...
+export const DEFAULT_JITTER_MS = 100;       // max randomized inter-probe delay + additive backoff jitter (ms)
+
+/** Await ms milliseconds (injectable in tests via sleepFn so no real time passes). */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
 
 /**
  * Categorize an Anthropic SDK error into a cloud-cap signal. PURE.
@@ -130,22 +145,49 @@ export function computeNextHealthState(prev, summary) {
 
 /**
  * Run a batch of cheap probes against the injected Anthropic client. IO (but client is injected).
- * Uses models.list() — no token spend — as the health probe.
+ * Uses models.list() — no token spend — as the health probe. Applies jitter between probes and retries a
+ * probe that hits a TRANSIENT (cap-category) error with exponential backoff before recording it as a failure,
+ * so a momentary blip does not inflate the rolling error rate (D2). All delays are injectable (sleepFn/randFn)
+ * so tests pass no real time. maxRetries=0 restores the original no-retry behavior.
  * @param {object} args
  * @param {object} args.client - Anthropic SDK client (injected; fake in tests)
  * @param {number} [args.count=DEFAULT_PROBE_COUNT]
  * @param {() => number} [args.nowFn=Date.now]
+ * @param {number} [args.maxRetries=DEFAULT_MAX_RETRIES]
+ * @param {number} [args.backoffBaseMs=DEFAULT_BACKOFF_BASE_MS]
+ * @param {number} [args.jitterMs=DEFAULT_JITTER_MS]
+ * @param {(ms:number)=>Promise<void>} [args.sleepFn=sleep]
+ * @param {() => number} [args.randFn=Math.random]
  * @returns {Promise<Array<{ok:boolean, latencyMs?:number, category?:string}>>}
  */
-export async function runProbeBatch({ client, count = DEFAULT_PROBE_COUNT, nowFn = Date.now } = {}) {
+export async function runProbeBatch({
+  client, count = DEFAULT_PROBE_COUNT, nowFn = Date.now,
+  maxRetries = DEFAULT_MAX_RETRIES, backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+  jitterMs = DEFAULT_JITTER_MS, sleepFn = sleep, randFn = Math.random,
+} = {}) {
   const results = [];
   for (let i = 0; i < count; i++) {
-    const t0 = nowFn();
-    try {
-      await client.models.list();
-      results.push({ ok: true, latencyMs: Math.max(0, nowFn() - t0) });
-    } catch (err) {
-      results.push({ ok: false, category: categorizeProbeError(err) });
+    // Jitter between probes so the batch is not a synchronized burst that itself trips a rate limit.
+    if (i > 0 && jitterMs > 0) await sleepFn(Math.floor(randFn() * jitterMs));
+    let attempt = 0;
+    for (;;) {
+      const t0 = nowFn();
+      try {
+        await client.models.list();
+        results.push({ ok: true, latencyMs: Math.max(0, nowFn() - t0) });
+        break;
+      } catch (err) {
+        const category = categorizeProbeError(err);
+        // Retry only TRANSIENT (cap-category) errors — a config error (401/400 -> 'other') is not retried.
+        if (CAP_FAILURE_CATEGORIES.has(category) && attempt < maxRetries) {
+          const backoffMs = backoffBaseMs * (2 ** attempt) + (jitterMs > 0 ? Math.floor(randFn() * jitterMs) : 0);
+          attempt++;
+          await sleepFn(backoffMs);
+          continue;
+        }
+        results.push({ ok: false, category });
+        break;
+      }
     }
   }
   return results;
@@ -159,9 +201,14 @@ export async function runProbeBatch({ client, count = DEFAULT_PROBE_COUNT, nowFn
  * @param {() => number} [args.nowFn=Date.now]
  * @param {() => string} [args.nowIso] - ISO timestamp provider (inject for tests)
  * @param {number} [args.probeCount=DEFAULT_PROBE_COUNT]
+ * @param {number} [args.maxRetries] - passthrough to runProbeBatch (transient-error retries)
+ * @param {number} [args.backoffBaseMs] - passthrough to runProbeBatch (exponential backoff base)
+ * @param {number} [args.jitterMs] - passthrough to runProbeBatch (inter-probe + backoff jitter)
+ * @param {(ms:number)=>Promise<void>} [args.sleepFn] - passthrough to runProbeBatch (inject in tests)
+ * @param {() => number} [args.randFn] - passthrough to runProbeBatch (inject in tests)
  * @returns {Promise<{summary:object, update:object}>}
  */
-export async function feedCloudHealth({ supabase, client, nowFn = Date.now, nowIso, probeCount = DEFAULT_PROBE_COUNT } = {}) {
+export async function feedCloudHealth({ supabase, client, nowFn = Date.now, nowIso, probeCount = DEFAULT_PROBE_COUNT, maxRetries, backoffBaseMs, jitterMs, sleepFn, randFn } = {}) {
   const isoFn = nowIso || (() => new Date(nowFn()).toISOString());
   const { data: prev, error: readErr } = await supabase
     .from('llm_cloud_health')
@@ -171,7 +218,7 @@ export async function feedCloudHealth({ supabase, client, nowFn = Date.now, nowI
   if (readErr) throw new Error(`[cloud-cap-feeder] read failed (fail-loud): ${readErr.message}`);
 
   const safeCount = Math.max(1, Math.min(MAX_PROBE_COUNT, Math.floor(Number(probeCount)) || DEFAULT_PROBE_COUNT));
-  const results = await runProbeBatch({ client, count: safeCount, nowFn });
+  const results = await runProbeBatch({ client, count: safeCount, nowFn, maxRetries, backoffBaseMs, jitterMs, sleepFn, randFn });
   const summary = summarizeBatch(results);
   const next = computeNextHealthState(prev, summary);
 

--- a/tests/unit/cloud-cap-feeder.test.js
+++ b/tests/unit/cloud-cap-feeder.test.js
@@ -80,16 +80,50 @@ describe('computeNextHealthState', () => {
 });
 
 describe('runProbeBatch (injected fake client; no real calls)', () => {
-  it('records ok/latency, categorizes failures, calls list() per probe', async () => {
+  const noSleep = async () => {}; // inject so jitter/backoff pass zero real time
+
+  it('records ok/latency, categorizes failures, calls list() per probe (maxRetries:0 = no retry)', async () => {
     let i = 0;
     const client = { models: { list: vi.fn(async () => { i++; if (i === 2) throw errWith({ status: 429 }); return { data: [] }; }) } };
     let t = 0; const nowFn = () => (t += 50);
-    const results = await runProbeBatch({ client, count: 3, nowFn });
+    const results = await runProbeBatch({ client, count: 3, nowFn, maxRetries: 0, sleepFn: noSleep });
     expect(results).toHaveLength(3);
     expect(results[0].ok).toBe(true);
     expect(results[1]).toEqual({ ok: false, category: 'rate_limit' });
     expect(results[2].ok).toBe(true);
     expect(client.models.list).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries a TRANSIENT (429) blip with backoff and resolves it to OK (D2)', async () => {
+    let i = 0;
+    // First probe hits 429 once, then succeeds on retry -> should record ok, not a failure.
+    const client = { models: { list: vi.fn(async () => { i++; if (i === 1) throw errWith({ status: 429 }); return { data: [] }; }) } };
+    const sleeps = [];
+    const results = await runProbeBatch({ client, count: 2, nowFn: () => 0, maxRetries: 2, backoffBaseMs: 250, jitterMs: 0, sleepFn: async (ms) => { sleeps.push(ms); }, randFn: () => 0 });
+    expect(results.every((r) => r.ok)).toBe(true);        // blip recovered -> no failure counted
+    expect(client.models.list).toHaveBeenCalledTimes(3);  // probe0: 429 + retry; probe1: ok
+    expect(sleeps).toContain(250);                         // exponential backoff base applied on retry
+  });
+
+  it('does NOT retry a config error (401 -> other) and records the failure', async () => {
+    const client = { models: { list: vi.fn(async () => { throw errWith({ status: 401 }); }) } };
+    const results = await runProbeBatch({ client, count: 1, nowFn: () => 0, maxRetries: 2, sleepFn: async () => {}, randFn: () => 0 });
+    expect(results[0]).toEqual({ ok: false, category: 'other' });
+    expect(client.models.list).toHaveBeenCalledTimes(1);  // no retry on non-cap error
+  });
+
+  it('exhausts retries on a SUSTAINED transient error and records the failure', async () => {
+    const client = { models: { list: vi.fn(async () => { throw errWith({ status: 429 }); }) } };
+    const results = await runProbeBatch({ client, count: 1, nowFn: () => 0, maxRetries: 2, jitterMs: 0, sleepFn: async () => {}, randFn: () => 0 });
+    expect(results[0]).toEqual({ ok: false, category: 'rate_limit' });
+    expect(client.models.list).toHaveBeenCalledTimes(3);  // initial + 2 retries, then recorded
+  });
+
+  it('applies inter-probe jitter between probes', async () => {
+    const client = { models: { list: async () => ({ data: [] }) } };
+    const sleeps = [];
+    await runProbeBatch({ client, count: 3, nowFn: () => 0, maxRetries: 0, jitterMs: 100, sleepFn: async (ms) => { sleeps.push(ms); }, randFn: () => 0.5 });
+    expect(sleeps).toEqual([50, 50]); // one jitter sleep before each probe after the first (floor(0.5*100))
   });
 });
 
@@ -112,7 +146,7 @@ describe('feedCloudHealth (fake client + fake supabase, ZERO live calls/writes)'
     let i = 0;
     const client = { models: { list: async () => { i++; if (i % 2 === 0) throw errWith({ status: 429 }); return { data: [] }; } } };
     let t = 0;
-    const { summary, update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => '2026-06-14T00:00:00Z', probeCount: 4 });
+    const { summary, update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => '2026-06-14T00:00:00Z', probeCount: 4, maxRetries: 0, sleepFn: async () => {} });
     expect(summary.capFailures).toBe(2);
     expect(update.status).toBe('rolling');
     expect(update.consecutive_failures).toBe(1);
@@ -124,7 +158,7 @@ describe('feedCloudHealth (fake client + fake supabase, ZERO live calls/writes)'
     const sb = fakeSupabase({ error_rate_threshold: 0.05, consecutive_failures: 3, baseline_latency_p95_ms: null });
     const client = { models: { list: async () => ({ data: [] }) } };
     let t = 0;
-    const { update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => 'T', probeCount: 3 });
+    const { update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => 'T', probeCount: 3, maxRetries: 0, sleepFn: async () => {} });
     expect(update.status).toBe('paused');
     expect(update.consecutive_failures).toBe(0);
   });


### PR DESCRIPTION
## D2 — rate-limit-health / active-breakage-canary false-ROLLING fix (chairman-ratified, build-vs-run D-set)

### Problem
The cloud-cap feeder (`scripts/continuity/cloud-cap-feeder.mjs`) probes Anthropic LLM cloud health in a batch and stamps `llm_cloud_health.current_error_rate = capFailures / batchSize`. The degradation ladder (`llm-degradation-detector.mjs`) compares that rolling error rate to the **5% `error_rate_threshold`**.

At **batchSize = 5**, a single transient blip (one 429/5xx/overloaded/timeout) is `1/5 = 20%`, which is `> 5%` → a **false ROLLING (degraded) alert**. The gauge could not be armed for real detection without tripping on transient noise.

### Fix (detection-tuning ONLY — no actuators, no threshold changes)
- **`DEFAULT_PROBE_COUNT` 5 → 10**: the rolling error-rate denominator doubles, so one blip weighs **10%**, not 20%.
- **Jitter between probes**: randomized inter-probe delay so the batch is not a synchronized burst that itself trips a rate limit.
- **Exponential backoff + retry on TRANSIENT errors**: a probe that hits a cap-category error (429 / 5xx / overloaded / timeout) retries with exponential backoff (250ms → 500ms) before being recorded as a failure, so a momentary blip resolves to OK and never counts. Config errors (401/400 → `other`) are **not** retried, and a **sustained** cap fails every bounded attempt and is still recorded — real degradation still surfaces.

All delays are injectable (`sleepFn` / `randFn`); tests pass zero real time. `maxRetries: 0` restores the original no-retry behavior.

### Scope guardrails honored
- No actuators added; the `error_rate_threshold` (5%) and alerting are **unchanged**.
- Change is localized to the feeder + its unit test.
- The cron/scheduled feeder is **NOT** armed here — the coordinator arms it after merge.

### Tests
- `tests/unit/cloud-cap-feeder.test.js`: **23 pass** (added coverage: transient-blip retry-to-OK, config-error no-retry, sustained-error retry-exhaustion, inter-probe jitter).
- `llm-degradation-detector` + `active-breakage-canary` suites unaffected: **41 pass**.

No Solomon design doc was found for this jitter/backoff; standard jitter + exponential-backoff was implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
