### PR TITLE
fix(SD-LEO-FIX-SOLOMON-MULTI-PART-001): collapse multi-part Solomon replies into one logical answer

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-FIX-SOLOMON-MULTI-PART-001.json
+++ b/.prd-payloads/PRD-SD-LEO-FIX-SOLOMON-MULTI-PART-001.json
@@ -1,0 +1,89 @@
+{
+  "executive_summary": "Solomon (the oracle) occasionally splits a long answer across multiple session_coordination rows (payload.kind='adam_advisory'), tagged in the subject line with an 'N/M' marker (e.g. 'COMMISSION VERDICT 1/2' ... 'COMMISSION VERDICT 2/2'). Ground-truthed against live rows (2026-07-17): the SD's original assumption -- group parts by a shared payload.correlation_id -- is FALSE. Solomon's own body text on a live part-2 row explains why: 'the send-path dedup blocks a second row on the same correlation, so the contract-documented ordered-parts mechanism cannot deliver -- part 2 rides clean' -- meaning part 2 is written with a FRESH, unrelated correlation_id as a workaround. The only signal reliably shared across parts is the subject-line 'N/M' marker plus the leading title text before it (e.g. 'COMMISSION VERDICT'), scoped to the same (target_session, sender_session). Today's consumer chain -- lib/coordinator/adam-advisory-store.cjs selectUnactionedAdvisories/stampActioned/fetchAdvisory, rendered by scripts/fleet-dashboard.cjs printAdamInbox and scripts/read-adam-advisories.cjs, retired one row at a time by scripts/coordinator-ack-adam.cjs --advisory <id> -- treats every row as an independent advisory, so a multi-part reply surfaces as N duplicate lines and can be partially acked (part 1 retired, part 2 silently orphaned, or vice versa). This PRD adds one pure grouping module keyed on the ground-truthed subject-marker signal and wires it into the render + ack paths so a split reply surfaces and is retired as ONE logical unit.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Pure multi-part grouping primitive keyed on the subject N/M marker",
+      "description": "New lib/coordinator/multi-part-reply.cjs exporting parsePartMarker(subject) -- strips known leading bracket tags (e.g. '[SOLOMON_ORACLE] [oracle] ') then matches a '<title> N/M' pattern, returning {prefix, index, total} or null when no marker is present. Exports groupMultiPartAdvisories(rows) -- groups rows sharing the same (target_session, sender_session, normalized prefix, total) into one logical-reply group ordered by parsed index ascending (NOT created_at, so out-of-order arrival still reassembles correctly); a row with no parseable marker is its own singleton group (byte-identical single-part behavior). Exports reassembleGroupBody(orderedRows) -- joins each part's body (payload.body falling back to the body column) in index order. All three are pure functions, no I/O.",
+      "acceptance_criteria": [
+        "parsePartMarker returns null for a subject with no N/M pattern (single-part case)",
+        "parsePartMarker extracts {prefix, index, total} from a subject like '[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 1/2 -- roadmap-anchored retro...'",
+        "groupMultiPartAdvisories groups two rows sharing (target_session, sender_session, prefix, total) into one group, ordered by index even when the higher-index row arrives first",
+        "groupMultiPartAdvisories does NOT merge two rows that share a subject prefix but target different sessions or different sender_sessions",
+        "groupMultiPartAdvisories marks a group isComplete=false when fewer than 'total' distinct indices have arrived",
+        "a marker-less row passes through as its own singleton group with isMultiPart=false"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Render path collapses a multi-part series into one logical entry",
+      "description": "scripts/fleet-dashboard.cjs printAdamInbox() and scripts/read-adam-advisories.cjs group the fetched advisories via groupMultiPartAdvisories() before rendering, printing ONE line per logical reply (using the last part's metadata for callsign/age/presence and the reassembled body for the preview, with a '(N parts)' suffix on a multi-part group) instead of one line per raw row. The read_at stamp still applies to every member row in every group (delivery tracking is per-row; only the human-facing render collapses).",
+      "acceptance_criteria": [
+        "A 2-part Solomon series renders as ONE line in printAdamInbox, not two",
+        "A single-part advisory renders unchanged (byte-identical to current output)",
+        "read_at is stamped on BOTH member rows of a 2-part group after render"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Ack path retires an entire multi-part series together, never part N alone while part N+1 sits unread",
+      "description": "lib/coordinator/adam-advisory-store.cjs adds resolveGroupForAdvisory(supabase, advisoryRow) -- re-queries the last 7 days of (target_session, sender_session) sibling rows and applies groupMultiPartAdvisories to find the full group a given advisory id belongs to (degrades to a safe singleton group on any lookup fault or when no marker is present) -- and stampActionedGroup(supabase, group, nowIso) -- stamps payload.actioned_at on every member row. scripts/coordinator-ack-adam.cjs --advisory <id> resolves the group FIRST, then acks every member id in one call, and prints an explicit WARNING (never silent) when the resolved group is incomplete (fewer parts have arrived than the marker's own stated total) so the coordinator knows more of the answer may still be in flight.",
+      "acceptance_criteria": [
+        "Acking part 1's id when part 2 already exists as a sibling row acks BOTH rows in the same invocation",
+        "Acking the only id in a single-part (marker-less) advisory behaves exactly as before (no regression)",
+        "Acking a part whose series is INCOMPLETE (e.g. only 1 of 2 parts has arrived) stamps the arrived part(s) and prints an explicit incomplete-series warning naming the missing index/indices",
+        "fetchAdvisory's select list includes 'subject' (required by parsePartMarker; previously only sender_session/target_session/payload/read_at were selected)"
+      ]
+    }
+  ],
+  "implementation_approach": {
+    "strategy": "One new pure grouping module (FR-1) plus two surgical consumer-side wiring changes (FR-2 render collapse, FR-3 group-aware ack) across the 4 call sites confirmed exhaustive by an Explore pass (lib/coordinator/adam-advisory-store.cjs, scripts/fleet-dashboard.cjs, scripts/read-adam-advisories.cjs, scripts/coordinator-ack-adam.cjs). Deliberately does NOT touch payload.correlation_id semantics, the send-path dedup Solomon's own body text describes, or the unrelated parent_correlation_id tail-inheritance mechanism in solomon_advice_outcome_ledger (a different concern scoped to ledger decisions, not to session_coordination advisory rows).",
+    "steps": [
+      "Add lib/coordinator/multi-part-reply.cjs (parsePartMarker, groupMultiPartAdvisories, reassembleGroupBody) + unit tests",
+      "Add resolveGroupForAdvisory + stampActionedGroup to lib/coordinator/adam-advisory-store.cjs; add 'subject' to fetchAdvisory's select",
+      "Wire scripts/fleet-dashboard.cjs printAdamInbox() to render grouped entries",
+      "Wire scripts/read-adam-advisories.cjs to render grouped entries",
+      "Wire scripts/coordinator-ack-adam.cjs --advisory <id> to resolve + ack the whole group, with an incomplete-series warning"
+    ],
+    "rollback": "Every change is additive (a new module plus a grouping pass inserted before existing render/ack logic); a marker-less advisory is untouched byte-for-byte. Reverting the PR restores per-row rendering/acking with no data loss -- no schema or DRAIN semantics changed."
+  },
+  "system_architecture": {
+    "overview": "Application-layer consumer fix only. No schema changes -- subject text and payload.body already exist on every session_coordination row. No new tables, no migration.",
+    "components": [
+      { "name": "lib/coordinator/multi-part-reply.cjs (new)", "responsibility": "Pure subject-marker parsing + grouping + body reassembly" },
+      { "name": "lib/coordinator/adam-advisory-store.cjs", "responsibility": "resolveGroupForAdvisory + stampActionedGroup -- the group-aware read/ack primitives" },
+      { "name": "scripts/fleet-dashboard.cjs printAdamInbox()", "responsibility": "Collapsed one-line-per-logical-reply render" },
+      { "name": "scripts/read-adam-advisories.cjs", "responsibility": "Read-only peek, same collapsed render" },
+      { "name": "scripts/coordinator-ack-adam.cjs", "responsibility": "Group-aware ack -- retires every part of a series together" }
+    ],
+    "data_flow": "Each consumer already fetches its row window (selectUnactionedAdvisories / fetchAdvisory); groupMultiPartAdvisories is applied client-side against that same already-fetched (or a small targeted re-query for ack) set -- no new query pattern, no new DB round-trips beyond the ack path's single bounded sibling lookup."
+  },
+  "integration_operationalization": {
+    "consumers": [
+      "Coordinator operators (fleet-dashboard.cjs ADAM ADVISORY INBOX render, coordinator-ack-adam.cjs ack verb)"
+    ],
+    "dependencies": [
+      "Subject-line 'N/M' convention Solomon already emits on split replies (observed live, not newly invented)"
+    ],
+    "data_contracts": [
+      "parsePartMarker(subject): {prefix, index, total} | null -- pure, no I/O",
+      "groupMultiPartAdvisories(rows): Array<{id, memberIds, rows, isMultiPart, isComplete, total, body}> -- pure, no I/O"
+    ],
+    "runtime_config": [
+      "None -- no new env vars or flags"
+    ],
+    "observability_rollout": "Single PR in EHG_Engineer. No migration, no chairman-gate. Post-merge: a multi-part Solomon reply surfaces once in the coordinator's ADAM ADVISORY INBOX and is retired as one unit via a single ack, closing the duplicate-surfacing / partial-ack class this SD targets."
+  },
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "parsePartMarker on a bracket-tagged multi-part subject vs. a plain single-part subject", "expected": "Returns {prefix, index, total} for the marker case, null for the plain case" },
+    { "id": "TS-2", "scenario": "groupMultiPartAdvisories with 2 parts arriving out of order (index 2 row created before index 1 row)", "expected": "Group's rows are ordered [index 1, index 2] regardless of created_at order" },
+    { "id": "TS-3", "scenario": "groupMultiPartAdvisories with rows sharing a subject prefix but different target_session", "expected": "Two separate singleton/groups, never merged" },
+    { "id": "TS-4", "scenario": "printAdamInbox render with a mock 2-part Solomon series plus one single-part advisory", "expected": "Two rendered lines total (one collapsed multi-part line, one single-part line), not three" },
+    { "id": "TS-5", "scenario": "coordinator-ack-adam.cjs --advisory <part-1-id> when part 2 already exists as a sibling row", "expected": "Both rows' payload.actioned_at get stamped in the same invocation" },
+    { "id": "TS-6", "scenario": "coordinator-ack-adam.cjs --advisory <part-1-id> when part 2 has NOT yet arrived (series total=2, only 1 seen)", "expected": "Part 1 is stamped actioned_at; an explicit incomplete-series warning is printed naming the missing index" }
+  ],
+  "risks": [
+    { "risk": "A future change to Solomon's subject-marker convention (e.g. dropping the N/M pattern) would silently degrade every multi-part reply to independent singletons again", "mitigation": "This is the identical failure mode as today (no regression) -- a marker-less row was always treated as its own advisory; the fix is additive, not a replacement of a more-robust mechanism that would be lost" },
+    { "risk": "The 7-day sibling lookback window in resolveGroupForAdvisory could miss a genuine part 2 that arrives more than 7 days after part 1", "mitigation": "Multi-part replies observed live arrive within ~1 minute of each other; 7 days is a generous safety margin, and a miss degrades to acking the known part(s) with no data loss -- never a false merge" }
+  ]
+}

