### PR TITLE
feat(SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001): Operator Contract merge-time gate (D8)

### DIFF
--- a/lib/eva/bridge/venture-build-merge-witness.js
+++ b/lib/eva/bridge/venture-build-merge-witness.js
@@ -21,6 +21,10 @@ import { verifyMerged } from '../../ship/auto-merge.mjs';
 // emitEvent is a hoisted `export async function` in the consumer, so this cyclic import is
 // runtime-safe (the binding is live and only ever dereferenced at call time).
 import { emitEvent } from './venture-build-consumer.js';
+// Operator Contract fractal binding (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001 FR-7):
+// ventures inherit operate-by-default via the SAME shared validator (no duplicated
+// logic). Observe-only advisory here — this seam is fail-soft telemetry, not a hard gate.
+import { evaluateVentureOperatorContract } from '../../gates/operator-contract/venture-adapter.js';
 
 export const LANE = 'venture-build';
 const GH_TIMEOUT_MS = 15000;
@@ -88,7 +92,7 @@ export async function observeLeafMergeWitness({ supabase, leaf, ventureId, repoO
     evaluateLadder = evaluateMergeWorkLadder,
     emitEvent: emit = emitEvent,
   } = deps;
-  const summary = { workKey: leaf?.sd_key ?? null, prNumber: null, mergedState: 'not_evaluable', telemetryWritten: false, readBack: false, unmergedEmitted: false };
+  const summary = { workKey: leaf?.sd_key ?? null, prNumber: null, mergedState: 'not_evaluable', telemetryWritten: false, readBack: false, unmergedEmitted: false, operatorContract: null };
   try {
     // (a) resolve the leaf's PR — fail-soft: any error or no PR ⇒ mergedState stays 'not_evaluable'
     let pr = null;
@@ -138,6 +142,33 @@ export async function observeLeafMergeWitness({ supabase, leaf, ventureId, repoO
         { ventureId, sdId: leaf.id, dryRun, logger });
       summary.unmergedEmitted = true;
     }
+
+    // (f) Operator Contract fractal binding (FR-7) — observe-only advisory via the
+    // SHARED validator. The leaf's build metadata may declare the persistent output
+    // it created (created_tables / capability_keys) and any waiver; a venture-stage
+    // CREATOR without its operator triple is surfaced with the SAME verdict a harness
+    // SD would get. Fail-open: any error leaves operatorContract null, never blocks.
+    try {
+      const meta = leaf?.metadata || {};
+      const createdTables = Array.isArray(meta.created_tables) ? meta.created_tables : [];
+      if (createdTables.length) {
+        const oc = evaluateVentureOperatorContract({
+          createdTables,
+          changedFiles: Array.isArray(meta.operator_changed_files) ? meta.operator_changed_files : [],
+          registryRows: Array.isArray(deps.registryRows) ? deps.registryRows : [],
+          retentionPolicies: Array.isArray(deps.retentionPolicies) ? deps.retentionPolicies : [],
+          capabilityKeys: Array.isArray(meta.operator_capability_keys) ? meta.operator_capability_keys : [],
+          waiver: meta.operator_contract_waiver || null,
+        });
+        summary.operatorContract = { verdict: oc.verdict, reason: oc.reason, missing: oc.missing };
+        if (oc.verdict === 'fail') {
+          logger.warn?.(`[venture-build-merge-witness] operator-contract advisory for ${leaf?.sd_key}: ${oc.reason}`);
+        }
+      }
+    } catch (e) {
+      logger.error?.(`[venture-build-merge-witness] operator-contract advisory threw (non-fatal): ${e?.message || e}`);
+    }
+
     return summary;
   } catch (e) {
     logger.error?.(`[venture-build-merge-witness] observe failed (non-fatal, observe-only) for ${leaf?.sd_key}: ${e?.message || e}`);

--- a/lib/gates/operator-contract/__tests__/harness-adapter.test.js
+++ b/lib/gates/operator-contract/__tests__/harness-adapter.test.js
@@ -1,0 +1,41 @@
+/**
+ * Operator Contract — harness adapter (FR-5) tests.
+ * Focus: fail-open contract + well-formed gate object. Core decision logic is
+ * covered exhaustively in operator-contract.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import { createOperatorContractGate, resolveOperatorContract } from '../harness-adapter.js';
+
+const supabaseStub = {
+  from() {
+    return {
+      select: async () => ({ data: [] }),
+      insert: async () => ({ error: null }),
+    };
+  },
+};
+
+describe('createOperatorContractGate (FR-5 factory)', () => {
+  it('returns a well-formed, required gate object', () => {
+    const gate = createOperatorContractGate(supabaseStub, { sd_key: 'SD-X' }, process.cwd());
+    expect(gate.name).toBe('OPERATOR_CONTRACT');
+    expect(gate.required).toBe(true);
+    expect(typeof gate.validator).toBe('function');
+  });
+
+  it('FAIL-OPEN: an execution error (non-git path) resolves to pass with a warning', async () => {
+    const gate = createOperatorContractGate(supabaseStub, { sd_key: 'SD-X' }, '/nonexistent-path-xyz');
+    const r = await gate.validator({ sd: { sd_key: 'SD-X' } });
+    expect(r.passed).toBe(true);
+    expect(r.details.fail_open).toBe(true);
+    expect(r.warnings[0]).toMatch(/fail-open/);
+  });
+});
+
+describe('resolveOperatorContract (adapter → core)', () => {
+  it('non-git path fails open by throwing (caught by the gate factory)', async () => {
+    await expect(
+      resolveOperatorContract({ sd: { sd_key: 'SD-X' }, appPath: '/nonexistent-path-xyz', supabase: supabaseStub })
+    ).rejects.toBeTruthy();
+  });
+});

--- a/lib/gates/operator-contract/__tests__/operator-contract.test.js
+++ b/lib/gates/operator-contract/__tests__/operator-contract.test.js
@@ -100,13 +100,23 @@ describe('validateConsumer (FR-2)', () => {
 });
 
 describe('validateCadence (FR-3)', () => {
-  it('accepts an enabled registry row with a schedule', () => {
+  it('accepts an active registry row with a positive interval + surfaces the witness', () => {
     const r = validateCadence({
-      registryRows: [{ process_key: 'foo-sweep', enabled: true, schedule: '*/30 * * * *' }],
+      registryRows: [{ process_key: 'foo-sweep', currently_expected_active: true, expected_interval_seconds: 1800, last_fired_at: '2026-07-13T00:00:00Z' }],
       capabilityKeys: ['foo-sweep'],
     });
     expect(r.cadence_armed).toBe(true);
     expect(r.process_key).toBe('foo-sweep');
