### PR TITLE
fix(QF-20260720-137): far-future not_before parks require --release-condition

### DIFF
--- a/scripts/defer-quick-fix.js
+++ b/scripts/defer-quick-fix.js
@@ -83,7 +83,9 @@ Options:
                       once enforce mode is armed.
   --owner <text>      Hold-state contract stamp: who reviews/releases this defer.
   --release-condition <text>  Hold-state contract stamp: the condition under
-                      which this defer should be released.
+                      which this defer should be released. REQUIRED whenever
+                      --not-before is more than 30 days out (QF-20260720-137) --
+                      a far-future park always needs a release trigger.
 
 Example:
   node scripts/defer-quick-fix.js QF-20260704-348 --not-before 2026-07-05T21:00:00Z --reopen \\
@@ -91,10 +93,25 @@ Example:
 `);
 }
 
+// QF-20260720-137: a not_before park beyond this horizon has no natural review
+// trigger (the 2027-sentinel class -- 6 retro-promoted QFs parked indefinitely
+// with reason=NULL, no owner, no release_condition, never resurfacing). Applies
+// to ANY caller of this shared write path, not just retro-sourced QFs, and is
+// enforced unconditionally -- independent of HOLD_STATE_CONTRACT_MODE, which
+// only governs the reason/owner/release_condition stamp as a whole.
+const FAR_FUTURE_PARK_DAYS = 30;
+
 export async function deferQuickFix(qfId, notBefore, { reopen = false, reason, owner, releaseCondition, writingSessionId, supabaseClient = null } = {}) {
   const validation = validateNotBefore(notBefore);
   if (!validation.valid) {
     throw new Error(validation.error);
+  }
+
+  const daysOut = (Date.parse(validation.iso) - Date.now()) / (24 * 60 * 60 * 1000);
+  if (daysOut > FAR_FUTURE_PARK_DAYS && !(releaseCondition && String(releaseCondition).trim())) {
+    const err = new Error(`--not-before is ${Math.round(daysOut)} days out (>${FAR_FUTURE_PARK_DAYS}) and requires --release-condition -- a far-future park with no release trigger never resurfaces (QF-20260720-137)`);
+    err.code = 'FAR_FUTURE_PARK_REQUIRES_RELEASE_CONDITION';
+    throw err;
   }
 
   const supabase = supabaseClient || createClient(

--- a/tests/unit/defer-quick-fix.test.js
+++ b/tests/unit/defer-quick-fix.test.js
@@ -92,6 +92,40 @@ describe('deferQuickFix', () => {
   });
 });
 
+describe('deferQuickFix — far-future park requires release-condition (QF-20260720-137)', () => {
+  function makeSupabaseStub(returnData, returnError = null) {
+    const update = vi.fn().mockReturnThis();
+    const eq = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({ data: returnData, error: returnError });
+    return { client: { from: () => ({ update, eq, select, single }) }, update, eq, select, single };
+  }
+
+  function daysFromNowIso(days) {
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  it('rejects a >30-day park with no --release-condition before any DB write', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X' });
+    await expect(deferQuickFix('QF-X', daysFromNowIso(60), { supabaseClient: stub.client }))
+      .rejects.toThrow(/FAR_FUTURE_PARK_REQUIRES_RELEASE_CONDITION|release-condition/);
+    expect(stub.update).not.toHaveBeenCalled();
+  });
+
+  it('allows a >30-day park when --release-condition is provided', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', not_before: daysFromNowIso(60) });
+    await expect(deferQuickFix('QF-X', daysFromNowIso(60), {
+      releaseCondition: 'sibling SD ships', supabaseClient: stub.client,
+    })).resolves.toMatchObject({ id: 'QF-X' });
+  });
+
+  it('does not require --release-condition for a near-future (<=30 day) park', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', not_before: daysFromNowIso(5) });
+    await expect(deferQuickFix('QF-X', daysFromNowIso(5), { supabaseClient: stub.client }))
+      .resolves.toMatchObject({ id: 'QF-X' });
+  });
+});
+
 describe('deferQuickFix — hold-state contract (SD-LEO-INFRA-HOLD-STATE-CONTRACT-001)', () => {
   const ORIGINAL = process.env.HOLD_STATE_CONTRACT_MODE;
   afterEach(() => { process.env.HOLD_STATE_CONTRACT_MODE = ORIGINAL; });


### PR DESCRIPTION
## Summary
- `deferQuickFix()` (the sole write path for `quick_fixes.not_before`) now rejects any park more than 30 days out unless `--release-condition` is supplied.
- Closes the root cause behind 6 retro-promoted QFs stuck at `not_before=2027-01-01` with `reason=NULL`, no owner, no release_condition — a park with no natural review trigger that never resurfaces.
- Applies unconditionally (independent of `HOLD_STATE_CONTRACT_MODE`) and covers any caller of the shared defer path, not just retro-sourced QFs.

## Test plan
- [x] `npx vitest run tests/unit/defer-quick-fix.test.js` — 20/20 passing (17 pre-existing + 3 new covering: far-future without release-condition throws before any DB write, far-future with release-condition succeeds, near-future (<=30d) unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)