### PR TITLE
fix(SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001): close fn_is_chairman privilege escalation (staged, chairman-apply)

### DIFF
--- a/database/migrations/20260716_a_backfill_chairman_app_metadata.sql
+++ b/database/migrations/20260716_a_backfill_chairman_app_metadata.sql
@@ -1,0 +1,68 @@
+-- Backfill legitimate chairman/admin identities into auth.users.raw_app_meta_data.
+-- SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (FR-1). Coordinator-sourced SECURITY-CRITICAL.
+--
+-- WHY: fn_is_chairman() and the archetype_benchmarks_admin RLS policy currently authorize the
+-- chairman/admin role off auth.users.raw_user_meta_data — the Supabase USER-WRITABLE user_metadata
+-- surface (any authenticated user can self-set it via supabase.auth.updateUser({data:{role:'chairman'}})).
+-- The fix (migrations _b_ and _c_) flips both reads to raw_app_meta_data (service-role-only, NOT
+-- user-writable). SEQUENCING HAZARD (verified live at filing): user_meta_chairman=2, app_meta_chairman=0
+-- — flipping the reads BEFORE this backfill would strand BOTH real chairman accounts and lock everyone
+-- out of all 21 fn_is_chairman-gated policies + the archetype policy. THIS MIGRATION MUST BE APPLIED
+-- FIRST (before _b_ and _c_).
+--
+-- Method: copy the qualifying role (and roles array, if present) from raw_user_meta_data into
+-- raw_app_meta_data for exactly the identities that currently hold chairman/admin/owner in user_metadata.
+-- Idempotent (re-run is a no-op once backfilled) and readback-verified (raises if app_meta chairman
+-- count < user_meta chairman count after the update). Merge-preserves any pre-existing app_metadata keys.
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. APPLY IS CHAIRMAN-ONLY / NON-DELEGATABLE (this is an
+-- access-control change — permission class, outside the @delegated-by additive tier). This file
+-- intentionally omits the @approved-by tag until the chairman explicitly applies it (staged, pending
+-- explicit chairman GO — see check-migration-readiness.mjs). The build worker STAGES; the chairman APPLIES.
+--
+-- requires-chairman-apply
+
+DO $$
+DECLARE
+  v_user_meta_chairman int;
+  v_app_meta_before    int;
+  v_app_meta_after     int;
+  v_updated            int;
+BEGIN
+  SELECT count(*) INTO v_user_meta_chairman FROM auth.users
+    WHERE raw_user_meta_data->>'role' IN ('chairman','admin','owner')
+       OR raw_user_meta_data->'roles' @> '"chairman"'::jsonb;
+
+  SELECT count(*) INTO v_app_meta_before FROM auth.users
+    WHERE raw_app_meta_data->>'role' IN ('chairman','admin','owner')
+       OR raw_app_meta_data->'roles' @> '"chairman"'::jsonb;
+
+  -- Copy the qualifying role (and roles, when present) into app_metadata, merge-preserving
+  -- any existing app_metadata keys. Idempotency guard: skip rows whose app_metadata role already
+  -- equals the user_metadata role (re-run is a no-op).
+  UPDATE auth.users u
+  SET raw_app_meta_data =
+        COALESCE(u.raw_app_meta_data, '{}'::jsonb)
+        || jsonb_build_object('role', u.raw_user_meta_data->>'role')
+        || CASE WHEN u.raw_user_meta_data ? 'roles'
+                THEN jsonb_build_object('roles', u.raw_user_meta_data->'roles')
+                ELSE '{}'::jsonb END
+  WHERE (u.raw_user_meta_data->>'role' IN ('chairman','admin','owner')
+         OR u.raw_user_meta_data->'roles' @> '"chairman"'::jsonb)
+    AND COALESCE(u.raw_app_meta_data->>'role','') IS DISTINCT FROM u.raw_user_meta_data->>'role';
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  SELECT count(*) INTO v_app_meta_after FROM auth.users
+    WHERE raw_app_meta_data->>'role' IN ('chairman','admin','owner')
+       OR raw_app_meta_data->'roles' @> '"chairman"'::jsonb;
+
+  RAISE NOTICE 'chairman/admin app_metadata backfill: user_meta_chairman=%, app_meta_before=%, rows_updated=%, app_meta_after=%',
+    v_user_meta_chairman, v_app_meta_before, v_updated, v_app_meta_after;
+
+  -- Readback assertion: after backfill, every legitimate (user_meta) chairman MUST also be an
+  -- app_meta chairman, so the subsequent read-flip cannot lock anyone out.
+  IF v_app_meta_after < v_user_meta_chairman THEN
+    RAISE EXCEPTION 'Backfill readback FAILED: app_meta chairman count (%) < user_meta chairman count (%) — DO NOT apply migrations _b_/_c_ until resolved',
+      v_app_meta_after, v_user_meta_chairman;
+  END IF;
+END $$;

