### PR TITLE
fix(QF-20260713-713): GATE_VISION_SCORE determinism — re-fetch dimension context + rich dim-value matching

### DIFF
--- a/lib/handoff/threshold-resolver.js
+++ b/lib/handoff/threshold-resolver.js
@@ -113,14 +113,8 @@ export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
  * @returns {{ addressable: number, total: number }}
  */
 /**
- * Extract the numeric score from a dimension_scores value. The vision-scorer
- * writes RICH values keyed by dimension ID: { A01: { name, score, weight, ... } } —
- * not the flat { dimName: score } shape older callers assumed (QF-20260713-713:
- * the typeof === 'number' checks silently matched nothing, so addressability
- * always collapsed to 0 for every real scorer row).
- *
- * @param {number|Object|null} value - a dimension_scores entry value
- * @returns {number|null} the numeric score, or null if none present
+ * Numeric score of a dimension_scores value — the vision-scorer writes RICH
+ * values ({ A01: { name, score, ... } }), not flat scores (QF-20260713-713).
  */
 export function dimScoreOf(value) {
   if (typeof value === 'number') return value;
@@ -128,14 +122,7 @@ export function dimScoreOf(value) {
   return null;
 }
 
-/**
- * Resolve the human dimension NAME for a dimension_scores entry. Rich values
- * carry .name ('automation_by_default'); flat legacy values fall back to the key.
- *
- * @param {string} key - the dimension_scores key (e.g. 'A01' or a legacy name)
- * @param {number|Object|null} value - the entry value
- * @returns {string} the matchable dimension name
- */
+/** Matchable dimension name: rich values' .name, else the key (legacy flat shape). */
 export function dimNameOf(key, value) {
   if (value && typeof value === 'object' && typeof value.name === 'string' && value.name) return value.name;
   return key;
@@ -144,9 +131,8 @@ export function dimNameOf(key, value) {
 /**
  * Resolve the array of addressable dimension KEYS for an SD. Single source of
  * truth for both countAddressableDimensions and the addressable-average floor.
- * Pattern matching runs against the dimension NAME (dimNameOf — rich values'
- * .name, legacy flat keys as-is) because scorer rows are keyed by opaque IDs
- * (A01/V01) that no type pattern can ever substring-match (QF-20260713-713).
+ * Patterns match the dimension NAME (dimNameOf) — scorer rows are keyed by
+ * opaque A01/V01 IDs no type pattern can substring-match (QF-20260713-713).
  * Returned strings are the KEYS so callers can index back into dimensionScores.
  * Precedence:
  *   1. Manual override: a non-empty sdMetadata.vision_addressable_dimensions pattern

--- a/lib/handoff/threshold-resolver.js
+++ b/lib/handoff/threshold-resolver.js
@@ -113,8 +113,41 @@ export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
  * @returns {{ addressable: number, total: number }}
  */
 /**
- * Resolve the array of addressable dimension NAMES for an SD. Single source of
+ * Extract the numeric score from a dimension_scores value. The vision-scorer
+ * writes RICH values keyed by dimension ID: { A01: { name, score, weight, ... } } —
+ * not the flat { dimName: score } shape older callers assumed (QF-20260713-713:
+ * the typeof === 'number' checks silently matched nothing, so addressability
+ * always collapsed to 0 for every real scorer row).
+ *
+ * @param {number|Object|null} value - a dimension_scores entry value
+ * @returns {number|null} the numeric score, or null if none present
+ */
+export function dimScoreOf(value) {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && typeof value.score === 'number') return value.score;
+  return null;
+}
+
+/**
+ * Resolve the human dimension NAME for a dimension_scores entry. Rich values
+ * carry .name ('automation_by_default'); flat legacy values fall back to the key.
+ *
+ * @param {string} key - the dimension_scores key (e.g. 'A01' or a legacy name)
+ * @param {number|Object|null} value - the entry value
+ * @returns {string} the matchable dimension name
+ */
+export function dimNameOf(key, value) {
+  if (value && typeof value === 'object' && typeof value.name === 'string' && value.name) return value.name;
+  return key;
+}
+
+/**
+ * Resolve the array of addressable dimension KEYS for an SD. Single source of
  * truth for both countAddressableDimensions and the addressable-average floor.
+ * Pattern matching runs against the dimension NAME (dimNameOf — rich values'
+ * .name, legacy flat keys as-is) because scorer rows are keyed by opaque IDs
+ * (A01/V01) that no type pattern can ever substring-match (QF-20260713-713).
+ * Returned strings are the KEYS so callers can index back into dimensionScores.
  * Precedence:
  *   1. Manual override: a non-empty sdMetadata.vision_addressable_dimensions pattern
  *      list (QF-20260505-102) — wins over everything.
@@ -134,23 +167,35 @@ export const SD_TYPE_ADDRESSABLE_DIMENSIONS = {
  */
 export function getAddressableDimNames(sdType, dimensionScores, sdMetadata) {
   if (!dimensionScores || typeof dimensionScores !== 'object') return [];
-  const dimNames = Object.keys(dimensionScores);
+  const entries = Object.entries(dimensionScores);
 
   const sdLevelPatterns = sdMetadata?.vision_addressable_dimensions;
   if (Array.isArray(sdLevelPatterns) && sdLevelPatterns.length > 0) {
-    return dimNames.filter(name =>
-      sdLevelPatterns.some(p => name.toLowerCase().includes(String(p).toLowerCase())));
+    return entries
+      .filter(([key, value]) => {
+        const name = dimNameOf(key, value).toLowerCase();
+        return sdLevelPatterns.some(p => name.includes(String(p).toLowerCase()));
+      })
+      .map(([key]) => key);
   }
 
   const patterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
   if (patterns === null || patterns === undefined) {
     // Carve-out: auto-detect addressable dims from scores for null-pattern types.
-    return dimNames.filter(name =>
-      typeof dimensionScores[name] === 'number' && dimensionScores[name] >= NARROW_FEATURE_DIM_FLOOR);
+    return entries
+      .filter(([, value]) => {
+        const score = dimScoreOf(value);
+        return score !== null && score >= NARROW_FEATURE_DIM_FLOOR;
+      })
+      .map(([key]) => key);
   }
 
-  return dimNames.filter(name =>
-    patterns.some(p => name.toLowerCase().includes(p.toLowerCase())));
+  return entries
+    .filter(([key, value]) => {
+      const name = dimNameOf(key, value).toLowerCase();
+      return patterns.some(p => name.includes(p.toLowerCase()));
+    })
+    .map(([key]) => key);
 }
 
 /**

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -196,8 +196,6 @@ async function checkOverride(sdType, supabase) {
  */
 function getDimensionWarnings(dimensionScores) {
   if (!dimensionScores || typeof dimensionScores !== 'object') return [];
-  // QF-20260713-713: rich scorer values ({ name, score, ... } keyed by A01/V01 IDs)
-  // previously failed the typeof === 'number' filter, silently muting all warnings.
   return Object.entries(dimensionScores)
     .map(([key, value]) => [dimNameOf(key, value), dimScoreOf(value)])
     .filter(([, score]) => typeof score === 'number' && score < DIMENSION_WARNING_THRESHOLD)
@@ -317,13 +315,9 @@ export async function validateVisionScore(sd, supabase, deps = {}) {
   let thresholdAction = sd.vision_score_action ?? null;
   let dimensionScores = sd.dimension_scores ?? null;
 
-  // Fetch latest score from eva_vision_scores if EITHER piece is missing.
-  // QF-20260713-713 (non-determinism): scoreSD() syncs only the SCALAR
-  // sd.vision_score back to strategic_directives_v2 (there is no dimension_scores
-  // column on the SD), so gating this fetch on the scalar alone starved every
-  // post-first-run evaluation of dimension context — countAddressableDimensions
-  // saw {0,0}, dynamic-threshold/floor-rule narrowing vanished, and a first-run
-  // floor-rule PASS flipped to a hard BLOCK on the very next run of the same SD.
+  // Fetch if EITHER piece is missing. QF-20260713-713: scoreSD() syncs only the
+  // SCALAR back to the SD (no dimension_scores column there); gating this fetch
+  // on the scalar alone starved retries of dimension context, flipping verdicts.
   if ((visionScore === null || dimensionScores === null) && supabase && sdKey) {
     try {
       const { data } = await supabase
@@ -427,8 +421,7 @@ export async function validateVisionScore(sd, supabase, deps = {}) {
     const typePatterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
     let addressableDimScores = null;
     if (typePatterns) {
-      // Type-pattern path. QF-20260713-713: match on the dimension NAME (rich
-      // values are keyed by opaque A01/V01 IDs) and extract .score from rich values.
+      // Type-pattern path: match the dimension NAME, not the opaque A01/V01 key.
       addressableDimScores = Object.entries(dimensionScores)
         .filter(([key, value]) => {
           const name = dimNameOf(key, value).toLowerCase();

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -41,6 +41,8 @@ import {
   getAddressableDimNames,
   countAddressableDimensions,
   calculateDynamicThreshold,
+  dimScoreOf,
+  dimNameOf,
 } from '../../../../../../lib/handoff/threshold-resolver.js';
 export {
   SD_TYPE_THRESHOLDS,
@@ -53,6 +55,8 @@ export {
   getAddressableDimNames,
   countAddressableDimensions,
   calculateDynamicThreshold,
+  dimScoreOf,
+  dimNameOf,
 };
 
 /**
@@ -192,7 +196,10 @@ async function checkOverride(sdType, supabase) {
  */
 function getDimensionWarnings(dimensionScores) {
   if (!dimensionScores || typeof dimensionScores !== 'object') return [];
+  // QF-20260713-713: rich scorer values ({ name, score, ... } keyed by A01/V01 IDs)
+  // previously failed the typeof === 'number' filter, silently muting all warnings.
   return Object.entries(dimensionScores)
+    .map(([key, value]) => [dimNameOf(key, value), dimScoreOf(value)])
     .filter(([, score]) => typeof score === 'number' && score < DIMENSION_WARNING_THRESHOLD)
     .map(([dim, score]) =>
       `Dimension '${dim}': ${score}/100 (below ${DIMENSION_WARNING_THRESHOLD} warning threshold)`
@@ -310,8 +317,14 @@ export async function validateVisionScore(sd, supabase, deps = {}) {
   let thresholdAction = sd.vision_score_action ?? null;
   let dimensionScores = sd.dimension_scores ?? null;
 
-  // Fetch latest score from eva_vision_scores if not cached
-  if (visionScore === null && supabase && sdKey) {
+  // Fetch latest score from eva_vision_scores if EITHER piece is missing.
+  // QF-20260713-713 (non-determinism): scoreSD() syncs only the SCALAR
+  // sd.vision_score back to strategic_directives_v2 (there is no dimension_scores
+  // column on the SD), so gating this fetch on the scalar alone starved every
+  // post-first-run evaluation of dimension context — countAddressableDimensions
+  // saw {0,0}, dynamic-threshold/floor-rule narrowing vanished, and a first-run
+  // floor-rule PASS flipped to a hard BLOCK on the very next run of the same SD.
+  if ((visionScore === null || dimensionScores === null) && supabase && sdKey) {
     try {
       const { data } = await supabase
         .from('eva_vision_scores')
@@ -321,9 +334,9 @@ export async function validateVisionScore(sd, supabase, deps = {}) {
         .limit(1);
 
       if (data && data.length > 0) {
-        visionScore = data[0].total_score;
-        thresholdAction = data[0].threshold_action;
-        dimensionScores = data[0].dimension_scores ?? null;
+        visionScore = visionScore ?? data[0].total_score;
+        thresholdAction = thresholdAction ?? data[0].threshold_action;
+        dimensionScores = dimensionScores ?? data[0].dimension_scores ?? null;
       }
     } catch (e) {
       // Intentionally suppressed: DB unavailable — proceed to hard block
@@ -414,15 +427,19 @@ export async function validateVisionScore(sd, supabase, deps = {}) {
     const typePatterns = SD_TYPE_ADDRESSABLE_DIMENSIONS[sdType];
     let addressableDimScores = null;
     if (typePatterns) {
-      // Type-pattern path (unchanged behavior).
+      // Type-pattern path. QF-20260713-713: match on the dimension NAME (rich
+      // values are keyed by opaque A01/V01 IDs) and extract .score from rich values.
       addressableDimScores = Object.entries(dimensionScores)
-        .filter(([name]) => typePatterns.some(p => name.toLowerCase().includes(p.toLowerCase())))
-        .map(([, score]) => score)
+        .filter(([key, value]) => {
+          const name = dimNameOf(key, value).toLowerCase();
+          return typePatterns.some(p => name.includes(p.toLowerCase()));
+        })
+        .map(([, value]) => dimScoreOf(value))
         .filter(s => typeof s === 'number');
     } else if (!hasManualOverride) {
       // null-type auto-detect carve-out path: score the auto-detected addressable dims.
       addressableDimScores = getAddressableDimNames(sdType, dimensionScores, sd.metadata)
-        .map(name => dimensionScores[name])
+        .map(key => dimScoreOf(dimensionScores[key]))
         .filter(s => typeof s === 'number');
     }
 

--- a/tests/unit/eva/vision-score-gate-dimension-context.test.js
+++ b/tests/unit/eva/vision-score-gate-dimension-context.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit Tests: GATE_VISION_SCORE determinism + rich dimension_scores handling
+ * QF-20260713-713 (retro f555deb9-1b91-4a3b-9888-b63a981d69e6, RCA feedback
+ * 16560e8a-d929-4fb2-bb44-934277589020)
+ *
+ * Two bugs made the gate non-deterministic across consecutive runs:
+ *  1. scoreSD() syncs only the SCALAR sd.vision_score back to the SD row, and
+ *     the gate fetched eva_vision_scores dimension context ONLY when that
+ *     scalar was null — so every post-first-run evaluation lost dimension
+ *     context and a floor-rule/dynamic-threshold PASS flipped to a hard BLOCK.
+ *  2. Addressability matching compared SD-type patterns against
+ *     dimension_scores KEYS (opaque A01/V01 IDs) instead of each value's .name,
+ *     and typeof === 'number' checks missed rich { name, score, ... } values.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validateVisionScore,
+} from '../../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
+import {
+  getAddressableDimNames,
+  countAddressableDimensions,
+  dimScoreOf,
+  dimNameOf,
+} from '../../../lib/handoff/threshold-resolver.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Rich scorer shape: keyed by opaque IDs, values carry { name, score, ... }. */
+const RICH_DIMS = {
+  A01: { name: 'stateless_architecture', score: 80, weight: 0.1, source: 'architecture' },
+  A02: { name: 'reliability_first', score: 80, weight: 0.1, source: 'architecture' },
+  V01: { name: 'automation_by_default', score: 80, weight: 0.1, source: 'vision' },
+  V02: { name: 'security_posture', score: 80, weight: 0.1, source: 'vision' },
+  V03: { name: 'market_fit', score: 40, weight: 0.1, source: 'vision' },
+  V04: { name: 'brand_presence', score: 40, weight: 0.1, source: 'vision' },
+  V05: { name: 'customer_delight', score: 40, weight: 0.1, source: 'vision' },
+  V06: { name: 'revenue_expansion', score: 40, weight: 0.1, source: 'vision' },
+  V07: { name: 'community_growth', score: 40, weight: 0.1, source: 'vision' },
+  V08: { name: 'partner_ecosystem', score: 40, weight: 0.1, source: 'vision' },
+};
+
+function makeSupabase(record) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: record ? [record] : [] }),
+    insert: vi.fn().mockResolvedValue({ error: null }),
+  };
+  return { from: vi.fn().mockReturnValue(chain), _chain: chain };
+}
+
+// ─── Resolver: rich-value addressability (bug 2) ─────────────────────────────
+
+describe('threshold-resolver rich dimension_scores handling', () => {
+  it('dimScoreOf extracts numbers from flat and rich values', () => {
+    expect(dimScoreOf(85)).toBe(85);
+    expect(dimScoreOf({ name: 'x', score: 42 })).toBe(42);
+    expect(dimScoreOf({ name: 'x' })).toBeNull();
+    expect(dimScoreOf(null)).toBeNull();
+  });
+
+  it('dimNameOf prefers .name on rich values, falls back to the key', () => {
+    expect(dimNameOf('A01', { name: 'automation_by_default', score: 1 })).toBe('automation_by_default');
+    expect(dimNameOf('reliability', 80)).toBe('reliability');
+  });
+
+  it('type-pattern matching works against rich values keyed by opaque IDs', () => {
+    // infrastructure patterns include architecture/reliability/automation/security
+    const keys = getAddressableDimNames('infrastructure', RICH_DIMS, null);
+    expect(keys.sort()).toEqual(['A01', 'A02', 'V01', 'V02']);
+    // Returned strings are KEYS so callers can index back into dimensionScores.
+    expect(RICH_DIMS[keys[0]]).toBeDefined();
+  });
+
+  it('null-pattern carve-out auto-detects addressable dims from rich .score values', () => {
+    const keys = getAddressableDimNames('feature', RICH_DIMS, null);
+    // NARROW_FEATURE_DIM_FLOOR = 50 → only the four 80-scored dims qualify
+    expect(keys.sort()).toEqual(['A01', 'A02', 'V01', 'V02']);
+  });
+
+  it('manual override patterns match rich value names', () => {
+    const keys = getAddressableDimNames('feature', RICH_DIMS, { vision_addressable_dimensions: ['automation'] });
+    expect(keys).toEqual(['V01']);
+  });
+
+  it('legacy flat { name: score } shape is unchanged', () => {
+    const flat = { reliability: 80, market_fit: 40 };
+    expect(getAddressableDimNames('bugfix', flat, null)).toEqual(['reliability']);
+    expect(countAddressableDimensions('bugfix', flat, null)).toEqual({ addressable: 1, total: 2 });
+  });
+});
+
+// ─── Gate: retry determinism (bug 1) ──────────────────────────────────────────
+
+describe('validateVisionScore retry determinism (QF-20260713-713)', () => {
+  const scoreRow = {
+    total_score: 71,
+    threshold_action: 'gap_closure_sd',
+    dimension_scores: RICH_DIMS,
+    scored_at: new Date().toISOString(),
+  };
+
+  it('first run (no cached scalar) passes via dynamic threshold narrowing', async () => {
+    const supabase = makeSupabase(scoreRow);
+    const sd = { sd_key: 'SD-TEST-DET-001', sd_type: 'infrastructure', vision_score: null };
+    const result = await validateVisionScore(sd, supabase);
+    // 4/10 addressable → threshold max(80*0.4, 80*0.6) = 48 → 71 passes
+    expect(result.passed).toBe(true);
+  });
+
+  it('retry (cached scalar, no SD dimension column) re-fetches dimension context and returns the SAME verdict', async () => {
+    const supabase = makeSupabase(scoreRow);
+    // scoreSD() synced the scalar back; strategic_directives_v2 has no dimension_scores column.
+    const sd = { sd_key: 'SD-TEST-DET-001', sd_type: 'infrastructure', vision_score: 71, vision_score_action: 'gap_closure_sd' };
+    const result = await validateVisionScore(sd, supabase);
+    // Pre-fix: dims stayed null → {0,0} addressable → threshold 80 → 71 hard-BLOCKED.
+    expect(result.passed).toBe(true);
+    expect(supabase.from).toHaveBeenCalledWith('eva_vision_scores');
+  });
+
+  it('cached scalar is NOT overwritten by the dimension-context fetch', async () => {
+    const supabase = makeSupabase({ ...scoreRow, total_score: 5 });
+    const sd = { sd_key: 'SD-TEST-DET-002', sd_type: 'infrastructure', vision_score: 71, vision_score_action: 'gap_closure_sd' };
+    const result = await validateVisionScore(sd, supabase);
+    // The fetch fills ONLY the missing dimension context; the cached 71 stands.
+    expect(result.details).toContain('71/100');
+  });
+
+  it('rich low-scoring dimensions surface as named warnings on a pass', async () => {
+    const supabase = makeSupabase(scoreRow);
+    const sd = { sd_key: 'SD-TEST-DET-003', sd_type: 'infrastructure', vision_score: 71, vision_score_action: 'gap_closure_sd' };
+    const result = await validateVisionScore(sd, supabase);
+    expect(result.passed).toBe(true);
+    // Pre-fix getDimensionWarnings silently muted rich values (typeof object).
+    expect(result.warnings.some(w => w.includes('market_fit'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the GATE_VISION_SCORE non-determinism harness bug (QF-20260713-713, retro f555deb9, RCA feedback 16560e8a, confidence 0.95).

**Primary — pass/fail flip between consecutive runs**: `scoreSD()` syncs only the scalar `sd.vision_score` back to `strategic_directives_v2` (no `dimension_scores` column exists there), but the gate fetched `eva_vision_scores` dimension context only when that scalar was null. The gate's own first-run auto-score therefore starved every retry of dimension context — addressability collapsed to {0,0}, dynamic-threshold/floor-rule narrowing vanished, and a first-run PASS flipped to a hard BLOCK on the next run of the same SD. The fetch now fires when EITHER piece is missing and fills only the missing pieces.

**Secondary — latent addressability dead-match**: the vision-scorer writes `dimension_scores` keyed by opaque IDs (A01/V01) with rich `{ name, score, ... }` values. Pattern matching compared type patterns against the KEYS, and `typeof === 'number'` checks missed rich values — type-pattern matching could never succeed and dimension warnings were silently muted. New `dimNameOf()`/`dimScoreOf()` helpers match on `.name` and extract `.score`; legacy flat shapes unchanged. Also corrects `heal-before-complete.js`'s `countAddressableDimensions()` reads (same shared resolver).

## Tests
- New `tests/unit/eva/vision-score-gate-dimension-context.test.js`: 10 tests — retry-determinism regression (cached scalar → same verdict as first run), rich-value addressability, carve-out scoring, manual override, legacy flat-shape back-compat, named warnings.
- Existing `vision-score-gate-autoscore.test.js` (10) and colocated `vision-score.test.js` (43) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)