### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D): MMS-Gantt delivery

### DIFF
--- a/.prd-payloads/PLAN-SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D.json
+++ b/.prd-payloads/PLAN-SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D.json
@@ -1,0 +1,149 @@
+{
+  "executive_summary": "Child D (last of 4) of the daily-review automation delivers the Gantt-chart IMAGE via MMS through the existing hardened owed-state SMS path. CORRECTION TO THE PARENT PRD (FR-3): the parent SD's own PRD names scripts/lib/visualization-provider.js as the Gantt-render reuse target and lib/eva/logo-image-generator.js / lib/eva/stage-handlers/s11.js as private-bucket+signed-URL precedent -- both are wrong. visualization-provider.js is a generative-AI (text-prompt) image tool with zero chart capability; the two 'precedent' files are actually PUBLIC-bucket examples (createBucket public:true + getPublicUrl), the opposite of this SD's hard, chairman-ratified confidentiality requirement. grep -rl createSignedUrl over lib/ and scripts/ returns zero real-implementation hits repo-wide -- there is no existing private+signed-URL precedent to reuse. This PRD therefore builds both pieces from first principles: a hand-rolled SVG Gantt generator rasterized via the already-installed `sharp` package (no new dependency), and a private-bucket+signed-URL upload helper. It also extends twilio-provider.js with an optional mediaUrl param and threads media_url through the STAGED sms_outbound_obligations schema, sms-bridge.js, and sms-outbound-worker.js. Both VALIDATION and Explore sub-agents independently spot-checked and confirmed all wrong-precedent claims before this PRD was written.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Gantt SVG + PNG renderer (built from scratch -- visualization-provider.js is not a valid reuse target)",
+      "description": "NEW lib/chairman/daily-review/gantt-renderer.js exporting: (a) buildGanttSvg(waves) -- a PURE function taking Child A's buildRoadmapStatusDoc() plan_of_record.waves shape ([{wave_id,title,status,progress_pct,calibrated_probability,item_counts}]) and returning a well-formed SVG string with one horizontal bar per wave (bar width proportional to progress_pct, plain text label = title, no external assets/fonts/network calls); (b) renderGanttPng(waves) -- calls buildGanttSvg then rasterizes via sharp(Buffer.from(svgString)).png().toBuffer(), returning a PNG Buffer. Uses the already-installed sharp@^0.35.3 -- no new dependency.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "buildGanttSvg(waves) returns a string containing each wave's title and starting with '<svg'",
+        "renderGanttPng(waves) returns a Buffer whose first 8 bytes match the PNG signature (0x89504E47...)",
+        "Both functions handle an empty waves array without throwing (render an empty/placeholder chart)"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Private-bucket + signed-URL upload helper (built from scratch -- the cited precedent files are public-bucket, not private)",
+      "description": "NEW lib/storage/private-signed-upload.js exporting uploadPrivateAndSign(supabase, {bucket, path, buffer, contentType, expiresInSeconds}) -> Promise<{path, signedUrl}>. Ensures the target bucket exists with public:false (create-or-use: attempt createBucket(bucket,{public:false}), tolerate an already-exists error), uploads via supabase.storage.from(bucket).upload(path, buffer, {contentType, upsert:true}), then returns supabase.storage.from(bucket).createSignedUrl(path, expiresInSeconds). MUST NEVER call getPublicUrl() or create a bucket with public:true anywhere in this file -- a CI-enforced grep assertion checks this (TR-2).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "uploadPrivateAndSign creates the bucket with public:false (or reuses an existing one) and never calls getPublicUrl",
+        "the returned signedUrl comes from createSignedUrl(path, expiresInSeconds), with expiresInSeconds honored (short TTL, minutes not hours)",
+        "a second call with the same bucket does not fail when the bucket already exists (create-or-use)"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "twilio-provider.js MMS (mediaUrl) support",
+      "description": "EDIT lib/messaging/providers/twilio-provider.js's send({to, body}) (lines ~31-60) to send({to, body, mediaUrl}). When mediaUrl is present, set the Twilio MediaUrl form param before the POST -- mirrors the existing optional StatusCallback pattern in the same function. When mediaUrl is absent (all existing call sites), behavior is byte-identical to today.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "send({to,body,mediaUrl}) sets Twilio's MediaUrl form param when mediaUrl is provided",
+        "send({to,body}) (mediaUrl omitted) produces the exact same form body as before this change",
+        "all pre-existing twilio-provider.js/sms-outbound-reconcile test assertions still pass unmodified"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "STAGED migration media_url column + sms-bridge.js/sms-outbound-worker.js threading",
+      "description": "EDIT database/migrations/20260718_sms_outbound_obligations_STAGED.sql (NOT YET APPLIED): add a nullable media_url TEXT column immediately before the closing paren of the CREATE TABLE (after the existing last_error TEXT NULL column), plus a matching COMMENT ON COLUMN entry following the existing 4-comment pattern (lines ~74-81) -- inserted before the RLS block (lines ~83-93). Preserve the STAGED/chairman-apply-ceremony header (lines 1-37) verbatim; do NOT create a second migration file. EDIT lib/chairman/sms-bridge.js's enqueueChairmanSms(supabase, {recipientPhone, kind, body, decisionId=null, dedupeKey=null, notBefore=null, mediaUrl=null}) -- add the mediaUrl param and include media_url in the inserted row. EDIT lib/chairman/sms-outbound-worker.js's reconcileOutboundSms(): add media_url to BOTH the owed-rows select (~line 219) AND the claim-update-returning select (~line 238) -- the variable `c` used at the provider.send() call site (~line 250) is destructured from the line-238 claim-update result, not the line-219 owed-query result, so media_url must be present in both selects for c.media_url to actually reach the send call. Pass mediaUrl: c.media_url into the provider.send() call.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "The STAGED migration file gains exactly one nullable media_url TEXT column (verified: no new table, exactly one migration file touched)",
+        "enqueueChairmanSms accepts an optional mediaUrl param and includes it in the inserted obligations row",
+        "reconcileOutboundSms's provider.send() call includes a populated mediaUrl when the claimed row has a non-null media_url -- verified against BOTH select() column lists containing media_url, not just one",
+        "all existing sms-bridge.js/sms-outbound-worker.js tests pass unmodified when mediaUrl/media_url is absent (backward compatible)"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "No new dependencies", "description": "sharp@^0.35.3 is already installed and sufficient for SVG-to-PNG rasterization; no canvas/chart/d3/puppeteer dependency is added." },
+    { "id": "TR-2", "title": "Confidentiality CI gate", "description": "A static test (grep-based or string-search-based) asserts zero occurrences of getPublicUrl or public:true anywhere in lib/chairman/daily-review/gantt-renderer.js and lib/storage/private-signed-upload.js -- guards against an accidental copy-paste from the parent PRD's incorrectly-cited public-bucket precedent files." },
+    { "id": "TR-3", "title": "Single migration file, additive-only", "description": "Exactly one migration file is touched (the existing STAGED file); no second migration is created. All edits to twilio-provider.js/sms-bridge.js/sms-outbound-worker.js are additive/backward-compatible -- every call site omitting mediaUrl behaves identically to pre-change behavior." },
+    { "id": "TR-4", "title": "No live sends/applies in this SD", "description": "This SD does not apply the STAGED migration (chairman-gated ceremony) and does not perform a real Twilio send (requires live credentials) -- all tests use mocked Supabase Storage / Twilio clients." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "buildGanttSvg/renderGanttPng against seeded waves data", "type": "unit", "expected": "SVG string contains each wave's title; PNG Buffer starts with the PNG magic bytes; empty-array input does not throw" },
+    { "id": "TS-2", "scenario": "uploadPrivateAndSign against a mocked Supabase Storage client", "type": "unit", "expected": "createBucket called with public:false (or bucket-exists tolerated); createSignedUrl (not getPublicUrl) is the source of the returned URL" },
+    { "id": "TS-3", "scenario": "twilio-provider.js send() with and without mediaUrl", "type": "unit", "expected": "MediaUrl form param present only when mediaUrl is passed; existing To/Body/MessagingServiceSid/StatusCallback assertions unaffected" },
+    { "id": "TS-4", "scenario": "STAGED migration file diff", "type": "static", "expected": "Exactly one new nullable media_url TEXT column added; header/RLS/existing columns unchanged; only one migration file in the diff" },
+    { "id": "TS-5", "scenario": "enqueueChairmanSms with mediaUrl", "type": "unit", "expected": "inserted row includes media_url; omitting mediaUrl produces the same row shape as before this change" },
+    { "id": "TS-6", "scenario": "reconcileOutboundSms end-to-end with a claimed row carrying media_url", "type": "unit", "expected": "provider.send() is called with mediaUrl equal to the claimed row's media_url -- verifies BOTH select() column lists (owed-query and claim-update-returning) include media_url" },
+    { "id": "TS-7", "scenario": "confidentiality static gate", "type": "static", "expected": "Zero getPublicUrl/public:true occurrences in gantt-renderer.js and private-signed-upload.js" },
+    { "id": "TS-8", "scenario": "full-repo regression", "type": "integration", "expected": "Zero new failures attributable to touched modules (twilio-provider.js, sms-bridge.js, sms-outbound-worker.js, new gantt-renderer.js/private-signed-upload.js files)" }
+  ],
+  "acceptance_criteria": [
+    "renderGanttPng() produces a valid PNG from Child A's plan_of_record.waves data with no generative-AI/network call",
+    "uploadPrivateAndSign() never creates a public bucket and never returns a getPublicUrl-sourced URL -- signed URL only, short TTL",
+    "twilio-provider.js send() supports an optional mediaUrl param, fully backward-compatible when omitted",
+    "media_url flows end-to-end: STAGED migration column -> enqueueChairmanSms() -> sms_outbound_obligations row -> reconcileOutboundSms() (both select() calls) -> provider.send()",
+    "Zero new regressions attributable to touched modules",
+    "The parent PRD's FR-3 wrong-precedent claims (visualization-provider.js, logo-image-generator.js/s11.js) are not mirrored anywhere in this SD's code"
+  ],
+  "risks": [
+    {
+      "risk": "A hand-rolled SVG Gantt chart could be visually broken or hard to read since no charting library or design precedent exists in the repo",
+      "mitigation": "Keep the SVG generation simple and deterministic (fixed-width bars scaled by progress_pct, one row per wave, plain text labels); verify visually via the smoke_test_steps PNG-file-write step",
+      "severity": "medium"
+    },
+    {
+      "risk": "A future reader trusting the parent SD's PRD prose (which cites now-known-wrong precedent files) could accidentally copy the public-bucket pattern into new code",
+      "mitigation": "TR-2's CI-enforced grep assertion (zero getPublicUrl/public:true in the new files) turns an accidental copy-paste into a hard CI failure, not just a review miss",
+      "severity": "high"
+    },
+    {
+      "risk": "media_url added to only one of reconcileOutboundSms's two select() calls would silently leave c.media_url undefined at the send call, shipping code that appears correct but never actually sends the image",
+      "mitigation": "FR-4/TS-6 explicitly require verifying BOTH select() column lists and asserting the send() call receives a populated mediaUrl end-to-end, not just checking the column exists somewhere",
+      "severity": "medium"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "The 5:45 AM daily-review cron (sibling B's scope, SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B) will eventually call renderGanttPng() on Child A's buildRoadmapStatusDoc() output, upload via uploadPrivateAndSign(), and enqueue an MMS obligation -- not built by this SD, which ships the individual pieces only",
+      "reconcileOutboundSms (existing owed-state worker) sends the enqueued MMS via the now-media-aware twilio-provider.js"
+    ],
+    "dependencies": [
+      "Child A's buildRoadmapStatusDoc() plan_of_record.waves shape (render input)",
+      "sharp@^0.35.3 (already installed)",
+      "The STAGED sms_outbound_obligations table being chairman-applied (external, not performed by this SD) before any real MMS can send",
+      "Supabase Storage (bucket create/upload/signed-URL) and Twilio credentials (external, not exercised live by this SD's tests)"
+    ],
+    "data_contracts": [
+      "renderGanttPng(waves) -> Promise<Buffer> (PNG bytes)",
+      "uploadPrivateAndSign(supabase, {bucket, path, buffer, contentType, expiresInSeconds}) -> Promise<{path, signedUrl}>",
+      "twilio-provider.js send({to, body, mediaUrl?}) -- mediaUrl optional, additive",
+      "sms_outbound_obligations gains one nullable media_url TEXT column; enqueueChairmanSms/reconcileOutboundSms thread it end-to-end"
+    ],
+    "runtime_config": [
+      "No new environment variables -- reuses existing SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY and Twilio credentials the caller already provides",
+      "New private bucket name (e.g. daily-review-gantt) is a code constant, not env-configurable in this SD's scope"
+    ],
+    "observability_rollout": [
+      "This SD ships all 4 pieces individually tested but NOT wired into a live cron -- the daily-review sweep (sibling B) is the actual runtime consumer and is out of this SD's scope",
+      "Real end-to-end MMS sends remain blocked until the chairman applies the STAGED sms_outbound_obligations migration -- a deliberate, already-documented dependency, not a gap in this SD",
+      "Unit tests (mocked Storage/Twilio clients) + the static confidentiality grep gate are the verification surface for this SD"
+    ]
+  },
+  "system_architecture": {
+    "summary": "Two new from-scratch modules (Gantt renderer, private-signed-upload helper) plus three additive edits (twilio-provider.js, STAGED migration, sms-bridge.js/sms-outbound-worker.js threading) that together give the owed-state SMS path MMS capability without touching its send/reconcile control flow.",
+    "components": [
+      { "name": "lib/chairman/daily-review/gantt-renderer.js", "change": "NEW -- buildGanttSvg(waves) + renderGanttPng(waves) via sharp" },
+      { "name": "lib/storage/private-signed-upload.js", "change": "NEW -- uploadPrivateAndSign(supabase, opts) -> {path, signedUrl}, public:false + createSignedUrl only" },
+      { "name": "lib/messaging/providers/twilio-provider.js", "change": "EDIT -- send() gains optional mediaUrl -> Twilio MediaUrl form param" },
+      { "name": "database/migrations/20260718_sms_outbound_obligations_STAGED.sql", "change": "EDIT -- add nullable media_url TEXT column + comment (STAGED, not applied)" },
+      { "name": "lib/chairman/sms-bridge.js", "change": "EDIT -- enqueueChairmanSms threads mediaUrl into the inserted row" },
+      { "name": "lib/chairman/sms-outbound-worker.js", "change": "EDIT -- reconcileOutboundSms selects media_url in both queries and passes it to provider.send()" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the two missing pieces (renderer, private-upload helper) from scratch since the parent PRD's cited reuse targets are wrong; thread mediaUrl additively through the existing owed-state pipeline.",
+    "steps": [
+      "Write buildGanttSvg(waves) as a pure function; verify output against seeded wave fixtures",
+      "Write renderGanttPng(waves) using sharp to rasterize the SVG string; verify PNG magic bytes",
+      "Write uploadPrivateAndSign() against a mocked Supabase Storage client; add the TR-2 confidentiality grep test",
+      "Extend twilio-provider.js send() with optional mediaUrl (mirrors StatusCallback pattern); verify existing tests unaffected",
+      "Amend the STAGED migration file (media_url column + comment) preserving its header verbatim",
+      "Thread mediaUrl through enqueueChairmanSms and BOTH of reconcileOutboundSms's select() calls; write an end-to-end unit test asserting provider.send() receives the populated mediaUrl",
+      "Run the full-repo regression scan and confirm zero new failures attributable to touched modules"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Call renderGanttPng(waves) against a seeded/live waves array and write the resulting Buffer to a local PNG file.", "expected_outcome": "A valid, viewable PNG image showing per-wave bars/labels is produced -- no thrown error, no external network call." },
+    { "step_number": 2, "instruction": "Call uploadPrivateAndSign() against a test Supabase project/bucket with a small PNG buffer, then attempt to fetch the object directly (no signed token) and separately fetch the returned signedUrl.", "expected_outcome": "The direct/unsigned fetch is denied; the signedUrl fetch succeeds and returns the PNG bytes." },
+    { "step_number": 3, "instruction": "npx vitest run tests/unit/chairman/daily-review-gantt-renderer.test.js tests/unit/storage/private-signed-upload.test.js tests/unit/chairman/sms-bridge.test.js tests/unit/chairman/sms-outbound-reconcile.test.js", "expected_outcome": "All tests pass, including the new mediaUrl/media_url cases, with no regressions in pre-existing text-only-SMS test cases." }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D"
+  }
+}

--- a/database/migrations/20260718_sms_outbound_obligations_STAGED.sql
+++ b/database/migrations/20260718_sms_outbound_obligations_STAGED.sql
@@ -56,7 +56,8 @@ CREATE TABLE IF NOT EXISTS sms_outbound_obligations (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   sent_at TIMESTAMPTZ NULL,           -- set when the provider ACCEPTS (201) — NOT delivery
   delivered_at TIMESTAMPTZ NULL,      -- set ONLY on a signature-valid MessageStatus=delivered
-  last_error TEXT NULL
+  last_error TEXT NULL,
+  media_url TEXT NULL                 -- SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D: signed URL for an MMS attachment (e.g. the Gantt PNG); NULL for text-only sends
 );
 
 -- Claimable-work index: the worker scans owed rows whose not_before has elapsed, oldest first.
@@ -79,6 +80,8 @@ COMMENT ON COLUMN sms_outbound_obligations.delivered_at IS
   'Stamped ONLY by a signature-valid MessageStatus=delivered status callback (FR-2). A 201-accept alone never sets this — the F1 fix.';
 COMMENT ON COLUMN sms_outbound_obligations.not_before IS
   'Sleep-window gate: a row enqueued inside 10PM-6AM ET carries not_before=next-6AM so the worker does not claim it until the morning batch.';
+COMMENT ON COLUMN sms_outbound_obligations.media_url IS
+  'Short-TTL signed URL (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D) for an MMS attachment (e.g. the daily-review Gantt PNG), sourced from a PRIVATE (public:false) Supabase Storage bucket — never a public URL. NULL for text-only sends. Passed to the Twilio provider as the MediaUrl form param.';
 
 -- RLS + policy in the SAME migration (RLS-at-create; SPINE-001-B recurrence guard),
 -- mirroring sms_inbound_suspensions_service_all in 20260717_sms_relay_staging.sql. Only the

--- a/lib/chairman/daily-review/gantt-renderer.js
+++ b/lib/chairman/daily-review/gantt-renderer.js
@@ -1,0 +1,66 @@
+/**
+ * gantt-renderer — SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D.
+ *
+ * Hand-rolled SVG Gantt-bar chart + sharp rasterization for the daily-review MMS. NOT built
+ * on scripts/lib/visualization-provider.js (that module is a generative-AI text-prompt image
+ * tool with zero chart capability, and the repo has no deterministic charting library) — this
+ * is a from-scratch, deterministic renderer taking Child A's buildRoadmapStatusDoc()
+ * plan_of_record.waves shape directly, with no external network/AI-generation call.
+ */
+import sharp from 'sharp';
+
+const CHART_WIDTH = 640;
+const ROW_HEIGHT = 40;
+const BAR_X = 220;
+const BAR_MAX_WIDTH = 380;
+const TOP_MARGIN = 30;
+const BOTTOM_MARGIN = 20;
+
+function escapeXml(text) {
+  return String(text ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[c]));
+}
+
+/**
+ * Pure function: builds a well-formed SVG string for a Gantt-style bar chart, one row per
+ * wave, bar width scaled by progress_pct. No I/O, no external assets/fonts, no network call.
+ * @param {Array<{wave_id?:string, title:string, status?:string, progress_pct?:number|null}>} waves
+ * @returns {string} SVG markup
+ */
+export function buildGanttSvg(waves) {
+  const rows = Array.isArray(waves) ? waves : [];
+  const height = TOP_MARGIN + BOTTOM_MARGIN + Math.max(rows.length, 1) * ROW_HEIGHT;
+
+  const bars = rows.map((wave, i) => {
+    const y = TOP_MARGIN + i * ROW_HEIGHT;
+    const pct = Math.max(0, Math.min(100, Number(wave.progress_pct) || 0));
+    const barWidth = (pct / 100) * BAR_MAX_WIDTH;
+    const label = escapeXml(wave.title || `Wave ${i + 1}`);
+    return [
+      `<text x="10" y="${y + 20}" font-family="sans-serif" font-size="14" fill="#222">${label}</text>`,
+      `<rect x="${BAR_X}" y="${y + 8}" width="${BAR_MAX_WIDTH}" height="18" fill="#e0e0e0" />`,
+      `<rect x="${BAR_X}" y="${y + 8}" width="${barWidth}" height="18" fill="#3b82f6" />`,
+      `<text x="${BAR_X + BAR_MAX_WIDTH + 8}" y="${y + 20}" font-family="sans-serif" font-size="12" fill="#555">${pct}%</text>`,
+    ].join('');
+  }).join('');
+
+  const placeholder = rows.length === 0
+    ? `<text x="10" y="${TOP_MARGIN + 20}" font-family="sans-serif" font-size="14" fill="#888">No roadmap waves available</text>`
+    : '';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${CHART_WIDTH}" height="${height}" viewBox="0 0 ${CHART_WIDTH} ${height}">` +
+    `<rect x="0" y="0" width="${CHART_WIDTH}" height="${height}" fill="#ffffff" />` +
+    bars + placeholder +
+    '</svg>';
+}
+
+/**
+ * Rasterizes buildGanttSvg(waves) into a PNG Buffer via sharp — no network/AI-generation call.
+ * @param {Array<object>} waves
+ * @returns {Promise<Buffer>}
+ */
+export async function renderGanttPng(waves) {
+  const svg = buildGanttSvg(waves);
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+export default { buildGanttSvg, renderGanttPng };

--- a/lib/chairman/sms-bridge.js
+++ b/lib/chairman/sms-bridge.js
@@ -110,10 +110,10 @@ export async function smsOutboundObligationsLive(supabase) {
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {{recipientPhone: string, kind: string, body: string, decisionId?: string|null,
- *   dedupeKey?: string|null, notBefore?: string|null}} args
+ *   dedupeKey?: string|null, notBefore?: string|null, mediaUrl?: string|null}} args
  * @returns {Promise<{enqueued: boolean, obligationId?: string, deduped?: boolean, reason?: string}>}
  */
-export async function enqueueChairmanSms(supabase, { recipientPhone, kind, body, decisionId = null, dedupeKey = null, notBefore = null } = {}) {
+export async function enqueueChairmanSms(supabase, { recipientPhone, kind, body, decisionId = null, dedupeKey = null, notBefore = null, mediaUrl = null } = {}) {
   if (!recipientPhone || !kind || !body) return { enqueued: false, reason: 'missing_fields' };
   const row = {
     recipient_phone: recipientPhone,
@@ -122,6 +122,7 @@ export async function enqueueChairmanSms(supabase, { recipientPhone, kind, body,
     decision_id: decisionId,
     dedupe_key: dedupeKey,
     not_before: notBefore,
+    media_url: mediaUrl,
     status: 'owed',
   };
   try {

--- a/lib/chairman/sms-outbound-worker.js
+++ b/lib/chairman/sms-outbound-worker.js
@@ -216,7 +216,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
   // ---- Pass 2: claim + send owed rows (serialized, exactly once) ----
   const { data: owed } = await supabase
     .from('sms_outbound_obligations')
-    .select('id, recipient_phone, body, attempts, decision_id, not_before')
+    .select('id, recipient_phone, body, attempts, decision_id, not_before, media_url')
     .eq('status', 'owed')
     .order('created_at', { ascending: true })
     .limit(batchLimit);
@@ -235,7 +235,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
       .eq('id', row.id)
       .eq('status', 'owed')
       .is('claimed_at', null)
-      .select('id, recipient_phone, body, attempts');
+      .select('id, recipient_phone, body, attempts, media_url');
 
     if (!claimed || claimed.length === 0) {
       summary.skipped++;
@@ -247,7 +247,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
     const attempts = (c.attempts || 0) + 1;
     let result;
     try {
-      result = await provider.send({ to: c.recipient_phone, body: c.body });
+      result = await provider.send({ to: c.recipient_phone, body: c.body, mediaUrl: c.media_url });
     } catch (err) {
       result = { status: 'failed', reason: err?.message || 'provider_threw' };
     }

--- a/lib/messaging/providers/twilio-provider.js
+++ b/lib/messaging/providers/twilio-provider.js
@@ -25,10 +25,10 @@ function messagingService() { return process.env.TWILIO_MESSAGING_SERVICE || '';
 function statusCallbackUrl() { return process.env.TWILIO_STATUS_CALLBACK_URL || ''; }
 
 /**
- * @param {{to: string, body: string}} args
+ * @param {{to: string, body: string, mediaUrl?: string}} args
  * @returns {Promise<{provider_message_id: string, status: 'queued'|'sent'|'failed'}>}
  */
-export async function send({ to, body }) {
+export async function send({ to, body, mediaUrl }) {
   const sid = accountSid();
   const token = authToken();
   if (!sid || !token) {
@@ -43,6 +43,9 @@ export async function send({ to, body }) {
   // statusCallbackUrl above). Fail-soft when unset — no callback requested.
   const callbackUrl = statusCallbackUrl();
   if (callbackUrl) form.set('StatusCallback', callbackUrl);
+  // SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D: MMS support. Optional, backward-compatible —
+  // omitted mediaUrl produces the exact same form body as before this change.
+  if (mediaUrl) form.set('MediaUrl', mediaUrl);
 
   const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`, {
     method: 'POST',

--- a/lib/storage/private-signed-upload.js
+++ b/lib/storage/private-signed-upload.js
@@ -1,0 +1,39 @@
+/**
+ * private-signed-upload — SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D.
+ *
+ * Built from first principles: the parent SD's PRD cited lib/eva/logo-image-generator.js and
+ * lib/eva/stage-handlers/s11.js as "private-bucket + signed-URL precedent" -- both are actually
+ * PUBLIC-bucket examples (createBucket public:true + getPublicUrl). grep -rl createSignedUrl
+ * over lib/ and scripts/ returns zero real-implementation hits repo-wide. This module NEVER
+ * calls getPublicUrl and NEVER creates a bucket with public:true -- confidentiality-critical for
+ * the chairman's roadmap image (a public-URL attempt was already correctly blocked, 2026-07-18).
+ */
+
+/**
+ * Ensures `bucket` exists as a PRIVATE (public:false) Supabase Storage bucket, uploads `buffer`
+ * to `path`, and returns a short-TTL signed URL. Never calls getPublicUrl.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{bucket: string, path: string, buffer: Buffer, contentType: string, expiresInSeconds: number}} args
+ * @returns {Promise<{path: string, signedUrl: string}>}
+ */
+export async function uploadPrivateAndSign(supabase, { bucket, path, buffer, contentType, expiresInSeconds }) {
+  // Create-or-use: tolerate an already-exists error rather than failing the whole upload.
+  const { error: createErr } = await supabase.storage.createBucket(bucket, { public: false });
+  if (createErr && !/already exists/i.test(createErr.message || '')) {
+    throw new Error(`private-signed-upload: createBucket failed: ${createErr.message}`);
+  }
+
+  const { error: uploadErr } = await supabase.storage
+    .from(bucket)
+    .upload(path, buffer, { contentType, upsert: true });
+  if (uploadErr) throw new Error(`private-signed-upload: upload failed: ${uploadErr.message}`);
+
+  const { data, error: signErr } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(path, expiresInSeconds);
+  if (signErr) throw new Error(`private-signed-upload: createSignedUrl failed: ${signErr.message}`);
+
+  return { path, signedUrl: data.signedUrl };
+}
+
+export default { uploadPrivateAndSign };

--- a/scripts/one-off/deboilerplate-daily-review-child-d.mjs
+++ b/scripts/one-off/deboilerplate-daily-review-child-d.mjs
@@ -1,0 +1,115 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SD_KEY = 'SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D';
+
+const key_changes = [
+  {
+    change: 'Add lib/chairman/daily-review/gantt-renderer.js exporting renderGanttPng(waves) -> Buffer, composed of buildGanttSvg(waves) (pure, hand-rolled SVG string generation from Child A\'s plan_of_record.waves shape: {title, status, progress_pct, item_counts}) + rasterizeSvgToPng(svgString) using the already-installed `sharp` package (sharp(Buffer.from(svg)).png().toBuffer()) -- no new dependency needed. CORRECTION to the parent SD\'s PRD FR-3 prose: scripts/lib/visualization-provider.js (cited there as a reuse target) is a generative-AI image tool (Gemini/DALL-E from a text prompt), not a chart renderer, and the repo has zero deterministic charting libraries -- a real Gantt renderer must be hand-built, which this SD does.',
+    impact: 'Produces the actual Gantt PNG bytes to upload/MMS -- the one missing piece the parent PRD assumed already existed via visualization-provider.js.',
+  },
+  {
+    change: 'Add lib/storage/private-signed-upload.js exporting uploadPrivateAndSign(supabase, {bucket, path, buffer, contentType, expiresInSeconds}) -> {path, signedUrl} -- creates/uses a bucket with public:false, uploads via .storage.from(bucket).upload(path, buffer, {contentType, upsert:true}), then .storage.from(bucket).createSignedUrl(path, expiresInSeconds). CORRECTION to the parent SD\'s PRD FR-3 prose: the cited precedent files (lib/eva/logo-image-generator.js, lib/eva/stage-handlers/s11.js) are actually PUBLIC-bucket examples (createBucket public:true + getPublicUrl) -- the opposite of this SD\'s hard, chairman-ratified requirement (\"NEVER a public URL\"). grep -rl createSignedUrl over lib/ and scripts/ returns zero hits repo-wide -- there was no existing private+signed precedent to reuse, so this SD builds the pattern from first principles.',
+    impact: 'Closes the confidentiality-critical gap: without this, the only existing bucket-upload precedent in the repo is public, which would leak the chairman\'s roadmap data if copied naively.',
+  },
+  {
+    change: 'Extend lib/messaging/providers/twilio-provider.js send({to, body}) to send({to, body, mediaUrl}) -- when mediaUrl is present, set the Twilio MediaUrl form param before the POST, mirroring the existing optional StatusCallback pattern in the same function (line ~31-60).',
+    impact: 'Gives the Twilio send path MMS capability; a null/absent mediaUrl is fully backward-compatible with today\'s text-only sends.',
+  },
+  {
+    change: 'Add a nullable media_url TEXT column (+ matching COMMENT ON COLUMN) to the NOT-YET-APPLIED database/migrations/20260718_sms_outbound_obligations_STAGED.sql file, immediately before the closing CREATE TABLE paren, preserving the file\'s existing STAGED/chairman-apply-ceremony header verbatim. Thread mediaUrl through lib/chairman/sms-bridge.js enqueueChairmanSms() (new optional param, added to the inserted row) and lib/chairman/sms-outbound-worker.js reconcileOutboundSms() (select the column, pass row.media_url to provider.send()).',
+    impact: 'Completes the owed-state plumbing so an MMS obligation carries its image URL end-to-end from enqueue through the reconcile-and-send worker, without a second migration file or a parallel delivery path.',
+  },
+];
+
+const strategic_objectives = [
+  'Deliver the Gantt-chart IMAGE leg of the daily-review automation via the existing hardened owed-state SMS/MMS path (enqueueChairmanSms -> sms_outbound_obligations -> reconcileOutboundSms), never a fresh fire-and-forget send.',
+  'Guarantee the roadmap image is never publicly reachable -- private bucket + short-TTL signed URL only, matching the chairman-ratified confidentiality requirement (a public-URL attempt was already correctly blocked once, 2026-07-18).',
+];
+
+const success_criteria = [
+  {
+    criterion: 'renderGanttPng(waves) returns a valid PNG Buffer built from Child A\'s plan_of_record.waves data (per-wave title, status, progress_pct rendered as bars), with no external network/AI-generation call.',
+    measure: 'Unit test asserts the returned Buffer starts with the PNG magic bytes (0x89504E47) and that buildGanttSvg(waves) output is well-formed SVG containing each wave\'s title text.',
+  },
+  {
+    criterion: 'uploadPrivateAndSign() creates/uses a bucket with public:false and returns a signedUrl from createSignedUrl(), never calling getPublicUrl() or creating a public:true bucket anywhere in this SD\'s code.',
+    measure: 'Unit test (mocked Supabase Storage client) asserts createBucket is called with public:false and that createSignedUrl (not getPublicUrl) is the source of the returned URL; a grep-based static assertion confirms zero getPublicUrl/public:true occurrences in the new files.',
+  },
+  {
+    criterion: 'twilio-provider.js send() sets the Twilio MediaUrl form param only when mediaUrl is provided, and omits it (unchanged from today\'s behavior) when mediaUrl is absent.',
+    measure: 'Unit test asserts the constructed form body contains MediaUrl when passed and does not when omitted, without altering any existing To/Body/MessagingServiceSid/StatusCallback assertions in the current test suite.',
+  },
+  {
+    criterion: 'The STAGED migration file gains exactly one nullable media_url TEXT column (no new table, no second migration file) and mediaUrl flows enqueueChairmanSms() -> the inserted obligations row -> reconcileOutboundSms() -> provider.send({mediaUrl}).',
+    measure: 'Unit tests on sms-bridge.js and sms-outbound-worker.js (extending their existing test files) assert media_url is threaded through both functions; a diff-based check confirms only one migration file changed.',
+  },
+];
+
+const implementation_guidelines = [
+  'Use the already-installed `sharp` package for SVG-to-PNG rasterization -- do not add a new charting/canvas dependency; hand-roll the SVG string generation as a pure function (buildGanttSvg) so it is unit-testable without any image library.',
+  'Build the private-bucket + signed-URL helper from first principles per the PRD\'s corrected FR (the two files the parent PRD cited as precedent are public-bucket examples and must NOT be mirrored) -- public:false at bucket creation, createSignedUrl with a short TTL (minutes, not hours) for the returned URL.',
+  'Amend the existing STAGED migration file in place -- do not create a second migration -- and preserve its chairman-apply-ceremony header exactly so the apply runbook stays valid when the chairman eventually applies it.',
+  'twilio-provider.js, sms-bridge.js, and sms-outbound-worker.js changes must be strictly additive/backward-compatible: every existing call site that omits mediaUrl must behave identically to today.',
+  'This SD does not attempt to apply the STAGED migration or perform a real Twilio send -- both are gated on the chairman-apply ceremony and real credentials respectively; unit tests use mocked Supabase Storage/Twilio clients throughout.',
+];
+
+const success_metrics = [
+  { metric: 'Test coverage', target: '>=80% coverage across lib/chairman/daily-review/gantt-renderer.js, lib/storage/private-signed-upload.js, and the twilio-provider.js/sms-bridge.js/sms-outbound-worker.js diffs' },
+  { metric: 'Zero regressions', target: '0 existing tests broken (full-repo regression pass), especially the existing twilio/sms-bridge/sms-outbound-reconcile test suites' },
+  { metric: 'Confidentiality invariant', target: 'Zero getPublicUrl/public:true occurrences anywhere in the new gantt-renderer.js/private-signed-upload.js files (grep-verified)' },
+];
+
+const smoke_test_steps = [
+  {
+    instruction: 'Run renderGanttPng(waves) against a seeded waves array (from a live Child A buildRoadmapStatusDoc() call) and write the resulting Buffer to a local PNG file.',
+    expected_outcome: 'A valid, viewable PNG image showing per-wave bars/labels is produced -- no thrown error, no external network call made.',
+  },
+  {
+    instruction: 'Call uploadPrivateAndSign() against a test Supabase project/bucket with a small PNG buffer, then attempt to fetch the bucket object directly (no signed token) and separately fetch the returned signedUrl.',
+    expected_outcome: 'The direct/unsigned fetch is denied (403/404); the signedUrl fetch succeeds and returns the PNG bytes.',
+  },
+  {
+    instruction: 'Run the extended unit test suites: `npx vitest run tests/unit/chairman/daily-review-gantt-renderer.test.js tests/unit/storage/private-signed-upload.test.js` plus the existing `tests/unit/chairman/sms-bridge.test.js tests/unit/chairman/sms-outbound-reconcile.test.js` (now extended with mediaUrl cases) and any twilio-provider.js test coverage.',
+    expected_outcome: 'All tests pass, with no regressions in the pre-existing text-only-SMS test cases.',
+  },
+];
+
+const risks = [
+  {
+    risk: 'A hand-rolled SVG Gantt renderer could produce a visually broken or unreadable chart (wrong proportions, overlapping labels) since there is no existing charting library or design precedent in the repo to build against.',
+    impact: 'medium',
+    likelihood: 'medium',
+    mitigation: 'Keep the SVG generation simple and deterministic (fixed-width bars scaled by progress_pct, one row per wave, plain text labels) and verify visually via the smoke_test_steps PNG-file-write step before considering this SD chairman-review-ready.',
+  },
+  {
+    risk: 'The corrected reuse plan (building the private-bucket+signed-URL pattern from scratch, since no repo precedent exists) could be missed by a reviewer who only reads the parent SD\'s PRD prose (which cites now-known-wrong precedent files) and assumes those files were correctly mirrored.',
+    impact: 'high',
+    likelihood: 'low',
+    mitigation: 'This SD\'s own key_changes/success_criteria explicitly document the correction and add a grep-based static test asserting zero getPublicUrl/public:true occurrences in the new files, so any accidental copy-paste from the wrong precedent fails CI, not just review.',
+  },
+];
+
+async function main() {
+  const { error } = await supabase
+    .from('strategic_directives_v2')
+    .update({
+      key_changes,
+      strategic_objectives,
+      success_criteria,
+      implementation_guidelines,
+      success_metrics,
+      smoke_test_steps,
+      risks,
+    })
+    .eq('sd_key', SD_KEY);
+  if (error) { console.error(error); process.exit(1); }
+  console.log(`De-boilerplated ${SD_KEY}.`);
+}
+
+main();

--- a/tests/unit/chairman/daily-review-gantt-renderer.test.js
+++ b/tests/unit/chairman/daily-review-gantt-renderer.test.js
@@ -1,0 +1,48 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D (FR-1) — Gantt SVG + PNG renderer.
+ * Hand-rolled, no external network/AI-generation call — no mocks needed beyond the real sharp lib.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildGanttSvg, renderGanttPng } from '../../../lib/chairman/daily-review/gantt-renderer.js';
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const waves = [
+  { wave_id: 'w1', title: 'Wave 1: Foundation', status: 'active', progress_pct: 71 },
+  { wave_id: 'w2', title: 'Wave 2: Revenue rails', status: 'approved', progress_pct: 20 },
+];
+
+describe('buildGanttSvg (FR-1)', () => {
+  it('returns well-formed SVG containing each wave title', () => {
+    const svg = buildGanttSvg(waves);
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg).toContain('Wave 1: Foundation');
+    expect(svg).toContain('Wave 2: Revenue rails');
+    expect(svg).toContain('71%');
+    expect(svg).toContain('20%');
+  });
+
+  it('handles an empty waves array without throwing', () => {
+    expect(() => buildGanttSvg([])).not.toThrow();
+    const svg = buildGanttSvg([]);
+    expect(svg).toContain('No roadmap waves available');
+  });
+
+  it('escapes XML-unsafe characters in wave titles', () => {
+    const svg = buildGanttSvg([{ title: 'A & B <script>', progress_pct: 50 }]);
+    expect(svg).not.toContain('<script>');
+    expect(svg).toContain('&amp;');
+  });
+});
+
+describe('renderGanttPng (FR-1)', () => {
+  it('returns a Buffer starting with the PNG magic bytes', async () => {
+    const png = await renderGanttPng(waves);
+    expect(Buffer.isBuffer(png)).toBe(true);
+    expect(png.subarray(0, 8).equals(PNG_MAGIC)).toBe(true);
+  });
+
+  it('handles an empty waves array without throwing', async () => {
+    await expect(renderGanttPng([])).resolves.toBeInstanceOf(Buffer);
+  });
+});

--- a/tests/unit/chairman/sms-outbound-mms-media-url.test.js
+++ b/tests/unit/chairman/sms-outbound-mms-media-url.test.js
@@ -1,0 +1,105 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D (FR-4, TS-6) — reconcileOutboundSms media_url
+ * threading, end-to-end.
+ *
+ * TESTING sub-agent finding (PLAN-TO-EXEC): the existing fake-Supabase double in
+ * tests/unit/chairman/sms-outbound-reconcile.test.js ignores the .select(cols) column
+ * projection entirely (select(_cols) discards the argument), so it always returns the full
+ * row regardless of what was actually selected -- a test built on that fake would FALSE-PASS
+ * even if EXEC forgot to add media_url to the real load-bearing select (line ~238, the
+ * claim-update RETURNING that `c` in provider.send() is destructured from). This test uses a
+ * PROJECTION-HONORING fake instead: select(cols) actually strips the row down to only the
+ * requested columns, so a missing media_url in either select() call surfaces as
+ * c.media_url === undefined and fails the assertion below -- closing the exact gap TESTING
+ * found rather than just checking the column exists somewhere.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { reconcileOutboundSms } from '../../../lib/chairman/sms-outbound-worker.js';
+
+function projectRow(row, cols) {
+  const wanted = cols.split(',').map((c) => c.trim());
+  const out = {};
+  for (const c of wanted) out[c] = row[c];
+  return out;
+}
+
+function makeProjectionHonoringSupabase(seedRow) {
+  const table = [{ ...seedRow }];
+  function from(_tableName) {
+    const ctx = { filters: [], cols: null, mode: 'select', vals: null };
+    const api = {
+      select(cols) { ctx.cols = cols; return api; },
+      update(vals) { ctx.mode = 'update'; ctx.vals = vals; return api; },
+      eq(col, val) { ctx.filters.push((r) => r[col] === val); return api; },
+      is(col, val) { ctx.filters.push((r) => (r[col] ?? null) === val); return api; },
+      in(col, vals) { ctx.filters.push((r) => vals.includes(r[col])); return api; },
+      order() { return api; },
+      limit() { return api; },
+      then(resolve) {
+        let rows = table.filter((r) => ctx.filters.every((f) => f(r)));
+        if (ctx.mode === 'update') {
+          rows.forEach((r) => Object.assign(r, ctx.vals));
+        }
+        const projected = ctx.cols ? rows.map((r) => projectRow(r, ctx.cols)) : rows.map((r) => ({ ...r }));
+        resolve({ data: projected, error: null });
+        return Promise.resolve();
+      },
+    };
+    return api;
+  }
+  return { from };
+}
+
+describe('reconcileOutboundSms media_url end-to-end (FR-4, TS-6)', () => {
+  it('provider.send() receives the populated mediaUrl for an owed row carrying media_url', async () => {
+    const seedRow = {
+      id: 'ob-1', recipient_phone: '+15551234567', kind: 'morning_review', decision_id: null,
+      body: 'Gantt attached', dedupe_key: null, status: 'owed', provider_message_id: null,
+      attempts: 0, not_before: null, claimed_at: null, claimed_by: null,
+      created_at: new Date().toISOString(), sent_at: null, delivered_at: null, last_error: null,
+      media_url: 'https://signed.example/gantt.png',
+    };
+    const supabase = makeProjectionHonoringSupabase(seedRow);
+    const provider = { send: vi.fn(async () => ({ provider_message_id: 'SM-1', status: 'queued' })) };
+
+    const summary = await reconcileOutboundSms(supabase, {
+      provider,
+      statusCallbackUrl: 'https://example.com/cb',
+      // Force the liveness probe (a plain select().limit()) to resolve truthy via the fake.
+    });
+
+    expect(summary.sent).toBe(1);
+    expect(provider.send).toHaveBeenCalledTimes(1);
+    expect(provider.send.mock.calls[0][0].mediaUrl).toBe('https://signed.example/gantt.png');
+  });
+
+  it('provider.send() receives mediaUrl=null for a text-only owed row (backward compatible)', async () => {
+    const seedRow = {
+      id: 'ob-2', recipient_phone: '+15551234567', kind: 'decision_question', decision_id: null,
+      body: 'Approve?', dedupe_key: null, status: 'owed', provider_message_id: null,
+      attempts: 0, not_before: null, claimed_at: null, claimed_by: null,
+      created_at: new Date().toISOString(), sent_at: null, delivered_at: null, last_error: null,
+      media_url: null,
+    };
+    const supabase = makeProjectionHonoringSupabase(seedRow);
+    const provider = { send: vi.fn(async () => ({ provider_message_id: 'SM-2', status: 'queued' })) };
+
+    await reconcileOutboundSms(supabase, { provider, statusCallbackUrl: 'https://example.com/cb' });
+
+    expect(provider.send.mock.calls[0][0].mediaUrl).toBeNull();
+  });
+});
+
+describe('static pin: media_url present in both reconcileOutboundSms select() calls (FR-4)', () => {
+  it('the owed-query select and the claim-update-returning select both include media_url', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync('lib/chairman/sms-outbound-worker.js', 'utf8');
+    const owedSelectMatch = src.match(/select\('id, recipient_phone, body, attempts, decision_id, not_before[^']*'\)/);
+    const claimSelectMatch = src.match(/select\('id, recipient_phone, body, attempts[^']*'\)/g);
+    expect(owedSelectMatch?.[0]).toMatch(/media_url/);
+    // claimSelectMatch[0] is the owed-query variant (superset match); the LAST match is the
+    // claim-update-returning select, which is what `c` in provider.send() is sourced from.
+    expect(claimSelectMatch?.at(-1)).toMatch(/media_url/);
+    expect(src).toMatch(/mediaUrl:\s*c\.media_url/);
+  });
+});

--- a/tests/unit/chairman/sms-outbound-reconcile.test.js
+++ b/tests/unit/chairman/sms-outbound-reconcile.test.js
@@ -119,6 +119,18 @@ describe('enqueueChairmanSms (FR-1)', () => {
     expect(r.enqueued).toBe(false);
     expect(r.reason).toBe('table_absent_or_error');
   });
+
+  it('SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D FR-4: threads mediaUrl into the inserted row as media_url', async () => {
+    const sb = makeFakeSupabase();
+    await enqueueChairmanSms(sb, { recipientPhone: '+15551234567', kind: 'morning_review', body: 'x', dedupeKey: 'k-media', mediaUrl: 'https://signed.example/gantt.png' });
+    expect(sb._tables.sms_outbound_obligations[0].media_url).toBe('https://signed.example/gantt.png');
+  });
+
+  it('SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D FR-4: omitting mediaUrl produces the same row shape as before this change (media_url null)', async () => {
+    const sb = makeFakeSupabase();
+    await enqueueChairmanSms(sb, { recipientPhone: '+15551234567', kind: 'morning_review', body: 'x', dedupeKey: 'k-nomedia' });
+    expect(sb._tables.sms_outbound_obligations[0].media_url).toBeNull();
+  });
 });
 
 // =======================================================================================

--- a/tests/unit/messaging/twilio-provider-mediaurl.test.js
+++ b/tests/unit/messaging/twilio-provider-mediaurl.test.js
@@ -1,0 +1,51 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D (FR-3) — twilio-provider.js MediaUrl support.
+ * No existing dedicated send() test file exists for twilio-provider.js (confirmed by Explore
+ * recon) -- this is the first direct unit test of send()'s form-body construction.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { send } from '../../../lib/messaging/providers/twilio-provider.js';
+
+describe('twilio-provider send() MediaUrl (FR-3)', () => {
+  const originalEnv = { ...process.env };
+  let fetchMock;
+
+  beforeEach(() => {
+    process.env.TWILIO_ACCOUNT_SID = 'AC_test';
+    process.env.TWILIO_AUTH_TOKEN = 'token_test';
+    process.env.TWILIO_MESSAGING_SERVICE = 'MG_test';
+    delete process.env.TWILIO_STATUS_CALLBACK_URL;
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ sid: 'SM_test' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+  });
+
+  function bodyFromCall() {
+    return new URLSearchParams(fetchMock.mock.calls[0][1].body);
+  }
+
+  it('sets the MediaUrl form param when mediaUrl is provided', async () => {
+    await send({ to: '+15551234567', body: 'hi', mediaUrl: 'https://signed.example/gantt.png' });
+    expect(bodyFromCall().get('MediaUrl')).toBe('https://signed.example/gantt.png');
+  });
+
+  it('omits MediaUrl when not provided -- byte-identical to pre-change behavior', async () => {
+    await send({ to: '+15551234567', body: 'hi' });
+    expect(bodyFromCall().has('MediaUrl')).toBe(false);
+  });
+
+  it('still sets To/Body/MessagingServiceSid regardless of mediaUrl', async () => {
+    await send({ to: '+15551234567', body: 'hi', mediaUrl: 'https://signed.example/gantt.png' });
+    const params = bodyFromCall();
+    expect(params.get('To')).toBe('+15551234567');
+    expect(params.get('Body')).toBe('hi');
+    expect(params.get('MessagingServiceSid')).toBe('MG_test');
+  });
+});

--- a/tests/unit/storage/private-signed-upload.test.js
+++ b/tests/unit/storage/private-signed-upload.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D (FR-2) — private-bucket + signed-URL upload.
+ * The cited "precedent" in the parent SD's PRD (lib/eva/logo-image-generator.js,
+ * lib/eva/stage-handlers/s11.js) is actually PUBLIC-bucket -- this module and its tests
+ * assert the OPPOSITE behavior: never public, signed URL only.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { uploadPrivateAndSign } from '../../../lib/storage/private-signed-upload.js';
+
+function makeFakeStorage({ createBucketError = null, uploadError = null } = {}) {
+  const calls = { createBucket: [], upload: [], createSignedUrl: [] };
+  return {
+    calls,
+    storage: {
+      createBucket: vi.fn(async (name, opts) => {
+        calls.createBucket.push({ name, opts });
+        return { error: createBucketError };
+      }),
+      from(bucket) {
+        return {
+          upload: vi.fn(async (path, buffer, opts) => {
+            calls.upload.push({ bucket, path, opts });
+            return { error: uploadError };
+          }),
+          createSignedUrl: vi.fn(async (path, expiresInSeconds) => {
+            calls.createSignedUrl.push({ bucket, path, expiresInSeconds });
+            return { data: { signedUrl: `https://signed.example/${bucket}/${path}?exp=${expiresInSeconds}` }, error: null };
+          }),
+          getPublicUrl: vi.fn(() => { throw new Error('getPublicUrl must never be called by uploadPrivateAndSign'); }),
+        };
+      },
+    },
+  };
+}
+
+describe('uploadPrivateAndSign (FR-2)', () => {
+  it('creates the bucket with public:false', async () => {
+    const fake = makeFakeStorage();
+    await uploadPrivateAndSign(fake, { bucket: 'daily-review-gantt', path: 'p.png', buffer: Buffer.from('x'), contentType: 'image/png', expiresInSeconds: 300 });
+    expect(fake.calls.createBucket[0].opts).toEqual({ public: false });
+  });
+
+  it('returns a signedUrl sourced from createSignedUrl, never getPublicUrl', async () => {
+    const fake = makeFakeStorage();
+    const result = await uploadPrivateAndSign(fake, { bucket: 'daily-review-gantt', path: 'p.png', buffer: Buffer.from('x'), contentType: 'image/png', expiresInSeconds: 300 });
+    expect(result.signedUrl).toContain('signed.example');
+    expect(fake.calls.createSignedUrl).toHaveLength(1);
+    expect(fake.calls.createSignedUrl[0].expiresInSeconds).toBe(300);
+  });
+
+  it('tolerates a bucket-already-exists error and still returns a signed URL (create-or-use)', async () => {
+    const fake = makeFakeStorage({ createBucketError: { message: 'Bucket already exists' } });
+    const result = await uploadPrivateAndSign(fake, { bucket: 'daily-review-gantt', path: 'p.png', buffer: Buffer.from('x'), contentType: 'image/png', expiresInSeconds: 300 });
+    expect(result.signedUrl).toContain('signed.example');
+  });
+
+  it('throws on a genuine (non-already-exists) createBucket error', async () => {
+    const fake = makeFakeStorage({ createBucketError: { message: 'permission denied' } });
+    await expect(uploadPrivateAndSign(fake, { bucket: 'x', path: 'p.png', buffer: Buffer.from('x'), contentType: 'image/png', expiresInSeconds: 300 })).rejects.toThrow(/permission denied/);
+  });
+
+  it('throws on an upload error', async () => {
+    const fake = makeFakeStorage({ uploadError: { message: 'quota exceeded' } });
+    await expect(uploadPrivateAndSign(fake, { bucket: 'x', path: 'p.png', buffer: Buffer.from('x'), contentType: 'image/png', expiresInSeconds: 300 })).rejects.toThrow(/quota exceeded/);
+  });
+});
+
+// Strips /** */ block comments and // line comments so the gate checks actual CODE, not the
+// module's own docstrings explaining the anti-pattern it deliberately avoids.
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+describe('confidentiality static gate (TR-2)', () => {
+  it('the new gantt-renderer.js and private-signed-upload.js CODE (comments excluded) contains zero getPublicUrl/public:true occurrences', () => {
+    const files = [
+      'lib/chairman/daily-review/gantt-renderer.js',
+      'lib/storage/private-signed-upload.js',
+    ];
+    for (const f of files) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      expect(code).not.toMatch(/getPublicUrl/);
+      expect(code).not.toMatch(/public:\s*true/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Deliver the Gantt-chart image via MMS through the existing hardened owed-state SMS path (Child D, last of 4 children of SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001).
- **Correction to the parent SD's PRD (FR-3)**: the cited reuse targets are wrong. `scripts/lib/visualization-provider.js` is a generative-AI text-prompt image tool with zero chart capability (no deterministic charting library exists in the repo). `lib/eva/logo-image-generator.js` / `lib/eva/stage-handlers/s11.js` are PUBLIC-bucket examples (`createBucket public:true` + `getPublicUrl`) — the opposite of this SD's confidentiality requirement (a public-URL attempt was already correctly blocked once, 2026-07-18). Both corrections were independently spot-checked by VALIDATION (95%) and Explore sub-agents before the PRD was written.
- `lib/chairman/daily-review/gantt-renderer.js`: hand-rolled SVG Gantt generation + `sharp`-based PNG rasterization (sharp already installed — no new dependency).
- `lib/storage/private-signed-upload.js`: private-bucket (`public:false`) + `createSignedUrl` upload helper, built from first principles (zero `createSignedUrl` precedent existed anywhere in the repo). A static test strips comments and asserts zero `getPublicUrl`/`public:true` in the actual code.
- `lib/messaging/providers/twilio-provider.js`: `send()` gains an optional `mediaUrl` param → Twilio `MediaUrl` form param, fully backward-compatible.
- `database/migrations/20260718_sms_outbound_obligations_STAGED.sql` (not yet applied — chairman-gated): add a nullable `media_url` column, header preserved verbatim.
- `lib/chairman/sms-bridge.js` / `sms-outbound-worker.js`: thread `media_url` end-to-end. The worker has two separate `.select()` calls (owed-query and claim-update-returning) — only the second actually feeds the `provider.send()` call, a real bug risk the TESTING sub-agent flagged during PLAN-TO-EXEC review.

## Test plan
- [x] 66 tests pass across new + extended files (`gantt-renderer`, `private-signed-upload`, `twilio-provider` mediaUrl, `sms-outbound-reconcile` extended, plus a dedicated projection-honoring end-to-end test)
- [x] The projection-honoring test matters: the pre-existing fake-Supabase double in `sms-outbound-reconcile.test.js` ignores `.select(cols)` projections entirely and would have false-passed even if `media_url` were missing from the real load-bearing select — a new test double actually strips unselected columns so a regression there fails loudly, plus a static source-pin as a second line of defense.
- [x] `npx eslint` clean on all touched/new files (one pre-existing, unrelated warning at `sms-outbound-worker.js:79`)
- [x] Full-repo regression (`npx vitest run --reporter=dot`): 48 failed test files, all pre-existing `|db|`-tagged live-database race/deadlock tests unrelated to touched modules (matches this repo's known live-DB baseline noise) — zero new failures
- [x] LEAD-TO-PLAN 97%, PLAN-TO-EXEC 100% (VALIDATION 95% + Explore + TESTING 88% sub-agent evidence on file, all 3 EXEC conditions TESTING flagged addressed above)

Note on LOC: 695 lines, over the 500-line auto-flag threshold — permitted per the LOC gate since an SD reference is present. This SD touches 5 files across 2 new modules + 3 existing files (twilio provider, migration, 2 owed-state modules), all directly required by the corrected FR-1..FR-4 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)