### PR TITLE
chore(loop-governance): CRON-WIRE — daily GHA cadence for runClosureVerifier

### DIFF
--- a/.github/workflows/loop-closure-verifier-cron.yml
+++ b/.github/workflows/loop-closure-verifier-cron.yml
@@ -1,0 +1,49 @@
+name: "Loop-closure verifier (daily)"
+
+# SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001 — the CRON-WIRE. PR #6090 armed the
+# closure verifier (g3-armed-loop-closure-verifier, daily expected interval) but no
+# recurring cron actually invoked runClosureVerifier, so loop_registry verdicts only
+# advanced on manual runs. This workflow is the real cadence: it runs the verifier
+# daily with the honest empty-evidence baseline (STARVED until per-loop evidence
+# collectors land — a separate, dependency-ordered SD), stamps the registry witness,
+# and goes red on any GT-1 false-CLOSE. The op-co GO gate requires this to fire on
+# real cadence, not just once by hand. Mirrors wave-progress-refresher.yml.
+
+on:
+  schedule:
+    # Daily, minute offset to dodge the :00/:15 cron clusters.
+    - cron: '19 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  verify-closures:
+    name: Evaluate loop_registry closures
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run loop-closure verifier
+        run: node scripts/loop-closure-verifier-run.mjs

--- a/scripts/loop-closure-verifier-run.mjs
+++ b/scripts/loop-closure-verifier-run.mjs
@@ -1,0 +1,71 @@
+/**
+ * Loop-closure verifier cadence runner (the CRON-WIRE).
+ * (SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001 — operational hardening gap (a))
+ *
+ * PR #6090 shipped and ARMED the closure verifier (periodic_process_registry row
+ * `g3-armed-loop-closure-verifier`, daily cadence) but nothing invokes it on a real
+ * schedule — evaluated_at only advances when someone runs it by hand. This CLI is the
+ * missing invoker, called daily by .github/workflows/loop-closure-verifier-cron.yml
+ * (and manually via workflow_dispatch or `node scripts/loop-closure-verifier-run.mjs`).
+ *
+ * Evidence collector: per-loop collectors are a separate, dependency-ordered SD (Adam's
+ * lane — D5 retention is the golden-test first collector). Until they land, this runner
+ * supplies the EMPTY collector, which the closure engine evaluates as STARVED — the
+ * chairman-ratified honest baseline (33/33 STARVED, 2026-07-14). Collectors plug in
+ * here when they exist.
+ *
+ * GT-1 guard: with empty evidence no loop can legitimately evaluate CLOSED (edge
+ * freshness of a null edge is false). A CLOSED verdict under this baseline is a
+ * false-CLOSE — the exact failure the op-co GO gate exists to prevent — so it is
+ * surfaced as GT1_VIOLATION and the run exits non-zero to turn the workflow red.
+ *
+ * Witness: stamps last_fired_at on the ARMED registry row via stampLastFired (NOT
+ * registerVerifierCadence, whose upsert resets last_fired_at to null).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { runClosureVerifier, VERIFIER_PROCESS_KEY } from '../lib/loop-governance/verifier.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
+
+// Per-loop evidence collectors not wired yet — empty evidence => honest STARVED.
+const emptyEvidenceCollector = () => ({});
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[loop-closure-verifier-run] missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+
+  const result = await runClosureVerifier(supabase, emptyEvidenceCollector);
+  if (!result.ran) {
+    console.error(`[loop-closure-verifier-run] verifier did not run: ${result.reason}`);
+    process.exit(1);
+  }
+
+  const tally = {};
+  for (const v of result.verdicts || []) tally[v.status] = (tally[v.status] || 0) + 1;
+  console.log(
+    `[loop-closure-verifier-run] evaluated=${result.evaluated} written=${result.written} ` +
+    `tally=${JSON.stringify(tally)}`
+  );
+
+  const falseClosed = (result.verdicts || []).filter((v) => v.status === 'closed');
+  if (falseClosed.length > 0) {
+    console.error(
+      `GT1_VIOLATION false-CLOSE under empty-evidence baseline: ` +
+      falseClosed.map((v) => v.loop_key).join(', ')
+    );
+    process.exit(1);
+  }
+
+  const stamp = await stampLastFired(supabase, VERIFIER_PROCESS_KEY);
+  console.log(`[loop-closure-verifier-run] witness ${VERIFIER_PROCESS_KEY} stamped=${stamp.stamped}${stamp.reason ? ` (${stamp.reason})` : ''}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => {
+  console.error('[loop-closure-verifier-run] error:', e && e.message ? e.message : e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
The governor (SD-LEO-INFRA-UNIVERSAL-LOOP-GOVERNANCE-001, PR #6090) shipped ARMED but nothing invoked `runClosureVerifier` on a schedule — `loop_registry.evaluated_at` only advanced on manual runs, holding the op-co GO gate. This is the missing cron-wire (chairman-directed Friday-pair item, pulled forward to today; corr 132cd44a).

- **scripts/loop-closure-verifier-run.mjs** — CLI invoker: empty-evidence collector (honest STARVED baseline until Adam's per-loop collectors land), GT-1 false-CLOSE guard (any CLOSED under empty evidence exits non-zero → red run), witness stamp via `stampLastFired` (NOT `registerVerifierCadence`, whose upsert nulls `last_fired_at`).
- **.github/workflows/loop-closure-verifier-cron.yml** — daily `19 8 * * *` + `workflow_dispatch`, mirrors `wave-progress-refresher.yml`.

## Verification
Smoke-run against live DB from this branch: `evaluated=33 written=33 tally={\"starved\":33}`, witness `g3-armed-loop-closure-verifier` stamped, zero GT-1 violations. Post-merge: `workflow_dispatch` canary, then confirm the first scheduled fire advances `last_fired_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)