### PR TITLE
feat(SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B): Fable-suitability scoring engine

### DIFF
--- a/lib/fable-suitability/cluster-families.mjs
+++ b/lib/fable-suitability/cluster-families.mjs
@@ -1,0 +1,54 @@
+/**
+ * cluster-families.mjs — per-duty-cluster axis families.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-4).
+ *
+ * Each kind of Fable work is best ranked by DIFFERENT signals: a flaky-RCA candidate is mostly
+ * about recurrence (how often it re-breaks), while an architecture-refactor is mostly about
+ * centrality (how much depends on it). A family supplies per-axis WEIGHTS applied when mapping raw
+ * signals into the 1-5 band, so the same region can score differently under different duty clusters.
+ *
+ * Weights are relative multipliers within an axis's own signal blend — they never change the axis
+ * range (still 1-5) and never let one axis substitute for another (the composite stays multiplicative,
+ * so the anti-gaming floor in score-region is unaffected). Pure data + a lookup; no DB, no model.
+ */
+
+export const DUTY_CLUSTERS = ['architecture-refactor', 'dedup', 'flaky-RCA', 'harness-depth'];
+
+/**
+ * Per-family signal weights. Each block sums to ~1.0 within an axis so the weighting is a
+ * re-balancing of that axis's own inputs, not an inflation.
+ *   impact:      { centrality, fanOut, crossRepo }   (structural — score-impact)
+ *   opportunity: { recurrence, bypass, failurePatterns, nthConsumer } (recurrence — score-opportunity)
+ *   reasoningDepth: { blastRadius, lookAhead }        (judgment — score-reasoning-depth rubric hint)
+ */
+const FAMILIES = {
+  'architecture-refactor': {
+    impact: { centrality: 0.6, fanOut: 0.3, crossRepo: 0.1 },
+    opportunity: { recurrence: 0.3, bypass: 0.2, failurePatterns: 0.2, nthConsumer: 0.3 },
+    reasoningDepth: { blastRadius: 0.7, lookAhead: 0.3 },
+  },
+  dedup: {
+    impact: { centrality: 0.3, fanOut: 0.3, crossRepo: 0.4 },
+    opportunity: { recurrence: 0.25, bypass: 0.15, failurePatterns: 0.2, nthConsumer: 0.4 },
+    reasoningDepth: { blastRadius: 0.4, lookAhead: 0.6 },
+  },
+  'flaky-RCA': {
+    impact: { centrality: 0.4, fanOut: 0.4, crossRepo: 0.2 },
+    opportunity: { recurrence: 0.55, bypass: 0.25, failurePatterns: 0.15, nthConsumer: 0.05 },
+    reasoningDepth: { blastRadius: 0.5, lookAhead: 0.5 },
+  },
+  'harness-depth': {
+    impact: { centrality: 0.5, fanOut: 0.35, crossRepo: 0.15 },
+    opportunity: { recurrence: 0.35, bypass: 0.35, failurePatterns: 0.2, nthConsumer: 0.1 },
+    reasoningDepth: { blastRadius: 0.55, lookAhead: 0.45 },
+  },
+};
+
+/** Return the axis-weight family for a duty cluster. Throws on an unknown cluster (fail loud). */
+export function getFamily(dutyCluster) {
+  const family = FAMILIES[dutyCluster];
+  if (!family) {
+    throw new Error(`getFamily: unknown duty_cluster "${dutyCluster}" (expected one of ${DUTY_CLUSTERS.join(', ')})`);
+  }
+  return family;
+}

--- a/lib/fable-suitability/region-cluster.mjs
+++ b/lib/fable-suitability/region-cluster.mjs
@@ -1,0 +1,47 @@
+/**
+ * region-cluster.mjs — derive a coarse, stable region_key from a file path.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-4).
+ *
+ * A "region" is a coarse structural boundary (a top-level module/dir), NOT an individual file —
+ * scoring at file granularity would be noisy and would explode the ledger. deriveRegion collapses
+ * a path to its top one-or-two path segments and hands the result to child A's normalizeRegionKey
+ * so the key is single-sourced and provably CHECK-safe (a drifting key forks the section-11 ledger
+ * JOIN). Pure: no DB, no model.
+ */
+import { normalizeRegionKey } from './map-writer.mjs';
+
+// How many leading path segments define a region. lib/foo/bar/baz.js -> "lib/foo".
+const REGION_DEPTH = 2;
+
+/**
+ * Map a repo-relative (or absolute) path to a canonical region_key.
+ * @param {string} filePath  e.g. "lib/fable-suitability/score-impact.mjs" or a Windows abs path
+ * @param {object} [opts]    { repo?: string } — repo is prepended so the same dir in two repos
+ *                           yields distinct regions (matches the child-A (region_key, repo) key).
+ * @returns {string} a normalized region_key that passes child A's CHECK/normalizeRegionKey.
+ */
+export function deriveRegion(filePath, { repo = '' } = {}) {
+  if (typeof filePath !== 'string' || filePath.trim() === '') {
+    throw new Error('deriveRegion: filePath must be a non-empty string');
+  }
+  // Normalize separators, strip a leading drive/abs prefix, split into segments.
+  const segments = filePath
+    .replace(/\\/g, '/')
+    .replace(/^[a-zA-Z]:\//, '')
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean);
+
+  // Drop the filename if the last segment looks like a file (has an extension).
+  const dirSegments = /\.[a-z0-9]+$/i.test(segments[segments.length - 1] ?? '')
+    ? segments.slice(0, -1)
+    : segments;
+
+  const regionSegments = (dirSegments.length ? dirSegments : segments).slice(0, REGION_DEPTH);
+  if (regionSegments.length === 0) {
+    throw new Error(`deriveRegion: "${filePath}" has no clusterable path segment`);
+  }
+
+  const raw = repo ? `${repo}/${regionSegments.join('/')}` : regionSegments.join('/');
+  return normalizeRegionKey(raw);
+}

