### PR TITLE
fix(SD-FDBK-ENH-LLM-SUB-AGENT-001): intra-repo explicit_null tolerance (gate + SECURITY writer)

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js
@@ -64,7 +64,11 @@ function pathsAreToplevelCompatible(writerNorm, expectedNorm) {
 }
 
 // Statuses that downgrade to CONDITIONAL_PASS
-const CONDITIONAL_STATUSES = new Set(['skipped', 'empty_probe', 'unresolved_intra']);
+// SD-FDBK-ENH-LLM-SUB-AGENT-001: explicit_null_intra — an explicit-null repo_path on an
+// INTRA-REPO target (EHG/EHG_Engineer) is tolerated (conditional), at parity with the
+// unresolved_intra / cwd_leak / violation intra-repo carve-outs. Cross-repo explicit_null
+// still BLOCKS (stays 'explicit_null').
+const CONDITIONAL_STATUSES = new Set(['skipped', 'empty_probe', 'unresolved_intra', 'explicit_null_intra']);
 
 /**
  * Re-classify a raw row using metadata fields that v_sub_agent_repo_compliance
@@ -119,10 +123,24 @@ function classifyRow(viewRow, rawRow, targetApp) {
     };
   }
   if (viewRow.compliance_status === 'explicit_null') {
+    // SD-FDBK-ENH-LLM-SUB-AGENT-001: intra-repo carve-out, at parity with the cwd_leak /
+    // violation path-normalization overrides and the unresolved_intra split. For an intra-repo
+    // target (EHG/EHG_Engineer, or an unknown/absent target — same tolerance the unresolved
+    // branch applies), a null repo_path is NOT a cross-repo leak — the sub-agent ran in the
+    // single repo — so it degrades to CONDITIONAL_PASS instead of blocking. A cross-repo target
+    // with explicit_null still BLOCKS below. (explicit_null was the one blocking status missing
+    // the carve-out its own header, lines 20-22, documents.)
+    if (!targetApp || INTRA_REPO_TARGETS.has(targetApp)) {
+      return {
+        status: 'explicit_null_intra',
+        reasonCode: REASON_CODES.EXPLICIT_NULL,
+        detail: `metadata.repo_path is null but intra-repo target=${targetApp || 'unknown'} (conditional; not a cross-repo leak)`
+      };
+    }
     return {
       status: 'explicit_null',
       reasonCode: REASON_CODES.EXPLICIT_NULL,
-      detail: 'metadata.repo_path key present but value is null'
+      detail: `metadata.repo_path key present but value is null (cross-repo target=${targetApp})`
     };
   }
   if (viewRow.compliance_status === 'violation') {
@@ -195,7 +213,7 @@ function classifyRow(viewRow, rawRow, targetApp) {
     return {
       status: 'healthy',
       reasonCode: REASON_CODES.HEALTHY,
-      detail: `repo_path matches applications.local_path`
+      detail: 'repo_path matches applications.local_path'
     };
   }
 
@@ -328,7 +346,7 @@ export function createSubAgentRepoResolutionGate(supabase) {
       const buckets = {
         healthy: [], legacy: [], skipped: [], empty_probe: [],
         unresolved: [], unresolved_intra: [], cwd_leak: [],
-        explicit_null: [], violation: [], unknown_application: []
+        explicit_null: [], explicit_null_intra: [], violation: [], unknown_application: []
       };
 
       const blockingDetails = [];

--- a/scripts/prd/sub-agent-orchestrator.js
+++ b/scripts/prd/sub-agent-orchestrator.js
@@ -221,7 +221,14 @@ export async function executeSecurityAnalysis(sdId, sdData) {
 
     console.log('Executing SECURITY sub-agent programmatically...\n');
 
-    const securityResult = await executeSubAgent('SECURITY', sdId, { timeout: 120000 });
+    // SD-FDBK-ENH-LLM-SUB-AGENT-001: thread target_application (mirrors executeDesignAnalysis)
+    // so resolveSubAgentRepo resolves the intra-repo target to applications.local_path and
+    // applySubAgentRepoVerdict stamps a real repo_path — instead of emitting metadata.repo_path=null
+    // (an explicit_null the SUB_AGENT_REPO_RESOLUTION gate hard-blocks for intra-repo SDs).
+    const securityResult = await executeSubAgent('SECURITY', sdId, {
+      timeout: 120000,
+      target_application: sdData.target_application
+    });
     const securityOutput = formatSubAgentResult(securityResult, 'SECURITY');
 
     console.log('Security analysis complete!\n');

--- a/tests/unit/gates/sub-agent-repo-resolution.test.js
+++ b/tests/unit/gates/sub-agent-repo-resolution.test.js
@@ -248,6 +248,53 @@ describe('SUB_AGENT_REPO_RESOLUTION gate', () => {
     expect(result.reasonCode).toBe(REASON_CODES.EXPLICIT_NULL);
   });
 
+  // SD-FDBK-ENH-LLM-SUB-AGENT-001: intra-repo explicit_null carve-out (parity with unresolved_intra).
+  it('CONDITIONAL_PASS (explicit_null_intra) for INTRA-REPO SD (EHG_Engineer) with explicit_null row', async () => {
+    const viewRows = [
+      { id: 'EN1', sub_agent_code: 'SECURITY', phase: 'PLAN', target_application: 'EHG_Engineer',
+        expected_repo_path: '/path/to/EHG_Engineer', metadata_repo_path: null, metadata_repo_resolved: null,
+        executed_from_cwd: null, compliance_status: 'explicit_null' }
+    ];
+    const rawRows = [{ id: 'EN1', sub_agent_code: 'SECURITY', metadata: { repo_path: null } }];
+    const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+
+    const result = await gate.validator({ sd: makeSD({ target_application: 'EHG_Engineer' }) });
+
+    expect(result.passed).toBe(true);                     // no longer hard-blocks
+    expect(result.score).toBeGreaterThanOrEqual(60);      // conditional band
+    expect(JSON.stringify(result)).toContain('explicit_null_intra');
+  });
+
+  it('CONDITIONAL_PASS (explicit_null_intra) for INTRA-REPO SD (EHG) with explicit_null row', async () => {
+    const viewRows = [
+      { id: 'EN2', sub_agent_code: 'SECURITY', phase: 'PLAN', target_application: 'EHG',
+        expected_repo_path: '/path/to/EHG', metadata_repo_path: null, metadata_repo_resolved: null,
+        executed_from_cwd: null, compliance_status: 'explicit_null' }
+    ];
+    const rawRows = [{ id: 'EN2', sub_agent_code: 'SECURITY', metadata: { repo_path: null } }];
+    const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+
+    const result = await gate.validator({ sd: makeSD({ target_application: 'EHG' }) });
+
+    expect(result.passed).toBe(true);
+    expect(JSON.stringify(result)).toContain('explicit_null_intra');
+  });
+
+  it('STILL BLOCKS explicit_null for a genuine cross-repo target (no tolerance regression)', async () => {
+    const viewRows = [
+      { id: 'EN3', sub_agent_code: 'SECURITY', phase: 'PLAN', target_application: 'crongenius',
+        expected_repo_path: '/path/to/crongenius', metadata_repo_path: null, metadata_repo_resolved: null,
+        executed_from_cwd: null, compliance_status: 'explicit_null' }
+    ];
+    const rawRows = [{ id: 'EN3', sub_agent_code: 'SECURITY', metadata: { repo_path: null } }];
+    const gate = createSubAgentRepoResolutionGate(buildSupabase({ viewRows, rawRows }));
+
+    const result = await gate.validator({ sd: makeSD({ target_application: 'crongenius' }) });
+
+    expect(result.passed).toBe(false);
+    expect(result.reasonCode).toBe(REASON_CODES.EXPLICIT_NULL);
+  });
+
   it('CONDITIONAL_PASS in 60-80 band for mixed HEALTHY + SKIPPED', async () => {
     const viewRows = [
       {

--- a/tests/unit/sub-agents/sub-agent-orchestrator-security-repo.test.js
+++ b/tests/unit/sub-agents/sub-agent-orchestrator-security-repo.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-FDBK-ENH-LLM-SUB-AGENT-001 — executeSecurityAnalysis repo threading.
+ *
+ * executeSecurityAnalysis invoked executeSubAgent('SECURITY', sdId, { timeout }) and dropped
+ * sdData.target_application — so SECURITY's resolveSubAgentRepo received undefined and
+ * applySubAgentRepoVerdict stamped metadata.repo_path=null (an explicit_null), which the
+ * SUB_AGENT_REPO_RESOLUTION gate hard-blocked for intra-repo SDs. It must now thread
+ * target_application (mirroring executeDesignAnalysis / FR-2).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const executeSubAgentMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/sub-agent-executor.js', () => ({
+  executeSubAgent: executeSubAgentMock,
+}));
+
+vi.mock('../../../lib/repo-paths.js', () => ({
+  resolveRepoPathDbFirst: vi.fn(),
+}));
+
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({ __client: true })),
+}));
+
+vi.mock('../../../scripts/prd/formatters.js', () => ({
+  formatObjectives: vi.fn(),
+  formatArrayField: vi.fn(),
+  formatRisks: vi.fn(),
+  formatMetadata: vi.fn(),
+}));
+
+const { executeSecurityAnalysis } = await import('../../../scripts/prd/sub-agent-orchestrator.js');
+
+describe('SD-FDBK-ENH-LLM-SUB-AGENT-001 — executeSecurityAnalysis repo threading (FR-2)', () => {
+  beforeEach(() => {
+    executeSubAgentMock.mockReset();
+  });
+
+  it('threads sdData.target_application into executeSubAgent (SECURITY, intra-repo)', async () => {
+    executeSubAgentMock.mockResolvedValue({ verdict: 'PASS', confidence: 100 });
+
+    await executeSecurityAnalysis('SD-X', {
+      sd_type: 'security',
+      scope: 'security review of the auth surface',
+      target_application: 'EHG_Engineer',
+    });
+
+    expect(executeSubAgentMock).toHaveBeenCalledTimes(1);
+    const [code, sdId, opts] = executeSubAgentMock.mock.calls[0];
+    expect(code).toBe('SECURITY');
+    expect(sdId).toBe('SD-X');
+    expect(opts.target_application).toBe('EHG_Engineer'); // the fix: no longer dropped → resolves, not explicit_null
+    expect(opts.timeout).toBe(120000);
+  });
+
+  it('threads target_application for an auth-scoped SD (needsSecurity via scope keyword)', async () => {
+    executeSubAgentMock.mockResolvedValue({ verdict: 'PASS' });
+
+    await executeSecurityAnalysis('SD-Y', {
+      sd_type: 'feature',
+      scope: 'add an auth flow',
+      target_application: 'EHG',
+    });
+
+    expect(executeSubAgentMock).toHaveBeenCalledTimes(1);
+    expect(executeSubAgentMock.mock.calls[0][2].target_application).toBe('EHG');
+  });
+
+  it('skips SECURITY (returns null, no invocation) when no security signals are present', async () => {
+    const out = await executeSecurityAnalysis('SD-Z', {
+      sd_type: 'infrastructure',
+      scope: 'gate validator refactor',
+      description: 'classifier tweak',
+      target_application: 'EHG_Engineer',
+    });
+
+    expect(out).toBeNull();
+    expect(executeSubAgentMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
The PLAN-TO-EXEC `SUB_AGENT_REPO_RESOLUTION` gate hard-blocked an intra-repo sub-agent whose metadata carried an explicit-null `repo_path`, contradicting its own documented intra-repo tolerance. Two root causes (verified vs origin/main), both fixed (defense-in-depth), **pure-JS, no DDL**:

- **RC1 — WRITER**: `scripts/prd/sub-agent-orchestrator.js` `executeSecurityAnalysis` dropped `sdData.target_application` when calling `executeSubAgent('SECURITY', …)`, so SECURITY's `resolveSubAgentRepo` received `undefined` and `applySubAgentRepoVerdict` stamped `repo_path=null` (explicit_null). Now threads `target_application`, mirroring `executeDesignAnalysis`.
- **RC2 — GATE**: `sub-agent-repo-resolution.js` `classifyRow` returned the blocking `explicit_null` with no intra-repo carve-out (unlike `cwd_leak`/`violation`/`unresolved_intra`). Added an `explicit_null_intra` CONDITIONAL status for `EHG`/`EHG_Engineer` (registered in the buckets initializer + `CONDITIONAL_STATUSES`; **not** `BLOCKING_STATUSES`). A genuine cross-repo `explicit_null` **still BLOCKS**.

## Test plan
- [x] 6 new tests (3 gate carve-out incl. cross-repo-still-blocks + no-throw aggregation; 3 SECURITY writer threading)
- [x] 30/30 gate/orchestrator/regression tests pass; existing tests unchanged
- [x] Prospective testing-agent review — PASS (evidence 165b0c83)

Follow-up filed: `sync-deliverables-from-git.js` resolves `target_application=EHG_Engineer` to the `ehg` repo path (repo-resolution bug surfaced during this SD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)