--- a/lib/coordinator/adam-advisory-store.cjs
+++ b/lib/coordinator/adam-advisory-store.cjs
@@ -13,8 +13,14 @@
  */
 'use strict';
 
+const { groupMultiPartAdvisories } = require('./multi-part-reply.cjs');
+
 const ADAM_ADVISORY_KIND = 'adam_advisory';
 const BROADCAST_COORDINATOR = 'broadcast-coordinator';
+// SD-LEO-FIX-SOLOMON-MULTI-PART-001: how far back resolveGroupForAdvisory looks for sibling
+// parts of a series. Live multi-part replies arrive within ~1 minute of each other; 7 days
+// is a generous safety margin, not a tuned value.
+const GROUP_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Read-only: unactioned advisories targeting the coordinator (or the broadcast sentinel).
@@ -71,10 +77,64 @@ function isActionRequiredAdvisory(row) {
 async function fetchAdvisory(supabase, advisoryId) {
   const { data, error } = await supabase
     .from('session_coordination')
-    .select('id, sender_session, target_session, payload, read_at')
+    .select('id, sender_session, target_session, subject, payload, read_at')
     .eq('id', advisoryId)
     .maybeSingle();
   return { row: data || null, error: error || null };
+}
+
+/**
+ * SD-LEO-FIX-SOLOMON-MULTI-PART-001 (FR-3): resolve the full multi-part group a single
+ * advisory row belongs to, by re-querying its (target_session, sender_session) sibling
+ * rows from the last GROUP_LOOKBACK_MS and grouping them (multi-part-reply.cjs). Degrades
+ * to the row's own singleton group when it carries no "N/M" series marker, no sibling
+ * parts are found, or the lookup errors — never throws.
+ * @param {object} supabase
+ * @param {object} advisoryRow - must include {id, target_session, sender_session, subject}
+ * @returns {Promise<object>} a group shape from groupMultiPartAdvisories
+ */
+async function resolveGroupForAdvisory(supabase, advisoryRow) {
+  const singleton = {
+    id: advisoryRow.id,
+    memberIds: [advisoryRow.id],
+    rows: [advisoryRow],
+    isMultiPart: false,
+    isComplete: true,
+    total: 1,
+  };
+  if (!advisoryRow || !advisoryRow.target_session || !advisoryRow.sender_session) return singleton;
+  try {
+    const cutoffIso = new Date(Date.now() - GROUP_LOOKBACK_MS).toISOString();
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id, subject, body, payload, target_session, sender_session, created_at')
+      .eq('target_session', advisoryRow.target_session)
+      .eq('sender_session', advisoryRow.sender_session)
+      .gte('created_at', cutoffIso)
+      .order('created_at', { ascending: true })
+      .limit(50);
+    if (error || !data) return singleton;
+    const groups = groupMultiPartAdvisories(data);
+    return groups.find((g) => g.memberIds.includes(advisoryRow.id)) || singleton;
+  } catch {
+    return singleton;
+  }
+}
+
+/**
+ * SD-LEO-FIX-SOLOMON-MULTI-PART-001 (FR-3): stamp payload.actioned_at on EVERY member row
+ * of a group (see resolveGroupForAdvisory) — never retire only part of a multi-part series.
+ * Each row's payload differs, so each member is stamped with its OWN JSONB-merged payload
+ * (mirrors stampActioned's per-row merge; never a single blanket update across ids).
+ * @returns {Promise<{error: object|null}>} error is the FIRST failure encountered, if any
+ */
+async function stampActionedGroup(supabase, group, nowIso) {
+  let firstError = null;
+  for (const row of group.rows) {
+    const { error } = await stampActioned(supabase, row, nowIso);
+    if (error && !firstError) firstError = error;
+  }
+  return { error: firstError };
 }
 
 /**
@@ -101,4 +161,6 @@ module.exports = {
   isActionRequiredAdvisory,
   fetchAdvisory,
   stampActioned,
+  resolveGroupForAdvisory,
+  stampActionedGroup,
 };

--- a/lib/coordinator/adam-advisory-store.cjs
+++ b/lib/coordinator/adam-advisory-store.cjs
@@ -36,7 +36,12 @@ async function selectUnactionedAdvisories(supabase, coordinatorId, opts = {}) {
   const targets = [coordinatorId, BROADCAST_COORDINATOR].filter(Boolean);
   let q = supabase
     .from('session_coordination')
-    .select('id, sender_session, sender_type, subject, body, payload, read_at, created_at')
+    // SD-LEO-FIX-SOLOMON-MULTI-PART-001 (adversarial-review fix, PR #6191): target_session
+    // is REQUIRED here — groupMultiPartAdvisories keys a series on it, and this selector
+    // deliberately unions rows from TWO different targets (coordinatorId + the broadcast
+    // sentinel). Omitting it left every row's target_session undefined, silently defeating
+    // the cross-target collision guard groupMultiPartAdvisories' own tests assert.
+    .select('id, sender_session, sender_type, target_session, subject, body, payload, read_at, created_at')
     .eq('payload->>kind', ADAM_ADVISORY_KIND)
     .is('payload->>actioned_at', null)
     .order('created_at', { ascending: false })
@@ -107,11 +112,21 @@ async function resolveGroupForAdvisory(supabase, advisoryRow) {
     const cutoffIso = new Date(Date.now() - GROUP_LOOKBACK_MS).toISOString();
     const { data, error } = await supabase
       .from('session_coordination')
+      // Scoped to payload->>kind=adam_advisory (adversarial-review fix, PR #6191) so an
+      // unrelated row between the same session pair that happens to carry a numeric
+      // "N/M"-shaped subject is never pulled into the group / stamped actioned_at.
+      .eq('payload->>kind', ADAM_ADVISORY_KIND)
       .select('id, subject, body, payload, target_session, sender_session, created_at')
       .eq('target_session', advisoryRow.target_session)
       .eq('sender_session', advisoryRow.sender_session)
       .gte('created_at', cutoffIso)
-      .order('created_at', { ascending: true })
+      // DESCENDING (adversarial-review fix, PR #6191): ascending + limit(50) returned the
+      // OLDEST 50 rows in the window, so a busy (target_session, sender_session) pair with
+      // >50 rows in 7 days could silently exclude the CURRENT advisory's own sibling parts
+      // (and even the advisory itself) — the exact high-volume case this function targets.
+      // groupMultiPartAdvisories re-sorts by parsed part index internally, so input order
+      // doesn't otherwise matter.
+      .order('created_at', { ascending: false })
       .limit(50);
     if (error || !data) return singleton;
     const groups = groupMultiPartAdvisories(data);

--- a/lib/coordinator/adam-advisory-store.cjs
+++ b/lib/coordinator/adam-advisory-store.cjs
@@ -112,11 +112,16 @@ async function resolveGroupForAdvisory(supabase, advisoryRow) {
     const cutoffIso = new Date(Date.now() - GROUP_LOOKBACK_MS).toISOString();
     const { data, error } = await supabase
       .from('session_coordination')
+      .select('id, subject, body, payload, target_session, sender_session, created_at')
       // Scoped to payload->>kind=adam_advisory (adversarial-review fix, PR #6191) so an
       // unrelated row between the same session pair that happens to carry a numeric
       // "N/M"-shaped subject is never pulled into the group / stamped actioned_at.
+      // MUST come after .select() -- @supabase/postgrest-js's builder only exposes
+      // filter methods (.eq/.gte/.order/...) on the PostgrestFilterBuilder .select()
+      // returns; calling .eq() straight off .from() throws (caught by this function's
+      // try/catch, silently degrading every call to the singleton fallback -- a real
+      // regression this round-2 review caught before merge).
       .eq('payload->>kind', ADAM_ADVISORY_KIND)
-      .select('id, subject, body, payload, target_session, sender_session, created_at')
       .eq('target_session', advisoryRow.target_session)
       .eq('sender_session', advisoryRow.sender_session)
       .gte('created_at', cutoffIso)

--- a/lib/coordinator/multi-part-reply.cjs
+++ b/lib/coordinator/multi-part-reply.cjs
@@ -67,7 +67,13 @@ function groupMultiPartAdvisories(rows) {
     if (!marker) { if (row) singles.push(row); continue; }
     const key = [row.target_session, row.sender_session, marker.prefix, marker.total].join('::');
     if (!seriesMap.has(key)) seriesMap.set(key, { total: marker.total, parts: new Map() });
-    seriesMap.get(key).parts.set(marker.index, row);
+    const seriesParts = seriesMap.get(key).parts;
+    // Adversarial-review fix (PR #6191, round 3): a second row landing on an
+    // already-occupied index (e.g. a retried/duplicate send -- no unique
+    // constraint prevents this) must never silently vanish. Route it to its own
+    // visible singleton instead of overwriting the first row in the Map.
+    if (seriesParts.has(marker.index)) { singles.push(row); continue; }
+    seriesParts.set(marker.index, row);
   }
 
   const groups = [];

--- a/lib/coordinator/multi-part-reply.cjs
+++ b/lib/coordinator/multi-part-reply.cjs
@@ -1,0 +1,101 @@
+/**
+ * Multi-part Solomon reply grouping — SD-LEO-FIX-SOLOMON-MULTI-PART-001.
+ *
+ * Ground-truthed against live session_coordination rows (2026-07-17): a split
+ * Solomon reply does NOT share payload.correlation_id across parts — Solomon's
+ * own body text on a live part-2 row explains why: "the send-path dedup blocks
+ * a second row on the same correlation, so the contract-documented ordered-
+ * parts mechanism cannot deliver -- part 2 rides clean" (a fresh, unrelated
+ * correlation_id). The only signal both parts reliably carry is the subject-
+ * line "N/M" marker plus the leading title text before it (e.g. a subject
+ * "[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 1/2 -- ..." and a sibling
+ * "... COMMISSION VERDICT 2/2 -- ..." share the "COMMISSION VERDICT" prefix
+ * even though their trailing text diverges completely).
+ *
+ * Pure, no I/O.
+ */
+'use strict';
+
+const BRACKET_TAG_RE = /^(\s*\[[^\]]+\]\s*)+/;
+const PART_MARKER_RE = /^(.*?)\s*(\d+)\s*\/\s*(\d+)\b/;
+
+/**
+ * Parse a "part N/M" series marker out of a subject line. Strips known leading
+ * bracket tags (e.g. "[SOLOMON_ORACLE] [oracle] ") before matching.
+ * @param {string} subject
+ * @returns {{prefix: string, index: number, total: number} | null}
+ */
+function parsePartMarker(subject) {
+  const stripped = String(subject || '').replace(BRACKET_TAG_RE, '').trim();
+  const m = PART_MARKER_RE.exec(stripped);
+  if (!m) return null;
+  const index = Number(m[2]);
+  const total = Number(m[3]);
+  if (!Number.isFinite(index) || !Number.isFinite(total) || index < 1 || total < 1 || index > total) return null;
+  return { prefix: m[1].trim().toLowerCase(), index, total };
+}
+
+/** Read a row's body: payload.body first (canonical for adam_advisory rows), then the body column. */
+function readBody(row) {
+  return (row && row.payload && row.payload.body) || (row && row.body) || '';
+}
+
+/** Join a series' parts, in index order, into one logical reply body. */
+function reassembleGroupBody(orderedRows) {
+  return orderedRows
+    .map((r) => String(readBody(r)).trim())
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+/**
+ * Group a batch of advisory-shaped rows into logical replies. Rows sharing the
+ * same series -- (target_session, sender_session, subject prefix, total) --
+ * collapse into one group, ordered by parsed part index (NOT created_at, so
+ * out-of-order arrival still reassembles correctly). A row with no parseable
+ * marker is its own singleton group (byte-identical single-part behavior).
+ * @param {Array<object>} rows - each with {id, subject, target_session, sender_session, body, payload, created_at}
+ * @returns {Array<{id: string, memberIds: string[], rows: object[], isMultiPart: boolean, isComplete: boolean, total: number, body: string}>}
+ */
+function groupMultiPartAdvisories(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const seriesMap = new Map(); // key -> { total, parts: Map(index -> row) }
+  const singles = [];
+
+  for (const row of list) {
+    const marker = row && parsePartMarker(row.subject);
+    if (!marker) { if (row) singles.push(row); continue; }
+    const key = [row.target_session, row.sender_session, marker.prefix, marker.total].join('::');
+    if (!seriesMap.has(key)) seriesMap.set(key, { total: marker.total, parts: new Map() });
+    seriesMap.get(key).parts.set(marker.index, row);
+  }
+
+  const groups = [];
+  for (const { total, parts } of seriesMap.values()) {
+    const orderedRows = [...parts.keys()].sort((a, b) => a - b).map((i) => parts.get(i));
+    const lastRow = orderedRows[orderedRows.length - 1];
+    groups.push({
+      id: lastRow.id,
+      memberIds: orderedRows.map((r) => r.id),
+      rows: orderedRows,
+      isMultiPart: true,
+      isComplete: parts.size === total,
+      total,
+      body: reassembleGroupBody(orderedRows),
+    });
+  }
+  for (const row of singles) {
+    groups.push({
+      id: row.id,
+      memberIds: [row.id],
+      rows: [row],
+      isMultiPart: false,
+      isComplete: true,
+      total: 1,
+      body: readBody(row),
+    });
+  }
+  return groups;
+}
+
+module.exports = { parsePartMarker, groupMultiPartAdvisories, reassembleGroupBody };

--- a/lib/coordinator/multi-part-reply.cjs
+++ b/lib/coordinator/multi-part-reply.cjs
@@ -81,6 +81,7 @@ function groupMultiPartAdvisories(rows) {
       isMultiPart: true,
       isComplete: parts.size === total,
       total,
+      presentIndices: [...parts.keys()].sort((a, b) => a - b),
       body: reassembleGroupBody(orderedRows),
     });
   }

