### PR TITLE
feat(SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001): PR-A — model_capability_reference STAGED schema + redacting golden-task loader

### DIFF
--- a/database/migrations/20260716_model_capability_reference_STAGED.sql
+++ b/database/migrations/20260716_model_capability_reference_STAGED.sql
@@ -39,11 +39,13 @@ CREATE TABLE IF NOT EXISTS model_capability_reference (
 -- RLS in the SAME migration as CREATE TABLE (SPINE-001-B recurrence guard).
 ALTER TABLE model_capability_reference ENABLE ROW LEVEL SECURITY;
 
+-- Service-role ONLY by design: every consumer (runner, migrator, GT gate,
+-- routing scripts) is a server-side harness process. The table has no tenant
+-- dimension, so an authenticated/anon read policy would be an unconditional
+-- USING (true) — the exact defect class of SD-LEO-GEN-SCOPE-ANON-KEY-001 /
+-- SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001. None is granted.
 CREATE POLICY model_capability_reference_service_write ON model_capability_reference
   FOR ALL TO service_role USING (true) WITH CHECK (true);
-
-CREATE POLICY model_capability_reference_authenticated_read ON model_capability_reference
-  FOR SELECT TO authenticated USING (true);
 
 COMMENT ON TABLE model_capability_reference IS
   'Measured model/effort capability per problem shape (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001). Results-only: never stores golden-task text or answer keys. Consumers must filter trusted_for_routing=true.';

--- a/database/migrations/20260716_model_capability_reference_STAGED.sql
+++ b/database/migrations/20260716_model_capability_reference_STAGED.sql
@@ -1,0 +1,51 @@
+-- @approved-by: PENDING — chairman-gated apply ceremony required (do NOT apply outside it)
+-- STAGED migration — SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001 (FR-1)
+-- model_capability_reference: measured capability-per-cost, keyed
+-- (problem_shape R1-R5 + mechanical, model_id, effort, task_id).
+-- Spec: Part 4 of docs/design/solomon-fable-capability-grounding.md @ 75d8cf8e333.
+--
+-- SCHEMA-ONLY by design: zero INSERTs. Sealed golden-task text and answer keys
+-- live DB-side (feedback.category='model_capability_baseline') and are moved by
+-- a runtime loader (scripts/eval/migrate-sealed-baselines.mjs) — never by SQL
+-- committed to a repo the evaluated models can read (contamination guard).
+--
+-- trusted_for_routing is the fail-closed trust gate: DEFAULT false, and only
+-- scripts/eval/ground-truth-gate.mjs may set it true, after the eval reproduces
+-- >= 1 already-adjudicated result. Routing consumers MUST filter on it.
+
+CREATE TABLE IF NOT EXISTS model_capability_reference (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  problem_shape text NOT NULL CHECK (problem_shape IN (
+    'R1-compounding','R2-negative-space','R3-taste','R4-coupling','R5-reversal','mechanical-baseline'
+  )),
+  model_id text NOT NULL,
+  effort text NOT NULL CHECK (effort IN ('low','medium','high','xhigh')),
+  task_id text NOT NULL,
+  clears_bar boolean,
+  quality_score numeric,
+  tokens integer,
+  wall_clock_ms integer,
+  cost_norm numeric,
+  graded_at timestamptz,
+  grader text,
+  run_at timestamptz,
+  content_hash text NOT NULL,
+  source_ref text NOT NULL,
+  trusted_for_routing boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (task_id, model_id, effort, content_hash)
+);
+
+-- RLS in the SAME migration as CREATE TABLE (SPINE-001-B recurrence guard).
+ALTER TABLE model_capability_reference ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY model_capability_reference_service_write ON model_capability_reference
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY model_capability_reference_authenticated_read ON model_capability_reference
+  FOR SELECT TO authenticated USING (true);
+
+COMMENT ON TABLE model_capability_reference IS
+  'Measured model/effort capability per problem shape (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001). Results-only: never stores golden-task text or answer keys. Consumers must filter trusted_for_routing=true.';
+COMMENT ON COLUMN model_capability_reference.trusted_for_routing IS
+  'Fail-closed trust gate. DEFAULT false. Flipped true only by scripts/eval/ground-truth-gate.mjs after reproducing >=1 adjudicated result (incl. an adversarial negative).';

--- a/lib/eval/golden-task-loader.mjs
+++ b/lib/eval/golden-task-loader.mjs
@@ -1,0 +1,92 @@
+/**
+ * golden-task-loader.mjs — DB-side golden-task + answer-key loader
+ * (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001 FR-2).
+ *
+ * Loads the sealed capability suite at RUNTIME from
+ * feedback.category='model_capability_baseline' (fallback:
+ * system_events.event_type='fable5_baseline_seal').
+ *
+ * REDACTION CONTRACT: answer_key and task_text never appear on any serialized
+ * surface. GoldenTask#toJSON exposes only {task_id, shape, content_hash,
+ * answer_key_ref}; the full task text is reachable only via .taskText (WeakMap
+ * backing, invisible to JSON.stringify/console.log enumeration), and keys only
+ * via suite.getKey(task_id). Error messages must never interpolate either.
+ */
+
+const SECRET = new WeakMap(); // GoldenTask -> { taskText }
+
+export class GoldenTask {
+  constructor({ task_id, shape, task_text, content_hash, answer_key_ref }) {
+    this.task_id = task_id;
+    this.shape = shape;
+    this.content_hash = content_hash;
+    this.answer_key_ref = answer_key_ref || null;
+    SECRET.set(this, { taskText: task_text });
+  }
+  /** Full prompt text — memory-only accessor; never serialized. */
+  get taskText() {
+    return SECRET.get(this).taskText;
+  }
+  toJSON() {
+    return {
+      task_id: this.task_id,
+      shape: this.shape,
+      content_hash: this.content_hash,
+      answer_key_ref: this.answer_key_ref,
+    };
+  }
+}
+
+export class GoldenSuite {
+  constructor(tasks, keysById) {
+    this.tasks = tasks;
+    // Map serializes to {} under JSON.stringify — keys stay off every surface.
+    this._keys = keysById;
+  }
+  /** Answer key for one task — memory-only; callers must not persist it. */
+  getKey(taskId) {
+    return this._keys.get(taskId) || null;
+  }
+  get size() {
+    return this.tasks.length;
+  }
+  toJSON() {
+    return { tasks: this.tasks, task_count: this.tasks.length };
+  }
+}
+
+/** Pure: build a GoldenSuite from feedback-style rows ({metadata} objects). */
+export function buildSuite(rows) {
+  const tasks = [];
+  const keys = new Map();
+  for (const row of rows || []) {
+    const m = row.metadata || row.payload || {};
+    if (m.record_kind !== 'answer_key') continue;
+    tasks.push(new GoldenTask({
+      task_id: m.task_id,
+      shape: m.shape,
+      task_text: m.task_text,
+      content_hash: m.content_hash,
+      answer_key_ref: `db:${row.id || m.task_id}`,
+    }));
+    keys.set(m.task_id, { answer_key: m.answer_key, answer_key_ref: `db:${row.id || m.task_id}` });
+  }
+  tasks.sort((a, b) => a.task_id.localeCompare(b.task_id));
+  return new GoldenSuite(tasks, keys);
+}
+
+/** Load the sealed suite from the DB. Throws generic errors — never key text. */
+export async function loadGoldenSuite(supabase) {
+  const primary = await supabase
+    .from('feedback')
+    .select('id, metadata')
+    .eq('category', 'model_capability_baseline');
+  if (!primary.error && primary.data && primary.data.length) return buildSuite(primary.data);
+
+  const mirror = await supabase
+    .from('system_events')
+    .select('id, payload')
+    .eq('event_type', 'fable5_baseline_seal');
+  if (mirror.error) throw new Error('golden-task-loader: sealed corpus unavailable from both stores');
+  return buildSuite(mirror.data);
+}

--- a/tests/unit/eval/golden-task-loader.test.js
+++ b/tests/unit/eval/golden-task-loader.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { buildSuite, GoldenTask } from '../../../lib/eval/golden-task-loader.mjs';
+
+// TS-1 (redaction) + TS-7 (contamination sweep on serialized surfaces).
+// Sentinels are fabricated — no sealed content appears in this repo.
+const KEY_SENTINEL = 'FAKE-ANSWER-KEY-SENTINEL-93f1';
+const TEXT_SENTINEL = 'FAKE-TASK-TEXT-SENTINEL-77ab';
+
+const rows = [
+  {
+    id: 'row-1',
+    metadata: {
+      record_kind: 'answer_key',
+      task_id: 'FAKE-R2-01',
+      shape: 'R2-negative-space',
+      task_text: `Some long prompt ${TEXT_SENTINEL}`,
+      answer_key: `The graded key ${KEY_SENTINEL}`,
+      content_hash: 'abc123',
+    },
+  },
+  {
+    id: 'row-2',
+    metadata: {
+      record_kind: 'sealed_run', // runs are not tasks; must be ignored
+      task_id: 'FAKE-R2-01',
+      shape: 'R2-negative-space',
+      task_text: `run copy ${TEXT_SENTINEL}`,
+      fable5_answer: 'answer body',
+      content_hash: 'abc123',
+    },
+  },
+];
+
+describe('golden-task-loader redaction contract', () => {
+  it('builds tasks from answer_key rows only, keys retrievable in memory', () => {
+    const suite = buildSuite(rows);
+    expect(suite.size).toBe(1);
+    expect(suite.tasks[0]).toBeInstanceOf(GoldenTask);
+    expect(suite.tasks[0].taskText).toContain(TEXT_SENTINEL);
+    expect(suite.getKey('FAKE-R2-01').answer_key).toContain(KEY_SENTINEL);
+    expect(suite.getKey('MISSING')).toBeNull();
+  });
+
+  it('JSON.stringify of the suite and tasks leaks neither key nor task text', () => {
+    const suite = buildSuite(rows);
+    const surfaces = [
+      JSON.stringify(suite),
+      JSON.stringify(suite.tasks),
+      JSON.stringify(suite.tasks[0]),
+      JSON.stringify({ nested: { deep: suite } }),
+    ];
+    for (const s of surfaces) {
+      expect(s).not.toContain(KEY_SENTINEL);
+      expect(s).not.toContain(TEXT_SENTINEL);
+    }
+    // Safe fields ARE present so the object is still useful in logs.
+    expect(JSON.stringify(suite.tasks[0])).toContain('FAKE-R2-01');
+    expect(JSON.stringify(suite.tasks[0])).toContain('abc123');
+  });
+
+  it('own-property enumeration exposes no secret fields', () => {
+    const suite = buildSuite(rows);
+    const task = suite.tasks[0];
+    const dumped = JSON.stringify(Object.entries(task));
+    expect(dumped).not.toContain(KEY_SENTINEL);
+    expect(dumped).not.toContain(TEXT_SENTINEL);
+    expect(Object.keys(task)).not.toContain('task_text');
+    expect(Object.keys(task)).not.toContain('answer_key');
+  });
+});


### PR DESCRIPTION
PR-A of 3 (stacked). 143 source LOC + 51 SQL — size justification: the schema and the contamination-guard surface must land together so PR-B/PR-C build against the redaction contract.

- STAGED migration (schema-only, zero INSERTs; RLS + policies in the SAME file per SPINE-001-B; trusted_for_routing NOT NULL DEFAULT false). Apply is chairman-gated via the @approved-by ceremony — this SD is complete with the file STAGED.
- lib/eval/golden-task-loader.mjs: runtime loader for the sealed Fable-5 suite; WeakMap-backed task text + Map-held answer keys mean no serialized surface ever exposes sealed content (keys stay DB-side per the contamination guard).
- TS-1 redaction tests with fabricated sentinels.

Spec: Part 4 of docs/design/solomon-fable-capability-grounding.md @ 75d8cf8e333. Stack: PR-B (engine) and PR-C (regression trigger) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)