### PR TITLE
fix(SD-LEO-FIX-EXEMPT-REGISTERED-RECURRING-001): config-driven recurring-tick exemptions for the RCA 3-strikes counter

### DIFF
--- a/scripts/hooks/__tests__/retry-state-tick-exemptions-config.test.js
+++ b/scripts/hooks/__tests__/retry-state-tick-exemptions-config.test.js
@@ -1,0 +1,136 @@
+// SD-LEO-FIX-EXEMPT-REGISTERED-RECURRING-001 — config-driven recurring-tick exemptions.
+// Pins the four safety properties of recurring-tick-exemptions.json loading:
+//   (1) seeded registered ticks (adam-quiet-tick, adam-startup-check) are exempt end-to-end
+//       (isExempt true; recordAndCount never accrues across repeated successful runs);
+//   (2) BLOCKING loader validation — bare prefixes / bare extensions / paths / regex
+//       metachars can never compile (an entry exempts exactly one physical script);
+//   (3) fail-safe NARROWS, never widens — missing/corrupt config leaves builtins working
+//       and config-seeded entries counting again; no throw escapes the loader;
+//   (4) the 3-strikes teeth survive for failing non-allowlisted commands.
+// The config path is deliberately __dirname-fixed (NOT LEO_RETRY_STATE_DIR-overridable),
+// so these tests back up and restore the real tracked file around each variation.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const MODULE_PATH = path.resolve(__dirname, '../retry-state-manager.cjs');
+const CONFIG_PATH = path.resolve(__dirname, '../recurring-tick-exemptions.json');
+
+function loadFresh() {
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+const NO_RCA = { rcaCheck: async () => null };
+const SESSION = 'tick-exemptions-test-session';
+
+let originalConfig;
+let tmpStateDir;
+
+beforeEach(() => {
+  originalConfig = fs.readFileSync(CONFIG_PATH, 'utf8');
+  tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-state-'));
+  process.env.LEO_RETRY_STATE_DIR = tmpStateDir;
+});
+
+afterEach(() => {
+  fs.writeFileSync(CONFIG_PATH, originalConfig);
+  delete process.env.LEO_RETRY_STATE_DIR;
+  try { fs.rmSync(tmpStateDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  loadFresh(); // leave the module cache holding the restored real config
+});
+
+describe('(1) seeded registered ticks are exempt end-to-end', () => {
+  it('isExempt covers both seeded scripts incl. flag variants and windows path separators', () => {
+    const { isExempt } = loadFresh();
+    for (const cmd of [
+      'node scripts/adam-quiet-tick.mjs',
+      'node scripts/adam-quiet-tick.mjs --json',
+      'node scripts\\adam-quiet-tick.mjs --dry-run',
+      'node scripts/adam-startup-check.mjs',
+      'node scripts/adam-startup-check.mjs --armed "tick"',
+    ]) {
+      expect(isExempt(cmd), cmd).toBe(true);
+    }
+  });
+
+  it('4 successful same-target runs within 10 minutes never accrue (no warn/block/auto-signal input)', async () => {
+    const { recordAndCount } = loadFresh();
+    const now = Date.now();
+    for (let i = 0; i < 4; i++) {
+      const res = await recordAndCount(SESSION, null, 'Bash',
+        { command: 'node scripts/adam-quiet-tick.mjs' },
+        { ...NO_RCA, now: now + i * 60_000 });
+      expect(res.attempts).toBe(0);
+    }
+  });
+});
+
+describe('(2) BLOCKING loader validation — over-match rejection matrix', () => {
+  it('bare prefixes, bare extensions, short tokens, paths, and metachars never compile', () => {
+    const evil = ['adam', '.mjs', 'a', '../evil.mjs', 'scripts/adam-quiet-tick.mjs', 'ad*am.mjs', 'adam|.mjs'];
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      exempt_scripts: evil.map((script) => ({ script, reason: 'over-match attempt' })),
+    }));
+    const { isExempt } = loadFresh();
+    // The over-match probe: were a bare "adam" entry compiled, adam-advisory's NON-idempotent
+    // answer path would silently lose its 3-strikes teeth. It must stay gated.
+    expect(isExempt('node scripts/adam-advisory.cjs advisory --send')).toBe(false);
+    // And the malformed entries must not have produced working exemptions for the real ticks.
+    expect(isExempt('node scripts/adam-quiet-tick.mjs')).toBe(false);
+    // Builtins are unaffected by config contents.
+    expect(isExempt('node scripts/coordinator-quiet-tick.mjs')).toBe(true);
+  });
+
+  it('an entry without a reason is rejected; the 32-entry cap holds', () => {
+    const entries = [];
+    for (let i = 0; i < 33; i++) entries.push({ script: `tick-${i}.mjs`, reason: `cadence ${i}` });
+    entries.push({ script: 'no-reason-tick.mjs' });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({ exempt_scripts: entries }));
+    const { isExempt } = loadFresh();
+    expect(isExempt('node scripts/tick-0.mjs')).toBe(true);
+    expect(isExempt('node scripts/tick-31.mjs')).toBe(true);
+    expect(isExempt('node scripts/tick-32.mjs')).toBe(false); // beyond the cap
+    expect(isExempt('node scripts/no-reason-tick.mjs')).toBe(false);
+  });
+});
+
+describe('(3) fail-safe narrows, never widens', () => {
+  it('corrupt JSON: builtins hold, seeded entries count again, loader never throws', async () => {
+    fs.writeFileSync(CONFIG_PATH, '{ this is not json');
+    const { isExempt, recordAndCount } = loadFresh();
+    expect(isExempt('node scripts/coordinator-quiet-tick.mjs')).toBe(true); // builtin unaffected
+    expect(isExempt('node scripts/adam-quiet-tick.mjs')).toBe(false);       // narrowed, not widened
+    const now = Date.now();
+    let last;
+    for (let i = 0; i < 3; i++) {
+      last = await recordAndCount(SESSION, null, 'Bash',
+        { command: 'node scripts/adam-quiet-tick.mjs' },
+        { ...NO_RCA, now: now + i * 60_000 });
+    }
+    expect(last.attempts).toBe(3); // with config lost, the tick counts like any command
+  });
+
+  it('missing file behaves the same as corrupt (builtin-only)', () => {
+    fs.rmSync(CONFIG_PATH);
+    const { isExempt } = loadFresh();
+    expect(isExempt('node scripts/coordinator-quiet-tick.mjs')).toBe(true);
+    expect(isExempt('node scripts/adam-quiet-tick.mjs')).toBe(false);
+  });
+});
+
+describe('(4) teeth preserved for non-allowlisted repeats', () => {
+  it('3 same-target invocations of an unregistered script reach the block threshold', async () => {
+    const { recordAndCount } = loadFresh();
+    const now = Date.now();
+    let last;
+    for (let i = 0; i < 3; i++) {
+      last = await recordAndCount(SESSION, null, 'Bash',
+        { command: 'node scripts/some-random-task.mjs --retry' },
+        { ...NO_RCA, now: now + i * 60_000 });
+    }
+    expect(last.attempts).toBe(3);
+  });
+});

