### PR TITLE
fix(QF-20260720-111): realign Solomon weekly budget-line cron to the active account's reset epoch

### DIFF
--- a/.github/workflows/solomon-duty-triggers-cron.yml
+++ b/.github/workflows/solomon-duty-triggers-cron.yml
@@ -11,7 +11,13 @@ name: "Solomon duty triggers (cron)"
 on:
   schedule:
     - cron: '37 11 * * *'   # daily forecast-trigger evaluation
-    - cron: '23 12 * * 1'   # Monday weekly budget-line reminder
+    # QF-20260720-111: realigned from Monday to Thursday 08:20 UTC (~4:20 AM ET) — the
+    # actual weekly reset epoch for the currently-active account (Deep Soul Sessions,
+    # resets Thu ~3:59 AM ET), not an arbitrary Monday. Per-account rotation means this
+    # drifts again if the active account changes (rickfelix2000 resets Fri ~6:59 AM ET,
+    # codestreetlabs' reset time is not yet confirmed) — the reminder body now names the
+    # account it fired against so a stale anchor is visible, not silent.
+    - cron: '20 8 * * 4'   # weekly budget-line reminder (Thursday epoch)
   workflow_dispatch:
     inputs:
       weekly:
@@ -51,7 +57,7 @@ jobs:
 
       - name: Run duty triggers (mode by schedule)
         run: |
-          if [ "${{ github.event.schedule }}" = "23 12 * * 1" ] || [ "${{ github.event.inputs.weekly }}" = "true" ]; then
+          if [ "${{ github.event.schedule }}" = "20 8 * * 4" ] || [ "${{ github.event.inputs.weekly }}" = "true" ]; then
             node scripts/solomon-forecast-trigger-check.mjs --weekly
           else
             node scripts/solomon-forecast-trigger-check.mjs

--- a/scripts/solomon-forecast-trigger-check.mjs
+++ b/scripts/solomon-forecast-trigger-check.mjs
@@ -9,7 +9,10 @@
  * against the LAST-ISSUED FORECAST BASIS (convention defined here: one feedback row,
  * category='solomon_forecast_basis', metadata { velocity_per_day, open_scope_count } —
  * Solomon stamps one whenever he issues a forecast). --weekly mode emits the
- * Monday-budget-line reminder (per-ISO-week dedupe).
+ * weekly budget-line reminder (per-ISO-week dedupe), fired at the currently-active
+ * account's reset epoch (QF-20260720-111 — was hardcoded Monday, now Thursday to match
+ * Deep Soul Sessions' actual weekly reset; account-named in the reminder so a future
+ * account rotation surfaces as a visible mismatch rather than silent drift).
  *
  * On fire: ONE typed row (kind='solomon_duty_reminder', payload.duty discriminator —
  * registered in the solomon drain set + SOLOMON_INBOX_KINDS) via the canonical
@@ -26,6 +29,19 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+const { getAccountIdentity } = require('../lib/fleet/account-identity.cjs');
+
+// QF-20260720-111: the weekly cron fires on the CURRENTLY-ACTIVE account's known reset day
+// (Thu = Deep Soul Sessions today) — but per-account rotation means that anchor drifts
+// silently if the active account changes. Naming the resolved account in the reminder
+// makes a stale anchor visible instead of silent. Keyed by email (the only reliably-known
+// identifier for all three rotation accounts — their accountUuid8 values are not all
+// independently verified here); codestreetlabs' reset day is not yet confirmed, so it is
+// deliberately absent from this map rather than guessed.
+export const KNOWN_RESET_DAYS = {
+  'deepsoulsessionslabel@gmail.com': 'Thursday (~3:59 AM ET)',
+  'rickfelix2000@gmail.com': 'Friday (~6:59 AM ET)',
+};
 
 const DAY = 24 * 60 * 60 * 1000;
 const OPEN_STATUSES = ['draft', 'in_progress', 'active', 'pending_approval'];
@@ -37,11 +53,11 @@ async function resolveTarget(sb) {
   return 'broadcast-solomon';
 }
 
