### PR TITLE
fix(QF-20260720-161): coordinator-health live_workers stale-read fix

### DIFF
--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -41,7 +41,16 @@ export const IN_FLIGHT_STATUSES = ['in_progress', 'active', 'pending_approval'];
  * still has sd_key set, so it is correctly counted as claimed, never idle.
  */
 export async function computeUtilization(supabase, { nowMs = Date.now() } = {}) {
-  const { data: sessions, error } = await supabase.from('claude_sessions').select('*');
+  // QF-20260720-161: claude_sessions accumulates historical rows (12,973 live-verified,
+  // well past PostgREST's 1000-row default page cap). An unordered select('*') silently
+  // returned an arbitrary/oldest-leaning 1000-row slice containing ZERO status='active'
+  // rows, so every live session was excluded and this KPI reported live_workers=0 with
+  // full confidence. Ordering by heartbeat_at descending guarantees the freshest rows —
+  // the only ones liveFleetWorkers' window filter can ever keep — land inside the cap.
+  const { data: sessions, error } = await supabase
+    .from('claude_sessions')
+    .select('*')
+    .order('heartbeat_at', { ascending: false });
   if (error) throw new Error(`utilization: claude_sessions query failed: ${error.message}`);
   const rows = sessions || [];
   const coordinatorId =
@@ -116,6 +125,10 @@ export async function computePlanAdherence(supabase) {
  * failure in EITHER path is surfaced as integrity_ok=false with the error attached — it MUST NEVER
  * be null-coalesced into a silent 0/"no work" result. selfReportedCounts (test seam) overrides the
  * real computeClaimableLeaves call so unit tests can inject a divergence without a live DB.
+ *
+ * QF-20260720-161: additionally surfaces human_action_held (from the same computeClaimableLeaves
+ * call, no extra query) and flags instrument_suspect when the recomputed-vs-self_reported gap is
+ * NOT substantially explained by that known hold count — see the inline comment below.
  */
 export async function computeFailLoudIntegrity(supabase, { selfReportedCounts, claimableLeavesFn = computeClaimableLeaves } = {}) {
   const { data, error } = await supabase
@@ -129,20 +142,33 @@ export async function computeFailLoudIntegrity(supabase, { selfReportedCounts, c
   const recomputed = { dispatchable_count: (data || []).length };
 
   let selfReported = selfReportedCounts;
+  let humanActionHeld = null;
   if (!selfReported) {
     const leaves = await claimableLeavesFn(supabase, { quiet: true });
     if (leaves?.error) {
       return { integrity_ok: false, error: leaves.error.message || String(leaves.error), divergent_fields: ['dispatchable_count'] };
     }
     selfReported = { dispatchable_count: (leaves?.claimable || []).filter((sd) => sd.status === 'draft').length };
+    humanActionHeld = (leaves?.humanActionHolds || []).length;
   }
 
   const divergentFields = Object.keys(recomputed).filter((k) => (selfReported[k] ?? 0) > recomputed[k]);
+  // QF-20260720-161: self_reported <= recomputed is the healthy narrowing invariant (deps/
+  // holds/fixtures only ever REMOVE candidates), so a wide gap alone is not evidence of a
+  // stale read — 3 vs 20 with 11 held for human-action is real, verified fleet state. But a
+  // gap NOT explained by known holds is exactly the "confident but wrong" shape that hid
+  // live_workers=0 — flag the instrument as suspect instead of printing two opaque numbers.
+  const dc = recomputed.dispatchable_count;
+  const unexplained = humanActionHeld === null ? null : dc - selfReported.dispatchable_count - humanActionHeld;
+  const instrumentSuspect = unexplained !== null && dc > 0 && unexplained / dc > 0.5;
+  if (instrumentSuspect) divergentFields.push('dispatchable_count_unexplained_gap');
+
   return {
     integrity_ok: divergentFields.length === 0,
     recomputed,
     self_reported: selfReported,
     divergent_fields: divergentFields,
+    ...(humanActionHeld !== null ? { human_action_held: humanActionHeld, instrument_suspect: instrumentSuspect } : {}),
   };
 }
 

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -19,8 +19,13 @@ import * as coordinatorResolve from '../../../lib/coordinator/resolve.cjs';
 
 const minutesAgo = (m) => new Date(Date.now() - m * 60_000).toISOString();
 
-/** Minimal fake Supabase: select().eq()/.in()/.not()/.order()/.limit() over seeded tables; insert() logs rows. */
-function makeFakeSupabase(tables, { onInsert } = {}) {
+/**
+ * Minimal fake Supabase: select().eq()/.in()/.not()/.order()/.limit() over seeded tables; insert() logs rows.
+ * capAt: { tableName: n } simulates PostgREST's default page cap (QF-20260720-161 regression coverage) —
+ * applied post-filter/post-sort like the real server-side default, so an unordered query truncates to an
+ * arbitrary slice while an explicitly-ordered one keeps the correct (e.g. freshest) rows within the cap.
+ */
+function makeFakeSupabase(tables, { onInsert, capAt } = {}) {
   return {
     from(tableName) {
       const filters = [];
@@ -38,7 +43,8 @@ function makeFakeSupabase(tables, { onInsert } = {}) {
         then(resolve) {
           let rows = (tables[tableName] || []).filter((r) => filters.every((f) => f(r)));
           if (orderCol) rows = [...rows].sort((a, b) => (orderAsc ? 1 : -1) * (a[orderCol] > b[orderCol] ? 1 : -1));
-          if (limitN != null) rows = rows.slice(0, limitN);
+          const effectiveLimit = limitN != null ? limitN : capAt?.[tableName];
+          if (effectiveLimit != null) rows = rows.slice(0, effectiveLimit);
           resolve({ data: rows, error: null });
         },
         insert(row) {
@@ -109,6 +115,25 @@ describe('computeUtilization (TS-1, TS-2)', () => {
     });
     const result = await computeUtilization(supabase);
     expect(result.live_workers).toBe(0);
+  });
+
+  it('QF-20260720-161: keeps the freshest session inside a simulated PostgREST page cap via explicit heartbeat ordering', async () => {
+    const supabase = makeFakeSupabase(
+      {
+        claude_sessions: [
+          { session_id: 'stale1', sd_key: 'SD-OLD-1', status: 'active', heartbeat_at: '2025-12-01T00:00:00Z', metadata: {} },
+          { session_id: 'stale2', sd_key: 'SD-OLD-2', status: 'active', heartbeat_at: '2025-12-02T00:00:00Z', metadata: {} },
+          { session_id: 'fresh', sd_key: 'SD-NEW', status: 'active', heartbeat_at: minutesAgo(1), metadata: {} },
+        ],
+        strategic_directives_v2: [],
+      },
+      { capAt: { claude_sessions: 2 } },
+    );
+    // Without explicit ordering, an unordered query capped at 2 rows returns [stale1, stale2] in
+    // insertion order and silently drops 'fresh' — this would report live_workers=0.
+    const result = await computeUtilization(supabase);
+    expect(result.live_workers).toBe(1);
+    expect(result.claimed).toBe(1);
   });
 });
 
@@ -184,6 +209,34 @@ describe('computeFailLoudIntegrity (TS-3)', () => {
     const claimableLeavesFn = vi.fn().mockResolvedValue({ claimable: [{ sd_key: 'SD-A', status: 'draft' }] });
     const result = await computeFailLoudIntegrity(supabase, { claimableLeavesFn });
     expect(result.integrity_ok).toBe(true);
+  });
+
+  // QF-20260720-161
+  it('does NOT flag instrument_suspect when a wide self-reported/recomputed gap is explained by human-action holds (live-verified: 3 vs 20, 11 held)', async () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ id: `${i}`, status: 'draft', claiming_session_id: null }));
+    const supabase = makeFakeSupabase({ strategic_directives_v2: rows });
+    const claimableLeavesFn = vi.fn().mockResolvedValue({
+      claimable: Array.from({ length: 3 }, (_, i) => ({ sd_key: `SD-${i}`, status: 'draft' })),
+      humanActionHolds: Array.from({ length: 11 }, (_, i) => ({ sd_key: `SD-HELD-${i}`, provenance: null })),
+    });
+    const result = await computeFailLoudIntegrity(supabase, { claimableLeavesFn });
+    expect(result.human_action_held).toBe(11);
+    expect(result.instrument_suspect).toBe(false);
+    expect(result.integrity_ok).toBe(true);
+  });
+
+  it('flags instrument_suspect when the gap is NOT substantially explained by known human-action holds', async () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ id: `${i}`, status: 'draft', claiming_session_id: null }));
+    const supabase = makeFakeSupabase({ strategic_directives_v2: rows });
+    const claimableLeavesFn = vi.fn().mockResolvedValue({
+      claimable: [{ sd_key: 'SD-0', status: 'draft' }],
+      humanActionHolds: [{ sd_key: 'SD-HELD-0', provenance: null }],
+    });
+    const result = await computeFailLoudIntegrity(supabase, { claimableLeavesFn });
+    expect(result.human_action_held).toBe(1);
+    expect(result.instrument_suspect).toBe(true);
+    expect(result.integrity_ok).toBe(false);
+    expect(result.divergent_fields).toContain('dispatchable_count_unexplained_gap');
   });
 });
 


### PR DESCRIPTION
## Summary
- `computeUtilization`'s `claude_sessions` query was unordered and unbounded against a 12,973-row table, silently hitting PostgREST's 1000-row default cap and returning an oldest-leaning slice with zero `status='active'` rows — `live_workers` reported 0 with full confidence. Live-verified before/after: 0 → 8.
- Fixed by ordering the query by `heartbeat_at` descending, guaranteeing the freshest rows (the only ones the liveness window filter can keep) land inside the page cap.
- Additionally surfaces `human_action_held` on the KPI-3 fail-loud integrity check (from the existing `computeClaimableLeaves` call, no extra query) and adds an `instrument_suspect` flag when the self_reported/recomputed dispatchable gap isn't substantially explained by known holds — turning two opaque numbers into a self-diagnosing reading, per the QF's ask to flag the instrument rather than emit confident-but-wrong output.
- Live-verified the 3-vs-20 dispatchable divergence mentioned in the QF is real, healthy fleet state (11 human-action holds explain most of the gap) — not a second stale-read bug; confirmed via direct DB queries before writing the fix.

## Test plan
- [x] `npx vitest run tests/unit/adam/adam-coordinator-health.test.js` — 24/24 pass, including 3 new regression tests (page-cap ordering, explained-gap non-suspect, unexplained-gap suspect)
- [x] `npx vitest run tests/unit/adam/` — 375/375 pass
- [x] `npm run test:unit` — only 2 pre-existing, unrelated failures (verified present on clean origin/main before this change)
- [x] Live-verified against production DB: `computeUtilization` now returns `live_workers: 8` (was 0); `computeFailLoudIntegrity` returns `integrity_ok: true, human_action_held: 11, instrument_suspect: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)