### PR TITLE
feat(SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001): GHA cron migration for remaining SCRIPT-SHAPED STANDARD_LOOPS (FR-2)

### DIFF
--- a/.github/workflows/feedback-sla-cron.yml
+++ b/.github/workflows/feedback-sla-cron.yml
@@ -1,0 +1,44 @@
+name: "Feedback-consumption SLA reminder (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `feedback-sla` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '45 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  feedback-sla:
+    name: Feedback-consumption SLA breach reminder
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run feedback-consumption SLA gauge
+        run: node scripts/coordinator-feedback-sla-gauge.cjs

--- a/.github/workflows/flag-review-cron.yml
+++ b/.github/workflows/flag-review-cron.yml
@@ -1,0 +1,44 @@
+name: "Feature-flag governance review (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `flag-review` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  flag-review:
+    name: Feature-flag governance review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Feature-flag governance review
+        run: node scripts/flag-governance-review.mjs

--- a/.github/workflows/fleet-retro-cron.yml
+++ b/.github/workflows/fleet-retro-cron.yml
@@ -1,0 +1,52 @@
+name: "Worker fleet-retro capture (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `fleet-retro` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+#
+# Scope note: coordinator-fleet-retro.mjs's own header describes two steps — (1) CAPTURE
+# durable FLEET-RETRO signals into the `feedback` table (deterministic: regex match + dedup
+# insert) and (2) print recent retros with an [ACTION] line asking the coordinator session
+# to synthesize themes. Neither step makes an LLM call; step 2 only emits log lines for a
+# human/coordinator reader to act on later. FR-2 scopes this migration to the deterministic
+# capture path, which is the entirety of what this script executes — invoked as-is, matching
+# its STANDARD_LOOPS prompt.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  fleet-retro:
+    name: Worker fleet-retro capture
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Capture worker fleet-retro signals
+        run: node scripts/coordinator-fleet-retro.mjs

--- a/.github/workflows/gauge-runner-cron.yml
+++ b/.github/workflows/gauge-runner-cron.yml
@@ -1,0 +1,44 @@
+name: "Invariant-gauges runner (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `gauge-runner` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  gauge-runner:
+    name: Invariant-gauges execution surface
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run invariant gauges
+        run: node scripts/gauge-runner.mjs --json

--- a/.github/workflows/relay-drain-cron.yml
+++ b/.github/workflows/relay-drain-cron.yml
@@ -1,0 +1,44 @@
+name: "Coordinator relay-drain (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `relay-drain` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '1,16,31,46 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  relay-drain:
+    name: Relay-request queue drain + confirm-on-relay
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Drain relay-request queue
+        run: node scripts/coordinator-relay-drain.cjs

--- a/.github/workflows/relay-drop-gauge-cron.yml
+++ b/.github/workflows/relay-drop-gauge-cron.yml
@@ -1,0 +1,44 @@
+name: "Relay/decision/review drop gauge (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `relay-drop-gauge` (scripts/coordinator-startup-check.mjs). Always-on
+# so it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays
+# in place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '11,26,41,56 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  relay-drop-gauge:
+    name: Unactioned relay/decision/review drop gauge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run relay/decision/review drop gauge
+        run: node scripts/coordinator-relay-drop-gauge.cjs

--- a/.github/workflows/review-rotation-cron.yml
+++ b/.github/workflows/review-rotation-cron.yml
@@ -1,0 +1,44 @@
+name: "Subsystem review rotation (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `review-rotation` (scripts/coordinator-startup-check.mjs). Always-on
+# so it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays
+# in place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  review-rotation:
+    name: Subsystem review rotation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Advance subsystem review rotation
+        run: node scripts/subsystem-review-rotation.cjs

--- a/.github/workflows/row-growth-cron.yml
+++ b/.github/workflows/row-growth-cron.yml
@@ -1,0 +1,44 @@
+name: "Governance row-growth snapshot (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `row-growth` (scripts/coordinator-startup-check.mjs). Always-on so
+# it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '30 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  row-growth:
+    name: Governance row-growth gauge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Snapshot governance row-growth
+        run: node scripts/row-growth-snapshot.cjs

