### PR TITLE
fix(QF-20260713-266): [Retro action items] 5c4c65de-1d10-4a21-9edf-37cee7c0920c

### DIFF
--- a/lib/sub-agents/testing/phases/phase3-execution.js
+++ b/lib/sub-agents/testing/phases/phase3-execution.js
@@ -7,10 +7,15 @@
  * SD: SD-LEO-REFAC-TESTING-INFRA-001
  */
 
+import { spawn } from 'child_process';
+import { mkdirSync, readFileSync } from 'fs';
+import path from 'path';
 import {
   suggestTroubleshootingTactics,
   logTroubleshootingTactics
 } from '../utils/troubleshooting.js';
+
+const DEFAULT_E2E_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Execute E2E tests
@@ -35,17 +40,11 @@ export async function executeE2ETests(sdId, options, supabase) {
 
   try {
     if (options.full_e2e) {
-      console.log('      🚀 Full E2E suite requested');
-      console.log('      💡 Would execute: npm run test:e2e');
-      console.log('      ⏭️  Simulated execution (implement actual test runner)');
-
-      // Simulated results for demonstration
-      results.tests_executed = 10;
-      results.tests_passed = 10;
-      results.execution_time_ms = 15000;
-      results.report_url = `tests/e2e/evidence/${sdId}/playwright-report.html`;
-
-      console.log('      ✅ Simulated: 10/10 tests passed (15s)');
+      console.log('      🚀 Full E2E suite requested — executing Playwright');
+      const e2eResults = await runFullE2ESuite(sdId, options);
+      Object.assign(results, e2eResults);
+      const icon = results.failed_tests === 0 && !results.error ? '✅' : '❌';
+      console.log(`      ${icon} E2E: ${results.tests_passed}/${results.tests_executed} passed, ${results.failed_tests} failed, ${results.skipped_tests} skipped (${Math.round(results.execution_time_ms / 1000)}s)`);
     } else {
       console.log('      ℹ️  Full E2E suite not requested (use --full-e2e flag)');
       console.log('      💡 Checking for existing test evidence...');
@@ -70,6 +69,68 @@ export async function executeE2ETests(sdId, options, supabase) {
   }
 
   return results;
+}
+
+/**
+ * Run the full Playwright E2E suite for real and parse the JSON report.
+ * Was a simulated no-op (hard-coded 10/10 pass) until QF-20260713-266 —
+ * gate verdicts consumed fabricated evidence.
+ * @param {string} sdId - Strategic Directive ID (evidence directory key)
+ * @param {Object} options - may carry e2e_timeout_ms override
+ * @returns {Promise<Object>} results fields for executeE2ETests
+ */
+export async function runFullE2ESuite(sdId, options = {}) {
+  const evidenceDir = path.join('tests', 'e2e', 'evidence', String(sdId));
+  mkdirSync(evidenceDir, { recursive: true });
+  const jsonReportPath = path.join(evidenceDir, 'playwright-results.json');
+  const timeoutMs = options.e2e_timeout_ms || DEFAULT_E2E_TIMEOUT_MS;
+  const startedAt = Date.now();
+
+  const exitCode = await new Promise((resolve, reject) => {
+    const child = spawn('npx', ['playwright', 'test', '--config=playwright.config.js', '--reporter=json'], {
+      env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_NAME: jsonReportPath },
+      stdio: ['ignore', 'inherit', 'inherit'],
+      shell: process.platform === 'win32'
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`E2E suite timed out after ${Math.round(timeoutMs / 1000)}s`));
+    }, timeoutMs);
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('exit', (code) => { clearTimeout(timer); resolve(code ?? 1); });
+  });
+
+  const report = JSON.parse(readFileSync(jsonReportPath, 'utf8'));
+  const stats = report.stats || {};
+  const failures = [];
+  for (const suite of report.suites || []) collectFailures(suite, failures);
+
+  const parsed = {
+    tests_executed: (stats.expected || 0) + (stats.unexpected || 0) + (stats.flaky || 0),
+    tests_passed: (stats.expected || 0) + (stats.flaky || 0),
+    failed_tests: stats.unexpected || 0,
+    skipped_tests: stats.skipped || 0,
+    execution_time_ms: Math.round(stats.duration || (Date.now() - startedAt)),
+    failures: failures.slice(0, 20),
+    report_url: jsonReportPath
+  };
+  // Non-zero exit with zero reported failures = config/infra error, never a pass
+  if (exitCode !== 0 && parsed.failed_tests === 0) {
+    parsed.error = `Playwright exited ${exitCode} with no failing tests in report — config/infra error, not a pass`;
+  }
+  return parsed;
+}
+
+/**
+ * Recursively collect failed specs from a Playwright JSON-report suite.
+ * @param {Object} suite - report suite node
+ * @param {Array} failures - accumulator of {test, file, line}
+ */
+export function collectFailures(suite, failures) {
+  for (const spec of suite.specs || []) {
+    if (spec.ok === false) failures.push({ test: spec.title, file: spec.file, line: spec.line });
+  }
+  for (const child of suite.suites || []) collectFailures(child, failures);
 }
 
 /**

--- a/lib/sub-agents/testing/phases/phase3-execution.js
+++ b/lib/sub-agents/testing/phases/phase3-execution.js
@@ -73,11 +73,7 @@ export async function executeE2ETests(sdId, options, supabase) {
 
 /**
  * Run the full Playwright E2E suite for real and parse the JSON report.
- * Was a simulated no-op (hard-coded 10/10 pass) until QF-20260713-266 —
- * gate verdicts consumed fabricated evidence.
- * @param {string} sdId - Strategic Directive ID (evidence directory key)
- * @param {Object} options - may carry e2e_timeout_ms override
- * @returns {Promise<Object>} results fields for executeE2ETests
+ * Was a simulated no-op (hard-coded 10/10 pass) until QF-20260713-266.
  */
 export async function runFullE2ESuite(sdId, options = {}) {
   const evidenceDir = path.join('tests', 'e2e', 'evidence', String(sdId));
@@ -121,11 +117,7 @@ export async function runFullE2ESuite(sdId, options = {}) {
   return parsed;
 }
 
-/**
- * Recursively collect failed specs from a Playwright JSON-report suite.
- * @param {Object} suite - report suite node
- * @param {Array} failures - accumulator of {test, file, line}
- */
+/** Recursively collect failed specs from a Playwright JSON-report suite. */
 export function collectFailures(suite, failures) {
   for (const spec of suite.specs || []) {
     if (spec.ok === false) failures.push({ test: spec.title, file: spec.file, line: spec.line });

--- a/tests/unit/testing-subagent/phase3-collect-failures.test.js
+++ b/tests/unit/testing-subagent/phase3-collect-failures.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { collectFailures } from '../../../lib/sub-agents/testing/phases/phase3-execution.js';
+
+describe('QF-20260713-266: Playwright JSON report failure collection', () => {
+  it('collects failed specs recursively and skips passing ones', () => {
+    const suite = {
+      specs: [
+        { title: 'passes', ok: true, file: 'a.spec.js', line: 1 },
+        { title: 'fails', ok: false, file: 'a.spec.js', line: 9 }
+      ],
+      suites: [
+        { specs: [{ title: 'nested fail', ok: false, file: 'b.spec.js', line: 3 }], suites: [] }
+      ]
+    };
+    const failures = [];
+    collectFailures(suite, failures);
+    expect(failures).toEqual([
+      { test: 'fails', file: 'a.spec.js', line: 9 },
+      { test: 'nested fail', file: 'b.spec.js', line: 3 }
+    ]);
+  });
+
+  it('handles suites with no specs/suites arrays', () => {
+    const failures = [];
+    collectFailures({}, failures);
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260713-266

**Type:** bug
**Severity:** medium

### Issue Description
Auto-promoted from 2 high-priority action item(s) in retrospective 3137fb11-829b-4bb5-bf4b-b54b04ee1362 (SD 5c4c65de-1d10-4a21-9edf-37cee7c0920c).
1. Investigate and fix the root cause of the simulated no-op in the TESTING sub-agent's --full-e2e flag (fake pass count instead of a real Playwright invocation) -- already logged as a harness bug this session; needs a durable fix so the gate's pass/fail verdict can be trusted without manual cross-checking. (owner: harness / TESTING sub-agent maintainer, success criteria: n/a)
2. Investigate the sprint's auto doc-gen pipeline for the template-contamination bug that copied this SD's design-spec boilerplate verbatim into sibling SD J3's description field -- root cause needed to prevent future OVERLAPPING_SCOPE_DETECTION false-similarity flags on unrelated SDs. (owner: sprint doc-gen pipeline maintainer, success criteria: n/a)




### Changes
- **Files Changed:** 2
  - lib/sub-agents/testing/phases/phase3-execution.js
  - tests/unit/testing-subagent/phase3-collect-failures.test.js
- **LOC:** 92 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Item 1 fixed: full_e2e now spawns real 'npx playwright test --reporter=json' into tests/e2e/evidence/<sd>/playwright-results.json, parses stats, collects failures, treats nonzero-exit+no-failures as infra error. Unit test added (collectFailures, 2 passing). Item 2 (J3 template contamination): symptom already remediated in DB (J3 description carries correction note); root cause sits in the sprint child-SD LLM layer-decomposition generation reusing sibling design-spec context — flagged to coordinator, out of QF scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol