### PR TITLE
fix(QF-20260720-497): fail-loud on fleet workers with no self-reported model

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -471,6 +471,40 @@ export function detectCoordinatorWithoutAdam({ coordinatorAlive, adamAlive } = {
   };
 }
 
+/**
+ * QF-20260720-497 — model-stamp gauge FAIL-LOUD: a LIVE, participating worker with NO self-reported
+ * model (metadata.model absent OR metadata.effort_source !== 'worker_self_report') must be FLAGGED,
+ * not silently counted 'unknown'. The silent-unknown posture let a capacity/allocation decision keyed
+ * on claude_sessions.metadata.model run at a fraction of true resolution (live evidence: workers
+ * switched to Sonnet-UltraCode via /model while the DB gauge stayed stale — '3 Fable invisible, DB
+ * stamped 1'). PURE: injected liveSessions in, verdict out (data-in / verdict-out like its siblings).
+ * A fresh startup ghost that has not yet participated (no claim / worktree / completed-SD counter) is
+ * NOT a violation — it may simply not have self-reported yet.
+ * @param {{ liveSessions?: Array<{session_id?:string, metadata?:object, claimed_at?:string, worktree_path?:string, continuous_sds_completed?:number}> }} facts
+ */
+export function detectUnstampedModel({ liveSessions = [] } = {}) {
+  const selfReportsModel = (s) => {
+    const m = s && s.metadata;
+    return !!(m && typeof m.model === 'string' && m.model.trim() && m.effort_source === 'worker_self_report');
+  };
+  const everParticipated = (s) => !!(s && (s.claimed_at || s.worktree_path || (s.continuous_sds_completed > 0)));
+  const participating = liveSessions.filter(everParticipated);
+  const unstamped = participating.filter((s) => !selfReportsModel(s));
+  const violation = unstamped.length > 0;
+  return {
+    violation,
+    unstampedCount: unstamped.length,
+    participatingCount: participating.length,
+    unstampedSessions: unstamped.map((s) => s.session_id),
+    detail: violation
+      ? `${unstamped.length}/${participating.length} live participating worker(s) have NO worker_self_report model — the model gauge is silently blind on them (capacity decisions keyed on metadata.model run at reduced resolution)`
+      : `all ${participating.length} live participating worker(s) self-report a model`,
+    remediation: violation
+      ? 'ACTION: have each flagged worker re-run worker-checkin.cjs --model <m> --effort <e> (writes effort_source=worker_self_report); verify /model-switch propagates to metadata.model+effort (QF-20260710-406 path must cover model+effort, not just tier) — do NOT silently count them unknown'
+      : null,
+  };
+}
+
 /** Collect violations (each with its remediation) from a list of detector results. */
 export function summarizeViolations(results = []) {
   const violations = results.filter((r) => r && r.violation).map((r) => ({ detail: r.detail, remediation: r.remediation || null }));

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -27,7 +27,7 @@ import { countActiveWorktrees, MAX_WORKTREE_COUNT, countFilesystemWorktreeDirs }
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness dimension.
 import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
 import {
-  classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
+  classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool, detectUnstampedModel,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall, detectCrossRepoStarvation,
   // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3): coordinator mirror detectors.
@@ -252,6 +252,7 @@ async function main() {
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
     idle: detectIdleWithWork({ liveSessions: liveWorkers, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds, nowMs, isWithinArmedSilence: isWithinArmedSilenceWindow }),
+    modelStamp: detectUnstampedModel({ liveSessions: liveWorkers }), // QF-20260720-497: fail-loud on live participating workers with no worker_self_report model (not silent 'unknown')
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     // SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: cross-repo SDs no live worker checkout can build (silent starvation).

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -9,7 +9,7 @@ import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectCrossRepoStarvation,
-  detectAutoRefillBacklog, detectInProgressOrphans,
+  detectAutoRefillBacklog, detectInProgressOrphans, detectUnstampedModel,
 } from '../../../lib/coordinator/charter-audit-detectors.mjs';
 import { STANDARD_LOOPS } from '../../../scripts/coordinator-startup-check.mjs';
 
@@ -428,5 +428,31 @@ describe('detectInProgressOrphans — DUTY-3b in_progress+unclaimed orphan (SD-R
     expect(detectInProgressOrphans().violation).toBe(false);
     expect(detectInProgressOrphans({ sds: null, liveSessions: null }).violation).toBe(false);
     expect(detectInProgressOrphans({ sds: [orphanSd()], liveSessions: [] }).violation).toBe(true); // nowMs undefined → age guard skipped, still flags
+  });
+});
+
+describe('detectUnstampedModel (QF-20260720-497) — model-stamp gauge fail-loud', () => {
+  const participating = (over = {}) => ({ session_id: 's', claimed_at: ago(1000), metadata: {}, ...over });
+  it('flags a live participating worker with no worker_self_report model (not silent unknown)', () => {
+    const r = detectUnstampedModel({ liveSessions: [participating({ session_id: 'w1', metadata: { model: 'fable' /* no effort_source */ } })] });
+    expect(r.violation).toBe(true);
+    expect(r.unstampedCount).toBe(1);
+    expect(r.unstampedSessions).toContain('w1');
+    expect(r.remediation).toMatch(/worker-checkin/);
+  });
+  it('does NOT flag a worker that self-reports (effort_source=worker_self_report + model)', () => {
+    const r = detectUnstampedModel({ liveSessions: [participating({ metadata: { model: 'sonnet', effort_source: 'worker_self_report' } })] });
+    expect(r.violation).toBe(false);
+    expect(r.unstampedCount).toBe(0);
+    expect(r.participatingCount).toBe(1);
+  });
+  it('does NOT flag a fresh startup ghost that has not yet participated', () => {
+    const r = detectUnstampedModel({ liveSessions: [{ session_id: 'ghost', metadata: {} /* no claim/worktree/completed */ }] });
+    expect(r.violation).toBe(false);
+    expect(r.participatingCount).toBe(0);
+  });
+  it('empty / missing input → no violation (conservative)', () => {
+    expect(detectUnstampedModel().violation).toBe(false);
+    expect(detectUnstampedModel({ liveSessions: [] }).violation).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
The fleet model-stamp gauge silently counted live workers with no self-reported model as 'unknown', so capacity/allocation decisions keyed on `claude_sessions.metadata.model` ran at reduced resolution (workers switched via `/model` but the DB gauge stayed stale — "3 Fable invisible, DB stamped 1").

- **`lib/coordinator/charter-audit-detectors.mjs`**: new pure `detectUnstampedModel` detector (data-in/verdict-out, like its siblings) — flags LIVE, *participating* workers (claim/worktree/completed-SD) whose metadata lacks a `model` + `effort_source='worker_self_report'`, with a remediation (re-run `worker-checkin --model/--effort`; verify `/model-switch` → metadata.model+effort propagation, the QF-20260710-406 path). A fresh startup ghost that hasn't participated is not flagged (conservative).
- **`scripts/coordinator-charter-audit.mjs`**: wire the detector into the charter self-audit `D` dict (auto-included in `summarizeViolations`) using the existing `liveWorkers`.

Scope: fail-loud (part 1, the load-bearing part per the QF title). Reconcile-to-window (part 2) + a deeper /model-propagation repair (part 3) are noted follow-ups.

## Test plan
- [x] 4 new unit tests (flag unstamped / pass self-reported / skip ghost / empty-safe) — 64/64 green
- [x] tsc + syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)