### PR TITLE
fix(QF-20260712-917): put DR restore-rehearsal on automated monthly cadence

### DIFF
--- a/.github/workflows/dr-restore-rehearsal-cron.yml
+++ b/.github/workflows/dr-restore-rehearsal-cron.yml
@@ -1,0 +1,74 @@
+name: DR restore rehearsal (cron)
+
+# QF-20260712-917 (D6, chairman-ratified 2026-07-12, doc @ aee41d6c).
+# The weekly off-box DR dump (governance-data-dump.yml) is the estate's ONLY
+# off-box copy; its restore rehearsal (npm run dr:rehearse) had no cadence --
+# last PASS was manual, 2026-06-10. Runs monthly, which trivially satisfies
+# both "quarterly baseline" and "monthly while schema churn is high" without
+# needing runtime churn detection. Read-only against sources (see
+# ops/runbooks/disaster-recovery.md §7); writes only to a throwaway scratch
+# schema the rehearsal itself drops.
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'  # 1st of each month, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  rehearse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      PGHOST: ${{ secrets.PGHOST_PROD }}
+      PGPORT: ${{ secrets.PGPORT_PROD }}
+      PGDATABASE: ${{ secrets.PGDATABASE_PROD }}
+      PGUSER: ${{ secrets.PGUSER_PROD }}
+      PGPASSWORD: ${{ secrets.PGPASSWORD_PROD }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run restore rehearsal
+        continue-on-error: true
+        run: node scripts/dr/restore-rehearsal.mjs --out dr-rehearsal-report.json
+
+      - name: Stamp registry + runbook witness
+        if: always()
+        run: node scripts/dr/stamp-rehearsal-result.mjs dr-rehearsal-report.json
+
+      - name: Commit runbook update
+        if: always()
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          if git diff --quiet ops/runbooks/disaster-recovery.md; then
+            echo "No runbook changes to commit"
+          else
+            git add ops/runbooks/disaster-recovery.md
+            git commit -m "chore(dr): record $(date -u +%Y-%m-%d) restore rehearsal result
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+          Co-Authored-By: GitHub Actions <noreply@github.com>"
+            git push || echo "Push skipped"
+          fi

--- a/ops/runbooks/disaster-recovery.md
+++ b/ops/runbooks/disaster-recovery.md
@@ -184,18 +184,26 @@ failure). Drill A samples ≤500 `retention_archive` rows for
 `workflow_trace_log` and proves the documented "re-insert `row_data`" restore
 path with field-level fidelity asserts; drill B copies a sample of
 `management_reviews_quarantine_20260610` and asserts per-row
-`md5(row::text)` identity. Cadence: run after any retention/quarantine schema
-change, after any platform restore, and at least quarterly.
+`md5(row::text)` identity. Cadence (QF-20260712-917, D6): automated monthly via
+`.github/workflows/dr-restore-rehearsal-cron.yml` (1st of month, 06:00 UTC;
+also `workflow_dispatch`-able on demand) — monthly trivially satisfies both the
+"quarterly baseline" and "monthly while schema churn is high" chairman-ratified
+targets without needing runtime churn detection. Also run manually after any
+retention/quarantine schema change or platform restore. Each run stamps
+`periodic_process_registry` (`gha_cron:dr-restore-rehearsal-cron.yml`) and
+rewrites the witness below via `scripts/dr/stamp-rehearsal-result.mjs`.
+PRECONDITION for `SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001`'s `retention_archive`
+365d TTL step: do not enable that TTL until a rehearsal PASS below is <90d old.
 
-**Latest live run — 2026-06-10T23:31:44Z: `PASS`** (scratch schema
-`dr_rehearsal_20260610_2331`, 2.5 s):
+**Latest live run — 2026-07-13T03:06:17.381Z: `PASS`** (scratch schema
+`dr_rehearsal_20260713_0306`, 1.3 s):
 
 | Drill | Result |
 |---|---|
 | A — retention_archive → workflow_trace_log | PASS — 500 rows restored, **8,500 field checks, 0 mismatches**, 0 schema-drift keys, 0 missing rows |
 | B — quarantine copy md5 identity | PASS — 500/500 rows, md5 sets identical |
