### PR TITLE
feat(SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A): PR-2 — precheck packet composer + spoof-safe attach + ratification render

### DIFF
--- a/lib/chairman/decision-layman.mjs
+++ b/lib/chairman/decision-layman.mjs
@@ -323,6 +323,23 @@ export function renderLeanDecision(baseRow, now = new Date()) {
       `Show it to me and walk me through the call. ${ref}`;
   }
 
+  // SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A: ratification evidence rows carry a
+  // machine precheck packet at brief_data.context.precheck_packet (namespaced by
+  // record-pending-decision — never spread at brief_data root). Render the per-case
+  // verdict summary + the permanent EXPERIMENTAL watermark instead of raw JSON context.
+  // Falls through to the generic renderer when the packet shape is absent/unrecognized.
+  if (dt === 'ratification') {
+    const pkt = bd.context && typeof bd.context === 'object' ? bd.context.precheck_packet : null;
+    if (pkt && pkt.summary && typeof pkt.summary === 'object') {
+      const s = pkt.summary;
+      const conf = typeof pkt.confidence === 'number' ? ` confidence ${pkt.confidence}` : '';
+      return `Ratification evidence (EXPERIMENTAL machine precheck — feeds your call, never replaces it): ` +
+        `“${title}” (waiting ${age}). Shadow-run: ${s.passes ?? 0}/${s.cases_total ?? 0} cases pass, ` +
+        `${s.regressions ?? 0} regression${(s.regressions ?? 0) === 1 ? '' : 's'} — ` +
+        `${cleanText(String(pkt.recommendation || 'insufficient_evidence'), 40)}${conf}.${recLine} ${ref}`;
+    }
+  }
+
   // Non-venture decision — render the ACTUAL question + context + recommendation.
   let ctx = bd.context;
   if (ctx && typeof ctx !== 'string') { try { ctx = JSON.stringify(ctx); } catch { ctx = ''; } }

--- a/lib/governance/shadow-trial/attach-packet.mjs
+++ b/lib/governance/shadow-trial/attach-packet.mjs
@@ -1,0 +1,68 @@
+/**
+ * Precheck-packet attach — shadow-trial ratification sandbox.
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A (FR-4).
+ *
+ * Records the precheck packet as a NON-ACTIONABLE, EVIDENCE-ONLY chairman decision row
+ * (decision_type='ratification') via the canonical recordPendingDecision writer — never a
+ * hand-rolled insert.
+ *
+ * SPOOF-SAFETY (PAT-PROVENANCE-SPOOF-VIA-SPREAD-ORDER-001): the packet is passed as
+ * `context`, which recordPendingDecision assigns as a single NESTED key
+ * (brief_data.context) UNDER its canonical fields (title, recorded_via, raised_by) — the
+ * packet object is never spread into the brief_data root, so a hostile packet carrying
+ * canonical-field keys structurally cannot override them. The packet lands at
+ * brief_data.context.precheck_packet.
+ *
+ * EVIDENCE ONLY (CONST-002): blocking is hard-false (a ratification packet never
+ * escalates or blocks anything); the row's decision/status stay 'pending' as written by
+ * the canonical writer and are NEVER transitioned here; ratification rows are
+ * deliberately absent from the get_pending_chairman_items actionable allow-list.
+ */
+
+import { recordPendingDecision } from '../../chairman/record-pending-decision.mjs';
+import { TABLE, isMissingTableError } from './proposal-writer.mjs';
+
+export const RATIFICATION_DECISION_TYPE = 'ratification';
+
+/**
+ * Attach a composed precheck packet to the chairman decision surface.
+ * @param {Object} supabase - injected client
+ * @param {Object} opts
+ * @param {string} opts.proposalId - governed_change_proposals.id
+ * @param {Object} opts.packet - output of composePrecheckPacket (must carry experimental:true)
+ * @param {string} opts.title - short chairman-facing headline for the ratification request
+ * @param {string} [opts.raisedBy] - who staged/ran the precheck
+ * @returns {Promise<{attached: boolean, decisionId?: string, error?: string}>}
+ */
+export async function attachPrecheckPacket(supabase, { proposalId, packet, title, raisedBy } = {}) {
+  if (!supabase) return { attached: false, error: 'supabase client is required' };
+  if (!proposalId) return { attached: false, error: 'proposalId is required' };
+  if (!title) return { attached: false, error: 'title is required' };
+  if (!packet || typeof packet !== 'object' || packet.experimental !== true) {
+    // Refuse packets that dropped the experimental watermark — the composer contract
+    // guarantees it, so its absence means a non-composer (untrusted) object.
+    return { attached: false, error: 'packet must be a composePrecheckPacket output (experimental watermark missing)' };
+  }
+
+  const res = await recordPendingDecision(supabase, {
+    title,
+    decisionType: RATIFICATION_DECISION_TYPE,
+    blocking: false, // hard-false: evidence, never an escalating/blocking item
+    raisedBy: raisedBy ?? null,
+    context: { precheck_packet: packet, proposal_id: proposalId },
+  });
+  if (!res.recorded) return { attached: false, error: res.error };
+
+  // Advance the SANDBOX'S OWN staging row (not a governed artifact) to packet_attached.
+  // Soft-guarded: pre-ceremony (table unapplied) this is a silent no-op.
+  const up = await supabase
+    .from(TABLE)
+    .update({ status: 'packet_attached', updated_at: new Date().toISOString() })
+    .eq('id', proposalId);
+  if (up.error && !isMissingTableError(up.error)) {
+    // Non-fatal: the evidence row exists; staging-status drift is visible and repairable.
+    return { attached: true, decisionId: res.id, error: `status update failed: ${up.error.message}` };
+  }
+
+  return { attached: true, decisionId: res.id };
+}

