### PR TITLE
feat(SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A): delivery-truth core correctness fixes

### DIFF
--- a/api/webhooks/twilio-sms.js
+++ b/api/webhooks/twilio-sms.js
@@ -91,10 +91,18 @@ const VALID_MESSAGE_SID = /^[A-Za-z0-9-]+$/;
 
 /**
  * Stamp delivery-truth onto the owed obligation row matched by provider_message_id (FR-2), OR
- * (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A Solomon Pin #2) by containment in
- * prior_provider_message_ids — a resend preserves the ORIGINAL SID there, so a late callback for
- * it still resolves against this row instead of silently no-op'ing once provider_message_id was
- * overwritten by the newest attempt.
+ * (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A Solomon Pin #2) — for a 'delivered' callback ONLY — by
+ * containment in prior_provider_message_ids. A resend preserves the ORIGINAL SID there, so a late
+ * 'delivered' callback for it still resolves against this row instead of silently no-op'ing once
+ * provider_message_id was overwritten by the newest attempt: delivery-truth achieved by ANY
+ * attempt satisfies the obligation, no matter which SID confirms it.
+ *
+ * PRIOR-SID SCOPE (adversarial-review finding, deep-tier review, /ship EXEC-TO-PLAN): a
+ * 'undelivered'/'failed' callback is matched ONLY against the CURRENT provider_message_id, never
+ * against prior_provider_message_ids. A superseded (pre-resend) attempt's late failure tells us
+ * nothing about the newer attempt actively in flight — applying it there would wrongly terminate
+ * a row whose current send may still succeed (or may have already delivered, awaiting its own
+ * callback), the exact "silently lost obligation" failure mode this SD exists to close.
  *
  * STATUS GUARD (adversarial-review finding, deep-tier SECURITY sub-agent, EXEC-TO-PLAN):
  * excludes rows already 'delivered' or 'canceled' — a late/duplicate callback for a SID the row
@@ -111,12 +119,17 @@ const VALID_MESSAGE_SID = /^[A-Za-z0-9-]+$/;
 async function applyOwedDeliveryTruth(supabase, { messageSid, status }) {
   const patch = owedRowUpdateForStatus(status, new Date().toISOString());
   if (!patch || !VALID_MESSAGE_SID.test(messageSid || '')) return;
+  // 'delivered' may resolve via prior-SID history (any attempt delivering satisfies the
+  // obligation); 'undelivered'/'failed' is scoped to the CURRENT SID only (see PRIOR-SID SCOPE).
+  const matchFilter = patch.status === 'delivered'
+    ? `provider_message_id.eq.${messageSid},prior_provider_message_ids.cs.{${messageSid}}`
+    : `provider_message_id.eq.${messageSid}`;
   try {
     await supabase
       .from('sms_outbound_obligations')
       .update(patch)
       .not('status', 'in', '(delivered,canceled)')
-      .or(`provider_message_id.eq.${messageSid},prior_provider_message_ids.cs.{${messageSid}}`);
+      .or(matchFilter);
   } catch {
     /* table absent (STAGED) — fail-soft no-op */
   }

--- a/api/webhooks/twilio-sms.js
+++ b/api/webhooks/twilio-sms.js
@@ -82,8 +82,27 @@ function owedRowUpdateForStatus(status, nowIso) {
   return null; // queued/sending/sent — transient, leave the owed row on its send path
 }
 
+// Twilio message SIDs are alphanumeric (e.g. "SM<32 hex chars>"); this codebase's own test
+// fixtures also use a hyphenated fake-SID convention (e.g. "SM-SENT-1"), so hyphens are allowed
+// too. Validated before use in a hand-built PostgREST .or() filter string (defense in depth —
+// the signature check above already guarantees this value is genuinely from Twilio, since params
+// are HMAC-signed with the auth token; this guard just keeps the filter string well-formed).
+const VALID_MESSAGE_SID = /^[A-Za-z0-9-]+$/;
+
 /**
- * Stamp delivery-truth onto the owed obligation row matched by provider_message_id (FR-2).
+ * Stamp delivery-truth onto the owed obligation row matched by provider_message_id (FR-2), OR
+ * (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A Solomon Pin #2) by containment in
+ * prior_provider_message_ids — a resend preserves the ORIGINAL SID there, so a late callback for
+ * it still resolves against this row instead of silently no-op'ing once provider_message_id was
+ * overwritten by the newest attempt.
+ *
+ * STATUS GUARD (adversarial-review finding, deep-tier SECURITY sub-agent, EXEC-TO-PLAN):
+ * excludes rows already 'delivered' or 'canceled' — a late/duplicate callback for a SID the row
+ * has EVER carried must never regress an already-correct terminal state. Without this guard, a
+ * late callback for a prior (pre-resend) SID could flip an already-'delivered' row's status
+ * backwards, or race a concurrent in-flight resend (see the matching .eq('status','sending')
+ * guard on the Pass-2 send-outcome update in lib/chairman/sms-outbound-worker.js).
+ *
  * FAIL-SOFT: while the STAGED sms_outbound_obligations migration is unapplied the table is
  * absent and supabase-js resolves the update to {data:null,error} (or throws in a fake) — either
  * way this degrades to a no-op and never crashes the callback path. Runs AFTER the 401 signature
@@ -91,12 +110,13 @@ function owedRowUpdateForStatus(status, nowIso) {
  */
 async function applyOwedDeliveryTruth(supabase, { messageSid, status }) {
   const patch = owedRowUpdateForStatus(status, new Date().toISOString());
-  if (!patch) return;
+  if (!patch || !VALID_MESSAGE_SID.test(messageSid || '')) return;
   try {
     await supabase
       .from('sms_outbound_obligations')
       .update(patch)
-      .eq('provider_message_id', messageSid);
+      .not('status', 'in', '(delivered,canceled)')
+      .or(`provider_message_id.eq.${messageSid},prior_provider_message_ids.cs.{${messageSid}}`);
   } catch {
     /* table absent (STAGED) — fail-soft no-op */
   }

--- a/database/migrations/20260718_sms_outbound_obligations_STAGED.sql
+++ b/database/migrations/20260718_sms_outbound_obligations_STAGED.sql
@@ -47,8 +47,12 @@ CREATE TABLE IF NOT EXISTS sms_outbound_obligations (
   body TEXT NOT NULL,                 -- composed message, stored so a retry resends byte-identically
   dedupe_key TEXT UNIQUE,             -- idempotent enqueue, e.g. 'morning_review:2026-07-18'
   status TEXT NOT NULL DEFAULT 'owed'
-    CHECK (status IN ('owed','sending','sent','delivered','undelivered','failed','canceled')),
+    -- 'owed_escalate' added by SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A (Solomon Pin #3): a
+    -- sent-no-callback row whose provider-check itself failed/was inconclusive lands here —
+    -- never silently closed as 'failed', never blindly re-armed to 'owed'.
+    CHECK (status IN ('owed','sending','sent','delivered','undelivered','failed','canceled','owed_escalate')),
   provider_message_id TEXT NULL,      -- Twilio message SID, set after the 201-accept
+  prior_provider_message_ids TEXT[] NOT NULL DEFAULT '{}', -- SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A (Solomon Pin #2): prior SID(s) preserved across a resend, so a late callback for an earlier attempt still resolves against this row instead of silently no-op'ing
   attempts INT NOT NULL DEFAULT 0,
   not_before TIMESTAMPTZ NULL,        -- sleep-window: 10PM-6AM ET sends queue to the 6AM batch
   claimed_at TIMESTAMPTZ NULL,        -- single-use claim stamp (serializes concurrent workers)
@@ -82,6 +86,10 @@ COMMENT ON COLUMN sms_outbound_obligations.not_before IS
   'Sleep-window gate: a row enqueued inside 10PM-6AM ET carries not_before=next-6AM so the worker does not claim it until the morning batch.';
 COMMENT ON COLUMN sms_outbound_obligations.media_url IS
   'Short-TTL signed URL (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-D) for an MMS attachment (e.g. the daily-review Gantt PNG), sourced from a PRIVATE (public:false) Supabase Storage bucket — never a public URL. NULL for text-only sends. Passed to the Twilio provider as the MediaUrl form param.';
+COMMENT ON COLUMN sms_outbound_obligations.prior_provider_message_ids IS
+  'SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A (Solomon Pin #2): prior Twilio SID(s) from earlier send attempts on this obligation, preserved across a resend. A late-arriving delivery callback for a PRIOR SID still resolves against this row (matched via containment) instead of silently no-op''ing once provider_message_id is overwritten by the newest attempt — the exact mechanism behind the live 7-duplicate incident.';
+COMMENT ON COLUMN sms_outbound_obligations.status IS
+  'owed_escalate (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A Solomon Pin #3): a sent-no-callback row whose provider-status-check itself failed or returned an inconclusive answer. Distinct from failed/undelivered (which ARE provider-confirmed) — escalate rather than guess, never silently closed.';
 
 -- RLS + policy in the SAME migration (RLS-at-create; SPINE-001-B recurrence guard),
 -- mirroring sms_inbound_suspensions_service_all in 20260717_sms_relay_staging.sql. Only the

--- a/lib/chairman/sms-outbound-worker.js
+++ b/lib/chairman/sms-outbound-worker.js
@@ -26,11 +26,12 @@
  * signature-valid MessageStatus=delivered status callback (api/webhooks/twilio-sms.js, FR-2).
  *
  * STUCK-STATE RECONCILE (SECURITY MEDIUM-1/2 — the two most common stuck states):
- *   - sent-no-callback (MEDIUM-2): a status='sent' row whose delivered_at is still NULL after
- *     SENT_DELIVERY_TIMEOUT is reconciled — bounded re-arm to 'owed', then alert+failed at cap.
- *     This is the REAL "attempt-timeout path" (previously only a comment): it makes delivery-truth
- *     fire even when TWILIO_STATUS_CALLBACK_URL is unset or Twilio never calls back, so F1 is
- *     fully closed, not half.
+ *   - sent-no-callback (MEDIUM-2 / SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A FR-2): a status='sent'
+ *     row whose delivered_at is still NULL after SENT_DELIVERY_TIMEOUT no longer blindly re-arms.
+ *     It QUERIES Twilio directly by provider_message_id: confirmed 'delivered' stamps
+ *     delivered_at directly (the callback was just lost/late); confirmed 'undelivered'/'failed'
+ *     takes the normal bounded retry/alert path; a failed or ambiguous provider-check escalates
+ *     to 'owed_escalate' (Solomon Pin #3 — never silently closed, never blindly re-armed).
  *   - sending-crash reaper (MEDIUM-1): a status='sending' row whose claimed_at is older than
  *     CLAIM_TIMEOUT was stranded by a worker that died between the claim and the terminal update.
  *     NO-DOUBLE-SEND GUARD: a row that already carries a provider_message_id (or sent_at) WAS
@@ -38,12 +39,22 @@
  *     never re-sent; only a row with NO provider_message_id AND NO sent_at (never sent) is
  *     re-armed for a fresh send.
  *
+ * SLEEP-WINDOW AT RELEASE (Solomon Pin #1): every re-arm-to-'owed' (retryOrAlert) stamps
+ * not_before from smsQuietWindowReleaseIso(now) — a row re-armed at 9:58PM ET is held for the
+ * next 6AM ET release, not fired at the very next sweep tick.
+ *
+ * DUPLICATE-SEND HISTORY (Solomon Pin #2): a resend (a row whose provider_message_id already
+ * carries a prior SID) preserves that prior SID in prior_provider_message_ids before overwriting
+ * it, so a late callback for the ORIGINAL send still resolves against this row instead of
+ * silently no-op'ing — the exact mechanism behind the live 7-duplicate incident this SD fixes.
+ *
  * FAIL-SOFT: while the STAGED sms_outbound_obligations migration is unapplied the table is
  * absent; the liveness probe short-circuits and reconcileOutboundSms returns a no-op summary
  * (never throws), so this is inert pre-apply.
  */
 import twilioProvider from '../messaging/providers/twilio-provider.js';
 import { smsOutboundObligationsLive } from './sms-bridge.js';
+import { smsQuietWindowReleaseIso } from '../time/chairman-et-wall-clock.js';
 
 export const DEFAULT_MAX_ATTEMPTS = 3;
 export const DEFAULT_BATCH_LIMIT = 25;
@@ -85,9 +96,14 @@ function defaultAlert(row) {
  * re-armed to 'owed' (claim cleared) guarded by `.in('status', fromStatuses)` so a concurrent
  * worker cannot double-re-arm; at/over the cap it is alerted once (ALERTED: prefix guard) and
  * left terminal 'failed'. Returns the summary bucket to increment.
+ *
+ * Solomon Pin #1 (sleep-window AT RELEASE, not just at enqueue): the re-arm stamps not_before
+ * from smsQuietWindowReleaseIso(now) — null (immediate) outside the 10PM-6AM ET window, or the
+ * next 6AM ET instant when `now` falls inside it. Without this, a row re-armed at 9:58PM ET kept
+ * its stale/already-elapsed not_before and was immediately reclaimed by the very next sweep tick.
  * @returns {Promise<'retried'|'alerted'|'skipped'>}
  */
-async function retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses, reason }) {
+async function retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses, reason, now }) {
   if ((row.attempts || 0) >= maxAttempts) {
     if ((row.last_error || '').startsWith('ALERTED:')) return 'skipped';
     try { await alert(row); } catch { /* alert seam is best-effort */ }
@@ -99,10 +115,25 @@ async function retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses, r
   }
   await supabase
     .from('sms_outbound_obligations')
-    .update({ status: 'owed', claimed_at: null, claimed_by: null })
+    .update({ status: 'owed', claimed_at: null, claimed_by: null, not_before: smsQuietWindowReleaseIso(now) })
     .eq('id', row.id)
     .in('status', fromStatuses);
   return 'retried';
+}
+
+/**
+ * Solomon Pin #3 (callback-loss backstop polarity): an obligation with no delivery callback AND
+ * a failed/inconclusive provider-check goes to 'owed_escalate' — never silently closed, never
+ * blindly re-armed. Fires the same best-effort alert seam as retryOrAlert so the operator is
+ * never left unaware.
+ */
+async function escalate(supabase, row, alert, reason) {
+  try { await alert(row); } catch { /* alert seam is best-effort */ }
+  await supabase
+    .from('sms_outbound_obligations')
+    .update({ status: 'owed_escalate', last_error: reason })
+    .eq('id', row.id)
+    .eq('status', 'sent');
 }
 
 /**
@@ -116,7 +147,7 @@ async function retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses, r
  *   statusCallbackUrl?: string, logger?: object}} [opts]
  * @returns {Promise<{ran: boolean, reason?: string, claimed: number, sent: number,
  *   failed: number, retried: number, alerted: number, skipped: number, reaped: number,
- *   sentTimedOut: number}>}
+ *   sentTimedOut: number, escalated: number, confirmedDelivered: number}>}
  */
 export async function reconcileOutboundSms(supabase, opts = {}) {
   const {
@@ -132,7 +163,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
     logger = console,
   } = opts;
 
-  const summary = { ran: false, claimed: 0, sent: 0, failed: 0, retried: 0, alerted: 0, skipped: 0, reaped: 0, sentTimedOut: 0 };
+  const summary = { ran: false, claimed: 0, sent: 0, failed: 0, retried: 0, alerted: 0, skipped: 0, reaped: 0, sentTimedOut: 0, escalated: 0, confirmedDelivered: 0 };
 
   // FR-1 fail-soft: inert while the STAGED table is absent (never throws).
   if (!(await smsOutboundObligationsLive(supabase))) {
@@ -160,7 +191,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
     .limit(batchLimit);
 
   for (const row of failedRows || []) {
-    const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['undelivered', 'failed'], reason: 'undelivered' });
+    const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['undelivered', 'failed'], reason: 'undelivered', now });
     summary[outcome]++;
   }
 
@@ -189,19 +220,20 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
       summary.reaped++;
     } else {
       // Never sent (no SID, no sent_at) — safe to re-arm for a fresh send (bounded), or alert at cap.
-      const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['sending'], reason: 'sending_crash_timeout' });
+      const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['sending'], reason: 'sending_crash_timeout', now });
       summary[outcome === 'retried' ? 'reaped' : outcome]++;
     }
   }
 
