### PR TITLE
feat(SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001): dead-coordinator chairman-SMS alert + STANDARD_LOOPS durability classification

### DIFF
--- a/.github/workflows/fleet-down-alert-cron.yml
+++ b/.github/workflows/fleet-down-alert-cron.yml
@@ -8,6 +8,13 @@ name: "Fleet-down alert (cron)"
 # Oscillation-robust: scripts/fleet-down-alert.mjs requires ~3 consecutive active_count==0 pulses
 # (~45min) AND claimable work, with edge-triggered dedup so a long outage emails once, not every run.
 # Read-only against fleet_worker_pulse + v_sd_next_candidates; sends at most one email per outage.
+#
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-3: this run also independently checks for a
+# DEAD COORDINATOR (getActiveCoordinatorId() null OR heartbeat stale >15min) and pages the
+# chairman via sendChairmanSMS() — a distinct outage class from the worker-fleet-down case above,
+# closing the 43h coverage-gap where the coordinator itself (not the worker fleet) was dead and
+# nothing paged the chairman. Same always-on-Actions rationale applies doubly here: this is
+# EXACTLY the moment the coordinator-audit path can't run.
 
 on:
   schedule:
@@ -25,7 +32,7 @@ concurrency:
 
 jobs:
   alert:
-    name: Email the operator on a sustained fleet-down
+    name: Email the operator on a sustained fleet-down / page chairman on a dead coordinator
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -34,6 +41,11 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       CLAUDE_NOTIFY_EMAIL: ${{ secrets.CLAUDE_NOTIFY_EMAIL }}
+      CHAIRMAN_PHONE: ${{ secrets.CHAIRMAN_PHONE }}
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+      TWILIO_MESSAGING_SERVICE: ${{ secrets.TWILIO_MESSAGING_SERVICE }}
+      TWILIO_STATUS_CALLBACK_URL: ${{ secrets.TWILIO_STATUS_CALLBACK_URL }}
 
     steps:
       - name: Checkout
@@ -48,5 +60,5 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Check fleet pulse and alert if sustained-down
+      - name: Check fleet pulse / dead-coordinator, alert if either condition trips
         run: node scripts/fleet-down-alert.mjs

--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -1,9 +1,9 @@
 ---
 category: documentation
 status: approved
-version: 1.0.0
+version: 1.1.0
 author: rickfelix
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 tags: [documentation, protocol]
 ---
 
@@ -13,10 +13,10 @@ tags: [documentation, protocol]
 
 - **Category**: Protocol
 - **Status**: Approved
-- **Version**: 1.1.0
-- **Last Updated**: 2026-06-08
-- **Tags**: fleet, coordinator, worker, cron, self-review, adam
-- **Author**: SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001
+- **Version**: 1.2.0
+- **Last Updated**: 2026-07-19
+- **Tags**: fleet, coordinator, worker, cron, self-review, adam, durability, gha-cron
+- **Author**: SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001
 
 Memory-independent source of truth for how the LEO fleet **coordinator** and its **worker** sessions
 behave. It exists so these behaviors survive even if an agent's personal auto-memory is lost, or a
