### PR TITLE
fix(QF-20260719-188): CLI authoring surface for chairman DECISION packets

### DIFF
--- a/scripts/adam-chairman-decision.mjs
+++ b/scripts/adam-chairman-decision.mjs
@@ -1,0 +1,65 @@
+// adam-chairman-decision.mjs — QF-20260719-188: CLI authoring surface for chairman DECISION
+// packets. adam-chairman-sms.mjs is status-only (--body/--kind/--dedupe-key); the rubric-engine
+// lint hard-blocks any decision-shaped body unless the message carries the structured fields
+// (labeled options, replyInstruction, replyId, DETAILS keyword, no-reply consequence) — so every
+// decision sent via the status CLI bounced at the gate. This wrapper maps flags to that structured
+// shape and routes through the SAME rubric-gated sendChairmanSMS path adam-chairman-sms.mjs already
+// uses, so decisions get gate+staging+owed-state instead of bouncing to the raw fallback.
+import 'dotenv/config';
+import crypto from 'crypto';
+import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
+import { sendChairmanSMS } from '../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+
+enforceCliSendGuard({
+  scriptName: 'scripts/adam-chairman-decision.mjs',
+  flags: [
+    { name: '--dry-run' }, { name: '--body', takesValue: true }, { name: '--option', takesValue: true },
+    { name: '--recommend', takesValue: true }, { name: '--reply-instruction', takesValue: true },
+    { name: '--reply-id', takesValue: true }, { name: '--no-reply-policy', takesValue: true },
+    { name: '--decision-id', takesValue: true }, { name: '--dedupe-key', takesValue: true },
+  ],
+});
+
+const DRY = process.argv.includes('--dry-run');
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+function argValues(flag) {
+  const out = [];
+  for (let i = 0; i < process.argv.length; i++) if (process.argv[i] === flag) out.push(process.argv[i + 1]);
+  return out;
+}
+
+const bodyText = argValue('--body');
+const options = argValues('--option').map((label) => ({ label }));
+const recommend = argValue('--recommend');
+const replyId = argValue('--reply-id') || crypto.randomBytes(4).toString('hex');
+const noReplyConsequence = argValue('--no-reply-policy');
+const replyInstruction = argValue('--reply-instruction')
+  || `Reply with the option letter, or DETAILS for more context (ref ${replyId}).`;
+
+if (!bodyText || !bodyText.trim() || options.length < 2 || !noReplyConsequence || !noReplyConsequence.trim()) {
+  console.warn('[adam-chairman-decision] --body, at least two --option, and --no-reply-policy are required — nothing sent');
+  process.exit(0);
+}
+
+const body = recommend ? `${bodyText.trim()}\nRecommend: ${recommend.trim()}` : bodyText.trim();
+const message = {
+  type: 'decision',
+  body,
+  options,
+  replyInstruction,
+  replyId,
+  noReplyConsequence: noReplyConsequence.trim(),
+  decisionId: argValue('--decision-id') || null,
+  dedupeKey: argValue('--dedupe-key') || null,
+};
+const context = { now: new Date() };
+
+if (DRY) {
+  console.log('=== [ADAM CHAIRMAN DECISION — DRY RUN] no send ===\n' + JSON.stringify(message, null, 2));
+} else {
+  const r = await sendChairmanSMS(message, context);
+  console.log('ADAM-CHAIRMAN-DECISION', JSON.stringify(r));
+}


### PR DESCRIPTION
## Summary
- `scripts/adam-chairman-sms.mjs` is status-only (`--body`/`--kind`/`--dedupe-key`); the rubric-engine lint hard-blocks any decision-shaped body unless it carries labeled options, a reply instruction, a reply ID, a DETAILS affordance, and a no-reply consequence — so every decision packet sent through the status CLI either bounced at the gate (pre-QF-793) or now silently downgrades to a status send (post-QF-793's classifier hardening).
- Adds `scripts/adam-chairman-decision.mjs`, mapping `--option`/`--reply-id`/`--reply-instruction`/`--no-reply-policy`/`--recommend`/`--decision-id`/`--dedupe-key` flags to the structured decision message shape and routing through the same rubric-gated `sendChairmanSMS` path, so decisions always explicitly declare `type:'decision'` and pass the gate with staging + owed-state (matching the ratified SMS decision-packet format: terse context → labeled options → recommendation → explicit reply instruction → DETAILS keyword).

## Test plan
- [x] `npx eslint scripts/adam-chairman-decision.mjs` — clean
- [x] `npx vitest run tests/unit/comms/rubric-engine tests/unit/chairman/sms-bridge.test.js tests/unit/chairman/sms-channel-health.test.js tests/unit/notifications/cli-send-guard.test.js` — 47/47 pass
- [x] Manual `--dry-run` verification of the constructed message shape
- [x] Verified the constructed message passes `evaluate()`/`lint()` (verdict: pass, 0 blocked reasons) — reproduces the fix for the exact rubric checks the QF cites
- [x] Verified `--help`, missing-required-fields, and unknown-flag fail-closed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)