### PR TITLE
feat(SD-LEO-INFRA-SEND-TIME-TARGET-001): send-time target-role drain-set validation (warn-only)

### DIFF
--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -175,6 +175,8 @@ Before relying on the worker<->coordinator channel (especially overnight / unatt
 
 Run it at `/coordinator start` (after identity assignment) and any time you need to TRUST signal delivery. **Worker rule:** poll your coordination inbox **as a `/loop` step each iteration** (`/checkin`, or `node scripts/fleet-dashboard.cjs inbox` / worker-inbox) — never a hand-rolled bounded Bash poll (overshoots the 120000ms Bash timeout → exit-143) — ACK a comms check in one line, then continue and `ScheduleWakeup` so the next iteration re-fires.
 
+**Role canaries (Solomon leg — SD-LEO-INFRA-SEND-TIME-TARGET-001):** a canary/radio-check directed at **Solomon** must ride `kind=comms_check` — NEVER a default `adam_advisory` (Solomon's inbox never auto-drains that kind; the 2026-07-17 good-morning canary orphaned exactly this way). `solomon-advisory.cjs inbox` surfaces Solomon-directed `comms_check` rows first-class with the ack instruction. More generally, every send path now emits a `[target-drain]` WARN when the outgoing `payload.kind` is not in the target role's drain set (`DRAIN_SETS` in `lib/fleet/worker-status.cjs`) — warn-only; treat a warn as "this delivery will orphan, pick a kind the role drains."
+
 ---
 ### Related documentation
 - [The LEO Harness](./README.md) — canonical overview tying the roles, channels, loop model, and failure modes together.

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -54,17 +54,28 @@ const SENTINEL_ROLES = Object.freeze({
  * it). Null keeps the warn helper silent (fail-open; SEND-TIME-TARGET-001 TR-3).
  * @private
  */
+// Adversarial-review fix (PR #6170): the three identity resolutions are memoized with a
+// short TTL so an unhinted burst of UUID-targeted sends pays ~one lookup trio, not one per
+// send, on the fleet's hottest write path. 60s is far shorter than any real role-identity
+// churn (coordinator/Adam/Solomon identities change on session start/stop, minutes apart).
+const ROLE_IDS_TTL_MS = 60_000;
+let _roleIdsCache = { at: 0, ids: null };
+
 async function resolveTargetRole(supabase, target, targetRoleHint) {
   if (targetRoleHint) return String(targetRoleHint).toLowerCase();
   if (!target || typeof target !== 'string') return null;
   if (SENTINEL_ROLES[target]) return SENTINEL_ROLES[target];
   if (target === 'broadcast' || !isFullUuid(target)) return null;
   try {
-    const [adamId, solomonId, coordinatorId] = await Promise.all([
-      getActiveAdamId(supabase, {}).catch(() => null),
-      getActiveSolomonId(supabase, {}).catch(() => null),
-      getActiveCoordinatorId(supabase).catch(() => null),
-    ]);
+    if (!_roleIdsCache.ids || (Date.now() - _roleIdsCache.at) > ROLE_IDS_TTL_MS) {
+      const [adamId, solomonId, coordinatorId] = await Promise.all([
+        getActiveAdamId(supabase, {}).catch(() => null),
+        getActiveSolomonId(supabase, {}).catch(() => null),
+        getActiveCoordinatorId(supabase).catch(() => null),
+      ]);
+      _roleIdsCache = { at: Date.now(), ids: { adamId, solomonId, coordinatorId } };
+    }
+    const { adamId, solomonId, coordinatorId } = _roleIdsCache.ids;
     if (target === adamId) return 'adam';
     if (target === solomonId) return 'solomon';
     if (target === coordinatorId) return 'coordinator';
@@ -775,8 +786,10 @@ async function getThreadByTopicId(supabase, topicId) {
 async function dispatchToWorker(supabase, row, opts = {}) {
   // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: this wrapper IS the coordinator→worker intent,
   // so it carries the 'worker' role hint for the target-drain warn (resolveTargetRole never
-  // infers 'worker' from a UUID — positive identity matches only). Caller-supplied hint wins.
-  return insertCoordinationRow(supabase, row, { targetRoleHint: 'worker', ...opts });
+  // infers 'worker' from a UUID — positive identity matches only). Caller-supplied hint wins;
+  // ?? (not spread-order) so a caller's conditional `targetRoleHint: undefined` idiom cannot
+  // silently clobber the default (adversarial-review fix, PR #6170).
+  return insertCoordinationRow(supabase, row, { ...opts, targetRoleHint: opts.targetRoleHint ?? 'worker' });
 }
 
 module.exports = {

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -28,6 +28,51 @@ const crypto = require('crypto');
 const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cjs');
 // QF-20260709-053: no circular-require risk (adam-identity.cjs has zero requires of its own).
 const { getActiveAdamId } = require('./adam-identity.cjs');
+// SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: send-time target-drain warn at THE choke point —
+// every send path (adam-advisory, solomon-advisory, worker-signal, coordinator dispatch)
+// already routes through insertCoordinationRow, so the kind-vs-drain-set contract lives here
+// once instead of per-file. None of these requires dispatch.cjs back (no cycle).
+const { warnIfUndrainedKind } = require('../fleet/worker-status.cjs');
+const { getActiveSolomonId } = require('./solomon-identity.cjs');
+const { getActiveCoordinatorId } = require('./resolve.cjs');
+
+// Sentinel target → role, for the target-drain warn. 'broadcast' (all roles) resolves to
+// null: no single drain set applies, so the check stays silent.
+const SENTINEL_ROLES = Object.freeze({
+  'broadcast-coordinator': 'coordinator',
+  'broadcast-solomon': 'solomon',
+  'broadcast-adam': 'adam',
+});
+
+/**
+ * Resolve the ROLE a target_session will be drained by: caller hint > sentinel map >
+ * POSITIVE role-identity match (adam/solomon/coordinator resolvers, all fail-open).
+ * A UUID matching none of the three named roles resolves to null, NOT 'worker' — a
+ * transiently-unresolvable Adam/Solomon must never be misclassified into a mis-warn
+ * (warn-only contract: precision over recall). Coordinator→worker senders that KNOW
+ * their target is a worker say so via opts.targetRoleHint (dispatchToWorker defaults
+ * it). Null keeps the warn helper silent (fail-open; SEND-TIME-TARGET-001 TR-3).
+ * @private
+ */
+async function resolveTargetRole(supabase, target, targetRoleHint) {
+  if (targetRoleHint) return String(targetRoleHint).toLowerCase();
+  if (!target || typeof target !== 'string') return null;
+  if (SENTINEL_ROLES[target]) return SENTINEL_ROLES[target];
+  if (target === 'broadcast' || !isFullUuid(target)) return null;
+  try {
+    const [adamId, solomonId, coordinatorId] = await Promise.all([
+      getActiveAdamId(supabase, {}).catch(() => null),
+      getActiveSolomonId(supabase, {}).catch(() => null),
+      getActiveCoordinatorId(supabase).catch(() => null),
+    ]);
+    if (target === adamId) return 'adam';
+    if (target === solomonId) return 'solomon';
+    if (target === coordinatorId) return 'coordinator';
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 // QF-20260710-750 (closure-map line 39): a claude_sessions ROW existing is not the same as the
 // session being LIVE -- a row persists long after its process ends. 10min mirrors the SAME
@@ -680,6 +725,21 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
       }
     }
   }
+  // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: kind-vs-target-drain-set contract. WARN-ONLY —
+  // a mismatch never blocks the insert (warn→reject tightening is an explicit follow-on after
+  // burn-in). Fires only on a CONFIDENT mismatch: resolvable target role + a non-terminal
+  // payload.kind absent from that role's DRAIN_SETS entry (lib/fleet/worker-status.cjs).
+  // Callers that know their target's role statically pass opts.targetRoleHint (e.g.
+  // adam-advisory `--to solomon` → 'solomon') so a UUID target needs no identity lookup.
+  try {
+    const kind = row.payload && typeof row.payload === 'object' ? row.payload.kind : null;
+    if (kind) {
+      const targetRole = await resolveTargetRole(supabase, row.target_session, opts.targetRoleHint);
+      warnIfUndrainedKind({ targetRole, kind, log: (logger && logger.warn) || console.warn });
+    }
+  } catch (e) {
+    logger && logger.warn && logger.warn(`[dispatch] target-drain check skipped (fail-open): ${e.message}`);
+  }
   let q = supabase.from('session_coordination').insert(row);
   if (select) {
     q = q.select(select);
@@ -713,15 +773,20 @@ async function getThreadByTopicId(supabase, topicId) {
  * insertCoordinationRow; exists so call sites read intentionally.
  */
 async function dispatchToWorker(supabase, row, opts = {}) {
-  return insertCoordinationRow(supabase, row, opts);
+  // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: this wrapper IS the coordinator→worker intent,
+  // so it carries the 'worker' role hint for the target-drain warn (resolveTargetRole never
+  // infers 'worker' from a UUID — positive identity matches only). Caller-supplied hint wins.
+  return insertCoordinationRow(supabase, row, { targetRoleHint: 'worker', ...opts });
 }
 
 module.exports = {
   FULL_UUID_RE,
   SENTINEL_TARGETS,
+  SENTINEL_ROLES,
   isFullUuid,
   isSentinelTarget,
   assertValidTarget,
+  resolveTargetRole,
   insertCoordinationRow,
   getThreadByTopicId,
   dispatchToWorker,

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -130,6 +130,82 @@ const PRIORITY_EXEMPT_DIRECTIVE_KINDS = Object.freeze(['fence_notice']);
 // the same "mechanical, never authored" rationale as canary_request/comms_check.
 const ADAM_EXCLUDED_KINDS = Object.freeze(['canary_request', 'comms_check', 'ack', 'coordinator_ack', 'cross_party_ping']);
 
+// SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-1: per-role DRAIN SETS — the kinds SOMEONE at
+// that role actually drains (generic inbox, dedicated responder, or read-only fence check).
+// Send-time validation previously checked only the GLOBAL kind vocabulary, so a send could
+// pass validation yet orphan at the target (Adam's good-morning canary sent adam_advisory
+// to Solomon, which SOLOMON_INBOX_KINDS never drains — Solomon MODE-B finding b93d8966).
+// The contract here is "will this delivery ever be drained at that role", NOT "does the
+// generic inbox consume it" — handler-owned kinds (canary_request, comms_check) count as
+// drained because a dedicated responder owns them. Receiver modules (SOLOMON_INBOX_KINDS
+// in solomon-advisory.cjs, the Adam lane lists above) are mirrors of these entries; when a
+// role learns a new kind, add it HERE first.
+const DRAIN_SETS = Object.freeze({
+  solomon: Object.freeze([
+    ...DIRECTIVE_KINDS,                 // mirrors SOLOMON_INBOX_KINDS (DIRECTIVE_KINDS spread)
+    PAYLOAD_KINDS.SOLOMON_CONSULT,      // mirrors SOLOMON_INBOX_KINDS (+ solomon_consult)
+    'comms_check',                      // FR-3: Solomon-directed canary (surfaced by solomon-advisory inbox)
+  ]),
+  adam: Object.freeze([
+    ...DIRECTIVE_KINDS,
+    PAYLOAD_KINDS.ADAM_ADVISORY,
+    PAYLOAD_KINDS.COORDINATOR_REPLY,
+    PAYLOAD_KINDS.CANARY_REQUEST,       // handler-owned (canary responder) — drained, just not by the generic inbox
+    'comms_check',                      // handler-owned, same rationale
+    PAYLOAD_KINDS.CROSS_PARTY_PING,     // handler-owned (quiet-tick machinery)
+  ]),
+  coordinator: Object.freeze([
+    ...DIRECTIVE_KINDS,
+    PAYLOAD_KINDS.ROLL_CALL,
+    PAYLOAD_KINDS.COORDINATOR_REPLY,
+    PAYLOAD_KINDS.ADAM_ADVISORY,        // Adam→coordinator advisory lane
+    PAYLOAD_KINDS.RELAY_REQUEST,        // coordinator-relay-drain.cjs owns these
+    PAYLOAD_KINDS.RELAY_CONFIRM,
+    PAYLOAD_KINDS.CROSS_PARTY_PING,
+    PAYLOAD_KINDS.SOLOMON_CONSULT,      // consult via coordinator-relay default path
+  ]),
+  worker: Object.freeze([
+    PAYLOAD_KINDS.WORK_ASSIGNMENT,
+    PAYLOAD_KINDS.COORDINATOR_REQUEST,
+    PAYLOAD_KINDS.COORDINATOR_REPLY,
+    PAYLOAD_KINDS.FENCE_NOTICE,
+    PAYLOAD_KINDS.COORDINATOR_RESERVATION, // read-only fence drain (drain-reservations.cjs)
+    PAYLOAD_KINDS.SEAT_BUSY_RESERVATION,   // read-only fence drain (seat-busy-fence.cjs)
+    // Coordinator→worker kinds that live outside PAYLOAD_KINDS (dispatch-side literals the
+    // worker /checkin drain + fleet loop act on today):
+    'comms_check', 'coordinator_reminder', 'completion_nudge', 'CLAIM_RELEASED', 'SET_IDENTITY',
+    'claim_released', 'coordinator_directive',
+  ]),
+});
+
+// Terminal replies/acks are SENT legitimately but no inbox "drains" them (they close a
+// correlation and rest). Never warn on these — they are the reply direction of the contract.
+const TERMINAL_REPLY_KINDS = Object.freeze(['ack', 'coordinator_ack', 'chairman_directive_ack', 'relay_confirm']);
+
+/**
+ * SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: send-time target-drain check. WARN-ONLY —
+ * never throws, never blocks a send; returns true iff a warning was emitted so send
+ * paths/tests can observe it. Silent (fail-open) when kind or role is missing/unknown:
+ * the contract only fires on a CONFIDENT mismatch (known role, known non-terminal kind,
+ * absent from that role's drain set). Warn→reject tightening is an explicit follow-on
+ * after burn-in, never this helper's job.
+ * @param {{targetRole?: string|null, kind?: string|null, log?: Function}} args
+ * @returns {boolean} true iff a target-drain warning was emitted
+ */
+function warnIfUndrainedKind({ targetRole, kind, log = console.warn } = {}) {
+  if (!kind || !targetRole) return false;
+  const set = DRAIN_SETS[String(targetRole).toLowerCase()];
+  if (!set) return false;
+  if (TERMINAL_REPLY_KINDS.includes(kind)) return false;
+  if (set.includes(kind)) return false;
+  log(
+    `[target-drain] WARN: kind '${kind}' is not in role '${targetRole}' drain set — ` +
+    `this delivery may orphan at the target (drained kinds: ${set.join(', ')}). ` +
+    `Send proceeds (warn-only, SD-LEO-INFRA-SEND-TIME-TARGET-001).`
+  );
+  return true;
+}
+
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;
 
 /**
@@ -212,6 +288,9 @@ module.exports = {
   DIRECTIVE_KINDS,
   PRIORITY_EXEMPT_DIRECTIVE_KINDS,
   ADAM_EXCLUDED_KINDS,
+  DRAIN_SETS,
+  TERMINAL_REPLY_KINDS,
+  warnIfUndrainedKind,
   FLEET_ACTIVE_WINDOW_MS,
   getServiceClient,
   getReadClient,

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -164,18 +164,19 @@ const DRAIN_SETS = Object.freeze({
     PAYLOAD_KINDS.CROSS_PARTY_PING,
     PAYLOAD_KINDS.SOLOMON_CONSULT,      // consult via coordinator-relay default path
   ]),
-  worker: Object.freeze([
-    PAYLOAD_KINDS.WORK_ASSIGNMENT,
-    PAYLOAD_KINDS.COORDINATOR_REQUEST,
+  worker: Object.freeze([...new Set([
+    // Adversarial-review fix (PR #6170): the worker generic inbox surfaces ANY kind in
+    // DIRECTIVE_KINDS (scripts/hooks/coordination-inbox.cjs), so the full spread belongs
+    // here — omitting a subset produced spurious warns on directed chairman_directive /
+    // review_request sends through dispatchToWorker's hard 'worker' hint.
+    ...DIRECTIVE_KINDS,
     PAYLOAD_KINDS.COORDINATOR_REPLY,
-    PAYLOAD_KINDS.FENCE_NOTICE,
     PAYLOAD_KINDS.COORDINATOR_RESERVATION, // read-only fence drain (drain-reservations.cjs)
     PAYLOAD_KINDS.SEAT_BUSY_RESERVATION,   // read-only fence drain (seat-busy-fence.cjs)
     // Coordinator→worker kinds that live outside PAYLOAD_KINDS (dispatch-side literals the
     // worker /checkin drain + fleet loop act on today):
-    'comms_check', 'coordinator_reminder', 'completion_nudge', 'CLAIM_RELEASED', 'SET_IDENTITY',
-    'claim_released', 'coordinator_directive',
-  ]),
+    'comms_check', 'completion_nudge', 'CLAIM_RELEASED', 'SET_IDENTITY', 'claim_released',
+  ])]),
 });
 
 // Terminal replies/acks are SENT legitimately but no inbox "drains" them (they close a

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -993,7 +993,7 @@ async function main() {
             try { solomonId = await getActiveSolomonId(supabase); } catch { solomonId = null; }
             const correlationId = crypto.randomUUID();
             const cp = buildSolomonConsultPayload({ correlationId, body: `[PRE-SEND CONSULT] ${payload.body.slice(0, 300)}`, senderCallsign, repo: process.cwd(), severity: 'high', isAwait: true });
-            await insertCoordinationRow(supabase, { sender_session: sessionId, sender_type: 'adam', target_session: solomonId || 'broadcast-solomon', message_type: 'INFO', subject: `[SOLOMON_CONSULT] pre-send`, body: cp.body, payload: cp, expires_at: expiresAt });
+            await insertCoordinationRow(supabase, { sender_session: sessionId, sender_type: 'adam', target_session: solomonId || 'broadcast-solomon', message_type: 'INFO', subject: `[SOLOMON_CONSULT] pre-send`, body: cp.body, payload: cp, expires_at: expiresAt }, { targetRoleHint: 'solomon' });
             const reply = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs: consultTimeoutMs });
             return reply.timedOut ? null : ((reply.reply && (readCanonicalBody(reply.reply) || reply.reply.body)) || { received: true });
           },
@@ -1035,7 +1035,9 @@ async function main() {
     const { data, error } = await insertCoordinationRow(
       supabase,
       { sender_session: sessionId, sender_type: 'adam', target_session: target, message_type: 'INFO', subject, body: payload.body, payload, expires_at: expiresAt },
-      { select: 'id', single: true }
+      // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: `--to solomon` is statically a Solomon-role
+      // target — hint the target-drain warn so a resolved UUID needs no identity lookup.
+      { select: 'id', single: true, targetRoleHint: toSolomon ? 'solomon' : undefined }
     );
     if (error) { console.error('ERROR: failed to insert advisory:', error.message); process.exit(1); }
     inserted = data;

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -280,6 +280,21 @@ async function drainInbox(supabase, sessionId, { quiet = false, background = fal
   if (error) { console.error('ERROR: solomon inbox query failed:', error.message); process.exit(1); }
 
   const rows = (allRows || []).filter((r) => isReplyRow(r) || isSolomonInboxRow(r));
+  // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-3: Solomon-directed canary coverage. comms_check
+  // was listed handler-owned (EXCLUDED_KINDS) but NO Solomon-side handler existed — a
+  // comms_check sent to Solomon orphaned silently (the exact class this SD closes send-side).
+  // Surface it FIRST-CLASS with the ack instruction; never consumed here (ack via `ack <id>`
+  // or a /signal reply, mirroring the worker comms-check contract).
+  const commsChecks = (allRows || []).filter((r) => r && r.payload && r.payload.kind === 'comms_check');
+  if (commsChecks.length > 0) {
+    console.log(`📡 ${commsChecks.length} comms_check (radio check) directed at Solomon — reply to confirm the two-way link:`);
+    for (const r of commsChecks) {
+      const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+      const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
+      console.log(`  📡 [comms_check] id=${r.id} (${ageMin}m) ${text}`);
+      console.log(`     Ack: node scripts/solomon-advisory.cjs ack ${r.id}  (or reply on the sender's channel)`);
+    }
+  }
   const orphaned = (allRows || []).filter(isOrphanedSolomonRow);
   if (orphaned.length > 0) {
     console.warn(`⚠ ${orphaned.length} unread Solomon-directed row${orphaned.length === 1 ? '' : 's'} with unrecognized/untyped kind NOT auto-drained (visibility — NOT consumed):`);
@@ -768,7 +783,9 @@ async function main() {
     const { data, error } = await insertCoordinationRow(
       supabase,
       { sender_session: sessionId, sender_type: 'solomon', target_session: target, message_type: 'INFO', subject, body: payload.body, payload, expires_at: expiresAt },
-      { select: 'id', single: true }
+      // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: `--to adam` is statically an Adam-role
+      // target — hint the target-drain warn so a resolved UUID needs no identity lookup.
+      { select: 'id', single: true, targetRoleHint: toAdam ? 'adam' : undefined }
     );
     if (error) { console.error('ERROR: failed to insert advisory:', error.message); process.exit(1); }
     inserted = data;

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -270,10 +270,16 @@ async function drainInbox(supabase, sessionId, { quiet = false, background = fal
   // recoverable filter is acknowledged_at IS NULL, never read_at IS NULL — a row this drain surfaces but
   // the reasoning turn doesn't genuinely act on must stay recoverable on the NEXT drain instead of
   // silently vanishing the moment it's first read-stamped.
+  // Adversarial-review fix (PR #6170): also read the 'broadcast-solomon' sentinel lane.
+  // Senders fall back to that sentinel exactly when Solomon's identity is transiently
+  // unresolvable (adam-advisory resolveAdamAdvisoryTarget) — the overnight/canary scenario —
+  // and no Solomon-side consumer read those rows at all, so a fallback comms_check/consult
+  // orphaned silently while DRAIN_SETS.solomon vouched for delivery. Solomon IS the intended
+  // consumer of its own sentinel; drain both lanes.
   const { data: allRows, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at')
-    .eq('target_session', sessionId)
+    .in('target_session', [sessionId, 'broadcast-solomon'])
     .is('acknowledged_at', null)
     .order('created_at', { ascending: true })
     .limit(100);
@@ -358,7 +364,10 @@ async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
       .update({ acknowledged_at: now })
       .eq('id', id)
       .is('acknowledged_at', null);
-    if (expectedTarget) q = q.eq('target_session', expectedTarget);
+    // Adversarial-review fix (PR #6170): drainInbox now also surfaces the 'broadcast-solomon'
+    // sentinel lane (Solomon is that sentinel's intended consumer), so the ownership scope
+    // must admit those rows too or a surfaced fallback row could never be acked.
+    if (expectedTarget) q = q.in('target_session', [expectedTarget, 'broadcast-solomon']);
     const { data, error } = await q.select('id, read_at');
     if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
     if (data && data.length > 0) {

--- a/tests/unit/coordination/protocol-version-skew-surfacing.test.js
+++ b/tests/unit/coordination/protocol-version-skew-surfacing.test.js
@@ -16,6 +16,9 @@ function stub(rows) {
   const selectChain = {
     select() { return selectChain; },
     eq() { return selectChain; },
+    // SD-LEO-INFRA-SEND-TIME-TARGET-001: Solomon drainInbox now two-lane scopes the target
+    // via .in('target_session', [sessionId, 'broadcast-solomon']).
+    in() { return selectChain; },
     is() { return selectChain; },
     // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001: drainInbox now window-scopes (gte)
     // and runs an advisory older-rows head-count (terminal .lt).

--- a/tests/unit/fleet/drain-sets-send-warn.test.js
+++ b/tests/unit/fleet/drain-sets-send-warn.test.js
@@ -42,8 +42,8 @@ describe('DRAIN_SETS (FR-1)', () => {
     expect(DRAIN_SETS.solomon).not.toContain(PAYLOAD_KINDS.ADAM_ADVISORY);
   });
 
-  test('every role drains all DIRECTIVE_KINDS except worker (worker drains its directed subset)', () => {
-    for (const role of ['solomon', 'adam', 'coordinator']) {
+  test('every role drains all DIRECTIVE_KINDS (worker inbox surfaces the full directive allowlist)', () => {
+    for (const role of ['solomon', 'adam', 'coordinator', 'worker']) {
       for (const kind of DIRECTIVE_KINDS) {
         expect(DRAIN_SETS[role]).toContain(kind);
       }
@@ -132,6 +132,7 @@ describe('solomon-advisory drainInbox surfaces comms_check (FR-3)', () => {
 
   function mockSupabase(rows) {
     const updates = [];
+    const inFilters = [];
     const chain = {
       select() { return chain; },
       eq() { return chain; },
@@ -139,9 +140,9 @@ describe('solomon-advisory drainInbox surfaces comms_check (FR-3)', () => {
       order() { return chain; },
       limit() { return Promise.resolve({ data: rows, error: null }); },
       update(p) { updates.push(p); return chain; },
-      in() { return Promise.resolve({ data: [], error: null }); },
+      in(col, vals) { inFilters.push([col, vals]); return chain; },
     };
-    return { from() { return chain; }, _updates: updates };
+    return { from() { return chain; }, _updates: updates, _inFilters: inFilters };
   }
 
   test('a Solomon-directed comms_check row renders with the ack instruction and is not consumed', async () => {
@@ -161,5 +162,14 @@ describe('solomon-advisory drainInbox surfaces comms_check (FR-3)', () => {
     expect(warned).not.toContain('cc-row-1');
     // acknowledged_at is never stamped by the drain (surface, don't consume).
     expect(client._updates.every((u) => !('acknowledged_at' in u))).toBe(true);
+  });
+
+  test('drainInbox reads BOTH the session lane and the broadcast-solomon sentinel lane (adversarial fix)', async () => {
+    const client = mockSupabase([]);
+    await drainInbox(client, 'solomon-session-id', { quiet: true });
+    const targetFilter = client._inFilters.find(([col]) => col === 'target_session');
+    expect(targetFilter).toBeDefined();
+    expect(targetFilter[1]).toContain('solomon-session-id');
+    expect(targetFilter[1]).toContain('broadcast-solomon');
   });
 });

--- a/tests/unit/fleet/drain-sets-send-warn.test.js
+++ b/tests/unit/fleet/drain-sets-send-warn.test.js
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the send-time target-drain contract.
+ * SD: SD-LEO-INFRA-SEND-TIME-TARGET-001
+ *
+ * Send-time validation checked only the GLOBAL kind vocabulary, so a send could pass
+ * yet orphan at the target role (Adam's good-morning canary sent adam_advisory to
+ * Solomon — SOLOMON_INBOX_KINDS never drains it; Solomon MODE-B finding b93d8966).
+ * These tests pin:
+ *   - DRAIN_SETS shape: frozen per-role map; solomon mirrors SOLOMON_INBOX_KINDS
+ *     semantics plus comms_check (FR-1/FR-3),
+ *   - warnIfUndrainedKind: warns on a confident mismatch, silent on drained kinds,
+ *     terminal replies, unknown roles, missing input; never throws (FR-2),
+ *   - resolveTargetRole: caller hint wins; sentinel targets map to roles (FR-2),
+ *   - solomon-advisory drainInbox surfaces a Solomon-directed comms_check with the
+ *     ack instruction instead of orphaning it (FR-3).
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  DRAIN_SETS, TERMINAL_REPLY_KINDS, warnIfUndrainedKind, DIRECTIVE_KINDS, PAYLOAD_KINDS,
+} = require('../../../lib/fleet/worker-status.cjs');
+const { resolveTargetRole, SENTINEL_ROLES } = require('../../../lib/coordinator/dispatch.cjs');
+const { SOLOMON_INBOX_KINDS, drainInbox } = require('../../../scripts/solomon-advisory.cjs');
+
+describe('DRAIN_SETS (FR-1)', () => {
+  test('frozen per-role map naming solomon, adam, coordinator, worker', () => {
+    expect(Object.isFrozen(DRAIN_SETS)).toBe(true);
+    for (const role of ['solomon', 'adam', 'coordinator', 'worker']) {
+      expect(Array.isArray(DRAIN_SETS[role])).toBe(true);
+      expect(Object.isFrozen(DRAIN_SETS[role])).toBe(true);
+      expect(DRAIN_SETS[role].length).toBeGreaterThan(0);
+    }
+  });
+
+  test('solomon set mirrors SOLOMON_INBOX_KINDS plus comms_check (FR-3)', () => {
+    for (const kind of SOLOMON_INBOX_KINDS) {
+      expect(DRAIN_SETS.solomon).toContain(kind);
+    }
+    expect(DRAIN_SETS.solomon).toContain('comms_check');
+    // The founding defect: adam_advisory must NOT be in Solomon's drain set.
+    expect(DRAIN_SETS.solomon).not.toContain(PAYLOAD_KINDS.ADAM_ADVISORY);
+  });
+
+  test('every role drains all DIRECTIVE_KINDS except worker (worker drains its directed subset)', () => {
+    for (const role of ['solomon', 'adam', 'coordinator']) {
+      for (const kind of DIRECTIVE_KINDS) {
+        expect(DRAIN_SETS[role]).toContain(kind);
+      }
+    }
+    expect(DRAIN_SETS.worker).toContain(PAYLOAD_KINDS.WORK_ASSIGNMENT);
+    expect(DRAIN_SETS.worker).toContain('comms_check');
+  });
+});
+
+describe('warnIfUndrainedKind (FR-2)', () => {
+  test('warns on the founding defect: adam_advisory → solomon', () => {
+    const log = vi.fn();
+    const warned = warnIfUndrainedKind({ targetRole: 'solomon', kind: 'adam_advisory', log });
+    expect(warned).toBe(true);
+    expect(log).toHaveBeenCalledOnce();
+    const msg = log.mock.calls[0][0];
+    expect(msg).toContain('adam_advisory');
+    expect(msg).toContain('solomon');
+    expect(msg).toContain('warn-only');
+  });
+
+  test('silent on a drained kind: solomon_consult → solomon', () => {
+    const log = vi.fn();
+    expect(warnIfUndrainedKind({ targetRole: 'solomon', kind: 'solomon_consult', log })).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  test('silent on terminal reply kinds regardless of role', () => {
+    const log = vi.fn();
+    for (const kind of TERMINAL_REPLY_KINDS) {
+      expect(warnIfUndrainedKind({ targetRole: 'solomon', kind, log })).toBe(false);
+    }
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  test('silent (fail-open) on unknown role, missing role, missing kind — and never throws', () => {
+    const log = vi.fn();
+    expect(warnIfUndrainedKind({ targetRole: 'chairman', kind: 'adam_advisory', log })).toBe(false);
+    expect(warnIfUndrainedKind({ targetRole: null, kind: 'adam_advisory', log })).toBe(false);
+    expect(warnIfUndrainedKind({ targetRole: 'solomon', kind: null, log })).toBe(false);
+    expect(warnIfUndrainedKind({})).toBe(false);
+    expect(warnIfUndrainedKind()).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  test('role match is case-insensitive', () => {
+    const log = vi.fn();
+    expect(warnIfUndrainedKind({ targetRole: 'Solomon', kind: 'adam_advisory', log })).toBe(true);
+  });
+});
+
+describe('resolveTargetRole (FR-2)', () => {
+  const throwingClient = { from() { throw new Error('no lookup expected'); } };
+
+  test('caller hint wins without any lookup', async () => {
+    await expect(resolveTargetRole(throwingClient, '9d03c69f-9178-46e0-9ff6-8164d24171b7', 'solomon'))
+      .resolves.toBe('solomon');
+  });
+
+  test('sentinel targets map to their role without any lookup', async () => {
+    expect(SENTINEL_ROLES['broadcast-solomon']).toBe('solomon');
+    await expect(resolveTargetRole(throwingClient, 'broadcast-solomon')).resolves.toBe('solomon');
+    await expect(resolveTargetRole(throwingClient, 'broadcast-coordinator')).resolves.toBe('coordinator');
+    await expect(resolveTargetRole(throwingClient, 'broadcast-adam')).resolves.toBe('adam');
+  });
+
+  test("'broadcast' (all roles) and non-UUID targets resolve to null (silent)", async () => {
+    await expect(resolveTargetRole(throwingClient, 'broadcast')).resolves.toBe(null);
+    await expect(resolveTargetRole(throwingClient, 'not-a-uuid')).resolves.toBe(null);
+    await expect(resolveTargetRole(throwingClient, null)).resolves.toBe(null);
+  });
+
+  test('a UUID matching no role identity resolves to null — never inferred as worker (no mis-warn)', async () => {
+    await expect(resolveTargetRole(throwingClient, '9d03c69f-9178-46e0-9ff6-8164d24171b7'))
+      .resolves.toBe(null);
+  });
+});
+
+describe('solomon-advisory drainInbox surfaces comms_check (FR-3)', () => {
+  let logSpy, warnSpy;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => { logSpy.mockRestore(); warnSpy.mockRestore(); });
+
+  function mockSupabase(rows) {
+    const updates = [];
+    const chain = {
+      select() { return chain; },
+      eq() { return chain; },
+      is() { return chain; },
+      order() { return chain; },
+      limit() { return Promise.resolve({ data: rows, error: null }); },
+      update(p) { updates.push(p); return chain; },
+      in() { return Promise.resolve({ data: [], error: null }); },
+    };
+    return { from() { return chain; }, _updates: updates };
+  }
+
+  test('a Solomon-directed comms_check row renders with the ack instruction and is not consumed', async () => {
+    const client = mockSupabase([{
+      id: 'cc-row-1', sender_session: 'coord', sender_type: 'coordinator', message_type: 'INFO',
+      subject: 'COMMS CHECK', body: null,
+      payload: { kind: 'comms_check', body: 'radio check from coordinator' },
+      created_at: new Date().toISOString(),
+    }]);
+    await drainInbox(client, 'solomon-session-id', { quiet: true });
+    const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).toContain('comms_check');
+    expect(out).toContain('cc-row-1');
+    expect(out).toContain('Ack:');
+    // Not treated as an orphan (the pre-fix behavior was silence; the orphan tier warns).
+    const warned = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).not.toContain('cc-row-1');
+    // acknowledged_at is never stamped by the drain (surface, don't consume).
+    expect(client._updates.every((u) => !('acknowledged_at' in u))).toBe(true);
+  });
+});

--- a/tests/unit/solomon-advisory.test.js
+++ b/tests/unit/solomon-advisory.test.js
@@ -251,6 +251,9 @@ describe('QF-20260710-593: ackRows — the action-time stamp', () => {
         update: (payload) => { state.payload = payload; return c; },
         eq: (col, v) => { state.guards.push(['eq', col, v]); return c; },
         is: (col, v) => { state.guards.push(['is', col, v]); return c; },
+        // SD-LEO-INFRA-SEND-TIME-TARGET-001: ownership scope moved from .eq to .in so the
+        // broadcast-solomon sentinel lane (now surfaced by drainInbox) can be acked too.
+        in: (col, v) => { state.guards.push(['in', col, v]); return c; },
         select: async () => { updates.push(state); return { data: [{ id: 'id-1', read_at: '2026-07-10T00:00:00Z' }], error: null }; },
       };
       return c;
@@ -266,10 +269,11 @@ describe('QF-20260710-593: ackRows — the action-time stamp', () => {
     expect(updates[0].guards).toContainEqual(['is', 'acknowledged_at', null]);
   });
 
-  it('ownership guard: with expectedTarget the update is scoped to target_session', async () => {
+  it('ownership guard: with expectedTarget the update is scoped to target_session (+ sentinel lane)', async () => {
     const { supabase, updates } = ackMock();
     await m.ackRows(supabase, ['id-1'], { expectedTarget: 'solomon-sess' });
     expect(updates).toHaveLength(1);
-    expect(updates[0].guards).toContainEqual(['eq', 'target_session', 'solomon-sess']);
+    // SD-LEO-INFRA-SEND-TIME-TARGET-001: scope admits the session AND its sentinel lane.
+    expect(updates[0].guards).toContainEqual(['in', 'target_session', ['solomon-sess', 'broadcast-solomon']]);
   });
 });


### PR DESCRIPTION
## Summary
- Closes the kind-vs-drain-set drift class (Solomon MODE-B finding b93d8966, 4 documented instances): send-time validation checked the GLOBAL kind vocabulary but never whether the TARGET ROLE ever drains that kind — Adam's daily good-morning canary to Solomon (kind=adam_advisory) orphaned exactly this way.
- **FR-1**: `lib/fleet/worker-status.cjs` exports per-role `DRAIN_SETS` (solomon/adam/coordinator/worker, composed from existing constants) + `warnIfUndrainedKind` (pure, warn-only).
- **FR-2**: the check lives at `insertCoordinationRow` — the single choke point all four named send paths (adam-advisory, solomon-advisory, worker-signal, coordinator dispatch) already route through. Role resolution: caller hint > sentinel map > POSITIVE identity match only (never inferred → no mis-warns; `dispatchToWorker` carries the explicit 'worker' hint). WARN-ONLY — no send is ever blocked; warn→reject is an explicit follow-on after burn-in.
- **FR-3**: Solomon-directed `comms_check` rows now surface FIRST-CLASS in `solomon-advisory.cjs inbox` with the ack instruction (previously listed handler-owned with NO handler — silent orphan). Protocol doc names `comms_check` as the canary kind for Solomon legs.

## Verification
- 12 new unit tests (`tests/unit/fleet/drain-sets-send-warn.test.js`) — DRAIN_SETS shape/mirroring, warn predicate incl. terminal-reply + fail-open cases, role resolution, comms_check surfacing.
- 122 tests green across all affected suites (dispatch guards, addressee-warn, coord-adam-comms-resilient source-pins, adam-solomon channel).
- Live smoke: DRAIN_SETS roles print; adam_advisory→solomon warns; solomon_consult→solomon silent.
- Adversarial catch fixed mid-EXEC: initial version inferred 'worker' for unmatched UUIDs — existing addressee-warn suite caught the mis-warn; now positive-match-only.

SD: SD-LEO-INFRA-SEND-TIME-TARGET-001 (PRD PRD-SD-LEO-INFRA-SEND-TIME-TARGET-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)