### PR TITLE
docs(QF-20260717-397): add uniform-testability-pattern audit to EXEC-phase checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 11fa68d8a9c45992 -->
+<!-- file_content_hash: e477007259bfecfd -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-07-16 1:13:36 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-17 5:50:52 AM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8d04ee65d9cd453d -->
+<!-- file_content_hash: 1792590c41d3ac4c -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -333,6 +333,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 89f43be6d23a4c88 -->
+<!-- file_content_hash: 0c54ee17d39b76bd -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 2d8607c4b86c5ff6 -->
+<!-- file_content_hash: 023118ad29df09fe -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -81,6 +81,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: e2193c38a26944c9 -->
+<!-- file_content_hash: 6f865d0fbdb2d11a -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 2d74f9c7a70eb9c2 -->
+<!-- file_content_hash: 8b95c59c694c122f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1737,7 +1737,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 8cf4a32ed8dd3b32 -->
+<!-- file_content_hash: b9088b2fc3288a01 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-07-16 1:13:36 PM*
+*DIGEST generated: 2026-07-17 5:50:52 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 2b19bebf82ff4410 -->
+<!-- file_content_hash: 1b1360c1683efcef -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-07-16 1:13:36 PM*
+*DIGEST generated: 2026-07-17 5:50:52 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 6ce724ce53b5da95 -->
+<!-- file_content_hash: 6fa474dcbe574d1d -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -152,6 +152,7 @@ Before writing code, review the PRD's `test_scenarios` and `testing_strategy` an
 2. **Export key functions independently** — Pipeline stages, validators, and transforms should be importable/callable outside their runtime context
 3. **Use injectable dependencies** — Database clients, API callers, and config should be parameters, not hardcoded imports, for functions that will need testing
 4. **Design clear seams** — When building multi-step workflows, each step should be independently testable with well-defined inputs/outputs
+5. **Uniformity audit (verify before EXEC-TO-PLAN)** — if you applied a client-injectable/testability pattern to some of the N functions this SD adds or modifies, enumerate all N and confirm the pattern is applied to EVERY one — especially the SD's own headline/CRITICAL-priority fix. Ask "which functions did NOT get the pattern?" and justify each exception explicitly. Partial application is how a core fix ships untested: in one SD, 3 of 4 new functions followed the pattern and the unpatterned 4th was the headline dedup gate.
 
 Ask yourself: "If the testing-agent had to write tests for this, would the architecture make that easy or painful?"
 