--- a/database/migrations/20260716_b_fn_is_chairman_read_app_metadata.sql
+++ b/database/migrations/20260716_b_fn_is_chairman_read_app_metadata.sql
@@ -1,0 +1,41 @@
+-- Rewrite fn_is_chairman() to authorize off raw_app_meta_data (not user-writable).
+-- SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (FR-2). SECURITY-CRITICAL privilege-escalation fix.
+--
+-- WHY: the live fn_is_chairman() reads auth.users.raw_user_meta_data->>'role' / ->'roles' — the
+-- Supabase USER-WRITABLE user_metadata surface — so any authenticated user can self-elevate to
+-- chairman and defeat all 21 fn_is_chairman-gated RLS policies across 16 tables. This CREATE OR
+-- REPLACE changes ONLY the metadata source column (raw_user_meta_data -> raw_app_meta_data);
+-- the role/roles predicate, the zero-arg signature, SECURITY DEFINER, and search_path are IDENTICAL
+-- to the prior definition, so the 21 dependent policies bind unchanged with no policy edits.
+--
+-- APPLY ORDER: MUST be applied AFTER 20260716_a_backfill_chairman_app_metadata.sql. Applying this
+-- before the backfill would return FALSE for both real chairman accounts (app_meta_chairman=0 at
+-- filing) and lock everyone out of all 21 policies.
+--
+-- ROLLBACK (chairman-gated): CREATE OR REPLACE the prior body reading raw_user_meta_data.
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. APPLY IS CHAIRMAN-ONLY / NON-DELEGATABLE (access-control
+-- change). Intentionally omits the @approved-by tag until the chairman explicitly applies it.
+--
+-- requires-chairman-apply
+
+CREATE OR REPLACE FUNCTION public.fn_is_chairman()
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  BEGIN
+    RETURN (SELECT EXISTS(
+      SELECT 1 FROM auth.users u
+      WHERE u.id = auth.uid()
+      AND (
+        u.raw_app_meta_data->>'role' IN ('chairman', 'admin', 'owner')
+        OR u.raw_app_meta_data->'roles' @> '"chairman"'::jsonb
+      )
+    ));
+  END;
+  $function$;
+
+COMMENT ON FUNCTION public.fn_is_chairman() IS
+  'Authorizes the chairman/admin/owner role off auth.users.raw_app_meta_data (service-role-only, NOT user-writable). SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001: moved off raw_user_meta_data to close an authenticated-user privilege-escalation. Read source is the ONLY change vs the prior definition.';

--- a/database/migrations/20260716_c_archetype_benchmarks_admin_read_app_metadata.sql
+++ b/database/migrations/20260716_c_archetype_benchmarks_admin_read_app_metadata.sql
@@ -1,0 +1,38 @@
+-- Rewrite the archetype_benchmarks_admin RLS policy to authorize off raw_app_meta_data.
+-- SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (FR-4 fold-in). SECURITY-CRITICAL.
+--
+-- WHY: the FR-4 authorization audit (docs/audits/fn-is-chairman-authz-audit.md) found a SECOND
+-- instance of the exact same privilege-escalation class OUTSIDE fn_is_chairman: the RLS policy
+-- public.archetype_benchmarks.archetype_benchmarks_admin authorizes admin/chairman DIRECTLY off
+-- auth.users.raw_user_meta_data->>'role' (user-writable). Any authenticated user could self-set
+-- user_metadata.role='admin' and gain FOR ALL access to archetype_benchmarks. FR-4 authorizes
+-- folding in-scope siblings; this shares the same raw_app_meta_data backfill enabler (migration _a_),
+-- so the class is closed completely rather than partially.
+--
+-- The rewrite preserves the policy exactly (FOR ALL, TO public, same admin/chairman role set) and
+-- changes ONLY the metadata source column (raw_user_meta_data -> raw_app_meta_data). Original policy
+-- had no WITH CHECK; recreated the same way (USING applies to add/modify for FOR ALL policies).
+--
+-- APPLY ORDER: MUST be applied AFTER 20260716_a_backfill_chairman_app_metadata.sql (same lockout
+-- hazard as fn_is_chairman). Independent of migration _b_.
+--
+-- ROLLBACK (chairman-gated): recreate the policy with the raw_user_meta_data USING expression.
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. APPLY IS CHAIRMAN-ONLY / NON-DELEGATABLE (access-control
+-- change). Intentionally omits the @approved-by tag until the chairman explicitly applies it.
+--
+-- requires-chairman-apply
+
+DROP POLICY IF EXISTS archetype_benchmarks_admin ON public.archetype_benchmarks;
+
+CREATE POLICY archetype_benchmarks_admin ON public.archetype_benchmarks
+  FOR ALL
+  TO public
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM auth.users
+      WHERE auth.uid() = users.id
+        AND (users.raw_app_meta_data->>'role') = ANY (ARRAY['admin'::text, 'chairman'::text])
+    )
+  );

