### PR TITLE
docs(QF-20260716-091): land Venture Foresight Board spec to main (durability)

### DIFF
--- a/docs/design/ehg-venture-foresight-board-spec.md
+++ b/docs/design/ehg-venture-foresight-board-spec.md
@@ -1,0 +1,1327 @@
+# EHG Venture Foresight Board — Product & Technical Specification
+
+> PROVENANCE: chairman-authored spec, evaluated + preserved by Solomon 2026-07-16 (Mode-C commission).
+> Source of record: 'C:/Users/rickf/Dropbox/_EHG/20_research/Futurist Board/Futurist Board.docx' (text extracted verbatim; formatting flattened).
+> DISPOSITION (chairman-ratified 2026-07-16): Phase-1 build DEFERRED — trigger = v3 selection cycle opening (Alt-Text first-dollar or kill).
+> CONSOLIDATION CONSTRAINTS (binding at sourcing): (1) Signal-Scan mode == the ratified Market-Signal Scanner (one signal system); (2) §17 model routing consumes model_capability_reference (eval SD); (3) Venture-Screen mode extends SD-LEO-INFRA-VENTURE-SELECTION-DEMAND-001's shipped stage. Supersedes deferred stub SD-REFILL-00X2A49J.
+
+EHG Venture Foresight Board
+Product and Technical Specification
+Document status: Initial functional specification
+Primary owner: EHG
+Final decision authority: Rick
+System orchestrator: EVA
+Primary use case: Discovering, evaluating, prioritizing, and monitoring future-oriented venture opportunities
+---
+1. Executive Summary
+EHG should incorporate a structured Venture Foresight Board into its venture-creation process.
+The board will not consist of actual human advisors. Instead, it will use documented public thinking from selected futurists, strategists, researchers, and technology analysts to create a set of distinct analytical lenses.
+The system will contain five primary councils:
+1. Frontier Capability Council
+2. Human Transition Council
+3. Strategic Foresight Council
+4. Exponential Systems Council
+5. Market Reality Council
+Each council will contain:
+- Three specialist perspectives
+- One adjudicating perspective
+- A structured evidence and disagreement process
+- A standardized council output
+The five council outputs will be synthesized by EVA into an EHG Venture Decision Dossier.
+Rick will retain final authority over:
+- Venture incubation
+- Capital allocation
+- Experiment approval
+- Launch decisions
+- Scaling decisions
+- Venture termination
+The purpose of the system is not to predict the future with certainty. Its purpose is to improve the quality of EHG venture decisions by examining each opportunity through multiple complementary and sometimes conflicting perspectives.
+---
+2. Primary Objective
+The Venture Foresight Board should help EHG answer:
+«What emerging changes are likely to create valuable customer problems, and which of those problems is EHG unusually well positioned to solve?»
+The system should identify opportunities at the intersection of:
+- Emerging technical capability
+- Human or organizational need
+- Strategic resilience
+- Economic and institutional timing
+- Commercial viability
+- EHG-specific operating advantage
+The system should produce actions, not merely observations.
+Every meaningful analysis should conclude with one of the following recommendations:
+- Reject
+- Monitor
+- Research
+- Build an option
+- Prototype
+- Validate demand
+- Incubate
+- Launch
+- Scale
+- Pause
+- Terminate
+---
+3. Non-Goals
+The system should not:
+- Claim that the named individuals work for or endorse EHG
+- Impersonate the individuals
+- Fabricate opinions that cannot be grounded in their public work
+- Treat futurist predictions as facts
+- Automatically approve or fund ventures
+- Replace Rick’s judgment
+- Average all opinions into artificial consensus
+- Run twenty expensive agent analyses for every minor idea
+- generate generic technology-news summaries without EHG implications
+- Recommend ventures solely because a technology is interesting
+- Treat high market growth as proof of product-market fit
+- Hide minority opinions or material disagreement
+Internally, these agents should be described as:
+«Public-thought-informed analytical perspectives»
+Examples:
+- Wissner-Gross-informed capability analysis
+- Bovell-informed human-transition analysis
+- Webb-informed scenario analysis
+The system should never imply that a real-world person authored an EHG recommendation unless that person actually did so.
+---
+4. Core Design Principles
+4.1 Evidence before personality
+The system should not attempt to mimic speech patterns or personal mannerisms.
+It should extract and apply:
+- Recurring arguments
+- Analytical frameworks
+- Forecasts
+- Assumptions
+- Areas of expertise
+- Known cautions
+- Areas of disagreement
+- Historical forecast accuracy
+The value should come from the quality of the analytical lens, not from simulated personality.
+4.2 Facts, interpretations, and forecasts must remain separate
+Every important statement should be classified as one of:
+- Verified observation
+- Strong inference
+- Weak signal
+- Forecast
+- Speculation
+- Advocacy
+- Promotional claim
+- Contradicted claim
+4.3 Dissent must be preserved
+An adjudicator may issue a final council conclusion, but the system must retain:
+- Majority view
+- Minority view
+- Key disagreement
+- Underlying assumptions
+- Conditions under which the minority view could prove correct
+4.4 Confidence must be explicit
+Every conclusion should include:
+- Confidence percentage or confidence band
+- Relevant time horizon
+- Evidence strength
+- Major assumptions
+- Events that would increase or decrease confidence
+4.5 EHG relevance is mandatory
+A source item should not enter the high-priority workflow merely because it is important in general.
+It must have a plausible implication for one or more of:
+- Venture discovery
+- Venture prioritization
+- Agent architecture
+- Shared EHG infrastructure
+- Distribution
+- Customer behavior
+- Revenue models
+- Cost structures
+- Regulatory risk
+- Competitive positioning
+- Rick’s attention
+- EHG’s portfolio strategy
+4.6 Prefer reversible experiments
+The system should generally recommend the smallest experiment that materially reduces uncertainty.
+It should avoid immediately recommending full venture builds when the same question could be answered through:
+- Interviews
+- Landing pages
+- Concierge pilots
+- Pre-sales
+- Workflow simulations
+- Prototype testing
+- Data collection
+- Small paid campaigns
+- Manual service delivery
+- Partner validation
+---
+5. Board Structure
+5.1 Frontier Capability Council
+Purpose
+Determine what has recently become technically possible, reliable, or economical enough to enable new ventures.
+Specialist perspectives
+- Jack Clark
+- Nathan Benaich
+- Rodney Brooks
+Adjudicator
+- Alex Wissner-Gross
+Primary questions
+- What new capability has emerged?
+- What evidence shows that it works?
+- Is it available in production or only in a demonstration?
+- What does it currently cost?
+- What reliability limitations remain?
+- What is likely to improve within 12, 24, and 60 months?
+- Which capabilities are becoming commodities?
+- What new venture categories could this capability enable?
+- What is technically overhyped?
+Required output
+Technical Opportunity Brief
+---
+5.2 Human Transition Council
+Purpose
+Identify new customer needs, anxieties, behaviors, skills gaps, trust gaps, and institutional problems created by technological change.
+Specialist perspectives
+- Marina Gorbis
+- Heather McGowan
+- Rumman Chowdhury
+Adjudicator
+- Sínead Bovell
+Primary questions
+- Who is affected by the change?
+- Which tasks, roles, or behaviors are changing?
+- What new pain is being created?
+- What old pain is becoming easier to solve?
+- Who experiences the problem?
+- Who pays to solve it?
+- What trust or adoption barriers exist?
+- What new educational, supervisory, or governance needs emerge?
+- Could the proposed solution reduce human agency or create harmful dependency?
+Required output
+Emerging Human Need Brief
+---
+5.3 Strategic Foresight Council
+Purpose
+Determine whether a venture remains attractive across multiple plausible futures.
+Specialist perspectives
+- Peter Schwartz
+- Sohail Inayatullah
+- Jamais Cascio
+Adjudicator
+- Amy Webb
+Primary questions
+- What assumptions must be true?
+- What critical uncertainties could change the outcome?
+- What future scenarios should EHG consider?
+- Does the venture survive when technology improves faster than expected?
+- Does it survive when adoption is slower?
+- Does it survive regulatory restrictions?
+- Does it survive provider consolidation or commoditization?
+- What commitments are reversible?
+- What events should cause EHG to accelerate, pause, or exit?
+Required output
+Venture Resilience Brief
+---
+5.4 Exponential Systems Council
+Purpose
+Determine whether technology, costs, infrastructure, policy, geography, and institutional readiness are aligned sufficiently for a venture.
+Specialist perspectives
+- Carlota Perez
+- Tony Seba
+- Parag Khanna
+Adjudicator
+- Azeem Azhar
+Primary questions
+- Which cost curves are changing?
+- Which technologies are converging?
+- What infrastructure is required?
+- What geographic or jurisdictional differences matter?
+- What regulatory conditions affect the opportunity?
+- Is the market too early, ready, rapidly scaling, or becoming commoditized?
+- Are incumbents structurally disadvantaged?
+- What supply-chain, compute, energy, or capital dependencies exist?
+- Is a temporary subsidy being mistaken for sustainable economics?
+Required output
+Systems Timing Brief
+---
+5.5 Market Reality Council
+Purpose
+Determine whether a future-oriented opportunity can become a practical, defensible, distributable, and profitable EHG venture.
+Specialist perspectives
+- Ben Thompson
+- Horace Dediu
+- Rita McGrath
+Adjudicator
+- Benedict Evans
+Primary questions
+- Who is the initial customer?
+- Who is the buyer?
+- Who controls the budget?
+- How severe and frequent is the problem?
+- Why would the customer switch?
+- How will EHG reach the customer?
+- Is the sales motion compatible with an AI-agent-operated company?
+- What creates retention?
+- What creates defensibility?
+- Is AI the product, an enabling capability, or a replaceable feature?
+- What prevents a larger platform from copying the product?
+- Why should EHG enter now?
+Required output
+Commercial Viability Brief
+---
+6. Final Authority and System Roles
+6.1 Specialist agents
+Specialist agents should:
+- Review relevant evidence
+- Apply their assigned analytical framework
+- Produce structured findings
+- Identify assumptions
+- State confidence
+- Highlight risks
+- Recommend EHG implications
+They should not:
+- Make final venture decisions
+- Conceal uncertainty
+- Invent a source position
+- Speak as the real individual
+- Use charisma or writing style as evidence
+6.2 Council adjudicators
+Each adjudicator should:
+1. Compare the three specialist analyses
+2. Identify areas of agreement
+3. Identify material disagreement
+4. Evaluate evidence quality
+5. Expose hidden assumptions
+6. Preserve minority opinions
+7. Assign confidence
+8. Translate the findings into EHG actions
+9. Produce the council’s final brief
+The adjudicator should not merely count votes.
+A two-to-one specialist split does not automatically determine the final answer. Evidence quality and relevance matter more than numerical agreement.
+6.3 EVA
+EVA should act as:
+- Workflow orchestrator
+- Evidence coordinator
+- Cross-council synthesizer
+- Conflict detector
+- Portfolio-context provider
+- Recommendation formatter
+- Chairman-attention manager
+EVA should not independently override Rick’s capital-allocation authority.
+6.4 Rick
+Rick remains:
+- Final portfolio authority
+- Final capital allocator
+- Final approval authority for launch and scale decisions
+- Owner of EHG’s risk tolerance
+- Owner of EHG’s strategic direction
+- Final arbiter when the councils disagree
+---
+7. Recommended System Architecture
+The Venture Foresight Board should be implemented as a reusable EHG platform service rather than embedded separately inside every venture.
+Suggested service name:
+«EHG Foresight and Venture Intelligence Service»
+The service should be callable from:
+- EVA
+- EHG ideation workflows
+- EHG’s stage-gate process
+- Portfolio reviews
+- Venture proposal workflows
+- Strategic planning workflows
+- Model and infrastructure planning
+- Future recurring monitoring processes
+7.1 Major components
+A. Source Ingestion Layer
+Collects public materials associated with the selected perspectives.
+Potential source types:
+- Articles
+- Newsletters
+- Interviews
+- Podcasts
+- Conference talks
+- Books
+- Public social-media posts
+- Research publications
+- Annual reports
+- Forecast reports
+- Recorded predictions
+Each source should include:
+- Source URL
+- Source title
+- Author
+- Publication date
+- Retrieval date
+- Source type
+- Relevant lens
+- Full text or transcript, when legally permitted
+- Extracted claims
+- Citation locations
+- Reliability metadata
+B. Doctrine Extraction Layer
+Transforms raw public material into structured perspective records.
+Examples of extracted doctrine:
+- Recurring themes
+- Preferred analytical frameworks
+- Claims about technological direction
+- Forecasts
+- Assumptions
+- Areas of skepticism
+- Typical time horizons
+- Commercial principles
+- Ethical cautions
+- Past prediction outcomes
+C. Evidence Store
+Stores factual evidence independently from the futurist doctrine.
+This is important because the system should not validate a claim merely because a futurist stated it.
+Evidence should be collected from:
+- Primary research
+- Official company announcements
+- Government data
+- Regulatory publications
+- Industry reports
+- Financial reports
+- Customer research
+- EHG internal evidence
+D. Council Orchestrator
+Determines:
+- Which operating depth to use
+- Which councils to invoke
+- Which specialists are relevant
+- What evidence each agent receives
+- How results are validated
+- When adjudication begins
+- When Rick’s attention is required
+E. Venture Intelligence Store
+Stores:
+- Venture candidates
+- Venture theses
+- Council assessments
+- Scores
+- Assumptions
+- Experiments
+- Decisions
+- Kill criteria
+- Monitoring triggers
+- Forecast outcomes
+- Portfolio dependencies
+F. Chairman Interface
+Presents concise decision-ready information to Rick.
+The interface should emphasize:
+- What changed
+- Why it matters
+- Council agreement
+- Material disagreement
+- Recommended decision
+- Cost of the next experiment
+- Consequence of waiting
+- Reversibility
+- Required Chairman decision
+---
+8. Suggested Data Model
+The exact database technology may vary, but the following entities should exist.
+8.1 PerspectiveProfile
+Represents one public-thought-informed analytical perspective.
+Suggested fields:
+- perspective_id
+- person_name
+- council_id
+- role_type
+- expertise_domains
+- analytical_frameworks
+- recurring_themes
+- known_cautions
+- known_biases
+- source_count
+- doctrine_version
+- last_refreshed_at
+- confidence_in_profile
+- active_status
+"role_type" values:
+- specialist
+- adjudicator
+- governance_reviewer
+- external_scout
+8.2 Council
+Suggested fields:
+- council_id
+- council_name
+- purpose
+- adjudicator_perspective_id
+- specialist_perspective_ids
+- required_output_type
+- default_prompt_version
+- status
+8.3 SourceArtifact
+Suggested fields:
+- source_id
+- author
+- title
+- publication_date
+- retrieval_date
+- source_type
+- source_url
+- full_text_location
+- transcript_location
+- citation_metadata
+- rights_or_usage_notes
+- content_hash
+- superseded_status
+8.4 DoctrineClaim
+Suggested fields:
+- doctrine_claim_id
+- perspective_id
+- source_id
+- claim_text
+- claim_type
+- topic
+- time_horizon
+- confidence
+- source_quote_or_paraphrase
+- citation_location
+- valid_from
+- valid_to
+- superseded_by
+- contradiction_status
+"claim_type" values:
+- observation
+- interpretation
+- forecast
+- framework
+- warning
+- recommendation
+- speculation
+8.5 ForecastRecord
+Suggested fields:
+- forecast_id
+- perspective_id
+- forecast_text
+- forecast_date
+- forecast_target_date
+- probability
+- measurable_condition
+- source_id
+- current_status
+- outcome_score
+- adjudication_notes
+"current_status" values:
+- open
+- confirmed
+- partially_confirmed
+- premature
+- contradicted
+- unresolved
+8.6 Signal
+Suggested fields:
+- signal_id
+- title
+- description
+- detected_at
+- source_ids
+- affected_domains
+- evidence_strength
+- novelty_score
+- velocity_score
+- EHG_relevance_score
+- urgency
+- status
+8.7 VentureCandidate
+Suggested fields:
+- venture_candidate_id
+- venture_name
+- venture_thesis
+- target_customer
+- problem_statement
+- proposed_solution
+- revenue_hypothesis
+- distribution_hypothesis
+- EHG_advantage_hypothesis
+- originating_signal_ids
+- current_stage
+- owner_agent
+- created_at
+- updated_at
+8.8 SpecialistAssessment
+Suggested fields:
+- assessment_id
+- venture_candidate_id
+- council_id
+- perspective_id
+- evidence_reviewed
+- findings
+- opportunities
+- risks
+- assumptions
+- confidence
+- recommended_action
+- dissent_flags
+- created_at
+- prompt_version
+- model_version
+8.9 CouncilAdjudication
+Suggested fields:
+- adjudication_id
+- venture_candidate_id
+- council_id
+- adjudicator_perspective_id
+- consensus_summary
+- disagreement_summary
+- minority_view
+- evidence_quality
+- council_confidence
+- recommendation
+- recommended_experiments
+- monitoring_triggers
+- kill_conditions
+- created_at
+8.10 VentureDecisionDossier
+Suggested fields:
+- dossier_id
+- venture_candidate_id
+- council_adjudication_ids
+- overall_score
+- overall_confidence
+- key_assumptions
+- major_disagreements
+- recommended_posture
+- next_experiment
+- experiment_budget
+- expected_information_gain
+- cost_of_waiting
+- reversibility
+- Rick_decision_required
+- generated_at
+8.11 PortfolioDecision
+Suggested fields:
+- decision_id
+- venture_candidate_id
+- dossier_id
+- decision
+- decision_maker
+- decision_date
+- rationale
+- approved_budget
+- review_date
+- kill_criteria
+- monitoring_requirements
+8.12 Experiment
+Suggested fields:
+- experiment_id
+- venture_candidate_id
+- hypothesis
+- method
+- cost
+- start_date
+- end_date
+- success_metric
+- failure_metric
+- result
+- interpretation
+- next_action
+---
+9. Operating Modes
+The system should support three levels of analysis.
+9.1 Signal Scan
+Purpose
+Rapidly review emerging developments and determine whether they deserve further analysis.
+Participants
+- Five council adjudicators
+- Stored specialist doctrine
+- Current evidence summaries
+Frequency
+- Daily or weekly
+- Event-driven when major signals appear
+Output
+- Signal summary
+- EHG relevance
+- Initial opportunity areas
+- Recommended disposition
+Disposition options:
+- Ignore
+- Archive
+- Monitor
+- Research
+- Create venture candidate
+This mode should be inexpensive and fast.
+---
+9.2 Venture Screen
+Purpose
+Evaluate an identified venture candidate before meaningful engineering effort begins.
+Participants
+- Five adjudicators
+- Selected specialists based on relevance
+- EHG portfolio context
+- Market and technical evidence
+Output
+- Initial five-lens analysis
+- Venture scorecard
+- Key assumptions
+- Major risks
+- Recommended validation experiment
+- Decision whether to proceed to full-board review
+This should be the default evaluation mode for promising ideas.
+---
+9.3 Full Board Review
+Purpose
+Perform deep analysis before incubation, significant investment, launch, or scale.
+Participants
+- All fifteen specialists
+- All five adjudicators
+- EVA
+- Relevant EHG operational agents
+- Internal venture evidence
+- External research
+Output
+- Complete Venture Decision Dossier
+- Council-level findings
+- Dissent report
+- Scenario analysis
+- Commercial analysis
+- Recommended operating model
+- Experiment or launch plan
+- Kill criteria
+- Monitoring plan
+- Required Rick decision
+The full-board mode should be reserved for consequential decisions because it will require greater cost and latency.
+---
+10. Standard Workflow
+Step 1: Detect a signal
+A signal may originate from:
+- Public technology developments
+- Futurist publications
+- Customer conversations
+- EHG venture activity
+- Competitor behavior
+- Regulatory changes
+- Cost-curve changes
+- New model capabilities
+- New infrastructure
+- Rick’s ideas
+- EVA’s observations
+Step 2: Determine novelty and relevance
+EVA should evaluate:
+- Is the signal actually new?
+- Does it alter an existing assumption?
+- Is it relevant to EHG?
+- Does it create a new problem or opportunity?
+- Is it likely to persist?
+- Does it justify additional analysis?
+Step 3: Create or update a venture candidate
+A venture candidate should contain at minimum:
+- Customer
+- Problem
+- Proposed value
+- Why now
+- Why EHG
+- Revenue hypothesis
+- Distribution hypothesis
+- Key assumptions
+Step 4: Run the councils
+Recommended sequence:
+1. Frontier Capability
+2. Human Transition
+3. Strategic Foresight
+4. Exponential Systems
+5. Market Reality
+The later councils should have access to relevant conclusions from earlier councils, while still being instructed to challenge them.
+Step 5: Perform adjudication within each council
+The adjudicator should produce:
+- Consensus
+- Dissent
+- Evidence judgment
+- Confidence
+- EHG implications
+- Recommended action
+Step 6: EVA performs cross-council synthesis
+EVA should identify:
+- Agreements across councils
+- Contradictions across councils
+- Assumptions affecting multiple councils
+- Dependencies
+- Potential portfolio synergies
+- Reusable EHG capabilities
+- Opportunity costs
+- Rick decisions required
+Step 7: Generate Venture Decision Dossier
+The dossier should be concise enough for executive review, while allowing drill-down into every source, specialist assessment, and council adjudication.
+Step 8: Rick makes the portfolio decision
+Rick selects:
+- Reject
+- Monitor
+- Research
+- Prototype
+- Validate
+- Incubate
+- Launch
+- Scale
+- Pause
+- Terminate
+Step 9: Create experiments and monitoring triggers
+Approved venture candidates should receive:
+- Next experiment
+- Owner
+- Budget
+- Deadline
+- Success metric
+- Failure metric
+- Kill criteria
+- Review date
+Step 10: Feed results back into the system
+Experiment outcomes should update:
+- Venture confidence
+- Council conclusions
+- Forecast records
+- Perspective reliability
+- EHG portfolio strategy
+---
+11. Standard Specialist Output Schema
+Every specialist agent should return structured output similar to the following:
+{
+  "perspective_id": "string",
+  "venture_candidate_id": "string",
+  "executive_conclusion": "string",
+  "observations": [
+    {
+      "statement": "string",
+      "classification": "verified_observation | strong_inference | weak_signal | forecast | speculation",
+      "confidence": 0.0,
+      "source_ids": ["string"]
+    }
+  ],
+  "opportunities": [
+    {
+      "description": "string",
+      "time_horizon": "0-6m | 6-24m | 2-5y | 5y+",
+      "confidence": 0.0
+    }
+  ],
+  "risks": [
+    {
+      "description": "string",
+      "severity": "low | medium | high | critical",
+      "probability": 0.0
+    }
+  ],
+  "assumptions": [
+    {
+      "assumption": "string",
+      "importance": "low | medium | high",
+      "test_method": "string"
+    }
+  ],
+  "minority_or_counter_view": "string",
+  "recommended_action": "reject | monitor | research | prototype | validate | incubate | launch | scale",
+  "recommended_experiment": "string",
+  "overall_confidence": 0.0
+}
+The exact schema may be adjusted, but structured outputs should be enforced.
+Free-form essays alone should not be accepted as valid specialist output.
+---
+12. Standard Adjudicator Output Schema
+{
+  "council_id": "string",
+  "venture_candidate_id": "string",
+  "consensus": ["string"],
+  "material_disagreements": [
+    {
+      "issue": "string",
+      "positions": ["string"],
+      "why_it_matters": "string"
+    }
+  ],
+  "minority_view": "string",
+  "shared_assumptions": ["string"],
+  "weakest_assumptions": ["string"],
+  "evidence_quality": "low | moderate | strong | very_strong",
+  "council_confidence": 0.0,
+  "EHG_implications": ["string"],
+  "recommended_action": "string",
+  "recommended_experiments": ["string"],
+  "monitoring_triggers": ["string"],
+  "kill_conditions": ["string"]
+}
+---
+13. Venture Scoring Model
+A venture should receive a score out of 100.
+Recommended weighted criteria
+Criterion| Weight
+Severity and frequency of customer pain| 20
+EHG agentic operating advantage| 20
+Distribution accessibility| 15
+Technical timing| 15
+Revenue potential and margins| 10
+Defensibility and proprietary data| 10
+Cross-venture reuse| 5
+Future option value| 5
+13.1 Pass/fail gates
+A high weighted score should not override failure in one of these areas:
+- Legal viability
+- Ethical acceptability
+- Financial survivability
+- Security viability
+- Data-access legitimacy
+13.2 Confidence adjustment
+A high venture score with low evidence confidence should not be treated the same as a high score with strong evidence.
+Recommended presentation:
+- Raw attractiveness score: 82/100
+- Evidence confidence: 55%
+- Confidence-adjusted score: 45
+- Primary uncertainty: customer willingness to pay
+- Next experiment: ten paid design-partner conversations
+The system should avoid false precision. Scores are decision-support tools, not mathematical truth.
+---
+14. EHG-Specific Evaluation Criteria
+Every venture should be tested against EHG’s operating model.
+14.1 Agentic leverage
+- Can AI agents perform most recurring work?
+- Can human intervention remain exception-based?
+- Can the work be verified?
+- Can failures be detected and reversed?
+- Can the venture operate with minimal human staffing?
+14.2 Shared-service reuse
+Can the venture reuse EHG capabilities such as:
+- Identity
+- Authentication
+- Billing
+- Communications
+- CRM and pipeline
+- Analytics
+- Agent orchestration
+- Model routing
+- Customer support
+- Knowledge management
+- Compliance logging
+- Financial reporting
+- Venture experimentation
+14.3 Low fixed-cost compatibility
+- Can the venture begin with minimal fixed costs?
+- Can infrastructure scale to zero or near zero?
+- Can expensive capabilities be used on demand?
+- Can the venture avoid large dedicated teams?
+14.4 Distribution compatibility
+EHG should favor ventures that can acquire customers through:
+- Product-led growth
+- Search
+- Content
+- Partnerships
+- Marketplaces
+- Communities
+- Self-service onboarding
+- Automated outbound
+- Existing EHG audiences
+- Cross-venture distribution
+Ventures requiring large enterprise sales teams should receive a lower EHG-fit score unless the economics justify building that capability.
+14.5 Proprietary learning
+Every venture should identify what it learns over time.
+Examples:
+- Customer workflows
+- Decision patterns
+- Outcomes
+- Industry benchmarks
+- Failure modes
+- Conversion patterns
+- Pricing sensitivity
+- Agent-performance data
+A venture that generates proprietary learning may be more valuable to EHG than one that only produces short-term revenue.
+---
+15. User Interface Recommendations
+15.1 Foresight Dashboard
+The main dashboard should show:
+- New signals
+- Signals gaining strength
+- Signals losing strength
+- Open venture candidates
+- Council review status
+- Upcoming decision points
+- Experiments in progress
+- Forecast accuracy
+- Portfolio exposure by future theme
+15.2 Venture Candidate Page
+Each venture candidate should have tabs for:
+- Overview
+- Customer problem
+- Evidence
+- Five council analyses
+- Dissent
+- Scenarios
+- Scorecard
+- Experiments
+- Decisions
+- Monitoring
+- Sources
+- Change history
+15.3 Chairman Decision View
+Rick’s view should be compressed into:
+Decision requested
+What decision is required?
+Recommendation
+What does EVA recommend?
+Why now
+What changed?
+Council consensus
+Where do the councils agree?
+Material disagreement
+What remains disputed?
+Financial exposure
+What will the next step cost?
+Information gained
+What uncertainty will the next step reduce?
+Reversibility
+Can EHG undo the decision?
+Cost of waiting
+What may be lost by delaying?
+Recommended response
+One-tap or voice-supported options:
+- Approve experiment
+- Request deeper review
+- Monitor
+- Reject
+- Pause
+- Escalate for discussion
+This view should eventually be compatible with EHG’s SMS, phone, and watch-based Chairman interface.
+---
+16. Knowledge Refresh and Source Management
+16.1 Doctrine versioning
+Each public-thought-informed profile should be versioned.
+Example:
+- Alex Wissner-Gross doctrine v1.0
+- Alex Wissner-Gross doctrine v1.1
+- Alex Wissner-Gross doctrine v2.0
+A new version should be created when:
+- A substantial new body of work is published
+- The individual materially changes a position
+- A prior forecast is resolved
+- New evidence contradicts a recurring claim
+- EHG changes how the lens is applied
+Historical doctrine versions should be retained so EHG can understand why a prior decision was made.
+16.2 Staleness controls
+Every doctrine and claim should have:
+- Last-reviewed date
+- Source recency
+- Staleness status
+- Contradiction status
+The system should warn when an analysis relies heavily on stale doctrine.
+16.3 Forecast ledger
+The system should track specific, measurable predictions made by the selected perspectives.
+The goal is not to publicly grade or criticize individuals. The goal is to calibrate EHG’s reliance on each analytical lens.
+Forecast accuracy may differ by category.
+For example:
+- One perspective may be strong on AI capability
+- Another may be strong on adoption
+- Another may be strong on regulation
+- Another may be consistently premature on timelines
+The system should eventually weight perspectives based on domain-specific evidence, while continuing to preserve contrarian views.
+---
+17. Model and Agent Routing
+The full board should not use the most expensive reasoning model for every action.
+Recommended routing:
+Low-cost model
+Use for:
+- Source classification
+- Metadata extraction
+- Deduplication
+- Topic tagging
+- Basic signal detection
+- Formatting
+- Citation checks
+Mid-tier reasoning model
+Use for:
+- Doctrine extraction
+- Specialist analysis
+- Comparison of evidence
+- Assumption detection
+- Preliminary scoring
+High-reasoning model
+Use for:
+- Council adjudication
+- Cross-council conflict resolution
+- Scenario synthesis
+- Major venture dossiers
+- High-cost or irreversible decisions
+All model-generated outputs should store:
+- Model provider
+- Model name
+- Prompt version
+- Run date
+- Token or cost metadata
+- Input evidence set
+- Output validation status
+This will allow EHG to benchmark cost and quality over time.
+---
+18. Prompting Guidance
+Prompts should instruct agents to apply a framework, not impersonate an individual.
+Avoid:
+«You are Alex Wissner-Gross. Tell EHG what to build.»
+Prefer:
+«Apply the recurring analytical frameworks, published arguments, technical interests, and documented cautions associated with the Wissner-Gross-informed Frontier Capability lens. Do not imitate personal style, claim endorsement, or invent an opinion. Distinguish sourced doctrine from your own inference.»
+Every specialist prompt should require:
+- Evidence citations
+- Clear uncertainty
+- Assumption identification
+- A counterargument
+- EHG implications
+- Recommended experiment
+- Structured output
+Every adjudicator prompt should require:
+- Comparison across specialists
+- Preservation of dissent
+- Evidence-quality ranking
+- Explicit confidence
+- Actionable conclusion
+---
+19. Integration With the Existing EHG Venture Workflow
+The Venture Foresight Board should function as a reusable stage-gate capability.
+Suggested integration points:
+Ideation stage
+Use the board to:
+- Generate opportunity spaces
+- Identify emerging customer problems
+- Connect signals to potential ventures
+Initial screening stage
+Use signal-scan or venture-screen mode to eliminate:
+- Technically premature ideas
+- Weak customer problems
+- Poor EHG-fit ideas
+- Ventures with inaccessible distribution
+Concept validation stage
+Use the councils to define:
+- Critical assumptions
+- Customer interviews
+- Landing-page tests
+- Pricing tests
+- Technical prototypes
+Incubation decision stage
+Run the full board before assigning significant engineering or financial resources.
+Launch stage
+Re-run selected councils to test whether:
+- Timing has changed
+- Competition has changed
+- Regulation has changed
+- Distribution remains viable
+Scale stage
+Use the board to identify:
+- Adjacent markets
+- Platform opportunities
+- Commoditization threats
+- Strategic partnerships
+- Acquisition opportunities
+Termination review
+Use the system to distinguish:
+- A bad venture
+- Bad execution
+- Premature timing
+- Invalid customer assumptions
+- A market that changed after launch
+---
+20. Phased Implementation Plan
+Phase 1: Minimum Viable Foresight Board
+Build:
+- Five council definitions
+- Twenty perspective profiles
+- Manual doctrine documents
+- Venture candidate record
+- Specialist assessment workflow
+- Adjudicator workflow
+- EVA synthesis
+- Basic Venture Decision Dossier
+- Manual source citations
+Do not initially build continuous social-media ingestion or complex autonomous monitoring.
+The first goal is to validate whether the framework improves decisions.
+Phase 2: Structured Knowledge and Automation
+Add:
+- SourceArtifact database
+- DoctrineClaim extraction
+- Forecast ledger
+- Versioned perspective profiles
+- Automated source ingestion
+- Signal detection
+- Structured confidence scoring
+- Portfolio connections
+- Experiment tracking
+Phase 3: Living Foresight System
+Add:
+- Continuous monitoring
+- Change detection
+- Prediction resolution
+- Perspective calibration
+- Automated weekly briefs
+- Chairman mobile, SMS, and watch interface
+- Portfolio scenario simulations
+- Cross-venture opportunity discovery
+- Automated review triggers
+Phase 4: EHG Proprietary Intelligence
+Over time, blend public futurist perspectives with:
+- EHG venture outcomes
+- Customer interviews
+- Revenue data
+- Agent-performance data
+- Experiment results
+- Competitive intelligence
+- Internal forecasts
+The long-term goal is for EHG to develop its own proprietary foresight system rather than permanently depending on external commentators.
+The external lenses should become inputs into an increasingly EHG-native intelligence capability.
+---
+21. Minimum Acceptance Criteria
+The first implementation should be considered successful when it can:
+1. Create a venture candidate from a signal or Rick’s idea
+2. Run three specialist analyses within each council
+3. Produce one adjudicated conclusion per council
+4. Preserve material disagreement
+5. Cite the evidence used
+6. Clearly separate facts, forecasts, and speculation
+7. Generate a consolidated Venture Decision Dossier
+8. Score EHG fit
+9. Recommend a next experiment
+10. Define kill criteria
+11. Store Rick’s final decision
+12. Revisit the decision when a monitoring trigger occurs
+The system should fail validation when:
+- An agent invents a source position
+- A conclusion lacks evidence
+- Dissent is omitted
+- Confidence is not stated
+- The output contains no EHG-specific recommendation
+- A venture is recommended without identifying a customer
+- A venture is recommended without a distribution hypothesis
+- An expensive build is recommended before a lower-cost validation step is considered
+---
+22. Example Venture Flow
+Assume a signal suggests that AI agents are becoming capable of performing a large portion of small-business bookkeeping.
+Frontier Capability Council
+Determines:
+- What bookkeeping tasks agents can perform
+- Reliability
+- Cost
+- Remaining failure modes
+- Expected capability improvements
+Human Transition Council
+Identifies:
+- Trust concerns
+- New supervision needs
+- Accountant role changes
+- Small-business owner anxiety
+- Demand for verification and explanations
+Strategic Foresight Council
+Tests:
+- Rapid adoption scenario
+- Slow adoption scenario
+- Heavy regulation scenario
+- Major model-failure scenario
+Exponential Systems Council
+Evaluates:
+- Banking integrations
+- Data access
+- Compliance
+- Insurance
+- Inference economics
+- Regional regulation
+Market Reality Council
+Determines:
+- Initial customer
+- Buyer
+- Pricing
+- Distribution
+- Competition
+- Retention
+- Defensibility
+EVA synthesis
+EVA may conclude:
+«Do not begin by building a fully autonomous accounting replacement. Test an AI bookkeeping verification and exception-management service for owner-operated businesses.»
+Proposed experiment
+- Recruit five design partners
+- Manually provide the service using existing AI and accounting tools
+- Charge a small monthly fee
+- Track exception rates
+- Measure time saved
+- Measure trust
+- Determine whether customers value automation, verification, or both
+This is the type of decision improvement the system should produce.
+---
+23. Developer Guidance
+23.1 Build for traceability first
+The system’s value will depend on the ability to answer:
+- Why did the agent reach this conclusion?
+- Which source supported it?
+- Which model generated it?
+- Which prompt version was used?
+- What assumptions were made?
+- What changed since the previous analysis?
+Do not optimize only for impressive generated text.
+23.2 Use schemas and validation
+Agent outputs should be validated against schemas.
+The orchestrator should reject or retry outputs when:
+- Required fields are missing
+- Citations are absent
+- Confidence is invalid
+- The recommendation is unsupported
+- The agent speaks as the real person
+- The response is merely a summary
+23.3 Preserve raw and processed records
+Store:
+- Raw source
+- Extracted doctrine
+- Specialist output
+- Adjudicated output
+- EVA synthesis
+- Final decision
+- Experiment result
+Do not overwrite historical records.
+23.4 Separate knowledge from prompts
+Perspective doctrine should be stored as versioned knowledge, not hard-coded inside large prompts.
+This will make it easier to:
+- Refresh perspectives
+- Replace members
+- Test alternative councils
+- Compare prompt versions
+- Reduce token costs
+- Audit source usage
+23.5 Design for member substitution
+EHG may later decide to replace or add perspectives.
+The architecture should allow:
+- New council members
+- Temporary guest perspectives
+- Domain-specific councils
+- Different adjudicators
+- Different scoring weights
+- Venture-specific specialist selection
+Do not hard-code the twenty names into core business logic.
+23.6 Avoid premature autonomy
+The initial system should recommend and organize decisions.
+It should not autonomously:
+- Allocate significant capital
+- Launch public ventures
+- Sign legal agreements
+- Purchase expensive services
+- Make irreversible infrastructure choices
+- Terminate operating ventures
+Those actions should remain subject to explicit EHG governance.
+23.7 Optimize for information gain
+The recommended next action should not simply be the easiest task.
+It should be the action that reduces the most important uncertainty for the lowest reasonable cost.
+A useful experiment-ranking formula may include:
+- Expected information gain
+- Cost
+- Time
+- Reversibility
+- Customer contact
+- Strategic reuse
+23.8 Prevent analysis paralysis
+Set limits on:
+- Number of review cycles
+- Maximum specialists per mode
+- Maximum report length
+- Maximum unresolved questions before experiment
+- Maximum time before a decision is forced
+The system should prefer learning through action when further theoretical analysis has diminishing value.
+---
+24. Long-Term Vision
+The Venture Foresight Board should eventually become more than a collection of futurist-inspired agents.
+It should become an EHG proprietary system that learns:
+- Which signals matter
+- Which perspectives are reliable by domain
+- Which opportunity patterns suit EHG
+- Which assumptions commonly fail
+- Which experiments produce the most information
+- Which distribution models work
+- Which venture characteristics predict success
+- Which shared capabilities create portfolio leverage
+The long-term strategic asset is not the simulation of twenty public thinkers.
+The strategic asset is:
+«EHG’s accumulated ability to translate changes in technology, society, economics, and markets into well-timed, evidence-driven, agent-operable ventures.»
+---
+25. Final Product Principle
+The developer should use the following principle as the system’s design anchor:
+«The Venture Foresight Board exists to help EHG identify valuable problems earlier, avoid acting on hype, test assumptions cheaply, preserve dissent, and allocate Rick’s attention and EHG’s capital toward the most promising future-facing opportunities.»


