### PR TITLE
fix(QF-20260719-828): exempt ADAM_EXCLUDED_KINDS stubs from hourly undelivered-outbound check

### DIFF
--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -264,12 +264,17 @@ async function main() {
     const myId = process.env.CLAUDE_SESSION_ID;
     if (myId) {
       const { findUndelivered } = require('../lib/coordinator/receipts.cjs');
+      const { ADAM_EXCLUDED_KINDS } = require('../lib/fleet/worker-status.cjs');
       const sinceIso = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      // QF-20260719-828: EXCLUDED_KINDS stubs (cross_party_ping et al) are by-design
+      // never read — they'd both false-flag as undelivered AND eat the 100-row limit.
+      // Filter DB-side, null-safe (a bare NOT IN would silently drop kind-less rows).
       const { data: outbound } = await sb.from('session_coordination')
         .select('id, target_session, message_type, subject, payload, created_at, read_at')
         .eq('sender_session', myId)
         .is('read_at', null)
         .gte('created_at', sinceIso)
+        .or('payload->>kind.is.null,payload->>kind.not.in.(' + ADAM_EXCLUDED_KINDS.join(',') + ')')
         .limit(100);
       const { data: sessions } = await sb.from('claude_sessions')
         .select('session_id, heartbeat_at')


### PR DESCRIPTION
The hourly-review undelivered-outbound check flagged coordinator→adam
cross_party_ping rows as unread-at-live-target, but EXCLUDED_KINDS stubs are
by-design never read — they false-flagged ~6 rows every hour (observed 17:23Z:
6 of 8 flagged rows) and eat the 100-row fetch limit. Filter DB-side via the
SSOT constant, null-safe (a bare NOT IN drops kind-less rows via NULL
comparison semantics — the .or() keeps them).

Live-verified against the coordinator's real outbound: 13→7 rows, exactly the
6 stub pings removed, 0 excluded kinds leak through.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
