### PR TITLE
feat(SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-G): escalation-latency budgets SSOT

### DIFF
--- a/lib/org/escalation-latency-budgets.mjs
+++ b/lib/org/escalation-latency-budgets.mjs
@@ -1,0 +1,39 @@
+// FW-3 Child F (SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-G): value-neutral escalation-latency budgets.
+// The SSOT bounding how long a framing/escalation may sit before it MUST move. Data-only frozen config
+// + pure helpers so the framing self-escalation and chairman-escalation paths carry no hardcoded
+// latency literals. Defaults borrow the sourcing-engine SLA shape (lib/sourcing-engine/escalator.js
+// DEFAULT_SLA_HOURS: CHAIRMAN_GATED 72h / OUTCOME_GATED 168h) and the chairman-decision-timeout poller
+// semantics. This is PLUMBING — it carries no "better"; the apex objective function recurses into the
+// spine §3.3 row (FW-3 Child G / -001-H), never here.
+
+/** Per-stage escalation-latency ceilings. Frozen so it is a true single-source-of-truth. */
+export const ESCALATION_LATENCY_BUDGETS = Object.freeze({
+  framing_floor_attempt: Object.freeze({ hours: 1, note: 'apex floor attempt (Opus@high) before it must emit a residual-depth signal' }),
+  self_escalation_to_fable: Object.freeze({ hours: 4, note: 'intra-wake self-escalation to a higher-effort (Fable) pass once residual trips' }),
+  chairman_escalation_delivery: Object.freeze({ hours: 72, note: 'a pick-class framing must reach the chairman within this SLA (mirrors sourcing CHAIRMAN_GATED 72h)' }),
+  outcome_gated: Object.freeze({ hours: 168, note: 'outcome-gated escalation window (mirrors sourcing OUTCOME_GATED 168h)' }),
+});
+
+/**
+ * Budget (in hours) for an escalation stage. Returns null for an unknown stage (never throws) —
+ * consumers treat null as "no budget configured for this stage".
+ * @param {string} stage
+ * @returns {number|null}
+ */
+export function budgetHours(stage) {
+  const b = ESCALATION_LATENCY_BUDGETS[stage];
+  return b && typeof b.hours === 'number' ? b.hours : null;
+}
+
+/**
+ * Has `elapsedMs` since the stage began exceeded that stage's latency budget?
+ * Unknown stage (no budget) -> false (nothing to breach); non-finite elapsed -> false (fail-open).
+ * @param {string} stage
+ * @param {number} elapsedMs  milliseconds elapsed since the stage was entered
+ * @returns {boolean}
+ */
+export function isOverBudget(stage, elapsedMs) {
+  const hours = budgetHours(stage);
+  if (hours === null || !Number.isFinite(elapsedMs)) return false;
+  return elapsedMs > hours * 3600 * 1000;
+}

--- a/tests/unit/escalation-latency-budgets.test.js
+++ b/tests/unit/escalation-latency-budgets.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { ESCALATION_LATENCY_BUDGETS, budgetHours, isOverBudget } from '../../lib/org/escalation-latency-budgets.mjs';
+
+// FW-3 Child F (SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-G): value-neutral escalation-latency budgets SSOT.
+
+describe('escalation-latency budgets (FW3 Child F)', () => {
+  it('every stage has a finite positive hours budget + a note', () => {
+    const stages = Object.keys(ESCALATION_LATENCY_BUDGETS);
+    expect(stages.length).toBeGreaterThanOrEqual(4);
+    for (const b of Object.values(ESCALATION_LATENCY_BUDGETS)) {
+      expect(Number.isFinite(b.hours)).toBe(true);
+      expect(b.hours).toBeGreaterThan(0);
+      expect(typeof b.note).toBe('string');
+    }
+  });
+
+  it('budgetHours returns the stage hours for known stages', () => {
+    expect(budgetHours('framing_floor_attempt')).toBe(1);
+    expect(budgetHours('self_escalation_to_fable')).toBe(4);
+  });
+
+  it('defaults mirror the sourcing SLA shape (72h CHAIRMAN_GATED / 168h OUTCOME_GATED)', () => {
+    expect(budgetHours('chairman_escalation_delivery')).toBe(72);
+    expect(budgetHours('outcome_gated')).toBe(168);
+  });
+
+  it('isOverBudget is false below and true above the budget', () => {
+    const ceil = 72 * 3600 * 1000;
+    expect(isOverBudget('chairman_escalation_delivery', ceil - 1)).toBe(false);
+    expect(isOverBudget('chairman_escalation_delivery', ceil + 1)).toBe(true);
+  });
+
+  it('unknown stage / non-finite elapsed is graceful (null / false, never throws)', () => {
+    expect(budgetHours('does_not_exist')).toBeNull();
+    expect(isOverBudget('does_not_exist', 999999999999)).toBe(false);
+    expect(isOverBudget('chairman_escalation_delivery', NaN)).toBe(false);
+    expect(() => isOverBudget('x')).not.toThrow();
+  });
+
+  it('the config is frozen (immutable SSOT)', () => {
+    expect(Object.isFrozen(ESCALATION_LATENCY_BUDGETS)).toBe(true);
+    expect(Object.isFrozen(ESCALATION_LATENCY_BUDGETS.chairman_escalation_delivery)).toBe(true);
+  });
+});


### PR DESCRIPTION
FW-3 Child F — value-neutral escalation-latency budgets: the SSOT bounding how long a framing/escalation may sit before it must move. Formalizes the prose-only `task_budget` into a real, testable config so the framing self-escalation and chairman-escalation paths carry no hardcoded latency literals.

- `lib/org/escalation-latency-budgets.mjs`: frozen `ESCALATION_LATENCY_BUDGETS` + pure `budgetHours()`/`isOverBudget()`; defaults mirror the sourcing SLA shape (CHAIRMAN_GATED 72h / OUTCOME_GATED 168h); unknown stage / non-finite elapsed degrade gracefully (null/false, never throw).
- `tests/unit/escalation-latency-budgets.test.js`: 6 scenarios, all green.

Parent: SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001 (orchestrator). Value-neutral plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)