### PR TITLE
feat(SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A): reversibility classifier + chairman policy table + release_condition predicate

### DIFF
--- a/database/migrations/20260718_chairman_switchon_policy_STAGED.sql
+++ b/database/migrations/20260718_chairman_switchon_policy_STAGED.sql
@@ -1,0 +1,92 @@
+-- Chairman switch-on policy — the DB-backed reversible/consequential class list for the
+-- intelligent op-co switch-on automation.
+-- SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A (FR-2, child A of the switch-on
+-- orchestrator; scope is the policy table + ratchet ONLY -- wiring into the real
+-- dispatch-authorization.cjs enforcement path is child B).
+-- Chairman-ratified 2026-07-18 (SMS Yes) policy boundary; delegated auto-proceed authority.
+--
+-- WHY: the switch-on classifier (lib/switch-automation/reversibility-classifier.js) needs a
+-- chairman-ratified, DB-backed source of truth for its NEVER-AUTO class list -- not code
+-- comments, which drift silently and cannot be audited or widened through a governed
+-- ceremony. This table generalizes sms_decision_class_whitelist's shape for that purpose.
+--
+-- GOVERNANCE -- WHO IS STOPPED BY WHAT (mirrors 20260717_sms_decision_class_whitelist_STAGED.sql,
+-- the ratified precedent for chairman-gated STAGED policy tables):
+--   * anon / ordinary authenticated users are stopped at the RLS LAYER: no INSERT/UPDATE/
+--     DELETE policy exists for them, and SELECT is chairman-only (fn_is_chairman()).
+--   * service_role BYPASSES RLS (rolbypassrls=true), so RLS alone would NOT stop the fleet's
+--     service_role client from widening the policy. The DB-HARD RATCHET below closes that:
+--     a REVOKE of INSERT/UPDATE/DELETE binds the TABLE PRIVILEGE layer, which service_role
+--     does NOT bypass. The only principal that can widen the policy is the table OWNER
+--     (postgres) acting through the chairman apply ceremony -- the ratchet is thus DB-enforced,
+--     not just application discipline (same guard class as the SMS whitelist and the
+--     self-reference rule: "the policy/ratchet itself" is itself a NEVER-AUTO class, row-seeded
+--     below, so this table can never be used to widen itself).
+--   * the read path (the classifier's policy lookup, child B) MUST use a service_role client:
+--     service_role bypasses the chairman-only SELECT policy to read the list; an
+--     anon/authenticated read sees ZERO rows (fail-closed to consequential/chairman, never
+--     fail-open to auto-proceed).
+--
+-- STAGED -- NOT YET APPLIED. requires-chairman-apply. Do NOT auto-apply on merge; no
+-- approved-by attestation. APPLY RUNBOOK (chairman ceremony):
+--   (1) chairman verbal/written approval of the row contents below (the NEVER-AUTO seed list);
+--   (2) apply via the standard migration path with an approved-by attestation commit,
+--       AS THE TABLE OWNER (postgres) -- the owner is exempt from the REVOKE and is the ONLY
+--       principal that seeds/widens the policy;
+--   (3) run `npm run schema:snapshot:lint` and commit the regenerated snapshot in the same PR;
+--   (4) verify with a real service_role select probe against chairman_switchon_policy --
+--       child B's enforcement gate flips from fail-closed-to-chairman to policy-gated
+--       automatically once rows exist; no code change needed in child B.
+
+CREATE TABLE IF NOT EXISTS chairman_switchon_policy (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- The action class this policy row governs. Stored NORMALIZED (lowercased/trimmed) by the
+  -- chairman ceremony, matching lib/switch-automation/reversibility-classifier.js's
+  -- NEVER_AUTO_CLASSES string keys via an EXACT compare (never substring/ilike).
+  action_class TEXT NOT NULL UNIQUE
+    CHECK (action_class = lower(btrim(action_class)) AND action_class <> ''),
+
+  -- 'never_auto' = always routes to chairman regardless of precheck; 'reversible_eligible' =
+  -- MAY auto-proceed if the precheck (child C) is green. There is no third value -- unknown/
+  -- unclassified actions are handled by the classifier's own fail-closed default, not a row here.
+  classification TEXT NOT NULL CHECK (classification IN ('never_auto', 'reversible_eligible')),
+
+  -- A class can be de-listed without deleting its audit row.
+  active BOOLEAN NOT NULL DEFAULT true,
+
+  -- Provenance for the audit trail (CONST-003: actor, policy version, evidence snapshot).
+  added_by TEXT,
+  added_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rationale TEXT
+);
+
+-- RLS + policies in the SAME migration as CREATE TABLE (SPINE-001-B recurrence guard).
+ALTER TABLE chairman_switchon_policy ENABLE ROW LEVEL SECURITY;
+
+-- Chairman-only read: the policy is a chairman-audience security control.
+DROP POLICY IF EXISTS chairman_switchon_policy_chairman_select ON chairman_switchon_policy;
+CREATE POLICY chairman_switchon_policy_chairman_select ON chairman_switchon_policy
+  FOR SELECT USING (fn_is_chairman());
+
+-- Deliberately NO INSERT/UPDATE/DELETE policy: widening the policy is a chairman-ceremony
+-- act performed by the table owner, never by anon/authenticated/service_role at runtime.
+
+-- DB-HARD RATCHET: bind the TABLE-PRIVILEGE layer so even service_role (which bypasses RLS,
+-- but NOT GRANT/REVOKE) cannot INSERT/UPDATE/DELETE. Self-reference guard: this table cannot
+-- be used to widen itself, since widening IS an INSERT/UPDATE and those are revoked here.
+REVOKE INSERT, UPDATE, DELETE ON chairman_switchon_policy FROM anon, authenticated, service_role;
+
+COMMENT ON TABLE chairman_switchon_policy IS
+  'Chairman-ratified reversible/consequential class list for op-co switch-on automation (SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A FR-2). Fail-closed: absent/unlisted/inactive class routes to consequential (chairman), never auto-proceed. Chairman-only SELECT; INSERT/UPDATE/DELETE REVOKEd from anon/authenticated/service_role so only the table owner (chairman ceremony) can widen it -- including widening the policy/ratchet itself.';
+
+-- ============================================================
+-- Chairman-ratified NEVER-AUTO seed rows (applied by the ceremony, NOT by this migration --
+-- listed here for the chairman's approval review; the INSERT itself runs as the table owner
+-- during apply, per the runbook above, not as part of this STAGED file).
+-- ============================================================
+-- venture-gate-binding-flip, live-money-enablement, public-launch, first-external-send,
+-- venture-selection, venture-kill, venture-promote, gate-config-change, gate-threshold-change,
+-- gate-skiplist-change, agent-authority-expansion, credential-grant-expansion,
+-- freeze-machinery, kill-switch-machinery, policy-ratchet-self-reference
+-- (verbatim match to lib/switch-automation/reversibility-classifier.js NEVER_AUTO_CLASSES)

--- a/database/migrations/20260718_chairman_switchon_policy_STAGED.sql
+++ b/database/migrations/20260718_chairman_switchon_policy_STAGED.sql
@@ -85,8 +85,11 @@ COMMENT ON TABLE chairman_switchon_policy IS
 -- listed here for the chairman's approval review; the INSERT itself runs as the table owner
 -- during apply, per the runbook above, not as part of this STAGED file).
 -- ============================================================
