### PR TITLE
feat(SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001): wire DEPLOY/EMAIL/GUARDRAILS venture substrate joints

### DIFF
--- a/lib/agents/eva-coo-integration.js
+++ b/lib/agents/eva-coo-integration.js
@@ -319,6 +319,35 @@ export class EVACOOIntegration {
   async onboardVenture(venture, createCeo = true) {
     console.log(`\n🚀 EVA onboarding venture: ${venture.name}`);
 
+    // SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-2: provisionVentureEmail had
+    // ZERO production callers. Wired here (this venture-onboarding entry point),
+    // guarded on venture.domain being present -- provisionVentureEmail requires
+    // it and there is no domain to fabricate. Fail-soft: an email-provisioning
+    // failure never blocks venture onboarding itself, only surfaces on the result.
+    // NOTE: onboardVenture() itself is not yet reached by a live production
+    // caller (per docs/audits/venture-ceo-factory-reachability-verdict.json,
+    // superseded by a chairman-adjudicated REVIVE direction --
+    // SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-B is chartered to wire a real
+    // onboarding entry point). This wiring activates automatically once that
+    // sibling SD lands, without further changes here.
+    let emailProvisioning = null;
+    if (venture.domain) {
+      try {
+        const { provisionVentureEmail } = await import('../venture-email/provision-venture-email.js');
+        const result = await provisionVentureEmail({ id: venture.id, domain: venture.domain }, { supabase: this.supabase });
+        emailProvisioning = { state: result.state, revealedKey: result.revealedKey || null };
+        if (result.revealedKey) {
+          // NC-7 (non-recoverable secret): revealedKey is surfaced by Resend exactly
+          // once. If this onboardVenture return value is not observed by the caller,
+          // this log line is the only remaining capture point before the key is
+          // stranded (recoverable only via revoke-by-journaled-ID + re-mint).
+          console.error(`[eva-coo-integration] REVEALED KEY for venture ${venture.id} (secretRef=${result.revealedKey.secretRef}, keyId=${result.revealedKey.keyId}) -- capture into VENTURE_CHANNEL_SECRET_STORE now, this value is not recoverable.`);
+        }
+      } catch (e) {
+        emailProvisioning = { state: 'failed', error: e?.message || String(e) };
+      }
+    }
+
     if (createCeo) {
       // Import factory dynamically to avoid circular dependency
       const { VentureFactory } = await import('./venture-ceo-factory.js');
@@ -335,7 +364,8 @@ export class EVACOOIntegration {
         onboarded: true,
         mode: 'delegated',
         ceo_agent_id: result.ceo_agent_id,
-        total_agents: result.total_agents_created
+        total_agents: result.total_agents_created,
+        email_provisioning: emailProvisioning
       };
     }
 
@@ -343,7 +373,8 @@ export class EVACOOIntegration {
     return {
       onboarded: true,
       mode: 'direct',
-      ceo_agent_id: null
+      ceo_agent_id: null,
+      email_provisioning: emailProvisioning
     };
   }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
@@ -28,6 +28,11 @@ import { collectExternalObservations, verifyExternalObservation } from '../../ex
 // SD-LEO-INFRA-LAUNCH-MODE-POLICY-002 (FR-3): shared per-mode evidence — sim-gates
 // now FAIL unlabeled launch evidence instead of only stamping the label.
 import { evaluateSimArtifacts, LAUNCH_EVIDENCE_TYPES } from '../../mode-evidence.js';
+// SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-1/FR-3: the deploy/guardrails
+// joints were built-but-unwired -- promote()/publish() and
+// evaluateGuardrails()/persistGuardrailDecisions() had ZERO production callers.
+import { buildGuardrailContext, persistGuardrailDecisions } from '../../../venture-deploy/spend-guardrails.js';
+import { promote } from '../../../venture-deploy/promote.js';
 
 const SUCCESS_VERDICTS = new Set(['PASS', 'READY']);
 
@@ -172,6 +177,45 @@ export async function analyzeStage24GoLive(params) {
       if (externalObservation.verified) {
         result.launch_status = 'launched';
         result.launched_at = launchedAt;
+
+        // SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-3/FR-1: this is the ONLY
+        // branch that reaches launch_status='launched' via real external
+        // verification (never the simulated branch above) -- the correct, sole
+        // point to wire the deploy/guardrails joints. Plan-mode only (no
+        // deps.execute) -- a real execute-mode deploy for a real venture remains
+        // SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-A's separately chairman-gated
+        // scope; this wiring never bypasses that gate. Fail-soft: a wiring
+        // failure never blocks the go-live result itself (the launch decision
+        // already stands), but is recorded on the result for visibility.
+        if (hasDbContext) {
+          try {
+            const guardrailCtx = await buildGuardrailContext(supabase, ventureId);
+            const { persisted, error: gErr } = await persistGuardrailDecisions(supabase, ventureId, guardrailCtx);
+            result.guardrails_persisted = persisted;
+            if (gErr) result.guardrails_persist_error = gErr;
+          } catch (e) {
+            result.guardrails_persist_error = e?.message || String(e);
+          }
+
+          try {
+            const { data: previewRow } = await supabase
+              .from('venture_preview_instances')
+              .select('sha')
+              .eq('venture_id', ventureId)
+              .eq('status', 'live')
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle();
+            if (previewRow?.sha) {
+              const promoteResult = await promote(ventureId, previewRow.sha, supabase);
+              result.promote_status = promoteResult.status;
+            } else {
+              result.promote_status = 'skipped_no_verified_sha';
+            }
+          } catch (e) {
+            result.promote_error = e?.message || String(e);
+          }
+        }
       } else {
         result.launch_status = 'hold_external_observation_unverified';
         result.launched_at = null;

--- a/lib/venture-deploy/spend-guardrails.js
+++ b/lib/venture-deploy/spend-guardrails.js
@@ -243,4 +243,62 @@ export async function isKillswitchClear(supabase, ventureId) {
   return { clear: true, reason: '' };
 }
 
-export default { GUARDRAILS, GUARDRAIL_NAMES, evaluateGuardrails, formatGuardrailReport, persistGuardrailDecisions, isGuardrailsActive, isKillswitchClear };
+/**
+ * Build a guardrail evaluation ctx for a venture from REAL measured sources —
+ * SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-3.
+ *
+ * HONESTY NOTE: repo-wide investigation (LEAD/PLAN phase) confirmed only 3 of the
+ * 8 guardrails have a real measurement source anywhere in this codebase today:
+ *   - agent-token-ceiling: venture_token_budgets (budget_allocated - budget_remaining)
+ *   - human-gate: latest chairman_decisions row for this venture with decision='proceed'
+ *     (best-available proxy — no purpose-built deploy-approval flag exists yet)
+ *   - per-venture-isolation: trivially ventureId itself
+ * The other 5 (deterministic-ci-migration, d1-write-ceiling, operator-export,
+ * neon-paid-plan, cloud-run-max-instances) have NO real source anywhere — this
+ * function deliberately leaves them undefined rather than fabricating a passing
+ * default, so evaluateGuardrails() fails them CLOSED (per its own contract) until
+ * a future SD builds real measurement for each. `deps.override` lets a TEST
+ * inject values for those 5 to exercise the PASS path; production callers never
+ * pass override, so real ventures correctly stay fail-closed on those fields.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} ventureId
+ * @param {{ override?: object }} [deps] - deps.override merges OVER the measured ctx (test-only escape hatch)
+ * @returns {Promise<object>} ctx shaped for evaluateGuardrails/persistGuardrailDecisions
+ */
+export async function buildGuardrailContext(supabase, ventureId, deps = {}) {
+  const ctx = { ventureId, usage: {}, limits: {}, config: {}, state: { isolationScope: ventureId } };
+
+  const { data: budget } = await supabase
+    .from('venture_token_budgets')
+    .select('budget_remaining, budget_allocated')
+    .eq('venture_id', ventureId)
+    .maybeSingle();
+  if (budget && isNum(budget.budget_allocated) && isNum(budget.budget_remaining)) {
+    ctx.usage.agentTokens = budget.budget_allocated - budget.budget_remaining;
+    ctx.limits.agentTokenCeiling = budget.budget_allocated;
+  }
+
+  const { data: decision } = await supabase
+    .from('chairman_decisions')
+    .select('decision')
+    .eq('venture_id', ventureId)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (decision) {
+    ctx.state.humanGateApproved = decision.decision === 'proceed';
+  }
+
+  const override = deps.override || {};
+  return {
+    ventureId,
+    usage: { ...ctx.usage, ...override.usage },
+    limits: { ...ctx.limits, ...override.limits },
+    config: { ...ctx.config, ...override.config },
+    state: { ...ctx.state, ...override.state },
+  };
+}
+
+export default { GUARDRAILS, GUARDRAIL_NAMES, evaluateGuardrails, formatGuardrailReport, persistGuardrailDecisions, isGuardrailsActive, isKillswitchClear, buildGuardrailContext };

--- a/tests/unit/agents/eva-coo-integration-onboard-email.test.js
+++ b/tests/unit/agents/eva-coo-integration-onboard-email.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const provisionVentureEmailMock = vi.fn();
+vi.mock('../../../lib/venture-email/provision-venture-email.js', () => ({
+  provisionVentureEmail: (...args) => provisionVentureEmailMock(...args),
+}));
+
+const instantiateVentureMock = vi.fn();
+vi.mock('../../../lib/agents/venture-ceo-factory.js', () => ({
+  VentureFactory: class {
+    instantiateVenture(...args) {
+      return instantiateVentureMock(...args);
+    }
+  },
+}));
+
+import { EVACOOIntegration } from '../../../lib/agents/eva-coo-integration.js';
+
+function makeIntegration() {
+  return new EVACOOIntegration({ supabaseClient: {}, evaAgentId: 'eva-1' });
+}
+
+describe('SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-2 onboardVenture email wiring', () => {
+  beforeEach(() => {
+    provisionVentureEmailMock.mockReset();
+    instantiateVentureMock.mockReset();
+    instantiateVentureMock.mockResolvedValue({ ceo_agent_id: 'ceo-1', total_agents_created: 3 });
+  });
+
+  it('skips email provisioning entirely when venture.domain is absent', async () => {
+    const eva = makeIntegration();
+    const result = await eva.onboardVenture({ id: 'v-1', name: 'NoDomainCo' }, true);
+
+    expect(provisionVentureEmailMock).not.toHaveBeenCalled();
+    expect(result.email_provisioning).toBeNull();
+    expect(result.mode).toBe('delegated');
+  });
+
+  it('provisions email and surfaces state when venture.domain is present (delegated mode)', async () => {
+    provisionVentureEmailMock.mockResolvedValue({ state: 'provisioned', revealedKey: null });
+    const eva = makeIntegration();
+
+    const result = await eva.onboardVenture({ id: 'v-2', name: 'DomainCo', domain: 'domainco.com' }, true);
+
+    expect(provisionVentureEmailMock).toHaveBeenCalledWith(
+      { id: 'v-2', domain: 'domainco.com' },
+      { supabase: eva.supabase }
+    );
+    expect(result.email_provisioning).toEqual({ state: 'provisioned', revealedKey: null });
+  });
+
+  it('surfaces revealedKey on the result without throwing (non-recoverable secret)', async () => {
+    const revealedKey = { secretRef: 'ref-1', keyId: 'key-1', keyValue: 'secret-value' };
+    provisionVentureEmailMock.mockResolvedValue({ state: 'provisioned', revealedKey });
+    const eva = makeIntegration();
+
+    const result = await eva.onboardVenture({ id: 'v-3', name: 'KeyCo', domain: 'keyco.com' }, false);
+
+    expect(result.email_provisioning.revealedKey).toEqual(revealedKey);
+    expect(result.mode).toBe('direct');
+  });
+
+  it('fails soft: a provisioning error is captured on the result, never thrown, and never blocks onboarding', async () => {
+    provisionVentureEmailMock.mockRejectedValue(new Error('registrar unreachable'));
+    const eva = makeIntegration();
+
+    const result = await eva.onboardVenture({ id: 'v-4', name: 'FlakyCo', domain: 'flakyco.com' }, true);
+
+    expect(result.onboarded).toBe(true);
+    expect(result.email_provisioning).toEqual({ state: 'failed', error: 'registrar unreachable' });
+    expect(instantiateVentureMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/eva/stage-24-go-live-launch-mode.test.js
+++ b/tests/unit/eva/stage-24-go-live-launch-mode.test.js
@@ -4,7 +4,7 @@ import { analyzeStage24GoLive } from '../../../lib/eva/stage-templates/analysis-
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
 
-function buildSupabase({ ventureRow, appRow, telemetryRow } = {}) {
+function buildSupabase({ ventureRow, appRow, telemetryRow, tokenBudgetRow, chairmanDecisionRow, previewRow, guardrailUpsertError } = {}) {
   return {
     from: (table) => {
       if (table === 'ventures') {
@@ -24,6 +24,25 @@ function buildSupabase({ ventureRow, appRow, telemetryRow } = {}) {
         // SD-LEO-INFRA-LAUNCH-MODE-POLICY-002 (FR-3): the sim-label enforcement
         // reads prior launch evidence; these -001 scenarios have none (empty).
         const chain = { eq: () => chain, in: async () => ({ data: [], error: null }) };
+        return { select: () => chain };
+      }
+      // SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-1/FR-3: the live-mode-verified
+      // branch now also reads/writes these tables. Safe defaults (no row found) so
+      // the pre-existing -001/-002 test cases above are unaffected; guardrailUpsertError
+      // and the *Row params let the new FR-1/FR-3 test cases below exercise the wiring.
+      if (table === 'venture_token_budgets') {
+        const chain = { eq: () => chain, maybeSingle: async () => ({ data: tokenBudgetRow || null, error: null }) };
+        return { select: () => chain };
+      }
+      if (table === 'chairman_decisions') {
+        const chain = { eq: () => chain, is: () => chain, order: () => chain, limit: () => chain, maybeSingle: async () => ({ data: chairmanDecisionRow || null, error: null }) };
+        return { select: () => chain };
+      }
+      if (table === 'venture_guardrail_state') {
+        return { upsert: async () => ({ error: guardrailUpsertError || null }) };
+      }
+      if (table === 'venture_preview_instances') {
+        const chain = { eq: () => chain, order: () => chain, limit: () => chain, maybeSingle: async () => ({ data: previewRow || null, error: null }) };
         return { select: () => chain };
       }
       throw new Error(`unexpected table: ${table}`);
@@ -188,5 +207,106 @@ describe('analyzeStage24GoLive launch_mode branch (SD-LEO-INFRA-LAUNCH-MODE-POLI
     expect(evidence.verdict).toBe('PASS');
     expect(typeof evidence.external_observation.verified).toBe('boolean');
     expect(Array.isArray(evidence.external_observation.checks)).toBe(true);
+  });
+
+  // SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-1/FR-3: promote()/publish() and
+  // evaluateGuardrails()/persistGuardrailDecisions() had ZERO production callers.
+  // These pin that the ONLY branch reaching a real external-verification launch
+  // (never the simulated branch) wires both, and that a simulated go-live never
+  // invokes either (avoiding the "simulated-mode leakage" risk flagged at LEAD).
+  describe('SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 FR-1/FR-3 wiring', () => {
+    function liveVerifiedParams(supabase) {
+      return {
+        stage23Data: { verdict: 'PASS' },
+        stage22Data: { channels: [] },
+        ventureName: 'TestVenture',
+        logger: silentLogger,
+        launchedAt: '2026-07-03T00:00:00.000Z',
+        supabase,
+        ventureId: 'venture-1',
+      };
+    }
+
+    it('simulated-mode launch NEVER invokes the guardrails/deploy wiring (no result.guardrails_persisted/promote_status)', async () => {
+      const supabase = buildSupabase({ ventureRow: { launch_mode: 'simulated' } });
+      const result = await analyzeStage24GoLive(liveVerifiedParams(supabase));
+      expect(result.launch_status).toBe('launched');
+      expect(result.artifacts[0].payload.labeled_simulation).toBe(true);
+      expect(result.guardrails_persisted).toBeUndefined();
+      expect(result.promote_status).toBeUndefined();
+    });
+
+    it('live-verified launch persists real guardrail decisions (fail-closed on unmeasured inputs, never a fabricated pass)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+      const supabase = buildSupabase({
+        ventureRow: { launch_mode: 'live' },
+        appRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: null },
+        telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+        tokenBudgetRow: { budget_allocated: 250000, budget_remaining: 200000 },
+        chairmanDecisionRow: { decision: 'proceed' },
+      });
+      const result = await analyzeStage24GoLive(liveVerifiedParams(supabase));
+      expect(result.launch_status).toBe('launched');
+      expect(result.guardrails_persisted).toBe(true);
+      expect(result.guardrails_persist_error).toBeUndefined();
+    });
+
+    it('live-verified launch: a persist error is surfaced, never silently swallowed (fail-soft on the go-live result, loud on the field)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+      const supabase = buildSupabase({
+        ventureRow: { launch_mode: 'live' },
+        appRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: null },
+        telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+        guardrailUpsertError: { message: 'venture_guardrail_state unavailable' },
+      });
+      const result = await analyzeStage24GoLive(liveVerifiedParams(supabase));
+      expect(result.launch_status).toBe('launched'); // the launch decision itself is not blocked by a wiring failure
+      expect(result.guardrails_persisted).toBe(false);
+      expect(result.guardrails_persist_error).toBe('venture_guardrail_state unavailable');
+    });
+
+    it('live-verified launch with no venture_preview_instances row: skips promote() (never fabricates a sha), reports skipped_no_verified_sha', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+      const supabase = buildSupabase({
+        ventureRow: { launch_mode: 'live' },
+        appRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: null },
+        telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+      });
+      const result = await analyzeStage24GoLive(liveVerifiedParams(supabase));
+      expect(result.launch_status).toBe('launched');
+      expect(result.promote_status).toBe('skipped_no_verified_sha');
+    });
+
+    it('live-verified launch with a verified preview sha: calls promote() in PLAN mode only (never execute:true) -- writes a planned venture_deployments row, no real deploy', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ status: 200 });
+      let insertedRow = null;
+      const supabase = buildSupabase({
+        ventureRow: {
+          launch_mode: 'live',
+          stack_descriptor: { db_provider: 'neon', deployment_target: 'cloud-run', connection: { provider: 'neon', secret_ref: 'ref-1' } },
+        },
+        appRow: { id: 'app-1', deployment_url: 'https://example.com', metadata: { billing_product_id: 'prod_123' }, metrics_cadence_hours: null },
+        telemetryRow: { kpis: { signups: 3 }, pulled_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), ingest_status: 'ok' },
+        previewRow: { sha: 'abc1234' },
+      });
+      // promote() also queries 'ventures' (already handled) and inserts into 'venture_deployments' --
+      // wrap the base mock's `from` to add that table without duplicating the whole helper.
+      const baseFrom = supabase.from.bind(supabase);
+      supabase.from = (table) => {
+        if (table === 'venture_deployments') {
+          return {
+            insert: (row) => {
+              insertedRow = row;
+              return { select: () => ({ maybeSingle: async () => ({ data: { id: 'dep-1' }, error: null }) }) };
+            },
+          };
+        }
+        return baseFrom(table);
+      };
+      const result = await analyzeStage24GoLive(liveVerifiedParams(supabase));
+      expect(result.launch_status).toBe('launched');
+      expect(result.promote_status).toBe('planned'); // plan-mode: no deps.execute passed -- this SD never bypasses the 001-A chairman gate
+      expect(insertedRow).toMatchObject({ venture_id: 'venture-1', sha: 'abc1234', status: 'planned' });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Wires 3 of 4 "built-but-unwired" venture substrate joints into their live owning flows: `stage-24-go-live.js` now calls `promote()` (DEPLOY) and `buildGuardrailContext`/`persistGuardrailDecisions` (GUARDRAILS) inside the existing live-verified launch branch only; `eva-coo-integration.js`'s `onboardVenture()` now calls `provisionVentureEmail` (EMAIL), guarded on `venture.domain`, fail-soft.
- FR-4 (ATTRIBUTION at-source stamping) is honestly descoped: no checkout-creation call site exists anywhere in the app to wire `createVentureCheckoutSession` into — documented in `strategic_directives_v2.metadata.attribution_wiring_gap` for a future SD, not fabricated.
- GUARDRAILS reads 3 real measurable inputs (agent-token ceiling, chairman human-gate, isolation scope) and fails closed (undefined) on 5 inputs with no measurement source anywhere in the codebase today — by design, not a defect.

## Evidence
- 4 independent sub-agents, all PASS: TESTING (95, mutation-tested), SECURITY (90, 3 low/info advisories only), VALIDATION (90), REGRESSION (95, 88/88 tests, confirmed zero breaking changes).
- 17 new/updated unit tests; SD-completion retrospective on file.

## Test plan
- [x] `stage-24-go-live-launch-mode.test.js` — 13 tests (8 pre-existing regression + 5 new DEPLOY/GUARDRAILS)
- [x] `eva-coo-integration-onboard-email.test.js` — 4 new EMAIL wiring tests
- [x] Full consumer regression suite (guardrails/publish/acquisition) — 88/88 passing
- [x] Independent SECURITY review of secret handling (revealedKey) and guardrail query scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)