### PR TITLE
docs(SD-LEO-INFRA-PLAN-LINKAGE-BELT-001): document plan-linkage tie-break rule

### DIFF
--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -3,7 +3,7 @@ category: documentation
 status: approved
 version: 1.0.0
 author: rickfelix
-last_updated: 2026-06-09
+last_updated: 2026-07-18
 tags: [documentation, protocol]
 ---
 
@@ -163,7 +163,7 @@ There is a SEPARATE failure mode (feedback `34113d39`, `category='harness_backlo
 | Chairman email (post-cutover 2026-06-10: Adam exec-summary, NOT the retired coordinator email) | `.github/workflows/adam-exec-email-cron.yml` → `scripts/adam-exec-summary.mjs` |
 | Recurring 3-source audit | `scripts/coordinator-audit.mjs` |
 | Capacity forecasting + predictive belt refill (duty 5) | `scripts/coordinator-capacity-forecast.mjs` (armed cron `3,13,…`, `--dispatch`) |
-| Backlog prioritization + dispatch ordering (duty 6) | `scripts/coordinator-backlog-rank.mjs` (armed cron `9,24,39,54 * * * *`, ~15min) → `metadata.dispatch_rank`, honored by `scripts/worker-checkin.cjs` `sortByDispatchRank`. Event-driven refresh (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C) also fires on SD creation, `needs_coordinator_review` clearance (`lib/coordinator/clear-coordinator-review.js` / `scripts/clear-coordinator-review.mjs`), and predecessor SD completion, via `lib/coordinator/trigger-rank-pass.mjs` — so a freshly-claimable SD is ranked within seconds instead of waiting for the next cron tick |
+| Backlog prioritization + dispatch ordering (duty 6) | `scripts/coordinator-backlog-rank.mjs` (armed cron `9,24,39,54 * * * *`, ~15min) → `metadata.dispatch_rank`, honored by `scripts/worker-checkin.cjs` `sortByDispatchRank`. Event-driven refresh (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C) also fires on SD creation, `needs_coordinator_review` clearance (`lib/coordinator/clear-coordinator-review.js` / `scripts/clear-coordinator-review.mjs`), and predecessor SD completion, via `lib/coordinator/trigger-rank-pass.mjs` — so a freshly-claimable SD is ranked within seconds instead of waiting for the next cron tick. Chairman-ratified plan-linkage tie-break (SD-LEO-INFRA-PLAN-LINKAGE-BELT-001, 2026-07-18): at equal standing on every prior objective comparator (unlock score, product-pivot band, needle, priority), plan-linked SDs (`metadata.plan_linkage.linked=true`, stamped at creation or fence-lift) sort first — `lib/roadmap/plan-linkage-comparator.js`, shared by both this ranker and `scripts/fleet-dashboard.cjs`'s fence-review ordering. Belt-admission linkage is also surfaced in `PLAN CHECK` (`lib/roadmap/plan-check-status.js` section 5) and the roadmap retro (`scripts/vision/rung-progress-rollup.mjs`, feedback category `plan_linkage_retro`) |
 | Question→operator escalation (durable row; rendered by the Adam exec email / operator conversation) | `scripts/coordinator-escalate-question.mjs` (writes `operator_question` row) |
 | Teardown cron inventory + matcher | `lib/coordinator/teardown-coordinator.cjs` (`listCoordinatorCrons`, `selectCoordinatorCronJobs`) |
 


### PR DESCRIPTION
## Summary
- Post-completion /document step for SD-LEO-INFRA-PLAN-LINKAGE-BELT-001 (merged in #6219).
- Extends the existing "Backlog prioritization + dispatch ordering (duty 6)" row in `docs/protocol/fleet-coordinator-and-worker-behavior.md` rather than creating a new doc, per the Documentation Discovery decision matrix (existing doc partially covers topic → EDIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)