### PR TITLE
feat(SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A): shared pre-send rubric engine

### DIFF
--- a/lib/comms/adam-outbound/rubric-engine/index.js
+++ b/lib/comms/adam-outbound/rubric-engine/index.js
@@ -1,0 +1,96 @@
+/**
+ * Shared pre-send rubric engine — SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A.
+ *
+ * The single, reusable, side-effect-free pre-send evaluator that BOTH outbound gates call
+ * (the chairman-SMS gate -C and the Adam-outbound gate -D). One source of truth for
+ * pre-send validation so the two gates cannot drift.
+ *
+ * Layering (order is the contract, not a suggestion):
+ *   1. Deterministic lint runs FIRST and can block. On a lint block the independent review
+ *      is NEVER called — a malformed decision must be structurally unsendable (the F3 fix),
+ *      not left to a judgment model.
+ *   2. Only if the lint passes does the INDEPENDENT review run (a separate evaluation of the
+ *      finished message; never the composer self-grading).
+ *
+ * evaluate() is pure: no I/O, no send, no credential handling (credential isolation is the
+ * chairman-SMS gate -C's job). It returns a structured, JSON-serializable verdict the gates
+ * and the durable send-log (-B/-E) consume uniformly.
+ */
+
+import { lint, effectiveType } from './lint.js';
+import { reviewMessage } from './llm-review.js';
+
+const CONSOLE_AUTHORITY = new Set(['spend', 'irreversible', 'chairman_only']);
+
+/**
+ * Authority-class routing: spend / irreversible / chairman-only decisions go to the console
+ * (a human, ratifiable surface) — NEVER SMS-decided — regardless of whether they reduce to a
+ * clean YES/NO. Reducibility is orthogonal to authority (PRD FR-4). Everything else is 'sms'.
+ * @param {object} message
+ * @returns {'console'|'sms'}
+ */
+export function authorityClass(message = {}) {
+  return CONSOLE_AUTHORITY.has(message.authority) ? 'console' : 'sms';
+}
+
+/**
+ * Evaluate a message against the full pre-send rubric.
+ * @param {object} message - { type?, body, options?, replyInstruction?, replyId?, decisionCount?, authority?, noReplyConsequence? }
+ * @param {object} context - { nowHourET?/now?, maxLength?, sentInWindow?, rateCap?, allowQuietHours? }
+ * @param {object} opts - { reviewer? } injectable independent reviewer (production wires a real LLM)
+ * @returns {Promise<{verdict:'pass'|'blocked', effectiveType:string, authorityClass:'console'|'sms', noReplyConsequence:string|null, lintFindings:Array, llmReview:object|null, blockedReasons:string[]}>}
+ */
+export async function evaluate(message = {}, context = {}, opts = {}) {
+  const type = effectiveType(message);
+  const isDecision = type === 'decision';
+  const routing = authorityClass(message);
+  const noReplyConsequence = typeof message.noReplyConsequence === 'string' && message.noReplyConsequence.trim().length > 0
+    ? message.noReplyConsequence.trim()
+    : null;
+
+  const { findings, blocked: lintBlocked } = lint(message, context);
+
+  // Rubric addition (consent integrity, PRD FR-4): a DECISION must state its no-reply
+  // consequence so the ratified auto-default never operates invisibly. Treated as a
+  // blocking pre-send finding alongside the lint.
+  const consentFindings = [];
+  if (isDecision && !noReplyConsequence) {
+    consentFindings.push({
+      check: 'no_reply_consequence', ok: false, blocking: true,
+      detail: 'a decision must state its no-reply consequence (e.g. "no reply by <T> -> I proceed <default> (reversible)")',
+    });
+  }
+
+  const lintFindings = [...findings, ...consentFindings];
+  const blocked = lintBlocked || consentFindings.length > 0;
+
+  if (blocked) {
+    // Hard fail: do NOT run the independent review (structural F3 fix — no LLM on a block).
+    return {
+      verdict: 'blocked',
+      effectiveType: type,
+      authorityClass: routing,
+      noReplyConsequence,
+      lintFindings,
+      llmReview: null,
+      blockedReasons: lintFindings.filter((f) => f.blocking && !f.ok).map((f) => `${f.check}: ${f.detail}`),
+    };
+  }
+
+  // Lint passed → run the independent review (separate call, never the composer).
+  const llmReview = await reviewMessage(message, context, opts);
+
+  return {
+    verdict: 'pass',
+    effectiveType: type,
+    authorityClass: routing,
+    noReplyConsequence,
+    lintFindings,
+    llmReview,
+    blockedReasons: [],
+  };
+}
+
+export { lint, effectiveType } from './lint.js';
+export { reviewMessage, heuristicReviewer } from './llm-review.js';
+export { findSecrets, SECRET_PATTERNS } from './secret-patterns.js';

