### PR TITLE
fix(QF-20260719-509): chairman-sms-gate false success, phantom fallback

### DIFF
--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -11,10 +11,15 @@
  *      A console-authority (spend/irreversible/chairman-only) message routes to the console, never
  *      SMS. If the rubric/gate is unavailable (evaluate throws), a DECISION is FAIL-CLOSED — held
  *      + console-logged, never sent ungated.
+ *   3. TRANSPORT HONESTY (QF-20260719-509, LIVE INCIDENT 2026-07-19) — sent:true is reported ONLY
+ *      when the sender actually delivered/durably-enqueued the message. A soft-failed transport
+ *      (durable table absent, no recipient, etc.) reports sent:false and fires a REAL fallback
+ *      (defaultFallbackSend) — this module previously reported sent:true on a soft-failed
+ *      transport while claiming a fallback had fired that never existed.
  *
- * The Twilio sender, the rubric evaluate(), and the console are all INJECTABLE (opts) so unit
- * tests open zero live Twilio connections. Production wires a real Twilio sender via
- * makeDefaultSender() (a private factory); it is NOT exported.
+ * The Twilio sender, the rubric evaluate(), the console, and the fallback sender are all
+ * INJECTABLE (opts) so unit tests open zero live Twilio/email connections. Production wires a
+ * real Twilio sender via makeDefaultSender() (a private factory); it is NOT exported.
  */
 
 import { evaluate as defaultEvaluate, effectiveType } from '../rubric-engine/index.js';
@@ -36,9 +41,10 @@ function makeDefaultSender() {
     //
     // TRANSPORT fail-SOFT (distinct from the gate's RUBRIC fail-CLOSED): a rubric PASS has already
     // been earned before send() is called; if the durable enqueue is unavailable (the STAGED
-    // sms_outbound_obligations migration is not applied pre-go-live), we DO NOT throw — the existing
-    // chairman EMAIL escalation is the guaranteed live fallback and has already fired. Returns the
-    // enqueue outcome so the caller can log delivered-durably vs deferred-to-email.
+    // sms_outbound_obligations migration is not applied pre-go-live), we DO NOT throw. Returns the
+    // enqueue outcome so sendChairmanSMS (the caller) can report the truth and fire a real
+    // fallback (QF-20260719-509 — this send() previously claimed 'the email fallback has already
+    // fired' when NO fallback existed anywhere in the call path; the caller now owns that).
     async send(message = {}) {
       const recipientPhone = message.recipientPhone || process.env.CHAIRMAN_PHONE || null;
       if (!recipientPhone) {
@@ -70,15 +76,42 @@ function makeDefaultSender() {
 }
 
 /**
+ * Private production fallback (QF-20260719-509, LIVE INCIDENT 2026-07-19): when the durable SMS
+ * transport soft-fails, fire a REAL email alert — the code previously CLAIMED "the existing
+ * chairman EMAIL escalation has already fired" while nothing in the call path ever sent one.
+ * Reuses the same Resend adapter as adam-heartbeat-email.mjs. Never throws (a fallback failure
+ * must not mask the original soft-fail); no-ops when CLAUDE_NOTIFY_EMAIL is unset.
+ */
+async function defaultFallbackSend({ message, reason }) {
+  try {
+    const to = process.env.CLAUDE_NOTIFY_EMAIL;
+    if (!to) return { fired: false, reason: 'no_notify_email' };
+    const mod = await import('../../../notifications/resend-adapter.js');
+    const text = `A chairman-SMS send soft-failed and was NOT delivered.\n\nReason: ${reason}\nKind: ${message.kind || 'n/a'}\n\nOriginal message:\n${message.body || ''}`;
+    await mod.sendEmail({
+      from: 'Adam — LEO Fleet Advisor <onboarding@resend.dev>',
+      to,
+      subject: '[ACTION NEEDED - ADAM] chairman SMS failed to send',
+      html: `<pre>${text}</pre>`,
+      text,
+    });
+    return { fired: true };
+  } catch (err) {
+    return { fired: false, reason: `fallback_error: ${err.message}` };
+  }
+}
+
+/**
  * The sole chairman-SMS send path.
  * @param {object} message - the message (see rubric-engine evaluate() shape)
  * @param {object} context - rubric context (quiet-hours, rate cap, etc.)
- * @param {object} opts - { sender?, evaluate?, console? } injectable seams
- * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[]}>}
+ * @param {object} opts - { sender?, evaluate?, console?, fallbackSend? } injectable seams
+ * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, transportFailed?:boolean, fallbackFired?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[]}>}
  */
 export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   const sender = opts.sender || makeDefaultSender();
   const evaluate = typeof opts.evaluate === 'function' ? opts.evaluate : defaultEvaluate;
+  const fallbackSend = typeof opts.fallbackSend === 'function' ? opts.fallbackSend : defaultFallbackSend;
   const log = opts.console || console;
   const isDecision = effectiveType(message) === 'decision'; // classifier hardening (FR-4)
 
@@ -108,6 +141,13 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   }
 
   // pass + sms-authority -> send via the isolated sender.
-  await sender.send(message);
+  const sendResult = await sender.send(message);
+  if (sendResult && sendResult.softFailed) {
+    // QF-20260719-509 LIVE INCIDENT: a soft-failed transport must NEVER report sent:true (the
+    // exact "false success" the chairman hit — "text me if you need me" dropped silently).
+    log.error(`[chairman-sms-gate] TRANSPORT SOFT-FAILED, message NOT delivered: ${sendResult.reason}`);
+    const fb = await fallbackSend({ message, reason: sendResult.reason });
+    return { sent: false, transportFailed: true, fallbackFired: !!fb.fired, reason: sendResult.reason, verdict: 'pass', authorityClass: 'sms' };
+  }
   return { sent: true, reason: 'sent', verdict: 'pass', authorityClass: 'sms' };
 }

--- a/tests/unit/comms/chairman-sms-gate-live-intercept.test.js
+++ b/tests/unit/comms/chairman-sms-gate-live-intercept.test.js
@@ -43,14 +43,19 @@ describe('makeDefaultSender delegation (FR-2) — durable path, fail-soft, no Tw
     expect(gateSrc).toMatch(/enqueueChairmanSms/);
     expect(gateSrc).not.toMatch(/new\s+twilio|require\(['"]twilio|from ['"]twilio/i);
   });
-  it('a rubric-PASS with no recipient phone fails SOFT (no throw), proving transport degradation', async () => {
+  it('a rubric-PASS with no recipient phone fails SOFT (no throw) and reports sent:false honestly', async () => {
     // No opts.sender -> makeDefaultSender is used; no recipient -> early soft-fail (no durable import).
+    // QF-20260719-509 LIVE INCIDENT (2026-07-19): this test previously asserted sent:true on a
+    // soft-failed transport, claiming "email is the guaranteed fallback" — proven false in
+    // production (no email ever fired). The gate must not throw AND must not lie about delivery.
     const prev = process.env.CHAIRMAN_PHONE;
     delete process.env.CHAIRMAN_PHONE;
-    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval });
-    // The gate still reports sent (sender.send resolved without throwing) — the SOFT-fail is inside
-    // the durable delegate; the point is it did NOT throw (email is the guaranteed fallback).
-    expect(r.sent).toBe(true);
+    const fallbackSend = vi.fn(async () => ({ fired: true }));
+    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval, fallbackSend });
+    expect(r.sent).toBe(false); // did not throw, but honestly reports the transport drop
+    expect(r.transportFailed).toBe(true);
+    expect(r.reason).toBe('no_recipient_phone');
+    expect(fallbackSend).toHaveBeenCalledOnce(); // the real fallback now fires instead of the phantom one
     if (prev !== undefined) process.env.CHAIRMAN_PHONE = prev;
   });
 });