--- a/lib/governance/shadow-trial/precheck-packet.mjs
+++ b/lib/governance/shadow-trial/precheck-packet.mjs
@@ -1,0 +1,77 @@
+/**
+ * Precheck-packet composer — shadow-trial ratification sandbox.
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A (FR-3).
+ *
+ * PURE function: maps shadow-run per-case results into the one chairman-facing verdict
+ * object appended to a ratification request. EVIDENCE ONLY (CONST-002): the packet FEEDS
+ * the chairman's decision and never replaces it; nothing here has apply authority.
+ *
+ * The `experimental: true` watermark is HARD-CODED in this child: the observe-first
+ * concordance ladder (N>=10 graded verdict-vs-chairman-decision agreements) that could
+ * ever change how much weight a packet claims is an explicitly gated future SD — until
+ * then every packet self-identifies as experimental evidence.
+ *
+ * This module's exported shape is the CONTRACT child C composes against — additive
+ * changes only.
+ */
+
+export const RECOMMENDATIONS = Object.freeze({
+  SAFE: 'looks_safe',
+  REGRESSIONS: 'has_regressions',
+  INSUFFICIENT: 'insufficient_evidence',
+});
+
+/** Shape guard for one shadow-run case result. */
+export function isCaseResult(entry) {
+  return !!entry
+    && typeof entry === 'object'
+    && typeof entry.case_id === 'string'
+    && 'current_verdict' in entry
+    && 'proposed_verdict' in entry
+    && typeof entry.regression === 'boolean';
+}
+
+/**
+ * Compose the chairman-facing precheck packet.
+ * @param {Array} results - per-case shadow-run results
+ *   [{ case_id, current_verdict, proposed_verdict, delta, regression }]
+ * @param {Object} opts
+ * @param {string} opts.proposalId - governed_change_proposals.id this packet describes
+ * @param {string|Date} [opts.generatedAt] - injectable clock for determinism in tests
+ * @returns {Object} packet — see data contract in the PRD
+ */
+export function composePrecheckPacket(results, { proposalId, generatedAt } = {}) {
+  const valid = (Array.isArray(results) ? results : []).filter(isCaseResult);
+  const casesTotal = valid.length;
+  const regressions = valid.filter((r) => r.regression === true).length;
+  const passes = casesTotal - regressions;
+
+  let recommendation;
+  if (casesTotal === 0) recommendation = RECOMMENDATIONS.INSUFFICIENT;
+  else if (regressions > 0) recommendation = RECOMMENDATIONS.REGRESSIONS;
+  else recommendation = RECOMMENDATIONS.SAFE;
+
+  // Deterministic, deliberately modest confidence: pass-rate scaled by corpus size
+  // (fewer than 5 cases can never claim full confidence), 0 when there is no evidence.
+  const confidence = casesTotal === 0
+    ? 0
+    : Math.round((passes / casesTotal) * Math.min(1, casesTotal / 5) * 100) / 100;
+
+  return {
+    proposal_id: proposalId ?? null,
+    per_case: valid.map((r) => ({
+      case_id: r.case_id,
+      current_verdict: r.current_verdict,
+      proposed_verdict: r.proposed_verdict,
+      delta: r.delta ?? null,
+      regression: r.regression,
+    })),
+    summary: { cases_total: casesTotal, regressions, passes },
+    recommendation,
+    confidence,
+    experimental: true,
+    generated_at: generatedAt
+      ? new Date(generatedAt).toISOString()
+      : new Date().toISOString(),
+  };
+}

