### PR TITLE
feat(SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001): V1 org-template delta (VP_CUSTOMER + Sales_Crew + mandate extensions + 4 EHG-shared operators)

### DIFF
--- a/lib/agents/venture-ceo-factory.js
+++ b/lib/agents/venture-ceo-factory.js
@@ -6,13 +6,21 @@
  *
  * Creates complete organizational structure from template:
  * - 1 CEO agent (hierarchy_level=2, parent=EVA)
- * - 5 VP agents (VP_STRATEGY, VP_PRODUCT, VP_TECH, VP_GROWTH, VP_MARKETING)
- * - 18 crew agents distributed across VPs
+ * - 6 VP agents (VP_STRATEGY, VP_PRODUCT, VP_TECH, VP_GROWTH, VP_MARKETING, VP_CUSTOMER)
+ * - 21 crew agents distributed across VPs
  *
  * SD-FDBK-ENH-ADD-MARKETING-STANDARD-001: VP_MARKETING added as a STANDARD
  * (unconditionally instantiated) role per chairman ruling 2026-07-12, covering
  * continuous post-launch brand/content/SEO/demand-gen/lifecycle marketing —
  * a mandate that does not terminate at Stage 26, unlike VP_GROWTH's.
+ *
+ * SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (chairman-ratified V1 org-template delta):
+ * per-venture VP_CUSTOMER (CS+Support folded) + Sales_Crew under VP_GROWTH; three
+ * mandate extensions (post_stage_mandate on VP_TECH/VP_PRODUCT/VP_GROWTH — no VP
+ * mandate terminates at a build stage anymore); and a SEPARATE EHG_SHARED_OPERATORS
+ * export (FINANCE_BILLING/LEGAL_COMPLIANCE/SECURITY_POSTURE/DATA_PLATFORM — commodity
+ * rails instantiated ONCE at the holdco level). Every new role carries its §1 run-state
+ * duty cycle + an honest-idle no-op (define-now = behavior definition, not decoration).
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
@@ -28,13 +36,15 @@ const WELL_KNOWN_IDS = {
 };
 
 /**
- * Standard venture template with CEO, 4 VPs, and 14 crews
+ * Standard venture template with CEO, 6 VPs, and 21 crews (per-venture roster).
+ * EHG-shared operators (EHG_SHARED_OPERATORS) are instantiated ONCE at holdco level,
+ * separately — they are NOT part of this per-venture count.
  * Based on spec Section 6.1 VentureTemplate interface
  */
 const STANDARD_VENTURE_TEMPLATE = {
   id: 'standard',
   name: 'Standard Venture Template',
-  description: 'Standard 24-agent organizational structure',
+  description: 'Standard 28-agent per-venture organizational structure (1 CEO + 6 VPs + 21 crews)',
 
   ceo: {
     agent_role: 'venture_ceo',
@@ -68,6 +78,10 @@ const STANDARD_VENTURE_TEMPLATE = {
       capabilities: ['product_definition', 'user_research', 'narrative_development', 'naming'],
       tools: ['document_writer', 'sentiment_analyzer'],
       stage_ownership: [10, 11, 12],
+      // SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F8): mandate extension past S12 — the
+      // build-stage ownership above is unchanged; this adds the continuous live duty.
+      post_stage_mandate: 'live-iteration past S12: weekly feedback/analytics review → backlog grooming (inbound-ingestion as intake); monthly roadmap iteration; per-release acceptance',
+      honest_idle: 'no live users/feedback yet → no backlog fabricated; grooming no-ops on an empty inbound queue',
       token_budget: 25000
     },
     {
@@ -76,6 +90,9 @@ const STANDARD_VENTURE_TEMPLATE = {
       capabilities: ['tech_architecture', 'data_modeling', 'code_generation', 'qa_testing'],
       tools: ['code_generator', 'venture_query', 'artifact_store'],
       stage_ownership: [13, 14, 15, 16, 17, 18, 19, 20, 21],
+      // SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F1/F5): keep-live/SRE mandate past S21.
+      post_stage_mandate: 'keep-live/SRE past S21: daily cert/renewal/DNS-drift/deploy-health watch; on-alert remediation (restart/rollback) via factory work orders; weekly dependency/CVE patch; deprovision-on-kill (harvest-before-teardown)',
+      honest_idle: 'no deployed venture surface yet → monitors/remediation no-op; nothing to keep live',
       token_budget: 40000
     },
     {
@@ -84,6 +101,9 @@ const STANDARD_VENTURE_TEMPLATE = {
       capabilities: ['launch_planning', 'analytics', 'optimization', 'user_acquisition'],
       tools: ['web_search', 'sentiment_analyzer'],
       stage_ownership: [22, 23, 24, 25, 26],
+      // SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F9/F10): post-launch mandate past S26.
+      post_stage_mandate: 'post-launch acquisition/analytics past S26: continuous user-acquisition + weekly KPI/analytics rollups to the evidence fabric (mandate no longer terminates at launch)',
+      honest_idle: 'no launched venture yet → acquisition/analytics rounds no-op; no metrics fabricated',
       token_budget: 25000
     },
     {
@@ -95,6 +115,19 @@ const STANDARD_VENTURE_TEMPLATE = {
       capabilities: ['brand_strategy', 'content_marketing', 'seo', 'demand_generation', 'lifecycle_marketing'],
       tools: ['web_search', 'document_writer', 'sentiment_analyzer', 'email_sender', 'image_generator'],
       stage_ownership: [],
+      token_budget: 25000
+    },
+    {
+      // SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F3+F12 folded): new standard per-venture
+      // VP_CUSTOMER — Customer Success + Support at this scale (split at scale per the
+      // audit). Continuous mandate (stage_ownership=[]) like VP_MARKETING.
+      agent_role: 'VP_CUSTOMER',
+      display_name_template: '{venture_name} VP Customer',
+      capabilities: ['customer_health_scoring', 'at_risk_detection', 'onboarding_sequence', 'support_intake', 'ticket_triage', 'churn_save_motion'],
+      tools: ['document_writer', 'sentiment_analyzer', 'email_sender', 'venture_query'],
+      stage_ownership: [],
+      duty_cycle: 'on-signup onboarding sequence; weekly health scoring + at-risk detection → save-motion outreach; monthly cohort review; continuous support intake + triage + FAQ-class autonomous response (graduated autonomy); escalate bugs → VP_PRODUCT backlog, at-risk signals → CS',
+      honest_idle: 'no customers/tickets yet → health scorer and support intake no-op; never fabricate health scores or tickets (no customers table populated)',
       token_budget: 25000
     }
   ],
@@ -117,16 +150,30 @@ const STANDARD_VENTURE_TEMPLATE = {
     { agent_role: 'QA_Crew', executive_parent: 'VP_TECH', capabilities: ['qa_testing'], token_budget: 5000 },
     { agent_role: 'DevOps_Crew', executive_parent: 'VP_TECH', capabilities: ['deployment'], token_budget: 5000 },
 
-    // VP_GROWTH crews (3)
+    // VP_GROWTH crews (4)
     { agent_role: 'Launch_Crew', executive_parent: 'VP_GROWTH', capabilities: ['launch_planning'], token_budget: 5000 },
     { agent_role: 'Analytics_Crew', executive_parent: 'VP_GROWTH', capabilities: ['analytics'], token_budget: 5000 },
     { agent_role: 'Growth_Crew', executive_parent: 'VP_GROWTH', capabilities: ['optimization'], token_budget: 5000 },
+    // SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F9): new Sales_Crew — a crew, not a VP
+    // (smallest honest role; revisit VP_SALES at scale). ARM-ABLE for the v2 demand
+    // test (arming is a separate named action; define-now ships the duty cycle text).
+    { agent_role: 'Sales_Crew', executive_parent: 'VP_GROWTH', capabilities: ['outreach', 'reply_triage', 'pipeline_review', 'suppression_management'], token_budget: 5000,
+      duty_cycle: 'daily outreach batch (manual-1:1, AUP-compliant) + reply triage via inbound-ingestion; pilot/preorder conversion; weekly pipeline review; suppression/opt-out honored',
+      honest_idle: 'no prospects/replies yet → no outreach fabricated; suppression list always respected' },
 
     // VP_MARKETING crews (4)
     { agent_role: 'Brand_Content_Crew', executive_parent: 'VP_MARKETING', capabilities: ['brand_strategy', 'content_marketing'], token_budget: 5000 },
     { agent_role: 'SEO_Crew', executive_parent: 'VP_MARKETING', capabilities: ['seo'], token_budget: 5000 },
     { agent_role: 'Demand_Gen_Crew', executive_parent: 'VP_MARKETING', capabilities: ['demand_generation'], token_budget: 5000 },
-    { agent_role: 'Lifecycle_Crew', executive_parent: 'VP_MARKETING', capabilities: ['lifecycle_marketing'], token_budget: 5000 }
+    { agent_role: 'Lifecycle_Crew', executive_parent: 'VP_MARKETING', capabilities: ['lifecycle_marketing'], token_budget: 5000 },
+
+    // VP_CUSTOMER crews (2) — SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (F3+F12 folded)
+    { agent_role: 'Customer_Success_Crew', executive_parent: 'VP_CUSTOMER', capabilities: ['customer_health_scoring', 'onboarding_sequence', 'churn_save_motion'], token_budget: 5000,
+      duty_cycle: 'weekly health scoring across the 4 dimensions + at-risk detection → outreach; on-signup onboarding; monthly cohort review',
+      honest_idle: 'no customers yet → scorer no-ops; never fabricate a health score for a customer that does not exist' },
+    { agent_role: 'Support_Crew', executive_parent: 'VP_CUSTOMER', capabilities: ['support_intake', 'ticket_triage', 'faq_response'], token_budget: 5000,
+      duty_cycle: 'continuous intake from the venture public email rail; triage + FAQ-class autonomous response; escalate bugs → VP_PRODUCT, at-risk → CS; injection-quarantine draining',
+      honest_idle: 'empty ticket queue → intake no-ops; no synthetic tickets, no fabricated responses' }
   ],
 
   budget_distribution: {
@@ -134,6 +181,59 @@ const STANDARD_VENTURE_TEMPLATE = {
     vp_percentage: 90
   }
 };
+
+/**
+ * EHG-SHARED operators — SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 (§2 delta, chairman-ratified V1).
+ *
+ * Commodity rails that instantiate ONCE at the EHG (holdco) level — NOT per venture — so
+ * chairman cost scales sub-linearly (one agent serves N ventures as ledger/tenant rows).
+ * They are deliberately a SEPARATE structure from STANDARD_VENTURE_TEMPLATE (which
+ * standard-instantiates per venture). Placement default = 'shared' for all four
+ * (chairman-ratified; flippable per-operator later when a single venture's scale justifies
+ * a dedicated agent). Each carries its §1 run-state duty cycle AND an honest-idle no-op —
+ * define-now is real behavior definition, never role-rows-as-decoration; a defined-but-
+ * unarmed operator no-ops honestly on empty inputs and NEVER fabricates activity.
+ * Arming (wiring the duty cycle to a live scheduler/webhook) is a deferred named-trigger
+ * action per §5 (V2/V3 demand-test riders), out of this define-now SD's scope.
+ */
+const EHG_SHARED_OPERATORS = [
+  {
+    agent_role: 'FINANCE_BILLING_OPERATOR',
+    display_name: 'EHG Finance/Billing Operator',
+    placement: 'shared',
+    capabilities: ['payment_capture', 'reconciliation', 'mrr_churn_rollup', 'dunning', 'revenue_recognition', 'webhook_liveness_watch'],
+    duty_cycle: 'event-driven payment capture (webhook → ledger); daily reconcile; weekly MRR/churn rollup to the evidence fabric; dunning sequence on failures (day 0/3/7 + email); monthly recognition; webhook-liveness watch',
+    honest_idle: 'no payment/checkout events → capture, reconcile and dunning all no-op; never fabricate a ledger row or MRR figure',
+    token_budget: 15000
+  },
+  {
+    agent_role: 'LEGAL_COMPLIANCE_OPERATOR',
+    display_name: 'EHG Legal/Compliance Operator',
+    placement: 'shared',
+    capabilities: ['policy_generation', 'consent_records', 'dsar_fulfillment', 'quarterly_policy_refresh'],
+    duty_cycle: 'at-launch ToS/privacy/DPA/cookie-consent generation (templated per venture); consent records on signup; DSAR fulfillment on request (30-day statutory clock); quarterly policy refresh',
+    honest_idle: 'no launches / no DSAR requests → generator and fulfillment no-op; never emit a policy for a venture that has not launched',
+    token_budget: 12000
+  },
+  {
+    agent_role: 'SECURITY_POSTURE_OPERATOR',
+    display_name: 'EHG Security-Posture Operator',
+    placement: 'shared',
+    capabilities: ['cve_scanning', 'posture_recheck', 'secret_rotation_watch', 'abuse_anomaly_watch'],
+    duty_cycle: 'weekly dependency/CVE scan of each live venture; posture re-check on each deploy; secret/credential rotation watch; abuse/anomaly watch (injection-quarantine consumer); findings → patch PRs as factory work orders',
+    honest_idle: 'no deployed venture surface → scans and posture checks no-op; no synthetic findings',
+    token_budget: 12000
+  },
+  {
+    agent_role: 'DATA_PLATFORM_OPERATOR',
+    display_name: 'EHG Data-Platform Operator',
+    placement: 'shared',
+    capabilities: ['telemetry_ingest', 'kpi_rollup', 'experiment_readouts'],
+    duty_cycle: 'daily telemetry ingest across ventures; weekly KPI rollup to the evidence fabric; per-decision experiment readouts (incl. demand-test gauges) with real_event provenance',
+    honest_idle: 'metrics_base_url null / no telemetry exposed → ingest skips HONESTLY (records a skip, never a fabricated metric); the pull stops skipping only when a venture deploys with /v1/metrics',
+    token_budget: 15000
+  }
+];
 
 /**
  * VentureFactory - Creates complete venture organizational structure
@@ -514,7 +614,7 @@ export class VentureFactory {
 }
 
 // Export template for reference
-export { STANDARD_VENTURE_TEMPLATE, WELL_KNOWN_IDS };
+export { STANDARD_VENTURE_TEMPLATE, EHG_SHARED_OPERATORS, WELL_KNOWN_IDS };
 
 // Default export
 export default VentureFactory;

--- a/tests/unit/venture-ceo-factory.test.js
+++ b/tests/unit/venture-ceo-factory.test.js
@@ -10,15 +10,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { VentureFactory, STANDARD_VENTURE_TEMPLATE } from '../../lib/agents/venture-ceo-factory.js';
+import { VentureFactory, STANDARD_VENTURE_TEMPLATE, EHG_SHARED_OPERATORS } from '../../lib/agents/venture-ceo-factory.js';
 
 vi.mock('uuid', () => ({
   v4: () => `mock-uuid-${Math.random().toString(36).slice(2)}`
 }));
 
 describe('STANDARD_VENTURE_TEMPLATE shape', () => {
-  it('has 5 executives (was 4)', () => {
-    expect(STANDARD_VENTURE_TEMPLATE.executives).toHaveLength(5);
+  it('has 6 executives (was 5)', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.executives).toHaveLength(6);
   });
 
   it('includes VP_MARKETING with the expected capabilities/tools/stage_ownership', () => {
@@ -42,8 +42,8 @@ describe('STANDARD_VENTURE_TEMPLATE shape', () => {
     expect(vpMarketing).not.toHaveProperty('enabled');
   });
 
-  it('has 18 crews (was 14), 4 of which report to VP_MARKETING', () => {
-    expect(STANDARD_VENTURE_TEMPLATE.crews).toHaveLength(18);
+  it('has 21 crews (was 18), 4 of which report to VP_MARKETING', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.crews).toHaveLength(21);
     const marketingCrews = STANDARD_VENTURE_TEMPLATE.crews.filter(c => c.executive_parent === 'VP_MARKETING');
     expect(marketingCrews).toHaveLength(4);
     expect(marketingCrews.map(c => c.agent_role)).toEqual(
@@ -71,8 +71,75 @@ describe('STANDARD_VENTURE_TEMPLATE shape', () => {
     }
   });
 
-  it('description reflects the 24-agent total (1 CEO + 5 VP + 18 crew)', () => {
-    expect(STANDARD_VENTURE_TEMPLATE.description).toContain('24-agent');
+  it('description reflects the 28-agent per-venture total (1 CEO + 6 VP + 21 crew)', () => {
+    expect(STANDARD_VENTURE_TEMPLATE.description).toContain('28-agent');
+  });
+});
+
+describe('SD-FDBK-ENH-ORG-TEMPLATE-DELTA-001 — org-template delta', () => {
+  const NEW_ROLES_MUST_HAVE_DUTY = ['VP_CUSTOMER', 'Sales_Crew', 'Customer_Success_Crew', 'Support_Crew'];
+
+  it('FR-1: VP_CUSTOMER is a standard per-venture executive with a continuous mandate + duty cycle + honest idle', () => {
+    const vp = STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_CUSTOMER');
+    expect(vp).toBeDefined();
+    expect(vp.stage_ownership).toEqual([]); // continuous, like VP_MARKETING
+    expect(vp.duty_cycle).toBeTruthy();
+    expect(vp.honest_idle).toBeTruthy();
+    expect(vp).not.toHaveProperty('lazy'); // unconditional, no gating flag
+  });
+
+  it('FR-1: Customer_Success_Crew + Support_Crew report to VP_CUSTOMER with duty cycles', () => {
+    const cust = STANDARD_VENTURE_TEMPLATE.crews.filter(c => c.executive_parent === 'VP_CUSTOMER');
+    expect(cust.map(c => c.agent_role).sort()).toEqual(['Customer_Success_Crew', 'Support_Crew']);
+    for (const c of cust) { expect(c.duty_cycle).toBeTruthy(); expect(c.honest_idle).toBeTruthy(); }
+  });
+
+  it('FR-2: Sales_Crew is a crew (not a VP) under VP_GROWTH with duty cycle + honest idle', () => {
+    const sales = STANDARD_VENTURE_TEMPLATE.crews.find(c => c.agent_role === 'Sales_Crew');
+    expect(sales).toBeDefined();
+    expect(sales.executive_parent).toBe('VP_GROWTH');
+    expect(sales.duty_cycle).toMatch(/outreach/i);
+    expect(sales.honest_idle).toMatch(/suppression|no outreach/i);
+    expect(STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_SALES')).toBeUndefined();
+  });
+
+  it('FR-3: the 3 mandate extensions retire the every-mandate-ends-at-a-stage defect', () => {
+    for (const role of ['VP_TECH', 'VP_PRODUCT', 'VP_GROWTH']) {
+      const vp = STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === role);
+      expect(vp.post_stage_mandate, `${role} must carry a post_stage_mandate`).toBeTruthy();
+      expect(vp.honest_idle, `${role} mandate extension needs an honest-idle`).toBeTruthy();
+    }
+    // stage_ownership arrays are UNCHANGED (additive field only — no routing change).
+    expect(STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_TECH').stage_ownership).toEqual([13, 14, 15, 16, 17, 18, 19, 20, 21]);
+    expect(STANDARD_VENTURE_TEMPLATE.executives.find(e => e.agent_role === 'VP_GROWTH').stage_ownership).toEqual([22, 23, 24, 25, 26]);
+  });
+
+  it('FR-4: EHG_SHARED_OPERATORS exports exactly the 4 named commodity operators, instantiate-once', () => {
+    expect(Array.isArray(EHG_SHARED_OPERATORS)).toBe(true);
+    expect(EHG_SHARED_OPERATORS.map(o => o.agent_role).sort()).toEqual(
+      ['DATA_PLATFORM_OPERATOR', 'FINANCE_BILLING_OPERATOR', 'LEGAL_COMPLIANCE_OPERATOR', 'SECURITY_POSTURE_OPERATOR']
+    );
+    for (const op of EHG_SHARED_OPERATORS) {
+      expect(op.placement).toBe('shared'); // chairman-ratified default
+      expect(op.duty_cycle).toBeTruthy();
+      expect(op.honest_idle).toBeTruthy();
+    }
+    // They are SEPARATE from the per-venture template (instantiate once at holdco level).
+    const perVentureRoles = STANDARD_VENTURE_TEMPLATE.executives.map(e => e.agent_role);
+    for (const op of EHG_SHARED_OPERATORS) expect(perVentureRoles).not.toContain(op.agent_role);
+  });
+
+  it('FR-5 anti-decoration guard: every new role has a NON-EMPTY duty_cycle AND honest_idle', () => {
+    const newVentureRoles = [
+      ...STANDARD_VENTURE_TEMPLATE.executives.filter(e => NEW_ROLES_MUST_HAVE_DUTY.includes(e.agent_role)),
+      ...STANDARD_VENTURE_TEMPLATE.crews.filter(c => NEW_ROLES_MUST_HAVE_DUTY.includes(c.agent_role)),
+      ...EHG_SHARED_OPERATORS
+    ];
+    expect(newVentureRoles.length).toBeGreaterThanOrEqual(8);
+    for (const r of newVentureRoles) {
+      expect(typeof r.duty_cycle === 'string' && r.duty_cycle.trim().length > 0, `${r.agent_role} duty_cycle`).toBe(true);
+      expect(typeof r.honest_idle === 'string' && r.honest_idle.trim().length > 0, `${r.agent_role} honest_idle`).toBe(true);
+    }
   });
 });
 
@@ -97,28 +164,29 @@ describe('VentureFactory.instantiateVenture with mocked Supabase', () => {
     };
   });
 
-  it('creates 5 executive agents (was 4), including VP_MARKETING', async () => {
+  it('creates 6 executive agents (was 5), including VP_CUSTOMER', async () => {
     const factory = new VentureFactory(mockSupabase);
     const result = await factory.instantiateVenture({
       ventureName: 'Test Venture',
       ventureId: 'test-venture-id-123'
     });
 
-    expect(Object.keys(result.executive_agent_ids)).toHaveLength(5);
+    expect(Object.keys(result.executive_agent_ids)).toHaveLength(6);
     expect(result.executive_agent_ids).toHaveProperty('VP_MARKETING');
+    expect(result.executive_agent_ids).toHaveProperty('VP_CUSTOMER');
     expect(result.executive_agent_ids).toHaveProperty('VP_STRATEGY');
     expect(result.executive_agent_ids).toHaveProperty('VP_PRODUCT');
     expect(result.executive_agent_ids).toHaveProperty('VP_TECH');
     expect(result.executive_agent_ids).toHaveProperty('VP_GROWTH');
   });
 
-  it('total_agents_created reflects 1 CEO + 5 VP + 18 crew = 24', async () => {
+  it('total_agents_created reflects 1 CEO + 6 VP + 21 crew = 28', async () => {
     const factory = new VentureFactory(mockSupabase);
     const result = await factory.instantiateVenture({
       ventureName: 'Test Venture 2',
       ventureId: 'test-venture-id-456'
     });
 
-    expect(result.total_agents_created).toBe(24);
+    expect(result.total_agents_created).toBe(28);
   });
 });


### PR DESCRIPTION
## Summary
Chairman-ratified V1 org-template delta, mirroring the completed VP_MARKETING SD. Extends `lib/agents/venture-ceo-factory.js`:
- **VP_CUSTOMER** (per-venture, CS+Support folded, continuous) + Customer_Success_Crew + Support_Crew
- **Sales_Crew** under VP_GROWTH (crew, not a VP)
- **3 mandate extensions** (post_stage_mandate on VP_TECH/VP_PRODUCT/VP_GROWTH — no VP mandate ends at a build stage; stage_ownership untouched)
- **EHG_SHARED_OPERATORS** export — FINANCE_BILLING / LEGAL_COMPLIANCE / SECURITY_POSTURE / DATA_PLATFORM, instantiate-once holdco pattern

Every new role carries its §1 duty_cycle + an honest_idle no-op (define-now = behavior, not decoration). Per-venture roster 24→28.

## Test plan
- `tests/unit/venture-ceo-factory.test.js` — 14 tests (delta FR-1..FR-5 + zero-regression + anti-decoration guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)