--- a/scripts/hooks/recurring-tick-exemptions.json
+++ b/scripts/hooks/recurring-tick-exemptions.json
@@ -1,0 +1,24 @@
+{
+  "_doc": [
+    "SD-LEO-FIX-EXEMPT-REGISTERED-RECURRING-001 — registered recurring-tick exemptions for the",
+    "RCA 3x-same-target counter (retry-state-manager.cjs LEARN-129 lineage).",
+    "POLICY: entries are FULL script basenames with extension (validated: ^[A-Za-z0-9._-]+\\.(mjs|cjs|js)$),",
+    "compiled into anchored scripts/<name> patterns — one entry can only ever exempt one physical script.",
+    "Each entry REQUIRES a reason. Max 32 entries. Adding an entry needs a reviewed PR: this file being",
+    "git-tracked IS the teeth-erosion guard (risk ca54579b). Only register scripts that are scheduled,",
+    "idempotent cadences (every healthy run exits 0 on the same target by design).",
+    "TRADEOFF (shared with the builtin EXEMPT_PATTERNS): exemption is exit-code-blind — a persistently",
+    "FAILING registered tick is invisible to this repeat-guard; tick health is owned by the",
+    "periodic-liveness watcher lane instead."
+  ],
+  "exempt_scripts": [
+    {
+      "script": "adam-quiet-tick.mjs",
+      "reason": "Adam hibernation aggregator, healthy idempotent ~4-min cadence; tripped false 3x-blocks daily forcing EMERGENCY_RCA_BYPASS / PowerShell detours (feedback cc659006, advisory 79135adb)"
+    },
+    {
+      "script": "adam-startup-check.mjs",
+      "reason": "Adam startup probe re-run on session/loop restarts — parity with the builtin-exempt coordinator-startup-check.mjs"
+    }
+  ]
+}

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -90,6 +90,60 @@ const EXEMPT_PATTERNS = [
   /\bgh\s+pr\s+checks\b/,
 ];
 
