### PR TITLE
fix(SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001): archive-before-delete session_coordination cleanup + retention hardening

### DIFF
--- a/database/migrations/20260713_fix_cleanup_expired_coordination.sql
+++ b/database/migrations/20260713_fix_cleanup_expired_coordination.sql
@@ -1,0 +1,58 @@
+-- Fix cleanup_expired_coordination(): P0003 crash + archive-before-delete + guard predicates
+-- SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-1)
+--
+-- Prior body used `DELETE ... RETURNING 1 INTO deleted_count` -- a scalar INTO that raises
+-- P0003 too_many_rows whenever the DELETE matches more than one row, rolling back the whole
+-- statement. This has been a silent no-op for months (caller swallows the error).
+--
+-- This version: (a) uses GET DIAGNOSTICS ROW_COUNT instead of a scalar INTO, (b) archives
+-- every deleted row into retention_archive BEFORE deleting (mirrors scripts/retention-enforce.js's
+-- proven archive-before-delete invariant), aborting with zero deletes on any archive/delete
+-- count mismatch, and (c) only ever deletes rows that are expired AND (acknowledged OR read
+-- >=7 days ago) -- expired-but-never-surfaced rows (read_at IS NULL AND acknowledged_at IS
+-- NULL) are NEVER deleted here; they are already routed through the existing dead-letter pass
+-- (lib/sweep/passes/dead-letter-planning.cjs), which stamps payload.dead_letter=true rather
+-- than deleting.
+
+CREATE OR REPLACE FUNCTION cleanup_expired_coordination()
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  deleted_count integer;
+  archived_count integer;
+BEGIN
+  -- Snapshot the exact candidate id set once, so the archive INSERT and the
+  -- DELETE operate on identically the same rows (no re-evaluation race).
+  CREATE TEMP TABLE IF NOT EXISTS _cleanup_expired_coord_candidates (id uuid) ON COMMIT DROP;
+  DELETE FROM _cleanup_expired_coord_candidates;
+
+  INSERT INTO _cleanup_expired_coord_candidates (id)
+  SELECT id FROM session_coordination
+  WHERE expires_at < now()
+    AND (
+      acknowledged_at IS NOT NULL
+      OR (read_at IS NOT NULL AND read_at <= now() - interval '7 days')
+    );
+
+  INSERT INTO retention_archive (source_table, source_id, row_data, row_timestamp, archived_by)
+  SELECT 'session_coordination', sc.id::text, to_jsonb(sc), sc.expires_at, 'cleanup_expired_coordination'
+  FROM session_coordination sc
+  JOIN _cleanup_expired_coord_candidates c ON c.id = sc.id;
+  GET DIAGNOSTICS archived_count = ROW_COUNT;
+
+  DELETE FROM session_coordination sc
+  USING _cleanup_expired_coord_candidates c
+  WHERE sc.id = c.id;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  IF archived_count <> deleted_count THEN
+    RAISE EXCEPTION 'cleanup_expired_coordination archive/delete count mismatch: archived=%, deleted=%', archived_count, deleted_count;
+  END IF;
+
+  RETURN deleted_count;
+END;
+$$;
+
+COMMENT ON FUNCTION cleanup_expired_coordination() IS
+  'Archive-before-delete cleanup of expired session_coordination rows. Only deletes rows that are acknowledged or read >=7d ago; never-surfaced rows are routed via the dead-letter pass instead. Fixed P0003 (SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001).';

--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -32,6 +32,13 @@ export const BATCH_SIZE = 1000;
 export const DELETE_CHUNK = 200;
 export const LIVENESS_MAX_AGE_DAYS = 8;
 
