### PR TITLE
fix(eva_vision_scores): add 'unverified' to threshold_action CHECK constraint

### DIFF
--- a/database/migrations/20260713_eva_vision_scores_add_unverified_threshold_action.sql
+++ b/database/migrations/20260713_eva_vision_scores_add_unverified_threshold_action.sql
@@ -1,0 +1,27 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Add 'unverified' as a valid eva_vision_scores.threshold_action value.
+-- SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001 (campaign-mode inline fix)
+--
+-- scripts/eva/heal-command.mjs's persist path (SD-WRITERCONSUMER-ASYMMETRY-DETECTION-
+-- SCOPECOMPLETION-ORCH-001-0 / FR-C0-5, TESTING AC-C0-006) computes
+-- threshold_action='unverified' whenever an SD's lineage_verdict is
+-- BACKFILLED_LOW_CONFIDENCE (a per-SD verdict-tier override that trumps the
+-- score-based threshold) -- but the original CHECK constraint was never widened
+-- to allow that value, so every heal-score persist attempt for a low-confidence-
+-- lineage SD has been failing with a CHECK-constraint violation since that
+-- feature was written. Confirmed live: this SD's own heal-score persist hit
+-- exactly this error, because it was itself swept into the vision_key backfill
+-- batch (fixed earlier in this same SD) and stamped lineage_verdict=
+-- BACKFILLED_LOW_CONFIDENCE. The bug was previously unreachable/latent, since
+-- the backfill tool that stamps lineage_verdict was ALSO broken (silently wrote
+-- nothing) until this SD's own FR-3 fixed it.
+
+ALTER TABLE eva_vision_scores
+  DROP CONSTRAINT eva_vision_scores_threshold_action_check;
+
+ALTER TABLE eva_vision_scores
+  ADD CONSTRAINT eva_vision_scores_threshold_action_check
+  CHECK (threshold_action IN ('accept', 'minor_sd', 'gap_closure_sd', 'escalate', 'unverified'));
+
+COMMENT ON COLUMN eva_vision_scores.threshold_action IS
+  'Action taken based on score: accept (>=93), minor_sd (83-92), gap_closure_sd (70-82), escalate (<70), unverified (lineage_verdict=BACKFILLED_LOW_CONFIDENCE override, independent of score).';


### PR DESCRIPTION
## Summary
- `scripts/eva/heal-command.mjs`'s persist path computes `threshold_action='unverified'` for any SD whose `lineage_verdict='BACKFILLED_LOW_CONFIDENCE'` (a verdict-tier override that trumps the score-based threshold, per SD-WRITERCONSUMER-ASYMMETRY-DETECTION-SCOPECOMPLETION-ORCH-001-0 FR-C0-5), but `eva_vision_scores.threshold_action`'s CHECK constraint only ever allowed `accept/minor_sd/gap_closure_sd/escalate` — so every heal-score persist attempt for a low-confidence-lineage SD has been failing with a CHECK-constraint violation since that feature was written.
- Discovered live via SD-LEO-INFRA-VISION-KEY-STAMP-AT-SD-CREATION-001's own post-completion `/heal` step, which tripped this exact error — that SD was itself swept into an earlier vision_key backfill batch (a separate fix, same SD) and got `lineage_verdict=BACKFILLED_LOW_CONFIDENCE` stamped. This bug was previously latent/unreachable, since the backfill tool that stamps `lineage_verdict` was ALSO silently broken (wrote nothing) until fixed in that same SD.
- Also corrected the column comment, which had drifted from the code's actual thresholds (documented `accept>=85/minor_sd 70-84/gap_closure_sd 50-69/escalate<50`; the real code uses `93/83/70` boundaries).

## Test plan
- [x] Applied live via `apply-migration.js --prod-deploy`
- [x] Confirmed the constraint change live: a direct insert with `threshold_action='unverified'` now succeeds
- N/A automated tests — single additive CHECK-constraint widening, no application logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)