### PR TITLE
feat(QF-20260720-638): standing coordinator idle-worker QF auto-hint core

### DIFF
--- a/scripts/coordinator-idle-qf-hint.mjs
+++ b/scripts/coordinator-idle-qf-hint.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * coordinator-idle-qf-hint.mjs — standing coordinator-loop core that auto-absorbs idle worker
+ * capacity into ranked, eligible open QFs via directed claim-hints. QF-20260720-638
+ * (Solomon-designed verdict ca1be286/6eb7cf54, coordinator-traced b16aebb1, Adam-sourced).
+ *
+ * CONTEXT: idle workers were not self-claiming non-critical open QFs because the
+ * directed-dispatch grace window fences non-critical QFs from self-claim until the coordinator
+ * routes them or grace ages out (anti reverse-starvation of SDs — WORKING AS DESIGNED; QF-161
+ * proved the aging path fires unhinted too). Solomon's verdict: do NOT shorten the grace on one
+ * day's evidence — encode the coordinator's manual hint intervention as STANDING behavior. This
+ * is the directed-dispatch consumer arriving ON TIME to absorb idle, NOT a fence bypass — the
+ * SD-priority fence still protects SDs when the fleet is busy.
+ *
+ * PROPOSE-ONLY (mirrors adam-coordinator-health.mjs's CONST-002): this core NEVER claims or
+ * mutates quick_fixes state — it only reads and, per eligible idle worker, writes ONE advisory
+ * session_coordination hint row. qf-start.js's own claim-guard resolves any race; a stale/
+ * already-claimed hint is a harmless no-op for the worker that receives it.
+ *
+ * GOVERNANCE (2026-07-20 near-miss hardening): during a MANUAL idle-remediation hint, the ad-hoc
+ * isChairmanGatedQF() guard alone let QF-20260719-281 (chairman-gated DDL) through into a hint
+ * to a worker — caught and retracted before the worker acted. The chairman-gated exclusion here
+ * is BELT-AND-SUSPENDERS: exclude on ANY of four independent signals firing —
+ *   (1) not_before-in-future            — via isAutoStartableQF (the 2027-park orphan class)
+ *   (2) title/description text heuristic — CHAIRMAN_GATED_TEXT_RE, independent of any column
+ *   (3) an explicit exclude-list         — KNOWN_GATED_QF_IDS, seeded with the near-miss QF
+ *   (4) isChairmanGatedQF()              — via isAutoStartableQF (owner/release_condition)
+ * A standing hint that bypasses a chairman gate even once is a governance-fence breach — this
+ * guard is the load-bearing safety of the whole enhancement.
+ *
+ * Usage: node scripts/coordinator-idle-qf-hint.mjs [--dry-run]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'node:module';
+import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
+import { getActiveCoordinatorId } from '../lib/coordinator/resolve.cjs';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { isAutoStartableQF, sortQfCandidatesBySeverity } = require('./worker-checkin.cjs');
+const { resolveWorkerTierRank } = require('../lib/fleet/tier-ladder.cjs');
+const { workClassIneligibilityReason } = require('../lib/fleet/work-class.cjs');
+
+// A worker whose session just (re)started gets a grace period to resolve its own state
+// (resume/self-claim) before the coordinator auto-hints it — prevents hinting mid-restart.
+export const SPIN_UP_GRACE_MS = 3 * 60 * 1000; // 3 min
+
+// GOVERNANCE layer 2 (belt-and-suspenders): independent of isChairmanGatedQF's owner/
+// release_condition columns — catches a QF whose content clearly signals a chairman-gated
+// apply even if those columns are unset/stale.
+// NB: @approved-by/@delegated-by are NOT \b-wrapped — '@' is a non-word char, so a \b
+// immediately before it never matches (no \w/\W transition at that position).
+export const CHAIRMAN_GATED_TEXT_RE = /\b(?:CHAIRMAN[- ]GATED|migration|DDL|gated)\b|@approved-by|@delegated-by/i;
+
+// GOVERNANCE layer 3 (belt-and-suspenders): explicit exclude-list, seeded with the QF that
+// slipped past isChairmanGatedQF() alone in the 2026-07-20 near-miss.
+export const KNOWN_GATED_QF_IDS = new Set(['QF-20260719-281']);
+
+/** Belt-and-suspenders governance layers 2+3 (layers 1+4 already run inside isAutoStartableQF). */
+export function isHintExcludedGated(qf) {
+  if (KNOWN_GATED_QF_IDS.has(qf.id)) return true;
+  return CHAIRMAN_GATED_TEXT_RE.test(`${qf.title || ''} ${qf.description || ''}`);
+}
+
+/**
+ * Deliberately simple, conservative tier-fit: routing_tier is a QF SIZE/RISK axis (1=auto-
+ * approve, 2=standard), not the same scale as worker capability tier_rank — no existing
+ * primitive compares them (assertWorkerTierAllowed explicitly exempts QFs from tier gating
+ * entirely). Reserve anything above the simplest routing tier for the fleet's top capability
+ * rung; never the reverse (errs toward under-hinting complex work, never over-hinting it).
+ */
+export function tierFitOk(qf, workerSession) {
+  const routingTier = Number(qf.routing_tier);
+  if (!Number.isFinite(routingTier) || routingTier <= 1) return true;
+  return resolveWorkerTierRank(workerSession) === 1;
+}
+
+/** Pure: idle, past-spin-up fleet workers eligible to receive a hint this tick. */
+export function eligibleIdleWorkers(liveWorkers, nowMs) {
+  return (liveWorkers || []).filter((w) => {
+    if (w.sd_key) return false; // already claiming something — not idle
+    const createdAt = w.created_at ? Date.parse(w.created_at) : NaN;
+    return Number.isFinite(createdAt) && (nowMs - createdAt) >= SPIN_UP_GRACE_MS;
+  });
+}
+
+/** Pure: the ranked, eligible-for-hint QF candidate list (belt-and-suspenders governance applied). */
+export function eligibleQfCandidates(qfs, nowMs) {
+  return sortQfCandidatesBySeverity(qfs || []).filter(
+    (qf) => isAutoStartableQF(qf, nowMs) && !isHintExcludedGated(qf)
+  );
+}
+
+function buildHintRow({ qf, coordinatorId, targetSession }) {
+  const subject = `Claim hint: ${qf.id} available (idle-absorb)`;
+  const body = `IDLE-CAPACITY CLAIM HINT (Adam-authorized, coordinator-relayed): an open unclaimed QF is available for you to absorb idle capacity: ${qf.id} — ${(qf.title || '').slice(0, 120)}. To claim+start: node scripts/qf-start.js ${qf.id}. This is a suggestion, not a hard fence; if you are already mid-work ignore it. If ${qf.id} is already claimed when you try, pick any other open QF or resume your loop.`;
+  return {
+    sender_type: 'coordinator',
+    sender_session: coordinatorId,
+    target_session: targetSession,
+    message_type: 'INFO',
+    subject,
+    body,
+    payload: { kind: 'coordinator_request', chairman_directive: false, qf_id: qf.id, reply_class: 'fire-and-forget' },
+  };
+}
+
+export async function runIdleQfHintCore(supabase, { nowMs = Date.now(), dryRun = false } = {}) {
+  const summary = { idleWorkers: 0, hinted: 0, skippedGated: 0 };
+
+  const { data: sessions } = await supabase
+    .from('claude_sessions')
+    .select('*')
+    .order('heartbeat_at', { ascending: false }); // QF-763 lesson: explicit order avoids the page-cap staleness trap
+  const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+  const live = liveFleetWorkers(sessions || [], coordinatorId, nowMs);
+  const idle = eligibleIdleWorkers(live, nowMs);
+  summary.idleWorkers = idle.length;
+  if (idle.length === 0) return summary;
+
+  const { data: qfs } = await supabase
+    .from('quick_fixes')
+    .select('id, title, description, severity, status, pr_url, commit_sha, created_at, routing_tier, not_before, owner, release_condition')
+    .eq('status', 'open')
+    .is('pr_url', null)
+    .is('commit_sha', null)
+    .order('created_at', { ascending: true });
+
+  const ranked = eligibleQfCandidates(qfs, nowMs);
+  summary.skippedGated = (qfs || []).length - ranked.length;
+  if (ranked.length === 0) return summary;
+
+  // One-hint-per-worker, one-QF-per-hint this tick: consume the ranked list as we go so no QF
+  // is double-hinted and no worker gets more than one suggestion.
+  const remaining = [...ranked];
+  for (const worker of idle) {
+    const sessionModel = worker.metadata && worker.metadata.model;
+    const idx = remaining.findIndex(
+      (qf) => tierFitOk(qf, worker) && (typeof sessionModel !== 'string' || !workClassIneligibilityReason(qf, sessionModel))
+    );
+    if (idx === -1) continue;
+    const [qf] = remaining.splice(idx, 1);
+    if (!dryRun) {
+      await insertCoordinationRow(supabase, buildHintRow({ qf, coordinatorId, targetSession: worker.session_id }));
+    }
+    summary.hinted += 1;
+  }
+  return summary;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[coordinator-idle-qf-hint] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+  const dryRun = process.argv.includes('--dry-run');
+  const summary = await runIdleQfHintCore(supabase, { dryRun });
+  console.log(`IDLE_QF_HINT idleWorkers=${summary.idleWorkers} hinted=${summary.hinted} skippedGated=${summary.skippedGated}${dryRun ? ' (dry-run)' : ''}`);
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((e) => {
+    console.error(`[coordinator-idle-qf-hint] FATAL: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -103,6 +103,13 @@ export const COMPOSED_CORES = [
   // quiescentSkip: an aged pending recommendation is exactly as stale-and-worth-surfacing during a
   // quiet fleet window as during an active one.
   { key: 'solomon-ledger-resurface', script: 'solomon-ledger-pending-resurface.cjs', args: ['scripts/solomon-ledger-pending-resurface.cjs'], quiescentSkip: false },
+  // QF-20260720-638: encodes the coordinator's manual idle-QF claim-hint intervention as
+  // standing behavior (Solomon-designed, Adam-sourced). PROPOSE-ONLY (writes an advisory hint
+  // row per idle worker, never claims/mutates quick_fixes) with belt-and-suspenders chairman-
+  // gated exclusion — see the script's own header for the full governance rationale. NOT
+  // quiescentSkip: an idle worker sitting behind the directed-dispatch grace window is exactly
+  // as worth absorbing during a quiet fleet window as during an active one.
+  { key: 'idle-qf-hint', script: 'coordinator-idle-qf-hint.mjs', args: ['scripts/coordinator-idle-qf-hint.mjs'], quiescentSkip: false },
 ];
 
 /** Build the fail-soft core list for the current mode (quiescent skips the expensive cores). */

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -305,6 +305,14 @@ export const STANDARD_LOOPS = [
   { key: 'solomon-ledger-resurface', label: 'Solomon ledger-pending resurface (aged advice-outcome rows -> Adam inbox)', script: 'solomon-ledger-pending-resurface.cjs', cron: '13,43 * * * *',
     gha_backed: true,
     prompt: 'node scripts/solomon-ledger-pending-resurface.cjs' },
+  // QF-20260720-638 (Solomon-designed, Adam-sourced): encodes the coordinator's manual
+  // idle-QF claim-hint intervention as standing behavior. PROPOSE-ONLY (advisory hint row per
+  // idle worker, never claims/mutates quick_fixes); belt-and-suspenders chairman-gated
+  // exclusion — see the script's own header. Also composed into
+  // scripts/coordinator-quiet-tick.mjs's COMPOSED_CORES.
+  { key: 'idle-qf-hint', label: 'Idle-worker QF auto-hint (idle-capacity absorption into ranked open QFs)', script: 'coordinator-idle-qf-hint.mjs', cron: '5,15,25,35,45,55 * * * *',
+    gha_backed: true,
+    prompt: 'node scripts/coordinator-idle-qf-hint.mjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/coordinator/idle-qf-hint.test.js
+++ b/tests/unit/coordinator/idle-qf-hint.test.js
@@ -1,0 +1,156 @@
+/**
+ * QF-20260720-638 — coordinator-idle-qf-hint.mjs: idle-worker QF auto-hint core.
+ *
+ * SAFETY-CRITICAL: the belt-and-suspenders chairman-gated exclusion is the load-bearing
+ * guard of this whole feature (2026-07-20 near-miss: a chairman-gated QF slipped past
+ * isChairmanGatedQF() alone during a manual hint, caught before the worker acted). The tests
+ * here specifically replicate that near-miss to prove it cannot recur even when the DB columns
+ * (owner/release_condition) that isChairmanGatedQF reads are unset/stale.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isHintExcludedGated,
+  tierFitOk,
+  eligibleIdleWorkers,
+  eligibleQfCandidates,
+  runIdleQfHintCore,
+  SPIN_UP_GRACE_MS,
+  KNOWN_GATED_QF_IDS,
+} from '../../../scripts/coordinator-idle-qf-hint.mjs';
+
+const NOW = Date.parse('2026-07-20T12:00:00Z');
+
+const qf = (over = {}) => ({
+  id: 'QF-20260720-001', title: 'fix a small thing', description: 'a routine bug fix',
+  severity: 'medium', status: 'open', pr_url: null, commit_sha: null,
+  created_at: '2026-07-20T11:00:00Z', routing_tier: 1, not_before: null,
+  owner: null, release_condition: null, ...over,
+});
+
+const worker = (over = {}) => ({
+  session_id: 'sess-1', sd_key: null, status: 'active',
+  heartbeat_at: new Date(NOW - 60_000).toISOString(),
+  created_at: new Date(NOW - SPIN_UP_GRACE_MS - 60_000).toISOString(),
+  claimed_at: '2026-07-01T00:00:00Z', metadata: { model: 'sonnet' }, ...over,
+});
+
+describe('isHintExcludedGated — belt-and-suspenders governance (near-miss regression)', () => {
+  it('excludes the exact QF that slipped through the 2026-07-20 near-miss, via the explicit list, even with clean owner/release_condition', () => {
+    const gated = qf({ id: 'QF-20260719-281', title: 'Apply 5 committed-but-unapplied migrations', owner: null, release_condition: null });
+    expect(KNOWN_GATED_QF_IDS.has('QF-20260719-281')).toBe(true);
+    expect(isHintExcludedGated(gated)).toBe(true);
+  });
+
+  it('excludes via the text heuristic (layer 2) when owner/release_condition are unset (the exact near-miss shape)', () => {
+    const gated = qf({ id: 'QF-99999999-999', title: 'Apply a CHAIRMAN-GATED migration', owner: null, release_condition: null });
+    expect(isHintExcludedGated(gated)).toBe(true);
+  });
+
+  it('does NOT exclude a genuinely routine QF', () => {
+    expect(isHintExcludedGated(qf())).toBe(false);
+  });
+
+  it('text heuristic matches on description too, not just title', () => {
+    const gated = qf({ title: 'small fix', description: 'requires @approved-by chairman before apply' });
+    expect(isHintExcludedGated(gated)).toBe(true);
+  });
+});
+
+describe('eligibleQfCandidates — full pipeline exclusion (isAutoStartableQF + governance)', () => {
+  it('the near-miss QF is excluded from the ranked list even as the ONLY open QF', () => {
+    const gated = qf({ id: 'QF-20260719-281', title: 'Apply 5 committed-but-unapplied migrations (CHAIRMAN-GATED DDL)' });
+    expect(eligibleQfCandidates([gated], NOW)).toEqual([]);
+  });
+
+  it('a routine QF passes through', () => {
+    const routine = qf();
+    expect(eligibleQfCandidates([routine], NOW).map((q) => q.id)).toEqual([routine.id]);
+  });
+
+  it('excludes a not_before-in-future row (layer 1, via isAutoStartableQF)', () => {
+    const parked = qf({ not_before: '2027-01-01T00:00:00Z' });
+    expect(eligibleQfCandidates([parked], NOW)).toEqual([]);
+  });
+
+  it('excludes a row carrying the canonical chairman-gated columns (layer 4, via isAutoStartableQF)', () => {
+    const columnGated = qf({ owner: 'chairman', release_condition: 'EU-send-planned' });
+    expect(eligibleQfCandidates([columnGated], NOW)).toEqual([]);
+  });
+});
+
+describe('tierFitOk — conservative routing_tier vs worker-rank heuristic', () => {
+  it('a routing_tier-1 QF is fine for any worker', () => {
+    expect(tierFitOk(qf({ routing_tier: 1 }), worker({ metadata: {} }))).toBe(true);
+  });
+
+  it('a routing_tier-2 QF requires the top capability rung', () => {
+    const bottomRung = worker({ metadata: { tier_rank: 5 } });
+    expect(tierFitOk(qf({ routing_tier: 2 }), bottomRung)).toBe(false);
+    const topRung = worker({ metadata: { tier_rank: 1 } });
+    expect(tierFitOk(qf({ routing_tier: 2 }), topRung)).toBe(true);
+  });
+});
+
+describe('eligibleIdleWorkers — sd_key + spin-up grace', () => {
+  it('excludes a worker already claiming something', () => {
+    expect(eligibleIdleWorkers([worker({ sd_key: 'SD-X-001' })], NOW)).toEqual([]);
+  });
+
+  it('excludes a session that just (re)started (inside the spin-up grace)', () => {
+    const fresh = worker({ created_at: new Date(NOW - 30_000).toISOString() });
+    expect(eligibleIdleWorkers([fresh], NOW)).toEqual([]);
+  });
+
+  it('includes an idle worker past the spin-up grace', () => {
+    const w = worker();
+    expect(eligibleIdleWorkers([w], NOW).map((x) => x.session_id)).toEqual([w.session_id]);
+  });
+});
+
+describe('runIdleQfHintCore — end-to-end decision (dry-run seam, no live insert)', () => {
+  function makeFakeSupabase({ sessions, qfs }) {
+    return {
+      from(table) {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          is() { return this; },
+          order() { return this; },
+          then(resolve) {
+            if (table === 'claude_sessions') return resolve({ data: sessions, error: null });
+            if (table === 'quick_fixes') return resolve({ data: qfs, error: null });
+            resolve({ data: [], error: null });
+          },
+        };
+      },
+    };
+  }
+
+  it('hints one idle worker with one eligible QF (dry-run counts, no insert)', async () => {
+    const sb = makeFakeSupabase({
+      sessions: [worker()],
+      qfs: [qf()],
+    });
+    const summary = await runIdleQfHintCore(sb, { nowMs: NOW, dryRun: true });
+    expect(summary.idleWorkers).toBe(1);
+    expect(summary.hinted).toBe(1);
+  });
+
+  it('the near-miss QF is never hinted even as the only open QF, idle worker present', async () => {
+    const sb = makeFakeSupabase({
+      sessions: [worker()],
+      qfs: [qf({ id: 'QF-20260719-281', title: 'Apply 5 committed-but-unapplied migrations (CHAIRMAN-GATED DDL)' })],
+    });
+    const summary = await runIdleQfHintCore(sb, { nowMs: NOW, dryRun: true });
+    expect(summary.idleWorkers).toBe(1);
+    expect(summary.hinted).toBe(0);
+    expect(summary.skippedGated).toBe(1);
+  });
+
+  it('no idle workers -> zero hints, short-circuits before the QF query', async () => {
+    const sb = makeFakeSupabase({ sessions: [], qfs: [qf()] });
+    const summary = await runIdleQfHintCore(sb, { nowMs: NOW, dryRun: true });
+    expect(summary.idleWorkers).toBe(0);
+    expect(summary.hinted).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Encodes the coordinator's previously-manual idle-QF claim-hint intervention as standing tick behavior (Solomon-designed verdict ca1be286/6eb7cf54, Adam-sourced, coordinator-traced b16aebb1).
- Idle workers were not self-claiming non-critical open QFs because the directed-dispatch grace window fences non-critical QFs from self-claim until the coordinator routes them or grace ages out — working as designed (anti reverse-starvation of SDs; QF-161 proved the aging path fires unhinted too). This is the directed-dispatch consumer arriving on time to absorb idle, **not** a fence bypass — the SD-priority fence still protects SDs when the fleet is busy.
- **PROPOSE-ONLY** (mirrors `adam-coordinator-health.mjs`'s CONST-002): never claims or mutates `quick_fixes` state, only writes an advisory hint row per idle worker. `qf-start.js`'s own claim-guard resolves any race.
- **GOVERNANCE (2026-07-20 near-miss hardening)**: during a manual idle-remediation hint, a chairman-gated QF (`QF-20260719-281`) slipped past `isChairmanGatedQF()` alone, caught before the worker acted. The exclusion here is **belt-and-suspenders** — four independent signals, exclude on ANY hit: (1) `not_before`-in-future, (2) a title/description text heuristic, (3) an explicit exclude-list seeded with the near-miss QF, (4) `isChairmanGatedQF()`. Regression-tested against the exact near-miss shape (clean `owner`/`release_condition` columns, gated only by content).
- Registered as a new `coordinator-quiet-tick.mjs` `COMPOSED_CORES` entry plus a `STANDARD_LOOPS` cron backstop, matching the existing two-layer durability pattern.

## Scope note
Implementation (186 code lines across 3 files) exceeds the QF's 60 LOC estimate and the Tier-2 cap. The belt-and-suspenders governance guard and its regression coverage are explicitly REQUIRED by the QF's own description ("load-bearing safety of the whole enhancement"), not incidental scope growth — shrinking it would cut a mandated safety guard against a real, already-witnessed near-miss.

## Test plan
- [x] `npx vitest run tests/unit/coordinator/idle-qf-hint.test.js` — 16/16 pass, including a direct regression test replicating the exact near-miss (QF-20260719-281 excluded even as the only open QF, idle worker present)
- [x] `npx vitest run tests/unit/coordinator/ tests/unit/adam-startup-check.test.mjs tests/unit/worker-checkin*.test.js` — 618/618 pass, no regressions (including the `quiet-tick-loop-parity` test that verifies every composed core maps to a registered `STANDARD_LOOPS` entry)
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] Live dry-run verified against production (`node scripts/coordinator-idle-qf-hint.mjs --dry-run`) — runs cleanly, read-only, zero inserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)