+// SD-LEO-FIX-EXEMPT-REGISTERED-RECURRING-001: config-driven registration of recurring-tick
+// exemptions, so adding a scheduled cadence script (adam-quiet-tick etc.) is a reviewed
+// config PR instead of a code change. SAFETY PROPERTIES (risk ca54579b — both BLOCKING):
+//   1. The config lives at a GIT-TRACKED path resolved __dirname-relative (NEVER the
+//      LEO_RETRY_STATE_DIR-overridable state dir) — PR review is the teeth-erosion guard.
+//   2. Entries are FULL basenames with extension only (validated below), escaped and
+//      compiled into the same anchored `scripts/<name>` family as the builtins — an entry
+//      can only ever exempt one physical script; bare prefixes ("adam") or extensions
+//      (".mjs") that would disable a script family are rejected before compilation.
+//   3. Fail-safe NARROWS, never widens: missing/unreadable/malformed config → builtin
+//      EXEMPT_PATTERNS only; a rejected entry is skipped, never approximated.
+// TRADEOFF (shared with every builtin entry): isExempt is exit-code-blind, so a
+// persistently FAILING allowlisted tick is invisible to this repeat-guard — tick health
+// is owned by the periodic-liveness watcher lane, not LEARN-129.
+const TICK_EXEMPTIONS_CONFIG = path.resolve(__dirname, 'recurring-tick-exemptions.json');
+const TICK_ENTRY_RE = /^[A-Za-z0-9._-]+\.(mjs|cjs|js)$/;
+const TICK_ENTRY_MAX = 32;
+
+function loadConfigExemptions() {
+  const compiled = [];
+  try {
+    if (!fs.existsSync(TICK_EXEMPTIONS_CONFIG)) return compiled;
+    const parsed = JSON.parse(fs.readFileSync(TICK_EXEMPTIONS_CONFIG, 'utf8'));
+    const entries = Array.isArray(parsed && parsed.exempt_scripts) ? parsed.exempt_scripts : [];
+    for (const entry of entries.slice(0, TICK_ENTRY_MAX)) {
+      const script = entry && typeof entry.script === 'string' ? entry.script : '';
+      const reason = entry && typeof entry.reason === 'string' ? entry.reason.trim() : '';
+      if (!TICK_ENTRY_RE.test(script) || !reason) {
+        process.stderr.write(`[retry-state-manager] tick-exemption entry rejected (needs full basename + extension and a reason): ${JSON.stringify(script)}\n`);
+        continue;
+      }
+      try {
+        const escaped = script.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        compiled.push(new RegExp(`\\bscripts[/\\\\]${escaped}\\b`));
+      } catch {
+        // A single uncompilable entry is skipped — never approximated into a wider pattern.
+      }
+    }
+    if (entries.length > TICK_ENTRY_MAX) {
+      process.stderr.write(`[retry-state-manager] tick-exemption config capped at ${TICK_ENTRY_MAX} entries (${entries.length} present)\n`);
+    }
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      process.stderr.write(`[retry-state-manager] tick-exemption config loaded: ${compiled.length} entr${compiled.length === 1 ? 'y' : 'ies'}\n`);
+    }
+  } catch (err) {
+    // Fail-safe: config trouble can only NARROW exemptions (builtins still apply) and must
+    // never block a tool call (this module runs inside a fail-open PreToolUse hook).
+    process.stderr.write(`[retry-state-manager] tick-exemption config unreadable (builtins only): ${err.message}\n`);
+  }
+  return compiled;
+}
+
+const CONFIG_EXEMPT_PATTERNS = loadConfigExemptions();
+
 /**
  * Whether a Bash command should bypass invocation tracking entirely (allowlist backstop).
  * Returns false for any non-string input.
@@ -98,7 +152,8 @@ const EXEMPT_PATTERNS = [
  */
 function isExempt(commandStr) {
   if (typeof commandStr !== 'string' || !commandStr) return false;
-  return EXEMPT_PATTERNS.some(rx => rx.test(commandStr));
+  return EXEMPT_PATTERNS.some(rx => rx.test(commandStr)) ||
+    CONFIG_EXEMPT_PATTERNS.some(rx => rx.test(commandStr));
 }
 
 // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 2 — structural read-only


