### PR TITLE
feat(SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C): FR-3 ground-truth binding gate + regression + sole-writer invariant

### DIFF
--- a/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
+++ b/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
@@ -27,3 +27,47 @@ COMMENT ON COLUMN model_capability_reference.bound_at IS
   'When the ground-truth binding gate (lib/eval/ground-truth-gate.mjs, EVAL-002-C) flipped trusted_for_routing=true. NULL until a grader verdict reproduces an independently-adjudicated verdict.';
 COMMENT ON COLUMN model_capability_reference.binding_id IS
   'Provenance id of the binding run that flipped trusted_for_routing. Set ONLY by the sole-writer gate/regression path; NULL otherwise (incl. after a stale-bind clear).';
+
+-- ---------------------------------------------------------------------------
+-- SOLE-WRITER INVARIANT AT THE DB TIER (RISK e25f3adf, C1 CRITICAL).
+-- The circular-binding hazard is that ANY writer (the canonical child-C binder,
+-- the EVAL-001 sibling script, an ad-hoc psql/service-role UPDATE, a future code
+-- path) could flip trusted_for_routing=true with no adjudicated provenance. Code
+-- guards catch only the writers we know about; this trigger is the durable root-
+-- cause fix — it structurally REJECTS any UPDATE that transitions
+-- trusted_for_routing from false/NULL to true UNLESS the same NEW row carries
+-- BOTH binding_id AND bound_at. It therefore makes circular binding impossible
+-- regardless of which code path attempts the write.
+--
+-- SCOPE: BEFORE UPDATE only. It NEVER constrains true->false — clearing a stale
+-- bind (trusted_for_routing=false, bound_at=NULL, binding_id=NULL) must always be
+-- allowed so a bind cannot outlive the evidence that justified it.
+--
+-- ADDITIVE + IDEMPOTENT: CREATE OR REPLACE FUNCTION; DROP TRIGGER IF EXISTS then
+-- CREATE TRIGGER. Reuses the base table's RLS/service-role policy — no new grants.
+-- By design this file carries NO approved-by attestation; the chairman applies it
+-- at the gated ceremony after review.
+
+CREATE OR REPLACE FUNCTION model_capability_reference_enforce_binding_provenance()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Only guard the false/NULL -> true transition. OLD IS DISTINCT FROM TRUE is
+  -- true when OLD was false OR NULL; leaves true->true and true->false untouched.
+  IF NEW.trusted_for_routing IS TRUE
+     AND (OLD.trusted_for_routing IS DISTINCT FROM TRUE)
+     AND (NEW.binding_id IS NULL OR NEW.bound_at IS NULL) THEN
+    RAISE EXCEPTION
+      'trusted_for_routing cannot be set true without binding provenance (binding_id + bound_at) — sole-writer invariant, RISK e25f3adf C1'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_model_capability_reference_binding_provenance ON model_capability_reference;
+CREATE TRIGGER trg_model_capability_reference_binding_provenance
+  BEFORE UPDATE ON model_capability_reference
+  FOR EACH ROW
+  EXECUTE FUNCTION model_capability_reference_enforce_binding_provenance();

--- a/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
+++ b/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
@@ -39,9 +39,14 @@ COMMENT ON COLUMN model_capability_reference.binding_id IS
 -- BOTH binding_id AND bound_at. It therefore makes circular binding impossible
 -- regardless of which code path attempts the write.
 --
--- SCOPE: BEFORE UPDATE only. It NEVER constrains true->false — clearing a stale
--- bind (trusted_for_routing=false, bound_at=NULL, binding_id=NULL) must always be
--- allowed so a bind cannot outlive the evidence that justified it.
+-- SCOPE: BEFORE INSERT OR UPDATE. On UPDATE it guards only the false/NULL->true
+-- transition; it NEVER constrains true->false — clearing a stale bind
+-- (trusted_for_routing=false, bound_at=NULL, binding_id=NULL) must always be
+-- allowed so a bind cannot outlive the evidence that justified it. On INSERT it
+-- rejects a row born trusted_for_routing=true without provenance (there is no OLD
+-- to transition from — a trusted INSERT is itself the false/NULL->true edge). This
+-- INSERT arm closes the direct-INSERT hole the UPDATE-only guard left open
+-- (SECURITY re-verify LOW residual, EVAL-002-C).
 --
 -- ADDITIVE + IDEMPOTENT: CREATE OR REPLACE FUNCTION; DROP TRIGGER IF EXISTS then
 -- CREATE TRIGGER. Reuses the base table's RLS/service-role policy — no new grants.
@@ -53,10 +58,14 @@ RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-  -- Only guard the false/NULL -> true transition. OLD IS DISTINCT FROM TRUE is
-  -- true when OLD was false OR NULL; leaves true->true and true->false untouched.
+  -- Guard the false/NULL -> true edge on BOTH INSERT and UPDATE.
+  --  UPDATE: OLD IS DISTINCT FROM TRUE is true when OLD was false OR NULL, so
+  --          true->true and true->false are left untouched.
+  --  INSERT: OLD does not exist (its fields are NULL under FOR EACH ROW), so a
+  --          row born trusted_for_routing=true is itself the false/NULL->true edge
+  --          and is guarded. Gate on TG_OP so the OLD reference is only read on UPDATE.
   IF NEW.trusted_for_routing IS TRUE
-     AND (OLD.trusted_for_routing IS DISTINCT FROM TRUE)
+     AND (TG_OP = 'INSERT' OR OLD.trusted_for_routing IS DISTINCT FROM TRUE)
      AND (NEW.binding_id IS NULL OR NEW.bound_at IS NULL) THEN
     RAISE EXCEPTION
       'trusted_for_routing cannot be set true without binding provenance (binding_id + bound_at) — sole-writer invariant, RISK e25f3adf C1'
@@ -68,6 +77,6 @@ $$;
 
 DROP TRIGGER IF EXISTS trg_model_capability_reference_binding_provenance ON model_capability_reference;
 CREATE TRIGGER trg_model_capability_reference_binding_provenance
-  BEFORE UPDATE ON model_capability_reference
+  BEFORE INSERT OR UPDATE ON model_capability_reference
   FOR EACH ROW
   EXECUTE FUNCTION model_capability_reference_enforce_binding_provenance();