--- a/docs/audits/fn-is-chairman-authz-audit.md
+++ b/docs/audits/fn-is-chairman-authz-audit.md
@@ -46,14 +46,22 @@ independent of `fn_is_chairman`. Per FR-4 ("in-scope siblings folded in"), and b
 same `raw_app_meta_data` backfill enabler, it is fixed in this SD (migration `_c_`) rather than
 deferred, so the vulnerability class is closed completely.
 
-## Backfill targets (legitimate chairman identities)
+## Backfill targets (identities the chairman-authz predicate treats as privileged)
 
-- `69c8aa7a-7661-48ed-9779-746fa6290873` — rickfelix2000@gmail.com (chairman)
-- `48d7ec58-faf9-4772-ba72-fb0c2fb297da` — test@ehg.dev (chairman)
+`fn_is_chairman()` authorizes `role IN ('chairman','admin','owner')`. The two current holders (verified live) are:
 
-> Note: `test@ehg.dev` currently holds chairman. It is backfilled to avoid lockout (preserving the
-> status quo, per the no-lockout acceptance criterion). Whether a test account *should* retain
-> chairman is a separate access-governance question for the chairman — **out of scope** for this SD.
+- `69c8aa7a-7661-48ed-9779-746fa6290873` — rickfelix2000@gmail.com — `raw_user_meta_data.role = 'admin'`
+- `48d7ec58-faf9-4772-ba72-fb0c2fb297da` — test@ehg.dev — `raw_user_meta_data.role = 'owner'`
+
+The backfill copies each identity's **actual** role value (admin / owner — not a hardcoded 'chairman')
+into `raw_app_meta_data`, and **merge-preserves** the existing app_metadata `provider`/`providers`
+keys (clobbering those would break Supabase auth). Post-fix authorization is therefore identical:
+both remain `fn_is_chairman()=TRUE`; for the archetype policy (admin/chairman only), `admin` still
+matches and `owner` still does not — exactly as before this change (no regression, no lockout).
+
+> Note: `test@ehg.dev` (role=owner) is a test account. It is backfilled to preserve the status quo
+> (no-lockout criterion). Whether a test account *should* retain owner/chairman-equivalent access is a
+> separate access-governance question for the chairman — **out of scope** for this SD.
 
 ## Deliverables (all STAGED — chairman applies, in order)
 

