### PR TITLE
feat(SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001): wire away-bridge decision scheduler to real seams

### DIFF
--- a/.github/workflows/adam-decision-scheduler-cron.yml
+++ b/.github/workflows/adam-decision-scheduler-cron.yml
@@ -1,0 +1,51 @@
+name: "Adam decision-scheduler tick (cron)"
+
+# SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 — wires the previously-unwired away-bridge
+# (lib/comms/adam-outbound/away-bridge/index.js) to real seams via
+# lib/comms/adam-outbound/decision-scheduler/index.js. This workflow is the named
+# activation trigger the ARMED registration references. Static wiring pinned by
+# tests/unit/cron/adam-decision-scheduler-wiring.test.js — renaming this file, the tick
+# script, or its imports fails CI.
+
+on:
+  schedule:
+    # Hourly at :20, EXCLUDING 02:00-10:59 UTC — the chairman SMS sleep window is
+    # 22:00-06:00 America/New_York (02:00-10:00 UTC in EDT, 03:00-11:00 UTC in EST);
+    # skipping 02-10 UTC covers the union across both DST states year-round. The sender
+    # seam (chairman-sms-gate) ALSO guards its own quiet window in-process, so this
+    # schedule is belt-and-suspenders, not the only protection.
+    - cron: '20 0-1,11-23 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  tick:
+    name: Decision-scheduler tick
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run tick (--once)
+        run: node scripts/cron/adam-decision-scheduler-tick.mjs --once