-| Statement audit | 11 statements: 5 reads, 6 scratch-writes, **0 forbidden** |
-| Cleanup | scratch schema dropped (verified `pg_namespace` count = 0 after run) |
+| Statement audit | 13 statements: 5 reads, 8 scratch-writes, **0 forbidden** |
+| Cleanup | scratch schema dropped |
 
 First full dump-driver run (same day, local, `scripts/temp/` — not
 committed): 14/14 tables, 51,816 rows, 412.0 MB NDJSON in ~98 s.

--- a/scripts/dr/rehearsal-witness-format.mjs
+++ b/scripts/dr/rehearsal-witness-format.mjs
@@ -1,0 +1,26 @@
+/**
+ * QF-20260712-917 (D6): pure formatting logic for the runbook §7 "Latest live
+ * run" witness block, split out of stamp-rehearsal-result.mjs for unit testing.
+ */
+const fmt = (n) => Number(n).toLocaleString('en-US');
+
+/** Matches runbook §7's "Latest live run" block, from its bold header through the Cleanup row. */
+export const RUNBOOK_BLOCK_REGEX = /\*\*Latest live run[\s\S]*?\| Cleanup \|[^\n]*\|/;
+
+/** @param {object} report - restore-rehearsal.mjs's buildReport() output */
+export function buildWitnessBlock(report) {
+  const { A, B } = report.drills;
+  const rowA = `| A — retention_archive → workflow_trace_log | ${A.status}${A.status === 'PASS' ? ` — ${fmt(A.restored)} rows restored, **${fmt(A.fieldChecks)} field checks, ${fmt(A.mismatchCount ?? 0)} mismatches**, ${(A.schemaDriftKeys || []).length} schema-drift keys, ${(A.missingRestored || []).length} missing rows` : A.error ? ` — ${A.error}` : ''} |`;
+  const rowB = `| B — quarantine copy md5 identity | ${B.status}${B.status === 'PASS' ? ` — ${B.copied}/${B.sampled} rows, md5 sets identical` : B.error ? ` — ${B.error}` : ''} |`;
+  const durationMs = report.startedAt ? new Date(report.finishedAt).getTime() - new Date(report.startedAt).getTime() : null;
+
+  return `**Latest live run — ${report.finishedAt}: \`${report.overall}\`** (scratch schema
+\`${report.scratchSchema}\`${durationMs != null ? `, ${(durationMs / 1000).toFixed(1)} s` : ''}):
+
+| Drill | Result |
+|---|---|
+${rowA}
+${rowB}
+| Statement audit | ${report.statementAudit.total} statements: ${report.statementAudit.reads} reads, ${report.statementAudit.scratchWrites} scratch-writes, **${report.statementAudit.forbidden} forbidden** |
+| Cleanup | scratch schema ${report.cleanup.schemaDropped ? 'dropped' : 'NOT CONFIRMED DROPPED — manual check needed'} |`;
+}