### PR DESCRIPTION
## Summary
Registered recurring ticks (`adam-quiet-tick.mjs` every ~4 min, `adam-startup-check.mjs`) exit 0 on schedule against the same target — yet trip the LEARN-129 3x-same-target counter because the succeeding-poll exemption's single-slot `last-outcome-<session>.json` is clobbered under interleaving. Adam sessions burned daily `EMERGENCY_RCA_BYPASS` / PowerShell detours (which mask coordinator replies) and generated false STUCK auto-signals the coordinator triaged by hand (feedback `cc659006`, advisory `79135adb`).

**Fix**: `scripts/hooks/recurring-tick-exemptions.json` — a git-tracked, reviewed registry of recurring-tick basenames, unioned into `EXEMPT_PATTERNS` at require time, seeded with the two Adam scripts. Registering a future tick becomes a config PR, not a code change.

**Safety properties** (risk evidence `ca54579b`, both blocking mitigations encoded):
- **Loader validation is blocking**: entries must be full `basename.(mjs|cjs|js)` — bare prefixes (`adam`), bare extensions (`.mjs`), paths, and regex metachars are rejected before compilation; each compiled pattern anchors to exactly one physical `scripts/<name>`. The over-match probe test proves `adam-advisory.cjs`'s non-idempotent answer path keeps its 3-strikes teeth.
- **Fail-safe narrows, never widens**: missing/corrupt config → builtin-only (seeded entries count again); loader errors can never block a tool call; 32-entry cap; required per-entry `reason`; `__dirname`-relative read (immune to `LEO_RETRY_STATE_DIR` test overrides and cwd drift).
- **Documented tradeoff**: exemption is exit-code-blind (shared with all ~22 builtin entries) — a persistently failing registered tick is the periodic-liveness watcher's job, not this guard's.

216 LOC (81 source+config / 136 tests) — over the 100 target with justification: the blocking rejection matrix and fail-safe direction tests are the mitigations that keep the RCA guard's teeth.

## Test plan
`npx vitest run scripts/hooks/__tests__/retry-state-tick-exemptions-config.test.js tests/unit/retry-state-exempt-recurring-ticks.test.js scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js` — 30 tests green (9 new: seeded-exempt end-to-end, rejection matrix, cap, no-reason rejection, corrupt/missing-config fail-safe, teeth regression).

PRD: `PRD-SD-LEO-FIX-EXEMPT-REGISTERED-RECURRING-001` (approved) · Evidence: VALIDATION `8332f59c` / RISK `ca54579b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)