### PR TITLE
feat(SD-LEO-INFRA-AUTHENTICATE-CHAIRMAN-OVERRIDES-001): authenticate chairman overrides (L6)

### DIFF
--- a/lib/chairman/__tests__/override-authentication.test.js
+++ b/lib/chairman/__tests__/override-authentication.test.js
@@ -1,0 +1,119 @@
+/**
+ * Chairman override authentication tests (L6, FR-1..FR-4).
+ * (SD-LEO-INFRA-AUTHENTICATE-CHAIRMAN-OVERRIDES-001)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAuthenticatedIdentity,
+  recordAuthenticatedOverride,
+  authenticationRatio,
+  surfaceAuthMechanismQuestion,
+} from '../override-authentication.js';
+
+const UID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('resolveAuthenticatedIdentity (FR-2 — never fabricate)', () => {
+  it('returns a UUID from an explicit authenticated id', () => {
+    expect(resolveAuthenticatedIdentity({ authenticatedUserId: UID })).toBe(UID);
+  });
+  it('returns a UUID from a supabase auth session', () => {
+    expect(resolveAuthenticatedIdentity({ session: { user: { id: UID } } })).toBe(UID);
+  });
+  it('returns NULL when no authenticated identity is present', () => {
+    expect(resolveAuthenticatedIdentity({})).toBeNull();
+  });
+  it('does NOT accept a free-text decided_by string as an identity', () => {
+    expect(resolveAuthenticatedIdentity({ authenticatedUserId: 'chairman-verbal-relay:codestreetlabs@gmail.com' })).toBeNull();
+    expect(resolveAuthenticatedIdentity({ authenticatedUserId: 'adam' })).toBeNull();
+  });
+});
+
+describe('recordAuthenticatedOverride (FR-1/FR-2 — fail-soft, honest)', () => {
+  function mockSupabase() {
+    const calls = { updates: [] };
+    return {
+      calls,
+      from() {
+        return {
+          update(patch) { this._p = patch; return this; },
+          eq(_c, v) { calls.updates.push({ id: v, patch: this._p }); return Promise.resolve({ error: null }); },
+        };
+      },
+    };
+  }
+
+  it('stamps decided_by_user_id when authenticated', async () => {
+    const sb = mockSupabase();
+    const r = await recordAuthenticatedOverride({ supabase: sb }, { decisionId: 'd1', decision: 'approved', identityContext: { authenticatedUserId: UID } });
+    expect(r.authenticated).toBe(true);
+    expect(r.userId).toBe(UID);
+    expect(sb.calls.updates[0].patch.decided_by_user_id).toBe(UID);
+  });
+
+  it('leaves decided_by_user_id UNSET when no identity (honest unauthenticated)', async () => {
+    const sb = mockSupabase();
+    const r = await recordAuthenticatedOverride({ supabase: sb }, { decisionId: 'd2', decision: 'approved', decidedBy: 'chairman-verbal-relay:x@y.com' });
+    expect(r.authenticated).toBe(false);
+    expect(r.userId).toBeNull();
+    expect(sb.calls.updates[0].patch).not.toHaveProperty('decided_by_user_id');
+    expect(sb.calls.updates[0].patch.decided_by).toBe('chairman-verbal-relay:x@y.com'); // free-text kept as provenance
+  });
+
+  it('FAIL-SOFT: a tracker throw does not block the decision', async () => {
+    const sb = mockSupabase();
+    const recordOverride = async () => { throw new Error('tracker boom'); };
+    const r = await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd3', decision: 'approved', identityContext: { authenticatedUserId: UID } });
+    expect(r.decisionUpdated).toBe(true);
+    expect(r.trackerRecorded).toBe(false); // tracker failed, but decision succeeded
+  });
+
+  it('fires the tracker with decided_by_user_id=null when unauthenticated', async () => {
+    const sb = mockSupabase();
+    let trackerArg = null;
+    const recordOverride = async (_d, arg) => { trackerArg = arg; };
+    await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd4', decision: 'rejected' });
+    expect(trackerArg.authenticated).toBe(false);
+    expect(trackerArg.decided_by_user_id).toBeNull();
+  });
+});
+
+describe('authenticationRatio (FR-3 — honest, legacy stays unauthenticated)', () => {
+  it('computes authenticated/total with legacy NULL rows as unauthenticated', async () => {
+    const supabase = {
+      from() {
+        const q = {
+          _notNull: false,
+          select() { return this; },
+          not() { this._notNull = true; return this; },
+          then(res) { return Promise.resolve({ count: this._notNull ? 3 : 100, error: null }).then(res); },
+        };
+        return q;
+      },
+    };
+    const r = await authenticationRatio(supabase);
+    expect(r.ok).toBe(true);
+    expect(r.total).toBe(100);
+    expect(r.authenticated).toBe(3);
+    expect(r.unauthenticated).toBe(97); // the ~97% NULL legacy rows, honestly unauthenticated
+    expect(r.ratio).toBeCloseTo(0.03);
+  });
+
+  it('fail-soft on a query error', async () => {
+    const supabase = { from() { return { select() { return this; }, not() { return this; }, then(res) { return Promise.resolve({ error: { message: 'boom' } }).then(res); } }; } };
+    const r = await authenticationRatio(supabase);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('surfaceAuthMechanismQuestion (FR-4 — chairman-owned, not invented)', () => {
+  it('records a blocking chairman question via the canonical recorder', async () => {
+    let recorded = null;
+    const recordPendingDecision = async (_sb, args) => { recorded = args; return { recorded: true, id: 'q1' }; };
+    const r = await surfaceAuthMechanismQuestion({ supabase: {}, recordPendingDecision });
+    expect(r.recorded).toBe(true);
+    expect(recorded.blocking).toBe(true);
+    expect(recorded.title).toMatch(/authenticate/i);
+    expect(recorded.context).toMatch(/verbal-relay/); // carries the live-proof context
+    expect(recorded.context).toMatch(/OPTIONS/); // presents options, does not decide
+  });
+});

--- a/lib/chairman/__tests__/override-authentication.test.js
+++ b/lib/chairman/__tests__/override-authentication.test.js
@@ -59,21 +59,32 @@ describe('recordAuthenticatedOverride (FR-1/FR-2 — fail-soft, honest)', () => 
     expect(sb.calls.updates[0].patch.decided_by).toBe('chairman-verbal-relay:x@y.com'); // free-text kept as provenance
   });
 
-  it('FAIL-SOFT: a tracker throw does not block the decision', async () => {
+  it('FAIL-SOFT: a tracker throw does not block the decision (with venture-score context)', async () => {
     const sb = mockSupabase();
     const recordOverride = async () => { throw new Error('tracker boom'); };
-    const r = await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd3', decision: 'approved', identityContext: { authenticatedUserId: UID } });
+    const r = await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd3', decision: 'approved', identityContext: { authenticatedUserId: UID }, ventureId: 'v1', component: 'moat' });
     expect(r.decisionUpdated).toBe(true);
     expect(r.trackerRecorded).toBe(false); // tracker failed, but decision succeeded
   });
 
-  it('fires the tracker with decided_by_user_id=null when unauthenticated', async () => {
+  it('fires the venture-score tracker with the tracker shape (ventureId/component/scores)', async () => {
     const sb = mockSupabase();
     let trackerArg = null;
-    const recordOverride = async (_d, arg) => { trackerArg = arg; };
-    await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd4', decision: 'rejected' });
-    expect(trackerArg.authenticated).toBe(false);
-    expect(trackerArg.decided_by_user_id).toBeNull();
+    const recordOverride = async (_d, arg) => { trackerArg = arg; return { id: 'ov1' }; };
+    const r = await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd4', decision: 'rejected', ventureId: 'v1', component: 'moat', systemScore: 60, overrideScore: 90 });
+    expect(trackerArg.ventureId).toBe('v1');
+    expect(trackerArg.component).toBe('moat');
+    expect(trackerArg.systemScore).toBe(60);
+    expect(r.trackerRecorded).toBe(true);
+  });
+
+  it('does NOT fire the venture-score tracker for a decision without venture context', async () => {
+    const sb = mockSupabase();
+    let called = false;
+    const recordOverride = async () => { called = true; };
+    const r = await recordAuthenticatedOverride({ supabase: sb, recordOverride }, { decisionId: 'd5', decision: 'approved' });
+    expect(called).toBe(false); // no ventureId/component -> tracker not applicable
+    expect(r.decisionUpdated).toBe(true); // identity capture still runs
   });
 });
 

--- a/lib/chairman/override-authentication.js
+++ b/lib/chairman/override-authentication.js
@@ -15,6 +15,23 @@
  */
 
 /**
+ * FR-1 (activation) — the canonical server-side entry point for resolving a chairman
+ * decision WITH authenticated-identity capture. This binds the REAL override-tracker
+ * (lib/eva/stage-zero/chairman-override-tracker.js) as the live caller so it stops being
+ * dormant (zero callers). Any server-side path that resolves a chairman decision should
+ * call THIS instead of updating chairman_decisions directly. Fail-soft.
+ *
+ * @param {Object} supabase - service-role client
+ * @param {Object} params - see recordAuthenticatedOverride params
+ * @returns {Promise<Object>} recordAuthenticatedOverride result
+ */
+export async function resolveChairmanDecisionAuthenticated(supabase, params) {
+  // Lazy import so the pure helpers above stay dependency-free/testable.
+  const { recordOverride } = await import('../eva/stage-zero/chairman-override-tracker.js');
+  return recordAuthenticatedOverride({ supabase, recordOverride }, params);
+}
+
+/**
  * FR-2 — resolve an authenticated identity from a decision/session context, ONLY if one
  * is genuinely present. Returns a UUID user id or null. Never fabricates.
  *
@@ -77,18 +94,23 @@ export async function recordAuthenticatedOverride(deps, params) {
     } catch { /* fail-soft: caller decides how to surface */ }
   }
 
-  // FR-1 — fire the override-tracker, FAIL-SOFT (never block the decision).
+  // FR-1 — fire the override-tracker, FAIL-SOFT (never block the decision). The tracker's
+  // domain is VENTURE synthesis-score overrides (chairman_overrides needs ventureId +
+  // component + scores), so we only record there when this override carries that context
+  // (params.ventureId + component). Identity capture above is decision-scoped and always
+  // runs; the tracker record is the venture-score-override half.
   let trackerRecorded = false;
-  if (typeof recordOverride === 'function') {
+  const { ventureId = null, systemScore = null, overrideScore = null, reason = null } = params || {};
+  if (typeof recordOverride === 'function' && ventureId && component) {
     try {
-      await recordOverride({ supabase }, {
-        decision_id: decisionId,
+      const res = await recordOverride({ supabase }, {
+        ventureId,
         component,
-        decided_by_user_id: userId,      // null when unauthenticated (honest)
-        authenticated,
-        decision,
+        systemScore,
+        overrideScore,
+        reason: reason || (authenticated ? `authenticated chairman override (user ${userId})` : 'unauthenticated override'),
       });
-      trackerRecorded = true;
+      trackerRecorded = res != null;
     } catch { /* tracker failure must not block */ }
   }
 

--- a/lib/chairman/override-authentication.js
+++ b/lib/chairman/override-authentication.js
@@ -41,6 +41,15 @@ export async function resolveChairmanDecisionAuthenticated(supabase, params) {
  *   3. context.auth.userId — a generic auth carrier
  * Free-text `decided_by` (e.g. 'adam', 'chairman-verbal-relay:...') is NOT an identity.
  *
+ * SECURITY (SD-LEO-INFRA-AUTHENTICATE-CHAIRMAN-OVERRIDES-001 review, CONDITIONAL_PASS):
+ * this resolver validates UUID *format* only — it trusts that the caller's context is
+ * already server-verified. At the wiring site you MUST populate identityContext EXCLUSIVELY
+ * from a server-verified Supabase session (e.g. supabase.auth.getUser() / session.user.id),
+ * NEVER from a client-supplied authenticatedUserId/auth.userId — otherwise a valid-format
+ * UUID could be spoofed into decided_by_user_id. Note: decided_by_user_id is an audit/
+ * provenance field, not an RLS predicate, and the stamping UPDATE is service-role-only, so
+ * a spoof pollutes the honesty ratio but grants no DB privilege.
+ *
  * @param {Object} [context]
  * @returns {string|null}
  */

--- a/lib/chairman/override-authentication.js
+++ b/lib/chairman/override-authentication.js
@@ -1,0 +1,156 @@
+/**
+ * Chairman override authentication — loop-map gap L6.
+ * (SD-LEO-INFRA-AUTHENTICATE-CHAIRMAN-OVERRIDES-001)
+ *
+ * Wires the EXISTING-but-dormant substrate: chairman_decisions.decided_by_user_id
+ * (added but ~97% NULL) and the override-tracker (lib/eva/stage-zero/
+ * chairman-override-tracker.js, zero live callers) so a genuine chairman override is
+ * distinguishable from an AI self-approval.
+ *
+ * HONESTY-FIRST (the whole point): an authenticated identity is captured ONLY when one
+ * is genuinely present. We NEVER fabricate/hardcode a chairman user_id and NEVER derive
+ * identity from the free-text `decided_by` string — an unknown identity stays NULL and
+ * is counted as UNAUTHENTICATED. Inflating the number would re-create the exact
+ * AI-self-approval conflation this SD exists to end.
+ */
+
+/**
+ * FR-2 — resolve an authenticated identity from a decision/session context, ONLY if one
+ * is genuinely present. Returns a UUID user id or null. Never fabricates.
+ *
+ * Recognized authenticated sources (in priority order):
+ *   1. context.authenticatedUserId — an explicitly-authenticated user id
+ *   2. context.session.user.id — a Supabase auth session user
+ *   3. context.auth.userId — a generic auth carrier
+ * Free-text `decided_by` (e.g. 'adam', 'chairman-verbal-relay:...') is NOT an identity.
+ *
+ * @param {Object} [context]
+ * @returns {string|null}
+ */
+export function resolveAuthenticatedIdentity(context = {}) {
+  const candidates = [
+    context.authenticatedUserId,
+    context.session?.user?.id,
+    context.auth?.userId,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && isUuid(c)) return c;
+  }
+  return null;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isUuid(s) { return typeof s === 'string' && UUID_RE.test(s); }
+
+/**
+ * FR-1/FR-2 — record a chairman override with authenticated identity capture. Populates
+ * chairman_decisions.decided_by_user_id when an identity is genuinely available, and
+ * fires the override-tracker. FAIL-SOFT: a tracker error NEVER blocks the decision, and
+ * an absent identity does not fail — it records an unauthenticated override honestly.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.supabase - service-role client
+ * @param {Function} [deps.recordOverride] - the override-tracker recordOverride (injected for reuse/testing)
+ * @param {Object} params
+ * @param {string} params.decisionId - chairman_decisions.id being overridden/resolved
+ * @param {string} params.decision - 'approved' | 'rejected' | ...
+ * @param {Object} [params.identityContext] - carries an authenticated identity if present
+ * @param {string} [params.decidedBy] - free-text label (kept for provenance, NOT an identity)
+ * @param {string} [params.component]
+ * @returns {Promise<{decisionUpdated:boolean, authenticated:boolean, userId:string|null, trackerRecorded:boolean, reason?:string}>}
+ */
+export async function recordAuthenticatedOverride(deps, params) {
+  const { supabase, recordOverride } = deps || {};
+  const { decisionId, decision, identityContext, decidedBy = null, component = null } = params || {};
+  const userId = resolveAuthenticatedIdentity(identityContext || {});
+  const authenticated = userId != null;
+
+  let decisionUpdated = false;
+  if (supabase && decisionId) {
+    try {
+      const patch = { decision, status: 'decided', decided_at: new Date().toISOString() };
+      // Only stamp decided_by_user_id when genuinely authenticated (else leave NULL — honest).
+      if (authenticated) patch.decided_by_user_id = userId;
+      if (decidedBy) patch.decided_by = decidedBy; // free-text provenance, not identity
+      const { error } = await supabase.from('chairman_decisions').update(patch).eq('id', decisionId);
+      decisionUpdated = !error;
+    } catch { /* fail-soft: caller decides how to surface */ }
+  }
+
+  // FR-1 — fire the override-tracker, FAIL-SOFT (never block the decision).
+  let trackerRecorded = false;
+  if (typeof recordOverride === 'function') {
+    try {
+      await recordOverride({ supabase }, {
+        decision_id: decisionId,
+        component,
+        decided_by_user_id: userId,      // null when unauthenticated (honest)
+        authenticated,
+        decision,
+      });
+      trackerRecorded = true;
+    } catch { /* tracker failure must not block */ }
+  }
+
+  return {
+    decisionUpdated,
+    authenticated,
+    userId,
+    trackerRecorded,
+    reason: authenticated ? 'authenticated chairman identity captured' : 'no authenticated identity — recorded as unauthenticated',
+  };
+}
+
+/**
+ * FR-3 — honest authenticated-vs-unauthenticated ratio over chairman_decisions. Legacy
+ * NULL-identity rows are counted as unauthenticated (never reclassified). Fail-soft.
+ *
+ * @param {Object} supabase - service-role client
+ * @returns {Promise<{total:number, authenticated:number, unauthenticated:number, ratio:number|null, ok:boolean, reason?:string}>}
+ */
+export async function authenticationRatio(supabase) {
+  try {
+    const totalRes = await supabase.from('chairman_decisions').select('*', { count: 'exact', head: true });
+    const authRes = await supabase.from('chairman_decisions').select('*', { count: 'exact', head: true }).not('decided_by_user_id', 'is', null);
+    if (totalRes.error || authRes.error) {
+      return { total: 0, authenticated: 0, unauthenticated: 0, ratio: null, ok: false, reason: (totalRes.error || authRes.error).message };
+    }
+    const total = totalRes.count || 0;
+    const authenticated = authRes.count || 0;
+    const unauthenticated = total - authenticated;
+    return { total, authenticated, unauthenticated, ratio: total > 0 ? authenticated / total : null, ok: true };
+  } catch (e) {
+    return { total: 0, authenticated: 0, unauthenticated: 0, ratio: null, ok: false, reason: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * FR-4 — surface the chairman-auth-MECHANISM question to the chairman. This SD does NOT
+ * invent a mechanism; the decision (how to authenticate a chairman identity going
+ * forward) is chairman-owned. Records a blocking chairman_decisions question via the
+ * canonical recorder so it lands in the chairman decision-queue + fires the escalation email.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.supabase
+ * @param {Function} deps.recordPendingDecision - lib/chairman/record-pending-decision.mjs recorder
+ * @returns {Promise<{recorded:boolean, id?:string, error?:string}>}
+ */
+export async function surfaceAuthMechanismQuestion(deps) {
+  const { supabase, recordPendingDecision } = deps || {};
+  if (typeof recordPendingDecision !== 'function') return { recorded: false, error: 'recordPendingDecision is required' };
+  return recordPendingDecision(supabase, {
+    title: 'How should a chairman identity be authenticated? (L6 override-authentication)',
+    decisionType: 'session_question',
+    blocking: true,
+    raisedBy: 'loop-governance-L6',
+    recommendation: null,
+    context:
+      'chairman_decisions.decided_by_user_id exists but ~97% of rows are NULL because no path captures an ' +
+      'authenticated chairman identity. LIVE PROOF (2026-07-13): the Alt-Text Stage-3 approval recorded ' +
+      "decided_by='chairman-verbal-relay:codestreetlabs@gmail.com', decided_by_user_id=NULL. The wiring is done " +
+      '(override-tracker activated, capture path added, honest ratio query) but it can only stamp an identity when ' +
+      'one is genuinely authenticated. OPTIONS to decide: (a) a chairman Supabase-auth login that stamps auth.uid() ' +
+      'on decisions; (b) a signed chairman-approval token; (c) a dedicated authenticated chairman console. Until a ' +
+      'mechanism is chosen, chairman decisions remain honestly unauthenticated and indistinguishable from AI self-approval.',
+  });
+}


### PR DESCRIPTION
## Summary
Loop-map gap L6: the system cannot distinguish a genuine chairman override from an AI self-approval (~97% of chairman_decisions rows have NULL decided_by_user_id; the override-tracker had zero callers). WIRE-not-BUILD — the substrate existed but was unwired.

- **lib/chairman/override-authentication.js**: resolveAuthenticatedIdentity (captures a chairman user_id ONLY when a genuine authenticated identity is present — never fabricates, never accepts free-text as identity), recordAuthenticatedOverride (stamps decided_by_user_id only when authenticated; fires the venture-score override-tracker fail-soft), resolveChairmanDecisionAuthenticated (canonical live caller binding the real tracker), authenticationRatio (honest — legacy NULL rows stay unauthenticated), surfaceAuthMechanismQuestion.
- **FR-4 executed live**: the chairman auth-mechanism question is recorded in the decision queue (chairman_decisions, escalation fired) — the mechanism is chairman-owned, not invented here.
- SECURITY sub-agent: CONDITIONAL_PASS — honesty invariant confirmed; wiring guidance (server-verified session only) documented in-code.

## Honesty posture
decided_by_user_id can only populate once an authenticated identity SOURCE is wired at the UI/session layer (a chairman-owned mechanism decision, now surfaced). The ratio starts low honestly; legacy rows are NOT backfilled.

## Test plan
- 12 unit tests (identity honesty, fail-soft tracker, correct tracker shape, honest ratio, question surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)