--- a/lib/fable-suitability/score-impact.mjs
+++ b/lib/fable-suitability/score-impact.mjs
@@ -1,0 +1,114 @@
+/**
+ * score-impact.mjs — DETERMINISTIC impact axis (1-5). NEVER calls a model.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-1).
+ *
+ * Impact = "how much of the system leans on this region". It is computed ONLY from structural
+ * signals — an LLM-judged impact would be unfalsifiable and gameable (RISK R1, the central
+ * garbage-ranking risk). The signals:
+ *   - centrality (consumer in-degree): how many distinct files import this region's exports
+ *     (from lib/static-analysis buildConsumerIndex).
+ *   - fanOut (call-graph out-degree): how many other regions this region reaches
+ *     (from lib/static-analysis buildCallGraph).
+ *   - crossRepo: whether the region is reached from more than one application (applications.local_path
+ *     TRACKED_SCOPE) — a cross-repo region is higher-blast-radius.
+ *
+ * scoreImpact is a PURE band-mapper over already-extracted numeric signals (testable with fixtures);
+ * extractImpactSignals is the thin adapter that derives those signals from static-analysis outputs,
+ * so child C can feed real data without the scorer knowing about ASTs.
+ */
+import { getFamily } from './cluster-families.mjs';
+
+// Documented thresholds mapping a blended structural score into a 1-5 band.
+// Bands are on the WEIGHTED blend of normalized signals, not any single raw count.
+const BAND_THRESHOLDS = [
+  { min: 0.8, score: 5 },
+  { min: 0.6, score: 4 },
+  { min: 0.4, score: 3 },
+  { min: 0.2, score: 2 },
+  { min: 0.0, score: 1 },
+];
+
+// Saturating normalizers: raw counts -> [0,1]. Documented, deterministic, no magic per-run tuning.
+const norm = (value, saturateAt) => Math.min(1, Math.max(0, (Number(value) || 0) / saturateAt));
+
+function bandFor(blend) {
+  for (const b of BAND_THRESHOLDS) if (blend >= b.min) return b.score;
+  return 1;
+}
+
+/**
+ * @param {{centrality:number, fanOut:number, crossRepoCount:number}} signals raw structural counts
+ * @param {string} dutyCluster
+ * @returns {{score:number, inputs:object, rationale:string}}
+ */
+export function scoreImpact(signals = {}, dutyCluster) {
+  const w = getFamily(dutyCluster).impact;
+  const nCentrality = norm(signals.centrality, 20);      // 20+ consumers saturates centrality
+  const nFanOut = norm(signals.fanOut, 15);              // 15+ outbound edges saturates fan-out
+  // Cross-repo reach is a BONUS over the single-repo baseline: 1 repo -> 0, 2+ repos -> saturated.
+  const nCrossRepo = norm((Number(signals.crossRepoCount) || 1) - 1, 1);
+
+  const blend = w.centrality * nCentrality + w.fanOut * nFanOut + w.crossRepo * nCrossRepo;
+  const score = bandFor(blend);
+
+  return {
+    score,
+    inputs: {
+      centrality: Number(signals.centrality) || 0,
+      fanOut: Number(signals.fanOut) || 0,
+      crossRepoCount: Number(signals.crossRepoCount) || 0,
+      normalized: { centrality: nCentrality, fanOut: nFanOut, crossRepo: nCrossRepo },
+      blend: Number(blend.toFixed(4)),
+      weights: w,
+    },
+    rationale: `impact ${score}/5 — centrality=${signals.centrality || 0} in-degree, fanOut=${signals.fanOut || 0} out-degree, crossRepo=${signals.crossRepoCount || 0} repo(s), ${dutyCluster}-weighted blend=${blend.toFixed(2)}`,
+  };
+}
+
+/**
+ * Derive raw impact signals for a region from static-analysis outputs. Thin, deterministic adapter.
+ * @param {object} args
+ * @param {object} args.consumerIndex  result of buildConsumerIndex ({named, wholeModule} Maps)
+ * @param {object} args.callGraph      result of buildCallGraph (adjacency)
+ * @param {string} args.region         the region_key
+ * @param {(file:string)=>string} args.regionOf  maps a defining file to its region_key
+ * @param {Set<string>} [args.crossRepoRegions]  region_keys observed in >1 repo
+ * @returns {{centrality:number, fanOut:number, crossRepoCount:number}}
+ */
+export function extractImpactSignals({ consumerIndex, callGraph, region, regionOf, crossRepoRegions = new Set() }) {
+  let centrality = 0;
+  let fanOut = 0;
+
+  // Centrality: count distinct consumer files whose imported defining-file belongs to `region`.
+  if (consumerIndex) {
+    const consumers = new Set();
+    const collect = (map) => {
+      for (const [definingFile, entry] of map.entries()) {
+        if (regionOf(definingFile) !== region) continue;
+        const lists = entry instanceof Map ? [...entry.values()] : [entry];
+        for (const list of lists) for (const c of list) consumers.add(c.file);
+      }
+    };
+    if (consumerIndex.named) collect(consumerIndex.named);
+    if (consumerIndex.wholeModule) collect(consumerIndex.wholeModule);
+    centrality = consumers.size;
+  }
+
+  // Fan-out: distinct OTHER regions this region's files reach in the call graph.
+  if (callGraph && typeof callGraph === 'object') {
+    const reached = new Set();
+    const edges = callGraph.edges || callGraph.adjacency || callGraph;
+    const iter = edges instanceof Map ? edges.entries() : Object.entries(edges);
+    for (const [fromFile, tos] of iter) {
+      if (regionOf(fromFile) !== region) continue;
+      for (const to of tos || []) {
+        const toFile = typeof to === 'string' ? to : to.file;
+        const toRegion = regionOf(toFile);
+        if (toRegion && toRegion !== region) reached.add(toRegion);
+      }
+    }
+    fanOut = reached.size;
+  }
+
+  return { centrality, fanOut, crossRepoCount: crossRepoRegions.has(region) ? 2 : 1 };
+}

