### PR TITLE
docs(SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001): document remainder_state schema

### DIFF
--- a/docs/reference/schema/engineer/tables/roadmap_wave_items.md
+++ b/docs/reference/schema/engineer/tables/roadmap_wave_items.md
@@ -4,8 +4,8 @@
 **Database**: dedlbzhpgkmetvhbkyzq
 **Repository**: EHG_Engineer (this repository)
 **Purpose**: Strategic Directive management, PRD tracking, retrospectives, LEO Protocol configuration
-**Generated**: 2026-07-02T14:19:23.450Z
-**Rows**: 741
+**Generated**: 2026-07-02T14:19:23.450Z (manually amended 2026-07-19 for SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001 — the automated generator, scripts/generate-schema-docs-from-db.js, hung during this SD's /document step; regenerate this file properly next time it's runnable)
+**Rows**: 741 (stale — pre-dates this SD's backfill)
 **RLS**: Enabled (2 policies)
 
 ⚠️ **This is a REFERENCE document** - Query database directly for validation
@@ -31,6 +31,9 @@
 | item_disposition | `text` | YES | `'pending'::text` | Flow state: pending->selected->brainstormed->promoted (or deferred/dropped at any point) |
 | brainstorm_session_id | `uuid` | YES | - | FK to brainstorm_sessions when item has been brainstormed. Null = not yet brainstormed. |
 | lane | `text` | YES | - | Sourcing-engine routing lane (mutable; SEPARATE from terminal item_disposition). Vocab: lib/sourcing-engine/lane.js. SD-LEO-INFRA-SOURCING-ENGINE-LEDGER-LANE-COLUMN-001. |
+| remainder_state | `text` | YES | - | Stamped (never inferred) plan-of-record classification: promotable_now, gated_on_chairman, in_flight_or_sequence_blocked, satisfied_elsewhere, or void. Written by trg_stamp_plan_of_record_remainder_state on insert/update of item_disposition/lane/promoted_to_sd_key, and by trg_restamp_items_on_sd_cancel whenever a linked SD's status changes. SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001. |
+| remainder_state_stamped_at | `timestamp with time zone` | YES | - | When remainder_state was last (re-)stamped. SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001. |
+| remainder_state_stamped_by | `text` | YES | - | Always 'stamp_plan_of_record_remainder_state' — the one canonical function that writes this column. SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001. |
 
 ## Constraints
 
@@ -48,6 +51,7 @@
 - `roadmap_wave_items_item_disposition_check`: CHECK ((item_disposition = ANY (ARRAY['pending'::text, 'selected'::text, 'deferred'::text, 'brainstormed'::text, 'promoted'::text, 'dropped'::text])))
 - `roadmap_wave_items_lane_check`: CHECK (((lane IS NULL) OR (lane = ANY (ARRAY['belt-ready'::text, 'chairman-gated'::text, 'outcome-gated'::text, 'dedup'::text, 'decline'::text])) OR (lane ~~ 'blocked-on-_%'::text)))
 - `roadmap_wave_items_source_type_check`: CHECK ((source_type = ANY (ARRAY['todoist'::text, 'youtube'::text, 'brainstorm'::text, 'adam_direct'::text, 'vdr_gauge'::text])))
+- `roadmap_wave_items_remainder_state_check`: CHECK ((remainder_state IS NULL) OR (remainder_state = ANY (ARRAY['promotable_now'::text, 'gated_on_chairman'::text, 'in_flight_or_sequence_blocked'::text, 'satisfied_elsewhere'::text, 'void'::text])))
 
 ## Indexes
 
@@ -91,6 +95,18 @@
 
 - **Timing**: BEFORE UPDATE
 - **Action**: `EXECUTE FUNCTION update_roadmap_wave_items_updated_at()`
+
+### roadmap_wave_items_stamp_remainder
+
+- **Timing**: AFTER INSERT OR UPDATE OF item_disposition, lane, promoted_to_sd_key
+- **Action**: `EXECUTE FUNCTION trg_stamp_plan_of_record_remainder_state()`
+- SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001. Keeps `remainder_state` current whenever the columns it's derived from change.
+
+## Related Views
+
+### v_plan_of_record_remainder
+
+Approved-wave-only view over this table (joined to `roadmap_waves`), exposing the stamped `remainder_state` and provenance columns. `security_invoker = true`; `REVOKE ALL ... FROM PUBLIC, anon, authenticated` + `GRANT SELECT ... TO service_role` (RLS alone does not restrict it, since both source tables carry a permissive `authenticated SELECT USING (true)` policy). A cross-table trigger, `sd_cancel_restamp_remainder` on `strategic_directives_v2` (`AFTER UPDATE OF status`), re-stamps affected rows whenever a linked SD's status changes in either direction. SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001.
 
 ---
 


### PR DESCRIPTION
## Summary
- Small doc-only follow-up to PR #6300 (SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001, already merged).
- Documents the 3 new `roadmap_wave_items` columns (`remainder_state` + provenance), the new CHECK constraint, the `roadmap_wave_items_stamp_remainder` trigger, and a "Related Views" section for `v_plan_of_record_remainder` in the schema reference doc.
- Manual edit — `scripts/generate-schema-docs-from-db.js` hung/misbehaved during the `/document` step (logged as a harness bug), so this file needs a proper regen once that's fixed; this is a stopgap so the reference doc isn't left stale in the meantime.

## Test plan
- [x] Doc-only change, no code/behavior affected
- [x] Verified only the intended file (`roadmap_wave_items.md`) is touched — a runaway generator invocation touched ~370 unrelated files earlier and was fully reverted before this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>