### PR TITLE
chore(SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A): wire-check exemptions for child-C-consumed packet modules

### DIFF
--- a/lib/governance/shadow-trial/attach-packet.mjs
+++ b/lib/governance/shadow-trial/attach-packet.mjs
@@ -1,4 +1,9 @@
 /**
+ * // @wire-check-exempt: library module for the shadow-trial sandbox; production
+ * // consumer is child C (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C shadow-run
+ * // core), whose acceptance criteria mandate wiring one real producer end-to-end
+ * // (staged proposal -> shadow-run -> packet -> ratification row). Until child C
+ * // ships, reachability is via the test suites + this documented seam.
  * Precheck-packet attach — shadow-trial ratification sandbox.
  * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A (FR-4).
  *

--- a/lib/governance/shadow-trial/precheck-packet.mjs
+++ b/lib/governance/shadow-trial/precheck-packet.mjs
@@ -1,4 +1,9 @@
 /**
+ * // @wire-check-exempt: library module for the shadow-trial sandbox; production
+ * // consumer is child C (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C shadow-run
+ * // core), whose acceptance criteria mandate wiring one real producer end-to-end
+ * // (staged proposal -> shadow-run -> packet -> ratification row). Until child C
+ * // ships, reachability is via the test suites + this documented seam.
  * Precheck-packet composer — shadow-trial ratification sandbox.
  * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-A (FR-3).
  *


### PR DESCRIPTION
precheck-packet.mjs and attach-packet.mjs are library modules whose
production consumer is child C's shadow-run core (its acceptance criteria
mandate wiring one real producer end-to-end). Annotate the documented
@wire-check-exempt seam so LEAD-FINAL's WIRE_CHECK_GATE records the
intentional decomposition boundary instead of flagging dark code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Fleet-Worker: Alpha-2
Claude-Session: 75390de2-42eb-4dff-a669-393b708737d1
