### PR TITLE
fix(QF-20260720-751): Feedback Pipeline Health SLO workflow fails unconditionally on breach detection due to missing GitHub label

### DIFF
--- a/.github/workflows/feedback-pipeline-health.yml
+++ b/.github/workflows/feedback-pipeline-health.yml
@@ -49,6 +49,15 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Ensure breach label exists
+        if: steps.health.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "feedback-pipeline-slo-breach" \
+            --description "Weekly feedback-pipeline SLO health check breach (auto-filed)" \
+            --color "d73a4a" 2>/dev/null || true
+
       - name: Open GitHub issue on breach
         if: steps.health.outputs.exit_code == '1'
         env:
@@ -59,4 +68,7 @@ jobs:
           gh issue create \
             --title "$TITLE" \
             --body "$BODY" \
-            --label "feedback-pipeline-slo-breach"
+            --label "feedback-pipeline-slo-breach" || \
+          gh issue create \
+            --title "$TITLE" \
+            --body "$BODY"


### PR DESCRIPTION
## Quick-Fix: QF-20260720-751

**Type:** bug
**Severity:** medium

### Issue Description
The weekly Feedback Pipeline Health (SLO) GitHub Action's breach-issue-creation step hard-fails (exit 1) whenever it detects a real SLO breach, because it calls gh issue create --label feedback-pipeline-slo-breach and that label does not exist in the repo. This means the workflow's CI status can never report the true underlying pipeline health -- every breach detection is masked by an unrelated labeling error. Confirmed via 3 consecutive weekly failures (2026-07-06, 07-13, 07-20) all showing the same could not add label error, while a genuine underlying breach (1063 stale-untriaged feedback rows, auto-triage capped at 20 items/hour) is separately ongoing.

### Steps to Reproduce
Run the Feedback Pipeline Health (SLO) workflow (or wait for its weekly Monday 14:00 UTC cron) when a real breach condition exists

### Expected Behavior
Workflow correctly reports failure/success based ONLY on the actual SLO breach state, and successfully opens a labeled GitHub issue

### Actual Behavior
Workflow job exits 1 due to could not add label: feedback-pipeline-slo-breach not found, regardless of whether check-pipeline-health.js itself detected a breach or not

### Changes
- **Files Changed:** 1
  - .github/workflows/feedback-pipeline-health.yml
- **LOC:** 13 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol