### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B): durable 5:45 ET morning-review cron + text-only SMS via hardened owed-state bridge

### DIFF
--- a/.github/workflows/chairman-morning-review-cron.yml
+++ b/.github/workflows/chairman-morning-review-cron.yml
@@ -1,0 +1,58 @@
+name: "Chairman morning-review (5:45 ET cron)"
+
+# SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B — durable 5:45 AM ET daily-review SMS.
+# The one-shot runner (scripts/cron/chairman-morning-review-sweep.mjs --once) builds a short
+# status + "what moved yesterday" body and enqueues a TEXT-only 'morning_review' obligation via
+# the hardened owed-state bridge (enqueueChairmanSms). Delivery-truth is reconciled by the
+# pre-existing sms-outbound-worker — this cron never sends via the provider directly.
+#
+# DST DESIGN: GitHub Actions cron is UTC and does NOT observe DST. 5:45 AM ET is 09:45 UTC under
+# EDT (summer) and 10:45 UTC under EST (winter), so BOTH entries are scheduled. The sweep gates
+# real work on an America/New_York wall-clock check (proceed only when the ET local hour is 5),
+# so in each season exactly one of the two fires maps to 05:45 ET and does work; the other sees
+# ET hour != 5 and exits inert. The per-ET-date dedupeKey is the idempotency backstop, so even if
+# both were to do work the chairman is texted at most once/day.
+#
+# Real sends begin only once the chairman APPLIES the STAGED sms_outbound_obligations migration;
+# until then enqueueChairmanSms is fail-soft and the sweep logs inert + exits 0.
+
+on:
+  schedule:
+    - cron: '45 9 * * *'   # 09:45 UTC = 05:45 EDT (summer)
+    - cron: '45 10 * * *'  # 10:45 UTC = 05:45 EST (winter)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  morning-review:
+    name: Enqueue the 5:45 ET chairman morning-review SMS
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      CHAIRMAN_PHONE: ${{ secrets.CHAIRMAN_PHONE }}
+      TWILIO_STATUS_CALLBACK_URL: ${{ secrets.TWILIO_STATUS_CALLBACK_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Enqueue morning-review SMS (5:45 ET, DST-gated)
+        run: node scripts/cron/chairman-morning-review-sweep.mjs --once

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Chairman morning-review sweep — the DURABLE 5:45 AM ET daily-review runner.
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B (child B: text-only floor).
+ *
+ * Mirrors scripts/cron/sms-outbound-reconcile-sweep.mjs: a --once runner holding NO
+ * session-local setTimeout/setInterval work-timer, so a fresh cold GitHub Actions process
+ * does exactly one pass and exits. It builds a SHORT, segment-aware status body (a completion
+ * forecast line + a roadmap build/wave line + a "what moved yesterday" line) and enqueues it
+ * as a TEXT-only 'morning_review' obligation via the hardened owed-state bridge
+ * (enqueueChairmanSms). The actual provider send + delivery-truth is owned by the pre-existing
+ * claim-serialized worker (lib/chairman/sms-outbound-worker.js) — this sweep NEVER calls
+ * twilioProvider.send (that would re-open the F1 201-as-success defect).
+ *
+ * DST: GitHub cron is UTC/no-DST. The workflow fires at BOTH 09:45 and 10:45 UTC; this sweep
+ * gates real work on an America/New_York wall-clock check (proceed only when the ET local hour
+ * is 5), so exactly one of the two fires maps to 05:45 ET per season and does work — the other
+ * exits inert. The per-ET-date dedupeKey is the idempotency backstop against a double-fire.
+ *
+ * FAIL-SOFT: while the STAGED sms_outbound_obligations table is unapplied, enqueueChairmanSms
+ * returns {enqueued:false, reason:'table_absent...'} without throwing and this sweep logs inert
+ * + exits 0 (no crash, no direct provider.send fallback).
+ *
+ * Usage:
+ *   node scripts/cron/chairman-morning-review-sweep.mjs --once
+ *   node scripts/cron/chairman-morning-review-sweep.mjs --once --dry-run
+ *
+ * Env: SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (required),
+ *      CHAIRMAN_PHONE (recipient — inert if unset).
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { createClient } from '@supabase/supabase-js';
+import { enqueueChairmanSms } from '../../lib/chairman/sms-bridge.js';
+import { computeForecast, formatForecastLine } from '../../lib/vision/build-completion-forecast.mjs';
+
+export const SD_KEY = 'SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B';
+export const ACTIVATION_TRIGGER = '.github/workflows/chairman-morning-review-cron.yml';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TZ = 'America/New_York';
+const NOT_IN_TERMINAL = '("completed","cancelled","deferred")';
+// ~2 GSM segments (153 chars/segment concatenated). The built body is capped here so a long
+// forecast note can never balloon past the segment budget.
+export const BODY_CEILING = 306;
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+// ── ET wall-clock helpers (Intl only — never hand-roll UTC±offset arithmetic) ──
+function etParts(instant) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ, hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+  const p = {};
+  for (const x of dtf.formatToParts(instant)) p[x.type] = x.value;
+  return { year: p.year, month: p.month, day: p.day, hour: p.hour === '24' ? 0 : Number(p.hour), minute: Number(p.minute), second: Number(p.second) };
+}
+export function etLocalHour(now) { return etParts(now).hour; }
+export function etDateStr(now) { const p = etParts(now); return `${p.year}-${p.month}-${p.day}`; }
+/** ms the ET zone is ahead of UTC at `instant` (negative — ET is behind UTC). */
+function tzOffsetMs(instant) {
+  const p = etParts(instant);
+  return Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), p.hour, p.minute, p.second) - instant.getTime();
+}
+/** The UTC instant for a given ET wall-clock time on today's ET calendar date. */
+function etWallClockUtc(now, hour, minute = 0) {
+  const p = etParts(now);
+  const wall = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), hour, minute, 0);
+  let t = wall - tzOffsetMs(new Date(wall));
+  t = wall - tzOffsetMs(new Date(t)); // second pass converges near a DST edge
+  return new Date(t);
+}
+export function et6amIso(now) { return etWallClockUtc(now, 6).toISOString(); }
+/** The prior 5:45 AM ET instant (~24h back) as the "what moved yesterday" window start. */
+export function etPrior545Iso(now) { return new Date(etWallClockUtc(now, 5, 45).getTime() - DAY_MS).toISOString(); }
+
+// ── body data (DB-only, fail-soft; surgical — no git-grep VDR gauge / CLI refactor) ──
+async function gatherForecastInputs(supabase, nowMs, windowDays = 14) {
+  const sinceIso = new Date(nowMs - windowDays * DAY_MS).toISOString();
+  let velocityPerDay = 0, sourcingPerDay = 0, queueDepth = 0, buildableRemaining = 0;
+  try {
+    const { data } = await supabase.from('strategic_directives_v2').select('sd_key, updated_at').eq('status', 'completed').gte('updated_at', sinceIso);
+    velocityPerDay = (data?.length || 0) / windowDays;
+  } catch { /* fail-soft */ }
+  try {
+    const { data } = await supabase.from('strategic_directives_v2').select('sd_key, created_at, claiming_session_id, sd_type').not('status', 'in', NOT_IN_TERMINAL);
+    const rows = (Array.isArray(data) ? data : []).filter((d) => d.sd_type !== 'orchestrator');
+    buildableRemaining = rows.length;
+    sourcingPerDay = rows.filter((d) => d.created_at && d.created_at >= sinceIso).length / windowDays;
+    queueDepth = rows.filter((d) => !d.claiming_session_id).length;
+  } catch { /* fail-soft */ }
+  return { buildPct: null, buildableRemaining, velocityPerDay, sourcingPerDay, queueDepth };
+}
+
+async function gatherWaves(supabase) {
+  try {
+    const { data: roadmaps } = await supabase.from('strategic_roadmaps').select('id, status, created_at').order('created_at', { ascending: false }).limit(1);
+    const rm = roadmaps?.[0];
+    if (!rm) return { waveCount: 0, doneWaves: 0, avgPct: null };
+    const { data: waves } = await supabase.from('roadmap_waves').select('status, progress_pct').eq('roadmap_id', rm.id);
+    const ws = waves || [];
+    const waveCount = ws.length;
+    const doneWaves = ws.filter((w) => Number(w.progress_pct || 0) >= 100 || w.status === 'completed').length;
+    const avgPct = waveCount ? Math.round(ws.reduce((s, w) => s + Number(w.progress_pct || 0), 0) / waveCount) : null;
+    return { waveCount, doneWaves, avgPct };
+  } catch { return { waveCount: 0, doneWaves: 0, avgPct: null }; }
+}
+
+async function gatherYesterday(supabase, priorMorningIso) {
+  let shipped = 0, inFlight = 0;
+  try {
+    const { data } = await supabase.from('strategic_directives_v2').select('sd_key').eq('status', 'completed').gte('updated_at', priorMorningIso);
+    shipped = data?.length || 0;
+  } catch { /* fail-soft */ }
+  try {
+    const { data } = await supabase.from('strategic_directives_v2').select('sd_key').not('status', 'in', NOT_IN_TERMINAL);
+    inFlight = data?.length || 0;
+  } catch { /* fail-soft */ }
+  return { shipped, inFlight };
+}
+
+/** Build the SHORT, PII-free morning-review body. Login-gated summary data only. */
+export async function buildMorningReviewBody(supabase, { now = new Date() } = {}) {
+  const nowMs = now.getTime();
+  const inputs = await gatherForecastInputs(supabase, nowMs);
+  const forecastLine = formatForecastLine(computeForecast({ ...inputs, nowMs }), null);
+
+  const waves = await gatherWaves(supabase);
+  const roadmapLine = waves.waveCount
+    ? `Roadmap: ${waves.avgPct == null ? '?' : waves.avgPct}% build, waves ${waves.doneWaves}/${waves.waveCount} done`
+    : 'Roadmap: (no active roadmap)';
+
+  const { shipped, inFlight } = await gatherYesterday(supabase, etPrior545Iso(now));
+  const yesterdayLine = `Yesterday: ${shipped} shipped, ${inFlight} in-flight`;
+
+  let body = [forecastLine, roadmapLine, yesterdayLine].join('\n');
+  if (body.length > BODY_CEILING) body = `${body.slice(0, BODY_CEILING - 1)}…`;
+  return body;
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  const logger = deps.logger || console;
+  const env = deps.env || process.env;
+  const now = deps.now instanceof Date ? deps.now : (Number.isFinite(deps.now) ? new Date(deps.now) : new Date());
+  const enqueue = deps.enqueue || enqueueChairmanSms;
+  const log = (obj) => logger.log?.(`[morning-review] ${JSON.stringify(obj)}`);
+
+  if (args.help) { logger.log?.('chairman-morning-review-sweep --once [--dry-run]'); return { exitCode: 0, action: 'help' }; }
+
+  // FR-2 ET wall-clock gate: only the season-correct UTC fire (05:XX ET) does work.
+  const etHour = etLocalHour(now);
+  if (etHour !== 5) {
+    log({ action: 'inert', reason: 'outside_et_window', et_hour: etHour });
+    return { exitCode: 0, action: 'inert', reason: 'outside_et_window' };
+  }
+
+  const recipientPhone = env.CHAIRMAN_PHONE;
+  if (!recipientPhone) {
+    log({ action: 'inert', reason: 'chairman_phone_unset' });
+    return { exitCode: 0, action: 'inert', reason: 'chairman_phone_unset' };
+  }
+
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) { logger.error?.(`[morning-review] supabase client unavailable: ${err.message}`); return { exitCode: 2, action: 'no_supabase' }; }
+
+  const dedupeKey = `morning_review:${etDateStr(now)}`;
+  const notBefore = et6amIso(now); // defer an overnight/early enqueue to the 6AM batch (sleep-window)
+
+  let body;
+  try { body = await (deps.buildBody || buildMorningReviewBody)(supabase, { now }); }
+  catch (err) { logger.warn?.(`[morning-review] body build degraded (${err.message})`); body = 'Morning review: status unavailable this run.'; }
+
+  if (args.dryRun) {
+    log({ action: 'dry_run', dedupe_key: dedupeKey, not_before: notBefore, body_len: body.length });
+    return { exitCode: 0, action: 'dry_run', summary: { dedupeKey, notBefore, bodyLength: body.length } };
+  }
+
+  // Owed-state enqueue ONLY — the worker owns the provider send + delivery-truth.
+  const enq = await enqueue(supabase, { recipientPhone, kind: 'morning_review', body, decisionId: null, dedupeKey, notBefore });
+  const action = enq.enqueued ? 'enqueued' : (enq.deduped ? 'deduped' : 'inert');
+  // PII-safe: log counts/ids/reason only — never the recipient phone or the body text.
+  log({ action, obligation_id: enq.obligationId || null, reason: enq.reason || null, dedupe_key: dedupeKey, not_before: notBefore, body_len: body.length });
+  return {
+    exitCode: 0,
+    action,
+    summary: { enqueued: !!enq.enqueued, deduped: !!enq.deduped, reason: enq.reason || null, dedupeKey, notBefore, bodyLength: body.length, obligationId: enq.obligationId || null },
+  };
+}
+
+/** Windows-safe termination (mirrors scripts/cron/sms-outbound-reconcile-sweep.mjs::gracefulExit). */
+export async function gracefulExit(exitCode, { backstopMs = 4000 } = {}) {
+  process.exitCode = exitCode;
+  try {
+    const undici = await import('undici');
+    await undici.getGlobalDispatcher?.()?.close?.();
+  } catch { /* undici absent — natural drain still applies */ }
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().then(({ exitCode }) => gracefulExit(exitCode))
+        .catch((err) => { console.error('chairman-morning-review-sweep fatal:', err.message); return gracefulExit(2); });
+}

