### PR TITLE
fix(QF-20260720-706): scope overnight capacity governor budget to the current account

### DIFF
--- a/lib/eva/capacity-governor.js
+++ b/lib/eva/capacity-governor.js
@@ -53,21 +53,45 @@ export function projectTimeToWall({
   return { hoursToWall, adjustedBudgetSessionHours, burnMultiplier: safeMultiplier };
 }
 
+// QF-20260720-706: capacity_limit_events.account is a free-text label
+// (scripts/eva/overnight-capacity-governor.mjs's record-event CLI, e.g. 'codestreetlabs',
+// 'rickfelix2000'), populated by a human typing it at record time -- NOT auto-derived, and NOT
+// the same key scheme as lib/fleet/account-capacity-gauge.cjs's accountUuid8 (QF-20260720-406,
+// a SEPARATE store for chairman-pasted /usage-dashboard readings -- a different data source
+// entirely, not reconciled here). Live-verified the free-text label is the account email's
+// local-part (rickfelix2000@gmail.com -> 'rickfelix2000', matching the ledger's own seed data)
+// -- resolveAccountLabel derives it from getAccountIdentity() so callers never hand-type it.
+export function resolveAccountLabel(identity) {
+  if (!identity || typeof identity.email !== 'string') return null;
+  const local = identity.email.split('@')[0];
+  return local ? local.toLowerCase() : null;
+}
+
 /**
  * Budget (session-hours a window can sustain) learned from the ledger's
  * session_window_exhausted rows. Falls back to the documented default when the
  * ledger is empty -- never throws.
+ *
+ * QF-20260720-706: an optional account filter scopes the average to the account the fleet is
+ * CURRENTLY on -- unfiltered, a genuinely-exhausted account's events were diluted by a fresh
+ * account's events (and vice versa), corrupting the overnight park/core-size verdict. No
+ * matching events for that account (a fresh/never-exhausted account) falls back to the SAME
+ * documented default as an empty ledger -- never silently widens back out to the pooled
+ * cross-account average, which would defeat the fix.
  */
-export async function getCalibratedBudget(supabase) {
+export async function getCalibratedBudget(supabase, { account = null } = {}) {
   try {
     // Paginated (FR-6 batch 7): the ledger grows without bound and the average must
     // see every row. Page errors throw into the catch below (default budget).
-    const data = await fetchAllPaginated(() => supabase
-      .from('capacity_limit_events')
-      .select('id, session_hours_burned')
-      .eq('event_type', 'session_window_exhausted')
-      .not('session_hours_burned', 'is', null)
-      .order('id', { ascending: true }));
+    const data = await fetchAllPaginated(() => {
+      let q = supabase
+        .from('capacity_limit_events')
+        .select('id, session_hours_burned')
+        .eq('event_type', 'session_window_exhausted')
+        .not('session_hours_burned', 'is', null);
+      if (account) q = q.eq('account', account);
+      return q.order('id', { ascending: true });
+    });
 
     if (!data || data.length === 0) {
       return { budgetSessionHours: DEFAULT_BUDGET_SESSION_HOURS, source: 'default', eventCount: 0 };
@@ -77,7 +101,7 @@ export async function getCalibratedBudget(supabase) {
       return { budgetSessionHours: DEFAULT_BUDGET_SESSION_HOURS, source: 'default', eventCount: 0 };
     }
     const avg = values.reduce((sum, v) => sum + v, 0) / values.length;
-    return { budgetSessionHours: avg, source: 'ledger_average', eventCount: values.length };
+    return { budgetSessionHours: avg, source: account ? 'ledger_average_per_account' : 'ledger_average', eventCount: values.length };
   } catch {
     return { budgetSessionHours: DEFAULT_BUDGET_SESSION_HOURS, source: 'default', eventCount: 0 };
   }
@@ -88,6 +112,13 @@ export async function getCalibratedBudget(supabase) {
  * session_coordination row counts (the existing "sends-first" signal) divided by
  * the count of distinct active fleet sessions. Never throws; 0 on any failure or
  * empty input, never NaN.
+ *
+ * QF-20260720-706: NOT given an account filter, deliberately -- session_coordination carries
+ * no account column, and the fleet runs under ONE account at a time (a rotation model, not
+ * concurrent multi-account operation); getFleetRoster's own freshness filter already excludes
+ * any stale session left over from before the last account switch. This burn-rate snapshot is
+ * inherently scoped to whichever account is live right now -- unlike getCalibratedBudget's
+ * ledger average, there is no cross-account pooling to fix here.
  */
 export async function getCurrentBurnRate(supabase, { windowHours = 1, fleetSize = null } = {}) {
   try {

--- a/scripts/eva/overnight-capacity-governor.mjs
+++ b/scripts/eva/overnight-capacity-governor.mjs
@@ -18,8 +18,16 @@ import {
   getCurrentBurnRate,
   getFleetRoster,
   computeVerdict,
+  resolveAccountLabel,
   CONSTANTS,
 } from '../../lib/eva/capacity-governor.js';
+import { getAccountIdentity } from '../../lib/fleet/account-identity.cjs';
+
+// QF-20260720-706: resolve the account label ONCE per CLI invocation, from the CURRENTLY
+// active identity -- never hand-typed, so project/verdict can never drift from record-event's
+// free-text scheme. null (identity unavailable) falls back to getCalibratedBudget's
+// pre-fix pooled-average behavior, byte-identical -- never a hard failure.
+const currentAccount = resolveAccountLabel(getAccountIdentity());
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -99,7 +107,7 @@ function parseFlag(args, name, fallback) {
 }
 
 async function project(args) {
-  const { budgetSessionHours, source, eventCount } = await getCalibratedBudget(supabase);
+  const { budgetSessionHours, source, eventCount } = await getCalibratedBudget(supabase, { account: currentAccount });
   const fleetSize = Number(parseFlag(args, 'fleet-size', 6));
   const burnMultiplier = Number(parseFlag(args, 'burn-multiplier', 1));
   const burnRate = CONSTANTS.REFERENCE_BURN_PER_SESSION_PER_HOUR * burnMultiplier;
@@ -123,7 +131,7 @@ async function project(args) {
 }
 
 async function verdict(args) {
-  const { budgetSessionHours, eventCount } = await getCalibratedBudget(supabase);
+  const { budgetSessionHours, eventCount } = await getCalibratedBudget(supabase, { account: currentAccount });
   const roster = await getFleetRoster(supabase);
   const fleetSize = roster.length || 1;
   const burnRate = await getCurrentBurnRate(supabase, { windowHours: 1, fleetSize });

--- a/tests/unit/eva/capacity-governor.test.js
+++ b/tests/unit/eva/capacity-governor.test.js
@@ -9,6 +9,7 @@ import {
   getCalibratedBudget,
   computeVerdict,
   resolveModelWeight,
+  resolveAccountLabel,
   CONSTANTS,
 } from '../../../lib/eva/capacity-governor.js';
 
@@ -104,6 +105,67 @@ describe('getCalibratedBudget()', () => {
     };
     const result = await getCalibratedBudget(supabase);
     expect(result.budgetSessionHours).toBeCloseTo(22.4, 5);
+  });
+
+  // QF-20260720-706: getCalibratedBudget pooled session_hours_burned across ALL accounts,
+  // corrupting the overnight park/core-size verdict when accounts have different quota states.
+  function accountFilterableBuilder(rows) {
+    const b = {
+      eq: (col, val) => accountFilterableBuilder(rows.filter((r) => r[col] === val)),
+      order: () => b,
+      range: () => Promise.resolve({ data: rows, error: null }),
+    };
+    return b;
+  }
+  function makeAccountAwareSupabase(rows) {
+    return {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ // event_type filter — pass-through, this mock's rows are all pre-filtered
+            not: () => accountFilterableBuilder(rows),
+          }),
+        }),
+      }),
+    };
+  }
+
+  it('filters by account when provided, never mixing accounts (QF-20260720-706)', async () => {
+    const supabase = makeAccountAwareSupabase([
+      { session_hours_burned: 10, account: 'accountA' },
+      { session_hours_burned: 30, account: 'accountB' },
+    ]);
+    const resultA = await getCalibratedBudget(supabase, { account: 'accountA' });
+    expect(resultA.budgetSessionHours).toBe(10);
+    expect(resultA.eventCount).toBe(1);
+    expect(resultA.source).toBe('ledger_average_per_account');
+
+    const resultB = await getCalibratedBudget(supabase, { account: 'accountB' });
+    expect(resultB.budgetSessionHours).toBe(30);
+
+    // No account param -> pooled behavior is unchanged (byte-identical to pre-fix).
+    const pooled = await getCalibratedBudget(supabase);
+    expect(pooled.budgetSessionHours).toBe(20);
+    expect(pooled.source).toBe('ledger_average');
+  });
+
+  it('falls back to the default (never the pooled cross-account average) when the account has zero calibration events', async () => {
+    const supabase = makeAccountAwareSupabase([{ session_hours_burned: 10, account: 'accountA' }]);
+    const result = await getCalibratedBudget(supabase, { account: 'freshAccount' });
+    expect(result.budgetSessionHours).toBeCloseTo(22.4, 5);
+    expect(result.source).toBe('default');
+    expect(result.eventCount).toBe(0);
+  });
+});
+
+describe('resolveAccountLabel() (QF-20260720-706)', () => {
+  it('derives the free-text account label from the email local-part (live-verified: rickfelix2000@gmail.com -> rickfelix2000, matching the ledger seed data)', () => {
+    expect(resolveAccountLabel({ email: 'rickfelix2000@gmail.com', orgName: 'x', accountUuid8: 'y' })).toBe('rickfelix2000');
+  });
+
+  it('returns null for a missing or malformed identity, never throws', () => {
+    expect(resolveAccountLabel(null)).toBeNull();
+    expect(resolveAccountLabel({})).toBeNull();
+    expect(resolveAccountLabel({ email: 123 })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- `lib/eva/capacity-governor.js::getCalibratedBudget()` averaged `capacity_limit_events.session_hours_burned` across ALL accounts in the fleet's rotation with no account filter, despite the table already carrying a free-text `account` label column (populated via `overnight-capacity-governor.mjs`'s `record-event` CLI). A genuinely-exhausted account's events got diluted by a fresh account's events (and vice versa), corrupting the **live** overnight park/core-size governance decision — the same pooled-vs-per-account bug class QF-20260720-406 fixed for the manual /usage-dashboard gauge, but here feeding an active decision, not a display.
- Adds `resolveAccountLabel()`, deriving the free-text label from `getAccountIdentity()` (live-verified: `rickfelix2000@gmail.com`'s local-part matches the ledger's own seed data exactly) so the CLI never hand-types it.
- `getCalibratedBudget` accepts an optional `account` filter; zero events for that account falls back to the SAME documented default as an empty ledger — never back to the pooled cross-account average, which would defeat the fix.
- **Design note on `getCurrentBurnRate`**: left unfiltered, deliberately. `session_coordination` carries no account column, and the fleet runs under ONE account at a time (rotation, not concurrent multi-account) — `getFleetRoster`'s own freshness filter already excludes stale pre-switch sessions, so this real-time snapshot is inherently account-scoped already.
- The two account-label schemes (this free-text column vs QF-406's `accountUuid8` store) are genuinely separate data sources and are **not** reconciled here — that's a bigger design decision than this fix's scope, flagged explicitly rather than silently assumed.

## Test plan
- [x] `npx vitest run tests/unit/eva/capacity-governor.test.js` — 17/17 pass, including new coverage: per-account filtering never mixes accounts, zero-events-for-account falls back to default (not pooled), and `resolveAccountLabel` derivation
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] Live-verified against production: `getCalibratedBudget(supabase, { account: 'rickfelix2000' })` correctly filters, `{ account: 'codestreetlabs' }` correctly falls back to default (zero events for that account today); `node scripts/eva/overnight-capacity-governor.mjs project` and `verdict` both run cleanly with `budgetSource: "ledger_average_per_account"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)