--- a/tests/unit/comms/chairman-sms-gate/chairman-sms-gate.test.js
+++ b/tests/unit/comms/chairman-sms-gate/chairman-sms-gate.test.js
@@ -69,13 +69,46 @@ describe('chairman-sms-gate sendChairmanSMS()', () => {
   it('TS-6: default sender DELEGATES to the -B durable path and fails SOFT (no throw) — SD-LEO-INFRA-ADAM-OUTBOUND-WIRE-LIVE-001 FR-2', async () => {
     // FR-2 wired makeDefaultSender (the former throw-stub) to the -B durable send path
     // (enqueueChairmanSms) — NOT a second Twilio client. With no recipient/durable state it must fail
-    // SOFT (never throw) so the guaranteed chairman EMAIL escalation delivers. The RUBRIC fail-closed
-    // guarantee is UNCHANGED — a bad decision is still HELD before send (see the blocked/fail-closed
-    // cases above); only the TRANSPORT is now fail-soft.
+    // SOFT (never throw). The RUBRIC fail-closed guarantee is UNCHANGED — a bad decision is still HELD
+    // before send (see the blocked/fail-closed cases above); only the TRANSPORT is now fail-soft.
+    //
+    // QF-20260719-509 LIVE INCIDENT (2026-07-19): this test previously asserted sent:true on a
+    // soft-failed transport — the exact "false success" defect that dropped a real chairman SMS
+    // silently. A soft-failed transport must now report sent:false and fire the fallback.
     const prev = process.env.CHAIRMAN_PHONE;
     delete process.env.CHAIRMAN_PHONE; // force the no-recipient soft-fail branch (no durable I/O)
-    const res = await sendChairmanSMS(wellFormedDecision(), DAYTIME, { console: silentConsole });
-    expect(res.sent).toBe(true); // rubric admitted; transport soft-failed to the email fallback, no throw
+    const fallbackSend = vi.fn(async () => ({ fired: true }));
+    const res = await sendChairmanSMS(wellFormedDecision(), DAYTIME, { console: silentConsole, fallbackSend });
+    expect(res.sent).toBe(false); // rubric admitted; transport soft-failed -> honest sent:false
+    expect(res.transportFailed).toBe(true);
+    expect(res.reason).toBe('no_recipient_phone');
+    expect(res.fallbackFired).toBe(true);
+    expect(fallbackSend).toHaveBeenCalledTimes(1);
     if (prev !== undefined) process.env.CHAIRMAN_PHONE = prev;
+  });
+
+  it('TS-7 (QF-20260719-509): an injected sender reporting the live-incident softFailed shape returns sent:false and fires the fallback', async () => {
+    // Reproduces the exact live incident: sms_outbound_obligations table absent -> enqueueChairmanSms
+    // throws -> makeDefaultSender catches -> softFailed 'durable_path_error'. Injecting the sender
+    // directly (matching TS-1..TS-6's convention) so the assertion is on sendChairmanSMS's own
+    // honesty, independent of makeDefaultSender's internals.
+    const sender = { send: vi.fn(async () => ({ sid: null, softFailed: true, reason: 'durable_path_error: relation "sms_outbound_obligations" does not exist' })) };
+    const fallbackSend = vi.fn(async ({ message, reason }) => ({ fired: true, message, reason }));
+    const res = await sendChairmanSMS(wellFormedDecision(), DAYTIME, { sender, console: silentConsole, fallbackSend });
+    expect(res.sent).toBe(false);
+    expect(res.transportFailed).toBe(true);
+    expect(res.fallbackFired).toBe(true);
+    expect(res.reason).toContain('durable_path_error');
+    expect(fallbackSend).toHaveBeenCalledTimes(1);
+    expect(fallbackSend.mock.calls[0][0].reason).toContain('sms_outbound_obligations');
+  });
+
+  it('TS-8 (QF-20260719-509): a real (successful) send is unaffected — sent:true, fallback never invoked', async () => {
+    const sender = makeSender(); // resolves {sid:'SM-test'}, no softFailed field
+    const fallbackSend = vi.fn(async () => ({ fired: true }));
+    const res = await sendChairmanSMS(wellFormedDecision(), DAYTIME, { sender, console: silentConsole, fallbackSend });
+    expect(res.sent).toBe(true);
+    expect(res.transportFailed).toBeUndefined();
+    expect(fallbackSend).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
**CRITICAL — live incident.** LIVE INCIDENT 2026-07-19 ~13:45Z: the first production use of the sanctioned gated sender (`scripts/adam-chairman-sms.mjs` -> `sendChairmanSMS`) returned `{sent:true}` while the chairman's away-acknowledgment was silently dropped end-to-end, right after the chairman said "text me if you need me."

Root cause: `sendChairmanSMS` awaited `sender.send()` and discarded the result, unconditionally returning `sent:true` regardless of transport outcome. The transport's own comment falsely claimed "the existing chairman EMAIL escalation has already fired" — no email path existed anywhere in the call chain (a phantom fallback).

- `sendChairmanSMS` now inspects the sender's result. A `softFailed` transport (durable `sms_outbound_obligations` table absent, no recipient phone, etc.) returns `sent:false` with the real reason — never a false positive.
- Added a real fallback (`defaultFallbackSend`, injectable via `opts.fallbackSend`) that fires an actual email alert via the existing Resend adapter (same path as `adam-heartbeat-email.mjs`) when the transport soft-fails, replacing the phantom fallback claim.
- Fixed two existing tests that had baked in the false-success assumption (`chairman-sms-gate.test.js` TS-6, `chairman-sms-gate-live-intercept.test.js`) and added TS-7/TS-8 covering the exact incident shape (table-absent `durable_path_error`) and the unaffected-on-success path.

## Deliberately out of scope (flagged as follow-ups, not silently dropped)
- **Applying the STAGED `sms_outbound_obligations` migration** (`database/migrations/20260718_sms_outbound_obligations_STAGED.sql`) requires the chairman-ceremony 3-factor apply process per the migration's own runbook — this is explicitly not a worker action (see `lib/migration/adam-delegated-apply.js`, which scopes DB-apply delegation to Adam only, chairman-authorized 2026-06-16).
- **Wiring `scripts/cron/sms-outbound-reconcile-sweep.mjs`** into a scheduled workflow (currently built but not wired to any GH Actions cron) is a safe, low-risk follow-up mirroring `.github/workflows/chairman-morning-review-cron.yml` — inert (fail-soft no-op) until the migration above lands, so not urgent to bundle with this critical fix.

## Test plan
- [x] `npx vitest run tests/unit/comms/chairman-sms-gate/chairman-sms-gate.test.js tests/unit/comms/chairman-sms-gate-live-intercept.test.js tests/unit/chairman/record-pending-decision-escalation.test.js tests/unit/chairman/record-pending-decision-fixture-guard.test.js tests/unit/comms/adam-outbound/decision-scheduler.test.js tests/unit/cron/adam-decision-scheduler-wiring.test.js` — 72/72 pass, no regressions in any caller of `sendChairmanSMS`.
- [x] `node --check` on the modified source file.
- [x] Repo-wide sweep for other tests asserting the old `sent:true`-on-soft-fail contract — none remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)