### PR TITLE
fix(SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001): dispatch-eligibility fails closed on lead_blocker and factory-lane markers

### DIFF
--- a/database/migrations/20260713_quick_fixes_factory_lane.sql
+++ b/database/migrations/20260713_quick_fixes_factory_lane.sql
@@ -1,0 +1,36 @@
+-- Migration: Add factory_lane to quick_fixes table
+-- Purpose: Structured, machine-readable marker for "coordinator-dispatch only,
+--          not worker-self-claimable" quick-fixes. Previously this class of QF
+--          (e.g. QF-20260712-481, routed through the venture machine) was
+--          encoded ONLY as free text inside the description column
+--          ("FACTORY-LANE: ..."), invisible to scripts/worker-checkin.cjs's
+--          isAutoStartableQF() self-claim predicate, which self-claimed it
+--          anyway.
+-- Created: 2026-07-13
+-- Related: SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001
+-- @staged: additive, LEAD RISK-cleared as safe to apply live (not content-gated,
+--          precedent 20260705_quick_fixes_not_before.sql on the same table) --
+--          but the actual apply still requires the canonical authorized-apply
+--          handshake (scripts/apply-migration.js --prod-deploy with either a
+--          genuine chairman -- @approved-by: <email> header or a genuine
+--          Adam-delegated -- @delegated-by: adam token apply), which a LEO
+--          fleet worker session cannot self-stamp. A human/coordinator/Adam
+--          must run the apply (+ the QF-20260712-481 backfill below) after
+--          this PR merges.
+
+BEGIN;
+
+-- Structured factory-lane marker (default false = no behavior change for any
+-- pre-existing row not explicitly marked).
+ALTER TABLE quick_fixes
+ADD COLUMN IF NOT EXISTS factory_lane BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN quick_fixes.factory_lane IS
+  'Structured marker: TRUE means this quick-fix is coordinator-dispatch-only
+   (e.g. routes through the venture machine) and must be excluded from worker
+   self-claim (scripts/worker-checkin.cjs isAutoStartableQF()). Default false.';
+
+COMMIT;
+
+-- Rollback:
+-- ALTER TABLE quick_fixes DROP COLUMN IF EXISTS factory_lane;

--- a/lib/coordinator/clear-coordinator-review.js
+++ b/lib/coordinator/clear-coordinator-review.js
@@ -24,6 +24,16 @@ import { triggerRankPass } from './trigger-rank-pass.mjs';
 /**
  * buildClearReviewQuery — pure helper: the exact atomic-merge SQL/params. Extracted for
  * unit testing without a live pg connection.
+ *
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: the WHERE clause now ALSO guards on
+ * metadata.lead_blocker NOT being active, so a still-lead_blocker-active SD can never have its
+ * needs_coordinator_review flag cleared out from under it (closes the live G1 "RE-FENCE #3" bug).
+ * This guard is folded into the SAME atomic UPDATE...WHERE (never a separate SELECT-then-UPDATE)
+ * per LEAD RISK: a read-then-write here would reintroduce the exact TOCTOU race this module's
+ * atomic-merge design was built to avoid. The fail-closed truthiness matrix mirrors
+ * lib/fleet/claim-eligibility.cjs's isLeadBlockerActive() EXACTLY (TR-2): a row's lead_blocker is
+ * "not active" (guard passes) only when the key is absent/SQL-null, the JSON value is literally
+ * false, or it is a string that trims to empty -- every other shape blocks the clear.
  * @param {string} sdKey
  * @returns {{sql: string, params: any[]}}
  */
@@ -33,7 +43,14 @@ export function buildClearReviewQuery(sdKey) {
   // blob while still reporting success. metadata is nullable (default '{}'::jsonb); COALESCE
   // makes the merge safe regardless of the column's current value.
   return {
-    sql: "UPDATE strategic_directives_v2 SET metadata = COALESCE(metadata, '{}'::jsonb) || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1",
+    sql: `UPDATE strategic_directives_v2
+          SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"needs_coordinator_review": false}'::jsonb
+          WHERE sd_key = $1
+            AND (
+              metadata->'lead_blocker' IS NULL
+              OR metadata->'lead_blocker' = 'false'::jsonb
+              OR (jsonb_typeof(metadata->'lead_blocker') = 'string' AND trim(metadata->>'lead_blocker') = '')
+            )`,
     params: [sdKey],
   };
 }
@@ -67,8 +84,16 @@ export async function clearCoordinatorReview(sdKey, opts = {}) {
     const cleared = result.rowCount > 0;
     if (cleared) {
       triggerFn({ reason: 'clear_coordinator_review', sdKey });
+      return { cleared: true, sdKey };
     }
-    return { cleared, sdKey, ...(cleared ? {} : { error: 'no_matching_row' }) };
+    // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: the atomic UPDATE above already made the ONLY
+    // decision that matters (clear or refuse) — this follow-up SELECT is purely for a more useful
+    // error message and does NOT reintroduce a TOCTOU race (nothing decision-relevant depends on
+    // its result; the clear was already correctly refused or the row was already confirmed absent
+    // by the UPDATE's own WHERE evaluation).
+    const { rows } = await client.query('SELECT 1 FROM strategic_directives_v2 WHERE sd_key = $1', [sdKey]);
+    const error = rows.length > 0 ? 'refused_lead_blocker_active' : 'no_matching_row';
+    return { cleared: false, sdKey, error };
   } catch (queryErr) {
     return { cleared: false, sdKey, error: queryErr.message };
   } finally {

--- a/lib/coordinator/clear-coordinator-review.js
+++ b/lib/coordinator/clear-coordinator-review.js
@@ -48,6 +48,7 @@ export function buildClearReviewQuery(sdKey) {
           WHERE sd_key = $1
             AND (
               metadata->'lead_blocker' IS NULL
+              OR metadata->'lead_blocker' = 'null'::jsonb
               OR metadata->'lead_blocker' = 'false'::jsonb
               OR (jsonb_typeof(metadata->'lead_blocker') = 'string' AND trim(metadata->>'lead_blocker') = '')
             )`,

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -30,6 +30,16 @@
  * self_claim/evaluate paths use draftDepsSatisfied).
  */
 
+// SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: pure fail-closed truthiness classifier for
+// metadata.lead_blocker. Recognized-INACTIVE shapes: absent, null, false, '', or a whitespace-only
+// string. Every other shape (object -- the live producer convention -- non-empty string, true,
+// number, array) is ACTIVE. Never silently coerces an unrecognized/malformed shape to inactive.
+function isLeadBlockerActive(value) {
+  if (value === undefined || value === null || value === false) return false;
+  if (typeof value === 'string' && value.trim() === '') return false;
+  return true;
+}
+
 /** Test-fixture key families that must never be dispatched onto a worker. Word-boundary anchored so
  *  real keys that merely START with these letters (SD-TESTABLE-*, SD-DEMONSTRATE-*) are NOT excluded.
  *  QF-20260703-773: the SD- prefix is OPTIONAL -- some fixtures (e.g. tests/integration/migrations/
@@ -211,6 +221,17 @@ const INELIGIBILITY_AXES = [
   // so a fleet_critical-AND-review-pending SD is correctly surfaced-then-EXCLUDED (the hold wins).
   function needsCoordinatorReview(row) {
     return (row.metadata && row.metadata.needs_coordinator_review === true) ? 'needs_coordinator_review' : null;
+  },
+  // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: metadata.lead_blocker (a LEAD circuit-breaker
+  // bubble-up marker -- see CLAUDE_LEAD.md) was PRODUCED but never READ by any dispatch path --
+  // only needs_coordinator_review was checked, so a clear-review of a stale needs_coordinator_review
+  // flag let a still-lead_blocker-active SD (SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G1) slip past
+  // dispatch (live incident, documented in the SD's own metadata.coordinator_review_reason as
+  // "RE-FENCE #3"). FAIL-CLOSED truthiness (isLeadBlockerActive below): only absent/null/false/''/
+  // whitespace-only-string is recognized as inactive -- ANY other shape (object, non-empty string,
+  // true, number, array) is treated as active/fenced, never silently coerced to "not blocking."
+  function leadBlockerActive(row) {
+    return (row.metadata && isLeadBlockerActive(row.metadata.lead_blocker)) ? 'lead_blocker_active' : null;
   },
   // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture's build-tree (orchestrator +
   // children + grandchildren, stamped metadata.test_clone_build_tree=true at creation by
@@ -620,7 +641,7 @@ function execBoundaryHoldReason(sdRow) {
 // one_way door (documented directed-assign exemption in the oneWayDoor axis comment above).
 // GUARDRAIL (SD-LEO-INFRA-PHASE-SCOPED-FENCE-001): do NOT add exec_boundary_hold here either
 // -- same reasoning as the INELIGIBILITY_AXES guardrail above.
-const CLAIM_WRITE_FENCE_AXES = new Set(['human_action_required', 'needs_coordinator_review', 'not_before_hold']);
+const CLAIM_WRITE_FENCE_AXES = new Set(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active']);
 
 /**
  * Live fence re-check at the claim-WRITE boundary (QF-20260711-272). Re-fetches the SD row so a
@@ -649,4 +670,4 @@ async function liveClaimWriteFenceReason(sb, sdKey) {
   }
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive };

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -348,7 +348,7 @@ export async function loadOpenQuickFixes(supabase) {
     // Race-safety: exclude rows where pr_url or commit_sha are populated. A parallel session
     // populates those fields the moment complete-quick-fix.js begins, ~30-90s before status flips
     // to 'completed'. Filtering on status alone surfaces phantom QFs during the merge window.
-    // schema-lint-disable-line: factory_lane is a staged, not-yet-applied column
+    // factory_lane is a staged, not-yet-applied column
     // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- see
     // scripts/worker-checkin.cjs selfClaimQuickFix() for the identical fail-soft
     // rationale. SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: without this, the
@@ -356,10 +356,14 @@ export async function loadOpenQuickFixes(supabase) {
     // factory_lane and would still emit AUTO_PROCEED_ACTION:qf_start for a
     // coordinator-dispatch-only QF -- the same bug class this SD fixes, via the
     // recommendation path instead of the automated self-claim loop (adversarial
-    // review finding, /ship deep-tier pass).
+    // review finding, /ship deep-tier pass). The pragma below MUST stay on the
+    // same physical line as .select( -- schema-reference-extract.mjs's pragmaAt()
+    // only checks the line containing the .select( match itself (RCA'd during
+    // this SD's own round-2 adversarial review after the pragma-on-its-own-line
+    // form above silently failed to suppress the lint).
     const { data, error } = await supabase
       .from('quick_fixes')
-      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane')
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane') // schema-lint-disable-line: factory_lane staged, see comment above
       .in('status', ['open', 'in_progress'])
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -348,9 +348,18 @@ export async function loadOpenQuickFixes(supabase) {
     // Race-safety: exclude rows where pr_url or commit_sha are populated. A parallel session
     // populates those fields the moment complete-quick-fix.js begins, ~30-90s before status flips
     // to 'completed'. Filtering on status alone surfaces phantom QFs during the merge window.
+    // schema-lint-disable-line: factory_lane is a staged, not-yet-applied column
+    // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- see
+    // scripts/worker-checkin.cjs selfClaimQuickFix() for the identical fail-soft
+    // rationale. SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: without this, the
+    // sd:next recommendation path (classifyQuickFixes -> topStartableQF) can't see
+    // factory_lane and would still emit AUTO_PROCEED_ACTION:qf_start for a
+    // coordinator-dispatch-only QF -- the same bug class this SD fixes, via the
+    // recommendation path instead of the automated self-claim loop (adversarial
+    // review finding, /ship deep-tier pass).
     const { data, error } = await supabase
       .from('quick_fixes')
-      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before')
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane')
       .in('status', ['open', 'in_progress'])
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -138,7 +138,13 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
     const notBeforeMs = qf.not_before ? Date.parse(qf.not_before) : NaN;
     const deferred = Number.isFinite(notBeforeMs) && notBeforeMs > Date.now();
 
-    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther, _verifyFirst: verifyFirst, _deferred: deferred };
+    // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: mirrors the isAutoStartableQF()
+    // factory_lane guard in worker-checkin.cjs. Without this, topStartableQF (and
+    // therefore AUTO_PROCEED_ACTION:qf_start) could recommend a coordinator-
+    // dispatch-only QF the automated self-claim loop already refuses.
+    const factoryLane = qf.factory_lane === true;
+
+    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther, _verifyFirst: verifyFirst, _deferred: deferred, _factoryLane: factoryLane };
   });
 
   classified.sort((a, b) => {
@@ -157,7 +163,7 @@ export function classifyQuickFixes(quickFixes, triageResults = new Map(), sessio
   // => claiming_session_id null, no PR) would otherwise be emitted as AUTO_PROCEED_ACTION:
   // qf_start and auto-started without verify-first. in_progress is either actively owned or
   // orphaned; neither is auto-startable.
-  summary.topStartableQF = classified.find(qf => qf.status === 'open' && !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst && !qf._deferred) || null;
+  summary.topStartableQF = classified.find(qf => qf.status === 'open' && !qf._escalate && !qf._isClaimedByOther && !qf._verifyFirst && !qf._deferred && !qf._factoryLane) || null;
 
   return { summary, classified };
 }
@@ -192,13 +198,18 @@ export function renderQFRow(qf, indent = '') {
     const verifyBadge = qf._verifyFirst ? `${colors.yellow}⚠ VERIFY-FIRST${colors.reset} ` : '';
     // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: surface a durable time-gated defer.
     const deferBadge = qf._deferred ? `${colors.yellow}⏳ DEFERRED${colors.reset} ` : '';
-    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${verifyBadge}${deferBadge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+    // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: surface the coordinator-dispatch-only marker.
+    const factoryLaneBadge = qf._factoryLane ? `${colors.yellow}🏭 FACTORY-LANE${colors.reset} ` : '';
+    console.log(`${indent}  ${colors.bold}${tierBadge}${colors.reset} ${badge}${verifyBadge}${deferBadge}${factoryLaneBadge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
     console.log(`${indent}       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
     if (qf._verifyFirst) {
       console.log(`${indent}       ${colors.dim}⚠ open ${ageDays(qf.created_at)}d & unclaimed — may already be resolved by another SD; verify before starting (not auto-routed)${colors.reset}`);
     }
     if (qf._deferred) {
       console.log(`${indent}       ${colors.dim}⏳ gated until ${qf.not_before} — not claimable/auto-startable until then${colors.reset}`);
+    }
+    if (qf._factoryLane) {
+      console.log(`${indent}       ${colors.dim}🏭 coordinator-dispatch only — not claimable/auto-startable by a worker${colors.reset}`);
     }
   }
 }

--- a/scripts/one-off/backfill-qf-20260712-481-factory-lane.mjs
+++ b/scripts/one-off/backfill-qf-20260712-481-factory-lane.mjs
@@ -1,0 +1,31 @@
+/**
+ * One-off backfill: QF-20260712-481.factory_lane = true.
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001 FR-5.
+ *
+ * RUN ONLY AFTER database/migrations/20260713_quick_fixes_factory_lane.sql has
+ * been applied live (requires chairman/Adam-delegated authorization -- see the
+ * migration's @staged header). Idempotent: safe to re-run.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const { data, error } = await supabase
+  .from('quick_fixes')
+  .update({ factory_lane: true })
+  .eq('id', 'QF-20260712-481')
+  .select('id, factory_lane');
+
+if (error) {
+  console.error('Backfill failed:', error.message);
+  process.exit(1);
+}
+if (!data || data.length === 0) {
+  console.error('QF-20260712-481 not found -- nothing backfilled.');
+  process.exit(1);
+}
+console.log('Backfilled:', JSON.stringify(data[0]));

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -580,15 +580,20 @@ function isAutoStartableQF(qf, nowMs) {
  */
 async function selfClaimQuickFix(sb, sessionId, base) {
   try {
+    // factory_lane is a staged, not-yet-applied column
+    // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- until a human/coordinator
+    // applies it, this SELECT fails soft (data undefined -> sortQfCandidatesBySeverity's (qfs||[])
+    // -> no QF self-claimed this tick), the same documented fail-open contract this function
+    // already has, never a throw/crash. SD self-claim (a separate, higher-priority tier) is
+    // unaffected either way. The pragma below MUST stay on the same physical line as .select( --
+    // schema-reference-extract.mjs's pragmaAt() only checks the line containing the .select( match
+    // itself (RCA'd during this SD's own round-2 adversarial review: this line's original
+    // pragma-on-its-own-line form only escaped detection by accident -- the long comment block
+    // pushed .select( past the extractor's 600-char lookahead, silently skipping the whole column
+    // list rather than being intentionally suppressed).
     const { data: qfs } = await sb
       .from('quick_fixes')
-      // schema-lint-disable-line: factory_lane is a staged, not-yet-applied column
-      // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- until a human/coordinator
-      // applies it, this SELECT fails soft (data undefined -> sortQfCandidatesBySeverity's (qfs||[])
-      // -> no QF self-claimed this tick), the same documented fail-open contract this function
-      // already has, never a throw/crash. SD self-claim (a separate, higher-priority tier) is
-      // unaffected either way.
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before, factory_lane')
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before, factory_lane') // schema-lint-disable-line: factory_lane staged, see comment above
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -547,6 +547,12 @@ async function rehydrateCallsign(sb, sessionId, currentMeta) {
 function isAutoStartableQF(qf, nowMs) {
   if (!qf || qf.status !== 'open') return false;
   if (qf.pr_url || qf.commit_sha) return false;        // already in PR/commit (verify-first / merge-race guard)
+  // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: quick_fixes.factory_lane is the structured
+  // "coordinator-dispatch only, not worker-self-claimable" marker (replaces the pre-fix free-text
+  // "FACTORY-LANE:" convention buried in description, which this predicate could not see -- live
+  // incident: QF-20260712-481 self-claimed despite being factory-lane). Fail-closed: any truthy
+  // value excludes; only exactly false (the column default) allows self-claim.
+  if (qf.factory_lane) return false;
   if (qf.routing_tier != null && Number(qf.routing_tier) >= 3) return false;  // persisted Tier-3 -> full SD, not auto-QF
   if (TIER3_RISK_RE.test(qf.title || '')) return false;                        // risk-keyword drift -> hold for triage/human
   // SD-LEO-FIX-QUICK-FIXES-NEEDS-001: durable time-gated defer -- a QF genuinely not ready
@@ -576,7 +582,13 @@ async function selfClaimQuickFix(sb, sessionId, base) {
   try {
     const { data: qfs } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before')
+      // schema-lint-disable-line: factory_lane is a staged, not-yet-applied column
+      // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- until a human/coordinator
+      // applies it, this SELECT fails soft (data undefined -> sortQfCandidatesBySeverity's (qfs||[])
+      // -> no QF self-claimed this tick), the same documented fail-open contract this function
+      // already has, never a throw/crash. SD self-claim (a separate, higher-priority tier) is
+      // unaffected either way.
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, severity, not_before, factory_lane')
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/tests/unit/coordinator/clear-coordinator-review.test.js
+++ b/tests/unit/coordinator/clear-coordinator-review.test.js
@@ -139,6 +139,11 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildClearReviewQuer
   it('SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: WHERE clause allows the clear when lead_blocker is absent/null/false/empty-string', () => {
     const { sql } = buildClearReviewQuery('SD-ABC-001');
     expect(sql).toMatch(/metadata->'lead_blocker'\s+IS\s+NULL/i);
+    // TESTING sub-agent (EXEC phase) found the SQL/JS truthiness matrices diverged on an EXPLICIT
+    // JSON null value ({"lead_blocker": null}): Postgres `->` returns a JSON-null (not SQL-NULL)
+    // for a present-but-null key, so `IS NULL` alone doesn't catch it -- an explicit '= null::jsonb'
+    // check is required to match isLeadBlockerActive(null) === false (inactive) exactly.
+    expect(sql).toMatch(/metadata->'lead_blocker'\s*=\s*'null'::jsonb/i);
     expect(sql).toMatch(/metadata->'lead_blocker'\s*=\s*'false'::jsonb/i);
     expect(sql).toMatch(/jsonb_typeof\(metadata->'lead_blocker'\)\s*=\s*'string'/i);
   });

--- a/tests/unit/coordinator/clear-coordinator-review.test.js
+++ b/tests/unit/coordinator/clear-coordinator-review.test.js
@@ -4,18 +4,34 @@
  * The FIRST canonical write-site for metadata.needs_coordinator_review. Covers: the atomic
  * merge query shape (no read-spread-write), that a successful clear triggers a rank pass
  * (and a failed/no-op clear does NOT), and fail-soft behavior on connection/query errors.
+ *
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001 (TS-4/TS-5): the atomic UPDATE now ALSO guards on
+ * metadata.lead_blocker NOT being active, so a still-lead_blocker-active SD can never have its
+ * needs_coordinator_review cleared out from under it. On a 0-row UPDATE result, a follow-up
+ * existence-only SELECT (which does NOT reintroduce a decision-relevant race -- the atomic UPDATE
+ * already made the only real decision) disambiguates 'refused_lead_blocker_active' from
+ * 'no_matching_row'.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { clearCoordinatorReview, buildClearReviewQuery } from '../../../lib/coordinator/clear-coordinator-review.js';
 
-function fakeClient({ rowCount = 1, queryError = null } = {}) {
+/**
+ * fakeClient — supports two distinct call shapes exercised by clearCoordinatorReview:
+ *   1. the atomic UPDATE (returns { rowCount })
+ *   2. the follow-up disambiguation SELECT, only run when the UPDATE's rowCount is 0
+ *      (returns { rows: [...] })
+ * `existsForSelect` controls what the follow-up SELECT reports when it runs.
+ */
+function fakeClient({ updateRowCount = 1, queryError = null, existsForSelect = false } = {}) {
   const queries = [];
   return {
     queries,
     query: vi.fn(async (sql, params) => {
       queries.push({ sql, params });
       if (queryError) throw queryError;
-      return { rowCount };
+      if (/^\s*UPDATE/i.test(sql)) return { rowCount: updateRowCount };
+      if (/^\s*SELECT/i.test(sql)) return { rows: existsForSelect ? [{ '?column?': 1 }] : [] };
+      throw new Error(`fakeClient: unexpected query shape: ${sql}`);
     }),
     end: vi.fn(async () => {}),
   };
@@ -26,41 +42,58 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: clearCoordinatorRevi
     await expect(clearCoordinatorReview()).rejects.toThrow('sdKey is required');
   });
 
-  it('issues an atomic || merge (not a read-then-full-write) and closes the connection', async () => {
-    const client = fakeClient({ rowCount: 1 });
+  it('issues ONE atomic || merge (not a read-then-full-write) and closes the connection on success', async () => {
+    const client = fakeClient({ updateRowCount: 1 });
     const createClientFn = vi.fn(async () => client);
     const triggerFn = vi.fn();
 
     const result = await clearCoordinatorReview('SD-TEST-001', { createClientFn, triggerFn });
 
     expect(result).toEqual({ cleared: true, sdKey: 'SD-TEST-001' });
-    expect(client.queries).toHaveLength(1);
+    expect(client.queries).toHaveLength(1); // no follow-up SELECT on the success path
     expect(client.queries[0].sql).toMatch(/\|\|/);
-    expect(client.queries[0].sql).not.toMatch(/SELECT/i); // no read-then-write round trip
+    expect(client.queries[0].sql).toMatch(/^\s*UPDATE/i);
     expect(client.queries[0].params).toEqual(['SD-TEST-001']);
     expect(client.end).toHaveBeenCalledOnce();
   });
 
   it('uses a service-role client via createDatabaseClient(\'engineer\', ...), matching the ranker\'s convention', async () => {
-    const client = fakeClient({ rowCount: 1 });
+    const client = fakeClient({ updateRowCount: 1 });
     const createClientFn = vi.fn(async () => client);
     await clearCoordinatorReview('SD-TEST-001', { createClientFn, triggerFn: vi.fn() });
     expect(createClientFn).toHaveBeenCalledWith('engineer', { verify: false });
   });
 
   it('triggers a rank pass ONLY after a successful clear', async () => {
-    const client = fakeClient({ rowCount: 1 });
+    const client = fakeClient({ updateRowCount: 1 });
     const triggerFn = vi.fn();
     await clearCoordinatorReview('SD-TEST-001', { createClientFn: async () => client, triggerFn });
     expect(triggerFn).toHaveBeenCalledWith({ reason: 'clear_coordinator_review', sdKey: 'SD-TEST-001' });
   });
 
   it('does NOT trigger a rank pass when no row matched (sdKey not found)', async () => {
-    const client = fakeClient({ rowCount: 0 });
+    const client = fakeClient({ updateRowCount: 0, existsForSelect: false });
     const triggerFn = vi.fn();
     const result = await clearCoordinatorReview('SD-DOES-NOT-EXIST', { createClientFn: async () => client, triggerFn });
     expect(result).toEqual({ cleared: false, sdKey: 'SD-DOES-NOT-EXIST', error: 'no_matching_row' });
     expect(triggerFn).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: refuses the clear and disambiguates the reason when the row exists but lead_blocker is active', async () => {
+    const client = fakeClient({ updateRowCount: 0, existsForSelect: true });
+    const triggerFn = vi.fn();
+    const result = await clearCoordinatorReview('SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G1', { createClientFn: async () => client, triggerFn });
+    expect(result).toEqual({ cleared: false, sdKey: 'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G1', error: 'refused_lead_blocker_active' });
+    expect(triggerFn).not.toHaveBeenCalled();
+    expect(client.queries).toHaveLength(2); // the atomic UPDATE, then the disambiguation SELECT
+  });
+
+  it('TS-5: clears successfully when lead_blocker is absent (byte-identical happy path)', async () => {
+    const client = fakeClient({ updateRowCount: 1 });
+    const triggerFn = vi.fn();
+    const result = await clearCoordinatorReview('SD-TEST-002', { createClientFn: async () => client, triggerFn });
+    expect(result).toEqual({ cleared: true, sdKey: 'SD-TEST-002' });
+    expect(triggerFn).toHaveBeenCalledOnce();
   });
 
   it('is fail-soft on a DB connection failure (never throws, returns a structured error)', async () => {
@@ -90,14 +123,23 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: clearCoordinatorRevi
 });
 
 describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildClearReviewQuery', () => {
-  it('is a pure function returning the exact atomic-merge SQL/params', () => {
+  it('is a pure function returning the atomic-merge SQL/params, guarded on lead_blocker', () => {
     const { sql, params } = buildClearReviewQuery('SD-ABC-001');
-    expect(sql).toBe("UPDATE strategic_directives_v2 SET metadata = COALESCE(metadata, '{}'::jsonb) || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1");
+    expect(sql).toMatch(/^\s*UPDATE strategic_directives_v2/);
+    expect(sql).toMatch(/SET metadata = COALESCE\(metadata,\s*'\{\}'::jsonb\)\s*\|\|\s*'\{"needs_coordinator_review":\s*false\}'::jsonb/);
+    expect(sql).toMatch(/WHERE sd_key = \$1/);
     expect(params).toEqual(['SD-ABC-001']);
   });
 
   it('guards against NULL metadata via COALESCE (Postgres NULL || jsonb = NULL, verified live in adversarial review)', () => {
     const { sql } = buildClearReviewQuery('SD-ABC-001');
     expect(sql).toMatch(/COALESCE\(metadata,\s*'\{\}'::jsonb\)\s*\|\|/);
+  });
+
+  it('SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: WHERE clause allows the clear when lead_blocker is absent/null/false/empty-string', () => {
+    const { sql } = buildClearReviewQuery('SD-ABC-001');
+    expect(sql).toMatch(/metadata->'lead_blocker'\s+IS\s+NULL/i);
+    expect(sql).toMatch(/metadata->'lead_blocker'\s*=\s*'false'::jsonb/i);
+    expect(sql).toMatch(/jsonb_typeof\(metadata->'lead_blocker'\)\s*=\s*'string'/i);
   });
 });

--- a/tests/unit/fleet/claim-eligibility-lead-blocker.test.js
+++ b/tests/unit/fleet/claim-eligibility-lead-blocker.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: lead_blocker fail-closed axis (TS-1/TS-2/TS-3).
+ *
+ * Live incident: SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G1 carries metadata.lead_blocker (a
+ * LEAD circuit-breaker bubble-up marker) but claim-eligibility.cjs had no axis reading it -- only
+ * needs_coordinator_review was checked, so a clear-review of a stale needs_coordinator_review flag
+ * let the SD slip past the still-active lead_blocker (documented in the SD's own
+ * metadata.coordinator_review_reason as "RE-FENCE #3").
+ */
+import { describe, it, expect } from 'vitest';
+
+const { classifyDispatchIneligibility, classifyAllDispatchIneligibility, CLAIM_WRITE_FENCE_AXES, isLeadBlockerActive } =
+  require('../../../lib/fleet/claim-eligibility.cjs');
+
+describe('SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: isLeadBlockerActive (pure truthiness matrix)', () => {
+  it('recognizes absent/null/false/empty-string/whitespace-string as INACTIVE', () => {
+    expect(isLeadBlockerActive(undefined)).toBe(false);
+    expect(isLeadBlockerActive(null)).toBe(false);
+    expect(isLeadBlockerActive(false)).toBe(false);
+    expect(isLeadBlockerActive('')).toBe(false);
+    expect(isLeadBlockerActive('   ')).toBe(false);
+  });
+
+  it('treats the live G1 object shape as ACTIVE', () => {
+    expect(isLeadBlockerActive({
+      detail: '-G under-decomposed: api-only leaf, no UI/data-model leaf',
+      reason: 'DECOMPOSITION_GAP / spec-conflict — LEAD circuit-breaker bubble-up',
+    })).toBe(true);
+  });
+
+  it('FAIL-CLOSED: non-empty string, true, number, array, and empty object are all ACTIVE', () => {
+    expect(isLeadBlockerActive('some reason')).toBe(true);
+    expect(isLeadBlockerActive(true)).toBe(true);
+    expect(isLeadBlockerActive(1)).toBe(true);
+    expect(isLeadBlockerActive(0)).toBe(true); // ambiguous shape -> fail-closed, not "falsy = ok"
+    expect(isLeadBlockerActive([])).toBe(true);
+    expect(isLeadBlockerActive({})).toBe(true); // empty object is still a truthy, unrecognized shape
+  });
+});
+
+describe('SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: claim-eligibility lead_blocker axis', () => {
+  it('classifyDispatchIneligibility returns lead_blocker_active for the live G1 shape', () => {
+    const row = {
+      sd_key: 'SD-FIXTURE-LEAD-BLOCKER-001',
+      sd_type: 'feature',
+      status: 'draft',
+      metadata: {
+        lead_blocker: { detail: 'under-decomposed', reason: 'DECOMPOSITION_GAP / spec-conflict' },
+        needs_coordinator_review: false, // the exact live bug: ncr cleared, lead_blocker still active
+      },
+    };
+    expect(classifyDispatchIneligibility(row)).toBe('lead_blocker_active');
+  });
+
+  it('falls through cleanly when lead_blocker is absent/false', () => {
+    const row = { sd_key: 'SD-FIXTURE-LEAD-BLOCKER-002', sd_type: 'feature', status: 'draft', metadata: {} };
+    expect(classifyDispatchIneligibility(row)).toBeNull();
+    const rowFalse = { sd_key: 'SD-FIXTURE-LEAD-BLOCKER-003', sd_type: 'feature', status: 'draft', metadata: { lead_blocker: false } };
+    expect(classifyDispatchIneligibility(rowFalse)).toBeNull();
+  });
+
+  it('classifyAllDispatchIneligibility surfaces lead_blocker_active alongside other axes', () => {
+    const row = {
+      sd_key: 'SD-FIXTURE-LEAD-BLOCKER-004',
+      sd_type: 'feature',
+      status: 'draft',
+      metadata: { lead_blocker: 'blocked pending re-decomposition', needs_coordinator_review: true },
+    };
+    const all = classifyAllDispatchIneligibility(row);
+    expect(all).toContain('lead_blocker_active');
+    expect(all).toContain('needs_coordinator_review');
+  });
+
+  it('CLAIM_WRITE_FENCE_AXES includes lead_blocker_active', () => {
+    expect(CLAIM_WRITE_FENCE_AXES.has('lead_blocker_active')).toBe(true);
+  });
+});

--- a/tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js
+++ b/tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js
@@ -48,7 +48,8 @@ describe('SD-LEO-INFRA-PHASE-SCOPED-FENCE-001 FR-4/TS-3: claim-eligibility negat
 
   it('CLAIM_WRITE_FENCE_AXES does not contain exec_boundary_hold (static assertion)', () => {
     expect(CLAIM_WRITE_FENCE_AXES.has('exec_boundary_hold')).toBe(false);
-    expect([...CLAIM_WRITE_FENCE_AXES]).toEqual(['human_action_required', 'needs_coordinator_review', 'not_before_hold']);
+    // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: lead_blocker_active added as a 4th write-fence axis.
+    expect([...CLAIM_WRITE_FENCE_AXES]).toEqual(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active']);
   });
 
   it('a held SD with no OTHER ineligibility axis is fully claimable (regression baseline)', () => {

--- a/tests/unit/sd-next/quick-fix-factory-lane-gate.test.js
+++ b/tests/unit/sd-next/quick-fix-factory-lane-gate.test.js
@@ -1,0 +1,71 @@
+/**
+ * Unit test: factory_lane exclusion in classifyQuickFixes
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001
+ *
+ * Adversarial review (deep-tier /ship gate, PR #6069) found that the original fix only
+ * closed the automated worker self-claim loop (isAutoStartableQF() in worker-checkin.cjs)
+ * but left the sd:next recommendation path (classifyQuickFixes -> topStartableQF ->
+ * AUTO_PROCEED_ACTION:qf_start) unaware of factory_lane -- a coordinator-dispatch-only QF
+ * could still be recommended and manually worked via that path, reproducing the same bug
+ * class this SD closes. Mirrors quick-fix-not-before-gate.test.js exactly.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyQuickFixes } from '../../../scripts/modules/sd-next/display/quick-fixes.js';
+
+const qf = (over = {}) => ({
+  id: 'QF-X',
+  title: 'x',
+  type: 'bug',
+  severity: 'medium',
+  status: 'open',
+  estimated_loc: 10,
+  created_at: new Date().toISOString(),
+  claiming_session_id: null,
+  pr_url: null,
+  commit_sha: null,
+  not_before: null,
+  factory_lane: false,
+  ...over,
+});
+
+describe('QF factory_lane exclusion (SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001)', () => {
+  it('flags a QF with factory_lane=true and excludes it from topStartableQF', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-FACTORY', factory_lane: true })]);
+    expect(classified[0]._factoryLane).toBe(true);
+    expect(summary.topStartableQF).toBeNull();
+    expect(summary.topQF).not.toBeNull(); // still visible in the queue
+  });
+
+  it('does NOT flag a QF with factory_lane=false (the default)', () => {
+    const { summary, classified } = classifyQuickFixes([qf({ id: 'QF-PLAIN', factory_lane: false })]);
+    expect(classified[0]._factoryLane).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-PLAIN');
+  });
+
+  it('does NOT flag a QF with factory_lane absent (undefined) -- no regression to pre-migration rows', () => {
+    const row = qf({ id: 'QF-ABSENT' });
+    delete row.factory_lane;
+    const { summary, classified } = classifyQuickFixes([row]);
+    expect(classified[0]._factoryLane).toBe(false);
+    expect(summary.topStartableQF?.id).toBe('QF-ABSENT');
+  });
+
+  it('prefers a non-factory-lane QF over a factory-lane one as the auto-startable pick', () => {
+    const { summary } = classifyQuickFixes([
+      qf({ id: 'QF-FACTORY', factory_lane: true }),
+      qf({ id: 'QF-OPEN', factory_lane: false }),
+    ]);
+    expect(summary.topStartableQF?.id).toBe('QF-OPEN');
+  });
+
+  it('reproduces the QF-20260712-481 shape: factory_lane=true, benign title, low tier', () => {
+    const { summary } = classifyQuickFixes([
+      qf({
+        id: 'QF-20260712-481',
+        title: 'V10: venture-2 approval stamped pre-isfixture-merge never got a chairman_decisions row',
+        factory_lane: true,
+      }),
+    ]);
+    expect(summary.topStartableQF).toBeNull();
+  });
+});

--- a/tests/unit/worker-checkin-qf-factory-lane.test.js
+++ b/tests/unit/worker-checkin-qf-factory-lane.test.js
@@ -1,0 +1,56 @@
+/**
+ * SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001 (TS-6/TS-7): isAutoStartableQF() must exclude
+ * factory_lane=true quick_fixes from worker self-claim.
+ *
+ * Live incident: QF-20260712-481 was marked "FACTORY-LANE: routes through the venture machine,
+ * coordinator-dispatched" ONLY as free text inside quick_fixes.description -- invisible to this
+ * predicate, which self-claimed it anyway. quick_fixes.factory_lane (a new structured column,
+ * database/migrations/20260713_quick_fixes_factory_lane.sql) replaces that free-text convention.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { isAutoStartableQF } = require('../../scripts/worker-checkin.cjs');
+
+const NOW = Date.parse('2026-07-13T12:00:00Z');
+
+function qf(overrides = {}) {
+  return {
+    id: 'QF-X',
+    status: 'open',
+    pr_url: null,
+    commit_sha: null,
+    created_at: '2026-07-12T00:00:00Z',
+    routing_tier: null,
+    title: 'x',
+    severity: 'medium',
+    not_before: null,
+    factory_lane: false,
+    ...overrides,
+  };
+}
+
+describe('isAutoStartableQF — factory_lane structured marker', () => {
+  it('TS-6: excludes a QF with factory_lane=true even though every other condition is satisfiable', () => {
+    expect(isAutoStartableQF(qf({ factory_lane: true }), NOW)).toBe(false);
+  });
+
+  it('reproduces the QF-20260712-481 live bug fixed: factory_lane=true, routing_tier=1, benign title', () => {
+    const liveShape = qf({
+      title: 'V10: venture-2 approval stamped pre-isfixture-merge never got a chairman_decisions row',
+      routing_tier: 1,
+      factory_lane: true,
+    });
+    expect(isAutoStartableQF(liveShape, NOW)).toBe(false);
+  });
+
+  it('TS-7: includes a QF with factory_lane=false (the default) -- byte-identical to pre-fix behavior', () => {
+    expect(isAutoStartableQF(qf({ factory_lane: false }), NOW)).toBe(true);
+  });
+
+  it('includes a QF with factory_lane absent (undefined) -- fail-open only in the falsy direction, matches column default', () => {
+    const row = qf();
+    delete row.factory_lane;
+    expect(isAutoStartableQF(row, NOW)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Coordinator-requested fix for a live "dispatch-eligibility fails open where it must fail closed" bug class, 2 confirmed instances
- New `lead_blocker_active` axis in `lib/fleet/claim-eligibility.cjs`'s `INELIGIBILITY_AXES` + `CLAIM_WRITE_FENCE_AXES`, fail-closed on any truthy `metadata.lead_blocker` shape (closes SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G1's live "RE-FENCE #3" bypass)
- `clearCoordinatorReview()`'s atomic UPDATE gains a WHERE-clause guard refusing to clear `needs_coordinator_review` while `lead_blocker` is active — folded into the SAME statement (no separate SELECT-then-UPDATE, avoiding the exact TOCTOU race the module's atomic-merge design exists to prevent)
- New `quick_fixes.factory_lane` structured column (additive migration, **staged** — requires chairman/Adam-delegated authorized apply, not something a worker session can self-stamp) + `isAutoStartableQF()` now excludes `factory_lane=true` rows (closes QF-20260712-481's live self-claim bug, previously only a free-text convention inside `description`)
- Fixed a real (fail-safe-direction) truthiness divergence caught by TESTING sub-agent: explicit JSON `null` for `lead_blocker` was inactive on the JS side but active on the SQL side — added `= 'null'::jsonb` for exact parity

## Test plan
- [x] 98 tests across 13 files, all passing (4 new/rewritten test files)
- [x] `schema-reference-lint` — 0 violations
- [x] LEAD VALIDATION + RISK, EXEC TESTING, PLAN_VERIFICATION VALIDATION + REGRESSION sub-agent evidence recorded
- [x] LEAD RISK confirmed the new axis is purely additive-safe (queried live DB: exactly 1 row fleet-wide currently affected, already ineligible today)
- [x] REGRESSION sub-agent swept every consumer of the 3 modified shared modules — 0 regressions, 840 tests green across the full affected surface
- [x] SD-completion retrospective recorded (quality 100/100)
- [ ] Chairman/coordinator apply of the staged `factory_lane` migration + `scripts/one-off/backfill-qf-20260712-481-factory-lane.mjs` (separate authorized action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)