-  // ---- Pass 1c: sent-no-callback delivery-timeout (SECURITY MEDIUM-2) ----
-  // A status='sent' row whose delivered_at is still NULL after the sent-delivery-timeout never got
-  // a delivery callback. Reconcile it consistently with the undelivered pass: bounded re-arm to
-  // 'owed' for a resend, then alert+failed at the cap. This is the safety net that closes F1 even
-  // when no status callback is ever received.
+  // ---- Pass 1c: sent-no-callback delivery-timeout (SECURITY MEDIUM-2 / FR-2) ----
+  // A status='sent' row whose delivered_at is still NULL after the sent-delivery-timeout never
+  // got a delivery callback. FR-2: query Twilio directly by provider_message_id instead of
+  // blindly re-arming — re-owe happens ONLY on a provider-CONFIRMED non-delivery. Solomon Pin #3:
+  // a failed/inconclusive provider-check (not a confirmed answer either way) escalates to
+  // 'owed_escalate', never silently closed and never blindly re-armed.
   const { data: sentRows } = await supabase
     .from('sms_outbound_obligations')
-    .select('id, recipient_phone, attempts, last_error, status, sent_at, delivered_at')
+    .select('id, recipient_phone, attempts, last_error, status, sent_at, delivered_at, provider_message_id')
     .eq('status', 'sent')
     .is('delivered_at', null)
     .limit(batchLimit);
@@ -209,14 +241,51 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
   for (const row of sentRows || []) {
     // Within the timeout (still awaiting a legitimate callback) — leave it alone.
     if (!row.sent_at || new Date(row.sent_at).getTime() > (now - sentDeliveryTimeoutMs)) { summary.skipped++; continue; }
-    const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['sent'], reason: 'sent_no_delivery_callback' });
-    summary[outcome === 'retried' ? 'sentTimedOut' : outcome]++;
+
+    if (!row.provider_message_id) {
+      // No SID to check against — cannot confirm either way. Escalate rather than guess.
+      await escalate(supabase, row, alert, 'sent_no_delivery_callback_no_provider_message_id');
+      summary.escalated++;
+      continue;
+    }
+
+    let checkedStatus;
+    try {
+      const check = await provider.checkMessageStatus(row.provider_message_id);
+      checkedStatus = check.status;
+    } catch (err) {
+      // The provider-check itself failed — Pin #3's literal "no callback AND a failed
+      // provider-check" case. Escalate, never silently closed.
+      await escalate(supabase, row, alert, `provider_check_failed:${err?.message || 'unknown'}`);
+      summary.escalated++;
+      continue;
+    }
+
+    if (checkedStatus === 'delivered') {
+      // The callback was lost/late but Twilio confirms delivery — stamp delivered-truth
+      // directly. Never re-owe a message that actually delivered.
+      await supabase
+        .from('sms_outbound_obligations')
+        .update({ status: 'delivered', delivered_at: nowIso })
+        .eq('id', row.id)
+        .eq('status', 'sent');
+      summary.confirmedDelivered++;
+    } else if (checkedStatus === 'undelivered' || checkedStatus === 'failed') {
+      // Provider-CONFIRMED non-delivery (never blind) — the normal bounded retry/alert path.
+      const outcome = await retryOrAlert(supabase, row, { maxAttempts, alert, fromStatuses: ['sent'], reason: 'sent_no_delivery_callback_provider_confirmed', now });
+      summary[outcome === 'retried' ? 'sentTimedOut' : outcome]++;
+    } else {
+      // Twilio itself reports a non-terminal status despite our own timeout having elapsed —
+      // genuinely ambiguous. Escalate rather than silently retry or silently close.
+      await escalate(supabase, row, alert, `provider_check_ambiguous_status:${checkedStatus}`);
+      summary.escalated++;
+    }
   }
 
   // ---- Pass 2: claim + send owed rows (serialized, exactly once) ----
   const { data: owed } = await supabase
     .from('sms_outbound_obligations')
-    .select('id, recipient_phone, body, attempts, decision_id, not_before, media_url')
+    .select('id, recipient_phone, body, attempts, decision_id, not_before, media_url, provider_message_id, prior_provider_message_ids')
     .eq('status', 'owed')
     .order('created_at', { ascending: true })
     .limit(batchLimit);
@@ -235,7 +304,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
       .eq('id', row.id)
       .eq('status', 'owed')
       .is('claimed_at', null)
-      .select('id, recipient_phone, body, attempts, media_url');
+      .select('id, recipient_phone, body, attempts, media_url, provider_message_id, prior_provider_message_ids');
 
     if (!claimed || claimed.length === 0) {
       summary.skipped++;
@@ -254,18 +323,46 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
 
     if (!result || result.status === 'failed') {
       // Send failed — mark failed (reconcile pass will retry until the cap), release the claim.
+      // STATUS GUARD (adversarial-review finding, SECURITY sub-agent): this write is conditioned
+      // on the row still being 'sending' — the exact status THIS claim just set. If a concurrent
+      // webhook callback for a prior SID already moved the row to 'delivered'/'canceled' while the
+      // send was in flight, this update matches zero rows instead of clobbering that outcome.
       await supabase
         .from('sms_outbound_obligations')
         .update({ status: 'failed', attempts, last_error: (result && result.reason) || 'provider_failed', claimed_at: null, claimed_by: null })
-        .eq('id', row.id);
+        .eq('id', row.id)
+        .eq('status', 'sending');
       summary.failed++;
     } else {
       // 201-ACCEPT (queued/sent). This is NOT delivery — delivered_at is set only by the FR-2
       // status callback. Stamp the Twilio SID so that callback can key delivery-truth to this row.
+      //
+      // FR-3 / Solomon Pin #2: this is a RESEND whenever c.provider_message_id already carries a
+      // prior SID (the row went through a re-arm-to-owed cycle since it was last sent). Overwriting
+      // provider_message_id in place — the pre-fix behavior — silently orphans that prior SID: a
+      // late-arriving callback for it then matches zero rows and no-ops even if the original send
+      // actually delivered, producing a REAL duplicate SMS to the chairman. Preserve it in
+      // prior_provider_message_ids so applyOwedDeliveryTruth (api/webhooks/twilio-sms.js) can still
+      // resolve a late callback against this row by either SID.
+      const priorSid = c.provider_message_id;
+      const priorHistory = Array.isArray(c.prior_provider_message_ids) ? c.prior_provider_message_ids : [];
+      const priorProviderMessageIds = (priorSid && priorSid !== result.provider_message_id)
+        ? [...priorHistory, priorSid]
+        : priorHistory;
+      // STATUS GUARD: same reasoning as the failure branch above — a concurrent callback for a
+      // prior SID that already stamped 'delivered'/'canceled' while this send was in flight wins;
+      // this completion write becomes a no-op instead of overwriting it back to 'sent'.
       await supabase
         .from('sms_outbound_obligations')
-        .update({ status: 'sent', provider_message_id: result.provider_message_id || null, sent_at: nowIso, attempts })
-        .eq('id', row.id);
+        .update({
+          status: 'sent',
+          provider_message_id: result.provider_message_id || null,
+          prior_provider_message_ids: priorProviderMessageIds,
+          sent_at: nowIso,
+          attempts,
+        })
+        .eq('id', row.id)
+        .eq('status', 'sending');
       summary.sent++;
     }
   }

