### PR TITLE
fix(SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001): mount Stripe webhook route

### DIFF
--- a/api/webhooks/github-ci-status.js
+++ b/api/webhooks/github-ci-status.js
@@ -3,12 +3,19 @@
  * LEO Protocol Integration for Automated Pipeline Monitoring
  */
 
-import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { lazyServiceClient } from '../../lib/supabase-client.js';
 import crypto from 'crypto';
 import { executeSubAgent } from '../../lib/sub-agent-executor.js';
 
-// Initialize Supabase client
-const supabase = createSupabaseServiceClient();
+// Lazy client (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, adversarial review): this
+// module is now statically imported by server/index.js, so an eager
+// createSupabaseServiceClient() call here would throw at server BOOT (not
+// just on a request to this route) whenever SUPABASE_SERVICE_ROLE_KEY is
+// unset — taking down every other route too. lazyServiceClient() defers the
+// env-var check until first use, matching api/webhooks/stripe.js's db()
+// pattern and this server's existing fail-soft boot design (see
+// src/services/database-loader/connections.js).
+const supabase = lazyServiceClient();
 
 /**
  * Verify GitHub webhook signature

--- a/api/webhooks/github-ci-status.js
+++ b/api/webhooks/github-ci-status.js
@@ -296,9 +296,18 @@ async function handleGitHubWebhook(req, res) {
       .eq('repository_name', repository)
       .single();
 
-    // Verify signature (skip in development)
-    const isSignatureValid = process.env.NODE_ENV === 'development' ||
-      (config?.webhook_secret_hash && verifyGitHubSignature(payload, signature, config.webhook_secret_hash));
+    // Verify signature. The prior `NODE_ENV === 'development'` bypass is
+    // removed (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, adversarial review): this
+    // route was previously unreachable (CJS require() crash under ESM), so the
+    // bypass was dead code; mounting the route made it a live, unauthenticated
+    // write path into strategic_directives_v2 whenever NODE_ENV was
+    // 'development' (a common staging/preview value). Fails closed (401) for
+    // everyone until signature verification is fixed for real GitHub delivery
+    // (separate follow-up: config.webhook_secret_hash is currently a hash of
+    // the secret, not the raw secret, so verifyGitHubSignature can never
+    // succeed against a genuine HMAC-SHA256-signed delivery either).
+    const isSignatureValid = Boolean(config?.webhook_secret_hash) &&
+      verifyGitHubSignature(payload, signature, config.webhook_secret_hash);
 
     // Table github_webhook_events does not exist yet — skip audit storage
 

--- a/api/webhooks/github-ci-status.js
+++ b/api/webhooks/github-ci-status.js
@@ -3,19 +3,12 @@
  * LEO Protocol Integration for Automated Pipeline Monitoring
  */
 
-import { lazyServiceClient } from '../../lib/supabase-client.js';
-import crypto from 'crypto';
-import { executeSubAgent } from '../../lib/sub-agent-executor.js';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+const crypto = require('crypto');
+const { executeSubAgent } = require('../../lib/sub-agent-executor.js');
 
-// Lazy client (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, adversarial review): this
-// module is now statically imported by server/index.js, so an eager
-// createSupabaseServiceClient() call here would throw at server BOOT (not
-// just on a request to this route) whenever SUPABASE_SERVICE_ROLE_KEY is
-// unset — taking down every other route too. lazyServiceClient() defers the
-// env-var check until first use, matching api/webhooks/stripe.js's db()
-// pattern and this server's existing fail-soft boot design (see
-// src/services/database-loader/connections.js).
-const supabase = lazyServiceClient();
+// Initialize Supabase client
+const supabase = createSupabaseServiceClient();
 
 /**
  * Verify GitHub webhook signature
@@ -303,18 +296,9 @@ async function handleGitHubWebhook(req, res) {
       .eq('repository_name', repository)
       .single();
 
-    // Verify signature. The prior `NODE_ENV === 'development'` bypass is
-    // removed (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, adversarial review): this
-    // route was previously unreachable (CJS require() crash under ESM), so the
-    // bypass was dead code; mounting the route made it a live, unauthenticated
-    // write path into strategic_directives_v2 whenever NODE_ENV was
-    // 'development' (a common staging/preview value). Fails closed (401) for
-    // everyone until signature verification is fixed for real GitHub delivery
-    // (separate follow-up: config.webhook_secret_hash is currently a hash of
-    // the secret, not the raw secret, so verifyGitHubSignature can never
-    // succeed against a genuine HMAC-SHA256-signed delivery either).
-    const isSignatureValid = Boolean(config?.webhook_secret_hash) &&
-      verifyGitHubSignature(payload, signature, config.webhook_secret_hash);
+    // Verify signature (skip in development)
+    const isSignatureValid = process.env.NODE_ENV === 'development' ||
+      (config?.webhook_secret_hash && verifyGitHubSignature(payload, signature, config.webhook_secret_hash));
 
     // Table github_webhook_events does not exist yet — skip audit storage
 
@@ -366,5 +350,7 @@ async function handleGitHubWebhook(req, res) {
   }
 }
 
-export { handleGitHubWebhook };
-export default handleGitHubWebhook;
+module.exports = { handleGitHubWebhook };
+
+// Export for serverless environments
+module.exports.default = handleGitHubWebhook;

--- a/api/webhooks/github-ci-status.js
+++ b/api/webhooks/github-ci-status.js
@@ -4,8 +4,8 @@
  */
 
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
-const crypto = require('crypto');
-const { executeSubAgent } = require('../../lib/sub-agent-executor.js');
+import crypto from 'crypto';
+import { executeSubAgent } from '../../lib/sub-agent-executor.js';
 
 // Initialize Supabase client
 const supabase = createSupabaseServiceClient();
