### PR TITLE
fix(SD-LEO-FIX-SESSION-RESTORE-HOOK-001): session-scope the local checkpoint restore hooks

### DIFF
--- a/scripts/hooks/__tests__/session-restore-hook-scoping.test.js
+++ b/scripts/hooks/__tests__/session-restore-hook-scoping.test.js
@@ -1,0 +1,196 @@
+/**
+ * SD-LEO-FIX-SESSION-RESTORE-HOOK-001 — session-scoping fix for
+ * persist-session-state.cjs / recover-session-state.cjs.
+ *
+ * Before the fix, both hooks used a single machine-global checkpoint directory
+ * ($HOME/.claude-checkpoints) and state file ($HOME/.claude-session-state.json)
+ * shared by EVERY Claude Code session on the host, with the restore hook simply
+ * picking the most-recent checkpoint file by mtime — zero session_id filtering.
+ * On a fleet host running several concurrent sessions, this let one session's
+ * restore silently apply a completely different session's state.
+ *
+ * These tests prove: (1) each hook's persisted/read paths are keyed on
+ * session_id, (2) a genuine two-session round trip (FR-3's exact ask) — two
+ * sessions each persist distinct state, each restore reads back ONLY its own,
+ * (3) cleanup in one session never touches a peer session's checkpoints.
+ *
+ * Both hooks compute their file paths from process.env.HOME at require() time,
+ * so tests override HOME to an isolated temp dir and delete the require cache
+ * before each require (matching the established loadHook() pattern used by
+ * node-modules-autoheal.test.js).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const PERSIST_PATH = path.resolve(__dirname, '../persist-session-state.cjs');
+const RECOVER_PATH = path.resolve(__dirname, '../recover-session-state.cjs');
+
+function loadFresh(modulePath) {
+  delete require.cache[require.resolve(modulePath)];
+  return require(modulePath);
+}
+
+describe('persist-session-state.cjs / recover-session-state.cjs — per-session scoping', () => {
+  let tmpHome;
+  let originalHome;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'session-restore-scoping-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+  });
+
+  it('sessionStateFile() and checkpointDir() are keyed on session_id, not shared', () => {
+    const persist = loadFresh(PERSIST_PATH);
+    const fileA = persist.sessionStateFile('session-aaa');
+    const fileB = persist.sessionStateFile('session-bbb');
+    expect(fileA).not.toBe(fileB);
+    expect(fileA).toContain('session-aaa');
+    expect(fileB).toContain('session-bbb');
+
+    const dirA = persist.checkpointDir('session-aaa');
+    const dirB = persist.checkpointDir('session-bbb');
+    expect(dirA).not.toBe(dirB);
+  });
+
+  it('FR-3: two sessions each persist distinct state; each recovers ONLY its own (no cross-session leak)', () => {
+    const persist = loadFresh(PERSIST_PATH);
+
+    const stateA = { session_id: 'session-aaa', tool_executions: 3, current_sd: 'SD-AAA-001', current_phase: 'EXEC', checkpoints: [] };
+    const stateB = { session_id: 'session-bbb', tool_executions: 7, current_sd: 'SD-BBB-002', current_phase: 'PLAN', checkpoints: [] };
+
+    // Session A checkpoints first (older mtime)...
+    const cpA = persist.createCheckpoint(stateA, 'session-aaa');
+    persist.saveSessionState(stateA, 'session-aaa');
+    // ...then session B checkpoints LATER (newer mtime — this is the exact
+    // condition that made the pre-fix global-most-recent-mtime selection wrong).
+    const cpB = persist.createCheckpoint(stateB, 'session-bbb');
+    persist.saveSessionState(stateB, 'session-bbb');
+
+    expect(cpA.session_id).toBe('session-aaa');
+    expect(cpB.session_id).toBe('session-bbb');
+
+    const recover = loadFresh(RECOVER_PATH);
+
+    const checkpointsForA = recover.getAvailableCheckpoints('session-aaa');
+    const checkpointsForB = recover.getAvailableCheckpoints('session-bbb');
+
+    // Each session sees ONLY its own checkpoint(s), even though B's is newer.
+    expect(checkpointsForA).toHaveLength(1);
+    expect(checkpointsForB).toHaveLength(1);
+
+    const restoredA = recover.loadCheckpoint(checkpointsForA[0].path);
+    const restoredB = recover.loadCheckpoint(checkpointsForB[0].path);
+
+    expect(restoredA.current_sd).toBe('SD-AAA-001');
+    expect(restoredA.current_phase).toBe('EXEC');
+    expect(restoredB.current_sd).toBe('SD-BBB-002');
+    expect(restoredB.current_phase).toBe('PLAN');
+
+    // The witnessed bug shape: session A's restore must NEVER pick up B's newer checkpoint.
+    expect(restoredA.session_id).not.toBe(restoredB.session_id);
+  });
+
+  it('cleanupOldCheckpoints scoped to session A never deletes session B checkpoints', () => {
+    const persist = loadFresh(PERSIST_PATH);
+    const stateB = { session_id: 'session-bbb', tool_executions: 1, checkpoints: [] };
+
+    // Session A gets several checkpoints, written directly with distinct ids
+    // (bypasses the pre-existing, out-of-scope Date.now()-collision quirk in
+    // createCheckpoint() when called in a tight synchronous loop). Session B
+    // gets one, via the real createCheckpoint() path.
+    const dirA = persist.checkpointDir('session-aaa');
+    fs.mkdirSync(dirA, { recursive: true });
+    for (const id of ['cp_1', 'cp_2', 'cp_3']) {
+      fs.writeFileSync(path.join(dirA, `${id}.json`), JSON.stringify({ checkpoint_id: id, session_id: 'session-aaa' }));
+    }
+    persist.createCheckpoint(stateB, 'session-bbb');
+
+    // Clean up session A keeping only 1 — should remove 2 from A, touch 0 from B.
+    const removed = persist.cleanupOldCheckpoints('session-aaa', 1);
+    expect(removed).toBe(2);
+
+    const recover = loadFresh(RECOVER_PATH);
+    expect(recover.getAvailableCheckpoints('session-aaa')).toHaveLength(1);
+    expect(recover.getAvailableCheckpoints('session-bbb')).toHaveLength(1); // untouched
+  });
+
+  it('end-to-end: persist hook run twice for two distinct sessions via real stdin payloads, recover hook restores each correctly', () => {
+    const runPersist = (sessionId) => spawnSync('node', [PERSIST_PATH], {
+      input: JSON.stringify({ session_id: sessionId, hook_event_name: 'PostToolUse', tool_name: 'Bash' }),
+      env: { ...process.env, HOME: tmpHome },
+      encoding: 'utf8',
+    });
+    const runRecover = (sessionId) => spawnSync('node', [RECOVER_PATH], {
+      input: JSON.stringify({ session_id: sessionId, hook_event_name: 'PreToolUse' }),
+      env: { ...process.env, HOME: tmpHome },
+      encoding: 'utf8',
+    });
+
+    const rA = runPersist('e2e-session-a');
+    expect(rA.status).toBe(0);
+    const rB = runPersist('e2e-session-b');
+    expect(rB.status).toBe(0);
+
+    const persist = loadFresh(PERSIST_PATH);
+    expect(fs.existsSync(persist.sessionStateFile('e2e-session-a'))).toBe(true);
+    expect(fs.existsSync(persist.sessionStateFile('e2e-session-b'))).toBe(true);
+
+    // Both hooks ran; verify the checkpoint directories are session-scoped on disk.
+    expect(fs.existsSync(persist.checkpointDir('e2e-session-a'))).toBe(true);
+    expect(fs.existsSync(persist.checkpointDir('e2e-session-b'))).toBe(true);
+
+    const recoverA = runRecover('e2e-session-a');
+    expect(recoverA.status).toBe(0);
+    const recoverB = runRecover('e2e-session-b');
+    expect(recoverB.status).toBe(0);
+  });
+
+  it('recover hook with an unresolvable session_id fails closed (no restore, no crash, clean exit)', () => {
+    const result = spawnSync('node', [RECOVER_PATH], {
+      input: 'not-json-at-all',
+      env: { ...process.env, HOME: tmpHome },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/Could not resolve session_id|Starting fresh session/);
+  });
+
+  it('persist hook with an unresolvable session_id fails closed (no global-shared-file write)', () => {
+    const result = spawnSync('node', [PERSIST_PATH], {
+      input: 'not-json-at-all',
+      env: { ...process.env, HOME: tmpHome },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    // No legacy global state file should ever be written.
+    expect(fs.existsSync(path.join(tmpHome, '.claude-session-state.json'))).toBe(false);
+  });
+});
+
+describe('Static-source guard — no legacy machine-global path literals remain', () => {
+  it('persist-session-state.cjs no longer references the old shared SESSION_STATE_FILE/CHECKPOINT_DIR globals', () => {
+    const src = fs.readFileSync(PERSIST_PATH, 'utf8');
+    expect(src).not.toMatch(/const SESSION_STATE_FILE =/);
+    expect(src).not.toMatch(/const CHECKPOINT_DIR =/);
+    expect(src).toMatch(/resolveSessionId/);
+  });
+
+  it('recover-session-state.cjs no longer references the old shared SESSION_STATE_FILE/CHECKPOINT_DIR globals', () => {
+    const src = fs.readFileSync(RECOVER_PATH, 'utf8');
+    expect(src).not.toMatch(/const SESSION_STATE_FILE =/);
+    expect(src).not.toMatch(/const CHECKPOINT_DIR =/);
+    expect(src).toMatch(/resolveSessionId/);
+  });
+});

--- a/scripts/hooks/persist-session-state.cjs
+++ b/scripts/hooks/persist-session-state.cjs
@@ -5,10 +5,22 @@
  * SD-CLAUDE-CODE-2.1.0-LEO-001 - Phase 2 Hook Infrastructure
  *
  * PostToolUse hook that persists session state as a LOCAL checkpoint file
- * ($HOME/.claude-checkpoints) after each tool execution. This is a single-machine
- * restore aid for re-attaching after a local restart on the SAME host — NOT a
- * distributed crash-recovery system. The authoritative cross-session/cross-machine
- * source of truth is the DB (claude_sessions); these files are a convenience cache.
+ * ($HOME/.claude-checkpoints/<session_id>/) after each tool execution. This is a
+ * single-machine restore aid for re-attaching after a local restart on the SAME
+ * host — NOT a distributed crash-recovery system. The authoritative cross-session/
+ * cross-machine source of truth is the DB (claude_sessions); these files are a
+ * convenience cache.
+ *
+ * SD-LEO-FIX-SESSION-RESTORE-HOOK-001: the checkpoint dir and state file were
+ * previously a single machine-global path ($HOME/.claude-checkpoints,
+ * $HOME/.claude-session-state.json) shared by EVERY Claude Code session on the
+ * host — on a fleet host running several concurrent sessions, every session's
+ * PostToolUse call read-modified-wrote the SAME file and wrote checkpoints into
+ * the SAME shared directory, with no session_id filtering at read time (see
+ * recover-session-state.cjs). Now scoped per-session using the canonical
+ * resolveSessionId() (lib/hooks/session-id.cjs) — the same stdin-first resolver
+ * already used by post-tool-rca-outcome.cjs for the same "CLAUDE_SESSION_ID env
+ * var is never propagated to PostToolUse subprocesses" reason.
  *
  * Hook Type: PostToolUse (after every tool)
  * Purpose: Single-machine local-checkpoint restore aid (DB is authoritative)
@@ -17,32 +29,43 @@
 
 const fs = require('fs');
 const path = require('path');
+const { resolveSessionId } = require('../../lib/hooks/session-id.cjs');
 
-const SESSION_STATE_FILE = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
-const CHECKPOINT_DIR = path.join(process.env.HOME || '/tmp', '.claude-checkpoints');
+const HOME_DIR = process.env.HOME || '/tmp';
+const CHECKPOINT_ROOT = path.join(HOME_DIR, '.claude-checkpoints');
+
+function sessionStateFile(sessionId) {
+  return path.join(HOME_DIR, `.claude-session-state-${sessionId}.json`);
+}
+
+function checkpointDir(sessionId) {
+  return path.join(CHECKPOINT_ROOT, sessionId);
+}
 
 /**
  * Ensure checkpoint directory exists
  */
-function ensureCheckpointDir() {
-  if (!fs.existsSync(CHECKPOINT_DIR)) {
-    fs.mkdirSync(CHECKPOINT_DIR, { recursive: true });
+function ensureCheckpointDir(sessionId) {
+  const dir = checkpointDir(sessionId);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
   }
 }
 
 /**
  * Load current session state
  */
-function loadSessionState() {
+function loadSessionState(sessionId) {
   try {
-    if (fs.existsSync(SESSION_STATE_FILE)) {
-      return JSON.parse(fs.readFileSync(SESSION_STATE_FILE, 'utf8'));
+    const file = sessionStateFile(sessionId);
+    if (fs.existsSync(file)) {
+      return JSON.parse(fs.readFileSync(file, 'utf8'));
     }
   } catch (error) {
     console.error('[persist-session] Error loading session state:', error.message);
   }
   return {
-    session_id: `session_${Date.now()}_${process.pid}`,
+    session_id: sessionId,
     checkpoints: [],
     tool_executions: 0
   };
@@ -51,9 +74,9 @@ function loadSessionState() {
 /**
  * Save session state
  */
-function saveSessionState(state) {
+function saveSessionState(state, sessionId) {
   try {
-    fs.writeFileSync(SESSION_STATE_FILE, JSON.stringify(state, null, 2));
+    fs.writeFileSync(sessionStateFile(sessionId), JSON.stringify(state, null, 2));
   } catch (error) {
     console.error('[persist-session] Error saving session state:', error.message);
   }
@@ -62,13 +85,13 @@ function saveSessionState(state) {
 /**
  * Create a checkpoint of current session state
  */
-function createCheckpoint(state) {
-  ensureCheckpointDir();
+function createCheckpoint(state, sessionId) {
+  ensureCheckpointDir(sessionId);
 
   const checkpoint = {
     checkpoint_id: `cp_${Date.now()}`,
     created_at: new Date().toISOString(),
-    session_id: state.session_id,
+    session_id: sessionId,
     tool_executions: state.tool_executions,
     current_sd: state.current_sd,
     current_phase: state.current_phase,
@@ -78,26 +101,30 @@ function createCheckpoint(state) {
     git: state.git
   };
 
-  const checkpointPath = path.join(CHECKPOINT_DIR, `${checkpoint.checkpoint_id}.json`);
+  const checkpointPath = path.join(checkpointDir(sessionId), `${checkpoint.checkpoint_id}.json`);
   fs.writeFileSync(checkpointPath, JSON.stringify(checkpoint, null, 2));
 
   return checkpoint;
 }
 
 /**
- * Clean up old checkpoints (keep last N)
+ * Clean up old checkpoints (keep last N) — scoped to THIS session's own
+ * checkpoint directory only, so cleaning up session A never touches session B's
+ * checkpoints (the pre-fix global directory made every session's cleanup pass
+ * a candidate to delete a concurrent peer session's checkpoints).
  */
-function cleanupOldCheckpoints(keepCount = 10) {
+function cleanupOldCheckpoints(sessionId, keepCount = 10) {
   try {
-    ensureCheckpointDir();
-    const files = fs.readdirSync(CHECKPOINT_DIR)
+    ensureCheckpointDir(sessionId);
+    const dir = checkpointDir(sessionId);
+    const files = fs.readdirSync(dir)
       .filter(f => f.startsWith('cp_') && f.endsWith('.json'))
       .sort()
       .reverse();
 
     // Remove old checkpoints beyond keepCount
     for (let i = keepCount; i < files.length; i++) {
-      fs.unlinkSync(path.join(CHECKPOINT_DIR, files[i]));
+      fs.unlinkSync(path.join(dir, files[i]));
     }
 
     return files.length - keepCount;
@@ -129,15 +156,26 @@ function shouldCreateCheckpoint(state) {
 /**
  * Main hook execution
  */
-function main() {
-  const state = loadSessionState();
+async function main() {
+  // SD-LEO-FIX-SESSION-RESTORE-HOOK-001: resolve the REAL Claude session_id
+  // (stdin-first — CLAUDE_SESSION_ID is never propagated to PostToolUse
+  // subprocesses). Fail closed on an unresolved identity rather than falling
+  // back to a shared/global path — that fallback IS the bug being fixed.
+  const sessionId = await resolveSessionId();
+  if (!sessionId) {
+    console.error('[persist-session] Could not resolve session_id — skipping checkpoint (fail-closed, not global-fallback)');
+    return;
+  }
+
+  const state = loadSessionState(sessionId);
+  state.session_id = sessionId;
 
   // Increment tool execution count
   state.tool_executions = (state.tool_executions || 0) + 1;
   state.last_activity = new Date().toISOString();
 
   if (shouldCreateCheckpoint(state)) {
-    const checkpoint = createCheckpoint(state);
+    const checkpoint = createCheckpoint(state, sessionId);
 
     // Track checkpoint in state
     state.checkpoints = state.checkpoints || [];
@@ -152,8 +190,8 @@ function main() {
       state.checkpoints = state.checkpoints.slice(-20);
     }
 
-    // Clean up old checkpoint files
-    const removed = cleanupOldCheckpoints(10);
+    // Clean up old checkpoint files (scoped to THIS session only)
+    const removed = cleanupOldCheckpoints(sessionId, 10);
 
     console.log(`[persist-session] Checkpoint created: ${checkpoint.checkpoint_id}`);
     if (removed > 0) {
@@ -161,12 +199,14 @@ function main() {
     }
   }
 
-  saveSessionState(state);
+  saveSessionState(state, sessionId);
 }
 
-// Execute if run directly
+// Execute if run directly. Explicit process.exit(0) afterward — resolveSessionId()'s
+// stdin listeners can otherwise keep the process alive past the hook's expected
+// lifetime (same fail-open safety net already used by post-tool-rca-outcome.cjs).
 if (require.main === module) {
-  main();
+  main().finally(() => process.exit(0));
 }
 
-module.exports = { createCheckpoint, loadSessionState, saveSessionState, cleanupOldCheckpoints };
+module.exports = { createCheckpoint, loadSessionState, saveSessionState, cleanupOldCheckpoints, sessionStateFile, checkpointDir };

--- a/scripts/hooks/recover-session-state.cjs
+++ b/scripts/hooks/recover-session-state.cjs
@@ -5,10 +5,21 @@
  * SD-CLAUDE-CODE-2.1.0-LEO-001 - Phase 2 Hook Infrastructure
  *
  * Restores session state from the most recent LOCAL checkpoint file
- * ($HOME/.claude-checkpoints) after a restart on the SAME host. This is a
- * single-machine restore aid — NOT distributed crash recovery; the authoritative
- * cross-session/cross-machine state lives in the DB (claude_sessions). Use this only
- * to re-attach quickly after a local restart; for true session identity/state, query the DB.
+ * ($HOME/.claude-checkpoints/<session_id>/) after a restart on the SAME host.
+ * This is a single-machine restore aid — NOT distributed crash recovery; the
+ * authoritative cross-session/cross-machine state lives in the DB
+ * (claude_sessions). Use this only to re-attach quickly after a local restart;
+ * for true session identity/state, query the DB.
+ *
+ * SD-LEO-FIX-SESSION-RESTORE-HOOK-001: getAvailableCheckpoints() previously
+ * globbed EVERY checkpoint file in the single machine-shared checkpoint
+ * directory and picked the most-recent by mtime with ZERO session_id filtering
+ * — on a fleet host running several concurrent Claude Code sessions, a restore
+ * could silently apply a completely different, unrelated session's state
+ * (current_sd, current_phase, git info) as if it were the invoking session's
+ * own. Now resolves the real session_id via the canonical resolveSessionId()
+ * (lib/hooks/session-id.cjs, stdin-first) and reads only that session's own
+ * checkpoint subdirectory.
  *
  * Can be invoked manually or as a PreToolUse (once) hook for session init.
  *
@@ -19,23 +30,36 @@
 
 const fs = require('fs');
 const path = require('path');
+const { resolveSessionId } = require('../../lib/hooks/session-id.cjs');
 
-const SESSION_STATE_FILE = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
-const CHECKPOINT_DIR = path.join(process.env.HOME || '/tmp', '.claude-checkpoints');
+const HOME_DIR = process.env.HOME || '/tmp';
+const CHECKPOINT_ROOT = path.join(HOME_DIR, '.claude-checkpoints');
+
+function sessionStateFile(sessionId) {
+  return path.join(HOME_DIR, `.claude-session-state-${sessionId}.json`);
+}
+
+function checkpointDir(sessionId) {
+  return path.join(CHECKPOINT_ROOT, sessionId);
+}
 
 /**
- * Get list of available checkpoints sorted by recency
+ * Get list of available checkpoints for ONE session, sorted by recency.
+ * Reads ONLY that session's own checkpoint subdirectory — never globs the
+ * shared parent directory, so a concurrent peer session's checkpoints are
+ * never candidates for this session's restore.
  */
-function getAvailableCheckpoints() {
+function getAvailableCheckpoints(sessionId) {
   try {
-    if (!fs.existsSync(CHECKPOINT_DIR)) {
+    const dir = checkpointDir(sessionId);
+    if (!fs.existsSync(dir)) {
       return [];
     }
 
-    const files = fs.readdirSync(CHECKPOINT_DIR)
+    const files = fs.readdirSync(dir)
       .filter(f => f.startsWith('cp_') && f.endsWith('.json'))
       .map(f => {
-        const filePath = path.join(CHECKPOINT_DIR, f);
+        const filePath = path.join(dir, f);
         const stat = fs.statSync(filePath);
         return {
           filename: f,
@@ -107,9 +131,9 @@ function restoreFromCheckpoint(checkpoint) {
 /**
  * Save restored session state
  */
-function saveSessionState(state) {
+function saveSessionState(state, sessionId) {
   try {
-    fs.writeFileSync(SESSION_STATE_FILE, JSON.stringify(state, null, 2));
+    fs.writeFileSync(sessionStateFile(sessionId), JSON.stringify(state, null, 2));
     return true;
   } catch (error) {
     console.error('[recover-session] Error saving session state:', error.message);
@@ -139,15 +163,26 @@ function printRecoverySummary(checkpoint, restoredState, recoveryTime) {
 /**
  * Main recovery execution
  */
-function main() {
+async function main() {
   const startTime = Date.now();
   console.log('[recover-session] Starting session recovery...');
 
-  // Get available checkpoints
-  const checkpoints = getAvailableCheckpoints();
+  // SD-LEO-FIX-SESSION-RESTORE-HOOK-001: resolve the REAL Claude session_id
+  // (stdin-first). Fail closed — an unresolved identity must NOT fall back to
+  // "most recent checkpoint across the whole shared directory"; that fallback
+  // is exactly the cross-session-leak bug being fixed.
+  const sessionId = await resolveSessionId();
+  if (!sessionId) {
+    console.error('[recover-session] Could not resolve session_id — cannot safely restore (fail-closed, not global-fallback)');
+    console.log('[recover-session] Starting fresh session');
+    return;
+  }
+
+  // Get available checkpoints for THIS session only
+  const checkpoints = getAvailableCheckpoints(sessionId);
 
   if (checkpoints.length === 0) {
-    console.log('[recover-session] No checkpoints available');
+    console.log('[recover-session] No checkpoints available for this session');
     console.log('[recover-session] Starting fresh session');
     return;
   }
@@ -168,7 +203,7 @@ function main() {
       const fallbackCheckpoint = loadCheckpoint(secondRecent.path);
       if (fallbackCheckpoint) {
         const restoredState = restoreFromCheckpoint(fallbackCheckpoint);
-        if (saveSessionState(restoredState)) {
+        if (saveSessionState(restoredState, sessionId)) {
           const recoveryTime = Date.now() - startTime;
           printRecoverySummary(fallbackCheckpoint, restoredState, recoveryTime);
           return;
@@ -177,13 +212,14 @@ function main() {
     }
 
     console.error('[recover-session] All recovery attempts failed');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Restore from checkpoint
   const restoredState = restoreFromCheckpoint(checkpoint);
 
-  if (saveSessionState(restoredState)) {
+  if (saveSessionState(restoredState, sessionId)) {
     const recoveryTime = Date.now() - startTime;
     printRecoverySummary(checkpoint, restoredState, recoveryTime);
 
@@ -195,17 +231,22 @@ function main() {
     }
   } else {
     console.error('[recover-session] Failed to save restored state');
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 
-// Execute if run directly
+// Execute if run directly. Explicit process.exit() afterward, preserving any
+// exitCode set above — resolveSessionId()'s stdin listeners can otherwise
+// keep the process alive past this script's expected lifetime.
 if (require.main === module) {
-  main();
+  main().finally(() => process.exit(process.exitCode || 0));
 }
 
 module.exports = {
   getAvailableCheckpoints,
   loadCheckpoint,
-  restoreFromCheckpoint
+  restoreFromCheckpoint,
+  saveSessionState,
+  sessionStateFile,
+  checkpointDir
 };

--- a/scripts/run-leo.cjs
+++ b/scripts/run-leo.cjs
@@ -704,11 +704,23 @@ async function recoveryMenu() {
       label: 'View Session State',
       description: 'See current session details',
       action: () => {
-        const statePath = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
-        if (fs.existsSync(statePath)) {
-          const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+        // SD-LEO-FIX-SESSION-RESTORE-HOOK-001: persist-session-state.cjs now
+        // writes a per-session state file (.claude-session-state-<session_id>.json)
+        // instead of one machine-global file, so there is no longer a single
+        // canonical path to read. Show the most-recently-modified session state
+        // file on this host, labeled as such.
+        const homeDir = process.env.HOME || '/tmp';
+        const stateFiles = fs.existsSync(homeDir)
+          ? fs.readdirSync(homeDir)
+              .filter(f => f.startsWith('.claude-session-state-') && f.endsWith('.json'))
+              .map(f => ({ file: f, path: path.join(homeDir, f), mtime: fs.statSync(path.join(homeDir, f)).mtimeMs }))
+              .sort((a, b) => b.mtime - a.mtime)
+          : [];
+
+        if (stateFiles.length > 0) {
+          const state = JSON.parse(fs.readFileSync(stateFiles[0].path, 'utf8'));
           console.log('\n' + '═'.repeat(60));
-          console.log('SESSION STATE');
+          console.log('SESSION STATE (most recent of ' + stateFiles.length + ' session(s) on this host)');
           console.log('═'.repeat(60));
           console.log('Session ID:', state.session_id);
           console.log('Current SD:', state.current_sd || 'none');
@@ -731,11 +743,20 @@ async function recoveryMenu() {
       action: async () => {
         const confirm = await question('\nAre you sure? This deletes all checkpoints. [y/N]: ');
         if (confirm.toLowerCase() === 'y') {
-          const statePath = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
-          const checkpointDir = path.join(process.env.HOME || '/tmp', '.claude-checkpoints');
-          if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
-          if (fs.existsSync(checkpointDir)) {
-            fs.readdirSync(checkpointDir).forEach(f => fs.unlinkSync(path.join(checkpointDir, f)));
+          // SD-LEO-FIX-SESSION-RESTORE-HOOK-001: checkpoints now live under
+          // per-session subdirectories (.claude-checkpoints/<session_id>/), and
+          // state files are per-session (.claude-session-state-<session_id>.json)
+          // — glob and remove all of each, recursively, rather than a flat
+          // unlinkSync loop (which throws EISDIR on the new subdirectory entries).
+          const homeDir = process.env.HOME || '/tmp';
+          const checkpointRoot = path.join(homeDir, '.claude-checkpoints');
+          if (fs.existsSync(checkpointRoot)) {
+            fs.rmSync(checkpointRoot, { recursive: true, force: true });
+          }
+          if (fs.existsSync(homeDir)) {
+            fs.readdirSync(homeDir)
+              .filter(f => f.startsWith('.claude-session-state-') && f.endsWith('.json'))
+              .forEach(f => fs.unlinkSync(path.join(homeDir, f)));
           }
           console.log('✅ Session state cleared.');
         }


### PR DESCRIPTION
## Summary
- `scripts/hooks/persist-session-state.cjs` and `scripts/hooks/recover-session-state.cjs` used a single machine-global checkpoint directory (`$HOME/.claude-checkpoints`) and state file (`$HOME/.claude-session-state.json`) shared by every Claude Code session on the host, with `getAvailableCheckpoints()` selecting the single most-recent checkpoint by mtime and zero session_id filtering. On a fleet host running several concurrent sessions (confirmed live: 5 concurrent sessions on this exact host during this SD's own authoring), a restore could silently apply a completely different session's state.
- Both hooks now resolve the real session_id via the canonical `resolveSessionId()` (`lib/hooks/session-id.cjs`, stdin-first — the same resolver already proven in `post-tool-rca-outcome.cjs`) and scope the checkpoint directory/state file/cleanup to that identity. Fail closed (skip, log, exit 0) on an unresolvable identity rather than falling back to any shared path.
- Companion fix in `scripts/run-leo.cjs`'s interactive Session Recovery menu — necessitated by the directory-structure change (`Clear Session` would otherwise crash with `EISDIR` against the new per-session subdirectory layout).
- Neither hook is wired as an active Claude Code hook today (opt-in only via `scripts/setup-global-hooks.cjs`), so this closes a latent landmine before any worker who opts in — or an operator manually running the recovery script on a shared fleet host — can trigger it.

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/session-restore-hook-scoping.test.js` — 8/8 pass, including a real subprocess two-session round trip (session B checkpoints AFTER, and with a newer mtime than, session A — the exact condition that broke the old code)
- [x] `npx vitest run scripts/hooks/__tests__/` (full hooks suite) — 25 files / 298 tests pass, zero regressions
- [x] `npx eslint` on all 4 changed files — clean
- [x] TESTING and SECURITY sub-agent evidence recorded (PASS)

SD: SD-LEO-FIX-SESSION-RESTORE-HOOK-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)