--- a/lib/fable-suitability/score-opportunity.mjs
+++ b/lib/fable-suitability/score-opportunity.mjs
@@ -1,0 +1,106 @@
+/**
+ * score-opportunity.mjs — DETERMINISTIC opportunity axis (1-5). NEVER calls a model.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-2).
+ *
+ * Opportunity = "how much unrealized value is trapped in this region" — recurrence-weighted from
+ * signals that already exist in the DB. LLM-free (RISK R1). Signals:
+ *   - recurrence: issue_patterns.occurrence_count + trend for this region. SYNTHETIC vision-gap rows
+ *     (occurrence_count in the 10k-73k band) MUST be filtered BEFORE weighting — they are seeded
+ *     gauge rows, not real recurrence, and would otherwise dominate every region (mirrors the
+ *     ventures-table synthetic-hygiene lesson).
+ *   - bypass: sd_phase_handoffs where resolution_type IN ('bypass','bypass_planned','library_sd_bypass').
+ *     (There is NO 'ADMIN_OVERRIDE' label — using it would silently match nothing.)
+ *   - failurePatterns: retrospectives.failure_patterns touching this region.
+ *   - nthConsumer: (consumer count x git churn) x a cheap complexity proxy (AST-node-count + LOC +
+ *     churn). No cyclomatic tool exists, so the proxy is intentionally coarse and documented.
+ *
+ * scoreOpportunity is a PURE band-mapper over already-aggregated counts (fixture-testable). The DB
+ * aggregation lives in the caller / child C; the SYNTHETIC_FLOOR/CEILING here is the reusable guard
+ * so any caller can apply the filter identically.
+ */
+import { getFamily } from './cluster-families.mjs';
+
+// Synthetic vision-gap rows carry an occurrence_count in this band. Filter them BEFORE weighting.
+export const SYNTHETIC_OCCURRENCE_FLOOR = 10000;
+export const SYNTHETIC_OCCURRENCE_CEILING = 73000;
+
+export const BYPASS_RESOLUTION_TYPES = ['bypass', 'bypass_planned', 'library_sd_bypass'];
+
+const BAND_THRESHOLDS = [
+  { min: 0.8, score: 5 },
+  { min: 0.6, score: 4 },
+  { min: 0.4, score: 3 },
+  { min: 0.2, score: 2 },
+  { min: 0.0, score: 1 },
+];
+const norm = (value, saturateAt) => Math.min(1, Math.max(0, (Number(value) || 0) / saturateAt));
+function bandFor(blend) {
+  for (const b of BAND_THRESHOLDS) if (blend >= b.min) return b.score;
+  return 1;
+}
+
+/**
+ * Filter out synthetic vision-gap issue_patterns rows before they are weighted.
+ * A row is synthetic when its occurrence_count sits in the seeded [FLOOR, CEILING] band.
+ * @param {Array<{occurrence_count:number}>} patterns
+ * @returns {Array} real (non-synthetic) patterns
+ */
+export function filterSyntheticPatterns(patterns = []) {
+  return patterns.filter((p) => {
+    const n = Number(p?.occurrence_count) || 0;
+    return !(n >= SYNTHETIC_OCCURRENCE_FLOOR && n <= SYNTHETIC_OCCURRENCE_CEILING);
+  });
+}
+
+/**
+ * @param {object} signals
+ * @param {Array<{occurrence_count:number, trend?:string}>} signals.issuePatterns  RAW rows (synthetic filtered here)
+ * @param {number} signals.bypassCount        count of matching sd_phase_handoffs
+ * @param {number} signals.failurePatternCount count of retrospectives.failure_patterns hits
+ * @param {number} signals.consumerCount       consumers of the region (for Nth-consumer-patch)
+ * @param {number} signals.churn               git churn (commits/edits touching the region)
+ * @param {number} signals.complexityProxy     AST-node-count + LOC + churn proxy
+ * @param {string} dutyCluster
+ * @returns {{score:number, inputs:object, rationale:string, recurrenceWeight:number, sourceIds:string[]}}
+ */
+export function scoreOpportunity(signals = {}, dutyCluster) {
+  const w = getFamily(dutyCluster).opportunity;
+
+  const realPatterns = filterSyntheticPatterns(signals.issuePatterns || []);
+  const filteredCount = (signals.issuePatterns || []).length - realPatterns.length;
+  const recurrenceRaw = realPatterns.reduce((sum, p) => {
+    const trendMult = p.trend === 'increasing' ? 1.5 : p.trend === 'decreasing' ? 0.5 : 1;
+    return sum + (Number(p.occurrence_count) || 0) * trendMult;
+  }, 0);
+
+  // Nth-consumer-patch: the more consumers x churn x complexity, the more a fix pays back.
+  const nthConsumer = (Number(signals.consumerCount) || 0) * (Number(signals.churn) || 0) * Math.max(1, Number(signals.complexityProxy) || 1);
+
+  const nRecurrence = norm(recurrenceRaw, 50);           // 50 real weighted recurrences saturates
+  const nBypass = norm(signals.bypassCount, 5);          // 5 bypasses saturates
+  const nFailure = norm(signals.failurePatternCount, 5); // 5 failure-pattern hits saturates
+  const nNth = norm(nthConsumer, 500);                   // coarse proxy saturation
+
+  const blend = w.recurrence * nRecurrence + w.bypass * nBypass + w.failurePatterns * nFailure + w.nthConsumer * nNth;
+  const score = bandFor(blend);
+
+  const sourceIds = realPatterns.map((p) => p.id).filter(Boolean);
+
+  return {
+    score,
+    recurrenceWeight: Number(recurrenceRaw.toFixed(2)),
+    sourceIds,
+    inputs: {
+      realPatternCount: realPatterns.length,
+      syntheticFiltered: filteredCount,
+      recurrenceRaw: Number(recurrenceRaw.toFixed(2)),
+      bypassCount: Number(signals.bypassCount) || 0,
+      failurePatternCount: Number(signals.failurePatternCount) || 0,
+      nthConsumer: Number(nthConsumer.toFixed(2)),
+      normalized: { recurrence: nRecurrence, bypass: nBypass, failure: nFailure, nthConsumer: nNth },
+      blend: Number(blend.toFixed(4)),
+      weights: w,
+    },
+    rationale: `opportunity ${score}/5 — ${realPatterns.length} real recurrence pattern(s) (${filteredCount} synthetic filtered), ${signals.bypassCount || 0} bypass(es), ${signals.failurePatternCount || 0} failure-pattern hit(s), ${dutyCluster}-weighted blend=${blend.toFixed(2)}`,
+  };
+}