--- a/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
+++ b/database/migrations/20260718_model_capability_reference_binding_columns_STAGED.sql
@@ -1,0 +1,29 @@
+-- STAGED migration — SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C (FR-4)
+-- requires_chairman_apply: yes — do-not-auto-apply. Runs at the chairman-gated apply
+-- ceremony, NOT by any automated path.
+--
+-- APPLIES AFTER database/migrations/20260716_model_capability_reference_STAGED.sql:
+-- the filename date 20260718 > 20260716 orders it strictly after the base CREATE TABLE,
+-- so the columns below always attach to an existing table.
+--
+-- WHAT: adds the DURABLE binding-provenance columns for the FR-3 ground-truth binding
+-- gate (lib/eval/ground-truth-gate.mjs). The base table already carries
+-- trusted_for_routing (boolean NOT NULL DEFAULT false); this gives that trust signal a
+-- cross-process provenance home so "trusted_for_routing=true only if bound=true" is
+-- enforceable by the sole-writer gate rather than living only in an in-memory {bound}.
+--
+--   bound_at   — timestamptz, when the sole-writer gate flipped trusted_for_routing=true.
+--   binding_id — uuid, provenance id of the binding run that flipped it.
+--
+-- ADDITIVE, NO RLS: only ADD COLUMN IF NOT EXISTS (idempotent). It reuses the base
+-- table's RLS + service-role policy — no new grants — so it stays within the
+-- additive-no-rls delegated-apply scope. By design this file carries NO approved-by
+-- attestation directive; the chairman applies it at the ceremony after review.
+
+ALTER TABLE model_capability_reference ADD COLUMN IF NOT EXISTS bound_at timestamptz;
+ALTER TABLE model_capability_reference ADD COLUMN IF NOT EXISTS binding_id uuid;
+
+COMMENT ON COLUMN model_capability_reference.bound_at IS
+  'When the ground-truth binding gate (lib/eval/ground-truth-gate.mjs, EVAL-002-C) flipped trusted_for_routing=true. NULL until a grader verdict reproduces an independently-adjudicated verdict.';
+COMMENT ON COLUMN model_capability_reference.binding_id IS
+  'Provenance id of the binding run that flipped trusted_for_routing. Set ONLY by the sole-writer gate/regression path; NULL otherwise (incl. after a stale-bind clear).';

--- a/lib/eval/__tests__/ground-truth-gate.test.js
+++ b/lib/eval/__tests__/ground-truth-gate.test.js
@@ -21,7 +21,7 @@ import {
   GROUND_TRUTH_ABSENT,
   TABLE,
 } from '../ground-truth-gate.mjs';
-import { SEAL_EVENT_TYPE, MIRROR_CATEGORY, MIRROR_SUITE } from '../golden-task-loader.js';
+import { SEAL_EVENT_TYPE, MIRROR_SUITE } from '../golden-task-loader.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GATE_SRC_PATH = join(__dirname, '..', 'ground-truth-gate.mjs');

--- a/lib/eval/__tests__/ground-truth-gate.test.js
+++ b/lib/eval/__tests__/ground-truth-gate.test.js
@@ -244,4 +244,42 @@ describe('ground-truth-gate (FR-3)', () => {
     expect(vJson).not.toContain(KEY_TOKEN);
     expect(vJson).not.toContain('SECRET PROMPT TEXT');
   });
+
+  it('TS-7: readAdjudicatedVerdicts POSITIVE extraction — adjudicated row INCLUDED (verdict only, key + task_text STRIPPED); NOT-GRADED row EXCLUDED', async () => {
+    // Uses the REAL readAdjudicatedVerdicts (no stub) so the actual extractor runs — every
+    // other oracle-present test injects verdictAccessor, leaving this extraction path unproven.
+    const ADJ_TASK = 'T-ADJ';
+    const UNGRADED_TASK = 'T-UNGRADED';
+    const sealed = [
+      // (i) ADJUDICATED: explicit expected verdict + a grading that is NOT the "NOT GRADED"
+      // sentinel (and adjudicated_by provenance) → the extraction path INCLUDES it.
+      { event_type: SEAL_EVENT_TYPE, payload: {
+        record_kind: 'answer_key', task_id: ADJ_TASK, model_id: 'm', effort: 'high',
+        expected_verdict: 'pass', answer_key: sentinelFor(ADJ_TASK), task_text: 'SECRET ADJ PROMPT',
+        grading: 'ADJUDICATED by Solomon 2026-07-18 — pass confirmed', adjudicated_by: 'solomon',
+        suite: MIRROR_SUITE } },
+      // (ii) SELF-GRADED/UNGRADED: expected verdict present but grading is the sentinel →
+      // the self-graded-exclusion filter (~line 106) EXCLUDES it.
+      { event_type: SEAL_EVENT_TYPE, payload: {
+        record_kind: 'answer_key', task_id: UNGRADED_TASK, model_id: 'm', effort: 'high',
+        expected_clears_bar: false, answer_key: sentinelFor(UNGRADED_TASK), task_text: 'SECRET UNGRADED PROMPT',
+        grading: 'NOT GRADED — sealing only; grading belongs to the eval harness', suite: MIRROR_SUITE } },
+    ];
+    const stub = makeStub({ tables: { system_events: sealed } });
+
+    const adjudicated = await readAdjudicatedVerdicts(stub);
+
+    // (i) the adjudicated row is INCLUDED, carrying ONLY the verdict fields...
+    expect(adjudicated).toHaveLength(1);
+    expect(adjudicated[0]).toEqual({ task_id: ADJ_TASK, model_id: 'm', effort: 'high', expected_clears_bar: true });
+    // ...and the real extractor STRIPPED answer_key AND task_text (contamination guard on the extraction path).
+    const asJson = JSON.stringify(adjudicated);
+    expect(asJson).not.toContain('answer_key');
+    expect(asJson).not.toContain(KEY_TOKEN);
+    expect(asJson).not.toContain('task_text');
+    expect(asJson).not.toContain('SECRET ADJ PROMPT');
+
+    // (ii) the NOT-GRADED row is EXCLUDED (self-graded-exclusion filter).
+    expect(adjudicated.some((a) => a.task_id === UNGRADED_TASK)).toBe(false);
+  });
 });

