### PR TITLE
fix(QF-20260719-702): add 'closed' to remaining hardcoded QF terminal-status lists

### DIFF
--- a/lib/checkin/steps/directed-assignment.cjs
+++ b/lib/checkin/steps/directed-assignment.cjs
@@ -85,7 +85,7 @@ module.exports = {
               .select('status, not_before').eq('id', sdKey).maybeSingle();
             if (qfErr) {
               assignedSdFetchFailed = true;
-            } else if (qfRow && ['completed', 'cancelled', 'escalated'].includes(qfRow.status)) {
+            } else if (qfRow && ['completed', 'cancelled', 'escalated', 'closed'].includes(qfRow.status)) { // QF-20260719-702
               terminalStatus = qfRow.status;
             } else {
               const nb = qfRow && qfRow.not_before ? Date.parse(qfRow.not_before) : NaN;

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -182,7 +182,9 @@ async function assertValidTarget(supabase, target, logger = console) {
 // dispatches one only creates a WORK_ASSIGNMENT the worker's claim_sd will bounce ('sd_terminal_status')
 // — a wasted dispatch + a confusing worker error. Refusing at the dispatch choke point closes that gap.
 const TERMINAL_SD_STATUSES = Object.freeze(new Set(['completed', 'cancelled', 'deferred']));
-const TERMINAL_QF_STATUSES = Object.freeze(new Set(['completed', 'cancelled', 'escalated']));
+// QF-20260719-702: 'closed' added — same missing-terminal-status gap class as
+// lib/checkin/steps/resume.cjs:62 (QF-20260719-406).
+const TERMINAL_QF_STATUSES = Object.freeze(new Set(['completed', 'cancelled', 'escalated', 'closed']));
 
 /** Pure: is an SD status terminal (un-dispatchable)? */
 function isTerminalSdStatus(status) {

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1047,7 +1047,7 @@ async function clearStaleQfClaims(supabase, now, actions, warnings) {
     const { data: terminalClaimed } = await supabase
       .from('quick_fixes')
       .select('id, status, claiming_session_id')
-      .in('status', ['completed', 'cancelled', 'escalated'])
+      .in('status', ['completed', 'cancelled', 'escalated', 'closed']) // QF-20260719-702
       .not('claiming_session_id', 'is', null);
     for (const qf of (terminalClaimed || [])) {
       const { error } = await supabase
@@ -2815,7 +2815,8 @@ async function main() {
   // preserves audit + the row's expires_at), NOT a hard-DELETE. Only drain rows older than one
   // sweep interval (assignment-age floor) so a transient terminal read can't drop a mid-transition
   // in-flight assignment. Terminal sets BRANCH by target shape: SD → {completed,cancelled,deferred};
-  // QF → {completed,cancelled,escalated} (escalated is QF-only; deferred is SD-only). Fail-open.
+  // QF → {completed,cancelled,escalated,closed} (escalated/closed are QF-only; deferred is SD-only;
+  // 'closed' added by QF-20260719-702). Fail-open.
   // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): the drain is a
   // WORK_ASSIGNMENT-table coordinator mutation — skip it when not the canonical coordinator.
   if (!_coordMutationAllowed) {
@@ -2840,7 +2841,7 @@ async function main() {
     }
     if (qfAssignTargets.length > 0) {
       const { data: qfRows2 } = await supabase.from('quick_fixes').select('id, status').in('id', qfAssignTargets);
-      (qfRows2 || []).forEach(r => { if (['completed', 'cancelled', 'escalated'].includes(r.status)) terminalTargetSet.add(r.id); });
+      (qfRows2 || []).forEach(r => { if (['completed', 'cancelled', 'escalated', 'closed'].includes(r.status)) terminalTargetSet.add(r.id); });
     }
     const drainIds = (openAssignments || []).filter(a => terminalTargetSet.has(a.target_sd)).map(a => a.id);
     for (let i = 0; i < drainIds.length; i += 50) {

--- a/tests/unit/coordinator-dispatch-terminal-guard.test.js
+++ b/tests/unit/coordinator-dispatch-terminal-guard.test.js
@@ -50,8 +50,8 @@ describe('pure terminal-status classifiers', () => {
     for (const s of ['completed', 'cancelled', 'deferred', 'COMPLETED']) expect(isTerminalSdStatus(s)).toBe(true);
     for (const s of ['draft', 'active', 'in_progress', 'pending_approval', '', null, undefined]) expect(isTerminalSdStatus(s)).toBe(false);
   });
-  it('QF terminal set = completed/cancelled/escalated', () => {
-    for (const s of ['completed', 'cancelled', 'escalated']) expect(isTerminalQfStatus(s)).toBe(true);
+  it('QF terminal set = completed/cancelled/escalated/closed', () => {
+    for (const s of ['completed', 'cancelled', 'escalated', 'closed']) expect(isTerminalQfStatus(s)).toBe(true);
     for (const s of ['open', 'in_progress', null]) expect(isTerminalQfStatus(s)).toBe(false);
   });
 });

--- a/tests/unit/scripts/sweep-residuals.test.js
+++ b/tests/unit/scripts/sweep-residuals.test.js
@@ -33,7 +33,7 @@ describe('FR-1: terminal-target WORK_ASSIGNMENT drain', () => {
   });
   it('branches the terminal set by target shape (SD vs QF)', () => {
     expect(fr1).toMatch(/sdAssignTargets[\s\S]*\['completed', 'cancelled', 'deferred'\]/); // SD: deferred, not escalated
-    expect(fr1).toMatch(/qfAssignTargets[\s\S]*\['completed', 'cancelled', 'escalated'\]/); // QF: escalated, not deferred
+    expect(fr1).toMatch(/qfAssignTargets[\s\S]*\['completed', 'cancelled', 'escalated', 'closed'\]/); // QF: escalated+closed, not deferred
   });
   it('keys on the target_sd column and applies an assignment-age floor', () => {
     expect(fr1).toMatch(/message_type', 'WORK_ASSIGNMENT'/);

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -156,7 +156,7 @@ describe('QF-20260525-211 (early-exit gap): QF claim clear runs before the early
   it('QF-20260711-176: terminal QFs are cleared unconditionally (no legitimate holder)', () => {
     const idx = src.indexOf('async function clearStaleQfClaims');
     const fn = src.slice(idx, idx + 3600);
-    expect(fn).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]completed['"]\s*,\s*['"]cancelled['"]\s*,\s*['"]escalated['"]\s*\]/);
+    expect(fn).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]completed['"]\s*,\s*['"]cancelled['"]\s*,\s*['"]escalated['"]\s*,\s*['"]closed['"]\s*\]/);
     expect(fn).toMatch(/TERMINAL/);
   });
 });


### PR DESCRIPTION
## Summary
- Same gap class as QF-20260719-406 (`lib/checkin/steps/resume.cjs:62`): `'closed'` was missing from three sibling hardcoded QF terminal-status lists.
- `lib/coordinator/dispatch.cjs`: `TERMINAL_QF_STATUSES` (the dispatch choke point) now refuses a closed QF.
- `scripts/stale-session-sweep.cjs`: both the stale-claim-clear query and the WORK_ASSIGNMENT terminal-drain now recognize `closed` as terminal.
- `lib/checkin/steps/directed-assignment.cjs`: a directed assignment to a closed QF now takes the terminal/stale_assignment_purged branch instead of re-offering it.
- Swept the codebase for the `['completed', 'cancelled', 'escalated']` pattern; `resume.cjs` and `scripts/qf-link-resolution.mjs` already included `'closed'`. 6 total call sites (>3) so left inline per existing precedent rather than extracting a shared constant.
- **Not in scope**: `claim_sd`'s own SQL terminal-guard (in a DB migration) has the same gap — fixing it requires a new migration, which CLAUDE.md's routing rules force to Tier 3 (full SD), not a QF. Flagging as a follow-up rather than bundling here.

## Test plan
- [x] `npx vitest run tests/unit/coordinator-dispatch-terminal-guard.test.js tests/unit/scripts/sweep-residuals.test.js` — 28/28 pass (updated assertions for the new list).
- [x] `npx vitest run tests/unit/checkin-pipeline.test.js tests/unit/worker-checkin-qf-directed-dispatch-and-severity.test.js tests/unit/worker-checkin-assignment-surfacing.test.js tests/unit/worker-checkin-own-claim-detect.test.js` — 69/69 pass (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)