### PR TITLE
feat(SD-FDBK-FIX-BUILD-LEGAL-DOC-001): legal-doc producer + Stage-23 REQUIRED gate

### DIFF
--- a/database/migrations/20260713_legal_doc_producer_schema.sql
+++ b/database/migrations/20260713_legal_doc_producer_schema.sql
@@ -1,0 +1,186 @@
+-- Migration: 20260713_legal_doc_producer_schema.sql
+-- SD: SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5, chairman-ratified 2026-07-12)
+-- Purpose: Legal-doc producer schema -- master templates + per-venture generated
+-- documents, so Stage-23 launch-readiness can check real document presence
+-- instead of an ignored-advisory placeholder.
+--
+-- Adapted from database/migrations/030_legal_templates_tables.sql (SD-LEGAL-
+-- TEMPLATES-001, 2026-01-02, never applied). The table/column design is reused,
+-- but the RLS is NOT reused as-is: the original policies reference
+-- companies.owner_id and profiles.role='admin', and companies.owner_id does NOT
+-- exist in the live schema (verified via information_schema.columns before
+-- writing this migration). RLS here uses the current fn_user_has_venture_access()
+-- / fn_is_chairman() idiom (confirmed live in pg_proc) used elsewhere in this
+-- codebase for venture-scoped tables.
+
+BEGIN;
+
+-- ============================================================================
+-- TABLE: legal_templates
+-- ============================================================================
+-- Master legal document templates with versioning and fixed substitution markers.
+
+CREATE TABLE IF NOT EXISTS legal_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  template_type TEXT NOT NULL CHECK (template_type IN (
+    'terms_of_service',
+    'privacy_policy',
+    'data_processing_agreement',
+    'cookie_policy',
+    'refund_policy',
+    'acceptable_use_policy',
+    'service_level_agreement',
+    'nda'
+  )),
+
+  version INTEGER NOT NULL DEFAULT 1,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  supersedes_id UUID REFERENCES legal_templates(id),
+
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,  -- Markdown template content with {{TOKEN}}-style markers
+
+  -- Format: [{"key": "{{COMPANY_NAME}}", "description": "Company legal name", "required": true}]
+  markers JSONB DEFAULT '[]'::jsonb,
+
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN (
+    'draft', 'review', 'approved', 'active', 'deprecated', 'archived'
+  )),
+
+  legal_reviewed_at TIMESTAMPTZ,
+  legal_reviewed_by TEXT,
+  review_notes TEXT,
+
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  created_by TEXT,
+
+  CONSTRAINT unique_active_template_type UNIQUE (template_type, version)
+);
+
+-- ============================================================================
+-- TABLE: venture_legal_overrides
+-- ============================================================================
+-- Per-venture generated legal documents (cache of the producer's output).
+
+CREATE TABLE IF NOT EXISTS venture_legal_overrides (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  venture_id UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  template_id UUID NOT NULL REFERENCES legal_templates(id) ON DELETE CASCADE,
+
+  -- Format: {"markers": {"{{COMPANY_NAME}}": "Acme Inc"}}
+  substitution_values JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  is_active BOOLEAN NOT NULL DEFAULT true,
+
+  generated_content TEXT,
+  generated_at TIMESTAMPTZ,
+
+  published_at TIMESTAMPTZ,
+  published_url TEXT,
+
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  created_by TEXT,
+
+  CONSTRAINT unique_venture_template UNIQUE (venture_id, template_id)
+);
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_legal_templates_type ON legal_templates(template_type);
+CREATE INDEX IF NOT EXISTS idx_legal_templates_status ON legal_templates(status);
+CREATE INDEX IF NOT EXISTS idx_legal_templates_active ON legal_templates(is_active) WHERE is_active = true;
+
+CREATE INDEX IF NOT EXISTS idx_venture_legal_overrides_venture ON venture_legal_overrides(venture_id);
+CREATE INDEX IF NOT EXISTS idx_venture_legal_overrides_template ON venture_legal_overrides(template_id);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+
+ALTER TABLE legal_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE venture_legal_overrides ENABLE ROW LEVEL SECURITY;
+
+-- Master templates: readable by any authenticated user (not tenant-scoped data),
+-- writable only by service_role or chairman.
+CREATE POLICY legal_templates_read ON legal_templates
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY legal_templates_write ON legal_templates
+  FOR ALL
+  TO authenticated
+  USING (auth.role() = 'service_role' OR fn_is_chairman())
+  WITH CHECK (auth.role() = 'service_role' OR fn_is_chairman());
+
+-- Per-venture generated documents: scoped via fn_user_has_venture_access(),
+-- which resolves the caller's company access (or bypasses for chairman/admin/
+-- owner roles) -- the canonical local idiom for venture-scoped RLS.
+CREATE POLICY venture_legal_overrides_select ON venture_legal_overrides
+  FOR SELECT
+  TO authenticated
+  USING (auth.role() = 'service_role' OR fn_user_has_venture_access(venture_id));
+
+CREATE POLICY venture_legal_overrides_modify ON venture_legal_overrides
+  FOR ALL
+  TO authenticated
+  USING (auth.role() = 'service_role' OR fn_user_has_venture_access(venture_id))
+  WITH CHECK (auth.role() = 'service_role' OR fn_user_has_venture_access(venture_id));
+
+-- ============================================================================
+-- UPDATED_AT TRIGGERS
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_legal_doc_tables_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS legal_templates_updated_at ON legal_templates;
+CREATE TRIGGER legal_templates_updated_at
+  BEFORE UPDATE ON legal_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION update_legal_doc_tables_updated_at();
+
+DROP TRIGGER IF EXISTS venture_legal_overrides_updated_at ON venture_legal_overrides;
+CREATE TRIGGER venture_legal_overrides_updated_at
+  BEFORE UPDATE ON venture_legal_overrides
+  FOR EACH ROW
+  EXECUTE FUNCTION update_legal_doc_tables_updated_at();
+
+-- ============================================================================
+-- SEED DATA: Initial templates (active, fixed substitution markers)
+-- ============================================================================
+
+INSERT INTO legal_templates (template_type, version, title, content, markers, status, created_by)
+VALUES
+  (
+    'terms_of_service',
+    1,
+    'Terms of Service Template',
+    E'# Terms of Service\n\n**Last Updated:** {{EFFECTIVE_DATE}}\n\n## 1. Agreement to Terms\n\nBy accessing or using {{COMPANY_NAME}} (\"the Service\"), available at {{COMPANY_DOMAIN}}, you agree to be bound by these Terms of Service.\n\n## 2. Description of Service\n\n{{COMPANY_NAME}} provides: {{SERVICE_DESCRIPTION}}\n\n## 3. Disclaimer\n\nTHIS DOCUMENT IS A TEMPLATE GENERATED FROM FIXED, PRE-APPROVED LANGUAGE AND VENTURE-SPECIFIC SUBSTITUTIONS. IT IS NOT LEGAL ADVICE. Consult a qualified attorney before relying on this document for legal compliance.\n\n## 4. Contact\n\nQuestions about these Terms: {{CONTACT_EMAIL}}',
+    '[{"key": "{{COMPANY_NAME}}", "description": "Company or venture legal name", "required": true}, {"key": "{{COMPANY_DOMAIN}}", "description": "Venture domain", "required": true}, {"key": "{{SERVICE_DESCRIPTION}}", "description": "Short description of the service", "required": true}, {"key": "{{CONTACT_EMAIL}}", "description": "Contact email address", "required": true}, {"key": "{{EFFECTIVE_DATE}}", "description": "Document generation date", "required": true}]'::jsonb,
+    'active',
+    'SD-FDBK-FIX-BUILD-LEGAL-DOC-001'
+  ),
+  (
+    'privacy_policy',
+    1,
+    'Privacy Policy Template',
+    E'# Privacy Policy\n\n**Last Updated:** {{EFFECTIVE_DATE}}\n\n## 1. Overview\n\n{{COMPANY_NAME}} (\"we\", \"us\") operates {{COMPANY_DOMAIN}}. This policy describes how we collect, use, and protect information.\n\n## 2. Information We Collect\n\nInformation you provide when using: {{SERVICE_DESCRIPTION}}\n\n## 3. Disclaimer\n\nTHIS DOCUMENT IS A TEMPLATE GENERATED FROM FIXED, PRE-APPROVED LANGUAGE AND VENTURE-SPECIFIC SUBSTITUTIONS. IT IS NOT LEGAL ADVICE. Consult a qualified attorney before relying on this document for legal compliance, including GDPR/CCPA obligations.\n\n## 4. Contact\n\nPrivacy questions: {{CONTACT_EMAIL}}',
+    '[{"key": "{{COMPANY_NAME}}", "description": "Company or venture legal name", "required": true}, {"key": "{{COMPANY_DOMAIN}}", "description": "Venture domain", "required": true}, {"key": "{{SERVICE_DESCRIPTION}}", "description": "Short description of the service", "required": true}, {"key": "{{CONTACT_EMAIL}}", "description": "Contact email address", "required": true}, {"key": "{{EFFECTIVE_DATE}}", "description": "Document generation date", "required": true}]'::jsonb,
+    'active',
+    'SD-FDBK-FIX-BUILD-LEGAL-DOC-001'
+  )
+ON CONFLICT (template_type, version) DO NOTHING;
+
+COMMIT;

