### PR TITLE
fix(SD-LEO-INFRA-COACHING-BODY-COLUMN-001): mirror payload.body into top-level body for coaching rows

### DIFF
--- a/scripts/coordinator-comms-check.mjs
+++ b/scripts/coordinator-comms-check.mjs
@@ -81,7 +81,7 @@ const ACK_RE = /comms.?check ack|read you/i;
       console.log('  ⚠ NO-ACK   ' + String(wid).slice(0, 8) + '  (' + cs + ')  ping ' + age + 'm unacked' + (lastPing.read_at ? ' (read, no reply)' : ' (never read → worker not polling inbox)') + ' — re-send + fix prompt');
     }
     const body = '📡 COMMS CHECK (radio check) from coordinator ' + String(me).slice(0, 8) + '. Confirm the two-way link: reply ONCE with  /signal feedback "comms-check ack — read you"  then continue your work. One-line ack only.';
-    await insertCoordinationRow(db, { sender_session: me, target_session: wid, message_type: 'COACHING', subject: 'COMMS CHECK', payload: { body, kind: 'comms_check', sent_at: new Date().toISOString() }, created_at: new Date().toISOString() });
+    await insertCoordinationRow(db, { sender_session: me, target_session: wid, message_type: 'COACHING', subject: 'COMMS CHECK', body, payload: { body, kind: 'comms_check', sent_at: new Date().toISOString() }, created_at: new Date().toISOString() });
     if (!lastPing) console.log('  📨 SENT     ' + String(wid).slice(0, 8) + '  (' + cs + ')  comms-check ping — awaiting ack');
   }
   console.log('[ACTION] ✓=link good · ⏳=wait a tick · ⚠=worker not reading inbox (add an inbox-poll + ack step to its loop prompt).');

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -153,7 +153,7 @@ export async function selfReviewMain() {
   const body = 'COORDINATOR-FEEDBACK REQUEST (recurring review of the COORDINATOR, triggered by ' + delta + ' SDs shipped since the last review): candid critique of how the coordinator is running the fleet — (1) what worked (routing/sourcing/RCA/conflict-resolution/keeping you fed), (2) friction caused BY the coordinator (slow/missing replies, mis-routing, bad SD sourcing, unclear guidance, missed signals), (3) ONE concrete thing to do differently. Be blunt. Reply: /signal feedback, prefix "COORDINATOR-FEEDBACK".';
   for (const w of workers) {
     try {
-      await insertCoordinationRow(db, { target_session: w, sender_session: me, subject: 'Coordinator review (every ' + REVIEW_EVERY + ' SDs) — your candid feedback', message_type: 'COACHING', payload: { kind: 'coordinator_reply', body } });
+      await insertCoordinationRow(db, { target_session: w, sender_session: me, subject: 'Coordinator review (every ' + REVIEW_EVERY + ' SDs) — your candid feedback', message_type: 'COACHING', body, payload: { kind: 'coordinator_reply', body } });
       solicited++;
     } catch (e) { solicitFailed++; console.error('[COORD-REVIEW] solicit skip ' + w + ': ' + e.message.split('\n')[0]); }
   }
@@ -167,7 +167,7 @@ export async function selfReviewMain() {
         // DIRECTIVE_KIND, so this substantive review was fully collapsible to a routine ack
         // (2026-07-13 co-drive review finding). review_request is a DIRECTIVE_KIND: deliver-not-
         // consume, never auto-acked, distinct from both coordinator_request and coordinator_reply.
-        await insertCoordinationRow(db, { target_session: a, sender_session: me, subject: 'Coordinator<->Adam review (every ' + REVIEW_EVERY + ' SDs) — candid bidirectional feedback', message_type: 'COACHING', payload: { kind: 'review_request', body: adamBody } });
+        await insertCoordinationRow(db, { target_session: a, sender_session: me, subject: 'Coordinator<->Adam review (every ' + REVIEW_EVERY + ' SDs) — candid bidirectional feedback', message_type: 'COACHING', body: adamBody, payload: { kind: 'review_request', body: adamBody } });
         adamSolicited++;
       } catch (e) { solicitFailed++; console.error('[COORD-REVIEW] adam solicit skip ' + a + ': ' + e.message.split('\n')[0]); }
     }

