### PR TITLE
feat(SD-LEO-INFRA-UNIFY-BELT-REFILL-001): unify belt-refill discriminant to item_disposition + chairman-accept-to-stamp writer + scope refill-cron to active roadmap

### DIFF
--- a/lib/eva/consultant/action-executor.js
+++ b/lib/eva/consultant/action-executor.js
@@ -13,6 +13,7 @@
 import { createSD } from '../../../scripts/leo-create-sd.js';
 import { generateSDKey, SD_SOURCES } from '../../../scripts/modules/sd-key-generator.js';
 import { recordDecision } from './feedback-recorder.js';
+import { stampAcceptedWaveItem } from './stamp-accepted-wave-item.js';
 
 const MAX_SDS_PER_MEETING = 5;
 
@@ -89,6 +90,15 @@ async function executeDecisions(supabase, decisions) {
       if (fetchError || !rec) {
         results.errors.push({ phase: 'fetch', id: decision.recommendationId, error: fetchError?.message || 'Not found' });
         continue;
+      }
+
+      // SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-2): stamp the originating roadmap_wave_items row
+      // build-eligible (item_disposition='selected') so an accepted distilled candidate becomes a
+      // belt-refill candidate. Fail-soft: a stamp error is recorded but never aborts the accept. Null
+      // source_wave_item_id is a clean no-op.
+      const stamp = await stampAcceptedWaveItem(supabase, rec.source_wave_item_id);
+      if (stamp.reason === 'error') {
+        results.errors.push({ phase: 'wave_item_stamp', id: rec.id, error: stamp.error });
       }
 
       // Create SD if action_type warrants it and under rate limit

--- a/lib/eva/consultant/stamp-accepted-wave-item.js
+++ b/lib/eva/consultant/stamp-accepted-wave-item.js
@@ -1,0 +1,65 @@
+/**
+ * Chairman-accept -> build-eligible stamp writer.
+ * SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-2).
+ *
+ * When the chairman ACCEPTS an eva_consultant_recommendations row, the originating roadmap_wave_items row
+ * must become a belt-refill candidate. Before this SD, NO code stamped acceptance back onto the wave item
+ * (grep-verified; the live DB had 0 items at item_disposition='selected'), so an accepted distilled
+ * candidate never became build-eligible — the belt auto-refill starved. This is the single, shared,
+ * idempotent writer that closes that seam.
+ *
+ * The unified belt-refill discriminant (see lib/sourcing-engine/refill-candidate-validity.js
+ * hasBuildDisposition / BUILD_DISPOSITIONS) reads roadmap_wave_items.item_disposition === 'selected' as the
+ * build-eligible marker. 'selected' is the chairman/distiller-accepted, pre-promotion value in the
+ * item_disposition vocabulary and is already a valid CHECK value — so this is CODE-ONLY, no migration.
+ *
+ * Idempotent + terminal-guarded: only sets 'selected' when the row is NOT already in a terminal state
+ * ('promoted'/'dropped') — it never clobbers a terminal disposition, and re-stamping a 'selected' row is a
+ * value no-op. Fail-soft: never throws; a stamp failure is returned (and logged) so the caller's accept is
+ * not aborted by a stamping error.
+ */
+
+// The build-eligible item_disposition value the unified belt-refill discriminant reads (BUILD_DISPOSITIONS
+// in refill-candidate-validity.js). Kept as a local literal (with this comment) rather than importing the
+// predicate's Set so the write seam stays decoupled from the pure predicate module.
+export const BUILD_ELIGIBLE_DISPOSITION = 'selected';
+
+// Terminal item_disposition states that must never be overwritten by an accept stamp.
+export const TERMINAL_DISPOSITIONS = ['promoted', 'dropped'];
+
+/**
+ * Stamp the linked roadmap_wave_items row build-eligible (item_disposition='selected') on chairman accept.
+ * Idempotent, terminal-guarded, fail-soft.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string|null|undefined} waveItemId  the recommendation's source_wave_item_id (may be null)
+ * @returns {Promise<{stamped:boolean, reason:string, error?:string}>}
+ *          reason: 'no_source_wave_item' | 'stamped' | 'skipped_terminal' | 'error'
+ */
+export async function stampAcceptedWaveItem(supabase, waveItemId) {
+  // Guard a null/absent source link: a clean no-op (many recommendations have no wave-item provenance).
+  if (!waveItemId) return { stamped: false, reason: 'no_source_wave_item' };
+
+  try {
+    // Single atomic UPDATE ... WHERE id = ? AND item_disposition NOT IN ('promoted','dropped').
+    // The terminal guard lives in the WHERE clause so a terminal row matches 0 rows (never clobbered);
+    // .select() returns the affected rows so we can tell a real stamp from a terminal skip.
+    const { data, error } = await supabase
+      .from('roadmap_wave_items')
+      .update({ item_disposition: BUILD_ELIGIBLE_DISPOSITION })
+      .eq('id', waveItemId)
+      .not('item_disposition', 'in', `("${TERMINAL_DISPOSITIONS.join('","')}")`)
+      .select('id, item_disposition');
+
+    if (error) {
+      console.error(`[stamp-accepted-wave-item] update failed for ${waveItemId}: ${error.message}`);
+      return { stamped: false, reason: 'error', error: error.message };
+    }
+    const stamped = Array.isArray(data) && data.length > 0;
+    return { stamped, reason: stamped ? 'stamped' : 'skipped_terminal' };
+  } catch (err) {
+    // Fail-soft: the accept must not abort on a stamp error.
+    console.error(`[stamp-accepted-wave-item] threw for ${waveItemId}: ${err.message}`);
+    return { stamped: false, reason: 'error', error: err.message };
+  }
+}

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -55,27 +55,47 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   ACCEPTED_KNOWN_STATE: 'accepted_known_state',
 });
 
-// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: the disposition value(s) that mark a staged item
-// as a chairman/distiller-approved BUILDABLE idea (set by the distiller -001-C / chairman queue -001-A).
-// Anything else — including an absent disposition (legacy/undistilled) — is NOT build-dispositioned.
-export const BUILD_DISPOSITIONS = new Set(['build']);
+// SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1a): the ONE unified belt-refill discriminant lives on the REAL
+// column roadmap_wave_items.item_disposition. 'selected' is the chairman/distiller build-eligible state in
+// the item_disposition vocabulary (pending|selected|deferred|brainstormed|promoted|dropped) — the only
+// pre-promotion, chairman-pickable value — so it is the canonical build marker. NO migration: 'selected'
+// is already a valid CHECK value; nothing wrote it before this SD. The pre-unification 'build' literal
+// (which lived on a SEPARATE, never-populated item.disposition/metadata.disposition field — the schism that
+// starved the belt) is intentionally NOT in this Set; it survives only as the inert legacy fallback below.
+export const BUILD_DISPOSITIONS = new Set(['selected']);
+
+// SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1b): inert backward-compat only. Historical rows (pre-unification)
+// may still carry a top-level disposition / metadata.disposition === 'build'; honor it so a legacy row is
+// not orphaned. This is a legacy no-op path — the PRIMARY (and only forward) signal is item_disposition.
+export const LEGACY_BUILD_DISPOSITION = 'build';
 
 /**
- * Has this staged item been dispositioned as BUILDABLE? Reads the canonical `disposition` field (top-level,
- * the shape the router/escalator/populator already stamp) with a `metadata.disposition` fallback. An absent
- * or non-'build' disposition returns false (the safe default — undistilled items are not auto-buildable).
- * PURE/TOTAL.
- * @param {{ disposition?:string, metadata?:object }} item
+ * Has this staged item been dispositioned as BUILDABLE? SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1b): the
+ * PRIMARY signal is the real column `item_disposition` === 'selected' (the unified discriminant). A legacy
+ * top-level `disposition` / `metadata.disposition` === 'build' is still honored as an inert backward-compat
+ * fallback. An absent / non-'selected' / non-legacy-'build' disposition returns false (the safe default —
+ * undistilled items are not auto-buildable). PURE/TOTAL.
+ * @param {{ item_disposition?:string, disposition?:string, metadata?:object }} item
  * @returns {boolean}
  */
 export function hasBuildDisposition(item) {
   if (!item || typeof item !== 'object') return false;
+  // PRIMARY: the unified discriminant — roadmap_wave_items.item_disposition === 'selected'.
+  if (BUILD_DISPOSITIONS.has(String(item.item_disposition ?? '').trim().toLowerCase())) return true;
+  // LEGACY inert fallback: a historical disposition/metadata.disposition === 'build'.
   const md = item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
-  const raw = nonEmpty(item.disposition) ? item.disposition : (nonEmpty(md.disposition) ? md.disposition : '');
-  return BUILD_DISPOSITIONS.has(String(raw).trim().toLowerCase());
+  const legacy = nonEmpty(item.disposition) ? item.disposition : (nonEmpty(md.disposition) ? md.disposition : '');
+  return String(legacy).trim().toLowerCase() === LEGACY_BUILD_DISPOSITION;
 }
 
 const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
