### PR TITLE
fix(QF-20260719-387): sender-role guard + target-role assert on advisory send chokes

### DIFF
--- a/lib/coordinator/role-comms-guard.cjs
+++ b/lib/coordinator/role-comms-guard.cjs
@@ -1,0 +1,130 @@
+'use strict';
+/**
+ * role-comms-guard.cjs — QF-20260719-387 (chairman-directed after live misroute d442d8ec:
+ * Adam ran scripts/solomon-advisory.cjs send from the Adam session, so an Adam->Solomon
+ * proposal silently applied Solomon's routing defaults and landed on the coordinator lane).
+ *
+ * Two FAIL-CLOSED checks shared by the adam-advisory.cjs / solomon-advisory.cjs send+request
+ * chokes — a blocked send is recoverable, a misroute is not:
+ *
+ *  1. SENDER-ROLE GUARD (assertSenderRole): the invoking session's registered role
+ *     (claude_sessions.metadata->>role, session_id from CLAUDE_SESSION_ID) must match the
+ *     tool's owner role; the error names the correct tool for the caller's actual role.
+ *  2. TARGET-ROLE ASSERT (assertTargetRole): after target resolution, the resolved target
+ *     session's registered role is read back and must match the intended recipient class;
+ *     success prints "target-role verified: <role> <session>" so every send output carries
+ *     the verification. Broadcast sentinels (broadcast-*) have no live session and are
+ *     reported as buffered sentinels, not role-verified.
+ *
+ * Role-resolution errors (DB error, session not found) hard-error with exit 4.
+ * Pure decision helpers are exported separately so the policy is unit-testable without exits.
+ */
+
+const ROLE_TOOL = Object.freeze({
+  solomon: 'scripts/solomon-advisory.cjs',
+  adam: 'scripts/adam-advisory.cjs',
+  coordinator: 'the coordinator reply lane (scripts/coordinator-reply.cjs)',
+});
+
+/** Name the correct outbound tool for a caller's registered role (workers -> /signal lane). */
+function toolForRole(role) {
+  return ROLE_TOOL[role] || 'scripts/worker-signal.cjs (the worker /signal lane)';
+}
+
+/**
+ * Resolve a session's registered role from claude_sessions.
+ * Keyed on the session_id COLUMN (not id — the two differ; see claims/dispatch gotchas).
+ * Multiple rows per session_id can exist across re-registrations: newest heartbeat wins.
+ *
+ * Effective role = metadata.role, else 'coordinator' when metadata.is_coordinator is set:
+ * the coordinator ELECTION discriminator is is_coordinator (lib/coordinator/resolve.cjs
+ * electCoordinatorFromDb), and the live coordinator row verifiably carries is_coordinator
+ * WITHOUT a role field (registration lapse during long inline hosting) — a strict
+ * role==='coordinator' read would false-block the entire default relay lane.
+ *
+ * THROWS on DB error or unknown session — callers decide fail-closed handling.
+ * @returns {Promise<string|null>} effective role, or null when registered without one
+ */
+async function resolveSessionRole(supabase, sessionId) {
+  if (!sessionId) throw new Error('no session id provided');
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, heartbeat_at, metadata')
+    .eq('session_id', sessionId)
+    .order('heartbeat_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(`role lookup failed for ${sessionId}: ${error.message}`);
+  if (!Array.isArray(data) || data.length === 0) throw new Error(`session ${sessionId} not found in claude_sessions`);
+  const meta = data[0].metadata || {};
+  if (meta.role) return meta.role;
+  if (meta.is_coordinator === true || meta.is_coordinator === 'true') return 'coordinator';
+  return null;
+}
+
+/** PURE sender-role decision. @returns {{ok: boolean, message?: string}} */
+function checkSenderRole({ actualRole, requiredRole, toolName }) {
+  if (actualRole === requiredRole) return { ok: true };
+  return {
+    ok: false,
+    message: `${toolName} is the ${requiredRole} outbound lane, but this session's registered role is "${actualRole || 'unregistered'}". Use ${toolForRole(actualRole)} instead.`,
+  };
+}
+
+/** PURE target-role decision. @returns {{ok: boolean, message?: string}} */
+function checkTargetRole({ actualRole, expectedRole, target }) {
+  if (actualRole === expectedRole) return { ok: true };
+  return {
+    ok: false,
+    message: `resolved target ${target} has registered role "${actualRole || 'unregistered'}" but this send intends the ${expectedRole} lane — refusing (misroute).`,
+  };
+}
+
+/** Sender-role guard at the send choke. Hard-errors (exit 4) on mismatch or resolution failure. */
+async function assertSenderRole(supabase, { sessionId, requiredRole, toolName }) {
+  let actualRole;
+  try {
+    actualRole = await resolveSessionRole(supabase, sessionId);
+  } catch (e) {
+    console.error(`ERROR: [ROLE_GUARD] cannot verify sender role (fail-closed): ${e.message}`);
+    process.exit(4);
+  }
+  const verdict = checkSenderRole({ actualRole, requiredRole, toolName });
+  if (!verdict.ok) {
+    console.error(`ERROR: [ROLE_GUARD] ${verdict.message}`);
+    process.exit(4);
+  }
+}
+
+/**
+ * Target-role assert after target resolution. Hard-errors (exit 4) on mismatch or resolution
+ * failure; prints the verification line on success. Sentinel targets (broadcast-*) are buffered
+ * rows with no live session — reported, not role-verified. A direct raw-session target (R1,
+ * expectedRole=null) gets a best-effort informational print only: R1 exists precisely to address
+ * arbitrary sessions, so no recipient class is enforced there.
+ */
+async function assertTargetRole(supabase, { target, expectedRole }) {
+  if (typeof target === 'string' && target.startsWith('broadcast-')) {
+    console.log(`  target-role verified: ${target} (buffered sentinel — no live session)`);
+    return;
+  }
+  let actualRole;
+  try {
+    actualRole = await resolveSessionRole(supabase, target);
+  } catch (e) {
+    if (expectedRole === null) { console.log(`  target-role: (direct target ${target} — role unresolved: ${e.message})`); return; }
+    console.error(`ERROR: [ROLE_GUARD] cannot verify target role (fail-closed): ${e.message}`);
+    process.exit(4);
+  }
+  if (expectedRole === null) {
+    console.log(`  target-role verified: ${actualRole || 'unregistered'} ${target} (direct target — no class constraint)`);
+    return;
+  }
+  const verdict = checkTargetRole({ actualRole, expectedRole, target });
+  if (!verdict.ok) {
+    console.error(`ERROR: [ROLE_GUARD] ${verdict.message}`);
+    process.exit(4);
+  }
+  console.log(`  target-role verified: ${actualRole} ${target}`);
+}
+
+module.exports = { resolveSessionRole, checkSenderRole, checkTargetRole, assertSenderRole, assertTargetRole, toolForRole };

--- a/lib/coordinator/role-comms-guard.test.js
+++ b/lib/coordinator/role-comms-guard.test.js
@@ -1,0 +1,135 @@
+/**
+ * QF-20260719-387 — role-comms guard at the advisory send chokes.
+ *
+ * Live misroute d442d8ec: Adam ran solomon-advisory.cjs send from the Adam session;
+ * the tool silently applied Solomon's routing defaults and an Adam->Solomon proposal
+ * landed on the coordinator lane. These tests pin the guard policy:
+ *   - sender-role mismatch is refused and the error names the caller's correct tool;
+ *   - target-role read-back refuses a recipient-class mismatch;
+ *   - role-resolution failures are fail-closed (exit) for classed sends;
+ *   - broadcast sentinels are reported without a role lookup.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  resolveSessionRole, checkSenderRole, checkTargetRole,
+  assertSenderRole, assertTargetRole, toolForRole,
+} from './role-comms-guard.cjs';
+
+function mockSupabase({ data, error } = {}) {
+  const chain = {
+    from: vi.fn(() => chain),
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(async () => ({ data, error })),
+  };
+  return chain;
+}
+
+const exitAsThrow = () => vi.spyOn(process, 'exit').mockImplementation((code) => {
+  throw new Error(`EXIT:${code}`);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('resolveSessionRole', () => {
+  it('returns the newest-heartbeat row role', async () => {
+    const supabase = mockSupabase({ data: [{ session_id: 's1', heartbeat_at: 'now', metadata: { role: 'adam' } }] });
+    await expect(resolveSessionRole(supabase, 's1')).resolves.toBe('adam');
+    expect(supabase.eq).toHaveBeenCalledWith('session_id', 's1');
+    expect(supabase.order).toHaveBeenCalledWith('heartbeat_at', { ascending: false });
+  });
+
+  it('returns null for a registered session without a role', async () => {
+    const supabase = mockSupabase({ data: [{ session_id: 's1', metadata: {} }] });
+    await expect(resolveSessionRole(supabase, 's1')).resolves.toBeNull();
+  });
+
+  it('derives coordinator from is_coordinator when role is absent (live lapse shape)', async () => {
+    // The real coordinator election keys on metadata.is_coordinator, and the live row
+    // verifiably has is_coordinator:true with NO role — strict role would false-block.
+    const supabase = mockSupabase({ data: [{ session_id: 'c1', metadata: { is_coordinator: true } }] });
+    await expect(resolveSessionRole(supabase, 'c1')).resolves.toBe('coordinator');
+    const supabase2 = mockSupabase({ data: [{ session_id: 'c1', metadata: { is_coordinator: 'true' } }] });
+    await expect(resolveSessionRole(supabase2, 'c1')).resolves.toBe('coordinator');
+  });
+
+  it('throws on DB error and on unknown session (fail-closed inputs)', async () => {
+    await expect(resolveSessionRole(mockSupabase({ error: { message: 'boom' } }), 's1')).rejects.toThrow(/role lookup failed/);
+    await expect(resolveSessionRole(mockSupabase({ data: [] }), 's1')).rejects.toThrow(/not found/);
+    await expect(resolveSessionRole(mockSupabase({ data: [] }), null)).rejects.toThrow(/no session id/);
+  });
+});
+
+describe('checkSenderRole — the incident shape', () => {
+  it('refuses Adam running solomon-advisory and names adam-advisory as the right tool', () => {
+    const verdict = checkSenderRole({ actualRole: 'adam', requiredRole: 'solomon', toolName: 'solomon-advisory.cjs' });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toContain('solomon outbound lane');
+    expect(verdict.message).toContain('scripts/adam-advisory.cjs');
+  });
+
+  it('routes unregistered/worker roles to the /signal lane', () => {
+    expect(toolForRole(null)).toContain('worker-signal');
+    const verdict = checkSenderRole({ actualRole: null, requiredRole: 'adam', toolName: 'adam-advisory.cjs' });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toContain('unregistered');
+  });
+
+  it('passes the owner role through', () => {
+    expect(checkSenderRole({ actualRole: 'solomon', requiredRole: 'solomon', toolName: 'x' }).ok).toBe(true);
+  });
+});
+
+describe('checkTargetRole', () => {
+  it('refuses a recipient-class mismatch', () => {
+    const verdict = checkTargetRole({ actualRole: 'worker', expectedRole: 'coordinator', target: 't1' });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toContain('misroute');
+  });
+  it('passes a matching class', () => {
+    expect(checkTargetRole({ actualRole: 'adam', expectedRole: 'adam', target: 't1' }).ok).toBe(true);
+  });
+});
+
+describe('assert wrappers (fail-closed exits)', () => {
+  it('assertSenderRole exits 4 on role mismatch', async () => {
+    const exit = exitAsThrow();
+    const supabase = mockSupabase({ data: [{ session_id: 's1', metadata: { role: 'adam' } }] });
+    await expect(assertSenderRole(supabase, { sessionId: 's1', requiredRole: 'solomon', toolName: 'solomon-advisory.cjs' }))
+      .rejects.toThrow('EXIT:4');
+    expect(exit).toHaveBeenCalledWith(4);
+  });
+
+  it('assertSenderRole exits 4 when role resolution fails (fail-closed)', async () => {
+    exitAsThrow();
+    await expect(assertSenderRole(mockSupabase({ error: { message: 'net down' } }), { sessionId: 's1', requiredRole: 'adam', toolName: 'adam-advisory.cjs' }))
+      .rejects.toThrow('EXIT:4');
+  });
+
+  it('assertTargetRole exits 4 on class mismatch, prints verification on match', async () => {
+    exitAsThrow();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(assertTargetRole(mockSupabase({ data: [{ session_id: 't1', metadata: { role: 'worker' } }] }), { target: 't1', expectedRole: 'coordinator' }))
+      .rejects.toThrow('EXIT:4');
+    await assertTargetRole(mockSupabase({ data: [{ session_id: 't2', metadata: { role: 'coordinator' } }] }), { target: 't2', expectedRole: 'coordinator' });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('target-role verified: coordinator t2'));
+  });
+
+  it('assertTargetRole reports broadcast sentinels without a role lookup', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const supabase = { from: () => { throw new Error('must not query'); } };
+    await assertTargetRole(supabase, { target: 'broadcast-coordinator', expectedRole: 'coordinator' });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('broadcast-coordinator (buffered sentinel'));
+  });
+
+  it('assertTargetRole treats a direct raw-session target as print-only (no class constraint)', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await assertTargetRole(mockSupabase({ data: [{ session_id: 't3', metadata: { role: 'worker' } }] }), { target: 't3', expectedRole: null });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('direct target'));
+    // And an unresolvable direct target must NOT exit — informational only.
+    await assertTargetRole(mockSupabase({ data: [] }), { target: 'ghost', expectedRole: null });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('role unresolved'));
+  });
+});

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -46,6 +46,8 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { redact, capBody, awaitCoordinatorReply, buildSolomonConsultPayload } = require('./worker-signal.cjs');
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+// QF-20260719-387: fail-closed sender-role guard + target-role assert at the send/request chokes.
+const { assertSenderRole, assertTargetRole } = require('../lib/coordinator/role-comms-guard.cjs');
 const { insertCoordinationRow, isSentinelTarget } = require('../lib/coordinator/dispatch.cjs');
 const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
 const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
@@ -887,6 +889,12 @@ async function main() {
     process.exit(3);
   }
 
+  // QF-20260719-387 (chairman-directed after live misroute d442d8ec): this is ADAM's outbound
+  // lane — a non-Adam session running it silently applies Adam's routing defaults (the mirror
+  // of Adam running solomon-advisory.cjs, the incident shape). Hard-error (fail-closed) unless
+  // the invoking session's registered role is adam; covers send + request (relay path included).
+  await assertSenderRole(supabase, { sessionId, requiredRole: 'adam', toolName: 'adam-advisory.cjs' });
+
   // FR-4 relay-class path: eva/ceo have no live session, so a relay-class --to enqueues a
   // tracked FR-1 relay_request via the coordinator queue instead of a direct insert — the
   // coordinator's relay-drain tick (FR-1/FR-2) performs the actual delivery + writes the
@@ -918,6 +926,10 @@ async function main() {
   // byte-identical to before.
   const target = isDirectTarget ? peerArg : defaultTarget;
   const via = isDirectTarget ? 'direct' : defaultVia;
+  // QF-20260719-387: read back the resolved target's registered role and hard-error on a
+  // recipient-class mismatch (--to solomon -> role=solomon; default -> the active coordinator).
+  // An R1 direct raw-session target has no recipient class (expectedRole null -> print-only).
+  await assertTargetRole(supabase, { target, expectedRole: isDirectTarget ? null : (toSolomon ? 'solomon' : 'coordinator') });
   const addressee = peerArg || 'coordinator';
   const senderCallsign = await snapshotSender(supabase, sessionId);
 

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -50,6 +50,8 @@ const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.c
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
+// QF-20260719-387: fail-closed sender-role guard + target-role assert at the send/request chokes.
+const { assertSenderRole, assertTargetRole } = require('../lib/coordinator/role-comms-guard.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
@@ -727,6 +729,12 @@ async function main() {
     process.exit(3);
   }
 
+  // QF-20260719-387 (chairman-directed after live misroute d442d8ec): this is SOLOMON's outbound
+  // lane — a non-Solomon session running it silently applies Solomon's routing defaults, so an
+  // Adam->Solomon proposal landed on the coordinator lane. Hard-error (fail-closed) unless the
+  // invoking session's registered role is solomon; covers send + request (relay path included).
+  await assertSenderRole(supabase, { sessionId, requiredRole: 'solomon', toolName: 'solomon-advisory.cjs' });
+
   // FR-4 relay-class path: eva/ceo have no live session, so a relay-class --to enqueues a
   // tracked FR-1 relay_request via the coordinator queue instead of a direct insert — the
   // coordinator's relay-drain tick (FR-1/FR-2) performs the actual delivery + writes the
@@ -753,6 +761,9 @@ async function main() {
   const toAdam = peerArg === 'adam';
   const adamId = toAdam && twoWayV1On ? await getActiveAdamId(supabase).catch(() => null) : null;
   const { target, via } = resolveSolomonAdvisoryTarget({ toAdam, flagOn: twoWayV1On, coordinatorId, adamId });
+  // QF-20260719-387: read back the resolved target's registered role and hard-error on a
+  // recipient-class mismatch (--to adam -> role=adam; default -> the active coordinator).
+  await assertTargetRole(supabase, { target, expectedRole: toAdam ? 'adam' : 'coordinator' });
   const senderCallsign = await snapshotSender(supabase, sessionId);
   const correlationId = crypto.randomUUID();
   const expectsReply = mode === 'request';


### PR DESCRIPTION
## Summary
Chairman-directed after live misroute d442d8ec (Adam ran `solomon-advisory.cjs send` from the Adam session — an Adam→Solomon proposal silently applied Solomon's routing defaults and landed on the coordinator lane; the chairman's verbal directive: *'Solomon has very different characteristics than the coordinator… whatever it takes, make sure that distinction is clear.'*).

New `lib/coordinator/role-comms-guard.cjs`, wired into the `send`+`request` chokes of **both** `adam-advisory.cjs` and `solomon-advisory.cjs` (relay path included):
- **Sender-role guard** — the invoking session's registered role must match the tool's owner role (solomon-advisory ⇒ `solomon`, adam-advisory ⇒ `adam`); the hard-error names the correct tool for the caller's actual role.
- **Target-role assert** — after target resolution, the target's role is read back and must match the intended recipient class; every successful send prints `target-role verified: <role> <session>`. Broadcast sentinels are reported as buffered; R1 direct raw-session targets stay print-only (no class constraint, by design).
- **Fail-closed** (exit 4) on role-resolution errors for classed sends.
- Coordinator class derives from `metadata.is_coordinator` when `role` is absent — that is the actual election discriminator (`resolve.cjs`), and the live coordinator row verifiably carries `is_coordinator` with no `role`; a strict role read would have false-blocked the entire default relay lane.

## Testing
- 15 new unit tests (mocked supabase + exit-trapping) covering the incident shape, fail-closed paths, sentinel/direct-target handling, and the is_coordinator lapse shape; 54/54 across guard + existing advisory suites.
- Live UAT: running `solomon-advisory.cjs send` from a worker session now refuses: `[ROLE_GUARD] solomon-advisory.cjs is the solomon outbound lane… Use scripts/worker-signal.cjs`.

Note: 153 source LOC vs the 75 Tier-2 cap — chairman-directed scope spans a shared lib + two script chokes; completion will use the audited force path with this justification.

Closes QF-20260719-387 (coordinator-sourced, chairman-directed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)