--- a/lib/fable-suitability/score-reasoning-depth.mjs
+++ b/lib/fable-suitability/score-reasoning-depth.mjs
@@ -1,0 +1,104 @@
+/**
+ * score-reasoning-depth.mjs — the ONLY LLM axis (1-5). Cheap-model rubric, injected + mockable.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-3).
+ *
+ * Reasoning-depth = "how much genuine judgment / look-ahead a Fable pass here would exercise" — the
+ * axis that DOWN-weights high-value-but-mechanical work (a huge but rote rename should not out-rank
+ * a small, deeply-entangled refactor). This is the one axis where a cheap model is warranted, because
+ * it is genuine judgment rather than a countable structural fact.
+ *
+ * Design guards:
+ *   - The model client is INJECTED (opts.client). Tests pass a mock; CI never calls a live model.
+ *   - The score is obtained via CONSTRAINED/STRUCTURED decoding into an integer 1-5, never a
+ *     free-text parse + regex repair (the free-text+repair failure mode).
+ *   - This axis alone CANNOT float a region: score-region multiplies the three axes, so a max
+ *     reasoning-depth over a low deterministic impact/opportunity still yields a low composite
+ *     (the anti-gaming floor, RISK R1).
+ *   - On any decode failure the axis degrades to a NEUTRAL 3 with a logged rationale — it never
+ *     throws into the pipeline and never silently floats to 5.
+ */
+import { getFamily } from './cluster-families.mjs';
+
+const NEUTRAL_SCORE = 3;
+
+/**
+ * The structured-output contract the injected client must satisfy. A real client wires this to a
+ * constrained-decoding / tool-schema call; the mock in tests just returns a matching object.
+ */
+export const REASONING_DEPTH_SCHEMA = {
+  type: 'object',
+  properties: {
+    score: { type: 'integer', minimum: 1, maximum: 5 },
+    rationale: { type: 'string' },
+  },
+  required: ['score', 'rationale'],
+  additionalProperties: false,
+};
+
+function clampScore(n) {
+  const v = Number(n);
+  if (!Number.isFinite(v)) return null;
+  const r = Math.round(v);
+  // Out-of-contract (not 1-5) DEGRADES to neutral rather than silently clamping to 5 —
+  // clamping a runaway score up to the max would be an anti-gaming hole.
+  if (r < 1 || r > 5) return null;
+  return r;
+}
+
+/**
+ * @param {object} region  { region_key, sample?, summary? } — the material the rubric reasons over
+ * @param {object} ctx     { blastRadius?, lookAhead? } deterministic hints the family weights
+ * @param {object} opts
+ * @param {{ scoreStructured:(args:{prompt:string, schema:object})=>Promise<{score:number,rationale:string}>}} opts.client
+ * @param {string} opts.dutyCluster
+ * @returns {Promise<{score:number, inputs:object, rationale:string, degraded:boolean}>}
+ */
+export async function scoreReasoningDepth(region = {}, ctx = {}, opts = {}) {
+  const { client, dutyCluster } = opts;
+  if (!client || typeof client.scoreStructured !== 'function') {
+    throw new Error('scoreReasoningDepth: an injected client with scoreStructured() is required');
+  }
+  const w = getFamily(dutyCluster).reasoningDepth;
+
+  const prompt = buildRubricPrompt(region, ctx, dutyCluster, w);
+
+  let raw;
+  try {
+    raw = await client.scoreStructured({ prompt, schema: REASONING_DEPTH_SCHEMA });
+  } catch (err) {
+    return degraded(`model call failed: ${err?.message || 'unknown'}`, { blastRadius: ctx.blastRadius, lookAhead: ctx.lookAhead });
+  }
+
+  const score = clampScore(raw?.score);
+  if (score === null) {
+    return degraded(`model returned a non-1-5 score (${JSON.stringify(raw?.score)})`, { blastRadius: ctx.blastRadius, lookAhead: ctx.lookAhead });
+  }
+
+  return {
+    score,
+    degraded: false,
+    inputs: { blastRadius: ctx.blastRadius ?? null, lookAhead: ctx.lookAhead ?? null, weights: w, decoded: true },
+    rationale: `reasoning-depth ${score}/5 — ${String(raw.rationale || '').slice(0, 200)}`,
+  };
+}
+
+function degraded(reason, inputs) {
+  return {
+    score: NEUTRAL_SCORE,
+    degraded: true,
+    inputs: { ...inputs, decoded: false },
+    rationale: `reasoning-depth ${NEUTRAL_SCORE}/5 (NEUTRAL fallback) — ${reason}`,
+  };
+}
+
+function buildRubricPrompt(region, ctx, dutyCluster, w) {
+  return [
+    `Rate the REASONING DEPTH (1-5) that a careful engineer would need to do "${dutyCluster}" work in the region "${region.region_key || '(unknown)'}".`,
+    `1 = purely mechanical (rote rename, generated code); 5 = deeply entangled, high look-ahead, many interacting constraints.`,
+    `Weight blast-radius ${w.blastRadius} and look-ahead ${w.lookAhead}.`,
+    ctx.blastRadius != null ? `Observed blast-radius hint: ${ctx.blastRadius}.` : '',
+    ctx.lookAhead != null ? `Observed look-ahead hint: ${ctx.lookAhead}.` : '',
+    region.summary ? `Region summary: ${region.summary}` : '',
+    `Return ONLY the structured {score, rationale}.`,
+  ].filter(Boolean).join('\n');
+}