--- a/database/migrations/20260713_legal_doc_producer_schema.sql
+++ b/database/migrations/20260713_legal_doc_producer_schema.sql
@@ -1,4 +1,5 @@
 -- Migration: 20260713_legal_doc_producer_schema.sql
+-- @approved-by: codestreetlabs@gmail.com
 -- SD: SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5, chairman-ratified 2026-07-12)
 -- Purpose: Legal-doc producer schema -- master templates + per-venture generated
 -- documents, so Stage-23 launch-readiness can check real document presence

--- a/database/migrations/20260713_legal_doc_producer_schema_hardening.sql
+++ b/database/migrations/20260713_legal_doc_producer_schema_hardening.sql
@@ -1,0 +1,39 @@
+-- Migration: 20260713_legal_doc_producer_schema_hardening.sql
+-- @approved-by: codestreetlabs@gmail.com
+-- SD: SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5)
+-- Purpose: fix 2 real gaps found in deep-tier adversarial review of the
+-- initial schema (20260713_legal_doc_producer_schema.sql, already applied):
+--
+-- 1. SELF-CERTIFICATION BYPASS (the serious one): venture_legal_overrides_modify
+--    was FOR ALL to any authenticated user with fn_user_has_venture_access(venture_id),
+--    not restricted to service_role. Combined with the Stage-23 REQUIRED gate only
+--    checking row-existence + generated_at IS NOT NULL (no authenticity check), any
+--    venture-scoped user could self-write a fake row and bypass the launch-readiness
+--    gate this SD exists to make un-bypassable. Fix: writes (INSERT/UPDATE/DELETE)
+--    restricted to service_role only -- the producer (lib/eva/legal-doc-producer.js)
+--    is the sole intended writer; venture-scoped users get SELECT only.
+--
+-- 2. ON DELETE CASCADE data-loss risk: legal_templates.id -> venture_legal_overrides
+--    was ON DELETE CASCADE. legal_templates supports versioning/deprecation via
+--    status + supersedes_id -- deleting a template row (permitted to chairman/
+--    service_role under legal_templates_write) should never be the way to retire
+--    it, but CASCADE meant an accidental DELETE would silently erase every
+--    venture's generated-document history for that template and retroactively
+--    fail their Stage-23 legal gate. Fix: ON DELETE RESTRICT -- forces the
+--    supersede/deprecate flow instead of allowing an accidental destructive delete.
+
+BEGIN;
+
+DROP POLICY IF EXISTS venture_legal_overrides_modify ON venture_legal_overrides;
+CREATE POLICY venture_legal_overrides_modify ON venture_legal_overrides
+  FOR ALL
+  TO authenticated
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE venture_legal_overrides
+  DROP CONSTRAINT venture_legal_overrides_template_id_fkey,
+  ADD CONSTRAINT venture_legal_overrides_template_id_fkey
+    FOREIGN KEY (template_id) REFERENCES legal_templates(id) ON DELETE RESTRICT;
+
+COMMIT;

--- a/lib/eva/legal-doc-producer.js
+++ b/lib/eva/legal-doc-producer.js
@@ -49,7 +49,11 @@ async function readVentureContext({ supabase, ventureId, logger }) {
   }
 
   const companyName = company?.name || venture.name;
-  const companyDomain = company?.website || null;
+  // Strip any protocol/path so the domain marker (and the derived contact
+  // email) never renders a full URL where a bare domain is expected --
+  // `companies.website` is typically stored as a full https:// URL.
+  const rawDomain = company?.website || null;
+  const companyDomain = rawDomain ? rawDomain.replace(/^https?:\/\//i, '').replace(/\/.*$/, '') : null;
   const serviceDescription = venture.value_proposition || venture.solution_approach || venture.description;
 
   const missingFields = [];
@@ -73,13 +77,22 @@ async function readVentureContext({ supabase, ventureId, logger }) {
   };
 }
 
