### PR TITLE
feat(SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A): history-preserving Fable-suitability persistence layer

### DIFF
--- a/database/migrations/20260717_fable_suitability_map_STAGED.sql
+++ b/database/migrations/20260717_fable_suitability_map_STAGED.sql
@@ -74,10 +74,20 @@ CREATE INDEX IF NOT EXISTS idx_fable_suitability_cluster ON fable_suitability_ma
 CREATE INDEX IF NOT EXISTS idx_fable_suitability_region ON fable_suitability_map (region_key, repo, score_version DESC);
 
 -- Latest-per-region read surface (child C / reader consume this, not the raw history).
-CREATE OR REPLACE VIEW v_fable_suitability_map_current AS
+-- security_invoker = on is MANDATORY: without it a Postgres view runs with the view OWNER's
+-- privileges (the table owner, who bypasses RLS), and Supabase exposes public-schema views to
+-- anon/authenticated via PostgREST by default — so a plain SELECT * view would leak every
+-- ranking + the full evidence jsonb, defeating the base table's chairman-only RLS. This is the
+-- exact recurring leak class already remediated three times in this repo (fix_security_definer_views
+-- 20251216 / 20260211 / 20260602). security_invoker makes the view honor the querying role's RLS.
+CREATE OR REPLACE VIEW v_fable_suitability_map_current
+WITH (security_invoker = on) AS
 SELECT DISTINCT ON (region_key, repo) *
 FROM fable_suitability_map
 ORDER BY region_key, repo, score_version DESC;
+
+-- Belt-and-braces: even with security_invoker, do not expose the view to the API roles.
+REVOKE ALL ON v_fable_suitability_map_current FROM anon, authenticated;
 
 COMMENT ON COLUMN fable_suitability_map.region_key IS
   'Deterministic region identity: canonical repo id + declared coarse structural boundary, normalized (lowercase/forward-slash). CHECK-enforced so child B cannot emit a drifting/path-derived key — stability is required for the section-11 advice-outcome ledger JOIN.';

