### PR TITLE
fix(SD-LEO-INFRA-BLOCK-TEST-SESSION-001): block phantom test-session claims + reap in the sweep

### DIFF
--- a/database/migrations/20260717_claim_sd_phantom_session_guard.sql
+++ b/database/migrations/20260717_claim_sd_phantom_session_guard.sql
@@ -1,0 +1,488 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-1)
+--
+-- RCA: claim_sd() never validated that the CALLING p_session_id has a live row in
+-- claude_sessions before writing the claim. The terminal `UPDATE claude_sessions SET
+-- sd_key=p_sd_id ... WHERE session_id=p_session_id` silently no-ops when no row matches,
+-- but the paired `UPDATE strategic_directives_v2 SET claiming_session_id=p_session_id ...`
+-- runs unconditionally -- so a phantom/never-registered session_id (witnessed live incident:
+-- test-session-nswcf-fenced, zero rows in claude_sessions) can claim a real SD/QF and strand
+-- it. Mirrors the existing session_not_found idiom already used by release_session()
+-- (database/migrations/20260408_claim_check_hardening.sql).
+--
+-- A test-session-*-fenced regex fence was considered and DROPPED: tests/database/
+-- seat-busy-fence.test.js deliberately registers a REAL claude_sessions row for session_id
+-- literally 'test-session-nswcf-fenced' to exercise unrelated seat-busy-fence/checkin logic
+-- via the real worker-checkin.cjs CLI -- a regex fence would reject that legitimately
+-- registered session and corrupt that test's intent. The NOT-EXISTS check alone is durable
+-- (the witnessed incident session had zero claude_sessions rows) and does not collide with it.
+--
+-- Signature is UNCHANGED (still 5 args, same defaults) -- CREATE OR REPLACE is safe here,
+-- no DROP needed (same precedent as 20260704_claim_sd_client_gate_version.sql).
+--
+-- The body below is the LIVE production claim_sd() definition (database/migrations/
+-- 20260712_claim_sd_claim_switch_clobber_guard.sql) with exactly ONE behavioral addition,
+-- marked below: a phantom-session existence guard immediately after the advisory lock,
+-- before any other read. Every existing guard, comment, and provenance note is preserved
+-- verbatim so this migration is a pure additive change.
+
+CREATE OR REPLACE FUNCTION public.claim_sd(p_sd_id text, p_session_id text, p_track text, p_force_takeover boolean DEFAULT false, p_client_gate_version integer DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_session    text;
+  v_existing_hb_age     numeric;
+  v_existing_status     text;
+  v_existing_wt_path    text;
+  v_existing_wt_branch  text;
+  v_sd_claiming_id      text;
+  v_sd_parent_id        text;
+  v_drift_detected      boolean := FALSE;
+  v_takeover            boolean := FALSE;
+  v_takeover_reason     text;
+  v_caller_parent_id    text;
+  v_audit_event_id      uuid;
+  v_conflict            RECORD;
+  v_is_qf               boolean := p_sd_id LIKE 'QF-%';
+  v_sd_status           text;
+  v_qf_status           text;
+  v_sd_claim_hb_age     numeric;
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: armed-silence-window awareness (parity with cleanup_stale_sessions).
+  v_respect_inflight       boolean := FALSE;
+  v_ttl_minutes            integer := 15;
+  v_hardcap_minutes        integer := 45;
+  v_existing_silence_until timestamptz;
+  v_sd_claim_silence_until timestamptz;
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): the sd_key/QF-id evicted by the
+  -- claim-switch UPDATE below, captured so its SD/QF-side claim pointer can be cleared.
+  v_evicted_sd_key         text;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-1): reject a claim from a session_id with NO
+  -- live claude_sessions row. Real sessions always upsert into claude_sessions at
+  -- SessionStart (session-register.cjs hook) before ever calling claim_sd, so this never
+  -- rejects a genuine worker. Fires before any other read/lock (SD or QF path), so it
+  -- applies uniformly to both.
+  IF NOT EXISTS (SELECT 1 FROM claude_sessions WHERE session_id = p_session_id) THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'phantom_session',
+      'message', format('[CLAIM_PHANTOM_SESSION] session_id %s has no live claude_sessions row — refusing to claim %s.', p_session_id, p_sd_id));
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: read the SAME respect-in-flight flag cleanup_stale_sessions
+  -- uses, so the sweep and the claim arbiter never disagree about an armed silence window. FAIL-OPEN:
+  -- any error leaves the flag OFF (today's reap-on-stale behavior).
+  BEGIN
+    SELECT
+      COALESCE((metadata->>'sweep_respect_inflight_agent')::boolean, FALSE),
+      COALESCE((metadata->>'claim_ttl_minutes')::integer, 15)
+    INTO v_respect_inflight, v_ttl_minutes
+    FROM chairman_dashboard_config
+    WHERE config_key = 'default'
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_respect_inflight := FALSE;
+    v_ttl_minutes := 15;
+  END;
+  -- Hard-cap ceiling = max in-flight silence window (30 min) + claim TTL margin; beyond this no
+  -- expected_silence_until can wedge a dead claim open forever. Mirrors cleanup_stale_sessions.
+  v_hardcap_minutes := 30 + GREATEST(COALESCE(v_ttl_minutes, 15), 0);
+
+  -- 2a. Capture prior session's worktree state (for audit metadata) under the
+  --     SAME FOR UPDATE row lock as the existing-session check.
+  SELECT cs.session_id, cs.status,
+         EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+         cs.worktree_path, cs.worktree_branch,
+         cs.expected_silence_until
+    INTO v_existing_session, v_existing_status, v_existing_hb_age,
+         v_existing_wt_path, v_existing_wt_branch,
+         v_existing_silence_until
+    FROM claude_sessions cs
+   WHERE cs.sd_key = p_sd_id
+     AND cs.session_id != p_session_id
+     AND cs.status IN ('active', 'idle')
+   ORDER BY cs.heartbeat_at DESC
+   LIMIT 1
+     FOR UPDATE;
+
+  IF NOT v_is_qf THEN
+    SELECT sd.claiming_session_id, sd.parent_sd_id, sd.status
+      INTO v_sd_claiming_id, v_sd_parent_id, v_sd_status
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_sd_id
+       FOR UPDATE;
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: reject phantom (non-existent) SD ids instead of
+    -- optimistically returning success. claim_sd was OPTIMISTIC -- a typo / stale sd_key used
+    -- to self-claim a non-existent SD and write claude_sessions.sd_key. The existing FOR UPDATE
+    -- SELECT above sets FOUND only when an sd_key row exists, so this is the minimal guard.
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: terminal-status guard. Refuse to claim an SD whose
+    -- lifecycle has already ended (completed/cancelled/deferred) instead of optimistically
+    -- stomping claiming_session_id. Orthogonal to the sd_not_found guard above; fires BEFORE
+    -- the claim UPDATE so it pre-empts trigger 393's raw P0001 with a clean structured failure
+    -- and additionally covers completed/deferred which that cancelled-only trigger does not.
+    IF v_sd_status IN ('completed', 'cancelled', 'deferred') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_sd_status,
+        'message', format('[CLAIM_SD_TERMINAL] SD %s is in terminal status %s — refusing to claim a finished/cancelled/deferred SD.', p_sd_id, v_sd_status));
+    END IF;
+
+    -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: capture the SD-side claimant's heartbeat age so the
+    -- live-foreign-claim guard below can refuse to stomp a LIVE peer even when its session-side
+    -- claude_sessions.sd_key pointer has drifted out of sync with the SD-side claiming_session_id.
+    -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: also capture its expected_silence_until for the silence guard.
+    IF v_sd_claiming_id IS NOT NULL AND v_sd_claiming_id != p_session_id THEN
+      SELECT EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+             cs.expected_silence_until
+        INTO v_sd_claim_hb_age,
+             v_sd_claim_silence_until
+        FROM claude_sessions cs
+       WHERE cs.session_id = v_sd_claiming_id
+         AND cs.status IN ('active', 'idle')
+       ORDER BY cs.heartbeat_at DESC
+       LIMIT 1;
+    END IF;
+  ELSE
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: same guard for the QF path (claim_sd resolves QFs
+    -- by quick_fixes.id = p_sd_id, mirrored from the QF UPDATE below).
+    SELECT qf.status INTO v_qf_status FROM quick_fixes qf WHERE qf.id = p_sd_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: QF terminal-status guard. 'escalated' is a one-way
+    -- promotion to a full SD (classify-quick-fix.js never reverts it), so claiming an escalated
+    -- QF resumes superseded work. Mirrors the SD terminal guard; fires before the QF UPDATE.
+    IF v_qf_status IN ('completed', 'cancelled', 'escalated') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_qf_status,
+        'message', format('[CLAIM_QF_TERMINAL] Quick-fix %s is in terminal status %s — refusing to claim a finished/cancelled/escalated quick-fix.', p_sd_id, v_qf_status));
+    END IF;
+  END IF;
+
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_existing_session IS NULL
+  THEN
+    v_drift_detected := TRUE;
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age < 900 THEN
+    IF NOT p_force_takeover THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'already_claimed',
+        'message', format(
+          '[CLAIM_PEER_ACTIVE] SD %s is already claimed by active session %s (heartbeat %ss ago). Use --force to take over or wait for release.',
+          p_sd_id, v_existing_session, ROUND(v_existing_hb_age)),
+        'claimed_by', v_existing_session,
+        'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+      );
+    END IF;
+
+    SELECT cs2.sd_key INTO v_caller_parent_id
+      FROM claude_sessions cs2
+     WHERE cs2.session_id = p_session_id
+       AND cs2.status IN ('active', 'idle')
+     LIMIT 1;
+
+    IF v_existing_hb_age >= 60 THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_heartbeat_threshold';
+    ELSIF v_sd_parent_id IS NOT NULL
+          AND v_caller_parent_id = v_sd_parent_id THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_parent_authority';
+    ELSE
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'unauthorized_force',
+        'message', format(
+          '[CLAIM_FORCE_DENIED] SD %s force-takeover refused: caller session %s lacks authority (prior heartbeat %ss < 60s threshold and no parent SD authority). Use sd:release first or wait.',
+          p_sd_id, p_session_id, ROUND(v_existing_hb_age))
+      );
+    END IF;
+  END IF;
+
+  -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: refuse to overwrite a claim held by a LIVE foreign session.
+  -- The session-side refusal above only fires when the live peer's claude_sessions.sd_key still
+  -- equals p_sd_id; it misses the case where only the SD-side claim (claiming_session_id) points
+  -- to a still-live session whose session pointer drifted. Without this guard the drift_recovery
+  -- takeover below would silently stomp that live peer. A stale claimant (hb >= 900s) or an absent
+  -- session leaves v_sd_claim_hb_age NULL / >= 900 and still falls through to takeover; --force too.
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age < 900
+     AND NOT p_force_takeover
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_live_peer',
+      'message', format(
+        '[CLAIM_LIVE_PEER] SD %s is claimed by LIVE session %s (heartbeat %ss ago) — refusing to overwrite a live peer''s claim. Use --force to take over or wait for release.',
+        p_sd_id, v_sd_claiming_id, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: drift_recovery choke point. If the SD-side claimant is a
+  -- parked worker inside its armed silence window (flag ON, window in the future, heartbeat within
+  -- the hard-cap ceiling), refuse to reap it. --force and expired / beyond-cap windows still take
+  -- over (this guard requires NOT p_force_takeover and a future window <= hard-cap). Mutually
+  -- exclusive with the auto_stale guard below: v_drift_detected implies v_existing_session IS NULL.
+  IF v_respect_inflight
+     AND v_drift_detected AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_sd_claim_silence_until IS NOT NULL
+     AND v_sd_claim_silence_until > NOW()
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by session %s parked inside an armed silence window (until %s, heartbeat %ss ago) — refusing to reap a parked worker. Use --force to override.',
+        p_sd_id, v_sd_claiming_id, v_sd_claim_silence_until, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'silence_until', v_sd_claim_silence_until,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  IF v_drift_detected AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'drift_recovery';
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: auto_stale_takeover choke point. A session silent past 900s
+  -- but inside its armed silence window (flag ON, within the hard-cap ceiling) is a PARKED worker,
+  -- not a dead one — refuse the auto-stale takeover. --force and expired / beyond-cap windows still
+  -- reap (a window beyond the 45-min hard-cap, or already past, falls through to takeover below).
+  IF v_respect_inflight
+     AND v_existing_session IS NOT NULL
+     AND v_existing_hb_age >= 900 AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_existing_silence_until IS NOT NULL
+     AND v_existing_silence_until > NOW()
+     AND v_existing_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by parked session %s inside an armed silence window (until %s, heartbeat %ss ago) — refusing auto-stale takeover. Use --force to override.',
+        p_sd_id, v_existing_session, v_existing_silence_until, ROUND(v_existing_hb_age)),
+      'claimed_by', v_existing_session,
+      'silence_until', v_existing_silence_until,
+      'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+    );
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'auto_stale_takeover';
+  END IF;
+
+  IF NOT v_is_qf AND NOT v_takeover THEN
+    SELECT cm.*, cs_other.sd_key AS active_sd, cs_other.session_id AS active_session
+      INTO v_conflict
+      FROM sd_conflict_matrix cm
+      JOIN claude_sessions cs_other ON (
+        (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_key) OR
+        (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_key)
+      )
+     WHERE cm.conflict_severity = 'blocking'
+       AND cm.resolved_at IS NULL
+       AND cs_other.sd_key IS NOT NULL
+       AND cs_other.status IN ('active', 'idle')
+       AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+       AND cs_other.session_id != p_session_id
+     LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+  END IF;
+
+  -- ============================================================================
+  -- TAKEOVER PATH: NULL the prior session's claim AND its worktree state.
+  -- (FR-1 of SD-LEO-INFRA-LEO-INFRA-SESSION-001 — only the worktree_* columns
+  -- are new vs. 20260427.)
+  -- ============================================================================
+  IF v_takeover AND v_existing_session IS NOT NULL THEN
+    UPDATE claude_sessions
+       SET sd_key = NULL,
+           track = NULL,
+           claimed_at = NULL,
+           released_at = NOW(),
+           released_reason = v_takeover_reason,
+           status = 'idle',
+           updated_at = NOW(),
+           worktree_path = NULL,
+           worktree_branch = NULL
+     WHERE session_id = v_existing_session;
+  END IF;
+
+  -- Claim-switch path: caller is releasing some OTHER SD to claim p_sd_id.
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): RETURNING captures the evicted sd_key
+  -- (NULL if no row matched) so its own claim pointer can be cleared symmetrically below.
+  UPDATE claude_sessions
+     SET sd_key = NULL,
+         track = NULL,
+         claimed_at = NULL,
+         released_at = NOW(),
+         released_reason = 'claim_switch',
+         status = 'idle',
+         worktree_path = NULL,
+         worktree_branch = NULL
+   WHERE session_id = p_session_id
+     AND sd_key IS NOT NULL
+     AND sd_key != p_sd_id
+     AND (v_sd_parent_id IS NULL OR sd_key != v_sd_parent_id)
+   RETURNING sd_key INTO v_evicted_sd_key;
+
+  -- SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 (FR-4): symmetric clear of the EVICTED SD's/QF's
+  -- claim pointer. The claim-switch UPDATE above only clears the CALLING SESSION's
+  -- claude_sessions row; without this, strategic_directives_v2.claiming_session_id (or
+  -- quick_fixes.claiming_session_id) on the evicted item was never cleared, leaving it
+  -- looking claimed by a session that has since moved to a different SD (RCA QF-20260712-310).
+  -- Guarded by `claiming_session_id = p_session_id` so this never clobbers a claim some OTHER
+  -- session has since legitimately taken on the evicted item.
+  IF v_evicted_sd_key IS NOT NULL THEN
+    IF v_evicted_sd_key LIKE 'QF-%' THEN
+      UPDATE quick_fixes
+         SET claiming_session_id = NULL
+       WHERE id = v_evicted_sd_key
+         AND claiming_session_id = p_session_id;
+    ELSE
+      UPDATE strategic_directives_v2
+         SET claiming_session_id = NULL,
+             active_session_id = NULL,
+             is_working_on = FALSE
+       WHERE sd_key = v_evicted_sd_key
+         AND claiming_session_id = p_session_id;
+    END IF;
+  END IF;
+
+  -- New-claim UPDATE intentionally does NOT set worktree_path / worktree_branch.
+  -- sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after
+  -- createWorktree completes. Keeping them NULL here means the FR-5 CHECK
+  -- constraint is never violated transiently.
+  UPDATE claude_sessions
+     SET sd_key = p_sd_id,
+         track = p_track,
+         claimed_at = NOW(),
+         released_at = NULL,
+         released_reason = NULL,
+         heartbeat_at = NOW(),
+         status = 'active'
+   WHERE session_id = p_session_id;
+
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+       SET claiming_session_id = p_session_id,
+           status = 'in_progress'
+     WHERE id = p_sd_id;
+  ELSE
+    -- SD-LEO-INFRA-SIDE-CLAIM-ELIGIBILITY-001 (FR-2): the ONLY behavioral addition to this
+    -- function -- stamp the caller's gate-code version on the SD-side claim mirror so the
+    -- observe-only trigger (next migration) can compare it against the version-floor.
+    UPDATE strategic_directives_v2
+       SET claiming_session_id = p_session_id,
+           active_session_id = p_session_id,
+           is_working_on = TRUE,
+           claim_gate_client_version = p_client_gate_version
+     WHERE sd_key = p_sd_id;
+  END IF;
+
+  IF v_takeover THEN
+    INSERT INTO session_lifecycle_events (
+      event_type,
+      session_id,
+      reason,
+      metadata
+    ) VALUES (
+      CASE
+        WHEN v_takeover_reason = 'auto_stale_takeover' THEN 'CLAIM_AUTO_RECLAIM'
+        ELSE 'CLAIM_TAKEOVER'
+      END,
+      p_session_id,
+      v_takeover_reason,
+      jsonb_build_object(
+        'sd_key', p_sd_id,
+        'prior_session_id', v_existing_session,
+        'prior_heartbeat_age_seconds', ROUND(COALESCE(v_existing_hb_age, 0)),
+        'drift_detected', v_drift_detected,
+        'force_authorized_by', CASE
+          WHEN v_takeover_reason LIKE 'force_%' THEN v_takeover_reason
+          ELSE NULL
+        END,
+        'sd_claiming_id_before', v_sd_claiming_id,
+        'worktree_path_before', v_existing_wt_path,
+        'worktree_branch_before', v_existing_wt_branch
+      )
+    )
+    RETURNING id INTO v_audit_event_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_sd_parent_id IS NOT NULL,
+    'takeover', v_takeover,
+    'takeover_reason', v_takeover_reason,
+    'prior_session_id', v_existing_session,
+    'prior_heartbeat_age_seconds', CASE
+      WHEN v_existing_hb_age IS NOT NULL THEN ROUND(v_existing_hb_age)
+      ELSE NULL
+    END,
+    'drift_detected', v_drift_detected,
+    'evicted_sd_key', v_evicted_sd_key,
+    'audit_event_id', v_audit_event_id
+  );
+END;
+$function$;
+
+-- Prompt PostgREST to reload its schema cache promptly (unchanged signature, but the
+-- function body changed).
+NOTIFY pgrst, 'reload schema';
+
+DO $$
+DECLARE
+  v_overload_count int;
+BEGIN
+  SELECT count(*) INTO v_overload_count FROM pg_proc WHERE proname = 'claim_sd';
+  IF v_overload_count != 1 THEN
+    RAISE EXCEPTION 'VERIFICATION FAILED: expected exactly 1 claim_sd overload, found %', v_overload_count;
+  END IF;
+  RAISE NOTICE 'claim_sd: exactly one overload confirmed (5-arg, phantom-session guard added).';
+END $$;

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -29,7 +29,7 @@ const { PLAN_CONTENT_MARKER } = require('../lib/sd-enrichment-markers.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
-const { evaluateDispatchEligibility, classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+const { evaluateDispatchEligibility, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: the sweep is the primary scheduled WORK_ASSIGNMENT producer
 // and inserts raw (it does NOT route through insertCoordinationRow), so the dispatch-side terminal
 // guard would never reach it. Call assertSdDispatchable here so the sweep also refuses to nudge a
@@ -1606,6 +1606,90 @@ async function runCoordinatorHousekeeping(ctx) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-2/FR-3): reap a claim held by a PHANTOM
+ * session -- strategic_directives_v2.claiming_session_id set to a session_id with NO
+ * row in claude_sessions at all (never registered, or long since purged). Distinct
+ * from the FIXTURE_SESSION_RE CLAIM_FIX loop elsewhere in this file, which only
+ * iterates over EXISTING claude_sessions rows with sd_key set and so never sees a
+ * session_id that has no row on that side at all -- the exact shape of the reported
+ * leak (test-session-nswcf-fenced claimed two real SDs while never appearing in
+ * claude_sessions).
+ *
+ * Cross-signal guard (validation-agent advisory, referencing the deferred
+ * SD-REFILL-00ZDA5MQ precedent): a reaper trusting claiming_session_id ALONE can
+ * false-release an SD a DIFFERENT live session is legitimately working via a desynced
+ * active_session_id or its own claude_sessions.sd_key pointer. Before reaping, this
+ * checks all three claim signals and only reaps when NONE resolves to a live session --
+ * fails toward NOT reaping on any ambiguity.
+ *
+ * Each successful reap is race-guarded (`.eq('claiming_session_id', phantomId)` on the
+ * UPDATE) and audited to session_lifecycle_events (event_type='PHANTOM_CLAIM_REAPED')
+ * ONLY when the race-guarded update actually affected a row.
+ *
+ * @param {object} supabase - service-role client
+ * @param {{ actions: string[], warnings: string[] }} ctx - sweep-pass accumulators
+ */
+async function reapPhantomSessionClaims(supabase, { actions, warnings }) {
+  const { data: candidateRows } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, claiming_session_id, active_session_id, status')
+    .not('claiming_session_id', 'is', null)
+    .not('status', 'in', '(completed,cancelled)');
+
+  // Never reap a SD-TEST-*/SD-DEMO-*/bare TEST-*/DEMO-* fixture key -- other live-DB test
+  // suites (e.g. claim-sd-cross-table.test.js TS-2) deliberately stamp a non-existent
+  // claiming_session_id on such fixtures mid-test; a concurrently-running production sweep
+  // must not reap that fixture out from under them.
+  const phantomClaimCandidates = (candidateRows || []).filter((sd) => !TEST_FIXTURE_KEY_RE.test(sd.sd_key));
+
+  if (!phantomClaimCandidates.length) return;
+
+  const referencedIds = new Set();
+  for (const sd of phantomClaimCandidates) {
+    if (sd.claiming_session_id) referencedIds.add(sd.claiming_session_id);
+    if (sd.active_session_id) referencedIds.add(sd.active_session_id);
+  }
+  const sdKeysForCrossCheck = phantomClaimCandidates.map((sd) => sd.sd_key);
+
+  const [{ data: liveSessionsById }, { data: liveSessionsByKey }] = await Promise.all([
+    supabase.from('claude_sessions').select('session_id').in('session_id', [...referencedIds]),
+    supabase.from('claude_sessions').select('sd_key').in('sd_key', sdKeysForCrossCheck),
+  ]);
+  const liveIdSet = new Set((liveSessionsById || []).map((s) => s.session_id));
+  const liveKeySet = new Set((liveSessionsByKey || []).map((s) => s.sd_key));
+
+  for (const sd of phantomClaimCandidates) {
+    if (liveIdSet.has(sd.claiming_session_id)) continue; // claiming_session_id has a real row -- not phantom
+    if (sd.active_session_id && liveIdSet.has(sd.active_session_id)) {
+      warnings.push('CLAIM_FIX: skipped phantom-claim reap on ' + sd.sd_key + ' -- claiming_session_id ' + String(sd.claiming_session_id).slice(0, 20) + ' is phantom but active_session_id ' + String(sd.active_session_id).slice(0, 20) + ' is live (cross-signal, not reaping)');
+      continue;
+    }
+    if (liveKeySet.has(sd.sd_key)) {
+      warnings.push('CLAIM_FIX: skipped phantom-claim reap on ' + sd.sd_key + ' -- claiming_session_id ' + String(sd.claiming_session_id).slice(0, 20) + ' is phantom but a live session already holds this SD via its own claude_sessions.sd_key pointer (cross-signal, not reaping)');
+      continue;
+    }
+
+    const phantomId = sd.claiming_session_id;
+    const { data: released, error: reapError } = await supabase
+      .from('strategic_directives_v2')
+      .update({ claiming_session_id: null, active_session_id: null, is_working_on: false })
+      .eq('sd_key', sd.sd_key)
+      .eq('claiming_session_id', phantomId) // race guard: only clear if still held by the same phantom
+      .select('sd_key');
+
+    if (!reapError && released && released.length > 0) {
+      actions.push('CLAIM_FIX: released PHANTOM session ' + String(phantomId).slice(0, 20) + ' claim on ' + sd.sd_key + ' (no claude_sessions row for this session_id)');
+      await supabase.from('session_lifecycle_events').insert({
+        event_type: 'PHANTOM_CLAIM_REAPED',
+        session_id: phantomId,
+        reason: 'phantom_session_no_claude_sessions_row',
+        metadata: { sd_key: sd.sd_key, freed_at: new Date().toISOString() },
+      });
+    }
+  }
+}
+
 async function main() {
   const now = new Date();
   const actions = [];
@@ -1988,6 +2072,14 @@ async function main() {
       actions.push('QA: reset phantom ' + sd.sd_key + ' from in_progress/' + sd.current_phase + '/' + sd.progress_percentage + '% → draft/LEAD/0% (no claiming session)');
     }
   }
+
+  // SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-2/FR-3): reap claims held by a PHANTOM
+  // session. Positioned AFTER the phantom-in_progress reset above and the earlier
+  // terminal-claim clears (FIX #2), so a terminal SD's claiming_session_id is already
+  // NULL by the time this pass runs -- no double-processing. Extracted to a standalone,
+  // exported function (mirroring runClaimBoundaryProbe) so it is directly testable
+  // against real tables without spawning the whole sweep as a child process.
+  await reapPhantomSessionClaims(supabase, { actions, warnings });
 
   // 3e. QA — detect and auto-enrich bare-shell SDs (FIX #6)
   // SD-FDBK-INFRA-QUALITY-GATE-COUPLED-001 (FR-1): metadata is now selected so
@@ -3230,6 +3322,10 @@ module.exports.splitCollidingSessions = splitCollidingSessions;
 // WORK_ASSIGNMENT dispatch so the single-writer gate is unit-testable (assert NO sender_type:'sweep'
 // insert happens when !allowed; insert happens when allowed).
 module.exports.dispatchWorkAssignmentsIfAllowed = dispatchWorkAssignmentsIfAllowed;
+
+// SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-2/FR-3): exported so the integration test drives
+// the real phantom-claim reap against real tables (no mocked gate).
+module.exports.reapPhantomSessionClaims = reapPhantomSessionClaims;
 
 // SD-LEO-INFRA-SWEEP-LEGACY-KILL-SWITCH-RETIRE-001: exported so its shape (owner/condition/
 // retirement_action all present and non-empty) is unit-testable.

--- a/tests/database/claim-sd-phantom-session-guard.test.js
+++ b/tests/database/claim-sd-phantom-session-guard.test.js
@@ -1,0 +1,101 @@
+/**
+ * SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-1) — claim_sd must reject a phantom caller.
+ *
+ * claim_sd never validated that the CALLING p_session_id has a live row in
+ * claude_sessions. Its terminal `UPDATE claude_sessions ... WHERE session_id=p_session_id`
+ * silently no-oped on a missing row, but the paired strategic_directives_v2/quick_fixes
+ * UPDATE ran unconditionally — so a phantom session_id (witnessed live incident:
+ * test-session-nswcf-fenced, zero rows in claude_sessions) could claim a real SD/QF.
+ *
+ * The new guard fires immediately after the advisory lock, BEFORE the sd_not_found /
+ * sd_terminal_status guards and before any FOR UPDATE select — so it applies uniformly
+ * to the SD path and the QF path, and pre-empts every other error this RPC can return.
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips
+ * cleanly without service-role creds.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const RUN_ID = `${Date.now()}-${process.pid}`;
+const PHANTOM_SESSION = `phantom-guard-test-${RUN_ID}`; // deliberately NEVER inserted into claude_sessions
+const REGISTERED_SESSION = `test-claim-phantom-guard-registered-${RUN_ID}`;
+
+describe.skipIf(!HAS_REAL_DB)('claim_sd rejects a phantom caller session (SD-LEO-INFRA-BLOCK-TEST-SESSION-001 FR-1)', () => {
+  beforeAll(async () => {
+    await supabase.from('claude_sessions').upsert({
+      session_id: REGISTERED_SESSION,
+      status: 'idle',
+      heartbeat_at: new Date().toISOString(),
+      machine_id: 'test-machine',
+      terminal_id: `test-${REGISTERED_SESSION}`,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+      sd_key: null,
+    }, { onConflict: 'session_id' });
+    // Guard against test pollution: confirm the phantom id truly has no row.
+    await supabase.from('claude_sessions').delete().eq('session_id', PHANTOM_SESSION);
+  });
+
+  afterAll(async () => {
+    await supabase.from('claude_sessions').delete().eq('session_id', REGISTERED_SESSION);
+    await supabase.from('claude_sessions').delete().eq('session_id', PHANTOM_SESSION);
+  });
+
+  it('rejects a claim from a session_id with no claude_sessions row (SD path)', async () => {
+    const { data: cand } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id').is('claiming_session_id', null).in('status', ['draft', 'active']).limit(1);
+    if (!cand || !cand[0]) return; // env-dependent
+    const key = cand[0].sd_key;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: key, p_session_id: PHANTOM_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('phantom_session');
+    // zero writes: the SD's claiming_session_id is still untouched
+    const { data: after } = await supabase.from('strategic_directives_v2').select('claiming_session_id').eq('sd_key', key).maybeSingle();
+    expect(after?.claiming_session_id ?? null).toBe(cand[0].claiming_session_id ?? null);
+  });
+
+  it('rejects a phantom claim on the QF path the same way', async () => {
+    const { data: qf } = await supabase.from('quick_fixes').select('id, claiming_session_id')
+      .is('claiming_session_id', null).not('status', 'in', '(completed,cancelled,escalated)').limit(1);
+    if (!qf || !qf[0]) return; // env-dependent
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: qf[0].id, p_session_id: PHANTOM_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('phantom_session');
+  });
+
+  it('phantom_session guard fires BEFORE sd_not_found (guard ordering)', async () => {
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: 'SD-FAKE-PROBE-PHANTOM-GUARD-000', p_session_id: PHANTOM_SESSION, p_track: null });
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('phantom_session'); // NOT sd_not_found — the caller-identity guard pre-empts it
+  });
+
+  it('does NOT reject a claim from a real registered session (no false positive)', async () => {
+    const { data: cand } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, active_session_id, is_working_on')
+      .is('claiming_session_id', null).in('status', ['draft', 'active']).limit(1);
+    if (!cand || !cand[0]) return; // env-dependent
+    const key = cand[0].sd_key;
+    const { data } = await supabase.rpc('claim_sd', { p_sd_id: key, p_session_id: REGISTERED_SESSION, p_track: null });
+    expect(data?.success).toBe(true);
+    // restore (net-zero)
+    await supabase.from('strategic_directives_v2').update({
+      claiming_session_id: cand[0].claiming_session_id,
+      active_session_id: cand[0].active_session_id,
+      is_working_on: cand[0].is_working_on,
+    }).eq('sd_key', key);
+    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', REGISTERED_SESSION);
+  });
+});

--- a/tests/database/claim-sd-terminal-status.test.js
+++ b/tests/database/claim-sd-terminal-status.test.js
@@ -7,11 +7,16 @@
  * BEFORE any write for terminal SDs (completed/cancelled/deferred) and terminal QFs
  * (completed/cancelled/escalated) — while leaving real claims and the existence guard intact.
  *
+ * SD-LEO-INFRA-BLOCK-TEST-SESSION-001: claim_sd now ALSO rejects any caller session_id with
+ * no live claude_sessions row (a PHANTOM caller), fired before this suite's own terminal-status
+ * and sd_not_found guards. PROBE_SESSION must therefore be a real registered session for every
+ * assertion in this file, not just the happy-path claim.
+ *
  * Live-DB integration test, gated like the other tests/database suites so CI skips cleanly
  * without service-role creds. The guard fires before any UPDATE, so the terminal probes are
  * inherently net-zero (asserted explicitly).
  */
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 import 'dotenv/config';
 
@@ -35,8 +40,21 @@ async function firstSdWithStatus(status) {
 }
 
 describe.skipIf(!HAS_REAL_DB)('claim_sd rejects terminal-status items (SD-LEO-FIX-CLAIM-RPC-TERMINAL-001)', () => {
+  beforeAll(async () => {
+    await supabase.from('claude_sessions').upsert({
+      session_id: PROBE_SESSION,
+      status: 'idle',
+      heartbeat_at: new Date().toISOString(),
+      machine_id: 'test-machine',
+      terminal_id: `test-${PROBE_SESSION}`,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+      sd_key: null,
+    }, { onConflict: 'session_id' });
+  });
+
   afterAll(async () => {
-    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+    await supabase.from('claude_sessions').delete().eq('session_id', PROBE_SESSION);
   });
 
   it('rejects a completed SD with sd_terminal_status and does NOT stomp claiming_session_id', async () => {

--- a/tests/database/claim-sd-validate-exists.test.js
+++ b/tests/database/claim-sd-validate-exists.test.js
@@ -7,10 +7,16 @@
  * quick_fixes.id) that returns {success:false, error:'sd_not_found'} for phantom ids —
  * while leaving real claims (and the takeover/QF/cross-table logic) unchanged.
  *
+ * SD-LEO-INFRA-BLOCK-TEST-SESSION-001: claim_sd now ALSO rejects any caller session_id
+ * with no live claude_sessions row (a PHANTOM caller), fired before this suite's own
+ * sd_not_found guard. PROBE_SESSION must therefore be a real registered session for
+ * every assertion in this file, not just the happy-path claim — mirroring the
+ * convention already used in claim-sd-refuse-live-foreign.test.js / claim-sd-cross-table.test.js.
+ *
  * Live-DB integration test, gated like the other tests/database suites so CI skips
  * cleanly without service-role creds.
  */
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 import 'dotenv/config';
 
@@ -28,8 +34,21 @@ const HAS_REAL_DB = process.env.SUPABASE_URL
 const PROBE_SESSION = 'test-claim-validate-exists-session';
 
 describe.skipIf(!HAS_REAL_DB)('claim_sd rejects non-existent ids (SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001)', () => {
+  beforeAll(async () => {
+    await supabase.from('claude_sessions').upsert({
+      session_id: PROBE_SESSION,
+      status: 'idle',
+      heartbeat_at: new Date().toISOString(),
+      machine_id: 'test-machine',
+      terminal_id: `test-${PROBE_SESSION}`,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+      sd_key: null,
+    }, { onConflict: 'session_id' });
+  });
+
   afterAll(async () => {
-    await supabase.from('claude_sessions').update({ sd_key: null }).eq('session_id', PROBE_SESSION);
+    await supabase.from('claude_sessions').delete().eq('session_id', PROBE_SESSION);
   });
 
   it('returns sd_not_found for a non-existent SD id (no phantom self-claim)', async () => {

--- a/tests/integration/phantom-session-reap.integration.test.js
+++ b/tests/integration/phantom-session-reap.integration.test.js
@@ -1,0 +1,147 @@
+/**
+ * phantom-session-reap.integration.test.js — SD-LEO-INFRA-BLOCK-TEST-SESSION-001 (FR-2/FR-3)
+ *
+ * Drives the REAL reapPhantomSessionClaims pass (exported from stale-session-sweep.cjs)
+ * against REAL tables — no mocked gate (test-masking lesson: mocking the gate ships green
+ * on dead code). Covers: a genuinely orphaned claim gets released + audited; the
+ * cross-signal guard refuses to reap when a DIFFERENT live session references the SD via
+ * active_session_id; a claim held by a live registered session is left untouched; the
+ * pass is idempotent across two runs.
+ *
+ * Isolation: every fixture id carries a unique per-run RUN_ID, cleaned in afterAll.
+ * Fixture SD keys deliberately do NOT match TEST_FIXTURE_KEY_RE (SD-/DEMO-/TEST- prefix)
+ * so reapPhantomSessionClaims's own fixture-key exclusion does not skip them.
+ *
+ * LIVE-gated: skips (not fails) without Supabase creds so hermetic CI stays green.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const HAS_DB = !!((process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+  && process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const RUN_ID = `${Date.now()}-${process.pid}`;
+const SD_PHANTOM_ONLY = `SD-PHANTOMREAP-ONLY-${RUN_ID}`;
+const SD_CROSS_SIGNAL = `SD-PHANTOMREAP-XSIG-${RUN_ID}`;
+const SD_LIVE_CLAIM = `SD-PHANTOMREAP-LIVE-${RUN_ID}`;
+const PHANTOM_ID_A = `phantomreap-phantom-a-${RUN_ID}`; // never inserted into claude_sessions
+const PHANTOM_ID_B = `phantomreap-phantom-b-${RUN_ID}`; // never inserted into claude_sessions
+const LIVE_SESSION = `phantomreap-live-session-${RUN_ID}`; // real registered session
+
+describe.skipIf(!HAS_DB)('reapPhantomSessionClaims (LIVE tables, ephemeral fixtures)', () => {
+  let sb;
+  let reapPhantomSessionClaims;
+
+  function fixtureSd(key, { claiming_session_id, active_session_id, is_working_on }) {
+    return {
+      id: crypto.randomUUID(),
+      sd_key: key,
+      title: `[fixture] phantom-reap integration test ${RUN_ID}`,
+      description: 'Ephemeral integration fixture — safe to delete on sight.',
+      rationale: 'FR-2/FR-3 live phantom-reap coverage.',
+      status: 'draft',
+      current_phase: 'LEAD',
+      sd_type: 'infrastructure',
+      category: 'Infrastructure',
+      priority: 'low',
+      scope: 'ephemeral test fixture',
+      target_application: 'EHG_Engineer',
+      success_criteria: [{ criterion: 'fixture', measure: 'n/a' }],
+      claiming_session_id,
+      active_session_id,
+      is_working_on,
+    };
+  }
+
+  beforeAll(async () => {
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    sb = createSupabaseServiceClient();
+    ({ reapPhantomSessionClaims } = require('../../scripts/stale-session-sweep.cjs'));
+
+    await sb.from('claude_sessions').upsert({
+      session_id: LIVE_SESSION,
+      status: 'active',
+      heartbeat_at: new Date().toISOString(),
+      machine_id: 'test-machine',
+      terminal_id: `test-${LIVE_SESSION}`,
+      hostname: 'test-host',
+      codebase: 'EHG_Engineer',
+    }, { onConflict: 'session_id' });
+
+    const { error: sdErr } = await sb.from('strategic_directives_v2').insert([
+      fixtureSd(SD_PHANTOM_ONLY, { claiming_session_id: PHANTOM_ID_A, active_session_id: PHANTOM_ID_A, is_working_on: true }),
+      fixtureSd(SD_CROSS_SIGNAL, { claiming_session_id: PHANTOM_ID_B, active_session_id: LIVE_SESSION, is_working_on: true }),
+      fixtureSd(SD_LIVE_CLAIM, { claiming_session_id: LIVE_SESSION, active_session_id: LIVE_SESSION, is_working_on: true }),
+    ]);
+    expect(sdErr, `strategic_directives_v2 fixture insert: ${sdErr?.message}`).toBeNull();
+  }, 30000);
+
+  afterAll(async () => {
+    await sb.from('strategic_directives_v2').delete().in('sd_key', [SD_PHANTOM_ONLY, SD_CROSS_SIGNAL, SD_LIVE_CLAIM]);
+    await sb.from('claude_sessions').delete().eq('session_id', LIVE_SESSION);
+    await sb.from('session_lifecycle_events').delete().in('session_id', [PHANTOM_ID_A, PHANTOM_ID_B]);
+  }, 30000);
+
+  async function getSdClaimState(key) {
+    const { data } = await sb.from('strategic_directives_v2')
+      .select('claiming_session_id, active_session_id, is_working_on').eq('sd_key', key).single();
+    return data;
+  }
+
+  it('TS-5: reaps a genuinely orphaned claim, co-nulling all three claim columns, and audits it', async () => {
+    const actions = [];
+    const warnings = [];
+    await reapPhantomSessionClaims(sb, { actions, warnings });
+
+    const after = await getSdClaimState(SD_PHANTOM_ONLY);
+    expect(after.claiming_session_id).toBeNull();
+    expect(after.active_session_id).toBeNull();
+    expect(after.is_working_on).toBe(false);
+    expect(actions.some((a) => a.includes(SD_PHANTOM_ONLY))).toBe(true);
+
+    const { data: events } = await sb.from('session_lifecycle_events')
+      .select('event_type, metadata').eq('session_id', PHANTOM_ID_A);
+    expect(events.some((e) => e.event_type === 'PHANTOM_CLAIM_REAPED' && e.metadata?.sd_key === SD_PHANTOM_ONLY)).toBe(true);
+  }, 20000);
+
+  it('TS-6/cross-signal: does NOT reap when active_session_id points to a DIFFERENT live session', async () => {
+    const actions = [];
+    const warnings = [];
+    await reapPhantomSessionClaims(sb, { actions, warnings });
+
+    const after = await getSdClaimState(SD_CROSS_SIGNAL);
+    expect(after.claiming_session_id).toBe(PHANTOM_ID_B); // untouched — cross-signal guard fired
+    expect(after.active_session_id).toBe(LIVE_SESSION);
+    expect(warnings.some((w) => w.includes(SD_CROSS_SIGNAL))).toBe(true);
+
+    const { data: events } = await sb.from('session_lifecycle_events')
+      .select('id').eq('session_id', PHANTOM_ID_B);
+    expect(events.length).toBe(0); // no audit row for a claim that was not reaped
+  }, 20000);
+
+  it('TS-7: leaves a claim held by a live registered session untouched', async () => {
+    const actions = [];
+    const warnings = [];
+    await reapPhantomSessionClaims(sb, { actions, warnings });
+
+    const after = await getSdClaimState(SD_LIVE_CLAIM);
+    expect(after.claiming_session_id).toBe(LIVE_SESSION);
+    expect(after.is_working_on).toBe(true);
+  }, 20000);
+
+  it('TS-8: idempotent — a second run finds nothing left to reap for the already-cleared SD', async () => {
+    const actionsFirst = [];
+    await reapPhantomSessionClaims(sb, { actions: actionsFirst, warnings: [] });
+    expect(actionsFirst.some((a) => a.includes(SD_PHANTOM_ONLY))).toBe(false); // already cleared by TS-5
+
+    const actionsSecond = [];
+    await reapPhantomSessionClaims(sb, { actions: actionsSecond, warnings: [] });
+    expect(actionsSecond.some((a) => a.includes(SD_PHANTOM_ONLY))).toBe(false);
+
+    const { data: events } = await sb.from('session_lifecycle_events')
+      .select('id').eq('session_id', PHANTOM_ID_A);
+    expect(events.length).toBe(1); // still exactly one audit row from the original TS-5 reap
+  }, 20000);
+});


### PR DESCRIPTION
## Summary
- `claim_sd()` never validated that the calling `p_session_id` has a live `claude_sessions` row — a phantom/never-registered session (witnessed incident: `test-session-nswcf-fenced`) could claim real SDs/QFs. Adds a `phantom_session` existence guard immediately after the advisory lock, mirroring `release_session()`'s existing `session_not_found` idiom. Signature unchanged (`CREATE OR REPLACE`). **Already applied to production** via `apply-migration.js --prod-deploy`.
- Adds `reapPhantomSessionClaims()` to `scripts/stale-session-sweep.cjs`: detects an already-leaked phantom claim (antijoin against `claude_sessions`), cross-signal-guarded (checks `claiming_session_id`, `active_session_id`, and `claude_sessions.sd_key` before reaping — never false-releases a claim a *different* live session legitimately holds), race-guarded release, audited via `session_lifecycle_events`.
- Updates the two live-DB tests that relied on the pre-fix gap (`claim-sd-validate-exists.test.js`, `claim-sd-terminal-status.test.js`) to register their probe session first.
- A candidate `test-session-*-fenced` regex fence was considered and dropped after discovering `tests/database/seat-busy-fence.test.js` legitimately registers a real row for that exact literal session id — the NOT-EXISTS check alone is durable and doesn't collide with it (verified: seat-busy-fence still passes).

## Test plan
- [x] New `tests/database/claim-sd-phantom-session-guard.test.js` (4 tests) — run against live DB, all pass
- [x] New `tests/integration/phantom-session-reap.integration.test.js` (4 tests) — run against live DB, all pass
- [x] Regression: `claim-sd-validate-exists`, `claim-sd-terminal-status`, `claim-sd-cross-table`, `claim-sd-refuse-live-foreign` (20 tests) — all pass
- [x] `seat-busy-fence.test.js` (the specifically-protected test) — 2/2 pass
- [x] LEAD/PLAN/EXEC sub-agent evidence: RISK, DATABASE, TESTING, VALIDATION, Explore, SECURITY all PASS/CONDITIONAL_PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)