### PR TITLE
feat(SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A): chairman-governed portfolio-strategy artifact

### DIFF
--- a/lib/eva/__tests__/vision-upsert.test.js
+++ b/lib/eva/__tests__/vision-upsert.test.js
@@ -137,6 +137,61 @@ describe('upsertVision', () => {
     });
   });
 
+  // ── SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: governed-tier keys ────────
+  describe('governed-tier vision_key (FORCE-APPROVE trap closure)', () => {
+    const GOVERNED_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
+
+    test('governed key with no options at all writes draft + not approved (no auto-activate)', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: GOVERNED_KEY }, captured });
+
+      await upsertVision({ supabase, visionKey: GOVERNED_KEY, content: 'test' });
+
+      expect(captured.record.status).toBe('draft');
+      expect(captured.record.chairman_approved).toBe(false);
+    });
+
+    test('governed key with approved=true but no chairmanRatified still writes draft (approved is ignored)', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: GOVERNED_KEY }, captured });
+
+      await upsertVision({ supabase, visionKey: GOVERNED_KEY, content: 'test', approved: true });
+
+      expect(captured.record.status).toBe('draft');
+      expect(captured.record.chairman_approved).toBe(false);
+    });
+
+    test('governed key with chairmanRatified=true writes active + chairman_approved', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: GOVERNED_KEY }, captured });
+
+      await upsertVision({ supabase, visionKey: GOVERNED_KEY, content: 'test', chairmanRatified: true });
+
+      expect(captured.record.status).toBe('active');
+      expect(captured.record.chairman_approved).toBe(true);
+    });
+
+    test('governed key with chairmanRatified=false explicitly writes draft', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: GOVERNED_KEY }, captured });
+
+      await upsertVision({ supabase, visionKey: GOVERNED_KEY, content: 'test', approved: true, chairmanRatified: false });
+
+      expect(captured.record.status).toBe('draft');
+      expect(captured.record.chairman_approved).toBe(false);
+    });
+
+    test('non-governed key is unaffected by chairmanRatified option (default approval behavior preserved)', async () => {
+      const captured = {};
+      const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });
+
+      await upsertVision({ supabase, visionKey: 'V-1', content: 'test' });
+
+      expect(captured.record.status).toBe('active');
+      expect(captured.record.chairman_approved).toBe(true);
+    });
+  });
+
   // ── FR-1: vision→venture linkage at write time ─────────────────────────────
   describe('FR-1 venture linkage at write time', () => {
     test('explicit ventureId is used and wins (no brainstorm lookup needed)', async () => {

--- a/lib/eva/__tests__/vision-upsert.test.js
+++ b/lib/eva/__tests__/vision-upsert.test.js
@@ -181,6 +181,21 @@ describe('upsertVision', () => {
       expect(captured.record.chairman_approved).toBe(false);
     });
 
+    test('an unratified revision proposal to an already-ACTIVE governed row demotes it back to draft — each revision needs its own ratification', async () => {
+      const captured = {};
+      const supabase = mockSupabase({
+        existing: { id: 'u', version: 1, addendums: [], extracted_dimensions: ['x'] },
+        upsertResult: { id: 'u', vision_key: GOVERNED_KEY },
+        captured,
+      });
+
+      // Simulates a new revision proposal (e.g. updated content) landing without re-ratification.
+      await upsertVision({ supabase, visionKey: GOVERNED_KEY, content: 'revised content', approved: true });
+
+      expect(captured.record.status).toBe('draft');
+      expect(captured.record.chairman_approved).toBe(false);
+    });
+
     test('non-governed key is unaffected by chairmanRatified option (default approval behavior preserved)', async () => {
       const captured = {};
       const supabase = mockSupabase({ upsertResult: { id: 'u', vision_key: 'V-1' }, captured });

--- a/lib/eva/__tests__/vision-upsert.test.js
+++ b/lib/eva/__tests__/vision-upsert.test.js
@@ -4,7 +4,7 @@
  * SD: SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 (FR-1 venture linkage, FR-2 deliberate approval)
  */
 import { describe, test, expect, vi } from 'vitest';
-import { upsertVision } from '../vision-upsert.js';
+import { upsertVision, buildAddendumUpdatePayload } from '../vision-upsert.js';
 
 // Table-aware mock supabase client.
 //  - eva_vision_documents: select(...).eq(vision_key).maybeSingle() => existing,
@@ -279,6 +279,62 @@ describe('upsertVision', () => {
       await upsertVision({ supabase, visionKey: 'V-1', content: 'test', brainstormId: 'bs-1' });
 
       expect(captured.record.venture_id).toBeUndefined();
+    });
+  });
+
+  // ── SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: addendum bypass closure ───
+  // Adversarial review (PR #6138) found the CLI's `addendum` subcommand wrote
+  // directly to eva_vision_documents, bypassing upsertVision()'s governed-key
+  // ratification gate entirely. buildAddendumUpdatePayload() closes that gap.
+  describe('buildAddendumUpdatePayload (governed-key demotion on addendum)', () => {
+    const GOVERNED_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
+
+    test('addendum to a governed key demotes an already-active row back to draft', () => {
+      const existing = { content: 'original content', addendums: [] };
+
+      const { updatePayload } = buildAddendumUpdatePayload({
+        visionKey: GOVERNED_KEY, existing, section: 'new section text', dimensions: null,
+      });
+
+      expect(updatePayload.status).toBe('draft');
+      expect(updatePayload.chairman_approved).toBe(false);
+    });
+
+    test('addendum to a non-governed key does not touch status/chairman_approved', () => {
+      const existing = { content: 'original content', addendums: [] };
+
+      const { updatePayload } = buildAddendumUpdatePayload({
+        visionKey: 'V-1', existing, section: 'new section text', dimensions: null,
+      });
+
+      expect(updatePayload.status).toBeUndefined();
+      expect(updatePayload.chairman_approved).toBeUndefined();
+    });
+
+    test('combined content and addendums array are built correctly regardless of governance', () => {
+      const existing = { content: 'original content', addendums: [{ section: 'first' }] };
+
+      const { updatePayload, updatedAddendums, combinedContent } = buildAddendumUpdatePayload({
+        visionKey: GOVERNED_KEY, existing, section: 'second addendum', dimensions: ['dim'],
+      });
+
+      expect(updatedAddendums).toHaveLength(2);
+      expect(updatedAddendums[1].section).toBe('second addendum');
+      expect(combinedContent).toContain('original content');
+      expect(combinedContent).toContain('second addendum');
+      expect(updatePayload.content).toBe(combinedContent);
+      expect(updatePayload.extracted_dimensions).toEqual(['dim']);
+    });
+
+    test('brainstormId is threaded into both the addendum entry and the top-level payload', () => {
+      const existing = { content: 'original content', addendums: [] };
+
+      const { updatePayload, updatedAddendums } = buildAddendumUpdatePayload({
+        visionKey: 'V-1', existing, section: 'new section', dimensions: null, brainstormId: 'bs-1',
+      });
+
+      expect(updatePayload.source_brainstorm_id).toBe('bs-1');
+      expect(updatedAddendums[0].source_brainstorm_id).toBe('bs-1');
     });
   });
 });

--- a/lib/eva/__tests__/vision-upsert.test.js
+++ b/lib/eva/__tests__/vision-upsert.test.js
@@ -4,7 +4,7 @@
  * SD: SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001 (FR-1 venture linkage, FR-2 deliberate approval)
  */
 import { describe, test, expect, vi } from 'vitest';
-import { upsertVision, buildAddendumUpdatePayload } from '../vision-upsert.js';
+import { upsertVision, buildAddendumUpdatePayload, rejectStringFlagValue, selectFirstNonGoverned } from '../vision-upsert.js';
 
 // Table-aware mock supabase client.
 //  - eva_vision_documents: select(...).eq(vision_key).maybeSingle() => existing,
@@ -335,6 +335,68 @@ describe('upsertVision', () => {
 
       expect(updatePayload.source_brainstorm_id).toBe('bs-1');
       expect(updatedAddendums[0].source_brainstorm_id).toBe('bs-1');
+    });
+  });
+
+  // ── SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: CLI bare-flag footgun ─────
+  // Adversarial review (PR #6138) found `--chairman-ratified false` parses to
+  // the string 'false', which Boolean('false') coerces to true — silently
+  // ratifying against operator intent. The identical bug pre-existed for
+  // --approved/--draft. rejectStringFlagValue() closes both.
+  describe('rejectStringFlagValue (CLI bare-boolean-flag footgun)', () => {
+    test('returns an error message when a string value is passed', () => {
+      expect(rejectStringFlagValue('false', '--chairman-ratified')).toContain('--chairman-ratified');
+      expect(rejectStringFlagValue('true', '--approved')).toContain('--approved');
+      expect(rejectStringFlagValue('anything', '--draft')).toContain('--draft');
+    });
+
+    test('returns null for the correct bare-flag boolean true', () => {
+      expect(rejectStringFlagValue(true, '--chairman-ratified')).toBeNull();
+    });
+
+    test('returns null when the flag is absent (undefined)', () => {
+      expect(rejectStringFlagValue(undefined, '--chairman-ratified')).toBeNull();
+    });
+
+    test('returns null for boolean false (flag simply not set by parseArgs)', () => {
+      expect(rejectStringFlagValue(false, '--draft')).toBeNull();
+    });
+  });
+
+  // ── SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: L1-resolution bypass closure ──
+  // Adversarial review (PR #6138) found brainstorm-to-vision.mjs's "most recent
+  // active L1" resolution could silently select a governed vision_key.
+  describe('selectFirstNonGoverned (L1-resolution governed-key exclusion)', () => {
+    const GOVERNED_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
+
+    test('skips a governed candidate even when it is first (most recent)', () => {
+      const candidates = [
+        { vision_key: GOVERNED_KEY },
+        { vision_key: 'VISION-EHG-L1-001' },
+      ];
+
+      expect(selectFirstNonGoverned(candidates)).toEqual({ vision_key: 'VISION-EHG-L1-001' });
+    });
+
+    test('returns the first candidate when none are governed', () => {
+      const candidates = [
+        { vision_key: 'VISION-EHG-L1-001' },
+        { vision_key: 'VISION-OTHER-L1-002' },
+      ];
+
+      expect(selectFirstNonGoverned(candidates)).toEqual({ vision_key: 'VISION-EHG-L1-001' });
+    });
+
+    test('returns null when every candidate is governed', () => {
+      const candidates = [{ vision_key: GOVERNED_KEY }];
+
+      expect(selectFirstNonGoverned(candidates)).toBeNull();
+    });
+
+    test('returns null for an empty or missing candidate list', () => {
+      expect(selectFirstNonGoverned([])).toBeNull();
+      expect(selectFirstNonGoverned(null)).toBeNull();
+      expect(selectFirstNonGoverned(undefined)).toBeNull();
     });
   });
 });

--- a/lib/eva/stage-zero/__tests__/strategic-context-loader.test.js
+++ b/lib/eva/stage-zero/__tests__/strategic-context-loader.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for the additive portfolio-strategy sub-loader.
+ * SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { loadStrategicContext, PORTFOLIO_STRATEGY_VISION_KEY } from '../strategic-context-loader.js';
+
+// Minimal table-aware mock supabase client. Every table other than
+// eva_vision_documents returns an empty/null fail-soft shape so each sub-loader
+// resolves quickly without asserting on tables outside this test's concern.
+function mockSupabase({ portfolioStrategyRow = null, portfolioStrategyError = null } = {}) {
+  return {
+    from: vi.fn((table) => {
+      if (table === 'eva_vision_documents') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({ data: portfolioStrategyRow, error: portfolioStrategyError })),
+              })),
+              in: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(async () => ({ data: [], error: null })),
+                })),
+              })),
+            })),
+          })),
+        };
+      }
+      // missions / key_results / strategic_themes / anything else: empty fail-soft shape
+      return {
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({ limit: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: { message: 'no rows' } })) })) })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+          lt: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) })),
+        })),
+      };
+    }),
+  };
+}
+
+describe('loadStrategicContext — portfolio strategy sub-loader', () => {
+  test('PORTFOLIO_STRATEGY_VISION_KEY is a distinct, exported constant', () => {
+    expect(PORTFOLIO_STRATEGY_VISION_KEY).toBe('VISION-PORTFOLIO-STRATEGY-001');
+  });
+
+  test('when the row is active, raw.portfolioStrategy is populated and included in the formatted prompt block', async () => {
+    const row = { vision_key: PORTFOLIO_STRATEGY_VISION_KEY, content: 'CHAINING THESIS: anchor-customer pattern...', extracted_dimensions: ['chaining', 'capital-allocation'] };
+    const supabase = mockSupabase({ portfolioStrategyRow: row });
+
+    const result = await loadStrategicContext(supabase);
+
+    expect(result.raw.portfolioStrategy).toEqual(row);
+    expect(result.isEmpty).toBe(false);
+    expect(result.formattedPromptBlock).toContain('PORTFOLIO STRATEGY');
+    expect(result.formattedPromptBlock).toContain('CHAINING THESIS');
+  });
+
+  test('when no active row exists and no other signal is present, isEmpty stays true', async () => {
+    const supabase = mockSupabase({ portfolioStrategyRow: null });
+
+    const result = await loadStrategicContext(supabase);
+
+    expect(result.raw.portfolioStrategy).toBeNull();
+    expect(result.isEmpty).toBe(true);
+  });
+
+  test('portfolioStrategy alone (no mission/vision/okr/themes) is sufficient to make isEmpty=false — it must never be silently dropped', async () => {
+    const row = { vision_key: PORTFOLIO_STRATEGY_VISION_KEY, content: 'CHAINING THESIS: anchor-customer pattern...', extracted_dimensions: ['chaining'] };
+    const supabase = mockSupabase({ portfolioStrategyRow: row });
+
+    const result = await loadStrategicContext(supabase);
+
+    expect(result.isEmpty).toBe(false);
+    expect(result.formattedPromptBlock).toContain('PORTFOLIO STRATEGY');
+  });
+
+  test('a query error is swallowed fail-soft (never throws), returns null', async () => {
+    const supabase = mockSupabase({ portfolioStrategyError: { message: 'boom' } });
+
+    await expect(loadStrategicContext(supabase)).resolves.not.toThrow();
+    const result = await loadStrategicContext(supabase);
+    expect(result.raw.portfolioStrategy).toBeNull();
+  });
+
+  test('queries by exact vision_key and status=active (never "the active L1 row")', async () => {
+    const eqVisionKey = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })),
+    }));
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'eva_vision_documents') {
+          return { select: vi.fn(() => ({ eq: eqVisionKey, in: vi.fn(() => ({ order: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) })) })) })) };
+        }
+        return { select: vi.fn(() => ({ order: vi.fn(() => ({ limit: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: { message: 'no rows' } })) })) })), limit: vi.fn(async () => ({ data: [], error: null })), lt: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) })) })) };
+      }),
+    };
+
+    await loadStrategicContext(supabase);
+
+    expect(eqVisionKey).toHaveBeenCalledWith('vision_key', PORTFOLIO_STRATEGY_VISION_KEY);
+  });
+});

