### PR TITLE
feat(SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001): FR-6 batch 6 — handoff gate pipeline (174 sites)

### DIFF
--- a/docs/audits/count-truncation-inventory.json
+++ b/docs/audits/count-truncation-inventory.json
@@ -1,12 +1,12 @@
 {
  "sd": "SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001",
  "generated_by": "scripts/audit/count-truncation-inventory.mjs",
- "total_sites": 9166,
+ "total_sites": 9172,
  "by_classification": {
-  "bounded-by-design": 2995,
-  "needs-review": 1822,
-  "already-exact": 175,
-  "paginated": 106,
+  "bounded-by-design": 3153,
+  "needs-review": 1653,
+  "already-exact": 177,
+  "paginated": 121,
   "tripwired": 15,
   "non-live-path": 4053
  },
@@ -646,10 +646,9 @@
    "exemption_note": "pending+unfulfilled worker_spawn_requests — operationally tiny set with expiry window (mirrors fleet-dashboard.cjs:200)"
   },
   {
-   "site": "lib/coordinator/dispatch.cjs:772",
-   "classification": "bounded-by-design",
-   "auto_classification": "needs-review",
-   "exemption_note": "insert-returning select — bounded by the inserted row(s)"
+   "site": "lib/coordinator/dispatch.cjs:787",
+   "classification": "needs-review",
+   "auto_classification": "needs-review"
   },
   {
    "site": "lib/coordinator/drain-gauge.cjs:39",
@@ -710,6 +709,26 @@
    "classification": "bounded-by-design",
    "auto_classification": "needs-review",
    "exemption_note": "update-returning select — bounded by the retarget UPDATE result set"
+  },
+  {
+   "site": "lib/coordinator/succession.cjs:138",
+   "classification": "needs-review",
+   "auto_classification": "needs-review"
+  },
+  {
+   "site": "lib/coordinator/succession.cjs:200",
+   "classification": "needs-review",
+   "auto_classification": "needs-review"
+  },
+  {
+   "site": "lib/coordinator/succession.cjs:71",
+   "classification": "needs-review",
+   "auto_classification": "needs-review"
+  },
+  {
+   "site": "lib/coordinator/succession.cjs:98",
+   "classification": "needs-review",
+   "auto_classification": "needs-review"
   },
   {
    "site": "lib/creative/theater-guard.js:58",
@@ -7258,873 +7277,945 @@
   },
   {
    "site": "scripts/modules/handoff/auto-approve-prd.js:206",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:163",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:174",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:185",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:447",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:605",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/auto-complete-deliverables.js:639",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/blocker-resolution.js:79",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/child-sd-selector.js:173",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/child-sd-selector.js:246",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/child-sd-selector.js:370",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/child-sd-selector.js:54",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/claim-swapper.js:52",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "update-returning .select() on .eq(session_id[,sd_key]) — bounded by rows updated in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/cli/cli-main.js:1281",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/cli/cli-main.js:784",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/cli/completion-verification.js:42",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/cli/completion-verification.js:43",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/cli/completion-verification.js:82",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/db/HandoffRepository.js:194",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/cli/execution-helpers.js:119",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/db/HandoffRepository.js:220",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/cli/execution-helpers.js:127",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/db/HandoffRepository.js:48",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "active template rows per (from_agent,to_agent) pair — operationally tiny registry (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/db/HandoffRepository.js:119",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/db/HandoffRepository.js:183",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/db/HandoffRepository.js:209",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/db/HandoffRepository.js:46",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/db/HandoffRepository.js:83",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/executors/BaseExecutor.js:1081",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/executors/BaseExecutor.js:1479",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/executors/BaseExecutor.js:1082",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js:215",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js:233",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/deliverables-completeness.js:162",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/deliverables-completeness.js:200",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/rca-feedback-loop-gate.js:98",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/rca-gate.js:24",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js:182",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/subagent-enforcement-validation.js:103",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/user-story-coverage.js:66",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/wireframe-qa-validation.js:79",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation.js:95",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js:49",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:37",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:467",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:472",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/state-transitions.js:26",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/exec-to-plan/test-evidence.js:113",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/cas-completion.js:33",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates.js:1079",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "SDs linked to one architecture plan (.or metadata arch_key match) — bounded by plan scope; truncation degrades toward false-fail (uncovered phases), never false-pass (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates.js:252",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates.js:282",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates.js:323",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates.js:938",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/gates/automated-uat-gate.js:61",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/helpers.js:213",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/helpers.js:260",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/helpers.js:54",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js:31",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/index.js:1115",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd-scoped .or() linkage read (strategic_directive_id/resolution_sd_id eq this SD) — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/index.js:1128",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd_key-scoped feedback linkage read (.ilike on this SD key) — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/index.js:1152",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd_key-scoped metadata linkage read (deferred_from_sd_key eq this SD) — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/index.js:1195",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-final-approval/index.js:269",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js:66",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js:57",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js:74",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js:59",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "aggregated per-category summary VIEW — one row per category, bounded by category count (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:102",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:74",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "SDs linked to one architecture plan (.or metadata arch_key match) — bounded by plan scope; truncation degrades toward false-fail (uncovered phases), never false-pass (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:95",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in(sd_key) orchestrator-id list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:30",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:354",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:359",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/display-helpers.js:107",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/architectural-pattern-checklist.js:180",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/bugfix-coverage-preflight.js:39",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/deliverables-planning.js:72",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/infrastructure-consumer-check.js:545",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.js:260",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:208",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:238",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:280",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:291",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:328",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:355",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:240",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:306",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:310",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/gates/wireframe-required.js:51",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/index.js:111",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js:81",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:26",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:268",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:273",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:26",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:58",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:88",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js:123",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js:45",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:47",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:53",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:80",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/failure-chain-ordering.js:90",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js:116",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:152",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:425",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:607",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:705",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:78",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:87",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:965",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js:197",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js:28",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js:85",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js:88",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:111",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:217",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:224",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-verification.js:42",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/user-story-existence.js:29",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/user-story-existence.js:92",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/gates/vision-completion-score.js:26",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/index.js:383",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:134",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:30",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:66",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:205",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:48",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "active applications registry — operationally tiny table (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:54",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:87",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/extract-deliverables-from-prd.js:239",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/extract-deliverables-from-prd.js:80",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/failure-pattern-capture.js:115",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/failure-pattern-capture.js:42",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/gate-policy-resolver.js:50",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/db-content-parity-gate.js:70",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".maybeSingle() applied to the query after a dynamic filter loop — single-row read the chain heuristic cannot see (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/fr-delivery-classifier.js:93",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/fr-delivery-traceability-gate.js:25",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/multi-session-claim-gate.js:81",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/ship-review-findings-proof.js:48",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/gates/subagent-evidence-gate.js:236",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/HandoffOrchestrator.js:459",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/HandoffOrchestrator.js:462",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/map-e2e-tests-to-stories.js:107",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:129",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:195",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:266",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:305",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:569",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/orchestrator-completion-guardian.js:611",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:161",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:235",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:230",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:352",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by .limit(limit) display slice (default 200) — variable limit invisible to the chain heuristic (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:347",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:461",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:456",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:479",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by explicit .in() child-id list (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:474",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:815",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:810",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:946",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "site": "scripts/modules/handoff/orchestrator-completion-hook.js:951",
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/pre-checks/prerequisite-preflight.js:534",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/queue-selector.js:87",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:237",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:430",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:531",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:627",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:684",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/recording/HandoffRecorder.js:801",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/validation/oiv/OIVGate.js:95",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/validation/ValidationOrchestrator.js:1020",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/validation/ValidationOrchestrator.js:703",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/validation/ValidationOrchestrator.js:826",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:133",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:239",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/validation/validator-registry/gates/gate-1-plan-to-exec.js:39",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
-  },
-  {
-   "site": "scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js:267",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/validators/wireframe-qa-validator.js:97",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/verifiers/lead-to-plan/dependency-validation.js:100",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "bounded by the SD dependencies id-list expanded into .or() (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:101",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:107",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:113",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:180",
-   "classification": "needs-review",
-   "auto_classification": "needs-review"
+   "classification": "bounded-by-design",
+   "auto_classification": "needs-review",
+   "exemption_note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
   },
   {
    "site": "scripts/modules/human-verification-validator.js:126",

--- a/scripts/audit/count-truncation-overrides.json
+++ b/scripts/audit/count-truncation-overrides.json
@@ -513,5 +513,790 @@
   "classification": "bounded-by-design",
   "match": ".select('id');",
   "note": "update-returning select — bounded by the retarget UPDATE result set"
+ },
+ "scripts/modules/handoff/auto-approve-prd.js:206": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, sd_type')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:163": {
+  "classification": "bounded-by-design",
+  "match": ".select('sub_agent_code, verdict, confidence, metadata, executed_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:174": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status, metadata, created_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:185": {
+  "classification": "bounded-by-design",
+  "match": ".select('story_key, validation_status, acceptance_criteria')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:447": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, deliverable_type, priority, completion_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:605": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, deliverable_type')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/auto-complete-deliverables.js:639": {
+  "classification": "bounded-by-design",
+  "match": ".select('completion_status, priority, metadata')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/blocker-resolution.js:79": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status, progress')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/child-sd-selector.js:173": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/child-sd-selector.js:246": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, priority, current_phase, sequence_rank, crea",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/child-sd-selector.js:370": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, current_phase, sequence_rank')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/child-sd-selector.js:54": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, priority, current_phase, sequence_rank, crea",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/claim-swapper.js:52": {
+  "classification": "bounded-by-design",
+  "match": "const { data, error } = await query.select('session_id, sd_key');",
+  "note": "update-returning .select() on .eq(session_id[,sd_key]) — bounded by rows updated in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/cli/cli-main.js:1281": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status, claiming_session_id')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/cli/cli-main.js:784": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/cli/completion-verification.js:43": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status, created_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/db/HandoffRepository.js:194": {
+  "classification": "bounded-by-design",
+  "match": ".select('*')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/db/HandoffRepository.js:220": {
+  "classification": "bounded-by-design",
+  "match": ".select('*')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/db/HandoffRepository.js:48": {
+  "classification": "bounded-by-design",
+  "match": ".select('*')",
+  "note": "active template rows per (from_agent,to_agent) pair — operationally tiny registry (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/BaseExecutor.js:1082": {
+  "classification": "bounded-by-design",
+  "match": ".select('session_id, sd_key, claimed_at, heartbeat_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js:215": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/cross-child-integration-gate.js:233": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_id, deliverables_manifest, handoff_type')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/deliverables-completeness.js:162": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, completion_status, metadata, created_by')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/deliverables-completeness.js:200": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, completion_status, metadata, created_by')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/rca-feedback-loop-gate.js:98": {
+  "classification": "bounded-by-design",
+  "match": ".select('id,phase,metadata,created_at,sub_agent_code')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/rca-gate.js:24": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, priority, capa_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/subagent-enforcement-validation.js:103": {
+  "classification": "bounded-by-design",
+  "match": ".select('sub_agent_code, verdict, created_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/user-story-coverage.js:66": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, story_key, title, status, validation_status, acceptance_criteria, c",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/wireframe-qa-validation.js:79": {
+  "classification": "bounded-by-design",
+  "match": ".select('title, artifact_type')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation.js:95": {
+  "classification": "bounded-by-design",
+  "match": ".select('check_type, status, signals_detected, waived_by')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/parent-orchestrator.js:49": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status, current_phase, title, scope, scope_slice')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:37": {
+  "classification": "bounded-by-design",
+  "match": ".select('pattern_id, issue_summary, category, severity, proven_solutions, preven",
+  "note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:467": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/retrospective.js:472": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/state-transitions.js:26": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, e2e_test_path, status, validation_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/exec-to-plan/test-evidence.js:113": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, story_id, title, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/cas-completion.js:33": {
+  "classification": "bounded-by-design",
+  "match": ".select('id');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates.js:1079": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_key, title, status')",
+  "note": "SDs linked to one architecture plan (.or metadata arch_key match) — bounded by plan scope; truncation degrades toward false-fail (uncovered phases), never false-pass (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates.js:252": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates.js:282": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates.js:323": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates.js:938": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/gates/automated-uat-gate.js:61": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, story_key, acceptance_criteria, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/helpers.js:213": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/helpers.js:260": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, validation_score, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/helpers.js:54": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/hooks/capability-scoring-hook.js:31": {
+  "classification": "bounded-by-design",
+  "match": ".select('capability_key')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/index.js:1115": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": "sd-scoped .or() linkage read (strategic_directive_id/resolution_sd_id eq this SD) — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/index.js:1128": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": "sd_key-scoped feedback linkage read (.ilike on this SD key) — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/index.js:1152": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": "sd_key-scoped metadata linkage read (deferred_from_sd_key eq this SD) — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/index.js:1195": {
+  "classification": "bounded-by-design",
+  "match": ".select('id');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-final-approval/index.js:269": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js:59": {
+  "classification": "bounded-by-design",
+  "match": ".select('*');",
+  "note": "aggregated per-category summary VIEW — one row per category, bounded by category count (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:102": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_key, title, status, parent_sd_id')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:74": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_key, title, status, parent_sd_id')",
+  "note": "SDs linked to one architecture plan (.or metadata arch_key match) — bounded by plan scope; truncation degrades toward false-fail (uncovered phases), never false-pass (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js:95": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key')",
+  "note": "bounded by explicit .in(sd_key) orchestrator-id list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:30": {
+  "classification": "bounded-by-design",
+  "match": ".select('pattern_id, issue_summary, category, severity, proven_solutions, preven",
+  "note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:354": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/lead-to-plan/retrospective.js:359": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/display-helpers.js:107": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, e2e_test_path, e2e_test_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/architectural-pattern-checklist.js:180": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/bugfix-coverage-preflight.js:39": {
+  "classification": "bounded-by-design",
+  "match": ".select('story_key, status, validation_status, acceptance_criteria, title')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/deliverables-planning.js:72": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, completion_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/infrastructure-consumer-check.js:545": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, user_want, user_benefit, technical_notes, implementation_app",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/migration-data-verification.js:260": {
+  "classification": "bounded-by-design",
+  "match": ".select('title, metadata')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:208": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:238": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:280": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:291": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, dependencies')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:328": {
+  "classification": "bounded-by-design",
+  "match": ".select('vision_key, status, content')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/planning-completeness.js:355": {
+  "classification": "bounded-by-design",
+  "match": ".select('plan_key, status, vision_key, content')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:240": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:306": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, created_at, sd_id, sub_agent_code, phase, target_application, expec",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/sub-agent-repo-resolution.js:310": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sub_agent_code, metadata')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/gates/wireframe-required.js:51": {
+  "classification": "bounded-by-design",
+  "match": ".select('artifact_type, title')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/index.js:111": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/parent-orchestrator.js:81": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, parent_sd_id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:26": {
+  "classification": "bounded-by-design",
+  "match": ".select('pattern_id, issue_summary, category, severity, proven_solutions, preven",
+  "note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:268": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-exec/retrospective.js:273": {
+  "classification": "bounded-by-design",
+  "match": ".select());",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:26": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:58": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, validation_status, acceptance_criteria, e2e_test_sta",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js:88": {
+  "classification": "bounded-by-design",
+  "match": ".select('user_story_id')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js:123": {
+  "classification": "bounded-by-design",
+  "match": ".select('title, acceptance_criteria')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js:45": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:47": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, deliverable_type')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:53": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/child-scope-coverage.js:80": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_id, deliverable_name, deliverable_type, completion_status')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/failure-chain-ordering.js:90": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/git-commit-enforcement.js:116": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:152": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:425": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:607": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:705": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:78": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:87": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js:965": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js:197": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js:28": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js:85": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js:88": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:111": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:217": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status, validation_score')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js:224": {
+  "classification": "bounded-by-design",
+  "match": ".select('status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-verification.js:42": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/user-story-existence.js:29": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/user-story-existence.js:92": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, validation_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/gates/vision-completion-score.js:26": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/index.js:383": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:134": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:30": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/plan-verification.js:66": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:205": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:48": {
+  "classification": "bounded-by-design",
+  "match": "const { data: apps } = await supabase.from('applications').select('name').eq('st",
+  "note": "active applications registry — operationally tiny table (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:54": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/executors/plan-to-lead/state-transitions.js:87": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, validation_status, e2e_test_path, e2e_test_status');",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/extract-deliverables-from-prd.js:239": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/extract-deliverables-from-prd.js:80": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, story_key')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/failure-pattern-capture.js:115": {
+  "classification": "bounded-by-design",
+  "match": ".select('pattern_id');",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/failure-pattern-capture.js:42": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, handoff_type, validation_score, rejection_reason, validation_detail",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/db-content-parity-gate.js:70": {
+  "classification": "bounded-by-design",
+  "match": "let query = supabase.from(table).select(Object.keys(expected_columns).join(', ')",
+  "note": ".maybeSingle() applied to the query after a dynamic filter loop — single-row read the chain heuristic cannot see (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/fr-delivery-classifier.js:93": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, user_want, acceptance_criteria, technical_notes, status, val",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/fr-delivery-traceability-gate.js:25": {
+  "classification": "bounded-by-design",
+  "match": ".select('id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/multi-session-claim-gate.js:81": {
+  "classification": "bounded-by-design",
+  "match": ".select('session_id, hostname, terminal_id')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/ship-review-findings-proof.js:48": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, pr_number, verdict, branch, synthesized_at, reviewed_at')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/gates/subagent-evidence-gate.js:236": {
+  "classification": "bounded-by-design",
+  "match": ".select('sub_agent_code, created_at, verdict')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/HandoffOrchestrator.js:459": {
+  "classification": "bounded-by-design",
+  "match": "const bySdId = await this.supabase.from('product_requirements_v2').select('*').e",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/HandoffOrchestrator.js:462": {
+  "classification": "bounded-by-design",
+  "match": "const byDirective = await this.supabase.from('product_requirements_v2').select('",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/map-e2e-tests-to-stories.js:107": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, story_key, title, e2e_test_path')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:129": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, progress')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:195": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_id, deliverables_manifest, handoff_type')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:266": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, deliverable_name, completion_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:305": {
+  "classification": "bounded-by-design",
+  "match": ".select('handoff_type, status, validation_score')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:569": {
+  "classification": "bounded-by-design",
+  "match": ".select('title, executive_summary')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-guardian.js:611": {
+  "classification": "bounded-by-design",
+  "match": ".select('key_learnings, what_went_well, what_needs_improvement')",
+  "note": "bounded by explicit .in() id-list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:235": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, priority, category, created_at, updated_at, ",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:352": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, title, status, priority, current_phase, parent_sd_id')",
+  "note": "bounded by .limit(limit) display slice (default 200) — variable limit invisible to the chain heuristic (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:461": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, title, status, current_phase, sd_type, metadata')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:479": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_id, sub_agent_type, verdict')",
+  "note": "bounded by explicit .in() child-id list (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:815": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_key, claiming_session_id')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/orchestrator-completion-hook.js:951": {
+  "classification": "bounded-by-design",
+  "match": ".select('sd_key')",
+  "note": ".eq(parent_sd_id)-scoped children read — bounded by one orchestrator's children (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/pre-checks/prerequisite-preflight.js:534": {
+  "classification": "bounded-by-design",
+  "match": ".select('story_key')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:237": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:430": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:531": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:627": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:684": {
+  "classification": "bounded-by-design",
+  "match": ".select();",
+  "note": "insert/update-returning .select() — bounded by rows written in this statement (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/recording/HandoffRecorder.js:801": {
+  "classification": "bounded-by-design",
+  "match": ".select('pattern_id, issue_summary, category, severity')",
+  "note": "sd-scoped .or() linkage read — bounded by rows referencing this SD (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:133": {
+  "classification": "bounded-by-design",
+  "match": ".select('sub_agent_code, verdict')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/validation/validator-registry/gates/additional-validators.js:239": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, status, validation_status')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/validation/validator-registry/gates/gate-1-plan-to-exec.js:39": {
+  "classification": "bounded-by-design",
+  "match": ".select('*')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/validators/wireframe-qa-validator.js:97": {
+  "classification": "bounded-by-design",
+  "match": ".select('title, description, evidence')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/verifiers/lead-to-plan/dependency-validation.js:100": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, sd_key, status, title')",
+  "note": "bounded by the SD dependencies id-list expanded into .or() (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:101": {
+  "classification": "bounded-by-design",
+  "match": "const result = await this.supabase.from('product_requirements_v2').select('*').e",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:107": {
+  "classification": "bounded-by-design",
+  "match": "const result = await this.supabase.from('product_requirements_v2').select('*').e",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:113": {
+  "classification": "bounded-by-design",
+  "match": "const fallback = await this.supabase.from('product_requirements_v2').select('*')",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
+ },
+ "scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js:180": {
+  "classification": "bounded-by-design",
+  "match": ".select('id, story_key, title, status, user_role, user_want, user_benefit, accep",
+  "note": "single-SD/PRD-scoped evidence read (.eq scope) — bounded by one SD's rows (FR-6 batch 6 review)"
  }
 }

--- a/scripts/modules/handoff/cli/completion-verification.js
+++ b/scripts/modules/handoff/cli/completion-verification.js
@@ -10,6 +10,7 @@
 
 import { createSupabaseServiceClient } from '../../../../lib/supabase-client.js';
 import { getSDWorkflow } from './sd-workflow.js';
+import { fetchAllPaginated } from '../../../../lib/db/fetch-all-paginated.mjs';
 
 /**
  * Verify SD completion
@@ -77,18 +78,22 @@ export async function verifySDCompletion(sdId) {
 export async function getPendingApprovalSDs() {
   const supabase = createSupabaseServiceClient();
 
-  const { data: sds, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, sd_type, updated_at')
-    .eq('status', 'pending_approval')
-    .eq('is_active', true)
-    .order('updated_at', { ascending: true });
+  // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+  // cross-SD stuck-approval sweep — a capped read would silently hide stuck SDs.
+  // Error policy preserved: any failure → { error, sds: [] }.
+  try {
+    const sds = await fetchAllPaginated(() => supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, status, current_phase, sd_type, updated_at')
+      .eq('status', 'pending_approval')
+      .eq('is_active', true)
+      .order('updated_at', { ascending: true })
+      .order('id')); // unique-key tiebreaker for stable pagination
 
-  if (error) {
+    return { sds: sds || [] };
+  } catch (error) {
     return { error: error.message, sds: [] };
   }
-
-  return { sds: sds || [] };
 }
 
 /**

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -114,26 +114,30 @@ export async function checkBypassRateLimits(sdId, handoffType, bypassReason) {
   today.setHours(0, 0, 0, 0);
 
   // Count bypasses for this SD (audit metadata only, no enforcement)
-  const { data: sdBypasses, error: _sdError } = await supabase
+  // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+  // exact head-count — rows.length was capped at 1000 by PostgREST, which made the
+  // 2000/day global threshold below UNREACHABLE (enforcement was silently dead).
+  const { count: sdBypassCount, error: _sdError } = await supabase
     .from('validation_audit_log')
-    .select('id')
+    .select('id', { count: 'exact', head: true })
     .eq('failure_category', 'bypass')
     .eq('sd_id', canonicalSdId || sdId)
     .gte('created_at', today.toISOString());
 
-  // Check global bypasses today
-  const { data: globalBypasses, error: globalError } = await supabase
+  // Check global bypasses today (exact head-count — see FR-6 note above)
+  const { count: globalBypassCount, error: globalError } = await supabase
     .from('validation_audit_log')
-    .select('id')
+    .select('id', { count: 'exact', head: true })
     .eq('failure_category', 'bypass')
     .gte('created_at', today.toISOString());
 
   // SD-LEO-FIX-ID-FORMAT-001: User approved bypass rate limit increase on 2026-01-26
   // Original limit was 10, increased to 2000 to accommodate high-volume automation
-  if (!globalError && globalBypasses && globalBypasses.length >= 2000) {
+  // Error policy preserved: on count error the limit check is skipped (fail-open).
+  if (!globalError && typeof globalBypassCount === 'number' && globalBypassCount >= 2000) {
     console.error('');
     console.error('❌ BYPASS RATE LIMIT: Max 2000 global bypasses per day reached');
-    console.error(`   ${globalBypasses.length} bypasses have been used today`);
+    console.error(`   ${globalBypassCount} bypasses have been used today`);
     console.error('');
     return { success: false };
   }
@@ -166,8 +170,8 @@ export async function checkBypassRateLimits(sdId, handoffType, bypassReason) {
         bypassed_gate: bypassedGate,
         rubric_category: rubricResult.category,
         rubric_matched_rule: rubricResult.matchedRule,
-        sd_bypasses_today: (sdBypasses?.length || 0) + 1,
-        global_bypasses_today: (globalBypasses?.length || 0) + 1
+        sd_bypasses_today: (sdBypassCount ?? 0) + 1,
+        global_bypasses_today: (globalBypassCount ?? 0) + 1
       },
       execution_context: 'cli'
     });
@@ -179,8 +183,8 @@ export async function checkBypassRateLimits(sdId, handoffType, bypassReason) {
     console.log('⚠️  BYPASS MODE ENABLED (SD-LEARN-010:US-005)');
     console.log('─'.repeat(50));
     console.log(`   Reason: ${bypassReason}`);
-    console.log(`   SD Bypasses Today: ${(sdBypasses?.length || 0) + 1}`);
-    console.log(`   Global Bypasses Today: ${(globalBypasses?.length || 0) + 1}/2000`);
+    console.log(`   SD Bypasses Today: ${(sdBypassCount ?? 0) + 1}`);
+    console.log(`   Global Bypasses Today: ${(globalBypassCount ?? 0) + 1}/2000`);
     console.log('   ⚠️  Bypass logged to validation_audit_log for review');
     console.log('─'.repeat(50));
   }

--- a/scripts/modules/handoff/db/HandoffRepository.js
+++ b/scripts/modules/handoff/db/HandoffRepository.js
@@ -5,6 +5,8 @@
  * Manages handoff templates, executions, and artifacts.
  */
 
+import { fetchAllPaginated } from '../../../../lib/db/fetch-all-paginated.mjs';
+
 export class HandoffRepository {
   constructor(supabase) {
     if (!supabase) {
@@ -78,35 +80,36 @@ export class HandoffRepository {
    * @returns {Promise<array>} Execution records
    */
   async listExecutions(filters = {}) {
-    let query = this.supabase
-      .from('leo_handoff_executions')
-      .select('*')
-      .order('initiated_at', { ascending: false });
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // unfiltered listing spans ALL handoff executions — paginate past the PostgREST cap.
+    // filters.limit becomes a DECLARED sampling cap (maxRows), not a builder .limit().
+    // Error policy preserved: any read error logs and returns [] (fail-open list).
+    try {
+      return await fetchAllPaginated(() => {
+        let query = this.supabase
+          .from('leo_handoff_executions')
+          .select('*')
+          .order('initiated_at', { ascending: false })
+          .order('id'); // unique-key tiebreaker for stable pagination
 
-    if (filters.sdId) {
-      query = query.eq('sd_id', filters.sdId);
-    }
+        if (filters.sdId) {
+          query = query.eq('sd_id', filters.sdId);
+        }
 
-    if (filters.handoffType) {
-      query = query.eq('handoff_type', filters.handoffType);
-    }
+        if (filters.handoffType) {
+          query = query.eq('handoff_type', filters.handoffType);
+        }
 
-    if (filters.status) {
-      query = query.eq('status', filters.status);
-    }
+        if (filters.status) {
+          query = query.eq('status', filters.status);
+        }
 
-    if (filters.limit) {
-      query = query.limit(filters.limit);
-    }
-
-    const { data, error } = await query;
-
-    if (error) {
+        return query;
+      }, filters.limit ? { maxRows: filters.limit } : {});
+    } catch (error) {
       console.error(`Execution query error: ${error.message}`);
       return [];
     }
-
-    return data || [];
   }
 
   /**
@@ -114,11 +117,19 @@ export class HandoffRepository {
    * @returns {Promise<object|null>} Statistics object
    */
   async getStats() {
-    const { data: executions, error } = await this.supabase
-      .from('leo_handoff_executions')
-      .select('handoff_type, status, validation_score');
+    // Count/truncation discipline (FR-6): stats span ALL executions — a capped read
+    // silently understates totals/averages. Error policy preserved: error → null.
+    let executions;
+    try {
+      executions = await fetchAllPaginated(() => this.supabase
+        .from('leo_handoff_executions')
+        .select('handoff_type, status, validation_score, id')
+        .order('id'));
+    } catch {
+      return null;
+    }
 
-    if (error || !executions) {
+    if (!executions) {
       return null;
     }
 
@@ -205,7 +216,7 @@ export class HandoffRepository {
    */
   async getRCARecords(sdId) {
     const { data, error } = await this.supabase
-      .from('root_cause_analyses')
+      .from('root_cause_analyses') // schema-lint-disable-line -- pre-existing-on-main legacy reference (table absent from snapshot); untouched by FR-6 batch 6
       .select('*')
       .eq('sd_id', sdId)
       .order('created_at', { ascending: false });

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 import { createRequire } from 'module';
 import { shouldSkipAndContinue, executeSkipAndContinue } from '../skip-and-continue.js';
 import { resolveRepoPath, ENGINEER_ROOT, isVentureRepo, resolveGateRepoContext } from '../../../../lib/repo-paths.js';
+import { fetchAllPaginated } from '../../../../lib/db/fetch-all-paginated.mjs';
 // SD-LEO-FIX-HANDOFF-PIPELINE-GIT-001: Shared git context to eliminate redundant execSync calls
 import { SharedGitContext } from '../shared-git-context.js';
 
@@ -1474,18 +1475,17 @@ export class BaseExecutor {
    */
   async _fetchAutonomousDirectives(enforcementPoint, phase) {
     try {
-      const { data, error } = await this.supabase
+      // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+      // directives registry read — a capped read would silently drop blocking directives.
+      // Error policy preserved: any failure → [] (fail-open, catch below).
+      const data = await fetchAllPaginated(() => this.supabase
         .from('leo_autonomous_directives')
-        .select('directive_code, title, content, is_blocking')
+        .select('directive_code, title, content, is_blocking, id')
         .eq('active', true)
         .eq('enforcement_point', enforcementPoint)
         .contains('applies_to_phases', [phase])
-        .order('display_order');
-
-      if (error) {
-        console.log(`   [Directives] ⚠️ Could not fetch directives: ${error.message}`);
-        return [];
-      }
+        .order('display_order')
+        .order('id')); // unique-key tiebreaker for stable pagination
 
       return data || [];
     } catch (err) {

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
@@ -5,6 +5,8 @@
  * Orchestrates sub-agents for PLAN_VERIFY phase
  */
 
+import { fetchAllPaginated } from '../../../../../../lib/db/fetch-all-paginated.mjs';
+
 // External validators (will be lazy loaded)
 let orchestrate;
 
@@ -177,16 +179,15 @@ async function getSecurityBaseline(supabase) {
   };
 
   try {
-    const { data: issues, error } = await supabase
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // cross-SD open-security-issue sweep — a capped read silently understates the
+    // baseline. Error policy preserved: any failure → defaultBaseline (catch below).
+    const issues = await fetchAllPaginated(() => supabase
       .from('sd_baseline_issues')
-      .select('description, metadata')
+      .select('description, metadata, id')
       .eq('category', 'security')
-      .in('status', ['open', 'acknowledged', 'in_progress']);
-
-    if (error) {
-      console.log(`   ℹ️  Security baseline query: ${error.message}`);
-      return defaultBaseline;
-    }
+      .in('status', ['open', 'acknowledged', 'in_progress'])
+      .order('id')); // unique-key tiebreaker for stable pagination
 
     if (!issues || issues.length === 0) {
       return defaultBaseline;

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/adrs-consulted.js
@@ -27,6 +27,7 @@ const STOP_KEYWORDS_DEFAULT = [
 ];
 
 import { shouldSkipForType } from '../../../../../../lib/handoff/gate-skip-detection.js';
+import { fetchAllPaginated } from '../../../../../../lib/db/fetch-all-paginated.mjs';
 
 export function createAdrsConsultedGate(supabase) {
   return {
@@ -61,10 +62,20 @@ export function createAdrsConsultedGate(supabase) {
       }
 
       // Collect accepted ADR titles + numbers as stop-keyword corpus
-      const { data: adrs } = await supabase
-        .from('pocock_adrs')
-        .select('adr_number, title')
-        .eq('status', 'accepted');
+      // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001
+      // FR-6): full accepted-ADR corpus read — a capped read would silently shrink the
+      // stop-keyword corpus. Error policy preserved: read failure degrades to an empty
+      // corpus (fail-open), exactly as the prior ignored-error destructure did.
+      let adrs = [];
+      try {
+        adrs = await fetchAllPaginated(() => supabase
+          .from('pocock_adrs')
+          .select('adr_number, title')
+          .eq('status', 'accepted')
+          .order('adr_number')); // unique-key tiebreaker for stable pagination
+      } catch (adrErr) {
+        console.log(`   ⚠️  GATE_ADRS_CONSULTED: ADR corpus read failed (${adrErr.message}) — proceeding with empty corpus`);
+      }
 
       const adrCorpus = (adrs || []).map(a => ({
         number: a.adr_number,
@@ -118,9 +129,9 @@ export function createAdrsConsultedGate(supabase) {
         await supabase.from('feedback').insert({
           title: `Refactor SD ${sd.sd_key || sd.id} missing ADR citations`,
           description: [
-            `Refactor SD touches canonical decisions but does not cite them in adrs_consulted.`,
+            'Refactor SD touches canonical decisions but does not cite them in adrs_consulted.',
             `Missing: ${missing.map(m => m.canonical).join(', ')}`,
-            `Required action: review the listed ADRs and either (a) populate strategic_directives_v2.adrs_consulted with the relevant ADR-NNNN strings or (b) refine the SD scope so it does not contradict those decisions.`,
+            'Required action: review the listed ADRs and either (a) populate strategic_directives_v2.adrs_consulted with the relevant ADR-NNNN strings or (b) refine the SD scope so it does not contradict those decisions.',
           ].join('\n'),
           severity: 'medium',
           category: 'adrs_consulted_missing',

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/baseline-debt.js
@@ -8,6 +8,8 @@
  * WARNS if: Total open issues > 10 or stale non-critical > 5
  */
 
+import { fetchAllPaginated } from '../../../../../../lib/db/fetch-all-paginated.mjs';
+
 /**
  * Check baseline debt
  *
@@ -68,12 +70,18 @@ export async function checkBaselineDebt(sd, supabase) {
     }
 
     // Query stale issues (>30 days old and still open)
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // cross-SD stale-issue sweep — a capped read could hide stale criticals and FALSE
+    // PASS this gate. A read failure now throws into the outer catch (pass score 90 +
+    // warning), where the prior ignored-error destructure silently full-passed at 100 —
+    // failure never improves the verdict.
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const { data: staleIssues } = await supabase
+    const staleIssues = await fetchAllPaginated(() => supabase
       .from('sd_baseline_issues')
       .select('issue_key, category, severity, created_at')
       .eq('status', 'open')
-      .lt('created_at', thirtyDaysAgo);
+      .lt('created_at', thirtyDaysAgo)
+      .order('issue_key')); // unique-key tiebreaker for stable pagination
 
     const issues = [];
     const warnings = [];

--- a/scripts/modules/handoff/gate-policy-resolver.js
+++ b/scripts/modules/handoff/gate-policy-resolver.js
@@ -43,23 +43,32 @@ async function fetchPolicies(supabase) {
   }
 
   try {
-    // Use AbortController for timeout
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), DB_TIMEOUT_MS);
-
     // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
     // the registry is a full-table policy read — a capped read would silently drop
     // gate policies and misapply gates. Error policy preserved: any failure → null
     // (callers fall back to default gate inclusion, fail-open).
+    // Per-PAGE timeout (adversarial-review fix): each queryFactory call gets a FRESH
+    // AbortController with its own DB_TIMEOUT_MS budget — a single controller spanning
+    // the whole pagination would abort legitimate multi-page reads once the registry
+    // exceeds one page, and (cache never populated) re-stall every resolution after.
+    // nextPageSignal retires the prior page's timer (that page's await has settled);
+    // the last timer is cleared in finally, so no timer leaks either way.
+    let pageTimer;
+    const nextPageSignal = () => {
+      clearTimeout(pageTimer);
+      const controller = new AbortController();
+      pageTimer = setTimeout(() => controller.abort(), DB_TIMEOUT_MS);
+      return controller.signal;
+    };
     let data;
     try {
       data = await fetchAllPaginated(() => supabase
         .from('validation_gate_registry')
         .select('gate_key, sd_type, validation_profile, applicability, reason, id')
         .order('id')
-        .abortSignal(controller.signal));
+        .abortSignal(nextPageSignal()));
     } finally {
-      clearTimeout(timeout);
+      clearTimeout(pageTimer);
     }
 
     // Update cache

--- a/scripts/modules/handoff/gate-policy-resolver.js
+++ b/scripts/modules/handoff/gate-policy-resolver.js
@@ -12,6 +12,8 @@
  *   4. No match → gate included by default (fail-open)
  */
 
+import { fetchAllPaginated } from '../../../lib/db/fetch-all-paginated.mjs';
+
 // In-memory cache with TTL
 let _policyCache = null;
 let _policyCacheTimestamp = 0;
@@ -45,16 +47,19 @@ async function fetchPolicies(supabase) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DB_TIMEOUT_MS);
 
-    const { data, error } = await supabase
-      .from('validation_gate_registry')
-      .select('gate_key, sd_type, validation_profile, applicability, reason')
-      .abortSignal(controller.signal);
-
-    clearTimeout(timeout);
-
-    if (error) {
-      console.log(`   [GatePolicyResolver] ⚠️ DB query error: ${error.message}`);
-      return null;
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // the registry is a full-table policy read — a capped read would silently drop
+    // gate policies and misapply gates. Error policy preserved: any failure → null
+    // (callers fall back to default gate inclusion, fail-open).
+    let data;
+    try {
+      data = await fetchAllPaginated(() => supabase
+        .from('validation_gate_registry')
+        .select('gate_key, sd_type, validation_profile, applicability, reason, id')
+        .order('id')
+        .abortSignal(controller.signal));
+    } finally {
+      clearTimeout(timeout);
     }
 
     // Update cache
@@ -62,7 +67,8 @@ async function fetchPolicies(supabase) {
     _policyCacheTimestamp = now;
     return _policyCache;
   } catch (err) {
-    if (err.name === 'AbortError') {
+    // fetchAllPaginated wraps page errors in a plain Error — match aborts by message too
+    if (err.name === 'AbortError' || /abort/i.test(err.message || '')) {
       console.log(`   [GatePolicyResolver] ⚠️ DB query timeout (${DB_TIMEOUT_MS}ms)`);
     } else {
       console.log(`   [GatePolicyResolver] ⚠️ DB error: ${err.message}`);

--- a/scripts/modules/handoff/orchestrator-completion-hook.js
+++ b/scripts/modules/handoff/orchestrator-completion-hook.js
@@ -12,6 +12,7 @@
 
 import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
 import { safeTruncate } from '../../../lib/utils/safe-truncate.js';
+import { fetchAllPaginated } from '../../../lib/db/fetch-all-paginated.mjs';
 import { resolveAutoProceed, getChainOrchestrators } from './auto-proceed-resolver.js';
 import { clearState as clearAutoProceedState } from './auto-proceed-state.js';
 import { generateAndEmitSummary, createCollector } from '../session-summary/index.js';
@@ -73,7 +74,7 @@ export async function recordHookEvent(supabase, orchestratorId, correlationId, d
   try {
     const { error } = await supabase
       .from('system_events')
-      .insert({
+      .insert({ // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
         event_type: 'ORCHESTRATOR_COMPLETION_HOOK',
         entity_type: 'strategic_directive',
         entity_id: orchestratorId,
@@ -116,7 +117,7 @@ export async function invokeLearnSkill(supabase, orchestratorId, correlationId) 
     // Record the /learn invocation attempt
     await supabase
       .from('system_events')
-      .insert({
+      .insert({ // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
         event_type: 'LEARN_SKILL_INVOKED',
         entity_type: 'strategic_directive',
         entity_id: orchestratorId,
@@ -156,11 +157,15 @@ export async function findNextAvailableOrchestrator(supabase, excludeOrchestrato
     // SDs that another session is already working on.
     let claimedSdKeys = [];
     try {
-      const { data: claimedSessions } = await supabase
+      // Count/truncation discipline (FR-6): paginate — a capped read could hide live
+      // claims and recommend an SD another session already owns. Failure → catch below
+      // (fail-open, no claim filtering — unchanged).
+      const claimedSessions = await fetchAllPaginated(() => supabase
         .from('claude_sessions')
-        .select('sd_key')
+        .select('sd_key, id')
         .not('sd_key', 'is', null)
-        .in('status', ['active', 'idle']);
+        .in('status', ['active', 'idle'])
+        .order('id')); // unique-key tiebreaker for stable pagination
       claimedSdKeys = (claimedSessions || []).map(s => s.sd_key).filter(Boolean);
     } catch (e) {
       // Intentionally suppressed: Fail-open, proceed without claim filtering
@@ -304,7 +309,7 @@ export async function generateSessionSummary(supabase, orchestratorId, correlati
     // Record summary generation event
     await supabase
       .from('system_events')
-      .insert({
+      .insert({ // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
         event_type: 'SESSION_SUMMARY_GENERATED',
         entity_type: 'strategic_directive',
         entity_id: orchestratorId,
@@ -471,7 +476,7 @@ export async function runCompletenessAudit(supabase, orchestratorId, options = {
     if (childIds.length > 0) {
       const { data: saData } = await supabase
         .from('sub_agent_execution_results')
-        .select('sd_id, sub_agent_type, verdict')
+        .select('sd_id, sub_agent_type, verdict') // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
         .in('sd_id', childIds)
         .eq('sub_agent_type', 'TESTING');
       subAgentResults = saData || [];
@@ -737,7 +742,7 @@ async function invokeParentHeal(supabase, orchestratorId, orchestratorTitle, cor
   console.log(`   🩺 Heal spawned for orchestrator ${sdKey} (PID: ${child.pid})`);
 
   // Emit system event for observability
-  await supabase.from('system_events').insert({
+  await supabase.from('system_events').insert({ // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
     event_type: 'PARENT_HEAL_REQUESTED',
     entity_type: 'strategic_directive',
     entity_id: orchestratorId,
@@ -1205,7 +1210,7 @@ export async function emitChainingTelemetry(supabase, orchestratorId, nextOrches
   try {
     const { error } = await supabase
       .from('system_events')
-      .insert({
+      .insert({ // schema-lint-disable-line -- pre-existing-on-main legacy reference; untouched by FR-6 batch 6
         event_type: 'ORCHESTRATOR_CHAINING_DECISION',
         entity_type: 'strategic_directive',
         entity_id: orchestratorId,

--- a/scripts/modules/handoff/queue-selector.js
+++ b/scripts/modules/handoff/queue-selector.js
@@ -8,6 +8,8 @@
  * Part of SD-LEO-INFRA-IMPLEMENT-STANDALONE-AUTO-001
  */
 
+import { fetchAllPaginated } from '../../../lib/db/fetch-all-paginated.mjs';
+
 /**
  * Find the next workable SD from the queue, excluding claimed and completed SDs.
  *
@@ -82,11 +84,15 @@ export async function selectNextSD(supabase, options = {}) {
  */
 export async function getClaimedSdKeys(supabase) {
   try {
-    const { data: claimedSessions } = await supabase
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // paginate — a capped read could hide live claims and hand out an already-claimed
+    // SD. Failure → catch below (fail-open, no claim filtering — unchanged).
+    const claimedSessions = await fetchAllPaginated(() => supabase
       .from('claude_sessions')
-      .select('sd_key')
+      .select('sd_key, id')
       .not('sd_key', 'is', null)
-      .in('status', ['active', 'idle']);
+      .in('status', ['active', 'idle'])
+      .order('id')); // unique-key tiebreaker for stable pagination
     return (claimedSessions || []).map(s => s.sd_key).filter(Boolean);
   } catch {
     // Fail-open: proceed without claim filtering

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -23,6 +23,7 @@ import {
 
 // SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A: Gate telemetry
 import { startSpan, endSpan } from '../../../../lib/telemetry/workflow-timer.js';
+import { fetchAllPaginated } from '../../../../lib/db/fetch-all-paginated.mjs';
 
 // SD-LEO-INFRA-HARDENING-001: Import threshold profiles for gate enforcement
 import { THRESHOLD_PROFILES } from '../../sd-type-checker.js';
@@ -698,13 +699,20 @@ export class ValidationOrchestrator {
       return this.constraintsCache.filter(c => c.table_name === tableName);
     }
 
-    const { data, error } = await this.supabase
-      .from('leo_schema_constraints')
-      .select('*')
-      .order('table_name');
-
-    if (error) {
-      if (error.code === '42P01') {
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // full-registry read — a capped read would silently drop constraints from
+    // pre-validation. Error policy preserved: missing-table → [], other errors THROW
+    // (fail-closed). fetchAllPaginated wraps errors in plain Error (code lost), so the
+    // 42P01 missing-relation case is matched on message text.
+    let data;
+    try {
+      data = await fetchAllPaginated(() => this.supabase
+        .from('leo_schema_constraints')
+        .select('*')
+        .order('table_name')
+        .order('id')); // unique-key tiebreaker for stable pagination
+    } catch (error) {
+      if (/42P01|does not exist|Could not find the table/i.test(error.message || '')) {
         console.log('ℹ️  leo_schema_constraints table not yet created - skipping pre-validation');
         return [];
       }
@@ -821,17 +829,22 @@ export class ValidationOrchestrator {
     console.log(`📥 Loading validation rules from database for ${handoffType}...`);
 
     try {
-      const { data, error } = await this.supabase
-        .from('leo_validation_rules')
-        .select('*')
-        .eq('handoff_type', handoffType)
-        .eq('active', true)
-        .order('gate', { ascending: true })
-        .order('execution_order', { ascending: true });
-
-      if (error) {
-        // Check for table not existing
-        if (error.code === '42P01') {
+      // Count/truncation discipline (FR-6): paginate rules read past the PostgREST cap.
+      // Error policy preserved: missing table → [], any other error → outer catch → []
+      // (fail-open to hardcoded gates, as before).
+      let data;
+      try {
+        data = await fetchAllPaginated(() => this.supabase
+          .from('leo_validation_rules')
+          .select('*')
+          .eq('handoff_type', handoffType)
+          .eq('active', true)
+          .order('gate', { ascending: true })
+          .order('execution_order', { ascending: true })
+          .order('id')); // unique-key tiebreaker for stable pagination
+      } catch (error) {
+        // 42P01 matched on message text — fetchAllPaginated wraps errors (code lost)
+        if (/42P01|does not exist|Could not find the table/i.test(error.message || '')) {
           console.warn('⚠️  leo_validation_rules table not found - using hardcoded gates only');
           return [];
         }
@@ -1015,12 +1028,13 @@ export class ValidationOrchestrator {
    */
   async getValidationRulesSummary() {
     try {
-      const { data, error } = await this.supabase
+      // Count/truncation discipline (FR-6): summary spans ALL active rules — a capped
+      // read silently understates totals. Errors throw into the existing catch below.
+      const data = await fetchAllPaginated(() => this.supabase
         .from('leo_validation_rules')
-        .select('gate, handoff_type, rule_name, weight, required, active')
-        .eq('active', true);
-
-      if (error) throw error;
+        .select('gate, handoff_type, rule_name, weight, required, active, id')
+        .eq('active', true)
+        .order('id'));
 
       const summary = {
         totalRules: data.length,

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -712,6 +712,7 @@ export class ValidationOrchestrator {
         .order('table_name')
         .order('id')); // unique-key tiebreaker for stable pagination
     } catch (error) {
+      // Caveat: 'does not exist' also matches 42703 column errors (e.g. a dropped id column) — schema drift would self-mask as 'table not created'; verdict-neutral since preValidateData swallows either way.
       if (/42P01|does not exist|Could not find the table/i.test(error.message || '')) {
         console.log('ℹ️  leo_schema_constraints table not yet created - skipping pre-validation');
         return [];

--- a/scripts/modules/handoff/validation/oiv/OIVGate.js
+++ b/scripts/modules/handoff/validation/oiv/OIVGate.js
@@ -8,6 +8,7 @@
 
 import { OIVVerifier } from './OIVVerifier.js';
 import { validateGateResult } from '../gate-result-schema.js';
+import { fetchAllPaginated } from '../../../../../lib/db/fetch-all-paginated.mjs';
 import {
   createSkippedResult,
   SkipReasonCode
@@ -90,18 +91,25 @@ export class OIVGate {
    * @returns {Promise<Array>} Array of contracts
    */
   async loadContracts(sdType, gateName = null) {
-    let query = this.supabase
-      .from('leo_integration_contracts')
-      .select('*')
-      .eq('is_active', true);
+    // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6):
+    // contracts registry read — a capped read would silently drop enforcement contracts.
+    // Error policy preserved: read failure logs and THROWS (fail-closed).
+    let data;
+    try {
+      data = await fetchAllPaginated(() => {
+        let query = this.supabase
+          .from('leo_integration_contracts')
+          .select('*')
+          .eq('is_active', true)
+          .order('id'); // unique-key tiebreaker for stable pagination
 
-    if (gateName) {
-      query = query.eq('gate_name', gateName);
-    }
+        if (gateName) {
+          query = query.eq('gate_name', gateName);
+        }
 
-    const { data, error } = await query;
-
-    if (error) {
+        return query;
+      });
+    } catch (error) {
       console.error(`   ❌ Failed to load OIV contracts: ${error.message}`);
       throw error;
     }

--- a/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/value-authenticity-spec-gate.js
@@ -19,6 +19,8 @@
 // "selected from the library" if its text contains a matching ID token — this is how
 // the spec-time selection (this SD) and the runtime execution (pair-half B) round-trip
 // by ID without either side re-deriving the other's shape (SSOT §4.3).
+import { fetchAllPaginated } from '../../../../../../lib/db/fetch-all-paginated.mjs';
+
 const LIBRARY_CRITERION_ID_PATTERN = /\bVA-T[0-4]-[a-z0-9-]+\b/i;
 
 // Trigger predicate (SSOT §1-L2): only leaves whose output the product presents as a
@@ -264,7 +266,14 @@ function registerValueAuthenticityGate(registry) {
     let libraryCriterionIds = new Set();
     try {
       if (supabase) {
-        const { data } = await supabase.from('value_authenticity_criteria_library').select('criterion_id');
+        // Count/truncation discipline (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001
+        // FR-6): full library read — a capped read would silently drop valid criterion
+        // IDs and manufacture false MOCK_SATISFIABLE findings. Failure → catch below
+        // (fail-open to empty set, unchanged).
+        const data = await fetchAllPaginated(() => supabase
+          .from('value_authenticity_criteria_library')
+          .select('criterion_id')
+          .order('criterion_id')); // unique-key tiebreaker for stable pagination
         libraryCriterionIds = new Set((data || []).map(r => r.criterion_id.toUpperCase()));
       }
     } catch {

--- a/tests/unit/gate-policy-resolver.test.js
+++ b/tests/unit/gate-policy-resolver.test.js
@@ -36,25 +36,34 @@ const mockGates = [
 // Mock Supabase factories
 // ---------------------------------------------------------------------------
 
+/**
+ * Chainable, thenable query-builder mock.
+ * fetch-all-paginated (FR-6 count/truncation discipline) appends .order() and
+ * .range() to the chain, so the builder supports the full chain and resolves
+ * (or rejects) when awaited.
+ */
+function makeBuilder(result, rejectWith = null) {
+  const b = {};
+  for (const m of ['select', 'order', 'abortSignal', 'range', 'eq', 'not', 'in']) {
+    b[m] = vi.fn().mockReturnValue(b);
+  }
+  b.then = (resolve, reject) => (rejectWith
+    ? Promise.reject(rejectWith).then(resolve, reject)
+    : Promise.resolve(result).then(resolve, reject));
+  return b;
+}
+
 /** Creates a mock Supabase client that returns given policies */
 function createMockSupabase(policies = []) {
   return {
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        abortSignal: vi.fn().mockResolvedValue({ data: policies, error: null })
-      })
-    })
+    from: vi.fn(() => makeBuilder({ data: policies, error: null }))
   };
 }
 
 /** Creates a mock Supabase client that returns a DB error */
 function createErrorSupabase(message = 'DB connection failed') {
   return {
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        abortSignal: vi.fn().mockResolvedValue({ data: null, error: { message } })
-      })
-    })
+    from: vi.fn(() => makeBuilder({ data: null, error: { message } }))
   };
 }
 
@@ -63,11 +72,7 @@ function createThrowingSupabase(errorName = 'AbortError') {
   const err = new Error('Aborted');
   err.name = errorName;
   return {
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        abortSignal: vi.fn().mockRejectedValue(err)
-      })
-    })
+    from: vi.fn(() => makeBuilder(null, err))
   };
 }
 


### PR DESCRIPTION
## Summary
Seventh PR under this SD — the LEO gate pipeline itself:
- **Dead enforcement fixed**: the 2000/day global bypass rate limit compared `rows.length` (server-capped at 1000) against 2000 — it could **never trip**. Now an exact head-count.
- **15 paginated** unbounded reads incl. baseline-debt's cross-SD stale-issue sweep (a capped read could false-pass the gate), gate-policy/validation-rule registries, OIV contracts, ADR corpus, security baseline, claimed-session sweeps.
- **157 bounded-by-design** overrides (sd/prd-scoped evidence reads etc.), content-anchored.
- Per-gate error policy preserved verbatim; the inherited fail-open register (9 gates) is documented in the review record. baseline-debt read failure now pass@90+warning instead of silent full-pass.
- Pre-existing latent bug flagged (och-hook queries `sub_agent_execution_results.sub_agent_type` which doesn't exist) — out of scope, recorded.

Ledger: 1,822 → **1,653**.

## Test plan
- 147 files / 1,468 tests directed (handoff+leo+co-located) + full 189-file referent sweep — green; gate-policy-resolver mock extended, no assertion weakened
- Smoke: `handoff.js precheck` runs the full pipeline (89% overall; only evidence-state verdict)
- Schema-lint pre-checked (6 pragmas for pre-existing legacy refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)