### PR TITLE
fix(QF-20260719-793): explicit status raises effectiveType reclassification bar

### DIFF
--- a/lib/comms/adam-outbound/rubric-engine/lint.js
+++ b/lib/comms/adam-outbound/rubric-engine/lint.js
@@ -27,11 +27,25 @@ export function effectiveType(message = {}) {
   if (message.type === 'decision') return 'decision';
   const body = typeof message.body === 'string' ? message.body : '';
   const hasOptions = Array.isArray(message.options) && message.options.length > 0;
+  // Structured options are decisive evidence regardless of the claimed type.
+  if (hasOptions) return 'decision';
   // Option markers ("A)", "1.", "- ") near line starts, or an interrogative asking to choose.
   const optionPattern = /(^|\n)\s*(?:[A-Za-z]\)|[A-Za-z]\.|\d\)|\d\.|-)\s+\S/;
   const questionPattern = /\?\s*$|\b(reply|choose|approve|which|should i|yes\/no|y\/n)\b/i;
-  if (hasOptions || optionPattern.test(body) || questionPattern.test(body)) return 'decision';
-  return message.type === 'status' ? 'status' : (message.type || 'status');
+  // QF-20260719-793: an EXPLICIT type:'status' raises the reclassification bar. Bare single
+  // signals ('which'/'reply' in prose, hyphen bullets in a summary) false-blocked 4 live
+  // chairman-facing status texts on 2026-07-19. An explicit status still upgrades on STRONG
+  // evidence — a trailing question mark, or option-marker lines COMBINED with an interrogative —
+  // so a decision dressed as status cannot skip the decision checks (upgrade-only preserved;
+  // under-classification stays fail-closed: status sends still pass quiet-hours/rate/secrets).
+  if (message.type === 'status') {
+    const trailingQuestion = /\?\s*$/.test(body.trim());
+    if (trailingQuestion || (optionPattern.test(body) && questionPattern.test(body))) return 'decision';
+    return 'status';
+  }
+  // Undeclared/ambiguous types keep the aggressive single-signal promotion.
+  if (optionPattern.test(body) || questionPattern.test(body)) return 'decision';
+  return message.type || 'status';
 }
 
 /**

--- a/tests/unit/comms/rubric-engine/rubric-engine.test.js
+++ b/tests/unit/comms/rubric-engine/rubric-engine.test.js
@@ -93,3 +93,25 @@ describe('rubric-engine evaluate()', () => {
     expect(res.blockedReasons.some((r) => r.startsWith('no_reply_consequence'))).toBe(true);
   });
 });
+
+describe('QF-20260719-793 — explicit status raises the reclassification bar', () => {
+  it('live false positives stay status: bare interrogative words in prose', () => {
+    expect(effectiveType({ type: 'status', body: 'Cursor verdict v2: regardless of which host wins, the runner stays pinned.' })).toBe('status');
+    expect(effectiveType({ type: 'status', body: 'Heartbeat 13:15 — dedupe keys resolved; no reply needed from you.' })).toBe('status');
+  });
+
+  it('live false positive stays status: hyphen bullets in a status summary', () => {
+    expect(effectiveType({ type: 'status', body: 'Overnight summary:\n- three QFs shipped\n- belt drained\n- fleet green' })).toBe('status');
+  });
+
+  it('explicit status STILL upgrades on strong evidence (decision dressed as status)', () => {
+    expect(effectiveType({ type: 'status', body: 'Should I proceed with the migration?' })).toBe('decision'); // trailing ?
+    expect(effectiveType({ type: 'status', body: 'Two paths:\n- A) ship now\n- B) wait for soak\nreply A or B' })).toBe('decision'); // options + interrogative
+    expect(effectiveType({ type: 'status', body: 'x', options: ['a', 'b'] })).toBe('decision'); // structured options always decisive
+  });
+
+  it('undeclared/ambiguous types keep the aggressive single-signal promotion', () => {
+    expect(effectiveType({ body: 'which one do you want' })).toBe('decision');
+    expect(effectiveType({ body: '- A) yes\n- B) no' })).toBe('decision');
+  });
+});


### PR DESCRIPTION
Live 4x on 2026-07-19: chairman-facing STATUS texts hard-blocked by the
decision lint because any bare \b(which|reply|choose|approve)\b or a
hyphen-bullet line promoted the body to type=decision over the caller's
explicit type:'status' ('regardless of which host wins', 'no reply needed',
bullet summaries).

An explicit status now upgrades only on STRONG evidence: a trailing question
mark, option-marker lines COMBINED with an interrogative, or structured
options[] (always decisive). Undeclared/ambiguous types keep the aggressive
single-signal promotion; upgrade-only direction preserved, and status sends
still pass quiet-hours/rate/secrets (fail-closed posture unchanged).

4 regression tests pin the live false positives + the dressed-decision
upgrades; 45/45 comms suites.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
