### PR TITLE
feat(SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C): Fable-suitability activation (fan-out + living-update + inert-but-reachable Solomon Mode-B seam)

### DIFF
--- a/docs/architecture/solomon-activation-runbook.md
+++ b/docs/architecture/solomon-activation-runbook.md
@@ -98,3 +98,43 @@ advice-uptake (`applied`/total) · advice-accuracy (`worked`/`applied`) · syste
 became shipped fixes) · escalations-avoided (resolved at the Solomon rung that would have reached the
 Chairman) · cost-per-accepted-proposal. A cluster consistently declined/inaccurate or with
 unjustifiable cost-per-accepted-proposal is a candidate to drop — Solomon earns scope empirically.
+
+---
+
+## 7. Fable-suitability Mode-B priority source (SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C)
+
+> **Status: INERT-BUT-REACHABLE.** A read seam that projects the Fable-suitability map (children A+B)
+> into a versioned candidate contract Mode-B can consult as an additional priority source. Nothing in
+> production calls it yet (Solomon parked; child A's table STAGED) — but it is proven reachable, not
+> dark-shipped. Registering it here means un-parking is wire-up, not archaeology.
+
+**Read contract**
+- Entry point: `lib/fable-suitability/mode-b-seam.mjs` → `readModeBCandidates(supabase, { dutyCluster?, limit? })`.
+- Version: `MODE_B_CONTRACT_VERSION` (currently `1`) — bump on any candidate-shape change so an
+  un-parking Mode-B detects a mismatch instead of silently mis-reading.
+- Candidate shape: `{ contract_version, region_key, repo, duty_cluster, composite_score, score_version,
+  scored_at, rationale, source:'fable-suitability-map' }`, highest `composite_score` first.
+- Source view: child A's `v_fable_suitability_map_current`.
+- Return states: `{ status:'ok', candidates[] }`, or `{ status:'CEREMONY_PENDING', candidates:[] }`
+  while child A's table is STAGED (reachable but dormant, no throw).
+
+**Reachability proof (anti dark-ship, RISK R3)**
+- Dry-run: `node scripts/fable-suitability/dry-run.mjs --no-model` executes the *real*
+  produce → score → persist path over a live codebase slice and writes a ranked artifact.
+- Versioned contract e2e: `tests/database/fable-suitability-seam.db.test.js` drives
+  fan-out → child-A persist → `readModeBCandidates` and asserts a **fixture** Mode-B consumer reads
+  the versioned contract back (no full-seam mock — recurred-family rule).
+
+**Un-park wire-up (couples to the §3 Fable-pin trigger)**
+1. Apply child A's `fable_suitability_map` migration (chairman ceremony) — until then the seam is
+   `CEREMONY_PENDING`.
+2. Schedule `runFanout` (`lib/fable-suitability/fanout.mjs`) with a **Sonnet-floor** reasoning-depth
+   client — **NEVER Fable**; Fable is the expensive tier this map exists to *protect*, not consume.
+   Enable the living-update loop (`lib/fable-suitability/living-update.mjs`) and watch its freshness
+   gauge (`computeFreshness`) so staleness is observable (LIVENESS ≠ CLOSURE).
+3. Register `readModeBCandidates` as a Mode-B priority source in Solomon's launch config, checking
+   `contract_version === MODE_B_CONTRACT_VERSION`. This slots in at Stage **B** above (Mode-B sweeps),
+   which already auto-enables on the Solomon Fable-pin swap.
+
+The launch-time pointer lives on the SD (`metadata.solomon_modeb_seam`: entry point + contract version
++ this runbook path).

--- a/lib/fable-suitability/fanout.mjs
+++ b/lib/fable-suitability/fanout.mjs
@@ -1,0 +1,82 @@
+/**
+ * fanout.mjs — cost-bounded cheap-model fan-out over codebase regions.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C (FR-1).
+ *
+ * Runs child B's scorers over BATCHED regions and persists each via child A's writer. The cost bound
+ * (RISK R5) is STRUCTURAL, not advisory — three mechanisms make cost a function of CHANGED regions,
+ * not total regions:
+ *   1. maxBatch — a hard ceiling on regions scored per invocation.
+ *   2. input-hash cache — a region whose input-hash matches the cache is SKIPPED (no re-score); only
+ *      the hash is compared. Full cold-start fan-out is rare.
+ *   3. incremental — with a prior cache, only regions whose input-hash changed are scored.
+ *
+ * The reasoning-depth model client is INJECTED and must be Sonnet-floor (NEVER Fable — Fable is
+ * parked and is the expensive tier this whole map exists to protect). Persist is CEREMONY_PENDING-
+ * aware: while child A's table is still STAGED, each persist returns CEREMONY_PENDING without aborting
+ * the run, so a ranked artifact is still produced (inert-but-reachable).
+ */
+import { scoreRegion } from './score-region.mjs';
+
+/**
+ * Deterministic content hash of a region's scoring inputs. Two identical input sets -> identical
+ * hash -> cache hit -> skip. Pure (no crypto dependency needed for a cache key).
+ */
+export function hashRegionInputs(region, signals) {
+  const canonical = JSON.stringify({ r: region.region_key, repo: region.repo, s: signals });
+  let h = 5381;
+  for (let i = 0; i < canonical.length; i++) h = ((h << 5) + h + canonical.charCodeAt(i)) | 0;
+  return `h${(h >>> 0).toString(36)}`;
+}
+
+/**
+ * @param {object} args
+ * @param {Array<{region:object, signals:object, dutyCluster:string}>} args.regions
+ * @param {object} args.client         injected Sonnet-floor reasoning-depth client (scoreStructured)
+ * @param {(row:object)=>Promise<{status:string}>} args.persist  child A upsertRegionScore bound to a supabase client
+ * @param {Map<string,string>} [args.cache]  region_key -> last input-hash (mutated in place)
+ * @param {number} [args.maxBatch]     hard ceiling on regions scored this invocation
+ * @param {boolean} [args.incremental] when true (default), skip regions whose hash is unchanged
+ * @param {number} [args.scoreVersion] the score_version to stamp on newly-scored rows (default 1;
+ *                                     living-update re-floats bump this via evaluateRefloat). Child B's
+ *                                     scoreRegion intentionally omits score_version — versioning is a
+ *                                     fan-out/cadence concern, so the fan-out layer assigns it here.
+ * @returns {Promise<{scored:object[], skipped:string[], ceremonyPending:number, persisted:number, batchTruncated:boolean}>}
+ */
+export async function runFanout({ regions = [], client, persist, cache = new Map(), maxBatch = 25, incremental = true, scoreVersion = 1 }) {
+  if (typeof persist !== 'function') throw new Error('runFanout: persist(row) is required');
+
+  const scored = [];
+  const skipped = [];
+  let ceremonyPending = 0;
+  let persisted = 0;
+  let batchTruncated = false;
+
+  for (const item of regions) {
+    const { region, signals, dutyCluster } = item;
+    const key = region.region_key;
+    const hash = hashRegionInputs(region, signals);
+
+    // Cache/incremental: unchanged region -> skip (no model call, no persist).
+    if (incremental && cache.get(key) === hash) {
+      skipped.push(key);
+      continue;
+    }
+
+    // Cost bound: never score more than maxBatch per invocation.
+    if (scored.length >= maxBatch) {
+      batchTruncated = true;
+      break;
+    }
+
+    const { row } = await scoreRegion(region, signals, { dutyCluster, client });
+    row.score_version = row.score_version ?? scoreVersion; // fan-out assigns the version child B omits
+    scored.push(row);
+    cache.set(key, hash);
+
+    const result = await persist(row);
+    if (result?.status === 'CEREMONY_PENDING') ceremonyPending += 1;
+    else if (result?.status === 'ok') persisted += 1;
+  }
+
+  return { scored, skipped, ceremonyPending, persisted, batchTruncated };
+}

--- a/lib/fable-suitability/living-update.mjs
+++ b/lib/fable-suitability/living-update.mjs
@@ -1,0 +1,83 @@
+/**
+ * living-update.mjs — debounced, threshold-gated re-float + observable freshness gauge.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C (FR-2).
+ *
+ * The suitability map is LIVING: as a region's defect history recurs, its opportunity climbs and it
+ * should re-float to the top. But a PER-EVENT re-float would thrash the table and the section-11
+ * ledger (RISK R2). So a re-float fires ONLY when:
+ *   - the recurrence signal has CLIMBED past a threshold since the last score, AND
+ *   - we are outside the debounce window since the region's last re-float.
+ * A re-float is provenance-stamped: score_version increments, refloated_at + trigger_reason set, and
+ * the input snapshot recorded — so a later grade can see exactly what drove it.
+ *
+ * computeFreshness is the observable gauge: staleness must be DETECTABLE, not silent (LIVENESS !=
+ * CLOSURE) — a map that silently goes stale is worse than one that reports it. Pure/deterministic:
+ * `now` is injected so tests are not clock-dependent.
+ */
+
+/**
+ * Decide whether a region should re-float given a new defect signal.
+ * @param {object} region  { region_key, score_version, recurrence_weight, refloated_at }
+ * @param {object} defectSignal  { recurrenceWeight } the freshly-observed recurrence weight
+ * @param {object} opts  { threshold, debounceMs, now (ms epoch), reason }
+ * @returns {{ refloat:boolean, reason:string, patch?:object }}
+ */
+export function evaluateRefloat(region = {}, defectSignal = {}, opts = {}) {
+  const { threshold = 1.0, debounceMs = 6 * 60 * 60 * 1000, now = 0, reason = 'recurrence-climb' } = opts;
+
+  const prev = Number(region.recurrence_weight) || 0;
+  const next = Number(defectSignal.recurrenceWeight) || 0;
+  const climb = next - prev;
+
+  if (climb < threshold) {
+    return { refloat: false, reason: `climb ${climb.toFixed(2)} < threshold ${threshold}` };
+  }
+
+  // Debounce: suppress a re-float too soon after the last one.
+  const lastRefloatMs = region.refloated_at ? Date.parse(region.refloated_at) : NaN;
+  if (Number.isFinite(lastRefloatMs) && now - lastRefloatMs < debounceMs) {
+    return { refloat: false, reason: `within debounce window (${Math.round((now - lastRefloatMs) / 1000)}s < ${Math.round(debounceMs / 1000)}s)` };
+  }
+
+  const nowIso = new Date(now).toISOString();
+  return {
+    refloat: true,
+    reason,
+    patch: {
+      score_version: (Number(region.score_version) || 0) + 1, // history-preserving bump (child A appends)
+      recurrence_weight: next,
+      refloated_at: nowIso,
+      last_scored_at: nowIso,
+      trigger_reason: `${reason}: recurrence ${prev.toFixed(2)} -> ${next.toFixed(2)} (climb ${climb.toFixed(2)})`,
+      input_snapshot: { prev_recurrence: prev, new_recurrence: next, threshold, evaluated_at: nowIso },
+    },
+  };
+}
+
+/**
+ * Observable freshness gauge over a set of current rows.
+ * @param {Array<{region_key:string, last_scored_at:string}>} rows
+ * @param {object} opts  { now (ms epoch), staleAfterMs }
+ * @returns {{fresh:number, stale:number, oldestAgeMs:number, staleRegionKeys:string[]}}
+ */
+export function computeFreshness(rows = [], opts = {}) {
+  const { now = 0, staleAfterMs = 7 * 24 * 60 * 60 * 1000 } = opts;
+  let fresh = 0;
+  let stale = 0;
+  let oldestAgeMs = 0;
+  const staleRegionKeys = [];
+
+  for (const r of rows) {
+    const scoredMs = r.last_scored_at ? Date.parse(r.last_scored_at) : NaN;
+    const ageMs = Number.isFinite(scoredMs) ? now - scoredMs : Infinity;
+    if (ageMs > oldestAgeMs && Number.isFinite(ageMs)) oldestAgeMs = ageMs;
+    if (ageMs > staleAfterMs) {
+      stale += 1;
+      staleRegionKeys.push(r.region_key);
+    } else {
+      fresh += 1;
+    }
+  }
+
+  return { fresh, stale, oldestAgeMs, staleRegionKeys };
+}

--- a/lib/fable-suitability/mode-b-seam.mjs
+++ b/lib/fable-suitability/mode-b-seam.mjs
@@ -1,0 +1,71 @@
+/**
+ * mode-b-seam.mjs — the Solomon Mode-B read seam. Ships INERT but REACHABLE.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C (FR-3).
+ *
+ * When Solomon un-parks, its Mode-B (leo_protocol_sections #611, "Solomon Role Contract") consults
+ * additional PRIORITY SOURCES to decide what to work on. This seam projects child A's
+ * v_fable_suitability_map_current into a versioned, machine-readable candidate contract that Mode-B
+ * can read as one such source.
+ *
+ * DARK-SHIP GUARD (RISK R3 — the single gating risk): Solomon is parked, so NOTHING calls this in
+ * production yet. But a seam that is never exercised silently rots (a whole-seam mock ships green on
+ * dead code). Two things keep it honest: the dry-run entrypoint (scripts/fable-suitability/dry-run.mjs)
+ * exercises the real produce->persist->read path, and the versioned contract test reads this back via
+ * a fixture consumer. The contract is VERSIONED so an un-park is wire-up (bump-aware) not archaeology.
+ *
+ * CEREMONY_PENDING-aware: while child A's table/view is unapplied, this returns an empty inert result
+ * (status 'CEREMONY_PENDING') rather than throwing — the seam exists and is reachable, just dormant.
+ */
+import { isMissingTableError } from './map-writer.mjs';
+
+/**
+ * The Mode-B read contract version. Bump when the candidate shape changes so an un-parking Solomon
+ * detects a mismatch instead of silently mis-reading.
+ */
+export const MODE_B_CONTRACT_VERSION = 1;
+
+const CURRENT_VIEW = 'v_fable_suitability_map_current';
+
+/** Project a raw current-view row into the versioned Mode-B candidate shape. */
+export function toModeBCandidate(row) {
+  return {
+    contract_version: MODE_B_CONTRACT_VERSION,
+    region_key: row.region_key,
+    repo: row.repo,
+    duty_cluster: row.duty_cluster,
+    composite_score: row.composite_score,
+    score_version: row.score_version,
+    scored_at: row.last_scored_at,
+    rationale: row.evidence?.axes
+      ? [row.evidence.axes.impact?.rationale, row.evidence.axes.opportunity?.rationale, row.evidence.axes.reasoning_depth?.rationale]
+          .filter(Boolean)
+          .join(' | ')
+      : null,
+    source: 'fable-suitability-map',
+  };
+}
+
+/**
+ * Read the current Mode-B candidate list (highest composite first). Inert-but-reachable: returns
+ * a typed CEREMONY_PENDING result while child A is unapplied.
+ * @returns {Promise<{status:'ok', contract_version:number, candidates:object[]} | {status:'CEREMONY_PENDING', contract_version:number, candidates:[]}>}
+ */
+export async function readModeBCandidates(supabase, { dutyCluster = null, limit = 20 } = {}) {
+  let query = supabase.from(CURRENT_VIEW).select('*');
+  if (dutyCluster) query = query.eq('duty_cluster', dutyCluster);
+
+  const { data, error } = await query;
+  if (error) {
+    if (isMissingTableError(error)) {
+      return { status: 'CEREMONY_PENDING', contract_version: MODE_B_CONTRACT_VERSION, candidates: [] };
+    }
+    throw new Error(`readModeBCandidates: ${error.message}`);
+  }
+
+  const candidates = (data || [])
+    .map(toModeBCandidate)
+    .sort((a, b) => (b.composite_score ?? -1) - (a.composite_score ?? -1))
+    .slice(0, Number.isInteger(limit) && limit > 0 ? limit : 20);
+
+  return { status: 'ok', contract_version: MODE_B_CONTRACT_VERSION, candidates };
+}

--- a/scripts/fable-suitability/dry-run.mjs
+++ b/scripts/fable-suitability/dry-run.mjs
@@ -78,7 +78,14 @@ async function main() {
   const files = collectFiles(root, join(root, dir), [], 200);
   const regions = buildRegionBatch(files, root, 'EHG_Engineer', duty).slice(0, max);
 
-  const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  // Disable the auth auto-refresh timer + session persistence: this is a one-shot CLI, and the
+  // lingering setInterval handle is what trips the Windows libuv teardown assertion on exit
+  // (fable-suitability dry-run must honor its documented exit-0 contract, FR-4).
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
   const client = noModel ? deterministicClient : requireInjectedClient();
 
   const result = await runFanout({
@@ -112,5 +119,7 @@ function requireInjectedClient() {
 
 const invokedDirectly = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedDirectly) {
-  main().then(() => process.exit(0)).catch((err) => { console.error('dry-run failed:', err.message); process.exit(1); });
+  // Set exitCode and let the event loop drain naturally (auth timer disabled above) rather than a
+  // hard process.exit that trips the Windows libuv teardown assertion mid-handle-close.
+  main().then(() => { process.exitCode = 0; }).catch((err) => { console.error('dry-run failed:', err.message); process.exitCode = 1; });
 }

--- a/scripts/fable-suitability/dry-run.mjs
+++ b/scripts/fable-suitability/dry-run.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * dry-run.mjs — INERT-BUT-REACHABLE Fable-suitability entrypoint.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C (FR-4).
+ *
+ * Proves the whole path is REACHABLE (RISK R3 anti dark-ship): it ACTUALLY scans a real slice of the
+ * live codebase, derives regions, runs child B's scorers, attempts to persist via child A's writer,
+ * and writes a REAL ranked artifact. It is NOT a mock. With child A still STAGED the persist returns
+ * CEREMONY_PENDING per region (inert) — the ranked artifact is still produced, so the chairman can
+ * validate ranking quality BEFORE the apply ceremony.
+ *
+ * --no-model (default in CI): use a deterministic reasoning-depth stub so the run needs no live
+ * model. Without it, an injected Sonnet-floor client would be required (NEVER Fable).
+ *
+ * Usage:
+ *   node scripts/fable-suitability/dry-run.mjs [--dir lib/fable-suitability] [--duty harness-depth] [--no-model] [--max 10]
+ * Exits 0 on a successful reachable run (even when every persist is CEREMONY_PENDING).
+ */
+import 'dotenv/config';
+import { readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { deriveRegion } from '../../lib/fable-suitability/region-cluster.mjs';
+import { upsertRegionScore } from '../../lib/fable-suitability/map-writer.mjs';
+import { runFanout } from '../../lib/fable-suitability/fanout.mjs';
+
+/** Deterministic reasoning-depth stub for --no-model runs (mid band, no live call). */
+export const deterministicClient = {
+  async scoreStructured() {
+    return { score: 3, rationale: 'deterministic --no-model stub (neutral judgment)' };
+  },
+};
+
+/** Walk a directory (bounded) and collect source files. */
+function collectFiles(root, dir, out = [], cap = 200) {
+  for (const entry of readdirSync(dir)) {
+    if (out.length >= cap) break;
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectFiles(root, full, out, cap);
+    else if (/\.(m?js|ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** Build a batch of {region, signals, dutyCluster} from a codebase slice. Coarse, real, cheap. */
+export function buildRegionBatch(files, root, repo, dutyCluster) {
+  const byRegion = new Map();
+  for (const f of files) {
+    const rel = relative(root, f);
+    let region;
+    try { region = deriveRegion(rel, { repo }); } catch { continue; }
+    if (!byRegion.has(region)) byRegion.set(region, { files: 0 });
+    byRegion.get(region).files += 1;
+  }
+  return [...byRegion.entries()].map(([region_key, agg]) => ({
+    region: { region_key, repo, summary: `${agg.files} source file(s)` },
+    dutyCluster,
+    signals: {
+      impact: { centrality: Math.min(20, agg.files), fanOut: Math.min(15, agg.files), crossRepoCount: 1 },
+      opportunity: { issuePatterns: [], bypassCount: 0, failurePatternCount: 0, consumerCount: agg.files, churn: 1, complexityProxy: agg.files },
+      reasoning: { blastRadius: agg.files, lookAhead: agg.files },
+    },
+  }));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dir = argVal(args, '--dir') || 'lib/fable-suitability';
+  const duty = argVal(args, '--duty') || 'harness-depth';
+  const max = Number(argVal(args, '--max')) || 10;
+  const noModel = args.includes('--no-model');
+
+  const root = process.cwd();
+  const files = collectFiles(root, join(root, dir), [], 200);
+  const regions = buildRegionBatch(files, root, 'EHG_Engineer', duty).slice(0, max);
+
+  const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const client = noModel ? deterministicClient : requireInjectedClient();
+
+  const result = await runFanout({
+    regions,
+    client,
+    persist: (row) => upsertRegionScore(supabase, row),
+    maxBatch: max,
+  });
+
+  const ranked = result.scored
+    .map((r) => ({ region_key: r.region_key, duty_cluster: r.duty_cluster, composite_score: r.composite_score, axes: [r.axis_impact, r.axis_opportunity, r.axis_reasoning_depth] }))
+    .sort((a, b) => b.composite_score - a.composite_score);
+
+  const outDir = join(tmpdir(), 'fable-suitability');
+  mkdirSync(outDir, { recursive: true });
+  const artifact = join(outDir, `dry-run-ranked-${duty}-${regions.length}.json`);
+  writeFileSync(artifact, JSON.stringify({ duty, generated_from: dir, ranked, persistedSummary: { persisted: result.persisted, ceremonyPending: result.ceremonyPending, skipped: result.skipped.length } }, null, 2));
+
+  console.log(`\n── Fable-suitability DRY-RUN (inert-but-reachable) ──`);
+  console.log(`   scanned ${files.length} file(s) in ${dir} -> ${regions.length} region(s), duty=${duty}${noModel ? ' (--no-model stub)' : ''}`);
+  console.log(`   scored ${result.scored.length}; persisted ${result.persisted}; CEREMONY_PENDING ${result.ceremonyPending} (child A staged => inert)`);
+  console.log(`   ranked artifact: ${artifact}`);
+  for (const r of ranked.slice(0, 5)) console.log(`     ${r.composite_score}  ${r.region_key}  [${r.axes.join('x')}]`);
+  console.log(`   ✅ path reachable end-to-end (produce -> score -> persist); exit 0`);
+}
+
+function argVal(args, flag) { const i = args.indexOf(flag); return i !== -1 ? args[i + 1] : null; }
+function requireInjectedClient() {
+  throw new Error('dry-run: a Sonnet-floor model client must be injected for a live-model run; use --no-model for CI. (NEVER Fable — parked/expensive tier.)');
+}
+
+const invokedDirectly = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().then(() => process.exit(0)).catch((err) => { console.error('dry-run failed:', err.message); process.exit(1); });
+}

--- a/tests/database/fable-suitability-seam.db.test.js
+++ b/tests/database/fable-suitability-seam.db.test.js
@@ -1,0 +1,82 @@
+/**
+ * Live-DB seam contract e2e for the Fable-suitability Mode-B seam.
+ * SD-LEO-INFRA-FABLE-SUITABILITY-MAP-001-C (FR-5, TS-6).
+ *
+ * Recurred-family rule: mocking the WHOLE seam ships green on dead code. This test drives the REAL
+ * produce -> persist -> read path — fan-out (child B scorers) -> child A upsertRegionScore ->
+ * readModeBCandidates -> a FIXTURE consumer standing in for parked Solomon Mode-B — so the seam is
+ * provably wired, not merely present.
+ *
+ * Two-state around the STAGED child-A gate:
+ *   - Child A unapplied  -> persist returns CEREMONY_PENDING and the seam returns the inert
+ *     CEREMONY_PENDING result. We assert THAT (reachable-but-dormant proven against a real absent view).
+ *   - Child A applied     -> a real ranked candidate round-trips to the fixture consumer at the
+ *     current MODE_B_CONTRACT_VERSION.
+ */
+import { afterAll, beforeAll, it, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { describeDb } from '../helpers/db-available.js';
+import { upsertRegionScore } from '../../lib/fable-suitability/map-writer.mjs';
+import { runFanout } from '../../lib/fable-suitability/fanout.mjs';
+import { readModeBCandidates, MODE_B_CONTRACT_VERSION } from '../../lib/fable-suitability/mode-b-seam.mjs';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const TEST_REGION = 'ehg_engineer/__test__/fable-seam-ts6';
+const detClient = { async scoreStructured() { return { score: 4, rationale: 'seam e2e' }; } };
+
+/** Fixture Mode-B consumer: reads candidates and validates the versioned contract (stands in for Solomon). */
+function fixtureModeBConsumer(seamResult) {
+  if (seamResult.contract_version !== MODE_B_CONTRACT_VERSION) throw new Error('contract version mismatch');
+  return seamResult.candidates.filter((c) => c.source === 'fable-suitability-map');
+}
+
+async function tableApplied() {
+  const { error } = await supabase.from('fable_suitability_map').select('id').limit(1);
+  return !error;
+}
+
+describeDb('Fable-suitability Mode-B seam — real produce->persist->read e2e (TS-6)', () => {
+  let applied = false;
+
+  beforeAll(async () => {
+    applied = await tableApplied();
+    if (applied) await supabase.from('fable_suitability_map').delete().eq('region_key', TEST_REGION);
+  });
+  afterAll(async () => {
+    if (applied) await supabase.from('fable_suitability_map').delete().eq('region_key', TEST_REGION);
+  });
+
+  it('drives fan-out -> persist -> Mode-B read to a fixture consumer', async () => {
+    const regions = [{
+      region: { region_key: TEST_REGION, repo: 'EHG_Engineer', summary: 'seam e2e' },
+      dutyCluster: 'harness-depth',
+      signals: {
+        impact: { centrality: 20, fanOut: 15, crossRepoCount: 2 },
+        opportunity: { issuePatterns: [{ id: 'x', occurrence_count: 45, trend: 'increasing' }], bypassCount: 5, failurePatternCount: 5, consumerCount: 20, churn: 30, complexityProxy: 8 },
+        reasoning: { blastRadius: 5, lookAhead: 5 },
+      },
+    }];
+
+    const fan = await runFanout({ regions, client: detClient, persist: (row) => upsertRegionScore(supabase, row), maxBatch: 5 });
+    expect(fan.scored).toHaveLength(1); // scoring is real regardless of persist state
+
+    const seamResult = await readModeBCandidates(supabase, { dutyCluster: 'harness-depth' });
+
+    if (!applied) {
+      // Reachable-but-dormant: persist and seam are both CEREMONY_PENDING against the real absent view.
+      expect(fan.ceremonyPending).toBe(1);
+      expect(seamResult.status).toBe('CEREMONY_PENDING');
+      expect(seamResult.candidates).toHaveLength(0);
+      return;
+    }
+
+    // Applied: a real candidate round-trips to the fixture consumer at the current contract version.
+    expect(fan.persisted).toBe(1);
+    expect(seamResult.status).toBe('ok');
+    const consumed = fixtureModeBConsumer(seamResult);
+    const mine = consumed.filter((c) => c.region_key === TEST_REGION);
+    expect(mine).toHaveLength(1);
+    expect(mine[0].contract_version).toBe(MODE_B_CONTRACT_VERSION);
+    expect(mine[0].composite_score).toBeGreaterThan(0); // a real ranked composite persisted + read back
+  });
+});

--- a/tests/unit/fable-suitability/activation.test.js
+++ b/tests/unit/fable-suitability/activation.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { runFanout, hashRegionInputs } from '../../../lib/fable-suitability/fanout.mjs';
+import { evaluateRefloat, computeFreshness } from '../../../lib/fable-suitability/living-update.mjs';
+import { readModeBCandidates, toModeBCandidate, MODE_B_CONTRACT_VERSION } from '../../../lib/fable-suitability/mode-b-seam.mjs';
+
+const mockClient = { async scoreStructured() { return { score: 3, rationale: 'mid' }; } };
+
+function region(key, files = 5) {
+  return {
+    region: { region_key: key, repo: 'EHG_Engineer', summary: `${files} files` },
+    dutyCluster: 'harness-depth',
+    signals: {
+      impact: { centrality: files, fanOut: files, crossRepoCount: 1 },
+      opportunity: { issuePatterns: [], bypassCount: 0, failurePatternCount: 0, consumerCount: files, churn: 1, complexityProxy: files },
+      reasoning: { blastRadius: files, lookAhead: files },
+    },
+  };
+}
+
+describe('runFanout — cost bound (FR-1 / TS-1)', () => {
+  it('skips a region whose input-hash is unchanged (cache hit)', async () => {
+    const r = region('ehg_engineer/lib/a');
+    const cache = new Map([[r.region.region_key, hashRegionInputs(r.region, r.signals)]]);
+    const persistCalls = [];
+    const out = await runFanout({ regions: [r], client: mockClient, persist: async (row) => { persistCalls.push(row); return { status: 'CEREMONY_PENDING' }; }, cache });
+    expect(out.skipped).toContain(r.region.region_key);
+    expect(out.scored).toHaveLength(0);
+    expect(persistCalls).toHaveLength(0);
+  });
+
+  it('scores only changed regions and respects maxBatch', async () => {
+    const regions = [region('ehg_engineer/lib/a'), region('ehg_engineer/lib/b'), region('ehg_engineer/lib/c')];
+    const out = await runFanout({ regions, client: mockClient, persist: async () => ({ status: 'CEREMONY_PENDING' }), maxBatch: 2 });
+    expect(out.scored).toHaveLength(2);
+    expect(out.batchTruncated).toBe(true);
+  });
+
+  it('CEREMONY_PENDING persist does not abort the run (inert-but-reachable)', async () => {
+    const out = await runFanout({ regions: [region('ehg_engineer/lib/a')], client: mockClient, persist: async () => ({ status: 'CEREMONY_PENDING' }) });
+    expect(out.scored).toHaveLength(1);
+    expect(out.ceremonyPending).toBe(1);
+    expect(out.persisted).toBe(0);
+  });
+
+  it('counts a successful persist', async () => {
+    const out = await runFanout({ regions: [region('ehg_engineer/lib/a')], client: mockClient, persist: async () => ({ status: 'ok' }) });
+    expect(out.persisted).toBe(1);
+  });
+});
+
+describe('evaluateRefloat — debounced threshold (FR-2 / TS-2)', () => {
+  const base = { region_key: 'lib/x', score_version: 1, recurrence_weight: 2, refloated_at: null };
+
+  it('re-floats when recurrence climbs past threshold', () => {
+    const r = evaluateRefloat(base, { recurrenceWeight: 4 }, { threshold: 1, now: 1_000_000_000_000 });
+    expect(r.refloat).toBe(true);
+    expect(r.patch.score_version).toBe(2);
+    expect(r.patch.trigger_reason).toMatch(/recurrence/);
+    expect(r.patch.input_snapshot).toBeTruthy();
+  });
+
+  it('does NOT re-float below threshold', () => {
+    const r = evaluateRefloat(base, { recurrenceWeight: 2.5 }, { threshold: 1, now: 1_000_000_000_000 });
+    expect(r.refloat).toBe(false);
+  });
+
+  it('does NOT re-float within the debounce window', () => {
+    const recent = { ...base, refloated_at: new Date(1_000_000_000_000 - 1000).toISOString() };
+    const r = evaluateRefloat(recent, { recurrenceWeight: 10 }, { threshold: 1, debounceMs: 60_000, now: 1_000_000_000_000 });
+    expect(r.refloat).toBe(false);
+    expect(r.reason).toMatch(/debounce/);
+  });
+});
+
+describe('computeFreshness — observable gauge (FR-2 / TS-3)', () => {
+  it('reports stale regions past staleAfterMs', () => {
+    const now = 1_000_000_000_000;
+    const rows = [
+      { region_key: 'fresh', last_scored_at: new Date(now - 1000).toISOString() },
+      { region_key: 'stale', last_scored_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString() },
+    ];
+    const g = computeFreshness(rows, { now, staleAfterMs: 7 * 24 * 60 * 60 * 1000 });
+    expect(g.fresh).toBe(1);
+    expect(g.stale).toBe(1);
+    expect(g.staleRegionKeys).toContain('stale');
+  });
+});
+
+describe('mode-b-seam — versioned inert-but-reachable contract (FR-3 / TS-4)', () => {
+  it('projects a current-view row into the versioned candidate shape', () => {
+    const cand = toModeBCandidate({
+      region_key: 'ehg_engineer/lib/gates', repo: 'EHG_Engineer', duty_cluster: 'harness-depth',
+      composite_score: 60, score_version: 2, last_scored_at: '2026-07-17T00:00:00.000Z',
+      evidence: { axes: { impact: { rationale: 'i' }, opportunity: { rationale: 'o' }, reasoning_depth: { rationale: 'r' } } },
+    });
+    expect(cand.contract_version).toBe(MODE_B_CONTRACT_VERSION);
+    expect(cand.source).toBe('fable-suitability-map');
+    expect(cand.rationale).toBe('i | o | r');
+  });
+
+  it('returns CEREMONY_PENDING (inert) when the view is missing, without throwing', async () => {
+    // The no-filter path awaits select('*') directly; resolve it with the PostgREST missing-table error.
+    const seam = {
+      from() {
+        return { select() { return Promise.resolve({ error: { code: 'PGRST205', message: 'Could not find the table' } }); } };
+      },
+    };
+    const r = await readModeBCandidates(seam);
+    expect(r.status).toBe('CEREMONY_PENDING');
+    expect(r.contract_version).toBe(MODE_B_CONTRACT_VERSION);
+    expect(r.candidates).toHaveLength(0);
+  });
+
+  it('returns sorted candidates on a successful read', async () => {
+    const rows = [
+      { region_key: 'a', repo: 'EHG_Engineer', duty_cluster: 'dedup', composite_score: 10, score_version: 1, last_scored_at: 't', evidence: {} },
+      { region_key: 'b', repo: 'EHG_Engineer', duty_cluster: 'dedup', composite_score: 40, score_version: 1, last_scored_at: 't', evidence: {} },
+    ];
+    const seam = { from() { return { select() { return Promise.resolve({ data: rows, error: null }); } }; } };
+    const r = await readModeBCandidates(seam);
+    expect(r.status).toBe('ok');
+    expect(r.candidates[0].region_key).toBe('b'); // highest composite first
+  });
+});


### PR DESCRIPTION
## Summary
Child C — the final piece of the Fable-suitability orchestrator (depends on A #6205 + B #6207, both merged). **Activation + wiring.** Ships **inert** (Solomon parked, child A STAGED) but proven **reachable** — the anti dark-ship guarantee.

Three subsystems, each answering a governing risk:
1. **Cost-bounded cheap-model fan-out** (`fanout.mjs`, RISK R5) — `maxBatch` ceiling + input-hash **cache** (skip unchanged) + **incremental** (re-score only changed regions). Injected **Sonnet-floor** client (never Fable — Fable is the expensive tier this map *protects*). CEREMONY_PENDING-aware persist. Assigns the `score_version` child B intentionally omits.
2. **Living-update** (`living-update.mjs`, RISK R2) — **debounced, threshold-gated** re-float off the recurrence stream (not per-event), provenance-stamped (score_version bump + refloated_at + trigger_reason + input snapshot). `computeFreshness` is an **observable** staleness gauge (LIVENESS ≠ CLOSURE).
3. **Solomon Mode-B seam** (`mode-b-seam.mjs`, RISK R3 — the gating risk) — a **versioned** (`MODE_B_CONTRACT_VERSION`) candidate read-contract over child A's current view; inert CEREMONY_PENDING result while staged.

## Anti dark-ship (why this isn't green-on-dead-code)
- **Dry-run entrypoint** (`scripts/fable-suitability/dry-run.mjs`) — really scans a live codebase slice, scores, attempts persist, writes a ranked artifact, exits 0. Verified: scanned 11 files → scored → CEREMONY_PENDING persist → artifact.
- **Real-DB seam e2e** — drives real produce → child-A persist → `readModeBCandidates` → a **fixture** Mode-B consumer. Asserts the CEREMONY_PENDING inert path while child A is staged. **No full-seam mock** (recurred-family rule).

## Docs
Appends **§7** to the existing `solomon-activation-runbook.md` (does not clobber it) registering the read-contract + un-park wire-up; launch-time pointer persisted at `metadata.solomon_modeb_seam`.

## Test plan
- [x] 9 unit (cache/incremental, refloat threshold+debounce, freshness gauge, versioned contract shape + inert path).
- [x] Real-DB skipIf seam e2e (produce→persist→read to fixture consumer / CEREMONY_PENDING inert).
- [x] Dry-run entrypoint executes end-to-end, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)