### PR TITLE
feat(SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D): independent adversarial CMV-rejecter + fake-separation gauge

### DIFF
--- a/lib/governance/fw3-cmv-rejecter.cjs
+++ b/lib/governance/fw3-cmv-rejecter.cjs
@@ -1,0 +1,193 @@
+'use strict';
+/**
+ * fw3-cmv-rejecter.cjs — SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D (FW-3 Child C).
+ *
+ * PURE verdict machinery for the independent adversarial CMV-rejecter
+ * (docs/design/fw3-effort-distribution-tier-design.md §3): the mandatory
+ * CMV-alignment lens is PROPOSER-side, so a framing's self-generated CMV-trace
+ * is Solomon certifying Solomon — the CONST-002 correction requires a
+ * structurally-separate rejecter whose only job is to try to REJECT
+ * instrument-class framings on CMV grounds, plus a gauge on the rejecter
+ * itself: reject-rate ≈ 0 over a sufficient sample means the separation is
+ * FAKE (structural deference) and must flag (§7.3 rejecter-reality test).
+ *
+ * DESIGN INVARIANTS (PLAN evidence rows d2f7360a / 0bd7fcf6 / 9a79c3c6):
+ *  - The adversarial JUDGMENT is NOT in this module (DESIGN A1 / spine §3.3
+ *    owns the objective function — sibling Child G): the invoking session
+ *    reasons; this module only lists, records, and measures.
+ *  - No process.env reads and no process.exit here (DESIGN A2): config is
+ *    injected by the CLI/runner boundary; helpers are pure or fail-soft.
+ *  - Wire contract (VALIDATION C2): framings ride the Solomon oracle leg
+ *    (sender_type='solomon', payload.oracle=true) with the Child-A
+ *    contract-fixed discriminator payload.framing_class='instrument'. Zero
+ *    such rows (Child A unmerged) is a BENIGN empty world, never an error.
+ *  - First-verdict-wins is enforced by a SINGLE conditional statement:
+ *    PostgREST compiles .filter('payload->cmv_rejecter','is',null) into the
+ *    UPDATE's WHERE, so only one writer can claim the key (0 rows = lost).
+ *    Raceability note (DATABASE d2f7360a): rejecter passes run one session
+ *    at a time by construction; the residual read→update window affects only
+ *    SIBLING payload keys (marker-class risk, accepted). json-null-vs-missing
+ *    conflation is moot — this module only ever writes an object.
+ */
+
+const DEFAULT_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // design §7.3 measurement window
+
+/** PURE (TS-1): is this row an instrument-class oracle framing awaiting a verdict? */
+function isPendingInstrumentFraming(row) {
+  const p = row && row.payload;
+  if (!p || typeof p !== 'object') return false;
+  if (row.sender_type !== 'solomon' && p.oracle !== true) return false;
+  if (p.framing_class !== 'instrument') return false;
+  return p.cmv_rejecter == null;
+}
+
+/** PURE (TS-1): predicate applied to UNFILTERED rows — the tested artifact. */
+function filterPendingFramings(rows) {
+  return (rows || []).filter(isPendingInstrumentFraming);
+}
+
+/**
+ * List instrument-class framings awaiting an adversarial verdict. The DB query
+ * is deliberately BROAD (solomon-sent rows in the window); the discriminating
+ * logic lives in the pure predicate above so a broken builder filter cannot
+ * ship green (TESTING gap 2). Fail-soft: { items: [], error? }.
+ */
+async function listPendingFramings(supabase, { windowMs = DEFAULT_WINDOW_MS, nowMs = Date.now() } = {}) {
+  if (!supabase) return { items: [], error: 'no supabase client' };
+  try {
+    const cutoff = new Date(nowMs - windowMs).toISOString();
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, sender_type, subject, payload, created_at')
+      .eq('sender_type', 'solomon')
+      .gte('created_at', cutoff);
+    if (error) return { items: [], error: error.message };
+    return { items: filterPendingFramings(data) };
+  } catch (e) {
+    return { items: [], error: (e && e.message) || String(e) };
+  }
+}
+
+const VERDICTS = ['rejected', 'survived'];
+
+/** PURE: build the payload.cmv_rejecter object; throws on an invalid verdict. */
+function buildVerdictPatch({ verdict, grounds, rejecterSession, nowIso }) {
+  if (!VERDICTS.includes(verdict)) throw new Error(`verdict must be one of ${VERDICTS.join('|')} (got "${verdict}")`);
+  if (!grounds || !String(grounds).trim()) throw new Error('grounds required — an adversarial verdict without grounds is unauditable');
+  return {
+    verdict,
+    grounds: String(grounds).trim(),
+    at: nowIso || new Date().toISOString(),
+    rejecter_session: rejecterSession || null,
+  };
+}
+
+/**
+ * Record a verdict with FIRST-VERDICT-WINS: the .filter(payload->cmv_rejecter
+ * is null) guard rides in the UPDATE's WHERE (single statement, atomic for the
+ * key). 0 matched rows → { ok: false, alreadyVerdicted: true }. Fail-soft.
+ */
+async function recordVerdict(supabase, { rowId, verdict, grounds, rejecterSession } = {}) {
+  if (!supabase || !rowId) return { ok: false, error: 'rowId required' };
+  let patch;
+  try { patch = buildVerdictPatch({ verdict, grounds, rejecterSession }); }
+  catch (e) { return { ok: false, error: e.message }; }
+  try {
+    const { data: current, error: readErr } = await supabase
+      .from('session_coordination')
+      .select('payload')
+      .eq('id', rowId)
+      .single();
+    if (readErr) return { ok: false, error: readErr.message };
+    if (current && current.payload && current.payload.cmv_rejecter != null) {
+      return { ok: false, alreadyVerdicted: true };
+    }
+    const merged = { ...((current && current.payload) || {}), cmv_rejecter: patch };
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .update({ payload: merged })
+      .eq('id', rowId)
+      .filter('payload->cmv_rejecter', 'is', null) // first-verdict-wins guard (in the WHERE)
+      .select('id');
+    if (error) return { ok: false, error: error.message };
+    if (!Array.isArray(data) || data.length === 0) return { ok: false, alreadyVerdicted: true };
+    return { ok: true, verdict: patch };
+  } catch (e) {
+    return { ok: false, error: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * PURE (TS-5): reject-rate over verdicted instrument framings. Malformed
+ * cmv_rejecter entries (no recognizable verdict) are EXCLUDED from the sample
+ * so the rate can never leak NaN/undefined (TESTING gap 4).
+ * @returns {{ sample: number, rejected: number, rejectRate: number|null }}
+ */
+function computeRejectRate(rows) {
+  let sample = 0;
+  let rejected = 0;
+  for (const row of rows || []) {
+    const p = row && row.payload;
+    if (!p || typeof p !== 'object') continue;
+    if (p.framing_class !== 'instrument') continue;
+    const v = p.cmv_rejecter && p.cmv_rejecter.verdict;
+    if (!VERDICTS.includes(v)) continue;
+    sample += 1;
+    if (v === 'rejected') rejected += 1;
+  }
+  return { sample, rejected, rejectRate: sample > 0 ? rejected / sample : null };
+}
+
+/**
+ * PURE (TS-3): the fake-separation trip predicate. Trips ONLY when the sample
+ * is sufficient (>= minSample, inclusive) AND the reject-rate is at-or-below
+ * epsilon (inclusive). Small samples NEVER trip (design §7.1 low-volume
+ * caution); a zero-sample world returns count=0 cleanly (pre-Child-A).
+ */
+function evaluateFakeSeparation({ sample, rejected, rejectRate }, { minSample = 10, epsilon = 0.05 } = {}) {
+  const trip = sample >= minSample && rejectRate !== null && rejectRate <= epsilon;
+  return { count: trip ? 1 : 0, sample, rejected, rejectRate, minSample, epsilon };
+}
+
+/**
+ * PURE (TS-4): structural-separation check — the rejecter must never be the
+ * proposing Solomon session. Fail-CLOSED on an unresolvable invoker: without a
+ * provable identity, separation cannot be certified.
+ */
+function checkStructuralSeparation({ invokerSession, activeSolomonSession }) {
+  if (!invokerSession) return { ok: false, reason: 'invoker session unresolvable — separation cannot be certified (fail-closed)' };
+  if (activeSolomonSession && invokerSession === activeSolomonSession) {
+    return { ok: false, reason: `invoker ${invokerSession} IS the active Solomon — proposer cannot be its own rejecter (CONST-002)` };
+  }
+  return { ok: true };
+}
+
+/** Runner-boundary detector: fetch window, measure, evaluate. Fail-soft {count:0, error?}. */
+async function detectFakeSeparation(supabase, { windowMs = DEFAULT_WINDOW_MS, minSample, epsilon, nowMs = Date.now() } = {}) {
+  if (!supabase) return { count: 0, sample: 0, error: 'no supabase client' };
+  try {
+    const cutoff = new Date(nowMs - windowMs).toISOString();
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('payload')
+      .eq('sender_type', 'solomon')
+      .gte('created_at', cutoff);
+    if (error) return { count: 0, sample: 0, error: error.message };
+    return evaluateFakeSeparation(computeRejectRate(data), { minSample, epsilon });
+  } catch (e) {
+    return { count: 0, sample: 0, error: (e && e.message) || String(e) };
+  }
+}
+
+module.exports = {
+  DEFAULT_WINDOW_MS,
+  isPendingInstrumentFraming,
+  filterPendingFramings,
+  listPendingFramings,
+  buildVerdictPatch,
+  recordVerdict,
+  computeRejectRate,
+  evaluateFakeSeparation,
+  checkStructuralSeparation,
+  detectFakeSeparation,
+};

--- a/lib/governance/fw3-cmv-rejecter.test.js
+++ b/lib/governance/fw3-cmv-rejecter.test.js
@@ -1,0 +1,156 @@
+/**
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D — fw3-cmv-rejecter unit suite.
+ * Covers PRD TS-1..TS-5 + TESTING PLAN-gap closures (row 9a79c3c6):
+ *  gap-1/TS-2: assert the EMITTED first-verdict-wins guard shape (.filter on
+ *              payload->cmv_rejecter is null) — mock cannot witness row locks,
+ *              so the guard's presence in the query IS the unit-tier witness;
+ *              live atomicity defers to the parent per design §7.3.
+ *  gap-2/TS-1: predicate exercised over UNFILTERED rows (a broken builder
+ *              filter cannot ship green).
+ *  gap-3/TS-3: exact boundary inclusivity (sample 9|10, rate at|above epsilon).
+ *  gap-4/TS-5: malformed cmv_rejecter entries excluded — no NaN leakage.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  filterPendingFramings, buildVerdictPatch, recordVerdict,
+  computeRejectRate, evaluateFakeSeparation, checkStructuralSeparation,
+} from './fw3-cmv-rejecter.cjs';
+
+const framing = (over = {}) => ({
+  id: 'r1', sender_type: 'solomon',
+  payload: { oracle: true, framing_class: 'instrument', body: 'framing' },
+  ...over,
+});
+
+describe('TS-1 filterPendingFramings — predicate over UNFILTERED rows (gap-2)', () => {
+  it('keeps only unverdicted instrument-class oracle framings', () => {
+    const rows = [
+      framing({ id: 'keep' }),
+      framing({ id: 'pick', payload: { oracle: true, framing_class: 'pick' } }),
+      framing({ id: 'verdicted', payload: { oracle: true, framing_class: 'instrument', cmv_rejecter: { verdict: 'survived' } } }),
+      { id: 'worker-row', sender_type: 'worker', payload: { framing_class: 'instrument' } },
+      { id: 'no-payload', sender_type: 'solomon' },
+      framing({ id: 'no-class', payload: { oracle: true } }),
+    ];
+    expect(filterPendingFramings(rows).map((r) => r.id)).toEqual(['keep']);
+  });
+  it('empty world (pre-Child-A) returns [] — never an error', () => {
+    expect(filterPendingFramings([])).toEqual([]);
+    expect(filterPendingFramings(null)).toEqual([]);
+  });
+});
+
+describe('TS-2 recordVerdict — first-verdict-wins guard shape (gap-1) + merge-not-clobber', () => {
+  function mockSupabase({ payload, updateResult }) {
+    const calls = { filters: [], updates: [] };
+    const chain = {
+      from: () => chain,
+      select: (cols) => { calls.lastSelect = cols; return chain; },
+      eq: () => chain,
+      single: async () => ({ data: { payload }, error: null }),
+      update: (patch) => { calls.updates.push(patch); return chain; },
+      filter: (...args) => { calls.filters.push(args); return chain; },
+    };
+    // terminal .select after update/filter chain resolves the update result
+    let selectCount = 0;
+    const origSelect = chain.select;
+    chain.select = (cols) => {
+      selectCount += 1;
+      if (calls.updates.length > 0) return Promise.resolve(updateResult);
+      return origSelect(cols);
+    };
+    return { chain, calls };
+  }
+
+  it('emits the payload->cmv_rejecter IS NULL guard and preserves sibling keys', async () => {
+    const { chain, calls } = mockSupabase({
+      payload: { oracle: true, framing_class: 'instrument', correlation_id: 'keep-me' },
+      updateResult: { data: [{ id: 'r1' }], error: null },
+    });
+    const r = await recordVerdict(chain, { rowId: 'r1', verdict: 'rejected', grounds: 'drifts from north-star', rejecterSession: 's-rej' });
+    expect(r.ok).toBe(true);
+    expect(calls.filters).toContainEqual(['payload->cmv_rejecter', 'is', null]); // the guard IS the witness
+    const merged = calls.updates[0].payload;
+    expect(merged.correlation_id).toBe('keep-me'); // merge-not-clobber
+    expect(merged.cmv_rejecter.verdict).toBe('rejected');
+  });
+
+  it('0 matched rows → alreadyVerdicted (first verdict wins)', async () => {
+    const { chain } = mockSupabase({ payload: { framing_class: 'instrument' }, updateResult: { data: [], error: null } });
+    const r = await recordVerdict(chain, { rowId: 'r1', verdict: 'survived', grounds: 'traces honestly' });
+    expect(r).toEqual({ ok: false, alreadyVerdicted: true });
+  });
+
+  it('pre-read short-circuit also refuses an already-verdicted row', async () => {
+    const { chain, calls } = mockSupabase({
+      payload: { cmv_rejecter: { verdict: 'survived' } },
+      updateResult: { data: [{ id: 'r1' }], error: null },
+    });
+    const r = await recordVerdict(chain, { rowId: 'r1', verdict: 'rejected', grounds: 'x' });
+    expect(r.alreadyVerdicted).toBe(true);
+    expect(calls.updates.length).toBe(0);
+  });
+
+  it('buildVerdictPatch validates verdict vocabulary and requires grounds', () => {
+    expect(() => buildVerdictPatch({ verdict: 'approved', grounds: 'x' })).toThrow(/rejected\|survived/);
+    expect(() => buildVerdictPatch({ verdict: 'rejected', grounds: '  ' })).toThrow(/grounds required/);
+  });
+});
+
+describe('TS-3 evaluateFakeSeparation — trip matrix + boundaries (gap-3)', () => {
+  const cfg = { minSample: 10, epsilon: 0.05 };
+  const rate = (sample, rejected) => ({ sample, rejected, rejectRate: sample ? rejected / sample : null });
+
+  it('trips at sample>=minSample and rate<=epsilon', () => {
+    expect(evaluateFakeSeparation(rate(10, 0), cfg).count).toBe(1);
+    expect(evaluateFakeSeparation(rate(20, 1), cfg).count).toBe(1); // 0.05 exactly → inclusive trip
+  });
+  it('never trips below minSample regardless of rate', () => {
+    expect(evaluateFakeSeparation(rate(9, 0), cfg).count).toBe(0);  // boundary: 9 vs 10
+    expect(evaluateFakeSeparation(rate(3, 0), cfg).count).toBe(0);
+  });
+  it('does not trip on a healthy reject rate', () => {
+    expect(evaluateFakeSeparation(rate(20, 8), cfg).count).toBe(0); // 0.4
+    expect(evaluateFakeSeparation(rate(20, 2), cfg).count).toBe(0); // 0.1 just above epsilon
+  });
+  it('zero-sample world returns count=0 cleanly (fail-soft pre-Child-A)', () => {
+    const r = evaluateFakeSeparation(rate(0, 0), cfg);
+    expect(r.count).toBe(0);
+    expect(r.rejectRate).toBeNull();
+  });
+});
+
+describe('TS-4 checkStructuralSeparation', () => {
+  it('refuses when the invoker IS the active Solomon (CONST-002)', () => {
+    const r = checkStructuralSeparation({ invokerSession: 'sol-1', activeSolomonSession: 'sol-1' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('proposer cannot be its own rejecter');
+  });
+  it('fail-closed on an unresolvable invoker', () => {
+    expect(checkStructuralSeparation({ invokerSession: null, activeSolomonSession: 'sol-1' }).ok).toBe(false);
+  });
+  it('passes a genuinely separate session (incl. no live Solomon)', () => {
+    expect(checkStructuralSeparation({ invokerSession: 'w-1', activeSolomonSession: 'sol-1' }).ok).toBe(true);
+    expect(checkStructuralSeparation({ invokerSession: 'w-1', activeSolomonSession: null }).ok).toBe(true);
+  });
+});
+
+describe('TS-5 computeRejectRate — purity + malformed exclusion (gap-4)', () => {
+  it('counts only well-formed instrument verdicts; malformed never leak NaN', () => {
+    const rows = [
+      { payload: { framing_class: 'instrument', cmv_rejecter: { verdict: 'rejected' } } },
+      { payload: { framing_class: 'instrument', cmv_rejecter: { verdict: 'survived' } } },
+      { payload: { framing_class: 'instrument', cmv_rejecter: {} } },              // malformed: no verdict
+      { payload: { framing_class: 'instrument', cmv_rejecter: { verdict: 'ok' } } }, // malformed vocabulary
+      { payload: { framing_class: 'pick', cmv_rejecter: { verdict: 'rejected' } } }, // pick-class excluded
+      { payload: { framing_class: 'instrument' } },                                 // unverdicted
+      {},
+    ];
+    const r = computeRejectRate(rows);
+    expect(r).toEqual({ sample: 2, rejected: 1, rejectRate: 0.5 });
+    expect(Number.isNaN(r.rejectRate)).toBe(false);
+  });
+  it('deterministic and null at sample 0', () => {
+    expect(computeRejectRate([])).toEqual({ sample: 0, rejected: 0, rejectRate: null });
+  });
+});

--- a/lib/governance/fw3-cmv-rejecter.test.js
+++ b/lib/governance/fw3-cmv-rejecter.test.js
@@ -52,10 +52,8 @@ describe('TS-2 recordVerdict — first-verdict-wins guard shape (gap-1) + merge-
       filter: (...args) => { calls.filters.push(args); return chain; },
     };
     // terminal .select after update/filter chain resolves the update result
-    let selectCount = 0;
     const origSelect = chain.select;
     chain.select = (cols) => {
-      selectCount += 1;
       if (calls.updates.length > 0) return Promise.resolve(updateResult);
       return origSelect(cols);
     };

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -81,6 +81,17 @@ export const GAUGE_REGISTRY = [
     tracesToLayer: null,
   },
   {
+    id: 'fw3-cmv-rejecter-fake-separation',
+    name: 'FW-3 CMV-rejecter reject-rate ~0 over sufficient sample (fake separation / structural deference)',
+    detectorFn: 'fw3-cmv-rejecter-fake-separation',
+    thresholdConfig: { tripWhen: (result) => (result?.count || 0) > 0 },
+    ownerRole: 'coordinator',
+    remediation: 'The independent adversarial CMV-rejecter is approving everything: sample >= FW3_REJECTER_MIN_SAMPLE instrument framings verdicted with rejectRate <= FW3_REJECTER_EPSILON means the proposer/rejecter separation is fake (structural deference to the bigger brain — design fw3 §3). Audit recent payload.cmv_rejecter verdicts and grounds; confirm the rejecter session is genuinely separate and genuinely adversarial.',
+    prevent: 'SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D — this gauge IS the durable detection for the CONST-002 proposer-certifies-itself class; small samples never trip (design §7.1), so pre-Child-A silence is benign zero-sample, visible in the result sample field.',
+    enabled: true,
+    tracesToLayer: null,
+  },
+  {
     id: 'ship-witness-unwitnessed-merge',
     name: 'Platform-repo merge with zero merge_witness_telemetry row (WATCH-HOLE)',
     detectorFn: 'ship-witness-unwitnessed-merge',

--- a/scripts/fw3-cmv-rejecter.cjs
+++ b/scripts/fw3-cmv-rejecter.cjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * fw3-cmv-rejecter.cjs CLI — SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D (FR-2).
+ *
+ * The STRUCTURAL-SEPARATION surface of the adversarial CMV-rejecter: a cheap,
+ * separate session lists pending instrument-class framings, performs the
+ * adversarial CMV-rejection REASONING itself (the judgment is deliberately not
+ * in code — spine §3.3 owns the objective function), and records the verdict.
+ * The CLI hard-refuses when the invoking session IS the active Solomon:
+ * the proposer must never be its own rejecter (CONST-002 correction,
+ * docs/design/fw3-effort-distribution-tier-design.md §3).
+ *
+ * Usage:
+ *   node scripts/fw3-cmv-rejecter.cjs list
+ *   node scripts/fw3-cmv-rejecter.cjs record <row-id> rejected|survived --grounds "<why>"
+ *
+ * Env (read HERE, injected into the pure core per DESIGN A2):
+ *   FW3_REJECTER_MIN_SAMPLE (default 10), FW3_REJECTER_EPSILON (default 0.05)
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const {
+  listPendingFramings, recordVerdict, checkStructuralSeparation, detectFakeSeparation,
+} = require('../lib/governance/fw3-cmv-rejecter.cjs');
+const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const mode = argv[0];
+  if (mode !== 'list' && mode !== 'record' && mode !== 'gauge') {
+    console.error('Usage: node scripts/fw3-cmv-rejecter.cjs list | record <row-id> rejected|survived --grounds "<why>" | gauge');
+    process.exit(2);
+  }
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  if (mode === 'list') {
+    const { items, error } = await listPendingFramings(supabase);
+    if (error) { console.error('ERROR:', error); process.exit(1); }
+    if (!items.length) {
+      console.log('No pending instrument-class framings (benign pre-Child-A empty world, or all verdicted).');
+      return;
+    }
+    console.log(`${items.length} pending instrument-class framing(s) awaiting an adversarial CMV pass:`);
+    for (const f of items) {
+      console.log(`\n• id=${f.id} from=${String(f.sender_session).slice(0, 8)} at=${f.created_at}`);
+      console.log(`  subject: ${f.subject}`);
+      const body = (f.payload && f.payload.body) || '';
+      console.log(`  body: ${String(body).slice(0, 400)}${body.length > 400 ? '…' : ''}`);
+    }
+    console.log('\nAdversarial pass: for each framing, try to REJECT on CMV grounds (does it drift from the north-star? is the framing foreclosing the real problem?). Then: record <id> rejected|survived --grounds "..."');
+    return;
+  }
+
+  if (mode === 'gauge') {
+    const minSample = Number(process.env.FW3_REJECTER_MIN_SAMPLE) || 10;
+    const epsilon = Number(process.env.FW3_REJECTER_EPSILON) || 0.05;
+    console.log(JSON.stringify(await detectFakeSeparation(supabase, { minSample, epsilon }), null, 2));
+    return;
+  }
+
+  // record — the structural-separation guard runs FIRST (fail-closed, FR-2 AC2).
+  const invokerSession = process.env.CLAUDE_SESSION_ID || null;
+  let activeSolomonSession = null;
+  try { activeSolomonSession = await getActiveSolomonId(supabase); } catch { activeSolomonSession = null; }
+  const sep = checkStructuralSeparation({ invokerSession, activeSolomonSession });
+  if (!sep.ok) {
+    console.error(`ERROR: [STRUCTURAL_SEPARATION] ${sep.reason}`);
+    process.exit(4);
+  }
+
+  const rowId = argv[1];
+  const verdict = argv[2];
+  const gIdx = argv.indexOf('--grounds');
+  const grounds = gIdx >= 0 ? argv[gIdx + 1] : null;
+  const r = await recordVerdict(supabase, { rowId, verdict, grounds, rejecterSession: invokerSession });
+  if (r.alreadyVerdicted) { console.error('REFUSED: framing already carries a cmv_rejecter verdict (first verdict wins).'); process.exit(3); }
+  if (!r.ok) { console.error('ERROR:', r.error); process.exit(1); }
+  console.log(`✓ Verdict recorded: ${r.verdict.verdict} on ${rowId}`);
+  console.log(`  grounds: ${r.verdict.grounds}`);
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('UNHANDLED:', (e && e.message) || e); process.exit(1); });
+}

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -206,6 +206,16 @@ function buildDetectorResolvers(supabase) {
     // planted miss-direction fixture never trips the live gauge.
     'expired-premise-tags': async () => detectExpiredPremises(process.cwd(), { now: new Date() }),
     'stale-tree': async () => shapeStaleTreeResult(checkoutFreshness(process.cwd(), { role: 'fleet-gauge-runner' })),
+    // SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D: fake-separation detector (design fw3 §3/§7.3).
+    // Env read at THIS boundary and injected into the pure core (DESIGN A2); zero-sample
+    // pre-Child-A worlds return count=0 cleanly with the sample visible.
+    'fw3-cmv-rejecter-fake-separation': async () => {
+      const { detectFakeSeparation } = await import('../lib/governance/fw3-cmv-rejecter.cjs');
+      return detectFakeSeparation(supabase, {
+        minSample: Number(process.env.FW3_REJECTER_MIN_SAMPLE) || 10,
+        epsilon: Number(process.env.FW3_REJECTER_EPSILON) || 0.05,
+      });
+    },
     'ship-witness-unwitnessed-merge': async () => {
       const ghRunner = (args) => {
         const r = spawnSync('gh', args, { encoding: 'utf8' });

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -21,14 +21,14 @@ import {
 const VALID_FEEDBACK_TYPES = ['issue', 'enhancement'];
 
 describe('GAUGE_REGISTRY shape', () => {
-  it('exports exactly 24 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001 + operator-cash-attestation-missing, QF-20260705-915 + plan-drift-coverage/plan-drift-mix, SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 + ghost-ceo, SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001 + hold-state-overdue, SD-LEO-INFRA-HOLD-STATE-CONTRACT-001)', () => {
-    expect(GAUGE_REGISTRY).toHaveLength(24);
+  it('exports exactly 25 seed entries (8 original + venture-capture-completeness, SD-LEO-INFRA-CAPTURE-FORWARD-GATE-001 + 6 loop-health-*, SD-LEO-INFRA-009-LEAF-PER-001 + 3 self-score-age stubs, SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-4 + expired-premise-tags, SD-LEO-INFRA-BITTER-LESSON-AUDIT-001 + operator-cash-attestation-missing, QF-20260705-915 + plan-drift-coverage/plan-drift-mix, SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 + ghost-ceo, SD-LEO-GEN-SATELLITE-AGENT-LIFECYCLE-001 + hold-state-overdue, SD-LEO-INFRA-HOLD-STATE-CONTRACT-001 + fw3-cmv-rejecter-fake-separation, SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D)', () => {
+    expect(GAUGE_REGISTRY).toHaveLength(25);
   });
 
-  it('21 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
+  it('22 entries are activated; the 3 self-score-age entries ship as stubs (writers default-OFF)', () => {
     const live = GAUGE_REGISTRY.filter((e) => e.enabled === true);
     const stubs = GAUGE_REGISTRY.filter((e) => e.enabled === false);
-    expect(live).toHaveLength(21);
+    expect(live).toHaveLength(22);
     expect(stubs.map((e) => e.id).sort()).toEqual(['adam_self_score_age', 'coordinator_self_score_age', 'solomon_self_score_age']);
   });
 
@@ -102,13 +102,14 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
     expect(selectEnabledEntries(undefined)).toEqual([]);
   });
 
-  it('the real GAUGE_REGISTRY selects all 21 enabled entries', () => {
+  it('the real GAUGE_REGISTRY selects all 22 enabled entries', () => {
     const selected = selectEnabledEntries(GAUGE_REGISTRY);
-    expect(selected).toHaveLength(21);
+    expect(selected).toHaveLength(22);
     expect(selected.map((e) => e.id).sort()).toEqual([
       'adam-claimed-or-built-sd',
       'coordinator-sourced-sd',
       'expired-premise-tags',
+      'fw3-cmv-rejecter-fake-separation',
       'ghost-ceo',
       'hold-state-overdue',
       'loop-health-A_applied_rate',


### PR DESCRIPTION
## Summary
FW-3 Child C (design `docs/design/fw3-effort-distribution-tier-design.md` §3 + §7.3): the mandatory CMV-alignment lens is **proposer-side** — a framing's self-generated CMV-trace is Solomon certifying Solomon (the CONST-002 violation dressed as compliance). This ships the **independent rejecter** surface and the gauge that makes a rubber-stamp rejecter loudly visible.

- `lib/governance/fw3-cmv-rejecter.cjs` — pure verdict machinery: pending-list predicate over unfiltered rows, **first-verdict-wins** recordVerdict (the guard rides the UPDATE's WHERE via `.filter('payload->cmv_rejecter','is',null)`), computeRejectRate (malformed entries excluded, NaN-proof), evaluateFakeSeparation (**sample ≥ minSample AND rate ≤ epsilon trips; small samples never trip; zero-sample pre-Child-A world returns count=0 cleanly**), fail-closed structural-separation check. No env reads, no exits; the adversarial judgment itself is deliberately NOT in code (spine §3.3 / Child G owns the objective function).
- `scripts/fw3-cmv-rejecter.cjs` — `list|record|gauge` CLI for a structurally-separate cheap session; `record` **hard-refuses when the invoker IS the active Solomon** (proposer can never be its own rejecter).
- Gauge `fw3-cmv-rejecter-fake-separation` registered (additive registry entry + runner resolver; `FW3_REJECTER_MIN_SAMPLE`/`FW3_REJECTER_EPSILON` read at the runner boundary and injected).
- Wire contract: adam_advisory/oracle leg + `payload.framing_class` (Child A's contract-fixed field) — **no build-order dependency**; fail-soft empty until Child A lands.

## Verification
- 15 unit tests covering PRD TS-1..TS-5 including all four TESTING plan-gap closures (guard-shape witness, unfiltered-predicate discipline, boundary inclusivity 9|10 and 0.05|0.1, malformed-entry NaN-proofing); registry count pins updated (25 entries / 22 enabled); 684/684 across governance suites.
- Live smoke against the real DB: 0 pending framings + gauge `{count:0, sample:0, rejectRate:null}` — the benign pre-Child-A world, visible not silent.

Implements SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-D (PRD approved 3 FRs; VALIDATION/EXPLORE/DATABASE/DESIGN/STORIES/TESTING evidence on file; LOC 472 justified by approved SD scope — 156 of it tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)