### PR TITLE
fix(QF-20260719-163): explicit --actual-loc 0 survives autoDetectGitInfo

### DIFF
--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -429,8 +429,11 @@ export function autoDetectGitInfo(testDir, options = {}) {
     actualLoc: options.actualLoc
   };
 
-  // Fast path: nothing to detect.
-  if (result.commitSha && result.branchName && result.actualLoc) {
+  // Fast path: nothing to detect. QF-20260719-163: presence checks, not truthiness —
+  // an explicit --actual-loc 0 (legit for analysis/triage QFs with no code diff) is
+  // falsy and used to fall through to the isInQFWorktree guard, throwing the
+  // misleading "Pass ... explicitly" error even when all three flags WERE passed.
+  if (result.commitSha != null && result.branchName != null && result.actualLoc != null) {
     return result;
   }
 
@@ -458,7 +461,7 @@ export function autoDetectGitInfo(testDir, options = {}) {
       console.log(`🔍 PR #${prNumber} → branch: ${result.branchName}`);
     }
 
-    if (!result.actualLoc) {
+    if (result.actualLoc == null) { // preserve an explicit 0 (QF-20260719-163)
       // gh additions+deletions overcounts vs git --shortstat for renames, but feeds the
       // QF hard-cap (see QF_HARD_LOC_CAP in verification.js) fail-safely (stricter,
       // never under-rejects).
@@ -538,7 +541,7 @@ export function autoDetectGitInfo(testDir, options = {}) {
       console.log(`🔍 Auto-detected branch: ${result.branchName}`);
     }
 
-    if (!result.actualLoc) {
+    if (result.actualLoc == null) { // preserve an explicit 0 (QF-20260719-163)
       try {
         const diffStats = execSync('git diff origin/main --shortstat', { encoding: 'utf-8', cwd: testDir, timeout: EXTERNAL_STEP_TIMEOUT_MS }).trim();
         const match = diffStats.match(/(\d+) insertion/);


### PR DESCRIPTION
The fast path used truthiness (result.commitSha && result.branchName &&
result.actualLoc), so an explicit --actual-loc 0 — legitimate for
analysis/triage QFs with no code diff — fell through to the isInQFWorktree
guard and threw 'Pass --commit-sha / --branch-name / --actual-loc explicitly'
even when all three flags WERE passed (reproduced 3x on QF-20260719-162).
Presence (!= null) checks on the fast path; the two later actualLoc
re-derivation branches also preserve an explicit 0 instead of overwriting it
with PR/diff-derived counts.

Verified: fast path returns {actualLoc: 0} outside any worktree; truly-absent
flags still throw; 268/268 module + ship tests green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
