### PR TITLE
feat(SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001): arm payment-attribution resolver on a registry-stamped cron

### DIFF
--- a/.github/workflows/payment-attribution-cron.yml
+++ b/.github/workflows/payment-attribution-cron.yml
@@ -1,0 +1,50 @@
+name: "Payment attribution sweep (cron)"
+
+# SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001 — arms
+# lib/payments/attribution-resolver.js's resolveUnattributedEvents() on a schedule
+# instead of the manual-only scripts/backfill-payment-attribution.mjs CLI. The
+# resolver itself shipped complete under SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002;
+# its own runbook explicitly deferred scheduling — this workflow is that follow-up.
+# See scripts/cron/payment-attribution-sweep.mjs for the ARMED registration + the
+# per-cycle summary log (periodic_process_registry witness proof).
+
+on:
+  schedule:
+    # Every 6 hours — matches the sibling venture-ops-actuals-cron.yml cadence;
+    # attribution has no real-time urgency (revenue is still captured immediately
+    # by the ingester, only venture_id is deferred), so tighter polling isn't needed.
+    - cron: '35 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: Payment-attribution resolver
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run sweep (--once)
+        run: node scripts/cron/payment-attribution-sweep.mjs --once

--- a/docs/runbooks/payment-rail-attribution-resolver.md
+++ b/docs/runbooks/payment-rail-attribution-resolver.md
@@ -2,7 +2,7 @@
 category: runbook
 status: active
 sd: SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002
-last_updated: 2026-07-10
+last_updated: 2026-07-13
 ---
 
 # Payment Rail — Venture Attribution Resolver (Phase 2)
@@ -20,12 +20,18 @@ Phase 1 (`SD-LEO-INFRA-PAYMENT-RAIL-FOUNDATION-001`) captures every Stripe webho
 
 ## Running it
 
-- **Ongoing**: wire `resolveUnattributedEvents(supabase, { limit: 500 })` into a cron/scheduled job (not yet scheduled as of this SD — FR-5 ships the mechanism; scheduling is a follow-up).
-- **One-shot backfill**: `node scripts/backfill-payment-attribution.mjs` — loops `resolveUnattributedEvents` until a round processes zero rows. Safe to interrupt/re-run.
+- **Ongoing (ARMED, SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001)**: `scripts/cron/payment-attribution-sweep.mjs` wires `resolveUnattributedEvents(supabase, { limit: 500 })` into a registry-stamped cron (`.github/workflows/payment-attribution-cron.yml`, every 6h) — registers a `periodic_process_registry` row via `registerArmedMachinery`/`armedProcessKey` and stamps `last_fired_at` on each successful cycle, so the cron's liveness is provable (not just runnable-in-theory).
+- **One-shot backfill**: `node scripts/backfill-payment-attribution.mjs` — loops `resolveUnattributedEvents` until a round processes zero rows. Safe to interrupt/re-run; still useful for an out-of-cycle manual pass.
+
+## Provenance contract for any FUTURE checkout implementation
+
+As of 2026-07-13 (ARM-001 EXEC investigation), **no live checkout mechanism exists yet for any venture** — the live Stripe account has zero products, zero prices, zero payment links configured, and `createVentureCheckoutSession()` (`lib/payments/checkout-provenance.js`) is called by nothing in production. Building a venture's actual checkout/payment flow is out of scope for this infrastructure track (it routes through the venture factory/stage-build pipeline, not a LEO harness SD) — but **whoever builds it must call `createVentureCheckoutSession()`** (or stamp `metadata.venture_id` / `metadata.source_surface` equivalently, e.g. on a Stripe Payment Link's dashboard-configured metadata) for that venture's revenue to ever be attributed. Skipping this means every resulting `ops_payment_events` row resolves `attribution_status='unattributed'` forever — the resolver has no lineage to fall back on for a venture's *first* payment. Alt-Text (venture `50763b6a-1fad-4e1e-b2fc-296a1d66ebf9`) is the nearest venture expected to need this.
 
 ## The paid-revenue KPI (`computePaidGaugeState`)
 
 `lib/telemetry/funnel-gauge.mjs` `computePaidGaugeState({ supabase, ventureId })` is fail-closed: it returns `state: 'gated_on_attribution'` until the resolver has run at least once anywhere in the fleet (`attribution_status IS NOT NULL` on at least one row). Once resolver coverage exists, it returns `state: 'live'` with `paid_amount_cents`, `currency`, and `unattributed_count_fleet_wide` (always surfaced, never hidden, even when zero).
