### PR TITLE
fix(QF-20260719-343): ADAM_LOOPS heartbeat-email -> heartbeat-sms + morning-brief-sms

### DIFF
--- a/scripts/adam-chairman-sms.mjs
+++ b/scripts/adam-chairman-sms.mjs
@@ -1,0 +1,41 @@
+// adam-chairman-sms.mjs — QF-20260719-343
+//
+// Chairman-directed 2026-07-19 (contract c3/c4, leo_protocol_sections id=601): the routine
+// heartbeat and the daily 6:00 AM morning brief both go to the chairman by SMS via the sole
+// sanctioned chairman-SMS path (lib/comms/adam-outbound/chairman-sms-gate). Caller composes
+// the body; this script never fabricates content. Quiet hours (22:00-06:00 ET) and rate caps
+// are enforced INSIDE sendChairmanSMS's rubric gate — this script does not re-derive them.
+//
+// Fail-soft; --dry-run prints only.
+import 'dotenv/config';
+import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
+import { sendChairmanSMS } from '../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+
+enforceCliSendGuard({
+  scriptName: 'scripts/adam-chairman-sms.mjs',
+  flags: [{ name: '--dry-run' }, { name: '--body', takesValue: true }, { name: '--kind', takesValue: true }, { name: '--dedupe-key', takesValue: true }],
+});
+
+const DRY = process.argv.includes('--dry-run');
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+const body = argValue('--body');
+const kind = argValue('--kind') || 'status_update';
+const dedupeKey = argValue('--dedupe-key');
+
+if (!body || !body.trim()) {
+  console.warn('[adam-chairman-sms] --body "<text>" is required — nothing sent');
+  process.exit(0);
+}
+
+const message = { type: 'status', body: body.trim(), kind, dedupeKey };
+const context = { now: new Date() };
+
+if (DRY) {
+  console.log('=== [ADAM CHAIRMAN SMS — DRY RUN] no send ===\nKIND: ' + kind + '\n---\n' + message.body + '\n---');
+} else {
+  const r = await sendChairmanSMS(message, context);
+  console.log('ADAM-CHAIRMAN-SMS', JSON.stringify(r));
+}

