### PR TITLE
feat(SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001): belt claim-eligibility honors chairman_ratified + soft_depends_on

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001.json
@@ -1,0 +1,171 @@
+{
+  "title": "Belt claim-eligibility honors Adam-sourced metadata (chairman_ratified + soft_depends_on)",
+  "executive_summary": "The shared dispatch-eligibility predicate (lib/fleet/claim-eligibility.cjs), the single source of truth used by both the worker-PULL self-claim path and the coordinator/sweep-PUSH path, did not read two machine-readable metadata fields Adam already stamps at sourcing time: metadata.chairman_ratified and metadata.soft_depends_on. This left 'is this SD claimable yet' encoded only in prose/human relay instead of in the row. This PRD wires both fields into the existing predicate (INELIGIBILITY_AXES table and draftDepsSatisfied respectively) without introducing a second predicate, fail-open on absence so no existing claimable SD becomes silently unclaimable.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Claim-eligibility keys on metadata.chairman_ratified (priority)",
+      "description": "Add a new axis, chairmanRatificationPending, to the ordered INELIGIBILITY_AXES table in lib/fleet/claim-eligibility.cjs. An SD is ineligible for dispatch when metadata.chairman_ratified === false (Adam stamps this explicitly for an SD sitting draft/unfenced/ranked but awaiting chairman ratification). Absent field or chairman_ratified === true fall through unchanged (fail-open). The new reason string 'chairman_ratification_pending' is added to CLAIM_WRITE_FENCE_AXES, the same authority-fence set as needs_coordinator_review, since the ratification stamp itself is the only valid clear mechanism.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "classifyDispatchIneligibility returns 'chairman_ratification_pending' for a row with metadata.chairman_ratified === false",
+        "classifyDispatchIneligibility returns null for a row with metadata.chairman_ratified === true",
+        "classifyDispatchIneligibility returns null when metadata.chairman_ratified is absent (fail-open)",
+        "CLAIM_WRITE_FENCE_AXES.has('chairman_ratification_pending') === true"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Dispatch/belt reads metadata.soft_depends_on and auto-honors it",
+      "description": "Fold metadata.soft_depends_on into the existing draftDepsSatisfied() live-status re-check (the same function that already folds in metadata.blocked_on_sd), rather than introducing a second predicate. soft_depends_on may be a single value or an array; each entry is FREE-FORM PROSE in practice (the live example on SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001 reads 'D8 (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) provides merge-time enrollment; can build in parallel, integrate at PLAN'), not a bare SD key. The referenced key is extracted via SD_KEY_TOKEN_RE (matches an SD-XXX-YYY-NNN shaped token embedded anywhere in the string) rather than treated as a literal key, which would otherwise fail to match and wrongly block an already-in-progress SD. A string with no embedded key token is non-blocking.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "draftDepsSatisfied returns false when metadata.soft_depends_on references a not-yet-completed SD (string or array form)",
+        "draftDepsSatisfied returns true once every referenced soft-dependency SD is completed",
+        "draftDepsSatisfied correctly extracts the embedded SD key from free-form prose (the live Adam-authored shape) rather than treating the whole string as a literal key",
+        "draftDepsSatisfied returns true (non-blocking) when soft_depends_on is absent, empty array, or 'none'"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Regression safety: additive, fail-open, zero newly-blocked live SDs",
+      "description": "Both FR-1 and FR-2 are purely additive to the existing eligibility predicate. Verified against the live non-terminal strategic_directives_v2 row set (26 rows at implementation time): 0 rows carry metadata.chairman_ratified === false, and the 1 row carrying metadata.soft_depends_on (SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001, prose-form referencing the already-completed SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) resolves to draftDepsSatisfied === true under the new logic, matching its current in_progress claimable state. Existing CLAIM_WRITE_FENCE_AXES exact-array pin test updated to include the new axis.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Live-data check: classifyDispatchIneligibility(row) is identical before/after the new chairman_ratified axis for every non-terminal SD row",
+        "Live-data check: the one live soft_depends_on-bearing SD (SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001) resolves draftDepsSatisfied === true",
+        "No existing test in the claim-eligibility suite regresses"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Single source of truth preserved",
+      "description": "Both FRs extend lib/fleet/claim-eligibility.cjs's existing INELIGIBILITY_AXES table / draftDepsSatisfied function -- no second predicate, no new module. Shared unchanged by both the worker-checkin self_claim path and the stale-session-sweep CLAIM_FIX path."
+    },
+    {
+      "id": "TR-2",
+      "title": "Pure, synchronous axis for FR-1",
+      "description": "chairmanRatificationPending follows the existing axis contract: pure (row, ctx) => reason|null, DB-free, so it composes into both classifyDispatchIneligibility (first-match) and classifyAllDispatchIneligibility (all-match) with zero extra wiring."
+    },
+    {
+      "id": "TR-3",
+      "title": "No schema/migration change",
+      "description": "Both fields are read from the existing strategic_directives_v2.metadata JSONB column. No DDL required."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "chairman_ratified=false blocks dispatch",
+      "type": "unit",
+      "expected": "classifyDispatchIneligibility returns 'chairman_ratification_pending'"
+    },
+    {
+      "id": "TS-2",
+      "scenario": "chairman_ratified=true is claimable",
+      "type": "unit",
+      "expected": "classifyDispatchIneligibility returns null"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "chairman_ratified absent (fail-open)",
+      "type": "unit",
+      "expected": "classifyDispatchIneligibility returns null, byte-identical to pre-change behavior"
+    },
+    {
+      "id": "TS-4",
+      "scenario": "soft_depends_on prose references a not-yet-completed SD",
+      "type": "unit",
+      "expected": "draftDepsSatisfied returns false"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "soft_depends_on prose references an already-completed SD (live shape)",
+      "type": "unit",
+      "expected": "draftDepsSatisfied returns true, extracting the embedded key from the sentence"
+    },
+    {
+      "id": "TS-6",
+      "scenario": "soft_depends_on array with a mix of completed/incomplete targets",
+      "type": "unit",
+      "expected": "draftDepsSatisfied returns false while any target is incomplete, true once all are completed"
+    },
+    {
+      "id": "TS-7",
+      "scenario": "Live-data regression check across all non-terminal SDs",
+      "type": "integration",
+      "expected": "Zero SDs newly blocked by either new axis; the one live soft_depends_on-bearing SD stays claimable"
+    }
+  ],
+  "acceptance_criteria": [
+    "The claim-eligibility predicate reads metadata.chairman_ratified and metadata.soft_depends_on and gates claimability on both, with fail-open on absence",
+    "Regression tests pin all transitions: chairman_ratified=false NOT claimable, =true claimable, absent claimable; soft_depends_on incomplete target NOT claimable, completed claimable, absent/none/empty claimable",
+    "No existing claimable SD becomes silently unclaimable due to a missing field (verified against the live non-terminal SD set)"
+  ],
+  "risks": [
+    {
+      "risk": "A future Adam-authored soft_depends_on string could embed a malformed or non-existent SD-key-shaped token, permanently blocking the SD",
+      "mitigation": "draftDepsSatisfied's existing dep-query already treats a referenced key with no matching row as unsatisfied (conservative), consistent with how the pre-existing dependencies/blocked_on_sd axes already behave for a bad reference -- no new failure mode introduced",
+      "severity": "low"
+    },
+    {
+      "risk": "CLAIM_WRITE_FENCE_AXES exact-array pin tests elsewhere in the suite could break on the new axis addition",
+      "mitigation": "Searched and updated the one exact-array pin test found (tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js); full claim-eligibility test suite (51 files, 580 tests) re-run green",
+      "severity": "low"
+    },
+    {
+      "risk": "SD_KEY_TOKEN_RE could false-positive-match an SD-key-shaped substring in unrelated prose",
+      "mitigation": "The regex requires the real production sd_key shape (SD- prefix plus 2+ hyphen-separated alphanumeric segments), which is specific enough that accidental prose collisions are not observed in the live data; a false match degrades to a dep-query miss (conservative unsatisfied), never a false-eligible",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "scripts/worker-checkin.cjs (self_claim path, via baselinedCandidateEligible/evaluateDispatchEligibility)",
+      "scripts/stale-session-sweep.cjs (CLAIM_FIX path, via classifyDispatchIneligibility/draftDepsSatisfied)",
+      "lib/coordinator/dispatch.cjs (DIRECTED-ASSIGN path, via classifyDispatchIneligibility with ctx=undefined)"
+    ],
+    "dependencies": [
+      "SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001 (DB-side observe-only claim-eligibility trigger)",
+      "SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001 (converged dispatch + self_claim on one extended eligibility predicate)"
+    ],
+    "data_contracts": [
+      "strategic_directives_v2.metadata.chairman_ratified (boolean, Adam-stamped)",
+      "strategic_directives_v2.metadata.soft_depends_on (string or array of strings, free-form prose containing an SD-key reference, Adam-stamped)"
+    ],
+    "runtime_config": ["none"],
+    "observability_rollout": [
+      "Live-data verification script run against all 26 non-terminal SDs at implementation time confirmed zero newly-blocked rows",
+      "Regression covered by the existing unit test suite (no separate monitoring needed -- this is a pure, synchronous, DB-free predicate change plus one DB-backed dependency-check extension already exercised by existing callers)"
+    ]
+  },
+  "system_architecture": {
+    "summary": "Two additive extensions to the single shared dispatch-eligibility predicate module: a new pure axis in the INELIGIBILITY_AXES table (FR-1), and a new ref-key source folded into the existing draftDepsSatisfied dependency re-check (FR-2).",
+    "components": [
+      { "name": "lib/fleet/claim-eligibility.cjs", "change": "Add chairmanRatificationPending axis to INELIGIBILITY_AXES + CLAIM_WRITE_FENCE_AXES; add SD_KEY_TOKEN_RE constant; fold metadata.soft_depends_on into draftDepsSatisfied's refKeys derivation" },
+      { "name": "tests/unit/fleet/claim-eligibility-chairman-ratified.test.js", "change": "NEW -- FR-1 axis unit tests" },
+      { "name": "tests/unit/claim-eligibility.test.js", "change": "Extended -- FR-2 draftDepsSatisfied soft_depends_on unit tests (string, prose, array, fail-open)" },
+      { "name": "tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js", "change": "Updated exact-array CLAIM_WRITE_FENCE_AXES pin to include the new axis" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Extend the existing shared predicate in place; no new module, no schema change.",
+    "steps": [
+      "Add chairmanRatificationPending as a new entry in INELIGIBILITY_AXES (fail-open on absence, blocks only on explicit false)",
+      "Add 'chairman_ratification_pending' to CLAIM_WRITE_FENCE_AXES",
+      "Add SD_KEY_TOKEN_RE and fold metadata.soft_depends_on (string or array, prose-tolerant extraction) into draftDepsSatisfied's refKeys",
+      "Verify against live non-terminal SD data that no existing claimable SD becomes newly blocked",
+      "Add/extend unit tests for both FRs and update the one exact-array pin test that needed it"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "node -e \"const {classifyDispatchIneligibility}=require('./lib/fleet/claim-eligibility.cjs'); console.log(classifyDispatchIneligibility({sd_key:'SD-X',metadata:{chairman_ratified:false}}))\"", "expected_outcome": "Prints 'chairman_ratification_pending'" },
+    { "step_number": 2, "instruction": "node -e \"const {classifyDispatchIneligibility}=require('./lib/fleet/claim-eligibility.cjs'); console.log(classifyDispatchIneligibility({sd_key:'SD-X',metadata:{chairman_ratified:true}}))\"", "expected_outcome": "Prints 'null'" },
+    { "step_number": 3, "instruction": "npx vitest run tests/unit/claim-eligibility.test.js tests/unit/fleet/claim-eligibility-chairman-ratified.test.js", "expected_outcome": "All tests pass" }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001"
+  }
+}

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -48,6 +48,11 @@ function isLeadBlockerActive(value) {
  *  afterEach cleanup was interrupted. Mirrors FIXTURE_TITLE_RE in lib/sourcing-engine/refill-candidate-validity.js. */
 const TEST_FIXTURE_KEY_RE = /^(SD-)?(DEMO|TEST)\b/i;
 
+// SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-2): matches an SD-key-shaped token (SD-XXX-YYY-NNN)
+// embedded anywhere in a string -- used to extract a real dependency reference out of free-form
+// prose (metadata.soft_depends_on is Adam-authored narrative text in practice, not a bare key).
+const SD_KEY_TOKEN_RE = /\bSD-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+\b/;
+
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): claim-time fitness predicate (repo-match + premise +
 // preconditions), composed here so the same gate that excludes orchestrator parents / fixtures /
 // human-action SDs also excludes work that is unfit for the CURRENT checkout. Fail-open by design.
@@ -156,7 +161,7 @@ function isSeatBusyOnDirectedWork(ctx) {
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
  * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object, fable_window_active?: boolean, reservations?: object, sessionId?: string }} [ctx]  when present, applies the claim-time fitness + tier + reservation axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'reserved_for_other_session' | 'reserved_for_other_tier' | 'tier_stamp_missing' | 'above_worker_tier' | 'fable_window_downward_claim_blocked' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'not_before_hold' | 'one_way_door_requires_supervision' | 'co_author_pending' | 'chairman_ratification_pending' | 'test_clone_build_tree' | 'unactionable_venture_remediation' | 'sd_deferred' | 'sd_terminal' | 'reserved_for_other_session' | 'reserved_for_other_tier' | 'tier_stamp_missing' | 'above_worker_tier' | 'fable_window_downward_claim_blocked' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 // ── Ordered ineligibility axis table (SD-ARCH-HOTSPOT-SD-START-001 FR-1) ──
 // Each axis is a pure (row, ctx) => reason|null. BOTH classifiers below walk this ONE
@@ -207,6 +212,15 @@ const INELIGIBILITY_AXES = [
   // baselined) and stale-session-sweep paths all route through this predicate, so they exclude it too.
   function coAuthorPending(row) {
     return (row.metadata && row.metadata.co_author_pending === true) ? 'co_author_pending' : null;
+  },
+  // SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-1, PRIORITY): an SD Adam has explicitly marked as
+  // awaiting chairman ratification (metadata.chairman_ratified === false) is NOT belt-eligible.
+  // Adam flips it to true when the chairman approves; a worker/coordinator clears nothing here --
+  // the ratification stamp IS the dispatch authorization, same pattern as needs_coordinator_review.
+  // Fail-open on absence/true: an SD that never carries this field (the overwhelming majority) or
+  // is already ratified=true falls through unchanged -- ONLY the explicit false shape blocks.
+  function chairmanRatificationPending(row) {
+    return (row.metadata && row.metadata.chairman_ratified === false) ? 'chairman_ratification_pending' : null;
   },
   // SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001: a review-pending SD (metadata.needs_coordinator_review
   // === true) is NON-CLAIMABLE until the coordinator REVIEWS it — the coordinator clearing the flag
@@ -391,6 +405,20 @@ async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
   // this axis is re-derived from LIVE status every time, independent of that flag.
   const blockedOn = sd.metadata && sd.metadata.blocked_on_sd;
   if (typeof blockedOn === 'string' && blockedOn && blockedOn !== 'none') refKeys.push(blockedOn);
+  // SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-2): metadata.soft_depends_on -- an Adam-sourced
+  // soft-dependency (single value or array), folded into the SAME live-status re-check as
+  // dependencies/blocked_on_sd rather than a second predicate. Adam stamps this as FREE-FORM PROSE
+  // in practice (live example: "D8 (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) provides merge-time
+  // enrollment; can build in parallel, integrate at PLAN"), not a bare key -- a naive whole-string
+  // match would treat that sentence as a literal (non-matching) sd_key and wrongly block an
+  // already-in-progress SD. Extract the embedded SD-KEY-shaped token instead; a string with no
+  // such token (pure description, no reference) is non-blocking (fail-open).
+  const softDeps = sd.metadata && sd.metadata.soft_depends_on;
+  for (const entry of Array.isArray(softDeps) ? softDeps : [softDeps]) {
+    if (typeof entry !== 'string') continue;
+    const match = entry.match(SD_KEY_TOKEN_RE);
+    if (match) refKeys.push(match[0]);
+  }
   if (!refKeys.length) return true;
   try {
     const { data, error } = await sb.from('strategic_directives_v2').select('sd_key, status').in('sd_key', refKeys);
@@ -641,7 +669,10 @@ function execBoundaryHoldReason(sdRow) {
 // one_way door (documented directed-assign exemption in the oneWayDoor axis comment above).
 // GUARDRAIL (SD-LEO-INFRA-PHASE-SCOPED-FENCE-001): do NOT add exec_boundary_hold here either
 // -- same reasoning as the INELIGIBILITY_AXES guardrail above.
-const CLAIM_WRITE_FENCE_AXES = new Set(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active']);
+// SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-1): chairman_ratification_pending is the same
+// authority-fence shape as needs_coordinator_review (a chairman-controlled hold; the ratification
+// stamp itself IS the clear), so it binds at the claim-write boundary alongside it.
+const CLAIM_WRITE_FENCE_AXES = new Set(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active', 'chairman_ratification_pending']);
 
 /**
  * Live fence re-check at the claim-WRITE boundary (QF-20260711-272). Re-fetches the SD row so a

--- a/tests/unit/claim-eligibility.test.js
+++ b/tests/unit/claim-eligibility.test.js
@@ -107,6 +107,47 @@ describe('draftDepsSatisfied', () => {
     const sd = { dependencies: [], metadata: { blocked_on_sd: 'none' } };
     expect(await draftDepsSatisfied(makeSb({}), sd)).toBe(true);
   });
+
+  // SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-2): metadata.soft_depends_on (single key or array)
+  // folded into the same live-status re-check, fail-open on absence.
+  it('false when metadata.soft_depends_on (string) references a not-yet-completed SD', async () => {
+    const sb = makeSb({ 'SD-GOVERNOR-D8-001': { status: 'in_progress' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: 'SD-GOVERNOR-D8-001' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(false);
+  });
+  it('true once the metadata.soft_depends_on (string) referenced SD is completed', async () => {
+    const sb = makeSb({ 'SD-GOVERNOR-D8-001': { status: 'completed' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: 'SD-GOVERNOR-D8-001' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(true);
+  });
+  // Live example (SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001): Adam stamps soft_depends_on as
+  // free-form prose, not a bare key -- the referenced key must be extracted from the sentence.
+  it('extracts the referenced key from free-form prose (the live Adam-authored shape)', async () => {
+    const sb = makeSb({ 'SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001': { status: 'completed' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: 'D8 (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) provides merge-time enrollment; can build in parallel, integrate at PLAN' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(true);
+  });
+  it('false when the prose-embedded referenced SD is not yet completed', async () => {
+    const sb = makeSb({ 'SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001': { status: 'in_progress' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: 'D8 (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) provides merge-time enrollment' } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(false);
+  });
+  it('false when metadata.soft_depends_on (array) has any not-yet-completed target', async () => {
+    const sb = makeSb({ 'SD-TEST-A-001': { status: 'completed' }, 'SD-TEST-B-001': { status: 'in_progress' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: ['SD-TEST-A-001', 'SD-TEST-B-001'] } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(false);
+  });
+  it('true once every metadata.soft_depends_on (array) target is completed', async () => {
+    const sb = makeSb({ 'SD-TEST-A-001': { status: 'completed' }, 'SD-TEST-B-001': { status: 'completed' } });
+    const sd = { dependencies: [], metadata: { soft_depends_on: ['SD-TEST-A-001', 'SD-TEST-B-001'] } };
+    expect(await draftDepsSatisfied(sb, sd)).toBe(true);
+  });
+  it('treats metadata.soft_depends_on="none", [], and absence as non-blocking (fail-open)', async () => {
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [], metadata: { soft_depends_on: 'none' } })).toBe(true);
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [], metadata: { soft_depends_on: [] } })).toBe(true);
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [], metadata: {} })).toBe(true);
+    expect(await draftDepsSatisfied(makeSb({}), { dependencies: [] })).toBe(true);
+  });
 });
 
 describe('evaluateDispatchEligibility (discriminated verdict; throws on query error)', () => {

--- a/tests/unit/fleet/claim-eligibility-chairman-ratified.test.js
+++ b/tests/unit/fleet/claim-eligibility-chairman-ratified.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001 (FR-1): chairman_ratification_pending axis.
+ *
+ * Adam stamps metadata.chairman_ratified === false on an SD that sits draft/unfenced/ranked but
+ * is awaiting chairman ratification; belt eligibility must key on it. Fail-open on absence: an SD
+ * that never carries the field (today's overwhelming majority) must remain claimable unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+
+const { classifyDispatchIneligibility, classifyAllDispatchIneligibility, CLAIM_WRITE_FENCE_AXES } =
+  require('../../../lib/fleet/claim-eligibility.cjs');
+
+describe('SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001: chairman_ratification_pending axis', () => {
+  it('blocks an SD explicitly stamped chairman_ratified=false', () => {
+    const row = {
+      sd_key: 'SD-FIXTURE-CHAIRMAN-RATIFIED-001',
+      sd_type: 'feature',
+      status: 'draft',
+      metadata: { chairman_ratified: false },
+    };
+    expect(classifyDispatchIneligibility(row)).toBe('chairman_ratification_pending');
+  });
+
+  it('is claimable once chairman_ratified flips to true', () => {
+    const row = {
+      sd_key: 'SD-FIXTURE-CHAIRMAN-RATIFIED-002',
+      sd_type: 'feature',
+      status: 'draft',
+      metadata: { chairman_ratified: true },
+    };
+    expect(classifyDispatchIneligibility(row)).toBeNull();
+  });
+
+  it('fails OPEN when the field is absent (preserves today\'s behavior for the overwhelming majority of SDs)', () => {
+    const row = { sd_key: 'SD-FIXTURE-CHAIRMAN-RATIFIED-003', sd_type: 'feature', status: 'draft', metadata: {} };
+    expect(classifyDispatchIneligibility(row)).toBeNull();
+  });
+
+  it('fails OPEN when metadata itself is absent', () => {
+    const row = { sd_key: 'SD-FIXTURE-CHAIRMAN-RATIFIED-004', sd_type: 'feature', status: 'draft' };
+    expect(classifyDispatchIneligibility(row)).toBeNull();
+  });
+
+  it('classifyAllDispatchIneligibility surfaces chairman_ratification_pending alongside other axes', () => {
+    const row = {
+      sd_key: 'SD-FIXTURE-CHAIRMAN-RATIFIED-005',
+      sd_type: 'feature',
+      status: 'draft',
+      metadata: { chairman_ratified: false, needs_coordinator_review: true },
+    };
+    const all = classifyAllDispatchIneligibility(row);
+    expect(all).toContain('chairman_ratification_pending');
+    expect(all).toContain('needs_coordinator_review');
+  });
+
+  it('CLAIM_WRITE_FENCE_AXES includes chairman_ratification_pending', () => {
+    expect(CLAIM_WRITE_FENCE_AXES.has('chairman_ratification_pending')).toBe(true);
+  });
+});

--- a/tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js
+++ b/tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js
@@ -49,7 +49,8 @@ describe('SD-LEO-INFRA-PHASE-SCOPED-FENCE-001 FR-4/TS-3: claim-eligibility negat
   it('CLAIM_WRITE_FENCE_AXES does not contain exec_boundary_hold (static assertion)', () => {
     expect(CLAIM_WRITE_FENCE_AXES.has('exec_boundary_hold')).toBe(false);
     // SD-FDBK-FIX-DISPATCH-ELIGIBILITY-HONOR-001: lead_blocker_active added as a 4th write-fence axis.
-    expect([...CLAIM_WRITE_FENCE_AXES]).toEqual(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active']);
+    // SD-LEO-INFRA-BELT-CLAIM-ELIGIBILITY-001: chairman_ratification_pending added as a 5th.
+    expect([...CLAIM_WRITE_FENCE_AXES]).toEqual(['human_action_required', 'needs_coordinator_review', 'not_before_hold', 'lead_blocker_active', 'chairman_ratification_pending']);
   });
 
   it('a held SD with no OTHER ineligibility axis is fully claimable (regression baseline)', () => {


### PR DESCRIPTION
## Summary
- Extends the shared dispatch-eligibility predicate (`lib/fleet/claim-eligibility.cjs`, used by both the worker self-claim path and the coordinator sweep path) to read two Adam-sourced `metadata` fields that were previously only encoded in prose/human relay.
- **FR-1** (priority): new `chairmanRatificationPending` axis blocks dispatch only when `metadata.chairman_ratified === false`. Fail-open on absence or `true`. Added to `CLAIM_WRITE_FENCE_AXES` (same chairman-authority-fence class as `needs_coordinator_review`).
- **FR-2**: `metadata.soft_depends_on` folded into the existing `draftDepsSatisfied` live-status re-check (not a second predicate). Adam stamps this as **free-form prose** in practice — the one live example is `"D8 (SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001) provides merge-time enrollment; can build in parallel, integrate at PLAN"` — so a new `SD_KEY_TOKEN_RE` extracts the embedded SD-key reference rather than treating the whole sentence as a literal key (which would have wrongly blocked that already-in-progress SD).
- **FR-3** (regression safety): verified against all 26 live non-terminal `strategic_directives_v2` rows — zero rows newly blocked by either axis; the one live `soft_depends_on`-bearing SD (`SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001`) resolves `draftDepsSatisfied === true`, matching its current claimable state.

## Test plan
- [x] New unit test file `tests/unit/fleet/claim-eligibility-chairman-ratified.test.js` (6 tests): blocks on `=false`, claimable on `=true`/absent, `classifyAllDispatchIneligibility` surfaces it, `CLAIM_WRITE_FENCE_AXES` includes it
- [x] Extended `tests/unit/claim-eligibility.test.js` with `soft_depends_on` cases: bare-key string, **free-form prose extraction** (the live shape), array with mixed completion, fail-open on none/empty/absent
- [x] Updated the one exact-array `CLAIM_WRITE_FENCE_AXES` pin test (`tests/unit/fleet/exec-boundary-hold-claim-eligibility.test.js`) to include the new axis
- [x] Full claim-eligibility-related suite: 51 test files, 580 tests, all passing
- [x] Live-data regression script run against all 26 non-terminal SDs — zero newly-blocked
- [x] Live verification of the one `soft_depends_on`-bearing SD — resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)