--- a/lib/comms/adam-outbound/rubric-engine/lint.js
+++ b/lib/comms/adam-outbound/rubric-engine/lint.js
@@ -1,0 +1,126 @@
+/**
+ * Deterministic pre-send lint — the FIRST, blocking, ungameable layer of the rubric engine.
+ *
+ * SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A.
+ *
+ * Runs BEFORE any LLM call. Pure and synchronous. Returns itemized findings; the caller
+ * (index.js) blocks the send if any finding has blocking=true and NEVER calls the LLM
+ * review on a lint failure (that ordering is the structural fix for F3 — a malformed
+ * decision must be impossible to send, not merely discouraged by a judgment model).
+ */
+
+import { findSecrets } from './secret-patterns.js';
+
+const DEFAULT_MAX_LEN = 1600; // ~10 SMS segments; callers may override via context.maxLength
+
+/**
+ * Decide the EFFECTIVE type of a message. Classifier hardening: a message that carries
+ * options, or whose body contains an option/question pattern, is treated as a DECISION
+ * regardless of a claimed type==='status'. Misclassified-as-status is the dangerous bypass
+ * (a decision that skips the decision checks), so detection is one-directional: we only ever
+ * UPGRADE toward 'decision', never downgrade.
+ * @param {object} message
+ * @returns {'decision'|'status'}
+ */
+export function effectiveType(message = {}) {
+  if (message.type === 'decision') return 'decision';
+  const body = typeof message.body === 'string' ? message.body : '';
+  const hasOptions = Array.isArray(message.options) && message.options.length > 0;
+  // Option markers ("A)", "1.", "- ") near line starts, or an interrogative asking to choose.
+  const optionPattern = /(^|\n)\s*(?:[A-Za-z]\)|[A-Za-z]\.|\d\)|\d\.|-)\s+\S/;
+  const questionPattern = /\?\s*$|\b(reply|choose|approve|which|should i|yes\/no|y\/n)\b/i;
+  if (hasOptions || optionPattern.test(body) || questionPattern.test(body)) return 'decision';
+  return message.type === 'status' ? 'status' : (message.type || 'status');
+}
+
+/**
+ * Return the current hour (0-23) in America/New_York, DST-aware, dependency-free.
+ * context.nowHourET (a number) wins when provided (deterministic tests); otherwise derive
+ * from context.now (a Date) or, last resort, throw — the engine must never guess quiet-hours.
+ * @param {object} context
+ * @returns {number}
+ */
+export function etHour(context = {}) {
+  if (Number.isInteger(context.nowHourET)) return context.nowHourET;
+  const d = context.now instanceof Date ? context.now : null;
+  if (!d) throw new Error('rubric-engine lint: quiet-hours needs context.nowHourET or context.now (Date)');
+  const hourStr = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York', hour: '2-digit', hour12: false,
+  }).format(d);
+  const h = parseInt(hourStr, 10);
+  return h === 24 ? 0 : h; // some ICU builds render midnight as 24
+}
+
+/** Quiet hours: 22:00–05:59 ET (the 22:00–06:00 window). */
+export function inQuietHours(context = {}) {
+  const h = etHour(context);
+  return h >= 22 || h < 6;
+}
+
+/**
+ * Run the 9-check deterministic lint.
+ * @param {object} message
+ * @param {object} context - { maxLength?, nowHourET?/now?, sentInWindow?, rateCap?, allowQuietHours? }
+ * @returns {{ findings: Array<{check:string, ok:boolean, blocking:boolean, detail:string}>, blocked: boolean, effectiveType: string }}
+ */
+export function lint(message = {}, context = {}) {
+  const findings = [];
+  const body = typeof message.body === 'string' ? message.body : '';
+  const type = effectiveType(message);
+  const isDecision = type === 'decision';
+  const add = (check, ok, blocking, detail) => findings.push({ check, ok, blocking, detail });
+
+  // 1. labeled options (decisions only)
+  if (isDecision) {
+    const opts = Array.isArray(message.options) ? message.options : [];
+    const labeled = opts.length >= 2 && opts.every((o) => o && typeof (o.label ?? o) === 'string' && String(o.label ?? o).trim().length > 0);
+    add('labeled_options', labeled, true, labeled ? 'ok' : 'a decision needs >=2 explicitly labeled options');
+  }
+
+  // 2. exactly one decision (decisions only)
+  if (isDecision) {
+    const count = Number.isInteger(message.decisionCount) ? message.decisionCount : 1;
+    add('exactly_one_decision', count === 1, true, count === 1 ? 'ok' : `message bundles ${count} decisions; send one decision per message`);
+  }
+
+  // 3. explicit reply instruction (decisions only)
+  if (isDecision) {
+    const ri = typeof message.replyInstruction === 'string' && message.replyInstruction.trim().length > 0;
+    add('reply_instruction', ri, true, ri ? 'ok' : 'a decision needs an explicit reply instruction (how to answer)');
+  }
+
+  // 4. DETAILS keyword affordance (decisions only)
+  if (isDecision) {
+    const hasDetails = /\bDETAILS\b/.test(body) || /\bDETAILS\b/.test(String(message.replyInstruction || ''));
+    add('details_keyword', hasDetails, true, hasDetails ? 'ok' : 'a decision must offer the DETAILS reply keyword');
+  }
+
+  // 5. length bounds (all)
+  const maxLen = Number.isInteger(context.maxLength) ? context.maxLength : DEFAULT_MAX_LEN;
+  const lenOk = body.trim().length > 0 && body.length <= maxLen;
+  add('length', lenOk, true, lenOk ? 'ok' : `body length ${body.length} outside (0, ${maxLen}]`);
+
+  // 6. no secrets (all)
+  const secrets = findSecrets(body);
+  add('no_secrets', secrets.length === 0, true, secrets.length === 0 ? 'ok' : `secret(s) detected: ${secrets.join(', ')}`);
+
+  // 7. quiet hours (all, unless explicitly allowed e.g. a ratified heartbeat schedule)
+  const quiet = inQuietHours(context) && !context.allowQuietHours;
+  add('quiet_hours', !quiet, true, quiet ? 'within 22:00-06:00 ET quiet window' : 'ok');
+
+  // 8. rate cap (all, when the caller supplies window state)
+  if (Number.isInteger(context.rateCap)) {
+    const sent = Number.isInteger(context.sentInWindow) ? context.sentInWindow : 0;
+    const under = sent < context.rateCap;
+    add('rate_cap', under, true, under ? 'ok' : `rate cap reached (${sent}/${context.rateCap})`);
+  }
+
+  // 9. reply IDs (decisions only — correlation for the reconcile/away-bridge layers)
+  if (isDecision) {
+    const hasId = typeof message.replyId === 'string' && message.replyId.trim().length > 0;
+    add('reply_ids', hasId, true, hasId ? 'ok' : 'a decision needs a reply-ID for delivery/answer correlation');
+  }
+
+  const blocked = findings.some((f) => f.blocking && !f.ok);
+  return { findings, blocked, effectiveType: type };
+}

