### PR TITLE
fix(QF-20260720-054): decomposition children inherit metadata.sourced_by + backfill 106 rows

### DIFF
--- a/lib/sd/child-linkage.js
+++ b/lib/sd/child-linkage.js
@@ -24,6 +24,13 @@
  * child set leaves parent scope elements uncovered. This is advisory-only — see
  * scope-coverage.js's module doc for why a hard-blocking check here would be wrong.
  *
+ * QF-20260720-054 (Solomon Mode-B advisory d64ca850): linkChild() now also INHERITS the
+ * parent's metadata.sourced_by onto the child as a PERSISTED stamp (computeInheritedSourcedBy)
+ * so sourced_by-keyed yield gauges count decomposition children instead of undercounting them
+ * (children were created with a null stamp). Never overwrites an existing child stamp. A
+ * one-time backfill of pre-existing null children lives in
+ * scripts/backfill-child-sourced-by.mjs (companion key sourced_by_backfilled=true).
+ *
  * @module lib/sd/child-linkage
  */
 
@@ -101,6 +108,29 @@ export function computeChildLinkage(parent, childKey, opts = {}) {
 }
 
 /**
+ * PURE: decide the metadata.sourced_by value to STAMP on a decomposition child so its
+ * provenance is INHERITED from the parent — a PERSISTED stamp, NOT a read-time join. This
+ * is what lets sourced_by-keyed yield gauges count children instead of undercounting them
+ * (the child-creation path never inherited, so children carried a null stamp).
+ *
+ * Returns the parent's sourced_by when the parent carries one AND the child does not yet
+ * (never overwrites an existing child stamp); returns null when there is nothing to inherit.
+ * QF-20260720-054 (Solomon Mode-B advisory d64ca850).
+ *
+ * @param {object|null|undefined} parentMeta - parent SD metadata
+ * @param {object|null|undefined} childMeta - child SD's CURRENT metadata
+ * @returns {string|null} the value to stamp, or null for "no change"
+ */
+export function computeInheritedSourcedBy(parentMeta, childMeta) {
+  const isObj = (m) => m && typeof m === 'object' && !Array.isArray(m);
+  const parentStamp = isObj(parentMeta) ? parentMeta.sourced_by : null;
+  if (parentStamp == null || parentStamp === '') return null;      // nothing to inherit
+  const childStamp = isObj(childMeta) ? childMeta.sourced_by : null;
+  if (childStamp != null && childStamp !== '') return null;        // never overwrite an existing stamp
+  return parentStamp;
+}
+
+/**
  * Governed IO wrapper: wire a child to its parent in ONE step — set the child's
  * parent_sd_id + relationship_type='child' AND (idempotently) register the child in the
  * parent's registry. RE-FETCHES the parent's current metadata before merging so the
@@ -131,9 +161,27 @@ export async function linkChild(supabase, parent, childKey, opts = {}) {
     computeChildLinkage(parentNow, childKey, opts);
 
   // 1) Child fields — parent_sd_id + relationship_type='child' (the linkage contract).
+  // Also INHERIT the parent's provenance stamp (metadata.sourced_by) onto the child as a
+  // PERSISTED stamp (QF-20260720-054) so sourced_by-keyed yield gauges count children. The
+  // child is inserted with its own metadata before linkChild runs, so re-fetch it and merge
+  // — computeInheritedSourcedBy never clobbers an existing child stamp.
+  let childUpdate = childFields;
+  const { data: childRow } = await supabase
+    .from('strategic_directives_v2')
+    .select('metadata')
+    .eq('sd_key', childKey)
+    .single();
+  const childMeta = (childRow?.metadata && typeof childRow.metadata === 'object' && !Array.isArray(childRow.metadata))
+    ? childRow.metadata
+    : {};
+  const inheritedSourcedBy = computeInheritedSourcedBy(parentNow.metadata, childMeta);
+  if (inheritedSourcedBy != null) {
+    childUpdate = { ...childFields, metadata: { ...childMeta, sourced_by: inheritedSourcedBy, sourced_by_inherited: true } };
+  }
+
   const { error: cErr } = await supabase
     .from('strategic_directives_v2')
-    .update(childFields)
+    .update(childUpdate)
     .eq('sd_key', childKey);
   if (cErr) throw new Error(`linkChild: failed to set child fields on ${childKey}: ${cErr.message}`);
 
@@ -197,4 +245,4 @@ export async function linkChild(supabase, parent, childKey, opts = {}) {
   };
 }
 
-export default { computeChildLinkage, linkChild, deriveChildLetter };
+export default { computeChildLinkage, computeInheritedSourcedBy, linkChild, deriveChildLetter };

--- a/scripts/backfill-child-sourced-by.mjs
+++ b/scripts/backfill-child-sourced-by.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * QF-20260720-054 — one-time backfill: stamp metadata.sourced_by on decomposition children
+ * created before linkChild() inherited it (Solomon Mode-B advisory d64ca850).
+ *
+ * For every child (parent_sd_id set) whose metadata.sourced_by is null/absent, copy the
+ * PARENT's metadata.sourced_by onto the child with a companion key sourced_by_backfilled=true
+ * (so a backfilled stamp is distinguishable from a natively-sourced one). Reuses the SAME
+ * inheritance rule as the live path (computeInheritedSourcedBy) so the two never drift.
+ *
+ * DRY-RUN by default; pass --apply to write. Idempotent — a second --apply run finds nothing
+ * (children now carry a stamp). Run from the shared repo root so dotenv resolves .env:
+ *   node scripts/backfill-child-sourced-by.mjs            # dry-run
+ *   node scripts/backfill-child-sourced-by.mjs --apply    # write
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { computeInheritedSourcedBy } from '../lib/sd/child-linkage.js';
+
+const APPLY = process.argv.includes('--apply');
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) { console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY'); process.exit(1); }
+const sb = createClient(url, key);
+
+const isObj = (m) => m && typeof m === 'object' && !Array.isArray(m);
+
+// 1) Page through ALL children (PostgREST caps at 1000/req — never trust a single page).
+const PAGE = 1000;
+let offset = 0;
+const children = [];
+for (;;) {
+  const { data, error } = await sb
+    .from('strategic_directives_v2')
+    .select('sd_key, parent_sd_id, metadata')
+    .not('parent_sd_id', 'is', null)
+    .range(offset, offset + PAGE - 1);
+  if (error) { console.error('child fetch failed:', error.message); process.exit(1); }
+  children.push(...data);
+  if (data.length < PAGE) break;
+  offset += PAGE;
+}
+
+// 2) Candidates = children with a null/absent stamp.
+const candidates = children.filter((c) => {
+  const s = isObj(c.metadata) ? c.metadata.sourced_by : null;
+  return s == null || s === '';
+});
+
+// Parent metadata lookup (cached). parent_sd_id stores parent.id (uuid or sd_key); try id,
+// then uuid_id, then sd_key so both autonomy (id=sd_key) and generic (id=uuid) parents match.
+const parentCache = new Map();
+async function parentMeta(ref) {
+  if (!ref) return null;
+  if (parentCache.has(ref)) return parentCache.get(ref);
+  let { data } = await sb.from('strategic_directives_v2').select('metadata').eq('id', ref).maybeSingle();
+  if (!data) ({ data } = await sb.from('strategic_directives_v2').select('metadata').eq('uuid_id', ref).maybeSingle());
+  if (!data) ({ data } = await sb.from('strategic_directives_v2').select('metadata').eq('sd_key', ref).maybeSingle());
+  const meta = data?.metadata ?? null;
+  parentCache.set(ref, meta);
+  return meta;
+}
+
+let backfilled = 0, noParentStamp = 0, errors = 0;
+const changes = [];
+for (const c of candidates) {
+  const inherited = computeInheritedSourcedBy(await parentMeta(c.parent_sd_id), c.metadata);
+  if (inherited == null) { noParentStamp++; continue; }   // parent absent or itself unstamped
+  changes.push({ sd_key: c.sd_key, sourced_by: inherited });
+  if (APPLY) {
+    const merged = { ...(isObj(c.metadata) ? c.metadata : {}), sourced_by: inherited, sourced_by_backfilled: true };
+    const { error } = await sb.from('strategic_directives_v2').update({ metadata: merged }).eq('sd_key', c.sd_key);
+    if (error) { console.error(`  ✗ ${c.sd_key}: ${error.message}`); errors++; continue; }
+    backfilled++;
+  }
+}
+
+console.log(`\nchildren=${children.length}  null-stamp candidates=${candidates.length}`);
+console.log(`would-backfill=${changes.length}  skipped (no parent stamp)=${noParentStamp}`);
+for (const ch of changes.slice(0, 25)) console.log(`  ${APPLY ? '✓' : '·'} ${ch.sd_key} ← sourced_by='${ch.sourced_by}'`);
+if (changes.length > 25) console.log(`  … +${changes.length - 25} more`);
+console.log(APPLY ? `\nAPPLIED: backfilled=${backfilled} errors=${errors}` : `\nDRY-RUN (no writes). Re-run with --apply to persist.`);

--- a/tests/unit/sd-child-linkage.test.js
+++ b/tests/unit/sd-child-linkage.test.js
@@ -8,7 +8,7 @@
  * AND a child is NEVER an 'orchestrator'. No DB/IO — every assertion is over the pure fn.
  */
 import { describe, it, expect } from 'vitest';
