### PR TITLE
fix(QF-20260719-097): chunk retention archive-dedup .in() (URL-limit 400)

### DIFF
--- a/scripts/retention-enforce.js
+++ b/scripts/retention-enforce.js
@@ -103,14 +103,21 @@ export async function enforcePolicy(supabase, policy, { apply = false, runId = n
       // retention_archive copies before retrying the delete. Check which of this batch's
       // ids already have an archive row for this table and skip re-archiving those —
       // only their delete is retried.
+      // QF-20260719-097: the dedup .in() must be CHUNKED like the delete below — a full
+      // BATCH_SIZE (1000) of UUIDs in one query string blows the PostgREST URL limit and
+      // 400s ('Bad Request'), failing every table with >~a few hundred eligible rows
+      // (live: the 07-19 cron red on 5 tables; ≤106-row tables passed).
       const candidateIds = rows.map((r) => String(r.id));
-      const { data: alreadyArchived, error: archCheckErr } = await supabase
-        .from('retention_archive')
-        .select('source_id')
-        .eq('source_table', policy.table)
-        .in('source_id', candidateIds);
-      if (archCheckErr) throw new Error(`archive-dedup check failed: ${archCheckErr.message}`);
-      const archivedIdSet = new Set((alreadyArchived || []).map((a) => a.source_id));
+      const archivedIdSet = new Set();
+      for (const idCh of chunk(candidateIds, DELETE_CHUNK)) {
+        const { data: alreadyArchived, error: archCheckErr } = await supabase
+          .from('retention_archive')
+          .select('source_id')
+          .eq('source_table', policy.table)
+          .in('source_id', idCh);
+        if (archCheckErr) throw new Error(`archive-dedup check failed: ${archCheckErr.message}`);
+        for (const a of (alreadyArchived || [])) archivedIdSet.add(a.source_id);
+      }
       const toArchive = rows.filter((r) => !archivedIdSet.has(String(r.id)));
 
       // 1) ARCHIVE — must succeed before any delete (TR-1). Skips ids already archived by


### PR DESCRIPTION
The FR-6b id-cursor dedup guard sent a full BATCH_SIZE (1000) of UUIDs in one
.in() query string — over the PostgREST URL limit → 400 'Bad Request' for every
table with more than ~a few hundred eligible rows. That is why the 07-19
retention cron went red after the 07-12 green (the guard shipped in between).
Chunk it with the same DELETE_CHUNK (200) the URL-length-safe delete below
already uses.

Live-verified: audit_log (593), validation_audit_log (2016), model_usage_log
(7347) now archive+delete cleanly where all three previously 400'd. Two
DISTINCT residual defects observed and filed separately (not URL-related):
workflow_trace_log dedup times out at 229k eligible (needs an index on
retention_archive(source_table, source_id) — chairman-gated DDL), and
sub_agent_execution_results deletes are FK-blocked by
design_quality_scores.source_result_id (policy needs dependent-row handling).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
