### PR TITLE
fix(SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001): make runProbe pg-client injectable — hermetic tests

### DIFF
--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -290,8 +290,18 @@ export async function runProbe(supabase, opts = {}) {
   // diverges (or can't produce a field) does — never null-coalesced.
   let recompute = { status: 'unavailable', recompute_ok: null };
   try {
-    const { createDatabaseClient } = await import('../lib/supabase-connection.js');
-    const pg = await createDatabaseClient('engineer', { verify: false });
+    // Injectable pg-client factory (SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001): the
+    // default reproduces prior behavior EXACTLY, but a caller (the unit tests) can
+    // inject a stub so no live Postgres connection is opened and the recompute is
+    // deterministic — the raw-SQL client is created OUTSIDE the injected supabase,
+    // so without this seam the unit test's outcome flipped on ambient DB
+    // reachability. Mirrors the claimableLeavesFn / gitGrep injectable-default
+    // precedent used elsewhere in this file.
+    const makePgClient = opts.makePgClient || (async () => {
+      const { createDatabaseClient } = await import('../lib/supabase-connection.js');
+      return createDatabaseClient('engineer', { verify: false });
+    });
+    const pg = await makePgClient();
     try {
       const { recomputeViaRawSql, compareReadings } = await import('../lib/oversight/coordinator-health-recompute.mjs');
       const raw = await recomputeViaRawSql(pg);

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -245,6 +245,13 @@ describe('persistReading (TS-6)', () => {
 });
 
 describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
+  // SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001: runProbe's raw-SQL recompute creates its
+  // OWN pg client (createDatabaseClient) OUTSIDE the injected supabase; without an
+  // injectable seam the test's pass/fail flipped on ambient DB reachability. Inject a
+  // stub that forces the pre-existing recompute-unavailable path (recompute_ok=null,
+  // no breach) — deterministic, no live connection.
+  const pgDisabled = async () => { throw new Error('pg-disabled-in-unit'); };
+
   it('runs all three KPIs, persists a reading, and skips the advisory when there is no breach', async () => {
     vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: null, linked: 0, total: 0, starved: false, unlinkedKeys: [] });
     const inserted = [];
@@ -252,7 +259,8 @@ describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
       { claude_sessions: [], strategic_directives_v2: [], codebase_health_snapshots: [] },
       { onInsert: (t, r) => inserted.push({ t, r }) },
     );
-    const reading = await runProbe(supabase, {});
+    const reading = await runProbe(supabase, { makePgClient: pgDisabled });
+    expect(reading.recompute.recompute_ok).toBeNull(); // pg seam stubbed — no live recompute, deterministic
     expect(reading.utilization).toBeDefined();
     expect(reading.plan_adherence.status).toBe('unmeasurable_until_linkage');
     expect(reading.integrity.integrity_ok).toBe(true);
@@ -272,9 +280,26 @@ describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
       },
       { onInsert: (t, r) => inserted.push({ t, r }) },
     );
-    await runProbe(supabase, {});
+    await runProbe(supabase, { makePgClient: pgDisabled });
     const advisory = inserted.find((i) => i.t === 'session_coordination');
     expect(advisory).toBeDefined();
     expect(advisory.r.target_session).toBe('live-coordinator-session-1');
+  });
+
+  it('a divergent recompute via the INJECTED pg seam drives a breach + advisory (runProbe->recomputeBreach glue)', async () => {
+    // Covers the recompute-breach glue the pg stub otherwise bypasses: an injected
+    // fake pg that "connects" and returns finite raw counts diverges from the empty
+    // fake-supabase-derived probe -> recompute_ok=false -> breach -> advisory.
+    vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: null, linked: 0, total: 0, starved: false, unlinkedKeys: [] });
+    const inserted = [];
+    const supabase = makeFakeSupabase(
+      { claude_sessions: [], strategic_directives_v2: [], codebase_health_snapshots: [] },
+      { onInsert: (t, r) => inserted.push({ t, r }) },
+    );
+    const fakePg = { query: async () => ({ rows: [{ n: 7 }] }), end: async () => {} };
+    const reading = await runProbe(supabase, { makePgClient: async () => fakePg, recipients: { coordinatorId: 'c-test' } });
+    expect(reading.recompute.recompute_ok).toBe(false);
+    expect(reading.breach.recomputeBreach).toBe(true);
+    expect(inserted.some((i) => i.t === 'session_coordination')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
The `adam-coordinator-health` probe's `runProbe()` created its **own** Postgres client (`createDatabaseClient('engineer')`) for the raw-SQL recompute, **outside** the injected fake Supabase. Because the script imports `dotenv/config`, real DB creds load in the unit tier regardless of shell env — so with a reachable DB the recompute diverged from the empty in-memory fake → `recompute_ok=false` → breach → advisory inserted → the "skips advisory when no breach" test **failed**. The outcome flipped on ambient DB reachability (reproduced 10/10 fail with DB reachable vs 20/20 pass without) — the exact non-hermeticity the SD targets.

## Fix (OPT-A)
Hoist the pg-client creation into an **opts-injectable `makePgClient`** whose default reproduces prior behavior byte-identically — mirroring the file's existing `claimableLeavesFn`/`gitGrep` injectable-default precedent. The two `runProbe` unit tests inject a throwing stub → deterministic recompute-unavailable path, zero live connections. Added a **divergent-pg glue test** (injected fake pg → `recompute_ok=false` → `recomputeBreach` → advisory) so stubbing the pg path doesn't leave the breach glue untested; `compareReadings` stays independently covered by `coordinator-health-recompute.test.js`.

## Verification
- **21/21 deterministic** across repeated runs WITH real `.env` present (the previously-failing env) AND with DB unreachable
- Sibling suites green (recompute 16/16); smoke 15/15
- Production `runProbe` behavior unchanged when `makePgClient` is not injected
- 39-line diff (2 files)

## Note
This SD is the same coordinator "belt-low #4" batch as the cancelled flag-kill SD, but its premise is **genuine** — verified by a reproduced 10/10 failure, not assumed.

SD: SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001 · PRD: PRD-SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001
Claude-Session: 356833d8-2c04-4d59-941e-8edf5f64c391

🤖 Generated with [Claude Code](https://claude.com/claude-code)