### PR TITLE
fix(SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001): re-scope venture support pipeline per-venture

### DIFF
--- a/database/migrations/20260713_venture_support_tickets.sql
+++ b/database/migrations/20260713_venture_support_tickets.sql
@@ -1,0 +1,124 @@
+-- Migration: Venture Support Tickets
+-- SD: SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001
+-- Purpose: Dedicated table for venture customer-support tickets, so
+--          lib/support/intake-pipeline.js stops writing into the shared
+--          harness `feedback` table (chairman-ratified, deep-dive ed675631
+--          Section 5, Solomon F12).
+-- Considered-and-rejected alternative: reusing feedback.venture_id +
+--          feedback_type='user_*' (added 2026-04-01 by
+--          SD-LEO-INFRA-VENTURE-USER-FEEDBACK-001) -- that channel is for
+--          user-submitted bug/feature-request feedback, a different domain
+--          from customer support tickets (SLA/resolution tracking), and
+--          reusing it would still route through every consumer of the
+--          shared feedback table (pattern bridge, quality config,
+--          LLM-triage, auto-close triggers, unified-inbox-builder).
+-- @chairman-gated: staged, not yet applied
+-- Date: 2026-07-13
+
+BEGIN;
+
+-- ============================================================
+-- 1. venture_support_tickets table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.venture_support_tickets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id uuid REFERENCES public.ventures(id) ON DELETE CASCADE,
+  ticket_id text NOT NULL,
+  channel text NOT NULL,
+  subject text,
+  body text NOT NULL,
+  customer_ref text,
+  category text NOT NULL,
+  severity text NOT NULL DEFAULT 'normal',
+  routing_decision text,
+  status text NOT NULL DEFAULT 'open',
+  resolution_notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT venture_support_tickets_severity_check
+    CHECK (severity IN ('low', 'normal', 'high', 'critical')),
+  CONSTRAINT venture_support_tickets_status_check
+    CHECK (status IN ('open', 'auto_resolved', 'escalated', 'resolved', 'closed')),
+  CONSTRAINT venture_support_tickets_ticket_id_venture_unique
+    UNIQUE (venture_id, ticket_id)
+);
+
+COMMENT ON TABLE public.venture_support_tickets
+  IS 'Venture customer-support tickets. Replaces the shared feedback table as the write destination for lib/support/intake-pipeline.js (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001) -- never routes through harness feedback consumers.';
+
+COMMENT ON COLUMN public.venture_support_tickets.venture_id
+  IS 'Owning venture. Nullable: an unresolvable/unattributed ticket still escalates and is persisted here (venture_id=NULL) for human triage, rather than being silently dropped -- but is NEVER auto-resolved without one.';
+
+COMMENT ON COLUMN public.venture_support_tickets.ticket_id
+  IS 'Caller-supplied ticket identifier from the intake channel (unique per venture).';
+
+COMMENT ON COLUMN public.venture_support_tickets.channel
+  IS 'Intake channel the ticket arrived on (e.g. email, webhook) -- used to resolve the per-venture rail address.';
+
+-- ============================================================
+-- 2. FIRST CUSTOMER activation flag + per-venture rail address on ventures
+--    is_armed is an explicit, human/chairman-armed gate -- NOT auto-detected.
+-- ============================================================
+ALTER TABLE public.ventures
+  ADD COLUMN IF NOT EXISTS support_is_armed boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.ventures
+  ADD COLUMN IF NOT EXISTS support_armed_at timestamptz;
+
+ALTER TABLE public.ventures
+  ADD COLUMN IF NOT EXISTS support_rail_address text;
+
+ALTER TABLE public.ventures
+  ADD CONSTRAINT ventures_support_rail_address_unique UNIQUE (support_rail_address);
+
+COMMENT ON COLUMN public.ventures.support_is_armed
+  IS 'Explicit human/chairman-set FIRST CUSTOMER flag for the support pipeline. Default false. Never auto-detected (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001). Informational/readiness signal only -- does not block ticket intake/processing.';
+
+COMMENT ON COLUMN public.ventures.support_armed_at
+  IS 'Timestamp support_is_armed was last set true by a human/chairman action.';
+
+COMMENT ON COLUMN public.ventures.support_rail_address
+  IS 'Per-venture support intake address (e.g. email alias or webhook path). lib/support/intake-pipeline.js resolves venture_id from a ticket''s rail_address against this column when the caller does not already know the venture_id.';
+
+-- ============================================================
+-- 3. Indexes
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_venture_support_tickets_venture_created
+  ON public.venture_support_tickets (venture_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_venture_support_tickets_status
+  ON public.venture_support_tickets (status)
+  WHERE status IN ('open', 'escalated');
+
+-- ============================================================
+-- 4. RLS -- enabled + service_role policy in the SAME migration
+--    (SPINE-001-B anon-writable-table recurrence: an RLS-less table,
+--    even briefly, is a blocking condition, not a follow-up.)
+-- ============================================================
+ALTER TABLE public.venture_support_tickets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY venture_support_tickets_service_role_all
+  ON public.venture_support_tickets
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- No anon policy: the support pipeline is a backend-only writer
+-- (lib/support/intake-pipeline.js runs with the service-role key).
+-- Unlike the 2026-04-01 venture_user_feedback channel, there is no
+-- direct-from-browser anon INSERT path for support tickets today.
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed):
+-- ============================================================
+-- DROP POLICY IF EXISTS venture_support_tickets_service_role_all ON public.venture_support_tickets;
+-- DROP INDEX IF EXISTS idx_venture_support_tickets_status;
+-- DROP INDEX IF EXISTS idx_venture_support_tickets_venture_created;
+-- ALTER TABLE public.ventures DROP CONSTRAINT IF EXISTS ventures_support_rail_address_unique;
+-- ALTER TABLE public.ventures DROP COLUMN IF EXISTS support_rail_address;
+-- ALTER TABLE public.ventures DROP COLUMN IF EXISTS support_armed_at;
+-- ALTER TABLE public.ventures DROP COLUMN IF EXISTS support_is_armed;
+-- DROP TABLE IF EXISTS public.venture_support_tickets;

--- a/database/migrations/20260713_venture_support_tickets.sql
+++ b/database/migrations/20260713_venture_support_tickets.sql
@@ -29,14 +29,17 @@ CREATE TABLE IF NOT EXISTS public.venture_support_tickets (
   body text NOT NULL,
   customer_ref text,
   category text NOT NULL,
-  severity text NOT NULL DEFAULT 'normal',
+  severity text NOT NULL DEFAULT 'low',
   routing_decision text,
   status text NOT NULL DEFAULT 'open',
   resolution_notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
+  -- Matches triageSupportTicket()'s exact severity taxonomy (lib/support/intake-pipeline.js
+  -- SEVERITY_HIGH/SEVERITY_MED buckets emit 'high'/'medium'/'low'); 'critical' reserved for
+  -- future manual escalation, not currently emitted by the classifier.
   CONSTRAINT venture_support_tickets_severity_check
-    CHECK (severity IN ('low', 'normal', 'high', 'critical')),
+    CHECK (severity IN ('low', 'medium', 'high', 'critical')),
   CONSTRAINT venture_support_tickets_status_check
     CHECK (status IN ('open', 'auto_resolved', 'escalated', 'resolved', 'closed')),
   CONSTRAINT venture_support_tickets_ticket_id_venture_unique

