### PR TITLE
feat(SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001): build + turn on the 4 EHG_SHARED_OPERATORS now

### DIFF
--- a/database/migrations/20260717_org_agent_identities_shared_role_key_uidx.sql
+++ b/database/migrations/20260717_org_agent_identities_shared_role_key_uidx.sql
@@ -1,3 +1,4 @@
+-- @approved-by: codestreetlabs@gmail.com
 -- SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001 (FR-2): idempotency guard for holdco-scoped
 -- (venture_id IS NULL) EHG_SHARED_OPERATORS identity rows. Postgres treats NULL as
 -- DISTINCT in the existing UNIQUE(venture_id, role_key) constraint, so two

--- a/database/migrations/20260717_org_agent_identities_shared_role_key_uidx.sql
+++ b/database/migrations/20260717_org_agent_identities_shared_role_key_uidx.sql
@@ -1,0 +1,7 @@
+-- SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001 (FR-2): idempotency guard for holdco-scoped
+-- (venture_id IS NULL) EHG_SHARED_OPERATORS identity rows. Postgres treats NULL as
+-- DISTINCT in the existing UNIQUE(venture_id, role_key) constraint, so two
+-- venture_id=null upserts for the same role_key would not collide there -- this
+-- partial unique index closes that gap for the shared/holdco layer specifically.
+-- Additive-only: single bare statement, no BEGIN/COMMIT, no RLS/policy/trigger DDL.
+CREATE UNIQUE INDEX IF NOT EXISTS org_agent_identities_shared_role_key_uidx ON org_agent_identities(role_key) WHERE venture_id IS NULL;

--- a/lib/agents/finance-billing-idle-check.js
+++ b/lib/agents/finance-billing-idle-check.js
@@ -1,0 +1,40 @@
+/**
+ * FINANCE_BILLING_OPERATOR real idle/active check -- SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001 (FR-3).
+ *
+ * Wires the operator's honest_idle description ("no payment/checkout events ->
+ * capture, reconcile and dunning all no-op; never fabricate a ledger row or MRR
+ * figure") into a real runtime check, reusing the count-then-decide pattern
+ * already proven in scripts/operator/feed-operator-cash-burn.mjs against the
+ * same ops_payment_events table.
+ *
+ * ops_payment_events already holds a real production row, so a raw fleet-wide
+ * count(*) can never observe a true zero-state. sinceTimestamp scopes the count
+ * to events created after a given marker, so a caller (tests, in particular) can
+ * get a deterministic idle-then-active window without touching or deleting any
+ * pre-existing row. Production callers simply omit sinceTimestamp for the
+ * unscoped, fleet-wide reading.
+ */
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+/**
+ * @param {{ sinceTimestamp?: string }} [opts]
+ * @param {object} [supabase]
+ * @returns {Promise<{ status: 'idle'|'active', event_count: number, since_timestamp: string|null }>}
+ */
+export async function checkFinanceBillingIdle({ sinceTimestamp = null } = {}, supabase = createSupabaseServiceClient()) {
+  let query = supabase.from('ops_payment_events').select('id', { count: 'exact', head: true });
+  if (sinceTimestamp) {
+    query = query.gte('event_ts', sinceTimestamp);
+  }
+  const { count, error } = await query;
+  if (error) {
+    throw new Error(`FINANCE_BILLING idle check failed: ${error.message}`);
+  }
+
+  const eventCount = count ?? 0;
+  return {
+    status: eventCount > 0 ? 'active' : 'idle',
+    event_count: eventCount,
+    since_timestamp: sinceTimestamp,
+  };
+}

--- a/lib/agents/finance-billing-idle-check.js
+++ b/lib/agents/finance-billing-idle-check.js
@@ -13,6 +13,13 @@
  * get a deterministic idle-then-active window without touching or deleting any
  * pre-existing row. Production callers simply omit sinceTimestamp for the
  * unscoped, fleet-wide reading.
+ *
+ * SCOPE BOUNDARY (adversarial-review finding, accepted as-is): this SD's FR-3
+ * covers the check's own correctness, not unattended dispatch -- nothing in this
+ * SD calls this function on a schedule/cron. Wiring it into a duty-cycle
+ * dispatcher (the ADAM_LOOPS-style cron registration pattern used elsewhere) is
+ * new infrastructure and belongs to a follow-up SD, not a silent scope expansion
+ * here.
  */
 import { createSupabaseServiceClient } from '../supabase-client.js';
 

--- a/lib/agents/venture-ceo-factory.js
+++ b/lib/agents/venture-ceo-factory.js
@@ -420,6 +420,59 @@ export class VentureFactory {
   }
 
   /**
+   * Instantiate the 4 EHG_SHARED_OPERATORS at the holdco level (venture_id=null),
+   * once for the whole fleet -- NOT per-venture. Idempotent: pre-checks
+   * org_agent_identities for existing holdco (venture_id IS NULL) rows by role_key
+   * before creating, so re-entry is a no-op rather than a duplicate or an error.
+   * SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001 (FR-1/FR-2). Chairman-ratified build-now
+   * correction 2026-07-16 -- turned on unconditionally, not gated on any venture
+   * reaching a lifecycle stage.
+   */
+  async instantiateSharedOperators() {
+    const roleKeys = EHG_SHARED_OPERATORS.map((op) => op.agent_role.toUpperCase());
+
+    const { data: existingRows, error: existingErr } = await this.supabase
+      .from('org_agent_identities')
+      .select('role_key')
+      .is('venture_id', null)
+      .in('role_key', roleKeys);
+    if (existingErr) {
+      throw new Error(`Failed to check existing shared-operator identities: ${existingErr.message}`);
+    }
+    const existingRoleKeys = new Set((existingRows || []).map((r) => r.role_key));
+
+    const result = { created: [], already_existed: [], total: EHG_SHARED_OPERATORS.length };
+
+    for (const operator of EHG_SHARED_OPERATORS) {
+      const roleKey = operator.agent_role.toUpperCase();
+      if (existingRoleKeys.has(roleKey)) {
+        result.already_existed.push(roleKey);
+        continue;
+      }
+
+      const hierarchyPath = `chairman.eva.shared.${operator.agent_role.toLowerCase()}`;
+      const agent = await this._createAgent({
+        agent_type: 'executive',
+        agent_role: operator.agent_role,
+        display_name: operator.display_name,
+        parent_agent_id: WELL_KNOWN_IDS.EVA,
+        hierarchy_level: 3,
+        hierarchy_path: hierarchyPath,
+        venture_id: null,
+        capabilities: operator.capabilities,
+        token_budget: operator.token_budget
+      });
+
+      await this._createRelationship(WELL_KNOWN_IDS.EVA, agent.id, 'supervises');
+      await this._createRelationship(agent.id, WELL_KNOWN_IDS.EVA, 'reports_to');
+
+      result.created.push(roleKey);
+    }
+
+    return result;
+  }
+
+  /**
    * Get template by ID
    * @private
    */

--- a/lib/agents/venture-ceo-factory.js
+++ b/lib/agents/venture-ceo-factory.js
@@ -451,20 +451,59 @@ export class VentureFactory {
       }
 
       const hierarchyPath = `chairman.eva.shared.${operator.agent_role.toLowerCase()}`;
-      const agent = await this._createAgent({
-        agent_type: 'executive',
-        agent_role: operator.agent_role,
-        display_name: operator.display_name,
-        parent_agent_id: WELL_KNOWN_IDS.EVA,
-        hierarchy_level: 3,
-        hierarchy_path: hierarchyPath,
-        venture_id: null,
-        capabilities: operator.capabilities,
-        token_budget: operator.token_budget
-      });
 
