### PR TITLE
feat(SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001): exclude chairman-gated QFs from the worker open-work lane

### DIFF
--- a/lib/fleet/qf-gated-hold.cjs
+++ b/lib/fleet/qf-gated-hold.cjs
@@ -1,0 +1,35 @@
+// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold marker predicate.
+//
+// A QF whose APPLY is chairman-gated (the QF-508/QF-970 class — e.g. gated DDL with a
+// release condition like "EU-send-planned") must not sit in the worker-facing open-QF
+// lane as false open work: every idle worker re-discovers it, burns a claim/triage
+// cycle, and re-concludes "blocked on chairman". The marker uses EXISTING quick_fixes
+// columns (owner + release_condition — no DDL; live witness QF-20260713-970 already
+// carries owner='CHAIRMAN' + a release condition):
+//
+//   gated  ⇔  owner ilike 'chairman'  AND  release_condition is a non-empty string
+//
+// This module is the SINGLE source for that predicate — both worker-lane exclusion
+// sites (worker-checkin.cjs isAutoStartableQF, sd-next data-loaders loadOpenQuickFixes)
+// and the coordinator dashboard surface import it, so the sites can never drift.
+// Fail-open (TR-3): absent/null columns ⇒ NOT gated (normal lane behavior); exclusion
+// only on a confident marker match. The hold must stay AUDITABLE — consumers that hide
+// gated rows from workers must keep them visible on the coordinator/chairman surface.
+
+/**
+ * @param {{owner?: string|null, release_condition?: string|null}|null|undefined} qf
+ * @returns {boolean} true iff the row carries the canonical chairman-gated-hold marker
+ */
+function isChairmanGatedQF(qf) {
+  if (!qf || typeof qf !== 'object') return false;
+  const owner = typeof qf.owner === 'string' ? qf.owner.trim().toLowerCase() : '';
+  if (owner !== 'chairman') return false;
+  const cond = typeof qf.release_condition === 'string' ? qf.release_condition.trim() : '';
+  return cond.length > 0;
+}
+
+// Columns a caller's .select() must include for isChairmanGatedQF to evaluate — exported
+// so query sites can compose their select lists without hand-typing the pair.
+const GATED_HOLD_COLUMNS = Object.freeze(['owner', 'release_condition']);
+
+module.exports = { isChairmanGatedQF, GATED_HOLD_COLUMNS };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1405,6 +1405,36 @@ async function resolveInboxAudience({ argv = process.argv, env = process.env, cl
 // distinct intake surface the coordinator must drain (clearCoordinatorReview IS the
 // dispatch authorization). Without this, a whole wave of held SDs can sit invisible
 // while the coordinator reports belt-empty. Read-only: never mutates the flag.
+
+// ── Section: Chairman-gated QFs (SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001) ──
+// QFs whose APPLY is chairman-gated (owner='chairman' + release_condition — the
+// QF-508/QF-970 class) are EXCLUDED from the worker-facing open-QF lane so idle workers
+// stop burning claim/triage cycles on them. This surface keeps the hold AUDITABLE:
+// every gated row renders here with age + condition until released via
+// scripts/release-chairman-gated-qf.js — never silently lost.
+async function printChairmanGatedQfs() {
+  const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
+  const { data: rows, error } = await supabase
+    .from('quick_fixes')
+    .select('id, title, status, owner, release_condition, created_at')
+    .not('release_condition', 'is', null)
+    .not('status', 'in', '(completed,cancelled)')
+    .order('created_at', { ascending: true })
+    .limit(30);
+  if (error) { return; } // additive surface — degrade silently, never break the dashboard
+  const gated = (rows || []).filter(isChairmanGatedQF);
+  if (gated.length === 0) return; // render nothing when no holds exist (no empty-section noise)
+  console.log('CHAIRMAN-GATED QFS (excluded from worker lane until released)');
+  console.log('─'.repeat(72));
+  for (const qf of gated) {
+    const ageDays = Math.floor((Date.now() - Date.parse(qf.created_at)) / 86_400_000);
+    console.log('  ' + pad(qf.id, 20) + pad(qf.status, 12) + pad(ageDays + 'd', 6) + (qf.title || '').substring(0, 34));
+    console.log('    condition: ' + String(qf.release_condition).replace(/\n/g, ' ').substring(0, 100));
+  }
+  console.log('  Release: node scripts/release-chairman-gated-qf.js <QF-ID> --reason "<why>"');
+  console.log('');
+}
+
 async function printReviewHeldSds() {
   console.log('REVIEW-HELD SDS');
   console.log('─'.repeat(72));
@@ -2150,8 +2180,8 @@ async function main() {
     workers:       () => printWorkers(d),
     orchestrator:  () => printOrchestrator(d),
     available:     () => printAvailable(d),
-    quickfixes:    () => printQuickFixes(d), // QF-20260525-836
-    qf:            () => printQuickFixes(d), // QF-20260525-836 (alias)
+    quickfixes:    async () => { printQuickFixes(d); await printChairmanGatedQfs(); }, // QF-20260525-836 + SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001
+    qf:            async () => { printQuickFixes(d); await printChairmanGatedQfs(); }, // QF-20260525-836 (alias)
     revival:       () => printRevivalPending(d),
     coordination:  () => printCoordination(d),
     coaching:      async () => await printCoaching(d),
@@ -2186,6 +2216,8 @@ async function main() {
       await printAdamInbox();
       // QF-20260704-742: third intake surface — SDs held with metadata.needs_coordinator_review.
       await printReviewHeldSds();
+      // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: fourth intake surface — chairman-gated QF holds.
+      await printChairmanGatedQfs();
     },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
     solomon:       async () => { await printSolomonInbox(); await printSolomonLedgerRollup(); }, // SD-LEO-INFRA-SOLOMON-CONSULT-001F + SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001
@@ -2217,6 +2249,7 @@ async function main() {
       await printDrainGauge(); // SD-LEO-INFRA-HARNESS-BACKLOG-DRAIN-POLICY-001 (FR-9) — harness-backlog drain gauge
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
       await printReviewHeldSds(); // QF-20260704-742 — third intake surface: needs_coordinator_review holds
+      await printChairmanGatedQfs(); // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001 — auditable gated-QF holds
       await printSolomonInbox(); // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane (dormant until SOLOMON_CONSULT_V1)
       await printSolomonLedgerRollup(); // SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-5) — accuracy + cost-per-accepted rollup
       await printWorkingContext(); // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3) — standing context dual-render

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1428,8 +1428,12 @@ async function printChairmanGatedQfs() {
   const { data: rows, error } = await supabase
     .from('quick_fixes')
     .select('id, title, status, owner, release_condition, created_at')
+    // '%chairman%' (not exact): the canonical predicate is trim-tolerant and defer-quick-fix
+    // writes owner verbatim, so a padded ' chairman ' must still reach this surface (round-2
+    // adversarial finding — exact ilike silently lost it). Overmatches like 'vice-chairman'
+    // are rejected by the client-side isChairmanGatedQF re-check below (exact after trim).
     .not('release_condition', 'is', null)
-    .ilike('owner', 'chairman')
+    .ilike('owner', '%chairman%')
     .not('status', 'in', '(completed,cancelled,closed)')
     .order('created_at', { ascending: true })
     .limit(30);

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -365,7 +365,10 @@ async function loadData() {
   try {
     const { data: qfRows } = await supabase
       .from('quick_fixes')
-      .select('id, title, status, claiming_session_id, created_at')
+      // owner/release_condition: SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001 — the main list
+      // must MARK gated rows (adversarial-review fix, PR #6178), not render them as
+      // ordinary claimable open work while only the dedicated section knows better.
+      .select('id, title, status, claiming_session_id, created_at, owner, release_condition')
       .in('status', ['open', 'in_progress'])
       .order('created_at', { ascending: true });
     quickFixes = qfRows || [];
@@ -648,7 +651,11 @@ function printQuickFixes(d) {
   for (const qf of qfs) {
     const ageH = qf.created_at ? Math.max(0, Math.round((now - Date.parse(qf.created_at)) / 3600000)) + 'h' : '?';
     const holder = qf.claiming_session_id ? String(qf.claiming_session_id).substring(0, 8) : '—';
-    console.log('  ' + pad(qf.id, 18) + pad(qf.status, 12) + pad(ageH, 6) + pad(holder, 10) + (qf.title || '').substring(0, 40));
+    // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: gated rows are NOT claimable open work —
+    // badge them here so the primary list agrees with the worker-lane exclusion.
+    const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
+    const gatedBadge = isChairmanGatedQF(qf) ? ' ⛔CHAIRMAN-GATED' : '';
+    console.log('  ' + pad(qf.id, 18) + pad(qf.status, 12) + pad(ageH, 6) + pad(holder, 10) + (qf.title || '').substring(0, 40) + gatedBadge);
   }
   console.log('');
 }
@@ -1414,11 +1421,16 @@ async function resolveInboxAudience({ argv = process.argv, env = process.env, cl
 // scripts/release-chairman-gated-qf.js — never silently lost.
 async function printChairmanGatedQfs() {
   const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
+  // Adversarial-review fixes (PR #6178): owner filtered SERVER-side (ilike) so non-chairman
+  // release_condition rows can't crowd chairman holds out of the limit window ("never
+  // silently lost" contract); 'closed' is a real terminal status (auto-close migration) —
+  // excluded so a superseded gated QF doesn't display as an active hold forever.
   const { data: rows, error } = await supabase
     .from('quick_fixes')
     .select('id, title, status, owner, release_condition, created_at')
     .not('release_condition', 'is', null)
-    .not('status', 'in', '(completed,cancelled)')
+    .ilike('owner', 'chairman')
+    .not('status', 'in', '(completed,cancelled,closed)')
     .order('created_at', { ascending: true })
     .limit(30);
   if (error) { return; } // additive surface — degrade silently, never break the dashboard

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -7,6 +7,10 @@ import { execSync } from 'child_process';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { parseHarnessBacklog } from './harness-backlog-parser.js';
+// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold predicate (CJS
+// module; ESM default-import interop). Shared with worker-checkin + the coordinator dashboard.
+import qfGatedHold from '../../../lib/fleet/qf-gated-hold.cjs';
+const { isChairmanGatedQF } = qfGatedHold;
 
 /**
  * Log a query failure with structured context for diagnostics.
@@ -363,7 +367,7 @@ export async function loadOpenQuickFixes(supabase) {
     // form above silently failed to suppress the lint).
     const { data, error } = await supabase
       .from('quick_fixes')
-      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane') // schema-lint-disable-line: factory_lane staged, see comment above
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane, owner, release_condition') // schema-lint-disable-line: factory_lane staged, see comment above
       .in('status', ['open', 'in_progress'])
       .is('pr_url', null)
       .is('commit_sha', null)
@@ -375,7 +379,13 @@ export async function loadOpenQuickFixes(supabase) {
       return [];
     }
 
-    return data || [];
+    // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: chairman-gated holds (owner='chairman' +
+    // release_condition — the QF-508/QF-970 class) are false open work for the worker-facing
+    // lane: every idle worker re-discovers them and re-concludes "blocked on chairman".
+    // Excluded here (Track C display + AUTO_PROCEED_ACTION source); they remain visible on
+    // the coordinator surface (fleet-dashboard CHAIRMAN-GATED section) until released via
+    // scripts/release-chairman-gated-qf.js. Shared predicate — never re-derive inline.
+    return (data || []).filter((qf) => !isChairmanGatedQF(qf));
   } catch {
     return [];
   }

--- a/scripts/qf-start.js
+++ b/scripts/qf-start.js
@@ -18,7 +18,11 @@
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { spawnSync } from 'node:child_process';
 import dotenv from 'dotenv';
+import { createRequire } from 'node:module';
 import { repoUnfitReason } from '../lib/fleet/qf-repo-fitness.js';
+
+// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold predicate (CJS).
+const { isChairmanGatedQF } = createRequire(import.meta.url)('../lib/fleet/qf-gated-hold.cjs');
 
 dotenv.config();
 
@@ -55,6 +59,21 @@ async function main() {
     console.error(`✗ Quick-fix ${qfId} NOT claimed: ${unfitReason}`);
     await safeExit(3);
   }
+
+  // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001 (adversarial-review fix, PR #6178): enforce the
+  // chairman-gated hold at the CLAIM boundary too — the discovery-lane exclusions alone left
+  // this path able to claim a gated QF by explicit id and start chairman-gated work without
+  // release. Fail-open on read error (never wedge ungated claims on a DB hiccup).
+  try {
+    const { data: holdRow } = await supabase
+      .from('quick_fixes').select('owner, release_condition').eq('id', qfId).maybeSingle();
+    if (holdRow && isChairmanGatedQF(holdRow)) {
+      console.error(`✗ Quick-fix ${qfId} NOT claimed: CHAIRMAN-GATED hold`);
+      console.error(`  release condition: ${String(holdRow.release_condition).replace(/\n/g, ' ').slice(0, 160)}`);
+      console.error(`  Release first: node scripts/release-chairman-gated-qf.js ${qfId} --reason "<why>"`);
+      await safeExit(3);
+    }
+  } catch { /* fail-open — the gate must never wedge ungated claims */ }
 
   const { data, error } = await supabase.rpc('claim_sd', {
     p_sd_id: qfId,

--- a/scripts/release-chairman-gated-qf.js
+++ b/scripts/release-chairman-gated-qf.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * Release a chairman-gated QF back to the worker-facing open-work lane.
+ * SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001 (FR-3/FR-4)
+ *
+ * Counterpart to the gated-hold marker (owner='chairman' + release_condition — set via
+ * scripts/defer-quick-fix.js --owner chairman --release-condition "<text>"). Clears the
+ * marker and stamps WHO/WHEN/WHY into verification_notes so the release is auditable,
+ * mirroring the clear-coordinator-review.mjs pattern. The QF re-admits to the worker
+ * lane (sd:next Track C + worker-checkin self-claim) on the next queue refresh.
+ *
+ * REFUSES (non-zero exit) on a row without the marker — a silent no-op would mask a
+ * typo'd QF id or a double-release.
+ *
+ * Usage:
+ *   node scripts/release-chairman-gated-qf.js QF-20260713-970 --reason "chairman approved (verbal, 2026-08-01)"
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { createRequire } from 'module';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+dotenv.config();
+const require = createRequire(import.meta.url);
+const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
+
+export function parseReleaseArgs(argv) {
+  const args = argv.slice();
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') return { showHelp: true };
+  const qfId = args[0];
+  let reason = null;
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--reason') { reason = args[i + 1]; i++; }
+  }
+  return { showHelp: false, qfId, reason };
+}
+
+export async function releaseChairmanGatedQf(qfId, { reason, releasingSessionId, supabaseClient = null } = {}) {
+  if (!reason || !String(reason).trim()) {
+    throw new Error('--reason "<why released>" is required — the release stamp is the audit trail');
+  }
+  const supabase = supabaseClient || createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const { data: row, error: readErr } = await supabase
+    .from('quick_fixes')
+    .select('id, status, owner, release_condition, verification_notes')
+    .eq('id', qfId)
+    .maybeSingle();
+  if (readErr) throw new Error(`read failed for ${qfId}: ${readErr.message}`);
+  if (!row) throw new Error(`Quick-fix not found: ${qfId}`);
+  if (!isChairmanGatedQF(row)) {
+    throw new Error(`${qfId} does not carry the chairman-gated-hold marker (owner='chairman' + release_condition) — nothing to release`);
+  }
+
+  const stamp = `[GATED-RELEASE ${new Date().toISOString()}] by session ${releasingSessionId || '(unknown)'}: ${String(reason).trim()} (was: ${String(row.release_condition).replace(/\n/g, ' ').slice(0, 200)})`;
+  const notes = row.verification_notes ? `${row.verification_notes}\n${stamp}` : stamp;
+
+  const { data, error } = await supabase
+    .from('quick_fixes')
+    .update({ owner: null, release_condition: null, verification_notes: notes })
+    .eq('id', qfId)
+    .select('id, status, owner, release_condition')
+    .single();
+  if (error) throw new Error(`release failed for ${qfId}: ${error.message}`);
+  return data;
+}
+
+async function main() {
+  const parsed = parseReleaseArgs(process.argv.slice(2));
+  if (parsed.showHelp) {
+    console.log('Usage: node scripts/release-chairman-gated-qf.js <QF-ID> --reason "<why released>"');
+    return;
+  }
+  try {
+    const data = await releaseChairmanGatedQf(parsed.qfId, {
+      reason: parsed.reason,
+      releasingSessionId: process.env.CLAUDE_SESSION_ID || null,
+    });
+    console.log(`✓ ${data.id} released to the worker lane (status=${data.status}) — release stamped in verification_notes`);
+  } catch (e) {
+    console.error('ERROR:', e.message);
+    process.exit(1);
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/scripts/release-chairman-gated-qf.js
+++ b/scripts/release-chairman-gated-qf.js
@@ -60,13 +60,19 @@ export async function releaseChairmanGatedQf(qfId, { reason, releasingSessionId,
   const stamp = `[GATED-RELEASE ${new Date().toISOString()}] by session ${releasingSessionId || '(unknown)'}: ${String(reason).trim()} (was: ${String(row.release_condition).replace(/\n/g, ' ').slice(0, 200)})`;
   const notes = row.verification_notes ? `${row.verification_notes}\n${stamp}` : stamp;
 
+  // Adversarial-review fix (PR #6178): condition the update on the marker still being
+  // present so a concurrent double-release can't both succeed and double-append stamps
+  // (read-then-update is otherwise non-atomic). Zero rows updated ⇒ someone else released
+  // between our read and write — surface that instead of a silent success.
   const { data, error } = await supabase
     .from('quick_fixes')
     .update({ owner: null, release_condition: null, verification_notes: notes })
     .eq('id', qfId)
+    .not('release_condition', 'is', null)
     .select('id, status, owner, release_condition')
-    .single();
+    .maybeSingle();
   if (error) throw new Error(`release failed for ${qfId}: ${error.message}`);
+  if (!data) throw new Error(`${qfId} was released concurrently by another session — no double-stamp written`);
   return data;
 }
 

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -47,6 +47,9 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, liveClaimWriteFenceReason } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: canonical chairman-gated-hold predicate (shared
+// with sd-next data-loaders + the coordinator dashboard so the sites can never drift).
+const { isChairmanGatedQF } = require('../lib/fleet/qf-gated-hold.cjs');
 // SD-ARCH-HOTSPOT-SD-START-001 FR-2: the CONVERGED dependency gate shared with scripts/sd-start.js
 // (one resolution truth — deps array shapes + blocked_on_sd fold + sd_key-OR-id lookup). This
 // consumer applies its native FAIL-CLOSED polarity via depsSatisfiedFromVerdict: skip on
@@ -563,6 +566,11 @@ function isAutoStartableQF(qf, nowMs) {
     const notBefore = Date.parse(qf.not_before);
     if (Number.isFinite(notBefore) && notBefore > nowMs) return false;
   }
+  // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: chairman-gated hold (owner='chairman' +
+  // release_condition) -- the QF-508/QF-970 class whose APPLY awaits a chairman condition.
+  // Stays status='open' but is false open work for a worker: exclude until released via
+  // scripts/release-chairman-gated-qf.js. Visible on the coordinator surface, never lost.
+  if (isChairmanGatedQF(qf)) return false;
   const created = qf.created_at ? Date.parse(qf.created_at) : NaN;
   if (!Number.isFinite(created)) return false;
   const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
@@ -594,7 +602,7 @@ async function selfClaimQuickFix(sb, sessionId, base, sessionModel) {
     // list rather than being intentionally suppressed).
     const { data: qfs } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, description, severity, not_before, factory_lane') // schema-lint-disable-line: factory_lane staged, see comment above
+      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, description, severity, not_before, factory_lane, owner, release_condition') // schema-lint-disable-line: factory_lane staged, see comment above
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)

--- a/tests/unit/fleet/qf-gated-hold.test.js
+++ b/tests/unit/fleet/qf-gated-hold.test.js
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the chairman-gated QF hold: marker predicate, worker-lane exclusion,
+ * and the release path.
+ * SD: SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001
+ *
+ * Chairman-gated QFs (owner='chairman' + release_condition — the QF-508/QF-970 class)
+ * sat in the worker-facing open-QF lane as false open work; every idle worker burned a
+ * claim/triage cycle re-concluding "blocked on chairman". These tests pin:
+ *   - isChairmanGatedQF: case-insensitive owner + non-empty condition; fail-open on
+ *     missing/null columns (TS-3, TR-2/TR-3),
+ *   - loadOpenQuickFixes excludes marked rows, returns unmarked ones (TS-2),
+ *   - releaseChairmanGatedQf clears the marker + stamps who/when/why, and REFUSES an
+ *     unmarked row (TS-4/TS-5).
+ * (worker-checkin's isAutoStartableQF clause reuses the same predicate module —
+ * single-source parity is the design, pinned here via the predicate tests.)
+ */
+import { describe, test, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { isChairmanGatedQF, GATED_HOLD_COLUMNS } = require('../../../lib/fleet/qf-gated-hold.cjs');
+import { loadOpenQuickFixes } from '../../../scripts/modules/sd-next/data-loaders.js';
+import { releaseChairmanGatedQf } from '../../../scripts/release-chairman-gated-qf.js';
+
+describe('isChairmanGatedQF (FR-1 marker predicate)', () => {
+  test('matches owner case variants with a non-empty condition (TS-3)', () => {
+    for (const owner of ['CHAIRMAN', 'chairman', 'Chairman', ' chairman ']) {
+      expect(isChairmanGatedQF({ owner, release_condition: 'EU-send-planned' })).toBe(true);
+    }
+  });
+
+  test('fail-open: missing/empty owner or condition is NOT gated (TR-3)', () => {
+    expect(isChairmanGatedQF({ owner: 'chairman', release_condition: null })).toBe(false);
+    expect(isChairmanGatedQF({ owner: 'chairman', release_condition: '   ' })).toBe(false);
+    expect(isChairmanGatedQF({ owner: null, release_condition: 'x' })).toBe(false);
+    expect(isChairmanGatedQF({ owner: 'coordinator', release_condition: 'x' })).toBe(false);
+    expect(isChairmanGatedQF({})).toBe(false);
+    expect(isChairmanGatedQF(null)).toBe(false);
+    expect(isChairmanGatedQF(undefined)).toBe(false);
+  });
+
+  test('GATED_HOLD_COLUMNS names the columns the predicate reads', () => {
+    expect(GATED_HOLD_COLUMNS).toEqual(['owner', 'release_condition']);
+  });
+});
+
+describe('loadOpenQuickFixes worker-lane exclusion (FR-2 / TS-2)', () => {
+  function mockSupabase(rows) {
+    const chain = {
+      select() { return chain; },
+      in() { return chain; },
+      is() { return chain; },
+      order() { return chain; },
+      limit() { return Promise.resolve({ data: rows, error: null }); },
+    };
+    return { from() { return chain; } };
+  }
+
+  test('marked rows excluded; unmarked rows returned', async () => {
+    const rows = [
+      { id: 'QF-GATED', status: 'open', owner: 'CHAIRMAN', release_condition: 'EU send planned' },
+      { id: 'QF-NORMAL', status: 'open', owner: null, release_condition: null },
+      { id: 'QF-OWNED-NO-COND', status: 'open', owner: 'chairman', release_condition: null },
+    ];
+    const result = await loadOpenQuickFixes(mockSupabase(rows));
+    const ids = result.map((r) => r.id);
+    expect(ids).not.toContain('QF-GATED');
+    expect(ids).toContain('QF-NORMAL');
+    expect(ids).toContain('QF-OWNED-NO-COND'); // no condition -> not gated (fail-open)
+  });
+});
+
+describe('releaseChairmanGatedQf (FR-4 / TS-4, TS-5)', () => {
+  function mockSupabase(row) {
+    const updates = [];
+    const readChain = {
+      select() { return readChain; },
+      eq() { return readChain; },
+      maybeSingle() { return Promise.resolve({ data: row, error: null }); },
+    };
+    const updateChain = {
+      update(p) { updates.push(p); return updateChain; },
+      eq() { return updateChain; },
+      select() { return updateChain; },
+      single() { return Promise.resolve({ data: { id: row.id, status: row.status, owner: null, release_condition: null }, error: null }); },
+    };
+    let call = 0;
+    return {
+      from() { call += 1; return call === 1 ? readChain : updateChain; },
+      _updates: updates,
+    };
+  }
+
+  test('clears the marker and stamps who/when/why into verification_notes (TS-4)', async () => {
+    const client = mockSupabase({
+      id: 'QF-X', status: 'open', owner: 'CHAIRMAN',
+      release_condition: 'EU send planned', verification_notes: 'prior notes',
+    });
+    const result = await releaseChairmanGatedQf('QF-X', {
+      reason: 'chairman approved (verbal)', releasingSessionId: 'sess-123', supabaseClient: client,
+    });
+    expect(result.owner).toBe(null);
+    expect(result.release_condition).toBe(null);
+    expect(client._updates).toHaveLength(1);
+    const u = client._updates[0];
+    expect(u.owner).toBe(null);
+    expect(u.release_condition).toBe(null);
+    expect(u.verification_notes).toContain('prior notes');
+    expect(u.verification_notes).toContain('GATED-RELEASE');
+    expect(u.verification_notes).toContain('sess-123');
+    expect(u.verification_notes).toContain('chairman approved (verbal)');
+  });
+
+  test('refuses an unmarked row — no silent no-op (TS-5)', async () => {
+    const client = mockSupabase({ id: 'QF-Y', status: 'open', owner: null, release_condition: null });
+    await expect(releaseChairmanGatedQf('QF-Y', { reason: 'x', supabaseClient: client }))
+      .rejects.toThrow(/does not carry the chairman-gated-hold marker/);
+    expect(client._updates).toHaveLength(0);
+  });
+
+  test('refuses a missing --reason — the stamp is the audit trail', async () => {
+    const client = mockSupabase({ id: 'QF-Z', status: 'open', owner: 'chairman', release_condition: 'c' });
+    await expect(releaseChairmanGatedQf('QF-Z', { supabaseClient: client }))
+      .rejects.toThrow(/--reason/);
+  });
+});

--- a/tests/unit/fleet/qf-gated-hold.test.js
+++ b/tests/unit/fleet/qf-gated-hold.test.js
@@ -80,8 +80,11 @@ describe('releaseChairmanGatedQf (FR-4 / TS-4, TS-5)', () => {
     const updateChain = {
       update(p) { updates.push(p); return updateChain; },
       eq() { return updateChain; },
+      // Concurrency guard (adversarial fix): the update is conditioned on the marker still
+      // being present via .not('release_condition','is',null).
+      not() { return updateChain; },
       select() { return updateChain; },
-      single() { return Promise.resolve({ data: { id: row.id, status: row.status, owner: null, release_condition: null }, error: null }); },
+      maybeSingle() { return Promise.resolve({ data: { id: row.id, status: row.status, owner: null, release_condition: null }, error: null }); },
     };
     let call = 0;
     return {


### PR DESCRIPTION
## Summary
- Chairman-gated QFs (`owner='chairman'` + `release_condition` — the QF-508/QF-970 class, e.g. the gated GDPR-migration apply) sat in the worker-facing open-QF lane as false open work; every idle worker re-discovered them, burned a claim/triage cycle, and re-concluded 'blocked on chairman' (coordinator-sourced from Alpha-4 + Bravo retros, ping fdd474bf item 3).
- **FR-1**: canonical marker predicate `lib/fleet/qf-gated-hold.cjs` on EXISTING columns (no DDL — verified live; witness QF-20260713-970 already carries the shape). Setter already existed (`defer-quick-fix.js --owner/--release-condition`, HOLD-STATE-CONTRACT-001) — verified, not duplicated.
- **FR-2**: both worker-facing surfaces exclude marked rows — `worker-checkin.cjs isAutoStartableQF` (self-claim picker) and `sd-next data-loaders loadOpenQuickFixes` (Track C + AUTO_PROCEED_ACTION source). Fail-open: absent/empty marker ⇒ normal lane behavior.
- **FR-3**: never silently lost — `fleet-dashboard` renders a CHAIRMAN-GATED section (id, status, age, condition) on quickfixes/inbox-coordinator/all views.
- **FR-4**: `scripts/release-chairman-gated-qf.js` — one-command release stamping who/when/why into verification_notes; refuses unmarked rows and empty --reason.

## Verification
- 7 new unit tests (predicate case/fail-open matrix, lane exclusion, release stamp + refusal paths).
- Regression sweep: 167 tests green (worker-checkin suites + dashboard + defer-quick-fix).
- Live witness shape check passes; worker-checkin wiring grep-verified.

SD: SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001 (PRD PRD-SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)