+
+// SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1c): the lifecycle "staged" states that may still reach the
+// belt-quality axes. BOTH 'pending' (auto-staged, un-accepted) and 'selected' (chairman/distiller-accepted,
+// build-eligible) are pre-promotion staged states, so the NOT_STAGED gate must admit BOTH — otherwise an
+// accepted 'selected' item is rejected as NOT_STAGED before CHECK #11 (hasBuildDisposition) ever runs, and
+// the belt never refills. Everything else (deferred|brainstormed|dropped|promoted|null) stays NOT_STAGED.
+export const STAGED_DISPOSITIONS = new Set(['pending', 'selected']);
 
 // SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-1): source_types whose staged items must NEVER be promoted by the
 // GENERAL auto-refill funnel — they belong to a SEPARATE, dedicated, flag-gated promoter. 'vdr_gauge'
@@ -220,12 +240,14 @@ export function evaluateRefillCandidate(item, opts = {}) {
   if (!item || typeof item !== 'object' || Array.isArray(item)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM };
   }
-  // Lifecycle first: an item already promoted to the belt, or not in the staged ('pending') state, is
-  // not a refill candidate regardless of its fields.
+  // Lifecycle first: an item already promoted to the belt, or not in a staged state, is not a refill
+  // candidate regardless of its fields. SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1c): "staged" now admits
+  // BOTH 'pending' and 'selected' (the chairman-accepted, build-eligible state) so an accepted item can
+  // reach CHECK #11; deferred/brainstormed/dropped/promoted/null still report NOT_STAGED.
   if (nonEmpty(item.promoted_to_sd_key)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.ALREADY_PROMOTED };
   }
-  if (item.item_disposition !== 'pending') {
+  if (!STAGED_DISPOSITIONS.has(item.item_disposition)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED };
   }
   // A lane explicitly routed away from the belt must never be auto-promoted.

--- a/scripts/eva/recommendation-feedback.mjs
+++ b/scripts/eva/recommendation-feedback.mjs
@@ -14,6 +14,7 @@
  */
 
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { stampAcceptedWaveItem } from '../../lib/eva/consultant/stamp-accepted-wave-item.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -67,10 +68,11 @@ async function processFeedback(action, recId, notes) {
     return;
   }
 
-  // Fetch recommendation
+  // Fetch recommendation. SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-2): also pull source_wave_item_id so an
+  // accept can stamp the originating roadmap_wave_items row build-eligible.
   const { data: rec, error: fetchErr } = await supabase
     .from('eva_consultant_recommendations')
-    .select('id, title, trend_id, application_domain, status')
+    .select('id, title, trend_id, application_domain, status, source_wave_item_id')
     .eq('id', recId)
     .single();
 
@@ -100,6 +102,18 @@ async function processFeedback(action, recId, notes) {
   }
 
   console.log(`✅ Recommendation "${rec.title}" marked as ${action}`);
