### PR TITLE
feat(SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001): CA-14 soft-reserve a fresh leaf to the longest-idle signaled worker (fleet fairness)

### DIFF
--- a/lib/checkin/steps/drain-reservations.cjs
+++ b/lib/checkin/steps/drain-reservations.cjs
@@ -11,6 +11,15 @@
 // is the one contractually required to self-compare expires_at > now() (never relying on
 // cleanup_expired_coordination()'s GC, which lags to the next stale-session-sweep tick). This
 // step only threads raw expiresAt through; expiry is judged where the claim decision is made.
+//
+// SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-3 net-new): resolve the live-fleet session set ONCE
+// per tick and stamp each session-scoped fence with reservedForSessionLive, so coordinatorReservation
+// can VOID a fence whose reserved-for worker is dead (heartbeat stale) immediately — the leaf opens to
+// everyone without waiting out the TTL. Fail-open: a live-set resolution fault leaves the stamp absent,
+// so fences keep enforcing under the TTL backstop (never a strand, never a throw — the existing
+// read-error fail-open below is unchanged).
+const { liveFleetSessions } = require('../../fleet/live-fleet-sessions.cjs');
+
 module.exports = {
   name: 'drain-reservations',
   async run(ctx) {
@@ -45,7 +54,26 @@ module.exports = {
           expiresAt: row.expires_at || null,
         });
       }