--- a/.prd-payloads/PRD-SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001.json
@@ -1,0 +1,199 @@
+{
+  "executive_summary": "Part 2 of the adam-outbound wiring: builds the F3 decision-scheduler tick that invokes the already-shipped away-bridge (lib/comms/adam-outbound/away-bridge/index.js, SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E, currently marked @wire-check-exempt because it has zero callers) to re-surface presence-gated OWED chairman decisions. Part 1 (F2: route Adam outbound through the chairman-sms-gate + rubric) shipped live in PR #6241. The away-bridge's owed-state source (child B, sms_outbound_obligations) is a STAGED, chairman-gated migration NOT YET APPLIED to the live DB -- this SD builds the tick fail-soft against that (mirrors the exact convention already used by sms-outbound-worker.js/sms-outbound-reconcile-sweep.mjs: reconcileOutboundSms returns a no-op summary while the table is absent, never throws), so the tick is inert-but-correct today and activates automatically once the chairman applies the STAGED migration -- no further code change needed at that point. LOW priority, resilience backstop only: Adam already surfaces owed decisions manually and reliably.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Decision-scheduler tick module wiring the away-bridge to real seams",
+      "description": "New module lib/comms/adam-outbound/decision-scheduler/index.js exporting runDecisionSchedulerTick(supabase, opts). Builds an owedStore adapter around sms_outbound_obligations reusing the EXISTING smsOutboundObligationsLive() liveness probe (lib/chairman/sms-bridge.js) for fail-soft table-absent handling -- getOwedDecisions() returns [] (not a throw) when the table is absent, matching the away-bridge's already-tested no-op-on-empty behavior. Resolves the presence context {now, lastInputAt} from the most recent claude_sessions.heartbeat_at across active sessions -- an empty/error session query maps to lastInputAt=null, which away-bridge's own isAway() already treats as 'unknown presence => treat as present' (never texts blindly, fail-safe by construction). Wires sender to the ALREADY-LIVE chairman-sms-gate + rubric send path (lib/comms/adam-outbound/chairman-sms-gate/index.js, shipped Part 1/F2) and escalateEmail to the existing chairman decision-email escalation pipeline (lib/chairman/record-pending-decision.mjs's escalateChairmanDecision, or an equivalent existing seam -- reused, not reinvented, per the away-bridge module's own K-reached email-escalation contract). Calls the UNMODIFIED processOwedDecisions(context, {owedStore, sender, escalateEmail}) from lib/comms/adam-outbound/away-bridge/index.js. [VALIDATION (2026-07-18) HONESTY CORRECTION]: fleet worker sessions heartbeat roughly every ~2s and are near-continuously active, so MAX(claude_sessions.heartbeat_at) will almost always be within seconds of 'now' -- isAway() will be near-ALWAYS false with this signal, meaning the tick will near-NEVER re-surface, not merely 'occasionally under-fire' as originally stated. This is documented here as an EXPLICIT, ACCEPTED limitation (not a silent gap): the tick is correctly wired and will activate the moment a better chairman-specific presence signal exists, but with today's only available fleet-wide signal it functions as a structurally-inert-but-harmless backstop, consistent with the SD's own LOW-priority/resilience-backstop framing. A real chairman-terminal-presence signal is explicitly OUT OF SCOPE for this SD (would require new instrumentation, not wiring) and is noted as a natural future enhancement, not a defect of this SD.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "runDecisionSchedulerTick calls processOwedDecisions with a correctly-shaped owedStore/sender/escalateEmail per the away-bridge module's own documented interface, with zero modification to away-bridge/index.js's exported functions",
+        "While sms_outbound_obligations is absent (current live state), the tick runs to completion and returns a no-op summary -- never throws, matching the sibling sms-outbound-worker.js fail-soft convention",
+        "An empty or errored presence-signal query resolves to lastInputAt=null, which away-bridge's own isAway() treats as present (safe default) -- verified by a test, not just asserted",
+        "Once sms_outbound_obligations is live (future chairman-apply), the SAME code path (no new code) reads real owed rows and re-surfaces per away-bridge's existing, already-tested policy",
+        "The near-inertness of the claude_sessions.heartbeat_at presence signal is documented in the module's own header comment, not just the PRD -- so a future reader does not mistake this for a fully-functional presence gate"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Durable cron runner (no session-local timers)",
+      "description": "New script scripts/cron/adam-decision-scheduler-tick.mjs --once, mirroring scripts/cron/chairman-decision-sla-sweep.mjs's shape (parseArgs, buildSupabase, main(argv, deps), gracefulExit, isMain guard, AND its ensureArmedRegistration/registerArmedMachinery call -- NOT the sms-outbound-reconcile-sweep.mjs template, which lacks ARMED registration) -- a plain async invocation with NO setTimeout/setInterval/cron of its own, so a fresh cold process can run it. Calls registerArmedMachinery(supabase, {sd_key:'SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001'}, {activationTrigger: 'sms_outbound_obligations STAGED migration applied by chairman ceremony', expectedIntervalSeconds, owner}) idempotently on each run (check-then-upsert, mirroring chairman-decision-sla-sweep.mjs's ensureArmedRegistration, never wiping a real last_fired_at) -- this SD's own machinery genuinely cannot demonstrate real events yet (the owed-decision producer table is unapplied), so ARMED registration is the correct Definition-of-Done shape (SD-LEO-INFRA-DEFINITION-DONE-ACTIVATION-001 G3), not an afterthought. [VALIDATION (2026-07-18) FIX]: a package.json scripts entry (e.g. 'adam:decision-scheduler:tick:cron': 'node scripts/cron/adam-decision-scheduler-tick.mjs --once', matching the existing <name>:cron naming convention seen at eva:scheduler:watch:cron/cascade:watch:cron) is REQUIRED -- the blocking LEAD-FINAL WIRE_CHECK_GATE discovers entry points ONLY from package.json scripts + a small hardcoded pipeline list (scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js discoverEntryPoints()); a GHA-cron-only script with no package.json entry has NO static reachability root and both new files (this script + decision-scheduler/index.js) would FAIL WIRE_CHECK at LEAD-FINAL without it. A new .github/workflows/adam-decision-scheduler-cron.yml registers the CADENCE (separate from WIRE_CHECK reachability, which the package.json entry alone satisfies), mirroring .github/workflows/chairman-decision-sla-cron.yml's shape (schedule + workflow_dispatch, concurrency group). [VALIDATION FIX]: use the chairman's actual SMS quiet window (22:00-06:00 America/New_York per feedback_chairman_sleep_window_sms_10pm_6am_et, DST-aware) for this cron's schedule math, NOT a direct copy of the SLA sweep's 23:00-05:00 email-window numbers -- they are different, purpose-specific windows and copying the wrong one would fire SMS-adjacent machinery during part of the real sleep window. [EXPLORE (2026-07-18) FINDING]: no existing SMS-specific 22:00-06:00 quiet-window function exists anywhere in the repo (confirmed by repo-wide search; the STAGED sms_outbound_obligations migration column comment describes intended semantics but implements nothing) -- this SD must inline a small, DST-aware Intl-based hour check mirroring isWithinChairmanQuietWindow (lib/notifications/resend-adapter.js) but with the 22/6 boundary, scoped to this cron only (not a new shared export unless a natural home emerges during EXEC).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "scripts/cron/adam-decision-scheduler-tick.mjs --once runs to completion with exit code 0 against the current (table-absent) live DB state",
+        "package.json gains a <name>:cron script entry invoking the new script, so WIRE_CHECK_GATE has a real static reachability root for both new files",
+        "The tick idempotently ensures an ARMED periodic_process_registry row exists (registerArmedMachinery, activationTrigger naming the STAGED-migration-apply event) without wiping a real last_fired_at on repeat runs",
+        "The cron YAML's schedule excludes the chairman's 22:00-06:00 America/New_York SMS sleep window (DST-aware), NOT a copy-pasted different window from an unrelated sweep",
+        "A static wiring test (mirroring tests/unit/cron/chairman-decision-sla-wiring.test.js) pins the script -> tick-module import path, so a rename/refactor breaks CI loudly instead of silently un-wiring the tick"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Remove the now-inaccurate WIRE_CHECK exemption comment on the away-bridge (hygiene, not a gate-blocking fix)",
+      "description": "Remove the `// @wire-check-exempt: away-bridge...` comment from lib/comms/adam-outbound/away-bridge/index.js now that FR-1's tick module genuinely imports and calls processOwedDecisions, so the comment stops being misleading. [VALIDATION (2026-07-18) CORRECTION]: the blocking LEAD-FINAL WIRE_CHECK_GATE only evaluates files NEWLY ADDED in this SD's diff (git diff --diff-filter=A origin/main...HEAD) -- away-bridge/index.js already exists on origin/main from a prior SD, so it is a MODIFIED file this gate does NOT re-check regardless of the marker's presence. Removing the marker is therefore documentation hygiene (the comment would otherwise be false -- it now HAS a caller), not something the gate enforces either way for this file. The REAL WIRE_CHECK exposure for this SD is FR-2's two genuinely-new files, which is why FR-2 requires a package.json entry point.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "lib/comms/adam-outbound/away-bridge/index.js no longer carries the @wire-check-exempt marker (now inaccurate since it has a real caller)",
+        "The LEAD-FINAL WIRE_CHECK_GATE passes for this SD's two genuinely-new files (FR-2's tick module and cron script) via the FR-2 package.json entry point -- verified at the LEAD-FINAL-APPROVAL handoff"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "No mutation of the away-bridge or chairman-sms-gate contracts",
+      "description": "processOwedDecisions, isAway, and the chairman-sms-gate's send interface are consumed as-is; this SD is purely a caller/wirer."
+    },
+    {
+      "id": "TR-2",
+      "title": "Fail-soft on every missing dependency",
+      "description": "sms_outbound_obligations absent, a presence-query error, or a send-path error must each degrade to a safe no-op (skip / treat-as-present / log-and-continue) -- never throw uncaught, never crash the durable runner."
+    },
+    {
+      "id": "TR-3",
+      "title": "No new email-sending or SMS-sending code",
+      "description": "Re-surface sends route through the existing chairman-sms-gate; escalation emails route through the existing chairman decision-email pipeline. Zero new provider-calling code in this SD."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Tick runs to completion (no-op) while sms_outbound_obligations is absent",
+      "type": "unit",
+      "expected": "Returns a no-op summary, zero throws, zero sends"
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Tick wires owedStore/sender/escalateEmail correctly into processOwedDecisions",
+      "type": "unit",
+      "expected": "processOwedDecisions is called with the documented interface shape; a mocked owed decision flows through resurfaced/dropped_answered/escalated_email per away-bridge's existing policy"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Presence resolution: empty/errored session query maps to lastInputAt=null (treated as present)",
+      "type": "unit",
+      "expected": "isAway() returns false, no re-surface fires"
+    },
+    {
+      "id": "TS-4",
+      "scenario": "Cron script --once exits 0 against current live DB (table absent)",
+      "type": "integration",
+      "expected": "Exit code 0, no-op summary logged, ARMED registration ensured idempotently"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "Static wiring test pins the cron script's tick-module import",
+      "type": "unit",
+      "expected": "A rename/refactor of the import path fails the test"
+    },
+    {
+      "id": "TS-6",
+      "scenario": "package.json entry gives the two new files a real WIRE_CHECK reachability root",
+      "type": "integration",
+      "expected": "decision-scheduler/index.js and adam-decision-scheduler-tick.mjs are both statically reachable from the package.json script entry"
+    },
+    {
+      "id": "TS-7",
+      "scenario": "ARMED registration is idempotent across repeat runs",
+      "type": "unit",
+      "expected": "A second call to ensureArmedRegistration against an already-registered process_key does not wipe a real last_fired_at value"
+    }
+  ],
+  "acceptance_criteria": [
+    "(a) A live entry point (the cron script, package.json-wired for WIRE_CHECK reachability) invokes the away-bridge on a cadence, with an ARMED periodic_process_registry registration since the real producer (sms_outbound_obligations) is not yet live",
+    "(b) An owed decision left un-surfaced beyond a threshold is re-surfaced -- proven at the unit level against the away-bridge's own already-tested K-reached/idempotent policy, since the live table is not yet populated",
+    "(c) No double-surface of a decision Adam already raised manually -- inherited for free from away-bridge's own answered-check + resurfacedThisWindow idempotency, not reimplemented"
+  ],
+  "risks": [
+    {
+      "risk": "sms_outbound_obligations stays STAGED/unapplied indefinitely, so the tick never does real work",
+      "mitigation": "This is explicitly acceptable per the SD's own framing (LOW priority, resilience backstop, manual surfacing works today) -- the tick activates automatically once the chairman applies the migration, no follow-up SD needed; the ARMED registration makes this a tracked, monitored state rather than a silent no-op",
+      "severity": "low"
+    },
+    {
+      "risk": "The claude_sessions.heartbeat_at presence proxy makes the tick STRUCTURALLY NEAR-INERT (fleet sessions heartbeat ~every 2s, so isAway() is near-always false), not merely occasionally under-firing",
+      "mitigation": "VALIDATION-confirmed and explicitly documented in-code and in this PRD as an accepted limitation, not a silent gap -- away-bridge's own fail-safe default means this degrades toward UNDER-firing (safe direction), and the tick's wiring is otherwise complete and correct; a real chairman-presence signal is an explicit future enhancement, out of scope here",
+      "severity": "medium"
+    },
+    {
+      "risk": "A second, uncoordinated cron cadence duplicates the SLA sweep's own quiet-window logic and drifts out of sync over time",
+      "mitigation": "The new cron YAML uses the chairman's actual SMS-specific 22:00-06:00 America/New_York window (not a copy of the SLA sweep's different email-window numbers), with a comment cross-referencing the SLA sweep for future-edit awareness",
+      "severity": "low"
+    },
+    {
+      "risk": "Forgetting the package.json entry point silently fails WIRE_CHECK_GATE at LEAD-FINAL, forcing a 2nd PR",
+      "mitigation": "Explicitly called out as a required FR-2 acceptance criterion (VALIDATION-caught), not left implicit",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "Chairman (re-surfaced owed decisions via the live SMS/console channel)"
+    ],
+    "dependencies": [
+      "SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E (merged, away-bridge)",
+      "SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-B (merged code, STAGED migration -- sms_outbound_obligations not yet applied)",
+      "SD-LEO-INFRA-ADAM-OUTBOUND-WIRE-LIVE-001 Part 1 (merged, PR #6241 -- chairman-sms-gate + rubric live)"
+    ],
+    "data_contracts": [
+      "Reads sms_outbound_obligations (fail-soft if absent), reads claude_sessions.heartbeat_at (existing column)"
+    ],
+    "runtime_config": [
+      "Cron schedule via the new GHA workflow; no new env vars"
+    ],
+    "observability_rollout": [
+      "Structured log line per tick run (mirrors sms-outbound-sweep's log shape); inert (logs a clear no-op) until the chairman applies the STAGED migration"
+    ]
+  },
+  "system_architecture": {
+    "summary": "One new lib module (the tick, pure wiring) + one new cron script (durable runner) + one new GHA workflow (cadence) + removal of one exempt marker.",
+    "components": [
+      {
+        "name": "lib/comms/adam-outbound/decision-scheduler/index.js",
+        "change": "NEW"
+      },
+      {
+        "name": "scripts/cron/adam-decision-scheduler-tick.mjs",
+        "change": "NEW"
+      },
+      {
+        "name": ".github/workflows/adam-decision-scheduler-cron.yml",
+        "change": "NEW"
+      },
+      {
+        "name": "lib/comms/adam-outbound/away-bridge/index.js",
+        "change": "MODIFIED (remove @wire-check-exempt marker only, no logic change)"
+      }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the tick module first (independently unit-testable against mocks), then the cron runner mirroring the sms-outbound sibling exactly, then the GHA workflow mirroring the SLA-sweep sibling, then remove the exempt marker last (once real reachability exists).",
+    "steps": [
+      "Write lib/comms/adam-outbound/decision-scheduler/index.js with an injectable-seams design (owedStore, sender, escalateEmail, sessionQuery), unit tests for all branches including fail-soft paths",
+      "Write scripts/cron/adam-decision-scheduler-tick.mjs mirroring sms-outbound-reconcile-sweep.mjs's structure",
+      "Write the static wiring test pinning the cron-script -> tick-module import",
+      "Write .github/workflows/adam-decision-scheduler-cron.yml mirroring chairman-decision-sla-cron.yml's schedule shape",
+      "Remove the @wire-check-exempt marker from away-bridge/index.js and verify WIRE_CHECK_GATE passes without it"
+    ]
+  },
+  "smoke_test_steps": [
+    {
+      "step_number": 1,
+      "instruction": "Run node scripts/cron/adam-decision-scheduler-tick.mjs --once against the live (table-absent) DB",
+      "expected_outcome": "Exits 0, logs a clear no-op summary, zero throws"
+    },
+    {
+      "step_number": 2,
+      "instruction": "Run the unit test suite for the new decision-scheduler module with a mocked populated owedStore",
+      "expected_outcome": "A mocked owed decision correctly flows through resurfaced/dropped/escalated per away-bridge's existing policy"
+    },
+    {
+      "step_number": 3,
+      "instruction": "Run the WIRE_CHECK_GATE reachability check against away-bridge/index.js post-marker-removal",
+      "expected_outcome": "Passes (file is statically reachable from the new cron entry point)"
+    }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001"
+  }
+}

