### PR TITLE
fix(QF-20260720-763): retry QF self-claim query without factory_lane on missing-column error

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -613,24 +613,36 @@ function isAutoStartableQF(qf, nowMs) {
 async function selfClaimQuickFix(sb, sessionId, base, sessionModel) {
   try {
     // factory_lane is a staged, not-yet-applied column
-    // (database/migrations/20260713_quick_fixes_factory_lane.sql) -- until a human/coordinator
-    // applies it, this SELECT fails soft (data undefined -> sortQfCandidatesBySeverity's (qfs||[])
-    // -> no QF self-claimed this tick), the same documented fail-open contract this function
-    // already has, never a throw/crash. SD self-claim (a separate, higher-priority tier) is
-    // unaffected either way. The pragma below MUST stay on the same physical line as .select( --
-    // schema-reference-extract.mjs's pragmaAt() only checks the line containing the .select( match
-    // itself (RCA'd during this SD's own round-2 adversarial review: this line's original
-    // pragma-on-its-own-line form only escaped detection by accident -- the long comment block
-    // pushed .select( past the extractor's 600-char lookahead, silently skipping the whole column
-    // list rather than being intentionally suppressed).
-    const { data: qfs } = await sb
+    // (database/migrations/20260713_quick_fixes_factory_lane.sql). The comment here previously
+    // assumed a missing column fails this SELECT soft per-row; it actually fails the WHOLE
+    // multi-column select (error 42703, data:null), which the caller never checked -- a total
+    // self-claim outage fleet-wide, not graceful degradation (QF-20260720-763, live-verified:
+    // every checkin returned action:idle with claimable QFs sitting open). Retry once without
+    // factory_lane specifically on that error code -- qf.factory_lane then comes back undefined,
+    // which isAutoStartableQF's `if (qf.factory_lane)` truthy-check already treats identically to
+    // the column's own DEFAULT false, so behavior is unchanged once the column eventually lands
+    // (self-heals with no follow-up code change). The pragma below MUST stay on the same physical
+    // line as .select( -- schema-reference-extract.mjs's pragmaAt() only checks the line
+    // containing the .select( match itself.
+    const QF_CANDIDATE_COLUMNS = 'id, status, pr_url, commit_sha, created_at, routing_tier, title, description, severity, not_before, factory_lane, owner, release_condition'; // schema-lint-disable-line: factory_lane staged, see comment above
+    let { data: qfs, error: qfErr } = await sb
       .from('quick_fixes')
-      .select('id, status, pr_url, commit_sha, created_at, routing_tier, title, description, severity, not_before, factory_lane, owner, release_condition') // schema-lint-disable-line: factory_lane staged, see comment above
+      .select(QF_CANDIDATE_COLUMNS)
       .eq('status', 'open')
       .is('pr_url', null)
       .is('commit_sha', null)
       .order('created_at', { ascending: true })
       .limit(QF_CANDIDATE_LIMIT);
+    if (qfErr && qfErr.code === '42703') {
+      ({ data: qfs } = await sb
+        .from('quick_fixes')
+        .select(QF_CANDIDATE_COLUMNS.replace(', factory_lane', ''))
+        .eq('status', 'open')
+        .is('pr_url', null)
+        .is('commit_sha', null)
+        .order('created_at', { ascending: true })
+        .limit(QF_CANDIDATE_LIMIT));
+    }
     const nowMs = Date.now();
     // SD-LEO-INFRA-WORK-CLASS-CLAIM-001 (C-QF-SEAM): the QF path was the model-blind gap —
     // isAutoStartableQF has no capability check, so a Fable seat could always fall through to

--- a/tests/unit/worker-checkin-qf-candidate-query-retry.test.js
+++ b/tests/unit/worker-checkin-qf-candidate-query-retry.test.js
@@ -1,0 +1,75 @@
+/**
+ * QF-20260720-763 — selfClaimQuickFix's candidate query requests quick_fixes.factory_lane, a
+ * staged-not-yet-applied column (database/migrations/20260713_quick_fixes_factory_lane.sql).
+ * A missing column fails the WHOLE multi-column select (Postgres error 42703, data:null), not
+ * per-row — the code only read {data:qfs} and never checked error, so this was a total
+ * self-claim outage fleet-wide (live-verified: every checkin returned action:idle despite open,
+ * unfenced QFs sitting in the queue), not the graceful degradation the original comment assumed.
+ * The fix retries the same query without factory_lane specifically on error.code===42703.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { selfClaimQuickFix } = require('../../scripts/worker-checkin.cjs');
+
+function makeFakeSb({ onSelect, secondAttemptRows = [] } = {}) {
+  return {
+    rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+    from(table) {
+      let selectedCols = '';
+      const builder = {
+        select(cols) {
+          selectedCols = cols || '';
+          onSelect?.(selectedCols);
+          return builder;
+        },
+        eq() { return builder; },
+        is() { return builder; },
+        order() { return builder; },
+        limit() {
+          if (table !== 'quick_fixes') return Promise.resolve({ data: [], error: null });
+          if (selectedCols.includes('factory_lane')) {
+            return Promise.resolve({ data: null, error: { code: '42703', message: 'column quick_fixes.factory_lane does not exist' } });
+          }
+          return Promise.resolve({ data: secondAttemptRows, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('selfClaimQuickFix — retries the candidate query without factory_lane on 42703', () => {
+  it('retries without the missing column instead of silently treating it as zero candidates', async () => {
+    const selects = [];
+    const sb = makeFakeSb({ onSelect: (cols) => selects.push(cols) });
+    const result = await selfClaimQuickFix(sb, 'sess-1', {}, 'sonnet');
+    expect(selects.length).toBe(2);
+    expect(selects[0]).toContain('factory_lane');
+    expect(selects[1]).not.toContain('factory_lane');
+    // Empty candidate fixture on the successful retry -> no claim to make; proves the retry
+    // path ran (2 selects), not that a claim happened.
+    expect(result).toBeNull();
+  });
+
+  it('does not retry when the query succeeds on the first attempt (no unnecessary second query)', async () => {
+    const selects = [];
+    const sb = makeFakeSb({ onSelect: (cols) => selects.push(cols) });
+    // Force the first attempt to "succeed" by never matching factory_lane in this variant's select.
+    const sbNoError = {
+      rpc: sb.rpc,
+      from(table) {
+        const builder = {
+          select(cols) { selects.push(cols); return builder; },
+          eq() { return builder; },
+          is() { return builder; },
+          order() { return builder; },
+          limit() { return Promise.resolve({ data: [], error: null }); },
+        };
+        return builder;
+      },
+    };
+    await selfClaimQuickFix(sbNoError, 'sess-1', {}, 'sonnet');
+    expect(selects.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `selfClaimQuickFix`'s (`scripts/worker-checkin.cjs`) candidate SELECT requests `quick_fixes.factory_lane`, a staged-but-never-applied column (`database/migrations/20260713_quick_fixes_factory_lane.sql` — its own header requires a chairman/Adam-authorized apply, which a fleet worker session cannot self-stamp).
- A missing column fails the **whole** multi-column select (Postgres error `42703`, `data:null`), not per-row as the prior comment assumed. The code only read `{data:qfs}` and never checked `error`, so this silently zeroed self-claim candidates on **every worker checkin, fleet-wide**, since this code path went live.
- Live-verified this session: `belt_claimable_at_my_tier:5` but `action:idle`, repeated across two checkins; direct reproduction confirmed `error.code 42703` on the exact query.
- Fix: retry the same query once without `factory_lane` specifically on that error code. `qf.factory_lane` then comes back `undefined`, which `isAutoStartableQF`'s truthy-check already treats identically to the column's own `DEFAULT false` — unchanged behavior once the column eventually lands, self-heals with no follow-up code change needed.
- Signaled to the coordinator as a high-severity harness bug (`/signal harness-bug`) before filing this QF.

## Test plan
- [x] `npx vitest run tests/unit/worker-checkin-qf-candidate-query-retry.test.js` — 2/2 pass (asserts the retry fires only on `42703`, and only once)
- [x] `npx vitest run tests/unit/worker-checkin*.test.js` — 164/164 pass across 19 files, no regressions
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] Live-verified against production DB: the fallback query (without `factory_lane`) returns 8 real open QF rows and classifies 7 of them as claimable, where the original query throws `42703` every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)