### PR TITLE
feat(SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001): archive 2 pre-guard duplicate EVA Intake Roadmap rows

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001.json
@@ -1,0 +1,84 @@
+{
+  "executive_summary": "One-time archive of 2 pre-guard duplicate draft 'EVA Intake Roadmap' rows in strategic_roadmaps (a89b078b, 8ffa7fdf), created 2026-07-17 by two Solomon /distill runs before the now-shipped single-writer guard (SD-LEO-INFRA-DISTILL-ROADMAP-SINGLE-001). Chairman-confirmed 2026-07-17: the LEO Roadmap (3aa2f3e2, active, vision-linked) is the sole plan-of-record. Ground truth independently re-verified live 2026-07-18 (twice, by both the worker and an independent VALIDATION sub-agent pass): all 4 strategic_roadmaps rows match the SD's stated shape exactly; all 1080 roadmap_wave_items across the 2 draft roadmaps' 9 waves (731 todoist + 349 youtube) are pure intake-table references with zero unresolved source_id, zero promoted_to_sd_key, and zero populated title/metadata/disposition/lane/priority_rank/brainstorm_session_id fields -- confirming the roadmaps are a clustering VIEW over the intake backlog SSOT (the 1080 items map to only 497 distinct intake rows, an expected overlap artifact of the two /distill runs), not a store of unique authored content. No counterfactual migration is needed.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Archive the 2 pre-guard duplicate draft roadmap rows",
+      "description": "UPDATE strategic_roadmaps SET status='archived' WHERE id IN ('a89b078b-836c-437f-9c40-09fb6b23a41a', '8ffa7fdf-5d67-42a7-b135-2f7200fe9da0'). Reversible (status flip, no delete). Row ed12bf74 (already archived, Mar-8 2026) and row 3aa2f3e2 (LEO Roadmap, active) are explicitly untouched.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Both target rows have status='archived' after the change",
+        "Row ed12bf74's status is unchanged (still archived, no re-touch)",
+        "Row 3aa2f3e2 (LEO Roadmap) status/vision_key/all other fields are unchanged",
+        "No row is hard-deleted -- the operation is a reversible status update only"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Post-cleanup acceptance verification",
+      "description": "Verify count(*) FROM strategic_roadmaps WHERE status='active' = 1 (LEO Roadmap only) after the archive. This SD does not re-run a distill pipeline (out of scope -- the single-writer guard from SD-LEO-INFRA-DISTILL-ROADMAP-SINGLE-001 is already shipped and verified separately); it only confirms the DB-state acceptance criterion the SD's own scope names.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "A query confirms exactly 1 active strategic_roadmaps row post-archive",
+        "The active row's id is 3aa2f3e2 (LEO Roadmap)"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Pre-write dependency safety check (no external referrer breaks)",
+      "description": "Before writing, confirm zero rows in roadmap_baseline_snapshots reference either target roadmap id, zero loop_registry rows reference any of their 9 child waves, and zero strategic_directives_v2 rows reference either target id in metadata -- independently verified by the LEAD-TO-PLAN VALIDATION sub-agent pass already, re-confirmed here as an explicit script-level precondition so the archive script itself hard-stops (not just a human eyeballing it beforehand) if a referrer appears between review and execution.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "The archive script queries roadmap_baseline_snapshots, loop_registry, and strategic_directives_v2.metadata for any reference to the 2 target ids or their 9 child wave ids before writing",
+        "If any referrer is found, the script aborts with a clear message and makes zero writes (fail-closed)",
+        "Given the already-verified zero-referrer state, the script proceeds to FR-1's archive step"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "No hard deletes", "description": "strategic_roadmaps is shared governed state; the operation is a status update, never a DELETE, so the change is reversible by a human/coordinator flipping status back." },
+    { "id": "TR-2", "title": "No mutation of roadmap_waves / roadmap_wave_items", "description": "Only the parent strategic_roadmaps.status column changes. Child waves/items under the archived roadmaps are left as-is (already-verified pure intake references, orphaned-but-harmless under an archived parent)." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Pre-archive ground truth matches the SD's stated shape", "type": "unit", "expected": "4 strategic_roadmaps rows with the exact ids/status/vision_key the SD names" },
+    { "id": "TS-2", "scenario": "Archive updates exactly the 2 target rows", "type": "integration", "expected": "a89b078b and 8ffa7fdf become status=archived; 3aa2f3e2 and ed12bf74 unchanged" },
+    { "id": "TS-3", "scenario": "Post-archive active count", "type": "integration", "expected": "count(status=active)=1, id=3aa2f3e2" }
+  ],
+  "acceptance_criteria": [
+    "After cleanup, count(*) FROM strategic_roadmaps WHERE status='active' = 1 (LEO Roadmap only)",
+    "Both draft duplicate rows reversibly archived (status update, not delete)",
+    "Row ed12bf74 and the LEO Roadmap row are provably untouched"
+  ],
+  "risks": [
+    { "risk": "A draft roadmap row is discovered mid-cleanup to hold unique authored content not backed by an intake row", "mitigation": "Already verified pre-EXEC (1080/1080 items pure intake-references, full resolution check by an independent VALIDATION pass, not just a spot-check): the counterfactual does not manifest, so no migration step is needed", "severity": "low" },
+    { "risk": "A live consumer reads strategic_roadmaps.status='draft' rows and would break on archive", "mitigation": "The standing single-writer guard SD already treats status transitions as normal lifecycle; archived rows are the expected terminal state for retired drafts", "severity": "low" },
+    { "risk": "A future re-run of the script (accidental or against a different environment) re-applies the archive update or targets the wrong ids", "mitigation": "The script defaults to a dry-run mode (following the repo's existing scripts/one-off/backfill-roadmap-promote-titles.js precedent) and requires an explicit --apply flag plus a hardcoded, reviewed id allowlist -- never a dynamic WHERE title= match, which could catch an unintended future row", "severity": "low" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["Chairman/Adam roadmap views (LEO Roadmap remains the sole active plan-of-record)"],
+    "dependencies": ["SD-LEO-INFRA-DISTILL-ROADMAP-SINGLE-001 (merged, the standing single-writer guard preventing recurrence)"],
+    "data_contracts": ["strategic_roadmaps.status (existing column, no schema change)"],
+    "runtime_config": ["none"],
+    "observability_rollout": ["One-off DB update via a scripted, session-attributed change; no feature flag needed"]
+  },
+  "system_architecture": {
+    "summary": "Pure data cleanup -- a scoped UPDATE against strategic_roadmaps, no code/schema change.",
+    "components": [
+      { "name": "scripts/one-off/archive-duplicate-roadmaps.mjs", "change": "NEW (one-shot data migration script)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Re-verify ground truth live, run the archive update via a small attributable script, verify the acceptance count.",
+    "steps": [
+      "Re-query strategic_roadmaps + roadmap_waves + roadmap_wave_items to reconfirm ground truth immediately before the write",
+      "UPDATE the 2 target rows to status=archived",
+      "Verify the post-archive active count and row identity"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Query strategic_roadmaps for all 4 rows before the change", "expected_outcome": "Matches the SD's documented ground truth exactly" },
+    { "step_number": 2, "instruction": "Run the archive script", "expected_outcome": "a89b078b and 8ffa7fdf flip to status=archived" },
+    { "step_number": 3, "instruction": "Query count(*) WHERE status=active", "expected_outcome": "Exactly 1, id=3aa2f3e2" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001" }
+}

--- a/scripts/one-off/archive-duplicate-roadmaps.mjs
+++ b/scripts/one-off/archive-duplicate-roadmaps.mjs
@@ -1,0 +1,136 @@
+/**
+ * One-time archive of 2 pre-guard duplicate draft "EVA Intake Roadmap" rows.
+ * SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001.
+ *
+ * Chairman-confirmed 2026-07-17: the LEO Roadmap (3aa2f3e2) is the sole
+ * plan-of-record. These 2 rows are distill-pipeline artifacts created BEFORE
+ * the now-shipped single-writer guard (SD-LEO-INFRA-DISTILL-ROADMAP-SINGLE-001).
+ * Verified (VALIDATION sub-agent, LEAD-TO-PLAN pass): all 1080 roadmap_wave_items
+ * under these 2 roadmaps are pure youtube/todoist intake-table references with
+ * zero unique authored content -- safe to archive without migrating anything.
+ *
+ * Defaults to dry-run (prints the plan, makes ZERO writes). Requires --apply to
+ * write. Hardcoded id allowlist (never a dynamic title= match, so a future
+ * unrelated row titled "EVA Intake Roadmap" can never be caught by accident).
+ * Status update only -- never a DELETE -- so the change is reversible.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+const TARGET_IDS = ['a89b078b-836c-437f-9c40-09fb6b23a41a', '8ffa7fdf-5d67-42a7-b135-2f7200fe9da0'];
+const LEO_ROADMAP_ID = '3aa2f3e2-75fa-4fc8-a17e-44d553b86674';
+
+async function fetchTargetWaveIds(supabase) {
+  const { data, error } = await supabase.from('roadmap_waves').select('id').in('roadmap_id', TARGET_IDS);
+  if (error) throw new Error(`Failed to fetch target wave ids: ${error.message}`);
+  return (data || []).map((r) => r.id);
+}
+
+/**
+ * FR-3: fail-closed precondition -- abort if any external referrer exists.
+ * @returns {Promise<{safe: boolean, reasons: string[]}>}
+ */
+export async function checkReferrers(supabase, waveIds) {
+  const reasons = [];
+
+  const { data: snapshots, error: snapError } = await supabase
+    .from('roadmap_baseline_snapshots')
+    .select('id')
+    .in('roadmap_id', TARGET_IDS);
+  if (snapError) throw new Error(`roadmap_baseline_snapshots check failed: ${snapError.message}`);
+  if (snapshots && snapshots.length > 0) {
+    reasons.push(`${snapshots.length} roadmap_baseline_snapshots row(s) reference a target roadmap id`);
+  }
+
+  if (waveIds.length > 0) {
+    const { data: loops, error: loopError } = await supabase
+      .from('loop_registry')
+      .select('id')
+      .in('roadmap_wave_id', waveIds);
+    if (loopError) throw new Error(`loop_registry check failed: ${loopError.message}`);
+    if (loops && loops.length > 0) {
+      reasons.push(`${loops.length} loop_registry row(s) reference a target wave id`);
+    }
+  }
+
+  // A JSONB-text ilike filter isn't reliably expressible through PostgREST's column-cast
+  // syntax via supabase-js, so pull sd_key+metadata and substring-search client-side --
+  // strategic_directives_v2 is a bounded, low-thousands table, so this is cheap.
+  const { data: allSds, error: sdError } = await supabase.from('strategic_directives_v2').select('sd_key, metadata');
+  if (sdError) throw new Error(`strategic_directives_v2 metadata check failed: ${sdError.message}`);
+  for (const id of TARGET_IDS) {
+    const matches = (allSds || []).filter((sd) => sd.metadata && JSON.stringify(sd.metadata).includes(id));
+    if (matches.length > 0) {
+      reasons.push(`${matches.length} strategic_directives_v2 row(s) reference target id ${id} in metadata: ${matches.map((m) => m.sd_key).join(', ')}`);
+    }
+  }
+
+  return { safe: reasons.length === 0, reasons };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: before, error: beforeError } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, vision_key, created_at')
+    .order('created_at');
+  if (beforeError) {
+    console.error('Failed to load strategic_roadmaps:', beforeError.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`\n=== Roadmap duplicate cleanup (${apply ? 'APPLY' : 'DRY-RUN'}) ===`);
+  console.log('\n--- BEFORE ---');
+  for (const row of before) console.log(`  ${row.id}  ${row.status.padEnd(10)}  ${row.title}`);
+
+  const waveIds = await fetchTargetWaveIds(supabase);
+  const { safe, reasons } = await checkReferrers(supabase, waveIds);
+  if (!safe) {
+    console.log('\n[ABORT] External referrer(s) found -- making ZERO writes:');
+    for (const r of reasons) console.log(`  - ${r}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\n[OK] No external referrers found (roadmap_baseline_snapshots, loop_registry, strategic_directives_v2.metadata all clear).');
+
+  if (!apply) {
+    console.log('\n[DRY-RUN] Would archive:', TARGET_IDS.join(', '));
+    console.log('[DRY-RUN] No writes made. Re-run with --apply to write.');
+    return;
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('strategic_roadmaps')
+    .update({ status: 'archived' })
+    .in('id', TARGET_IDS)
+    .select('id, status');
+  if (updateError) {
+    console.error('Update failed:', updateError.message);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\n[APPLIED]', JSON.stringify(updated));
+
+  const { count: activeCount, error: countError } = await supabase
+    .from('strategic_roadmaps')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'active');
+  if (countError) {
+    console.error('Post-archive verification query failed:', countError.message);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`\n[VERIFY] active count = ${activeCount} (expected 1, id=${LEO_ROADMAP_ID})`);
+  if (activeCount !== 1) {
+    console.error('[VERIFY FAILED] Expected exactly 1 active roadmap.');
+    process.exitCode = 1;
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/tests/unit/roadmap/archive-duplicate-roadmaps.test.js
+++ b/tests/unit/roadmap/archive-duplicate-roadmaps.test.js
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the roadmap duplicate-cleanup referrer check.
+ * SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { checkReferrers } from '../../../scripts/one-off/archive-duplicate-roadmaps.mjs';
+
+const TARGET_IDS = ['a89b078b-836c-437f-9c40-09fb6b23a41a', '8ffa7fdf-5d67-42a7-b135-2f7200fe9da0'];
+const WAVE_IDS = ['wave-1', 'wave-2'];
+
+function makeSupabase({ snapshots = [], loops = [], sds = [] } = {}) {
+  return {
+    from: vi.fn((table) => {
+      if (table === 'roadmap_baseline_snapshots') {
+        return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: snapshots, error: null }) };
+      }
+      if (table === 'loop_registry') {
+        return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: loops, error: null }) };
+      }
+      if (table === 'strategic_directives_v2') {
+        return { select: vi.fn().mockResolvedValue({ data: sds, error: null }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    }),
+  };
+}
+
+describe('checkReferrers (FR-3 fail-closed precondition)', () => {
+  it('TS-1/TS-3 precondition: no referrers -> safe:true, empty reasons', async () => {
+    const supabase = makeSupabase({});
+    const result = await checkReferrers(supabase, WAVE_IDS);
+    expect(result).toEqual({ safe: true, reasons: [] });
+  });
+
+  it('TS-5: a roadmap_baseline_snapshots referrer aborts (safe:false) with zero implied writes', async () => {
+    const supabase = makeSupabase({ snapshots: [{ id: 'snap-1' }] });
+    const result = await checkReferrers(supabase, WAVE_IDS);
+    expect(result.safe).toBe(false);
+    expect(result.reasons[0]).toContain('roadmap_baseline_snapshots');
+  });
+
+  it('TS-5: a loop_registry referrer aborts (safe:false)', async () => {
+    const supabase = makeSupabase({ loops: [{ id: 'loop-1' }] });
+    const result = await checkReferrers(supabase, WAVE_IDS);
+    expect(result.safe).toBe(false);
+    expect(result.reasons[0]).toContain('loop_registry');
+  });
+
+  it('TS-5: a strategic_directives_v2.metadata referrer (target id embedded anywhere in the JSON) aborts', async () => {
+    const supabase = makeSupabase({
+      sds: [{ sd_key: 'SD-SOME-OTHER-001', metadata: { children: [{ related_roadmap: TARGET_IDS[0] }] } }],
+    });
+    const result = await checkReferrers(supabase, WAVE_IDS);
+    expect(result.safe).toBe(false);
+    expect(result.reasons.some((r) => r.includes(TARGET_IDS[0]) && r.includes('SD-SOME-OTHER-001'))).toBe(true);
+  });
+
+  it('an unrelated SD whose metadata does not mention either target id does not trigger an abort', async () => {
+    const supabase = makeSupabase({ sds: [{ sd_key: 'SD-UNRELATED-001', metadata: { note: 'nothing to see here' } }] });
+    const result = await checkReferrers(supabase, WAVE_IDS);
+    expect(result.safe).toBe(true);
+  });
+
+  it('an empty waveIds array skips the loop_registry query entirely (no [].in() call on an empty set)', async () => {
+    const supabase = makeSupabase({});
+    const result = await checkReferrers(supabase, []);
+    expect(result.safe).toBe(true);
+    // loop_registry's .from() is never invoked when waveIds is empty
+    const calledTables = supabase.from.mock.calls.map((c) => c[0]);
+    expect(calledTables).not.toContain('loop_registry');
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman-confirmed 2026-07-17: the LEO Roadmap is the sole plan-of-record; EVA Intake Roadmaps retire
- Archives the 2 draft "EVA Intake Roadmap" rows created by two Solomon /distill runs before the now-shipped single-writer guard (SD-LEO-INFRA-DISTILL-ROADMAP-SINGLE-001)
- Verified independently twice (worker + VALIDATION sub-agent) before writing: all 1080 `roadmap_wave_items` under these 2 roadmaps are pure youtube/todoist intake-table references, zero unique authored content, zero external referrers in `roadmap_baseline_snapshots`/`loop_registry`/`strategic_directives_v2.metadata`
- Reversible status update only (never DELETE), dry-run default, hardcoded id allowlist, fail-closed referrer precondition built into the script

## Review trail
- LEAD-TO-PLAN VALIDATION: PASS 95/100 — full-resolution referrer/content check (stronger than the PRD's own spot-check claim)
- PLAN-TO-EXEC TESTING: PASS 92/100 — added 2 test scenarios (dry-run zero-writes, fail-closed abort-on-referrer)
- EXEC-TO-PLAN TESTING: PASS 95/100 — re-verified live DB state matches the script exactly
- EXEC-TO-PLAN SECURITY: PASS 95/100 — no injection risk, allowlist non-bypassable, reversibility sufficient

## Test plan
- [x] `tests/unit/roadmap/archive-duplicate-roadmaps.test.js` — 6 tests covering the fail-closed referrer precondition
- [x] Full `tests/unit/roadmap/` suite: 48 tests, 0 failures (includes the exactly-one-active-roadmap invariant test, unaffected since target rows were already draft)
- [x] Script run against the live DB with `--apply`; verified active count = 1 (LEO Roadmap only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)