### PR TITLE
fix(SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001): unified dual-surface claim release

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -497,12 +497,15 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
             p_reason: 'manual'
           });
           if (releaseError) {
-            // Fallback: direct update on claude_sessions if RPC fails
-            console.warn(`[claimGuard] RPC release failed, using direct update: ${releaseError.message}`);
-            await supabase
-              .from('claude_sessions')
-              .update({ sd_key: null, released_at: new Date().toISOString(), released_reason: 'manual', status: 'idle' })
-              .eq('session_id', claim.session_id);
+            // Fallback: dual-surface direct release if the release_sd RPC fails. Co-clears the
+            // SD-side AND nulls sd_key + worktree_* together (a bare sd_key clear trips the
+            // ck_worktree_state_consistency CHECK — SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001). Mirrors
+            // release_sd's status='idle'. tryRpc:false — the release_sd RPC just failed.
+            console.warn(`[claimGuard] RPC release failed, using dual-surface direct update: ${releaseError.message}`);
+            const { releaseClaimBothSurfaces } = await import('./claim/release-claim-both-surfaces.mjs');
+            await releaseClaimBothSurfaces(supabase, {
+              sdKey, holderSessionId: claim.session_id, reason: 'manual', sessionStatus: 'idle', tryRpc: false,
+            });
           }
           continue; // Proceed to acquire
         }
@@ -601,15 +604,18 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
     });
     if (releaseError) {
       console.warn(`[claimGuard] Failed to release stale session ${claim.session_id}: ${releaseError.message}`);
-      // Fallback: direct update on claude_sessions if RPC fails
-      const { error: directErr } = await supabase
-        .from('claude_sessions')
-        .update({ sd_key: null, released_at: new Date().toISOString(), released_reason: 'stale_session', status: 'idle' })
-        .eq('session_id', claim.session_id);
-      if (directErr) {
-        console.warn(`[claimGuard] Direct release also failed: ${directErr.message}`);
+      // Fallback: dual-surface direct release. Co-clears the SD-side AND nulls sd_key +
+      // worktree_* together (a bare sd_key clear trips the ck_worktree_state_consistency
+      // CHECK — SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001). Mirrors release_sd's status='idle';
+      // tryRpc:false since the release_sd RPC just failed.
+      const { releaseClaimBothSurfaces } = await import('./claim/release-claim-both-surfaces.mjs');
+      const r = await releaseClaimBothSurfaces(supabase, {
+        sdKey, holderSessionId: claim.session_id, reason: 'stale_session', sessionStatus: 'idle', tryRpc: false,
+      });
+      if (r.error) {
+        console.warn(`[claimGuard] Direct release also failed: ${r.error}`);
       } else {
-        console.log(`[claimGuard] Released stale claim via direct update`);
+        console.log(`[claimGuard] Released stale claim via dual-surface direct update`);
       }
     }
   }

--- a/lib/claim-lifecycle-release.mjs
+++ b/lib/claim-lifecycle-release.mjs
@@ -100,6 +100,12 @@ export async function releaseClaimOnPROpen(snapshot) {
     return { released: false, reason: 'no_snapshot' };
   }
   const sb = getSupabase();
