### PR TITLE
fix(QF-20260720-851): rejection writers stamp a reason + subagent-evidence preflight

### DIFF
--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -1142,7 +1142,7 @@ export class BaseExecutor {
 
     if (!session) {
       console.log('   [Claim] ❌ No session available - cannot proceed without claim');
-      return { success: false, error: 'Claim required - no session available' };
+      return { success: false, error: 'Claim required - no session available', message: 'Claim required - no session available' };
     }
 
     const result = await claimGuard(claimId, session.session_id);
@@ -1150,7 +1150,13 @@ export class BaseExecutor {
     if (!result.success) {
       console.log(formatClaimFailure(result));
       console.log('   [Claim] ❌ Cannot proceed - claim guard rejected');
-      return { success: false, error: 'Claim required - cannot proceed without valid SD claim', claimConflict: true };
+      // QF-20260720-851 (P1): fold the claimGuard verdict's own error/status into a
+      // concrete `.message` — recorder writers key rejection_reason off `.message`, and
+      // the prior hardcoded string (with no verdict detail) is exactly what produced a
+      // NULL/uninformative rejection_reason for every claim-guard rejection.
+      const detail = result.status ? `${result.error} (status=${result.status})` : (result.fence || result.error || 'unknown');
+      const message = `Claim guard rejected: ${detail}`;
+      return { success: false, error: message, message, claimConflict: true };
     }
 
     console.log(`   [Claim] ✅ SD ${claimId} claimed (${result.claim.status})`);

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -157,6 +157,32 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
       default:
         break;
     }
+
+    // QF-20260720-851 (P2): surface missing sub-agent evidence BEFORE the full gate
+    // run. Reuses the SAME validator the real GATE_SUBAGENT_EVIDENCE gate enforces
+    // (no drift, no gate weakening, no auto-invoking agents) so a worker sees the
+    // missing-agent checklist in ~10s instead of discovering it after a full,
+    // expensive gate-pipeline run (SUBAGENT_EVIDENCE_MISSING was 24 rejections over
+    // 9 SDs in a 48h window, ~12-min mean retry latency, 23/24 resolved on retry —
+    // an ordering speed-bump, not a quality catch). A WAIT verdict (evidence may
+    // still be mid-write) is intentionally NOT treated as a preflight failure.
+    try {
+      const { validateSubagentEvidence } = await import('../gates/subagent-evidence-gate.js');
+      const evidenceResult = await validateSubagentEvidence(
+        { sd, handoffType: handoffType.toUpperCase(), supabase, sdId: sd.id },
+        supabase
+      );
+      if (evidenceResult.passed === false && !evidenceResult.wait) {
+        issues.push({
+          code: 'SUBAGENT_EVIDENCE_MISSING',
+          message: `Missing sub-agent evidence for: ${(evidenceResult.details?.missing || []).join(', ') || 'required agent(s)'}`,
+          remediation: evidenceResult.remediation || 'Invoke the missing sub-agent(s) via the Task tool before re-running the handoff.'
+        });
+      }
+    } catch (evidenceErr) {
+      // Fail-open: the real gate still enforces this later — preflight is UX only.
+      console.warn(`   ⚠️  Sub-agent evidence preflight error (non-blocking): ${evidenceErr.message}`);
+    }
   } catch (err) {
     // Fail-open: don't block handoff if preflight itself errors
     console.warn(`   ⚠️  Prerequisite preflight error (non-blocking): ${err.message}`);

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -344,12 +344,16 @@ export class HandoffRecorder {
         : null;
     const actualScore = result.details?.actualScore ?? result.actualScore ?? null;
     const requiredScore = result.details?.requiredScore ?? result.requiredScore ?? null;
-    let enrichedRejectionReason = result.message;
+    // QF-20260720-851 (P1): some rejecting callers (e.g. BaseExecutor's claim-guard early
+    // return) set only `.error`/`.reasonCode`, never `.message` — that silently wrote
+    // rejection_reason=NULL (40% of rejections over a 48h Solomon sweep, diagnosis-resistant
+    // by construction). Every rejection writer now stamps SOME reason.
+    let enrichedRejectionReason = result.message || result.error || result.reasonCode || 'UNSPECIFIED_REJECTION (see validation_details)';
     if (requiredImprovements) {
       const scoreSuffix = (actualScore != null && requiredScore != null)
         ? ` (score ${actualScore}%, required ${requiredScore}%)`
         : '';
-      enrichedRejectionReason = `${result.message} | deficits: ${requiredImprovements.join('; ')}${scoreSuffix}`.slice(0, 1000);
+      enrichedRejectionReason = `${enrichedRejectionReason} | deficits: ${requiredImprovements.join('; ')}${scoreSuffix}`.slice(0, 1000);
     }
 
     // SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 (FR-1): completion actions record
@@ -509,7 +513,9 @@ export class HandoffRecorder {
           ? { gate_results: perGateResults, gate_results_version: 2 }
           : {})
       },
-      rejection_reason: result.message,
+      // QF-20260720-851 (P1): same NULL-reason fix as recordFailure — some rejecting
+      // callers (e.g. the claim-guard early return) set only `.error`/`.reasonCode`.
+      rejection_reason: result.message || result.error || result.reasonCode || 'UNSPECIFIED_REJECTION (see validation_details)',
       created_by: recorderIdentity()
     };
 

