### PR TITLE
fix(QF-20260719-275): gantt-renderer title overflow + progress_pct rung-gauge bug

### DIFF
--- a/lib/chairman/daily-review/gantt-renderer.js
+++ b/lib/chairman/daily-review/gantt-renderer.js
@@ -15,15 +15,38 @@ const BAR_X = 220;
 const BAR_MAX_WIDTH = 380;
 const TOP_MARGIN = 30;
 const BOTTOM_MARGIN = 20;
+// QF-20260719-275: long titles at x=10 overflowed under the bar area into the right-edge pct
+// labels. Column is [10, BAR_X-10]; at font-size 14 sans-serif (~7.5px/char) that's ~26 chars.
+const TITLE_MAX_CHARS = 24;
 
 function escapeXml(text) {
   return String(text ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[c]));
 }
 
+function truncateTitle(title) {
+  const s = String(title ?? '');
+  return s.length > TITLE_MAX_CHARS ? s.slice(0, TITLE_MAX_CHARS - 1) + '…' : s;
+}
+
+// QF-20260719-275 (Solomon correction 08bde2ed): roadmap_waves.progress_pct is one shared V1
+// rung gauge repeated across every wave, not a per-wave value — rendering bars from it made
+// W0-W2 show an identical 71% and W5 show 0% while 78/213 items were actually complete. Child
+// A's per-wave item_counts {total, promoted} are the real per-wave signal; fall back to
+// progress_pct only when item_counts is absent (older/malformed wave shape).
+function computeWavePct(wave) {
+  const counts = wave.item_counts;
+  if (counts && Number.isFinite(counts.total) && counts.total > 0) {
+    const promoted = Number(counts.promoted) || 0;
+    return Math.max(0, Math.min(100, Math.round((promoted / counts.total) * 100)));
+  }
+  return Math.max(0, Math.min(100, Number(wave.progress_pct) || 0));
+}
+
 /**
  * Pure function: builds a well-formed SVG string for a Gantt-style bar chart, one row per
- * wave, bar width scaled by progress_pct. No I/O, no external assets/fonts, no network call.
- * @param {Array<{wave_id?:string, title:string, status?:string, progress_pct?:number|null}>} waves
+ * wave, bar width scaled by per-wave item_counts (falls back to progress_pct when absent). No
+ * I/O, no external assets/fonts, no network call.
+ * @param {Array<{wave_id?:string, title:string, status?:string, progress_pct?:number|null, item_counts?:{total:number,promoted:number}}>} waves
  * @returns {string} SVG markup
  */
 export function buildGanttSvg(waves) {
@@ -32,9 +55,9 @@ export function buildGanttSvg(waves) {
 
   const bars = rows.map((wave, i) => {
     const y = TOP_MARGIN + i * ROW_HEIGHT;
-    const pct = Math.max(0, Math.min(100, Number(wave.progress_pct) || 0));
+    const pct = computeWavePct(wave);
     const barWidth = (pct / 100) * BAR_MAX_WIDTH;
-    const label = escapeXml(wave.title || `Wave ${i + 1}`);
+    const label = escapeXml(truncateTitle(wave.title || `Wave ${i + 1}`));
     return [
       `<text x="10" y="${y + 20}" font-family="sans-serif" font-size="14" fill="#222">${label}</text>`,
       `<rect x="${BAR_X}" y="${y + 8}" width="${BAR_MAX_WIDTH}" height="18" fill="#e0e0e0" />`,

--- a/tests/unit/chairman/daily-review-gantt-renderer.test.js
+++ b/tests/unit/chairman/daily-review-gantt-renderer.test.js
@@ -13,7 +13,7 @@ const waves = [
 ];
 
 describe('buildGanttSvg (FR-1)', () => {
-  it('returns well-formed SVG containing each wave title', () => {
+  it('returns well-formed SVG containing each wave title (falls back to progress_pct when item_counts absent)', () => {
     const svg = buildGanttSvg(waves);
     expect(svg.startsWith('<svg')).toBe(true);
     expect(svg).toContain('Wave 1: Foundation');
@@ -32,6 +32,39 @@ describe('buildGanttSvg (FR-1)', () => {
     const svg = buildGanttSvg([{ title: 'A & B <script>', progress_pct: 50 }]);
     expect(svg).not.toContain('<script>');
     expect(svg).toContain('&amp;');
+  });
+
+  // QF-20260719-275: progress_pct is one shared V1 rung gauge repeated across every wave —
+  // bars must derive from per-wave item_counts instead, so distinct waves render distinct pcts.
+  it('derives bar pct from item_counts, not the shared progress_pct, when item_counts is present', () => {
+    const svg = buildGanttSvg([
+      { title: 'W0', progress_pct: 71, item_counts: { total: 10, promoted: 10 } },
+      { title: 'W2', progress_pct: 71, item_counts: { total: 10, promoted: 3 } },
+      { title: 'W5', progress_pct: 0, item_counts: { total: 213, promoted: 78 } },
+    ]);
+    expect(svg).toContain('100%');
+    expect(svg).toContain('30%');
+    expect(svg).toContain('37%'); // 78/213 rounds to 37%, not the stale shared 0%
+    expect(svg).not.toContain('>0%<');
+  });
+
+  it('treats item_counts.total === 0 as no signal and falls back to progress_pct', () => {
+    const svg = buildGanttSvg([{ title: 'Empty wave', progress_pct: 45, item_counts: { total: 0, promoted: 0 } }]);
+    expect(svg).toContain('45%');
+  });
+
+  // QF-20260719-275: long titles overflowed under the bar area into the right-edge pct labels.
+  it('truncates long titles with an ellipsis so they never collide with the pct label column', () => {
+    const longTitle = 'A very long wave title that would otherwise overflow the label column';
+    const svg = buildGanttSvg([{ title: longTitle, progress_pct: 50 }]);
+    expect(svg).not.toContain(longTitle);
+    expect(svg).toContain('…');
+  });
+
+  it('leaves short titles untouched', () => {
+    const svg = buildGanttSvg([{ title: 'Short', progress_pct: 50 }]);
+    expect(svg).toContain('>Short<');
+    expect(svg).not.toContain('…');
   });
 });
 


### PR DESCRIPTION
## Summary
- Live render 2026-07-19 (chairman sample, Drive `17L-F870EfkexH_HU4zuMM55DFDl1zpBS`) surfaced two chairman-facing daily defects in `lib/chairman/daily-review/gantt-renderer.js` (child D, the Gantt chart in the required daily-review MMS).
- **Layout**: long wave titles at x=10 overflowed under the bar area into the right-edge pct labels ('e7r1ev', 're0%', 'd20%' overlap artifacts). Titles now truncate to 24 chars + ellipsis, sized to comfortably fit the `[10, BAR_X-10]` column at 14px sans-serif.
- **Semantics** (Solomon correction 08bde2ed): bars scaled by `roadmap_waves.progress_pct`, but that field is one shared V1 rung gauge repeated across every wave — W0-W2 all showed an identical 71% and W5 showed 0% while 78/213 items were actually complete. Bars now derive pct from Child A's per-wave `item_counts {total, promoted}` (falls back to `progress_pct` only when `item_counts` is absent or `total === 0`).

## Test plan
- [x] `npx vitest run tests/unit/chairman/daily-review-gantt-renderer.test.js` — 9/9 pass, including 4 new tests (item_counts-derived pct differs per-wave, total===0 fallback, title truncation, short-title passthrough).
- [x] `npx vitest run tests/unit/chairman/daily-review-roadmap-status-doc.test.js` — 11/11 pass (no regression).
- [x] Manually rendered a sample SVG with the reported live scenario (W0-W2 with distinct item_counts + a long W5 title) — confirmed titles truncate correctly and W5 now shows 37% instead of the stale shared 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)