### PR TITLE
fix(SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001): remove Control-4 exit_code:0 fabrication so 3-strikes guard fires on same-command blind retries

### DIFF
--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -63,8 +63,12 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     expect(written.stderr_sha).toBe(expectedSha);
   });
 
-  it('TS-5 (Control 4): a SUCCESS payload (no exit_code, no stderr) records exit_code 0', () => {
-    // Claude Code Bash tool_response carries NO exit_code; success was previously skipped.
+  it('TS-5 (SUCCEEDING-POLL-EXEMPTION-001, inverted contract): a SUCCESS payload (no exit_code, no stderr) writes NO file and never records exit_code 0', () => {
+    // Claude Code Bash tool_response carries NO exit_code and routes error text to stdout,
+    // so the OLD Control-4 inference fabricated exit_code:0 for success AND hard failure
+    // alike. That fabrication is removed: absence-of-failure stays null and hits the
+    // `exitCode===null && !stderrSha` skip, so no last-outcome file is written and the
+    // succeeding-poll exemption can never fire on a fabricated success.
     const payload = JSON.stringify({
       tool_name: 'Bash',
       tool_input: { command: 'node scripts/my-idempotent-tick.js' },
@@ -77,14 +81,10 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     });
     expect(result.status).toBe(0);
     const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
-    expect(fs.existsSync(outFile)).toBe(true);
-    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
-    expect(written.exit_code).toBe(0);              // success inferred from absence of failure
-    expect(written.stderr_sha).toBe('');
-    expect(written.command_sha).toMatch(/^[0-9a-f]{16}$/); // captured so the poll exemption can scope
+    expect(fs.existsSync(outFile)).toBe(false); // no fabricated success signal
   });
 
-  it('TS-5b (Control 4 — strict/teeth): an interrupted call is NOT recorded as success', () => {
+  it('TS-5b (strict/teeth): an interrupted call is NOT recorded as success', () => {
     const payload = JSON.stringify({
       tool_name: 'Bash',
       tool_input: { command: 'node scripts/hangs.js' },

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -154,26 +154,20 @@ async function run() {
           : '';
     const stderrSha = digestStderr(stderr);
 
-    // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 4 — exit-code capture).
-    // Claude Code's Bash tool_response carries NO numeric exit_code, so a SUCCESSFUL
-    // command previously hit the `exitCode===null && !stderrSha` skip below and wrote no
-    // last-outcome file → the next PreToolUse signature collapsed to command-only (zero
-    // entropy) → identical read-only/idempotent ticks accumulated to the 3-strikes
-    // hard-block (43 false 'stuck' signals in 26h). FIX: infer success from ABSENCE OF
-    // FAILURE and record exit_code 0 so the succeeding-poll exemption in recordAndCount
-    // can fire. STRICT (R2/R3): never infer success when a numeric non-zero code is
-    // present, when stderr/error is non-empty, or when the call was interrupted/flagged —
-    // those keep accumulating (teeth preserved). When numericExit is a number it is used
-    // verbatim (0 = success, non-zero = failure).
-    const failureFlag =
-      resp.is_error === true ||
-      resp.isError === true ||
-      resp.interrupted === true ||
-      (resp.error != null && resp.error !== '');
-    let exitCode = numericExit;
-    if (exitCode === null && !stderrSha && !failureFlag) {
-      exitCode = 0; // no failure signal of any kind → record success
-    }
+    // SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001 (removes SD-LEO-INFRA-RCA-AUTOSIGNAL-
+    // FALSE-POSITIVE-001 Control 4's absence-of-failure inference). exit_code is recorded
+    // ONLY from a GENUINE numeric exit code — never inferred from absence-of-failure.
+    // Claude Code's Bash tool_response carries NO numeric exit_code and routes error text
+    // to stdout (stderr empty), so the old `exitCode===null → 0` inference fabricated
+    // success for EVERY non-interrupted Bash call — success OR hard failure — which fed the
+    // succeeding-poll exemption in recordAndCount() a lie and silently nullified the
+    // 3-strikes guard on the dominant same-command blind-retry pattern (0,0,0 not 1,2,3).
+    // Genuine idempotent ticks are already covered without exit-code inference by the
+    // Control 1+2 read-only classifier (structural) and the EXEMPT_PATTERNS allowlist
+    // (explicit), so removing the fabrication does not regress the original 43-false-stuck
+    // read-only case. numericExit is still used verbatim (0 = success, non-zero = failure)
+    // for any future tool that reports a real code.
+    const exitCode = numericExit;
 
     // Skip only when there is STILL no usable signal (e.g. a bare failure flag with no
     // detail) — accumulation/teeth for genuine failures are preserved by NOT exempting.

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -523,10 +523,18 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
       return { attempts: 0, signature, rcaResetApplied: false, progressStalled: undefined };
     }
 
-    // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001 + Control 4: a blind retry is, by definition,
-    // re-running a FAILED command. If the immediately-prior invocation of THIS SAME command
-    // exited 0 (now RELIABLY captured by post-tool-rca-outcome.cjs Control 4), this is a
-    // succeeding poll (a recurring monitor/scheduled cron), not a retry — do not accumulate.
+    // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: a blind retry is, by definition, re-running a
+    // FAILED command. If the immediately-prior invocation of THIS SAME command exited 0,
+    // this is a succeeding poll (a recurring monitor/scheduled cron), not a retry — do not
+    // accumulate. PROVENANCE (SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001): exit_code:0 now
+    // comes SOLELY from a genuine numeric exit code — it is NEVER inferred from absence-of-
+    // failure. The old post-tool-rca-outcome.cjs Control 4 fabricated exit_code:0 for every
+    // non-interrupted Bash call (which Claude's Bash tool never numerically reports), feeding
+    // this branch a lie and nullifying the guard on same-command failures; that inference was
+    // removed. This branch is therefore inert for Claude Bash today (no exit_code:0 is ever
+    // recorded) yet remains correct for any future tool that reports a real numeric 0.
+    // Idempotent ticks are covered independently of exit-code inference by the Control 1+2
+    // read-only classifier and the EXEMPT_PATTERNS allowlist below.
     // COMMAND-SCOPED: lastOutcome.command_sha must match the current command's hash, so an
     // interleaved success of a DIFFERENT command can never exempt a genuine failure loop.
     // STRICT: only exit_code 0/'0' exempts; non-zero codes still accumulate.

--- a/tests/unit/retry-state-succeeding-poll-exemption-e2e.test.js
+++ b/tests/unit/retry-state-succeeding-poll-exemption-e2e.test.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-INFRA-SUCCEEDING-POLL-EXEMPTION-001 — end-to-end + anti-test-masking proof.
+ *
+ * The 3-strikes RCA guard was silently nullified for the dominant blind-retry pattern
+ * (a worker re-running the EXACT SAME failing Bash command) because Control 4 in
+ * post-tool-rca-outcome.cjs fabricated exit_code:0 from ABSENCE of a failure signal —
+ * and Claude Code's Bash tool_response never exposes a numeric exit_code and routes
+ * error text to STDOUT (stderr empty). So a genuine hard failure was recorded as
+ * exit_code:0, and the succeeding-poll exemption in recordAndCount() returned attempts:0
+ * for every same-command retry (0,0,0 instead of 1,2,3).
+ *
+ * The prior polling-exemption unit test was GREEN only because it injected a SYNTHETIC
+ * {exit_code:2} / {exit_code:0} lastOutcome that Claude Bash never actually produces —
+ * that test-masking is why the bug shipped. This suite drives the REAL production writer
+ * (post-tool-rca-outcome.cjs via spawnSync) with a Claude-SHAPED payload and threads its
+ * actual output (or absence) into recordAndCount(), proving enforcement at the counter
+ * through the true writer→reader seam rather than a hand-crafted object.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { recordAndCount, bashCmdHash } = require('../../scripts/hooks/retry-state-manager.cjs');
+const HOOK_PATH = path.resolve(__dirname, '../../scripts/hooks/post-tool-rca-outcome.cjs');
+
+const SESSION = 'sess-succeeding-poll-e2e';
+// Non-read-only, non-EXEMPT_PATTERNS command → falls through to the 3-strikes counter.
+const FAIL_CMD = 'node scripts/deploy-artifact.mjs --push';
+const noReset = async () => null;
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-poll-e2e-'));
+  process.env.LEO_RETRY_STATE_DIR = tmpDir;
+});
+
+afterEach(() => {
+  delete process.env.LEO_RETRY_STATE_DIR;
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+/**
+ * Drive the REAL post-tool-rca-outcome.cjs hook with a payload and return the
+ * last-outcome object it wrote (or undefined if it wrote no file). This is the true
+ * writer seam — NOT a hand-crafted lastOutcome.
+ */
+function driveHook(payloadObj, session = SESSION) {
+  const res = spawnSync('node', [HOOK_PATH], {
+    input: JSON.stringify(payloadObj),
+    env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: session, LEO_RETRY_STATE_DIR: tmpDir },
+    encoding: 'utf8',
+  });
+  expect(res.status).toBe(0); // hook is fail-open, always exits 0
+  const outFile = path.join(tmpDir, `last-outcome-${session}.json`);
+  return fs.existsSync(outFile) ? JSON.parse(fs.readFileSync(outFile, 'utf8')) : undefined;
+}
+
+// A genuine Claude Bash FAILURE: error text in stdout, empty stderr, NO exit_code,
+// no is_error/interrupted — exactly the shape the real tool emits (and the shape the
+// synthetic {exit_code:2} test never exercised).
+function claudeShapedFailurePayload() {
+  return {
+    tool_name: 'Bash',
+    tool_input: { command: FAIL_CMD },
+    tool_response: {
+      stdout: 'Error: deploy failed — connection refused\n  at deploy (scripts/deploy-artifact.mjs:42)',
+      stderr: '',
+    },
+  };
+}
+
+describe('SUCCEEDING-POLL-EXEMPTION-001 — real writer→reader seam', () => {
+  it('TS-1/AC-1: 3 identical GENUINE failures (Claude-shaped) accumulate 1,2,3 (pre-fix: 0,0,0)', async () => {
+    const attempts = [];
+    for (let i = 0; i < 3; i++) {
+      const lastOutcome = driveHook(claudeShapedFailurePayload());
+      // Post-fix: absence-of-failure is no longer fabricated into exit_code:0, so the hook
+      // writes NO last-outcome file for a Claude-shaped failure — the lie is gone at source.
+      expect(lastOutcome).toBeUndefined();
+      const r = await recordAndCount(SESSION, null, 'Bash', { command: FAIL_CMD }, {
+        rcaCheck: noReset, now: 1000 + i * 1000, lastOutcome,
+      });
+      attempts.push(r.attempts);
+    }
+    expect(attempts).toEqual([1, 2, 3]); // crosses the 3-strikes RCA-tiered threshold
+  });
+
+  it('TS-5/AC-5: a SUCCESS payload yields no exit_code:0, so the exemption cannot fire on a fabricated success', async () => {
+    const successPayload = {
+      tool_name: 'Bash',
+      tool_input: { command: FAIL_CMD },
+      tool_response: { stdout: 'ok', stderr: '' }, // Claude success shape: no exit_code
+    };
+    const lastOutcome = driveHook(successPayload);
+    expect(lastOutcome).toBeUndefined(); // no fabricated exit_code:0 reaches the reader
+
+    // Because no succeeding poll was recorded, a subsequent identical FAILURE is NOT
+    // exempted — it accumulates rather than being masked by an inferred success.
+    const r = await recordAndCount(SESSION, null, 'Bash', { command: FAIL_CMD }, {
+      rcaCheck: noReset, now: 1000, lastOutcome,
+    });
+    expect(r.attempts).toBe(1);
+  });
+
+  it('teeth intact: a GENUINE numeric exit_code:2 IS still written verbatim and does NOT exempt the retry', async () => {
+    const numericFailure = {
+      tool_name: 'Bash',
+      tool_input: { command: FAIL_CMD },
+      tool_response: { exit_code: 2, stderr: 'Error: boom' },
+    };
+    const lastOutcome = driveHook(numericFailure);
+    expect(lastOutcome).toBeDefined();
+    expect(lastOutcome.exit_code).toBe(2); // genuine numeric code recorded verbatim
+    expect(lastOutcome.command_sha).toBe(bashCmdHash(FAIL_CMD));
+
+    const r = await recordAndCount(SESSION, null, 'Bash', { command: FAIL_CMD }, {
+      rcaCheck: noReset, now: 1000, lastOutcome,
+    });
+    expect(r.attempts).toBe(1); // exit_code:2 is not success → accumulates (exemption only on 0)
+  });
+});


### PR DESCRIPTION
## Summary
PROVEN, VALIDATION-caught HIGH-severity harness defect. `scripts/hooks/post-tool-rca-outcome.cjs` Control 4 fabricated `exit_code:0` from *absence* of a failure signal — but Claude Code's Bash `tool_response` exposes no reliable success/failure boolean (stderr always empty, error text lands in stdout), so Control 4 recorded `exit_code:0` for essentially **every** non-interrupted Bash call, success OR failure. The succeeding-poll exemption in `retry-state-manager.cjs` then trusted that fabricated success and returned `attempts:0` unconditionally — silently nullifying the 3-strikes RCA-tiered enforcement guard for the *dominant* blind-retry pattern (a worker re-running the exact same failing command). Live-verified: 3 identical genuine failures → attempts `0,0,0` instead of `1,2,3`.

## Fix
Remove the fabrication at its source: `exitCode` is now recorded only from a genuine numeric exit code (which Claude Bash never emits), so a Claude-shaped failure writes **no** last-outcome and the exemption cannot fire on a lie. The guard now accumulates `[1,2,3]`. `retry-state-manager.cjs` is comment-only (the exemption logic is sound and left byte-unchanged — inert-but-correct for any future tool that reports real exit codes).

Two PLAN-phase sub-agents (discovery + RCA) **independently converged** on this approach.

## Anti-test-masking
The pre-existing test was green only because it injected a synthetic `exit_code:2` that Claude Bash never produces — exactly why the bug shipped. New e2e `tests/unit/retry-state-succeeding-poll-exemption-e2e.test.js` drives the **real writer→reader seam** with a Claude-shaped stdout-only failure.

## Preserved (must-not-regress)
- The 43-false-stuck-signal coverage → migrates to the already-shipped Control 1+2 read-only classifier + `EXEMPT_PATTERNS` allowlist (no exit-code dependency).
- `stdout_sha` / `signatureFor` differentiation intact.

## Evidence
- Unit: 88/88 green across affected suites; the `[1,2,3]` accumulation asserted at the counter via the writer→reader seam.
- TESTING PASS 95 · SECURITY PASS 95 (adversarially confirmed: control restored, no test-masking, no bypass, fail-toward-enforcement) · VALIDATION PASS 96 · REGRESSION PASS 94 (protected controls behavior-preserving) · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 96
- ~12 net production LOC, 2 hook files + tests. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)