### PR TITLE
fix(QF-20260719-760): shared-tree-contention guard in complete-quick-fix commit path

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -71,7 +71,8 @@ export function resolveQFWorktreeFromCwd(qfId, cwd = process.cwd()) {
 export function parseGitStatusFiles(statusOutput) {
   if (!statusOutput) return [];
   const files = new Set();
-  for (const line of statusOutput.split('\n')) {
+  for (let line of statusOutput.split('\n')) {
+    line = line.replace(/\r$/, '');
     if (!line || line.length < 4) continue;
     let rest = line.slice(3);
     const arrowIdx = rest.indexOf(' -> ');
@@ -863,10 +864,15 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
   try {
     const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8', cwd: testDir }).trim();
 
-    const gitStatus = execSync('git status --short', { encoding: 'utf-8', cwd: testDir }).trim();
+    // QF-20260719-760: parse the UNTRIMMED output — .trim() strips the leading
+    // space of the first line's XY status field (' M foo' → 'M foo'), so the
+    // first unstaged-modified file parsed as its name minus one char and was
+    // silently mis-scoped.
+    const gitStatusRaw = execSync('git status --short', { encoding: 'utf-8', cwd: testDir });
+    const gitStatus = gitStatusRaw.trim();
 
     if (gitStatus) {
-      const dirtyFiles = parseGitStatusFiles(gitStatus);
+      const dirtyFiles = parseGitStatusFiles(gitStatusRaw);
       const { scopedDirty, unrelatedDirty } = partitionDirtyByScope(dirtyFiles, filesChanged);
 
       if (scopedDirty.length === 0) {
@@ -878,6 +884,25 @@ export async function commitAndPushChanges(testDir, qf, gitInfo, actualLoc, file
           if (unrelatedDirty.length > 10) console.log(`        ... and ${unrelatedDirty.length - 10} more`);
         }
         console.log(`   Current commit: ${commitSha?.substring(0, 7) || 'Unknown'}\n`);
+        return commitSha;
+      }
+
+      // QF-20260719-760: shared-tree-contention guard. On a shared (non-isolated)
+      // working tree, filesChanged is the BRANCH's diff vs origin/main — not proof
+      // of QF authorship. A concurrent session's dirty files that overlap branch
+      // history (e.g. regenerated CLAUDE_*.md) classify as "scoped" and get swept
+      // into the QF commit (live incident: QF-20260719-038 committed 3 unrelated
+      // regen files). Out-of-scope dirty files alongside scoped ones are the
+      // contention signature — refuse the auto-commit outright instead of
+      // trusting the partition.
+      if (unrelatedDirty.length > 0 && !isInQFWorktree(testDir)) {
+        console.log(`   Current Branch: ${currentBranch}`);
+        console.log(`   🚫 Shared-tree contention: ${unrelatedDirty.length} dirty file(s) outside the QF scope and ${testDir} is not an isolated QF worktree.`);
+        unrelatedDirty.slice(0, 10).forEach(f => console.log(`        - ${f}`));
+        if (unrelatedDirty.length > 10) console.log(`        ... and ${unrelatedDirty.length - 10} more`);
+        console.log('   Refusing auto-commit: concurrent sessions may own files the scope partition would sweep in.');
+        console.log('   Re-run from the isolated QF worktree (.worktrees/qf/<QF-ID>), or commit the QF files manually.\n');
+        displayManualCommitInstructions(qf, currentBranch);
         return commitSha;
       }
 

--- a/scripts/modules/complete-quick-fix/shared-tree-contention-guard.test.js
+++ b/scripts/modules/complete-quick-fix/shared-tree-contention-guard.test.js
@@ -1,0 +1,107 @@
+/**
+ * Regression test for QF-20260719-760.
+ *
+ * Live incident (2026-07-19, worker signal dfd48574): on the stale shared root
+ * with 5 concurrent sessions, complete-quick-fix.js for a zero-diff QF
+ * (QF-20260719-038, force-complete referencing already-merged PR #6252)
+ * silently git-committed+pushed 3 UNRELATED dirty files (CLAUDE_ADAM.md,
+ * CLAUDE_ADAM_DIGEST.md, claude-generation-manifest.json) belonging to a
+ * concurrent regen process, under the QF's commit message.
+ *
+ * Root cause: commitAndPushChanges treats filesChanged (the BRANCH's diff vs
+ * origin/main) as the QF's scope. On a shared tree whose branch history
+ * already touched those files, a concurrent session's dirty copies classify
+ * as "scoped" and get swept into the commit.
+ *
+ * The guard: when the tree is NOT an isolated QF worktree AND out-of-scope
+ * dirty files are present (the contention signature), refuse the auto-commit
+ * entirely instead of trusting the scope partition.
+ *
+ * Uses REAL temporary git repos (like working-tree-fallback-fence.test.js)
+ * so the guard is proven against actual git behavior.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { commitAndPushChanges } from './git-operations.js';
+
+function git(cwd, cmd) {
+  return execSync(`git ${cmd}`, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+const QF = {
+  id: 'QF-20260719-760',
+  title: 'shared-tree contention guard fixture',
+  description: 'fixture',
+  type: 'bug',
+  severity: 'high',
+};
+
+// A prompt that would approve everything — the guard must return BEFORE any
+// prompt/auto-confirm path can commit.
+const yesPrompt = async () => 'yes';
+
+describe('commitAndPushChanges shared-tree-contention guard (QF-20260719-760)', () => {
+  let repoDir;
+  let qfWorktreeDir;
+
+  beforeAll(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'qf760-repo-'));
+    git(repoDir, 'init -q -b main');
+    git(repoDir, 'config user.email "test@test.local"');
+    git(repoDir, 'config user.name "Test"');
+    writeFileSync(join(repoDir, 'scoped-file.txt'), 'initial\n');
+    git(repoDir, 'add scoped-file.txt');
+    git(repoDir, 'commit -q -m "initial"');
+
+    qfWorktreeDir = join(repoDir, '.worktrees', 'qf', 'QF-20260719-760-fixture');
+    git(repoDir, `worktree add -q -B qf-760-fixture "${qfWorktreeDir}" main`);
+  });
+
+  afterAll(() => {
+    try { git(repoDir, `worktree remove --force "${qfWorktreeDir}"`); } catch { /* best-effort */ }
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('REFUSES auto-commit on a shared root when out-of-scope dirty files are present', async () => {
+    const headBefore = git(repoDir, 'rev-parse HEAD').trim();
+    // "Scoped" dirty file (overlaps filesChanged, i.e. branch history) + a
+    // concurrent session's unrelated dirty file — the incident signature.
+    writeFileSync(join(repoDir, 'scoped-file.txt'), 'dirty scoped change\n');
+    writeFileSync(join(repoDir, 'peer-session-file.txt'), 'concurrent session work\n');
+
+    const sha = await commitAndPushChanges(
+      repoDir, QF, { commitSha: headBefore }, 10, ['scoped-file.txt'],
+      null, true, yesPrompt, { nonInteractive: true }
+    );
+
+    expect(sha).toBe(headBefore);
+    expect(git(repoDir, 'rev-parse HEAD').trim()).toBe(headBefore);
+    // Both files must still be dirty — nothing was staged or committed.
+    const status = git(repoDir, 'status --short');
+    expect(status).toContain('scoped-file.txt');
+    expect(status).toContain('peer-session-file.txt');
+  });
+
+  it('still commits ONLY scoped files from an isolated QF worktree (no regression)', async () => {
+    const headBefore = git(qfWorktreeDir, 'rev-parse HEAD').trim();
+    writeFileSync(join(qfWorktreeDir, 'scoped-file.txt'), 'the actual QF change\n');
+    writeFileSync(join(qfWorktreeDir, 'stray-note.txt'), 'stray unrelated file\n');
+
+    const sha = await commitAndPushChanges(
+      qfWorktreeDir, QF, { commitSha: headBefore }, 10, ['scoped-file.txt'],
+      null, true, yesPrompt, { nonInteractive: true }
+    );
+
+    const headAfter = git(qfWorktreeDir, 'rev-parse HEAD').trim();
+    expect(headAfter).not.toBe(headBefore);
+    expect(sha).toBe(headAfter);
+    const committed = git(qfWorktreeDir, 'diff-tree --no-commit-id --name-only -r HEAD').trim().split('\n');
+    expect(committed).toEqual(['scoped-file.txt']);
+    // The stray file is ignored (existing behavior), not swept into the commit.
+    expect(git(qfWorktreeDir, 'status --short')).toContain('stray-note.txt');
+  });
+});


### PR DESCRIPTION
## Summary
- Refuse the auto-commit in `commitAndPushChanges` when running **outside an isolated QF worktree** with out-of-scope dirty files present. On a shared tree, `filesChanged` (branch diff vs origin/main) is not proof of QF authorship — a concurrent session's dirty files overlapping branch history were classified as scoped and swept into the QF commit (live incident: QF-20260719-038 committed 3 unrelated regen files under its message).
- Fix a first-line mis-parse feeding the same partition: `.trim()` on the whole `git status --short` output stripped the leading space of the first line's XY field, so the first unstaged-modified file parsed minus its first character and was silently mis-scoped. Parse untrimmed output; tolerate CRLF.

## Testing
- New `shared-tree-contention-guard.test.js` with real git fixtures: shared root + contention → refuses (HEAD unchanged, nothing staged); isolated QF worktree → still commits scoped-only files.
- 26/26 passing across guard, working-tree-fallback-fence, empty-diff-guard, scoped-staging suites. Compliance gate: 97/100 PASS.

Closes QF-20260719-760 (coordinator-sourced from worker harness-bug signal dfd48574).

🤖 Generated with [Claude Code](https://claude.com/claude-code)