+  // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001 — INTENTIONAL SINGLE-SURFACE CLEAR (R4 exclusion).
+  // This fires when a PR OPENS while the worker keeps SHIPPING. Only the SD-side claim is
+  // released (so the SD can be reclaimed / rolled up); the session-side (claude_sessions.sd_key +
+  // worktree_*) is deliberately LEFT INTACT because the worker is still ALIVE in that worktree.
+  // It must NOT be routed through releaseClaimBothSurfaces (that would evict a live worker).
+  // Allowlisted in the dual-surface release guard (tests/unit/claim/release-dual-surface-guard.test.js).
   const { data, error } = await sb
     .from('strategic_directives_v2')
     .update({ claiming_session_id: null })

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -489,13 +489,17 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // SEAM 1: drift always releases; a dead-looking owner releases ONLY if not within an armed
     // silence window (a within-cap silenced holder yields to foreign_claim instead of being reaped).
     if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive })) {
-      // Idempotent canonical claim-release — WHERE-clause restricts to the orphan pair so a fresh claim
-      // acquired between detection and write cannot be overwritten.
-      await supabase
-        .from('strategic_directives_v2')
-        .update({ claiming_session_id: null, is_working_on: false, active_session_id: null })
-        .eq('sd_key', sdKey)
-        .eq('claiming_session_id', sd.claiming_session_id);
+      // Idempotent canonical claim-release — routes through the unified dual-surface
+      // helper so the dead owner's session-side surface (claude_sessions.sd_key +
+      // worktree_*) is co-cleared, not just the SD-side (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).
+      // Holder-pinned CAS on both surfaces: a fresh claim acquired between detection and
+      // write cannot be overwritten, and a drifted owner (now on another SD) is untouched.
+      const { releaseClaimBothSurfaces } = await import('./claim/release-claim-both-surfaces.mjs');
+      await releaseClaimBothSurfaces(supabase, {
+        sdKey,
+        holderSessionId: sd.claiming_session_id,
+        reason: ownerIsDead ? (owner?.status ?? 'missing') : 'sd_key_drift',
+      });
       // SD-LEO-INFRA-CROSS-HOST-CONCURRENT-001 (FR-5): SIBLING RELEASE SITE 2/4 —
       // co-clear file_claim_locks alongside the claiming_session_id clear above.
       try {

--- a/lib/claim/release-claim-both-surfaces.mjs
+++ b/lib/claim/release-claim-both-surfaces.mjs
@@ -1,0 +1,197 @@
+// Unified dual-surface claim release — SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001
+// (escalated from QF-20260712-817).
+//
+// THE BUG THIS CLOSES
+// A claim lives on TWO surfaces that must be released together:
+//   • SD-side      strategic_directives_v2: claiming_session_id + active_session_id + is_working_on
+//   • session-side claude_sessions:         sd_key + worktree_path + worktree_branch
+// Several JS release paths historically cleared only ONE surface via a bare
+// `.update()`, leaving the other stuck. Witnessed 2026-07-12: a dead seat kept
+// claude_sessions.sd_key set after an SD-side "verified release", so the belt saw
+// the SD as CLAIMED and neither takeover nor belt-fallback could fire for ~45 min.
+//
+// The Postgres RPCs (release_sd / release_session / cleanup_stale_sessions /
+// switch_sd_claim / claim_sd) ALREADY co-clear both surfaces atomically since
+// migration 20260506000000_claim_dual_column_atomicity.sql. This helper is the JS
+// counterpart: it routes every remaining JS release path through ONE dual-surface
+// clear so a single-surface release can never be written again.
+//
+// INVARIANTS (see the SD's PRD / risk + testing evidence c228dc44 / f492c95e):
+//   R1 — holder-pinned CAS on BOTH surfaces. Every UPDATE is guarded by the holder
+//        (SD-side WHERE claiming_session_id = holder; session-side WHERE
+//        session_id = holder AND sd_key = sdKey). A 0-row no-op — never an
+//        overwrite — so a peer that legitimately re-claimed is never clobbered.
+//   R3 — the session-side clear nulls sd_key + worktree_path + worktree_branch
+//        TOGETHER (the ck_claude_sessions_worktree_state_consistency CHECK rejects a
+//        partial clear, SQLSTATE 23514). We surface any DB error in the result — we
+//        NEVER silently swallow it (a swallowed 23514 would re-persist the desync).
+//   R4 — session-alive paths (releaseClaimOnPROpen) are NOT routed here; the helper
+//        always fully releases the session, which would evict a still-working worker.
+//   R6 — readback asserts OLD-HOLDER-GONE (the holder no longer appears on either
+//        surface), NOT `=== null`, so a legitimate peer re-claim between clear and
+//        readback does not false-fail the release.
+//
+// Preferred mechanism: when the holder session_id is known and `tryRpc` is on, call
+// the already-correct release_session RPC (a single atomic transaction). The direct
+// dual-CAS clear (mirroring worker-checkin.cjs selfHealStaleClaim) is the fallback
+// for callers whose primary RPC already failed, or when only sdKey is known.
+
+/**
+ * @typedef {Object} ReleaseResult
+ * @property {boolean} ok              true when both surfaces are confirmed released for the old holder
+ * @property {'rpc'|'direct'|'noop'} method  which mechanism ran
+ * @property {string|null} holder      the holder session_id that was released (resolved if not supplied)
+ * @property {boolean} clearedSd       an SD-side clear was attempted and did not error
+ * @property {boolean} clearedSession  a session-side clear was attempted and did not error
+ * @property {boolean} oldHolderGone   readback confirms the old holder is off both surfaces
+ * @property {string|null} error       first DB error message (e.g. 23514), or null
+ */
+
+/**
+ * Release a claim across BOTH surfaces for a single holder.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} sb
+ * @param {Object} opts
+ * @param {string}  opts.sdKey            the claimed SD key (strategic_directives_v2.sd_key). Required.
+ * @param {string} [opts.holderSessionId] the session that holds the claim. Resolved from
+ *                                          strategic_directives_v2.claiming_session_id when omitted.
+ * @param {string} [opts.reason='release'] released_reason stamped on the session row / RPC.
+ * @param {'released'|'idle'} [opts.sessionStatus='released'] status stamped on the released session.
+ *                                          'released' fully RETIRES a dead/stale/superseded holder;
+ *                                          'idle' UNCLAIMS a session that stays alive (manual release).
+ * @param {boolean}[opts.tryRpc=false]    prefer the atomic release_session RPC. Only honoured for
+ *                                          sessionStatus='released' (the RPC always retires the session,
+ *                                          so it must never run for a keep-alive 'idle' unclaim). Opt-in.
+ * @param {boolean}[opts.readback=true]   run the OLD-HOLDER-GONE readback (adds one SELECT).
+ * @returns {Promise<ReleaseResult>}
+ */
+export async function releaseClaimBothSurfaces(sb, opts = {}) {
+  const { sdKey, reason = 'release', sessionStatus = 'released', tryRpc = false, readback = true } = opts;
+  let holder = opts.holderSessionId || null;
+
+  const result = {
+    ok: false, method: 'noop', holder, clearedSd: false,
+    clearedSession: false, oldHolderGone: false, error: null,
+  };
+
+  if (!sdKey) {
+    result.error = 'releaseClaimBothSurfaces: sdKey is required';
+    return result;
+  }
+
+  // Resolve the holder from the SD-side surface when the caller did not supply one.
+  if (!holder) {
+    const { data: sd, error: readErr } = await sb
+      .from('strategic_directives_v2')
+      .select('claiming_session_id')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (readErr) { result.error = readErr.message; return result; }
+    holder = sd?.claiming_session_id || null;
+    result.holder = holder;
+  }
+
+  // Nothing on the SD-side to release and no explicit holder → already free.
+  if (!holder) {
+    result.method = 'noop';
+    result.ok = true;
+    result.oldHolderGone = true;
+    return result;
+  }
+
+  // ── Optional: atomic co-clear via the release_session RPC (retire only) ───────
+  // release_session ALWAYS retires the session (status='released'), so it is only
+  // valid for sessionStatus='released'. It clears whatever the session currently
+  // holds; guard it with a pre-read so we never release a holder that has since
+  // moved to a DIFFERENT SD.
+  if (tryRpc && sessionStatus === 'released') {
+    const { data: sess, error: sessReadErr } = await sb
+      .from('claude_sessions')
+      .select('sd_key')
+      .eq('session_id', holder)
+      .maybeSingle();
+    // Only RPC-release when the holder is still parked on THIS sdKey (CAS-equivalent).
+    if (!sessReadErr && sess && sess.sd_key === sdKey) {
+      const { data: rpcRes, error: rpcErr } = await sb.rpc('release_session', {
+        p_session_id: holder,
+        p_reason: reason,
+      });
+      if (!rpcErr && !(rpcRes && rpcRes.success === false)) {
+        result.method = 'rpc';
+        result.clearedSd = true;
+        result.clearedSession = true;
+        return readback ? await verifyOldHolderGone(sb, sdKey, holder, result) : ok(result);
+      }
+      // RPC failed → fall through to the direct dual-CAS clear.
+      result.error = rpcErr ? rpcErr.message : (rpcRes && rpcRes.error) || null;
+    }
+  }
+
+  // ── Fallback: direct dual-CAS clear (session-side FIRST) ──────────────────────
+  // Session-side first: the belt-visible sd_key is the surface whose staleness
+  // stalled the fleet; clearing it first shrinks the desync window on a crash
+  // between the two writes (any residue is reaped by the dual-surface sweep).
+  result.method = 'direct';
+
+  const { error: sessErr } = await sb
+    .from('claude_sessions')
+    .update({
+      sd_key: null,
+      worktree_path: null,     // R3: null all three worktree columns together …
+      worktree_branch: null,   // … or the ck_worktree_state_consistency CHECK raises 23514.
+      status: sessionStatus,   // 'released' (retire) or 'idle' (keep-alive unclaim)
+      released_at: new Date().toISOString(),
+      released_reason: reason,
+    })
+    .eq('session_id', holder)  // R1: holder-pinned CAS …
+    .eq('sd_key', sdKey);      // … only while this session still points at this SD.
+  if (sessErr) { result.error = result.error || sessErr.message; }
+  else { result.clearedSession = true; }
+
+  const { error: sdErr } = await sb
+    .from('strategic_directives_v2')
+    .update({ claiming_session_id: null, active_session_id: null, is_working_on: false })
+    .eq('sd_key', sdKey)
+    .eq('claiming_session_id', holder); // R1: only while the SD is still this holder's.
+  if (sdErr) { result.error = result.error || sdErr.message; }
+  else { result.clearedSd = true; }
+
+  // R3: never swallow — a DB error is returned so the caller can log/fail-loud.
+  if (result.error) return result;
+
+  return readback ? await verifyOldHolderGone(sb, sdKey, holder, result) : ok(result);
+}
+
+// R6: OLD-HOLDER-GONE readback. Asserts the old holder is off BOTH surfaces rather
+// than asserting `=== null`, so a legitimate peer re-claim does not false-fail.
+async function verifyOldHolderGone(sb, sdKey, holder, result) {
+  try {
+    const { data: sd } = await sb
+      .from('strategic_directives_v2')
+      .select('claiming_session_id')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    const { data: sess } = await sb
+      .from('claude_sessions')
+      .select('session_id')
+      .eq('session_id', holder)
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    const sdGone = !sd || sd.claiming_session_id !== holder;
+    const sessGone = !sess; // no row where this holder still points at sdKey
+    result.oldHolderGone = sdGone && sessGone;
+    result.ok = result.oldHolderGone;
+  } catch (e) {
+    result.error = result.error || (e && e.message) || 'readback failed';
+    result.ok = false;
+  }
+  return result;
+}
+
+function ok(result) {
+  result.ok = true;
+  result.oldHolderGone = true; // readback skipped by caller opt-out
+  return result;
+}
+
+export default { releaseClaimBothSurfaces };

--- a/lib/commands/claim-command.js
+++ b/lib/commands/claim-command.js
@@ -185,19 +185,21 @@ export async function releaseClaim(sessionId) {
   });
 
   if (releaseError) {
-    console.warn(`RPC release failed: ${releaseError.message}. Trying direct update...`);
-    const { error: directErr } = await supabase
-      .from('claude_sessions')
-      .update({
-        sd_key: null,
-        released_at: new Date().toISOString(),
-        released_reason: 'manual_claim_release',
-        status: 'idle'
-      })
-      .eq('session_id', sessionId);
-
-    if (directErr) {
-      console.error(`Failed to release claim: ${directErr.message}`);
+    console.warn(`RPC release failed: ${releaseError.message}. Trying dual-surface direct update...`);
+    // Dual-surface fallback: co-clears the SD-side AND nulls sd_key + worktree_* together
+    // (a bare sd_key clear trips the ck_worktree_state_consistency CHECK —
+    // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001). Mirrors release_sd's status='idle'; tryRpc:false
+    // since the release_sd RPC just failed.
+    const { releaseClaimBothSurfaces } = await import('../claim/release-claim-both-surfaces.mjs');
+    const r = await releaseClaimBothSurfaces(supabase, {
+      sdKey: session.sd_key,
+      holderSessionId: sessionId,
+      reason: 'manual_claim_release',
+      sessionStatus: 'idle',
+      tryRpc: false,
+    });
+    if (r.error) {
+      console.error(`Failed to release claim: ${r.error}`);
       return;
     }
   }

--- a/lib/coordinator/singleton-refresh-sequencer.cjs
+++ b/lib/coordinator/singleton-refresh-sequencer.cjs
@@ -127,6 +127,29 @@ async function retireOldSession(supabase, { oldSessionId, oldWorktreePath = null
     })
     .eq('session_id', oldSessionId);
 
+  // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001: the retired session may still hold the SD-side
+  // claim (strategic_directives_v2.claiming_session_id). The session-side clear above alone
+  // would leave that SD looking CLAIMED by a now-released session. Resolve the held SD and
+  // co-clear the SD-side through the unified helper (holder-pinned CAS; the helper's own
+  // session-side clear no-ops since sd_key was already nulled above). Fail-soft — the retire
+  // itself already succeeded.
+  let sdClaimError = null;
+  try {
+    const { data: heldSd } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key')
+      .eq('claiming_session_id', oldSessionId)
+      .maybeSingle();
+    if (heldSd && heldSd.sd_key) {
+      const { releaseClaimBothSurfaces } = await import('../claim/release-claim-both-surfaces.mjs');
+      const r = await releaseClaimBothSurfaces(supabase, {
+        sdKey: heldSd.sd_key, holderSessionId: oldSessionId, reason, sessionStatus: 'released', readback: false,
+      });
+      sdClaimError = r.error;
+    }
+  } catch (e) { sdClaimError = e && e.message ? e.message : String(e); }
+  if (sdClaimError) console.warn(`[singleton-refresh] SD-side co-clear for retired ${oldSessionId} failed: ${sdClaimError}`);
+
   let worktreeResult = null;
   if (oldWorktreePath) {
     // Dynamic import: lib/worktree-manager.js is ESM, this module is CJS.
@@ -142,6 +165,7 @@ async function retireOldSession(supabase, { oldSessionId, oldWorktreePath = null
   return {
     ok: !updateError && (worktreeResult ? worktreeResult.ok !== false || Boolean(worktreeResult.skipped) : true),
     sessionUpdateError: updateError ? updateError.message : null,
+    sdClaimError,
     worktreeResult,
   };
 }

--- a/scripts/claim-orchestrator-for-rollup.mjs
+++ b/scripts/claim-orchestrator-for-rollup.mjs
@@ -63,11 +63,20 @@ export async function claimOrchestratorForRollup(supabase, { sdKey, sessionId, r
   }
 
   if (release) {
-    const { error } = await supabase
-      .from('strategic_directives_v2')
-      .update({ is_working_on: false, claiming_session_id: null })
-      .eq('id', sd.id);
-    if (error) return { ok: false, action: 'error', reason: `release failed: ${error.message}` };
+    // Route through the unified dual-surface helper so the holder's session-side
+    // surface (claude_sessions.sd_key + worktree_*) is co-cleared, not just the
+    // SD-side — otherwise the belt keeps seeing the parent as CLAIMED
+    // (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001). sessionStatus:'idle' = unclaim the
+    // parent without retiring the holder session; holder-pinned CAS avoids
+    // clobbering a peer that re-claimed between lookup and write.
+    const { releaseClaimBothSurfaces } = await import('../lib/claim/release-claim-both-surfaces.mjs');
+    const r = await releaseClaimBothSurfaces(supabase, {
+      sdKey: sd.sd_key,
+      holderSessionId: sd.claiming_session_id,
+      reason: 'orchestrator_rollup_release',
+      sessionStatus: 'idle',
+    });
+    if (r.error) return { ok: false, action: 'error', reason: `release failed: ${r.error}` };
     return { ok: true, action: 'released', sdKey: sd.sd_key };
   }
 

--- a/scripts/coordinator-cold-recovery.cjs
+++ b/scripts/coordinator-cold-recovery.cjs
@@ -93,13 +93,19 @@ async function alreadyRedispatched(supabase, sdKey, { nowMs }) {
   return (data || []).some((r) => r && r.target_sd === sdKey && r.payload && r.payload.kind === 'resume');
 }
 
-/** Release an orphaned claim. PRESERVES current_phase + progress (resume, not restart). */
+/** Release an orphaned claim. PRESERVES current_phase + progress (resume, not restart).
+ * Routes through the unified dual-surface helper so the orphaned owner's session-side
+ * surface (claude_sessions.sd_key + worktree_*) is co-cleared, not just the SD-side —
+ * otherwise the belt keeps seeing the SD as CLAIMED (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).
+ * Holder-pinned CAS also prevents clobbering a peer that legitimately took over. */
 async function releaseClaim(supabase, sd) {
-  const { error } = await supabase
-    .from('strategic_directives_v2')
-    .update({ claiming_session_id: null, is_working_on: false })
-    .eq('id', sd.id);
-  if (error) throw new Error(`releaseClaim failed for ${sd.sd_key}: ${error.message}`);
+  const { releaseClaimBothSurfaces } = await import('../lib/claim/release-claim-both-surfaces.mjs');
+  const r = await releaseClaimBothSurfaces(supabase, {
+    sdKey: sd.sd_key,
+    holderSessionId: sd.claiming_session_id,
+    reason: 'cold_recovery_orphan',
+  });
+  if (r.error) throw new Error(`releaseClaim failed for ${sd.sd_key}: ${r.error}`);
 }
 
 /** Broadcast a RESUME re-dispatch (no live worker to target on a cold start → sentinel). */

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -80,11 +80,15 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
         return isSameConversation(currentTerminalId, s.terminal_id) !== false;
       });
 
+      // Dual-surface release: co-clears the SD-side AND nulls sd_key + worktree_* together
+      // (a bare sd_key clear trips the ck_worktree_state_consistency CHECK —
+      // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001). Mirrors release_sd's status='idle'; tryRpc:false
+      // (this branch is itself the fallback for the release_same_conversation_claims RPC).
+      const { releaseClaimBothSurfaces } = await import('../../../../lib/claim/release-claim-both-surfaces.mjs');
       for (const s of toRelease) {
-        await supabase
-          .from('claude_sessions')
-          .update({ sd_key: null, status: 'idle', released_at: new Date().toISOString() })
-          .eq('session_id', s.session_id);
+        await releaseClaimBothSurfaces(supabase, {
+          sdKey: sdId, holderSessionId: s.session_id, reason: 'stale_same_conversation', sessionStatus: 'idle', tryRpc: false,
+        });
         console.log(`   🧹 Released stale same-conversation claim: ${s.session_id.substring(0, 24)}...`);
       }
     }

--- a/tests/unit/claim-silence-consume-verify.test.js
+++ b/tests/unit/claim-silence-consume-verify.test.js
@@ -99,7 +99,13 @@ function fakeSupabase({ owner, onRelease }) {
         };
       }
       if (table === 'claude_sessions') {
-        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: owner, error: null }) }) }) };
+        // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001: orphan-release now co-clears the session-side
+        // surface via releaseClaimBothSurfaces — the helper's session-side UPDATE + its
+        // OLD-HOLDER-GONE readback both chain two .eq() calls, so give this branch a chainable
+        // eq for select AND an update method (the old single-surface code never touched it).
+        const selChain = { eq: () => selChain, maybeSingle: async () => ({ data: owner, error: null }) };
+        const updChain = { eq: () => updChain, then: (res) => res({ error: null }) };
+        return { select: () => selChain, update: () => updChain };
       }
       return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) };
     },

