### PR TITLE
docs(D4): chairman email attestation for applied CHECK-widening migration

### DIFF
--- a/database/migrations/20260713_periodic_process_registry_gha_source_and_state_anchor.sql
+++ b/database/migrations/20260713_periodic_process_registry_gha_source_and_state_anchor.sql
@@ -4,6 +4,8 @@
 -- SD: SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-1)
 -- Date: 2026-07-13
 -- @approved-by: chairman-ratified build-vs-run D-set (D4)
+-- @approved-by: codestreetlabs@gmail.com
+--   (chairman verbal approval, 2026-07-13 ~06:25 ET, Adam session d02c9e34 — D4 apply-ceremony)
 --
 -- Two additive changes, bundled in one migration per this SD's own PRD (TR-2):
 --


### PR DESCRIPTION
Upstreams the chairman attestation line for the D4 apply-ceremony so git history matches the applied DB state.

- Migration: `20260713_periodic_process_registry_gha_source_and_state_anchor.sql` (SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 FR-1)
- Applied to prod 2026-07-13 ~06:30 ET via ceremony (MIGRATION_APPLY_PROD_PASS, token 7b34fe59…), chairman verbal approval in-session ~06:25 ET
- pg readback confirmed: CHECK includes `github_actions_api`; `last_state_changed_at` column live
- Companion backfill applied separately (70 gha_cron rows → github_actions_api)
- 2-line comment-only change; the applied file sha (f9ace238…) corresponds to THIS content

Opened by Adam (propose-only) — merge via normal ship path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)