--- a/database/migrations/20260717_fable_suitability_map_STAGED.sql
+++ b/database/migrations/20260717_fable_suitability_map_STAGED.sql
@@ -1,0 +1,98 @@
+-- Fable-suitability map — durable, gradeable ranked codebase-region suitability scores.
+-- SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A (child A of the Fable-suitability orchestrator).
+-- Chairman-directed pre-Fable infrastructure; provenance = Solomon Mode-B activation prep.
+--
+-- WHY: the Fable-suitability map ranks codebase regions for Fable's (expensive) attention
+-- on Impact x Opportunity x Reasoning-Depth. This is its DURABLE, GRADEABLE store. The
+-- table is HISTORY-PRESERVING by design: every (region_key, repo, score_version) is a
+-- distinct row so Solomon's section-11 advice-outcome ledger can later JOIN a prediction
+-- made at score_version=N against an outcome that lands LATER. A latest-only key would
+-- destroy the historical prediction row and make the map ungradeable — defeating its whole
+-- justification (RISK 3b2d91f1 R1). Within a version, a re-score UPDATES in place (LIVING:
+-- last_scored_at / refloated_at / recurrence_weight climb); a version bump INSERTS.
+--
+-- GOVERNANCE — WHO IS STOPPED BY WHAT (mirrors the ratified STAGED chairman-gated pattern):
+--   * anon / ordinary authenticated users are stopped at the RLS LAYER: no write policy
+--     exists for them and SELECT is chairman-only (fn_is_chairman()) — suitability rankings
+--     are a GOVERNED-decision-audience artifact, not open data.
+--   * service_role BYPASSES RLS (rolbypassrls=true): the machine writer (child B via
+--     lib/fable-suitability/map-writer.mjs) and Solomon's reader (child C) both run as
+--     service_role, so the barrier for THAT principal is APPLICATION-CODE DISCIPLINE — the
+--     writer only ever upserts this table, and region_key is CHECK-constrained so a
+--     drifting/path-derived key is rejected at write time (keeps the ledger JOIN stable).
+--   * a human CHAIRMAN (fn_is_chairman()) may read; no principal gets a permissive
+--     FOR SELECT USING(true) that would leak the rankings.
+--
+-- STAGED — NOT YET APPROVED FOR APPLY. requires-chairman-apply. Do NOT auto-apply on merge;
+-- no @approved-by. APPLY RUNBOOK (chairman ceremony): (1) chairman approval; (2) apply via
+-- the standard path with an @approved-by attestation commit; (3) run
+-- `npm run schema:snapshot:lint` and commit the regenerated snapshot in the same PR;
+-- (4) verify with a real select. The writer's typed CEREMONY_PENDING (42P01) flips to live
+-- automatically on apply — no code change. NOTE: this table yields zero value until child C
+-- wires the Solomon Mode-B read — the orchestrator must not silently drop child C.
+
+CREATE TABLE IF NOT EXISTS fable_suitability_map (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Falsifiability keys (RISK R1). region_key is a DETERMINISTIC function of stable inputs
+  -- only — canonical repo id + a declared coarse structural boundary, normalized (lowercase,
+  -- forward-slash). The CHECK rejects a path-derived / backslash / absolute-path key so
+  -- child B physically cannot emit a key that would fork the section-11 ledger JOIN.
+  region_key TEXT NOT NULL
+    CONSTRAINT fable_region_key_shape
+    CHECK (region_key ~ '^[a-z0-9][a-z0-9._/-]{0,199}$' AND region_key !~ '(\\|:| |//|^/|/$)'),
+  repo TEXT NOT NULL,
+  score_version INTEGER NOT NULL,
+
+  duty_cluster TEXT NOT NULL
+    CHECK (duty_cluster IN ('architecture-refactor', 'dedup', 'flaky-RCA', 'harness-depth')),
+
+  -- Axes 1-5. composite = product (populated by child B).
+  axis_impact INTEGER CHECK (axis_impact BETWEEN 1 AND 5),
+  axis_opportunity INTEGER CHECK (axis_opportunity BETWEEN 1 AND 5),
+  axis_reasoning_depth INTEGER CHECK (axis_reasoning_depth BETWEEN 1 AND 5),
+  composite_score INTEGER,
+
+  -- Auditability: per-axis inputs + rationale (documented shape, app-validated before insert).
+  evidence JSONB NOT NULL,
+
+  -- LIVING re-float signals.
+  recurrence_weight NUMERIC,
+  trigger_reason TEXT,
+  status TEXT NOT NULL DEFAULT 'scored',
+
+  last_scored_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  refloated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- HISTORY-PRESERVING: one row per region per repo per score_version. A version bump
+  -- appends (preserving the prediction the ledger will grade); same version upserts in place.
+  CONSTRAINT fable_suitability_map_versioned UNIQUE (region_key, repo, score_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fable_suitability_cluster ON fable_suitability_map (duty_cluster, composite_score DESC);
+CREATE INDEX IF NOT EXISTS idx_fable_suitability_region ON fable_suitability_map (region_key, repo, score_version DESC);
+
+-- Latest-per-region read surface (child C / reader consume this, not the raw history).
+CREATE OR REPLACE VIEW v_fable_suitability_map_current AS
+SELECT DISTINCT ON (region_key, repo) *
+FROM fable_suitability_map
+ORDER BY region_key, repo, score_version DESC;
+
+COMMENT ON COLUMN fable_suitability_map.region_key IS
+  'Deterministic region identity: canonical repo id + declared coarse structural boundary, normalized (lowercase/forward-slash). CHECK-enforced so child B cannot emit a drifting/path-derived key — stability is required for the section-11 advice-outcome ledger JOIN.';
+COMMENT ON COLUMN fable_suitability_map.evidence IS
+  'Documented shape (validated pre-insert): { evidence_schema_version, axes:{impact/opportunity/reasoning_depth:{score,inputs,rationale}}, recurrence:{weight,count,source_ids}, scored_by, computed_at }. issue_patterns referenced by ID; no embedded file/log dumps. evidence_schema_version is distinct from the row score_version.';
+
+-- RLS + policy in the SAME migration (SPINE-001-B recurrence guard).
+ALTER TABLE fable_suitability_map ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fable_suitability_chairman_select ON fable_suitability_map;
+CREATE POLICY fable_suitability_chairman_select ON fable_suitability_map
+  FOR SELECT USING (fn_is_chairman());
+
+-- Deliberately NO write policy and NO permissive USING(true): only service_role
+-- (rolbypassrls) writes/reads for the machine pipeline; humans read chairman-only.
+
+COMMENT ON TABLE fable_suitability_map IS
+  'History-preserving Fable-suitability rankings (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A). One row per (region_key, repo, score_version); v_fable_suitability_map_current exposes latest-per-region. Gradeable by Solomon section-11 via the (region_key, score_version) keys.';

--- a/lib/fable-suitability/map-reader.mjs
+++ b/lib/fable-suitability/map-reader.mjs
@@ -1,0 +1,75 @@
+/**
+ * map-reader.mjs — reader for the Fable-suitability map (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A).
+ *
+ * Read side of the persistence seam. Child C (Solomon Mode-B fan-out) reads the LATEST score per
+ * region through the v_fable_suitability_map_current view — NEVER the raw history table — so a
+ * consumer always sees exactly one row per (region_key, repo): the highest score_version. The raw
+ * table keeps every version for the section-11 ledger; the view is the "what is the current
+ * ranking" surface.
+ *
+ * Like the writer, an absent (not-yet-ceremonially-applied) table surfaces as a typed
+ * CEREMONY_PENDING result rather than an exception, so a caller can degrade gracefully before the
+ * chairman apply ceremony runs.
+ */
+
+import { isMissingTableError } from './map-writer.mjs';
+
+const CURRENT_VIEW = 'v_fable_suitability_map_current';
+
+/**
+ * Read the current suitability map (latest score_version per region), optionally filtered by
+ * duty_cluster, ordered by composite_score DESC (NULLS effectively last via the view's own order,
+ * re-sorted client-side for a stable ranking).
+ *
+ * @returns {Promise<{status:'ok', rows:object[]} | {status:'CEREMONY_PENDING', reason:string}>}
+ */
+export async function readCurrentMap(supabase, { dutyCluster = null, limit = null } = {}) {
+  let query = supabase.from(CURRENT_VIEW).select('*');
+  if (dutyCluster) query = query.eq('duty_cluster', dutyCluster);
+  if (Number.isInteger(limit) && limit > 0) query = query.limit(limit);
+
+  const { data, error } = await query;
+  if (error) {
+    if (isMissingTableError(error)) {
+      return {
+        status: 'CEREMONY_PENDING',
+        reason: `${CURRENT_VIEW} not available — fable_suitability_map STAGED migration not yet chairman-applied (Postgres 42P01).`,
+      };
+    }
+    throw new Error(`readCurrentMap: ${error.message}`);
+  }
+
+  const rows = (data || []).slice().sort((a, b) => (b.composite_score ?? -1) - (a.composite_score ?? -1));
+  return { status: 'ok', rows };
+}
+
+/**
+ * Read the full version history for a single region (all score_versions, newest first).
+ * This is the ledger-grading read: Solomon joins a prediction made at score_version=N against a
+ * later outcome, so it must see every version, not just the current one.
+ */
+export async function readRegionHistory(supabase, { regionKey, repo }) {
+  if (typeof regionKey !== 'string' || regionKey.trim() === '') {
+    throw new Error('readRegionHistory: regionKey is required');
+  }
+  if (typeof repo !== 'string' || repo.trim() === '') {
+    throw new Error('readRegionHistory: repo is required');
+  }
+  const { data, error } = await supabase
+    .from('fable_suitability_map')
+    .select('*')
+    .eq('region_key', regionKey)
+    .eq('repo', repo)
+    .order('score_version', { ascending: false });
+
+  if (error) {
+    if (isMissingTableError(error)) {
+      return {
+        status: 'CEREMONY_PENDING',
+        reason: 'fable_suitability_map STAGED migration not yet chairman-applied (Postgres 42P01).',
+      };
+    }
+    throw new Error(`readRegionHistory: ${error.message}`);
+  }
+  return { status: 'ok', rows: data || [] };
+}

--- a/lib/fable-suitability/map-writer.mjs
+++ b/lib/fable-suitability/map-writer.mjs
@@ -1,0 +1,152 @@
+/**
+ * map-writer.mjs — writer for the Fable-suitability map (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A).
+ *
+ * The DURABLE, GRADEABLE persistence seam for Fable-region suitability scores. Child B (the
+ * scoring engine) calls upsertRegionScore(); this module owns key normalization, evidence-shape
+ * validation, and the history-preserving upsert semantics — so scoring logic never has to know
+ * the table contract.
+ *
+ * HISTORY-PRESERVING (RISK R1): ON CONFLICT (region_key, repo, score_version). A version bump
+ * INSERTS a new row (preserving the prediction Solomon's section-11 ledger will later grade); a
+ * re-score at the SAME version UPDATES in place (living re-float: last_scored_at / refloated_at /
+ * recurrence_weight climb without forking the graded key).
+ *
+ * CEREMONY_PENDING: the STAGED migration is chairman-gated and may not be applied yet. A write
+ * against the absent table surfaces Postgres 42P01 (undefined_table). We type THAT code
+ * specifically — never a blanket catch — into a { status:'CEREMONY_PENDING' } result so the
+ * caller can treat "table not yet ceremonially applied" as an expected, non-fatal state distinct
+ * from a real write failure. On apply, the same code path flips to live with no code change.
+ */
+
+export const EVIDENCE_SCHEMA_VERSION = 1;
+const VALID_DUTY_CLUSTERS = new Set(['architecture-refactor', 'dedup', 'flaky-RCA', 'harness-depth']);
+const REGION_KEY_RE = /^[a-z0-9][a-z0-9._/-]{0,199}$/;
+
+/**
+ * "STAGED migration not yet applied" detector. Typed NARROWLY (RISK mandate) — two specific
+ * codes, never a blanket catch — because the missing-table signal differs by access path:
+ *   - PGRST205: PostgREST/supabase-js path. When the table is absent, PostgREST answers from its
+ *     schema cache and NEVER reaches Postgres, so `.from('fable_suitability_map')` yields this,
+ *     NOT raw 42P01. This is the code the writer/reader actually hit against a real absent table
+ *     (verified live — the unit mock's 42P01 hid it: the mocked-seam trap).
+ *   - 42P01: raw Postgres undefined_table, surfaced only on a direct-SQL / RPC path.
+ * Any other error is a genuine failure and must propagate.
+ */
+export function isMissingTableError(error) {
+  if (!error) return false;
+  if (error.code === 'PGRST205' || error.code === '42P01') return true;
+  // Message fallbacks for paths that don't thread the code through.
+  if (typeof error.message !== 'string') return false;
+  return (
+    /could not find the table .*fable_suitability_map.* in the schema cache/i.test(error.message) ||
+    /relation .*fable_suitability_map.* does not exist/i.test(error.message)
+  );
+}
+
+/**
+ * Normalize a region key to its canonical, deterministic form: lowercase, backslashes → forward
+ * slashes, collapse duplicate slashes, trim a leading/trailing slash and surrounding whitespace.
+ * This is the ONLY sanctioned transform — it must stay a pure function of stable structural inputs
+ * so the same region always yields the same key across score versions (ledger-JOIN stability).
+ * It deliberately does NOT accept a filesystem path; child B passes a declared structural boundary.
+ */
+export function normalizeRegionKey(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new Error('normalizeRegionKey: region key must be a non-empty string');
+  }
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/\\/g, '/')
+    .replace(/\/{2,}/g, '/')
+    .replace(/^\/+|\/+$/g, '');
+  if (!REGION_KEY_RE.test(normalized)) {
+    throw new Error(`normalizeRegionKey: "${raw}" does not normalize to a canonical region key (got "${normalized}")`);
+  }
+  return normalized;
+}
+
+/**
+ * Validate the evidence jsonb against its documented shape before it reaches the DB. Fail loud —
+ * a malformed evidence blob makes a score unauditable, which defeats the map's justification.
+ */
+export function validateEvidence(evidence) {
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    throw new Error('validateEvidence: evidence must be an object');
+  }
+  if (evidence.evidence_schema_version !== EVIDENCE_SCHEMA_VERSION) {
+    throw new Error(`validateEvidence: evidence_schema_version must be ${EVIDENCE_SCHEMA_VERSION}`);
+  }
+  const axes = evidence.axes;
+  if (!axes || typeof axes !== 'object') {
+    throw new Error('validateEvidence: evidence.axes is required');
+  }
+  for (const axis of ['impact', 'opportunity', 'reasoning_depth']) {
+    const a = axes[axis];
+    if (!a || typeof a !== 'object') throw new Error(`validateEvidence: axes.${axis} is required`);
+    if (!Number.isInteger(a.score) || a.score < 1 || a.score > 5) {
+      throw new Error(`validateEvidence: axes.${axis}.score must be an integer 1-5`);
+    }
+    if (typeof a.rationale !== 'string' || a.rationale.trim() === '') {
+      throw new Error(`validateEvidence: axes.${axis}.rationale is required`);
+    }
+  }
+  if (typeof evidence.scored_by !== 'string' || evidence.scored_by.trim() === '') {
+    throw new Error('validateEvidence: scored_by is required');
+  }
+  return true;
+}
+
+/**
+ * Upsert one region's suitability score. History-preserving on (region_key, repo, score_version).
+ *
+ * @returns {Promise<{status:'ok', row:object} | {status:'CEREMONY_PENDING', reason:string}>}
+ */
+export async function upsertRegionScore(supabase, input) {
+  const region_key = normalizeRegionKey(input.region_key);
+  const repo = input.repo;
+  if (typeof repo !== 'string' || repo.trim() === '') {
+    throw new Error('upsertRegionScore: repo is required');
+  }
+  if (!Number.isInteger(input.score_version) || input.score_version < 1) {
+    throw new Error('upsertRegionScore: score_version must be a positive integer');
+  }
+  if (!VALID_DUTY_CLUSTERS.has(input.duty_cluster)) {
+    throw new Error(`upsertRegionScore: duty_cluster must be one of ${[...VALID_DUTY_CLUSTERS].join(', ')}`);
+  }
+  validateEvidence(input.evidence);
+
+  const row = {
+    region_key,
+    repo,
+    score_version: input.score_version,
+    duty_cluster: input.duty_cluster,
+    axis_impact: input.axis_impact ?? null,
+    axis_opportunity: input.axis_opportunity ?? null,
+    axis_reasoning_depth: input.axis_reasoning_depth ?? null,
+    composite_score: input.composite_score ?? null,
+    evidence: input.evidence,
+    recurrence_weight: input.recurrence_weight ?? null,
+    trigger_reason: input.trigger_reason ?? null,
+    status: input.status ?? 'scored',
+    last_scored_at: input.last_scored_at ?? new Date().toISOString(),
+    refloated_at: input.refloated_at ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from('fable_suitability_map')
+    .upsert(row, { onConflict: 'region_key,repo,score_version' })
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (isMissingTableError(error)) {
+      return {
+        status: 'CEREMONY_PENDING',
+        reason: 'fable_suitability_map STAGED migration not yet chairman-applied (Postgres 42P01); write skipped.',
+      };
+    }
+    throw new Error(`upsertRegionScore: ${error.message}`);
+  }
+  return { status: 'ok', row: data };
+}