-      if (Object.keys(reservations).length) ctx.reservations = reservations;
+      const sdKeys = Object.keys(reservations);
+      if (sdKeys.length) {
+        // FR-3 (SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001): stamp reservedForSessionLive from ONE
+        // live-fleet resolve per tick, so a dead-session fence voids immediately at claim time.
+        // Wrapped independently so a live-set fault (or an injected test override) leaves the stamp
+        // undefined — the fence keeps enforcing under the TTL backstop rather than throwing/unfencing.
+        const liveFn = ctx.liveFleetSessionsFn || liveFleetSessions;
+        try {
+          const liveSessions = await liveFn(sb, { coordinatorId });
+          const liveIds = new Set((liveSessions || []).map((s) => s && s.session_id).filter(Boolean));
+          for (const key of sdKeys) {
+            for (const fence of reservations[key]) {
+              if (fence.reservedForSession) fence.reservedForSessionLive = liveIds.has(fence.reservedForSession);
+            }
+          }
+        } catch (liveErr) {
+          console.warn(`[drain-reservations] live-fleet resolve failed, fences keep enforcing under TTL: ${liveErr.message || liveErr}`);
+        }
+        ctx.reservations = reservations;
+      }
     } catch (err) {
       // TR-3: fail-open — a transient read failure must never block the rest of the self-claim
       // pipeline. ctx.reservations stays absent, byte-identical to pre-SD behavior.

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -89,6 +89,14 @@ function coordinatorReservation(row, ctx) {
     const expiresAt = fence.expiresAt ? Date.parse(fence.expiresAt) : NaN;
     if (Number.isFinite(expiresAt) && expiresAt <= now) continue; // expired -- does not fence
     if (fence.reservedForSession) {
+      // SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-3 net-new liveness fail-open): a fence whose
+      // reserved-for session is no longer heartbeat-fresh is VOID — the leaf opens to EVERY worker
+      // immediately, without waiting out the TTL. drain-reservations.cjs stamps reservedForSessionLive
+      // from ONE liveFleetSessions resolve per tick. Strict === false so an UNSTAMPED fence (liveness
+      // unknown / a drain that couldn't resolve the live set) still enforces, backstopped by the
+      // expires_at self-compare above — belt (TTL) and suspenders (liveness). A dead reservation can
+      // therefore never permanently strand a leaf.
+      if (fence.reservedForSessionLive === false) continue; // reserved session dead -> not fencing
       if (ctx.sessionId && fence.reservedForSession === ctx.sessionId) continue; // the reserved-for session is exempt
       return 'reserved_for_other_session';
     }

--- a/lib/fleet/pick-reserve-target.cjs
+++ b/lib/fleet/pick-reserve-target.cjs
@@ -1,0 +1,104 @@
+'use strict';
+/**
+ * SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1): pick the SINGLE longest-idle signaled-ready
+ * worker to soft-reserve a freshly-sourced leaf to, so a live idle worker that keeps losing the
+ * open-queue race to faster-polling peers (the CA-14 incident: Alpha-2 stranded ~15h) wins the
+ * leaf on its next natural checkin.
+ *
+ * PURE ranking (pickLongestIdleFromRows) is split from the IO fetch (pickLongestIdleSignaledReady),
+ * mirroring reserve-sd.cjs's builder/IO split and refill-auto-promote.js's selectRefillBatch purity.
+ * Both fail OPEN to null — a fault (no ready worker, read error, unexpected shape) never blocks
+ * sourcing; it simply leaves the leaf in the open queue exactly as today.
+ *
+ * @module lib/fleet/pick-reserve-target
+ */
+
+const { liveFleetSessions } = require('./live-fleet-sessions.cjs');
+const { PAYLOAD_KINDS } = require('./worker-status.cjs');
+
+/** Coerce a Set | array | nullish into a Set (never throws). */
+function toSet(v) {
+  if (v instanceof Set) return v;
+  if (Array.isArray(v)) return new Set(v);
+  return new Set();
+}
+
+/**
+ * PURE + TOTAL: from raw session_coordination rows (roll_call registrations) and a set of live
+ * (heartbeat-fresh) session ids, return the SINGLE longest-idle, signaled-ready, live, unclaimed
+ * session_id — or null when the intersection is empty. Never throws.
+ *
+ * A session is a candidate when it has an ACTIVE roll_call row with payload.available===true and no
+ * working sd_key, and it is in the live set, and it is not in excludeSessions. The longest-idle
+ * proxy is the EARLIEST currently-active roll_call created_at (smallest ms => longest idle); ties
+ * break by session_id ascending so the pick is fully deterministic. excludeSessions removes
+ * already-reserved-this-run workers so a refill batch spreads across DISTINCT workers (TR-3).
+ *
+ * @param {Array<{sender_session?:string, created_at?:string, payload?:object}>} rollCallRows
+ * @param {Set<string>|Array<string>} liveSessionIds  heartbeat-fresh worker session ids
+ * @param {Set<string>|Array<string>} [excludeSessions]  sessions already reserved this run
+ * @returns {string|null}
+ */
+function pickLongestIdleFromRows(rollCallRows, liveSessionIds, excludeSessions) {
+  const live = toSet(liveSessionIds);
+  if (live.size === 0) return null;
+  const exclude = toSet(excludeSessions);
+  // idle-since proxy per session = earliest active roll_call created_at (longest idle => smallest).
+  const idleSinceBySession = new Map();
+  for (const row of Array.isArray(rollCallRows) ? rollCallRows : []) {
+    if (!row || typeof row !== 'object') continue;
+    const p = row.payload || {};
+    if (p.kind !== PAYLOAD_KINDS.ROLL_CALL) continue; // only availability registrations
+    if (p.available !== true) continue;               // busy (working an SD) => not ready
+    if (p.sd_key) continue;                            // named a working SD => not unclaimed
+    const sid = row.sender_session;
+    if (!sid || !live.has(sid) || exclude.has(sid)) continue;
+    const ms = Date.parse(row.created_at);
+    const idleSince = Number.isFinite(ms) ? ms : Number.POSITIVE_INFINITY;
+    const prev = idleSinceBySession.get(sid);
+    if (prev === undefined || idleSince < prev) idleSinceBySession.set(sid, idleSince);
+  }
+  let best = null;
+  for (const [sid, idleSince] of idleSinceBySession) {
+    if (best === null
+      || idleSince < best.idleSince
+      || (idleSince === best.idleSince && sid < best.sid)) {
+      best = { sid, idleSince };
+    }
+  }
+  return best ? best.sid : null;
+}
+
+/**
+ * IO: fetch active-unexpired roll_call rows + the live-fleet session set, then rank via the pure
+ * function above. FAIL-OPEN: any fault (read error, resolver throw, unexpected shape) returns null,
+ * leaving the leaf open. Never throws.
+ *
+ * @param {object} supabase service-role client
+ * @param {{excludeSessions?:Set<string>|Array<string>, nowMs?:number, liveOpts?:object,
+ *   liveFleetSessionsFn?:Function}} [opts]  liveFleetSessionsFn is injectable for tests; defaults
+ *   to the real liveFleetSessions.
+ * @returns {Promise<string|null>}
+ */
+async function pickLongestIdleSignaledReady(supabase, opts = {}) {
+  try {
+    const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+    // (a) active-unexpired roll_call rows — expires_at > now bounds to still-signaling workers
+    // (registerRollCall sets a ~1h TTL); payload.kind/available are filtered in the pure ranker.
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('sender_session, created_at, payload, expires_at')
+      .eq('message_type', 'INFO')
+      .gt('expires_at', new Date(nowMs).toISOString());
+    if (error) return null; // fail-open
+    // (b) live workers (heartbeat-fresh, server-side bounded)
+    const liveFn = opts.liveFleetSessionsFn || liveFleetSessions;
+    const liveSessions = await liveFn(supabase, { ...(opts.liveOpts || {}), nowMs });
+    const liveIds = new Set((liveSessions || []).map((s) => s && s.session_id).filter(Boolean));
+    return pickLongestIdleFromRows(data || [], liveIds, opts.excludeSessions);
+  } catch {
+    return null; // fail-open: never block sourcing
+  }
+}
+
+module.exports = { pickLongestIdleFromRows, pickLongestIdleSignaledReady };

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -20,6 +20,12 @@ import { buildTwoWayStamp, deriveSdFieldsFromRoadmapItem } from './register-firs
 // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix): the disposition-gate helpers.
 import { hasBuildDisposition, REFILL_INVALID_REASONS } from './refill-candidate-validity.js';
 import { checkFeedbackPremiseLiveness } from '../eva/feedback-premise-adapter.js';
+// SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1): auto-soft-reserve a freshly-sourced leaf to the
+// longest-idle signaled-ready worker BEFORE it hits the open claim queue, reusing the shipped
+// COORDINATOR_RESERVATION writer (reserveSd) + the new longest-idle picker. Named imports from CJS
+// modules are resolved by Node's cjs-module-lexer (both use `module.exports = { ... }`).
+import { reserveSd } from '../coordinator/reserve-sd.cjs';
+import { pickLongestIdleSignaledReady } from '../fleet/pick-reserve-target.cjs';
 
 /**
  * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: is distilled-only auto-mint mode on? When ON, the
@@ -165,6 +171,56 @@ export function buildRefillSdPayload(item, sdKey) {
 }
 
 /**
+ * SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1 / TR-2): soft-reserve TTL in seconds. It MUST
+ * comfortably EXCEED DEFAULT_IDLE_WAKEUP_SECONDS=600 (scripts/worker-checkin.cjs) so a slow-polling
+ * idle worker re-checks-in while the fence is still live — a literal ~60s TTL is a KNOWN BUG (it
+ * expires long before a 10-min-cadence idle worker re-polls, so the reserved worker would still
+ * lose). Configurable via SOFT_RESERVE_TTL_SECONDS (read at call time so it can flip without a
+ * restart; injectable via `env` for tests). A non-positive / NaN override falls back to the default.
+ */
+export const DEFAULT_SOFT_RESERVE_TTL_SECONDS = 720; // > DEFAULT_IDLE_WAKEUP_SECONDS (600)
+export function softReserveTtlSeconds(env = process.env) {
+  const n = Number(env && env.SOFT_RESERVE_TTL_SECONDS);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_SOFT_RESERVE_TTL_SECONDS;
+}
+
+/**
+ * SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1): fence the just-created leaf `sdKey` to the
+ * longest-idle signaled-ready worker via the SHIPPED reserveSd writer (which resolves the live
+ * active coordinator itself, so the refill cron need not BE the coordinator). FAIL-OPEN everywhere:
+ * no ready worker, a pick fault, or a reserve-write error all leave the leaf in the open queue with
+ * NO reservation — byte-identical to pre-SD behavior. Never throws.
+ *
+ * `reserveState.reservedSessions` (a Set) is threaded across a refill batch so each successive leaf
+ * reserves to a DISTINCT longest-idle worker (TR-3 batch-spread — no single-worker hoard, no
+ * all-peers-fenced-from-all-leaves); it is mutated in place with the chosen session on success.
+ * Deps (pickFn/reserveFn) are injectable for tests; default to the real picker + writer.
+ *
+ * @param {object} supabase
+ * @param {string} sdKey  the freshly-created leaf's sd_key
+ * @param {{reservedSessions?:Set<string>}} [reserveState]
+ * @param {{pickFn?:Function, reserveFn?:Function, env?:object}} [deps]
+ * @returns {Promise<{reserved:boolean, reservedForSession?:string, expiresAt?:string, reason?:string}>}
+ */
+export async function softReserveLeaf(supabase, sdKey, reserveState, deps = {}) {
+  const pickFn = deps.pickFn || pickLongestIdleSignaledReady;
+  const reserveFn = deps.reserveFn || reserveSd;
+  try {
+    if (!sdKey) return { reserved: false, reason: 'missing_sd_key' };
+    const excludeSessions = reserveState && reserveState.reservedSessions;
+    const target = await pickFn(supabase, { excludeSessions });
+    if (!target) return { reserved: false, reason: 'no_ready_worker' }; // leaf enters open queue
+    const expiresAt = new Date(Date.now() + softReserveTtlSeconds(deps.env) * 1000).toISOString();
+    const { error } = await reserveFn(supabase, { targetSd: sdKey, reservedForSession: target, expiresAt });
+    if (error) return { reserved: false, reason: String(error) }; // fail-open: leaf just stays open
+    if (reserveState && reserveState.reservedSessions instanceof Set) reserveState.reservedSessions.add(target);
+    return { reserved: true, reservedForSession: target, expiresAt };
+  } catch (e) {
+    return { reserved: false, reason: String((e && e.message) || e) }; // fail-open
+  }
+}
+
+/**
  * Promote a SINGLE staged candidate onto the belt: create a draft SD + stamp the roadmap row's
  * promoted_to_sd_key (two-way link). The ONLY writer here. Dry-run (apply:false, the default) performs NO
  * writes and just reports what it WOULD do. Idempotent: an item already carrying promoted_to_sd_key, or
@@ -172,7 +228,8 @@ export function buildRefillSdPayload(item, sdKey) {
  *
  * @param {object} supabase  service-role client
  * @param {Object} item      a staged roadmap_wave_items row (must have id)
- * @param {{apply?:boolean}} [opts]
+ * @param {{apply?:boolean, distilledOnly?:boolean, reserveState?:{reservedSessions?:Set<string>}}} [opts]
+ *        reserveState threads the already-reserved-this-run session set across a batch (TR-3 spread).
  * @returns {Promise<{promoted:boolean, dry_run:boolean, sd_key:string|null, reason:string|null}>}
  */
 export async function promoteStagedCandidate(supabase, item, opts = {}) {
@@ -232,6 +289,14 @@ export async function promoteStagedCandidate(supabase, item, opts = {}) {
     }
     out.reason = `insert_failed: ${insErr.message}`; return out;
   }
+
+  // SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1): the leaf now exists — soft-reserve it to the
+  // longest-idle signaled-ready worker BEFORE it hits the open claim queue, so a live idle worker
+  // (the CA-14 incident victim) wins the leaf on its next natural checkin instead of losing every
+  // open-queue race to faster-polling peers. Fully fail-open (softReserveLeaf never throws and swallows
+  // every fault): a missing worker or a reserve error just leaves the leaf open, exactly as today.
+  // Runs before the two-way stamp so the fence lands regardless of the (recoverable) stamp outcome.
+  await softReserveLeaf(supabase, sdKey, opts.reserveState);
 
   // Two-way stamp (fail-soft — the SD already exists; a missed stamp is recoverable, not corrupting).
   const stamp = buildTwoWayStamp(item, sdKey);

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -188,9 +188,13 @@ async function main() {
   // Phase 1 advisory pass (pure helper) — surfaces lookalike matches WITHOUT changing any verdict.
   const { matches: advisoryMatches, byReason: advisoryByReason } =
     collectShippedTitleAdvisories(sel.batch, shippedTitleSet);
+  // SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (TR-3 batch-spread): one shared reserved-session set
+  // across the whole batch so each successive leaf soft-reserves to a DISTINCT longest-idle worker —
+  // no single worker hoards every fresh leaf and no long TTL fences all peers from all leaves at once.
+  const reserveState = { reservedSessions: new Set() };
   for (const item of sel.batch) {
     // Gate 2 (write) flows through to the only writer; apply:false => dry-run no-op.
-    results.push(await promoteStagedCandidate(supabase, item, { apply }));
+    results.push(await promoteStagedCandidate(supabase, item, { apply, reserveState }));
   }
   const promoted = results.filter((r) => r.promoted).length;
 

--- a/tests/unit/fleet/pick-reserve-target.test.js
+++ b/tests/unit/fleet/pick-reserve-target.test.js
@@ -1,0 +1,130 @@
+// SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1): the longest-idle signaled-ready picker.
+// Covers TS-6 (pick correctness + null) and TS-7 (batch-spread across distinct workers), plus the
+// IO wrapper's fail-open contract. Pure/IO split — the ranking is exercised directly; the IO wrapper
+// is stubbed (session_coordination query + an injected live-fleet resolver).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { pickLongestIdleFromRows, pickLongestIdleSignaledReady } = require('../../../lib/fleet/pick-reserve-target.cjs');
+const { PAYLOAD_KINDS } = require('../../../lib/fleet/worker-status.cjs');
+
+const iso = (ms) => new Date(ms).toISOString();
+/** An active roll_call availability row for `sid` created at `createdMs`. */
+const rollCall = (sid, createdMs, over = {}) => ({
+  sender_session: sid,
+  created_at: iso(createdMs),
+  payload: { kind: PAYLOAD_KINDS.ROLL_CALL, available: true, sd_key: null, ...over },
+});
+
+describe('pickLongestIdleFromRows — TS-6: single longest-idle signaled-ready+live+unclaimed', () => {
+  it('returns the session with the EARLIEST active roll_call (longest idle)', () => {
+    const rows = [rollCall('w-new', 5000), rollCall('w-old', 1000), rollCall('w-mid', 3000)];
+    const live = new Set(['w-new', 'w-old', 'w-mid']);
+    expect(pickLongestIdleFromRows(rows, live)).toBe('w-old');
+  });
+
+  it('breaks a created_at tie by session_id ascending (determinism)', () => {
+    const rows = [rollCall('w-b', 1000), rollCall('w-a', 1000)];
+    expect(pickLongestIdleFromRows(rows, new Set(['w-a', 'w-b']))).toBe('w-a');
+  });
+
+  it('collapses multiple roll_calls per session to its EARLIEST (idle-since proxy)', () => {
+    // w-old first signaled at t=500 (longest idle) even though it re-signaled at t=9000.
+    const rows = [rollCall('w-old', 9000), rollCall('w-old', 500), rollCall('w-young', 2000)];
+    expect(pickLongestIdleFromRows(rows, new Set(['w-old', 'w-young']))).toBe('w-old');
+  });
+
+  it('excludes non-live workers (signaled but heartbeat-stale)', () => {
+    const rows = [rollCall('w-dead', 1000), rollCall('w-live', 4000)];
+    expect(pickLongestIdleFromRows(rows, new Set(['w-live']))).toBe('w-live');
+  });
+
+  it('excludes busy workers (available=false) and workers naming a working sd_key', () => {
+    const rows = [
+      rollCall('w-busy', 1000, { available: false }),
+      rollCall('w-working', 1500, { sd_key: 'SD-CLAIMED-1' }),
+      rollCall('w-ready', 8000),
+    ];
+    expect(pickLongestIdleFromRows(rows, new Set(['w-busy', 'w-working', 'w-ready']))).toBe('w-ready');
+  });
+
+  it('ignores rows whose payload.kind is not roll_call', () => {
+    const rows = [
+      { sender_session: 'w-x', created_at: iso(100), payload: { kind: PAYLOAD_KINDS.COORDINATOR_RESERVATION } },
+      rollCall('w-ready', 5000),
+    ];
+    expect(pickLongestIdleFromRows(rows, new Set(['w-x', 'w-ready']))).toBe('w-ready');
+  });
+
+  it('returns null when the intersection is empty (no live signaled worker)', () => {
+    expect(pickLongestIdleFromRows([rollCall('w-1', 1000)], new Set())).toBeNull();
+    expect(pickLongestIdleFromRows([], new Set(['w-1']))).toBeNull();
+    expect(pickLongestIdleFromRows([rollCall('w-1', 1000)], new Set(['other']))).toBeNull();
+  });
+
+  it('is TOTAL on malformed input (never throws)', () => {
+    expect(pickLongestIdleFromRows(null, null)).toBeNull();
+    expect(pickLongestIdleFromRows([null, 42, 'x', {}], ['w-1'])).toBeNull();
+    expect(pickLongestIdleFromRows(undefined, undefined)).toBeNull();
+  });
+});
+
+describe('pickLongestIdleFromRows — TS-7: batch-spread via excludeSessions', () => {
+  it('excludes already-reserved-this-run sessions so N leaves pick N distinct workers', () => {
+    const rows = [rollCall('w-old', 1000), rollCall('w-mid', 2000), rollCall('w-new', 3000)];
+    const live = new Set(['w-old', 'w-mid', 'w-new']);
+    const reserved = new Set();
+    const p1 = pickLongestIdleFromRows(rows, live, reserved); reserved.add(p1);
+    const p2 = pickLongestIdleFromRows(rows, live, reserved); reserved.add(p2);
+    const p3 = pickLongestIdleFromRows(rows, live, reserved); reserved.add(p3);
+    const p4 = pickLongestIdleFromRows(rows, live, reserved);
+    expect([p1, p2, p3]).toEqual(['w-old', 'w-mid', 'w-new']); // longest-idle first, all distinct
+    expect(new Set([p1, p2, p3]).size).toBe(3);
+    expect(p4).toBeNull(); // pool exhausted -> no hoard, next leaf just stays open
+  });
+});
+
+describe('pickLongestIdleSignaledReady — IO wrapper (fail-open + happy path)', () => {
+  // Minimal chainable stub for the session_coordination roll_call query.
+  const makeSb = (rcRows, { throwOnQuery = false, errorOnQuery = false } = {}) => ({
+    from(table) {
+      expect(table).toBe('session_coordination');
+      return {
+        select() { return this; },
+        eq() { return this; },
+        gt() {
+          if (throwOnQuery) throw new Error('query boom');
+          return Promise.resolve({ data: errorOnQuery ? null : rcRows, error: errorOnQuery ? { message: 'boom' } : null });
+        },
+      };
+    },
+  });
+
+  it('returns the longest-idle worker when both fetches succeed (injected live resolver)', async () => {
+    const sb = makeSb([rollCall('w-old', 1000), rollCall('w-new', 5000)]);
+    const liveFleetSessionsFn = async () => [{ session_id: 'w-old' }, { session_id: 'w-new' }];
+    expect(await pickLongestIdleSignaledReady(sb, { liveFleetSessionsFn })).toBe('w-old');
+  });
+
+  it('honors excludeSessions end-to-end', async () => {
+    const sb = makeSb([rollCall('w-old', 1000), rollCall('w-new', 5000)]);
+    const liveFleetSessionsFn = async () => [{ session_id: 'w-old' }, { session_id: 'w-new' }];
+    expect(await pickLongestIdleSignaledReady(sb, { liveFleetSessionsFn, excludeSessions: new Set(['w-old']) })).toBe('w-new');
+  });
+
+  it('fail-open: a query error returns null', async () => {
+    const sb = makeSb([], { errorOnQuery: true });
+    expect(await pickLongestIdleSignaledReady(sb, { liveFleetSessionsFn: async () => [] })).toBeNull();
+  });
+
+  it('fail-open: a thrown query returns null (never propagates)', async () => {
+    const sb = makeSb([], { throwOnQuery: true });
+    await expect(pickLongestIdleSignaledReady(sb, { liveFleetSessionsFn: async () => [] })).resolves.toBeNull();
+  });
+
+  it('fail-open: a live-resolver throw returns null', async () => {
+    const sb = makeSb([rollCall('w-old', 1000)]);
+    const liveFleetSessionsFn = async () => { throw new Error('live boom'); };
+    await expect(pickLongestIdleSignaledReady(sb, { liveFleetSessionsFn })).resolves.toBeNull();
+  });
+});

--- a/tests/unit/fleet/soft-reserve-liveness.test.js
+++ b/tests/unit/fleet/soft-reserve-liveness.test.js
@@ -1,0 +1,100 @@
+// SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-3): the net-new reserved-session-liveness fail-open.
+// TS-4 (dead reserved session -> open to all immediately, before TTL) at BOTH seams:
+//   (a) coordinatorReservation voids a fence stamped reservedForSessionLive:false, and
+//   (b) drain-reservations stamps reservedForSessionLive from one live-fleet resolve per tick.
+// Plus the no-stranding invariant (dead OR expired OR read-error => always eventually claimable).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { coordinatorReservation, classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+const drainReservations = require('../../../lib/checkin/steps/drain-reservations.cjs');
+const { PAYLOAD_KINDS } = require('../../../lib/fleet/worker-status.cjs');
+
+const future = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const past = () => new Date(Date.now() - 60 * 1000).toISOString();
+const helpers = { ws: require('../../../lib/fleet/worker-status.cjs') };
+
+// Chainable stub matching drain-reservations' session_coordination query:
+//   .select().eq('message_type','INFO').is('target_session',null).not('target_sd','is',null)
+function makeSb(rows) {
+  return {
+    from(table) {
+      expect(table).toBe('session_coordination');
+      return {
+        select: () => ({
+          eq: () => ({
+            is: () => ({ not: async () => ({ data: rows, error: null }) }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+describe('TS-4a: coordinatorReservation voids a fence whose reserved session is DEAD', () => {
+  const row = { sd_key: 'SD-X' };
+
+  it('a peer can claim immediately when reservedForSessionLive===false (before TTL expiry)', () => {
+    const ctx = { sessionId: 'peer', reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'dead-worker', reservedForSessionLive: false, expiresAt: future() }] } };
+    expect(coordinatorReservation(row, ctx)).toBeNull(); // void -> not fencing
+  });
+
+  it('even the (dead) reserved session is not fenced — the leaf is open to ALL', () => {
+    const ctx = { sessionId: 'dead-worker', reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'dead-worker', reservedForSessionLive: false, expiresAt: future() }] } };
+    expect(coordinatorReservation(row, ctx)).toBeNull();
+  });
+
+  it('still ENFORCES while the reserved session is live (reservedForSessionLive===true) — peer blocked, reserved admitted', () => {
+    const base = { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'live-worker', reservedForSessionLive: true, expiresAt: future() }] };
+    expect(coordinatorReservation(row, { sessionId: 'peer', reservations: base })).toBe('reserved_for_other_session');
+    expect(coordinatorReservation(row, { sessionId: 'live-worker', reservations: base })).toBeNull();
+  });
+
+  it('an UNSTAMPED fence (liveness unknown) still enforces — backward-compatible, TTL-backstopped', () => {
+    const ctx = { sessionId: 'peer', reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'w', expiresAt: future() }] } };
+    expect(coordinatorReservation(row, ctx)).toBe('reserved_for_other_session');
+  });
+
+  it('is enforced through classifyDispatchIneligibility (dead fence -> eligible on this axis)', () => {
+    const ctx = { sessionId: 'peer', reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'dead', reservedForSessionLive: false, expiresAt: future() }] } };
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X' }, ctx)).toBeNull();
+  });
+});
+
+describe('TS-4b: drain-reservations stamps reservedForSessionLive from the live-fleet set', () => {
+  const mkRow = (session) => ({ id: 'r1', target_sd: 'SD-X', sender_session: 'coord-1', payload: { kind: PAYLOAD_KINDS.COORDINATOR_RESERVATION, reserved_for_session: session }, expires_at: future() });
+
+  it('stamps TRUE when the reserved session is in the live set', async () => {
+    const ctx = { sb: makeSb([mkRow('alpha')]), coordinatorId: 'coord-1', helpers, liveFleetSessionsFn: async () => [{ session_id: 'alpha' }, { session_id: 'beta' }] };
+    await drainReservations.run(ctx);
+    expect(ctx.reservations['SD-X'][0].reservedForSessionLive).toBe(true);
+  });
+
+  it('stamps FALSE when the reserved session is NOT live (dead-session immediate open)', async () => {
+    const ctx = { sb: makeSb([mkRow('ghost')]), coordinatorId: 'coord-1', helpers, liveFleetSessionsFn: async () => [{ session_id: 'alpha' }] };
+    await drainReservations.run(ctx);
+    expect(ctx.reservations['SD-X'][0].reservedForSessionLive).toBe(false);
+    // downstream: coordinatorReservation now voids it for any session
+    expect(coordinatorReservation({ sd_key: 'SD-X' }, { sessionId: 'peer', reservations: ctx.reservations })).toBeNull();
+  });
+
+  it('leaves the stamp UNDEFINED (fences keep enforcing) when the live-set resolve throws', async () => {
+    const ctx = { sb: makeSb([mkRow('alpha')]), coordinatorId: 'coord-1', helpers, liveFleetSessionsFn: async () => { throw new Error('live boom'); } };
+    await drainReservations.run(ctx); // must not reject
+    expect(ctx.reservations['SD-X'][0].reservedForSessionLive).toBeUndefined();
+    expect(coordinatorReservation({ sd_key: 'SD-X' }, { sessionId: 'peer', reservations: ctx.reservations })).toBe('reserved_for_other_session');
+  });
+});
+
+describe('TS-8 / AC-3 no-stranding invariant: a leaf is ALWAYS eventually claimable', () => {
+  const row = { sd_key: 'SD-X' };
+  const peer = 'peer';
+  it('dead reserved-session OR expired TTL OR (no fence at all) each yield null for a peer', () => {
+    // dead session, TTL still live
+    expect(coordinatorReservation(row, { sessionId: peer, reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'w', reservedForSessionLive: false, expiresAt: future() }] } })).toBeNull();
+    // live session but TTL expired
+    expect(coordinatorReservation(row, { sessionId: peer, reservations: { 'SD-X': [{ sd: 'SD-X', reservedForSession: 'w', reservedForSessionLive: true, expiresAt: past() }] } })).toBeNull();
+    // read error / no fence drained at all
+    expect(coordinatorReservation(row, { sessionId: peer })).toBeNull();
+  });
+});