--- a/scripts/adam-chairman-sms.mjs
+++ b/scripts/adam-chairman-sms.mjs
@@ -1,12 +1,7 @@
-// adam-chairman-sms.mjs — QF-20260719-343
-//
-// Chairman-directed 2026-07-19 (contract c3/c4, leo_protocol_sections id=601): the routine
-// heartbeat and the daily 6:00 AM morning brief both go to the chairman by SMS via the sole
-// sanctioned chairman-SMS path (lib/comms/adam-outbound/chairman-sms-gate). Caller composes
-// the body; this script never fabricates content. Quiet hours (22:00-06:00 ET) and rate caps
-// are enforced INSIDE sendChairmanSMS's rubric gate — this script does not re-derive them.
-//
-// Fail-soft; --dry-run prints only.
+// adam-chairman-sms.mjs — QF-20260719-343 (contract c3/c4, leo_protocol_sections id=601):
+// sends the hourly heartbeat + daily 6AM morning brief to the chairman via the sole sanctioned
+// chairman-SMS path. Caller composes the body; quiet hours/rate caps are enforced inside
+// sendChairmanSMS's rubric gate. Fail-soft; --dry-run prints only.
 import 'dotenv/config';
 import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
 import { sendChairmanSMS } from '../lib/comms/adam-outbound/chairman-sms-gate/index.js';

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -167,13 +167,10 @@ export const ADAM_LOOPS = [
     prompt: 'node scripts/adam-quiet-tick.mjs',
   },
   {
-    // QF-20260719-343 (contract c3, leo_protocol_sections id=601, chairman-directed 2026-07-19,
-    // superseding QF-20260702-433's email cadence): the routine heartbeat is now a BRIEF HOURLY
-    // SMS, not a half-hourly email — "your hourly updates" (chairman verbal). Quiet hours
-    // (22:00-06:00 ET) and rate caps are enforced inside sendChairmanSMS's rubric gate, so a
-    // quiet-window tick fails closed (held, not sent) with no prompt-side time arithmetic needed.
-    // Was SESSION-ONLY (session c514430f hand-armed as interim) — registering here so it
-    // survives session restarts, mirroring the belt-countdown/doc-drift durability fix.
+    // QF-20260719-343 (contract c3, leo_protocol_sections id=601, chairman-directed 2026-07-19):
+    // routine heartbeat is now a BRIEF HOURLY SMS, not a half-hourly email. Quiet hours
+    // (22:00-06:00 ET) + rate caps are enforced inside sendChairmanSMS's rubric gate. Was
+    // SESSION-ONLY (session c514430f hand-armed as interim); registered here for durability.
     key: 'heartbeat-sms',
     label: 'Hourly brief status SMS (quiet-hours-respecting, silence-by-default on truly-nothing ticks)',
     script: 'adam-chairman-sms.mjs',
@@ -182,14 +179,10 @@ export const ADAM_LOOPS = [
   },
   {
     // QF-20260719-343 (contract c4, leo_protocol_sections id=601, chairman-directed 2026-07-19):
-    // the daily 6:00 AM ET morning brief — "your 6:00 AM daily morning brief" (chairman verbal).
-    // Plan-first (roadmap position + overnight Slipped/Committing/Done condensed to phone scale),
-    // self-contained. RECONCILED via a per-ET-date dedupe key on sms_outbound_obligations
-    // (dedupe_key upsert ignoreDuplicates -- enqueueChairmanSms already enforces at-most-once/day),
-    // not fire-and-forget: the hourly heartbeat-sms tick above doubles as the late-delivery check
-    // (compose + send the brief late, same dedupe key, if the 6:00 fire was ever missed -- late >
-    // never, the 2026-07-18 missed-morning-review RCA). Distinct from the unchanged doc+Gantt-MMS
-    // daily-review surface (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001), its fuller companion.
+    // daily 6:00 AM ET plan-first morning brief by SMS. RECONCILED via a per-ET-date dedupe key
+    // (enqueueChairmanSms already enforces at-most-once/day); the hourly heartbeat-sms tick
+    // above doubles as the late-delivery check. Distinct from the unchanged doc+Gantt-MMS
+    // daily-review surface (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001).
     key: 'morning-brief-sms',
     label: 'Daily 6:00 AM ET plan-first morning brief SMS (reconciled via per-date dedupe key)',
     script: 'adam-chairman-sms.mjs',

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -167,16 +167,34 @@ export const ADAM_LOOPS = [
     prompt: 'node scripts/adam-quiet-tick.mjs',
   },
   {
-    // QF-20260702-433 (Chairman directive 2026-07-02): a half-hourly reassurance email whose
-    // SUBJECT alone signals all-is-well ("All good - Adam heartbeat <time> ET"), so silence never
-    // reads as stuck. Was SESSION-ONLY (armed ad hoc, cadence 14,44 * * * *) — the exact
-    // session-fragility class the belt-countdown duty already fixed; registering here so it
-    // survives session restarts.
-    key: 'heartbeat-email',
-    label: 'Half-hourly all-good reassurance email (subject-only signal, never a false all-good)',
-    script: 'adam-heartbeat-email.mjs',
-    cron: '14,44 * * * *',
-    prompt: 'Adam heartbeat-email tick: compose ONE fresh, honest status line, then run node scripts/adam-heartbeat-email.mjs --body "<line>" — never send a false all-good; if something is actually wrong, send the decision/alert email instead (node scripts/adam-decision-email.mjs) rather than this heartbeat.',
+    // QF-20260719-343 (contract c3, leo_protocol_sections id=601, chairman-directed 2026-07-19,
+    // superseding QF-20260702-433's email cadence): the routine heartbeat is now a BRIEF HOURLY
+    // SMS, not a half-hourly email — "your hourly updates" (chairman verbal). Quiet hours
+    // (22:00-06:00 ET) and rate caps are enforced inside sendChairmanSMS's rubric gate, so a
+    // quiet-window tick fails closed (held, not sent) with no prompt-side time arithmetic needed.
+    // Was SESSION-ONLY (session c514430f hand-armed as interim) — registering here so it
+    // survives session restarts, mirroring the belt-countdown/doc-drift durability fix.
+    key: 'heartbeat-sms',
+    label: 'Hourly brief status SMS (quiet-hours-respecting, silence-by-default on truly-nothing ticks)',
+    script: 'adam-chairman-sms.mjs',
+    cron: '14 * * * *',
+    prompt: 'Adam heartbeat-sms tick: if there is truly nothing plan-relevant to report, stay SILENT (silence-by-default) — otherwise compose ONE short (1-2 sentence), professional-casual, plan-relevant status line and run node scripts/adam-chairman-sms.mjs --kind heartbeat_status --body "<line>" (quiet hours and rate caps are enforced by the send gate itself — do not skip the call to pre-empt them). Never send a false all-good; if something is actually wrong, send the decision/alert email instead (node scripts/adam-decision-email.mjs) rather than this heartbeat.',
+  },
+  {
+    // QF-20260719-343 (contract c4, leo_protocol_sections id=601, chairman-directed 2026-07-19):
+    // the daily 6:00 AM ET morning brief — "your 6:00 AM daily morning brief" (chairman verbal).
+    // Plan-first (roadmap position + overnight Slipped/Committing/Done condensed to phone scale),
+    // self-contained. RECONCILED via a per-ET-date dedupe key on sms_outbound_obligations
+    // (dedupe_key upsert ignoreDuplicates -- enqueueChairmanSms already enforces at-most-once/day),
+    // not fire-and-forget: the hourly heartbeat-sms tick above doubles as the late-delivery check
+    // (compose + send the brief late, same dedupe key, if the 6:00 fire was ever missed -- late >
+    // never, the 2026-07-18 missed-morning-review RCA). Distinct from the unchanged doc+Gantt-MMS
+    // daily-review surface (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001), its fuller companion.
+    key: 'morning-brief-sms',
+    label: 'Daily 6:00 AM ET plan-first morning brief SMS (reconciled via per-date dedupe key)',
+    script: 'adam-chairman-sms.mjs',
+    cron: '0 6 * * *',
+    prompt: 'Adam morning-brief-sms tick: compose a self-contained, plan-first morning brief (roadmap position + overnight Slipped/Committing/Done condensed to phone scale, professional-casual), then run node scripts/adam-chairman-sms.mjs --kind morning_brief --dedupe-key "adam-morning-brief-<YYYY-MM-DD ET>" --body "<brief>". If a later tick finds today\'s dedupe key was never sent (the 6:00 fire was missed), compose and send it then instead -- late is better than never.',
   },
 ];
 

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -24,16 +24,17 @@ import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 11 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 12 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
   // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
   // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties);
   // board-reconcile added by SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (durable contract duty);
-  // heartbeat-email added by QF-20260702-433 (chairman directive 2026-07-02 — half-hourly all-good reassurance email);
+  // heartbeat-sms (was heartbeat-email, QF-20260702-433) + morning-brief-sms added by QF-20260719-343
+  //   (contract c3/c4, leo_protocol_sections id=601, chairman-directed 2026-07-19);
   // quiet-tick added by SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001 (folds inbox-monitor/belt-countdown/offer-help);
   // coordinator-health added by SD-LEO-INFRA-ADAM-COORDINATOR-HEALTH-001 (3-KPI coordinator oversight probe).
-  assert.equal(ADAM_LOOPS.length, 11);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'heartbeat-email']);
+  assert.equal(ADAM_LOOPS.length, 12);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'heartbeat-sms', 'morning-brief-sms']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);