--- a/tests/database/fable-suitability-map.db.test.js
+++ b/tests/database/fable-suitability-map.db.test.js
@@ -1,0 +1,107 @@
+/**
+ * Live-DB integration test for the Fable-suitability map writer/reader
+ * (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-A, TS-4).
+ *
+ * Defeats the mocked-seam trap: the unit tests (tests/unit/fable-suitability/map-writer.test.js)
+ * prove the code's control flow against a fake supabase, but they cannot prove the SQL contract —
+ * that the UNIQUE(region_key, repo, score_version) key actually preserves history, that the
+ * region_key CHECK actually rejects a drifting key, and that v_fable_suitability_map_current
+ * actually returns latest-per-region. This suite exercises the REAL table.
+ *
+ * Two-state design around the STAGED chairman-gate:
+ *   - Before the chairman apply ceremony, the table does not exist → the writer returns
+ *     CEREMONY_PENDING. We assert THAT typed state (proves the 42P01 seam against a real absent
+ *     table, not a mock).
+ *   - After apply, the same suite asserts the full history-preserving + current-view behavior.
+ * The `describeDb` guard skips the whole suite cleanly in the no-DB `unit` vitest project.
+ */
+import { afterAll, beforeAll, it, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { describeDb } from '../helpers/db-available.js';
+import { upsertRegionScore, EVIDENCE_SCHEMA_VERSION } from '../../lib/fable-suitability/map-writer.mjs';
+import { readCurrentMap, readRegionHistory } from '../../lib/fable-suitability/map-reader.mjs';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const TEST_REGION = 'ehg_engineer/__test__/fable-suitability-ts4';
+
+function evidence() {
+  return {
+    evidence_schema_version: EVIDENCE_SCHEMA_VERSION,
+    axes: {
+      impact: { score: 4, inputs: {}, rationale: 'ts4 impact' },
+      opportunity: { score: 3, inputs: {}, rationale: 'ts4 opportunity' },
+      reasoning_depth: { score: 5, inputs: {}, rationale: 'ts4 reasoning' },
+    },
+    recurrence: { weight: 1, count: 1, source_ids: ['ts4'] },
+    scored_by: 'ts4-integration-test',
+    computed_at: '2026-07-17T00:00:00.000Z',
+  };
+}
+
+async function tableExists() {
+  const { error } = await supabase.from('fable_suitability_map').select('id').limit(1);
+  return !error;
+}
+
+describeDb('fable_suitability_map — live persistence contract (TS-4)', () => {
+  let applied = false;
+
+  beforeAll(async () => {
+    applied = await tableExists();
+    if (applied) {
+      await supabase.from('fable_suitability_map').delete().eq('region_key', TEST_REGION);
+    }
+  });
+
+  afterAll(async () => {
+    if (applied) {
+      await supabase.from('fable_suitability_map').delete().eq('region_key', TEST_REGION);
+    }
+  });
+
+  it('writer returns CEREMONY_PENDING while the STAGED table is unapplied', async () => {
+    if (applied) return; // covered by the post-apply cases below
+    const res = await upsertRegionScore(supabase, {
+      region_key: TEST_REGION,
+      repo: 'EHG_Engineer',
+      score_version: 1,
+      duty_cluster: 'harness-depth',
+      evidence: evidence(),
+    });
+    expect(res.status).toBe('CEREMONY_PENDING');
+  });
+
+  it('history-preserving: a version bump appends; current view shows the latest', async () => {
+    if (!applied) return; // table not yet ceremonially applied
+    const v1 = await upsertRegionScore(supabase, {
+      region_key: TEST_REGION, repo: 'EHG_Engineer', score_version: 1,
+      duty_cluster: 'harness-depth', composite_score: 40, evidence: evidence(),
+    });
+    const v2 = await upsertRegionScore(supabase, {
+      region_key: TEST_REGION, repo: 'EHG_Engineer', score_version: 2,
+      duty_cluster: 'harness-depth', composite_score: 75, evidence: evidence(),
+    });
+    expect(v1.status).toBe('ok');
+    expect(v2.status).toBe('ok');
+
+    const history = await readRegionHistory(supabase, { regionKey: TEST_REGION, repo: 'EHG_Engineer' });
+    expect(history.status).toBe('ok');
+    expect(history.rows.length).toBe(2); // BOTH versions preserved
+
+    const current = await readCurrentMap(supabase, { dutyCluster: 'harness-depth' });
+    expect(current.status).toBe('ok');
+    const mine = current.rows.filter((r) => r.region_key === TEST_REGION);
+    expect(mine).toHaveLength(1); // exactly one row per region
+    expect(mine[0].score_version).toBe(2); // the latest
+  });
+
+  it('region_key CHECK rejects a drifting/path-derived key at the DB', async () => {
+    if (!applied) return;
+    // Bypass the app-layer normalizeRegionKey to prove the DB CHECK itself rejects a bad key.
+    const { error } = await supabase.from('fable_suitability_map').insert({
+      region_key: 'C:\\abs\\path', repo: 'EHG_Engineer', score_version: 1,
+      duty_cluster: 'harness-depth', evidence: evidence(),
+    });
+    expect(error).toBeTruthy(); // CHECK constraint refuses it
+  });
+});

--- a/tests/unit/fable-suitability/map-writer.test.js
+++ b/tests/unit/fable-suitability/map-writer.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeRegionKey,
+  validateEvidence,
+  isMissingTableError,
+  upsertRegionScore,
+  EVIDENCE_SCHEMA_VERSION,
+} from '../../../lib/fable-suitability/map-writer.mjs';
+
+/** Minimal evidence blob that satisfies validateEvidence. */
+function goodEvidence(overrides = {}) {
+  return {
+    evidence_schema_version: EVIDENCE_SCHEMA_VERSION,
+    axes: {
+      impact: { score: 4, inputs: {}, rationale: 'high blast radius' },
+      opportunity: { score: 3, inputs: {}, rationale: 'moderate churn' },
+      reasoning_depth: { score: 5, inputs: {}, rationale: 'deep cross-module reasoning' },
+    },
+    recurrence: { weight: 1.2, count: 3, source_ids: ['a', 'b', 'c'] },
+    scored_by: 'fable-scoring-engine',
+    computed_at: '2026-07-17T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Fake supabase whose .upsert(...).select().maybeSingle() resolves to a caller-supplied
+ * { data, error }. Records the table name it was pointed at (TS-5 table-name spy) and the
+ * onConflict target so we can assert the history-preserving key.
+ */
+function fakeSupabase({ data = null, error = null } = {}) {
+  const calls = { from: [], onConflict: [], rowUpserted: null };
+  const builder = {
+    upsert(row, opts) {
+      calls.rowUpserted = row;
+      calls.onConflict.push(opts?.onConflict);
+      return {
+        select() {
+          return { maybeSingle: async () => ({ data: data === '__echo__' ? row : data, error }) };
+        },
+      };
+    },
+  };
+  return {
+    calls,
+    from(table) {
+      calls.from.push(table);
+      return builder;
+    },
+  };
+}
+
+describe('normalizeRegionKey', () => {
+  it('canonicalizes case, backslashes, duplicate + edge slashes', () => {
+    expect(normalizeRegionKey('  EHG_Engineer\\Lib\\\\Sub-Agents/  ')).toBe('ehg_engineer/lib/sub-agents');
+  });
+  it('rejects empty / non-string', () => {
+    expect(() => normalizeRegionKey('')).toThrow();
+    expect(() => normalizeRegionKey(null)).toThrow();
+  });
+  it('rejects a key that cannot normalize to the canonical shape', () => {
+    // A colon is not permitted by the region_key CHECK regex; it must fail loud, not silently pass.
+    expect(() => normalizeRegionKey('c:foo')).toThrow();
+  });
+});
+
+describe('validateEvidence', () => {
+  it('accepts a well-formed evidence blob', () => {
+    expect(validateEvidence(goodEvidence())).toBe(true);
+  });
+  it('rejects wrong schema version', () => {
+    expect(() => validateEvidence(goodEvidence({ evidence_schema_version: 99 }))).toThrow();
+  });
+  it('rejects an out-of-range axis score', () => {
+    const ev = goodEvidence();
+    ev.axes.impact.score = 9;
+    expect(() => validateEvidence(ev)).toThrow();
+  });
+  it('rejects a missing rationale', () => {
+    const ev = goodEvidence();
+    ev.axes.opportunity.rationale = '';
+    expect(() => validateEvidence(ev)).toThrow();
+  });
+});
+
+describe('isMissingTableError', () => {
+  it('types PGRST205 (the REAL supabase-js/PostgREST missing-table code) as missing-table', () => {
+    // This is what the live DB actually returns for an absent table — verified against the real
+    // Supabase project. The raw-SQL 42P01 below never surfaces on the .from() path.
+    expect(isMissingTableError({
+      code: 'PGRST205',
+      message: "Could not find the table 'public.fable_suitability_map' in the schema cache",
+    })).toBe(true);
+  });
+  it('types raw Postgres 42P01 as missing-table (direct-SQL / RPC path)', () => {
+    expect(isMissingTableError({ code: '42P01' })).toBe(true);
+  });
+  it('does NOT type an unrelated error as missing-table (no blanket catch)', () => {
+    expect(isMissingTableError({ code: '23505', message: 'duplicate key' })).toBe(false);
+    expect(isMissingTableError({ code: 'PGRST116', message: 'no rows' })).toBe(false);
+    expect(isMissingTableError(null)).toBe(false);
+  });
+});
+
+describe('upsertRegionScore', () => {
+  it('TS-1: history-preserving — upserts on (region_key, repo, score_version) and targets fable_suitability_map', async () => {
+    const supabase = fakeSupabase({ data: '__echo__' });
+    const res = await upsertRegionScore(supabase, {
+      region_key: 'EHG_Engineer/lib/gates',
+      repo: 'EHG_Engineer',
+      score_version: 2,
+      duty_cluster: 'harness-depth',
+      axis_impact: 4,
+      axis_opportunity: 3,
+      axis_reasoning_depth: 5,
+      composite_score: 60,
+      evidence: goodEvidence(),
+    });
+    expect(res.status).toBe('ok');
+    expect(supabase.calls.from).toContain('fable_suitability_map'); // TS-5 table-name spy
+    expect(supabase.calls.onConflict).toContain('region_key,repo,score_version');
+    expect(supabase.calls.rowUpserted.region_key).toBe('ehg_engineer/lib/gates'); // normalized
+  });
+
+  it('TS-2: typed CEREMONY_PENDING on 42P01, not a throw', async () => {
+    const supabase = fakeSupabase({ error: { code: '42P01', message: 'relation "fable_suitability_map" does not exist' } });
+    const res = await upsertRegionScore(supabase, {
+      region_key: 'ehg/app',
+      repo: 'EHG',
+      score_version: 1,
+      duty_cluster: 'dedup',
+      evidence: goodEvidence(),
+    });
+    expect(res.status).toBe('CEREMONY_PENDING');
+  });
+
+  it('TS-3a: a non-42P01 DB error propagates (not swallowed as ceremony-pending)', async () => {
+    const supabase = fakeSupabase({ error: { code: '23514', message: 'check constraint violated' } });
+    await expect(
+      upsertRegionScore(supabase, {
+        region_key: 'ehg/app',
+        repo: 'EHG',
+        score_version: 1,
+        duty_cluster: 'dedup',
+        evidence: goodEvidence(),
+      }),
+    ).rejects.toThrow(/check constraint/);
+  });
+
+  it('TS-3b: rejects an invalid duty_cluster before touching the DB', async () => {
+    const supabase = fakeSupabase({ data: '__echo__' });
+    await expect(
+      upsertRegionScore(supabase, {
+        region_key: 'ehg/app',
+        repo: 'EHG',
+        score_version: 1,
+        duty_cluster: 'not-a-cluster',
+        evidence: goodEvidence(),
+      }),
+    ).rejects.toThrow(/duty_cluster/);
+    expect(supabase.calls.from).toHaveLength(0); // guarded before any DB call
+  });
+});


### PR DESCRIPTION
## Summary
Child A of the Fable-suitability orchestrator (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001). Delivers the **durable, gradeable persistence layer** for Fable-region suitability scores. Children B (scoring engine) and C (Solomon Mode-B fan-out) build on this seam.

## What's here
- **STAGED chairman-gated migration** `20260717_fable_suitability_map_STAGED.sql`
  - `UNIQUE (region_key, repo, score_version)` — history-preserving: a version bump appends (preserving the prediction Solomon's section-11 advice-outcome ledger will later grade); a same-version re-score upserts in place.
  - `region_key` CHECK + regex — rejects a drifting / backslash / absolute-path key so child B can't fork the ledger JOIN.
  - `v_fable_suitability_map_current` view — latest score_version per region.
  - RLS `fn_is_chairman()` SELECT-only + **no** write policy (service_role writes; humans read chairman-only). RLS + policy in the same file (SPINE-001-B guard).
  - **No `@approved-by`** — requires the chairman apply ceremony (4-step runbook in the file header).
- **`lib/fable-suitability/map-writer.mjs`** — `upsertRegionScore`, `normalizeRegionKey`, `validateEvidence`, typed `CEREMONY_PENDING`.
- **`lib/fable-suitability/map-reader.mjs`** — `readCurrentMap` (via the view) + `readRegionHistory` (all versions for ledger grading).
- **Tests** — 13 unit (mocked seam) + real-DB `skipIf` integration (TS-4).

## Mocked-seam trap caught
The real-DB test surfaced that PostgREST returns **`PGRST205`** ("Could not find the table … in the schema cache") for an absent table on the `.from()` path — **not** raw Postgres `42P01`. The unit mock's `42P01` had hidden this. `isMissingTableError` now types **both** codes (narrow, no blanket catch), verified live against the unapplied STAGED table.

## Apply
STAGED — do not auto-apply on merge. The writer's typed `CEREMONY_PENDING` flips to live automatically once the chairman applies the migration; no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)