### PR TITLE
feat(SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B): wire Stage-0 dataFeed into tech-trajectory

### DIFF
--- a/.prd-payloads/PLAN-SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B.json
+++ b/.prd-payloads/PLAN-SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B.json
@@ -1,0 +1,171 @@
+{
+  "executive_summary": "Stage-0 synthesis component tech-trajectory.js has an async dataFeed.getTechSignals() hook (lib/eva/stage-zero/synthesis/tech-trajectory.js:41-47) that has never been fed: no caller anywhere constructs a dataFeed object, so every venture's technology-trajectory analysis runs on a training-data-only fallback with the hardcoded caveat 'Framework-informed projections based on training data. Not real-time signals.'. The plumbing is already faithful end-to-end -- runSynthesis (synthesis/index.js:133) forwards deps untouched to analyzeTechTrajectory, and its sole production caller executeStageZero (stage-zero-orchestrator.js:65,106) spreads deps into enrichedDeps. This child closes the 'nobody constructed the object' gap by adding a new module lib/eva/stage-zero/data-feed.js whose getTechSignals() reads Child A's standing table research_intelligence_reference (is_current tech_landscape/model_landscape rows), and by constructing+injecting that dataFeed at the single injection site in executeStageZero. Verified via unit tests with a mock supabase client and an orchestrator wiring assertion; an audit of all 14 synthesis components confirms tech-trajectory is the only starved dataFeed hook, so no other component is wired. Additive and non-breaking; tech-trajectory's own analysis logic and prompt are unchanged.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Stage-0 dataFeed module backed by the standing reference table",
+      "description": "Add lib/eva/stage-zero/data-feed.js exporting createStageZeroDataFeed(supabase, { logger } = {}). It returns an object exposing async getTechSignals() that reads Child A's standing table research_intelligence_reference (database/migrations/20260718_research_intelligence_reference.sql) filtering entry_type IN ('tech_landscape','model_landscape') AND is_current = true, and maps each row to a compact signal { subject, entry_type, confidence, version, payload, source_refs }. Honest-idle: if supabase is missing, the query errors, or zero current rows are returned, getTechSignals() resolves to null and NEVER fabricates a signal -- preserving tech-trajectory.js's existing training-data-only fallback (signalContext stays empty). The returned shape matches the existing consumption contract at tech-trajectory.js:47 which JSON.stringifies the value into the LLM prompt when truthy.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "createStageZeroDataFeed(supabase) returns an object with typeof feed.getTechSignals === 'function'",
+        "getTechSignals() queries research_intelligence_reference with entry_type IN ('tech_landscape','model_landscape') and is_current filter",
+        "Rows present -> resolves to a non-empty array of compact signal objects each carrying subject + entry_type + payload + source_refs",
+        "Zero rows, a supabase error, or a null client -> resolves to null (honest-idle, no throw, no fabricated signal)"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Construct and inject the dataFeed at the single Stage-0 injection site",
+      "description": "In lib/eva/stage-zero/stage-zero-orchestrator.js executeStageZero, construct the dataFeed once and thread it through enrichedDeps so it reaches synthesis. At the enrichedDeps assignment (currently line 65: `const enrichedDeps = { ...deps, strategicContext };`), set dataFeed = deps.dataFeed || (supabase ? createStageZeroDataFeed(supabase, { logger }) : null) and include it: `const enrichedDeps = { ...deps, strategicContext, dataFeed };`. A caller-provided deps.dataFeed (e.g. a test double) always wins; when only supabase is present, this is the FIRST place in the codebase that ever constructs the dataFeed object. enrichedDeps already flows to runSynthesis (line 106) which forwards it to analyzeTechTrajectory, so tech-trajectory begins receiving live signals with no change to its own code.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "executeStageZero constructs dataFeed from deps.supabase when deps.dataFeed is not supplied",
+        "A caller-supplied deps.dataFeed is preserved (not overwritten)",
+        "enrichedDeps includes dataFeed and is the object passed to runSynthesis, so analyzeTechTrajectory receives a non-null deps.dataFeed",
+        "skipSynthesis and dryRun paths are unaffected (no new required behavior on those branches)"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Audit all 14 synthesis components for the same unfed-hook pattern",
+      "description": "Audit every component orchestrated by runSynthesis (synthesis/index.js) -- agentic-fit, archetype-mapping, archetypes, attention-capital, build-cost-estimation, chairman-constraints, cross-reference, design-evaluation, mental-model-analysis, moat-architecture, narrative-risk, portfolio-evaluation, time-horizon, virality, and tech-trajectory -- for a dataFeed-shaped external-signal injection hook that is declared-but-never-fed. A codebase-wide grep for dataFeed/getTechSignals confirms the pattern exists ONLY in tech-trajectory.js. Conclusion recorded here in the PRD: tech-trajectory is the sole consumer; no other synthesis component has an analogous starved hook, so no additional wiring is performed (per the parent SD's 'or documents that none exist').",
+      "priority": "high",
+      "acceptance_criteria": [
+        "grep of lib/eva/stage-zero/synthesis/ shows dataFeed and getTechSignals appear only in tech-trajectory.js",
+        "PRD documents that the other 13 components have no analogous unfed external-signal hook and therefore require no wiring"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Unit tests: honest-idle read path and orchestrator wiring",
+      "description": "Add tests/unit/eva/stage-zero/data-feed.test.js using a hand-rolled mock supabase client (mirroring the from().select().eq()/chained-query pattern used by sibling stage-zero tests) that asserts: (a) getTechSignals() maps returned tech_landscape/model_landscape rows to compact signals, (b) an empty result resolves to null, (c) a query error resolves to null (no throw), (d) the query targets research_intelligence_reference with the is_current + entry_type filter. Add an orchestrator wiring assertion (extend or add a stage-zero-orchestrator test) proving executeStageZero passes a constructed dataFeed into the synthesize function and that a caller-provided deps.dataFeed is preserved. Tests are deterministic and require no live DB.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "data-feed test covers rows-present, empty-result, and error paths with a mock supabase client",
+        "wiring test asserts the synthesize function receives deps.dataFeed !== null when supabase is present",
+        "wiring test asserts a caller-supplied deps.dataFeed is used unchanged",
+        "New tests pass under npx vitest run and require no live database"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Additive and non-breaking",
+      "description": "One new module (data-feed.js) plus one additive change to the enrichedDeps line in stage-zero-orchestrator.js. No change to tech-trajectory.js analysis logic or its LLM prompt (out of scope). No schema change -- read-only consumer of Child A's existing research_intelligence_reference table."
+    },
+    {
+      "id": "TR-2",
+      "title": "Honest-idle read semantics",
+      "description": "getTechSignals() must fail closed to null (never throw, never fabricate) on missing client / query error / zero rows, so the tech-trajectory fallback path is preserved exactly when no live signals exist. Read path uses the is_current filter to honor the one-current-version-per-(entry_type,subject) invariant enforced by Child A's partial unique index."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "getTechSignals maps current tech_landscape/model_landscape rows to compact signals",
+      "type": "unit",
+      "expected": "Returns an array of { subject, entry_type, confidence, version, payload, source_refs } for the mock rows"
+    },
+    {
+      "id": "TS-2",
+      "scenario": "getTechSignals is honest-idle on empty result",
+      "type": "unit",
+      "expected": "Resolves to null (not [] and not a fabricated signal) so tech-trajectory keeps its training-data-only fallback"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "getTechSignals fails closed on supabase error or missing client",
+      "type": "unit",
+      "expected": "Resolves to null without throwing"
+    },
+    {
+      "id": "TS-4",
+      "scenario": "executeStageZero constructs and injects the dataFeed into synthesis",
+      "type": "unit",
+      "expected": "The synthesize function receives deps.dataFeed !== null when supabase is present; analyzeTechTrajectory would report data_feed_active true"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "Caller-provided deps.dataFeed is preserved",
+      "type": "unit",
+      "expected": "executeStageZero does not overwrite an injected deps.dataFeed (test double wins)"
+    }
+  ],
+  "acceptance_criteria": [
+    "New data-feed.js module reads Child A's research_intelligence_reference (is_current tech_landscape/model_landscape) and is honest-idle (null on empty/error)",
+    "executeStageZero constructs+injects the dataFeed at the single injection site; analyzeTechTrajectory receives it for the first time",
+    "Audit records tech-trajectory as the sole starved dataFeed hook among the 14 synthesis components",
+    "Unit tests (mock supabase + orchestrator wiring) pass; ESLint clean; no new regressions vs the live-DB baseline"
+  ],
+  "risks": [
+    {
+      "risk": "Injecting an empty/fabricated signal block would change tech-trajectory output when no live data exists",
+      "mitigation": "getTechSignals returns null (not []) on empty/error so signalContext stays empty and the existing fallback is preserved byte-for-byte",
+      "severity": "medium"
+    },
+    {
+      "risk": "Overwriting a caller-supplied deps.dataFeed would break test overrides and future callers",
+      "mitigation": "Construction is `deps.dataFeed || (supabase ? createStageZeroDataFeed(...) : null)` -- caller value always wins",
+      "severity": "low"
+    },
+    {
+      "risk": "Reading non-current rows would violate the single-current-version invariant",
+      "mitigation": "Query filters is_current = true, matching Child A's partial unique index on (entry_type, subject) WHERE is_current",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "lib/eva/stage-zero/synthesis/tech-trajectory.js analyzeTechTrajectory() -- calls deps.dataFeed.getTechSignals() (line 47) and stamps data_feed_active (line 147)",
+      "lib/eva/stage-zero/synthesis/index.js runSynthesis() -- forwards enrichedDeps (including dataFeed) to all synthesis components",
+      "lib/eva/stage-zero/stage-zero-orchestrator.js executeStageZero() -- the injection site that constructs the dataFeed and owns enrichedDeps"
+    ],
+    "dependencies": [
+      "UPSTREAM: Child A (SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-A) standing table research_intelligence_reference + migration 20260718_research_intelligence_reference.sql -- the data source getTechSignals reads",
+      "UPSTREAM: deps.supabase (service-role client) provided to executeStageZero -- required to construct a live dataFeed; absent -> dataFeed is null and fallback is used",
+      "PEER (not touched): Child C reads market_size/unit_economics/comparables from the same table via modeling.js; Child D reads superseded rows -- out of scope here"
+    ],
+    "data_contracts": [
+      "READ-ONLY of research_intelligence_reference: id, entry_type, subject, payload (jsonb), source_refs (jsonb), confidence, version, is_current (all existing columns from Child A's migration -- no new columns, no ALTER)",
+      "Filter contract: entry_type IN ('tech_landscape','model_landscape') AND is_current = true",
+      "getTechSignals() output contract: null OR Array<{ subject, entry_type, confidence, version, payload, source_refs }> (consumed by tech-trajectory via JSON.stringify)"
+    ],
+    "runtime_config": [
+      "No new env vars or feature flags. Behavior is data-gated: with zero current tech_landscape/model_landscape rows the feed is null and Stage-0 behavior is identical to today.",
+      "Requires SUPABASE service-role credentials already present for Stage-0 (deps.supabase) -- no additional configuration."
+    ],
+    "observability_rollout": [
+      "Observability: tech-trajectory result already carries data_feed_active (true once a live feed with signals is injected) -- observable in synthesis output/metadata per venture run",
+      "Rollout: additive and inert until Child A's operator writes tech_landscape/model_landscape rows (operator ships defined-but-unarmed), so this can merge safely ahead of live data",
+      "Rollback: revert the single enrichedDeps line (or pass deps.dataFeed=null) to restore the training-data-only fallback; the new module is otherwise unreferenced"
+    ]
+  },
+  "system_architecture": {
+    "summary": "One new read-only data-feed module + one additive injection line thread Child A's standing reference into the long-dormant tech-trajectory hook.",
+    "components": [
+      { "name": "lib/eva/stage-zero/data-feed.js", "change": "NEW: createStageZeroDataFeed(supabase) with honest-idle getTechSignals() reading research_intelligence_reference" },
+      { "name": "lib/eva/stage-zero/stage-zero-orchestrator.js", "change": "Additive: construct dataFeed and include it in enrichedDeps (single line at the enrichedDeps assignment)" },
+      { "name": "tests/unit/eva/stage-zero/data-feed.test.js", "change": "NEW: mock-supabase unit tests for the read path + honest-idle" },
+      { "name": "tests/unit/eva/stage-zero/stage-zero-orchestrator-datafeed.test.js", "change": "NEW: orchestrator wiring assertion (dataFeed constructed + injected, caller override preserved)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the read-only feed, inject it at the single production entry point, prove it with mock-supabase unit tests, audit the rest.",
+    "steps": [
+      "Create lib/eva/stage-zero/data-feed.js: createStageZeroDataFeed(supabase,{logger}) -> { getTechSignals() } reading is_current tech_landscape/model_landscape rows, null on empty/error",
+      "Edit stage-zero-orchestrator.js enrichedDeps line to construct+include dataFeed (caller override wins)",
+      "Add data-feed.test.js (rows/empty/error) + orchestrator wiring test with mock supabase / mock synthesize",
+      "Run ESLint on touched files, targeted vitest, then full regression scan; confirm zero new failures overlap touched modules",
+      "Record the 14-component audit result (tech-trajectory is the sole hook) in this PRD"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "npx vitest run tests/unit/eva/stage-zero/data-feed.test.js", "expected_outcome": "Rows-present maps to signals; empty result and error both resolve to null; suite passes" },
+    { "step_number": 2, "instruction": "npx vitest run tests/unit/eva/stage-zero/stage-zero-orchestrator-datafeed.test.js", "expected_outcome": "executeStageZero passes a non-null dataFeed into synthesize when supabase is present, and preserves a caller-supplied deps.dataFeed" },
+    { "step_number": 3, "instruction": "npx vitest run --reporter=dot and grep the failed-file list for data-feed / stage-zero-orchestrator / tech-trajectory", "expected_outcome": "No new failing files attributable to touched modules vs the pre-existing live-DB baseline" }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B"
+  }
+}

--- a/.prd-payloads/explore-evidence-B.json
+++ b/.prd-payloads/explore-evidence-B.json
@@ -1,0 +1,52 @@
+{
+  "status": "PASS",
+  "verdict": "PASS",
+  "confidence": 95,
+  "confidence_score": 95,
+  "summary": "Explore of the Stage-0 dataFeed wiring gap for SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B. Confirmed the consumption hook, traced the full call chain to the single production entry point, verified Child A's shipped standing-reference table/module contract, and audited all 14 synthesis components for the same unfed-hook pattern.",
+  "findings": [
+    {
+      "area": "consumption contract",
+      "file": "lib/eva/stage-zero/synthesis/tech-trajectory.js",
+      "lines": "41-47,147",
+      "detail": "analyzeTechTrajectory(pathOutput, deps={}) destructures deps.dataFeed=null and calls `const externalSignals = dataFeed ? await dataFeed.getTechSignals() : null` (line 47). externalSignals is JSON.stringified into the LLM prompt as signalContext; data_feed_active mirrors dataFeed!==null (line 147). Contract: dataFeed exposes async getTechSignals()."
+    },
+    {
+      "area": "call chain",
+      "file": "lib/eva/stage-zero/synthesis/index.js",
+      "lines": "84,133",
+      "detail": "runSynthesis(pathOutput, deps={}) forwards the whole deps object untouched to analyzeTechTrajectory(pathOutput, deps) inside the Promise.all (line 133). No dataFeed is added or stripped."
+    },
+    {
+      "area": "production entry point / injection site",
+      "file": "lib/eva/stage-zero/stage-zero-orchestrator.js",
+      "lines": "40,64-65,106",
+      "detail": "executeStageZero(params, deps={}) is the sole production caller of runSynthesis. It builds `enrichedDeps = { ...deps, strategicContext }` (line 65) and passes enrichedDeps to synthesizeFn (line 106). deps.dataFeed is never set by any caller -> the hook is permanently null. THIS (line 65) is the correct, minimal injection point: construct dataFeed from deps.supabase here."
+    },
+    {
+      "area": "dataFeed construction audit",
+      "file": "codebase-wide grep",
+      "detail": "grep for dataFeed/getTechSignals across lib/ and scripts/ finds references ONLY in tech-trajectory.js. No dataFeed object is constructed anywhere -> this is a greenfield construction within an existing hook, not a broken-wiring bug."
+    },
+    {
+      "area": "Child A dependency (standing reference table)",
+      "file": "database/migrations/20260718_research_intelligence_reference.sql",
+      "detail": "Child A shipped table research_intelligence_reference (id, entry_type CHECK in tech_landscape/model_landscape/market_size/unit_economics/comparables, subject, payload jsonb, source_refs jsonb, confidence, version, is_current, superseded_by, created_by, created_at, updated_at) with RLS + partial unique index on (entry_type,subject) WHERE is_current. Child B reads entry_type IN ('tech_landscape','model_landscape') AND is_current."
+    },
+    {
+      "area": "Child A operator module (reuse candidate)",
+      "file": "lib/agents/research-intelligence-operator.js",
+      "detail": "Exports REFERENCE_ENTRY_TYPES, buildReferenceEntry, ingestAcceptedSignals, etc. Provides the row shape / entry_type vocabulary Child B's data-feed reads back. Child B is a read-only consumer of this table; it does not write."
+    },
+    {
+      "area": "synthesis component audit (all 14)",
+      "detail": "Audited agentic-fit, archetype-mapping, archetypes, attention-capital, build-cost-estimation, chairman-constraints, cross-reference, design-evaluation, mental-model-analysis, moat-architecture, narrative-risk, portfolio-evaluation, time-horizon, virality + tech-trajectory. Only tech-trajectory.js declares/consumes a dataFeed-shaped external-signal hook. No other component has an analogous starved injection point -> no additional wiring required (document 'none exist')."
+    }
+  ],
+  "risks": [
+    "getTechSignals must be honest-idle: return null on zero current rows so tech-trajectory keeps its existing training-data-only fallback rather than injecting an empty/fabricated signal block.",
+    "Must preserve caller-provided deps.dataFeed (test override) and not break skipSynthesis/dryRun paths.",
+    "Read path must use is_current filter to respect the one-current-version-per-subject invariant."
+  ],
+  "recommended_scope": "1 new module (data-feed.js) + 1 additive injection line in stage-zero-orchestrator.js + unit tests. Additive, non-breaking, no change to tech-trajectory analysis logic."
+}

--- a/lib/eva/stage-zero/data-feed.js
+++ b/lib/eva/stage-zero/data-feed.js
@@ -1,0 +1,97 @@
+/**
+ * Stage-0 external data feed — the FIRST real construction of the dataFeed object that
+ * lib/eva/stage-zero/synthesis/tech-trajectory.js has accepted (deps.dataFeed) and called
+ * (dataFeed.getTechSignals(), line ~47) since it shipped, but which no caller ever built.
+ *
+ * SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B.
+ *
+ * getTechSignals() reads Child A's standing landscape reference table
+ * (research_intelligence_reference — database/migrations/20260718_research_intelligence_reference.sql)
+ * for the CURRENT technology/model-landscape rows and hands them to tech-trajectory as
+ * external grounding, replacing the training-data-only fallback ("Framework-informed
+ * projections based on training data. Not real-time signals.") whenever live rows exist.
+ *
+ * Honest-idle: with no current rows, a missing client, or a query error, getTechSignals()
+ * resolves to null and NEVER fabricates a signal — so tech-trajectory keeps its existing
+ * fallback behavior byte-for-byte when there is nothing live to say. This mirrors the
+ * defined-but-unarmed posture of the RESEARCH_INTELLIGENCE_OPERATOR that fills the table.
+ *
+ * Read-only consumer: this module never writes to the reference table (the operator owns
+ * writes via lib/agents/research-intelligence-operator.js ingestAcceptedSignals).
+ *
+ * @module lib/eva/stage-zero/data-feed
+ */
+
+/**
+ * entry_type values Child B (tech-trajectory) reads. Mirrors the migration CHECK subset:
+ * Child B -> tech_landscape/model_landscape (Child C reads the market_size/unit_economics/
+ * comparables family; Child D reads superseded rows). Kept local + explicit so a read here
+ * cannot silently widen if the operator's full vocabulary grows.
+ */
+export const TECH_ENTRY_TYPES = Object.freeze(['tech_landscape', 'model_landscape']);
+
+/** Columns pulled from the reference table (all pre-existing from Child A's migration). */
+const SELECT_COLUMNS = 'subject, entry_type, confidence, version, payload, source_refs';
+
+/**
+ * Map a raw reference-table row to the compact tech-signal shape tech-trajectory consumes
+ * (it JSON.stringifies the value into the LLM prompt). Never invents fields.
+ * @param {object} row
+ * @returns {{ subject: string, entry_type: string, confidence: string, version: number, payload: object, source_refs: Array }}
+ */
+function toTechSignal(row) {
+  return {
+    subject: row?.subject ?? null,
+    entry_type: row?.entry_type ?? null,
+    confidence: row?.confidence ?? 'unverified',
+    version: row?.version ?? 1,
+    payload: row?.payload ?? {},
+    source_refs: Array.isArray(row?.source_refs) ? row.source_refs : [],
+  };
+}
+
+/**
+ * Build a Stage-0 data feed backed by the standing landscape reference table.
+ *
+ * @param {object} supabase a supabase client (or a mock exposing from().select().eq().in())
+ * @param {object} [options]
+ * @param {object} [options.logger] logger (defaults to console)
+ * @returns {{ getTechSignals: () => Promise<Array<object>|null> }}
+ */
+export function createStageZeroDataFeed(supabase, options = {}) {
+  const { logger = console } = options;
+
+  return {
+    /**
+     * Read the CURRENT tech/model-landscape rows and return them as compact signals.
+     * Honest-idle: resolves to null (never throws, never fabricates) when there is no
+     * client, the query errors, or there are zero current rows.
+     * @returns {Promise<Array<object>|null>}
+     */
+    async getTechSignals() {
+      if (!supabase || typeof supabase.from !== 'function') {
+        return null;
+      }
+      try {
+        const { data, error } = await supabase
+          .from('research_intelligence_reference')
+          .select(SELECT_COLUMNS)
+          .eq('is_current', true)
+          .in('entry_type', TECH_ENTRY_TYPES);
+
+        if (error) {
+          logger.warn?.(`   Stage-0 dataFeed: tech-signal read failed (${error.message || error}); using fallback.`);
+          return null;
+        }
+        if (!Array.isArray(data) || data.length === 0) {
+          // Honest-idle: no live landscape rows -> tech-trajectory keeps its training-data fallback.
+          return null;
+        }
+        return data.map(toTechSignal);
+      } catch (err) {
+        logger.warn?.(`   Stage-0 dataFeed: tech-signal read threw (${err.message}); using fallback.`);
+        return null;
+      }
+    },
+  };
+}

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -15,6 +15,7 @@
 import { routePath, ENTRY_PATHS, PATH_OPTIONS, listDiscoveryStrategies } from './path-router.js';
 import { conductChairmanReview, persistVentureBrief } from './chairman-review.js';
 import { runSynthesis } from './synthesis/index.js';
+import { createStageZeroDataFeed } from './data-feed.js';
 import { generateForecast, calculateVentureScore } from './modeling.js';
 import { loadStrategicContext } from './strategic-context-loader.js';
 import { getActiveExperiment } from '../experiments/experiment-manager.js';
@@ -34,6 +35,8 @@ import { evaluateDual, defaultEvaluator } from '../experiments/dual-evaluator.js
  * @param {Object} deps - Injected dependencies
  * @param {Object} deps.supabase - Supabase client
  * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.dataFeed] - External data feed (constructed here from deps.supabase
+ *   when not supplied; a caller-provided feed — e.g. a test double — always wins)
  * @param {Function} [deps.synthesize] - Custom synthesis function (for testing)
  * @returns {Promise<Object>} Stage 0 result
  */
