### PR TITLE
feat(SD-LEO-INFRA-TIME-CRITICAL-SEAL-001): Fable-5 baseline seal attestation tooling

### DIFF
--- a/lib/eval/__tests__/verify-baseline-seal.test.js
+++ b/lib/eval/__tests__/verify-baseline-seal.test.js
@@ -74,6 +74,42 @@ describe('verifyBaselineSeal', () => {
     expect(r.reasons.join(' ')).toMatch(/1 answer_key row\(s\) missing task_text/);
   });
 
+  it('INCOMPLETE when a duplicate answer_key task_id masks a fully-missing task, even though total count (10) and shape coverage look correct (adversarial /ship review finding)', () => {
+    // Re-point one existing key's task_id onto another existing key's task_id.
+    // Net effect: the target task now has TWO answer_key rows (duplicate), the
+    // source task has ZERO (fully missing) — but keys.length stays 10 and every
+    // shape is still represented (R2-negative-space survives via its sibling task),
+    // so the pre-fix count+shape-only checks would have reported SEALED.
+    const rows = buildCorpus();
+    const orphanedKey = rows.find((r) => r.metadata.record_kind === 'answer_key' && r.metadata.task_id === 'FAB5-R2-02');
+    orphanedKey.metadata.task_id = 'FAB5-R2-01'; // now duplicates FAB5-R2-01's key; FAB5-R2-02 has none
+
+    const r = verifyBaselineSeal(rows);
+    expect(r.stats.keys).toBe(10); // total count is unchanged — the trap
+    expect(r.stats.shapes_covered).toContain('R2-negative-space'); // shape still covered — the trap
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/duplicate answer_key task_id\(s\): FAB5-R2-01/);
+    expect(r.reasons.join(' ')).toMatch(/task\(s\) with sealed_run\(s\) but no answer_key: FAB5-R2-02/);
+  });
+
+  it('INCOMPLETE when a task has sealed_runs but no answer_key (or vice versa), even though raw run count (30) is unchanged (adversarial /ship review finding)', () => {
+    // Re-point one task's sealed_run rows onto another task's task_id. Net effect:
+    // one task vanishes from the run side entirely while its answer_key remains —
+    // runs.length stays 30 and the target task still has all 3 effort tiers (now
+    // duplicated), so tasksMissingTiers alone would not flag it.
+    const rows = buildCorpus();
+    rows.forEach((r) => {
+      if (r.metadata.record_kind === 'sealed_run' && r.metadata.task_id === 'FAB5-R3-02') {
+        r.metadata.task_id = 'FAB5-R3-01';
+      }
+    });
+
+    const r = verifyBaselineSeal(rows);
+    expect(r.stats.runs).toBe(30); // total count is unchanged — the trap
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/task\(s\) with an answer_key but no sealed_run: FAB5-R3-02/);
+  });
+
   it('INCOMPLETE on a foreign-model run (only Fable-5 answers belong in the seal)', () => {
     const rows = buildCorpus();
     rows.find((x) => x.metadata.record_kind === 'sealed_run').metadata.model_id = 'claude-opus-5';

--- a/lib/eval/__tests__/verify-baseline-seal.test.js
+++ b/lib/eval/__tests__/verify-baseline-seal.test.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-TIME-CRITICAL-SEAL-001 — pure baseline-seal attestation.
+ */
+import { describe, it, expect } from 'vitest';
+import { verifyBaselineSeal, SEAL_SHAPES, SEAL_EFFORTS, SEAL_MODEL } from '../verify-baseline-seal.mjs';
+
+const TASKS = ['FAB5-MECH-01', 'FAB5-R1-01', 'FAB5-R2-01', 'FAB5-R2-02', 'FAB5-R3-01', 'FAB5-R3-02', 'FAB5-R4-01', 'FAB5-R4-02', 'FAB5-R5-01', 'FAB5-R5-02'];
+const SHAPE_OF = {
+  'FAB5-MECH-01': 'mechanical-baseline', 'FAB5-R1-01': 'R1-compounding',
+  'FAB5-R2-01': 'R2-negative-space', 'FAB5-R2-02': 'R2-negative-space',
+  'FAB5-R3-01': 'R3-taste', 'FAB5-R3-02': 'R3-taste',
+  'FAB5-R4-01': 'R4-coupling', 'FAB5-R4-02': 'R4-coupling',
+  'FAB5-R5-01': 'R5-reversal', 'FAB5-R5-02': 'R5-reversal',
+};
+
+/** Build a corpus mirroring the real seal: 10 keys + 10 tasks × 3 efforts. */
+function buildCorpus({ withTelemetryTiers = ['high'], dropAnswer = 0, dropKeys = 0, dropTaskText = 0 } = {}) {
+  const rows = [];
+  let droppedTaskText = 0;
+  TASKS.slice(0, TASKS.length - dropKeys).forEach((t) => {
+    const hasTaskText = droppedTaskText < dropTaskText ? (droppedTaskText++, false) : true;
+    rows.push({ metadata: { record_kind: 'answer_key', task_id: t, shape: SHAPE_OF[t], answer_key: 'reality-adjudicated key ' + t, task_text: hasTaskText ? 'task prompt text for ' + t : undefined, content_hash: 'kh_' + t } });
+  });
+  let dropped = 0;
+  TASKS.forEach((t) => {
+    SEAL_EFFORTS.forEach((e) => {
+      const withTel = withTelemetryTiers.includes(e);
+      const m = {
+        record_kind: 'sealed_run', task_id: t, shape: SHAPE_OF[t], model_id: SEAL_MODEL, effort: e,
+        fable5_answer: (dropped < dropAnswer ? (dropped++, null) : 'fable5 answer for ' + t + '/' + e),
+        content_hash: 'rh_' + t + '_' + e,
+        tokens: withTel ? 40000 : null, wall_clock_ms: withTel ? 120000 : null,
+      };
+      rows.push({ metadata: m });
+    });
+  });
+  return rows;
+}
+
+describe('verifyBaselineSeal', () => {
+  it('SEALED when 10 keys + 30 runs complete, warns on low/medium telemetry gap', () => {
+    const r = verifyBaselineSeal(buildCorpus({ withTelemetryTiers: ['high'] }));
+    expect(r.verdict).toBe('SEALED');
+    expect(r.reasons).toEqual([]);
+    expect(r.stats.keys).toBe(10);
+    expect(r.stats.runs).toBe(30);
+    expect(r.stats.shapes_covered.sort()).toEqual([...SEAL_SHAPES].sort());
+    expect(r.stats.telemetry_complete_tiers).toEqual(['high']);
+    expect(r.warnings.join(' ')).toMatch(/telemetry missing/);
+  });
+
+  it('SEALED with no warnings when all tiers have telemetry', () => {
+    const r = verifyBaselineSeal(buildCorpus({ withTelemetryTiers: ['low', 'medium', 'high'] }));
+    expect(r.verdict).toBe('SEALED');
+    expect(r.warnings).toEqual([]);
+    expect(r.stats.telemetry_gap_tiers).toEqual([]);
+  });
+
+  it('INCOMPLETE when a sealed run is missing its fable5_answer (the ungeneratable artifact)', () => {
+    const r = verifyBaselineSeal(buildCorpus({ dropAnswer: 1 }));
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/missing fable5_answer/);
+  });
+
+  it('INCOMPLETE when answer keys are missing (count + shape coverage)', () => {
+    const r = verifyBaselineSeal(buildCorpus({ dropKeys: 1 }));
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/answer_key count 9/);
+  });
+
+  it('INCOMPLETE when an answer_key row is missing task_text (SD-LEO-INFRA-TIME-CRITICAL-SEAL-001 LEAD finding: golden-task-loader.mjs requires it)', () => {
+    const r = verifyBaselineSeal(buildCorpus({ dropTaskText: 1 }));
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/1 answer_key row\(s\) missing task_text/);
+  });
+
+  it('INCOMPLETE on a foreign-model run (only Fable-5 answers belong in the seal)', () => {
+    const rows = buildCorpus();
+    rows.find((x) => x.metadata.record_kind === 'sealed_run').metadata.model_id = 'claude-opus-5';
+    const r = verifyBaselineSeal(rows);
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/not model claude-fable-5/);
+  });
+
+  it('fail-closed on empty input', () => {
+    const r = verifyBaselineSeal([]);
+    expect(r.verdict).toBe('INCOMPLETE');
+  });
+
+  it('redaction regression: sentinel answer_key/task_text/fable5_answer values never appear in the verifier result, SEALED or INCOMPLETE (PLAN-phase SECURITY recommendation)', () => {
+    const SENTINEL_KEY = 'SENTINEL-ANSWER-KEY-DO-NOT-LEAK-8f3c9a';
+    const SENTINEL_TASK_TEXT = 'SENTINEL-TASK-TEXT-DO-NOT-LEAK-2b7e14';
+    const SENTINEL_ANSWER = 'SENTINEL-FABLE5-ANSWER-DO-NOT-LEAK-91da02';
+
+    const sealedRows = buildCorpus();
+    sealedRows.forEach((row) => {
+      if (row.metadata.record_kind === 'answer_key') {
+        row.metadata.answer_key = SENTINEL_KEY;
+        row.metadata.task_text = SENTINEL_TASK_TEXT;
+      } else {
+        row.metadata.fable5_answer = SENTINEL_ANSWER;
+      }
+    });
+    const sealed = verifyBaselineSeal(sealedRows);
+    expect(sealed.verdict).toBe('SEALED');
+    const sealedJson = JSON.stringify(sealed);
+    expect(sealedJson).not.toContain(SENTINEL_KEY);
+    expect(sealedJson).not.toContain(SENTINEL_TASK_TEXT);
+    expect(sealedJson).not.toContain(SENTINEL_ANSWER);
+
+    // Same check on the INCOMPLETE path (reasons array is human-readable text —
+    // must never interpolate the actual sensitive value, only counts/labels).
+    const incompleteRows = buildCorpus({ dropAnswer: 1 });
+    incompleteRows.forEach((row) => {
+      if (row.metadata.record_kind === 'answer_key') {
+        row.metadata.answer_key = SENTINEL_KEY;
+        row.metadata.task_text = SENTINEL_TASK_TEXT;
+      } else if (row.metadata.fable5_answer) {
+        row.metadata.fable5_answer = SENTINEL_ANSWER;
+      }
+    });
+    const incomplete = verifyBaselineSeal(incompleteRows);
+    expect(incomplete.verdict).toBe('INCOMPLETE');
+    const incompleteJson = JSON.stringify(incomplete);
+    expect(incompleteJson).not.toContain(SENTINEL_KEY);
+    expect(incompleteJson).not.toContain(SENTINEL_TASK_TEXT);
+    expect(incompleteJson).not.toContain(SENTINEL_ANSWER);
+  });
+});

