### PR TITLE
fix(SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001): scope sub-agent-evidence dedup to phase

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -390,16 +390,26 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   };
 
   // SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-B (TR-003): Dedup check
-  // Prevent duplicate records for same sd_id + sub_agent_code within 5 minutes
+  // Prevent duplicate records for same sd_id + sub_agent_code + phase within 5 minutes
+  // SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001: the dedup key was phase-blind, so a
+  // multi-phase SD's second-phase call (e.g. EXEC after PLAN) matched the first phase's
+  // row and overwrote it in place -- corrupting created_at (frozen at the earlier phase's
+  // time, since the update path preserves it) and making the row invisible to
+  // GATE_SUBAGENT_EVIDENCE's created_at >= phaseStartedAt freshness check for the later
+  // phase. Scoping the dedup match to the SAME phase (or both null, for legacy callers
+  // that never pass options.phase) ensures each phase always gets its own fresh row.
   const DEDUP_WINDOW_MS = 5 * 60 * 1000;
   const dedupCutoff = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
 
-  const { data: existing } = await supabase
+  let dedupQuery = supabase
     .from('sub_agent_execution_results')
     .select('id')
     .eq('sd_id', normalizedSdId)
     .eq('sub_agent_code', code)
-    .gte('created_at', dedupCutoff)
+    .gte('created_at', dedupCutoff);
+  dedupQuery = phaseValue ? dedupQuery.eq('phase', phaseValue) : dedupQuery.is('phase', null);
+
+  const { data: existing } = await dedupQuery
     .order('created_at', { ascending: false })
     .limit(1);
 

