### PR TITLE
fix(SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001): populate handoffType in validation context, closing GATE_SUBAGENT_EVIDENCE fail-open

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.dryrun-handofftype.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.dryrun-handofftype.test.js
@@ -1,0 +1,61 @@
+/**
+ * SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001 (FR-3): dryRunHandoff's --evaluate path must
+ * populate validationContext.handoffType, or subagent-evidence-gate.js's
+ * REQUIRED_SUBAGENTS[ctx.handoffType] silently resolves to [] (fail-open) regardless
+ * of the actual handoff type.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+const validateGatesAllMock = vi.fn().mockResolvedValue({
+  passed: true, gateResults: {}, failedGates: [], passedGates: [], normalizedScore: 100
+});
+const buildGatesFromRulesMock = vi.fn(async (gates) => gates);
+
+vi.mock('./gate-policy-resolver.js', () => ({
+  applyGatePolicies: vi.fn().mockResolvedValue({
+    filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
+  })
+}));
+vi.mock('./gates/dfe-escalation-gate.js', () => ({
+  createDFEEscalationGate: () => ({ name: 'DFE_ESCALATION_GATE' })
+}));
+vi.mock('../../../lib/supabase-client.js', () => ({ createSupabaseServiceClient: () => ({}) }));
+
+const { HandoffOrchestrator } = await import('./HandoffOrchestrator.js');
+
+const INFRA_SD = { id: 'X', sd_key: 'X', sd_type: 'infrastructure', title: 't' };
+
+function makeOrchestrator() {
+  return new HandoffOrchestrator({
+    supabase: { mock: true },
+    sdRepo: { getById: vi.fn().mockResolvedValue(INFRA_SD) },
+    prdRepo: { getBySdId: vi.fn().mockResolvedValue(null) },
+    validationOrchestrator: {
+      loadValidationRules: vi.fn().mockResolvedValue([]),
+      buildGatesFromRules: buildGatesFromRulesMock,
+      validateGatesAll: validateGatesAllMock
+    },
+    executors: { 'PLAN-TO-LEAD': { getRequiredGates: vi.fn().mockResolvedValue([{ name: 'GATE_KEEP' }]) } }
+  });
+}
+
+describe('HandoffOrchestrator.dryRunHandoff --evaluate populates handoffType', () => {
+  it('passes handoffType through to buildGatesFromRules and validateGatesAll', async () => {
+    const orchestrator = makeOrchestrator();
+    await orchestrator.dryRunHandoff('PLAN-TO-LEAD', 'X', { evaluate: true });
+
+    const buildCtx = buildGatesFromRulesMock.mock.calls[0][2];
+    expect(buildCtx.handoffType).toBe('PLAN-TO-LEAD');
+
+    const validateCtx = validateGatesAllMock.mock.calls[0][1];
+    expect(validateCtx.handoffType).toBe('PLAN-TO-LEAD');
+  });
+
+  it('normalizes lowercase handoff type input to the canonical uppercase REQUIRED_SUBAGENTS key', async () => {
+    const orchestrator = makeOrchestrator();
+    await orchestrator.dryRunHandoff('plan-to-lead', 'X', { evaluate: true });
+
+    expect(validateGatesAllMock.mock.calls[0][1].handoffType).toBe('PLAN-TO-LEAD');
+  });
+});

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -472,7 +472,11 @@ export class HandoffOrchestrator {
         prd: precheckPrd,
         options,
         precheckMode: true,
-        supabase: this.supabase
+        supabase: this.supabase,
+        // SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001: without this, subagent-evidence-gate.js's
+        // REQUIRED_SUBAGENTS[ctx.handoffType] always resolved to [] (undefined key), so
+        // GATE_SUBAGENT_EVIDENCE has been fail-open fleet-wide since introduction.
+        handoffType: normalizedType
       };
       const gatesWithRules = await this.validationOrchestrator.buildGatesFromRules(
         filteredGates,
@@ -685,7 +689,11 @@ export class HandoffOrchestrator {
           prd,
           prdId: prd?.id,
           options: {},
-          supabase: this.supabase
+          supabase: this.supabase,
+          // SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001: without this, subagent-evidence-gate.js's
+          // REQUIRED_SUBAGENTS[ctx.handoffType] always resolved to [] (undefined key), so
+          // GATE_SUBAGENT_EVIDENCE has been fail-open fleet-wide since introduction.
+          handoffType: normalizedType
         };
 
         // Build final gate set from rules + policy-filtered gates

--- a/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.precheck-policy.test.js
@@ -121,4 +121,15 @@ describe('HandoffOrchestrator.precheckHandoff applies gate policies', () => {
     const ctx = validateGatesAllMock.mock.calls[0][1];
     expect(ctx.prd).toEqual(prdRow);
   });
+
+  it('SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001: populates handoffType in the precheck context so GATE_SUBAGENT_EVIDENCE resolves REQUIRED_SUBAGENTS correctly (was undefined -> always [])', async () => {
+    applyGatePoliciesMock.mockResolvedValue({
+      filteredGates: [{ name: 'GATE_KEEP' }], resolutions: [], fallbackUsed: false
+    });
+    const orchestrator = makeOrchestrator(INFRA_SD, [{ name: 'GATE_KEEP' }]);
+    await orchestrator.precheckHandoff('PLAN-TO-LEAD', 'X');
+
+    const ctx = validateGatesAllMock.mock.calls[0][1];
+    expect(ctx.handoffType).toBe('PLAN-TO-LEAD');
+  });
 });

--- a/scripts/modules/handoff/executors/BaseExecutor.handofftype.test.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.handofftype.test.js
@@ -1,0 +1,52 @@
+/**
+ * SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001 (FR-1): BaseExecutor.execute()'s validationContext
+ * (passed to validationOrchestrator.buildGatesFromRules -> validateGates ->
+ * subagent-evidence-gate.js) must include handoffType: this.handoffType, or
+ * REQUIRED_SUBAGENTS[ctx.handoffType] silently resolves to [] (fail-open) regardless
+ * of the actual handoff type.
+ *
+ * execute() is a ~700-line template method with 10+ dynamic-import dependencies
+ * (claim validity, claim-eligibility fencing, migration checks, gate-policy
+ * resolution, telemetry) that must all be traversed before validationContext is
+ * built. A full mocked execute() integration test would require ~10 vi.mock()
+ * targets plus ~6 vi.spyOn() instance-method stubs to reach this one object
+ * literal -- disproportionate to a one-line fix and independently verified by two
+ * sub-agents (validation-agent 5498d47a, risk-agent eec31685) via direct code
+ * inspection. A structural assertion on the source directly guards the exact
+ * regression class (the field being dropped again) without that fragility, and
+ * subagent-evidence-gate.test.js already exhaustively covers the downstream gate
+ * logic once ctx.handoffType is populated.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const source = readFileSync(path.join(__dirname, 'BaseExecutor.js'), 'utf8');
+
+describe('BaseExecutor.js execute() validationContext includes handoffType', () => {
+  it('the object literal passed into buildGatesFromRules sets handoffType: this.handoffType', () => {
+    const literalStart = source.indexOf('const validationContext = {');
+    expect(literalStart).toBeGreaterThan(-1);
+    const literalEnd = source.indexOf('\n      };', literalStart);
+    expect(literalEnd).toBeGreaterThan(literalStart);
+    const literal = source.slice(literalStart, literalEnd);
+
+    expect(literal).toMatch(/handoffType:\s*this\.handoffType/);
+    // Sanity check we grabbed the right literal (same one gitContext/sdId live in),
+    // not some other unrelated object.
+    expect(literal).toContain('gitContext');
+    expect(literal).toContain('sdId,');
+  });
+
+  it('the literal is actually threaded into buildGatesFromRules (not a dead field)', () => {
+    const literalStart = source.indexOf('const validationContext = {');
+    const buildCallIdx = source.indexOf('buildGatesFromRules(', literalStart);
+    expect(buildCallIdx).toBeGreaterThan(literalStart);
+    const callSlice = source.slice(buildCallIdx, buildCallIdx + 200);
+    expect(callSlice).toContain('validationContext');
+  });
+});

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -354,7 +354,11 @@ export class BaseExecutor {
         prdId: prd?.id,  // Also provide prdId for convenience
         options: options ? structuredClone(options) : {},  // Deep copy options
         supabase: this.supabase,  // Supabase client cannot be cloned (has methods)
-        gitContext  // SD-LEO-FIX-HANDOFF-PIPELINE-GIT-001: Cached git state (branch, diffFiles, gitRoot)
+        gitContext,  // SD-LEO-FIX-HANDOFF-PIPELINE-GIT-001: Cached git state (branch, diffFiles, gitRoot)
+        // SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001: without this, subagent-evidence-gate.js's
+        // REQUIRED_SUBAGENTS[ctx.handoffType] always resolved to [] (undefined key), so
+        // GATE_SUBAGENT_EVIDENCE has been fail-open fleet-wide since introduction.
+        handoffType: this.handoffType
       };
 
       // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 FR-5/TR-4: surface prior consecutive-wait


### PR DESCRIPTION
## Summary
- `subagent-evidence-gate.js` computes `REQUIRED_SUBAGENTS[ctx.handoffType] || []`. None of the 3 validation-context builders ever set `ctx.handoffType`, so this always resolved to an empty array and the gate has trivially passed **fleet-wide since introduction**, regardless of whether required sub-agent evidence actually existed.
- Fix: add `handoffType: this.handoffType` / `handoffType: normalizedType` at all 3 sites, mirroring the value expression already used elsewhere in each file for the same purpose:
  - `scripts/modules/handoff/executors/BaseExecutor.js` (execute path)
  - `scripts/modules/handoff/HandoffOrchestrator.js` (precheck path)
  - `scripts/modules/handoff/HandoffOrchestrator.js` (dry-run `--evaluate` path)
- `subagent-evidence-gate.js` and `required-subagents.js` are **unchanged** — their logic was already correct once fed a real `handoffType`; the bug was purely in the upstream callers.
- Independently confirmed live at HEAD by two LEAD-phase sub-agents (validation-agent, risk-agent) before this fix, then independently re-confirmed by TESTING, SECURITY, VALIDATION, REGRESSION, and RETRO sub-agents during EXEC/PLAN_VERIFICATION.

## Fleet rollout note (flagged, not this PR's scope to execute)
Restoring real enforcement means any in-flight handoff from another parallel worker that hasn't actually invoked its required sub-agents will newly block with `SUBAGENT_EVIDENCE_MISSING` the instant this reaches `main`. This is the **correct, intended behavior being restored**, not a new bug. Risk-agent measured ~53/55 currently-active SDs as exposed. Mitigation (pre-existing `LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1` kill-switch, staged fleet broadcast + removal) is a coordinator-owned rollout decision, already signaled to the active coordinator — out of scope for this PR's code.

## Test plan
- [x] `npx vitest run scripts/modules/handoff tests/unit/subagent-evidence-gate.test.js` — 45 files / 463 tests pass, 0 regressions
- [x] New regression tests added: `HandoffOrchestrator.dryrun-handofftype.test.js`, `BaseExecutor.handofftype.test.js`, plus an addition to `HandoffOrchestrator.precheck-policy.test.js`
- [x] This SD's own EXEC-TO-PLAN handoff is a live end-to-end proof: `GATE_SUBAGENT_EVIDENCE` scored 100% with real TESTING+SECURITY evidence correctly detected (pre-fix it would have silently passed with 0 evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)