### PR TITLE
fix(SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001): close TS-3/TS-7 gaps found by EXEC-TO-PLAN TESTING review

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -85,6 +85,33 @@ export const RESPONSIBILITIES = [
 // NOTE: the original SD scope text also named a "root-freshness" loop. It does not exist anywhere
 // in this array or the codebase (verified by VALIDATION, evidence row dd2f16c2-9c2e-424e-b7fb-94e76860b590)
 // — dropped as a phantom/typo'd scope-text reference, not implemented.
+//
+// TS-3 — per-loop double-fire (session-armed + GHA both trigger the same window) idempotency
+// verdict. TESTING gate finding (evidence row f3ece776-9f0e-4fc7-933d-40c2ca326c5d): a blanket
+// "these scripts are idempotent" claim by analogy to retention/backlog-rank is explicitly
+// insufficient — each of the 13 migrated scripts is verified individually below, citing the
+// concrete evidence (source-file comment, dedup-key/query-before-insert pattern, or read-only
+// no-write shape) rather than assumed safety.
+//
+//   key                       | verdict | evidence
+//   --------------------------|---------|------------------------------------------------------
+//   sweep                     | SAFE    | stale-session-sweep.cjs's own header: "Safe to run repeatedly — fully idempotent."
+//   flag-review               | SAFE    | flag-governance-review.mjs queries feedback for an existing metadata->>digest_key='flag-gov:<today>' row before inserting; the flags .update(last_reviewed_at) is a plain timestamp overwrite (repeat-safe by construction)
+//   unranked-gauge            | SAFE    | gauge-unranked-claimable-leaves.mjs is read + log only (no .insert/.upsert calls) — a pure gauge has nothing to duplicate
+//   singleton-relaunch        | SAFE    | singleton-relaunch-scheduler.mjs defaults to dry-run/report-only (SINGLETON_RELAUNCH_SCHEDULING_ENABLED gate) and guards real writes behind its own stampLastFired marker
+//   relay-drain                | SAFE    | coordinator-relay-drain.cjs only selects UNDRAINED relay_request rows (relay-queue.cjs's drainOne marks a row drained as part of processing it) — a second concurrent run finds nothing left to drain
+//   relay-drop-gauge          | SAFE    | coordinator-relay-drop-gauge.cjs's own header: "Idempotent per (correlationId): a row already flagged for the same correlation is [skipped]"
+//   fleet-retro               | SAFE    | coordinator-fleet-retro.mjs's insert uses an explicit dedup key on the capture path (source_id/type-scoped)
+//   row-growth                | SAFE    | row-growth-snapshot.cjs is internally due-gated (~22h) per its own STANDARD_LOOPS comment above — an extra run inside the gate window is a documented no-op
+//   review-rotation            | SAFE    | subsystem-review-rotation.cjs is internally due-gated (~6 days) per its own STANDARD_LOOPS comment above — extra arms/manual runs are documented no-ops
+//   scripts-reachability        | SAFE    | scripts-reachability-gauge.mjs is internally due-gated (~6 days) per its own STANDARD_LOOPS comment above
+//   gauge-runner                | SAFE    | gauge-runner.mjs's own header: "Idempotent (safe to re-run — findings are [deduped])"
+//   feedback-sla                | SAFE    | lib/coordinator/feedback-sla-gauge.cjs's remindSlaBreaches is rate-limited/deduped per category per day via metadata.sla_key, per its own STANDARD_LOOPS comment above
+//   solomon-ledger-resurface     | SAFE    | solomon-ledger-pending-resurface.cjs's own header: capped to once per stale ledger row per day via payload.dedup_key checked before insert
+//
+// All 13 verified SAFE for an occasional session+GHA double-fire. None required a code change to
+// reach this verdict — the additive migration pattern only works because these loops were already
+// built idempotent (a prerequisite the design doc's precedent, retention/backlog-rank, also relied on).
 export const STANDARD_LOOPS = [
   { key: 'sweep',       label: 'Stale-session sweep',  script: 'stale-session-sweep.cjs',   cron: '*/5 * * * *',
     gha_backed: true,

--- a/scripts/fleet-down-alert.mjs
+++ b/scripts/fleet-down-alert.mjs
@@ -185,13 +185,37 @@ async function checkWorkerFleetDown(db, DRY) {
   console.log('[fleet-down-alert] email sent:', r?.id || JSON.stringify(r));
 }
 
+/** Pure: the chairman-SMS message payload for a dead-coordinator trip (TS-7). */
+export function buildDeadCoordinatorMessage(verdict, now = new Date()) {
+  return {
+    type: 'status',
+    body: `DEAD COORDINATOR: no active-coordinator heartbeat for ${verdict.elapsedMin.toFixed(0)}min. Coordinator standing duties (sweeps, gauges, dispatch-rank) are unattended. Start/restart a coordinator session.`,
+    kind: 'dead_coordinator_alert',
+    dedupeKey: `dead-coordinator-${now.toISOString().slice(0, 13)}`,
+  };
+}
+
 // SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-001 / FR-3: independent of checkWorkerFleetDown above —
 // a live worker fleet does not imply a live coordinator (the coordinator's standing
 // responsibilities — sweeps, gauges, dispatch-rank — are a distinct outage class). Deliberately
 // kept as a SEPARATE function with its own query and its own edge-trigger state, so a bug in one
 // predicate can never mask or entangle the other (TESTING gate finding, non-regression scenario).
-async function checkDeadCoordinator(db, DRY) {
-  const coordinatorId = await getActiveCoordinatorId(db);
+//
+// TS-7: sendChairmanSMSFn is injectable (defaults to the real dynamic import) so a test can assert
+// the trip actually invokes the sender with the right message, not just that the pure predicate
+// returns alert:true — mirrors the opts.fallbackSend injectable pattern already used by
+// lib/comms/adam-outbound/chairman-sms-gate/index.js for the same testability reason.
+export async function checkDeadCoordinator(db, DRY, sendChairmanSMSFn = null, now = new Date()) {
+  // getActiveCoordinatorId is used here purely for the log line (console visibility into WHY
+  // an alert fired); the actual trip decision below is entirely heartbeat-elapsed-time-driven.
+  // Fail-open on any resolution hiccup (e.g. a minimal test double lacking the full resolution
+  // chain's query surface) so a coordinator-ID lookup failure can never suppress the alert.
+  let coordinatorId = null;
+  try {
+    coordinatorId = await getActiveCoordinatorId(db);
+  } catch (e) {
+    console.error('[dead-coordinator-alert] getActiveCoordinatorId failed (non-fatal, continuing):', e.message);
+  }
 
   // Regardless of whether a coordinator is CURRENTLY elected, find the most recent heartbeat any
   // coordinator-flagged session has ever reported — this is what evaluateDeadCoordinatorAlert()'s
@@ -205,23 +229,18 @@ async function checkDeadCoordinator(db, DRY) {
   if (error) { console.error('[fleet-down-alert] coordinator-heartbeat query failed:', error.message); return; }
 
   const lastCoordinatorHeartbeatAt = rows && rows[0] ? rows[0].heartbeat_at : null;
-  const verdict = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt, now: new Date() });
+  const verdict = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt, now });
   console.log(`[dead-coordinator-alert] activeCoordinatorId=${coordinatorId || 'null'} ${verdict.alert ? 'ALERT' : 'no-alert'}: ${verdict.reason}`);
 
   if (!verdict.alert) return;
 
-  const message = {
-    type: 'status',
-    body: `DEAD COORDINATOR: no active-coordinator heartbeat for ${verdict.elapsedMin.toFixed(0)}min. Coordinator standing duties (sweeps, gauges, dispatch-rank) are unattended. Start/restart a coordinator session.`,
-    kind: 'dead_coordinator_alert',
-    dedupeKey: `dead-coordinator-${new Date().toISOString().slice(0, 13)}`,
-  };
+  const message = buildDeadCoordinatorMessage(verdict, now);
   if (DRY) {
     console.log('[dead-coordinator-alert] [DRY] would page chairman via sendChairmanSMS:', message.body);
     return;
   }
-  const { sendChairmanSMS } = await import(pathToFileURL(path.resolve('lib/comms/adam-outbound/chairman-sms-gate/index.js')).href);
-  const r = await sendChairmanSMS(message, { now: new Date() });
+  const send = sendChairmanSMSFn || (await import(pathToFileURL(path.resolve('lib/comms/adam-outbound/chairman-sms-gate/index.js')).href)).sendChairmanSMS;
+  const r = await send(message, { now });
   console.log('[dead-coordinator-alert] sendChairmanSMS result:', JSON.stringify(r));
 }
 

--- a/tests/unit/fleet-down-alert.test.js
+++ b/tests/unit/fleet-down-alert.test.js
@@ -1,8 +1,8 @@
 // SD-LEO-INFRA-FLEET-DOWN-EMAIL-ALERT-001 — pure decision logic for the fleet-down operator alert.
 // Oscillation-robust (sustained window, not point-in-time), claimable-gated, and edge-trigger-deduped
 // so a long outage emails once rather than every 15-min run.
-import { describe, it, expect } from 'vitest';
-import { evaluateFleetDownAlert, evaluateDeadCoordinatorAlert } from '../../scripts/fleet-down-alert.mjs';
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateFleetDownAlert, evaluateDeadCoordinatorAlert, buildDeadCoordinatorMessage, checkDeadCoordinator } from '../../scripts/fleet-down-alert.mjs';
 
 // Helper: build a newest-first pulse list from active_count values.
 const pulses = (...active) => active.map((a) => ({ active_count: a }));
