### PR TITLE
fix(SD-LEO-FEAT-SMS-INBOUND-RELAY-001): wire red-team script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "security:audit": "node scripts/security-audit-dashboard.js",
     "security:rls": "node scripts/audit-rls-policies.js",
     "security:linter": "node scripts/sentinels/audit-security-linter.mjs",
+    "security:sms-relay-redteam": "node scripts/security/sms-relay-redteam.js",
     "eva:dlq:replay": "node scripts/eva-dlq-replay.js",
     "eva:constitution": "node scripts/eva/constitution-command.mjs",
     "eva:constitution:view": "node scripts/eva/constitution-command.mjs view",


### PR DESCRIPTION
## Summary
- LEAD-FINAL-APPROVAL's WIRE_CHECK_GATE flagged `scripts/security/sms-relay-redteam.js` (added in #6154) as unreachable from any entry point.
- Adds `npm run security:sms-relay-redteam` per the gate's own remediation guidance.

Tiny follow-up to the already-merged #6154, closing the LEAD-FINAL gate finding.

## Test plan
- [x] `node scripts/security/sms-relay-redteam.js` still runs and passes via the new script alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)