### PR TITLE
fix(SD-LEO-INFRA-GOV-TABLE-WRITE-GRANT-REVOKE-001): stage defense-in-depth REVOKE of sensitive-table write grants (chairman-apply)

### DIFF
--- a/database/migrations/20260716_revoke_anon_authenticated_write_grants_sensitive_tables.sql
+++ b/database/migrations/20260716_revoke_anon_authenticated_write_grants_sensitive_tables.sql
@@ -1,0 +1,45 @@
+-- Defense-in-depth: REVOKE redundant anon/authenticated write grants on chairman-authority + kill-switch tables.
+-- SD-LEO-INFRA-GOV-TABLE-WRITE-GRANT-REVOKE-001 (F7 security, coordinator-directed).
+--
+-- WHY: all 6 tables carry the Supabase-default base grant giving anon AND authenticated FULL write+truncate
+-- (INSERT/UPDATE/DELETE/TRUNCATE) at the GRANT layer (verified live via pg_class.relacl 2026-07-16). RLS is
+-- ENABLED on all 6 and is the SOLE write barrier — a single RLS misconfig/policy bug would expose these to
+-- anon writes. This adds a SECOND layer: the GRANT layer ALSO denies. RLS is unchanged. service_role (the
+-- only legitimate writer, which also BYPASSes RLS) is UNTOUCHED. Complements SD-LEO-INFRA-FN-IS-CHAIRMAN-
+-- APP-METADATA-001 (identity layer); this SD hardens the GRANT layer.
+--
+-- NON-BREAKING (verified live): the 5 FR-1 tables have service_role-only / deny-for-public write RLS (no
+-- anon/authenticated permissive write policy), so revoking their anon/authenticated write grants changes
+-- nothing a legitimate caller could do. chairman_directives is the ONE exception (FR-2) — it has a
+-- legitimate authenticated write path (chairman_directives_insert / _update, WITH CHECK fn_is_chairman());
+-- because GRANT is checked BEFORE RLS, its authenticated INSERT+UPDATE grants are KEPT.
+--
+-- IDEMPOTENT: REVOKE of an absent privilege is a harmless no-op. Order-independent; no dependency on the
+-- fn_is_chairman migration (independent layer).
+--
+-- ROLLBACK (chairman-gated): re-GRANT the exact revoked privileges per table if a legitimate anon/
+-- authenticated write path is later discovered (none exists today).
+--
+-- STAGED, NOT YET APPROVED FOR APPLY. APPLY IS CHAIRMAN-ONLY / NON-DELEGATABLE (REVOKE = access-control /
+-- permission change, fail-closed, outside the Adam @delegated-by additive tier). Intentionally omits the
+-- @approved-by tag until the chairman explicitly applies it.
+--
+-- requires-chairman-apply
+
+-- FR-1: tables with NO legitimate non-service_role writer — revoke all write from anon AND authenticated.
+-- (SELECT intentionally kept; write-hardening only.)
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.protocol_constitution  FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.leo_feature_flags      FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.eva_vision_documents   FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.chairman_decisions     FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.ventures_kill_log      FROM anon, authenticated;
+
+-- FR-2: chairman_directives SPECIAL CASE — it HAS a legitimate authenticated write path
+-- (chairman_directives_insert / _update, WITH CHECK fn_is_chairman()). Do NOT revoke authenticated
+-- INSERT/UPDATE (GRANT is checked before RLS; a blanket revoke would break the chairman app write path).
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.chairman_directives FROM anon;            -- anon: zero legit access
+REVOKE DELETE, TRUNCATE               ON public.chairman_directives FROM authenticated;     -- no legit authenticated delete
+-- KEEP: authenticated INSERT, UPDATE on chairman_directives (RLS-gated by fn_is_chairman()).
+
+COMMENT ON TABLE public.chairman_directives IS
+  'Write grants hardened by SD-LEO-INFRA-GOV-TABLE-WRITE-GRANT-REVOKE-001: anon has no write; authenticated keeps only INSERT+UPDATE (RLS fn_is_chairman()-gated); DELETE/TRUNCATE revoked. service_role unaffected.';