--- a/lib/comms/adam-outbound/away-bridge/index.js
+++ b/lib/comms/adam-outbound/away-bridge/index.js
@@ -1,6 +1,9 @@
-// @wire-check-exempt: away-bridge — invoked by the Adam decision-scheduler tick (not yet wired); consumes -B owed-state. Part of SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E.
 /**
  * Away-bridge — SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E (Layer 3, parent FR-5).
+ *
+ * Wired to real seams by lib/comms/adam-outbound/decision-scheduler/index.js
+ * (SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001), invoked by
+ * scripts/cron/adam-decision-scheduler-tick.mjs.
  *
  * A presence-gated re-surfacer for OWED, UNANSWERED chairman DECISIONS.
  *

--- a/lib/comms/adam-outbound/decision-scheduler/index.js
+++ b/lib/comms/adam-outbound/decision-scheduler/index.js
@@ -1,0 +1,156 @@
+/**
+ * Adam decision-scheduler tick — SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 (Part 2 of
+ * adam-outbound wiring; Part 1 = the chairman-sms-gate + rubric, live in PR #6241).
+ *
+ * Wires the already-shipped away-bridge (lib/comms/adam-outbound/away-bridge/index.js,
+ * SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E) to real seams: an owedStore adapter over
+ * sms_outbound_obligations, a presence signal, the live chairman-sms-gate sender, and
+ * the existing chairman decision-email escalation path. away-bridge itself is NOT
+ * modified (TR-1) -- this module is purely the wiring layer.
+ *
+ * FAIL-SOFT (TR-2): sms_outbound_obligations is a STAGED migration, not yet applied to
+ * the live DB. getOwedDecisions() returns [] (never throws) while the table is absent,
+ * reusing the existing smsOutboundObligationsLive() liveness probe. Once applied, the
+ * SAME code path reads real rows -- but see the column-mapping caveat below.
+ *
+ * COLUMN-MAPPING CAVEAT (real, documented, not a silent gap): sms_outbound_obligations
+ * has NO `answered`, `resurfaceCount`, or `resurfacedThisWindow` columns -- `status`
+ * tracks SMS delivery, not decision-answered state, and `attempts` is provider
+ * send-attempts, not away-bridge re-surfaces. This adapter transforms the columns that
+ * DO exist (id -> owedId, body -> message.body, decision_id threaded to the escalation
+ * seam) and filters to decision rows only (kind='decision_question' AND decision_id IS
+ * NOT NULL). The answered-derivation and durable re-surface bookkeeping that the STAGED
+ * schema has no columns for are EXPLICITLY DEFERRED to the chairman-apply follow-up
+ * under the same named ARMED activation trigger (see scripts/cron/adam-decision-scheduler-tick.mjs)
+ * -- never silently assumed to arrive "for free" once the table is live.
+ *
+ * PRESENCE SIGNAL (accepted limitation, documented not hidden): {now, lastInputAt} is
+ * resolved from the most recent claude_sessions.heartbeat_at across active sessions.
+ * Fleet worker sessions heartbeat roughly every ~2s and are near-continuously active, so
+ * this signal makes away-bridge's isAway() near-ALWAYS false -- the tick will near-NEVER
+ * fire a re-surface with today's only available fleet-wide signal. This degrades toward
+ * UNDER-firing (the safe direction for a LOW-priority resilience backstop), never toward
+ * spamming the chairman. A real chairman-terminal-presence signal is a future
+ * enhancement, explicitly out of scope here.
+ */
+import { smsOutboundObligationsLive } from '../../../chairman/sms-bridge.js';
+import { sendChairmanSMS } from '../chairman-sms-gate/index.js';
+import { escalateChairmanDecision } from '../../../chairman/record-pending-decision.mjs';
+import { processOwedDecisions, isAway } from '../away-bridge/index.js';
+
+const DECISION_KIND = 'decision_question';
+
+/**
+ * Build the owedStore adapter over sms_outbound_obligations.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {{getOwedDecisions: () => Promise<Array>, markResurfaced: (id: string) => Promise<void>}}
+ */
+export function buildOwedStore(supabase) {
+  return {
+    async getOwedDecisions() {
+      const live = await smsOutboundObligationsLive(supabase);
+      if (!live) return [];
+      try {
+        const { data, error } = await supabase
+          .from('sms_outbound_obligations')
+          .select('id, decision_id, body, status')
+          .eq('kind', DECISION_KIND)
+          .not('decision_id', 'is', null);
+        if (error || !data) return [];
+        // COLUMN-MAPPING CAVEAT (see module header): no backing column for
+        // answered/resurfaceCount/resurfacedThisWindow. Deferred defaults chosen so
+        // away-bridge's policy still runs safely: answered=false (never silently drop a
+        // real owed decision), resurfaceCount=0 / resurfacedThisWindow=false (never
+        // silently skip -- correct behavior is deferred to the chairman-apply follow-up,
+        // not faked here).
+        return data.map((row) => ({
+          owedId: row.id,
+          decisionId: row.decision_id,
+          message: { body: row.body, decisionId: row.decision_id },
+          answered: false,
+          resurfaceCount: 0,
+          resurfacedThisWindow: false,
+        }));
+      } catch {
+        return [];
+      }
+    },
+    async markResurfaced() {
+      // COLUMN-MAPPING CAVEAT: no durable sink for resurfacedThisWindow in the STAGED
+      // schema -- deferred to the chairman-apply follow-up. Intentionally a no-op today
+      // (documented, not silent) rather than writing to a column that doesn't exist.
+    },
+  };
+}
+
+/**
+ * Resolve the fleet-wide presence context from claude_sessions.heartbeat_at.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{now: number, lastInputAt: number|null}>}
+ */
+export async function resolvePresenceContext(supabase) {
+  const now = Date.now();
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('heartbeat_at')
+      .order('heartbeat_at', { ascending: false })
+      .limit(1);
+    if (error || !data || data.length === 0 || !data[0].heartbeat_at) {
+      return { now, lastInputAt: null };
+    }
+    const lastInputAt = Date.parse(data[0].heartbeat_at);
+    return { now, lastInputAt: Number.isFinite(lastInputAt) ? lastInputAt : null };
+  } catch {
+    return { now, lastInputAt: null };
+  }
+}
+
+/**
+ * Build a sender wrapping the live chairman-sms-gate.
+ * @returns {(message: object) => Promise<void>}
+ */
+function buildSender() {
+  return async (message) => {
+    await sendChairmanSMS(
+      { decisionId: message.decisionId, body: message.body, type: 'decision' },
+      {},
+      {}
+    );
+  };
+}
+
+/**
+ * Build an escalateEmail seam wrapping the existing chairman decision-email pipeline.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {(owed: object) => Promise<void>}
+ */
+function buildEscalateEmail(supabase) {
+  return async (owed) => {
+    if (!owed || !owed.decisionId) return;
+    await escalateChairmanDecision(supabase, owed.decisionId);
+  };
+}
+
+/**
+ * Run one decision-scheduler tick: wire the away-bridge to real seams and process owed
+ * decisions once. Fail-soft throughout (TR-2) -- never throws.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {object} [opts] - injectable seams for tests: {owedStore, sender, escalateEmail, presence}
+ * @returns {Promise<{ran: boolean, results: Array}>}
+ */
+export async function runDecisionSchedulerTick(supabase, opts = {}) {
+  try {
+    const owedStore = opts.owedStore || buildOwedStore(supabase);
+    const sender = opts.sender || buildSender();
+    const escalateEmail = opts.escalateEmail || buildEscalateEmail(supabase);
+    const context = opts.presence || (await resolvePresenceContext(supabase));
+
+    const results = await processOwedDecisions(context, { owedStore, sender, escalateEmail });
+    return { ran: true, results };
+  } catch (err) {
+    return { ran: false, results: [], error: (err && err.message) || String(err) };
+  }
+}
+
+export { isAway };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cascade:watch:cron": "node scripts/cron/cascade-watcher.mjs --once",
     "leo:build:start:cron": "node scripts/cron/leo-build-starter.mjs --once",
     "eva:scheduler:watch:cron": "node scripts/cron/eva-scheduler-watcher.mjs --once",