--- a/lib/comms/adam-outbound/rubric-engine/llm-review.js
+++ b/lib/comms/adam-outbound/rubric-engine/llm-review.js
@@ -1,0 +1,61 @@
+/**
+ * Independent review layer — the SECOND rubric layer, runs ONLY after the deterministic
+ * lint passes. SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A.
+ *
+ * The structural invariant (the F3 fix): this review is a SEPARATE evaluation of the
+ * FINISHED message — it never receives, and cannot be, the composer that drafted it.
+ * Same-frame blindness (an author grading their own draft) is exactly how the malformed
+ * F3 decision slipped past. The reviewer is INJECTABLE (opts.reviewer): production wires a
+ * real independent LLM reviewer; unit tests inject a deterministic stub and open zero live
+ * calls. The default reviewer is a deterministic heuristic (NOT an LLM) so the engine is
+ * functional and testable out of the box — wiring a real LLM reviewer in production is a
+ * captured completion flag, not a silent gap.
+ *
+ * The reviewer judges (per PRD FR-3): tone, honest-reassurance, rationale quality,
+ * reducibility, and classification. It returns a verdict of 'pass' or 'flag' — 'flag'
+ * does not itself block (the deterministic lint is the hard gate); it is surfaced in the
+ * structured verdict so the calling gate/send-log can act and the retro can learn.
+ */
+
+/**
+ * Deterministic default reviewer (placeholder for a real independent LLM reviewer).
+ * Judges only from the finished message + context — never the composer.
+ * @param {object} message
+ * @param {object} context
+ * @returns {{verdict:'pass'|'flag', classification:string, reducible:boolean, reasons:string[], reviewer:'heuristic-default'}}
+ */
+export function heuristicReviewer(message = {}, context = {}) {
+  const body = typeof message.body === 'string' ? message.body : '';
+  const reasons = [];
+  // Reducibility: a decision is "reducible" when it collapses to a small labeled choice set.
+  const reducible = Array.isArray(message.options) && message.options.length > 0 && message.options.length <= 4;
+  // Classification echo (the lint already computed effectiveType; the reviewer independently
+  // re-derives from the body so a mislabeled type surfaces as a disagreement).
+  const classification = /\?\s*$|\b(reply|choose|approve|which|yes\/no|y\/n)\b/i.test(body) ? 'decision' : (message.type || 'status');
+  // Honest-reassurance smell: flag over-promising language on a decision.
+  if (/\b(guarantee|definitely|no risk|always works|never fails)\b/i.test(body)) {
+    reasons.push('over-promising language — soften to honest reassurance');
+  }
+  return {
+    verdict: reasons.length === 0 ? 'pass' : 'flag',
+    classification,
+    reducible,
+    reasons,
+    reviewer: 'heuristic-default',
+  };
+}
+
+/**
+ * Run the independent review. Pure w.r.t. its inputs; the only side effect possible is
+ * inside an injected async reviewer (a real LLM call), which the engine awaits.
+ * @param {object} message
+ * @param {object} context
+ * @param {object} opts - { reviewer?: (message, context) => review|Promise<review> }
+ * @returns {Promise<object>} the reviewer's structured result
+ */
+export async function reviewMessage(message = {}, context = {}, opts = {}) {
+  const reviewer = typeof opts.reviewer === 'function' ? opts.reviewer : heuristicReviewer;
+  // Defensive copy so a reviewer cannot mutate the caller's message (independence hygiene).
+  const frozenMessage = Object.freeze({ ...message });
+  return reviewer(frozenMessage, context);
+}

