### PR TITLE
feat(SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-D): Adam Outbound Gate

### DIFF
--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -76,7 +76,9 @@ export const REQUIRED_RATIONALE_FIELDS = [
 ];
 
 // CONST-010: no manipulative/urgent/certainty/emotional framing.
-const MANIPULATIVE_PATTERNS =
+// Exported (SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-D) so the Adam Outbound Gate reuses the SAME
+// regex rather than re-deriving a parallel one that would silently drift from this authority.
+export const MANIPULATIVE_PATTERNS =
   /\b(urgent(?:ly)?|immediately|act now|act fast|must act|critical(?:ly)?|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
 
 /**

--- a/lib/coordinator/adam-outbound-gate.js
+++ b/lib/coordinator/adam-outbound-gate.js
@@ -1,0 +1,164 @@
+/**
+ * adam-outbound-gate.js — the Adam Outbound Gate.
+ * SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-D (child of the SMS-channel-hardening orchestrator).
+ *
+ * A PURE gate that runs over every Adam outbound in the scripts/adam-advisory.cjs send path,
+ * mirroring the existing pure-detector style of sanityCheckUrgentAdvisory ({ tripped, reasons }).
+ * It enforces three checks, each COMPOSING an existing fleet authority rather than re-deriving a
+ * parallel heuristic that would drift:
+ *
+ *   1. advisory rationale bar   — an advisory-kind body must carry reasoning and NO manipulative
+ *      framing. Reuses lib/adam/rationale-bar.js MANIPULATIVE_PATTERNS (single-sourced) + the
+ *      REQUIRED_RATIONALE_FIELDS vocabulary. Scoped to advisory kinds ONLY; DIRECTIVE_KINDS and
+ *      SOLOMON_CONSULT are exempt (they are not advisories).
+ *   2. should-answer rubric     — flags Adam ASKING the chairman a decision that is his to
+ *      execute-and-report. Routes context.decision through lib/adam/execute-vs-escalate.js
+ *      classifyDecision: a chairman-addressed question whose decision classifies EXECUTE means
+ *      "am I asking what I should decide myself?"; an ESCALATE decision means asking is correct.
+ *   3. Solomon-review check     — warns when a CONSEQUENTIAL decision is sent without a prior
+ *      Solomon consult (the pre-send "consult Solomon on consequential decisions" rubric). A
+ *      solomon_consult-kind message IS the consult and is exempt.
+ *
+ * PURE: no DB / network / model I/O. The caller resolves the decision signals + solomonConsulted
+ * and passes them via `context`; the gate only classifies. It NEVER re-implements the
+ * model-availability alarm (sanityCheckUrgentAdvisory stays a separate, earlier gate).
+ */
+import { classifyDecision, VERDICT } from '../adam/execute-vs-escalate.js';
+import { MANIPULATIVE_PATTERNS, REQUIRED_RATIONALE_FIELDS } from '../adam/rationale-bar.js';
+import workerStatus from '../fleet/worker-status.cjs';
+
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = workerStatus;
+
+// Fail loud if the CJS->ESM interop silently yields undefined kind constants — otherwise the
+// exemptions would quietly disable themselves (TESTING interop warning).
+if (!PAYLOAD_KINDS || !PAYLOAD_KINDS.ADAM_ADVISORY || !Array.isArray(DIRECTIVE_KINDS)) {
+  throw new Error('adam-outbound-gate: kind constants failed to resolve from lib/fleet/worker-status.cjs');
+}
+
+const ADVISORY_KIND = PAYLOAD_KINDS.ADAM_ADVISORY;      // 'adam_advisory'
+const SOLOMON_CONSULT_KIND = PAYLOAD_KINDS.SOLOMON_CONSULT; // 'solomon_consult'
+const DIRECTIVE_KIND_SET = new Set(DIRECTIVE_KINDS);
+
+// Reasoning scaffolding an advisory body must show — drawn from the rationale-bar vocabulary plus
+// the natural-language connectives a free-text advisory uses to justify itself.
+const RATIONALE_MARKERS = new RegExp(
+  `\\b(because|since|so that|therefore|which means|the reason|driver:|rationale|why:|due to|in order to|${REQUIRED_RATIONALE_FIELDS.join('|')})\\b`,
+  'i',
+);
+
+// A chairman-addressed message is question-shaped when it ends with '?' or opens with a
+// decision-seeking phrase. Used only to gate the should-answer check to genuine questions.
+const QUESTION_SHAPE = /\?\s*$|\b(should (?:we|i)|do you want|which (?:one|option|venture)|approve\??|shall (?:we|i)|ok to|go ahead\?)\b/i;
+
+const CHAIRMAN_ADDRESSEES = new Set(['chairman']);
+
+/** True when this outbound is directed at the chairman (should-answer only concerns chairman asks). */
+function isChairmanAddressed(addressee) {
+  return CHAIRMAN_ADDRESSEES.has(String(addressee || '').toLowerCase());
+}
+
+/**
+ * @param {object} message  { body, kind, addressee, expectsReply, mode }
+ * @param {object} [context]
+ *   context.decision       { reversible, inRole, flagship, governance, dataLoss } — classifyDecision input
+ *   context.consequential  explicit override marking the decision consequential
+ *   context.solomonConsulted true if a Solomon consult already happened for this decision
+ * @returns {{ tripped:boolean, reasons:string[], verdict:'pass'|'block'|'warn',
+ *   checks:{ rationaleBar:{pass,reason}, shouldAnswer:{pass,reason}, solomonReview:{pass,reason} } }}
+ */
+export function checkAdamOutbound(message = {}, context = {}) {
+  const body = String(message.body || '');
+  const kind = message.kind || ADVISORY_KIND;
+  const expectsReply = message.expectsReply === true || message.mode === 'request';
+
+  const checks = {
+    rationaleBar: evalRationaleBar(body, kind),
+    shouldAnswer: evalShouldAnswer(message, expectsReply, context),
+    solomonReview: evalSolomonReview(kind, context),
+  };
+
+  const reasons = [];
+  let block = false;
+  let warn = false;
+  for (const [name, c] of Object.entries(checks)) {
+    if (c.pass) continue;
+    reasons.push(`${name}: ${c.reason}`);
+    if (c.severity === 'warn') warn = true;
+    else block = true;
+  }
+
+  return {
+    tripped: reasons.length > 0,
+    reasons,
+    verdict: block ? 'block' : warn ? 'warn' : 'pass',
+    checks,
+  };
+}
+
+/** Check 1 — advisory rationale bar (advisory kinds only). */
+function evalRationaleBar(body, kind) {
+  // Exempt non-advisory classes: directives and Solomon consults are not advisories.
+  if (kind !== ADVISORY_KIND) {
+    return { pass: true, reason: `exempt (kind '${kind}' is not an advisory)`, severity: 'block' };
+  }
+  if (!body.trim()) {
+    return { pass: false, reason: 'advisory body is empty (no rationale possible)', severity: 'block' };
+  }
+  if (MANIPULATIVE_PATTERNS.test(body)) {
+    return { pass: false, reason: 'manipulative/urgent/certainty framing (CONST-010)', severity: 'block' };
+  }
+  if (!RATIONALE_MARKERS.test(body)) {
+    return { pass: false, reason: 'advisory states a conclusion with no reasoning (missing why/because/rationale)', severity: 'block' };
+  }
+  return { pass: true, reason: 'advisory carries reasoning, no manipulative framing', severity: 'block' };
+}
+
+/** Check 2 — should-answer rubric (chairman-addressed questions only). */
+function evalShouldAnswer(message, expectsReply, context) {
+  const question = expectsReply && QUESTION_SHAPE.test(String(message.body || ''));
+  if (!isChairmanAddressed(message.addressee) || !question) {
+    return { pass: true, reason: 'not a chairman-addressed question', severity: 'block' };
+  }
+  // No decision signals -> classifyDecision is conservative (uncertain => escalate). Asking is then
+  // correct, so shouldAnswer passes — we NEVER emit a false "you should have decided this" flag.
+  const decision = context.decision;
+  if (!decision || typeof decision !== 'object') {
+    return { pass: true, reason: 'no decision signals; conservative (escalate) — asking is fine', severity: 'block' };
+  }
+  const { verdict, reasons } = classifyDecision(decision);
+  if (verdict === VERDICT.EXECUTE) {
+    return { pass: false, reason: 'asking the chairman a decision that classifies EXECUTE (Adam should decide-and-report it)', severity: 'block' };
+  }
+  return { pass: true, reason: `escalation is correct (${reasons.join(', ') || 'escalate'})`, severity: 'block' };
+}
+
+/** Check 3 — Solomon-review check (consequential decisions must show a prior consult). */
+function evalSolomonReview(kind, context) {
+  // A solomon_consult message IS the consult — exempt.
+  if (kind === SOLOMON_CONSULT_KIND) {
+    return { pass: true, reason: 'exempt (this IS a Solomon consult)', severity: 'warn' };
+  }
+  const consequential = isConsequential(context);
+  if (!consequential) {
+    return { pass: true, reason: 'not a consequential decision', severity: 'warn' };
+  }
+  if (context.solomonConsulted === true) {
+    return { pass: true, reason: 'consequential, Solomon already consulted', severity: 'warn' };
+  }
+  return { pass: false, reason: 'consequential decision sent without a prior Solomon consult', severity: 'warn' };
+}
+
+/**
+ * A decision is consequential when explicitly marked, or when classifyDecision escalates for a
+ * strategic reason (governance / flagship). A merely reversibility-uncertain escalation is NOT
+ * on its own consequential — that would over-warn on routine asks.
+ */
+function isConsequential(context) {
+  if (context.consequential === true) return true;
+  const decision = context.decision;
+  if (!decision || typeof decision !== 'object') return false;
+  if (decision.governance === true || decision.flagship === true || decision.dataLoss === true) return true;
+  return false;
+}
+
+export default checkAdamOutbound;

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -961,6 +961,32 @@ async function main() {
     );
     process.exit(3);
   }