--- venture-gate-binding-flip, live-money-enablement, public-launch, first-external-send,
+-- venture-gate-binding-flip, live-venture-deploy, live-money-enablement,
+-- live-payment-account-creation, dns-mutation, public-launch, first-external-send,
 -- venture-selection, venture-kill, venture-promote, gate-config-change, gate-threshold-change,
 -- gate-skiplist-change, agent-authority-expansion, credential-grant-expansion,
 -- freeze-machinery, kill-switch-machinery, policy-ratchet-self-reference
--- (verbatim match to lib/switch-automation/reversibility-classifier.js NEVER_AUTO_CLASSES)
+-- (verbatim match to lib/switch-automation/reversibility-classifier.js NEVER_AUTO_CLASSES.
+--  live-venture-deploy / live-payment-account-creation / dns-mutation satisfy GUARDRAIL-1's
+--  explicit enumeration requirement.)

--- a/database/migrations/20260718_release_condition_predicate.sql
+++ b/database/migrations/20260718_release_condition_predicate.sql
@@ -1,0 +1,26 @@
+-- Migration: release_condition_predicate — additive machine-evaluable predicate column
+-- SD: SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A (FR-3)
+-- Purpose: hold_state_contract_violations.release_condition is free-TEXT, observe-mode-only,
+--          stored raw/unparsed (SD-LEO-INFRA-HOLD-STATE-CONTRACT-001). Per Solomon's folded
+--          adjudication (ab03cf18), the switch-on class registry homes IN the hold-state-
+--          contract surface -- a switch-on class row IS a hold row with a machine-verifiable
+--          release_condition. This adds a NEW, additive predicate column alongside the
+--          existing free-text one (non-breaking) so child B/C can programmatically evaluate
+--          a release condition instead of just logging its raw text.
+-- All-additive (nullable column, IF NOT EXISTS) -- TIER-1 auto-apply eligible, same class as
+-- the parent 20260716_hold_state_contract.sql migration. NOT chairman-gated (schema-shape
+-- only; carries no auto-proceed authority itself -- unlike chairman_switchon_policy above).
+-- Date: 2026-07-18
+
+BEGIN;
+
+ALTER TABLE public.hold_state_contract_violations
+  ADD COLUMN IF NOT EXISTS release_condition_predicate JSONB;
+
+COMMENT ON COLUMN public.hold_state_contract_violations.release_condition_predicate IS
+  'Machine-evaluable predicate form of release_condition (SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A FR-3), additive alongside the existing free-text release_condition column (which remains the raw-text log, unchanged). Shape: {type: "test_green"|"manual_flag"|"db_row_exists", params: {...}}. Evaluated via lib/governance/release-condition-predicate.js evaluate(predicate, state) -- state is caller-injected, never read live by the evaluator itself, so it stays pure/testable in isolation. NULL for existing rows and for any release_condition that has not yet been expressed as a predicate.';
+
+COMMIT;
+
+-- Rollback:
+-- ALTER TABLE public.hold_state_contract_violations DROP COLUMN IF EXISTS release_condition_predicate;

