### PR TITLE
feat(SD-LEO-INFRA-FLEET-WATCHDOG-001): fleet session watchdog — CRASHED/AUTH-LOST/STOPPED/ALIVE

### DIFF
--- a/lib/fleet/session-watchdog.js
+++ b/lib/fleet/session-watchdog.js
@@ -1,0 +1,99 @@
+/**
+ * Fleet WATCHDOG — SD-LEO-INFRA-FLEET-WATCHDOG-001 (Solomon SD-E / U5).
+ *
+ * @wire-check-exempt: foundation watchdog over the SD-A session registry, built first; the
+ * coordinator-audit / operator-badge consumer is the activation follow-up. Consumed today by tests.
+ *
+ * Heartbeat-staleness detection that badges THREE DISTINCT states (+ ALIVE) because the OPERATOR
+ * RESPONSE differs for each (U5) — the whole point vs a naive staleness alarm:
+ *   - ALIVE     — recent heartbeat; no action.
+ *   - STOPPED   — intentionally parked (awaiting_tick / armed-silence / lifecycle-terminated); NO action.
+ *                 (Restarting a deliberately-stopped session is the naive-alarm's first failure mode.)
+ *   - AUTH-LOST — heartbeat stale but the PROCESS IS ALIVE ⇒ logged out (wake-from-sleep / mass-logout
+ *                 class); response: RE-AUTH. (Ignoring this is the naive-alarm's second failure mode.)
+ *   - CRASHED   — heartbeat stale AND the process is DEAD; response: RESTART.
+ *
+ * PURE CORE (data-in / verdict-out, no DB). isPidAlive / isWithinArmedSilence are injected so the
+ * classifier is unit-testable without a live process table; the adapter supplies the real predicates
+ * (lib/fleet/cc-pid-liveness.cjs isProcessRunning). Read-only / advisory — never mutates a session.
+ */
+
+export const WATCHDOG_STATES = Object.freeze({ ALIVE: 'ALIVE', STOPPED: 'STOPPED', AUTH_LOST: 'AUTH-LOST', CRASHED: 'CRASHED' });
+
+const REMEDIATION = Object.freeze({
+  ALIVE: null,
+  STOPPED: null,
+  'AUTH-LOST': 're-auth: process alive but session logged out (wake-from-sleep / mass-logout) — restore auth',
+  CRASHED: 'restart: process dead and heartbeat stale',
+});
+
+/**
+ * Classify ONE session's watchdog state.
+ * @param {{heartbeat_at?:string, pid?:number, loop_state?:string, expected_silence_until?:string, status?:string, session_id?:string}} session
+ * @param {{ nowMs:number, staleThresholdMs:number, isPidAlive?:(s:object)=>boolean, isWithinArmedSilence?:(until:string,now:number)=>boolean }} ctx
+ * @returns {{ state:string, remediation:string|null, session_id:string|null }}
+ */
+export function classifyWatchdogState(session, { nowMs, staleThresholdMs, isPidAlive, isWithinArmedSilence } = {}) {
+  const s = session || {};
+  const sid = s.session_id || null;
+  const hbAgeMs = s.heartbeat_at ? Math.max(0, nowMs - new Date(s.heartbeat_at).getTime()) : Infinity;
+  if (Number.isFinite(staleThresholdMs) && hbAgeMs < staleThresholdMs) {
+    return { state: 'ALIVE', remediation: null, session_id: sid };
+  }
+  // Stale — is it intentionally parked? (never restart a deliberately-stopped session)
+  const parked = s.loop_state === 'awaiting_tick'
+    || s.status === 'released' || s.status === 'stale' || s.status === 'ended'
+    || !!(isWithinArmedSilence && isWithinArmedSilence(s.expected_silence_until, nowMs));
+  if (parked) return { state: 'STOPPED', remediation: null, session_id: sid };
+  // Stale + not parked: process alive but not heartbeating = logged out (AUTH-LOST); dead = CRASHED.
+  const state = (isPidAlive && isPidAlive(s)) ? 'AUTH-LOST' : 'CRASHED';
+  return { state, remediation: REMEDIATION[state], session_id: sid };
+}
+
+/**
+ * Badge summary over a classified set: per-state counts + the ACTIONABLE list (CRASHED + AUTH-LOST
+ * only — STOPPED/ALIVE are non-actionable, surfaced as counts).
+ * @param {Array<{state:string, remediation?:string|null, session_id?:string|null}>} classified
+ */
+export function summarizeWatchdog(classified = []) {
+  const counts = { CRASHED: 0, 'AUTH-LOST': 0, STOPPED: 0, ALIVE: 0 };
+  const actionable = [];
+  const list = Array.isArray(classified) ? classified : [];
+  for (const c of list) {
+    if (!c || !c.state || !(c.state in counts)) continue;
+    counts[c.state] += 1;
+    if (c.state === 'CRASHED' || c.state === 'AUTH-LOST') {
+      actionable.push({ session_id: c.session_id || null, state: c.state, remediation: c.remediation || REMEDIATION[c.state] });
+    }
+  }
+  return { counts, actionable, total: list.length };
+}
+
+/** Fail-soft absence probe (42P01 / PGRST205) — mirrors lib/fleet/session-registry.js. */
+export function tableAbsent(error) {
+  if (!error) return false;
+  const code = error.code || error.details || '';
+  return code === '42P01' || code === 'PGRST205' || /does not exist|relation .* not exist|not found/i.test(error.message || '');
+}
+
+/**
+ * FR-2 adapter: read live sessions from claude_sessions (the SD-A registry) and classify each.
+ * Fail-soft: an absent table / read error → empty watchdog set (never throws). deps.isPidAlive /
+ * deps.isWithinArmedSilence default to conservative no-ops so a caller can inject the real predicates.
+ * @param {{ supabase:object, isPidAlive?:Function, isWithinArmedSilence?:Function }} deps
+ * @param {{ nowMs:number, staleThresholdMs:number }} opts
+ */
+export async function runWatchdog(deps = {}, opts = {}) {
+  const { supabase, isPidAlive, isWithinArmedSilence } = deps;
+  const { nowMs, staleThresholdMs } = opts;
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, terminal_id, pid, pid_validated_at, heartbeat_at, loop_state, expected_silence_until, status');
+    if (error) return tableAbsent(error) ? { inert: true, ...summarizeWatchdog([]) } : { error: error.message, ...summarizeWatchdog([]) };
+    const classified = (data || []).map((s) => classifyWatchdogState(s, { nowMs, staleThresholdMs, isPidAlive, isWithinArmedSilence }));
+    return { ...summarizeWatchdog(classified), classified };
+  } catch (e) {
+    return { inert: true, error: (e && e.message) || String(e), ...summarizeWatchdog([]) };
+  }
+}

