### PR TITLE
fix(QF-20260719-144): idle.cjs: fix tier-misattribution in idle message (blames tier without checking cause)

### DIFF
--- a/lib/checkin/steps/idle.cjs
+++ b/lib/checkin/steps/idle.cjs
@@ -1,8 +1,33 @@
 // Extracted VERBATIM from scripts/worker-checkin.cjs resolveCheckin (rung 7: tier note +
 // adaptive cadence + final idle return) — SD-ARCH-HOTSPOT-CHECKIN-001. This step ALWAYS
 // returns. Only edits: locals -> ctx.* + helper destructuring.
+const TIER_FAMILY_AXES = new Set([
+  'above_worker_tier', 'tier_stamp_missing', 'fable_window_downward_claim_blocked', 'reserved_no_lower_backlog',
+]);
+// QF-20260719-144: format the idle "nothing claimable" note from the ACTUAL per-item ineligibility
+// breakdown (belt_ineligibility_breakdown, tallied in merged-pool-self-claim via
+// classifyDispatchIneligibility). The prior code blamed TIER whenever tiering was active, but the tier
+// axis is near-LAST in precedence — a 0-claimable belt is usually orchestrator-parent / human-action /
+// test-fixture / held, NOT a tier deficit. Blame the rung ONLY for items actually in the tier family.
+// Fail-open: absent breakdown keeps the prior tiering-aware wording.
+function formatIdleIneligibilityNote(rankedAgnostic, claimableAtTier, breakdown, tieringActive) {
+  if (!(rankedAgnostic > 0 && claimableAtTier === 0)) return '';
+  const entries = breakdown && typeof breakdown === 'object' ? Object.entries(breakdown) : [];
+  if (!entries.length) {
+    return tieringActive === true
+      ? ` (${rankedAgnostic} ranked, but 0 claimable at your tier — all above your rung; a higher-tier worker must take them.)`
+      : ` (${rankedAgnostic} ranked, but 0 claimable by any worker — orchestrator parents / clone build-trees / human-action / held, not tier-blocked.)`;
+  }
+  const tierCount = entries.filter(([r]) => TIER_FAMILY_AXES.has(r)).reduce((n, [, c]) => n + c, 0);
+  const parts = entries.slice().sort((a, b) => b[1] - a[1]).map(([r, c]) => `${c}x ${r}`).join(', ');
+  return tierCount > 0
+    ? ` (${rankedAgnostic} ranked, 0 claimable to you: ${parts}; ${tierCount} above your rung — a higher-tier worker must take those.)`
+    : ` (${rankedAgnostic} ranked, 0 claimable to you but NONE tier-blocked: ${parts} — a higher-tier worker could not take them either.)`;
+}
+
 module.exports = {
   name: 'idle',
+  formatIdleIneligibilityNote,
   async run(ctx) {
     const { sb, sessionId } = ctx;
     const { getCommsActivitySignals, computeAdaptiveCadence, DEFAULT_IDLE_WAKEUP_SECONDS } = ctx.helpers;
@@ -12,15 +37,12 @@ module.exports = {
     // "work exists for me" and the idle looks like a bug rather than a tier deficit.
     const rankedAgnostic = ctx.base.belt_ranked_claimable ?? 0;
     const claimableAtTier = ctx.base.belt_claimable_at_my_tier ?? rankedAgnostic;
-    // QF-20260630-761: only blame TIER when tiering is actually active. When tiering is OFF (degrade-to-1,
-    // <2 live workers) the tier axis is inert, so a 0-claimable belt with ranked>0 means the ranked items
-    // are ineligible for NON-tier reasons (orchestrator parents / clone build-trees / human-action / held)
-    // — a higher-tier worker could not take them either. Attributing it to "your rung" misdirects.
-    const tierNote = (rankedAgnostic > 0 && claimableAtTier === 0)
-      ? (ctx.base.belt_tiering_active === true
-          ? ` (${rankedAgnostic} ranked, but 0 claimable at your tier — all above your rung; a higher-tier worker must take them.)`
-          : ` (${rankedAgnostic} ranked, but 0 claimable by any worker — they are orchestrator parents / clone build-trees / human-action / held, not tier-blocked.)`)
-      : '';
+    // QF-20260719-144 (supersedes QF-20260630-761's tiering-flag heuristic): derive the idle note from
+    // the ACTUAL per-item ineligibility breakdown (tallied upstream via classifyDispatchIneligibility),
+    // so the message names the real blockers (human-action / orchestrator / test-fixture / held / tier)
+    // instead of blaming "your rung" whenever tiering happens to be active.
+    const tierNote = formatIdleIneligibilityNote(
+      rankedAgnostic, claimableAtTier, ctx.base.belt_ineligibility_breakdown, ctx.base.belt_tiering_active);
     // SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001 (FR-6): opt-in tightening. A worker
     // idling on the belt but awaiting a reply on a live comms thread (e.g. a blocked-item question
     // to the coordinator) shouldn't wait a full baseline interval to notice the reply. ADDITIVE

--- a/lib/checkin/steps/merged-pool-self-claim.cjs
+++ b/lib/checkin/steps/merged-pool-self-claim.cjs
@@ -177,6 +177,18 @@ module.exports = {
           tieringActive: tierCtx.tiering_active === true,
           cwd: process.cwd(),
         }).length;
+        // QF-20260719-144: tally the REAL ineligibility reason per pooled row so idle.cjs can name the
+        // actual blockers instead of blaming TIER whenever tiering is active. classifyDispatchIneligibility
+        // is the SSOT and its tier axis is near-LAST in precedence, so an orchestrator / human-action /
+        // test-fixture row classifies as THAT — never as tier. Eligible rows return null (skipped). Pure/
+        // sync/DB-free tally over the already-fetched pool; the surrounding try keeps it fail-open.
+        const { classifyDispatchIneligibility } = require('../../fleet/claim-eligibility.cjs');
+        const ineligBreakdown = {};
+        for (const r of pool) {
+          const reason = classifyDispatchIneligibility(r, tierCtx);
+          if (reason) ineligBreakdown[reason] = (ineligBreakdown[reason] || 0) + 1;
+        }
+        ctx.base.belt_ineligibility_breakdown = ineligBreakdown;
         // SD-LEO-INFRA-WORK-CLASS-CLAIM-001 (C-STARVE observability): fenced-away items are
         // never silent — surface which ranked SDs this restricted session skipped and why,
         // mirroring reservation_fences_skipped. Empty/no-op for unrestricted sessions.

--- a/tests/unit/checkin-idle-ineligibility-note.test.js
+++ b/tests/unit/checkin-idle-ineligibility-note.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { formatIdleIneligibilityNote } from '../../lib/checkin/steps/idle.cjs';
+
+// QF-20260719-144: the idle "nothing claimable" note must report the ACTUAL ineligibility
+// breakdown (from classifyDispatchIneligibility), not blame TIER whenever tiering is active.
+// Regression: a worker saw "0 claimable at your tier — all above your rung" while the ground
+// truth was 12x human_action_required / 5x orchestrator_parent / 1x test_fixture_key, 0 tier.
+
+describe('formatIdleIneligibilityNote (QF-20260719-144)', () => {
+  it('names real non-tier blockers instead of blaming the rung', () => {
+    const note = formatIdleIneligibilityNote(18, 0,
+      { human_action_required: 12, orchestrator_parent: 5, test_fixture_key: 1 }, true);
+    expect(note).toContain('NONE tier-blocked');
+    expect(note).toContain('12x human_action_required');
+    expect(note).toContain('5x orchestrator_parent');
+    expect(note).not.toContain('above your rung');
+  });
+
+  it('blames the rung ONLY for items actually in the tier family', () => {
+    const note = formatIdleIneligibilityNote(4, 0,
+      { above_worker_tier: 3, human_action_required: 1 }, true);
+    expect(note).toContain('3 above your rung');
+    expect(note).toContain('1x human_action_required');
+  });
+
+  it('falls back to the prior tiering-aware wording when no breakdown is available', () => {
+    expect(formatIdleIneligibilityNote(5, 0, null, true)).toContain('all above your rung');
+    expect(formatIdleIneligibilityNote(5, 0, undefined, false)).toContain('0 claimable by any worker');
+  });
+
+  it('returns empty when work IS claimable at this tier (or nothing is ranked)', () => {
+    expect(formatIdleIneligibilityNote(5, 2, { orchestrator_parent: 3 }, true)).toBe('');
+    expect(formatIdleIneligibilityNote(0, 0, {}, true)).toBe('');
+  });
+
+  it('sorts reasons by descending count (dominant blocker first)', () => {
+    const note = formatIdleIneligibilityNote(10, 0,
+      { needs_coordinator_review: 2, human_action_required: 8 }, true);
+    expect(note.indexOf('8x human_action_required')).toBeLessThan(note.indexOf('2x needs_coordinator_review'));
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260719-144

**Type:** bug
**Severity:** medium

### Issue Description
Worker signal db0318da (Alpha): lib/checkin/steps/idle.cjs:21 reports '0 claimable at your tier — all above your rung' whenever belt_tiering_active=true AND claimable=0, without verifying tier was the cause. Ground truth via classifyDispatchIneligibility: 0 of 18 unclaimed workable SDs are tier-blocked (12x human_action_required, 5x orchestrator_parent, 1x test_fixture_key); same worker saw claimable=0 with tiering_active=false. Fix: derive the idle-reason breakdown from classifyDispatchIneligibility and report actual causes. Sourced by coordinator 185c0ecf from worker harness-bug signal.


### Expected Behavior
Idle message reports the real ineligibility breakdown (human-action/orchestrator/test-fixture/tier)

### Actual Behavior
Idle message asserts tier-blocking that is not the actual cause

### Changes
- **Files Changed:** 3
  - lib/checkin/steps/idle.cjs
  - lib/checkin/steps/merged-pool-self-claim.cjs
  - tests/unit/checkin-idle-ineligibility-note.test.js
- **LOC:** 98 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Backend checkin-message logic fix (lib/checkin/steps). No UI/UAT surface; verified by 5 scoped unit tests in checkin-idle-ineligibility-note.test.js (all green) + module-load sample matching the sourcing ground-truth breakdown. Worktree based on origin/main (shared root was 571 behind).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol