### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002): keep fixture-venture decisions off every chairman surface

### DIFF
--- a/database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql
+++ b/database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql
@@ -1,0 +1,99 @@
+-- SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-2)
+-- Extend the fixture-venture exclusion in get_pending_chairman_items() with the
+-- realdb-suite fixture families that leaked into the chairman digest
+-- ("HCGate-RealDB-unclassified-noop-<ts>" et al., RCA Adam 2026-07-16), plus the
+-- write-guard families from lib/eva/chairman-decision-watcher.js so every chairman
+-- SURFACE excludes them (the watcher deliberately stays narrower at its WRITE seam).
+--
+-- LOCKSTEP: this pattern list mirrors FIXTURE_NAME_PATTERNS in
+-- lib/chairman/chairman-actionable.mjs — change BOTH in the same PR; pinned by
+-- tests/integration/get-pending-chairman-items.contract.test.js parity assertions.
+--
+-- Everything except the fixture-exclusion block is byte-identical to
+-- database/migrations/20260710_create_get_pending_chairman_items.sql.
+--
+-- APPLY (chairman-gated, requires_chairman_apply — same standing policy as the
+-- 20260710 original):
+--   node scripts/apply-migration.js database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql --prod-deploy
+--   with the chairman @approved-by stamp.
+--
+-- ROLLBACK: re-apply database/migrations/20260710_create_get_pending_chairman_items.sql
+-- (restores the previous pattern list; function signature unchanged).
+
+CREATE OR REPLACE FUNCTION public.get_pending_chairman_items(
+  p_decision_type text DEFAULT NULL,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+WITH actionable AS (
+  SELECT d.*
+  FROM public.chairman_pending_decisions d
+  LEFT JOIN public.ventures v ON v.id = d.venture_id
+  WHERE d.status = 'pending'
+    AND (
+      d.decision_type IN ('chairman_approval', 'gate_decision')
+      OR (d.decision_type IN ('escalation', 'okr_acceptance') AND d.blocking IS TRUE)
+    )
+    -- Fixture exclusion: exclude only rows POSITIVELY identified as fixture-linked.
+    -- COALESCE(..., false) makes NULL venture name / dangling reference / RLS-invisible
+    -- venture resolve to INCLUDE — a real pending decision must never vanish because its
+    -- venture row is missing or unreadable (adversarial-review W2).
+    -- SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: extended with '%-realdb-%', '%-noop-%',
+    -- 'parity-test-%', 'test-stub%', 'test-harness-%', 'ts-fixture-%',
+    -- '\_pipeline\_test\_%', 'pipeline-test-%', 'gate-test-%' (real-path test suites whose
+    -- ventures deliberately stay is_demo=false so decision minting works; surfaces filter them).
+    AND NOT COALESCE(
+      v.is_demo IS TRUE
+      OR v.name LIKE '\_\_%'
+      OR v.name ILIKE 'test venture%'
+      OR v.name ILIKE '%citest%'
+      OR v.name ILIKE 'canonical-source-test%'
+      OR v.name ILIKE '%-realdb-%'
+      OR v.name ILIKE '%-noop-%'
+      OR v.name ILIKE 'parity-test-%'
+      OR v.name ILIKE 'test-stub%'
+      OR v.name ILIKE 'test-harness-%'
+      OR v.name ILIKE 'ts-fixture-%'
+      OR v.name ILIKE '\_pipeline\_test\_%'
+      OR v.name ILIKE 'pipeline-test-%'
+      OR v.name ILIKE 'gate-test-%'
+    , false)
+    AND (p_decision_type IS NULL OR d.decision_type = p_decision_type)
+),
+page AS (
+  SELECT *
+  FROM actionable
+  ORDER BY
+    CASE effective_priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+    created_at ASC,
+    id ASC -- unique tiebreaker: LIMIT/OFFSET pages must be deterministic (adversarial-review W1)
+  LIMIT LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1) - 1)::bigint * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
+)
+SELECT jsonb_build_object(
+  'items', COALESCE(
+    (SELECT jsonb_agg(
+       to_jsonb(page.*)
+       || jsonb_build_object('deadline', page.response_deadline, 'summary', page.recommendation)
+     ) FROM page),
+    '[]'::jsonb
+  ),
+  'total', (SELECT count(*) FROM actionable),
+  'page', GREATEST(COALESCE(p_page, 1), 1),
+  'page_size', LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200)
+);
+$$;
+
+-- Least-privilege: strip the Postgres default PUBLIC EXECUTE before granting (security-agent review).
+REVOKE EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_pending_chairman_items(text, integer, integer) TO service_role;
+
+COMMENT ON FUNCTION public.get_pending_chairman_items(text, integer, integer) IS
+'Canonical chairman-actionable pending-items source (SD-EHG-CONSOLE-PENDING-ITEMS-RPC-001; fixture patterns extended by SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002). Predicate is the shared artifact for QUEUE-POLLUTION-001 / PENDING-COUNT-SSOT-001 — change it here first. Envelope: {items,total,page,page_size}.';