+/**
+ * `mode` is currently always 'archive' and is NOT read by scripts/retention-enforce.js's
+ * enforcePolicy() (which always archives-before-delete unconditionally) -- it exists as a
+ * forward-declared field for a possible future non-archive mode (e.g. hard-delete-only for a
+ * table with no audit value), not as live-branched behavior today (SD-FDBK-FIX-BUS-RETENTION-
+ * CLEANUP-001 FR-6a).
+ */
 /** Verified per-table timestamp columns (live schema, 2026-06-10). */
 export const RETENTION_POLICIES = [
   { table: 'workflow_trace_log',   timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
@@ -44,6 +51,10 @@ export const RETENTION_POLICIES = [
   // x1.63 in 24h per row-growth-snapshot.cjs) and uncovered by RETENTION-POLICY-UNBOUNDED-001.
   // created_at verified on live schema (occurred_at also exists); 0 triggers/FKs/inbound-FKs.
   { table: 'eva_scheduler_metrics', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  // SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-3): sub_agent_execution_results had no retention
+  // policy despite high write volume (one row per sub-agent invocation). Verified every
+  // automated consumer reads at most the last 30 days, so a 90-day hot window is safe.
+  { table: 'sub_agent_execution_results', timestampColumn: 'created_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
 ];
 
 /**

--- a/lib/retention/session-coordination-ack-convergence.js
+++ b/lib/retention/session-coordination-ack-convergence.js
@@ -1,0 +1,45 @@
+/**
+ * ack-TTL convergence for session_coordination (SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 FR-2).
+ *
+ * cleanup_expired_coordination()'s fixed guard predicate only deletes expired rows that are
+ * acknowledged, or read >=7 days ago -- it never deletes never-surfaced rows. Rows that were
+ * read (or never even read) but never acknowledged accumulate until they age out on their own.
+ * This convergence pass stamps acknowledged_at (+ payload.auto_acked=true) on rows unacked for
+ * >=14 days, so the cleanup RPC's guard predicate can eventually reap them once they also
+ * expire. It deletes nothing.
+ */
+
+const ACK_TTL_DAYS = 14;
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ now?: Date }} [opts]
+ * @returns {Promise<{ converged: number, error: string|null }>}
+ */
+export async function convergeAckTTL(supabase, { now = new Date() } = {}) {
+  const cutoff = new Date(now.getTime() - ACK_TTL_DAYS * 86_400_000).toISOString();
+
+  const { data: candidates, error: selErr } = await supabase
+    .from('session_coordination')
+    .select('id, payload')
+    .is('acknowledged_at', null)
+    .lte('created_at', cutoff);
+
+  if (selErr) return { converged: 0, error: `select failed: ${selErr.message}` };
+  if (!candidates || candidates.length === 0) return { converged: 0, error: null };
+
+  let converged = 0;
+  for (const row of candidates) {
+    const { error: updErr } = await supabase
+      .from('session_coordination')
+      .update({
+        acknowledged_at: now.toISOString(),
+        payload: { ...(row.payload || {}), auto_acked: true },
+      })
+      .eq('id', row.id);
+    if (updErr) return { converged, error: `update failed for id=${row.id}: ${updErr.message}` };
+    converged += 1;
+  }
+
+  return { converged, error: null };
+}

--- a/lib/retention/system-events-retention.js
+++ b/lib/retention/system-events-retention.js
@@ -1,0 +1,126 @@
+/**
+ * Bespoke system_events retention pass (SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 FR-4).
+ *
+ * system_events cannot take a naive age-cutoff RETENTION_POLICIES entry because three live
+ * readers do unbounded "latest row" lookups:
+ *   - lib/decision-binding/disposition.js: latest DECISION_DISPOSITION row per idempotency_key,
+ *     with payload->>status='awaiting_disposition' (non-terminal) rows that must never purge.
+ *   - lib/governance/manifesto-mode.js: latest signing event per event_type.
+ *   - lib/governance/portfolio-calibrator.js: latest AGENT_OUTCOME row per venture_id.
+ *
+ * This pass purges rows older than the hot cutoff EXCEPT the single most-recent row per
+ * (event_type, group key) and any row whose payload/event_data status is non-terminal.
+ * Archive-before-delete, mirroring scripts/retention-enforce.js's invariant.
+ */
+
+const NON_TERMINAL_STATUSES = new Set(['awaiting_disposition']);
+const DELETE_CHUNK = 200;
+
+function statusOf(row) {
+  return row.payload?.status ?? row.event_data?.status ?? null;
+}
+
+function isNonTerminal(row) {
+  const status = statusOf(row);
+  return status != null && NON_TERMINAL_STATUSES.has(status);
+}
+
+function groupKeyFor(row) {
+  if (row.event_type === 'AGENT_OUTCOME') {
+    const ventureId = row.venture_id ?? row.event_data?.venture_id ?? row.payload?.venture_id ?? '';
+    return `${row.event_type}:${ventureId}`;
+  }
+  if (row.event_type === 'DECISION_DISPOSITION') {
+    return `${row.event_type}:${row.idempotency_key ?? ''}`;
+  }
+  return row.event_type;
+}
+
+async function findLatestIdForGroup(supabase, row) {
+  let query = supabase.from('system_events').select('id, created_at').eq('event_type', row.event_type);
+  if (row.event_type === 'AGENT_OUTCOME') {
+    const ventureId = row.venture_id ?? row.event_data?.venture_id ?? row.payload?.venture_id;
+    if (ventureId) query = query.eq('venture_id', ventureId);
+  } else if (row.event_type === 'DECISION_DISPOSITION') {
+    if (row.idempotency_key) query = query.eq('idempotency_key', row.idempotency_key);
+  }
+  const { data, error } = await query.order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (error) throw new Error(`latest-for-group lookup failed: ${error.message}`);
+  return data?.id ?? null;
+}
+
+function chunk(arr, n) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+}
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ hotDays?: number, now?: Date, runId?: string }} [opts]
+ * @returns {Promise<{ eligible: number, preservedLatest: number, preservedNonTerminal: number, archived: number, deleted: number, error: string|null }>}
+ */
+export async function enforceSystemEventsRetention(supabase, { hotDays = 90, now = new Date(), runId = null } = {}) {
+  const cutoff = new Date(now.getTime() - hotDays * 86_400_000).toISOString();
+  const result = { eligible: 0, preservedLatest: 0, preservedNonTerminal: 0, archived: 0, deleted: 0, error: null };
+
+  try {
+    const { data: candidates, error: selErr } = await supabase
+      .from('system_events')
+      .select('*')
+      .lt('created_at', cutoff);
+    if (selErr) throw new Error(`select failed: ${selErr.message}`);
+    if (!candidates || candidates.length === 0) return result;
+    result.eligible = candidates.length;
+
+    const latestIdCache = new Map();
+    const toDelete = [];
+
+    for (const row of candidates) {
+      const key = groupKeyFor(row);
+      if (!latestIdCache.has(key)) {
+        latestIdCache.set(key, await findLatestIdForGroup(supabase, row));
+      }
+      if (latestIdCache.get(key) === row.id) {
+        result.preservedLatest += 1;
+        continue;
+      }
+      if (isNonTerminal(row)) {
+        result.preservedNonTerminal += 1;
+        continue;
+      }
+      toDelete.push(row);
+    }
+
+    if (toDelete.length === 0) return result;
+
+    const archiveRows = toDelete.map((r) => ({
+      source_table: 'system_events',
+      source_id: r.id != null ? String(r.id) : null,
+      row_data: r,
+      row_timestamp: r.created_at || null,
+      archived_by: 'system-events-retention',
+      run_id: runId,
+    }));
+    const { error: insErr, count: insCount } = await supabase
+      .from('retention_archive')
+      .insert(archiveRows, { count: 'exact' });
+    if (insErr) throw new Error(`archive insert failed (NO rows deleted): ${insErr.message}`);
+    if ((insCount ?? archiveRows.length) !== archiveRows.length) {
+      throw new Error(`archive insert count mismatch (${insCount} != ${archiveRows.length}) — aborting before delete`);
+    }
+    result.archived = toDelete.length;
+
+    const ids = toDelete.map((r) => r.id);
+    for (const ch of chunk(ids, DELETE_CHUNK)) {
+      const { error: delErr } = await supabase.from('system_events').delete().in('id', ch);
+      if (delErr) throw new Error(`delete failed after archive (rows ARE archived; rerun converges): ${delErr.message}`);
+      result.deleted += ch.length;
+    }
+
+    return result;
+  } catch (err) {
+    result.error = err.message;
+    return result;
+  }
+}