+  // SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-D: the ADAM OUTBOUND GATE. Runs over EVERY Adam outbound
+  // right after the alarm bar and before dispatch, mirroring the sanityCheckUrgentAdvisory precedent.
+  // Pure classifier composing lib/adam authorities (classifyDecision + rationale-bar) into three
+  // checks: advisory rationale bar (BLOCK), should-answer rubric (BLOCK), Solomon-review (WARN).
+  // WIRE_CHECK-safe string-literal dynamic import (CJS->ESM, same form as scope-registry at ~L230).
+  // A tripped BLOCK is overridable with --outbound-verified / ADAM_OUTBOUND_VERIFIED=1 (audit-logged,
+  // mirrors --alarm-verified). Degrade-safe: any gate error fails OPEN — a gate bug never hard-blocks Adam.
+  try {
+    const { checkAdamOutbound } = await import('../lib/coordinator/adam-outbound-gate.js');
+    const gate = checkAdamOutbound(
+      { body: payload.body, kind: payload.kind, addressee, expectsReply, mode },
+      {},
+    );
+    if (gate.tripped) {
+      const outboundAttested = argv.includes('--outbound-verified') || process.env.ADAM_OUTBOUND_VERIFIED === '1';
+      if (gate.verdict === 'block' && !outboundAttested) {
+        console.error(`\n[adam-advisory] ⛔ ADAM OUTBOUND GATE blocked this send:\n  - ${gate.reasons.join('\n  - ')}\n` +
+          `Fix the outbound (add rationale / own the decision / consult Solomon), or attest with --outbound-verified (or ADAM_OUTBOUND_VERIFIED=1).\n`);
+        process.exit(4);
+      }
+      // WARN-only (or attested block): surface the reasons, do not block.
+      console.error(`[adam-advisory] ⚠️  Adam Outbound Gate ${outboundAttested ? 'BYPASSED (attested)' : 'warning'}: ${gate.reasons.join('; ')}`);
+    }
+  } catch (err) {
+    console.error(`[adam-advisory] Adam Outbound Gate skipped (fail-open): ${err.message}`);
+  }
   const subject = `[ADAM_ADVISORY] ${payload.body.slice(0, 80)}`;
   // SD-LEO-INFRA-ADAM-ADVISORY-COMMS-001 (RCA 076cf785): expires_at is the DURABLE delivery TTL
   // (how long the row stays discoverable / survives the expired-row sweep) and is decoupled from