### PR DESCRIPTION
## Summary
- Chairman-directed 2026-07-19 (contract c3/c4, `leo_protocol_sections` id=601): the routine Adam heartbeat is now an hourly brief SMS (not the half-hourly heartbeat-email), and a daily 6:00 AM ET morning brief goes by SMS.
- `ADAM_LOOPS` in `scripts/adam-startup-check.mjs` still emitted the stale `heartbeat-email` spec and had no morning-brief loop, so every fresh `/adam` session armed the wrong loops (the interim hand-armed session c514430f pattern this durable fix closes).
- Replaces `heartbeat-email` with `heartbeat-sms` (cron `14 * * * *`) and adds `morning-brief-sms` (cron `0 6 * * *`), both routed through the sole sanctioned chairman-SMS path (`sendChairmanSMS`). Quiet hours (22:00-06:00 ET) and rate caps are already enforced inside that gate's rubric — neither loop prompt re-derives them.
- Morning-brief reconciliation rides on `enqueueChairmanSms`'s existing per-`dedupe_key` at-most-once/day upsert; the hourly heartbeat-sms tick doubles as the late-delivery check.
- Adds `scripts/adam-chairman-sms.mjs`, a thin CLI wrapper mirroring the existing `adam-heartbeat-email.mjs` contract (`--body`/`--dry-run`, fail-soft, `enforceCliSendGuard`).

## Test plan
- [x] `node --test tests/unit/adam-startup-check.test.mjs` — 18/18 pass (updated loop-count/key assertions for the 11→12 change).
- [x] `npx vitest run tests/unit/coord-adam-comms-resilient.test.js` — 35/35 pass.
- [x] `npx vitest run tests/unit/coordinator/quiet-tick-loop-parity.test.js` — 6/6 pass.
- [x] `node scripts/adam-chairman-sms.mjs --dry-run --kind heartbeat_status --body "..."` — dry-run output correct; `--help` and unknown-flag guard behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)