--- a/lib/chairman/chairman-actionable.mjs
+++ b/lib/chairman/chairman-actionable.mjs
@@ -25,13 +25,34 @@ export const CONSOLE_BLOCKING_ONLY_TYPES = Object.freeze(['escalation', 'okr_acc
 /** Machine-telemetry decision types deliberately NOT chairman-actionable (never escalate/email). */
 export const TELEMETRY_DECISION_TYPES = Object.freeze(['flag_review', 'flag_enablement']);
 
-/** Fixture-venture name patterns (mirrors the SQL: is_demo, '__%', 'test venture%', '%citest%', 'canonical-source-test%'). */
-const FIXTURE_NAME_PATTERNS = [
+/**
+ * Fixture-venture name patterns (mirrors the SQL: is_demo, '__%', 'test venture%',
+ * '%citest%', 'canonical-source-test%', '%-realdb-%', '%-noop-%', 'parity-test-%',
+ * 'test-stub%', 'test-harness-%', 'ts-fixture-%', '\_pipeline\_test\_%',
+ * 'pipeline-test-%', 'gate-test-%').
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: extended with the HCGate-RealDB-* /
+ * *-noop-<ts> realdb-suite families that leaked into the chairman digest, plus the
+ * write-guard families from lib/eva/chairman-decision-watcher.js so every SURFACE
+ * excludes them too (the watcher deliberately stays narrower at the WRITE seam —
+ * see its doc comment; surfaces filter what its carve-outs let through).
+ * Exported for the JS↔SQL pattern-parity test — keep in lockstep with the
+ * canonical SQL (latest get_pending_chairman_items migration).
+ */
+export const FIXTURE_NAME_PATTERNS = Object.freeze([
   /^__/i,
   /^test venture/i,
   /citest/i,
   /^canonical-source-test/i,
-];
+  /-realdb-/i,
+  /-noop-/i,
+  /^parity-test-/i,
+  /^test-stub/i,
+  /^test-harness-/i,
+  /^ts-fixture-/i,
+  /^_pipeline_test_/i,
+  /^pipeline-test-/i,
+  /^gate-test-/i,
+]);
 
 /**
  * Is this venture a fixture (demo/test) venture? NULL/unreadable venture resolves to

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -23,6 +23,7 @@ import { spawn as nodeSpawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { isWithinChairmanQuietWindow } from '../notifications/resend-adapter.js';
+import { isFixtureVenture } from './chairman-actionable.mjs';
 
 const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'pause']);
 
@@ -198,11 +199,27 @@ export async function recordPendingDecision(supabase, {
   ventureId = null,
   lifecycleStage = 0,
   raisedBy = null,
+  allowFixture = false,
   _spawnEscalation,
   _quietWindow,
 } = {}) {
   if (!supabase) return { recorded: false, error: 'supabase client is required' };
   if (!title) return { recorded: false, error: 'title is required' };
+
+  // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-4): fixture ventures never enter the
+  // chairman queue at source. Fail-open — a venture-lookup error must never drop a REAL
+  // decision, so only a POSITIVE fixture identification skips the insert. Tests that
+  // deliberately mint decisions on fixture ventures pass allowFixture: true.
+  if (ventureId && !allowFixture) {
+    try {
+      const { data: v, error: vErr } = await supabase
+        .from('ventures').select('id, name, is_demo').eq('id', ventureId).maybeSingle();
+      if (!vErr && v && isFixtureVenture(v)) {
+        console.log(`[record-pending-decision] fixture venture ${v.name} — decision "${title}" not recorded (allowFixture to override)`);
+        return { recorded: false, skipped_fixture: true };
+      }
+    } catch { /* fail-open: lookup failure never blocks a real decision */ }
+  }
 
   const briefData = {
     title,

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -216,7 +216,10 @@ export async function recordPendingDecision(supabase, {
         .from('ventures').select('id, name, is_demo').eq('id', ventureId).maybeSingle();
       if (!vErr && v && isFixtureVenture(v)) {
         console.log(`[record-pending-decision] fixture venture ${v.name} — decision "${title}" not recorded (allowFixture to override)`);
-        return { recorded: false, skipped_fixture: true };
+        // error is a descriptive skip reason so callers that branch on recorded/error
+        // (e.g. stage-22's NC-7 loud-failure marker) report the guard, not an
+        // "unknown insert failure" (adversarial-review W1).
+        return { recorded: false, skipped_fixture: true, error: 'skipped: fixture venture is not chairman-actionable (pass allowFixture to override)' };
       }
     } catch { /* fail-open: lookup failure never blocks a real decision */ }
   }

--- a/scripts/adam-decision-email.mjs
+++ b/scripts/adam-decision-email.mjs
@@ -91,8 +91,14 @@ try {
 // console-superset that admits blocking non-console rows — plus the shared fixture
 // exclusion). No chairman surface is more permissive than this pair; before this filter,
 // fixture decisions the console correctly hid still reached the chairman by email.
+// PRIMARY EXEMPTION (adversarial-review CRITICAL): the --decision row is exempt from the
+// ACTIONABILITY leg only — its spawner already decided it deserves this email (e.g.
+// chairman-product-review escalates non-blocking product_review rows that no other surface
+// carries, and escalation_email_sent_at is stamped at spawn, so dropping it here would
+// strand the decision on every surface with no retry). The FIXTURE leg still applies to the
+// primary — the HCGate flood specimen was itself a --decision primary and must stay filtered.
 const preActionable = rows.length;
-rows = rows.filter((r) => isEscalationActionable(r) && !fixtureVentureIds.has(r.venture_id));
+rows = rows.filter((r) => (isEscalationActionable(r) || r.id === primaryId) && !fixtureVentureIds.has(r.venture_id));
 const nonActionableCount = preActionable - rows.length;
 if (nonActionableCount > 0) console.log(`[adam-decision-email] ${nonActionableCount} non-actionable/fixture row(s) excluded by shared predicate`);
 if (rows.length === 0) {

--- a/scripts/adam-decision-email.mjs
+++ b/scripts/adam-decision-email.mjs
@@ -15,6 +15,7 @@ import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { renderLeanDecisionEmail, filterStaleLeanDecisions, DEAD_VENTURE_STATUSES } from '../lib/chairman/decision-layman.mjs';
+import { isEscalationActionable, isFixtureVenture } from '../lib/chairman/chairman-actionable.mjs';
 import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
 import { isWithinChairmanQuietWindow } from '../lib/notifications/resend-adapter.js';
 
@@ -70,16 +71,34 @@ if (rows.length === 0) {
 // 2026-07-02: 9 of 12 pending rows were such noise. Fail-soft: a venture-status lookup error simply
 // skips the filter (show all), mirroring adam-exec-summary.mjs's dead-venture pattern.
 let deadVentureIds = new Set();
+let fixtureVentureIds = new Set();
 try {
   const vids = [...new Set(rows.filter((r) => r.venture_id).map((r) => r.venture_id))];
   if (vids.length) {
-    const { data: vrows, error: vErr } = await db.from('ventures').select('id, status').in('id', vids);
+    const { data: vrows, error: vErr } = await db.from('ventures').select('id, status, name, is_demo').in('id', vids);
     if (!vErr) {
       const found = new Set((vrows || []).map((v) => v.id));
       deadVentureIds = new Set(vids.filter((id) => !found.has(id) || (vrows || []).some((v) => v.id === id && DEAD_VENTURE_STATUSES.has(String(v.status || '').toLowerCase()))));
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-1): fixture ventures resolve fail-INCLUDE
+      // (missing/unreadable venture row is NOT treated as a fixture), matching the console RPC.
+      fixtureVentureIds = new Set((vrows || []).filter((v) => isFixtureVenture(v)).map((v) => v.id));
     }
   }
 } catch (e) { console.warn('[adam-decision-email] venture-status filter skipped (fail-soft): ' + (e?.message || e)); }
+
+// SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-1): the digest applies the SAME
+// chairman-actionable predicate as the SLA sweep (isEscalationActionable — the documented
+// console-superset that admits blocking non-console rows — plus the shared fixture
+// exclusion). No chairman surface is more permissive than this pair; before this filter,
+// fixture decisions the console correctly hid still reached the chairman by email.
+const preActionable = rows.length;
+rows = rows.filter((r) => isEscalationActionable(r) && !fixtureVentureIds.has(r.venture_id));
+const nonActionableCount = preActionable - rows.length;
+if (nonActionableCount > 0) console.log(`[adam-decision-email] ${nonActionableCount} non-actionable/fixture row(s) excluded by shared predicate`);
+if (rows.length === 0) {
+  console.log('[adam-decision-email] no chairman-actionable decisions after predicate — nothing to send');
+  process.exit(0);
+}
 const { kept, excludedCount } = filterStaleLeanDecisions(rows, { deadVentureIds, primaryId });
 
 const { subject, lines } = renderLeanDecisionEmail(kept, new Date(), { primaryId });

--- a/scripts/backfill-fixture-venture-flags.mjs
+++ b/scripts/backfill-fixture-venture-flags.mjs
@@ -61,3 +61,8 @@ if (updErr) {
   process.exit(1);
 }
 console.log(`Flagged ${candidates.length} venture(s) is_demo=true.`);
+// Durable audit trail: every flipped row had is_demo != true before this run, so this
+// line IS the rollback recipe (adversarial-review W2 — is_demo semantics are system-wide,
+// not chairman-only; a wrongly-flagged real venture must be recoverable).
+console.log('ROLLBACK (if any row above is a real venture): node -e "supabase.from(\'ventures\').update({is_demo:false}).in(\'id\',[...])" with ids:');
+console.log(JSON.stringify(candidates.map((v) => v.id)));

--- a/scripts/backfill-fixture-venture-flags.mjs
+++ b/scripts/backfill-fixture-venture-flags.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * backfill-fixture-venture-flags.mjs — SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-3)
+ *
+ * Flags leaked fixture ventures (created is_demo=false by test suites/harnesses)
+ * as is_demo=true so every chairman surface excludes them STRUCTURALLY instead of
+ * by name-regex alone. Targets only ventures whose name matches the canonical
+ * FIXTURE_NAME_PATTERNS (lib/chairman/chairman-actionable.mjs) while is_demo is
+ * not already true — i.e. rows the surface predicate already treats as fixtures,
+ * so flagging them changes no surface behavior, only makes it durable.
+ *
+ * DRY-RUN BY DEFAULT: prints the candidate list and exits. Pass --apply to write.
+ * Idempotent: a second --apply run finds zero candidates.
+ *
+ * Run:  node scripts/backfill-fixture-venture-flags.mjs [--apply]
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { isFixtureVenture } from '../lib/chairman/chairman-actionable.mjs';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const APPLY = process.argv.includes('--apply');
+
+const { data: ventures, error } = await supabase
+  .from('ventures')
+  .select('id, name, is_demo, created_at')
+  .not('is_demo', 'is', true);
+
+if (error) {
+  console.error('Fetch failed:', error.message);
+  process.exit(1);
+}
+
+const candidates = (ventures || []).filter((v) => isFixtureVenture({ ...v, is_demo: false }));
+
+console.log(`${candidates.length} unflagged fixture venture(s) matching canonical name patterns:`);
+for (const v of candidates) console.log(`  ${v.id}  ${v.created_at}  ${v.name}`);
+
+if (!APPLY) {
+  console.log(candidates.length ? '\nDry-run only — re-run with --apply to set is_demo=true on the rows above.' : '\nNothing to do.');
+  process.exit(0);
+}
+
+if (candidates.length === 0) {
+  console.log('Nothing to apply.');
+  process.exit(0);
+}
+
+const { error: updErr } = await supabase
+  .from('ventures')
+  .update({ is_demo: true })
+  .in('id', candidates.map((v) => v.id));
+
+if (updErr) {
+  console.error('Update failed:', updErr.message);
+  process.exit(1);
+}
+console.log(`Flagged ${candidates.length} venture(s) is_demo=true.`);

--- a/tests/integration/artifact-gate.test.js
+++ b/tests/integration/artifact-gate.test.js
@@ -61,6 +61,7 @@ describe.skipIf(!HAS_REAL_DB)('fn_advance_venture_stage artifact precondition ga
       .from('ventures')
       .insert({
         name: `artifact-gate-test-${Date.now()}`,
+        is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
         current_lifecycle_stage: 1,
         status: 'active',
         problem_statement: 'Test venture for artifact gate integration tests'

--- a/tests/integration/eva/chairman-product-review-gate-realdb.test.js
+++ b/tests/integration/eva/chairman-product-review-gate-realdb.test.js
@@ -45,7 +45,7 @@ import { resolve } from 'path';
 // `node scripts/adam-decision-email.mjs` spawn) as a production feature (FR-4: never strand a
 // venture with nobody having asked the chairman). That side effect must NEVER fire from an
 // automated test run -- it would attempt to send a real chairman email referencing a disposable
-// __e2e_product_review_gate_* venture on every CI execution. The wiring itself (does _advanceStage
+// ProductReviewGate-RealDB-* venture on every CI execution. The wiring itself (does _advanceStage
 // call requestProductReview on block, does it NOT call it on release) is already covered by fully
 // mocked unit tests (tests/unit/eva/stage-execution-worker-product-review-gate.test.js); this
 // integration test's job is the GATE mechanics against real Postgres constraints, not the
@@ -77,7 +77,12 @@ async function createVenture(tag) {
   const { data, error } = await supabase
     .from('ventures')
     .insert({
-      name: `__e2e_product_review_gate_${tag}_${ts}__`,
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: renamed off the watcher's FIXTURE_VENTURE_NAME_RE
+      // (QF-20260710-243 widened it to match __e2e_*, latently breaking the sanity pin below) onto
+      // the HCGate suite's *-RealDB-* convention: misses the WRITE-guard regex (real code path
+      // preserved) while the extended SURFACE patterns ('%-realdb-%') cover any interrupted-teardown
+      // residue so it can never reach the chairman queue/digest.
+      name: `ProductReviewGate-RealDB-${tag}-${ts}`,
       problem_statement: 'Disposable venture for SD-LEO-INFRA-CHAIRMAN-PRODUCT-REVIEW-001 real-DB gate test',
       current_lifecycle_stage: 23,
       is_demo: false,

--- a/tests/integration/eva/fn-advance-venture-stage-canonical-source.test.js
+++ b/tests/integration/eva/fn-advance-venture-stage-canonical-source.test.js
@@ -50,6 +50,7 @@ describe.skipIf(!HAS_REAL_DB)('fn_advance_venture_stage canonical artifact sourc
       .from('ventures')
       .insert({
         name: `canonical-source-test-${Date.now()}`,
+        is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
         current_lifecycle_stage: 22,
         status: 'active',
         problem_statement: 'Integration test for FR-2 canonical artifact source migration',

--- a/tests/integration/eva/stage-advancement-artifact-gate-realdb.test.js
+++ b/tests/integration/eva/stage-advancement-artifact-gate-realdb.test.js
@@ -40,7 +40,9 @@ async function createVenture(tag) {
   const { data, error } = await supabase
     .from('ventures')
     .insert({
-      name: `__e2e_stage_artifact_gate_${tag}_${ts}__`,
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: *-RealDB-* convention — misses the write-guard
+      // regex (real path preserved), matches the extended surface patterns (residue protected).
+      name: `StageArtifactGate-RealDB-${tag}-${ts}`,
       problem_statement: 'Disposable venture for SD-LEO-INFRA-STAGE-ADVANCEMENT-ARTIFACT-001 real-DB gate test',
       current_lifecycle_stage: FIXTURE_STAGE,
       is_demo: false,

--- a/tests/integration/financial-engine-api.test.js
+++ b/tests/integration/financial-engine-api.test.js
@@ -79,6 +79,7 @@ describe.skipIf(!HAS_REAL_DB)('Financial Engine API', () => {
     const { error: ventureError } = await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Test Venture for Financial Engine',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'Test problem statement for financial engine API tests',
       current_lifecycle_stage: 1,

--- a/tests/integration/legal-doc-producer-activation.test.js
+++ b/tests/integration/legal-doc-producer-activation.test.js
@@ -54,6 +54,7 @@ describe.skipIf(!HAS_REAL_DB)('Legal-doc producer activation invariant (SD-FDBK-
     const { error: ventureError } = await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Activation Invariant Test Venture',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'legal-doc-producer activation invariant integration test',
       value_proposition: 'Proves the schema-worker-consumer chain end to end',

--- a/tests/integration/marketing-distribution-api.test.js
+++ b/tests/integration/marketing-distribution-api.test.js
@@ -73,6 +73,7 @@ describe.skipIf(!HAS_REAL_DB)('Marketing Distribution API', () => {
     const { error: ventureError } = await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Test Venture for Marketing',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'Test problem statement',
       current_lifecycle_stage: 1,

--- a/tests/integration/marketing-producer-binding.test.js
+++ b/tests/integration/marketing-producer-binding.test.js
@@ -51,6 +51,7 @@ describe.skipIf(!HAS_REAL_DB)('Marketing Producer Binding (SD-EHG-MARKETING-DIST
     const { error: ventureError } = await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Test Venture for Producer Binding',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'Producer binding integration test',
       current_lifecycle_stage: 1,

--- a/tests/integration/marketlens-owned-audience-loop.test.js
+++ b/tests/integration/marketlens-owned-audience-loop.test.js
@@ -51,6 +51,7 @@ describe.skipIf(!HAS_REAL_DB)('MarketLens Owned-Audience Content Loop (integrati
     await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Test Venture for Owned-Audience Loop',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'Test problem statement',
       current_lifecycle_stage: 24,

--- a/tests/integration/naming-engine-api.test.js
+++ b/tests/integration/naming-engine-api.test.js
@@ -77,6 +77,7 @@ describe.skipIf(!HAS_REAL_DB)('Naming Engine API', () => {
     const { error: ventureError } = await supabase.from('ventures').insert({
       id: testVentureId,
       name: 'Test Venture for Naming Engine',
+      is_demo: true, // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002: fixture flagged at creation
       company_id: testCompanyId,
       problem_statement: 'Test problem statement for naming engine API tests',
       current_lifecycle_stage: 1,

--- a/tests/integration/sd-completed-handler.test.js
+++ b/tests/integration/sd-completed-handler.test.js
@@ -63,7 +63,7 @@ async function createTestVenture() {
 
   const { data, error } = await supabase
     .from('ventures')
-    .insert({ name: `Test Venture (sd-completed-tests-${PREFIX})` })
+    .insert({ name: `Test Venture (sd-completed-tests-${PREFIX})`, is_demo: true })
     .select('id')
     .single();
 

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -50,7 +50,7 @@ beforeAll(async () => {
   await sweepStaleFixtures(svc);
 
   const { data: v1, error: e1 } = await svc.from('ventures')
-    .insert({ name: `TS-fixture-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js' })
+    .insert({ name: `TS-fixture-${randomUUID()}`, is_demo: true, problem_statement: 'fixture for venture-error-aggregation.db.test.js' })
     .select('id').single();
   if (e1) throw e1;
   ventureId = v1.id;
@@ -59,7 +59,7 @@ beforeAll(async () => {
   // rethrowing so a half-created pair never persists into the venture list.
   try {
     const { data: v2, error: e2 } = await svc.from('ventures')
-      .insert({ name: `TS-fixture-other-${randomUUID()}`, problem_statement: 'fixture for venture-error-aggregation.db.test.js (revocation-isolation control)' })
+      .insert({ name: `TS-fixture-other-${randomUUID()}`, is_demo: true, problem_statement: 'fixture for venture-error-aggregation.db.test.js (revocation-isolation control)' })
       .select('id').single();
     if (e2) throw e2;
     otherVentureId = v2.id;

--- a/tests/unit/chairman/chairman-actionable.test.js
+++ b/tests/unit/chairman/chairman-actionable.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 — direct unit coverage for the canonical
+ * chairman-actionable fixture predicate (previously untested; the digest leak shipped
+ * because nothing pinned which names the surfaces exclude).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isFixtureVenture,
+  isConsoleActionable,
+  isEscalationActionable,
+  FIXTURE_NAME_PATTERNS,
+} from '../../../lib/chairman/chairman-actionable.mjs';
+
+describe('isFixtureVenture', () => {
+  it('excludes the HCGate-RealDB leak specimens (RCA 2026-07-16)', () => {
+    expect(isFixtureVenture({ name: 'HCGate-RealDB-unclassified-noop-1784238026383', is_demo: false })).toBe(true);
+    expect(isFixtureVenture({ name: 'HCGate-RealDB-classified-block-1784238026383', is_demo: false })).toBe(true);
+  });
+
+  it('excludes the legacy fixture families', () => {
+    for (const name of [
+      '__e2e_product_review_gate_a_1__',
+      'Test Venture for Owned-Audience Loop',
+      'my-citest-venture',
+      'canonical-source-test-1752',
+    ]) expect(isFixtureVenture({ name, is_demo: false }), name).toBe(true);
+  });
+
+  it('excludes the extended realdb/write-guard/real-path-suite families', () => {
+    for (const name of [
+      'ProductReviewGate-RealDB-a-1752',
+      'StageArtifactGate-RealDB-b-1752',
+      'something-noop-1752',
+      'parity-test-venture',
+      'test-stub-venture',
+      'TEST-HARNESS-s20',
+      'TS-fixture-abc',
+      '_PIPELINE_TEST_1752',
+      'Pipeline-Test-1752',
+      'Gate-Test-1752',
+    ]) expect(isFixtureVenture({ name, is_demo: false }), name).toBe(true);
+  });
+
+  it('always excludes is_demo=true regardless of name', () => {
+    expect(isFixtureVenture({ name: 'ApexNiche AI', is_demo: true })).toBe(true);
+  });
+
+  it('includes real ventures and fail-includes null/unreadable ventures', () => {
+    expect(isFixtureVenture({ name: 'ApexNiche AI', is_demo: false })).toBe(false);
+    expect(isFixtureVenture({ name: 'Image Alt Text Generator', is_demo: false })).toBe(false);
+    expect(isFixtureVenture(null)).toBe(false);
+    expect(isFixtureVenture(undefined)).toBe(false);
+    expect(isFixtureVenture({})).toBe(false);
+  });
+});
+
+describe('actionability predicates (unchanged semantics)', () => {
+  it('console admits pending allowlist types; escalation additionally admits blocking non-telemetry', () => {
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'chairman_approval' })).toBe(true);
+    expect(isConsoleActionable({ status: 'pending', decision_type: 'session_question', blocking: true })).toBe(false);
+    expect(isEscalationActionable({ status: 'pending', decision_type: 'session_question', blocking: true })).toBe(true);
+    expect(isEscalationActionable({ status: 'pending', decision_type: 'flag_review', blocking: true })).toBe(false);
+    expect(isEscalationActionable({ status: 'resolved', decision_type: 'chairman_approval' })).toBe(false);
+  });
+});
+
+describe('pattern export', () => {
+  it('exports a frozen non-empty pattern list for the SQL parity test', () => {
+    expect(Object.isFrozen(FIXTURE_NAME_PATTERNS)).toBe(true);
+    expect(FIXTURE_NAME_PATTERNS.length).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/tests/unit/chairman/fixture-pattern-parity.test.js
+++ b/tests/unit/chairman/fixture-pattern-parity.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-2) — JS↔SQL fixture-pattern lockstep pin.
+ *
+ * The chairman-actionable predicate lives in TWO places by design: the canonical SQL
+ * (latest get_pending_chairman_items migration) and the JS mirror
+ * (lib/chairman/chairman-actionable.mjs FIXTURE_NAME_PATTERNS). This test pins them to a
+ * single expected pairs table so a pattern added on one side without the other FAILS here
+ * — the leak class this SD fixes shipped precisely because nothing enforced the lockstep.
+ * (Recipe follows tests/integration/get-pending-chairman-items.contract.test.js: static
+ * readFileSync assertions, no live DB needed.)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { FIXTURE_NAME_PATTERNS } from '../../../lib/chairman/chairman-actionable.mjs';
+
+const MIGRATION = resolve(
+  process.cwd(),
+  'database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql'
+);
+const sql = readFileSync(MIGRATION, 'utf-8');
+
+/** The single source of truth for the lockstep: JS regex source ↔ SQL clause. */
+const EXPECTED_PAIRS = [
+  { js: '^__', sql: "v.name LIKE '\\_\\_%'" },
+  { js: '^test venture', sql: "v.name ILIKE 'test venture%'" },
+  { js: 'citest', sql: "v.name ILIKE '%citest%'" },
+  { js: '^canonical-source-test', sql: "v.name ILIKE 'canonical-source-test%'" },
+  { js: '-realdb-', sql: "v.name ILIKE '%-realdb-%'" },
+  { js: '-noop-', sql: "v.name ILIKE '%-noop-%'" },
+  { js: '^parity-test-', sql: "v.name ILIKE 'parity-test-%'" },
+  { js: '^test-stub', sql: "v.name ILIKE 'test-stub%'" },
+  { js: '^test-harness-', sql: "v.name ILIKE 'test-harness-%'" },
+  { js: '^ts-fixture-', sql: "v.name ILIKE 'ts-fixture-%'" },
+  { js: '^_pipeline_test_', sql: "v.name ILIKE '\\_pipeline\\_test\\_%'" },
+  { js: '^pipeline-test-', sql: "v.name ILIKE 'pipeline-test-%'" },
+  { js: '^gate-test-', sql: "v.name ILIKE 'gate-test-%'" },
+];
+
+describe('fixture-pattern JS↔SQL parity', () => {
+  it('every expected pair exists in the JS pattern list', () => {
+    const jsSources = FIXTURE_NAME_PATTERNS.map((re) => re.source);
+    for (const { js } of EXPECTED_PAIRS) {
+      expect(jsSources, `JS missing /${js}/`).toContain(js);
+    }
+  });
+
+  it('every expected pair exists in the canonical SQL migration', () => {
+    for (const { sql: clause } of EXPECTED_PAIRS) {
+      expect(sql.includes(clause), `SQL missing ${clause}`).toBe(true);
+    }
+  });
+
+  it('neither side has patterns beyond the expected pairs (bidirectional pin)', () => {
+    // JS side: exact count.
+    expect(FIXTURE_NAME_PATTERNS).toHaveLength(EXPECTED_PAIRS.length);
+    // SQL side: count the name-clauses inside the fixture COALESCE block.
+    const nameClauses = sql.match(/v\.name I?LIKE '/g) || [];
+    expect(nameClauses).toHaveLength(EXPECTED_PAIRS.length);
+  });
+
+  it('both sides keep the fail-include NULL semantics and is_demo primary signal', () => {
+    expect(sql.includes('v.is_demo IS TRUE')).toBe(true);
+    expect(sql.includes(', false)')).toBe(true); // COALESCE(..., false) fail-include
+  });
+});

--- a/tests/unit/chairman/record-pending-decision-fixture-guard.test.js
+++ b/tests/unit/chairman/record-pending-decision-fixture-guard.test.js
@@ -1,0 +1,79 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 (FR-4) — fixture guard at the decision-creation
+ * source: recordPendingDecision refuses to mint chairman_decisions rows for fixture ventures
+ * (positive identification only; lookup failures fail-open so a REAL decision is never lost).
+ */
+import { describe, it, expect } from 'vitest';
+import { recordPendingDecision } from '../../../lib/chairman/record-pending-decision.mjs';
+
+/** Minimal supabase fake: routes from('ventures') lookups and from('chairman_decisions') inserts. */
+function makeFakeDb({ venture, ventureError = null } = {}) {
+  const inserted = [];
+  return {
+    inserted,
+    from(table) {
+      if (table === 'ventures') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          async maybeSingle() { return { data: venture ?? null, error: ventureError }; },
+        };
+      }
+      return {
+        insert(row) {
+          inserted.push(row);
+          return { select: async () => ({ data: [{ id: 'dec-1' }], error: null }) };
+        },
+      };
+    },
+  };
+}
+
+describe('recordPendingDecision fixture guard', () => {
+  it('refuses to record a decision for a fixture venture (name pattern)', async () => {
+    const db = makeFakeDb({ venture: { id: 'v1', name: 'HCGate-RealDB-unclassified-noop-1', is_demo: false } });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
+    expect(r).toEqual({ recorded: false, skipped_fixture: true });
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('refuses to record a decision for an is_demo venture', async () => {
+    const db = makeFakeDb({ venture: { id: 'v1', name: 'Anything', is_demo: true } });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
+    expect(r.skipped_fixture).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('allowFixture: true overrides the guard (deliberate test minting)', async () => {
+    const db = makeFakeDb({ venture: { id: 'v1', name: 'HCGate-RealDB-x-noop-1', is_demo: false } });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1', allowFixture: true });
+    expect(r.recorded).toBe(true);
+    expect(db.inserted).toHaveLength(1);
+  });
+
+  it('records normally for a real venture', async () => {
+    const db = makeFakeDb({ venture: { id: 'v1', name: 'ApexNiche AI', is_demo: false } });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
+    expect(r.recorded).toBe(true);
+    expect(db.inserted).toHaveLength(1);
+  });
+
+  it('fail-open: venture lookup error never blocks a real decision', async () => {
+    const db = makeFakeDb({ venture: null, ventureError: { message: 'boom' } });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
+    expect(r.recorded).toBe(true);
+    expect(db.inserted).toHaveLength(1);
+  });
+
+  it('fail-open: missing venture row (dangling reference) records the decision', async () => {
+    const db = makeFakeDb({ venture: null });
+    const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
+    expect(r.recorded).toBe(true);
+  });
+
+  it('ventureless decisions skip the guard entirely', async () => {
+    const db = makeFakeDb({ ventureError: { message: 'should never be queried' } });
+    const r = await recordPendingDecision(db, { title: 'q' });
+    expect(r.recorded).toBe(true);
+  });
+});

--- a/tests/unit/chairman/record-pending-decision-fixture-guard.test.js
+++ b/tests/unit/chairman/record-pending-decision-fixture-guard.test.js
@@ -33,7 +33,9 @@ describe('recordPendingDecision fixture guard', () => {
   it('refuses to record a decision for a fixture venture (name pattern)', async () => {
     const db = makeFakeDb({ venture: { id: 'v1', name: 'HCGate-RealDB-unclassified-noop-1', is_demo: false } });
     const r = await recordPendingDecision(db, { title: 'q', ventureId: 'v1' });
-    expect(r).toEqual({ recorded: false, skipped_fixture: true });
+    expect(r.recorded).toBe(false);
+    expect(r.skipped_fixture).toBe(true);
+    expect(r.error).toMatch(/fixture venture/); // descriptive skip reason for recorded/error callers (W1)
     expect(db.inserted).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
Stops test/fixture-venture decisions leaking into the chairman's decision queue and digest email (RCA Adam, chairman-directed 2026-07-16 — the HCGate-RealDB specimen that also triggered the 5:41 PM email-flood incident).

- **FR-1** `scripts/adam-decision-email.mjs` applies the shared chairman-actionable predicate (`isEscalationActionable` + `isFixtureVenture`) exactly as the SLA sweep does — the digest was the only surface with no fixture filter; console-hidden decisions still reached the chairman by email.
- **FR-2** `FIXTURE_NAME_PATTERNS` extended (HCGate-RealDB-\*, \*-noop-\*, \*-realdb-\*, write-guard families, real-path-suite families) in **JS↔SQL lockstep** via `database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql`, pinned by a bidirectional parity test.
- **FR-3** 10 venture-creating test suites now set `is_demo: true` at creation; the 2 realdb suites with latently-broken `__e2e_` sanity pins are renamed onto the `*-RealDB-*` convention (write path preserved — watcher regex misses it; interrupted-teardown residue is surface-protected); `scripts/backfill-fixture-venture-flags.mjs` (dry-run default, idempotent) covers the already-leaked rows.
- **FR-4** `recordPendingDecision` refuses fixture-venture decisions at source — positive identification only, fail-open on lookup errors so a real decision is never lost; `allowFixture` override for deliberate test minting. The watcher's narrower write-guard predicate is intentionally preserved (documented seam: `__citest` must mint real decisions; surfaces filter them).

## Chairman-gated follow-ups (not executed here)
- Apply the migration: `node scripts/apply-migration.js database/migrations/20260717_extend_fixture_patterns_get_pending_chairman_items.sql --prod-deploy` (standing policy on get_pending_chairman_items).
- Run the backfill: `node scripts/backfill-fixture-venture-flags.mjs --apply` (dry-run verified live: 12+ leaked fixture rows, zero real ventures).

## Verification
- New: `chairman-actionable.test.js`, `fixture-pattern-parity.test.js`, `record-pending-decision-fixture-guard.test.js`
- Regression sweep: 207 tests / 14 files green (chairman unit suites, watcher, SLA sweep, contract test); smoke 15/15
- Backfill dry-run executed against live DB — candidates are exclusively fixture families

## PR size justification
461 insertions = 217 test + 105 migration (mandated CREATE OR REPLACE copy of the canonical function); net product-code delta ≈ 60 LOC.

SD: SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002 · PRD: PRD-SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-002
Claude-Session: 356833d8-2c04-4d59-941e-8edf5f64c391

🤖 Generated with [Claude Code](https://claude.com/claude-code)