### PR TITLE
fix(QF-20260713-742): populate target_application on auto-created orchestrator retrospective

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
@@ -22,6 +22,52 @@ import {
 // LEAD-FINAL-APPROVAL executor is the only completion writer.
 import { routeOrchestratorToLeadFinal } from '../../lib/orchestrator-terminal-guard.js';
 
+import { normalizeAppName } from '../../../../../lib/repo-paths.js';
+
+/**
+ * Resolve a safe, registry-valid target_application for an auto-created
+ * orchestrator retrospective. Priority: sd.metadata.venture_name (if
+ * registered) -> a completed child's own retrospective.target_application ->
+ * 'EHG_Engineer'. Any lookup failure falls back to 'EHG_Engineer' rather than
+ * blocking retro creation (QF-20260713-742 / PAT-TEMPLATE-CODE-SYNC-001:
+ * the insert had no target_application at all, failing NOT NULL /
+ * trg_validate_retrospective_target_application on every orchestrator).
+ */
+async function resolveOrchestratorRetroTargetApplication(supabase, sdId) {
+  try {
+    const { data: sdRow } = await supabase
+      .from('strategic_directives_v2')
+      .select('metadata')
+      .eq('id', sdId)
+      .maybeSingle();
+
+    const ventureName = sdRow?.metadata?.venture_name;
+    if (ventureName) {
+      const needle = normalizeAppName(ventureName);
+      if (needle === 'ehg' || needle === 'ehgengineer') return ventureName;
+      const { data: apps } = await supabase.from('applications').select('name').eq('status', 'active');
+      if ((apps || []).some((a) => normalizeAppName(a.name) === needle)) return ventureName;
+    }
+
+    const { data: children } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('parent_sd_id', sdId);
+    if (children?.length) {
+      const { data: childRetros } = await supabase
+        .from('retrospectives')
+        .select('target_application')
+        .in('sd_id', children.map((c) => c.id))
+        .not('target_application', 'is', null)
+        .limit(1);
+      if (childRetros?.[0]?.target_application) return childRetros[0].target_application;
+    }
+  } catch {
+    // Any lookup failure falls through to the platform default below.
+  }
+  return 'EHG_Engineer';
+}
+
 /**
  * Finalize user stories to completed status
  *
@@ -305,10 +351,12 @@ export async function satisfyOrchestratorTemplateRequirements(supabase, sdId, sd
         console.warn(`[ENFORCE] skipped state-transitions orchestrator-completion INSERT for sdId=${sdId} reason=${guard.reason}`);
         return { satisfied: true, created };
       }
+      const targetApplication = await resolveOrchestratorRetroTargetApplication(supabase, sdId);
       const { error: rErr } = await supabase
         .from('retrospectives')
         .insert({
           sd_id: sdId,
+          target_application: targetApplication,
           title: `Orchestrator Completion: ${sdTitle}`,
           // SD-FDBK-FIX-ORCHESTRATOR-GHOST-COMPLETE-001: must be the canonical
           // completion type — retro-filters.js and the LEAD-FINAL-APPROVAL gate

--- a/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js
@@ -150,6 +150,129 @@ describe('satisfyOrchestratorTemplateRequirements', () => {
     expect(insertFn.mock.calls[0][0].retro_type).toBe('SD_COMPLETION');
   });
 
+  // QF-20260713-742 / PAT-TEMPLATE-CODE-SYNC-001: the insert previously had no
+  // target_application at all, failing NOT NULL / the registry-aware validation
+  // trigger on every orchestrator with zero existing retros.
+  it('should resolve target_application from sd.metadata.venture_name when registered', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+
+    mockDb = {
+      from: vi.fn((table) => {
+        if (table === 'sd_phase_handoffs') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  eq: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: [{ id: 'existing-handoff' }], error: null }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'retrospectives') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+            insert: insertFn,
+          };
+        }
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: vi.fn((cols) => {
+              if (cols === 'metadata') {
+                return {
+                  eq: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: { metadata: { venture_name: 'ApexNiche AI' } },
+                      error: null,
+                    }),
+                  }),
+                };
+              }
+              return { eq: vi.fn().mockResolvedValue({ data: [], error: null }) };
+            }),
+          };
+        }
+        if (table === 'applications') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: [{ name: 'ApexNiche AI' }], error: null }),
+            }),
+          };
+        }
+      }),
+    };
+
+    const result = await satisfyOrchestratorTemplateRequirements(mockDb, 'sd-123', 'Test SD');
+    expect(result.satisfied).toBe(true);
+    expect(insertFn.mock.calls[0][0].target_application).toBe('ApexNiche AI');
+  });
+
+  it('should fall back to EHG_Engineer when venture_name is unregistered and no child retro exists', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+
+    mockDb = {
+      from: vi.fn((table) => {
+        if (table === 'sd_phase_handoffs') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  eq: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: [{ id: 'existing-handoff' }], error: null }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'retrospectives') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+            insert: insertFn,
+          };
+        }
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: vi.fn((cols) => {
+              if (cols === 'metadata') {
+                return {
+                  eq: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: { metadata: { venture_name: 'Unregistered Venture' } },
+                      error: null,
+                    }),
+                  }),
+                };
+              }
+              return { eq: vi.fn().mockResolvedValue({ data: [], error: null }) };
+            }),
+          };
+        }
+        if (table === 'applications') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          };
+        }
+      }),
+    };
+
+    const result = await satisfyOrchestratorTemplateRequirements(mockDb, 'sd-123', 'Test SD');
+    expect(result.satisfied).toBe(true);
+    expect(insertFn.mock.calls[0][0].target_application).toBe('EHG_Engineer');
+  });
+
   it('should create both when both missing', async () => {
     const handoffInsert = vi.fn().mockResolvedValue({ error: null });
     const retroInsert = vi.fn().mockResolvedValue({ error: null });


### PR DESCRIPTION
## Summary
- `satisfyOrchestratorTemplateRequirements()` (`scripts/modules/handoff/executors/plan-to-lead/state-transitions.js`) auto-creates a `retro_type='SD_COMPLETION'` retrospective for an orchestrator SD when none exists, but the insert never set `target_application` — a `NOT NULL` column with no default. This fails both the NOT NULL constraint and `trg_validate_retrospective_target_application`, so the auto-retro insert silently errors (logged as a warning, non-blocking) for every orchestrator SD with zero existing retrospectives.
- Verified live: `retrospectives.target_application` is `text NOT NULL DEFAULT NULL`. Confirmed against the SD that generated this QF's source retrospective (`SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-D`, sd_type=orchestrator) — its `metadata.venture_name = "ApexNiche AI"`, which is an active row in the `applications` registry.
- Fix: new `resolveOrchestratorRetroTargetApplication()` resolves in priority order: (1) `sd.metadata.venture_name` if it matches an active row in `applications` (registry-validated, using the same `normalizeAppName` case/separator-insensitive matching as `lib/repo-paths.js` and the DB trigger), (2) a completed child SD's own `retrospectives.target_application`, (3) `'EHG_Engineer'` platform default. Any lookup failure falls back to the platform default rather than blocking retro creation.

## Test plan
- [x] Existing 6 unit tests in `tests/unit/handoff/executors/plan-to-lead/state-transitions.test.js` pass unchanged
- [x] 2 new unit tests added: venture_name resolves when registered; falls back to `EHG_Engineer` when unregistered and no child retro exists — both pass
- [x] Full `tests/unit/handoff/` suite (78 files, 766 tests) passes with no regressions
- [x] Module imports cleanly (`node --experimental-vm-modules` import check)

Source: auto-promoted from retrospective `c17f634b-c089-4e41-a715-379aa782596c` (SD `SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-D`), action item confirmed still live against current code before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)