### PR TITLE
fix(SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001): differentiate Bash retry signatures via stdout content

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001.json
@@ -1,0 +1,73 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Capture a real content fingerprint (stdout_sha) alongside the existing stderr_sha",
+      "priority": "critical",
+      "description": "scripts/hooks/post-tool-rca-outcome.cjs gains digestStdoutTail(stdout) (generalized from the existing digestStderr via a shared digestContent(firstLine + normalized bounded body-window) helper), captures tool_response.stdout (fallback .output) UNCONDITIONALLY (not gated on inferred failure), and writes a new stdout_sha field into .claude/last-outcome-<session>.json alongside the existing tool_name/exit_code/stderr_sha/command_sha fields. ROOT CAUSE (empirically confirmed, not assumed): Claude Code's Bash tool_response never populates real stderr content or a numeric exit_code -- confirmed by the coordinator-confirmed RCA (session 89b12649, 169-session proof: stderr_sha only ever {'', sha256('')}, exit_code only ever {0,null}) AND independently re-confirmed live during this SD's own investigation by capturing a genuine failure's real PostToolUse payload: {stdout: '<all error text + an uncaught native crash message>', stderr: '', interrupted: false, isImage: false, noOutputExpected: false} -- structurally IDENTICAL in shape to a successful command's tool_response, with zero distinguishing boolean/field difference; only stdout CONTENT differs. Additive-only change: the existing stderr_sha/exit_code fields and their consumers (Control 1+2's noFailureSignal read-only-command exemption) are left byte-identical in semantics.",
+      "acceptance_criteria": [
+        "digestStdoutTail(stdout) returns a 16-hex-char digest for non-empty input, '' for empty/non-string input, using the same first-line + normalized-body-window approach as digestStderr",
+        "The outcome file written by post-tool-rca-outcome.cjs includes a stdout_sha field for every Bash invocation where stdout has content, independent of whether exit_code/stderr_sha are populated",
+        "Independently verified (Explore sub-agent, this SD's LEAD-TO-PLAN phase, PASS 95%) that no other consumer in the repo reads stderr_sha in a way this addition could break -- confirmed via full-repo grep of .stderr_sha property access (exactly 2 production sites, both inside retry-state-manager.cjs itself)"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Mix stdout_sha into the Bash retry signature's outcome digest",
+      "priority": "critical",
+      "description": "scripts/hooks/retry-state-manager.cjs's signatureFor() mixes lastOutcome.stdout_sha into the Bash outcome digest (SHA256 of exit_code|stderr_sha|stdout_sha, truncated to 8 hex chars) alongside the existing exit_code/stderr_sha fields, producing signatures shaped Bash:<cmdHash>:<outcomeDigest>. The outcome-admixture trigger condition is extended so a lastOutcome carrying ONLY stdout_sha (no exit_code/stderr_sha) still gets outcome admixture instead of falling back to the legacy command-only signature. SCOPE BOUNDARY (VALIDATION-imposed, LEAD-TO-PLAN CONDITIONAL_PASS->corrected): this FR fixes signature DIFFERENTIATION only. It does NOT touch, and does NOT fix, the separate succeeding-poll exemption in recordAndCount() (scripts/hooks/retry-state-manager.cjs, from SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001) or the Control 4 absence-of-failure exit_code inference (post-tool-rca-outcome.cjs, from SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001) -- both are pre-existing, separately-shipped, separately-tested features; bundling a fix to them into this PR would be a materially larger, riskier change requiring its own RCA-informed design. See the KNOWN LIMITATIONS section below and follow-up SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001 (filed this session, priority=high, by VALIDATION's explicit recommendation).",
+      "acceptance_criteria": [
+        "3 distinct real-shaped Bash failures on the same command (identical command text, distinct stdout content, real-harness-shaped lastOutcome with NO matching command_sha carried -- i.e. the succeeding-poll exemption does not apply) each produce a DISTINCT signature and track attempts=1 under their own signature -- no false collapse into a shared stuck-loop signature",
+        "A legitimately-different 4th attempt (distinct stdout content again, e.g. an eventual success) on the same command also gets a fresh signature at attempts=1 -- not hard-blocked by the accumulated count of a prior (now-distinct) signature",
+        "REGRESSION GUARD: 3 IDENTICAL real-shaped failures (same stdout content each time, no matching command_sha) still correctly accumulate to attempts=3 under ONE shared signature -- the stuck-loop detection this feature exists for is preserved, not weakened, by the stdout_sha admixture",
+        "KNOWN LIMITATION test (not a failure of this FR, an honest documentation of a DIFFERENT, pre-existing defect): when a matching command_sha IS carried on lastOutcome (the dominant real-world shape once outcome capture has fired at least once for a repeated command), the succeeding-poll exemption in recordAndCount() pre-empts signature-based counting entirely BEFORE this FR's stdout_sha admixture is even consulted -- attempts stays 0 across repeats, regardless of stdout content. This is proven by a dedicated test and tracked as its own follow-up SD (SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001), NOT silently claimed as fixed by this SD"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "De-mask the test suite against the REAL Claude Code tool_response shape",
+      "priority": "critical",
+      "description": "New test file tests/unit/rca-tiered-signature-real-payload.test.js exercises the fix end-to-end using ONLY the empirically-real payload shape (no exit_code field, stderr always '', distinguishing content only in stdout) -- the exact shape the RCA proved is the ONLY shape Claude Code ever produces, in contrast to the pre-existing test suite (scripts/hooks/__tests__/retry-state-manager-outcome-mix.test.js and incidental cases elsewhere) which constructs synthetic lastOutcome objects with distinct stderr_sha values per attempt, a shape that never occurs in production and which is why the pre-fix collapse shipped green. This SD's new test file FIRST demonstrates the pre-fix collapse explicitly (stderr_sha alone is constant across 3 distinct real-shaped failures) before proving the post-fix signature differentiation. Pre-existing test-mask sites (identified by the Explore sub-agent this SD's LEAD-TO-PLAN phase) are catalogued but explicitly NOT modified -- out of scope for this SD, which fixes the PRODUCTION code path, not every pre-existing test fixture.",
+      "acceptance_criteria": [
+        "tests/unit/rca-tiered-signature-real-payload.test.js exists and passes, using ONLY the real empirically-captured tool_response shape ({stdout, stderr:'', interrupted:false, isImage:false, noOutputExpected:false}, no exit_code/is_error/isError/error field anywhere)",
+        "The test file includes an explicit 'PRE-FIX REGRESSION DOCUMENTATION' case proving stderr_sha alone collapses to a single constant value across 3 distinct real-shaped failures -- the exact defect being fixed, made undeniable rather than merely asserted in prose",
+        "Full relevant test suite (post-tool-rca-outcome.test.js, retry-state-manager*.test.js, the new de-masking file) passes with zero regressions"
+      ]
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "type": "unit", "scenario": "digestStdoutTail on empty/non-string input", "expected": "Returns ''" },
+    { "id": "TS-2", "type": "unit", "scenario": "digestStdoutTail on two distinct governance-trigger error strings", "expected": "Two different 16-hex digests" },
+    { "id": "TS-3", "type": "unit", "scenario": "digestStdoutTail on a genuinely-identical recurrence differing only by a volatile timestamp", "expected": "Same digest (normalization preserved)" },
+    { "id": "TS-4", "type": "unit", "scenario": "post-tool-rca-outcome.cjs writes stdout_sha into the outcome file for a real-shaped Bash payload with non-empty stdout, empty stderr", "expected": "stdout_sha is a 16-hex digest matching digestStdoutTail(stdout) exactly" },
+    { "id": "TS-5", "type": "unit", "scenario": "signatureFor: stdout_sha alone (no exit_code/stderr_sha) triggers outcome admixture", "expected": "Signature format Bash:<hash>:<8-hex-digest>, distinct from the command-only baseline" },
+    { "id": "TS-6", "type": "unit", "scenario": "signatureFor: same exit_code+stderr_sha but different stdout_sha", "expected": "Distinct signatures" },
+    { "id": "TS-7", "type": "unit", "scenario": "signatureFor: identical {exit_code, stderr_sha, stdout_sha}", "expected": "Identical signature (stuck-loop detection preserved)" },
+    { "id": "TS-8", "type": "integration", "scenario": "recordAndCount: 3 distinct real-shaped failures (no matching command_sha) on the same command", "expected": "3 distinct signatures, each attempts=1; a legitimately-different 4th attempt also gets a fresh signature at attempts=1 -- not hard-blocked" },
+    { "id": "TS-9", "type": "integration", "scenario": "recordAndCount: 3 IDENTICAL real-shaped failures (no matching command_sha)", "expected": "One shared signature, attempts increments 1,2,3 -- stuck-loop detection (teeth) preserved" },
+    { "id": "TS-10", "type": "integration", "scenario": "KNOWN LIMITATION: recordAndCount with a matching command_sha carried on lastOutcome (the dominant real-world repeat-command shape) for 3 IDENTICAL real-shaped failures", "expected": "attempts stays 0 across all 3 (the succeeding-poll exemption pre-empts counting) -- documented honestly as a pre-existing, separate defect NOT fixed by this SD, tracked in follow-up SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001" },
+    { "id": "TS-11", "type": "unit", "scenario": "Regression: full pre-existing test suite for both hook files (post-tool-rca-outcome.test.js, retry-state-manager*.test.js) with the additive stdout_sha change", "expected": "Zero regressions, all pre-existing tests still pass unmodified" }
+  ],
+  "risks": [
+    {
+      "risk": "The succeeding-poll exemption's over-broad match (command_sha + Control-4-inferred exit_code:0) means this fix's real-world impact is narrower than the SD's original problem narrative implied -- it fully protects the signature-differentiation layer but does not restore end-to-end 3-strikes efficacy for the dominant same-command-repeat blind-retry pattern",
+      "severity": "high",
+      "mitigation": "VALIDATION-caught during LEAD-TO-PLAN adversarial review (not silently shipped). Filed as a first-class, high-priority follow-up SD (SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001) rather than bundled into this SD's smaller, safer, well-tested scope. This SD's own test suite includes an explicit KNOWN LIMITATION test (TS-10) so the gap is a regression canary, not a silent claim of completeness."
+    },
+    {
+      "risk": "digestStdoutTail's normalizeVolatileTokens reuse could over-normalize genuinely-distinguishing stdout content (e.g. two different failures whose only difference is a large number that happens to look like a volatile numeric id), causing an unintended re-collapse",
+      "severity": "low",
+      "mitigation": "Reuses the EXACT SAME, already-tested normalizeVolatileTokens function shipped by SD-LEO-FIX-RCA-HASH-COLLISION-001 for digestStderr -- no new normalization logic introduced, so no new over-normalization risk beyond what that already-verified function carries. Existing tests (post-tool-rca-outcome.test.js's normalizeVolatileTokens suite) already cover this boundary."
+    },
+    {
+      "risk": "Capturing stdout unconditionally (not gated on inferred failure) could grow the outcome file size or leak sensitive command output into .claude/last-outcome-<session>.json",
+      "severity": "low",
+      "mitigation": "digestStdoutTail only stores a bounded 16-hex-char SHA256 digest of a truncated (first line + 5 body lines) window -- never the raw stdout text itself. The outcome file's total size growth is negligible (one short string field), and no raw command output is persisted."
+    },
+    {
+      "risk": "This session's own investigation found the shared repo root (used for hook execution via CLAUDE_PROJECT_DIR) was stale relative to origin/main (checked out on an unrelated docs-changelog branch from earlier session work), meaning production hooks may be running an OLDER version of retry-state-manager.cjs/post-tool-rca-outcome.cjs than what ships in this PR until the shared root is updated",
+      "severity": "medium",
+      "mitigation": "Out of scope for this SD to fix (a separate session/environment-hygiene issue, not a code defect) -- flagged via /signal harness-bug this session for coordinator awareness. The fix itself is correct and will take effect fleet-wide once the shared root's checkout is refreshed to include this merged commit (the normal path once the PR merges to main and the shared root's session or a maintenance job re-syncs)."
+    }
+  ]
+}

--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -63,6 +63,26 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     expect(written.stderr_sha).toBe(expectedSha);
   });
 
+  it('SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: stdout_sha is captured alongside stderr_sha when stderr is empty', () => {
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X' },
+      tool_response: { stdout: 'SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason', stderr: '', interrupted: false, isImage: false, noOutputExpected: false },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: SESSION_ID, LEO_RETRY_STATE_DIR: tmpDir },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.stderr_sha).toBe('');
+    expect(written.stdout_sha).toMatch(/^[0-9a-f]{16}$/);
+    const { digestStdoutTail } = require(HOOK_PATH);
+    expect(written.stdout_sha).toBe(digestStdoutTail('SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason'));
+  });
+
   it('TS-5 (Control 4): a SUCCESS payload (no exit_code, no stderr) records exit_code 0', () => {
     // Claude Code Bash tool_response carries NO exit_code; success was previously skipped.
     const payload = JSON.stringify({

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -2,14 +2,24 @@
 /**
  * post-tool-rca-outcome.cjs — capture tool outcome for next PreToolUse signature mix.
  *
- * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001, SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001
  *
  * Reads tool_response from STDIN payload (per verified 2026-05-04 hook
  * stdin/env contract — env contains only 6 CLAUDE_* vars, NOT tool_response).
  * Writes .claude/last-outcome-<session>.json with {tool_name, exit_code,
- * stderr_sha, captured_at}. PreToolUse reads this file on next call and threads
- * the digest into signatureFor() so iterative TDD (different stderr each retry)
- * naturally tracks attempts=1 instead of tripping the 3-strikes counter.
+ * stderr_sha, stdout_sha, captured_at}. PreToolUse reads this file on next call and
+ * threads the digest into signatureFor() so iterative TDD (different stdout/stderr
+ * each retry) naturally tracks attempts=1 instead of tripping the 3-strikes counter.
+ *
+ * stdout_sha (SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001): Claude Code's
+ * Bash tool_response never populates real stderr content on this harness — confirmed
+ * empirically (169-session RCA + a direct live capture of a genuine failure: `stderr`
+ * was `''` even though the command printed an error AND crashed; the entire error
+ * text landed in `stdout`, and no numeric exit_code / is_error / isError field exists
+ * anywhere in tool_response). stderr_sha therefore collapses to a near-constant value
+ * across distinct failures, which zeroed out the outcome-digest entropy the tiered
+ * signature relies on. stdout_sha gives the signature a real content fingerprint so
+ * genuinely distinct failures (and successes) produce genuinely distinct signatures.
  *
  * Hook contract:
  *   - Always exits 0 (fail-open). Bookkeeping must NOT block tool execution.
@@ -88,19 +98,39 @@ function normalizeVolatileTokens(line) {
     .replace(/\b\d{6,}\b/g, '<NUM>');
 }
 
-function digestStderr(stderr) {
-  if (typeof stderr !== 'string' || !stderr) return '';
-  // First-line canonicalization — captures the failure shape without tying
-  // the digest to volatile fields like file paths or timestamps in subsequent lines.
-  const lines = stderr.split(/\r?\n/).filter((l) => l.length > 0);
+// SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: shared bounded-window digest,
+// generalized from the stderr-only digestStderr so the SAME normalization applies to
+// stdout tail content (see digestStderr / digestStdoutTail below). First line + a
+// normalized window of the next few body lines — bounded so huge output doesn't blow
+// up the hash input, and normalized so volatile per-run tokens (paths, timestamps,
+// UUIDs, large numeric ids) don't split a genuine recurrence into distinct digests.
+function digestContent(text) {
+  if (typeof text !== 'string' || !text) return '';
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
   const firstLine = lines[0] || '';
-  // SD-LEO-FIX-RCA-HASH-COLLISION-001: first-line-only hashing collided for distinct
-  // failures whose first line is a count/summary (e.g. "N violation(s):") and whose
-  // actual identity lives on later lines — mix in a normalized digest of a bounded
-  // window of body lines so distinct failures split while genuine recurrences (same
-  // shape, different volatile detail) still collapse to one digest.
   const body = lines.slice(1, 6).map(normalizeVolatileTokens).join('\n');
   return crypto.createHash('sha256').update(`${firstLine}\n${body}`).digest('hex').slice(0, 16);
+}
+
+// SD-LEO-FIX-RCA-HASH-COLLISION-001: first-line-only hashing collided for distinct
+// failures whose first line is a count/summary (e.g. "N violation(s):") and whose
+// actual identity lives on later lines — mix in a normalized digest of a bounded
+// window of body lines so distinct failures split while genuine recurrences (same
+// shape, different volatile detail) still collapse to one digest.
+function digestStderr(stderr) {
+  return digestContent(stderr);
+}
+
+// SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: Claude Code's Bash
+// tool_response never populates real stderr content (empirically confirmed: `stderr`
+// is `''` on this harness even for a genuine failure whose error text — including an
+// uncaught native crash — landed entirely in `stdout`). digestStderr therefore almost
+// always returns `''`, collapsing every failure into the same zero-entropy outcome
+// digest downstream in signatureFor(). digestStdoutTail gives distinct failures (and
+// distinct successes) a real content fingerprint to differentiate on, mirroring
+// digestStderr's same bounded/normalized approach.
+function digestStdoutTail(stdout) {
+  return digestContent(stdout);
 }
 
 async function run() {
@@ -154,6 +184,18 @@ async function run() {
           : '';
     const stderrSha = digestStderr(stderr);
 
+    // SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: real distinguishing content
+    // for a Bash command lives in tool_response.stdout on this harness (both success AND
+    // failure text land there — stderr is not a reliable source). Captured unconditionally
+    // (not just on inferred failure) so signatureFor() can mix it into the outcome digest.
+    const stdout =
+      typeof resp.stdout === 'string'
+        ? resp.stdout
+        : typeof resp.output === 'string'
+          ? resp.output
+          : '';
+    const stdoutSha = digestStdoutTail(stdout);
+
     // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 4 — exit-code capture).
     // Claude Code's Bash tool_response carries NO numeric exit_code, so a SUCCESSFUL
     // command previously hit the `exitCode===null && !stderrSha` skip below and wrote no
@@ -177,7 +219,9 @@ async function run() {
 
     // Skip only when there is STILL no usable signal (e.g. a bare failure flag with no
     // detail) — accumulation/teeth for genuine failures are preserved by NOT exempting.
-    if (exitCode === null && !stderrSha) return;
+    // stdoutSha counts as a usable signal too (SD-LEO-INFRA-RCA-TIERED-SIGNATURE-
+    // FALSE-POSITIVE-001) — content on this harness lives in stdout, not stderr.
+    if (exitCode === null && !stderrSha && !stdoutSha) return;
 
     // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: capture command_sha so the next PreToolUse
     // can scope the succeeding-poll exemption to the SAME command (recordAndCount compares
@@ -198,6 +242,7 @@ async function run() {
       tool_name: toolName,
       exit_code: exitCode,
       stderr_sha: stderrSha,
+      stdout_sha: stdoutSha,
       command_sha: commandSha,
       captured_at: new Date().toISOString(),
     };
@@ -217,7 +262,7 @@ async function run() {
   }
 }
 
-module.exports = { digestStderr, normalizeVolatileTokens, stateFilePath };
+module.exports = { digestStderr, digestStdoutTail, digestContent, normalizeVolatileTokens, stateFilePath };
 
 if (require.main === module) {
   run();

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -104,9 +104,17 @@ function normalizeVolatileTokens(line) {
 // normalized window of the next few body lines — bounded so huge output doesn't blow
 // up the hash input, and normalized so volatile per-run tokens (paths, timestamps,
 // UUIDs, large numeric ids) don't split a genuine recurrence into distinct digests.
+// SECURITY (EXEC-TO-PLAN review, SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001):
+// this diff makes digestContent fire on real stdout content far more often than the
+// stderr-only predecessor (stdout is populated on this harness; stderr is near-always
+// empty) — cap each line's length BEFORE normalization/hashing so a single
+// pathologically long line can't dominate the regex/hash work. Defense-in-depth only;
+// the existing regexes are already linear (no catastrophic-backtracking risk).
+const MAX_DIGEST_LINE_LENGTH = 500;
+
 function digestContent(text) {
   if (typeof text !== 'string' || !text) return '';
-  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0).map((l) => l.slice(0, MAX_DIGEST_LINE_LENGTH));
   const firstLine = lines[0] || '';
   const body = lines.slice(1, 6).map(normalizeVolatileTokens).join('\n');
   return crypto.createHash('sha256').update(`${firstLine}\n${body}`).digest('hex').slice(0, 16);

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -260,16 +260,21 @@ function stateFilePath(sessionId) {
  * Build a stable signature for a tool invocation.
  *
  * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-001: optional `lastOutcome` param mixes a
- * digest of {exit_code, stderr_sha} into the Bash signature so iterative TDD
- * (different failure each retry) does NOT collapse into the stuck-loop signature.
+ * digest of {exit_code, stderr_sha, stdout_sha} into the Bash signature so iterative
+ * TDD (different failure each retry) does NOT collapse into the stuck-loop signature.
  * Same outcome → same digest → stuck-loop detection preserved.
+ *
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: stdout_sha is the primary real
+ * differentiator on Claude Code — stderr_sha is near-always '' (real stderr is never
+ * delivered on this harness; error text lands in stdout instead), so stderr_sha+exit_code
+ * alone systematically collapsed distinct failures into one signature.
  *
  * Edit/Write/MultiEdit signatures are unchanged — file_path is the natural key.
  *
  * @param {string} toolName
  * @param {Object} input
- * @param {{exit_code?: number|string, stderr_sha?: string}} [lastOutcome] - optional outcome
- *        from the prior tool call (captured by post-tool-rca-outcome.cjs).
+ * @param {{exit_code?: number|string, stderr_sha?: string, stdout_sha?: string}} [lastOutcome] -
+ *        optional outcome from the prior tool call (captured by post-tool-rca-outcome.cjs).
  *        Without it, returns the legacy command-only signature (back-compat).
  * @returns {string|null}
  */
@@ -292,14 +297,21 @@ function signatureFor(toolName, input, lastOutcome) {
     if (!cmd) return null;
     const hash = bashCmdHash(cmd);
     // Outcome admixture (back-compat: missing/malformed lastOutcome → command-only signature).
+    // SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: also admix stdout_sha — on
+    // Claude Code, stderr_sha is near-always '' (real stderr is never delivered; error
+    // text lands in stdout instead), so stderr_sha ALONE zeroed out the digest's entropy
+    // and distinct failures collapsed into one signature. stdout_sha carries the real
+    // distinguishing content. Trigger condition includes stdout_sha so a lastOutcome
+    // carrying ONLY stdout_sha (no exit_code/stderr_sha) still gets outcome admixture.
     if (
       lastOutcome &&
       typeof lastOutcome === 'object' &&
-      (lastOutcome.exit_code !== undefined || lastOutcome.stderr_sha !== undefined)
+      (lastOutcome.exit_code !== undefined || lastOutcome.stderr_sha !== undefined || lastOutcome.stdout_sha !== undefined)
     ) {
       const ec = lastOutcome.exit_code === undefined ? '' : String(lastOutcome.exit_code);
       const ss = typeof lastOutcome.stderr_sha === 'string' ? lastOutcome.stderr_sha : '';
-      const outcomeDigest = crypto.createHash('sha256').update(`${ec}|${ss}`).digest('hex').slice(0, 8);
+      const so = typeof lastOutcome.stdout_sha === 'string' ? lastOutcome.stdout_sha : '';
+      const outcomeDigest = crypto.createHash('sha256').update(`${ec}|${ss}|${so}`).digest('hex').slice(0, 8);
       return `Bash:${hash}:${outcomeDigest}`;
     }
     return `Bash:${hash}`;

--- a/tests/unit/rca-tiered-signature-real-payload.test.js
+++ b/tests/unit/rca-tiered-signature-real-payload.test.js
@@ -1,0 +1,220 @@
+/**
+ * SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001 — de-masking test.
+ *
+ * Coordinator-confirmed RCA (session 89b12649, 169-session empirical proof, corroborated
+ * live during this SD's own investigation): Claude Code's Bash tool_response NEVER
+ * populates real stderr content or a numeric exit_code, on success OR failure — verified
+ * by directly capturing a real PostToolUse payload for a genuinely-failing command
+ * (explicit `console.error()` + `process.exit(1)` + an uncaught native crash), whose
+ * tool_response was `{stdout: "<all the error/crash text>", stderr: "", interrupted:
+ * false, isImage: false, noOutputExpected: false}` — structurally IDENTICAL in shape to
+ * a successful command's tool_response, differing only in stdout CONTENT.
+ *
+ * The pre-fix unit tests for this feature (scripts/hooks/__tests__/post-tool-rca-outcome
+ * .test.js, tests/unit/retry-state-manager-signature.test.js) all construct synthetic
+ * lastOutcome objects with distinct stderr_sha values per attempt — a shape that never
+ * occurs on the real harness. Those tests stayed green while the real signal (stderr_sha)
+ * silently collapsed to '' every time in production: TEST-MASKING, per the RCA's own
+ * classification.
+ *
+ * These tests use ONLY the empirically-real payload shape (no exit_code field, stderr
+ * always '', distinguishing content only in stdout) end-to-end through both hooks, and
+ * FIRST demonstrate the pre-fix collapse would have occurred (documents the regression
+ * this fix closes) before proving the post-fix behavior satisfies the SD's 3 acceptance
+ * criteria.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const HOOK_PATH = path.resolve(__dirname, '../../scripts/hooks/post-tool-rca-outcome.cjs');
+const RETRY_MGR_PATH = path.resolve(__dirname, '../../scripts/hooks/retry-state-manager.cjs');
+
+/** The real, empirically-captured Claude Code Bash tool_response shape. No exit_code,
+ *  no is_error/isError/error field, stderr always ''. Only `stdout` varies. */
+function realShapedPayload({ sessionId, command, stdout }) {
+  return JSON.stringify({
+    session_id: sessionId,
+    tool_name: 'Bash',
+    tool_input: { command },
+    tool_response: { stdout, stderr: '', interrupted: false, isImage: false, noOutputExpected: false },
+  });
+}
+
+function runHookOnce({ sessionId, tmpDir, command, stdout }) {
+  const payload = realShapedPayload({ sessionId, command, stdout });
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: payload,
+    env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: sessionId, LEO_RETRY_STATE_DIR: tmpDir },
+    encoding: 'utf8',
+  });
+  expect(result.status).toBe(0);
+  const outFile = path.join(tmpDir, `last-outcome-${sessionId}.json`);
+  return JSON.parse(fs.readFileSync(outFile, 'utf8'));
+}
+
+describe('de-masked capture: real tool_response shape produces a real content fingerprint', () => {
+  let tmpDir;
+  const SESSION_ID = 'real-shape-' + Math.random().toString(36).slice(2);
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-real-shape-'));
+  });
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it('PRE-FIX REGRESSION DOCUMENTATION: on the real payload shape, stderr_sha alone is constant across 3 distinct failures', () => {
+    // This is the bug this SD fixes, made explicit: with the REAL shape (stderr always
+    // ''), stderr_sha collapses to '' regardless of how different the failures are.
+    const outcomes = [
+      runHookOnce({ sessionId: SESSION_ID + '-a', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason' }),
+      runHookOnce({ sessionId: SESSION_ID + '-b', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'anti-gaming-threshold exceeded: too many type changes' }),
+      runHookOnce({ sessionId: SESSION_ID + '-c', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'SD_TYPE_CHANGE_TIMING_BLOCKED: cool-down window active' }),
+    ];
+    expect(new Set(outcomes.map((o) => o.stderr_sha)).size).toBe(1); // all collapse to ''
+    expect(outcomes[0].stderr_sha).toBe('');
+  });
+
+  it('TS-A / AC(a): the SAME 3 distinct failures produce 3 DISTINCT stdout_sha values', () => {
+    const outcomes = [
+      runHookOnce({ sessionId: SESSION_ID + '-a2', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason' }),
+      runHookOnce({ sessionId: SESSION_ID + '-b2', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'anti-gaming-threshold exceeded: too many type changes' }),
+      runHookOnce({ sessionId: SESSION_ID + '-c2', tmpDir, command: 'node scripts/handoff.js execute PLAN-TO-LEAD SD-X', stdout: 'SD_TYPE_CHANGE_TIMING_BLOCKED: cool-down window active' }),
+    ];
+    const shas = outcomes.map((o) => o.stdout_sha);
+    expect(new Set(shas).size).toBe(3);
+    shas.forEach((s) => expect(s).toMatch(/^[0-9a-f]{16}$/));
+  });
+
+  it('a genuine crash payload (real empirical capture shape) is also captured, not skipped', () => {
+    // Mirrors the real captured payload from this SD's own investigation: stdout carries
+    // BOTH a console.error()'d message AND an uncaught native-crash line; stderr is ''.
+    const outcome = runHookOnce({
+      sessionId: SESSION_ID + '-crash',
+      tmpDir,
+      command: 'node -e "some-script.js"',
+      stdout: 'ERR column sub_agent_execution_results.status does not exist\nAssertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76',
+    });
+    expect(outcome.stdout_sha).toMatch(/^[0-9a-f]{16}$/);
+    expect(outcome.stdout_sha).not.toBe('');
+  });
+});
+
+describe('TS-B / AC(a)+AC(b): end-to-end recordAndCount — 3 distinct real-shaped failures never collapse, a 4th correct attempt is not hard-blocked', () => {
+  let tmpDir;
+  const SESSION_ID = 'e2e-' + Math.random().toString(36).slice(2);
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-e2e-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+    delete require.cache[require.resolve(RETRY_MGR_PATH)];
+  });
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    delete process.env.LEO_RETRY_STATE_DIR;
+  });
+
+  it('3 distinct real-shaped Bash failures on the SAME command each track attempts=1 under their own signature (no false collapse) -- SCOPE: this models the case where the succeeding-poll exemption in recordAndCount() does NOT apply (no matching command_sha carried on lastOutcome, e.g. the first invocation this session, or a session where outcome capture has not yet fired for this command). See the "PRODUCTION REALITY" test below for the dominant real-world case where a matching command_sha IS present.', async () => {
+    const mod = require(RETRY_MGR_PATH);
+    const noopRca = async () => null;
+    const cmd = 'node scripts/handoff.js execute PLAN-TO-LEAD SD-REAL-001';
+
+    // Each lastOutcome mirrors the REAL Claude Code shape: no exit_code, stderr_sha '',
+    // only stdout_sha differs (as computed by post-tool-rca-outcome.cjs's digestStdoutTail).
+    // Deliberately OMITS command_sha (see scope note above).
+    const { digestStdoutTail } = require(HOOK_PATH);
+    const outcomes = [
+      { exit_code: 0, stderr_sha: '', stdout_sha: digestStdoutTail('SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason') },
+      { exit_code: 0, stderr_sha: '', stdout_sha: digestStdoutTail('anti-gaming-threshold exceeded: too many type changes') },
+      { exit_code: 0, stderr_sha: '', stdout_sha: digestStdoutTail('SD_TYPE_CHANGE_TIMING_BLOCKED: cool-down window active') },
+    ];
+
+    const results = [];
+    for (const lastOutcome of outcomes) {
+      results.push(await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome }));
+    }
+
+    // AC(a): 3 distinct signatures — none collapsed.
+    const sigs = results.map((r) => r.signature);
+    expect(new Set(sigs).size).toBe(3);
+    // Each new signature starts fresh at attempts=1 — the hard block (attempts>=3 on ONE
+    // signature) never triggers.
+    results.forEach((r) => expect(r.attempts).toBe(1));
+
+    // AC(b): a legitimately-different 4th attempt (this time succeeding) is not blocked.
+    const fourthOutcome = { exit_code: 0, stderr_sha: '', stdout_sha: digestStdoutTail('Handoff PLAN-TO-LEAD complete, score 97') };
+    const fourth = await mod.recordAndCount(SESSION_ID, null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: fourthOutcome });
+    expect(fourth.attempts).toBe(1); // fresh signature, not the accumulated 4th strike on a collapsed one
+    expect(new Set([...sigs, fourth.signature]).size).toBe(4);
+  });
+
+  it('REGRESSION GUARD (teeth preserved when the succeeding-poll exemption does not apply): 3 IDENTICAL real-shaped failures (same stdout each time, no matching command_sha carried) still accumulate to attempts=3', async () => {
+    const mod = require(RETRY_MGR_PATH);
+    const noopRca = async () => null;
+    const cmd = 'node scripts/genuinely-broken-script.js';
+    const { digestStdoutTail } = require(HOOK_PATH);
+    const sameOutcome = { exit_code: 0, stderr_sha: '', stdout_sha: digestStdoutTail('TypeError: cannot read property "x" of undefined') };
+
+    const a = await mod.recordAndCount(SESSION_ID + '-stuck', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcome });
+    const b = await mod.recordAndCount(SESSION_ID + '-stuck', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcome });
+    const c = await mod.recordAndCount(SESSION_ID + '-stuck', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcome });
+    expect(a.attempts).toBe(1);
+    expect(b.attempts).toBe(2);
+    expect(c.attempts).toBe(3);
+    expect(a.signature).toBe(b.signature);
+    expect(b.signature).toBe(c.signature);
+  });
+
+  it('KNOWN LIMITATION (VALIDATION-caught, tracked in follow-up SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001, NOT fixed by this SD): when a matching command_sha IS carried on lastOutcome (the dominant real-world shape -- pre-tool-enforce.cjs always passes the FULL captured outcome, including command_sha, per scripts/hooks/post-tool-rca-outcome.cjs), the succeeding-poll exemption in recordAndCount() short-circuits BEFORE this SD stdout_sha signature-differentiation is even consulted. Because Control 4 (SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001) infers exit_code:0 from mere absence of a failure signal -- and Claude Code never exposes a real failure signal for a genuine failure either -- the exemption fires on every same-command repeat, so even 3+ IDENTICAL genuine failures never accumulate. This documents CURRENT reality (attempts stays 0), not a desired behavior -- it is a regression canary for the follow-up SD, not proof this SD is complete.', async () => {
+    const mod = require(RETRY_MGR_PATH);
+    const noopRca = async () => null;
+    const cmd = 'node scripts/genuinely-broken-script.js';
+    const { digestStdoutTail, bashCmdHash } = { ...require(HOOK_PATH), ...require(RETRY_MGR_PATH) };
+    const commandSha = bashCmdHash(cmd);
+    // Mirrors what post-tool-rca-outcome.cjs ACTUALLY writes in production for a
+    // genuine failure on this harness: exit_code inferred 0 (Control 4), stderr_sha '',
+    // stdout_sha real, AND command_sha present (always captured when a command is known).
+    const sameOutcomeWithCommandSha = {
+      exit_code: 0, stderr_sha: '',
+      stdout_sha: digestStdoutTail('TypeError: cannot read property "x" of undefined'),
+      command_sha: commandSha,
+    };
+
+    const a = await mod.recordAndCount(SESSION_ID + '-exempted', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcomeWithCommandSha });
+    const b = await mod.recordAndCount(SESSION_ID + '-exempted', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcomeWithCommandSha });
+    const c = await mod.recordAndCount(SESSION_ID + '-exempted', null, 'Bash', { command: cmd }, { rcaCheck: noopRca, lastOutcome: sameOutcomeWithCommandSha });
+    // The succeeding-poll exemption pre-empts counting entirely -- attempts never
+    // accumulates past 0, regardless of how many identical failures occur.
+    expect(a.attempts).toBe(0);
+    expect(b.attempts).toBe(0);
+    expect(c.attempts).toBe(0);
+  });
+});
+
+describe('digestStdoutTail (unit)', () => {
+  it('empty/non-string input returns an empty string', () => {
+    const { digestStdoutTail } = require(HOOK_PATH);
+    expect(digestStdoutTail('')).toBe('');
+    expect(digestStdoutTail(null)).toBe('');
+    expect(digestStdoutTail(undefined)).toBe('');
+  });
+
+  it('two distinct governance-trigger error strings produce different digests', () => {
+    const { digestStdoutTail } = require(HOOK_PATH);
+    const a = digestStdoutTail('SD_TYPE_CHANGE_EXPLANATION_REQUIRED: provide a reason');
+    const b = digestStdoutTail('SD_TYPE_CHANGE_TIMING_BLOCKED: cool-down window active');
+    expect(a).not.toBe(b);
+  });
+
+  it('a genuinely-identical recurrence with a different volatile timestamp still collides to the SAME digest (Control preserved)', () => {
+    const { digestStdoutTail } = require(HOOK_PATH);
+    const a = digestStdoutTail('FAIL: gate rejected\n at 2026-07-17T14:16:47.153Z');
+    const b = digestStdoutTail('FAIL: gate rejected\n at 2026-07-18T09:02:11.900Z');
+    expect(a).toBe(b);
+  });
+});

