### PR TITLE
feat(role-measurement): measurement integrity — probes fix-or-delete, ledger falsifiability, cost_tokens capture (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001)

### DIFF
--- a/database/migrations/20260719_solomon_ledger_batch_stamped.sql
+++ b/database/migrations/20260719_solomon_ledger_batch_stamped.sql
@@ -1,0 +1,31 @@
+-- solomon_advice_outcome_ledger batch-stamp exclusion marker.
+-- SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W2, FR-5/TR-3).
+--
+-- The disease: 198 of the decided rows had their decision stamped in ONE non-contemporaneous retro
+-- batch on 2026-07-12 (decision_at in [2026-07-12, 2026-07-13); every one of them has a decision_at
+-- more than an hour after its created_at — ZERO are contemporaneous). Those retro dispositions are
+-- narrative reconciliations ("consumed", "EXECUTED", "OBE", ...), not contemporaneous accept-decisions
+-- with a verified downstream outcome, so folding them into the accuracy denominator makes the accuracy
+-- number meaningless. FR-5 marks them with a DURABLE column and the rollup EXCLUDES marked rows from
+-- both the numerator and the denominator (TR-3: keyed on the durable column, never a re-derived
+-- timestamp heuristic, so the rollup is deterministic and re-runnable).
+--
+-- Purely ADDITIVE (one new nullable column, DEFAULT false — every pre-existing row is backfilled to
+-- false by the default). No existing column altered or dropped; no data loss. RLS unchanged (adding a
+-- nullable column to an existing RLS-enabled table needs none). The backfill UPDATE below is
+-- idempotent (fixed 2026-07-12 window + IS DISTINCT FROM guard) so re-applying is a no-op.
+-- @approved-by: SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 EXEC (W2; additive nullable column, parent-directed apply 2026-07-19)
+
+ALTER TABLE solomon_advice_outcome_ledger
+  ADD COLUMN IF NOT EXISTS batch_stamped boolean DEFAULT false;
+
+COMMENT ON COLUMN solomon_advice_outcome_ledger.batch_stamped IS 'Durable exclusion marker (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 W2, FR-5/TR-3): true iff this row''s decision was stamped in the 2026-07-12 non-contemporaneous retro backfill (198 rows). The accuracy rollup (fleet-dashboard.cjs computeSolomonLedgerRollup) EXCLUDES batch_stamped=true rows from BOTH the numerator and denominator so accuracy reflects only trustworthy contemporaneous evidence. Deterministic durable column, NOT a re-derived timestamp heuristic. false (the default) = a normal contemporaneous row.';
+
+-- Backfill: mark the ONE known retro batch — every row decided in the 2026-07-12 UTC window (verified
+-- 198 rows, 0 of them contemporaneous). The RESULT is stored durably in the column above; the rollup
+-- never re-derives it from timestamps.
+UPDATE solomon_advice_outcome_ledger
+   SET batch_stamped = true
+ WHERE decision_at >= '2026-07-12T00:00:00Z'
+   AND decision_at <  '2026-07-13T00:00:00Z'
+   AND batch_stamped IS DISTINCT FROM true;

--- a/database/migrations/20260719_solomon_ledger_cost_captured.sql
+++ b/database/migrations/20260719_solomon_ledger_cost_captured.sql
@@ -1,0 +1,18 @@
+-- solomon_advice_outcome_ledger cost-capture marker.
+-- SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W3, FR-6/TR-4).
+-- cost_tokens + cost_wall_ms already exist on this table (20260701_solomon_advice_outcome_ledger.sql);
+-- W3 populates them at write time from the writing session's authoritative telemetry. This migration
+-- adds ONLY the durable cost_captured marker the fail-soft path needs: when telemetry is unavailable
+-- the ledger row still lands with cost_tokens/cost_wall_ms = NULL and cost_captured = false, and the
+-- budget rollup counts ONLY cost_captured rows so a missing datum never blocks a write nor silently
+-- distorts the rollup (TR-4).
+--
+-- Purely ADDITIVE (one new nullable column, DEFAULT false — every pre-existing row is backfilled to
+-- false by the default, i.e. "cost was never captured for it"). No existing column altered or dropped,
+-- no data loss. RLS unchanged (adding a nullable column to an existing RLS-enabled table needs none).
+-- @approved-by: SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 EXEC (W3; additive nullable column, parent-directed apply 2026-07-19)
+
+ALTER TABLE solomon_advice_outcome_ledger
+  ADD COLUMN IF NOT EXISTS cost_captured boolean DEFAULT false;
+
+COMMENT ON COLUMN solomon_advice_outcome_ledger.cost_captured IS 'Durable marker: true iff cost_tokens/cost_wall_ms were captured from the writing session''s authoritative telemetry at write time (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 W3, FR-6/TR-4). false (the fail-soft default) means telemetry was unavailable and the cost columns are NULL. The weekly Fable budget rollup counts ONLY cost_captured=true rows so a missing datum never distorts spend share.';

--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -154,8 +154,16 @@ export function probeFrictionSignaling(facts = {}) {
 
 /**
  * P4 — Propose-only / never-build (CONST-002). Governed duty: Adam NEVER authors/builds; it only
- * sources. Drift = any Adam-authored build/PR exists in the window. This is the cardinal Adam
- * constraint — a single authored build is a fail.
+ * sources. Drift = Adam stepped into the claim/build lane. This is the cardinal Adam constraint —
+ * a single build-lane entry is a fail.
+ *
+ * COUNTERFACTUAL-PRESENCE signal (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-1): the resolver
+ * populates `adamAuthoredBuildsInWindow` from the live, ROLE-ATTRIBUTABLE claim census — the count of
+ * claude_sessions carrying metadata.role='adam' that ALSO hold a non-null sd_key (an Adam-role
+ * session that claimed an SD to build). This is the mirror of solomon-self-assessment's
+ * solomon_claim_count discipline signal, and deliberately NOT sub_agent_execution_results
+ * session-lineage (mixed-role → fabricated FAILs). A real 0 is a real PASS (Adam stayed
+ * propose-only, falsifiably); a query error leaves the fact null → 'unknown'.
  * @param {{ adamAuthoredBuildsInWindow?: number|null }} facts
  */
 export function probeProposeOnly(facts = {}) {
@@ -165,8 +173,8 @@ export function probeProposeOnly(facts = {}) {
     return bar('propose_only', duty, VERDICT.UNKNOWN, 'adamAuthoredBuildsInWindow unresolved — cannot confirm propose-only (not a pass)');
   }
   return Number(builds) === 0
-    ? bar('propose_only', duty, VERDICT.PASS, 'no Adam-authored builds in the window — propose-only upheld')
-    : bar('propose_only', duty, VERDICT.FAIL, `${builds} Adam-authored build(s) detected — CONST-002 propose-only violated`);
+    ? bar('propose_only', duty, VERDICT.PASS, 'no Adam-role session holds a build claim — propose-only upheld')
+    : bar('propose_only', duty, VERDICT.FAIL, `${builds} Adam-role session(s) hold a build claim (sd_key) — CONST-002 propose-only violated`);
 }
 
 /**

--- a/lib/telemetry/session-cost.cjs
+++ b/lib/telemetry/session-cost.cjs
@@ -1,0 +1,86 @@
+'use strict';
+/**
+ * Session/agent cost telemetry reader — SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W3, FR-6/TR-4).
+ *
+ * The AUTHORITATIVE per-session cost telemetry at write time is the statusline hook's real-time
+ * usage log (.claude/logs/context-usage.jsonl). The hook appends one JSONL snapshot per session
+ * every ~10s: { ts, session, model, context_used, input, output, cache_create, cache_read, ... }.
+ * scripts/sync-context-usage.js treats this exact file as the source of truth it uploads into the
+ * context_usage_log DB table, so reading it directly is reading the same authoritative signal at
+ * write time (not a backfilled estimate).
+ *
+ * FAIL-SOFT (TR-4): every failure mode — log absent, unreadable, no snapshot for this session, an
+ * unusable snapshot — returns { captured: false, reason } and NEVER throws. The caller writes the
+ * ledger row anyway with cost_tokens/cost_wall_ms = null + cost_captured = false.
+ */
+const fs = require('fs');
+const path = require('path');
+
+// The module lives at <repo-root>/lib/telemetry/; the log lives at <repo-root>/.claude/logs/.
+function defaultLogPath() {
+  return path.resolve(__dirname, '..', '..', '.claude', 'logs', 'context-usage.jsonl');
+}
+
+function toFiniteNumber(v) {
+  const n = typeof v === 'string' ? Number(v) : v;
+  return Number.isFinite(n) ? n : null;
+}
+
+// Total tokens accounted to one snapshot: prefer the server-authoritative context_used, else fall
+// back to summing the raw token fields the same snapshot carries.
+function snapshotTokens(e) {
+  const ctx = toFiniteNumber(e && e.context_used);
+  if (ctx != null) return ctx;
+  const sum = ['input', 'output', 'cache_create', 'cache_read']
+    .reduce((acc, k) => acc + (toFiniteNumber(e && e[k]) || 0), 0);
+  return sum > 0 ? sum : null;
+}
+
+/**
+ * Read the authoritative session cost telemetry for `sessionId` at write time.
+ * @param {object} o
+ * @param {string}  o.sessionId    the writing session's CLAUDE_SESSION_ID
+ * @param {string} [o.logPath]     override the JSONL path (else CONTEXT_USAGE_LOG env, else default)
+ * @param {number} [o.nowMs]       injectable clock (defaults to Date.now())
+ * @param {string} [o.logContent]  inject raw JSONL directly (tests) instead of reading a file
+ * @returns {{captured:boolean, costTokens?:number, wallMs?:number, source?:string, reason?:string}}
+ *   captured=true  → costTokens (latest snapshot's total tokens) + wallMs (session wall-clock
+ *                    elapsed, from its FIRST telemetry snapshot to now) are both non-null.
+ *   captured=false → telemetry unavailable; caller must fail-soft to nulls.
+ */
+function readSessionCostTelemetry({ sessionId, logPath, nowMs = Date.now(), logContent = null } = {}) {
+  try {
+    if (!sessionId) return { captured: false, reason: 'no sessionId' };
+    let content = logContent;
+    if (content == null) {
+      const p = logPath || process.env.CONTEXT_USAGE_LOG || defaultLogPath();
+      if (!fs.existsSync(p)) return { captured: false, reason: `no telemetry log at ${p}` };
+      content = fs.readFileSync(p, 'utf8');
+    }
+    const matching = [];
+    for (const line of String(content).split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      let e;
+      try { e = JSON.parse(t); } catch { continue; }
+      if (e && e.session === sessionId) matching.push(e);
+    }
+    if (matching.length === 0) return { captured: false, reason: `no telemetry snapshot for session ${sessionId}` };
+
+    const costTokens = snapshotTokens(matching[matching.length - 1]);
+    if (costTokens == null) return { captured: false, reason: 'latest snapshot has no usable token count' };
+
+    let earliestMs = null;
+    for (const e of matching) {
+      const ms = Date.parse(e && e.ts);
+      if (Number.isFinite(ms) && (earliestMs == null || ms < earliestMs)) earliestMs = ms;
+    }
+    if (earliestMs == null) return { captured: false, reason: 'no parseable telemetry timestamp' };
+
+    return { captured: true, costTokens, wallMs: Math.max(0, nowMs - earliestMs), source: 'context-usage.jsonl' };
+  } catch (e) {
+    return { captured: false, reason: (e && e.message) || String(e) };
+  }
+}
+
+module.exports = { readSessionCostTelemetry, snapshotTokens, defaultLogPath };

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -49,6 +49,13 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     adamMachineRaisedNoiseInWindow: null,
     pmBoardSnapshot: null,
     pmBoardPriorSnapshot: null,
+    // SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-1: the belt-starvation (D1) + dispatch-boundary
+    // (D2) cardinal facts are now resolved in the retro audit from LIVE claim tables (below), so
+    // those probes no longer degrade to 'unknown' here (the 297/297-unknown class).
+    claimableBelt: null,
+    idleWorkers: null,
+    sourceableBacklogCount: null,
+    advisoryBody: null,
   };
 
   // P3 friction-signaling (signals side): Adam-originated coordination messages within the window.
@@ -120,36 +127,36 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     }
   } catch { /* leave null -> unknown */ }
 