--- a/docs/audits/fn-is-chairman-authz-audit.md
+++ b/docs/audits/fn-is-chairman-authz-audit.md
@@ -1,0 +1,79 @@
+# Authorization Audit — `raw_user_meta_data` privilege escalation
+
+**SD:** SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (SECURITY-CRITICAL, coordinator-sourced)
+**Date:** 2026-07-16
+**Auditor:** fleet worker Alpha (opus/xhigh), EXEC phase
+**Class:** authenticated-user privilege escalation via user-writable metadata
+
+## Vulnerability
+
+Supabase exposes `auth.users.raw_user_meta_data` as the **user-writable** `user_metadata` surface:
+any authenticated user can set it with `supabase.auth.updateUser({ data: { role: 'chairman' } })`.
+Any authorization decision that reads `raw_user_meta_data` for a role check is therefore
+**self-elevatable** by any authenticated user. The fix is to authorize off `raw_app_meta_data`
+(`app_metadata`), which is settable **only** by the service role / admin API.
+
+## Executed verification (pre-apply, live DB, read-only introspection)
+
+| Check | Result |
+|-------|--------|
+| `fn_is_chairman()` body | reads `u.raw_user_meta_data->>'role' IN ('chairman','admin','owner') OR ...->'roles' @> '"chairman"'` — **VULNERABLE** |
+| `total_users` | 3 |
+| `user_meta_chairman` | **2** |
+| `app_meta_chairman` | **0** — sequencing hazard: flipping the read before backfill locks out both real chairmen |
+| RLS policies gating on `fn_is_chairman` | **21** across **16** tables |
+| Other SECURITY DEFINER functions reading `raw_user_meta_data` | none (only `fn_is_chairman`) |
+| RLS policies reading `raw_user_meta_data` **directly** (not via `fn_is_chairman`) | **1** — `public.archetype_benchmarks.archetype_benchmarks_admin` (same vuln class) |
+
+## Blast radius — 21 `fn_is_chairman`-gated policies (16 tables)
+
+agent_registry(chairman_read_agents), agents(agents_chairman_full_access),
+ai_gen_dwell_tracking(ai_gen_dwell_chairman_select), ai_gen_provenance(ai_gen_provenance_chairman_select),
+chairman_decisions(chairman_decisions_select_policy),
+chairman_directives(chairman_directives_insert / _select / _update),
+gvos_adherence_logs(gvos_adherence_logs_select_chairman), legal_templates(legal_templates_write),
+public_portfolio("Chairman can manage portfolio"), sd_proposals(sd_proposals_select),
+tool_usage_ledger(chairman_read_ledger), venture_artifacts(venture_artifacts_delete_policy),
+venture_gvos_profile(_delete / _insert / _select / _update _chairman),
+venture_revenue_entries(venture_revenue_entries_insert_chairman),
+venture_stage_work(venture_stage_work_delete_policy), ventures_kill_log(ventures_kill_log_select).
+
+## Second finding — folded in (FR-4)
+
+`public.archetype_benchmarks.archetype_benchmarks_admin` (cmd=ALL, roles=public) authorizes
+directly off `users.raw_user_meta_data->>'role' = ANY('admin','chairman')` — the **same** exploit,
+independent of `fn_is_chairman`. Per FR-4 ("in-scope siblings folded in"), and because it shares the
+same `raw_app_meta_data` backfill enabler, it is fixed in this SD (migration `_c_`) rather than
+deferred, so the vulnerability class is closed completely.
+
+## Backfill targets (legitimate chairman identities)
+
+- `69c8aa7a-7661-48ed-9779-746fa6290873` — rickfelix2000@gmail.com (chairman)
+- `48d7ec58-faf9-4772-ba72-fb0c2fb297da` — test@ehg.dev (chairman)
+
+> Note: `test@ehg.dev` currently holds chairman. It is backfilled to avoid lockout (preserving the
+> status quo, per the no-lockout acceptance criterion). Whether a test account *should* retain
+> chairman is a separate access-governance question for the chairman — **out of scope** for this SD.
+
+## Deliverables (all STAGED — chairman applies, in order)
+
+1. `database/migrations/20260716_a_backfill_chairman_app_metadata.sql` — backfill (idempotent, readback-verified). **Apply first.**
+2. `database/migrations/20260716_b_fn_is_chairman_read_app_metadata.sql` — `fn_is_chairman` reads `raw_app_meta_data`. Apply after (1).
+3. `database/migrations/20260716_c_archetype_benchmarks_admin_read_app_metadata.sql` — archetype policy reads `raw_app_meta_data`. Apply after (1).
+4. `tests/security/fn-is-chairman-app-metadata.acceptance.sql` — post-apply acceptance assertions.
+
+**Apply authority:** CHAIRMAN-ONLY / non-delegatable (access-control change, permission class). The
+build worker stages only; the migrations carry no `@approved-by` tag. **Rollback** (chairman-gated):
+`CREATE OR REPLACE` the prior `fn_is_chairman` body / recreate the archetype policy against
+`raw_user_meta_data`; the additive backfill can be left in place.
+
+## Acceptance criteria → coverage
+
+| Criterion | Covered by |
+|-----------|-----------|
+| Exploit closed (self-set user_metadata → NOT chairman) | migrations `_b_`/`_c_`; acceptance checks (1),(4) + behavioral E2E |
+| No chairman lockout | migration `_a_` (backfill + readback); acceptance check (2) |
+| 21-policy spot-check authorizes correctly | `fn_is_chairman` contract preserved (signature/SECURITY DEFINER/search_path unchanged); acceptance check (1) |
+| Sequencing hazard neutralized | apply order enforced in headers + `_a_` readback assertion |
+| No other authz path reads user_metadata | this audit (only `fn_is_chairman` + `archetype_benchmarks_admin`, both fixed) |
+| Staged, chairman-only apply | all migrations `requires-chairman-apply`, no `@approved-by` |