--- a/lib/governance/release-condition-predicate.js
+++ b/lib/governance/release-condition-predicate.js
@@ -1,0 +1,53 @@
+/**
+ * Machine-evaluable release_condition predicate evaluator.
+ * SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A (FR-3).
+ *
+ * Pure, deterministic: evaluate(predicate, state) never reads live system state itself --
+ * the caller injects `state`, keeping this testable in isolation with stubbed inputs and
+ * with no dependency on child B/C's not-yet-built consumers.
+ *
+ * @module lib/governance/release-condition-predicate
+ */
+
+export const PREDICATE_TYPE = Object.freeze({
+  TEST_GREEN: 'test_green',
+  MANUAL_FLAG: 'manual_flag',
+  DB_ROW_EXISTS: 'db_row_exists',
+});
+
+/**
+ * @param {{type: string, params: Object}} predicate
+ * @param {Object} state - caller-injected snapshot of whatever the predicate needs to check.
+ *   For 'test_green': state.testResults = { [suiteName]: boolean }.
+ *   For 'manual_flag': state.flags = { [flagName]: boolean }.
+ *   For 'db_row_exists': state.rowCounts = { [tableOrQueryKey]: number }.
+ * @returns {boolean} true iff the predicate resolves satisfied given `state`.
+ *   Fail-closed: an unrecognized predicate type, missing state, or malformed predicate
+ *   returns false (never true) -- an unevaluable release condition is NOT released.
+ */
+export function evaluate(predicate, state = {}) {
+  if (!predicate || typeof predicate !== 'object') return false;
+  const { type, params = {} } = predicate;
+
+  switch (type) {
+    case PREDICATE_TYPE.TEST_GREEN: {
+      const suite = params.suite;
+      if (typeof suite !== 'string' || !state.testResults) return false;
+      return state.testResults[suite] === true;
+    }
+    case PREDICATE_TYPE.MANUAL_FLAG: {
+      const flag = params.flag;
+      if (typeof flag !== 'string' || !state.flags) return false;
+      return state.flags[flag] === true;
+    }
+    case PREDICATE_TYPE.DB_ROW_EXISTS: {
+      const key = params.key;
+      if (typeof key !== 'string' || !state.rowCounts) return false;
+      return (state.rowCounts[key] || 0) > 0;
+    }
+    default:
+      return false; // fail-closed on unrecognized type
+  }
+}
+
+export default evaluate;

