### PR TITLE
fix(QF-20260719-662): refuse WORK_ASSIGNMENT to non-fleet role singletons

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -444,6 +444,45 @@ async function stampModelRecommendation(supabase, row, logger = console) {
  * blocks a real dispatch; fail-CLOSED only once a violation is CONFIRMED against live data.
  * @private
  */
+/**
+ * QF-20260719-662: WORK_ASSIGNMENT must target a FLEET WORKER, never a role singleton.
+ * Live incident 17:08Z: WORK_ASSIGNMENT b8eb6111 dispatched to Adam's session inserted
+ * cleanly (assertValidTarget vets aliveness, not role) and sat invisible to every claim
+ * path — Adam's drain excludes work_assignment handling. Reuses the CANONICAL claim-side
+ * predicate lib/claim/build-forbidden-session.cjs isBuildForbiddenSession (non_fleet /
+ * role=adam / is_coordinator) — this is exactly the "symmetric guard" that module's
+ * header anticipated; never a second hand-rolled role list. Fail-OPEN on lookup faults
+ * and sentinel/unknown targets; fail-CLOSED only on a CONFIRMED non-fleet target —
+ * the same posture as assertWorkerTierAllowed at this choke.
+ * @private
+ */
+async function assertFleetAssignmentTarget(supabase, row, logger = console) {
+  try {
+    if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
+    const { data: sess } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', row.target_session)
+      .maybeSingle();
+    if (!sess) return; // sentinel/unknown target -> fail-open (assertValidTarget already vetted real ones)
+    const { isBuildForbiddenSession } = require('../claim/build-forbidden-session.cjs');
+    if (isBuildForbiddenSession(sess.metadata)) {
+      const md = sess.metadata || {};
+      const why = md.is_coordinator === true ? 'is_coordinator' : (md.role ? `role=${md.role}` : 'non_fleet');
+      const e = new Error(
+        `[dispatch] REFUSED WORK_ASSIGNMENT: target ${String(row.target_session).slice(0, 8)} is a non-fleet `
+        + `role singleton (${why}) — its drain never claims work_assignment rows, so the assignment would sit `
+        + `invisible to every claim path (incident b8eb6111). Dispatch to a fleet worker instead.`
+      );
+      e.code = 'DISPATCH_NON_FLEET_TARGET';
+      throw e;
+    }
+  } catch (e) {
+    if (e && e.code === 'DISPATCH_NON_FLEET_TARGET') throw e; // fail CLOSED on a confirmed violation
+    logger && logger.warn && logger.warn(`[dispatch] fleet-target check skipped (fail-open): ${e.message}`);
+  }
+}
+
 async function assertWorkerTierAllowed(supabase, row, logger = console) {
   try {
     if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
@@ -706,6 +745,10 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     logger && logger.warn && logger.warn(`[dispatch] Adam-inbox-kind check skipped (fail-open): ${e.message}`);
   }
   await assertValidTarget(supabase, row.target_session, logger);
+  // QF-20260719-662: refuse WORK_ASSIGNMENT to a non-fleet role singleton (Adam/Solomon/coordinator).
+  // assertValidTarget checks aliveness but not ROLE, so an assignment to a propose-only session
+  // inserted cleanly and sat invisible to every claim path (live incident b8eb6111 → Adam c514430f).
+  await assertFleetAssignmentTarget(supabase, row, logger);
   // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the
   // insert (mirrors claim_sd's terminal guard — fails CLOSED on terminal/not-found, open on a DB hiccup).
   await assertSdDispatchable(supabase, row, logger);
@@ -850,6 +893,7 @@ module.exports = {
   isTerminalSdStatus,
   isTerminalQfStatus,
   assertSdDispatchable,
+  assertFleetAssignmentTarget, // QF-20260719-662 — exported for the choke-guard unit fixtures
   assertWorkerTierAllowed,
   assertDoorRoutingAllowed, // SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001 — exported for TS-3/TS-5 fixtures
 };

--- a/tests/unit/coordinator/dispatch-fleet-target-guard.test.js
+++ b/tests/unit/coordinator/dispatch-fleet-target-guard.test.js
@@ -1,0 +1,69 @@
+/**
+ * QF-20260719-662 — assertFleetAssignmentTarget choke guard.
+ * A WORK_ASSIGNMENT must target a FLEET WORKER: a role singleton
+ * (non_fleet / role=adam / is_coordinator) never claims work_assignment rows,
+ * so the dispatch would sit invisible (live incident b8eb6111 → Adam c514430f).
+ * Same chain-stub convention as dispatch-topic-id.test.js at this choke point.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { assertFleetAssignmentTarget } = require('../../../lib/coordinator/dispatch.cjs');
+
+const silentLog = { warn() {}, error() {}, log() {} };
+
+function fakeSupabaseWithSession(sessRow, { throwOnLookup = false } = {}) {
+  return {
+    from() {
+      if (throwOnLookup) throw new Error('lookup exploded');
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() { return Promise.resolve({ data: sessRow, error: null }); },
+      };
+      return chain;
+    },
+  };
+}
+
+const waRow = (target = 'aaaaaaaa-bbbb-cccc-dddd-eeeeffff0000') => ({
+  message_type: 'WORK_ASSIGNMENT',
+  target_session: target,
+  payload: { assigned_sd: 'QF-20260719-162' },
+});
+
+describe('assertFleetAssignmentTarget (QF-20260719-662)', () => {
+  it('REFUSES a WORK_ASSIGNMENT to an is_coordinator target (fail-closed, typed code)', async () => {
+    const sb = fakeSupabaseWithSession({ metadata: { is_coordinator: true } });
+    await expect(assertFleetAssignmentTarget(sb, waRow(), silentLog))
+      .rejects.toMatchObject({ code: 'DISPATCH_NON_FLEET_TARGET' });
+  });
+
+  it('REFUSES a WORK_ASSIGNMENT to a non_fleet role singleton (the Adam incident shape)', async () => {
+    const sb = fakeSupabaseWithSession({ metadata: { non_fleet: true, role: 'adam' } });
+    await expect(assertFleetAssignmentTarget(sb, waRow(), silentLog))
+      .rejects.toMatchObject({ code: 'DISPATCH_NON_FLEET_TARGET' });
+  });
+
+  it('allows a WORK_ASSIGNMENT to a plain fleet worker', async () => {
+    const sb = fakeSupabaseWithSession({ metadata: { fleet_identity: 'Alpha-2', model: 'opus' } });
+    await expect(assertFleetAssignmentTarget(sb, waRow(), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('bails without any lookup for non-WORK_ASSIGNMENT rows', async () => {
+    let looked = false;
+    const sb = { from() { looked = true; throw new Error('should not be called'); } };
+    await assertFleetAssignmentTarget(sb, { message_type: 'coordinator_reply', target_session: 'x' }, silentLog);
+    expect(looked).toBe(false);
+  });
+
+  it('fail-open on unknown/sentinel target (no session row)', async () => {
+    const sb = fakeSupabaseWithSession(null);
+    await expect(assertFleetAssignmentTarget(sb, waRow('broadcast-coordinator'), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('fail-open on a lookup fault (transient DB error never blocks a real dispatch)', async () => {
+    const sb = fakeSupabaseWithSession(null, { throwOnLookup: true });
+    await expect(assertFleetAssignmentTarget(sb, waRow(), silentLog)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
assertValidTarget vets target aliveness but not ROLE, so a WORK_ASSIGNMENT to a
propose-only session (Adam/Solomon/coordinator) inserted cleanly and sat
invisible to every claim path — those drains never handle work_assignment (live
incident b8eb6111 → Adam c514430f; correction + re-route were needed).

New assertFleetAssignmentTarget at the insertCoordinationRow choke, beside
assertWorkerTierAllowed with the identical posture: fail-OPEN on lookup faults
and sentinel/unknown targets, fail-CLOSED (DISPATCH_NON_FLEET_TARGET) only on a
CONFIRMED non-fleet target. Reuses the CANONICAL claim-side predicate
lib/claim/build-forbidden-session.cjs isBuildForbiddenSession — this is exactly
the symmetric guard that module's header anticipated; no second role list.

6 unit tests (refuse coordinator + non_fleet shapes, allow worker, no lookup on
other message types, fail-open on missing row and lookup fault); 24/24 across
the choke-guard suites.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
