### PR TITLE
fix(SD-LEO-INFRA-MULTI-SESSION-CLAIM-001): multi-session claim gate reads wrong SSOT surface

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -280,8 +280,10 @@ export function shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, own
 }
 
 /** Host-local: is the owner session's Claude Code PROCESS still running? Best-effort / fail-open
- *  (any error, an unknown session, or a cross-host owner → false → no added protection). */
-function isOwnerProcessAlive(ownerSessionId) {
+ *  (any error, an unknown session, or a cross-host owner → false → no added protection).
+ *  Exported (SD-LEO-INFRA-MULTI-SESSION-CLAIM-001 FR-2) so multi-session-claim-gate.js can
+ *  delegate to this SAME primitive instead of re-deriving liveness independently. */
+export function isOwnerProcessAlive(ownerSessionId) {
   if (!ownerSessionId) return false;
   try {
     const { getMarkerSessionIds } = _require('./fleet/cc-pid-liveness.cjs');

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -246,7 +246,10 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
       issues: [
         `SD ${sdId} is claimed by another active session (${ownerRow?.hostname || 'unknown'}, heartbeat: ${heartbeatAgeHuman})`
       ],
-      warnings: [],
+      // Surface any owner-row read error here too — the BLOCK path can still be reached with
+      // ownerErr set (e.g. ownerRow null from a DB error, but isOwnerProcessAlive independently
+      // true), and dropping it here would silently reintroduce the visibility gap round-1 fixed.
+      warnings: ownerErr ? [`Owner liveness computed with a missing owner row (DB error: ${ownerErr.message}) — proceeding to BLOCK on available signals`] : [],
       claimDetails: {
         sessionId: ownerSessionId,
         hostname: ownerRow?.hostname,

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -34,6 +34,14 @@ import { getTerminalId } from '../../../../lib/terminal-identity.js';
 // Handles ambiguous case where one terminal_id has PID suffix and the other doesn't
 import { isSameConversation } from '../../../../lib/claim-guard.mjs';
 
+// SD-LEO-INFRA-MULTI-SESSION-CLAIM-001 (FR-1/FR-2): the SAME liveness primitives
+// lib/claim-validity-gate.js's assertValidClaim uses for its foreign_claim path —
+// delegated here instead of re-deriving liveness from v_active_sessions.computed_status
+// (a heartbeat-only view that misses the silence-window / PID-alive escape hatches and
+// can read a dead peer's technically-fresh heartbeat as "active").
+import { ownerIsDeadByLiveness, shouldReleaseStaleOwner, isOwnerProcessAlive } from '../../../../lib/claim-validity-gate.js';
+import { isWithinArmedSilenceWindow } from '../../../../lib/fleet/silence-cap.cjs';
+
 /**
  * Validate that no session on another machine has claimed this SD
  *
@@ -93,87 +101,35 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
       }
     }
 
-    // Query v_active_sessions for any active claim on this SD
-    const { data, error } = await supabase
-      .from('v_active_sessions')
-      .select('session_id, sd_key, sd_title, hostname, tty, terminal_id, heartbeat_age_human, heartbeat_age_seconds, computed_status, codebase')
+    // SD-LEO-INFRA-MULTI-SESSION-CLAIM-001 (FR-1): read strategic_directives_v2.claiming_session_id
+    // (Surface A) FIRST — this is the AUTHORITATIVE claim owner used by every other claim-checking
+    // code path (lib/claim-validity-gate.js's assertValidClaim). v_active_sessions/claude_sessions
+    // is advisory context only from here on, never the decision authority. A stale/phantom sd_key
+    // stamp on some OTHER session's own claude_sessions row (Surface B) must never override the
+    // caller's genuine Surface-A ownership — that was the exact witnessed bug (2026-07-17 01:57Z).
+    const { data: sdRow, error: sdErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('claiming_session_id')
       .eq('sd_key', sdId)
-      .in('computed_status', ['active']);
+      .maybeSingle();
 
-    if (error) {
+    if (sdErr) {
       // DB error → fail-open (don't block on infrastructure issues)
-      console.log(`   ⚠️  Could not check session claims: ${error.message}`);
+      console.log(`   ⚠️  Could not read Surface A claiming_session_id: ${sdErr.message}`);
       console.log('   → Proceeding (fail-open on DB error)');
       return {
         pass: true,
         score: 80,
         max_score: 100,
         issues: [],
-        warnings: [`Could not verify session claims: ${error.message}`]
+        warnings: [`Could not verify Surface A ownership: ${sdErr.message}`]
       };
     }
 
-    // Filter out claims from the SAME Claude Code conversation.
-    // PAT-SESSION-IDENTITY-002: A single Claude Code conversation spawns multiple
-    // CLI processes (sd:start, handoff.js), each with different PIDs and session IDs.
-    // These share the same hostname AND terminal_id (based on parent PID).
-    // Two DIFFERENT Claude Code conversations on the same machine have the same
-    // hostname but DIFFERENT terminal_ids — those ARE conflicts.
-    //
-    // RCA-TERMINAL-IDENTITY-CHAIN-BREAK-001: When findClaudeCodePid() fails
-    // (e.g., npm run subprocess), terminal_id falls back to SSE-port-only
-    // (win-cc-{port} instead of win-cc-{port}-{pid}). Use isSameConversation()
-    // for three-case matching: true/false/'ambiguous'.
-    const otherClaims = (data || []).filter(claim => {
-      // Exact session ID match → always exclude (backward compat)
-      if (claim.session_id === currentSessionId) return false;
-      // Same hostname check first
-      if (claim.hostname && claim.hostname === currentHostname) {
-        // Use three-case terminal_id matching from claim-guard
-        const sameConvo = isSameConversation(currentTerminalId, claim.terminal_id);
-        if (sameConvo === true) return false; // Definitely same conversation
-        if (sameConvo === 'ambiguous') {
-          // Quick-fix QF-20260404-512: Before blocking on ambiguity, check if
-          // the claiming session's PID is still alive. When terminal_id uses the
-          // unstable win-pid-* fallback, every Bash call gets a new PID, making
-          // the claiming PID dead by definition. A dead PID means the claim is
-          // from the same conversation's prior Bash invocation, not a competitor.
-          const claimPidMatch = claim.terminal_id?.match(/^win-pid-(\d+)$/);
-          if (claimPidMatch) {
-            const claimPid = parseInt(claimPidMatch[1], 10);
-            try {
-              process.kill(claimPid, 0); // Signal 0 = existence check, no actual kill
-            } catch {
-              // PID is dead — this is a stale claim from a prior Bash invocation
-              console.log(`   ✅ Ambiguous terminal_id but claiming PID ${claimPid} is dead — allowing (same conversation)`);
-              return false;
-            }
-          }
-          // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: DENY-on-ambiguity
-          // Ambiguous identity (e.g., UUID vs win-cc format mismatch) now blocks
-          // rather than allowing passthrough. Blocking a handoff is recoverable;
-          // allowing duplicate work from a different session is not.
-          console.log(`   ⚠️  Ambiguous terminal_id match (${currentTerminalId} vs ${claim.terminal_id}) — BLOCKING (DENY-on-ambiguity)`);
-          return true;
-        }
-        // sameConvo === false → different conversation on same machine → conflict
-      }
-      return true;
-    });
+    const ownerSessionId = sdRow?.claiming_session_id ?? null;
 
-    if (otherClaims.length === 0) {
-      // Check if we passed due to same-conversation exclusion (log for visibility)
-      const sameConversationClaims = (data || []).filter(
-        claim => claim.session_id !== currentSessionId &&
-                 claim.hostname === currentHostname &&
-                 isSameConversation(currentTerminalId, claim.terminal_id) !== false
-      );
-      if (sameConversationClaims.length > 0) {
-        console.log(`   ✅ SD claimed by same-conversation session (${sameConversationClaims[0].session_id?.substring(0, 24)}...) — allowing`);
-        console.log(`      (hostname: ${currentHostname}, terminal_id: ${currentTerminalId})`);
-      } else {
-        console.log('   ✅ No conflicting session claims found');
-      }
+    if (!ownerSessionId || ownerSessionId === currentSessionId) {
+      console.log('   ✅ Surface A (strategic_directives_v2.claiming_session_id) confirms this session owns the claim (or SD is unclaimed) — passing');
       return {
         pass: true,
         score: 100,
@@ -183,26 +139,87 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
       };
     }
 
-    // Another active session (different machine OR different conversation) has this SD → BLOCK
-    const claim = otherClaims[0];
-    const isSameMachine = claim.hostname === currentHostname;
+    // FR-2: genuine foreign claim per Surface A. Delegate the "is that owner actually alive"
+    // determination to the SAME primitives assertValidClaim uses, evaluated against the OWNER's
+    // OWN claude_sessions row — never re-derive liveness from v_active_sessions.computed_status.
+    const { data: ownerRow } = await supabase
+      .from('claude_sessions')
+      .select('status, is_alive, heartbeat_at, expected_silence_until, hostname, terminal_id, tty, sd_key, codebase')
+      .eq('session_id', ownerSessionId)
+      .maybeSingle();
+
+    const nowMs = Date.now();
+    const ownerIsDead = ownerIsDeadByLiveness(ownerRow, nowMs);
+    const ownerIsSilenced = isWithinArmedSilenceWindow(ownerRow?.expected_silence_until, nowMs);
+    const ownerPidAlive = isOwnerProcessAlive(ownerSessionId);
+    // Owner's OWN session-side sd_key no longer points at this SD → they've moved on (drift).
+    const ownerHasSdKeyDrifted = !!ownerRow && ownerRow.sd_key !== sdId;
+
+    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive })) {
+      console.log(`   ✅ Surface-A owner ${ownerSessionId.substring(0, 24)}... is dead/drifted (delegated liveness check) — no real conflict, passing`);
+      console.log(`      (ownerIsDead=${ownerIsDead}, ownerIsSilenced=${ownerIsSilenced}, ownerPidAlive=${ownerPidAlive}, sdKeyDrifted=${ownerHasSdKeyDrifted})`);
+      return {
+        pass: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: []
+      };
+    }
+
+    // Owner is genuinely alive per Surface A + delegated liveness. Preserve the EXISTING
+    // same-conversation carve-out (PAT-SESSION-IDENTITY-002): multiple CLI subprocesses from
+    // ONE Claude Code instance share hostname + terminal_id and must not be treated as a conflict.
+    if (ownerRow?.hostname && ownerRow.hostname === currentHostname) {
+      const sameConvo = isSameConversation(currentTerminalId, ownerRow.terminal_id);
+      if (sameConvo === true) {
+        console.log(`   ✅ SD claimed by same-conversation session (${ownerSessionId.substring(0, 24)}...) — allowing`);
+        return { pass: true, score: 100, max_score: 100, issues: [], warnings: [] };
+      }
+      if (sameConvo === 'ambiguous') {
+        // Quick-fix QF-20260404-512: Before blocking on ambiguity, check if the claiming
+        // session's PID is still alive. When terminal_id uses the unstable win-pid-* fallback,
+        // every Bash call gets a new PID, making the claiming PID dead by definition.
+        const claimPidMatch = ownerRow.terminal_id?.match(/^win-pid-(\d+)$/);
+        if (claimPidMatch) {
+          const claimPid = parseInt(claimPidMatch[1], 10);
+          try {
+            process.kill(claimPid, 0); // Signal 0 = existence check, no actual kill
+          } catch {
+            console.log(`   ✅ Ambiguous terminal_id but claiming PID ${claimPid} is dead — allowing (same conversation)`);
+            return { pass: true, score: 100, max_score: 100, issues: [], warnings: [] };
+          }
+        }
+        // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: DENY-on-ambiguity — blocking a handoff is
+        // recoverable; allowing duplicate work from a different session is not.
+        console.log(`   ⚠️  Ambiguous terminal_id match (${currentTerminalId} vs ${ownerRow.terminal_id}) — BLOCKING (DENY-on-ambiguity)`);
+      }
+      // sameConvo === false → different conversation on same machine → conflict, falls through to BLOCK
+    }
+
+    // Genuine foreign LIVE claim on a different conversation → BLOCK
+    const isSameMachine = ownerRow?.hostname === currentHostname;
+    const heartbeatAgeSeconds = ownerRow?.heartbeat_at
+      ? Math.round((nowMs - new Date(ownerRow.heartbeat_at).getTime()) / 1000)
+      : null;
+    const heartbeatAgeHuman = heartbeatAgeSeconds != null ? `${heartbeatAgeSeconds}s ago` : 'unknown';
 
     console.log('');
     console.log('   ┌─────────────────────────────────────────────────────────────┐');
     console.log('   │  🚫 BLOCKED: SD CLAIMED BY ANOTHER ACTIVE SESSION           │');
     console.log('   ├─────────────────────────────────────────────────────────────┤');
     console.log(`   │  SD:            ${sdId}`);
-    console.log(`   │  Session:       ${claim.session_id?.substring(0, 36) || 'unknown'}`);
-    console.log(`   │  Hostname:      ${claim.hostname || 'unknown'}`);
-    console.log(`   │  Terminal ID:   ${claim.terminal_id || 'unknown'}`);
-    console.log(`   │  TTY:           ${claim.tty || 'unknown'}`);
-    console.log(`   │  Heartbeat:     ${claim.heartbeat_age_human || 'unknown'}`);
-    console.log(`   │  Codebase:      ${claim.codebase || 'unknown'}`);
+    console.log(`   │  Session:       ${ownerSessionId?.substring(0, 36) || 'unknown'}`);
+    console.log(`   │  Hostname:      ${ownerRow?.hostname || 'unknown'}`);
+    console.log(`   │  Terminal ID:   ${ownerRow?.terminal_id || 'unknown'}`);
+    console.log(`   │  TTY:           ${ownerRow?.tty || 'unknown'}`);
+    console.log(`   │  Heartbeat:     ${heartbeatAgeHuman}`);
+    console.log(`   │  Codebase:      ${ownerRow?.codebase || 'unknown'}`);
     if (isSameMachine) {
       console.log('   ├─────────────────────────────────────────────────────────────┤');
       console.log('   │  ⚠️  SAME MACHINE, DIFFERENT CONVERSATION                   │');
       console.log(`   │  Your terminal_id:  ${currentTerminalId}`);
-      console.log(`   │  Their terminal_id: ${claim.terminal_id || 'unknown'}`);
+      console.log(`   │  Their terminal_id: ${ownerRow?.terminal_id || 'unknown'}`);
     }
     console.log('   ├─────────────────────────────────────────────────────────────┤');
     console.log('   │  Another Claude Code instance is actively working on this   │');
@@ -220,17 +237,17 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
       score: 0,
       max_score: 100,
       issues: [
-        `SD ${sdId} is claimed by another active session (${claim.hostname || 'unknown'}, heartbeat: ${claim.heartbeat_age_human || 'unknown'})`
+        `SD ${sdId} is claimed by another active session (${ownerRow?.hostname || 'unknown'}, heartbeat: ${heartbeatAgeHuman})`
       ],
       warnings: [],
       claimDetails: {
-        sessionId: claim.session_id,
-        hostname: claim.hostname,
-        terminalId: claim.terminal_id,
-        tty: claim.tty,
-        heartbeatAgeHuman: claim.heartbeat_age_human,
-        heartbeatAgeSeconds: claim.heartbeat_age_seconds,
-        codebase: claim.codebase,
+        sessionId: ownerSessionId,
+        hostname: ownerRow?.hostname,
+        terminalId: ownerRow?.terminal_id,
+        tty: ownerRow?.tty,
+        heartbeatAgeHuman,
+        heartbeatAgeSeconds,
+        codebase: ownerRow?.codebase,
         isSameMachine
       }
     };

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -142,11 +142,18 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
     // FR-2: genuine foreign claim per Surface A. Delegate the "is that owner actually alive"
     // determination to the SAME primitives assertValidClaim uses, evaluated against the OWNER's
     // OWN claude_sessions row — never re-derive liveness from v_active_sessions.computed_status.
-    const { data: ownerRow } = await supabase
+    const { data: ownerRow, error: ownerErr } = await supabase
       .from('claude_sessions')
       .select('status, is_alive, heartbeat_at, expected_silence_until, hostname, terminal_id, tty, sd_key, codebase')
       .eq('session_id', ownerSessionId)
       .maybeSingle();
+
+    if (ownerErr) {
+      // Surfaced (not silent) — a transient error here must not read as an undetected
+      // "owner missing" pass. Deep-tier adversarial review flagged the asymmetry with the
+      // Surface A query above, which explicitly checks/surfaces its own error.
+      console.log(`   ⚠️  Could not read owner's claude_sessions row: ${ownerErr.message}`);
+    }
 
     const nowMs = Date.now();
     const ownerIsDead = ownerIsDeadByLiveness(ownerRow, nowMs);
@@ -163,7 +170,7 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
         score: 100,
         max_score: 100,
         issues: [],
-        warnings: []
+        warnings: ownerErr ? [`Owner liveness computed with a missing owner row (DB error: ${ownerErr.message}) — treated as dead/fail-open`] : []
       };
     }
 

--- a/tests/integration/multi-session-claim-gate-surface-a.integration.test.js
+++ b/tests/integration/multi-session-claim-gate-surface-a.integration.test.js
@@ -1,0 +1,165 @@
+/**
+ * multi-session-claim-gate-surface-a.integration.test.js — SD-LEO-INFRA-MULTI-SESSION-CLAIM-001
+ *
+ * RECURRED-FAMILY e2e acceptance test (live DB, no mocked seam). A prior fix
+ * (SD-LEO-FIX-FIX-MULTI-SESSION-001) for this gate completed, yet the same
+ * false-block/false-read defect class recurred: validateMultiSessionClaim()
+ * derived ownership from v_active_sessions (heartbeat-view / Surface B)
+ * instead of strategic_directives_v2.claiming_session_id (the authoritative
+ * Surface A written by claim_sd()). Per the recurred-family rule, a mocked
+ * unit test is not sufficient acceptance evidence — this drives the REAL
+ * validateMultiSessionClaim() against REAL tables.
+ *
+ * Reproduces the exact witnessed live scenario (2026-07-17 01:57Z, session
+ * be313562, SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001): an unrelated dead/phantom
+ * peer session holds a stale sd_key stamp on ITS OWN claude_sessions row with
+ * a fresh-looking heartbeat (computed_status='active' per
+ * v_active_sessions), while the true owner holds Surface A
+ * (claiming_session_id). The true owner's own handoff must PASS. The inverse
+ * (a genuinely live foreign claim on a different conversation) must still
+ * BLOCK — no fail-open regression introduced while fixing the false-block.
+ *
+ * LIVE-gated: skips (not fails) without Supabase creds so hermetic CI stays
+ * green. Ephemeral fixtures, unique RUN_ID, zero-survivors afterAll cleanup.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const HAS_DB = !!((process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+  && process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const RUN_ID = `msess-e2e-${Date.now()}-${process.pid}`;
+const SD_KEY_PHANTOM = `SD-TEST-MSESS-E2E-${Date.now()}${process.pid}A`;
+const SD_KEY_FOREIGN = `SD-TEST-MSESS-E2E-${Date.now()}${process.pid}B`;
+const SESSION_OWNER = `${RUN_ID}-owner`;
+const SESSION_PHANTOM_PEER = `${RUN_ID}-phantom-peer`;
+const SESSION_FOREIGN_OWNER = `${RUN_ID}-foreign-owner`;
+
+// Distinct from the caller's own identity so the gate's pre-cleanup step
+// (release_same_conversation_claims / same-hostname fallback) never touches
+// these fixtures — it filters on `hostname = currentHostname`.
+const CALLER_HOSTNAME = `${RUN_ID}-caller-host`;
+const CALLER_TERMINAL_ID = `win-cc-${RUN_ID}-caller`;
+const PHANTOM_HOSTNAME = `${RUN_ID}-phantom-host`;
+const FOREIGN_HOSTNAME = `${RUN_ID}-foreign-host`;
+const FOREIGN_TERMINAL_ID = `win-cc-${RUN_ID}-foreign`;
+
+function sdFixture(sdKey, ownerSessionId) {
+  return {
+    id: crypto.randomUUID(),
+    sd_key: sdKey,
+    title: `[fixture] multi-session-claim-gate e2e ${RUN_ID}`,
+    description: 'Ephemeral integration fixture — safe to delete on sight.',
+    rationale: 'SD-LEO-INFRA-MULTI-SESSION-CLAIM-001 recurred-family e2e coverage.',
+    status: 'in_progress',
+    current_phase: 'EXEC',
+    sd_type: 'infrastructure',
+    category: 'Infrastructure',
+    priority: 'low',
+    scope: 'ephemeral test fixture',
+    target_application: 'EHG_Engineer',
+    success_criteria: [{ criterion: 'fixture', measure: 'n/a' }],
+    claiming_session_id: ownerSessionId,
+    active_session_id: ownerSessionId,
+    is_working_on: true,
+  };
+}
+
+describe.skipIf(!HAS_DB)('multi-session-claim-gate: Surface A e2e (LIVE tables, recurred-family acceptance)', () => {
+  let sb;
+  let validateMultiSessionClaim;
+
+  beforeAll(async () => {
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    sb = createSupabaseServiceClient();
+    ({ validateMultiSessionClaim } = await import('../../scripts/modules/handoff/gates/multi-session-claim-gate.js'));
+
+    const { error: sdErr } = await sb.from('strategic_directives_v2').insert([
+      sdFixture(SD_KEY_PHANTOM, SESSION_OWNER),
+      sdFixture(SD_KEY_FOREIGN, SESSION_FOREIGN_OWNER),
+    ]);
+    expect(sdErr, `strategic_directives_v2 fixture insert: ${sdErr?.message}`).toBeNull();
+
+    const nowIso = new Date().toISOString();
+    const { error: sessErr } = await sb.from('claude_sessions').insert([
+      // The witnessed bug vector: an UNRELATED peer whose OWN claude_sessions row
+      // stamps sd_key = SD_KEY_PHANTOM with a FRESH heartbeat (computed_status
+      // would read 'active' in v_active_sessions), even though Surface A
+      // (claiming_session_id) on the SD names SESSION_OWNER, not this peer.
+      {
+        session_id: SESSION_PHANTOM_PEER,
+        status: 'active',
+        sd_key: SD_KEY_PHANTOM,
+        claimed_at: nowIso,
+        heartbeat_at: nowIso, // fresh — the exact "fresh-looking heartbeat" signature
+        last_tool_at: nowIso,
+        terminal_id: `win-cc-${RUN_ID}-phantom`,
+        tty: 'win-99999',
+        hostname: PHANTOM_HOSTNAME,
+        is_alive: false, // dead by PID-liveness — computed_status ignores this field entirely
+        metadata: {},
+      },
+      // A genuinely live foreign owner for the inverse (no-regression) case.
+      {
+        session_id: SESSION_FOREIGN_OWNER,
+        status: 'active',
+        sd_key: SD_KEY_FOREIGN,
+        claimed_at: nowIso,
+        heartbeat_at: nowIso,
+        last_tool_at: nowIso,
+        terminal_id: FOREIGN_TERMINAL_ID,
+        tty: 'win-88888',
+        hostname: FOREIGN_HOSTNAME,
+        is_alive: true,
+        metadata: {},
+      },
+    ]);
+    expect(sessErr, `claude_sessions fixture insert: ${sessErr?.message}`).toBeNull();
+  }, 30_000);
+
+  afterAll(async () => {
+    if (!sb) return;
+    await sb.from('claude_sessions').delete().like('session_id', `${RUN_ID}%`);
+    await sb.from('strategic_directives_v2').delete().in('sd_key', [SD_KEY_PHANTOM, SD_KEY_FOREIGN]);
+
+    const { count: sessLeft } = await sb.from('claude_sessions')
+      .select('session_id', { count: 'exact', head: true }).like('session_id', `${RUN_ID}%`);
+    const { count: sdLeft } = await sb.from('strategic_directives_v2')
+      .select('sd_key', { count: 'exact', head: true }).in('sd_key', [SD_KEY_PHANTOM, SD_KEY_FOREIGN]);
+    expect(sessLeft ?? 0).toBe(0);
+    expect(sdLeft ?? 0).toBe(0);
+  }, 30_000);
+
+  it('RECURRED-FAMILY: the rightful Surface-A owner PASSES despite an unrelated dead peer holding a stale sd_key stamp with a fresh heartbeat', async () => {
+    const result = await validateMultiSessionClaim(sb, SD_KEY_PHANTOM, {
+      currentSessionId: SESSION_OWNER,
+      currentHostname: CALLER_HOSTNAME,
+      currentTerminalId: CALLER_TERMINAL_ID,
+    });
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.issues).toEqual([]);
+
+    // Prove the phantom peer's row was never mutated/consulted as ownership authority.
+    const { data: phantomRow } = await sb.from('claude_sessions')
+      .select('sd_key, status').eq('session_id', SESSION_PHANTOM_PEER).maybeSingle();
+    expect(phantomRow.sd_key).toBe(SD_KEY_PHANTOM);
+  }, 30_000);
+
+  it('NO-REGRESSION: a genuinely live foreign claim on a different conversation still BLOCKS', async () => {
+    const result = await validateMultiSessionClaim(sb, SD_KEY_FOREIGN, {
+      currentSessionId: SESSION_OWNER, // NOT the SD's claiming_session_id (SESSION_FOREIGN_OWNER)
+      currentHostname: CALLER_HOSTNAME,
+      currentTerminalId: CALLER_TERMINAL_ID,
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.claimDetails?.hostname).toBe(FOREIGN_HOSTNAME);
+    expect(result.claimDetails?.terminalId).toBe(FOREIGN_TERMINAL_ID);
+  }, 30_000);
+});

--- a/tests/unit/claim-default.test.js
+++ b/tests/unit/claim-default.test.js
@@ -31,7 +31,7 @@ describe('isSameConversation DENY-on-ambiguity', () => {
 
 // Test that multi-session gate treats ambiguous as BLOCK (not ALLOW)
 describe('multi-session-claim-gate ambiguous handling', () => {
-  it('should treat ambiguous terminal_id as conflict (return true)', async () => {
+  it('should treat ambiguous terminal_id as conflict (falls through to BLOCK)', async () => {
     // Read the gate source to verify the logic changed
     const fs = await import('fs');
     const path = await import('path');
@@ -40,15 +40,33 @@ describe('multi-session-claim-gate ambiguous handling', () => {
 
     // Verify DENY-on-ambiguity is in place
     expect(source).toContain('DENY-on-ambiguity');
-    expect(source).toContain('return true;');
 
-    // Verify old ALLOW pattern is removed
+    // SD-LEO-INFRA-MULTI-SESSION-CLAIM-001: the gate was rewritten to read Surface A
+    // (strategic_directives_v2.claiming_session_id) first and delegate liveness to
+    // lib/claim-validity-gate.js's primitives. The ambiguous branch no longer needs an
+    // explicit `return true;` inside a .filter() callback (the old shape) — it now simply
+    // does NOT early-return a pass, so control falls through to the BLOCK banner further
+    // down. Pin the BEHAVIORAL invariant instead of the old literal code shape: within the
+    // ambiguous-handling window, there is no early "pass: true" escape, and the old removed
+    // ALLOW pattern is absent.
     const ambiguousIdx = source.indexOf("sameConvo === 'ambiguous'");
+    expect(ambiguousIdx).toBeGreaterThan(-1);
     // Window widened: QF-20260404-512 inserted a PID-liveness block between
     // `sameConvo === 'ambiguous'` and the DENY-on-ambiguity comment.
     const ambiguousBlock = source.substring(ambiguousIdx, ambiguousIdx + 1500);
     expect(ambiguousBlock).not.toContain('treating as same conversation');
     expect(ambiguousBlock).toContain('DENY-on-ambiguity');
+    // The ambiguous branch legitimately still contains ONE conditional pass — the pre-existing
+    // QF-20260404-512 carve-out for a CONFIRMED-DEAD claiming PID (not a same-conversation
+    // guess). That carve-out is gated behind `catch` on a `process.kill(pid, 0)` liveness probe;
+    // pin that it stays conditional (inside the try/catch), not an unconditional escape.
+    expect(ambiguousBlock).toMatch(/catch\s*\{[\s\S]{0,400}pass:\s*true/);
+
+    // The ambiguous block must be followed (within the rest of the function) by the BLOCK
+    // banner, confirming the fallthrough actually reaches a blocking return.
+    const restOfFunction = source.substring(ambiguousIdx);
+    expect(restOfFunction).toContain('BLOCKED: SD CLAIMED BY ANOTHER ACTIVE SESSION');
+    expect(restOfFunction).toContain('pass: false');
   });
 });
 

--- a/tests/unit/multi-session-claim-gate.test.js
+++ b/tests/unit/multi-session-claim-gate.test.js
@@ -3,6 +3,10 @@
  * PAT-MSESS-BYP-001 corrective action
  * PAT-SESSION-IDENTITY-002: Updated to test hostname + terminal_id comparison
  * SD-LEO-FIX-FIX-MULTI-SESSION-001: Added terminal_id discriminator tests
+ * SD-LEO-INFRA-MULTI-SESSION-CLAIM-001: rewritten for the Surface-A-first contract —
+ * the gate now reads strategic_directives_v2.claiming_session_id (Surface A) as the
+ * authoritative owner, and only consults claude_sessions (Surface B) as advisory
+ * context for a genuine foreign claim's liveness/same-conversation determination.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -11,41 +15,53 @@ import {
   createMultiSessionClaimGate
 } from '../../scripts/modules/handoff/gates/multi-session-claim-gate.js';
 
-// Helper: mock Supabase that returns active session data
-function createMockSupabase(sessions = []) {
+/**
+ * Mock supabase for the Surface-A-first contract.
+ * @param {object} opts
+ * @param {string|null} [opts.ownerSessionId] - strategic_directives_v2.claiming_session_id (Surface A)
+ * @param {object|null} [opts.ownerSessionRow] - claude_sessions row for ownerSessionId (Surface B, advisory)
+ * @param {object|null} [opts.sdError] - simulate an error reading Surface A
+ */
+function createMockSupabase({ ownerSessionId = null, ownerSessionRow = null, sdError = null } = {}) {
   return {
-    // validateMultiSessionClaim first calls rpc('release_same_conversation_claims').
-    // It must resolve so the SUT skips the claude_sessions fallback (whose 3-deep
-    // .eq() chain this mock doesn't provide), otherwise the gate fails open (score 80).
+    // validateMultiSessionClaim first calls rpc('release_same_conversation_claims'). It must
+    // resolve so the SUT skips the claude_sessions fallback (whose 3-deep .eq() chain this
+    // mock doesn't provide) — otherwise it would collide with the Surface-A-owner mock below.
     rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          in: vi.fn().mockResolvedValue({ data: sessions, error: null })
-        })
-      })
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue(
+                sdError
+                  ? { data: null, error: sdError }
+                  : { data: { claiming_session_id: ownerSessionId }, error: null }
+              )
+            })
+          })
+        };
+      }
+      if (table === 'claude_sessions') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: ownerSessionRow, error: null })
+            })
+          })
+        };
+      }
+      throw new Error(`createMockSupabase: unexpected table "${table}"`);
     })
   };
 }
 
