### PR TITLE
feat(SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C): fail-closed pick-vs-instrument framing routing

### DIFF
--- a/lib/governance/fw3-framing-router.cjs
+++ b/lib/governance/fw3-framing-router.cjs
@@ -1,0 +1,58 @@
+'use strict';
+/**
+ * FW-3 fail-closed pick-vs-instrument framing router.
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (FR-1, FR-4).
+ *
+ * PURE predicate over the framing_class wire contract established by sibling -B
+ * (lib/fleet/worker-status.cjs FRAMING_CLASSES): for a row on the oracle
+ * systemic-finding leg (payload.oracle === true),
+ *   instrument            -> adam_sourcing
+ *   pick                  -> chairman_escalation (CMV/portfolio-altitude)
+ *   missing/unrecognized  -> chairman_escalation (FAIL-CLOSED: a framing that
+ *                            cannot PROVE it is instrument-class escalates)
+ * Non-oracle rows are OUT OF DOMAIN (route: null) — they are plain advisories,
+ * not framings. This domain bound is the flood-guard that makes fail-closed
+ * safe against legacy rows (TR-2).
+ *
+ * laneAnalog reuses the sourcing-engine lane vocabulary (lib/sourcing-engine/
+ * lane.js) so downstream FW-3 consumers persist consistently — imported, not
+ * re-typed (FR-4). require-of-ESM: Node >= 22.12 loads a synchronous ESM module
+ * from CJS; lane.js is pure and TLA-free (same pattern as lib/fleet/tier-claimable.cjs).
+ */
+const { FRAMING_CLASSES } = require('../fleet/worker-status.cjs');
+const { LANE } = require('../sourcing-engine/lane.js');
+
+/** Routing destinations. Frozen. */
+const FRAMING_ROUTES = Object.freeze({
+  ADAM_SOURCING: 'adam_sourcing',
+  CHAIRMAN_ESCALATION: 'chairman_escalation',
+});
+
+/** Sourcing-engine lane analogs per route (FR-4) — values from lane.js, not literals. */
+const LANE_ANALOG = Object.freeze({
+  [FRAMING_ROUTES.ADAM_SOURCING]: LANE.BELT_READY,
+  [FRAMING_ROUTES.CHAIRMAN_ESCALATION]: LANE.CHAIRMAN_GATED,
+});
+
+/**
+ * Route a session_coordination row's framing. PURE — no IO.
+ * @param {{payload?: {oracle?: boolean, framing_class?: string}}} row
+ * @returns {{route: string|null, reason: string, laneAnalog: string|null}}
+ */
+function routeFraming(row) {
+  const payload = (row && row.payload) || {};
+  if (payload.oracle !== true) {
+    return { route: null, reason: 'not-a-framing', laneAnalog: null };
+  }
+  const fc = payload.framing_class;
+  if (fc === FRAMING_CLASSES.INSTRUMENT) {
+    return { route: FRAMING_ROUTES.ADAM_SOURCING, reason: 'instrument', laneAnalog: LANE_ANALOG[FRAMING_ROUTES.ADAM_SOURCING] };
+  }
+  if (fc === FRAMING_CLASSES.PICK) {
+    return { route: FRAMING_ROUTES.CHAIRMAN_ESCALATION, reason: 'pick-class', laneAnalog: LANE_ANALOG[FRAMING_ROUTES.CHAIRMAN_ESCALATION] };
+  }
+  // FAIL-CLOSED: absent or unrecognized framing_class on the oracle leg escalates.
+  return { route: FRAMING_ROUTES.CHAIRMAN_ESCALATION, reason: 'unproven', laneAnalog: LANE_ANALOG[FRAMING_ROUTES.CHAIRMAN_ESCALATION] };
+}
+
+module.exports = { routeFraming, FRAMING_ROUTES, LANE_ANALOG };

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -53,7 +53,10 @@ const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version
 const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
-const { PAYLOAD_KINDS, DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS, FRAMING_CLASSES } = require('../lib/fleet/worker-status.cjs');
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
+// SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C: fail-closed pick-vs-instrument routing predicate
+// (consumes the -B framing_class contract; FRAMING_CLASSES matching now lives in the router).
+const { routeFraming, FRAMING_ROUTES } = require('../lib/governance/fw3-framing-router.cjs');
 // SD-LEO-INFRA-COORDINATION-LANE-DELIVERY-CONTRACT-001 FR-2: canonical body read (payload.body
 // primary, body-column fallback) — closes instance 4, the coordinator_request body-drop below.
 const { readCanonicalBody } = require('../lib/coordination/lane-contract.cjs');
@@ -540,6 +543,50 @@ async function renderChairmanDirectives(supabase, role, { quiet = false } = {}) 
  * DELIVERED-but-unacked directive stays recoverable via scripts/read-adam-directives.cjs (the
  * acknowledged_at IS NULL tier) until Adam genuinely acts.
  */
+/**
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (FR-2/FR-3): record a chairman-escalation
+ * pending decision for a pick/unproven oracle framing. Idempotent per advisory row id
+ * (probe-before-insert on brief_data->context->>advisory_row_id; drainInbox is
+ * single-process so retries serialize). Returns true iff the row is durably queued
+ * (pre-existing counts). NEVER throws — fail-soft for drain liveness, loud on failure.
+ */
+async function recordFramingEscalation(supabase, r, routed) {
+  try {
+    const { data: existing } = await supabase
+      .from('chairman_decisions')
+      .select('id')
+      .eq('brief_data->context->>advisory_row_id', String(r.id))
+      .limit(1);
+    if (existing && existing.length > 0) return true; // already queued (idempotent)
+    const body = (r.payload && r.payload.body) || r.body || r.subject || '';
+    const { recordPendingDecision } = await import('../lib/chairman/record-pending-decision.mjs');
+    const res = await recordPendingDecision(supabase, {
+      title: `Framing escalation (${routed.reason}): ${String(body).slice(0, 120) || '(no body)'}`,
+      // RISK condition (a): blocking:false + non-session_question decisionType makes
+      // shouldAutoEscalate() provably false — queue-only, zero per-row standout email/SMS.
+      decisionType: 'framing_escalation',
+      blocking: false,
+      raisedBy: 'adam',
+      context: {
+        advisory_row_id: String(r.id),
+        framing_class: (r.payload && r.payload.framing_class) || 'unproven',
+        reason: routed.reason,
+        lane_analog: routed.laneAnalog,
+        sender_session: r.sender_session || null,
+        excerpt: String(body).slice(0, 400),
+      },
+    });
+    if (!res || res.recorded !== true) {
+      console.error(`  ✖ ESCALATION WRITE FAILED (id=${r.id}): ${(res && res.error) || 'unknown'}`);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error(`  ✖ ESCALATION WRITE FAILED (id=${r.id}): ${(e && e.message) || e}`);
+    return false;
+  }
+}
+
 async function drainInbox(supabase, sessionId, { quiet = false, background = false, windowMs = DEFAULT_DRAIN_WINDOW_MS } = {}) {
   // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-4): recoverable filter is
   // acknowledged_at IS NULL — a row any background/legacy pass read-stamped still surfaces
@@ -626,19 +673,25 @@ async function drainInbox(supabase, sessionId, { quiet = false, background = fal
     // instead of silently misreading the row — surfaced, not consumed-differently (still drained).
     const skew = detectVersionSkew(r.payload);
     if (skew) console.warn(`  ⚠ PROTOCOL VERSION SKEW: sender v${skew.senderVersion}, receiver v${skew.receiverVersion} (id=${r.id})`);
-    // SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-B: surface payload.framing_class on the
-    // adam_advisory+oracle:true leg — wire-plumbing only (this SD does not implement the
-    // fail-closed pick-vs-instrument ROUTING; that is a sibling FW-3 child SD's scope), so a
-    // pick-class framing is flagged loudly rather than silently auto-sourced without visibility.
-    // Like the orphan/skew warnings above (see line ~615), this warn is UNCONDITIONAL — never
-    // gated by --quiet/background (quiet only suppresses the empty-lane no-op message) — so a
-    // background/cron drain still emits it to stderr rather than silently dropping it.
+    // SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C: fail-closed pick-vs-instrument ROUTING
+    // (supersedes the -B interim PICK-CLASS warn). pick/unproven oracle framings route to the
+    // chairman-escalation fork (recordPendingDecision -> decision-scheduler surfacing) with
+    // EXPLICIT non-auto-escalating params (blocking:false, decisionType:'framing_escalation')
+    // so shouldAutoEscalate() is provably false — rows QUEUE, no per-row standout email/SMS
+    // (RISK conditions a+b). instrument framings render sourcing-eligible and flow as today.
+    // Escalation writes are fail-SOFT for drain liveness but LOUD on failure, and a failed
+    // write is rendered routing:escalation-write-failed — never as safely routed.
     const framingClass = r.payload && r.payload.framing_class;
     const framingTag = framingClass ? ` framing:${framingClass}` : '';
-    if (framingClass === FRAMING_CLASSES.PICK) {
-      console.warn(`  ⚠ PICK-CLASS FRAMING (id=${r.id}): CMV/portfolio-altitude framing on the oracle leg — fail-closed chairman-escalation routing is not yet wired here (tracked by a sibling FW-3 child SD); do not auto-source.`);
+    const routed = routeFraming(r);
+    let routingTag = '';
+    if (routed.route === FRAMING_ROUTES.CHAIRMAN_ESCALATION) {
+      const ok = await recordFramingEscalation(supabase, r, routed);
+      routingTag = ok ? ' routing:chairman-escalation' : ' routing:escalation-write-failed';
+    } else if (routed.route === FRAMING_ROUTES.ADAM_SOURCING) {
+      routingTag = ' routing:adam-sourcing';
     }
-    console.log(`  • [${lane}/${kind}${framingTag}] id=${r.id} (${ageMin}m) ${text}`);
+    console.log(`  • [${lane}/${kind}${framingTag}${routingTag}] id=${r.id} (${ageMin}m) ${text}`);
     ids.push(r.id);
   }
   // SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (FR-1): stamp routing by context —

--- a/scripts/one-off/_insert-prd-fw3-framing-plumbing-001-c.mjs
+++ b/scripts/one-off/_insert-prd-fw3-framing-plumbing-001-c.mjs
@@ -1,0 +1,114 @@
+// Insert PRD for SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (INLINE mode — add-prd-to-database.js
+// printed the generation prompt and expects Claude Code to insert directly; same precedent as
+// sibling -B's scripts/one-off/_insert-prd-fw3-framing-plumbing-001-b.mjs).
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const s = createClient(supabaseUrl, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const KEY = 'SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C';
+
+const { data: sd } = await s.from('strategic_directives_v2').select('id, sd_key, title').eq('sd_key', KEY).single();
+const SD_UUID = sd.id;
+
+const functional_requirements = [
+  {
+    id: 'FR-1', priority: 'critical',
+    title: 'Pure fail-closed routing predicate (lib/governance/fw3-framing-router.cjs)',
+    description: "New CJS module (consistent with sibling fw3-abstraction-rubric.cjs / fw3-cmv-rejecter.cjs) exporting routeFraming(row): for a row on the oracle systemic-finding leg (payload.oracle===true), framing_class==='instrument' -> {route:'adam_sourcing'}; framing_class==='pick' -> {route:'chairman_escalation', reason:'pick-class'}; missing or unrecognized framing_class -> {route:'chairman_escalation', reason:'unproven'} (FAIL-CLOSED: a framing that cannot PROVE instrument-class escalates). Non-oracle rows are OUT OF DOMAIN -> {route:null} (they are advisories, not framings — prevents chairman-queue flooding by legacy rows). Enum values come from the FRAMING_CLASSES SSOT (lib/fleet/worker-status.cjs, established by sibling -B).",
+    acceptance_criteria: ["routeFraming is pure (no IO, no DB)", "instrument -> adam_sourcing; pick -> chairman_escalation", "oracle row with missing framing_class -> chairman_escalation reason 'unproven'", "oracle row with framing_class 'garbage' -> chairman_escalation (fail-closed, never adam_sourcing)", "non-oracle row -> route null regardless of framing_class"],
+  },
+  {
+    id: 'FR-2', priority: 'critical',
+    title: 'Drain-site wiring in scripts/adam-advisory.cjs (replaces -B interim warn)',
+    description: "At the -B PICK-CLASS warn site in drainInbox, invoke routeFraming per row: chairman_escalation routes call recordPendingDecision (lib/chairman/record-pending-decision.mjs — the chairman-escalation fork that feeds lib/comms/adam-outbound decision-scheduler surfacing) and render 'routing:chairman-escalation'; adam_sourcing routes render 'routing:adam-sourcing' and proceed exactly as today (no fork). The escalation write is fail-SOFT for the drain (never breaks draining) but LOUD on failure (stderr) and a failed write does NOT render the row as routed.",
+    acceptance_criteria: ["pick row triggers exactly one recordPendingDecision call and renders routing:chairman-escalation", "instrument row triggers zero decision writes and renders routing:adam-sourcing", "unproven oracle row (no framing_class) escalates like pick with reason surfaced", "decision-write failure emits stderr matching /ESCALATION WRITE FAILED/ and the drain continues", "plain (non-oracle) advisory rows render byte-identical to pre-SD", "RISK condition (a): recordPendingDecision is called with EXPLICIT non-auto-escalating params — blocking:false and decisionType:'framing_escalation' (NOT 'session_question') — so shouldAutoEscalate() is false and rows QUEUE for decision-scheduler surfacing without per-row standout email/SMS", "RISK condition (b): draining N>3 pick/unproven oracle rows fires ZERO immediate standout escalations (test asserts escalated===false / no escalateChairmanDecision invocation on the FW-3 path)"],
+  },
+  {
+    id: 'FR-3', priority: 'high',
+    title: 'Escalation payload carries framing context + per-row idempotency',
+    description: "The pending-decision row's brief_data includes: source advisory row id, framing_class (or 'unproven'), sender session, and a body excerpt. Idempotent per advisory row id — re-draining the same row (or a retry) must not create a duplicate pending decision (probe by advisory row id marker in brief_data/decision key before insert).",
+    acceptance_criteria: ["brief_data contains advisory_row_id + framing_class + excerpt", "double-drain of the same pick row records exactly one pending decision", "decision row status='pending' (records, never decides — constitutional constraint of record-pending-decision.mjs)"],
+  },
+  {
+    id: 'FR-4', priority: 'high',
+    title: 'Lane-vocabulary analog mapping (sourcing-engine consistency)',
+    description: "The router's result carries a laneAnalog field reusing the sourcing-engine lane vocabulary (lib/sourcing-engine/lane.js): chairman_escalation -> LANE.CHAIRMAN_GATED analog, adam_sourcing -> LANE.BELT_READY analog — mapping constants only (no conversion_ledger writes in this SD), so downstream FW-3 consumers persist consistently.",
+    acceptance_criteria: ["routeFraming(...).laneAnalog === 'chairman-gated' for pick/unproven", "laneAnalog === 'belt-ready' for instrument", "values imported from/equal to lane.js constants, not re-typed literals"],
+  },
+  {
+    id: 'FR-5', priority: 'critical',
+    title: 'Tests: router matrix + drain wiring + -B pin-test update',
+    description: "New tests/unit/governance/fw3-framing-router.test.js pinning the full fail-closed matrix (instrument/pick/missing/unknown/non-oracle + laneAnalog). Extend/UPDATE tests/unit/adam-advisory-framing-class.test.js: the -B interim warn assertions are superseded by routed-behavior assertions (routing tag + escalation call + fail-soft error path) — updated in the SAME PR (two-pin-location lesson: sweep repo-wide for pins on the replaced warn text before merging). Full regression on touched files.",
+    acceptance_criteria: ["fw3-framing-router.test.js passes with full matrix coverage", "adam-advisory-framing-class.test.js updated + passing (no stale /PICK-CLASS FRAMING/ pin left anywhere repo-wide)", "solomon-advisory.test.js + fleet/framing-classes.test.js still pass unchanged"],
+  },
+];
+
+const technical_requirements = [
+  { id: 'TR-1', description: 'No new PAYLOAD_KINDS/DRAIN_SETS entries, no DDL, no new transport. Consumes the payload.framing_class field contract established by sibling -B; CJS module style consistent with existing fw3-* governance modules.' },
+  { id: 'TR-2', description: 'FAIL-CLOSED DOMAIN BOUND: the predicate domain is exactly payload.oracle===true rows (systemic-finding framings). Plain advisories (no oracle flag) are untouched — this is the flood-guard that makes fail-closed safe to ship against legacy rows.' },
+  { id: 'TR-3', description: 'recordPendingDecision is invoked as the RECORD-only fork (constitutional: records pending, never decides; its own shouldAutoEscalate policy governs email/SMS side-effects). The drain awaits it inside try/catch: fail-soft for drain liveness, loud (stderr) on failure, and the row is not rendered as routed on failure.' },
+];
+
+const test_scenarios = [
+  { id: 'TS-1', scenario: 'Drain a pick-class oracle row', expected: 'one recordPendingDecision call; line renders routing:chairman-escalation; no PICK warn (superseded)' },
+  { id: 'TS-2', scenario: 'Drain an instrument-class oracle row', expected: 'zero decision writes; renders routing:adam-sourcing; drain proceeds as today' },
+  { id: 'TS-3', scenario: 'Drain an oracle row with NO framing_class', expected: 'escalated fail-closed (reason unproven); routing:chairman-escalation rendered' },
+  { id: 'TS-4', scenario: 'Drain a non-oracle advisory row', expected: 'route null; rendering byte-identical to pre-SD; no escalation' },
+  { id: 'TS-5', scenario: 'Drain the same pick row twice (retry/replay)', expected: 'exactly one pending decision exists (idempotent on advisory row id)' },
+  { id: 'TS-6', scenario: 'Decision insert throws (mocked DB error)', expected: 'stderr /ESCALATION WRITE FAILED/; drain continues; row not rendered as routed' },
+  { id: 'TS-7', scenario: "oracle row with framing_class 'garbage'", expected: 'escalated (fail-closed) — never adam_sourcing' },
+  { id: 'TS-8', scenario: 'Drain 5 pick/unproven oracle rows in one background pass (legacy-backlog simulation)', expected: '5 pending decision rows queue; ZERO standout chairman emails/SMS fire (escalated===false each; shouldAutoEscalate never true on the FW-3 path)' },
+];
+
+const risks = [
+  { risk: 'Chairman-queue flooding from legacy oracle rows lacking framing_class once fail-closed routing activates', impact: 'medium', likelihood: 'medium', mitigation: 'Domain bounded to oracle:true rows only + per-row idempotency; oracle-leg volume is low (Solomon systemic findings). Queue growth observable in chairman decision queue; reversible by reverting the drain wiring (predicate stays pure).' },
+  { risk: "-B pin tests on the interim PICK-CLASS warn break when the warn is superseded by routing", impact: 'low', likelihood: 'high', mitigation: 'FR-5 mandates updating adam-advisory-framing-class.test.js in the same PR and sweeping repo-wide (tests/ AND scripts/**/__tests__) for any other pin on the warn text — the QF-20260719-120 two-pin-location lesson.' },
+  { risk: 'recordPendingDecision AUTO-ESCALATES on insert (standout email + gated SMS) whenever shouldAutoEscalate() is true — blocking:true OR (raisedBy adam && decisionType session_question) — so a first background drain over a legacy backlog of unproven oracle rows could fire per-row chairman escalations (the known ~165-emails-in-20-min Resend-burn pattern); per-row idempotency does NOT prevent this since each distinct row is a distinct escalation (RISK sub-agent verified in code, L87-90/L305-313)', impact: 'high', likelihood: 'medium', mitigation: "PINNED by FR-2 acceptance criteria: the drain site passes blocking:false + decisionType:'framing_escalation' (non-session_question) so shouldAutoEscalate() is provably false — rows QUEUE for decision-scheduler surfacing only. Enforced by TS-8 (N>3 drain fires zero standout escalations) so EXEC cannot silently reintroduce the flood. Rate-cap/digest-fold in the escalation module remain as defense-in-depth, not the primary control." },
+];
+
+const system_architecture = {
+  overview: 'A pure fail-closed routing predicate over the framing_class wire (-B contract), wired at the single drain chokepoint where framings are consumed. PICK/unproven -> the existing chairman-escalation fork (record-pending-decision -> decision-scheduler surfacing); INSTRUMENT -> the existing Adam-sourcing flow.',
+  components: [
+    { name: 'lib/governance/fw3-framing-router.cjs', role: 'NEW: pure routeFraming predicate + lane-analog mapping. No IO.' },
+    { name: 'scripts/adam-advisory.cjs (drainInbox)', role: 'Wiring: per-row routing at the -B warn site; fail-soft loud escalation write; rendering tags.' },
+    { name: 'lib/chairman/record-pending-decision.mjs', role: 'EXISTING chairman-escalation fork (records pending decision; feeds decision-scheduler).' },
+    { name: 'lib/sourcing-engine/lane.js', role: 'EXISTING lane vocabulary; source of the laneAnalog constants.' },
+  ],
+  data_flow: "Solomon framing (adam_advisory + oracle:true + framing_class from -B) -> Adam drainInbox -> routeFraming: pick/unproven -> recordPendingDecision (chairman_decisions status=pending, brief_data carries framing context) -> decision-scheduler surfaces to chairman; instrument -> rendered sourcing-eligible, existing Adam-sourcing flow proceeds. Fail-closed: nothing on the oracle leg auto-sources without a proven instrument classification.",
+};
+
+const prd = {
+  id: `PRD-${KEY}`,
+  directive_id: KEY,
+  sd_id: SD_UUID,
+  title: `Product Requirements for ${KEY}`,
+  version: '1.0',
+  status: 'planning',
+  category: 'Infrastructure',
+  priority: 'high',
+  phase: 'PLAN',
+  executive_summary: "Build the FAIL-CLOSED pick-vs-instrument routing that sibling -B's wire discriminator was plumbed for: a pure predicate (routeFraming) over payload.framing_class on the oracle systemic-finding leg, wired at the Adam drain chokepoint. PICK-class (CMV/portfolio-altitude) and UNPROVEN framings route to the chairman-escalation fork (record-pending-decision -> decision-scheduler); INSTRUMENT-class framings route to Adam-sourcing. This closes the govern-by-ABSENCE risk: a framing silently degrading govern-by-exception can no longer auto-source past the chairman.",
+  business_context: "FW-3 parent: framing is upstream of every approval gate — 'deciding what the problem is' is the chairman's most consequential strategic act. -B made pick-class framings VISIBLE (loud warn, explicitly deferring routing to this SD); this child makes the routing REAL and fail-closed, so the chairman gauge can never read green while pick-class framings quietly auto-source.",
+  technical_context: 'No DDL, no new kinds. Consumes -B field contract (FRAMING_CLASSES SSOT), reuses the existing chairman-escalation fork and sourcing-engine lane vocabulary. Domain bounded to oracle:true rows to prevent legacy-row queue flooding.',
+  functional_requirements,
+  technical_requirements,
+  test_scenarios,
+  acceptance_criteria: functional_requirements.flatMap(fr => fr.acceptance_criteria),
+  risks,
+  system_architecture,
+  implementation_approach: '(1) fw3-framing-router.cjs pure predicate + matrix tests; (2) drainInbox wiring replacing the -B interim warn (routing tags + fail-soft loud escalation write + per-row idempotency); (3) update -B pin test to routed behavior + repo-wide pin sweep; (4) full regression on touched files. Target <=100 LOC source diff.',
+  dependencies: ['SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-B (completed — framing_class wire contract)'],
+  constraints: ['Fail-closed: unproven never auto-sources', 'Domain bounded to payload.oracle===true rows', 'record-only escalation (never decides)', 'No new kinds/DDL'],
+  assumptions: ['Oracle-leg volume stays low (Solomon systemic findings), so fail-closed escalation of unproven rows is chairman-tolerable', 'Sibling -D (adversarial rejecter) consumes the same routed output downstream'],
+  metadata: { field_contract_source: 'SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-B PRD FR-1' },
+};
+
+const { data: existing } = await s.from('product_requirements_v2').select('id').eq('directive_id', KEY).maybeSingle();
+let result;
+if (existing) {
+  result = await s.from('product_requirements_v2').update(prd).eq('directive_id', KEY).select('id').single();
+} else {
+  result = await s.from('product_requirements_v2').insert(prd).select('id').single();
+}
+if (result.error) { console.log('PRD INSERT ERROR:', JSON.stringify(result.error)); process.exit(1); }
+console.log('PRD_ID', result.data.id);

--- a/tests/unit/adam-advisory-framing-class.test.js
+++ b/tests/unit/adam-advisory-framing-class.test.js
@@ -1,79 +1,146 @@
 /**
- * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-B — payload.framing_class consumption in adam-advisory.cjs's
- * drainInbox. Wire-plumbing scope only: this SD does not implement fail-closed pick-vs-instrument
- * ROUTING (a sibling FW-3 child SD's job) — it makes the field visible/consumable instead of silently
- * dropped, and loudly flags pick-class rows so they are never mistaken for an already-handled case.
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C — fail-closed pick-vs-instrument ROUTING in
+ * drainInbox (supersedes sibling -B's interim PICK-CLASS warn, whose assertions this file
+ * previously pinned: routing is now REAL, so the warn is replaced by routed behavior).
+ * pick/unproven oracle framings -> chairman-escalation queue via recordPendingDecision with
+ * provably non-auto-escalating params; instrument -> renders sourcing-eligible; non-oracle
+ * advisories untouched. -B's framing:<value> rendering tag is retained.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const m = require('../../scripts/adam-advisory.cjs');
+import { shouldAutoEscalate } from '../../lib/chairman/record-pending-decision.mjs';
 
-function makeRecordingMock(selectRows = []) {
-  const updates = [];
-  function chain() {
-    const state = { op: 'select', updatePayload: null };
+/**
+ * Table-aware supabase mock: session_coordination selects return `inboxRows`;
+ * chairman_decisions selects return `decisionProbeRows` (idempotency probe), inserts are
+ * recorded (and fail when failDecisionInsert), updates recorded per-table.
+ */
+function makeTableMock({ inboxRows = [], decisionProbeRows = [], failDecisionInsert = false } = {}) {
+  const decisionInserts = [];
+  const decisionUpdates = [];
+  function chain(table) {
+    const state = { op: 'select', payload: null };
     const c = {
       select: () => c,
-      update: (payload) => { state.op = 'update'; state.updatePayload = payload; return c; },
-      eq: () => c,
-      in: () => c,
-      is: () => c,
-      gte: () => c,
-      order: () => c,
-      limit: () => c,
+      update: (payload) => { state.op = 'update'; state.payload = payload; return c; },
+      insert: (payload) => { state.op = 'insert'; state.payload = payload; return c; },
+      eq: () => c, in: () => c, is: () => c, gte: () => c, order: () => c, limit: () => c,
+      maybeSingle: () => finish().then((r) => ({ ...r, data: (r.data && r.data[0]) || null })),
+      single: () => finish().then((r) => ({ ...r, data: (r.data && r.data[0]) || null })),
       then: (res, rej) => finish().then(res, rej),
     };
     async function finish() {
-      if (state.op === 'update') { updates.push(state); return { data: [], error: null }; }
-      return { data: selectRows, error: null };
+      if (table === 'chairman_decisions') {
+        if (state.op === 'insert') {
+          if (failDecisionInsert) return { data: null, error: { message: 'boom' } };
+          decisionInserts.push(state.payload);
+          return { data: [{ id: `dec-${decisionInserts.length}` }], error: null };
+        }
+        if (state.op === 'update') { decisionUpdates.push(state.payload); return { data: [], error: null }; }
+        return { data: decisionProbeRows, error: null };
+      }
+      if (state.op === 'update' || state.op === 'insert') return { data: [], error: null };
+      return { data: inboxRows, error: null };
     }
     return c;
   }
-  return { supabase: { from: chain }, updates };
+  return { supabase: { from: chain }, decisionInserts, decisionUpdates };
 }
 
-describe('SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-B: drainInbox surfaces payload.framing_class', () => {
-  it('renders framing:pick/instrument in the surfaced line — never silently dropped', async () => {
-    const rows = [
-      { id: 'p1', payload: { kind: 'adam_advisory', oracle: true, framing_class: 'pick', body: 'thesis reversal' }, created_at: new Date().toISOString() },
-      { id: 'i1', payload: { kind: 'adam_advisory', oracle: true, framing_class: 'instrument', body: 'routine finding' }, created_at: new Date().toISOString() },
-    ];
-    const { supabase } = makeRecordingMock(rows);
-    const logs = []; const warns = [];
-    const log = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
-    const warn = vi.spyOn(console, 'warn').mockImplementation((...a) => warns.push(a.join(' ')));
-    await m.drainInbox(supabase, 'adam-sess', { quiet: false });
-    log.mockRestore(); warn.mockRestore();
-    expect(logs.join(' ')).toMatch(/framing:pick/);
-    expect(logs.join(' ')).toMatch(/framing:instrument/);
+const oracleRow = (id, framing, body = 'systemic finding') => ({
+  id, sender_session: 'solomon-1', created_at: new Date().toISOString(),
+  payload: { kind: 'adam_advisory', oracle: true, ...(framing ? { framing_class: framing } : {}), body },
+});
+
+async function drainWith(mock) {
+  const logs = []; const errs = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+  const err = vi.spyOn(console, 'error').mockImplementation((...a) => errs.push(a.join(' ')));
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  await m.drainInbox(mock.supabase, 'adam-sess', { quiet: false });
+  log.mockRestore(); err.mockRestore(); warn.mockRestore();
+  return { logs: logs.join(' '), errs: errs.join(' ') };
+}
+
+describe('SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C: fail-closed routing in drainInbox', () => {
+  it('TS-1: pick row -> one pending decision + routing:chairman-escalation (framing tag retained)', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('p1', 'pick')] });
+    const { logs } = await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(1);
+    expect(logs).toMatch(/framing:pick/);
+    expect(logs).toMatch(/routing:chairman-escalation/);
   });
 
-  it('flags a pick-class row with an explicit do-not-auto-source warning', async () => {
-    const rows = [
-      { id: 'p2', payload: { kind: 'adam_advisory', oracle: true, framing_class: 'pick', body: 'kill/scale decision' }, created_at: new Date().toISOString() },
-    ];
-    const { supabase } = makeRecordingMock(rows);
-    const warns = [];
-    const warn = vi.spyOn(console, 'warn').mockImplementation((...a) => warns.push(a.join(' ')));
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    await m.drainInbox(supabase, 'adam-sess', { quiet: false });
-    warn.mockRestore();
-    expect(warns.join(' ')).toMatch(/PICK-CLASS FRAMING/);
-    expect(warns.join(' ')).toMatch(/do not auto-source/i);
+  it('TS-2: instrument row -> zero decision writes + routing:adam-sourcing', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('i1', 'instrument')] });
+    const { logs } = await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(0);
+    expect(logs).toMatch(/framing:instrument/);
+    expect(logs).toMatch(/routing:adam-sourcing/);
   });
 
-  it('a row with no framing_class renders exactly as before (no tag, no warning)', async () => {
-    const rows = [
-      { id: 'n1', payload: { kind: 'adam_advisory', oracle: true, body: 'plain advisory' }, created_at: new Date().toISOString() },
-    ];
-    const { supabase } = makeRecordingMock(rows);
-    const logs = []; const warns = [];
-    vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
-    const warn = vi.spyOn(console, 'warn').mockImplementation((...a) => warns.push(a.join(' ')));
-    await m.drainInbox(supabase, 'adam-sess', { quiet: false });
-    warn.mockRestore();
-    expect(logs.join(' ')).not.toMatch(/framing:/);
-    expect(warns.join(' ')).not.toMatch(/PICK-CLASS/);
+  it('TS-3/TS-7: unproven (missing or garbage framing_class) oracle rows escalate fail-closed', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('u1', null), oracleRow('u2', 'garbage')] });
+    const { logs } = await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(2);
+    expect(logs.match(/routing:chairman-escalation/g)).toHaveLength(2);
+    expect(logs).not.toMatch(/routing:adam-sourcing/);
+  });
+
+  it('TS-4: non-oracle advisory rows render with no routing/framing tags and no escalation', async () => {
+    const mock = makeTableMock({
+      inboxRows: [{ id: 'n1', created_at: new Date().toISOString(), payload: { kind: 'adam_advisory', body: 'plain advisory' } }],
+    });
+    const { logs } = await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(0);
+    expect(logs).not.toMatch(/framing:/);
+    expect(logs).not.toMatch(/routing:/);
+  });
+
+  it('TS-5: re-drain of an already-queued row is idempotent (probe hit -> no duplicate insert)', async () => {
+    const mock = makeTableMock({
+      inboxRows: [oracleRow('p2', 'pick')],
+      decisionProbeRows: [{ id: 'dec-existing' }],
+    });
+    const { logs } = await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(0); // probe found existing -> skip
+    expect(logs).toMatch(/routing:chairman-escalation/); // still rendered as routed
+  });
+
+  it('TS-6: decision-write failure is loud, drain continues, row not rendered as routed', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('p3', 'pick'), oracleRow('i2', 'instrument')], failDecisionInsert: true });
+    const { logs, errs } = await drainWith(mock);
+    expect(errs).toMatch(/ESCALATION WRITE FAILED/);
+    expect(logs).toMatch(/routing:escalation-write-failed/);
+    expect(logs).toMatch(/routing:adam-sourcing/); // drain continued to the next row
+  });
+
+  it('TS-8: legacy-backlog drain (5 pick/unproven rows) fires ZERO standout escalations', async () => {
+    const mock = makeTableMock({
+      inboxRows: [oracleRow('b1', 'pick'), oracleRow('b2', null), oracleRow('b3', 'pick'), oracleRow('b4', null), oracleRow('b5', 'garbage')],
+    });
+    await drainWith(mock);
+    expect(mock.decisionInserts).toHaveLength(5); // all queued...
+    for (const row of mock.decisionInserts) {
+      // ...with provably non-auto-escalating params (RISK conditions a+b):
+      expect(row.blocking).toBe(false);
+      expect(row.decision_type).toBe('framing_escalation');
+      expect(shouldAutoEscalate({ decisionType: row.decision_type, blocking: row.blocking, raisedBy: row.brief_data && row.brief_data.raised_by })).toBe(false);
+    }
+    // and zero escalation-path updates on chairman_decisions (no CAS/email-marker write):
+    expect(mock.decisionUpdates).toHaveLength(0);
+  });
+
+  it('FR-3: pending-decision brief_data carries the framing context', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('c1', 'pick', 'portfolio kill/scale reversal')] });
+    await drainWith(mock);
+    const ctx = mock.decisionInserts[0].brief_data.context;
+    expect(ctx.advisory_row_id).toBe('c1');
+    expect(ctx.framing_class).toBe('pick');
+    expect(ctx.lane_analog).toBe('chairman-gated');
+    expect(ctx.excerpt).toMatch(/portfolio kill\/scale reversal/);
+    expect(mock.decisionInserts[0].status).toBe('pending'); // records, never decides
   });
 });

--- a/tests/unit/governance/fw3-framing-router.test.js
+++ b/tests/unit/governance/fw3-framing-router.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (FR-1/FR-4) — fail-closed pick-vs-instrument
+ * routing matrix + lane-analog mapping. The predicate is PURE (no IO); this pins the
+ * complete matrix so no future edit can open an auto-sourcing path for unproven framings.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { routeFraming, FRAMING_ROUTES, LANE_ANALOG } = require('../../../lib/governance/fw3-framing-router.cjs');
+const { FRAMING_CLASSES } = require('../../../lib/fleet/worker-status.cjs');
+const { LANE } = require('../../../lib/sourcing-engine/lane.js');
+
+describe('fw3-framing-router: fail-closed matrix', () => {
+  it('instrument -> adam_sourcing with belt-ready analog', () => {
+    const r = routeFraming({ payload: { oracle: true, framing_class: FRAMING_CLASSES.INSTRUMENT } });
+    expect(r.route).toBe(FRAMING_ROUTES.ADAM_SOURCING);
+    expect(r.reason).toBe('instrument');
+    expect(r.laneAnalog).toBe(LANE.BELT_READY);
+  });
+
+  it('pick -> chairman_escalation with chairman-gated analog', () => {
+    const r = routeFraming({ payload: { oracle: true, framing_class: FRAMING_CLASSES.PICK } });
+    expect(r.route).toBe(FRAMING_ROUTES.CHAIRMAN_ESCALATION);
+    expect(r.reason).toBe('pick-class');
+    expect(r.laneAnalog).toBe(LANE.CHAIRMAN_GATED);
+  });
+
+  it('FAIL-CLOSED: oracle row with missing framing_class escalates as unproven', () => {
+    const r = routeFraming({ payload: { oracle: true } });
+    expect(r.route).toBe(FRAMING_ROUTES.CHAIRMAN_ESCALATION);
+    expect(r.reason).toBe('unproven');
+  });
+
+  it('FAIL-CLOSED: unrecognized framing_class never reaches adam_sourcing', () => {
+    for (const bogus of ['garbage', '', 'INSTRUMENT', 'Pick', 0, null, {}]) {
+      const r = routeFraming({ payload: { oracle: true, framing_class: bogus } });
+      expect(r.route, `framing_class=${JSON.stringify(bogus)}`).toBe(FRAMING_ROUTES.CHAIRMAN_ESCALATION);
+    }
+  });
+
+  it('non-oracle rows are OUT OF DOMAIN (route null) regardless of framing_class', () => {
+    expect(routeFraming({ payload: { framing_class: 'pick' } }).route).toBeNull();
+    expect(routeFraming({ payload: { oracle: false, framing_class: 'instrument' } }).route).toBeNull();
+    expect(routeFraming({ payload: {} }).route).toBeNull();
+    expect(routeFraming({}).route).toBeNull();
+    expect(routeFraming(null).route).toBeNull();
+  });
+
+  it('laneAnalog values come from lane.js constants (FR-4), not re-typed literals', () => {
+    expect(LANE_ANALOG[FRAMING_ROUTES.CHAIRMAN_ESCALATION]).toBe(LANE.CHAIRMAN_GATED);
+    expect(LANE_ANALOG[FRAMING_ROUTES.ADAM_SOURCING]).toBe(LANE.BELT_READY);
+  });
+});


### PR DESCRIPTION
## Summary
FW-3 child B: builds the FAIL-CLOSED routing that sibling -B's `framing_class` wire discriminator (#6294) was plumbed for — closing the govern-by-ABSENCE risk (a CMV/portfolio-altitude framing silently auto-sourcing past the chairman).

- **New** `lib/governance/fw3-framing-router.cjs` — pure predicate: `instrument` → adam_sourcing; `pick` → chairman_escalation; **missing/unknown framing_class on the oracle leg → chairman_escalation (fail-closed)**. Non-oracle rows out of domain (legacy-row flood-guard). `laneAnalog` reuses `lane.js` constants.
- **drainInbox wiring** (supersedes -B's interim PICK-CLASS warn): escalations queue via `recordPendingDecision` with **explicitly non-auto-escalating params** (`blocking:false`, `decisionType:'framing_escalation'`) — `shouldAutoEscalate()` provably false, zero per-row standout email/SMS (closes the RISK sub-agent's CONDITIONAL_PASS conditions). Idempotent per advisory row; fail-soft loud on write failure.
- **Tests**: full fail-closed matrix + TS-1..TS-8 drain wiring incl. 5-row legacy-backlog zero-escalation assertion; -B pin test rewritten; repo-wide pin sweep clean. 46/46 passing.

SD: SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C · PRD: PRD-SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C · PLAN-TO-EXEC score 98
Source ~125 LOC (comment-heavy safety module) — justified in commit message per tiered PR-size policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)