### PR TITLE
feat(SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001): fleet session-registry + manifest SSOT substrate

### DIFF
--- a/lib/fleet/session-manifest.js
+++ b/lib/fleet/session-manifest.js
@@ -1,0 +1,64 @@
+/**
+ * Fleet session-manifest SSOT — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-3).
+ *
+ * Per the coordinator design review (APPROVE + required amendment: "manifest = DESIRED state, U6/G1"):
+ * the manifest declares the TARGET fleet session set — what the fleet SHOULD be (e.g. one live
+ * coordinator, one live Adam, and N live workers) — NOT a passive view of whatever happens to be
+ * alive. Pairing the desired manifest with the ACTUAL live set (counts derived from the session-
+ * registry SSOT, FR-1) yields observable DRIFT: the manifest is the source of truth for the intended
+ * fleet shape, and any shortfall (a missing/under-provisioned role) is surfaced, never silent.
+ *
+ * PURE CORE (data-in / verdict-out, no DB) so both the manifest normalization and the drift
+ * computation are unit-testable without a database; a thin adapter supplies the desired manifest
+ * (config/roadmap) and the actual per-role live counts.
+ */
+
+/**
+ * Normalize desired-manifest entries to { role, min } where `min` is the minimum number of live
+ * sessions DESIRED for that role (defaults to 1). Entries without a role are dropped.
+ * @param {Array<{role?:string, min?:number}>} desired
+ * @returns {Array<{role:string, min:number}>}
+ */
+export function normalizeDesiredManifest(desired = []) {
+  return (Array.isArray(desired) ? desired : [])
+    .map((d) => ({ role: (d && d.role) || null, min: d && Number.isFinite(d.min) && d.min > 0 ? d.min : 1 }))
+    .filter((d) => d.role);
+}
+
+/**
+ * Compute DRIFT of the actual live fleet vs the DESIRED manifest. A role whose live count is below
+ * its desired minimum is UNDER-provisioned (drift); at/above is satisfied. Extra live roles not in
+ * the manifest are surfaced separately (unexpected) but do not, by themselves, constitute a shortfall.
+ * @param {{ desired?: Array<{role:string,min?:number}>, actualByRole?: Record<string,number> }} input
+ * @returns {{ drift:boolean, under:Array<{role:string,desired:number,actual:number}>, satisfied:Array<{role:string,actual:number}>, unexpected:string[] }}
+ */
+export function computeManifestDrift({ desired = [], actualByRole = {} } = {}) {
+  const norm = normalizeDesiredManifest(desired);
+  const desiredRoles = new Set(norm.map((d) => d.role));
+  const under = [];
+  const satisfied = [];
+  for (const d of norm) {
+    const actual = Number(actualByRole[d.role]) || 0;
+    if (actual < d.min) under.push({ role: d.role, desired: d.min, actual });
+    else satisfied.push({ role: d.role, actual });
+  }
+  const unexpected = Object.keys(actualByRole || {})
+    .filter((role) => !desiredRoles.has(role) && (Number(actualByRole[role]) || 0) > 0);
+  return { drift: under.length > 0, under, satisfied, unexpected };
+}
+
+/**
+ * Human/remediation summary of a drift verdict (for a coordinator advisory / audit line).
+ * @param {ReturnType<typeof computeManifestDrift>} verdict
+ * @returns {{ detail:string, remediation:string|null }}
+ */
+export function summarizeManifestDrift(verdict) {
+  if (!verdict || !verdict.drift) {
+    return { detail: `fleet matches desired manifest (${(verdict && verdict.satisfied.length) || 0} role(s) satisfied)`, remediation: null };
+  }
+  const gaps = verdict.under.map((u) => `${u.role}: ${u.actual}/${u.desired}`).join(', ');
+  return {
+    detail: `fleet DRIFT vs desired manifest — under-provisioned: ${gaps}`,
+    remediation: `ACTION: spawn/route sessions to satisfy the desired manifest roles: ${verdict.under.map((u) => u.role).join(', ')}`,
+  };
+}