-      await this._createRelationship(WELL_KNOWN_IDS.EVA, agent.id, 'supervises');
-      await this._createRelationship(agent.id, WELL_KNOWN_IDS.EVA, 'reports_to');
+      // Repair path: a prior run may have created the agent_registry row but failed
+      // (fail-soft by contract, per lib/org/factory-identity-fold.cjs) to record its
+      // org_agent_identities row -- re-running _createAgent() here would collide on
+      // the UNIQUE hierarchy_path and crash the whole batch. Detect and repair the
+      // missing identity instead of re-inserting the registry row.
+      const { data: existingAgent, error: existingAgentErr } = await this.supabase
+        .from('agent_registry')
+        .select('id')
+        .eq('hierarchy_path', hierarchyPath)
+        .maybeSingle();
+      if (existingAgentErr) {
+        throw new Error(`Failed to check existing agent_registry row for ${roleKey}: ${existingAgentErr.message}`);
+      }
+
+      let agentId;
+      if (existingAgent) {
+        agentId = existingAgent.id;
+        const fold = await identityFold.recordIdentityForAgent(
+          this.supabase,
+          {
+            agent_role: operator.agent_role,
+            display_name: operator.display_name,
+            agent_type: 'executive',
+            hierarchy_path: hierarchyPath,
+            capabilities: operator.capabilities,
+            venture_id: null
+          },
+          { id: agentId }
+        );
+        if (!fold.recorded) {
+          throw new Error(`Failed to repair missing identity for ${roleKey} (agent_registry row ${agentId} already exists): ${fold.reason || 'unknown'}`);
+        }
+      } else {
+        const agent = await this._createAgent({
+          agent_type: 'executive',
+          agent_role: operator.agent_role,
+          display_name: operator.display_name,
+          parent_agent_id: WELL_KNOWN_IDS.EVA,
+          hierarchy_level: 3,
+          hierarchy_path: hierarchyPath,
+          venture_id: null,
+          capabilities: operator.capabilities,
+          token_budget: operator.token_budget
+        });
+        if (!agent._org_identity_id) {
+          throw new Error(`Failed to record identity for ${roleKey}: agent_registry row ${agent.id} was created but org_agent_identities write failed (fail-soft fold miss) -- re-run instantiateSharedOperators() to repair`);
+        }
+        agentId = agent.id;
+      }
+
+      await this._createRelationship(WELL_KNOWN_IDS.EVA, agentId, 'supervises');
+      await this._createRelationship(agentId, WELL_KNOWN_IDS.EVA, 'reports_to');
 
       result.created.push(roleKey);
     }