--- a/lib/fable-suitability/score-region.mjs
+++ b/lib/fable-suitability/score-region.mjs
@@ -1,0 +1,76 @@
+/**
+ * score-region.mjs — compose the three axes into a scored region row + child-A evidence jsonb.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-B (FR-5).
+ *
+ * Orchestrates score-impact (deterministic) + score-opportunity (deterministic) + score-reasoning-depth
+ * (LLM, injected) under a duty-cluster family, then computes:
+ *
+ *   composite = axis_impact * axis_opportunity * axis_reasoning_depth
+ *
+ * MULTIPLICATIVE by design — this IS the anti-gaming floor (RISK R1). Because the product collapses
+ * when any deterministic axis is low, a maxed-out LLM reasoning-depth alone can never float a region
+ * whose structural impact/opportunity are low (5*1*1 = 5, a low band). The LLM axis can only AMPLIFY
+ * a region the deterministic signals already rank highly.
+ *
+ * The emitted evidence matches child A's documented shape EXACTLY and is validated through child A's
+ * validateEvidence before return, so a drift in either contract fails loud here rather than at write.
+ * This module is PURE: it returns the scored row; it does NOT persist (child A's map-writer) and does
+ * NOT fan out over the codebase (child C).
+ */
+import { scoreImpact } from './score-impact.mjs';
+import { scoreOpportunity } from './score-opportunity.mjs';
+import { scoreReasoningDepth } from './score-reasoning-depth.mjs';
+import { validateEvidence, EVIDENCE_SCHEMA_VERSION } from './map-writer.mjs';
+
+/**
+ * @param {object} region  { region_key, repo, summary? }
+ * @param {object} signals { impact:{centrality,fanOut,crossRepoCount}, opportunity:{...}, reasoning:{blastRadius,lookAhead} }
+ * @param {object} opts    { dutyCluster, client (for reasoning-depth), scoredBy, computedAt }
+ * @returns {Promise<{row:object, evidence:object}>} row is ready for child A upsertRegionScore
+ */
+export async function scoreRegion(region = {}, signals = {}, opts = {}) {
+  const { dutyCluster, client, scoredBy = 'fable-scoring-engine', computedAt } = opts;
+  if (!region.region_key) throw new Error('scoreRegion: region.region_key is required');
+  if (!region.repo) throw new Error('scoreRegion: region.repo is required');
+
+  const impact = scoreImpact(signals.impact || {}, dutyCluster);
+  const opportunity = scoreOpportunity(signals.opportunity || {}, dutyCluster);
+  const reasoning = await scoreReasoningDepth(region, signals.reasoning || {}, { client, dutyCluster });
+
+  // Anti-gaming floor: multiplicative composite.
+  const composite = impact.score * opportunity.score * reasoning.score;
+
+  const evidence = {
+    evidence_schema_version: EVIDENCE_SCHEMA_VERSION,
+    axes: {
+      impact: { score: impact.score, inputs: impact.inputs, rationale: impact.rationale },
+      opportunity: { score: opportunity.score, inputs: opportunity.inputs, rationale: opportunity.rationale },
+      reasoning_depth: { score: reasoning.score, inputs: reasoning.inputs, rationale: reasoning.rationale },
+    },
+    recurrence: {
+      weight: opportunity.recurrenceWeight,
+      count: opportunity.inputs.realPatternCount,
+      source_ids: opportunity.sourceIds,
+    },
+    scored_by: scoredBy,
+    computed_at: computedAt || new Date().toISOString(),
+  };
+
+  // Fail loud if either contract drifted (child A owns the canonical shape validator).
+  validateEvidence(evidence);
+
+  const row = {
+    region_key: region.region_key,
+    repo: region.repo,
+    duty_cluster: dutyCluster,
+    axis_impact: impact.score,
+    axis_opportunity: opportunity.score,
+    axis_reasoning_depth: reasoning.score,
+    composite_score: composite,
+    recurrence_weight: opportunity.recurrenceWeight,
+    evidence,
+    reasoning_degraded: reasoning.degraded,
+  };
+
+  return { row, evidence };
+}

