### PR TITLE
fix(QF-20260720-171): wire --live Sonnet-floor client into fable-suitability dry-run

### DIFF
--- a/scripts/fable-suitability/dry-run.mjs
+++ b/scripts/fable-suitability/dry-run.mjs
@@ -10,10 +10,11 @@
  * validate ranking quality BEFORE the apply ceremony.
  *
  * --no-model (default in CI): use a deterministic reasoning-depth stub so the run needs no live
- * model. Without it, an injected Sonnet-floor client would be required (NEVER Fable).
+ * model. --live (QF-20260720-171): wire a genuine Sonnet-floor client (NEVER Fable) via constrained
+ * tool-use decoding (never a free-text parse + regex repair). Requires ANTHROPIC_API_KEY.
  *
  * Usage:
- *   node scripts/fable-suitability/dry-run.mjs [--dir lib/fable-suitability] [--duty harness-depth] [--no-model] [--max 10]
+ *   node scripts/fable-suitability/dry-run.mjs [--dir lib/fable-suitability] [--duty harness-depth] [--no-model|--live] [--max 10]
  * Exits 0 on a successful reachable run (even when every persist is CEREMONY_PENDING).
  */
 import 'dotenv/config';
@@ -25,6 +26,31 @@ import { createClient } from '@supabase/supabase-js';
 import { deriveRegion } from '../../lib/fable-suitability/region-cluster.mjs';
 import { upsertRegionScore } from '../../lib/fable-suitability/map-writer.mjs';
 import { runFanout } from '../../lib/fable-suitability/fanout.mjs';
