### PR TITLE
feat(SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B): sweep schedule + degradation alarm + carrier-filter email fallback

### DIFF
--- a/lib/chairman/sms-channel-health.js
+++ b/lib/chairman/sms-channel-health.js
@@ -136,9 +136,11 @@ export async function escalateCarrierFiltered(supabase, { sendEmail, logger = co
   const out = { scanned: 0, escalated: 0, emailUnavailable: 0 };
   let rows;
   try {
+    // SECURITY least-data note: recipient_phone deliberately NOT selected — the email
+    // fallback needs only the body/error, and the adapter fixes the recipient itself.
     const res = await supabase
       .from('sms_outbound_obligations')
-      .select('id, recipient_phone, body, last_error, status')
+      .select('id, body, last_error, status')
       .in('status', ['undelivered', 'failed', 'owed_escalate'])
       .limit(batchLimit);
     if (res.error) return out; // fail-soft: absent table => nothing to escalate

--- a/lib/chairman/sms-channel-health.js
+++ b/lib/chairman/sms-channel-health.js
@@ -1,0 +1,176 @@
+/**
+ * SMS channel health — durable sweep schedule, degradation alarm, carrier-filter escalation.
+ * SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B (FR-1/FR-2/FR-3), run-side operator layer over the
+ * parent's owed-state substrate (sms_outbound_obligations).
+ *
+ * All IO is fail-soft (absent STAGED tables degrade to loud logs, never throws — the
+ * tableAbsent 42P01/PGRST205 posture of sms-outbound-worker.js); ratio computation and
+ * carrier-filter classification are PURE (TR-2) so they unit-test without a DB.
+ * Invoked from scripts/cron/sms-outbound-reconcile-sweep.mjs after each reconcile pass.
+ */
+import { registerArmedMachinery, armedProcessKey } from '../machinery-class/armed-registration.js';
+import { stampLastFired } from '../periodic-liveness/stamp-last-fired.js';
+import { emitFeedback } from '../governance/emit-feedback.js';
+
+export const SWEEP_SD_KEY = 'SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B';
+/** The sweep's periodic_process_registry key (machinery-class helper derivation). */
+export const SWEEP_PROCESS_KEY = armedProcessKey(SWEEP_SD_KEY);
+export const DEFAULT_SWEEP_INTERVAL_SECONDS = 900; // 15 min — matches the reconcile cadence
+export const DEFAULT_DEGRADATION_WINDOW_MS = 6 * 60 * 60 * 1000; // 6h observation window
+export const DEFAULT_DEGRADATION_THRESHOLD = 0.5; // >=50% of windowed sends bad => degraded
+export const DEFAULT_MIN_SAMPLE = 3; // never alarm on 1-2 rows (noise floor)
+/** One-shot escalation stamp prefix on the owed row (mirrors the worker's ALERTED: guard). */
+export const EMAIL_ESCALATED_PREFIX = 'EMAIL_ESCALATED: ';
+
+/**
+ * FR-1: register the reconcile sweep as an on-by-default governed cadence
+ * (currently_expected_active=true, positive interval). Fail-soft: absent registry
+ * table => loud canary, current manual behavior continues.
+ * @returns {Promise<{ok: boolean, processKey?: string, error?: string}>}
+ */
+export async function ensureSweepSchedule(supabase, { intervalSeconds = DEFAULT_SWEEP_INTERVAL_SECONDS, logger = console } = {}) {
+  const res = await registerArmedMachinery(supabase, { sd_key: SWEEP_SD_KEY }, {
+    activationTrigger: 'sms-outbound-reconcile-sweep run (scripts/cron/sms-outbound-reconcile-sweep.mjs)',
+    expectedIntervalSeconds: intervalSeconds,
+    owner: 'sms-delivery-truth',
+  });
+  if (!res.ok) {
+    logger.warn?.(`[sms-channel-health] CANARY: sweep-schedule registration unavailable (${res.error}) — reconcile continues on manual/current behavior.`);
+  }
+  return res;
+}
+
+/**
+ * FR-1: witness the cadence as fired — stamps last_fired_at on the registry row.
+ * Fail-soft (a stamp failure never fails the sweep).
+ */
+export async function witnessSweepFired(supabase, { logger = console } = {}) {
+  try {
+    // stampLastFired THROWS on a DB error and returns {stamped:false, reason} on a
+    // missing/mismatched registry row — both degrade to the canary here.
+    const res = await stampLastFired(supabase, SWEEP_PROCESS_KEY);
+    if (res && res.stamped === false) logger.warn?.(`[sms-channel-health] CANARY: last_fired_at not stamped (${res.reason || 'row_missing'})`);
+    return res || { stamped: false };
+  } catch (e) {
+    logger.warn?.(`[sms-channel-health] CANARY: last_fired_at stamp threw (${e?.message || e})`);
+    return { stamped: false, reason: e?.message || String(e) };
+  }
+}
+
+/**
+ * FR-2 PURE core: sustained undelivered/failed ratio over the recent window.
+ * owed_escalate counts as bad (it is a confirmed-ambiguous non-delivery, never a success).
+ * @param {Array<{status: string, created_at: string}>} rows
+ * @returns {{ratio: number, total: number, bad: number}}
+ */
+export function computeDegradationRatio(rows, { windowMs = DEFAULT_DEGRADATION_WINDOW_MS, now = Date.now() } = {}) {
+  const cutoff = now - windowMs;
+  const windowed = (rows || []).filter((r) => r && r.created_at && new Date(r.created_at).getTime() >= cutoff);
+  const bad = windowed.filter((r) => ['undelivered', 'failed', 'owed_escalate'].includes(r.status)).length;
+  const total = windowed.length;
+  return { ratio: total > 0 ? bad / total : 0, total, bad };
+}
+
+/**
+ * FR-2: detect sustained channel degradation and raise a DURABLE alarm (a structured
+ * feedback row naming the ratio and window — idempotent per day via emitFeedback's
+ * dedup_hash). Fail-soft on absent owed-state table (no alarm, no throw).
+ * @returns {Promise<{alarmed: boolean, ratio?: number, total?: number, reason?: string}>}
+ */
+export async function detectChannelDegradation(supabase, {
+  windowMs = DEFAULT_DEGRADATION_WINDOW_MS, threshold = DEFAULT_DEGRADATION_THRESHOLD,
+  minSample = DEFAULT_MIN_SAMPLE, now = Date.now(), emit = emitFeedback, logger = console,
+} = {}) {
+  let rows;
+  try {
+    const cutoffIso = new Date(now - windowMs).toISOString();
+    const res = await supabase
+      .from('sms_outbound_obligations')
+      .select('status, created_at')
+      .gte('created_at', cutoffIso)
+      .limit(500);
+    if (res.error) return { alarmed: false, reason: 'table_absent' };
+    rows = res.data || [];
+  } catch { return { alarmed: false, reason: 'table_absent' }; }
+
+  const { ratio, total, bad } = computeDegradationRatio(rows, { windowMs, now });
+  if (total < minSample || ratio < threshold) return { alarmed: false, ratio, total };
+
+  const windowH = Math.round(windowMs / 3600000 * 10) / 10;
+  try {
+    await emit({
+      supabase,
+      title: `SMS channel DEGRADED: ${bad}/${total} undelivered/failed (${Math.round(ratio * 100)}%) over ${windowH}h`,
+      description: `Sustained SMS non-delivery ratio ${ratio.toFixed(2)} (bad=${bad}, total=${total}) over the last ${windowH}h window crossed the ${threshold} threshold — the chairman SMS channel is degraded; investigate carrier/provider state and rely on email fallback meanwhile.`,
+      type: 'issue', category: 'sms_channel_degradation', severity: 'high',
+      source_application: 'EHG_Engineer', source_type: 'automated_detector',
+      dedup_key: 'sms-channel-degradation',
+      metadata: { ratio, bad, total, window_ms: windowMs, threshold, process_key: SWEEP_PROCESS_KEY },
+    });
+  } catch (e) {
+    logger.warn?.(`[sms-channel-health] CANARY: degradation alarm write failed (${e?.message || e}) — ratio ${ratio.toFixed(2)} over ${windowH}h remains UNRECORDED.`);
+    return { alarmed: false, ratio, total, reason: 'alarm_write_failed' };
+  }
+  return { alarmed: true, ratio, total };
+}
+
+/**
+ * FR-3 PURE core: is this owed row's failure carrier-filtered (Twilio 30007 / carrier-filter
+ * classification)? Already-escalated rows (EMAIL_ESCALATED stamp) are excluded — one-shot.
+ */
+export function isCarrierFiltered(row) {
+  const err = (row && row.last_error) || '';
+  if (err.includes(EMAIL_ESCALATED_PREFIX.trim())) return false;
+  return /\b30007\b/.test(err) || /carrier[\s_-]?filter/i.test(err);
+}
+
+/**
+ * FR-3: escalate carrier-filtered undelivered owed messages to the existing email-fallback
+ * path (lib/notifications sendEmail) so the chairman still receives them, and stamp the
+ * escalation on the owed row (idempotent one-shot via the EMAIL_ESCALATED prefix; the stamp
+ * is written ONLY after a successful email attempt so a transiently-absent email path retries
+ * on a later sweep — "absent email path degrades to a logged non-escalation").
+ * @returns {Promise<{scanned: number, escalated: number, emailUnavailable: number}>}
+ */
+export async function escalateCarrierFiltered(supabase, { sendEmail, logger = console, batchLimit = 25 } = {}) {
+  const out = { scanned: 0, escalated: 0, emailUnavailable: 0 };
+  let rows;
+  try {
+    const res = await supabase
+      .from('sms_outbound_obligations')
+      .select('id, recipient_phone, body, last_error, status')
+      .in('status', ['undelivered', 'failed', 'owed_escalate'])
+      .limit(batchLimit);
+    if (res.error) return out; // fail-soft: absent table => nothing to escalate
+    rows = res.data || [];
+  } catch { return out; }
+
+  let send = sendEmail;
+  if (!send) {
+    try { send = (await import('../notifications/resend-adapter.js')).sendEmail; }
+    catch { send = null; }
+  }
+
+  for (const row of rows) {
+    if (!isCarrierFiltered(row)) continue;
+    out.scanned++;
+    if (!send) { out.emailUnavailable++; logger.warn?.(`[sms-channel-health] carrier-filtered obligation ${row.id} NOT escalated — email path unavailable.`); continue; }
+    try {
+      await send({
+        subject: `[SMS carrier-filtered] owed message escalated to email (obligation ${row.id})`,
+        text: `The following chairman SMS was blocked by carrier filtering (Twilio 30007) and is delivered here instead:\n\n${row.body || '(no body)'}\n\n(last_error: ${row.last_error})`,
+      });
+    } catch (e) {
+      logger.warn?.(`[sms-channel-health] email-fallback attempt failed for obligation ${row.id} (${e?.message || e}) — will retry next sweep.`);
+      out.emailUnavailable++;
+      continue; // no stamp on failure — retryable
+    }
+    await supabase
+      .from('sms_outbound_obligations')
+      .update({ last_error: `${EMAIL_ESCALATED_PREFIX}${row.last_error || 'carrier_filtered'}` })
+      .eq('id', row.id)
+      .in('status', ['undelivered', 'failed', 'owed_escalate']);
+    out.escalated++;
+  }
+  return out;
+}

--- a/scripts/cron/sms-outbound-reconcile-sweep.mjs
+++ b/scripts/cron/sms-outbound-reconcile-sweep.mjs
@@ -67,6 +67,21 @@ export async function main(argv = process.argv, deps = {}) {
   const reconcile = deps.reconcile || reconcileOutboundSms;
   const summary = await reconcile(supabase, {});
   logger.log?.(`[sms-outbound-sweep] ${JSON.stringify({ ts: new Date().toISOString(), ...summary })}`);
+
+  // SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B: run-side operator layer, all fail-soft —
+  // FR-1 governed cadence (register + witness the fire), FR-2 degradation alarm,
+  // FR-3 carrier-filter email-fallback escalation. deps.channelHealth is the test seam.
+  try {
+    const health = deps.channelHealth || await import('../../lib/chairman/sms-channel-health.js');
+    await health.ensureSweepSchedule(supabase, { logger });
+    await health.witnessSweepFired(supabase, { logger });
+    const degradation = await health.detectChannelDegradation(supabase, { logger });
+    const escalation = await health.escalateCarrierFiltered(supabase, { logger });
+    logger.log?.(`[sms-outbound-sweep] channel-health ${JSON.stringify({ degradation, escalation })}`);
+  } catch (err) {
+    logger.warn?.(`[sms-outbound-sweep] channel-health layer failed soft: ${err?.message || err}`);
+  }
+
   return { exitCode: 0, action: summary.ran ? 'reconciled' : 'inert', summary };
 }
 

--- a/tests/unit/chairman/sms-channel-health.test.js
+++ b/tests/unit/chairman/sms-channel-health.test.js
@@ -1,0 +1,210 @@
+/**
+ * SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B — sweep schedule (FR-1/TS-1), degradation
+ * alarm (FR-2/TS-2), carrier-filter email-fallback escalation (FR-3/TS-3).
+ * Pure cores tested directly; IO via a table-aware supabase mock (no live DB).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SWEEP_PROCESS_KEY, EMAIL_ESCALATED_PREFIX,
+  ensureSweepSchedule, witnessSweepFired,
+  computeDegradationRatio, detectChannelDegradation,
+  isCarrierFiltered, escalateCarrierFiltered,
+} from '../../../lib/chairman/sms-channel-health.js';
+import { main as sweepMain } from '../../../scripts/cron/sms-outbound-reconcile-sweep.mjs';
+
+const NOW = Date.parse('2026-07-20T12:00:00Z');
+const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
+
+/** Table-aware supabase mock: per-table select rows + recorded upserts/updates. */
+function makeMock({ obligations = [], selectError = null, registryError = null } = {}) {
+  const upserts = []; const updates = [];
+  function chain(table) {
+    const state = { op: 'select', payload: null };
+    const c = {
+      select: () => c,
+      update: (p) => { state.op = 'update'; state.payload = p; return c; },
+      upsert: (p) => { state.op = 'upsert'; state.payload = p; return finishThenable(); },
+      eq: () => c, in: () => c, is: () => c, gte: () => c, order: () => c, limit: () => c,
+      then: (res, rej) => finish().then(res, rej),
+    };
+    function finishThenable() { return { then: (res, rej) => finish().then(res, rej), select: () => finishThenable() }; }
+    async function finish() {
+      if (table === 'periodic_process_registry') {
+        if (registryError) return { data: null, error: { message: registryError } };
+        if (state.op === 'upsert') { upserts.push(state.payload); return { data: [], error: null }; }
+        if (state.op === 'update') { updates.push({ table, payload: state.payload }); return { data: [{ process_key: SWEEP_PROCESS_KEY }], error: null }; }
+        return { data: [], error: null };
+      }
+      if (table === 'sms_outbound_obligations') {
+        if (selectError && state.op === 'select') return { data: null, error: { message: selectError } };
+        if (state.op === 'update') { updates.push({ table, payload: state.payload }); return { data: [], error: null }; }
+        return { data: obligations, error: null };
+      }
+      if (state.op === 'update') { updates.push({ table, payload: state.payload }); return { data: [], error: null }; }
+      return { data: [], error: null };
+    }
+    return c;
+  }
+  return { supabase: { from: chain }, upserts, updates };
+}
+
+const quiet = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+
+describe('FR-1 / TS-1: durable sweep-runner schedule', () => {
+  it('registers an on-by-default armed cadence with positive interval', async () => {
+    const m = makeMock();
+    const res = await ensureSweepSchedule(m.supabase, { logger: quiet });
+    expect(res.ok).toBe(true);
+    expect(res.processKey).toBe(SWEEP_PROCESS_KEY);
+    expect(m.upserts).toHaveLength(1);
+    expect(m.upserts[0].currently_expected_active).toBe(true);
+    expect(m.upserts[0].expected_interval_seconds).toBeGreaterThan(0);
+    expect(m.upserts[0].process_key).toBe(SWEEP_PROCESS_KEY);
+  });
+
+  it('witnesses the cadence as fired (last_fired_at stamped)', async () => {
+    const m = makeMock();
+    const res = await witnessSweepFired(m.supabase, { logger: quiet });
+    expect(res.stamped).toBe(true);
+    expect(m.updates.some((u) => u.table === 'periodic_process_registry' && u.payload.last_fired_at)).toBe(true);
+  });
+
+  it('fail-soft: absent registry emits a loud canary and never throws', async () => {
+    const m = makeMock({ registryError: 'relation "periodic_process_registry" does not exist' });
+    const warn = vi.fn();
+    const res = await ensureSweepSchedule(m.supabase, { logger: { warn } });
+    expect(res.ok).toBe(false);
+    expect(warn.mock.calls.join(' ')).toMatch(/CANARY/);
+    const res2 = await witnessSweepFired({ from: () => { throw new Error('42P01'); } }, { logger: { warn } });
+    expect(res2.stamped).toBe(false);
+  });
+});
+
+describe('FR-2 / TS-2: channel-state degradation alarm', () => {
+  const HOUR = 3600000;
+  it('pure ratio: windowed bad/total, empty window => 0', () => {
+    const rows = [
+      { status: 'delivered', created_at: iso(1 * HOUR) },
+      { status: 'undelivered', created_at: iso(2 * HOUR) },
+      { status: 'failed', created_at: iso(3 * HOUR) },
+      { status: 'owed_escalate', created_at: iso(4 * HOUR) },
+      { status: 'failed', created_at: iso(50 * HOUR) }, // outside window — excluded
+    ];
+    const r = computeDegradationRatio(rows, { windowMs: 6 * HOUR, now: NOW });
+    expect(r.total).toBe(4);
+    expect(r.bad).toBe(3);
+    expect(r.ratio).toBeCloseTo(0.75);
+    expect(computeDegradationRatio([], { now: NOW }).ratio).toBe(0);
+  });
+
+  it('raises a durable alarm naming the ratio when above threshold', async () => {
+    const m = makeMock({ obligations: [
+      { status: 'undelivered', created_at: iso(HOUR) }, { status: 'failed', created_at: iso(HOUR) },
+      { status: 'failed', created_at: iso(HOUR) }, { status: 'delivered', created_at: iso(HOUR) },
+    ] });
+    const emit = vi.fn(async () => ({}));
+    const res = await detectChannelDegradation(m.supabase, { now: NOW, emit, logger: quiet });
+    expect(res.alarmed).toBe(true);
+    expect(emit).toHaveBeenCalledOnce();
+    const arg = emit.mock.calls[0][0];
+    expect(arg.title).toMatch(/75%|3\/4/);
+    expect(arg.metadata.ratio).toBeCloseTo(0.75);
+    expect(arg.category).toBe('sms_channel_degradation');
+  });
+
+  it('below threshold or below min-sample: no alarm', async () => {
+    const emit = vi.fn(async () => ({}));
+    const below = makeMock({ obligations: [
+      { status: 'delivered', created_at: iso(HOUR) }, { status: 'delivered', created_at: iso(HOUR) },
+      { status: 'failed', created_at: iso(HOUR) }, { status: 'delivered', created_at: iso(HOUR) },
+    ] });
+    expect((await detectChannelDegradation(below.supabase, { now: NOW, emit, logger: quiet })).alarmed).toBe(false);
+    const tiny = makeMock({ obligations: [{ status: 'failed', created_at: iso(HOUR) }] });
+    expect((await detectChannelDegradation(tiny.supabase, { now: NOW, emit, logger: quiet })).alarmed).toBe(false);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: absent owed-state table => no alarm, no throw', async () => {
+    const m = makeMock({ selectError: 'relation "sms_outbound_obligations" does not exist' });
+    const res = await detectChannelDegradation(m.supabase, { now: NOW, emit: vi.fn(), logger: quiet });
+    expect(res).toEqual({ alarmed: false, reason: 'table_absent' });
+  });
+});
+
+describe('FR-3 / TS-3: carrier-filter email-fallback escalation', () => {
+  it('pure classifier: 30007/carrier-filter yes; others and already-escalated no', () => {
+    expect(isCarrierFiltered({ last_error: 'Twilio error 30007' })).toBe(true);
+    expect(isCarrierFiltered({ last_error: 'carrier-filter block' })).toBe(true);
+    expect(isCarrierFiltered({ last_error: 'carrier_filtered by network' })).toBe(true);
+    expect(isCarrierFiltered({ last_error: 'timeout talking to provider' })).toBe(false);
+    expect(isCarrierFiltered({ last_error: `${EMAIL_ESCALATED_PREFIX}Twilio error 30007` })).toBe(false);
+    expect(isCarrierFiltered({})).toBe(false);
+  });
+
+  it('escalates a 30007 row to email once and stamps the owed row (idempotent)', async () => {
+    const row = { id: 'ob1', recipient_phone: '+15551234567', body: 'decision packet', last_error: 'Twilio 30007 blocked', status: 'undelivered' };
+    const m = makeMock({ obligations: [row] });
+    const sendEmail = vi.fn(async () => ({ success: true }));
+    const res = await escalateCarrierFiltered(m.supabase, { sendEmail, logger: quiet });
+    expect(res.escalated).toBe(1);
+    expect(sendEmail).toHaveBeenCalledOnce();
+    expect(sendEmail.mock.calls[0][0].text).toMatch(/decision packet/);
+    const stamp = m.updates.find((u) => u.table === 'sms_outbound_obligations');
+    expect(stamp.payload.last_error.startsWith(EMAIL_ESCALATED_PREFIX)).toBe(true);
+    // second pass over the STAMPED row: classifier excludes it — no double escalation
+    const m2 = makeMock({ obligations: [{ ...row, last_error: stamp.payload.last_error }] });
+    const send2 = vi.fn();
+    const res2 = await escalateCarrierFiltered(m2.supabase, { sendEmail: send2, logger: quiet });
+    expect(res2.escalated).toBe(0);
+    expect(send2).not.toHaveBeenCalled();
+  });
+
+  it('non-carrier-filter failures never trigger email escalation', async () => {
+    const m = makeMock({ obligations: [{ id: 'ob2', last_error: 'provider timeout', status: 'failed' }] });
+    const sendEmail = vi.fn();
+    const res = await escalateCarrierFiltered(m.supabase, { sendEmail, logger: quiet });
+    expect(res.escalated).toBe(0);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('email-send failure: logged non-escalation, NO stamp (retryable next sweep)', async () => {
+    const m = makeMock({ obligations: [{ id: 'ob3', last_error: 'Twilio 30007', status: 'undelivered', body: 'x' }] });
+    const warn = vi.fn();
+    const res = await escalateCarrierFiltered(m.supabase, { sendEmail: vi.fn(async () => { throw new Error('resend down'); }), logger: { warn } });
+    expect(res.escalated).toBe(0);
+    expect(res.emailUnavailable).toBe(1);
+    expect(m.updates.filter((u) => u.table === 'sms_outbound_obligations')).toHaveLength(0);
+    expect(warn.mock.calls.join(' ')).toMatch(/retry next sweep/);
+  });
+});
+
+describe('sweep wiring: channel-health layer runs after reconcile, fail-soft', () => {
+  it('invokes all four hooks via deps.channelHealth', async () => {
+    const health = {
+      ensureSweepSchedule: vi.fn(async () => ({ ok: true })),
+      witnessSweepFired: vi.fn(async () => ({ stamped: true })),
+      detectChannelDegradation: vi.fn(async () => ({ alarmed: false })),
+      escalateCarrierFiltered: vi.fn(async () => ({ scanned: 0, escalated: 0, emailUnavailable: 0 })),
+    };
+    const res = await sweepMain(['node', 'x', '--once'], {
+      supabase: makeMock().supabase,
+      reconcile: vi.fn(async () => ({ ran: true, claimed: 0 })),
+      channelHealth: health,
+      logger: quiet,
+    });
+    expect(res.exitCode).toBe(0);
+    for (const fn of Object.values(health)) expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('a throwing channel-health layer never fails the sweep', async () => {
+    const warn = vi.fn();
+    const res = await sweepMain(['node', 'x', '--once'], {
+      supabase: makeMock().supabase,
+      reconcile: vi.fn(async () => ({ ran: true })),
+      channelHealth: { ensureSweepSchedule: vi.fn(async () => { throw new Error('boom'); }) },
+      logger: { ...quiet, warn },
+    });
+    expect(res.exitCode).toBe(0);
+    expect(warn.mock.calls.join(' ')).toMatch(/failed soft/);
+  });
+});


### PR DESCRIPTION
## Summary
Child B (run-side operator layer) of the SMS delivery-truth orchestrator, over the parent's owed-state substrate:

- **FR-1 durable sweep schedule** — the reconcile sweep registers itself as an on-by-default `periodic_process_registry` cadence (machinery-class armed-registration, 15-min interval) and witnesses each run via `stampLastFired`; loud fail-soft canary when the registry is absent.
- **FR-2 degradation alarm** — pure windowed undelivered/failed ratio + a DURABLE feedback-row alarm (`sms_channel_degradation`, idempotent per day via emitFeedback dedup) naming ratio/window; min-sample floor; fail-soft on absent owed-state.
- **FR-3 carrier-filter (30007) email fallback** — pure classifier + escalation of the owed body through the existing `lib/notifications` sendEmail path; `EMAIL_ESCALATED` stamp written only after a successful send (one-shot idempotent, email-path failure = logged non-escalation, retryable).
- Wired into `scripts/cron/sms-outbound-reconcile-sweep.mjs` post-reconcile, whole layer fail-soft with a `deps.channelHealth` test seam.

## Verification
- 13/13 new tests (pure cores, table-aware mock IO, sweep wiring incl. fail-soft throw path).
- Chairman suite regression 181 passing; the 3 reds are **pre-existing time-of-day flakes** in the -A sibling suite (verified with this diff stashed — `now: Date.now()` inside the ET quiet window; signaled 84b0fe1e for a separate QF).
- No DDL, no new tables — additive module + wiring only (TR-1).

SD: SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B · PRD approved · ~180 source LOC justified: three coupled FRs share one module + seams and land with their tests in a single reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)