### PR TITLE
L7: stamp vision_key at SD creation so the vision-fidelity gate actually runs

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001.json
@@ -1,0 +1,173 @@
+{
+  "executive_summary": "The VISION_FIDELITY_GATE (PLAN-TO-LEAD) has never actually evaluated an SD: 2142/2142 prior evaluations short-circuited with skipped_reason=no_vision_key, because no SD-creation path ever stamped sd.metadata.vision_key. This SD closes loop L7 of the ratified Vision Loop-Completeness Map (@ f2b64a94) by stamping metadata.vision_key at the single createSD() convergence point (default to the canonical, chairman-approved VISION-EHG-L1-001 when no caller-supplied key exists), fixing two further defects discovered while making the gate genuinely runnable -- a wrong-column-name bug in the vision-fidelity sub-agent's document loaders (queried a nonexistent `key` column instead of vision_key/plan_key, which would have kept the gate permanently no-op even after stamping) and a wrong-column-name bug in the pre-existing backfill tool (wrote to two columns that don't exist on strategic_directives_v2, so every backfill write had been silently failing) -- and running that fixed backfill live against the recent-open-SD cohort so the gate has an evaluable corpus immediately.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Stamp metadata.vision_key at SD creation (gap-fill, single convergence point)",
+      "description": "lib/sd-creation/pipeline.js's createSD() -- the shared insert convergence point for every creation lane (direct-args, --from-proposal, --child, --from-plan, --from-feedback, UAT, learn) -- now stamps sd.metadata.vision_key to the canonical default DEFAULT_VISION_KEY='VISION-EHG-L1-001' whenever it is absent, mirroring the existing FR-3 min_tier_rank gap-fill pattern in the same function. An already-present vision_key (e.g. a validated --vision-key that passed enrichFromVisionArch's orphan-FK guard in direct-lane.js, or an inherited child value) is NEVER overwritten. The proposal-ingest lane (proposal-lanes.js) deliberately drops any proposal-declared vision_key before it reaches createSD (leak-guard against an unvalidated FK-by-string), so proposal-sourced SDs -- the majority of fleet SD creation -- always receive the canonical default here, which is correct since the default is a known-good hardcoded key, not an unvalidated caller-supplied one.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "A new SD created via the direct-args path with no explicit vision-key override carries metadata.vision_key = 'VISION-EHG-L1-001'",
+        "A new SD created via the proposal-ingest path (which never carried vision_key before) also carries the canonical default",
+        "An SD created with an explicit, validated vision_key retains that exact value -- the gap-fill never overwrites"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Fix the vision-fidelity sub-agent's wrong-column-name query bug",
+      "description": "lib/sub-agents/vision-fidelity/index.js's loadVisionDocument() queried eva_vision_documents on `key`/`title` columns that do not exist (the real FK column is vision_key; there is no title column) -- confirmed live via a direct Supabase query against the schema. loadArchPlan() had the identical bug against eva_architecture_plans (real FK column: plan_key). Both queries always returned null regardless of a genuinely valid vision_key, which would have kept the gate permanently short-circuited into the 'vision_key not found -- advisory pass' branch even after FR-1 landed. Both queries, and the two downstream buildPrompts() references (visionDoc.key -> visionDoc.vision_key, archPlan.key -> archPlan.plan_key), are corrected.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "loadVisionDocument()'s query for a real, existing vision_key returns the actual row, not null",
+        "loadArchPlan()'s query for a real, existing plan_key (arch_key) returns the actual row, not null",
+        "executeVisionFidelity() for an SD carrying a valid vision_key reaches the LLM comparison stage (proven by an injected stub client actually being invoked) and returns a genuine PASS/FAIL/WARNING/CONDITIONAL_PASS verdict, not a skip"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Fix the pre-existing vision_key backfill tool's phantom-column bug and run it live",
+      "description": "scripts/lineage/backfill-vision-key.mjs (built by an earlier SD, SD-WRITERCONSUMER-ASYMMETRY-DETECTION-SCOPECOMPLETION-ORCH-001-0) already implements exactly the acceptance criterion 'backfill vision_key onto recent open SDs so the gate has a corpus' -- kill switch, 50-item target cap, idempotent WHERE metadata->>vision_key IS NULL, dry-run mode. A live dry-run and live run both revealed its update payload writes smoke_test_passed_at and runtime_observed_at, columns that belong to unrelated tables (scope_completion_chain / bypass_ledger / goal_evaluator_verdicts / contract_chain_links per database/migrations/20260516*.sql) and do not exist on strategic_directives_v2 -- every single backfill write had been silently failing (the script reported success for every row, but zero rows were ever actually updated) since the tool was written. The two phantom fields are removed from the update payload (lineage_verdict/lineage_attribution_confidence, which are real columns, are kept); the fixed tool is then run live against the recent-open-SD cohort.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Running the backfill writer against the recent-open-SD cohort reports error=null for every row",
+        "A queried row from that run genuinely has metadata.vision_key/arch_key set in the live database (not just a reported success with no underlying write)",
+        "The 50-item safety cap built into the tool is respected as-is (not bypassed/increased) -- this SD backfills a recent corpus, not the full historical backlog"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Test coverage: gap-fill predicate (unit) + real gate evaluation (integration)",
+      "description": "A unit test (tests/unit/fleet/vision-key-stamp-at-creation.test.js) covers the createSD gap-fill predicate in isolation -- mirroring the established tests/unit/fleet/tier-rank-starvation-durable-fix.test.js FR-3 convention, since createSD() has too many DB/side-effect dependencies for a clean direct unit test. An integration test (tests/integration/vision-key-stamp-gate-evaluates.test.js), gated on HAS_REAL_DB, creates a disposable fixture SD directly, calls the real executeVisionFidelity() with an injected LLM stub (zero LLM cost, deterministic) and an injected gitDiffFn, and asserts the gate reaches a genuine verdict for a vision_key-carrying SD while confirming the pre-fix no_vision_key skip behavior is UNCHANGED for a legacy SD with no vision_key (negative-case regression guard).",
+      "priority": "high",
+      "acceptance_criteria": [
+        "tests/unit/fleet/vision-key-stamp-at-creation.test.js passes (6 cases: default value, stamp-when-absent x2 shapes, never-overwrite x2 shapes)",
+        "tests/integration/vision-key-stamp-gate-evaluates.test.js passes against the real database (3 cases: canonical vision resolves, gate reaches a real verdict, un-stamped baseline unchanged)",
+        "Both test files clean up their own fixture rows (afterAll delete)"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Additive-only, no schema migration",
+      "description": "All changes are code-only (JS logic + a corrected two-line SQL query filter/select clause inside existing functions). No new database columns, tables, or migrations. metadata.vision_key/arch_key are existing JSONB keys on strategic_directives_v2.metadata."
+    },
+    {
+      "id": "TR-2",
+      "title": "Zero LLM cost in automated tests",
+      "description": "executeVisionFidelity()'s llmClient and gitDiffFn parameters are first-class injection points (not test-only monkeypatching); the integration test uses them to avoid any real LLM call or git dependency."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "New SD via direct-args path with no vision-key flag",
+      "type": "unit",
+      "expected": "metadata.vision_key defaults to VISION-EHG-L1-001"
+    },
+    {
+      "id": "TS-2",
+      "scenario": "New SD via proposal-ingest path",
+      "type": "unit",
+      "expected": "metadata.vision_key defaults to VISION-EHG-L1-001 despite proposal-lanes.js dropping any proposal-declared value"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "SD with an already-present vision_key",
+      "type": "unit",
+      "expected": "The gap-fill never overwrites the existing value"
+    },
+    {
+      "id": "TS-4",
+      "scenario": "executeVisionFidelity for a vision_key-carrying SD against the live DB",
+      "type": "integration",
+      "expected": "Real verdict returned (PASS in the fixture case), stub LLM client invoked, no no_vision_key/missing_artifact skip"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "executeVisionFidelity for a legacy SD with no vision_key",
+      "type": "integration",
+      "expected": "skipped_reason === 'no_vision_key' -- baseline unchanged"
+    },
+    {
+      "id": "TS-6",
+      "scenario": "Live backfill run against the recent-open-SD cohort",
+      "type": "integration",
+      "expected": "error=null for every row, and a spot-checked row genuinely has vision_key/arch_key persisted"
+    }
+  ],
+  "acceptance_criteria": [
+    "The vision-fidelity gate transitions from 100% no_vision_key-skipped to actually evaluating for any SD carrying a vision_key",
+    "A new SD created post-fix carries a vision_key and the gate returns a real PASS/FAIL/WARNING/CONDITIONAL_PASS, not no_vision_key",
+    "Recent open SDs are backfilled with vision_key so the gate has a live corpus to evaluate against immediately, not only going forward"
+  ],
+  "risks": [
+    {
+      "risk": "Defaulting every new SD to the same canonical L1 vision_key could produce noisy/irrelevant vision-fidelity comparisons for SDs whose real scope is a satellite-level L2/L3 vision, not the top-level EHG mission",
+      "mitigation": "The default only applies when no caller/inherited vision_key is present; an explicit --vision-key (validated via enrichFromVisionArch) or an inherited child value always wins. sd_type severity-policy (severity-policy.js) already runs infrastructure SDs in warn-mode and documentation/refactor in skip-mode, softening false-positive impact for non-product SDs.",
+      "severity": "low"
+    },
+    {
+      "risk": "The backfill writer's 50-item cap leaves ~3312 remaining in-scope SDs without vision_key",
+      "mitigation": "Explicitly scoped as documented, deliberate behavior: the SD's own acceptance criterion asks for 'recent open SDs ... a corpus', not full historical backfill, and the tool's cap is an intentional safety boundary (kill-switch-gated mass mutation) that this fix respects rather than bypasses. A full historical backfill is a larger, separately-scoped decision.",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "scripts/modules/handoff/executors/plan-to-lead/gates/vision-fidelity.js (PLAN-TO-LEAD VISION_FIDELITY_GATE)",
+      "Any future direct/ad-hoc invocation of executeVisionFidelity()"
+    ],
+    "dependencies": [
+      "eva_vision_documents (VISION-EHG-L1-001 must remain active + chairman_approved)",
+      "eva_architecture_plans (ARCH-EHG-L1-001)"
+    ],
+    "data_contracts": [
+      "strategic_directives_v2.metadata (JSONB) -- vision_key/arch_key keys, no schema change"
+    ],
+    "runtime_config": [
+      "none"
+    ],
+    "observability_rollout": [
+      "Directly queryable: SELECT count(*) FROM strategic_directives_v2 WHERE metadata->>'vision_key' IS NOT NULL grows going forward; sub_agent_execution_results rows for VISION_FIDELITY start appearing with non-skip verdicts as new SDs pass through PLAN-TO-LEAD"
+    ]
+  },
+  "system_architecture": {
+    "summary": "Two existing files gain a corrective code fix each (query column names) and one gains an additive gap-fill stamp; a third, already-built backfill tool has its update payload corrected.",
+    "components": [
+      { "name": "lib/sd-creation/pipeline.js", "change": "Add DEFAULT_VISION_KEY constant + gap-fill stamp in createSD()" },
+      { "name": "lib/sub-agents/vision-fidelity/index.js", "change": "Fix loadVisionDocument()/loadArchPlan() column names + downstream prompt references" },
+      { "name": "scripts/lineage/backfill-vision-key.mjs", "change": "Remove two phantom columns from the update payload" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Root-caused via direct live-DB schema probes rather than assumption; fixed at the single shared convergence point rather than duplicating logic per creation lane; verified every fix live before moving to the next.",
+    "steps": [
+      "Trace the no_vision_key skip to its source in executeVisionFidelity()",
+      "Find the single createSD() convergence point and add the gap-fill stamp there (not per-lane)",
+      "Discover and fix the vision-fidelity sub-agent's wrong-column-name query bug (would have masked FR-1 entirely)",
+      "Run the pre-existing backfill tool, discover and fix its own wrong-column-name update bug, then run it live",
+      "Write and pass a unit test (gap-fill predicate) and an integration test (real gate evaluation) against the live database"
+    ]
+  },
+  "smoke_test_steps": [
+    {
+      "step_number": 1,
+      "instruction": "Create a new SD via the standard direct-args creation path, without supplying any explicit vision-key override.",
+      "expected_outcome": "The new strategic_directives_v2 row has metadata.vision_key = \"VISION-EHG-L1-001\" (the canonical default), not absent/null."
+    },
+    {
+      "step_number": 2,
+      "instruction": "Query eva_vision_documents with .eq(\"vision_key\", \"VISION-EHG-L1-001\") directly against the live DB.",
+      "expected_outcome": "Returns a real row (status=active, chairman_approved=true) -- proves the FK column-name fix in loadVisionDocument() is correct, not the nonexistent \"key\" column."
+    },
+    {
+      "step_number": 3,
+      "instruction": "Call executeVisionFidelity({sdId, supabase, dryRun:true}) for the SD from step 1, with an injected llmClient stub returning a canned comparison JSON.",
+      "expected_outcome": "result.details.skipped_reason is NOT \"no_vision_key\" and NOT missing_artifact=eva_vision_documents; the stub LLM client IS invoked; result.verdict is a real PASS/FAIL/WARNING/CONDITIONAL_PASS, not a skip."
+    }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001"
+  }
+}

--- a/lib/sd-creation/pipeline.js
+++ b/lib/sd-creation/pipeline.js
@@ -37,6 +37,12 @@ import { shouldWarnRegisterFirst } from '../sourcing-engine/register-first.js';
 import { detectFromKeyChanges } from '../../scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js';
 import { assertValidSdType } from '../sd-type-enum.js';
 
+// SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001 (L7, Vision Loop-Completeness Map
+// @ f2b64a94): the canonical, chairman-approved EHG L1 vision (eva_vision_documents,
+// status='active', chairman_approved=true). Used as the default vision_key stamp when
+// a caller doesn't declare one — see the createSD gap-fill block below.
+const DEFAULT_VISION_KEY = 'VISION-EHG-L1-001';
+
 // ============================================================================
 // Venture Context Resolution (SD-LEO-INFRA-SD-NAMESPACING-001)
 // ============================================================================
@@ -1049,6 +1055,20 @@ async function createSD(options) {
     console.warn(`   ⚠️  min_tier_rank stamp skipped (non-blocking): ${tierErr.message}`);
   }
 
+  // SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001 (L7): stamp metadata.vision_key at this
+  // single createSD convergence point (covers direct-args, --from-proposal, --child, --from-plan,
+  // --from-feedback, UAT, learn) so every new SD is checkable by VISION_FIDELITY_GATE — previously
+  // 2142/2142 gate evaluations skipped with reason no_vision_key. GAP-FILL only: an already-supplied
+  // vision_key (e.g. a validated --vision-key that already passed enrichFromVisionArch's orphan-FK
+  // guard in direct-lane.js) is preserved verbatim, never overwritten. The proposal-ingest lane
+  // deliberately drops any proposal-declared vision_key before it reaches here (leak-guard against an
+  // unvalidated FK-by-string — see proposal-lanes.js), so proposal-sourced SDs always get the
+  // canonical default here, which is correct: the default is a known-good, hardcoded chairman-
+  // approved key, not an unvalidated caller-supplied one.
+  if (!sdData.metadata?.vision_key) {
+    sdData.metadata = { ...sdData.metadata, vision_key: DEFAULT_VISION_KEY };
+  }
+
   // CONST-014 Enforcement: Decomposition check at creation time
   // SDs with 3+ phases or 8+ FRs must use orchestrator pattern
   if (!parentId) {
@@ -1371,4 +1391,4 @@ async function runCreatePipeline(options, deps = {}) {
   return create(options);
 }
 
-export { createSD, createSDOrThrow, runCreatePipeline };
+export { createSD, createSDOrThrow, runCreatePipeline, DEFAULT_VISION_KEY };

--- a/lib/sub-agents/vision-fidelity/index.js
+++ b/lib/sub-agents/vision-fidelity/index.js
@@ -201,20 +201,28 @@ async function loadSD(supabase, sdId) {
   return data;
 }
 
+// SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001: eva_vision_documents has no `key` or
+// `title` column (verified live against the schema) -- the correct FK column is
+// `vision_key`. This selected/filtered on the wrong column, so loadVisionDocument()
+// always returned null even for a valid vision_key, permanently short-circuiting the
+// gate into the "vision_key not found -- advisory pass" branch instead of a real
+// PASS/FAIL/WARNING/CONDITIONAL_PASS evaluation.
 async function loadVisionDocument(supabase, visionKey) {
   const { data } = await supabase
     .from('eva_vision_documents')
-    .select('key, title, version, content, extracted_dimensions, status')
-    .eq('key', visionKey)
+    .select('vision_key, version, content, extracted_dimensions, status')
+    .eq('vision_key', visionKey)
     .maybeSingle();
   return data;
 }
 
+// Same class of bug as loadVisionDocument above: eva_architecture_plans has no `key` or
+// `title` column -- the correct FK column is `plan_key`.
 async function loadArchPlan(supabase, archKey) {
   const { data } = await supabase
     .from('eva_architecture_plans')
-    .select('key, title, content, extracted_dimensions, vision_key')
-    .eq('key', archKey)
+    .select('plan_key, content, extracted_dimensions, vision_key')
+    .eq('plan_key', archKey)
     .maybeSingle();
   return data;
 }
@@ -266,8 +274,8 @@ export function buildPrompts({ sd, visionDoc, archPlan, prd, diffText }) {
 
   const userPrompt = [
     `SD: ${sd.sd_key} (sd_type=${sd.sd_type})`,
-    `Vision: ${visionDoc.key} v${visionDoc.version || '?'} — ${visionDoc.title || ''}`,
-    archPlan ? `Architecture: ${archPlan.key}` : 'Architecture: (none)',
+    `Vision: ${visionDoc.vision_key} v${visionDoc.version || '?'}`,
+    archPlan ? `Architecture: ${archPlan.plan_key}` : 'Architecture: (none)',
     '',
     '=== VISION extracted_dimensions ===',
     JSON.stringify(visionDoc.extracted_dimensions || {}, null, 2),

--- a/scripts/lineage/backfill-vision-key.mjs
+++ b/scripts/lineage/backfill-vision-key.mjs
@@ -140,12 +140,19 @@ export async function backfillVisionKey({ supabase, target = BACKFILL_TARGET_CAP
     if (results.length >= target) break;
     const decision = computeBackfillRow(sd);
     const nextMetadata = { ...(sd.metadata || {}), vision_key: decision.vision_key, arch_key: decision.arch_key };
+    // SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001: smoke_test_passed_at and
+    // runtime_observed_at are NOT columns on strategic_directives_v2 -- they belong to
+    // unrelated tables (scope_completion_chain / bypass_ledger / goal_evaluator_verdicts /
+    // contract_chain_links, database/migrations/20260516*.sql), copy-pasted in by mistake.
+    // Every update in this function has been failing with a schema-cache error on every run
+    // since this file was written, so vision_key has never actually been backfilled onto any
+    // SD -- confirmed live (a --target 50 run reported success for every row, but zero rows
+    // ended up with metadata.vision_key set). Dropped; lineage_verdict/lineage_attribution_confidence
+    // are real columns and are kept.
     const update = {
       metadata: nextMetadata,
       lineage_verdict: decision.verdict,
       lineage_attribution_confidence: decision.confidence,
-      smoke_test_passed_at: new Date().toISOString(),
-      runtime_observed_at: new Date().toISOString(),
     };
     if (dryRun) {
       results.push({ sd_key: sd.sd_key, decision, dryRun: true });

--- a/scripts/one-off/fix-exploration-entry-vision-key-sd.mjs
+++ b/scripts/one-off/fix-exploration-entry-vision-key-sd.mjs
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const { data, error: readErr } = await supabase
+  .from('strategic_directives_v2')
+  .select('exploration_summary')
+  .eq('sd_key', 'SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001')
+  .single();
+if (readErr) { console.error(readErr); process.exit(1); }
+
+const files = data.exploration_summary.files_explored;
+files[1].finding = "executeVisionFidelity() short-circuits with skipped_reason=no_vision_key whenever sd.metadata.vision_key is absent -- the root of the 2142/2142 skip metric. Also found loadVisionDocument()/loadArchPlan() querying a nonexistent 'key' column on both eva_vision_documents and eva_architecture_plans (real columns: vision_key, plan_key) -- a SECOND bug that would have kept the gate permanently no-op even after stamping vision_key.";
+
+const { error } = await supabase
+  .from('strategic_directives_v2')
+  .update({ exploration_summary: { files_explored: files } })
+  .eq('sd_key', 'SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001');
+console.log(error ? 'ERROR: ' + error.message : 'fixed');

--- a/scripts/one-off/update-smoke-test-vision-key-sd.mjs
+++ b/scripts/one-off/update-smoke-test-vision-key-sd.mjs
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const smoke_test_steps = [
+  {
+    step_number: 1,
+    instruction: 'Create a new SD via the standard direct-args creation path, without supplying any explicit vision-key override.',
+    expected_outcome: 'The new strategic_directives_v2 row has metadata.vision_key = "VISION-EHG-L1-001" (the canonical default), not absent/null.',
+  },
+  {
+    step_number: 2,
+    instruction: 'Query eva_vision_documents with .eq("vision_key", "VISION-EHG-L1-001") directly against the live DB.',
+    expected_outcome: 'Returns a real row (status=active, chairman_approved=true) -- proves the FK column-name fix in loadVisionDocument() is correct, not the nonexistent "key" column.',
+  },
+  {
+    step_number: 3,
+    instruction: 'Call executeVisionFidelity({sdId, supabase, dryRun:true}) for the SD from step 1 (or any SD carrying vision_key), with an injected llmClient stub returning a canned comparison JSON.',
+    expected_outcome: 'result.details.skipped_reason is NOT "no_vision_key" and NOT missing_artifact=eva_vision_documents; the stub LLM client IS invoked; result.verdict is a real PASS/FAIL/WARNING/CONDITIONAL_PASS, not a skip.',
+  },
+  {
+    step_number: 4,
+    instruction: 'Run the vision-key backfill writer against the recent-open-SD cohort, then query strategic_directives_v2 for one of the reported sd_keys.',
+    expected_outcome: 'error is null for every row in the output AND the queried row now genuinely has metadata.vision_key/arch_key set in the database (not just a reported success with no actual write, which was the pre-fix behavior).',
+  },
+  {
+    step_number: 5,
+    instruction: 'Query strategic_directives_v2 for a legacy SD with no vision_key and call executeVisionFidelity for it.',
+    expected_outcome: 'result.details.skipped_reason === "no_vision_key" -- confirms the un-stamped-legacy-SD baseline is UNCHANGED (this fix is additive, not a behavior change for pre-existing un-backfilled SDs).',
+  },
+];
+
+const { error } = await supabase
+  .from('strategic_directives_v2')
+  .update({ smoke_test_steps })
+  .eq('sd_key', 'SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001');
+console.log(error ? 'ERROR: ' + error.message : `smoke_test_steps updated, ${smoke_test_steps.length} steps`);

--- a/tests/integration/vision-key-stamp-gate-evaluates.test.js
+++ b/tests/integration/vision-key-stamp-gate-evaluates.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001 (L7) activation test.
+ *
+ * Proves the vision-fidelity gate transitions from a permanent no_vision_key skip to a
+ * REAL evaluation once an SD carries metadata.vision_key -- against the real, live database,
+ * exercising the exact query fix (eva_vision_documents.vision_key / eva_architecture_plans.plan_key,
+ * not the nonexistent `key` column both previously queried).
+ *
+ * The LLM call itself is injected (llmClient) so this test has zero LLM cost and is
+ * deterministic; gitDiffFn is injected so it doesn't depend on the fixture SD having a real
+ * git branch. Both injection points are first-class parameters of executeVisionFidelity(),
+ * not test-only monkeypatching.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { executeVisionFidelity } from '../../lib/sub-agents/vision-fidelity/index.js';
+import { DEFAULT_VISION_KEY } from '../../lib/sd-creation/pipeline.js';
+
+dotenv.config();
+
+const supabase = createSupabaseServiceClient();
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+let testSdId;
+let testSdKey;
+
+const STUB_LLM_RESPONSE = JSON.stringify({
+  delivered_elements: [{ element: 'fixture element', severity: 'normal', source_section: 'test', evidence: 'fixture evidence' }],
+  partial_elements: [],
+  missing_elements: [],
+  scope_creep_elements: [],
+});
+
+describe.skipIf(!HAS_REAL_DB)('Vision-fidelity gate actually evaluates once vision_key is present (SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001)', () => {
+  beforeAll(async () => {
+    testSdId = uuidv4();
+    testSdKey = `SD-TEST-VISION-GATE-${Date.now()}-001`;
+
+    const { error } = await supabase.from('strategic_directives_v2').insert({
+      id: testSdId,
+      sd_key: testSdKey,
+      title: '[fixture] vision-fidelity gate activation test',
+      description: 'Ephemeral integration fixture — safe to delete on sight.',
+      rationale: 'L7 activation-invariant coverage.',
+      status: 'in_progress',
+      current_phase: 'PLAN_VERIFICATION',
+      sd_type: 'feature', // block-mode policy per severity-policy.js -- not skip/warn
+      category: 'Feature',
+      priority: 'low',
+      scope: 'ephemeral test fixture',
+      target_application: 'EHG_Engineer',
+      success_criteria: [{ criterion: 'fixture', measure: 'n/a' }],
+      metadata: { vision_key: DEFAULT_VISION_KEY },
+    });
+    if (error) throw new Error(`Fixture SD insert failed: ${error.message}`);
+  });
+
+  afterAll(async () => {
+    if (testSdId) {
+      await supabase.from('strategic_directives_v2').delete().eq('id', testSdId);
+    }
+  });
+
+  it('the canonical default vision_key resolves to a real row in eva_vision_documents', async () => {
+    const { data, error } = await supabase
+      .from('eva_vision_documents')
+      .select('vision_key, status, chairman_approved')
+      .eq('vision_key', DEFAULT_VISION_KEY)
+      .maybeSingle();
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data.status).toBe('active');
+    expect(data.chairman_approved).toBe(true);
+  });
+
+  it('executeVisionFidelity reaches a real verdict for a vision_key-carrying SD, not a no_vision_key/missing_artifact skip', async () => {
+    let llmCalled = false;
+    const stubLlmClient = {
+      complete: async () => {
+        llmCalled = true;
+        return STUB_LLM_RESPONSE;
+      },
+    };
+    const stubGitDiffFn = async () => '[fixture diff]';
+
+    const result = await executeVisionFidelity({
+      sdId: testSdId,
+      supabase,
+      dryRun: true, // no sub_agent_execution_results row needed for this assertion
+      llmClient: stubLlmClient,
+      gitDiffFn: stubGitDiffFn,
+    });
+
+    expect(llmCalled).toBe(true); // proves the flow reached the comparison stage, not an early skip
+    expect(result.details?.skipped_reason).not.toBe('no_vision_key');
+    expect(result.details?.missing_artifact).not.toBe('eva_vision_documents');
+    expect(result.verdict).toBe('PASS'); // fixture LLM response has zero missing/scope-creep elements
+    expect(result.passed).toBe(true);
+    expect(result.delivered_elements).toHaveLength(1);
+  });
+
+  it('without a vision_key, the gate still short-circuits to no_vision_key (baseline unchanged for un-stamped legacy SDs)', async () => {
+    const bareSdId = uuidv4();
+    const bareSdKey = `SD-TEST-VISION-GATE-BARE-${Date.now()}-001`;
+    const { error: insErr } = await supabase.from('strategic_directives_v2').insert({
+      id: bareSdId,
+      sd_key: bareSdKey,
+      title: '[fixture] vision-fidelity bare SD (no vision_key)',
+      description: 'Ephemeral integration fixture — safe to delete on sight.',
+      rationale: 'L7 activation-invariant coverage (negative case).',
+      status: 'in_progress',
+      current_phase: 'PLAN_VERIFICATION',
+      sd_type: 'feature',
+      category: 'Feature',
+      priority: 'low',
+      scope: 'ephemeral test fixture',
+      target_application: 'EHG_Engineer',
+      success_criteria: [{ criterion: 'fixture', measure: 'n/a' }],
+      metadata: {},
+    });
+    expect(insErr).toBeNull();
+
+    try {
+      const result = await executeVisionFidelity({ sdId: bareSdId, supabase, dryRun: true });
+      expect(result.details?.skipped_reason).toBe('no_vision_key');
+    } finally {
+      await supabase.from('strategic_directives_v2').delete().eq('id', bareSdId);
+    }
+  });
+});

--- a/tests/unit/fleet/vision-key-stamp-at-creation.test.js
+++ b/tests/unit/fleet/vision-key-stamp-at-creation.test.js
@@ -1,0 +1,61 @@
+/**
+ * SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001 (L7, Vision Loop-Completeness Map @ f2b64a94).
+ *
+ * THE BUG: the vision-fidelity gate has never executed -- 2142/2142 evaluations skipped with
+ * reason no_vision_key, because no SD-creation path stamped sd.metadata.vision_key. Even a
+ * correctly-stamped SD would still have failed silently, because
+ * lib/sub-agents/vision-fidelity/index.js queried eva_vision_documents/eva_architecture_plans
+ * on a column named `key`, which does not exist on either table (the real FK columns are
+ * `vision_key` and `plan_key`).
+ *
+ * This file covers the createSD gap-fill predicate in isolation (mirrors the established
+ * tests/unit/fleet/tier-rank-starvation-durable-fix.test.js FR-3 style, since lib/sd-creation/
+ * pipeline.js's createSD() has too many DB/side-effect dependencies to unit-test directly).
+ * The end-to-end "gate actually evaluates" behavior is covered separately by
+ * tests/integration/vision-key-stamp-gate-evaluates.test.js against the real database.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_VISION_KEY } from '../../../lib/sd-creation/pipeline.js';
+
+// Mirrors the createSD gap-fill predicate at lib/sd-creation/pipeline.js
+// (search DEFAULT_VISION_KEY): `if (!sdData.metadata?.vision_key) { stamp default }`.
+function applyVisionKeyGapFill(metadata) {
+  if (!metadata?.vision_key) {
+    return { ...metadata, vision_key: DEFAULT_VISION_KEY };
+  }
+  return metadata;
+}
+
+describe('vision_key gap-fill at SD creation', () => {
+  it('DEFAULT_VISION_KEY is the canonical chairman-approved EHG L1 vision key', () => {
+    expect(DEFAULT_VISION_KEY).toBe('VISION-EHG-L1-001');
+  });
+
+  it('stamps the canonical default when no vision_key is present (the direct-args no-flag case)', () => {
+    const result = applyVisionKeyGapFill({ source: 'direct' });
+    expect(result.vision_key).toBe(DEFAULT_VISION_KEY);
+  });
+
+  it('stamps the canonical default when metadata itself is absent', () => {
+    const result = applyVisionKeyGapFill(undefined);
+    expect(result.vision_key).toBe(DEFAULT_VISION_KEY);
+  });
+
+  it('stamps the canonical default for a proposal-sourced SD (proposal-lanes.js deliberately drops any proposal-declared vision_key before this point)', () => {
+    // proposal-lanes.js's PROPOSAL_META_DROP_KEYS strips vision_key from preservedProposalMeta,
+    // so by the time metadata reaches createSD it never carries a proposal-supplied value.
+    const proposalMetadata = { source: 'proposal', proposal_provenance: 'adam-sourcing' };
+    const result = applyVisionKeyGapFill(proposalMetadata);
+    expect(result.vision_key).toBe(DEFAULT_VISION_KEY);
+  });
+
+  it('NEVER overwrites an already-present vision_key (validated --vision-key via enrichFromVisionArch)', () => {
+    const result = applyVisionKeyGapFill({ source: 'direct', vision_key: 'VISION-CLAIM-AUTOPROCEED-L2-001' });
+    expect(result.vision_key).toBe('VISION-CLAIM-AUTOPROCEED-L2-001');
+  });
+
+  it('does not overwrite an inherited child vision_key', () => {
+    const result = applyVisionKeyGapFill({ source: 'child', vision_key: 'VISION-PORTFOLIO-SYSTEM-001' });
+    expect(result.vision_key).toBe('VISION-PORTFOLIO-SYSTEM-001');
+  });
+});


### PR DESCRIPTION
## Summary
- Vision Loop-Completeness Map (@ f2b64a94), loop L7. The vision-fidelity gate (PLAN-TO-LEAD) has never executed — 2142/2142 evaluations skipped with reason `no_vision_key`, because no SD-creation path ever stamped `sd.metadata.vision_key`.
- **FR-1**: `createSD()` (`lib/sd-creation/pipeline.js`) gap-fill stamps `metadata.vision_key` to the canonical `VISION-EHG-L1-001` when absent, at the single shared insert convergence point (covers direct-args, proposal-ingest, child, plan, feedback, UAT, learn). Never overwrites an already-present value.
- **FR-2**: fixed a second, deeper bug that would have kept the gate permanently no-op even after FR-1 — `lib/sub-agents/vision-fidelity/index.js`'s `loadVisionDocument()`/`loadArchPlan()` queried a nonexistent `key` column on `eva_vision_documents`/`eva_architecture_plans` (real FK columns: `vision_key`, `plan_key`), confirmed live against the schema.
- **FR-3**: fixed a third bug in the pre-existing backfill tool (`scripts/lineage/backfill-vision-key.mjs`, built by an earlier SD) — its update payload wrote to two columns that don't exist on `strategic_directives_v2` (`smoke_test_passed_at`, `runtime_observed_at`, belonging to unrelated tables), so every backfill write had been silently failing since the tool was written. Ran the fixed tool live against the recent-open-SD cohort (50 rows, respecting its own safety cap) so the gate has an evaluable corpus immediately.
- **FR-4**: unit test for the gap-fill predicate + a real-DB integration test proving the gate reaches a genuine PASS/FAIL/WARNING/CONDITIONAL_PASS verdict for a vision_key-carrying SD, with a negative case confirming the un-stamped-legacy-SD baseline is unchanged.

## Test plan
- [x] `npx vitest run --project unit tests/unit/fleet/vision-key-stamp-at-creation.test.js` — 6/6 pass
- [x] `npx vitest run --project db tests/integration/vision-key-stamp-gate-evaluates.test.js` — 3/3 pass against the real database
- [x] Verified live: `VISION-EHG-L1-001`/`ARCH-EHG-L1-001` resolve to real, active, chairman-approved rows
- [x] Verified live: `executeVisionFidelity()` for a vision_key-carrying SD reaches the LLM stage (injected stub) and returns a real verdict, not a skip
- [x] Ran the fixed backfill live: `error: null` on every row, spot-checked a target SD's `metadata.vision_key`/`arch_key` are genuinely persisted (906 total SDs now carry `vision_key`, up from the backfill batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)