### PR TITLE
fix(SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001): session-scoped sub-agent evidence attribution

### DIFF
--- a/scripts/hooks/task-subagent-recorder.cjs
+++ b/scripts/hooks/task-subagent-recorder.cjs
@@ -178,25 +178,81 @@ function prepareRawOutput(output) {
 }
 
 /**
- * Get active SD from session state
- * @returns {string|null} SD ID if found
+ * Read `state.sd.id` from a `.claude` state file, tolerant of BOM/parse errors.
+ * @returns {string|null}
  */
-function getActiveSD() {
-  const fs = require('fs');
-  const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || detectProjectDir();
-  const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
-
+function readSdIdFromFile(fs, filePath) {
   try {
-    if (fs.existsSync(SESSION_STATE_FILE)) {
-      const content = fs.readFileSync(SESSION_STATE_FILE, 'utf8');
-      const cleanContent = content.replace(/^\uFEFF/, '');
-      const state = JSON.parse(cleanContent);
+    if (fs.existsSync(filePath)) {
+      const state = JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, ''));
       return state.sd?.id || null;
     }
   } catch (_e) {
-    // Ignore errors
+    // fail-soft \u2014 treat an unreadable/corrupt state file as "not found"
   }
   return null;
+}
+
+/**
+ * Resolve the active SD for an evidence row \u2014 SESSION-SCOPED, immune to the shared-file
+ * race (SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001).
+ *
+ * THE BUG THIS FIXES: the previous body read ONLY the SHARED
+ * `.claude/unified-session-state.json`, which ~10 concurrent workers overwrite \u2014 so a
+ * worker's evidence attributed to whichever SD last wrote that file, corrupting
+ * `sub_agent_execution_results` (the surface every SUBAGENT_EVIDENCE gate rests on).
+ *
+ * Resolution order (first hit wins), each stamped so auditors/gates can distrust the racy path:
+ *   1. `claim-lookup`         \u2014 CLAUDE_SESSION_ID \u2192 strategic_directives_v2.claiming_session_id
+ *                               (Surface A, authoritative; a session's own claim can't be raced).
+ *   2. `session-file`         \u2014 `.claude/session-state-<session_id>.json` (per-session, never shared).
+ *   3. `shared-file-fallback` \u2014 the shared unified file (LAST RESORT; the racy legacy path).
+ *   4. `none`                 \u2014 nothing resolved.
+ * FAIL-SOFT throughout: any lookup error falls through to the next source and NEVER throws,
+ * preserving the recorder's best-effort contract.
+ *
+ * @returns {Promise<{sdId: string|null, attributionSource: string}>}
+ */
+async function getActiveSD(deps = {}) {
+  // deps (all optional) are injectable for unit tests — default to the real modules.
+  const fs = deps.fs || require('fs');
+  const resolveCreateClient = typeof deps.createClient === 'function'
+    ? deps.createClient
+    : require('@supabase/supabase-js').createClient;
+  const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || detectProjectDir();
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+
+  // 1. Authoritative: the invoking session's own claim (immune to the shared-file race).
+  if (sessionId) {
+    try {
+      require('dotenv').config({ path: path.join(__dirname, '../..', '.env') });
+      const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+      if (url && key) {
+        const supabase = resolveCreateClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+        const { data } = await supabase
+          .from('strategic_directives_v2')
+          .select('id')
+          .eq('claiming_session_id', sessionId)
+          .order('updated_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (data && data.id) return { sdId: data.id, attributionSource: 'claim-lookup' };
+      }
+    } catch (_e) {
+      // fail-soft \u2192 next source
+    }
+
+    // 2. Per-session state file (never shared, so never raced by peers).
+    const sessionFileId = readSdIdFromFile(fs, path.join(PROJECT_DIR, '.claude', `session-state-${sessionId}.json`));
+    if (sessionFileId) return { sdId: sessionFileId, attributionSource: 'session-file' };
+  }
+
+  // 3. LAST RESORT: the shared unified file (the racy legacy path). Stamp it so it's distrusted.
+  const sharedId = readSdIdFromFile(fs, path.join(PROJECT_DIR, '.claude', 'unified-session-state.json'));
+  if (sharedId) return { sdId: sharedId, attributionSource: 'shared-file-fallback' };
+
+  return { sdId: null, attributionSource: 'none' };
 }
 
 /**
@@ -344,8 +400,8 @@ async function processHookInput(hookInput) {
   // Prepare raw_output (FR-3)
   const rawOutput = prepareRawOutput(toolResult);
 
-  // Get active SD if available
-  const sdId = getActiveSD();
+  // Get active SD if available — session-scoped resolution (SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001).
+  const { sdId, attributionSource } = await getActiveSD();
 
   // Build record
   const record = {
@@ -361,7 +417,9 @@ async function processHookInput(hookInput) {
     metadata: {
       tool_call_id: toolCallId,
       recorded_by: 'task-subagent-recorder.cjs',
-      recorded_at: new Date().toISOString()
+      recorded_at: new Date().toISOString(),
+      // FR-2: how the SD was resolved, so gates/auditors can distrust 'shared-file-fallback' rows.
+      attribution_source: attributionSource
     }
   };
 
@@ -445,4 +503,10 @@ function main() {
   }, 5000);
 }
 
-main();
+// Only run the stdin hook when executed directly — `require()` (unit tests) must not block on stdin.
+if (require.main === module) {
+  main();
+}
+
+// SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001: export the resolver for the concurrent-session regression test.
+module.exports = { getActiveSD, readSdIdFromFile };

--- a/tests/unit/hooks/task-subagent-recorder-attribution.test.js
+++ b/tests/unit/hooks/task-subagent-recorder-attribution.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001 — session-scoped SD resolution (FR-1/2/3).
+ *
+ * Proves the fix for the evidence mis-attribution bug: getActiveSD() must resolve from the
+ * INVOKING session's own claim, so two concurrent sessions never contaminate each other via
+ * the shared .claude/unified-session-state.json. All I/O is injected (no real DB/fs).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+// This is a PURE unit test — all I/O (supabase + fs) is injected via deps; a live client is
+// never reached. The mock is a belt-and-suspenders guarantee: if any path ever falls back to
+// the real module, it throws instead of touching a live DB.
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => { throw new Error('unit test must never reach a live supabase client'); },
+}));
+
+const require = createRequire(import.meta.url);
+const { getActiveSD } = require('../../../scripts/hooks/task-subagent-recorder.cjs');
+
+// fake fs whose existsSync/readFileSync match by path suffix (filename)
+function fakeFs(files) {
+  const keyFor = (p) => Object.keys(files).find((k) => String(p).endsWith(k));
+  return {
+    existsSync: (p) => keyFor(p) !== undefined,
+    readFileSync: (p) => JSON.stringify(files[keyFor(p)]),
+  };
+}
+// fake supabase client whose claim-lookup chain resolves to { id: sdId } (or null)
+function fakeClient(sdId) {
+  const chain = {
+    select: () => chain, eq: () => chain, order: () => chain, limit: () => chain,
+    maybeSingle: async () => ({ data: sdId ? { id: sdId } : null }),
+  };
+  return { from: () => chain };
+}
+function throwingClient() { return { from: () => { throw new Error('db down'); } }; }
+
+describe('getActiveSD — session-scoped attribution (SD-LEO-INFRA-SUB-AGENT-EVIDENCE-001)', () => {
+  const savedEnv = { ...process.env };
+  beforeEach(() => { process.env.SUPABASE_URL = 'http://test'; process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'; });
+  afterEach(() => { process.env = { ...savedEnv }; });
+
+  it('FR-3: two concurrent sessions each resolve to their OWN claimed SD, never the racy shared file', async () => {
+    // The shared file holds a stale/other value (the exact contamination vector) — the claim must win.
+    const fs = fakeFs({ 'unified-session-state.json': { sd: { id: 'SD-SHARED-CONTAMINANT' } } });
+
+    process.env.CLAUDE_SESSION_ID = 'sess-A';
+    const a = await getActiveSD({ fs, createClient: () => fakeClient('SD-A') });
+    process.env.CLAUDE_SESSION_ID = 'sess-B';
+    const b = await getActiveSD({ fs, createClient: () => fakeClient('SD-B') });
+
+    expect(a).toEqual({ sdId: 'SD-A', attributionSource: 'claim-lookup' });
+    expect(b).toEqual({ sdId: 'SD-B', attributionSource: 'claim-lookup' });
+    expect(a.sdId).not.toBe(b.sdId);               // no cross-session contamination
+    expect(a.sdId).not.toBe('SD-SHARED-CONTAMINANT'); // claim beat the shared file
+  });
+
+  it('FR-2: no session identity → shared-file fallback, STAMPED as shared-file-fallback', async () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const fs = fakeFs({ 'unified-session-state.json': { sd: { id: 'SD-SHARED' } } });
+    const r = await getActiveSD({ fs, createClient: () => fakeClient('SD-A') });
+    expect(r).toEqual({ sdId: 'SD-SHARED', attributionSource: 'shared-file-fallback' });
+  });
+
+  it('FR-1 fail-soft: a claim-lookup error falls through to the next source, never throws', async () => {
+    process.env.CLAUDE_SESSION_ID = 'sess-A';
+    const fs = fakeFs({ 'unified-session-state.json': { sd: { id: 'SD-SHARED' } } });
+    const r = await getActiveSD({ fs, createClient: () => throwingClient() });
+    expect(r.sdId).toBe('SD-SHARED');
+    expect(r.attributionSource).toBe('shared-file-fallback');
+  });
+
+  it('FR-1: a per-session state file is preferred over the shared file', async () => {
+    process.env.CLAUDE_SESSION_ID = 'sess-A';
+    const fs = fakeFs({
+      'session-state-sess-A.json': { sd: { id: 'SD-SESSFILE' } },
+      'unified-session-state.json': { sd: { id: 'SD-SHARED' } },
+    });
+    const r = await getActiveSD({ fs, createClient: () => fakeClient(null) }); // no claim → session-file
+    expect(r).toEqual({ sdId: 'SD-SESSFILE', attributionSource: 'session-file' });
+  });
+
+  it('resolves { null, none } when nothing is available', async () => {
+    process.env.CLAUDE_SESSION_ID = 'sess-A';
+    const r = await getActiveSD({ fs: fakeFs({}), createClient: () => fakeClient(null) });
+    expect(r).toEqual({ sdId: null, attributionSource: 'none' });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes sub-agent evidence mis-attribution across the fleet. `getActiveSD()` in task-subagent-recorder.cjs read ONLY the SHARED `.claude/unified-session-state.json`; with ~10 concurrent workers that file is overwritten constantly, so a worker's TESTING/SECURITY/VALIDATION evidence attributed to whichever SD last wrote it — corrupting `sub_agent_execution_results`, the surface every SUBAGENT_EVIDENCE gate rests on.

- **FR-1** session-scoped resolution (first hit wins): CLAUDE_SESSION_ID -> strategic_directives_v2.claiming_session_id (authoritative, race-immune), then a per-session state file, then the shared file as LAST RESORT. Fail-soft (never throws; preserves the best-effort recorder contract).
- **FR-2** every row stamps `metadata.attribution_source` (claim-lookup|session-file|shared-file-fallback|none) so gates/auditors can distrust the racy path.
- **FR-3** concurrent-session regression test — two sessions with distinct claims each resolve to their OWN SD, never the shared contaminant.
- getActiveSD is now async + deps-injectable; main() guarded by require.main===module for testability.

Root-caused live this session (signal 118ceca0) while shipping SD-LEO-INFRA-ADAM-PRE-SEND-001.

## Test plan
- 5/5 unit tests (tests/unit/hooks/task-subagent-recorder-attribution.test.js)
- Handoffs: LEAD-TO-PLAN 94 / PLAN-TO-EXEC 97 / EXEC-TO-PLAN 95 / PLAN-TO-LEAD 97

🤖 Generated with [Claude Code](https://claude.com/claude-code)