--- a/lib/eval/__tests__/ground-truth-gate.test.js
+++ b/lib/eval/__tests__/ground-truth-gate.test.js
@@ -1,0 +1,247 @@
+/**
+ * ground-truth-gate.test.js — FR-3 binding gate + regression
+ * (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C, child C).
+ *
+ * Stubbed supabase/loader/grader — NO live model calls (gradeFn injected). Proves the
+ * anti-tautology rule (GROUND_TRUTH_ABSENT steady state), the sole-writer flip, fail-closed
+ * behavior on every uncertainty, trigger-scoped regression, and the contamination guard.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertReproducesKnownResult,
+  runRegression,
+  bindTrustedForRouting,
+  clearStaleBinds,
+  evaluateBinding,
+  readAdjudicatedVerdicts,
+  GROUND_TRUTH_ABSENT,
+  TABLE,
+} from '../ground-truth-gate.mjs';
+import { SEAL_EVENT_TYPE, MIRROR_CATEGORY, MIRROR_SUITE } from '../golden-task-loader.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GATE_SRC_PATH = join(__dirname, '..', 'ground-truth-gate.mjs');
+
+/**
+ * A distinctive answer-key sentinel assembled AT RUNTIME so the full literal never appears
+ * verbatim in any tracked file — the repo-scan guard can grep the whole tree and find zero.
+ */
+const KEY_TOKEN = ['ANSWERKEY', 'SENTINEL', 'DONOTCOMMIT'].join('-');
+const sentinelFor = (taskId) => `${KEY_TOKEN}::${taskId}::7f3a9c1e`;
+
+/**
+ * Chainable supabase stub. Tracks .update() writes and mutates the backing table rows so
+ * trusted_for_routing changes are observable. `errors[table]` injects a query error.
+ */
+function makeStub({ tables = {}, errors = {} } = {}) {
+  const writes = [];
+  function builderFor(table) {
+    const filters = [];
+    let limit = null;
+    let op = 'select';
+    let payload = null;
+    const builder = {
+      select() { return builder; },
+      eq(col, val) { filters.push([col, val, 'eq']); return builder; },
+      in(col, vals) { filters.push([col, vals, 'in']); return builder; },
+      limit(n) { limit = n; return builder; },
+      update(p) { op = 'update'; payload = p; return builder; },
+      then(resolve, reject) {
+        return Promise.resolve().then(() => {
+          if (errors[table]) return { data: null, error: errors[table] };
+          let rows = (tables[table] || []).slice();
+          for (const [col, val, kind] of filters) {
+            rows = kind === 'in'
+              ? rows.filter((r) => val.includes(r[col]))
+              : rows.filter((r) => r[col] === val);
+          }
+          if (op === 'update') {
+            for (const r of rows) Object.assign(r, payload);
+            writes.push({ table, payload, matched: rows.length });
+            return { data: rows.map((r) => ({ id: r.id })), error: null };
+          }
+          if (limit != null) rows = rows.slice(0, limit);
+          return { data: rows, error: null };
+        }).then(resolve, reject);
+      },
+    };
+    return builder;
+  }
+  return { from: builderFor, _writes: writes };
+}
+
+/** One sealed golden set with a single sealed_run (loader stub shape). */
+function loaderStub(sets) {
+  return async () => ({ sets, integrityErrors: [], source: 'stub' });
+}
+const ONE_SET = [{
+  task_id: 'T1',
+  shape: 'R1-compounding',
+  task_text: 'PROMPT for T1',
+  sealed_runs: [{ effort: 'high', model_id: 'm', tokens: 100, wall_clock: 5, run_at: '2026-07-16T00:00:00Z', output: 'run output T1/high' }],
+}];
+const keyAccessorStub = async () => 'db-side-key';
+
+describe('ground-truth-gate (FR-3)', () => {
+  it('TS-1: adjudicated verdict present AND matching → bound=true + sole-writer flip applied', async () => {
+    const verdictAccessor = async () => [{ task_id: 'T1', model_id: 'm', effort: 'high', expected_clears_bar: true }];
+    // High-margin grade (0.95, well clear of 0.70±0.10) → single cheap pass, no deep re-grade.
+    let gradeCalls = 0;
+    const gradeFn = async () => { gradeCalls += 1; return { clears_bar: true, quality_score: 0.95, grader: 'stub', graded_at: '2026-07-16T01:00:00Z' }; };
+
+    const verdict = await assertReproducesKnownResult({}, { gradeFn, loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub, verdictAccessor });
+    expect(verdict.bound).toBe(true);
+    expect(verdict.reason).toBe('REPRODUCED');
+    expect(verdict.reproduced_task_ids).toEqual(['T1']);
+    expect(gradeCalls).toBe(1); // grader IS spent when there is an oracle to reproduce
+
+    // Sole-writer flip on a live table.
+    const tables = { [TABLE]: [{ id: 'r1', task_id: 'T1', model_id: 'm', effort: 'high', trusted_for_routing: false, bound_at: null, binding_id: null }] };
+    const stub = makeStub({ tables });
+    const flip = await bindTrustedForRouting(stub, { reproduced_task_ids: verdict.reproduced_task_ids });
+    expect(flip.status).toBe('BOUND');
+    expect(flip.flipped).toBe(1);
+    expect(tables[TABLE][0].trusted_for_routing).toBe(true);
+    expect(tables[TABLE][0].bound_at).toBeTruthy();
+    expect(tables[TABLE][0].binding_id).toBeTruthy();
+  });
+
+  it("TS-2: today's ungraded corpus → bound=false / GROUND_TRUTH_ABSENT, grader NOT called, nothing flipped", async () => {
+    // Sealed rows carry the "NOT GRADED — sealing only" sentinel and NO expected verdict.
+    const sealed = [
+      { event_type: SEAL_EVENT_TYPE, payload: { record_kind: 'answer_key', task_id: 'T1', task_text: 'PROMPT for T1', answer_key: sentinelFor('T1'), grading: 'NOT GRADED — sealing only; grading belongs to the eval harness', suite: MIRROR_SUITE } },
+      { event_type: SEAL_EVENT_TYPE, payload: { record_kind: 'sealed_run', task_id: 'T1', model_id: 'm', effort: 'high', task_text: 'PROMPT for T1', fable5_answer: 'run output', grading: 'NOT GRADED — sealing only; grading belongs to the eval harness', suite: MIRROR_SUITE } },
+    ];
+    const stub = makeStub({ tables: { system_events: sealed } });
+
+    let gradeCalls = 0;
+    const gradeFn = async () => { gradeCalls += 1; return { clears_bar: true, quality_score: 0.95, grader: 'stub', graded_at: 'x' }; };
+
+    const verdict = await assertReproducesKnownResult(stub, { gradeFn, loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub });
+    expect(verdict.bound).toBe(false);
+    expect(verdict.reason).toBe(GROUND_TRUTH_ABSENT);
+    expect(verdict.reproduced_task_ids).toEqual([]);
+    // Anti-tautology: with no oracle to reproduce, the grader is never invoked.
+    expect(gradeCalls).toBe(0);
+
+    // The default accessor over today's corpus returns zero adjudicated verdicts.
+    expect(await readAdjudicatedVerdicts(stub)).toEqual([]);
+  });
+
+  it('TS-3: grader mismatch / grader throws / ambiguous grader → bound=false each (fail-closed)', async () => {
+    const verdictAccessor = async () => [{ task_id: 'T1', model_id: 'm', effort: 'high', expected_clears_bar: true }];
+
+    // (a) mismatch: adjudicated expects pass, grader says fail.
+    const mismatch = await assertReproducesKnownResult({}, {
+      gradeFn: async () => ({ clears_bar: false, quality_score: 0.20, grader: 'stub', graded_at: 'x' }),
+      loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub, verdictAccessor,
+    });
+    expect(mismatch.bound).toBe(false);
+    expect(mismatch.reason).toBe('REPRODUCTION_MISMATCH');
+
+    // (b) grader throws.
+    const threw = await assertReproducesKnownResult({}, {
+      gradeFn: async () => { throw new Error('grader exploded'); },
+      loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub, verdictAccessor,
+    });
+    expect(threw.bound).toBe(false);
+    expect(threw.reason).toBe('GRADER_ERROR');
+
+    // (c) ambiguous grader verdict (clears_bar null) → that unit skipped → no match.
+    const ambiguous = await assertReproducesKnownResult({}, {
+      gradeFn: async () => ({ clears_bar: null, quality_score: 0.71, grader: 'stub', graded_at: 'x' }),
+      loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub, verdictAccessor,
+    });
+    expect(ambiguous.bound).toBe(false);
+    expect(ambiguous.reason).toBe('REPRODUCTION_MISMATCH');
+
+    // pure evaluateBinding: empty adjudicated → GROUND_TRUTH_ABSENT.
+    expect(evaluateBinding([], [{ task_id: 'T1', model_id: 'm', effort: 'high', clears_bar: true }]))
+      .toEqual({ bound: false, reason: GROUND_TRUTH_ABSENT, reproduced_task_ids: [] });
+  });
+
+  it('TS-4: STAGED-absent table → CEREMONY_PENDING, no flip, no throw', async () => {
+    const absent = makeStub({ errors: { [TABLE]: { message: 'relation "model_capability_reference" does not exist' } } });
+
+    const flip = await bindTrustedForRouting(absent, { reproduced_task_ids: ['T1'] });
+    expect(flip.status).toBe('CEREMONY_PENDING');
+    expect(flip.flipped).toBe(0);
+
+    const cleared = await clearStaleBinds(absent);
+    expect(cleared.status).toBe('CEREMONY_PENDING');
+
+    const reg = await runRegression(absent, { trigger: 'model', gradeFn: async () => ({}) });
+    expect(reg.status).toBe('CEREMONY_PENDING');
+
+    // A supabase client that THROWS on .from() must still not throw out of the gate.
+    const thrower = { from() { throw new Error('client boom'); } };
+    const flip2 = await bindTrustedForRouting(thrower, { reproduced_task_ids: ['T1'] });
+    expect(flip2.status).toBe('CEREMONY_PENDING');
+  });
+
+  it('TS-5: runRegression trigger=pricing recomputes cost_norm only (no re-grade) vs model=full re-grade; post-rerun bound=false clears trusted_for_routing', async () => {
+    // --- pricing: cost_norm recomputed, grader NOT called, stale bind cleared ---
+    const staleRow = { id: 'r1', task_id: 'T1', model_id: 'm', effort: 'high', quality_score: 0.9, tokens: 100, cost_norm: 0, trusted_for_routing: true, bound_at: 'old', binding_id: 'old' };
+    const pricingStub = makeStub({ tables: { [TABLE]: [staleRow], system_events: [] } });
+    let pricingGradeCalls = 0;
+    const pricingRes = await runRegression(pricingStub, {
+      trigger: 'pricing',
+      gradeFn: async () => { pricingGradeCalls += 1; return {}; },
+      verdictAccessor: async () => [], // steady-state: no oracle
+    });
+    expect(pricingGradeCalls).toBe(0); // NO re-grade
+    expect(pricingRes.recomputed.ok).toBe(true);
+    expect(pricingRes.recomputed.updated).toBe(1);
+    expect(staleRow.cost_norm).toBeCloseTo((0.9 / 100) * 1000, 6); // costNorm reused
+    // post-rerun bound=false → stale bind cleared
+    expect(pricingRes.binding.bound).toBe(false);
+    expect(pricingRes.binding.reason).toBe(GROUND_TRUTH_ABSENT);
+    expect(pricingRes.flip.status).toBe('CLEARED');
+    expect(staleRow.trusted_for_routing).toBe(false);
+    expect(staleRow.bound_at).toBe(null);
+    expect(staleRow.binding_id).toBe(null);
+
+    // --- model: FULL re-grade (grader IS called when an oracle is present) ---
+    const modelStub = makeStub({ tables: { [TABLE]: [{ id: 'r1', task_id: 'T1', model_id: 'm', effort: 'high', trusted_for_routing: false }] } });
+    let modelGradeCalls = 0;
+    const modelRes = await runRegression(modelStub, {
+      trigger: 'model',
+      gradeFn: async () => { modelGradeCalls += 1; return { clears_bar: true, quality_score: 0.95, grader: 'stub', graded_at: 'x' }; },
+      loader: loaderStub(ONE_SET),
+      keyAccessor: keyAccessorStub,
+      verdictAccessor: async () => [{ task_id: 'T1', model_id: 'm', effort: 'high', expected_clears_bar: true }],
+    });
+    expect(modelGradeCalls).toBe(1); // full re-grade happened
+    expect(modelRes.binding.bound).toBe(true);
+    expect(modelRes.flip.status).toBe('BOUND');
+  });
+
+  it('TS-6: contamination guard — no key/task_text in gate output or fixtures, gate imports no fs / no fs write', async () => {
+    // (a) gate module imports no fs and performs no filesystem write.
+    const src = readFileSync(GATE_SRC_PATH, 'utf8');
+    expect(src).not.toMatch(/require\(['"](node:)?fs['"]\)/);
+    expect(src).not.toMatch(/from\s+['"](node:)?fs(\/promises)?['"]/);
+    expect(src).not.toMatch(/writeFile|writeFileSync|appendFile|createWriteStream|mkdtemp/);
+
+    // (b) a sealed fixture carrying a key + task_text yields adjudicated output with NEITHER.
+    const sealed = [
+      { event_type: SEAL_EVENT_TYPE, payload: { record_kind: 'answer_key', task_id: 'T1', task_text: 'SECRET PROMPT TEXT', answer_key: sentinelFor('T1'), grading: 'NOT GRADED — sealing only', suite: MIRROR_SUITE } },
+    ];
+    const stub = makeStub({ tables: { system_events: sealed } });
+    const adjudicated = await readAdjudicatedVerdicts(stub);
+    const asJson = JSON.stringify(adjudicated);
+    expect(asJson).not.toContain(KEY_TOKEN);
+    expect(asJson).not.toContain('SECRET PROMPT TEXT');
+    expect(asJson).not.toContain('answer_key');
+
+    // (c) a full assert path output likewise carries no key/text.
+    const verdict = await assertReproducesKnownResult(stub, { gradeFn: async () => ({ clears_bar: true, quality_score: 0.95, grader: 'g', graded_at: 'x' }), loader: loaderStub(ONE_SET), keyAccessor: keyAccessorStub });
+    const vJson = JSON.stringify(verdict);
+    expect(vJson).not.toContain(KEY_TOKEN);
+    expect(vJson).not.toContain('SECRET PROMPT TEXT');
+  });
+});

--- a/lib/eval/golden-task-loader.js
+++ b/lib/eval/golden-task-loader.js
@@ -178,6 +178,14 @@ export const MODEL_CAPABILITY_REFERENCE_CONTRACT = Object.freeze({
     wall_clock: 'integer',
     cost_norm: 'numeric',
     graded_at: 'timestamptz',
+    // FR-3 (EVAL-002-C) durable binding-provenance columns. trusted_for_routing exists on
+    // the base table (DEFAULT false); bound_at + binding_id are added by the STAGED
+    // migration 20260718_model_capability_reference_binding_columns_STAGED.sql. Listed here
+    // so the JS contract matches the durable schema — the ground-truth binding gate is the
+    // SOLE writer that flips trusted_for_routing=true (tied to bound=true).
+    trusted_for_routing: 'boolean',
+    bound_at: 'timestamptz',
+    binding_id: 'uuid',
   }),
 });
 

--- a/lib/eval/ground-truth-gate.mjs
+++ b/lib/eval/ground-truth-gate.mjs
@@ -1,0 +1,330 @@
+/**
+ * ground-truth-gate.mjs — FR-3 ground-truth BINDING gate + regression for the
+ * model-capability eval (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C, child C).
+ *
+ * This is the routing-TRUST seam: it is the SOLE code path allowed to flip
+ * model_capability_reference.trusted_for_routing=true, and it does so ONLY when a
+ * grader verdict REPRODUCES an INDEPENDENTLY-ADJUDICATED expected verdict for >=1
+ * (task,model,effort). Everything is fail-closed: on any doubt it does NOT bind.
+ *
+ * ANTI-TAUTOLOGY RULE (RISK e25f3adf, C1 CRITICAL): grading a sealed run against
+ * its OWN key is a FRESH grade, not a REPRODUCTION of a KNOWN verdict. A run always
+ * grades against its own key, so "grader ran without throwing" is circular — a broken
+ * grader stuck at clears_bar=true would bind routing. Therefore bound=true requires
+ * grader_verdict === an independently-adjudicated expected verdict. The sealed Fable-5
+ * corpus is UNGRADED today (every row grading="NOT GRADED — sealing only; grading
+ * belongs to the eval harness"), so NO adjudicated expected verdict exists. The correct,
+ * PERMANENT steady-state until an authority (Solomon/chairman/Opus-5-GA) seals an
+ * adjudicated-verdict oracle is: { bound:false, reason:'GROUND_TRUTH_ABSENT',
+ * reproduced_task_ids:[] } — a distinct, honest fail-closed reason, NOT an error and
+ * NOT a broken child. Child C must NEVER self-author the verdict (that re-circularizes).
+ *
+ * DISTINCT FROM scripts/eval/ground-truth-gate.mjs (EVAL-001 FR-5): that is a CLI
+ * (`evaluateGroundTruth(rows)` + a `main()`) using an adversarial-split heuristic over
+ * already-graded rows. THIS module is the EVAL-002-C library API (adjudicated-verdict
+ * reproduction) — different directory, different export names, no import collision
+ * (mirrors the golden-task-loader.js/.mjs coexistence precedent).
+ *
+ * CONTAMINATION GUARD (inherited absolute): keys/task_text stay DB-side. This module
+ * imports NO `fs` and performs NO filesystem writes; nothing it returns ever carries an
+ * answer_key or task_text (mirrors child B's results-only toReferenceRow).
+ */
+import crypto from 'node:crypto';
+import {
+  loadGoldenTaskSets,
+  getAnswerKey,
+  SEAL_EVENT_TYPE,
+  MIRROR_CATEGORY,
+  MIRROR_SUITE,
+} from './golden-task-loader.js';
+import { gradeGoldenTasks } from './grader.mjs';
+import { costNorm } from './capability-scorer.mjs';
+
+/** The staged reference table (already carries trusted_for_routing DEFAULT false). */
+export const TABLE = 'model_capability_reference';
+
+/** Distinct fail-closed reason: no adjudicated verdict exists to reproduce (steady state). */
+export const GROUND_TRUTH_ABSENT = 'GROUND_TRUTH_ABSENT';
+
+/** Sealed rows carry this grading text until an authority adjudicates — never a verdict. */
+export const UNADJUDICATED_GRADING_PREFIX = 'NOT GRADED';
+
+/** Composite identity of a (task,model,effort) grading unit. */
+function keyOf(r) {
+  return `${r.task_id}::${r.model_id ?? null}::${r.effort ?? null}`;
+}
+
+/**
+ * Parse an adjudicated expected clears_bar from a durable field, or null when the row
+ * carries no independently-adjudicated verdict. Accepts an explicit boolean
+ * `expected_clears_bar` or an `expected_verdict` of 'pass'|'fail'. Anything else → null
+ * (fail-closed: absence, not a guess).
+ */
+export function expectedClearsBar(row) {
+  if (row == null) return null;
+  if (typeof row.expected_clears_bar === 'boolean') return row.expected_clears_bar;
+  if (row.expected_verdict === 'pass') return true;
+  if (row.expected_verdict === 'fail') return false;
+  return null;
+}
+
+/**
+ * Read the sealed corpus payloads (system_events canonical FIRST, feedback mirror only
+ * when canonical is empty/errors). Reuses the loader's store constants — never a second
+ * copy. Fail-closed: any read error yields [] (caller treats as GROUND_TRUTH_ABSENT).
+ * CONTAMINATION GUARD: returns the raw payloads to the local adjudication reader ONLY;
+ * this function is not exported and no key/text ever escapes into a gate return.
+ */
+async function readSealedPayloads(supabase) {
+  const canonical = await supabase.from('system_events').select('id, payload').eq('event_type', SEAL_EVENT_TYPE);
+  if (!canonical.error && Array.isArray(canonical.data) && canonical.data.length) {
+    return canonical.data.map((r) => r.payload || {});
+  }
+  const mirror = await supabase.from('feedback').select('id, metadata').eq('category', MIRROR_CATEGORY);
+  if (mirror.error) return [];
+  return (mirror.data || []).map((r) => r.metadata || {}).filter((p) => p.suite === MIRROR_SUITE);
+}
+
+/**
+ * Default adjudicated-verdict accessor. Returns one entry per (task,model,effort) that
+ * carries an INDEPENDENTLY-ADJUDICATED expected verdict — i.e. an explicit expected_*
+ * field AND a grading that is NOT the "NOT GRADED — sealing only" sentinel (or an
+ * explicit adjudicated_by provenance). A run graded against its own key is deliberately
+ * EXCLUDED (that is the tautology this guards). Today's corpus yields [] — GROUND_TRUTH_ABSENT.
+ *
+ * Extracts ONLY task_id/model_id/effort/expected_clears_bar — never answer_key or task_text.
+ * @returns {Promise<Array<{task_id:string, model_id:string|null, effort:string|null, expected_clears_bar:boolean}>>}
+ */
+export async function readAdjudicatedVerdicts(supabase) {
+  const payloads = await readSealedPayloads(supabase);
+  const out = [];
+  for (const p of payloads) {
+    if (!p || !p.task_id) continue;
+    const expected = expectedClearsBar(p);
+    if (expected === null) continue; // no explicit expected verdict → not adjudicated
+    const gradingIsAdjudicated = typeof p.grading === 'string' && !p.grading.startsWith(UNADJUDICATED_GRADING_PREFIX);
+    if (!gradingIsAdjudicated && !p.adjudicated_by) continue; // self-graded/ungraded → excluded
+    out.push({
+      task_id: p.task_id,
+      model_id: p.model_id ?? null,
+      effort: p.effort ?? null,
+      expected_clears_bar: expected,
+    });
+  }
+  return out;
+}
+
+/**
+ * PURE binding decision: does the grader reproduce >=1 adjudicated verdict?
+ * Fail-closed at every seam: no adjudicated verdicts → GROUND_TRUTH_ABSENT; a grader row
+ * missing or with clears_bar null → that unit is skipped (ambiguous, never a match); zero
+ * matches → REPRODUCTION_MISMATCH. bound=true ONLY when at least one adjudicated verdict
+ * equals the grader's verdict for the same (task,model,effort).
+ *
+ * @param {Array} adjudicated entries from readAdjudicatedVerdicts (or a stub)
+ * @param {Array} graderRows results-only rows with {task_id,model_id,effort,clears_bar}
+ * @returns {{bound:boolean, reason:string, reproduced_task_ids:string[]}}
+ */
+export function evaluateBinding(adjudicated, graderRows) {
+  const adj = Array.isArray(adjudicated) ? adjudicated : [];
+  if (adj.length === 0) {
+    return { bound: false, reason: GROUND_TRUTH_ABSENT, reproduced_task_ids: [] };
+  }
+  const byKey = new Map();
+  for (const r of graderRows || []) byKey.set(keyOf(r), r);
+
+  const reproduced = new Set();
+  for (const a of adj) {
+    const expected = expectedClearsBar(a);
+    if (expected === null) continue; // ambiguous adjudication → skip (fail-closed)
+    const row = byKey.get(keyOf(a));
+    if (!row) continue; // no grader verdict for this unit → skip
+    if (row.clears_bar === null || row.clears_bar === undefined) continue; // ambiguous grader → skip
+    if (row.clears_bar === expected) reproduced.add(a.task_id);
+  }
+  if (reproduced.size >= 1) {
+    return { bound: true, reason: 'REPRODUCED', reproduced_task_ids: [...reproduced] };
+  }
+  return { bound: false, reason: 'REPRODUCTION_MISMATCH', reproduced_task_ids: [] };
+}
+
+/**
+ * Assert the grader REPRODUCES a known (adjudicated) result. The anti-tautology core.
+ *
+ * Order matters: read the adjudicated oracle FIRST. If it is absent, return
+ * GROUND_TRUTH_ABSENT WITHOUT grading — there is nothing to reproduce, so a fresh grade
+ * would be pure circularity (and wastes model calls). Only when an adjudicated verdict
+ * exists do we grade (child B path) and compare.
+ *
+ * @param {Object} supabase
+ * @param {Object} deps
+ * @param {Function} deps.gradeFn required — (request,{tier})=>grade, dependency-injected (no live model)
+ * @param {Function} [deps.loader] default loadGoldenTaskSets
+ * @param {Function} [deps.keyAccessor] default getAnswerKey
+ * @param {Function} [deps.verdictAccessor] default readAdjudicatedVerdicts
+ * @returns {Promise<{bound:boolean, reason:string, reproduced_task_ids:string[]}>}
+ */
+export async function assertReproducesKnownResult(supabase, {
+  gradeFn,
+  loader = loadGoldenTaskSets,
+  keyAccessor = getAnswerKey,
+  verdictAccessor = readAdjudicatedVerdicts,
+} = {}) {
+  let adjudicated;
+  try {
+    adjudicated = await verdictAccessor(supabase);
+  } catch {
+    return { bound: false, reason: 'ADJUDICATION_READ_ERROR', reproduced_task_ids: [] };
+  }
+  if (!Array.isArray(adjudicated) || adjudicated.length === 0) {
+    // Steady state until an authority seals an adjudicated-verdict oracle.
+    return { bound: false, reason: GROUND_TRUTH_ABSENT, reproduced_task_ids: [] };
+  }
+
+  let graded;
+  try {
+    graded = await gradeGoldenTasks(supabase, { gradeFn, loader, keyAccessor });
+  } catch {
+    return { bound: false, reason: 'GRADER_ERROR', reproduced_task_ids: [] };
+  }
+  return evaluateBinding(adjudicated, graded.rows || []);
+}
+
+/**
+ * Probe table liveness with a REAL-ROW select (NOT head:true — that false-positives on a
+ * missing table). STAGED-absent → { live:false } so callers return CEREMONY_PENDING.
+ */
+async function probeTable(supabase) {
+  try {
+    const probe = await supabase.from(TABLE).select('id').limit(1);
+    if (probe && probe.error) return { live: false, reason: probe.error.message || 'table absent' };
+    return { live: true };
+  } catch (err) {
+    return { live: false, reason: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * SOLE-WRITER binding flip. Called ONLY when bound=true. Flips trusted_for_routing=true +
+ * stamps bound_at + a binding_id provenance for the reproduced task rows. STAGED-absent →
+ * { status:'CEREMONY_PENDING' } (no flip, no throw). Never flips on bound=false — that path
+ * goes through clearStaleBinds instead.
+ *
+ * @param {Object} supabase
+ * @param {{reproduced_task_ids:string[], binding_id?:string}} args
+ */
+export async function bindTrustedForRouting(supabase, { reproduced_task_ids, binding_id = crypto.randomUUID() } = {}) {
+  const probe = await probeTable(supabase);
+  if (!probe.live) return { status: 'CEREMONY_PENDING', flipped: 0, reason: probe.reason };
+  if (!Array.isArray(reproduced_task_ids) || reproduced_task_ids.length === 0) {
+    return { status: 'NO_ROWS', flipped: 0 };
+  }
+  const up = await supabase
+    .from(TABLE)
+    .update({ trusted_for_routing: true, bound_at: new Date().toISOString(), binding_id })
+    .in('task_id', reproduced_task_ids)
+    .select('id');
+  if (up && up.error) return { status: 'WRITE_ERROR', flipped: 0, reason: up.error.message };
+  return { status: 'BOUND', flipped: (up.data || []).length, binding_id, reproduced_task_ids };
+}
+
+/**
+ * Clear any STALE bind: trusted_for_routing→false + null out bound_at/binding_id on every
+ * currently-trusted row. Run whenever a rerun yields bound=false so a prior bind cannot
+ * outlive the evidence that justified it. STAGED-absent → CEREMONY_PENDING (no-op, no throw).
+ */
+export async function clearStaleBinds(supabase) {
+  const probe = await probeTable(supabase);
+  if (!probe.live) return { status: 'CEREMONY_PENDING', cleared: 0, reason: probe.reason };
+  const up = await supabase
+    .from(TABLE)
+    .update({ trusted_for_routing: false, bound_at: null, binding_id: null })
+    .eq('trusted_for_routing', true)
+    .select('id');
+  if (up && up.error) return { status: 'WRITE_ERROR', cleared: 0, reason: up.error.message };
+  return { status: 'CLEARED', cleared: (up.data || []).length };
+}
+
+/**
+ * Pricing/limits rerun helper: recompute cost_norm ONLY (reuse capability-scorer costNorm),
+ * NO re-grade. quality_score/clears_bar are untouched — pricing cannot change a grader verdict.
+ */
+async function recomputeCostNorm(supabase) {
+  const { data, error } = await supabase.from(TABLE).select('id, quality_score, tokens');
+  if (error) return { ok: false, updated: 0, reason: error.message };
+  let updated = 0;
+  for (const r of data || []) {
+    const cn = costNorm(r.quality_score, r.tokens);
+    const up = await supabase.from(TABLE).update({ cost_norm: cn }).eq('id', r.id).select('id');
+    if (!(up && up.error)) updated += 1;
+  }
+  return { ok: true, updated };
+}
+
+/**
+ * Binding re-check WITHOUT re-grading: compare adjudicated verdicts against the grader
+ * verdicts ALREADY STORED in the table (clears_bar). Used by pricing/limits reruns, which
+ * must not spend a fresh grade. In steady state (adjudicated absent) → GROUND_TRUTH_ABSENT.
+ */
+async function bindingFromStored(supabase, { verdictAccessor = readAdjudicatedVerdicts } = {}) {
+  let adjudicated;
+  try {
+    adjudicated = await verdictAccessor(supabase);
+  } catch {
+    return { bound: false, reason: 'ADJUDICATION_READ_ERROR', reproduced_task_ids: [] };
+  }
+  if (!Array.isArray(adjudicated) || adjudicated.length === 0) {
+    return { bound: false, reason: GROUND_TRUTH_ABSENT, reproduced_task_ids: [] };
+  }
+  const { data, error } = await supabase.from(TABLE).select('task_id, model_id, effort, clears_bar');
+  if (error) return { bound: false, reason: 'STORED_VERDICT_READ_ERROR', reproduced_task_ids: [] };
+  return evaluateBinding(adjudicated, data || []);
+}
+
+/**
+ * Regression rerun, SCOPED by trigger (RISK e25f3adf):
+ *   - 'model'            → FULL re-grade (re-run the binding gate via the grader path).
+ *   - 'pricing'|'limits' → recompute cost_norm ONLY (no re-grade); re-check binding from
+ *                          STORED grader verdicts.
+ * After any rerun the binding gate is re-run: bound=true → sole-writer flip; bound=false →
+ * clear stale binds. STAGED-absent → CEREMONY_PENDING (real-row liveness probe, not head:true).
+ *
+ * @param {Object} supabase
+ * @param {Object} deps
+ * @param {'model'|'pricing'|'limits'} deps.trigger
+ * @param {Function} deps.gradeFn required for trigger='model' (dependency-injected)
+ * @param {Function} [deps.loader]
+ * @param {Function} [deps.keyAccessor]
+ * @param {Function} [deps.verdictAccessor]
+ */
+export async function runRegression(supabase, {
+  trigger,
+  gradeFn,
+  loader = loadGoldenTaskSets,
+  keyAccessor = getAnswerKey,
+  verdictAccessor = readAdjudicatedVerdicts,
+} = {}) {
+  if (!['model', 'pricing', 'limits'].includes(trigger)) {
+    throw new Error(`runRegression: trigger must be one of model|pricing|limits, got ${trigger}`);
+  }
+  const probe = await probeTable(supabase);
+  if (!probe.live) return { status: 'CEREMONY_PENDING', trigger, reason: probe.reason };
+
+  let recomputed = null;
+  let binding;
+  if (trigger === 'pricing' || trigger === 'limits') {
+    recomputed = await recomputeCostNorm(supabase); // cost_norm only — NO re-grade
+    binding = await bindingFromStored(supabase, { verdictAccessor });
+  } else {
+    // 'model' → full re-grade through the grader path
+    binding = await assertReproducesKnownResult(supabase, { gradeFn, loader, keyAccessor, verdictAccessor });
+  }
+
+  let flip;
+  if (binding.bound) {
+    flip = await bindTrustedForRouting(supabase, { reproduced_task_ids: binding.reproduced_task_ids });
+  } else {
+    flip = await clearStaleBinds(supabase); // clear any stale bind post-rerun
+  }
+  return { status: 'RERUN', trigger, recomputed, binding, flip };
+}

--- a/scripts/eval/ground-truth-gate.mjs
+++ b/scripts/eval/ground-truth-gate.mjs
@@ -1,18 +1,24 @@
 #!/usr/bin/env node
 /**
- * ground-truth-gate.mjs — fail-closed trust flip for model_capability_reference
- * (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001 FR-5).
+ * ground-truth-gate.mjs — ADVISORY adversarial-split signal for
+ * model_capability_reference (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-001 FR-5).
  *
- * trusted_for_routing defaults false on every row, and THIS SCRIPT is the only
- * code path allowed to set it true. It does so only when the graded table
- * REPRODUCES >= 1 already-adjudicated result, including an ADVERSARIAL
- * negative (spec Part 5 verification_plan: e.g. a delegate-tier/low-effort
- * failure on a sealed task the high-effort Fable-5 run passed) — a
- * positives-only reproduction is a rubber stamp and does not count.
+ * ADVISORY ONLY — MUST NEVER FLIP ROUTING TRUST (RISK e25f3adf C1, sole-writer
+ * invariant). The CANONICAL binder is lib/eval/ground-truth-gate.mjs
+ * `bindTrustedForRouting` (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C, child C):
+ * it is the SOLE code path allowed to set trusted_for_routing=true, and it binds
+ * ONLY against an INDEPENDENTLY-ADJUDICATED oracle, stamping binding_id + bound_at.
+ *
+ * This EVAL-001 script computes and REPORTS an adversarial-split heuristic over
+ * already-graded rows (a task with a clears_bar=true row AND a clears_bar=false
+ * row from a different model/effort — a positives-only reproduction is a rubber
+ * stamp and does not count). But that split is SELF-GRADED, not adjudicated, so
+ * under the fail-closed doctrine it must NOT bind: this script performs NO write
+ * to trusted_for_routing. It surfaces the signal and exits; binding is the child-C
+ * binder's job alone.
  *
  * Consumers (intelligent-switch routing, coordinator dispatch tiering, Solomon
- * mode-resolution) MUST filter trusted_for_routing=true. Until this gate
- * passes it exits non-zero and no row is trusted.
+ * mode-resolution) MUST filter trusted_for_routing=true.
  *
  * Run from the repo SHARED ROOT: node scripts/eval/ground-truth-gate.mjs [--dry]
  */
@@ -60,18 +66,18 @@ async function main() {
   if (error) { console.error('read failed (table missing = ceremony pending):', error.message); process.exitCode = 2; return; }
 
   const verdict = evaluateGroundTruth(data || []);
-  console.log(`ground-truth-gate: ${verdict.pass ? 'PASS' : 'BLOCKED'} — ${verdict.reason}`);
+  console.log(`ground-truth-gate (ADVISORY): ${verdict.pass ? 'REPRODUCED-SPLIT' : 'BLOCKED'} — ${verdict.reason}`);
   if (!verdict.pass) { process.exitCode = 1; return; }
 
-  if (dry) { console.log('--dry: trust flip skipped'); return; }
-  const gradedIds = (data || []).filter(r => r.graded_at).map(r => r.id);
-  const up = await supabase
-    .from('model_capability_reference')
-    .update({ trusted_for_routing: true })
-    .in('id', gradedIds)
-    .select('id');
-  if (up.error) { console.error('trust flip failed:', up.error.message); process.exitCode = 1; return; }
-  console.log(`trusted_for_routing=true on ${up.data.length} graded row(s). Routing consumers may now read them.`);
+  // ADVISORY ONLY (RISK e25f3adf C1, sole-writer invariant): this script has no
+  // adjudicated oracle, so it MUST NOT flip trusted_for_routing. Binding is owned
+  // exclusively by lib/eval/ground-truth-gate.mjs bindTrustedForRouting (child C),
+  // which reproduces an independently-adjudicated verdict and stamps binding_id +
+  // bound_at. Report the split signal and stop — no row is modified here.
+  const gradedCount = (data || []).filter(r => r.graded_at).length;
+  console.log(dry
+    ? `--dry: advisory only — ${gradedCount} graded row(s) show an adversarial split; the child-C binder owns any flip (no row modified).`
+    : `advisory only — ${gradedCount} graded row(s) show an adversarial split, but routing trust is NOT flipped here; the child-C binder (lib/eval/ground-truth-gate.mjs) is the sole writer. No row modified.`);
 }
 
 const isMain = process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]));


### PR DESCRIPTION
## SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-C — FR-3 GT binding gate (child C of the EVAL-002 eval-harness orchestrator)

Fail-closed ground-truth binding gate that decides whether the model-capability reference table may bind a routing decision. Composes child A (loader/keys) + child B (grader).

### What
- **`lib/eval/ground-truth-gate.mjs`** — `assertReproducesKnownResult` compares a grader verdict against an **independently-adjudicated** expected verdict (never a self-grade — the circular-binding hole RISK e25f3adf C1 caught). `bound=true` only on a real match; since the sealed corpus is ungraded today the honest steady-state is `{bound:false, reason:'GROUND_TRUTH_ABSENT'}`. Every uncertainty (grader throws / table absent / ambiguous / no oracle) → `bound=false`. `runRegression` scoped by trigger (pricing/limits recompute `cost_norm` only; model = full re-grade); clears a stale bind on post-rerun `bound=false`. `bindTrustedForRouting` is the **sole writer** that flips `trusted_for_routing=true`, co-stamping `bound_at`+`binding_id`.
- **STAGED chairman-gated migration** — additive `bound_at`+`binding_id` columns **and** a `BEFORE INSERT OR UPDATE` trigger that structurally rejects any `trusted_for_routing` false/NULL→true transition lacking binding provenance (DB-tier sole-writer enforcement — catches every writer, not just known code paths). No `@approved-by`; reuses base RLS.
- **Neutered the EVAL-001 sibling** `scripts/eval/ground-truth-gate.mjs` — was a second circular writer of the trust flag; now advisory-only.
- Contamination guard preserved (keys server-side via `getAnswerKey`, never in gate output/fixtures); `TS-7` proves the real extractor strips `answer_key`/`task_text`.

### Review evidence (all recorded in sub_agent_execution_results)
- SECURITY: **PASS** (90, upgraded from CONDITIONAL after the sole-writer trigger + sibling neuter closed a HIGH)
- TESTING: CONDITIONAL PASS (extraction-path hardening added as TS-7)
- VALIDATION: **PASS** (95) — all 6 ACs met with non-trivial tests
- REGRESSION: **PASS** (92) — additive/neutering changes, no consumer depended on the sibling flipping the flag
- Tests: `npx vitest run lib/eval` → 32 green; `tests/unit/eval` → 57 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)