### PR TITLE
fix(SD-LEO-FIX-SMS-PILOT-SPEND-001): SMS pilot spend-lockout — route ALL spend to console until financial envelope ships

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -322,3 +322,12 @@ STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-signing-secret
 # ==============================================================================
 REDDIT_CLIENT_ID=your-reddit-app-client-id
 REDDIT_CLIENT_SECRET=your-reddit-app-client-secret
+
+# ==============================================================================
+# SMS pilot spend-lockout (SD-LEO-FIX-SMS-PILOT-SPEND-001)
+# Chairman pilot posture 2026-07-17: ALL spend-bearing decisions route to console
+# while the SMS bridge pilot runs. DEFAULT ON when unset (fail-closed on money).
+# ONLY the explicit value 'off' restores the $5,000 HIGH_SPEND_THRESHOLD behavior --
+# flipped by SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001 when caps+undo ship.
+# ==============================================================================
+# SMS_SPEND_PILOT_LOCKOUT=off

--- a/lib/chairman/consequence-classifier.js
+++ b/lib/chairman/consequence-classifier.js
@@ -136,6 +136,14 @@ export function classifyConsequence({ decisionType = '', title = '', context = '
 
   const amount = extractDollarAmount(text);
   if (amount !== null) {
+    // SD-LEO-FIX-SMS-PILOT-SPEND-001 (chairman pilot posture 2026-07-17): while the
+    // SMS pilot spend-lockout is active, ANY detected dollar amount routes to console
+    // ('high') — not just >= $5,000 — until SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001
+    // (the Solomon-ratified financial envelope: spend caps + undo window) ships and
+    // flips the flag off. DEFAULT ON: only the explicit value 'off' deactivates the
+    // lockout (fail-closed on money). Non-spend decisions (no detected amount) are
+    // unaffected by this branch.
+    if (process.env.SMS_SPEND_PILOT_LOCKOUT !== 'off') return 'high';
     return amount >= HIGH_SPEND_THRESHOLD ? 'high' : 'medium';
   }
 

--- a/tests/unit/chairman/consequence-classifier.test.js
+++ b/tests/unit/chairman/consequence-classifier.test.js
@@ -41,11 +41,60 @@ describe('classifyConsequence — LOW', () => {
 });
 
 describe('classifyConsequence — MEDIUM', () => {
-  it('a small, real dollar amount below the HIGH threshold', () => {
-    expect(classifyConsequence({ title: 'Approve a $200 tool subscription?' })).toBe('medium');
+  it('a small, real dollar amount below the HIGH threshold (envelope-era behavior, lockout OFF)', () => {
+    // SD-LEO-FIX-SMS-PILOT-SPEND-001: this is the POST-envelope behavior, reachable only
+    // when the pilot spend-lockout is explicitly deactivated (the envelope SD flips it off).
+    const prev = process.env.SMS_SPEND_PILOT_LOCKOUT;
+    process.env.SMS_SPEND_PILOT_LOCKOUT = 'off';
+    try {
+      expect(classifyConsequence({ title: 'Approve a $200 tool subscription?' })).toBe('medium');
+    } finally {
+      if (prev === undefined) delete process.env.SMS_SPEND_PILOT_LOCKOUT;
+      else process.env.SMS_SPEND_PILOT_LOCKOUT = prev;
+    }
   });
   it('bounded operational approve/pause/defer without risk keywords', () => {
     expect(classifyConsequence({ title: 'Approve the blog post draft?' })).toBe('medium');
+  });
+});
+
+// SD-LEO-FIX-SMS-PILOT-SPEND-001 — chairman pilot posture 2026-07-17: ALL spend to
+// console until the financial envelope ships. Lockout is DEFAULT ON (flag absent) and
+// only the explicit value 'off' restores the $5,000-threshold behavior (fail-closed on money).
+describe('classifyConsequence — SMS pilot spend-lockout (FR-1/FR-3)', () => {
+  const withFlag = (value, fn) => {
+    const prev = process.env.SMS_SPEND_PILOT_LOCKOUT;
+    if (value === undefined) delete process.env.SMS_SPEND_PILOT_LOCKOUT;
+    else process.env.SMS_SPEND_PILOT_LOCKOUT = value;
+    try { return fn(); } finally {
+      if (prev === undefined) delete process.env.SMS_SPEND_PILOT_LOCKOUT;
+      else process.env.SMS_SPEND_PILOT_LOCKOUT = prev;
+    }
+  };
+
+  it('DEFAULT ON (flag absent): a $200 spend routes to console (high)', () => {
+    withFlag(undefined, () => {
+      expect(classifyConsequence({ title: 'Approve a $200 tool subscription?' })).toBe('high');
+    });
+  });
+  it('explicit on-values keep the lockout: any detected amount is high', () => {
+    for (const v of ['on', 'true', '1', '']) {
+      withFlag(v, () => {
+        expect(classifyConsequence({ title: 'Approve a $49 payment?' })).toBe('high');
+      });
+    }
+  });
+  it('non-spend decisions are UNAFFECTED under lockout (still SMS-eligible medium/low)', () => {
+    withFlag(undefined, () => {
+      expect(classifyConsequence({ title: 'Approve the blog post draft?' })).toBe('medium');
+      expect(classifyConsequence({ title: 'Which time works better for the call, 2pm or 4pm?' })).toBe('low');
+    });
+  });
+  it("only the explicit 'off' value restores the $5,000 threshold", () => {
+    withFlag('off', () => {
+      expect(classifyConsequence({ title: 'Approve a $200 tool subscription?' })).toBe('medium');
+      expect(classifyConsequence({ title: 'Approve the $6,000 vendor payment?' })).toBe('high');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Chairman-decided pilot posture (2026-07-17): the SMS two-way bridge goes live for NOTIFY + non-spend DECIDE, but **all spend-bearing decisions route to console** until `SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001` ships Solomon's ratified financial envelope (spend caps + undo window). Today the consequence classifier only routes `>= $5,000` to console, so sub-$5k spend was still SMS-approvable — violating the chairman's "all spend to console" default and leaving money exposed from the first live webhook minute.

## Change
- `lib/chairman/consequence-classifier.js`: in the amount-detected branch, when `SMS_SPEND_PILOT_LOCKOUT !== 'off'` (**default ON when unset — fail-closed on money**), **any** detected dollar amount classifies `high` (console-only). Only the literal value `off` restores the $5,000 threshold. The env var is read **per-call** — flipping it needs no restart.
- Non-spend decisions (no detected amount) are **unaffected** — approvals/scheduling/notifies stay SMS-eligible; HIGH keyword categories (kill/governance/secrets/contracts) unchanged.
- `.env.example` documents the flag + its owner SD; the envelope SD's metadata carries the reverse linkage (flip `off` when caps+undo ship). Corrected the linkage from a phantom key to the real `SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001` (per VALIDATION `d5d82548`).

## Why it's safe (RISK `caac0f53` — PASS/LOW)
Only 2 consumers of `classifyConsequence` exist repo-wide: `sms-bridge.js` **suppresses** the SMS on `high` (fewer sends, cannot spam), and `should-consult-solomon.js` adds a bounded fail-open consult (never hard-blocks). Regression surface is strictly one-directional: **more console routing, never less**. `extractDollarAmount` is untouched (the documented bare-number residual is not widened).

## Test plan
`npx vitest run tests/unit/chairman/consequence-classifier.test.js` — 23 tests incl. the new lockout matrix (default-ON $200→high, explicit on-values, non-spend-unaffected, `off` restores threshold). Full chairman suite: **111/111 green**.

PRD: `PRD-SD-LEO-FIX-SMS-PILOT-SPEND-001` (approved) · Evidence: VALIDATION `d5d82548` / RISK `caac0f53`

🤖 Generated with [Claude Code](https://claude.com/claude-code)