### PR TITLE
feat(SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001): encode always-sweep in design-of-record; resolver reads DoR policy not the stale pin

### DIFF
--- a/scripts/one-off/set-solomon-sweep-policy-always.mjs
+++ b/scripts/one-off/set-solomon-sweep-policy-always.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// @wire-check-exempt one-shot DB annotation (lives under scripts/one-off/, the recognized one-shot home).
+//
+// SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001 (FR-1a): encode the chairman-ratified ALWAYS-SWEEP
+// policy as a MACHINE-READABLE field on Solomon's design-of-record row (leo_protocol_sections
+// id=611, section_type=solomon_role_contract). This is the authoritative slot the sweep-mode
+// resolver (scripts/solomon-startup-check.mjs :: resolveSolomonSweepMode) reads.
+//
+// TARGETED read-merge-write (NOT a generic re-seed): SELECT the row's current metadata, spread it,
+// set sweep_policy + provenance, UPDATE only id=611. The seed script
+// (scripts/one-off/_seed-solomon-role-contract.mjs) writes only content/title/target_file/order_index
+// and NEVER touches metadata — so metadata.sweep_policy is a re-seed-safe slot and survives a future
+// content re-seed. No migration: existing row + existing metadata JSONB column.
+//
+// Idempotent: re-running merges the same keys onto whatever metadata is present.
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+const ROW_ID = 611;
+const PROVENANCE = 'SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001; chairman-ratified';
+const DIVERGENCE_NOTE =
+  'always-sweep is the design-of-record policy — do NOT re-derive Solomon sweep mode from the ' +
+  'configured model pin. getClaudeModel(\'solomon\') resolves the CONFIGURED pin (claude-opus-4-8), ' +
+  'NOT the live serving model; a /model switch never reaches the resolver and a returning Fable pin ' +
+  'does not auto-revert. The resolver reads this metadata.sweep_policy as authoritative.';
+
+const sb = createSupabaseServiceClient();
+
+const { data: row, error: readErr } = await sb
+  .from('leo_protocol_sections')
+  .select('id, section_type, metadata')
+  .eq('id', ROW_ID)
+  .single();
+if (readErr || !row) {
+  console.error(`Could not read leo_protocol_sections id=${ROW_ID}:`, readErr?.message);
+  process.exit(1);
+}
+if (row.section_type !== 'solomon_role_contract') {
+  console.error(`Row id=${ROW_ID} is section_type='${row.section_type}', expected 'solomon_role_contract' — aborting (design-of-record row moved).`);
+  process.exit(1);
+}
+
+const merged = {
+  ...(row.metadata && typeof row.metadata === 'object' ? row.metadata : {}),
+  sweep_policy: 'always',
+  sweep_policy_provenance: PROVENANCE,
+  sweep_policy_note: DIVERGENCE_NOTE,
+};
+
+const { error: writeErr } = await sb
+  .from('leo_protocol_sections')
+  .update({ metadata: merged })
+  .eq('id', ROW_ID);
+if (writeErr) {
+  console.error('UPDATE ERR:', writeErr.message);
+  process.exit(1);
+}
+
+const { data: verify } = await sb
+  .from('leo_protocol_sections')
+  .select('id, section_type, metadata')
+  .eq('id', ROW_ID)
+  .single();
+console.log(`OK — id=${verify.id} section_type=${verify.section_type} metadata.sweep_policy=${JSON.stringify(verify.metadata?.sweep_policy)}`);
+console.log('full metadata:', JSON.stringify(verify.metadata));
+if (verify.metadata?.sweep_policy !== 'always') {
+  console.error('POST-WRITE CHECK FAILED: metadata.sweep_policy is not "always".');
+  process.exit(1);
+}

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -19,6 +19,9 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { getClaudeModel } from '../lib/config/model-config.js';
+// SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001: the sweep-mode resolver reads the design-of-record
+// policy (leo_protocol_sections id=611 metadata.sweep_policy) via the canonical service-role client.
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 // SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001: Solomon previously had NO checkout-freshness
 // check at all (Adam and the coordinator already did) — this closes that gap.
 import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