-import { computeChildLinkage, deriveChildLetter } from '../../lib/sd/child-linkage.js';
+import { computeChildLinkage, computeInheritedSourcedBy, deriveChildLetter } from '../../lib/sd/child-linkage.js';
 
 const AUTONOMY_PARENT = {
   id: 'SD-LEO-INFRA-ADAM-AUTONOMY-HARDENING-001',
@@ -105,5 +105,28 @@ describe('computeChildLinkage — invariants', () => {
     expect(deriveChildLetter('SD-X-001-F')).toBe('F');
     expect(deriveChildLetter('SD-X-001')).toBeNull();
     expect(deriveChildLetter('')).toBeNull();
+  });
+});
+
+describe('computeInheritedSourcedBy — provenance inheritance (QF-20260720-054)', () => {
+  it('returns the parent stamp when the child has none', () => {
+    expect(computeInheritedSourcedBy({ sourced_by: 'solomon' }, {})).toBe('solomon');
+    expect(computeInheritedSourcedBy({ sourced_by: 'adam' }, { source: 'leo' })).toBe('adam');
+  });
+
+  it('never overwrites an existing child stamp', () => {
+    expect(computeInheritedSourcedBy({ sourced_by: 'solomon' }, { sourced_by: 'chairman' })).toBeNull();
+  });
+
+  it('returns null when the parent has nothing to inherit', () => {
+    expect(computeInheritedSourcedBy({}, {})).toBeNull();
+    expect(computeInheritedSourcedBy({ sourced_by: '' }, {})).toBeNull();
+    expect(computeInheritedSourcedBy(null, {})).toBeNull();
+  });
+
+  it('tolerates null / array metadata without throwing', () => {
+    expect(computeInheritedSourcedBy(undefined, undefined)).toBeNull();
+    expect(computeInheritedSourcedBy([{ sourced_by: 'x' }], {})).toBeNull();          // array parent → no stamp
+    expect(computeInheritedSourcedBy({ sourced_by: 'solomon' }, ['x'])).toBe('solomon'); // array child → no existing stamp
   });
 });