--- a/lib/eva/stage-zero/strategic-context-loader.js
+++ b/lib/eva/stage-zero/strategic-context-loader.js
@@ -11,14 +11,14 @@
  */
 
 import { computePortfolioMaturity } from '../../capabilities/scanner-context.js';
+// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: re-export the canonical governed
+// vision_key from vision-upsert.js (the single source of truth) rather than
+// redefining it here — a second, independently-hardcoded copy of this string
+// was found (adversarial review, PR #6138) to risk silently desyncing from the
+// ratification gate it must always match.
+import { PORTFOLIO_STRATEGY_VISION_KEY } from '../vision-upsert.js';
 
-// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: the distinct vision_key for the
-// chairman-governed holdco portfolio-strategy artifact. Disambiguated from the
-// existing active VISION-EHG-L1-001 (mission/vision) — both legitimately
-// coexist at level=L1 as role-distinct artifacts (VALIDATION/RISK sub-agents
-// confirmed no unique index blocks this). Always read by exact vision_key,
-// never "the active L1 row".
-export const PORTFOLIO_STRATEGY_VISION_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
+export { PORTFOLIO_STRATEGY_VISION_KEY };
 
 /**
  * Load all strategic context for Stage 0 ideation.

--- a/lib/eva/stage-zero/strategic-context-loader.js
+++ b/lib/eva/stage-zero/strategic-context-loader.js
@@ -12,6 +12,14 @@
 
 import { computePortfolioMaturity } from '../../capabilities/scanner-context.js';
 
+// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: the distinct vision_key for the
+// chairman-governed holdco portfolio-strategy artifact. Disambiguated from the
+// existing active VISION-EHG-L1-001 (mission/vision) — both legitimately
+// coexist at level=L1 as role-distinct artifacts (VALIDATION/RISK sub-agents
+// confirmed no unique index blocks this). Always read by exact vision_key,
+// never "the active L1 row".
+export const PORTFOLIO_STRATEGY_VISION_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
+
 /**
  * Load all strategic context for Stage 0 ideation.
  *
@@ -28,23 +36,28 @@ export async function loadStrategicContext(supabase, options = {}) {
   }
 
   // Run all sub-loaders in parallel - each catches independently
-  const [mission, visionDimensions, okrGaps, themes, portfolioMaturity] = await Promise.all([
+  const [mission, visionDimensions, okrGaps, themes, portfolioMaturity, portfolioStrategy] = await Promise.all([
     loadMission(supabase, logger),
     loadVisionDimensions(supabase, logger),
     loadOkrGaps(supabase, logger),
     loadStrategicThemes(supabase, logger),
     loadPortfolioMaturity(supabase, logger),
+    loadPortfolioStrategy(supabase, logger),
   ]);
 
   const agentEconomyContext = getAgentEconomyContext();
 
-  const raw = { mission, visionDimensions, okrGaps, themes, agentEconomyContext, portfolioMaturity };
+  const raw = { mission, visionDimensions, okrGaps, themes, agentEconomyContext, portfolioMaturity, portfolioStrategy };
 
-  // portfolioMaturity is informational context, not a presence signal — exclude it from isEmpty.
+  // portfolioMaturity is purely supplementary/derived context — excluded from isEmpty (existing behavior).
+  // portfolioStrategy is NOT excluded: it is the chairman-ratified artifact this loader exists to
+  // guarantee gets injected (SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A FR-3) — if it is the only
+  // signal present, the short-circuit below must not silently drop it.
   const isEmpty = !mission
     && visionDimensions.length === 0
     && okrGaps.length === 0
-    && themes.length === 0;
+    && themes.length === 0
+    && !portfolioStrategy;
 
   if (isEmpty) {
     logger.log('   Strategic context: no data available');
@@ -52,7 +65,7 @@ export async function loadStrategicContext(supabase, options = {}) {
   }
 
   const formattedPromptBlock = formatPromptBlock(raw);
-  logger.log(`   Strategic context loaded: mission=${mission ? 'yes' : 'no'}, visions=${visionDimensions.length}, okrGaps=${okrGaps.length}, themes=${themes.length}`);
+  logger.log(`   Strategic context loaded: mission=${mission ? 'yes' : 'no'}, visions=${visionDimensions.length}, okrGaps=${okrGaps.length}, themes=${themes.length}, portfolioStrategy=${portfolioStrategy ? 'yes' : 'no'}`);
 
   return { formattedPromptBlock, raw, isEmpty: false };
 }
@@ -156,6 +169,31 @@ async function loadPortfolioMaturity(supabase, logger) {
 }
 
 /**
+ * Load the chairman-ratified holdco portfolio-strategy artifact by its exact,
+ * distinct vision_key (SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A). Additive
+ * only — does NOT read via the generic loadVisionDimensions() above, which a
+ * VALIDATION/RISK sub-agent pass found separately broken (non-existent column,
+ * invalid status filter, silently returns zero rows) — repairing that is out
+ * of scope here. Fail-soft: never throws, returns null on any miss.
+ */
+async function loadPortfolioStrategy(supabase, logger) {
+  try {
+    const { data, error } = await supabase
+      .from('eva_vision_documents')
+      .select('vision_key, content, extracted_dimensions')
+      .eq('vision_key', PORTFOLIO_STRATEGY_VISION_KEY)
+      .eq('status', 'active')
+      .maybeSingle();
+
+    if (error || !data) return null;
+    return data;
+  } catch (err) {
+    logger.warn(`   Warning: Portfolio strategy load failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * Format all strategic context into a prompt block for LLM injection.
  */
 function formatPromptBlock(raw) {
@@ -199,6 +237,11 @@ function formatPromptBlock(raw) {
     for (const t of raw.themes) {
       sections.push(`  - ${t.name}${t.description ? ': ' + t.description : ''}`);
     }
+  }
+
+  if (raw.portfolioStrategy) {
+    sections.push('\nPORTFOLIO STRATEGY (chairman-ratified holdco artifact):');
+    sections.push(`  ${raw.portfolioStrategy.content}`);
   }
 
   if (raw.portfolioMaturity) {
@@ -253,7 +296,7 @@ export function getAgentEconomyContext() {
 function emptyResult() {
   return {
     formattedPromptBlock: '',
-    raw: { mission: null, visionDimensions: [], okrGaps: [], themes: [], agentEconomyContext: null },
+    raw: { mission: null, visionDimensions: [], okrGaps: [], themes: [], agentEconomyContext: null, portfolioMaturity: null, portfolioStrategy: null },
     isEmpty: true,
   };
 }

--- a/lib/eva/vision-upsert.js
+++ b/lib/eva/vision-upsert.js
@@ -7,6 +7,15 @@
  * @module lib/eva/vision-upsert
  */
 
+// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: vision_key(s) requiring GOVERNED-TIER
+// approval — a revision can activate ONLY via an explicit chairmanRatified:true, never
+// via the `approved` default. Scoped deliberately to these keys only: VALIDATION/RISK
+// sub-agent passes confirmed all 3 existing L2 callers (stage-17-doc-generation.js,
+// vision-repair-loop.js, CLI vision-command.mjs) already pass `approved` explicitly, so
+// flipping the GLOBAL default would be unnecessary and untested — this guard closes the
+// FORCE-APPROVE trap for the portfolio-strategy artifact without touching that default.
+const GOVERNED_VISION_KEYS = new Set(['VISION-PORTFOLIO-STRATEGY-001']);
+
 /**
  * Upsert an EVA vision document.
  *
@@ -20,6 +29,12 @@
  *    wrapper (scripts/eva/vision-command.mjs) makes the choice mandatory so the
  *    chairman-facing path is deliberate, not silent.
  *
+ * SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A:
+ *  - GOVERNED_VISION_KEYS entries ignore `approved` entirely and require an
+ *    explicit `chairmanRatified: true` to activate — a revision proposal for
+ *    one of these keys defaults to draft (never auto-activates), closing the
+ *    upsertVision FORCE-APPROVE trap for the portfolio-strategy artifact.
+ *
  * @param {Object}  params
  * @param {Object}  params.supabase   - Supabase client (required)
  * @param {string}  params.visionKey  - vision_key (required)
@@ -30,10 +45,11 @@
  * @param {string}  [params.ventureId] - explicit venture linkage (wins over brainstorm resolution)
  * @param {string}  [params.brainstormId] - source brainstorm session id (used for FR-1 venture resolution)
  * @param {string}  [params.createdBy='eva-vision-upsert']
- * @param {boolean} [params.approved=true] - FR-2: controls chairman_approved AND status
+ * @param {boolean} [params.approved=true] - FR-2: controls chairman_approved AND status (ignored for GOVERNED_VISION_KEYS)
+ * @param {boolean} [params.chairmanRatified=false] - required true to activate a GOVERNED_VISION_KEYS revision
  * @returns {Promise<{data: Object|null, error: Object|null}>}
  */
-export async function upsertVision({ supabase, visionKey, level = 'L2', content, sections, dimensions, ventureId, brainstormId, createdBy = 'eva-vision-upsert', approved = true }) {
+export async function upsertVision({ supabase, visionKey, level = 'L2', content, sections, dimensions, ventureId, brainstormId, createdBy = 'eva-vision-upsert', approved = true, chairmanRatified = false }) {
   if (!supabase) throw new Error('supabase client is required');
   if (!visionKey) throw new Error('visionKey is required');
   if (!content) throw new Error('content is required');
@@ -71,7 +87,10 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
     : prevAddendums;
 
   // FR-2: deliberate approval — `approved` controls BOTH chairman_approved and status.
-  const isApproved = approved !== false;
+  // Governed keys ignore `approved` entirely — only an explicit chairmanRatified:true activates.
+  const isApproved = GOVERNED_VISION_KEYS.has(visionKey)
+    ? chairmanRatified === true
+    : approved !== false;
 
   const record = {
     vision_key: visionKey,

--- a/lib/eva/vision-upsert.js
+++ b/lib/eva/vision-upsert.js
@@ -183,6 +183,50 @@ export function buildAddendumUpdatePayload({ visionKey, existing, section, dimen
 }
 
 /**
+ * SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: scripts/eva/vision-command.mjs's
+ * hand-rolled parseArgs() treats any non-`--`-prefixed following token as a
+ * VALUE for a flag, so a bare boolean flag documented as "pass it, or omit it"
+ * (`--approved`, `--draft`, `--chairman-ratified`) silently accepts
+ * `--flag false`, parses it to the STRING 'false', and `Boolean('false')`
+ * coerces that to `true` — the exact opposite of the operator's intent.
+ * Adversarial review (PR #6138) found this live for `--chairman-ratified`;
+ * the identical bug already existed for `--approved`/`--draft`. Extracted
+ * here (rather than left inline in the CLI script) because vision-command.mjs
+ * has no isMainModule() guard around its dispatch — importing it directly
+ * for a unit test would execute the CLI's live argv-driven switch statement.
+ *
+ * @param {*} flagValue - the raw parsed opts[key] value
+ * @param {string} flagName - the flag's CLI spelling, for the error message
+ * @returns {string|null} an error message if a string value was passed, else null
+ */
+export function rejectStringFlagValue(flagValue, flagName) {
+  if (typeof flagValue === 'string') {
+    return `${flagName} takes no value (got "${flagValue}") — pass it bare, or omit it entirely.`;
+  }
+  return null;
+}
+
+/**
+ * SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: select the most-recent-first
+ * candidate that is NOT a governed vision_key. Extracted from
+ * scripts/eva/brainstorm-to-vision.mjs's "most recent active L1" resolution
+ * for testability — a second-pass adversarial review (PR #6138) found that
+ * resolution could silently pick up a governed vision_key (e.g.
+ * VISION-PORTFOLIO-STRATEGY-001) once it is chairman-ratified and coexists at
+ * L1 alongside the mission/vision doc, then append content to it via a raw
+ * write with no ratification check. Pure — the caller is responsible for
+ * fetching `candidates` pre-sorted most-recent-first and windowed wide enough
+ * to guarantee a non-governed row exists if one is active (e.g.
+ * `GOVERNED_VISION_KEYS.size + N`).
+ *
+ * @param {Array<{vision_key: string}>} candidates - pre-sorted most-recent-first
+ * @returns {Object|null} the first non-governed candidate, or null if none
+ */
+export function selectFirstNonGoverned(candidates) {
+  return (candidates || []).find(v => !GOVERNED_VISION_KEYS.has(v.vision_key)) || null;
+}
+
+/**
  * FR-1: Resolve a single, unambiguous venture_id from a brainstorm session.
  *
  * A brainstorm session carries `venture_ids` (array) and a `cross_venture`

--- a/lib/eva/vision-upsert.js
+++ b/lib/eva/vision-upsert.js
@@ -14,7 +14,13 @@
 // vision-repair-loop.js, CLI vision-command.mjs) already pass `approved` explicitly, so
 // flipping the GLOBAL default would be unnecessary and untested — this guard closes the
 // FORCE-APPROVE trap for the portfolio-strategy artifact without touching that default.
-const GOVERNED_VISION_KEYS = new Set(['VISION-PORTFOLIO-STRATEGY-001']);
+//
+// Exported as the single canonical source: any other write path to eva_vision_documents
+// touching one of these keys (e.g. scripts/eva/vision-command.mjs's addendum subcommand)
+// MUST import and check against this same set — a second, independently-hardcoded copy of
+// the key string was found (adversarial review, PR #6138) to risk silently desyncing.
+export const GOVERNED_VISION_KEYS = new Set(['VISION-PORTFOLIO-STRATEGY-001']);
+export const PORTFOLIO_STRATEGY_VISION_KEY = 'VISION-PORTFOLIO-STRATEGY-001';
 
 /**
  * Upsert an EVA vision document.
@@ -123,6 +129,57 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
     .single();
 
   return { data, error };
+}
+
+/**
+ * Build the UPDATE payload for an addendum to an existing vision document.
+ * Extracted from scripts/eva/vision-command.mjs's cmdAddendum for testability
+ * (SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A) — pure, no I/O.
+ *
+ * SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: a direct addendum UPDATE is a
+ * second write path to eva_vision_documents that would otherwise bypass
+ * upsertVision()'s GOVERNED_VISION_KEYS ratification gate entirely — an
+ * adversarial review (PR #6138) found this let an already-ACTIVE governed
+ * document's content change while status/chairman_approved stayed untouched.
+ * Mirrors upsertVision's "each revision needs its own ratification" rule: any
+ * addendum to a governed key demotes the row back to draft.
+ *
+ * @param {Object} params
+ * @param {string} params.visionKey
+ * @param {Object} params.existing - existing row: { content, addendums }
+ * @param {string} params.section - addendum text
+ * @param {Array|null} [params.dimensions] - freshly re-extracted dimensions
+ * @param {string} [params.brainstormId]
+ * @param {string} [params.addedBy='eva-vision-command']
+ * @returns {{updatePayload: Object, updatedAddendums: Array, combinedContent: string}}
+ */
+export function buildAddendumUpdatePayload({ visionKey, existing, section, dimensions, brainstormId, addedBy = 'eva-vision-command' }) {
+  const addendum = {
+    section,
+    added_at: new Date().toISOString(),
+    added_by: addedBy,
+    ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
+  };
+
+  const currentAddendums = existing.addendums || [];
+  const updatedAddendums = [...currentAddendums, addendum];
+
+  const combinedContent = `${existing.content}\n\n---\n\n## Addendum ${updatedAddendums.length}\n\n${section}`;
+
+  const updatePayload = {
+    addendums: updatedAddendums,
+    extracted_dimensions: dimensions,
+    content: combinedContent,
+    updated_at: new Date().toISOString(),
+  };
+  if (brainstormId) updatePayload.source_brainstorm_id = brainstormId;
+
+  if (GOVERNED_VISION_KEYS.has(visionKey)) {
+    updatePayload.status = 'draft';
+    updatePayload.chairman_approved = false;
+  }
+
+  return { updatePayload, updatedAddendums, combinedContent };
 }
 
 /**

--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -20,6 +20,14 @@
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { getValidationClient } from '../../lib/llm/client-factory.js';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
+// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: this pipeline's "most recent active
+// L1 vision" resolution (below) is a THIRD direct-write path to eva_vision_documents
+// that a second-pass adversarial review (PR #6138) found could silently pick up a
+// GOVERNED vision_key (e.g. VISION-PORTFOLIO-STRATEGY-001) once it is chairman-ratified
+// and coexists at L1 alongside the mission/vision doc — then append brainstorm content
+// to it via a raw .update() with no ratification check at all, reproducing the exact
+// bug class this SD closed for the CLI's addendum path. Excluded at the query below.
+import { GOVERNED_VISION_KEYS } from '../../lib/eva/vision-upsert.js';
 
 const VISION_RELEVANT_OUTCOMES = ['sd_created', 'significant_departure'];
 const MAX_LLM_CONTENT_CHARS = 15000;
@@ -114,15 +122,19 @@ async function main() {
 
   if (!unlinked.length) { console.log('✅ All sessions already linked to vision docs.'); return; }
 
-  // Dynamically resolve L1 vision doc (most recent active L1)
-  const { data: l1Vision } = await supabase
+  // Dynamically resolve L1 vision doc (most recent active L1, excluding GOVERNED
+  // keys — see import note above). Fetch a small window of candidates ordered by
+  // recency and pick the first non-governed one, rather than relying on a
+  // limit(1) that could silently select a governed artifact.
+  const { data: l1Candidates } = await supabase
     .from('eva_vision_documents')
     .select('id, vision_key, content, addendums, version')
     .eq('level', 'L1')
     .eq('status', 'active')
     .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .limit(GOVERNED_VISION_KEYS.size + 5);
+
+  const l1Vision = (l1Candidates || []).find(v => !GOVERNED_VISION_KEYS.has(v.vision_key)) || null;
 
   if (!l1Vision) {
     console.warn('   ⚠️  No active L1 vision document found — significant_departure sessions will be skipped');

--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -27,7 +27,7 @@ import { isMainModule } from '../../lib/utils/is-main-module.js';
 // and coexists at L1 alongside the mission/vision doc — then append brainstorm content
 // to it via a raw .update() with no ratification check at all, reproducing the exact
 // bug class this SD closed for the CLI's addendum path. Excluded at the query below.
-import { GOVERNED_VISION_KEYS } from '../../lib/eva/vision-upsert.js';
+import { GOVERNED_VISION_KEYS, selectFirstNonGoverned } from '../../lib/eva/vision-upsert.js';
 
 const VISION_RELEVANT_OUTCOMES = ['sd_created', 'significant_departure'];
 const MAX_LLM_CONTENT_CHARS = 15000;
@@ -134,7 +134,7 @@ async function main() {
     .order('created_at', { ascending: false })
     .limit(GOVERNED_VISION_KEYS.size + 5);
 
-  const l1Vision = (l1Candidates || []).find(v => !GOVERNED_VISION_KEYS.has(v.vision_key)) || null;
+  const l1Vision = selectFirstNonGoverned(l1Candidates);
 
   if (!l1Vision) {
     console.warn('   ⚠️  No active L1 vision document found — significant_departure sessions will be skipped');

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -48,6 +48,11 @@ import { parseMarkdownToSections, buildDefaultMapping } from './markdown-to-sect
 import { buildSectionKeyMapping, getSectionSchema, validateSections } from './document-section-registry.mjs';
 import { renderSectionsToMarkdown, renderSectionsSummary } from './sections-to-markdown-renderer.mjs';
 import { readStdin } from '../../lib/utils/read-stdin.mjs';
+// SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: the same GOVERNED_VISION_KEYS gate cmdUpsert
+// applies via upsertVision() must also apply to cmdAddendum's direct DB write below — an
+// adversarial review (PR #6138) found the addendum path bypassed ratification entirely,
+// letting an already-active governed document's content change with no re-ratification.
+import { buildAddendumUpdatePayload } from '../../lib/eva/vision-upsert.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../');
@@ -311,21 +316,10 @@ async function cmdAddendum({ visionKey, section, brainstormId }) {
     process.exit(1);
   }
 
-  // Build addendum entry
-  const addendum = {
-    section,
-    added_at: new Date().toISOString(),
-    added_by: 'eva-vision-command',
-    ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
-  };
-
-  const currentAddendums = existing.addendums || [];
-  const updatedAddendums = [...currentAddendums, addendum];
-
-  // Re-extract dimensions from combined content
-  const combinedContent = `${existing.content}\n\n---\n\n## Addendum ${updatedAddendums.length}\n\n${section}`;
+  // Re-extract dimensions from the combined content (addendum text is appended to existing content)
+  const pendingCombinedContent = `${existing.content}\n\n---\n\n## Addendum ${(existing.addendums || []).length + 1}\n\n${section}`;
   console.error(`\n🤖 Re-extracting dimensions from updated content...`);
-  const dimensions = await extractDimensions(combinedContent);
+  const dimensions = await extractDimensions(pendingCombinedContent);
 
   if (dimensions) {
     const weightSum = dimensions.reduce((sum, d) => sum + (d.weight || 0), 0);
@@ -334,25 +328,36 @@ async function cmdAddendum({ visionKey, section, brainstormId }) {
     }
   }
 
-  const updatePayload = {
-    addendums: updatedAddendums,
-    extracted_dimensions: dimensions,
-    content: combinedContent,
-    updated_at: new Date().toISOString(),
-  };
-  if (brainstormId) updatePayload.source_brainstorm_id = brainstormId;
+  // SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: this is a second write path to
+  // eva_vision_documents that would otherwise bypass upsertVision()'s
+  // GOVERNED_VISION_KEYS gate entirely (adversarial review, PR #6138) — an
+  // addendum to an already-ACTIVE governed document would change its content
+  // while leaving status='active'/chairman_approved=true untouched, surfacing
+  // unratified content to stage-zero ideation as "chairman-ratified".
+  // buildAddendumUpdatePayload() mirrors upsertVision's "each revision needs
+  // its own ratification" rule: any addendum to a governed key demotes the
+  // row back to draft, requiring an explicit --approved --chairman-ratified
+  // upsert to re-activate.
+  const { updatePayload, updatedAddendums } = buildAddendumUpdatePayload({
+    visionKey, existing, section, dimensions, brainstormId,
+  });
+  if (updatePayload.status === 'draft') {
+    console.warn(`\n   ⚠️  ${visionKey} is a GOVERNED vision_key — this addendum demotes it back to draft.`);
+    console.warn(`      Re-run: node scripts/eva/vision-command.mjs upsert --vision-key ${visionKey} --level L1 --approved --chairman-ratified --content <updated content> to re-ratify.`);
+  }
 
   const { data, error } = await supabase
     .from('eva_vision_documents')
     .update(updatePayload)
     .eq('vision_key', visionKey)
-    .select('id, vision_key, version')
+    .select('id, vision_key, version, status, chairman_approved')
     .single();
 
   if (error) { console.error('❌ Addendum failed:', error.message); process.exit(1); }
 
   console.log('\n✅ Addendum added:');
   console.log(`   Key:      ${data.vision_key}`);
+  console.log(`   Status:   ${data.status}`);
   console.log(`   Addendums: ${updatedAddendums.length}`);
   if (dimensions) console.log(`   Dimensions re-extracted: ${dimensions.length}`);
 }

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -129,6 +129,15 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
     process.exit(1);
   }
   const approved = Boolean(approvedFlag);
+  // SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: the shared parseArgs() treats any
+  // non-`--`-prefixed following token as a value, so `--chairman-ratified false`
+  // parses to the STRING 'false', which Boolean('false') coerces to true — silently
+  // ratifying when an operator plainly intended the opposite (adversarial review,
+  // PR #6138). --chairman-ratified is documented as a bare flag; reject any value.
+  if (typeof chairmanRatifiedFlag === 'string') {
+    console.error(`--chairman-ratified takes no value (got "${chairmanRatifiedFlag}") — pass it bare to ratify, or omit it entirely to leave the document unratified.`);
+    process.exit(1);
+  }
   const chairmanRatified = Boolean(chairmanRatifiedFlag);
 
   // Read content from stdin when --stdin is set. Cross-platform alternative to

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -19,6 +19,11 @@
  *           (--approved | --draft)        REQUIRED: deliberate approval choice.
  *                                         --approved => active + chairman_approved
  *                                         --draft    => draft, not approved
+ *           [--chairman-ratified]         REQUIRED in addition to --approved for GOVERNED
+ *                                         vision_keys (e.g. VISION-PORTFOLIO-STRATEGY-001,
+ *                                         see lib/eva/vision-upsert.js GOVERNED_VISION_KEYS)
+ *                                         — --approved alone is silently downgraded to draft
+ *                                         for those keys (SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A)
  *           [--venture-id <id>]           Explicit venture linkage
  *           [--brainstorm-id <id>]        Source brainstorm (auto-links a single-venture session)
  *           [--dimensions <json>]
@@ -100,7 +105,7 @@ async function cmdExtract({ source, content: contentArg }) {
   console.log(JSON.stringify(dimensions, null, 2));
 }
 
-async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId, sections: sectionsJson, content: contentArg, stdin: stdinFlag, approved: approvedFlag, draft: draftFlag }) {
+async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId, sections: sectionsJson, content: contentArg, stdin: stdinFlag, approved: approvedFlag, draft: draftFlag, chairmanRatified: chairmanRatifiedFlag }) {
   if (!visionKey) { console.error('--vision-key is required'); process.exit(1); }
   if (!level || !['L1', 'L2'].includes(level)) { console.error('--level must be L1 or L2'); process.exit(1); }
   if (!source && !sectionsJson && !contentArg && !stdinFlag) { console.error('--source, --sections, --content, or --stdin is required'); process.exit(1); }
@@ -119,6 +124,7 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
     process.exit(1);
   }
   const approved = Boolean(approvedFlag);
+  const chairmanRatified = Boolean(chairmanRatifiedFlag);
 
   // Read content from stdin when --stdin is set. Cross-platform alternative to
   // --content which hits OS CLI length limits (~8K on Windows) for large docs.
@@ -267,7 +273,7 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   const { upsertVision } = await import('../../lib/eva/vision-upsert.js');
   const { data, error } = await upsertVision({
     supabase, visionKey, level, content, sections, dimensions,
-    ventureId, brainstormId, createdBy: 'eva-vision-command', approved,
+    ventureId, brainstormId, createdBy: 'eva-vision-command', approved, chairmanRatified,
   });
 
   if (error) { console.error('❌ Upsert failed:', error.message); process.exit(1); }
@@ -278,7 +284,11 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   console.log(`   Level:   ${data.level}`);
   console.log(`   Version: ${data.version}`);
   console.log(`   Status:  ${data.status}`);
-  console.log(`   Approval: ${approved ? 'APPROVED (chairman_approved=true, build can start)' : 'DRAFT (not approved — review then re-run with --approved to start build)'}`);
+  // Report the ACTUAL persisted outcome (data.status/chairman_approved), not the requested
+  // --approved flag: for GOVERNED vision_keys, --approved alone is silently downgraded to
+  // draft unless --chairman-ratified is also passed (SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A) —
+  // echoing the request instead of the outcome would misreport a governed key as activated.
+  console.log(`   Approval: ${data.status === 'active' ? 'APPROVED (chairman_approved=true, build can start)' : 'DRAFT (not approved — review then re-run with --approved [+ --chairman-ratified if this is a governed key] to start build)'}`);
   if (dimensions) console.log(`   Dimensions: ${dimensions.length} extracted`);
   if (sections) console.log(`   Sections: ${renderSectionsSummary(sections)}`);
 }

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -52,7 +52,7 @@ import { readStdin } from '../../lib/utils/read-stdin.mjs';
 // applies via upsertVision() must also apply to cmdAddendum's direct DB write below — an
 // adversarial review (PR #6138) found the addendum path bypassed ratification entirely,
 // letting an already-active governed document's content change with no re-ratification.
-import { buildAddendumUpdatePayload } from '../../lib/eva/vision-upsert.js';
+import { buildAddendumUpdatePayload, rejectStringFlagValue } from '../../lib/eva/vision-upsert.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../');
@@ -115,6 +115,14 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   if (!level || !['L1', 'L2'].includes(level)) { console.error('--level must be L1 or L2'); process.exit(1); }
   if (!source && !sectionsJson && !contentArg && !stdinFlag) { console.error('--source, --sections, --content, or --stdin is required'); process.exit(1); }
 
+  // Reject a value on any of these three bare boolean flags (see
+  // rejectStringFlagValue's docblock) BEFORE the mutual-exclusivity checks below,
+  // so `--approved false` (etc.) errors instead of silently parsing as approved.
+  for (const [flagValue, flagName] of [[approvedFlag, '--approved'], [draftFlag, '--draft'], [chairmanRatifiedFlag, '--chairman-ratified']]) {
+    const err = rejectStringFlagValue(flagValue, flagName);
+    if (err) { console.error(err); process.exit(1); }
+  }
+
   // FR-2 (SD-LEO-FEAT-DELIBERATE-VISION-APPROVAL-001): approval must be a
   // DELIBERATE, explicit chairman choice — never a silent default. Require
   // exactly one of --approved / --draft so registering a vision is an explicit
@@ -129,15 +137,6 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
     process.exit(1);
   }
   const approved = Boolean(approvedFlag);
-  // SD-LEO-INFRA-PORTFOLIO-STRATEGY-FIRST-001-A: the shared parseArgs() treats any
-  // non-`--`-prefixed following token as a value, so `--chairman-ratified false`
-  // parses to the STRING 'false', which Boolean('false') coerces to true — silently
-  // ratifying when an operator plainly intended the opposite (adversarial review,
-  // PR #6138). --chairman-ratified is documented as a bare flag; reject any value.
-  if (typeof chairmanRatifiedFlag === 'string') {
-    console.error(`--chairman-ratified takes no value (got "${chairmanRatifiedFlag}") — pass it bare to ratify, or omit it entirely to leave the document unratified.`);
-    process.exit(1);
-  }
   const chairmanRatified = Boolean(chairmanRatifiedFlag);
 
   // Read content from stdin when --stdin is set. Cross-platform alternative to


### PR DESCRIPTION
## Summary
- Adds a distinct, chairman-governed `eva_vision_documents` artifact (`VISION-PORTFOLIO-STRATEGY-001`) that grounds every stage-zero ideation run, disambiguated from the existing active `VISION-EHG-L1-001` and the `VISION-PORTFOLIO-SYSTEM-001` draft_seed stub.
- `lib/eva/vision-upsert.js`: vision_key-scoped `GOVERNED_VISION_KEYS` guard requires an explicit `chairmanRatified:true` to activate a governed revision.
- `lib/eva/stage-zero/strategic-context-loader.js`: additive `loadPortfolioStrategy()` sub-loader reads by exact vision_key + `status=active`; does not modify the pre-existing (separately broken) `loadVisionDimensions()`.
- Seeded the draft `VISION-PORTFOLIO-STRATEGY-001` row (status=draft, chairman_approved=false) — ready for chairman ratification, never auto-activated by EXEC.

### Deep-tier adversarial review (3 rounds, all findings closed)
- **Round 1** found a CRITICAL bypass: the CLI's `addendum` subcommand wrote directly to `eva_vision_documents`, skipping the new ratification gate entirely. Fixed via `buildAddendumUpdatePayload()` (demotes a governed row back to draft on any addendum).
- **Round 2** re-review found a second CRITICAL: `scripts/eva/brainstorm-to-vision.mjs`'s "most recent active L1 vision" resolution could silently pick up the governed key once ratified, and a WARNING that `--chairman-ratified false` would be parsed as truthy (string coercion bug). Both fixed.
- **Round 3** (final verification) confirmed the bug class genuinely closed, found two adjacent WARNINGs (the same string-coercion footgun pre-existed for `--approved`/`--draft`; missing regression tests for round-2 fixes) — both closed with extracted, tested pure functions (`rejectStringFlagValue`, `selectFirstNonGoverned`).

## Test plan
- [x] 41/41 tests pass in the 2 new/changed test files (`vision-upsert.test.js`, `strategic-context-loader.test.js`)
- [x] Full `lib/eva/` suite: 43 files, 566 passed, 5 skipped, 0 failed — zero regressions across all 3 rounds
- [x] Live-verified against the real DB row: `--approved` alone left status=draft; only explicit `chairmanRatified:true` (unit-tested) activates
- [x] VALIDATION, RISK, TESTING, REGRESSION sub-agents all PASS (evidence in `sub_agent_execution_results`)
- [ ] Full monorepo `npx vitest run`: 118 pre-existing failures, all `|db|`-tagged live-DB integration tests, zero overlap with touched files (same fleet-load-contention class already documented this session) — shipped with `--skip-tests` bypass per established precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)