--- a/tests/unit/handoff/prerequisite-preflight-smoke-exemption.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-smoke-exemption.test.js
@@ -111,7 +111,18 @@ describe('shouldRequireSmokeTest() helper', () => {
 describe('checkLeadToPlanPrereqs SMOKE_TEST bypass behavior', () => {
   function makeMockSupabase({ sdRow }) {
     return {
-      from: () => {
+      from: (table) => {
+        // QF-20260720-851 (P2): the subagent-evidence preflight check now runs for
+        // every handoffType — stub fresh evidence so these unrelated (smoke-test
+        // exemption) tests don't also see a spurious SUBAGENT_EVIDENCE_MISSING issue.
+        if (table === 'sub_agent_execution_results') {
+          const rows = ['VALIDATION', 'Explore', 'TESTING', 'SECURITY', 'RETRO'].map((code) => ({
+            sub_agent_code: code, created_at: new Date().toISOString(), verdict: 'PASS'
+          }));
+          return {
+            select: () => ({ eq: () => ({ gte: async () => ({ data: rows, error: null }) }) })
+          };
+        }
         const builder = {
           select: () => builder,
           eq: () => builder,

--- a/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-stories-exemption.test.js
@@ -69,6 +69,18 @@ describe('checkPlanToExecPrereqs USER_STORIES bypass behavior', () => {
             })
           };
         }
+        // QF-20260720-851 (P2): the subagent-evidence preflight check now runs for
+        // every handoffType — stub fresh evidence for all possible required agents
+        // so these unrelated (stories-exemption) tests don't also see a spurious
+        // SUBAGENT_EVIDENCE_MISSING issue.
+        if (table === 'sub_agent_execution_results') {
+          const rows = ['VALIDATION', 'Explore', 'TESTING', 'SECURITY', 'RETRO'].map((code) => ({
+            sub_agent_code: code, created_at: new Date().toISOString(), verdict: 'PASS'
+          }));
+          return {
+            select: () => ({ eq: () => ({ gte: async () => ({ data: rows, error: null }) }) })
+          };
+        }
         const builder = {
           select: () => builder,
           eq: () => builder,
@@ -207,6 +219,18 @@ describe('QF-20260423-666: passed filters info-severity entries', () => {
             select: () => ({
               eq: async () => ({ data: storyRows, error: null })
             })
+          };
+        }
+        // QF-20260720-851 (P2): the subagent-evidence preflight check now runs for
+        // every handoffType — stub fresh evidence for all possible required agents
+        // so these unrelated (stories-exemption) tests don't also see a spurious
+        // SUBAGENT_EVIDENCE_MISSING issue.
+        if (table === 'sub_agent_execution_results') {
+          const rows = ['VALIDATION', 'Explore', 'TESTING', 'SECURITY', 'RETRO'].map((code) => ({
+            sub_agent_code: code, created_at: new Date().toISOString(), verdict: 'PASS'
+          }));
+          return {
+            select: () => ({ eq: () => ({ gte: async () => ({ data: rows, error: null }) }) })
           };
         }
         const builder = {

--- a/tests/unit/handoff/prerequisite-preflight-subagent-evidence.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-subagent-evidence.test.js
@@ -1,0 +1,87 @@
+/**
+ * QF-20260720-851 (P2): surface missing sub-agent evidence at PREFLIGHT time
+ * (before the expensive full gate run), reusing the SAME validator the real
+ * GATE_SUBAGENT_EVIDENCE gate enforces.
+ *
+ * Solomon Mode-B sweep 90c52ff1: SUBAGENT_EVIDENCE_MISSING was 24/87 rejections
+ * over 9 SDs in a 48h window, mean 12-min retry latency, 23/24 resolved on
+ * retry — an ordering speed-bump, not a real quality catch. This converts that
+ * into a ~10-second checklist read at preflight instead of a full gate-pipeline
+ * round trip.
+ */
+import { describe, it, expect } from 'vitest';
+import { runPrerequisitePreflight } from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+function makeMockSupabase({ sdRow, evidenceRows = [] }) {
+  return {
+    from: (table) => {
+      if (table === 'sub_agent_execution_results') {
+        return {
+          select: () => ({ eq: () => ({ gte: async () => ({ data: evidenceRows, error: null }) }) })
+        };
+      }
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        or: () => builder,
+        gte: () => builder,
+        not: () => builder,
+        order: () => builder,
+        limit: async () => ({ data: [], error: null }),
+        single: async () => {
+          if (table === 'strategic_directives_v2') return { data: sdRow, error: null };
+          return { data: null, error: null };
+        }
+      };
+      return builder;
+    }
+  };
+}
+
+const BASE_SD = {
+  id: 'SD-TEST-EVIDENCE-001',
+  sd_key: 'SD-TEST-EVIDENCE-001',
+  sd_type: 'infrastructure',
+};
+
+describe('QF-20260720-851 (P2): subagent-evidence preflight', () => {
+  it('surfaces SUBAGENT_EVIDENCE_MISSING when the required agent has no fresh row (PLAN-TO-LEAD needs RETRO)', async () => {
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: [] });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-EVIDENCE-001');
+    const issue = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_MISSING');
+    expect(issue).toBeTruthy();
+    expect(issue.message).toContain('RETRO');
+    expect(result.passed).toBe(false);
+  });
+
+  it('does NOT surface SUBAGENT_EVIDENCE_MISSING when fresh evidence exists', async () => {
+    const supabase = makeMockSupabase({
+      sdRow: BASE_SD,
+      evidenceRows: [{ sub_agent_code: 'RETRO', created_at: new Date().toISOString(), verdict: 'PASS' }],
+    });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-EVIDENCE-001');
+    expect(result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_MISSING')).toBeUndefined();
+  });
+
+  it('never blocks LEAD-FINAL-APPROVAL (empty required set for that handoff type)', async () => {
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: [] });
+    const result = await runPrerequisitePreflight(supabase, 'LEAD-FINAL-APPROVAL', 'SD-TEST-EVIDENCE-001');
+    expect(result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_MISSING')).toBeUndefined();
+  });
+
+  it('fails open (never throws) if the evidence gate import/query itself errors', async () => {
+    const brokenSupabase = {
+      from: (table) => {
+        if (table === 'sub_agent_execution_results') {
+          return { select: () => ({ eq: () => ({ gte: () => { throw new Error('boom'); } }) }) };
+        }
+        return makeMockSupabase({ sdRow: BASE_SD }).from(table);
+      }
+    };
+    const result = await runPrerequisitePreflight(brokenSupabase, 'PLAN-TO-LEAD', 'SD-TEST-EVIDENCE-001');
+    // A gate-internal DB_ERROR is itself a FAIL verdict (not a throw) — the preflight
+    // surfaces it as a blocking issue rather than silently passing, but must never throw.
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result.issues)).toBe(true);
+  });
+});

--- a/tests/unit/handoff/recorder-rejection-enrichment.test.js
+++ b/tests/unit/handoff/recorder-rejection-enrichment.test.js
@@ -102,3 +102,43 @@ describe('FR-3: recordFailure rejection enrichment', () => {
     expect(row.validation_details.summary.required_improvements).toBeUndefined();
   });
 });
+
+// QF-20260720-851 (P1): a Solomon 48h sweep found 35/87 (40%) rejections with
+// rejection_reason=NULL — reproduced live via a claim-guard rejection on
+// SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B (BaseExecutor._claimSDForSession sets only
+// `.error`/`.claimConflict`, never `.message`). Every rejection writer must stamp
+// SOME reason rather than silently writing NULL.
+describe('QF-20260720-851 (P1): rejection_reason is never NULL', () => {
+  it('recordFailure falls back to result.error when .message is absent (claim-guard shape)', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    await recorder.recordFailure('PLAN-TO-EXEC', 'SD-TEST-002', {
+      success: false,
+      error: 'Claim guard rejected: sd_terminal_status (status=completed)',
+      claimConflict: true
+    });
+    const row = captured.find(r => r.status === 'rejected');
+    expect(row.rejection_reason).toBe('Claim guard rejected: sd_terminal_status (status=completed)');
+  });
+
+  it('_recordCompletionActionFailure (LEAD-FINAL-APPROVAL) falls back to result.error too', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    await recorder.recordFailure('LEAD-FINAL-APPROVAL', 'SD-TEST-003', {
+      success: false,
+      error: 'Claim guard rejected: sd_terminal_status (status=completed)',
+      claimConflict: true
+    });
+    const row = captured.find(r => r.rejection_reason != null);
+    expect(row).toBeTruthy();
+    expect(row.rejection_reason).toBe('Claim guard rejected: sd_terminal_status (status=completed)');
+  });
+
+  it('falls back to a labeled placeholder when neither .message, .error, nor .reasonCode is set', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    await recorder.recordFailure('PLAN-TO-EXEC', 'SD-TEST-004', { success: false });
+    const row = captured.find(r => r.status === 'rejected');
+    expect(row.rejection_reason).toBe('UNSPECIFIED_REJECTION (see validation_details)');
+  });
+});


### PR DESCRIPTION
## Summary
- **P1**: `rejection_reason` was silently NULL for any rejecting caller that set only `.error`/`.reasonCode` and never `.message` (root cause: `BaseExecutor._claimSDForSession`'s claim-guard early return). Confirmed via a live Solomon 48h sweep (35/87 rejections, 40%, NULL-reasoned) and reproduced directly against my own SD-LEO-INFRA-SMS-DELIVERY-TRUTH-001-B claim-guard rejection (row `9bbfcaf9`). `recordFailure` / `_recordCompletionActionFailure` now fall back `message -> error -> reasonCode -> labeled placeholder`; `_claimSDForSession` now sets a real `.message` from the claimGuard verdict instead of a generic string.
- **P2**: the required sub-agent evidence check now also runs at preflight (reuses the exact `GATE_SUBAGENT_EVIDENCE` validator — no gate weakening, no auto-invoking agents), converting a ~12-min reject-retry loop into a ~10s checklist read. `SUBAGENT_EVIDENCE_MISSING` was 24/87 rejections over 9 SDs in the same 48h window, 23/24 resolved on retry (an ordering speed-bump, not a quality catch).

## Test plan
- [x] `recorder-rejection-enrichment.test.js` — 3 new regression cases: claim-guard-shaped rejection on a phase-transition handoff, on the completion-action (LEAD-FINAL-APPROVAL) path, and the fully-empty-result placeholder fallback. All existing cases (legacy `.message`-only shape, deficit enrichment, 1000-char cap) unchanged.
- [x] `prerequisite-preflight-subagent-evidence.test.js` (new) — missing-evidence surfaced, fresh-evidence silent, LEAD-FINAL-APPROVAL never blocked (empty required set), fail-open on internal error.
- [x] Fixed 2 pre-existing test mocks (`prerequisite-preflight-stories-exemption.test.js`, `prerequisite-preflight-smoke-exemption.test.js`) that didn't stub `sub_agent_execution_results` — they were asserting exact issue-code arrays for an unrelated dimension (user-stories/smoke-test exemption) and needed fresh-evidence stubs so the new preflight check doesn't pollute them.
- [x] Full affected suite: 88 test files, 890 passed / 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)