### PR TITLE
fix(quiet-tick): emit cross_party_ping row from the tick, not the agent (QF-20260719-138)

### DIFF
--- a/lib/coordinator/cross-party-ping.cjs
+++ b/lib/coordinator/cross-party-ping.cjs
@@ -1,0 +1,52 @@
+'use strict';
+
+// QF-20260719-138: emit the mechanical cross-party ping row directly from the quiet-tick
+// scripts instead of instructing the agent to hand-insert a byte-identical row every tick.
+// The coordinator hand-running the same insert each tick tripped the RCA tiered-enforcement
+// 3x-same-target guard — a mechanical, byte-identical insert is a script's job, not an agent's.
+// payload.kind='cross_party_ping' is an EXCLUDED_KIND (excluded from the Adam advisory drain),
+// so a coordinator->adam ping passes the dispatch Adam-inbox-kind guard. Fail-soft: any
+// resolve/insert error is logged and swallowed so a quiet tick never throws on a ping.
+
+const { getActiveCoordinatorId } = require('./resolve.cjs');
+const { getActiveAdamId } = require('./adam-identity.cjs');
+const { insertCoordinationRow } = require('./dispatch.cjs');
+
+/**
+ * Emit a coordinator<->adam cross-party ping row for a real salient-state delta.
+ * @param {object} sb - Supabase client
+ * @param {{ from: 'coordinator'|'adam', fields: string[] }} opts - sender role + the changed fields
+ * @returns {Promise<boolean>} true if a ping row was inserted, false if skipped/failed (fail-soft)
+ */
+async function emitCrossPartyPing(sb, { from, fields }) {
+  try {
+    const [coordinatorId, adamId] = await Promise.all([
+      getActiveCoordinatorId(sb),
+      getActiveAdamId(sb, {}),
+    ]);
+    const sender = from === 'adam' ? adamId : coordinatorId;
+    const target = from === 'adam' ? coordinatorId : adamId;
+    if (!sender || !target) return false; // can't resolve both live parties — skip (fail-soft)
+    const to = from === 'adam' ? 'coordinator' : 'adam';
+    const now = new Date().toISOString();
+    await insertCoordinationRow(sb, {
+      sender_session: sender,
+      target_session: target,
+      message_type: 'INFO',
+      subject: `cross-party ping ${from}->${to} — salient delta: ${fields.join(',')}`,
+      payload: {
+        kind: 'cross_party_ping',
+        reason: fields,
+        body: `${from} salient-state delta (${fields.join(',')}) — mechanical cross-party ping; awareness only, no action required.`,
+        sent_at: now,
+      },
+      created_at: now,
+    });
+    return true;
+  } catch (e) {
+    console.error(`QUIET_TICK_PING_ERROR=${from} ${e && e.message ? e.message : e}`);
+    return false;
+  }
+}
+
+module.exports = { emitCrossPartyPing };

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -37,6 +37,9 @@ const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/
 const { getAccountIdentity, detectAccountSwitch } = require('../lib/fleet/account-identity.cjs');
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+// QF-20260719-138: emit the mechanical cross-party ping stub ourselves (mirror of
+// coordinator-quiet-tick.mjs) rather than instructing the agent to hand-insert it each tick.
+const { emitCrossPartyPing } = require('../lib/coordinator/cross-party-ping.cjs');
 
 const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -430,6 +433,10 @@ async function main() {
     nextWakeSeconds: delaySeconds,
   };
 
+  // QF-20260719-138: a real salient delta emits the mechanical cross_party_ping stub HERE
+  // (side-effect in both --json and human modes); the console line below is a record-of-sent.
+  const pingSent = delta.changed ? await emitCrossPartyPing(sb, { from: 'adam', fields: delta.fields }) : false;
+
   if (asJson) {
     console.log(JSON.stringify(result));
   } else {
@@ -445,7 +452,7 @@ async function main() {
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
     if (delta.changed) {
-      console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing; if sending a subject-only stub ping, stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
+      console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} sent=${pingSent} (mechanical cross_party_ping stub emitted by the tick — record of sent, not an instruction; author substantive help/sourcing separately only if warranted)`);
     }
     if (acctSwitch.changed) {
       const noticeStatus = acctNotified

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -32,6 +32,9 @@ const { createClient } = require('@supabase/supabase-js');
 const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+// QF-20260719-138: emit the cross-party ping row ourselves (mechanical, byte-identical) rather
+// than instructing the coordinator to hand-insert it every tick (that tripped the RCA 3x guard).
+const { emitCrossPartyPing } = require('../lib/coordinator/cross-party-ping.cjs');
 const { DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 // SD-LEO-INFRA-FLEET-ACCOUNT-IDENTITY-001 (FR-2): surface which Claude account this fleet is
 // running under in the tick's status line.
@@ -283,6 +286,10 @@ async function main() {
     nextWakeSeconds: delaySeconds,
   };
 
+  // QF-20260719-138: a real salient delta emits the cross_party_ping row HERE (side-effect in
+  // both --json and human modes); the console line below is a record-of-sent, not an instruction.
+  const pingSent = delta.changed ? await emitCrossPartyPing(sb, { from: 'coordinator', fields: delta.fields }) : false;
+
   if (asJson) {
     console.log(JSON.stringify(result));
   } else {
@@ -294,7 +301,7 @@ async function main() {
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
     if (delta.changed) {
-      console.log(`QUIET_TICK_PING=coordinator->adam reason=${delta.fields.join(',')} (real delta — emit a prompt cross-party ping; stamp payload.kind='cross_party_ping' per SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-5 — mechanical, never authored)`);
+      console.log(`QUIET_TICK_PING=coordinator->adam reason=${delta.fields.join(',')} sent=${pingSent} (cross_party_ping row emitted by the tick — record of sent, not an instruction)`);
     }
   }
   return result;


### PR DESCRIPTION
## QF-20260719-138

**Problem:** `coordinator-quiet-tick.mjs` (and `adam-quiet-tick.mjs`) printed `QUIET_TICK_PING=...` **instructing** the coordinator/Adam agent to hand-insert a byte-identical `cross_party_ping` row on every salient-delta tick. A mechanical, byte-identical insert repeated each tick tripped the RCA tiered-enforcement **3×-same-target guard** (`Bash:f0593c1e46d85f66` blocked 12:14Z). Sourced by coordinator `185c0ecf` (self-observed friction).

**Fix:** both ticks now emit the stub **themselves** via a shared `lib/coordinator/cross-party-ping.cjs` helper, and print `QUIET_TICK_PING` as a *record-of-sent*, not an instruction. The coordinator turn stays a pure NO-OP on ping ticks.

- `payload.kind='cross_party_ping'` is an `EXCLUDED_KIND` (excluded from the Adam advisory drain), so the coordinator→adam send passes the dispatch Adam-inbox-kind guard.
- Direction-parameterized (`from: 'coordinator' | 'adam'`) so both files share one tested code path (keeps token/loop parity).
- **Fail-soft:** any party-resolution/insert error is logged (`QUIET_TICK_PING_ERROR`) and swallowed — a quiet tick never throws on a ping.
- Adam's record-of-sent preserves the separate agent judgment to author substantive help/sourcing only when warranted (the mechanical stub ≠ the help-offer).

## Verification
- `node --check` + dynamic import (all `require` paths resolve; `main()` stays guarded — no DB side effects on import).
- Functional test via mocked deps: coordinator→adam and adam→coordinator directions correct, `kind=cross_party_ping`, fail-soft skip returns `false` when a party can't be resolved.
- Targeted unit tests green (80 tests / 7 files): quiet-tick token-parity lint, loop-parity, pure quiet-tick logic, coordinator directive-wake, adam reconcile / venture-stall / inbox-surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)