+
+  // SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-2): on accept, stamp the originating roadmap_wave_items row
+  // build-eligible (item_disposition='selected') so it becomes a belt-refill candidate. Fail-soft: a stamp
+  // error is logged but must not abort the accept. Null source_wave_item_id is a clean no-op.
+  if (action === 'accepted') {
+    const stamp = await stampAcceptedWaveItem(supabase, rec.source_wave_item_id);
+    if (stamp.stamped) {
+      console.log(`   🎯 Wave item ${rec.source_wave_item_id} marked build-eligible (item_disposition='selected')`);
+    } else if (stamp.reason === 'error') {
+      console.error(`   ⚠️  Build-eligible stamp failed (accept still recorded): ${stamp.error}`);
+    }
+  }
 
   // Feedback loop: adjust trend confidence for accepted recommendations
   if (action === 'accepted' && rec.trend_id) {

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -69,6 +69,37 @@ export function collectShippedTitleAdvisories(batch, shippedTitleSet) {
   return { matches, byReason };
 }
 
+/**
+ * SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-3): resolve the ACTIVE roadmap's wave ids so the candidate query
+ * is scoped to the plan-of-record only. Mirrors the existing active-roadmap SSOT predicate
+ * (strategic_roadmaps.status='active') used by lib/roadmap/wave-disposition.js and
+ * scripts/eva/friday-meeting.mjs — NOT a new/duplicate flag. PostgREST cannot filter a grandparent in one
+ * .from() call, so this is done as two bounded pre-queries (active roadmap ids -> their wave ids) and the
+ * caller applies the resulting .in('wave_id', ...) filter.
+ *
+ * FAIL-CLOSED: on any error, no active roadmap, or zero active waves, returns [] so the caller promotes
+ * NOTHING (never a full-corpus fallback — the belt-flood defect this SD closes).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<string[]>} the active roadmap's wave ids (empty => fail-closed, promote nothing)
+ */
+export async function resolveActiveWaveIds(supabase) {
+  const { data: roadmaps, error: rErr } = await supabase
+    .from('strategic_roadmaps')
+    .select('id')
+    .eq('status', 'active');
+  if (rErr) { console.error('refill-cron: active-roadmap lookup failed:', rErr.message); return []; }
+  const roadmapIds = (roadmaps || []).map((r) => r.id).filter(Boolean);
+  if (roadmapIds.length === 0) return [];
+
+  const { data: waves, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id')
+    .in('roadmap_id', roadmapIds);
+  if (wErr) { console.error('refill-cron: active-wave lookup failed:', wErr.message); return []; }
+  return (waves || []).map((w) => w.id).filter(Boolean);
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const apply = args.includes('--apply');
@@ -90,12 +121,25 @@ async function main() {
     process.exit(0);
   }
 
-  // Staged = item_disposition='pending' AND not yet promoted.
+  // SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-3): scope the candidate query to the ACTIVE roadmap's waves so
+  // draft/archived roadmap items are never eligible belt candidates. FAIL-CLOSED: no active roadmap / zero
+  // active waves => promote NOTHING (never a full-corpus fallback).
+  const activeWaveIds = await resolveActiveWaveIds(supabase);
+  if (activeWaveIds.length === 0) {
+    console.log('[SKIP] no active roadmap / zero active waves (fail-closed). No candidates fetched, nothing promoted.');
+    process.exit(0);
+  }
+
+  // Staged = item_disposition IN ('pending','selected') AND not yet promoted, within the active roadmap.
+  // SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1d): broaden from .eq('pending') to .in(['pending','selected'])
+  // so chairman-accepted 'selected' rows are actually fetched (an 'pending' un-accepted row still fails
+  // CHECK #11 downstream under the default fail-closed distilledOnly gate).
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
     // lane is live (sourcing-engine activation migrations) but postdates the schema-reference snapshot.
     .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id, metadata') // schema-lint-disable-line
-    .eq('item_disposition', 'pending')
+    .in('item_disposition', ['pending', 'selected'])
+    .in('wave_id', activeWaveIds)
     .is('promoted_to_sd_key', null)
     .limit(1000);
 

--- a/tests/unit/eva/stamp-accepted-wave-item.test.js
+++ b/tests/unit/eva/stamp-accepted-wave-item.test.js
@@ -1,0 +1,96 @@
+/**
+ * SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-2 / TS-5) — chairman-accept -> build-eligible stamp writer.
+ *
+ * Pins: stamps 'selected', is idempotent, skips a null source_wave_item_id, never clobbers a terminal
+ * ('promoted'/'dropped') disposition, and is fail-soft (a DB error / throw never aborts the accept).
+ */
+import { describe, it, expect } from 'vitest';
+import { stampAcceptedWaveItem } from '../../../lib/eva/consultant/stamp-accepted-wave-item.js';
+
+// In-memory roadmap_wave_items mock that faithfully applies the writer's chain:
+//   .update(patch).eq('id', v).not('item_disposition','in','("promoted","dropped")').select(...)
+function makeSb(rows) {
+  return {
+    from() {
+      let patch = null;
+      const eqs = [];
+      const nots = [];
+      const builder = {
+        update(p) { patch = p; return builder; },
+        eq(col, val) { eqs.push({ col, val }); return builder; },
+        not(col, op, val) { nots.push({ col, op, val }); return builder; },
+        select() {
+          let hits = rows.filter((r) => eqs.every((f) => r[f.col] === f.val));
+          hits = hits.filter((r) => nots.every((nf) => {
+            if (nf.op !== 'in') return true;
+            const vals = nf.val.replace(/[()"]/g, '').split(',');
+            return !vals.includes(String(r[nf.col]));
+          }));
+          if (patch) for (const r of hits) Object.assign(r, patch);
+          return Promise.resolve({ data: hits.map((r) => ({ id: r.id, item_disposition: r.item_disposition })), error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('stampAcceptedWaveItem', () => {
+  it("stamps item_disposition='selected' on a pending row", async () => {
+    const rows = [{ id: 'w1', item_disposition: 'pending' }];
+    const out = await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    expect(out).toEqual({ stamped: true, reason: 'stamped' });
+    expect(rows[0].item_disposition).toBe('selected');
+  });
+
+  it('advances a brainstormed row to selected', async () => {
+    const rows = [{ id: 'w1', item_disposition: 'brainstormed' }];
+    await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    expect(rows[0].item_disposition).toBe('selected');
+  });
+
+  it('is idempotent: re-stamping an already-selected row leaves it selected', async () => {
+    const rows = [{ id: 'w1', item_disposition: 'selected' }];
+    const first = await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    const second = await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    expect(first.stamped).toBe(true);
+    expect(second.stamped).toBe(true);
+    expect(rows[0].item_disposition).toBe('selected');
+  });
+
+  it('null / undefined source_wave_item_id is a clean no-op (no DB touch, no throw)', async () => {
+    const sb = { from() { throw new Error('DB must not be touched for a null source_wave_item_id'); } };
+    expect(await stampAcceptedWaveItem(sb, null)).toEqual({ stamped: false, reason: 'no_source_wave_item' });
+    expect(await stampAcceptedWaveItem(sb, undefined)).toEqual({ stamped: false, reason: 'no_source_wave_item' });
+  });
+
+  it("never clobbers a terminal 'promoted' disposition", async () => {
+    const rows = [{ id: 'w1', item_disposition: 'promoted' }];
+    const out = await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    expect(out).toEqual({ stamped: false, reason: 'skipped_terminal' });
+    expect(rows[0].item_disposition).toBe('promoted');
+  });
+
+  it("never clobbers a terminal 'dropped' disposition", async () => {
+    const rows = [{ id: 'w1', item_disposition: 'dropped' }];
+    const out = await stampAcceptedWaveItem(makeSb(rows), 'w1');
+    expect(out).toEqual({ stamped: false, reason: 'skipped_terminal' });
+    expect(rows[0].item_disposition).toBe('dropped');
+  });
+
+  it('fail-soft on a DB error (returns error, does not throw)', async () => {
+    const sb = { from: () => ({ update: () => ({ eq: () => ({ not: () => ({ select: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) }) };
+    const out = await stampAcceptedWaveItem(sb, 'w1');
+    expect(out.stamped).toBe(false);
+    expect(out.reason).toBe('error');
+    expect(out.error).toBe('boom');
+  });
+
+  it('fail-soft on a thrown client error (caught, returns error)', async () => {
+    const sb = { from() { throw new Error('client exploded'); } };
+    const out = await stampAcceptedWaveItem(sb, 'w1');
+    expect(out.stamped).toBe(false);
+    expect(out.reason).toBe('error');
+    expect(out.error).toBe('client exploded');
+  });
+});

--- a/tests/unit/sourcing-engine/belt-refill-unify-discriminant.test.js
+++ b/tests/unit/sourcing-engine/belt-refill-unify-discriminant.test.js
@@ -1,0 +1,105 @@
+/**
+ * SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-1) — unify the belt-refill discriminant onto item_disposition.
+ *
+ * Before this SD the belt auto-refill NEVER worked: hasBuildDisposition read a SEPARATE, never-populated
+ * item.disposition/metadata.disposition field ('build'), while the real column roadmap_wave_items
+ * .item_disposition never carried 'build' — a two-field / zero-overlap schism that starved the fleet.
+ * These tests pin the unified discriminant: item_disposition === 'selected' is build-eligible; the
+ * NOT_STAGED lifecycle gate now admits {'pending','selected'}; and the >0-candidates regression proof.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  hasBuildDisposition,
+  evaluateRefillCandidate,
+  BUILD_DISPOSITIONS,
+  STAGED_DISPOSITIONS,
+  REFILL_INVALID_REASONS,
+} from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+import { selectRefillBatch } from '../../../lib/sourcing-engine/refill-auto-promote.js';
+
+// A well-formed staged refill candidate; item_disposition overridden per case.
+const validItem = (over = {}) => ({
+  item_disposition: 'selected',
+  promoted_to_sd_key: null,
+  title: 'Harden the worktree reaper against orphaned junctions',
+  source_type: 'conversion_ledger',
+  source_id: '11111111-1111-1111-1111-111111111111',
+  lane: 'belt',
+  ...over,
+});
+
+describe('FR-1a: BUILD_DISPOSITIONS is the unified marker', () => {
+  it("contains 'selected' and does NOT contain 'build'", () => {
+    expect(BUILD_DISPOSITIONS.has('selected')).toBe(true);
+    expect(BUILD_DISPOSITIONS.has('build')).toBe(false);
+  });
+  it("STAGED_DISPOSITIONS admits exactly {'pending','selected'}", () => {
+    expect(STAGED_DISPOSITIONS.has('pending')).toBe(true);
+    expect(STAGED_DISPOSITIONS.has('selected')).toBe(true);
+    expect(STAGED_DISPOSITIONS.has('deferred')).toBe(false);
+    expect(STAGED_DISPOSITIONS.has('promoted')).toBe(false);
+  });
+});
+
+describe('FR-1b: hasBuildDisposition reads item_disposition (TS-1)', () => {
+  it("true for item_disposition='selected'", () => {
+    expect(hasBuildDisposition({ item_disposition: 'selected' })).toBe(true);
+  });
+  it('false for pending / deferred / dropped / brainstormed / promoted / null / absent', () => {
+    expect(hasBuildDisposition({ item_disposition: 'pending' })).toBe(false);
+    expect(hasBuildDisposition({ item_disposition: 'deferred' })).toBe(false);
+    expect(hasBuildDisposition({ item_disposition: 'dropped' })).toBe(false);
+    expect(hasBuildDisposition({ item_disposition: 'brainstormed' })).toBe(false);
+    // 'promoted' is already-promoted (not a refill candidate) — intentionally NOT build-eligible.
+    expect(hasBuildDisposition({ item_disposition: 'promoted' })).toBe(false);
+    expect(hasBuildDisposition({ item_disposition: null })).toBe(false);
+    expect(hasBuildDisposition({})).toBe(false);
+    expect(hasBuildDisposition(null)).toBe(false);
+  });
+  it('still honors the inert legacy disposition==="build" fallback (backward-compat)', () => {
+    expect(hasBuildDisposition({ disposition: 'build' })).toBe(true);
+    expect(hasBuildDisposition({ metadata: { disposition: 'build' } })).toBe(true);
+  });
+});
+
+describe('FR-1c: NOT_STAGED gate admits pending + selected (TS-2)', () => {
+  it("a 'selected' item passes the lifecycle gate and reaches CHECK #11 (and passes it under distilledOnly)", () => {
+    const v = evaluateRefillCandidate(validItem({ item_disposition: 'selected' }), { distilledOnly: true });
+    expect(v).toEqual({ valid: true, reason: null });
+  });
+  it("the identical 'pending' item is rejected at CHECK #11 (UNDISPOSITIONED_OR_NON_BUILD), NOT at NOT_STAGED", () => {
+    const v = evaluateRefillCandidate(validItem({ item_disposition: 'pending' }), { distilledOnly: true });
+    expect(v).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD });
+  });
+  it('deferred / brainstormed / dropped / promoted / null still report NOT_STAGED', () => {
+    for (const d of ['deferred', 'brainstormed', 'dropped', 'promoted', null]) {
+      expect(evaluateRefillCandidate(validItem({ item_disposition: d })).reason)
+        .toBe(REFILL_INVALID_REASONS.NOT_STAGED);
+    }
+  });
+  it("a 'pending' item still passes the lifecycle gate when distilledOnly is OFF (legacy behavior)", () => {
+    // NOT_STAGED must admit pending; with the flag off CHECK #11 is inert so it is fully valid.
+    expect(evaluateRefillCandidate(validItem({ item_disposition: 'pending' }))).toEqual({ valid: true, reason: null });
+  });
+});
+
+describe('FR-1 REGRESSION PROOF (TS-3 / AC-4): the belt now produces >0 candidates', () => {
+  it("a chairman-accepted (item_disposition='selected') unpromoted item is selected onto the belt batch", () => {
+    const rows = [
+      validItem({ item_disposition: 'selected', source_id: 'rw-accepted' }),
+      // an un-accepted 'pending' sibling must NOT flood the belt under the default fail-closed gate
+      validItem({ item_disposition: 'pending', source_id: 'rw-pending' }),
+    ];
+    const sel = selectRefillBatch(rows, { distilledOnly: true });
+    expect(sel.validCount).toBeGreaterThanOrEqual(1);
+    const ids = sel.batch.map((b) => b.source_id);
+    expect(ids).toContain('rw-accepted');
+    expect(ids).not.toContain('rw-pending');
+  });
+
+  it('flood-safety (TS-6): with 0 selected items, the belt batch is empty even amid many pending rows', () => {
+    const rows = Array.from({ length: 20 }, (_, i) => validItem({ item_disposition: 'pending', source_id: `rw-${i}` }));
+    const sel = selectRefillBatch(rows, { distilledOnly: true });
+    expect(sel.batch).toHaveLength(0);
+  });
+});

--- a/tests/unit/sourcing-engine/refill-cron-active-roadmap-scope.test.js
+++ b/tests/unit/sourcing-engine/refill-cron-active-roadmap-scope.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-UNIFY-BELT-REFILL-001 (FR-3 / TS-4, TS-6) — scope refill-cron to the ACTIVE roadmap.
+ *
+ * Before this SD the candidate query had NO roadmap filter, so 1,415 pending items from draft/archived
+ * EVA-Intake roadmaps were eligible belt candidates. resolveActiveWaveIds resolves the plan-of-record's
+ * wave ids (strategic_roadmaps.status='active' -> roadmap_waves.roadmap_id) that the cron then applies via
+ * .in('wave_id', ...). FAIL-CLOSED: on any error / no active roadmap / zero active waves it returns []
+ * (the caller promotes NOTHING — never a full-corpus fallback).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveActiveWaveIds } from '../../../scripts/sourcing-engine/refill-cron.mjs';
+
+// Mock supabase: strategic_roadmaps.select('id').eq('status','active') is awaited directly, and
+// roadmap_waves.select('id').in('roadmap_id', ids) is awaited directly.
+function makeSb({ roadmaps = [], waves = [], roadmapErr = null, waveErr = null } = {}) {
+  return {
+    from(table) {
+      return {
+        select() { return this; },
+        eq() {
+          return Promise.resolve(
+            table === 'strategic_roadmaps'
+              ? { data: roadmapErr ? null : roadmaps, error: roadmapErr }
+              : { data: [], error: null },
+          );
+        },
+        in() {
+          return Promise.resolve(
+            table === 'roadmap_waves'
+              ? { data: waveErr ? null : waves, error: waveErr }
+              : { data: [], error: null },
+          );
+        },
+      };
+    },
+  };
+}
+
+describe('resolveActiveWaveIds', () => {
+  it('returns the active roadmap wave ids (TS-4 mechanism)', async () => {
+    const sb = makeSb({ roadmaps: [{ id: 'r-active' }], waves: [{ id: 'w1' }, { id: 'w2' }] });
+    expect(await resolveActiveWaveIds(sb)).toEqual(['w1', 'w2']);
+  });
+
+  it('fail-closed: no active roadmap -> [] (promote nothing, no full-corpus fallback) (TS-6)', async () => {
+    const sb = makeSb({ roadmaps: [] });
+    expect(await resolveActiveWaveIds(sb)).toEqual([]);
+  });
+
+  it('fail-closed: active roadmap but zero waves -> []', async () => {
+    const sb = makeSb({ roadmaps: [{ id: 'r-active' }], waves: [] });
+    expect(await resolveActiveWaveIds(sb)).toEqual([]);
+  });
+
+  it('fail-closed: a roadmap-lookup error -> []', async () => {
+    const sb = makeSb({ roadmapErr: { message: 'db down' } });
+    expect(await resolveActiveWaveIds(sb)).toEqual([]);
+  });
+
+  it('fail-closed: a wave-lookup error -> []', async () => {
+    const sb = makeSb({ roadmaps: [{ id: 'r-active' }], waveErr: { message: 'db down' } });
+    expect(await resolveActiveWaveIds(sb)).toEqual([]);
+  });
+
+  it('only the active roadmap ids drive the wave lookup (non-active roadmaps excluded)', async () => {
+    // The mock only returns the active roadmaps we inject; a draft/archived roadmap is never passed in
+    // because the .eq('status','active') predicate excludes it at the source query.
+    let receivedRoadmapIds = null;
+    const sb = {
+      from() {
+        return {
+          select() { return this; },
+          eq() { return Promise.resolve({ data: [{ id: 'r-active' }], error: null }); },
+          in(_col, ids) { receivedRoadmapIds = ids; return Promise.resolve({ data: [{ id: 'w1' }], error: null }); },
+        };
+      },
+    };
+    await resolveActiveWaveIds(sb);
+    expect(receivedRoadmapIds).toEqual(['r-active']);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-UNIFY-BELT-REFILL-001 — fix the belt auto-refill that has NEVER worked

**Root cause** (Solomon-adjudicated, code-verified): a two-field/zero-overlap discriminant schism. `hasBuildDisposition()` in `lib/sourcing-engine/refill-candidate-validity.js` read `item.disposition`/`metadata.disposition === 'build'` — a field **nothing ever writes** — while the real column `roadmap_wave_items.item_disposition` has vocabulary `pending|selected|deferred|brainstormed|promoted|dropped` (no `'build'`). So CHECK #11 rejected all **1,839** roadmap items → the belt could never auto-refill → the fleet idled by arithmetic whenever manual sourcing paused.

### The fix (3 interdependent parts, ~200 LOC + 25 tests, NO migration — `'selected'` is already a valid CHECK value)
- **FR-1 unify discriminant** — `hasBuildDisposition` now reads `item_disposition === 'selected'` (the canonical build marker; nothing wrote `'selected'` before, so activating it can't retroactively flood the belt). `NOT_STAGED` gate loosened `{pending}` → `{pending,selected}` so an accepted item reaches CHECK #11. Old `'build'` path kept only as an inert legacy fallback.
- **FR-2 chairman-accept-to-stamp writer** — new `lib/eva/consultant/stamp-accepted-wave-item.js` (idempotent, terminal-guarded so it never downgrades `promoted`/`dropped`, fail-soft, null-safe) wired into **both** chairman-accept seams (`recommendation-feedback.mjs`, `action-executor.js`) so an accept stamps the originating wave item `'selected'` → build-eligible.
- **FR-3 scope refill-cron to active roadmap** — `refill-cron.mjs` scoped to `strategic_roadmaps.status='active'` (fail-closed on none) + fetch broadened to `.in(item_disposition,[pending,selected])`. Pool 1,424 → 9.

### Three interdependent safety layers (flood-safe)
`'selected'` is set only by the chairman-accept writer; a `'pending'`-alone item dies at CHECK #11 (proven); CHECK #11 is fail-closed by default; cron scoped to the active roadmap.

### Verification
- **Core regression proof** exercises the **real** predicate chain (`selectRefillBatch → evaluateRefillCandidate → hasBuildDisposition`, not mocked) → belt now yields ≥1 candidate for a chairman-accepted item. Flood-safety proven (pending-alone excluded).
- Full touched-module run: **7212 passed / 0 failed**. No migration. Second consumer (`roadmap-manager.js`) works with the unified discriminant.
- Reviews (sub_agent_execution_results): TESTING 92, SECURITY 92, VALIDATION 95, REGRESSION 96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)