### PR TITLE
fix(QF-20260713-897): guard module-scope .env loads under the unit-vitest runner

### DIFF
--- a/lib/__tests__/supabase-client-env-walk.test.js
+++ b/lib/__tests__/supabase-client-env-walk.test.js
@@ -30,6 +30,11 @@ function spawnAndProbeEnv(modulePath, cwd, dotenvDir, dotenvContents) {
   delete cleanEnv.NEXT_PUBLIC_SUPABASE_URL;
   delete cleanEnv.SUPABASE_URL;
   delete cleanEnv.QF755_PROBE_KEY;
+  // QF-20260713-897: this probe validates the REAL runtime .env walk, so the child must
+  // run as a production process — strip the test-runner flags the parent (vitest) carries,
+  // otherwise supabase-client's new test-runner guard would (correctly) skip the walk.
+  delete cleanEnv.VITEST;
+  delete cleanEnv.NODE_ENV;
   const probe = spawn('node', ['-e', code], {
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd,

--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -17,7 +17,9 @@ import { execSync } from 'child_process';
 import { mkdirSync, writeFileSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import dotenv from 'dotenv';
-dotenv.config();
+// QF-20260713-897: skip the module-level .env load under the test runner (library
+// modules must not leak live creds into the unit-vitest project). Runtime unchanged.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') dotenv.config();
 
 import {
   formatArtifactContent,

--- a/lib/eva/bridge/repo-readiness.js
+++ b/lib/eva/bridge/repo-readiness.js
@@ -21,7 +21,11 @@ import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { resolveVentureRepoUrl } from './resolve-venture-repo.js';
 import { resolveBuildScreens } from './replit-repo-seeder.js';
-dotenv.config();
+// QF-20260713-897: skip the module-level .env load under the test runner. A library
+// module loading real .env leaks live creds into the unit-vitest project (unit tests
+// must not reach the live DB); analyzeStageNN transitively imports this file. Real
+// processes still load .env (the entry script/runtime env is unchanged).
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') dotenv.config();
 
 // The Claude-Code-ready artifacts seedRepo() commits to a venture repo
 // (lib/eva/bridge/replit-repo-seeder.js — the SD-...-001-B wiring block).

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -22,7 +22,9 @@ import { maybeMintReviewGate } from './review-gate-mint.js';
 import { canAutoAdvance } from './governance/can-auto-advance.js';
 import { checkExitGates } from './lifecycle/exit-gate-enforcer.js';
 
-dotenv.config();
+// QF-20260713-897: skip the module-level .env load under the test runner (library
+// modules must not leak live creds into the unit-vitest project). Runtime unchanged.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') dotenv.config();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const STAGE_TEMPLATES_DIR = join(__dirname, 'stage-templates');

--- a/lib/eva/stage-registry.js
+++ b/lib/eva/stage-registry.js
@@ -18,7 +18,9 @@ import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-dotenv.config();
+// QF-20260713-897: skip the module-level .env load under the test runner (library
+// modules must not leak live creds into the unit-vitest project). Runtime unchanged.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') dotenv.config();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const STAGE_TEMPLATES_DIR = join(__dirname, 'stage-templates');

--- a/lib/supabase-client.cjs
+++ b/lib/supabase-client.cjs
@@ -10,7 +10,7 @@ const { createClient } = require('@supabase/supabase-js');
 // QF-20260504-755: walk up from cwd looking for .env. Pre-fix, dotenv only
 // loaded .env from cwd, so manual `git worktree add` (which doesn't copy .env)
 // caused crashes. Now finds parent worktree's .env automatically.
-(function loadEnvFromAncestors() {
+function loadEnvFromAncestors() {
   const fs = require('fs');
   const path = require('path');
   let dir = process.cwd();
@@ -22,7 +22,10 @@ const { createClient } = require('@supabase/supabase-js');
     }
     dir = path.dirname(dir);
   }
-})();
+}
+// QF-20260713-897: skip the module-level .env walk under the test runner (library
+// modules must not leak live creds into the unit-vitest project). Runtime unchanged.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') loadEnvFromAncestors();
 
 // SD-FDBK-FIX-GUARD-ANON-SUPABASE-001: the ANON key is RLS-restricted, so a write to a
 // governance table is SILENTLY dropped (0 rows affected, NO error) — easily mistaken for a

--- a/lib/supabase-client.js
+++ b/lib/supabase-client.js
@@ -18,7 +18,7 @@ import path from 'path';
 // loaded .env from cwd, so manual `git worktree add` (which doesn't copy .env)
 // caused crashes. Now finds parent worktree's .env automatically. Skips
 // .env.uat per existing convention to avoid expired keys.
-(function loadEnvFromAncestors() {
+function loadEnvFromAncestors() {
   let dir = process.cwd();
   while (dir !== path.dirname(dir)) {
     const envFile = path.join(dir, '.env');
@@ -31,7 +31,13 @@ import path from 'path';
     }
     dir = path.dirname(dir);
   }
-})();
+}
+// QF-20260713-897: the module-level .env walk leaks live creds into the unit-vitest
+// project (tests/setup.unit.js already stubs SUPABASE_URL/keys and must NOT reach the
+// live DB). supabase-client.js is imported transitively by nearly everything (incl.
+// analyzeStageNN), so guard the load under the test runner — real processes/CLIs are
+// unchanged. This is the root fix for the fleet-wide unit-lane .env leak.
+if (!process.env.VITEST && process.env.NODE_ENV !== 'test') loadEnvFromAncestors();
 
 /**
  * Create Supabase client with ANON key only

--- a/tests/unit/harness/env-leak-guard.test.js
+++ b/tests/unit/harness/env-leak-guard.test.js
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * QF-20260713-897 — unit-vitest .env leak guard (retro action item, SD 5b334fdd).
+ *
+ * DEFECT: library modules called dotenv.config() (or the ancestor-walk equivalent) at
+ * MODULE SCOPE. Any unit test transitively importing them (e.g. analyzeStageNN →
+ * artifact-persistence-service / eva-orchestrator-helpers → … → lib/supabase-client.js)
+ * loaded the REAL .env into the unit-vitest project, which must never reach the live DB
+ * (tests/setup.unit.js deliberately stubs SUPABASE_URL/keys and does NOT load .env).
+ *
+ * FIX: each module-level .env load is gated behind a test-runner check
+ * `if (!process.env.VITEST && process.env.NODE_ENV !== 'test') <load>`. Real processes
+ * still load .env; the unit lane never does. This test pins that every guarded loader in
+ * the analyzeStage11 transitive chain keeps its guard (else the leak silently returns).
+ */
+
+const ROOT = process.cwd();
+const GUARDED = [
+  'lib/supabase-client.js',
+  'lib/eva/bridge/repo-readiness.js',
+  'lib/eva/bridge/replit-repo-seeder.js',
+  'lib/eva/stage-execution-engine.js',
+  'lib/eva/stage-registry.js',
+];
+
+describe('unit-lane .env leak guard (QF-20260713-897)', () => {
+  for (const rel of GUARDED) {
+    const src = readFileSync(join(ROOT, rel), 'utf8');
+
+    it(`${rel}: the module-scope .env load is gated by the test-runner guard`, () => {
+      // The module still performs a dotenv load (not accidentally deleted)...
+      expect(
+        /\b(dotenv|dotenvx)\.config\(/.test(src),
+        `${rel} should still perform a dotenv load for real processes`,
+      ).toBe(true);
+      // ...and the load (or its invocation, for the ancestor-walk in supabase-client)
+      // is gated behind the canonical test-runner guard so the unit lane never loads .env.
+      expect(
+        /!process\.env\.VITEST\b/.test(src) && /process\.env\.NODE_ENV\s*!==\s*['"]test['"]/.test(src),
+        `${rel} is MISSING the "!process.env.VITEST && process.env.NODE_ENV !== 'test'" guard — it will leak .env into the unit lane`,
+      ).toBe(true);
+    });
+  }
+
+  it('the guard predicate is inert here (this test IS the unit runner)', () => {
+    // Sanity: under vitest, process.env.VITEST is set, so the guard skips the load.
+    expect(!!process.env.VITEST || process.env.NODE_ENV === 'test').toBe(true);
+  });
+});

--- a/tests/unit/harness/env-leak-guard.test.js
+++ b/tests/unit/harness/env-leak-guard.test.js
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
 const ROOT = process.cwd();
 const GUARDED = [
   'lib/supabase-client.js',
+  'lib/supabase-client.cjs',
   'lib/eva/bridge/repo-readiness.js',
   'lib/eva/bridge/replit-repo-seeder.js',
   'lib/eva/stage-execution-engine.js',
@@ -31,9 +32,10 @@ describe('unit-lane .env leak guard (QF-20260713-897)', () => {
     const src = readFileSync(join(ROOT, rel), 'utf8');
 
     it(`${rel}: the module-scope .env load is gated by the test-runner guard`, () => {
-      // The module still performs a dotenv load (not accidentally deleted)...
+      // The module still performs a dotenv load (not accidentally deleted) — matches both
+      // ESM `dotenv.config(` and CJS `require('dotenv').config(`.
       expect(
-        /\b(dotenv|dotenvx)\.config\(/.test(src),
+        /\.config\(/.test(src) && /dotenv/.test(src),
         `${rel} should still perform a dotenv load for real processes`,
       ).toBe(true);
       // ...and the load (or its invocation, for the ancestor-walk in supabase-client)


### PR DESCRIPTION
## Summary
Retro action item (SD 5b334fdd): library modules called `dotenv.config()` (or an ancestor `.env` walk) at module scope, so any unit test transitively importing them (analyzeStageNN → … → `lib/supabase-client.js`) loaded the **real** `.env` into the unit-vitest project — which must never reach the live DB.

Root: `lib/supabase-client.js`'s `loadEnvFromAncestors()` IIFE (imported ~everywhere) + 4 eva chain modules. Each module-scope load is now gated behind `!process.env.VITEST && process.env.NODE_ENV !== 'test'`. Real processes/CLIs load `.env` unchanged; the unit lane never does.

Verified: importing the analysis-steps index under VITEST no longer populates SUPABASE_URL; 62 stage-11 unit tests stay green. Regression pin added.

## Test plan
- `tests/unit/harness/env-leak-guard.test.js` (6) — pins the guard on all 5 loaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)