--- a/lib/fleet/session-manifest.js
+++ b/lib/fleet/session-manifest.js
@@ -1,3 +1,6 @@
+// @wire-check-exempt: foundation desired-state manifest (SD-A fleet-launcher substrate). Pure
+// drift core built first; the coordinator-audit consumer (computeManifestDrift over live counts)
+// is the activation follow-up. Consumed today by its unit tests.
 /**
  * Fleet session-manifest SSOT — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-3).
  *

--- a/lib/fleet/session-metering.js
+++ b/lib/fleet/session-metering.js
@@ -1,0 +1,45 @@
+/**
+ * Fleet session-metering surface — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-4).
+ *
+ * Pure aggregation over the session-registry SSOT (FR-1 joined identities): live-session counts by
+ * role / model / identity-namespace, for the fleet metering surface (observability). This is the
+ * ACTUAL side that pairs with the FR-3 DESIRED manifest — computeManifestDrift consumes the by-role
+ * counts produced here to surface actual-vs-desired drift.
+ *
+ * PURE (data-in / verdict-out, no DB). `roleOf` / `modelOf` are injected accessors so the aggregation
+ * stays decoupled from where role (SET_IDENTITY rows) and model (claude_sessions.metadata.model) live.
+ */
+
+/**
+ * Aggregate joined session identities into a metering snapshot.
+ * @param {Array<object>} joined - session identities (from joinSessionIdentity, FR-1)
+ * @param {{ roleOf?: (s:object)=>string|null, modelOf?: (s:object)=>string|null }} [accessors]
+ * @returns {{ total:number, byRole:Record<string,number>, byModel:Record<string,number>, byNamespace:{session_id:number,terminal_id:number,pid:number,callsign:number} }}
+ */
+export function meterSessions(joined = [], { roleOf, modelOf } = {}) {
+  const list = Array.isArray(joined) ? joined : [];
+  const byRole = {};
+  const byModel = {};
+  const byNamespace = { session_id: 0, terminal_id: 0, pid: 0, callsign: 0 };
+  for (const s of list) {
+    if (!s) continue;
+    const role = (roleOf ? roleOf(s) : s.role) || 'unknown';
+    byRole[role] = (byRole[role] || 0) + 1;
+    const model = (modelOf ? modelOf(s) : s.model) || 'unknown';
+    byModel[model] = (byModel[model] || 0) + 1;
+    for (const ns of ['session_id', 'terminal_id', 'pid', 'callsign']) {
+      if (s[ns] != null && s[ns] !== '') byNamespace[ns] += 1;
+    }
+  }
+  return { total: list.length, byRole, byModel, byNamespace };
+}
+
+/**
+ * Reduce a metering snapshot's byRole map to the actual-per-role counts computeManifestDrift expects
+ * (identity passthrough — kept explicit so the metering→manifest-drift contract is named + testable).
+ * @param {ReturnType<typeof meterSessions>} snapshot
+ * @returns {Record<string,number>}
+ */
+export function actualByRole(snapshot) {
+  return (snapshot && snapshot.byRole) || {};
+}

