### PR TITLE
fix(QF-20260719-148): headless Solomon duty triggers (L2) + registered reminder kind

### DIFF
--- a/.github/workflows/solomon-duty-triggers-cron.yml
+++ b/.github/workflows/solomon-duty-triggers-cron.yml
@@ -1,0 +1,58 @@
+name: "Solomon duty triggers (cron)"
+
+# QF-20260719-148 (Solomon L2, advisory 94204a87; chairman-directed session-survival
+# requirement): the judgment halves of Solomon's forecast/weekly duties stay with a live
+# Solomon; the TRIGGERS never sleep. Daily 11:37 UTC (7:37 AM ET DST): exact-count
+# forecast re-issue triggers vs the stamped basis. Monday 12:23 UTC (8:23 AM ET DST):
+# weekly budget-line reminder. Reminders are owed-state rows — a dead Solomon session
+# means they queue at broadcast-solomon for whichever successor registers next.
+# Not var-gated, not fail-softed: a failing trigger checker must be visible.
+
+on:
+  schedule:
+    - cron: '37 11 * * *'   # daily forecast-trigger evaluation
+    - cron: '23 12 * * 1'   # Monday weekly budget-line reminder
+  workflow_dispatch:
+    inputs:
+      weekly:
+        description: "Run the weekly reminder instead of the daily triggers"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  solomon-duty-triggers:
+    name: Solomon duty triggers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run duty triggers (mode by schedule)
+        run: |
+          if [ "${{ github.event.schedule }}" = "23 12 * * 1" ] || [ "${{ github.event.inputs.weekly }}" = "true" ]; then
+            node scripts/solomon-forecast-trigger-check.mjs --weekly
+          else
+            node scripts/solomon-forecast-trigger-check.mjs
+          fi

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -63,7 +63,8 @@ const PAYLOAD_KINDS = Object.freeze({
   WORK_ASSIGNMENT: 'work_assignment',
   ADAM_ADVISORY: 'adam_advisory',     // SD-...-001-B: Adam advisory clean lane (off friction router)
   CANARY_REQUEST: 'canary_request',   // SD-LEO-INFRA-CANARY-SUPPORT-TRIGGER-RELIABILITY-001: durable Adam canary-verification request (advisory; excluded from the Adam generic inbox drain — owned by the canary responder)
-  SOLOMON_CONSULT: 'solomon_consult', // SD-LEO-INFRA-SOLOMON-CONSULT-001D: worker/Adam→Solomon oracle consult (off friction router; reply travels under adam_advisory+oracle:true; intentionally NOT a DIRECTIVE_KIND)
+  SOLOMON_CONSULT: 'solomon_consult',
+  SOLOMON_DUTY_REMINDER: 'solomon_duty_reminder', // QF-20260719-148: headless duty-trigger reminders (payload.duty discriminates forecast_reissue | weekly_budget_line — one kind + shape discriminator per FW3 §6c, never a kind per duty) // SD-LEO-INFRA-SOLOMON-CONSULT-001D: worker/Adam→Solomon oracle consult (off friction router; reply travels under adam_advisory+oracle:true; intentionally NOT a DIRECTIVE_KIND)
   RELAY_REQUEST: 'relay_request',     // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1: a tracked relay-request the coordinator drains deliberately (never processed inline in the active thread). Intentionally NOT a DIRECTIVE_KIND — the generic worker inbox drain must never auto-consume it; only coordinator-relay-drain.cjs may act on it.
   RELAY_CONFIRM: 'relay_confirm',     // FR-2: the durable confirm-back row correlated to a relay_request via payload.correlation_id — CONFIRM-ON-RELAY is only satisfied once this row exists.
   CHAIRMAN_DIRECTIVE: 'chairman_directive', // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: a durable BROADCAST chairman directive all 3 roles (Adam/coordinator/Solomon) surface FIRST-CLASS with per-role ack-tracking. Intentionally a DIRECTIVE_KIND (below) so the generic inbox drain NEVER auto-acks/consumes it (the last-hop silent-death root cause). Its ack REPLY carries payload.kind='chairman_directive_ack' (NOT a directive — a terminal reply, so it is deliberately NOT in DIRECTIVE_KINDS).
@@ -156,6 +157,7 @@ const DRAIN_SETS = Object.freeze({
   solomon: Object.freeze([
     ...DIRECTIVE_KINDS,                 // mirrors SOLOMON_INBOX_KINDS (DIRECTIVE_KINDS spread)
     PAYLOAD_KINDS.SOLOMON_CONSULT,      // mirrors SOLOMON_INBOX_KINDS (+ solomon_consult)
+    PAYLOAD_KINDS.SOLOMON_DUTY_REMINDER, // QF-20260719-148: cron-written duty triggers (drained by solomon inbox)
     'comms_check',                      // FR-3: Solomon-directed canary (surfaced by solomon-advisory inbox)
   ]),
   adam: Object.freeze([

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -162,7 +162,7 @@ function isReplyRow(r) {
 // DIRECTIVE_KIND (spread below) — Solomon drains it via the shared allowlist (no re-list). Its FIRST-CLASS
 // render partition (renderChairmanDirectives, wired into the inbox mode) surfaces it above consults so a
 // chairman baseline directive can never silently die at Solomon's last hop (the 2h-non-compliant incident).
-const SOLOMON_INBOX_KINDS = Object.freeze([...DIRECTIVE_KINDS, SOLOMON_CONSULT_KIND]);
+const SOLOMON_INBOX_KINDS = Object.freeze([...DIRECTIVE_KINDS, SOLOMON_CONSULT_KIND, 'solomon_duty_reminder' /* QF-20260719-148: cron-written duty triggers */]);
 function isSolomonInboxRow(r) {
   const k = r && r.payload && r.payload.kind;
   return k != null && SOLOMON_INBOX_KINDS.includes(k);

--- a/scripts/solomon-forecast-trigger-check.mjs
+++ b/scripts/solomon-forecast-trigger-check.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * solomon-forecast-trigger-check.mjs — QF-20260719-148 (Solomon L2, advisory 94204a87;
+ * chairman-directed session-survival requirement 2026-07-19; companion to QF-072's L1
+ * registry entries and the same shape as Adam's QF-997 checker).
+ *
+ * The JUDGMENT halves of Solomon's forecast duties stay with a live Solomon; the
+ * TRIGGERS never sleep. Daily mode evaluates the re-issue triggers with exact counts
+ * against the LAST-ISSUED FORECAST BASIS (convention defined here: one feedback row,
+ * category='solomon_forecast_basis', metadata { velocity_per_day, open_scope_count } —
+ * Solomon stamps one whenever he issues a forecast). --weekly mode emits the
+ * Monday-budget-line reminder (per-ISO-week dedupe).
+ *
+ * On fire: ONE typed row (kind='solomon_duty_reminder', payload.duty discriminator —
+ * registered in the solomon drain set + SOLOMON_INBOX_KINDS) via the canonical
+ * insertCoordinationRow choke, targeting the live role=solomon session or the
+ * 'broadcast-solomon' sentinel (owed-state: a dead Solomon means the row WAITS for the
+ * successor — nothing rides memory). Idempotent: an unread row with the same
+ * payload.staleness_key suppresses re-sends. NO basis stamped yet → honest NO_BASIS
+ * inertness (a trigger cannot fire against nothing; the weekly reminder carries the
+ * stamping instruction).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+
+const DAY = 24 * 60 * 60 * 1000;
+const OPEN_STATUSES = ['draft', 'in_progress', 'active', 'pending_approval'];
+export const VELOCITY_DELTA = 0.15;
+export const SCOPE_DELTA = 0.10;
+
+async function resolveTarget(sb) {
+  try { const id = await getActiveSolomonId(sb); if (id) return id; } catch { /* fall through */ }
+  return 'broadcast-solomon';
+}
+
+async function sendOnce(sb, target, { duty, stalenessKey, subject, body }) {
+  const { data } = await sb.from('session_coordination').select('id')
+    .eq('target_session', target).eq('payload->>staleness_key', stalenessKey).is('read_at', null).limit(1);
+  if (Array.isArray(data) && data.length) return false; // unread reminder pending — no spam
+  await insertCoordinationRow(sb, {
+    sender_session: process.env.CLAUDE_SESSION_ID || 'solomon-duty-triggers-cron',
+    target_session: target,
+    message_type: 'INFO',
+    subject,
+    payload: { kind: 'solomon_duty_reminder', duty, staleness_key: stalenessKey, body },
+  }, { targetRoleHint: 'solomon' });
+  return true;
+}
+
+export async function runDailyTriggers(sb, { nowMs = Date.now() } = {}) {
+  const { data: basisRows, error } = await sb.from('feedback')
+    .select('created_at, metadata').eq('category', 'solomon_forecast_basis')
+    .order('created_at', { ascending: false }).limit(1);
+  if (error) throw new Error(`basis read failed: ${error.message}`);
+  const basis = basisRows && basisRows[0];
+  if (!basis) return { status: 'NO_BASIS' }; // honest inertness — nothing to compare against
+
+  const m = basis.metadata || {};
+  const since = new Date(nowMs - 7 * DAY).toISOString();
+  const { count: completed7d } = await sb.from('strategic_directives_v2')
+    .select('id', { count: 'exact', head: true }).eq('status', 'completed').gte('completion_date', since);
+  const { count: openScope } = await sb.from('strategic_directives_v2')
+    .select('id', { count: 'exact', head: true }).in('status', OPEN_STATUSES);
+
+  const liveVelocity = (completed7d || 0) / 7;
+  const fired = [];
+  if (Number(m.velocity_per_day) > 0 && Math.abs(liveVelocity - m.velocity_per_day) / m.velocity_per_day > VELOCITY_DELTA) {
+    fired.push(`velocity ${m.velocity_per_day}/d -> ${liveVelocity.toFixed(1)}/d`);
+  }
+  if (Number(m.open_scope_count) > 0 && Math.abs((openScope || 0) - m.open_scope_count) / m.open_scope_count > SCOPE_DELTA) {
+    fired.push(`scope ${m.open_scope_count} -> ${openScope}`);
+  }
+  if (!fired.length) return { status: 'clean', liveVelocity, openScope };
+
+  const target = await resolveTarget(sb);
+  // One episode per basis: keyed on the basis timestamp so a re-check of the SAME drift
+  // never re-sends, while a fresh basis (re-issued forecast) re-arms the trigger.
+  const sent = await sendOnce(sb, target, {
+    duty: 'forecast_reissue',
+    stalenessKey: `forecast-reissue-${basis.created_at}`,
+    subject: `Forecast re-issue trigger fired: ${fired.join('; ')}`,
+    body: `Re-issue trigger(s) vs basis ${basis.created_at}: ${fired.join('; ')} (thresholds ${VELOCITY_DELTA * 100}% velocity / ${SCOPE_DELTA * 100}% scope). Re-issue the per-wave forecast naming the trigger, and stamp a fresh basis row (feedback category=solomon_forecast_basis, metadata {velocity_per_day, open_scope_count}). QF-20260719-148 L2 trigger — judgment stays with you.`,
+  });
+  return { status: 'FIRED', fired, sent, target };
+}
+
+export async function runWeeklyReminder(sb, { nowMs = Date.now() } = {}) {
+  const week = (() => { const d = new Date(nowMs); const o = new Date(d.getFullYear(), 0, 1); return `${d.getFullYear()}-W${String(Math.ceil(((d - o) / DAY + o.getDay() + 1) / 7)).padStart(2, '0')}`; })();
+  const target = await resolveTarget(sb);
+  const sent = await sendOnce(sb, target, {
+    duty: 'weekly_budget_line',
+    stalenessKey: `weekly-budget-line-${week}`,
+    subject: `Monday budget reset: weekly program duties due (${week})`,
+    body: `Monday reset reminder (${week}): send the P3 budget line to Adam, set the standing program, run the accuracy review + autonomy-report rollup, P4 Fable-terms re-check, and stamp a fresh forecast basis (feedback category=solomon_forecast_basis) if you re-issue. Owed-state row — if you are a successor Solomon reading this, the duty transferred with it. QF-20260719-148 L2.`,
+  });
+  return { status: sent ? 'SENT' : 'pending-reminder', week, target };
+}
+
+const isMain = process.argv[1] && import.meta.url.replace(/\\/g, '/').endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (isMain) {
+  const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const out = process.argv.includes('--weekly') ? await runWeeklyReminder(sb) : await runDailyTriggers(sb);
+  console.log(`[solomon-duty-triggers] ${JSON.stringify(out)}`);
+}


### PR DESCRIPTION
Solomon L2 (advisory 94204a87, chairman-directed session-survival): judgment
stays with a live Solomon; the TRIGGERS never sleep.

- kind 'solomon_duty_reminder' registered (worker-status PAYLOAD_KINDS + solomon
  drain set + SOLOMON_INBOX_KINDS) with a payload.duty discriminator
  (forecast_reissue | weekly_budget_line) — ONE kind + shape discriminator per
  the FW3 §6c doctrine, never a kind per duty.
- scripts/solomon-forecast-trigger-check.mjs: daily mode evaluates exact-count
  re-issue triggers (>15% velocity delta, >10% scope delta) against the
  last-stamped basis (convention defined here: feedback
  category=solomon_forecast_basis, metadata {velocity_per_day,
  open_scope_count}); NO basis → honest NO_BASIS inertness. --weekly emits the
  Monday budget-line reminder (per-ISO-week dedupe). All sends ride the
  canonical insertCoordinationRow choke to the live Solomon or the
  broadcast-solomon sentinel — the queued row IS the owed-state for a successor.
  Idempotent via payload.staleness_key + unread suppression; the forecast
  episode keys on the basis timestamp so a fresh basis re-arms the trigger.
- solomon-duty-triggers-cron.yml: daily 11:37 UTC + Monday 12:23 UTC (mode
  branched on github.event.schedule), workflow_dispatch with a weekly input.

Live-verified: daily → NO_BASIS; weekly → SENT to live Solomon c45a24ea;
re-run → pending-reminder (duplicate suppressed). 964/964 fleet+coordinator
suites green with the drain-set registration.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