-  // FR-3 — propose-only (CONST-002): count build/PR/handoff/file-write actions AUTHORED by Adam
-  // within the window. HONEST-UNMEASURABLE by design: this fact stays null -> 'unknown'.
-  //
-  // Why we do NOT attribute via session lineage (the prior approach, which fabricated a FAIL):
-  //   - session_coordination.sender_session is a Claude session UUID, NOT a role tag. Sessions are
-  //     MIXED-ROLE — one session can speak as 'adam' (sender_type='adam') AND, in the same session,
-  //     run LEO worker/PLAN/EXEC phases that legitimately write sub_agent_execution_results. Counting
-  //     every build of any session that EVER sent an 'adam' message attributes legitimate LEO builds
-  //     to Adam -> a fabricated CONST-002 FAIL -> a false high-severity remediation flag.
-  //   - There is NO reliable PER-BUILD / PER-ROW Adam-author marker on sub_agent_execution_results.
-  //     Verified against live data (14d, 4,464 rows): metadata has NO 'sender_type' key (0 rows) and
-  //     NO 'actor' key (0 rows); 'sender_type'='adam'=0, 'actor'='adam'=0. The build rows carry
-  //     machinery keys (findings, routing, phase, session_id, repo_path, ...), none of which is a
-  //     per-build author identity. Adam is propose-only, so builds are simply never adam-tagged.
-  //
-  // The HONEST answer is therefore "could not measure": we leave adamAuthoredBuildsInWindow = null,
-  // which the probe turns into verdict='unknown' (never a fabricated 0/PASS and never a fabricated
-  // FAIL). propose_only honestly degrades to 'unknown' until a build-actor-tagging scheme exists
-  // (e.g. a per-row metadata->>'actor'='adam' stamp at the authoring seam). The SD target is 3-of-4
-  // measurable; the three measured dims are sourcing-cadence, friction-signaling, and vision-going-
-  // forward. NO query is issued here — there is no reliable source to query.
-  // facts.adamAuthoredBuildsInWindow stays null -> probe 'unknown' (honest).
+  // FR-1 (propose_only, CONST-002) — COUNTERFACTUAL-PRESENCE signal. Adam is propose-only: it NEVER
+  // steps into the claim/build lane. Prior code left this null -> 'unknown' FOREVER (108/108 unknown)
+  // arguing sub_agent_execution_results had no per-build Adam marker. That is true, but the SOUND
+  // signal is not "find an Adam build row" — it is the ROLE-ATTRIBUTABLE claim census: count
+  // claude_sessions carrying metadata.role='adam' that ALSO hold a non-null sd_key (an Adam-role
+  // session that claimed an SD to build). This is exactly the mirror of solomon-self-assessment's
+  // solomon_claim_count discipline signal (scripts/solomon-self-assessment-writer.cjs), keys on the
+  // durable role tag (NOT mixed-role session lineage, which fabricated FAILs), and NEVER fabricates:
+  // a real 0 is a real PASS (Adam stayed propose-only — falsifiable: it WOULD fail if an adam-role
+  // session held a claim), a >0 is a real violation, and only a query error leaves the fact
+  // null -> 'unknown'. Verified live 2026-07-19: 0 adam-role sessions hold an sd_key (PASS).
+  try {
+    const { count, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id', { count: 'exact', head: true })
+      .eq('metadata->>role', 'adam')
+      .not('sd_key', 'is', null);
+    if (error) throw error; // a query error must NOT masquerade as a real "0 build-claims"
+    if (Number.isFinite(count)) facts.adamAuthoredBuildsInWindow = count;
+  } catch { /* leave null -> unknown */ }
 
-  // FR-4 — vision monitoring: did Adam read the vision gauge within the window? The durable read
-  // marker is an audit_log row event_type='vision_gauge_read' written when Adam runs
+  // FR-4 / FR-1 — vision monitoring: did Adam read the vision gauge within the window? The durable
+  // read marker is an audit_log row event_type='vision_gauge_read' written when Adam runs
   // scripts/adam-exec-summary.mjs (recordVisionGaugeRead below; existing store, no new table).
-  // HONEST (highest-risk dim): if NO such event exists in the window — or the source is unavailable
-  // (query error) — the fact stays null -> unknown. It MUST NOT default to false: an absent durable
-  // signal is "could not confirm", not "definitely not read". This dim may legitimately remain
-  // 'unknown' (the SD target is 3-of-4 measurable).
+  // MEASURED, FALSIFIABLE (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-1): the vision-read marker
+  // is THE durable signal for this duty, so a SUCCESSFUL query with 0 events in the window means the
+  // duty was not evidenced -> FALSE -> probe FAIL (monitoring lapsed). Prior code degraded absence to
+  // null -> 'unknown', producing an unknown-forever gauge (66/108 unknown) that FR-1 forbids ("an
+  // unknown-forever probe is worse than none"). ONLY a query ERROR (infra fault) now leaves the fact
+  // null -> 'unknown' — a measured absence is a real, falsifiable FAIL, not a could-not-confirm.
   try {
     const { count, error } = await supabase
       .from('audit_log')
@@ -160,11 +167,10 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
       // always stamps metadata.sender_type='adam', so this filter is precise — a non-Adam writer of
       // the same event_type (should none ever exist) cannot satisfy Adam's monitoring duty.
       .eq('metadata->>sender_type', 'adam');
-    if (error) throw error;
-    // >=1 event -> measured TRUE. 0 events -> NOT measured-false: the marker is best-effort and may
-    // simply be absent for this window, so we honestly degrade to null -> unknown (never false).
-    if (Number.isFinite(count) && count >= 1) facts.visionGaugeReadInWindow = true;
-  } catch { /* leave null -> unknown */ }
+    if (error) throw error; // a query error must NOT masquerade as a measured "0 reads"
+    // >=1 event -> PASS (read). Successful 0 -> measured FALSE -> FAIL (lapsed). Error -> null/unknown.
+    if (Number.isFinite(count)) facts.visionGaugeReadInWindow = count >= 1;
+  } catch { /* leave null -> unknown (query error only) */ }
 
   // P7 decision-rubric (FR-1): the Adam->chairman decision-questions in the window. Adam's outward
   // advisory channel is session_coordination sender_type='adam', payload.kind='adam_advisory'
@@ -188,6 +194,18 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
       }));
     }
   } catch { /* leave null -> unknown */ }
+
+  // FR-1 (dispatch_boundary, D2) — resolve the advisory corpus body from the SAME in-window Adam
+  // advisory set resolved just above (session_coordination sender_type='adam', kind='adam_advisory').
+  // The pure probe scans for fleet-lifecycle/dispatch language; joining the window's advisory bodies
+  // makes it a real-window check — FAIL if ANY advisory crossed into the coordinator's capacity lane,
+  // PASS if none. Reuses the already-fetched corpus (no extra query). Null ONLY when that fetch itself
+  // failed (advisory set unresolved) -> probe 'unknown'; an empty-but-resolved corpus is '' -> PASS.
+  if (Array.isArray(facts.adamChairmanDecisionQuestionsInWindow)) {
+    facts.advisoryBody = facts.adamChairmanDecisionQuestionsInWindow
+      .map((q) => (q && q.body ? String(q.body) : ''))
+      .join('\n');
+  }
 
   // QF-20260704-748: the decision_rubric probe above only sees Adam's free-text advisory channel.
   // The stall detector (lib/adam/stall-alert.js) raises a SEPARATE, structured escalation channel --
@@ -265,6 +283,65 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     if (error) throw error;
     facts.pmBoardPriorSnapshot = parseSnapshotTail(lastRow && lastRow.detail);
   } catch { /* leave null -> unknown */ }
+
+  // FR-1 (belt_starvation, D1) — resolve the belt/idle census from the SAME live claim tables sd:next
+  // and the sweep read. claimableBelt = GENUINELY-claimable SDs (unclaimed + the canonical
+  // isClaimableSd predicate: non-orchestrator, all dependency blockers terminal) so a
+  // dependency-blocked SD never inflates the belt; idleWorkers = live WORKER sessions (recent
+  // heartbeat, active/idle, not a role-tagged non-worker) holding no SD claim — the claiming_session_id
+  // definition mirrored from lib/fleet/tier-backlog.cjs. The probe FAILs only when belt==0 AND idle>0
+  // AND backlog>0. HONEST: if EITHER census query errors, both facts stay null -> probe 'unknown'
+  // (never a fabricated belt=0 FAIL). Point-in-time snapshot: a real-time gauge's "window" is now.
+  try {
+    const mod = await import('../lib/coordinator/claimable-work.cjs');
+    const { isClaimableSd, dependencyKeys } = mod.default || mod;
+    const liveCutoff = new Date(nowMs - 15 * 60 * 1000).toISOString();
+    const [{ data: sdRows, error: sdErr }, { data: sessRows, error: sErr }] = await Promise.all([
+      supabase.from('strategic_directives_v2')
+        .select('sd_key, sd_type, status, dependencies, claiming_session_id')
+        .not('status', 'in', '(completed,cancelled,archived,deferred)'),
+      supabase.from('claude_sessions')
+        .select('session_id, metadata, sd_key, status, heartbeat_at')
+        .in('status', ['active', 'idle'])
+        .gte('heartbeat_at', liveCutoff),
+    ]);
+    if (sdErr) throw sdErr;
+    if (sErr) throw sErr;
+    const rows = Array.isArray(sdRows) ? sdRows : [];
+    // Resolve dependency-blocker statuses so isClaimableSd can judge each SD (unknown keys => UNMET,
+    // conservative). ONE .in() lookup over the distinct blocker keys (mirrors coordinator-audit).
+    const depKeys = dependencyKeys(rows);
+    const depStatus = {};
+    if (depKeys.length) {
+      const { data: depRows, error: depErr } = await supabase
+        .from('strategic_directives_v2').select('sd_key, status').in('sd_key', depKeys);
+      if (depErr) throw depErr;
+      for (const d of (depRows || [])) depStatus[d.sd_key] = d.status;
+    }
+    facts.claimableBelt = rows.filter((r) => !r.claiming_session_id && isClaimableSd(r, depStatus)).length;
+    const claimedSessionIds = new Set(rows.filter((r) => r.claiming_session_id).map((r) => r.claiming_session_id));
+    const NON_WORKER = new Set(['adam', 'solomon', 'coordinator', 'chairman', 'eva']);
+    const sess = Array.isArray(sessRows) ? sessRows : [];
+    facts.idleWorkers = sess.filter((s) => {
+      const role = String((s.metadata && s.metadata.role) || '').toLowerCase();
+      return !NON_WORKER.has(role) && !claimedSessionIds.has(s.session_id);
+    }).length;
+  } catch { /* leave claimableBelt/idleWorkers null -> belt probe unknown */ }
+
+  // FR-1 (belt_starvation, D1 third input) — sourceable backlog: genuine (auto-capture-excluded)
+  // open harness_backlog feedback, via the canonical scripts/lib/sourceable-backlog.mjs filter (the
+  // same the sweep's action-time check uses). HONEST: a real 0 is a real 0; only a query error leaves
+  // the fact null -> belt probe 'unknown'.
+  try {
+    const { sourceableBacklog } = await import('./lib/sourceable-backlog.mjs');
+    const { data: blRows, error: blErr } = await supabase
+      .from('feedback')
+      .select('id, status, title, metadata')
+      .eq('category', 'harness_backlog')
+      .in('status', ['open', 'new', 'backlog']);
+    if (blErr) throw blErr;
+    if (Array.isArray(blRows)) facts.sourceableBacklogCount = sourceableBacklog(blRows).length;
+  } catch { /* leave sourceableBacklogCount null -> belt probe unknown */ }
 
   return facts;
 }

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -18,6 +18,15 @@
  * Idempotent (ON CONFLICT correlation_id DO UPDATE — re-running never duplicates a row). Fail-open:
  * a ledger write failure is logged but never blocks the advisory ack/retire above.
  *
+ * MANDATORY OUTCOME LINKAGE (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001, W2/FR-3): an
+ * `--disposition accepted|partial` MUST name its tracking artifact via `--outcome-ref <SD/QF/PR/issue/commit id>`
+ * OR carry `--no-artifact "<reason>"` (the explicit no-trackable-artifact marker). An accept with
+ * neither is REJECTED before any ledger write — an unfalsifiable accept (no linkage a later
+ * revert/red-merge/RCA can back-propagate a negative outcome onto) is exactly the disease this closes.
+ * decision_at is always the real current time (contemporaneous-only; there is no backfill path here).
+ *   node scripts/coordinator-ack-adam.cjs --advisory <id> --disposition accepted --outcome-ref SD-FOO-001
+ *   node scripts/coordinator-ack-adam.cjs --advisory <id> --disposition accepted --no-artifact "verbal chairman ack"
+ *
  * `--disposition deferred` REQUIRES `--defer-trigger "<named re-fire event>"` — a deferral without a
  * named trigger is rejected before any DB write (the DB's own CHECK constraint is a second line of
  * defense once database/migrations/20260705_solomon_ledger_tail_and_deferral.sql is chairman-applied).
@@ -45,17 +54,54 @@ const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered }
 
 const VALID_DISPOSITIONS = Object.freeze(['accepted', 'rejected', 'partial', 'deferred']);
 