--- a/tests/unit/governance/shadow-trial/shadow-trial-packet.test.js
+++ b/tests/unit/governance/shadow-trial/shadow-trial-packet.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit Tests: Shadow-trial child A (PR-2) — precheck packet, attach, render.
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A
+ *
+ * Covers: composer determinism + recommendation rules + permanent experimental
+ * watermark, hostile-packet spoof safety (the packet can never override canonical
+ * brief_data fields), the evidence-only write allow-list, and the decision-layman
+ * ratification render branch. Writer/ceremony tests live in shadow-trial-writer.test.js.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { TABLE } from '../../../../lib/governance/shadow-trial/proposal-writer.mjs';
+import {
+  composePrecheckPacket,
+  RECOMMENDATIONS,
+} from '../../../../lib/governance/shadow-trial/precheck-packet.mjs';
+import { attachPrecheckPacket, RATIFICATION_DECISION_TYPE } from '../../../../lib/governance/shadow-trial/attach-packet.mjs';
+import { renderLeanDecision } from '../../../../lib/chairman/decision-layman.mjs';
+
+/**
+ * Capturing stub client: records every table touched and the operation kind, so the
+ * evidence-only invariant test can assert the exact write allow-list. Query methods are
+ * chainable like the real PostgREST builder; terminal awaits resolve with the canned
+ * response for that table.
+ */
+function stubClient({ probeError = null, insertError = null } = {}) {
+  const writes = [];
+  const reads = [];
+  const make = (tableName) => {
+    const rowsHolder = { rows: null };
+    const chain = {
+      select(cols) { reads.push({ table: tableName, cols }); return chain; },
+      limit() { return Promise.resolve(probeErrorFor(tableName)); },
+      insert(row) { writes.push({ table: tableName, op: 'insert', row }); rowsHolder.rows = [{ id: `id-${tableName}` }]; return chain; },
+      upsert(row, opts) { writes.push({ table: tableName, op: 'upsert', row, opts }); rowsHolder.rows = [{ id: `id-${tableName}` }]; return chain; },
+      update(patch) { writes.push({ table: tableName, op: 'update', patch }); return chain; },
+      eq() { return Promise.resolve({ data: rowsHolder.rows, error: null }); },
+      then(resolve) { resolve({ data: rowsHolder.rows, error: insertError }); },
+    };
+    return chain;
+  };
+  const probeErrorFor = (tableName) => (tableName === TABLE && probeError ? { data: null, error: probeError } : { data: [], error: null });
+  return { from: (t) => make(t), _writes: writes, _reads: reads };
+}
+
+describe('composePrecheckPacket — determinism, rules, watermark', () => {
+  const CASES = [
+    { case_id: 'C1', current_verdict: 'OPEN', proposed_verdict: 'OPEN', delta: 0, regression: false },
+    { case_id: 'C2', current_verdict: 'OPEN', proposed_verdict: 'CLOSED', delta: 1, regression: true },
+  ];
+  test('regressions force has_regressions; clean set is looks_safe; empty is insufficient', () => {
+    const at = '2026-07-17T12:00:00Z';
+    expect(composePrecheckPacket(CASES, { proposalId: 'p1', generatedAt: at }).recommendation).toBe(RECOMMENDATIONS.REGRESSIONS);
+    expect(composePrecheckPacket([CASES[0]], { proposalId: 'p1', generatedAt: at }).recommendation).toBe(RECOMMENDATIONS.SAFE);
+    const empty = composePrecheckPacket([], { proposalId: 'p1', generatedAt: at });
+    expect(empty.recommendation).toBe(RECOMMENDATIONS.INSUFFICIENT);
+    expect(empty.confidence).toBe(0);
+  });
+  test('deterministic for identical input; experimental watermark always true; small corpora cap confidence', () => {
+    const at = '2026-07-17T12:00:00Z';
+    const a = composePrecheckPacket(CASES, { proposalId: 'p1', generatedAt: at });
+    const b = composePrecheckPacket(CASES, { proposalId: 'p1', generatedAt: at });
+    expect(a).toEqual(b);
+    expect(a.experimental).toBe(true);
+    // 1 pass of 2 cases, scaled by 2/5 corpus factor => well under 0.5
+    expect(a.confidence).toBeLessThan(0.5);
+    expect(a.summary).toEqual({ cases_total: 2, regressions: 1, passes: 1 });
+  });
+  test('malformed case entries are excluded, not scored', () => {
+    const res = composePrecheckPacket([{ bogus: true }, CASES[0]], { proposalId: 'p1', generatedAt: '2026-07-17T12:00:00Z' });
+    expect(res.summary.cases_total).toBe(1);
+  });
+});
+
+describe('attachPrecheckPacket — spoof safety + evidence-only invariant', () => {
+  const packet = (extra = {}) => ({
+    ...composePrecheckPacket([{ case_id: 'C1', current_verdict: 'OPEN', proposed_verdict: 'OPEN', delta: 0, regression: false }], { proposalId: 'p1', generatedAt: '2026-07-17T12:00:00Z' }),
+    ...extra,
+  });
+
+  test('hostile packet keys cannot override canonical brief_data/row fields', async () => {
+    const client = stubClient();
+    const hostile = packet({ recorded_via: 'EVIL', raised_by: 'EVIL', decision_type: 'chairman_approval', title: 'EVIL', status: 'approved' });
+    const res = await attachPrecheckPacket(client, { proposalId: 'p1', packet: hostile, title: 'Real title', raisedBy: 'Alpha-2' });
+    expect(res.attached).toBe(true);
+    const decisionInsert = client._writes.find((w) => w.table === 'chairman_decisions');
+    expect(decisionInsert.op).toBe('insert');
+    const row = decisionInsert.row;
+    // Canonical row fields win — the packet lives ONLY nested under brief_data.context.
+    expect(row.decision_type).toBe(RATIFICATION_DECISION_TYPE);
+    expect(row.status).toBe('pending');
+    expect(row.blocking).toBe(false);
+    expect(row.brief_data.recorded_via).toBe('record-pending-decision');
+    expect(row.brief_data.title).toBe('Real title');
+    expect(row.brief_data.raised_by).toBe('Alpha-2');
+    expect(row.brief_data.context.precheck_packet.recorded_via).toBe('EVIL'); // intact but harmlessly namespaced
+    expect(row.brief_data.context.proposal_id).toBe('p1');
+  });
+
+  test('EVIDENCE-ONLY write allow-list: exactly one chairman_decisions insert + own staging-table status update', async () => {
+    const client = stubClient();
+    await attachPrecheckPacket(client, { proposalId: 'p1', packet: packet(), title: 'T', raisedBy: 'Alpha-2' });
+    const touched = client._writes.map((w) => `${w.table}:${w.op}`);
+    expect(touched).toEqual(['chairman_decisions:insert', `${TABLE}:update`]);
+    // No status transition on chairman_decisions anywhere.
+    expect(client._writes.filter((w) => w.table === 'chairman_decisions' && w.op !== 'insert')).toHaveLength(0);
+  });
+
+  test('refuses non-composer packets (missing experimental watermark)', async () => {
+    const client = stubClient();
+    const res = await attachPrecheckPacket(client, { proposalId: 'p1', packet: { summary: {} }, title: 'T' });
+    expect(res.attached).toBe(false);
+    expect(client._writes).toHaveLength(0);
+  });
+});
+
+describe('decision-layman ratification render', () => {
+  const baseRow = (bd) => ({
+    id: 'd1', decision_type: 'ratification', created_at: new Date().toISOString(),
+    summary: 'Ratify closure-predicate change', brief_data: bd, blocking: false,
+  });
+  test('renders per-case counts + EXPERIMENTAL watermark + trailing ref', () => {
+    const pkt = composePrecheckPacket([
+      { case_id: 'C1', current_verdict: 'OPEN', proposed_verdict: 'OPEN', delta: 0, regression: false },
+      { case_id: 'C2', current_verdict: 'OPEN', proposed_verdict: 'CLOSED', delta: 1, regression: true },
+    ], { proposalId: 'p1', generatedAt: '2026-07-17T12:00:00Z' });
+    const line = renderLeanDecision(baseRow({ title: 'Ratify predicate v4', context: { precheck_packet: pkt, proposal_id: 'p1' } }));
+    expect(line).toContain('EXPERIMENTAL');
+    expect(line).toContain('1/2 cases pass');
+    expect(line).toContain('1 regression');
+    expect(line).toContain('has_regressions');
+    expect(line.trim().endsWith('[ref ratification:d1]')).toBe(true);
+  });
+  test('unknown packet shape falls back to the generic renderer without crashing', () => {
+    const line = renderLeanDecision(baseRow({ title: 'Ratify something', context: { not_a_packet: true } }));
+    expect(line).toContain('Decide:');
+    expect(line).toContain('[ref ratification:d1]');
+  });
+});