--- a/docs/audits/sensitive-table-write-grant-audit.md
+++ b/docs/audits/sensitive-table-write-grant-audit.md
@@ -1,0 +1,57 @@
+# Sensitive-table write-grant audit (defense-in-depth REVOKE)
+
+**SD:** SD-LEO-INFRA-GOV-TABLE-WRITE-GRANT-REVOKE-001 (F7 security, coordinator-directed)
+**Date:** 2026-07-16
+**Class:** GRANT-layer over-permissioning — anon/authenticated hold redundant write grants; RLS is the sole barrier.
+
+## Finding (live-grounded, pg_class.relacl 2026-07-16)
+
+All 6 chairman-authority / kill-switch tables carry the Supabase-default base grant
+`anon = arwdDxtm` **and** `authenticated = arwdDxtm` — i.e. both roles hold **INSERT, UPDATE,
+DELETE, TRUNCATE** (plus SELECT/REFERENCES/TRIGGER/MAINTAIN) at the GRANT layer. **RLS is ENABLED on
+all 6** (relrowsecurity=true) and is the **sole** write barrier. A single RLS misconfig/policy bug
+would expose these tables to anon writes.
+
+| Table | anon write | authenticated write | write RLS policy |
+|-------|-----------|---------------------|------------------|
+| protocol_constitution | I/U/D/T | I/U/D/T | deny-for-public (no_update/no_delete USING false); service_role bypass |
+| leo_feature_flags | I/U/D/T | I/U/D/T | service_role-only (leo_feature_flags_service_role_all) |
+| eva_vision_documents | I/U/D/T | I/U/D/T | service_role-only (eva_vision_docs_service_role_all) |
+| chairman_decisions | I/U/D/T | I/U/D/T | service_role-only (service_role_all_chairman_decisions) |
+| ventures_kill_log | I/U/D/T | I/U/D/T | no permissive write policy → deny (service_role bypass) |
+| chairman_directives | I/U/D/T | I/U/D/T | service_role-only + **authenticated INSERT/UPDATE WITH CHECK fn_is_chairman()** |
+
+## Fix — table-specific REVOKE (belt-and-suspenders; RLS unchanged; service_role untouched)
+
+- **FR-1** (protocol_constitution, leo_feature_flags, eva_vision_documents, chairman_decisions, ventures_kill_log):
+  `REVOKE INSERT, UPDATE, DELETE, TRUNCATE FROM anon, authenticated`. **Non-breaking** — their write RLS is
+  service_role-only / deny-for-public, so no legitimate anon/authenticated write path exists. SELECT kept.
+- **FR-2** chairman_directives: it HAS a legitimate authenticated write path (`chairman_directives_insert` /
+  `_update`, WITH CHECK `fn_is_chairman()`). GRANT is checked **before** RLS, so a blanket revoke would break
+  the chairman app. Instead: `REVOKE INSERT,UPDATE,DELETE,TRUNCATE FROM anon`;
+  `REVOKE DELETE,TRUNCATE FROM authenticated`; **KEEP** authenticated INSERT,UPDATE.
+
+## FR-3 — dependency cross-reference
+
+chairman_directives (and every `fn_is_chairman`-gated write) inherits the `fn_is_chairman`
+user_metadata privilege-escalation closed by **SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001**
+(completed this session, staged). That SD hardens the **identity** layer (authorize off
+`raw_app_meta_data`); this SD hardens the **GRANT** layer. Together they close the surface:
+a self-elevated user still can't reach chairman_directives (identity), and an RLS bypass still
+can't write the 5 no-writer tables (grant). The two migrations are **independent** — either apply
+order is safe.
+
+## FR-4 — standing guard
+
+`tests/security/sensitive-table-grants-guard.sql` RAISEs if any anon/authenticated write grant
+(INSERT/UPDATE/DELETE/TRUNCATE) exists on the 6 tables except the chairman_directives authenticated
+INSERT/UPDATE carve-out — catching a future migration or Supabase default re-grant. **Pre-apply it
+correctly RAISEs** (all 6 tables currently fully write-granted); post-apply it PASSES.
+
+## Apply / rollback
+
+- **Apply authority:** CHAIRMAN-ONLY / non-delegatable (REVOKE = access-control / permission change,
+  fail-closed). Migration is STAGED (`requires-chairman-apply`, no `@approved-by`). Build worker stages;
+  chairman applies.
+- **Rollback (chairman-gated):** re-GRANT the exact revoked privileges per table if a legitimate
+  anon/authenticated write path is ever found (none exists today). service_role is never touched.

