### PR TITLE
fix(checkin): add 'closed' to QF terminal-status allowlist

### DIFF
--- a/lib/checkin/steps/resume.cjs
+++ b/lib/checkin/steps/resume.cjs
@@ -59,7 +59,7 @@ module.exports = {
           const { data: qfRow, error: qfErr } = await sb.from('quick_fixes').select('status').eq('id', ctx.mySd).maybeSingle();
           if (qfErr) throw qfErr;
           if (qfRow) {
-            if (['completed', 'cancelled', 'escalated'].includes(qfRow.status)) staleTerminal = true;
+            if (['completed', 'cancelled', 'escalated', 'closed'].includes(qfRow.status)) staleTerminal = true;
           } else if (await confirmRowGone(sb, 'quick_fixes', 'id', ctx.mySd)) {
             staleDeleted = true; // FR-1/FR-2: a hard-deleted quick-fix, confirmed absent
           }

--- a/tests/unit/worker-checkin-own-claim-detect.test.js
+++ b/tests/unit/worker-checkin-own-claim-detect.test.js
@@ -181,4 +181,38 @@ describe('resume.cjs step — SILENT-STARVE reproduction and fix (reproduces the
     expect(result.sd).toBe('SD-ALREADY-CACHED-001');
     expect(ctx.base.self_healed_own_claim_pointer).toBeUndefined();
   });
+
+  // QF-20260719-406: quick_fixes.status='closed' (the sanctioned _close-qf one-off outcome for
+  // a QF whose fix already landed before it was claimed) was missing from the QF terminal-status
+  // allowlist, so checkin looped action=resume forever on a just-closed QF.
+  it('self-heals and falls through when the cached QF claim is status=closed (does NOT loop resume)', async () => {
+    const selfHealStaleClaim = vi.fn(async () => {});
+    const ctx = {
+      sb: {
+        from: () => ({
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: { status: 'closed' }, error: null }),
+        }),
+      },
+      sessionId: 'sess',
+      sessionRole: null,
+      mySd: 'QF-20260719-635', // cache still points at the just-closed QF
+      base: {},
+      helpers: {
+        ws: { getMessagesForSession: vi.fn(async () => []) },
+        confirmRowGone: vi.fn(async () => false),
+        selfHealStaleClaim,
+        findOwnSdClaim: vi.fn(),
+        healOwnClaimPointer: vi.fn(),
+        extractDirectedSd: () => null,
+        ASSIGNMENT_RECENCY_WINDOW_MS: 3600000,
+      },
+    };
+    const result = await runResumeStep(ctx);
+    expect(selfHealStaleClaim).toHaveBeenCalledWith(ctx.sb, 'sess', 'QF-20260719-635');
+    expect(ctx.base.self_healed_stale_claim).toBe('QF-20260719-635');
+    expect(ctx.mySd).toBeNull(); // falls through to assignment / self-claim, not resume
+    expect(result).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- `quick_fixes.status='closed'` (the sanctioned `_close-qf` one-off outcome for a QF whose underlying fix already landed before it was claimed) was missing from the terminal-status allowlist in `lib/checkin/steps/resume.cjs:62`.
- This caused `worker-checkin` to loop `action=resume` forever on a just-closed QF instead of self-healing the stale claim and falling through to the next claimable work.
- Sourced by coordinator `185c0ecf` from worker signal `a92a6223` (Bravo, hit live on QF-20260719-464). Reproduced independently on QF-20260719-635 this session (had to manually clear `claude_sessions.sd_key` via `bestEffortReleaseSd`).

## Changes
- `lib/checkin/steps/resume.cjs`: add `'closed'` to the QF `staleTerminal` allowlist (was `['completed', 'cancelled', 'escalated']`).
- `tests/unit/worker-checkin-own-claim-detect.test.js`: new test asserting a cached QF claim with `status='closed'` self-heals and falls through instead of resuming.

QF-20260719-406.

## Test plan
- [x] `npx vitest run tests/unit/worker-checkin-own-claim-detect.test.js` — 12/12 passing (new test included)
- [x] Verified `main` does not already contain the fix
- [x] Diff scoped to exactly the 2 intended files (2 LOC source change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)