--- a/scripts/one-off/explore-results-coaching-body-column.json
+++ b/scripts/one-off/explore-results-coaching-body-column.json
@@ -1,0 +1,14 @@
+{
+  "verdict": "PASS",
+  "confidence": 95,
+  "summary": "Discovery pass confirmed the only session_coordination inserts with message_type='COACHING' that lacked a top-level body column were the 3 sites already fixed (scripts/coordinator-self-review.mjs lines ~156 and ~170, scripts/coordinator-comms-check.mjs line ~84). All other COACHING-typed writers (scripts/fleet-coaching.cjs sendCoaching/sendDeconflictionReply, lib/coordinator/adam-action-ack.cjs applyEscalation) already set a top-level body alongside their payload and were never bugged. No production call site remains that writes payload.body without a matching top-level body for this message class.",
+  "findings": [
+    "scripts/coordinator-comms-check.mjs:84 -- fixed, now has top-level body",
+    "scripts/coordinator-self-review.mjs:156 -- fixed, now has top-level body",
+    "scripts/coordinator-self-review.mjs:170 -- fixed, now has top-level body: adamBody",
+    "scripts/fleet-coaching.cjs:89 (sendCoaching) -- already correct (pre-existing)",
+    "scripts/fleet-coaching.cjs:172 (sendDeconflictionReply) -- already correct (pre-existing)",
+    "lib/coordinator/adam-action-ack.cjs:291 -- already correct (pre-existing)",
+    "scripts/adam-self-adherence-review.mjs -- read-only consumer of payload.body, never inserts a COACHING row -- not in scope"
+  ]
+}

--- a/scripts/one-off/update-sd-fields-coaching-body-column.mjs
+++ b/scripts/one-off/update-sd-fields-coaching-body-column.mjs
@@ -1,0 +1,33 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const key_changes = [
+  { change: "scripts/coordinator-self-review.mjs: worker-directed periodic-review solicitation (line ~156) now sets top-level `body` alongside `payload.body` (was payload-only, top-level NULL).", type: "fix" },
+  { change: "scripts/coordinator-self-review.mjs: Adam-directed bidirectional review solicitation (line ~170) now sets top-level `body: adamBody` alongside `payload.body: adamBody`.", type: "fix" },
+  { change: "scripts/coordinator-comms-check.mjs: COMMS CHECK ping (line ~84) now sets top-level `body` alongside `payload.body`.", type: "fix" },
+];
+
+const success_criteria = [
+  { criterion: "Every coaching/self-review row written by the 3 fixed emitter call sites has a non-empty top-level body column", measure: "tests/unit/coordinator-coaching-body-column.test.js static-source assertions pass for all 3 sites" },
+  { criterion: "A regression asserts top-level body === payload.body for these kinds", measure: "New test file asserts the same source variable feeds both the top-level `body` key and `payload.body` at each site" },
+  { criterion: "No reader path depends on payload.body-only for these kinds", measure: "scripts/hooks/coordination-inbox.cjs already reads only the top-level body column; once writers populate it, the existing reader works with zero reader-side changes" },
+];
+
+const smoke_test_steps = [
+  { step_number: 1, instruction: "Run `node scripts/coordinator-comms-check.mjs` in a session with at least one live worker (or a test fixture worker row)", expected_outcome: "The inserted session_coordination row has a non-null top-level `body` column matching payload.body, verifiable via a direct DB select" },
+  { step_number: 2, instruction: "Trigger a coordinator-self-review.mjs DUE cycle (or directly call insertCoordinationRow with the same shape) for a worker-directed periodic review", expected_outcome: "The resulting COACHING row's top-level body is non-empty and equals payload.body" },
+  { step_number: 3, instruction: "Run `npx vitest run tests/unit/coordinator-coaching-body-column.test.js`", expected_outcome: "All static-source regression assertions pass, confirming the fix is present at all 3 call sites and cannot silently regress" },
+];
+
+const { error } = await supabase
+  .from('strategic_directives_v2')
+  .update({ key_changes, success_criteria, smoke_test_steps })
+  .eq('sd_key', 'SD-LEO-INFRA-COACHING-BODY-COLUMN-001');
+
+if (error) { console.error(error); process.exit(1); }
+console.log('SD fields updated.');

