### PR TITLE
fix(QF-20260720-287): retry SMS reconcile claim+send without prior_provider_message_ids on missing-column error

### DIFF
--- a/lib/chairman/sms-outbound-worker.js
+++ b/lib/chairman/sms-outbound-worker.js
@@ -283,12 +283,36 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
   }
 
   // ---- Pass 2: claim + send owed rows (serialized, exactly once) ----
-  const { data: owed } = await supabase
+  // QF-20260720-287: prior_provider_message_ids (Solomon Pin #2, database/migrations/
+  // 20260718_sms_outbound_obligations_STAGED.sql) is chairman-gated STAGED and was never
+  // actually applied live, though the base table + every other column WAS. A missing column
+  // fails this WHOLE select (error 42703, data:null) rather than degrading per-row, so
+  // (owed||[]) silently emptied claimable on every sweep — a total send outage on the gated
+  // path, live-verified: claimed:0/sent:0 fleet-wide since this SD's code merged, masked only
+  // by the direct-Twilio workaround. Detect the column once and drop it from every touchpoint
+  // (this select, the claim-UPDATE's own RETURNING select, and the 'sent' write below) when
+  // absent — the Pin #2 duplicate-SID history feature is simply inert pre-apply, matching the
+  // fail-soft contract this table's own migration file documents; core claim+send is restored.
+  const OWED_SELECT_COLUMNS = 'id, recipient_phone, body, attempts, decision_id, not_before, media_url, provider_message_id, prior_provider_message_ids';
+  let { data: owed, error: owedErr } = await supabase
     .from('sms_outbound_obligations')
-    .select('id, recipient_phone, body, attempts, decision_id, not_before, media_url, provider_message_id, prior_provider_message_ids')
+    .select(OWED_SELECT_COLUMNS)
     .eq('status', 'owed')
     .order('created_at', { ascending: true })
     .limit(batchLimit);
+  let hasPriorSidColumn = true;
+  if (owedErr && owedErr.code === '42703') {
+    hasPriorSidColumn = false;
+    ({ data: owed } = await supabase
+      .from('sms_outbound_obligations')
+      .select(OWED_SELECT_COLUMNS.replace(', prior_provider_message_ids', ''))
+      .eq('status', 'owed')
+      .order('created_at', { ascending: true })
+      .limit(batchLimit));
+  }
+  const claimSelectColumns = hasPriorSidColumn
+    ? 'id, recipient_phone, body, attempts, media_url, provider_message_id, prior_provider_message_ids'
+    : 'id, recipient_phone, body, attempts, media_url, provider_message_id';
 
   // not_before honored: a row queued inside the 10PM-6AM ET sleep window is not eligible until
   // its not_before elapses (FR-3 / sleep-window). Filtered here so an un-due row is never claimed.
@@ -304,7 +328,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
       .eq('id', row.id)
       .eq('status', 'owed')
       .is('claimed_at', null)