@@ -166,6 +166,17 @@ There is a SEPARATE failure mode (feedback `34113d39`, `category='harness_backlo
 | Backlog prioritization + dispatch ordering (duty 6) | `scripts/coordinator-backlog-rank.mjs` (armed cron `9,24,39,54 * * * *`, ~15min) → `metadata.dispatch_rank`, honored by `scripts/worker-checkin.cjs` `sortByDispatchRank`. Event-driven refresh (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C) also fires on SD creation, `needs_coordinator_review` clearance (`lib/coordinator/clear-coordinator-review.js` / `scripts/clear-coordinator-review.mjs`), and predecessor SD completion, via `lib/coordinator/trigger-rank-pass.mjs` — so a freshly-claimable SD is ranked within seconds instead of waiting for the next cron tick. Chairman-ratified plan-linkage tie-break (SD-LEO-INFRA-PLAN-LINKAGE-BELT-001, 2026-07-18): at equal standing on every prior objective comparator (unlock score, product-pivot band, needle, priority), plan-linked SDs (`metadata.plan_linkage.linked=true`, stamped at creation or fence-lift) sort first — `lib/roadmap/plan-linkage-comparator.js`, shared by both this ranker and `scripts/fleet-dashboard.cjs`'s fence-review ordering. Belt-admission linkage is also surfaced in `PLAN CHECK` (`lib/roadmap/plan-check-status.js` section 5) and the roadmap retro (`scripts/vision/rung-progress-rollup.mjs`, feedback category `plan_linkage_retro`) |
 | Question→operator escalation (durable row; rendered by the Adam exec email / operator conversation) | `scripts/coordinator-escalate-question.mjs` (writes `operator_question` row) |
 | Teardown cron inventory + matcher | `lib/coordinator/teardown-coordinator.cjs` (`listCoordinatorCrons`, `selectCoordinatorCronJobs`) |
+| SCRIPT-SHAPED loop durability (GHA-backed, additive) | `.github/workflows/*-cron.yml` per migrated `STANDARD_LOOPS` entry (`gha_backed:true` marker in `scripts/coordinator-startup-check.mjs`) |
+| Dead-coordinator chairman page | `scripts/fleet-down-alert.mjs` (`evaluateDeadCoordinatorAlert`) → `.github/workflows/fleet-down-alert-cron.yml` |
+
+## Two-layer durability contract (SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001)
+
+`CronCreate` is structurally session-only (in-memory, 7-day cap) — every `STANDARD_LOOPS` entry armed via `/coordinator start` dies with the coordinator session that armed it. A coordinator crash orphans all of them until an operator manually restarts. This is addressed by two independent layers, not one:
+
+1. **Durable layer (GHA-backed, SCRIPT-SHAPED loops).** Deterministic loops with no LLM judgment (sweep, gauge-runner, unranked-gauge, relay-drain, relay-drop-gauge, solomon-ledger-resurface, row-growth, feedback-sla, flag-review, scripts-reachability, review-rotation, fleet-retro-capture, plus the already-shipped retention and backlog-rank) get an always-on GitHub Actions cron matching their `STANDARD_LOOPS` schedule. **The design is ADDITIVE, not exclusive** — the GHA cron becomes the primary reliable trigger, but the `STANDARD_LOOPS` session-armed entry stays in place as a harmless redundant backup (idempotent/fail-soft scripts tolerate an occasional double-fire), matching the pattern `retention-enforce-cron.yml` and `backlog-rank-cron.yml` already shipped. This was chosen over a flag-gated mutually-exclusive design (`gha_backed`-suppresses-session-arming) because that design was never implemented anywhere and would have diverged from the already-shipped, already-proven precedent. A `gha_backed: true` field is stamped on each migrated `STANDARD_LOOPS` entry, purely as an informational/reporting marker — it does not gate anything.
+2. **Session-armed layer (JUDGMENT-SHAPED loops).** LLM-driven review/adjudication loops (quiet-tick, self-review, hourly-review, roles-review, audit, charter-audit, capacity-forecast, dashboard, identity) require a live coordinator session and stay re-armed at every `/coordinator start` — they are not migrated, because a GHA runner cannot perform the judgment they require.
+
+**Coordinator death itself is a third, separate failure mode** from any individual loop dying: the coordinator's *standing* responsibilities (sweeps, gauges, dispatch-rank) go silently unattended, and — before this SD — nothing paged anyone (the 43h coverage-gap class from Solomon tri-role evidence). `scripts/fleet-down-alert.mjs`'s `evaluateDeadCoordinatorAlert()` runs alongside the existing worker-fleet-down check (independent predicate, own edge-triggered dedup, no shared state) inside `fleet-down-alert-cron.yml` — itself already always-on GHA, for the same reason the worker-fleet alert is: this is exactly the path that must survive the coordinator's own death. It checks `getActiveCoordinatorId()` (`lib/coordinator/resolve.cjs`) for `null`, or the most recently seen coordinator-flagged session's heartbeat exceeding a dedicated 15-minute staleness constant (deliberately independent of `resolve.cjs`'s own internal 10-minute `STALE_THRESHOLD_MIN`, which governs an unrelated resolution chain), and pages the chairman via `sendChairmanSMS()` (`lib/comms/adam-outbound/chairman-sms-gate/index.js`) rather than the worker-fleet alert's plain email.
 
 ## Comms check (radio check) — verify the two-way link at startup
 

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -46,6 +46,45 @@ export const RESPONSIBILITIES = [
 // SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001 (FR-5) added the daily flag-governance review loop.
 // SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001 added the work-triggered tri-party self-review loop so a
 // coordinator restart re-arms it instead of leaving it dormant (its state file had silently frozen). ──
+//
+// SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-1 — SCRIPT-SHAPED vs JUDGMENT-SHAPED
+// classification (durability migration table). A `gha_backed: true` entry means this loop also
+// has an always-on GitHub Actions cron that survives a coordinator session death (ADDITIVE, not
+// exclusive — this STANDARD_LOOPS entry stays session-armed as a harmless redundant backup, per
+// the shipped retention/backlog-rank precedent; see the FR-2 GHA workflow batch for the file list).
+//
+//   key                        | class          | GHA-backed?              | rationale
+//   ---------------------------|----------------|---------------------------|--------------------------------
+//   sweep                      | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic sweep, no judgment
+//   quiet-tick                 | JUDGMENT-SHAPED| no                        | folds flag/audit/advisory triage
+//   dashboard                  | (report)       | no (out of FR-1 scope)    | deterministic but not migrated by this SD
+//   identity                   | (report)       | no (out of FR-1 scope)    | deterministic but not migrated by this SD
+//   inbox (folded)             | JUDGMENT-SHAPED| no                        | folded into quiet-tick
+//   audit (folded)             | JUDGMENT-SHAPED| no                        | folded into quiet-tick
+//   charter-audit (folded)     | JUDGMENT-SHAPED| no                        | self-audit, remediate-then-verify judgment
+//   flag-review                | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic governance review script
+//   self-review                | JUDGMENT-SHAPED| no                        | LLM-driven tri-party self-review
+//   hourly-review               | JUDGMENT-SHAPED| no                        | LLM-driven responsibilities review
+//   capacity-forecast (folded) | JUDGMENT-SHAPED| no                        | predictive forecasting, folded into quiet-tick
+//   backlog-rank (folded)      | SCRIPT-SHAPED  | YES (backlog-rank-cron.yml)| already migrated — excluded from FR-2
+//   unranked-gauge             | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic invariant gauge
+//   singleton-relaunch          | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic detection+scheduling only
+//   relay-drain                | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic queue drain
+//   relay-drop-gauge           | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic invariant gauge
+//   fleet-retro                | SCRIPT-SHAPED  | pending (FR-2 batch)      | capture is deterministic (label says capture/synthesis — FR-2 scopes strictly to the capture path; any judgment-shaped synthesis stays session-armed)
+//   row-growth                 | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic daily snapshot
+//   review-rotation            | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic rotation bookkeeping (WHICH subsystem is reviewed next), not the review itself
+//   scripts-reachability        | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic weekly gauge
+//   retention                  | SCRIPT-SHAPED  | YES (retention-enforce-cron.yml) | already migrated — excluded from FR-2
+//   roles-review                | JUDGMENT-SHAPED| no                        | coordinator self-review of duties
+//   gauge-runner                | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic invariant-gauge execution surface
+//   feedback-sla                | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic SLA-breach reminder
+//   liveness-watcher            | SCRIPT-SHAPED  | PARTIAL (periodic-liveness-watcher-cron.yml owns self_stamped/eva_scheduler_heartbeat/github_actions_api classes) | this STANDARD_LOOPS entry keeps only the PID-anchored claude_sessions_heartbeat class a CI runner can't evaluate — FR-2 does NOT duplicate the already-GHA-backed classes
+//   solomon-ledger-resurface     | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic aged-row resurface
+//
+// NOTE: the original SD scope text also named a "root-freshness" loop. It does not exist anywhere
+// in this array or the codebase (verified by VALIDATION, evidence row dd2f16c2-9c2e-424e-b7fb-94e76860b590)
+// — dropped as a phantom/typo'd scope-text reference, not implemented.
 export const STANDARD_LOOPS = [
   { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
     prompt: 'node scripts/stale-session-sweep.cjs' },

--- a/scripts/fleet-down-alert.mjs
+++ b/scripts/fleet-down-alert.mjs
@@ -19,10 +19,76 @@ import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'url';
 import path from 'path';
 import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
+import { getActiveCoordinatorId } from '../lib/coordinator/resolve.cjs';
 
 const REQUIRED_CONSECUTIVE = Number(process.env.FLEET_DOWN_CONSECUTIVE_PULSES) > 0
   ? Number(process.env.FLEET_DOWN_CONSECUTIVE_PULSES)
   : 3;
+
+// SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-3: a coordinator's own death is a DISTINCT
+// outage class from the worker-fleet-down case above (a live worker fleet with no coordinator
+// still drains claimable work; the risk here is the coordinator's standing responsibilities —
+// sweeps, gauges, dispatch-rank — silently going unattended for 43h+, per Solomon tri-role
+// evidence). Deliberately a SEPARATE, independently-named constant from
+// lib/coordinator/resolve.cjs's own internal STALE_THRESHOLD_MIN (10min) — that constant governs
+// resolve.cjs's own multi-source resolution chain and has unrelated blast radius; changing it to
+// serve this alert would silently affect every OTHER getActiveCoordinatorId() caller fleet-wide.
+const DEAD_COORDINATOR_STALE_MIN = Number(process.env.DEAD_COORDINATOR_STALE_MIN) > 0
+  ? Number(process.env.DEAD_COORDINATOR_STALE_MIN)
+  : 15;
+// This leg runs on fleet-down-alert-cron.yml's existing ~15min cadence (11,26,41,56 * * * *) —
+// used only to size the edge-trigger window below, not to gate execution.
+const DEAD_COORDINATOR_CRON_INTERVAL_MIN = Number(process.env.DEAD_COORDINATOR_CRON_INTERVAL_MIN) > 0
+  ? Number(process.env.DEAD_COORDINATOR_CRON_INTERVAL_MIN)
+  : 15;
+
+/**
+ * Pure decision: should we page the chairman that the coordinator itself is dead?
+ *
+ * No new table is introduced for edge-trigger dedup (TR-4: no schema changes). Instead this
+ * derives dedup purely from elapsed time since the last known coordinator heartbeat: the alert
+ * fires only on the tick where elapsed time FIRST crosses the staleness threshold (a window one
+ * cron interval wide just past the threshold) — the next tick's elapsed time will already be past
+ * that window, so it self-suppresses without persisted state, mirroring evaluateFleetDownAlert()'s
+ * edge-triggered intent with a continuous-timestamp signal instead of discrete pulses.
+ *
+ * @param {Object} args
+ * @param {string|null} args.lastCoordinatorHeartbeatAt - ISO timestamp of the most recently
+ *   known coordinator session's heartbeat (from claude_sessions, regardless of whether that
+ *   session is still the currently-elected coordinator), or null if none has ever been seen.
+ * @param {Date} [args.now] - injectable clock for tests.
+ * @param {number} [args.staleMin=DEAD_COORDINATOR_STALE_MIN]
+ * @param {number} [args.cronIntervalMin=DEAD_COORDINATOR_CRON_INTERVAL_MIN]
+ * @returns {{alert:boolean, reason:string, elapsedMin:number|null}}
+ */
+export function evaluateDeadCoordinatorAlert({
+  lastCoordinatorHeartbeatAt,
+  now = new Date(),
+  staleMin = DEAD_COORDINATOR_STALE_MIN,
+  cronIntervalMin = DEAD_COORDINATOR_CRON_INTERVAL_MIN,
+} = {}) {
+  if (!lastCoordinatorHeartbeatAt) {
+    return { alert: false, reason: 'no coordinator has ever been seen — insufficient history to confirm a dead-coordinator outage', elapsedMin: null };
+  }
+  const last = new Date(lastCoordinatorHeartbeatAt);
+  if (Number.isNaN(last.getTime())) {
+    return { alert: false, reason: 'invalid lastCoordinatorHeartbeatAt', elapsedMin: null };
+  }
+  const nowTs = now instanceof Date && !Number.isNaN(now.getTime()) ? now : new Date();
+  const elapsedMin = (nowTs.getTime() - last.getTime()) / 60000;
+
+  if (elapsedMin < staleMin) {
+    return { alert: false, reason: `coordinator heartbeat is ${elapsedMin.toFixed(1)}min old, within the ${staleMin}min staleness window`, elapsedMin };
+  }
+  if (elapsedMin >= staleMin + cronIntervalMin) {
+    return { alert: false, reason: `coordinator has been dead for ${elapsedMin.toFixed(1)}min — already past the first alertable tick (edge-trigger dedup)`, elapsedMin };
+  }
+  return {
+    alert: true,
+    reason: `DEAD COORDINATOR: no coordinator heartbeat for ${elapsedMin.toFixed(1)}min (>= ${staleMin}min threshold)`,
+    elapsedMin,
+  };
+}
 
 /**
  * Pure decision: should we email the operator that the fleet is sustained-down?
@@ -84,30 +150,20 @@ function buildEmail({ claimableCount, consecutiveZero, requiredConsecutive }) {
   return { subject, text, html };
 }
 
-async function main() {
-  enforceCliSendGuard({ scriptName: 'scripts/fleet-down-alert.mjs', flags: [{ name: '--dry-run' }] });
-  const DRY = !!process.env.FLEET_DOWN_ALERT_DRYRUN || process.argv.includes('--dry-run');
-  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) {
-    console.error('[fleet-down-alert] missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
-    process.exit(2);
-  }
-  const db = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-
+async function checkWorkerFleetDown(db, DRY) {
   // Read one more than the window so the edge-trigger dedup can inspect the pulse before it.
   const { data: pulses, error: pErr } = await db
     .from('fleet_worker_pulse')
     .select('active_count, captured_at')
     .order('captured_at', { ascending: false })
     .limit(REQUIRED_CONSECUTIVE + 1);
-  if (pErr) { console.error('[fleet-down-alert] pulse query failed:', pErr.message); process.exit(2); }
+  if (pErr) { console.error('[fleet-down-alert] pulse query failed:', pErr.message); return; }
 
   // Claimable-work-exists: count candidates the fleet could pick up right now.
   const { count: claimableCount, error: cErr } = await db
     .from('v_sd_next_candidates')
     .select('*', { count: 'exact', head: true });
-  if (cErr) { console.error('[fleet-down-alert] claimable query failed:', cErr.message); process.exit(2); }
+  if (cErr) { console.error('[fleet-down-alert] claimable query failed:', cErr.message); return; }
 
   const verdict = evaluateFleetDownAlert({
     pulses: pulses || [],
@@ -127,6 +183,61 @@ async function main() {
   const mod = await import(pathToFileURL(path.resolve('lib/notifications/resend-adapter.js')).href);
   const r = await mod.sendEmail({ from: 'LEO Fleet Reliability <onboarding@resend.dev>', to, subject: email.subject, html: email.html, text: email.text });
   console.log('[fleet-down-alert] email sent:', r?.id || JSON.stringify(r));
+}
+
+// SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-3: independent of checkWorkerFleetDown above —
+// a live worker fleet does not imply a live coordinator (the coordinator's standing
+// responsibilities — sweeps, gauges, dispatch-rank — are a distinct outage class). Deliberately
+// kept as a SEPARATE function with its own query and its own edge-trigger state, so a bug in one
+// predicate can never mask or entangle the other (TESTING gate finding, non-regression scenario).
+async function checkDeadCoordinator(db, DRY) {
+  const coordinatorId = await getActiveCoordinatorId(db);
+
+  // Regardless of whether a coordinator is CURRENTLY elected, find the most recent heartbeat any
+  // coordinator-flagged session has ever reported — this is what evaluateDeadCoordinatorAlert()'s
+  // elapsed-time edge-trigger needs, and it degrades gracefully to "no alert" if none exists yet.
+  const { data: rows, error } = await db
+    .from('claude_sessions')
+    .select('heartbeat_at')
+    .eq('metadata->>is_coordinator', 'true')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1);
+  if (error) { console.error('[fleet-down-alert] coordinator-heartbeat query failed:', error.message); return; }
+
+  const lastCoordinatorHeartbeatAt = rows && rows[0] ? rows[0].heartbeat_at : null;
+  const verdict = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt, now: new Date() });
+  console.log(`[dead-coordinator-alert] activeCoordinatorId=${coordinatorId || 'null'} ${verdict.alert ? 'ALERT' : 'no-alert'}: ${verdict.reason}`);
+
+  if (!verdict.alert) return;
+
+  const message = {
+    type: 'status',
+    body: `DEAD COORDINATOR: no active-coordinator heartbeat for ${verdict.elapsedMin.toFixed(0)}min. Coordinator standing duties (sweeps, gauges, dispatch-rank) are unattended. Start/restart a coordinator session.`,
+    kind: 'dead_coordinator_alert',
+    dedupeKey: `dead-coordinator-${new Date().toISOString().slice(0, 13)}`,
+  };
+  if (DRY) {
+    console.log('[dead-coordinator-alert] [DRY] would page chairman via sendChairmanSMS:', message.body);
+    return;
+  }
+  const { sendChairmanSMS } = await import(pathToFileURL(path.resolve('lib/comms/adam-outbound/chairman-sms-gate/index.js')).href);
+  const r = await sendChairmanSMS(message, { now: new Date() });
+  console.log('[dead-coordinator-alert] sendChairmanSMS result:', JSON.stringify(r));
+}
+
+async function main() {
+  enforceCliSendGuard({ scriptName: 'scripts/fleet-down-alert.mjs', flags: [{ name: '--dry-run' }] });
+  const DRY = !!process.env.FLEET_DOWN_ALERT_DRYRUN || process.argv.includes('--dry-run');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[fleet-down-alert] missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(2);
+  }
+  const db = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+  await checkWorkerFleetDown(db, DRY);
+  await checkDeadCoordinator(db, DRY);
 }
 
 // Run main() only as a CLI (guarded so tests can import the pure helper).

--- a/tests/unit/fleet-down-alert.test.js
+++ b/tests/unit/fleet-down-alert.test.js
@@ -2,7 +2,7 @@
 // Oscillation-robust (sustained window, not point-in-time), claimable-gated, and edge-trigger-deduped
 // so a long outage emails once rather than every 15-min run.
 import { describe, it, expect } from 'vitest';
-import { evaluateFleetDownAlert } from '../../scripts/fleet-down-alert.mjs';
+import { evaluateFleetDownAlert, evaluateDeadCoordinatorAlert } from '../../scripts/fleet-down-alert.mjs';
 
 // Helper: build a newest-first pulse list from active_count values.
 const pulses = (...active) => active.map((a) => ({ active_count: a }));
@@ -63,5 +63,65 @@ describe('evaluateFleetDownAlert (SD-LEO-INFRA-FLEET-DOWN-EMAIL-ALERT-001)', () 
   it('counts the leading zero-run in consecutiveZero', () => {
     expect(evaluateFleetDownAlert({ pulses: pulses(0, 0, 3), claimableCount: 1 }).consecutiveZero).toBe(2);
     expect(evaluateFleetDownAlert({ pulses: pulses(1, 0, 0), claimableCount: 1 }).consecutiveZero).toBe(0);
+  });
+});
+
+// SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-3 — dead-coordinator chairman-SMS page.
+// Independent predicate from evaluateFleetDownAlert() above (TS-10 non-regression scenario):
+// this describe block never touches the worker-fleet-down pulses/claimable inputs.
+describe('evaluateDeadCoordinatorAlert (SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001)', () => {
+  const NOW = new Date('2026-07-19T22:00:00.000Z');
+  const minutesAgo = (m) => new Date(NOW.getTime() - m * 60000).toISOString();
+
+  it('TS-4: fires exactly once per outage — first tick past the threshold alerts', () => {
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(16), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    expect(r.alert).toBe(true);
+    expect(r.reason).toMatch(/DEAD COORDINATOR/);
+  });
+
+  it('TS-4: does not re-fire on a later tick while still dead (edge-trigger dedup)', () => {
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(45), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    expect(r.alert).toBe(false);
+    expect(r.reason).toMatch(/already past the first alertable tick/);
+  });
+
+  it('TS-5: heartbeat within the staleness window does not fire', () => {
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(5), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    expect(r.alert).toBe(false);
+    expect(r.reason).toMatch(/within the/);
+  });
+
+  it('TS-5: heartbeat exactly at the staleness boundary fires (>=)', () => {
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(15), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    expect(r.alert).toBe(true);
+  });
+
+  it('TS-6: defaults are independently named from resolve.cjs STALE_THRESHOLD_MIN (15min default, not 10)', () => {
+    // 12min elapsed: dead under resolve.cjs's 10min internal constant, but NOT dead under this
+    // alert's own default (15min) — proves the two thresholds are not silently sharing a value.
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(12), now: NOW });
+    expect(r.alert).toBe(false);
+  });
+
+  it('no coordinator ever seen -> insufficient history, does not alert', () => {
+    const r = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: null, now: NOW });
+    expect(r.alert).toBe(false);
+    expect(r.reason).toMatch(/insufficient history/);
+  });
+
+  it('is total / fail-safe on odd input', () => {
+    expect(evaluateDeadCoordinatorAlert().alert).toBe(false);
+    expect(evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: 'not-a-date', now: NOW }).alert).toBe(false);
+  });
+
+  it('TS-10 (non-regression): evaluateFleetDownAlert is unaffected by dead-coordinator inputs and vice versa', () => {
+    // Worst case simultaneously: fleet is down AND coordinator is dead — each predicate must
+    // reach its own independent verdict from its own inputs only.
+    const fleetVerdict = evaluateFleetDownAlert({ pulses: pulses(0, 0, 0, 2), claimableCount: 5, requiredConsecutive: 3 });
+    const coordVerdict = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(16), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    expect(fleetVerdict.alert).toBe(true);
+    expect(coordVerdict.alert).toBe(true);
+    expect(fleetVerdict.reason).toMatch(/FLEET DOWN/);
+    expect(coordVerdict.reason).toMatch(/DEAD COORDINATOR/);
   });
 });


### PR DESCRIPTION
## Summary
- FR-3: `evaluateDeadCoordinatorAlert()` in `scripts/fleet-down-alert.mjs` — independent predicate alongside the existing worker-fleet-down check, pages the chairman via `sendChairmanSMS` on a genuine dead-coordinator condition (own edge-triggered dedup, own 15min staleness constant distinct from `resolve.cjs`'s internal 10min one). Closes the 43h coverage-gap class from Solomon tri-role evidence.
- FR-1: SCRIPT-SHAPED vs JUDGMENT-SHAPED classification table for every `STANDARD_LOOPS` entry (comment-only), documents `liveness-watcher`'s partial-GHA status, drops the phantom "root-freshness" scope-text reference.
- FR-4: two-layer durability contract documented in `docs/protocol/fleet-coordinator-and-worker-behavior.md`.
- FR-2 (the ~12 GHA cron workflow files migrating SCRIPT-SHAPED loops) follows as a separate PR per the PRD's batch-split plan (PR size).

## Test plan
- [x] `npx vitest run tests/unit/fleet-down-alert.test.js` — 25/25 passing (includes 9 new dead-coordinator tests + non-regression test proving the two alert predicates never entangle state)
- [x] `node --check` on both modified `.mjs` files
- [x] Workflow YAML parses (pre-commit hook)