--- a/lib/fleet/session-metering.js
+++ b/lib/fleet/session-metering.js
@@ -1,3 +1,6 @@
+// @wire-check-exempt: foundation metering surface (SD-A fleet-launcher substrate). Pure aggregation
+// built first; the metering-surface consumer + manifest-drift wiring is the activation follow-up.
+// Consumed today by its unit tests (incl. the metering→manifest-drift contract test).
 /**
  * Fleet session-metering surface — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-4).
  *

--- a/lib/fleet/session-registry.js
+++ b/lib/fleet/session-registry.js
@@ -1,0 +1,60 @@
+/**
+ * Fleet session-registry SSOT — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-1).
+ *
+ * Joins the four fleet-identity namespaces into ONE resolvable session identity so every consumer
+ * (claim-guard, worker-checkin, coordinator) can read one source instead of re-deriving identity
+ * per-caller:
+ *   - session_id, terminal_id, pid  — from claude_sessions
+ *   - callsign                      — from the SET_IDENTITY row (the callsign authority is a
+ *                                     SET_IDENTITY row, not a claude_sessions column)
+ *
+ * PURE CORE (data-in / verdict-out, NO DB) so the join + resolution are unit-testable without a
+ * live database; the thin DB adapter passes claude_sessions rows + a session_id->callsign map in.
+ *
+ * COLLISION-VISIBLE by contract: resolving a namespace key that matches MORE THAN ONE distinct
+ * session returns an explicit `{ resolved:false, reason:'ambiguous', ... }` — never a silent wrong
+ * match. This is the exact failure the Method-3 marker-file fallback caused (two sessions collapsing
+ * to one identity) before SD-LEO-FIX-DETERMINISTIC-FLEET-SESSION-001 removed it: the registry keeps
+ * the ambiguity OBSERVABLE instead of guessing.
+ */
+
+/**
+ * Join claude_sessions rows with a session_id->callsign map into the 4-namespace identity set.
+ * @param {{ sessions?: Array<{session_id?:string, terminal_id?:string, pid?:number}>, callsignBySession?: Record<string,string> }} input
+ * @returns {Array<{session_id:string|null, terminal_id:string|null, pid:number|null, callsign:string|null}>}
+ */
+export function joinSessionIdentity({ sessions = [], callsignBySession = {} } = {}) {
+  return (Array.isArray(sessions) ? sessions : []).map((s) => ({
+    session_id: (s && s.session_id) || null,
+    terminal_id: (s && s.terminal_id) || null,
+    pid: s && s.pid != null ? s.pid : null,
+    callsign: (s && s.session_id && callsignBySession[s.session_id]) || null,
+  }));
+}
+
+/**
+ * Resolve ONE joined identity by a namespace key. Collision-visible: >1 match → explicit ambiguous;
+ * zero matches → not_found; a missing key → no_key. Never returns a silently-picked wrong session.
+ * @param {Array<object>} joined - output of joinSessionIdentity
+ * @param {{ by?: string, value?: any }} key
+ * @returns {{ resolved:boolean, identity?:object, reason?:string, count?:number, matches?:object[] }}
+ */
+export function resolveSessionIdentity(joined = [], { by, value } = {}) {
+  if (!by || value == null || value === '') return { resolved: false, reason: 'no_key' };
+  const matches = (Array.isArray(joined) ? joined : []).filter((j) => j && j[by] === value);
+  if (matches.length === 0) return { resolved: false, reason: 'not_found' };
+  if (matches.length > 1) return { resolved: false, reason: 'ambiguous', count: matches.length, matches };
+  return { resolved: true, identity: matches[0] };
+}
+
+/**
+ * Fail-soft absence probe — mirrors lib/forecasting / sms-bridge drain semantics so the DB adapter
+ * degrades to an empty registry when the backing table is absent, never throwing (42P01 / PGRST205).
+ * @param {{code?:string, message?:string, details?:string}|null} error
+ * @returns {boolean}
+ */
+export function tableAbsent(error) {
+  if (!error) return false;
+  const code = error.code || error.details || '';
+  return code === '42P01' || code === 'PGRST205' || /does not exist|relation .* not exist|not found/i.test(error.message || '');
+}