--- a/tests/security/fn-is-chairman-app-metadata.acceptance.sql
+++ b/tests/security/fn-is-chairman-app-metadata.acceptance.sql
@@ -1,0 +1,85 @@
+-- Acceptance test for SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (FR-3).
+-- Run POST-APPLY (after migrations _a_ backfill, _b_ fn_is_chairman flip, _c_ archetype policy flip)
+-- in the Supabase SQL editor / psql as the service role. Every check RAISE EXCEPTIONs on failure;
+-- a clean run ends with 'ALL ACCEPTANCE CHECKS PASSED'.
+--
+-- Covers the SD acceptance criteria:
+--   (a) exploit closed  — fn_is_chairman (and the archetype policy) no longer read the user-writable
+--                         raw_user_meta_data; a user who self-sets user_metadata.role='chairman' is NOT chairman.
+--   (b) no lockout      — every legitimate chairman (user_metadata) is present in raw_app_meta_data.
+--   (c) policy spot      — the fn_is_chairman contract is preserved so the 21 dependent policies bind unchanged.
+--
+-- A behavioral end-to-end check (sign in as a normal user, supabase.auth.updateUser({data:{role:'chairman'}}),
+-- then SELECT fn_is_chairman() -> expect FALSE) is documented at the bottom for manual/CI post-apply runs;
+-- it requires an authenticated session and cannot be asserted from a service-role SQL context.
+
+DO $$
+DECLARE
+  v_fn_def text;
+  v_user_meta_chairman int;
+  v_app_meta_chairman int;
+  v_user_only_chairman int;
+  v_archetype_using text;
+BEGIN
+  -- (1) fn_is_chairman must read raw_app_meta_data and NOT raw_user_meta_data
+  SELECT pg_get_functiondef(p.oid) INTO v_fn_def
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname='public' AND p.proname='fn_is_chairman';
+
+  IF v_fn_def IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL: public.fn_is_chairman() not found';
+  END IF;
+  IF position('raw_user_meta_data' in v_fn_def) > 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (a): fn_is_chairman still reads raw_user_meta_data (exploit OPEN)';
+  END IF;
+  IF position('raw_app_meta_data' in v_fn_def) = 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (a): fn_is_chairman does not read raw_app_meta_data';
+  END IF;
+
+  -- (2) no lockout: every legitimate (user_metadata) chairman is also an app_metadata chairman
+  SELECT count(*) INTO v_user_meta_chairman FROM auth.users
+    WHERE raw_user_meta_data->>'role' IN ('chairman','admin','owner')
+       OR raw_user_meta_data->'roles' @> '"chairman"'::jsonb;
+  SELECT count(*) INTO v_app_meta_chairman FROM auth.users
+    WHERE raw_app_meta_data->>'role' IN ('chairman','admin','owner')
+       OR raw_app_meta_data->'roles' @> '"chairman"'::jsonb;
+  IF v_app_meta_chairman < v_user_meta_chairman THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (b): app_meta chairman (%) < user_meta chairman (%) — real chairman would be locked out',
+      v_app_meta_chairman, v_user_meta_chairman;
+  END IF;
+
+  -- (3) exploit closed: a user holding chairman ONLY in user_metadata (not app_metadata) is NOT authorized.
+  -- Because fn_is_chairman now reads only app_metadata (asserted in (1)), such an identity is rejected.
+  -- Post-backfill this count should be 0 for legitimate accounts; a FUTURE self-elevator would land here
+  -- and be correctly denied. We assert the function no longer consults user_metadata (done in (1)); this
+  -- count is reported for visibility.
+  SELECT count(*) INTO v_user_only_chairman FROM auth.users
+    WHERE (raw_user_meta_data->>'role' IN ('chairman','admin','owner')
+           OR raw_user_meta_data->'roles' @> '"chairman"'::jsonb)
+      AND NOT (raw_app_meta_data->>'role' IN ('chairman','admin','owner')
+               OR raw_app_meta_data->'roles' @> '"chairman"'::jsonb);
+  RAISE NOTICE 'Info: % identity(ies) hold chairman in user_metadata only (now correctly NON-chairman via app_metadata read)', v_user_only_chairman;
+
+  -- (4) archetype_benchmarks_admin policy (FR-4 fold-in) must read raw_app_meta_data, not raw_user_meta_data
+  SELECT qual INTO v_archetype_using FROM pg_policies
+   WHERE schemaname='public' AND tablename='archetype_benchmarks' AND policyname='archetype_benchmarks_admin';
+  IF v_archetype_using IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (FR-4): archetype_benchmarks_admin policy missing';
+  END IF;
+  IF position('raw_user_meta_data' in v_archetype_using) > 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (FR-4): archetype_benchmarks_admin still reads raw_user_meta_data (exploit OPEN)';
+  END IF;
+  IF position('raw_app_meta_data' in v_archetype_using) = 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE FAIL (FR-4): archetype_benchmarks_admin does not read raw_app_meta_data';
+  END IF;
+
+  RAISE NOTICE 'ALL ACCEPTANCE CHECKS PASSED (fn_is_chairman + archetype policy read app_metadata; % legitimate chairman backfilled; exploit closed)', v_app_meta_chairman;
+END $$;
+
+-- Behavioral end-to-end (manual/CI post-apply; requires an authenticated session, not assertable here):
+--   1. Sign in as a normal (non-chairman) user via the anon key.
+--   2. await supabase.auth.updateUser({ data: { role: 'chairman' } });   -- self-set user_metadata
+--   3. SELECT fn_is_chairman();                                          -- EXPECT: false (exploit closed)
+--   4. SELECT count(*) FROM chairman_decisions;                          -- EXPECT: 0 rows / RLS denied
+--   5. Sign in as a real chairman; SELECT fn_is_chairman();              -- EXPECT: true (no lockout)
+--   6. SELECT count(*) FROM chairman_decisions as the real chairman;     -- EXPECT: rows visible