--- a/tests/unit/retry-state-manager-signature.test.js
+++ b/tests/unit/retry-state-manager-signature.test.js
@@ -53,4 +53,24 @@ describe('signatureFor content discrimination (SD-FDBK-ENH-PRE-TOOL-ENFORCE-001)
   it('Edit: missing file_path → null (unchanged guard)', () => {
     expect(signatureFor('Edit', {})).toBeNull();
   });
+
+  it('SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: Bash — stdout_sha alone (no exit_code/stderr_sha) still triggers outcome admixture', () => {
+    const baseline = signatureFor('Bash', { command: 'x' });
+    const withStdoutSha = signatureFor('Bash', { command: 'x' }, { stdout_sha: 'abc123' });
+    expect(withStdoutSha).not.toBe(baseline);
+    expect(withStdoutSha).toMatch(/^Bash:[0-9a-f]{16}:[0-9a-f]{8}$/);
+  });
+
+  it('SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: Bash — same exit_code+stderr_sha but different stdout_sha → distinct signatures', () => {
+    const a = signatureFor('Bash', { command: 'x' }, { exit_code: 0, stderr_sha: '', stdout_sha: 'aaa' });
+    const b = signatureFor('Bash', { command: 'x' }, { exit_code: 0, stderr_sha: '', stdout_sha: 'bbb' });
+    expect(a).not.toBe(b);
+  });
+
+  it('SD-LEO-INFRA-RCA-TIERED-SIGNATURE-FALSE-POSITIVE-001: Bash — identical {exit_code, stderr_sha, stdout_sha} → identical signature (stuck-loop detection preserved)', () => {
+    const outcome = { exit_code: 0, stderr_sha: '', stdout_sha: 'same' };
+    const a = signatureFor('Bash', { command: 'x' }, outcome);
+    const b = signatureFor('Bash', { command: 'x' }, outcome);
+    expect(a).toBe(b);
+  });
 });


