### PR TITLE
fix(QF-20260713-172): stop referencing non-existent eva_ventures.completed_at column

### DIFF
--- a/lib/eva/post-lifecycle-decisions.js
+++ b/lib/eva/post-lifecycle-decisions.js
@@ -298,13 +298,11 @@ async function handleExit({ ventureId, ventureContext }, { supabase, logger = co
     .from('eva_ventures')
     .update({
       status: 'archived',
-      // PRE-EXISTING BUG (not introduced by SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-E,
-      // discovered via schema-reference-lint while this file was already in this SD's diff
-      // for an unrelated reason): eva_ventures has no `completed_at` column live, so this
-      // update() genuinely fails on every EXIT decision (surfaces as `success: false` on
-      // the return value below, not silent). Out of this SD's scope to fix; flagged via
-      // completion-flags/harness-bug signal for separate remediation. schema-lint-disable-line
-      completed_at: new Date().toISOString(),
+      // QF-20260713-172: eva_ventures has no `completed_at` column live (confirmed via
+      // schema-reference-lint + a direct column probe) -- this update() failed on every
+      // EXIT decision. `updated_at` is the real, existing column; it is not
+      // trigger-maintained on this table, so it must be set explicitly here.
+      updated_at: new Date().toISOString(),
     })
     .eq('id', ventureId);
 

--- a/tests/unit/eva/post-lifecycle-decisions.test.js
+++ b/tests/unit/eva/post-lifecycle-decisions.test.js
@@ -209,6 +209,25 @@ describe('handlePostLifecycleDecision', () => {
     expect(result.result.action).toBe('exit');
     expect(result.result.success).toBe(true);
   });
+
+  it('QF-20260713-172: EXIT archive update must not reference the non-existent eva_ventures.completed_at column', async () => {
+    const supabase = makeMockSupabase();
+    await handlePostLifecycleDecision(
+      { ventureId: 'venture-1', ventureContext, stageOutput, artifacts: [], decision: { type: 'exit' } },
+      { supabase, logger: silentLogger },
+    );
+
+    // supabase.from() returns the same mocked object regardless of table name,
+    // so the shared update() mock records calls from BOTH markCompleted()
+    // (targets 'ventures', sets status:'completed') and handleExit's own
+    // eva_ventures update (status:'archived') -- isolate the latter by payload.
+    const archiveCall = supabase.from().update.mock.calls.find(
+      (call) => call[0]?.status === 'archived',
+    );
+    expect(archiveCall).toBeDefined();
+    expect(archiveCall[0]).not.toHaveProperty('completed_at');
+    expect(archiveCall[0]).toHaveProperty('updated_at');
+  });
 });
 
 describe('decision options', () => {


### PR DESCRIPTION
## Summary
- `handleExit()`'s `eva_ventures` update failed on every EXIT decision because `completed_at` is not a real column on that table (confirmed via `schema-reference-lint` + a direct column probe). Switches to `updated_at`, the real existing column (not trigger-maintained on this table, so set explicitly).

## Scope note
Auto-promoted from 2 retrospective action items (SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-E, retro `48923287`). The second item ("formalize dual DESIGN+DATABASE sub-agent grounding as a PLAN-TO-EXEC checklist gate") was descoped from this QF — it's infrastructure-shaped work matching how the sibling `GATE_ARCHITECTURAL_PATTERN_CHECKLIST` gate was itself built via a dedicated SD, not a 50-LOC quick-fix.

## Test plan
- [x] Standalone harness verifies the archive update payload no longer contains `completed_at` and now contains `updated_at`, with `success: true`
- [x] New regression test added to `tests/unit/eva/post-lifecycle-decisions.test.js` pinning this (note: the whole file is pre-existing-quarantined for an unrelated assertion-drift issue from 2026-06-11, confirmed via `git diff` that the lint error on line 324 and the quarantine reason both predate this change)
- [x] Sibling consumer tests (`lesson-quality-guard.test.js`, `traversal-reflection-emitter.test.js`) pass, 19/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)