--- a/tests/unit/coordinator/adam-outbound-gate.test.js
+++ b/tests/unit/coordinator/adam-outbound-gate.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { checkAdamOutbound } from '../../../lib/coordinator/adam-outbound-gate.js';
+import { MANIPULATIVE_PATTERNS } from '../../../lib/adam/rationale-bar.js';
+import { classifyDecision, VERDICT } from '../../../lib/adam/execute-vs-escalate.js';
+import workerStatus from '../../../lib/fleet/worker-status.cjs';
+
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = workerStatus;
+const ADVISORY = PAYLOAD_KINDS.ADAM_ADVISORY;
+const SOLOMON_CONSULT = PAYLOAD_KINDS.SOLOMON_CONSULT;
+
+// GAP-warning: assert the CJS->ESM interop actually yields the kind constants (else the gate's
+// exemptions would silently disable themselves).
+describe('kind-constant interop (CJS -> ESM)', () => {
+  it('resolves advisory/solomon/directive kinds non-undefined', () => {
+    expect(ADVISORY).toBe('adam_advisory');
+    expect(SOLOMON_CONSULT).toBe('solomon_consult');
+    expect(DIRECTIVE_KINDS).toContain('chairman_directive');
+  });
+});
+
+describe('rationaleBar — advisory rationale bar (FR-2 / TS-1, TS-2)', () => {
+  it('fails an advisory with no reasoning marker', () => {
+    const r = checkAdamOutbound({ body: 'Parking the Alt-Text venture.', kind: ADVISORY });
+    expect(r.checks.rationaleBar.pass).toBe(false);
+    expect(r.verdict).toBe('block');
+  });
+  it('fails an advisory with manipulative framing (via the SHARED MANIPULATIVE_PATTERNS)', () => {
+    const body = 'You need to act now — approve immediately, this is critical.';
+    // Composition-identity: the same exported regex the gate uses must itself match this body.
+    expect(MANIPULATIVE_PATTERNS.test(body)).toBe(true);
+    const r = checkAdamOutbound({ body, kind: ADVISORY });
+    expect(r.checks.rationaleBar.pass).toBe(false);
+    expect(r.checks.rationaleBar.reason).toMatch(/manipulative|CONST-010/i);
+  });
+  it('passes a well-reasoned advisory', () => {
+    const r = checkAdamOutbound({ body: 'Recommend parking Alt-Text because demand-test CHECK forbids truth_ metrics; rationale: no live anchor.', kind: ADVISORY });
+    expect(r.checks.rationaleBar.pass).toBe(true);
+  });
+  it('fails a body-less advisory (no rationale possible)', () => {
+    const r = checkAdamOutbound({ body: '   ', kind: ADVISORY });
+    expect(r.checks.rationaleBar.pass).toBe(false);
+    expect(r.checks.rationaleBar.reason).toMatch(/empty/i);
+  });
+  it('EXEMPTS a directive kind and a solomon_consult kind from the rationale bar', () => {
+    const directive = checkAdamOutbound({ body: 'Pause all fleet claims.', kind: 'chairman_directive' });
+    expect(directive.checks.rationaleBar.pass).toBe(true);
+    const consult = checkAdamOutbound({ body: 'Which venture next?', kind: SOLOMON_CONSULT });
+    expect(consult.checks.rationaleBar.pass).toBe(true);
+  });
+});
+
+describe('shouldAnswer — should-answer rubric (FR-3 / TS-3, TS-4)', () => {
+  const execDecision = { reversible: true, inRole: true }; // classifyDecision -> EXECUTE
+  const escalateDecision = { reversible: true, inRole: true, flagship: true }; // -> ESCALATE
+
+  it('composition-identity: the same classifyDecision the gate uses returns EXECUTE / ESCALATE here', () => {
+    expect(classifyDecision(execDecision).verdict).toBe(VERDICT.EXECUTE);
+    expect(classifyDecision(escalateDecision).verdict).toBe(VERDICT.ESCALATE);
+  });
+  it('trips when asking the chairman a decision that classifies EXECUTE', () => {
+    const r = checkAdamOutbound(
+      { body: 'Should we unpark the Alt-Text venture?', kind: SOLOMON_CONSULT, addressee: 'chairman', expectsReply: true },
+      { decision: execDecision },
+    );
+    expect(r.checks.shouldAnswer.pass).toBe(false);
+    expect(r.checks.shouldAnswer.reason).toMatch(/EXECUTE/);
+  });
+  it('passes when the chairman question classifies ESCALATE (flagship/irreversible)', () => {
+    const r = checkAdamOutbound(
+      { body: 'Should we unpark the flagship venture?', kind: SOLOMON_CONSULT, addressee: 'chairman', expectsReply: true },
+      { decision: escalateDecision },
+    );
+    expect(r.checks.shouldAnswer.pass).toBe(true);
+  });
+  it('is conservative when no decision signals are provided (no false over-answer flag)', () => {
+    const r = checkAdamOutbound(
+      { body: 'Should we unpark it?', kind: SOLOMON_CONSULT, addressee: 'chairman', expectsReply: true },
+      {},
+    );
+    expect(r.checks.shouldAnswer.pass).toBe(true);
+  });
+  it('passes a non-question outbound trivially (shouldAnswer only gates questions)', () => {
+    const r = checkAdamOutbound(
+      { body: 'FYI the venture is parked.', kind: ADVISORY, addressee: 'chairman', expectsReply: false },
+      { decision: execDecision },
+    );
+    expect(r.checks.shouldAnswer.pass).toBe(true);
+  });
+});
+
+describe('solomonReview — Solomon-review check (FR-4 / TS-5)', () => {
+  it('warns on a consequential (governance-derived) decision with no prior Solomon consult', () => {
+    const r = checkAdamOutbound(
+      { body: 'Proposing a new kill-gate policy because recurrence is high.', kind: ADVISORY },
+      { decision: { governance: true }, solomonConsulted: false },
+    );
+    expect(r.checks.solomonReview.pass).toBe(false);
+    expect(r.verdict).toBe('warn');
+  });
+  it('warns on an explicitly-consequential decision not yet consulted', () => {
+    const r = checkAdamOutbound({ body: 'Because X, do Y.', kind: ADVISORY }, { consequential: true, solomonConsulted: false });
+    expect(r.checks.solomonReview.pass).toBe(false);
+  });
+  it('EXEMPTS a solomon_consult-kind message (it IS the consult)', () => {
+    const r = checkAdamOutbound({ body: 'Which option?', kind: SOLOMON_CONSULT }, { consequential: true, solomonConsulted: false });
+    expect(r.checks.solomonReview.pass).toBe(true);
+  });
+  it('passes a consequential decision when Solomon was already consulted', () => {
+    const r = checkAdamOutbound({ body: 'Because X, do Y.', kind: ADVISORY }, { consequential: true, solomonConsulted: true });
+    expect(r.checks.solomonReview.pass).toBe(true);
+  });
+  it('passes a routine (non-consequential) outbound', () => {
+    const r = checkAdamOutbound({ body: 'Because the run finished, closing out.', kind: ADVISORY }, { decision: { reversible: true, inRole: true } });
+    expect(r.checks.solomonReview.pass).toBe(true);
+  });
+});
+
+describe('aggregate verdict', () => {
+  it('block outranks warn; a clean advisory passes all three', () => {
+    const clean = checkAdamOutbound({ body: 'Recommend closing because the smoke test passed and no anchor remains.', kind: ADVISORY }, { decision: { reversible: true, inRole: true } });
+    expect(clean.tripped).toBe(false);
+    expect(clean.verdict).toBe('pass');
+  });
+});