--- a/lib/coordinator/multi-part-reply.cjs
+++ b/lib/coordinator/multi-part-reply.cjs
@@ -37,7 +37,7 @@ function parsePartMarker(subject) {
 
 /** Read a row's body: payload.body first (canonical for adam_advisory rows), then the body column. */
 function readBody(row) {
-  return (row && row.payload && row.payload.body) || (row && row.body) || '';
+  return row?.payload?.body || row?.body || '';
 }
 
 /** Join a series' parts, in index order, into one logical reply body. */

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -155,7 +155,9 @@ async function main() {
   console.log('  advisory_id:', advisoryId);
   if (group.isMultiPart) console.log('  series_member_ids:', group.memberIds.join(', '));
   if (group.isMultiPart && !group.isComplete) {
-    console.warn(`  ⚠ INCOMPLETE SERIES: only ${group.memberIds.length} of ${group.total} part(s) have arrived — additional part(s) may still be en route; re-run ack once they land.`);
+    const missing = Array.from({ length: group.total }, (_, i) => i + 1)
+      .filter((i) => !group.presentIndices.includes(i));
+    console.warn(`  ⚠ INCOMPLETE SERIES: only ${group.memberIds.length} of ${group.total} part(s) have arrived (missing part(s): ${missing.join(', ')}) — additional part(s) may still be en route; re-run ack once they land.`);
   }
   console.log('  actioned_at:', nowIso);
 

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -39,7 +39,7 @@ require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 const { isFullUuid } = require('../lib/coordinator/dispatch.cjs');
-const { fetchAdvisory, stampActioned } = require('../lib/coordinator/adam-advisory-store.cjs');
+const { fetchAdvisory, resolveGroupForAdvisory, stampActionedGroup } = require('../lib/coordinator/adam-advisory-store.cjs');
 const { sendCoordinatorReply } = require('./coordinator-reply.cjs');
 const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = require('../lib/coordinator/adam-identity.cjs');
 
@@ -141,11 +141,22 @@ async function main() {
   if (!adv) { console.error('ERROR: advisory not found:', advisoryId); process.exit(1); }
 
   // Stage 2: stamp actioned_at — the only thing that retires the advisory (idempotent).
+  // SD-LEO-FIX-SOLOMON-MULTI-PART-001 (FR-3): resolve the FULL multi-part group this
+  // advisory belongs to FIRST, then ack every member together — never retire part N
+  // while a sibling part sits unactioned. A marker-less advisory resolves to its own
+  // singleton group, byte-identical to the prior single-row ack.
   const nowIso = new Date().toISOString();
-  const { error: sErr } = await stampActioned(supabase, adv, nowIso);
+  const group = await resolveGroupForAdvisory(supabase, adv);
+  const { error: sErr } = await stampActionedGroup(supabase, group, nowIso);
   if (sErr) { console.error('ERROR: failed to stamp actioned_at:', sErr.message); process.exit(1); }
-  console.log('✓ Advisory actioned (retired)');
+  console.log('✓ Advisory actioned (retired)' + (group.isMultiPart
+    ? ` — multi-part series, ${group.memberIds.length}${group.isComplete ? '' : '/' + group.total} part(s) acked together`
+    : ''));
   console.log('  advisory_id:', advisoryId);
+  if (group.isMultiPart) console.log('  series_member_ids:', group.memberIds.join(', '));
+  if (group.isMultiPart && !group.isComplete) {
+    console.warn(`  ⚠ INCOMPLETE SERIES: only ${group.memberIds.length} of ${group.total} part(s) have arrived — additional part(s) may still be en route; re-run ack once they land.`);
+  }
   console.log('  actioned_at:', nowIso);
 
   const disposition = typeof flags.disposition === 'string' ? flags.disposition : null;

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1479,11 +1479,20 @@ async function printAdamInbox() {
     return;
   }
 
+  // SD-LEO-FIX-SOLOMON-MULTI-PART-001: collapse a multi-part Solomon reply (split across
+  // several rows, joined by subject-line "N/M" marker) into ONE rendered entry. A
+  // marker-less advisory passes through as its own singleton group, byte-identical to
+  // before. read_at below still stamps EVERY member row of every group (delivery tracking
+  // stays per-row; only the human-facing render collapses).
+  const { groupMultiPartAdvisories } = require('../lib/coordinator/multi-part-reply.cjs');
+  const groups = groupMultiPartAdvisories(advisories);
+
   // QF-20260621-174: partition the lane so action-required advisories ALWAYS render
   // un-truncated; passive status relays (belt-countdowns) get a capped tail so they can
   // never crowd out an ask. Both subsets stamp read_at below (DELIVERED, not actioned).
-  const actionRows = advisories.filter(isActionRequiredAdvisory);
-  const statusRows = advisories.filter((a) => !isActionRequiredAdvisory(a));
+  const isActionRequiredGroup = (g) => g.rows.some(isActionRequiredAdvisory);
+  const actionRows = groups.filter(isActionRequiredGroup);
+  const statusRows = groups.filter((g) => !isActionRequiredGroup(g));
 
   console.log('  ' + advisories.length + ' unactioned (' + actionRows.length +
     ' action-required, ' + statusRows.length + ' status relay(s))');
@@ -1505,20 +1514,22 @@ async function printAdamInbox() {
   console.log('  ' + '─'.repeat(68));
 
   const ids = [];
-  const renderRow = (a) => {
-    const callsign = a.payload?.sender_callsign || '(none)';
-    const presence = formatPresence(presenceMap.get(a.sender_session));
-    const wantsReply = a.payload?.expects_reply ? 'yes' : '-';
-    const ageMin = Math.floor((Date.now() - new Date(a.created_at).getTime()) / 60_000);
+  const renderRow = (g) => {
+    const last = g.rows[g.rows.length - 1];
+    const callsign = last.payload?.sender_callsign || '(none)';
+    const presence = formatPresence(presenceMap.get(last.sender_session));
+    const wantsReply = g.rows.some((a) => a.payload?.expects_reply) ? 'yes' : '-';
+    const ageMin = Math.floor((Date.now() - new Date(last.created_at).getTime()) / 60_000);
     const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
-    const bodyPreview = (a.body || a.payload?.body || '').replace(/\n/g, ' ').substring(0, 32);
+    const partsSuffix = g.isMultiPart ? ` (${g.rows.length}${g.isComplete ? '' : '/' + g.total} parts)` : '';
+    const bodyPreview = g.body.replace(/\n/g, ' ').substring(0, 32) + partsSuffix;
     console.log('  ' + pad(callsign, 12) + pad(presence, 12) + pad(wantsReply, 8) + pad(ageStr, 8) + bodyPreview);
-    ids.push(a.id);
+    ids.push(...g.memberIds);
   };
 
-  for (const a of actionRows) renderRow(a); // action-required: never truncated
+  for (const g of actionRows) renderRow(g); // action-required: never truncated
   const STATUS_CAP = 15;
-  for (const a of statusRows.slice(0, STATUS_CAP)) renderRow(a);
+  for (const g of statusRows.slice(0, STATUS_CAP)) renderRow(g);
   if (statusRows.length > STATUS_CAP) {
     console.log('  … and ' + (statusRows.length - STATUS_CAP) + ' older status relay(s) hidden');
   }

--- a/scripts/read-adam-advisories.cjs
+++ b/scripts/read-adam-advisories.cjs
@@ -15,6 +15,9 @@ require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const { selectUnactionedAdvisories } = require('../lib/coordinator/adam-advisory-store.cjs');
+// SD-LEO-FIX-SOLOMON-MULTI-PART-001: collapse a split Solomon reply (subject "N/M" marker)
+// into ONE peeked entry, matching printAdamInbox's render. Stamps nothing either way.
+const { groupMultiPartAdvisories } = require('../lib/coordinator/multi-part-reply.cjs');
 
 async function main() {
   let supabase;
@@ -29,15 +32,18 @@ async function main() {
   console.log('─'.repeat(60));
   if (!rows.length) { console.log('  (no unactioned Adam advisories)'); return; }
 
-  console.log(`  ${rows.length} unactioned advisory(ies):`);
-  for (const a of rows) {
-    const callsign = (a.payload && a.payload.sender_callsign) || '(none)';
-    const intent = a.payload && a.payload.expects_reply ? 'awaiting-reply' : 'fire-and-forget';
-    const delivered = a.read_at ? 'delivered' : 'new';
-    const ageMin = Math.floor((Date.now() - new Date(a.created_at).getTime()) / 60_000);
+  const groups = groupMultiPartAdvisories(rows);
+  console.log(`  ${groups.length} unactioned advisory(ies):`);
+  for (const g of groups) {
+    const last = g.rows[g.rows.length - 1];
+    const callsign = (last.payload && last.payload.sender_callsign) || '(none)';
+    const intent = g.rows.some((a) => a.payload && a.payload.expects_reply) ? 'awaiting-reply' : 'fire-and-forget';
+    const delivered = last.read_at ? 'delivered' : 'new';
+    const ageMin = Math.floor((Date.now() - new Date(last.created_at).getTime()) / 60_000);
     const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
-    const body = (a.body || (a.payload && a.payload.body) || '').replace(/\n/g, ' ');
-    console.log(`  • ${a.id}`);
+    const partsSuffix = g.isMultiPart ? ` (${g.rows.length}${g.isComplete ? '' : '/' + g.total} parts)` : '';
+    const body = g.body.replace(/\n/g, ' ');
+    console.log(`  • ${g.id}${partsSuffix}`);
     console.log(`      ${callsign} | ${intent} | ${delivered} | ${ageStr} ago`);
     console.log(`      ${body}`);
   }

--- a/tests/unit/coordinator/adam-advisory-group.test.js
+++ b/tests/unit/coordinator/adam-advisory-group.test.js
@@ -7,21 +7,34 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { resolveGroupForAdvisory, stampActionedGroup } = require('../../../lib/coordinator/adam-advisory-store.cjs');
 
-// Minimal thenable supabase builder matching the query chain resolveGroupForAdvisory /
-// stampActionedGroup (via stampActioned) actually issue. Captures eq()/order() args so
-// tests can assert the query SHAPE, not just its result.
+// STRICT supabase builder mirroring @supabase/postgrest-js's REAL staged shape: .from()
+// returns a query-builder exposing ONLY select/insert/update/... — filter methods
+// (.eq/.gte/.order/.limit) exist ONLY on the object .select() returns. A round-2
+// adversarial review caught a real bug that a permissive "everything-on-one-object" mock
+// had hidden: production code called .eq() directly on .from(...), which throws against
+// the real client (TypeError: ...eq is not a function) but was silently swallowed by
+// resolveGroupForAdvisory's own try/catch. This mock enforces the same call-order
+// constraint so that class of bug fails a test instead of passing one. Captures
+// eq()/order() args so tests can assert the query SHAPE, not just its result.
 function makeSupabase({ selectResult, updateResult = { error: null }, captured = {} } = {}) {
-  const chain = {
-    from() { return chain; },
-    select() { return chain; },
-    eq(k, v) { (captured.eq = captured.eq || []).push([k, v]); return chain; },
-    gte() { return chain; },
-    order(k, opts) { captured.order = [k, opts]; return chain; },
+  const filterChain = {
+    eq(k, v) { (captured.eq = captured.eq || []).push([k, v]); return filterChain; },
+    gte() { return filterChain; },
+    order(k, opts) { captured.order = [k, opts]; return filterChain; },
     limit() { return Promise.resolve(selectResult); },
-    update() { return chain; },
+  };
+  const updateChain = {
+    eq() { return updateChain; },
     then(res, rej) { return Promise.resolve(updateResult).then(res, rej); },
   };
-  return chain;
+  return {
+    from() {
+      return {
+        select() { return filterChain; },
+        update() { return updateChain; },
+      };
+    },
+  };
 }
 
 describe('resolveGroupForAdvisory', () => {

--- a/tests/unit/coordinator/adam-advisory-group.test.js
+++ b/tests/unit/coordinator/adam-advisory-group.test.js
@@ -8,14 +8,15 @@ const require = createRequire(import.meta.url);
 const { resolveGroupForAdvisory, stampActionedGroup } = require('../../../lib/coordinator/adam-advisory-store.cjs');
 
 // Minimal thenable supabase builder matching the query chain resolveGroupForAdvisory /
-// stampActionedGroup (via stampActioned) actually issue.
-function makeSupabase({ selectResult, updateResult = { error: null } } = {}) {
+// stampActionedGroup (via stampActioned) actually issue. Captures eq()/order() args so
+// tests can assert the query SHAPE, not just its result.
+function makeSupabase({ selectResult, updateResult = { error: null }, captured = {} } = {}) {
   const chain = {
     from() { return chain; },
     select() { return chain; },
-    eq() { return chain; },
+    eq(k, v) { (captured.eq = captured.eq || []).push([k, v]); return chain; },
     gte() { return chain; },
-    order() { return chain; },
+    order(k, opts) { captured.order = [k, opts]; return chain; },
     limit() { return Promise.resolve(selectResult); },
     update() { return chain; },
     then(res, rej) { return Promise.resolve(updateResult).then(res, rej); },
@@ -49,6 +50,29 @@ describe('resolveGroupForAdvisory', () => {
     const supabase = makeSupabase({ selectResult: { data: null, error: { message: 'boom' } } });
     const group = await resolveGroupForAdvisory(supabase, advisoryRow);
     expect(group.memberIds).toEqual(['row-1']);
+  });
+
+  // Adversarial-review regression (PR #6191): the sibling query MUST order newest-first —
+  // ascending + limit(50) silently returned the OLDEST 50 rows, excluding the current
+  // advisory's own recent siblings (or even itself) on a busy (target_session,
+  // sender_session) pair with >50 rows in the lookback window.
+  it('orders the sibling query created_at DESCENDING (newest-first), not ascending', async () => {
+    const advisoryRow = { id: 'row-1', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 1/2' };
+    const captured = {};
+    const supabase = makeSupabase({ selectResult: { data: [advisoryRow], error: null }, captured });
+    await resolveGroupForAdvisory(supabase, advisoryRow);
+    expect(captured.order).toEqual(['created_at', { ascending: false }]);
+  });
+
+  // Adversarial-review regression (PR #6191): scope the sibling lookup to adam_advisory
+  // rows only, so an unrelated row between the same session pair that coincidentally
+  // carries a numeric "N/M"-shaped subject is never pulled into the group.
+  it('scopes the sibling query to payload->>kind=adam_advisory', async () => {
+    const advisoryRow = { id: 'row-1', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 1/2' };
+    const captured = {};
+    const supabase = makeSupabase({ selectResult: { data: [advisoryRow], error: null }, captured });
+    await resolveGroupForAdvisory(supabase, advisoryRow);
+    expect(captured.eq).toContainEqual(['payload->>kind', 'adam_advisory']);
   });
 });
 

--- a/tests/unit/coordinator/adam-advisory-group.test.js
+++ b/tests/unit/coordinator/adam-advisory-group.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests — SD-LEO-FIX-SOLOMON-MULTI-PART-001
+ * lib/coordinator/adam-advisory-store.cjs — resolveGroupForAdvisory / stampActionedGroup
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveGroupForAdvisory, stampActionedGroup } = require('../../../lib/coordinator/adam-advisory-store.cjs');
+
+// Minimal thenable supabase builder matching the query chain resolveGroupForAdvisory /
+// stampActionedGroup (via stampActioned) actually issue.
+function makeSupabase({ selectResult, updateResult = { error: null } } = {}) {
+  const chain = {
+    from() { return chain; },
+    select() { return chain; },
+    eq() { return chain; },
+    gte() { return chain; },
+    order() { return chain; },
+    limit() { return Promise.resolve(selectResult); },
+    update() { return chain; },
+    then(res, rej) { return Promise.resolve(updateResult).then(res, rej); },
+  };
+  return chain;
+}
+
+describe('resolveGroupForAdvisory', () => {
+  it('resolves a full 2-part group when a sibling row is found', async () => {
+    const advisoryRow = { id: 'row-2', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 2/2' };
+    const siblingData = [
+      { id: 'row-1', subject: 'VERDICT 1/2', body: 'first', target_session: 'coord-1', sender_session: 'solomon-1', created_at: '2026-07-17T13:15:12Z' },
+      { id: 'row-2', subject: 'VERDICT 2/2', body: 'second', target_session: 'coord-1', sender_session: 'solomon-1', created_at: '2026-07-17T13:16:12Z' },
+    ];
+    const supabase = makeSupabase({ selectResult: { data: siblingData, error: null } });
+    const group = await resolveGroupForAdvisory(supabase, advisoryRow);
+    expect(group.isMultiPart).toBe(true);
+    expect(group.isComplete).toBe(true);
+    expect(group.memberIds).toEqual(['row-1', 'row-2']);
+  });
+
+  it('degrades to a singleton group when the row has no target_session/sender_session', async () => {
+    const advisoryRow = { id: 'row-1', subject: 'VERDICT 1/2' };
+    const supabase = makeSupabase({ selectResult: { data: [], error: null } });
+    const group = await resolveGroupForAdvisory(supabase, advisoryRow);
+    expect(group).toMatchObject({ id: 'row-1', memberIds: ['row-1'], isMultiPart: false, isComplete: true, total: 1 });
+  });
+
+  it('degrades to a singleton group on a lookup error (never throws)', async () => {
+    const advisoryRow = { id: 'row-1', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 1/2' };
+    const supabase = makeSupabase({ selectResult: { data: null, error: { message: 'boom' } } });
+    const group = await resolveGroupForAdvisory(supabase, advisoryRow);
+    expect(group.memberIds).toEqual(['row-1']);
+  });
+});
+
+describe('stampActionedGroup', () => {
+  it('stamps actioned_at on every member row of the group', async () => {
+    const supabase = makeSupabase({ updateResult: { error: null } });
+    const group = { rows: [{ id: 'row-1', payload: { kind: 'adam_advisory' } }, { id: 'row-2', payload: { kind: 'adam_advisory' } }] };
+    const { error } = await stampActionedGroup(supabase, group, '2026-07-17T00:00:00.000Z');
+    expect(error).toBeNull();
+  });
+
+  it('returns the first error encountered without stopping the remaining stamps', async () => {
+    let call = 0;
+    const supabase = {
+      from() { return this; },
+      update() { return this; },
+      eq() { return this; },
+      then(res) {
+        call += 1;
+        return Promise.resolve(call === 1 ? { error: { message: 'row-1 failed' } } : { error: null }).then(res);
+      },
+    };
+    const group = { rows: [{ id: 'row-1', payload: {} }, { id: 'row-2', payload: {} }] };
+    const { error } = await stampActionedGroup(supabase, group, '2026-07-17T00:00:00.000Z');
+    expect(error.message).toBe('row-1 failed');
+  });
+});

--- a/tests/unit/coordinator/multi-part-reply.test.js
+++ b/tests/unit/coordinator/multi-part-reply.test.js
@@ -1,0 +1,104 @@
+/**
+ * Unit tests — SD-LEO-FIX-SOLOMON-MULTI-PART-001
+ * lib/coordinator/multi-part-reply.cjs
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parsePartMarker, groupMultiPartAdvisories, reassembleGroupBody } = require('../../../lib/coordinator/multi-part-reply.cjs');
+
+describe('parsePartMarker', () => {
+  it('returns null for a subject with no N/M pattern', () => {
+    expect(parsePartMarker('[SOLOMON_ORACLE] [oracle] SHAPE VERDICT (ref your relay fc0c082f)')).toBeNull();
+  });
+
+  it('extracts {prefix, index, total} from a bracket-tagged multi-part subject', () => {
+    const marker = parsePartMarker('[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 1/2 — roadmap-anchored retro as scheduled Adam duty');
+    expect(marker).toEqual({ prefix: 'commission verdict', index: 1, total: 2 });
+  });
+
+  it('extracts the same prefix from the sibling part-2 subject despite diverging trailing text', () => {
+    const marker = parsePartMarker('[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 2/2 — CLEAN-CORRELATION DELIVERY (part 2 of my answer)');
+    expect(marker).toEqual({ prefix: 'commission verdict', index: 2, total: 2 });
+  });
+
+  it('returns null for a garbage index/total (index > total)', () => {
+    expect(parsePartMarker('VERDICT 3/2')).toBeNull();
+  });
+
+  it('handles a subject with no bracket tags at all', () => {
+    expect(parsePartMarker('COMMISSION VERDICT 1/2 plain')).toEqual({ prefix: 'commission verdict', index: 1, total: 2 });
+  });
+});
+
+describe('groupMultiPartAdvisories', () => {
+  const base = { target_session: 'coord-1', sender_session: 'solomon-1' };
+
+  it('groups two parts sharing (target_session, sender_session, prefix, total), ordered by index even when arriving out of order', () => {
+    const rows = [
+      { ...base, id: 'row-2', subject: 'COMMISSION VERDICT 2/2 — CLEAN-CORRELATION DELIVERY', body: 'second half', created_at: '2026-07-17T13:16:12Z' },
+      { ...base, id: 'row-1', subject: 'COMMISSION VERDICT 1/2 — roadmap-anchored retro', body: 'first half', created_at: '2026-07-17T13:15:12Z' },
+    ];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups).toHaveLength(1);
+    const [g] = groups;
+    expect(g.isMultiPart).toBe(true);
+    expect(g.isComplete).toBe(true);
+    expect(g.total).toBe(2);
+    expect(g.rows.map((r) => r.id)).toEqual(['row-1', 'row-2']); // ordered by index, not created_at
+    expect(g.memberIds).toEqual(['row-1', 'row-2']);
+    expect(g.id).toBe('row-2'); // anchored on the LAST part
+    expect(g.body).toBe('first half\n\nsecond half');
+  });
+
+  it('never merges rows sharing a subject prefix but a different target_session', () => {
+    const rows = [
+      { id: 'a', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 1/2', body: 'a' },
+      { id: 'b', target_session: 'coord-2', sender_session: 'solomon-1', subject: 'VERDICT 2/2', body: 'b' },
+    ];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => !g.isMultiPart || g.rows.length === 1)).toBe(true);
+  });
+
+  it('never merges rows sharing a subject prefix but a different sender_session', () => {
+    const rows = [
+      { id: 'a', target_session: 'coord-1', sender_session: 'solomon-1', subject: 'VERDICT 1/2', body: 'a' },
+      { id: 'b', target_session: 'coord-1', sender_session: 'solomon-2', subject: 'VERDICT 2/2', body: 'b' },
+    ];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups).toHaveLength(2);
+  });
+
+  it('marks a group isComplete=false when fewer than "total" distinct indices have arrived', () => {
+    const rows = [{ ...base, id: 'row-1', subject: 'VERDICT 1/3', body: 'only part' }];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups[0].isComplete).toBe(false);
+    expect(groups[0].total).toBe(3);
+    expect(groups[0].memberIds).toEqual(['row-1']);
+  });
+
+  it('passes a marker-less row through as its own singleton group', () => {
+    const rows = [{ ...base, id: 'row-1', subject: 'SHAPE VERDICT (no marker)', body: 'plain reply' }];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ id: 'row-1', memberIds: ['row-1'], isMultiPart: false, isComplete: true, total: 1, body: 'plain reply' });
+  });
+
+  it('reads body from payload.body when the body column is absent', () => {
+    const rows = [{ ...base, id: 'row-1', subject: 'PLAIN', payload: { body: 'from payload' } }];
+    const groups = groupMultiPartAdvisories(rows);
+    expect(groups[0].body).toBe('from payload');
+  });
+
+  it('handles an empty input array', () => {
+    expect(groupMultiPartAdvisories([])).toEqual([]);
+  });
+});
+
+describe('reassembleGroupBody', () => {
+  it('joins parts in the given order, dropping blanks', () => {
+    const rows = [{ body: 'first' }, { body: '' }, { body: 'second' }];
+    expect(reassembleGroupBody(rows)).toBe('first\n\nsecond');
+  });
+});

--- a/tests/unit/coordinator/multi-part-reply.test.js
+++ b/tests/unit/coordinator/multi-part-reply.test.js
@@ -70,12 +70,13 @@ describe('groupMultiPartAdvisories', () => {
     expect(groups).toHaveLength(2);
   });
 
-  it('marks a group isComplete=false when fewer than "total" distinct indices have arrived', () => {
+  it('marks a group isComplete=false when fewer than "total" distinct indices have arrived, tracking which indices ARE present', () => {
     const rows = [{ ...base, id: 'row-1', subject: 'VERDICT 1/3', body: 'only part' }];
     const groups = groupMultiPartAdvisories(rows);
     expect(groups[0].isComplete).toBe(false);
     expect(groups[0].total).toBe(3);
     expect(groups[0].memberIds).toEqual(['row-1']);
+    expect(groups[0].presentIndices).toEqual([1]); // caller can diff against 1..total to name missing parts
   });
 
   it('passes a marker-less row through as its own singleton group', () => {

--- a/tests/unit/coordinator/multi-part-reply.test.js
+++ b/tests/unit/coordinator/multi-part-reply.test.js
@@ -95,6 +95,23 @@ describe('groupMultiPartAdvisories', () => {
   it('handles an empty input array', () => {
     expect(groupMultiPartAdvisories([])).toEqual([]);
   });
+
+  // Adversarial-review regression (PR #6191, round 3): a second row landing on an
+  // already-occupied series index (e.g. a retried/duplicate send) must never silently
+  // vanish -- it must surface as its own visible singleton, not be dropped.
+  it('never silently drops a duplicate/retried row sharing an already-occupied index', () => {
+    const rows = [
+      { ...base, id: 'row-1', subject: 'VERDICT 1/2', body: 'first' },
+      { ...base, id: 'row-1-dup', subject: 'VERDICT 1/2', body: 'retried duplicate' },
+      { ...base, id: 'row-2', subject: 'VERDICT 2/2', body: 'second' },
+    ];
+    const groups = groupMultiPartAdvisories(rows);
+    const allMemberIds = groups.flatMap((g) => g.memberIds);
+    expect(allMemberIds).toEqual(expect.arrayContaining(['row-1', 'row-1-dup', 'row-2']));
+    expect(allMemberIds).toHaveLength(3); // every input row appears in SOME group
+    const dupGroup = groups.find((g) => g.memberIds.includes('row-1-dup'));
+    expect(dupGroup.isMultiPart).toBe(false); // routed to its own singleton, not merged in
+  });
 });
 
 describe('reassembleGroupBody', () => {

--- a/tests/unit/resilient-symmetric-adam.test.js
+++ b/tests/unit/resilient-symmetric-adam.test.js
@@ -46,6 +46,10 @@ describe('FR-1: selectUnactionedAdvisories gates on payload.actioned_at IS NULL'
     expect(error).toBeNull();
     expect(rows).toHaveLength(1);
     expect(captured.eq).toContainEqual(['payload->>kind', 'adam_advisory']);
+    // SD-LEO-FIX-SOLOMON-MULTI-PART-001 (adversarial-review fix, PR #6191): target_session
+    // MUST be selected — the multi-part grouping consumer keys a series on it, and this
+    // selector unions rows from two different targets (coordinatorId + broadcast sentinel).
+    expect(captured.select).toContain('target_session');
     expect(captured.is).toContainEqual(['payload->>actioned_at', null]); // the FR-1 re-surface gate
     expect(captured.in).toEqual(['target_session', ['coord-uuid-aaaa', BROADCAST_COORDINATOR]]);
     expect(captured.limit).toBe(5);


### PR DESCRIPTION
## Summary
- Solomon oracle replies occasionally split across multiple `session_coordination` rows tagged with a subject-line "N/M" marker (e.g. "COMMISSION VERDICT 1/2" / "... 2/2"). The coordinator's advisory render/ack lane treated each part as an independent advisory — duplicate surfacing, and one part could be acked while a sibling part went unread.
- Ground-truthed against live rows: the SD's original design assumption (group by shared `payload.correlation_id`) is **wrong** — Solomon's own body text on a live part-2 row explains the send-path forces a fresh, unrelated `correlation_id` per part ("the send-path dedup blocks a second row on the same correlation"). The real join key is the subject `N/M` marker scoped to `(target_session, sender_session)`.
- Adds `lib/coordinator/multi-part-reply.cjs` (pure grouping/reassembly, no I/O) and wires it into the render path (`fleet-dashboard.cjs printAdamInbox`, `read-adam-advisories.cjs`) and the group-aware ack path (`coordinator-ack-adam.cjs` + new `resolveGroupForAdvisory`/`stampActionedGroup` in `adam-advisory-store.cjs`) so a split reply surfaces once and is retired as one unit — with a loud, index-naming warning when a series is incomplete.
- A marker-less (single-part) advisory is byte-identical to prior behavior in both render and ack paths (verified empirically: 60/60 sampled live rows show `body === payload.body`, confirming the `readBody` precedence flip is a no-op on real data).

## Sub-agent evidence
- VALIDATION (LEAD + PLAN_VERIFICATION): PASS
- Explore: PASS (confirmed 4 consumer call sites are exhaustive)
- TESTING: PASS (28219/28221 unit tests pass on `--project unit`; 2 pre-existing unrelated failures)
- SECURITY: PASS (no ReDoS, no cross-session leakage, no raw SQL, fail-safe partial-failure handling)
- REGRESSION: PASS (additive API only; marker-less advisories byte-identical)
- RETRO: PASS

## Notable RCA
`ship-preflight.js`'s `TestExecutionVerifier` runs `npx vitest run` with no `--project` filter, sweeping this repo's opt-in `db`-tier integration tests into the ship gate in a credential-less worktree — 55 failing files, zero overlap with this PR's 5 changed files. RCA confirmed GO; signaled as a harness bug (`/signal harness-bug`) for separate tracked follow-up (`TestExecutionVerifier.js:156` should pin `--project unit` like `npm run test:unit`).

## Test plan
- [x] `npx vitest run tests/unit/coordinator/multi-part-reply.test.js tests/unit/coordinator/adam-advisory-group.test.js` — 18 new tests, all pass
- [x] Full pre-existing consumer suite (`resilient-symmetric-adam`, `adam-machinery-consumer-invariant`, `adam-advisory-comms`, `coordinator-ack-adam-disposition`, `adam-advisory-action-required`, fleet-dashboard suite) — all pass, zero regressions
- [x] `npx vitest run --project unit` (full unit project) — 28219 passed, 2 pre-existing unrelated failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>