@@ -46,6 +49,63 @@ export function solomonSweepMode(pin = getClaudeModel('solomon'), env = process.
 
 export function isProactiveSweepEnabled(pin = getClaudeModel('solomon'), env = process.env) {
   return solomonSweepMode(pin, env) === 'proactive';
+}
+
+// SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001: the DESIGN-OF-RECORD row for Solomon's sweep policy.
+// The pin-derivation above (solomonSweepMode) is a STALE-PIN gauge: getClaudeModel('solomon') resolves
+// the CONFIGURED pin (claude-opus-4-8), NOT the live serving model — so a live Fable-5 session with the
+// opus pin resolves 'consult', a /model switch never reaches the resolver, and a returning Fable pin
+// does NOT auto-revert. The chairman-ratified ALWAYS-SWEEP policy is therefore encoded authoritatively
+// as leo_protocol_sections id=611 metadata.sweep_policy='always' (a re-seed-safe metadata slot — the
+// content seed never touches metadata). resolveSolomonSweepMode() below reads that policy as the
+// authoritative source and DEMOTES the pin-derivation to a fail-safe fallback. Do NOT re-introduce
+// pure pin-derivation for the live path.
+const SWEEP_POLICY_ROW_ID = 611;
+
+/**
+ * Read the design-of-record sweep policy: leo_protocol_sections id=611 metadata.sweep_policy.
+ * Returns the policy string (e.g. 'always') or null. FAIL-SOFT: any read error → null (never throws),
+ * so the caller can fall back to the legacy pin-derivation. An optional client may be injected (tests);
+ * otherwise the canonical service-role client is used.
+ * @param {import('@supabase/supabase-js').SupabaseClient} [client]
+ * @returns {Promise<string|null>}
+ */
+export async function getSolomonSweepPolicy(client) {
+  try {
+    const sb = client || createSupabaseServiceClient();
+    const { data, error } = await sb
+      .from('leo_protocol_sections')
+      .select('metadata')
+      .eq('id', SWEEP_POLICY_ROW_ID)
+      .single();
+    if (error) return null;
+    const policy = data?.metadata?.sweep_policy;
+    return typeof policy === 'string' ? policy : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * AUTHORITATIVE sweep-mode resolver (async — reads the design-of-record at tick time). Precedence:
+ *   (1) SOLOMON_SWEEP_MODE env override ('proactive'|'consult') → return it (unchanged escape hatch);
+ *   (2) design-of-record policy === 'always' → 'proactive', REGARDLESS of pin / live model / /model switch;
+ *   (3) else (policy unset OR DB-read failure) → FAIL-SAFE to the legacy sync solomonSweepMode(pin, env).
+ * Never throws (getSolomonSweepPolicy is fail-soft) — safe to call from the fail-open deep-sweep tick.
+ * @param {{env?: object, pin?: string, client?: import('@supabase/supabase-js').SupabaseClient}} [opts]
+ * @returns {Promise<'proactive'|'consult'>}
+ */
+export async function resolveSolomonSweepMode({ env = process.env, pin = getClaudeModel('solomon'), client } = {}) {
+  const override = String(env.SOLOMON_SWEEP_MODE || '').trim().toLowerCase();
+  if (override === 'proactive' || override === 'consult') return override;
+  const policy = await getSolomonSweepPolicy(client);
+  if (policy === 'always') return 'proactive';
+  return solomonSweepMode(pin, env);
+}
+
+/** Async authoritative variant of isProactiveSweepEnabled — delegates to resolveSolomonSweepMode. */
+export async function resolveIsProactiveSweepEnabled(opts = {}) {
+  return (await resolveSolomonSweepMode(opts)) === 'proactive';
 }
 
 // The Solomon role contract (durable). Loaded on /solomon startup; referenced here for the summary.
@@ -119,10 +179,12 @@ export const SOLOMON_LOOPS = [
     label: 'Solomon Mode-B deep-reasoning sweep (agent judgment; HARD task_budget at entry, before any Read/Grep)',
     script: null, // agent-prompt tick — the deep sweep is reasoning, not a script
     cron: '0 */6 * * *',
-    // SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: the tick resolves its MODE at tick time from the
-    // LIVE Solomon pin (solomonSweepMode). Fable pin -> proactive backlog sweep; else -> consult-only
-    // (today's behavior). Mode-B activation is coupled to the Fable-5 pin swap, not the §11 ledger.
-    prompt: 'Solomon deep-sweep tick: (1) FIRST enforce the per-sweep task_budget at ENTRY (node -e require("./scripts/solomon-advisory.cjs").enforceSweepBudget — count/wall-clock/token) BEFORE any Read/Grep; if over budget, STOP. (2) Resolve the sweep MODE at TICK TIME from the LIVE Solomon model pin and log it: node -e "import(\'./scripts/solomon-startup-check.mjs\').then(m=>process.stdout.write(m.solomonSweepMode()))". (3a) If mode===proactive (Fable pin — SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001): pull ONE §4 backlog item, investigate the LIVE codebase with deep analysis, and surface EXACTLY ONE propose-only finding via node scripts/solomon-advisory.cjs send "<finding>" (dedup + quota + silence-by-default enforced). (3b) Else (consult mode, default): drain the consult inbox and answer the highest-value open solomon_consult with deep analysis via node scripts/solomon-advisory.cjs send "<answer>" --reply-to <consult-correlation> (dedup + quota enforced). Propose, NEVER execute/build in either mode (CONST-002).',
+    // SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001 + SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001:
+    // the tick resolves its MODE at tick time via resolveSolomonSweepMode — which reads the DESIGN-OF-RECORD
+    // policy (leo_protocol_sections id=611 metadata.sweep_policy) as authoritative (always -> proactive,
+    // REGARDLESS of the configured pin / live model / a /model switch), env override still wins, and it
+    // fail-safes to the legacy pin-derivation when the policy is unset or the DB read fails.
+    prompt: 'Solomon deep-sweep tick: (1) FIRST enforce the per-sweep task_budget at ENTRY (node -e require("./scripts/solomon-advisory.cjs").enforceSweepBudget — count/wall-clock/token) BEFORE any Read/Grep; if over budget, STOP. (2) Resolve the sweep MODE at TICK TIME from the DESIGN-OF-RECORD policy (fail-safe to the live pin) and log it: node -e "import(\'./scripts/solomon-startup-check.mjs\').then(m=>m.resolveSolomonSweepMode()).then(x=>process.stdout.write(x))". (3a) If mode===proactive (always-sweep policy of record, or a Fable pin fallback): pull ONE §4 backlog item, investigate the LIVE codebase with deep analysis, and surface EXACTLY ONE propose-only finding via node scripts/solomon-advisory.cjs send "<finding>" (dedup + quota + silence-by-default enforced). (3b) Else (consult mode, default): drain the consult inbox and answer the highest-value open solomon_consult with deep analysis via node scripts/solomon-advisory.cjs send "<answer>" --reply-to <consult-correlation> (dedup + quota enforced). Propose, NEVER execute/build in either mode (CONST-002).',
   },
 ];
 

--- a/tests/unit/solomon-startup-check.test.js
+++ b/tests/unit/solomon-startup-check.test.js
@@ -10,6 +10,7 @@ import {
   SOLOMON_LOOPS, ROLE_CONTEXT_DOC, parseDurableDutyMarkers, missingDurableDuties,
   loopStatus, parseArmedSet, renderContractParity, slugifyDuty, wiredDutySlugs,
   solomonSweepMode, isProactiveSweepEnabled,
+  resolveSolomonSweepMode, getSolomonSweepPolicy, resolveIsProactiveSweepEnabled,
   renderFreshness, buildReport, SOLOMON_CRITICAL_PATHS,
 } from '../../scripts/solomon-startup-check.mjs';
 import { buildSelfAdherenceVerdict } from '../../scripts/solomon-self-adherence-review.mjs';
@@ -160,6 +161,82 @@ describe('SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: solomonSweepMode Fab
     expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'consult' })).toBe('consult');
     expect(solomonSweepMode('claude-opus-4-8', { SOLOMON_SWEEP_MODE: 'PROACTIVE' })).toBe('proactive'); // case-insensitive
     expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'garbage' })).toBe('proactive'); // invalid override ignored
