### PR TITLE
fix(QF-20260720-230): paginate fleet-dashboard.cjs's unfiltered v_active_sessions read

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -151,17 +151,31 @@ function formatEtaTime(iso) {
 // ── Data Loading ──
 
 async function loadData() {
-  const [sessRes, allSessRes, childRes, coordRes, rawSessRes, drainRes] = await Promise.all([
+  // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 (QF-20260720-230): this read has NO filter
+  // (feeds allSessions -> isDispatchableFleetMember idle/liveness detection) and was silently
+  // capped at the PostgREST 1000-row max — v_active_sessions has 5,921+ rows live, so this was
+  // missing ~83% of sessions. Paginate to completion; fail-soft to [] (dashboard render must
+  // never crash on this display-only read).
+  const allSessionsPromise = (async () => {
+    try {
+      return await fapPaginate(() => supabase
+        .from('v_active_sessions')
+        // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + metadata so the idle filter can apply
+        // isDispatchableFleetMember (excludes coordinator/adam/non_fleet/fixture).
+        .select('session_id, sd_key, computed_status, metadata, tty, heartbeat_age_seconds, heartbeat_age_human')
+        .order('heartbeat_age_seconds', { ascending: true })
+        .order('session_id', { ascending: true })); // unique tiebreaker: stable page boundaries (FR-6)
+    } catch (e) {
+      console.warn(`⚠️  [count-discipline] v_active_sessions (all): pagination failed (${e.message}) — degrading to empty`);
+      return [];
+    }
+  })();
+
+  const [sessRes, childRes, coordRes, rawSessRes, drainRes] = await Promise.all([
     supabase
       .from('v_active_sessions')
       .select('session_id, sd_key, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track, terminal_id, loop_state')
       .not('sd_key', 'is', null)
-      .order('heartbeat_age_seconds', { ascending: true }),
-    supabase
-      .from('v_active_sessions')
-      // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + metadata so the idle filter can apply
-      // isDispatchableFleetMember (excludes coordinator/adam/non_fleet/fixture).
-      .select('session_id, sd_key, computed_status, metadata, tty, heartbeat_age_seconds, heartbeat_age_human')
       .order('heartbeat_age_seconds', { ascending: true }),
     supabase
       .from('strategic_directives_v2')
@@ -228,7 +242,7 @@ async function loadData() {
   }
 
   const sessions = warnIfCapTruncated(sessRes.data, 'v_active_sessions (claimed)');
-  const allSessions = warnIfCapTruncated(allSessRes.data, 'v_active_sessions (all)');
+  const allSessions = await allSessionsPromise;
   const drainAgents = warnIfCapTruncated(drainRes.data, 'claude_sessions (drain agents)');
   const children = warnIfCapTruncated(childRes.data, 'orchestrator children');
   // QF-20260704-051: orchestrator children are tracked separately (above) — exclude their

--- a/tests/unit/fleet-dashboard-all-sessions-pagination.test.js
+++ b/tests/unit/fleet-dashboard-all-sessions-pagination.test.js
@@ -1,0 +1,30 @@
+/**
+ * QF-20260720-230 — fleet-dashboard.cjs's v_active_sessions "all" read (feeds allSessions,
+ * consumed by isDispatchableFleetMember idle/liveness detection) had NO filter and was a raw
+ * unpaginated select, silently capped at PostgREST's 1000-row max. Live-verified: v_active_sessions
+ * had 5,921 rows, so this read was missing ~83% of sessions. Converted to fapPaginate, matching
+ * the pattern already used for every other unfiltered read in this file (PR #6280,
+ * SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001). Static source pin — no live DB — so a future
+ * edit can't silently revert this one site back to a capped raw select.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+describe('fleet-dashboard.cjs allSessions read — paginated, not capped (QF-20260720-230)', () => {
+  it('the v_active_sessions "all" read (feeding allSessions) calls fapPaginate', () => {
+    const src = readFileSync(
+      fileURLToPath(new URL('../../scripts/fleet-dashboard.cjs', import.meta.url)),
+      'utf8',
+    );
+    const idx = src.indexOf('allSessionsPromise');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 700);
+    expect(block).toContain('fapPaginate');
+    expect(block).toContain("select('session_id, sd_key, computed_status, metadata, tty, heartbeat_age_seconds, heartbeat_age_human')");
+    // Regression guard against reintroducing the old raw-select variant that fed
+    // allSessRes/warnIfCapTruncated instead of the paginated promise.
+    expect(src).not.toMatch(/warnIfCapTruncated\(allSessRes\.data/);
+    expect(src).toMatch(/allSessions\s*=\s*await allSessionsPromise/);
+  });
+});


### PR DESCRIPTION
## Summary
- The `v_active_sessions` "all" read in `scripts/fleet-dashboard.cjs` (feeds `allSessions`, consumed by `isDispatchableFleetMember` idle/liveness detection) had no filter and was a raw `.select()`, silently capped at PostgREST's 1000-row max — the batch-1 disposition on this file was a tripwire, not pagination coverage.
- Live-verified: `v_active_sessions` has 5,921 rows — this read was silently missing ~83% of sessions, risking wrong idle/liveness classifications for sessions past the cap.
- Converts this one site to `fapPaginate`, matching the pattern already used at every other unfiltered read in this file (PR #6280, `SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001`).

## Test plan
- [x] `npx vitest run tests/unit/fleet-dashboard-all-sessions-pagination.test.js` — 1/1 pass (static regression guard against reverting this site back to a capped raw select)
- [x] `npx vitest run` across 8 related `fleet-dashboard`-touching suites — 53/53 pass, no regressions
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean
- [x] Live-verified: `node scripts/fleet-dashboard.cjs` runs cleanly, and the `[count-discipline] v_active_sessions (all)` truncation warning no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)