### PR TITLE
fix(QF-20260719-120): drain undici pool on every post-fetch exit path in pre-tool-enforce.cjs

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce-block-await.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce-block-await.test.js
@@ -65,10 +65,13 @@ describe('QF-20260510-170: block-path audit await guard', () => {
     );
   });
 
-  it('NPM-INSTALL-RACE retains the QF-20260510-148 inline Promise.race pattern', () => {
-    // Functional parity site; documented predecessor of the auditAndExit helper.
+  it('NPM-INSTALL-RACE awaits auditAndExit (QF-20260719-120: inline race converged into the helper)', () => {
+    // QF-20260510-148 introduced the inline `await Promise.race` here; QF-20260719-120
+    // converged it into auditAndExit so the exit ALSO drains the undici pool (the raw
+    // exit(2) after the audit fetch raced libuv teardown → UV_HANDLE_CLOSING assertion).
+    // Same bounded audit-await guarantee, now with the drain.
     expect(HOOK_SRC).toMatch(
-      /'NPM-INSTALL-RACE'[\s\S]{0,2000}?await Promise\.race\(\[[\s\S]*?auditPromise[\s\S]*?setTimeout/
+      /'NPM-INSTALL-RACE'[\s\S]{0,2000}?await auditAndExit\(auditPromise,\s*2,\s*\d+\)/
     );
   });
 
@@ -80,7 +83,7 @@ describe('QF-20260510-170: block-path audit await guard', () => {
     const violations = [...HOOK_SRC.matchAll(regressionRe)];
     expect(
       violations,
-      `Found bare auditPermissionDecision(...'block'...) without 'const auditPromise = ' prefix:\n` +
+      'Found bare auditPermissionDecision(...\'block\'...) without \'const auditPromise = \' prefix:\n' +
       violations.map(m => '  ' + m[0]).join('\n')
     ).toEqual([]);
   });

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -692,11 +692,10 @@ async function main() {
             `  Wait ~30-60s and retry, OR isolate via: npm run session:worktree -- --sd-key <key>\n` +
             `  If staging is stuck (no actual peer): rm -rf node_modules/.staging\n`
           );
-          await Promise.race([
-            Promise.resolve(auditPromise),
-            new Promise(resolve => setTimeout(resolve, 1000))
-          ]).catch(() => { /* audit never blocks enforcement */ });
-          process.exit(2);
+          // QF-20260719-120: auditAndExit (same 1s audit cap) so this post-fetch exit
+          // drains the undici pool — raw exit(2) here races the audit POST's async
+          // handle and trips the src\win\async.c:76 libuv assertion.
+          await auditAndExit(auditPromise, 2, 1000);
         }
       } catch { /* fail-open on any internal error */ }
     }
@@ -720,11 +719,9 @@ async function main() {
           `  Use the additive install instead:  npm install --ignore-scripts --no-audit --no-fund\n` +
           `  Override (single-session only):    LEO_NPM_INSTALL_GUARD=off\n`
         );
-        await Promise.race([
-          Promise.resolve(auditPromise),
-          new Promise(resolve => setTimeout(resolve, 1000))
-        ]).catch(() => { /* audit never blocks enforcement */ });
-        process.exit(2);
+        // QF-20260719-120: auditAndExit (same 1s audit cap) drains before exit — see
+        // NPM-INSTALL-RACE block above for the libuv assertion this prevents.
+        await auditAndExit(auditPromise, 2, 1000);
       }
     } catch { /* fail-open on any internal error */ }
   }
@@ -1537,7 +1534,14 @@ async function main() {
   // already use process.exit(2); the ALLOW path was the asymmetric outlier — caused
   // ~5s hangs in CI where Supabase fetches don't resolve. Documented contract for all
   // those async writes is "fire and forget — never block enforcement".
+  // QF-20260719-120: drain first — the ALLOW audit fetch just fired, and a raw exit
+  // races its async-handle setup (the same src\win\async.c:76 window as the block paths).
+  await drainUndiciPool();
   process.exit(0);
 }
 
-main().catch(() => process.exit(0)); // Fail-open: async errors never block
+// QF-20260719-120: the fail-open catch must ALSO drain — any throw after a
+// fire-and-forget fetch landed here and exited un-drained, which was the last
+// remaining path to the libuv UV_HANDLE_CLOSING assertion (crash = PreToolUse
+// aborted = enforcement silently skipped). drainUndiciPool never throws.
+main().catch(async () => { await drainUndiciPool(); process.exit(0); }); // Fail-open: async errors never block

--- a/tests/unit/hooks/enforcement-12-audit-await.test.js
+++ b/tests/unit/hooks/enforcement-12-audit-await.test.js
@@ -29,26 +29,46 @@ describe('pre-tool-enforce ENF-12 audit-await regression (QF-20260510-148)', () 
     expect(body).toMatch(/return\s+Promise\.resolve\(\)/);
   });
 