### PR DESCRIPTION
## QF-20260720-054 — Decomposition children inherit `metadata.sourced_by`

**Source:** Solomon Mode-B sweep advisory `d64ca850` (2026-07-20; primary verdict CLEAN on 30-SD grounding sample — this was the one hygiene find).

### Problem
The child-creation path (`lib/sd/child-linkage.js`) set only `parent_sd_id` + `relationship_type='child'` on children — it never inherited the parent's `metadata.sourced_by`. Children carried a null stamp, so `sourced_by`-keyed yield gauges undercounted (A-EV1 excluded all children).

### Fix
- **`computeInheritedSourcedBy(parentMeta, childMeta)`** — new PURE, unit-tested helper: returns the parent's `sourced_by` only when the parent carries one and the child does not (never overwrites an existing child stamp; returns null when there's nothing to inherit).
- **`linkChild()`** — re-fetches the child's current metadata and stamps the inherited value as a **persisted** field (companion key `sourced_by_inherited=true`), merged so existing child metadata is preserved.
- **`scripts/backfill-child-sourced-by.mjs`** — one-time, dry-run-by-default, idempotent, paginated (1000-row cap safe) migration reusing the same rule (companion key `sourced_by_backfilled=true`).

### Backfill result (applied via service role)
- **106** pre-existing null children stamped from their parent (mostly `adam`).
- **2198** children whose parent *itself* has no `sourced_by` are correctly left null — provenance is inherited, never fabricated.
- Idempotent: post-apply dry-run shows `would-backfill=0`.

### Overlap check (per QF description)
ROLE-MEASUREMENT-INTEGRITY-001 was flagged as possibly owning this surface — **cleared**: that SD (shipped, PR #6307) touched cost telemetry / adherence probes, not `child-linkage.js`. This surface had zero `sourced_by` references before this change.

### Tests
`tests/unit/sd-child-linkage.test.js` — 4 new cases for the pure helper. **15/15 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)