--- a/lib/eval/__tests__/verify-baseline-seal.test.js
+++ b/lib/eval/__tests__/verify-baseline-seal.test.js
@@ -110,6 +110,24 @@ describe('verifyBaselineSeal', () => {
     expect(r.reasons.join(' ')).toMatch(/task\(s\) with an answer_key but no sealed_run: FAB5-R3-02/);
   });
 
+  it('INCOMPLETE when an answer_key row is missing task_id (round-2 adversarial /ship review finding: identity must be asserted, not just count/shape/duplicate-freedom)', () => {
+    const rows = buildCorpus();
+    const key = rows.find((r) => r.metadata.record_kind === 'answer_key' && r.metadata.task_id === 'FAB5-MECH-01');
+    delete key.metadata.task_id;
+    const r = verifyBaselineSeal(rows);
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/1 answer_key row\(s\) missing task_id/);
+  });
+
+  it('INCOMPLETE when a sealed_run row is missing task_id (round-2 adversarial /ship review finding)', () => {
+    const rows = buildCorpus();
+    const run = rows.find((r) => r.metadata.record_kind === 'sealed_run' && r.metadata.task_id === 'FAB5-MECH-01');
+    delete run.metadata.task_id;
+    const r = verifyBaselineSeal(rows);
+    expect(r.verdict).toBe('INCOMPLETE');
+    expect(r.reasons.join(' ')).toMatch(/1 sealed_run\(s\) missing task_id/);
+  });
+
   it('INCOMPLETE on a foreign-model run (only Fable-5 answers belong in the seal)', () => {
     const rows = buildCorpus();
     rows.find((x) => x.metadata.record_kind === 'sealed_run').metadata.model_id = 'claude-opus-5';

--- a/lib/eval/verify-baseline-seal.mjs
+++ b/lib/eval/verify-baseline-seal.mjs
@@ -49,9 +49,16 @@ export function verifyBaselineSeal(rows, { expectedKeys = 10, expectedRuns = 30 
   // ends up with a task it can't load. Never log task.task_text itself here — only
   // the count of rows missing it (contamination guard).
   const keysMissingTaskText = keys.filter((k) => !k.task_text).length;
+  // Round-2 adversarial /ship review finding: the completeness logic keys purely off
+  // task_id equality (Map/Set) with no assertion that task_id itself is a real,
+  // non-falsy identifier. A single task whose key+runs all coincidentally share the
+  // same falsy task_id (e.g. undefined, from a shared upstream serialization bug)
+  // would otherwise pass every other check silently.
+  const keysMissingTaskId = keys.filter((k) => !k.task_id).length;
   if (keysMissingText) reasons.push(`${keysMissingText} answer_key row(s) missing answer_key text`);
   if (keysMissingTaskText) reasons.push(`${keysMissingTaskText} answer_key row(s) missing task_text`);
   if (keysMissingHash) reasons.push(`${keysMissingHash} answer_key row(s) missing content_hash`);
+  if (keysMissingTaskId) reasons.push(`${keysMissingTaskId} answer_key row(s) missing task_id`);
   const keyShapes = new Set(keys.map((k) => k.shape));
   const missingShapes = SEAL_SHAPES.filter((s) => !keyShapes.has(s));
   if (missingShapes.length) reasons.push(`answer keys miss shape(s): ${missingShapes.join(', ')}`);
@@ -70,8 +77,10 @@ export function verifyBaselineSeal(rows, { expectedKeys = 10, expectedRuns = 30 
   if (runs.length !== expectedRuns) reasons.push(`sealed_run count ${runs.length} != expected ${expectedRuns}`);
   const runsMissingAnswer = runs.filter((r) => !r.fable5_answer).length;
   const runsMissingHash = runs.filter((r) => !r.content_hash).length;
+  const runsMissingTaskId = runs.filter((r) => !r.task_id).length;
   if (runsMissingAnswer) reasons.push(`${runsMissingAnswer} sealed_run(s) missing fable5_answer (the ungeneratable artifact)`);
   if (runsMissingHash) reasons.push(`${runsMissingHash} sealed_run(s) missing content_hash`);
+  if (runsMissingTaskId) reasons.push(`${runsMissingTaskId} sealed_run(s) missing task_id`);
   const foreignModel = runs.filter((r) => r.model_id !== SEAL_MODEL);
   if (foreignModel.length) reasons.push(`${foreignModel.length} sealed_run(s) not model ${SEAL_MODEL}`);
 

--- a/lib/eval/verify-baseline-seal.mjs
+++ b/lib/eval/verify-baseline-seal.mjs
@@ -56,6 +56,16 @@ export function verifyBaselineSeal(rows, { expectedKeys = 10, expectedRuns = 30 
   const missingShapes = SEAL_SHAPES.filter((s) => !keyShapes.has(s));
   if (missingShapes.length) reasons.push(`answer keys miss shape(s): ${missingShapes.join(', ')}`);
 
+  // Adversarial /ship review finding: total-count and shape-set checks alone can be
+  // fooled — a duplicate answer_key row for one task can offset another task's total
+  // absence and still hit expectedKeys/all-shapes-covered, since two sibling tasks
+  // often share a shape (e.g. both R2-negative-space tasks). Catch this directly by
+  // requiring exactly one answer_key per task_id.
+  const keyTaskIdCounts = new Map();
+  for (const k of keys) keyTaskIdCounts.set(k.task_id, (keyTaskIdCounts.get(k.task_id) || 0) + 1);
+  const duplicateKeyTasks = [...keyTaskIdCounts.entries()].filter(([, c]) => c > 1).map(([t]) => t);
+  if (duplicateKeyTasks.length) reasons.push(`duplicate answer_key task_id(s): ${duplicateKeyTasks.join(', ')}`);
+
   // Sealed runs: count, the load-bearing fable5_answer, hash, model, effort matrix.
   if (runs.length !== expectedRuns) reasons.push(`sealed_run count ${runs.length} != expected ${expectedRuns}`);
   const runsMissingAnswer = runs.filter((r) => !r.fable5_answer).length;
@@ -78,6 +88,19 @@ export function verifyBaselineSeal(rows, { expectedKeys = 10, expectedRuns = 30 
     .filter(([, set]) => SEAL_EFFORTS.some((e) => !set.has(e)))
     .map(([t]) => t);
   if (tasksMissingTiers.length) reasons.push(`task(s) missing effort tiers: ${tasksMissingTiers.join(', ')}`);
+
+  // Adversarial /ship review finding: tasksMissingTiers only inspects task_ids that
+  // actually APPEAR in sealed_run — a task with ZERO runs at all is invisible to it
+  // (never registered in byTask), and duplicate runs for another task can offset the
+  // total count back to expectedRuns. A bidirectional set-compare between answer_key
+  // task_ids and sealed_run task_ids catches a task missing entirely from either side,
+  // independent of totals.
+  const keyTaskIdSet = new Set(keys.map((k) => k.task_id));
+  const runTaskIdSet = new Set(byTask.keys());
+  const tasksMissingFromRuns = [...keyTaskIdSet].filter((t) => !runTaskIdSet.has(t));
+  const tasksMissingFromKeys = [...runTaskIdSet].filter((t) => !keyTaskIdSet.has(t));
+  if (tasksMissingFromRuns.length) reasons.push(`task(s) with an answer_key but no sealed_run: ${tasksMissingFromRuns.join(', ')}`);
+  if (tasksMissingFromKeys.length) reasons.push(`task(s) with sealed_run(s) but no answer_key: ${tasksMissingFromKeys.join(', ')}`);
 
   // Telemetry gap (WARNING, not fail): tokens/wall_clock on low/medium tiers.
   const tokenGapTiers = {};

--- a/lib/eval/verify-baseline-seal.mjs
+++ b/lib/eval/verify-baseline-seal.mjs
@@ -1,0 +1,108 @@
+/**
+ * Fable-5 baseline-seal verification — SD-LEO-INFRA-TIME-CRITICAL-SEAL-001.
+ *
+ * The Fable-5 golden-task answers are the ONLY window-dependent, ungeneratable-
+ * after-2026-07-19 artifact (chairman intel: Fable access ends ~07-19). This
+ * PURE attestation asserts the sealed corpus in feedback.category=
+ * 'model_capability_baseline' is complete and integrity-hashed, so downstream
+ * consumers (golden-task-loader, migrate-sealed-baselines, ground-truth-gate)
+ * can grade it later — grading is DEFERRED to the cross-model harness / Opus-5
+ * first run BY DESIGN (docs/design/solomon-fable-capability-grounding.md Part 4;
+ * each sealed_run's run_context confirms "grading belongs to the eval harness").
+ *
+ * Verdict is SEALED iff every expected answer (fable5_answer) + answer key is
+ * present with a content_hash. Token/wall-clock telemetry gaps on the low/medium
+ * tiers are REPORTED as a known limitation (not a fail): re-running to backfill
+ * telemetry would produce different answers and break the content-hash seal, so
+ * the captured answers — the load-bearing artifact — take precedence.
+ */
+
+export const SEAL_SUITE = 'FABLE5-BASELINE-2026-07-16';
+export const SEAL_MODEL = 'claude-fable-5';
+export const SEAL_EFFORTS = Object.freeze(['low', 'medium', 'high']);
+export const SEAL_SHAPES = Object.freeze([
+  'R1-compounding', 'R2-negative-space', 'R3-taste', 'R4-coupling', 'R5-reversal', 'mechanical-baseline',
+]);
+
+/**
+ * @param {Array<{metadata?:Object}>} rows - feedback rows (category=model_capability_baseline)
+ * @param {Object} [opts]
+ * @param {number} [opts.expectedKeys=10]  - one answer_key per task
+ * @param {number} [opts.expectedRuns=30]  - tasks × effort tiers
+ * @returns {{verdict:'SEALED'|'INCOMPLETE', reasons:string[], warnings:string[], stats:Object}}
+ */
+export function verifyBaselineSeal(rows, { expectedKeys = 10, expectedRuns = 30 } = {}) {
+  const meta = (rows || []).map((r) => r?.metadata || r?.payload || {}).filter((m) => m && m.record_kind);
+  const keys = meta.filter((m) => m.record_kind === 'answer_key');
+  const runs = meta.filter((m) => m.record_kind === 'sealed_run');
+
+  const reasons = [];
+  const warnings = [];
+
+  // Answer keys: count, hash, key text, task text, shape coverage.
+  if (keys.length !== expectedKeys) reasons.push(`answer_key count ${keys.length} != expected ${expectedKeys}`);
+  const keysMissingText = keys.filter((k) => !k.answer_key).length;
+  const keysMissingHash = keys.filter((k) => !k.content_hash).length;
+  // LEAD-phase Explore finding: golden-task-loader.mjs requires task_text on these
+  // same rows to populate GoldenTask#taskText. A seal that verifies answer_key text
+  // but not task_text would let SEALED pass while the actual eval-harness consumer
+  // ends up with a task it can't load. Never log task.task_text itself here — only
+  // the count of rows missing it (contamination guard).
+  const keysMissingTaskText = keys.filter((k) => !k.task_text).length;
+  if (keysMissingText) reasons.push(`${keysMissingText} answer_key row(s) missing answer_key text`);
+  if (keysMissingTaskText) reasons.push(`${keysMissingTaskText} answer_key row(s) missing task_text`);
+  if (keysMissingHash) reasons.push(`${keysMissingHash} answer_key row(s) missing content_hash`);
+  const keyShapes = new Set(keys.map((k) => k.shape));
+  const missingShapes = SEAL_SHAPES.filter((s) => !keyShapes.has(s));
+  if (missingShapes.length) reasons.push(`answer keys miss shape(s): ${missingShapes.join(', ')}`);
+
+  // Sealed runs: count, the load-bearing fable5_answer, hash, model, effort matrix.
+  if (runs.length !== expectedRuns) reasons.push(`sealed_run count ${runs.length} != expected ${expectedRuns}`);
+  const runsMissingAnswer = runs.filter((r) => !r.fable5_answer).length;
+  const runsMissingHash = runs.filter((r) => !r.content_hash).length;
+  if (runsMissingAnswer) reasons.push(`${runsMissingAnswer} sealed_run(s) missing fable5_answer (the ungeneratable artifact)`);
+  if (runsMissingHash) reasons.push(`${runsMissingHash} sealed_run(s) missing content_hash`);
+  const foreignModel = runs.filter((r) => r.model_id !== SEAL_MODEL);
+  if (foreignModel.length) reasons.push(`${foreignModel.length} sealed_run(s) not model ${SEAL_MODEL}`);
+
+  // Effort × task matrix: each task should have all three effort tiers.
+  // PLAN-phase SECURITY finding: a plain object keyed by task_id crashes on a
+  // task_id of '__proto__' (Object.prototype method returned instead of a Set) —
+  // a Map has no such collision, even on this trusted internal data path.
+  const byTask = new Map();
+  for (const r of runs) {
+    if (!byTask.has(r.task_id)) byTask.set(r.task_id, new Set());
+    byTask.get(r.task_id).add(r.effort);
+  }
+  const tasksMissingTiers = [...byTask.entries()]
+    .filter(([, set]) => SEAL_EFFORTS.some((e) => !set.has(e)))
+    .map(([t]) => t);
+  if (tasksMissingTiers.length) reasons.push(`task(s) missing effort tiers: ${tasksMissingTiers.join(', ')}`);
+
+  // Telemetry gap (WARNING, not fail): tokens/wall_clock on low/medium tiers.
+  const tokenGapTiers = {};
+  for (const e of SEAL_EFFORTS) {
+    const tier = runs.filter((r) => r.effort === e);
+    const missTokens = tier.filter((r) => r.tokens == null).length;
+    if (missTokens) tokenGapTiers[e] = missTokens;
+  }
+  if (Object.keys(tokenGapTiers).length) {
+    warnings.push(`token/wall-clock telemetry missing on tiers ${JSON.stringify(tokenGapTiers)} — NOT recoverable (re-run would change answers + break the seal); cost_norm unavailable for those tiers, high tier has full telemetry`);
+  }
+
+  const stats = {
+    keys: keys.length,
+    runs: runs.length,
+    shapes_covered: [...keyShapes],
+    tasks: byTask.size,
+    telemetry_complete_tiers: SEAL_EFFORTS.filter((e) => !tokenGapTiers[e]),
+    telemetry_gap_tiers: Object.keys(tokenGapTiers),
+  };
+
+  return {
+    verdict: reasons.length === 0 ? 'SEALED' : 'INCOMPLETE',
+    reasons,
+    warnings,
+    stats,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -482,6 +482,7 @@
     "fleet:freeze-drill": "node scripts/freeze-drill.mjs",
     "sre:scripts-reachability": "node scripts/scripts-reachability-gauge.mjs",
     "subagents:collect": "node scripts/collect-subagent-evidence.js",
+    "eval:verify-fable5-seal": "node scripts/eval/verify-fable5-baseline-seal.mjs",
     "gov:situation-report": "node scripts/governance/catch-layer-migration-report.mjs",
     "gov:register-loop": "node scripts/governance/register-governance-situation-loop.mjs",
     "gov:run-probes": "node lib/governance/probe-runner.mjs",

--- a/scripts/eval/verify-fable5-baseline-seal.mjs
+++ b/scripts/eval/verify-fable5-baseline-seal.mjs
@@ -61,6 +61,12 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(`Fatal: unexpected error: ${err?.message || err}`);
+  // Round-2 adversarial /ship review finding: set exitCode BEFORE the console.error
+  // call, not after — if the error write itself throws (e.g. EPIPE on a closed pipe),
+  // the exit-code assignment must already be in effect, or the process could fall
+  // through to the default exit code (0) for what should be a hard failure.
   process.exitCode = 1;
+  try {
+    console.error(`Fatal: unexpected error: ${err?.message || err}`);
+  } catch { /* stderr write failed — exitCode is already set above */ }
 });

--- a/scripts/eval/verify-fable5-baseline-seal.mjs
+++ b/scripts/eval/verify-fable5-baseline-seal.mjs
@@ -24,7 +24,11 @@ async function main() {
     .eq('category', 'model_capability_baseline');
   if (error) {
     console.error(`Fatal: baseline corpus read failed: ${error.message}`);
-    process.exit(1);
+    // Same process.exitCode reasoning as below — a forced process.exit() right after
+    // this Supabase query returns is exactly when its HTTP handle is still closing;
+    // this branch is even MORE likely to hit the libuv race than the success path.
+    process.exitCode = 1;
+    return;
   }
 
   const result = verifyBaselineSeal(data || []);
@@ -56,4 +60,7 @@ async function main() {
   process.exitCode = result.verdict === 'SEALED' ? 0 : 1;
 }
 
-main();
+main().catch((err) => {
+  console.error(`Fatal: unexpected error: ${err?.message || err}`);
+  process.exitCode = 1;
+});

--- a/scripts/eval/verify-fable5-baseline-seal.mjs
+++ b/scripts/eval/verify-fable5-baseline-seal.mjs
@@ -1,0 +1,59 @@
+/**
+ * CLI: attest the Fable-5 golden-task baseline seal is complete before the Fable
+ * window closes (~2026-07-19). SD-LEO-INFRA-TIME-CRITICAL-SEAL-001 FR-1/FR-3.
+ *
+ * Reads the sealed corpus DB-side (feedback.category='model_capability_baseline'),
+ * runs the pure verifier, and prints a machine-readable verdict. Redaction: never
+ * prints task_text or answer_key (contamination guard) — only counts/shape/hash.
+ *
+ * Usage: npm run eval:verify-fable5-seal
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { verifyBaselineSeal, SEAL_SUITE } from '../../lib/eval/verify-baseline-seal.mjs';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+async function main() {
+  const { data, error } = await supabase
+    .from('feedback')
+    .select('id, metadata')
+    .eq('category', 'model_capability_baseline');
+  if (error) {
+    console.error(`Fatal: baseline corpus read failed: ${error.message}`);
+    process.exit(1);
+  }
+
+  const result = verifyBaselineSeal(data || []);
+
+  console.log(`Fable-5 Baseline Seal Verification (${SEAL_SUITE})`);
+  console.log('='.repeat(60));
+  console.log(`Verdict: ${result.verdict}`);
+  console.log(`Answer keys: ${result.stats.keys} | Sealed runs: ${result.stats.runs} | Tasks: ${result.stats.tasks}`);
+  console.log(`Shapes covered: ${result.stats.shapes_covered.sort().join(', ')}`);
+  console.log(`Telemetry-complete tiers: ${result.stats.telemetry_complete_tiers.join(', ') || 'none'}`);
+  if (result.reasons.length) {
+    console.log('\nBLOCKING reasons:');
+    for (const r of result.reasons) console.log(`  - ${r}`);
+  }
+  if (result.warnings.length) {
+    console.log('\nWarnings (known limitations, non-blocking):');
+    for (const w of result.warnings) console.log(`  - ${w}`);
+  }
+  console.log(`\nBASELINE_SEAL_VERDICT=${JSON.stringify({ verdict: result.verdict, stats: result.stats })}`);
+
+  // SEALED => the window-critical artifact is secured (exit 0). INCOMPLETE => the
+  // answers/keys have a real gap that must be closed while Fable is still live.
+  // process.exitCode (not process.exit()) lets the event loop drain naturally —
+  // a forced exit() here races the Supabase client's still-closing HTTP handle and
+  // crashes with a Windows libuv assertion (UV_HANDLE_CLOSING) AFTER the verdict is
+  // printed, corrupting the real exit code to 127. A CI step keying on $? (rather
+  // than parsing the BASELINE_SEAL_VERDICT line) would misread a genuine SEALED
+  // result as a failure.
+  process.exitCode = result.verdict === 'SEALED' ? 0 : 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
- Chairman-approved (Solomon Mode-C handoff, ledger 4eb2b4ab), hard deadline ~2026-07-19: the Fable-5 golden-task baseline answers are already sealed live in the DB (10 answer_key + 30 sealed_run rows, feedback.category='model_capability_baseline') — this PR ships the formal attestation tooling that confirms and locks in that seal for future consumers (golden-task-loader.mjs, migrate-sealed-baselines.mjs, ground-truth-gate.mjs).
- `lib/eval/verify-baseline-seal.mjs`: pure `verifyBaselineSeal()` asserting corpus completeness (keys, hashes, shape coverage, effort-tier matrix, model identity, and task_text presence).
- `scripts/eval/verify-fable5-baseline-seal.mjs`: CLI wrapper (`npm run eval:verify-fable5-seal`), machine-readable verdict line, never logs sensitive content.
- `lib/eval/__tests__/verify-baseline-seal.test.js`: 8 tests including a sentinel-based redaction regression test.
- Two real gaps found and fixed during sub-agent review: a Windows libuv exit-code corruption bug (`process.exit()` → `process.exitCode`) and a missing `task_text` completeness check needed by the downstream loader.
- Prototype-pollution hardening: effort×task matrix converted from a plain object to a `Map`.

## Test plan
- [x] `npx vitest run lib/eval/__tests__/verify-baseline-seal.test.js` — 8/8 pass
- [x] `npm run eval:verify-fable5-seal` against the live corpus — Verdict=SEALED, exit code 0 (verified via `$?`, not just the printed line)
- [x] `eslint` clean across all 3 files
- [x] LEAD (VALIDATION CONDITIONAL_PASS 88%, Explore CONDITIONAL_PASS 78%), PLAN (DATABASE/RISK/STORIES PASS, SECURITY PASS 88%), EXEC (TESTING PASS 92%/95%, SECURITY PASS 95%), RETRO PASS 90% — all sub-agent evidence in place
- [x] Handoffs: LEAD-TO-PLAN 96, PLAN-TO-EXEC 97, EXEC-TO-PLAN 95, PLAN-TO-LEAD 96

🤖 Generated with [Claude Code](https://claude.com/claude-code)