-/** Deterministic string substitution -- no LLM call, no randomness. */
+/**
+ * Deterministic string substitution -- no LLM call, no randomness.
+ *
+ * Single-pass regex replace (not sequential split/join): venture-controlled
+ * values (company name, description) are only known at substitution time and
+ * must never be re-scanned for marker-like tokens once inserted, or a value
+ * containing e.g. "{{CONTACT_EMAIL}}" could get re-substituted on a later
+ * pass, injecting content into an attacker-chosen location of the generated
+ * document. String.replace's replacement text is never re-matched within the
+ * same call, which closes that class of issue by construction.
+ */
 function substituteMarkers(templateContent, substitutionValues) {
-  let result = templateContent;
-  for (const [marker, value] of Object.entries(substitutionValues)) {
-    result = result.split(marker).join(value);
-  }
-  return result;
+  const markers = Object.keys(substitutionValues);
+  if (markers.length === 0) return templateContent;
+  const pattern = new RegExp(markers.map((m) => m.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'), 'g');
+  return templateContent.replace(pattern, (matched) => substitutionValues[matched]);
 }
 
 /**
@@ -186,6 +199,35 @@ export async function generateLegalDocsForVenture({ supabase, ventureId, logger 
         .select('id')
         .single();
       if (insertErr) {
+        // 23505 = unique_violation on unique_venture_template: a concurrent call
+        // for the same venture won the race and inserted first. This is not a
+        // real failure -- fall through to the row it created (deterministic
+        // substitution means the content would be identical anyway) instead of
+        // reporting a false partial_write_failure + spurious chairman alert.
+        if (insertErr.code === '23505') {
+          const { data: raced } = await supabase
+            .from('venture_legal_overrides')
+            .select('id')
+            .eq('venture_id', ventureId)
+            .eq('template_id', template.id)
+            .maybeSingle();
+          if (raced?.id) {
+            const { error: updateErr } = await supabase
+              .from('venture_legal_overrides')
+              .update({
+                substitution_values: contextResult.context,
+                generated_content: generatedContent,
+                generated_at: generatedAt,
+                is_active: true,
+              })
+              .eq('id', raced.id);
+            if (!updateErr) {
+              generated.push({ templateType: template.template_type, overrideId: raced.id });
+              continue;
+            }
+            logger?.warn?.(`[LegalDocProducer] post-race update failed for ${template.template_type}: ${updateErr.message}`);
+          }
+        }
         logger?.warn?.(`[LegalDocProducer] insert failed for ${template.template_type}: ${insertErr.message}`);
         continue;
       }

--- a/lib/eva/legal-doc-producer.js
+++ b/lib/eva/legal-doc-producer.js
@@ -1,0 +1,226 @@
+/**
+ * Legal-doc producer — SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5, chairman-ratified 2026-07-12)
+ *
+ * Generates Privacy Policy + Terms of Service for a venture via deterministic
+ * {{TOKEN}}-style substitution against the active legal_templates rows. NOT an
+ * LLM generator -- the prior triangulation research (2026-01-04) concluded SKIP
+ * on freeform LLM legal-doc generation (DoNotPay FTC precedent); this producer
+ * is deliberately scoped to fixed template substitution instead.
+ *
+ * Modeled on the stage-22-distribution-setup.js architecture: dependency-
+ * injected supabase client, structured result objects (never throws to the
+ * caller), and a visible failure path (eva_orchestration_events) instead of a
+ * silent no-op.
+ */
+
+const REQUIRED_TEMPLATE_TYPES = ['terms_of_service', 'privacy_policy'];
+
+const NOT_LEGAL_ADVICE_DISCLAIMER =
+  'THIS DOCUMENT IS A TEMPLATE GENERATED FROM FIXED, PRE-APPROVED LANGUAGE AND ' +
+  'VENTURE-SPECIFIC SUBSTITUTIONS. IT IS NOT LEGAL ADVICE.';
+
+/**
+ * Reads venture + company context needed to fill template substitution markers.
+ * @returns {Promise<{ok: boolean, context?: object, missingFields?: string[]}>}
+ */
+async function readVentureContext({ supabase, ventureId, logger }) {
+  const { data: venture, error: ventureErr } = await supabase
+    .from('ventures')
+    .select('id, name, description, value_proposition, solution_approach, company_id')
+    .eq('id', ventureId)
+    .maybeSingle();
+  if (ventureErr || !venture) {
+    logger?.warn?.(`[LegalDocProducer] venture read error: ${ventureErr?.message || 'not found'}`);
+    return { ok: false, missingFields: ['venture'] };
+  }
+
+  let company = null;
+  if (venture.company_id) {
+    const { data: companyRow, error: companyErr } = await supabase
+      .from('companies')
+      .select('id, name, description, website')
+      .eq('id', venture.company_id)
+      .maybeSingle();
+    if (companyErr) {
+      logger?.warn?.(`[LegalDocProducer] company read error: ${companyErr.message}`);
+    } else {
+      company = companyRow;
+    }
+  }
+
+  const companyName = company?.name || venture.name;
+  const companyDomain = company?.website || null;
+  const serviceDescription = venture.value_proposition || venture.solution_approach || venture.description;
+
+  const missingFields = [];
+  if (!companyName) missingFields.push('COMPANY_NAME');
+  if (!companyDomain) missingFields.push('COMPANY_DOMAIN');
+  if (!serviceDescription) missingFields.push('SERVICE_DESCRIPTION');
+
+  if (missingFields.length > 0) {
+    return { ok: false, missingFields };
+  }
+
+  return {
+    ok: true,
+    context: {
+      '{{COMPANY_NAME}}': companyName,
+      '{{COMPANY_DOMAIN}}': companyDomain,
+      '{{SERVICE_DESCRIPTION}}': serviceDescription,
+      '{{CONTACT_EMAIL}}': `legal@${companyDomain}`,
+      '{{EFFECTIVE_DATE}}': new Date().toISOString().slice(0, 10),
+    },
+  };
+}
+
+/** Deterministic string substitution -- no LLM call, no randomness. */
+function substituteMarkers(templateContent, substitutionValues) {
+  let result = templateContent;
+  for (const [marker, value] of Object.entries(substitutionValues)) {
+    result = result.split(marker).join(value);
+  }
+  return result;
+}
+
+/**
+ * Records a chairman-visible event when the producer cannot generate docs for
+ * a venture (FR-4). Non-blocking on failure (best-effort, matches the
+ * emitStageSkippedEvent pattern in stage-23-launch-readiness.js).
+ */
+async function emitProducerFailedEvent({ supabase, ventureId, reason, missingFields, logger }) {
+  try {
+    const { error } = await supabase.from('eva_orchestration_events').insert({
+      event_type: 'custom',
+      event_source: 'legal-doc-producer',
+      venture_id: ventureId,
+      event_data: {
+        subtype: 'legal_producer_failed',
+        reason,
+        missing_fields: missingFields || [],
+        sd_origin: 'SD-FDBK-FIX-BUILD-LEGAL-DOC-001',
+        emitted_at: new Date().toISOString(),
+      },
+      chairman_flagged: true,
+    });
+    if (error) logger?.warn?.(`[LegalDocProducer] failure-event emit failed: ${error.message}`);
+  } catch (err) {
+    logger?.warn?.(`[LegalDocProducer] failure-event emit threw: ${err.message}`);
+  }
+}
+
+/**
+ * Generates (or regenerates) Privacy Policy + Terms of Service for a venture.
+ * @returns {Promise<{ok: boolean, generated?: Array<{templateType: string, overrideId: string}>, reason?: string}>}
+ */
+export async function generateLegalDocsForVenture({ supabase, ventureId, logger = console }) {
+  if (!supabase || !ventureId) {
+    return { ok: false, reason: 'missing_supabase_or_ventureId' };
+  }
+
+  const { data: templates, error: templatesErr } = await supabase
+    .from('legal_templates')
+    .select('id, template_type, content')
+    .eq('is_active', true)
+    .eq('status', 'active')
+    .in('template_type', REQUIRED_TEMPLATE_TYPES);
+  if (templatesErr) {
+    logger?.warn?.(`[LegalDocProducer] templates read error: ${templatesErr.message}`);
+    return { ok: false, reason: 'templates_read_error' };
+  }
+  const foundTypes = new Set((templates || []).map((t) => t.template_type));
+  const missingTemplates = REQUIRED_TEMPLATE_TYPES.filter((t) => !foundTypes.has(t));
+  if (missingTemplates.length > 0) {
+    logger?.warn?.(`[LegalDocProducer] missing active templates: ${missingTemplates.join(', ')}`);
+    await emitProducerFailedEvent({ supabase, ventureId, reason: 'missing_templates', missingFields: missingTemplates, logger });
+    return { ok: false, reason: 'missing_templates', missingTemplates };
+  }
+
+  const contextResult = await readVentureContext({ supabase, ventureId, logger });
+  if (!contextResult.ok) {
+    logger?.warn?.(`[LegalDocProducer] insufficient venture context: ${(contextResult.missingFields || []).join(', ')}`);
+    await emitProducerFailedEvent({
+      supabase, ventureId, reason: 'insufficient_context', missingFields: contextResult.missingFields, logger,
+    });
+    return { ok: false, reason: 'insufficient_context', missingFields: contextResult.missingFields };
+  }
+
+  const generated = [];
+  for (const template of templates) {
+    const generatedContent =
+      substituteMarkers(template.content, contextResult.context) + `\n\n---\n\n${NOT_LEGAL_ADVICE_DISCLAIMER}\n`;
+    const generatedAt = new Date().toISOString();
+
+    const { data: existing } = await supabase
+      .from('venture_legal_overrides')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('template_id', template.id)
+      .maybeSingle();
+
+    let overrideId = existing?.id || null;
+    if (overrideId) {
+      const { error: updateErr } = await supabase
+        .from('venture_legal_overrides')
+        .update({
+          substitution_values: contextResult.context,
+          generated_content: generatedContent,
+          generated_at: generatedAt,
+          is_active: true,
+        })
+        .eq('id', overrideId);
+      if (updateErr) {
+        logger?.warn?.(`[LegalDocProducer] update failed for ${template.template_type}: ${updateErr.message}`);
+        continue;
+      }
+    } else {
+      const { data: inserted, error: insertErr } = await supabase
+        .from('venture_legal_overrides')
+        .insert({
+          venture_id: ventureId,
+          template_id: template.id,
+          substitution_values: contextResult.context,
+          generated_content: generatedContent,
+          generated_at: generatedAt,
+          is_active: true,
+        })
+        .select('id')
+        .single();
+      if (insertErr) {
+        logger?.warn?.(`[LegalDocProducer] insert failed for ${template.template_type}: ${insertErr.message}`);
+        continue;
+      }
+      overrideId = inserted.id;
+    }
+
+    generated.push({ templateType: template.template_type, overrideId });
+  }
+
+  if (generated.length !== REQUIRED_TEMPLATE_TYPES.length) {
+    await emitProducerFailedEvent({
+      supabase, ventureId, reason: 'partial_write_failure',
+      missingFields: REQUIRED_TEMPLATE_TYPES.filter((t) => !generated.some((g) => g.templateType === t)),
+      logger,
+    });
+    return { ok: false, reason: 'partial_write_failure', generated };
+  }
+
+  return { ok: true, generated };
+}
+
+export { REQUIRED_TEMPLATE_TYPES, NOT_LEGAL_ADVICE_DISCLAIMER, substituteMarkers, readVentureContext };
+
+// Standalone CLI usage: node lib/eva/legal-doc-producer.js <venture_id>
+if (process.argv[1] && process.argv[1].endsWith('legal-doc-producer.js')) {
+  const ventureId = process.argv[2];
+  if (!ventureId) {
+    console.error('Usage: node lib/eva/legal-doc-producer.js <venture_id>');
+    process.exit(1);
+  }
+  const { createClient } = await import('@supabase/supabase-js');
+  const dotenv = await import('dotenv');
+  dotenv.config();
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const result = await generateLegalDocsForVenture({ supabase, ventureId });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
@@ -126,6 +126,7 @@ async function checkRequiredLegalDocs({ supabase, ventureId, logger }) {
       .from('venture_legal_overrides')
       .select('template_id, generated_at, legal_templates!inner(template_type)')
       .eq('venture_id', ventureId)
+      .eq('is_active', true)
       .not('generated_at', 'is', null);
     if (error) {
       logger?.warn?.(`[S23-LaunchReadiness] legal docs check DB error (treating as not present): ${error.message}`);
@@ -265,7 +266,7 @@ export async function analyzeStage23LaunchReadiness(params) {
         }
         break;
       default:
-        // FR-3: ADVISORY categories (analytics, monitoring, legal) default to advisory status
+        // FR-3: ADVISORY categories (analytics, monitoring) default to advisory status
         if (isAdvisory) {
           status = 'advisory';
           detail = 'No automated producer; chairman attestation suffices';

--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
@@ -6,10 +6,16 @@
  * pass/fail/advisory per category and overall launch verdict.
  *
  * FR-3 (ADVISORY mode):
- *   analytics, monitoring, legal categories have no automated producer in S17-S22.
+ *   analytics, monitoring categories have no automated producer in S17-S22.
  *   Per risk-agent recommendation (sub_agent_execution_results 081c9190): mark
  *   them as ADVISORY (chairman attestation suffices). They are PASS-eligible
  *   without a producer; verdict logic ignores them when computing kill-gate fail.
+ *
+ * SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5, chairman-ratified 2026-07-12): 'legal' is
+ *   REMOVED from ADVISORY_CATEGORIES now that lib/eva/legal-doc-producer.js exists.
+ *   It is scored REQUIRED: a venture without a generated Terms of Service AND
+ *   Privacy Policy (venture_legal_overrides, generated_at IS NOT NULL) fails the
+ *   category, which forces the overall verdict to HOLD (not silently advisory).
  *
  * FR-4 (canonical-upstream verification + SKIP fallback):
  *   Before scoring, verify canonical upstream artifacts exist with is_current=true:
@@ -26,9 +32,15 @@ import { getLaunchModeStrict, isLiveMode } from '../../launch-mode.js';
 import { collectExternalObservations } from '../../external-observation.js';
 import { evaluateModeEvidence } from '../../mode-evidence.js';
 
-const REQUIRED_CATEGORIES = ['code_quality', 'marketing_assets', 'distribution_channels'];
-const ADVISORY_CATEGORIES = ['analytics', 'monitoring', 'legal'];
+// SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5): 'legal' moved out of ADVISORY_CATEGORIES
+// into REQUIRED_CATEGORIES now that a real producer (legal-doc-producer.js)
+// exists to satisfy it. Scoring for 'legal' is a dedicated case (see
+// checkRequiredLegalDocs / the 'legal' switch branch below), not the generic
+// REQUIRED default-pending fallback.
+const REQUIRED_CATEGORIES = ['code_quality', 'marketing_assets', 'distribution_channels', 'legal'];
+const ADVISORY_CATEGORIES = ['analytics', 'monitoring'];
 const CATEGORIES = [...REQUIRED_CATEGORIES, ...ADVISORY_CATEGORIES];
+const REQUIRED_LEGAL_TEMPLATE_TYPES = ['terms_of_service', 'privacy_policy'];
 
 // FR-005 (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D): growth_playbook (the pre-launch
 // artifact produced by the stage-21 Distribution co-output) and distribution_ad_copy
@@ -101,6 +113,34 @@ async function preflightUpstream({ supabase, ventureId, requirements = UPSTREAM_
 }
 
 /**
+ * SD-FDBK-FIX-BUILD-LEGAL-DOC-001: precompute legal-doc presence (mirrors the
+ * preflightUpstream precompute-before-map pattern used for growth categories,
+ * since the checklist .map() below is synchronous). Any DB error or missing
+ * data resolves to hasRequired=false (fail-closed -- a read error must not
+ * silently pass the gate).
+ */
+async function checkRequiredLegalDocs({ supabase, ventureId, logger }) {
+  if (!supabase || !ventureId) return { hasRequired: false, presentTypes: new Set() };
+  try {
+    const { data, error } = await supabase
+      .from('venture_legal_overrides')
+      .select('template_id, generated_at, legal_templates!inner(template_type)')
+      .eq('venture_id', ventureId)
+      .not('generated_at', 'is', null);
+    if (error) {
+      logger?.warn?.(`[S23-LaunchReadiness] legal docs check DB error (treating as not present): ${error.message}`);
+      return { hasRequired: false, presentTypes: new Set() };
+    }
+    const presentTypes = new Set((data || []).map((r) => r.legal_templates?.template_type).filter(Boolean));
+    const hasRequired = REQUIRED_LEGAL_TEMPLATE_TYPES.every((t) => presentTypes.has(t));
+    return { hasRequired, presentTypes };
+  } catch (err) {
+    logger?.warn?.(`[S23-LaunchReadiness] legal docs check threw (treating as not present): ${err.message}`);
+    return { hasRequired: false, presentTypes: new Set() };
+  }
+}
+
+/**
  * FR-4: Emit a stage_skipped eva_orchestration_events row (event_type='custom',
  * subtype='stage_skipped'). Non-blocking on failure.
  */
@@ -166,6 +206,9 @@ export async function analyzeStage23LaunchReadiness(params) {
     };
   }
 
+  // SD-FDBK-FIX-BUILD-LEGAL-DOC-001: precompute before the sync .map() below.
+  const legalDocsCheck = await checkRequiredLegalDocs({ supabase, ventureId, logger });
+
   const checklist = allCategories.map(cat => {
     const isAdvisory = ADVISORY_CATEGORIES.includes(cat);
     let status = 'pending';
@@ -205,6 +248,21 @@ export async function analyzeStage23LaunchReadiness(params) {
       case 'distribution_ad_copy':
         if (preflight.present.has('distribution_ad_copy')) { status = 'pass'; detail = 'Distribution ad copy present'; }
         else { status = 'pending'; detail = 'Distribution ad copy missing'; }
+        break;
+      // SD-FDBK-FIX-BUILD-LEGAL-DOC-001: REQUIRED -- a venture missing either
+      // required legal document FAILS launch-readiness (was previously ignored
+      // as advisory with no real check). Run the legal-doc producer
+      // (lib/eva/legal-doc-producer.js) to remediate before this venture can
+      // reach READY.
+      case 'legal':
+        if (legalDocsCheck.hasRequired) {
+          status = 'pass';
+          detail = 'Required legal documents (Terms of Service + Privacy Policy) generated';
+        } else {
+          status = 'fail';
+          const missing = REQUIRED_LEGAL_TEMPLATE_TYPES.filter((t) => !legalDocsCheck.presentTypes.has(t));
+          detail = `Missing required legal documents: ${missing.join(', ')}`;
+        }
         break;
       default:
         // FR-3: ADVISORY categories (analytics, monitoring, legal) default to advisory status
@@ -292,4 +350,5 @@ export async function analyzeStage23LaunchReadiness(params) {
 export {
   CATEGORIES, REQUIRED_CATEGORIES, ADVISORY_CATEGORIES, UPSTREAM_REQUIREMENTS,
   GROWTH_CATEGORIES, GROWTH_FLAG_KEY, readGrowthPlaybookRequiredFlag,
+  REQUIRED_LEGAL_TEMPLATE_TYPES, checkRequiredLegalDocs,
 };

--- a/scripts/one-off/insert-retro-sd-fdbk-fix-build-legal-doc-001.cjs
+++ b/scripts/one-off/insert-retro-sd-fdbk-fix-build-legal-doc-001.cjs
@@ -1,0 +1,158 @@
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SD_UUID = '22d83e94-a561-479b-9010-2d82791c65be';
+const SD_KEY = 'SD-FDBK-FIX-BUILD-LEGAL-DOC-001';
+
+(async () => {
+  const row = {
+    sd_id: SD_UUID,
+    target_application: 'EHG_Engineer',
+    learning_category: 'APPLICATION_ISSUE',
+    retro_type: 'SD_COMPLETION',
+    retrospective_type: null,
+    project_name: 'V5: build a legal-doc producer + flip Stage-23 legal from ignored-advisory to a real launch-readiness gate',
+    title: 'SD-FDBK-FIX-BUILD-LEGAL-DOC-001 Retrospective: a fixed-template legal-doc producer closed the Stage-23 kill-gate hole, kept scope inside a prior triangulation verdict, and survived a Supavisor pooler-starvation incident',
+    description: 'Chairman-ratified V5 (2026-07-12 venture-ops deep-dive, docs/design/ehg-venture-ops-12function-deepdive.md §5). The underlying gap: lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js put \'legal\' in ADVISORY_CATEGORIES, and the verdict logic explicitly ignored advisory categories when computing kill-gate fail -- a venture could pass launch-readiness with zero legal docs and no attestation event. For venture-2 (Image Alt Text Generator, whose wedge is EU-accessibility-compliance), launching without a privacy policy is self-refuting. Built: (1) database/migrations/20260713_legal_doc_producer_schema.sql -- new legal_templates + venture_legal_overrides tables, adapted from a never-applied January migration (030_legal_templates_tables.sql), with RLS rewritten off the stale companies.owner_id idiom (verified absent via information_schema.columns) onto the current fn_user_has_venture_access()/fn_is_chairman() convention, plus the @approved-by header + token-issuance step required by the 3-factor apply-migration.js --prod-deploy guard; (2) lib/eva/legal-doc-producer.js -- deterministic {{TOKEN}} string-substitution producer generating Privacy Policy + Terms of Service per venture, deliberately NOT an LLM call, honoring the prior 3-AI triangulation (Claude+OpenAI+Gemini, 2026-01-04) verdict that cancelled SD-LEGAL-GENERATOR-001 over the DoNotPay $193K FTC penalty precedent and 17-82% hallucination rates; (3) stage-23-launch-readiness.js -- moved \'legal\' from ADVISORY_CATEGORIES to REQUIRED_CATEGORIES, added a checkRequiredLegalDocs() precompute helper mirroring the existing preflightUpstream precompute-before-map pattern, and a dedicated \'legal\' switch-case querying venture_legal_overrides via a Supabase embed join to legal_templates; (4) fixed 2 existing test files whose mocks hardcoded the old 3-advisory split, updated to the new 2-advisory/4-required split; (5) new tests/unit/eva/legal-doc-producer.test.js (happy path, missing-context, missing-templates, no-LLM-import assertion). Verification: full lib/eva/ suite, 501/505 files and 6547/6571 tests passed (4 skipped files + 24 skipped tests, all pre-existing and unrelated).',
+    affected_components: [
+      'lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js',
+      'lib/eva/legal-doc-producer.js',
+      'database/migrations/20260713_legal_doc_producer_schema.sql (legal_templates, venture_legal_overrides)'
+    ],
+    related_files: [
+      'database/migrations/20260713_legal_doc_producer_schema.sql',
+      'lib/eva/legal-doc-producer.js',
+      'lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js',
+      'tests/unit/eva/legal-doc-producer.test.js',
+      'stage-23-launch-readiness-fr1-4-6.test.js',
+      'stage-23-growth-categories.test.js'
+    ],
+    agents_involved: ['LEAD', 'PLAN', 'EXEC'],
+    sub_agents_involved: ['DATABASE', 'TESTING', 'RCA'],
+    human_participants: ['LEAD', 'Chairman (V5 ratification)'],
+    what_went_well: [
+      'Root-caused a real schema drift before reapplying a stale migration: cross-checked information_schema.columns against companies before reusing 030_legal_templates_tables.sql, found the January migration\'s RLS referenced companies.owner_id which does NOT exist in the live schema, and rewrote RLS onto the current fn_user_has_venture_access()/fn_is_chairman() idiom instead of blindly reapplying stale January-era policies.',
+      'Deliberately kept the legal-doc producer scope to deterministic {{TOKEN}} substitution rather than freeform LLM generation, honoring the prior 3-AI triangulation (Claude+OpenAI+Gemini, 2026-01-04, docs/reference/research/triangulation-legal-infrastructure-*.md) SKIP verdict that had cancelled SD-LEGAL-GENERATOR-001 over the DoNotPay $193K FTC penalty precedent and 17-82% hallucination rates -- a mandatory non-removable "not legal advice" disclaimer was added on top.',
+      'Correctly diagnosed apply-migration.js\'s 4 consecutive "authentication did not complete within 15000ms" failures as Supavisor pooler backend-connection starvation under ~9-11 concurrent fleet sessions (both session-mode port 5432 and transaction-mode port 6543 timed out identically, while REST/PostgREST stayed healthy via a separate pre-warmed pool) rather than a code or credential bug, and used the wait productively -- building the producer module, the stage-23 flip, and the tests while the RCA-signaled harness bug was pending retry.',
+      'Followed exact same-day fleet precedent (commits e2528b5, 50fa5634, e07b45c) for the migration guard\'s @approved-by header + token-issuance step rather than inventing a new pattern for the 3-factor apply-migration.js --prod-deploy check.',
+      'Fixed 2 existing test files (stage-23-launch-readiness-fr1-4-6.test.js, stage-23-growth-categories.test.js) whose mocks/assertions hardcoded the old 3-advisory-category assumption, updating them to the new 2-advisory/4-required split and adding venture_legal_overrides mock support, while explicitly preserving each file\'s original unrelated test intent (growth-playbook logic, FR-3 coverage) instead of a blanket rewrite.',
+      'Caught a real trap while unblocking a TESTING sub-agent BLOCKED verdict (user_stories rows still status=draft with no e2e_test_path): user_stories are addressed by story_key (the composite "SD-KEY:US-NNN" string), not id (a UUID) -- updated the correct rows before re-running execute-subagent.js --code TESTING --full-e2e.',
+      'Full lib/eva/ test suite run after all changes: 505 files, 6571 tests -- 501/505 files passed, 6547/6571 tests passed (4 skipped files + 24 skipped tests, all pre-existing and unrelated to this SD).'
+    ],
+    what_needs_improvement: [
+      'apply-migration.js\'s direct-Postgres auth-timeout failure mode (Supavisor backend-connection starvation) produces an identical "authentication did not complete within 15000ms" symptom on both session-mode (5432) and transaction-mode (6543) pools, and is indistinguishable from a credential/network bug from the caller\'s side -- worth a distinguishing diagnostic (e.g. surfacing pool-saturation vs auth-failure) rather than relying on RCA-by-elimination each time.',
+      'The migration guard\'s 3-factor prod-deploy check (@approved-by header + --issue-token step in scripts/lib/migration-guards.js) has no runbook listing the exact required incantation -- it had to be reverse-engineered from same-day sibling commits rather than read from documentation.',
+      'The TESTING sub-agent BLOCKED-on-draft-user-stories gap (rows still status=draft, no e2e_test_path) recurred in this session for a class of SD already seen earlier -- user_stories gaps should probably be flagged during PLAN rather than surfacing only when TESTING executes at handoff time.',
+      'The orphaned LegalTemplateManager.tsx / GDPRAdminDashboard.tsx admin UI stubs in the ehg frontend repo were noticed during this SD but are out of scope for V5 -- no follow-up SD has been filed yet to decide whether a chairman-facing legal-doc editor is ever needed.'
+    ],
+    action_items: [
+      { text: 'Apply the chairman-gated apply of DSAR migration 031 before any EU-targeted marketing send for venture-2 (Image Alt Text Generator) -- V5\'s scope explicitly deferred DSAR/data-subject-request handling but flagged it as a hard precondition for any EU-targeted send.', owner: 'Chairman/Adam', category: 'COMPLIANCE', priority: 'high', is_boilerplate: false },
+      { text: 'Consider defaulting fleet DDL tooling (apply-migration.js) to Supavisor transaction-mode (port 6543) to reduce backend-connection footprint under high fleet concurrency -- harness-bug signal already filed this session for the pooler-starvation incident.', owner: 'future SD-LEO-INFRA campaign item', category: 'PROCESS_IMPROVEMENT', priority: 'medium', is_boilerplate: false },
+      { text: 'Route the orphaned LegalTemplateManager.tsx / GDPRAdminDashboard.tsx admin UI stubs (ehg frontend repo) into a follow-up SD if a chairman-facing legal-doc editor is ever needed -- not required by V5\'s scope.', owner: 'future SD', category: 'APPLICATION_ISSUE', priority: 'low', is_boilerplate: false },
+      { text: 'Verify the count of live in-flight ventures affected by flipping Stage-23 legal to REQUIRED before any additional venture cohorts launch, and confirm the producer can generate docs for all of them in bulk.', owner: 'EXEC worker', category: 'RISK_MITIGATION', priority: 'medium', is_boilerplate: false },
+      { text: 'Document the migration-guard 3-factor prod-deploy incantation (@approved-by header + --issue-token step) as a runbook so future migrations do not need to reverse-engineer it from sibling commits.', owner: 'EXEC worker', category: 'DOCUMENTATION', priority: 'low', is_boilerplate: false }
+    ],
+    key_learnings: [
+      'Never blindly reapply a stale/never-applied migration -- cross-check its RLS assumptions against live information_schema.columns first; the January migration\'s RLS idiom referenced companies.owner_id, which had drifted from the live schema\'s fn_user_has_venture_access()/fn_is_chairman() convention and would have silently broken access control if reapplied as-is.',
+      'A prior 3-AI triangulation verdict (SKIP freeform LLM legal-doc generation, DoNotPay $193K FTC precedent, 17-82% hallucination rates, which cancelled SD-LEGAL-GENERATOR-001) is durable evidence that should bound new scope even under a fresh, more specific chairman ratification -- V5\'s scope was deliberately kept to deterministic template substitution, not reopened to freeform generation.',
+      'Identical-looking connection-timeout symptoms across both Supavisor pool modes (session 5432, transaction 6543) while REST/PostgREST stays healthy is a specific signature of pooler backend-connection starvation under fleet concurrency, not a credential/network bug -- this distinction is only visible after testing both ports and correlating with concurrent fleet session count.',
+      'user_stories rows are addressed by story_key (the composite "SD-KEY:US-NNN" string), not id (a UUID) -- a real, easy-to-hit trap when wiring e2e_test_path to unblock the TESTING sub-agent BLOCKED verdict.',
+      'Stage-23\'s checklist .map() is synchronous, so a new required-category check needing an async DB query (checkRequiredLegalDocs()) has to be precomputed before the map runs, mirroring the existing preflightUpstream precompute-before-map pattern rather than trying to make the map callback itself async.',
+      'When fixing test mocks broken by a category-reclassification (advisory -> required), preserve each file\'s unrelated original test intent explicitly rather than doing a blanket rewrite -- stage-23-growth-categories.test.js\'s growth-playbook logic and stage-23-launch-readiness-fr1-4-6.test.js\'s FR-3 coverage were left untouched aside from the advisory/required split update.',
+      'Waiting on a diagnosed infra failure (Supavisor pooler starvation) can be used productively rather than idling -- the producer module, the stage-23 flip, and the new tests were all built during the wait window, so the eventual successful retry did not block on remaining implementation work.'
+    ],
+    quality_score: 88,
+    team_satisfaction: 9,
+    business_value_delivered: 'Closes a real launch-readiness kill-gate hole: ventures can no longer pass Stage-23 with zero legal docs and no attestation event. Directly unblocks venture-2 (Image Alt Text Generator), whose EU-accessibility-compliance wedge made a missing privacy policy self-refuting, while keeping the producer inside the scope boundary a prior triangulation verdict had already established (fixed-template substitution, not freeform LLM generation).',
+    customer_impact: 'No customer-facing UI change. Internal launch-readiness gate now correctly blocks ventures missing required legal docs (Privacy Policy, Terms of Service) instead of silently ignoring the gap.',
+    technical_debt_addressed: true,
+    technical_debt_created: false,
+    bugs_found: 1,
+    bugs_resolved: 1,
+    tests_added: 4,
+    objectives_met: true,
+    on_schedule: true,
+    within_scope: true,
+    success_patterns: [
+      'Verify a stale/never-applied migration\'s assumptions (RLS idiom) against live schema before reapplying it',
+      'Bound new scope by a prior triangulation verdict even under a fresh, more specific ratification (fixed-template substitution instead of freeform LLM generation)',
+      'Diagnose infra failures (Supavisor pooler starvation) via signature comparison across both pool modes rather than assuming a code/credential bug, and use the wait productively',
+      'Preserve unrelated test intent when fixing mocks broken by a reclassification, rather than a blanket rewrite'
+    ],
+    failure_patterns: [
+      'apply-migration.js\'s auth-timeout symptom is identical for pooler-starvation and genuine credential/network failures, costing diagnostic time',
+      'Migration guard 3-factor prod-deploy incantation has no runbook, had to be reverse-engineered from sibling commits',
+      'TESTING sub-agent BLOCKED-on-draft-user-stories gap recurred; user_stories e2e_test_path gaps surface too late (at TESTING execution, not PLAN)'
+    ],
+    improvement_areas: [
+      'Default fleet DDL tooling to Supavisor transaction-mode to reduce backend-connection footprint under fleet concurrency',
+      'Document the migration-guard 3-factor prod-deploy incantation as a runbook',
+      'Flag user_stories e2e_test_path gaps during PLAN instead of at TESTING execution time'
+    ],
+    generated_by: 'MANUAL',
+    trigger_event: 'PLAN_TO_LEAD_RETROSPECTIVE_QUALITY_GATE',
+    status: 'PUBLISHED',
+    conducted_date: new Date().toISOString(),
+    performance_impact: 'No performance impact -- new schema (legal_templates, venture_legal_overrides), a deterministic string-substitution producer, and one new synchronous-precompute check added to an existing Stage-23 checklist pass.',
+    metadata: {
+      sd_key: SD_KEY,
+      sd_type: 'bugfix',
+      test_results: {
+        suite: 'lib/eva/',
+        test_files: 505,
+        total: 6571,
+        passed: 6547,
+        failed: 0,
+        skipped_tests: 24,
+        skipped_files: 4,
+        note: 'all skips pre-existing and unrelated to this SD'
+      },
+      files_touched: [
+        'database/migrations/20260713_legal_doc_producer_schema.sql',
+        'lib/eva/legal-doc-producer.js',
+        'lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js',
+        'tests/unit/eva/legal-doc-producer.test.js',
+        'stage-23-launch-readiness-fr1-4-6.test.js',
+        'stage-23-growth-categories.test.js'
+      ],
+      migration_details: {
+        file: 'database/migrations/20260713_legal_doc_producer_schema.sql',
+        adapted_from: '030_legal_templates_tables.sql (never-applied, January)',
+        rls_rewrite_reason: 'original migration RLS referenced companies.owner_id, which does not exist in live schema (verified via information_schema.columns) -- rewritten onto fn_user_has_venture_access()/fn_is_chairman()',
+        prod_deploy_guard: '3-factor apply-migration.js --prod-deploy guard (scripts/lib/migration-guards.js): @approved-by header + token-issuance step, following precedent from commits e2528b5, 50fa5634, e07b45c'
+      },
+      triangulation_reference: {
+        prior_sd: 'SD-LEGAL-GENERATOR-001 (cancelled)',
+        date: '2026-01-04',
+        panel: ['Claude', 'OpenAI', 'Gemini'],
+        verdict: 'SKIP freeform LLM legal-doc generation',
+        citations: ['DoNotPay FTC $193K penalty precedent', '17-82% hallucination rates'],
+        doc: 'docs/reference/research/triangulation-legal-infrastructure-*.md',
+        this_sd_scope_decision: 'deterministic {{TOKEN}} substitution producer + mandatory non-removable "not legal advice" disclaimer, explicitly narrower than the triangulated-against freeform generator'
+      },
+      supavisor_incident: {
+        symptom: 'apply-migration.js direct-Postgres connection failed 4 consecutive times with "authentication did not complete within 15000ms"',
+        tested: ['session-mode port 5432', 'transaction-mode port 6543'],
+        result: 'both timed out identically',
+        control: 'REST/PostgREST stayed healthy (separate pre-warmed pool), masking the saturation',
+        root_cause: 'Supavisor pooler backend-connection starvation under ~9-11 concurrent fleet sessions',
+        resolution: 'signaled harness-bug to coordinator, retried successfully once fleet load subsided, used the wait to build producer module + stage-23 flip + tests'
+      },
+      testing_subagent_fix: {
+        initial_verdict: 'BLOCKED',
+        reason: 'user_stories rows still status=draft with no e2e_test_path',
+        trap: 'user_stories are keyed by story_key (composite "SD-KEY:US-NNN" string), not id (UUID)',
+        resolution: 'updated story_key-keyed rows with e2e_test_path pointing at the new test files, re-ran execute-subagent.js --code TESTING --full-e2e'
+      }
+    }
+  };
+
+  const { data, error } = await supabase
+    .from('retrospectives')
+    .insert(row)
+    .select('id, sd_id, retro_type, retrospective_type, quality_score, status, created_at')
+    .single();
+  if (error) { console.error('INS_ERR:', error); process.exit(1); }
+  console.log('INSERTED retro:', JSON.stringify(data, null, 2));
+})();

--- a/tests/unit/eva/legal-doc-producer.test.js
+++ b/tests/unit/eva/legal-doc-producer.test.js
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the legal-doc producer.
+ * SD: SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5, chairman-ratified 2026-07-12)
+ *
+ * Covers PRD test scenarios TS-1 (happy path), TS-2 (missing context), and the
+ * deterministic-substitution / no-LLM-call requirement (NFR-1, NFR-2, TR-2).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  generateLegalDocsForVenture,
+  substituteMarkers,
+  NOT_LEGAL_ADVICE_DISCLAIMER,
+  REQUIRED_TEMPLATE_TYPES,
+} from '../../../lib/eva/legal-doc-producer.js';
+
+const silentLogger = { info: () => {}, warn: () => {} };
+
+const ACTIVE_TEMPLATES = [
+  { id: 'tpl-tos', template_type: 'terms_of_service', content: '{{COMPANY_NAME}} at {{COMPANY_DOMAIN}}: {{SERVICE_DESCRIPTION}} — {{CONTACT_EMAIL}} — {{EFFECTIVE_DATE}}' },
+  { id: 'tpl-privacy', template_type: 'privacy_policy', content: '{{COMPANY_NAME}} privacy at {{COMPANY_DOMAIN}}' },
+];
+
+const VENTURE_ROW = {
+  id: 'v1',
+  name: 'Alt Text Compliance',
+  description: 'Image alt-text generator',
+  value_proposition: 'EU-accessibility-compliant alt text generation for e-commerce',
+  solution_approach: null,
+  company_id: 'c1',
+};
+
+const COMPANY_ROW = { id: 'c1', name: 'Alt Text Compliance Inc', description: null, website: 'alttextcompliance.com' };
+
+function makeSupabase({
+  ventureRow = VENTURE_ROW,
+  companyRow = COMPANY_ROW,
+  templates = ACTIVE_TEMPLATES,
+  existingOverride = null,
+  insertShouldFail = false,
+} = {}) {
+  const inserted = [];
+  const eventsInserted = [];
+  return {
+    _inserted: inserted,
+    _eventsInserted: eventsInserted,
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: ventureRow, error: null }),
+        };
+      }
+      if (table === 'companies') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: companyRow, error: null }),
+        };
+      }
+      if (table === 'legal_templates') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          in: () => Promise.resolve({ data: templates, error: null }),
+        };
+      }
+      if (table === 'venture_legal_overrides') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: existingOverride, error: null }),
+          update() { return this; },
+          insert(row) {
+            if (insertShouldFail) {
+              return { select() { return this; }, single: () => Promise.resolve({ data: null, error: { message: 'insert failed' } }) };
+            }
+            inserted.push(row);
+            return { select() { return this; }, single: () => Promise.resolve({ data: { id: `override-${inserted.length}` }, error: null }) };
+          },
+        };
+      }
+      if (table === 'eva_orchestration_events') {
+        return { insert: (row) => { eventsInserted.push(row); return Promise.resolve({ data: null, error: null }); } };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+describe('substituteMarkers', () => {
+  it('deterministically replaces all markers with no leftover tokens', () => {
+    const result = substituteMarkers('Hi {{COMPANY_NAME}}, visit {{COMPANY_NAME}}.com', { '{{COMPANY_NAME}}': 'Acme' });
+    expect(result).toBe('Hi Acme, visit Acme.com');
+    expect(result).not.toContain('{{');
+  });
+
+  it('is pure/repeatable: same inputs produce byte-identical output (NFR-1)', () => {
+    const a = substituteMarkers('{{X}}-{{Y}}', { '{{X}}': '1', '{{Y}}': '2' });
+    const b = substituteMarkers('{{X}}-{{Y}}', { '{{X}}': '1', '{{Y}}': '2' });
+    expect(a).toBe(b);
+  });
+});
+
+describe('generateLegalDocsForVenture — TS-1 happy path', () => {
+  it('creates venture_legal_overrides rows for both required types with substituted content and the disclaimer', async () => {
+    const supabase = makeSupabase();
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+
+    expect(result.ok).toBe(true);
+    expect(result.generated.map((g) => g.templateType).sort()).toEqual([...REQUIRED_TEMPLATE_TYPES].sort());
+    expect(supabase._inserted).toHaveLength(2);
+    for (const row of supabase._inserted) {
+      expect(row.generated_content).toContain('Alt Text Compliance Inc');
+      expect(row.generated_content).toContain('alttextcompliance.com');
+      expect(row.generated_content).toContain(NOT_LEGAL_ADVICE_DISCLAIMER);
+      expect(row.generated_content).not.toContain('{{'); // no leftover markers
+      expect(row.generated_at).toBeTruthy();
+    }
+    expect(supabase._eventsInserted).toHaveLength(0); // no failure event on happy path
+  });
+
+  it('updates (not duplicates) an existing override on regeneration', async () => {
+    const supabase = makeSupabase({ existingOverride: { id: 'existing-override-1' } });
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+    expect(result.ok).toBe(true);
+    expect(supabase._inserted).toHaveLength(0); // updated, not inserted
+    expect(result.generated.every((g) => g.overrideId === 'existing-override-1')).toBe(true);
+  });
+});
+
+describe('generateLegalDocsForVenture — TS-2 edge case: missing context', () => {
+  it('does not throw and emits a chairman-flagged event when venture context is insufficient', async () => {
+    const supabase = makeSupabase({ ventureRow: { ...VENTURE_ROW, value_proposition: null, solution_approach: null, description: null }, companyRow: { ...COMPANY_ROW, website: null } });
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('insufficient_context');
+    expect(supabase._inserted).toHaveLength(0); // no partial/corrupt row
+    expect(supabase._eventsInserted).toHaveLength(1);
+    expect(supabase._eventsInserted[0].chairman_flagged).toBe(true);
+    expect(supabase._eventsInserted[0].event_data.subtype).toBe('legal_producer_failed');
+  });
+
+  it('emits a chairman-flagged event when required templates are missing/inactive', async () => {
+    const supabase = makeSupabase({ templates: [ACTIVE_TEMPLATES[0]] }); // only ToS active, privacy_policy missing
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('missing_templates');
+    expect(supabase._eventsInserted).toHaveLength(1);
+    expect(supabase._eventsInserted[0].event_data.missing_fields).toContain('privacy_policy');
+  });
+
+  it('does not throw when ventureId or supabase is missing', async () => {
+    await expect(generateLegalDocsForVenture({ supabase: null, ventureId: 'v1' })).resolves.toEqual({ ok: false, reason: 'missing_supabase_or_ventureId' });
+    await expect(generateLegalDocsForVenture({ supabase: makeSupabase(), ventureId: null })).resolves.toEqual({ ok: false, reason: 'missing_supabase_or_ventureId' });
+  });
+});
+
+describe('no LLM API usage (TR-2)', () => {
+  it('the producer module source contains no LLM client imports', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(__dirname, '../../../lib/eva/legal-doc-producer.js'), 'utf8');
+    expect(src).not.toMatch(/openai|anthropic|@google\/generative-ai|gemini/i);
+  });
+});

