### PR TITLE
fix(QF-20260717-737): defuse fleet-wide CI time-bomb — pin system Date in session-coordination-retention test

### DIFF
--- a/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
+++ b/lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js
@@ -3,9 +3,22 @@
  * (SD-LEO-INFRA-LOOP-EVIDENCE-COLLECTORS-001, TS-1..TS-3, TS-5 / GT-1 golden regression;
  *  SD-LEO-INFRA-L30-CLOSURE-EDGE-001, measured-decline gate)
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { collectSessionCoordinationRetentionEvidence } from '../session-coordination-retention.js';
 import { evaluateLoopClosure, PREDICATE_TYPES } from '../../closure-engine.js';
+
+// The collector reads the REAL clock (Date.now() for the RETENTION_ARCHIVE_STALE
+// window) while these tests pin `now` only for the evaluator. Fixtures built
+// relative to the pinned instant therefore age against wall time — the ago(29)
+// case crossed the 30-day staleness window at 2026-07-17T12:00Z and turned into
+// a deterministic fleet-wide CI failure. Fake ONLY Date (not timers, so async
+// stays real) at the same pinned instant so both clocks agree (QF-20260717-737).
+beforeAll(() => {
+  vi.useFakeTimers({ now: new Date('2026-07-16T12:00:00.000Z'), toFake: ['Date'] });
+});
+afterAll(() => {
+  vi.useRealTimers();
+});
 
 /**
  * Chainable stub routing by table name: 'retention_archive' gets the


### PR DESCRIPTION
## Summary
- Since 2026-07-17T12:00Z every Unit Tier run (main pushes + all PRs) fails GT-1 `'29 days ago' -> closed` in `lib/loop-governance/collectors/__tests__/session-coordination-retention.test.js`: the test pins `now=2026-07-16T12:00Z` for `evaluateLoopClosure` but the collector internally uses real `Date.now()` for the 30-day `RETENTION_ARCHIVE_STALE` window, so the `ago(29)` fixture aged across the boundary on the wall clock.
- Fix: `vi.useFakeTimers({ now: <pinned instant>, toFake: ['Date'] })` for the file (async timers stay real) so collector and evaluator share one clock. Test-only change; production collector behavior is untouched and correct.

## Test plan
- [x] npx vitest run lib/loop-governance/.../session-coordination-retention.test.js — 19/19 (was failing at current wall time)
- [x] npx vitest run lib/loop-governance — 67/67

🤖 Generated with [Claude Code](https://claude.com/claude-code)