### PR TITLE
fix(QF-20260716-579): closure-predicate design rules -- freshness decay + provenance

### DIFF
--- a/lib/loop-governance/__tests__/closure-engine.test.js
+++ b/lib/loop-governance/__tests__/closure-engine.test.js
@@ -65,27 +65,59 @@ describe('evaluateLoopClosure — witness_recent (FR-3)', () => {
 
 describe('validateClosurePredicate (FR-4 — required-at-registration)', () => {
   it('accepts a well-formed edge_freshness predicate', () => {
-    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600 } });
+    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600, authorized_writer: 'reflection-emitter' } });
     expect(r.valid).toBe(true);
   });
   it('rejects a missing predicate_type', () => {
-    const r = validateClosurePredicate({ closure_predicate: { window_seconds: 3600 } });
+    const r = validateClosurePredicate({ closure_predicate: { window_seconds: 3600, authorized_writer: 'reflection-emitter' } });
     expect(r.valid).toBe(false);
     expect(r.reasons.join(' ')).toMatch(/predicate_type/);
   });
   it('rejects edge_freshness without a positive window', () => {
-    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: {} });
+    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { authorized_writer: 'reflection-emitter' } });
     expect(r.valid).toBe(false);
     expect(r.reasons.join(' ')).toMatch(/window_seconds/);
   });
   it('rejects backlog_drained without a threshold', () => {
-    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.BACKLOG_DRAINED, closure_predicate: {} });
+    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.BACKLOG_DRAINED, closure_predicate: { authorized_writer: 'reaper-cron' } });
     expect(r.valid).toBe(false);
     expect(r.reasons.join(' ')).toMatch(/threshold/);
   });
   it('rejects a non-object closure_predicate', () => {
     const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: null });
     expect(r.valid).toBe(false);
+  });
+
+  // QF-20260716-579 (b) EVIDENCE PROVENANCE — a predicate that omits the authorized
+  // writer is not machine-checkable: nothing stops a maker from authoring its own
+  // closure evidence.
+  it('rejects a well-formed edge_freshness predicate that omits authorized_writer', () => {
+    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600 } });
+    expect(r.valid).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/authorized_writer/);
+  });
+  it('rejects an authorized_writer that is an empty string', () => {
+    const r = validateClosurePredicate({ predicate_type: PREDICATE_TYPES.BACKLOG_DRAINED, closure_predicate: { threshold: 0, authorized_writer: '   ' } });
+    expect(r.valid).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/authorized_writer/);
+  });
+});
+
+// QF-20260716-579 (a) FRESHNESS WINDOW DECAY — proven on one real loop (L30's
+// edge_freshness shape): a loop that evaluates CLOSED at time T with fresh evidence
+// reverts to OPEN once that SAME evidence ages past the window on a later tick. No
+// permanent CLOSE survives from a single historical write.
+describe('evaluateLoopClosure — freshness-window decay (QF-20260716-579 rule a)', () => {
+  const loop = { predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600, authorized_writer: 'session-coordination-reaper' } };
+  const evidence = { edgeAt: ago(60), upstreamFiredAt: ago(120) }; // fresh relative to NOW
+
+  it('is CLOSED at the tick when the evidence is fresh', () => {
+    expect(evaluateLoopClosure(loop, evidence, NOW).status).toBe(LOOP_STATUS.CLOSED);
+  });
+
+  it('reverts to OPEN on a LATER tick once the SAME evidence has aged past the window', () => {
+    const later = new Date(NOW.getTime() + 2 * 3600 * 1000); // +2h, well past the 1h window
+    expect(evaluateLoopClosure(loop, evidence, later).status).toBe(LOOP_STATUS.OPEN);
   });
 });
 

--- a/lib/loop-governance/__tests__/governance.test.js
+++ b/lib/loop-governance/__tests__/governance.test.js
@@ -17,7 +17,7 @@ const ago = (s) => new Date(NOW.getTime() - s * 1000).toISOString();
 
 describe('assertLoopRegistrationHasPredicate (FR-4)', () => {
   it('passes a loop registering with a valid closure predicate', () => {
-    const r = assertLoopRegistrationHasPredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600 } });
+    const r = assertLoopRegistrationHasPredicate({ predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 3600, authorized_writer: 'reflection-emitter' } });
     expect(r.ok).toBe(true);
     expect(r.reason).toMatch(/PRESENT/);
   });

