### PR TITLE
feat(SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001): fleet account-identity awareness

### DIFF
--- a/lib/fleet/account-identity.cjs
+++ b/lib/fleet/account-identity.cjs
@@ -40,18 +40,18 @@ function loadConfigObject(source) {
 const MAX_FIELD_LENGTH = 256;
 
 /**
- * Sanitize a whitelisted string field before it is ever returned/logged: strips all C0/C1
- * control characters (including newlines, carriage returns, and ANSI/CSI escape sequences,
- * which start with ESC 0x1B) and clamps length. This guards downstream template-literal log
- * lines (e.g. `acct=${acctLabel}`) against log-line forgery/injection or terminal escape
- * sequences if the on-disk ~/.claude.json is ever tampered with or an OAuth response field is
- * attacker-influenced.
+ * Sanitize a whitelisted string field before it is ever returned/logged: strips ALL C0 AND C1
+ * control characters (0x00-0x1F, 0x7F-0x9F — covers newlines, carriage returns, DEL, and both
+ * 7-bit ESC-introduced (0x1B) and 8-bit (0x80-0x9F, incl. CSI 0x9B) ANSI/terminal escape
+ * sequences) and clamps length. This guards downstream template-literal log lines (e.g.
+ * `acct=${acctLabel}`) against log-line forgery/injection or terminal escape sequences if the
+ * on-disk ~/.claude.json is ever tampered with or an OAuth response field is attacker-influenced.
  * @param {string} value
  * @returns {string}
  */
 function sanitizeField(value) {
   // eslint-disable-next-line no-control-regex
-  const stripped = value.replace(/[\x00-\x1F\x7F]/g, '');
+  const stripped = value.replace(/[\x00-\x1F\x7F-\x9F]/g, '');
   return stripped.slice(0, MAX_FIELD_LENGTH);
 }
 

--- a/lib/fleet/account-identity.cjs
+++ b/lib/fleet/account-identity.cjs
@@ -1,0 +1,122 @@
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-1/FR-3): the fleet has no awareness of which
+// Claude Code account it runs under. This module reads the on-disk ~/.claude.json config's
+// top-level oauthAccount object and returns ONLY a whitelisted 3-field identity — never the
+// full config (which has ~87 top-level keys, some credential-adjacent) and never any other
+// oauthAccount sub-field (billingType/seatTier/userRateLimitTier/etc — confirmed on-disk shape
+// has ~16 non-identity fields alongside the 3 this module surfaces).
+//
+// getAccountIdentity(source) accepts an OPTIONAL injection seam so unit tests never touch the
+// real logged-in account's file: `source` may be a plain object (already-parsed config) or a
+// string file path to read+parse instead of the real config. Omitting it reads the real config.
+//
+// Fail-safe throughout: a missing file, a JSON parse error, a missing/malformed oauthAccount,
+// or oauthAccount missing any of the 3 required sub-fields all resolve to `null` — this
+// function NEVER throws.
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/** Resolve the real ~/.claude.json path (Windows-first, os.homedir() fallback). */
+function resolveRealConfigPath() {
+  const base = process.env.USERPROFILE || os.homedir();
+  return path.join(base, '.claude.json');
+}
+
+/**
+ * Load the config object for a given `source` (see getAccountIdentity doc above).
+ * Throws on any read/parse failure — callers must catch.
+ */
+function loadConfigObject(source) {
+  if (source && typeof source === 'object') return source;
+  const filePath = typeof source === 'string' ? source : resolveRealConfigPath();
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+/** Max length applied to each whitelisted field after sanitization. */
+const MAX_FIELD_LENGTH = 256;
+
+/**
+ * Sanitize a whitelisted string field before it is ever returned/logged: strips all C0/C1
+ * control characters (including newlines, carriage returns, and ANSI/CSI escape sequences,
+ * which start with ESC 0x1B) and clamps length. This guards downstream template-literal log
+ * lines (e.g. `acct=${acctLabel}`) against log-line forgery/injection or terminal escape
+ * sequences if the on-disk ~/.claude.json is ever tampered with or an OAuth response field is
+ * attacker-influenced.
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizeField(value) {
+  // eslint-disable-next-line no-control-regex
+  const stripped = value.replace(/[\x00-\x1F\x7F]/g, '');
+  return stripped.slice(0, MAX_FIELD_LENGTH);
+}
+
+/**
+ * @param {object|string} [source] optional injection seam — a parsed config object, a file
+ *   path string, or omitted to read the real ~/.claude.json.
+ * @returns {{email:string, orgName:string, accountUuid8:string}|null} EXACTLY these 3 keys,
+ *   nothing else, ever — or null on any failure/malformed shape.
+ */
+function getAccountIdentity(source) {
+  try {
+    const config = loadConfigObject(source);
+    const oauthAccount = config && config.oauthAccount;
+    if (!oauthAccount || typeof oauthAccount !== 'object') return null;
+
+    const { emailAddress, organizationName, accountUuid } = oauthAccount;
+    if (
+      typeof emailAddress !== 'string' || emailAddress.length === 0 ||
+      typeof organizationName !== 'string' || organizationName.length === 0 ||
+      typeof accountUuid !== 'string' || accountUuid.length === 0
+    ) {
+      return null;
+    }
+
+    const email = sanitizeField(emailAddress);
+    const orgName = sanitizeField(organizationName);
+    const accountUuid8 = sanitizeField(accountUuid).slice(0, 8);
+    if (email.length === 0 || orgName.length === 0 || accountUuid8.length === 0) {
+      return null;
+    }
+
+    return { email, orgName, accountUuid8 };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * FR-3: pure switch detector. Compares a prior persisted identity (or null on cold start) to
+ * the current tick's identity and decides whether a genuine ACCOUNT_SWITCH occurred.
+ *
+ * Cold-start rule (CRITICAL): when `prior` is null (no persisted state yet — first tick after
+ * deploy/restart, or the state file was unreadable), this ALWAYS returns changed:false — the
+ * caller is expected to silently persist `current` as the new baseline without emitting an
+ * event. A switch only fires when a PRIOR state EXISTED and differs from `current`.
+ *
+ * @param {{email:string,orgName:string,accountUuid8:string}|null} prior
+ * @param {{email:string,orgName:string,accountUuid8:string}|null} current
+ * @returns {{changed:boolean, event:object|null}}
+ */
+function detectAccountSwitch(prior, current) {
+  if (!prior || !current) return { changed: false, event: null };
+  const changed =
+    prior.email !== current.email ||
+    prior.orgName !== current.orgName ||
+    prior.accountUuid8 !== current.accountUuid8;
+  if (!changed) return { changed: false, event: null };
+  return {
+    changed: true,
+    event: {
+      type: 'ACCOUNT_SWITCH',
+      from: { email: prior.email, orgName: prior.orgName, accountUuid8: prior.accountUuid8 },
+      to: { email: current.email, orgName: current.orgName, accountUuid8: current.accountUuid8 },
+    },
+  };
+}
+
+module.exports = { getAccountIdentity, detectAccountSwitch };

--- a/lib/fleet/spawn-executor-core.cjs
+++ b/lib/fleet/spawn-executor-core.cjs
@@ -7,19 +7,32 @@
 // daemon (scripts/fleet/worker-spawn-executor.cjs) handles the actual I/O and the
 // default-OFF live spawn; this module just makes the decision.
 
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): this module previously had ZERO
+// limit-classification/failure-diagnostic code — it only records SKIP reasons (decision-level,
+// not a real spawn attempt failing). Since no genuine failure-recording path exists here to
+// attach to, this stamps the whitelisted 3-field account identity onto the returned `skipped`
+// diagnostics so a FUTURE limit-classification pass can correlate skip patterns with the
+// Claude account the fleet was running under. No limit-detection logic is added — out of scope.
+const { getAccountIdentity } = require('./account-identity.cjs');
+
 /**
  * @param {object} input
  * @param {Array<{id:string, requested_callsign:string, status:string, requested_at:string, expires_at:string}>} input.pendingRequests
  * @param {Set<string>|Array<string>} input.liveCallsigns - callsigns already backed by a live session
  * @param {number} input.nowMs - injected clock
  * @param {number} input.perTickCap - max spawns to authorize this tick (>=0)
- * @returns {{toSpawn: Array<object>, skipped: Array<{request: object, reason: string}>}}
+ * @param {{email:string,orgName:string,accountUuid8:string}|null} [input.accountIdentity] - optional
+ *   injection seam (tests / a caller with an already-resolved identity); defaults to a real
+ *   getAccountIdentity() read (fail-safe: null when unavailable). Keeps this function
+ *   deterministic/pure whenever a caller injects a fixed value.
+ * @returns {{toSpawn: Array<object>, skipped: Array<{request: object, reason: string, identity: object|null}>}}
  */
-function resolveSpawnDecisions({ pendingRequests, liveCallsigns, nowMs, perTickCap } = {}) {
+function resolveSpawnDecisions({ pendingRequests, liveCallsigns, nowMs, perTickCap, accountIdentity } = {}) {
   const requests = Array.isArray(pendingRequests) ? pendingRequests : [];
   const live = liveCallsigns instanceof Set ? liveCallsigns : new Set(liveCallsigns || []);
   const cap = Number.isFinite(perTickCap) && perTickCap >= 0 ? Math.floor(perTickCap) : 0;
   const now = Number.isFinite(nowMs) ? nowMs : 0;
+  const identity = accountIdentity !== undefined ? accountIdentity : getAccountIdentity();
 
   const skipped = [];
   // Stable order: oldest requested_at first, so dedup keeps the oldest and the cap is fair.
@@ -47,7 +60,8 @@ function resolveSpawnDecisions({ pendingRequests, liveCallsigns, nowMs, perTickC
   const toSpawn = eligible.slice(0, cap);
   for (const r of eligible.slice(cap)) { skipped.push({ request: r, reason: 'cap_exceeded' }); }
 
-  return { toSpawn, skipped };
+  // FR-2: stamp identity onto every skip diagnostic without touching the skip-decision logic above.
+  return { toSpawn, skipped: skipped.map((s) => ({ ...s, identity })) };
 }
 
 module.exports = { resolveSpawnDecisions };

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -32,11 +32,21 @@ const require = createRequire(import.meta.url);
 const { createClient } = require('@supabase/supabase-js');
 const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2/FR-3): surface which Claude account the fleet
+// is running under, and detect a genuine account switch across ticks.
+const { getAccountIdentity, detectAccountSwitch } = require('../lib/fleet/account-identity.cjs');
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 
 const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 const LAST_STATE_FILE = join(REPO_ROOT, '.adam-quiet-tick-last.json');
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-3): a SEPARATE identity-only state file, kept
+// independent of detectSalientDelta's tracked-field set (beltZero/openSignalCount/venture1State)
+// so the two concerns don't have to share a shape. Mirrors LAST_STATE_FILE's own
+// try/catch-load, JSON.stringify-write, single-slot pattern (see loadLastState/saveLastState).
+const ACCOUNT_IDENTITY_STATE_FILE = join(REPO_ROOT, '.account-identity-last.json');
 const ADAM_PARTY_OFFSET_S = 420; // phase Adam's park 7min after the coordinator's (FR-5).
 
 function makeClient() {
@@ -279,6 +289,15 @@ function saveLastState(s) {
   try { writeFileSync(LAST_STATE_FILE, JSON.stringify(s)); } catch { /* fail-soft */ }
 }
 
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-3): mirrors loadLastState/saveLastState's
+// pattern for a dedicated single-slot identity state file.
+function loadLastAccountIdentity() {
+  try { return JSON.parse(readFileSync(ACCOUNT_IDENTITY_STATE_FILE, 'utf8')); } catch { return null; }
+}
+function saveLastAccountIdentity(s) {
+  try { writeFileSync(ACCOUNT_IDENTITY_STATE_FILE, JSON.stringify(s)); } catch { /* fail-soft */ }
+}
+
 async function main() {
   const asJson = process.argv.includes('--json');
   const sb = makeClient();
@@ -293,6 +312,12 @@ async function main() {
     quiescent = false;
     modeReason = 'assess_error_fail_active: ' + (e && e.message);
   }
+
+  // SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2/FR-3): which Claude account is this fleet
+  // running under, and did it just switch? getAccountIdentity() is fail-safe (never throws;
+  // null when the config is missing/malformed).
+  const currentIdentity = getAccountIdentity();
+  const acctLabel = (currentIdentity && currentIdentity.email) || 'unknown';
 
   // FR-1: inbox-monitor always runs (cheap, catch /signal); the offer-help core
   // is delta-gated below, so only the inbox core needs composing here.
@@ -348,12 +373,39 @@ async function main() {
   const delta = detectSalientDelta(priorSalient, salient);
   saveLastState({ salient, stallSnapshot: stall.snapshot, ventureStallSnapshot: ventureStall.snapshot });
 
+  // SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-3): cold-start rule — loadLastAccountIdentity()
+  // returning null (no prior state file / first tick after deploy-restart) means
+  // detectAccountSwitch always reports changed:false; the baseline write below still happens
+  // silently. A switch only fires when a PRIOR state EXISTED and differs from currentIdentity.
+  const priorIdentity = loadLastAccountIdentity();
+  const acctSwitch = detectAccountSwitch(priorIdentity, currentIdentity);
+  if (currentIdentity) saveLastAccountIdentity(currentIdentity);
+  if (acctSwitch.changed) {
+    // Fail-soft: a notification failure (identity resolution, dispatch refusal, DB hiccup) must
+    // never abort the tick — the console line below is the durable, always-emitted signal.
+    try {
+      const coordinatorId = await getActiveCoordinatorId(sb);
+      if (coordinatorId) {
+        await insertCoordinationRow(sb, {
+          sender_type: 'adam',
+          target_session: coordinatorId,
+          message_type: 'INFO',
+          subject: '[ACCOUNT_SWITCH] Adam session Claude account changed',
+          body: `Adam's Claude account switched from ${acctSwitch.event.from.email} (${acctSwitch.event.from.orgName}) ` +
+            `to ${acctSwitch.event.to.email} (${acctSwitch.event.to.orgName}).`,
+          payload: { kind: 'account_switch_notice', ...acctSwitch.event, reply_class: 'fire-and-forget' },
+        });
+      }
+    } catch { /* fail-soft — see comment above */ }
+  }
+
   const delaySeconds = decideCadence({ quiescent, partyOffsetS: ADAM_PARTY_OFFSET_S });
 
   const result = {
     party: 'adam',
     mode: quiescent ? 'QUIESCENT' : 'ACTIVE',
     modeReason,
+    acct: acctLabel,
     cores: tick.summary,
     failedCount: tick.failedCount,
     boardReconcile,
@@ -364,6 +416,7 @@ async function main() {
     outboundSilence,
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
+    accountSwitch: acctSwitch.changed,
     nextWakeSeconds: delaySeconds,
   };
 
@@ -371,7 +424,7 @@ async function main() {
     console.log(JSON.stringify(result));
   } else {
     console.log(
-      `QUIET_TICK=adam mode=${result.mode} cores=[${tick.summary}] ` +
+      `QUIET_TICK=adam mode=${result.mode} acct=${acctLabel} cores=[${tick.summary}] ` +
       `fail=${tick.failedCount} ` +
       `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
       `stalls=${stall.alerted.length} ` +
@@ -383,6 +436,9 @@ async function main() {
     );
     if (delta.changed) {
       console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing; if sending a subject-only stub ping, stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
+    }
+    if (acctSwitch.changed) {
+      console.log(`ACCOUNT_SWITCH detected: adam session Claude account changed from ${acctSwitch.event.from.email} to ${acctSwitch.event.to.email} — notice sent to active coordinator`);
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -379,10 +379,15 @@ async function main() {
   // silently. A switch only fires when a PRIOR state EXISTED and differs from currentIdentity.
   const priorIdentity = loadLastAccountIdentity();
   const acctSwitch = detectAccountSwitch(priorIdentity, currentIdentity);
-  if (currentIdentity) saveLastAccountIdentity(currentIdentity);
-  if (acctSwitch.changed) {
-    // Fail-soft: a notification failure (identity resolution, dispatch refusal, DB hiccup) must
-    // never abort the tick — the console line below is the durable, always-emitted signal.
+  let acctNotified = false;
+  if (!acctSwitch.changed) {
+    // Cold start / stable tick: no notification to send, always advance the baseline.
+    if (currentIdentity) saveLastAccountIdentity(currentIdentity);
+  } else {
+    // Fail-soft, but NOT silent-drop: the baseline is only advanced on CONFIRMED delivery
+    // (below). If the coordinator lookup fails or the DB insert throws, priorIdentity stays
+    // persisted, so the NEXT tick sees the same delta and retries — a security-relevant
+    // "which account is the fleet authenticated as" switch is never lost, only delayed.
     try {
       const coordinatorId = await getActiveCoordinatorId(sb);
       if (coordinatorId) {
@@ -395,8 +400,10 @@ async function main() {
             `to ${acctSwitch.event.to.email} (${acctSwitch.event.to.orgName}).`,
           payload: { kind: 'account_switch_notice', ...acctSwitch.event, reply_class: 'fire-and-forget' },
         });
+        acctNotified = true;
       }
-    } catch { /* fail-soft — see comment above */ }
+    } catch { /* fail-soft — see comment above; acctNotified stays false, baseline not advanced */ }
+    if (acctNotified && currentIdentity) saveLastAccountIdentity(currentIdentity);
   }
 
   const delaySeconds = decideCadence({ quiescent, partyOffsetS: ADAM_PARTY_OFFSET_S });
@@ -417,6 +424,7 @@ async function main() {
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
     accountSwitch: acctSwitch.changed,
+    accountSwitchNotified: acctSwitch.changed ? acctNotified : null,
     nextWakeSeconds: delaySeconds,
   };
 
@@ -438,7 +446,10 @@ async function main() {
       console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing; if sending a subject-only stub ping, stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
     }
     if (acctSwitch.changed) {
-      console.log(`ACCOUNT_SWITCH detected: adam session Claude account changed from ${acctSwitch.event.from.email} to ${acctSwitch.event.to.email} — notice sent to active coordinator`);
+      const noticeStatus = acctNotified
+        ? 'notice sent to active coordinator'
+        : 'notice NOT sent (no active coordinator / send error) — will retry next tick';
+      console.log(`ACCOUNT_SWITCH detected: adam session Claude account changed from ${acctSwitch.event.from.email} to ${acctSwitch.event.to.email} — ${noticeStatus}`);
     }
     for (const a of stall.alerted) {
       console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -33,6 +33,9 @@ const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const { DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): surface which Claude account this fleet is
+// running under in the tick's status line.
+const { getAccountIdentity } = require('../lib/fleet/account-identity.cjs');
 // SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001 FR-1 (adversarial-review finding): a
 // chairman_directive rides on target_session='broadcast' (never a real session id — see
 // scripts/issue-chairman-directive.cjs), so it can NEVER match the target_session=coordinatorId
@@ -249,6 +252,11 @@ async function main() {
   ]);
   const unactionedDirective = sessionDirective || chairmanDirective;
 
+  // SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): fail-safe — null/unavailable prints 'unknown'
+  // rather than crashing the tick.
+  const currentIdentity = getAccountIdentity();
+  const acctLabel = (currentIdentity && currentIdentity.email) || 'unknown';
+
   // FR-5/FR-6: self-paced next wake (capped at 15min when quiescent, never 300s;
   // overridden to a short hard-wake band when a directive is pending, per FR-1 above).
   const delaySeconds = decideCadence({
@@ -266,6 +274,7 @@ async function main() {
   const result = {
     mode: quiescent ? 'QUIESCENT' : 'ACTIVE',
     modeReason: unactionedDirective ? `${modeReason} [DIRECTIVE_HARD_WAKE]` : modeReason,
+    acct: acctLabel,
     cores: tick.summary,
     failedCount: tick.failedCount,
     skippedCount: tick.skippedCount,
@@ -279,7 +288,7 @@ async function main() {
   } else {
     // ONE summary line for the whole tick.
     console.log(
-      `QUIET_TICK=coordinator mode=${result.mode} cores=[${tick.summary}] ` +
+      `QUIET_TICK=coordinator mode=${result.mode} acct=${acctLabel} cores=[${tick.summary}] ` +
       `fail=${tick.failedCount} skip=${tick.skippedCount} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -42,6 +42,9 @@ const supabase = createSupabaseServiceClient();
 // coordinator standing-report (fleet-quiescence) and this dashboard read it from
 // one source. Behavior-identical to the prior local copies.
 const { isProcessRunning, getMarkerSessionIds, getAliveCcPids } = require('../lib/fleet/cc-pid-liveness.cjs');
+// SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): surface which Claude account this dashboard's
+// session is running under in the WORKERS header line.
+const { getAccountIdentity } = require('../lib/fleet/account-identity.cjs');
 
 const STALE_THRESHOLD = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS, 10) || 300;
 
@@ -442,8 +445,13 @@ function printWorkers(d) {
     headerSuffix = '  [MC unavailable — falling back to binary classification]';
   }
 
+  // SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): fail-safe — null/unavailable prints
+  // 'unknown' rather than crashing the dashboard render.
+  const identity = getAccountIdentity();
+  const acctLabel = (identity && identity.email) || 'unknown';
+
   console.log('');
-  console.log('WORKERS [' + now.toLocaleTimeString() + ']' + headerSuffix);
+  console.log('WORKERS [' + now.toLocaleTimeString() + ']' + headerSuffix + '  acct=' + acctLabel);
   console.log('─'.repeat(hasCollision ? 100 : 88));
 
   if (d.activeSessions.length === 0) {

--- a/tests/unit/fleet/account-identity.test.js
+++ b/tests/unit/fleet/account-identity.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 — FR-4 tests for lib/fleet/account-identity.cjs.
+ *
+ * getAccountIdentity() is exercised ONLY via the injection seam (a fixture object or a fixture
+ * file path) so these tests never touch the real logged-in account's ~/.claude.json.
+ *
+ * detectAccountSwitch() is pure (no IO, no persisted state of its own — the tick script owns
+ * persistence), so "ticks" are simulated in-test by threading the previous call's `current`
+ * into the next call's `prior`, mirroring how scripts/adam-quiet-tick.mjs uses it against its
+ * `.account-identity-last.json` state file.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { getAccountIdentity, detectAccountSwitch } = require('../../../lib/fleet/account-identity.cjs');
+
+// Token-shaped leak regex — pinned to the exact pattern from the SD spec.
+const LEAK_RE = /(sk-[A-Za-z0-9]+|Bearer\s+\S+|eyJ[A-Za-z0-9_-]+|[A-Za-z0-9_-]{40,})/;
+
+function validFixture(overrides = {}) {
+  return {
+    oauthAccount: {
+      emailAddress: 'chairman@example.com',
+      organizationName: 'ExecHoldings Global LLC',
+      accountUuid: 'abcd1234-5678-90ab-cdef-1234567890ab',
+      billingType: 'enterprise',
+      seatTier: 'max',
+      userRateLimitTier: 'tier-5',
+      ...overrides.oauthAccountExtra,
+    },
+    ...overrides.siblings,
+  };
+}
+
+describe('getAccountIdentity (FR-1)', () => {
+  it('Test 1 — positive whitelist: returns EXACTLY the 3 whitelisted keys', () => {
+    const result = getAccountIdentity(validFixture());
+    expect(result).not.toBeNull();
+    expect(Object.keys(result).sort()).toEqual(['accountUuid8', 'email', 'orgName']);
+    expect(result.email).toBe('chairman@example.com');
+    expect(result.orgName).toBe('ExecHoldings Global LLC');
+    expect(result.accountUuid8).toBe('abcd1234');
+  });
+
+  it('Test 2 — leak-safety: no token-shaped substring from oauthAccount or sibling keys ever appears in the result', () => {
+    const fixture = validFixture({
+      // NOTE: fixture strings below are intentionally SHORT fakes (under real credential
+      // length) — long enough to trip this test's own LEAK_RE, short enough to stay clear of
+      // the repo's pre-commit secret scanner's length-gated patterns (which require 16-20+
+      // chars). See .husky/pre-commit's documented false-positive guidance for test/mock data.
+      oauthAccountExtra: {
+        // extra oauthAccount sub-fields carrying token-shaped strings — must never leak.
+        accessToken: 'eyJfakeJwtFixtureNoRealToken',
+        apiKeyHint: 'sk-fakeFixture1',
+        authHeader: 'Bearer fake-fixture-not-a-real-token-0123456789-abcdef',
+        longOpaqueId: 'a'.repeat(64),
+      },
+      siblings: {
+        // sibling TOP-LEVEL config keys (outside oauthAccount) carrying token-shaped strings —
+        // getAccountIdentity must never even look at these, let alone leak them.
+        apiKey: 'sk-fakeTopFixture2',
+        sessionToken: 'eyJfakeTopLevelJwtFixtureNoRealToken',
+        someBearerHeader: 'Bearer fake-top-level-fixture-not-a-real-token-abcdef',
+      },
+    });
+
+    const result = getAccountIdentity(fixture);
+    expect(result).not.toBeNull();
+    const serialized = JSON.stringify(result);
+
+    // Sanity: the fixture DOES contain leak-shaped strings (proves the regex + fixture are wired
+    // correctly, i.e. this isn't a vacuously-passing test).
+    expect(LEAK_RE.test(JSON.stringify(fixture))).toBe(true);
+    // The actual assertion: none of that leaks through the whitelisted result.
+    expect(LEAK_RE.test(serialized)).toBe(false);
+  });
+
+  it('Test 6 — fail-soft: missing file path returns null, never throws', () => {
+    expect(() => getAccountIdentity('/no/such/path/.claude.json')).not.toThrow();
+    expect(getAccountIdentity('/no/such/path/.claude.json')).toBeNull();
+  });
+
+  it('Test 6 — fail-soft: malformed JSON file returns null, never throws', () => {
+    const os = require('os');
+    const path = require('path');
+    const fs = require('fs');
+    const tmpFile = path.join(os.tmpdir(), `account-identity-malformed-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, '{ not valid json ][');
+    try {
+      expect(() => getAccountIdentity(tmpFile)).not.toThrow();
+      expect(getAccountIdentity(tmpFile)).toBeNull();
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('Test 6 — fail-soft: oauthAccount missing a required sub-field returns null, never throws', () => {
+    const missingEmail = validFixture();
+    delete missingEmail.oauthAccount.emailAddress;
+    expect(() => getAccountIdentity(missingEmail)).not.toThrow();
+    expect(getAccountIdentity(missingEmail)).toBeNull();
+
+    const missingOrg = validFixture();
+    delete missingOrg.oauthAccount.organizationName;
+    expect(getAccountIdentity(missingOrg)).toBeNull();
+
+    const missingUuid = validFixture();
+    delete missingUuid.oauthAccount.accountUuid;
+    expect(getAccountIdentity(missingUuid)).toBeNull();
+  });
+
+  it('Test 6 — fail-soft: missing/malformed oauthAccount object returns null, never throws', () => {
+    expect(getAccountIdentity({})).toBeNull();
+    expect(getAccountIdentity({ oauthAccount: 'not-an-object' })).toBeNull();
+    expect(getAccountIdentity({ oauthAccount: null })).toBeNull();
+  });
+});
+
+describe('detectAccountSwitch (FR-3)', () => {
+  const identityA = { email: 'a@example.com', orgName: 'Org A', accountUuid8: 'aaaa1111' };
+  const identityB = { email: 'b@example.com', orgName: 'Org B', accountUuid8: 'bbbb2222' };
+
+  /** Threads prior/current through detectAccountSwitch the same way the tick script does. */
+  function simulateTicks(identitySequence) {
+    let prior = null;
+    const events = [];
+    for (const current of identitySequence) {
+      const result = detectAccountSwitch(prior, current);
+      if (result.changed) events.push(result.event);
+      prior = current; // baseline write happens every tick regardless of switch
+    }
+    return events;
+  }
+
+  it('Test 3 — switch fires exactly once from an established prior', () => {
+    // tick 1: cold start (baseline write, no event) -> tick 2: stable -> tick 3: switch
+    const events = simulateTicks([identityA, identityA, identityB]);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('ACCOUNT_SWITCH');
+    expect(events[0].from.email).toBe('a@example.com');
+    expect(events[0].to.email).toBe('b@example.com');
+  });
+
+  it('Test 3b — debounce holds on the tick immediately following a genuine switch', () => {
+    // tick 1: cold start -> tick 2: stable -> tick 3: switch (fires) -> tick 4: stable at the
+    // NEW identity — must stay silent. Regression guard against accidentally gating the
+    // baseline-write behind the `changed` branch (which would make tick 4 fire again).
+    const events = simulateTicks([identityA, identityA, identityB, identityB]);
+    expect(events).toHaveLength(1);
+    expect(events[0].to.email).toBe('b@example.com');
+  });
+
+  it('Test 4 — silent across N stable ticks with the same identity', () => {
+    const events = simulateTicks([identityA, identityA, identityA, identityA]);
+    expect(events).toHaveLength(0);
+  });
+
+  it('Test 5 — cold start is silent even though a current identity exists', () => {
+    const result = detectAccountSwitch(null, identityA);
+    expect(result.changed).toBe(false);
+    expect(result.event).toBeNull();
+
+    const events = simulateTicks([identityA]);
+    expect(events).toHaveLength(0);
+  });
+
+  it('is silent when there is no current identity to compare (fail-soft)', () => {
+    const result = detectAccountSwitch(identityA, null);
+    expect(result.changed).toBe(false);
+    expect(result.event).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The fleet had no awareness of which Claude Code account it runs under. A scheduled run around a session-limit reset silently stopped applying once the chairman switched accounts mid-session via `/login` (machine-global — one login switches ALL sessions), and nothing noticed.
- Adds a whitelist-only reader (`lib/fleet/account-identity.cjs`) surfacing `{email, orgName, accountUuid8}` from `~/.claude.json`'s `oauthAccount` (never any of its ~16 other sub-fields or the config's ~87 other top-level keys).
- Wires an `acct=<email>` token into `adam-quiet-tick.mjs`, `coordinator-quiet-tick.mjs`, `fleet-dashboard.cjs`, and stamps identity onto `spawn-executor-core.cjs` diagnostics.
- Adds debounced `ACCOUNT_SWITCH` detection (cold-start-silent, fires exactly once per genuine change) sending one coordinator notice via the existing `insertCoordinationRow()` choke point.

## Adversarial review trail
A workflow-driven deep review (3 independent lenses: static-code-review, fixture-injection-attack, cold-start-and-debounce) found and closed 2 real gaps before this PR:
- Unsanitized whitelist fields could forge log lines via embedded control/ANSI-escape characters if the on-disk config were ever tampered with — fixed via `sanitizeField()` (control-char strip + 256-char clamp).
- Missing debounce-after-switch regression test — added (Test 3b).

## Test plan
- [x] `tests/unit/fleet/account-identity.test.js` — 11/11 passing (positive whitelist, pinned-regex leak-safety, fires-once, debounce-holds-after-switch, silent-when-stable, cold-start-silent, fail-soft x4)
- [x] Regression sweep: `tests/unit/fleet/` + `tests/unit/coordinator/` — 77 files / 861 tests, zero regressions
- [x] LEAD/PLAN/EXEC-TO-PLAN sub-agent evidence (VALIDATION, Explore, TESTING x2, SECURITY) all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)