--- a/lib/comms/adam-outbound/rubric-engine/secret-patterns.js
+++ b/lib/comms/adam-outbound/rubric-engine/secret-patterns.js
@@ -1,0 +1,41 @@
+/**
+ * Secret-redaction patterns for the shared pre-send rubric engine's no-secrets lint.
+ *
+ * SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A (rubric engine).
+ *
+ * Provenance: these are the SAME 6 patterns the worker-signal outbound path already
+ * redacts with (scripts/worker-signal.cjs REDACTION_PATTERNS, ~line 119). They are
+ * replicated here — rather than imported — because that definition lives inline in a
+ * CommonJS CLI script, not an importable module. Keeping the sets identical is a
+ * correctness invariant; a follow-up to extract ONE shared module (imported by both the
+ * signal path and this engine) is captured as a completion flag on this SD so the two
+ * copies cannot drift.
+ *
+ * The lint only needs to DETECT a secret (block the send); it does not redact-and-continue,
+ * because a chairman/coordinator message that contains a live secret is a hard fail, not a
+ * thing to silently scrub and ship.
+ */
+
+export const SECRET_PATTERNS = [
+  { re: /AKIA[0-9A-Z]{16}/g, label: 'AWS_KEY' },
+  { re: /gh[pousr]_[A-Za-z0-9]{36,}/g, label: 'GH_TOKEN' },
+  { re: /sk-[A-Za-z0-9_-]{20,}/g, label: 'PROVIDER_KEY' },
+  { re: /eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, label: 'JWT' },
+  { re: /password\s*[=:]\s*[^&\s"']+/gi, label: 'PASSWORD' },
+  { re: /postgres(?:ql)?:\/\/[^:@\s]+:[^@\s]+@/g, label: 'PG_CONN_STRING' },
+];
+
+/**
+ * Return the labels of any secret patterns found in `text` (empty array = clean).
+ * Fresh RegExp per call so the global-flag lastIndex is never shared across invocations.
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function findSecrets(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const hits = [];
+  for (const { re, label } of SECRET_PATTERNS) {
+    if (new RegExp(re.source, re.flags).test(text)) hits.push(label);
+  }
+  return hits;
+}

--- a/tests/unit/comms/rubric-engine/rubric-engine.test.js
+++ b/tests/unit/comms/rubric-engine/rubric-engine.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluate, authorityClass, effectiveType } from '../../../../lib/comms/adam-outbound/rubric-engine/index.js';
+
+/** A well-formed decision message (passes every deterministic lint check). */
+function wellFormedDecision(overrides = {}) {
+  return {
+    type: 'decision',
+    body: 'Approve the deploy? Reply A or B. Reply DETAILS for the rationale.',
+    options: [{ label: 'A) ship now' }, { label: 'B) hold until morning' }],
+    decisionCount: 1,
+    replyInstruction: 'Reply A or B (or DETAILS)',
+    replyId: 'dec-123',
+    noReplyConsequence: 'no reply by 5pm ET -> I hold (reversible)',
+    ...overrides,
+  };
+}
+
+const DAYTIME = { nowHourET: 14, rateCap: 10, sentInWindow: 0 };
+
+describe('rubric-engine evaluate()', () => {
+  it('TS-1: malformed decision (missing labeled options) is blocked BEFORE any LLM call', async () => {
+    const reviewer = vi.fn();
+    const msg = wellFormedDecision({ options: [] });
+    const res = await evaluate(msg, DAYTIME, { reviewer });
+    expect(res.verdict).toBe('blocked');
+    expect(res.blockedReasons.some((r) => r.startsWith('labeled_options'))).toBe(true);
+    expect(res.llmReview).toBeNull();
+    expect(reviewer).not.toHaveBeenCalled(); // structural F3 fix: no review on a lint block
+  });
+
+  it('TS-2: well-formed decision passes lint, THEN runs the independent review (separate call)', async () => {
+    const reviewer = vi.fn(() => ({ verdict: 'pass', classification: 'decision', reducible: true, reasons: [], reviewer: 'stub' }));
+    const res = await evaluate(wellFormedDecision(), DAYTIME, { reviewer });
+    expect(res.verdict).toBe('pass');
+    expect(reviewer).toHaveBeenCalledTimes(1);
+    // the reviewer receives the finished message, never a composer
+    expect(reviewer.mock.calls[0][0]).toMatchObject({ type: 'decision' });
+    expect(res.llmReview).toMatchObject({ reviewer: 'stub' });
+  });
+
+  it('TS-3: spend/irreversible decision routes to console regardless of YES/NO reducibility', async () => {
+    const reviewer = vi.fn(() => ({ verdict: 'pass', reasons: [] }));
+    const res = await evaluate(wellFormedDecision({ authority: 'spend' }), DAYTIME, { reviewer });
+    expect(res.authorityClass).toBe('console');
+    // irreversible + chairman_only too
+    expect(authorityClass({ authority: 'irreversible' })).toBe('console');
+    expect(authorityClass({ authority: 'chairman_only' })).toBe('console');
+    expect(authorityClass({ authority: 'reducible' })).toBe('sms');
+  });
+
+  it('TS-4: type=status carrying options is classified as a DECISION and gets decision checks', async () => {
+    const reviewer = vi.fn();
+    // claims status, but has options and no reply instruction -> decision checks must fire and block
+    const msg = { type: 'status', body: 'Pick one: A) x  B) y', options: [{ label: 'A) x' }, { label: 'B) y' }] };
+    expect(effectiveType(msg)).toBe('decision');
+    const res = await evaluate(msg, DAYTIME, { reviewer });
+    expect(res.effectiveType).toBe('decision');
+    expect(res.verdict).toBe('blocked'); // missing reply instruction / details / replyId / no-reply-consequence
+    expect(reviewer).not.toHaveBeenCalled();
+  });
+
+  it('TS-5: a send inside quiet hours (22:00-06:00 ET) is blocked', async () => {
+    const reviewer = vi.fn();
+    const res = await evaluate(wellFormedDecision(), { ...DAYTIME, nowHourET: 23 }, { reviewer });
+    expect(res.verdict).toBe('blocked');
+    expect(res.blockedReasons.some((r) => r.startsWith('quiet_hours'))).toBe(true);
+    expect(reviewer).not.toHaveBeenCalled();
+  });
+
+  it('TS-6: no live LLM calls — the default reviewer is deterministic and blocks never invoke it', async () => {
+    // default (no injected reviewer): deterministic heuristic, no network
+    const passed = await evaluate(wellFormedDecision(), DAYTIME);
+    expect(passed.verdict).toBe('pass');
+    expect(passed.llmReview.reviewer).toBe('heuristic-default');
+    // a secret in the body is blocked by lint and never reaches any reviewer
+    const reviewer = vi.fn();
+    // Build an AWS-key-shaped token at runtime so no literal secret enters git history
+    // (the pre-commit secret scanner would flag a literal), while still exercising the lint.
+    const fakeAwsKey = 'AKIA' + 'ABCDEFGHIJKLMNOP';
+    const withSecret = await evaluate(
+      wellFormedDecision({ body: `Approve? A or B. DETAILS. token ${fakeAwsKey}` }),
+      DAYTIME,
+      { reviewer },
+    );
+    expect(withSecret.verdict).toBe('blocked');
+    expect(withSecret.blockedReasons.some((r) => r.startsWith('no_secrets'))).toBe(true);
+    expect(reviewer).not.toHaveBeenCalled();
+  });
+
+  it('a decision missing its no-reply consequence is blocked (consent integrity)', async () => {
+    const res = await evaluate(wellFormedDecision({ noReplyConsequence: undefined }), DAYTIME);
+    expect(res.verdict).toBe('blocked');
+    expect(res.blockedReasons.some((r) => r.startsWith('no_reply_consequence'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Child -A of the SMS-channel-hardening orchestrator: the shared pre-send rubric engine both outbound gates (chairman-SMS -C, Adam-outbound -D) call.

- **Deterministic lint first** (9 checks: labeled options, one-decision, reply instruction, DETAILS keyword, length, no-secrets [reuses worker-signal M1 patterns], quiet-hours 22:00-06:00 ET DST-aware, rate cap, reply-IDs) — blocks BEFORE any LLM call.
- **Independent injectable review** runs only after lint passes — never the composer self-grading (the F3 structural fix).
- **Authority-class routing** — spend/irreversible/chairman-only → console regardless of YES/NO reducibility.
- **Consent integrity** — decisions must carry a no-reply consequence.
- Pure `evaluate()`; no credentials (that is -C).

## Test plan
- `npx vitest run tests/unit/comms/rubric-engine` — 7/7 green (TS-1..TS-6 + consent), incl. proof no review runs on a lint block and zero live LLM calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)