@@ -123,5 +123,55 @@ describe('evaluateDeadCoordinatorAlert (SD-LEO-INFRA-DURABLE-COORDINATOR-LOOPS-0
     expect(coordVerdict.alert).toBe(true);
     expect(fleetVerdict.reason).toMatch(/FLEET DOWN/);
     expect(coordVerdict.reason).toMatch(/DEAD COORDINATOR/);
+  });
+
+  it('TS-7: buildDeadCoordinatorMessage names the dead-coordinator condition, not the worker-fleet-down one', () => {
+    const verdict = evaluateDeadCoordinatorAlert({ lastCoordinatorHeartbeatAt: minutesAgo(16), now: NOW, staleMin: 15, cronIntervalMin: 15 });
+    const msg = buildDeadCoordinatorMessage(verdict, NOW);
+    expect(msg.body).toMatch(/DEAD COORDINATOR/);
+    expect(msg.body).not.toMatch(/FLEET DOWN/);
+    expect(msg.kind).toBe('dead_coordinator_alert');
+    expect(msg.dedupeKey).toBe(`dead-coordinator-${NOW.toISOString().slice(0, 13)}`);
+  });
+
+  it('TS-7: checkDeadCoordinator() calls the injected sendChairmanSMS exactly once on a genuine trip, with the dead-coordinator message', async () => {
+    const sendChairmanSMSFn = vi.fn().mockResolvedValue({ sent: true });
+    const db = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: async () => ({ data: [{ heartbeat_at: minutesAgo(16) }], error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+    // getActiveCoordinatorId reads from the pointer file / DB internally; in this unit test we
+    // only care that checkDeadCoordinator's OWN heartbeat-driven trip logic calls the sender —
+    // stub the module's db-facing query surface above and let getActiveCoordinatorId resolve
+    // however it naturally does in this env (it degrades gracefully with no supabase writes).
+    await checkDeadCoordinator(db, false, sendChairmanSMSFn, NOW);
+    expect(sendChairmanSMSFn).toHaveBeenCalledTimes(1);
+    const [message] = sendChairmanSMSFn.mock.calls[0];
+    expect(message.body).toMatch(/DEAD COORDINATOR/);
+    expect(message.kind).toBe('dead_coordinator_alert');
+  });
+
+  it('TS-7: checkDeadCoordinator() does NOT call sendChairmanSMS when the coordinator heartbeat is fresh', async () => {
+    const sendChairmanSMSFn = vi.fn();
+    const db = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: async () => ({ data: [{ heartbeat_at: minutesAgo(5) }], error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+    await checkDeadCoordinator(db, false, sendChairmanSMSFn, NOW);
+    expect(sendChairmanSMSFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- TS-7: `checkDeadCoordinator()` and its send call now take injectable `sendChairmanSMSFn`/`now` params (mirrors chairman-sms-gate's own `opts.fallbackSend` pattern), so a test can assert the sender is actually invoked with the right message on a genuine trip, not just that the pure predicate returns `alert:true`. `getActiveCoordinatorId()` is now wrapped in try/catch (fail-open — its result is log-only; the trip decision is entirely heartbeat-elapsed-driven).
- TS-3: replaced the blanket "idempotent scripts tolerate double-fire" assertion with a per-loop verdict table citing concrete evidence (source-file idempotency comments, dedup-key/query-before-insert patterns, or read-only no-write shape) for each of the 13 migrated `STANDARD_LOOPS` scripts.

Follow-up to #6305 and #6309 (already merged — auto-merge fired on #6309's first commit before this fix commit landed on that branch, so it needs its own PR), same SD.

## Test plan
- [x] `npx vitest run tests/unit/fleet-down-alert.test.js` — 21/21 passing (2 new TS-7 tests: sender called on trip, not called when heartbeat fresh)
- [x] `node --check scripts/fleet-down-alert.mjs`