### PR TITLE
fix(SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001): never-null phase derivation for sub-agent evidence

### DIFF
--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -370,7 +370,13 @@ export async function executeSubAgent(code, sdId, options = {}) {
 
     // Step 7: Store results in database
     // Pass sdUUID for foreign key, sdKey for display/metadata
-    const stored = await storeSubAgentResults(code, sdUUID, subAgent, results, { sdKey });
+    // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-2): thread the RAW sdPhase
+    // (current_phase, e.g. PLAN_PRD/PLAN_VERIFICATION/EXEC_TO_PLAN) computed at
+    // Step 0b above -- NOT the narrower `normalizedPhase` bucket (which only
+    // maps to LEAD/PLAN/EXEC and would re-collapse distinct sub-phases,
+    // reintroducing the created_at-freezing bug fb 0b12ca77 targeted). An
+    // explicit caller-supplied options.phase still wins if ever provided.
+    const stored = await storeSubAgentResults(code, sdUUID, subAgent, results, { sdKey, phase: options.phase || sdPhase });
 
     console.log(`\n${code} execution complete (${executionTime}ms)`);
     console.log(`   Verdict: ${results.verdict}`);

--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -62,6 +62,14 @@ export async function executeSubAgent(code, sdId, options = {}) {
 
     // Step 0b: Determine optimal model based on phase context
     const sdPhase = resolved?.current_phase || resolved?.status || null;
+    // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-2): a phase-only value for
+    // the evidence-storage call below, deliberately WITHOUT the `resolved.status`
+    // fallback `sdPhase` uses for model routing. `status` (e.g. 'active') is
+    // constant across an SD's entire LEAD->PLAN->EXEC lifecycle -- threading it
+    // as the stored phase for an SD whose current_phase happens to be null would
+    // make every call look like the SAME phase, defeating the dedup fix this SD
+    // exists to deliver and reproducing fb 0b12ca77 for exactly those SDs.
+    const rawCurrentPhase = resolved?.current_phase || null;
     const normalizedPhase = sdPhase ? ({
       'lead_review': 'LEAD',
       'plan_active': 'PLAN',
@@ -370,13 +378,16 @@ export async function executeSubAgent(code, sdId, options = {}) {
 
     // Step 7: Store results in database
     // Pass sdUUID for foreign key, sdKey for display/metadata
-    // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-2): thread the RAW sdPhase
-    // (current_phase, e.g. PLAN_PRD/PLAN_VERIFICATION/EXEC_TO_PLAN) computed at
-    // Step 0b above -- NOT the narrower `normalizedPhase` bucket (which only
-    // maps to LEAD/PLAN/EXEC and would re-collapse distinct sub-phases,
-    // reintroducing the created_at-freezing bug fb 0b12ca77 targeted). An
-    // explicit caller-supplied options.phase still wins if ever provided.
-    const stored = await storeSubAgentResults(code, sdUUID, subAgent, results, { sdKey, phase: options.phase || sdPhase });
+    // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-2): thread `rawCurrentPhase`
+    // (current_phase alone, e.g. PLAN_PRD/PLAN_VERIFICATION/EXEC) -- NOT `sdPhase`
+    // (which falls back to `resolved.status`, constant across the SD's whole
+    // lifecycle and would defeat the phase-scoped dedup for any SD whose
+    // current_phase happens to be null) and NOT the narrower `normalizedPhase`
+    // bucket (which only maps to LEAD/PLAN/EXEC and would re-collapse distinct
+    // sub-phases, reintroducing the created_at-freezing bug fb 0b12ca77
+    // targeted). An explicit caller-supplied options.phase still wins if ever
+    // provided.
+    const stored = await storeSubAgentResults(code, sdUUID, subAgent, results, { sdKey, phase: options.phase || rawCurrentPhase });
 
     console.log(`\n${code} execution complete (${executionTime}ms)`);
     console.log(`   Verdict: ${results.verdict}`);

--- a/lib/sub-agent-executor/phase-token.js
+++ b/lib/sub-agent-executor/phase-token.js
@@ -1,0 +1,26 @@
+/**
+ * SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-3): format-only phase token
+ * normalization SSOT for sub-agent evidence storage.
+ *
+ * Canonicalizes casing/separator variants of the SAME phase token (e.g.
+ * "PLAN-VERIFICATION" and "PLAN_VERIFICATION" collapse to one spelling).
+ * Deliberately does NOT bucket distinct sub-phases together (e.g. PLAN_PRD
+ * and PLAN_VERIFICATION must remain distinct) -- coarse bucketing to
+ * {LEAD, PLAN, EXEC} would re-collapse sub-phase boundaries and reintroduce
+ * a smaller version of the created_at-freezing bug fb 0b12ca77 targeted.
+ */
+
+/**
+ * @param {*} raw - candidate phase token (any type; non-strings are rejected)
+ * @returns {string|null} canonical uppercase, underscore-separated token, or null
+ */
+export function normalizePhaseToken(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return trimmed
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '') || null;
+}

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -23,6 +23,8 @@ import { USE_TASK_CONTRACTS, RESULT_COMPRESSION_THRESHOLD, PRD_LINKABLE_SUBAGENT
 import { createArtifact } from '../artifact-tools.js';
 // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
 import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
+// SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-3): shared format-only phase normalizer
+import { normalizePhaseToken } from './phase-token.js';
 
 /**
  * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): refresh the owning worker's claim heartbeat
@@ -290,10 +292,41 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   //   resolve phase from options (canonical), results.phase, or incoming
   //   metadata.phase.  Dual-write to the native `phase` column AND
   //   metadata.phase during the one-release burn-in window.
-  const phaseValue = (typeof options.phase === 'string' && options.phase.trim())
+  let phaseValue = (typeof options.phase === 'string' && options.phase.trim())
     || (typeof results.phase === 'string' && results.phase.trim())
     || (typeof results.metadata?.phase === 'string' && results.metadata.phase.trim())
     || null;
+
+  // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-1): never-null fallback.
+  // Most real callers (the canonical executor.js path, the execute-subagent.js
+  // CLI, one-off scripts) never supply a phase at all, so phaseValue was almost
+  // always null -- which made the phase-scoped dedup added by
+  // EVIDENCE-DEDUP-PHASE-KEY-001 degenerate back to phase-blind behavior for the
+  // majority of writes (two null-phase calls for genuinely different real SD
+  // phases still collide via .is('phase', null)). When nothing supplied a
+  // phase, derive it from the SD's own raw current_phase instead of leaving it
+  // null.
+  if (!phaseValue && normalizedSdId) {
+    try {
+      const { data: sdRow } = await supabase
+        .from('strategic_directives_v2')
+        .select('current_phase')
+        .eq('id', normalizedSdId)
+        .maybeSingle();
+      if (typeof sdRow?.current_phase === 'string' && sdRow.current_phase.trim()) {
+        // FR-3: normalize only the DERIVED value at this new choke point.
+        // Explicitly-supplied caller phases (options/results/metadata, resolved
+        // above) are left byte-identical -- many real writers (handoff
+        // executors, cross-sd-overlap gates) intentionally use a hyphenated
+        // convention (e.g. 'PLAN-TO-EXEC') and HandoffRepository.getForPhase()
+        // does an exact .eq('phase', phase) lookup against it; rewriting those
+        // in place would silently break that lookup for existing consumers.
+        phaseValue = normalizePhaseToken(sdRow.current_phase.trim());
+      }
+    } catch (phaseLookupError) {
+      console.warn(`   [PHASE-DERIVATION] Warning: could not derive phase from SD current_phase: ${phaseLookupError.message}`);
+    }
+  }
 
   let metadata = {
     sub_agent_version: subAgent?.metadata?.version || '1.0.0',

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -308,19 +308,22 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   // null.
   if (!phaseValue && normalizedSdId) {
     try {
-      const { data: sdRow } = await supabase
+      const { data: sdRow, error: sdLookupError } = await supabase
         .from('strategic_directives_v2')
         .select('current_phase')
         .eq('id', normalizedSdId)
         .maybeSingle();
-      if (typeof sdRow?.current_phase === 'string' && sdRow.current_phase.trim()) {
+      if (sdLookupError) {
+        console.warn(`   [PHASE-DERIVATION] Warning: SD lookup returned an error, phase stays unresolved: ${sdLookupError.message}`);
+      } else if (typeof sdRow?.current_phase === 'string' && sdRow.current_phase.trim()) {
         // FR-3: normalize only the DERIVED value at this new choke point.
         // Explicitly-supplied caller phases (options/results/metadata, resolved
-        // above) are left byte-identical -- many real writers (handoff
-        // executors, cross-sd-overlap gates) intentionally use a hyphenated
-        // convention (e.g. 'PLAN-TO-EXEC') and HandoffRepository.getForPhase()
-        // does an exact .eq('phase', phase) lookup against it; rewriting those
-        // in place would silently break that lookup for existing consumers.
+        // above) are left byte-identical -- storeSubAgentResults' documented
+        // contract (see tests/unit/sub-agent-execution-results-phase-column.test.js,
+        // from SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-C) is to
+        // dual-write whatever phase string a caller supplies verbatim; rewriting
+        // an explicitly-supplied value here would silently break that tested
+        // contract for any current or future caller relying on it.
         phaseValue = normalizePhaseToken(sdRow.current_phase.trim());
       }
     } catch (phaseLookupError) {

--- a/scripts/execute-subagent.js
+++ b/scripts/execute-subagent.js
@@ -14,9 +14,11 @@
  */
 
 import { executeSubAgent, listAllSubAgents } from '../lib/sub-agent-executor.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 // Parse command line arguments
-function parseArgs() {
+// SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-4): exported for direct unit testing.
+export function parseArgs() {
   const args = process.argv.slice(2);
   const parsed = {
     code: null,
@@ -41,6 +43,12 @@ function parseArgs() {
       parsed.options.prd_id = args[++i];
     } else if (arg === '--table-name' || arg === '--table') {
       parsed.options.table_name = args[++i];
+    } else if (arg === '--phase') {
+      // SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-4): explicit string-valued
+      // flag -- must NOT fall through to the generic boolean-flag branch below,
+      // which would silently coerce this to `true` and drop the phase value.
+      const value = args[++i];
+      parsed.options.phase = typeof value === 'string' ? value : null;
     } else if (arg.startsWith('--')) {
       // Boolean flag (e.g., --full-e2e)
       const flagName = arg.slice(2).replace(/-/g, '_');
@@ -73,6 +81,9 @@ OPTIONAL FLAGS (sub-agent specific):
   --no-auto-migrations    Don't auto-execute migrations (DATABASE)
   --diagnose-rls          Diagnose RLS policy issues via Supabase CLI (DATABASE)
   --table-name <table>    Specify table for RLS diagnosis (DATABASE)
+  --phase <phase>         Explicit SD phase to stamp on the stored evidence row
+                          (e.g. EXEC_TO_PLAN). Optional -- omitted calls derive
+                          phase from the SD's own current_phase automatically.
 
 UTILITY OPTIONS:
   --list, -l              List all available sub-agents
@@ -236,4 +247,8 @@ async function main() {
 }
 
 // Run
-main();
+// SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-4): guard entrypoint execution
+// so a test file can `import { parseArgs } from ...` without triggering main().
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/tests/unit/execute-subagent-phase-flag.test.js
+++ b/tests/unit/execute-subagent-phase-flag.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-4)
+ *
+ * scripts/execute-subagent.js's parseArgs() previously had no --phase flag;
+ * any unrecognized `--foo` fell through to the generic boolean-flag branch,
+ * so a naive `--phase EXEC` would have set options.phase = true (dropping
+ * the string value) rather than options.phase = 'EXEC'. This pins the fix:
+ * --phase is parsed as an explicit string-valued flag, consistent with
+ * --sd-id / --prd-id / --table-name.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../../scripts/execute-subagent.js';
+
+function withArgv(args, fn) {
+  const original = process.argv;
+  process.argv = ['node', 'execute-subagent.js', ...args];
+  try {
+    return fn();
+  } finally {
+    process.argv = original;
+  }
+}
+
+describe('execute-subagent.js parseArgs --phase flag', () => {
+  it('parses an explicit --phase value as a string, not a boolean', () => {
+    const parsed = withArgv(
+      ['--code', 'TESTING', '--sd-id', 'SD-TEST-001', '--phase', 'EXEC_TO_PLAN'],
+      () => parseArgs()
+    );
+    expect(parsed.options.phase).toBe('EXEC_TO_PLAN');
+    expect(typeof parsed.options.phase).toBe('string');
+  });
+
+  it('leaves options.phase unset when --phase is omitted (backstop derivation applies downstream)', () => {
+    const parsed = withArgv(
+      ['--code', 'TESTING', '--sd-id', 'SD-TEST-001'],
+      () => parseArgs()
+    );
+    expect(parsed.options.phase).toBeUndefined();
+  });
+
+  it('does not coerce a trailing --phase with no value into boolean true', () => {
+    const parsed = withArgv(
+      ['--code', 'TESTING', '--sd-id', 'SD-TEST-001', '--phase'],
+      () => parseArgs()
+    );
+    expect(parsed.options.phase).not.toBe(true);
+    expect(parsed.options.phase).toBeNull();
+  });
+
+  it('other unrecognized flags still fall through to the boolean branch unaffected', () => {
+    const parsed = withArgv(
+      ['--code', 'TESTING', '--sd-id', 'SD-TEST-001', '--full-e2e'],
+      () => parseArgs()
+    );
+    expect(parsed.options.full_e2e).toBe(true);
+  });
+});

--- a/tests/unit/sub-agent-execution-results-dedup-phase-key.test.js
+++ b/tests/unit/sub-agent-execution-results-dedup-phase-key.test.js
@@ -7,21 +7,47 @@
  * place -- corrupting created_at (frozen at the earlier phase's time) and
  * making the row invisible to GATE_SUBAGENT_EVIDENCE's freshness check for the
  * later phase. The fix scopes the dedup match to the SAME phase (or both null).
+ *
+ * SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 extends this: the phase-scoped
+ * dedup above was a no-op for the majority of real callers, which never
+ * supply a phase at all (phaseValue stayed null on both sides, colliding via
+ * .is('phase', null) exactly like the original bug). The tests below default
+ * `sdTable` to EMPTY so every pre-existing test case keeps exercising the
+ * "SD lookup finds nothing -> phaseValue stays null" graceful-degradation
+ * path unchanged; new test cases populate `sdTable` explicitly to exercise
+ * the new never-null derivation path.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /**
- * Stateful mock: tracks inserted/updated rows in a simple array so the dedup
- * query's .eq('sd_id')/.eq('sub_agent_code')/.eq('phase') or .is('phase', null)
- * filters can be honored against genuinely distinct simulated rows -- unlike a
- * mock that always returns an empty existing-rows array, this can prove the
- * fix actually discriminates by phase.
+ * Stateful mock covering two tables:
+ *  - sub_agent_execution_results (subAgentRows): the existing dedup-fixture
+ *    behavior, unchanged from the pre-derivation test file.
+ *  - strategic_directives_v2 (sdTable): a plain object keyed by SD id,
+ *    supporting the FR-1 fallback's `.select('current_phase').eq('id', X)
+ *    .maybeSingle()` call. Empty by default (SD-not-found), populate a key to
+ *    simulate an SD whose current_phase the derivation can find.
  */
-function makeStatefulMockSupabase(rows) {
+function makeStatefulMockSupabase(subAgentRows, sdTable) {
   let nextId = 1;
   return {
     from(table) {
+      if (table === 'strategic_directives_v2') {
+        const filters = {};
+        const sdBuilder = {
+          select() { return sdBuilder; },
+          eq(col, val) { filters[col] = val; return sdBuilder; },
+          maybeSingle: async () => {
+            const match = Object.values(sdTable).find((sd) =>
+              Object.entries(filters).every(([col, val]) => sd[col] === val)
+            );
+            return { data: match ? { current_phase: match.current_phase } : null, error: null };
+          },
+        };
+        return sdBuilder;
+      }
+
       const filters = {};
       const builder = {
         select() { return builder; },
@@ -30,7 +56,7 @@ function makeStatefulMockSupabase(rows) {
         gte(col, val) { filters[col] = { ...(filters[col] || {}), gte: val }; return builder; },
         order() { return builder; },
         limit() {
-          const matches = rows.filter((r) => {
+          const matches = subAgentRows.filter((r) => {
             return Object.entries(filters).every(([col, f]) => {
               if (f.op === 'is') return r[col] === null || r[col] === undefined;
               if (f.op === 'eq') return r[col] === f.val;
@@ -41,7 +67,7 @@ function makeStatefulMockSupabase(rows) {
         },
         insert(record) {
           const row = { id: `row-${nextId++}`, ...record };
-          rows.push(row);
+          subAgentRows.push(row);
           return {
             select() {
               return { single: async () => ({ data: row, error: null }) };
@@ -55,7 +81,7 @@ function makeStatefulMockSupabase(rows) {
                 select() {
                   return {
                     single: async () => {
-                      const row = rows.find((r) => r.id === id);
+                      const row = subAgentRows.find((r) => r.id === id);
                       Object.assign(row, fields);
                       return { data: row, error: null };
                     },
@@ -73,11 +99,13 @@ function makeStatefulMockSupabase(rows) {
 
 describe('storeSubAgentResults: phase-scoped dedup (SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001)', () => {
   let rows;
+  let sdTable;
 
   beforeEach(() => {
     rows = [];
+    sdTable = {}; // SD-not-found by default -- preserves pre-derivation null-phase behavior
     vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
-      getSupabaseClient: async () => makeStatefulMockSupabase(rows),
+      getSupabaseClient: async () => makeStatefulMockSupabase(rows, sdTable),
     }));
     vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
       normalizeSDId: async (_s, v) => v,
@@ -137,13 +165,14 @@ describe('storeSubAgentResults: phase-scoped dedup (SD-LEO-INFRA-EVIDENCE-DEDUP-
     expect(row.confidence ?? row.confidence_score).toBe(95);
   });
 
-  it('TS-4: two null-phase calls (legacy caller) still dedup against each other', async () => {
+  it('TS-4: two null-phase calls (legacy caller, SD lookup finds nothing) still dedup against each other', async () => {
     const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
 
     await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 80 });
     await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 95 });
 
     expect(rows).toHaveLength(1);
+    expect(rows[0].phase).toBeNull();
   });
 
   it('a null-phase call and a non-null-phase call never dedup against each other', async () => {
@@ -153,5 +182,105 @@ describe('storeSubAgentResults: phase-scoped dedup (SD-LEO-INFRA-EVIDENCE-DEDUP-
     await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 90 }, { phase: 'PLAN' });
 
     expect(rows).toHaveLength(2);
+  });
+
+  describe('SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (FR-1): never-null phase derivation', () => {
+    it('derives phase from the SD current_phase when no phase is supplied anywhere', async () => {
+      sdTable['SD-TEST-002'] = { id: 'SD-TEST-002', current_phase: 'EXEC' };
+      const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+      await storeSubAgentResults('VALIDATION', 'SD-TEST-002', null, { verdict: 'PASS', confidence: 90 });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].phase).toBe('EXEC');
+    });
+
+    it('two omitted-phase calls straddling a real phase boundary (current_phase changes between calls) produce TWO distinct rows, not one overwritten row', async () => {
+      sdTable['SD-TEST-003'] = { id: 'SD-TEST-003', current_phase: 'PLAN' };
+      const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+      const planId = await storeSubAgentResults('TESTING', 'SD-TEST-003', null, { verdict: 'PASS', confidence: 85 });
+
+      // Simulate the SD progressing from PLAN to EXEC between the two calls --
+      // this is the exact scenario that reproduced fb 0b12ca77 on the majority
+      // (phase-omitting) invocation path even after the phase-scoped dedup shipped.
+      sdTable['SD-TEST-003'].current_phase = 'EXEC';
+
+      const execId = await storeSubAgentResults('TESTING', 'SD-TEST-003', null, { verdict: 'PASS', confidence: 88 });
+
+      expect(rows).toHaveLength(2);
+      expect(execId).not.toBe(planId);
+      const planRow = rows.find((r) => r.phase === 'PLAN');
+      const execRow = rows.find((r) => r.phase === 'EXEC');
+      expect(planRow).toBeDefined();
+      expect(execRow).toBeDefined();
+      expect(planRow.confidence ?? planRow.confidence_score).not.toBe(88);
+    });
+
+    it('two omitted-phase calls with an UNCHANGED current_phase still dedup to one row (derivation does not break same-phase collapsing)', async () => {
+      sdTable['SD-TEST-004'] = { id: 'SD-TEST-004', current_phase: 'PLAN_VERIFICATION' };
+      const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+      const firstId = await storeSubAgentResults('REGRESSION', 'SD-TEST-004', null, { verdict: 'PASS', confidence: 70 });
+      const secondId = await storeSubAgentResults('REGRESSION', 'SD-TEST-004', null, { verdict: 'PASS', confidence: 99 });
+
+      expect(rows).toHaveLength(1);
+      expect(secondId).toBe(firstId);
+      expect(rows[0].phase).toBe('PLAN_VERIFICATION');
+      expect(rows[0].confidence ?? rows[0].confidence_score).toBe(99);
+    });
+
+    it('explicit options.phase still wins over derivation (options.phase takes priority)', async () => {
+      sdTable['SD-TEST-005'] = { id: 'SD-TEST-005', current_phase: 'EXEC' };
+      const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+      await storeSubAgentResults('VALIDATION', 'SD-TEST-005', null, { verdict: 'PASS', confidence: 90 }, { phase: 'LEAD_FINAL_APPROVAL' });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].phase).toBe('LEAD_FINAL_APPROVAL');
+    });
+
+    it('a derived phase (FR-1 fallback) is format-normalized, but an explicitly-supplied phase is left byte-identical', async () => {
+      // Derived path: current_phase has mixed casing/hyphens -> normalized on the way in.
+      sdTable['SD-TEST-006'] = { id: 'SD-TEST-006', current_phase: 'plan-verification' };
+      const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+      await storeSubAgentResults('VALIDATION', 'SD-TEST-006', null, { verdict: 'PASS', confidence: 90 });
+      expect(rows[0].phase).toBe('PLAN_VERIFICATION');
+
+      // Explicit path: many real writers intentionally use a hyphenated convention
+      // (e.g. handoff executors writing 'PLAN-TO-EXEC') and HandoffRepository does an
+      // exact .eq('phase', phase) lookup against it -- this must NOT be rewritten.
+      await storeSubAgentResults('TESTING', 'SD-TEST-007', null, { verdict: 'PASS', confidence: 91 }, { phase: 'PLAN-TO-EXEC' });
+      const explicitRow = rows.find((r) => r.sub_agent_code === 'TESTING');
+      expect(explicitRow.phase).toBe('PLAN-TO-EXEC');
+    });
+  });
+});
+
+describe('normalizePhaseToken (SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 FR-3)', () => {
+  it('collapses casing/separator variants of the SAME phase to one canonical token', async () => {
+    const { normalizePhaseToken } = await import('../../lib/sub-agent-executor/phase-token.js');
+    expect(normalizePhaseToken('PLAN-VERIFICATION')).toBe(normalizePhaseToken('PLAN_VERIFICATION'));
+    expect(normalizePhaseToken('plan verification')).toBe(normalizePhaseToken('PLAN_VERIFICATION'));
+    expect(normalizePhaseToken('exec-to-plan')).toBe('EXEC_TO_PLAN');
+  });
+
+  it('never collapses genuinely distinct sub-phases (no coarse LEAD/PLAN/EXEC bucketing)', async () => {
+    const { normalizePhaseToken } = await import('../../lib/sub-agent-executor/phase-token.js');
+    expect(normalizePhaseToken('PLAN_PRD')).not.toBe(normalizePhaseToken('PLAN_VERIFICATION'));
+    expect(normalizePhaseToken('PLAN_PRD')).toBe('PLAN_PRD');
+    expect(normalizePhaseToken('EXEC_TO_PLAN')).not.toBe(normalizePhaseToken('PLAN_TO_LEAD'));
+  });
+
+  it('is a format-only, non-throwing, idempotent function', async () => {
+    const { normalizePhaseToken } = await import('../../lib/sub-agent-executor/phase-token.js');
+    expect(normalizePhaseToken(null)).toBeNull();
+    expect(normalizePhaseToken(undefined)).toBeNull();
+    expect(normalizePhaseToken('')).toBeNull();
+    expect(normalizePhaseToken('   ')).toBeNull();
+    expect(normalizePhaseToken(123)).toBeNull();
+    const once = normalizePhaseToken('Exec-To-Plan');
+    expect(normalizePhaseToken(once)).toBe(once);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to SD-LEO-INFRA-EVIDENCE-DEDUP-PHASE-KEY-001 (#6237). That SD scoped the sub-agent-evidence dedup query by phase, but RCA (confidence 0.92) found it was a no-op on the majority invocation path: `executor.js` never passed a phase to `storeSubAgentResults`, and the fleet-standard `execute-subagent.js` CLI had no `--phase` flag. 61.4% of `sub_agent_execution_results` rows carried `phase=null`, so two null-phase writes for genuinely different real SD phases still collided, silently reproducing the original bug (fb 0b12ca77).

- **FR-1**: never-null phase-derivation fallback in `results-storage.js` (queries the SD's raw `current_phase` when nothing else supplies a phase)
- **FR-2**: `executor.js` threads the raw `current_phase` into the storage call (not the executor's coarse LEAD/PLAN/EXEC bucket, which would re-collapse sub-phases like `PLAN_PRD` vs `PLAN_VERIFICATION`)
- **FR-3**: new `phase-token.js` with a format-only `normalizePhaseToken()` SSOT, applied **only** to the derived value — explicit caller-supplied phases (e.g. handoff executors writing `'PLAN-TO-EXEC'`) are left byte-identical, since `HandoffRepository.js` does exact `.eq('phase', phase)` lookups against them (this scope-narrowing was discovered via a failing pre-existing test during EXEC, documented in the retrospective)
- **FR-4**: typeof-string-safe `--phase` flag on `scripts/execute-subagent.js` (previously any unrecognized flag coerced to boolean, so `--phase EXEC` silently became `true`)
- **FR-5**: 12 tests extended/added, non-tautologically verified via git-stash before/after (7/12 genuinely fail pre-fix)

DB-level backfill of historical null rows and NOT NULL/CHECK constraints are deferred to a dependent follow-up SD (SD-LEO-INFRA-EVIDENCE-PHASE-NEVER-NULL-001).

## Test plan
- [x] `tests/unit/sub-agent-execution-results-dedup-phase-key.test.js` (12/12, extended)
- [x] `tests/unit/execute-subagent-phase-flag.test.js` (4/4, new)
- [x] `tests/unit/sub-agent-execution-results-phase-column.test.js` + `tests/unit/sub-agent-repo-evidence-persistence.test.js` (9/9, zero regressions)
- [x] Broader related suite (8 files / 105 tests) — zero regressions
- [x] Non-tautology confirmed via git-stash revert
- [x] TESTING (95%), SECURITY (96%), VALIDATION (93%), REGRESSION (96%) sub-agent evidence all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)