+    expect(r.witnessed).toBe(true);
+  });
+
+  it('accepts an ARMED-but-not-yet-fired row (armed, witnessed=false)', () => {
+    const r = validateCadence({
+      registryRows: [{ process_key: 'foo-sweep', currently_expected_active: true, expected_interval_seconds: 1800, last_fired_at: null }],
+      capabilityKeys: ['foo-sweep'],
+    });
+    expect(r.cadence_armed).toBe(true);
+    expect(r.witnessed).toBe(false);
   });
 
   it('rejects a bare CLI (no registry row)', () => {
@@ -114,9 +124,9 @@ describe('validateCadence (FR-3)', () => {
     expect(r.cadence_armed).toBe(false);
   });
 
-  it('rejects an off-by-default (disabled) registry row', () => {
+  it('rejects an inactive (currently_expected_active=false) registry row', () => {
     const r = validateCadence({
-      registryRows: [{ process_key: 'foo-sweep', enabled: false, schedule: '*/30 * * * *' }],
+      registryRows: [{ process_key: 'foo-sweep', currently_expected_active: false, expected_interval_seconds: 1800 }],
       capabilityKeys: ['foo-sweep'],
     });
     expect(r.cadence_armed).toBe(false);

--- a/lib/gates/operator-contract/__tests__/operator-contract.test.js
+++ b/lib/gates/operator-contract/__tests__/operator-contract.test.js
@@ -1,0 +1,195 @@
+/**
+ * Operator Contract gate — core validator tests
+ * (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001, FR-1..FR-6, FR-8 fixtures).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectCreator,
+  validateConsumer,
+  validateCadence,
+  validateReaper,
+  evaluateWaiver,
+  evaluateOperatorContract,
+  CREATOR_KINDS,
+} from '../index.js';
+
+const FIXED_NOW = new Date('2026-07-13T00:00:00.000Z');
+const future = (days) => new Date(FIXED_NOW.getTime() + days * 86_400_000).toISOString();
+const past = (days) => new Date(FIXED_NOW.getTime() - days * 86_400_000).toISOString();
+
+describe('detectCreator (FR-1)', () => {
+  it('flags a CREATE TABLE migration as a table CREATOR with evidence', () => {
+    const r = detectCreator({
+      migrations: [{ path: 'db/migrations/20260713_foo.sql', sql: 'CREATE TABLE IF NOT EXISTS foo_events (id uuid);' }],
+    });
+    expect(r.is_creator).toBe(true);
+    expect(r.creator_kinds).toContain(CREATOR_KINDS.TABLE);
+    expect(r.evidence[0]).toMatch(/CREATE TABLE/);
+  });
+
+  it('flags an insert/writer module as a writer CREATOR', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/foo/writer.js', added: "await supabase.from('foo_events').insert(row)" }],
+    });
+    expect(r.is_creator).toBe(true);
+    expect(r.creator_kinds).toContain(CREATOR_KINDS.WRITER);
+  });
+
+  it('flags a leo_feature_flags insert as a flag CREATOR', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/flags/new.js', added: "supabase.from('leo_feature_flags').insert({ key: 'x' })" }],
+    });
+    expect(r.creator_kinds).toContain(CREATOR_KINDS.FLAG);
+  });
+
+  it('does NOT flag edits to existing non-creator code', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/util/format.js', added: 'return value.trim().toLowerCase();' }],
+    });
+    expect(r.is_creator).toBe(false);
+    expect(r.creator_kinds).toHaveLength(0);
+  });
+});
+
+describe('validateConsumer (FR-2)', () => {
+  it('accepts a non-test read-path against the created table', () => {
+    const r = validateConsumer({
+      changedFiles: [{ path: 'lib/foo/consumer.js', added: "const { data } = await supabase.from('foo_events').select('*')" }],
+      createdTables: ['foo_events'],
+    });
+    expect(r.consumer_present).toBe(true);
+  });
+
+  it('rejects when only the writer exists (no consumer)', () => {
+    const r = validateConsumer({
+      changedFiles: [{ path: 'lib/foo/writer.js', added: "await supabase.from('foo_events').insert(row)" }],
+      createdTables: ['foo_events'],
+    });
+    expect(r.consumer_present).toBe(false);
+  });
+
+  it('does not count a test file as a consumer', () => {
+    const r = validateConsumer({
+      changedFiles: [{ path: 'lib/foo/__tests__/foo.test.js', added: "supabase.from('foo_events').select('*')" }],
+      createdTables: ['foo_events'],
+    });
+    expect(r.consumer_present).toBe(false);
+  });
+});
+
+describe('validateCadence (FR-3)', () => {
+  it('accepts an enabled registry row with a schedule', () => {
+    const r = validateCadence({
+      registryRows: [{ process_key: 'foo-sweep', enabled: true, schedule: '*/30 * * * *' }],
+      capabilityKeys: ['foo-sweep'],
+    });
+    expect(r.cadence_armed).toBe(true);
+    expect(r.process_key).toBe('foo-sweep');
+  });
+
+  it('rejects a bare CLI (no registry row)', () => {
+    const r = validateCadence({ registryRows: [], capabilityKeys: ['foo-sweep'] });
+    expect(r.cadence_armed).toBe(false);
+  });
+
+  it('rejects an off-by-default (disabled) registry row', () => {
+    const r = validateCadence({
+      registryRows: [{ process_key: 'foo-sweep', enabled: false, schedule: '*/30 * * * *' }],
+      capabilityKeys: ['foo-sweep'],
+    });
+    expect(r.cadence_armed).toBe(false);
+  });
+});
+
+describe('validateReaper (FR-4)', () => {
+  it('accepts a created table covered by a retention policy', () => {
+    const r = validateReaper({ retentionPolicies: [{ table: 'foo_events' }], createdTables: ['foo_events'] });
+    expect(r.reaper_present).toBe(true);
+  });
+
+  it('rejects a created table with no retention policy', () => {
+    const r = validateReaper({ retentionPolicies: [{ table: 'other' }], createdTables: ['foo_events'] });
+    expect(r.reaper_present).toBe(false);
+    expect(r.evidence[0]).toMatch(/foo_events/);
+  });
+});
+
+describe('evaluateWaiver (FR-6)', () => {
+  it('accepts a future-dated waiver with owner+expiry and emits an audit payload', () => {
+    const r = evaluateWaiver({ owner: 'chairman', reason: 'build-ahead', expiry: future(30) }, FIXED_NOW);
+    expect(r.valid).toBe(true);
+    expect(r.audit.event).toBe('OPERATOR_CONTRACT_WAIVER_APPLIED');
+    expect(r.audit.owner).toBe('chairman');
+  });
+
+  it('rejects an expired waiver', () => {
+    const r = evaluateWaiver({ owner: 'chairman', expiry: past(1) }, FIXED_NOW);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/expired/);
+  });
+
+  it('rejects a waiver missing owner', () => {
+    const r = evaluateWaiver({ expiry: future(30) }, FIXED_NOW);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/owner/);
+  });
+
+  it('rejects a waiver missing expiry', () => {
+    const r = evaluateWaiver({ owner: 'chairman' }, FIXED_NOW);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/expiry/);
+  });
+});
+
+describe('evaluateOperatorContract (FR-5) — end-to-end verdicts', () => {
+  const creator = { is_creator: true, creator_kinds: ['table', 'writer'], evidence: ['x'] };
+  const fullTriple = { consumer_present: true, cadence_armed: true, reaper_present: true };
+  const noTriple = { consumer_present: false, cadence_armed: false, reaper_present: false };
+
+  it('NEGATIVE fixture: CREATOR without triple → fail with all three missing', () => {
+    const r = evaluateOperatorContract({ creator, triple: noTriple, now: FIXED_NOW });
+    expect(r.verdict).toBe('fail');
+    expect(r.reason).toMatch(/OPERATOR_CONTRACT_INCOMPLETE/);
+    expect(r.missing).toEqual(['consumer', 'armed_cadence', 'reaper']);
+  });
+
+  it('POSITIVE fixture: CREATOR with full triple → pass', () => {
+    const r = evaluateOperatorContract({ creator, triple: fullTriple, now: FIXED_NOW });
+    expect(r.verdict).toBe('pass');
+    expect(r.reason).toBe('OPERATOR_CONTRACT_COMPLETE');
+  });
+
+  it('WAIVER fixture: incomplete triple + future waiver → pass with audit', () => {
+    const r = evaluateOperatorContract({
+      creator,
+      triple: noTriple,
+      waiver: { owner: 'chairman', expiry: future(30) },
+      now: FIXED_NOW,
+    });
+    expect(r.verdict).toBe('pass');
+    expect(r.reason).toMatch(/OPERATOR_CONTRACT_WAIVED/);
+    expect(r.waiver_audit.event).toBe('OPERATOR_CONTRACT_WAIVER_APPLIED');
+  });
+
+  it('EXPIRED-WAIVER fixture: incomplete triple + expired waiver → fail', () => {
+    const r = evaluateOperatorContract({
+      creator,
+      triple: noTriple,
+      waiver: { owner: 'chairman', expiry: past(1) },
+      now: FIXED_NOW,
+    });
+    expect(r.verdict).toBe('fail');
+    expect(r.waiver_audit).toBeNull();
+  });
+
+  it('ZERO-FALSE-POSITIVE: non-CREATOR SD → no-op pass regardless of triple', () => {
+    const r = evaluateOperatorContract({
+      creator: { is_creator: false, creator_kinds: [], evidence: [] },
+      triple: noTriple,
+      now: FIXED_NOW,
+    });
+    expect(r.verdict).toBe('pass');
+    expect(r.reason).toMatch(/NOT_APPLICABLE/);
+    expect(r.missing).toHaveLength(0);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/operator-contract.test.js
+++ b/lib/gates/operator-contract/__tests__/operator-contract.test.js
@@ -27,12 +27,20 @@ describe('detectCreator (FR-1)', () => {
     expect(r.evidence[0]).toMatch(/CREATE TABLE/);
   });
 
-  it('flags an insert/writer module as a writer CREATOR', () => {
+  it('flags a writer as a CREATOR only when it targets a table the SD also creates', () => {
     const r = detectCreator({
+      migrations: [{ path: 'db/m.sql', sql: 'CREATE TABLE foo_events (id uuid);' }],
       changedFiles: [{ path: 'lib/foo/writer.js', added: "await supabase.from('foo_events').insert(row)" }],
     });
     expect(r.is_creator).toBe(true);
     expect(r.creator_kinds).toContain(CREATOR_KINDS.WRITER);
+  });
+
+  it('does NOT flag a writer that only writes to an EXISTING table (SC#5 zero-false-positive)', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/foo/logger.js', added: "await supabase.from('audit_log').insert(row)" }],
+    });
+    expect(r.is_creator).toBe(false);
   });
 
   it('flags a leo_feature_flags insert as a flag CREATOR', () => {
@@ -40,6 +48,20 @@ describe('detectCreator (FR-1)', () => {
       changedFiles: [{ path: 'lib/flags/new.js', added: "supabase.from('leo_feature_flags').insert({ key: 'x' })" }],
     });
     expect(r.creator_kinds).toContain(CREATOR_KINDS.FLAG);
+  });
+
+  it('flags a new detector MODULE (path-based) as a detector CREATOR', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/detectors/drift-detector.js', added: 'export function run() {}' }],
+    });
+    expect(r.creator_kinds).toContain(CREATOR_KINDS.DETECTOR);
+  });
+
+  it('does NOT flag a loose detectX() call-site as a detector (would false-positive)', () => {
+    const r = detectCreator({
+      changedFiles: [{ path: 'lib/util/thing.js', added: 'const x = detectSomething(input);' }],
+    });
+    expect(r.is_creator).toBe(false);
   });
 
   it('does NOT flag edits to existing non-creator code', () => {

--- a/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
+++ b/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
@@ -1,0 +1,79 @@
+/**
+ * Operator Contract — venture binding (FR-7) + self-cadence/regression (FR-8) tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateVentureOperatorContract } from '../venture-adapter.js';
+import { registerOperatorContractCadence, regressionFalsePositives, OPERATOR_CONTRACT_PROCESS_KEY } from '../self-cadence.js';
+
+describe('evaluateVentureOperatorContract (FR-7 — shared validator at the venture seam)', () => {
+  const creatorStage = {
+    migrations: [{ path: 'venture/db/m.sql', sql: 'CREATE TABLE venture_signals (id uuid);' }],
+    changedFiles: [{ path: 'venture/writer.js', added: "supabase.from('venture_signals').insert(x)" }],
+    createdTables: ['venture_signals'],
+  };
+
+  it('BLOCKS a venture-stage CREATOR with no operator triple (same verdict as harness)', () => {
+    const r = evaluateVentureOperatorContract({ ...creatorStage, registryRows: [], retentionPolicies: [], now: new Date('2026-07-13') });
+    expect(r.verdict).toBe('fail');
+    expect(r.reason).toMatch(/OPERATOR_CONTRACT_INCOMPLETE/);
+    expect(r.missing).toContain('armed_cadence');
+    expect(r.missing).toContain('reaper');
+  });
+
+  it('PASSES a venture-stage CREATOR that ships its full triple', () => {
+    const r = evaluateVentureOperatorContract({
+      ...creatorStage,
+      changedFiles: [
+        { path: 'venture/writer.js', added: "supabase.from('venture_signals').insert(x)" },
+        { path: 'venture/consumer.js', added: "const {data} = await supabase.from('venture_signals').select('*')" },
+      ],
+      registryRows: [{ process_key: 'venture_signals-sweep', currently_expected_active: true, expected_interval_seconds: 3600 }],
+      retentionPolicies: [{ table: 'venture_signals' }],
+      now: new Date('2026-07-13'),
+    });
+    expect(r.verdict).toBe('pass');
+    expect(r.reason).toBe('OPERATOR_CONTRACT_COMPLETE');
+  });
+
+  it('is a no-op pass for a non-CREATOR venture stage', () => {
+    const r = evaluateVentureOperatorContract({ changedFiles: [{ path: 'venture/x.js', added: 'return 1;' }] });
+    expect(r.verdict).toBe('pass');
+    expect(r.reason).toMatch(/NOT_APPLICABLE/);
+  });
+});
+
+describe('registerOperatorContractCadence (FR-8 self-registration)', () => {
+  it('upserts an ARMED registry row for the gate itself via the shared primitive', async () => {
+    let upserted = null;
+    const supabase = { from: () => ({ upsert: async (row) => { upserted = row; return { error: null }; } }) };
+    const r = await registerOperatorContractCadence(supabase, { expectedIntervalSeconds: 3600 });
+    expect(r.ok).toBe(true);
+    expect(upserted.process_key).toMatch(/operator-contract-gate/);
+    expect(upserted.currently_expected_active).toBe(true);
+    expect(upserted.expected_interval_seconds).toBe(3600);
+    expect(OPERATOR_CONTRACT_PROCESS_KEY).toBe('operator-contract-gate');
+  });
+});
+
+describe('regressionFalsePositives (FR-8 / SC#5 zero-false-positive)', () => {
+  it('reports zero false-positives for a set of non-CREATOR SD diffs', () => {
+    const nonCreatorSds = [
+      { sd_key: 'SD-A', changedFiles: [{ path: 'lib/util/a.js', added: 'return x + 1;' }] },
+      { sd_key: 'SD-B', changedFiles: [{ path: 'lib/log.js', added: "supabase.from('audit_log').insert(row)" }] }, // existing table
+      { sd_key: 'SD-C', changedFiles: [{ path: 'src/ui/Btn.tsx', added: 'const detected = detectClick();' }] }, // loose detectX call
+      { sd_key: 'SD-D', changedFiles: [{ path: 'docs/readme.md', added: '# heading' }] },
+    ];
+    const r = regressionFalsePositives(nonCreatorSds);
+    expect(r.clean).toBe(true);
+    expect(r.falsePositives).toHaveLength(0);
+    expect(r.checked).toBe(4);
+  });
+
+  it('DOES report a genuine CREATOR (guards against the detector going blind)', () => {
+    const r = regressionFalsePositives([
+      { sd_key: 'SD-CREATOR', migrations: [{ path: 'm.sql', sql: 'CREATE TABLE new_thing (id uuid);' }] },
+    ]);
+    expect(r.clean).toBe(false);
+    expect(r.falsePositives[0].sd_key).toBe('SD-CREATOR');
+  });
+});

--- a/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
+++ b/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
@@ -51,7 +51,10 @@ describe('registerOperatorContractCadence (FR-8 self-registration)', () => {
     expect(upserted.process_key).toMatch(/operator-contract-gate/);
     expect(upserted.currently_expected_active).toBe(true);
     expect(upserted.expected_interval_seconds).toBe(3600);
-    expect(OPERATOR_CONTRACT_PROCESS_KEY).toBe('operator-contract-gate');
+    // The ARMED primitive prefixes the logical key — the exported process key must
+    // match the ACTUAL registry row so a witness lookup can find it.
+    expect(OPERATOR_CONTRACT_PROCESS_KEY).toBe('g3-armed-operator-contract-gate');
+    expect(upserted.process_key).toBe(OPERATOR_CONTRACT_PROCESS_KEY);
   });
 });
 

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -1,0 +1,169 @@
+/**
+ * Operator Contract — harness adapter (FR-5 enforcement point).
+ * (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001)
+ *
+ * Assembles the DB/git inputs for the pure core validator and produces a gate
+ * verdict for the handoff final-gate. This is the DB-reading layer; all decision
+ * logic lives in ./index.js so the harness gate and the venture seam (FR-7) share
+ * ONE validator with zero duplicated logic.
+ *
+ * FAIL-OPEN CONTRACT: this gate binds the SHARED PLAN-TO-LEAD pipeline that every
+ * session hits. Any execution error (git unavailable, DB read failure, parse
+ * error) resolves to PASS with a warning — never a false block. Only an
+ * unambiguous CREATOR-without-triple-and-no-valid-waiver produces a hard block.
+ */
+import { execSync } from 'node:child_process';
+import { evaluateOperatorContract, detectCreator, validateConsumer, validateCadence, validateReaper } from './index.js';
+import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
+
+/**
+ * Collect changed files (with added-line text) and migration SQL for an SD branch
+ * by diffing the branch tip against origin/main. Pure-ish: only shells out to git.
+ *
+ * @param {Object} opts
+ * @param {string} opts.appPath - repo root to run git in
+ * @param {string} [opts.baseRef='origin/main']
+ * @returns {{changedFiles: Array<{path,added}>, migrations: Array<{path,sql}>, createdTables: string[]}}
+ */
+export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
+  const run = (cmd) => execSync(cmd, { cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  // merge-base diff so we only see the SD's own changes
+  const nameOnly = run(`git diff --name-only ${baseRef}...HEAD`).split('\n').map((s) => s.trim()).filter(Boolean);
+  const changedFiles = [];
+  const migrations = [];
+  const createdTables = [];
+
+  for (const path of nameOnly) {
+    let added = '';
+    try {
+      // only the added lines (leading '+', excluding the +++ header)
+      const patch = run(`git diff ${baseRef}...HEAD -- "${path}"`);
+      added = patch.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).map((l) => l.slice(1)).join('\n');
+    } catch { /* fail-open per-file */ }
+
+    if (/\.sql$/i.test(path)) {
+      migrations.push({ path, sql: added });
+      const m = added.match(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?([a-z0-9_]+)/gi) || [];
+      for (const stmt of m) {
+        const name = stmt.replace(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?/i, '').trim();
+        if (name) createdTables.push(name);
+      }
+    } else {
+      changedFiles.push({ path, added });
+    }
+  }
+  return { changedFiles, migrations, createdTables: [...new Set(createdTables)] };
+}
+
+/**
+ * Resolve the full operator-contract verdict for an SD.
+ *
+ * @param {Object} opts
+ * @param {Object} opts.sd - strategic_directives_v2 row (metadata may hold operator_contract_waiver + capability keys)
+ * @param {string} opts.appPath
+ * @param {Object} opts.supabase
+ * @param {Date} [opts.now]
+ * @returns {Promise<{verdict, reason, missing, creator, waiver_audit}>}
+ */
+export async function resolveOperatorContract({ sd, appPath, supabase, now = new Date() }) {
+  const { changedFiles, migrations, createdTables } = collectSdDiff({ appPath });
+  const creator = detectCreator({ changedFiles, migrations });
+
+  // Short-circuit: non-CREATOR → no-op pass (no DB reads needed).
+  if (!creator.is_creator) {
+    return evaluateOperatorContract({ creator, triple: {}, now });
+  }
+
+  const consumer = validateConsumer({ changedFiles, createdTables });
+
+  // Capability keys for the cadence lookup: explicit metadata list, else derived from created tables.
+  const meta = sd?.metadata || {};
+  const capabilityKeys = Array.isArray(meta.operator_capability_keys) && meta.operator_capability_keys.length
+    ? meta.operator_capability_keys
+    : createdTables.flatMap((t) => [t, `${t}-sweep`, `${t}-reaper`, t.replace(/_/g, '-')]);
+
+  let registryRows = [];
+  try {
+    const { data } = await supabase.from('periodic_process_registry').select('process_key, enabled, schedule');
+    registryRows = data || [];
+  } catch { /* fail-open: no rows → cadence fails, but still a real verdict */ }
+  const cadence = validateCadence({ registryRows, capabilityKeys });
+
+  const reaper = validateReaper({ retentionPolicies: [...RETENTION_POLICIES, ...SOAK_ENTRIES], createdTables });
+
+  return evaluateOperatorContract({
+    creator,
+    triple: {
+      consumer_present: consumer.consumer_present,
+      cadence_armed: cadence.cadence_armed,
+      reaper_present: reaper.reaper_present,
+    },
+    waiver: meta.operator_contract_waiver || null,
+    now,
+  });
+}
+
+/**
+ * PLAN-TO-LEAD gate factory (FR-5). Additive, fail-open.
+ * @param {Object} supabase
+ * @param {Object} sd
+ * @param {string} appPath
+ */
+export function createOperatorContractGate(supabase, sd, appPath) {
+  return {
+    name: 'OPERATOR_CONTRACT',
+    required: true,
+    validator: async (ctx) => {
+      console.log('\n🔗 OPERATOR CONTRACT GATE (D8 build-vs-run)');
+      console.log('-'.repeat(50));
+      const targetSd = ctx?.sd || sd || {};
+      const repoPath = appPath || process.cwd();
+
+      let audited = false;
+      try {
+        const result = await resolveOperatorContract({ sd: targetSd, appPath: repoPath, supabase });
+
+        // Audit-log a valid waiver application (FR-6) — best-effort, non-blocking.
+        if (result.waiver_audit) {
+          try {
+            await supabase.from('audit_log').insert({
+              event: result.waiver_audit.event,
+              metadata: { sd_key: targetSd.sd_key, ...result.waiver_audit },
+            });
+            audited = true;
+          } catch { /* audit is best-effort */ }
+        }
+
+        if (result.verdict === 'pass') {
+          console.log(`   ✅ ${result.reason}`);
+          return {
+            passed: true, score: 100, max_score: 100, issues: [],
+            warnings: result.missing?.length ? [`waived missing: ${result.missing.join(', ')}`] : [],
+            details: { reason: result.reason, missing: result.missing, waiver_audited: audited },
+          };
+        }
+
+        console.log(`   ❌ ${result.reason}`);
+        console.log('   A CREATOR (new table/writer/flag/detector) must ship its OPERATOR TRIPLE:');
+        console.log('     • CONSUMER — code that acts on the created output');
+        console.log('     • ARMED CADENCE — a periodic_process_registry cron (not a bare CLI / off-by-default flag)');
+        console.log('     • REAPER — a lib/retention/policies.js entry');
+        console.log('   Or attach a dated waiver: metadata.operator_contract_waiver {owner, expiry, reason}');
+        return {
+          passed: false, score: 0, max_score: 100,
+          issues: [result.reason],
+          warnings: [],
+          details: { reason: result.reason, missing: result.missing, creator_kinds: result.creator?.creator_kinds },
+        };
+      } catch (err) {
+        // FAIL-OPEN: never false-block the shared pipeline on an execution error.
+        console.log(`   ⚠️  fail-open (execution error): ${err.message}`);
+        return {
+          passed: true, score: 100, max_score: 100, issues: [],
+          warnings: [`operator-contract gate fail-open: ${err.message}`],
+          details: { fail_open: true, error: err.message },
+        };
+      }
+    },
+  };
+}

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -84,7 +84,9 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
 
   let registryRows = [];
   try {
-    const { data } = await supabase.from('periodic_process_registry').select('process_key, enabled, schedule');
+    const { data } = await supabase
+      .from('periodic_process_registry')
+      .select('process_key, currently_expected_active, expected_interval_seconds, last_fired_at');
     registryRows = data || [];
   } catch { /* fail-open: no rows → cadence fails, but still a real verdict */ }
   const cadence = validateCadence({ registryRows, capabilityKeys });

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -41,24 +41,37 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
   const kinds = new Set();
   const evidence = [];
 
+  // First pass: tables this SD CREATEs (its own new persistent state).
+  const createdTables = [];
   for (const mig of migrations) {
     const sql = String(mig?.sql || '');
-    // CREATE TABLE (not CREATE TABLE ... only-if-temp, not CREATE INDEX/POLICY/VIEW)
-    const m = sql.match(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?([a-z0-9_.]+)/gi);
-    if (m) {
+    // CREATE TABLE (not CREATE INDEX/POLICY/VIEW).
+    const stmts = sql.match(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?([a-z0-9_.]+)/gi);
+    if (stmts) {
       kinds.add(CREATOR_KINDS.TABLE);
-      evidence.push(`migration ${mig.path}: ${m.length} CREATE TABLE statement(s)`);
+      evidence.push(`migration ${mig.path}: ${stmts.length} CREATE TABLE statement(s)`);
+      for (const s of stmts) {
+        const name = s.replace(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?/i, '').trim();
+        if (name) createdTables.push(name);
+      }
     }
   }
 
   for (const f of changedFiles) {
     const path = String(f?.path || '');
     const added = String(f?.added || '');
+    if (!/\.(?:js|cjs|mjs|ts)$/.test(path)) continue;
 
-    // WRITER: a module that inserts/updates a table.
-    if (/\.(?:js|cjs|mjs|ts)$/.test(path) && /\.(?:insert|upsert|update)\s*\(/.test(added)) {
-      kinds.add(CREATOR_KINDS.WRITER);
-      evidence.push(`writer: ${path} contains an insert/upsert/update call`);
+    // WRITER — a CREATOR signal ONLY when the writer targets a table this SD also
+    // CREATEs. Writing to an EXISTING table (audit_log, feedback, ...) is ordinary
+    // work, not a build-vs-run CREATOR — flagging it would false-positive nearly
+    // every SD (SC#5: zero false-positives across the last 10 non-CREATOR SDs).
+    if (createdTables.length && /\.(?:insert|upsert)\s*\(/.test(added)) {
+      const hit = createdTables.find((t) => added.includes(t));
+      if (hit) {
+        kinds.add(CREATOR_KINDS.WRITER);
+        evidence.push(`writer: ${path} inserts into newly-created table '${hit}'`);
+      }
     }
 
     // FLAG: a new leo_feature_flags insert.
@@ -67,10 +80,12 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
       evidence.push(`flag: ${path} inserts into leo_feature_flags`);
     }
 
-    // DETECTOR: a new detector/heuristic module (naming heuristic — conservative).
-    if (/(?:detector|heuristic)s?\/.*\.(?:js|cjs|mjs|ts)$/.test(path) || /\bdetect[A-Z]\w*\s*\(/.test(added)) {
+    // DETECTOR: a NEW detector/heuristic MODULE (path-based only — a loose
+    // `detectX(` call-site heuristic matches countless existing functions and
+    // would false-positive; the design means a new detector module).
+    if (/(?:detector|heuristic)s?\/[^/]*\.(?:js|cjs|mjs|ts)$/.test(path)) {
       kinds.add(CREATOR_KINDS.DETECTOR);
-      evidence.push(`detector: ${path} defines a detector/heuristic`);
+      evidence.push(`detector: ${path} defines a new detector/heuristic module`);
     }
   }
 

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -1,0 +1,252 @@
+/**
+ * Operator Contract gate — the D8 build-vs-run merge-time invariant.
+ * (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001, design:
+ *  docs/design/ehg-build-vs-run-deepdive-decisions.md @ aee41d6c §4)
+ *
+ * PURE MODULE — no DB access, no fs. Every input (changed files, migration SQL,
+ * periodic_process_registry rows, retention policy list, SD metadata) is injected
+ * so the same logic binds BOTH the harness handoff gate and the venture-factory
+ * seam (FR-7) with zero duplicated detection/validation logic. The DB-reading
+ * adapters live alongside this module and call these functions.
+ *
+ * The invariant: an SD that ships a CREATOR (new table / writer / feature flag /
+ * detector) may not pass its final gate unless the SAME SD (or a dated,
+ * audit-logged waiver) also ships its OPERATOR TRIPLE —
+ *   (1) CONSUMER      — code that acts on the created output,
+ *   (2) ARMED CADENCE — a periodic_process_registry-stamped, on-by-default cron,
+ *   (3) REAPER        — a retention/TTL/retire path (lib/retention/policies.js).
+ */
+
+export const CREATOR_KINDS = Object.freeze({
+  TABLE: 'table',
+  WRITER: 'writer',
+  FLAG: 'flag',
+  DETECTOR: 'detector',
+});
+
+export const TRIPLE_MEMBERS = Object.freeze(['consumer', 'armed_cadence', 'reaper']);
+
+/**
+ * FR-1 — CREATOR detection heuristic.
+ *
+ * Conservative-inclusive: ambiguous cases classify AS a CREATOR so the operator
+ * triple is demanded rather than silently skipped (TR-2 fail-toward-safe).
+ *
+ * @param {Object} input
+ * @param {Array<{path: string, added?: string}>} input.changedFiles - changed files with (optional) added-line text
+ * @param {Array<{path: string, sql: string}>} [input.migrations] - migration files with SQL body
+ * @returns {{is_creator: boolean, creator_kinds: string[], evidence: string[]}}
+ */
+export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
+  const kinds = new Set();
+  const evidence = [];
+
+  for (const mig of migrations) {
+    const sql = String(mig?.sql || '');
+    // CREATE TABLE (not CREATE TABLE ... only-if-temp, not CREATE INDEX/POLICY/VIEW)
+    const m = sql.match(/create\s+table\s+(?:if\s+not\s+exists\s+)?["`]?([a-z0-9_.]+)/gi);
+    if (m) {
+      kinds.add(CREATOR_KINDS.TABLE);
+      evidence.push(`migration ${mig.path}: ${m.length} CREATE TABLE statement(s)`);
+    }
+  }
+
+  for (const f of changedFiles) {
+    const path = String(f?.path || '');
+    const added = String(f?.added || '');
+
+    // WRITER: a module that inserts/updates a table.
+    if (/\.(?:js|cjs|mjs|ts)$/.test(path) && /\.(?:insert|upsert|update)\s*\(/.test(added)) {
+      kinds.add(CREATOR_KINDS.WRITER);
+      evidence.push(`writer: ${path} contains an insert/upsert/update call`);
+    }
+
+    // FLAG: a new leo_feature_flags insert.
+    if (/leo_feature_flags/.test(added) && /\.(?:insert|upsert)\s*\(/.test(added)) {
+      kinds.add(CREATOR_KINDS.FLAG);
+      evidence.push(`flag: ${path} inserts into leo_feature_flags`);
+    }
+
+    // DETECTOR: a new detector/heuristic module (naming heuristic — conservative).
+    if (/(?:detector|heuristic)s?\/.*\.(?:js|cjs|mjs|ts)$/.test(path) || /\bdetect[A-Z]\w*\s*\(/.test(added)) {
+      kinds.add(CREATOR_KINDS.DETECTOR);
+      evidence.push(`detector: ${path} defines a detector/heuristic`);
+    }
+  }
+
+  return {
+    is_creator: kinds.size > 0,
+    creator_kinds: [...kinds],
+    evidence,
+  };
+}
+
+/**
+ * FR-2 — CONSUMER validator. A consumer READS the created output and acts on it.
+ * We look for a read-path (select/read/get against the created table/flag) in a
+ * non-test changed file. A test file alone does not count as a consumer.
+ *
+ * @param {Object} input
+ * @param {Array<{path: string, added?: string}>} input.changedFiles
+ * @param {string[]} [input.createdTables] - table names the SD creates (from migrations)
+ * @returns {{consumer_present: boolean, evidence: string[]}}
+ */
+export function validateConsumer({ changedFiles = [], createdTables = [] } = {}) {
+  const evidence = [];
+  for (const f of changedFiles) {
+    const path = String(f?.path || '');
+    const added = String(f?.added || '');
+    if (/(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(path)) continue; // tests are not consumers
+    const readsSomething = /\.(?:select|maybeSingle|single)\s*\(/.test(added) || /\bread[A-Z]\w*\s*\(/.test(added);
+    if (!readsSomething) continue;
+    if (createdTables.length === 0) {
+      evidence.push(`consumer: ${path} contains a read-path acting on created output`);
+    } else if (createdTables.some((t) => added.includes(t))) {
+      evidence.push(`consumer: ${path} reads created table(s): ${createdTables.filter((t) => added.includes(t)).join(', ')}`);
+    }
+  }
+  return { consumer_present: evidence.length > 0, evidence };
+}
+
+/**
+ * FR-3 — ARMED CADENCE validator. The capability must be driven by a
+ * periodic_process_registry row that is ENABLED with a non-null schedule. A bare
+ * CLI (no registry row) or an off-by-default flag does NOT satisfy this.
+ *
+ * @param {Object} input
+ * @param {Array<{process_key: string, enabled?: boolean, schedule?: string|null}>} input.registryRows
+ * @param {string[]} input.capabilityKeys - candidate process_keys tied to the SD capability
+ * @returns {{cadence_armed: boolean, process_key: string|null, evidence: string[]}}
+ */
+export function validateCadence({ registryRows = [], capabilityKeys = [] } = {}) {
+  for (const key of capabilityKeys) {
+    const row = registryRows.find((r) => r?.process_key === key);
+    if (!row) continue;
+    if (row.enabled === true && row.schedule != null && String(row.schedule).trim() !== '') {
+      return {
+        cadence_armed: true,
+        process_key: key,
+        evidence: [`armed cadence: periodic_process_registry '${key}' enabled with schedule '${row.schedule}'`],
+      };
+    }
+  }
+  return {
+    cadence_armed: false,
+    process_key: null,
+    evidence: [
+      capabilityKeys.length === 0
+        ? 'no capability key supplied for cadence lookup'
+        : `no armed registry row for: ${capabilityKeys.join(', ')} (bare CLI / off-by-default does not satisfy)`,
+    ],
+  };
+}
+
+/**
+ * FR-4 — REAPER validator. The created data must have a retention/TTL/retire path:
+ * an entry in lib/retention/policies.js RETENTION_POLICIES (or SOAK_ENTRIES) keyed
+ * to the created table.
+ *
+ * @param {Object} input
+ * @param {Array<{table: string}>} input.retentionPolicies - RETENTION_POLICIES (+ SOAK_ENTRIES)
+ * @param {string[]} input.createdTables
+ * @returns {{reaper_present: boolean, policy_key: string|null, evidence: string[]}}
+ */
+export function validateReaper({ retentionPolicies = [], createdTables = [] } = {}) {
+  // No created tables → nothing to reap (table CREATOR check is table-scoped).
+  if (createdTables.length === 0) {
+    return { reaper_present: true, policy_key: null, evidence: ['no created table requires a reaper'] };
+  }
+  const covered = createdTables.filter((t) => retentionPolicies.some((p) => p?.table === t));
+  const missing = createdTables.filter((t) => !covered.includes(t));
+  if (missing.length === 0) {
+    return {
+      reaper_present: true,
+      policy_key: covered.join(', '),
+      evidence: [`reaper: retention policy covers ${covered.join(', ')}`],
+    };
+  }
+  return {
+    reaper_present: false,
+    policy_key: null,
+    evidence: [`reaper MISSING for created table(s): ${missing.join(', ')} (add to lib/retention/policies.js)`],
+  };
+}
+
+/**
+ * FR-6 — Waiver evaluator. A dated waiver with a FUTURE expiry lets a CREATOR SD
+ * pass; an expired or malformed waiver does NOT. Shape:
+ *   { owner: string, reason: string, expiry: ISO-8601, granted_at?: ISO-8601 }
+ *
+ * @param {Object|null|undefined} waiver
+ * @param {Date} [now]
+ * @returns {{valid: boolean, reason: string, audit: Object|null}}
+ */
+export function evaluateWaiver(waiver, now = new Date()) {
+  if (waiver == null) return { valid: false, reason: 'no waiver', audit: null };
+  if (typeof waiver !== 'object' || Array.isArray(waiver)) {
+    return { valid: false, reason: 'waiver malformed (not an object)', audit: null };
+  }
+  const { owner, expiry } = waiver;
+  if (!owner || typeof owner !== 'string') {
+    return { valid: false, reason: 'waiver malformed (missing owner)', audit: null };
+  }
+  if (!expiry) {
+    return { valid: false, reason: 'waiver malformed (missing expiry)', audit: null };
+  }
+  const expiryMs = Date.parse(expiry);
+  if (Number.isNaN(expiryMs)) {
+    return { valid: false, reason: `waiver malformed (unparseable expiry: ${expiry})`, audit: null };
+  }
+  if (expiryMs <= now.getTime()) {
+    return { valid: false, reason: `waiver expired at ${expiry}`, audit: null };
+  }
+  return {
+    valid: true,
+    reason: `waiver valid until ${expiry}`,
+    audit: { event: 'OPERATOR_CONTRACT_WAIVER_APPLIED', owner, expiry, reason: waiver.reason || null },
+  };
+}
+
+/**
+ * FR-5 — Composite operator-contract evaluation (the gate verdict).
+ *
+ * @param {Object} input
+ * @param {ReturnType<typeof detectCreator>} input.creator
+ * @param {{consumer_present: boolean, cadence_armed: boolean, reaper_present: boolean}} input.triple
+ * @param {Object|null} [input.waiver] - raw SD metadata.operator_contract_waiver
+ * @param {Date} [input.now]
+ * @returns {{verdict: 'pass'|'fail', reason: string, missing: string[], waiver_audit: Object|null}}
+ */
+export function evaluateOperatorContract({ creator, triple, waiver = null, now = new Date() } = {}) {
+  // Non-CREATOR SD → the gate is a no-op pass (FR-5 AC3, zero false-positives).
+  if (!creator || !creator.is_creator) {
+    return { verdict: 'pass', reason: 'OPERATOR_CONTRACT_NOT_APPLICABLE (non-CREATOR)', missing: [], waiver_audit: null };
+  }
+
+  const missing = [];
+  if (!triple?.consumer_present) missing.push('consumer');
+  if (!triple?.cadence_armed) missing.push('armed_cadence');
+  if (!triple?.reaper_present) missing.push('reaper');
+
+  if (missing.length === 0) {
+    return { verdict: 'pass', reason: 'OPERATOR_CONTRACT_COMPLETE', missing: [], waiver_audit: null };
+  }
+
+  // Triple incomplete — a valid waiver rescues it (and must be audit-logged).
+  const w = evaluateWaiver(waiver, now);
+  if (w.valid) {
+    return {
+      verdict: 'pass',
+      reason: `OPERATOR_CONTRACT_WAIVED (${w.reason}); missing: ${missing.join(', ')}`,
+      missing,
+      waiver_audit: w.audit,
+    };
+  }
+
+  return {
+    verdict: 'fail',
+    reason: `OPERATOR_CONTRACT_INCOMPLETE — missing: ${missing.join(', ')} (${w.reason})`,
+    missing,
+    waiver_audit: null,
+  };
+}

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -125,33 +125,46 @@ export function validateConsumer({ changedFiles = [], createdTables = [] } = {})
 
 /**
  * FR-3 — ARMED CADENCE validator. The capability must be driven by a
- * periodic_process_registry row that is ENABLED with a non-null schedule. A bare
- * CLI (no registry row) or an off-by-default flag does NOT satisfy this.
+ * periodic_process_registry row that is ACTIVE (currently_expected_active=true)
+ * with a positive expected_interval_seconds. A bare CLI (no registry row) or an
+ * inactive/off registration does NOT satisfy this. `last_fired_at` (when present)
+ * is surfaced as the WITNESS that the cadence has genuinely fired.
+ *
+ * Column names mirror the live periodic_process_registry schema
+ * (lib/machinery-class/armed-registration.js): currently_expected_active,
+ * expected_interval_seconds, last_fired_at.
  *
  * @param {Object} input
- * @param {Array<{process_key: string, enabled?: boolean, schedule?: string|null}>} input.registryRows
+ * @param {Array<{process_key: string, currently_expected_active?: boolean, expected_interval_seconds?: number, last_fired_at?: string|null}>} input.registryRows
  * @param {string[]} input.capabilityKeys - candidate process_keys tied to the SD capability
- * @returns {{cadence_armed: boolean, process_key: string|null, evidence: string[]}}
+ * @returns {{cadence_armed: boolean, process_key: string|null, witnessed: boolean, evidence: string[]}}
  */
 export function validateCadence({ registryRows = [], capabilityKeys = [] } = {}) {
   for (const key of capabilityKeys) {
     const row = registryRows.find((r) => r?.process_key === key);
     if (!row) continue;
-    if (row.enabled === true && row.schedule != null && String(row.schedule).trim() !== '') {
+    const interval = Number(row.expected_interval_seconds);
+    if (row.currently_expected_active === true && Number.isFinite(interval) && interval > 0) {
+      const witnessed = row.last_fired_at != null;
       return {
         cadence_armed: true,
         process_key: key,
-        evidence: [`armed cadence: periodic_process_registry '${key}' enabled with schedule '${row.schedule}'`],
+        witnessed,
+        evidence: [
+          `armed cadence: periodic_process_registry '${key}' active every ${interval}s` +
+            (witnessed ? ` (witness: last fired ${row.last_fired_at})` : ' (ARMED, not yet fired)'),
+        ],
       };
     }
   }
   return {
     cadence_armed: false,
     process_key: null,
+    witnessed: false,
     evidence: [
       capabilityKeys.length === 0
         ? 'no capability key supplied for cadence lookup'
-        : `no armed registry row for: ${capabilityKeys.join(', ')} (bare CLI / off-by-default does not satisfy)`,
+        : `no active registry row for: ${capabilityKeys.join(', ')} (bare CLI / inactive registration does not satisfy)`,
     ],
   };
 }

--- a/lib/gates/operator-contract/self-cadence.js
+++ b/lib/gates/operator-contract/self-cadence.js
@@ -1,0 +1,53 @@
+/**
+ * Operator Contract — self-cadence + regression (FR-8).
+ * (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001)
+ *
+ * The gate must satisfy its OWN contract: it operates on a registered cadence with
+ * a witness, not merely as inline merge-time code. This registers the gate in
+ * periodic_process_registry (reusing the existing ARMED-registration primitive —
+ * no new table, no schema change) and provides the zero-false-positive regression
+ * harness over recently-merged non-CREATOR SDs (SC#5).
+ */
+import { registerArmedMachinery } from '../../machinery-class/armed-registration.js';
+import { detectCreator } from './index.js';
+
+export const OPERATOR_CONTRACT_PROCESS_KEY = 'operator-contract-gate';
+
+/**
+ * Register the operator-contract gate itself on a cadence with an activation
+ * trigger. ARMED until the gate first fires at a real PLAN-TO-LEAD, at which point
+ * the owning path stamps last_fired_at (the witness).
+ *
+ * @param {Object} supabase - service-role client
+ * @param {{expectedIntervalSeconds?: number}} [opts]
+ * @returns {Promise<{ok: boolean, processKey?: string, error?: string}>}
+ */
+export async function registerOperatorContractCadence(supabase, opts = {}) {
+  return registerArmedMachinery(
+    supabase,
+    { sd_key: OPERATOR_CONTRACT_PROCESS_KEY },
+    {
+      activationTrigger: 'operator_contract_gate_fired_at_plan_to_lead',
+      owner: 'operator-contract-gate',
+      expectedIntervalSeconds: opts.expectedIntervalSeconds || 86400,
+    },
+  );
+}
+
+/**
+ * Zero-false-positive regression (SC#5): run detectCreator over a set of already
+ * merged, known non-CREATOR SD diffs and assert NONE is classified as a CREATOR.
+ * Pure — the caller supplies the diffs (from git or fixtures) so this stays
+ * testable and DB-free.
+ *
+ * @param {Array<{sd_key: string, changedFiles?: Array, migrations?: Array}>} sdDiffs
+ * @returns {{falsePositives: Array<{sd_key, creator_kinds}>, checked: number, clean: boolean}}
+ */
+export function regressionFalsePositives(sdDiffs = []) {
+  const falsePositives = [];
+  for (const d of sdDiffs) {
+    const r = detectCreator({ changedFiles: d.changedFiles || [], migrations: d.migrations || [] });
+    if (r.is_creator) falsePositives.push({ sd_key: d.sd_key, creator_kinds: r.creator_kinds });
+  }
+  return { falsePositives, checked: sdDiffs.length, clean: falsePositives.length === 0 };
+}

--- a/lib/gates/operator-contract/self-cadence.js
+++ b/lib/gates/operator-contract/self-cadence.js
@@ -8,10 +8,18 @@
  * no new table, no schema change) and provides the zero-false-positive regression
  * harness over recently-merged non-CREATOR SDs (SC#5).
  */
-import { registerArmedMachinery } from '../../machinery-class/armed-registration.js';
+import { registerArmedMachinery, armedProcessKey } from '../../machinery-class/armed-registration.js';
 import { detectCreator } from './index.js';
 
-export const OPERATOR_CONTRACT_PROCESS_KEY = 'operator-contract-gate';
+/** Logical key passed to the ARMED primitive. */
+export const OPERATOR_CONTRACT_LOGICAL_KEY = 'operator-contract-gate';
+
+/**
+ * The ACTUAL periodic_process_registry.process_key of the gate's self-registration
+ * (the ARMED primitive prefixes the logical key). Use THIS to look up the row /
+ * its witness (last_fired_at).
+ */
+export const OPERATOR_CONTRACT_PROCESS_KEY = armedProcessKey(OPERATOR_CONTRACT_LOGICAL_KEY);
 
 /**
  * Register the operator-contract gate itself on a cadence with an activation
@@ -25,7 +33,7 @@ export const OPERATOR_CONTRACT_PROCESS_KEY = 'operator-contract-gate';
 export async function registerOperatorContractCadence(supabase, opts = {}) {
   return registerArmedMachinery(
     supabase,
-    { sd_key: OPERATOR_CONTRACT_PROCESS_KEY },
+    { sd_key: OPERATOR_CONTRACT_LOGICAL_KEY },
     {
       activationTrigger: 'operator_contract_gate_fired_at_plan_to_lead',
       owner: 'operator-contract-gate',

--- a/lib/gates/operator-contract/venture-adapter.js
+++ b/lib/gates/operator-contract/venture-adapter.js
@@ -18,6 +18,7 @@ import {
   validateCadence,
   validateReaper,
   evaluateOperatorContract,
+  CREATOR_KINDS,
 } from './index.js';
 
 /**
@@ -50,6 +51,16 @@ export function evaluateVentureOperatorContract({
   now = new Date(),
 } = {}) {
   const creator = detectCreator({ changedFiles, migrations });
+
+  // The venture seam declares its created persistent output via metadata
+  // (created_tables), not always as raw migration SQL. An explicitly-declared
+  // created table IS a TABLE CREATOR even when detectCreator saw no CREATE TABLE.
+  if (createdTables.length && !creator.creator_kinds.includes(CREATOR_KINDS.TABLE)) {
+    creator.creator_kinds.push(CREATOR_KINDS.TABLE);
+    creator.evidence.push(`venture-declared created table(s): ${createdTables.join(', ')}`);
+    creator.is_creator = true;
+  }
+
   if (!creator.is_creator) {
     return evaluateOperatorContract({ creator, triple: {}, now });
   }

--- a/lib/gates/operator-contract/venture-adapter.js
+++ b/lib/gates/operator-contract/venture-adapter.js
@@ -1,0 +1,72 @@
+/**
+ * Operator Contract — venture-factory binding (FR-7).
+ * (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001)
+ *
+ * Ventures inherit operate-by-default: a venture-stage CREATOR (a stage that
+ * produces new persistent output — a new table/writer/flag/detector) is held to
+ * the SAME operator-contract as a harness SD, at the venture completion seam.
+ *
+ * CRITICAL (FR-7 AC): this calls the SHARED core validator (detectCreator +
+ * triple validators + evaluateOperatorContract from ./index.js). There is NO
+ * duplicated detection/validation logic — the venture seam and the harness gate
+ * are ONE validator with two input adapters. If the harness heuristics change,
+ * the venture binding changes with them automatically.
+ */
+import {
+  detectCreator,
+  validateConsumer,
+  validateCadence,
+  validateReaper,
+  evaluateOperatorContract,
+} from './index.js';
+
+/**
+ * Evaluate the operator contract for a venture-stage output.
+ *
+ * The caller (the venture completion seam) supplies the stage's changed files /
+ * migrations (however the factory represents them), the live
+ * periodic_process_registry rows, the retention policy list, and any waiver — the
+ * SAME inputs the harness adapter assembles, just from venture sources.
+ *
+ * @param {Object} input
+ * @param {Array<{path,added}>} [input.changedFiles]
+ * @param {Array<{path,sql}>} [input.migrations]
+ * @param {string[]} [input.createdTables]
+ * @param {Array<Object>} [input.registryRows]
+ * @param {Array<{table:string}>} [input.retentionPolicies]
+ * @param {string[]} [input.capabilityKeys]
+ * @param {Object|null} [input.waiver]
+ * @param {Date} [input.now]
+ * @returns {{verdict:'pass'|'fail', reason:string, missing:string[], waiver_audit:Object|null}}
+ */
+export function evaluateVentureOperatorContract({
+  changedFiles = [],
+  migrations = [],
+  createdTables = [],
+  registryRows = [],
+  retentionPolicies = [],
+  capabilityKeys = [],
+  waiver = null,
+  now = new Date(),
+} = {}) {
+  const creator = detectCreator({ changedFiles, migrations });
+  if (!creator.is_creator) {
+    return evaluateOperatorContract({ creator, triple: {}, now });
+  }
+
+  const consumer = validateConsumer({ changedFiles, createdTables });
+  const keys = capabilityKeys.length ? capabilityKeys : createdTables.flatMap((t) => [t, `${t}-sweep`, t.replace(/_/g, '-')]);
+  const cadence = validateCadence({ registryRows, capabilityKeys: keys });
+  const reaper = validateReaper({ retentionPolicies, createdTables });
+
+  return evaluateOperatorContract({
+    creator,
+    triple: {
+      consumer_present: consumer.consumer_present,
+      cadence_armed: cadence.cadence_armed,
+      reaper_present: reaper.reaper_present,
+    },
+    waiver,
+    now,
+  });
+}

--- a/scripts/lint/schema-reference-allowlist.json
+++ b/scripts/lint/schema-reference-allowlist.json
@@ -1,6 +1,10 @@
 {
  "_comment": "schema-reference-lint escapes (SD-LEO-INFRA-SCHEMA-REFERENCE-LINT-001). files: repo-relative paths whose DB client targets ANOTHER database (e.g. the EHG app project) or whose table names are dynamic/templated. tables: relation names to skip everywhere (e.g. tables that exist only in the EHG app DB but are referenced from cross-DB scripts). Prefer the inline pragma (schema-lint-disable-line) for single intentional lines.",
- "files": [],
+ "files": [
+  "lib/gates/operator-contract/__tests__/operator-contract.test.js",
+  "lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js"
+ ],
+ "_operator_contract_test_note": "SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001: these unit tests use deliberately-fictional fixture table names (foo_events, venture_signals) to exercise detectCreator/consumer/reaper against synthetic CREATOR diffs — they are not real relations.",
  "tables": [
   "north_star",
   "vision_ladder_rungs",

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
@@ -46,3 +46,9 @@ export { createRcaFeedbackLoopGate } from '../../exec-to-plan/gates/rca-feedback
 // to LEO at PLAN-TO-LEAD. Scoped-block (only a stage-config-relevant SD's real drift),
 // WARN on unrelated pre-existing drift, fail-open on execution error.
 export { createCrossRepoStageConfigDriftGate } from './cross-repo-stage-config-drift.js';
+
+// Operator Contract Gate (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001, D8 build-vs-run)
+// Blocks a CREATOR (new table/writer/flag/detector) that lacks its OPERATOR TRIPLE
+// (consumer + armed cadence + reaper) unless a dated, audit-logged waiver applies.
+// Fail-open on execution error — only an unambiguous incomplete-triple hard-blocks.
+export { createOperatorContractGate } from '../../../../../../lib/gates/operator-contract/harness-adapter.js';

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -50,7 +50,9 @@ import {
   createChildScopeCoverageGate,
   // Vision Fidelity Gate (SD-LEO-INFRA-VISION-FIDELITY-GATE-001 FR-2)
   createVisionFidelityGate,
-  createCrossRepoStageConfigDriftGate
+  createCrossRepoStageConfigDriftGate,
+  // Operator Contract Gate (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001, D8)
+  createOperatorContractGate
 } from './gates/index.js';
 // Note: requiresTraceabilityGates is re-exported via 'export * from ./gates/index.js'
 
@@ -351,6 +353,12 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // LEAD-FINAL. Scoped-block (only this SD's real drift), WARN on unrelated pre-existing
     // drift, fail-open on execution error (DB down / sibling repo absent / git error).
     gates.push(createCrossRepoStageConfigDriftGate(this.supabase));
+
+    // Operator Contract Gate (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001, D8 build-vs-run):
+    // a CREATOR (new table/writer/flag/detector) may not pass its final gate without its
+    // OPERATOR TRIPLE (consumer + armed cadence + reaper) or a dated, audit-logged waiver.
+    // Fail-open on execution error — only an unambiguous incomplete-triple hard-blocks.
+    gates.push(createOperatorContractGate(this.supabase, sd, appPath));
 
     // DB Content Parity — runs before /learn (SD-LEO-INFRA-CODE-CONTENT-PARITY-001)
     gates.push(createDbContentParityGate());

--- a/tests/unit/eva/bridge/venture-build-merge-witness.test.js
+++ b/tests/unit/eva/bridge/venture-build-merge-witness.test.js
@@ -255,4 +255,26 @@ describe('TS-7 — dryRun=true ⇒ the witness never runs (no telemetry)', () =>
     expect(calls.length).toBe(0);
     expect((tables.merge_witness_telemetry || []).length).toBe(0);
   });
+
+  // Operator Contract fractal binding (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001 FR-7):
+  // a venture-stage CREATOR (leaf declaring created_tables) without its operator triple
+  // is surfaced as an observe-only advisory via the SHARED validator — same verdict a
+  // harness SD gets. Never blocks the observe-only walk.
+  it('FR-7: surfaces an operator-contract advisory for a venture CREATOR leaf lacking its triple', async () => {
+    const sb = new MockSB({});
+    const deps = { prLookup: async () => ({ pr_number: 900 }), verifyMerged: async () => true, registryRows: [], retentionPolicies: [] };
+    const leaf = { id: 'leaf-oc', sd_key: 'LEAF-OC', metadata: { created_tables: ['venture_signals'] } };
+    const summary = await observeLeafMergeWitness({ supabase: sb, leaf, ventureId: VID, deps });
+    expect(summary.operatorContract).toBeTruthy();
+    expect(summary.operatorContract.verdict).toBe('fail');
+    expect(summary.operatorContract.missing).toContain('reaper');
+    expect(summary.mergedState).toBe('merged'); // advisory does NOT alter the merge observation
+  });
+
+  it('FR-7: no operator-contract advisory for a non-CREATOR leaf (no created_tables)', async () => {
+    const sb = new MockSB({});
+    const deps = { prLookup: async () => ({ pr_number: 901 }), verifyMerged: async () => true };
+    const summary = await observeLeafMergeWitness({ supabase: sb, leaf: { id: 'l2', sd_key: 'LEAF-N2', metadata: {} }, ventureId: VID, deps });
+    expect(summary.operatorContract).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
Implements the D8 build-vs-run **Operator Contract** gate: a CREATOR (new table/writer/flag/detector) may not pass its final gate without its OPERATOR TRIPLE — a CONSUMER, an ARMED CADENCE (periodic_process_registry cron, not a bare CLI/off-by-default flag), and a REAPER (lib/retention/policies.js) — or a dated, audit-logged waiver.

- **Core validator** (`lib/gates/operator-contract/index.js`): detectCreator, consumer/cadence/reaper validators, waiver eval, composite verdict (FR-1..FR-6).
- **Harness enforcement** (`harness-adapter.js`): wired into the PLAN-TO-LEAD gate pipeline, fail-open (only an unambiguous incomplete-triple hard-blocks) (FR-5).
- **Venture binding** (`venture-adapter.js`): bound into `venture-build-merge-witness.js` as an observe-only advisory via the SAME shared validator, no duplicated logic (FR-7).
- **Self-cadence + regression** (`self-cadence.js`): the gate self-registers in periodic_process_registry (ARMED) + a zero-false-positive regression harness (FR-8, SC#5).
- Detection tightened so writing to an existing table / a loose detectX() call are NOT CREATORs (protects SC#5). Cadence validator schema-aligned to the live registry columns.

## Test plan
- 44 unit tests pass (core, harness-adapter fail-open, venture binding, self-cadence, regression, witness-seam advisory).
- Gate's own cadence row is live + ARMED in periodic_process_registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)