### PR TITLE
fix(QF-20260719-986): widen ship-witness grace window 5→15 min (merge-wave false trips)

### DIFF
--- a/lib/ship/witness-adoption.mjs
+++ b/lib/ship/witness-adoption.mjs
@@ -67,7 +67,12 @@ export function classifyMerges(merges, telemetryRows) {
 // false-tripped (evidence 2026-07-04: tripped twice, both times the unwitnessed array read []
 // on immediate re-query). Excludes merges younger than graceMs from the count/unwitnessed
 // array; `total` stays the full classified count (informational, not grace-filtered).
-export const DEFAULT_GRACE_MS = 5 * 60 * 1000;
+// QF-20260719-986: 5 min proved too tight under merge waves — tripped twice on 2026-07-19
+// (12:07 count=4, 13:04 count=9), both self-clearing on re-run, costing two coordinator
+// investigations. The async witness pipeline (incl. the gauge-runner's own same-pass
+// reconcile sweep) can lag well past 5 min during a wave; 15 min bounds the observed lag
+// class while still catching real gaps within a single gauge cadence.
+export const DEFAULT_GRACE_MS = 15 * 60 * 1000;
 
 /** Pure: WATCH-HOLE detector shaped for gauge-registry's {count,...} convention. */
 export function detectUnwitnessedMerges(merges, telemetryRows, { graceMs = DEFAULT_GRACE_MS, now = Date.now() } = {}) {

--- a/tests/unit/ship/witness-adoption.test.js
+++ b/tests/unit/ship/witness-adoption.test.js
@@ -85,26 +85,27 @@ describe('classifyMerges / detectUnwitnessedMerges (identity matching)', () => {
   });
 });
 
-describe('detectUnwitnessedMerges grace window (QF-20260704-403)', () => {
+describe('detectUnwitnessedMerges grace window (QF-20260704-403, widened by QF-20260719-986)', () => {
   const now = Date.parse('2026-07-04T12:00:00Z');
 
-  it('a merge inside the grace window (< 5 min old) is NOT counted as unwitnessed', () => {
-    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:57:00Z' }]; // 3 min ago
+  it('a merge inside the grace window (< 15 min old) is NOT counted as unwitnessed', () => {
+    // 10 min ago: false-tripped under the old 5-min window (2026-07-19 merge-wave evidence)
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:50:00Z' }];
     const result = detectUnwitnessedMerges(merges, [], { now });
     expect(result.count).toBe(0);
     expect(result.unwitnessed).toEqual([]);
   });
 
   it('a merge older than the grace window IS counted as unwitnessed', () => {
-    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:50:00Z' }]; // 10 min ago
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:40:00Z' }]; // 20 min ago
     const result = detectUnwitnessedMerges(merges, [], { now });
     expect(result.count).toBe(1);
   });
 
   it('total stays the full classified count regardless of the grace window', () => {
     const merges = [
-      { repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:57:00Z' }, // grace-window, excluded from count
-      { repo: 'rickfelix/ehg', prNumber: 2, mergedAt: '2026-07-04T11:50:00Z' }, // older, counted
+      { repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T11:50:00Z' }, // grace-window, excluded from count
+      { repo: 'rickfelix/ehg', prNumber: 2, mergedAt: '2026-07-04T11:40:00Z' }, // older, counted
     ];
     const result = detectUnwitnessedMerges(merges, [], { now });
     expect(result.total).toBe(2);


### PR DESCRIPTION
## Summary
The `ship-witness-unwitnessed-merge` gauge false-tripped twice today (12:07Z count=4, 13:04Z count=9), both times self-clearing on immediate re-run — fresh merges were counted before the async witness pipeline landed rows. The existing 5-minute grace (QF-20260704-403) is too tight during merge waves. This widens `DEFAULT_GRACE_MS` to 15 minutes, which bounds the observed lag class (the gauge-runner's own same-pass reconcile sweep witnesses anything that survives one pass) while still catching real gaps within a single cadence.

## Testing
- Grace-window suite updated: 10-min-old merge (the exact false-trip class) now excluded; 20-min-old still trips; `total` unaffected. 29/29 across witness-adoption + ship-witness-reconcile.

Closes QF-20260719-986 (coordinator-sourced after 2 false investigations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)