### PR DESCRIPTION
## Summary
SECURITY-CRITICAL privilege-escalation fix. `fn_is_chairman()` (SECURITY DEFINER) and the RLS policy `archetype_benchmarks_admin` authorize the chairman/admin role off `auth.users.raw_user_meta_data` — the Supabase **user-writable** `user_metadata` surface. Any authenticated user can `supabase.auth.updateUser({data:{role:'chairman'}})` and self-elevate, defeating **21 fn_is_chairman-gated RLS policies across 16 tables** plus the archetype policy. Verified live: both read user_meta; `user_meta_chairman=2`, `app_meta_chairman=0`.

Fix authorizes off `raw_app_meta_data` (service-role-only, not user-writable). All deliverables are **STAGED** (`requires-chairman-apply`, no `@approved-by`) — merging lands files only; **apply is chairman-only / non-delegatable**, ordered backfill-before-flip to avoid chairman lockout.

## Changes (staged migrations, chairman applies in order)
- `20260716_a_backfill_chairman_app_metadata.sql` — idempotent, readback-verified backfill (apply FIRST)
- `20260716_b_fn_is_chairman_read_app_metadata.sql` — `fn_is_chairman` reads `raw_app_meta_data` (contract preserved → 21 policies unchanged)
- `20260716_c_archetype_benchmarks_admin_read_app_metadata.sql` — FR-4 fold-in: 2nd live instance of the same exploit, fixed (shares backfill)
- `tests/security/fn-is-chairman-app-metadata.acceptance.sql` — post-apply acceptance assertions
- `docs/audits/fn-is-chairman-authz-audit.md` — FR-4 authorization audit

## Test plan
- [ ] (chairman, post-apply) Apply `_a_` then `_b_`/`_c_`; run `tests/security/fn-is-chairman-app-metadata.acceptance.sql` → ALL ACCEPTANCE CHECKS PASSED
- [ ] Behavioral: normal user self-sets `user_metadata.role='chairman'` → `fn_is_chairman()` = FALSE (exploit closed); real chairman → TRUE (no lockout)
- Pre-apply verification (executed): fn+policy confirmed reading user_meta; counts 2/0 confirm sequencing hazard

🤖 Generated with [Claude Code](https://claude.com/claude-code)