--- a/tests/unit/fable-suitability/scoring.test.js
+++ b/tests/unit/fable-suitability/scoring.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest';
+import { scoreImpact, extractImpactSignals } from '../../../lib/fable-suitability/score-impact.mjs';
+import {
+  scoreOpportunity,
+  filterSyntheticPatterns,
+  BYPASS_RESOLUTION_TYPES,
+  SYNTHETIC_OCCURRENCE_FLOOR,
+  SYNTHETIC_OCCURRENCE_CEILING,
+} from '../../../lib/fable-suitability/score-opportunity.mjs';
+import { scoreReasoningDepth } from '../../../lib/fable-suitability/score-reasoning-depth.mjs';
+import { scoreRegion } from '../../../lib/fable-suitability/score-region.mjs';
+import { deriveRegion } from '../../../lib/fable-suitability/region-cluster.mjs';
+import { getFamily, DUTY_CLUSTERS } from '../../../lib/fable-suitability/cluster-families.mjs';
+import { validateEvidence } from '../../../lib/fable-suitability/map-writer.mjs';
+
+/** A mock reasoning-depth client that records whether it was called. */
+function mockClient(score = 4, rationale = 'entangled') {
+  return {
+    calls: 0,
+    async scoreStructured() {
+      this.calls += 1;
+      return { score, rationale };
+    },
+  };
+}
+
+describe('deriveRegion (FR-4)', () => {
+  it('collapses a file path to a canonical, child-A-valid region_key', () => {
+    expect(deriveRegion('lib/fable-suitability/score-impact.mjs')).toBe('lib/fable-suitability');
+  });
+  it('prepends repo and normalizes Windows separators (repo-relative path)', () => {
+    expect(deriveRegion('Lib\\Gates\\x.js', { repo: 'EHG_Engineer' })).toBe('ehg_engineer/lib/gates');
+  });
+  it('strips a Windows drive prefix from an absolute path', () => {
+    // Absolute paths keep their real leading dir segments (here "proj/src" is the first region depth).
+    expect(deriveRegion('C:\\proj\\src\\thing.js')).toBe('proj/src');
+  });
+  it('rejects an empty path', () => {
+    expect(() => deriveRegion('')).toThrow();
+  });
+});
+
+describe('cluster-families (FR-4)', () => {
+  it('exposes all four duty clusters with axis weights', () => {
+    for (const c of DUTY_CLUSTERS) {
+      const fam = getFamily(c);
+      expect(fam.impact).toBeTruthy();
+      expect(fam.opportunity).toBeTruthy();
+      expect(fam.reasoningDepth).toBeTruthy();
+    }
+  });
+  it('throws on an unknown cluster (fail loud)', () => {
+    expect(() => getFamily('nope')).toThrow();
+  });
+});
+
+describe('scoreImpact — deterministic, no model (FR-1 / TS-1)', () => {
+  it('maps known structural signals to a 1-5 band with inputs + rationale', () => {
+    const r = scoreImpact({ centrality: 20, fanOut: 15, crossRepoCount: 2 }, 'architecture-refactor');
+    expect(r.score).toBeGreaterThanOrEqual(4); // high centrality/fan-out -> high band
+    expect(r.inputs.centrality).toBe(20);
+    expect(typeof r.rationale).toBe('string');
+  });
+  it('low structural signals -> low band', () => {
+    const r = scoreImpact({ centrality: 0, fanOut: 0, crossRepoCount: 1 }, 'dedup');
+    expect(r.score).toBeLessThanOrEqual(2);
+  });
+  it('is synchronous/deterministic — returns a value, not a Promise (no async model call)', () => {
+    const out = scoreImpact({ centrality: 5, fanOut: 5, crossRepoCount: 1 }, 'dedup');
+    expect(out).not.toBeInstanceOf(Promise);
+    expect(typeof out.score).toBe('number');
+  });
+  it('extractImpactSignals derives centrality/fan-out from static-analysis-shaped inputs', () => {
+    const consumerIndex = {
+      named: new Map([['lib/target/x.js', new Map([['foo', [{ file: 'a.js' }, { file: 'b.js' }]]])]]),
+      wholeModule: new Map(),
+    };
+    const callGraph = { edges: new Map([['lib/target/x.js', ['lib/other/y.js', 'lib/target/z.js']]]) };
+    const regionOf = (f) => f.split('/').slice(0, 2).join('/');
+    const sig = extractImpactSignals({ consumerIndex, callGraph, region: 'lib/target', regionOf });
+    expect(sig.centrality).toBe(2); // a.js + b.js
+    expect(sig.fanOut).toBe(1);     // reaches lib/other (not itself)
+  });
+});
+
+describe('scoreOpportunity — deterministic, synthetic-filtered (FR-2 / TS-2)', () => {
+  it('filters synthetic vision-gap rows before weighting', () => {
+    const real = { id: 'p1', occurrence_count: 8, trend: 'increasing' };
+    const synthetic = { id: 'p2', occurrence_count: 73000 };
+    const kept = filterSyntheticPatterns([real, synthetic]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].id).toBe('p1');
+  });
+  it('a 73k synthetic row does NOT float the opportunity score', () => {
+    const withSynthetic = scoreOpportunity(
+      { issuePatterns: [{ id: 's', occurrence_count: 73000 }], bypassCount: 0, failurePatternCount: 0 },
+      'flaky-RCA',
+    );
+    expect(withSynthetic.score).toBe(1); // filtered out -> nothing floats it
+    expect(withSynthetic.inputs.syntheticFiltered).toBe(1);
+    expect(withSynthetic.inputs.realPatternCount).toBe(0);
+  });
+  it('real recurrence + bypass raise the score', () => {
+    const r = scoreOpportunity(
+      {
+        issuePatterns: [{ id: 'p', occurrence_count: 40, trend: 'increasing' }],
+        bypassCount: 5,
+        failurePatternCount: 5,
+        consumerCount: 10,
+        churn: 20,
+        complexityProxy: 5,
+      },
+      'flaky-RCA',
+    );
+    expect(r.score).toBeGreaterThanOrEqual(3);
+    expect(r.sourceIds).toContain('p');
+  });
+  it('exposes the correct bypass resolution_type set (no ADMIN_OVERRIDE)', () => {
+    expect(BYPASS_RESOLUTION_TYPES).toEqual(['bypass', 'bypass_planned', 'library_sd_bypass']);
+    expect(BYPASS_RESOLUTION_TYPES).not.toContain('ADMIN_OVERRIDE');
+  });
+  it('synthetic band constants match the seeded vision-gap range', () => {
+    expect(SYNTHETIC_OCCURRENCE_FLOOR).toBe(10000);
+    expect(SYNTHETIC_OCCURRENCE_CEILING).toBe(73000);
+  });
+});
+
+describe('scoreReasoningDepth — LLM-only, injected + constrained (FR-3 / TS-3)', () => {
+  it('uses the injected mock client and returns a 1-5 score via structured decode', async () => {
+    const client = mockClient(4, 'deep');
+    const r = await scoreReasoningDepth({ region_key: 'lib/x' }, { blastRadius: 3, lookAhead: 4 }, { client, dutyCluster: 'harness-depth' });
+    expect(r.score).toBe(4);
+    expect(client.calls).toBe(1);
+    expect(r.degraded).toBe(false);
+  });
+  it('degrades to a NEUTRAL 3 (never floats to 5) when the model returns garbage', async () => {
+    const badClient = { async scoreStructured() { return { score: 99, rationale: 'x' }; } };
+    const r = await scoreReasoningDepth({ region_key: 'lib/x' }, {}, { client: badClient, dutyCluster: 'dedup' });
+    expect(r.score).toBe(3);
+    expect(r.degraded).toBe(true);
+  });
+  it('degrades on a client throw rather than crashing the pipeline', async () => {
+    const throwing = { async scoreStructured() { throw new Error('rate limited'); } };
+    const r = await scoreReasoningDepth({ region_key: 'lib/x' }, {}, { client: throwing, dutyCluster: 'dedup' });
+    expect(r.score).toBe(3);
+    expect(r.degraded).toBe(true);
+  });
+  it('requires an injected client (no implicit live model)', async () => {
+    await expect(scoreReasoningDepth({ region_key: 'lib/x' }, {}, { dutyCluster: 'dedup' })).rejects.toThrow(/injected client/);
+  });
+});
+
+describe('scoreRegion — composite + evidence (FR-5 / TS-4, TS-5)', () => {
+  const baseSignals = {
+    impact: { centrality: 20, fanOut: 15, crossRepoCount: 2 },
+    opportunity: { issuePatterns: [{ id: 'p', occurrence_count: 45, trend: 'increasing' }], bypassCount: 5, failurePatternCount: 5, consumerCount: 20, churn: 30, complexityProxy: 8 },
+    reasoning: { blastRadius: 4, lookAhead: 4 },
+  };
+
+  it('TS-4 anti-gaming: max reasoning-depth alone cannot float a low-impact/opportunity region', async () => {
+    const client = mockClient(5, 'max judgment');
+    const { row } = await scoreRegion(
+      { region_key: 'lib/mechanical', repo: 'EHG_Engineer' },
+      { impact: { centrality: 0, fanOut: 0, crossRepoCount: 1 }, opportunity: { issuePatterns: [] }, reasoning: {} },
+      { dutyCluster: 'dedup', client, computedAt: '2026-07-17T00:00:00.000Z' },
+    );
+    expect(row.axis_reasoning_depth).toBe(5);
+    expect(row.axis_impact).toBe(1);
+    expect(row.axis_opportunity).toBe(1);
+    expect(row.composite_score).toBe(5); // 1 * 1 * 5 — NOT floated
+  });
+
+  it('composite is the product of the three axes and evidence round-trips validateEvidence', async () => {
+    const client = mockClient(4, 'deep');
+    const { row, evidence } = await scoreRegion(
+      { region_key: 'lib/gates', repo: 'EHG_Engineer' },
+      baseSignals,
+      { dutyCluster: 'harness-depth', client, computedAt: '2026-07-17T00:00:00.000Z' },
+    );
+    expect(row.composite_score).toBe(row.axis_impact * row.axis_opportunity * row.axis_reasoning_depth);
+    expect(() => validateEvidence(evidence)).not.toThrow();
+    expect(evidence.recurrence.source_ids).toContain('p');
+  });
+
+  it('TS-6: family weighting changes the score for the same signals', async () => {
+    const client = mockClient(3, 'mid');
+    const region = { region_key: 'lib/gates', repo: 'EHG_Engineer' };
+    const flaky = await scoreRegion(region, baseSignals, { dutyCluster: 'flaky-RCA', client, computedAt: '2026-07-17T00:00:00.000Z' });
+    const arch = await scoreRegion(region, baseSignals, { dutyCluster: 'architecture-refactor', client, computedAt: '2026-07-17T00:00:00.000Z' });
+    // Both produce valid rows; the family blend is applied (opportunity inputs carry the weights).
+    expect(flaky.row.evidence.axes.opportunity.inputs.weights).not.toEqual(arch.row.evidence.axes.opportunity.inputs.weights);
+  });
+
+  it('requires region_key and repo (fail loud)', async () => {
+    const client = mockClient();
+    await expect(scoreRegion({ repo: 'EHG_Engineer' }, baseSignals, { dutyCluster: 'dedup', client })).rejects.toThrow(/region_key/);
+    await expect(scoreRegion({ region_key: 'lib/x' }, baseSignals, { dutyCluster: 'dedup', client })).rejects.toThrow(/repo/);
+  });
+});