--- a/lib/switch-automation/reversibility-classifier.js
+++ b/lib/switch-automation/reversibility-classifier.js
@@ -25,10 +25,18 @@ export const SWITCHON_VERDICT = Object.freeze({
 });
 
 /** Chairman-ratified NEVER-AUTO action classes (Solomon adjudication ab03cf18). Data, not code
- * comments -- child A seeds these same string keys as rows in chairman_switchon_policy. */
+ * comments -- child A seeds these same string keys as rows in chairman_switchon_policy.
+ * GUARDRAIL-1 (chairman_conditioned_acceptance_criteria) explicitly names 3 irreversible
+ * production actions the set MUST enumerate: live venture deploy, live payment-account
+ * creation, DNS mutation -- listed here as 'live-venture-deploy', 'live-payment-account-
+ * creation', and 'dns-mutation' (SECURITY finding, added post-review; see
+ * chairman-switchon-policy-migration.test.js's GUARDRAIL-1 parity test). */
 export const NEVER_AUTO_CLASSES = Object.freeze([
   'venture-gate-binding-flip',
+  'live-venture-deploy',
   'live-money-enablement',
+  'live-payment-account-creation',
+  'dns-mutation',
   'public-launch',
   'first-external-send',
   'venture-selection',

--- a/lib/switch-automation/reversibility-classifier.js
+++ b/lib/switch-automation/reversibility-classifier.js
@@ -1,0 +1,98 @@
+/**
+ * Op-co switch-on reversibility classifier — SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-A.
+ *
+ * Answers reversible / consequential / unknown for a proposed switch-on request, by
+ * ADAPTING (not mutating) lib/adam/execute-vs-escalate.js's deterministic 3-gate rubric.
+ * That module has 2 verdicts (execute/escalate); this classifier maps its gates onto a
+ * 3rd, explicit "unknown" verdict, and layers the chairman-ratified NEVER-AUTO class list
+ * on top with absolute precedence (CONST-001/002: machine-precheck feeds chairman
+ * ratification, never replaces it for irreversible/live-money/venture-commitment actions).
+ *
+ * Precedence (highest first):
+ *   1. NEVER-AUTO-listed action  -> always 'consequential', regardless of other inputs.
+ *   2. Any required field missing/ambiguous -> 'unknown' (conservative, per ADAM's own
+ *      "if you are not sure it is reversible, treat it as not reversible" rule).
+ *   3. Otherwise, delegate to classifyDecision(): EXECUTE -> 'reversible', ESCALATE -> 'consequential'.
+ *
+ * @module lib/switch-automation/reversibility-classifier
+ */
+import { classifyDecision, VERDICT as ADAM_VERDICT } from '../adam/execute-vs-escalate.js';
+
+export const SWITCHON_VERDICT = Object.freeze({
+  REVERSIBLE: 'reversible',
+  CONSEQUENTIAL: 'consequential',
+  UNKNOWN: 'unknown',
+});
+
+/** Chairman-ratified NEVER-AUTO action classes (Solomon adjudication ab03cf18). Data, not code
+ * comments -- child A seeds these same string keys as rows in chairman_switchon_policy. */
+export const NEVER_AUTO_CLASSES = Object.freeze([
+  'venture-gate-binding-flip',
+  'live-money-enablement',
+  'public-launch',
+  'first-external-send',
+  'venture-selection',
+  'venture-kill',
+  'venture-promote',
+  'gate-config-change',
+  'gate-threshold-change',
+  'gate-skiplist-change',
+  'agent-authority-expansion',
+  'credential-grant-expansion',
+  'freeze-machinery',
+  'kill-switch-machinery',
+  'policy-ratchet-self-reference',
+]);
+
+/** Required input fields; any missing/ambiguous one forces 'unknown' (gate 2). */
+const REQUIRED_FIELDS = ['component', 'action'];
+
+/**
+ * @param {Object} input
+ * @param {string} [input.component]                     - the op-co component being switched on.
+ * @param {string} [input.action]                         - the action class (checked against NEVER_AUTO_CLASSES).
+ * @param {boolean|null} [input.reversible]                - passed through to classifyDecision (null/undefined = uncertain).
+ * @param {boolean|null} [input.inRole]                    - passed through to classifyDecision (null/undefined = uncertain).
+ * @param {boolean} [input.isLiveMoney]                    - maps to ADAM's flagship gate.
+ * @param {boolean} [input.isVentureCommitment]            - maps to ADAM's governance gate.
+ * @param {boolean} [input.isReversibleByMechanism]        - true only if the class declares a revert verb/TTL/invoker AND a revert rehearsal has passed. Missing/false -> not reversible.
+ * @returns {{ verdict: string, reasons: string[], neverAuto: boolean }}
+ */
+export function classifySwitchOn(input = {}) {
+  const { component, action, reversible, inRole, isLiveMoney = false, isVentureCommitment = false, isReversibleByMechanism } = input;
+
+  // Gate 1 (highest precedence): NEVER-AUTO class list always wins.
+  if (typeof action === 'string' && NEVER_AUTO_CLASSES.includes(action)) {
+    return { verdict: SWITCHON_VERDICT.CONSEQUENTIAL, reasons: [`never-auto:${action}`], neverAuto: true };
+  }
+
+  // Gate 2: any required field missing/ambiguous -> unknown, even if action happens to
+  // resemble a NEVER-AUTO class textually elsewhere -- this branch only runs once gate 1
+  // has already ruled out an exact NEVER-AUTO match.
+  const missing = REQUIRED_FIELDS.filter((f) => typeof input[f] !== 'string' || input[f].trim() === '');
+  if (missing.length > 0) {
+    return { verdict: SWITCHON_VERDICT.UNKNOWN, reasons: missing.map((f) => `missing:${f}`), neverAuto: false };
+  }
+
+  // Gate 3: delegate to the shared ADAM rubric. "Reversible by mechanism" (revert
+  // verb/TTL/invoker declared + rehearsed) is required in addition to the raw `reversible`
+  // flag -- an untested revert path is not reversible (Solomon adjudication point 3).
+  const effectiveReversible = reversible === true && isReversibleByMechanism === true ? true
+    : reversible === false || isReversibleByMechanism === false ? false
+    : null; // uncertain if either signal is missing
+
+  const { verdict } = classifyDecision({
+    reversible: effectiveReversible,
+    inRole,
+    flagship: isLiveMoney,
+    governance: isVentureCommitment,
+  });
+
+  return {
+    verdict: verdict === ADAM_VERDICT.EXECUTE ? SWITCHON_VERDICT.REVERSIBLE : SWITCHON_VERDICT.CONSEQUENTIAL,
+    reasons: verdict === ADAM_VERDICT.EXECUTE ? [] : ['adam-rubric-escalate'],
+    neverAuto: false,
+  };
+}
+
+export default classifySwitchOn;

--- a/tests/unit/governance/release-condition-predicate.test.js
+++ b/tests/unit/governance/release-condition-predicate.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate, PREDICATE_TYPE } from '../../../lib/governance/release-condition-predicate.js';
+
+describe('evaluate (release_condition predicate)', () => {
+  it('test_green: true when the named suite is green in state', () => {
+    const predicate = { type: PREDICATE_TYPE.TEST_GREEN, params: { suite: 'switch-on-precheck' } };
+    expect(evaluate(predicate, { testResults: { 'switch-on-precheck': true } })).toBe(true);
+    expect(evaluate(predicate, { testResults: { 'switch-on-precheck': false } })).toBe(false);
+    expect(evaluate(predicate, { testResults: {} })).toBe(false);
+  });
+
+  it('manual_flag: true when the named flag is true in state', () => {
+    const predicate = { type: PREDICATE_TYPE.MANUAL_FLAG, params: { flag: 'chairman-cleared' } };
+    expect(evaluate(predicate, { flags: { 'chairman-cleared': true } })).toBe(true);
+    expect(evaluate(predicate, { flags: { 'chairman-cleared': false } })).toBe(false);
+  });
+
+  it('db_row_exists: true when the row count for the key is > 0', () => {
+    const predicate = { type: PREDICATE_TYPE.DB_ROW_EXISTS, params: { key: 'revert-rehearsal-log' } };
+    expect(evaluate(predicate, { rowCounts: { 'revert-rehearsal-log': 3 } })).toBe(true);
+    expect(evaluate(predicate, { rowCounts: { 'revert-rehearsal-log': 0 } })).toBe(false);
+    expect(evaluate(predicate, {})).toBe(false);
+  });
+
+  it('fails closed on unrecognized predicate type', () => {
+    expect(evaluate({ type: 'unknown_type', params: {} }, { testResults: {} })).toBe(false);
+  });
+
+  it('fails closed on malformed/missing predicate', () => {
+    expect(evaluate(null, {})).toBe(false);
+    expect(evaluate(undefined, {})).toBe(false);
+    expect(evaluate('not-an-object', {})).toBe(false);
+    expect(evaluate({}, {})).toBe(false);
+  });
+
+  it('fails closed when required state is missing entirely', () => {
+    const predicate = { type: PREDICATE_TYPE.TEST_GREEN, params: { suite: 'x' } };
+    expect(evaluate(predicate, {})).toBe(false);
+    expect(evaluate(predicate)).toBe(false);
+  });
+
+  it('never reads live state -- pure function of its two arguments', () => {
+    const predicate = { type: PREDICATE_TYPE.MANUAL_FLAG, params: { flag: 'f' } };
+    const stateA = { flags: { f: true } };
+    const stateB = { flags: { f: false } };
+    expect(evaluate(predicate, stateA)).toBe(true);
+    expect(evaluate(predicate, stateB)).toBe(false);
+    // Same predicate object, different injected state -> different result; no hidden I/O.
+  });
+});

--- a/tests/unit/switch-automation/chairman-switchon-policy-migration.test.js
+++ b/tests/unit/switch-automation/chairman-switchon-policy-migration.test.js
@@ -21,6 +21,13 @@ describe('chairman_switchon_policy STAGED migration (static file-lint, TS-2a)', 
     expect(sql).not.toMatch(/FOR (INSERT|UPDATE|DELETE)/i);
   });
 
