### PR TITLE
feat(SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001): per-script liveness instrumentation + bare-CLI classification (FR-3/FR-4)

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -567,7 +567,21 @@ async function main() {
 module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, identityNeedsRebroadcast };
 
 if (require.main === module) {
-  main().catch(err => {
+  main().then(async () => {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+    // regardless of which internal early-return branch main() took (e.g. mutation-guard
+    // block or "no active workers found") — reflects loop liveness (the tick ran to
+    // completion), not whether a particular action fired this cycle. main()'s own
+    // `supabase` is local-scoped, so a fresh client is created here per the documented
+    // fallback pattern.
+    try {
+      const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+      const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+      await stampLastFired(createSupabaseServiceClient(), 'standard_loop:identity');
+    } catch (err) {
+      console.error(`[assign-fleet-identities] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  }).catch(err => {
     console.error('Fleet identity assignment failed:', err.message);
     process.exit(1);
   });

--- a/scripts/backfill-bare-cli-expected-active.mjs
+++ b/scripts/backfill-bare-cli-expected-active.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Backfill: classify truly-bare CLIs as currently_expected_active=false
+ * (SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001, FR-4).
+ *
+ * Of the 9 cron_script:* candidate rows investigated during PLAN, 5 have NO invoker found
+ * anywhere (no GHA workflow, no STANDARD_LOOPS/COMPOSED_CORES entry, no programmatic caller --
+ * only an npm alias or a documented not-yet-wired gap):
+ *   - cascade-status.mjs          (only npm alias `cascade:status`)
+ *   - cascade-watcher.mjs         (only npm alias `cascade:watch:cron`)
+ *   - leo-build-starter.mjs       (only a manual slash-command; venture-build-consumer.js:7-8
+ *                                  explicitly documents "NOTHING consumes that signal today")
+ *   - quality-findings-aggregator.mjs (only a cross-reference comment in a separate legacy script)
+ *   - review-self-tune.js         (weakest footprint of all 9 -- no npm alias, only an .rca/ doc mention)
+ *
+ * The other 4 candidates (chairman-decision-sla-sweep.mjs, eva-scheduler-watcher.mjs,
+ * fr-c-generator.mjs, venture-ops-actuals-sweep.mjs) DO have a real GHA cron workflow invoking
+ * them and are deliberately EXCLUDED here -- FR-4's acceptance criteria require rows with a real
+ * invoker to be left as-is, not misclassified. Those 4 need FR-3-style stampLastFired()
+ * instrumentation instead (added directly in their own scripts), not suppression.
+ *
+ * Dry-run by default; --apply performs the update. Idempotent: a second run matches 0 rows
+ * that still need changing.
+ *
+ * Usage:
+ *   node scripts/backfill-bare-cli-expected-active.mjs           # dry run
+ *   node scripts/backfill-bare-cli-expected-active.mjs --apply   # perform the update
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { pathToFileURL } from 'node:url';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export const GENUINELY_BARE_PROCESS_KEYS = [
+  'cron_script:cascade-status.mjs',
+  'cron_script:cascade-watcher.mjs',
+  'cron_script:leo-build-starter.mjs',
+  'cron_script:quality-findings-aggregator.mjs',
+  'cron_script:review-self-tune.js',
+];
+
+export async function run({ apply = false } = {}) {
+  const { data: rows, error } = await supabase
+    .from('periodic_process_registry')
+    .select('process_key, currently_expected_active')
+    .in('process_key', GENUINELY_BARE_PROCESS_KEYS)
+    .eq('currently_expected_active', true);
+
+  if (error) throw new Error(`registry query failed: ${error.message}`);
+
+  const processKeys = (rows || []).map((r) => r.process_key);
+  console.log(`[backfill-bare-cli-expected-active] ${processKeys.length}/${GENUINELY_BARE_PROCESS_KEYS.length} genuinely-bare row(s) still currently_expected_active=true`);
+
+  if (processKeys.length === 0) {
+    console.log('[backfill-bare-cli-expected-active] nothing to do');
+    return { matched: 0, updated: 0 };
+  }
+
+  if (!apply) {
+    console.log('[backfill-bare-cli-expected-active] DRY RUN -- pass --apply to update:');
+    for (const k of processKeys) console.log(`  ${k}`);
+    return { matched: processKeys.length, updated: 0 };
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('periodic_process_registry')
+    .update({ currently_expected_active: false, updated_at: new Date().toISOString() })
+    .in('process_key', processKeys)
+    .select('process_key');
+
+  if (updateError) throw new Error(`update failed: ${updateError.message}`);
+
+  console.log(`[backfill-bare-cli-expected-active] updated ${updated?.length || 0} row(s)`);
+  return { matched: processKeys.length, updated: updated?.length || 0 };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const apply = process.argv.includes('--apply');
+  run({ apply }).catch((err) => {
+    console.error(`[backfill-bare-cli-expected-active] FAILED: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -25,6 +25,7 @@ import { detectLoopExpiry, detectStalledLoop, detectEvaSchedulerStale } from '..
 // same pattern as detectors.cjs above). SSOT shared with stale-session-sweep.cjs (QF-20260525-542).
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
 import { isDependentBlocked } from '../lib/coordinator/dep-readiness.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -232,3 +233,9 @@ try {
   reviewLine = computeReviewHealth({ completedCount: completedNow || 0, lastReviewCount, threshold }).line;
 } catch (e) { reviewLine = 'unavailable (' + e.message + ')'; }
 console.log('  REVIEW HEALTH   : ' + reviewLine);
+
+try {
+  await stampLastFired(db, 'standard_loop:audit');
+} catch (err) {
+  console.error(`[coordinator-audit] stampLastFired failed (non-fatal): ${err.message}`);
+}

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -163,6 +163,7 @@ import { runRollup } from '../lib/vision/rung-progress-rollup.mjs';
 import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
 import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
 import { needleScore, rungProgressByKey, buildSdRungMap } from '../lib/vision/needle-priority.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const DRY = process.argv.includes('--dry-run');
 const PRIORITY_W = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
@@ -569,6 +570,12 @@ async function main() {
       fs.appendFileSync(new URL('rank-pass-events.log', logDir),
         `${JSON.stringify({ at: now, writes, clears, dry: DRY })}\n`);
     } catch { /* observability line must never fail the pass */ }
+  }
+
+  try {
+    await stampLastFired(sb, 'standard_loop:backlog-rank');
+  } catch (err) {
+    console.error(`[BACKLOG-RANK] stampLastFired failed (non-fatal): ${err.message}`);
   }
 }
 

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -32,6 +32,7 @@ import { dirname, join } from 'path';
 // fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
 // counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
 import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the forecaster builds its OWN claimable
 // belt (it does not read the ranker's dispatch_rank), so it must apply the SAME shared claim-eligibility
 // predicate the worker resolver uses — else RHA-held / co_author_pending SDs inflate belt depth and the
@@ -477,6 +478,12 @@ async function main() {
 
   // machine-readable last line for the cron/log (+ sourcing-engine awareness fields, FR-2)
   console.log(`  GAUGE belt=${beltDepth} idle=${idleNow} freeing_soon=${freeingSoon} demand=${demandSoon} deficit=${Math.max(0, deficit)} verdict=${verdict} masked_stall=${maskedIds.size} engine_on=${awareness.anyOn} unpromoted=${awareness.countStr}`);
+
+  try {
+    await stampLastFired(sb, 'standard_loop:capacity-forecast');
+  } catch (err) {
+    console.error(`[capacity-forecast] stampLastFired failed (non-fatal): ${err.message}`);
+  }
 }
 
 function readMaskedCooldown() {

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -49,6 +49,7 @@ import { findLeadAgingDrafts } from '../lib/coordinator/lead-aging-detector.mjs'
 // miscounted as idle WORKERS. detectIdleWithWork only knows "no sd_key" → without this, the coordinator + Adam —
 // which legitimately never hold an SD claim — read as idle workers (a false DUTY-3 no WORK_ASSIGNMENT can clear).
 import { isDispatchableFleetMember } from '../lib/fleet/session-predicates.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const require = createRequire(import.meta.url);
 // SD-LEO-INFRA-FLEET-HIBERNATION-001 FR-2/FR-3: the SINGLE 'line stopped' signal, consumed here so the
@@ -308,6 +309,12 @@ async function main() {
     console.log('  ✓ CHARTER CLEAN — 0 violations');
   }
   console.log('CHARTER_AUDIT_VIOLATIONS=' + summary.count);
+
+  try {
+    await stampLastFired(db, 'standard_loop:charter-audit');
+  } catch (err) {
+    console.error(`[coordinator-charter-audit] stampLastFired failed (non-fatal): ${err.message}`);
+  }
 }
 
 main().catch((err) => { console.error('[COORD-CHARTER-AUDIT] FATAL: ' + ((err && err.message) || err)); process.exit(1); });

--- a/scripts/coordinator-feedback-sla-gauge.cjs
+++ b/scripts/coordinator-feedback-sla-gauge.cjs
@@ -9,6 +9,16 @@ const { remindSlaBreaches } = require('../lib/coordinator/feedback-sla-gauge.cjs
 (async () => {
   const supabase = createSupabaseServiceClient();
   const { breaches, sent } = await remindSlaBreaches(supabase, {});
+
+  // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+  // before the no-breaches/breaches branch (both are a completed tick).
+  try {
+    const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+    await stampLastFired(supabase, 'standard_loop:feedback-sla');
+  } catch (err) {
+    console.error(`[feedback-sla-gauge] stampLastFired failed (non-fatal): ${err.message}`);
+  }
+
   if (breaches.length === 0) {
     console.log('[feedback-sla-gauge] no SLA breaches — all actionable categories consumed within SLA.');
     return;

--- a/scripts/coordinator-fleet-retro.mjs
+++ b/scripts/coordinator-fleet-retro.mjs
@@ -11,6 +11,7 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const t = Date.now();
@@ -50,5 +51,11 @@ const RETRO_RE = /FLEET[\s-]?RETRO/i;
     console.log('[ACTION] Coordinator: cluster these into what-worked / friction / suggestions; ADJUST (wake-up prompt, coordinator behavior, or file a harness SD for recurring friction). Surface a digest to the operator when a clear pattern emerges.');
   } else {
     console.log('(no fleet retros yet — workers emit them at SD completion via /signal)');
+  }
+
+  try {
+    await stampLastFired(db, 'standard_loop:fleet-retro');
+  } catch (err) {
+    console.error(`[FLEET-RETRO] stampLastFired failed (non-fatal): ${err.message}`);
   }
 })();

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -329,7 +329,18 @@ async function main() {
 // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: guard the main() invocation so the Solomon leg can be
 // imported + unit-tested without running the whole hourly review.
 if (require.main === module) {
-  main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
+  main().then(async function () {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+    // regardless of which internal early-return branch main() took (supabase unavailable,
+    // CYCLE-DOWN quiescent, no-live-Adam, dry-run) — reflects loop liveness (the tick ran
+    // to completion), not whether a reminder actually fired this cycle.
+    try {
+      const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+      await stampLastFired(createSupabaseServiceClient(), 'standard_loop:hourly-review');
+    } catch (err) {
+      console.error('[HOURLY-REVIEW] stampLastFired failed (non-fatal): ' + err.message);
+    }
+  }).catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
 }
 
 module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer, reconcileStaleSolomonInbound };

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
 import 'dotenv/config';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const require = createRequire(import.meta.url);
 const { createClient } = require('@supabase/supabase-js');
@@ -255,6 +256,12 @@ async function main() {
     partyOffsetS: COORD_PARTY_OFFSET_S,
     hasUnactionedDirective: unactionedDirective,
   });
+
+  try {
+    await stampLastFired(sb, 'standard_loop:quiet-tick');
+  } catch (err) {
+    console.error(`[coordinator-quiet-tick] stampLastFired failed (non-fatal): ${err.message}`);
+  }
 
   const result = {
     mode: quiescent ? 'QUIESCENT' : 'ACTIVE',

--- a/scripts/coordinator-relay-drain.cjs
+++ b/scripts/coordinator-relay-drain.cjs
@@ -87,7 +87,16 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().catch((e) => {
+  main().then(async () => {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+    // including --dry-run (no queue writes performed, but the tick still ran to completion).
+    try {
+      const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+      await stampLastFired(getSupabase(), 'standard_loop:relay-drain');
+    } catch (err) {
+      console.error(`[coordinator-relay-drain] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  }).catch((e) => {
     console.error('coordinator-relay-drain failed:', (e && e.message) || e);
     process.exit(1);
   });

--- a/scripts/coordinator-relay-drop-gauge.cjs
+++ b/scripts/coordinator-relay-drop-gauge.cjs
@@ -88,7 +88,17 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().catch((e) => {
+  main().then(async () => {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+    // regardless of which internal early-return branch main() took (--dry-run or the
+    // RELAY_DROP_GAUGE_V1 kill-switch) — the read/report leg always ran.
+    try {
+      const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+      await stampLastFired(getSupabase(), 'standard_loop:relay-drop-gauge');
+    } catch (err) {
+      console.error(`[coordinator-relay-drop-gauge] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  }).catch((e) => {
     console.error('coordinator-relay-drop-gauge failed:', (e && e.message) || e);
     process.exit(1);
   });

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -16,6 +16,7 @@ const { insertCoordinationRow, isFullUuid } = createRequire(import.meta.url)('..
 import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-guard.mjs';
 // SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-2: graded coordinator self-score (shared role-agnostic core).
 import { COORDINATOR_CONFIG } from '../lib/coordinator/self-score-config.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 const roleScoreCore = createRequire(import.meta.url)('../lib/governance/role-self-score.cjs');
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -289,5 +290,15 @@ export async function selfReviewMain() {
 
 // Main-guard: run only when invoked directly (the cron path), not on import (tests).
 if (process.argv[1] && /coordinator-self-review\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
-  selfReviewMain();
+  selfReviewMain().then(async () => {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+    // regardless of which internal early-return branch selfReviewMain() took (not-due-by-work,
+    // suppressed-by-min-interval-floor, or full DUE processing) — reflects loop liveness (the
+    // tick ran to completion), not whether a review actually fired this cycle.
+    try {
+      await stampLastFired(db, 'standard_loop:self-review');
+    } catch (err) {
+      console.error(`[COORD-REVIEW] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  });
 }

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -373,7 +373,18 @@ function main() {
     console.warn('⚠️  coordinator-startup-check hiccup (non-blocking, fail-open): ' + (err && err.message ? err.message : String(err)));
   }
   renderColdRecovery(process.argv.slice(2), process.env)
-    .then((out) => console.log(out))
+    .then(async (out) => {
+      console.log(out);
+      // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful
+      // startup-check tick (the report + cold-recovery leg are fail-open by design).
+      try {
+        const { createSupabaseServiceClient } = await import('../lib/supabase-client.cjs');
+        const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+        await stampLastFired(createSupabaseServiceClient(), 'standard_loop:roles-review');
+      } catch (err) {
+        console.warn('[COORD-STARTUP] stampLastFired failed (non-fatal): ' + err.message);
+      }
+    })
     .finally(() => process.exit(0));
 }
 

--- a/scripts/cron/chairman-decision-sla-sweep.mjs
+++ b/scripts/cron/chairman-decision-sla-sweep.mjs
@@ -169,6 +169,11 @@ export async function main(argv = process.argv, deps = {}) {
     const processKey = await ensureArmedRegistration(supabase, logger);
     try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
     catch (err) { logger.warn?.(`[sla-sweep] liveness stamp failed (non-fatal): ${err.message}`); }
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): also stamp the standing GHA-cron
+    // process_key (distinct from the ARMED-machinery key above) so the central liveness
+    // watcher can see this cron loop directly.
+    try { await (deps.stampLastFired || stampLastFired)(supabase, 'cron_script:chairman-decision-sla-sweep.mjs'); }
+    catch (err) { logger.warn?.(`[sla-sweep] cron liveness stamp failed (non-fatal): ${err.message}`); }
   }
 
   // One shared read of the pending set powers both the enforcer filter and the blocking pass.

--- a/scripts/cron/eva-scheduler-watcher.mjs
+++ b/scripts/cron/eva-scheduler-watcher.mjs
@@ -242,6 +242,11 @@ export async function main(argv = process.argv, deps = {}) {
   if (!args.dryRun) {
     try { await (deps.stampLastFired || stampLastFired)(supabase, WATCHER_SELF_PROCESS_KEY); }
     catch (err) { logger.warn?.(`${tag} self-liveness stamp failed (non-fatal): ${err.message}`); }
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): also stamp the standing GHA-cron
+    // process_key (distinct from WATCHER_SELF_PROCESS_KEY above) so the central liveness
+    // watcher can see this cron loop directly.
+    try { await (deps.stampLastFired || stampLastFired)(supabase, 'cron_script:eva-scheduler-watcher.mjs'); }
+    catch (err) { logger.warn?.(`${tag} cron liveness stamp failed (non-fatal): ${err.message}`); }
   }
 
   // 1. Liveness by heartbeat age.

--- a/scripts/cron/fr-c-generator.mjs
+++ b/scripts/cron/fr-c-generator.mjs
@@ -35,6 +35,7 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { generateRemediationSdsBatch, writeAuditLog } from '../../lib/eva/quality-findings/sd-generator.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
 
 const LOCK_NAME = 'fr_c_generator';
 const DEFAULT_INTERVAL_SEC = 3600;
@@ -120,6 +121,13 @@ async function runOneBatch({ supabase, dryRun }) {
 }
 
 async function runOnce({ args, supabase, owner, ttlSec }) {
+  // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): self-stamp BEFORE any lock/generator logic
+  // so a genuine invocation (each runOnce() call, in --daemon or single-shot mode) is always
+  // recorded, even if the lock is held by another tick or the generator errors below (mirrors
+  // scripts/cron/eva-scheduler-watcher.mjs / chairman-decision-sla-sweep.mjs's own convention).
+  try { await stampLastFired(supabase, 'cron_script:fr-c-generator.mjs'); }
+  catch (err) { process.stderr.write(`[fr-c-generator] liveness stamp failed (non-fatal): ${err.message}\n`); }
+
   const acquired = await tryClaimLock(supabase, owner, ttlSec);
   if (!acquired) {
     process.stdout.write('[fr-c-generator] cron lock held by another tick; no-op exit\n');

--- a/scripts/cron/venture-ops-actuals-sweep.mjs
+++ b/scripts/cron/venture-ops-actuals-sweep.mjs
@@ -117,6 +117,15 @@ export async function main(argv = process.argv, deps = {}) {
     return { exitCode: 2, action: 'no_supabase' };
   }
 
+  // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): self-stamp the standing GHA-cron
+  // process_key BEFORE any per-job logic so a genuine invocation is always recorded, even
+  // if the ventures query or a downstream job errors (distinct from the three per-job
+  // ARMED-machinery keys below; mirrors chairman-decision-sla-sweep.mjs's own convention).
+  if (!args.dryRun) {
+    try { await (deps.stampLastFired || stampLastFired)(supabase, 'cron_script:venture-ops-actuals-sweep.mjs'); }
+    catch (err) { logger.warn?.(`[ops-actuals-sweep] cron liveness stamp failed (non-fatal): ${err.message}`); }
+  }
+
   const ventures = await fetchLiveDeploymentVentures(supabase);
   const summary = { ts: new Date().toISOString(), dry_run: args.dryRun, ventures_scanned: ventures.length, jobs: {} };
 

--- a/scripts/flag-governance-review.mjs
+++ b/scripts/flag-governance-review.mjs
@@ -12,6 +12,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { computeStaleFlags, formatDigest } from '../lib/feature-flags/governance-review.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const GATE_FLAG = 'FLAG_GOVERNANCE_REVIEW_V1';
@@ -65,12 +66,21 @@ export async function reviewMain({ force = false } = {}) {
   }
 
   console.log(`[FLAG-GOV] reviewed ${reviewed} flag(s); ${result.stale.length} stale.`);
+
   return { skipped: false, stale: result.stale.length, reviewed };
 }
 
 // Main-guard: run only when invoked directly (the cron path), not on import (tests).
 if (process.argv[1] && /flag-governance-review\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
-  reviewMain({ force: process.argv.includes('--force') }).then((r) => {
-    if (r && r.error) process.exit(1);
+  reviewMain({ force: process.argv.includes('--force') }).then(async (r) => {
+    if (r && r.error) { process.exit(1); return; }
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick
+    // (including the gate-off cheap no-op poll) — reflects loop liveness, not whether
+    // the governance review actually fired this cycle.
+    try {
+      await stampLastFired(db, 'standard_loop:flag-review');
+    } catch (err) {
+      console.error(`[FLAG-GOV] stampLastFired failed (non-fatal): ${err.message}`);
+    }
   });
 }

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -2169,6 +2169,19 @@ async function main() {
 
   await fn();
 
+  // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp the process_key matching
+  // whichever mode actually ran -- 'all' backs standard_loop:dashboard, 'inbox' backs
+  // standard_loop:inbox; other sections (workers, health, etc.) are not registered
+  // periodic processes, so no-op there.
+  if (section === 'all' || section === 'inbox') {
+    try {
+      const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+      await stampLastFired(supabase, section === 'all' ? 'standard_loop:dashboard' : 'standard_loop:inbox');
+    } catch (err) {
+      console.error(`[fleet-dashboard] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  }
+
   if (suppressEnabled) {
     console.log = origLog;
     const out = buf.join('\n');

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -67,6 +67,7 @@ import {
   fetchLastNDispatchedKeys,
   hasOpenFinding,
 } from '../lib/governance/plan-drift-detectors.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const RECURSION_GOVERNOR_DIMENSION = 'recursion-governor-ratio';
 const PLAN_DRIFT_MIX_DIMENSION = 'plan-drift-mix';
@@ -445,6 +446,12 @@ async function main() {
   }
 
   await writeHeartbeat(supabase, results.length);
+
+  try {
+    await stampLastFired(supabase, 'standard_loop:gauge-runner');
+  } catch (err) {
+    console.error(`[gauge-runner] stampLastFired failed (non-fatal): ${err.message}`);
+  }
 
   if (JSON_MODE) console.log(JSON.stringify({ ran: results.length, results }));
   process.exit(0); // advisory: the runner itself never fails the tick

--- a/scripts/gauge-unranked-claimable-leaves.mjs
+++ b/scripts/gauge-unranked-claimable-leaves.mjs
@@ -25,6 +25,7 @@ import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const require = createRequire(import.meta.url);
 const { DISPATCH_RANK_TTL_MS } = require('./worker-checkin.cjs');
@@ -85,5 +86,13 @@ async function main() {
 
 // process.argv[1] is undefined under `node -e`/some loaders, so guard it before pathToFileURL.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
+  main().then(async () => {
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every completed tick, including
+    // the fail-open "transient read error" branch (advisory gauge — the tick still ran).
+    try {
+      await stampLastFired(sb, 'standard_loop:unranked-gauge');
+    } catch (err) {
+      console.error(`[UNRANKED-GAUGE] stampLastFired failed (non-fatal): ${err.message}`);
+    }
+  });
 }

--- a/scripts/retention-enforce.js
+++ b/scripts/retention-enforce.js
@@ -37,6 +37,7 @@ import {
   BATCH_SIZE, DELETE_CHUNK, LIVENESS_MAX_AGE_DAYS,
 } from '../lib/retention/policies.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 dotenv.config();
 
@@ -170,6 +171,13 @@ export async function runEnforcement({ apply = false } = {}) {
   } else {
     console.log('  ✓ retention_runs stamp written');
   }
+
+  try {
+    await stampLastFired(supabase, 'standard_loop:retention');
+  } catch (err) {
+    console.warn(`  ⚠ stampLastFired failed (non-fatal): ${err.message}`);
+  }
+
   return anyError ? 1 : 0;
 }
 

--- a/scripts/row-growth-snapshot.cjs
+++ b/scripts/row-growth-snapshot.cjs
@@ -118,6 +118,17 @@ if (require.main === module) {
   // sockets and lets the loop drain naturally, with an unref'd 8s backstop. Exit code is
   // always 0 — a gauge never breaks its host loop.
   main()
+    .then(async () => {
+      // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+      // regardless of which internal early-return branch main() took (not-due, no
+      // estimates readable, first baseline, or no anomalies) — reflects loop liveness.
+      try {
+        const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+        await stampLastFired(createSupabaseServiceClient(), 'standard_loop:row-growth');
+      } catch (err) {
+        console.warn(`[row-growth] stampLastFired failed (non-fatal): ${err.message}`);
+      }
+    })
     .catch((e) => { console.warn(`[row-growth] unexpected error (non-fatal): ${e.message}`); })
     .finally(async () => {
       try {

--- a/scripts/scripts-reachability-gauge.mjs
+++ b/scripts/scripts-reachability-gauge.mjs
@@ -293,6 +293,18 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   // drains naturally with an unref'd backstop. Exit code always 0 — a gauge never
   // breaks its host loop.
   main()
+    .then(async () => {
+      // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+      // regardless of which internal early-return branch main() took (not-due, or no
+      // growth/no broken aliases) — reflects loop liveness.
+      try {
+        const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+        const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+        await stampLastFired(createSupabaseServiceClient(), 'standard_loop:scripts-reachability');
+      } catch (err) {
+        console.warn(`[scripts-reachability] stampLastFired failed (non-fatal): ${err.message}`);
+      }
+    })
     .catch((e) => { console.warn(`[scripts-reachability] unexpected error (non-fatal): ${e.message}`); })
     .finally(async () => {
       try {

--- a/scripts/singleton-relaunch-scheduler.mjs
+++ b/scripts/singleton-relaunch-scheduler.mjs
@@ -15,6 +15,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { evaluateAllSingletons } from '../lib/coordinator/singleton-relaunch-trigger.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const ENABLED = process.env.SINGLETON_RELAUNCH_SCHEDULING_ENABLED === 'true';
 
@@ -37,6 +38,12 @@ async function main() {
     const behind = r.freshness ? r.freshness.behind : '?';
     console.log(`[singleton-relaunch-scheduler] role=${r.role} scheduled=${r.scheduled} reason=${r.reason} behind=${behind} loop_state=${r.loopState}`);
     if (r.error) console.error(`[singleton-relaunch-scheduler] role=${r.role} write error: ${r.error}`);
+  }
+
+  try {
+    await stampLastFired(supabase, 'standard_loop:singleton-relaunch');
+  } catch (err) {
+    console.error(`[singleton-relaunch-scheduler] stampLastFired failed (non-fatal): ${err.message}`);
   }
 }
 

--- a/scripts/solomon-ledger-pending-resurface.cjs
+++ b/scripts/solomon-ledger-pending-resurface.cjs
@@ -89,6 +89,15 @@ async function main() {
   let supabase;
   try { supabase = createSupabaseServiceClient(); }
   catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+  // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick, before
+  // the no-active-Adam early-return (both are a completed tick — supabase is already live here).
+  try {
+    const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+    await stampLastFired(supabase, 'standard_loop:solomon-ledger-resurface');
+  } catch (err) {
+    console.error(`[solomon-ledger-pending-resurface] stampLastFired failed (non-fatal): ${err.message}`);
+  }
+
   const adamId = await getActiveAdamId(supabase);
   if (!adamId) { console.log('SOLOMON LEDGER PENDING RESURFACE: no active Adam session found — nothing to resurface into.'); return; }
   const thresholdHours = parseThresholdHours(process.argv.slice(2));

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -3140,10 +3140,26 @@ function planDeadLetters(unreadMsgs, { allSessionIds, deadIds }, nowMs) {
     }));
 }
 
+// SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful sweep tick,
+// regardless of which internal early-return branch main() took (e.g. the "no sessions with
+// claims" all-clear path) — this reflects loop liveness (the tick ran to completion), not
+// whether any particular action fired this cycle. Kept as its own named function (rather than
+// inlined in the .then() below) so main().then(...) stays a short chain with its rejection
+// handler close by -- see tests/unit/stale-session-sweep-builder-catch.test.js's regression
+// guard for the FATAL crash class this file was previously fixed for.
+async function stampSweepLiveness() {
+  try {
+    const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+    await stampLastFired(supabase, 'standard_loop:sweep');
+  } catch (err) {
+    console.error(`[stale-session-sweep] stampLastFired failed (non-fatal): ${err.message}`);
+  }
+}
+
 // SD-FDBK-INFRA-CROSS-SESSION-CONFLICTION-001 / FR-2: guard auto-run so the pure
 // collision functions can be imported by unit tests without main() hitting the DB.
 if (require.main === module) {
-  main().catch(err => {
+  main().then(stampSweepLiveness).catch(err => {
     console.error('SWEEP FATAL:', err.message);
     process.exit(1);
   });

--- a/scripts/subsystem-review-rotation.cjs
+++ b/scripts/subsystem-review-rotation.cjs
@@ -80,6 +80,17 @@ if (require.main === module) {
   // Graceful bounded exit: avoid the Windows UV_HANDLE_CLOSING abort after undici
   // queries (same primitive as row-growth-snapshot.cjs).
   main()
+    .then(async () => {
+      // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful tick,
+      // regardless of which internal early-return branch main() took (not-due, empty
+      // rotation, or --dry-run) — reflects loop liveness.
+      try {
+        const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+        await stampLastFired(createSupabaseServiceClient(), 'standard_loop:review-rotation');
+      } catch (err) {
+        console.warn(`[review-rotation] stampLastFired failed (non-fatal): ${err.message}`);
+      }
+    })
     .catch((e) => { console.warn(`[review-rotation] unexpected error (non-fatal): ${e.message}`); })
     .finally(async () => {
       try {

--- a/tests/unit/cron/venture-ops-actuals-sweep.test.js
+++ b/tests/unit/cron/venture-ops-actuals-sweep.test.js
@@ -84,7 +84,11 @@ describe('venture-ops-actuals-sweep main()', () => {
     expect(collectProductHealth).toHaveBeenCalledTimes(2);
     expect(collectRevenueMetrics).toHaveBeenCalledTimes(2);
     expect(runVentureUptimeProbe).toHaveBeenCalledTimes(1);
-    expect(stampLastFired).toHaveBeenCalledTimes(3); // one per job
+    // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): a 4th whole-tick stamp
+    // ('cron_script:venture-ops-actuals-sweep.mjs') was added before the per-job stamps, distinct
+    // from the three per-job ARMED-machinery keys asserted below.
+    expect(stampLastFired).toHaveBeenCalledTimes(4);
+    expect(stampLastFired.mock.calls.some(([, key]) => key === 'cron_script:venture-ops-actuals-sweep.mjs')).toBe(true);
     expect(result.summary.jobs['ops-product-health-collector'].written).toBe(2);
     expect(result.summary.jobs['ops-revenue-metrics-collector'].written).toBe(2);
     expect(result.exitCode).toBe(0);

--- a/tests/unit/periodic-liveness/fr3-instrumentation-wiring.test.js
+++ b/tests/unit/periodic-liveness/fr3-instrumentation-wiring.test.js
@@ -1,0 +1,88 @@
+/**
+ * SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3, TS-4) -- static wiring coverage over the ~29
+ * distinct scripts backing the 26 standard_loop:* registry rows plus the 4 cron_script:* rows
+ * with a real GHA invoker (per PLAN-phase investigation). Asserts each script's SOURCE references
+ * stampLastFired and its correct process_key literal(s), rather than actually executing 29
+ * fleet-coordination scripts (which would fire real DB writes / session messages) -- pattern
+ * mirrors tests/unit/cron/venture-ops-actuals-wiring.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function src(relPath) {
+  const full = path.join(repoRoot, relPath);
+  expect(fs.existsSync(full), `missing instrumented script: ${relPath}`).toBe(true);
+  return fs.readFileSync(full, 'utf8');
+}
+
+// file -> process_key(s) it must reference alongside a stampLastFired call.
+const STANDARD_LOOP_SCRIPTS = {
+  'scripts/stale-session-sweep.cjs': ['standard_loop:sweep'],
+  'scripts/coordinator-quiet-tick.mjs': ['standard_loop:quiet-tick'],
+  'scripts/fleet-dashboard.cjs': ['standard_loop:dashboard', 'standard_loop:inbox'],
+  'scripts/assign-fleet-identities.cjs': ['standard_loop:identity'],
+  'scripts/coordinator-audit.mjs': ['standard_loop:audit'],
+  'scripts/coordinator-charter-audit.mjs': ['standard_loop:charter-audit'],
+  'scripts/flag-governance-review.mjs': ['standard_loop:flag-review'],
+  'scripts/coordinator-self-review.mjs': ['standard_loop:self-review'],
+  'scripts/coordinator-hourly-review.cjs': ['standard_loop:hourly-review'],
+  'scripts/coordinator-capacity-forecast.mjs': ['standard_loop:capacity-forecast'],
+  'scripts/coordinator-backlog-rank.mjs': ['standard_loop:backlog-rank'],
+  'scripts/gauge-unranked-claimable-leaves.mjs': ['standard_loop:unranked-gauge'],
+  'scripts/singleton-relaunch-scheduler.mjs': ['standard_loop:singleton-relaunch'],
+  'scripts/coordinator-relay-drain.cjs': ['standard_loop:relay-drain'],
+  'scripts/coordinator-relay-drop-gauge.cjs': ['standard_loop:relay-drop-gauge'],
+  'scripts/coordinator-fleet-retro.mjs': ['standard_loop:fleet-retro'],
+  'scripts/row-growth-snapshot.cjs': ['standard_loop:row-growth'],
+  'scripts/subsystem-review-rotation.cjs': ['standard_loop:review-rotation'],
+  'scripts/scripts-reachability-gauge.mjs': ['standard_loop:scripts-reachability'],
+  'scripts/retention-enforce.js': ['standard_loop:retention'],
+  'scripts/coordinator-startup-check.mjs': ['standard_loop:roles-review'],
+  'scripts/gauge-runner.mjs': ['standard_loop:gauge-runner'],
+  'scripts/coordinator-feedback-sla-gauge.cjs': ['standard_loop:feedback-sla'],
+  'scripts/solomon-ledger-pending-resurface.cjs': ['standard_loop:solomon-ledger-resurface'],
+  'scripts/periodic-liveness-watcher.mjs': ['standard_loop:liveness-watcher'],
+};
+
+const CRON_SCRIPT_SCRIPTS = {
+  'scripts/cron/chairman-decision-sla-sweep.mjs': ['cron_script:chairman-decision-sla-sweep.mjs'],
+  'scripts/cron/eva-scheduler-watcher.mjs': ['cron_script:eva-scheduler-watcher.mjs'],
+  'scripts/cron/fr-c-generator.mjs': ['cron_script:fr-c-generator.mjs'],
+  'scripts/cron/venture-ops-actuals-sweep.mjs': ['cron_script:venture-ops-actuals-sweep.mjs'],
+};
+
+describe('FR-3: every standard_loop:* backing script self-stamps', () => {
+  for (const [file, keys] of Object.entries(STANDARD_LOOP_SCRIPTS)) {
+    it(`${file} references stampLastFired and its process_key(s)`, () => {
+      const content = src(file);
+      expect(content, `${file} does not reference stampLastFired`).toMatch(/stampLastFired/);
+      for (const key of keys) {
+        expect(content, `${file} does not reference process_key '${key}'`).toContain(key);
+      }
+    });
+  }
+
+  it('covers all 26 standard_loop:* keys across the 25 distinct scripts (one script, fleet-dashboard.cjs, backs two)', () => {
+    expect(Object.keys(STANDARD_LOOP_SCRIPTS)).toHaveLength(25);
+    const allKeys = Object.values(STANDARD_LOOP_SCRIPTS).flat();
+    expect(allKeys).toHaveLength(26);
+    expect(new Set(allKeys).size).toBe(26);
+  });
+});
+
+describe('FR-3 extension: the 4 cron_script:* rows with a real GHA invoker also self-stamp', () => {
+  for (const [file, keys] of Object.entries(CRON_SCRIPT_SCRIPTS)) {
+    it(`${file} references stampLastFired and its process_key`, () => {
+      const content = src(file);
+      expect(content, `${file} does not reference stampLastFired`).toMatch(/stampLastFired/);
+      for (const key of keys) {
+        expect(content, `${file} does not reference process_key '${key}'`).toContain(key);
+      }
+    });
+  }
+});

--- a/tests/unit/scripts/backfill-bare-cli-expected-active.test.js
+++ b/tests/unit/scripts/backfill-bare-cli-expected-active.test.js
@@ -1,0 +1,61 @@
+/**
+ * SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-4) -- scripts/backfill-bare-cli-expected-active.mjs
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = { activeBareRows: [] };
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from() {
+      const chain = {
+        select: () => chain,
+        in: () => chain,
+        eq: () => chain,
+        update: () => chain,
+        then: (resolve) => resolve({ data: state.activeBareRows, error: null }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+const { run, GENUINELY_BARE_PROCESS_KEYS } = await import('../../../scripts/backfill-bare-cli-expected-active.mjs');
+
+describe('backfill-bare-cli-expected-active', () => {
+  it('the genuinely-bare list is exactly the 5 confirmed rows -- the 4 with a real GHA invoker are deliberately excluded', () => {
+    expect(GENUINELY_BARE_PROCESS_KEYS).toEqual([
+      'cron_script:cascade-status.mjs',
+      'cron_script:cascade-watcher.mjs',
+      'cron_script:leo-build-starter.mjs',
+      'cron_script:quality-findings-aggregator.mjs',
+      'cron_script:review-self-tune.js',
+    ]);
+    // Explicitly NOT included -- these have a real GHA cron invoker (FR-4 acceptance criteria:
+    // rows confirmed to have a real invoker must be left as-is, not misclassified).
+    for (const excluded of [
+      'cron_script:chairman-decision-sla-sweep.mjs',
+      'cron_script:eva-scheduler-watcher.mjs',
+      'cron_script:fr-c-generator.mjs',
+      'cron_script:venture-ops-actuals-sweep.mjs',
+    ]) {
+      expect(GENUINELY_BARE_PROCESS_KEYS).not.toContain(excluded);
+    }
+  });
+
+  beforeEach(() => {
+    state.activeBareRows = GENUINELY_BARE_PROCESS_KEYS.map((process_key) => ({ process_key, currently_expected_active: true }));
+  });
+
+  it('dry run reports matched rows without updating', async () => {
+    const result = await run({ apply: false });
+    expect(result.matched).toBe(5);
+    expect(result.updated).toBe(0);
+  });
+
+  it('nothing to do once all 5 are already currently_expected_active=false', async () => {
+    state.activeBareRows = [];
+    const result = await run({ apply: false });
+    expect(result).toEqual({ matched: 0, updated: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- FR-3: instruments the 25 distinct scripts backing the 26 `standard_loop:*` registry rows (the coordinator has no single shared runner -- each STANDARD_LOOPS entry is independently armed via ~20 distinct backing scripts, per LEAD-phase investigation that corrected the SD's original "one call in one runner" premise), each self-stamping via the existing `stampLastFired()` helper at the point its tick completes.
- FR-3 extension: also instruments the 4 `cron_script:*` rows independently confirmed (during FR-4's investigation) to have a real GitHub Actions cron invoker but no self-stamp yet -- otherwise they'd stay permanently UNVERIFIED despite being genuinely alive, undermining this SD's own witness metric.
- FR-4: classifies the 5 `cron_script:*` rows confirmed to have **no invoker anywhere** (only an npm alias, or a documented not-yet-wired gap) as `currently_expected_active=false` via a data backfill script. The 4 rows WITH a real invoker are deliberately left active and get instrumented above instead of suppressed (FR-4 acceptance criteria: never misclassify a row with a real invoker).

Part 2 of 2 for this SD. Part 1 (FR-1/FR-2/FR-5, #6059) already merged to `main` -- this branch's parent commit is that merge, re-pointed at `main` directly after #6060 was auto-closed when its stacked base branch was deleted post-merge (commits unaffected, same two commits, just retargeted).

## Test plan
- [x] Static wiring test (`fr3-instrumentation-wiring.test.js`) asserts all 29 scripts reference `stampLastFired` and their correct `process_key` literal(s) -- no live execution of 29 fleet-coordination scripts (which would fire real DB writes / session messages)
- [x] `backfill-bare-cli-expected-active` unit tests pin the exact 5-row genuinely-bare list and confirm the 4 real-invoker rows are excluded
- [x] One pre-existing test (`venture-ops-actuals-sweep.test.js`) updated for the legitimate 4th stamp call this SD adds
- [x] `node --check` on all 28 touched scripts
- [x] Full `periodic-liveness` + `cron` + `coordinator` + `scripts` + `sweep` + `governance` test directories re-run against the combined FR-1..FR-5 tree -- 1769 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)