### PR TITLE
feat(SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-D): FR-4 single routing-doctrine consumption seam

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -448,7 +448,7 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
     const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
     if (!sdKey || /^QF-/.test(sdKey)) return; // QFs and SD-less nudges are not tier-gated
-    const { isTieringActive, resolveWorkerTierRank } = require('../fleet/tier-ladder.cjs');
+    const { isTieringActive, resolveWorkerTierRank, resolveRoutingScore, capabilityScore } = require('../fleet/tier-ladder.cjs');
     if (!(await isTieringActive(supabase))) return; // FR-5: tiering off with < 2 live workers
     const { data: sess } = await supabase
       .from('claude_sessions')
@@ -462,6 +462,20 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
       .select('metadata')
       .eq('sd_key', sdKey)
       .maybeSingle();
+    // FR-4.3 (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-D): dispatch tiering's routing score
+    // resolves through the ONE doctrine seam. Shape comes from the SD's problem_shape stamp
+    // when present; an unstamped SD (all of today's) or an unbound reference table makes the
+    // seam return the static capabilityScore, so the rank comparison below is unchanged until
+    // child C binds trusted rows. A graded divergence is surfaced as a breadcrumb ONLY — a
+    // graded→rank binding is deliberately not invented here (single-doctrine guard).
+    const declared = sess.metadata || {};
+    const shape = (sd && sd.metadata && sd.metadata.problem_shape) || null;
+    const routingScore = await resolveRoutingScore({ supabase, shape, model: declared.model, effort: declared.effort });
+    if (shape && routingScore !== capabilityScore(declared.model, declared.effort)) {
+      logger && logger.info && logger.info(
+        `[dispatch] graded routing score ${routingScore} for ${sdKey} (${shape}/${declared.model}/${declared.effort}) — rank stamps remain authoritative until a graded→rank binding ships`
+      );
+    }
     const minRank = Number(sd && sd.metadata && sd.metadata.min_tier_rank);
     if (!Number.isFinite(minRank)) return; // unscored SD -> don't block dispatch
     if (minRank > workerRank) {

--- a/lib/eval/__tests__/routing-consumption.test.js
+++ b/lib/eval/__tests__/routing-consumption.test.js
@@ -1,0 +1,168 @@
+/**
+ * routing-consumption.test.js — FR-4 single routing-doctrine seam
+ * (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-D, child D).
+ *
+ * Stubbed supabase — no live reads. Proves the fail-closed trust posture (FR-4.2),
+ * zero-trusted-rows parity with tier-ladder capabilityScore (FR-4.3), and the
+ * anti-fork + contamination-inheritance guards (FR-4.4).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  resolveCapabilityRouting,
+  gradedRoutingScore,
+  REFERENCE_RESULT_COLUMNS,
+  ROUTING_DOCTRINE_CONSUMERS,
+} from '../routing-consumption.mjs';
+import ladder from '../../fleet/tier-ladder.cjs';
+
+const { capabilityScore, resolveRoutingScore } = ladder;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SEAM_SRC = readFileSync(join(__dirname, '..', 'routing-consumption.mjs'), 'utf8');
+const LADDER_SRC = readFileSync(join(__dirname, '..', '..', 'fleet', 'tier-ladder.cjs'), 'utf8');
+const DISPATCH_SRC = readFileSync(join(__dirname, '..', '..', 'coordinator', 'dispatch.cjs'), 'utf8');
+
+/** Chainable supabase stub; records filters, resolves {data, error} as a thenable. */
+function makeStub({ rows = [], error = null, throws = false } = {}) {
+  const calls = { table: null, select: null, eq: [] };
+  const chain = {
+    select(cols) { calls.select = cols; return chain; },
+    eq(col, val) { calls.eq.push([col, val]); return chain; },
+    then(resolve, reject) { return Promise.resolve({ data: rows, error }).then(resolve, reject); },
+  };
+  const client = {
+    from(table) {
+      calls.table = table;
+      if (throws) throw new Error('synthetic client fault');
+      return chain;
+    },
+  };
+  return { client, calls };
+}
+
+const TUPLE = { shape: 'R3-taste', model: 'opus', effort: 'high' };
+const TRUSTED_ROW = {
+  problem_shape: 'R3-taste', model_id: 'opus', effort: 'high',
+  quality_score: 0.8, cost_norm: 3.25, trusted_for_routing: true,
+};
+
+describe('FR-4.2 fail-closed trust', () => {
+  it('absent table (query error, e.g. PGRST205) returns fallback without throwing', async () => {
+    const { client } = makeStub({ error: { code: 'PGRST205', message: 'relation missing' } });
+    const score = await resolveCapabilityRouting({ supabase: client, ...TUPLE });
+    expect(score).toBe(capabilityScore('opus', 'high'));
+  });
+
+  it('thrown client fault still resolves to fallback (CEREMONY_PENDING-safe)', async () => {
+    const { client } = makeStub({ throws: true });
+    await expect(resolveCapabilityRouting({ supabase: client, ...TUPLE })).resolves
+      .toBe(capabilityScore('opus', 'high'));
+  });
+
+  it('table present, zero trusted rows for the tuple → fallback', async () => {
+    const { client } = makeStub({ rows: [] });
+    const score = await resolveCapabilityRouting({ supabase: client, ...TUPLE });
+    expect(score).toBe(capabilityScore('opus', 'high'));
+  });
+
+  it('a trusted row present → its graded routing score (cost_norm preferred)', async () => {
+    const { client } = makeStub({ rows: [TRUSTED_ROW] });
+    const score = await resolveCapabilityRouting({ supabase: client, ...TUPLE });
+    expect(score).toBe(3.25);
+  });
+
+  it('untrusted rows are structurally ignored: the query itself filters trusted_for_routing=true', async () => {
+    const { client, calls } = makeStub({ rows: [] });
+    await resolveCapabilityRouting({ supabase: client, ...TUPLE });
+    expect(calls.table).toBe('model_capability_reference');
+    expect(calls.eq).toContainEqual(['trusted_for_routing', true]);
+  });
+
+  it('no supabase / no shape short-circuits to fallback (no query attempted)', async () => {
+    const { client, calls } = makeStub({ rows: [TRUSTED_ROW] });
+    const score = await resolveCapabilityRouting({ supabase: client, shape: null, model: 'opus', effort: 'high' });
+    expect(score).toBe(capabilityScore('opus', 'high'));
+    expect(calls.table).toBeNull();
+  });
+
+  it('explicit fallback (number or fn) wins over the default', async () => {
+    const { client } = makeStub({ rows: [] });
+    await expect(resolveCapabilityRouting({ supabase: client, ...TUPLE, fallback: 42 })).resolves.toBe(42);
+    await expect(resolveCapabilityRouting({ supabase: client, ...TUPLE, fallback: (m, e) => `${m}:${e}` }))
+      .resolves.toBe('opus:high');
+  });
+});
+
+describe('FR-4.3 behavior-preserving parity', () => {
+  const REPRESENTATIVE = [
+    ['fable', 'xhigh'], ['opus', 'high'], ['sonnet', 'medium'], ['haiku', 'low'],
+  ];
+
+  it('with zero trusted rows, seam output === capabilityScore for representative tuples', async () => {
+    for (const [model, effort] of REPRESENTATIVE) {
+      const { client } = makeStub({ rows: [] });
+      const seam = await resolveCapabilityRouting({ supabase: client, shape: 'R1-compounding', model, effort });
+      expect(seam).toBe(capabilityScore(model, effort));
+    }
+  });
+
+  it('tier-ladder resolveRoutingScore adapter matches capabilityScore with an empty trusted set', async () => {
+    for (const [model, effort] of REPRESENTATIVE) {
+      const { client } = makeStub({ rows: [] });
+      const viaAdapter = await resolveRoutingScore({ supabase: client, shape: 'R2-negative-space', model, effort });
+      expect(viaAdapter).toBe(capabilityScore(model, effort));
+    }
+  });
+
+  it('dispatch tiering is wired live through the adapter (reachability pin)', () => {
+    expect(DISPATCH_SRC).toMatch(/resolveRoutingScore\(\{ supabase, shape/);
+  });
+
+  it('§17 consumption is a durable contract marker, not live forked code', () => {
+    const c2 = ROUTING_DOCTRINE_CONSUMERS['foresight-board-section-17'];
+    expect(c2.status).toBe('deferred-with-trigger');
+    expect(c2.contract).toBe('C2');
+    expect(ROUTING_DOCTRINE_CONSUMERS['dispatch-tiering'].status).toBe('live');
+    expect(Object.isFrozen(ROUTING_DOCTRINE_CONSUMERS)).toBe(true);
+  });
+});
+
+describe('FR-4.4 anti-fork + contamination inheritance', () => {
+  it('single routing-score path: only the seam computes a graded score; the adapter delegates', () => {
+    // Adapter delegates to the seam module (never re-derives a metric)...
+    expect(LADDER_SRC).toContain("import('../eval/routing-consumption.mjs')");
+    // ...and no second graded-score implementation exists in the tiering/dispatch modules.
+    expect(LADDER_SRC).not.toMatch(/gradedRoutingScore\s*\(/);
+    expect(DISPATCH_SRC).not.toMatch(/gradedRoutingScore\s*\(/);
+    expect(SEAM_SRC.match(/export function gradedRoutingScore/g)).toHaveLength(1);
+  });
+
+  it('the seam selects only results-only reference columns (no task or key text)', () => {
+    expect(REFERENCE_RESULT_COLUMNS).toEqual([
+      'problem_shape', 'model_id', 'effort', 'quality_score', 'cost_norm', 'trusted_for_routing',
+    ]);
+    expect(Object.isFrozen(REFERENCE_RESULT_COLUMNS)).toBe(true);
+    // Contamination inheritance: the seam source never references task/key content columns.
+    expect(SEAM_SRC).not.toMatch(/task_text|answer_key|golden_task|expected_answer/);
+    // The only .select() uses the allow-list constant, not an inline column string.
+    expect(SEAM_SRC).toMatch(/\.select\(REFERENCE_RESULT_COLUMNS\.join\(','\)\)/);
+    expect(SEAM_SRC.match(/\.select\(/g)).toHaveLength(1);
+  });
+
+  it('the seam is a read-only consumer: it never writes/flips trusted_for_routing', () => {
+    expect(SEAM_SRC).not.toMatch(/\.(insert|update|upsert|delete)\s*\(/);
+  });
+});
+
+describe('gradedRoutingScore core', () => {
+  it('averages cost_norm across trusted rows, falls back to quality_score per row', () => {
+    expect(gradedRoutingScore([{ cost_norm: 2 }, { cost_norm: 4 }])).toBe(3);
+    expect(gradedRoutingScore([{ cost_norm: null, quality_score: 0.5 }])).toBe(0.5);
+    expect(gradedRoutingScore([])).toBeNull();
+    expect(gradedRoutingScore([{ cost_norm: 'NaN-ish' }])).toBeNull();
+  });
+});

--- a/lib/eval/routing-consumption.mjs
+++ b/lib/eval/routing-consumption.mjs
@@ -10,7 +10,7 @@
  *     yet per SD-LEO-INFRA-LAND-VENTURE-FORESIGHT-001); bound by the C2 consumption
  *     contract in ROUTING_DOCTRINE_CONSUMERS below, not live code. When §17 ships it
  *     MUST import resolveCapabilityRouting — forking a second doctrine violates the
- *     anti-fork guard test (tests/unit/eval/routing-consumption.test.js).
+ *     anti-fork guard test (lib/eval/__tests__/routing-consumption.test.js).
  *
  * FAIL-CLOSED TRUST (FR-4.2): only trusted_for_routing=true rows are consumed
  * (only child C's ground-truth gate flips that flag). Absent table (STAGED /

--- a/lib/eval/routing-consumption.mjs
+++ b/lib/eval/routing-consumption.mjs
@@ -1,0 +1,93 @@
+/**
+ * routing-consumption.mjs — THE single routing-doctrine consumption seam
+ * (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-D FR-4).
+ *
+ * ONE resolver for reality-graded routing scores from model_capability_reference.
+ * Both named consumers delegate here — neither computes its own routing metric:
+ *   - dispatch tiering: LIVE, via lib/fleet/tier-ladder.cjs resolveRoutingScore()
+ *     (consumed at the lib/coordinator/dispatch.cjs tier-enforcement choke point).
+ *   - Foresight Board §17 routing: DEFERRED-with-trigger (Phase-1 build not sourced
+ *     yet per SD-LEO-INFRA-LAND-VENTURE-FORESIGHT-001); bound by the C2 consumption
+ *     contract in ROUTING_DOCTRINE_CONSUMERS below, not live code. When §17 ships it
+ *     MUST import resolveCapabilityRouting — forking a second doctrine violates the
+ *     anti-fork guard test (tests/unit/eval/routing-consumption.test.js).
+ *
+ * FAIL-CLOSED TRUST (FR-4.2): only trusted_for_routing=true rows are consumed
+ * (only child C's ground-truth gate flips that flag). Absent table (STAGED /
+ * pre-ceremony, PGRST205) or zero trusted rows for the tuple → the FALLBACK is
+ * returned and the resolver NEVER throws (CEREMONY_PENDING-safe).
+ *
+ * FALLBACK SSOT (FR-4.1): tier-ladder.cjs capabilityScore — imported, never a
+ * re-derived ladder. With zero trusted rows the seam's output is therefore
+ * byte-identical to the static path (parity-tested), so live wiring is a
+ * behavior-preserving no-op until the reference table binds.
+ *
+ * CONTAMINATION GUARD (FR-4.4): reads ONLY results-only reference columns —
+ * never golden-task text or grading keys — and NEVER writes trusted_for_routing
+ * (read-only consumer; the flag's sole writer is scripts/eval/ground-truth-gate.mjs).
+ */
+import ladder from '../fleet/tier-ladder.cjs';
+
+const { capabilityScore } = ladder;
+
+/** Results-only column allow-list — the ONLY columns this seam may select. */
+export const REFERENCE_RESULT_COLUMNS = Object.freeze([
+  'problem_shape', 'model_id', 'effort', 'quality_score', 'cost_norm', 'trusted_for_routing',
+]);
+
+/** C2 consumption contract — durable anti-fork marker for both doctrine consumers. */
+export const ROUTING_DOCTRINE_CONSUMERS = Object.freeze({
+  'dispatch-tiering': Object.freeze({
+    status: 'live',
+    entry: 'lib/fleet/tier-ladder.cjs resolveRoutingScore()',
+    wired_at: 'lib/coordinator/dispatch.cjs assertWorkerTierAllowed()',
+  }),
+  'foresight-board-section-17': Object.freeze({
+    status: 'deferred-with-trigger',
+    contract: 'C2',
+    trigger: 'SD-LEO-INFRA-LAND-VENTURE-FORESIGHT-001 Phase-1 build sourced',
+    entry: 'MUST call resolveCapabilityRouting() — no forked metric',
+  }),
+});
+
+/**
+ * Pure core: graded routing score from already-fetched TRUSTED rows.
+ * Prefers cost_norm (the pairwise routing metric per capability-scorer.mjs);
+ * falls back to quality_score per row. Returns null when no finite metric exists.
+ */
+export function gradedRoutingScore(rows) {
+  const vals = (Array.isArray(rows) ? rows : [])
+    .map((r) => (Number.isFinite(r?.cost_norm) ? r.cost_norm : r?.quality_score))
+    .filter((v) => Number.isFinite(v));
+  if (vals.length === 0) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+/**
+ * THE routing-doctrine resolver (FR-4.1). Returns the reality-graded routing
+ * score for a (shape, model, effort) tuple when trusted rows exist, else the
+ * fallback (default: tier-ladder capabilityScore — the fallback SSOT).
+ * Never throws (FR-4.2). fallback may be a number or a (model, effort) => number.
+ */
+export async function resolveCapabilityRouting({ supabase = null, shape = null, model, effort, fallback } = {}) {
+  const fb = () => {
+    if (typeof fallback === 'function') return fallback(model, effort);
+    if (fallback !== undefined && fallback !== null) return fallback;
+    return capabilityScore(model, effort);
+  };
+  if (!supabase || !shape || !model || !effort) return fb();
+  try {
+    const { data, error } = await supabase
+      .from('model_capability_reference')
+      .select(REFERENCE_RESULT_COLUMNS.join(','))
+      .eq('problem_shape', shape)
+      .eq('model_id', model)
+      .eq('effort', effort)
+      .eq('trusted_for_routing', true);
+    if (error) return fb(); // PGRST205 / absent table / any read fault → fail-closed to fallback
+    const graded = gradedRoutingScore(data);
+    return graded === null ? fb() : graded;
+  } catch {
+    return fb(); // thrown client fault → still CEREMONY_PENDING-safe, never propagates
+  }
+}

--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -274,6 +274,27 @@ async function isTieringActive(supabase, opts = {}) {
 }
 
 /**
+ * FR-4.3 (SD-LEO-INFRA-MODEL-CAPABILITY-EVAL-002-D): dispatch tiering's routing-score
+ * resolution — a behavior-preserving adapter over the ONE routing-doctrine seam
+ * (lib/eval/routing-consumption.mjs). The seam's fallback SSOT is this module's own
+ * capabilityScore, so with zero trusted_for_routing rows (or no shape for the tuple)
+ * this returns exactly capabilityScore(model, effort) — a no-op until the
+ * model_capability_reference table binds (child C). SINGLE-DOCTRINE GUARD: no other
+ * routing metric may be defined here or in any consumer; graded scores enter dispatch
+ * tiering ONLY through this function. NEVER throws (fail-open to the static score).
+ * @param {{ supabase?: object|null, shape?: string|null, model?: string, effort?: string }} args
+ * @returns {Promise<number>}
+ */
+async function resolveRoutingScore({ supabase = null, shape = null, model, effort } = {}) {
+  try {
+    const { resolveCapabilityRouting } = await import('../eval/routing-consumption.mjs');
+    return await resolveCapabilityRouting({ supabase, shape, model, effort });
+  } catch {
+    return capabilityScore(model, effort);
+  }
+}
+
+/**
  * Test-only: reset the cached lastKnownTopRank back to the static default (LADDER.length).
  * lastKnownTopRank is module-level mutable state, so tests that call deriveLiveLadder must
  * reset it (e.g. in beforeEach) to avoid leaking a cached K across unrelated test cases.
@@ -299,5 +320,6 @@ module.exports = {
   deriveLiveLadder,
   deriveWorkerTierRank,
   stampRankForWorker,
+  resolveRoutingScore,
   __resetLadderCacheForTests,
 };


### PR DESCRIPTION
## Summary
- **FR-4.1** `lib/eval/routing-consumption.mjs` — THE single routing-doctrine resolver `resolveCapabilityRouting({supabase, shape, model, effort, fallback})`; fallback SSOT is tier-ladder `capabilityScore` (imported, never re-derived).
- **FR-4.2** Fail-closed trust: consumes ONLY `trusted_for_routing=true` rows; absent table (PGRST205 / STAGED pre-ceremony), zero trusted rows, or any client fault → fallback, never throws (CEREMONY_PENDING-safe).
- **FR-4.3** Live wiring: dispatch tiering resolves through the `resolveRoutingScore` adapter (tier-ladder) at the `assertWorkerTierAllowed` choke point in `lib/coordinator/dispatch.cjs`. Behavior-preserving no-op until child C binds trusted rows (parity-tested). Foresight Board §17 bound by the durable C2 contract marker (`ROUTING_DOCTRINE_CONSUMERS`), not forked code.
- **FR-4.4** Anti-fork + contamination guards: tests assert a single graded-score path, results-only column allow-list (no task/key text), and read-only consumption (never flips `trusted_for_routing`).

## Test plan
- 15 new unit tests in `lib/eval/__tests__/routing-consumption.test.js` (all ACs)
- Full fleet + eval + coordinator unit suites: 136 files / 1,453 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)