### PR TITLE
fix(QF-20260720-415): classify-quick-fix.js anon-key RLS blocks the claim CAS fleet-wide

### DIFF
--- a/scripts/classify-quick-fix.js
+++ b/scripts/classify-quick-fix.js
@@ -100,8 +100,14 @@ function analyzeDescription(description, title) {
 async function classifyQuickFix(qfId, options = {}) {
   console.log(`\n🔍 Classifying Quick-Fix: ${qfId}\n`);
 
+  // QF-20260720-415: this client claims (UPDATEs) quick_fixes rows via claimQuickFix()
+  // below, a privileged write RLS blocks for the anon role. The anon key silently no-ops
+  // the UPDATE (0 rows, no error) instead of throwing, which claimQuickFix() then
+  // misreports as "a different holder owns it" — every claim attempt failed fleet-wide
+  // regardless of actual claim state. Use the service-role key, matching every other
+  // privileged-write script in this codebase (e.g. the SD-claim path).
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
     console.log('❌ Missing Supabase credentials in .env file');

--- a/tests/unit/classify-quick-fix-keyword-boundary.test.js
+++ b/tests/unit/classify-quick-fix-keyword-boundary.test.js
@@ -61,3 +61,20 @@ describe('analyzeDescription — end-to-end (SD-REFILL-00202Z4B)', () => {
     expect(issues.some((i) => /refactor/i.test(i))).toBe(true);
   });
 });
+
+// QF-20260720-415: the Supabase client classifyQuickFix() builds performs a privileged
+// UPDATE (claimQuickFix's CAS) that RLS silently no-ops under the anon role — 0 rows
+// affected, no error — which claimQuickFix then misreports as "a different holder owns
+// it" regardless of the row's actual claim state. Every worker's claim attempt failed
+// fleet-wide until this was caught. Static source check (classifyQuickFix itself is
+// intentionally not exported — CLI-only per the file's own convention) so a future edit
+// can't silently reintroduce the anon key here.
+describe('classifyQuickFix Supabase client (QF-20260720-415)', () => {
+  it('constructs its client from SUPABASE_SERVICE_ROLE_KEY, never an anon key', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const source = readFileSync(fileURLToPath(new URL('../../scripts/classify-quick-fix.js', import.meta.url)), 'utf8');
+    expect(source).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(source).not.toContain('ANON_KEY');
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/classify-quick-fix.js` built its Supabase client from the anon key. `claimQuickFix()`'s privileged UPDATE (the claim CAS) is RLS-blocked for the anon role — 0 rows affected, no error — misreported as "a different holder owns it" regardless of actual claim state.
- Reproduced directly: an identical anon-key UPDATE against a confirmed-unclaimed QF wrote nothing and returned no error.
- Fix: switch to `SUPABASE_SERVICE_ROLE_KEY`, matching the SD-claim path and every other privileged-write script in this codebase.
- Added a regression test asserting the client construction never references an anon key.

## Test plan
- [x] `npx vitest run tests/unit/classify-quick-fix-keyword-boundary.test.js` — 10/10 passing
- [x] Manually verified fix: `classify-quick-fix.js` now successfully claims a genuinely-open QF (previously always failed)