--- a/lib/fleet/session-registry.js
+++ b/lib/fleet/session-registry.js
@@ -1,3 +1,6 @@
+// @wire-check-exempt: foundation session-identity SSOT (SD-A fleet-launcher substrate). Pure
+// primitive built first; consumer adoption (claim-guard / worker-checkin / coordinator-audit read
+// resolveSessionIdentity) is the activation follow-up. Consumed today by its unit tests.
 /**
  * Fleet session-registry SSOT — SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 (FR-1).
  *

--- a/tests/unit/fleet/session-manifest.test.js
+++ b/tests/unit/fleet/session-manifest.test.js
@@ -1,0 +1,44 @@
+// SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 FR-3 — manifest = DESIRED state + drift (coordinator amendment).
+// Fully in-memory (no DB): proves the manifest models the TARGET fleet shape and surfaces drift.
+import { describe, it, expect } from 'vitest';
+import { normalizeDesiredManifest, computeManifestDrift, summarizeManifestDrift } from '../../../lib/fleet/session-manifest.js';
+
+describe('session-manifest = DESIRED state (FR-3)', () => {
+  const desired = [{ role: 'coordinator', min: 1 }, { role: 'adam', min: 1 }, { role: 'worker', min: 3 }];
+
+  it('normalizes desired entries (default min=1, drops role-less)', () => {
+    const n = normalizeDesiredManifest([{ role: 'coordinator' }, { role: 'worker', min: 4 }, { min: 2 }]);
+    expect(n).toEqual([{ role: 'coordinator', min: 1 }, { role: 'worker', min: 4 }]);
+  });
+
+  it('DRIFT when a desired role is under-provisioned', () => {
+    const v = computeManifestDrift({ desired, actualByRole: { coordinator: 1, adam: 0, worker: 2 } });
+    expect(v.drift).toBe(true);
+    expect(v.under).toEqual([{ role: 'adam', desired: 1, actual: 0 }, { role: 'worker', desired: 3, actual: 2 }]);
+    expect(v.satisfied).toEqual([{ role: 'coordinator', actual: 1 }]);
+  });
+
+  it('NO drift when the fleet meets/exceeds the desired manifest', () => {
+    const v = computeManifestDrift({ desired, actualByRole: { coordinator: 1, adam: 1, worker: 5 } });
+    expect(v.drift).toBe(false);
+    expect(v.under).toEqual([]);
+  });
+
+  it('surfaces unexpected live roles not in the manifest (observable, not a shortfall)', () => {
+    const v = computeManifestDrift({ desired, actualByRole: { coordinator: 1, adam: 1, worker: 3, ghost: 2 } });
+    expect(v.drift).toBe(false);
+    expect(v.unexpected).toEqual(['ghost']);
+  });
+
+  it('summarizeManifestDrift → remediation on drift, null when satisfied', () => {
+    const drifted = computeManifestDrift({ desired, actualByRole: { coordinator: 0 } });
+    expect(summarizeManifestDrift(drifted).remediation).toMatch(/coordinator/);
+    const ok = computeManifestDrift({ desired, actualByRole: { coordinator: 1, adam: 1, worker: 3 } });
+    expect(summarizeManifestDrift(ok).remediation).toBeNull();
+  });
+
+  it('empty/absent input is drift-free (conservative)', () => {
+    expect(computeManifestDrift().drift).toBe(false);
+    expect(computeManifestDrift({ desired: [] }).drift).toBe(false);
+  });
+});

--- a/tests/unit/fleet/session-metering.test.js
+++ b/tests/unit/fleet/session-metering.test.js
@@ -1,0 +1,41 @@
+// SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 FR-4 — pure metering surface + manifest-drift contract.
+import { describe, it, expect } from 'vitest';
+import { meterSessions, actualByRole } from '../../../lib/fleet/session-metering.js';
+import { computeManifestDrift } from '../../../lib/fleet/session-manifest.js';
+
+describe('session-metering surface (FR-4)', () => {
+  const joined = [
+    { session_id: 's1', terminal_id: 't1', pid: 100, callsign: 'Alpha', role: 'coordinator', model: 'opus' },
+    { session_id: 's2', terminal_id: 't2', pid: 200, callsign: 'Bravo', role: 'worker', model: 'sonnet' },
+    { session_id: 's3', terminal_id: 't3', pid: null, callsign: null, role: 'worker', model: 'sonnet' },
+  ];
+
+  it('aggregates by role / model / namespace', () => {
+    const m = meterSessions(joined);
+    expect(m.total).toBe(3);
+    expect(m.byRole).toEqual({ coordinator: 1, worker: 2 });
+    expect(m.byModel).toEqual({ opus: 1, sonnet: 2 });
+    expect(m.byNamespace).toEqual({ session_id: 3, terminal_id: 3, pid: 2, callsign: 2 });
+  });
+
+  it('uses injected roleOf/modelOf accessors; missing → unknown', () => {
+    const m = meterSessions([{ session_id: 'x' }], { roleOf: () => null, modelOf: () => undefined });
+    expect(m.byRole).toEqual({ unknown: 1 });
+    expect(m.byModel).toEqual({ unknown: 1 });
+  });
+
+  it('empty/absent input → zeroed snapshot', () => {
+    expect(meterSessions().total).toBe(0);
+    expect(meterSessions(null).byRole).toEqual({});
+  });
+
+  it('metering byRole feeds computeManifestDrift (actual side of desired-vs-actual)', () => {
+    const snapshot = meterSessions(joined);
+    const drift = computeManifestDrift({
+      desired: [{ role: 'coordinator', min: 1 }, { role: 'worker', min: 3 }],
+      actualByRole: actualByRole(snapshot),
+    });
+    expect(drift.drift).toBe(true); // worker 2/3 under-provisioned
+    expect(drift.under).toEqual([{ role: 'worker', desired: 3, actual: 2 }]);
+  });
+});

--- a/tests/unit/fleet/session-registry.test.js
+++ b/tests/unit/fleet/session-registry.test.js
@@ -1,0 +1,56 @@
+// SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 FR-1 — pure session-registry SSOT join/resolve.
+// Fully in-memory (no DB, no supabase import): proves the 4-namespace join and the collision-VISIBLE
+// resolution (the anti-Method-3-marker-collapse guarantee).
+import { describe, it, expect } from 'vitest';
+import { joinSessionIdentity, resolveSessionIdentity, tableAbsent } from '../../../lib/fleet/session-registry.js';
+
+describe('session-registry SSOT (FR-1)', () => {
+  const sessions = [
+    { session_id: 's1', terminal_id: 't1', pid: 100 },
+    { session_id: 's2', terminal_id: 't2', pid: 200 },
+    { session_id: 's3', terminal_id: 't1', pid: 300 }, // shares terminal_id t1 with s1 (collision surface)
+  ];
+  const callsignBySession = { s1: 'Alpha', s2: 'Bravo' };
+
+  it('joins the four namespaces (session_id/terminal_id/pid/callsign)', () => {
+    const joined = joinSessionIdentity({ sessions, callsignBySession });
+    expect(joined).toHaveLength(3);
+    expect(joined[0]).toEqual({ session_id: 's1', terminal_id: 't1', pid: 100, callsign: 'Alpha' });
+    expect(joined[2].callsign).toBeNull(); // s3 has no SET_IDENTITY callsign
+  });
+
+  it('resolves a unique key to exactly one identity', () => {
+    const joined = joinSessionIdentity({ sessions, callsignBySession });
+    const r = resolveSessionIdentity(joined, { by: 'session_id', value: 's2' });
+    expect(r.resolved).toBe(true);
+    expect(r.identity.callsign).toBe('Bravo');
+  });
+
+  it('COLLISION-VISIBLE: a terminal_id shared by two sessions resolves AMBIGUOUS, never a silent match', () => {
+    const joined = joinSessionIdentity({ sessions, callsignBySession });
+    const r = resolveSessionIdentity(joined, { by: 'terminal_id', value: 't1' });
+    expect(r.resolved).toBe(false);
+    expect(r.reason).toBe('ambiguous');
+    expect(r.count).toBe(2);
+  });
+
+  it('not_found / no_key are explicit (never a wrong guess)', () => {
+    const joined = joinSessionIdentity({ sessions });
+    expect(resolveSessionIdentity(joined, { by: 'session_id', value: 'nope' }).reason).toBe('not_found');
+    expect(resolveSessionIdentity(joined, { by: 'session_id', value: '' }).reason).toBe('no_key');
+    expect(resolveSessionIdentity(joined, {}).reason).toBe('no_key');
+  });
+
+  it('join is fail-safe on empty/absent input', () => {
+    expect(joinSessionIdentity()).toEqual([]);
+    expect(joinSessionIdentity({ sessions: null })).toEqual([]);
+  });
+
+  it('tableAbsent detects 42P01/PGRST205 (fail-soft), false otherwise', () => {
+    expect(tableAbsent({ code: '42P01' })).toBe(true);
+    expect(tableAbsent({ code: 'PGRST205' })).toBe(true);
+    expect(tableAbsent({ message: 'relation "x" does not exist' })).toBe(true);
+    expect(tableAbsent(null)).toBe(false);
+    expect(tableAbsent({ code: '23505' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Fleet launcher SD-A — the session registry + manifest SSOT substrate (coordinator design-reviewed: APPROVE + FR-3 amendment "manifest = DESIRED state", addressed). Three pure, fail-soft, foundation cores:

- **FR-1 `lib/fleet/session-registry.js`** — four-namespace identity join (session_id/terminal_id/pid/callsign) with **collision-VISIBLE resolution** (a key matching >1 session returns explicit `{ambiguous}`, never a silent wrong match — the failure the removed Method-3 marker fallback caused).
- **FR-3 `lib/fleet/session-manifest.js`** — the manifest as the **DESIRED** fleet state (target roles/counts) + `computeManifestDrift` (actual-vs-desired, observable, with remediation).
- **FR-4 `lib/fleet/session-metering.js`** — pure metering (live counts by role/model/namespace), the ACTUAL side that feeds FR-3 drift via `actualByRole`.
- **FR-2** (terminal_id collision-root fix) is **already delivered on main** by SD-LEO-FIX-DETERMINISTIC-FLEET-SESSION-001 (Method 3 removed) — no rebuild.

Pure data-in/verdict-out cores (no DB) → unit-testable. Foundation libs built-first; consumer adoption (claim-guard/checkin/coordinator-audit) is the activation follow-up (`@wire-check-exempt`).

## Test plan
- [x] 16 new unit tests across the 3 modules — 569 fleet tests green, 0 regressions
- [x] EXEC-TO-PLAN + PLAN-TO-LEAD passed (score 97); HEAL 87%, retro quality 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)