+  });
+});
+
+// SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001: the authoritative resolver reads the design-of-record
+// policy (leo_protocol_sections id=611 metadata.sweep_policy) and DEMOTES the pin-derivation to a
+// fail-safe fallback — fixing the verified bug where a live Fable-5 session with the configured opus pin
+// resolved 'consult' because getClaudeModel('solomon') reads the pin, not the live serving model.
+describe('SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001: resolveSolomonSweepMode (design-of-record authoritative)', () => {
+  const noEnv = {}; // isolate from the ambient process.env override
+
+  // Stub the supabase client's .from(id).select().eq().single() chain.
+  //   policy: the metadata.sweep_policy value to return (undefined → metadata {} i.e. policy unset)
+  //   throws: if set, the client throws on read (simulates DB unreachable)
+  function stubClient({ policy, throws = false } = {}) {
+    return {
+      from() {
+        if (throws) throw new Error('DB unreachable');
+        const metadata = policy === undefined ? {} : { sweep_policy: policy };
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: { metadata }, error: null }),
+            }),
+          }),
+        };
+      },
+    };
+  }
+
+  it('TS-1 (core fix): policy=always → proactive EVEN with the opus pin + empty env (pin no longer forces consult)', async () => {
+    const client = stubClient({ policy: 'always' });
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: 'claude-opus-4-8', client })).toBe('proactive');
+    // and the async proactive helper agrees
+    expect(await resolveIsProactiveSweepEnabled({ env: noEnv, pin: 'claude-opus-4-8', client })).toBe(true);
+  });
+
+  it('TS-2: a /model switch / different pin does NOT flip it away from always-sweep when policy=always', async () => {
+    const client = stubClient({ policy: 'always' });
+    // pin stays opus (a /model switch never reaches the resolver) — still proactive
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: 'claude-opus-4-8', client })).toBe('proactive');
+    // an unrelated pin (sonnet) — policy still wins, still proactive
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: 'claude-sonnet-5', client })).toBe('proactive');
+    // an empty/undefined pin — policy still wins
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: '', client })).toBe('proactive');
+  });
+
+  it('TS-5: SOLOMON_SWEEP_MODE env override still wins (precedence 1) even when policy=always', async () => {
+    const client = stubClient({ policy: 'always' });
+    expect(await resolveSolomonSweepMode({ env: { SOLOMON_SWEEP_MODE: 'consult' }, pin: 'claude-fable-5', client })).toBe('consult');
+    expect(await resolveSolomonSweepMode({ env: { SOLOMON_SWEEP_MODE: 'proactive' }, pin: 'claude-opus-4-8', client })).toBe('proactive');
+  });
+
+  it('TS-3: policy UNSET (null) → falls back to legacy pin-derivation (fable→proactive, opus→consult)', async () => {
+    const client = stubClient({ policy: undefined }); // metadata {} → getSolomonSweepPolicy returns null
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: 'claude-fable-5', client })).toBe('proactive');
+    expect(await resolveSolomonSweepMode({ env: noEnv, pin: 'claude-opus-4-8', client })).toBe('consult');
+  });
+
+  it('TS-4 (fail-safe): DB-read failure (client throws) → falls back to legacy, never throws', async () => {
+    const client = stubClient({ throws: true });
+    await expect(resolveSolomonSweepMode({ env: noEnv, pin: 'claude-fable-5', client })).resolves.toBe('proactive');
+    await expect(resolveSolomonSweepMode({ env: noEnv, pin: 'claude-opus-4-8', client })).resolves.toBe('consult');
+    // getSolomonSweepPolicy itself is fail-soft (returns null, never throws)
+    expect(await getSolomonSweepPolicy(client)).toBe(null);
+  });
+
+  it('getSolomonSweepPolicy returns the policy string from row 611 metadata', async () => {
+    expect(await getSolomonSweepPolicy(stubClient({ policy: 'always' }))).toBe('always');
+    expect(await getSolomonSweepPolicy(stubClient({ policy: undefined }))).toBe(null);
+  });
+
+  it('TS-6: the legacy sync solomonSweepMode is UNCHANGED (pin-derivation preserved)', () => {
+    // guarded here too so a resolver refactor cannot silently alter the sync fallback contract
+    expect(solomonSweepMode('claude-fable-5', noEnv)).toBe('proactive');
+    expect(solomonSweepMode('claude-opus-4-8', noEnv)).toBe('consult');
+    expect(solomonSweepMode('claude-opus-4-8', { SOLOMON_SWEEP_MODE: 'proactive' })).toBe('proactive');
   });
 });
 