-async function sendOnce(sb, target, { duty, stalenessKey, subject, body }) {
+async function sendOnce(sb, target, { duty, stalenessKey, subject, body }, sendRow = insertCoordinationRow) {
   const { data } = await sb.from('session_coordination').select('id')
     .eq('target_session', target).eq('payload->>staleness_key', stalenessKey).is('read_at', null).limit(1);
   if (Array.isArray(data) && data.length) return false; // unread reminder pending — no spam
-  await insertCoordinationRow(sb, {
+  await sendRow(sb, {
     sender_session: process.env.CLAUDE_SESSION_ID || 'solomon-duty-triggers-cron',
     target_session: target,
     message_type: 'INFO',
@@ -88,15 +104,24 @@ export async function runDailyTriggers(sb, { nowMs = Date.now() } = {}) {
   return { status: 'FIRED', fired, sent, target };
 }
 
-export async function runWeeklyReminder(sb, { nowMs = Date.now() } = {}) {
+export async function runWeeklyReminder(sb, { nowMs = Date.now(), resolveIdentity = getAccountIdentity, sendRow = insertCoordinationRow } = {}) {
   const week = (() => { const d = new Date(nowMs); const o = new Date(d.getFullYear(), 0, 1); return `${d.getFullYear()}-W${String(Math.ceil(((d - o) / DAY + o.getDay() + 1) / 7)).padStart(2, '0')}`; })();
   const target = await resolveTarget(sb);
+  // QF-20260720-111: name the account this epoch is anchored to, so a rotation away from
+  // the assumed account (this cron's Thursday firing day) surfaces as a visible mismatch
+  // rather than a silent day-of-week drift.
+  const identity = resolveIdentity();
+  const acctNote = identity
+    ? (KNOWN_RESET_DAYS[identity.email]
+        ? `active account ${identity.email} (reset ${KNOWN_RESET_DAYS[identity.email]})`
+        : `active account ${identity.email} (reset day NOT in KNOWN_RESET_DAYS — verify this firing day still matches)`)
+    : 'active account identity unresolved — verify this firing day still matches the active account\'s reset';
   const sent = await sendOnce(sb, target, {
     duty: 'weekly_budget_line',
     stalenessKey: `weekly-budget-line-${week}`,
-    subject: `Monday budget reset: weekly program duties due (${week})`,
-    body: `Monday reset reminder (${week}): send the P3 budget line to Adam, set the standing program, run the accuracy review + autonomy-report rollup, P4 Fable-terms re-check, and stamp a fresh forecast basis (feedback category=solomon_forecast_basis) if you re-issue. Owed-state row — if you are a successor Solomon reading this, the duty transferred with it. QF-20260719-148 L2.`,
-  });
+    subject: `Weekly budget reset: duties due (${week}, ${acctNote})`,
+    body: `Weekly reset reminder (${week}, ${acctNote}): send the P3 budget line to Adam, set the standing program, run the accuracy review + autonomy-report rollup, P4 Fable-terms re-check, and stamp a fresh forecast basis (feedback category=solomon_forecast_basis) if you re-issue. Owed-state row — if you are a successor Solomon reading this, the duty transferred with it. QF-20260719-148 L2 / QF-20260720-111 (account-aware epoch).`,
+  }, sendRow);
   return { status: sent ? 'SENT' : 'pending-reminder', week, target };
 }
 

--- a/tests/unit/solomon-forecast-trigger-check.test.js
+++ b/tests/unit/solomon-forecast-trigger-check.test.js
@@ -1,0 +1,76 @@
+/**
+ * QF-20260720-111 — account-aware weekly budget-line epoch.
+ *
+ * The Monday-anchored cron (solomon-duty-triggers-cron.yml) misaligned with the real
+ * per-account weekly resets (DeepSoul Thu ~3:59AM ET, rickfelix2000 Fri ~6:59AM ET).
+ * runWeeklyReminder() now resolves the currently-active account and names it in the
+ * reminder, so a rotation away from the cron's assumed account (Thursday) surfaces as
+ * a visible mismatch instead of silent drift.
+ *
+ * insertCoordinationRow (lib/coordinator/dispatch.cjs) runs several real-DB assertion
+ * helpers before inserting — injected via the sendRow seam so these tests exercise only
+ * runWeeklyReminder's own logic (account resolution + reminder shaping), not dispatch's
+ * validation chain.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runWeeklyReminder, KNOWN_RESET_DAYS } from '../../scripts/solomon-forecast-trigger-check.mjs';
+
+function makeMockSupabase({ existingUnread = false } = {}) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            is: () => ({
+              limit: async () => ({ data: existingUnread ? [{ id: 'prior' }] : [] }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+const NOW = Date.parse('2026-07-23T08:20:00Z'); // a Thursday
+
+describe('runWeeklyReminder — account-aware epoch naming', () => {
+  it('names a KNOWN account + its reset day in the subject/body', async () => {
+    const sb = makeMockSupabase();
+    const sendRow = vi.fn(async () => ({ id: 'row-1' }));
+    const resolveIdentity = () => ({ email: 'deepsoulsessionslabel@gmail.com', orgName: 'x', accountUuid8: 'ca1de6e4' });
+    const res = await runWeeklyReminder(sb, { nowMs: NOW, resolveIdentity, sendRow });
+    expect(res.status).toBe('SENT');
+    const row = sendRow.mock.calls[0][1];
+    expect(row.subject).toContain('deepsoulsessionslabel@gmail.com');
+    expect(row.subject).toContain(KNOWN_RESET_DAYS['deepsoulsessionslabel@gmail.com']);
+    expect(row.payload.body).toContain('deepsoulsessionslabel@gmail.com');
+  });
+
+  it('flags an UNKNOWN account (e.g. codestreetlabs) rather than silently asserting a reset day', async () => {
+    const sb = makeMockSupabase();
+    const sendRow = vi.fn(async () => ({ id: 'row-1' }));
+    const resolveIdentity = () => ({ email: 'codestreetlabs@example.com', orgName: 'x', accountUuid8: 'deadbeef' });
+    const res = await runWeeklyReminder(sb, { nowMs: NOW, resolveIdentity, sendRow });
+    expect(res.status).toBe('SENT');
+    const row = sendRow.mock.calls[0][1];
+    expect(row.subject).toContain('codestreetlabs@example.com');
+    expect(row.subject).toContain('NOT in KNOWN_RESET_DAYS');
+  });
+
+  it('never throws when account identity is unresolved (null) — labels it explicitly instead', async () => {
+    const sb = makeMockSupabase();
+    const sendRow = vi.fn(async () => ({ id: 'row-1' }));
+    const res = await runWeeklyReminder(sb, { nowMs: NOW, resolveIdentity: () => null, sendRow });
+    expect(res.status).toBe('SENT');
+    const row = sendRow.mock.calls[0][1];
+    expect(row.subject).toContain('identity unresolved');
+  });
+
+  it('dedupes per ISO week regardless of which day it actually fires on (no send on an unread pending reminder)', async () => {
+    const sb = makeMockSupabase({ existingUnread: true });
+    const sendRow = vi.fn(async () => ({ id: 'row-1' }));
+    const res = await runWeeklyReminder(sb, { nowMs: NOW, resolveIdentity: () => null, sendRow });
+    expect(res.status).toBe('pending-reminder');
+    expect(sendRow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
The weekly budget-line reminder cron fired Monday 12:23 UTC, but the real Anthropic weekly resets are per-account: Deep Soul Sessions (currently active) resets Thu ~3:59 AM ET, rickfelix2000 resets Fri ~6:59 AM ET. Solomon confirmed the misalignment (weekly-tick delta advisory `433ec0da`) and was already manually treating Thursday as the real budget epoch.

- `.github/workflows/solomon-duty-triggers-cron.yml`: cron moved Monday 12:23 UTC → Thursday 08:20 UTC (~4:20 AM ET), matching Deep Soul Sessions' actual reset. Updated the matching bash condition in the same file.
- `scripts/solomon-forecast-trigger-check.mjs`: `runWeeklyReminder()` now resolves the currently-active account (`lib/fleet/account-identity.cjs`) and names it + its known reset day directly in the reminder subject/body — so a future account rotation (e.g. back to rickfelix2000, or on to codestreetlabs) surfaces as a **visible mismatch** in the reminder text rather than a silent day-of-week drift. `codestreetlabs`' reset day isn't independently confirmed, so it's deliberately absent from `KNOWN_RESET_DAYS` rather than guessed — an unknown account is flagged explicitly ("NOT in KNOWN_RESET_DAYS") instead of silently asserting a wrong day.

**Deliberately out of scope**: `scripts/solomon-startup-check.mjs`'s separate `weekly-program` SOLOMON_LOOPS cron (still Monday) — both the QF description and Solomon's own framing treat that as a lighter-weight "duty-review beat" distinct from the session-independent trigger this QF realigns.

## Test plan
- [x] New `tests/unit/solomon-forecast-trigger-check.test.js` (4 tests): known-account naming, unknown-account explicit flag (not a silent guess), null-identity fail-soft labeling, ISO-week dedup still works regardless of firing day. `insertCoordinationRow` (which runs real DB assertion helpers) is injected via a new `sendRow` seam rather than deep-mocked.
- [x] `tests/unit/solomon-startup-check.test.js` (pre-existing, unmodified): still 36/36 green — confirms no cross-contamination with the separate `weekly-program` cron.
- [x] YAML validated to parse correctly with the new schedule.
- [x] Verified no other references to the old Monday cron string / "Monday budget reset" text remain in this diff's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)