### PR TITLE
feat(SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001): reconcile intake against institutions + make reconcile standing

### DIFF
--- a/lib/integrations/refine-reconcile.js
+++ b/lib/integrations/refine-reconcile.js
@@ -11,16 +11,80 @@
  *   - **Token**: Fast keyword-overlap fallback (standalone script use)
  *
  * Produces a reconciliation status per item:
- *   - 'already_done'    — A completed SD covers this item
- *   - 'in_progress'     — An active SD is working on this
- *   - 'partially_done'  — Code exists but no SD tracked it
- *   - 'novel'           — No existing SD or code matches
+ *   - 'already_done'          — A completed SD covers this item
+ *   - 'already_institutionalized' — Absorbed by a protocol/role-duty/contract section
+ *                                   (SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001, seam 1)
+ *   - 'in_progress'           — An active SD is working on this
+ *   - 'partially_done'        — Code exists but no SD tracked it
+ *   - 'novel'                 — No existing SD or institution matches
+ *
+ * NON-GOAL (SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 FR-4, ratified DON'T-build):
+ *   Solomon is NEVER wired into per-item reconcile/scoring. Institution matching runs
+ *   in the inline Claude-Code semantic path only — no `kind=solomon_consult` seam here.
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+// SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-2, precision-first / RISK R1): the
+// `already_institutionalized` disposition — which EXCLUDES an item from the novel-work
+// review queue — requires a STRICTLY HIGHER confidence than `already_done` AND a
+// verifiable section pointer. A weak (60-84) or pointerless match degrades to `novel`
+// (fail-open to surfacing) and is NEVER silently suppressed. Excluding a genuinely-novel
+// item is far worse than an institutionalized item mildly padding the queue.
+export const INSTITUTION_CONFIDENCE_FLOOR = 85;
+
+/**
+ * Precision guard for the `already_institutionalized` disposition (pure; no I/O).
+ * Enforces the floor + pointer discipline on a single reconcile result, degrading to
+ * `novel` with an `institution_note` when the evidence is too weak to justify excluding
+ * the item from the chairman review queue. Applied to inline-semantic results before they
+ * are persisted or gate the enqueue. Token-mode never emits the disposition, so this is a
+ * no-op there.
+ * @param {Object} result - { item_index, status, matched_sd_key?, matched_section_id?,
+ *                            matched_section_title?, confidence }
+ * @returns {Object} the same result, or a downgraded { status:'novel', institution_note }
+ */
+export function enforceInstitutionDiscipline(result) {
+  if (!result || result.status !== 'already_institutionalized') return result;
+  const confidence = Number(result.confidence) || 0;
+  const hasPointer = typeof result.matched_section_id === 'string' && result.matched_section_id.length > 0;
+  if (confidence >= INSTITUTION_CONFIDENCE_FLOOR && hasPointer) return result;
+  // Too weak / pointerless — SURFACE it (never suppress), annotated with what was seen.
+  return {
+    ...result,
+    status: 'novel',
+    institution_note: {
+      downgraded_from: 'already_institutionalized',
+      reason: hasPointer ? `confidence ${confidence} < floor ${INSTITUTION_CONFIDENCE_FLOOR}` : 'no resolvable section pointer',
+      candidate_section_id: result.matched_section_id || null,
+      candidate_section_title: result.matched_section_title || null,
+      confidence,
+    },
+  };
+}
+
+/**
+ * Load the institution corpus — protocol/role-duty/contract sections that may already
+ * absorb an intake item's intent. SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-1).
+ * Fail-open: a load error yields [] so reconcile degrades to SD-only matching.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Array<{id: string, title: string, section_type: string, anchor_topic: string, content: string}>>}
+ */
+async function loadProtocolSections(supabase) {
+  const { data, error } = await supabase
+    .from('leo_protocol_sections')
+    .select('id, title, section_type, anchor_topic, content')
+    .order('id', { ascending: true })
+    .limit(400);
+  if (error) {
+    console.warn(`  Warning: protocol-section query error (SD-only reconcile): ${error.message}`);
+    return [];
+  }
+  return data || [];
+}
 
 /**
  * Load completed and active SDs for reconciliation matching.
@@ -57,6 +121,17 @@ export async function extractReconcileContext(items, options = {}) {
   const supabase = options.supabase || createSupabaseServiceClient();
 
   const sds = await loadSDs(supabase);
+  // SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-1): also load the institution corpus so
+  // the inline analyzer can match items already absorbed as a protocol/role duty. Loaded
+  // ONCE per run (RISK R3), inline-semantic only (RISK R2: no token index over prose).
+  const sections = await loadProtocolSections(supabase);
+  const sectionSummaries = sections.map(s => ({
+    section_id: String(s.id),
+    title: (s.title || '').slice(0, 160),
+    section_type: s.section_type || '',
+    anchor_topic: s.anchor_topic || '',
+    excerpt: (s.content || '').slice(0, 240),
+  }));
 
   // Compact SD summaries for context efficiency
   const sdSummaries = sds.map(sd => {
@@ -86,10 +161,16 @@ export async function extractReconcileContext(items, options = {}) {
 
   return {
     mode: 'RECONCILE_CONTEXT',
-    instruction: `Semantically match each wave item against the existing SDs below.
+    instruction: `Semantically match each wave item against BOTH the existing SDs and the
+protocol/role-duty/contract SECTIONS below.
 For each item, determine:
-  - "novel" — No existing SD covers this idea
+  - "novel" — No existing SD or institution section covers this idea
   - "already_done" — A completed SD already delivered this capability
+  - "already_institutionalized" — The intent is already an institutional duty: a role
+      contract, protocol clause, or standing responsibility captured in a SECTION below
+      (e.g. an item "run a deep architecture review" when a role contract already lists
+      "deep architecture review" as a standing duty). This EXCLUDES the item from the
+      novel-work queue, so it demands STRONGER evidence than "already_done".
   - "in_progress" — An active/in-progress SD is working on this
   - "partially_done" — An SD partially covers this (different scope or incomplete)
 
@@ -97,22 +178,31 @@ Rules:
   - Match on MEANING, not just keywords. "Add dark mode" matches "Implement theme switching".
   - Short/vague items (e.g., "script", "Next Steps") with no clear semantic match should be "novel".
   - Confidence 0-100: how certain the match is (100 = exact same scope, 50 = partial overlap).
-  - Only flag non-novel if confidence >= 60.
-  - When matching, consider the SD's key_changes for specificity, not just the title.
+  - Only flag "already_done"/"in_progress"/"partially_done" if confidence >= 60.
+  - PRECISION-FIRST for "already_institutionalized": flag it ONLY at confidence >= ${INSTITUTION_CONFIDENCE_FLOOR}
+    AND set matched_section_id to the specific section. If you are not that sure, or you
+    cannot name the section, choose "novel" — excluding a genuinely-new item from review
+    is far worse than surfacing a duplicate. When institutionalized, ALSO include a short
+    matched_section_title so a human can verify the absorption.
+  - When matching SDs, consider the SD's key_changes for specificity, not just the title.
 
 Respond with JSON:
 {
   "results": [
-    {"item_index": 1, "status": "novel", "matched_sd_key": null, "matched_sd_title": null, "confidence": 0},
-    {"item_index": 2, "status": "already_done", "matched_sd_key": "SD-XXX-001", "matched_sd_title": "...", "confidence": 85}
+    {"item_index": 1, "status": "novel", "matched_sd_key": null, "matched_sd_title": null, "matched_section_id": null, "matched_section_title": null, "confidence": 0},
+    {"item_index": 2, "status": "already_done", "matched_sd_key": "SD-XXX-001", "matched_sd_title": "...", "matched_section_id": null, "matched_section_title": null, "confidence": 85},
+    {"item_index": 3, "status": "already_institutionalized", "matched_sd_key": null, "matched_sd_title": null, "matched_section_id": "611", "matched_section_title": "Solomon Role Contract", "confidence": 90}
   ]
 }
 
 Every item must have exactly one result. Item indices are 1-based.`,
     sds: sdSummaries,
+    sections: sectionSummaries,
     items: itemSummaries,
     item_count: items.length,
     sd_count: sdSummaries.length,
+    section_count: sectionSummaries.length,
+    institution_confidence_floor: INSTITUTION_CONFIDENCE_FLOOR,
   };
 }
 

--- a/scripts/eva-distill-brainstorm.js
+++ b/scripts/eva-distill-brainstorm.js
@@ -61,8 +61,21 @@ export async function loadTopWaveItems(supabase, topN = 20) {
     refine_composite_score:
       typeof r.metadata?.refine_composite_score === 'number' ? r.metadata.refine_composite_score : null,
   }));
-  scored.sort((a, b) => (b.refine_composite_score ?? -1) - (a.refine_composite_score ?? -1));
-  return scored.slice(0, n);
+  // SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-3): make reconcile STANDING — a scored
+  // item whose persisted reconcile disposition is a done-state (a completed SD covers it)
+  // or already-institutionalized (an existing protocol/role duty absorbs it) does NOT
+  // consume a novel-work review slot. It is NOT dropped: its metadata.refine_disposition
+  // (with the section/SD pointer) stays on the row for chairman spot-check. FAIL-OPEN:
+  // any item with no reconcile disposition, or an unrecognized one, still surfaces — never
+  // fail-closed-suppress. `already_institutionalized` only reaches this metadata after the
+  // enforceInstitutionDiscipline guard (>=85 confidence + verifiable section pointer).
+  const RECONCILED_OUT = new Set(['already_done', 'already_institutionalized']);
+  const eligible = scored.filter((r) => {
+    const status = r.metadata?.refine_disposition?.status;
+    return !RECONCILED_OUT.has(status);
+  });
+  eligible.sort((a, b) => (b.refine_composite_score ?? -1) - (a.refine_composite_score ?? -1));
+  return eligible.slice(0, n);
 }
 
 /**
@@ -154,7 +167,7 @@ async function main() {
   // FR-1: read-only disposition-coverage probe (no distillation, no writes).
   if (args.includes('--coverage')) {
     const cov = await dispositionCoverage(supabase);
-    console.log(`\n── Brainstorm corpus disposition coverage ──`);
+    console.log('\n── Brainstorm corpus disposition coverage ──');
     console.log(`   ${cov.detail}`);
     console.log(`   coverage: ${cov.value === null ? 'unknown' : (cov.value * 100).toFixed(2) + '%'} (status=${cov.status})`);
     return;

--- a/scripts/eva-intake-refine.js
+++ b/scripts/eva-intake-refine.js
@@ -30,7 +30,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { dedup, extractDedupContext } from '../lib/integrations/refine-dedup.js';
-import { reconcile, extractReconcileContext } from '../lib/integrations/refine-reconcile.js';
+import { reconcile, extractReconcileContext, enforceInstitutionDiscipline } from '../lib/integrations/refine-reconcile.js';
 import { score, extractScoringContext } from '../lib/integrations/refine-score.js';
 import { promote, groupForPromotion } from '../lib/integrations/refine-promote.js';
 
@@ -47,6 +47,9 @@ const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const skipPromote = args.includes('--skip-promote');
 const extractReconcile = args.includes('--extract-reconcile');
+// SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-3): reconcile is STANDING (default-on) —
+// this escape hatch exists so standing means default-on, not un-disableable.
+const skipReconcile = args.includes('--skip-reconcile');
 const extractDedup = args.includes('--extract-dedup');
 const extractScoring = args.includes('--extract-scoring');
 
@@ -344,6 +347,45 @@ async function runPromotion(waves, scoringResults) {
 // metadata JSONB column AND write a non-fallback source title back to the title column, so a
 // promoted SD carries a human/source title instead of a fallback. Extracted from main() as a pure,
 // exported function for unit-testability. Returns the count persisted (rows updated without error).
+/**
+ * SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-2/FR-3): persist each item's reconcile
+ * disposition to metadata.refine_disposition (JSONB — the reconcile disposition set has no
+ * DB CHECK; roadmap_wave_items.item_disposition is a SEPARATE flow-state enum). The
+ * enforceInstitutionDiscipline guard is applied FIRST so a weak/pointerless
+ * already_institutionalized can never be persisted (it degrades to novel). This standing
+ * persistence is what lets the chairman-queue enqueue (eva-distill-brainstorm --apply) gate
+ * out done/institutionalized items while keeping them auditable via the stored pointer.
+ * @param {Array} waves
+ * @param {Array} reconcileResults - [{ item_index, status, matched_sd_key?, matched_section_id?, ... }]
+ * @param {{supabase: import('@supabase/supabase-js').SupabaseClient}} deps
+ * @returns {Promise<number>} count persisted
+ */
+export async function persistReconcile(waves, reconcileResults, { supabase }) {
+  const allItems = (waves || []).flatMap(w => w.items);
+  let persisted = 0;
+  for (const raw of (reconcileResults || [])) {
+    const r = enforceInstitutionDiscipline(raw);
+    const item = allItems[r.item_index - 1];
+    if (!item || !item.id) continue;
+    const existingMeta = item.metadata || {};
+    const disposition = {
+      status: r.status,
+      matched_sd_key: r.matched_sd_key || null,
+      matched_section_id: r.matched_section_id || null,
+      matched_section_title: r.matched_section_title || null,
+      confidence: Number(r.confidence) || 0,
+      ...(r.institution_note ? { institution_note: r.institution_note } : {}),
+      reconciled_at: new Date().toISOString(),
+    };
+    const { error } = await supabase
+      .from('roadmap_wave_items')
+      .update({ metadata: { ...existingMeta, refine_disposition: disposition } })
+      .eq('id', item.id);
+    if (!error) persisted++;
+  }
+  return persisted;
+}
+
 export async function persistScores(waves, scoringResults, { supabase }) {
   let persisted = 0;
   for (const waveResult of (scoringResults || [])) {
@@ -527,10 +569,21 @@ async function main() {
       console.warn('  Falling back to token-based reconciliation.');
       reconcileResults = await runReconcile(waves);
     }
+  } else if (skipReconcile) {
+    // SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-3): standing = default-on, but explicitly disableable.
+    console.log('\n── Step 2: Reconcile ── SKIPPED (--skip-reconcile)\n');
   } else if (fromStep <= 2 && !extractReconcile) {
     reconcileResults = await runReconcile(waves);
   } else if (!reconcileFile) {
     console.log('\n── Step 2: Reconcile ── SKIPPED\n');
+  }
+
+  // SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 (FR-2/FR-3): persist reconcile dispositions
+  // (guard-enforced) so the chairman-queue enqueue can gate on them. Standing on the
+  // default path; a no-op under --dry-run / --skip-reconcile (no results).
+  if (reconcileResults && reconcileResults.length > 0 && !dryRun) {
+    const persistedR = await persistReconcile(waves, reconcileResults, { supabase });
+    console.log(`  Persisted ${persistedR} reconcile disposition(s) to metadata.refine_disposition`);
   }
 
   // --extract-scoring: output scoring context for Claude Code inline analysis, then stop

--- a/tests/unit/integrations/refine-reconcile-institutions.test.js
+++ b/tests/unit/integrations/refine-reconcile-institutions.test.js
@@ -1,0 +1,128 @@
+/**
+ * SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001 — institution reconciliation + precision guard.
+ *
+ * Pins the precision-first discipline (RISK R1, governing): the `already_institutionalized`
+ * disposition — which excludes an item from the chairman review queue — can ONLY survive at
+ * >= INSTITUTION_CONFIDENCE_FLOOR AND with a verifiable section pointer; anything weaker
+ * degrades to `novel` (surface, never silently drop). Also pins: token mode never emits the
+ * disposition (RISK R2), the enqueue gate excludes reconciled-out items while failing open
+ * on unknown (FR-3), and no Solomon seam is introduced (FR-4).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  INSTITUTION_CONFIDENCE_FLOOR,
+  enforceInstitutionDiscipline,
+  tokenReconcile,
+} from '../../../lib/integrations/refine-reconcile.js';
+import { loadTopWaveItems } from '../../../scripts/eva-distill-brainstorm.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '../../..');
+
+describe('enforceInstitutionDiscipline — precision-first (RISK R1)', () => {
+  const base = { item_index: 1, status: 'already_institutionalized', matched_section_id: '611', matched_section_title: 'Solomon Role Contract' };
+
+  it('keeps a strong, pointered institution match (>= floor + section id)', () => {
+    const r = enforceInstitutionDiscipline({ ...base, confidence: INSTITUTION_CONFIDENCE_FLOOR });
+    expect(r.status).toBe('already_institutionalized');
+    expect(r.matched_section_id).toBe('611');
+  });
+
+  it('degrades a 60-84 confidence match to novel + institution_note (never suppressed)', () => {
+    const r = enforceInstitutionDiscipline({ ...base, confidence: 70 });
+    expect(r.status).toBe('novel');
+    expect(r.institution_note.downgraded_from).toBe('already_institutionalized');
+    expect(r.institution_note.candidate_section_id).toBe('611'); // preserved for spot-check
+  });
+
+  it('degrades a pointerless match to novel even at high confidence', () => {
+    const r = enforceInstitutionDiscipline({ item_index: 2, status: 'already_institutionalized', confidence: 95, matched_section_id: null });
+    expect(r.status).toBe('novel');
+    expect(r.institution_note.reason).toMatch(/pointer/);
+  });
+
+  it('is a no-op for non-institution dispositions (already_done, novel, in_progress)', () => {
+    for (const status of ['already_done', 'novel', 'in_progress', 'partially_done']) {
+      const r = enforceInstitutionDiscipline({ item_index: 3, status, confidence: 50 });
+      expect(r.status).toBe(status);
+    }
+  });
+
+  it('floor is strictly higher than the already_done floor (60)', () => {
+    expect(INSTITUTION_CONFIDENCE_FLOOR).toBeGreaterThan(60);
+  });
+});
+
+describe('tokenReconcile — never emits already_institutionalized (RISK R2)', () => {
+  function stubSupabase(sds) {
+    const builder = {
+      select: () => builder, in: () => builder, order: () => builder,
+      limit: () => Promise.resolve({ data: sds, error: null }),
+    };
+    return { from: () => builder };
+  }
+
+  it('token mode only produces SD-based dispositions, never the institution one', async () => {
+    const sds = [{ id: 'u1', sd_key: 'SD-X-001', title: 'deep architecture review cadence', status: 'completed', key_changes: [] }];
+    const items = [{ title: 'deep architecture review' }, { title: 'flaky RCA triage' }];
+    const results = await tokenReconcile(items, { supabase: stubSupabase(sds) });
+    for (const r of results) {
+      expect(r.status).not.toBe('already_institutionalized');
+      expect(['novel', 'already_done', 'in_progress', 'partially_done']).toContain(r.status);
+    }
+  });
+});
+
+describe('loadTopWaveItems — standing enqueue gate (FR-3)', () => {
+  function stubSupabase(rows) {
+    const builder = {
+      select: () => builder,
+      not: () => Promise.resolve({ data: rows, error: null }),
+    };
+    return { from: () => builder };
+  }
+  const mk = (id, score, disposition) => ({
+    id, wave_id: 'w', source_type: 's', source_id: 's', title: id,
+    metadata: { refine_composite_score: score, ...(disposition ? { refine_disposition: disposition } : {}) },
+    item_disposition: 'selected',
+  });
+
+  it('excludes already_done and already_institutionalized from the novel-work top-N', async () => {
+    const rows = [
+      mk('novelA', 90, { status: 'novel' }),
+      mk('doneB', 95, { status: 'already_done', matched_sd_key: 'SD-Y-001' }),
+      mk('instC', 99, { status: 'already_institutionalized', matched_section_id: '611' }),
+      mk('novelD', 80, null), // no disposition at all — fail-open
+    ];
+    const top = await loadTopWaveItems(stubSupabase(rows), 20);
+    const ids = top.map(r => r.id);
+    expect(ids).toContain('novelA');
+    expect(ids).toContain('novelD');       // unknown/absent disposition FAILS OPEN (surfaces)
+    expect(ids).not.toContain('doneB');
+    expect(ids).not.toContain('instC');
+  });
+
+  it('an unrecognized disposition status still surfaces (fail-open, never fail-closed)', async () => {
+    const rows = [mk('weird', 70, { status: 'something_new' })];
+    const top = await loadTopWaveItems(stubSupabase(rows), 20);
+    expect(top.map(r => r.id)).toContain('weird');
+  });
+});
+
+describe('FR-4 non-goal — no Solomon seam in reconcile', () => {
+  it('refine-reconcile.js wires no solomon-consult SEAM (imports/calls, not comments)', () => {
+    const raw = fs.readFileSync(path.join(REPO, 'lib/integrations/refine-reconcile.js'), 'utf8');
+    // Strip comments so the FR-4 non-goal documentation ("no solomon_consult seam here")
+    // does not itself trip the guard — we check executable seams only.
+    const code = raw
+      .replace(/\/\*[\s\S]*?\*\//g, '')          // block comments
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');        // line comments (not URLs)
+    expect(code).not.toMatch(/import[^;]*solomon/i);          // no solomon module import
+    expect(code).not.toMatch(/solomon[-_]?consult\s*\(/i);    // no solomon-consult call
+    expect(code).not.toMatch(/kind:\s*['"]solomon/i);         // no solomon_consult kind write
+  });
+});


### PR DESCRIPTION
## Summary
Distill refine reconciled intake items against `strategic_directives_v2` **only**, so items already institutionalized as a role duty / protocol clause resurfaced in the chairman review queue as "new" (witnessed: 3 Fable-era Solomon-duty items — deep-arch-review, flaky-RCA, dedup-sweep). And reconcile was **advisory-only** — computed, console-logged, never persisted or gating — so nothing actually stopped un-checked items reaching the queue.

## Change
- **FR-1/FR-2** (`lib/integrations/refine-reconcile.js`): `extractReconcileContext` now loads the `leo_protocol_sections` institution corpus (**inline-semantic path only** — token mode is barred from the disposition, RISK R2) and adds an `already_institutionalized` disposition. **PRECISION-FIRST** (RISK R1, governing): the pure `enforceInstitutionDiscipline` guard keeps it **only** at confidence ≥ `INSTITUTION_CONFIDENCE_FLOOR` (85, strictly above `already_done`'s 60) **and** with a verifiable section pointer; a weak/pointerless match degrades to `novel` with an `institution_note` — surfaced, **never silently suppressed** (excluding a genuinely-novel item is far worse than a duplicate padding the queue).
- **FR-3** (standing): `eva-intake-refine.js` persists guard-enforced dispositions to `metadata.refine_disposition` (default-on, `--skip-reconcile` hatch); the real chairman-queue feed `eva-distill-brainstorm.js --apply` now gates its novel-work top-N to exclude done/institutionalized items — **annotated on the row for spot-check, not dropped**; unknown disposition **fails open** to surfacing. No migration (JSONB; `item_disposition` is a separate enum).
- **FR-4** non-goal held: no Solomon seam in reconcile/scoring (guard test strips comments, checks executable seams only).

298 LOC (170 source / 128 tests). Over the 100 target with justification: FR-3's standing gate spans the reconcile engine + both pipeline scripts, and the precision-first discipline demands its full test matrix.

## Test plan
`npx vitest run tests/unit/integrations/refine-reconcile-institutions.test.js` — 9 tests (floor+pointer+degrade precision, token-mode bar, enqueue-gate fail-open, no-Solomon-seam). Distill-brainstorm suite **26/26** unregressed.

PRD: `PRD-SD-LEO-INFRA-DISTILL-REFINE-RECONCILE-001` (approved) · Evidence: VALIDATION `fc65d86d` / RISK `9c52b5da`

🤖 Generated with [Claude Code](https://claude.com/claude-code)