### PR DESCRIPTION
## SD-LEO-INFRA-ALWAYS-SWEEP-DESIGN-OF-RECORD-001

**Bug:** `scripts/solomon-startup-check.mjs solomonSweepMode()` derived Solomon's sweep mode from the **configured pin** (`getClaudeModel('solomon')` → `claude-opus-4-8`), not the **live serving model** — so it returned `consult` while live-serving Fable-5, a `/model` switch never reached the resolver, and it never auto-reverted. The chairman-ratified always-sweep override was load-bearing in every state.

### Fix (~211 LOC incl. tests; **no migration**)
- **FR-1** — encoded `metadata.sweep_policy='always'` on the design-of-record row `leo_protocol_sections id=611` (`solomon_role_contract`) via a **targeted read-merge-write** one-off (`scripts/one-off/set-solomon-sweep-policy-always.mjs`). The 52,919-char curated doctrine content is left **intact** — `metadata` is a re-seed-safe slot the content seed never touches (no generic re-seed).
- **FR-2** — `scripts/solomon-startup-check.mjs`: added `getSolomonSweepPolicy(client)` (fail-soft, DB error → `null`) + `resolveSolomonSweepMode({env,pin,client})` with precedence: (1) `SOLOMON_SWEEP_MODE` env override (unchanged), (2) DoR policy `'always'` → `'proactive'` **regardless of pin / live model / a /model switch**, (3) **fail-safe** to the byte-identical legacy `solomonSweepMode(pin,env)`. Rewired the deep-sweep tick to resolve mode **at tick time** so a mid-session pin swap can't bypass it.

### Verification
- Reviews (sub_agent_execution_results): **TESTING 93, VALIDATION 90, REGRESSION 96**.
- **28 tests** + an importer suite (8) green. **Live-DB before/after proof:** `resolveSolomonSweepMode({pin:'claude-opus-4-8', env:{}})` → `proactive` (**fixed**) vs legacy `solomonSweepMode('claude-opus-4-8')` → `consult` (old bug).
- Additive + backward-compatible: legacy `solomonSweepMode` byte-identical; the fail-safe path collapses to exactly the legacy result when the policy/DB is absent. No migration.
- Non-blocking follow-ups (documentation-only): the authoring doc `docs/architecture/solomon-agent-definition.md` doesn't exist in git (FR-1b prose recorded as metadata + a code comment); surface the policy in row-611 content so the `CLAUDE_SOLOMON.md` mirror shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)