+import { AnthropicAdapter } from '../../lib/sub-agents/vetting/provider-adapters.js';
+import { getClaudeModel } from '../../lib/config/model-config.js';
+
+/** Genuine Sonnet-floor client (NEVER Fable) via forced tool-use — constrained decoding,
+ * not free-text parse + repair. Requires ANTHROPIC_API_KEY. */
+export function createSonnetFloorClient() {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('--live requires ANTHROPIC_API_KEY to be set in this environment.');
+  }
+  const adapter = new AnthropicAdapter({ model: getClaudeModel('validation') });
+  return {
+    async scoreStructured({ prompt, schema }) {
+      const resp = await adapter.client.messages.create({
+        model: adapter.model,
+        max_tokens: 512,
+        tools: [{ name: 'submit_score', input_schema: schema }],
+        tool_choice: { type: 'tool', name: 'submit_score' },
+        messages: [{ role: 'user', content: prompt }],
+      });
+      const toolUse = resp.content.find((b) => b.type === 'tool_use');
+      if (!toolUse) throw new Error('live scoreStructured: no tool_use block in response');
+      return toolUse.input;
+    },
+  };
+}
 
 /** Deterministic reasoning-depth stub for --no-model runs (mid band, no live call). */
 export const deterministicClient = {
@@ -73,6 +99,7 @@ async function main() {
   const duty = argVal(args, '--duty') || 'harness-depth';
   const max = Number(argVal(args, '--max')) || 10;
   const noModel = args.includes('--no-model');
+  const live = args.includes('--live');
 
   const root = process.cwd();
   const files = collectFiles(root, join(root, dir), [], 200);
@@ -86,7 +113,7 @@ async function main() {
     process.env.SUPABASE_SERVICE_ROLE_KEY,
     { auth: { autoRefreshToken: false, persistSession: false } },
   );
-  const client = noModel ? deterministicClient : requireInjectedClient();
+  const client = noModel ? deterministicClient : live ? createSonnetFloorClient() : requireInjectedClient();
 
   const result = await runFanout({
     regions,
@@ -105,7 +132,7 @@ async function main() {
   writeFileSync(artifact, JSON.stringify({ duty, generated_from: dir, ranked, persistedSummary: { persisted: result.persisted, ceremonyPending: result.ceremonyPending, skipped: result.skipped.length } }, null, 2));
 
   console.log(`\n── Fable-suitability DRY-RUN (inert-but-reachable) ──`);
-  console.log(`   scanned ${files.length} file(s) in ${dir} -> ${regions.length} region(s), duty=${duty}${noModel ? ' (--no-model stub)' : ''}`);
+  console.log(`   scanned ${files.length} file(s) in ${dir} -> ${regions.length} region(s), duty=${duty}${noModel ? ' (--no-model stub)' : live ? ' (--live Sonnet-floor)' : ''}`);
   console.log(`   scored ${result.scored.length}; persisted ${result.persisted}; CEREMONY_PENDING ${result.ceremonyPending} (child A staged => inert)`);
   console.log(`   ranked artifact: ${artifact}`);
   for (const r of ranked.slice(0, 5)) console.log(`     ${r.composite_score}  ${r.region_key}  [${r.axes.join('x')}]`);

--- a/tests/unit/fable-suitability/dry-run-live.test.js
+++ b/tests/unit/fable-suitability/dry-run-live.test.js
@@ -1,0 +1,55 @@
+/**
+ * QF-20260720-171: --live Sonnet-floor client wiring for fable-suitability dry-run.mjs.
+ * Constrained tool-use decoding (never a free-text parse + repair) — mocks the Anthropic SDK
+ * so no network call or real API key is required.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let mockCreate;
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    constructor() {
+      this.messages = { create: (...args) => mockCreate(...args) };
+    }
+  },
+}));
+
+const { createSonnetFloorClient } = await import('../../../scripts/fable-suitability/dry-run.mjs');
+
+describe('createSonnetFloorClient (QF-20260720-171)', () => {
+  const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+  afterEach(() => { process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY; });
+
+  it('throws a clear, actionable error when ANTHROPIC_API_KEY is unset', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    expect(() => createSonnetFloorClient()).toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  describe('with ANTHROPIC_API_KEY set', () => {
+    beforeEach(() => {
+      process.env.ANTHROPIC_API_KEY = 'test-key';
+      mockCreate = vi.fn().mockResolvedValue({
+        content: [{ type: 'tool_use', name: 'submit_score', input: { score: 4, rationale: 'entangled' } }],
+      });
+    });
+
+    it('calls messages.create with forced tool_choice (constrained decoding, not free-text)', async () => {
+      const client = createSonnetFloorClient();
+      const schema = { type: 'object', properties: { score: { type: 'integer' } } };
+      const result = await client.scoreStructured({ prompt: 'rate this', schema });
+
+      expect(result).toEqual({ score: 4, rationale: 'entangled' });
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.tool_choice).toEqual({ type: 'tool', name: 'submit_score' });
+      expect(callArgs.tools[0].input_schema).toBe(schema);
+      expect(callArgs.messages[0].content).toBe('rate this');
+    });
+
+    it('throws when the response has no tool_use block', async () => {
+      mockCreate.mockResolvedValue({ content: [{ type: 'text', text: 'not structured' }] });
+      const client = createSonnetFloorClient();
+      await expect(client.scoreStructured({ prompt: 'x', schema: {} }))
+        .rejects.toThrow(/no tool_use block/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `dry-run.mjs` had no CLI path to a genuine live-model run (`requireInjectedClient()` unconditionally threw without `--no-model`). Adds `--live`, which builds a real Sonnet-floor client (NEVER Fable) via forced Anthropic tool-use — constrained decoding, not a free-text parse + repair.
- `--no-model`'s existing deterministic-stub path is unchanged.
- Verified **live end-to-end** in this environment: `--live` produced a genuine model-scored row (`axis_reasoning_depth=4`, detailed weighted-composite rationale) rather than the stub's fixed score or the degraded-neutral fallback — `ANTHROPIC_API_KEY` is present via `.env`/dotenv here. This corrects the QF's original "zero LLM API keys" premise (a plain `process.env` check without loading dotenv misses `.env`-sourced keys) — at least this fleet-reachable environment already has a usable key.

## Test plan
- [x] `npx vitest run tests/unit/fable-suitability/dry-run-live.test.js` — 3/3 passing (throws without `ANTHROPIC_API_KEY`; forces `tool_choice` for constrained decoding; throws on missing `tool_use` block), mocked `@anthropic-ai/sdk`, no network call
- [x] `npx vitest run tests/unit/fable-suitability/` — 51/51 passing (no regressions)
- [x] `node scripts/fable-suitability/dry-run.mjs --no-model` — regression-clean
- [x] `node scripts/fable-suitability/dry-run.mjs --live` — genuine live Anthropic call, real score persisted with real rationale (confirmed via DB read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)