+// FR-3 (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001, W2): an ADOPT-class decision (accepted/partial)
+// on the ledger must name its tracking artifact (outcome_ref) OR carry this explicit no-artifact
+// marker. A decision with neither is unfalsifiable — there is no linkage a later revert/red-merge/RCA
+// (FR-4) can back-propagate a NEGATIVE outcome onto. The marker is stored durably in outcome_ref; a
+// NO_ARTIFACT-prefixed ref is deliberately never matchable by the FR-4 back-prop (nothing to track).
+const NO_ARTIFACT_MARKER = 'NO_ARTIFACT';
+const LINKAGE_REQUIRED_DISPOSITIONS = Object.freeze(['accepted', 'partial']);
+
+/** True for the durable no-artifact sentinel (bare 'NO_ARTIFACT' or 'NO_ARTIFACT: <reason>'). */
+function isNoArtifactRef(ref) {
+  return typeof ref === 'string' && (ref === NO_ARTIFACT_MARKER || ref.startsWith(`${NO_ARTIFACT_MARKER}:`));
+}
+
+/**
+ * Pure: resolve the outcome_ref to store for a decision, enforcing FR-3 mandatory linkage.
+ * - accepted/partial: MUST supply a non-empty outcomeRef OR noArtifact — else { error }.
+ *   noArtifact may be `true` (bare --no-artifact) or a string reason (stored as 'NO_ARTIFACT: <reason>').
+ * - rejected/deferred: outcome_ref is optional (a stray outcomeRef is still recorded; none is fine).
+ * Returns { ref } (string|null) on success, or { error } when linkage is mandatory and missing.
+ * Exported for tests.
+ */
+function resolveOutcomeRef(disposition, { outcomeRef = null, noArtifact = null } = {}) {
+  const cleanRef = typeof outcomeRef === 'string' ? outcomeRef.trim() : (outcomeRef ? String(outcomeRef).trim() : '');
+  if (LINKAGE_REQUIRED_DISPOSITIONS.includes(disposition)) {
+    if (cleanRef) return { ref: cleanRef };
+    if (noArtifact) {
+      const reason = typeof noArtifact === 'string' && noArtifact.trim() ? noArtifact.trim() : '';
+      return { ref: reason ? `${NO_ARTIFACT_MARKER}: ${reason}` : NO_ARTIFACT_MARKER };
+    }
+    return { error: `disposition=${disposition} requires --outcome-ref <artifact-id> OR --no-artifact "<reason>" (mandatory outcome linkage, FR-3)` };
+  }
+  return { ref: cleanRef || null };
+}
+
 /**
  * Fail-open: stamp the identical decision onto any still-pending tail rows referencing
  * `correlationId` via parent_correlation_id. Never throws — returns the count inherited (0 on any
  * error, including "column does not exist yet" for a not-yet-chairman-applied migration).
  */
-async function inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger }) {
+async function inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger, outcomeRef }) {
   try {
     const patch = { decision: disposition, decision_by: decidedBy || null, decision_at: decisionAt };
     // A deferred primary's tails must carry the SAME defer_trigger, or the DB's
     // defer_trigger_required CHECK would reject the tail update once the migration is applied.
     if (disposition === 'deferred') patch.defer_trigger = deferTrigger;
+    // FR-3: tails of an adopt-class decision inherit the primary's outcome_ref too, so a later
+    // negative outcome back-propagates onto the whole advisory group (parent + sub-recommendations).
+    if (outcomeRef) patch.outcome_ref = outcomeRef;
     const { data, error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
       .update(patch)
@@ -74,12 +120,21 @@ async function inheritTailDecisions(supabase, { correlationId, disposition, deci
  * correlation_id (idempotent upsert), then inherit that same decision onto any pending tail rows
  * (FR-4). Never throws — returns { recorded, reason, tailsInherited }. Exported for tests.
  */
-async function recordLedgerDecision(supabase, { correlationId, disposition, decidedBy, deferTrigger }) {
+async function recordLedgerDecision(supabase, { correlationId, disposition, decidedBy, deferTrigger, outcomeRef = null, noArtifact = null }) {
   if (!correlationId) return { recorded: false, reason: 'no correlation_id' };
   if (!VALID_DISPOSITIONS.includes(disposition)) return { recorded: false, reason: `invalid disposition: ${disposition}` };
   if (disposition === 'deferred' && !deferTrigger) {
     return { recorded: false, reason: 'disposition=deferred requires --defer-trigger (a named re-fire event)' };
   }
+  // FR-3: mandatory outcome linkage at accept time. An accepted/partial decision with neither an
+  // outcome_ref nor an explicit no-artifact marker is REJECTED before any DB write (never a silent,
+  // unfalsifiable accept). Resolution is deterministic; the marker is stored durably in outcome_ref.
+  const refResult = resolveOutcomeRef(disposition, { outcomeRef, noArtifact });
+  if (refResult.error) return { recorded: false, reason: refResult.error };
+  const resolvedOutcomeRef = refResult.ref;
+  // FR-3 contemporaneous guarantee: decision_at is ALWAYS the real current time. This writer has no
+  // backfill path — a caller cannot inject a historical decision_at, so every new stamp is
+  // contemporaneous by construction (the exact opposite of the 2026-07-12 retro batch).
   const decisionAt = new Date().toISOString();
   try {
     const row = {
@@ -88,6 +143,7 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
       decision_by: decidedBy || null,
       decision_at: decisionAt,
     };
+    if (resolvedOutcomeRef) row.outcome_ref = resolvedOutcomeRef;
     if (disposition === 'deferred') row.defer_trigger = deferTrigger;
     const { error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
@@ -96,8 +152,8 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
   } catch (e) {
     return { recorded: false, reason: (e && e.message) || String(e) };
   }
-  const { inherited: tailsInherited } = await inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger });
-  return { recorded: true, tailsInherited };
+  const { inherited: tailsInherited } = await inheritTailDecisions(supabase, { correlationId, disposition, decidedBy, decisionAt, deferTrigger, outcomeRef: resolvedOutcomeRef });
+  return { recorded: true, tailsInherited, outcomeRef: resolvedOutcomeRef };
 }
 
 function parseArgs(argv) {
@@ -167,14 +223,20 @@ async function main() {
       ? flags['correlation-id']
       : (adv.payload && adv.payload.correlation_id);
     const deferTrigger = typeof flags['defer-trigger'] === 'string' ? flags['defer-trigger'] : null;
-    const result = await recordLedgerDecision(supabase, { correlationId, disposition, decidedBy: coordinatorSession, deferTrigger });
+    // FR-3: --outcome-ref names the tracking artifact (SD/QF/PR/issue/commit id); --no-artifact is the
+    // explicit "no trackable artifact" marker (optional reason). One of the two is mandatory for an
+    // accepted/partial disposition.
+    const outcomeRef = typeof flags['outcome-ref'] === 'string' ? flags['outcome-ref'] : null;
+    const noArtifact = flags['no-artifact'] !== undefined ? flags['no-artifact'] : null; // true (bare) or a reason string
+    const result = await recordLedgerDecision(supabase, { correlationId, disposition, decidedBy: coordinatorSession, deferTrigger, outcomeRef, noArtifact });
     if (result.recorded) {
       console.log('✓ Ledger decision recorded');
       console.log('  correlation_id:', correlationId);
       console.log('  decision:', disposition);
+      if (result.outcomeRef) console.log('  outcome_ref:', result.outcomeRef);
       if (result.tailsInherited > 0) console.log('  tails inherited:', result.tailsInherited);
     } else {
-      console.warn(`⚠ Ledger decision NOT recorded (advisory still actioned): ${result.reason}`);
+      console.warn(`⚠ Ledger decision REJECTED (advisory still actioned): ${result.reason}`);
     }
   }
 
@@ -209,7 +271,7 @@ async function main() {
   }
 }
 
-module.exports = { parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS };
+module.exports = { parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS, resolveOutcomeRef, isNoArtifactRef, NO_ARTIFACT_MARKER, LINKAGE_REQUIRED_DISPOSITIONS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1806,8 +1806,14 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
   const accuracyPct = Math.round((acceptedShippedClean / decided.length) * 100);
 
   const accepted = decided.filter((r) => r.decision === 'accepted');
-  const acceptedCostSum = accepted.reduce((sum, r) => sum + (Number.isFinite(r.cost_tokens) ? r.cost_tokens : 0), 0);
-  const costPerAccepted = accepted.length > 0 ? Math.round(acceptedCostSum / accepted.length) : null;
+  // TR-4 (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001, W3): the budget rollup counts ONLY rows whose
+  // cost was actually captured from telemetry — a fail-soft cost_captured=false row (cost_tokens=null)
+  // is excluded from BOTH the numerator and the denominator so a missing datum never silently distorts
+  // cost-per-accepted. The finiteness check equals the cost_captured marker (captured rows always carry
+  // a finite cost_tokens); the explicit !== false guard also drops any durable-marked uncaptured row.
+  const acceptedCaptured = accepted.filter((r) => r.cost_captured !== false && Number.isFinite(r.cost_tokens));
+  const acceptedCostSum = acceptedCaptured.reduce((sum, r) => sum + r.cost_tokens, 0);
+  const costPerAccepted = acceptedCaptured.length > 0 ? Math.round(acceptedCostSum / acceptedCaptured.length) : null;
 
   return {
     decidedCount: decided.length,
@@ -1816,6 +1822,7 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
     acceptedShippedClean,
     accuracyPct,
     acceptedCount: accepted.length,
+    costCapturedCount: acceptedCaptured.length,
     costPerAccepted,
   };
 }
@@ -1831,7 +1838,7 @@ async function printSolomonLedgerRollup() {
     // claiming a 5000-row sample. Paginate up to the declared 5000-row sampling cap.
     rows = await fapPaginate(() => supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
-      .select('decision, outcome, cost_tokens, created_at')
+      .select('decision, outcome, cost_tokens, cost_captured, created_at')
       .order('created_at', { ascending: false })
       .order('id', { ascending: true }), { maxRows: 5000 }); // most-recent 5000, stable boundaries
   } catch (e) {

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1784,7 +1784,13 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
   const all = rows || [];
   if (all.length === 0) return null;
 
-  const decided = all.filter((r) => r.decision && r.decision !== 'pending');
+  // FR-5/TR-3 (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001, W2): rows carrying the durable
+  // batch_stamped marker are the 2026-07-12 non-contemporaneous retro backfill. They are EXCLUDED
+  // from the accuracy math — numerator AND denominator — so accuracy reflects only trustworthy
+  // contemporaneous evidence. Deterministic: keys on the durable column, never a timestamp heuristic.
+  const decidedAll = all.filter((r) => r.decision && r.decision !== 'pending');
+  const batchExcludedCount = decidedAll.filter((r) => r.batch_stamped === true).length;
+  const decided = decidedAll.filter((r) => r.batch_stamped !== true);
   const pending = all.filter((r) => !r.decision || r.decision === 'pending');
   const oldestPendingAgeMs = pending.length > 0
     ? Math.max(...pending.map((r) => nowMs - new Date(r.created_at).getTime()))
@@ -1799,6 +1805,7 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
       accuracyPct: null,
       acceptedCount: 0,
       costPerAccepted: null,
+      batchExcludedCount,
     };
   }
 
@@ -1824,6 +1831,7 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
     acceptedCount: accepted.length,
     costCapturedCount: acceptedCaptured.length,
     costPerAccepted,
+    batchExcludedCount,
   };
 }
 
@@ -1838,7 +1846,7 @@ async function printSolomonLedgerRollup() {
     // claiming a 5000-row sample. Paginate up to the declared 5000-row sampling cap.
     rows = await fapPaginate(() => supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
-      .select('decision, outcome, cost_tokens, cost_captured, created_at')
+      .select('decision, outcome, cost_tokens, cost_captured, batch_stamped, created_at')
       .order('created_at', { ascending: false })
       .order('id', { ascending: true }), { maxRows: 5000 }); // most-recent 5000, stable boundaries
   } catch (e) {
@@ -1865,6 +1873,11 @@ async function printSolomonLedgerRollup() {
 
   console.log('  ' + rollup.decidedCount + ' decided proposal(s) (' + rollup.pendingCount + ' pending, oldest ' + oldestPendingStr + ')');
   console.log('  accuracy: ' + rollup.accuracyPct + '% (' + rollup.acceptedShippedClean + '/' + rollup.decidedCount + ' accepted+shipped_clean)');
+  // FR-5: surface how many non-contemporaneous batch-stamped rows were excluded so the accuracy
+  // number is chairman/KPI-readable (accuracy is over trustworthy contemporaneous evidence only).
+  if (rollup.batchExcludedCount > 0) {
+    console.log('  (excluded ' + rollup.batchExcludedCount + ' batch-stamped/non-contemporaneous row(s) from accuracy)');
+  }
   console.log('  cost-per-accepted-proposal: ' + (rollup.costPerAccepted !== null ? rollup.costPerAccepted + ' tokens' : 'n/a (0 accepted)'));
   console.log('');
 }

--- a/scripts/one-off/apply-solomon-ledger-batch-stamped.mjs
+++ b/scripts/one-off/apply-solomon-ledger-batch-stamped.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * apply-solomon-ledger-batch-stamped.mjs — service-role apply + verify for the FR-5/TR-3
+ * batch-stamp exclusion column. SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W2).
+ *
+ * solomon_advice_outcome_ledger is a chairman-apply-gated table that is NOT in the live schema
+ * snapshot, so it is applied via the direct service-role pg path (createDatabaseClient), mirroring
+ * how the W3 cost_captured column landed — NOT via MCP (MCP is read-only). Runs the additive
+ * migration (ADD COLUMN + backfill UPDATE for the 2026-07-12 retro batch) then verifies the column
+ * exists and the expected number of rows were marked.
+ *
+ * Usage: node scripts/one-off/apply-solomon-ledger-batch-stamped.mjs [--dry-run]
+ */
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createDatabaseClient } from '../lib/supabase-connection.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION = path.join(__dirname, '..', '..', 'database', 'migrations', '20260719_solomon_ledger_batch_stamped.sql');
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const sql = fs.readFileSync(MIGRATION, 'utf8');
+  const client = await createDatabaseClient('engineer', { verify: false });
+  try {
+    // Pre-state
+    const pre = await client.query(
+      `SELECT count(*)::int AS n FROM solomon_advice_outcome_ledger
+        WHERE decision_at >= '2026-07-12T00:00:00Z' AND decision_at < '2026-07-13T00:00:00Z'`
+    );
+    console.log(`Pre-apply: ${pre.rows[0].n} row(s) in the 2026-07-12 retro-batch window.`);
+
+    if (dryRun) { console.log('[dry-run] would apply:', MIGRATION); return; }
+
+    await client.query(sql);
+    console.log('✓ Applied migration:', path.basename(MIGRATION));
+
+    // Verify column exists
+    const col = await client.query(
+      `SELECT data_type, column_default FROM information_schema.columns
+        WHERE table_name = 'solomon_advice_outcome_ledger' AND column_name = 'batch_stamped'`
+    );
+    if (col.rows.length === 0) throw new Error('VERIFY FAILED: batch_stamped column not present after apply');
+    console.log(`✓ Column present: batch_stamped ${col.rows[0].data_type} default ${col.rows[0].column_default}`);
+
+    // Verify backfill result
+    const marked = await client.query(`SELECT count(*)::int AS n FROM solomon_advice_outcome_ledger WHERE batch_stamped = true`);
+    const window = await client.query(
+      `SELECT count(*)::int AS n FROM solomon_advice_outcome_ledger
+        WHERE decision_at >= '2026-07-12T00:00:00Z' AND decision_at < '2026-07-13T00:00:00Z'`
+    );
+    console.log(`✓ batch_stamped=true rows: ${marked.rows[0].n} (07-12 window has ${window.rows[0].n})`);
+    if (marked.rows[0].n !== window.rows[0].n) {
+      console.warn(`⚠ marked (${marked.rows[0].n}) != window (${window.rows[0].n}) — inspect for out-of-window batch rows.`);
+    }
+    // Confirm none of the marked rows are contemporaneous (sanity: no false positive)
+    const contemp = await client.query(
+      `SELECT count(*)::int AS n FROM solomon_advice_outcome_ledger
+        WHERE batch_stamped = true
+          AND decision_at IS NOT NULL AND created_at IS NOT NULL
+          AND abs(extract(epoch FROM (decision_at - created_at))) <= 3600`
+    );
+    console.log(`✓ contemporaneous rows wrongly marked: ${contemp.rows[0].n} (expected 0)`);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((e) => { console.error('FATAL:', e.message || e); process.exit(1); });

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -63,6 +63,9 @@ const {
 // lane Adam wires (lib/coordinator/presence-grounding-signals.cjs) — no per-role reimplementation.
 const { getFleetPresence, getReadReceipts, getWorkingSignal } = require('../lib/coordinator/presence-grounding-signals.cjs');
 const { writeWorkingSignal } = require('../lib/coordinator/working-signal-store.cjs');
+// SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W3, FR-6/TR-4): authoritative session cost telemetry
+// read at ledger-write time (fail-soft — a telemetry miss never blocks the write).
+const { readSessionCostTelemetry } = require('../lib/telemetry/session-cost.cjs');
 
 // The consult kind the Solomon lane drains (a deep-reasoning request routed to the oracle).
 const SOLOMON_CONSULT_KIND = 'solomon_consult';
@@ -503,9 +506,24 @@ async function ensureOriginatorCc(supabase, { replyRef, replyTo, target, session
  * advisory send — a ledger write failure (table not yet applied, transient DB error) must not
  * prevent the advisory from being sent. Mirrors the alreadyAnswered/checkConsultQuota fail-open
  * style above. SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-2, TR-2). Exported for tests.
+ *
+ * SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W3, FR-6/TR-4): also captures cost_tokens + cost_wall_ms
+ * from the writing session's authoritative telemetry AT WRITE TIME. FAIL-SOFT: when telemetry is
+ * unavailable the row still lands with cost_tokens/cost_wall_ms=null and the durable cost_captured=false
+ * marker, so a missing datum never blocks a write nor silently distorts the budget rollup (which counts
+ * only cost_captured rows). `readTelemetry` is injectable for tests.
  */
-async function captureLedgerRow(supabase, { advisoryId, correlationId, sdKey, body } = {}) {
+async function captureLedgerRow(
+  supabase,
+  { advisoryId, correlationId, sdKey, body, sessionId } = {},
+  { readTelemetry = readSessionCostTelemetry } = {}
+) {
   if (!correlationId) return { captured: false, reason: 'no correlation_id' };
+  // Read cost telemetry BEFORE the write; fully fail-soft (the reader never throws, but guard anyway).
+  let tele;
+  try { tele = readTelemetry({ sessionId }) || { captured: false }; }
+  catch { tele = { captured: false }; }
+  const costCaptured = tele.captured === true;
   try {
     const { error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot
@@ -516,11 +534,14 @@ async function captureLedgerRow(supabase, { advisoryId, correlationId, sdKey, bo
           sd_key: sdKey || null,
           proposal_summary: String(body || '').slice(0, 4000),
           proposal_kind: 'advisory',
+          cost_tokens: costCaptured ? tele.costTokens : null,
+          cost_wall_ms: costCaptured ? tele.wallMs : null,
+          cost_captured: costCaptured,
         },
         { onConflict: 'correlation_id', ignoreDuplicates: true }
       );
     if (error) return { captured: false, reason: error.message };
-    return { captured: true };
+    return { captured: true, costCaptured };
   } catch (e) {
     return { captured: false, reason: (e && e.message) || String(e) };
   }
@@ -824,6 +845,7 @@ async function main() {
     correlationId: payload.correlation_id,
     sdKey: process.env.SD_KEY || null,
     body: payload.body,
+    sessionId, // W3 (FR-6): key cost telemetry to the writing session at write time
   });
   if (!ledgerResult.captured) {
     ledgerCaptureFailures += 1;

--- a/scripts/solomon-ledger-reconcile.cjs
+++ b/scripts/solomon-ledger-reconcile.cjs
@@ -73,6 +73,114 @@ async function reconcileBatch(supabase, rows) {
   return results;
 }
 
+// ── FR-4 (SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001, W2): negative-outcome back-propagation ────────
+// The ledger had ZERO negative outcomes ever recorded, so "accuracy" was unfalsifiable. When a
+// revert / red-merge / RCA attribution names a tracked artifact, the linked ledger row's outcome
+// flips to 'reverted'. Attribution flows ONLY through EXACT outcome_ref equality — never a heuristic —
+// so a real accept that named that artifact (FR-3) is the only thing a negative signal can touch.
+const NEGATIVE_OUTCOME = 'reverted';
+const NEGATIVE_BACKPROP_SOURCE = 'solomon-ledger-negative-backprop.cjs';
+// audit_log events that constitute a durable negative signal. RED_MERGE_DETECTED is written by
+// scripts/ci/red-merge-detector.mjs; the revert/RCA events are matched defensively if present.
+const NEGATIVE_AUDIT_EVENTS = Object.freeze(['RED_MERGE_DETECTED', 'RED_MERGE', 'SD_REVERTED', 'REVERT', 'RCA_ATTRIBUTED_REGRESSION']);
+// Metadata keys a negative signal may carry a reference under (raw value used verbatim — the match
+// is still exact outcome_ref equality, so extra candidate keys never create mis-attribution).
+const NEGATIVE_REF_KEYS = Object.freeze(['sha', 'commit_sha', 'sd_key', 'sd_id', 'ref', 'outcome_ref', 'pr', 'pr_url', 'pr_number', 'signature']);
+
+/** Pure: add every non-empty candidate reference from a signal's metadata object into `set`. */
+function addRefsFromMetadata(set, metadata) {
+  if (!metadata || typeof metadata !== 'object') return;
+  for (const k of NEGATIVE_REF_KEYS) {
+    const v = metadata[k];
+    if (v != null && String(v).trim()) set.add(String(v).trim());
+  }
+}
+
+/**
+ * Pure: given ledger rows and a set of negative reference strings, return the rows to flip to
+ * 'reverted'. EXACT outcome_ref equality only. A NO_ARTIFACT sentinel ref (FR-3 no-artifact marker)
+ * is never linkable. Rows already terminal-negative (reverted/caused_rework) are skipped (idempotent);
+ * unknown/shipped_clean flip (a later revert means it was not actually clean). Exported for tests.
+ */
+function selectNegativeBackprop(ledgerRows, negativeRefs) {
+  const refSet = negativeRefs instanceof Set ? negativeRefs : new Set((negativeRefs || []).filter(Boolean).map(String));
+  const out = [];
+  for (const r of (ledgerRows || [])) {
+    const ref = r && r.outcome_ref;
+    if (!ref || typeof ref !== 'string') continue;
+    if (ref === 'NO_ARTIFACT' || ref.startsWith('NO_ARTIFACT:')) continue; // explicit no-artifact — nothing to track
+    if (!refSet.has(ref)) continue;                                        // EXACT linkage only, never heuristic
+    if (r.outcome === NEGATIVE_OUTCOME || r.outcome === 'caused_rework') continue; // already negative — idempotent
+    out.push({ id: r.id, outcome_ref: ref, priorOutcome: r.outcome });
+  }
+  return out;
+}
+
+/**
+ * Read DURABLE negative signals and return the set of reference strings they name. Fail-open per
+ * source (a query error yields no refs from that source, never throws). Exported for tests.
+ *   1. audit_log rows with a negative event (metadata refs)
+ *   2. strategic_directives_v2 rows with metadata.reverted_at set (a real SD revert -> its sd_key + id)
+ */
+async function collectNegativeRefs(supabase, { sinceMs = null } = {}) {
+  const refs = new Set();
+  try {
+    let q = supabase.from('audit_log').select('event, metadata, created_at').in('event', NEGATIVE_AUDIT_EVENTS);
+    if (sinceMs) q = q.gte('created_at', new Date(sinceMs).toISOString());
+    const { data, error } = await q.limit(2000);
+    if (!error && Array.isArray(data)) for (const row of data) addRefsFromMetadata(refs, row.metadata);
+  } catch { /* fail-open */ }
+  try {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, metadata')
+      .not('metadata->>reverted_at', 'is', null)
+      .limit(2000);
+    if (!error && Array.isArray(data)) {
+      for (const sd of data) { if (sd.sd_key) refs.add(String(sd.sd_key)); if (sd.id) refs.add(String(sd.id)); }
+    }
+  } catch { /* fail-open */ }
+  return refs;
+}
+
+/**
+ * Back-propagate a NEGATIVE outcome onto every ledger row whose outcome_ref EXACTLY matches a negative
+ * reference. Stamps outcome='reverted' + closer-of-record (closed_by/closed_at). Fail-open per row.
+ * dryRun returns the matches without writing. Exported for tests.
+ */
+async function backPropagateNegativeOutcomes(supabase, { negativeRefs, source = NEGATIVE_BACKPROP_SOURCE, nowIso = new Date().toISOString(), dryRun = false } = {}) {
+  const refSet = negativeRefs instanceof Set ? negativeRefs : new Set((negativeRefs || []).filter(Boolean).map(String));
+  if (refSet.size === 0) return { matched: [], updated: [] };
+  let rows = [];
+  try {
+    const { data, error } = await supabase
+      .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
+      .select('id, outcome, outcome_ref')
+      .not('outcome_ref', 'is', null)
+      .limit(5000);
+    if (error) return { matched: [], updated: [], reason: error.message };
+    rows = data || [];
+  } catch (e) {
+    return { matched: [], updated: [], reason: (e && e.message) || String(e) };
+  }
+  const matched = selectNegativeBackprop(rows, refSet);
+  if (dryRun) return { matched, updated: [] };
+  const updated = [];
+  for (const m of matched) {
+    try {
+      const { error } = await supabase
+        .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — chairman-apply-gated table, not yet in the live snapshot
+        .update({ outcome: NEGATIVE_OUTCOME, closed_by: source, closed_at: nowIso })
+        .eq('id', m.id);
+      if (error) { console.error(`  WARN: negative back-prop failed for ${m.id}: ${error.message}`); continue; }
+      updated.push(m.id);
+    } catch (e) {
+      console.error(`  WARN: negative back-prop threw for ${m.id}: ${(e && e.message) || e}`);
+    }
+  }
+  return { matched, updated };
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
   let supabase;
@@ -125,9 +233,25 @@ async function main() {
     .select('*', { count: 'exact', head: true })
     .eq('outcome', 'unknown');
   console.log(`Ledger state after this run: ${unknownAfter ?? '?'} row(s) outcome='unknown' (was ${unknownBefore ?? '?'}).`);
+
+  // FR-4: negative-outcome back-propagation. Collect durable revert/red-merge/RCA signals and flip any
+  // ledger row whose outcome_ref EXACTLY matches to 'reverted' (closes the "zero negatives ever" gap).
+  const negRefs = await collectNegativeRefs(supabase, {});
+  console.log(`Negative-signal refs collected (revert/red-merge/RCA): ${negRefs.size}.`);
+  const backprop = await backPropagateNegativeOutcomes(supabase, { negativeRefs: negRefs, dryRun });
+  if (dryRun) {
+    console.log(`  [dry-run] ${backprop.matched.length} ledger row(s) would flip to outcome='reverted' via exact outcome_ref linkage:`);
+    for (const m of backprop.matched) console.log(`    ${m.id}: ${m.priorOutcome} -> reverted (ref=${m.outcome_ref})`);
+  } else {
+    console.log(`  Negative back-prop: ${backprop.updated.length}/${backprop.matched.length} row(s) stamped outcome='reverted' via outcome_ref linkage.`);
+  }
 }
 
-module.exports = { mapSdStatusToOutcome, reconcileBatch };
+module.exports = {
+  mapSdStatusToOutcome, reconcileBatch,
+  selectNegativeBackprop, collectNegativeRefs, backPropagateNegativeOutcomes, addRefsFromMetadata,
+  NEGATIVE_OUTCOME, NEGATIVE_BACKPROP_SOURCE, NEGATIVE_AUDIT_EVENTS,
+};
 
 if (require.main === module) {
   main().catch((err) => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/solomon-self-adherence-review.mjs
+++ b/scripts/solomon-self-adherence-review.mjs
@@ -13,9 +13,16 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { SOLOMON_LOOPS, ROLE_CONTEXT_DOC, missingDurableDuties } from './solomon-startup-check.mjs';
 import { isMainModule } from '../lib/utils/is-main-module.js';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
+
+// SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-2: the 12h self-adherence review previously wrote
+// NOTHING to the DB — its self-scoring was dormant/invisible. We persist each review cycle to the
+// EXISTING feedback table (no new chairman-gated table), mirroring the sibling solomon_self_assessment
+// writer convention (category-scoped, review_key-idempotent, service-role client).
+const SELF_ADHERENCE_CATEGORY = 'solomon_self_adherence';
 
 /**
  * Pure: build the self-adherence verdict. Reads CLAUDE_SOLOMON.md (if present) and reports which
@@ -43,8 +50,93 @@ export function renderReport(repoRoot = REPO_ROOT) {
   return head + (v.ok ? `✅ ${v.note}` : `⚠️ ${v.note}`);
 }
 
-function main() {
+/**
+ * Deterministic per-cycle review key. The self-adherence cron fires every 12 hours, so two
+ * UTC slots/day (am/pm) dedupe a re-run WITHIN the same cadence window without suppressing the next
+ * legitimate cycle. Pure.
+ */
+export function selfAdherenceReviewKey(now = new Date()) {
+  const day = now.toISOString().slice(0, 10);
+  const slot = now.getUTCHours() < 12 ? 'am' : 'pm';
+  return `solomon-self-adherence:${day}:${slot}`;
+}
+
+/**
+ * FR-2 — persist ONE Solomon self-adherence review cycle to the DB. Writes a feedback row (mirrors
+ * the sibling solomon_self_assessment writer: category-scoped, review_key-idempotent, service-role).
+ * A parity-holds cycle records a benign AUDIT row (type='enhancement', status='resolved'); a DRIFT
+ * cycle records a PROPOSE-ONLY remediation (type='issue', status='new') for the coordinator —
+ * Solomon surfaces the drift, never builds the fix (CONST-002). FAIL-SOFT: any error returns null and
+ * NEVER throws, so the review can never block a Solomon tick. Returns the feedback row id (or the
+ * existing row's id when the cycle was already recorded), else null.
+ * @param {object} supabase service-role client
+ * @param {{ok:boolean, drifted:string[], note:string}} verdict
+ * @param {{ reviewKey?: string, sessionId?: string|null, now?: Date }} [opts]
+ */
+export async function persistSelfAdherenceReview(supabase, verdict, { reviewKey, sessionId = null, now = new Date() } = {}) {
+  const key = reviewKey || selfAdherenceReviewKey(now);
+  try {
+    // Idempotent on review_key — a re-run within the same 12h slot must not double-write.
+    const { data: existing } = await supabase
+      .from('feedback')
+      .select('id')
+      .eq('category', SELF_ADHERENCE_CATEGORY)
+      .filter('metadata->>review_key', 'eq', key)
+      .limit(1);
+    if (existing && existing.length) return existing[0].id;
+
+    const drift = !!(verdict && verdict.ok === false);
+    const drifted = (verdict && Array.isArray(verdict.drifted)) ? verdict.drifted : [];
+    const note = (verdict && verdict.note) || 'no verdict';
+    const row = {
+      type: drift ? 'issue' : 'enhancement',
+      source_application: 'EHG_Engineer',
+      source_type: 'auto_capture',
+      category: SELF_ADHERENCE_CATEGORY,
+      status: drift ? 'new' : 'resolved',
+      severity: drift ? 'medium' : 'low',
+      title: drift
+        ? `Solomon self-adherence DRIFT: ${drifted.join(', ')}`
+        : 'Solomon self-adherence — parity holds',
+      description: note,
+      metadata: {
+        review_key: key,
+        ok: !!(verdict && verdict.ok),
+        drifted,
+        session_id: sessionId,
+        sd: 'SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001',
+      },
+    };
+    // A parity-holds cycle is a self-resolved AUDIT record (not an open queue item): status='resolved'
+    // requires a non-empty resolution_notes per the feedback chk_feedback_terminal_resolution CHECK.
+    if (!drift) row.resolution_notes = `Self-adherence parity holds (auto-audit). ${note}`;
+    const { data, error } = await supabase
+      .from('feedback')
+      .insert(row)
+      .select('id')
+      .single();
+    if (error) throw error;
+    return data.id;
+  } catch (err) {
+    console.warn(`[solomon-self-adherence] persist failed (non-blocking): ${err?.message || String(err)}`);
+    return null;
+  }
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const verdict = (() => { try { return buildSelfAdherenceVerdict(); } catch { return { ok: true, drifted: [], note: 'verdict unavailable (fail-open)' }; } })();
   try { console.log(renderReport()); } catch (err) { console.log('solomon-self-adherence-review fail-open:', err?.message || String(err)); }
+  // FR-2: persist the cycle (unless --dry-run). Fail-open — a persistence hiccup never blocks the tick.
+  if (!dryRun) {
+    try {
+      const supabase = createSupabaseServiceClient();
+      const id = await persistSelfAdherenceReview(supabase, verdict, { sessionId: process.env.CLAUDE_SESSION_ID || null });
+      console.log(id ? `  self-adherence cycle persisted → feedback ${id}` : '  self-adherence cycle NOT persisted (fail-soft)');
+    } catch (err) {
+      console.log('  solomon-self-adherence persist fail-open:', err?.message || String(err));
+    }
+  }
   process.exit(0);
 }
 

--- a/tests/unit/adam/adherence-resolvers.test.js
+++ b/tests/unit/adam/adherence-resolvers.test.js
@@ -62,12 +62,12 @@ const ERR = (msg) => () => ({ count: null, data: null, error: new Error(msg) });
 const ROWS = (rows) => () => ({ count: null, data: rows, error: null });
 
 describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
-  it('reliable sources -> 3-of-4 facts are finite/real; propose_only is honestly unknown', async () => {
+  it('reliable sources -> all facts are finite/real; propose_only MEASURED via role-claim census', async () => {
     const sb = makeSupabase({
       session_coordination: COUNT(4), // FR-P3 signals: 4 Adam signals (head-count)
       strategic_directives_v2: COUNT(2), // FR-1b sourced
       issue_patterns: ROWS([{ trend: 'stable' }, { trend: 'decreasing' }]), // FR-2: 1 live-recurring (stable), decreasing excluded
-      sub_agent_execution_results: COUNT(0), // FR-3 builds — NOT consulted (no per-row Adam marker)
+      claude_sessions: COUNT(0), // FR-1 propose_only: 0 adam-role sessions hold a build-claim
       audit_log: COUNT(1), // FR-4 vision read present (Adam-authored)
     });
     const facts = await resolveFacts(sb, { windowDays: 1 });
@@ -75,11 +75,10 @@ describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
     expect(facts.signalsInWindow).toBe(4); // FR-P3 measured
     expect(facts.recurrencesInWindow).toBe(1); // FR-2 measured (stable counts, decreasing excluded)
     expect(facts.visionGaugeReadInWindow).toBe(true); // FR-4 measured (>=1 Adam marker)
-    // FR-3 is HONESTLY UNMEASURABLE: there is no per-row Adam-author marker on
-    // sub_agent_execution_results, so adamAuthoredBuilds is null -> probe 'unknown'. We do NOT
-    // fabricate a 0 (a fake CONST-002 pass) nor a session-attributed FAIL.
-    expect(facts.adamAuthoredBuildsInWindow).toBeNull();
-    // 3-of-4 measurable: sourcing-cadence + friction-signaling + vision-going-forward.
+    // FR-1: propose_only is now MEASURED via the COUNTERFACTUAL-PRESENCE signal (claude_sessions
+    // metadata.role='adam' holding a non-null sd_key). A real 0 is a real PASS (Adam stayed
+    // propose-only) — no longer honestly-unmeasurable, no longer unknown-forever.
+    expect(facts.adamAuthoredBuildsInWindow).toBe(0);
   });
 
   it('FR-1b: a real 0 sourced stays 0 (NOT unknown) — cadence stall is measurable', async () => {
@@ -139,19 +138,34 @@ describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
     expect(facts.sourcedInWindow).toBeNull();
   });
 
-  it('FR-3: no per-row Adam-author marker exists -> adamAuthoredBuilds stays null (no fabricated CONST-002 pass OR fail)', async () => {
-    // Even with a healthy fleet of build rows, the resolver does NOT consult
-    // sub_agent_execution_results for FR-3: there is no reliable per-build Adam-author key, and
-    // session-lineage attribution would fabricate a FAIL (mixed-role sessions). Honest = unknown.
+  it('FR-1 propose_only: signal is the adam-ROLE claim census, NOT sub_agent_execution_results lineage', async () => {
+    // The counterfactual-presence signal keys on claude_sessions metadata.role='adam' holding an
+    // sd_key (Adam in the build lane). sub_agent_execution_results is NOT consulted — mixed-role
+    // lineage would fabricate a FAIL, so even a large build fleet must NOT bleed into the fact.
     const sb = makeSupabase({
       session_coordination: COUNT(2),
       strategic_directives_v2: COUNT(1),
       issue_patterns: ROWS([]),
-      sub_agent_execution_results: COUNT(99), // intentionally large — must NOT bleed into the fact
+      sub_agent_execution_results: COUNT(99), // MUST NOT be consulted
+      claude_sessions: COUNT(3), // 3 adam-role sessions hold a build-claim -> a real violation
       audit_log: COUNT(0),
     });
     const facts = await resolveFacts(sb, { windowDays: 1 });
-    expect(facts.adamAuthoredBuildsInWindow).toBeNull(); // honest unknown, NOT a fabricated 0 or 99
+    expect(facts.adamAuthoredBuildsInWindow).toBe(3); // measured from the role-claim census
+    // 3 > 0 => a real CONST-002 propose-only violation (falsifiable FAIL, never fabricated).
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'propose_only').verdict).toBe('fail');
+  });
+
+  it('FR-1 propose_only: a claude_sessions query ERROR leaves the fact null -> unknown (honesty preserved)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(1),
+      issue_patterns: ROWS([]),
+      claude_sessions: ERR('db down'),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.adamAuthoredBuildsInWindow).toBeNull(); // query error -> unknown, never fabricated
   });
 
   it('FR-2: case-insensitive + widened allow-set (stable/increasing/persistent/recurring/new); wound-down trends excluded', async () => {
@@ -183,16 +197,29 @@ describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
     expect(facts.recurrencesInWindow).toBeNull();
   });
 
-  it('FR-4: zero Adam vision-read markers -> visionGaugeReadInWindow stays null (NEVER false)', async () => {
+  it('FR-1 vision: a SUCCESSFUL 0-marker window -> visionGaugeReadInWindow=false (FAIL, not unknown-forever)', async () => {
     const sb = makeSupabase({
       session_coordination: COUNT(1),
       strategic_directives_v2: COUNT(1),
       issue_patterns: ROWS([]),
-      sub_agent_execution_results: COUNT(0),
-      audit_log: COUNT(0), // no Adam marker this window
+      audit_log: COUNT(0), // no Adam vision-read marker in the window (a MEASURED absence)
     });
     const facts = await resolveFacts(sb, { windowDays: 1 });
-    expect(facts.visionGaugeReadInWindow).toBeNull(); // not false — could-not-confirm
+    // Post-FR-1: a measured absence of the durable read-marker is a falsifiable FAIL, not an
+    // unknown-forever gauge. ("An unknown-forever probe is worse than none.")
+    expect(facts.visionGaugeReadInWindow).toBe(false);
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'vision_monitoring').verdict).toBe('fail');
+  });
+
+  it('FR-1 vision: a query ERROR still leaves visionGaugeReadInWindow null -> unknown (honesty boundary preserved)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(1),
+      strategic_directives_v2: COUNT(1),
+      issue_patterns: ROWS([]),
+      audit_log: ERR('db down'), // infra fault != measured absence
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.visionGaugeReadInWindow).toBeNull();
   });
 });
 
@@ -217,9 +244,9 @@ describe('FR-5: the audit ACTUALLY CATCHES drift', () => {
     expect(sourcing.verdict).toBe('fail');
     expect(hasDrift(res.bars)).toBe(true);
 
-    // propose_only is honestly 'unknown' (no per-row Adam marker) — never a fabricated fail.
+    // propose_only now MEASURES the adam-role claim census; the mock seeds 0 (default) -> PASS.
     const proposeOnly = res.bars.find((b) => b.probe === 'propose_only');
-    expect(proposeOnly.verdict).toBe('unknown');
+    expect(proposeOnly.verdict).toBe('pass');
 
     // A propose-only remediation feedback row was sourced with the canonical category.
     expect(res.remediationRef).toBe('fb-remediation-1');
@@ -247,26 +274,100 @@ describe('FR-5: the audit ACTUALLY CATCHES drift', () => {
     expect(sb._calls.feedbackInsert[0].category).toBe('adam_adherence_drift');
   });
 
-  it('HONESTY: a genuinely-unresolved fact yields unknown and does NOT, alone, trigger remediation', async () => {
-    // All MEASURED dims clean; vision-monitoring AND propose-only are honestly unknown (no markers /
-    // unmeasurable). An 'unknown' is neither pass nor fail -> hasDrift stays false -> no remediation.
+  it('HONESTY: a genuinely-unresolved fact (query error) yields unknown and does NOT, alone, trigger remediation', async () => {
+    // All MEASURED dims clean; friction is honestly 'unknown' because its recurrence SOURCE errored
+    // (a real infra fault, not a measured absence). An 'unknown' is neither pass nor fail -> hasDrift
+    // stays false -> no remediation. (Post-FR-1, vision-absence and propose-presence are MEASURED, so
+    // the honest 'could-not-measure' path is now a query ERROR — the only remaining unknown source.)
     const sb = makeSupabase({
       session_coordination: COUNT(1), // signals present
       strategic_directives_v2: COUNT(3), // sourcing pass
-      issue_patterns: ROWS([]), // friction pass (nothing to signal)
-      sub_agent_execution_results: COUNT(0), // not consulted -> propose_only unknown
-      audit_log: COUNT(0), // <-- vision marker ABSENT -> unknown (not false, not a fail)
+      issue_patterns: ERR('db down'), // <-- recurrence source ERROR -> friction unknown
+      claude_sessions: COUNT(0), // propose_only measured 0 -> pass
+      audit_log: COUNT(1), // vision read present -> pass
       feedback: () => ({ id: 'fb-should-not-be-written' }),
       adam_adherence_ledger: () => ({ id: 'ledger-3' }),
     });
     const res = await runSelfAdherenceReview(sb, { windowDays: 1, runId: 'run-unknown' });
-    const vision = res.bars.find((b) => b.probe === 'vision_monitoring');
-    expect(vision.verdict).toBe('unknown'); // honest unknown, never coerced to fail
+    const friction = res.bars.find((b) => b.probe === 'friction_signaling');
+    expect(friction.verdict).toBe('unknown'); // query error -> honest unknown, never coerced to fail
     const proposeOnly = res.bars.find((b) => b.probe === 'propose_only');
-    expect(proposeOnly.verdict).toBe('unknown'); // honestly unmeasurable, not a fail
-    expect(hasDrift(res.bars)).toBe(false); // an unknown alone is NOT drift
+    expect(proposeOnly.verdict).toBe('pass'); // measured 0 build-claims
+    expect(hasDrift(res.bars)).toBe(false); // an unknown alone is NOT drift (no probe FAILED)
     expect(res.remediationRef).toBeNull(); // no remediation sourced
     expect(sb._calls.feedbackInsert).toHaveLength(0); // NO real/feedback row written for an unknown
+  });
+});
+
+describe('FR-1: belt_starvation + dispatch_boundary resolve from LIVE claim tables (297/297-unknown class extinct)', () => {
+  const nowIso = () => new Date().toISOString();
+
+  it('belt_starvation: healthy belt (unclaimed claimable SD + idle worker + backlog) => PASS', async () => {
+    const sb = makeSupabase({
+      strategic_directives_v2: ROWS([
+        { sd_key: 'SD-A', sd_type: 'implementation', status: 'active', dependencies: [], claiming_session_id: null }, // unclaimed + claimable
+        { sd_key: 'SD-B', sd_type: 'implementation', status: 'active', dependencies: [], claiming_session_id: 'sess-1' }, // claimed
+      ]),
+      claude_sessions: ROWS([
+        { session_id: 'sess-2', metadata: { role: 'worker' }, sd_key: null, status: 'active', heartbeat_at: nowIso() }, // idle worker
+      ]),
+      feedback: ROWS([{ id: 'fb1', status: 'open', title: 'real backlog item', metadata: {} }]),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.claimableBelt).toBe(1); // SD-A only (SD-B is claimed)
+    expect(facts.idleWorkers).toBe(1); // sess-2 holds no claim
+    expect(facts.sourceableBacklogCount).toBe(1);
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'belt_starvation').verdict).toBe('pass');
+  });
+
+  it('belt_starvation: belt=0 while a worker is idle and backlog exists => FAIL (real drift, not unknown)', async () => {
+    const sb = makeSupabase({
+      strategic_directives_v2: ROWS([
+        { sd_key: 'SD-C', sd_type: 'implementation', status: 'active', dependencies: [], claiming_session_id: 'sess-9' }, // all claimed
+      ]),
+      claude_sessions: ROWS([
+        { session_id: 'sess-idle', metadata: { role: 'worker' }, sd_key: null, status: 'idle', heartbeat_at: nowIso() },
+      ]),
+      feedback: ROWS([{ id: 'fb', status: 'open', title: 'genuine sourceable work', metadata: {} }]),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.claimableBelt).toBe(0);
+    expect(facts.idleWorkers).toBe(1);
+    expect(facts.sourceableBacklogCount).toBe(1);
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'belt_starvation').verdict).toBe('fail');
+  });
+
+  it('belt_starvation: a claim-census query ERROR leaves the facts null -> unknown (honesty)', async () => {
+    const sb = makeSupabase({
+      strategic_directives_v2: ERR('db down'),
+      claude_sessions: ERR('db down'),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.claimableBelt).toBeNull();
+    expect(facts.idleWorkers).toBeNull();
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'belt_starvation').verdict).toBe('unknown');
+  });
+
+  it('dispatch_boundary: an advisory carrying fleet-dispatch language => FAIL', async () => {
+    const sb = makeSupabase({
+      session_coordination: ROWS([
+        { payload: { kind: 'adam_advisory', body: 'Status: sourcing looks healthy.' }, created_at: 't1' },
+        { payload: { kind: 'adam_advisory', body: 'We should spin up a worker to cover the gap.' }, created_at: 't2' },
+      ]),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(typeof facts.advisoryBody).toBe('string');
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'dispatch_boundary').verdict).toBe('fail');
+  });
+
+  it('dispatch_boundary: a clean advisory corpus => PASS (resolved, not unknown)', async () => {
+    const sb = makeSupabase({
+      session_coordination: ROWS([
+        { payload: { kind: 'adam_advisory', body: 'Recommend we defer SD-X; belt is healthy.' }, created_at: 't1' },
+      ]),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(runAdherenceProbes(facts).find((b) => b.probe === 'dispatch_boundary').verdict).toBe('pass');
   });
 });
 

--- a/tests/unit/coordinator-ack-adam-disposition.test.js
+++ b/tests/unit/coordinator-ack-adam-disposition.test.js
@@ -35,14 +35,16 @@ function makeStubSupabase({ upsertError = null, updateError = null, updatedTailI
 describe('FR-3: recordLedgerDecision — idempotent decision update', () => {
   it('TS-3: upserts decision/decision_by/decision_at keyed on correlation_id (ON CONFLICT DO UPDATE)', async () => {
     const sb = makeStubSupabase();
-    const r1 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x' });
-    const r2 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x' });
+    // FR-3 (W2): an accepted decision now MUST name its tracking artifact (outcome_ref).
+    const r1 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x', outcomeRef: 'SD-X-001' });
+    const r2 = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', decidedBy: 'session-x', outcomeRef: 'SD-X-001' });
     expect(r1.recorded).toBe(true);
     expect(r2.recorded).toBe(true);
     expect(sb._upserts).toHaveLength(2); // two upsert calls, both keyed on the SAME correlation_id (idempotent — never a second row)
     expect(sb._upserts[0].row.correlation_id).toBe('corr-1');
     expect(sb._upserts[0].row.decision).toBe('accepted');
     expect(sb._upserts[0].row.decision_by).toBe('session-x');
+    expect(sb._upserts[0].row.outcome_ref).toBe('SD-X-001'); // FR-3: linkage stamped on the row
     expect(sb._upserts[0].opts.onConflict).toBe('correlation_id');
     expect(sb._upserts[1].row.correlation_id).toBe(sb._upserts[0].row.correlation_id);
   });
@@ -73,11 +75,12 @@ describe('FR-3: recordLedgerDecision — idempotent decision update', () => {
 describe('FR-4: recordLedgerDecision — tail-inheritance', () => {
   it('TS-3 (guardrail): stamping a primary auto-inherits the same decision onto matching pending tails', async () => {
     const sb = makeStubSupabase({ updatedTailIds: ['tail-1', 'tail-2'] });
-    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-primary', disposition: 'accepted', decidedBy: 'session-x' });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-primary', disposition: 'accepted', decidedBy: 'session-x', outcomeRef: 'SD-PRIMARY-001' });
     expect(result.recorded).toBe(true);
     expect(result.tailsInherited).toBe(2);
     expect(sb._updates).toHaveLength(1);
     expect(sb._updates[0].patch.decision).toBe('accepted');
+    expect(sb._updates[0].patch.outcome_ref).toBe('SD-PRIMARY-001'); // FR-3: tails inherit the primary's linkage too
     expect(sb._updates[0].col1).toBe('parent_correlation_id');
     expect(sb._updates[0].val1).toBe('corr-primary');
     expect(sb._updates[0].col2).toBe('decision');
@@ -92,7 +95,7 @@ describe('FR-4: recordLedgerDecision — tail-inheritance', () => {
 
   it('degrades to inherited:0 (never throws) when the migration has not been applied yet (column-missing error)', async () => {
     const sb = makeStubSupabase({ updateError: { message: 'column "parent_correlation_id" does not exist' } });
-    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted' });
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'corr-1', disposition: 'accepted', outcomeRef: 'SD-Z-001' });
     expect(result.recorded).toBe(true); // primary write still succeeds
     expect(result.tailsInherited).toBe(0);
   });
@@ -103,6 +106,61 @@ describe('FR-4: recordLedgerDecision — tail-inheritance', () => {
     expect(result.tailsInherited).toBe(1);
     expect(sb._updates[0].patch.decision).toBe('deferred');
     expect(sb._updates[0].patch.defer_trigger).toBe('next chairman weekly review');
+  });
+});
+
+describe('FR-3 (W2, SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001): mandatory outcome linkage at accept time', () => {
+  it('REJECTS an accept with neither outcome_ref nor a no-artifact marker, before any DB write', async () => {
+    const sb = { from: () => ({ upsert: () => { throw new Error('should not be called'); } }) };
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'accepted', decidedBy: 'session-x' });
+    expect(result.recorded).toBe(false);
+    expect(result.reason).toMatch(/outcome-ref|no-artifact|mandatory outcome linkage/);
+  });
+
+  it('REJECTS a partial with neither outcome_ref nor a no-artifact marker (partial is an adopt-class decision)', async () => {
+    const sb = { from: () => ({ upsert: () => { throw new Error('should not be called'); } }) };
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'partial' });
+    expect(result.recorded).toBe(false);
+    expect(result.reason).toMatch(/mandatory outcome linkage/);
+  });
+
+  it('accepts with an explicit --no-artifact marker (stored durably as the NO_ARTIFACT sentinel in outcome_ref)', async () => {
+    const sb = makeStubSupabase();
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'accepted', noArtifact: 'verbal chairman ack, no ticket' });
+    expect(result.recorded).toBe(true);
+    expect(sb._upserts[0].row.outcome_ref).toBe('NO_ARTIFACT: verbal chairman ack, no ticket');
+    expect(m.isNoArtifactRef(sb._upserts[0].row.outcome_ref)).toBe(true);
+  });
+
+  it('accepts with a bare --no-artifact flag (true) → the plain NO_ARTIFACT sentinel', async () => {
+    const sb = makeStubSupabase();
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'accepted', noArtifact: true });
+    expect(result.recorded).toBe(true);
+    expect(sb._upserts[0].row.outcome_ref).toBe('NO_ARTIFACT');
+  });
+
+  it('stamps a real contemporaneous decision_at (never a backfilled/historical timestamp)', async () => {
+    const sb = makeStubSupabase();
+    const before = Date.now();
+    await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'accepted', outcomeRef: 'PR-6284' });
+    const stamped = new Date(sb._upserts[0].row.decision_at).getTime();
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('does NOT require linkage for a rejected decision (nothing adopted → nothing to track)', async () => {
+    const sb = makeStubSupabase();
+    const result = await m.recordLedgerDecision(sb, { correlationId: 'c1', disposition: 'rejected' });
+    expect(result.recorded).toBe(true);
+    expect(sb._upserts[0].row.outcome_ref).toBeUndefined();
+  });
+
+  it('resolveOutcomeRef is pure and deterministic (accept requires linkage; reject does not)', () => {
+    expect(m.resolveOutcomeRef('accepted', {}).error).toMatch(/mandatory outcome linkage/);
+    expect(m.resolveOutcomeRef('accepted', { outcomeRef: '  SD-A-1  ' }).ref).toBe('SD-A-1'); // trimmed
+    expect(m.resolveOutcomeRef('partial', { noArtifact: true }).ref).toBe('NO_ARTIFACT');
+    expect(m.resolveOutcomeRef('rejected', {}).ref).toBeNull();
+    expect(m.LINKAGE_REQUIRED_DISPOSITIONS).toEqual(['accepted', 'partial']);
   });
 });
 

--- a/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
+++ b/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
@@ -69,12 +69,27 @@ describe('FR-5: computeSolomonLedgerRollup', () => {
     expect(r.costPerAccepted).toBeNull();
   });
 
-  it('treats a missing/non-finite cost_tokens as 0 rather than crashing', () => {
+  it('TR-4 (SD-...-ROLE-MEASUREMENT-INTEGRITY-001): excludes rows with no captured cost from the cost denominator (never distorts)', () => {
     const rows = [
-      { decision: 'accepted', outcome: 'shipped_clean' }, // no cost_tokens field
+      { decision: 'accepted', outcome: 'shipped_clean' }, // no cost_tokens — telemetry never captured
       { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 50 },
     ];
     const r = computeSolomonLedgerRollup(rows);
-    expect(r.costPerAccepted).toBe(25); // (0+50)/2
+    // The uncaptured row is dropped from BOTH numerator and denominator, so cost-per-accepted is the
+    // real captured cost (50), not a distorted 25. acceptedCount still reflects all accepted rows.
+    expect(r.acceptedCount).toBe(2);
+    expect(r.costCapturedCount).toBe(1);
+    expect(r.costPerAccepted).toBe(50);
+  });
+
+  it('TR-4: a durable cost_captured=false row is excluded from cost-per-accepted (fail-soft rows never inflate spend)', () => {
+    const rows = [
+      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: null, cost_captured: false }, // fail-soft write
+      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 400, cost_captured: true },
+    ];
+    const r = computeSolomonLedgerRollup(rows);
+    expect(r.acceptedCount).toBe(2);
+    expect(r.costCapturedCount).toBe(1);
+    expect(r.costPerAccepted).toBe(400); // only the captured row counts
   });
 });

--- a/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
+++ b/tests/unit/fleet-dashboard-solomon-ledger-rollup.test.js
@@ -93,3 +93,58 @@ describe('FR-5: computeSolomonLedgerRollup', () => {
     expect(r.costPerAccepted).toBe(400); // only the captured row counts
   });
 });
