### PR TITLE
fix(QF-20260720-597): metadata stamp writers use atomic JSONB partial-merge, never read-spread-write

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -339,7 +339,7 @@ const EVIDENCE_LOOKBACK_MS = 24 * 60 * 60 * 1000;
  * unchanged and never blocks dispatch. Nothing gates on any of these fields.
  * @private
  */
-async function stampModelRecommendation(supabase, row, logger = console) {
+async function stampModelRecommendation(supabase, row, logger = console, mergeMetadataKeysFn = null) {
   try {
     if (row.message_type !== 'WORK_ASSIGNMENT') return;
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
@@ -387,14 +387,17 @@ async function stampModelRecommendation(supabase, row, logger = console) {
     row.payload = newPayload;
 
     // FR-4: fire-and-forget audit trail on the target SD — never blocks dispatch on failure.
+    // QF-20260720-597: this used to read sd.metadata, spread it whole, and full-blob
+    // .update({ metadata: {...} }) — a TOCTOU race that silently RESURRECTS a hold flag
+    // (needs_coordinator_review / requires_human_action) a concurrent coordinator clear
+    // already flipped false between this read and this write. mergeMetadataKeys() writes
+    // ONLY model_tier_decisions via an atomic JSONB `||` merge, touching no other key.
     try {
       const existing = Array.isArray(sd.metadata && sd.metadata.model_tier_decisions) ? sd.metadata.model_tier_decisions : [];
       const entry = { at: new Date().toISOString(), criterion: rec.criterion, tier: rec.tier, reason: rec.reason, dispatch_row_id: row.id || null };
       const trimmed = [...existing, entry].slice(-MODEL_TIER_DECISIONS_CAP);
-      await supabase
-        .from('strategic_directives_v2')
-        .update({ metadata: { ...(sd.metadata || {}), model_tier_decisions: trimmed } })
-        .eq('sd_key', sdKey);
+      const mergeFn = mergeMetadataKeysFn || (await import('./safe-metadata-merge.mjs')).mergeMetadataKeys;
+      await mergeFn(sdKey, { model_tier_decisions: trimmed });
     } catch (e) {
       logger && logger.warn && logger.warn(`[dispatch] model_tier_decisions audit-trail write skipped: ${e.message}`);
     }

--- a/lib/coordinator/safe-metadata-merge.mjs
+++ b/lib/coordinator/safe-metadata-merge.mjs
@@ -1,0 +1,64 @@
+/**
+ * lib/coordinator/safe-metadata-merge.mjs — QF-20260720-597.
+ *
+ * Shared ATOMIC JSONB partial-merge helper for strategic_directives_v2.metadata writes.
+ * Exists so future metadata stampers (Adam's ad-hoc passes, dispatch.cjs's audit-trail
+ * writes, any future tooling) cannot reintroduce the read-spread-write anti-pattern that
+ * silently RESURRECTS a concurrently-cleared coordinator hold flag (needs_coordinator_review,
+ * requires_human_action) from a stale snapshot — the flag reads false at write time but the
+ * write still lands with a full-blob overwrite of an OLDER metadata copy. Live near-miss:
+ * an Adam LEO name-stamp pass (RCA a4587e48, Solomon advisory a91b0569); verified NO
+ * resurrection occurred that time, but the pattern is unsafe by construction. Exemplar fix:
+ * lib/coordinator/clear-coordinator-review.js (documents a prior REAL "RE-FENCE #3").
+ *
+ * mergeMetadataKeys(sdKey, patch) writes ONLY the keys present in `patch` via a Postgres
+ * JSONB `||` merge — every OTHER key (including any hold flag a concurrent process just
+ * cleared) is left completely untouched by this write, eliminating the read-then-write
+ * TOCTOU race a `.update({ metadata: { ...spread, ...patch } })` full-blob write has by
+ * construction. supabase-js's `.update()` cannot express a JSONB `||` merge directly, so
+ * this goes through the raw pg connection (same seam clear-coordinator-review.js uses).
+ */
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+/**
+ * @param {string} sdKey
+ * @param {object} patch - plain, JSON-serializable object of ONLY the keys to set/overwrite.
+ *   A nested object REPLACES (not deep-merges) the corresponding top-level key — the same
+ *   semantics as Postgres jsonb `||`.
+ * @param {object} [opts]
+ * @param {Function} [opts.createClientFn] test-injection seam (defaults to createDatabaseClient)
+ * @returns {Promise<{merged: boolean, sdKey: string, error?: string}>}
+ */
+export async function mergeMetadataKeys(sdKey, patch, opts = {}) {
+  if (!sdKey || typeof sdKey !== 'string') {
+    throw new Error('mergeMetadataKeys: sdKey is required');
+  }
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    throw new Error('mergeMetadataKeys: patch must be a plain object');
+  }
+  const { createClientFn = createDatabaseClient } = opts;
+
+  let client;
+  try {
+    client = await createClientFn('engineer', { verify: false });
+  } catch (connErr) {
+    return { merged: false, sdKey, error: `db_connect_failed: ${connErr.message}` };
+  }
+
+  try {
+    // COALESCE guards a SQL-NULL metadata column (NULL::jsonb || x evaluates to NULL in
+    // Postgres — see clear-coordinator-review.js's identical guard) from silently wiping
+    // the whole blob on a row whose metadata has never been set.
+    const result = await client.query(
+      `UPDATE strategic_directives_v2
+       SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb
+       WHERE sd_key = $1`,
+      [sdKey, JSON.stringify(patch)]
+    );
+    return { merged: result.rowCount > 0, sdKey };
+  } catch (queryErr) {
+    return { merged: false, sdKey, error: queryErr.message };
+  } finally {
+    try { await client.end(); } catch { /* best-effort close */ }
+  }
+}

--- a/tests/unit/coordinator/safe-metadata-merge.test.js
+++ b/tests/unit/coordinator/safe-metadata-merge.test.js
@@ -1,0 +1,85 @@
+/**
+ * QF-20260720-597: lib/coordinator/safe-metadata-merge.mjs
+ *
+ * Shared atomic-merge helper so future metadata stampers cannot reintroduce the
+ * read-spread-write anti-pattern that silently resurrects a concurrently-cleared
+ * coordinator hold flag (needs_coordinator_review / requires_human_action). Mirrors
+ * clear-coordinator-review.js's exemplar test style: a fake raw-pg client, one atomic
+ * `||` merge query, no follow-up read.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { mergeMetadataKeys } from '../../../lib/coordinator/safe-metadata-merge.mjs';
+
+function fakeClient({ rowCount = 1, queryError = null } = {}) {
+  const queries = [];
+  return {
+    queries,
+    query: vi.fn(async (sql, params) => {
+      queries.push({ sql, params });
+      if (queryError) throw queryError;
+      return { rowCount };
+    }),
+    end: vi.fn(async () => {}),
+  };
+}
+
+describe('mergeMetadataKeys', () => {
+  it('throws synchronously on a missing sdKey (programmer error)', async () => {
+    await expect(mergeMetadataKeys()).rejects.toThrow('sdKey is required');
+  });
+
+  it('throws synchronously on a non-object patch (programmer error)', async () => {
+    await expect(mergeMetadataKeys('SD-TEST-001', 'not-an-object')).rejects.toThrow('patch must be a plain object');
+    await expect(mergeMetadataKeys('SD-TEST-001', ['array'])).rejects.toThrow('patch must be a plain object');
+  });
+
+  it('issues ONE atomic || merge touching only the given keys, and closes the connection', async () => {
+    const client = fakeClient({ rowCount: 1 });
+    const createClientFn = vi.fn(async () => client);
+
+    const result = await mergeMetadataKeys('SD-TEST-001', { model_tier_decisions: [{ tier: 'fable' }] }, { createClientFn });
+
+    expect(result).toEqual({ merged: true, sdKey: 'SD-TEST-001' });
+    expect(client.queries).toHaveLength(1);
+    expect(client.queries[0].sql).toMatch(/\|\|/);
+    expect(client.queries[0].sql).toMatch(/^\s*UPDATE strategic_directives_v2/i);
+    expect(client.queries[0].sql).toMatch(/COALESCE\(metadata/i);
+    expect(client.queries[0].params[0]).toBe('SD-TEST-001');
+    expect(JSON.parse(client.queries[0].params[1])).toEqual({ model_tier_decisions: [{ tier: 'fable' }] });
+    expect(client.end).toHaveBeenCalledOnce();
+  });
+
+  it('never sends a full-metadata-blob spread — the patch param carries ONLY the caller-given keys', async () => {
+    const client = fakeClient({ rowCount: 1 });
+    const createClientFn = vi.fn(async () => client);
+    // A caller reading a stale snapshot with hold flags must never re-transmit them —
+    // the whole point is that this function's SQL param is the patch object as-given,
+    // never a spread of some larger metadata blob the caller may have read.
+    await mergeMetadataKeys('SD-TEST-001', { some_key: 'value' }, { createClientFn });
+    const sentPatch = JSON.parse(client.queries[0].params[1]);
+    expect(Object.keys(sentPatch)).toEqual(['some_key']);
+  });
+
+  it('reports merged:false (no throw) when no row matched', async () => {
+    const client = fakeClient({ rowCount: 0 });
+    const createClientFn = vi.fn(async () => client);
+    const result = await mergeMetadataKeys('SD-NOPE-001', { x: 1 }, { createClientFn });
+    expect(result).toEqual({ merged: false, sdKey: 'SD-NOPE-001' });
+  });
+
+  it('fail-soft on connection failure — never throws, closes nothing (no client to close)', async () => {
+    const createClientFn = vi.fn(async () => { throw new Error('connect refused'); });
+    const result = await mergeMetadataKeys('SD-TEST-001', { x: 1 }, { createClientFn });
+    expect(result.merged).toBe(false);
+    expect(result.error).toMatch(/db_connect_failed/);
+  });
+
+  it('fail-soft on query failure — still closes the connection', async () => {
+    const client = fakeClient({ queryError: new Error('constraint violation') });
+    const createClientFn = vi.fn(async () => client);
+    const result = await mergeMetadataKeys('SD-TEST-001', { x: 1 }, { createClientFn });
+    expect(result.merged).toBe(false);
+    expect(result.error).toMatch(/constraint violation/);
+    expect(client.end).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/fleet/stamp-model-recommendation.test.js
+++ b/tests/unit/fleet/stamp-model-recommendation.test.js
@@ -111,40 +111,54 @@ describe('stampModelRecommendation (FR-3) — evidence-first enforcement', () =>
 });
 
 describe('stampModelRecommendation (FR-4) — tier-decision audit trail', () => {
+  // QF-20260720-597: the audit-trail write now goes through mergeMetadataKeys (atomic JSONB
+  // partial-merge, lib/coordinator/safe-metadata-merge.mjs) instead of a read-spread-write
+  // supabase .update({metadata}) — injected as the 4th param so these tests never touch a
+  // live DB connection.
   it('AC-4-1: a fable/R1 decision appends one entry to metadata.model_tier_decisions', async () => {
-    const updateSpy = vi.fn();
+    const mergeSpy = vi.fn(async () => ({ merged: true }));
     const row = { id: 'row-abc', message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-X-009' } };
-    await stampModelRecommendation(fakeSb({ sdRow: { description: 'architecture decision', metadata: {} }, evidenceRows: [{ id: 'e1' }], updateSpy }), row);
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    const [{ metadata }] = updateSpy.mock.calls[0];
-    expect(metadata.model_tier_decisions).toHaveLength(1);
-    expect(metadata.model_tier_decisions[0]).toMatchObject({ criterion: 'R1', tier: 'fable', dispatch_row_id: 'row-abc' });
-    expect(typeof metadata.model_tier_decisions[0].at).toBe('string');
+    await stampModelRecommendation(fakeSb({ sdRow: { description: 'architecture decision', metadata: {} }, evidenceRows: [{ id: 'e1' }] }), row, console, mergeSpy);
+    expect(mergeSpy).toHaveBeenCalledTimes(1);
+    const [sdKey, patch] = mergeSpy.mock.calls[0];
+    expect(sdKey).toBe('SD-X-009');
+    expect(patch.model_tier_decisions).toHaveLength(1);
+    expect(patch.model_tier_decisions[0]).toMatchObject({ criterion: 'R1', tier: 'fable', dispatch_row_id: 'row-abc' });
+    expect(typeof patch.model_tier_decisions[0].at).toBe('string');
   });
 
   it('AC-4-2 / TS-6: metadata.model_tier_decisions is FIFO-capped at 20 entries', async () => {
-    const updateSpy = vi.fn();
+    const mergeSpy = vi.fn(async () => ({ merged: true }));
     const existing = Array.from({ length: 20 }, (_, i) => ({ at: `t${i}`, criterion: 'R1', tier: 'fable', reason: 'x', dispatch_row_id: `old-${i}` }));
     const row = { id: 'row-new', message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-X-010' } };
-    await stampModelRecommendation(fakeSb({ sdRow: { description: 'architecture decision', metadata: { model_tier_decisions: existing } }, evidenceRows: [{ id: 'e1' }], updateSpy }), row);
-    const [{ metadata }] = updateSpy.mock.calls[0];
-    expect(metadata.model_tier_decisions).toHaveLength(20);
-    expect(metadata.model_tier_decisions[0].dispatch_row_id).toBe('old-1'); // oldest (old-0) dropped
-    expect(metadata.model_tier_decisions[19].dispatch_row_id).toBe('row-new');
+    await stampModelRecommendation(fakeSb({ sdRow: { description: 'architecture decision', metadata: { model_tier_decisions: existing } }, evidenceRows: [{ id: 'e1' }] }), row, console, mergeSpy);
+    const [, patch] = mergeSpy.mock.calls[0];
+    expect(patch.model_tier_decisions).toHaveLength(20);
+    expect(patch.model_tier_decisions[0].dispatch_row_id).toBe('old-1'); // oldest (old-0) dropped
+    expect(patch.model_tier_decisions[19].dispatch_row_id).toBe('row-new');
   });
 
   it('AC-4-3: a metadata write failure is swallowed and never propagates', async () => {
+    const mergeSpy = vi.fn(async () => { throw new Error('write failed'); });
     const sb = fakeSb({ sdRow: { description: 'architecture decision', metadata: {} }, evidenceRows: [{ id: 'e1' }] });
-    sb.from = ((orig) => (table) => {
-      const base = orig(table);
-      if (table === 'strategic_directives_v2') {
-        return { ...base, update: () => ({ eq: () => Promise.reject(new Error('write failed')) }) };
-      }
-      return base;
-    })(sb.from.bind(sb));
     const row = { message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-X-011' } };
-    await expect(stampModelRecommendation(sb, row)).resolves.toBeUndefined();
+    await expect(stampModelRecommendation(sb, row, console, mergeSpy)).resolves.toBeUndefined();
     // The dispatch-relevant fields still landed even though the audit-trail write failed.
     expect(row.payload.model_recommendation).toBe('fable');
+  });
+
+  it('QF-20260720-597: the write is a targeted key-merge, never a full-metadata-blob spread (the resurrection vector)', async () => {
+    const mergeSpy = vi.fn(async () => ({ merged: true }));
+    // The read snapshot carries a hold flag a concurrent coordinator clear may have already
+    // flipped false in the DB — the merge call must NEVER re-send it.
+    const row = { id: 'row-xyz', message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-X-012' } };
+    await stampModelRecommendation(
+      fakeSb({ sdRow: { description: 'architecture decision', metadata: { needs_coordinator_review: true, requires_human_action: true } }, evidenceRows: [{ id: 'e1' }] }),
+      row, console, mergeSpy
+    );
+    const [, patch] = mergeSpy.mock.calls[0];
+    expect(Object.keys(patch)).toEqual(['model_tier_decisions']);
+    expect(patch.needs_coordinator_review).toBeUndefined();
+    expect(patch.requires_human_action).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Solomon catch (advisory `a91b0569`) + RCA `a4587e48`: any code that reads `strategic_directives_v2.metadata`, spreads it, then does a full-blob `.update({ metadata })` can **resurrect** a hold flag (`needs_coordinator_review`, `requires_human_action`) from a snapshot predating a concurrent coordinator clear — silently, success-reporting. Live near-miss: an Adam LEO name-stamp pass this morning; verified no live resurrection occurred that time, but the pattern is unsafe by construction. The exemplar fix is already in-repo: `lib/coordinator/clear-coordinator-review.js`.

- **`lib/coordinator/safe-metadata-merge.mjs`** (new): shared `mergeMetadataKeys(sdKey, patch)` helper — an atomic Postgres JSONB `||` merge via the raw pg connection (same seam `clear-coordinator-review.js` uses, since supabase-js can't express `||` merges directly), writing **only** the caller-given keys so any other key a concurrent process changed (a coordinator clear, another stamper) is never clobbered. This is the reusable safeguard so future stampers (Adam's ad-hoc passes, coordinator tooling) can't reintroduce the pattern.
- **`lib/coordinator/dispatch.cjs`**: migrated the `model_tier_decisions` audit-trail write (~line 396) from `.update({ metadata: {...sd.metadata, model_tier_decisions} })` to `mergeMetadataKeys(sdKey, { model_tier_decisions })`. `stampModelRecommendation` gained an injectable 4th param (`mergeMetadataKeysFn`) so this stays unit-testable without a live DB connection.

**Deliberately not touched**: a scoped search of `lib/` found no other read-spread-write site on `strategic_directives_v2.metadata`. Adam's own name-stamp pass that triggered this QF was an ad-hoc, uncommitted one-off — nothing to migrate in-repo for that specific incident; the shared helper is the forward-looking fix so any future stamp tooling (including Adam's) has a safe path available.

## Test plan
- [x] `tests/unit/coordinator/safe-metadata-merge.test.js` (new, 7 tests): atomic-query shape assertion (matches `clear-coordinator-review.test.js`'s style), patch-only-no-spread guarantee, no-row-matched / connect-failure / query-failure fail-soft paths.
- [x] `tests/unit/fleet/stamp-model-recommendation.test.js` (updated, 13 tests: 12 pre-existing rewired to the injected merge seam + 1 new): explicitly asserts the merge call NEVER carries a stale `needs_coordinator_review`/`requires_human_action` snapshot — the resurrection vector this QF closes.
- [x] Broader `dispatch.cjs`-adjacent suite (19 files, 252 tests): all green, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)