--- a/tests/unit/sourcing-engine/soft-reserve-wiring.test.js
+++ b/tests/unit/sourcing-engine/soft-reserve-wiring.test.js
@@ -1,0 +1,107 @@
+// SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 (FR-1 + TR-2 + TR-3): the reserve wiring at the
+// sourcing seam. softReserveLeaf resolves the longest-idle worker + writes a fence via the SHIPPED
+// reserveSd, with a cadence-tuned TTL, batch-spread, and total fail-open. Also proves the auto-written
+// fence blocks a peer and admits the reserved worker (FR-2 end-to-end, not just a manual fence).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import {
+  softReserveLeaf,
+  softReserveTtlSeconds,
+  DEFAULT_SOFT_RESERVE_TTL_SECONDS,
+} from '../../../lib/sourcing-engine/refill-auto-promote.js';
+const require = createRequire(import.meta.url);
+const { coordinatorReservation } = require('../../../lib/fleet/claim-eligibility.cjs');
+
+describe('softReserveTtlSeconds — TR-2: default must exceed DEFAULT_IDLE_WAKEUP_SECONDS (600)', () => {
+  it('defaults to 720s (> 600, and emphatically NOT 60)', () => {
+    expect(DEFAULT_SOFT_RESERVE_TTL_SECONDS).toBe(720);
+    expect(DEFAULT_SOFT_RESERVE_TTL_SECONDS).toBeGreaterThan(600);
+    expect(softReserveTtlSeconds({})).toBe(720);
+  });
+  it('honors a valid SOFT_RESERVE_TTL_SECONDS override', () => {
+    expect(softReserveTtlSeconds({ SOFT_RESERVE_TTL_SECONDS: '900' })).toBe(900);
+  });
+  it('falls back to the default for a non-positive / NaN override', () => {
+    expect(softReserveTtlSeconds({ SOFT_RESERVE_TTL_SECONDS: '-5' })).toBe(720);
+    expect(softReserveTtlSeconds({ SOFT_RESERVE_TTL_SECONDS: 'abc' })).toBe(720);
+    expect(softReserveTtlSeconds({ SOFT_RESERVE_TTL_SECONDS: '0' })).toBe(720);
+  });
+});
+
+describe('softReserveLeaf — FR-1 reserve at the sourcing seam', () => {
+  it('reserves the picked worker with a future ISO expiresAt (TTL ahead of now) and returns it', async () => {
+    const calls = [];
+    const pickFn = async () => 'w-old';
+    const reserveFn = async (_sb, args) => { calls.push(args); return { data: { id: 'res-1' }, error: null }; };
+    const before = Date.now();
+    const r = await softReserveLeaf({}, 'SD-REFILL-AAA', undefined, { pickFn, reserveFn });
+    expect(r.reserved).toBe(true);
+    expect(r.reservedForSession).toBe('w-old');
+    expect(calls[0].targetSd).toBe('SD-REFILL-AAA');
+    expect(calls[0].reservedForSession).toBe('w-old');
+    // expiresAt is ~720s ahead — well beyond the 600s idle cadence
+    const ttlMs = Date.parse(calls[0].expiresAt) - before;
+    expect(ttlMs).toBeGreaterThan(600 * 1000);
+  });
+
+  it('writes NO reservation when no ready worker is pickable (leaf enters the open queue)', async () => {
+    const reserveFn = async () => { throw new Error('should not be called'); };
+    const r = await softReserveLeaf({}, 'SD-REFILL-BBB', undefined, { pickFn: async () => null, reserveFn });
+    expect(r).toEqual({ reserved: false, reason: 'no_ready_worker' });
+  });
+
+  it('FAIL-OPEN: a reserve-write error never throws — the leaf just stays open', async () => {
+    const pickFn = async () => 'w-1';
+    const reserveFn = async () => ({ data: null, error: 'no live active coordinator resolved' });
+    const r = await softReserveLeaf({}, 'SD-REFILL-CCC', undefined, { pickFn, reserveFn });
+    expect(r.reserved).toBe(false);
+    expect(r.reason).toMatch(/coordinator/);
+  });
+
+  it('FAIL-OPEN: a picker throw never throws out of softReserveLeaf', async () => {
+    const pickFn = async () => { throw new Error('pick boom'); };
+    await expect(softReserveLeaf({}, 'SD-REFILL-DDD', undefined, { pickFn, reserveFn: async () => ({}) }))
+      .resolves.toMatchObject({ reserved: false });
+  });
+});
+
+describe('softReserveLeaf — TR-3 batch-spread across DISTINCT workers', () => {
+  it('a batch reserves N leaves to N distinct workers (already-reserved excluded from the next pick)', async () => {
+    // pickFn honors excludeSessions the way the real picker does.
+    const pool = ['w-old', 'w-mid', 'w-new'];
+    const pickFn = async (_sb, opts) => {
+      const excl = opts.excludeSessions instanceof Set ? opts.excludeSessions : new Set();
+      return pool.find((w) => !excl.has(w)) || null;
+    };
+    const reserveFn = async () => ({ data: {}, error: null });
+    const reserveState = { reservedSessions: new Set() };
+    const r1 = await softReserveLeaf({}, 'SD-1', reserveState, { pickFn, reserveFn });
+    const r2 = await softReserveLeaf({}, 'SD-2', reserveState, { pickFn, reserveFn });
+    const r3 = await softReserveLeaf({}, 'SD-3', reserveState, { pickFn, reserveFn });
+    const r4 = await softReserveLeaf({}, 'SD-4', reserveState, { pickFn, reserveFn });
+    expect([r1, r2, r3].map((r) => r.reservedForSession)).toEqual(['w-old', 'w-mid', 'w-new']);
+    expect(reserveState.reservedSessions.size).toBe(3); // no single-worker hoard
+    expect(r4).toEqual({ reserved: false, reason: 'no_ready_worker' }); // pool exhausted -> open
+  });
+
+  it('does NOT mutate reserveState on a failed reserve (no phantom exclusion)', async () => {
+    const reserveState = { reservedSessions: new Set() };
+    const r = await softReserveLeaf({}, 'SD-1', reserveState, { pickFn: async () => 'w-1', reserveFn: async () => ({ error: 'boom' }) });
+    expect(r.reserved).toBe(false);
+    expect(reserveState.reservedSessions.size).toBe(0);
+  });
+});
+
+describe('FR-2 end-to-end: an AUTO-written fence blocks a peer and admits the reserved worker', () => {
+  it('the reservedForSession from softReserveLeaf feeds coordinatorReservation correctly', async () => {
+    let written = null;
+    const pickFn = async () => 'reserved-worker';
+    const reserveFn = async (_sb, args) => { written = args; return { data: {}, error: null }; };
+    const r = await softReserveLeaf({}, 'SD-LEAF', undefined, { pickFn, reserveFn });
+    expect(r.reserved).toBe(true);
+    // Reconstruct the fence a drain would build from the written reservation (live worker).
+    const reservations = { 'SD-LEAF': [{ sd: 'SD-LEAF', reservedForSession: written.reservedForSession, reservedForSessionLive: true, expiresAt: written.expiresAt }] };
+    expect(coordinatorReservation({ sd_key: 'SD-LEAF' }, { sessionId: 'faster-peer', reservations })).toBe('reserved_for_other_session');
+    expect(coordinatorReservation({ sd_key: 'SD-LEAF' }, { sessionId: 'reserved-worker', reservations })).toBeNull();
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-SOFT-RESERVE-LONGEST-IDLE-001 — CA-14 soft-reserve fairness

Eliminates claim-race starvation: a live, signaled-ready worker sat idle ~15h after losing 9 consecutive open-queue races. Now a freshly-sourced leaf is **soft-reserved to the longest-idle signaled-ready worker for a TTL** before it enters the open claim queue.

### What (~100 net-new LOC + 33 tests; NO new table/migration — reuses shipped machinery)
- **FR-1** — new `lib/fleet/pick-reserve-target.cjs` (longest-idle signaled-ready picker: intersect active `roll_call` rows with heartbeat-fresh `liveFleetSessions()`, pick earliest/longest-idle, tie-break session_id) wired into the leaf-sourcing seam (`refill-auto-promote.js promoteStagedCandidate`, right after the SD insert) to call the **existing** `reserveSd()` with `reserved_until = now + TTL`. Reservations **batch-spread across distinct workers** so one refill batch can't hoard.
- **FR-2** — reuses the **already-shipped** enforcement (`claim-eligibility.cjs coordinatorReservation` blocks non-reserved, exempts reserved) — verified + tested, not rebuilt.
- **FR-3 fail-open triple** — a reservation never permanently strands a leaf: (i) TTL expiry, (ii) **dead reserved session** void (`drain-reservations.cjs` stamps `reservedForSessionLive`; the fence voids when the reserved worker's heartbeat is stale — opens the leaf *before* TTL), (iii) any read/drain error → unfenced.

### Design note
The spec's ~60s TTL was **too short** (idle workers re-poll at 600s, so a 60s fence expires before the victim re-polls) — TTL is configurable, **default 720s (>600)**.

### Verification
- Reviews (sub_agent_execution_results): **SECURITY 90** (no-permanent-strand / no-new-starvation / fail-open-write / identity / injection all confirmed; adversarial strand+starvation+spoof attempts refuted; fault directions found *safer* than documented), **VALIDATION 92**, **REGRESSION 95**, TESTING 90.
- **1246 tests, 0 fail** across the fleet/sourcing/checkin pipeline; additive + fail-open. Backward-compat: an unstamped fence still enforces under TTL (strict `===false`), so existing coordinator reservations are never silently voided. No migration. Picker is WIRE_CHECK-reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)