### PR TITLE
feat(SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-E): chairman-visible framing digest

### DIFF
--- a/lib/org/chairman-surface.mjs
+++ b/lib/org/chairman-surface.mjs
@@ -196,4 +196,46 @@ export function pickTopConstraint({ bottlenecks, signals, drift, runway }) {
   return section('none', { line: 'No live constraint surfaced by the four computations', kind: 'none' });
 }
 
+/**
+ * FW-3 Child D (SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-E): the chairman-visible framing DIGEST.
+ * Govern-by-ABSENCE mitigation — the chairman must see WHAT was framed and HOW even when every
+ * downstream gauge reads green (traces-to-CMV, Adam-approved, panel-survived). "Screen RANKS,
+ * chairman PICKS": pick-class framings rank FIRST (they route to the chairman fork), then
+ * instrument-class by recency. Pure + fail-safe: a null/empty input yields an EXPLICIT empty
+ * digest (visible absence), never a silent omission or a throw. Reads payload.framing_class from
+ * the FW-3 wire discriminator (child A / -001-B); degrades gracefully until that ships — an item
+ * with no framing_class is treated as instrument-class (lowest rank), never dropped.
+ * @param {Array<{framing_class?:string, source?:string, summary?:string, title?:string, created_at?:string}>} framings
+ * @returns {{empty:boolean, total:number, pickCount:number, instrumentCount:number, items:Array, note:string}}
+ */
+export function buildFramingDigest(framings) {
+  const list = Array.isArray(framings) ? framings : [];
+  const classOf = (f) => (f && f.framing_class === 'pick') ? 'pick' : 'instrument';
+  const stamp = (x) => Date.parse(x && x.created_at) || 0;
+  const items = list
+    .map((f) => ({
+      framing_class: classOf(f),
+      severity: classOf(f) === 'pick' ? 'high' : 'medium',
+      line: `[${classOf(f)}] ${(f && (f.summary || f.title)) || 'framing'}`,
+      source: (f && f.source) || 'apex-framing-role',
+      created_at: (f && f.created_at) || null,
+    }))
+    // pick-class before instrument-class; within a class, most-recent first.
+    .sort((a, b) => (a.framing_class === b.framing_class
+      ? stamp(b) - stamp(a)
+      : (a.framing_class === 'pick' ? -1 : 1)));
+  const pickCount = items.filter((i) => i.framing_class === 'pick').length;
+  const empty = items.length === 0;
+  return {
+    empty,
+    total: items.length,
+    pickCount,
+    instrumentCount: items.length - pickCount,
+    items,
+    note: empty
+      ? 'No framings this period — the apex framing role surfaced nothing to pick (shown so the chairman sees the absence too).'
+      : `${items.length} framing(s): ${pickCount} PICK (chairman decides) + ${items.length - pickCount} instrument.`,
+  };
+}
+
 export { RUNWAY_CRITICAL_MONTHS };

--- a/tests/unit/chairman-framing-digest.test.js
+++ b/tests/unit/chairman-framing-digest.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildFramingDigest } from '../../lib/org/chairman-surface.mjs';
+
+// FW-3 Child D (SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-E): the chairman-visible framing digest.
+// "Screen ranks, chairman picks" — pick-class first; the empty case is VISIBLE (govern-by-absence),
+// not silently omitted; null/degraded input never throws.
+
+describe('buildFramingDigest (FW3 Child D)', () => {
+  it('ranks pick-class framings before instrument-class', () => {
+    const d = buildFramingDigest([
+      { framing_class: 'instrument', summary: 'i1', created_at: '2026-07-19T10:00:00Z' },
+      { framing_class: 'pick', summary: 'p1', created_at: '2026-07-19T09:00:00Z' },
+    ]);
+    expect(d.items[0].framing_class).toBe('pick');
+    expect(d.pickCount).toBe(1);
+    expect(d.instrumentCount).toBe(1);
+    expect(d.total).toBe(2);
+    expect(d.empty).toBe(false);
+  });
+
+  it('sorts most-recent-first within a class', () => {
+    const d = buildFramingDigest([
+      { framing_class: 'pick', summary: 'older', created_at: '2026-07-19T08:00:00Z' },
+      { framing_class: 'pick', summary: 'newer', created_at: '2026-07-19T12:00:00Z' },
+    ]);
+    expect(d.items[0].line).toContain('newer');
+    expect(d.items[1].line).toContain('older');
+  });
+
+  it('renders an EXPLICIT visible-absence note for the empty case (govern-by-absence)', () => {
+    const d = buildFramingDigest([]);
+    expect(d.empty).toBe(true);
+    expect(d.total).toBe(0);
+    expect(d.items).toEqual([]);
+    expect(d.note).toMatch(/No framings this period/);
+    expect(d.note).toMatch(/absence/);
+  });
+
+  it('degrades gracefully on null/undefined/non-array input (never throws)', () => {
+    for (const bad of [null, undefined, {}, 42, 'x']) {
+      expect(() => buildFramingDigest(bad)).not.toThrow();
+      expect(buildFramingDigest(bad).empty).toBe(true);
+    }
+  });
+
+  it('treats a framing with no framing_class as instrument-class (never dropped) — degrade until FW3-B lands', () => {
+    const d = buildFramingDigest([{ summary: 'unclassified', created_at: '2026-07-19T10:00:00Z' }]);
+    expect(d.total).toBe(1);
+    expect(d.items[0].framing_class).toBe('instrument');
+    expect(d.instrumentCount).toBe(1);
+  });
+});


### PR DESCRIPTION
FW-3 Child D — the govern-by-absence mitigation: a chairman-visible digest of framings emitted per period ("screen ranks, chairman picks"), so the chairman sees WHAT was framed and HOW even when every downstream gauge reads green.

- `lib/org/chairman-surface.mjs`: pure, exported `buildFramingDigest()` — pick-class ranked first; empty periods render an EXPLICIT visible-absence note (never silently omitted); null/degraded input never throws; unclassified framings treated as instrument-class (graceful degradation until FW3-B / -001-B ships the `payload.framing_class` wire).
- `tests/unit/chairman-framing-digest.test.js`: 5 scenarios, all green.

Parent: SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001 (orchestrator). Chairman gate: digest cadence needs sign-off (default = fold into the 5:45 ET daily-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)