--- a/tests/unit/coordinator-coaching-body-column.test.js
+++ b/tests/unit/coordinator-coaching-body-column.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests — SD-LEO-INFRA-COACHING-BODY-COLUMN-001
+ * FIX: coordinator coaching / self-review solicitation rows must populate the TOP-LEVEL
+ * `body` column, not only `payload.body` (fb 0a9c63da). Readers keyed on the top-level
+ * body column (e.g. scripts/hooks/coordination-inbox.cjs) saw nothing on the buggy rows.
+ *
+ * Static-source regression (mirrors the established pattern in
+ * coordinator-self-review-review-request-kind.test.js): asserts each fixed call site
+ * carries BOTH a top-level `body` key AND a `payload.body` key, using the SAME source
+ * variable, so a future edit cannot silently reintroduce the divergence.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const src = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+describe('coordinator-self-review.mjs: coaching solicitation rows carry top-level body', () => {
+  const text = src('scripts/coordinator-self-review.mjs');
+
+  it('worker-directed periodic-review solicitation sets top-level body === payload.body (both from `body`)', () => {
+    const m = /insertCoordinationRow\(db, \{ target_session: w,[\s\S]{0,300}\}\);/.exec(text);
+    expect(m).toBeTruthy();
+    const call = m[0];
+    expect(call).toMatch(/\bbody,/);
+    expect(call).toMatch(/payload: \{ kind: 'coordinator_reply', body \}/);
+  });
+
+  it('Adam-directed bidirectional review solicitation sets top-level body === payload.body (both from `adamBody`)', () => {
+    const m = /insertCoordinationRow\(db, \{ target_session: a,[\s\S]{0,300}\}\);/.exec(text);
+    expect(m).toBeTruthy();
+    const call = m[0];
+    expect(call).toMatch(/body: adamBody,/);
+    expect(call).toMatch(/payload: \{ kind: 'review_request', body: adamBody \}/);
+  });
+});
+
+describe('coordinator-comms-check.mjs: COMMS CHECK ping carries top-level body', () => {
+  const text = src('scripts/coordinator-comms-check.mjs');
+
+  it('comms-check ping sets top-level body === payload.body (both from `body`)', () => {
+    const m = /insertCoordinationRow\(db, \{ sender_session: me, target_session: wid,[\s\S]{0,300}\}\);/.exec(text);
+    expect(m).toBeTruthy();
+    const call = m[0];
+    expect(call).toMatch(/subject: 'COMMS CHECK', body,/);
+    expect(call).toMatch(/payload: \{ body, kind: 'comms_check'/);
+  });
+});
+
+describe('insertCoordinationRow: top-level body reaches the actual insert unfiltered', () => {
+  const text = src('lib/coordinator/dispatch.cjs');
+
+  it('the row object (carrying any caller-supplied top-level body) is passed to .insert() as-is', () => {
+    expect(text).toMatch(/\.insert\(row\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- COACHING / periodic-review `session_coordination` rows written by the coordinator's self-review and comms-check emitters reached workers with top-level `body`=NULL (content lived only in `payload.body`). Any reader keyed on the top-level `body` column (e.g. `scripts/hooks/coordination-inbox.cjs`, which prints `"Details: " + msg.body` with no `payload.body` fallback) saw nothing — Alpha-2 received 4 consecutive blank COACHING solicitations (fb 0a9c63da).
- Fixes the 3 confirmed write sites in `scripts/coordinator-self-review.mjs` (worker-directed periodic review, Adam-directed bidirectional review) and `scripts/coordinator-comms-check.mjs` (COMMS CHECK ping) — each now sets a top-level `body` field mirroring the same variable already feeding `payload.body`.
- Adds `tests/unit/coordinator-coaching-body-column.test.js`, a static-source regression that pins `body === payload.body` at each site so the divergence cannot silently reoccur.
- Deliberately scoped to the "coaching/self-review emitter" family per the SD title — 3 other same-bug-class sites (`coordinator-capacity-forecast.mjs` ×2, `gauge-runner.mjs`) are a different message class (`message_type='INFO'`) and were left untouched; flagged as a fast-follow candidate.

## Test plan
- [x] New regression test: 4/4 assertions pass
- [x] Existing `coordinator-self-review-*` suite (21 tests) + this new file: 25/25 pass, zero regressions
- [x] ESLint clean on both fixed files + the new test file
- [x] Full-repo regression run: ~49-50 pre-existing failing files (live-DB-dependent, consistent with this session's established baseline), none referencing the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)