### PR TITLE
fix(SD-LEO-FEAT-FORECAST-LEDGER-001): CI lint + WIRE_CHECK follow-up (post-merge)

### DIFF
--- a/database/migrations/20260719_forecast_ledger_STAGED.sql
+++ b/database/migrations/20260719_forecast_ledger_STAGED.sql
@@ -27,11 +27,14 @@ CREATE INDEX IF NOT EXISTS idx_forecast_ledger_status         ON public.forecast
 
 ALTER TABLE public.forecast_ledger ENABLE ROW LEVEL SECURITY;
 
--- Writes are service-role only; advisory evidence is broadly readable (SELECT) by authenticated.
+-- Reads AND writes are service-role only: this is an INTERNAL org-service ledger with no tenant
+-- column and no user-facing surface. A broad authenticated USING(true) SELECT would leak every
+-- org forecast to any signed-in caller (rls-anon-tenant-predicate-lint class — cf. companies /
+-- feedback prior incidents). All real consumers (gate-attach, truth-layer, CLI) use the
+-- service-role client; a future chairman-dashboard read would go through a scoped view/API,
+-- wired when the chairman applies this migration (operator-triple follow-up).
 CREATE POLICY forecast_ledger_service_all ON public.forecast_ledger
   FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY forecast_ledger_read ON public.forecast_ledger
-  FOR SELECT TO authenticated USING (true);
 
 -- Sealed pre-registration: once a row exists its registered fields are immutable; only the
 -- resolution columns may change, and only on the open->resolved transition (no re-resolve).

--- a/docs/reference/forecast-ledger-org-service.md
+++ b/docs/reference/forecast-ledger-org-service.md
@@ -1,3 +1,12 @@
+---
+Category: Reference
+Status: Approved
+Version: 1.0.0
+Author: SD-LEO-FEAT-FORECAST-LEDGER-001
+Last Updated: 2026-07-19
+Tags: [forecasting, brier, kill-gate, advisory, chairman-gated]
+---
+
 # Forecast Ledger org-service
 
 SD-LEO-FEAT-FORECAST-LEDGER-001 — a general-purpose, immutable ledger of **pre-registered
@@ -5,19 +14,27 @@ probabilistic forecasts**, Brier-scored on resolution, attached as **advisory-we
 the venture kill-gates.
 
 ## Modules
-- `brier.js` — pure, shared Brier math (`brierScore`, `round3`, `meanBrier`, `interpretBrier`). The
+- `lib/forecasting/brier.js` — pure, shared Brier math (`brierScore`, `round3`, `meanBrier`, `interpretBrier`). The
   **canonical extraction** of the formula that was inline in `lib/eva/experiments/baseline-accuracy.js`
   (`analyzeAccuracy`) and `lib/agents/venture-ceo/truth-layer.js` (`_computeCalibrationDelta`). Reuse,
   do not reimplement. `brierScore` returns the RAW `(clamp01(p)-outcome)²` — callers round with
   `round3` (float hazard: `(0.7-1)² = 0.09000000000000002`).
-- `ledger.js` — `register` / `resolve` / `calibration`. Injected supabase client (`deps.supabase`);
+- `lib/forecasting/ledger.js` — `register` / `resolve` / `calibration`. Injected supabase client (`deps.supabase`);
   **fail-soft** when the table is absent (`tableAbsent()`), mirroring `sms-bridge` drain semantics.
-- `gate-attach.js` — READ-ONLY advisory attach to S3/S5/S16 briefs. `buildGateBrief()` passes the
+- `lib/forecasting/gate-attach.js` — READ-ONLY advisory attach to S3/S5/S16 briefs. `buildGateBrief()` passes the
   gate verdict through untouched via `structuredClone` — CONST-001: a forecast can never flip a verdict.
 
 CLI: `scripts/forecast-ledger.js register|resolve|calibration`.
 Table: `database/migrations/20260719_forecast_ledger_STAGED.sql` (RLS-at-create + sealed-immutability
 trigger; **chairman-gated apply** — `STAGED`, not auto-applied).
+
+## Access / RLS
+RLS is enabled at create with a **single service-role policy** (`forecast_ledger_service_all`, `FOR ALL`).
+This is an internal org-service ledger with no tenant column and no user-facing surface, so there is
+**deliberately no broad `authenticated` SELECT** — a `USING(true)` authenticated read would leak every
+org forecast to any signed-in caller (`rls-anon-tenant-predicate-lint` class). All real consumers
+(`gate-attach`, `truth-layer`, CLI) use the service-role client; a future chairman-dashboard read would
+go through a scoped view/API, wired when the chairman applies the migration (operator-triple follow-up).
 
 ## Boundary vs existing prediction infrastructure (FR-8)
 This ledger is a NEW, general-purpose org-service — NOT a duplicate. It **references, does not fork**:

--- a/lib/forecasting/gate-attach.js
+++ b/lib/forecasting/gate-attach.js
@@ -2,6 +2,10 @@
 // SD-LEO-FEAT-FORECAST-LEDGER-001. CONST-001: this module is READ-ONLY — it returns evidence
 // LINES for a brief and NEVER receives, scores, or mutates a gate verdict. buildGateBrief()
 // passes the verdict through untouched (structuredClone) so a forecast can never flip a verdict.
+// @wire-check-exempt: foundation advisory-attach surface — READ-ONLY kill-gate brief augmentation
+// (S3/S5/S16). Built first; wired into live gate execution at the activation follow-up (operator-triple
+// wiring when the chairman applies the STAGED migration). Consumed today by its unit tests; the live
+// gate call-site is the deferred follow-up flagged for the coordinator.
 import { interpretBrier } from './brier.js';
 import { tableAbsent } from './ledger.js';
 

--- a/package.json
+++ b/package.json
@@ -363,6 +363,7 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "forecast-ledger": "node scripts/forecast-ledger.js",
     "stamp:tier-rank": "node scripts/stamp-sd-tier-rank.mjs",
     "reconcile:gate-decisions": "node scripts/reconcile-gate-decisions.mjs",
     "backfill:gate-decisions": "node scripts/retro-backfill-gate-decisions.mjs",

--- a/scripts/lint/schema-reference-allowlist.json
+++ b/scripts/lint/schema-reference-allowlist.json
@@ -16,6 +16,7 @@
   "model_capability_reference",
   "chairman_constraints_proposals",
   "cost_governor_log",
+  "forecast_ledger",
   "sms_relay_staging",
   "sms_inbound_suspensions",
   "sms_decision_class_whitelist",
@@ -23,6 +24,7 @@
   "sms_outbound_obligations",
   "chairman_switchon_policy"
  ],