+  // AC-2 (a runtime privilege probe against an EPHEMERAL local Postgres, confirming the
+  // REVOKE actually denies anon/authenticated/service_role writes) is DEFERRED, not dropped:
+  // this migration ships STAGED and is never applied to any DB by this SD, so there is no
+  // live table to probe yet. Per the PRD, AC-2 is verified at the chairman-apply ceremony
+  // (child B's scope) instead. Tracked explicitly here so the deferral stays durable.
+  it.todo('AC-2: ephemeral-DB privilege probe (deferred to chairman-apply ceremony / child B -- migration is STAGED, not applied by this SD)');
+
   it('REVOKEs INSERT, UPDATE, DELETE from anon, authenticated, AND service_role in the same file', () => {
     expect(sql).toMatch(/REVOKE INSERT, UPDATE, DELETE ON chairman_switchon_policy FROM anon, authenticated, service_role/);
   });
@@ -39,5 +46,16 @@ describe('chairman_switchon_policy STAGED migration (static file-lint, TS-2a)', 
 
   it('does not contain a live INSERT statement seeding rows (seed happens at chairman-apply time, not in this file)', () => {
     expect(sql).not.toMatch(/^\s*INSERT INTO chairman_switchon_policy/im);
+  });
+
+  // GUARDRAIL-1 (chairman_conditioned_acceptance_criteria, mandatory): "the NEVER-AUTO set
+  // MUST explicitly enumerate irreversible production actions — live venture deploy, live
+  // payment-account creation, DNS mutation — and ALWAYS route them to the chairman."
+  // SECURITY sub-agent found the classifier's original list didn't map cleanly onto these 3
+  // named examples; explicit classes were added -- this test guards against silent regression.
+  it('GUARDRAIL-1: NEVER_AUTO_CLASSES explicitly enumerates all 3 named irreversible actions', () => {
+    expect(NEVER_AUTO_CLASSES).toContain('live-venture-deploy');
+    expect(NEVER_AUTO_CLASSES).toContain('live-payment-account-creation');
+    expect(NEVER_AUTO_CLASSES).toContain('dns-mutation');
   });
 });

