### PR TITLE
feat(SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001): D5 retention-reaper evidence collector

### DIFF
--- a/lib/loop-governance/collectors/__tests__/registry.test.js
+++ b/lib/loop-governance/collectors/__tests__/registry.test.js
@@ -1,0 +1,77 @@
+/**
+ * Collector registry tests.
+ * (SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001, TS-4, TS-6, FR-1/FR-4 regression)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createCollectEvidence, COLLECTORS } from '../index.js';
+import { evaluateLoopBatch } from '../../verifier.js';
+import { GENESIS_LOOPS, toLoopRow } from '../../genesis-loops.js';
+
+describe('createCollectEvidence (TS-6)', () => {
+  it('returns {} for an unregistered loop_key without touching Supabase', async () => {
+    const from = vi.fn();
+    const supabase = { from };
+    const collectEvidence = createCollectEvidence(supabase);
+    const evidence = await collectEvidence({ loop_key: 'L4' });
+    expect(evidence).toEqual({});
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the registered L30 collector, passing supabase through', async () => {
+    const archivedAt = '2026-07-16T11:25:57.681Z';
+    const builder = {
+      select: () => builder,
+      eq: () => builder,
+      order: () => builder,
+      limit: () => Promise.resolve({ data: [{ archived_at: archivedAt }], error: null }),
+    };
+    const supabase = { from: () => builder };
+    const collectEvidence = createCollectEvidence(supabase);
+    const evidence = await collectEvidence({ loop_key: 'L30' });
+    expect(evidence).toEqual({ upstreamFiredAt: archivedAt, edgeAt: null });
+  });
+
+  it('a thrown collector error propagates (not swallowed by the registry)', async () => {
+    const supabase = {
+      from: () => ({
+        select: function () { return this; },
+        eq: function () { return this; },
+        order: function () { return this; },
+        limit: () => Promise.resolve({ data: null, error: { message: 'boom' } }),
+      }),
+    };
+    const collectEvidence = createCollectEvidence(supabase);
+    await expect(collectEvidence({ loop_key: 'L30' })).rejects.toThrow(/boom/);
+  });
+});
+
+describe('Full 33-loop genesis batch (TS-4, FR-4 regression: un-collectored loops stay STARVED)', () => {
+  it('L30 evaluates open; every other genesis loop stays starved', async () => {
+    const archivedAt = '2026-07-16T11:25:57.681Z';
+    const builder = {
+      select: () => builder,
+      eq: () => builder,
+      order: () => builder,
+      limit: () => Promise.resolve({ data: [{ archived_at: archivedAt }], error: null }),
+    };
+    const supabase = { from: () => builder };
+    const collectEvidence = createCollectEvidence(supabase);
+
+    const loops = GENESIS_LOOPS.map(toLoopRow);
+    expect(loops.length).toBe(33);
+
+    const verdicts = await evaluateLoopBatch(loops, collectEvidence, new Date('2026-07-16T12:00:00.000Z'));
+    const byKey = Object.fromEntries(verdicts.map((v) => [v.loop_key, v.status]));
+
+    expect(byKey.L30).toBe('open');
+    for (const v of verdicts) {
+      if (v.loop_key !== 'L30') expect(v.status).toBe('starved');
+    }
+  });
+});
+
+describe('COLLECTORS map', () => {
+  it('registers exactly L30 today', () => {
+    expect(Object.keys(COLLECTORS)).toEqual(['L30']);
+  });
+});

--- a/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
+++ b/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
@@ -1,0 +1,61 @@
+/**
+ * L30 (D5 retention) collector tests.
+ * (SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001, TS-1..TS-3, TS-5 / GT-1 golden regression)
+ */
+import { describe, it, expect } from 'vitest';
+import { collectSessionCoordinationRetentionEvidence } from '../session-coordination-retention.js';
+import { evaluateLoopClosure, PREDICATE_TYPES } from '../../closure-engine.js';
+
+/** Chainable stub matching the .from().select().eq().eq().order().limit() shape used by the collector. */
+function stubSupabase({ data = null, error = null } = {}) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: () => Promise.resolve({ data, error }),
+  };
+  return { from: () => builder };
+}
+
+describe('collectSessionCoordinationRetentionEvidence (TS-1..TS-3)', () => {
+  it('returns { upstreamFiredAt, edgeAt: null } given a fresh retention_archive row', async () => {
+    const archivedAt = '2026-07-16T11:25:57.681Z';
+    const supabase = stubSupabase({ data: [{ archived_at: archivedAt }] });
+    const evidence = await collectSessionCoordinationRetentionEvidence(supabase);
+    expect(evidence).toEqual({ upstreamFiredAt: archivedAt, edgeAt: null });
+  });
+
+  it('returns {} (empty evidence) when no matching rows exist', async () => {
+    const supabase = stubSupabase({ data: [] });
+    const evidence = await collectSessionCoordinationRetentionEvidence(supabase);
+    expect(evidence).toEqual({});
+  });
+
+  it('throws when the Supabase query errors (never swallows into a fabricated verdict)', async () => {
+    const supabase = stubSupabase({ data: null, error: { message: 'relation "retention_archive" does not exist' } });
+    await expect(collectSessionCoordinationRetentionEvidence(supabase)).rejects.toThrow(/retention_archive query failed/);
+  });
+});
+
+describe('GT-1 golden regression: L30 can never evaluate CLOSED (TS-5)', () => {
+  // Real L30 closure_predicate shape (lib/loop-governance/genesis-loops.js DEFAULT_PREDICATE).
+  const loop = { loop_key: 'L30', predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 30 * 86400 } };
+  const now = new Date('2026-07-16T12:00:00.000Z');
+  const ago = (days) => new Date(now.getTime() - days * 86400 * 1000).toISOString();
+
+  it.each([
+    ['just now', ago(0)],
+    ['1 day ago', ago(1)],
+    ['29 days ago', ago(29)],
+  ])('status is open (never closed) when the reaper last fired %s', async (_label, upstreamFiredAt) => {
+    const evidence = await collectSessionCoordinationRetentionEvidence(stubSupabase({ data: [{ archived_at: upstreamFiredAt }] }));
+    const verdict = evaluateLoopClosure(loop, evidence, now);
+    expect(verdict.status).toBe('open');
+    expect(verdict.status).not.toBe('closed');
+  });
+
+  it('status is starved when the collector finds no evidence at all', async () => {
+    const evidence = await collectSessionCoordinationRetentionEvidence(stubSupabase({ data: [] }));
+    expect(evaluateLoopClosure(loop, evidence, now).status).toBe('starved');
+  });
+});