+
+**Confirmed intended (ARM-001 FR-5):** the readiness check above is fleet-wide, not per-venture — the *first* time the resolver processes any row anywhere (including a synthetic test-mode proof event), `gated_on_attribution` flips to `live` for every venture's gauge. This is safe: the actual `paid_amount_cents` computation separately filters `.eq('livemode', true)`, so a test-mode proof event changes only the *readiness* state, never the dollar figure.
 
 ### Revenue must be deduped by payment identity, not summed per row
 

--- a/scripts/cron/payment-attribution-sweep.mjs
+++ b/scripts/cron/payment-attribution-sweep.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Payment-attribution sweep — arms lib/payments/attribution-resolver.js's
+ * resolveUnattributedEvents() on a registry-stamped cadence instead of the
+ * manual-only scripts/backfill-payment-attribution.mjs CLI.
+ *
+ * SD: SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001 (FR-3)
+ *
+ * The resolver itself (SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002) shipped complete
+ * and DB-only (no live Stripe API calls) but its own runbook explicitly deferred
+ * scheduling — this script is that deferred follow-up. Registered as a G3 ARMED
+ * standalone_cron (lib/machinery-class/armed-registration.js) so a zero-backlog
+ * cycle (the common case — most cycles have nothing pending) is a normal, silent
+ * pass, while periodic_process_registry still proves the cron is genuinely firing
+ * via last_fired_at, satisfying the Operator-Contract "armed cron + witness" bar.
+ *
+ * Usage:
+ *   node scripts/cron/payment-attribution-sweep.mjs --once
+ *   node scripts/cron/payment-attribution-sweep.mjs --once --dry-run
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { createClient } from '@supabase/supabase-js';
+import { resolveUnattributedEvents } from '../../lib/payments/attribution-resolver.js';
+import { registerArmedMachinery, armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+
+export const SD_KEY = 'SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001';
+export const ACTIVATION_TRIGGER = '.github/workflows/payment-attribution-cron.yml';
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+/** Ensure ARMED registration exists WITHOUT wiping last_fired_at on re-run. */
+export async function ensureArmedRegistration(supabase, logger) {
+  const processKey = armedProcessKey(SD_KEY);
+  try {
+    const { data } = await supabase
+      .from('periodic_process_registry')
+      .select('process_key')
+      .eq('process_key', processKey)
+      .maybeSingle();
+    if (!data) {
+      const reg = await registerArmedMachinery(supabase, { sd_key: SD_KEY }, {
+        activationTrigger: ACTIVATION_TRIGGER,
+        expectedIntervalSeconds: 6 * 60 * 60, // 6h cadence — matches the sibling ops-actuals cron
+        owner: 'payment-attribution-resolver',
+      });
+      if (!reg.ok) logger.warn?.(`[payment-attribution-sweep] ARMED registration failed (non-fatal): ${reg.error}`);
+    }
+  } catch (err) {
+    logger.warn?.(`[payment-attribution-sweep] ARMED registration check failed (non-fatal): ${err.message}`);
+  }
+  return processKey;
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('payment-attribution-sweep --once [--dry-run]');
+    return { exitCode: 0, action: 'help' };
+  }
+
+  const logger = deps.logger || console;
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) {
+    logger.error?.(`[payment-attribution-sweep] supabase client unavailable: ${err.message}`);
+    return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  if (args.dryRun) {
+    logger.log?.('[payment-attribution-sweep] dry-run — skipping registration, resolution, and liveness stamp');
+    return { exitCode: 0, action: 'dry_run' };
+  }
+
+  const processKey = await ensureArmedRegistration(supabase, logger);
+
+  let result;
+  try {
+    result = await (deps.resolveUnattributedEvents || resolveUnattributedEvents)(supabase, { limit: 500 });
+  } catch (err) {
+    logger.error?.(`[payment-attribution-sweep] resolveUnattributedEvents failed: ${err.message}`);
+    // Liveness is only stamped on a genuinely successful cycle — a thrown resolver
+    // error must NOT read as "fired fine" to anything watching last_fired_at.
+    return { exitCode: 1, action: 'resolver_error', error: err.message };
+  }
+
+  try {
+    await (deps.stampLastFired || stampLastFired)(supabase, processKey);
+  } catch (err) {
+    logger.warn?.(`[payment-attribution-sweep] liveness stamp failed (non-fatal): ${err.message}`);
+  }
+
+  const summary = { ts: new Date().toISOString(), ...result };
+  logger.log?.(`[payment-attribution-sweep] ${JSON.stringify(summary)}`);
+  return { exitCode: 0, action: 'swept', summary };
+}
+
+/** Windows-safe termination (mirrors scripts/cron/venture-ops-actuals-sweep.mjs). */
+export async function gracefulExit(exitCode, { backstopMs = 4000 } = {}) {
+  process.exitCode = exitCode;
+  try {
+    const undici = await import('undici');
+    await undici.getGlobalDispatcher?.()?.close?.();
+  } catch { /* undici absent — natural drain still applies */ }
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  main().then(({ exitCode }) => gracefulExit(exitCode))
+        .catch((err) => { console.error('payment-attribution-sweep fatal:', err.message); return gracefulExit(2); });
+}

