### PR TITLE
docs(SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001): sync launch-mode-policy + venture-email-provisioning refs

### DIFF
--- a/docs/reference/launch-mode-policy.md
+++ b/docs/reference/launch-mode-policy.md
@@ -1,10 +1,10 @@
 ---
 category: reference
 status: approved
-version: 1.0.0
-author: Claude (SD-LEO-INFRA-LAUNCH-MODE-POLICY-001)
-last_updated: 2026-07-04
-tags: [reference, eva, launch-mode, go-live, chairman-gated]
+version: 1.1.0
+author: Claude (SD-LEO-INFRA-LAUNCH-MODE-POLICY-001, SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001)
+last_updated: 2026-07-17
+tags: [reference, eva, launch-mode, go-live, chairman-gated, spend-guardrails, promote]
 ---
 
 # Launch-Mode Policy
@@ -45,18 +45,32 @@ per-venture telemetry table. This is intentional, not a bug: no real evidence so
 
 When the chairman's go-live trigger fires (`launchedAt` set):
 - `launch_mode='simulated'` (default): unchanged existing behavior, plus `payload.labeled_simulation = true`.
+  Guardrail/deploy wiring below never fires on this path.
 - `launch_mode='live'`: collects + verifies external observations. If verified, proceeds to
-  `launch_status:'launched'`. If not, returns `launch_status:'hold_external_observation_unverified'`
-  (`launched_at: null`) instead of launching on unverified evidence.
+  `launch_status:'launched'` and (SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001) additionally: builds a guardrail
+  context and calls `persistGuardrailDecisions` (`lib/venture-deploy/spend-guardrails.js`), then calls
+  `promote()` (`lib/venture-deploy/promote.js`, plan-mode only — no `deps.execute`) sourcing the deploy sha
+  from the latest `venture_preview_instances` row with `status='live'`. Both calls are wrapped in their own
+  try/catch and record outcomes on the result (`guardrails_persisted`/`guardrails_persist_error`,
+  `promote_status`/`promote_error`) — a failure here never blocks the launch itself. If verification fails,
+  returns `launch_status:'hold_external_observation_unverified'` (`launched_at: null`) instead of launching
+  on unverified evidence, and none of the above fires.
 
 Both paths attach `payload.composable_evidence = { launch_mode, external_observation, verdict }` in live
 mode — a forward-compatibility data contract (pinned by a contract test in
 `tests/unit/eva/stage-24-go-live-launch-mode.test.js`) so a future SD formalizing "G3 done-means-shipped"
-or a live per-venture spend-guardrail (neither exists in this codebase as of this writing) can consume the
-artifact without another schema change.
+can consume the artifact without another schema change.
 
 ## Known gaps (forward dependencies)
 
 1. No real telemetry data source for the `telemetry_rows_arrive` external-observation check.
-2. No "G3 done-means-shipped" module or live per-venture spend-guardrail exists yet; `composable_evidence`
-   is the landing surface for whichever SD formalizes either.
+2. No "G3 done-means-shipped" module exists yet; `composable_evidence` is the landing surface for whichever
+   SD formalizes it.
+3. The live per-venture spend-guardrail is now wired (see Consumer above) but only 3 of 8 guardrail inputs
+   have a real measurement source (agent-token ceiling, chairman human-gate, isolation scope); the other 5
+   (CI/migration determinism, D1 writes, operator-export, Neon plan, Cloud Run max-instances) have no
+   measurement source anywhere in the codebase and are intentionally left `undefined` so the guardrail
+   fails closed rather than fabricating a pass — see `strategic_directives_v2.metadata.guardrail_measurement_gap`
+   for SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001.
+4. `promote()` here writes `venture_deployments.status='planned'` (plan-mode), not `'routed'` — real
+   execute-mode against a live venture remains SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-A's chairman-gated scope.

--- a/docs/reference/venture-email-provisioning.md
+++ b/docs/reference/venture-email-provisioning.md
@@ -2,9 +2,9 @@
 
 - **Category**: Reference
 - **Status**: Approved
-- **Version**: 1.0.0
-- **Author**: SD-LEO-FEAT-PROVISION-VENTURE-EMAIL-001
-- **Last Updated**: 2026-07-12
+- **Version**: 1.1.0
+- **Author**: SD-LEO-FEAT-PROVISION-VENTURE-EMAIL-001, SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001
+- **Last Updated**: 2026-07-17
 - **Tags**: venture-email, resend, cloudflare, provisioning, secrets
 
 One-call per-venture email identity: `provisionVentureEmail(venture)` in
@@ -53,6 +53,16 @@ domains (Pro cap 10; SES re-evaluation at venture 11+). AUP witness:
 `guardSequenceSend({captureRecordId})` refuses sequence-sends without a
 capture-record reference (typed `AupWitnessError`).
 
+## Callers
+
+`EVACOOIntegration.onboardVenture()` (`lib/agents/eva-coo-integration.js`) calls
+`provisionVentureEmail` when `venture.domain` is present, fail-soft (a provisioning
+error is captured on the result, never thrown/blocking), surfacing `revealedKey` on
+the return object per the pointer convention above (SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001).
+`onboardVenture()` itself has no live production caller yet — this wiring activates
+once SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-B lands a real venture-onboarding entry
+point; until then this is unit-tested but not reachable end-to-end.
+
 ## Operational notes
 
 - DMARC ships `p=none`; graduation to `p=quarantine` is a scheduled follow-up after
@@ -60,4 +70,5 @@ capture-record reference (typed `AupWitnessError`).
 - A freshly created central-inbox routing destination is unverified until the inbox
   owner confirms Cloudflare's email — surfaced as a MANUAL plan step.
 - Tests: `tests/unit/venture-email/provision-venture-email.test.mjs` (vitest unit
-  lane; registered in `tests/test-estate-mjs-allowlist.json`).
+  lane; registered in `tests/test-estate-mjs-allowlist.json`),
+  `tests/unit/agents/eva-coo-integration-onboard-email.test.js` (caller-side wiring).


### PR DESCRIPTION
## Summary
- `docs/reference/launch-mode-policy.md` was stale: it claimed the live per-venture spend-guardrail and `promote()` wiring "neither exists in this codebase as of this writing." SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001 (PR #6137) wired both into `stage-24-go-live.js`'s live-verified branch — this updates the Consumer section and Known Gaps accordingly.
- `docs/reference/venture-email-provisioning.md` gains a Callers section documenting the new `onboardVenture()` wiring and its current unreachability pending sibling SD SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-B.

Doc-only change, no code touched. Post-completion `/document` step for SD-LEO-INFRA-VENTURE-SUBSTRATE-WIRING-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)