--- a/lib/loop-governance/collectors/index.js
+++ b/lib/loop-governance/collectors/index.js
@@ -1,0 +1,32 @@
+/**
+ * Per-loop evidence-collector registry, injected through the existing collectEvidence
+ * seam (lib/loop-governance/verifier.js:35).
+ * (SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001)
+ *
+ * A loop_key with no registered collector returns {} (empty evidence), preserving the
+ * honest STARVED baseline the governor shipped with (SD-LEO-INFRA-UNIVERSAL-LOOP-
+ * GOVERNANCE-001) — the registry's presence must never flip an un-evidenced loop.
+ *
+ * A registered collector that throws is NOT caught here — it propagates so the
+ * EXISTING try/catch in evaluateLoopBatch (verifier.js:38-40) converts it to
+ * status='unknown'. Duplicating that fail-soft logic here would create two places
+ * that can diverge on what "collector failure" means.
+ */
+import { collectSessionCoordinationRetentionEvidence } from './session-coordination-retention.js';
+
+/** loop_key -> (supabase) => Promise<Object> */
+export const COLLECTORS = Object.freeze({
+  L30: collectSessionCoordinationRetentionEvidence,
+});
+
+/**
+ * @param {Object} supabase - service-role client
+ * @returns {(loop:Object)=>Promise<Object>} collectEvidence, matching runClosureVerifier's expected signature
+ */
+export function createCollectEvidence(supabase) {
+  return async function collectEvidence(loop) {
+    const collector = COLLECTORS[loop?.loop_key];
+    if (!collector) return {};
+    return collector(supabase);
+  };
+}