+ "_forecast_ledger_note": "chairman-gated, staged-not-applied table (SD-LEO-FEAT-FORECAST-LEDGER-001): migration database/migrations/20260719_forecast_ledger_STAGED.sql carries the @chairman-gated header (additive table WITH RLS+service-role policy — outside the additive-no-rls delegated-apply scope) and is deliberately not applied pre-chairman. The referencing code is FAIL-SOFT by construction: lib/forecasting/ledger.js + gate-attach.js use tableAbsent() (42P01/PGRST205 -> {inert:true} / empty attach) and lib/agents/venture-ceo/truth-layer.js computeCalibration() returns its empty-shape result when the table is absent — a missing table never crashes a live path. Remove from this allowlist and re-run npm run schema:snapshot:lint after a chairman applies the migration.",
  "_chairman_constraints_proposals_note": "chairman-gated, staged-not-applied table (SD-LEO-INFRA-STAGE-GROUNDING-INJECTOR-001 FR-3): migration database/migrations/20260716_chairman_constraints_proposals_governed_write_path.sql is deliberately not yet applied (requires-chairman-apply header). The referencing functions in lib/eva/stage-zero/synthesis/chairman-constraints.js (proposeConstraintFromOutcome / ratifyProposedConstraint) are the governed write-path API and are not yet wired into a live kill-gate/retro trigger, so the table's absence cannot crash a live path. Remove from this allowlist and re-run npm run schema:snapshot:lint after a chairman applies the migration.",
  "_door_routing_ledger_note": "apply-at-cutover table (SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001): migration 20260705_add_door_routing_ledger.sql applies at the Tuesday DOOR_ROUTING_ENABLED flip; the flag-gated fire-and-forget writer tolerates its absence pre-cutover. Remove from this allowlist after the migration applies.",
  "_venture_operating_burn_note": "chairman-gated, staged-not-applied table (SD-APEXNICHE-AI-LEO-ORCH-SPRINT-2026-001-E1): migration database/migrations/20260712_venture_operating_burn.sql is deliberately not yet applied to the live DB (per the @chairman-gated header). The fail-soft writer (scripts/operator/feed-venture-operating-burn.mjs) tolerates the table's absence -- every upsert call is wrapped in a per-step try/catch. Remove from this allowlist and re-run npm run schema:snapshot:lint after a chairman applies the migration.",

--- a/tests/unit/forecasting/migration-shape.test.js
+++ b/tests/unit/forecasting/migration-shape.test.js
@@ -25,10 +25,12 @@ describe('forecast_ledger migration shape (FR-1)', () => {
     expect(sql).toMatch(/CHECK \(p >= 0 AND p <= 1\)/);
     expect(sql).toMatch(/status IN \('open','resolved'\)/);
   });
-  it('enables RLS at create with policies (service-role write, authenticated read)', () => {
+  it('enables RLS at create with a service-role-only policy (no broad authenticated read)', () => {
     expect(sql).toMatch(/ENABLE ROW LEVEL SECURITY/);
     expect(sql).toMatch(/CREATE POLICY forecast_ledger_service_all/);
-    expect(sql).toMatch(/CREATE POLICY forecast_ledger_read/);
+    // Least privilege: internal org-service ledger, no tenant column — a broad authenticated
+    // USING(true) SELECT would leak every forecast (rls-anon-tenant-predicate-lint class).
+    expect(sql).not.toMatch(/TO authenticated/);
   });
   it('installs a sealed-immutability UPDATE guard trigger (immutable registered fields + no re-resolve)', () => {
     expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.forecast_ledger_seal_guard/);


### PR DESCRIPTION
## Summary
Follow-up to PR #6297 (SD-LEO-FEAT-FORECAST-LEDGER-001, already merged + SD completed). #6297 auto-merged on the required checks before these advisory-lint fixes existed, so main briefly carries 3 lint failures this PR resolves, plus the WIRE_CHECK exemptions for the foundation forecast files.

- **rls-anon-tenant-predicate-lint**: drop the broad `authenticated USING(true)` SELECT on `forecast_ledger` (internal org-service, no tenant column → service-role only, least privilege).
- **schema-reference-lint**: allowlist `forecast_ledger` (chairman-gated STAGED table, fail-soft consumers) — same pattern as `cost_governor_log`.
- **docmon RULE-PROHIB-002**: move `lib/forecasting/README.md` → `docs/reference/forecast-ledger-org-service.md` (docs belong in docs/) with required metadata frontmatter.
- **WIRE_CHECK**: `package.json` `forecast-ledger` script entry (CLI entry point → `ledger.js`→`brier.js` reachable) + `@wire-check-exempt` on `gate-attach.js` (advisory attach; live gate wiring is the activation follow-up).

## Test plan
- [x] rls-anon-tenant-predicate-lint: 0 forecast flags.
- [x] schema-reference-lint: 0 violations.
- [x] docmon: LF blob passes on CI (local Windows CRLF is a working-tree artifact only).
- [x] 37 forecasting unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)