### PR TITLE
docs(QF-20260717-794): document edgeAt-null-when-scope-exceeds-evidence pattern in collector registry

### DIFF
--- a/lib/loop-governance/collectors/index.js
+++ b/lib/loop-governance/collectors/index.js
@@ -11,6 +11,16 @@
  * EXISTING try/catch in evaluateLoopBatch (verifier.js:38-40) converts it to
  * status='unknown'. Duplicating that fail-soft logic here would create two places
  * that can diverge on what "collector failure" means.
+ *
+ * EDGE-AT-NULL WHEN SCOPE EXCEEDS EVIDENCE (required pattern for every new collector,
+ * QF-20260717-794 from the LOOP-EVIDENCE-COLLECTORS-001 retrospective): when a loop's
+ * display_name/definition describes broader scope than the collector's single evidence
+ * source can actually observe, return {upstreamFiredAt, edgeAt: null} — landing on the
+ * "fired but edge absent" OPEN path — rather than deriving a real edgeAt from partial
+ * evidence, which risks a false-CLOSE on a loop the evidence does not fully cover.
+ * A real edgeAt is justified ONLY by a measured, scope-matching closure signal, never
+ * by liveness alone; see session-coordination-retention.js's MEASURED-DECLINE GATE
+ * (GT-1, SD-LEO-INFRA-L30-CLOSURE-EDGE-001) for the exemplar of earning a real edge.
  */
 import { collectSessionCoordinationRetentionEvidence } from './session-coordination-retention.js';
 


### PR DESCRIPTION
## Summary
- Retro action item (high priority, owner EXEC) from the SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001 retrospective (d846a24e), auto-promoted as QF-20260717-794.
- Documents the **edgeAt-null-when-scope-exceeds-evidence** pattern directly in the `lib/loop-governance/collectors/index.js` registry header — the file every new collector touches — so future collector authors don't re-derive the reasoning from `session-coordination-retention.js` each time.
- Pattern as stated: when a loop's definition describes broader scope than the collector's evidence source can observe, return `edgeAt: null` (the "fired but edge absent" OPEN path) rather than a real edgeAt from partial evidence (false-CLOSE risk). A real edgeAt requires a measured, scope-matching signal — exemplar: L30's MEASURED-DECLINE GATE (GT-1, SD-LEO-INFRA-L30-CLOSURE-EDGE-001).

## Scope
Comment-only, +10 LOC, one file.

## Verification
- `node --check` passes.
- `vitest run` on `registry.test.js` + `session-coordination-retention.test.js`: 26/26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)