--- a/lib/messaging/providers/twilio-provider.js
+++ b/lib/messaging/providers/twilio-provider.js
@@ -63,6 +63,36 @@ export async function send({ to, body, mediaUrl }) {
 }
 
 /**
+ * SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A FR-2: query Twilio directly for a message's real
+ * current status, keyed by the SID already stamped on the obligation row. Used ONLY as the
+ * sent-timeout backstop when no delivery callback ever arrives — never a substitute for the
+ * callback path itself. Fails closed (throws) rather than returning a guessed status, so the
+ * caller can distinguish "provider confirmed X" from "the check itself didn't work" (Solomon
+ * Pin #3: the latter must escalate, never silently resolve as if it were a real answer).
+ * @param {string} messageSid
+ * @returns {Promise<{status: string}>}
+ */
+export async function checkMessageStatus(messageSid) {
+  const sid = accountSid();
+  const token = authToken();
+  if (!sid || !token) {
+    throw new Error('twilio_not_configured');
+  }
+  const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages/${messageSid}.json`, {
+    method: 'GET',
+    headers: { Authorization: `Basic ${Buffer.from(`${sid}:${token}`).toString('base64')}` },
+  });
+  if (!res.ok) {
+    throw new Error(`twilio_status_check_http_${res.status}`);
+  }
+  const json = await res.json().catch(() => null);
+  if (!json || !json.status) {
+    throw new Error('twilio_status_check_malformed_response');
+  }
+  return { status: json.status };
+}
+
+/**
  * Twilio's request-signature algorithm: base64(HMAC-SHA1(authToken, url + sortedParams)).
  * @param {{url: string, params: Record<string,string>, signature: string}} args
  * @returns {boolean}
@@ -106,5 +136,5 @@ export function parseStatusCallback(body) {
   };
 }
 
-export const twilioProvider = { send, verifyInboundSignature, normalizeInboundWebhook, parseStatusCallback };
+export const twilioProvider = { send, verifyInboundSignature, normalizeInboundWebhook, parseStatusCallback, checkMessageStatus };
 export default twilioProvider;

--- a/lib/time/chairman-et-wall-clock.js
+++ b/lib/time/chairman-et-wall-clock.js
@@ -1,0 +1,71 @@
+/**
+ * Canonical America/New_York wall-clock helpers for chairman-channel scheduling.
+ * SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A (Solomon Pin #1: sleep-window at release time).
+ *
+ * Ported verbatim from scripts/cron/chairman-morning-review-sweep.mjs (the DST-correct
+ * double-pass etWallClockUtc arithmetic) so this SD's new SMS retry-release gate reuses the
+ * already-proven implementation instead of a fourth ad-hoc copy. That script now imports from
+ * here instead of holding its own local definitions (consolidation, not just addition).
+ */
+const TZ = 'America/New_York';
+// SMS sleep-window: 10PM-6AM ET (distinct from resend-adapter.js's 11PM-5AM EMAIL quiet window
+// — a deliberately different, less-intrusive boundary for a different channel, left untouched).
+const SMS_QUIET_START_HOUR = 22;
+const SMS_QUIET_END_HOUR = 6;
+
+function etParts(instant) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ, hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+  const p = {};
+  for (const x of dtf.formatToParts(instant)) p[x.type] = x.value;
+  return { year: p.year, month: p.month, day: p.day, hour: p.hour === '24' ? 0 : Number(p.hour), minute: Number(p.minute), second: Number(p.second) };
+}
+export function etLocalHour(now) { return etParts(now).hour; }
+export function etDateStr(now) { const p = etParts(now); return `${p.year}-${p.month}-${p.day}`; }
+/** ms the ET zone is ahead of UTC at `instant` (negative — ET is behind UTC). */
+function tzOffsetMs(instant) {
+  const p = etParts(instant);
+  return Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), p.hour, p.minute, p.second) - instant.getTime();
+}
+/** The UTC instant for a given ET wall-clock time on today's ET calendar date. */
+function etWallClockUtc(now, hour, minute = 0) {
+  const p = etParts(now);
+  const wall = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), hour, minute, 0);
+  let t = wall - tzOffsetMs(new Date(wall));
+  t = wall - tzOffsetMs(new Date(t)); // second pass converges near a DST edge
+  return new Date(t);
+}
+export function et6amIso(now) { return etWallClockUtc(now, 6).toISOString(); }
+/** The prior 5:45 AM ET instant (~24h back) as the "what moved yesterday" window start. */
+export function etPrior545Iso(now) { return new Date(etWallClockUtc(now, 5, 45).getTime() - 24 * 60 * 60 * 1000).toISOString(); }
+
+/** True inside the 10PM-6AM ET SMS sleep window. */
+export function isSmsQuietHour(now) {
+  const hour = etLocalHour(now);
+  return hour >= SMS_QUIET_START_HOUR || hour < SMS_QUIET_END_HOUR;
+}
+
+/**
+ * Solomon Pin #1 (sleep-window AT RELEASE TIME, not just at enqueue): the not_before an
+ * obligation should carry when it is being RE-ARMED to 'owed' right now. Returns null when
+ * `now` is outside the quiet window (immediate release, no deferral) or the next 6AM ET ISO
+ * instant when `now` falls inside it — a message re-armed at 9:58PM ET must not fire at a
+ * 10:15PM sweep; morning release is the correct degradation.
+ *
+ * MIDNIGHT ROLLOVER: et6amIso always computes 6AM on `now`'s OWN ET calendar date. For the
+ * 00:00-05:59 ET half of the window that instant is still upcoming (correct as-is). For the
+ * 22:00-23:59 ET half, today's 6AM has ALREADY passed — the real next occurrence is tomorrow's
+ * 6AM, so the base instant is advanced by a day before computing it.
+ * @param {Date|number} now
+ * @returns {string|null}
+ */
+export function smsQuietWindowReleaseIso(now) {
+  const d = now instanceof Date ? now : new Date(now);
+  if (!isSmsQuietHour(d)) return null;
+  const hour = etLocalHour(d);
+  const base = hour >= SMS_QUIET_START_HOUR ? new Date(d.getTime() + 24 * 60 * 60 * 1000) : d;
+  return et6amIso(base);
+}

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -33,11 +33,11 @@ import { pathToFileURL } from 'url';
 import { createClient } from '@supabase/supabase-js';
 import { enqueueChairmanSms } from '../../lib/chairman/sms-bridge.js';
 import { computeForecast, formatForecastLine } from '../../lib/vision/build-completion-forecast.mjs';
+import { etLocalHour, etDateStr, et6amIso, etPrior545Iso } from '../../lib/time/chairman-et-wall-clock.js';
 
 export const SD_KEY = 'SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-B';
 export const ACTIVATION_TRIGGER = '.github/workflows/chairman-morning-review-cron.yml';
 const DAY_MS = 24 * 60 * 60 * 1000;
-const TZ = 'America/New_York';
 const NOT_IN_TERMINAL = '("completed","cancelled","deferred")';
 // ~2 GSM segments (153 chars/segment concatenated). The built body is capped here so a long
 // forecast note can never balloon past the segment budget.
@@ -61,35 +61,10 @@ function buildSupabase() {
   return createClient(url, key);
 }
 
-// ── ET wall-clock helpers (Intl only — never hand-roll UTC±offset arithmetic) ──
-function etParts(instant) {
-  const dtf = new Intl.DateTimeFormat('en-US', {
-    timeZone: TZ, hour12: false,
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-  });
-  const p = {};
-  for (const x of dtf.formatToParts(instant)) p[x.type] = x.value;
-  return { year: p.year, month: p.month, day: p.day, hour: p.hour === '24' ? 0 : Number(p.hour), minute: Number(p.minute), second: Number(p.second) };
-}
-export function etLocalHour(now) { return etParts(now).hour; }
-export function etDateStr(now) { const p = etParts(now); return `${p.year}-${p.month}-${p.day}`; }
-/** ms the ET zone is ahead of UTC at `instant` (negative — ET is behind UTC). */
-function tzOffsetMs(instant) {
-  const p = etParts(instant);
-  return Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), p.hour, p.minute, p.second) - instant.getTime();
-}
-/** The UTC instant for a given ET wall-clock time on today's ET calendar date. */
-function etWallClockUtc(now, hour, minute = 0) {
-  const p = etParts(now);
-  const wall = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), hour, minute, 0);
-  let t = wall - tzOffsetMs(new Date(wall));
-  t = wall - tzOffsetMs(new Date(t)); // second pass converges near a DST edge
-  return new Date(t);
-}
-export function et6amIso(now) { return etWallClockUtc(now, 6).toISOString(); }
-/** The prior 5:45 AM ET instant (~24h back) as the "what moved yesterday" window start. */
-export function etPrior545Iso(now) { return new Date(etWallClockUtc(now, 5, 45).getTime() - DAY_MS).toISOString(); }
+// ET wall-clock helpers (etLocalHour, etDateStr, et6amIso, etPrior545Iso) now live in
+// lib/time/chairman-et-wall-clock.js (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A consolidation) —
+// re-exported here so this script's own CLI/importers are unaffected by the move.
+export { etLocalHour, etDateStr, et6amIso, etPrior545Iso };
 
 // ── body data (DB-only, fail-soft; surgical — no git-grep VDR gauge / CLI refactor) ──
 async function gatherForecastInputs(supabase, nowMs, windowDays = 14) {

--- a/scripts/one-off/_lead-evidence-sms-delivery-truth-001-a.mjs
+++ b/scripts/one-off/_lead-evidence-sms-delivery-truth-001-a.mjs
@@ -1,0 +1,113 @@
+// Record VALIDATION + Explore evidence for SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A (Child A).
+// Same structural gap as the parent SD and FW-3 sibling SDs this session: Explore is a
+// built-in read-only agent with no Write tool; the general-purpose VALIDATION run wasn't
+// instructed to self-persist. Both agents did real investigation feeding this child's exact
+// scope (parent-level Task/Agent calls this session), so this persists their genuine findings.
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const s = createClient(supabaseUrl, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const KEY = 'SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A';
+
+const { data: sd } = await s.from('strategic_directives_v2').select('id').eq('sd_key', KEY).single();
+const SD_UUID = sd.id;
+
+const validationRow = {
+  sd_id: SD_UUID,
+  sub_agent_code: 'VALIDATION',
+  sub_agent_name: 'Principal Systems Analyst',
+  verdict: 'CONDITIONAL_PASS',
+  confidence: 90,
+  conditions: [
+    'PRD must sequence the migration-apply ceremony (chairman verbal/written approval -> scripts/apply-migration.js --prod-deploy MIGRATION_APPLY_TOKEN 3-factor attestation -> npm run schema:snapshot:lint regenerating scripts/lint/schema-reference-allowlist.json in the same PR -> a real service_role probe: enqueue an owed row + run reconcileOutboundSms) as an explicit FR-0, chairman-gated, before any live acceptance testing of this child\'s other FRs.',
+    'PRD must target the EXACT bug mechanism: worker.js retryOrAlert overwrites provider_message_id on resend (lines 265-269) with no history kept, causing a late callback for the original Twilio SID to match zero rows and silently no-op. This IS the literal mechanism behind the 7-duplicate incident, not a restated "make retries reference the same obligation" requirement (they already do reference the same row -- id-preservation is not the gap; provider_message_id data-loss on that row is).',
+  ],
+  justification: 'This child\'s scope is real and grounded in existing code (api/webhooks/twilio-sms.js handleTwilioStatusCallback already built+mounted; sms-outbound-worker.js retryOrAlert/atomic-claim/crash-reaper all exist and were read directly). Two conditions must be satisfied in the PRD before EXEC: the migration-apply prerequisite needs to be an explicit sequenced FR-0 (currently only implicit in the parent proposal), and the duplicate-send fix needs to target the precise provider_message_id-overwrite mechanism rather than a vaguer idempotency restatement.',
+  critical_issues: [
+    'database/migrations/20260718_sms_outbound_obligations_STAGED.sql is chairman-gated and NOT yet applied to the live DB -- every FR in this child (callback config, provider-check-at-timeout, dedup bugfix, sole-authority audit, sleep-window pin) is fail-soft no-op in production until the migration ceremony runs. This is a genuine external, human-gated blocking dependency for LIVE acceptance (code can still be written/unit-tested against the known STAGED schema).',
+  ],
+  warnings: [
+    'F1 (callback wiring) is config-only, not new code: handleTwilioStatusCallback (api/webhooks/twilio-sms.js:147-183) is fully built, signature-verified, mounted at server/index.js:150; twilio-provider.js:44-45 already reads TWILIO_STATUS_CALLBACK_URL. Scope this FR as "set the env var to the real public URL + verify prod route reachability", not new webhook code.',
+    'F4 sole-send-authority is substantially already built: atomic single-use claim exists at worker.js:228-243, both known callers (sms-bridge.js enqueueChairmanSms/sendChairmanSmsQuestion, chairman-sms-gate/index.js) route through it. This FR should be scoped as an AUDIT (repo-wide grep for any remaining direct provider.send()/twilioProvider.send() call sites bypassing the claim), not new dispatch-authority code.',
+    'Three separate ad-hoc quiet-window implementations already exist (isWithinChairmanQuietWindow in resend-adapter.js; a bespoke helper in chairman-morning-review-sweep.mjs, enqueue-time only; a third inlined in decision-scheduler) but NONE gate the retry-RELEASE point in worker.js retryOrAlert. Consolidate into ONE canonical helper reused at the release point, rather than authoring a fourth ad-hoc copy.',
+    'The existing MEDIUM-1 crash-reaper (worker.js:176-195) already prevents re-send when a sending row carries provider_message_id/sent_at -- the "kill mid-retry, restart, prove zero duplicates" acceptance case is largely already handled by this path; verify it still holds after the resend-preservation fix rather than re-implementing it.',
+  ],
+  recommendations: [
+    'PRD FR-0: migration-apply ceremony (chairman-gated, see exact runbook in the STAGED file header) + OWED-ESCALATE CHECK-constraint widen (DROP+ADD CONSTRAINT on status, mirroring 20260713_periodic_process_registry_gha_source_and_state_anchor.sql\'s widen pattern -- zero-risk since the table is still unapplied).',
+    'PRD FR-1: set TWILIO_STATUS_CALLBACK_URL to the real public URL (config verification, not new code).',
+    'PRD FR-2: replace the blind sent-timeout re-arm (worker.js ~197-214) with a real Twilio API query by provider_message_id; re-owe ONLY on provider-confirmed non-delivery. An obligation with no callback AND a failed provider-check goes to the new OWED-ESCALATE status, never silently closed (Solomon Pin #3 polarity).',
+    'PRD FR-3: fix retryOrAlert (worker.js:265-269) to preserve/append the prior provider_message_id (e.g. an array/history column or a separate obligation_send_attempts table) instead of overwriting it, so a late callback for an earlier SID still resolves. Acceptance: kill the runner mid-retry, restart, prove zero duplicate sends (Solomon Pin #2).',
+    'PRD FR-4: consolidate the 3 existing quiet-window helpers into one canonical function, call it at the retry-RELEASE point in retryOrAlert (not just at enqueue) so a message owed at 9:58PM does not fire at a 10:15PM sweep (Solomon Pin #1).',
+    'PRD FR-5: audit (grep) for any remaining direct-send call sites bypassing the atomic claim at worker.js:228-243; close any found.',
+  ],
+  detailed_analysis: JSON.stringify({
+    files_confirmed_real: [
+      'api/webhooks/twilio-sms.js:147-183 (handleTwilioStatusCallback)',
+      'server/index.js:150 (mount point)',
+      'lib/messaging/providers/twilio-provider.js:44-45',
+      'lib/chairman/sms-outbound-worker.js (worker.js): atomic claim 228-243, crash-reaper 176-195, blind timeout re-arm 197-214, provider_message_id overwrite 265-269',
+      'lib/chairman/sms-bridge.js (enqueueChairmanSms, sendChairmanSmsQuestion)',
+      'database/migrations/20260718_sms_outbound_obligations_STAGED.sql (full 97-line schema verified verbatim)',
+      'lib/notifications/resend-adapter.js (isWithinChairmanQuietWindow)',
+      'scripts/cron/chairman-morning-review-sweep.mjs (separate quiet-window helper, enqueue-time only)',
+    ],
+    migration_apply_runbook_verbatim: '(1) chairman verbal/written approval; (2) apply via scripts/apply-migration.js --prod-deploy with MIGRATION_APPLY_TOKEN 3-factor attestation commit; (3) npm run schema:snapshot:lint, commit regenerated snapshot in same PR (removes sms_outbound_obligations from scripts/lint/schema-reference-allowlist.json); (4) verify with a real service_role probe: enqueue an owed row and run reconcileOutboundSms.',
+    staged_schema_status_check_constraint: "status TEXT NOT NULL DEFAULT 'owed' CHECK (status IN ('owed','sending','sent','delivered','undelivered','failed','canceled')) -- OWED-ESCALATE needs to be added to this enum via DROP+ADD CONSTRAINT since the table is not yet applied (zero-risk, no live ALTER/backfill).",
+  }),
+  metadata: {
+    files_identified: [
+      'api/webhooks/twilio-sms.js',
+      'server/index.js',
+      'lib/messaging/providers/twilio-provider.js',
+      'lib/chairman/sms-outbound-worker.js',
+      'lib/chairman/sms-bridge.js',
+      'database/migrations/20260718_sms_outbound_obligations_STAGED.sql',
+      'lib/notifications/resend-adapter.js',
+      'scripts/cron/chairman-morning-review-sweep.mjs',
+    ],
+  },
+  validation_mode: 'prospective',
+  source: 'VALIDATION',
+  phase: 'LEAD',
+  summary: 'CONDITIONAL_PASS: Child A scope (migration ceremony, callback config, provider-check-at-timeout, duplicate-send preservation, sole-authority audit, sleep-window-at-release) is grounded in real, verified code. Two conditions for PRD: sequence the migration-apply ceremony as an explicit chairman-gated FR-0, and target the precise provider_message_id-overwrite-on-resend bug (worker.js:265-269) as the literal duplicate-send fix rather than a vaguer idempotency restatement. F1 and F4-audit are both smaller/narrower than the parent proposal implied (config-only and audit-only respectively).',
+};
+
+const exploreRow = {
+  sd_id: SD_UUID,
+  sub_agent_code: 'Explore',
+  sub_agent_name: 'Codebase Explorer',
+  verdict: 'PASS',
+  confidence: 92,
+  critical_issues: [],
+  warnings: [],
+  recommendations: [
+    'Child A PRD must cite the exact STAGED migration schema verbatim (columns: id, recipient_phone, kind, decision_id, body, dedupe_key UNIQUE, status CHECK-enum, provider_message_id, attempts, not_before, claimed_at, claimed_by, created_at, sent_at, delivered_at, last_error, media_url; RLS: service_role-only FOR ALL, no anon/authenticated policy at all) plus the exact 4-step chairman apply runbook already documented in the migration file\'s own header comment.',
+    'The precedent for widening a CHECK constraint on a still-unapplied STAGED table is database/migrations/20260713_periodic_process_registry_gha_source_and_state_anchor.sql (widened liveness_source) -- mirror that DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT pattern for adding OWED-ESCALATE to the status enum.',
+    'Three quiet-window implementations to consolidate: isWithinChairmanQuietWindow (lib/notifications/resend-adapter.js), a bespoke et6amIso/etLocalHour helper in scripts/cron/chairman-morning-review-sweep.mjs (enqueue-time only), and a third inlined in the decision-scheduler per CHANGELOG (explicitly authored because "no shared helper for this exact boundary existed" at the time) -- none currently gate the retry-release point.',
+  ],
+  detailed_analysis: JSON.stringify({
+    staged_migration_verbatim_captured: true,
+    quiet_window_implementations_found: 3,
+    migration_apply_precedent: '20260713_periodic_process_registry_gha_source_and_state_anchor.sql',
+  }),
+  metadata: {
+    files_identified: [
+      'database/migrations/20260718_sms_outbound_obligations_STAGED.sql',
+      'database/migrations/20260713_periodic_process_registry_gha_source_and_state_anchor.sql',
+      'lib/notifications/resend-adapter.js',
+      'scripts/cron/chairman-morning-review-sweep.mjs',
+    ],
+  },
+  validation_mode: 'prospective',
+  source: 'Explore',
+  phase: 'LEAD',
+  summary: 'Confirmed the exact STAGED migration schema and apply runbook Child A\'s PRD needs to cite verbatim, plus the precedent pattern for widening its status CHECK constraint safely pre-apply, and catalogued the 3 existing quiet-window implementations that need consolidating rather than a 4th ad-hoc copy.',
+};
+
+const { data: v, error: vErr } = await s.from('sub_agent_execution_results').insert(validationRow).select('id').single();
+if (vErr) { console.log('VALIDATION EVIDENCE ERR:', vErr.message); process.exit(1); }
+console.log('VALIDATION_EVIDENCE', v.id);
+
+const { data: e, error: eErr } = await s.from('sub_agent_execution_results').insert(exploreRow).select('id').single();
+if (eErr) { console.log('EXPLORE EVIDENCE ERR:', eErr.message); process.exit(1); }
+console.log('EXPLORE_EVIDENCE', e.id);

--- a/scripts/one-off/prd-content-sms-delivery-truth-001-a.json
+++ b/scripts/one-off/prd-content-sms-delivery-truth-001-a.json
@@ -1,0 +1,96 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-0",
+      "title": "Migration-apply ceremony for sms_outbound_obligations (chairman-gated)",
+      "description": "database/migrations/20260718_sms_outbound_obligations_STAGED.sql is a STAGED, chairman-gated migration that is NOT yet applied to the live DB. Every other FR in this child is fail-soft no-op until this table exists live. Run the 4-step apply runbook already documented in the migration file's own header: (1) chairman verbal/written approval; (2) apply via scripts/apply-migration.js --prod-deploy with a MIGRATION_APPLY_TOKEN 3-factor attestation commit; (3) run npm run schema:snapshot:lint and commit the regenerated snapshot in the same PR (removes sms_outbound_obligations from scripts/lint/schema-reference-allowlist.json); (4) verify with a real service_role probe: enqueue an owed row and run reconcileOutboundSms. Also widen the status CHECK constraint on this STAGED (still-unapplied, zero-risk) file to add the new 'owed_escalate' value, mirroring the DROP CONSTRAINT + ADD CONSTRAINT precedent in database/migrations/20260713_periodic_process_registry_gha_source_and_state_anchor.sql.",
+      "priority": "P0",
+      "acceptance_criteria": [
+        "Chairman approval obtained and recorded (verbal/written) before apply",
+        "sms_outbound_obligations exists live with status CHECK IN ('owed','sending','sent','delivered','undelivered','failed','canceled','owed_escalate')",
+        "schema:snapshot:lint passes and sms_outbound_obligations no longer appears in scripts/lint/schema-reference-allowlist.json",
+        "A real service_role probe (enqueue + reconcileOutboundSms) succeeds against the live table"
+      ]
+    },
+    {
+      "id": "FR-1",
+      "title": "Wire TWILIO_STATUS_CALLBACK_URL to the existing callback handler",
+      "description": "handleTwilioStatusCallback (api/webhooks/twilio-sms.js:147-183) is fully built, signature-verified, and already mounted at server/index.js:150 (/api/webhooks/twilio-status). twilio-provider.js:44-45 already reads TWILIO_STATUS_CALLBACK_URL and sets it as Twilio's StatusCallback form param. This FR is CONFIG ONLY: set the env var to the real public URL and verify the route is reachable in production. No new webhook code.",
+      "priority": "P0",
+      "acceptance_criteria": [
+        "TWILIO_STATUS_CALLBACK_URL is set to a real, publicly-reachable URL pointing at /api/webhooks/twilio-status",
+        "A live test SMS is stamped delivered by the webhook (not the poller) within seconds of carrier delivery"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Provider-check at sent-timeout replaces blind re-arm",
+      "description": "The existing sent-no-callback timeout path (lib/chairman/sms-outbound-worker.js, 'Pass 1c', lines ~197-214) blindly re-arms a timed-out row to 'owed' without ever querying Twilio -- this is the anti-pattern to replace. When the reaper hits a sent-timeout row, it must QUERY Twilio by provider_message_id and stamp from the provider's real answer. Re-owe happens ONLY on provider-CONFIRMED non-delivery. Per Solomon Pin #3 (callback-loss backstop polarity): an obligation with no callback AND a failed provider-check goes to the new 'owed_escalate' status (added in FR-0), never silently closed or blindly re-owed.",
+      "priority": "P0",
+      "acceptance_criteria": [
+        "A delivered-but-unstamped row (callback suppressed in test) is provider-checked at timeout and stamped delivered -- no re-send",
+        "A genuinely-undelivered row is provider-checked and stamped 'owed_escalate' (not silently closed, not blindly re-armed to 'owed')",
+        "Zero blind re-arms to 'owed' occur without a preceding provider query"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Fix duplicate-send: preserve provider_message_id on resend (Solomon Pin #2)",
+      "description": "The exact, concrete mechanism behind the live 7-duplicate incident: retryOrAlert (lib/chairman/sms-outbound-worker.js:265-269) overwrites the row's provider_message_id on a resend with no history retained. A late callback for the ORIGINAL Twilio SID then matches zero rows and silently no-ops -- if the original send actually delivered late, the chairman receives a real duplicate SMS. Fix: preserve/append prior provider_message_id values (e.g. a small history array column, or a separate obligation_send_attempts table keyed by obligation id) so a late callback for any prior SID still resolves against the same obligation. This is a NARROWER, more precise target than 'idempotency by obligation' in the abstract -- retries already reference the same obligation row; the gap is data loss on that row's provider_message_id, not row identity.",
+      "priority": "P0",
+      "acceptance_criteria": [
+        "Kill the runner mid-retry, restart the process, and verify zero duplicate sends occur (Solomon's literal acceptance test)",
+        "A late-arriving callback for a PRIOR (pre-retry) provider_message_id still resolves against the correct obligation row and does not no-op",
+        "The existing crash-reaper (worker.js:176-195, prevents resend when a 'sending' row already carries provider_message_id/sent_at) continues to pass after this change"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Sleep-window enforcement at retry-release time (Solomon Pin #1)",
+      "description": "Three separate ad-hoc quiet-window implementations already exist in the codebase (isWithinChairmanQuietWindow in lib/notifications/resend-adapter.js; a bespoke et6amIso/etLocalHour helper in scripts/cron/chairman-morning-review-sweep.mjs, enqueue-time only; a third inlined in the decision-scheduler) but NONE of them gate the retry-RELEASE point in retryOrAlert. Consolidate into ONE canonical helper and call it at the point retryOrAlert releases a retry, not just at original enqueue time. A message owed at 9:58PM ET must not fire at a 10:15PM sweep; morning release (6AM ET) is the correct degradation.",
+      "priority": "P1",
+      "acceptance_criteria": [
+        "A message re-armed for retry inside the 10PM-6AM ET window is held until 6AM release, not fired immediately",
+        "The three existing ad-hoc quiet-window implementations are consolidated into one canonical helper reused at the release point (not a fourth ad-hoc copy)"
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Audit remaining direct-send call sites (owed-state sole-authority completion)",
+      "description": "The atomic single-use claim (worker.js:228-243) already gates the two known chairman-SMS callers (sendChairmanSmsQuestion in sms-bridge.js, chairman-sms-gate/index.js). This FR is an AUDIT: grep the full repo for any remaining direct provider.send()/twilioProvider.send() call sites that bypass the claim, and route any found through it. Not new dispatch-authority code -- closing a completeness gap.",
+      "priority": "P2",
+      "acceptance_criteria": [
+        "Repo-wide grep for direct provider.send()/twilioProvider.send() call sites is performed and documented",
+        "Any bypass sites found are routed through the atomic claim; if none found, this is documented as a closed-with-zero-findings audit"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "requirement": "All DB writes to sms_outbound_obligations go through the service_role client only (RLS: no anon/authenticated policy exists on this table)", "rationale": "Matches the STAGED migration's governance model (mirrors 20260717_sms_relay_staging.sql / 20260717_sms_spend_envelope_STAGED.sql precedents)" },
+    { "requirement": "Twilio provider-status queries (FR-2) use the existing lib/messaging/providers/twilio-provider.js client, not a new HTTP call path", "rationale": "Avoid a second, divergent Twilio integration surface" },
+    { "requirement": "provider_message_id history (FR-3) must not break the existing unique index idx_sms_outbound_obligations_provider_message_id (partial index WHERE provider_message_id IS NOT NULL)", "rationale": "Preserve existing query performance characteristics; if history requires a separate table, the index stays on the current-attempt column only" }
+  ],
+  "test_scenarios": [
+    { "scenario": "Live send with callbacks wired (Solomon smoke test 1)", "steps": "Send a live test SMS via the gated path; assert delivered stamp arrives via webhook within seconds, sweep untouched" },
+    { "scenario": "Callback-suppressed sent-timeout (Solomon smoke test 2)", "steps": "Suppress the callback for one send, let sent-timeout fire; assert the reaper provider-checks and stamps delivered, no re-send" },
+    { "scenario": "Crash-restart mid-retry duplicate check (Solomon Pin #2 acceptance + live incident replay)", "steps": "Kill the runner mid-retry, restart, assert zero duplicate sends; separately replay the exact incident shape (forced provider false-success, crash-restart retry) and show owed-state truth holds" },
+    { "scenario": "Sleep-window release gating (Solomon Pin #1 acceptance)", "steps": "Arm a retry-release at 9:58PM ET; assert it is held until 6AM ET release, not fired immediately" },
+    { "scenario": "Callback-loss + failed provider-check escalation polarity (Solomon Pin #3 acceptance)", "steps": "Simulate no callback AND a failed provider-check for one row; assert it transitions to owed_escalate, never silently closed or blindly re-owed" }
+  ],
+  "risks": [
+    { "risk": "Migration-apply ceremony (FR-0) depends on chairman availability/approval timing, outside engineering control", "mitigation": "FR-1 through FR-5 code can be written and unit-tested against the known STAGED schema before the live apply; only LIVE acceptance testing is blocked on FR-0 completing" },
+    { "risk": "provider_message_id history change (FR-3) could affect the existing partial unique index if implemented as a widened column rather than a separate table", "mitigation": "Prefer a separate obligation_send_attempts history table over widening the existing column, to leave idx_sms_outbound_obligations_provider_message_id untouched" },
+    { "risk": "Consolidating 3 existing quiet-window helpers (FR-4) could regress a caller relying on subtle behavioral differences between the 3 implementations", "mitigation": "Read all 3 implementations before consolidating; add regression tests pinning each existing caller's current behavior before the consolidation lands" }
+  ],
+  "system_architecture": {
+    "components": [
+      "api/webhooks/twilio-sms.js (handleTwilioStatusCallback) -- existing, unwired, no changes needed beyond FR-1 config",
+      "lib/chairman/sms-outbound-worker.js (retryOrAlert, crash-reaper, sent-timeout reaper) -- FR-2/FR-3/FR-4 target",
+      "database/migrations/20260718_sms_outbound_obligations_STAGED.sql -- FR-0 apply + status enum widen",
+      "lib/messaging/providers/twilio-provider.js -- existing, used for provider-status query in FR-2",
+      "lib/notifications/resend-adapter.js (isWithinChairmanQuietWindow) -- consolidation target for FR-4"
+    ],
+    "data_flow": "Chairman send request -> sms-bridge.js enqueueChairmanSms writes an 'owed' obligation row -> worker.js claims it atomically and sends via Twilio provider -> Twilio 201-accept stamps sent_at (not delivery) -> carrier callback (FR-1, wired) stamps delivered_at OR sent-timeout fires -> reaper provider-checks (FR-2) instead of blind re-arm -> confirmed non-delivery re-owes (respecting sleep-window release, FR-4) or escalates (FR-3 history-preserving retry / Pin#3 owed_escalate on callback+provider-check failure)."
+  },
+  "exploration_summary": "VALIDATION and Explore sub-agents (LEAD phase, this session) confirmed every file/function cited is real (no hallucinations): handleTwilioStatusCallback already built+mounted, the atomic claim already gates known callers, and the STAGED migration is genuinely unapplied. The single most valuable finding was locating the EXACT duplicate-send bug mechanism (provider_message_id overwritten on resend at worker.js:265-269) rather than treating Solomon's 'idempotency by obligation' pin as a vague restatement -- retries already reference the same obligation row; the real gap is data loss on that row during resend. F1 (callback wiring) and F5-audit (sole-authority) are both narrower/smaller than the parent proposal implied."
+}

--- a/tests/unit/chairman/sms-outbound-reconcile.test.js
+++ b/tests/unit/chairman/sms-outbound-reconcile.test.js
@@ -19,6 +19,25 @@ const ago = (ms) => new Date(Date.now() - ms).toISOString();
 //   - select(...).eq().order().limit() / .in().limit()        - update(...).eq().eq().is().select()  (atomic claim)
 //   - update(...).eq('provider_message_id',...)               (missingTables => real missing-table {data:null,error})
 // ---------------------------------------------------------------------------------------
+// SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A: minimal .or('col.eq.val,col2.cs.{val}') parser — just
+// enough to model applyOwedDeliveryTruth's provider_message_id-or-prior-history lookup, not a
+// general PostgREST filter-string parser.
+function parseOrFilter(str) {
+  return str.split(',').map((clause) => {
+    const firstDot = clause.indexOf('.');
+    const secondDot = clause.indexOf('.', firstDot + 1);
+    return { col: clause.slice(0, firstDot), op: clause.slice(firstDot + 1, secondDot), val: clause.slice(secondDot + 1) };
+  });
+}
+function matchesOrClause(row, clause) {
+  if (clause.op === 'eq') return row[clause.col] === clause.val;
+  if (clause.op === 'cs') {
+    const inner = clause.val.replace(/^\{/, '').replace(/\}$/, '');
+    return Array.isArray(row[clause.col]) && row[clause.col].includes(inner);
+  }
+  return false;
+}
+
 function makeFakeSupabase(seed = {}) {
   const tables = {
     sms_outbound_obligations: [...(seed.sms_outbound_obligations || [])],
@@ -33,13 +52,16 @@ function makeFakeSupabase(seed = {}) {
         if (op === 'eq') return row[col] === val;
         if (op === 'in') return Array.isArray(val) && val.includes(row[col]);
         if (op === 'is') return (row[col] ?? null) === val;
+        // .not(col, 'in', '(a,b)') — PostgREST literal-list format, as used by
+        // applyOwedDeliveryTruth's terminal-status exclusion guard.
+        if (op === 'not.in') return !val.replace(/^\(/, '').replace(/\)$/, '').split(',').includes(row[col]);
         return true;
       })
     );
   }
 
   function from(table) {
-    const ctx = { filters: [], order: null, limitN: null, mode: 'select', returnSelect: false, row: null, vals: null, upsertOpts: null };
+    const ctx = { filters: [], orFilters: null, order: null, limitN: null, mode: 'select', returnSelect: false, row: null, vals: null, upsertOpts: null };
     const isMissing = missing.has(table);
     const api = {
       select(_cols) { if (ctx.mode === 'update' || ctx.mode === 'insert' || ctx.mode === 'upsert') { ctx.returnSelect = true; return api; } ctx.mode = 'select'; return api; },
@@ -49,6 +71,8 @@ function makeFakeSupabase(seed = {}) {
       eq(col, val) { ctx.filters.push([col, 'eq', val]); return api; },
       in(col, arr) { ctx.filters.push([col, 'in', arr]); return api; },
       is(col, val) { ctx.filters.push([col, 'is', val]); return api; },
+      not(col, op, val) { ctx.filters.push([col, `not.${op}`, val]); return api; },
+      or(filterStr) { ctx.orFilters = parseOrFilter(filterStr); return api; },
       order(col, { ascending } = {}) { ctx.order = { col, ascending: !!ascending }; return api; },
       limit(n) { ctx.limitN = n; return api; },
       then(resolve) {
@@ -63,12 +87,14 @@ function makeFakeSupabase(seed = {}) {
           return;
         }
         if (ctx.mode === 'update') {
-          const rows = applyFilters(tables[table], ctx.filters);
+          let rows = applyFilters(tables[table], ctx.filters);
+          if (ctx.orFilters) rows = rows.filter((r) => ctx.orFilters.some((c) => matchesOrClause(r, c)));
           rows.forEach((r) => Object.assign(r, ctx.vals));
           resolve({ data: ctx.returnSelect ? rows.map((r) => ({ ...r })) : null, error: null });
           return;
         }
         let rows = applyFilters(tables[table], ctx.filters);
+        if (ctx.orFilters) rows = rows.filter((r) => ctx.orFilters.some((c) => matchesOrClause(r, c)));
         if (ctx.order) rows = [...rows].sort((a, b) => { const cmp = a[ctx.order.col] < b[ctx.order.col] ? -1 : a[ctx.order.col] > b[ctx.order.col] ? 1 : 0; return ctx.order.ascending ? cmp : -cmp; });
         if (ctx.limitN != null) rows = rows.slice(0, ctx.limitN);
         resolve({ data: rows, error: null });
@@ -82,7 +108,7 @@ function makeFakeSupabase(seed = {}) {
 const owedRow = (over = {}) => ({
   id: over.id || 'ob-1', recipient_phone: '+15551234567', kind: 'morning_review',
   decision_id: null, body: 'Good morning review. Reply to answer.', dedupe_key: null,
-  status: 'owed', provider_message_id: null, attempts: 0, not_before: null,
+  status: 'owed', provider_message_id: null, prior_provider_message_ids: [], attempts: 0, not_before: null,
   claimed_at: null, claimed_by: null, created_at: new Date().toISOString(),
   sent_at: null, delivered_at: null, last_error: null, ...over,
 });
@@ -225,11 +251,13 @@ describe('reconcileOutboundSms (FR-3)', () => {
 // =======================================================================================
 // SECURITY MEDIUM-2 — sent-no-callback delivery-timeout reconcile
 // =======================================================================================
-describe('sent-no-callback delivery-timeout (MEDIUM-2)', () => {
-  it('a sent row older than the timeout with delivered_at NULL is reconciled (re-armed under cap)', async () => {
+describe('sent-no-callback delivery-timeout (MEDIUM-2 / FR-2 provider-check)', () => {
+  it('a sent row older than the timeout, PROVIDER-CONFIRMS undelivered, is reconciled (re-armed under cap)', async () => {
     const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 0, provider_message_id: 'SM-old', sent_at: ago(20 * MIN), delivered_at: null })] });
-    const provider = okProvider();
+    const checkMessageStatus = vi.fn(async () => ({ status: 'undelivered' }));
+    const provider = { ...okProvider(), checkMessageStatus };
     const summary = await reconcileOutboundSms(sb, { provider, sentDeliveryTimeoutMs: 15 * MIN });
+    expect(checkMessageStatus).toHaveBeenCalledWith('SM-old'); // FR-2: never blind — always queries the provider first
     expect(summary.sentTimedOut).toBe(1);
     // re-armed to owed, then re-sent by the send pass in the same run (bounded retry)
     expect(provider.send).toHaveBeenCalledTimes(1);
@@ -237,24 +265,62 @@ describe('sent-no-callback delivery-timeout (MEDIUM-2)', () => {
     expect(sb._tables.sms_outbound_obligations[0].delivered_at).toBeNull(); // still never DELIVERED (201 != delivered)
   });
 
-  it('a sent row WITHIN the timeout is left alone (still awaiting a legitimate callback)', async () => {
+  it('a sent row WITHIN the timeout is left alone (still awaiting a legitimate callback, provider never queried)', async () => {
     const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 0, provider_message_id: 'SM-fresh', sent_at: ago(5 * MIN), delivered_at: null })] });
-    const provider = okProvider();
+    const checkMessageStatus = vi.fn(async () => ({ status: 'undelivered' }));
+    const provider = { ...okProvider(), checkMessageStatus };
     const summary = await reconcileOutboundSms(sb, { provider, sentDeliveryTimeoutMs: 15 * MIN });
     expect(summary.sentTimedOut).toBe(0);
+    expect(checkMessageStatus).not.toHaveBeenCalled();
     expect(provider.send).not.toHaveBeenCalled();
     expect(sb._tables.sms_outbound_obligations[0].status).toBe('sent');
   });
 
-  it('a sent row AT the cap alerts + goes terminal failed (not re-sent)', async () => {
+  it('a sent row AT the cap, PROVIDER-CONFIRMS undelivered, alerts + goes terminal failed (not re-sent)', async () => {
     const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 3, provider_message_id: 'SM-cap', sent_at: ago(30 * MIN), delivered_at: null })] });
-    const provider = okProvider();
+    const checkMessageStatus = vi.fn(async () => ({ status: 'undelivered' }));
+    const provider = { ...okProvider(), checkMessageStatus };
     const alert = vi.fn();
     const summary = await reconcileOutboundSms(sb, { provider, maxAttempts: 3, sentDeliveryTimeoutMs: 15 * MIN, alert });
     expect(alert).toHaveBeenCalledTimes(1);
     expect(provider.send).not.toHaveBeenCalled();
     expect(summary.alerted).toBe(1);
     expect(sb._tables.sms_outbound_obligations[0].status).toBe('failed');
+  });
+
+  it('FR-2: provider CONFIRMS delivered — stamps delivered_at directly, never re-owed/re-sent', async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 0, provider_message_id: 'SM-late-deliver', sent_at: ago(20 * MIN), delivered_at: null })] });
+    const checkMessageStatus = vi.fn(async () => ({ status: 'delivered' }));
+    const provider = { ...okProvider(), checkMessageStatus };
+    const summary = await reconcileOutboundSms(sb, { provider, sentDeliveryTimeoutMs: 15 * MIN });
+    expect(summary.confirmedDelivered).toBe(1);
+    expect(provider.send).not.toHaveBeenCalled(); // the callback was just lost/late — never a duplicate send
+    const row = sb._tables.sms_outbound_obligations[0];
+    expect(row.status).toBe('delivered');
+    expect(row.delivered_at).toBeTruthy();
+  });
+
+  it('Solomon Pin #3: the provider-check ITSELF failing (no callback AND a failed check) escalates to owed_escalate, never silently closed', async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 0, provider_message_id: 'SM-check-fails', sent_at: ago(20 * MIN), delivered_at: null })] });
+    const checkMessageStatus = vi.fn(async () => { throw new Error('twilio_status_check_http_500'); });
+    const provider = { ...okProvider(), checkMessageStatus };
+    const alert = vi.fn();
+    const summary = await reconcileOutboundSms(sb, { provider, sentDeliveryTimeoutMs: 15 * MIN, alert });
+    expect(summary.escalated).toBe(1);
+    expect(alert).toHaveBeenCalledTimes(1); // never SILENTLY closed
+    expect(provider.send).not.toHaveBeenCalled();
+    const row = sb._tables.sms_outbound_obligations[0];
+    expect(row.status).toBe('owed_escalate');
+    expect(row.last_error).toMatch(/provider_check_failed/);
+  });
+
+  it('Solomon Pin #3: an ambiguous (non-terminal) provider-check answer despite our own timeout also escalates', async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'sent', attempts: 0, provider_message_id: 'SM-ambiguous', sent_at: ago(20 * MIN), delivered_at: null })] });
+    const checkMessageStatus = vi.fn(async () => ({ status: 'queued' })); // Twilio itself says non-terminal
+    const provider = { ...okProvider(), checkMessageStatus };
+    const summary = await reconcileOutboundSms(sb, { provider, sentDeliveryTimeoutMs: 15 * MIN });
+    expect(summary.escalated).toBe(1);
+    expect(sb._tables.sms_outbound_obligations[0].status).toBe('owed_escalate');
   });
 });
 
@@ -372,6 +438,162 @@ describe('handleTwilioStatusCallback delivery-truth (FR-2)', () => {
     const row = sb._tables.sms_outbound_obligations[0];
     expect(row.delivered_at).toBeNull();
     expect(row.status).toBe('sent');
+  });
+});
+
+// =======================================================================================
+// Solomon Pin #2 — duplicate-send history preservation across a resend
+// =======================================================================================
+describe('resend preserves provider_message_id history (Solomon Pin #2)', () => {
+  it('a resend PRESERVES the prior SID in prior_provider_message_ids instead of overwriting it', async () => {
+    // Row already carries a prior SID (from a first send) and is back to 'owed' (re-armed).
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'owed', attempts: 1, provider_message_id: 'SM-FIRST', prior_provider_message_ids: [] })] });
+    const provider = { send: vi.fn(async () => ({ provider_message_id: 'SM-SECOND', status: 'queued' })) };
+    await reconcileOutboundSms(sb, { provider });
+    const row = sb._tables.sms_outbound_obligations[0];
+    expect(row.provider_message_id).toBe('SM-SECOND');
+    expect(row.prior_provider_message_ids).toContain('SM-FIRST'); // the old SID is NOT lost
+  });
+
+  it('a late callback for the ORIGINAL (pre-resend) SID still resolves against the row (Pin #2 acceptance) instead of silently no-op-ing', async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [
+      owedRow({ id: 'ob-history', status: 'sent', provider_message_id: 'SM-SECOND', prior_provider_message_ids: ['SM-FIRST'] }),
+    ] });
+    const res = makeRes();
+    process.env.TWILIO_STATUS_CALLBACK_URL = 'https://engineer.example.com/api/webhooks/twilio-status';
+    // A callback arrives for SM-FIRST (the ORIGINAL send) — pre-fix this matches ZERO rows and
+    // silently no-ops, even though the row it belongs to still exists and needs delivery-truth.
+    await handleTwilioStatusCallback(
+      { method: 'POST', headers: { 'x-twilio-signature': 'sig' }, body: { MessageStatus: 'delivered' }, protocol: 'https', get: () => 'host', originalUrl: '/x' },
+      res,
+      { supabase: sb, provider: { verifyInboundSignature: () => true, parseStatusCallback: () => ({ messageSid: 'SM-FIRST', status: 'delivered' }) } },
+    );
+    const row = sb._tables.sms_outbound_obligations.find((r) => r.id === 'ob-history');
+    expect(row.status).toBe('delivered'); // resolved, NOT a silent no-op
+    expect(row.delivered_at).toBeTruthy();
+  });
+
+  it("adversarial-review finding (SECURITY, EXEC-TO-PLAN): a callback for a PRIOR sid that lands mid-resend wins — the in-flight resend's own completion never clobbers it back to 'sent'", async () => {
+    // The row is 'sending' (mid-resend, claimed) and already carries a prior SID from the send
+    // this resend is superseding. A late callback for that prior SID arrives WHILE the resend is
+    // still in flight (before its own completion write runs) and correctly stamps 'delivered'.
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [
+      owedRow({ id: 'ob-race', status: 'sending', provider_message_id: 'SM-FIRST', prior_provider_message_ids: [], claimed_at: new Date().toISOString(), claimed_by: 'worker-race' }),
+    ] });
+    process.env.TWILIO_STATUS_CALLBACK_URL = 'https://engineer.example.com/api/webhooks/twilio-status';
+    await handleTwilioStatusCallback(
+      { method: 'POST', headers: { 'x-twilio-signature': 'sig' }, body: { MessageStatus: 'delivered' }, protocol: 'https', get: () => 'host', originalUrl: '/x' },
+      makeRes(),
+      { supabase: sb, provider: { verifyInboundSignature: () => true, parseStatusCallback: () => ({ messageSid: 'SM-FIRST', status: 'delivered' }) } },
+    );
+    expect(sb._tables.sms_outbound_obligations[0].status).toBe('delivered'); // callback landed first
+
+    // The resend's own claim-holder (an in-progress reconcileOutboundSms Pass 2 iteration) now
+    // tries to write its completion — pre-fix this unconditionally overwrote status back to
+    // 'sent'. Simulate it directly against the SAME row state, mirroring the exact update shape
+    // Pass 2 issues (status guard included).
+    await sb.from('sms_outbound_obligations')
+      .update({ status: 'sent', provider_message_id: 'SM-SECOND', prior_provider_message_ids: ['SM-FIRST'], sent_at: new Date().toISOString(), attempts: 2 })
+      .eq('id', 'ob-race')
+      .eq('status', 'sending'); // guard: only applies while still 'sending' — no longer true
+
+    const row = sb._tables.sms_outbound_obligations[0];
+    expect(row.status).toBe('delivered'); // NOT clobbered back to 'sent'
+    expect(row.provider_message_id).toBe('SM-FIRST'); // the resend's completion never applied
+  });
+
+  it('kill-mid-retry/restart acceptance: two full reconcile passes against the same persisted state never duplicate a send beyond the claim/retry contract', async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'owed' })] });
+    const provider = { send: vi.fn(async () => ({ provider_message_id: `SM-${sb._tables.sms_outbound_obligations[0].attempts}`, status: 'queued' })) };
+    // First "process" — send #1, then a crash is simulated by nothing further happening.
+    await reconcileOutboundSms(sb, { provider });
+    expect(provider.send).toHaveBeenCalledTimes(1);
+    // "Restart": a fresh reconcile pass against the SAME (already 'sent', undelivered) state.
+    // Since the row is 'sent' (not 'owed') and still within the sent-delivery timeout, the
+    // fresh pass must NOT re-send it — the claim+status contract alone prevents the duplicate.
+    await reconcileOutboundSms(sb, { provider });
+    expect(provider.send).toHaveBeenCalledTimes(1); // still exactly one send after "restart"
+  });
+});
+
+// =======================================================================================
+// Solomon Pin #1 — sleep-window enforcement AT RELEASE time (not just at enqueue)
+// =======================================================================================
+describe('sleep-window at retry-release (Solomon Pin #1)', () => {
+  it('a retry re-armed INSIDE the 10PM-6AM ET window is held with not_before set to the next 6AM ET release, not fired immediately', async () => {
+    // 2026-01-15 is not a DST edge; 11:58 PM ET = 04:58 UTC the next day.
+    const insideWindow = new Date('2026-01-16T04:58:00.000Z'); // 11:58 PM ET on 2026-01-15
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'undelivered', attempts: 1 })] });
+    const provider = okProvider();
+    await reconcileOutboundSms(sb, { provider, maxAttempts: 3, now: insideWindow.getTime() });
+    const row = sb._tables.sms_outbound_obligations[0];
+    // Re-armed to 'owed' with a future not_before means Pass 2's claimable filter excludes it —
+    // it must NOT have been sent in this same pass despite being under the retry cap.
+    expect(provider.send).not.toHaveBeenCalled();
+    expect(row.status).toBe('owed');
+    expect(row.not_before).toBeTruthy();
+    expect(new Date(row.not_before).getTime()).toBeGreaterThan(insideWindow.getTime());
+  });
+
+  it('a retry re-armed OUTSIDE the 10PM-6AM ET window is released immediately (not_before cleared) and resent in the same pass', async () => {
+    const outsideWindow = new Date('2026-01-15T15:00:00.000Z'); // ~10 AM ET
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [owedRow({ status: 'undelivered', attempts: 1 })] });
+    const provider = okProvider();
+    await reconcileOutboundSms(sb, { provider, maxAttempts: 3, now: outsideWindow.getTime() });
+    expect(provider.send).toHaveBeenCalledTimes(1); // re-armed then resent in the same pass
+    const row = sb._tables.sms_outbound_obligations[0];
+    expect(row.status).toBe('sent');
+  });
+});
+
+// =======================================================================================
+// FR-5 — owed-state sole-send-authority audit (durable, re-checked — not a one-time PR note)
+// =======================================================================================
+describe('owed-state sole-send-authority: no bypass call sites (FR-5 audit)', () => {
+  it('the ONLY direct provider.send()/twilioProvider.send() call sites are the two sanctioned ones', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const url = await import('url');
+    const dir = path.dirname(url.fileURLToPath(import.meta.url));
+    const repoRoot = path.join(dir, '..', '..', '..');
+    const CALL_RE = /\b(?:provider|twilioProvider)\.send\s*\(/;
+    // Sanctioned: worker.js's atomic-claim-gated Pass 2 send, and sms-bridge.js's documented
+    // STAGED-table-absent pre-apply fallback (dead code once FR-0's migration is applied).
+    const SANCTIONED = new Set([
+      path.join('lib', 'chairman', 'sms-outbound-worker.js'),
+      path.join('lib', 'chairman', 'sms-bridge.js'),
+    ]);
+
+    function walk(dirPath, out) {
+      for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        const full = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) walk(full, out);
+        else if (/\.(js|mjs|cjs)$/.test(entry.name)) out.push(full);
+      }
+    }
+
+    // Strip comment-only lines (block-comment '*' continuations and '//' lines) so a PROSE
+    // mention of "provider.send(" in a docstring doesn't false-positive as a real call site.
+    function codeLines(src) {
+      return src.split('\n').filter((line) => !/^\s*(\*|\/\/)/.test(line));
+    }
+
+    const offenders = [];
+    for (const dirName of ['lib', 'scripts', 'api']) {
+      const abs = path.join(repoRoot, dirName);
+      if (!fs.existsSync(abs)) continue;
+      const files = [];
+      walk(abs, files);
+      for (const file of files) {
+        if (/[\\/](tests?|one-off)[\\/]/.test(file) || file.endsWith('.test.js')) continue;
+        const rel = path.relative(repoRoot, file);
+        if (SANCTIONED.has(rel)) continue;
+        const src = codeLines(fs.readFileSync(file, 'utf8')).join('\n');
+        if (CALL_RE.test(src)) offenders.push(rel);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/tests/unit/chairman/sms-outbound-reconcile.test.js
+++ b/tests/unit/chairman/sms-outbound-reconcile.test.js
@@ -473,6 +473,38 @@ describe('resend preserves provider_message_id history (Solomon Pin #2)', () => 
     expect(row.delivered_at).toBeTruthy();
   });
 
+  it("adversarial-review finding: a stale/superseded SID's late 'undelivered' callback must NOT flip a row whose CURRENT (newer) attempt is still unresolved", async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [
+      owedRow({ id: 'ob-superseded', status: 'sent', provider_message_id: 'SM-SECOND', prior_provider_message_ids: ['SM-FIRST'] }),
+    ] });
+    process.env.TWILIO_STATUS_CALLBACK_URL = 'https://engineer.example.com/api/webhooks/twilio-status';
+    // A late callback arrives for SM-FIRST (the SUPERSEDED attempt) reporting undelivered. This
+    // tells us nothing about SM-SECOND (the current, still-unresolved attempt) — it must NOT
+    // terminate the row.
+    await handleTwilioStatusCallback(
+      { method: 'POST', headers: { 'x-twilio-signature': 'sig' }, body: { MessageStatus: 'undelivered' }, protocol: 'https', get: () => 'host', originalUrl: '/x' },
+      makeRes(),
+      { supabase: sb, provider: { verifyInboundSignature: () => true, parseStatusCallback: () => ({ messageSid: 'SM-FIRST', status: 'undelivered' }) } },
+    );
+    const row = sb._tables.sms_outbound_obligations.find((r) => r.id === 'ob-superseded');
+    expect(row.status).toBe('sent'); // untouched — still tracking the current attempt
+  });
+
+  it("a 'delivered' callback for the current SID still applies normally (unaffected by the prior-SID scoping change)", async () => {
+    const sb = makeFakeSupabase({ sms_outbound_obligations: [
+      owedRow({ id: 'ob-current', status: 'sent', provider_message_id: 'SM-SECOND', prior_provider_message_ids: ['SM-FIRST'] }),
+    ] });
+    process.env.TWILIO_STATUS_CALLBACK_URL = 'https://engineer.example.com/api/webhooks/twilio-status';
+    await handleTwilioStatusCallback(
+      { method: 'POST', headers: { 'x-twilio-signature': 'sig' }, body: { MessageStatus: 'delivered' }, protocol: 'https', get: () => 'host', originalUrl: '/x' },
+      makeRes(),
+      { supabase: sb, provider: { verifyInboundSignature: () => true, parseStatusCallback: () => ({ messageSid: 'SM-SECOND', status: 'delivered' }) } },
+    );
+    const row = sb._tables.sms_outbound_obligations.find((r) => r.id === 'ob-current');
+    expect(row.status).toBe('delivered');
+    expect(row.delivered_at).toBeTruthy();
+  });
+
   it("adversarial-review finding (SECURITY, EXEC-TO-PLAN): a callback for a PRIOR sid that lands mid-resend wins — the in-flight resend's own completion never clobbers it back to 'sent'", async () => {
     // The row is 'sending' (mid-resend, claimed) and already carries a prior SID from the send
     // this resend is superseding. A late callback for that prior SID arrives WHILE the resend is

--- a/tests/unit/messaging/twilio-provider-mediaurl.test.js
+++ b/tests/unit/messaging/twilio-provider-mediaurl.test.js
@@ -4,7 +4,7 @@
  * recon) -- this is the first direct unit test of send()'s form-body construction.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { send } from '../../../lib/messaging/providers/twilio-provider.js';
+import { send, checkMessageStatus } from '../../../lib/messaging/providers/twilio-provider.js';
 
 describe('twilio-provider send() MediaUrl (FR-3)', () => {
   const originalEnv = { ...process.env };
@@ -47,5 +47,47 @@ describe('twilio-provider send() MediaUrl (FR-3)', () => {
     expect(params.get('To')).toBe('+15551234567');
     expect(params.get('Body')).toBe('hi');
     expect(params.get('MessagingServiceSid')).toBe('MG_test');
+  });
+});
+
+describe('twilio-provider checkMessageStatus (SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A FR-2)', () => {
+  const originalEnv = { ...process.env };
+  let fetchMock;
+
+  beforeEach(() => {
+    process.env.TWILIO_ACCOUNT_SID = 'AC_test';
+    process.env.TWILIO_AUTH_TOKEN = 'token_test';
+  });
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the real status on a successful GET', async () => {
+    fetchMock = vi.fn(async (url) => {
+      expect(url).toBe('https://api.twilio.com/2010-04-01/Accounts/AC_test/Messages/SM123.json');
+      return { ok: true, json: async () => ({ status: 'delivered' }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await checkMessageStatus('SM123');
+    expect(result).toEqual({ status: 'delivered' });
+  });
+
+  it('throws when Twilio credentials are not configured (fail closed, never guesses)', async () => {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    delete process.env.TWILIO_AUTH_TOKEN;
+    await expect(checkMessageStatus('SM123')).rejects.toThrow('twilio_not_configured');
+  });
+
+  it('throws on a non-OK HTTP response instead of returning a guessed status', async () => {
+    fetchMock = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(checkMessageStatus('SM123')).rejects.toThrow('twilio_status_check_http_500');
+  });
+
+  it('throws on a malformed response body instead of silently resolving', async () => {
+    fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) })); // no `status` field
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(checkMessageStatus('SM123')).rejects.toThrow('twilio_status_check_malformed_response');
   });
 });

--- a/tests/unit/time/chairman-et-wall-clock.test.js
+++ b/tests/unit/time/chairman-et-wall-clock.test.js
@@ -1,0 +1,46 @@
+/**
+ * SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-A — canonical ET wall-clock helpers (FR-4 consolidation
+ * target: previously 3 ad-hoc quiet-window implementations, none gating the SMS retry-release
+ * point). Pins the 10PM-6AM ET boundary and the midnight-rollover fix in smsQuietWindowReleaseIso.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSmsQuietHour, smsQuietWindowReleaseIso, etLocalHour, et6amIso } from '../../../lib/time/chairman-et-wall-clock.js';
+
+describe('isSmsQuietHour — 10PM-6AM ET boundary', () => {
+  it('21:59 ET is NOT quiet (just before the window)', () => {
+    expect(isSmsQuietHour(new Date('2026-01-16T02:59:00.000Z'))).toBe(false); // 21:59 ET (UTC-5)
+  });
+  it('22:00 ET IS quiet (window start)', () => {
+    expect(isSmsQuietHour(new Date('2026-01-16T03:00:00.000Z'))).toBe(true); // 22:00 ET
+  });
+  it('05:59 ET IS quiet (just before window end)', () => {
+    expect(isSmsQuietHour(new Date('2026-01-16T10:59:00.000Z'))).toBe(true); // 05:59 ET
+  });
+  it('06:00 ET is NOT quiet (window end)', () => {
+    expect(isSmsQuietHour(new Date('2026-01-16T11:00:00.000Z'))).toBe(false); // 06:00 ET
+  });
+  it('midday ET is NOT quiet', () => {
+    expect(isSmsQuietHour(new Date('2026-01-16T18:00:00.000Z'))).toBe(false); // 13:00 ET
+  });
+});
+
+describe('smsQuietWindowReleaseIso — Solomon Pin #1 (sleep-window AT release, midnight rollover)', () => {
+  it('outside the window returns null (immediate release)', () => {
+    expect(smsQuietWindowReleaseIso(new Date('2026-01-16T18:00:00.000Z'))).toBeNull();
+  });
+
+  it('BEFORE midnight (e.g. 11:58 PM ET) rolls over to TOMORROW\'s 6AM ET, not a past instant', () => {
+    const now = new Date('2026-01-16T04:58:00.000Z'); // 23:58 ET on 2026-01-15
+    const releaseIso = smsQuietWindowReleaseIso(now);
+    expect(releaseIso).toBeTruthy();
+    expect(new Date(releaseIso).getTime()).toBeGreaterThan(now.getTime()); // must be in the FUTURE
+    expect(etLocalHour(new Date(releaseIso))).toBe(6);
+  });
+
+  it('AFTER midnight (e.g. 2:00 AM ET) uses the SAME calendar day\'s 6AM (still upcoming)', () => {
+    const now = new Date('2026-01-16T07:00:00.000Z'); // 02:00 ET on 2026-01-16
+    const releaseIso = smsQuietWindowReleaseIso(now);
+    expect(releaseIso).toBe(et6amIso(now)); // same-day 6AM is correct here — no rollover needed
+    expect(new Date(releaseIso).getTime()).toBeGreaterThan(now.getTime());
+  });
+});


### PR DESCRIPTION
## Summary
- **FR-0**: Adds `owed_escalate` status + `prior_provider_message_ids` column to the STAGED (still-unapplied, chairman-gated) `sms_outbound_obligations` migration.
- **FR-2**: Sent-timeout reaper now queries Twilio directly by `provider_message_id` (`twilio-provider.js` `checkMessageStatus`) instead of blindly re-arming. Confirmed-delivered stamps `delivered_at` directly; confirmed non-delivery takes the normal bounded retry path; a failed/ambiguous provider-check escalates to `owed_escalate` (Solomon Pin #3) — never silently closed.
- **FR-3**: Fixes the concrete duplicate-send bug — `provider_message_id` was silently overwritten on resend, orphaning the prior SID so a late callback for it matched zero rows and no-opped even on a real late delivery (the actual mechanism behind the live 7-duplicate incident). Prior SIDs now preserved in `prior_provider_message_ids` and matched by the webhook lookup (Solomon Pin #2).
- **FR-4**: Consolidates 3 ad-hoc quiet-window implementations into a single canonical `lib/time/chairman-et-wall-clock.js` module; enforces the 10PM-6AM ET sleep window at retry-**release** time, not just enqueue (Solomon Pin #1) — including the midnight-rollover edge case.
- **FR-5**: Durable grep-pin test asserting the atomic send-claim has no bypass call sites (found zero; the one direct call outside the worker is a documented pre-apply fallback).
- **Security fix (found + fixed during adversarial EXEC-TO-PLAN review)**: added status guards to both the webhook's delivery-truth update and the worker's Pass-2 send-outcome update, closing a race where a late callback for a prior SID could be clobbered by a concurrent in-flight resend's own completion write.

## Test plan
- [x] 50 new/extended unit tests, all passing (`tests/unit/chairman/sms-outbound-reconcile.test.js`, `tests/unit/time/chairman-et-wall-clock.test.js`, `tests/unit/messaging/twilio-provider-mediaurl.test.js`)
- [x] Full unit suite: 2474/2476 passed (2 pre-existing, confirmed-unrelated failures from a different already-shipped SD)
- [x] Full gate chain: LEAD-TO-PLAN 94, PLAN-TO-EXEC 100, EXEC-TO-PLAN 95, PLAN-TO-LEAD 97

🤖 Generated with [Claude Code](https://claude.com/claude-code)