-  it('ENF-12 (NPM-INSTALL-RACE) block path awaits the audit before process.exit(2)', () => {
+  // QF-20260719-120: ENF-12/12c now route through auditAndExit (same bounded
+  // audit-await, PLUS drainUndiciPool before exit — raw exit(2) after the audit
+  // fetch raced its async handle and tripped libuv's UV_HANDLE_CLOSING assertion).
+  it('ENF-12 (NPM-INSTALL-RACE) block path awaits auditAndExit with a bounded timeout', () => {
     const ruleIdx = SRC.indexOf("'NPM-INSTALL-RACE'");
     expect(ruleIdx).toBeGreaterThan(-1);
-    const exitIdx = SRC.indexOf('process.exit(2)', ruleIdx);
-    expect(exitIdx).toBeGreaterThan(ruleIdx);
-    const window = SRC.slice(ruleIdx, exitIdx);
-
-    expect(window).toMatch(/\bawait\b/);
-    expect(window).toMatch(/Promise\.race\s*\(/);
-    expect(window).toMatch(/setTimeout\s*\(\s*resolve\s*,\s*\d+\s*\)/);
-  });
-
-  it('audit-await window in ENF-12 has a bounded timeout (never hangs hook longer than 5s)', () => {
-    const ruleIdx = SRC.indexOf("'NPM-INSTALL-RACE'");
-    const exitIdx = SRC.indexOf('process.exit(2)', ruleIdx);
-    const window = SRC.slice(ruleIdx, exitIdx);
-    const m = window.match(/setTimeout\s*\(\s*resolve\s*,\s*(\d+)\s*\)/);
+    const window = SRC.slice(ruleIdx, ruleIdx + 1500);
+    const m = window.match(/await\s+auditAndExit\s*\(\s*auditPromise\s*,\s*2\s*,\s*(\d+)\s*\)/);
     expect(m).toBeTruthy();
     const ms = parseInt(m[1], 10);
     expect(ms).toBeGreaterThan(0);
     expect(ms).toBeLessThanOrEqual(5000);
+  });
+
+  it('auditAndExit awaits the audit with a bounded race, drains undici, then exits', () => {
+    const fnStart = SRC.indexOf('async function auditAndExit(');
+    expect(fnStart).toBeGreaterThan(-1);
+    const body = SRC.slice(fnStart, SRC.indexOf('process.exit(code)', fnStart) + 20);
+    expect(body).toMatch(/Promise\.race\s*\(/);
+    expect(body).toMatch(/setTimeout\s*\(\s*resolve\s*,\s*ms\s*\)/);
+    expect(body).toMatch(/await\s+drainUndiciPool\s*\(\s*\)/);
+    // drain must come BEFORE the exit
+    expect(body.indexOf('drainUndiciPool')).toBeLessThan(body.indexOf('process.exit(code)'));
+  });
+
+  // QF-20260719-120: the last un-drained exit paths — the fail-open main().catch and
+  // the ALLOW-path exit — must drain the undici pool first. A crash here aborts the
+  // PreToolUse hook, which Claude Code treats as non-blocking: enforcement silently
+  // skipped.
+  it('fail-open main().catch drains the undici pool before exiting', () => {
+    const m = SRC.match(/main\(\)\.catch\(async \(\) => \{ await drainUndiciPool\(\); process\.exit\(0\); \}\)/);
+    expect(m).toBeTruthy();
+  });
+
+  it('ALLOW-path final exit drains the undici pool after the pass-through audit', () => {
+    const allowIdx = SRC.indexOf("'Tool call permitted by all enforcement rules'");
+    expect(allowIdx).toBeGreaterThan(-1);
+    // Match the statement sequence, not indexOf('process.exit(0)') — that string also
+    // appears in the QF-20260509-199 comment between the audit and the exit.
+    const window = SRC.slice(allowIdx, allowIdx + 1500);
+    expect(window).toMatch(/await drainUndiciPool\(\);\s*\n\s*process\.exit\(0\);/);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes the intermittent Windows libuv crash (`Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c:76`) from PreToolUse hooks — a crashed PreToolUse hook is treated as non-blocking, so **enforcement was silently skipped** on every crash.
- `main().catch(() => process.exit(0))` was the last un-drained exit: any throw after a fire-and-forget audit fetch exited while the undici keep-alive socket's async handle was closing. Now drains first.
- ENF-12 / ENF-12c npm guards: inline audit-race + raw `exit(2)` converted to the existing `auditAndExit(auditPromise, 2, 1000)` — identical 1s audit cap, adds the drain.
- ALLOW path: drains after the pass-through audit fetch (per the file's own contract: every post-fetch exit must drain).
- Exits before any fetch (parse-fail, TEST_DUMP_RESOLVED) unchanged.
- Pin test `enforcement-12-audit-await.test.js` updated to the auditAndExit mechanism + new drain guarantees.

## Verification
- 42/42 hook-related unit tests pass; smoke suite 15/15 in pre-commit.
- Hook exercised 10× on the allow path: exit 0, no assertion.
- The assertion **reproduced live from a sibling script during this very commit's pre-commit chain** — confirming the crash class and the QF's note that sibling hooks (post-tool, task-recorder.js) need the same sweep (left out of scope for this ≤50-LOC QF).

QF: QF-20260719-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)