### PR TITLE
fix(P0): post-merge cleanup must leave a live worktree in place, not archive-move it

### DIFF
--- a/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js
+++ b/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js
@@ -258,7 +258,11 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
   beforeEach(() => { env = setupTmpRepo(); });
   afterEach(() => cleanupTmp(env));
 
-  it('archives instead of deletes when active claim matches', async () => {
+  // P0 fix (feedback 65ef1075, Golf-3 2026-07-17): a LIVE claim must LEAVE the
+  // worktree fully in place. The prior behavior archived (moved) it, which yanked
+  // the active session's working dir out from under it — the reported P0. Archiving
+  // preserves the files but breaks the live session; leave-in-place preserves both.
+  it('leaves the worktree fully in place when active claim matches (does NOT move/archive)', async () => {
     const sb = mockSupabase({
       data: [{
         session_id: 'sess-A',
@@ -273,11 +277,11 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
     expect(result.cleaned).toBe(false);
     expect(result.reason).toBe('active_claim_protect');
     expect(result.claim?.session_id).toBe('sess-A');
-    // archive succeeded → original wtPath no longer present
-    expect(fs.existsSync(env.wtPath)).toBe(false);
-    // archive should exist under .worktrees/_archive
-    const archiveDir = path.join(env.main, '.worktrees', '_archive');
-    expect(fs.existsSync(archiveDir)).toBe(true);
+    // Live claim → worktree left untouched at its original path.
+    expect(fs.existsSync(env.wtPath)).toBe(true);
+    // Nothing was moved: no _archive dir was created, and the result carries no archivePath.
+    expect(fs.existsSync(path.join(env.main, '.worktrees', '_archive'))).toBe(false);
+    expect(result.archivePath).toBeUndefined();
   });
 
   it('proceeds with cleanup when no active claim matches', async () => {
@@ -288,19 +292,36 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
   });
 
   // R-6 (testing-agent binding): PostgrestError must NOT escape cleanupWorktreeByPath.
-  // Translate to fail-SAFE — treat unknown DB state as if a claim is held + archive
-  // (preserves work). This is the crucial UX guarantee for /ship CLI on a transient
-  // DB blip — a thrown PostgrestError would have been worse than the bug being fixed.
-  it('R-6: fail-safe on PostgrestError — archives, returns reason=db_error_fail_safe, no throw', async () => {
+  // Translate to fail-SAFE — treat unknown DB state as if a claim is held. P0 fix
+  // (feedback 65ef1075): "as if a claim is held" means LEAVE IN PLACE, not archive.
+  // Moving a possibly-live worktree is the exact P0; leave-in-place preserves the
+  // work AND avoids breaking a live session. A thrown PostgrestError is still averted.
+  it('R-6: fail-safe on PostgrestError — leaves worktree in place, reason=db_error_fail_safe, no throw', async () => {
     const sb = mockSupabase({ error: { message: 'connection terminated', code: 'XX000' } });
     const result = await cleanupWorktreeByPath(env.wtPath, { supabase: sb });
     expect(result.cleaned).toBe(false);
     expect(result.reason).toBe('db_error_fail_safe');
     expect(result.error).toMatch(/connection terminated/);
-    // Archive on fail-safe to preserve work (worktree may have uncommitted state).
+    // Fail-safe = do not touch the worktree (it may host a live session).
+    expect(fs.existsSync(env.wtPath)).toBe(true);
+    expect(fs.existsSync(path.join(env.main, '.worktrees', '_archive'))).toBe(false);
+    expect(result.archivePath).toBeUndefined();
+  });
+
+  // Surgical-fix pin: the delete-abort path (unpushed commits, NO active claim) must
+  // STILL archive — the P0 fix only stops archiving on the live-claim/DB-error paths,
+  // it must not regress code-loss prevention where there is genuinely no live session.
+  it('still archives on unpushed_commits when no active claim (code-loss prevention intact)', async () => {
+    // Create an unpushed commit in the worktree, with no matching active claim.
+    fs.writeFileSync(path.join(env.wtPath, 'unpushed.txt'), 'work in progress');
+    execSync('git add . && git commit -m "unpushed work"', { cwd: env.wtPath, stdio: 'pipe' });
+    const sb = mockSupabase({ data: [] }); // no claim
+    const result = await cleanupWorktreeByPath(env.wtPath, { supabase: sb });
+    expect(result.cleaned).toBe(false);
+    expect(result.reason).toBe('unpushed_commits');
+    // Delete-abort with unpushed code → archived (moved) to preserve recoverable copy.
     expect(fs.existsSync(env.wtPath)).toBe(false);
-    const archiveDir = path.join(env.main, '.worktrees', '_archive');
-    expect(fs.existsSync(archiveDir)).toBe(true);
+    expect(fs.existsSync(path.join(env.main, '.worktrees', '_archive'))).toBe(true);
   });
 });
 

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -330,27 +330,40 @@ async function cleanupWorktreeByPath(wtPath, options = {}) {
   try {
     claim = await hasActiveClaimOnBranch(wtPath, mainRepoPath, options);
   } catch (err) {
-    const archive = archiveWorktree(wtPath, sdKey);
+    // P0 fix (feedback 65ef1075, Golf-3 2026-07-17): on unknown DB state we fail SAFE
+    // by treating the worktree as if a live claim is held — which means LEAVE IT
+    // COMPLETELY IN PLACE. The prior behavior archived here, but archiveWorktree()
+    // MOVES the tree (fs.renameSync → _archive) + `git worktree prune`, destroying a
+    // live session's working directory out from under it. Not touching it preserves
+    // both the work AND the live session; a genuinely-dead worktree is reaped later
+    // via the stale-heartbeat path. Archiving is only correct on the actual
+    // delete-abort path (unpushed_commits below), where no live session is present.
     console.warn(JSON.stringify({
       event: 'worktree.cleanup_blocked_by_db_error',
       wtPath, sdKey, error: err.message,
-      archivePath: archive.archivePath,
+      action: 'left_in_place',
       timestamp: new Date().toISOString()
     }));
-    return { cleaned: false, reason: 'db_error_fail_safe', error: err.message, ...archive, mainRepoPath, workKey: sdKey };
+    return { cleaned: false, reason: 'db_error_fail_safe', error: err.message, mainRepoPath, workKey: sdKey };
   }
   if (claim) {
-    const archive = archiveWorktree(wtPath, sdKey);
+    // P0 fix (feedback 65ef1075, Golf-3 2026-07-17): a live worker still holds the
+    // claim (fresh heartbeat) or is cwd'd here (live-cwd guard) → LEAVE THE WORKTREE
+    // COMPLETELY IN PLACE. Do NOT archive: archiveWorktree() moves the tree to
+    // _archive and prunes it from git, which yanked the active session's working dir
+    // out from under it (witnessed: dir gone from disk + `git worktree list`, copy in
+    // _archive, cleaned:false reported all the same). For a live claim there is nothing
+    // to "preserve" by moving — the owner is alive and will clean up / ship normally.
     const blockedEntry = {
       event: 'worktree.cleanup_blocked_by_claim',
       wtPath,
       sdKey,
       claim,
-      archivePath: archive.archivePath,
+      action: 'left_in_place',
       timestamp: new Date().toISOString()
     };
     console.warn(JSON.stringify(blockedEntry));
-    return { cleaned: false, reason: 'active_claim_protect', claim, ...archive, mainRepoPath, workKey: sdKey };
+    return { cleaned: false, reason: 'active_claim_protect', claim, mainRepoPath, workKey: sdKey };
   }
 
   // SD-MAN-INFRA-WORKTREE-CODE-LOSS-001 (FR-2): Block cleanup if unpushed commits

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -217,14 +217,6 @@
       "triaged_by": "SD-REFILL-00L29WFH"
     },
     {
-      "file": "scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "AssertionError: expected -1 to be greater than 662",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "scripts/twoway-roundtrip.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected false to be true // Object.is equality",

--- a/tests/unit/post-merge-orphan-from-merge.test.js
+++ b/tests/unit/post-merge-orphan-from-merge.test.js
@@ -4,7 +4,8 @@
  * Verifies the NEW seam wiring the previously-dead detectOrphanWorktreeFromMerge
  * detector into the claim-aware post-merge cleanup:
  *   TS-6 positive: orphan detected + live claim → routed through cleanupWorktreeByPath
- *                  → archive-not-delete (NOT a hard delete).
+ *                  → left in place (NOT moved/archived, NOT hard-deleted). P0 fix 65ef1075:
+ *                  a live claim must not be relocated out from under the active session.
  *   TS-7 negative: merge output with no deleted branch → no_orphan_detected.
  *   mapping: feat/<SD> → .worktrees/<SD>; qf/<QF> → .worktrees/qf/<QF>.
  *   advisory: function returns a result object and never throws on the
@@ -73,7 +74,7 @@ describe('cleanupOrphanFromMergeOutput (FR-2 detector wiring)', () => {
     expect(res.candidate.replace(/\\/g, '/')).toMatch(/\.worktrees\/qf\/QF-20260101-001$/);
   });
 
-  it('TS-6: orphan detected + live claim → archived (claim-aware, NOT hard-deleted)', async () => {
+  it('TS-6: orphan detected + live claim → left in place (claim-aware, NOT moved/archived)', async () => {
     const mainRepoPath = makeTmpRepo();
     const wt = path.join(mainRepoPath, '.worktrees', 'SD-FOO-001');
     fs.mkdirSync(wt, { recursive: true });
@@ -93,14 +94,17 @@ describe('cleanupOrphanFromMergeOutput (FR-2 detector wiring)', () => {
       { mainRepoPath, supabase }
     );
 
-    // Routed through claim-aware cleanup → archived, not deleted.
+    // Routed through claim-aware cleanup → LEFT IN PLACE (P0 fix, feedback 65ef1075).
+    // A live claim must never be moved/archived: archiveWorktree() relocates the tree
+    // and prunes it from git, yanking the active session's working dir out from under
+    // it. The orphan detector inherits this via cleanupWorktreeByPath.
     expect(res.cleaned).toBe(false);
     expect(res.reason).toBe('active_claim_protect');
-    expect(res.archived).toBe(true);
+    expect(res.archived).toBeFalsy();
+    expect(res.archivePath).toBeUndefined();
     expect(res.source).toBe('merge_output_detector');
-    // Original worktree dir moved out (archived), not left in place or hard-removed silently.
-    expect(fs.existsSync(wt)).toBe(false);
-    expect(fs.existsSync(res.archivePath)).toBe(true);
+    // Original worktree dir left untouched at its original path.
+    expect(fs.existsSync(wt)).toBe(true);
   });
 
   it('advisory: never throws on negative/absent inputs (does not hard-fail /ship)', async () => {


### PR DESCRIPTION
## Summary

Fixes a **P0 data-loss bug** in post-merge worktree cleanup (feedback `65ef1075`, reported by Golf-3 on 2026-07-17).

`post-merge-worktree-cleanup.js` reported `{cleaned:false, reason:active_claim_protect}` for a **still-claimed** worktree — correctly refusing to *clean* it — but the worktree was nonetheless **removed from disk and from `git worktree list`**, with a full copy dumped in `.worktrees/_archive/`. The "protection" yanked a live worker's working directory out from under them.

## Root cause

On the two abort-cleanup guard paths — `active_claim_protect` (a live worker still holds the claim / is cwd'd in the tree) and `db_error_fail_safe` (unknown DB state) — `cleanupWorktreeByPath()` called `archiveWorktree()`, which does `fs.renameSync(wtPath, archivePath)` + `git worktree prune`. That **moves** the worktree, it doesn't copy it.

`archiveWorktree()` was introduced (SD-MAN-INFRA-WORKTREE-CODE-LOSS-001) as a *safe alternative to hard-delete*. But an abort-cleanup guard path is not a delete path — the worker is **alive** and still using the tree. Moving it breaks the live session (the recurring "gitdir wiped mid-EXEC → PR wrong head_ref" incident family cited in the file's own comments).

## Fix

- `active_claim_protect` and `db_error_fail_safe` now **leave the worktree fully in place** (no move, no prune). Nothing is "preserved" by relocating a live worktree; the owner is alive and will clean up / ship normally, and a genuinely-dead worktree is reaped later via the stale-heartbeat path.
- `archiveWorktree()` is **retained** on the real delete-abort path (`unpushed_commits`, where there is no live claim) — code-loss prevention there is legitimate.

## Why it slipped: quarantined regression test

The claim-protect suite has been in `tests/quarantine-manifest.json` since **2026-06-11** (stale `assertion-drift`: `"expected -1 to be greater than 662"` from the static-guard source-ordering pin, resolved long ago). So the protective test **never ran in CI** — the exact reason this P0 escaped. This PR un-quarantines it (config doc: *"un-quarantine = delete the entry"*).

## Test plan

Suite now green **17/17** under the default runner (previously excluded):

- ✅ leaves worktree in place on active claim *(was: asserted it gets moved/archived)*
- ✅ leaves worktree in place on DB-error fail-safe *(was: asserted moved/archived)*
- ✅ **new pin**: still archives on `unpushed_commits` — proves the fix is surgical
- ✅ all `hasActiveClaimOnBranch` + static-guard + schema-projection pins unchanged

## Merge note

Holding auto-merge: this reverses previously-tested behavior on fleet-critical shipping automation, so it warrants a human/coordinator glance. The change's downside is benign (a dead worktree lingers slightly longer before reaping) vs. the status-quo's severe downside (active data-loss), so **expedited review + merge is recommended** while the P0 is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