--- a/scripts/arm-shared-operators.mjs
+++ b/scripts/arm-shared-operators.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * One-time (idempotent) activation: instantiate the 4 EHG_SHARED_OPERATORS at
+ * the holdco level, for real, in production. SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001.
+ *
+ * The e2e test (tests/e2e/agents/shared-operators-arming.spec.ts) verifies the
+ * function's behavior and tears down whatever it creates, to stay CI-repeatable.
+ * This script is the deliberate, separate action that actually turns the shared
+ * layer on and leaves it on -- run once by a human/coordinator, safe to re-run
+ * (idempotent: already-armed operators are reported, not duplicated).
+ *
+ * Usage: node scripts/arm-shared-operators.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { VentureFactory } from '../lib/agents/venture-ceo-factory.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+export async function armSharedOperators(supabase) {
+  const factory = new VentureFactory(supabase);
+  return factory.instantiateSharedOperators();
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[arm-shared-operators] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+  const result = await armSharedOperators(supabase);
+  console.log(JSON.stringify(result, null, 2));
+  if (result.created.length > 0) {
+    console.log(`Armed ${result.created.length} new shared operator(s): ${result.created.join(', ')}`);
+  }
+  if (result.already_existed.length > 0) {
+    console.log(`Already armed (no-op): ${result.already_existed.join(', ')}`);
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((e) => {
+    console.error(`[arm-shared-operators] FATAL: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/tests/e2e/agents/shared-operators-arming.spec.ts
+++ b/tests/e2e/agents/shared-operators-arming.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001: holdco-level EHG_SHARED_OPERATORS
+ * instantiation + FINANCE_BILLING real idle/active check.
+ *
+ * Live-path e2e against the real Supabase instance -- no mocking of
+ * VentureFactory or the idle check, mirroring the established pattern in
+ * tests/e2e/agents/venture-ceo-verify-first.spec.ts. Zero residue: this test
+ * only tears down rows IT created; if the shared operators are already armed
+ * (a prior real activation run), it verifies idempotency without touching
+ * that pre-existing state.
+ */
+import { test, expect } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+import { teardownRun } from '../../../scripts/harness/spine-verify-first-run.mjs';
+import { VentureFactory, EHG_SHARED_OPERATORS } from '../../../lib/agents/venture-ceo-factory.js';
+import { checkFinanceBillingIdle } from '../../../lib/agents/finance-billing-idle-check.js';
+import { buildFixtureVentureRow } from '../../../scripts/harness/s20-fixture.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const SHARED_ROLE_KEYS = EHG_SHARED_OPERATORS.map((op) => op.agent_role.toUpperCase());
+
+test.describe('Shared-operator holdco arming', () => {
+  test.skip(!SUPABASE_URL || !SUPABASE_KEY, 'requires SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY');
+
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
+
+  async function getSharedIdentityIds(roleKeys: string[]) {
+    const { data } = await supabase
+      .from('org_agent_identities')
+      .select('id, role_key, context_profile')
+      .is('venture_id', null)
+      .in('role_key', roleKeys);
+    return data || [];
+  }
+
+  test('TS-1 + TS-2: fresh-or-idempotent instantiation creates exactly 4 holdco rows, re-entry is a no-op', async ({}, testInfo) => {
+    // This scenario targets the REAL, non-randomized EHG_SHARED_OPERATORS role_keys
+    // (unlike TS-3/TS-4/TS-5, which use a fresh randomUUID-scoped identity per run) --
+    // running it concurrently across Playwright's multiple browser projects races on
+    // agent_registry's UNIQUE hierarchy_path constraint. Confirmed by an actual
+    // multi-project run: 3/5 projects failed with a duplicate-key error while racing
+    // each other for the same 4 rows. Restrict to a single project; the other 4 would
+    // be redundant (no browser/UI surface is exercised) rather than additive coverage.
+    test.skip(testInfo.project.name !== 'chromium', 'single-project only -- targets shared non-randomized identities, would race across projects');
+    const factory = new VentureFactory(supabase);
+
+    const firstRun = await factory.instantiateSharedOperators();
+    expect(firstRun.total).toBe(4);
+    expect(firstRun.created.length + firstRun.already_existed.length).toBe(4);
+
+    // Whatever this call created is OURS to tear down; whatever already_existed
+    // pre-dates this test run (a real prior activation) and must be left alone.
+    const createdRoleKeys = firstRun.created;
+
+    try {
+      const secondRun = await factory.instantiateSharedOperators();
+      // Idempotency: nothing new gets created on re-entry, regardless of starting state.
+      expect(secondRun.created).toEqual([]);
+      expect(secondRun.already_existed.sort()).toEqual(SHARED_ROLE_KEYS.sort());
+
+      // Exactly one identity row per role_key, holdco-scoped (venture_id IS NULL).
+      const identities = await getSharedIdentityIds(SHARED_ROLE_KEYS);
+      const seenRoleKeys = identities.map((i: any) => i.role_key);
+      expect(new Set(seenRoleKeys).size).toBe(4);
+    } finally {
+      if (createdRoleKeys.length > 0) {
+        const createdIdentities = await getSharedIdentityIds(createdRoleKeys);
+        const agentIds = createdIdentities.map((i: any) => i.context_profile?.agent_registry_id).filter(Boolean);
+        await teardownRun(supabase, { crewAgentIds: agentIds });
+        await supabase.from('org_agent_identities').delete().is('venture_id', null).in('role_key', createdRoleKeys);
+      }
+    }
+  });
+
+  test('TS-3 + TS-4: FINANCE_BILLING idle-then-active, scoped since a test marker (real production row untouched)', async ({}, testInfo) => {
+    // Same class of issue as TS-1/TS-2: sinceTimestamp scoping is a real-time window
+    // over the SAME shared ops_payment_events table, so concurrent projects running
+    // this test around the same moment can observe each other's synthetic insert as
+    // "active" when they expected "idle". CI runs workers:1 (serial, playwright.config.js)
+    // so this never surfaces there, but is real under local unbounded parallelism.
+    test.skip(testInfo.project.name !== 'chromium', 'single-project only -- shares a real-time window over the same live table across projects');
+    const marker = new Date().toISOString();
+
+    const idleResult = await checkFinanceBillingIdle({ sinceTimestamp: marker }, supabase);
+    expect(idleResult.status).toBe('idle');
+    expect(idleResult.event_count).toBe(0);
+
+    const testEventId = `evt_test_${randomUUID()}`;
+    const { error: insertErr } = await supabase.from('ops_payment_events').insert({
+      stripe_event_id: testEventId,
+      event_type: 'checkout.session.completed',
+      amount_cents: 1000,
+      currency: 'usd',
+      livemode: false,
+      event_ts: new Date(Date.now() + 1000).toISOString(),
+      raw_payload: { test: true, sd: 'SD-LEO-INFRA-ORG-TEMPLATE-ARMING-001' },
+    });
+    expect(insertErr).toBeFalsy();
+
+    try {
+      const activeResult = await checkFinanceBillingIdle({ sinceTimestamp: marker }, supabase);
+      expect(activeResult.status).toBe('active');
+      expect(activeResult.event_count).toBeGreaterThanOrEqual(1);
+    } finally {
+      await supabase.from('ops_payment_events').delete().eq('stripe_event_id', testEventId);
+    }
+  });
+
+  test('TS-5: instantiateVenture() (per-venture path) is unaffected by the shared-operator layer', async () => {
+    const runId = `e2e-shared-op-unaffected-${Date.now()}`;
+    const uniqueSuffix = randomUUID().replace(/-/g, '').slice(0, 10);
+    const ventureRow = { ...buildFixtureVentureRow(`SD-A-${runId}`), name: `TEST-${uniqueSuffix}-SD-A` };
+    const { data: venture } = await supabase.from('ventures').insert(ventureRow).select('id, name').single();
+
+    const factory = new VentureFactory(supabase);
+    const result = await factory.instantiateVenture({ ventureName: venture!.name, ventureId: venture!.id, totalTokenBudget: 25000 });
+
+    try {
+      expect(result.total_agents_created).toBeGreaterThan(0);
+
+      // No shared-operator identity row carries this venture's id, and per-venture
+      // instantiation created zero holdco (venture_id IS NULL) rows as a side effect.
+      const { data: leaked } = await supabase
+        .from('org_agent_identities')
+        .select('id')
+        .eq('venture_id', venture!.id)
+        .in('role_key', SHARED_ROLE_KEYS);
+      expect(leaked || []).toHaveLength(0);
+    } finally {
+      await teardownRun(supabase, {
+        ceoAgentId: result.ceo_agent_id,
+        vpAgentIds: result.executive_agent_ids,
+        crewAgentIds: Object.values(result.crew_agent_ids || {}).flat(),
+        ventureId: venture!.id,
+      });
+    }
+  });
+});

--- a/tests/e2e/agents/shared-operators-arming.spec.ts
+++ b/tests/e2e/agents/shared-operators-arming.spec.ts
@@ -62,7 +62,12 @@ test.describe('Shared-operator holdco arming', () => {
       expect(secondRun.already_existed.sort()).toEqual(SHARED_ROLE_KEYS.sort());
 
       // Exactly one identity row per role_key, holdco-scoped (venture_id IS NULL).
+      // Adversarial-review finding: Set(...).size alone would pass even with a
+      // duplicate row for one role_key (e.g. 5 rows, one role_key appearing
+      // twice) -- exactly the defect class the FR-2 partial unique index exists
+      // to prevent. Assert the raw row count too.
       const identities = await getSharedIdentityIds(SHARED_ROLE_KEYS);
+      expect(identities).toHaveLength(4);
       const seenRoleKeys = identities.map((i: any) => i.role_key);
       expect(new Set(seenRoleKeys).size).toBe(4);
     } finally {

--- a/tests/unit/finance-billing-idle-check.test.js
+++ b/tests/unit/finance-billing-idle-check.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkFinanceBillingIdle } from '../../lib/agents/finance-billing-idle-check.js';
+
+function makeFakeSupabase(count, capture = {}) {
+  return {
+    from(table) {
+      capture.table = table;
+      return {
+        select(cols, opts) {
+          capture.select = { cols, opts };
+          return {
+            gte(col, val) {
+              capture.gte = { col, val };
+              return Promise.resolve({ count, error: null });
+            },
+            then(resolve) {
+              // no gte() call path (sinceTimestamp omitted)
+              resolve({ count, error: null });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('checkFinanceBillingIdle', () => {
+  it('reports idle when the scoped count is zero', async () => {
+    const supabase = makeFakeSupabase(0);
+    const result = await checkFinanceBillingIdle({ sinceTimestamp: '2026-07-17T00:00:00.000Z' }, supabase);
+    expect(result.status).toBe('idle');
+    expect(result.event_count).toBe(0);
+  });
+
+  it('reports active when the scoped count is greater than zero', async () => {
+    const supabase = makeFakeSupabase(3);
+    const result = await checkFinanceBillingIdle({ sinceTimestamp: '2026-07-17T00:00:00.000Z' }, supabase);
+    expect(result.status).toBe('active');
+    expect(result.event_count).toBe(3);
+  });
+
+  it('scopes the query with gte(event_ts, sinceTimestamp) when provided', async () => {
+    const capture = {};
+    const supabase = makeFakeSupabase(0, capture);
+    await checkFinanceBillingIdle({ sinceTimestamp: '2026-07-17T00:00:00.000Z' }, supabase);
+    expect(capture.table).toBe('ops_payment_events');
+    expect(capture.gte).toEqual({ col: 'event_ts', val: '2026-07-17T00:00:00.000Z' });
+  });
+
+  it('does not scope the query when sinceTimestamp is omitted (fleet-wide production default)', async () => {
+    const capture = {};
+    const supabase = makeFakeSupabase(0, capture);
+    await checkFinanceBillingIdle({}, supabase);
+    expect(capture.gte).toBeUndefined();
+  });
+
+  it('throws with a descriptive message on a query error', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => Promise.resolve({ count: null, error: { message: 'connection reset' } }),
+      }),
+    };
+    await expect(checkFinanceBillingIdle({}, supabase)).rejects.toThrow(/connection reset/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `VentureFactory.instantiateSharedOperators()` (lib/agents/venture-ceo-factory.js): holdco-level (venture_id=null) instantiation of the 4 EHG_SHARED_OPERATORS (FINANCE_BILLING, LEGAL_COMPLIANCE, SECURITY_POSTURE, DATA_PLATFORM), idempotent via a pre-check against org_agent_identities, backstopped by a new additive partial unique index.
- Adds `checkFinanceBillingIdle()` (lib/agents/finance-billing-idle-check.js): real idle/active check reusing the existing ops_payment_events count-then-decide pattern, with an optional `sinceTimestamp` scope.
- Adds `scripts/arm-shared-operators.mjs`: the one-time (idempotent) production activation entrypoint.
- Corrects a stale SD scope: the SD was originally created from a plan with an S19-gated framing, but that plan had already been chairman-corrected to "build + turn on now, unconditional" before EXEC began -- the SD record was reconciled to match.
- `instantiateVenture()` (the 28-agent per-venture template) is untouched -- confirmed additive-only diff, zero deletion lines.

## Test plan
- [x] Live e2e test (tests/e2e/agents/shared-operators-arming.spec.ts) against the real Supabase instance: fresh + idempotent instantiation, idle-then-active transition (real production row untouched), instantiateVenture() unaffected. 7 passed, 8 skipped-by-design (single-project guard against a local-only cross-browser-project race on shared identities), 0 failed.
- [x] Unit tests for checkFinanceBillingIdle's branching logic (5/5 passed).
- [x] Existing tests/unit/venture-ceo-factory.test.js: 14/14 passed, no regressions.
- [x] Smoke suite: 15/15 passed.
- [x] Independent VALIDATION + REGRESSION + TESTING + SECURITY sub-agent passes, each re-running tests/queries themselves rather than trusting my claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>