--- a/tests/integration/payments/attribution-arm-e2e.test.js
+++ b/tests/integration/payments/attribution-arm-e2e.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { main as runSweep, SD_KEY } from '../../../scripts/cron/payment-attribution-sweep.mjs';
+import { armedProcessKey } from '../../../lib/machinery-class/armed-registration.js';
+
+/**
+ * End-to-end proof for SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001 (FR-4).
+ *
+ * EXEC-phase grounding correction: the live Stripe account has zero products/
+ * prices/payment links configured (confirmed via read-only stripe.products.list
+ * etc.) and only a LIVE-mode STRIPE_SECRET_KEY is present in this environment --
+ * creating a real checkout session, even an uncompleted one, would be an
+ * unauthorized live-account side effect. This test instead inserts one synthetic
+ * ops_payment_events row shaped EXACTLY as lib/payments/checkout-provenance.js's
+ * createVentureCheckoutSession() stamps a real session (metadata.venture_id +
+ * metadata.source_surface merged onto the Stripe object, per its own source),
+ * then runs the real armed cron entry point end-to-end (registration + resolve +
+ * liveness stamp) against the live Supabase project, proving the full mechanism
+ * -- not just the pure resolver functions already covered in
+ * tests/unit/payments/attribution-resolver.test.js.
+ */
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const ALT_TEXT_VENTURE_ID = '50763b6a-1fad-4e1e-b2fc-296a1d66ebf9';
+const RUN = 'evt_test_arm_proof_' + Date.now();
+
+function syntheticCheckoutCompletedPayload(eventId) {
+  // Shape mirrors createVentureCheckoutSession(): provenance = { venture_id, source_surface }
+  // merged into sessionParams.metadata, which Stripe echoes back onto the session object
+  // included on the checkout.session.completed webhook payload's data.object.
+  return {
+    id: eventId,
+    object: 'event',
+    type: 'checkout.session.completed',
+    livemode: false,
+    created: Math.floor(Date.now() / 1000),
+    data: {
+      object: {
+        object: 'checkout.session',
+        id: 'cs_' + eventId,
+        payment_intent: 'pi_' + eventId,
+        amount_total: 2500,
+        currency: 'usd',
+        payment_status: 'paid',
+        status: 'complete',
+        metadata: { venture_id: ALT_TEXT_VENTURE_ID, source_surface: 'arm_001_e2e_proof' },
+      },
+    },
+  };
+}
+
+afterAll(async () => {
+  await sb.from('ops_payment_events').delete().like('stripe_event_id', RUN + '%');
+});
+
+describe('payment-attribution-sweep end-to-end proof (FR-4)', () => {
+  it('a synthetic Alt-Text checkout event attributes to venture_id=50763b6a after one real armed-cron cycle', async () => {
+    const eventId = RUN + '_positive';
+    const payload = syntheticCheckoutCompletedPayload(eventId);
+
+    const { error: insertError } = await sb.from('ops_payment_events').insert({
+      stripe_event_id: eventId,
+      stripe_charge_id: null,
+      payment_intent_id: payload.data.object.payment_intent,
+      event_type: payload.type,
+      amount_cents: payload.data.object.amount_total,
+      currency: payload.data.object.currency,
+      status: payload.data.object.status,
+      livemode: false,
+      event_ts: new Date(payload.created * 1000).toISOString(),
+      venture_id: null,
+      raw_payload: payload,
+    });
+    expect(insertError).toBeNull();
+
+    const result = await runSweep(process.argv, { supabase: sb });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('swept');
+    expect(result.summary.resolved).toBeGreaterThanOrEqual(1);
+
+    const { data: row, error: fetchError } = await sb
+      .from('ops_payment_events')
+      .select('venture_id, attribution_status, attribution_method')
+      .eq('stripe_event_id', eventId)
+      .single();
+    expect(fetchError).toBeNull();
+    expect(row.venture_id).toBe(ALT_TEXT_VENTURE_ID);
+    expect(row.attribution_status).toBe('resolved');
+    expect(row.attribution_method).toBe('direct_metadata');
+
+    const processKey = armedProcessKey(SD_KEY);
+    const { data: registryRow, error: registryError } = await sb
+      .from('periodic_process_registry')
+      .select('last_fired_at')
+      .eq('process_key', processKey)
+      .single();
+    expect(registryError).toBeNull();
+    expect(registryRow.last_fired_at).not.toBeNull();
+    const firedAgoMs = Date.now() - new Date(registryRow.last_fired_at).getTime();
+    expect(firedAgoMs).toBeLessThan(60_000);
+  });
+
+  it('negative case: an event with no venture metadata and no lineage match stays venture_id=NULL (never mis-attributed)', async () => {
+    const eventId = RUN + '_negative';
+    const { error: insertError } = await sb.from('ops_payment_events').insert({
+      stripe_event_id: eventId,
+      stripe_charge_id: null,
+      payment_intent_id: 'pi_' + eventId,
+      event_type: 'checkout.session.completed',
+      amount_cents: 1000,
+      currency: 'usd',
+      status: 'complete',
+      livemode: false,
+      event_ts: new Date().toISOString(),
+      venture_id: null,
+      raw_payload: { data: { object: { object: 'checkout.session', metadata: {} } } },
+    });
+    expect(insertError).toBeNull();
+
+    const result = await runSweep(process.argv, { supabase: sb });
+    expect(result.exitCode).toBe(0);
+
+    const { data: row, error: fetchError } = await sb
+      .from('ops_payment_events')
+      .select('venture_id, attribution_status')
+      .eq('stripe_event_id', eventId)
+      .single();
+    expect(fetchError).toBeNull();
+    expect(row.venture_id).toBeNull();
+    expect(row.attribution_status).toBe('unattributed');
+  });
+});