--- a/scripts/retention-enforce.js
+++ b/scripts/retention-enforce.js
@@ -96,25 +96,45 @@ export async function enforcePolicy(supabase, policy, { apply = false, runId = n
       if (selErr) throw new Error(`select failed: ${selErr.message}`);
       if (!rows || rows.length === 0) break;
 
-      // 1) ARCHIVE — must succeed before any delete (TR-1).
-      const archiveRows = rows.map((r) => ({
-        source_table: policy.table,
-        source_id: r.id != null ? String(r.id) : null,
-        row_data: r,
-        row_timestamp: r[policy.timestampColumn] || null,
-        archived_by: 'retention-enforce',
-        run_id: runId,
-      }));
-      const { error: insErr, count: insCount } = await supabase
+      // FR-6b (SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001): id-cursor guard. If a prior run
+      // archived a batch but its DELETE failed partway (e.g. transient error on one chunk),
+      // a later run would re-SELECT the same still-present rows and re-INSERT duplicate
+      // retention_archive copies before retrying the delete. Check which of this batch's
+      // ids already have an archive row for this table and skip re-archiving those —
+      // only their delete is retried.
+      const candidateIds = rows.map((r) => String(r.id));
+      const { data: alreadyArchived, error: archCheckErr } = await supabase
         .from('retention_archive')
-        .insert(archiveRows, { count: 'exact' });
-      if (insErr) throw new Error(`archive insert failed (NO rows deleted this batch): ${insErr.message}`);
-      if ((insCount ?? archiveRows.length) !== archiveRows.length) {
-        throw new Error(`archive insert count mismatch (${insCount} != ${archiveRows.length}) — aborting before delete`);
-      }
-      result.archived += rows.length;
+        .select('source_id')
+        .eq('source_table', policy.table)
+        .in('source_id', candidateIds);
+      if (archCheckErr) throw new Error(`archive-dedup check failed: ${archCheckErr.message}`);
+      const archivedIdSet = new Set((alreadyArchived || []).map((a) => a.source_id));
+      const toArchive = rows.filter((r) => !archivedIdSet.has(String(r.id)));
 
-      // 2) DELETE the archived ids (chunked — URL-length safe).
+      // 1) ARCHIVE — must succeed before any delete (TR-1). Skips ids already archived by
+      // a prior run whose delete failed (see id-cursor guard above).
+      if (toArchive.length > 0) {
+        const archiveRows = toArchive.map((r) => ({
+          source_table: policy.table,
+          source_id: r.id != null ? String(r.id) : null,
+          row_data: r,
+          row_timestamp: r[policy.timestampColumn] || null,
+          archived_by: 'retention-enforce',
+          run_id: runId,
+        }));
+        const { error: insErr, count: insCount } = await supabase
+          .from('retention_archive')
+          .insert(archiveRows, { count: 'exact' });
+        if (insErr) throw new Error(`archive insert failed (NO rows deleted this batch): ${insErr.message}`);
+        if ((insCount ?? archiveRows.length) !== archiveRows.length) {
+          throw new Error(`archive insert count mismatch (${insCount} != ${archiveRows.length}) — aborting before delete`);
+        }
+        result.archived += toArchive.length;
+      }
+
+      // 2) DELETE the archived ids (chunked — URL-length safe). Includes both
+      // freshly-archived ids and already-archived-pending-delete ids from a prior run.
       const ids = rows.map((r) => r.id);
       for (const ch of chunk(ids, DELETE_CHUNK)) {
         const { error: delErr } = await supabase.from(policy.table).delete().in('id', ch);

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2685,8 +2685,24 @@ async function main() {
     actions.push('CLAIM_REMINDER: nudged ' + claimIntegrityIssues.length + ' idle session(s) — ' + claimIntegrityIssues.join(', '));
   }
 
-  // Clean up expired messages first
-  try { await supabase.rpc('cleanup_expired_coordination'); } catch { /* ignore */ }
+  // Clean up expired messages first. SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-1): the RPC
+  // used to throw P0003 whenever >1 row was expired, silently swallowed here for months. The
+  // RPC itself is now fixed (archive-before-delete + guard predicates); still log a genuine
+  // failure instead of swallowing it, so a future regression surfaces instead of no-op'ing.
+  try {
+    await supabase.rpc('cleanup_expired_coordination');
+  } catch (cleanupErr) {
+    console.error(`[stale-session-sweep] cleanup_expired_coordination RPC failed: ${cleanupErr.message}`);
+  }
+
+  // FR-2: converge the ack-TTL backlog (stamps acknowledged_at on 14d+ no-ack rows; deletes
+  // nothing) so the cleanup RPC's guard predicate can eventually reap them once expired too.
+  try {
+    const { convergeAckTTL } = await import('../lib/retention/session-coordination-ack-convergence.js');
+    await convergeAckTTL(supabase);
+  } catch (ackErr) {
+    console.error(`[stale-session-sweep] ack-TTL convergence failed: ${ackErr.message}`);
+  }
 
   // FIX #3 — REWORKED by FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): coordination
   // messages targeting dead/gone sessions are DEAD-LETTERED, never hard-DELETEd. Selection

--- a/tests/unit/retention/cleanup-expired-coordination-migration.test.js
+++ b/tests/unit/retention/cleanup-expired-coordination-migration.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-1) — static content assertions on the
+ * cleanup_expired_coordination() fix migration. A live-DB round-trip test isn't practical
+ * in this suite (pure unit tests, no DB), so this pins the SQL text the same way
+ * retention-policy.test.js's "migration parity (TS-2 static)" block pins the substrate
+ * migration -- verifying the fix is actually present and the old bug is actually gone.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const MIGRATION = readFileSync(
+  resolve(REPO_ROOT, 'database/migrations/20260713_fix_cleanup_expired_coordination.sql'),
+  'utf8'
+);
+// The function BODY only -- excludes the header comment block, which intentionally
+// mentions the OLD buggy pattern ("Prior body used ... RETURNING 1 INTO ...") for context.
+const FUNCTION_BODY = MIGRATION.slice(MIGRATION.indexOf('CREATE OR REPLACE FUNCTION'));
+
+describe('cleanup_expired_coordination() fix migration (FR-1, static)', () => {
+  it('no longer uses the scalar RETURNING ... INTO pattern that raised P0003', () => {
+    expect(FUNCTION_BODY).not.toMatch(/RETURNING\s+1\s+INTO/i);
+  });
+
+  it('uses GET DIAGNOSTICS ... ROW_COUNT for both the archive insert and the delete', () => {
+    const matches = MIGRATION.match(/GET DIAGNOSTICS\s+\w+\s*=\s*ROW_COUNT/gi) || [];
+    expect(matches.length).toBe(2);
+  });
+
+  it('archives before deleting (INSERT INTO retention_archive precedes the DELETE)', () => {
+    const insertIdx = MIGRATION.indexOf('INSERT INTO retention_archive');
+    const deleteIdx = MIGRATION.indexOf('DELETE FROM session_coordination');
+    expect(insertIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(insertIdx).toBeLessThan(deleteIdx);
+  });
+
+  it('raises on an archive/delete count mismatch instead of silently proceeding', () => {
+    expect(MIGRATION).toMatch(/RAISE EXCEPTION.*archive\/delete count mismatch/i);
+  });
+
+  it('guard predicate never matches never-surfaced rows (read_at IS NULL AND acknowledged_at IS NULL)', () => {
+    // The candidate WHERE clause must require acknowledged_at IS NOT NULL OR a read_at cutoff --
+    // it must never select purely on expires_at alone.
+    expect(MIGRATION).toMatch(/acknowledged_at IS NOT NULL/);
+    expect(MIGRATION).toMatch(/read_at IS NOT NULL AND read_at <= now\(\) - interval '7 days'/);
+  });
+
+  it('snapshots candidate ids once via a temp table (no re-evaluation race between archive and delete)', () => {
+    expect(MIGRATION).toMatch(/CREATE TEMP TABLE IF NOT EXISTS _cleanup_expired_coord_candidates/);
+  });
+});

--- a/tests/unit/retention/retention-policy.test.js
+++ b/tests/unit/retention/retention-policy.test.js
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../../');
 
 describe('policy registry (TS-1)', () => {
-  it('registers all 7 unbounded tables with the VERIFIED timestamp columns', () => {
+  it('registers all 8 unbounded tables with the VERIFIED timestamp columns', () => {
     const m = Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.timestampColumn]));
     expect(m).toEqual({
       workflow_trace_log: 'created_at',
@@ -26,6 +26,8 @@ describe('policy registry (TS-1)', () => {
       permission_audit_log: 'created_at',
       // SD-REFILL-00LHUVME: eva_scheduler_metrics retention coverage
       eva_scheduler_metrics: 'created_at',
+      // SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 FR-3
+      sub_agent_execution_results: 'created_at',
     });
   });
 
@@ -73,7 +75,7 @@ describe('policy registry (TS-1)', () => {
 });
 
 // ── mock supabase builder helper ──
-function mockSupabase({ eligible = 5, rows = null, insertError = null, deleteError = null } = {}) {
+function mockSupabase({ eligible = 5, rows = null, insertError = null, deleteError = null, alreadyArchivedIds = [] } = {}) {
   const calls = { inserts: 0, deletes: 0 };
   const sampleRows = rows || Array.from({ length: eligible }, (_, i) => ({ id: `id-${i}`, created_at: '2026-01-01T00:00:00Z' }));
   const from = vi.fn((table) => {
@@ -84,6 +86,15 @@ function mockSupabase({ eligible = 5, rows = null, insertError = null, deleteErr
           if (insertError) return { error: { message: insertError }, count: null };
           return { error: null, count: rowsIn.length };
         }),
+        // FR-6b id-cursor dedup check
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: alreadyArchivedIds.map((id) => ({ source_id: String(id) })),
+              error: null,
+            })),
+          })),
+        })),
       };
     }
     // source table builder — chainable