--- a/scripts/dr/stamp-rehearsal-result.mjs
+++ b/scripts/dr/stamp-rehearsal-result.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * QF-20260712-917 (D6): stamp periodic_process_registry + rewrite runbook §7's
+ * "Latest live run" witness after a scheduled `dr:rehearse` fires. Called by
+ * .github/workflows/dr-restore-rehearsal-cron.yml on `always()` (PASS or FAIL
+ * both need a fresh dated witness).
+ *
+ * Usage: node scripts/dr/stamp-rehearsal-result.mjs <report.json>
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+import { buildWitnessBlock, RUNBOOK_BLOCK_REGEX } from './rehearsal-witness-format.mjs';
+
+const PROCESS_KEY = 'gha_cron:dr-restore-rehearsal-cron.yml';
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const runbookPath = path.join(repoRoot, 'ops', 'runbooks', 'disaster-recovery.md');
+
+const reportPath = process.argv[2];
+if (!reportPath) {
+  console.error('Usage: node scripts/dr/stamp-rehearsal-result.mjs <report.json>');
+  process.exit(1);
+}
+
+const report = fs.existsSync(reportPath)
+  ? JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+  : { overall: 'FAIL', error: 'no report produced (rehearsal crashed before --out was written)', scratchSchema: 'n/a', finishedAt: new Date().toISOString(), drills: { A: { status: 'NOT_RUN' }, B: { status: 'NOT_RUN' } }, statementAudit: { total: 0, reads: 0, scratchWrites: 0, forbidden: 0 }, cleanup: { schemaDropped: false } };
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const { stamped, reason } = await stampLastFired(supabase, PROCESS_KEY);
+console.log(`[stamp-rehearsal-result] registry stamp: stamped=${stamped}${reason ? ` reason=${reason}` : ''}`);
+
+const runbook = fs.readFileSync(runbookPath, 'utf8');
+if (!RUNBOOK_BLOCK_REGEX.test(runbook)) {
+  console.error('[stamp-rehearsal-result] could not locate the "Latest live run" block in the runbook — leaving it untouched');
+  process.exit(report.overall === 'PASS' ? 0 : 1);
+}
+fs.writeFileSync(runbookPath, runbook.replace(RUNBOOK_BLOCK_REGEX, buildWitnessBlock(report)));
+console.log(`[stamp-rehearsal-result] runbook §7 updated with ${report.overall} result dated ${report.finishedAt}`);
+
+process.exit(report.overall === 'PASS' ? 0 : 1);

