### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-002): filter recurring VALIDATION boilerplate (SAL-VALIDATION-REC)

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -153,6 +153,14 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /execute e2e tests before approval.*mandatory/i,
   /e2e testing is not optional per protocol/i,
   /node scripts\/execute-subagent\.js --code testing/i,
+  // SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-002: VALIDATION generic checklist boilerplate (SAL-VALIDATION-REC, 3x).
+  // These are the deterministic standard-checklist reminders the VALIDATION sub-agent always emits — normal
+  // process guidance, NOT specific problems to fix — so they must not keep minting noise /learn SDs.
+  /plan agent should create prd/i,
+  /link backlog items to define clear requirements/i,
+  /perform codebase search to identify existing infrastructure/i,
+  /complete gap analysis.*backlog requirements/i,
+  /execute qa engineering director before/i,
   // QF-20260210-539: Additional patterns from false positive analysis
   /test evidence is (?:fresh|recent|up.?to.?date)/i,
   /\d+ user stories? not fully (?:covered|tested|verified)/i,

--- a/tests/unit/learning/sal-validation-filter.test.js
+++ b/tests/unit/learning/sal-validation-filter.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isNonActionableRecommendation } from '../../../scripts/modules/learning/context-builder.js';
+
+// SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-002: the VALIDATION sub-agent's generic checklist boilerplate
+// (SAL-VALIDATION-REC) recurred 3x, minting noise /learn SDs. These are normal process reminders,
+// not specific problems — they must be filtered as non-actionable.
+
+describe('SAL-VALIDATION-REC filtering (SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-002)', () => {
+  const VALIDATION_BOILERPLATE = [
+    'PLAN agent should create PRD before EXEC phase begins',
+    'Link backlog items to define clear requirements OR document reason for no backlog',
+    'Perform codebase search to identify existing infrastructure (prevents duplicate work)',
+    'Complete gap analysis: Compare backlog requirements vs existing code',
+    'Execute QA Engineering Director before final approval (MANDATORY per protocol)',
+  ];
+
+  it('filters every recurring VALIDATION generic-checklist recommendation', () => {
+    for (const rec of VALIDATION_BOILERPLATE) {
+      expect(isNonActionableRecommendation(rec)).toBe(true);
+    }
+  });
+
+  it('does NOT over-filter a genuinely actionable VALIDATION finding', () => {
+    expect(isNonActionableRecommendation('Validation gate reads stale sub_agent_execution_results — dedupe by phase')).toBe(false);
+    expect(isNonActionableRecommendation('directive_id foreign key missing on product_requirements_v2')).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds VALIDATION generic-checklist boilerplate to NON_ACTIONABLE_SAL_PATTERNS in scripts/modules/learning/context-builder.js so the recurring SAL-VALIDATION-REC pattern stops minting noise /learn SDs (matches sibling SAL-*-REC filters). +5 regexes, +unit test (boilerplate filtered, real findings not over-filtered). 🤖 Generated with Claude Code