@@ -149,6 +160,17 @@ describe('enforcement invariants (TS-3/TS-4)', () => {
     const r = await enforcePolicy(supabase, policy, { apply: true, env: {} });
     expect(r.error).toMatch(/delete failed after archive/);
     expect(r.archived).toBe(5);
+  });
+
+  it('FR-6b id-cursor: ids already archived by a prior failed-delete run are NOT re-archived, only re-deleted', async () => {
+    const { supabase, calls } = mockSupabase({ eligible: 5, alreadyArchivedIds: ['id-0', 'id-1'] });
+    const r = await enforcePolicy(supabase, policy, { apply: true, env: {} });
+    expect(r.error).toBeNull();
+    // Only the 3 NOT-already-archived ids get inserted into retention_archive...
+    expect(r.archived).toBe(3);
+    // ...but all 5 (including the 2 already-archived) are retried for delete.
+    expect(r.deleted).toBe(5);
+    expect(calls.inserts).toBe(1);
   });
 
   it('per-table fail-soft: enforcePolicy returns the error rather than throwing', async () => {

--- a/tests/unit/retention/session-coordination-ack-convergence.test.js
+++ b/tests/unit/retention/session-coordination-ack-convergence.test.js
@@ -1,0 +1,69 @@
+/**
+ * SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-2) — ack-TTL convergence.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { convergeAckTTL } from '../../../lib/retention/session-coordination-ack-convergence.js';
+
+function mockSupabase({ candidates = [], updateError = null } = {}) {
+  const updates = [];
+  const from = vi.fn(() => ({
+    select: vi.fn(() => ({
+      is: vi.fn(() => ({
+        lte: vi.fn(async () => ({ data: candidates, error: null })),
+      })),
+    })),
+    update: vi.fn((patch) => {
+      updates.push(patch);
+      return {
+        eq: vi.fn(async () => {
+          if (updateError) return { error: { message: updateError } };
+          return { error: null };
+        }),
+      };
+    }),
+  }));
+  return { supabase: { from }, updates };
+}
+
+describe('convergeAckTTL', () => {
+  it('no-ops when there are no candidates', async () => {
+    const { supabase } = mockSupabase({ candidates: [] });
+    const r = await convergeAckTTL(supabase);
+    expect(r).toEqual({ converged: 0, error: null });
+  });
+
+  it('stamps acknowledged_at and payload.auto_acked=true, preserving existing payload keys', async () => {
+    const now = new Date('2026-07-13T00:00:00Z');
+    const { supabase, updates } = mockSupabase({
+      candidates: [{ id: 'row-1', payload: { kind: 'roll_call' } }],
+    });
+    const r = await convergeAckTTL(supabase, { now });
+    expect(r).toEqual({ converged: 1, error: null });
+    expect(updates[0]).toEqual({
+      acknowledged_at: now.toISOString(),
+      payload: { kind: 'roll_call', auto_acked: true },
+    });
+  });
+
+  it('handles a null payload gracefully', async () => {
+    const { supabase, updates } = mockSupabase({ candidates: [{ id: 'row-1', payload: null }] });
+    await convergeAckTTL(supabase);
+    expect(updates[0].payload).toEqual({ auto_acked: true });
+  });
+
+  it('deletes nothing -- only ever calls update, never delete', async () => {
+    const { supabase } = mockSupabase({ candidates: [{ id: 'row-1', payload: {} }] });
+    expect(supabase.from().delete).toBeUndefined();
+    await convergeAckTTL(supabase);
+  });
+
+  it('reports the error and stops on an update failure', async () => {
+    const { supabase } = mockSupabase({
+      candidates: [{ id: 'row-1', payload: {} }],
+      updateError: 'network blip',
+    });
+    const r = await convergeAckTTL(supabase);
+    expect(r.error).toMatch(/update failed for id=row-1/);
+    expect(r.converged).toBe(0);
+  });
+});

--- a/tests/unit/retention/system-events-retention.test.js
+++ b/tests/unit/retention/system-events-retention.test.js
@@ -1,0 +1,131 @@
+/**
+ * SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-4) — bespoke system_events retention pass.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { enforceSystemEventsRetention } from '../../../lib/retention/system-events-retention.js';
+
+/**
+ * @param {Array} candidates - rows older than the cutoff
+ * @param {(filters: object) => {id: string}|null} latestLookup - resolves the "latest row"
+ *   query given the accumulated .eq() filters for a group
+ */
+function mockSupabase({ candidates = [], latestLookup = () => null, insertError = null, deleteError = null } = {}) {
+  const calls = { inserts: 0, deletes: 0, deletedIds: [] };
+
+  const from = vi.fn((table) => {
+    if (table === 'retention_archive') {
+      return {
+        insert: vi.fn(async (rows) => {
+          calls.inserts += 1;
+          if (insertError) return { error: { message: insertError }, count: null };
+          return { error: null, count: rows.length };
+        }),
+      };
+    }
+    // system_events builder — supports both the candidates SELECT and the
+    // per-group latest-row lookup SELECT via the same chainable object.
+    const filters = {};
+    const builder = {
+      select: vi.fn((cols) => {
+        if (cols === '*') {
+          return { lt: vi.fn(async () => ({ data: candidates, error: null })) };
+        }
+        return builder; // 'id, created_at' path — continues to .eq()/.order()/.limit()
+      }),
+      eq: vi.fn((col, val) => {
+        filters[col] = val;
+        return builder;
+      }),
+      order: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      maybeSingle: vi.fn(async () => ({ data: latestLookup(filters), error: null })),
+      delete: vi.fn(() => ({
+        in: vi.fn(async (col, ids) => {
+          calls.deletes += 1;
+          calls.deletedIds.push(...ids);
+          if (deleteError) return { error: { message: deleteError } };
+          return { error: null };
+        }),
+      })),
+    };
+    return builder;
+  });
+
+  return { supabase: { from }, calls };
+}
+
+describe('enforceSystemEventsRetention', () => {
+  it('no-ops when nothing is past the cutoff', async () => {
+    const { supabase } = mockSupabase({ candidates: [] });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r).toEqual({ eligible: 0, preservedLatest: 0, preservedNonTerminal: 0, archived: 0, deleted: 0, error: null });
+  });
+
+  it('preserves the single latest row per (event_type, venture_id) for AGENT_OUTCOME', async () => {
+    const row = { id: 'evt-1', event_type: 'AGENT_OUTCOME', venture_id: 'v-1', created_at: '2020-01-01T00:00:00Z' };
+    const { supabase, calls } = mockSupabase({
+      candidates: [row],
+      latestLookup: (f) => (f.event_type === 'AGENT_OUTCOME' && f.venture_id === 'v-1' ? { id: 'evt-1' } : null),
+    });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r.preservedLatest).toBe(1);
+    expect(r.archived).toBe(0);
+    expect(calls.inserts).toBe(0);
+    expect(calls.deletes).toBe(0);
+  });
+
+  it('preserves a non-latest but non-terminal-status row (awaiting_disposition)', async () => {
+    const row = {
+      id: 'evt-2', event_type: 'DECISION_DISPOSITION', idempotency_key: 'q-1',
+      created_at: '2020-01-01T00:00:00Z', payload: { status: 'awaiting_disposition' },
+    };
+    const { supabase, calls } = mockSupabase({
+      candidates: [row],
+      latestLookup: () => ({ id: 'some-other-row' }), // NOT the latest
+    });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r.preservedNonTerminal).toBe(1);
+    expect(r.archived).toBe(0);
+    expect(calls.inserts).toBe(0);
+  });
+
+  it('archives-then-deletes a superseded, terminal-status row', async () => {
+    const row = {
+      id: 'evt-3', event_type: 'DECISION_DISPOSITION', idempotency_key: 'q-2',
+      created_at: '2020-01-01T00:00:00Z', payload: { status: 'resolved' },
+    };
+    const { supabase, calls } = mockSupabase({
+      candidates: [row],
+      latestLookup: () => ({ id: 'some-other-row' }),
+    });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r.error).toBeNull();
+    expect(r.archived).toBe(1);
+    expect(r.deleted).toBe(1);
+    expect(calls.inserts).toBe(1);
+    expect(calls.deletedIds).toEqual(['evt-3']);
+  });
+
+  it('archive-before-delete invariant: a failed archive insert issues zero deletes', async () => {
+    const row = { id: 'evt-4', event_type: 'MANIFESTO_VERSION_UPDATE', created_at: '2020-01-01T00:00:00Z' };
+    const { supabase, calls } = mockSupabase({
+      candidates: [row],
+      latestLookup: () => ({ id: 'some-other-row' }),
+      insertError: 'boom',
+    });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r.error).toMatch(/archive insert failed/);
+    expect(calls.deletes).toBe(0);
+  });
+
+  it('preserves the single latest signing event per event_type (no venture_id/idempotency_key)', async () => {
+    const row = { id: 'evt-5', event_type: 'MANIFESTO_VERSION_UPDATE', created_at: '2020-01-01T00:00:00Z' };
+    const { supabase, calls } = mockSupabase({
+      candidates: [row],
+      latestLookup: (f) => (f.event_type === 'MANIFESTO_VERSION_UPDATE' ? { id: 'evt-5' } : null),
+    });
+    const r = await enforceSystemEventsRetention(supabase);
+    expect(r.preservedLatest).toBe(1);
+    expect(calls.inserts).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **FR-1**: `cleanup_expired_coordination()` has thrown Postgres P0003 for months whenever >1 row expired (~20,327 currently), silently swallowed by an empty `catch{}` in `stale-session-sweep.cjs:2689`. Rewritten as archive-before-delete with guard predicates (never touches expired-but-never-surfaced unacknowledged rows — those route via the existing dead-letter pass); un-swallowed the caller's error.
- **FR-2**: ack-TTL convergence pass — stamps `acknowledged_at`+`payload.auto_acked=true` on 14d+ no-ack rows (deletes nothing), converging the 2,716-row backlog.
- **FR-3**: registered `sub_agent_execution_results` in `RETENTION_POLICIES` (90-day hot window).
- **FR-4**: new bespoke `system_events` retention pass preserving the single latest row per `(event_type, key)` and any non-terminal-status row (protects `awaiting_disposition`, manifesto activation, and latest-`AGENT_OUTCOME`-per-venture readers).
- **FR-6**: documented the dead `policy.mode` field (never read by the executor) rather than silently implying behavior it doesn't have; added an id-cursor dedup guard to `retention-enforce.js`'s batch loop so a partial-failure batch never re-archives already-archived rows on a later run.
- **FR-5 deferred**: retention_archive's 365d TTL was scoped contingent on the D6 DR restore-rehearsal drill being on a verified cadence. Investigated — the D6 SD is completed but no scheduled workflow/cron for `scripts/dr/restore-rehearsal.mjs` was found in-repo. Documented as an explicit follow-up rather than implemented blindly.

PR size (~550 LOC incl. tests) exceeds the 100-LOC target; justified per the chairman's explicit "ONE SD, sequenced" ratification — the pieces are tightly coupled around a single cleanup mechanism, mostly new isolated modules with dedicated tests.

## Test plan
- [x] New `tests/unit/retention/session-coordination-ack-convergence.test.js` (5 tests)
- [x] New `tests/unit/retention/system-events-retention.test.js` (6 tests)
- [x] Updated `tests/unit/retention/retention-policy.test.js` (8th policy entry, id-cursor guard test)
- [x] Full `tests/unit/retention/` suite: 27/27 pass
- [x] Full stale-session-sweep-adjacent regression surface (45 files, 403 tests across two batches): all pass except one unrelated pre-existing live-DB integration failure (`quick_fixes.target_application` — a different table, untouched by this diff; matches the known concurrent-fleet DB-pollution class)
- [ ] Migration is NOT applied in this PR — chairman-ratified scope calls for a "supervised single run before weekly cadence"; deployment is a separate, deliberately human-supervised step

🤖 Generated with [Claude Code](https://claude.com/claude-code)