-      .select('id, recipient_phone, body, attempts, media_url, provider_message_id, prior_provider_message_ids');
+      .select(claimSelectColumns);
 
     if (!claimed || claimed.length === 0) {
       summary.skipped++;
@@ -357,7 +381,7 @@ export async function reconcileOutboundSms(supabase, opts = {}) {
         .update({
           status: 'sent',
           provider_message_id: result.provider_message_id || null,
-          prior_provider_message_ids: priorProviderMessageIds,
+          ...(hasPriorSidColumn ? { prior_provider_message_ids: priorProviderMessageIds } : {}),
           sent_at: nowIso,
           attempts,
         })

--- a/tests/unit/chairman/sms-outbound-missing-prior-sid-column.test.js
+++ b/tests/unit/chairman/sms-outbound-missing-prior-sid-column.test.js
@@ -1,0 +1,92 @@
+/**
+ * QF-20260720-287 — reconcileOutboundSms's claim+send pass (Pass 2) references
+ * prior_provider_message_ids in three places: the owed-row select, the atomic claim
+ * UPDATE's own RETURNING select, and the terminal 'sent' UPDATE payload. That column is
+ * chairman-gated STAGED (database/migrations/20260718_sms_outbound_obligations_STAGED.sql,
+ * Solomon Pin #2) and was never actually applied live, though the base table + every other
+ * column WAS. A missing column fails the WHOLE query it appears in (Postgres error 42703),
+ * not per-column — live-verified: claimed:0/sent:0 on every real owed row, fleet-wide,
+ * masked only by the direct-Twilio workaround. This models that exact failure mode with a
+ * minimal fake Supabase (no live DB, no live Twilio) and asserts the retry-without-column
+ * path restores claim+send end to end.
+ */
+import { describe, it, expect } from 'vitest';
+import { reconcileOutboundSms } from '../../../lib/chairman/sms-outbound-worker.js';
+
+function makeFakeSupabaseMissingPriorSidColumn(seedRow) {
+  const table = { rows: [seedRow] };
+
+  function columnsRequested(cols) {
+    return String(cols || '').split(',').map((c) => c.trim());
+  }
+
+  function from(name) {
+    if (name !== 'sms_outbound_obligations') {
+      return {
+        select() { return this; }, eq() { return this; }, is() { return this; },
+        order() { return this; }, limit() { return this; },
+        then(resolve) { resolve({ data: [], error: null }); },
+      };
+    }
+    const ctx = { mode: 'select', filters: [], selectCols: null, vals: null };
+    const api = {
+      select(cols) { ctx.selectCols = cols; return api; },
+      update(vals) { ctx.mode = 'update'; ctx.vals = vals; return api; },
+      eq(col, val) { ctx.filters.push((r) => r[col] === val); return api; },
+      is(col, val) { ctx.filters.push((r) => (r[col] ?? null) === val); return api; },
+      in(col, vals) { ctx.filters.push((r) => vals.includes(r[col])); return api; },
+      order() { return api; },
+      limit() { return api; },
+      then(resolve) {
+        const requestsMissingColumn = ctx.selectCols && columnsRequested(ctx.selectCols).includes('prior_provider_message_ids');
+        if (ctx.mode === 'update') {
+          // The terminal 'sent' write has no trailing .select() (ctx.selectCols stays null) —
+          // its own missing-column exposure is via ctx.vals carrying the key directly.
+          const writesMissingColumn = ctx.vals && Object.prototype.hasOwnProperty.call(ctx.vals, 'prior_provider_message_ids');
+          if (requestsMissingColumn || writesMissingColumn) {
+            resolve({ data: null, error: { code: '42703', message: 'column sms_outbound_obligations.prior_provider_message_ids does not exist' } });
+            return;
+          }
+          const matched = table.rows.filter((r) => ctx.filters.every((f) => f(r)));
+          matched.forEach((r) => Object.assign(r, ctx.vals));
+          resolve({ data: ctx.selectCols ? matched.map((r) => ({ ...r })) : null, error: null });
+          return;
+        }
+        if (requestsMissingColumn) {
+          resolve({ data: null, error: { code: '42703', message: 'column sms_outbound_obligations.prior_provider_message_ids does not exist' } });
+          return;
+        }
+        resolve({ data: table.rows.filter((r) => ctx.filters.every((f) => f(r))).map((r) => ({ ...r })), error: null });
+      },
+    };
+    return api;
+  }
+
+  return { from };
+}
+
+describe('reconcileOutboundSms — retries without prior_provider_message_ids on 42703 (QF-20260720-287)', () => {
+  it('claims and sends a genuinely eligible owed row despite the missing column throughout', async () => {
+    const seedRow = {
+      id: 'ob-repro', recipient_phone: '+15550001234', body: 'test', kind: 'heartbeat',
+      decision_id: null, dedupe_key: 'qf-287-test', status: 'owed', provider_message_id: null,
+      attempts: 0, not_before: null, claimed_at: null, claimed_by: null,
+      created_at: new Date().toISOString(), sent_at: null, delivered_at: null, last_error: null, media_url: null,
+    };
+    const supabase = makeFakeSupabaseMissingPriorSidColumn(seedRow);
+
+    let sendCalled = false;
+    const stubProvider = {
+      send: async () => { sendCalled = true; return { provider_message_id: 'STUB-SID', status: 'queued' }; },
+      checkMessageStatus: async () => ({ status: 'queued' }),
+    };
+
+    const summary = await reconcileOutboundSms(supabase, { provider: stubProvider });
+
+    expect(sendCalled).toBe(true);
+    expect(summary.claimed).toBe(1);
+    expect(summary.sent).toBe(1);
+    expect(seedRow.status).toBe('sent');
+    expect(seedRow.provider_message_id).toBe('STUB-SID');
+  });
+});

--- a/tests/unit/chairman/sms-outbound-mms-media-url.test.js
+++ b/tests/unit/chairman/sms-outbound-mms-media-url.test.js
@@ -91,15 +91,18 @@ describe('reconcileOutboundSms media_url end-to-end (FR-4, TS-6)', () => {
 });
 
 describe('static pin: media_url present in both reconcileOutboundSms select() calls (FR-4)', () => {
+  // QF-20260720-287: the owed-select and the claim-update RETURNING columns moved from inline
+  // select('...') literals to named consts (OWED_SELECT_COLUMNS / claimSelectColumns) so a
+  // missing prior_provider_message_ids column (chairman-gated STAGED, never applied live) can
+  // be retried without it at every touchpoint. Pin against the const definitions instead of an
+  // inline select() call — same guard, adapted structure.
   it('the owed-query select and the claim-update-returning select both include media_url', async () => {
     const { readFileSync } = await import('fs');
     const src = readFileSync('lib/chairman/sms-outbound-worker.js', 'utf8');
-    const owedSelectMatch = src.match(/select\('id, recipient_phone, body, attempts, decision_id, not_before[^']*'\)/);
-    const claimSelectMatch = src.match(/select\('id, recipient_phone, body, attempts[^']*'\)/g);
-    expect(owedSelectMatch?.[0]).toMatch(/media_url/);
-    // claimSelectMatch[0] is the owed-query variant (superset match); the LAST match is the
-    // claim-update-returning select, which is what `c` in provider.send() is sourced from.
-    expect(claimSelectMatch?.at(-1)).toMatch(/media_url/);
+    const owedColumnsMatch = src.match(/OWED_SELECT_COLUMNS = '([^']*)'/);
+    expect(owedColumnsMatch?.[1]).toMatch(/media_url/);
+    expect(src).toMatch(/\? 'id, recipient_phone, body, attempts, media_url, provider_message_id, prior_provider_message_ids'/);
+    expect(src).toMatch(/: 'id, recipient_phone, body, attempts, media_url, provider_message_id'/);
     expect(src).toMatch(/mediaUrl:\s*c\.media_url/);
   });
 });


### PR DESCRIPTION
## Summary
- `reconcileOutboundSms`'s Pass 2 (claim+send owed rows, `lib/chairman/sms-outbound-worker.js`) references `prior_provider_message_ids` in three places: the owed-row select, the atomic claim UPDATE's own RETURNING select, and the terminal `'sent'` UPDATE payload.
- That column (Solomon Pin #2, `database/migrations/20260718_sms_outbound_obligations_STAGED.sql`) is chairman-gated STAGED and was never actually applied live, though the base table + every other column WAS.
- A missing column fails the **whole** query it appears in (Postgres error `42703`), not per-column. Live-verified via a safe stubbed-provider repro (no real Twilio call): every real owed row sat un-sent (`claimed:0/sent:0`) on the gated path — masked only by the interim direct-Twilio workaround already in use.
- **Data-integrity note**: during the live repro, two real pending chairman heartbeat rows were caught in exactly this false state (accidentally marked `'sent'` by the stub before the fix, since the reconcile pass processes ALL owed rows, not just test fixtures) and were restored to `'owed'` so they deliver properly on the next real sweep. No message was actually sent via the stub — this was a status-only correction.
- Fix: retry the owed-select and the claim's RETURNING select without the column on `42703`, and conditionally omit it from the `'sent'` write. The Solomon Pin #2 duplicate-SID-history feature is simply inert pre-apply (matches the fail-soft contract this table's own migration file documents) — core claim+send is restored, self-heals once the column eventually lands.

## Test plan
- [x] `npx vitest run tests/unit/chairman/sms-outbound-missing-prior-sid-column.test.js` — 1/1 pass (models the exact 42703 failure across all three touchpoints, asserts claimed:1/sent:1)
- [x] `npx vitest run tests/unit/chairman/` — 185/185 pass (one pre-existing static-source-pin test updated to match the new column-list-as-const structure, same guard intent preserved)
- [x] `npx vitest run tests/unit/cron/sms-relay-drain-wiring.test.js tests/unit/messaging/twilio-signature.test.js tests/unit/switch-automation/switchon-decision-packet.test.js tests/unit/webhooks/twilio-sms.test.js` — all pass, no regressions
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] Live-verified against production DB with a stubbed provider (no real Twilio send): before the fix, a freshly-enqueued owed row was never claimed; after the fix, `claimed:1/sent:1` and the stub's `send` was invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)