--- a/tests/unit/cron/chairman-morning-review-sweep.test.js
+++ b/tests/unit/cron/chairman-morning-review-sweep.test.js
@@ -1,0 +1,242 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B — durable 5:45 ET morning-review sweep.
+ *
+ * Pins the owed-state contract (TS-1..TS-7): enqueue-only (never provider.send), per-ET-date
+ * dedupe double-fire no-op, notBefore=6AM ET deferral, STAGED-absent fail-soft inert, the
+ * ET-wall-clock DST gate (exactly one of the two UTC fires works per season), a short/PII-free
+ * body, and the "what moved yesterday" query window.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  main,
+  parseArgs,
+  buildMorningReviewBody,
+  etLocalHour,
+  etDateStr,
+  et6amIso,
+  etPrior545Iso,
+  BODY_CEILING,
+} from '../../../scripts/cron/chairman-morning-review-sweep.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SWEEP_SRC = readFileSync(path.join(__dirname, '../../../scripts/cron/chairman-morning-review-sweep.mjs'), 'utf8');
+
+// Instants chosen so the ET wall-clock gate is exercised in BOTH DST seasons.
+const SUMMER_WORK = new Date('2026-07-18T09:45:00Z');  // 05:45 EDT -> ET hour 5 (does work)
+const SUMMER_INERT = new Date('2026-07-18T10:45:00Z');  // 06:45 EDT -> ET hour 6 (inert)
+const WINTER_WORK = new Date('2026-01-15T10:45:00Z');  // 05:45 EST -> ET hour 5 (does work)
+const WINTER_INERT = new Date('2026-01-15T09:45:00Z');  // 04:45 EST -> ET hour 4 (inert)
+
+/** Minimal chainable fake supabase; records terminal queries and resolves configured datasets. */
+function makeSupabase(data = {}) {
+  const calls = [];
+  function from(table) {
+    const q = { table, ops: [] };
+    const rec = (m, args) => { q.ops.push({ m, args }); return api; };
+    const api = {
+      select: (...a) => rec('select', a),
+      eq: (...a) => rec('eq', a),
+      gte: (...a) => rec('gte', a),
+      not: (...a) => rec('not', a),
+      order: (...a) => rec('order', a),
+      limit: (...a) => rec('limit', a),
+      then: (resolve, reject) => {
+        calls.push(q);
+        const has = (m) => q.ops.some((o) => o.m === m);
+        let rows = [];
+        if (table === 'strategic_roadmaps') rows = data.roadmaps || [];
+        else if (table === 'roadmap_waves') rows = data.waves || [];
+        else if (table === 'strategic_directives_v2') rows = has('not') ? (data.inFlight || []) : (data.completed || []);
+        return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+      },
+    };
+    return api;
+  }
+  return { from, _calls: calls };
+}
+
+const richData = {
+  roadmaps: [{ id: 'rm1', status: 'active', created_at: '2026-06-01T00:00:00Z' }],
+  waves: [{ status: 'completed', progress_pct: 100 }, { status: 'active', progress_pct: 40 }],
+  completed: [{ sd_key: 'A', updated_at: '2026-07-17T12:00:00Z' }, { sd_key: 'B', updated_at: '2026-07-17T18:00:00Z' }],
+  inFlight: [{ sd_key: 'C', created_at: '2026-07-16T00:00:00Z', sd_type: 'feature', claiming_session_id: null }],
+};
+
+function baseDeps(overrides = {}) {
+  return {
+    supabase: makeSupabase(richData),
+    env: { CHAIRMAN_PHONE: '+15555550123' },
+    now: SUMMER_WORK,
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe('parseArgs', () => {
+  it('parses --once and --dry-run', () => {
+    expect(parseArgs(['node', 's', '--once', '--dry-run'])).toEqual({ once: true, dryRun: true, help: false });
+  });
+});
+
+describe('ET wall-clock gate fixtures are valid (season sanity)', () => {
+  it('summer 09:45Z is 05:45 ET (hour 5); 10:45Z is hour 6', () => {
+    expect(etLocalHour(SUMMER_WORK)).toBe(5);
+    expect(etLocalHour(SUMMER_INERT)).toBe(6);
+  });
+  it('winter 10:45Z is 05:45 ET (hour 5); 09:45Z is hour 4', () => {
+    expect(etLocalHour(WINTER_WORK)).toBe(5);
+    expect(etLocalHour(WINTER_INERT)).toBe(4);
+  });
+});
+
+describe('TS-1 — enqueues via the owed-state path, never fire-and-forget', () => {
+  it('calls enqueueChairmanSms with kind=morning_review when ET hour===5 and phone set', async () => {
+    const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
+    const deps = baseDeps({ enqueue });
+    const r = await main(['node', 's', '--once'], deps);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.action).toBe('enqueued');
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const [, arg] = enqueue.mock.calls[0];
+    expect(arg.kind).toBe('morning_review');
+    expect(arg.recipientPhone).toBe('+15555550123');
+    expect(arg.decisionId).toBeNull();
+  });
+
+  it('the sweep source never calls a provider send seam (no twilioProvider / .send()) ', () => {
+    // Strip comments/docstrings — the invariant is that no CODE path imports a provider or calls .send().
+    const code = SWEEP_SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(code).not.toMatch(/twilioProvider/);
+    expect(code).not.toMatch(/\.send\(/);
+    expect(code).not.toMatch(/from ['"][^'"]*twilio/i);
+  });
+});
+
+describe('TS-2 — dedupeKey prevents a double-send on a cron double-fire', () => {
+  it('same ET-date dedupeKey; second pass is a deduped no-op success', async () => {
+    let firstSeen = false;
+    const enqueue = vi.fn(async (_sb, { dedupeKey }) => {
+      if (!firstSeen) { firstSeen = true; return { enqueued: true, obligationId: 'ob-1' }; }
+      expect(dedupeKey).toBe(`morning_review:${etDateStr(SUMMER_WORK)}`);
+      return { enqueued: false, deduped: true };
+    });
+    const deps = baseDeps({ enqueue });
+
+    const r1 = await main(['node', 's', '--once'], deps);
+    const r2 = await main(['node', 's', '--once'], deps);
+
+    expect(enqueue.mock.calls[0][1].dedupeKey).toBe('morning_review:2026-07-18');
+    expect(enqueue.mock.calls[1][1].dedupeKey).toBe('morning_review:2026-07-18');
+    expect(r1.action).toBe('enqueued');
+    expect(r2.action).toBe('deduped');
+    expect(r2.exitCode).toBe(0);
+  });
+});
+
+describe('TS-3 — notBefore = 6AM ET defers an overnight/early enqueue', () => {
+  it('the enqueued obligation carries not_before = the 6:00 AM ET instant', async () => {
+    const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
+    const deps = baseDeps({ enqueue });
+    await main(['node', 's', '--once'], deps);
+
+    const { notBefore } = enqueue.mock.calls[0][1];
+    expect(notBefore).toBe(et6amIso(SUMMER_WORK));
+    const nb = new Date(notBefore);
+    expect(etLocalHour(nb)).toBe(6);              // resolves to 6AM ET wall-clock
+    expect(nb.getTime()).toBeGreaterThan(SUMMER_WORK.getTime()); // 5:45 precedes 6:00 -> deferred
+  });
+});
+
+describe('TS-4 — STAGED obligations table absent -> fail-soft inert, no crash', () => {
+  it('table_absent return logs inert and exits 0 without throwing', async () => {
+    const enqueue = vi.fn(async () => ({ enqueued: false, reason: 'table_absent' }));
+    const deps = baseDeps({ enqueue });
+    const r = await main(['node', 's', '--once'], deps);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.action).toBe('inert');
+    expect(r.summary.reason).toBe('table_absent');
+  });
+});
+
+describe('TS-5 — ET-wall-clock gate makes exactly one DST entry do work', () => {
+  it('inert (no enqueue) when the ET hour is not 5 — summer 10:45Z fire', async () => {
+    const enqueue = vi.fn();
+    const r = await main(['node', 's', '--once'], baseDeps({ enqueue, now: SUMMER_INERT }));
+    expect(r.action).toBe('inert');
+    expect(r.reason).toBe('outside_et_window');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('inert (no enqueue) when the ET hour is not 5 — winter 09:45Z fire', async () => {
+    const enqueue = vi.fn();
+    const r = await main(['node', 's', '--once'], baseDeps({ enqueue, now: WINTER_INERT }));
+    expect(r.action).toBe('inert');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('works on the season-correct fire — winter 10:45Z', async () => {
+    const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
+    const r = await main(['node', 's', '--once'], baseDeps({ enqueue, now: WINTER_WORK }));
+    expect(r.action).toBe('enqueued');
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue.mock.calls[0][1].dedupeKey).toBe('morning_review:2026-01-15');
+  });
+});
+
+describe('TS-6 — body is short, segment-aware, and PII-free (no phone/body in logs)', () => {
+  it('body contains the forecast/roadmap/yesterday lines and stays under the segment ceiling', async () => {
+    const body = await buildMorningReviewBody(makeSupabase(richData), { now: SUMMER_WORK });
+    expect(body).toMatch(/Estimated completion/);   // formatForecastLine
+    expect(body).toMatch(/Roadmap:/);
+    expect(body).toMatch(/Yesterday: \d+ shipped, \d+ in-flight/);
+    expect(body.length).toBeLessThan(320);
+    expect(body.length).toBeLessThanOrEqual(BODY_CEILING);
+  });
+
+  it('no log line emits the recipient phone or the raw body text', async () => {
+    const PHONE = '+15555550123';
+    const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const body = await buildMorningReviewBody(makeSupabase(richData), { now: SUMMER_WORK });
+    await main(['node', 's', '--once'], baseDeps({ enqueue, logger, env: { CHAIRMAN_PHONE: PHONE } }));
+
+    const logged = logger.log.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).not.toContain(PHONE);
+    expect(logged).not.toContain(body);
+  });
+});
+
+describe('TS-7 — "what moved yesterday" query window', () => {
+  it('completed-since uses eq(status,completed)+gte(updated_at, prior 5:45 ET); in-flight uses not(status,in,terminal)', async () => {
+    const sb = makeSupabase(richData);
+    await buildMorningReviewBody(sb, { now: SUMMER_WORK });
+
+    const priorIso = etPrior545Iso(SUMMER_WORK);
+    const sdCalls = sb._calls.filter((c) => c.table === 'strategic_directives_v2');
+
+    const completedSince = sdCalls.some((c) =>
+      c.ops.some((o) => o.m === 'eq' && o.args[0] === 'status' && o.args[1] === 'completed') &&
+      c.ops.some((o) => o.m === 'gte' && o.args[0] === 'updated_at' && o.args[1] === priorIso));
+    expect(completedSince).toBe(true);
+
+    const inFlight = sdCalls.some((c) =>
+      c.ops.some((o) => o.m === 'not' && o.args[0] === 'status' && o.args[1] === 'in' && o.args[2] === '("completed","cancelled","deferred")'));
+    expect(inFlight).toBe(true);
+  });
+});
+
+describe('CHAIRMAN_PHONE unset -> inert', () => {
+  it('logs inert and exits 0 with no enqueue when the phone is unset', async () => {
+    const enqueue = vi.fn();
+    const r = await main(['node', 's', '--once'], baseDeps({ enqueue, env: {} }));
+    expect(r.exitCode).toBe(0);
+    expect(r.action).toBe('inert');
+    expect(r.reason).toBe('chairman_phone_unset');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Child B of the daily-review decompose (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001). Delivers a durable 5:45 AM ET morning-review that survives session compaction and sends a TEXT-only chairman SMS via the hardened owed-state bridge.

- **Durable cron** (`scripts/cron/chairman-morning-review-sweep.mjs`): `--once` runner mirroring `sms-outbound-reconcile-sweep.mjs` — no session-local timer.
- **DST handling** (`.github/workflows/chairman-morning-review-cron.yml`): two UTC entries (`45 9` + `45 10`) + an in-sweep `America/New_York` ET-hour===5 gate so exactly one fires per season.
- **Text-only SMS via owed-state path**: builds a short roadmap-status + forecast + yesterday-vs-today body and enqueues via `enqueueChairmanSms(kind='morning_review', dedupeKey='morning_review:<ET-date>', notBefore=6AM ET)` — reuses the delivery-truth path (no fire-and-forget), dedup on double-fire, sleep-window deferral, and fail-soft when the STAGED `sms_outbound_obligations` table is unapplied.

## Evidence
- Unit: 15/15 green (`tests/unit/cron/chairman-morning-review-sweep.test.js`)
- TESTING PASS 96 · SECURITY PASS 96 (no fire-and-forget, no PII in logs, sleep-window honored) · VALIDATION PASS 95 · REGRESSION PASS 96 (purely additive) · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 100
- No new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)