### PR TITLE
feat(SD-LEO-INFRA-EHG-VENTURE-FORESIGHT-001-A): PR-1 — foresight content machinery + 5 council definitions

### DIFF
--- a/lib/foresight/content/councils.json
+++ b/lib/foresight/content/councils.json
@@ -1,0 +1,110 @@
+[
+  {
+    "council_id": "frontier_capability",
+    "council_name": "Frontier Capability Council",
+    "purpose": "Determine what has recently become technically possible, reliable, or economical enough to enable new ventures.",
+    "adjudicator_perspective_id": "alex-wissner-gross",
+    "specialist_perspective_ids": ["jack-clark", "nathan-benaich", "rodney-brooks"],
+    "required_output_type": "Technical Opportunity Brief",
+    "default_prompt_version": "v1.0",
+    "status": "active",
+    "primary_questions": [
+      "What new capability has emerged?",
+      "What evidence shows that it works?",
+      "Is it available in production or only in a demonstration?",
+      "What does it currently cost?",
+      "What reliability limitations remain?",
+      "What is likely to improve within 12, 24, and 60 months?",
+      "Which capabilities are becoming commodities?",
+      "What new venture categories could this capability enable?",
+      "What is technically overhyped?"
+    ]
+  },
+  {
+    "council_id": "human_transition",
+    "council_name": "Human Transition Council",
+    "purpose": "Identify new customer needs, anxieties, behaviors, skills gaps, trust gaps, and institutional problems created by technological change.",
+    "adjudicator_perspective_id": "sinead-bovell",
+    "specialist_perspective_ids": ["marina-gorbis", "heather-mcgowan", "rumman-chowdhury"],
+    "required_output_type": "Emerging Human Need Brief",
+    "default_prompt_version": "v1.0",
+    "status": "active",
+    "primary_questions": [
+      "Who is affected by the change?",
+      "Which tasks, roles, or behaviors are changing?",
+      "What new pain is being created?",
+      "What old pain is becoming easier to solve?",
+      "Who experiences the problem?",
+      "Who pays to solve it?",
+      "What trust or adoption barriers exist?",
+      "What new educational, supervisory, or governance needs emerge?",
+      "Could the proposed solution reduce human agency or create harmful dependency?"
+    ]
+  },
+  {
+    "council_id": "strategic_foresight",
+    "council_name": "Strategic Foresight Council",
+    "purpose": "Determine whether a venture remains attractive across multiple plausible futures.",
+    "adjudicator_perspective_id": "amy-webb",
+    "specialist_perspective_ids": ["peter-schwartz", "sohail-inayatullah", "jamais-cascio"],
+    "required_output_type": "Venture Resilience Brief",
+    "default_prompt_version": "v1.0",
+    "status": "active",
+    "primary_questions": [
+      "What assumptions must be true?",
+      "What critical uncertainties could change the outcome?",
+      "What future scenarios should EHG consider?",
+      "Does the venture survive when technology improves faster than expected?",
+      "Does it survive when adoption is slower?",
+      "Does it survive regulatory restrictions?",
+      "Does it survive provider consolidation or commoditization?",
+      "What commitments are reversible?",
+      "What events should cause EHG to accelerate, pause, or exit?"
+    ]
+  },
+  {
+    "council_id": "exponential_systems",
+    "council_name": "Exponential Systems Council",
+    "purpose": "Determine whether technology, costs, infrastructure, policy, geography, and institutional readiness are aligned sufficiently for a venture.",
+    "adjudicator_perspective_id": "azeem-azhar",
+    "specialist_perspective_ids": ["carlota-perez", "tony-seba", "parag-khanna"],
+    "required_output_type": "Systems Timing Brief",
+    "default_prompt_version": "v1.0",
+    "status": "active",
+    "primary_questions": [
+      "Which cost curves are changing?",
+      "Which technologies are converging?",
+      "What infrastructure is required?",
+      "What geographic or jurisdictional differences matter?",
+      "What regulatory conditions affect the opportunity?",
+      "Is the market too early, ready, rapidly scaling, or becoming commoditized?",
+      "Are incumbents structurally disadvantaged?",
+      "What supply-chain, compute, energy, or capital dependencies exist?",
+      "Is a temporary subsidy being mistaken for sustainable economics?"
+    ]
+  },
+  {
+    "council_id": "market_reality",
+    "council_name": "Market Reality Council",
+    "purpose": "Determine whether a future-oriented opportunity can become a practical, defensible, distributable, and profitable EHG venture.",
+    "adjudicator_perspective_id": "benedict-evans",
+    "specialist_perspective_ids": ["ben-thompson", "horace-dediu", "rita-mcgrath"],
+    "required_output_type": "Commercial Viability Brief",
+    "default_prompt_version": "v1.0",
+    "status": "active",
+    "primary_questions": [
+      "Who is the initial customer?",
+      "Who is the buyer?",
+      "Who controls the budget?",
+      "How severe and frequent is the problem?",
+      "Why would the customer switch?",
+      "How will EHG reach the customer?",
+      "Is the sales motion compatible with an AI-agent-operated company?",
+      "What creates retention?",
+      "What creates defensibility?",
+      "Is AI the product, an enabling capability, or a replaceable feature?",
+      "What prevents a larger platform from copying the product?",
+      "Why should EHG enter now?"
+    ]
+  }
+]

--- a/lib/foresight/content/index.mjs
+++ b/lib/foresight/content/index.mjs
@@ -1,0 +1,157 @@
+/**
+ * Foresight Board Phase-1 content — loader + validators
+ * (SD-LEO-INFRA-EHG-VENTURE-FORESIGHT-001-A).
+ *
+ * Authored content for the chairman-authored EHG Venture Foresight Board spec
+ * (docs/design/ehg-venture-foresight-board-spec.md): 5 council definitions
+ * (§8.2 + §5) and 20 PerspectiveProfile documents (§8.1 + §4.1).
+ *
+ * FIELD-FIDELITY CONTRACT (C-5/C-6): JSON keys use the spec's §8.1/§8.2
+ * suggested field names VERBATIM so sibling -B's tables ingest key-for-key.
+ * ADDITIVE fields (documented deviations, never silent): councils carry
+ * `primary_questions` (§5 verbatim, for -C's prompts); profiles carry
+ * `sources` (manual citations of real public work — parent plan item 6),
+ * `provenance_note` (public-thought-informed disclaimer + staleness note),
+ * and `forecasting_style` (style characterization — NEVER fabricated dated
+ * predictions; the §16.3 forecast ledger is later machinery).
+ *
+ * ANTI-IMPERSONATION (§3/§4.1/§18, chairman-authored hard rule): profiles are
+ * third-person analytical LENSES — recurring arguments, actual public
+ * frameworks, cautions, biases. lintAntiImpersonation() below is the
+ * CI-enforced guard (C-1..C-4): structural enforcement, not author discipline.
+ */
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const COUNCIL_FIELDS = Object.freeze([
+  'council_id', 'council_name', 'purpose', 'adjudicator_perspective_id',
+  'specialist_perspective_ids', 'required_output_type', 'default_prompt_version', 'status',
+]);
+export const PROFILE_FIELDS = Object.freeze([
+  'perspective_id', 'person_name', 'council_id', 'role_type', 'expertise_domains',
+  'analytical_frameworks', 'recurring_themes', 'known_cautions', 'known_biases',
+  'source_count', 'doctrine_version', 'last_refreshed_at', 'confidence_in_profile', 'active_status',
+]);
+export const ADDITIVE_COUNCIL_FIELDS = Object.freeze(['primary_questions']);
+export const ADDITIVE_PROFILE_FIELDS = Object.freeze(['sources', 'provenance_note', 'forecasting_style']);
+export const ROLE_TYPES = Object.freeze(['specialist', 'adjudicator', 'governance_reviewer', 'external_scout']);
+
+/** The chairman-named §5 roster — part of the content contract (C-6). */
+export const SPEC_ROSTER = Object.freeze({
+  frontier_capability: { adjudicator: 'Alex Wissner-Gross', specialists: ['Jack Clark', 'Nathan Benaich', 'Rodney Brooks'] },
+  human_transition: { adjudicator: 'Sínead Bovell', specialists: ['Marina Gorbis', 'Heather McGowan', 'Rumman Chowdhury'] },
+  strategic_foresight: { adjudicator: 'Amy Webb', specialists: ['Peter Schwartz', 'Sohail Inayatullah', 'Jamais Cascio'] },
+  exponential_systems: { adjudicator: 'Azeem Azhar', specialists: ['Carlota Perez', 'Tony Seba', 'Parag Khanna'] },
+  market_reality: { adjudicator: 'Benedict Evans', specialists: ['Ben Thompson', 'Horace Dediu', 'Rita McGrath'] },
+});
+
+export function loadCouncils() {
+  return JSON.parse(readFileSync(path.join(HERE, 'councils.json'), 'utf8'));
+}
+
+export function loadProfiles() {
+  const dir = path.join(HERE, 'profiles');
+  return readdirSync(dir).filter((f) => f.endsWith('.json')).sort()
+    .map((f) => JSON.parse(readFileSync(path.join(dir, f), 'utf8')));
+}
+
+// ── Anti-impersonation lint (C-1..C-4) ────────────────────────────────────────
+const BANNED_KEYS = ['speech_style', 'mannerisms', 'persona', 'voice', 'tone', 'first_person_prompt', 'character', 'speaking_style'];
+const FIRST_PERSON_RE = /(^|[\s"“(])(I|I'm|I've|my|mine)\b/;
+const SPEAK_AS_RE = /\byou are\s+(?:the\s+)?[A-ZÁÉÍÓÚÀ-ÿ][a-zà-ÿ]+(?:\s+[A-ZÁÉÍÓÚÀ-ÿ][a-zà-ÿ-]+)+/i;
+const ENDORSEMENT_RE = /\b(endorses?|approved by|works? (?:with|for) EHG|partner(?:ed|ship)? with EHG|affiliated with EHG)\b/i;
+
+function allStrings(value, out = []) {
+  if (typeof value === 'string') out.push(value);
+  else if (Array.isArray(value)) value.forEach((v) => allStrings(v, out));
+  else if (value && typeof value === 'object') Object.values(value).forEach((v) => allStrings(v, out));
+  return out;
+}
+
+/**
+ * Pure: returns [] when clean, else violation strings. Fails on persona keys,
+ * first-person voice, speak-as-the-person prompt forms (the spec's own banned
+ * example: "You are Alex Wissner-Gross. Tell EHG what to build"), and
+ * endorsement/affiliation claims.
+ */
+export function lintAntiImpersonation(profile) {
+  const violations = [];
+  for (const k of Object.keys(profile || {})) {
+    if (BANNED_KEYS.includes(k)) violations.push(`banned persona field: ${k}`);
+  }
+  for (const s of allStrings(profile)) {
+    if (FIRST_PERSON_RE.test(s)) violations.push(`first-person voice: "${s.slice(0, 60)}"`);
+    if (SPEAK_AS_RE.test(s)) violations.push(`speak-as-person form: "${s.slice(0, 60)}"`);
+    if (ENDORSEMENT_RE.test(s)) violations.push(`endorsement/affiliation claim: "${s.slice(0, 60)}"`);
+  }
+  return violations;
+}
+
+// ── Shape + board validators ──────────────────────────────────────────────────
+export function validateCouncil(c) {
+  const problems = COUNCIL_FIELDS.filter((f) => c?.[f] === undefined).map((f) => `council missing ${f}`);
+  if (Array.isArray(c?.specialist_perspective_ids) && c.specialist_perspective_ids.length !== 3) {
+    problems.push(`council ${c.council_id}: expected 3 specialists, got ${c.specialist_perspective_ids.length}`);
+  }
+  const extras = Object.keys(c || {}).filter((k) => !COUNCIL_FIELDS.includes(k) && !ADDITIVE_COUNCIL_FIELDS.includes(k));
+  if (extras.length) problems.push(`council ${c?.council_id}: undocumented fields ${extras.join(',')}`);
+  return problems;
+}
+
+export function validateProfile(p) {
+  const problems = PROFILE_FIELDS.filter((f) => p?.[f] === undefined).map((f) => `profile ${p?.perspective_id}: missing ${f}`);
+  if (p && !ROLE_TYPES.includes(p.role_type)) problems.push(`profile ${p.perspective_id}: invalid role_type ${p.role_type}`);
+  if (p && !(Number(p.confidence_in_profile) > 0 && Number(p.confidence_in_profile) <= 1)) {
+    problems.push(`profile ${p.perspective_id}: confidence_in_profile must be in (0,1]`);
+  }
+  if (p && p.doctrine_version !== 'v1.0') problems.push(`profile ${p.perspective_id}: Phase-1 doctrine_version must be v1.0`);
+  if (p && !Number.isFinite(Date.parse(p.last_refreshed_at))) problems.push(`profile ${p.perspective_id}: last_refreshed_at not a date`);
+  if (p && !(typeof p.provenance_note === 'string' && /public/i.test(p.provenance_note) && /stale|knowledge|cutoff/i.test(p.provenance_note))) {
+    problems.push(`profile ${p?.perspective_id}: provenance_note must carry the public-thought disclaimer + staleness note`);
+  }
+  const extras = Object.keys(p || {}).filter((k) => !PROFILE_FIELDS.includes(k) && !ADDITIVE_PROFILE_FIELDS.includes(k));
+  if (extras.length) problems.push(`profile ${p?.perspective_id}: undocumented fields ${extras.join(',')}`);
+  return problems.concat(lintAntiImpersonation(p).map((v) => `profile ${p?.perspective_id}: ${v}`));
+}
+
+/** Full-board validation: shapes, integrity, and the chairman-named roster. */
+export function validateBoard(councils, profiles) {
+  const problems = [];
+  if ((councils || []).length !== 5) problems.push(`expected 5 councils, got ${(councils || []).length}`);
+  for (const c of councils || []) problems.push(...validateCouncil(c));
+  for (const p of profiles || []) problems.push(...validateProfile(p));
+
+  const byId = new Map((profiles || []).map((p) => [p.perspective_id, p]));
+  for (const c of councils || []) {
+    const adj = byId.get(c.adjudicator_perspective_id);
+    if (!adj) problems.push(`council ${c.council_id}: adjudicator ${c.adjudicator_perspective_id} not found`);
+    else if (adj.role_type !== 'adjudicator' || adj.council_id !== c.council_id) {
+      problems.push(`council ${c.council_id}: adjudicator ${adj.perspective_id} role/council mismatch`);
+    }
+    for (const sid of c.specialist_perspective_ids || []) {
+      const sp = byId.get(sid);
+      if (!sp) problems.push(`council ${c.council_id}: specialist ${sid} not found`);
+      else if (sp.role_type !== 'specialist' || sp.council_id !== c.council_id) {
+        problems.push(`council ${c.council_id}: specialist ${sid} role/council mismatch`);
+      }
+    }
+    const roster = SPEC_ROSTER[c.council_id];
+    if (roster) {
+      if (adj && adj.person_name !== roster.adjudicator) problems.push(`council ${c.council_id}: adjudicator must be ${roster.adjudicator} (§5)`);
+      const names = (c.specialist_perspective_ids || []).map((sid) => byId.get(sid)?.person_name).filter(Boolean).sort();
+      const expected = [...roster.specialists].sort();
+      if (JSON.stringify(names) !== JSON.stringify(expected)) {
+        problems.push(`council ${c.council_id}: specialists must be exactly ${expected.join(', ')} (§5)`);
+      }
+    } else problems.push(`unknown council_id ${c.council_id} (not in the §5 roster)`);
+  }
+  const roleCounts = (profiles || []).reduce((acc, p) => ((acc[p.role_type] = (acc[p.role_type] || 0) + 1), acc), {});
+  if ((profiles || []).length === 20) {
+    if (roleCounts.adjudicator !== 5) problems.push(`expected 5 adjudicators, got ${roleCounts.adjudicator || 0}`);
+    if (roleCounts.specialist !== 15) problems.push(`expected 15 specialists, got ${roleCounts.specialist || 0}`);
+  }
+  return problems;
+}

--- a/lib/foresight/content/index.mjs
+++ b/lib/foresight/content/index.mjs
@@ -20,7 +20,7 @@
  * frameworks, cautions, biases. lintAntiImpersonation() below is the
  * CI-enforced guard (C-1..C-4): structural enforcement, not author discipline.
  */
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync, existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -54,6 +54,10 @@ export function loadCouncils() {
 
 export function loadProfiles() {
   const dir = path.join(HERE, 'profiles');
+  // Stacked-PR tolerance: the machinery PR precedes the content PRs, and git
+  // does not track empty directories — a missing profiles/ dir is the valid
+  // pre-content state, not an error (live CI ENOENT on the machinery PR).
+  if (!existsSync(dir)) return [];
   return readdirSync(dir).filter((f) => f.endsWith('.json')).sort()
     .map((f) => JSON.parse(readFileSync(path.join(dir, f), 'utf8')));
 }

--- a/tests/unit/foresight/content.test.js
+++ b/tests/unit/foresight/content.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  loadCouncils, loadProfiles, validateBoard, validateProfile, lintAntiImpersonation,
+  COUNCIL_FIELDS, PROFILE_FIELDS, SPEC_ROSTER,
+} from '../../../lib/foresight/content/index.mjs';
+
+const councils = loadCouncils();
+const profiles = loadProfiles();
+// Stacked-PR tolerance: per-profile checks always run; FULL-board assertions
+// activate once the complete §5 roster (20) is present (the final content PR).
+const fullRoster = profiles.length === 20;
+const whenFull = fullRoster ? it : it.skip;
+
+describe('TS-1 full-board validation (spec §5 + §8.1/§8.2)', () => {
+  whenFull('5 councils + 20 profiles, all shapes and referential integrity, chairman-named roster in place', () => {
+    expect(councils).toHaveLength(5);
+    expect(profiles).toHaveLength(20);
+    expect(validateBoard(councils, profiles)).toEqual([]);
+  });
+  it('every §8.2 field on every council; every §8.1 field on every profile (TS-3 shape fidelity)', () => {
+    for (const c of councils) for (const f of COUNCIL_FIELDS) expect(c[f], `${c.council_id}.${f}`).toBeDefined();
+    for (const p of profiles) for (const f of PROFILE_FIELDS) expect(p[f], `${p.perspective_id}.${f}`).toBeDefined();
+  });
+  whenFull('TS-5 role_type distribution: exactly 5 adjudicators + 15 specialists', () => {
+    expect(profiles.filter((p) => p.role_type === 'adjudicator')).toHaveLength(5);
+    expect(profiles.filter((p) => p.role_type === 'specialist')).toHaveLength(15);
+  });
+  it('the roster constant covers all five councils', () => {
+    expect(Object.keys(SPEC_ROSTER)).toHaveLength(5);
+  });
+});
+
+describe('TS-2 anti-impersonation lint (§3/§4.1/§18 hard rule)', () => {
+  it('all 20 authored profiles pass the lint', () => {
+    for (const p of profiles) expect(lintAntiImpersonation(p), p.perspective_id).toEqual([]);
+  });
+  it('pinned negatives: persona field fails', () => {
+    expect(lintAntiImpersonation({ persona: 'wise futurist' })).not.toEqual([]);
+    expect(lintAntiImpersonation({ speech_style: 'gruff' })).not.toEqual([]);
+  });
+  it("pinned negative: the spec's own banned prompt form fails", () => {
+    expect(lintAntiImpersonation({ note: 'You are Alex Wissner-Gross. Tell EHG what to build.' })).not.toEqual([]);
+  });
+  it('pinned negatives: first-person voice and endorsement claims fail', () => {
+    expect(lintAntiImpersonation({ recurring_themes: ['I believe the future is bright'] })).not.toEqual([]);
+    expect(lintAntiImpersonation({ provenance_note: 'This thinker endorses EHG ventures.' })).not.toEqual([]);
+  });
+});
+
+describe('TS-4 versioning + provenance (§16.1)', () => {
+  it('doctrine_version v1.0, dated refresh, bounded confidence, disclaimer + staleness note on all 20', () => {
+    for (const p of profiles) {
+      expect(p.doctrine_version).toBe('v1.0');
+      expect(Number.isFinite(Date.parse(p.last_refreshed_at))).toBe(true);
+      expect(p.confidence_in_profile).toBeGreaterThan(0);
+      expect(p.confidence_in_profile).toBeLessThanOrEqual(1);
+      expect(p.provenance_note).toMatch(/public/i);
+      expect(p.provenance_note).toMatch(/stale|knowledge|cutoff/i);
+      expect(p.source_count).toBe(p.sources.length);
+    }
+  });
+});
+
+describe('validateProfile negative coverage', () => {
+  it('flags missing fields, bad role_type, bad confidence, wrong version, undocumented keys', () => {
+    const base = profiles[0];
+    expect(validateProfile({ ...base, role_type: 'oracle' }).join()).toMatch(/invalid role_type/);
+    expect(validateProfile({ ...base, confidence_in_profile: 1.5 }).join()).toMatch(/confidence/);
+    expect(validateProfile({ ...base, doctrine_version: 'v2.0' }).join()).toMatch(/v1\.0/);
+    expect(validateProfile({ ...base, mystery_field: 1 }).join()).toMatch(/undocumented/);
+    const { person_name, ...missing } = base;
+    expect(validateProfile(missing).join()).toMatch(/missing person_name/);
+  });
+});


### PR DESCRIPTION
PR-1 of 3 (stacked). Machinery lands before any profile content so the anti-impersonation lint (§3/§4.1/§18 chairman-authored hard rule) gates every profile PR: banned persona keys, first-person voice, speak-as-person forms (the spec's own banned example is a pinned fixture), endorsement claims. §8.1/§8.2 field-fidelity contract for sibling -B ingestion; SPEC_ROSTER pins the chairman-named 20. councils.json = the 5 §8.2 definitions with §5 primary questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)