### PR TITLE
feat(SD-LEO-INFRA-EVIDENCE-PHASE-NEVER-NULL-001): backfill historical null-phase evidence rows

### DIFF
--- a/scripts/backfill-null-phase-evidence.mjs
+++ b/scripts/backfill-null-phase-evidence.mjs
@@ -1,0 +1,190 @@
+// @wire-check-exempt: one-off historical data backfill CLI -- dry-run by default, --apply is run
+// manually under coordinator/human review. Pure logic (deriveHistoricalPhase) is unit-tested.
+/**
+ * SD-LEO-INFRA-EVIDENCE-PHASE-NEVER-NULL-001 -- backfill the ~24,400 historical
+ * sub_agent_execution_results rows with phase=null.
+ *
+ * SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (shipped) stopped NEW writes from landing
+ * null on the canonical write path, but did nothing for rows already written before it
+ * shipped. This script derives a historical phase for each null row:
+ *   (a) metadata.phase, if already set (cheapest, most accurate -- no query needed)
+ *   (b) otherwise, the most recent ACCEPTED sd_phase_handoffs row for that SD with
+ *       COALESCE(accepted_at, created_at) <= the evidence row's created_at (i.e. "the
+ *       phase this SD was actually in when the evidence was recorded"), using that
+ *       handoff's to_phase. Tie-broken by id DESC on an exact-timestamp collision (73
+ *       sampled sd_id groups have >1 accepted handoff sharing the same coalesced
+ *       timestamp -- TESTING sub-agent finding, PLAN_PRD phase).
+ *   (c) fallback sentinel: 'LEAD' when sd_id is set but no bracketing handoff exists
+ *       (evidence written before any handoff was ever accepted for that SD);
+ *       'UNKNOWN_HISTORICAL' when sd_id itself is null/un-derivable.
+ *
+ * current_phase (the SD's CURRENT state) is deliberately NOT used here -- it would
+ * misattribute nearly all rows for completed/cancelled SDs to a terminal phase they
+ * were never actually in at write time (VALIDATION sub-agent finding, LEAD phase).
+ *
+ * status='accepted' is a hard filter (12,571 rejected + 1,118 blocked handoffs exist
+ * fleet-wide and must never be treated as evidence of a completed phase transition).
+ *
+ * Dry-run by default; --apply to write. Idempotent (only ever touches rows still
+ * phase=null at run time; re-running after a successful apply is a no-op).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { normalizePhaseToken } from '../lib/sub-agent-executor/phase-token.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const APPLY = process.argv.includes('--apply');
+const BATCH_SIZE = 500;
+
+/**
+ * Pure: derive a historical phase for one null-phase row.
+ * @param {{sd_id: string|null, created_at: string, metadata: object|null}} row
+ * @param {Array<{to_phase: string, accepted_at: string|null, created_at: string, id: string}>} sortedHandoffsForSd
+ *   Handoffs for row.sd_id, status='accepted', PRE-SORTED by
+ *   COALESCE(accepted_at, created_at) DESC, then id DESC (caller's responsibility --
+ *   see sortHandoffs below).
+ * @returns {{phase: string, source: 'metadata'|'handoff'|'fallback_lead'|'fallback_unknown'}}
+ */
+export function deriveHistoricalPhase(row, sortedHandoffsForSd) {
+  const metaPhase = typeof row?.metadata?.phase === 'string' && row.metadata.phase.trim();
+  if (metaPhase) {
+    return { phase: normalizePhaseToken(metaPhase), source: 'metadata' };
+  }
+
+  if (!row?.sd_id) {
+    return { phase: 'UNKNOWN_HISTORICAL', source: 'fallback_unknown' };
+  }
+
+  const rowCreatedAt = new Date(row.created_at).getTime();
+  const bracketing = (sortedHandoffsForSd || []).find((h) => {
+    const windowTs = new Date(h.accepted_at || h.created_at).getTime();
+    return windowTs <= rowCreatedAt;
+  });
+
+  if (bracketing) {
+    return { phase: normalizePhaseToken(bracketing.to_phase), source: 'handoff' };
+  }
+
+  return { phase: 'LEAD', source: 'fallback_lead' };
+}
+
+/** Sort handoffs by COALESCE(accepted_at, created_at) DESC, then id DESC (deterministic tie-break). */
+export function sortHandoffs(handoffs) {
+  return [...(handoffs || [])].sort((a, b) => {
+    const aTs = new Date(a.accepted_at || a.created_at).getTime();
+    const bTs = new Date(b.accepted_at || b.created_at).getTime();
+    if (bTs !== aTs) return bTs - aTs;
+    return String(b.id).localeCompare(String(a.id));
+  });
+}
+
+async function fetchAllPaginated(sb, table, selectCols, applyFilters) {
+  const rows = [];
+  for (let from = 0; ; from += 1000) {
+    let query = sb.from(table).select(selectCols);
+    query = applyFilters(query);
+    const { data, error } = await query.range(from, from + 999);
+    if (error) { console.error(`${table} query failed:`, error.message); process.exit(1); }
+    rows.push(...(data || []));
+    if (!data || data.length < 1000) break;
+  }
+  return rows;
+}
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} sb
+ * @param {boolean} apply - false runs dry-run (zero writes)
+ */
+export async function main(sb, apply = APPLY) {
+  console.log(`[backfill-null-phase] mode=${apply ? 'APPLY' : 'DRY-RUN'}`);
+
+  const nullRows = await fetchAllPaginated(sb, 'sub_agent_execution_results', 'id, sd_id, created_at, metadata',
+    (q) => q.is('phase', null));
+  console.log(`[backfill-null-phase] found ${nullRows.length} null-phase rows`);
+
+  const sdIds = [...new Set(nullRows.map((r) => r.sd_id).filter(Boolean))];
+  const handoffsBySd = new Map();
+  for (const sdId of sdIds) handoffsBySd.set(sdId, []);
+  if (sdIds.length > 0) {
+    // Bulk-fetch accepted handoffs for exactly the SDs we need, in chunks of 50 ids per query
+    // (small enough that even the SD with the most accepted handoffs -- 10, per a live-data
+    // sample -- keeps a chunk's total well under Supabase's 1000-row default page size), each
+    // paginated in its own right in case a chunk's combined handoff count still exceeds 1000.
+    for (let i = 0; i < sdIds.length; i += 50) {
+      const chunk = sdIds.slice(i, i + 50);
+      const chunkHandoffs = await fetchAllPaginated(sb, 'sd_phase_handoffs', 'sd_id, to_phase, accepted_at, created_at, id',
+        (q) => q.eq('status', 'accepted').in('sd_id', chunk));
+      for (const h of chunkHandoffs) {
+        if (!handoffsBySd.has(h.sd_id)) handoffsBySd.set(h.sd_id, []);
+        handoffsBySd.get(h.sd_id).push(h);
+      }
+    }
+    for (const [sdId, handoffs] of handoffsBySd) handoffsBySd.set(sdId, sortHandoffs(handoffs));
+  }
+
+  const derived = nullRows.map((row) => ({
+    id: row.id,
+    ...deriveHistoricalPhase(row, handoffsBySd.get(row.sd_id)),
+  }));
+
+  const bySource = derived.reduce((acc, d) => { acc[d.source] = (acc[d.source] || 0) + 1; return acc; }, {});
+  console.log('[backfill-null-phase] derivation breakdown:', JSON.stringify(bySource));
+
+  if (!apply) {
+    console.log('[backfill-null-phase] sample (first 10):');
+    for (const d of derived.slice(0, 10)) console.log(`  ${d.id} -> phase='${d.phase}' (${d.source})`);
+    console.log('\nDRY RUN -- re-run with --apply to write.');
+    return { found: nullRows.length, bySource, written: 0, failed: 0, applied: false };
+  }
+
+  // Group by derived phase value so each write is a single bulk UPDATE covering many rows
+  // (one round-trip per BATCH_SIZE-sized id chunk within a phase group) instead of one
+  // network round-trip per row -- 24k+ individual updates would take far too long.
+  const idsByPhase = new Map();
+  for (const d of derived) {
+    if (!idsByPhase.has(d.phase)) idsByPhase.set(d.phase, []);
+    idsByPhase.get(d.phase).push(d.id);
+  }
+
+  let written = 0, failed = 0;
+  for (const [phase, ids] of idsByPhase) {
+    for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+      const chunk = ids.slice(i, i + BATCH_SIZE);
+      // Idempotent re-check via .is('phase', null): only rows still null get touched
+      // (protects against concurrent writers landing a phase on a row between fetch and write).
+      const { data, error } = await sb.from('sub_agent_execution_results')
+        .update({ phase, updated_at: new Date().toISOString() })
+        .in('id', chunk)
+        .is('phase', null)
+        .select('id');
+      if (error) { failed += chunk.length; console.log(`  ✗ batch (phase=${phase}, ${chunk.length} ids): ${error.message}`); }
+      else written += (data || chunk).length;
+    }
+  }
+  console.log(`[backfill-null-phase] APPLIED: written=${written} failed=${failed}`);
+
+  try {
+    const { error: evErr } = await sb.from('audit_log').insert({
+      event_type: 'backfill_run',
+      entity_type: 'script_run',
+      entity_id: 'backfill-null-phase-evidence',
+      metadata: { script: 'backfill-null-phase-evidence.mjs', found: nullRows.length, by_source: bySource, written, failed },
+      severity: failed > 0 ? 'warning' : 'info',
+      created_by: 'backfill-null-phase-evidence.mjs',
+    });
+    if (evErr) console.warn('[backfill-null-phase] run-evidence write skipped (non-fatal):', evErr.message);
+  } catch (e) { console.warn('[backfill-null-phase] run-evidence write skipped (non-fatal):', e.message); }
+
+  return { found: nullRows.length, bySource, written, failed, applied: true };
+}
+
+async function run() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required'); process.exit(1); }
+  await main(createClient(url, key), APPLY);
+}
+
+if (isMainModule(import.meta.url)) {
+  run();
+}