--- a/tests/unit/switch-automation/chairman-switchon-policy-migration.test.js
+++ b/tests/unit/switch-automation/chairman-switchon-policy-migration.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NEVER_AUTO_CLASSES } from '../../../lib/switch-automation/reversibility-classifier.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = path.resolve(__dirname, '../../../database/migrations/20260718_chairman_switchon_policy_STAGED.sql');
+const sql = readFileSync(MIGRATION_PATH, 'utf8');
+
+describe('chairman_switchon_policy STAGED migration (static file-lint, TS-2a)', () => {
+  it('enables RLS in the same file as CREATE TABLE', () => {
+    expect(sql).toMatch(/ALTER TABLE chairman_switchon_policy ENABLE ROW LEVEL SECURITY/);
+  });
+
+  it('has a chairman-only SELECT policy', () => {
+    expect(sql).toMatch(/FOR SELECT USING \(fn_is_chairman\(\)\)/);
+  });
+
+  it('has NO insert/update/delete policy defined', () => {
+    expect(sql).not.toMatch(/FOR (INSERT|UPDATE|DELETE)/i);
+  });
+
+  it('REVOKEs INSERT, UPDATE, DELETE from anon, authenticated, AND service_role in the same file', () => {
+    expect(sql).toMatch(/REVOKE INSERT, UPDATE, DELETE ON chairman_switchon_policy FROM anon, authenticated, service_role/);
+  });
+
+  it('is marked STAGED / requires-chairman-apply, not auto-applied', () => {
+    expect(sql).toMatch(/STAGED/);
+    expect(sql).toMatch(/requires-chairman-apply/);
+    expect(sql).toMatch(/NOT YET APPLIED/);
+  });
+
+  it('every NEVER_AUTO_CLASSES entry from the classifier is listed in the migration seed comment', () => {
+    for (const cls of NEVER_AUTO_CLASSES) {
+      expect(sql).toContain(cls);
+    }
+  });
+
+  it('does not contain a live INSERT statement seeding rows (seed happens at chairman-apply time, not in this file)', () => {
+    expect(sql).not.toMatch(/^\s*INSERT INTO chairman_switchon_policy/im);
+  });
+});