--- a/lib/loop-governance/collectors/session-coordination-retention.js
+++ b/lib/loop-governance/collectors/session-coordination-retention.js
@@ -1,0 +1,49 @@
+/**
+ * L30 evidence collector — "Harness retention-reaper (unbounded tables)".
+ * (SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001)
+ *
+ * Reads retention_archive for the most recent successful cleanup_expired_coordination
+ * round trip on session_coordination (the reaper fixed by SD-FDBK-FIX-BUS-RETENTION-
+ * CLEANUP-001 + QF-20260713-277). The function RAISE EXCEPTIONs on any archive/delete
+ * count mismatch inside one transaction, so a row's mere existence in retention_archive
+ * proves a matching DELETE also succeeded — this is stronger evidence than the sweep's
+ * self-stamped periodic_process_registry witness (which stamps on every tick regardless
+ * of whether the RPC itself succeeded).
+ *
+ * edgeAt is INTENTIONALLY always null. L30's display_name is plural — "unbounded
+ * TABLES" — but this collector only has evidence for ONE of them (session_coordination).
+ * Supplying a real edgeAt would let the edge_freshness predicate (30-day window) evaluate
+ * CLOSED the moment any single archive round lands, a false-CLOSE for a loop whose true
+ * scope (retention across every unbounded harness table) is nowhere near closed. Returning
+ * { upstreamFiredAt, edgeAt: null } lands on the documented "OPEN when it fired but the
+ * edge is absent" path in closure-engine.js — the correct honest shape for a collector
+ * that can prove activity but not full closure. Any FUTURE collector for a similarly
+ * broader-than-observed loop should follow this same pattern rather than inventing a
+ * synthetic edge just to reach CLOSED.
+ */
+
+const SOURCE_TABLE = 'session_coordination';
+const ARCHIVED_BY = 'cleanup_expired_coordination';
+
+/**
+ * @param {Object} supabase - service-role client
+ * @returns {Promise<Object>} evidence: {} if never fired, else {upstreamFiredAt, edgeAt:null}
+ */
+export async function collectSessionCoordinationRetentionEvidence(supabase) {
+  const { data, error } = await supabase
+    .from('retention_archive')
+    .select('archived_at')
+    .eq('source_table', SOURCE_TABLE)
+    .eq('archived_by', ARCHIVED_BY)
+    .order('archived_at', { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(`session-coordination-retention collector: retention_archive query failed: ${error.message}`);
+  }
+
+  const latest = Array.isArray(data) ? data[0] : null;
+  if (!latest || !latest.archived_at) return {};
+
+  return { upstreamFiredAt: latest.archived_at, edgeAt: null };
+}

--- a/scripts/loop-closure-verifier-run.mjs
+++ b/scripts/loop-closure-verifier-run.mjs
@@ -8,16 +8,18 @@
  * missing invoker, called daily by .github/workflows/loop-closure-verifier-cron.yml
  * (and manually via workflow_dispatch or `node scripts/loop-closure-verifier-run.mjs`).
  *
- * Evidence collector: per-loop collectors are a separate, dependency-ordered SD (Adam's
- * lane — D5 retention is the golden-test first collector). Until they land, this runner
- * supplies the EMPTY collector, which the closure engine evaluates as STARVED — the
- * chairman-ratified honest baseline (33/33 STARVED, 2026-07-14). Collectors plug in
- * here when they exist.
+ * Evidence collector: per-loop collectors now live in a registry (SD-LEO-INFRA-LOOP-
+ * EVIDENCE-COLLECTORS-001), injected here via createCollectEvidence(supabase). A
+ * loop_key with no registered collector still gets {} (empty evidence => STARVED) —
+ * the chairman-ratified honest baseline (33/33 STARVED, 2026-07-14) is unchanged for
+ * every loop except the ones a real collector now covers (L30 first).
  *
  * GT-1 guard: with empty evidence no loop can legitimately evaluate CLOSED (edge
- * freshness of a null edge is false). A CLOSED verdict under this baseline is a
- * false-CLOSE — the exact failure the op-co GO gate exists to prevent — so it is
- * surfaced as GT1_VIOLATION and the run exits non-zero to turn the workflow red.
+ * freshness of a null edge is false); registered collectors are themselves designed to
+ * never supply a closure edge they cannot prove (see collectors/session-coordination-
+ * retention.js). A CLOSED verdict under either baseline is a false-CLOSE — the exact
+ * failure the op-co GO gate exists to prevent — so it is surfaced as GT1_VIOLATION and
+ * the run exits non-zero to turn the workflow red.
  *
  * Witness: stamps last_fired_at on the ARMED registry row via stampLastFired (NOT
  * registerVerifierCadence, whose upsert resets last_fired_at to null).