--- a/tests/unit/sub-agent-execution-results-dedup-phase-key.test.js
+++ b/tests/unit/sub-agent-execution-results-dedup-phase-key.test.js
@@ -1,0 +1,157 @@
+/**
+ * SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001
+ *
+ * Reproduces and pins the fix for fb 0b12ca77: the TR-003 dedup check in
+ * results-storage.js was phase-blind, so a multi-phase SD's second-phase call
+ * (e.g. EXEC after PLAN) matched the first phase's row and overwrote it in
+ * place -- corrupting created_at (frozen at the earlier phase's time) and
+ * making the row invisible to GATE_SUBAGENT_EVIDENCE's freshness check for the
+ * later phase. The fix scopes the dedup match to the SAME phase (or both null).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Stateful mock: tracks inserted/updated rows in a simple array so the dedup
+ * query's .eq('sd_id')/.eq('sub_agent_code')/.eq('phase') or .is('phase', null)
+ * filters can be honored against genuinely distinct simulated rows -- unlike a
+ * mock that always returns an empty existing-rows array, this can prove the
+ * fix actually discriminates by phase.
+ */
+function makeStatefulMockSupabase(rows) {
+  let nextId = 1;
+  return {
+    from(table) {
+      const filters = {};
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { filters[col] = { op: 'eq', val }; return builder; },
+        is(col, val) { filters[col] = { op: 'is', val }; return builder; },
+        gte(col, val) { filters[col] = { ...(filters[col] || {}), gte: val }; return builder; },
+        order() { return builder; },
+        limit() {
+          const matches = rows.filter((r) => {
+            return Object.entries(filters).every(([col, f]) => {
+              if (f.op === 'is') return r[col] === null || r[col] === undefined;
+              if (f.op === 'eq') return r[col] === f.val;
+              return true;
+            });
+          });
+          return Promise.resolve({ data: matches.map((r) => ({ id: r.id })), error: null });
+        },
+        insert(record) {
+          const row = { id: `row-${nextId++}`, ...record };
+          rows.push(row);
+          return {
+            select() {
+              return { single: async () => ({ data: row, error: null }) };
+            },
+          };
+        },
+        update(fields) {
+          return {
+            eq(_col, id) {
+              return {
+                select() {
+                  return {
+                    single: async () => {
+                      const row = rows.find((r) => r.id === id);
+                      Object.assign(row, fields);
+                      return { data: row, error: null };
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('storeSubAgentResults: phase-scoped dedup (SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001)', () => {
+  let rows;
+
+  beforeEach(() => {
+    rows = [];
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeStatefulMockSupabase(rows),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+    vi.doMock('../../lib/artifact-tools.js', () => ({
+      createArtifact: async () => ({ artifact_id: 'a', token_count: 0, summary: '' }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../lib/sub-agent-executor/supabase-client.js');
+    vi.doUnmock('../../scripts/modules/sd-id-normalizer.js');
+    vi.doUnmock('../../lib/artifact-tools.js');
+  });
+
+  it('TS-2: cross-phase calls within the dedup window produce TWO distinct rows, not one overwritten row', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    const planId = await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 90,
+    }, { phase: 'PLAN' });
+
+    const execId = await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 92,
+    }, { phase: 'EXEC' });
+
+    expect(rows).toHaveLength(2);
+    expect(execId).not.toBe(planId);
+
+    const planRow = rows.find((r) => r.phase === 'PLAN');
+    const execRow = rows.find((r) => r.phase === 'EXEC');
+    expect(planRow).toBeDefined();
+    expect(execRow).toBeDefined();
+    // The PLAN row must be untouched by the EXEC call -- confidence proves no cross-phase overwrite.
+    expect(planRow.confidence ?? planRow.confidence_score).not.toBe(92);
+  });
+
+  it('TS-1: same-phase duplicate call within the dedup window updates the existing row in place (pre-fix behavior preserved)', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    const firstId = await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 80,
+    }, { phase: 'PLAN' });
+
+    const secondId = await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 95,
+    }, { phase: 'PLAN' });
+
+    expect(rows).toHaveLength(1);
+    expect(secondId).toBe(firstId);
+    const row = rows[0];
+    expect(row.confidence ?? row.confidence_score).toBe(95);
+  });
+
+  it('TS-4: two null-phase calls (legacy caller) still dedup against each other', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 80 });
+    await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 95 });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('a null-phase call and a non-null-phase call never dedup against each other', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 80 });
+    await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 90 }, { phase: 'PLAN' });
+
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/tests/unit/sub-agent-execution-results-phase-column.test.js
+++ b/tests/unit/sub-agent-execution-results-phase-column.test.js
@@ -21,6 +21,7 @@ function makeMockSupabase(captureTarget) {
       return {
         select() { return this; },
         eq() { return this; },
+        is() { return this; },
         gte() { return this; },
         order() { return this; },
         limit() { return Promise.resolve({ data: [], error: null }); },

--- a/tests/unit/sub-agent-repo-evidence-persistence.test.js
+++ b/tests/unit/sub-agent-repo-evidence-persistence.test.js
@@ -17,6 +17,7 @@ function makeMockSupabase(captureTarget) {
       return {
         select() { return this; },
         eq() { return this; },
+        is() { return this; },
         gte() { return this; },
         order() { return this; },
         limit() { return Promise.resolve({ data: [], error: null }); },


### PR DESCRIPTION
## Summary
- Fixes fb 0b12ca77 (confirmed recurring across workers): the TR-003 dedup check in `lib/sub-agent-executor/results-storage.js` matched only on `sd_id + sub_agent_code` within a 5-minute window -- phase-blind. A multi-phase SD's second-phase call (e.g. EXEC after PLAN) matched the first phase's row and overwrote it in place; since the update path preserves the original `created_at`, the row's timestamp stayed frozen at the earlier phase's time, making it invisible to `GATE_SUBAGENT_EVIDENCE`'s `created_at >= phaseStartedAt` freshness check and producing a false `SUBAGENT_EVIDENCE_MISSING`.
- Fix: scope the dedup match to the same phase (`.eq('phase', phaseValue)` when set, `.is('phase', null)` for legacy null-phase callers) -- cross-phase calls never collide; same-phase re-runs still dedup exactly as before (zero behavior change for the common case).
- The reader (`subagent-evidence-gate.js`) needed zero changes -- its logic was always correct given a non-corrupted `created_at`.

## Test plan
- [x] New reproduction test (`tests/unit/sub-agent-execution-results-dedup-phase-key.test.js`, 4 cases) -- independently verified via git-stash before/after that 2 of 4 cases genuinely fail against the pre-fix code (not tautological)
- [x] 2 pre-existing test files needed a trivial `.is()` mock-builder stub added
- [x] Full ~29,000-test unit suite run 3x independently (me + TESTING + REGRESSION sub-agents) -- zero new failures, only 3 pre-existing unrelated failures + 1 known-flaky test
- [x] TESTING (95%), SECURITY (97%), VALIDATION (94%), REGRESSION (96%) sub-agents all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)