--- a/tests/unit/switch-automation/reversibility-classifier.test.js
+++ b/tests/unit/switch-automation/reversibility-classifier.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { classifySwitchOn, SWITCHON_VERDICT, NEVER_AUTO_CLASSES } from '../../../lib/switch-automation/reversibility-classifier.js';
+
+describe('classifySwitchOn', () => {
+  it('classifies a reversible, in-role, non-live-money component as reversible', () => {
+    const r = classifySwitchOn({
+      component: 'ops-scheduler', action: 'enable-scheduler',
+      reversible: true, inRole: true, isReversibleByMechanism: true,
+    });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.REVERSIBLE);
+    expect(r.neverAuto).toBe(false);
+  });
+
+  it('classifies a live-money action as consequential via the ADAM rubric', () => {
+    const r = classifySwitchOn({
+      component: 'billing', action: 'enable-billing',
+      reversible: true, inRole: true, isReversibleByMechanism: true, isLiveMoney: true,
+    });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+  });
+
+  it('classifies missing required fields as unknown, never reversible', () => {
+    const r = classifySwitchOn({ component: 'ops-scheduler' }); // action missing
+    expect(r.verdict).toBe(SWITCHON_VERDICT.UNKNOWN);
+    expect(r.reasons).toContain('missing:action');
+  });
+
+  it('classifies empty-string required fields as unknown', () => {
+    const r = classifySwitchOn({ component: '  ', action: 'enable-scheduler' });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.UNKNOWN);
+  });
+
+  for (const action of NEVER_AUTO_CLASSES) {
+    it(`NEVER-AUTO class "${action}" always classifies as consequential`, () => {
+      const r = classifySwitchOn({ component: 'x', action, reversible: true, inRole: true, isReversibleByMechanism: true });
+      expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+      expect(r.neverAuto).toBe(true);
+    });
+  }
+
+  it('NEVER-AUTO precedence: a NEVER-AUTO action with a missing component still classifies as consequential, not unknown', () => {
+    const r = classifySwitchOn({ action: 'live-money-enablement' }); // component missing too
+    expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+    expect(r.neverAuto).toBe(true);
+  });
+
+  it('reversible=true but isReversibleByMechanism=false (untested revert path) is NOT reversible', () => {
+    const r = classifySwitchOn({
+      component: 'x', action: 'enable-x', reversible: true, inRole: true, isReversibleByMechanism: false,
+    });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+  });
+
+  it('uncertain reversibility (missing isReversibleByMechanism) is conservative -> consequential, never reversible', () => {
+    const r = classifySwitchOn({ component: 'x', action: 'enable-x', reversible: true, inRole: true });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+  });
+
+  it('venture-commitment action classifies as consequential', () => {
+    const r = classifySwitchOn({
+      component: 'x', action: 'enable-x', reversible: true, inRole: true, isReversibleByMechanism: true, isVentureCommitment: true,
+    });
+    expect(r.verdict).toBe(SWITCHON_VERDICT.CONSEQUENTIAL);
+  });
+});