--- a/tests/unit/dr-rehearsal-witness-format.test.js
+++ b/tests/unit/dr-rehearsal-witness-format.test.js
@@ -1,0 +1,70 @@
+/**
+ * QF-20260712-917 (D6): unit tests for the runbook §7 witness-block formatter.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWitnessBlock, RUNBOOK_BLOCK_REGEX } from '../../scripts/dr/rehearsal-witness-format.mjs';
+
+const PASS_REPORT = {
+  overall: 'PASS',
+  scratchSchema: 'dr_rehearsal_20260713_0306',
+  startedAt: '2026-07-13T03:06:16.081Z',
+  finishedAt: '2026-07-13T03:06:17.381Z',
+  drills: {
+    A: { status: 'PASS', restored: 500, fieldChecks: 8500, mismatchCount: 0, schemaDriftKeys: [], missingRestored: [] },
+    B: { status: 'PASS', copied: 500, sampled: 500 },
+  },
+  statementAudit: { total: 13, reads: 5, scratchWrites: 8, forbidden: 0 },
+  cleanup: { schemaDropped: true },
+};
+
+const FAIL_REPORT = {
+  overall: 'FAIL',
+  scratchSchema: 'dr_rehearsal_20260713_0400',
+  finishedAt: '2026-07-13T04:00:00.000Z',
+  drills: {
+    A: { status: 'FAIL', error: 'schema drift: column removed' },
+    B: { status: 'NOT_RUN' },
+  },
+  statementAudit: { total: 2, reads: 1, scratchWrites: 1, forbidden: 0 },
+  cleanup: { schemaDropped: false },
+};
+
+describe('RUNBOOK_BLOCK_REGEX', () => {
+  it('matches the existing runbook witness block shape', () => {
+    const runbook = `## 7. Restore rehearsal\n\n**Latest live run — 2026-06-10T23:31:44Z: \`PASS\`** (scratch schema\n\`dr_rehearsal_20260610_2331\`, 2.5 s):\n\n| Drill | Result |\n|---|---|\n| A — x | PASS |\n| B — y | PASS |\n| Statement audit | 11 statements |\n| Cleanup | scratch schema dropped |\n\n## 8. Next section`;
+    expect(RUNBOOK_BLOCK_REGEX.test(runbook)).toBe(true);
+  });
+});
+
+describe('buildWitnessBlock', () => {
+  it('formats a PASS report with thousands-separators and drill detail', () => {
+    const block = buildWitnessBlock(PASS_REPORT);
+    expect(block).toContain('**Latest live run — 2026-07-13T03:06:17.381Z: `PASS`**');
+    expect(block).toContain('dr_rehearsal_20260713_0306');
+    expect(block).toContain('1.3 s'); // (17.381 - 16.081)s duration
+    expect(block).toContain('500 rows restored');
+    expect(block).toContain('8,500 field checks'); // comma-formatted
+    expect(block).toContain('0 mismatches');
+    expect(block).toContain('500/500 rows, md5 sets identical');
+    expect(block).toContain('13 statements: 5 reads, 8 scratch-writes, **0 forbidden**');
+    expect(block).toContain('scratch schema dropped');
+  });
+
+  it('formats a FAIL report with drill errors and no duration (no startedAt)', () => {
+    const block = buildWitnessBlock(FAIL_REPORT);
+    expect(block).toContain('`FAIL`');
+    expect(block).toContain('schema drift: column removed');
+    expect(block).toContain('B — quarantine copy md5 identity | NOT_RUN');
+    expect(block).toContain('NOT CONFIRMED DROPPED — manual check needed');
+    expect(block).not.toMatch(/\d+\.\d s\)/); // no duration suffix when startedAt is absent
+  });
+
+  it('round-trips through RUNBOOK_BLOCK_REGEX.replace() cleanly against a realistic runbook fragment', () => {
+    const runbook = `preamble\n\n**Latest live run — 2026-06-10T23:31:44Z: \`PASS\`** (scratch schema\n\`dr_rehearsal_20260610_2331\`, 2.5 s):\n\n| Drill | Result |\n|---|---|\n| A — old | PASS |\n| B — old | PASS |\n| Statement audit | 11 statements |\n| Cleanup | scratch schema dropped |\n\n## 8. next`;
+    const updated = runbook.replace(RUNBOOK_BLOCK_REGEX, buildWitnessBlock(PASS_REPORT));
+    expect(updated).toContain('2026-07-13T03:06:17.381Z');
+    expect(updated).not.toContain('2026-06-10T23:31:44Z');
+    expect(updated).toContain('## 8. next'); // content after the block is preserved
+    expect(updated).toContain('preamble'); // content before the block is preserved
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman-ratified D6: the weekly off-box DR dump is the estate's only off-box copy, but its restore rehearsal (`npm run dr:rehearse`) had no cadence -- last PASS was manual, 2026-06-10 (>30d old).
- New `.github/workflows/dr-restore-rehearsal-cron.yml`: monthly cron (1st @ 06:00 UTC) + `workflow_dispatch`. Runs the rehearsal, stamps `periodic_process_registry` (`gha_cron:dr-restore-rehearsal-cron.yml`), and rewrites the runbook §7 witness with the dated PASS/FAIL result, committing the change back.
- New `scripts/dr/rehearsal-witness-format.mjs` (pure formatting logic, unit tested) + `scripts/dr/stamp-rehearsal-result.mjs` (CLI wrapper).
- Monthly cadence trivially satisfies both "quarterly baseline" and "monthly while schema churn is high" without needing runtime churn detection.
- Registered the new process via `node scripts/seed-periodic-process-registry.mjs` (existing infra, run once to activate the entry before first cron fire).

## Test plan
- [x] Ran the actual `npm run dr:rehearse` live (safe: scratch-schema only, self-cleaning) -- PASS
- [x] Ran `stamp-rehearsal-result.mjs` against the real report -- registry stamped, runbook §7 updated correctly
- [x] `npx vitest run tests/unit/dr-rehearsal-witness-format.test.js tests/unit/dr-restore-rehearsal.test.js` -- 40/40 pass, zero regressions
- [x] `node --check` on both new scripts -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)