### PR TITLE
fix: terminal-status guard on resume-eligibility queries (feedback d19f7f7e)

### DIFF
--- a/scripts/get-working-on-sd.js
+++ b/scripts/get-working-on-sd.js
@@ -119,6 +119,10 @@ async function getWorkingOnSD() {
         .from('strategic_directives_v2')
         .select(SD_COLUMNS)
         .eq('claiming_session_id', sessionId)
+        // feedback d19f7f7e: terminal-status guard — a CANCELLED/COMPLETED SD with a
+        // stale is_working_on=true / claim must never be reported as resume-eligible
+        // (would steer /leo continue into cancelled scope).
+        .not('status', 'in', '(cancelled,completed)')
         .lt('progress', 100);
       if (!ownError && ownClaim && ownClaim.length > 0) {
         workingOn = ownClaim;
@@ -146,6 +150,8 @@ async function getWorkingOnSD() {
         .from('strategic_directives_v2')
         .select(SD_COLUMNS)
         .or('claiming_session_id.not.is.null,is_working_on.eq.true')
+        // feedback d19f7f7e: same terminal-status guard on the spotlight fallback.
+        .not('status', 'in', '(cancelled,completed)')
         .lt('progress', 100);  // Less than 100% complete
 
       if (workingError) {

--- a/tests/unit/get-working-on-sd-session-scoped.test.js
+++ b/tests/unit/get-working-on-sd-session-scoped.test.js
@@ -8,6 +8,15 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+// The terminal-status guard is modeled faithfully: .not('status','in','(cancelled,completed)')
+// filters out rows whose status is terminal, mirroring the PostgREST behavior. This lets
+// the tests assert the guard's EFFECT, not just its presence in source.
+const TERMINAL = ['cancelled', 'completed'];
+function applyTerminalGuard(result) {
+  if (!result?.data) return result;
+  return { ...result, data: result.data.filter((r) => !TERMINAL.includes(r.status)) };
+}
+
 function buildSupabaseMock({ ownClaimResult, liveCountResult, spotlightResult }) {
   return {
     from(table) {
@@ -19,11 +28,11 @@ function buildSupabaseMock({ ownClaimResult, liveCountResult, spotlightResult })
           select: () => ({
             eq: (col) => {
               if (col === 'claiming_session_id') {
-                return { lt: () => Promise.resolve(ownClaimResult) };
+                return { not: () => ({ lt: () => Promise.resolve(applyTerminalGuard(ownClaimResult)) }) };
               }
               throw new Error(`Unexpected eq column: ${col}`);
             },
-            or: () => ({ lt: () => Promise.resolve(spotlightResult) }),
+            or: () => ({ not: () => ({ lt: () => Promise.resolve(applyTerminalGuard(spotlightResult)) }) }),
           }),
         };
       }
@@ -90,6 +99,36 @@ describe('QF-20260703-742: session-scoped getWorkingOnSD resolution', () => {
       ownClaimResult: { data: [], error: null },
       liveCountResult: { count: 3, error: null },
       spotlightResult: { data: null, error: new Error('must not be reached') },
+    });
+
+    const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');
+    const result = await getWorkingOnSD();
+
+    expect(result).toBeNull();
+  });
+
+  // feedback d19f7f7e: terminal-status guard. A CANCELLED/COMPLETED SD with a stale
+  // is_working_on=true / claim must not be reported as resume-eligible.
+  it('own-claim path: a CANCELLED SD with a stale claim is filtered out (not resumable)', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-mine';
+    mockSupabase = buildSupabaseMock({
+      ownClaimResult: { data: [{ id: 'sd-x', sd_key: 'SD-CANCELLED', title: 'Cancelled scope', status: 'cancelled', progress: 40, claiming_session_id: 'session-mine' }], error: null },
+      liveCountResult: { count: 3, error: null }, // multiple live → spotlight would refuse anyway
+      spotlightResult: { data: null, error: new Error('must not be reached') },
+    });
+
+    const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');
+    const result = await getWorkingOnSD();
+
+    expect(result).toBeNull();
+  });
+
+  it('spotlight path: a CANCELLED SD with stale is_working_on is filtered out (not resumable)', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-mine';
+    mockSupabase = buildSupabaseMock({
+      ownClaimResult: { data: [], error: null },
+      liveCountResult: { count: 1, error: null }, // sole live session → spotlight is consulted
+      spotlightResult: { data: [{ id: 'sd-y', sd_key: 'SD-CANCELLED-SPOT', title: 'Cancelled', status: 'cancelled', progress: 20, is_working_on: true }], error: null },
     });
 
     const { default: getWorkingOnSD } = await import('../../scripts/get-working-on-sd.js');


### PR DESCRIPTION
## Summary

Fixes a fleet-safety bug (feedback `d19f7f7e`, Alpha-2 diagnosed): `get-working-on-sd.js` could report a **CANCELLED/COMPLETED** SD as *"Resume eligible"*, steering a worker via `/leo continue` into cancelled scope.

## Root cause

Both resume-resolution queries (session-own claim + single-live-session spotlight fallback) filtered only `progress < 100` — no terminal-status guard. A terminal SD carrying a stale `is_working_on=true` / claim (instance: `SD-LEO-INFRA-ENABLE-TRI-PARTY-001`, cancelled but `is_working_on=true`) slipped through. `checkResumeEligibility()` only inspects the last **handoff** status, not the SD status, so it never caught it.

## Fix (Alpha-2 Fix #1 — defense-in-depth)

Add `.not('status', 'in', '(cancelled,completed)')` to **both** queries. Additive, low blast radius — a read query simply stops returning terminal SDs.

## Test plan

`tests/unit/get-working-on-sd-session-scoped.test.js` — **5/5 green**. The mock now models the guard's *effect* (filters terminal rows), so the two new tests assert a cancelled SD is not returned on **either** the own-claim or spotlight path. The 3 existing session-scoping tests are preserved.

## Follow-up (Alpha-2 Fix #2 — durable root)

Clear `is_working_on` when an SD transitions to a terminal status (trigger/transition-hook). Likely chairman-gated DDL; tracked on feedback `d19f7f7e`.

## Merge note

Holding auto-merge for a human/coordinator glance (consistent with PR #6210), though this change is lower-risk (additive query guard, no behavior reversal, existing tests preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)