--- a/database/migrations/20260713_venture_support_tickets.sql
+++ b/database/migrations/20260713_venture_support_tickets.sql
@@ -71,8 +71,18 @@ ALTER TABLE public.ventures
 ALTER TABLE public.ventures
   ADD COLUMN IF NOT EXISTS support_rail_address text;
 
-ALTER TABLE public.ventures
-  ADD CONSTRAINT ventures_support_rail_address_unique UNIQUE (support_rail_address);
+-- Postgres has no "ADD CONSTRAINT IF NOT EXISTS" -- guard explicitly so a re-run/retry of this
+-- migration (partial apply, staging->prod replay) doesn't throw "constraint already exists" and
+-- roll back the whole single-transaction migration (adversarial-review fix).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ventures_support_rail_address_unique'
+  ) THEN
+    ALTER TABLE public.ventures
+      ADD CONSTRAINT ventures_support_rail_address_unique UNIQUE (support_rail_address);
+  END IF;
+END $$;
 
 COMMENT ON COLUMN public.ventures.support_is_armed
   IS 'Explicit human/chairman-set FIRST CUSTOMER flag for the support pipeline. Default false. Never auto-detected (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001). Informational/readiness signal only -- does not block ticket intake/processing.';
@@ -93,6 +103,14 @@ CREATE INDEX IF NOT EXISTS idx_venture_support_tickets_status
   ON public.venture_support_tickets (status)
   WHERE status IN ('open', 'escalated');
 