--- a/tests/security/sensitive-table-grants-guard.sql
+++ b/tests/security/sensitive-table-grants-guard.sql
@@ -1,0 +1,40 @@
+-- FR-4 STANDING GUARD — SD-LEO-INFRA-GOV-TABLE-WRITE-GRANT-REVOKE-001.
+--
+-- Asserts the 6 chairman-authority / kill-switch tables carry NO anon/authenticated write grant
+-- (INSERT/UPDATE/DELETE/TRUNCATE) in pg_class.relacl, EXCEPT the ONE legitimate carve-out:
+-- chairman_directives authenticated INSERT + UPDATE (the RLS fn_is_chairman()-gated chairman path).
+--
+-- RAISEs EXCEPTION on any violation, so a future migration or a Supabase default-privilege re-grant
+-- that silently re-broadens the write surface fails this guard. Intended to run:
+--   (a) POST-APPLY once, to confirm the REVOKE migration achieved the target state; and
+--   (b) as a recurring CI/probe check thereafter.
+--
+-- NOTE: run PRE-APPLY it will (correctly) RAISE — the current state has all 6 tables fully write-granted
+-- to anon + authenticated; that IS the vulnerability this SD closes.
+
+DO $$
+DECLARE
+  v_violations text;
+BEGIN
+  SELECT string_agg(format('%s:%s:%s', tbl, grantee, priv), ', ' ORDER BY tbl, grantee, priv)
+  INTO v_violations
+  FROM (
+    SELECT c.relname AS tbl, g.grantee::regrole::text AS grantee, g.privilege_type AS priv
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    CROSS JOIN LATERAL aclexplode(c.relacl) AS g
+    WHERE c.relname IN ('protocol_constitution','leo_feature_flags','eva_vision_documents',
+                        'chairman_decisions','chairman_directives','ventures_kill_log')
+      AND g.grantee::regrole::text IN ('anon','authenticated')
+      AND g.privilege_type IN ('INSERT','UPDATE','DELETE','TRUNCATE')
+      -- Carve-out: chairman_directives authenticated INSERT+UPDATE is the ONE legitimate exception.
+      AND NOT (c.relname = 'chairman_directives'
+               AND g.grantee::regrole::text = 'authenticated'
+               AND g.privilege_type IN ('INSERT','UPDATE'))
+  ) v;
+
+  IF v_violations IS NOT NULL THEN
+    RAISE EXCEPTION 'FR-4 GUARD FAILED — sensitive-table write grant present/re-broadened: %', v_violations;
+  END IF;
+  RAISE NOTICE 'FR-4 GUARD PASSED — no anon/authenticated write grant on the 6 sensitive tables (except chairman_directives authenticated INSERT/UPDATE carve-out).';
+END $$;


### PR DESCRIPTION
## Summary
F7 defense-in-depth security. All 6 chairman-authority/kill-switch tables grant **anon AND authenticated FULL write+truncate** at the GRANT layer (verified live: **46 write-grant violations**); RLS (enabled) is the **sole** write barrier — one RLS misconfig would expose anon writes. Adds a second layer: the GRANT layer also denies. STAGED, **chairman-apply only** (REVOKE = access-control); `service_role` untouched.

## Changes (staged migration)
- **FR-1** (protocol_constitution, leo_feature_flags, eva_vision_documents, chairman_decisions, ventures_kill_log): `REVOKE INSERT,UPDATE,DELETE,TRUNCATE` from anon+authenticated — **non-breaking** (write RLS is service_role-only/deny; SELECT kept).
- **FR-2** chairman_directives: `REVOKE` all-write from anon + DELETE/TRUNCATE from authenticated; **KEEP** authenticated INSERT/UPDATE (legit RLS `fn_is_chairman()` path — GRANT is checked before RLS).
- **FR-4** `tests/security/sensitive-table-grants-guard.sql` — standing guard, RAISEs on re-broadened grants (pre-apply detects the 46 violations).
- **FR-3** audit artifact; complements SD-LEO-INFRA-FN-IS-CHAIRMAN-APP-METADATA-001 (identity layer).

## Test plan
- [ ] (chairman, post-apply) apply migration, run `sensitive-table-grants-guard.sql` → 46 violations → **0** (GUARD PASSED).
- [ ] anon write → denied at GRANT layer; authenticated chairman INSERT to chairman_directives → succeeds; authenticated DELETE → denied; service_role writes → unaffected.
- Pre-apply verification (executed): 46 anon/authenticated write-grant violations across all 6 tables confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)