@@ -62,7 +65,14 @@ export async function executeStageZero(params, deps = {}) {
 
   // Step 0: Load strategic context (mission, vision, OKR gaps, themes)
   const strategicContext = await loadStrategicContext(supabase, { logger });
-  const enrichedDeps = { ...deps, strategicContext };
+  // SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B: construct the Stage-0 dataFeed here —
+  // the single production injection site. tech-trajectory.js has long accepted deps.dataFeed
+  // and called getTechSignals(), but no caller ever built the object; this closes that gap by
+  // backing it with Child A's standing reference table. A caller-provided deps.dataFeed (test
+  // double) always wins; otherwise build one from the supabase client. It threads through
+  // enrichedDeps -> runSynthesis -> analyzeTechTrajectory unchanged.
+  const dataFeed = deps.dataFeed || createStageZeroDataFeed(supabase, { logger });
+  const enrichedDeps = { ...deps, strategicContext, dataFeed };
 
   // Step 1: Execute the selected path
   logger.log(`   Path: ${getPathLabel(path)}`);

--- a/tests/unit/eva/stage-zero/data-feed.test.js
+++ b/tests/unit/eva/stage-zero/data-feed.test.js
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the Stage-0 data feed.
+ * SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B.
+ *
+ * Covers the read path against Child A's standing reference table and the honest-idle
+ * contract that keeps tech-trajectory's training-data fallback intact when nothing is live.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { createStageZeroDataFeed, TECH_ENTRY_TYPES } from '../../../../lib/eva/stage-zero/data-feed.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+/**
+ * Build a mock supabase whose from('research_intelligence_reference') query chain
+ * (.select().eq().in()) resolves to the supplied { data, error }. Records the arguments
+ * so the test can assert the table + filters used.
+ */
+function mockSupabase(result) {
+  const calls = { table: null, select: null, eq: null, in: null };
+  const builder = {
+    select: vi.fn((cols) => { calls.select = cols; return builder; }),
+    eq: vi.fn((col, val) => { calls.eq = [col, val]; return builder; }),
+    in: vi.fn((col, vals) => { calls.in = [col, vals]; return Promise.resolve(result); }),
+  };
+  const supabase = {
+    from: vi.fn((table) => { calls.table = table; return builder; }),
+  };
+  return { supabase, calls };
+}
+
+const TECH_ROW = {
+  subject: 'llm_frontier_models',
+  entry_type: 'tech_landscape',
+  confidence: 'medium',
+  version: 3,
+  payload: { trend: 'reasoning gains accelerating' },
+  source_refs: [{ youtube_video_id: 'abc123' }],
+};
+const MODEL_ROW = {
+  subject: 'open_weight_models',
+  entry_type: 'model_landscape',
+  confidence: 'high',
+  version: 1,
+  payload: { note: 'cost deflation continuing' },
+  source_refs: [],
+};
+
+describe('createStageZeroDataFeed.getTechSignals', () => {
+  test('maps current tech/model-landscape rows to compact signals', async () => {
+    const { supabase, calls } = mockSupabase({ data: [TECH_ROW, MODEL_ROW], error: null });
+    const feed = createStageZeroDataFeed(supabase, { logger: silentLogger });
+
+    const signals = await feed.getTechSignals();
+
+    expect(Array.isArray(signals)).toBe(true);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toEqual({
+      subject: 'llm_frontier_models',
+      entry_type: 'tech_landscape',
+      confidence: 'medium',
+      version: 3,
+      payload: { trend: 'reasoning gains accelerating' },
+      source_refs: [{ youtube_video_id: 'abc123' }],
+    });
+    // Correct table + filters: is_current true, entry_type restricted to the tech family.
+    expect(calls.table).toBe('research_intelligence_reference');
+    expect(calls.eq).toEqual(['is_current', true]);
+    expect(calls.in).toEqual(['entry_type', TECH_ENTRY_TYPES]);
+  });
+
+  test('is honest-idle on an empty result (returns null, not [])', async () => {
+    const { supabase } = mockSupabase({ data: [], error: null });
+    const feed = createStageZeroDataFeed(supabase, { logger: silentLogger });
+
+    const signals = await feed.getTechSignals();
+
+    expect(signals).toBeNull();
+  });
+
+  test('fails closed to null on a supabase error (never throws)', async () => {
+    const { supabase } = mockSupabase({ data: null, error: { message: 'boom' } });
+    const feed = createStageZeroDataFeed(supabase, { logger: silentLogger });
+
+    await expect(feed.getTechSignals()).resolves.toBeNull();
+  });
+
+  test('returns null when the client is missing/malformed', async () => {
+    const feed = createStageZeroDataFeed(null, { logger: silentLogger });
+    await expect(feed.getTechSignals()).resolves.toBeNull();
+
+    const feed2 = createStageZeroDataFeed({}, { logger: silentLogger });
+    await expect(feed2.getTechSignals()).resolves.toBeNull();
+  });
+
+  test('fails closed to null when the query throws', async () => {
+    const supabase = { from: () => { throw new Error('unexpected'); } };
+    const feed = createStageZeroDataFeed(supabase, { logger: silentLogger });
+    await expect(feed.getTechSignals()).resolves.toBeNull();
+  });
+
+  test('normalizes missing/odd row fields without fabricating data', async () => {
+    const { supabase } = mockSupabase({ data: [{ subject: 'x', entry_type: 'tech_landscape' }], error: null });
+    const feed = createStageZeroDataFeed(supabase, { logger: silentLogger });
+
+    const [signal] = await feed.getTechSignals();
+
+    expect(signal.confidence).toBe('unverified');
+    expect(signal.version).toBe(1);
+    expect(signal.payload).toEqual({});
+    expect(signal.source_refs).toEqual([]);
+  });
+
+  test('exposes only the tech/model-landscape entry types (Child B read scope)', () => {
+    expect(TECH_ENTRY_TYPES).toEqual(['tech_landscape', 'model_landscape']);
+  });
+});

--- a/tests/unit/eva/stage-zero/stage-zero-orchestrator-datafeed.test.js
+++ b/tests/unit/eva/stage-zero/stage-zero-orchestrator-datafeed.test.js
@@ -1,0 +1,68 @@
+/**
+ * Orchestrator wiring test: executeStageZero constructs the Stage-0 dataFeed and threads it
+ * into synthesis (deps.dataFeed) — the first caller ever to build the object that
+ * tech-trajectory.js's getTechSignals() hook consumes.
+ * SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-B.
+ *
+ * The heavy Stage-0 collaborators are mocked so the test isolates the dataFeed construction
+ * + injection line. Synthesis is supplied as a capturing spy (deps.synthesize) so we can
+ * observe exactly what deps.dataFeed synthesis received.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../lib/eva/stage-zero/strategic-context-loader.js', () => ({
+  loadStrategicContext: vi.fn().mockResolvedValue({ mission: 'test' }),
+}));
+vi.mock('../../../../lib/eva/stage-zero/path-router.js', () => ({
+  routePath: vi.fn().mockResolvedValue({ suggested_name: 'Test Venture', metadata: {} }),
+  ENTRY_PATHS: {},
+  PATH_OPTIONS: [],
+  listDiscoveryStrategies: vi.fn(() => []),
+}));
+vi.mock('../../../../lib/eva/stage-zero/modeling.js', () => ({
+  generateForecast: vi.fn().mockResolvedValue({}),
+  calculateVentureScore: vi.fn(() => 50),
+}));
+vi.mock('../../../../lib/eva/stage-zero/chairman-review.js', () => ({
+  conductChairmanReview: vi.fn().mockResolvedValue({ brief: {}, decision: 'nursery', validation: {} }),
+  persistVentureBrief: vi.fn().mockResolvedValue({ id: 'rec-1' }),
+}));
+
+const { executeStageZero } = await import('../../../../lib/eva/stage-zero/stage-zero-orchestrator.js');
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const fakeSupabase = { from: vi.fn() };
+const baseOptions = { dryRun: true, skipExperiments: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('executeStageZero dataFeed wiring', () => {
+  test('constructs a dataFeed from supabase and passes it into synthesis', async () => {
+    const synthesize = vi.fn().mockResolvedValue({ metadata: {} });
+
+    await executeStageZero(
+      { path: 'test', pathParams: {}, options: baseOptions },
+      { supabase: fakeSupabase, logger: silentLogger, synthesize }
+    );
+
+    expect(synthesize).toHaveBeenCalledTimes(1);
+    const depsPassed = synthesize.mock.calls[0][1];
+    expect(depsPassed.dataFeed).toBeTruthy();
+    expect(typeof depsPassed.dataFeed.getTechSignals).toBe('function');
+  });
+
+  test('preserves a caller-provided deps.dataFeed (test double wins)', async () => {
+    const synthesize = vi.fn().mockResolvedValue({ metadata: {} });
+    const injectedFeed = { getTechSignals: vi.fn().mockResolvedValue([{ subject: 'x' }]) };
+
+    await executeStageZero(
+      { path: 'test', pathParams: {}, options: baseOptions },
+      { supabase: fakeSupabase, logger: silentLogger, synthesize, dataFeed: injectedFeed }
+    );
+
+    const depsPassed = synthesize.mock.calls[0][1];
+    expect(depsPassed.dataFeed).toBe(injectedFeed);
+  });
+});


### PR DESCRIPTION
## Summary
Child B of the RESEARCH_INTELLIGENCE_OPERATOR orchestrator (parent SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001). Closes the "nobody ever constructed the dataFeed object" gap in Stage-0 synthesis.

`lib/eva/stage-zero/synthesis/tech-trajectory.js` has accepted `deps.dataFeed` and called `dataFeed.getTechSignals()` (line ~47) since it shipped, but no caller anywhere ever built a dataFeed. The plumbing was already faithful end-to-end (`runSynthesis` forwards deps untouched; `executeStageZero` spreads deps into `enrichedDeps`), so every venture's technology-trajectory analysis ran on the training-data-only fallback ("Framework-informed projections based on training data. Not real-time signals.").

## Changes
- **NEW** `lib/eva/stage-zero/data-feed.js` — `createStageZeroDataFeed(supabase)` exposing an async `getTechSignals()` that reads Child A's standing `research_intelligence_reference` table (`is_current` `tech_landscape`/`model_landscape` rows) and maps them to compact signals. Honest-idle: returns `null` on empty/error/missing-client so the existing fallback is preserved byte-for-byte.
- **MODIFY** `lib/eva/stage-zero/stage-zero-orchestrator.js` — construct the dataFeed at the single production injection site (the `enrichedDeps` line) and thread it into synthesis. A caller-provided `deps.dataFeed` (test double) always wins.
- **Audit** of all 14 synthesis components: `dataFeed`/`getTechSignals` appear only in `tech-trajectory.js`; no other component has an analogous starved hook, so none is wired.
- **Tests**: `data-feed.test.js` (rows / empty / error / malformed-client / normalization, mock supabase) + `stage-zero-orchestrator-datafeed.test.js` (dataFeed constructed + injected; caller override preserved).

## Verification
- ESLint clean on all touched files.
- Targeted suites: 9/9 new tests pass; existing tech-trajectory + orchestrator suites 36/36 pass (no regression).
- Full `vitest run`: 45 failed files, all pre-existing `|db|` live-DB integration tests — zero overlap with touched modules.

## Scope
Additive and non-breaking. No schema change (read-only consumer of Child A's table). tech-trajectory analysis logic / LLM prompt unchanged (out of scope). Does not touch Child C (modeling.js) or Child D territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