+    "adam:decision-scheduler:tick:cron": "node scripts/cron/adam-decision-scheduler-tick.mjs --once",
     "apa:standing:probe:once": "node scripts/apa-standing-probe-once.mjs --once",
     "adam:exec:email:cron": "node scripts/adam-exec-summary.mjs",
     "fleet:spawn-executor": "node scripts/fleet/worker-spawn-executor.cjs",

--- a/scripts/cron/adam-decision-scheduler-tick.mjs
+++ b/scripts/cron/adam-decision-scheduler-tick.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Adam decision-scheduler tick — the durable production runner for the away-bridge
+ * (lib/comms/adam-outbound/away-bridge/index.js, SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E),
+ * wired to real seams via lib/comms/adam-outbound/decision-scheduler/index.js.
+ *
+ * SD: SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 (FR-2)
+ *
+ * FAIL-SOFT: sms_outbound_obligations is a STAGED migration, not yet applied live. While
+ * absent, runDecisionSchedulerTick() returns {ran:true, results:[]} (owedStore.getOwedDecisions
+ * returns [] fail-soft) and this sweep exits 0. Once the migration is applied, the SAME code
+ * path processes real owed decision rows -- see the decision-scheduler module header for the
+ * documented column-mapping caveat (no answered/resurfaceCount/resurfacedThisWindow columns).
+ *
+ * Liveness: registers ARMED machinery once (periodic_process_registry, named activation
+ * trigger = this cron workflow) and stamps last_fired_at on every real run, mirroring
+ * scripts/cron/chairman-decision-sla-sweep.mjs. Static wiring pinned by
+ * tests/unit/cron/adam-decision-scheduler-wiring.test.js.
+ *
+ * Usage:
+ *   node scripts/cron/adam-decision-scheduler-tick.mjs --once             # one tick (canonical cron)
+ *   node scripts/cron/adam-decision-scheduler-tick.mjs --once --dry-run   # report intent, no writes
+ *
+ * Env: SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (required)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+import { runDecisionSchedulerTick } from '../../lib/comms/adam-outbound/decision-scheduler/index.js';
+import { registerArmedMachinery, armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+
+export const SD_KEY = 'SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001';
+export const ACTIVATION_TRIGGER = 'sms_outbound_obligations STAGED migration applied by chairman ceremony';
+
+/**
+ * DST-aware chairman SMS sleep-window check — 22:00-06:00 America/New_York (a DIFFERENT,
+ * SMS-specific window from the general 23:00-05:00 chairman/email quiet window guarded by
+ * isWithinChairmanQuietWindow in lib/notifications/resend-adapter.js). No shared helper for
+ * this exact boundary exists repo-wide (confirmed by search), so it is inlined here, scoped
+ * to this cron only, mirroring the same Intl/toLocaleTimeString pattern.
+ *
+ * This RUNTIME check is authoritative. The GHA cron schedule (adam-decision-scheduler-cron.yml)
+ * is only a coarse UTC cadence limiter and cannot itself be DST-precise for an ET window.
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+export function isWithinAdamSmsQuietWindow(now = new Date()) {
+  const hour = Number(now.toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour12: false, hour: '2-digit' }));
+  return hour >= 22 || hour < 6;
+}
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+/** Ensure the ARMED registration exists WITHOUT wiping last_fired_at (registerArmedMachinery upserts null). */
+async function ensureArmedRegistration(supabase, logger) {
+  const processKey = armedProcessKey(SD_KEY);
+  try {
+    const { data } = await supabase
+      .from('periodic_process_registry')
+      .select('process_key')
+      .eq('process_key', processKey)
+      .maybeSingle();
+    if (!data) {
+      const reg = await registerArmedMachinery(supabase, { sd_key: SD_KEY }, {
+        activationTrigger: ACTIVATION_TRIGGER,
+        expectedIntervalSeconds: 2 * 60 * 60, // hourly cron with headroom
+        owner: 'adam-decision-scheduler-tick',
+      });
+      if (!reg.ok) logger.warn?.(`[decision-scheduler-tick] ARMED registration failed (non-fatal): ${reg.error}`);
+    }
+  } catch (err) {
+    logger.warn?.(`[decision-scheduler-tick] ARMED registration check failed (non-fatal): ${err.message}`);
+  }
+  return processKey;
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  const logger = deps.logger || console;
+  if (args.help) {
+    logger.log?.('adam-decision-scheduler-tick --once [--dry-run]');
+    return { exitCode: 0, action: 'help' };
+  }
+
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) {
+    logger.error?.(`[decision-scheduler-tick] supabase client unavailable: ${err.message}`);
+    return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  if (args.dryRun) {
+    logger.log?.('[decision-scheduler-tick] dry-run: no tick performed');
+    return { exitCode: 0, action: 'dry_run' };
+  }
+
+  // Liveness first — a genuine invocation is always recorded even if the tick errors below.
+  const processKey = await ensureArmedRegistration(supabase, logger);
+  try { await (deps.stampLastFired || stampLastFired)(supabase, processKey); }
+  catch (err) { logger.warn?.(`[decision-scheduler-tick] liveness stamp failed (non-fatal): ${err.message}`); }
+
+  // Authoritative runtime guard (FR-2 AC) — the GHA schedule is only a coarse cadence
+  // limiter and cannot itself be DST-precise for the 22:00-06:00 America/New_York window.
+  const now = deps.now || new Date();
+  const quietCheck = deps.isWithinAdamSmsQuietWindow || isWithinAdamSmsQuietWindow;
+  if (quietCheck(now)) {
+    logger.log?.(`[decision-scheduler-tick] ${JSON.stringify({ ts: now.toISOString(), action: 'quiet_window_skip' })}`);
+    return { exitCode: 0, action: 'quiet_window_skip' };
+  }
+
+  const tick = deps.runDecisionSchedulerTick || runDecisionSchedulerTick;
+  const result = await tick(supabase, {});
+  const summary = {
+    ts: new Date().toISOString(),
+    ran: result.ran,
+    processed: (result.results || []).length,
+    error: result.error || null,
+  };
+  logger.log?.(`[decision-scheduler-tick] ${JSON.stringify(summary)}`);
+  return { exitCode: result.ran ? 0 : 1, action: result.ran ? 'ticked' : 'error', summary };
+}
+
+/** Windows-safe termination (mirrors scripts/cron/chairman-decision-sla-sweep.mjs::gracefulExit). */
+export async function gracefulExit(exitCode, { backstopMs = 4000 } = {}) {
+  process.exitCode = exitCode;
+  try {
+    const undici = await import('undici');
+    await undici.getGlobalDispatcher?.()?.close?.();
+  } catch { /* undici absent — natural drain still applies */ }
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+}
+
+if (isMainModule(import.meta.url)) {
+  main().then(({ exitCode }) => gracefulExit(exitCode))
+        .catch((err) => { console.error('adam-decision-scheduler-tick fatal:', err.message); return gracefulExit(2); });
+}

--- a/tests/unit/comms/adam-outbound/decision-scheduler.test.js
+++ b/tests/unit/comms/adam-outbound/decision-scheduler.test.js
@@ -1,0 +1,202 @@
+/**
+ * SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 — wiring layer over the already-shipped
+ * away-bridge. TS-1, TS-2, TS-3, TS-8 per the amended PRD.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../lib/comms/adam-outbound/chairman-sms-gate/index.js', () => ({
+  sendChairmanSMS: vi.fn(async () => ({ sent: true })),
+}));
+vi.mock('../../../../lib/chairman/record-pending-decision.mjs', () => ({
+  escalateChairmanDecision: vi.fn(async () => ({ escalated: true })),
+}));
+
+import { sendChairmanSMS } from '../../../../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+import { escalateChairmanDecision } from '../../../../lib/chairman/record-pending-decision.mjs';
+import {
+  buildOwedStore,
+  resolvePresenceContext,
+  runDecisionSchedulerTick,
+} from '../../../../lib/comms/adam-outbound/decision-scheduler/index.js';
+
+/** Minimal fake supabase: supports select/eq/not/order/limit chains and an "absent table" mode. */
+function makeFakeSupabase({ tables = {}, absentTables = [] } = {}) {
+  const absent = new Set(absentTables);
+
+  function applyFilters(rows, filters) {
+    return rows.filter((row) =>
+      filters.every(([col, op, val]) => {
+        if (op === 'eq') return row[col] === val;
+        if (op === 'not_is_null') return row[col] !== null && row[col] !== undefined;
+        return true;
+      })
+    );
+  }
+
+  function from(table) {
+    const ctx = { filters: [], order: null, limitN: null };
+    const api = {
+      select() { return api; },
+      eq(col, val) { ctx.filters.push([col, 'eq', val]); return api; },
+      not(col) { ctx.filters.push([col, 'not_is_null', null]); return api; },
+      order(col, { ascending } = {}) { ctx.order = { col, ascending: !!ascending }; return api; },
+      limit(n) { ctx.limitN = n; return api; },
+      then(resolve) {
+        if (absent.has(table)) {
+          resolve({ data: null, error: { message: `relation "${table}" does not exist` } });
+          return;
+        }
+        let rows = applyFilters(tables[table] || [], ctx.filters);
+        if (ctx.order) {
+          rows = [...rows].sort((a, b) => {
+            const cmp = a[ctx.order.col] < b[ctx.order.col] ? -1 : a[ctx.order.col] > b[ctx.order.col] ? 1 : 0;
+            return ctx.order.ascending ? cmp : -cmp;
+          });
+        }
+        if (ctx.limitN != null) rows = rows.slice(0, ctx.limitN);
+        resolve({ data: rows, error: null });
+      },
+    };
+    return api;
+  }
+
+  return { from };
+}
+
+beforeEach(() => {
+  sendChairmanSMS.mockClear();
+  escalateChairmanDecision.mockClear();
+});
+
+describe('buildOwedStore', () => {
+  it('TS-1: getOwedDecisions returns [] (never throws) while sms_outbound_obligations is absent', async () => {
+    const sb = makeFakeSupabase({ absentTables: ['sms_outbound_obligations'] });
+    const store = buildOwedStore(sb);
+    await expect(store.getOwedDecisions()).resolves.toEqual([]);
+  });
+
+  it('TS-8: maps real columns, filters to decision rows, resolves unbacked fields to explicit deferred defaults', async () => {
+    const sb = makeFakeSupabase({
+      tables: {
+        sms_outbound_obligations: [
+          { id: 'row-1', kind: 'decision_question', decision_id: 'dec-1', body: 'Approve X?', status: 'owed' },
+          { id: 'row-2', kind: 'morning_review', decision_id: null, body: 'Good morning', status: 'sent' },
+          { id: 'row-3', kind: 'decision_question', decision_id: null, body: 'orphaned', status: 'owed' },
+        ],
+      },
+    });
+    const store = buildOwedStore(sb);
+    const owed = await store.getOwedDecisions();
+    expect(owed).toHaveLength(1);
+    expect(owed[0]).toMatchObject({
+      owedId: 'row-1',
+      decisionId: 'dec-1',
+      message: { body: 'Approve X?', decisionId: 'dec-1' },
+      answered: false,
+      resurfaceCount: 0,
+      resurfacedThisWindow: false,
+    });
+  });
+
+  it('markResurfaced is a documented no-op (no backing STAGED column)', async () => {
+    const sb = makeFakeSupabase({ tables: { sms_outbound_obligations: [] } });
+    const store = buildOwedStore(sb);
+    await expect(store.markResurfaced('row-1')).resolves.toBeUndefined();
+  });
+});
+
+describe('resolvePresenceContext', () => {
+  it('TS-3: empty claude_sessions -> lastInputAt null, which away-bridge isAway() treats as present', async () => {
+    const sb = makeFakeSupabase({ tables: { claude_sessions: [] } });
+    const ctx = await resolvePresenceContext(sb);
+    expect(ctx.lastInputAt).toBeNull();
+    expect(typeof ctx.now).toBe('number');
+  });
+
+  it('TS-3: errored session query -> lastInputAt null, never throws', async () => {
+    const sb = makeFakeSupabase({ absentTables: ['claude_sessions'] });
+    const ctx = await resolvePresenceContext(sb);
+    expect(ctx.lastInputAt).toBeNull();
+  });
+
+  it('resolves the most recent heartbeat_at when present', async () => {
+    const sb = makeFakeSupabase({
+      tables: {
+        claude_sessions: [
+          { heartbeat_at: '2026-07-18T00:00:00.000Z' },
+          { heartbeat_at: '2026-07-18T00:05:00.000Z' },
+        ],
+      },
+    });
+    const ctx = await resolvePresenceContext(sb);
+    expect(ctx.lastInputAt).toBe(Date.parse('2026-07-18T00:05:00.000Z'));
+  });
+});
+
+describe('runDecisionSchedulerTick', () => {
+  it('fail-soft: never throws when the tick errors internally', async () => {
+    const sb = makeFakeSupabase();
+    const result = await runDecisionSchedulerTick(sb, {
+      owedStore: { getOwedDecisions: async () => { throw new Error('boom'); }, markResurfaced: async () => {} },
+      presence: { now: 1000, lastInputAt: 0, awayThresholdMs: 900_000 },
+    });
+    expect(result.ran).toBe(false);
+    expect(result.error).toMatch(/boom/);
+  });
+
+  it('TS-2: wires owedStore/sender/escalateEmail into processOwedDecisions — away + owed -> resurfaced via sendChairmanSMS', async () => {
+    const sb = makeFakeSupabase();
+    const owedStore = {
+      getOwedDecisions: async () => [{
+        owedId: 'row-1', decisionId: 'dec-1', message: { body: 'Approve X?', decisionId: 'dec-1' },
+        answered: false, resurfaceCount: 0, resurfacedThisWindow: false,
+      }],
+      markResurfaced: vi.fn(async () => {}),
+    };
+    const AWAY = { now: 1_000_000, lastInputAt: 0, awayThresholdMs: 900_000 };
+    const result = await runDecisionSchedulerTick(sb, { owedStore, presence: AWAY });
+    expect(result.ran).toBe(true);
+    expect(result.results[0].action).toBe('resurfaced');
+    expect(sendChairmanSMS).toHaveBeenCalledTimes(1);
+    expect(sendChairmanSMS.mock.calls[0][0]).toMatchObject({ decisionId: 'dec-1' });
+    expect(owedStore.markResurfaced).toHaveBeenCalledWith('row-1');
+  });
+
+  it('TS-2: K-reached owed decision escalates via escalateChairmanDecision, decisionId threaded through, no SMS sent', async () => {
+    const sb = makeFakeSupabase();
+    const owedStore = {
+      getOwedDecisions: async () => [{
+        owedId: 'row-2', decisionId: 'dec-2', message: { body: 'Approve Y?', decisionId: 'dec-2' },
+        answered: false, resurfaceCount: 3, resurfacedThisWindow: false,
+      }],
+      markResurfaced: vi.fn(async () => {}),
+    };
+    const AWAY = { now: 1_000_000, lastInputAt: 0, awayThresholdMs: 900_000 };
+    const result = await runDecisionSchedulerTick(sb, { owedStore, presence: AWAY });
+    expect(result.results[0].action).toBe('escalated_email');
+    expect(escalateChairmanDecision).toHaveBeenCalledWith(sb, 'dec-2');
+    expect(sendChairmanSMS).not.toHaveBeenCalled();
+  });
+
+  it('TS-2/TS-3: present (recent fleet input) -> no re-surface, sender not called', async () => {
+    const sb = makeFakeSupabase();
+    const owedStore = {
+      getOwedDecisions: async () => [{
+        owedId: 'row-3', decisionId: 'dec-3', message: { body: 'Approve Z?', decisionId: 'dec-3' },
+        answered: false, resurfaceCount: 0, resurfacedThisWindow: false,
+      }],
+      markResurfaced: vi.fn(async () => {}),
+    };
+    const PRESENT = { now: 1_000_000, lastInputAt: 999_000, awayThresholdMs: 900_000 };
+    const result = await runDecisionSchedulerTick(sb, { owedStore, presence: PRESENT });
+    expect(result.results[0].action).toBe('skipped_present');
+    expect(sendChairmanSMS).not.toHaveBeenCalled();
+  });
+
+  it('uses resolvePresenceContext + buildOwedStore by default when opts are not injected — no throw, empty result', async () => {
+    const sb = makeFakeSupabase({ tables: { claude_sessions: [], sms_outbound_obligations: [] } });
+    const result = await runDecisionSchedulerTick(sb, {});
+    expect(result.ran).toBe(true);
+    expect(result.results).toEqual([]);
+  });
+});

--- a/tests/unit/cron/adam-decision-scheduler-wiring.test.js
+++ b/tests/unit/cron/adam-decision-scheduler-wiring.test.js
@@ -1,0 +1,186 @@
+/**
+ * SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 FR-2 — static + behavioral wiring pins,
+ * mirroring tests/unit/cron/chairman-decision-sla-wiring.test.js's role for the SLA sweep.
+ * TS-5 (import pin), TS-6 (package.json reachability root), TS-7 (ARMED idempotency),
+ * TS-9 (exact activationTrigger literal), TS-10 (DST-aware quiet-window boundary math).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  main,
+  isWithinAdamSmsQuietWindow,
+  ACTIVATION_TRIGGER,
+  SD_KEY,
+} from '../../../scripts/cron/adam-decision-scheduler-tick.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const WORKFLOW = path.join(repoRoot, '.github', 'workflows', 'adam-decision-scheduler-cron.yml');
+const SCRIPT = path.join(repoRoot, 'scripts', 'cron', 'adam-decision-scheduler-tick.mjs');
+const PACKAGE_JSON = path.join(repoRoot, 'package.json');
+
+const EXPECTED_ACTIVATION_TRIGGER = 'sms_outbound_obligations STAGED migration applied by chairman ceremony';
+
+describe('adam decision-scheduler machinery names its dispatcher (static wiring)', () => {
+  it('TS-5/TS-6: the cron workflow exists and its run step invokes the tick script with --once', () => {
+    expect(fs.existsSync(WORKFLOW), `missing dispatcher workflow: ${WORKFLOW}`).toBe(true);
+    const yml = fs.readFileSync(WORKFLOW, 'utf8');
+    expect(yml, 'workflow no longer references scripts/cron/adam-decision-scheduler-tick.mjs').toMatch(
+      /node\s+scripts\/cron\/adam-decision-scheduler-tick\.mjs\s+--once/
+    );
+    expect(yml, 'workflow lost its schedule trigger').toMatch(/schedule:/);
+  });
+
+  it('TS-5: the tick script exists and imports runDecisionSchedulerTick from the decision-scheduler module', () => {
+    expect(fs.existsSync(SCRIPT), `missing tick script: ${SCRIPT}`).toBe(true);
+    const src = fs.readFileSync(SCRIPT, 'utf8');
+    expect(src, 'script no longer imports runDecisionSchedulerTick from lib/comms/adam-outbound/decision-scheduler/index.js').toMatch(
+      /import\s*\{[^}]*runDecisionSchedulerTick[^}]*\}\s*from\s*['"][./]*\.\.\/\.\.\/lib\/comms\/adam-outbound\/decision-scheduler\/index\.js['"]/
+    );
+  });
+
+  it('TS-9: the tick registers ARMED machinery with the EXACT pinned activationTrigger literal', () => {
+    expect(SD_KEY).toBe('SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001');
+    expect(ACTIVATION_TRIGGER).toBe(EXPECTED_ACTIVATION_TRIGGER);
+    const src = fs.readFileSync(SCRIPT, 'utf8');
+    expect(src, 'script no longer calls registerArmedMachinery').toMatch(/registerArmedMachinery/);
+  });
+
+  it('TS-6: package.json gains a <name>:cron script entry giving the two new files a WIRE_CHECK reachability root', () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+    expect(pkg.scripts['adam:decision-scheduler:tick:cron']).toBe(
+      'node scripts/cron/adam-decision-scheduler-tick.mjs --once'
+    );
+  });
+
+  it('the cron YAML documents the chairman SMS-specific 22:00-06:00 America/New_York window, not the different SLA-sweep window', () => {
+    const yml = fs.readFileSync(WORKFLOW, 'utf8');
+    expect(yml).toMatch(/22:00-06:00/);
+    expect(yml).toMatch(/America\/New_York/);
+  });
+
+  it('the tick script exports the RUNTIME DST-aware quiet-window guard and main() gates on it', () => {
+    const src = fs.readFileSync(SCRIPT, 'utf8');
+    expect(src).toMatch(/export function isWithinAdamSmsQuietWindow/);
+    expect(typeof isWithinAdamSmsQuietWindow).toBe('function');
+  });
+});
+
+/** Minimal fake for periodic_process_registry: supports the select/eq/maybeSingle check
+ *  plus the real registerArmedMachinery's upsert call — no mocking of the armed-registration
+ *  module needed, mirroring tests/unit/cron/chairman-decision-sla-sweep.test.js's approach. */
+function makeRegistrySupabase({ existingRow = null } = {}) {
+  let row = existingRow;
+  const upserts = [];
+  return {
+    from(table) {
+      if (table !== 'periodic_process_registry') throw new Error(`unexpected table ${table}`);
+      const ctx = { mode: 'select' };
+      const api = {
+        select() { ctx.mode = 'select'; return api; },
+        eq() { return api; },
+        async maybeSingle() { return { data: row, error: null }; },
+        upsert(vals) { ctx.mode = 'upsert'; ctx.vals = vals; return api; },
+        then(resolve) {
+          if (ctx.mode === 'upsert') {
+            upserts.push(ctx.vals);
+            row = { process_key: ctx.vals.process_key, ...ctx.vals };
+            resolve({ error: null });
+          } else {
+            resolve({ data: row, error: null });
+          }
+        },
+      };
+      return api;
+    },
+    _upserts: upserts,
+  };
+}
+
+describe('adam decision-scheduler tick — behavioral wiring', () => {
+  it('TS-9: first run (no existing registry row) registers ARMED machinery with the exact pinned literal', async () => {
+    const sb = makeRegistrySupabase({ existingRow: null });
+    const stampLastFired = vi.fn(async () => ({ stamped: true }));
+    const tick = vi.fn(async () => ({ ran: true, results: [] }));
+    const result = await main(['node', 'script', '--once'], {
+      supabase: sb, logger: { log() {}, warn() {}, error() {} },
+      stampLastFired, runDecisionSchedulerTick: tick,
+      now: new Date(Date.UTC(2026, 6, 18, 12, 0, 0)), // 08:00 ET — outside quiet window
+    });
+    expect(result.exitCode).toBe(0);
+    expect(sb._upserts).toHaveLength(1);
+    expect(sb._upserts[0].liveness_source_ref.activation_trigger).toBe(EXPECTED_ACTIVATION_TRIGGER);
+    expect(stampLastFired).toHaveBeenCalledTimes(1);
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  it('TS-7: second run (registry row already exists) does NOT re-register — idempotent, never wipes last_fired_at', async () => {
+    const sb = makeRegistrySupabase({ existingRow: { process_key: 'g3-armed-sd-leo-infra-adam-decision-scheduler-001', last_fired_at: '2026-07-17T00:00:00.000Z' } });
+    const stampLastFired = vi.fn(async () => ({ stamped: true }));
+    const tick = vi.fn(async () => ({ ran: true, results: [] }));
+    const result = await main(['node', 'script', '--once'], {
+      supabase: sb, logger: { log() {}, warn() {}, error() {} },
+      stampLastFired, runDecisionSchedulerTick: tick,
+      now: new Date(Date.UTC(2026, 6, 18, 12, 0, 0)),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(sb._upserts).toHaveLength(0); // no re-registration, real last_fired_at never touched by an upsert
+    expect(stampLastFired).toHaveBeenCalledTimes(1); // liveness is still stamped every real run
+  });
+
+  it('quiet-window skip: a run during 22:00-06:00 ET skips the tick without erroring', async () => {
+    const sb = makeRegistrySupabase({ existingRow: { process_key: 'x' } });
+    const stampLastFired = vi.fn(async () => ({ stamped: true }));
+    const tick = vi.fn(async () => ({ ran: true, results: [] }));
+    const result = await main(['node', 'script', '--once'], {
+      supabase: sb, logger: { log() {}, warn() {}, error() {} },
+      stampLastFired, runDecisionSchedulerTick: tick,
+      now: new Date(Date.UTC(2026, 6, 18, 3, 0, 0)), // 23:00 ET (EDT) — inside quiet window
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('quiet_window_skip');
+    expect(tick).not.toHaveBeenCalled();
+  });
+
+  it('dry-run: reports intent, performs no ARMED registration and no tick', async () => {
+    const sb = makeRegistrySupabase();
+    const stampLastFired = vi.fn(async () => ({ stamped: true }));
+    const tick = vi.fn(async () => ({ ran: true, results: [] }));
+    const result = await main(['node', 'script', '--once', '--dry-run'], {
+      supabase: sb, logger: { log() {}, warn() {}, error() {} },
+      stampLastFired, runDecisionSchedulerTick: tick,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.action).toBe('dry_run');
+    expect(sb._upserts).toHaveLength(0);
+    expect(stampLastFired).not.toHaveBeenCalled();
+    expect(tick).not.toHaveBeenCalled();
+  });
+});
+
+describe('TS-10: isWithinAdamSmsQuietWindow — DST-aware 22:00-06:00 America/New_York boundary math', () => {
+  it('EST (January): 21:59 ET outside, 22:00 ET inside, 05:59 ET inside, 06:00 ET outside', () => {
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 0, 16, 2, 59)))).toBe(false); // 21:59 ET Jan 15
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 0, 16, 3, 0)))).toBe(true);   // 22:00 ET Jan 15
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 0, 15, 10, 59)))).toBe(true); // 05:59 ET Jan 15
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 0, 15, 11, 0)))).toBe(false); // 06:00 ET Jan 15
+  });
+
+  it('EDT (July): 21:59 ET outside, 22:00 ET inside, 05:59 ET inside, 06:00 ET outside', () => {
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 6, 19, 1, 59)))).toBe(false); // 21:59 ET Jul 18
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 6, 19, 2, 0)))).toBe(true);   // 22:00 ET Jul 18
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 6, 18, 9, 59)))).toBe(true);  // 05:59 ET Jul 18
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 6, 18, 10, 0)))).toBe(false); // 06:00 ET Jul 18
+  });
+
+  it('spring side of a DST transition (post spring-forward, EDT) classifies 22:00 ET as inside', () => {
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 2, 21, 2, 0)))).toBe(true); // 22:00 ET Mar 20 (EDT)
+  });
+
+  it('fall side of a DST transition (post fall-back, EST) classifies 22:00 ET as inside', () => {
+    expect(isWithinAdamSmsQuietWindow(new Date(Date.UTC(2026, 10, 21, 3, 0)))).toBe(true); // 22:00 ET Nov 20 (EST)
+  });
+});


