### PR TITLE
fix(SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001): canonical fixture exclusion — stop ZZZ_/UAT/TEST rows corrupting real gauges

### DIFF
--- a/lib/capabilities/scanner-context.js
+++ b/lib/capabilities/scanner-context.js
@@ -9,6 +9,8 @@
  * analysis approach. All blocks are capped at 2000 characters.
  */
 
+import { isFixtureVenture } from '../governance/fixture-exclusion.mjs';
+
 const MAX_CONTEXT_CHARS = 2000;
 const MAX_CAPABILITIES = 20;
 
@@ -50,13 +52,21 @@ export async function computePortfolioMaturity(supabase) {
     const [prodRes, reuseRes, ventureRes] = await Promise.all([
       supabase.from('v_unified_capabilities').select('*', { count: 'exact', head: true }).eq('maturity_level', 'production'),
       supabase.from('capability_reuse_log').select('*', { count: 'exact', head: true }),
-      supabase.from('ventures').select('*', { count: 'exact', head: true }),
+      // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fetch discriminant columns instead of a raw
+      // head-count — ventures is ~half unflagged-synthetic plus ZZZ_/__e2e fixture rows, which
+      // inflated maturityScore → the opportunity-scanner surfaced more caps than the real
+      // portfolio justified. The name-prefix predicate is the backstop for the unflagged class.
+      // NOTE: is_synthetic is a PHANTOM column on ventures (verified live — selecting it
+      // returns data:null with NO error, the classic Supabase trap, which live-smoked here
+      // as ventureCount=0 total over-exclusion). Select only columns that exist; the
+      // predicate's is_synthetic check stays inert-but-safe on rows lacking the field.
+      supabase.from('ventures').select('name, is_demo').limit(2000),
     ]);
     // A query error on any single signal is treated as 0 for that signal (valid low signal),
     // NOT a total failure — only a thrown exception triggers the full-weight fallback.
     const productionGradeCount = prodRes.error ? 0 : (prodRes.count || 0);
     const reuseVolume = reuseRes.error ? 0 : (reuseRes.count || 0);
-    const ventureCount = ventureRes.error ? 0 : (ventureRes.count || 0);
+    const ventureCount = ventureRes.error ? 0 : (ventureRes.data || []).filter((v) => !isFixtureVenture(v)).length;
 
     const prodC = Math.min(1, productionGradeCount / PROD_SATURATION);
     const reuseC = Math.min(1, reuseVolume / REUSE_SATURATION);

--- a/lib/governance/fixture-exclusion.mjs
+++ b/lib/governance/fixture-exclusion.mjs
@@ -1,0 +1,75 @@
+// SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: canonical fixture-exclusion predicates for
+// metrics/gauges/counts.
+//
+// Fixture/test rows (ZZZ_-, UAT-, TEST--prefixed keys; __e2e/is_demo/is_synthetic
+// ventures) leaked into real gauges because the exclusion logic was fragmented across
+// 7+ helpers with divergent prefix sets — none covered ZZZ_. This module is the
+// CANONICAL union. Pure, top-level-await-free .mjs so BOTH worlds consume it (the
+// proven lib/coordinator/sd-exclusion.mjs interop pattern): ESM `import`s it; CJS
+// `require()`s it.
+//
+// Existing helpers documented as MIRRORS of subsets of this union (full collapse is
+// follow-on scope; when adding a NEW fixture prefix, add it HERE first, then sync):
+//   - lib/coordinator/sd-exclusion.mjs FIXTURE_RE (SD dispatch/belt exclusion)
+//   - lib/fleet/claim-eligibility.cjs TEST_FIXTURE_KEY_RE (dispatch classifier)
+//   - lib/sourcing-engine/refill-candidate-validity.js FIXTURE_TITLE_RE
+//   - scripts/sweep-fixture-residue.mjs FIXTURE_CLASS_RE (venture residue sweep)
+//   - SQL view v_sd_next_candidates NOT LIKE list (chairman-gated DDL — parity deferred,
+//     flagged in this SD's completion flags)
+//
+// PRECISION OVER RECALL (TR-3): a real row must never be excluded. Regexes are
+// boundary-anchored (prefix-position only — 'LATEST'/'FASTEST' never match); missing
+// name/flags fail open to NOT-fixture.
+
+// SD keys / work-item keys. Union of the mirror helpers' prefixes PLUS the previously
+// uncovered ZZZ_, UAT-/UAT_, TEST-HARNESS-, __e2e classes.
+export const FIXTURE_KEY_RE =
+  /^ZZZ_|^__e2e|^UAT[-_]|^TEST-|^(SD-)?(DEMO|TEST)\b|^SD-UAT-FIX-TEST-|^SD-LEO-FEAT-TEST-E2E-|(?:^|-)TEST-E2E-\d{10,}(?:-|$)/i;
+
+// wave-linkage-coverage.js's exclusion set, lifted verbatim (FR-3): that gauge's
+// semantics are DESIGNED-SIGNAL-sensitive (WAVE_LINKAGE_STARVATION) and must not be
+// broadened — it keeps consuming exactly this regex plus claim-eligibility's
+// TEST_FIXTURE_KEY_RE, byte-equivalent to its pre-lift behavior.
+export const UAT_FIXTURE_KEY_RE = /^SD-UAT-FIX-TEST-/;
+
+// Venture names. Superset of sweep-fixture-residue.mjs FIXTURE_CLASS_RE plus ZZZ_,
+// TS-fixture-, and ANY dunder prefix (__e2e, __citest_… — no real venture starts with __).
+export const FIXTURE_VENTURE_NAME_RE = /^(ZZZ_|__|TEST-|UAT[-_]|TS-fixture-|parity-test-|test-stub|Test Venture for )/i;
+
+// Epoch/run-id tails (10+ digit numeric suffix after - or :) are test-generator residue —
+// live rows like 'Pipeline-Test-1784250113322', 'HCGate-RealDB-rpc-block-1784238026383',
+// '__citest_chairman__:28691380936'; no real venture name ends in a raw epoch/run id.
+export const EPOCH_TAIL_RE = /[-:]\d{10,}$/;
+
+/**
+ * Is this SD/work-item key a fixture? metadata.is_fixture===true short-circuits.
+ * @param {string|null|undefined} key
+ * @param {{is_fixture?: boolean}|null} [metadata]
+ */
+export function isFixtureSdKey(key, metadata) {
+  if (metadata && metadata.is_fixture === true) return true;
+  return typeof key === 'string' && FIXTURE_KEY_RE.test(key);
+}
+
+/**
+ * Is this ventures row a fixture? Flag-first (is_demo / is_synthetic), name-prefix
+ * backstop for the ~half-unflagged-synthetic class. Fail-open on missing fields.
+ * @param {{name?: string|null, is_demo?: boolean, is_synthetic?: boolean}|null} v
+ */
+export function isFixtureVenture(v) {
+  if (!v || typeof v !== 'object') return false;
+  if (v.is_demo === true || v.is_synthetic === true) return true;
+  if (typeof v.name !== 'string') return false;
+  return FIXTURE_VENTURE_NAME_RE.test(v.name) || EPOCH_TAIL_RE.test(v.name);
+}
+
+/**
+ * Is this quick_fixes row a fixture? quick_fixes has NO flag columns, so the title/id
+ * prefix is the only available discriminant.
+ * @param {{id?: string|null, title?: string|null}|null} qf
+ */
+export function isFixtureQf(qf) {
+  if (!qf || typeof qf !== 'object') return false;
+  if (typeof qf.id === 'string' && /^QF-(TEST|DEMO)\b/i.test(qf.id)) return true;
+  return typeof qf.title === 'string' && /^\s*(ZZZ_|__e2e|\[?TEST[-_\]]|\[?UAT[-_\]]|\[?DEMO\b)/i.test(qf.title);
+}

--- a/lib/governance/fixture-exclusion.mjs
+++ b/lib/governance/fixture-exclusion.mjs
@@ -21,10 +21,17 @@
 // boundary-anchored (prefix-position only — 'LATEST'/'FASTEST' never match); missing
 // name/flags fail open to NOT-fixture.
 
-// SD keys / work-item keys. Union of the mirror helpers' prefixes PLUS the previously
-// uncovered ZZZ_, UAT-/UAT_, TEST-HARNESS-, __e2e classes.
+// SD keys / work-item keys. PRECISION-FIRST (adversarial-review CRITICAL fix, PR #6186):
+// the broad ^(SD-)?(DEMO|TEST)\b / ^TEST- branches (borrowed from the dispatch-side
+// mirror) over-excluded REAL completed work — the SD-TEST-MANAGEMENT/TEST-MGMT-* family
+// (14+ genuine shipped SDs) — which is fatal for hierarchy/count consumers. This module
+// keeps only UNAMBIGUOUS fixture shapes: ZZZ_/dunder/bare-UAT prefixes, the named e2e
+// fixture families, and epoch-stamped keys (a raw 12+-digit ms timestamp embedded in the
+// key is generator residue — e.g. TEST-F3-RACE-1784287684096-bl1; no real SD key carries
+// one). Recall loss on prefix-only fixtures (e.g. SD-TEST-MRO18ZP0) is accepted: a
+// missed fixture inflates a count slightly; an excluded real row silently loses work.
 export const FIXTURE_KEY_RE =
-  /^ZZZ_|^__e2e|^UAT[-_]|^TEST-|^(SD-)?(DEMO|TEST)\b|^SD-UAT-FIX-TEST-|^SD-LEO-FEAT-TEST-E2E-|(?:^|-)TEST-E2E-\d{10,}(?:-|$)/i;
+  /^ZZZ_|^__|^UAT[-_]|^SD-DEMO-|^SD-UAT-FIX-TEST-|^SD-LEO-FEAT-TEST-E2E-|(?:^|-)TEST-E2E-\d{10,}(?:-|$)|[-_]\d{12,}(?:[-_][a-z0-9]{1,8})?$/i;
 
 // wave-linkage-coverage.js's exclusion set, lifted verbatim (FR-3): that gauge's
 // semantics are DESIGNED-SIGNAL-sensitive (WAVE_LINKAGE_STARVATION) and must not be
@@ -71,5 +78,9 @@ export function isFixtureVenture(v) {
 export function isFixtureQf(qf) {
   if (!qf || typeof qf !== 'object') return false;
   if (typeof qf.id === 'string' && /^QF-(TEST|DEMO)\b/i.test(qf.id)) return true;
-  return typeof qf.title === 'string' && /^\s*(ZZZ_|__e2e|\[?TEST[-_\]]|\[?UAT[-_\]]|\[?DEMO\b)/i.test(qf.title);
+  // PRECISION-FIRST (adversarial-review CRITICAL fix, PR #6186): the earlier bare
+  // TEST-/UAT-/DEMO title branches matched REAL bug reports titled 'Test-fixture
+  // ventures leak…' (two live instances in two weeks) — silently hiding real open work
+  // from every dispatch surface. Only unambiguous markers remain: ZZZ_/dunder prefixes.
+  return typeof qf.title === 'string' && /^\s*(ZZZ_|__)/i.test(qf.title);
 }

--- a/lib/governance/recursion-governor.js
+++ b/lib/governance/recursion-governor.js
@@ -81,13 +81,16 @@ export async function fetchThroughputItems(supabase, { windowDays = DEFAULT_WIND
 
   const [sdResult, qfResult] = await Promise.all([
     supabase.from('strategic_directives_v2').select('sd_key').eq('status', 'completed').gte('completion_date', sinceIso),
-    supabase.from('quick_fixes').select('id').eq('status', 'completed').gte('completed_at', sinceIso),
+    supabase.from('quick_fixes').select('id, title').eq('status', 'completed').gte('completed_at', sinceIso),
   ]);
   if (sdResult.error) throw new Error('fetchThroughputItems (SD) failed: ' + sdResult.error.message);
   if (qfResult.error) throw new Error('fetchThroughputItems (QF) failed: ' + qfResult.error.message);
 
-  const sdItems = (sdResult.data || []).map((r) => ({ key: r.sd_key }));
-  const qfItems = (qfResult.data || []).map((r) => ({ key: r.id }));
+  // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture rows (ZZZ_/TEST-/UAT keys or titles)
+  // must not count toward real throughput — the governor's ratios read this.
+  const { isFixtureSdKey, isFixtureQf } = await import('./fixture-exclusion.mjs');
+  const sdItems = (sdResult.data || []).filter((r) => !isFixtureSdKey(r.sd_key)).map((r) => ({ key: r.sd_key }));
+  const qfItems = (qfResult.data || []).filter((qf) => !isFixtureQf(qf)).map((r) => ({ key: r.id }));
   return [...sdItems, ...qfItems];
 }
 

--- a/lib/roadmap/wave-linkage-coverage.js
+++ b/lib/roadmap/wave-linkage-coverage.js
@@ -19,7 +19,11 @@ const CLOSED_STATUSES = ['completed', 'cancelled', 'archived', 'superseded', 'de
 // dragging coverage toward false starvation. Reuse the SSOT regex, never a local copy.
 const require = createRequire(import.meta.url);
 const { TEST_FIXTURE_KEY_RE } = require('../fleet/claim-eligibility.cjs');
-const UAT_FIXTURE_KEY_RE = /^SD-UAT-FIX-TEST-/;
+// SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001 (FR-3): UAT regex lifted to the canonical
+// fixture-exclusion module and imported back — this gauge's exclusion SET is unchanged
+// byte-for-byte (WAVE_LINKAGE_STARVATION is a designed signal; exclusions here are
+// deliberately NOT broadened to the full fixture union).
+const { UAT_FIXTURE_KEY_RE } = require('../governance/fixture-exclusion.mjs');
 
 /**
  * Compute wave-linkage coverage over claimable leaf SDs.

--- a/scripts/adam-github-assessment.mjs
+++ b/scripts/adam-github-assessment.mjs
@@ -98,9 +98,12 @@ export async function resolveGithubHealth(supabase, { windowDays = WINDOW_DAYS, 
 
   // (1b) open red-merge QFs.
   try {
-    const { count } = await supabase.from('quick_fixes')
-      .select('id', { count: 'exact', head: true }).eq('status', 'open').ilike('title', '%red-merge%');
-    if (Number.isFinite(count)) facts.openRedMergeQfs = count;
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fetch titles so a fixture-titled test QF
+    // mentioning red-merge can't inflate the gauge.
+    const { data: rmRows } = await supabase.from('quick_fixes')
+      .select('id, title').eq('status', 'open').ilike('title', '%red-merge%').limit(500);
+    const { isFixtureQf } = await import('../lib/governance/fixture-exclusion.mjs');
+    facts.openRedMergeQfs = (rmRows || []).filter((qf) => !isFixtureQf(qf)).length;
   } catch { /* null */ }
 
   // (2) failed CI runs in window.

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -82,8 +82,11 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     if (sdResult.error) throw sdResult.error;
     if (qfResult.error) throw qfResult.error;
     const { isFixtureQf } = await import('../lib/governance/fixture-exclusion.mjs');
-    const qfCount = (qfResult.data || []).filter((qf) => !isFixtureQf(qf)).length;
-    if (Number.isFinite(sdResult.count)) {
+    // Adversarial-review fix (PR #6186): preserve the original HONEST-unknown contract —
+    // a null data payload (the data:null-without-error Supabase trap) must leave the fact
+    // null/unknown, never a confidently-fabricated low count.
+    if (Number.isFinite(sdResult.count) && Array.isArray(qfResult.data)) {
+      const qfCount = qfResult.data.filter((qf) => !isFixtureQf(qf)).length;
       facts.sourcedInWindow = sdResult.count + qfCount;
     }
   } catch { /* leave null -> unknown */ }

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -75,13 +75,16 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     const [sdResult, qfResult] = await Promise.all([
       supabase.from('strategic_directives_v2').select('id', { count: 'exact', head: true })
         .gte('created_at', since).eq('metadata->>sourced_by', 'adam'),
-      supabase.from('quick_fixes').select('id', { count: 'exact', head: true })
-        .gte('created_at', since),
+      // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fetch id+title (not a head-count) so
+      // fixture-titled test QFs don't inflate the sourcing gauge.
+      supabase.from('quick_fixes').select('id, title').gte('created_at', since).limit(1000),
     ]);
     if (sdResult.error) throw sdResult.error;
     if (qfResult.error) throw qfResult.error;
-    if (Number.isFinite(sdResult.count) && Number.isFinite(qfResult.count)) {
-      facts.sourcedInWindow = sdResult.count + qfResult.count;
+    const { isFixtureQf } = await import('../lib/governance/fixture-exclusion.mjs');
+    const qfCount = (qfResult.data || []).filter((qf) => !isFixtureQf(qf)).length;
+    if (Number.isFinite(sdResult.count)) {
+      facts.sourcedInWindow = sdResult.count + qfCount;
     }
   } catch { /* leave null -> unknown */ }
 

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -371,9 +371,13 @@ async function loadData() {
       .select('id, title, status, claiming_session_id, created_at, owner, release_condition')
       .in('status', ['open', 'in_progress'])
       .order('created_at', { ascending: true });
-    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-titled QFs (ZZZ_/TEST-/UAT test
-    // residue) must not inflate the QUICK FIXES (N) count or render as real open work.
-    const { isFixtureQf } = require('../lib/governance/fixture-exclusion.mjs');
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-titled QFs (ZZZ_/dunder residue)
+    // must not inflate the QUICK FIXES (N) count or render as real open work.
+    // Filter availability degrades to UNFILTERED rows (adversarial-review fix, PR #6186):
+    // if require(esm) is unavailable on an older runtime, showing fixtures beats hiding
+    // ALL open work behind the outer catch's empty section.
+    let isFixtureQf = () => false;
+    try { ({ isFixtureQf } = require('../lib/governance/fixture-exclusion.mjs')); } catch { /* unfiltered fallback */ }
     quickFixes = (qfRows || []).filter((qf) => !isFixtureQf(qf));
   } catch { /* degrade-safe: empty QF section */ }
 

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -371,7 +371,10 @@ async function loadData() {
       .select('id, title, status, claiming_session_id, created_at, owner, release_condition')
       .in('status', ['open', 'in_progress'])
       .order('created_at', { ascending: true });
-    quickFixes = qfRows || [];
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-titled QFs (ZZZ_/TEST-/UAT test
+    // residue) must not inflate the QUICK FIXES (N) count or render as real open work.
+    const { isFixtureQf } = require('../lib/governance/fixture-exclusion.mjs');
+    quickFixes = (qfRows || []).filter((qf) => !isFixtureQf(qf));
   } catch { /* degrade-safe: empty QF section */ }
 
   return {

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -201,10 +201,14 @@ export async function loadSDHierarchy(supabase) {
 
     if (!sds) return { allSDs, sdHierarchy };
 
-    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-keyed SDs (ZZZ_, TEST-, UAT-,
-    // SD-TEST-…) leaked into the queue tree as real work (live examples: SD-TEST-MRO18ZP0
-    // and ZZZ_OKR_ALIGNMENTS rows rendering in Track views). Filter at the single load
-    // point for the hierarchy instead of per display site.
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: unambiguously-keyed fixture SDs (ZZZ_ /
+    // dunder prefixes, named e2e families, epoch-stamped generator keys like
+    // TEST-F3-RACE-1784287684096-bl1) leaked into the queue tree as real work. Filter at
+    // the single load point for the hierarchy instead of per display site. PRECISION-FIRST
+    // (adversarial-review, PR #6186): prefix-only keys like SD-TEST-MRO18ZP0 are NOT
+    // excluded — they are indistinguishable from the real SD-TEST-MANAGEMENT/TEST-MGMT
+    // family, and excluding a real SD silently drops it from every allSDs consumer, which
+    // is far worse than a fixture slightly padding the tree.
     const realSds = sds.filter((sd) => !isFixtureSdKey(sd.sd_key, sd.metadata));
 
     // Build lookup map and hierarchy

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -11,6 +11,9 @@ import { parseHarnessBacklog } from './harness-backlog-parser.js';
 // module; ESM default-import interop). Shared with worker-checkin + the coordinator dashboard.
 import qfGatedHold from '../../../lib/fleet/qf-gated-hold.cjs';
 const { isChairmanGatedQF } = qfGatedHold;
+// SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: canonical fixture-exclusion predicates —
+// ZZZ_/UAT/TEST fixture rows must not render as real queue/tree/QF work.
+import { isFixtureSdKey, isFixtureQf } from '../../../lib/governance/fixture-exclusion.mjs';
 
 /**
  * Log a query failure with structured context for diagnostics.
@@ -198,8 +201,14 @@ export async function loadSDHierarchy(supabase) {
 
     if (!sds) return { allSDs, sdHierarchy };
 
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-keyed SDs (ZZZ_, TEST-, UAT-,
+    // SD-TEST-…) leaked into the queue tree as real work (live examples: SD-TEST-MRO18ZP0
+    // and ZZZ_OKR_ALIGNMENTS rows rendering in Track views). Filter at the single load
+    // point for the hierarchy instead of per display site.
+    const realSds = sds.filter((sd) => !isFixtureSdKey(sd.sd_key, sd.metadata));
+
     // Build lookup map and hierarchy
-    for (const sd of sds) {
+    for (const sd of realSds) {
       const sdId = sd.sd_key || sd.id;
       allSDs.set(sdId, sd);
       allSDs.set(sd.id, sd); // Also map by UUID
@@ -385,7 +394,9 @@ export async function loadOpenQuickFixes(supabase) {
     // Excluded here (Track C display + AUTO_PROCEED_ACTION source); they remain visible on
     // the coordinator surface (fleet-dashboard CHAIRMAN-GATED section) until released via
     // scripts/release-chairman-gated-qf.js. Shared predicate — never re-derive inline.
-    return (data || []).filter((qf) => !isChairmanGatedQF(qf));
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: fixture-titled QFs excluded alongside
+    // chairman-gated holds — neither is real open work for the Track C lane.
+    return (data || []).filter((qf) => !isChairmanGatedQF(qf) && !isFixtureQf(qf));
   } catch {
     return [];
   }

--- a/tests/unit/adam/adherence-resolvers.test.js
+++ b/tests/unit/adam/adherence-resolvers.test.js
@@ -37,6 +37,9 @@ function makeSupabase(spec) {
       eq() { return builder; },
       in() { return builder; },
       not() { return builder; },
+      // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: the sourcedInWindow QF lane switched from a
+      // head-count to `.select('id, title').limit(1000)` so it can filter fixture-titled QFs.
+      limit() { return builder; },
       // insert flows: capture the row, then allow .select().single()
       insert(row) {
         if (table === 'feedback') calls.feedbackInsert.push(row);
@@ -107,7 +110,14 @@ describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
     const sb = makeSupabase({
       session_coordination: COUNT(0),
       strategic_directives_v2: COUNT(0), // no SD drafts this window
-      quick_fixes: COUNT(5), // 5 QFs filed in-window — the previously-blind lane
+      // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: the QF lane now fetches rows (id+title) and
+      // counts non-fixture ones, so seed 5 REAL-titled QFs (not a head-count). A fixture-
+      // titled row here would be correctly excluded — proven separately in the exclusion suite.
+      quick_fixes: ROWS([
+        { id: 'QF-1', title: 'real fix one' }, { id: 'QF-2', title: 'real fix two' },
+        { id: 'QF-3', title: 'real fix three' }, { id: 'QF-4', title: 'real fix four' },
+        { id: 'QF-5', title: 'real fix five' },
+      ]), // 5 QFs filed in-window — the previously-blind lane
       issue_patterns: ROWS([]),
       sub_agent_execution_results: COUNT(0),
       audit_log: COUNT(0),

--- a/tests/unit/governance/fixture-exclusion.test.js
+++ b/tests/unit/governance/fixture-exclusion.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the canonical fixture-exclusion predicates and the gauges they protect.
+ * SD: SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001
+ *
+ * Fixture/test rows (ZZZ_/UAT/TEST keys, __e2e/is_demo/is_synthetic ventures) leaked
+ * into real metrics because exclusion logic was fragmented across 7 helpers with
+ * divergent prefix sets — none covered ZZZ_. These tests pin:
+ *   - the predicate matrix: every fixture prefix + both venture flags match; real
+ *     names/keys never do (non-over-exclusion is the fatal failure mode) (TS-1),
+ *   - computePortfolioMaturity counts only non-fixture ventures (TS-2),
+ *   - loadOpenQuickFixes drops fixture-titled QFs, keeps real ones (TS-3),
+ *   - loadSDHierarchy drops fixture-key SDs, keeps real ones (TS-4),
+ *   - the lifted UAT_FIXTURE_KEY_RE is byte-equivalent to wave-linkage's original.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  FIXTURE_KEY_RE, UAT_FIXTURE_KEY_RE, isFixtureSdKey, isFixtureVenture, isFixtureQf,
+} from '../../../lib/governance/fixture-exclusion.mjs';
+import { computePortfolioMaturity } from '../../../lib/capabilities/scanner-context.js';
+import { loadOpenQuickFixes, loadSDHierarchy } from '../../../scripts/modules/sd-next/data-loaders.js';
+
+describe('predicate matrix (TS-1)', () => {
+  test('fixture SD keys match', () => {
+    for (const key of [
+      'ZZZ_OKR_ALIGNMENTS_SCHEMA_TEST_SD', 'TEST-F3-RACE-1784287684096-bl1',
+      'TEST-LAYER-CLAIMING-SD-1784287683799', 'SD-TEST-MRO18ZP0-ORCH-001',
+      'SD-DEMO-ANYTHING-001', 'UAT-RUN-42', 'UAT_FIXTURE_7', '__e2e_probe',
+      'SD-UAT-FIX-TEST-E2E-1781186358703-001', 'SD-LEO-FEAT-TEST-E2E-XYZ',
+      'TEST-HARNESS-CASE-9',
+    ]) {
+      expect(isFixtureSdKey(key), key).toBe(true);
+    }
+  });
+
+  test('real SD keys never match (non-over-exclusion)', () => {
+    for (const key of [
+      'SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001', 'SD-EHG-PRODUCT-UIUX-REMEDIATION-001',
+      'SD-UAT-020', 'SD-UAT-002', // real historic UAT SDs — must NOT be excluded
+      'SD-LEO-INFRA-SEND-TIME-TARGET-001', 'SD-LATEST-METRICS-001', 'SD-FASTEST-PATH-001',
+      'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G',
+    ]) {
+      expect(isFixtureSdKey(key), key).toBe(false);
+    }
+  });
+
+  test('metadata.is_fixture short-circuits; missing input fails open', () => {
+    expect(isFixtureSdKey('SD-REAL-001', { is_fixture: true })).toBe(true);
+    expect(isFixtureSdKey(null)).toBe(false);
+    expect(isFixtureSdKey(undefined, null)).toBe(false);
+  });
+
+  test('venture predicate: flags OR name-prefix backstop; real ventures pass through', () => {
+    expect(isFixtureVenture({ name: 'MarketLens', is_demo: false, is_synthetic: false })).toBe(false);
+    expect(isFixtureVenture({ name: 'MarketLens', is_demo: true })).toBe(true);
+    expect(isFixtureVenture({ name: 'Real Co', is_synthetic: true })).toBe(true);
+    for (const name of ['ZZZ_seed_venture', '__e2e_venture', 'TEST-venture', 'UAT-venture', 'parity-test-1', 'test-stub', 'Test Venture for claims']) {
+      expect(isFixtureVenture({ name }), name).toBe(true);
+    }
+    expect(isFixtureVenture({ name: 'Testify Analytics' })).toBe(false); // no separator — real name
+    expect(isFixtureVenture(null)).toBe(false);
+    expect(isFixtureVenture({})).toBe(false);
+  });
+
+  test('QF predicate: fixture ids/titles match, real ones do not', () => {
+    expect(isFixtureQf({ id: 'QF-TEST-123', title: 'anything' })).toBe(true);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: 'ZZZ_ probe row' })).toBe(true);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: '[TEST] harness row' })).toBe(true);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: '[Retro action items] real fix' })).toBe(false);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: 'Fix latest test failures in CI' })).toBe(false); // 'test' mid-title — real
+    expect(isFixtureQf(null)).toBe(false);
+  });
+
+  test('lifted UAT regex is byte-equivalent to wave-linkage original', () => {
+    expect(UAT_FIXTURE_KEY_RE.source).toBe('^SD-UAT-FIX-TEST-');
+    expect(FIXTURE_KEY_RE.test('SD-UAT-FIX-TEST-E2E-1781186358703-001')).toBe(true);
+  });
+});
+
+describe('computePortfolioMaturity excludes fixture ventures (TS-2)', () => {
+  function mockSupabase(ventures) {
+    return {
+      from(table) {
+        const chain = {
+          select() { return chain; },
+          eq() { return chain; },
+          limit() { return Promise.resolve({ data: ventures, error: null }); },
+          then(resolve) { // head-count queries resolve the chain directly
+            resolve({ count: 0, error: null, data: null });
+          },
+        };
+        if (table === 'ventures') return chain;
+        return chain;
+      },
+    };
+  }
+
+  test('2 real + 3 fixture ventures → ventureCount 2', async () => {
+    const result = await computePortfolioMaturity(mockSupabase([
+      { name: 'MarketLens', is_demo: false, is_synthetic: false },
+      { name: 'CronGenius', is_demo: false, is_synthetic: false },
+      { name: 'ZZZ_seed', is_demo: false, is_synthetic: false },
+      { name: 'Real-flagged', is_demo: true },
+      { name: 'Synthetic-co', is_synthetic: true },
+    ]));
+    expect(result.ventureCount).toBe(2);
+  });
+});
+
+describe('worker-facing loaders exclude fixtures (TS-3, TS-4)', () => {
+  function mockLoaderSupabase(rows) {
+    const chain = {
+      select() { return chain; },
+      in() { return chain; },
+      is() { return chain; },
+      eq() { return chain; },
+      order() { return chain; },
+      limit() { return Promise.resolve({ data: rows, error: null }); },
+    };
+    return { from() { return chain; } };
+  }
+
+  test('loadOpenQuickFixes drops fixture-titled QFs, keeps real ones (TS-3)', async () => {
+    const result = await loadOpenQuickFixes(mockLoaderSupabase([
+      { id: 'QF-REAL', status: 'open', title: '[Retro action items] real', owner: null, release_condition: null },
+      { id: 'QF-FIX', status: 'open', title: 'ZZZ_ test row', owner: null, release_condition: null },
+    ]));
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain('QF-REAL');
+    expect(ids).not.toContain('QF-FIX');
+  });
+
+  test('loadSDHierarchy drops fixture-key SDs, keeps real ones (TS-4)', async () => {
+    const { allSDs } = await loadSDHierarchy(mockLoaderSupabase([
+      { id: 'u1', sd_key: 'SD-REAL-001', parent_sd_id: null, metadata: {} },
+      { id: 'u2', sd_key: 'ZZZ_OKR_ALIGNMENTS_SCHEMA_TEST_SD', parent_sd_id: null, metadata: {} },
+      { id: 'u3', sd_key: 'TEST-F3-RACE-1784287684096-bl1', parent_sd_id: null, metadata: {} },
+    ]));
+    expect(allSDs.has('SD-REAL-001')).toBe(true);
+    expect(allSDs.has('ZZZ_OKR_ALIGNMENTS_SCHEMA_TEST_SD')).toBe(false);
+    expect(allSDs.has('TEST-F3-RACE-1784287684096-bl1')).toBe(false);
+  });
+});

--- a/tests/unit/governance/fixture-exclusion.test.js
+++ b/tests/unit/governance/fixture-exclusion.test.js
@@ -20,27 +20,37 @@ import { computePortfolioMaturity } from '../../../lib/capabilities/scanner-cont
 import { loadOpenQuickFixes, loadSDHierarchy } from '../../../scripts/modules/sd-next/data-loaders.js';
 
 describe('predicate matrix (TS-1)', () => {
-  test('fixture SD keys match', () => {
+  test('fixture SD keys match (unambiguous shapes only)', () => {
     for (const key of [
       'ZZZ_OKR_ALIGNMENTS_SCHEMA_TEST_SD', 'TEST-F3-RACE-1784287684096-bl1',
-      'TEST-LAYER-CLAIMING-SD-1784287683799', 'SD-TEST-MRO18ZP0-ORCH-001',
+      'TEST-LAYER-CLAIMING-SD-1784287683799', // epoch-stamped generator residue
       'SD-DEMO-ANYTHING-001', 'UAT-RUN-42', 'UAT_FIXTURE_7', '__e2e_probe',
       'SD-UAT-FIX-TEST-E2E-1781186358703-001', 'SD-LEO-FEAT-TEST-E2E-XYZ',
-      'TEST-HARNESS-CASE-9',
     ]) {
       expect(isFixtureSdKey(key), key).toBe(true);
     }
   });
 
-  test('real SD keys never match (non-over-exclusion)', () => {
+  test('real SD keys never match (non-over-exclusion — the fatal failure mode)', () => {
     for (const key of [
       'SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001', 'SD-EHG-PRODUCT-UIUX-REMEDIATION-001',
       'SD-UAT-020', 'SD-UAT-002', // real historic UAT SDs — must NOT be excluded
+      // Adversarial-review CRITICAL pin (PR #6186): the SD-TEST-MANAGEMENT/TEST-MGMT
+      // family is REAL completed work — the broad ^(SD-)?TEST branch that excluded it
+      // was removed; these must stay visible to hierarchy/count consumers forever.
+      'SD-TEST-MANAGEMENT-001', 'SD-TEST-MGMT-SCHEMA-001', 'TEST-MGMT-FIXES-001', 'TEST-LIFECYCLE-001',
       'SD-LEO-INFRA-SEND-TIME-TARGET-001', 'SD-LATEST-METRICS-001', 'SD-FASTEST-PATH-001',
       'SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-G',
     ]) {
       expect(isFixtureSdKey(key), key).toBe(false);
     }
+  });
+
+  test('accepted recall loss: prefix-only fixtures without strong shapes do NOT match (precision first)', () => {
+    // Missing a fixture slightly inflates a count; excluding a real row silently loses
+    // work. These prefix-only shapes are indistinguishable from real keys, so they pass.
+    expect(isFixtureSdKey('SD-TEST-MRO18ZP0-ORCH-001')).toBe(false);
+    expect(isFixtureSdKey('TEST-HARNESS-CASE-9')).toBe(false);
   });
 
   test('metadata.is_fixture short-circuits; missing input fails open', () => {
@@ -61,12 +71,18 @@ describe('predicate matrix (TS-1)', () => {
     expect(isFixtureVenture({})).toBe(false);
   });
 
-  test('QF predicate: fixture ids/titles match, real ones do not', () => {
+  test('QF predicate: unambiguous fixture ids/titles match, real ones never do', () => {
     expect(isFixtureQf({ id: 'QF-TEST-123', title: 'anything' })).toBe(true);
     expect(isFixtureQf({ id: 'QF-20260717-794', title: 'ZZZ_ probe row' })).toBe(true);
-    expect(isFixtureQf({ id: 'QF-20260717-794', title: '[TEST] harness row' })).toBe(true);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: '__e2e residue row' })).toBe(true);
     expect(isFixtureQf({ id: 'QF-20260717-794', title: '[Retro action items] real fix' })).toBe(false);
     expect(isFixtureQf({ id: 'QF-20260717-794', title: 'Fix latest test failures in CI' })).toBe(false); // 'test' mid-title — real
+    // Adversarial-review CRITICAL pin (PR #6186): real bug reports titled 'Test-…' exist
+    // (live: 'Test-fixture ventures leak stage gates…') — the bare TEST-/UAT-/DEMO title
+    // branches were removed; these must never be hidden from dispatch surfaces.
+    expect(isFixtureQf({ id: 'QF-20260703-236', title: 'Test-fixture ventures leak stage gates into the LIVE chairman decision queue' })).toBe(false);
+    expect(isFixtureQf({ id: 'QF-20260703-773', title: 'Test-fixture key guard misses bare TEST-*/DEMO- keys' })).toBe(false);
+    expect(isFixtureQf({ id: 'QF-20260717-794', title: '[TEST] harness row' })).toBe(false); // bracket tag unverified as fixture marker — precision first
     expect(isFixtureQf(null)).toBe(false);
   });
 

--- a/tests/unit/sd-next/load-open-quick-fixes.test.js
+++ b/tests/unit/sd-next/load-open-quick-fixes.test.js
@@ -39,7 +39,11 @@ describe('loadOpenQuickFixes — merge race safety', () => {
   });
 
   it('returns rows when loader gets data', async () => {
-    const rows = [{ id: 'QF-TEST-001', status: 'open', pr_url: null, commit_sha: null }];
+    // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: use a realistic date-stamped id, NOT a
+    // 'QF-TEST-…' placeholder — the loader now filters fixture-shaped ids/titles out of
+    // the worker lane, and a QF-TEST- id is (correctly) classified as a fixture. This
+    // test's intent is the pass-through of real rows, so the id must look real.
+    const rows = [{ id: 'QF-20260717-001', title: 'real open quick fix', status: 'open', pr_url: null, commit_sha: null }];
     const supabase = makeSupabase({ data: rows, error: null });
     const result = await loadOpenQuickFixes(supabase);
     expect(result).toEqual(rows);


### PR DESCRIPTION
## Summary
- Fixture/test rows (ZZZ_/UAT/TEST keys, __-prefixed + epoch-tailed ventures) leaked into real metrics — exclusion logic was fragmented across 7 helpers with divergent prefix sets, none covering ZZZ_. **Measured live impact: portfolio-maturity counted 113 ventures; only 21 are real (5x inflation feeding the Adam opportunity-scanner).**
- NEW `lib/governance/fixture-exclusion.mjs`: canonical predicates (SD key / venture / QF title), pure .mjs consumable from both CJS and ESM (the proven sd-exclusion.mjs pattern); existing helpers documented as mirrors.
- Repointed the FR-1-enumerated leaking sites: scanner-context portfolio count (HIGH), sd-next `loadOpenQuickFixes` + `loadSDHierarchy`, fleet-dashboard QF count, adam-self-adherence sourcing gauge, adam-github red-merge count, recursion-governor throughput.
- `wave-linkage-coverage` UAT regex lifted WITHOUT semantic change (WAVE_LINKAGE_STARVATION is a designed signal — exclusions not broadened; suite green).
- Caught live during EXEC: the `is_synthetic` **phantom-column trap** (select returned data:null with no error → transient total over-exclusion) — select now names only existing columns, with the trap documented in-code.
- SQL-view parity (`v_sd_next_candidates` NOT LIKE list) deferred — chairman-gated DDL, pre-flagged.

## Verification
- 9 new unit tests incl. the non-over-exclusion matrix (real SD-UAT-020-style keys, 'Testify Analytics', 'Fix latest test failures' all pass through).
- Live: raw 113 → real 21 ventures, every survivor a genuine venture by name; maturityScore corrected.
- Regression: scanner-context, wave-linkage-coverage, qf-gated-hold suites green; pre-commit smoke 15/15.

SD: SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001 (PRD PRD-SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)