--- a/tests/unit/claim/release-claim-both-surfaces.test.js
+++ b/tests/unit/claim/release-claim-both-surfaces.test.js
@@ -1,0 +1,171 @@
+/**
+ * SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001 (escalated from QF-20260712-817) — helper behaviour.
+ *
+ * Verifies lib/claim/release-claim-both-surfaces.mjs against the risk/testing conditions:
+ *   R1 — holder-pinned CAS on BOTH surfaces (a peer re-claim is never clobbered)
+ *   R3 — the session-side clear nulls sd_key + worktree_path + worktree_branch together;
+ *        a DB error is surfaced, never swallowed
+ *   R6 — readback asserts OLD-HOLDER-GONE, not `=== null`
+ *   + sessionStatus (retire vs keep-alive), the RPC path, drift protection, and no-op.
+ *
+ * Uses a tiny in-memory Supabase stub so CAS + readback are exercised end-to-end (no live DB).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { releaseClaimBothSurfaces } from '../../../lib/claim/release-claim-both-surfaces.mjs';
+
+// ── Minimal in-memory Supabase double ────────────────────────────────────────
+function makeDb({ sds = [], sessions = [], errorOn = null } = {}) {
+  const tables = {
+    strategic_directives_v2: sds.map((r) => ({ ...r })),
+    claude_sessions: sessions.map((r) => ({ ...r })),
+  };
+  const calls = { updates: [], rpc: [] };
+  const matches = (row, filters) => Object.entries(filters).every(([k, v]) => row[k] === v);
+
+  const client = {
+    from(table) {
+      const ctx = { table, filters: {}, op: null, payload: null };
+      const b = {
+        select() { ctx.op = 'select'; return b; },
+        update(payload) { ctx.op = 'update'; ctx.payload = payload; return b; },
+        eq(k, v) { ctx.filters[k] = v; return b; },
+        maybeSingle() {
+          const row = (tables[table] || []).find((r) => matches(r, ctx.filters));
+          return Promise.resolve({ data: row ? { ...row } : null, error: null });
+        },
+        then(onF, onR) {
+          if (ctx.op === 'update') {
+            calls.updates.push({ table, payload: { ...ctx.payload }, filters: { ...ctx.filters } });
+            if (errorOn && errorOn.table === table && errorOn.op === 'update') {
+              return Promise.resolve({ error: { message: errorOn.message || 'db error' } }).then(onF, onR);
+            }
+            for (const r of (tables[table] || [])) {
+              if (matches(r, ctx.filters)) Object.assign(r, ctx.payload);
+            }
+          }
+          return Promise.resolve({ error: null }).then(onF, onR);
+        },
+      };
+      return b;
+    },
+    rpc(name, params) {
+      calls.rpc.push({ name, params });
+      if (name === 'release_session' || name === 'release_sd') {
+        const sid = params.p_session_id;
+        const sess = tables.claude_sessions.find((r) => r.session_id === sid);
+        const sdKey = sess ? sess.sd_key : null;
+        if (sess) Object.assign(sess, {
+          sd_key: null, worktree_path: null, worktree_branch: null,
+          status: name === 'release_session' ? 'released' : 'idle',
+        });
+        if (sdKey) {
+          for (const sd of tables.strategic_directives_v2) {
+            if (sd.sd_key === sdKey && (sd.claiming_session_id === sid || sd.active_session_id === sid)) {
+              Object.assign(sd, { claiming_session_id: null, active_session_id: null, is_working_on: false });
+            }
+          }
+        }
+      }
+      return Promise.resolve({ data: { success: true }, error: null });
+    },
+  };
+  return { client, tables, calls };
+}
+
+const seed = (over = {}) => ({
+  sds: [{ sd_key: 'SD-X', claiming_session_id: 'H1', active_session_id: 'H1', is_working_on: true }],
+  sessions: [{ session_id: 'H1', sd_key: 'SD-X', worktree_path: '/w', worktree_branch: 'feat/x', status: 'active' }],
+  ...over,
+});
+
+describe('releaseClaimBothSurfaces', () => {
+  it('clears BOTH surfaces on the happy path (direct, retire)', async () => {
+    const db = makeDb(seed());
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1' });
+    expect(r.ok).toBe(true);
+    expect(r.method).toBe('direct');
+    expect(r.oldHolderGone).toBe(true);
+    const sd = db.tables.strategic_directives_v2[0];
+    const sess = db.tables.claude_sessions[0];
+    expect(sd.claiming_session_id).toBeNull();
+    expect(sd.active_session_id).toBeNull();
+    expect(sd.is_working_on).toBe(false);
+    expect(sess.sd_key).toBeNull();
+    expect(sess.worktree_path).toBeNull();
+    expect(sess.worktree_branch).toBeNull();
+    expect(sess.status).toBe('released');
+  });
+
+  it('R3: the session-side UPDATE payload nulls sd_key + worktree_path + worktree_branch together', async () => {
+    const db = makeDb(seed());
+    await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1' });
+    const sessUpdate = db.calls.updates.find((u) => u.table === 'claude_sessions');
+    expect(sessUpdate).toBeTruthy();
+    expect(sessUpdate.payload).toMatchObject({ sd_key: null, worktree_path: null, worktree_branch: null });
+    // holder-pinned CAS on the session-side clear
+    expect(sessUpdate.filters).toMatchObject({ session_id: 'H1', sd_key: 'SD-X' });
+  });
+
+  it('R1: a peer that re-claimed the SD is NOT clobbered (holder-pinned CAS)', async () => {
+    // SD-side now held by peer H2; the session-side row is still stale on H1.
+    const db = makeDb(seed({
+      sds: [{ sd_key: 'SD-X', claiming_session_id: 'H2', active_session_id: 'H2', is_working_on: true }],
+    }));
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1' });
+    // H2's claim is untouched (SD-side CAS keyed on H1 did not match).
+    expect(db.tables.strategic_directives_v2[0].claiming_session_id).toBe('H2');
+    // H1's stale session-side pointer WAS cleared.
+    expect(db.tables.claude_sessions[0].sd_key).toBeNull();
+    // Old holder H1 is gone from both surfaces → release considered clean.
+    expect(r.oldHolderGone).toBe(true);
+  });
+
+  it('sessionStatus: "idle" keeps the session alive (unclaim, not retire)', async () => {
+    const db = makeDb(seed());
+    await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1', sessionStatus: 'idle' });
+    expect(db.tables.claude_sessions[0].status).toBe('idle');
+  });
+
+  it('R3: a DB error is surfaced in the result, never swallowed or thrown', async () => {
+    const db = makeDb(seed({ errorOn: { table: 'claude_sessions', op: 'update', message: '23514 check violation' } }));
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/23514/);
+  });
+
+  it('tryRpc: uses the release_session RPC when the holder is still on the SD (retire)', async () => {
+    const db = makeDb(seed());
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1', tryRpc: true });
+    expect(r.method).toBe('rpc');
+    expect(db.calls.rpc.map((c) => c.name)).toContain('release_session');
+    expect(db.tables.claude_sessions[0].sd_key).toBeNull();
+    expect(db.tables.strategic_directives_v2[0].claiming_session_id).toBeNull();
+    expect(r.ok).toBe(true);
+  });
+
+  it('tryRpc: does NOT RPC-release a holder that has drifted to a different SD', async () => {
+    // Holder H1 is now parked on a DIFFERENT sd_key; releasing SD-X must not retire it.
+    const db = makeDb(seed({
+      sessions: [{ session_id: 'H1', sd_key: 'SD-OTHER', worktree_path: '/w', worktree_branch: 'b', status: 'active' }],
+    }));
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X', holderSessionId: 'H1', tryRpc: true });
+    expect(db.calls.rpc.length).toBe(0);          // RPC skipped (sd_key !== sdKey)
+    expect(db.tables.claude_sessions[0].sd_key).toBe('SD-OTHER'); // holder's real claim untouched
+    expect(r.method).toBe('direct');
+  });
+
+  it('no-op when the SD has no holder and none is supplied', async () => {
+    const db = makeDb(seed({ sds: [{ sd_key: 'SD-X', claiming_session_id: null }], sessions: [] }));
+    const r = await releaseClaimBothSurfaces(db.client, { sdKey: 'SD-X' });
+    expect(r.method).toBe('noop');
+    expect(r.ok).toBe(true);
+  });
+
+  it('requires sdKey', async () => {
+    const db = makeDb(seed());
+    const r = await releaseClaimBothSurfaces(db.client, { holderSessionId: 'H1' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/sdKey is required/);
+  });
+});

--- a/tests/unit/claim/release-dual-surface-guard.test.js
+++ b/tests/unit/claim/release-dual-surface-guard.test.js
@@ -1,0 +1,94 @@
+/**
+ * SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001 (escalated from QF-20260712-817) — FR-4 static guard.
+ *
+ * A claim lives on TWO surfaces that must be released together:
+ *   • SD-side      strategic_directives_v2: claiming_session_id (+ active_session_id, is_working_on)
+ *   • session-side claude_sessions:         sd_key (+ worktree_path, worktree_branch)
+ *
+ * Several JS release paths historically cleared only ONE surface, leaving the other stuck so
+ * the belt kept seeing a dead seat's SD as CLAIMED (~45min fleet stall, witnessed 2026-07-12).
+ * The fix routes every genuinely-desynced JS path through lib/claim/release-claim-both-surfaces.mjs.
+ *
+ * This guard prevents the class from silently reappearing:
+ *   (1) any claude_sessions UPDATE that nulls sd_key MUST also null worktree_path + worktree_branch
+ *       together (the ck_claude_sessions_worktree_state_consistency CHECK raises 23514 otherwise);
+ *   (2) the routed sites still call the unified helper (no silent revert to a single-surface clear);
+ *   (3) the helper itself co-clears both surfaces with holder-pinned CAS.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const read = (rel) => readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+
+const HELPER = 'lib/claim/release-claim-both-surfaces.mjs';
+
+// Files that were routed through the unified helper. Each must import/call it.
+const ROUTED_SITES = [
+  'lib/claim-validity-gate.js',
+  'lib/claim-guard.mjs',
+  'lib/commands/claim-command.js',
+  'lib/coordinator/singleton-refresh-sequencer.cjs',
+  'scripts/coordinator-cold-recovery.cjs',
+  'scripts/claim-orchestrator-for-rollup.mjs',
+  'scripts/modules/handoff/gates/multi-session-claim-gate.js',
+];
+
+// Files scanned for the session-side worktree-together invariant (routed sites + the helper).
+// After the fix, the only remaining DIRECT `claude_sessions` sd_key:null clear in these files is
+// singleton-refresh-sequencer's retire (which already nulls worktree_* together) and the helper.
+const WORKTREE_INVARIANT_FILES = [HELPER, ...ROUTED_SITES];
+
+describe('SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001 — dual-surface release guard', () => {
+  it('the unified helper exists and co-clears both surfaces with holder-pinned CAS', () => {
+    expect(existsSync(resolve(REPO_ROOT, HELPER))).toBe(true);
+    const src = read(HELPER);
+    expect(src).toContain('export async function releaseClaimBothSurfaces');
+    // Session-side clear nulls all three worktree/claim columns together (R3).
+    expect(src).toMatch(/sd_key:\s*null/);
+    expect(src).toMatch(/worktree_path:\s*null/);
+    expect(src).toMatch(/worktree_branch:\s*null/);
+    // SD-side clear + holder-pinned CAS on both surfaces (R1).
+    expect(src).toMatch(/claiming_session_id:\s*null/);
+    expect(src).toMatch(/\.eq\(\s*['"]claiming_session_id['"]/); // SD-side holder CAS
+    expect(src).toMatch(/\.eq\(\s*['"]sd_key['"]/);              // session-side sdKey CAS
+    // R6: readback asserts OLD-HOLDER-GONE, not `=== null`.
+    expect(src).toMatch(/oldHolderGone/);
+  });
+
+  it('every claude_sessions UPDATE that nulls sd_key also nulls worktree_path + worktree_branch (R3)', () => {
+    for (const rel of WORKTREE_INVARIANT_FILES) {
+      const src = read(rel);
+      const fromMatches = [...src.matchAll(/\.from\(\s*['"]claude_sessions['"]\s*\)/g)];
+      for (const m of fromMatches) {
+        const window = src.slice(m.index, m.index + 1000);
+        const updateMatch = window.match(/\.update\s*\(\s*\{([\s\S]*?)\}\s*\)/);
+        if (!updateMatch) continue; // SELECT, not UPDATE
+        const payload = updateMatch[1];
+        if (!/sd_key\s*:\s*null/.test(payload)) continue; // not a release-shaped UPDATE
+        const line = src.slice(0, m.index + updateMatch.index).split('\n').length;
+        expect(payload, `${rel}:~${line} nulls sd_key without worktree_path`).toMatch(/worktree_path\s*:\s*null/);
+        expect(payload, `${rel}:~${line} nulls sd_key without worktree_branch`).toMatch(/worktree_branch\s*:\s*null/);
+      }
+    }
+  });
+
+  it('routed sites still call releaseClaimBothSurfaces (no revert to single-surface clears)', () => {
+    for (const rel of ROUTED_SITES) {
+      const src = read(rel);
+      expect(src, `${rel} no longer routes through the unified release helper`)
+        .toMatch(/releaseClaimBothSurfaces/);
+    }
+  });
+
+  it('the R4 exclusion (releaseClaimOnPROpen) documents its intentional single-surface clear', () => {
+    // A PR-open release keeps the worker ALIVE, so it must NOT be routed (would evict the worktree).
+    const src = read('lib/claim-lifecycle-release.mjs');
+    expect(src).toMatch(/R4 exclusion/);
+    expect(src).toMatch(/SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001/);
+  });
+});

--- a/tests/unit/orchestrator-child/claim-orchestrator-for-rollup.test.js
+++ b/tests/unit/orchestrator-child/claim-orchestrator-for-rollup.test.js
@@ -14,27 +14,32 @@ function makeMock({ sd = null, children = [], session = null } = {}) {
   const client = {
     from(table) {
       return {
+        // SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001: the --release branch now co-clears BOTH
+        // surfaces via releaseClaimBothSurfaces, whose holder-pinned CAS + readback chain
+        // TWO .eq() calls. select/update builders must therefore accept chained .eq().
         select() {
-          return {
-            eq(col) {
-              return {
-                async maybeSingle() {
-                  if (table === 'strategic_directives_v2') return { data: sd, error: null };
-                  if (table === 'claude_sessions') return { data: session, error: null };
-                  return { data: null, error: null };
-                },
-                async limit() {
-                  if (table === 'strategic_directives_v2' && col === 'parent_sd_id') return { data: children, error: null };
-                  return { data: [], error: null };
-                },
-              };
+          const chain = {
+            _col: null,
+            eq(col) { chain._col = chain._col ?? col; return chain; },
+            async maybeSingle() {
+              if (table === 'strategic_directives_v2') return { data: sd, error: null };
+              if (table === 'claude_sessions') return { data: session, error: null };
+              return { data: null, error: null };
+            },
+            async limit() {
+              if (table === 'strategic_directives_v2' && chain._col === 'parent_sd_id') return { data: children, error: null };
+              return { data: [], error: null };
             },
           };
+          return chain;
         },
         update(payload) {
-          return {
-            async eq(col, val) { captured.updates.push({ table, payload, col, val }); return { error: null }; },
+          const filters = {};
+          const chain = {
+            eq(col, val) { filters[col] = val; return chain; },
+            then(res) { captured.updates.push({ table, payload, filters }); res({ error: null }); },
           };
+          return chain;
         },
       };
     },
@@ -53,11 +58,18 @@ describe('claimOrchestratorForRollup (FR-3 / AC-5)', () => {
     expect(captured.updates[0].payload).toEqual({ is_working_on: true, claiming_session_id: 'sess-me' });
   });
 
-  it('releases the parent (--release clears both columns)', async () => {
-    const { client, captured } = makeMock({ sd: { ...ORCH, is_working_on: true, claiming_session_id: 'sess-me' } });
+  it('releases the parent (--release clears BOTH surfaces)', async () => {
+    const { client, captured } = makeMock({
+      sd: { ...ORCH, is_working_on: true, claiming_session_id: 'sess-me' },
+      session: { session_id: 'sess-me', sd_key: 'SD-ORCH-001', worktree_path: '/w', worktree_branch: 'b' },
+    });
     const r = await claimOrchestratorForRollup(client, { sdKey: 'SD-ORCH-001', sessionId: 'sess-me', release: true });
     expect(r).toMatchObject({ ok: true, action: 'released' });
-    expect(captured.updates[0].payload).toEqual({ is_working_on: false, claiming_session_id: null });
+    // Dual-surface: SD-side claim fields cleared AND the holder's session-side surface co-cleared.
+    const sdU = captured.updates.find((u) => u.table === 'strategic_directives_v2');
+    const sessU = captured.updates.find((u) => u.table === 'claude_sessions');
+    expect(sdU.payload).toEqual({ claiming_session_id: null, active_session_id: null, is_working_on: false });
+    expect(sessU.payload).toMatchObject({ sd_key: null, worktree_path: null, worktree_branch: null });
   });
 
   it('refuses when the parent is claimed by a DIFFERENT live session (recent heartbeat)', async () => {


### PR DESCRIPTION
## Summary
Escalated from **QF-20260712-817** (mis-tiered ~50-LOC QF → Tier-3 SD). Fixes a claim-release desync where several JS release paths cleared only ONE of the two claim surfaces, so a dead seat kept `claude_sessions.sd_key` set, the belt saw the SD as CLAIMED, and takeover/belt-fallback stalled ~45min (witnessed 2026-07-12, seat 2951cbe1 / SPINE-001-B).

**Root cause:** the Postgres RPCs already co-clear both surfaces atomically since migration `20260506000000`; ~8 JS paths bypassed them with partial direct UPDATEs.

**Fix:** a unified helper `lib/claim/release-claim-both-surfaces.mjs` co-clears BOTH surfaces —
`strategic_directives_v2` (claiming_session_id/active_session_id/is_working_on) AND
`claude_sessions` (sd_key/worktree_path/worktree_branch) — with:
- **R1** holder-pinned CAS on both surfaces (a peer re-claim is never clobbered)
- **R3** worktree columns nulled together (ck_worktree_state_consistency / 23514-safe); DB errors surfaced, never swallowed
- **R6** OLD-HOLDER-GONE readback (not `=== null`)
- retire vs keep-alive `sessionStatus` split

**Routed (8 desynced paths):** claim-validity-gate, coordinator-cold-recovery, claim-orchestrator-for-rollup (SD-side-only); claim-guard ×2, claim-command, multi-session-claim-gate, singleton-refresh-sequencer (session-side fallbacks / retire).
**Excluded:** `releaseClaimOnPROpen` (R4 — session stays alive; documented).
**FR-4:** static CI guard against future single-surface clears.

## Test plan
- [x] 13 new tests (9 helper behavioural + 4 static guard) — pass
- [x] Full claim/coordinator suite — 78/78 pass, 0 regressions
- [x] Independent prospective + retrospective testing-agent review — PASS (evidence f492c95e / c78fd5e2)
- [x] LEAD risk-agent review — GO (evidence c228dc44)

Sibling follow-up filed: feedback `3432c61a` (QF reconcile short-circuit — quick_fixes-table analog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)