--- a/.github/workflows/scripts-reachability-cron.yml
+++ b/.github/workflows/scripts-reachability-cron.yml
@@ -1,0 +1,45 @@
+name: "Scripts-estate reachability gauge (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `scripts-reachability` (scripts/coordinator-startup-check.mjs).
+# Always-on so it survives a coordinator session death; the STANDARD_LOOPS session-armed
+# entry stays in place unchanged as a redundant backup (idempotent — an occasional
+# double-fire is safe).
+
+on:
+  schedule:
+    - cron: '40 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  scripts-reachability:
+    name: Scripts-estate reachability gauge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run scripts-estate reachability gauge
+        run: node scripts/scripts-reachability-gauge.mjs

--- a/.github/workflows/singleton-relaunch-cron.yml
+++ b/.github/workflows/singleton-relaunch-cron.yml
@@ -1,0 +1,44 @@
+name: "Singleton-relaunch scheduler (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `singleton-relaunch` (scripts/coordinator-startup-check.mjs). Always-on
+# so it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays
+# in place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '7,22,37,52 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  singleton-relaunch:
+    name: Singleton-relaunch quiescent-window scheduler
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run singleton-relaunch scheduler
+        run: npm run singleton-relaunch:run

--- a/.github/workflows/solomon-ledger-resurface-cron.yml
+++ b/.github/workflows/solomon-ledger-resurface-cron.yml
@@ -1,0 +1,45 @@
+name: "Solomon ledger-pending resurface (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `solomon-ledger-resurface` (scripts/coordinator-startup-check.mjs).
+# Always-on so it survives a coordinator session death; the STANDARD_LOOPS session-armed
+# entry stays in place unchanged as a redundant backup (idempotent — an occasional
+# double-fire is safe).
+
+on:
+  schedule:
+    - cron: '13,43 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  solomon-ledger-resurface:
+    name: Solomon ledger-pending resurface
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Resurface aged Solomon ledger rows
+        run: node scripts/solomon-ledger-pending-resurface.cjs

--- a/.github/workflows/sweep-cron.yml
+++ b/.github/workflows/sweep-cron.yml
@@ -1,0 +1,44 @@
+name: "Stale-session sweep (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `sweep` (scripts/coordinator-startup-check.mjs). Always-on so it
+# survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays in
+# place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: Sweep stale sessions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Sweep stale sessions
+        run: node scripts/stale-session-sweep.cjs

