### PR TITLE
fix(QF-20260719-365): stamp dispatch reason-band at rank time (honest KPI-2 coverage)

### DIFF
--- a/lib/oversight/coordinator-health-sharpenings.mjs
+++ b/lib/oversight/coordinator-health-sharpenings.mjs
@@ -133,6 +133,19 @@ export async function computeOutcomeFlow(supabase, { nowMs = Date.now(), windowD
 export function classifyDispatchReason(row) {
   const key = row?.sd_key || '';
   const md = row?.metadata || {};
+  // QF-20260719-365: the coordinator now stamps metadata.dispatch_reason_band at RANK time
+  // (coordinator-backlog-rank.mjs deriveReasonBand), so worker self-claims inherit it. The
+  // stamp is AUTHORITATIVE when present; the heuristics below remain the fallback for
+  // pre-stamp rows (coverage read 3.4% dishonestly because ~95% of claims are self-claims
+  // with no per-claim dispatch row — nothing for the heuristics to find).
+  const stampMap = {
+    'chairman-directed': 'chairman_directed',
+    feedback: 'feedback',
+    incident: 'incident',
+    'now-wave-remainder': 'now_wave_remainder',
+  };
+  const stamped = stampMap[String(md.dispatch_reason_band || '')];
+  if (stamped) return stamped;
   if (md.chairman_directed === true || md.directed_assignment === true || /chairman/i.test(String(md.sourced_by || ''))) return 'chairman_directed';
   if (/^SD-FDBK-/.test(key) || String(md.source || '').includes('feedback')) return 'feedback';
   if (/-FIX-|^QF-/.test(key) || /remediation|incident/i.test(String(md.source || ''))) return 'incident';
@@ -148,11 +161,26 @@ export function classifyDispatchReason(row) {
 /** S3 pure: shares per reason-code over a cohort. */
 export function deriveDispatchReasons(sdRows) {
   const counts = { chairman_directed: 0, feedback: 0, incident: 0, now_wave_remainder: 0, other: 0 };
-  for (const r of sdRows || []) counts[classifyDispatchReason(r)]++;
+  // QF-20260719-365: honest-coverage accounting — how many rows carry the authoritative
+  // rank-time stamp, partitioned into coordinator-direct dispatches (directed_assignment
+  // marker) vs worker self-claims (the ~95% majority the old coverage could not see).
+  let stamped = 0, directDispatch = 0, selfClaim = 0;
+  for (const r of sdRows || []) {
+    counts[classifyDispatchReason(r)]++;
+    if (r?.metadata?.dispatch_reason_band) {
+      stamped++;
+      if (r.metadata.directed_assignment === true) directDispatch++;
+      else selfClaim++;
+    }
+  }
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
   const distribution = {};
   for (const [k, v] of Object.entries(counts)) distribution[k] = total ? v / total : 0;
-  return { total, counts, distribution };
+  return {
+    total, counts, distribution,
+    stamped, stamped_coverage: total ? stamped / total : 0,
+    partition: { direct_dispatch: directDispatch, self_claim: selfClaim },
+  };
 }
 
 /** S3 pure: band check. Alarms only with a real cohort (insufficient-n never alarms). */

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -127,8 +127,28 @@ export function productPivotCompare(a, b) {
 }
 // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: pure helpers for the atomic JSONB merge
 // write path. Extracted so the query shape is unit-testable without a live pg connection.
-export function buildRankPatch(rank, nowIso, sessionId) {
-  return { dispatch_rank: rank, dispatch_rank_at: nowIso, dispatch_rank_by: sessionId };
+export function buildRankPatch(rank, nowIso, sessionId, reasonBand = null) {
+  const patch = { dispatch_rank: rank, dispatch_rank_at: nowIso, dispatch_rank_by: sessionId };
+  // QF-20260719-365: stamp the dispatch reason-band AT RANK TIME so worker SELF-claims
+  // inherit it (KPI-2 plan-adherence read 3.4% dishonestly because ~95% of claims are
+  // self-claims where the coordinator's dispatch decision IS the rank — there was no
+  // per-claim dispatch row to carry a band). Deliberately NOT removed by
+  // buildRankClearQuery: the band records why the SD was put on the belt and must
+  // SURVIVE the claim (rank fields clear on claim; the band persists for the probe).
+  if (reasonBand) patch.dispatch_reason_band = reasonBand;
+  return patch;
+}
+// QF-20260719-365: derive the dispatch reason-band from SD provenance. Pure; the vocabulary
+// is the KPI-2 contract set: chairman-directed | feedback | incident | now-wave-remainder.
+export function deriveReasonBand(d) {
+  const m = (d && d.metadata) || {};
+  const prov = [m.provenance, m.source, m.sourced_by, m.created_via, m.gold_origin, m.proposal_provenance]
+    .filter(Boolean).join(' ').toLowerCase();
+  if (prov.includes('chairman')) return 'chairman-directed';
+  if (/^SD-FDBK-/.test((d && d.sd_key) || '') || m.source === 'feedback'
+    || /\bfeedback\b|from-feedback|from-qf|qf-promoted|quick.?fix/.test(prov)) return 'feedback';
+  if (/incident|\brca\b|corrective|postmortem/.test(prov)) return 'incident';
+  return 'now-wave-remainder';
 }
 export function buildRankMergeQuery(rankPatch, sdKey) {
   // Adversarial review (ship gate): NULL::jsonb || '{...}'::jsonb evaluates to NULL in Postgres —
@@ -505,7 +525,7 @@ async function main() {
     const rank = i + 1;
     console.log(`  #${String(rank).padStart(2)}  unlocks=${String(unlockScore(d.sd_key)).padStart(2)}  ${String(d.priority || '-').padEnd(8)} ${d.sd_key}`);
     if (DRY) continue;
-    const rankPatch = buildRankPatch(rank, now, process.env.CLAUDE_SESSION_ID || 'coordinator');
+    const rankPatch = buildRankPatch(rank, now, process.env.CLAUDE_SESSION_ID || 'coordinator', deriveReasonBand(d));
     try {
       if (pgClient) {
         const { sql, params } = buildRankMergeQuery(rankPatch, d.sd_key);

--- a/tests/unit/oversight/coordinator-health-sharpenings.test.js
+++ b/tests/unit/oversight/coordinator-health-sharpenings.test.js
@@ -130,3 +130,30 @@ describe('S2 FALSE_COMPLETION sampler', () => {
     expect(r.samples[0].unverifiable).toBe(true);
   });
 });
+
+describe('QF-20260719-365 — rank-time reason-band stamp is authoritative', () => {
+  it('classifyDispatchReason prefers the stamp over heuristics', () => {
+    expect(classifyDispatchReason({ sd_key: 'SD-FDBK-X-001', metadata: { dispatch_reason_band: 'incident' } })).toBe('incident');
+    expect(classifyDispatchReason({ sd_key: 'SD-PLAIN-001', metadata: { dispatch_reason_band: 'now-wave-remainder' } })).toBe('now_wave_remainder');
+    expect(classifyDispatchReason({ sd_key: 'SD-PLAIN-001', metadata: { dispatch_reason_band: 'chairman-directed' } })).toBe('chairman_directed');
+  });
+
+  it('falls back to heuristics when unstamped or the stamp is unknown vocabulary', () => {
+    expect(classifyDispatchReason({ sd_key: 'SD-FDBK-X-001', metadata: {} })).toBe('feedback');
+    expect(classifyDispatchReason({ sd_key: 'SD-PLAIN-001', metadata: { dispatch_reason_band: 'bogus' } })).toBe('other');
+  });
+
+  it('deriveDispatchReasons reports stamped coverage + direct-dispatch/self-claim partition', () => {
+    const rows = [
+      { sd_key: 'SD-A-001', metadata: { dispatch_reason_band: 'feedback' } },                              // self-claim
+      { sd_key: 'SD-B-001', metadata: { dispatch_reason_band: 'chairman-directed', directed_assignment: true } }, // direct
+      { sd_key: 'SD-C-001', metadata: {} },                                                                // unstamped
+    ];
+    const r = deriveDispatchReasons(rows);
+    expect(r.stamped).toBe(2);
+    expect(r.stamped_coverage).toBeCloseTo(2 / 3);
+    expect(r.partition).toEqual({ direct_dispatch: 1, self_claim: 1 });
+    expect(r.counts.feedback).toBe(1);
+    expect(r.counts.chairman_directed).toBe(1);
+  });
+});


### PR DESCRIPTION
Adam oversight audit 5c8e49df: KPI-2 planBreach fired at 3.4% coverage because
~95% of claims are worker SELF-claims where the coordinator's dispatch decision
IS the rank — there was no per-claim dispatch row to carry a reason-band, so
the classifier's heuristics landed almost everything in 'other'.

(1) coordinator-backlog-rank.mjs: deriveReasonBand (pure; chairman-directed |
feedback | incident | now-wave-remainder from provenance) stamped into the
atomic rank merge as metadata.dispatch_reason_band. Deliberately NOT removed by
the rank-clear path — the band records why the SD was belted and must survive
the claim.
(2) coordinator-health-sharpenings: classifyDispatchReason treats the stamp as
AUTHORITATIVE when present (heuristics stay as fallback for pre-stamp rows);
deriveDispatchReasons reports stamped/stamped_coverage plus the
direct-dispatch (directed_assignment) vs self-claim partition, so KPI-2
coverage is honest.

3 pin tests (stamp precedence, heuristic fallback + unknown-vocab safety,
coverage/partition accounting); 15/15 sharpenings + 29/29 health/rank-merge
suites green. Live smoke: all four band derivations correct; patch shape
backward-compatible without a band.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
