### PR TITLE
fix(QF-20260719-208): wire pre-send Solomon-consult gate into adam-quiet-tick

### DIFF
--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -29,6 +29,7 @@ import { TABLE as TASK_LEDGER_TABLE, syncParentRollupStatus } from '../lib/adam/
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
+const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
 const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
@@ -469,13 +470,31 @@ async function main() {
     try {
       const coordinatorId = await getActiveCoordinatorId(sb);
       if (coordinatorId) {
+        const subject = '[ACCOUNT_SWITCH] Adam session Claude account changed';
+        const body = `Adam's Claude account switched from ${acctSwitch.event.from.email} (${acctSwitch.event.from.orgName}) ` +
+          `to ${acctSwitch.event.to.email} (${acctSwitch.event.to.orgName}).`;
+        // QF-20260719-208: mirror adam-advisory.cjs's L1 pre-send Solomon-consult gate at this
+        // tick's emit choke (previously bypassed it entirely). The tick is non-interactive (no
+        // live session to bounded-await a reply against), so a required consult fires a durable,
+        // non-blocking solomon_consult row alongside the send rather than adam-advisory's
+        // synchronous wait — Solomon still sees every consequential tick-originated send.
+        // Fail-open by construction: a gate/consult error never blocks the account-switch notice.
+        try {
+          const { evaluatePreSendConsult } = await import('../lib/adam/should-consult-solomon.js');
+          if (evaluatePreSendConsult({ title: subject, body, isChairmanTargeted: false }).action === 'consult-then-send') {
+            const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+            const { buildSolomonConsultPayload } = require('./worker-signal.cjs');
+            const solomonId = await getActiveSolomonId(sb).catch(() => null);
+            const cp = buildSolomonConsultPayload({ correlationId: crypto.randomUUID(), body: `[PRE-SEND CONSULT] ${body}`, senderCallsign: 'adam-quiet-tick', repo: process.cwd(), severity: 'high' });
+            await insertCoordinationRow(sb, { sender_type: 'adam', target_session: solomonId || 'broadcast-solomon', message_type: 'INFO', subject: '[SOLOMON_CONSULT] pre-send', body: cp.body, payload: cp }, { targetRoleHint: 'solomon' });
+          }
+        } catch { /* fail-open — see comment above */ }
         await insertCoordinationRow(sb, {
           sender_type: 'adam',
           target_session: coordinatorId,
           message_type: 'INFO',
-          subject: '[ACCOUNT_SWITCH] Adam session Claude account changed',
-          body: `Adam's Claude account switched from ${acctSwitch.event.from.email} (${acctSwitch.event.from.orgName}) ` +
-            `to ${acctSwitch.event.to.email} (${acctSwitch.event.to.orgName}).`,
+          subject,
+          body,
           payload: { kind: 'account_switch_notice', ...acctSwitch.event, reply_class: 'fire-and-forget' },
         });
         acctNotified = true;

--- a/tests/unit/adam/adam-quiet-tick-presend-consult.test.js
+++ b/tests/unit/adam/adam-quiet-tick-presend-consult.test.js
@@ -1,0 +1,37 @@
+/**
+ * QF-20260719-208 — regression coverage for the pre-send Solomon-consult gate at
+ * adam-quiet-tick.mjs's account-switch emit choke. SD-LEO-INFRA-ADAM-PRE-SEND-001
+ * shipped the L1 gate in scripts/adam-advisory.cjs, but the quiet-tick's
+ * insertCoordinationRow callsite (~line 472) had zero consult references — sends
+ * from the tick bypassed the gate entirely. The full bounded-consult machinery
+ * isn't unit-testable without extracting the tick's main() into smaller exported
+ * functions (out of scope for this fix), so this covers the two things that matter:
+ * the gate correctly flags this message class as consequential, and the source
+ * actually wires it at the right choke (regression guard against silently dropping
+ * the gate again).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { evaluatePreSendConsult } from '../../../lib/adam/should-consult-solomon.js';
+
+describe('adam-quiet-tick.mjs account-switch send — pre-send consult gate (QF-20260719-208)', () => {
+  it('a representative ACCOUNT_SWITCH body classifies as consequential (consult required)', () => {
+    const subject = '[ACCOUNT_SWITCH] Adam session Claude account changed';
+    const body = "Adam's Claude account switched from old@example.com (OldOrg) to new@example.com (NewOrg).";
+    const result = evaluatePreSendConsult({ title: subject, body, isChairmanTargeted: false });
+    expect(result.action).toBe('consult-then-send');
+  });
+
+  it('wires evaluatePreSendConsult ahead of the account-switch insertCoordinationRow choke (static regression guard)', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('../../../scripts/adam-quiet-tick.mjs', import.meta.url)),
+      'utf8',
+    );
+    const idx = source.indexOf("kind: 'account_switch_notice'");
+    expect(idx).toBeGreaterThan(-1);
+    const before = source.slice(Math.max(0, idx - 1500), idx);
+    expect(before).toContain('evaluatePreSendConsult');
+    expect(before).toContain('should-consult-solomon.js');
+  });
+});


### PR DESCRIPTION
## Summary
- `adam-advisory.cjs`'s L1 pre-send Solomon-consult gate (SD-LEO-INFRA-ADAM-PRE-SEND-001) was never wired into `adam-quiet-tick.mjs`'s ACCOUNT_SWITCH `insertCoordinationRow` choke (~line 472) — sends from the tick bypassed the L1 gate entirely.
- Live-verified `evaluatePreSendConsult` classifies a representative ACCOUNT_SWITCH body as `consult-then-send` (fail-closed unknown→high), confirming the gap was real, not theoretical.
- The tick runs non-interactively (no live session to bounded-await a Solomon reply against, unlike `adam-advisory.cjs`'s synchronous `performBoundedConsult`), so this mirrors the gate by firing a durable, non-blocking `solomon_consult` row alongside the send — Solomon still sees every consequential tick-originated send. Fail-open by construction: a gate/consult error never blocks the account-switch notice itself.

## Test plan
- [x] `npx vitest run tests/unit/adam/adam-quiet-tick-presend-consult.test.js` — 2/2 pass (classification check + static regression guard against the gate being silently dropped again)
- [x] `npx vitest run tests/unit/adam/ tests/unit/coordinator/` — 815/815 pass, no regressions
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] `node --check scripts/adam-quiet-tick.mjs` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)