--- a/lib/loop-governance/closure-engine.js
+++ b/lib/loop-governance/closure-engine.js
@@ -89,6 +89,20 @@ export function evaluateLoopClosure(loop, evidence = {}, now = new Date()) {
  * enforces this at registration — no loop enrolls without a probe). Returns the
  * reasons a predicate is NOT machine-checkable (empty array => valid).
  *
+ * Two rules every predicate MUST satisfy (Solomon Mode-C commission ITEM 2,
+ * chairman-ratified 2026-07-16, QF-20260716-579):
+ *   (a) FRESHNESS WINDOW DECAY — edge_freshness/witness_recent already re-evaluate
+ *       staleness against `now` on every call (see `fresh()` above), so a CLOSED
+ *       verdict can never persist past its window on a later tick; this is a
+ *       structural property of the stateless evaluator, not something to re-check
+ *       here. backlog_drained has no evidence timestamp to go stale (it queries a
+ *       live count each tick), so a window requirement does not apply to it.
+ *   (b) EVIDENCE PROVENANCE — the predicate must DECLARE which process/role is
+ *       authorized to write the evidence rows it trusts (maker/checker separation
+ *       at the data layer — a maker can never author its own closure evidence).
+ *       Enforced here at registration time; ITEM 3 (verifier read-only role)
+ *       enforces the complementary storage-layer half.
+ *
  * @param {Object} loop
  * @returns {{valid: boolean, reasons: string[]}}
  */
@@ -110,6 +124,9 @@ export function validateClosurePredicate(loop) {
     }
     if (type === PREDICATE_TYPES.WITNESS_RECENT && !(Number(predicate.window_seconds) > 0)) {
       reasons.push('witness_recent requires a positive window_seconds');
+    }
+    if (!(typeof predicate.authorized_writer === 'string' && predicate.authorized_writer.trim().length > 0)) {
+      reasons.push('closure_predicate missing authorized_writer (evidence provenance — a maker cannot author its own closure evidence)');
     }
   }
   return { valid: reasons.length === 0, reasons };

--- a/lib/loop-governance/genesis-loops.js
+++ b/lib/loop-governance/genesis-loops.js
@@ -12,11 +12,14 @@
  *
  * Each loop gets a default closure predicate (edge_freshness / 30-day window) as a
  * placeholder that satisfies validateClosurePredicate; per-loop probes are refined as
- * each loop's closing SD lands.
+ * each loop's closing SD lands. authorized_writer is 'unassigned' at genesis (no real
+ * collector yet writes evidence for most loops) — QF-20260716-579 requires every
+ * predicate to declare one; refined alongside window_seconds as each loop's collector
+ * is authored.
  */
 import { PREDICATE_TYPES } from './closure-engine.js';
 
-const DEFAULT_PREDICATE = { window_seconds: 30 * 86400 };
+const DEFAULT_PREDICATE = { window_seconds: 30 * 86400, authorized_writer: 'unassigned' };
 
 /** L1-L33 manifest (loop_key, gap summary, closing SD if named, status). */
 export const GENESIS_LOOPS = [


### PR DESCRIPTION
## Summary
- Amends the closure-predicate template (validateClosurePredicate) to require every predicate to declare `authorized_writer` (evidence provenance -- maker/checker separation)
- Proves freshness-window decay is already a structural property of the stateless evaluator via a new explicit test (CLOSED at tick T reverts to OPEN once evidence ages past the window on a later tick)
- Adam-sourced (CONST-002), chairman-ratified verbal 2026-07-16, Solomon Mode-C commission ITEM 2

## Test plan
- [x] 41/41 tests pass (`npx vitest run lib/loop-governance/__tests__/`)
- [x] Updated pre-existing test fixtures to include authorized_writer (governance.test.js, closure-engine.test.js)
- [x] genesis-loops.js's placeholder default predicate updated so existing genesis-seeded loops stay valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)