### PR TITLE
feat(SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-C): ground Stage-0 forecast in standing reference data

### DIFF
--- a/lib/eva/stage-zero/modeling.js
+++ b/lib/eva/stage-zero/modeling.js
@@ -12,9 +12,107 @@
  * to reflect early-stage uncertainty.
  *
  * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-J
+ *
+ * SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-C: the Stage-0 economic model now
+ * grounds its market-sizing / unit-economics / growth prompt in Child A's standing
+ * reference product (research_intelligence_reference) instead of a bare LLM guess.
+ * A new deps.referenceData (or deps.supabase read path) injects economic-family base
+ * rates, and an estimation-method rules block enforces the parent SD's Modeling
+ * Estimation Method appendix (ranges never bare points, Fermi decomposition, explicit
+ * assumptions, reference-class base rates). Reference-class base rates are the primary
+ * driver of estimate quality per the Fermi-estimation research folded into the parent SD.
  */
 
 import { getValidationClient } from '../../llm/client-factory.js';
+
+/**
+ * entry_type families this Stage-0 economic model consumes from Child A's
+ * research_intelligence_reference product. Child B owns tech_landscape/model_landscape;
+ * this module reads only the economic families. Mirrors the migration CHECK constraint.
+ */
+export const REFERENCE_DATA_ENTRY_TYPES = Object.freeze([
+  'market_size', 'unit_economics', 'comparables',
+]);
+
+/**
+ * The Modeling Estimation Method format rules (parent SD appendix). Always injected so
+ * the forecast states ranges (never bare points), decomposes before estimating, makes
+ * assumptions explicit, and anchors on reference-class base rates. Cited evidence: five
+ * professional analyst firms sizing one market spanned ~$91B-$297B (a 3x spread), so a
+ * bare point estimate implies false precision even among humans with real data.
+ */
+export const ESTIMATION_METHOD_RULES = `ESTIMATION METHOD (follow strictly):
+- Ranges, never bare points: every numeric estimate MUST be an optimistic/realistic/pessimistic range. A single point value implies false precision — five professional firms sizing one market spanned ~$91B-$297B, a 3x spread.
+- Fermi decomposition: decompose each estimate into factors you can reason about (e.g. market size = reachable population x adoption rate x annual price) BEFORE producing a number.
+- Explicit assumptions: record the assumptions behind each estimate in key_assumptions. An estimate without its assumptions is not usable.
+- Reference-class base rates: when a reference-data block is provided above, anchor on those base rates instead of your own training-data priors.`;
+
+/**
+ * Render current economic-family reference entries into a grounding block for the
+ * Stage-0 forecast prompt. PURE.
+ *
+ * Filters to this module's entry_type families (market_size/unit_economics/comparables)
+ * and to is_current rows, ignoring Child B's tech_landscape/model_landscape rows. Returns
+ * '' for empty/null/non-array input so the prompt stays unguided (honest-idle) rather than
+ * inventing base rates.
+ *
+ * @param {Array<Object>} referenceData research_intelligence_reference rows
+ * @returns {string} a REFERENCE DATA block, or '' when no usable rows
+ */
+export function formatReferenceDataForPrompt(referenceData) {
+  const list = Array.isArray(referenceData) ? referenceData : [];
+  const usable = list.filter(
+    (r) => r
+      && REFERENCE_DATA_ENTRY_TYPES.includes(r.entry_type)
+      && r.is_current !== false
+  );
+  if (usable.length === 0) return '';
+
+  const lines = usable.map((r) => {
+    let payload;
+    try {
+      payload = JSON.stringify(r.payload ?? {});
+    } catch {
+      payload = '{}';
+    }
+    const sources = Array.isArray(r.source_refs) ? r.source_refs.length : 0;
+    const confidence = r.confidence || 'unverified';
+    return `- [${r.entry_type}] ${r.subject} (confidence: ${confidence}, sources: ${sources}): ${payload}`;
+  });
+
+  return `REFERENCE DATA (standing landscape reference — use these as reference-class base rates, not your own priors):
+${lines.join('\n')}`;
+}
+
+/**
+ * Read the current economic-family reference rows from Child A's standing table.
+ * Degrades to [] on any error or a missing/malformed client (never throws) — the forecast
+ * must still run unguided if the reference product is unavailable.
+ *
+ * @param {Object} supabase a supabase client (or a mock exposing .from().select().eq().in())
+ * @param {Object} [opts]
+ * @param {Object} [opts.logger]
+ * @returns {Promise<Array<Object>>}
+ */
+export async function loadReferenceData(supabase, opts = {}) {
+  const { logger = console } = opts;
+  if (!supabase || typeof supabase.from !== 'function') return [];
+  try {
+    const { data, error } = await supabase
+      .from('research_intelligence_reference')
+      .select('*')
+      .eq('is_current', true)
+      .in('entry_type', REFERENCE_DATA_ENTRY_TYPES);
+    if (error) {
+      logger.warn?.(`   [forecast] reference data read failed: ${error.message || error}`);
+      return [];
+    }
+    return Array.isArray(data) ? data : [];
+  } catch (err) {
+    logger.warn?.(`   [forecast] reference data read threw: ${err.message}`);
+    return [];
+  }
+}
 
 /**
  * Generate a horizontal forecast for a venture brief.
@@ -23,20 +121,34 @@ import { getValidationClient } from '../../llm/client-factory.js';
  * @param {Object} deps - Injected dependencies
  * @param {Object} [deps.logger] - Logger
  * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @param {Array<Object>} [deps.referenceData] - Pre-fetched research_intelligence_reference
+ *        rows (economic families). When supplied, injected into the forecast prompt as
+ *        reference-class base rates. Takes precedence over deps.supabase.
+ * @param {Object} [deps.supabase] - Supabase client used to read reference data when
+ *        deps.referenceData is not supplied. Optional; absence leaves the forecast unguided.
  * @returns {Promise<Object>} Forecast result
  */
 export async function generateForecast(brief, deps = {}) {
-  const { logger = console, llmClient } = deps;
+  const { logger = console, llmClient, referenceData: injectedReferenceData, supabase } = deps;
   const client = llmClient || getValidationClient();
 
   logger.log('   Generating venture forecast...');
+
+  // Ground the forecast in Child A's standing reference product when available. Injected
+  // data wins; otherwise read via supabase when provided; otherwise none (honest-idle: the
+  // prompt stays unguided and never fabricates base rates).
+  let referenceData = injectedReferenceData;
+  if (!referenceData && supabase) {
+    referenceData = await loadReferenceData(supabase, { logger });
+  }
+  const referenceBlock = formatReferenceDataForPrompt(referenceData);
 
   const buildCost = brief.metadata?.synthesis?.build_cost || {};
   const archetype = brief.metadata?.synthesis?.archetypes?.primary_archetype || 'unknown';
   const timeHorizon = brief.metadata?.synthesis?.time_horizon?.position || 'build_now';
 
   const prompt = `You are a venture evaluator for an AI-first venture studio. Evaluate this venture fairly using the full 1-5 scale. Score based on the venture's POTENTIAL given its concept, target market, and business model — not on whether it has already been validated.
-
+${referenceBlock ? `\n${referenceBlock}\n` : ''}
 VENTURE:
 Name: ${brief.name}
 Problem: ${brief.problem_statement}
@@ -46,6 +158,8 @@ Archetype: ${archetype}
 Time Horizon: ${timeHorizon}
 Build Complexity: ${buildCost.complexity || 'moderate'}
 Estimated Timeline: ${buildCost.timeline_weeks?.realistic || 8} weeks to MVP
+
+${ESTIMATION_METHOD_RULES}
 
 EHG CONTEXT:
 - AI-first venture studio (AI accelerates development but does not eliminate complexity)

--- a/tests/unit/modeling.test.js
+++ b/tests/unit/modeling.test.js
@@ -4,12 +4,20 @@
  * Tests the horizontal forecasting infrastructure:
  * - generateForecast (LLM-powered financial projections)
  * - calculateVentureScore (scoring from forecast data)
+ * - reference-data injection (SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-C)
  *
  * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-J
  */
 
 import { describe, test, expect, vi } from 'vitest';
-import { generateForecast, calculateVentureScore } from '../../lib/eva/stage-zero/modeling.js';
+import {
+  generateForecast,
+  calculateVentureScore,
+  formatReferenceDataForPrompt,
+  loadReferenceData,
+  REFERENCE_DATA_ENTRY_TYPES,
+  ESTIMATION_METHOD_RULES,
+} from '../../lib/eva/stage-zero/modeling.js';
 
 // ── Test Data ──────────────────────────────────────────
 
@@ -83,6 +91,21 @@ function createMockLLMClient(overrideResponse = null) {
     },
   };
   return client;
+}
+
+// ── Mock Supabase (reference-data reader) ──────────────────────────────
+
+function createMockSupabase({ data = [], error = null } = {}) {
+  const calls = { from: [], select: [], eq: [], in: [] };
+  const builder = {
+    select: vi.fn(function select(cols) { calls.select.push(cols); return builder; }),
+    eq: vi.fn(function eq(col, val) { calls.eq.push([col, val]); return builder; }),
+    in: vi.fn(function inFn(col, vals) { calls.in.push([col, vals]); return Promise.resolve({ data, error }); }),
+  };
+  return {
+    from: vi.fn(function from(table) { calls.from.push(table); return builder; }),
+    _calls: calls,
+  };
 }
 
 // ── generateForecast Tests ──────────────────────────────
@@ -167,6 +190,160 @@ describe('Modeling - generateForecast', () => {
     // Missing fields get defaults
     expect(result.market_sizing.tam.value).toBe(0);
     expect(result.unit_economics.cac.realistic).toBe(0);
+  });
+});
+
+// ── Reference-Data Injection Tests (SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-C) ──
+
+describe('Modeling - reference-data injection', () => {
+  const REFERENCE_ROWS = [
+    { entry_type: 'market_size', subject: 'review_mgmt_smb', payload: { tam_usd: '5B-9B' }, source_refs: ['yt-abc'], confidence: 'medium', is_current: true },
+    { entry_type: 'unit_economics', subject: 'smb_saas_cac', payload: { cac_usd: '20-60' }, confidence: 'low', is_current: true },
+  ];
+
+  test('injects supplied reference data into the forecast prompt (TS-1)', async () => {
+    const llmClient = createMockLLMClient();
+    await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient, referenceData: REFERENCE_ROWS });
+
+    const prompt = llmClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('REFERENCE DATA');
+    expect(prompt).toContain('review_mgmt_smb');
+    expect(prompt).toContain('smb_saas_cac');
+    expect(prompt).toContain('tam_usd');
+  });
+
+  test('honest-idle: no reference data leaves the prompt unguided but keeps estimation rules (TS-2)', async () => {
+    const llmClient = createMockLLMClient();
+    const result = await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    const prompt = llmClient.complete.mock.calls[0][1];
+    expect(prompt).not.toContain('REFERENCE DATA');
+    expect(prompt).toContain('ESTIMATION METHOD');
+    // Backward-compatible output shape preserved
+    expect(result.component).toBe('forecast');
+    expect(result.confidence).toBe(72);
+  });
+
+  test('reads reference data via deps.supabase when referenceData is not supplied', async () => {
+    const llmClient = createMockLLMClient();
+    const supabase = createMockSupabase({
+      data: [{ entry_type: 'comparables', subject: 'comp_x', payload: { note: 'peer set' }, is_current: true }],
+    });
+
+    await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient, supabase });
+
+    expect(supabase.from).toHaveBeenCalledWith('research_intelligence_reference');
+    const prompt = llmClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('comp_x');
+  });
+
+  test('injected referenceData takes precedence over supabase read', async () => {
+    const llmClient = createMockLLMClient();
+    const supabase = createMockSupabase({ data: [{ entry_type: 'market_size', subject: 'db_row', payload: {}, is_current: true }] });
+
+    await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient, supabase, referenceData: REFERENCE_ROWS });
+
+    // Supabase should not be queried when referenceData is already supplied
+    expect(supabase.from).not.toHaveBeenCalled();
+    const prompt = llmClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('review_mgmt_smb');
+    expect(prompt).not.toContain('db_row');
+  });
+
+  test('estimation-method rules are present in the prompt (TS-5)', async () => {
+    const llmClient = createMockLLMClient();
+    await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    const prompt = llmClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('Ranges, never bare points');
+    expect(prompt).toContain('Fermi decomposition');
+    expect(prompt).toContain('Explicit assumptions');
+    expect(prompt).toContain('Reference-class base rates');
+  });
+});
+
+// ── formatReferenceDataForPrompt Tests (TS-3) ──────────────────────────────
+
+describe('Modeling - formatReferenceDataForPrompt', () => {
+  test('returns empty string for empty, null, and undefined input', () => {
+    expect(formatReferenceDataForPrompt([])).toBe('');
+    expect(formatReferenceDataForPrompt(null)).toBe('');
+    expect(formatReferenceDataForPrompt(undefined)).toBe('');
+    expect(formatReferenceDataForPrompt('not-an-array')).toBe('');
+  });
+
+  test('filters to Child-C economic families and excludes Child B landscape rows', () => {
+    const mixed = [
+      { entry_type: 'market_size', subject: 'ms1', payload: {}, is_current: true },
+      { entry_type: 'tech_landscape', subject: 'tl1', payload: {}, is_current: true },
+      { entry_type: 'model_landscape', subject: 'ml1', payload: {}, is_current: true },
+      { entry_type: 'comparables', subject: 'cmp1', payload: {}, is_current: true },
+    ];
+    const block = formatReferenceDataForPrompt(mixed);
+    expect(block).toContain('ms1');
+    expect(block).toContain('cmp1');
+    expect(block).not.toContain('tl1');
+    expect(block).not.toContain('ml1');
+  });
+
+  test('excludes non-current (superseded) rows', () => {
+    const rows = [
+      { entry_type: 'unit_economics', subject: 'ue_current', payload: {}, is_current: true },
+      { entry_type: 'unit_economics', subject: 'ue_old', payload: {}, is_current: false },
+    ];
+    const block = formatReferenceDataForPrompt(rows);
+    expect(block).toContain('ue_current');
+    expect(block).not.toContain('ue_old');
+  });
+
+  test('renders subject, confidence, and payload for each entry', () => {
+    const block = formatReferenceDataForPrompt([
+      { entry_type: 'market_size', subject: 'sizing_x', payload: { tam: '1B' }, confidence: 'high', source_refs: ['a', 'b'], is_current: true },
+    ]);
+    expect(block).toContain('sizing_x');
+    expect(block).toContain('high');
+    expect(block).toContain('tam');
+    expect(block).toContain('sources: 2');
+  });
+
+  test('REFERENCE_DATA_ENTRY_TYPES matches the Child-C read family', () => {
+    expect([...REFERENCE_DATA_ENTRY_TYPES]).toEqual(['market_size', 'unit_economics', 'comparables']);
+  });
+});
+
+// ── loadReferenceData Tests (TS-4) ──────────────────────────────
+
+describe('Modeling - loadReferenceData', () => {
+  test('queries the standing table filtering is_current and Child-C entry types', async () => {
+    const supabase = createMockSupabase({ data: [{ entry_type: 'market_size', subject: 's', is_current: true }] });
+    const rows = await loadReferenceData(supabase, { logger: silentLogger });
+
+    expect(supabase._calls.from).toContain('research_intelligence_reference');
+    expect(supabase._calls.eq).toContainEqual(['is_current', true]);
+    expect(supabase._calls.in).toContainEqual(['entry_type', REFERENCE_DATA_ENTRY_TYPES]);
+    expect(rows).toHaveLength(1);
+  });
+
+  test('returns [] on query error without throwing', async () => {
+    const supabase = createMockSupabase({ error: { message: 'boom' } });
+    const rows = await loadReferenceData(supabase, { logger: silentLogger });
+    expect(rows).toEqual([]);
+  });
+
+  test('returns [] for a missing or malformed client', async () => {
+    expect(await loadReferenceData(null, { logger: silentLogger })).toEqual([]);
+    expect(await loadReferenceData({}, { logger: silentLogger })).toEqual([]);
+  });
+});
+
+// ── ESTIMATION_METHOD_RULES ──────────────────────────────
+
+describe('Modeling - ESTIMATION_METHOD_RULES', () => {
+  test('encodes the parent SD Modeling Estimation Method appendix', () => {
+    expect(ESTIMATION_METHOD_RULES).toContain('Ranges, never bare points');
+    expect(ESTIMATION_METHOD_RULES).toContain('Fermi decomposition');
+    expect(ESTIMATION_METHOD_RULES).toContain('Explicit assumptions');
+    expect(ESTIMATION_METHOD_RULES).toContain('Reference-class base rates');
   });
 });
 


### PR DESCRIPTION
## Summary
Child C of the RESEARCH_INTELLIGENCE_OPERATOR orchestrator (parent SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001). Grounds the Stage-0 economic/forecasting model (`lib/eva/stage-zero/modeling.js` `generateForecast`) in Child A's versioned `research_intelligence_reference` product instead of a bare LLM guess.

## What changed
- **`deps.referenceData` injection point** on `generateForecast(brief, deps)`. When absent, an optional `deps.supabase` triggers `loadReferenceData()`. Both absent → prior behavior unchanged (honest-idle, no fabricated grounding).
- **`formatReferenceDataForPrompt()`** pure helper: filters to the Child-C economic families (`market_size`/`unit_economics`/`comparables`) and `is_current` rows, ignoring Child B's `tech_landscape`/`model_landscape` rows; returns `''` for empty input.
- **`loadReferenceData()`** reader over `research_intelligence_reference`, degrading to `[]` on error without throwing.
- **Estimation-method rules block** in the forecast prompt (ranges never bare points, Fermi decomposition, explicit assumptions, reference-class base rates) per the parent SD's Modeling Estimation Method appendix.

## Testing
- `tests/unit/modeling.test.js`: 25 passing (reference injection, honest-idle-absent, family/`is_current` filter, loader with mock supabase, estimation-method rules) + all pre-existing cases.
- ESLint clean on touched files.
- Full-repo `vitest run`: 50 failed files, all pre-existing live-DB tests; zero overlap with the touched module.

## Boundaries
Additive, backward compatible, single production file (`modeling.js`), no schema change (Child A owns the table), no orchestrator wiring (Child B territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)