### PR TITLE
fix(QF-20260719-720): durable STANDARD_LOOPS advisory-drain + silent-holder-audit + shared-root-freshness

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -258,6 +258,20 @@ export const STANDARD_LOOPS = [
   { key: 'gauge-runner', label: 'Invariant-gauges execution surface (hourly, durable)', script: 'gauge-runner.mjs', cron: '0 * * * *',
     gha_backed: true,
     prompt: 'node scripts/gauge-runner.mjs --json' },
+  // QF-20260719-720 (operator directive: duty adherence must be schedule-driven, not memory-driven):
+  // three duties proven necessary by 2026-07-19 live incidents existed only as the incumbent
+  // coordinator's session crons (f9382bc7/8d60db23/ea868bfd) — the exact session-fragility class
+  // fixed for roles-review (QF-272) and gauge-runner (QF-563). Durably encoded here so every
+  // coordinator startup re-arms them. Idempotency: advisory-drain acts per-item with per-item
+  // actioned_at acks (an extra run finds nothing unactioned); silent-holder-audit skips holders
+  // already carrying an unanswered status request; shared-root-freshness's pull is a no-op on an
+  // up-to-date tree.
+  { key: 'advisory-drain', label: 'Adam-advisory drain — ACT + per-item ack (the QF-298 gauge is the counter; this is the acting half)', script: 'read-adam-advisories.cjs', cron: '6,16,26,36,46,56 * * * *',
+    prompt: 'Run `node scripts/read-adam-advisories.cjs`. For EACH unactioned advisory listed: ACTION it per its kind (route/decide/reply — never lean-filter advisories) and ack it PER-ITEM (actioned_at) — never bulk-ack. If none are listed this is a NO-OP. Incident basis: 14 advisories incl a chairman decision sat unactioned ~2.5h while every tick read clean.' },
+  { key: 'silent-holder-audit', label: 'Silent-claim-holder audit — status-or-release on >3h no-signal with no work product', script: null, cron: '23 * * * *',
+    prompt: 'Silent-holder audit: list fleet workers currently holding an sd_key claim. For each holder with >3h since their last /signal AND no work product in that window (no PR, no commits on the claim branch — WORK PRODUCT is the discriminator, never loop_state/started_at), send a status-or-release coordinator_request via the dispatch choke — unless that holder already has an unanswered status request pending (skip, no re-nudge). Release decisions stay with the sweep; this loop only asks.' },
+  { key: 'shared-root-freshness', label: 'Shared-root freshness — pull when clean main is behind origin (remediation half of the stale-tree gauge)', script: null, cron: '51 */2 * * *',
+    prompt: 'Shared-root freshness: in the SHARED ROOT (never a worktree), if `git status --porcelain` is clean AND the branch is main AND `git fetch origin && git rev-list --count HEAD..origin/main` > 0, run `git pull --ff-only`. If the tree is dirty or not on main, REPORT the state instead of pulling (another session may be mid-work). The stale-tree gauge detects; this loop remediates.' },
   // QF-20260704-493: feedback-consumption SLA gauge daily reminder (Solomon referent-audit
   // cell [4]) — actionable feedback categories (adam_adherence_drift, completion_flag,
   // coordinator_review, harness_backlog escalations) had no consumption deadline. Internally


### PR DESCRIPTION
Operator directive 2026-07-19: duty adherence must be schedule-driven, not
memory-driven. Three coordinator duties proven necessary by live incidents
existed only as the incumbent session's crons (f9382bc7/8d60db23/ea868bfd) and
die with the session — the same fragility class fixed for roles-review
(QF-272) and gauge-runner (QF-563):

- advisory-drain (:6/10min): ACT + per-item ack on read-adam-advisories.cjs
  output (incident: 14 advisories incl a chairman decision unactioned ~2.5h;
  QF-298 added the counter, acting was prompt-carried)
- silent-holder-audit (:23 hourly): status-or-release coordinator_request for
  >3h no-signal holders with NO work product (PR/commits are the
  discriminator, never loop_state) — skip if a status ask is already pending
- shared-root-freshness (:51/2h): ff-only pull when clean main is behind
  origin; report instead when dirty/not-main (gauge detects, this remediates)

All three idempotent per the registry's double-fire discipline. 66/66
registry/parity suites green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
