### PR TITLE
fix(QF-20260720-296): review-gate CRIT-007 false positive on co-occurring env vars

### DIFF
--- a/config/review-critical-findings.json
+++ b/config/review-critical-findings.json
@@ -85,9 +85,10 @@
       "id": "CRIT-007",
       "name": "service_role_exposure",
       "description": "Service role key used in client-accessible code",
+      "_note": "QF-20260720-296: 'NEXT_PUBLIC.*SERVICE_ROLE' / 'VITE.*SERVICE_ROLE' used .* which matches ACROSS two separate, unrelated env var names on the same line -- e.g. the pervasive createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY) boilerplate used in 10+ merged files. Tightened to require NEXT_PUBLIC_/VITE_ as an immediate token prefix of SERVICE_ROLE (\\\\w* keeps matching within one identifier, but stops at the spaces/pipes/dots separating two distinct env var references) -- same same-token-boundary fix shape as CRIT-002's own _note. Still matches a genuine NEXT_PUBLIC_SERVICE_ROLE_KEY-style variable name.",
       "patterns": [
-        "NEXT_PUBLIC.*SERVICE_ROLE",
-        "VITE.*SERVICE_ROLE",
+        "NEXT_PUBLIC_\\w*SERVICE_ROLE",
+        "VITE_\\w*SERVICE_ROLE",
         "window\\..*service.?role"
       ],
       "severity": "critical",

--- a/tests/unit/review-gate-closed-enum-fp.test.js
+++ b/tests/unit/review-gate-closed-enum-fp.test.js
@@ -123,4 +123,32 @@ describe('review-gate closed-enum false-positive fixes (a78478f9 + 03ccc4d4)', (
     ].join('\n');
     expect(names(spoof)).toContain('auth_bypass');
   });
+
+  // CRIT-007 service_role_exposure — QF-20260720-296. `NEXT_PUBLIC.*SERVICE_ROLE` used
+  // .* which matched ACROSS two separate, unrelated env var references on the same line,
+  // not a single NEXT_PUBLIC_-prefixed service-role variable.
+  it('does NOT flag the pervasive createClient(SUPABASE_URL||NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY) boilerplate', () => {
+    expect(names(
+      '+const sb = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);'
+    )).not.toContain('service_role_exposure');
+  });
+  it('does NOT flag NEXT_PUBLIC_SUPABASE_ANON_KEY co-occurring with an unrelated SERVICE_ROLE reference', () => {
+    expect(names(
+      '+ const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY; const svc = process.env.SUPABASE_SERVICE_ROLE_KEY;'
+    )).not.toContain('service_role_exposure');
+  });
+  it('STILL flags a genuine NEXT_PUBLIC_-prefixed service-role variable name', () => {
+    expect(names('+ const key = process.env.NEXT_PUBLIC_SERVICE_ROLE_KEY;')).toContain('service_role_exposure');
+  });
+  it('STILL flags a genuine NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY-style variable name', () => {
+    expect(names('+ const key = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY;')).toContain('service_role_exposure');
+  });
+  it('STILL flags a genuine VITE_-prefixed service-role variable name', () => {
+    expect(names('+ const key = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY;')).toContain('service_role_exposure');
+  });
+  it('does NOT flag co-occurring VITE_SUPABASE_URL and an unrelated SERVICE_ROLE reference', () => {
+    expect(names(
+      '+ const sb = createClient(import.meta.env.VITE_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);'
+    )).not.toContain('service_role_exposure');
+  });
 });


### PR DESCRIPTION
## Summary
- \`lib/ship/review-gate.js\`'s CRIT-007 (\`service_role_exposure\`) patterns \`NEXT_PUBLIC.*SERVICE_ROLE\` / \`VITE.*SERVICE_ROLE\` used \`.*\` which matches ACROSS two separate, unrelated env var references on the same line — e.g. the pervasive \`createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY)\` boilerplate already used in 10+ merged files — not a genuine \`NEXT_PUBLIC_\`-prefixed service-role variable.
- Confirmed live: false-blocked \`/ship\`'s deep-tier review gate for PR #6342 (\`SD-LEO-INFRA-DRAIN-SET-REGISTRY-001-D\`) on a script using the exact same createClient pattern as \`scripts/solomon-forecast-trigger-check.mjs\`, which merged cleanly earlier this session via a different completion path (QF, not \`/ship\`).
- Tightened both patterns to require \`NEXT_PUBLIC_\`/\`VITE_\` as an immediate token prefix of \`SERVICE_ROLE\` (\`\w*\` keeps matching within one identifier but stops at the spaces/pipes/dots separating two distinct env var references) — same same-token-boundary fix shape CRIT-002's own \`_note\` documents for an analogous SQL-injection false positive.

## Test plan
- [x] 6 new regression tests in \`tests/unit/review-gate-closed-enum-fp.test.js\` pin both directions: the false positive no longer fires (the boilerplate pattern, plus a NEXT_PUBLIC_ANON_KEY / VITE_SUPABASE_URL co-occurrence variant), AND a genuine \`NEXT_PUBLIC_SERVICE_ROLE_KEY\` / \`NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY\` / \`VITE_SUPABASE_SERVICE_ROLE_KEY\`-style variable name still triggers CRIT-007
- [x] \`npx vitest run tests/unit/review-gate-closed-enum-fp.test.js\` — 26/26 pass
- [x] Re-ran \`runReview()\` against PR #6342's actual diff with the fix applied — \`checkCriticalFindings\` now returns \`[]\` (was blocking on CRIT-007 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)