+
+describe('FR-5/TR-3 (W2, SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001): batch-stamp exclusion via durable marker', () => {
+  it('excludes batch_stamped=true rows from BOTH the accuracy numerator and denominator', () => {
+    const rows = [
+      // Trustworthy contemporaneous evidence: 1 accepted+shipped_clean of 2 decided -> 50%.
+      { decision: 'accepted', outcome: 'shipped_clean', created_at: '2026-07-18T00:00:00Z' },
+      { decision: 'rejected', outcome: 'unknown', created_at: '2026-07-18T00:00:00Z' },
+      // The 2026-07-12 retro batch — durably marked. Without exclusion these 3 unknown-outcome
+      // accepts would crater accuracy to 1/5 = 20%.
+      { decision: 'accepted', outcome: 'unknown', batch_stamped: true, created_at: '2026-07-12T15:00:00Z' },
+      { decision: 'accepted', outcome: 'unknown', batch_stamped: true, created_at: '2026-07-12T15:00:00Z' },
+      { decision: 'partial', outcome: 'unknown', batch_stamped: true, created_at: '2026-07-12T15:00:00Z' },
+    ];
+    const r = computeSolomonLedgerRollup(rows);
+    expect(r.decidedCount).toBe(2);        // batch rows excluded from the denominator
+    expect(r.acceptedShippedClean).toBe(1);
+    expect(r.accuracyPct).toBe(50);        // 1/2, NOT 1/5
+    expect(r.batchExcludedCount).toBe(3);  // surfaced for chairman/KPI readability
+  });
+
+  it('deterministic durable marker, not a timestamp heuristic: a 07-12 row WITHOUT the marker still counts', () => {
+    const rows = [
+      { decision: 'accepted', outcome: 'shipped_clean', created_at: '2026-07-12T15:00:00Z' }, // no batch_stamped → included
+      { decision: 'accepted', outcome: 'unknown', batch_stamped: true, created_at: '2026-07-12T15:00:00Z' },
+    ];
+    const r = computeSolomonLedgerRollup(rows);
+    expect(r.decidedCount).toBe(1);       // only the unmarked row
+    expect(r.accuracyPct).toBe(100);      // 1/1
+    expect(r.batchExcludedCount).toBe(1);
+  });
+
+  it('when EVERY decided row is batch-stamped, accuracy is null (no trustworthy evidence) not a misleading number', () => {
+    const rows = [
+      { decision: 'accepted', outcome: 'unknown', batch_stamped: true, created_at: '2026-07-12T15:00:00Z' },
+      { decision: 'pending', outcome: 'unknown', created_at: '2026-07-18T00:00:00Z' },
+    ];
+    const r = computeSolomonLedgerRollup(rows);
+    expect(r.decidedCount).toBe(0);
+    expect(r.accuracyPct).toBeNull();
+    expect(r.pendingCount).toBe(1);
+    expect(r.batchExcludedCount).toBe(1);
+  });
+
+  it('rows with batch_stamped=false or undefined are unaffected (W3 cost tests stay green)', () => {
+    const rows = [
+      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 100, cost_captured: true, batch_stamped: false },
+      { decision: 'accepted', outcome: 'shipped_clean', cost_tokens: 300, cost_captured: true },
+    ];
+    const r = computeSolomonLedgerRollup(rows);
+    expect(r.decidedCount).toBe(2);
+    expect(r.acceptedCount).toBe(2);
+    expect(r.costPerAccepted).toBe(200);
+    expect(r.batchExcludedCount).toBe(0);
+  });
+});

--- a/tests/unit/solomon-ledger-cost-capture.test.js
+++ b/tests/unit/solomon-ledger-cost-capture.test.js
@@ -1,0 +1,115 @@
+/**
+ * SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 (W3, FR-6/TR-4) — cost_tokens + cost_wall_ms capture at
+ * ledger write time, from authoritative session telemetry, with a fail-soft cost_captured marker.
+ * Injected-stub coverage (no real DB, no real telemetry log).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { readSessionCostTelemetry } = require('../../lib/telemetry/session-cost.cjs');
+const { captureLedgerRow } = require('../../scripts/solomon-advisory.cjs');
+
+// A supabase stub whose upsert records the row it was asked to write.
+function stubSupabase() {
+  const calls = { upsertRow: null, upsertOpts: null, count: 0 };
+  const sb = {
+    from: () => ({
+      upsert: (row, opts) => {
+        calls.upsertRow = row;
+        calls.upsertOpts = opts;
+        calls.count += 1;
+        return Promise.resolve({ error: null });
+      },
+    }),
+  };
+  return { sb, calls };
+}
+
+describe('W3 FR-6: readSessionCostTelemetry — authoritative per-session telemetry', () => {
+  it('captures cost_tokens (latest snapshot) + wall_ms (elapsed since first snapshot) when telemetry is present', () => {
+    const logContent = [
+      JSON.stringify({ ts: '2026-07-19T10:00:00.000Z', session: 'S1', context_used: 50000, input: 40000, output: 10000 }),
+      JSON.stringify({ ts: '2026-07-19T10:05:00.000Z', session: 'OTHER', context_used: 999999 }), // different session — ignored
+      JSON.stringify({ ts: '2026-07-19T10:10:00.000Z', session: 'S1', context_used: 123456, input: 100000, output: 23456 }),
+    ].join('\n');
+    const nowMs = Date.parse('2026-07-19T10:20:00.000Z');
+    const t = readSessionCostTelemetry({ sessionId: 'S1', logContent, nowMs });
+    expect(t.captured).toBe(true);
+    expect(t.costTokens).toBe(123456);              // latest S1 snapshot's context_used
+    expect(t.wallMs).toBe(20 * 60 * 1000);          // 10:20 now − 10:00 first S1 snapshot = 20 min
+    expect(t.source).toBe('context-usage.jsonl');
+  });
+
+  it('falls back to summing token fields when context_used is absent', () => {
+    const logContent = JSON.stringify({ ts: '2026-07-19T10:00:00.000Z', session: 'S2', input: 30000, output: 5000, cache_read: 1000 });
+    const t = readSessionCostTelemetry({ sessionId: 'S2', logContent, nowMs: Date.parse('2026-07-19T10:00:01.000Z') });
+    expect(t.captured).toBe(true);
+    expect(t.costTokens).toBe(36000); // 30000 + 5000 + 1000
+  });
+
+  it('is fail-soft (captured:false) when there is no snapshot for this session', () => {
+    const logContent = JSON.stringify({ ts: '2026-07-19T10:00:00.000Z', session: 'SOMEONE_ELSE', context_used: 42 });
+    const t = readSessionCostTelemetry({ sessionId: 'S1', logContent });
+    expect(t.captured).toBe(false);
+    expect(t.reason).toMatch(/no telemetry snapshot/);
+  });
+
+  it('is fail-soft (captured:false, no throw) when the log file is missing', () => {
+    const t = readSessionCostTelemetry({ sessionId: 'S1', logPath: '/no/such/telemetry/log/context-usage.jsonl' });
+    expect(t.captured).toBe(false);
+    expect(t.reason).toMatch(/no telemetry log/);
+  });
+
+  it('is fail-soft (captured:false) when no sessionId is available', () => {
+    const t = readSessionCostTelemetry({ logContent: '{}' });
+    expect(t.captured).toBe(false);
+    expect(t.reason).toMatch(/sessionId/);
+  });
+});
+
+describe('W3 FR-6/TR-4: captureLedgerRow — cost capture at write time', () => {
+  it('(a) telemetry present → row carries non-null cost_tokens + cost_wall_ms + cost_captured=true', async () => {
+    const { sb, calls } = stubSupabase();
+    const readTelemetry = () => ({ captured: true, costTokens: 123456, wallMs: 6789 });
+    const result = await captureLedgerRow(
+      sb,
+      { advisoryId: 'adv-1', correlationId: 'corr-1', sdKey: 'SD-1', body: 'hello', sessionId: 'S1' },
+      { readTelemetry }
+    );
+    expect(result.captured).toBe(true);       // ledger write succeeded
+    expect(result.costCaptured).toBe(true);
+    expect(calls.upsertRow.cost_tokens).toBe(123456);
+    expect(calls.upsertRow.cost_wall_ms).toBe(6789);
+    expect(calls.upsertRow.cost_captured).toBe(true);
+  });
+
+  it('(b) telemetry absent → row STILL written with cost_tokens null + cost_wall_ms null + cost_captured=false', async () => {
+    const { sb, calls } = stubSupabase();
+    const readTelemetry = () => ({ captured: false, reason: 'no telemetry snapshot for session S1' });
+    const result = await captureLedgerRow(
+      sb,
+      { advisoryId: 'adv-2', correlationId: 'corr-2', sdKey: 'SD-1', body: 'hi', sessionId: 'S1' },
+      { readTelemetry }
+    );
+    expect(result.captured).toBe(true);        // TR-4: write still succeeds
+    expect(result.costCaptured).toBe(false);
+    expect(calls.count).toBe(1);               // the row WAS written
+    expect(calls.upsertRow.cost_tokens).toBeNull();
+    expect(calls.upsertRow.cost_wall_ms).toBeNull();
+    expect(calls.upsertRow.cost_captured).toBe(false);
+    // core ledger fields are unaffected by the telemetry miss
+    expect(calls.upsertRow.correlation_id).toBe('corr-2');
+    expect(calls.upsertRow.proposal_summary).toBe('hi');
+  });
+
+  it('default telemetry reader is fail-soft: no sessionId / no log → cost_captured=false, write still succeeds', async () => {
+    const { sb, calls } = stubSupabase();
+    // No readTelemetry override and no sessionId — exercises the real readSessionCostTelemetry default,
+    // which returns captured:false for a missing sessionId (never throws, never blocks the write).
+    const result = await captureLedgerRow(sb, { correlationId: 'corr-3', body: 'x' });
+    expect(result.captured).toBe(true);
+    expect(result.costCaptured).toBe(false);
+    expect(calls.upsertRow.cost_captured).toBe(false);
+    expect(calls.upsertRow.cost_tokens).toBeNull();
+  });
+});

--- a/tests/unit/solomon-ledger-reconcile.test.js
+++ b/tests/unit/solomon-ledger-reconcile.test.js
@@ -5,7 +5,11 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { mapSdStatusToOutcome, reconcileBatch } = require('../../scripts/solomon-ledger-reconcile.cjs');
+const {
+  mapSdStatusToOutcome, reconcileBatch,
+  selectNegativeBackprop, collectNegativeRefs, backPropagateNegativeOutcomes, addRefsFromMetadata,
+  NEGATIVE_OUTCOME, NEGATIVE_BACKPROP_SOURCE,
+} = require('../../scripts/solomon-ledger-reconcile.cjs');
 
 describe('FR-4: mapSdStatusToOutcome', () => {
   it('maps completed -> shipped_clean, cancelled -> reverted, else null (not yet terminal)', () => {
@@ -67,5 +71,93 @@ describe('FR-4: reconcileBatch — reads the actual downstream SD, not Solomon s
     expect(results[0].reason).toMatch(/transient db error/);
     expect(results[1].updated).toBe(true); // second row still processed despite the first failing
     expect(results[1].outcome).toBe('shipped_clean');
+  });
+});
+
+describe('FR-4 (W2, SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001): negative-outcome back-propagation', () => {
+  it('selectNegativeBackprop matches ONLY on exact outcome_ref equality (never a heuristic/substring)', () => {
+    const rows = [
+      { id: 'a', outcome: 'unknown', outcome_ref: 'SD-REVERTED-001' },       // exact match -> flip
+      { id: 'b', outcome: 'shipped_clean', outcome_ref: 'SD-REVERTED-001' }, // a later revert means it was NOT clean -> flip
+      { id: 'c', outcome: 'unknown', outcome_ref: 'SD-REVERTED-001-EXTRA' }, // superset string — must NOT match
+      { id: 'd', outcome: 'unknown', outcome_ref: 'SD-OTHER-002' },          // unrelated
+      { id: 'e', outcome: 'unknown', outcome_ref: null },                    // no linkage
+    ];
+    const picks = selectNegativeBackprop(rows, new Set(['SD-REVERTED-001']));
+    expect(picks.map((p) => p.id).sort()).toEqual(['a', 'b']);
+    expect(picks.find((p) => p.id === 'b').priorOutcome).toBe('shipped_clean');
+  });
+
+  it('never re-flips an already-negative row (idempotent) and never touches a NO_ARTIFACT sentinel', () => {
+    const rows = [
+      { id: 'a', outcome: 'reverted', outcome_ref: 'SD-X' },       // already negative
+      { id: 'b', outcome: 'caused_rework', outcome_ref: 'SD-X' },  // already negative
+      { id: 'c', outcome: 'unknown', outcome_ref: 'NO_ARTIFACT' }, // explicit no-artifact — nothing to track
+      { id: 'd', outcome: 'unknown', outcome_ref: 'NO_ARTIFACT: verbal ack' },
+    ];
+    // even if the ref set literally contained these strings, none should be selected
+    expect(selectNegativeBackprop(rows, new Set(['SD-X', 'NO_ARTIFACT', 'NO_ARTIFACT: verbal ack'])).length).toBe(0);
+  });
+
+  it('addRefsFromMetadata harvests candidate refs from a red-merge/revert signal metadata object', () => {
+    const set = new Set();
+    addRefsFromMetadata(set, { sha: 'abc123', sd_key: 'SD-Q', signature: 'red-merge:ci:abc123', irrelevant: 'x' });
+    expect(set.has('abc123')).toBe(true);
+    expect(set.has('SD-Q')).toBe(true);
+    expect(set.has('red-merge:ci:abc123')).toBe(true);
+    expect(set.has('x')).toBe(false); // only whitelisted keys
+  });
+
+  it('SEEDED end-to-end: a seeded revert signal back-propagates outcome=reverted onto its linked ledger row', async () => {
+    // Ledger candidate rows (returned by the .not(outcome_ref is null) select).
+    const ledger = [
+      { id: 'row-linked', outcome: 'unknown', outcome_ref: 'SD-SEEDED-REVERT-001' },
+      { id: 'row-unrelated', outcome: 'unknown', outcome_ref: 'SD-CLEAN-002' },
+    ];
+    const updates = [];
+    const sb = {
+      from: (table) => {
+        if (table === 'audit_log') {
+          return { select: () => ({ in: () => ({ limit: async () => ({ data: [{ event: 'SD_REVERTED', metadata: { sd_key: 'SD-SEEDED-REVERT-001' } }], error: null }) }) }) };
+        }
+        if (table === 'strategic_directives_v2') {
+          return { select: () => ({ not: () => ({ limit: async () => ({ data: [], error: null }) }) }) };
+        }
+        // solomon_advice_outcome_ledger
+        return {
+          select: () => ({ not: () => ({ limit: async () => ({ data: ledger, error: null }) }) }),
+          update: (patch) => ({ eq: (col, val) => { updates.push({ patch, col, val }); return Promise.resolve({ error: null }); } }),
+        };
+      },
+    };
+    const negRefs = await collectNegativeRefs(sb, {});
+    expect(negRefs.has('SD-SEEDED-REVERT-001')).toBe(true);
+    const res = await backPropagateNegativeOutcomes(sb, { negativeRefs: negRefs, nowIso: '2026-07-19T00:00:00Z' });
+    expect(res.updated).toEqual(['row-linked']);               // only the linked row flipped
+    expect(updates).toHaveLength(1);
+    expect(updates[0].val).toBe('row-linked');
+    expect(updates[0].patch.outcome).toBe(NEGATIVE_OUTCOME);   // 'reverted'
+    expect(updates[0].patch.closed_by).toBe(NEGATIVE_BACKPROP_SOURCE); // closer-of-record stamped
+    expect(updates[0].patch.closed_at).toBe('2026-07-19T00:00:00Z');
+  });
+
+  it('dryRun reports matches without writing', async () => {
+    const ledger = [{ id: 'r1', outcome: 'unknown', outcome_ref: 'SD-R' }];
+    let updateCalled = false;
+    const sb = { from: () => ({
+      select: () => ({ not: () => ({ limit: async () => ({ data: ledger, error: null }) }) }),
+      update: () => { updateCalled = true; return { eq: () => Promise.resolve({ error: null }) }; },
+    }) };
+    const res = await backPropagateNegativeOutcomes(sb, { negativeRefs: new Set(['SD-R']), dryRun: true });
+    expect(res.matched.map((m) => m.id)).toEqual(['r1']);
+    expect(res.updated).toEqual([]);
+    expect(updateCalled).toBe(false);
+  });
+
+  it('no negative refs → no-op (never queries the ledger)', async () => {
+    const sb = { from: () => ({ select: () => { throw new Error('should not query'); } }) };
+    const res = await backPropagateNegativeOutcomes(sb, { negativeRefs: new Set() });
+    expect(res.updated).toEqual([]);
+    expect(res.matched).toEqual([]);
   });
 });

--- a/tests/unit/solomon-self-adherence-review.test.js
+++ b/tests/unit/solomon-self-adherence-review.test.js
@@ -1,0 +1,110 @@
+/**
+ * Solomon self-adherence review — DB persistence + review-key tests.
+ * SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-2: the 12h self-adherence review previously wrote
+ * NOTHING to the DB (dormant/invisible self-scoring). These prove (a) the verdict resolves pass/fail
+ * (parity holds vs drift) on the live contract doc, and (b) EACH cycle now persists a feedback row.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildSelfAdherenceVerdict,
+  persistSelfAdherenceReview,
+  selfAdherenceReviewKey,
+} from '../../scripts/solomon-self-adherence-review.mjs';
+
+/**
+ * feedback-only supabase mock. `existing` seeds the idempotency lookup result; `insertError`
+ * forces the insert to fail (fail-soft path). Records the inserted row for assertions.
+ */
+function makeSb({ existing = [], insertError = null } = {}) {
+  const calls = { inserted: [] };
+  return {
+    _calls: calls,
+    from(table) {
+      expect(table).toBe('feedback');
+      const b = {
+        _op: 'read',
+        select() { return b; },
+        eq() { return b; },
+        filter() { return b; },
+        limit() { return Promise.resolve({ data: existing, error: null }); },
+        insert(row) { calls.inserted.push(row); b._op = 'insert'; return b; },
+      };
+      b.single = () => insertError
+        ? Promise.resolve({ data: null, error: insertError })
+        : Promise.resolve({ data: { id: 'fb-solomon-1' }, error: null });
+      // insert(...).select().single()
+      const origSelect = b.select;
+      b.select = () => (b._op === 'insert' ? { single: b.single } : origSelect());
+      return b;
+    },
+  };
+}
+
+describe('buildSelfAdherenceVerdict — resolves pass/fail on the live contract (never unknown)', () => {
+  it('returns a boolean ok + a drifted array (never an unknown verdict)', () => {
+    const v = buildSelfAdherenceVerdict();
+    expect(typeof v.ok).toBe('boolean'); // resolves to pass (ok) or fail (drift) — never 'unknown'
+    expect(Array.isArray(v.drifted)).toBe(true);
+    expect(v.ok).toBe(v.drifted.length === 0); // ok iff no durable duty drifted out of SOLOMON_LOOPS
+  });
+
+  it('reports contract-drift as a FAIL when a missing repoRoot has no contract doc (fail-open skip = ok)', () => {
+    // A repoRoot without CLAUDE_SOLOMON.md yields the fail-open skip (ok:true) — still a resolved verdict.
+    const v = buildSelfAdherenceVerdict('/no/such/dir');
+    expect(v.ok).toBe(true);
+    expect(v.drifted).toEqual([]);
+  });
+});
+
+describe('selfAdherenceReviewKey — deterministic per-cycle key (2 slots/day)', () => {
+  it('keys on UTC date + am/pm slot', () => {
+    expect(selfAdherenceReviewKey(new Date('2026-07-19T03:00:00Z'))).toBe('solomon-self-adherence:2026-07-19:am');
+    expect(selfAdherenceReviewKey(new Date('2026-07-19T15:00:00Z'))).toBe('solomon-self-adherence:2026-07-19:pm');
+  });
+});
+
+describe('persistSelfAdherenceReview (FR-2 — cycle persistence) — fail-soft', () => {
+  it('a parity-holds cycle writes a benign AUDIT row (enhancement/resolved) and returns its id', async () => {
+    const sb = makeSb();
+    const id = await persistSelfAdherenceReview(sb, { ok: true, drifted: [], note: 'all duties present' }, { reviewKey: 'k1' });
+    expect(id).toBe('fb-solomon-1');
+    expect(sb._calls.inserted).toHaveLength(1);
+    const row = sb._calls.inserted[0];
+    expect(row.category).toBe('solomon_self_adherence');
+    expect(row.type).toBe('enhancement');
+    expect(row.status).toBe('resolved');
+    expect(row.metadata.ok).toBe(true);
+    expect(row.metadata.review_key).toBe('k1');
+  });
+
+  it('a DRIFT cycle writes a PROPOSE-ONLY remediation (issue/new) naming the drifted duties', async () => {
+    const sb = makeSb();
+    const id = await persistSelfAdherenceReview(
+      sb,
+      { ok: false, drifted: ['taste-judgement', 'reality-simulation'], note: 'CONTRACT DRIFT: 2 duties' },
+      { reviewKey: 'k2' },
+    );
+    expect(id).toBe('fb-solomon-1');
+    const row = sb._calls.inserted[0];
+    expect(row.type).toBe('issue');
+    expect(row.status).toBe('new');
+    expect(row.severity).toBe('medium');
+    expect(row.title).toContain('taste-judgement');
+    expect(row.metadata.drifted).toEqual(['taste-judgement', 'reality-simulation']);
+  });
+
+  it('is idempotent: an existing cycle row short-circuits (returns its id, NO new insert)', async () => {
+    const sb = makeSb({ existing: [{ id: 'fb-existing' }] });
+    const id = await persistSelfAdherenceReview(sb, { ok: true, drifted: [], note: 'x' }, { reviewKey: 'k1' });
+    expect(id).toBe('fb-existing');
+    expect(sb._calls.inserted).toHaveLength(0);
+  });
+
+  it('is fail-soft: an insert error returns null and never throws (never blocks the tick)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sb = makeSb({ insertError: { message: 'insert blocked' } });
+    const id = await persistSelfAdherenceReview(sb, { ok: true, drifted: [], note: 'x' }, { reviewKey: 'k3' });
+    expect(id).toBeNull();
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001

**Measure-what-you-trust** applied to role-measurement machinery — gauges that never resolve read as false assurance. Three workstreams (W4 oracle source-enum **deferred** to SD-LEO-FEAT-FORECAST-LEDGER-001 per the coordinator second-defers rule).

### W3 — cost_tokens capture (sequence-first, fail-soft)
`solomon_advice_outcome_ledger` never populated cost_tokens (blocked Solomon weekly Fable budget governance). New `lib/telemetry/session-cost.cjs` reads the authoritative statusline usage log; `captureLedgerRow` writes cost_tokens/cost_wall_ms/cost_captured at write time; the rollup counts only captured rows. **Fail-soft:** a telemetry miss lands the row with nulls + `cost_captured=false`, never blocks the write.

### W1 — adherence probes fix-or-delete + Solomon self-adherence persistence
Adam's probes returned 'unknown' 297/297 times ever. **Decision: FIX ALL, zero deletions** — every probe wired to a verified live signal (counterfactual claim-lane presence, live claim tables, advisory corpus, measured-false vision). Verified live: **UNKNOWN 0/8**. **Honesty boundary preserved:** a genuine query error still yields 'unknown'; only a *measured* absence is a falsifiable FAIL (no fabricated FAILs). Solomon self-adherence cycles now persist to the `feedback` table.

### W2 — ledger accuracy falsifiability
286/321 outcomes 'unknown', **zero** negatives ever, 198/306 batch-stamped. FR-3: mandatory `outcome_ref`/no-artifact at accept (**reject before write**), contemporaneous-only. FR-4: negative-outcome back-propagation via **exact `outcome_ref` match only** (no heuristic mis-attribution), hooked to real red-merge/revert/RCA signals. FR-5/TR-3: durable `batch_stamped` column (198 rows backfilled) excluded from the accuracy rollup → **accuracy is now a meaningful 27%** vs the diluted ~10%.

### Migrations (additive, TIER-1)
`cost_captured` + `batch_stamped` nullable boolean columns on `solomon_advice_outcome_ledger` — applied + verified.

### Verification
~500 app LOC across 3 workstreams; each delegated diff **parent-reviewed before commit** (fail-soft guarantees, honesty boundary, exact-match/no-heuristic properties verified in-code). Workstream tests green: W3 16, W1 39, W2 combined 64 (incl. W3 cost regression). LEO gates: LEAD-TO-PLAN 93, PLAN-TO-EXEC 95, EXEC-TO-PLAN pass, PLAN-TO-LEAD 96 (retro quality 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)