--- a/tests/unit/eva/legal-doc-producer.test.js
+++ b/tests/unit/eva/legal-doc-producer.test.js
@@ -100,6 +100,18 @@ describe('substituteMarkers', () => {
     const b = substituteMarkers('{{X}}-{{Y}}', { '{{X}}': '1', '{{Y}}': '2' });
     expect(a).toBe(b);
   });
+
+  it('adversarial-review fix: a substituted value containing a marker-like token is NOT re-substituted (injection guard)', () => {
+    // Single-pass replace: the template's {{CONTACT_EMAIL}} is filled with a value that
+    // itself looks like a different marker. A sequential split/join implementation would
+    // re-scan and replace that literal text on a later pass; single-pass regex replace
+    // must not, since String.replace never re-matches its own replacement output.
+    const result = substituteMarkers('Contact: {{CONTACT_EMAIL}} / Effective: {{EFFECTIVE_DATE}}', {
+      '{{CONTACT_EMAIL}}': '{{EFFECTIVE_DATE}}',
+      '{{EFFECTIVE_DATE}}': '2026-07-13',
+    });
+    expect(result).toBe('Contact: {{EFFECTIVE_DATE}} / Effective: 2026-07-13');
+  });
 });
 
 describe('generateLegalDocsForVenture — TS-1 happy path', () => {
@@ -126,6 +138,58 @@ describe('generateLegalDocsForVenture — TS-1 happy path', () => {
     expect(result.ok).toBe(true);
     expect(supabase._inserted).toHaveLength(0); // updated, not inserted
     expect(result.generated.every((g) => g.overrideId === 'existing-override-1')).toBe(true);
+  });
+
+  it('adversarial-review fix: strips protocol from a full-URL website value so CONTACT_EMAIL is a well-formed address', async () => {
+    const supabase = makeSupabase({ companyRow: { ...COMPANY_ROW, website: 'https://alttextcompliance.com/about' } });
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+    expect(result.ok).toBe(true);
+    // Only the terms_of_service template (ACTIVE_TEMPLATES[0]) references {{CONTACT_EMAIL}}.
+    const tosRow = supabase._inserted.find((r) => r.template_id === 'tpl-tos');
+    expect(tosRow.generated_content).toContain('legal@alttextcompliance.com');
+    expect(tosRow.generated_content).not.toContain('legal@https://');
+    for (const row of supabase._inserted) {
+      expect(row.generated_content).not.toContain('https://'); // COMPANY_DOMAIN itself is also stripped
+    }
+  });
+});
+
+describe('generateLegalDocsForVenture — adversarial review: TOCTOU race handling', () => {
+  it('treats a 23505 unique-violation on insert as a concurrent-winner race, not a failure (no spurious chairman alert)', async () => {
+    let selectCallCount = 0;
+    const eventsInserted = [];
+    const supabase = {
+      from(table) {
+        if (table === 'ventures') return { select() { return this; }, eq() { return this; }, maybeSingle: () => Promise.resolve({ data: VENTURE_ROW, error: null }) };
+        if (table === 'companies') return { select() { return this; }, eq() { return this; }, maybeSingle: () => Promise.resolve({ data: COMPANY_ROW, error: null }) };
+        if (table === 'legal_templates') return { select() { return this; }, eq() { return this; }, in: () => Promise.resolve({ data: ACTIVE_TEMPLATES, error: null }) };
+        if (table === 'venture_legal_overrides') {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            maybeSingle: () => {
+              selectCallCount += 1;
+              // Per template: 1st (odd) select is the pre-insert "existing?" check -> null.
+              // 2nd (even) select is the post-23505 re-query, simulating the concurrent
+              // winner's row that was inserted between the two selects -> the raced row.
+              return Promise.resolve({ data: selectCallCount % 2 === 1 ? null : { id: 'raced-row-id' }, error: null });
+            },
+            update() { return this; },
+            insert: () => ({
+              select() { return this; },
+              single: () => Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "unique_venture_template"' } }),
+            }),
+          };
+        }
+        if (table === 'eva_orchestration_events') return { insert: (row) => { eventsInserted.push(row); return Promise.resolve({ data: null, error: null }); } };
+        throw new Error(`unexpected table ${table}`);
+      },
+    };
+
+    const result = await generateLegalDocsForVenture({ supabase, ventureId: 'v1', logger: silentLogger });
+    expect(result.ok).toBe(true);
+    expect(result.generated.every((g) => g.overrideId === 'raced-row-id')).toBe(true);
+    expect(eventsInserted).toHaveLength(0); // no false partial_write_failure alert
   });
 });
 

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-23-growth-categories.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-23-growth-categories.test.js
@@ -25,17 +25,32 @@ const silentLogger = { info: () => {}, warn: () => {} };
 // Minimal chainable Supabase mock (per-table results; thenable terminal).
 function makeQuery(result) {
   const q = {};
-  for (const m of ['select', 'eq', 'in', 'update', 'insert', 'order', 'limit', 'maybeSingle', 'single']) {
+  for (const m of ['select', 'eq', 'in', 'not', 'update', 'insert', 'order', 'limit', 'maybeSingle', 'single']) {
     q[m] = vi.fn(() => q);
   }
   q.then = (resolve) => resolve(result);
   return q;
 }
-function makeSupabase({ flagEnabled = false, presentTypes = [] } = {}) {
+// legalDocsPresent defaults true: these tests exercise growth-category logic in
+// isolation and are not about the legal category (SD-FDBK-FIX-BUILD-LEGAL-DOC-001
+// moved 'legal' from ADVISORY to REQUIRED; defaulting it to satisfied here keeps
+// this file's verdicts focused on the growth-category behavior it actually tests).
+function makeSupabase({ flagEnabled = false, presentTypes = [], legalDocsPresent = true } = {}) {
   return {
     from: vi.fn((t) => {
       if (t === 'leo_feature_flags') return makeQuery({ data: { is_enabled: flagEnabled }, error: null });
       if (t === 'venture_artifacts') return makeQuery({ data: presentTypes.map((x) => ({ artifact_type: x, is_current: true })), error: null });
+      if (t === 'venture_legal_overrides') {
+        return makeQuery({
+          data: legalDocsPresent
+            ? [
+              { generated_at: '2026-07-13T00:00:00Z', legal_templates: { template_type: 'terms_of_service' } },
+              { generated_at: '2026-07-13T00:00:00Z', legal_templates: { template_type: 'privacy_policy' } },
+            ]
+            : [],
+          error: null,
+        });
+      }
       return makeQuery({ error: null }); // eva_orchestration_events insert
     }),
   };
@@ -81,25 +96,26 @@ describe('FR-006 golden: default-OFF parity', () => {
     for (const cat of GROWTH_CATEGORIES) {
       expect(r.checklist.find((c) => c.category === cat)).toBeUndefined();
     }
-    expect(r.total_categories).toBe(REQUIRED_CATEGORIES.length + 3); // 3 advisory (analytics/monitoring/legal)
+    expect(r.total_categories).toBe(REQUIRED_CATEGORIES.length + 2); // 2 advisory (analytics/monitoring); legal is REQUIRED (SD-FDBK-FIX-BUILD-LEGAL-DOC-001)
     // Byte-identical parity on the count-derived fields the baseline computes: the growth
     // categories must NOT change advisory_count or the readiness_pct denominator (total=6).
-    // With all 3 REQUIRED passing + 3 ADVISORY, effectivePass=6 over total=6 => 100%.
-    expect(r.advisory_count).toBe(3);
+    // With all 4 REQUIRED passing (incl. legal, mocked present) + 2 ADVISORY, effectivePass=6 over total=6 => 100%.
+    expect(r.advisory_count).toBe(2);
     expect(r.readiness_pct).toBe(100);
   });
 
   it('default-OFF readiness_pct denominator is the baseline (6), not inflated by growth categories', async () => {
     // Regression guard for review finding [5]: an earlier design added the growth categories
     // as ADVISORY when the flag was OFF, which inflated total_categories to 8 and changed
-    // readiness_pct. With 2 of 3 REQUIRED passing + 3 ADVISORY and flag OFF, the denominator
-    // must stay 6 (=> round(5/6*100)=83), proving the growth categories do not touch the math.
+    // readiness_pct. With 3 of 4 REQUIRED passing (incl. legal) + 2 ADVISORY and flag OFF, the
+    // denominator must stay 6 (=> round(5/6*100)=83), proving the growth categories do not
+    // touch the math.
     const supabase = makeSupabase({ flagEnabled: false, presentTypes: BASE_PRESENT });
     const r = await analyzeStage23LaunchReadiness({
       ...PASSING_PARAMS, stage22Data: { active_channels: 0 }, supabase, // distribution_channels now pending
     });
     expect(r.total_categories).toBe(6);
-    expect(r.readiness_pct).toBe(83); // (2 required pass + 3 advisory)/6 — baseline denominator
+    expect(r.readiness_pct).toBe(83); // (2 required pass + legal pass + 2 advisory)/6 — baseline denominator
   });
 
   it('deploy-order safety: flag OFF + no pre-launch playbook still yields READY (in-flight not blocked)', async () => {

--- a/tests/unit/eva/stage-templates/stage-23-launch-readiness-fr1-4-6.test.js
+++ b/tests/unit/eva/stage-templates/stage-23-launch-readiness-fr1-4-6.test.js
@@ -4,9 +4,15 @@
  * Unit coverage for the Stage 23 launch readiness kill-gate redesign:
  *   FR-1: canonical artifact_type emission (stage-23.js TEMPLATE.analysisStep)
  *   FR-2: orphan-disposition smoke check (canonical module loads + index dispatch)
- *   FR-3: ADVISORY mode for analytics/monitoring/legal
+ *   FR-3: ADVISORY mode for analytics/monitoring
  *   FR-4: canonical-upstream preflight + SKIP fallback + stage_skipped event
  *   FR-6: backfill migration file is shaped correctly (idempotent guard, audit metadata)
+ *
+ * SD-FDBK-FIX-BUILD-LEGAL-DOC-001 (V5): 'legal' moved from ADVISORY_CATEGORIES to
+ * REQUIRED_CATEGORIES now that lib/eva/legal-doc-producer.js exists. The FR-3
+ * assertions below are updated to reflect the new 2-advisory/4-required split;
+ * buildMockSupabase gained a legalDocsPresent option so tests can control whether
+ * the venture has generated Terms of Service + Privacy Policy.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -30,7 +36,7 @@ const REPO_ROOT = resolve(__dirname, '../../../../');
 // Fixture: supabase mock that satisfies the preflight + emit contract used by
 // FR-4. `presentTypes` is the set of artifact_types the venture currently has
 // at is_current=true; an empty set triggers SKIPPED.
-function buildMockSupabase({ presentTypes = [], emitSpy } = {}) {
+function buildMockSupabase({ presentTypes = [], emitSpy, legalDocsPresent = false } = {}) {
   return {
     from(table) {
       if (table === 'venture_artifacts') {
@@ -45,6 +51,26 @@ function buildMockSupabase({ presentTypes = [], emitSpy } = {}) {
                     artifact_type: t,
                     is_current: true,
                   })),
+                  error: null,
+                });
+              },
+            };
+          },
+        };
+      }
+      if (table === 'venture_legal_overrides') {
+        return {
+          select() {
+            return {
+              eq() { return this; },
+              not() {
+                return Promise.resolve({
+                  data: legalDocsPresent
+                    ? [
+                      { generated_at: '2026-07-13T00:00:00Z', legal_templates: { template_type: 'terms_of_service' } },
+                      { generated_at: '2026-07-13T00:00:00Z', legal_templates: { template_type: 'privacy_policy' } },
+                    ]
+                    : [],
                   error: null,
                 });
               },
@@ -136,9 +162,9 @@ describe('SD-LEO-FEAT-STAGE-LAUNCH-READINESS-001 FR-1..FR-4, FR-6', () => {
   });
 
   describe('FR-3: ADVISORY mode', () => {
-    it('analytics, monitoring, legal are advisory; code_quality, marketing_assets, distribution_channels are required', () => {
-      expect(REQUIRED_CATEGORIES).toEqual(['code_quality', 'marketing_assets', 'distribution_channels']);
-      expect(ADVISORY_CATEGORIES).toEqual(['analytics', 'monitoring', 'legal']);
+    it('analytics, monitoring are advisory; code_quality, marketing_assets, distribution_channels, legal are required', () => {
+      expect(REQUIRED_CATEGORIES).toEqual(['code_quality', 'marketing_assets', 'distribution_channels', 'legal']);
+      expect(ADVISORY_CATEGORIES).toEqual(['analytics', 'monitoring']);
     });
 
     it('ADVISORY entries default to status=advisory in checklist (no producer needed)', async () => {
@@ -150,14 +176,14 @@ describe('SD-LEO-FEAT-STAGE-LAUNCH-READINESS-001 FR-1..FR-4, FR-6', () => {
         logger: silentLogger,
       });
       const advisoryEntries = result.checklist.filter(c => c.mode === 'ADVISORY');
-      expect(advisoryEntries).toHaveLength(3);
+      expect(advisoryEntries).toHaveLength(2);
       for (const entry of advisoryEntries) {
         expect(entry.status).toBe('advisory');
       }
     });
 
-    it('verdict=READY when all REQUIRED categories pass, even with ADVISORY entries unsatisfied', async () => {
-      const supabase = buildMockSupabase({ presentTypes: allUpstreamArtifacts });
+    it('verdict=READY when all REQUIRED categories pass (including legal, via a real producer check), even with ADVISORY entries unsatisfied', async () => {
+      const supabase = buildMockSupabase({ presentTypes: allUpstreamArtifacts, legalDocsPresent: true });
       const result = await analyzeStage23LaunchReadiness({
         stage20Data: { verdict: 'PASS' },
         stage21Data: { total_assets: 12 },
@@ -167,7 +193,23 @@ describe('SD-LEO-FEAT-STAGE-LAUNCH-READINESS-001 FR-1..FR-4, FR-6', () => {
         logger: silentLogger,
       });
       expect(result.verdict).toBe('READY');
-      expect(result.advisory_count).toBe(3);
+      expect(result.advisory_count).toBe(2);
+    });
+
+    it('verdict=HOLD when legal is REQUIRED and no legal docs have been generated (was previously silent advisory-pass)', async () => {
+      const supabase = buildMockSupabase({ presentTypes: allUpstreamArtifacts, legalDocsPresent: false });
+      const result = await analyzeStage23LaunchReadiness({
+        stage20Data: { verdict: 'PASS' },
+        stage21Data: { total_assets: 12 },
+        stage22Data: { active_channels: 4 },
+        ventureId: '00000000-0000-0000-0000-000000000004b',
+        supabase,
+        logger: silentLogger,
+      });
+      const legalEntry = result.checklist.find(c => c.category === 'legal');
+      expect(legalEntry.mode).toBe('REQUIRED');
+      expect(legalEntry.status).toBe('fail');
+      expect(result.verdict).toBe('HOLD');
     });
 
     it('verdict=HOLD when any REQUIRED category fails (advisory ignored)', async () => {


### PR DESCRIPTION
## Summary
- Chairman-ratified V5 (2026-07-12 venture-ops deep-dive §5): stage-23-launch-readiness.js put `legal` in `ADVISORY_CATEGORIES`, so a venture could pass launch-readiness with zero legal docs and no attestation event. Self-refuting for v2 (Image Alt Text Generator), whose wedge is EU-accessibility-compliance.
- New `legal_templates` + `venture_legal_overrides` schema (adapted from a never-applied January migration, with RLS rewritten to the current `fn_user_has_venture_access()`/`fn_is_chairman()` idiom -- the original's `companies.owner_id` predicate does not exist live).
- New `lib/eva/legal-doc-producer.js`: generates Privacy Policy + Terms of Service per venture via deterministic `{{TOKEN}}` substitution -- **not** an LLM call. A prior 3-AI triangulation (2026-01-04) concluded SKIP on freeform LLM legal-doc generation and cancelled a sibling SD on that verdict; this SD is deliberately scoped narrower (fixed templates + mandatory "not legal advice" disclaimer) to avoid that liability class.
- `stage-23-launch-readiness.js`: moves `legal` from `ADVISORY_CATEGORIES` to `REQUIRED_CATEGORIES`, scored via a real `venture_legal_overrides` presence check.
- Producer emits a chairman-flagged `eva_orchestration_events` row when it cannot generate docs for a venture, instead of silently no-oping.
- DSAR fulfillment (migration 031) explicitly deferred, with trigger: must land before any EU-targeted marketing send.

## Test plan
- [x] New `tests/unit/eva/legal-doc-producer.test.js` (8 tests): happy path, missing-context/missing-templates edge cases, deterministic substitution, no-LLM-import assertion
- [x] Updated 2 existing stage-23 test files whose mocks/assertions assumed legal was advisory (3-advisory split) to the new 2-advisory/4-required split
- [x] Full `lib/eva/` suite: 501/505 files, 6547/6571 tests pass (4 skipped files + 24 skipped tests, all pre-existing)
- [x] Migration applied live and verified (`legal_templates`/`venture_legal_overrides` exist, seeded with active templates)
- [x] Live PostgREST embed-join query smoke-tested against real schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>