+-- UNIQUE (venture_id, ticket_id) above does NOT dedup unattributed tickets -- Postgres treats
+-- NULLs as distinct, so forced-escalate rows (venture_id=NULL) with the same ticket_id would
+-- otherwise multiply unboundedly on redelivery. This partial index closes that gap (adversarial-
+-- review fix): ticket_id is unique among unattributed rows too.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_venture_support_tickets_unattributed_ticket_id_unique
+  ON public.venture_support_tickets (ticket_id)
+  WHERE venture_id IS NULL;
+
 -- ============================================================
 -- 4. RLS -- enabled + service_role policy in the SAME migration
 --    (SPINE-001-B anon-writable-table recurrence: an RLS-less table,
@@ -112,12 +130,20 @@ CREATE POLICY venture_support_tickets_service_role_all
 -- Unlike the 2026-04-01 venture_user_feedback channel, there is no
 -- direct-from-browser anon INSERT path for support tickets today.
 
+-- NOTE (adversarial-review, INFO): support_rail_address/support_is_armed/support_armed_at are
+-- added to the pre-existing public.ventures table via ADD COLUMN only -- this migration does not
+-- touch ventures' own RLS policies, which are out of scope here. If ventures ever grants a broad
+-- anon/authenticated SELECT, support_rail_address (a per-venture intake address) would be exposed
+-- through that existing grant, not through anything added by this migration. Auditing ventures'
+-- RLS posture as a whole is tracked separately, not duplicated per-migration.
+
 COMMIT;
 
 -- ============================================================
 -- ROLLBACK (manual, if needed):
 -- ============================================================
 -- DROP POLICY IF EXISTS venture_support_tickets_service_role_all ON public.venture_support_tickets;
+-- DROP INDEX IF EXISTS idx_venture_support_tickets_unattributed_ticket_id_unique;
 -- DROP INDEX IF EXISTS idx_venture_support_tickets_status;
 -- DROP INDEX IF EXISTS idx_venture_support_tickets_venture_created;
 -- ALTER TABLE public.ventures DROP CONSTRAINT IF EXISTS ventures_support_rail_address_unique;

--- a/lib/support/intake-pipeline.js
+++ b/lib/support/intake-pipeline.js
@@ -1,11 +1,13 @@
 /**
- * Venture-AGNOSTIC customer-support intake -> triage -> route pipeline (happy-path zero-touch).
- * SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001 (load-bearing-for-first-dollar).
+ * Venture-SCOPED customer-support intake -> triage -> route pipeline (happy-path zero-touch).
+ * SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001 (load-bearing-for-first-dollar), re-scoped per-venture by
+ * SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 (chairman-ratified, deep-dive ed675631 Section 5, Solomon F12).
  *
- * Three composable seams, DB INJECTED (the core is pure + unit-testable without a DB):
+ * Four composable seams, DB INJECTED (normalize/triage stay pure + unit-testable without a DB):
  *   1. normalizeSupportTicket(raw)            — channel-neutral capture -> normalized ticket (FR-1)
- *   2. triageSupportTicket(ticket)            — category + severity + routing decision (FR-2)
- *   3. disposeSupportTicket(sb, ticket, tri)  — auto-resolve happy path | escalate edge cases (FR-3)
+ *   2. resolveVentureContext(sb, ticket)      — venture_id + rail-address + armed-flag lookup (FR-4/5)
+ *   3. triageSupportTicket(ticket)            — category + severity + routing decision (FR-2)
+ *   4. disposeSupportTicket(sb, ticket, tri)  — auto-resolve happy path | escalate edge cases (FR-3)
  * plus runSupportPipeline / getSupportEscalationQueue (FR-4) and markPipelineLive (FR-5).
  *
  * REUSE (FR-2 / TR-1): the triage classifier reuses the EVA intake-classification keyword-scoring
@@ -13,10 +15,18 @@
  * "this is actually a new-venture pitch, not a support issue" signal) and mirrors its scoring shape
  * (keywords.filter(kw => text.includes(kw)).length) for the support taxonomy. NO greenfield engine.
  *
- * Persistence (TR-3): NO new table / NO migration. The surfaced escalation queue REUSES the existing
- * feedback store (category='support_escalation', surfaced via /inbox); auto-resolutions are recorded
- * as resolved feedback rows (category='support_auto_resolved'). Fail-loud: nothing is ever silently
- * dropped — an auto-resolution that cannot be recorded DOWNGRADES to escalate.
+ * Persistence (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001): venture support tickets write to the
+ * DEDICATED venture_support_tickets table (chairman-gated migration
+ * database/migrations/20260713_venture_support_tickets.sql) — NEVER to the shared harness `feedback`
+ * table. Fail-loud: nothing is ever silently dropped — an auto-resolution that cannot be recorded
+ * DOWNGRADES to escalate, and a ticket with no resolvable venture_id is FORCED to escalate (never
+ * auto-resolved unattributed) but is still persisted (venture_id=NULL) for human triage.
+ *
+ * FIRST CUSTOMER gate (ventures.support_is_armed): an explicit, human/chairman-set flag — never
+ * auto-detected. It is informational/readiness signal only: it does NOT block ticket intake or
+ * processing (a venture without a "first customer" yet should still get its support tickets
+ * triaged/escalated correctly, not ignored). Callers that need armed-gated behavior downstream
+ * (e.g. public rail-address activation) read `ticket.venture_armed` from the pipeline result.
  */
 'use strict';
 
@@ -62,7 +72,7 @@ function deriveTicketId(parts) {
   return `tkt_${h}`;
 }
 
-// ── FR-1: channel-neutral intake ingestion ───────────────────────────────────
+// ── FR-1/FR-4: channel-neutral intake ingestion + venture attribution capture ─
 /** Normalize any channel-neutral raw support input into a ticket. Pure + tolerant (never throws). */
 export function normalizeSupportTicket(raw = {}) {
   const r = raw && typeof raw === 'object' ? raw : {};
@@ -72,7 +82,38 @@ export function normalizeSupportTicket(raw = {}) {
   const customer_ref = r.customer_ref ?? r.customer ?? r.email ?? null;
   const received_at = typeof r.received_at === 'string' ? r.received_at : new Date().toISOString();
   const ticket_id = r.ticket_id ?? r.id ?? deriveTicketId([channel, subject, body, customer_ref ? String(customer_ref) : '']);
-  return { ticket_id, channel, subject, body, customer_ref, received_at, status: 'new' };
+  // venture_id: caller may already know it (e.g. an authenticated in-app support widget).
+  // rail_address: the per-venture intake address the ticket arrived on (e.g. "billing@<venture>.com"
+  // or a venture-specific webhook path) — resolved to a venture_id downstream (FR-4, DB-injected,
+  // stays out of this pure function so normalizeSupportTicket remains unit-testable without a DB).
+  const venture_id = typeof r.venture_id === 'string' && r.venture_id ? r.venture_id : null;
+  const rail_address = typeof r.rail_address === 'string' && r.rail_address ? r.rail_address : typeof r.to === 'string' && r.to ? r.to : null;
+  return { ticket_id, channel, subject, body, customer_ref, received_at, status: 'new', venture_id, rail_address };
+}
+
+// ── FR-4/FR-5: venture attribution + FIRST CUSTOMER armed-flag resolution ─────
+/**
+ * Resolve a ticket's venture_id (direct or via its rail_address) and the venture's FIRST CUSTOMER
+ * support_is_armed flag. DB-injected, fail-open to unresolved (never throws) — an unresolvable
+ * venture is a legitimate, expected outcome that disposeSupportTicket() handles (forced escalate).
+ */
+export async function resolveVentureContext(supabase, ticket = {}) {
+  try {
+    if (ticket.venture_id) {
+      // support_is_armed/support_rail_address: chairman-gated, staged-not-applied columns
+      // (database/migrations/20260713_venture_support_tickets.sql). schema-lint-disable-line
+      const { data } = await supabase.from('ventures').select('id, support_is_armed').eq('id', ticket.venture_id).maybeSingle(); // schema-lint-disable-line
+      if (data) return { venture_id: data.id, venture_armed: !!data.support_is_armed, resolved: true };
+      return { venture_id: null, venture_armed: false, resolved: false };
+    }
+    if (ticket.rail_address) {
+      const { data } = await supabase.from('ventures').select('id, support_is_armed').eq('support_rail_address', ticket.rail_address).maybeSingle(); // schema-lint-disable-line
+      if (data) return { venture_id: data.id, venture_armed: !!data.support_is_armed, resolved: true };
+    }
+    return { venture_id: null, venture_armed: false, resolved: false };
+  } catch {
+    return { venture_id: null, venture_armed: false, resolved: false };
+  }
 }
 
 // ── FR-2: triage classifier (reuse the intake-classifier engine/pattern) ──────
@@ -118,49 +159,55 @@ export function triageSupportTicket(ticket = {}) {
   }
 }
 
-// ── FR-3: routing / disposition (reuse the feedback store; fail-loud) ─────────
-async function writeFeedbackRow(supabase, row) {
-  // source_application is NOT NULL on feedback; default it (callers may override).
-  const fullRow = { source_application: 'EHG_Engineer', ...row };
-  const { data, error } = await supabase.from('feedback').insert(fullRow).select('id').single();
+// ── FR-3: routing / disposition (venture_support_tickets; fail-loud) ──────────
+async function writeSupportTicketRow(supabase, row) {
+  const { data, error } = await supabase.from('venture_support_tickets').insert(row).select('id').single();
   if (error) throw error;
   return data.id;
 }
 
 async function recordAutoResolution(supabase, ticket, triage) {
-  return writeFeedbackRow(supabase, {
-    type: 'issue',
-    source_type: 'user_feedback',
-    category: 'support_auto_resolved',
-    status: 'resolved',
+  return writeSupportTicketRow(supabase, {
+    venture_id: ticket.venture_id,
+    ticket_id: ticket.ticket_id,
+    channel: ticket.channel,
+    subject: ticket.subject || null,
+    body: ticket.body || '',
+    customer_ref: ticket.customer_ref ? String(ticket.customer_ref) : null,
+    category: triage.category,
     severity: triage.severity,
-    title: `Support auto-resolved: ${triage.category} (${triage.severity})`,
-    description: `${ticket.subject || '(no subject)'} — ${CANNED_RESOLUTIONS[triage.category] || 'Auto-resolved (happy path).'}`,
+    routing_decision: triage.routing_decision,
+    status: 'auto_resolved',
     resolution_notes: CANNED_RESOLUTIONS[triage.category] || 'Auto-resolved (happy path).',
-    metadata: { ticket_id: ticket.ticket_id, channel: ticket.channel, customer_ref: ticket.customer_ref, triage, sd: 'SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001' },
   });
 }
 
-async function escalateToFeedback(supabase, ticket, triage) {
-  return writeFeedbackRow(supabase, {
-    type: 'issue',
-    source_type: 'user_feedback',
-    category: 'support_escalation',
-    status: 'new',
+async function escalateSupportTicket(supabase, ticket, triage) {
+  return writeSupportTicketRow(supabase, {
+    venture_id: ticket.venture_id,
+    ticket_id: ticket.ticket_id,
+    channel: ticket.channel,
+    subject: ticket.subject || null,
+    body: ticket.body || '',
+    customer_ref: ticket.customer_ref ? String(ticket.customer_ref) : null,
+    category: triage.category,
     severity: triage.severity,
-    priority: triage.severity === 'high' ? 'high' : triage.severity === 'medium' ? 'medium' : 'low',
-    title: `Support escalation: ${triage.category} (${triage.severity})`,
-    description: `${ticket.subject || '(no subject)'}\n\n${ticket.body || ''}\n\n[triage] ${triage.rationale}`,
-    metadata: { ticket_id: ticket.ticket_id, channel: ticket.channel, customer_ref: ticket.customer_ref, triage, sd: 'SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001' },
+    routing_decision: triage.routing_decision,
+    status: 'escalated',
+    resolution_notes: triage.rationale || null,
   });
 }
 
 /**
- * Dispose a triaged ticket. Auto-resolve the happy path; ESCALATE everything else to the surfaced
- * feedback queue. FAIL-LOUD: an auto-resolution that cannot be recorded DOWNGRADES to escalate, so a
- * ticket is NEVER silently dropped.
+ * Dispose a triaged ticket. Auto-resolve the happy path; ESCALATE everything else to
+ * venture_support_tickets. FAIL-LOUD: an auto-resolution that cannot be recorded DOWNGRADES to
+ * escalate, and a ticket with no resolvable venture_id is FORCED to escalate (never auto-resolved
+ * unattributed) — so a ticket is NEVER silently dropped.
  */
 export async function disposeSupportTicket(supabase, ticket, triage) {
+  if (!ticket.venture_id) {
+    triage = { ...triage, routing_decision: 'escalate', rationale: `${triage.rationale}; escalated: no venture_id resolved (unattributed ticket)` };
+  }
   if (triage.routing_decision === 'auto_resolve') {
     let recordedId = null;
     try { recordedId = await recordAutoResolution(supabase, ticket, triage); } catch { recordedId = null; }
@@ -170,26 +217,34 @@ export async function disposeSupportTicket(supabase, ticket, triage) {
     // downgrade: the happy-path record failed -> do NOT drop; escalate instead.
     triage = { ...triage, routing_decision: 'escalate', rationale: `${triage.rationale}; downgraded: auto-resolve record failed` };
   }
-  const escalationId = await escalateToFeedback(supabase, ticket, triage);
+  const escalationId = await escalateSupportTicket(supabase, ticket, triage);
   return { status: 'escalated', escalation_id: escalationId, escalated: true, reason: triage.rationale };
 }
 
 // ── FR-4: orchestrator + surfaced queue ──────────────────────────────────────
-/** Run the full intake -> triage -> route pipeline for one raw input. */
+/** Run the full intake -> resolve-venture -> triage -> route pipeline for one raw input. */
 export async function runSupportPipeline(supabase, raw) {
   const ticket = normalizeSupportTicket(raw);
+  const ventureContext = await resolveVentureContext(supabase, ticket);
+  ticket.venture_id = ventureContext.venture_id;
+  ticket.venture_armed = ventureContext.venture_armed;
   const triage = triageSupportTicket(ticket);
   const disposition = await disposeSupportTicket(supabase, ticket, triage);
   return { ticket, triage, disposition };
 }
 
-/** List the surfaced escalation queue (open support_escalation feedback rows). */
+/**
+ * List the surfaced escalation queue (open venture_support_tickets rows). Formerly surfaced via the
+ * harness /inbox (unified-inbox-builder's unfiltered loadFeedback()) when this reused the feedback
+ * table — accepted tradeoff (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 TR-3): venture support tickets no
+ * longer appear in /inbox. A dedicated venture-support surfaced view is deferred to a future SD if/
+ * when the pipeline goes live with a real consumer.
+ */
 export async function getSupportEscalationQueue(supabase, { limit = 50 } = {}) {
   const { data, error } = await supabase
-    .from('feedback')
-    .select('id, title, description, status, priority, severity, created_at, metadata')
-    .eq('category', 'support_escalation')
-    .neq('status', 'resolved')
+    .from('venture_support_tickets')
+    .select('id, venture_id, ticket_id, channel, subject, body, category, severity, status, resolution_notes, created_at')
+    .eq('status', 'escalated')
     .order('created_at', { ascending: false })
     .limit(limit);
   if (error) {

--- a/lib/support/intake-pipeline.js
+++ b/lib/support/intake-pipeline.js
@@ -93,22 +93,35 @@ export function normalizeSupportTicket(raw = {}) {
 
 // ── FR-4/FR-5: venture attribution + FIRST CUSTOMER armed-flag resolution ─────
 /**
- * Resolve a ticket's venture_id (direct or via its rail_address) and the venture's FIRST CUSTOMER
- * support_is_armed flag. DB-injected, fail-open to unresolved (never throws) — an unresolvable
- * venture is a legitimate, expected outcome that disposeSupportTicket() handles (forced escalate).
+ * Resolve a ticket's venture_id (via its rail_address, or direct venture_id as a fallback) and the
+ * venture's FIRST CUSTOMER support_is_armed flag. DB-injected, fail-open to unresolved (never
+ * throws) — an unresolvable venture is a legitimate, expected outcome that disposeSupportTicket()
+ * handles (forced escalate).
+ *
+ * PRECEDENCE (adversarial-review fix): rail_address is checked FIRST, direct venture_id only as a
+ * fallback when no rail_address was provided. rail_address reflects the physical intake channel the
+ * ticket arrived on; a caller-supplied venture_id on raw channel-neutral input (email/webhook body)
+ * is otherwise spoofable — a sender could attribute their ticket to any existing venture. The
+ * fallback exists for a genuinely trusted caller (e.g. an authenticated in-app support widget that
+ * already knows its own venture_id and has no rail_address to give).
+ * RESIDUAL SCOPE NOTE: both venture_id and rail_address are still sourced from raw, unauthenticated
+ * input in normalizeSupportTicket() today — this pipeline has ZERO production callers (dormant,
+ * test-only). Full trust-context propagation from a real transport layer (e.g. a verified email
+ * envelope "to" address vs. spoofable body content) is deferred to whichever future SD wires a live
+ * intake channel, since no live trust boundary exists to violate yet.
  */
 export async function resolveVentureContext(supabase, ticket = {}) {
   try {
-    if (ticket.venture_id) {
+    if (ticket.rail_address) {
       // support_is_armed/support_rail_address: chairman-gated, staged-not-applied columns
       // (database/migrations/20260713_venture_support_tickets.sql). schema-lint-disable-line
+      const { data } = await supabase.from('ventures').select('id, support_is_armed').eq('support_rail_address', ticket.rail_address).maybeSingle(); // schema-lint-disable-line
+      if (data) return { venture_id: data.id, venture_armed: !!data.support_is_armed, resolved: true };
+    }
+    if (ticket.venture_id) {
       const { data } = await supabase.from('ventures').select('id, support_is_armed').eq('id', ticket.venture_id).maybeSingle(); // schema-lint-disable-line
       if (data) return { venture_id: data.id, venture_armed: !!data.support_is_armed, resolved: true };
       return { venture_id: null, venture_armed: false, resolved: false };
-    }
-    if (ticket.rail_address) {
-      const { data } = await supabase.from('ventures').select('id, support_is_armed').eq('support_rail_address', ticket.rail_address).maybeSingle(); // schema-lint-disable-line
-      if (data) return { venture_id: data.id, venture_armed: !!data.support_is_armed, resolved: true };
     }
     return { venture_id: null, venture_armed: false, resolved: false };
   } catch {
@@ -160,10 +173,25 @@ export function triageSupportTicket(ticket = {}) {
 }
 
 // ── FR-3: routing / disposition (venture_support_tickets; fail-loud) ──────────
+/**
+ * IDEMPOTENT insert (adversarial-review fix): ticket_id is deterministic (deriveTicketId), and the
+ * table enforces UNIQUE(venture_id, ticket_id) / a unique partial index for venture_id IS NULL.
+ * At-least-once redelivery (webhook/email retries are the norm) would otherwise hit a unique-
+ * violation on the SECOND write attempt — auto-resolve fails silently (caught by the caller),
+ * downgrades to escalate, then escalate hits the SAME violation UNCAUGHT and crashes the pipeline.
+ * On a Postgres unique-violation (23505), look up and return the already-persisted row instead of
+ * throwing — a benign redelivery becomes a no-op, not a crash.
+ */
 async function writeSupportTicketRow(supabase, row) {
   const { data, error } = await supabase.from('venture_support_tickets').insert(row).select('id').single();
-  if (error) throw error;
-  return data.id;
+  if (!error) return data.id;
+  if (error.code === '23505') {
+    let existingQuery = supabase.from('venture_support_tickets').select('id').eq('ticket_id', row.ticket_id);
+    existingQuery = row.venture_id ? existingQuery.eq('venture_id', row.venture_id) : existingQuery.is('venture_id', null);
+    const { data: existing } = await existingQuery.maybeSingle();
+    if (existing) return existing.id;
+  }
+  throw error;
 }
 
 async function recordAutoResolution(supabase, ticket, triage) {

--- a/scripts/lint/schema-reference-allowlist.json
+++ b/scripts/lint/schema-reference-allowlist.json
@@ -6,9 +6,12 @@
   "vision_ladder_rungs",
   "vision_ladder_criteria",
   "door_routing_ledger",
-  "venture_operating_burn"
+  "venture_operating_burn",
+  "venture_support_tickets"
  ],
  "_door_routing_ledger_note": "apply-at-cutover table (SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001): migration 20260705_add_door_routing_ledger.sql applies at the Tuesday DOOR_ROUTING_ENABLED flip; the flag-gated fire-and-forget writer tolerates its absence pre-cutover. Remove from this allowlist after the migration applies."
  ,
  "_venture_operating_burn_note": "chairman-gated, staged-not-applied table (SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-E1): migration database/migrations/20260712_venture_operating_burn.sql is deliberately not yet applied to the live DB (per the @chairman-gated header). The fail-soft writer (scripts/operator/feed-venture-operating-burn.mjs) tolerates the table's absence -- every upsert call is wrapped in a per-step try/catch. Remove from this allowlist and re-run npm run schema:snapshot:lint after a chairman applies the migration."
+ ,
+ "_venture_support_tickets_note": "chairman-gated, staged-not-applied table (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001): migration database/migrations/20260713_venture_support_tickets.sql is deliberately not yet applied to the live DB (per the @chairman-gated header). lib/support/intake-pipeline.js's persistence call sites must fail loud (escalate, not crash) if the table is absent. Remove from this allowlist and re-run npm run schema:snapshot:lint after a chairman applies the migration."
 }

--- a/tests/integration/support-intake-pipeline.test.js
+++ b/tests/integration/support-intake-pipeline.test.js
@@ -1,38 +1,47 @@
 /**
- * Integration pins: end-to-end intake->triage->route, surfaced escalation queue, KR-flip.
+ * Integration pins: end-to-end intake->resolve-venture->triage->route, surfaced escalation queue, KR-flip.
  * SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001 — FR-4/FR-5/FR-6.
+ * Re-scoped per-venture by SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001.
  */
 import { describe, it, expect } from 'vitest';
 import {
   runSupportPipeline, getSupportEscalationQueue, markPipelineLive, PIPELINE_LIVE_KR_CODE,
 } from '../../lib/support/intake-pipeline.js';
 
-/** Fuller supabase mock: feedback insert + escalation-queue select + key_results read/update. */
-function makeSb({ krValue = 0 } = {}) {
-  const feedback = [];
+/** Fuller supabase mock: venture_support_tickets insert/select, ventures lookup, key_results read/update. */
+function makeSb({ krValue = 0, ventures = [{ id: 'v-1', support_is_armed: false, support_rail_address: 'help@acme.example' }] } = {}) {
+  const tickets = [];
   let kr = { id: 'kr-1', current_value: krValue };
   return {
-    feedback,
+    tickets,
     get kr() { return kr; },
     from(table) {
-      const b = { _t: table, _op: null, _payload: null };
+      const b = { _t: table, _op: null, _payload: null, _filters: {} };
       b.insert = (row) => { b._op = 'insert'; b._payload = row; return b; };
       b.update = (obj) => { b._op = 'update'; b._payload = obj; return b; };
-      b.select = () => b; b.eq = () => b; b.neq = () => b; b.order = () => b; b.limit = () => b;
+      b.select = () => b;
+      b.eq = (col, val) => { b._filters[col] = val; return b; };
+      b.neq = () => b; b.order = () => b; b.limit = () => b;
       b.single = () => {
-        if (b._t === 'feedback' && b._op === 'insert') {
-          const id = `fb-${feedback.length + 1}`; feedback.push({ ...b._payload, id }); return Promise.resolve({ data: { id }, error: null });
+        if (b._t === 'venture_support_tickets' && b._op === 'insert') {
+          const id = `vst-${tickets.length + 1}`; tickets.push({ ...b._payload, id }); return Promise.resolve({ data: { id }, error: null });
         }
         return Promise.resolve({ data: null, error: null });
       };
       b.maybeSingle = () => {
         if (b._t === 'key_results') return Promise.resolve({ data: { ...kr }, error: null });
+        if (b._t === 'ventures') {
+          const match = ventures.find((v) =>
+            (b._filters.id !== undefined && v.id === b._filters.id) ||
+            (b._filters.support_rail_address !== undefined && v.support_rail_address === b._filters.support_rail_address));
+          return Promise.resolve({ data: match || null, error: null });
+        }
         return Promise.resolve({ data: null, error: null });
       };
       b.then = (res) => {
         if (b._t === 'key_results' && b._op === 'update') { kr = { ...kr, current_value: b._payload.current_value }; return res({ error: null }); }
-        if (b._t === 'feedback' && !b._op) {
-          return res({ data: feedback.filter((r) => r.category === 'support_escalation' && r.status !== 'resolved'), error: null });
+        if (b._t === 'venture_support_tickets' && !b._op) {
+          return res({ data: tickets.filter((r) => r.status === 'escalated'), error: null });
         }
         return res({ data: [], error: null });
       };
@@ -41,10 +50,11 @@ function makeSb({ krValue = 0 } = {}) {
   };
 }
 
-describe('runSupportPipeline end-to-end (FR-4)', () => {
-  it('happy-path ticket -> auto_resolved, NOT in the escalation queue', async () => {
+describe('runSupportPipeline end-to-end (FR-4, venture-scoped)', () => {
+  it('happy-path ticket via a resolvable rail address -> auto_resolved, NOT in the escalation queue', async () => {
     const sb = makeSb();
-    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'How do I reset my password', body: 'account login reset guide' });
+    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'How do I reset my password', body: 'account login reset guide', rail_address: 'help@acme.example' });
+    expect(result.ticket.venture_id).toBe('v-1');
     expect(result.disposition.status).toBe('auto_resolved');
     const queue = await getSupportEscalationQueue(sb);
     expect(queue.length).toBe(0); // auto-resolved tickets are not escalations
@@ -52,25 +62,40 @@ describe('runSupportPipeline end-to-end (FR-4)', () => {
 
   it('edge-case ticket -> escalated AND surfaced in the escalation queue (never dropped)', async () => {
     const sb = makeSb();
-    const result = await runSupportPipeline(sb, { channel: 'email', subject: 'URGENT: service down, charged twice', body: 'billing breach losing money' });
+    const result = await runSupportPipeline(sb, { channel: 'email', subject: 'URGENT: service down, charged twice', body: 'billing breach losing money', venture_id: 'v-1' });
     expect(result.disposition.status).toBe('escalated');
     const queue = await getSupportEscalationQueue(sb);
     expect(queue.length).toBe(1);
-    expect(queue[0].title).toMatch(/Support escalation/);
+    expect(queue[0].venture_id).toBe('v-1');
+  });
+
+  it('unattributed ticket (no venture_id, no matching rail address) -> forced escalate, surfaced for human triage', async () => {
+    const sb = makeSb();
+    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'How do I reset my password', body: 'account login reset guide' });
+    expect(result.ticket.venture_id).toBeNull();
+    expect(result.disposition.status).toBe('escalated');
+    const queue = await getSupportEscalationQueue(sb);
+    expect(queue.some((r) => r.venture_id === null)).toBe(true);
+  });
+
+  it('venture_support_tickets rows never bleed into a feedback-shaped queue (zero legacy category field)', async () => {
+    const sb = makeSb();
+    await runSupportPipeline(sb, { channel: 'email', subject: 'URGENT: service down, charged twice', body: 'billing breach losing money', venture_id: 'v-1' });
+    expect(sb.tickets.every((r) => !('source_application' in r))).toBe(true);
   });
 });
 
 describe('markPipelineLive — KR-2026-07-01 flip (FR-5)', () => {
   it('flips current_value 0 -> 1 (status achieved) on a real end-to-end run', async () => {
     const sb = makeSb({ krValue: 0 });
-    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'how to', body: 'account guide' });
+    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'how to', body: 'account guide', venture_id: 'v-1' });
     const flip = await markPipelineLive(sb, result);
     expect(flip.flipped).toBe(true);
     expect(sb.kr.current_value).toBe(1);
   });
   it('is IDEMPOTENT: a second flip leaves it at 1 (not 2)', async () => {
     const sb = makeSb({ krValue: 1 });
-    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'how to', body: 'account guide' });
+    const result = await runSupportPipeline(sb, { channel: 'web', subject: 'how to', body: 'account guide', venture_id: 'v-1' });
     const flip = await markPipelineLive(sb, result);
     expect(flip.flipped).toBe(false);
     expect(flip.already).toBe(true);

--- a/tests/unit/support/intake-pipeline.test.js
+++ b/tests/unit/support/intake-pipeline.test.js
@@ -14,10 +14,13 @@ import {
 
 /**
  * Minimal supabase mock: records venture_support_tickets inserts (can fail the first N, to exercise
- * downgrade); resolves ventures lookups (by id or support_rail_address) from a fixture list.
+ * downgrade); simulates a real Postgres unique-violation (code 23505) when a row with the same
+ * (ticket_id, venture_id) already exists (seed via `preExisting`), and the post-conflict lookup
+ * `writeSupportTicketRow` performs to recover idempotently; resolves ventures lookups (by id or
+ * support_rail_address) from a fixture list.
  */
-export function makeSb({ failInsert = false, failFirstNInserts = 0, ventures = [] } = {}) {
-  const inserted = [];
+export function makeSb({ failInsert = false, failFirstNInserts = 0, ventures = [], preExisting = [] } = {}) {
+  const inserted = [...preExisting];
   let attempts = 0;
   const sb = {
     inserted,
@@ -27,10 +30,13 @@ export function makeSb({ failInsert = false, failFirstNInserts = 0, ventures = [
       b.update = (obj) => { b._op = 'update'; b._payload = obj; return b; };
       b.select = () => b;
       b.eq = (col, val) => { b._filters[col] = val; return b; };
+      b.is = (col, val) => { b._filters[col] = val; return b; }; // val is always null (venture_id IS NULL)
       b.neq = () => b; b.order = () => b; b.limit = () => b;
       b.single = () => {
         if (b._t === 'venture_support_tickets' && b._op === 'insert') {
           attempts += 1;
+          const conflict = inserted.some((r) => r.ticket_id === b._payload.ticket_id && r.venture_id === (b._payload.venture_id ?? null));
+          if (conflict) return Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint' } });
           if (failInsert || attempts <= failFirstNInserts) return Promise.resolve({ data: null, error: { message: 'insert failed' } });
           const id = `vst-${inserted.length + 1}`; inserted.push({ ...b._payload, id }); return Promise.resolve({ data: { id }, error: null });
         }
@@ -41,6 +47,10 @@ export function makeSb({ failInsert = false, failFirstNInserts = 0, ventures = [
           const match = ventures.find((v) =>
             (b._filters.id !== undefined && v.id === b._filters.id) ||
             (b._filters.support_rail_address !== undefined && v.support_rail_address === b._filters.support_rail_address));
+          return Promise.resolve({ data: match || null, error: null });
+        }
+        if (b._t === 'venture_support_tickets') {
+          const match = inserted.find((r) => r.ticket_id === b._filters.ticket_id && r.venture_id === (b._filters.venture_id ?? null));
           return Promise.resolve({ data: match || null, error: null });
         }
         return Promise.resolve({ data: null, error: null });
@@ -89,6 +99,17 @@ describe('resolveVentureContext (FR-4/FR-5)', () => {
     const sb = makeSb({ ventures: [{ id: 'v-1', support_is_armed: true }] });
     const ctx = await resolveVentureContext(sb, { venture_id: 'v-1' });
     expect(ctx).toEqual({ venture_id: 'v-1', venture_armed: true, resolved: true });
+  });
+  it('PRECEDENCE (adversarial-review fix): rail_address wins over a caller-supplied venture_id when both are present', async () => {
+    // ticket claims venture_id='v-spoofed' (fully attacker-controllable on raw channel-neutral
+    // input), but arrived via a rail_address that legitimately resolves to a DIFFERENT venture --
+    // the physical channel signal must win, not the unauthenticated claim.
+    const sb = makeSb({ ventures: [
+      { id: 'v-real', support_is_armed: false, support_rail_address: 'help@acme.example' },
+      { id: 'v-spoofed', support_is_armed: false },
+    ] });
+    const ctx = await resolveVentureContext(sb, { venture_id: 'v-spoofed', rail_address: 'help@acme.example' });
+    expect(ctx.venture_id).toBe('v-real');
   });
   it('resolves via rail_address when venture_id is not already known', async () => {
     const sb = makeSb({ ventures: [{ id: 'v-2', support_is_armed: false, support_rail_address: 'billing@acme.example' }] });
@@ -208,6 +229,21 @@ describe('disposeSupportTicket (FR-3)', () => {
     const sb = makeSb({ failInsert: true });
     const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach', venture_id: 'v-1' });
     await expect(disposeSupportTicket(sb, ticket, triageSupportTicket(ticket))).rejects.toBeTruthy();
+  });
+  it('IDEMPOTENT REDELIVERY (adversarial-review fix): re-processing an already-persisted attributed ' +
+     'ticket recovers via the existing row instead of crashing on the unique-violation', async () => {
+    const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach', venture_id: 'v-1' });
+    const sb = makeSb({ preExisting: [{ id: 'vst-existing', ticket_id: ticket.ticket_id, venture_id: 'v-1', status: 'escalated' }] });
+    const d = await disposeSupportTicket(sb, ticket, triageSupportTicket(ticket));
+    expect(d.status).toBe('escalated');
+    expect(d.escalation_id).toBe('vst-existing'); // recovered the existing row, no duplicate/no throw
+  });
+  it('IDEMPOTENT REDELIVERY: an unattributed ticket redelivery also recovers via the NULL-venture_id row', async () => {
+    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide' }); // no venture_id
+    const sb = makeSb({ preExisting: [{ id: 'vst-existing-null', ticket_id: ticket.ticket_id, venture_id: null, status: 'escalated' }] });
+    const d = await disposeSupportTicket(sb, ticket, triageSupportTicket(ticket));
+    expect(d.status).toBe('escalated');
+    expect(d.escalation_id).toBe('vst-existing-null');
   });
 });
 

--- a/tests/unit/support/intake-pipeline.test.js
+++ b/tests/unit/support/intake-pipeline.test.js
@@ -152,6 +152,20 @@ describe('triageSupportTicket (FR-2)', () => {
     const t = triageSupportTicket(normalizeSupportTicket({ subject: 'bug error broken crash', body: '' }));
     expect(SUPPORT_CATEGORIES).toContain(t.category);
   });
+  it('DB VOCABULARY PIN: emitted severities stay within venture_support_tickets_severity_check ' +
+     "('low','medium','high','critical') — a mismatch here would throw a CHECK violation on insert " +
+     'once the chairman-gated migration is applied (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 VALIDATION finding)', () => {
+    const DB_ALLOWED_SEVERITIES = ['low', 'medium', 'high', 'critical'];
+    const fixtures = [
+      { subject: 'how do i reset my password', body: 'account login reset' }, // low
+      { subject: 'important: still waiting for a refund', body: 'blocked frustrated' }, // medium
+      { subject: 'URGENT: charged twice, service down', body: 'billing refund' }, // high
+    ];
+    for (const raw of fixtures) {
+      const t = triageSupportTicket(normalizeSupportTicket(raw));
+      expect(DB_ALLOWED_SEVERITIES).toContain(t.severity);
+    }
+  });
 });
 
 describe('disposeSupportTicket (FR-3)', () => {

--- a/tests/unit/support/intake-pipeline.test.js
+++ b/tests/unit/support/intake-pipeline.test.js
@@ -1,35 +1,50 @@
 /**
  * Unit pins for the support intake->triage->route pipeline.
  * SD-LEO-INFRA-SUPPORT-INTAKE-TRIAGE-001 — FR-1/FR-2/FR-3/FR-6.
+ * Re-scoped per-venture by SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 — FR-1..FR-6, TS-1..TS-6.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import {
-  normalizeSupportTicket, triageSupportTicket, disposeSupportTicket, SUPPORT_CATEGORIES,
+  normalizeSupportTicket, triageSupportTicket, disposeSupportTicket, resolveVentureContext,
+  runSupportPipeline, SUPPORT_CATEGORIES,
 } from '../../../lib/support/intake-pipeline.js';
 
-/** Minimal supabase mock: records feedback inserts; can fail the first N inserts (to exercise downgrade). */
-export function makeSb({ failFeedbackInsert = false, failFirstNInserts = 0 } = {}) {
+/**
+ * Minimal supabase mock: records venture_support_tickets inserts (can fail the first N, to exercise
+ * downgrade); resolves ventures lookups (by id or support_rail_address) from a fixture list.
+ */
+export function makeSb({ failInsert = false, failFirstNInserts = 0, ventures = [] } = {}) {
   const inserted = [];
   let attempts = 0;
   const sb = {
     inserted,
     from(table) {
-      const b = { _t: table, _op: null, _payload: null };
+      const b = { _t: table, _op: null, _payload: null, _filters: {} };
       b.insert = (row) => { b._op = 'insert'; b._payload = row; return b; };
       b.update = (obj) => { b._op = 'update'; b._payload = obj; return b; };
-      b.select = () => b; b.eq = () => b; b.neq = () => b; b.order = () => b; b.limit = () => b;
+      b.select = () => b;
+      b.eq = (col, val) => { b._filters[col] = val; return b; };
+      b.neq = () => b; b.order = () => b; b.limit = () => b;
       b.single = () => {
-        if (b._t === 'feedback' && b._op === 'insert') {
+        if (b._t === 'venture_support_tickets' && b._op === 'insert') {
           attempts += 1;
-          if (failFeedbackInsert || attempts <= failFirstNInserts) return Promise.resolve({ data: null, error: { message: 'insert failed' } });
-          const id = `fb-${inserted.length + 1}`; inserted.push({ ...b._payload, id }); return Promise.resolve({ data: { id }, error: null });
+          if (failInsert || attempts <= failFirstNInserts) return Promise.resolve({ data: null, error: { message: 'insert failed' } });
+          const id = `vst-${inserted.length + 1}`; inserted.push({ ...b._payload, id }); return Promise.resolve({ data: { id }, error: null });
         }
         return Promise.resolve({ data: null, error: null });
       };
-      b.maybeSingle = () => Promise.resolve({ data: null, error: null });
+      b.maybeSingle = () => {
+        if (b._t === 'ventures') {
+          const match = ventures.find((v) =>
+            (b._filters.id !== undefined && v.id === b._filters.id) ||
+            (b._filters.support_rail_address !== undefined && v.support_rail_address === b._filters.support_rail_address));
+          return Promise.resolve({ data: match || null, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      };
       return b;
     },
   };
@@ -53,6 +68,44 @@ describe('normalizeSupportTicket (FR-1)', () => {
     expect(a.ticket_id).toBe(b.ticket_id); // content-derived, stable
     expect(() => normalizeSupportTicket(null)).not.toThrow();
     expect(() => normalizeSupportTicket(undefined)).not.toThrow();
+  });
+  it('captures venture_id when the caller already knows it (FR-4)', () => {
+    const t = normalizeSupportTicket({ subject: 'x', body: 'y', venture_id: 'v-1' });
+    expect(t.venture_id).toBe('v-1');
+  });
+  it('captures rail_address from rail_address or "to" for downstream resolution (FR-4); defaults null', () => {
+    const t1 = normalizeSupportTicket({ subject: 'x', body: 'y', rail_address: 'billing@acme.example' });
+    expect(t1.rail_address).toBe('billing@acme.example');
+    const t2 = normalizeSupportTicket({ subject: 'x', body: 'y', to: 'support@acme.example' });
+    expect(t2.rail_address).toBe('support@acme.example');
+    const t3 = normalizeSupportTicket({ subject: 'x', body: 'y' });
+    expect(t3.venture_id).toBeNull();
+    expect(t3.rail_address).toBeNull();
+  });
+});
+
+describe('resolveVentureContext (FR-4/FR-5)', () => {
+  it('resolves directly by venture_id and returns the support_is_armed flag', async () => {
+    const sb = makeSb({ ventures: [{ id: 'v-1', support_is_armed: true }] });
+    const ctx = await resolveVentureContext(sb, { venture_id: 'v-1' });
+    expect(ctx).toEqual({ venture_id: 'v-1', venture_armed: true, resolved: true });
+  });
+  it('resolves via rail_address when venture_id is not already known', async () => {
+    const sb = makeSb({ ventures: [{ id: 'v-2', support_is_armed: false, support_rail_address: 'billing@acme.example' }] });
+    const ctx = await resolveVentureContext(sb, { rail_address: 'billing@acme.example' });
+    expect(ctx.venture_id).toBe('v-2');
+    expect(ctx.venture_armed).toBe(false);
+    expect(ctx.resolved).toBe(true);
+  });
+  it('unresolvable (no venture_id, no matching rail_address) => venture_id null, resolved false', async () => {
+    const sb = makeSb({ ventures: [] });
+    const ctx = await resolveVentureContext(sb, { rail_address: 'nobody@nowhere.example' });
+    expect(ctx).toEqual({ venture_id: null, venture_armed: false, resolved: false });
+  });
+  it('FAIL-OPEN: a lookup error never throws, degrades to unresolved', async () => {
+    const hostileSb = { from() { throw new Error('db down'); } };
+    const ctx = await resolveVentureContext(hostileSb, { venture_id: 'v-1' });
+    expect(ctx).toEqual({ venture_id: null, venture_armed: false, resolved: false });
   });
 });
 
@@ -102,44 +155,80 @@ describe('triageSupportTicket (FR-2)', () => {
 });
 
 describe('disposeSupportTicket (FR-3)', () => {
-  it('auto_resolve => records a resolved feedback row, status auto_resolved', async () => {
+  it('auto_resolve with a resolved venture_id => records a venture_support_tickets row, status auto_resolved', async () => {
     const sb = makeSb();
-    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide' });
+    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide', venture_id: 'v-1' });
     const triage = triageSupportTicket(ticket);
     const d = await disposeSupportTicket(sb, ticket, triage);
     expect(d.status).toBe('auto_resolved');
-    expect(sb.inserted.some((r) => r.category === 'support_auto_resolved' && r.status === 'resolved')).toBe(true);
+    expect(sb.inserted.some((r) => r.venture_id === 'v-1' && r.status === 'auto_resolved')).toBe(true);
   });
-  it('escalate => writes a surfaced support_escalation feedback row (never dropped)', async () => {
+  it('escalate => writes a surfaced venture_support_tickets row, status escalated (never dropped)', async () => {
     const sb = makeSb();
-    const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach' });
+    const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach', venture_id: 'v-1' });
     const d = await disposeSupportTicket(sb, ticket, triageSupportTicket(ticket));
     expect(d.status).toBe('escalated');
-    expect(sb.inserted.some((r) => r.category === 'support_escalation' && r.status === 'new')).toBe(true);
+    expect(sb.inserted.some((r) => r.venture_id === 'v-1' && r.status === 'escalated')).toBe(true);
+  });
+  it('UNATTRIBUTED: no venture_id forces escalate even when triage says auto_resolve, but is still persisted (venture_id null)', async () => {
+    const sb = makeSb();
+    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide' }); // no venture_id/rail_address
+    const triage = triageSupportTicket(ticket);
+    expect(triage.routing_decision).toBe('auto_resolve'); // triage itself is confident...
+    const d = await disposeSupportTicket(sb, ticket, triage);
+    expect(d.status).toBe('escalated'); // ...but disposition forces escalate: never auto-resolve unattributed
+    expect(d.reason).toMatch(/no venture_id resolved/);
+    expect(sb.inserted.some((r) => r.venture_id === null && r.status === 'escalated')).toBe(true);
   });
   it('DOWNGRADE: an auto_resolve whose record fails ESCALATES instead (re-routed, not dropped)', async () => {
     const sb = makeSb({ failFirstNInserts: 1 }); // the auto-resolution record fails; the escalation write succeeds
-    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide' });
+    const ticket = normalizeSupportTicket({ subject: 'how to setup', body: 'account login guide', venture_id: 'v-1' });
     const triage = triageSupportTicket(ticket);
     expect(triage.routing_decision).toBe('auto_resolve');
     const d = await disposeSupportTicket(sb, ticket, triage);
     expect(d.status).toBe('escalated'); // re-routed, NOT silently dropped
     expect(d.reason).toMatch(/downgraded/);
-    expect(sb.inserted.some((r) => r.category === 'support_escalation')).toBe(true);
+    expect(sb.inserted.some((r) => r.status === 'escalated')).toBe(true);
   });
   it('FAIL-LOUD: a total DB outage (every write fails) throws rather than silently dropping', async () => {
-    const sb = makeSb({ failFeedbackInsert: true });
-    const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach' });
+    const sb = makeSb({ failInsert: true });
+    const ticket = normalizeSupportTicket({ subject: 'URGENT down', body: 'breach', venture_id: 'v-1' });
     await expect(disposeSupportTicket(sb, ticket, triageSupportTicket(ticket))).rejects.toBeTruthy();
   });
 });
 
-describe('single-canonical reuse guard (FR-6)', () => {
-  it('the triage classifier REUSES intake-classifier.js (imports keywordClassify) — no greenfield duplicate', () => {
+describe('runSupportPipeline venture threading (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 TS-1..TS-5)', () => {
+  it('TS-1/TS-2: full run with a resolvable venture rail address => venture_id populated, zero feedback-table writes', async () => {
+    const sb = makeSb({ ventures: [{ id: 'v-3', support_is_armed: false, support_rail_address: 'help@acme.example' }] });
+    const result = await runSupportPipeline(sb, { subject: 'how to setup', body: 'account login guide', rail_address: 'help@acme.example' });
+    expect(result.ticket.venture_id).toBe('v-3');
+    expect(sb.inserted.length).toBeGreaterThan(0);
+    expect(sb.inserted.every((r) => !('category' in r) || r.category !== 'support_auto_resolved')).toBe(true); // no legacy feedback-shaped rows
+  });
+  it('TS-4: unresolvable venture_id escalates rather than auto-resolving', async () => {
+    const sb = makeSb({ ventures: [] });
+    const result = await runSupportPipeline(sb, { subject: 'how to setup', body: 'account login guide' });
+    expect(result.ticket.venture_id).toBeNull();
+    expect(result.disposition.status).toBe('escalated');
+  });
+  it('TS-5: support_is_armed=false still processes the ticket correctly (informational only, not a hard gate)', async () => {
+    const sb = makeSb({ ventures: [{ id: 'v-4', support_is_armed: false }] });
+    const result = await runSupportPipeline(sb, { subject: 'how to setup', body: 'account login guide', venture_id: 'v-4' });
+    expect(result.ticket.venture_armed).toBe(false);
+    expect(result.disposition.status).toBe('auto_resolved'); // armed flag does not block a normal auto-resolve
+  });
+});
+
+describe('venture-scoped persistence guard (SD-FDBK-FIX-SCOPE-VENTURE-SUPPORT-001 TS-6, was FR-6)', () => {
+  it('persistence targets the dedicated venture_support_tickets table, NEVER the shared feedback table; classifier reuse intact', () => {
     const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../../lib/support/intake-pipeline.js'), 'utf8');
+    // still reuses the EVA intake-classifier — no greenfield duplicate (FR-6 original intent preserved)
     expect(src).toMatch(/from '\.\.\/integrations\/intake-classifier\.js'/);
     expect(src).toMatch(/keywordClassify/);
-    // venture-agnostic: no venture-specific branching baked into the pipeline
-    expect(src).not.toMatch(/venture_id|first_venture|venture-specific/i);
+    // venture-SCOPED now (this SD's whole point): venture_id threading is expected and required
+    expect(src).toMatch(/venture_id/);
+    // zero direct writes to the shared harness feedback table
+    expect(src).not.toMatch(/\.from\('feedback'\)/);
+    expect(src).toMatch(/\.from\('venture_support_tickets'\)/);
   });
 });


### PR DESCRIPTION
## Summary
- Stop `lib/support/intake-pipeline.js` from writing venture customer-support tickets into the shared harness `feedback` table (chairman-ratified, deep-dive ed675631 Section 5, Solomon F12)
- Add a new dedicated `venture_support_tickets` table (chairman-gated, staged migration `database/migrations/20260713_venture_support_tickets.sql`), with RLS+policy in the same migration
- Thread `venture_id` through the pipeline via direct attribution or per-venture rail-address resolution (`resolveVentureContext`)
- `disposeSupportTicket` now FORCES escalate (never auto-resolve) when no `venture_id` is resolved — an unattributed ticket is never silently auto-closed
- FIRST CUSTOMER activation stays an explicit, human-armed flag (`ventures.support_is_armed`) rather than auto-detected — informational only, does not block ticket processing
- Fixed a real latent bug found by PLAN_VERIFICATION VALIDATION: the migration's severity CHECK constraint didn't allow `'medium'`, which `triageSupportTicket()` always emits for mid-severity tickets — aligned the constraint to the pipeline's actual (already-tested) taxonomy and added a DB-vocabulary pin test
- Rewrote `tests/unit/support/intake-pipeline.test.js` and `tests/integration/support-intake-pipeline.test.js` for venture-scoped fixtures (34 unit + integration tests, all passing)
- Added `venture_support_tickets` to `scripts/lint/schema-reference-allowlist.json` as a staged-not-applied table

## Test plan
- [x] `npx vitest run tests/unit/support/intake-pipeline.test.js tests/integration/support-intake-pipeline.test.js` — 34/34 passing
- [x] `node scripts/lint/schema-reference-lint.mjs` — 0 violations
- [x] LEAD VALIDATION + RISK, EXEC TESTING, PLAN_VERIFICATION VALIDATION + REGRESSION sub-agent evidence recorded
- [x] SD-completion retrospective recorded (quality 100/100)
- [ ] Chairman apply of the staged migration (separate action) before the pipeline can be wired live

🤖 Generated with [Claude Code](https://claude.com/claude-code)