### PR TITLE
feat(SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001): rewire dark fix-effectiveness infrastructure

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001.json
@@ -1,0 +1,128 @@
+{
+  "executive_summary": "lib/learning/outcome-tracker.js already contains BOTH halves of a fix-effectiveness back-edge (computeEffectiveness/recordSdCompleted and detectRecurrence) but they are dark: built, never wired to real data or real callers. This SD rewires four confirmed disconnects (Adam-sourced, Solomon hand-off #4 ITEM A, 5-agent-vetted, verified against live code and DB by both an Explore pass and the LEAD validation-agent): (FR-1) outcome-tracker.js reads a near-abandoned table (leo_feedback, 1 orphan row) instead of the table the sourcing engine actually writes (feedback, 8,815 rows) -- retable, mapping resolved_by_sd_id -> resolution_sd_id; (FR-2) detectRecurrence (jaccard-similarity fingerprint matching) has zero production callers -- wire it via the existing lightweight fire-and-forget vision-events.js bus (not the heavier durable event-router.js), triggered from the canonical emitFeedback/emitFeedbackBatch insert path; (FR-3) sd_effectiveness_metrics is effectively write-only (its one reader, getOutcomeSummary, is itself uncalled) -- add a real consumer, but ONLY after FR-1 ships, since all 2,886 existing rows are pre=0/post=0/pct=null garbage computed against the near-empty leo_feedback; (FR-4) scripts/complete-quick-fix.js never touches outcome-tracker.js -- QFs are a complete blind spot in fix-effectiveness tracking.",
+  "business_context": "This is remediation of dark infrastructure, not new build -- the progenitor SD (SD-LEO-ORCH-SELF-IMPROVING-LEO-001-C, 'Outcome Loop Closure Automation', completed) built both functions but never fully wired them. Without this rewiring, the system cannot answer 'did this fix actually work' or 'is this the same defect recurring' -- exactly the questions a self-improving fleet needs answered to avoid re-shipping the same broken fix repeatedly. LEAD validation-agent confirmed no duplicate/overlapping open SD exists; this is legitimate remediation.",
+  "technical_context": "Verified by an Explore-agent pass + LEAD validation-agent (evidence 64dffe42-e6df-47fb-bebf-1a69a2dfddb7) against live code and the live DB: (1) outcome-tracker.js:83,151,301 read leo_feedback (1 orphan row, no writer anywhere in the codebase); scripts/sd-from-feedback.js:306-314 writes/updates the feedback table (8,815 rows, active). scripts/leo-analytics.js:38 has the identical disjoint-table bug and should be retabled in the same pass. (2) feedback has NO resolved_by_sd_id column -- outcome-tracker.js's reads/writes of that column (lines 152,164-165,176-177,189-192,333,335,406) must map to feedback.resolution_sd_id (125 populated rows -- the same column sd-from-feedback.js already writes at promotion time, line 311-312). (3) detectRecurrence (lines 293-388) is a pure, already-correct jaccard-similarity matcher writing outcome_signals(signal_type='pattern_recurrence') -- outcome_signals currently has 3,169 rows, ALL sd_completion, ZERO pattern_recurrence, confirming it has genuinely never fired. (4) Feedback insert volume is 68-507/day (~300 avg, bursty) -- too heavy to run detectRecurrence's 3 queries + jaccard-over-~3,288-rows + 1 insert INLINE on the feedback-creation hot path. lib/eva/event-bus/vision-events.js's publishVisionEvent()/subscribeVisionEvent() is the established, already-proven lightweight fire-and-forget bus for exactly this kind of feedback-adjacent async work (see lib/eva/event-bus/handlers/feedback-quality-updated.js as the existing analog) -- publishVisionEvent catches BOTH sync and async handler errors internally so a subscriber can never cascade a failure back to the publisher (lib/governance/emit-feedback.js, which is documented 'MUST NOT throw -- best-effort', 44 importers). This is a lighter, already-sufficient seam versus the heavier durable lib/eva/event-bus/event-router.js (ledger/DLQ/retry) that a first pass considered -- using the simpler bus avoids over-building for this scope. KNOWN COVERAGE GAP (explicitly tracked, not solved in this SD): ~40+ files insert into feedback directly rather than through emitFeedback/emitFeedbackBatch, so wiring only at the canonical emit path covers those two call sites but not raw inserts elsewhere -- documented as a residual gap, matching this codebase's convention of surfacing known limitations rather than silently over-claiming full coverage. (5) scripts/modules/complete-quick-fix/orchestrator.js has zero import of outcome-tracker.js; it already has an existing fail-soft, gated hook pattern for post-merge feedback resolution (lines 687-791, RESOLVE_FEEDBACK_ON_QF_COMPLETE) calling lib/governance/resolve-feedback.js -- the new outcome-tracker hook should follow this exact same fail-soft/gated-flag convention, as a SEPARATE call alongside (not replacing) the existing resolve-feedback.js path, since outcome-tracker becomes a second resolution-writer and must not conflict with it.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Retable outcome-tracker.js (and leo-analytics.js) reads/writes from leo_feedback to feedback",
+      "description": "In lib/learning/outcome-tracker.js, change every leo_feedback reference (lines 83,151,301, and the .select()/.update()/.filter() calls around them) to feedback, and map every resolved_by_sd_id reference (152,164-165,176-177,189-192,333,335,406) to resolution_sd_id (feedback's actual column). Apply the identical table-name fix to scripts/leo-analytics.js:38 (same disjoint-table bug, confirmed by LEAD validation-agent). No other logic changes -- this is a pure retable + column-rename pass; the jaccard/effectiveness computation logic itself is already correct and untouched.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "computeEffectiveness/recordSdCompleted read exclusively from feedback (zero remaining leo_feedback references in outcome-tracker.js)",
+        "All resolved_by_sd_id references are mapped to resolution_sd_id, verified against feedback's live schema (no column-not-found errors)",
+        "scripts/leo-analytics.js's feedback metrics read from feedback, not leo_feedback",
+        "A unit test seeding feedback fixtures (not leo_feedback) proves computeEffectiveness resolves them correctly"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Wire detectRecurrence via the fire-and-forget vision-events bus, triggered from the canonical feedback-creation path",
+      "description": "Add a new event type to lib/eva/event-bus/vision-events.js's VISION_EVENTS map (e.g. FEEDBACK_CREATED: 'feedback.created'). In lib/governance/emit-feedback.js, call publishVisionEvent(VISION_EVENTS.FEEDBACK_CREATED, { feedbackId, supabase, ... }) immediately after the successful .insert() at line 275 (and the equivalent point in emitFeedbackBatch's insert at line 422) -- fire-and-forget, matching the existing 'MUST NOT throw' contract of emitFeedback. Add a new handler file lib/eva/event-bus/handlers/feedback-created.js (mirroring feedback-quality-updated.js's registration pattern: registerFeedbackCreatedHandlers(), idempotent _registered guard) whose single subscriber calls detectRecurrence({ supabase, newFeedbackId: feedbackId }) -- publishVisionEvent's own error isolation (catches both sync and async handler errors) means this subscriber can never cascade a failure back into emitFeedback's caller, so no additional try/catch wrapping is needed beyond what detectRecurrence itself already does internally. Document the known coverage gap (raw feedback inserts bypassing emitFeedback/emitFeedbackBatch are NOT covered by this wiring) directly in the handler's file comment.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "A feedback row created via emitFeedback() or emitFeedbackBatch() triggers detectRecurrence exactly once, verified by a unit test seeding two similar feedback rows above the jaccard threshold and asserting a real outcome_signals(signal_type='pattern_recurrence') insert results",
+        "A handler that throws (simulated in a unit test) does not propagate an error back to emitFeedback's caller -- emitFeedback's own return value/success path is unaffected",
+        "The known coverage gap (raw inserts bypassing emitFeedback) is documented in-code, not silently unaddressed"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Add a live consumer of sd_effectiveness_metrics (ships AFTER FR-1, not before)",
+      "description": "Add a real, reachable-from-production consumer of sd_effectiveness_metrics -- either exposing getOutcomeSummary() (lib/learning/outcome-tracker.js:390) through a new CLI script (e.g. scripts/outcome-effectiveness-summary.mjs) that a human or another automation can run to see real pre/post fix-effectiveness deltas, OR wiring it as one additional signal into an existing sourcing-priority scorer -- EXEC's choice, whichever is the smaller, more clearly-scoped change; either way it must be a genuinely CALLED path (verified reachable), not another dead export. This FR has a HARD DEPENDENCY on FR-1: shipping a consumer before the retable would surface the existing 2,886 garbage rows (pre=0/post=0/pct=null) as if they were real data -- FR-1 must land first (or in the same PR) so the consumer reads real, non-fabricated numbers from day one.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "A real, callable consumer of sd_effectiveness_metrics exists and is verified reachable from a production entry point (CLI invocation or an existing scheduled/triggered path), not merely an exported-but-uncalled function",
+        "Run live against the DB after FR-1 ships: the consumer's output reflects real (non-zero-garbage) computed values for at least one SD with genuine pre/post feedback counts",
+        "No consumer is added before FR-1's retable lands (sequencing verified in the PR itself, e.g. both FRs in one PR, or FR-3 explicitly follows FR-1's merge)"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Hook complete-quick-fix.js into the outcome tracker (fail-soft, alongside the existing resolve-feedback.js path)",
+      "description": "In scripts/modules/complete-quick-fix/orchestrator.js, add a new fail-soft, gated hook (mirroring the existing RESOLVE_FEEDBACK_ON_QF_COMPLETE pattern at lines 687-791) that records an outcome-tracker entry for the completed QF -- either calling recordSdCompleted with the QF's identity if its shape is QF-compatible, or a new lightweight QF-scoped equivalent if not. This is a SEPARATE, additive call alongside the existing resolve-feedback.js path -- it must NOT replace or conflict with resolve-feedback.js's existing resolution-writing behavior (outcome-tracker becomes a second, independent resolution-writer; both must coexist without racing or double-writing the same feedback row inconsistently).",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "Completing a quick-fix via scripts/complete-quick-fix.js produces a real outcome-tracker record (verified by a test asserting the hook fires on QF completion)",
+        "The existing resolve-feedback.js post-merge resolution behavior is unaffected -- a regression test confirms both paths run without conflicting writes to the same feedback row",
+        "The new hook follows the fail-soft convention (a hook failure never blocks or fails QF completion itself)"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "No schema change", "description": "feedback, leo_feedback, outcome_signals, sd_effectiveness_metrics all already exist with the needed columns (resolution_sd_id already on feedback) -- this is read/write logic and event-wiring only." },
+    { "id": "TR-2", "title": "Fire-and-forget event wiring", "description": "FR-2's detectRecurrence trigger must use vision-events.js's existing error-isolated publish/subscribe, never a synchronous inline call inside emitFeedback's hot path." },
+    { "id": "TR-3", "title": "FR-1 before FR-3 sequencing", "description": "The retable (FR-1) must land before or together with the new metrics consumer (FR-3) so the consumer never surfaces fabricated/garbage data." },
+    { "id": "TR-4", "title": "No regression to resolve-feedback.js", "description": "FR-4's new QF outcome-tracker hook must coexist with, not replace, the existing resolve-feedback.js resolution path." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "FR-1: computeEffectiveness against seeded feedback fixtures (not leo_feedback)", "type": "unit", "expected": "correctly resolves pre/post counts using resolution_sd_id" },
+    { "id": "TS-2", "scenario": "FR-2: two similar feedback rows above the jaccard threshold, created via emitFeedback()", "type": "unit", "expected": "detectRecurrence fires exactly once, writes a real outcome_signals pattern_recurrence row" },
+    { "id": "TS-3", "scenario": "FR-2: a subscriber handler that throws", "type": "unit", "expected": "emitFeedback's caller sees no error, its own success path is unaffected" },
+    { "id": "TS-4", "scenario": "FR-3: run the new consumer live against the DB after FR-1 lands", "type": "integration", "expected": "output reflects real, non-garbage computed effectiveness for at least one SD" },
+    { "id": "TS-5", "scenario": "FR-4: complete a quick-fix end-to-end", "type": "unit", "expected": "an outcome-tracker record is produced; resolve-feedback.js's existing behavior is unaffected (regression check)" }
+  ],
+  "acceptance_criteria": [
+    "FR-1/FR-2/FR-3/FR-4 all pass their respective acceptance criteria above",
+    "detectRecurrence fires for the first time ever in this system's history against real feedback data (outcome_signals gains its first pattern_recurrence row when a genuine recurrence is seeded)",
+    "sd_effectiveness_metrics gains a real, verified-reachable consumer, sequenced strictly after the FR-1 retable",
+    "Quick-fixes are no longer a blind spot in fix-effectiveness tracking",
+    "No regression to the existing resolve-feedback.js QF resolution path or to recordSdCompleted's existing lead-final-approval integration"
+  ],
+  "risks": [
+    {
+      "risk": "Retabling from leo_feedback to feedback could silently change effectiveness-computation results if the two tables have divergent historical shapes",
+      "mitigation": "Verified via Explore + validation-agent that leo_feedback is genuinely abandoned (1 orphan row, zero writers anywhere) while feedback is the live, actively-written table (8,815 rows) -- this is a bug fix, not a risky migration. Unit tests assert the new read path resolves real fixtures correctly.",
+      "severity": "low"
+    },
+    {
+      "risk": "Wiring detectRecurrence into the feedback-creation path could add latency or a new failure mode if done synchronously",
+      "mitigation": "Uses the already-proven fire-and-forget vision-events.js bus (error-isolated, both sync and async), matching the existing feedback-quality-updated.js handler pattern -- never an inline blocking call.",
+      "severity": "low"
+    },
+    {
+      "risk": "Outcome-tracker becomes a second resolution-writer (alongside resolve-feedback.js and sd-from-feedback.js), risking conflicting writes to the same feedback row",
+      "mitigation": "FR-4 is explicitly scoped as an ADDITIVE, separate call, not a replacement; a regression test confirms both paths coexist without conflicting writes.",
+      "severity": "medium"
+    },
+    {
+      "risk": "FR-2's coverage is incomplete -- ~40+ files insert into feedback directly, bypassing emitFeedback/emitFeedbackBatch",
+      "mitigation": "Explicitly documented as a known, tracked residual gap (matching this codebase's honest-limitation convention) rather than silently claiming full coverage; not solved in this SD's scope.",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": ["scripts/modules/handoff/executors/lead-final-approval/index.js (existing recordSdCompleted caller, now reading real data post-FR-1)", "New FR-3 consumer of sd_effectiveness_metrics", "scripts/complete-quick-fix.js (new FR-4 hook)"],
+    "dependencies": ["feedback table (existing, no schema change)", "lib/eva/event-bus/vision-events.js publishVisionEvent/subscribeVisionEvent (existing, reused)", "lib/governance/emit-feedback.js / emitFeedbackBatch (existing, extended with a publish call)"],
+    "data_contracts": ["No schema change -- read/write against existing columns only (resolution_sd_id, outcome_signals, sd_effectiveness_metrics)"],
+    "runtime_config": ["FR-4's hook should follow the existing RESOLVE_FEEDBACK_ON_QF_COMPLETE-style gated-flag convention if a similar off-switch is warranted"],
+    "observability_rollout": ["FR-2's handler logs recurrence matches (or lack thereof) to console, matching the feedback-quality-updated.js logging convention", "FR-3's consumer output IS the observability surface for fix-effectiveness"]
+  },
+  "system_architecture": {
+    "summary": "Four independent, additive changes to already-built-but-dark infrastructure: a retable (FR-1), a new lightweight event-wiring (FR-2) reusing the existing vision-events.js bus, a new consumer (FR-3, sequenced after FR-1), and a new fail-soft QF hook (FR-4). No new infrastructure classes -- everything reuses established patterns already proven elsewhere in this codebase.",
+    "components": [
+      { "name": "lib/learning/outcome-tracker.js", "change": "EDIT -- FR-1 retable (leo_feedback->feedback, resolved_by_sd_id->resolution_sd_id)" },
+      { "name": "scripts/leo-analytics.js", "change": "EDIT -- FR-1 same retable fix at line 38" },
+      { "name": "lib/eva/event-bus/vision-events.js", "change": "EDIT -- FR-2 add FEEDBACK_CREATED event type" },
+      { "name": "lib/governance/emit-feedback.js", "change": "EDIT -- FR-2 publish FEEDBACK_CREATED after insert (emitFeedback + emitFeedbackBatch)" },
+      { "name": "lib/eva/event-bus/handlers/feedback-created.js", "change": "NEW -- FR-2 subscriber calling detectRecurrence" },
+      { "name": "scripts/outcome-effectiveness-summary.mjs (or equivalent)", "change": "NEW -- FR-3 live consumer of sd_effectiveness_metrics" },
+      { "name": "scripts/modules/complete-quick-fix/orchestrator.js", "change": "EDIT -- FR-4 new fail-soft outcome-tracker hook, additive to existing resolve-feedback.js path" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "FR-1 first (retable, unblocks FR-3). FR-2 and FR-4 can proceed independently in parallel with FR-1/FR-3. FR-3 must not ship before FR-1.",
+    "steps": [
+      "FR-1: retable outcome-tracker.js + leo-analytics.js, column-map resolved_by_sd_id->resolution_sd_id, unit tests",
+      "FR-2: new vision-events.js event type + emit-feedback.js publish calls + new handler subscribing detectRecurrence, unit tests",
+      "FR-3 (after FR-1): new live consumer of sd_effectiveness_metrics, verified against real post-FR-1 data",
+      "FR-4: new fail-soft QF completion hook, additive to resolve-feedback.js, regression test for coexistence",
+      "PR + review + ship"
+    ]
+  },
+  "dependencies": [
+    "SD-LEO-ORCH-SELF-IMPROVING-LEO-001-C (completed) -- built the dark computeEffectiveness/detectRecurrence functions this SD wires up"
+  ],
+  "activation_test_id": "tests/unit/learning/outcome-tracker-rewiring.test.js",
+  "metadata": { "sd_key": "SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001" }
+}

--- a/lib/eva/event-bus/handlers/feedback-created.js
+++ b/lib/eva/event-bus/handlers/feedback-created.js
@@ -1,0 +1,48 @@
+/**
+ * Handler: feedback.created
+ * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-2
+ *
+ * Runs recurrence detection against freshly-inserted feedback rows so that
+ * pattern_recurrence signals are recorded without a caller having to remember
+ * to invoke detectRecurrence() manually.
+ *
+ * KNOWN COVERAGE GAP: this only fires for rows inserted through emitFeedback()/
+ * emitFeedbackBatch() (lib/governance/emit-feedback.js). Any caller that writes
+ * to the feedback table directly (raw supabase.from('feedback').insert(...))
+ * bypasses this handler entirely — detectRecurrence() will not run for those rows.
+ *
+ * Payload: { feedbackId, supabase }
+ */
+
+import { subscribeVisionEvent, VISION_EVENTS } from '../vision-events.js';
+import { detectRecurrence } from '../../../learning/outcome-tracker.js';
+
+let _registered = false;
+
+/**
+ * Register feedback.created subscribers.
+ * Idempotent — safe to call multiple times.
+ */
+export function registerFeedbackCreatedHandlers() {
+  if (_registered) return;
+
+  subscribeVisionEvent(VISION_EVENTS.FEEDBACK_CREATED, async ({ feedbackId, supabase }) => {
+    if (!supabase || !feedbackId) return;
+
+    try {
+      const result = await detectRecurrence({ supabase, newFeedbackId: feedbackId });
+      if (result?.matched) {
+        console.log(`[VisionBus] Recurrence detected for feedback ${feedbackId}: matches SD ${result.sdId} (score=${result.matchScore})`);
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] detectRecurrence failed for feedback ${feedbackId}: ${err.message}`);
+    }
+  });
+
+  _registered = true;
+}
+
+/** Reset registration flag (for testing only). */
+export function _resetFeedbackCreatedHandlers() {
+  _registered = false;
+}

--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -28,6 +28,7 @@ import { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescor
 import { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';
 import { registerFeedbackQualityUpdatedHandlers } from './handlers/feedback-quality-updated.js';
 import { registerVisionGapAcceptedHandlers } from './handlers/vision-gap-accepted.js';
+import { registerFeedbackCreatedHandlers } from './handlers/feedback-created.js';
 
 let _initialized = false;
 
@@ -159,6 +160,7 @@ export async function initializeEventBus(supabase) {
   registerLeoPatternResolvedHandlers();
   registerFeedbackQualityUpdatedHandlers();
   registerVisionGapAcceptedHandlers();
+  registerFeedbackCreatedHandlers();
 
   // --- Default governance hook observer (GAP-026: FR-002) ---
   // Bridge vision events into governance system for audit/observability.
@@ -231,3 +233,4 @@ export { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescor
 export { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';
 export { registerFeedbackQualityUpdatedHandlers } from './handlers/feedback-quality-updated.js';
 export { registerVisionGapAcceptedHandlers } from './handlers/vision-gap-accepted.js';
+export { registerFeedbackCreatedHandlers } from './handlers/feedback-created.js';

--- a/lib/eva/event-bus/vision-events.js
+++ b/lib/eva/event-bus/vision-events.js
@@ -64,6 +64,12 @@ export const VISION_EVENTS = {
   FEEDBACK_QUALITY_UPDATED: 'feedback.quality_updated',
   /** Emitted when a vision gap is accepted (dismissed/wont_fix) — payload: {sdKey, gapId, dimensionId, reason, supabase} */
   GAP_ACCEPTED: 'vision.gap_accepted',
+  /**
+   * Emitted when emitFeedback()/emitFeedbackBatch() inserts a new feedback row.
+   * Payload: {feedbackId, supabase}
+   * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-2
+   */
+  FEEDBACK_CREATED: 'feedback.created',
 };
 
 /**

--- a/lib/governance/emit-feedback.js
+++ b/lib/governance/emit-feedback.js
@@ -21,6 +21,7 @@
 import crypto from 'node:crypto';
 import { writeAuditEvent } from '../security/audit-events-emitter.js';
 import { resolveFeedbackAudience } from './feedback-audience.js';
+import { publishVisionEvent, VISION_EVENTS } from '../eva/event-bus/vision-events.js';
 
 /**
  * SD-LEO-INFRA-WIRE-FEEDBACK-TABLE-001 FR-2.
@@ -284,6 +285,11 @@ export async function emitFeedback({
     supabase, metadata, dedup_key, severity, sd_id, description, feedbackId: data.id,
   });
 
+  // SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-2: fire-and-forget notification
+  // for downstream recurrence detection. Never blocks or throws (vision-events
+  // isolates handler errors from the publisher).
+  publishVisionEvent(VISION_EVENTS.FEEDBACK_CREATED, { feedbackId: data.id, supabase });
+
   return { id: data.id, deduped: false };
 }
 
@@ -429,6 +435,11 @@ export async function emitFeedbackBatch({ supabase, items = [], shared = {} } = 
   for (let i = 0; i < dualWriteContexts.length; i++) {
     const ctx = dualWriteContexts[i];
     await _maybePa5DualWrite({ supabase, ...ctx, feedbackId: insertedIds[i] });
+  }
+
+  // SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-2: one notification per inserted row.
+  for (const feedbackId of insertedIds) {
+    publishVisionEvent(VISION_EVENTS.FEEDBACK_CREATED, { feedbackId, supabase });
   }
 
   return { inserted: insertedIds, skipped, deduped };

--- a/lib/learning/outcome-tracker.js
+++ b/lib/learning/outcome-tracker.js
@@ -80,7 +80,7 @@ async function fetchSd(supabase, sdId) {
 
 async function countFeedbackInWindow(supabase, { start, end, sdId, category }) {
   let query = supabase
-    .from('leo_feedback')
+    .from('feedback')
     .select('id', { count: 'exact', head: true })
     .gte('created_at', start.toISOString())
     .lt('created_at', end.toISOString());
@@ -148,8 +148,8 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
   const resolvedAt = new Date(completionTime).toISOString();
 
   const { data: feedbackRows, error: feedbackError } = await client
-    .from('leo_feedback')
-    .select('id, status, resolved_by_sd_id')
+    .from('feedback')
+    .select('id, status, resolution_sd_id')
     .eq('sd_id', sdId);
 
   if (feedbackError) {
@@ -161,7 +161,7 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
     .filter(row => row.status !== 'resolved')
     .map(row => row.id);
   const backfillIds = linkedFeedback
-    .filter(row => row.status === 'resolved' && !row.resolved_by_sd_id)
+    .filter(row => row.status === 'resolved' && !row.resolution_sd_id)
     .map(row => row.id);
 
   let resolvedCount = 0;
@@ -169,11 +169,11 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
 
   if (unresolvedIds.length > 0) {
     const { data: updated, error } = await client
-      .from('leo_feedback')
+      .from('feedback')
       .update({
         status: 'resolved',
         resolved_at: resolvedAt,
-        resolved_by_sd_id: sdId
+        resolution_sd_id: sdId
       })
       .in('id', unresolvedIds)
       .select('id');
@@ -187,13 +187,13 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
 
   if (backfillIds.length > 0) {
     const { data: updated, error } = await client
-      .from('leo_feedback')
-      .update({ resolved_by_sd_id: sdId })
+      .from('feedback')
+      .update({ resolution_sd_id: sdId })
       .in('id', backfillIds)
       .select('id');
 
     if (error) {
-      throw new Error(`Failed to backfill resolved_by_sd_id: ${error.message}`);
+      throw new Error(`Failed to backfill resolution_sd_id: ${error.message}`);
     }
 
     backfilledCount = updated?.length || 0;
@@ -217,6 +217,70 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
     linkedFeedbackCount: linkedFeedback.length,
     resolvedCount,
     backfilledCount
+  };
+}
+
+/**
+ * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-4: lightweight, schema-safe
+ * QF-scoped equivalent of recordSdCompleted.
+ *
+ * recordSdCompleted is NOT usable for a bare quick-fix id: outcome_signals.sd_id
+ * and sd_effectiveness_metrics.sd_id both carry a NOT NULL foreign key to
+ * strategic_directives_v2(id), and a QF id (e.g. "QF-20260704-300") never has a
+ * matching row there — that insert would fail the FK. This function instead tags
+ * every feedback row already linked to the QF (via feedback.quick_fix_id, set by
+ * resolveFeedback/resolve-feedback.js moments earlier in the same completion
+ * flow) with an outcome-tracker marker in feedback.metadata — no schema change,
+ * no FK risk, additive to the existing resolution write (status/resolved_at/
+ * quick_fix_id/resolution_notes are untouched here).
+ *
+ * For a QF that escalated to a real SD (quick_fixes.escalated_to_sd_id), callers
+ * should prefer recordSdCompleted(sdId: escalated_to_sd_id) instead — that case
+ * IS SD-compatible.
+ *
+ * @param {Object} args
+ * @param {Object} args.supabase
+ * @param {string} args.qfId
+ * @param {Date|string} [args.completionTime]
+ * @returns {Promise<{ qfId: string, linkedFeedbackCount: number, taggedCount: number }>}
+ */
+export async function recordQfCompleted({ supabase, qfId, completionTime = new Date() }) {
+  const client = await getSupabaseClient(supabase);
+  const trackedAt = new Date(completionTime).toISOString();
+
+  const { data: linkedFeedback, error } = await client
+    .from('feedback')
+    .select('id, metadata')
+    .eq('quick_fix_id', qfId);
+
+  if (error) {
+    throw new Error(`Failed to load feedback linked to QF ${qfId}: ${error.message}`);
+  }
+
+  const rows = linkedFeedback || [];
+  let taggedCount = 0;
+
+  for (const row of rows) {
+    const metadata = {
+      ...(row.metadata || {}),
+      outcome_tracked_at: trackedAt,
+      outcome_tracked_via: 'qf_completion'
+    };
+    const { error: updateError } = await client
+      .from('feedback')
+      .update({ metadata })
+      .eq('id', row.id);
+
+    if (updateError) {
+      throw new Error(`Failed to tag outcome-tracker metadata on feedback ${row.id}: ${updateError.message}`);
+    }
+    taggedCount += 1;
+  }
+
+  return {
+    qfId,
+    linkedFeedbackCount: rows.length,
+    taggedCount
   };
 }
 
@@ -298,7 +362,7 @@ export async function detectRecurrence({
   const client = await getSupabaseClient(supabase);
 
   const { data: feedback, error: feedbackError } = await client
-    .from('leo_feedback')
+    .from('feedback')
     .select('id, title, description, created_at')
     .eq('id', newFeedbackId)
     .single();
@@ -329,10 +393,10 @@ export async function detectRecurrence({
   const candidateSdIds = candidateSds.map(sd => sd.id);
 
   const { data: resolvedPatterns, error: patternError } = await client
-    .from('leo_feedback')
-    .select('id, title, description, resolved_by_sd_id')
+    .from('feedback')
+    .select('id, title, description, resolution_sd_id')
     .eq('status', 'resolved')
-    .in('resolved_by_sd_id', candidateSdIds);
+    .in('resolution_sd_id', candidateSdIds);
 
   if (patternError) {
     throw new Error(`Failed to load resolved feedback patterns: ${patternError.message}`);
@@ -352,7 +416,7 @@ export async function detectRecurrence({
       bestMatch = {
         score,
         resolvedFeedbackId: pattern.id,
-        sdId: pattern.resolved_by_sd_id
+        sdId: pattern.resolution_sd_id
       };
     }
   }
@@ -401,9 +465,9 @@ export async function getOutcomeSummary({ supabase, sdId, windowDays = DEFAULT_W
     .limit(1);
 
   const resolvedFeedbackQuery = client
-    .from('leo_feedback')
+    .from('feedback')
     .select('id', { count: 'exact', head: true })
-    .eq('resolved_by_sd_id', sdId)
+    .eq('resolution_sd_id', sdId)
     .eq('status', 'resolved');
 
   const metricsQuery = client

--- a/lib/learning/outcome-tracker.js
+++ b/lib/learning/outcome-tracker.js
@@ -234,9 +234,12 @@ export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalAppr
  * no FK risk, additive to the existing resolution write (status/resolved_at/
  * quick_fix_id/resolution_notes are untouched here).
  *
- * For a QF that escalated to a real SD (quick_fixes.escalated_to_sd_id), callers
- * should prefer recordSdCompleted(sdId: escalated_to_sd_id) instead — that case
- * IS SD-compatible.
+ * This function always runs regardless of escalation status — feedback.quick_fix_id
+ * is the QF's own real linkage, distinct from feedback.sd_id (which recordSdCompleted
+ * reads). For a QF that escalated to a real SD (quick_fixes.escalated_to_sd_id),
+ * callers should ALSO call recordSdCompleted(sdId: escalated_to_sd_id) — additively,
+ * not instead of this function (see recordQfOutcomeOnComplete in
+ * scripts/modules/complete-quick-fix/orchestrator.js).
  *
  * @param {Object} args
  * @param {Object} args.supabase

--- a/scripts/leo-analytics.js
+++ b/scripts/leo-analytics.js
@@ -35,7 +35,7 @@ async function main() {
 
   // Query all metrics sources in parallel
   const [feedbackResult, proposalsResult, patternsResult, vettingResult] = await Promise.all([
-    supabase.from('leo_feedback').select('id, status, created_at, updated_at, category, priority'),
+    supabase.from('feedback').select('id, status, created_at, updated_at, category, priority'),
     supabase.from('enhancement_proposals').select('id, status, created_at, vetted_at, approved_at, applied_at, source_type'),
     supabase.from('issue_patterns').select('id, status, severity, occurrence_count, created_at, resolution_date, category, trend'),
     supabase.from('leo_vetting_outcomes').select('id, rubric_score, verdict, processed_by, created_at, proposal_id')

--- a/scripts/leo-analytics.js
+++ b/scripts/leo-analytics.js
@@ -38,7 +38,7 @@ async function main() {
     supabase.from('feedback').select('id, status, created_at, updated_at, category, priority'),
     supabase.from('enhancement_proposals').select('id, status, created_at, vetted_at, approved_at, applied_at, source_type'),
     supabase.from('issue_patterns').select('id, status, severity, occurrence_count, created_at, resolution_date, category, trend'),
-    supabase.from('leo_vetting_outcomes').select('id, rubric_score, verdict, processed_by, created_at, proposal_id')
+    supabase.from('leo_vetting_outcomes').select('id, rubric_score, outcome, processed_by, created_at, proposal_id')
   ]);
 
   const feedback = feedbackResult.data || [];
@@ -95,8 +95,8 @@ function buildMetrics(feedback, proposals, patterns, vetting) {
   const avgRubricScore = vettingTotal > 0
     ? (vetting.reduce((sum, v) => sum + (v.rubric_score || 0), 0) / vettingTotal).toFixed(1)
     : '0.0';
-  const approvedVetting = vetting.filter(v => v.verdict === 'approved' || v.verdict === 'APPROVED').length;
-  const rejectedVetting = vetting.filter(v => v.verdict === 'rejected' || v.verdict === 'REJECTED').length;
+  const approvedVetting = vetting.filter(v => v.outcome === 'approved' || v.outcome === 'APPROVED').length;
+  const rejectedVetting = vetting.filter(v => v.outcome === 'rejected' || v.outcome === 'REJECTED').length;
   const vettingApprovalRate = vettingTotal > 0 ? ((approvedVetting / vettingTotal) * 100).toFixed(1) : '0.0';
 
   return {

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -37,6 +37,7 @@ import {
 import { runComplianceWithRefinement } from './compliance-loop.js';
 import { prompt, displayCompletionSummary } from './cli.js';
 import { resolveFeedback, parseAndExpandFeedbackFooters } from '../../../lib/governance/resolve-feedback.js';
+import { recordSdCompleted, recordQfCompleted } from '../../../lib/learning/outcome-tracker.js';
 import { checkResolverFreshness, logResolverFreshnessBanner } from '../../../lib/governance/check-resolver-freshness.js';
 import { execSync } from 'child_process';
 
@@ -696,6 +697,18 @@ export async function completeQuickFix(qfId, options = {}) {
     }
   }
 
+  // SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-4: outcome-tracker completion hook.
+  // ADDITIVE to the feedback auto-resolve block above -- a second, independent
+  // resolution-writer; never replaces resolve-feedback.js's own writes.
+  // Fail-soft + gated. Env opt-out: OUTCOME_TRACKER_ON_QF_COMPLETE=0.
+  if (process.env.OUTCOME_TRACKER_ON_QF_COMPLETE !== '0') {
+    try {
+      await recordQfOutcomeOnComplete(supabase, qf, qfId);
+    } catch (err) {
+      console.log(`   ⚠️  Outcome-tracker record skipped: ${err?.message || err}\n`);
+    }
+  }
+
   console.log('📍 Quick-Fix Complete!\n');
 
   return qf;
@@ -789,6 +802,34 @@ async function resolveLinkedFeedbackRows(supabase, qf, qfId, prUrl, commitSha, t
       console.log(`   ⚠️  feedback ${uuid} → resolve failed: ${result.error || 'unknown'}`);
     }
   }
+}
+
+/**
+ * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-4: post-merge outcome-tracker hook.
+ *
+ * Additive to resolveLinkedFeedbackRows above -- never replaces resolve-feedback.js's
+ * write path. recordSdCompleted is only valid when the QF escalated to a real
+ * strategic_directives_v2 row (quick_fixes.escalated_to_sd_id): outcome_signals.sd_id
+ * and sd_effectiveness_metrics.sd_id both carry a NOT NULL foreign key to
+ * strategic_directives_v2(id), and a bare QF id (e.g. "QF-20260704-300") has no
+ * matching row there -- that path would fail the FK. For the common,
+ * non-escalated QF, recordQfCompleted (a schema-safe, QF-scoped equivalent) is
+ * used instead.
+ *
+ * @param {Object} supabase
+ * @param {Object} qf - Quick-fix DB row (must include escalated_to_sd_id)
+ * @param {string} qfId
+ */
+export async function recordQfOutcomeOnComplete(supabase, qf, qfId) {
+  if (qf?.escalated_to_sd_id) {
+    return recordSdCompleted({
+      supabase,
+      sdId: qf.escalated_to_sd_id,
+      actor: 'complete-quick-fix',
+      completionTime: new Date()
+    });
+  }
+  return recordQfCompleted({ supabase, qfId, completionTime: new Date() });
 }
 
 /**

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -808,28 +808,33 @@ async function resolveLinkedFeedbackRows(supabase, qf, qfId, prUrl, commitSha, t
  * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-4: post-merge outcome-tracker hook.
  *
  * Additive to resolveLinkedFeedbackRows above -- never replaces resolve-feedback.js's
- * write path. recordSdCompleted is only valid when the QF escalated to a real
- * strategic_directives_v2 row (quick_fixes.escalated_to_sd_id): outcome_signals.sd_id
- * and sd_effectiveness_metrics.sd_id both carry a NOT NULL foreign key to
- * strategic_directives_v2(id), and a bare QF id (e.g. "QF-20260704-300") has no
- * matching row there -- that path would fail the FK. For the common,
- * non-escalated QF, recordQfCompleted (a schema-safe, QF-scoped equivalent) is
- * used instead.
+ * write path. recordQfCompleted always runs: it is the QF's own real linkage
+ * (feedback.quick_fix_id), and outcome_signals.sd_id / sd_effectiveness_metrics.sd_id
+ * both carry a NOT NULL foreign key to strategic_directives_v2(id), so a bare QF id
+ * (e.g. "QF-20260704-300") could never be written there directly.
+ *
+ * When the QF escalated to a real SD (quick_fixes.escalated_to_sd_id), recordSdCompleted
+ * ALSO runs -- but as an addition, not a replacement: recordSdCompleted resolves
+ * feedback via feedback.sd_id, a different linkage than the QF's own
+ * feedback.quick_fix_id, so routing to it exclusively would silently skip tagging
+ * the QF's actual linked feedback (caught in adversarial review of this SD's PR).
  *
  * @param {Object} supabase
  * @param {Object} qf - Quick-fix DB row (must include escalated_to_sd_id)
  * @param {string} qfId
  */
 export async function recordQfOutcomeOnComplete(supabase, qf, qfId) {
+  const qfResult = await recordQfCompleted({ supabase, qfId, completionTime: new Date() });
   if (qf?.escalated_to_sd_id) {
-    return recordSdCompleted({
+    const sdResult = await recordSdCompleted({
       supabase,
       sdId: qf.escalated_to_sd_id,
       actor: 'complete-quick-fix',
       completionTime: new Date()
     });
+    return { qf: qfResult, sd: sdResult };
   }
-  return recordQfCompleted({ supabase, qfId, completionTime: new Date() });
+  return qfResult;
 }
 
 /**

--- a/scripts/outcome-effectiveness-summary.mjs
+++ b/scripts/outcome-effectiveness-summary.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * outcome-effectiveness-summary.mjs — SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 (FR-3)
+ *
+ * CLI wrapper for getOutcomeSummary(): prints an SD's fix-effectiveness signals
+ * (completion signal, resolved feedback count, recurrence count, latest pre/post
+ * effectiveness delta) computed against the real `feedback` table (FR-1 retable).
+ * Sequenced strictly after FR-1 — run before that landed, this would have
+ * surfaced fabricated pre=0/post=0/pct=null rows as if they were real data.
+ *
+ * Usage: node scripts/outcome-effectiveness-summary.mjs <SD-KEY> [--json]
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { createSupabaseServiceClient } from './lib/supabase-connection.js';
+import { getOutcomeSummary } from '../lib/learning/outcome-tracker.js';
+
+function renderHuman(sdKey, summary) {
+  const lines = [`=== OUTCOME EFFECTIVENESS SUMMARY - ${sdKey} ===`, ''];
+  lines.push(`SD status:              ${summary.sd_status}`);
+  lines.push(`Completion signal:       ${summary.completion_signal ? 'yes' : 'MISSING'}`);
+  lines.push(`Resolved feedback:       ${summary.resolved_feedback_count}`);
+  lines.push(`Recurrence signals:      ${summary.recurrence_signal_count}`);
+  if (summary.latest_metrics) {
+    const m = summary.latest_metrics;
+    lines.push('');
+    lines.push(`Latest effectiveness window: ${m.window_start} -> ${m.window_end}`);
+    lines.push(`  pre_feedback_count:  ${m.pre_feedback_count}`);
+    lines.push(`  post_feedback_count: ${m.post_feedback_count}`);
+    lines.push(`  delta_count:         ${m.delta_count}`);
+    lines.push(`  pct_change:          ${m.pct_change === null || m.pct_change === undefined ? 'n/a' : `${Number(m.pct_change).toFixed(1)}%`}`);
+  } else {
+    lines.push('', 'No effectiveness metrics computed yet for this SD.');
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const sdKey = args.find((a) => !a.startsWith('--'));
+  if (!sdKey) {
+    console.error('Usage: node scripts/outcome-effectiveness-summary.mjs <SD-KEY> [--json]');
+    process.exit(1);
+  }
+
+  const supabase = await createSupabaseServiceClient('engineer');
+  const { data: sd, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('sd_key', sdKey)
+    .single();
+
+  if (error || !sd) {
+    console.error(`OUTCOME_SUMMARY_ERROR: SD not found for key ${sdKey}`);
+    process.exit(1);
+  }
+
+  const summary = await getOutcomeSummary({ supabase, sdId: sd.id });
+  console.log(asJson ? JSON.stringify(summary) : renderHuman(sdKey, summary));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().then(() => process.exit(0)).catch((err) => {
+    console.error('OUTCOME_SUMMARY_ERROR', err && err.message ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/complete-quick-fix/outcome-tracker-hook.test.js
+++ b/tests/unit/complete-quick-fix/outcome-tracker-hook.test.js
@@ -1,0 +1,150 @@
+/**
+ * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 FR-4 (TS-5) — QF completion outcome-tracker hook.
+ *
+ * recordQfOutcomeOnComplete is additive to resolve-feedback.js's existing
+ * resolution write (status/resolved_at/quick_fix_id/resolution_notes). This
+ * pins the routing decision (escalated -> recordSdCompleted, else ->
+ * recordQfCompleted) and proves both writers coexist on the same feedback row
+ * without conflicting.
+ */
+import { describe, it, expect } from 'vitest';
+import { recordQfOutcomeOnComplete } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+import { resolveFeedback } from '../../../lib/governance/resolve-feedback.js';
+
+function makeFakeSupabase(tables) {
+  function makeBuilder(tableName) {
+    const filters = [];
+    let mutation = null;
+
+    function table() {
+      if (!tables[tableName]) tables[tableName] = [];
+      return tables[tableName];
+    }
+    function matchedRows() {
+      return table().filter((r) => filters.every((f) => f(r)));
+    }
+    function execute() {
+      if (mutation) {
+        if (mutation.type === 'update') {
+          const matched = matchedRows();
+          matched.forEach((r) => Object.assign(r, mutation.payload));
+          return { data: matched.map((r) => ({ ...r })), error: null };
+        }
+        if (mutation.type === 'insert') {
+          const t = table();
+          const rows = Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload];
+          const inserted = rows.map((r, i) => ({ id: r.id ?? `gen-${tableName}-${t.length + i + 1}`, ...r }));
+          t.push(...inserted);
+          return { data: inserted.map((r) => ({ ...r })), error: null };
+        }
+        if (mutation.type === 'upsert') {
+          const t = table();
+          const conflictCols = mutation.onConflict ? mutation.onConflict.split(',') : null;
+          const payloadArr = Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload];
+          const out = [];
+          for (const row of payloadArr) {
+            const existing = conflictCols ? t.find((r) => conflictCols.every((c) => r[c] === row[c])) : null;
+            if (existing) { Object.assign(existing, row); out.push(existing); }
+            else { t.push({ ...row }); out.push(row); }
+          }
+          return { data: out.map((r) => ({ ...r })), error: null };
+        }
+      }
+      return { data: matchedRows().map((r) => ({ ...r })), error: null };
+    }
+    const builder = {
+      select() { return builder; },
+      eq(col, val) { filters.push((r) => r[col] != null && r[col] === val); return builder; },
+      neq(col, val) { filters.push((r) => r[col] != null && r[col] !== val); return builder; },
+      is(col, val) { filters.push((r) => (val === null ? r[col] == null : r[col] === val)); return builder; },
+      in(col, vals) { filters.push((r) => r[col] != null && vals.includes(r[col])); return builder; },
+      gte(col, val) { filters.push((r) => r[col] != null && r[col] >= val); return builder; },
+      lte(col, val) { filters.push((r) => r[col] != null && r[col] <= val); return builder; },
+      lt(col, val) { filters.push((r) => r[col] != null && r[col] < val); return builder; },
+      gt(col, val) { filters.push((r) => r[col] != null && r[col] > val); return builder; },
+      order() { return builder; },
+      limit() { return builder; },
+      update(payload) { mutation = { type: 'update', payload }; return builder; },
+      insert(payload) { mutation = { type: 'insert', payload }; return builder; },
+      upsert(payload, opts) { mutation = { type: 'upsert', payload, onConflict: opts?.onConflict }; return builder; },
+      single() {
+        const result = execute();
+        if (!result.data?.length) return Promise.resolve({ data: null, error: { message: `${tableName}: not found` } });
+        return Promise.resolve({ data: result.data[0], error: null });
+      },
+      then(resolve) { resolve(execute()); return Promise.resolve(); },
+    };
+    return builder;
+  }
+  return { from: (t) => makeBuilder(t) };
+}
+
+describe('recordQfOutcomeOnComplete routing', () => {
+  it('routes to recordQfCompleted (schema-safe) for a non-escalated QF, never touching outcome_signals', async () => {
+    const tables = {
+      feedback: [
+        { id: 'fb-1', quick_fix_id: 'QF-20260716-001', status: 'resolved', resolution_notes: 'Shipped via QF-20260716-001', metadata: { dedup_hash: 'x' } },
+      ],
+      outcome_signals: [],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    const result = await recordQfOutcomeOnComplete(supabase, { escalated_to_sd_id: null }, 'QF-20260716-001');
+
+    expect(result.qfId).toBe('QF-20260716-001');
+    expect(result.taggedCount).toBe(1);
+    expect(tables.outcome_signals).toHaveLength(0); // no FK-unsafe write attempted
+
+    const row = tables.feedback[0];
+    expect(row.metadata.outcome_tracked_via).toBe('qf_completion');
+    expect(row.metadata.dedup_hash).toBe('x'); // pre-existing metadata preserved, not clobbered
+    // resolve-feedback.js's own fields are untouched by this hook.
+    expect(row.status).toBe('resolved');
+    expect(row.resolution_notes).toBe('Shipped via QF-20260716-001');
+  });
+
+  it('routes to recordSdCompleted when the QF escalated to a real SD', async () => {
+    const tables = {
+      strategic_directives_v2: [{ id: 'SD-ESCALATED-001', status: 'completed', completion_date: null }],
+      feedback: [],
+      outcome_signals: [],
+      sd_effectiveness_metrics: [],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    const result = await recordQfOutcomeOnComplete(supabase, { escalated_to_sd_id: 'SD-ESCALATED-001' }, 'QF-20260716-002');
+
+    expect(result.linkedFeedbackCount).toBe(0);
+    expect(tables.outcome_signals.some((s) => s.signal_type === 'sd_completion' && s.sd_id === 'SD-ESCALATED-001')).toBe(true);
+  });
+
+  it('regression: coexists with resolve-feedback.js on the same row without conflicting writes', async () => {
+    const feedbackId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const tables = {
+      feedback: [
+        { id: feedbackId, status: 'new', quick_fix_id: null, resolution_notes: null, resolved_at: null, metadata: {} },
+      ],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    // Step 1: existing resolve-feedback.js path (runs first in the real orchestrator flow).
+    const resolveResult = await resolveFeedback({
+      supabase,
+      feedbackId,
+      quickFixId: 'QF-20260716-003',
+      notes: 'Shipped via QF-20260716-003',
+    });
+    expect(resolveResult.updated).toBe(true);
+
+    // Step 2: new, additive outcome-tracker hook (FR-4), same feedback row.
+    const outcomeResult = await recordQfOutcomeOnComplete(supabase, { escalated_to_sd_id: null }, 'QF-20260716-003');
+    expect(outcomeResult.taggedCount).toBe(1);
+
+    const row = tables.feedback[0];
+    // Both writers' fields present, neither clobbered the other.
+    expect(row.status).toBe('resolved');
+    expect(row.quick_fix_id).toBe('QF-20260716-003');
+    expect(row.resolution_notes).toBe('Shipped via QF-20260716-003');
+    expect(row.metadata.outcome_tracked_via).toBe('qf_completion');
+  });
+});

--- a/tests/unit/complete-quick-fix/outcome-tracker-hook.test.js
+++ b/tests/unit/complete-quick-fix/outcome-tracker-hook.test.js
@@ -103,10 +103,16 @@ describe('recordQfOutcomeOnComplete routing', () => {
     expect(row.resolution_notes).toBe('Shipped via QF-20260716-001');
   });
 
-  it('routes to recordSdCompleted when the QF escalated to a real SD', async () => {
+  it('ALSO records recordSdCompleted when the QF escalated to a real SD, without skipping its own quick_fix_id-linked feedback', async () => {
+    // Regression for an adversarial-review finding: routing exclusively to
+    // recordSdCompleted (which resolves via feedback.sd_id) would silently skip
+    // tagging the feedback rows actually linked to this QF via quick_fix_id --
+    // a different linkage. recordQfCompleted must ALWAYS run too.
     const tables = {
       strategic_directives_v2: [{ id: 'SD-ESCALATED-001', status: 'completed', completion_date: null }],
-      feedback: [],
+      feedback: [
+        { id: 'fb-escalated', quick_fix_id: 'QF-20260716-002', status: 'resolved', metadata: {} },
+      ],
       outcome_signals: [],
       sd_effectiveness_metrics: [],
     };
@@ -114,8 +120,13 @@ describe('recordQfOutcomeOnComplete routing', () => {
 
     const result = await recordQfOutcomeOnComplete(supabase, { escalated_to_sd_id: 'SD-ESCALATED-001' }, 'QF-20260716-002');
 
-    expect(result.linkedFeedbackCount).toBe(0);
+    // The SD-shaped signal still fires for the escalation target.
+    expect(result.sd.linkedFeedbackCount).toBe(0);
     expect(tables.outcome_signals.some((s) => s.signal_type === 'sd_completion' && s.sd_id === 'SD-ESCALATED-001')).toBe(true);
+
+    // But the QF's OWN linked feedback is still tagged -- not silently skipped.
+    expect(result.qf.taggedCount).toBe(1);
+    expect(tables.feedback[0].metadata.outcome_tracked_via).toBe('qf_completion');
   });
 
   it('regression: coexists with resolve-feedback.js on the same row without conflicting writes', async () => {

--- a/tests/unit/learning/outcome-tracker-rewiring.test.js
+++ b/tests/unit/learning/outcome-tracker-rewiring.test.js
@@ -1,0 +1,257 @@
+/**
+ * SD-LEO-INFRA-FIX-RECURRENCE-REWIRING-001 — FR-1/FR-2 unit tests. DB-free (seeded fixtures).
+ *
+ * TS-1: computeEffectiveness/recordSdCompleted resolve against `feedback` (not
+ *       leo_feedback), mapping resolution_sd_id (not resolved_by_sd_id).
+ * TS-2: a feedback row created via emitFeedback() triggers detectRecurrence
+ *       exactly once via the vision-events bus, producing a real
+ *       outcome_signals(signal_type='pattern_recurrence') row.
+ * TS-3: a throwing FEEDBACK_CREATED subscriber does not propagate an error
+ *       back to emitFeedback's caller.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { computeEffectiveness, recordSdCompleted } from '../../../lib/learning/outcome-tracker.js';
+import { emitFeedback } from '../../../lib/governance/emit-feedback.js';
+import { registerFeedbackCreatedHandlers, _resetFeedbackCreatedHandlers } from '../../../lib/eva/event-bus/handlers/feedback-created.js';
+import { subscribeVisionEvent, VISION_EVENTS, clearVisionSubscribers } from '../../../lib/eva/event-bus/vision-events.js';
+
+// ---- Minimal in-memory fake Supabase client, mutating seeded table arrays in place.
+// Models SQL three-valued NULL logic for eq/neq/in/is, a postgres json arrow
+// accessor (col->>key), and a generic order() comparator — mirrors the pattern
+// established in tests/unit/roadmap/plan-of-record-linkage.test.js.
+function parseCol(col) {
+  if (col.includes('->>')) {
+    const [base, key] = col.split('->>');
+    return (r) => r[base]?.[key];
+  }
+  return (r) => r[col];
+}
+
+function makeFakeSupabase(tables) {
+  function makeBuilder(tableName) {
+    const filters = [];
+    let orderCol = null;
+    let orderAsc = true;
+    let limitN = null;
+    let mutation = null;
+
+    function table() {
+      if (!tables[tableName]) tables[tableName] = [];
+      return tables[tableName];
+    }
+
+    function matchedRows() {
+      return table().filter((r) => filters.every((f) => f(r)));
+    }
+
+    function execute() {
+      if (mutation) {
+        const t = table();
+        if (mutation.type === 'insert') {
+          const rows = Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload];
+          const inserted = rows.map((r, i) => ({ id: r.id ?? `gen-${tableName}-${t.length + i + 1}`, ...r }));
+          t.push(...inserted);
+          return { data: inserted.map((r) => ({ ...r })), error: null };
+        }
+        if (mutation.type === 'update') {
+          const matched = matchedRows();
+          matched.forEach((r) => Object.assign(r, mutation.payload));
+          return { data: matched.map((r) => ({ ...r })), error: null };
+        }
+        if (mutation.type === 'upsert') {
+          const conflictCols = mutation.onConflict ? mutation.onConflict.split(',') : null;
+          const payloadArr = Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload];
+          const out = [];
+          for (const row of payloadArr) {
+            const existing = conflictCols ? t.find((r) => conflictCols.every((c) => r[c] === row[c])) : null;
+            if (existing) { Object.assign(existing, row); out.push(existing); }
+            else { t.push({ ...row }); out.push(row); }
+          }
+          return { data: out.map((r) => ({ ...r })), error: null };
+        }
+      }
+      let rows = matchedRows();
+      if (orderCol) {
+        rows = [...rows].sort((a, b) => {
+          const av = a[orderCol], bv = b[orderCol];
+          if (av == null && bv == null) return 0;
+          if (av == null) return orderAsc ? -1 : 1;
+          if (bv == null) return orderAsc ? 1 : -1;
+          const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+          return orderAsc ? cmp : -cmp;
+        });
+      }
+      if (limitN != null) rows = rows.slice(0, limitN);
+      return { data: rows.map((r) => ({ ...r })), error: null, count: rows.length };
+    }
+
+    const builder = {
+      select() { return builder; },
+      eq(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) === val); return builder; },
+      neq(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) !== val); return builder; },
+      in(col, vals) { const get = parseCol(col); filters.push((r) => get(r) != null && vals.includes(get(r))); return builder; },
+      is(col, val) { const get = parseCol(col); filters.push((r) => (val === null ? get(r) == null : get(r) === val)); return builder; },
+      gte(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) >= val); return builder; },
+      lte(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) <= val); return builder; },
+      gt(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) > val); return builder; },
+      lt(col, val) { const get = parseCol(col); filters.push((r) => get(r) != null && get(r) < val); return builder; },
+      order(col, opts) { orderCol = col; orderAsc = opts?.ascending !== false; return builder; },
+      limit(n) { limitN = n; return builder; },
+      update(payload) { mutation = { type: 'update', payload }; return builder; },
+      insert(payload) { mutation = { type: 'insert', payload }; return builder; },
+      upsert(payload, opts) { mutation = { type: 'upsert', payload, onConflict: opts?.onConflict }; return builder; },
+      single() {
+        const result = execute();
+        if (!result.data || result.data.length === 0) {
+          return Promise.resolve({ data: null, error: { message: `${tableName}: row not found` } });
+        }
+        return Promise.resolve({ data: result.data[0], error: null });
+      },
+      maybeSingle() {
+        const result = execute();
+        return Promise.resolve({ data: result.data?.[0] ?? null, error: null });
+      },
+      then(resolve) {
+        resolve(execute());
+        return Promise.resolve();
+      },
+    };
+    return builder;
+  }
+  return { from: (t) => makeBuilder(t) };
+}
+
+const daysAgo = (n) => new Date(Date.now() - n * 86_400_000).toISOString();
+
+describe('outcome-tracker retable (FR-1 / TS-1)', () => {
+  it('computeEffectiveness resolves pre/post counts from feedback, scoped to the linked sd_id', async () => {
+    const tables = {
+      strategic_directives_v2: [
+        { id: 'sd-1', sd_key: 'SD-TEST-001', category: 'bug', completion_date: daysAgo(5), status: 'completed' },
+      ],
+      feedback: [
+        { id: 'fb-1', sd_id: 'sd-1', created_at: daysAgo(10) },
+        { id: 'fb-2', sd_id: 'sd-1', created_at: daysAgo(8) },
+        { id: 'fb-3', sd_id: 'sd-1', created_at: daysAgo(2) },
+      ],
+      sd_effectiveness_metrics: [],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    const result = await computeEffectiveness({ supabase, sdId: 'sd-1', completionTime: daysAgo(5) });
+
+    expect(result.preCount).toBe(2);
+    expect(result.postCount).toBe(1);
+    expect(result.delta).toBe(-1);
+    expect(tables.sd_effectiveness_metrics).toHaveLength(1);
+    expect(tables.sd_effectiveness_metrics[0].sd_id).toBe('sd-1');
+    expect(tables.sd_effectiveness_metrics[0].pre_feedback_count).toBe(2);
+    expect(tables.sd_effectiveness_metrics[0].post_feedback_count).toBe(1);
+  });
+
+  it('recordSdCompleted resolves linked feedback via resolution_sd_id (not resolved_by_sd_id)', async () => {
+    const tables = {
+      strategic_directives_v2: [
+        { id: 'sd-2', sd_key: 'SD-TEST-002', category: 'bug', completion_date: null, status: 'completed' },
+      ],
+      feedback: [
+        { id: 'fb-open-1', sd_id: 'sd-2', status: 'new', resolution_sd_id: null },
+        { id: 'fb-open-2', sd_id: 'sd-2', status: 'new', resolution_sd_id: null },
+        { id: 'fb-already-resolved', sd_id: 'sd-2', status: 'resolved', resolution_sd_id: null },
+        { id: 'fb-unrelated', sd_id: 'sd-other', status: 'new', resolution_sd_id: null },
+      ],
+      outcome_signals: [],
+      sd_effectiveness_metrics: [],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    const result = await recordSdCompleted({ supabase, sdId: 'sd-2', completionTime: new Date() });
+
+    expect(result.linkedFeedbackCount).toBe(3);
+    expect(result.resolvedCount).toBe(2);
+    expect(result.backfilledCount).toBe(1);
+
+    const byId = Object.fromEntries(tables.feedback.map((r) => [r.id, r]));
+    expect(byId['fb-open-1'].status).toBe('resolved');
+    expect(byId['fb-open-1'].resolution_sd_id).toBe('sd-2');
+    expect(byId['fb-open-2'].status).toBe('resolved');
+    expect(byId['fb-open-2'].resolution_sd_id).toBe('sd-2');
+    // Already-resolved row gets its resolution_sd_id backfilled without touching status again.
+    expect(byId['fb-already-resolved'].status).toBe('resolved');
+    expect(byId['fb-already-resolved'].resolution_sd_id).toBe('sd-2');
+    // Unrelated SD's feedback is untouched.
+    expect(byId['fb-unrelated'].resolution_sd_id).toBe(null);
+
+    expect(tables.outcome_signals.some((s) => s.signal_type === 'sd_completion' && s.sd_id === 'sd-2')).toBe(true);
+  });
+});
+
+describe('detectRecurrence wiring via emitFeedback (FR-2 / TS-2, TS-3)', () => {
+  beforeEach(() => {
+    clearVisionSubscribers();
+    _resetFeedbackCreatedHandlers();
+  });
+
+  it('a new feedback row inserted via emitFeedback triggers detectRecurrence exactly once and writes a real pattern_recurrence signal', async () => {
+    registerFeedbackCreatedHandlers();
+
+    const sameText = 'Login button overlaps the password field on iPhone screens';
+    const tables = {
+      strategic_directives_v2: [
+        { id: 'sd-3', sd_key: 'SD-TEST-003', category: 'bug', completion_date: daysAgo(5), status: 'completed' },
+      ],
+      feedback: [
+        {
+          id: 'fb-old-pattern',
+          title: sameText,
+          description: sameText,
+          status: 'resolved',
+          resolution_sd_id: 'sd-3',
+          created_at: daysAgo(6),
+          category: 'ui_bug',
+          metadata: { dedup_hash: 'sentinel-old-hash' },
+        },
+      ],
+      outcome_signals: [],
+    };
+    const supabase = makeFakeSupabase(tables);
+
+    const insertResult = await emitFeedback({
+      supabase,
+      title: sameText,
+      description: sameText,
+      category: 'ui_bug',
+      dedup_key: 'new-report-1',
+      metadata: { deferred_from_sd_key: 'n/a' }, // short-circuits the v_active_sessions lookup
+    });
+
+    expect(insertResult.deduped).toBe(false);
+
+    // Fire-and-forget handler chain — give it a tick to settle (matches the
+    // convention in tests/unit/eva/feedback-quality-updated-handler.test.js).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const recurrenceSignals = tables.outcome_signals.filter((s) => s.signal_type === 'pattern_recurrence');
+    expect(recurrenceSignals).toHaveLength(1);
+    expect(recurrenceSignals[0].sd_id).toBe('sd-3');
+    expect(recurrenceSignals[0].source_feedback_id).toBe(insertResult.id);
+  });
+
+  it('a throwing FEEDBACK_CREATED subscriber does not propagate an error back to emitFeedback', async () => {
+    subscribeVisionEvent(VISION_EVENTS.FEEDBACK_CREATED, () => {
+      throw new Error('simulated subscriber failure');
+    });
+
+    const tables = { feedback: [] };
+    const supabase = makeFakeSupabase(tables);
+
+    await expect(emitFeedback({
+      supabase,
+      title: 'Some new issue',
+      description: 'Some new issue description',
+      metadata: { deferred_from_sd_key: 'n/a' },
+    })).resolves.toMatchObject({ deduped: false });
+
+    expect(tables.feedback).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- FR-1: retable `lib/learning/outcome-tracker.js` / `scripts/leo-analytics.js` from the abandoned `leo_feedback` table (1 orphan row) to the live `feedback` table (8,815 rows); map `resolved_by_sd_id` → `feedback.resolution_sd_id`.
- FR-2: wire `detectRecurrence` via a new `feedback.created` vision-event published from `emitFeedback`/`emitFeedbackBatch`'s insert path, consumed by a new fire-and-forget `feedback-created` handler.
- FR-3: add `scripts/outcome-effectiveness-summary.mjs`, a live CLI consumer of `getOutcomeSummary()`, verified against real post-FR-1 data.
- FR-4: hook `complete-quick-fix` completion into the outcome tracker via a new `recordQfCompleted` (schema-safe — avoids the `outcome_signals`/`sd_effectiveness_metrics` FK to `strategic_directives_v2` that a bare QF id would violate) or `recordSdCompleted` for escalated QFs — additive to the existing `resolve-feedback.js` path.

Known coverage gap (documented in-code, not solved here): ~40+ files insert into `feedback` directly, bypassing `emitFeedback`/`emitFeedbackBatch`, so FR-2's wiring doesn't cover those raw-insert call sites.

## Test plan
- [x] `tests/unit/learning/outcome-tracker-rewiring.test.js` — FR-1 retable (computeEffectiveness/recordSdCompleted resolve via `feedback`/`resolution_sd_id`) + FR-2 event wiring (emitFeedback → detectRecurrence → real `pattern_recurrence` signal; throwing subscriber doesn't propagate)
- [x] `tests/unit/complete-quick-fix/outcome-tracker-hook.test.js` — FR-4 routing (escalated → recordSdCompleted, else → recordQfCompleted) + regression proving coexistence with resolve-feedback.js
- [x] FR-3 verified live against the DB: `node scripts/outcome-effectiveness-summary.mjs SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001` — real pre=6/post=0/-100% computed post-retable (no longer garbage 0/0/null)
- [x] Full existing suite (526 files / 6806 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)