### PR TITLE
fix(QF-20260720-911): stop orphan-adoption from stealing a directed WORK_ASSIGNMENT

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1110,6 +1110,36 @@ const ORPHAN_CANDIDATE_LIMIT = 5;
 // one window past the clear. A genuine orphan sits indefinitely — the delay is safe.
 const ORPHAN_MIN_AGE_MS = 15 * 60 * 1000;
 
+// RCA a4587e48 (QF-20260720-911): adoptOrphanInProgress had no arbitration against a directed
+// WORK_ASSIGNMENT dispatched for the SAME SD — a just-cleared, just-dispatched orphan could be
+// stolen by a random worker before the assignee attached; the adopter then re-parked it
+// (requires_human_action=true), re-fencing before the assignee landed (a silent no-land loop).
+//
+// Deliberately does NOT reuse coordinatorReservation/ctx.reservations: drain-reservations.cjs's
+// own header documents that step running AFTER adopt-orphan in the checkin pipeline SPECIFICALLY
+// so orphan recovery stays unaffected by that fence mechanism — reordering the pipeline (or
+// plumbing a second, out-of-band reservations fetch) would fight that already-settled
+// architecture. This checks a narrower, independently-verifiable signal instead: an unread
+// directed WORK_ASSIGNMENT genuinely targeting this SD (target_sd, or the canonical
+// payload.assigned_sd/payload.sd_key dispatch keys — see extractSdFromAssignment/dispatch.cjs's
+// own resolution order) that has not yet expired. Fail-open: a query error never blocks adoption.
+async function pendingDirectedAssignmentBlocksAdoption(sb, sdKey) {
+  try {
+    const { data } = await sb
+      .from('session_coordination')
+      .select('id, expires_at')
+      .eq('message_type', 'WORK_ASSIGNMENT')
+      .is('read_at', null)
+      .or(`target_sd.eq.${sdKey},payload->>assigned_sd.eq.${sdKey},payload->>sd_key.eq.${sdKey}`)
+      .order('created_at', { ascending: false })
+      .limit(3);
+    const now = Date.now();
+    return (data || []).some((r) => !r.expires_at || new Date(r.expires_at).getTime() > now);
+  } catch {
+    return false;
+  }
+}
+
 async function adoptOrphanInProgress(sb, sessionId, base) {
   try {
     const cutoffIso = new Date(Date.now() - ORPHAN_MIN_AGE_MS).toISOString();
@@ -1147,6 +1177,9 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       // short-lived CLI invocations) -- foreignClaimantBlocksSteal() additionally requires the
       // live claimant to have real WIP before refusing. Fail-open: probe errors don't block.
       if (await foreignClaimantBlocksSteal(sb, sd.sd_key, sessionId)) continue;
+      // QF-20260720-911: a live, unread directed WORK_ASSIGNMENT for this SD means the
+      // coordinator already picked an assignee — honor that dispatch instead of stealing it.
+      if (await pendingDirectedAssignmentBlocksAdoption(sb, sd.sd_key)) continue;
       const claimed = await tryClaim(sb, sd.sd_key, sessionId);
       if (claimed.ok) {
         return {
@@ -1557,7 +1590,7 @@ async function main() {
 // top (imports are referenced directly — never re-derived).
 const CHECKIN_HELPERS = { ws, tryClaim, ackMessage, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, registerRollCall, rehydrateCallsign, selfClearQuarantine, mergeCheckinModelEffort, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isBuildForbiddenSession, ensureActiveBaseline, isCriticalQfJumpEligible, tryClaimDraftCandidate, baselinedCandidateEligible, isSdInFlight, selfClaimQuickFix, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, surfaceCoordinatorMessages, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, sortByDispatchRank, resolveWorkerTierRank, isTieringActive, fetchLowerTierBacklogData, ladderTopRank, fetchFableWindowActive, claimableForTier, claimableForRepo, getCommsActivitySignals, computeAdaptiveCadence, antiWinddownDirective, ASSIGNMENT_RECENCY_WINDOW_MS, TERMINAL_CLAIM_ERRORS, QF_CANDIDATE_LIMIT, SELF_CLAIM_CANDIDATE_LIMIT, DEFAULT_IDLE_WAKEUP_SECONDS };
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-orphan-adoption-directed-assignment-guard.test.js
+++ b/tests/unit/worker-checkin-orphan-adoption-directed-assignment-guard.test.js
@@ -1,0 +1,83 @@
+/**
+ * QF-20260720-911 (RCA a4587e48) — adoptOrphanInProgress had no arbitration against a directed
+ * WORK_ASSIGNMENT dispatched for the same SD: a random worker could steal a just-cleared,
+ * just-dispatched orphan before the assignee attached, and the adopter re-parking it
+ * (requires_human_action=true) re-fenced the SD before the real assignee ever landed — a
+ * silent no-land loop (live incident: SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001).
+ *
+ * pendingDirectedAssignmentBlocksAdoption checks a narrow, independently-verifiable signal
+ * (an unread, non-expired WORK_ASSIGNMENT genuinely targeting this SD) — deliberately NOT the
+ * coordinatorReservation/ctx.reservations fence mechanism, since drain-reservations.cjs's own
+ * header documents that step running AFTER adopt-orphan specifically so orphan recovery stays
+ * unaffected by that fence.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { pendingDirectedAssignmentBlocksAdoption } = require('../../scripts/worker-checkin.cjs');
+
+function makeSb(rows) {
+  return {
+    from(table) {
+      if (table !== 'session_coordination') throw new Error(`unexpected table: ${table}`);
+      return {
+        select: () => ({
+          eq: () => ({
+            is: () => ({
+              or: () => ({
+                order: () => ({
+                  limit: async () => ({ data: rows }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+describe('pendingDirectedAssignmentBlocksAdoption (QF-20260720-911)', () => {
+  it('blocks adoption when a live, unread WORK_ASSIGNMENT targets this SD', async () => {
+    const sb = makeSb([{ id: 'row-1', expires_at: null }]);
+    expect(await pendingDirectedAssignmentBlocksAdoption(sb, 'SD-X-001')).toBe(true);
+  });
+
+  it('does not block when no matching rows exist (the common case)', async () => {
+    const sb = makeSb([]);
+    expect(await pendingDirectedAssignmentBlocksAdoption(sb, 'SD-X-001')).toBe(false);
+  });
+
+  it('does not block when the only matching row has already expired', async () => {
+    const sb = makeSb([{ id: 'row-1', expires_at: new Date(Date.now() - 60_000).toISOString() }]);
+    expect(await pendingDirectedAssignmentBlocksAdoption(sb, 'SD-X-001')).toBe(false);
+  });
+
+  it('blocks when at least one of several candidate rows is still active', async () => {
+    const sb = makeSb([
+      { id: 'expired', expires_at: new Date(Date.now() - 60_000).toISOString() },
+      { id: 'active', expires_at: new Date(Date.now() + 60_000).toISOString() },
+    ]);
+    expect(await pendingDirectedAssignmentBlocksAdoption(sb, 'SD-X-001')).toBe(true);
+  });
+
+  it('fails open: a thrown query error never blocks adoption', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    expect(await pendingDirectedAssignmentBlocksAdoption(sb, 'SD-X-001')).toBe(false);
+  });
+});
+
+describe('adoptOrphanInProgress wiring — static pin (guard placed before the claim attempt)', () => {
+  it('calls pendingDirectedAssignmentBlocksAdoption inside the orphan guard loop, before tryClaim', () => {
+    const { readFileSync } = require('node:fs');
+    const src = readFileSync(require.resolve('../../scripts/worker-checkin.cjs'), 'utf8');
+    const fnStart = src.indexOf('async function adoptOrphanInProgress');
+    const fnEnd = src.indexOf('\n}', src.indexOf('const claimed = await tryClaim', fnStart));
+    const body = src.slice(fnStart, fnEnd);
+    const guardIdx = body.indexOf('pendingDirectedAssignmentBlocksAdoption');
+    const claimIdx = body.indexOf('const claimed = await tryClaim');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(claimIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(claimIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- **RCA a4587e48**: `adoptOrphanInProgress` re-adopts any `in_progress` + unclaimed SD >15min stale with no arbitration against a directed `WORK_ASSIGNMENT`. A just-cleared, just-dispatched orphan could be stolen by a random worker before the assignee attached; the adopter then re-parks it (`requires_human_action=true`), re-fencing the SD before the real assignee ever landed — a silent no-land loop (live incident: `SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001` re-fenced after every coordinator clear).
- Adds `pendingDirectedAssignmentBlocksAdoption`: an unread, non-expired `WORK_ASSIGNMENT` genuinely targeting this SD (`target_sd`, or the canonical `payload.assigned_sd`/`payload.sd_key` dispatch keys — the same resolution order `dispatch.cjs` itself uses) skips adoption. Fail-open: a query error never blocks adoption.

## Scoping note (important)
The QF's own suggestion was to reuse `coordinatorReservation`/`ctx.reservations` (the general coordinator-fence mechanism, already imported but never called). Deliberately did **not** go that route — `lib/checkin/steps/drain-reservations.cjs`'s own header documents that step running AFTER `adopt-orphan` in the checkin pipeline SPECIFICALLY so orphan recovery stays unaffected by that fence; reordering the pipeline (or plumbing a second out-of-band reservations fetch) would fight that already-settled architecture. This closes the exact described race with a narrower, independently-verifiable signal instead. The QF also suggested gating on `metadata.fence_cleared_at` — that field does not exist anywhere in the codebase, so this fix doesn't depend on it.

The QF's **RELATED** note (`lib/coordinator/dispatch.cjs`'s `model_tier_decisions` audit-trail write does a full-blob metadata read-spread-write that could resurrect a stale `requires_human_action=true`) is a genuinely separate data-integrity issue — left out of scope here per the QF's own "verify, may fold or split" hedge; flagging for a follow-up rather than silently dropping it.

Signaled to the coordinator before implementing, per the QF's own "DISPATCH-MECHANISM (fleet blast radius) — needs coordinator review" sourcing note (it was not hard-fenced with `needs_coordinator_review`, so self-claim proceeded normally).

## Test plan
- [x] `npx vitest run tests/unit/worker-checkin-orphan-adoption-directed-assignment-guard.test.js` — 6/6 pass (unit coverage for the new guard function + a static pin proving it's wired before the claim attempt)
- [x] `npx vitest run tests/unit/worker-checkin*.test.js` — 170/170 pass, no regressions
- [x] `npx vitest run tests/unit/checkin-pipeline.test.js tests/unit/coordinator-reservation-fence.test.js tests/unit/fleet/soft-reserve-liveness.test.js tests/unit/seat-busy-fence.test.js` — 51/51 pass, confirms the checkin pipeline ordering is untouched
- [x] `node scripts/audit-db-test-guards.mjs --staged` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)