@@ -26,9 +28,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { runClosureVerifier, VERIFIER_PROCESS_KEY } from '../lib/loop-governance/verifier.js';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
-
-// Per-loop evidence collectors not wired yet — empty evidence => honest STARVED.
-const emptyEvidenceCollector = () => ({});
+import { createCollectEvidence } from '../lib/loop-governance/collectors/index.js';
 
 async function main() {
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -39,7 +39,7 @@ async function main() {
   }
   const supabase = createClient(url, key);
 
-  const result = await runClosureVerifier(supabase, emptyEvidenceCollector);
+  const result = await runClosureVerifier(supabase, createCollectEvidence(supabase));
   if (!result.ran) {
     console.error(`[loop-closure-verifier-run] verifier did not run: ${result.reason}`);
     process.exit(1);
@@ -55,7 +55,7 @@ async function main() {
   const falseClosed = (result.verdicts || []).filter((v) => v.status === 'closed');
   if (falseClosed.length > 0) {
     console.error(
-      `GT1_VIOLATION false-CLOSE under empty-evidence baseline: ` +
+      `GT1_VIOLATION false-CLOSE: ` +
       falseClosed.map((v) => v.loop_key).join(', ')
     );
     process.exit(1);

--- a/scripts/one-off/_query-sd-loop-evidence-collectors.mjs
+++ b/scripts/one-off/_query-sd-loop-evidence-collectors.mjs
@@ -1,0 +1,27 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const s = createClient(url, key);
+
+const { data, error } = await s
+  .from('strategic_directives_v2')
+  .select('id, sd_key, title, status, sd_type, category, priority, created_at, updated_at')
+  .eq('sd_key', 'SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001')
+  .single();
+
+console.log(JSON.stringify({ data, error }, null, 2));
+
+const { data: handoffs } = await s
+  .from('sd_phase_handoffs')
+  .select('id, from_phase, to_phase, status, created_at')
+  .eq('sd_id', data?.id)
+  .order('created_at', { ascending: true });
+console.log('handoffs:', JSON.stringify(handoffs, null, 2));
+
+const { data: existingRetro } = await s
+  .from('retrospectives')
+  .select('id, retro_type, created_at, status')
+  .eq('sd_id', data?.id);
+console.log('existing retros:', JSON.stringify(existingRetro, null, 2));

--- a/scripts/one-off/_verify-retro-loop-evidence-collectors.mjs
+++ b/scripts/one-off/_verify-retro-loop-evidence-collectors.mjs
@@ -1,0 +1,27 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const s = createClient(url, key);
+
+const { data, error } = await s
+  .from('retrospectives')
+  .select('id, sd_id, retro_type, retrospective_type, status, quality_score, created_at, what_went_well, key_learnings, action_items, what_needs_improvement')
+  .eq('id', 'd846a24e-218b-4633-9cfb-0c362f2a260b')
+  .single();
+
+if (error) {
+  console.error(error);
+  process.exit(1);
+}
+
+console.log('id:', data.id);
+console.log('sd_id:', data.sd_id);
+console.log('retro_type:', data.retro_type, '| retrospective_type:', data.retrospective_type);
+console.log('status:', data.status, '| quality_score:', data.quality_score);
+console.log('created_at:', data.created_at);
+console.log('what_went_well count:', data.what_went_well?.length);
+console.log('key_learnings count:', data.key_learnings?.length);
+console.log('action_items count:', data.action_items?.length);
+console.log('what_needs_improvement count:', data.what_needs_improvement?.length);

--- a/scripts/one-off/insert-retro-sd-leo-infra-loop-evidence-collectors-001.mjs
+++ b/scripts/one-off/insert-retro-sd-leo-infra-loop-evidence-collectors-001.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * SD-completion retrospective for SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001.
+ *
+ * Written directly against the retrospectives table (same pattern as
+ * scripts/one-off/insert-retro-sd-leo-infra-payment-rail-attribution-002.mjs)
+ * so the PLAN-TO-LEAD RETROSPECTIVE_QUALITY_GATE has a fresh retro_type=SD_COMPLETION
+ * row created after the LEAD-TO-PLAN acceptance timestamp, with genuinely
+ * SD-specific insights rather than metric-only boilerplate.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_UUID = '556b87e9-537c-4d22-b572-06f635029809';
+const SD_KEY = 'SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001';
+
+const retro = {
+  sd_id: SD_UUID,
+  retro_type: 'SD_COMPLETION',
+  retrospective_type: null,
+  learning_category: 'PROCESS_IMPROVEMENT',
+  target_application: 'EHG_Engineer',
+  generated_by: 'MANUAL',
+  status: 'PUBLISHED',
+  title: `Retrospective: ${SD_KEY} — D5 retention loop's evidence collector, the golden first collector for the loop-governance closure verifier`,
+  description: 'The loop-governance closure verifier (lib/loop-governance/verifier.js) was live and cron-wired (scripts/loop-closure-verifier-run.mjs) but was called with an empty evidence collector, so all 33 genesis loops in loop_registry evaluated STARVED forever regardless of any real activity — a fully-wired governance mechanism producing a permanently dishonest baseline. This SD closes that gap for exactly one loop (L30, "Harness retention-reaper (unbounded tables)", the D5 retention loop) by adding a pluggable evidence-collector registry and the first real collector, proving the seam works end to end without attempting to collector-ize all 33 loops in one pass.',
+  affected_components: [
+    'lib/loop-governance/collectors/index.js',
+    'lib/loop-governance/collectors/session-coordination-retention.js',
+    'scripts/loop-closure-verifier-run.mjs',
+  ],
+  related_files: [
+    'lib/loop-governance/collectors/index.js',
+    'lib/loop-governance/collectors/session-coordination-retention.js',
+    'lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js',
+    'lib/loop-governance/collectors/__tests__/registry.test.js',
+    'scripts/loop-closure-verifier-run.mjs',
+    'lib/loop-governance/verifier.js',
+    'lib/loop-governance/closure-engine.js',
+  ],
+  what_went_well: [
+    'The fix required zero changes to lib/loop-governance/verifier.js or lib/loop-governance/closure-engine.js — the existing collectEvidence seam was already correctly shaped to accept a real collector; the bug was purely that scripts/loop-closure-verifier-run.mjs was invoking an emptyEvidenceCollector. Recognizing this meant the solution was additive (a new collectors/ module) rather than a risky refactor of the two files that actually decide closure state.',
+    'Built lib/loop-governance/collectors/index.js as a COLLECTORS registry keyed by loop_key plus a createCollectEvidence(supabase) factory, so scripts/loop-closure-verifier-run.mjs only needed a one-line swap (emptyEvidenceCollector -> createCollectEvidence(supabase)) plus a corrected header comment — the smallest possible diff to the cron-wired entrypoint that carries production risk.',
+    'The first real collector (session-coordination-retention.js, for L30) reads retention_archive for the most recent row where source_table=\'session_coordination\' AND archived_by=\'cleanup_expired_coordination\' — reusing the exact reaper identity fixed by QF-20260713-277 (the bus-reaper RPC) as the evidence source, so the collector is anchored to a mechanism already independently verified to be running, not a new unverified data path.',
+    'Deliberately chose to always return edgeAt:null from this collector (see key_learnings for the full reasoning) even though it has a real upstreamFiredAt — this lands on closure-engine.js\'s documented "fired but the edge is absent" path and keeps L30 honestly OPEN rather than letting a narrow one-table collector falsely CLOSE a loop whose display_name (\'Harness retention-reaper (unbounded tables)\', plural) describes a much broader scope than session_coordination alone.',
+    'Verified the fix live rather than trusting the test suite alone: ran node scripts/loop-closure-verifier-run.mjs after wiring the collector and confirmed tally={"starved":32,"open":1}, loop_registry row for L30 has status=\'open\' with reason \'fired but closure edge absent\', and the other 32 loops (spot-checked via L4) are untouched at \'starved\' — proving the collector affects exactly the one loop it targets and the injection point does not leak into unrelated loops.',
+    'Test coverage mirrors the two things that actually matter for this SD: session-coordination-retention.test.js includes a GT-1 golden regression test parametrized over 0/1/29-day-old evidence (so any future edit that starts supplying a real edgeAt gets caught immediately), and registry.test.js runs a full 33-genesis-loop batch regression so a future collector addition can\'t silently regress an unrelated loop\'s STARVED baseline.',
+  ],
+  what_needs_improvement: [
+    'This SD intentionally leaves 32 of the 33 genesis loops (L1-L29, L31-L33) uncollectored and therefore still permanently STARVED — the golden-first-collector scope was the right call for proving the seam, but the fleet is still one collector away from a governance mechanism that means anything for the loops it doesn\'t yet cover.',
+    'The edgeAt:null pattern this collector establishes is the correct default for any loop whose display_name scope exceeds what a single evidence source can observe, but that judgment call (does this loop\'s stated scope exceed this collector\'s evidence?) is currently made by inline code-comment reasoning in session-coordination-retention.js rather than by any structural check — a future collector author could supply a real edgeAt for a similarly under-observed loop without the registry or engine catching the mismatch.',
+    'The GT-1 acceptance criterion (D5 must evaluate \'open\', never \'closed\') is validated by a parametrized unit test today; there is no live/scheduled regression check yet that would catch a future collector edit silently starting to return a real edgeAt for L30 in production, only the next time someone runs the test suite.',
+  ],
+  key_learnings: [
+    'A cron-wired verifier that has been "live" for a while can still be producing a completely uninformative signal if its evidence-injection point was left as a stub — loop_registry showed all 33 genesis loops as STARVED not because nothing was happening in the system, but because scripts/loop-closure-verifier-run.mjs was calling emptyEvidenceCollector. "The verifier runs on schedule" and "the verifier tells you anything true" are separate claims, and only the second one required this SD.',
+    'The single most important design decision in this SD was choosing what NOT to report: session-coordination-retention.js always returns edgeAt:null, deliberately declining to supply a real closure edge, even though it has a genuine upstreamFiredAt timestamp from retention_archive. The reason is that L30\'s display_name (\'Harness retention-reaper (unbounded tables)\') describes scope across multiple unbounded tables, but this first collector only has evidence for one (session_coordination). Supplying a real edgeAt would let the edge_freshness predicate (30-day window) evaluate CLOSED almost immediately, since the session_coordination reaper fires frequently — producing a false-CLOSE for a loop whose true scope this one collector cannot actually attest to. Returning edgeAt:null while upstreamFiredAt is set instead lands on closure-engine.js\'s documented "OPEN when it fired but the edge is absent" path, satisfying the non-negotiable GT-1 acceptance criterion that D5 must evaluate \'open\', never \'closed\', with this partial evidence.',
+    'This pattern (edgeAt:null whenever a collector\'s evidence scope is narrower than the loop\'s stated scope) is the reusable template for every future collector in this family: a collector should only supply a real edgeAt when its evidence source demonstrably covers the FULL scope implied by the loop\'s display_name/definition, not merely SOME activity related to it. Reporting a real edge from partial evidence is a false-CLOSE risk, not a conservative default.',
+    'Injecting a real collector through an existing, already-correctly-shaped seam (collectEvidence) is lower-risk than it might look for a governance-critical verifier — because closure-engine.js and verifier.js needed zero changes, the blast radius of this fix is fully contained to the new collectors/ module and a one-line swap in the cron entrypoint, which is exactly why the REGRESSION sub-agent could confirm the other 32 loops were provably unaffected.',
+    'Anchoring a new evidence collector to an already-independently-verified mechanism (the bus-reaper RPC fixed by QF-20260713-277) rather than a fresh, unverified data path meant this collector inherited that mechanism\'s correctness instead of needing its own end-to-end verification of "does the reaper actually run" from scratch.',
+  ],
+  action_items: [
+    {
+      title: 'Build evidence collectors for the remaining 32 genesis loops (L1-L29, L31-L33)',
+      description: 'This SD intentionally scoped to D5/L30 only, as the golden first collector proving the collectEvidence injection seam. The other 32 genesis loops in loop_registry remain STARVED with no real evidence source. Each follow-on collector should be scoped and reviewed individually (one loop at a time, per the "one table at a time" prevention pattern) rather than attempted as a single bulk SD.',
+      priority: 'high',
+      owner_role: 'PLAN',
+    },
+    {
+      title: 'Copy the edgeAt-null-when-scope-exceeds-evidence pattern into every future collector',
+      description: 'Any new collector for a loop whose display_name/definition describes broader scope than a single available evidence source should follow session-coordination-retention.js\'s precedent: return edgeAt:null (landing on the "fired but edge absent" OPEN path) rather than supplying a real edgeAt derived from partial evidence, which risks a false-CLOSE. Document this explicitly in the collectors/index.js registry comment so it is discoverable without re-deriving the reasoning from session-coordination-retention.js each time.',
+      priority: 'high',
+      owner_role: 'EXEC',
+    },
+    {
+      title: 'Add a structural (not just inline-comment) guard against edgeAt/scope mismatch in the registry',
+      description: 'Currently the "does this collector\'s evidence scope match the loop\'s stated scope" judgment is enforced only by code-comment discipline in each collector file. Consider a lightweight registry-level check (e.g. a required scope-coverage annotation per collector, validated in registry.test.js) so a future collector author supplying a real edgeAt for an under-observed loop gets caught by the test suite rather than relying on the next reviewer re-reading the reasoning.',
+      priority: 'medium',
+      owner_role: 'PLAN',
+    },
+    {
+      title: 'Add a live/scheduled regression check for the GT-1 acceptance criterion, not just a unit test',
+      description: 'The parametrized unit test (0/1/29-day-old evidence) in session-coordination-retention.test.js validates GT-1 (D5 must evaluate \'open\', never \'closed\') at test-run time. Consider a lightweight scheduled check (e.g. alongside the existing loop-closure-verifier-run.mjs cron) that alerts if L30 ever evaluates \'closed\' in production, so a future collector edit that starts supplying a real edgeAt is caught in the live cadence, not only the next time the test suite runs.',
+      priority: 'low',
+      owner_role: 'EXEC',
+    },
+  ],
+  improvement_areas: [
+    {
+      area: '32 of 33 genesis loops remain uncollectored and permanently STARVED',
+      analysis: 'This SD deliberately scoped to exactly one loop (L30/D5) to prove the collectEvidence injection seam end to end before attempting the other 32. That was the right sequencing call, but it means loop_registry\'s tally={"starved":32,"open":1} is the honest, expected post-SD state, not a regression — the other 32 loops still tell you nothing true about real activity.',
+      prevention: 'Tracked as the first action item above: build the remaining 32 collectors incrementally, one loop at a time, each independently reviewed and verified live the same way L30 was (tally check + spot-checked unaffected loops), rather than as a single large follow-on SD.',
+    },
+    {
+      area: 'edgeAt/scope-mismatch judgment is enforced only by inline code comments today',
+      analysis: 'The core safety property of this SD (never let a narrow collector falsely CLOSE a broad-scoped loop) currently lives as reasoning in session-coordination-retention.js\'s comments, not as a structural check the registry or its tests would enforce for a future collector that gets this judgment wrong.',
+      prevention: 'Tracked as the third action item above: consider a lightweight scope-coverage annotation validated in registry.test.js so this stops depending on every future collector author re-deriving and correctly applying the reasoning from scratch.',
+    },
+  ],
+  success_patterns: [
+    'Diagnosed that the closure verifier\'s dishonest STARVED-forever output was caused by an empty evidence collector at the cron entrypoint, not a defect in the verifier or closure-engine logic itself, so the fix stayed additive (new collectors/ module + one-line swap) with zero changes to the two files that decide closure state',
+    'Deliberately returned edgeAt:null from the first real collector despite having a real upstreamFiredAt, to avoid a false-CLOSE on a loop (L30, "unbounded TABLES", plural) whose true scope exceeds what one collector\'s evidence (session_coordination only) can attest to — landing on closure-engine.js\'s documented OPEN-when-edge-absent path instead',
+    'Verified the fix live end to end (node scripts/loop-closure-verifier-run.mjs) rather than trusting tests alone, confirming tally={"starved":32,"open":1}, L30 status=\'open\' with reason \'fired but closure edge absent\', and that other loops (e.g. L4) remained untouched at \'starved\'',
+    'Anchored the new collector\'s evidence source (retention_archive rows for source_table=\'session_coordination\', archived_by=\'cleanup_expired_coordination\') to the bus-reaper mechanism already independently fixed and verified by QF-20260713-277, rather than a fresh unverified data path',
+    'Test suite included both a targeted GT-1 golden regression (0/1/29-day-old evidence parametrization) and a full 33-genesis-loop batch regression, so future edits get caught for both "did L30 stop being honest" and "did adding a new collector regress an unrelated loop"',
+  ],
+  failure_patterns: [
+    'The closure verifier had been live and cron-wired for a period of time while silently reporting a fully uninformative signal (all 33 loops STARVED) because its only evidence collector was an empty stub — a "the mechanism runs on schedule" check alone would not have caught that the mechanism told you nothing true',
+    '32 of 33 genesis loops remain without any real evidence collector after this SD, by deliberate scope decision rather than oversight, but still represent an open gap in the fleet-wide governance signal',
+  ],
+  business_value_delivered: 'Restores real signal to the loop-governance closure verifier for the D5 retention loop (L30) — the first of 33 genesis loops to move off a permanently dishonest STARVED baseline — and proves out the collectEvidence injection seam that every future per-loop collector will reuse.',
+  customer_impact: 'Indirect: internal governance/observability mechanism (loop_registry closure state) used to gate op-co GO decisions; no end-user-facing surface changed.',
+  technical_debt_addressed: true,
+  technical_debt_created: false,
+  bugs_found: 1,
+  bugs_resolved: 1,
+  tests_added: 2,
+  performance_impact: 'Standard',
+  objectives_met: true,
+  on_schedule: true,
+  within_scope: true,
+  conducted_date: new Date().toISOString(),
+  agents_involved: ['LEAD', 'PLAN', 'EXEC'],
+  human_participants: ['LEAD'],
+  team_satisfaction: 9,
+  metadata: {
+    sd_key: SD_KEY,
+    loop_key: 'L30',
+    d_ref: 'D5',
+    loop_display_name: 'Harness retention-reaper (unbounded tables)',
+    upstream_fix_reused: 'QF-20260713-277 (bus-reaper RPC, session_coordination cleanup_expired_coordination)',
+    verifier_run_result: '{"starved":32,"open":1}',
+    l30_reason: 'fired but closure edge absent',
+    subagent_verdicts: {
+      TESTING: '96%',
+      VALIDATION: '95% (re-ran verifier live independently)',
+      REGRESSION: '96% (confirmed emptyEvidenceCollector had zero external references; GHA cron call unchanged; 32 other loops unaffected)',
+    },
+    remaining_scope: 'L1-L29, L31-L33 still need their own collectors (32 of 33 genesis loops)',
+    handoffs_completed: ['LEAD-TO-PLAN', 'PLAN-TO-EXEC', 'EXEC-TO-PLAN'],
+  },
+};
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  const s = createClient(url, key);
+
+  // Dedup guard: don't create a second SD_COMPLETION row if one already exists.
+  const { data: existing } = await s
+    .from('retrospectives')
+    .select('id, created_at')
+    .eq('sd_id', SD_UUID)
+    .eq('retro_type', 'SD_COMPLETION')
+    .limit(1);
+
+  if (existing && existing.length > 0) {
+    console.log(`SD_COMPLETION retrospective already exists (id: ${existing[0].id}, created_at: ${existing[0].created_at}) — no new row needed.`);
+    return;
+  }
+
+  const { data: ins, error: insErr } = await s.from('retrospectives').insert(retro).select('id').single();
+  if (insErr) {
+    console.error('Insert failed:', insErr.message);
+    process.exit(1);
+  }
+  const retroId = ins.id;
+  console.log('Inserted retrospective id:', retroId);
+
+  const { data: ver, error: verErr } = await s
+    .from('retrospectives')
+    .select('id, sd_id, retro_type, retrospective_type, quality_score, status, created_at, learning_category, target_application')
+    .eq('id', retroId)
+    .single();
+  if (verErr) {
+    console.error('Verify failed:', verErr.message);
+    process.exit(1);
+  }
+  console.log('Verified:', JSON.stringify(ver, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a per-loop evidence-collector registry (`lib/loop-governance/collectors/`) injected through the existing `collectEvidence` seam in `lib/loop-governance/verifier.js` — no changes to the verifier or closure-engine needed.
- Adds the first real collector, for loop **L30 / D5 "Harness retention-reaper (unbounded tables)"**: reads `retention_archive` evidence for the `cleanup_expired_coordination` reaper (session_coordination table, fixed by QF-20260713-277).
- The collector deliberately always returns `edgeAt: null` — it only has evidence for one of the "unbounded tables" the loop covers, so it proves activity (`upstreamFiredAt`) but never fabricates full closure. This guarantees **GT-1**: L30 evaluates `open`, never `closed`.
- Wires the registry into `scripts/loop-closure-verifier-run.mjs`, replacing the old empty-evidence placeholder.
- Un-collectored loops (the other 32 genesis loops) are unaffected and remain `starved`.

Verified live: `node scripts/loop-closure-verifier-run.mjs` → `tally={"starved":32,"open":1}`; `loop_registry` row for L30 shows `status='open'`, reason `"fired but closure edge absent"`.

## Test plan
- [x] Unit tests: `npx vitest run --project unit lib/loop-governance/` — 6 files / 49 tests pass, including a GT-1 golden regression (L30 never evaluates `closed` across 0/1/29-day-old evidence) and a full 33-genesis-loop batch regression (only L30 flips to `open`).
- [x] Live smoke test: ran the cron script against the real DB, confirmed `L30='open'` and `L4='starved'` via direct `loop_registry` query.
- [x] TESTING (96%), VALIDATION (95%, independently re-ran the live verifier), REGRESSION (96%, confirmed zero external references to the removed placeholder, GHA workflow call signature unchanged, other 32 loops unaffected) sub-agents all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)