### PR DESCRIPTION
## Summary
- Child A of the intelligent op-co switch-on automation orchestrator (SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001), chairman-ratified 2026-07-18
- Reversibility classifier (`lib/switch-automation/reversibility-classifier.js`) adapting `lib/adam/execute-vs-escalate.js`'s deterministic rubric into reversible/consequential/unknown, with chairman-ratified NEVER-AUTO precedence
- Chairman policy table (`database/migrations/20260718_chairman_switchon_policy_STAGED.sql`) with DB-hard ratchet (RLS + REVOKE), mirroring the shipped `sms_decision_class_whitelist_STAGED.sql` pattern — ships STAGED, NOT applied by this PR
- `release_condition_predicate` additive column + pure evaluator, upgrading `hold_state_contract_violations.release_condition` per Solomon's folded adjudication
- SECURITY review caught a real gap: GUARDRAIL-1's mandatory named examples (live venture deploy, live payment-account creation, DNS mutation) weren't verbatim-covered — fixed with 3 explicit classes + a parity regression test

## Test plan
- [x] 41 unit tests passing (1 explicit `it.todo` for the STAGED-migration privilege probe, deferred to chairman-apply ceremony)
- [x] Static file-lint suite verifies the STAGED migration's RLS/REVOKE structure and NEVER-AUTO class parity with the classifier
- [x] TESTING sub-agent independently re-ran all tests and confirmed genuine pass
- [x] SECURITY sub-agent confirmed no secrets, fail-closed behavior, and the migration is not applied by this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)