### PR DESCRIPTION
## Summary
- Coordinator-confirmed RCA (session 89b12649, 169-session empirical proof, corroborated live by this SD's own investigation): Claude Code's Bash `tool_response` never populates real `stderr` content or a numeric `exit_code` — the entire error/crash text lands in `stdout`, with zero distinguishing field between a success and a genuine failure.
- `scripts/hooks/post-tool-rca-outcome.cjs`: new `digestStdoutTail()` (generalized from the existing `digestStderr`/`digestContent` bounded-window+normalization approach), captures `tool_response.stdout` unconditionally, writes a new `stdout_sha` field.
- `scripts/hooks/retry-state-manager.cjs`: `signatureFor()` mixes `stdout_sha` into the Bash outcome digest alongside the existing `exit_code`/`stderr_sha` fields. Additive-only — the Control 1+2 `noFailureSignal` exemption and the separate `progressStalled`/`auto-signal-threshold.cjs` mechanisms are untouched.
- `tests/unit/rca-tiered-signature-real-payload.test.js`: de-masking test using ONLY the empirically-real payload shape, proving 3 distinct failures produce 3 distinct signatures and a 4th correct attempt is not hard-blocked.

## Known limitation (intentionally not fixed here)
LEAD-TO-PLAN VALIDATION (adversarial review) found a deeper, separate defect: when a matching `command_sha` is carried on the prior outcome (the dominant real-world same-command-repeat shape), the pre-existing succeeding-poll exemption in `recordAndCount()` pre-empts this fix's signature differentiation entirely, since Control 4 infers `exit_code:0` from absence of a failure signal for genuine failures too. This is a materially larger, separately-shipped feature — filed as a first-class follow-up: **SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001** (priority=high). A `KNOWN LIMITATION` test (TS-10) documents this honestly as a regression canary rather than silently claiming completeness.

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/post-tool-rca-outcome.test.js scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js scripts/hooks/__tests__/retry-state-manager.test.js tests/unit/retry-state-manager-polling-exemption.test.js tests/unit/retry-state-manager-signature.test.js tests/unit/rca-tiered-signature-real-payload.test.js` — 82/82 pass
- [x] `npx eslint` on all changed/new files — clean
- [x] Independent Explore + VALIDATION + TESTING sub-agent review (LEAD-TO-PLAN, PLAN-TO-EXEC) — all PASS, additive-only confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)