--- a/tests/unit/fleet/session-watchdog.test.js
+++ b/tests/unit/fleet/session-watchdog.test.js
@@ -1,0 +1,83 @@
+// SD-LEO-INFRA-FLEET-WATCHDOG-001 — pure watchdog classifier + badge + fail-soft adapter (U5).
+import { describe, it, expect } from 'vitest';
+import { classifyWatchdogState, summarizeWatchdog, tableAbsent, runWatchdog } from '../../../lib/fleet/session-watchdog.js';
+
+const NOW = 1_750_000_000_000;
+const STALE = 5 * 60 * 1000; // 5 min
+const ago = (ms) => new Date(NOW - ms).toISOString();
+const ctx = (over = {}) => ({ nowMs: NOW, staleThresholdMs: STALE, isPidAlive: () => false, isWithinArmedSilence: () => false, ...over });
+
+describe('watchdog classifier (FR-1, U5 distinct states)', () => {
+  it('ALIVE on a fresh heartbeat', () => {
+    expect(classifyWatchdogState({ session_id: 'a', heartbeat_at: ago(1000) }, ctx()).state).toBe('ALIVE');
+  });
+  it('STOPPED when stale but intentionally parked (never CRASHED)', () => {
+    const parkedAwaiting = classifyWatchdogState({ session_id: 'p1', heartbeat_at: ago(STALE * 2), loop_state: 'awaiting_tick' }, ctx({ isPidAlive: () => false }));
+    expect(parkedAwaiting.state).toBe('STOPPED');
+    expect(parkedAwaiting.remediation).toBeNull();
+    const released = classifyWatchdogState({ session_id: 'p2', heartbeat_at: ago(STALE * 2), status: 'released' }, ctx());
+    expect(released.state).toBe('STOPPED');
+    const armed = classifyWatchdogState({ session_id: 'p3', heartbeat_at: ago(STALE * 2), expected_silence_until: ago(-1000) }, ctx({ isWithinArmedSilence: () => true }));
+    expect(armed.state).toBe('STOPPED');
+  });
+  it('AUTH-LOST when stale + not parked + PID ALIVE (wake-from-sleep/logout class)', () => {
+    const r = classifyWatchdogState({ session_id: 'w', heartbeat_at: ago(STALE * 3), pid: 123 }, ctx({ isPidAlive: () => true }));
+    expect(r.state).toBe('AUTH-LOST');
+    expect(r.remediation).toMatch(/re-auth/);
+  });
+  it('CRASHED when stale + not parked + PID DEAD', () => {
+    const r = classifyWatchdogState({ session_id: 'c', heartbeat_at: ago(STALE * 3), pid: 456 }, ctx({ isPidAlive: () => false }));
+    expect(r.state).toBe('CRASHED');
+    expect(r.remediation).toMatch(/restart/);
+  });
+  it('missing heartbeat_at → treated as infinitely stale', () => {
+    expect(classifyWatchdogState({ session_id: 'x' }, ctx({ isPidAlive: () => true })).state).toBe('AUTH-LOST');
+  });
+});
+
+describe('watchdog badge summary (FR-3)', () => {
+  it('counts all states; actionable = CRASHED + AUTH-LOST only', () => {
+    const classified = [
+      { state: 'ALIVE', session_id: 'a' },
+      { state: 'STOPPED', session_id: 's' },
+      { state: 'AUTH-LOST', session_id: 'w', remediation: 're-auth' },
+      { state: 'CRASHED', session_id: 'c', remediation: 'restart' },
+      { state: 'CRASHED', session_id: 'c2', remediation: 'restart' },
+    ];
+    const sum = summarizeWatchdog(classified);
+    expect(sum.counts).toEqual({ CRASHED: 2, 'AUTH-LOST': 1, STOPPED: 1, ALIVE: 1 });
+    expect(sum.actionable.map((a) => a.session_id).sort()).toEqual(['c', 'c2', 'w']);
+    expect(sum.actionable.every((a) => a.remediation)).toBe(true);
+  });
+  it('empty input → zeroed counts, empty actionable', () => {
+    expect(summarizeWatchdog().counts).toEqual({ CRASHED: 0, 'AUTH-LOST': 0, STOPPED: 0, ALIVE: 0 });
+    expect(summarizeWatchdog([]).actionable).toEqual([]);
+  });
+});
+
+describe('watchdog adapter (FR-2) + tableAbsent', () => {
+  const fakeSupabase = ({ rows = [], absent = false } = {}) => ({
+    from: () => ({ select: () => absent
+      ? Promise.resolve({ data: null, error: { code: '42P01', message: 'relation "claude_sessions" does not exist' } })
+      : Promise.resolve({ data: rows, error: null }) }),
+  });
+  it('classifies live rows via injected isPidAlive', async () => {
+    const rows = [
+      { session_id: 'a', heartbeat_at: ago(1000) },
+      { session_id: 'c', heartbeat_at: ago(STALE * 3), pid: 9 },
+    ];
+    const res = await runWatchdog({ supabase: fakeSupabase({ rows }), isPidAlive: () => false }, { nowMs: NOW, staleThresholdMs: STALE });
+    expect(res.counts.ALIVE).toBe(1);
+    expect(res.counts.CRASHED).toBe(1);
+  });
+  it('fail-soft on absent table → inert empty set, no throw', async () => {
+    const res = await runWatchdog({ supabase: fakeSupabase({ absent: true }) }, { nowMs: NOW, staleThresholdMs: STALE });
+    expect(res.inert).toBe(true);
+    expect(res.total).toBe(0);
+  });
+  it('tableAbsent detects 42P01/PGRST205', () => {
+    expect(tableAbsent({ code: '42P01' })).toBe(true);
+    expect(tableAbsent({ code: 'PGRST205' })).toBe(true);
+    expect(tableAbsent(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Fleet launcher **watchdog** (Solomon SD-E / U5) over the SD-A session registry. Heartbeat-staleness detection that badges **three distinct states** because the operator response differs for each — the whole point vs a naive staleness alarm:

- **ALIVE** — recent heartbeat; no action.
- **STOPPED** — intentionally parked (`awaiting_tick` / armed-silence / lifecycle-terminated); **no action** (never restart a deliberately-stopped session — naive-alarm failure mode #1).
- **AUTH-LOST** — heartbeat stale but the **process is ALIVE** ⇒ logged out (wake-from-sleep / mass-logout class); → **re-auth** (ignoring this is naive-alarm failure mode #2).
- **CRASHED** — heartbeat stale **and** process dead; → **restart**.

## What ships
- `lib/fleet/session-watchdog.js` — `classifyWatchdogState` (pure, injected `isPidAlive`/`isWithinArmedSilence`) + `summarizeWatchdog` (per-state counts + actionable = CRASHED+AUTH-LOST only) + a fail-soft `runWatchdog` adapter over `claude_sessions`.
- `tests/unit/fleet/session-watchdog.test.js` — 10 tests: classifier all-states (parked never CRASHED), badge actionable-only, adapter fail-soft on absent table.

Read-only / advisory — never mutates a session. Additive, no schema change. `@wire-check-exempt` (foundation; coordinator-audit/operator-badge consumer is the activation follow-up). Pure cores → unit-tested without a live DB.

## LEO
SD-LEO-INFRA-FLEET-WATCHDOG-001 · EXEC-TO-PLAN 95 · PLAN-TO-LEAD 96 · retro published (q90). Sibling of the FR-1 registry (#6352) and `classifyLiveness` in `lib/coordinator/charter-audit-detectors.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)