-// Helper: mock Supabase that returns a DB error
-function createErrorSupabase(message = 'Connection refused') {
-  return {
-    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          in: vi.fn().mockResolvedValue({ data: null, error: { message } })
-        })
-      })
-    })
-  };
-}
+const FRESH_HEARTBEAT = () => new Date().toISOString();
 
 describe('Multi-Session Claim Conflict Gate', () => {
   describe('validateMultiSessionClaim', () => {
-    it('should PASS when no sessions claim the SD', async () => {
-      const supabase = createMockSupabase([]);
+    it('should PASS when no session claims the SD (Surface A unclaimed)', async () => {
+      const supabase = createMockSupabase({ ownerSessionId: null });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
 
@@ -54,20 +70,21 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(0);
     });
 
-    it('should BLOCK when session on DIFFERENT hostname claims the SD', async () => {
-      const sessions = [{
-        session_id: 'other-session-123',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'REMOTE-SERVER',
-        tty: '/dev/pts/1',
-        heartbeat_age_human: '30s ago',
-        heartbeat_age_seconds: 30,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+    it('should BLOCK when Surface A owner is on a DIFFERENT hostname and genuinely alive', async () => {
+      const supabase = createMockSupabase({
+        ownerSessionId: 'other-session-123',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'REMOTE-SERVER',
+          terminal_id: null,
+          tty: '/dev/pts/1',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'my-session-456',
@@ -82,20 +99,10 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.claimDetails.hostname).toBe('REMOTE-SERVER');
     });
 
-    it('should PASS when the only claim is from the current session (exact match)', async () => {
-      const sessions = [{
-        session_id: 'my-session-456',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'MY-LAPTOP',
-        tty: '/dev/pts/0',
-        heartbeat_age_human: '10s ago',
-        heartbeat_age_seconds: 10,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+    it('should PASS when Surface A owner IS the current session (exact match)', async () => {
+      // Surface A alone is dispositive — the gate must not even need to consult
+      // claude_sessions (Surface B) when the caller already owns the claim.
+      const supabase = createMockSupabase({ ownerSessionId: 'my-session-456' });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'my-session-456',
@@ -107,23 +114,23 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(0);
     });
 
-    it('should PASS when claim is from same hostname + same terminal_id (same conversation)', async () => {
+    it('should PASS when Surface A owner is a DIFFERENT session but same hostname + same terminal_id (same conversation)', async () => {
       // PAT-SESSION-IDENTITY-002: sd:start creates session A, handoff.js creates session B,
       // both share hostname AND terminal_id (same parent Claude Code process) → allow
-      const sessions = [{
-        session_id: 'sd-start-session-111',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'MY-LAPTOP',
-        terminal_id: 'win-ppid-43456',
-        tty: 'win-12345',
-        heartbeat_age_human: '20s ago',
-        heartbeat_age_seconds: 20,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+      const supabase = createMockSupabase({
+        ownerSessionId: 'sd-start-session-111',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'MY-LAPTOP',
+          terminal_id: 'win-ppid-43456',
+          tty: 'win-12345',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'handoff-session-222',
@@ -136,23 +143,23 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(0);
     });
 
-    it('should BLOCK when claim is from same hostname but DIFFERENT terminal_id (different conversation)', async () => {
+    it('should BLOCK when Surface A owner is alive on same hostname but DIFFERENT terminal_id (different conversation)', async () => {
       // SD-LEO-FIX-FIX-MULTI-SESSION-001: Two Claude Code conversations on same machine
       // have same hostname but different terminal_ids → must block
-      const sessions = [{
-        session_id: 'other-conversation-session',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'MY-LAPTOP',
-        terminal_id: 'win-ppid-99999', // Different terminal_id
-        tty: 'win-99999',
-        heartbeat_age_human: '15s ago',
-        heartbeat_age_seconds: 15,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+      const supabase = createMockSupabase({
+        ownerSessionId: 'other-conversation-session',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'MY-LAPTOP',
+          terminal_id: 'win-ppid-99999', // Different terminal_id
+          tty: 'win-99999',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'my-session-456',
@@ -167,22 +174,22 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.claimDetails.terminalId).toBe('win-ppid-99999');
     });
 
-    it('should BLOCK when claim has null terminal_id on same hostname (safe default)', async () => {
+    it('should BLOCK when Surface A owner is alive with null terminal_id on same hostname (safe default)', async () => {
       // Legacy sessions without terminal_id should be treated as conflicts
-      const sessions = [{
-        session_id: 'legacy-session-333',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'MY-LAPTOP',
-        terminal_id: null, // Legacy session, no terminal_id
-        tty: 'win-33333',
-        heartbeat_age_human: '30s ago',
-        heartbeat_age_seconds: 30,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+      const supabase = createMockSupabase({
+        ownerSessionId: 'legacy-session-333',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'MY-LAPTOP',
+          terminal_id: null, // Legacy session, no terminal_id
+          tty: 'win-33333',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'handoff-session-222',
@@ -195,8 +202,8 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.score).toBe(0);
     });
 
-    it('should fail-open on DB error (score 80)', async () => {
-      const supabase = createErrorSupabase('Connection refused');
+    it('should fail-open on DB error reading Surface A (score 80)', async () => {
+      const supabase = createMockSupabase({ sdError: { message: 'Connection refused' } });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
 
@@ -208,6 +215,7 @@ describe('Multi-Session Claim Conflict Gate', () => {
 
     it('should fail-open on unexpected exception', async () => {
       const supabase = {
+        rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
         from: vi.fn().mockImplementation(() => {
           throw new Error('Unexpected crash');
         })
@@ -221,28 +229,29 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.warnings[0]).toContain('Unexpected crash');
     });
 
-    it('should PASS when no currentSessionId provided and no claims exist', async () => {
-      const supabase = createMockSupabase([]);
+    it('should PASS when no currentSessionId provided and Surface A is unclaimed', async () => {
+      const supabase = createMockSupabase({ ownerSessionId: null });
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
 
       expect(result.pass).toBe(true);
     });
 
-    it('should BLOCK when no currentSessionId and claim from different hostname', async () => {
-      const sessions = [{
-        session_id: 'other-session-123',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'REMOTE-SERVER',
-        tty: '/dev/pts/1',
-        heartbeat_age_human: '1m ago',
-        heartbeat_age_seconds: 60,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+    it('should BLOCK when no currentSessionId and Surface A owner is alive on a different hostname', async () => {
+      const supabase = createMockSupabase({
+        ownerSessionId: 'other-session-123',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'REMOTE-SERVER',
+          terminal_id: null,
+          tty: '/dev/pts/1',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       // No currentSessionId but different hostname → blocks
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
@@ -253,21 +262,21 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(1);
     });
 
-    it('should PASS when no currentSessionId but claim from same hostname + same terminal_id', async () => {
-      const sessions = [{
-        session_id: 'other-session-123',
-        sd_id: 'SD-TEST-001',
-        sd_title: 'Test SD',
-        hostname: 'MY-LAPTOP',
-        terminal_id: 'win-ppid-43456',
-        tty: '/dev/pts/1',
-        heartbeat_age_human: '1m ago',
-        heartbeat_age_seconds: 60,
-        computed_status: 'active',
-        codebase: 'EHG_Engineer'
-      }];
-
-      const supabase = createMockSupabase(sessions);
+    it('should PASS when no currentSessionId but Surface A owner is on same hostname + same terminal_id', async () => {
+      const supabase = createMockSupabase({
+        ownerSessionId: 'other-session-123',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: null,
+          hostname: 'MY-LAPTOP',
+          terminal_id: 'win-ppid-43456',
+          tty: '/dev/pts/1',
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
 
       // No currentSessionId but same hostname + terminal_id → same conversation → pass
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
@@ -277,11 +286,60 @@ describe('Multi-Session Claim Conflict Gate', () => {
 
       expect(result.pass).toBe(true);
     });
+
+    // SD-LEO-INFRA-MULTI-SESSION-CLAIM-001: the exact recurred-family witnessed scenario at the
+    // unit-mock level (the mandatory live-DB e2e equivalent lives in
+    // tests/integration/multi-session-claim-gate-surface-a.integration.test.js). The rightful
+    // owner (Surface A === currentSessionId) must pass EVEN THOUGH an unrelated dead peer session
+    // independently has a phantom sd_key stamp on itself with a fresh-looking heartbeat — because
+    // the gate no longer queries Surface B (v_active_sessions/claude_sessions by sd_key) at all
+    // once Surface A confirms self-ownership.
+    it('should PASS the rightful Surface-A owner even when an unrelated dead peer holds a stale sd_key stamp with a fresh heartbeat', async () => {
+      const supabase = createMockSupabase({ ownerSessionId: 'me-the-rightful-owner' });
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'me-the-rightful-owner',
+        currentHostname: 'MY-LAPTOP',
+        currentTerminalId: 'win-ppid-43456'
+      });
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100);
+      // Surface B (claude_sessions) is never even queried in this path — asserting the mock's
+      // claude_sessions branch was not called would over-specify implementation, so the
+      // observable contract (pass:true, no Surface-B-derived issues) is what's asserted.
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('should PASS when Surface A owner is dead (stale heartbeat, is_alive=false) — delegated liveness auto-heals', async () => {
+      const supabase = createMockSupabase({
+        ownerSessionId: 'dead-owner-session',
+        ownerSessionRow: {
+          status: 'idle',
+          is_alive: false,
+          heartbeat_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(), // 20 min old, beyond CLAIM_TTL_MS
+          expected_silence_until: null,
+          hostname: 'REMOTE-SERVER',
+          terminal_id: null,
+          tty: null,
+          sd_key: 'SD-TEST-001',
+          codebase: 'EHG_Engineer'
+        }
+      });
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456',
+        currentHostname: 'MY-LAPTOP'
+      });
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100);
+    });
   });
 
   describe('createMultiSessionClaimGate', () => {
     it('should create a gate with correct name and properties', () => {
-      const supabase = createMockSupabase([]);
+      const supabase = createMockSupabase({ ownerSessionId: null });
       const gate = createMultiSessionClaimGate(supabase, 'SD-TEST-001');
 
       expect(gate.name).toBe('GATE_MULTI_SESSION_CLAIM_CONFLICT');
@@ -292,7 +350,7 @@ describe('Multi-Session Claim Conflict Gate', () => {
     });
 
     it('should execute validator and return results', async () => {
-      const supabase = createMockSupabase([]);
+      const supabase = createMockSupabase({ ownerSessionId: null });
       const gate = createMultiSessionClaimGate(supabase, 'SD-TEST-001');
 
       const result = await gate.validator();


### PR DESCRIPTION
## Summary
- `validateMultiSessionClaim()` (the gate that runs before every LEAD/PLAN/EXEC handoff to block duplicate concurrent work) derived claim ownership from the `v_active_sessions` heartbeat view instead of the authoritative `strategic_directives_v2.claiming_session_id` column (Surface A, written by `claim_sd()`).
- An unrelated dead peer session holding a stale `sd_key` stamp with a fresh-looking heartbeat could false-block the legitimate claim owner's own handoff. Witnessed live 2026-07-17 01:57Z (session be313562, SD-FDBK-INFRA-FIX-GATE-SUBAGENT-001).
- This is a **recurred-family** defect — a prior fix (SD-LEO-FIX-FIX-MULTI-SESSION-001) completed, yet this facet recurred afterward.
- Fix: read Surface A first; delegate liveness/staleness to the same hardened primitives the canonical `assertValidClaim()` gate already uses (`lib/claim-validity-gate.js`, `lib/fleet/silence-cap.cjs`), preserving the existing same-conversation carve-out and DENY-on-ambiguity fallthrough.

## Test plan
- [x] `tests/unit/multi-session-claim-gate.test.js` — fully rewritten, 15/15 passing
- [x] `tests/unit/claim-default.test.js` — ambiguity-handling test updated to pin new behavior, 12/12 passing
- [x] `tests/integration/multi-session-claim-gate-surface-a.integration.test.js` — **new**, live-DB e2e (no mocks) reproducing the exact witnessed scenario + the inverse no-regression case (genuine live foreign claim still blocks), per the recurred-family rule
- [x] Regression sweep: `tests/unit/claim/`, `tests/unit/session-writer/` (102 tests) all green
- [x] LEAD/PLAN/EXEC-TO-PLAN sub-agent evidence (VALIDATION, Explore, TESTING, SECURITY) all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)