--- a/tests/unit/cron/payment-attribution-sweep.test.js
+++ b/tests/unit/cron/payment-attribution-sweep.test.js
@@ -1,0 +1,133 @@
+/**
+ * SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001 (FR-3) — payment-attribution sweep.
+ *
+ * Pins: --dry-run performs zero registration/resolve/stamp calls, a successful cycle
+ * registers (only if not already registered) + resolves + stamps liveness, a resolver
+ * error is NEVER masked as a fired cycle (liveness stamp is skipped, non-zero exit),
+ * and a liveness-stamp failure is non-fatal (mirrors the sibling ops-actuals sweep).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { main, parseArgs, ensureArmedRegistration, SD_KEY, ACTIVATION_TRIGGER } from '../../../scripts/cron/payment-attribution-sweep.mjs';
+
+function makeSupabase({ alreadyRegistered = false } = {}) {
+  const upsert = vi.fn().mockResolvedValue({ error: null });
+  const supabase = {
+    _upsert: upsert,
+    from(table) {
+      if (table === 'periodic_process_registry') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: async () => (alreadyRegistered
+            ? { data: { process_key: 'g3-armed-existing' }, error: null }
+            : { data: null, error: null }),
+          upsert,
+        };
+      }
+      throw new Error(`unexpected table in test fake: ${table}`);
+    },
+  };
+  return supabase;
+}
+
+describe('parseArgs', () => {
+  it('parses --once and --dry-run', () => {
+    expect(parseArgs(['node', 's', '--once', '--dry-run'])).toEqual({ once: true, dryRun: true, help: false });
+  });
+});
+
+describe('payment-attribution-sweep static wiring', () => {
+  it('exports SD_KEY and ACTIVATION_TRIGGER matching the cron workflow', () => {
+    expect(SD_KEY).toBe('SD-LEO-INFRA-VENTURE-REVENUE-ATTRIBUTION-ARM-001');
+    expect(ACTIVATION_TRIGGER).toBe('.github/workflows/payment-attribution-cron.yml');
+  });
+});
+
+describe('payment-attribution-sweep main()', () => {
+  it('--dry-run performs zero registration/resolve/stamp calls', async () => {
+    const resolveUnattributedEvents = vi.fn();
+    const stampLastFired = vi.fn();
+    const supabase = makeSupabase();
+
+    const result = await main(['node', 's', '--once', '--dry-run'], {
+      supabase, resolveUnattributedEvents, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(result.action).toBe('dry_run');
+    expect(result.exitCode).toBe(0);
+    expect(supabase._upsert).not.toHaveBeenCalled();
+    expect(resolveUnattributedEvents).not.toHaveBeenCalled();
+    expect(stampLastFired).not.toHaveBeenCalled();
+  });
+
+  it('a successful cycle registers (not yet registered), resolves, and stamps liveness', async () => {
+    const resolveUnattributedEvents = vi.fn().mockResolvedValue({ processed: 3, resolved: 2, unattributed: 1 });
+    const stampLastFired = vi.fn().mockResolvedValue({ stamped: true });
+    const supabase = makeSupabase({ alreadyRegistered: false });
+
+    const result = await main(['node', 's', '--once'], {
+      supabase, resolveUnattributedEvents, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(supabase._upsert).toHaveBeenCalledTimes(1);
+    expect(resolveUnattributedEvents).toHaveBeenCalledWith(supabase, { limit: 500 });
+    expect(stampLastFired).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('swept');
+    expect(result.summary.resolved).toBe(2);
+    expect(result.summary.unattributed).toBe(1);
+  });
+
+  it('skips re-registration when a registry row already exists (never wipes last_fired_at)', async () => {
+    const resolveUnattributedEvents = vi.fn().mockResolvedValue({ processed: 0, resolved: 0, unattributed: 0 });
+    const stampLastFired = vi.fn().mockResolvedValue({ stamped: true });
+    const supabase = makeSupabase({ alreadyRegistered: true });
+
+    await main(['node', 's', '--once'], {
+      supabase, resolveUnattributedEvents, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(supabase._upsert).not.toHaveBeenCalled();
+  });
+
+  it('a resolver error is never masked as a fired cycle — liveness stamp is skipped, exit is non-zero', async () => {
+    const resolveUnattributedEvents = vi.fn().mockRejectedValue(new Error('db unreachable'));
+    const stampLastFired = vi.fn();
+    const supabase = makeSupabase();
+
+    const result = await main(['node', 's', '--once'], {
+      supabase, resolveUnattributedEvents, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(stampLastFired).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+    expect(result.action).toBe('resolver_error');
+  });
+
+  it('a liveness-stamp failure is non-fatal — the cycle still reports success', async () => {
+    const resolveUnattributedEvents = vi.fn().mockResolvedValue({ processed: 0, resolved: 0, unattributed: 0 });
+    const stampLastFired = vi.fn().mockRejectedValue(new Error('not registered'));
+    const supabase = makeSupabase();
+
+    const result = await main(['node', 's', '--once'], {
+      supabase, resolveUnattributedEvents, stampLastFired,
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('swept');
+  });
+});
+
+describe('ensureArmedRegistration', () => {
+  it('registers exactly once for an unregistered process_key', async () => {
+    const supabase = makeSupabase({ alreadyRegistered: false });
+    const processKey = await ensureArmedRegistration(supabase, { log() {}, warn() {}, error() {} });
+    expect(processKey).toBe('g3-armed-sd-leo-infra-venture-revenue-attribution-arm-001');
+    expect(supabase._upsert).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Arms the already-shipped `resolveUnattributedEvents()` resolver (SD-LEO-INFRA-PAYMENT-RAIL-ATTRIBUTION-002) on a scheduled GitHub Actions cron (`scripts/cron/payment-attribution-sweep.mjs` + `.github/workflows/payment-attribution-cron.yml`), using the same `registerArmedMachinery`/`stampLastFired` template as the sibling `venture-ops-actuals-cron.yml` — closes the resolver's own runbook-documented "scheduling is a follow-up" gap.
- EXEC investigation found the live Stripe account has **zero products/prices/payment links** and `createVentureCheckoutSession()` is called by nothing in production — building Alt-Text's actual checkout is therefore out of scope (routes through a future venture-factory build, not this harness SD). Documented the provenance contract in the runbook so whoever builds it next knows to call that helper.
- Proves the full mechanism end-to-end via a synthetic test-mode `ops_payment_events` row shaped exactly like `createVentureCheckoutSession()`'s real metadata output, run through the real armed-cron entry point against the live DB (no live Stripe API writes — only a live-mode key is available in this environment).
- Zero diff to `api/webhooks/stripe.js` (PAT-PORT-ISOL-001 invariant preserved).

## Test plan
- [x] `tests/unit/cron/payment-attribution-sweep.test.js` — 8 tests (dry-run, success, already-registered, resolver-error-never-masked, stamp-failure-non-fatal)
- [x] `tests/integration/payments/attribution-arm-e2e.test.js` — 2 tests against the real Supabase DB (positive attribution to venture 50763b6a + negative unmapped-stays-NULL), with cleanup verified
- [x] Full regression: `tests/unit/payments/`, `tests/unit/cron/`, `tests/integration/payments/`, `tests/unit/scripts/` — 577 passed, 16 skipped (pre-existing/unrelated), 0 failures
- [x] TESTING sub-agent: PASS (93% confidence, independently re-ran the integration test and verified cleanup)
- [x] SECURITY sub-agent: PASS (96% confidence, confirmed least-privilege workflow, no new Stripe writes, no live-revenue contamination risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)