### PR DESCRIPTION
## Summary
- FR-1: `lib/comms/adam-outbound/decision-scheduler/index.js` wires the previously-unwired away-bridge (SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-E) to real seams — an owedStore adapter over `sms_outbound_obligations` (fail-soft while the STAGED migration is unapplied, documented column-mapping caveat for fields with no backing column), a presence signal from `claude_sessions.heartbeat_at`, the live chairman-sms-gate sender, and the existing chairman decision-email escalation path.
- FR-2: `scripts/cron/adam-decision-scheduler-tick.mjs` is the durable `--once` runner mirroring `chairman-decision-sla-sweep.mjs`'s shape, registers ARMED machinery (`periodic_process_registry`) with a pinned `activationTrigger` literal, and inlines an authoritative runtime DST-aware 22:00-06:00 America/New_York quiet-window guard. New `.github/workflows/adam-decision-scheduler-cron.yml` + a `package.json` cron script entry give both new files a WIRE_CHECK reachability root.
- FR-3: removes the now-inaccurate `@wire-check-exempt` marker from `away-bridge/index.js` (hygiene only — it now has a real caller; WIRE_CHECK only re-checks newly-added files).

## Test plan
- [x] `npx vitest run tests/unit/comms/adam-outbound/decision-scheduler.test.js` — 11 tests pass (TS-1, TS-2, TS-3, TS-8)
- [x] `npx vitest run tests/unit/cron/adam-decision-scheduler-wiring.test.js` — 14 tests pass (TS-5, TS-6, TS-7, TS-9, TS-10)
- [x] `npx vitest run tests/unit/comms/ tests/unit/chairman/sms-bridge.test.js` — 68 tests pass, no regressions
- [x] `npx eslint` on all new/modified files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)