--- a/tests/unit/backfill-null-phase-evidence.test.js
+++ b/tests/unit/backfill-null-phase-evidence.test.js
@@ -1,0 +1,203 @@
+/**
+ * SD-LEO-INFRA-EVIDENCE-PHASE-NEVER-NULL-001
+ *
+ * Tests for the historical null-phase backfill script. Pure-function tests
+ * (deriveHistoricalPhase, sortHandoffs) cover the derivation logic directly
+ * with plain arrays, per TESTING sub-agent guidance (avoids over-mocking).
+ * A stateful-mock integration test covers dry-run/idempotency (the only
+ * scenarios that genuinely need DB-shaped behavior).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { deriveHistoricalPhase, sortHandoffs, main } from '../../scripts/backfill-null-phase-evidence.mjs';
+
+describe('deriveHistoricalPhase (pure logic)', () => {
+  it('TS-1: prefers metadata.phase when already set, normalized', () => {
+    const row = { sd_id: 'sd-1', created_at: '2026-01-01T00:00:00Z', metadata: { phase: 'exec-to-plan' } };
+    const result = deriveHistoricalPhase(row, []);
+    expect(result).toEqual({ phase: 'EXEC_TO_PLAN', source: 'metadata' });
+  });
+
+  it('TS-2: derives from the most recent accepted handoff bracketing created_at', () => {
+    const row = { sd_id: 'sd-2', created_at: '2026-01-10T00:00:00Z', metadata: {} };
+    const handoffs = sortHandoffs([
+      { id: 'h1', to_phase: 'LEAD', accepted_at: '2026-01-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z' },
+      { id: 'h2', to_phase: 'PLAN', accepted_at: '2026-01-05T00:00:00Z', created_at: '2026-01-05T00:00:00Z' },
+    ]);
+    const result = deriveHistoricalPhase(row, handoffs);
+    expect(result).toEqual({ phase: 'PLAN', source: 'handoff' });
+  });
+
+  it('TS-3: falls back to LEAD when sd_id is set but no bracketing handoff exists', () => {
+    const row = { sd_id: 'sd-3', created_at: '2026-01-01T00:00:00Z', metadata: {} };
+    const handoffs = sortHandoffs([
+      { id: 'h1', to_phase: 'PLAN', accepted_at: '2026-02-01T00:00:00Z', created_at: '2026-02-01T00:00:00Z' },
+    ]);
+    const result = deriveHistoricalPhase(row, handoffs);
+    expect(result).toEqual({ phase: 'LEAD', source: 'fallback_lead' });
+  });
+
+  it('TS-4: falls back to UNKNOWN_HISTORICAL when sd_id is null', () => {
+    const row = { sd_id: null, created_at: '2026-01-01T00:00:00Z', metadata: {} };
+    const result = deriveHistoricalPhase(row, []);
+    expect(result).toEqual({ phase: 'UNKNOWN_HISTORICAL', source: 'fallback_unknown' });
+  });
+
+  it('TS-7: an accepted handoff with a null accepted_at falls back to created_at for the window comparison', () => {
+    const row = { sd_id: 'sd-7', created_at: '2026-01-10T00:00:00Z', metadata: {} };
+    const handoffs = sortHandoffs([
+      { id: 'h1', to_phase: 'EXEC', accepted_at: null, created_at: '2026-01-05T00:00:00Z' },
+    ]);
+    const result = deriveHistoricalPhase(row, handoffs);
+    expect(result).toEqual({ phase: 'EXEC', source: 'handoff' });
+  });
+
+  it('TS-8: exact-timestamp ties between two accepted handoffs are broken deterministically by id DESC', () => {
+    const row = { sd_id: 'sd-8', created_at: '2026-01-10T00:00:00Z', metadata: {} };
+    const tiedTs = '2026-01-05T00:00:00Z';
+    const handoffsAsc = sortHandoffs([
+      { id: 'aaa', to_phase: 'PLAN', accepted_at: tiedTs, created_at: tiedTs },
+      { id: 'zzz', to_phase: 'EXEC', accepted_at: tiedTs, created_at: tiedTs },
+    ]);
+    const handoffsDesc = sortHandoffs([
+      { id: 'zzz', to_phase: 'EXEC', accepted_at: tiedTs, created_at: tiedTs },
+      { id: 'aaa', to_phase: 'PLAN', accepted_at: tiedTs, created_at: tiedTs },
+    ]);
+    // Input order must not matter -- both produce the same winner (id 'zzz' sorts first under DESC).
+    expect(deriveHistoricalPhase(row, handoffsAsc)).toEqual({ phase: 'EXEC', source: 'handoff' });
+    expect(deriveHistoricalPhase(row, handoffsDesc)).toEqual({ phase: 'EXEC', source: 'handoff' });
+  });
+
+  it('TS-9: ordering uses COALESCE(accepted_at, created_at), not created_at alone', () => {
+    const row = { sd_id: 'sd-9', created_at: '2026-01-20T00:00:00Z', metadata: {} };
+    // h1 was CREATED earlier but ACCEPTED later than h2 -- the coalesced (accepted) timestamp must win.
+    const handoffs = sortHandoffs([
+      { id: 'h1', to_phase: 'EXEC', accepted_at: '2026-01-15T00:00:00Z', created_at: '2026-01-01T00:00:00Z' },
+      { id: 'h2', to_phase: 'PLAN', accepted_at: '2026-01-10T00:00:00Z', created_at: '2026-01-12T00:00:00Z' },
+    ]);
+    const result = deriveHistoricalPhase(row, handoffs);
+    expect(result).toEqual({ phase: 'EXEC', source: 'handoff' });
+  });
+
+  it('TS-10: the boundary is inclusive -- a handoff accepted at exactly created_at brackets the row', () => {
+    const sameTs = '2026-01-10T00:00:00Z';
+    const row = { sd_id: 'sd-10', created_at: sameTs, metadata: {} };
+    const handoffs = sortHandoffs([
+      { id: 'h1', to_phase: 'PLAN', accepted_at: sameTs, created_at: sameTs },
+    ]);
+    const result = deriveHistoricalPhase(row, handoffs);
+    expect(result).toEqual({ phase: 'PLAN', source: 'handoff' });
+  });
+});
+
+describe('main() integration (dry-run / idempotency / rejected-handoff-exclusion)', () => {
+  let subAgentRows;
+  let handoffRows;
+
+  function makeMockSupabase() {
+    return {
+      from(table) {
+        if (table === 'sd_phase_handoffs') {
+          const filters = {};
+          const builder = {
+            select() { return builder; },
+            eq(col, val) { filters[col] = val; return builder; },
+            in(col, vals) { filters[`${col}__in`] = vals; return builder; },
+          };
+          builder.range = async () => {
+            const matches = handoffRows.filter((h) =>
+              (!filters.status || h.status === filters.status) &&
+              (!filters.sd_id__in || filters.sd_id__in.includes(h.sd_id))
+            );
+            return { data: matches, error: null };
+          };
+          return builder;
+        }
+        if (table === 'audit_log') {
+          return { insert: async () => ({ error: null }) };
+        }
+        // sub_agent_execution_results
+        const filters = {};
+        const builder = {
+          select() { return builder; },
+          is(col, val) { filters[col] = { op: 'is', val }; return builder; },
+          eq(col, val) { filters[col] = { op: 'eq', val }; return builder; },
+          update(fields) {
+            return {
+              in(_col, ids) {
+                return {
+                  is(_col2, _val2) {
+                    return {
+                      select() {
+                        const touched = [];
+                        for (const id of ids) {
+                          const row = subAgentRows.find((r) => r.id === id && r.phase === null);
+                          if (!row) continue;
+                          Object.assign(row, fields);
+                          touched.push({ id });
+                        }
+                        return Promise.resolve({ data: touched, error: null });
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+        builder.range = async () => {
+          const matches = subAgentRows.filter((r) =>
+            Object.entries(filters).every(([col, f]) => {
+              if (f.op === 'is') return r[col] === null || r[col] === undefined;
+              if (f.op === 'eq') return r[col] === f.val;
+              return true;
+            })
+          );
+          return { data: matches, error: null };
+        };
+        return builder;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    subAgentRows = [
+      { id: 'row-1', sd_id: 'sd-int-1', phase: null, created_at: '2026-01-10T00:00:00Z', metadata: {} },
+      { id: 'row-2', sd_id: 'sd-int-1', phase: null, created_at: '2026-01-01T00:00:00Z', metadata: {} },
+    ];
+    handoffRows = [
+      { sd_id: 'sd-int-1', status: 'accepted', to_phase: 'PLAN', accepted_at: '2026-01-05T00:00:00Z', created_at: '2026-01-05T00:00:00Z', id: 'h-1' },
+      { sd_id: 'sd-int-1', status: 'rejected', to_phase: 'EXEC', accepted_at: '2026-01-08T00:00:00Z', created_at: '2026-01-08T00:00:00Z', id: 'h-2' },
+    ];
+  });
+
+  it('TS-5: dry-run (apply=false) makes zero writes and correctly excludes a rejected handoff from derivation', async () => {
+    const sb = makeMockSupabase();
+    const result = await main(sb, false);
+
+    expect(result.applied).toBe(false);
+    expect(result.written).toBe(0);
+    expect(result.found).toBe(2);
+    // row-1 derives PLAN (the accepted handoff), never EXEC (the rejected one) despite it bracketing too.
+    // Confirm no row was mutated by a dry-run.
+    expect(subAgentRows[0].phase).toBeNull();
+    expect(subAgentRows[1].phase).toBeNull();
+  });
+
+  it('TS-6: apply writes derived phases, and re-running is idempotent (0 rows touched on the second pass)', async () => {
+    const sb = makeMockSupabase();
+    const firstRun = await main(sb, true);
+
+    expect(firstRun.applied).toBe(true);
+    expect(firstRun.written).toBe(2);
+    expect(firstRun.failed).toBe(0);
+    // row-1 (created after the accepted PLAN handoff, before the rejected EXEC one) derives PLAN.
+    expect(subAgentRows.find((r) => r.id === 'row-1').phase).toBe('PLAN');
+    // row-2 (created before any accepted handoff) falls back to LEAD.
+    expect(subAgentRows.find((r) => r.id === 'row-2').phase).toBe('LEAD');
+
+    const secondRun = await main(sb, true);
+    expect(secondRun.found).toBe(0);
+    expect(secondRun.written).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Phase-2 follow-up to SD-LEO-INFRA-EVIDENCE-PHASE-DERIVATION-001 (#6249, merged). That SD stopped NEW sub-agent-evidence writes from landing `phase=null`; this SD cleans up the ~24,400 pre-existing historical null-phase rows.

`scripts/backfill-null-phase-evidence.mjs` derives a phase for each null row:
- prefer `metadata.phase` if already set (cheapest, most accurate)
- else derive from the most recent **ACCEPTED** `sd_phase_handoffs` row for that SD with `COALESCE(accepted_at, created_at) <= created_at` — the phase the SD was actually in when the evidence was recorded. `current_phase` (the SD's *current* state) was deliberately **not** used — it would misattribute historical rows for completed/cancelled SDs to a terminal phase they were never in at write time.
- else fall back to `'LEAD'` (sd_id set, no prior handoff) or `'UNKNOWN_HISTORICAL'` (sd_id null)

`status='accepted'` is a hard filter — 12,571 rejected + 1,118 blocked handoffs exist fleet-wide and must never be treated as evidence of a completed transition. Exact-timestamp ties are broken deterministically by `id DESC`.

**Ran live**: 24,437 historical null-phase rows → 0 remaining, using grouped bulk UPDATEs (per distinct derived phase) — the naive one-row-at-a-time loop timed out after ~7k rows during testing.

## Scope change: DB NOT NULL constraint deferred
The original scope also included a DB NOT NULL migration. Descoped during EXEC after discovering new null-phase writes are still landing fleet-wide — **not** from a bypassing writer (an initial hypothesis about `scripts/hooks/task-subagent-recorder.cjs` was independently checked against live data and does not hold), but because **other parallel fleet workers' worktrees haven't yet merged the DERIVATION-001 fix** and continue running pre-fix code until they next sync with `origin/main`. Applying NOT NULL today would break their in-flight writes. Deferred to a follow-up SD, gated on the new-write null rate dropping to near-zero as the fleet naturally syncs.

## Test plan
- [x] `tests/unit/backfill-null-phase-evidence.test.js` — 10 scenarios (7 planned + 3 gaps a TESTING sub-agent review caught: exact-timestamp tie-breaking, COALESCE ordering vs created_at-only, inclusive boundary)
- [x] Non-tautology confirmed by deliberately breaking the COALESCE ordering logic and verifying the relevant test genuinely fails
- [x] Live dry-run + apply run against production data; verified 0 null-phase rows remain; verified idempotent re-run reports 0 rows to update
- [x] Zero regressions to the 16 related tests from the dependency SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)