### PR DESCRIPTION
## Summary
Child D of the SMS-channel-hardening orchestrator (coordinator-directed, delivered via the new **longest-idle-first reserve** dispatch — thanks!). A **pure gate over every Adam outbound**, wired into `scripts/adam-advisory.cjs` right after the model-availability alarm bar and before dispatch (mirrors the `sanityCheckUrgentAdvisory` precedent).

It **composes existing `lib/adam` authorities** rather than re-deriving heuristics:
- **rationaleBar** (BLOCK) — advisory-kind bodies must carry reasoning and no manipulative framing. Reuses `lib/adam/rationale-bar.js` `MANIPULATIVE_PATTERNS` (now **exported** to single-source it) + `REQUIRED_RATIONALE_FIELDS`. `DIRECTIVE_KINDS` + `solomon_consult` exempt.
- **shouldAnswer** (BLOCK) — routes `context.decision` through `lib/adam/execute-vs-escalate.js` `classifyDecision`; flags Adam asking the chairman a decision that classifies **EXECUTE** (his to decide-and-report). Conservative on missing signals → no false over-answer flag.
- **solomonReview** (WARN) — consequential decisions sent without a prior Solomon consult; `solomon_consult`-kind exempt. Non-blocking, so it composes with the existing `ADAM_PRE_SEND_CONSULT` gate.

## Wire-in
String-literal dynamic import (CJS→ESM, WIRE_CHECK-safe, same form as `scope-registry.js`). A tripped **block** is overridable with `--outbound-verified` / `ADAM_OUTBOUND_VERIFIED=1` (audit-logged, mirrors `--alarm-verified`). Degrade-safe: any gate error fails **open** — a gate bug never hard-blocks Adam.

## Test plan
- [x] 17 unit tests: all three checks + exemptions; **composition-identity** (asserts the gate uses the *same* exported `MANIPULATIVE_PATTERNS` and `classifyDecision`, not a re-derived copy); body-less / non-question / governance-derived-consequential cases; and a CJS→ESM kind-constant interop guard.
- [x] `adam-advisory.cjs` passes `node --check`; wire-in vars (`mode`/`addressee`/`expectsReply`) confirmed in scope.

Deps=none (composes only already-shipped authorities; sibling child A completed but not required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)