### PR TITLE
feat(SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C): shadow-run core — isolated replay engine, witness, GT-replay, self-reference guard

### DIFF
--- a/lib/eval/eval-set-fixtures.mjs
+++ b/lib/eval/eval-set-fixtures.mjs
@@ -1,4 +1,10 @@
 /**
+ * @governed-by: SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001 shadow-trial contract —
+ * this corpus is itself a governed artifact; mutations require a staged
+ * governed_change_proposals row once the chairman ceremony applies the table
+ * (child C self-reference guard: writer check in scripts/eval/seal-eval-set.mjs
+ * + CI lint tests/ci/shadow-trial-self-reference-lint.test.js).
+ *
  * eval-set-fixtures.mjs — sealed eval-set corpus definitions, 2 governed-artifact
  * classes (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-B).
  *

--- a/lib/governance/shadow-trial/shadow-run.mjs
+++ b/lib/governance/shadow-trial/shadow-run.mjs
@@ -1,0 +1,152 @@
+/**
+ * shadow-run.mjs — the shadow-run core (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C).
+ *
+ * PURE module — no DB, no fs, no network. Replays a proposed governed-change
+ * variant against a class's sealed eval cases (child B's loadEvalSet output) and
+ * emits per-case rows in EXACTLY the shape child A's composePrecheckPacket
+ * consumes: [{ case_id, current_verdict, proposed_verdict, delta, regression }].
+ *
+ * Evaluators are INJECTED (capability-runner runPipeline precedent) so isolation
+ * is provable structurally: this module imports only the pure closure engine and
+ * the class registry; the static isolation witness (shadow-run-isolation.test.js)
+ * fails the build if a write-capable import ever appears here.
+ *
+ * VERDICT SEMANTICS (PRD plan decision, refined):
+ *   - current_verdict = the case's ADJUDICATED TRUTH (of-record baseline), never
+ *     the naive engine output — a naive baseline would flag known-bad cases under
+ *     an identity replay (the engine already disagrees with truth there by design).
+ *   - engineCurrent/engineProposed = the engine's verdicts under the current vs
+ *     proposed artifact, evidence and pinned `now` held constant from the seal.
+ *   - If the proposal does NOT change the engine's behavior on a case
+ *     (engineProposed === engineCurrent), the case is untouched: proposed_verdict
+ *     anchors to the adjudicated truth and regression=false. A pre-existing
+ *     known-bad the proposal neither fixes nor worsens is the CORPUS's documented
+ *     defect, not the proposal's regression.
+ *   - If the proposal CHANGES the engine's behavior, proposed_verdict is the raw
+ *     engineProposed and regression = (engineProposed !== adjudicated truth):
+ *     breaking a correct case (CP-003 open->closed) or re-breaking a known-bad in
+ *     a new way flags true; FIXING a known-bad (engine newly agrees with truth)
+ *     flags false.
+ *
+ * FAIL-CLOSED-TO-PLAIN-REVIEW: unknown artifact_class (or an unloadable corpus)
+ * yields NO verdict — { fall_through: true, results: [] }. An empty results array
+ * composes to recommendation='insufficient_evidence' in the packet; a proposal is
+ * never blocked and never granted a fabricated verdict.
+ */
+
+import { evaluateLoopClosure } from '../../loop-governance/closure-engine.js';
+import { EVAL_SET_CLASSES } from '../../eval/eval-set-fixtures.mjs';
+
+/**
+ * closure_predicates evaluator — mechanical replay through the pure closure engine
+ * with the proposal's predicate swapped in; evidence and pinned now held constant.
+ * @param {Object} evalCase - sealed case (whitelist projection from loadEvalSet)
+ * @param {Object|null} proposedPredicate - proposal's closure_predicate variant, or null for identity
+ * @returns {{engineCurrent: string, engineProposed: string}}
+ */
+export function closurePredicateEvaluator(evalCase, proposedPredicate) {
+  const now = new Date(evalCase.now);
+  const engineCurrent = evaluateLoopClosure(evalCase.loop, evalCase.evidence, now).status;
+  const engineProposed = proposedPredicate == null
+    ? engineCurrent
+    : evaluateLoopClosure(
+        { ...evalCase.loop, closure_predicate: proposedPredicate },
+        evalCase.evidence,
+        now
+      ).status;
+  return { engineCurrent, engineProposed };
+}
+
+/**
+ * leo_protocol_sections evaluator — no engine exists for prose, so verdicts are
+ * about THE PROPOSAL per case: does it match a sealed known-bad change class
+ * (target/description overlap)? Returns FINAL row semantics directly (the
+ * truth-anchored engine formula does not apply: a known-bad case's label
+ * describes the CASE, not the desired outcome). Synthetic cases never flag
+ * (pipeline exercise only). Class is EXPERIMENTAL per child B's GT floor.
+ */
+export function protocolSectionsEvaluator(evalCase, proposal) {
+  if (!proposal || evalCase.synthetic === true || evalCase.known_bad !== true) {
+    return { current_verdict: 'pass', proposed_verdict: 'pass', regression: false };
+  }
+  const target = String(proposal.target_ref || '').toLowerCase();
+  const diff = String(proposal.proposed_diff || '').toLowerCase();
+  const caseRef = String(evalCase.section_change?.section_ref || '').toLowerCase();
+  const matchesKnownBad = caseRef.length > 0
+    && (target.includes(caseRef) || caseRef.includes(target) || diff.includes(caseRef));
+  return matchesKnownBad
+    ? { current_verdict: 'pass', proposed_verdict: 'matches_known_bad', regression: true }
+    : { current_verdict: 'pass', proposed_verdict: 'pass', regression: false };
+}
+
+/** Default per-class evaluators; injectable for tests (runPipeline precedent). */
+export const DEFAULT_EVALUATORS = Object.freeze({
+  closure_predicates: (evalCase, proposal) =>
+    closurePredicateEvaluator(evalCase, proposal ? proposal.proposed_predicate ?? null : null),
+  leo_protocol_sections: protocolSectionsEvaluator,
+});
+
+/** Adjudicated truth of record for a case, class-agnostic. */
+function adjudicatedTruth(evalCase) {
+  return evalCase.adjudicated_status ?? evalCase.adjudicated_label ?? null;
+}
+
+/**
+ * Run the shadow replay.
+ * @param {Object} args
+ * @param {Object} args.proposal - child A REQUIRED_FIELDS shape (artifact_class, target_ref,
+ *   proposed_diff, ... plus proposed_predicate for closure_predicates)
+ * @param {Object} args.corpus - child B loadEvalSet result ({artifact_class, cases, bookkeeping})
+ * @param {Object} [args.evaluators] - injected per-class evaluators
+ * @returns {{artifact_class: string|null, fall_through: boolean, reason?: string,
+ *            results: Array, bookkeeping?: Object}}
+ */
+export function shadowRun({ proposal, corpus, evaluators = DEFAULT_EVALUATORS } = {}) {
+  const artifactClass = proposal?.artifact_class ?? null;
+  if (!artifactClass || !EVAL_SET_CLASSES[artifactClass] || !evaluators[artifactClass]) {
+    return {
+      artifact_class: artifactClass,
+      fall_through: true,
+      reason: `unknown artifact class "${artifactClass}" — no shadow verdict; proposal proceeds to plain chairman review`,
+      results: [],
+    };
+  }
+  if (!corpus || corpus.artifact_class !== artifactClass || !Array.isArray(corpus.cases) || corpus.cases.length === 0) {
+    return {
+      artifact_class: artifactClass,
+      fall_through: true,
+      reason: 'sealed corpus unavailable or empty — no shadow verdict; proposal proceeds to plain chairman review',
+      results: [],
+    };
+  }
+
+  const evaluator = evaluators[artifactClass];
+  const results = corpus.cases.map((evalCase) => {
+    const out = evaluator(evalCase, proposal);
+    // An evaluator may return FINAL row semantics ({current_verdict, proposed_verdict,
+    // regression}) when the truth-anchored engine formula does not apply (sections);
+    // otherwise it returns the engine pair and the generic formula runs.
+    if (typeof out.regression === 'boolean') {
+      return {
+        case_id: evalCase.case_id,
+        current_verdict: out.current_verdict,
+        proposed_verdict: out.proposed_verdict,
+        delta: out.proposed_verdict === out.current_verdict ? null : `${out.current_verdict}->${out.proposed_verdict}`,
+        regression: out.regression,
+      };
+    }
+    const truth = adjudicatedTruth(evalCase);
+    const { engineCurrent, engineProposed } = out;
+    const behaviorChanged = engineProposed !== engineCurrent;
+    const proposed_verdict = behaviorChanged ? engineProposed : truth;
+    return {
+      case_id: evalCase.case_id,
+      current_verdict: truth,
+      proposed_verdict,
+      delta: proposed_verdict === truth ? null : `${truth}->${proposed_verdict}`,
+      regression: behaviorChanged && engineProposed !== truth,
+    };
+  });
+
+  return { artifact_class: artifactClass, fall_through: false, results, bookkeeping: corpus.bookkeeping };
+}

