### PR TITLE
chore(SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A): wire-check-exempt rubric engine

### DIFF
--- a/lib/comms/adam-outbound/rubric-engine/index.js
+++ b/lib/comms/adam-outbound/rubric-engine/index.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: foundation shared library — consumed by SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-C (chairman-SMS gate) and -D (Adam-outbound gate); built first per the orchestrator dependency order, wired when those dependent children land.
 /**
  * Shared pre-send rubric engine — SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A.
  *

--- a/lib/comms/adam-outbound/rubric-engine/lint.js
+++ b/lib/comms/adam-outbound/rubric-engine/lint.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: foundation shared library — consumed by SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-C (chairman-SMS gate) and -D (Adam-outbound gate); built first per the orchestrator dependency order, wired when those dependent children land.
 /**
  * Deterministic pre-send lint — the FIRST, blocking, ungameable layer of the rubric engine.
  *

--- a/lib/comms/adam-outbound/rubric-engine/llm-review.js
+++ b/lib/comms/adam-outbound/rubric-engine/llm-review.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: foundation shared library — consumed by SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-C (chairman-SMS gate) and -D (Adam-outbound gate); built first per the orchestrator dependency order, wired when those dependent children land.
 /**
  * Independent review layer — the SECOND rubric layer, runs ONLY after the deterministic
  * lint passes. SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-A.

--- a/lib/comms/adam-outbound/rubric-engine/secret-patterns.js
+++ b/lib/comms/adam-outbound/rubric-engine/secret-patterns.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: foundation shared library — consumed by SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-C (chairman-SMS gate) and -D (Adam-outbound gate); built first per the orchestrator dependency order, wired when those dependent children land.
 /**
  * Secret-redaction patterns for the shared pre-send rubric engine's no-secrets lint.
  *


### PR DESCRIPTION
Foundation library consumed by not-yet-built -C/-D; add sanctioned @wire-check-exempt marker so LEAD-FINAL WIRE_CHECK passes. Follow-up to #6225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)