--- a/.github/workflows/unranked-gauge-cron.yml
+++ b/.github/workflows/unranked-gauge-cron.yml
@@ -1,0 +1,44 @@
+name: "Unranked-claimable-leaves gauge (cron)"
+
+# SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-2 — additive GHA-backed trigger for
+# STANDARD_LOOPS key `unranked-gauge` (scripts/coordinator-startup-check.mjs). Always-on
+# so it survives a coordinator session death; the STANDARD_LOOPS session-armed entry stays
+# in place unchanged as a redundant backup (idempotent — an occasional double-fire is safe).
+
+on:
+  schedule:
+    - cron: '9,24,39,54 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  unranked-gauge:
+    name: Eligible-but-unranked-leaf-count invariant gauge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run unranked-claimable-leaves gauge
+        run: node scripts/gauge-unranked-claimable-leaves.mjs

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -87,6 +87,7 @@ export const RESPONSIBILITIES = [
 // — dropped as a phantom/typo'd scope-text reference, not implemented.
 export const STANDARD_LOOPS = [
   { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/stale-session-sweep.cjs' },
   // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the quiet-tick cutover (docs/protocol/
   // fleet-hibernation-quiet-tick.md). ONE self-pacing LLM tick composes the folded loops below
@@ -115,6 +116,7 @@ export const STANDARD_LOOPS = [
   // SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001 (FR-5): daily feature-flag governance review.
   // Gated default-OFF behind leo_feature_flags FLAG_GOVERNANCE_REVIEW_V1 → cheap no-op until enabled.
   { key: 'flag-review', label: 'Feature-flag governance review', script: 'flag-governance-review.mjs', cron: '0 9 * * *',
+    gha_backed: true,
     prompt: 'node scripts/flag-governance-review.mjs' },
   // Work-triggered tri-party self-review: cheap poller (no-op below COORD_REVIEW_EVERY completed-SD delta),
   // fires the coordinator<->workers<->Adam review only when due. SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.
@@ -142,6 +144,7 @@ export const STANDARD_LOOPS = [
   // (reuses backlog-rank's own claimable computation); offset from backlog-rank's own cadence so it
   // always observes a just-refreshed rank rather than racing it.
   { key: 'unranked-gauge', label: 'Eligible-but-unranked-leaf-count invariant gauge', script: 'gauge-unranked-claimable-leaves.mjs', cron: '9,24,39,54 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/gauge-unranked-claimable-leaves.mjs' },
   // QF-20260702-976: the OPERATING layer for SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A.
   // The trigger + scheduler logic (lib/coordinator/singleton-relaunch-trigger.js, scripts/
@@ -155,23 +158,27 @@ export const STANDARD_LOOPS = [
   // and the human-gated spawn step). Cheap (git + a few DB reads); offset from the other */15-ish
   // loops so it doesn't cluster.
   { key: 'singleton-relaunch', label: 'Singleton-relaunch quiescent-window scheduler (detection + scheduling only)', script: 'singleton-relaunch-scheduler.mjs', cron: '7,22,37,52 * * * *',
+    gha_backed: true,
     prompt: 'npm run singleton-relaunch:run' },
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2: drains
   // the tracked relay-request queue deliberately (never processed inline in the active
   // thread) and writes the CONFIRM-ON-RELAY receipt. Frequent — a queued relay-request is
   // exactly as urgent when the fleet is quiet (confirmed incident #1: ~2h undrained).
   { key: 'relay-drain', label: 'Relay-request queue drain + confirm-on-relay', script: 'coordinator-relay-drain.cjs', cron: '1,16,31,46 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/coordinator-relay-drain.cjs' },
   // FR-3: the drop-gauge — flags any inbound RELAY/DECISION/REVIEW row with no matching
   // outbound within the window (default ~15min). Offset from relay-drain so it observes a
   // just-drained queue rather than racing it.
   { key: 'relay-drop-gauge', label: 'Unactioned relay/decision/review drop gauge', script: 'coordinator-relay-drop-gauge.cjs', cron: '11,26,41,56 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/coordinator-relay-drop-gauge.cjs' },
   // SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-2a): restore the worker fleet-retro to a schedule
   // (it had drifted to manual — last ran ~2.5d ago). Re-arms the existing, idempotent capture/
   // synthesis script (reuses the feedback/issue_patterns pipeline; dedups on metadata.retro_key).
   // Cheap read+insert; */30 captures session_coordination FLEET-RETRO signals before they are swept.
   { key: 'fleet-retro',  label: 'Worker fleet-retro (periodic capture/synthesis)', script: 'coordinator-fleet-retro.mjs', cron: '*/30 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/coordinator-fleet-retro.mjs' },
   // SD-LEO-INFRA-STANDING-ROW-GROWTH-001: daily governance-table row-growth gauge.
   // Snapshots estimated row counts (PostgREST head+estimated — pg statistics, no COUNT(*))
@@ -180,6 +187,7 @@ export const STANDARD_LOOPS = [
   // due-gated (~22h), so an extra arm or manual run is a cheap no-op. Catches the
   // management_reviews-45k / sd_baseline_items-13k class within a day, not by accident.
   { key: 'row-growth',  label: 'Governance row-growth gauge (daily)', script: 'row-growth-snapshot.cjs', cron: '30 8 * * *',
+    gha_backed: true,
     prompt: 'node scripts/row-growth-snapshot.cjs' },
   // SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001: weekly subsystem-review rotation.
   // Stateless (registry = completed SDs stamping metadata.subsystem_review); posts ONE
@@ -187,6 +195,7 @@ export const STANDARD_LOOPS = [
   // /review-subsystem command. Due-gated ~6 days; extra arms/manual runs are no-ops.
   // Converts idle-fleet gaps into review supply (4 reviews -> 27 evidenced SDs on 2026-06-10).
   { key: 'review-rotation', label: 'Subsystem review rotation (weekly)', script: 'subsystem-review-rotation.cjs', cron: '0 9 * * 1',
+    gha_backed: true,
     prompt: 'node scripts/subsystem-review-rotation.cjs' },
   // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1): weekly scripts-estate reachability
   // gauge. Scans scripts/** against the reference haystack (package.json, .github, .husky,
@@ -195,6 +204,7 @@ export const STANDARD_LOOPS = [
   // (orphan_count +>=10 week-over-week) or broken npm aliases. Internally due-gated (~6d),
   // so an extra arm or manual run is a cheap no-op. Advisory — never CI-blocking.
   { key: 'scripts-reachability', label: 'Scripts-estate reachability gauge (weekly)', script: 'scripts-reachability-gauge.mjs', cron: '40 9 * * 1',
+    gha_backed: true,
     prompt: 'node scripts/scripts-reachability-gauge.mjs' },
   // SD-MAN-INFRA-RETENTION-OPS-FINISHER-001: weekly archive-not-delete retention enforcement
   // (machinery shipped + chairman-GO'd by SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001; 196k rows
@@ -219,12 +229,14 @@ export const STANDARD_LOOPS = [
   // for unwired machinery was itself unwired. Hourly cadence — cheap, and the gauges'
   // detector functions are internally due-gated/idempotent, so an extra run is a no-op.
   { key: 'gauge-runner', label: 'Invariant-gauges execution surface (hourly, durable)', script: 'gauge-runner.mjs', cron: '0 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/gauge-runner.mjs --json' },
   // QF-20260704-493: feedback-consumption SLA gauge daily reminder (Solomon referent-audit
   // cell [4]) — actionable feedback categories (adam_adherence_drift, completion_flag,
   // coordinator_review, harness_backlog escalations) had no consumption deadline. Internally
   // rate-limited/deduped per category per day (metadata.sla_key), so an extra run is a no-op.
   { key: 'feedback-sla', label: 'Feedback-consumption SLA breach reminder (daily)', script: 'coordinator-feedback-sla-gauge.cjs', cron: '45 9 * * *',
+    gha_backed: true,
     prompt: 'node scripts/coordinator-feedback-sla-gauge.cjs' },
   // QF-20260705-533 (J1 adversarial sweep REFUTED-DORMANT): the watcher-of-watchers
   // (periodic-liveness-watcher.mjs, SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001) shipped with NO
@@ -250,6 +262,7 @@ export const STANDARD_LOOPS = [
   // to once per stale ledger row per day via its own payload.dedup_key, so a frequent tick is
   // safe. Also composed into scripts/coordinator-quiet-tick.mjs's COMPOSED_CORES.
   { key: 'solomon-ledger-resurface', label: 'Solomon ledger-pending resurface (aged advice-outcome rows -> Adam inbox)', script: 'solomon-ledger-pending-resurface.cjs', cron: '13,43 * * * *',
+    gha_backed: true,
     prompt: 'node scripts/solomon-ledger-pending-resurface.cjs' },
 ];
 
@@ -340,7 +353,8 @@ export function renderLoops(armed) {
     }
     const status = loopStatus(loop, armed);
     const badge = status === 'armed' ? '✅ armed' : status === 'MISSING' ? '❌ MISSING' : '… unverified';
-    lines.push(`  [${badge}] ${loop.key.padEnd(10)} ${loop.label}`);
+    const ghaMarker = loop.gha_backed ? ' [GHA-backed]' : '';
+    lines.push(`  [${badge}] ${loop.key.padEnd(10)} ${loop.label}${ghaMarker}`);
     lines.push(`              cron: ${loop.cron}   prompt: ${loop.prompt}`);
     if (status !== 'armed') toArm.push(loop);
   }

--- a/tests/unit/gha-loop-migration-parity.test.js
+++ b/tests/unit/gha-loop-migration-parity.test.js
@@ -1,0 +1,168 @@
+// SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 (FR-2) — creation-parity guard for the 13
+// SCRIPT-SHAPED STANDARD_LOOPS entries migrated to always-on GitHub Actions crons in this
+// batch (additive: the STANDARD_LOOPS session-armed entry stays in place as a redundant
+// backup — see retention-loop-parity.test.js for the shipped precedent this mirrors).
+//
+// TS-1/TS-9 (parity): each new `<key>-cron.yml` workflow's on.schedule cron string is a
+//   byte-exact match of the corresponding STANDARD_LOOPS entry's `cron` field.
+// TS-2: `gha_backed: true` is present on exactly the 13 migrated keys and absent/falsy on
+//   every JUDGMENT-SHAPED key, dashboard/identity (out of scope), and liveness-watcher
+//   (partial-only migration, handled by a different workflow).
+// TS-9 (YAML validity): each of the 13 new files has required top-level keys (name/on/jobs)
+//   and a syntactically valid 5-field cron string.
+// TS-11 (concurrency uniqueness): no two files anywhere in .github/workflows/ share the same
+//   `name:` value, since `concurrency.group: ${{ github.workflow }}` derives from it.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { STANDARD_LOOPS } from '../../scripts/coordinator-startup-check.mjs';
+
+const require = createRequire(import.meta.url);
+const yaml = require('js-yaml');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflowsDir = join(repoRoot, '.github', 'workflows');
+
+// The 13 SCRIPT-SHAPED loops migrated in this FR-2 batch.
+const MIGRATED_KEYS = [
+  'sweep',
+  'flag-review',
+  'unranked-gauge',
+  'singleton-relaunch',
+  'relay-drain',
+  'relay-drop-gauge',
+  'fleet-retro',
+  'row-growth',
+  'review-rotation',
+  'scripts-reachability',
+  'gauge-runner',
+  'feedback-sla',
+  'solomon-ledger-resurface',
+];
+
+// JUDGMENT-SHAPED keys (never gha_backed) + explicitly out-of-scope/partial keys, per the
+// STANDARD_LOOPS header-comment durability table (scripts/coordinator-startup-check.mjs).
+const NOT_MIGRATED_KEYS = [
+  'quiet-tick',
+  'self-review',
+  'hourly-review',
+  'roles-review',
+  'audit',
+  'charter-audit',
+  'capacity-forecast',
+  'dashboard',
+  'identity',
+  'liveness-watcher',
+];
+
+function loopByKey(key) {
+  const loop = STANDARD_LOOPS.find((l) => l.key === key);
+  if (!loop) throw new Error(`STANDARD_LOOPS has no entry for key "${key}"`);
+  return loop;
+}
+
+function workflowPathFor(key) {
+  return join(workflowsDir, `${key}-cron.yml`);
+}
+
+function loadWorkflow(key) {
+  return yaml.load(readFileSync(workflowPathFor(key), 'utf8'));
+}
+
+// `on.schedule` cron. js-yaml parses the `on:` YAML key as boolean `true` under YAML 1.1
+// core-schema rules, so read via the string key AND the boolean key defensively.
+function scheduleCronsOf(doc) {
+  const onBlock = doc.on ?? doc['on'] ?? doc[true] ?? doc['true'];
+  if (!onBlock || !Array.isArray(onBlock.schedule)) return [];
+  return onBlock.schedule.map((s) => s.cron);
+}
+
+describe('GHA loop migration — creation-site parity (TS-1/TS-9)', () => {
+  for (const key of MIGRATED_KEYS) {
+    it(`${key}-cron.yml on.schedule cron matches STANDARD_LOOPS['${key}'].cron exactly`, () => {
+      const loop = loopByKey(key);
+      const doc = loadWorkflow(key);
+      const crons = scheduleCronsOf(doc);
+      expect(crons).toHaveLength(1);
+      expect(crons[0]).toBe(loop.cron);
+    });
+  }
+});
+
+describe('GHA loop migration — gha_backed flag (TS-2)', () => {
+  for (const key of MIGRATED_KEYS) {
+    it(`STANDARD_LOOPS['${key}'].gha_backed is true`, () => {
+      expect(loopByKey(key).gha_backed).toBe(true);
+    });
+  }
+
+  for (const key of NOT_MIGRATED_KEYS) {
+    it(`STANDARD_LOOPS['${key}'].gha_backed is absent/falsy (not migrated by this batch)`, () => {
+      const loop = loopByKey(key);
+      expect(loop.gha_backed).toBeFalsy();
+    });
+  }
+
+  it('exactly 13 STANDARD_LOOPS entries carry gha_backed:true from this batch', () => {
+    const flagged = STANDARD_LOOPS.filter((l) => l.gha_backed === true).map((l) => l.key);
+    for (const key of MIGRATED_KEYS) expect(flagged).toContain(key);
+    // retention + backlog-rank were migrated by earlier SDs (also gha_backed:true) — this
+    // guard only asserts THIS batch's 13 keys are present, not an exclusive total count.
+  });
+});
+
+describe('GHA loop migration — YAML validity (TS-9)', () => {
+  for (const key of MIGRATED_KEYS) {
+    it(`${key}-cron.yml has required top-level keys and a valid 5-field cron`, () => {
+      const doc = loadWorkflow(key);
+      expect(doc).toBeTruthy();
+      expect(doc.name).toBeTruthy();
+      expect(typeof doc.name).toBe('string');
+      const onBlock = doc.on ?? doc['on'] ?? doc[true] ?? doc['true'];
+      expect(onBlock).toBeTruthy();
+      expect(doc.jobs).toBeTruthy();
+      expect(Object.keys(doc.jobs).length).toBeGreaterThan(0);
+
+      const crons = scheduleCronsOf(doc);
+      expect(crons).toHaveLength(1);
+      const fields = crons[0].trim().split(/\s+/);
+      expect(fields).toHaveLength(5);
+
+      // workflow_dispatch present, permissions read-only, concurrency keyed off github.workflow.
+      expect(onBlock.workflow_dispatch !== undefined).toBe(true);
+      expect(doc.permissions?.contents).toBe('read');
+      expect(doc.concurrency?.group).toBe('${{ github.workflow }}');
+      expect(doc.concurrency?.['cancel-in-progress']).toBe(true);
+    });
+  }
+});
+
+describe('GHA loop migration — concurrency-group uniqueness across all workflows (TS-11)', () => {
+  it('no two files in .github/workflows/ share the same name: value', () => {
+    const files = readdirSync(workflowsDir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+    const nameToFiles = new Map();
+    for (const file of files) {
+      let doc;
+      try {
+        doc = yaml.load(readFileSync(join(workflowsDir, file), 'utf8'));
+      } catch {
+        continue; // non-workflow or unparsable YAML — not this guard's concern
+      }
+      const name = doc && doc.name;
+      if (!name) continue;
+      if (!nameToFiles.has(name)) nameToFiles.set(name, []);
+      nameToFiles.get(name).push(file);
+    }
+    const duplicates = [...nameToFiles.entries()].filter(([, fs]) => fs.length > 1);
+    expect(duplicates, `duplicate workflow name(s): ${JSON.stringify(duplicates)}`).toHaveLength(0);
+  });
+
+  it('all 13 migrated workflow files are present and singly-named', () => {
+    for (const key of MIGRATED_KEYS) {
+      const doc = loadWorkflow(key);
+      expect(doc.name).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- FR-2: 13 new always-on GHA cron workflows migrating every remaining SCRIPT-SHAPED `STANDARD_LOOPS` entry (retention/backlog-rank already migrated in prior SDs; liveness-watcher already partially migrated — both excluded from this batch), following the `fleet-worker-pulse-cron.yml`/`retention-enforce-cron.yml` additive pattern.
- `gha_backed: true` informational marker added to the 13 migrated `STANDARD_LOOPS` entries; `renderLoops()` surfaces a `[GHA-backed]` badge per loop.
- New parity test asserts byte-exact cron match, correct `gha_backed` presence/absence, YAML shape validity, and zero `concurrency.group` (workflow name) collisions across the full `.github/workflows/` directory.

Follow-up to #6305 (FR-1/FR-3/FR-4), same SD.

## Test plan
- [x] `npx vitest run tests/unit/gha-loop-migration-parity.test.js tests/unit/retention-loop-parity.test.js` — 59/59 passing
- [x] `node --check scripts/coordinator-startup-check.mjs`
- [x] All 13 new workflow YAML files parse (pre-commit hook)