--- a/scripts/eval/seal-eval-set.mjs
+++ b/scripts/eval/seal-eval-set.mjs
@@ -59,21 +59,28 @@ export async function sealEvalSet({ supabase, artifactClass, apply = false, seal
   // legitimate re-seals before the ceremony has even begun.
   const guardProbe = await supabase
     .from('governed_change_proposals')
-    .select('id, status')
+    .select('id, status, proposed_diff')
     .eq('artifact_class', artifactClass)
     .limit(10);
   if (guardProbe.error) {
     if (isMissingTableError(guardProbe.error)) {
       log('SELF-REFERENCE GUARD: governed_change_proposals not applied (ceremony pending) — warn-and-proceed.');
     } else {
-      log(`SELF-REFERENCE GUARD: probe failed (${guardProbe.error.message}) — warn-and-proceed (fail-open on infrastructure error).`);
+      // FAIL CLOSED (SECURITY M2): once the table can exist, a permissions/transient
+      // probe failure must not silently bypass a governed-artifact guard.
+      throw new Error(`seal-eval-set: SELF-REFERENCE GUARD probe failed (${guardProbe.error.message}) — refusing to seal (fail-closed; only a missing table warn-and-proceeds)`);
     }
   } else {
-    const stagedProposal = (guardProbe.data || []).find((p) => ['staged', 'shadow_run', 'packet_attached'].includes(p.status));
-    if (!stagedProposal) {
-      throw new Error(`seal-eval-set: SELF-REFERENCE GUARD — no staged governed_change_proposals row for artifact_class=${artifactClass}; corpus mutations require a staged proposal (child C FR-4)`);
+    // CONTENT BINDING (SECURITY M1): a staged proposal authorizes only the seals it
+    // NAMES — its proposed_diff must reference at least one content hash being
+    // sealed. A stale/unrelated staged row for the class no longer authorizes
+    // arbitrary future seals.
+    const active = (guardProbe.data || []).filter((p) => ['staged', 'shadow_run', 'packet_attached'].includes(p.status));
+    const bound = active.find((p) => planned.some(({ content_hash }) => String(p.proposed_diff || '').includes(content_hash)));
+    if (!bound) {
+      throw new Error(`seal-eval-set: SELF-REFERENCE GUARD — no staged governed_change_proposals row for artifact_class=${artifactClass} references the content hashes being sealed; corpus mutations require a staged proposal naming this change (child C FR-4)`);
     }
-    log(`SELF-REFERENCE GUARD: staged proposal ${stagedProposal.id} (${stagedProposal.status}) authorizes this seal.`);
+    log(`SELF-REFERENCE GUARD: staged proposal ${bound.id} (${bound.status}) content-binds this seal.`);
   }
 
   const existing = await supabase

--- a/scripts/eval/seal-eval-set.mjs
+++ b/scripts/eval/seal-eval-set.mjs
@@ -52,6 +52,30 @@ export async function sealEvalSet({ supabase, artifactClass, apply = false, seal
     return { applied: false, planned: planned.length, sealed: 0, skipped: 0, bookkeeping };
   }
 
+  // SELF-REFERENCE GUARD (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C FR-4): the
+  // eval-set is itself a governed artifact — once the chairman ceremony applies
+  // governed_change_proposals, sealing requires a staged proposal for this class.
+  // Pre-ceremony (table absent) this warns and proceeds: refusing would deadlock
+  // legitimate re-seals before the ceremony has even begun.
+  const guardProbe = await supabase
+    .from('governed_change_proposals')
+    .select('id, status')
+    .eq('artifact_class', artifactClass)
+    .limit(10);
+  if (guardProbe.error) {
+    if (isMissingTableError(guardProbe.error)) {
+      log('SELF-REFERENCE GUARD: governed_change_proposals not applied (ceremony pending) — warn-and-proceed.');
+    } else {
+      log(`SELF-REFERENCE GUARD: probe failed (${guardProbe.error.message}) — warn-and-proceed (fail-open on infrastructure error).`);
+    }
+  } else {
+    const stagedProposal = (guardProbe.data || []).find((p) => ['staged', 'shadow_run', 'packet_attached'].includes(p.status));
+    if (!stagedProposal) {
+      throw new Error(`seal-eval-set: SELF-REFERENCE GUARD — no staged governed_change_proposals row for artifact_class=${artifactClass}; corpus mutations require a staged proposal (child C FR-4)`);
+    }
+    log(`SELF-REFERENCE GUARD: staged proposal ${stagedProposal.id} (${stagedProposal.status}) authorizes this seal.`);
+  }
+
   const existing = await supabase
     .from('feedback')
     .select('id, metadata')

--- a/scripts/eval/seal-eval-set.mjs
+++ b/scripts/eval/seal-eval-set.mjs
@@ -28,6 +28,7 @@ import { createClient } from '@supabase/supabase-js';
 import { EVAL_SET_CLASSES, EVAL_SET_CORPORA } from '../../lib/eval/eval-set-fixtures.mjs';
 import { evalCaseHash, computeFloorBookkeeping } from '../../lib/eval/eval-set-loader.mjs';
 import { isMissingTableError } from './migrate-sealed-baselines.mjs';
+import { TABLE as PROPOSALS_TABLE } from '../../lib/governance/shadow-trial/proposal-writer.mjs';
 
 function argValue(flag) {
   const i = process.argv.indexOf(flag);
@@ -57,8 +58,11 @@ export async function sealEvalSet({ supabase, artifactClass, apply = false, seal
   // governed_change_proposals, sealing requires a staged proposal for this class.
   // Pre-ceremony (table absent) this warns and proceeds: refusing would deadlock
   // legitimate re-seals before the ceremony has even begun.
+  // Referenced via the owning module's TABLE constant (child A convention for the
+  // chairman-gated STAGED table — the schema-reference lint rightly flags literal
+  // references to not-yet-applied tables).
   const guardProbe = await supabase
-    .from('governed_change_proposals')
+    .from(PROPOSALS_TABLE)
     .select('id, status, proposed_diff')
     .eq('artifact_class', artifactClass)
     .limit(10);

--- a/scripts/governance/shadow-run-proposal.mjs
+++ b/scripts/governance/shadow-run-proposal.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * shadow-run-proposal.mjs — the FIRST real shadow-trial producer path
+ * (SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C FR-5 reachability witness):
+ *
+ *   build proposal -> stageProposal (ceremony-aware) -> shadow-run against the
+ *   LIVE sealed corpus -> composePrecheckPacket -> [post-ceremony] attach packet.
+ *
+ * Default proposal: refine a genesis closure predicate by adding the
+ * authorized_writer field (QF-20260716-579: validateClosurePredicate requires it;
+ * 33 genesis predicates predate the requirement) — a real, chairman-relevant
+ * governed change whose shadow replay should be clean (authorized_writer does not
+ * alter evaluateLoopClosure verdicts).
+ *
+ * CEREMONY-AWARE (VALIDATION binding condition 1): governed_change_proposals is
+ * chairman-gated STAGED and absent live. Pre-ceremony, stageProposal returns
+ * ceremony_pending — this CLI honors it (exit 2 AFTER completing the shadow-run
+ * and packet on the in-memory proposal), so the full advisory pipeline is
+ * witnessed today and the persisted 4-hop chain activates with the ceremony.
+ *
+ * ZERO-LIVE-MUTATION READ-BACK (FR-2): the target loop_registry row is snapshot
+ * before and after the run and byte-compared; any drift fails loudly. ADVISORY
+ * ONLY: nothing here applies a change.
+ *
+ * Run (shared root): node scripts/governance/shadow-run-proposal.mjs [--loop-key L7] [--broken]
+ *   --broken  stages a deliberately-degenerate predicate (window so wide a stale
+ *             edge reads fresh) to demonstrate the regression catch (GT-replay).
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { stageProposal } from '../../lib/governance/shadow-trial/proposal-writer.mjs';
+import { composePrecheckPacket } from '../../lib/governance/shadow-trial/precheck-packet.mjs';
+import { shadowRun } from '../../lib/governance/shadow-trial/shadow-run.mjs';
+import { loadEvalSet, evalCaseHash } from '../../lib/eval/eval-set-loader.mjs';
+
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const loopKey = argValue('--loop-key') || 'L7';
+const broken = process.argv.includes('--broken');
+
+// ── Read-only snapshot of the proposal's target artifact ──
+const before = await supabase.from('loop_registry')
+  .select('loop_key, predicate_type, closure_predicate').eq('loop_key', loopKey).maybeSingle();
+if (before.error || !before.data) {
+  console.error(`target loop ${loopKey} unreadable: ${before.error?.message || 'not found'}`);
+  process.exit(1);
+}
+const currentPredicate = before.data.closure_predicate || {};
+
+const proposedPredicate = broken
+  ? { ...currentPredicate, window_seconds: 100 * 365 * 86400 } // degenerate: century window — stale edges read fresh (false-CLOSE)
+  : { ...currentPredicate, authorized_writer: 'loop-closure-verifier' };
+
+const proposal = {
+  artifact_class: 'closure_predicates',
+  target_ref: `loop_registry:${loopKey}`,
+  current_hash: evalCaseHash({ predicate: currentPredicate }),
+  proposed_diff: JSON.stringify({ from: currentPredicate, to: proposedPredicate }),
+  proposer: 'shadow-run-proposal.mjs',
+  provenance: 'SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C reachability witness',
+  rationale: broken
+    ? 'DEMO ONLY: deliberately-degenerate century window to prove the regression catch'
+    : 'Refine genesis predicate with authorized_writer per QF-20260716-579 validateClosurePredicate requirement',
+  proposed_predicate: proposedPredicate,
+};
+
+// ── Stage (ceremony-aware) ──
+const staged = await stageProposal(supabase, proposal);
+const proposalId = staged.staged ? staged.id : null;
+if (staged.ceremony_pending) {
+  console.log('CEREMONY_PENDING: governed_change_proposals not applied yet — continuing on the in-memory proposal (persisted chain activates with the chairman ceremony).');
+} else if (staged.staged) {
+  console.log(`Proposal staged: ${staged.id}`);
+} else if (staged.errors) {
+  console.error('Proposal invalid:', staged.errors.join('; '));
+  process.exit(1);
+} else {
+  console.error('stageProposal error:', staged.error);
+  process.exit(1);
+}
+
+// ── Shadow-run against the LIVE sealed corpus ──
+const corpus = await loadEvalSet(supabase, 'closure_predicates');
+const run = shadowRun({ proposal, corpus });
+if (run.fall_through) {
+  console.log(`FALL-THROUGH (no shadow verdict): ${run.reason}`);
+} else {
+  for (const r of run.results) {
+    console.log(`  ${r.case_id}  current=${r.current_verdict} proposed=${r.proposed_verdict} delta=${r.delta ?? 'none'} regression=${r.regression}`);
+  }
+}
+
+const packet = composePrecheckPacket(run.results, { proposalId });
+console.log(`PACKET: recommendation=${packet.recommendation} confidence=${packet.confidence} cases=${packet.summary.cases_total} regressions=${packet.summary.regressions} experimental=${packet.experimental}`);
+
+// ── Zero-live-mutation read-back ──
+const after = await supabase.from('loop_registry')
+  .select('loop_key, predicate_type, closure_predicate').eq('loop_key', loopKey).maybeSingle();
+const clean = !after.error && JSON.stringify(after.data) === JSON.stringify(before.data);
+console.log(`READ-BACK: target ${loopKey} ${clean ? 'UNCHANGED — zero live mutation' : 'CHANGED — ISOLATION VIOLATION'}`);
+if (!clean) process.exit(3);
+
+if (staged.ceremony_pending) process.exitCode = 2;

--- a/scripts/governance/shadow-run-proposal.mjs
+++ b/scripts/governance/shadow-run-proposal.mjs
@@ -46,6 +46,10 @@ const supabase = createClient(
 
 const loopKey = argValue('--loop-key') || 'L7';
 const broken = process.argv.includes('--broken');
+// SECURITY L1: the degenerate demo proposal must never be STAGED for real —
+// post-ceremony it would upsert a genuine staged row. Without the explicit demo
+// env the broken variant runs the shadow replay on the in-memory proposal only.
+const allowBrokenStage = process.env.SHADOW_TRIAL_DEMO === '1';
 
 // ── Read-only snapshot of the proposal's target artifact ──
 const before = await supabase.from('loop_registry')
@@ -73,10 +77,15 @@ const proposal = {
   proposed_predicate: proposedPredicate,
 };
 
-// ── Stage (ceremony-aware) ──
-const staged = await stageProposal(supabase, proposal);
+// ── Stage (ceremony-aware; broken demo never stages without SHADOW_TRIAL_DEMO=1) ──
+const staged = broken && !allowBrokenStage
+  ? { staged: false, demo_dry: true }
+  : await stageProposal(supabase, proposal);
+if (staged.demo_dry) console.log('DEMO-DRY: --broken proposal is never staged without SHADOW_TRIAL_DEMO=1 — replaying in-memory only.');
 const proposalId = staged.staged ? staged.id : null;
-if (staged.ceremony_pending) {
+if (staged.demo_dry) {
+  // logged above; continue the in-memory advisory pipeline
+} else if (staged.ceremony_pending) {
   console.log('CEREMONY_PENDING: governed_change_proposals not applied yet — continuing on the in-memory proposal (persisted chain activates with the chairman ceremony).');
 } else if (staged.staged) {
   console.log(`Proposal staged: ${staged.id}`);

--- a/tests/ci/shadow-trial-self-reference-lint.test.js
+++ b/tests/ci/shadow-trial-self-reference-lint.test.js
@@ -1,0 +1,42 @@
+/**
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C (TS-5) — self-reference CI lint:
+ * the shadow-trial sandbox's own governed artifacts (the eval-set corpus and the
+ * shadow-trial policy modules) must carry the @governed-by marker binding their
+ * mutations to the ratification contract. A direct edit that strips or forgets
+ * the marker fails this lint in the unit tier on every PR (content-scan pattern
+ * per tests/ci/sibling-a-recursive-failure-lint.test.js — commit trailers are not
+ * unit-tier testable). The marker convention is the pre-ceremony enforcement
+ * level; the hard proposal-row check lives in seal-eval-set.mjs's writer guard
+ * and activates when the chairman ceremony applies governed_change_proposals.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const MARKER = /@governed-by:\s*SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001/;
+
+/** The sandbox's own governed artifacts — extend when new policy modules land. */
+const GOVERNED_FILES = [
+  'lib/eval/eval-set-fixtures.mjs',
+];
+
+/** Pure lint core (exported shape for reuse): marker present? */
+export function hasGovernanceMarker(content) {
+  return MARKER.test(content);
+}
+
+describe('shadow-trial self-reference lint (TS-5)', () => {
+  for (const rel of GOVERNED_FILES) {
+    it(`${rel} carries the @governed-by marker`, () => {
+      const p = resolve(process.cwd(), rel);
+      expect(existsSync(p), `${rel} missing`).toBe(true);
+      expect(hasGovernanceMarker(readFileSync(p, 'utf-8'))).toBe(true);
+    });
+  }
+
+  it('NEGATIVE: a fixtures copy with the marker stripped fails the lint', () => {
+    const content = readFileSync(resolve(process.cwd(), 'lib/eval/eval-set-fixtures.mjs'), 'utf-8');
+    const stripped = content.replace(MARKER, 'governance marker removed by a direct edit');
+    expect(hasGovernanceMarker(stripped)).toBe(false);
+  });
+});

--- a/tests/fixtures/shadow-trial/planted-violation.mjs
+++ b/tests/fixtures/shadow-trial/planted-violation.mjs
@@ -7,6 +7,8 @@
  */
 import { createClient } from '@supabase/supabase-js';
 import { recordPendingDecision } from '../../../lib/chairman/record-pending-decision.mjs';
+// Re-export smuggling attempt — must ALSO be flagged (SECURITY M3).
+export { stageProposal } from '../../../lib/governance/shadow-trial/proposal-writer.mjs';
 
 export function totallyIsolatedShadowRun() {
   const db = createClient('http://example.invalid', 'not-a-key');

--- a/tests/fixtures/shadow-trial/planted-violation.mjs
+++ b/tests/fixtures/shadow-trial/planted-violation.mjs
@@ -1,0 +1,14 @@
+/**
+ * PLANTED VIOLATION FIXTURE — negative test material for the shadow-run isolation
+ * witness (tests/unit/governance/shadow-trial/shadow-run-isolation.test.js).
+ * This file is NEVER imported at runtime; it exists so the witness's ability to
+ * catch a write-capable import inside the engine core is itself pinned by a test
+ * (precedent: tests/fixtures/golden-references/planted-violation.mjs).
+ */
+import { createClient } from '@supabase/supabase-js';
+import { recordPendingDecision } from '../../../lib/chairman/record-pending-decision.mjs';
+
+export function totallyIsolatedShadowRun() {
+  const db = createClient('http://example.invalid', 'not-a-key');
+  return recordPendingDecision(db, { title: 'this import graph is the violation' });
+}

--- a/tests/unit/eval/seal-eval-set.test.js
+++ b/tests/unit/eval/seal-eval-set.test.js
@@ -14,14 +14,15 @@ import { evalCaseHash } from '../../../lib/eval/eval-set-loader.mjs';
  * the child-C self-reference guard warn-and-proceeds; pass `proposals` to simulate
  * the post-ceremony table (guard then requires a staged row).
  */
-function stubDb({ existingHashes = [], readError = null, proposals = undefined } = {}) {
+function stubDb({ existingHashes = [], readError = null, proposals = undefined, guardError = null } = {}) {
   const inserts = { feedback: [], system_events: [] };
   const MISSING = { code: 'PGRST205', message: "Could not find the table 'public.governed_change_proposals' in the schema cache" };
   return {
     inserts,
     from(table) {
       const result = table === 'governed_change_proposals'
-        ? (proposals === undefined ? { data: null, error: MISSING } : { data: proposals, error: null })
+        ? (guardError ? { data: null, error: guardError }
+           : proposals === undefined ? { data: null, error: MISSING } : { data: proposals, error: null })
         : (readError
             ? { data: null, error: readError }
             : { data: existingHashes.map((h) => ({ id: `x-${h}`, metadata: { content_hash: h } })), error: null });
@@ -96,10 +97,24 @@ describe('self-reference guard (child C FR-4)', () => {
     expect(r.sealed).toBe(4);
   });
 
-  it('post-ceremony with a staged proposal: seal authorized', async () => {
-    const db = stubDb({ proposals: [{ id: 'gp-1', status: 'staged' }] });
+  it('post-ceremony with a CONTENT-BOUND staged proposal: seal authorized (M1)', async () => {
+    const boundHash = evalCaseHash(EVAL_SET_CORPORA.closure_predicates[0]);
+    const db = stubDb({ proposals: [{ id: 'gp-1', status: 'staged', proposed_diff: `corpus reseal covering ${boundHash}` }] });
     const r = await sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent });
     expect(r.applied).toBe(true);
+  });
+
+  it('post-ceremony: a stale/unrelated staged proposal does NOT authorize (M1 content binding)', async () => {
+    const db = stubDb({ proposals: [{ id: 'gp-old', status: 'staged', proposed_diff: 'some unrelated earlier change' }] });
+    await expect(sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent }))
+      .rejects.toThrow(/SELF-REFERENCE GUARD/);
+  });
+
+  it('generic (non-missing-table) probe error FAILS CLOSED (M2)', async () => {
+    const db = stubDb({ guardError: { code: '42501', message: 'permission denied' } });
+    await expect(sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent }))
+      .rejects.toThrow(/fail-closed/);
+    expect(db.inserts.feedback).toHaveLength(0);
   });
 
   it('post-ceremony with NO staged proposal: seal refused', async () => {

--- a/tests/unit/eval/seal-eval-set.test.js
+++ b/tests/unit/eval/seal-eval-set.test.js
@@ -8,20 +8,26 @@ import { sealEvalSet } from '../../../scripts/eval/seal-eval-set.mjs';
 import { EVAL_SET_CORPORA } from '../../../lib/eval/eval-set-fixtures.mjs';
 import { evalCaseHash } from '../../../lib/eval/eval-set-loader.mjs';
 
-/** Stub with insert tracking; existing seals injectable per test. */
-function stubDb({ existingHashes = [], readError = null } = {}) {
+/**
+ * Stub with insert tracking; existing seals injectable per test.
+ * governed_change_proposals defaults to MISSING TABLE (pre-ceremony live state) so
+ * the child-C self-reference guard warn-and-proceeds; pass `proposals` to simulate
+ * the post-ceremony table (guard then requires a staged row).
+ */
+function stubDb({ existingHashes = [], readError = null, proposals = undefined } = {}) {
   const inserts = { feedback: [], system_events: [] };
+  const MISSING = { code: 'PGRST205', message: "Could not find the table 'public.governed_change_proposals' in the schema cache" };
   return {
     inserts,
     from(table) {
+      const result = table === 'governed_change_proposals'
+        ? (proposals === undefined ? { data: null, error: MISSING } : { data: proposals, error: null })
+        : (readError
+            ? { data: null, error: readError }
+            : { data: existingHashes.map((h) => ({ id: `x-${h}`, metadata: { content_hash: h } })), error: null });
+      const thenable = { then: (resolve) => resolve(result), limit: () => Promise.resolve(result) };
       return {
-        select: () => ({
-          eq: () => Promise.resolve(
-            readError
-              ? { data: null, error: readError }
-              : { data: existingHashes.map((h) => ({ id: `x-${h}`, metadata: { content_hash: h } })), error: null }
-          ),
-        }),
+        select: () => ({ eq: () => thenable }),
         insert(row) {
           inserts[table].push(row);
           return {
@@ -79,5 +85,33 @@ describe('sealEvalSet (TS-1)', () => {
 
   it('rejects unknown classes', async () => {
     await expect(sealEvalSet({ supabase: stubDb(), artifactClass: 'nope', log: silent })).rejects.toThrow(/unknown artifact class/);
+  });
+});
+
+describe('self-reference guard (child C FR-4)', () => {
+  it('pre-ceremony (proposals table missing): warns and proceeds', async () => {
+    const db = stubDb(); // governed_change_proposals defaults to MISSING
+    const r = await sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent });
+    expect(r.applied).toBe(true);
+    expect(r.sealed).toBe(4);
+  });
+
+  it('post-ceremony with a staged proposal: seal authorized', async () => {
+    const db = stubDb({ proposals: [{ id: 'gp-1', status: 'staged' }] });
+    const r = await sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent });
+    expect(r.applied).toBe(true);
+  });
+
+  it('post-ceremony with NO staged proposal: seal refused', async () => {
+    const db = stubDb({ proposals: [] });
+    await expect(sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', apply: true, log: silent }))
+      .rejects.toThrow(/SELF-REFERENCE GUARD/);
+    expect(db.inserts.feedback).toHaveLength(0);
+  });
+
+  it('dry-run never consults the guard (no writes to authorize)', async () => {
+    const db = stubDb({ proposals: [] });
+    const r = await sealEvalSet({ supabase: db, artifactClass: 'closure_predicates', log: silent });
+    expect(r.applied).toBe(false);
   });
 });

--- a/tests/unit/governance/shadow-trial/shadow-run-isolation.test.js
+++ b/tests/unit/governance/shadow-trial/shadow-run-isolation.test.js
@@ -1,0 +1,64 @@
+/**
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C (TS-4) — static isolation witness
+ * for the shadow-run engine core, reusing golden-reference-isolation's scanContent
+ * primitive with a C-SPECIFIC allowlist (VALIDATION binding condition 3: the engine
+ * legitimately imports pure repo modules, so the golden-reference builtins-only law
+ * does not apply; instead the witness pins EXACTLY which imports are permitted).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { scanContent } from '../../../../lib/governance/golden-reference-isolation.js';
+
+const ENGINE = resolve(process.cwd(), 'lib/governance/shadow-trial/shadow-run.mjs');
+const FIXTURE = resolve(process.cwd(), 'tests/fixtures/shadow-trial/planted-violation.mjs');
+
+/**
+ * The engine core's permitted import surface — pure modules only. Anything else
+ * (supabase, chairman writers, fs, proposal-writer, node:*) is a violation.
+ */
+const ENGINE_ALLOWED_SPECIFIERS = new Set([
+  '../../loop-governance/closure-engine.js',
+  '../../eval/eval-set-fixtures.mjs',
+]);
+
+/**
+ * C-specific STRICT classifier: every literal import specifier outside the
+ * allowlist is a violation — including npm packages the golden-reference
+ * ALLOWED_NPM would admit (supabase is legal in golden references but NEVER in
+ * the shadow-run engine core). scanContent still contributes its fail-closed
+ * non-literal-import detection.
+ */
+const IMPORT_SPEC = /(?:import\s[^'"]*from\s*|import\s*\(\s*|require\s*\(\s*)['"]([^'"]+)['"]/g;
+function engineViolations(content, filePath) {
+  const violations = scanContent(content, filePath).filter((v) => v.kind === 'violation:non_literal_import');
+  IMPORT_SPEC.lastIndex = 0;
+  let m;
+  while ((m = IMPORT_SPEC.exec(content)) !== null) {
+    if (!ENGINE_ALLOWED_SPECIFIERS.has(m[1])) violations.push({ file: filePath, specifier: m[1], kind: 'violation:outside_engine_allowlist' });
+  }
+  return violations;
+}
+
+describe('shadow-run isolation witness (TS-4)', () => {
+  it('the engine core has ZERO non-allowlisted imports', () => {
+    const violations = engineViolations(readFileSync(ENGINE, 'utf-8'), 'shadow-run.mjs');
+    expect(violations).toEqual([]);
+  });
+
+  it('the engine core imports exactly the two permitted pure modules (allowlist is tight)', () => {
+    const content = readFileSync(ENGINE, 'utf-8');
+    for (const spec of ENGINE_ALLOWED_SPECIFIERS) {
+      expect(content.includes(`'${spec}'`), spec).toBe(true);
+    }
+    // No supabase, no chairman writers, no fs, no dynamic import anywhere.
+    expect(content).not.toMatch(/@supabase|record-pending-decision|proposal-writer|node:fs|import\(/);
+  });
+
+  it('NEGATIVE: the planted-violation fixture IS flagged (witness has teeth)', () => {
+    const violations = engineViolations(readFileSync(FIXTURE, 'utf-8'), 'planted-violation.mjs');
+    const specifiers = violations.map((v) => v.specifier);
+    expect(specifiers).toContain('@supabase/supabase-js');
+    expect(specifiers.some((s) => s.includes('record-pending-decision'))).toBe(true);
+  });
+});

--- a/tests/unit/governance/shadow-trial/shadow-run-isolation.test.js
+++ b/tests/unit/governance/shadow-trial/shadow-run-isolation.test.js
@@ -29,7 +29,10 @@ const ENGINE_ALLOWED_SPECIFIERS = new Set([
  * the shadow-run engine core). scanContent still contributes its fail-closed
  * non-literal-import detection.
  */
-const IMPORT_SPEC = /(?:import\s[^'"]*from\s*|import\s*\(\s*|require\s*\(\s*)['"]([^'"]+)['"]/g;
+// SECURITY M3: `export { x } from '...'` re-exports smuggle bindings past
+// import-only regexes — the classifier covers import, require, dynamic import
+// AND export-from forms.
+const IMPORT_SPEC = /(?:import\s[^'"]*from\s*|import\s*\(\s*|require\s*\(\s*|export\s+(?:\*|\{[^}]*\})\s+from\s*)['"]([^'"]+)['"]/g;
 function engineViolations(content, filePath) {
   const violations = scanContent(content, filePath).filter((v) => v.kind === 'violation:non_literal_import');
   IMPORT_SPEC.lastIndex = 0;

--- a/tests/unit/governance/shadow-trial/shadow-run-replay.test.js
+++ b/tests/unit/governance/shadow-trial/shadow-run-replay.test.js
@@ -1,0 +1,146 @@
+/**
+ * SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C — shadow-run replay core:
+ * TS-1 identity, TS-2 broken-proposal regression catch (GT-replay), TS-3
+ * unknown-class/empty-corpus fall-through, packet-contract fidelity.
+ */
+import { describe, it, expect } from 'vitest';
+import { shadowRun, closurePredicateEvaluator, DEFAULT_EVALUATORS } from '../../../../lib/governance/shadow-trial/shadow-run.mjs';
+import { composePrecheckPacket, RECOMMENDATIONS, isCaseResult } from '../../../../lib/governance/shadow-trial/precheck-packet.mjs';
+import { EVAL_SET_CORPORA } from '../../../../lib/eval/eval-set-fixtures.mjs';
+import { computeFloorBookkeeping } from '../../../../lib/eval/eval-set-loader.mjs';
+
+const cases = EVAL_SET_CORPORA.closure_predicates;
+const corpus = {
+  artifact_class: 'closure_predicates',
+  cases,
+  refused: [],
+  bookkeeping: computeFloorBookkeeping(cases),
+};
+
+const identityProposal = {
+  artifact_class: 'closure_predicates',
+  target_ref: 'loop_registry:L30',
+  proposed_predicate: null, // no change
+};
+
+// Century window: every stale edge reads fresh — the classic false-CLOSE degenerate.
+const brokenProposal = {
+  artifact_class: 'closure_predicates',
+  target_ref: 'loop_registry:L30',
+  proposed_predicate: { window_seconds: 100 * 365 * 86400 },
+};
+
+describe('TS-1 identity replay', () => {
+  it('4/4 cases: delta none, regression false, adjudicated outcomes reproduced', () => {
+    const run = shadowRun({ proposal: identityProposal, corpus });
+    expect(run.fall_through).toBe(false);
+    expect(run.results).toHaveLength(4);
+    for (const r of run.results) {
+      expect(r.delta, r.case_id).toBeNull();
+      expect(r.regression, r.case_id).toBe(false);
+      expect(r.proposed_verdict, r.case_id).toBe(r.current_verdict);
+    }
+    const packet = composePrecheckPacket(run.results, { proposalId: 'p-identity' });
+    expect(packet.recommendation).toBe(RECOMMENDATIONS.SAFE);
+  });
+
+  it('current_verdict is the ADJUDICATED truth, never the naive engine output (known-bad case)', () => {
+    const run = shadowRun({ proposal: identityProposal, corpus });
+    const cp004 = run.results.find((r) => r.case_id === 'CP-004-known-bad-liveness-only-false-close');
+    expect(cp004.current_verdict).toBe('open'); // adjudicated truth; the naive engine says closed
+    expect(cp004.regression).toBe(false); // identity proposal owns no pre-existing corpus defect
+  });
+});
+
+describe('TS-2 broken proposal (GT-replay catch)', () => {
+  it('the century-window proposal false-CLOSEs CP-003 and is flagged regression', () => {
+    const run = shadowRun({ proposal: brokenProposal, corpus });
+    const cp003 = run.results.find((r) => r.case_id === 'CP-003-open-fired-but-edge-stale');
+    expect(cp003.proposed_verdict).toBe('closed');
+    expect(cp003.delta).toBe('open->closed');
+    expect(cp003.regression).toBe(true);
+    const packet = composePrecheckPacket(run.results, { proposalId: 'p-broken' });
+    expect(packet.recommendation).toBe(RECOMMENDATIONS.REGRESSIONS);
+  });
+
+  it('a proposal that FIXES the known-bad is NOT a regression (improvement reads clean)', () => {
+    // Narrow window: CP-004's 6h-old liveness edge STILL reads fresh (not a fix for
+    // liveness-masquerade), so instead prove via injected evaluator: engine newly
+    // agrees with truth on the known-bad -> regression false.
+    const fixingEvaluators = {
+      ...DEFAULT_EVALUATORS,
+      closure_predicates: (evalCase, proposal) => {
+        const base = closurePredicateEvaluator(evalCase, proposal ? proposal.proposed_predicate : null);
+        if (proposal && evalCase.known_bad) return { engineCurrent: base.engineCurrent, engineProposed: 'open' };
+        return base;
+      },
+    };
+    const run = shadowRun({ proposal: brokenProposal, corpus, evaluators: fixingEvaluators });
+    const cp004 = run.results.find((r) => r.case_id === 'CP-004-known-bad-liveness-only-false-close');
+    expect(cp004.regression).toBe(false); // engine changed TO the adjudicated truth
+    expect(cp004.proposed_verdict).toBe('open');
+  });
+
+  it('re-breaking a case in a NEW wrong direction flags regression', () => {
+    const wrongEvaluators = {
+      ...DEFAULT_EVALUATORS,
+      closure_predicates: (evalCase) => ({
+        engineCurrent: evalCase.engine_verdict_expected,
+        engineProposed: 'starved', // wrong for every case whose truth is not starved
+      }),
+    };
+    const run = shadowRun({ proposal: brokenProposal, corpus, evaluators: wrongEvaluators });
+    const cp001 = run.results.find((r) => r.case_id === 'CP-001-l30-measured-decline-closed');
+    expect(cp001.regression).toBe(true);
+    expect(cp001.delta).toBe('closed->starved');
+  });
+});
+
+describe('TS-3 fail-closed fall-through', () => {
+  it('unknown artifact class: no verdict, empty results, explicit reason', () => {
+    const run = shadowRun({ proposal: { artifact_class: 'unknown_thing' }, corpus });
+    expect(run.fall_through).toBe(true);
+    expect(run.results).toEqual([]);
+    expect(run.reason).toMatch(/unknown artifact class/);
+    // Empty results compose to insufficient_evidence — never a fabricated verdict.
+    const packet = composePrecheckPacket(run.results, { proposalId: 'p-x' });
+    expect(packet.recommendation).toBe(RECOMMENDATIONS.INSUFFICIENT);
+    expect(packet.confidence).toBe(0);
+  });
+
+  it('missing/empty/mismatched corpus: fall-through, never fabricated', () => {
+    for (const bad of [null, { artifact_class: 'closure_predicates', cases: [] }, { artifact_class: 'other', cases: [{}] }]) {
+      const run = shadowRun({ proposal: identityProposal, corpus: bad });
+      expect(run.fall_through).toBe(true);
+      expect(run.results).toEqual([]);
+    }
+  });
+});
+
+describe('packet-contract fidelity', () => {
+  it('every emitted row passes composePrecheckPacket.isCaseResult (no silent drops)', () => {
+    const run = shadowRun({ proposal: brokenProposal, corpus });
+    for (const r of run.results) expect(isCaseResult(r), r.case_id).toBe(true);
+    const packet = composePrecheckPacket(run.results, { proposalId: 'p-b' });
+    expect(packet.per_case).toHaveLength(run.results.length);
+  });
+});
+
+describe('leo_protocol_sections evaluator (experimental pipeline exercise)', () => {
+  it('a proposal targeting a sealed known-bad section class flags regression', () => {
+    const sCases = EVAL_SET_CORPORA.leo_protocol_sections;
+    const sCorpus = { artifact_class: 'leo_protocol_sections', cases: sCases, refused: [], bookkeeping: computeFloorBookkeeping(sCases) };
+    const proposal = {
+      artifact_class: 'leo_protocol_sections',
+      target_ref: 'session_prologue rule 4 (USE PROCESS SCRIPTS)',
+      proposed_diff: 'reintroduce the 3/SD + 10/day bypass quota as a generic cap',
+    };
+    const run = shadowRun({ proposal, corpus: sCorpus });
+    const ps001 = run.results.find((r) => r.case_id === 'PS-001-bypass-quota-folklore');
+    expect(ps001.regression).toBe(true);
+    // Synthetic cases never contribute regressions (pipeline exercise only).
+    for (const r of run.results.filter((x) => x.case_id.startsWith('PS-00') && ['PS-003', 'PS-004', 'PS-005'].some((p) => x.case_id.startsWith(p)))) {
+      expect(r.regression).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The shadow-run core: turns a staged governed-change proposal (child A) plus a sealed eval corpus (child B) into advisory precheck evidence — the missing producer `precheck-packet.mjs` names.

- **`lib/governance/shadow-trial/shadow-run.mjs`** — PURE replay core with injected per-class evaluators (capability-runner `runPipeline` precedent). Verdict semantics: `current_verdict` = ADJUDICATED truth (a naive-engine baseline would flag known-bads on identity replays); `regression` = the proposal *changed the engine's behavior away from truth* — identity replays read clean, fixing a known-bad reads clean, breaking a case flags. Sections evaluator returns final row semantics (proposal-vs-known-bad-class match; no prose engine exists — class stays experimental).
- **Fail-closed fall-through** — unknown class or unloadable corpus → NO verdict, empty results → `insufficient_evidence`; never blocks, never fabricates.
- **Layered isolation** — engine imports exactly two pure modules, pinned by a STRICT witness with its own classifier (supabase is legal in golden references but never here) + a planted-violation negative fixture; the producer CLI byte-compares the target `loop_registry` row before/after (zero-live-mutation read-back).
- **Self-reference guard** — `seal-eval-set --apply` requires a staged `governed_change_proposals` row once the chairman ceremony applies the table (warn-and-proceed pre-ceremony, so re-seals don't deadlock); `@governed-by` marker on the corpus + CI lint with negative fixture.
- **`scripts/governance/shadow-run-proposal.mjs`** — FIRST real producer path (reachability witness), ceremony_pending-aware (exit 2 after completing the advisory pipeline on the in-memory proposal).

## Live witness (run against the real sealed corpus)
- `authorized_writer` refinement (QF-20260716-579 class): **looks_safe**, 4/4 clean, READ-BACK unchanged
- `--broken` century window: **CP-003 open→closed regression=true CAUGHT**, `has_regressions` — GT-replay acceptance demonstrated
- Both runs: `CEREMONY_PENDING` honored; zero live mutation

## Verification
72 unit tests green (replay TS-1..TS-3, isolation TS-4 incl. negative, self-reference lint TS-5 incl. negative, seal-guard tests, full child-B eval regression). Smoke 15/15.

## PR size justification
Bulk is tests + documented pure engine; net runtime logic ≈220 LOC.

SD: SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C · PRD: PRD-SD-LEO-INFRA-SHADOW-TRIAL-RATIFICATION-001-C
Claude-Session: 356833d8-2c04-4d59-941e-8edf5f64c391

🤖 Generated with [Claude Code](https://claude.com/claude-code)