### PR DESCRIPTION
## Summary
- Lands `docs/design/ehg-venture-foresight-board-spec.md` (chairman-authored, extracted verbatim from Dropbox .docx) from the evidence branch `quick-fix/QF-20260711-736` @ `bdf819f3e58` onto main — removing the evaporates-across-sessions risk of an evidence-branch-only doc.
- Resolves `SD-REFILL-00X2A49J` (the deferred stub this spec supersedes) disposition: `item_disposition` set to `dropped` with a `superseded_by_doc` metadata pointer to this spec. No duplicate capture surface remains. (`item_disposition` enum has no `superseded` value — `pending/selected/deferred/brainstormed/promoted/dropped` per `20260314_wave_item_disposition.sql` — so `dropped` is the nearest valid semantic; full rationale recorded in the row's `metadata.disposition_note`.)
- No code changes — doc-only, Tier 1 QF.

## Test plan
- [x] Verified file content matches evidence-branch commit `bdf819f3e58` exactly (git checkout from that commit, no edits)
- [x] Confirmed `SD-REFILL-00X2A49J` roadmap_wave_items row updated via direct query (item_disposition=dropped, metadata pointer present)
- [x] No code/test surface touched — doc landing only

🤖 Generated with [Claude Code](https://claude.com/claude-code)