### PR TITLE
fix(QF-20260719-201): paginate merge_witness_telemetry reads past the 1000-row PostgREST default

### DIFF
--- a/lib/ship/witness-adoption.mjs
+++ b/lib/ship/witness-adoption.mjs
@@ -52,6 +52,32 @@ export function isInvalidated(telemetryRow) {
   return Array.isArray(telemetryRow?.rungs) && telemetryRow.rungs.some((r) => r?.id === 'INVALIDATED');
 }
 
+/**
+ * QF-20260719-201: fetch ALL merge_witness_telemetry rows with explicit pagination.
+ * The previous bare `.select('repo, pr_number')` in the three readers (gauge-runner,
+ * ship-witness-reconcile, ship-witness-enforce-readiness) silently truncated at
+ * PostgREST's default 1000-row limit: the moment the table crossed 1000 rows
+ * (2026-07-19 ~13:04Z) every NEWER row became invisible to the readers while the
+ * writers kept inserting — the writer/reader asymmetry that read six freshly-merged
+ * PRs (6277–6282) as unwitnessed and made the reconcile sweep re-backfill duplicate
+ * rows hourly (which only grew the table and worsened the truncation). Ordered by id
+ * so pages are stable; selects rungs too so isInvalidated() operates on real data.
+ */
+export async function fetchAllWitnessRows(supabase, { pageSize = 1000, select = 'repo, pr_number, rungs' } = {}) {
+  const rows = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from('merge_witness_telemetry')
+      .select(select)
+      .order('id', { ascending: true })
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error('merge_witness_telemetry query failed: ' + error.message);
+    rows.push(...(data || []));
+    if (!data || data.length < pageSize) break;
+  }
+  return rows;
+}
+
 /** Pure: IDENTITY-match (repo, prNumber) merges against telemetry rows. Never a raw count diff. */
 export function classifyMerges(merges, telemetryRows) {
   const validRows = (telemetryRows || []).filter((t) => !isInvalidated(t));

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -30,6 +30,7 @@ import {
   WITNESS_CUTOVER_ISO,
   defaultFetchMergedPlatformPRs,
   detectUnwitnessedMerges,
+  fetchAllWitnessRows,
 } from '../lib/ship/witness-adoption.mjs';
 import { reconcileUnwitnessedMerges } from './ship-witness-reconcile.mjs';
 import { spawnSync } from 'node:child_process';
@@ -211,8 +212,8 @@ function buildDetectorResolvers(supabase) {
         return { code: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
       };
       const merges = PLATFORM_REPOS.flatMap((r) => defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, ghRunner));
-      const { data: telemetryRows, error } = await supabase.from('merge_witness_telemetry').select('repo, pr_number');
-      if (error) throw new Error('merge_witness_telemetry query failed: ' + error.message);
+      // QF-20260719-201: paginated read — the bare select truncated at PostgREST's 1000-row default.
+      const telemetryRows = await fetchAllWitnessRows(supabase);
       const result = detectUnwitnessedMerges(merges, telemetryRows);
       // SD-LEO-INFRA-SHIP-WITNESS-COVERAGE-001 FR-1: best-effort backfill each gap this pass
       // finds, reusing the SAME merges/telemetryRows fetch above (no duplicate gh/DB round-trip).

--- a/scripts/ship-witness-enforce-readiness.mjs
+++ b/scripts/ship-witness-enforce-readiness.mjs
@@ -17,6 +17,7 @@ import {
   WITNESS_CUTOVER_ISO,
   defaultFetchMergedPlatformPRs,
   computeAdoptionReadiness,
+  fetchAllWitnessRows,
 } from '../lib/ship/witness-adoption.mjs';
 
 const JSON_MODE = process.argv.includes('--json');
@@ -38,8 +39,8 @@ function ghRunner(args) {
 export async function computeLiveReadiness(supabase, { fetchMerges } = {}) {
   const fetch = fetchMerges || ((owner, name) => defaultFetchMergedPlatformPRs(owner, name, WITNESS_CUTOVER_ISO, ghRunner));
   const merges = PLATFORM_REPOS.flatMap((r) => fetch(r.owner, r.name));
-  const { data: telemetryRows, error } = await supabase.from('merge_witness_telemetry').select('repo, pr_number');
-  if (error) throw new Error('merge_witness_telemetry query failed: ' + error.message);
+  // QF-20260719-201: paginated read — the bare select truncated at PostgREST's 1000-row default.
+  const telemetryRows = await fetchAllWitnessRows(supabase);
   return computeAdoptionReadiness({ merges, telemetryRows });
 }
 

--- a/scripts/ship-witness-reconcile.mjs
+++ b/scripts/ship-witness-reconcile.mjs
@@ -29,6 +29,7 @@ import {
   WITNESS_CUTOVER_ISO,
   defaultFetchMergedPlatformPRs,
   detectUnwitnessedMerges,
+  fetchAllWitnessRows,
 } from '../lib/ship/witness-adoption.mjs';
 import { writeMergeWitnessTelemetry } from '../lib/ship/merge-witness-telemetry.mjs';
 import { deriveWorkKey } from '../lib/ship/work-key-derivation.mjs';
@@ -87,8 +88,10 @@ async function main() {
   const supabase = createClient(url, key);
 
   const merges = PLATFORM_REPOS.flatMap((r) => defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, defaultGhRunner));
-  const { data: telemetryRows, error } = await supabase.from('merge_witness_telemetry').select('repo, pr_number');
-  if (error) { console.error('[ship-witness-reconcile] merge_witness_telemetry query failed: ' + error.message); process.exit(1); }
+  // QF-20260719-201: paginated read — the bare select truncated at PostgREST's 1000-row default.
+  let telemetryRows;
+  try { telemetryRows = await fetchAllWitnessRows(supabase); }
+  catch (e) { console.error('[ship-witness-reconcile] ' + e.message); process.exit(1); }
 
   const { unwitnessed } = detectUnwitnessedMerges(merges, telemetryRows);
   const summary = await reconcileUnwitnessedMerges(unwitnessed, { supabase });

--- a/tests/unit/ship/ship-witness-enforce-readiness-live.test.js
+++ b/tests/unit/ship/ship-witness-enforce-readiness-live.test.js
@@ -13,7 +13,9 @@ import { computeLiveReadiness } from '../../../scripts/ship-witness-enforce-read
 describe('computeLiveReadiness (TS-10): no caching/memoization between invocations', () => {
   it('calls the merge-fetch function fresh on every invocation — no memoized result reused', async () => {
     const fetchMerges = vi.fn((owner, name) => [{ repo: `${owner}/${name}`.toLowerCase(), prNumber: 1, mergedAt: '2026-07-04T00:00:00Z' }]);
-    const supabase = { from: () => ({ select: async () => ({ data: [{ repo: 'rickfelix/ehg_engineer', pr_number: 1 }], error: null }) }) };
+    // QF-20260719-201: reads now go through fetchAllWitnessRows (.select().order().range()).
+    const page = async () => ({ data: [{ repo: 'rickfelix/ehg_engineer', pr_number: 1 }], error: null });
+    const supabase = { from: () => ({ select: () => ({ order: () => ({ range: page }) }) }) };
 
     await computeLiveReadiness(supabase, { fetchMerges });
     await computeLiveReadiness(supabase, { fetchMerges });
@@ -24,7 +26,8 @@ describe('computeLiveReadiness (TS-10): no caching/memoization between invocatio
   });
 
   it('calls the merge_witness_telemetry select fresh on every invocation', async () => {
-    const select = vi.fn(async () => ({ data: [], error: null }));
+    // QF-20260719-201: count paginated reads at the select choke (one page per invocation).
+    const select = vi.fn(() => ({ order: () => ({ range: async () => ({ data: [], error: null }) }) }));
     const supabase = { from: () => ({ select }) };
     const fetchMerges = () => [];
 
@@ -42,7 +45,7 @@ describe('computeLiveReadiness (TS-10): no caching/memoization between invocatio
       if (callCount > 2) return [{ repo: `${owner}/${name}`.toLowerCase(), prNumber: 99, mergedAt: '2026-07-04T12:00:00Z' }];
       return [];
     };
-    const supabase = { from: () => ({ select: async () => ({ data: [], error: null }) }) };
+    const supabase = { from: () => ({ select: () => ({ order: () => ({ range: async () => ({ data: [], error: null }) }) }) }) };
 
     const first = await computeLiveReadiness(supabase, { fetchMerges });
     const second = await computeLiveReadiness(supabase, { fetchMerges });

--- a/tests/unit/ship/witness-adoption.test.js
+++ b/tests/unit/ship/witness-adoption.test.js
@@ -9,6 +9,7 @@ import {
   defaultFetchMergedPlatformPRs,
   classifyMerges,
   detectUnwitnessedMerges,
+  fetchAllWitnessRows,
   computeAdoptionReadiness,
   isInvalidated,
 } from '../../../lib/ship/witness-adoption.mjs';
@@ -237,5 +238,40 @@ describe('computeAdoptionReadiness', () => {
     const readiness = computeAdoptionReadiness({ merges, telemetryRows, today: '2026-07-03', requiredConsecutiveDays: 7 });
     expect(readiness.ready).toBe(false);
     expect(readiness.consecutiveDays).toBeLessThan(7);
+  });
+});
+
+describe('fetchAllWitnessRows pagination (QF-20260719-201)', () => {
+  function mockSupabase(pages) {
+    const rangeCalls = [];
+    const chain = {
+      from: () => chain,
+      select: () => chain,
+      order: () => chain,
+      range: async (from, to) => {
+        rangeCalls.push([from, to]);
+        return { data: pages.shift() || [], error: null };
+      },
+    };
+    return { chain, rangeCalls };
+  }
+
+  it('walks past the 1000-row PostgREST default (the 2026-07-19 ~13:04Z blindness)', async () => {
+    const page1 = Array.from({ length: 1000 }, (_, i) => ({ repo: 'rickfelix/ehg_engineer', pr_number: i }));
+    const page2 = Array.from({ length: 11 }, (_, i) => ({ repo: 'rickfelix/ehg_engineer', pr_number: 6277 + i }));
+    const { chain, rangeCalls } = mockSupabase([page1, page2]);
+    const rows = await fetchAllWitnessRows(chain);
+    expect(rows.length).toBe(1011);
+    expect(rangeCalls).toEqual([[0, 999], [1000, 1999]]);
+    // The newest PRs — invisible to the old bare select — are now in the result set.
+    expect(rows.some((r) => r.pr_number === 6282)).toBe(true);
+  });
+
+  it('stops after a single short page and surfaces DB errors', async () => {
+    const { chain, rangeCalls } = mockSupabase([[{ repo: 'r/x', pr_number: 1 }]]);
+    expect((await fetchAllWitnessRows(chain)).length).toBe(1);
+    expect(rangeCalls.length).toBe(1);
+    const err = { from: () => err, select: () => err, order: () => err, range: async () => ({ data: null, error: { message: 'boom' } }) };
+    await expect(fetchAllWitnessRows(err)).rejects.toThrow(/boom/);
   });
 });


### PR DESCRIPTION
## Summary
The ~13:00Z 'ship-witness pipeline break' was neither a writer failure nor a key/case mismatch: **the table crossed 1000 rows at 13:04:45Z**, and all three readers (`gauge-runner.mjs`, `ship-witness-reconcile.mjs`, `ship-witness-enforce-readiness.mjs`) used a bare `.select('repo, pr_number')`, which PostgREST silently truncates at its 1000-row default. Every row written after that moment was invisible to the readers while the writers kept inserting — the exact writer/reader asymmetry the QF hypothesized. The blind reconcile sweep then re-backfilled duplicate rows hourly (e.g. #6283 has both a 16:21Z completion-time row and a 17:04Z reconcile re-write), growing the table and worsening the truncation.

**Fix:** new `fetchAllWitnessRows()` in `lib/ship/witness-adoption.mjs` — pages via `.order(id).range()` until a short page, selects `rungs` so `isInvalidated()` operates on real data — wired into all three readers.

**Investigation answers:** (a) writers insert fine; readers truncated. (b) break correlates with the row-count threshold, NOT QF-986/#6279 nor the shared-root reset. (c) no backfill needed — rows for 6277–6284 already exist and now read witnessed.

## Testing
- Reproduced live: gauge-style bare select returns exactly 1000/1011 rows, newest visible 13:04:45Z, all 8 recent PRs invisible; new helper returns 1011/1011 with all 8 visible.
- New pagination regression tests (1000-row page walk, short-page stop, error surfacing); 31/31 across witness suites.

Closes QF-20260719-201 (coordinator-sourced, high severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)