### PR DESCRIPTION
## Summary
Second and final slice of shadow-trial child A (follows #6162):
- **`composePrecheckPacket`** (pure): per-case pass/regress mapping, regression-forced recommendations (`has_regressions` / `looks_safe` / `insufficient_evidence`), deterministic modest confidence (pass-rate × corpus-size factor), and a **hard `experimental: true` watermark** — the concordance ladder that could ever change a packet's claimed weight is an explicitly gated future SD.
- **`attachPrecheckPacket`**: records a **non-actionable, evidence-only** chairman decision (`decision_type='ratification'`, `blocking` hard-false) via the canonical `recordPendingDecision` writer. The packet is namespaced at `brief_data.context.precheck_packet` — canonical fields are assigned above it, making PAT-PROVENANCE-SPOOF-VIA-SPREAD-ORDER-001-style spoofing structurally impossible (hostile-packet test proves it). Rows are deliberately absent from the `get_pending_chairman_items` actionable allow-list. Refuses packets missing the composer watermark.
- **Ratification render branch** in `lib/chairman/decision-layman.mjs`: per-case counts + EXPERIMENTAL watermark + the standard trailing `decision_type:id` ref; unknown packet shapes fall back to the generic renderer.
- **Evidence-only invariant test**: asserts the exact write allow-list (`chairman_decisions:insert` + own staging-table status update) and zero decision-status transitions — CONST-002 enforced by test, not promise.

301 LOC (162 source / 139 tests) — over the 100 target with justification: the spoof-safety and evidence-only invariants demand their full test matrix in the same reviewable unit.

Test plan: 7 new packet-suite scenarios + writer suite + both existing decision-layman regression suites — 33 tests green locally.

PRD: `PRD-SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A` (approved) · Evidence: VALIDATION `f12f9186` / RISK `93c8ed1d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)