### PR TITLE
fix(tests): defuse date time-bomb blocking all PRs (session-coordination-retention GT-1)

### DIFF
--- a/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
+++ b/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
@@ -121,7 +121,12 @@ describe('collectSessionCoordinationRetentionEvidence (TS-1..TS-3)', () => {
 describe('GT-1 golden regression: liveness alone never closes L30, measured decline does (TS-5)', () => {
   // Real L30 closure_predicate shape (lib/loop-governance/genesis-loops.js DEFAULT_PREDICATE).
   const loop = { loop_key: 'L30', predicate_type: PREDICATE_TYPES.EDGE_FRESHNESS, closure_predicate: { window_seconds: 30 * 86400 } };
-  const now = new Date('2026-07-16T12:00:00.000Z');
+  // MUST be the real clock, not a pinned date: the collector's 30-day edge window uses
+  // Date.now() internally, while `now` here feeds evaluateLoopClosure. A pinned now
+  // (previously 2026-07-16T12:00Z) made ago(29) drift out of the collector's REAL window
+  // exactly one day after pinning — a repo-wide CI time bomb that detonated 2026-07-17T12:00Z.
+  // With both legs on the same clock the ago(0/1/29) fixtures sit safely inside both windows.
+  const now = new Date();
   const ago = (days) => new Date(now.getTime() - days * 86400 * 1000).toISOString();
 
   it.each([


### PR DESCRIPTION
## Summary
Repo-wide CI blocker since 2026-07-17T12:00Z: the GT-1 golden-regression block in `session-coordination-retention.test.js` pins `now = 2026-07-16T12:00Z` for `evaluateLoopClosure`, but the collector under test uses the real `Date.now()` for its 30-day edge window. The `ago(29)` fixture drifted out of the collector's real window exactly one day after pinning — every PR's **Run Unit Tier** went red at noon UTC today (first hit: PR #6156).

Fix: both legs share the real clock (`now = new Date()`), keeping the ago(0/1/29) fixtures ≥1 day inside both windows — deterministic, no boundary proximity.

## Test plan
- `npx vitest run lib/.../session-coordination-retention.test.js` → 19/19 pass (was 1 failing)

Claude-Session: 356833d8-2c04-4d59-941e-8edf5f64c391

🤖 Generated with [Claude Code](https://claude.com/claude-code)