@@ -350,7 +350,5 @@ async function handleGitHubWebhook(req, res) {
   }
 }
 
-module.exports = { handleGitHubWebhook };
-
-// Export for serverless environments
-module.exports.default = handleGitHubWebhook;
+export { handleGitHubWebhook };
+export default handleGitHubWebhook;

--- a/server/index.js
+++ b/server/index.js
@@ -58,9 +58,8 @@ import githubRepoRoutes from './routes/github-repo.js';
 import protocolLintRoutes, { requireAdminRole } from './routes/protocol-lint.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
-// Payment + CI/CD webhook handlers (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001)
+// Payment webhook handler (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001)
 import { handleStripeWebhook } from '../api/webhooks/stripe.js';
-import { handleGitHubWebhook } from '../api/webhooks/github-ci-status.js';
 
 // Import Story API
 import * as storiesAPI from '../src/api/stories.js';
@@ -142,11 +141,17 @@ app.all('/api/webhooks/stripe', express.raw({ type: 'application/json' }), handl
 
 app.use(express.json());
 
-// GitHub CI/CD status webhook: uses the global express.json() parser above
-// (no raw-body requirement) (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, FR-3).
-// app.all() for the same reason as the Stripe route above.
-app.all('/api/webhooks/github-ci-status', handleGitHubWebhook);
-
+// NOTE: /api/webhooks/github-ci-status (api/webhooks/github-ci-status.js) is
+// intentionally NOT mounted here. Its ESM/CJS crash and an unauthenticated
+// dev-mode bypass were fixed (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001), but CI's
+// schema-reference-lint + a live-schema probe confirmed the handler's business
+// logic references three tables that do not exist in production
+// (ci_cd_failure_resolutions, ci_cd_pipeline_status, ci_cd_monitoring_config)
+// and three non-existent strategic_directives_v2 columns (ci_cd_status,
+// last_pipeline_run, pipeline_health_score) — database/migrations/leo-ci-cd-
+// integration.sql defines them but was never applied. Mounting a route whose
+// core logic cannot run against the real schema is unsafe; deferred to a
+// follow-up once that migration gap is properly resolved.
 // =============================================================================
 // API ROUTES
 // =============================================================================

--- a/server/index.js
+++ b/server/index.js
@@ -58,6 +58,10 @@ import githubRepoRoutes from './routes/github-repo.js';
 import protocolLintRoutes, { requireAdminRole } from './routes/protocol-lint.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
+// Payment + CI/CD webhook handlers (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001)
+import { handleStripeWebhook } from '../api/webhooks/stripe.js';
+import { handleGitHubWebhook } from '../api/webhooks/github-ci-status.js';
+
 // Import Story API
 import * as storiesAPI from '../src/api/stories.js';
 
@@ -128,7 +132,20 @@ const apiLimiter = rateLimit({
 });
 app.use('/api', apiLimiter);
 
+// Stripe webhook: raw-body middleware MUST run before the global express.json()
+// parser below, or signature verification loses the exact bytes it needs
+// (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, FR-1). Registered with app.all() (not
+// app.post()) so handleStripeWebhook's own method check (405 for non-POST)
+// is reachable — app.post() would 404 non-POST requests before the handler
+// ever runs.
+app.all('/api/webhooks/stripe', express.raw({ type: 'application/json' }), handleStripeWebhook);
+
 app.use(express.json());
+
+// GitHub CI/CD status webhook: uses the global express.json() parser above
+// (no raw-body requirement) (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001, FR-3).
+// app.all() for the same reason as the Stripe route above.
+app.all('/api/webhooks/github-ci-status', handleGitHubWebhook);
 
 // =============================================================================
 // API ROUTES

--- a/tests/integration/webhooks/webhook-routes-mounted.test.js
+++ b/tests/integration/webhooks/webhook-routes-mounted.test.js
@@ -56,9 +56,11 @@ beforeAll(async () => {
       ...process.env,
       PORT: String(TEST_PORT),
       STRIPE_WEBHOOK_SECRET: WHSEC,
-      STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_')
-        ? process.env.STRIPE_SECRET_KEY
-        : 'sk_test_wiring_e2e_dummy',
+      // Signature verification only needs STRIPE_WEBHOOK_SECRET (PAYRAIL-SIG-001
+      // decouples constructEvent from the API key), so an obviously-fake,
+      // non-Stripe-shaped value is sufficient here and avoids ever forwarding
+      // a real Stripe secret key into this test's spawned child process.
+      STRIPE_SECRET_KEY: 'not-a-real-stripe-key-wiring-e2e-test',
       // Exercises github-ci-status.js's documented dev-mode signature bypass
       // (api/webhooks/github-ci-status.js:300) so the wiring test does not
       // need a live ci_cd_monitoring_config row to prove reachability.

--- a/tests/integration/webhooks/webhook-routes-mounted.test.js
+++ b/tests/integration/webhooks/webhook-routes-mounted.test.js
@@ -61,10 +61,6 @@ beforeAll(async () => {
       // non-Stripe-shaped value is sufficient here and avoids ever forwarding
       // a real Stripe secret key into this test's spawned child process.
       STRIPE_SECRET_KEY: 'not-a-real-stripe-key-wiring-e2e-test',
-      // Exercises github-ci-status.js's documented dev-mode signature bypass
-      // (api/webhooks/github-ci-status.js:300) so the wiring test does not
-      // need a live ci_cd_monitoring_config row to prove reachability.
-      NODE_ENV: 'development',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -118,8 +114,11 @@ describe('Webhook route mounting (real Express app, real HTTP)', () => {
     });
 
     // Reachability is the contract here: a 404 would mean the route is
-    // unmounted. Any other status proves the request reached handleGitHubWebhook.
+    // unmounted. An unsigned request with no matching ci_cd_monitoring_config
+    // row correctly fails closed with 401 (no dev-mode bypass) -- any status
+    // other than 404 proves the request reached handleGitHubWebhook.
     expect(res.status).not.toBe(404);
+    expect(res.status).toBe(401);
   });
 
   it('non-POST to the Stripe route returns 405 (proves the handler, not a generic router, answered)', async () => {

--- a/tests/integration/webhooks/webhook-routes-mounted.test.js
+++ b/tests/integration/webhooks/webhook-routes-mounted.test.js
@@ -10,9 +10,16 @@ import { buildStripeSignatureHeader, buildEventRawBody } from '../../../lib/test
  * Unlike tests/integration/payments/webhook-capture.test.js (which calls
  * handleStripeWebhook directly, bypassing Express entirely), this test boots
  * the REAL server entrypoint (server/index.js) as a child process and drives
- * real HTTP requests through it — proving both webhook routes are actually
- * mounted, and that the Stripe route's express.raw() middleware is correctly
- * ordered ahead of the global express.json() parser in the running app.
+ * real HTTP requests through it — proving the Stripe route is actually
+ * mounted, and that its express.raw() middleware is correctly ordered ahead
+ * of the global express.json() parser in the running app.
+ *
+ * NOTE: /api/webhooks/github-ci-status is intentionally NOT covered here.
+ * It is not mounted in server/index.js -- its handler's business logic
+ * references three tables that do not exist in the live database
+ * (confirmed via CI's schema-reference-lint + a direct existence probe);
+ * database/migrations/leo-ci-cd-integration.sql defines them but was never
+ * applied. Mounting was deferred pending that schema gap.
  */
 const TEST_PORT = 34519;
 const BASE_URL = `http://127.0.0.1:${TEST_PORT}`;
@@ -106,19 +113,14 @@ describe('Webhook route mounting (real Express app, real HTTP)', () => {
     expect(await countRows(id)).toBe(0);
   });
 
-  it('FR-2/FR-3: github-ci-status route is mounted and reachable (not 404) after the ESM conversion', async () => {
+  it('github-ci-status is NOT mounted (deferred pending the missing-tables schema gap)', async () => {
     const res = await fetch(`${BASE_URL}/api/webhooks/github-ci-status`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-github-event': 'check_suite' },
       body: JSON.stringify({ repository: { full_name: 'rickfelix/wiring-e2e-nonexistent' }, check_suite: { conclusion: 'success' } }),
     });
 
-    // Reachability is the contract here: a 404 would mean the route is
-    // unmounted. An unsigned request with no matching ci_cd_monitoring_config
-    // row correctly fails closed with 401 (no dev-mode bypass) -- any status
-    // other than 404 proves the request reached handleGitHubWebhook.
-    expect(res.status).not.toBe(404);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(404);
   });
 
   it('non-POST to the Stripe route returns 405 (proves the handler, not a generic router, answered)', async () => {

--- a/tests/integration/webhooks/webhook-routes-mounted.test.js
+++ b/tests/integration/webhooks/webhook-routes-mounted.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import 'dotenv/config';
+import { spawn } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+import { buildStripeSignatureHeader, buildEventRawBody } from '../../../lib/test-helpers/stripe-signature.js';
+
+/**
+ * End-to-end wiring proof for SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001.
+ *
+ * Unlike tests/integration/payments/webhook-capture.test.js (which calls
+ * handleStripeWebhook directly, bypassing Express entirely), this test boots
+ * the REAL server entrypoint (server/index.js) as a child process and drives
+ * real HTTP requests through it — proving both webhook routes are actually
+ * mounted, and that the Stripe route's express.raw() middleware is correctly
+ * ordered ahead of the global express.json() parser in the running app.
+ */
+const TEST_PORT = 34519;
+const BASE_URL = `http://127.0.0.1:${TEST_PORT}`;
+const WHSEC = 'whsec_test_wiring_e2e';
+const RUN = 'evt_wiring_e2e_' + Date.now();
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+let child;
+
+let bootOutput = '';
+
+async function waitForServer(timeoutMs = 40000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      // Stripe route rejects GET with 405 — reachable at all == server is up
+      // AND the route is registered (not a generic 404 catch-all).
+      const res = await fetch(`${BASE_URL}/api/webhooks/stripe`, { method: 'GET' });
+      if (res.status === 405) return;
+    } catch {
+      // ECONNREFUSED while booting — keep polling
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Server did not become ready on port ${TEST_PORT} within ${timeoutMs}ms. Boot output:\n${bootOutput}`);
+}
+
+async function countRows(eventId) {
+  const { count } = await sb
+    .from('ops_payment_events')
+    .select('id', { count: 'exact', head: true })
+    .eq('stripe_event_id', eventId);
+  return count || 0;
+}
+
+beforeAll(async () => {
+  child = spawn(process.execPath, ['server/index.js'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PORT: String(TEST_PORT),
+      STRIPE_WEBHOOK_SECRET: WHSEC,
+      STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_')
+        ? process.env.STRIPE_SECRET_KEY
+        : 'sk_test_wiring_e2e_dummy',
+      // Exercises github-ci-status.js's documented dev-mode signature bypass
+      // (api/webhooks/github-ci-status.js:300) so the wiring test does not
+      // need a live ci_cd_monitoring_config row to prove reachability.
+      NODE_ENV: 'development',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (d) => { bootOutput += d.toString(); });
+  child.stderr.on('data', (d) => { bootOutput += d.toString(); });
+  await waitForServer();
+}, 50000);
+
+afterAll(async () => {
+  if (child && !child.killed) {
+    child.kill('SIGTERM');
+  }
+  await sb.from('ops_payment_events').delete().like('stripe_event_id', RUN + '%');
+});
+
+describe('Webhook route mounting (real Express app, real HTTP)', () => {
+  it('FR-1/FR-4: a validly-signed Stripe event reaches handleStripeWebhook with the raw body intact and is captured', async () => {
+    const id = RUN + '_valid';
+    const body = buildEventRawBody({ id });
+    const sig = buildStripeSignatureHeader(body, WHSEC);
+
+    const res = await fetch(`${BASE_URL}/api/webhooks/stripe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'stripe-signature': sig },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await countRows(id)).toBe(1);
+  });
+
+  it('FR-1/FR-4: an invalid signature is rejected with 400 — proves the raw body reached the handler unmodified', async () => {
+    const id = RUN + '_invalid';
+    const body = buildEventRawBody({ id });
+
+    const res = await fetch(`${BASE_URL}/api/webhooks/stripe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'stripe-signature': 't=1,v1=deadbeef' },
+      body,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await countRows(id)).toBe(0);
+  });
+
+  it('FR-2/FR-3: github-ci-status route is mounted and reachable (not 404) after the ESM conversion', async () => {
+    const res = await fetch(`${BASE_URL}/api/webhooks/github-ci-status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-github-event': 'check_suite' },
+      body: JSON.stringify({ repository: { full_name: 'rickfelix/wiring-e2e-nonexistent' }, check_suite: { conclusion: 'success' } }),
+    });
+
+    // Reachability is the contract here: a 404 would mean the route is
+    // unmounted. Any other status proves the request reached handleGitHubWebhook.
+    expect(res.status).not.toBe(404);
+  });
+
+  it('non-POST to the Stripe route returns 405 (proves the handler, not a generic router, answered)', async () => {
+    const res = await fetch(`${BASE_URL}/api/webhooks/stripe`, { method: 'GET' });
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
## Summary
- Mounted `POST /api/webhooks/stripe` in `server/index.js` with `express.raw({type:'application/json'})` registered **before** the global `app.use(express.json())`, preserving the exact raw bytes Stripe signature verification requires.
- Registered via `app.all()` rather than `app.post()` so the handler's own internal method-guard (405 on non-POST) is actually reachable through real HTTP routing — `app.post()`-only registration causes Express to 404 non-POST requests before the handler ever runs (caught during manual verification of this PR).
- Added `tests/integration/webhooks/webhook-routes-mounted.test.js` — an end-to-end wiring test that boots the real `server/index.js` as a child process and drives real HTTP requests through it, proving the Stripe route is reachable and that raw-body middleware ordering is correct in the actual running app (the existing `webhook-capture.test.js` only exercises the isolated handler function directly, bypassing Express).

## Scope change during review (see commit history)
This PR originally also mounted `POST /api/webhooks/github-ci-status` (fixing a CJS/ESM crash-on-import bug along the way). Three rounds of adversarial review caught real problems with that route specifically:
1. Mounting it made a pre-existing `NODE_ENV==='development'` auth bypass network-reachable for the first time.
2. The module-top-level `createSupabaseServiceClient()` call would crash the **entire server's boot**, not just this route, whenever `SUPABASE_SERVICE_ROLE_KEY` is unset (since the module became statically imported for the first time).
3. CI's `schema-reference-lint` — plus a direct live-database probe — confirmed the handler's business logic references **three tables that don't exist in production** (`ci_cd_failure_resolutions`, `ci_cd_pipeline_status`, `ci_cd_monitoring_config`) and three non-existent `strategic_directives_v2` columns. `database/migrations/leo-ci-cd-integration.sql` defines them but was never applied.

(1) and (2) were fixed. (3) is a genuine, separate schema gap — well beyond "mount a pre-existing route" scope, and likely chairman-gated DDL (new tables). Rather than ship a mounted-but-permanently-broken route or fight a correct CI gate, `api/webhooks/github-ci-status.js` was reverted to its pre-PR state entirely and dropped from this PR. This SD's actual purpose — unblocking the v2 demand-test's K2 card-verified-preorder kill-gauge — only ever needed the Stripe route; the GitHub CI webhook was bundled in opportunistically as "the same class of bug" and turned out to need much deeper, unrelated schema work. Follow-up logged separately.

## Scope fence
`STRIPE_RAIL_LIVE_MODE`, `STRIPE_LIVE_DEPLOY_CONFIRM`, and `STRIPE_WEBHOOK_SECRET` are untouched — that live-money arming gate (`lib/payments/stripe-client.js` `assertKeyAllowed()`) remains chairman-only, armed separately.

## Test plan
- [x] `tests/integration/webhooks/webhook-routes-mounted.test.js` — 4/4 passing (new; boots the real server, proves Stripe mounting + raw-body ordering, confirms github-ci-status remains unmounted)
- [x] `tests/integration/payments/webhook-capture.test.js` — 11/11 passing (pre-existing, unmodified)
- [x] `tests/unit/gates/wire-check-gate.test.js` — 35/35 passing
- [x] `node scripts/lint/schema-reference-lint.mjs --diff` — 0 violations
- [x] Manually verified live via PowerShell: GET returns 405 (not 404); a validly-signed Stripe event returns 200 and lands in `ops_payment_events`; an invalid signature returns 400 with no row written
- [x] Three rounds of deep-tier adversarial review, final round clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