### PR DESCRIPTION
## Summary
Child B of the Fable-suitability orchestrator (depends on child A, already merged in #6205). A **pure, testable scoring engine** ranking codebase regions for Fable attention on Impact × Opportunity × Reasoning-Depth. No persistence write (child A's map-writer) and no fan-out (child C).

## Governing design: strict deterministic-vs-LLM axis split (RISK R1)
Garbage-ranking is the central risk — an LLM-judged impact/opportunity is unfalsifiable and gameable. So:
- **Impact** (`score-impact.mjs`) — DETERMINISTIC 1-5 from `lib/static-analysis` centrality (consumer in-degree) + fan-out (call-graph out-degree) + cross-repo reach. **Never** calls a model.
- **Opportunity** (`score-opportunity.mjs`) — DETERMINISTIC 1-5, recurrence-weighted. Filters **synthetic** vision-gap `issue_patterns` rows (occurrence_count 10k–73k) *before* weighting; bypass signal uses `resolution_type IN (bypass, bypass_planned, library_sd_bypass)` (no phantom `ADMIN_OVERRIDE`).
- **Reasoning-Depth** (`score-reasoning-depth.mjs`) — the **only** LLM axis. Injected + mockable client, **constrained/structured decoding** into 1-5. Out-of-range or model failure **degrades to a neutral 3** — never silently clamps up to 5 (that would be an anti-gaming hole).

## Anti-gaming floor
`score-region.mjs` composes `composite = impact × opportunity × reasoning_depth` (**multiplicative**). A maxed-out LLM axis alone cannot float a low-impact region: `5 × 1 × 1 = 5` (low band). The LLM axis only amplifies regions the deterministic signals already rank highly.

## Also
- `cluster-families.mjs` — per-duty-cluster axis weights (architecture-refactor / dedup / flaky-RCA / harness-depth).
- `region-cluster.mjs` — `deriveRegion` → canonical `region_key` via child A's `normalizeRegionKey` (single-sourced contract).
- Emits + round-trips child A's evidence jsonb through `validateEvidence`.

## Test plan
- [x] 23 unit tests: deterministic-axis (asserts zero model calls), synthetic-row filter, anti-gaming (`5×1×1=5` not floated), reasoning-depth mock + degrade paths, evidence round-trip, per-family weighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)