@@ -2147,6 +2148,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 6b7403a144fd49ad -->
+<!-- file_content_hash: dec6dcb45b1a54f5 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-16 1:13:36 PM*
+*DIGEST generated: 2026-07-17 5:50:52 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 760a38211050e033 -->
+<!-- file_content_hash: fb39e69c9dcc7ec7 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1586,6 +1586,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 8cb29d39206546f3 -->
+<!-- file_content_hash: 4b0be9f04d7c5313 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-07-16 1:13:36 PM*
+*DIGEST generated: 2026-07-17 5:50:52 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: ce9619a5351d93bc -->
+<!-- file_content_hash: c0dbc4f568f243fa -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2451,6 +2451,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: 0c090576e2142054 -->
+<!-- file_content_hash: 3bd6d0f8f664797e -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-07-16 1:13:36 PM*
+*DIGEST generated: 2026-07-17 5:50:52 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 7b32055a16c889a1 -->
+<!-- file_content_hash: d117d330a9039a9d -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-07-16 1:13:36 PM
+**Generated**: 2026-07-17 5:50:52 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -278,6 +278,6 @@ Solomon operates under the canonical crew-comms routing protocol: `docs/protocol
 
 ---
 
-*Generated from database: 2026-07-16*
+*Generated from database: 2026-07-17*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-16T17:13:36.066Z -->
-<!-- git_commit: 89c5e306 -->
+<!-- generated_at: 2026-07-17T09:50:52.534Z -->
+<!-- git_commit: a2c351ac -->
 <!-- db_snapshot_hash: 6bcd1672b5ba0df9 -->
-<!-- file_content_hash: d66030969773b257 -->
+<!-- file_content_hash: 8f66682f92b63ed3 -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,123 +1,123 @@
 {
-  "generated_at": "2026-07-16T17:13:36.066Z",
-  "git_commit": "89c5e306",
+  "generated_at": "2026-07-17T09:50:52.534Z",
+  "git_commit": "a2c351ac",
   "db_snapshot_hash": "6bcd1672b5ba0df9",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19564,
       "estimated_tokens": 4891,
-      "content_hash": "457c67146791e50d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE.md"
+      "content_hash": "b84f22d05a12cfbc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 91183,
       "estimated_tokens": 22796,
-      "content_hash": "21c33051ab96b25a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_CORE.md"
+      "content_hash": "6bd4768e44fde446",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65998,
       "estimated_tokens": 16500,
-      "content_hash": "e137b65a57cf9045",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_LEAD.md"
+      "content_hash": "7d5aa419cb46c6dc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 91830,
       "estimated_tokens": 22958,
-      "content_hash": "ddefa052cbd24b1e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_PLAN.md"
+      "content_hash": "536d599396006de8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 88410,
-      "estimated_tokens": 22103,
-      "content_hash": "84f718e3b79e26a6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_EXEC.md"
+      "chars": 88941,
+      "estimated_tokens": 22236,
+      "content_hash": "ce9a25af0ed156fe",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
       "chars": 63589,
       "estimated_tokens": 15898,
-      "content_hash": "1444fb7baa6879f6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_ADAM.md"
+      "content_hash": "e3c4b47a69a976de",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
       "chars": 22134,
       "estimated_tokens": 5534,
-      "content_hash": "e574d08f3340c4c7",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_COORDINATOR.md"
+      "content_hash": "cb167b65c1795af8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
       "chars": 49861,
       "estimated_tokens": 12466,
-      "content_hash": "999ff2134a0837d2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_SOLOMON.md"
+      "content_hash": "9c71f8301eee3a0f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "4f0fda6b21850616",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_DIGEST.md"
+      "content_hash": "f799a4c9e25589a3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11664,
       "estimated_tokens": 2916,
-      "content_hash": "9a4f07c6518f440d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "c8a75328f3f2b6c3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5551,
       "estimated_tokens": 1388,
-      "content_hash": "91262b87430326a2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "9bdf0f46f057f8c9",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8541,
       "estimated_tokens": 2136,
-      "content_hash": "b90e5a61601eca1e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "fa45cbe4c691d5cd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10964,
       "estimated_tokens": 2741,
-      "content_hash": "fabdcca3b46ed643",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "81758a392c126222",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 16604,
       "estimated_tokens": 4151,
-      "content_hash": "e805990b206c8ef8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "ef767cd27d91d5a8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 6076,
       "estimated_tokens": 1519,
-      "content_hash": "85577f8bad589f9a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "6d823ceef971bc5d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 4705,
       "estimated_tokens": 1177,
-      "content_hash": "614ba65aa51dd0ab",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PLAN-OF-RECORD-LINKAGE-001\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "039d07dbc7f0293a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\QF-20260717-397\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "4159fd8bda5e8db1",
+    "global": "e39c0c64923a49d4",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -139,7 +139,7 @@
       "207": "e445b9976ac071e4",
       "208": "a7d1a5ecfdf8499c",
       "209": "786efb98a8e2f3cb",
-      "210": "f2ad58fdc48f49a2",
+      "210": "7ae76b9f93023eec",
       "211": "5d137550e1e954b7",
       "212": "53916ba04560d9cf",
       "213": "05620e243a2c48a1",


### PR DESCRIPTION
## Summary
Adds item 5 (**Uniformity audit — verify before EXEC-TO-PLAN**) to the *Testability-Aware Implementation* list in `CLAUDE_EXEC.md`, DB-first via `leo_protocol_sections` id=210 (`scripts/update-exec-testability-uniformity-audit.mjs`, already applied) followed by `generate-claude-md-from-db.js` regeneration. The remaining file churn is regen timestamps/hashes.

## Why
Retrospective `bf811054` (SD-LEO-INFRA-EVA-CONSULTANT-GENERATOR-001) found that 3 of 4 new functions received the client-injectable testability pattern while the unpatterned 4th — the SD's own headline dedup-gate fix — shipped untested. This audit makes the "which functions did NOT get the pattern?" check an explicit EXEC-phase step.

## Verification
- Update script is idempotent (anchor-guarded, skips when already applied); dry-run then applied against live DB
- Regenerated with `node scripts/generate-claude-md-from-db.js` — drift check clean, smoke tests 15/15 pass at commit

Quick-Fix: QF-20260717-397
Claude-Session: 356833d8-2c04-4d59-941e-8edf5f64c391

🤖 Generated with [Claude Code](https://claude.com/claude-code)