### PR TITLE
feat(SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001): fleet launcher six-verb control layer

### DIFF
--- a/.prd-payloads/PRD-FLEET-SPAWN-CONTROL-001.json
+++ b/.prd-payloads/PRD-FLEET-SPAWN-CONTROL-001.json
@@ -1,0 +1,248 @@
+{
+  "executive_summary": "Fleet launcher SD-B delivers the CONTROL layer over the SD-A session registry: six governed verbs (spawn, attach, stop, restart, relaunch-under-profile, drain-and-restart) so fleet lifecycle stops being manual terminal-window janitor work. It composes existing primitives (worker-spawn-executor's spawn-detached pattern, singleton-relaunch's register-then-retire mutex, claim-boundary-probe's idle detection) rather than rebuilding them, and adds the three genuinely new pieces validation-agent confirmed have no prior art: Windows window-handle capture for real-terminal attach, per-account CLAUDE_CONFIG_DIR profile injection at spawn, and a thin DB adapter wiring SD-A's pure registry/manifest/metering libs to live claude_sessions data. Verified by: kill -9 on the supervisor leaves spawned children alive (proves spawn-detached); a role respawn drill exercises the existing singleton guard end-to-end; relaunch-under-profile switches one session's account while siblings are untouched.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Spawn-detached with window-handle capture",
+      "description": "New lib/fleet/spawn-control.js exports spawnSession({role, callsign, profile}) that launches a VISIBLE Windows Terminal (wt.exe) process via child_process.spawn(..., {detached:true, stdio:'ignore'}).unref() -- the exact spawn-detached pattern already proven in scripts/fleet/worker-spawn-executor.cjs, but extended from the current headless `claude -p` invocation to a visible terminal window. Immediately after spawn, poll (short retry loop, bounded) for the child process's MainWindowHandle via a PowerShell one-liner (Get-Process -Id <pid> | Select-Object MainWindowHandle) since window creation is asynchronous relative to process creation. Persist the captured handle against the session row.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "spawnSession() launches a real, visible Windows Terminal window (not headless claude -p)",
+        "The supervisor process is NEVER the OS process-parent of the spawned session (detached:true + unref() verified via process tree inspection)",
+        "Killing the supervisor process (taskkill /F on supervisor PID only) leaves the spawned session's process and window alive",
+        "A non-null window handle is captured and persisted within the bounded retry window, or the row is marked handle_capture_failed=true (never silently null with no signal)",
+        "SECURITY: the PowerShell MainWindowHandle capture interpolates ONLY a strictly-numeric PID into the command string (validated/coerced to Number before interpolation) -- never a raw/unvalidated session or role identifier"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Six-verb control API (spawn / attach / stop / restart / relaunch-under-profile / drain-and-restart) -- no more",
+      "description": "lib/fleet/spawn-control.js exposes exactly these six exported verb functions, each operating against the SD-A registry (lib/fleet/session-registry.js resolveSessionIdentity, lib/fleet/session-manifest.js computeManifestDrift). Each verb is the single governed implementation behind its corresponding launcher UI action button (mockup #1). No 7th verb is added even if a future need seems similar -- new needs compose these six, they do not add a seventh.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "spawn(), attach(), stop(), restart(), relaunchUnderProfile(), drainAndRestart() are the ONLY six exported control verbs",
+        "Each verb accepts a session/card identifier and resolves it through resolveSessionIdentity() (collision-visible: ambiguous/not_found/no_key handled, never silently picks the wrong session)",
+        "Each verb call is logged with verb name, target session_id, and outcome"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Attach resolves card -> registry -> real terminal window",
+      "description": "attach(cardId) resolves the UI card to a registry entry via resolveSessionIdentity(), reads the captured window handle from FR-1, and focuses that real terminal window (PowerShell/win32 foreground-window call). This directly addresses the named risk that Windows Terminal tab-targeting by title/PID alone is weak -- the captured handle from spawn time is the source of truth, not a runtime window-title guess.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Card-click attach in the launcher UI calls attach() and the correct terminal window comes to the foreground",
+        "If the stored handle is stale (window closed), attach() reports a clear degraded state rather than silently focusing the wrong window or a random terminal"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Role-serial respawn reuses the existing singleton guard mutex",
+      "description": "restart()/relaunchUnderProfile() for a SINGLETON role (solomon/adam/coordinator) call the EXISTING lib/singleton-relaunch.js relaunchOntoFreshCheckout() + lib/coordinator/singleton-refresh-sequencer.cjs sequenceSingletonRefresh() -- do NOT re-implement retire/register logic. This guarantees register-then-retire ordering (new session verified healthy BEFORE the old one retires) so the set_*_flag singleton guard is never raced.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Restarting a singleton role session calls sequenceSingletonRefresh(), never a bespoke retire-then-spawn sequence",
+        "A respawn drill on a role session shows the new session's guard registers successfully BEFORE the old session's released_at/released_reason is stamped",
+        "Two concurrent restart() calls against the SAME role never result in zero or two simultaneously-live singletons"
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Worker respawn is parallel, reusing spawn-executor-core's decision logic",
+      "description": "restart()/spawn() for WORKER (non-singleton) sessions reuse lib/fleet/spawn-executor-core.cjs resolveSpawnDecisions({pendingRequests, liveCallsigns, nowMs, perTickCap}) for dedup-by-callsign/expiry/per-tick-cap decisions, invoked in parallel across multiple workers (no artificial serialization). This composes the existing worker_spawn_requests table path rather than inventing a second request queue.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Multiple worker restarts triggered together execute concurrently, not one-at-a-time",
+        "A duplicate restart request for an already-live callsign is skipped per resolveSpawnDecisions(), not double-spawned"
+      ]
+    },
+    {
+      "id": "FR-6",
+      "title": "drain-and-restart waits for the idle boundary before restarting",
+      "description": "drainAndRestart(sessionId) calls lib/fleet/claim-boundary-probe.cjs evaluateClaimBoundary() and only proceeds to restart once the probe returns a genuine idle verdict (not mid-claim). This is explicitly required for the upgrade path (SD's own acceptance language: 'waits for an idle boundary'). Do NOT confuse this with lib/fleet/drain-set-registry.js / role_drain_sets (STAGED) -- that is an unrelated message-kind drain concept.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "drainAndRestart() calls evaluateClaimBoundary() and blocks/re-polls while the verdict is MISS (mid-claim), proceeding only on PASS",
+        "A session mid-claim when drainAndRestart() is invoked is NOT restarted immediately; it restarts once idle",
+        "drainAndRestart() never reads or writes role_drain_sets / drain_set_registry -- verified by a grep-pin test excluding that module"
+      ]
+    },
+    {
+      "id": "FR-7",
+      "title": "relaunch-under-profile: per-account CLAUDE_CONFIG_DIR injection, isolated to the target session only",
+      "description": "relaunchUnderProfile(sessionId, accountProfile) injects CLAUDE_CONFIG_DIR into the CHILD PROCESS'S env object at spawn time (process.env override on the spawn() call's env option), never mutating the supervisor's own process.env. This is the ratified account-switch verb: an account change is a relaunch of that one session under a new profile directory, never a global logout. Encodes the standing operational policy: one CLAUDE_CONFIG_DIR per Anthropic account.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "relaunchUnderProfile() passes CLAUDE_CONFIG_DIR only via the spawned child's env option, never via process.env of the supervisor",
+        "After relaunching one session under profile B, a second live sibling session under profile A is unaffected (no shared-credential mass-logout)",
+        "The new session comes up authenticated under the new profile without any global logout step",
+        "SECURITY: a direct assertion confirms the supervisor's own process.env.CLAUDE_CONFIG_DIR is unchanged after any relaunchUnderProfile() call",
+        "SECURITY: accountProfile resolves only to a known, allowlisted profile directory -- never a raw/absolute/traversal path supplied verbatim from card input"
+      ]
+    },
+    {
+      "id": "FR-8",
+      "title": "Thin DB adapter wiring live session data into SD-A's pure registry/manifest libs",
+      "description": "SD-A shipped PURE (no-DB, @wire-check-exempt) functions: joinSessionIdentity({sessions, callsignBySession}), resolveSessionIdentity(joined, {by, value}), normalizeDesiredManifest(desired), computeManifestDrift({desired, actualByRole}), meterSessions(joined, {roleOf, modelOf}). No DB adapter exists yet. This FR builds lib/fleet/session-registry-adapter.js: queries claude_sessions + the SET_IDENTITY callsign source, shapes them into the {sessions, callsignBySession} input joinSessionIdentity expects, and feeds live actualByRole() output into computeManifestDrift() so the six verbs can act on real fleet state rather than assumed shape.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "The adapter's output, fed through joinSessionIdentity(), matches the documented [{session_id, terminal_id, pid, callsign}] shape against real claude_sessions rows",
+        "computeManifestDrift() called with live actualByRole() data correctly identifies under-staffed roles that spawn()/restart() should act on",
+        "Callsign resolution uses the SET_IDENTITY row, never a nonexistent claude_sessions.callsign column"
+      ]
+    },
+    {
+      "id": "FR-9",
+      "title": "Fleet lifecycle event emission (spawn/stop/restart/attach) with a stable schema",
+      "description": "Every verb invocation (FR-2) emits a lifecycle event with a stable, documented schema. Persist via the existing coordination_events table (lib/coordinator/coordination-events.cjs logCoordinationEvent()) rather than inventing a new events table, since that table already exists and is the closest fit -- confirm the schema fields (event_type, session_id, verb, outcome, at) are sufficient for downstream consumers (SD-C badges, SD-E watchdog) and extend the payload shape if a genuine gap exists, but do not create a parallel event store.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "Each of the six verbs emits exactly one lifecycle event per invocation with a stable field shape",
+        "A mock downstream consumer can read back a spawn/stop/restart event and identify the affected session_id and verb outcome without any schema guessing",
+        "SECURITY: event payload is restricted to an explicit allowlist {event_type, session_id, verb, outcome, at} -- never the CLAUDE_CONFIG_DIR path, profile directory, email, or raw spawn argv"
+      ]
+    },
+    {
+      "id": "FR-10",
+      "title": "Verb/state-model alignment with SD-E's already-shipped AUTH-LOST remediation",
+      "description": "SD-E (FLEET-WATCHDOG-001, already shipped lib/fleet/session-watchdog.js) names 'relaunch-under-profile' as its AUTH-LOST remediation action. Confirm the exact verb name and session-identifier shape SD-B exposes (FR-7) match what SD-E's watchdog card remediation strings expect, so the watchdog's remediation button resolves to a real, callable SD-B verb rather than a dangling reference.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "SD-E's session-watchdog.js AUTH-LOST remediation reference is verified (by inspection or a shared contract test) to resolve to spawn-control.js's relaunchUnderProfile() with a compatible session-identifier shape",
+        "Any naming/shape mismatch found is either fixed in SD-B (preferred, since SD-E already shipped) or explicitly flagged to the coordinator as a follow-up"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Windows-only process/window control, no cross-platform abstraction required",
+      "description": "This SD targets the Windows fleet-hosting environment exclusively (win32 spawn-detached semantics, Windows Terminal, PowerShell window-handle capture). Do not build a cross-platform abstraction layer -- explicitly out of scope."
+    },
+    {
+      "id": "TR-2",
+      "title": "Compose, do not rebuild, existing spawn/singleton/drain primitives",
+      "description": "spawn-control.js MUST import and call scripts/fleet/worker-spawn-executor.cjs, lib/fleet/spawn-executor-core.cjs, lib/singleton-relaunch.js, lib/coordinator/singleton-refresh-sequencer.cjs, and lib/fleet/claim-boundary-probe.cjs rather than re-implementing their logic inline."
+    },
+    {
+      "id": "TR-3",
+      "title": "Supervisor is convenience, never load-bearing (design invariant)",
+      "description": "Every code path in this SD must preserve the invariant that supervisor process death/crash never kills a fleet session. This is the acceptance test for FR-1 and must not regress in any later verb implementation."
+    },
+    {
+      "id": "TR-4",
+      "title": "New columns behind an additive, default-off flag",
+      "description": "window_handle capture and any config-profile/resume-identity columns are additive (nullable, no backfill required) and the live spawn-control surface is gated behind a default-off env flag (e.g. FLEET_SPAWN_CONTROL_LIVE) mirroring the existing WORKER_SPAWN_EXECUTOR_LIVE convention, so rollout is opt-in and instantly reversible."
+    },
+    {
+      "id": "TR-5",
+      "title": "Allowlist all identifiers used to build spawn/PowerShell commands (SECURITY review)",
+      "description": "role, callsign, and accountProfile values driving any spawn() argv or PowerShell command string must be validated against a known allowlist (existing role/callsign vocabulary; known profile directories) before use -- never interpolated raw from card/UI input. PIDs used in window-handle capture must be coerced to Number before interpolation."
+    },
+    {
+      "id": "TR-6",
+      "title": "Lifecycle event payload allowlist (SECURITY review)",
+      "description": "logCoordinationEvent() calls from this SD's verbs pass an explicit field allowlist ({event_type, session_id, verb, outcome, at}), never a raw spread of internal state -- CLAUDE_CONFIG_DIR paths, profile directories, and spawn argv must never reach the event log."
+    }
+  ],
+  "ui_ux_requirements": [
+    {
+      "requirement": "relaunch-under-profile must be visually distinct from restart, not a peer icon button",
+      "rationale": "restart is same-account respawn; relaunch-under-profile is an account switch (DESIGN review, highest-risk finding). Use a distinct swap/account icon, a profile picker showing account A->B, and a confirmation step before executing."
+    },
+    {
+      "requirement": "handle_capture_failed / stale window handle gets a first-class degraded-state treatment",
+      "rationale": "A disabled attach action with a warning glyph + tooltip (\"no captured window handle\") is required so FR-1's honest failure signal is not wasted on a normal-looking attach button that silently no-ops."
+    },
+    {
+      "requirement": "Contextual verb visibility with overflow grouping; icon+label never icon-only; WCAG 2.1 AA",
+      "rationale": "Show only state-valid verbs per session card; keep attach/stop primary, move relaunch-under-profile and drain-and-restart into an overflow/kebab menu; 44x44 targets, non-color-only status indication, aria-labels on all six verb controls."
+    }
+  ],
+  "test_scenarios": [
+    {"id": "TS-1", "scenario": "Spawn a detached, visible session then kill the supervisor process only", "type": "e2e", "expected": "Session process and window remain alive; window handle was captured at spawn"},
+    {"id": "TS-2", "scenario": "Card-click attach on a live session", "type": "e2e", "expected": "The real terminal window for that session is focused via its captured handle"},
+    {"id": "TS-3", "scenario": "relaunch-under-profile on one of two live sibling sessions", "type": "e2e", "expected": "Target session returns under the new account profile; sibling session's auth/session is untouched"},
+    {"id": "TS-4", "scenario": "Full respawn drill: one singleton role + two workers", "type": "e2e", "expected": "Role re-registers serially through sequenceSingletonRefresh() before the old one retires; workers respawn in parallel; zero duplicate singletons"},
+    {"id": "TS-5", "scenario": "drain-and-restart invoked while the session is mid-claim", "type": "unit", "expected": "Restart is deferred until evaluateClaimBoundary() returns PASS; never restarts mid-claim"},
+    {"id": "TS-6", "scenario": "DB adapter feeds live claude_sessions rows through joinSessionIdentity() and computeManifestDrift()", "type": "unit", "expected": "Output shape matches SD-A's documented contract; under-staffed roles are correctly identified"},
+    {"id": "TS-7", "scenario": "Two concurrent restart() calls against the same singleton role", "type": "unit", "expected": "No race: exactly one new session ends up live and registered, old one retired, never zero or two simultaneously live"},
+    {"id": "TS-8", "scenario": "Verb invocation emits a lifecycle event", "type": "unit", "expected": "coordination_events row exists with correct event_type/session_id/verb/outcome, readable by a mock consumer"},
+    {"id": "TS-9", "scenario": "Contract test: SD-E's session-watchdog.js AUTH-LOST remediation string resolves to relaunchUnderProfile()", "type": "unit", "expected": "No dangling verb-name reference; the remediation string names a verb spawn-control.js actually exports with a compatible session-identifier shape (TESTING-agent-identified gap, FR-10)"},
+    {"id": "TS-10", "scenario": "spawn-control.js exports exactly the six named verbs, no more, no fewer", "type": "unit", "expected": "Module export list equals {spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart}; resolveSessionIdentity ambiguous/not_found/no_key branches are each exercised (FR-2)"}
+  ],
+  "acceptance_criteria": [
+    "All six verbs (spawn, attach, stop, restart, relaunch-under-profile, drain-and-restart) work against live sessions end-to-end",
+    "kill -9 (or taskkill /F) on the supervisor process results in zero child session deaths",
+    "A respawn drill exercises the singleton guard end-to-end with zero duplicate singletons",
+    "relaunch-under-profile isolates the account switch to the target session only",
+    "Card-click attach focuses the correct real terminal window via a captured window handle"
+  ],
+  "risks": [
+    {"risk": "Window-handle capture races window creation (MainWindowHandle is 0 immediately after spawn)", "mitigation": "Bounded poll/retry loop after spawn before giving up and marking handle_capture_failed=true", "severity": "medium"},
+    {"risk": "A future edit accidentally makes the supervisor the process-parent again (e.g. omitting detached:true in a refactor)", "mitigation": "TS-1 is a permanent regression test in the suite, not a one-time manual check", "severity": "high"},
+    {"risk": "Role-serial and worker-parallel respawn paths race the same singleton guard if not both routed through the existing sequencer", "mitigation": "TR-2 mandates reuse of sequenceSingletonRefresh(); TS-7 is a dedicated concurrency regression test", "severity": "high"},
+    {"risk": "relaunch-under-profile verb name/session-identifier shape diverges from what SD-E's already-shipped watchdog expects", "mitigation": "FR-10 explicit alignment check; coordinate with SD-E owner/coordinator before finalizing the verb signature", "severity": "medium"},
+    {"risk": "CLAUDE_CONFIG_DIR injected process-wide instead of per-child-process, causing account bleed across sibling sessions", "mitigation": "FR-7 acceptance criteria explicitly test sibling-session isolation (TS-3)", "severity": "high"}
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "Fleet launcher UI (mockup #1 action buttons) -- calls all six verbs directly",
+      "SD-C (FLEET-VIEW-BADGES-001, draft/LEAD, pure read/render consumer) -- reads the lifecycle event feed (FR-9) to badge session state; no direct dependency on this SD's internals beyond the event schema",
+      "SD-E (FLEET-WATCHDOG-001, already shipped session-watchdog.js) -- its AUTH-LOST remediation calls relaunch-under-profile (FR-10 alignment)"
+    ],
+    "dependencies": [
+      "SD-A (FLEET-REGISTRY-MANIFEST-001, completed) -- provides the pure session-registry.js/session-manifest.js/session-metering.js libs this SD adapts (FR-8)",
+      "scripts/fleet/worker-spawn-executor.cjs + lib/fleet/spawn-executor-core.cjs -- existing spawn-detached/parallel-decision infra reused, not rebuilt",
+      "lib/singleton-relaunch.js + lib/coordinator/singleton-refresh-sequencer.cjs -- existing singleton retire/register mutex reused",
+      "lib/fleet/claim-boundary-probe.cjs -- existing idle-boundary detection reused for drain-and-restart",
+      "coordination_events table -- reused as the lifecycle event feed rather than a new table"
+    ],
+    "data_contracts": [
+      "New nullable column(s) on claude_sessions (or a new fleet_session_windows table): window_handle, handle_capture_failed",
+      "coordination_events event_type values for spawn/stop/restart/attach lifecycle events (schema extension if a genuine field gap is found in PLAN's DATABASE sub-agent review)",
+      "No changes to SD-A's pure lib function signatures -- only additive DB-adapter code sits in front of them"
+    ],
+    "runtime_config": [
+      "FLEET_SPAWN_CONTROL_LIVE (new, default-off) -- gates the live six-verb surface, mirroring WORKER_SPAWN_EXECUTOR_LIVE",
+      "CLAUDE_CONFIG_DIR -- existing Claude Code env var, injected per-child-process only (never process-wide) for relaunch-under-profile"
+    ],
+    "observability_rollout": [
+      "Every verb invocation logged to coordination_events (FR-9) -- rollout is observed by watching event volume/outcome after flipping FLEET_SPAWN_CONTROL_LIVE on",
+      "Rollback: flip FLEET_SPAWN_CONTROL_LIVE off -- existing worker-spawn-executor/singleton-relaunch/claim-boundary-probe paths are untouched and continue operating exactly as before this SD"
+    ]
+  },
+  "system_architecture": {
+    "summary": "A new lib/fleet/spawn-control.js exposes six verb functions that compose existing spawn/singleton/drain primitives plus three new pieces (window-handle capture, CLAUDE_CONFIG_DIR injection, a DB adapter for SD-A's pure libs), emitting lifecycle events to the existing coordination_events table.",
+    "components": [
+      {"name": "lib/fleet/spawn-control.js", "change": "NEW -- six verb functions (spawn/attach/stop/restart/relaunchUnderProfile/drainAndRestart)"},
+      {"name": "lib/fleet/window-handle.js", "change": "NEW -- PowerShell-backed MainWindowHandle capture + foreground-focus helper"},
+      {"name": "lib/fleet/session-registry-adapter.js", "change": "NEW -- thin DB adapter feeding claude_sessions + SET_IDENTITY into SD-A's pure joinSessionIdentity/computeManifestDrift"},
+      {"name": "scripts/fleet/worker-spawn-executor.cjs", "change": "REUSED -- extended to launch a visible Windows Terminal instead of headless claude -p"},
+      {"name": "lib/fleet/spawn-executor-core.cjs", "change": "REUSED unchanged -- worker-parallel spawn decision logic"},
+      {"name": "lib/singleton-relaunch.js", "change": "REUSED unchanged -- role-serial respawn mutex"},
+      {"name": "lib/coordinator/singleton-refresh-sequencer.cjs", "change": "REUSED unchanged -- register-then-retire sequencing"},
+      {"name": "lib/fleet/claim-boundary-probe.cjs", "change": "REUSED unchanged -- idle-boundary detection for drain-and-restart"},
+      {"name": "lib/coordinator/coordination-events.cjs", "change": "REUSED, payload shape possibly extended -- lifecycle event feed"}
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the two genuinely-new primitives (window-handle capture, DB adapter) first since every verb depends on them, then implement the six verbs as thin composition functions over existing infra, then wire event emission and verify the SD-E naming alignment.",
+    "steps": [
+      "Build lib/fleet/window-handle.js (capture + focus) and lib/fleet/session-registry-adapter.js (DB adapter) with unit tests",
+      "Extend scripts/fleet/worker-spawn-executor.cjs's spawn call to launch a visible Windows Terminal and invoke window-handle capture",
+      "Implement lib/fleet/spawn-control.js's six verbs, each composing the existing primitives per TR-2",
+      "Wire lifecycle event emission (FR-9) into each verb",
+      "Verify FR-10 (SD-E naming alignment) by inspecting session-watchdog.js's remediation string against relaunchUnderProfile()'s exported signature",
+      "Run the full e2e smoke suite (TS-1 through TS-4) against live sessions behind FLEET_SPAWN_CONTROL_LIVE"
+    ]
+  },
+  "smoke_test_steps": [
+    {"step_number": 1, "instruction": "Spawn a session detached, then kill the supervisor", "expected_outcome": "Session lives; registry reconciles on supervisor restart"},
+    {"step_number": 2, "instruction": "relaunch-under-profile on one of two live sessions", "expected_outcome": "Target session returns under the new account; sibling session unaffected"},
+    {"step_number": 3, "instruction": "Full respawn drill with one role + two workers", "expected_outcome": "Role re-registers serially through its guard; workers respawn in parallel; zero duplicates"}
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001"
+  }
+}

--- a/lib/fleet/session-registry-adapter.js
+++ b/lib/fleet/session-registry-adapter.js
@@ -1,0 +1,57 @@
+/**
+ * DB adapter feeding live claude_sessions + SET_IDENTITY callsigns into SD-A's pure
+ * session-registry.js / session-manifest.js (FR-8). SD-A's libs are @wire-check-exempt --
+ * this is the activation follow-up.
+ */
+import { joinSessionIdentity, resolveSessionIdentity, tableAbsent } from './session-registry.js';
+import { computeManifestDrift, normalizeDesiredManifest } from './session-manifest.js';
+
+/** Read live sessions + resolve the SET_IDENTITY callsign source. Fail-soft: [] on any error. */
+export async function loadLiveSessionIdentity(supabase) {
+  const { data: sessions, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, terminal_id, pid, metadata, status, released_at')
+    .in('status', ['active', 'idle']);
+  if (error) return { sessions: [], callsignBySession: {}, error: tableAbsent(error) ? null : error.message };
+
+  // Callsign authority is the SET_IDENTITY row (metadata.fleet_identity.callsign), never a
+  // claude_sessions.callsign column (per session-registry.js's own documented contract).
+  const callsignBySession = {};
+  for (const s of sessions || []) {
+    const cs = s && s.metadata && s.metadata.fleet_identity && s.metadata.fleet_identity.callsign;
+    if (s && s.session_id && cs) callsignBySession[s.session_id] = cs;
+  }
+  return { sessions: sessions || [], callsignBySession, error: null };
+}
+
+/** Live joined identity set, ready for resolveSessionIdentity(). */
+export async function joinLiveSessionIdentity(supabase) {
+  const { sessions, callsignBySession } = await loadLiveSessionIdentity(supabase);
+  return joinSessionIdentity({ sessions, callsignBySession });
+}
+
+/** Resolve a card/session identifier (session_id OR callsign) to ONE live identity. Collision-visible. */
+export async function resolveLiveSession(supabase, { by, value } = {}) {
+  const joined = await joinLiveSessionIdentity(supabase);
+  return resolveSessionIdentity(joined, { by, value });
+}
+
+/**
+ * Live per-role counts derived from the joined identity set + a role-of-callsign resolver.
+ * @param {Array<{callsign:string|null}>} joined
+ * @param {(callsign:string)=>string|null} roleOf
+ */
+export function actualByRole(joined, roleOf) {
+  const counts = {};
+  for (const j of joined || []) {
+    const role = j && j.callsign && typeof roleOf === 'function' ? roleOf(j.callsign) : null;
+    if (role) counts[role] = (counts[role] || 0) + 1;
+  }
+  return counts;
+}
+
+/** Live manifest drift: desired roles vs the actual live fleet, derived from real session data (FR-8). */
+export async function computeLiveManifestDrift(supabase, { desired, roleOf } = {}) {
+  const joined = await joinLiveSessionIdentity(supabase);
+  return computeManifestDrift({ desired: normalizeDesiredManifest(desired), actualByRole: actualByRole(joined, roleOf) });
+}

--- a/lib/fleet/session-watchdog.js
+++ b/lib/fleet/session-watchdog.js
@@ -20,10 +20,13 @@
 
 export const WATCHDOG_STATES = Object.freeze({ ALIVE: 'ALIVE', STOPPED: 'STOPPED', AUTH_LOST: 'AUTH-LOST', CRASHED: 'CRASHED' });
 
+// SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 FR-10: name the real spawn-control verb so a card's
+// AUTH-LOST remediation resolves to a callable action (lib/fleet/spawn-control.js relaunchUnderProfile),
+// not just a human-readable description.
 const REMEDIATION = Object.freeze({
   ALIVE: null,
   STOPPED: null,
-  'AUTH-LOST': 're-auth: process alive but session logged out (wake-from-sleep / mass-logout) — restore auth',
+  'AUTH-LOST': 'relaunch-under-profile: process alive but session logged out (wake-from-sleep / mass-logout) — re-auth via relaunchUnderProfile()',
   CRASHED: 'restart: process dead and heartbeat stale',
 });
 

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -1,0 +1,313 @@
+/**
+ * Fleet spawn-control -- the SIX governed verbs (spawn/attach/stop/restart/relaunch-under-profile/
+ * drain-and-restart), SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001.
+ *
+ * Composes existing primitives rather than rebuilding them: scripts/fleet/worker-spawn-executor.cjs's
+ * spawn-detached pattern, lib/coordinator/singleton-refresh-sequencer.cjs's register-then-retire mutex,
+ * lib/fleet/claim-boundary-probe.cjs's idle-boundary probe, and lib/fleet/session-registry-adapter.js's
+ * DB adapter over SD-A's pure registry/manifest libs. Adds the three genuinely-new pieces: window-handle
+ * capture (window-handle.js), CLAUDE_CONFIG_DIR profile injection, and this six-verb composition layer.
+ *
+ * SAFETY -- STAGED / INERT BY DEFAULT (mirrors WORKER_SPAWN_EXECUTOR_LIVE, TR-4): the live OS spawn
+ * (a visible Windows Terminal process) is default-OFF behind FLEET_SPAWN_CONTROL_LIVE. With the flag
+ * unset every verb that would spawn/relaunch a process instead logs the invocation it WOULD run and
+ * returns { live:false, invocation }. Flipping the flag on requires the same operator host-validation
+ * gate worker-spawn-executor.cjs already documents (the exact wt.exe invocation is host-specific).
+ */
+import { spawn as spawnProcess } from 'node:child_process';
+import path from 'node:path';
+import {
+  resolveLiveSession,
+} from './session-registry-adapter.js';
+import { captureWindowHandle, focusWindow } from './window-handle.js';
+import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
+
+const SINGLETON_ROLES = new Set(['coordinator', 'adam', 'solomon']);
+const PROFILE_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+/** Derive a session's role from its metadata (mirrors coordination-events.cjs's own convention). */
+export function roleOf(session) {
+  const md = (session && session.metadata) || {};
+  if (String(md.is_coordinator) === 'true') return 'coordinator';
+  if (md.role) return md.role;
+  return 'worker';
+}
+
+export function isSingletonRole(role) {
+  return SINGLETON_ROLES.has(role);
+}
+
+/**
+ * Resolve an account-profile NAME to a directory under an operator-configured base dir. Rejects
+ * anything but a bare alnum/dash/underscore name -- never a raw/absolute/traversal path from card
+ * input (TR-5, FR-7 SECURITY acceptance criteria).
+ */
+export function resolveProfileDir(profileName, opts = {}) {
+  const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null;
+  if (!baseDir) throw new Error('resolveProfileDir: FLEET_ACCOUNT_PROFILES_DIR is not configured');
+  if (typeof profileName !== 'string' || !PROFILE_NAME_RE.test(profileName)) {
+    throw new Error(`resolveProfileDir: invalid profile name: ${JSON.stringify(profileName)}`);
+  }
+  return path.join(baseDir, profileName);
+}
+
+/** True only when the operator has explicitly enabled the live OS spawn/relaunch surface. */
+export function isLiveEnabled(env = process.env) {
+  return String(env.FLEET_SPAWN_CONTROL_LIVE || '').toLowerCase() === 'true';
+}
+
+/**
+ * Build the host command that WOULD launch a visible Windows Terminal session for a role/callsign,
+ * optionally under a switched account profile. Returns a structured command; NEVER executes it here.
+ * ⚠️ Host-specific, like worker-spawn-executor.cjs's buildSpawnInvocation -- operator-validate before
+ * flipping FLEET_SPAWN_CONTROL_LIVE.
+ */
+export function buildLiveSpawnInvocation({ role, callsign, profileDir } = {}) {
+  const env = { FLEET_WORKER_CALLSIGN: callsign || '', FLEET_WORKER_ROLE: role || 'worker' };
+  // FR-7 / SECURITY: CLAUDE_CONFIG_DIR is injected ONLY into this returned env object -- the caller
+  // must pass it to child_process.spawn's env option, never assign to process.env directly.
+  if (profileDir) env.CLAUDE_CONFIG_DIR = profileDir;
+  return {
+    program: 'wt.exe',
+    args: ['new-tab', '--', 'claude'],
+    env,
+  };
+}
+
+/** Restricted event payload -- never CLAUDE_CONFIG_DIR/profile paths/argv (FR-9, TR-6). */
+function verbEventPayload({ verb, outcome, extra }) {
+  return { verb, outcome, at: new Date().toISOString(), ...(extra || {}) };
+}
+
+async function emitVerbEvent(supabase, { verb, session_id, outcome, extra }) {
+  try {
+    const { logCoordinationEvent } = await import('../coordinator/coordination-events.cjs');
+    await logCoordinationEvent(supabase, {
+      event_type: `fleet_verb_${verb}`,
+      session_id: session_id ?? null,
+      payload: verbEventPayload({ verb, outcome, extra }),
+    });
+  } catch { /* fail-open: event emission never blocks a verb outcome */ }
+}
+
+/** FR-1: spawn a detached, visible session + capture its window handle. */
+export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const live = opts.live ?? isLiveEnabled();
+  const log = opts.log || (() => {});
+
+  let profileDir = null;
+  if (accountProfile) profileDir = resolveProfileDir(accountProfile, opts);
+  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir });
+
+  if (!live) {
+    log(`[spawn-control] DRY-RUN would spawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
+    await emitVerbEvent(supabase, { verb: 'spawn', outcome: 'dry_run' });
+    return { live: false, invocation };
+  }
+
+  const spawner = opts.spawnFn || ((program, args, env) => {
+    const child = spawnProcess(program, args, { detached: true, stdio: 'ignore', env: { ...process.env, ...env } });
+    child.unref();
+    return child;
+  });
+
+  const child = spawner(invocation.program, invocation.args, invocation.env);
+  const pid = child && child.pid;
+  const handleResult = pid ? await captureWindowHandle(pid, opts) : { handle: null, handleCaptureFailed: true };
+
+  if (supabase && pid) {
+    // Best-effort: persist the captured handle once the spawned session self-registers (bounded
+    // wait mirrors checkNewSessionHealth's own polling idiom -- never a hand-rolled sleep loop
+    // outside this bounded, injectable retry).
+    try {
+      await supabase.from('claude_sessions').update({
+        metadata: { window_handle: handleResult.handle, handle_capture_failed: handleResult.handleCaptureFailed },
+      }).eq('pid', pid);
+    } catch { /* fail-soft: the session row may not exist yet; a later attach() re-resolves */ }
+  }
+
+  await emitVerbEvent(supabase, { verb: 'spawn', session_id: null, outcome: handleResult.handleCaptureFailed ? 'handle_capture_failed' : 'ok' });
+  return { live: true, invocation, pid, ...handleResult };
+}
+
+/** FR-3: card -> registry -> real terminal window. */
+export async function attach(target, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    await emitVerbEvent(supabase, { verb: 'attach', outcome: `not_resolved:${resolution.reason}` });
+    return { ok: false, reason: resolution.reason };
+  }
+
+  const { session_id } = resolution.identity;
+  const { data: row } = await supabase.from('claude_sessions').select('metadata').eq('session_id', session_id).maybeSingle();
+  const handle = row && row.metadata && row.metadata.window_handle;
+  if (!handle) {
+    await emitVerbEvent(supabase, { verb: 'attach', session_id, outcome: 'no_captured_handle' });
+    return { ok: false, reason: 'no_captured_handle', session_id };
+  }
+
+  const focused = await focusWindow(handle, opts);
+  await emitVerbEvent(supabase, { verb: 'attach', session_id, outcome: focused ? 'ok' : 'stale_handle' });
+  return { ok: focused, reason: focused ? null : 'stale_handle', session_id };
+}
+
+/** Stop a live session without spawning a replacement. */
+export async function stop(target, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    await emitVerbEvent(supabase, { verb: 'stop', outcome: `not_resolved:${resolution.reason}` });
+    return { ok: false, reason: resolution.reason };
+  }
+
+  const { session_id } = resolution.identity;
+  const { error } = await supabase.from('claude_sessions').update({
+    status: 'released', released_at: new Date().toISOString(), released_reason: 'manual_stop',
+  }).eq('session_id', session_id);
+
+  await emitVerbEvent(supabase, { verb: 'stop', session_id, outcome: error ? 'db_error' : 'ok' });
+  return { ok: !error, session_id };
+}
+
+/** Internal: spawn a replacement session under the same role/callsign (shared by restart + relaunch). */
+async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts) {
+  const role = roleOf(oldSession);
+  const callsign = oldIdentity.callsign;
+  return spawn({ role, callsign, accountProfile }, opts);
+}
+
+/** FR-4/FR-5: restart -- role-serial for singletons (via the existing guard), parallel for workers. */
+export async function restart(target, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    await emitVerbEvent(supabase, { verb: 'restart', outcome: `not_resolved:${resolution.reason}` });
+    return { ok: false, reason: resolution.reason };
+  }
+
+  const oldIdentity = resolution.identity;
+  const { data: oldSession } = await supabase.from('claude_sessions').select('metadata').eq('session_id', oldIdentity.session_id).maybeSingle();
+  const role = roleOf(oldSession);
+
+  const spawnResult = await spawnReplacement({ oldIdentity, oldSession }, opts);
+
+  if (isSingletonRole(role)) {
+    // FR-4: never a bespoke retire-then-spawn sequence -- the EXISTING register-then-retire mutex owns
+    // this ordering. sequenceSingletonRefresh only retires the old session once the new one is verified
+    // healthy (a live claude_sessions row must exist for newSessionId -- opts.newSessionId lets a live
+    // caller supply it once the spawned process self-registers).
+    const { sequenceSingletonRefresh } = await import('../coordinator/singleton-refresh-sequencer.cjs');
+    if (!opts.newSessionId) {
+      await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration' });
+      return { ok: false, reason: 'awaiting_new_session_registration', spawnResult, role: 'singleton' };
+    }
+    const seqResult = await sequenceSingletonRefresh(supabase, { newSessionId: opts.newSessionId, oldSessionId: oldIdentity.session_id });
+    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: seqResult.action });
+    return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
+  }
+
+  // FR-5: worker restart is parallel-safe by construction -- no shared mutex, resolveSpawnDecisions
+  // (inside spawn -> worker-spawn-executor's decision path) already dedupes by callsign.
+  const { error } = await supabase.from('claude_sessions').update({
+    status: 'released', released_at: new Date().toISOString(), released_reason: 'restart',
+  }).eq('session_id', oldIdentity.session_id);
+  await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok' });
+  return { ok: !error, role: 'worker', spawnResult };
+}
+
+/** FR-7: the ratified account-switch verb -- isolated to the target session only. */
+export async function relaunchUnderProfile(target, accountProfile, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+
+  // Fail loud before touching anything if the profile doesn't resolve to a safe, allowlisted path.
+  resolveProfileDir(accountProfile, opts);
+
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', outcome: `not_resolved:${resolution.reason}` });
+    return { ok: false, reason: resolution.reason };
+  }
+
+  const oldIdentity = resolution.identity;
+  const { data: oldSession } = await supabase.from('claude_sessions').select('metadata').eq('session_id', oldIdentity.session_id).maybeSingle();
+  const role = roleOf(oldSession);
+
+  // SECURITY (FR-7): CLAUDE_CONFIG_DIR must be isolated to the spawned child's env only -- assert the
+  // supervisor's own process.env is untouched by this call, before and after.
+  const supervisorConfigDirBefore = process.env.CLAUDE_CONFIG_DIR;
+  const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
+  const supervisorConfigDirAfter = process.env.CLAUDE_CONFIG_DIR;
+  if (supervisorConfigDirBefore !== supervisorConfigDirAfter) {
+    throw new Error('relaunchUnderProfile: supervisor process.env.CLAUDE_CONFIG_DIR changed -- isolation invariant violated');
+  }
+
+  if (isSingletonRole(role)) {
+    const { sequenceSingletonRefresh } = await import('../coordinator/singleton-refresh-sequencer.cjs');
+    if (!opts.newSessionId) {
+      await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration' });
+      return { ok: false, reason: 'awaiting_new_session_registration', spawnResult, role: 'singleton' };
+    }
+    const seqResult = await sequenceSingletonRefresh(supabase, { newSessionId: opts.newSessionId, oldSessionId: oldIdentity.session_id });
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: seqResult.action });
+    return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
+  }
+
+  const { error } = await supabase.from('claude_sessions').update({
+    status: 'released', released_at: new Date().toISOString(), released_reason: 'relaunch_under_profile',
+  }).eq('session_id', oldIdentity.session_id);
+  await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok' });
+  return { ok: !error, role: 'worker', spawnResult };
+}
+
+/**
+ * FR-6: drain-and-restart waits for the idle boundary. A single call NEVER busy-waits/sleeps inline --
+ * it returns a deferred verdict on MISS/UNKNOWN so the caller (a tick-based scheduler, matching this
+ * codebase's own convention for every other evaluateClaimBoundary consumer) re-invokes on its own
+ * cadence. Restart only ever fires on a genuine PASS.
+ */
+export async function drainAndRestart(target, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    return { ok: false, reason: resolution.reason };
+  }
+
+  const { session_id } = resolution.identity;
+  const { data: row } = await supabase.from('claude_sessions')
+    .select('sd_key, claimed_at, last_tool_at, expected_silence_until, current_tool_expected_end_at')
+    .eq('session_id', session_id).maybeSingle();
+
+  let outboundSinceAnchor = 0;
+  if (row && row.claimed_at) {
+    const { count } = await supabase.from('session_coordination')
+      .select('id', { count: 'exact', head: true })
+      .eq('sender_session', session_id)
+      .gte('created_at', row.claimed_at);
+    outboundSinceAnchor = Number.isFinite(count) ? count : 0;
+  }
+
+  const verdict = evaluateClaimBoundary({
+    nowMs: opts.nowMs ?? Date.now(),
+    anchorMs: row && row.claimed_at ? Date.parse(row.claimed_at) : null,
+    anchorType: 'claim',
+    lastToolAtMs: row && row.last_tool_at ? Date.parse(row.last_tool_at) : null,
+    outboundSinceAnchor,
+    expectedSilenceUntilMs: row && row.expected_silence_until ? Date.parse(row.expected_silence_until) : null,
+    currentToolExpectedEndMs: row && row.current_tool_expected_end_at ? Date.parse(row.current_tool_expected_end_at) : null,
+  });
+
+  if (verdict.verdict !== 'PASS') {
+    await emitVerbEvent(supabase, { verb: 'drain_and_restart', session_id, outcome: `deferred:${verdict.verdict}` });
+    return { ok: false, deferred: true, verdict: verdict.verdict, reason: verdict.reason, session_id };
+  }
+
+  const result = await restart(target, opts);
+  return { ...result, deferred: false, verdict: 'PASS' };
+}

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -107,6 +107,12 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   const live = opts.live ?? isLiveEnabled();
   const log = opts.log || (() => {});
 
+  // ADVERSARIAL-REVIEW NOTE (known, accepted limitation): this dedup check reads liveCallsigns at a
+  // point in time with no reservation/lock written before the OS spawn -- two near-simultaneous calls
+  // for the same callsign can both observe "not live yet" and both proceed. This is the SAME inherent
+  // TOCTOU shape worker-spawn-executor.cjs's own resolveSpawnDecisions() already has (this surface
+  // reuses it rather than adding a new one); acceptable for a default-OFF, low-concurrency control
+  // surface, not a regression introduced here.
   if (supabase && callsign && opts.skipDedup !== true) {
     const { callsignBySession } = await loadLiveSessionIdentity(supabase);
     const liveCallsigns = new Set(Object.values(callsignBySession));
@@ -148,10 +154,24 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     // Best-effort: persist the captured handle once the spawned session self-registers (bounded
     // wait mirrors checkNewSessionHealth's own polling idiom -- never a hand-rolled sleep loop
     // outside this bounded, injectable retry).
+    //
+    // ADVERSARIAL-REVIEW FIX (data integrity): a bare `.update({ metadata: {...} }).eq('pid', pid)`
+    // REPLACES the whole metadata JSONB blob (wiping fleet_identity.callsign/role/etc.) and `pid` is
+    // an OS-recyclable identifier -- matching on it alone risks corrupting an unrelated row. Read the
+    // current row first, merge client-side, and only write back to the SAME session_id we just read
+    // (never a bare pid-scoped write), and only when the row is freshly created (this spawn, not a
+    // stale/recycled-pid session).
     try {
-      await supabase.from('claude_sessions').update({
-        metadata: { window_handle: handleResult.handle, handle_capture_failed: handleResult.handleCaptureFailed },
-      }).eq('pid', pid);
+      const nowMs2 = opts.nowMs ?? Date.now();
+      const { data: current } = await supabase.from('claude_sessions')
+        .select('session_id, metadata, created_at').eq('pid', pid).maybeSingle();
+      const freshMs = opts.pidMatchFreshMs ?? 2 * 60 * 1000;
+      const isFresh = current && current.created_at && (nowMs2 - Date.parse(current.created_at)) <= freshMs;
+      if (current && isFresh) {
+        await supabase.from('claude_sessions').update({
+          metadata: { ...(current.metadata || {}), window_handle: handleResult.handle, handle_capture_failed: handleResult.handleCaptureFailed },
+        }).eq('session_id', current.session_id);
+      }
     } catch { /* fail-soft: the session row may not exist yet; a later attach() re-resolves */ }
   }
 
@@ -246,6 +266,15 @@ export async function restart(target, opts = {}) {
 
   // FR-5: worker restart is parallel-safe by construction -- no shared mutex, resolveSpawnDecisions
   // (inside spawn -> worker-spawn-executor's decision path) already dedupes by callsign.
+  //
+  // ADVERSARIAL-REVIEW FIX (correctness): NEVER release the old session unless the replacement
+  // genuinely spawned live (spawnResult.live === true). In the default (FLEET_SPAWN_CONTROL_LIVE=off)
+  // dry-run mode, spawnReplacement() never launches a process -- releasing the old session anyway
+  // would silently drop the tracked worker from the registry with no functioning replacement.
+  if (!spawnResult || spawnResult.live !== true) {
+    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'replacement_not_live' });
+    return { ok: false, reason: 'replacement_not_live', role: 'worker', spawnResult };
+  }
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'restart',
   }).eq('session_id', oldIdentity.session_id);
@@ -291,6 +320,12 @@ export async function relaunchUnderProfile(target, accountProfile, opts = {}) {
     return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
   }
 
+  // ADVERSARIAL-REVIEW FIX: same guard as restart()'s worker path -- never release the old session
+  // unless the replacement genuinely spawned live.
+  if (!spawnResult || spawnResult.live !== true) {
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'replacement_not_live' });
+    return { ok: false, reason: 'replacement_not_live', role: 'worker', spawnResult };
+  }
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'relaunch_under_profile',
   }).eq('session_id', oldIdentity.session_id);

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -50,7 +50,10 @@ export function resolveProfileDir(profileName, opts = {}) {
   if (typeof profileName !== 'string' || !PROFILE_NAME_RE.test(profileName)) {
     throw new Error(`resolveProfileDir: invalid profile name: ${JSON.stringify(profileName)}`);
   }
-  return path.join(baseDir, profileName);
+  // TR-1: this SD is Windows-only infra (baseDir is always a Windows path on the fleet host). Use
+  // path.win32 explicitly so the join is correct even when this module runs under CI/tests on a
+  // non-Windows runner (path.join maps to path.posix there and would silently forward-slash-join).
+  return path.win32.join(baseDir, profileName);
 }
 
 /** True only when the operator has explicitly enabled the live OS spawn/relaunch surface. */

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -18,7 +18,9 @@ import { spawn as spawnProcess } from 'node:child_process';
 import path from 'node:path';
 import {
   resolveLiveSession,
+  loadLiveSessionIdentity,
 } from './session-registry-adapter.js';
+import { resolveSpawnDecisions } from './spawn-executor-core.cjs';
 import { captureWindowHandle, focusWindow } from './window-handle.js';
 import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
 
@@ -74,27 +76,53 @@ export function buildLiveSpawnInvocation({ role, callsign, profileDir } = {}) {
   };
 }
 
-/** Restricted event payload -- never CLAUDE_CONFIG_DIR/profile paths/argv (FR-9, TR-6). */
-function verbEventPayload({ verb, outcome, extra }) {
-  return { verb, outcome, at: new Date().toISOString(), ...(extra || {}) };
+/**
+ * Restricted event payload -- HARD-LOCKED to exactly {verb, outcome, at}, never
+ * CLAUDE_CONFIG_DIR/profile paths/argv (FR-9, TR-6). No extension point: a future verb needing a
+ * new field must widen this allowlist explicitly here, never spread arbitrary caller data through.
+ */
+function verbEventPayload({ verb, outcome }) {
+  return { verb, outcome, at: new Date().toISOString() };
 }
 
-async function emitVerbEvent(supabase, { verb, session_id, outcome, extra }) {
+async function emitVerbEvent(supabase, { verb, session_id, outcome }) {
   try {
     const { logCoordinationEvent } = await import('../coordinator/coordination-events.cjs');
     await logCoordinationEvent(supabase, {
       event_type: `fleet_verb_${verb}`,
       session_id: session_id ?? null,
-      payload: verbEventPayload({ verb, outcome, extra }),
+      payload: verbEventPayload({ verb, outcome }),
     });
   } catch { /* fail-open: event emission never blocks a verb outcome */ }
 }
 
-/** FR-1: spawn a detached, visible session + capture its window handle. */
+/**
+ * FR-1: spawn a detached, visible session + capture its window handle. FR-5: dedup-by-callsign via
+ * the SAME decision logic worker-spawn-executor.cjs already uses (resolveSpawnDecisions) -- never
+ * spawn a callsign that's already live, whether this call came from restart()'s worker path or a
+ * direct spawn() invocation.
+ */
 export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) {
   const supabase = opts.supabaseClient;
   const live = opts.live ?? isLiveEnabled();
   const log = opts.log || (() => {});
+
+  if (supabase && callsign && opts.skipDedup !== true) {
+    const { callsignBySession } = await loadLiveSessionIdentity(supabase);
+    const liveCallsigns = new Set(Object.values(callsignBySession));
+    const decision = resolveSpawnDecisions({
+      pendingRequests: [{ id: 'spawn-verb', requested_callsign: callsign, status: 'pending', requested_at: new Date().toISOString() }],
+      liveCallsigns,
+      nowMs: opts.nowMs ?? Date.now(),
+      perTickCap: 1,
+    });
+    if (decision.toSpawn.length === 0) {
+      const reason = (decision.skipped[0] && decision.skipped[0].reason) || 'already_live';
+      log(`[spawn-control] skip spawn for ${callsign}: ${reason}`);
+      await emitVerbEvent(supabase, { verb: 'spawn', outcome: `skipped:${reason}` });
+      return { live: false, skipped: true, reason };
+    }
+  }
 
   let profileDir = null;
   if (accountProfile) profileDir = resolveProfileDir(accountProfile, opts);
@@ -173,11 +201,16 @@ export async function stop(target, opts = {}) {
   return { ok: !error, session_id };
 }
 
-/** Internal: spawn a replacement session under the same role/callsign (shared by restart + relaunch). */
+/**
+ * Internal: spawn a replacement session under the same role/callsign (shared by restart + relaunch).
+ * skipDedup:true -- restart()/relaunchUnderProfile() already resolved ONE specific old session to
+ * replace (not a speculative fresh request), so spawn()'s FR-5 already-live dedup would otherwise
+ * always skip this (the old session under the same callsign is still live until it's retired).
+ */
 async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts) {
   const role = roleOf(oldSession);
   const callsign = oldIdentity.callsign;
-  return spawn({ role, callsign, accountProfile }, opts);
+  return spawn({ role, callsign, accountProfile }, { ...opts, skipDedup: true });
 }
 
 /** FR-4/FR-5: restart -- role-serial for singletons (via the existing guard), parallel for workers. */

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -1,0 +1,88 @@
+/**
+ * Windows window-handle capture + focus for fleet spawn-control (FR-1, FR-3).
+ * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001.
+ *
+ * MainWindowHandle capture races window creation (the process exists before its window does),
+ * so capture is a bounded poll/retry, not a single read. The PowerShell command interpolates
+ * ONLY a coerced-numeric PID -- never a raw identifier -- closing the injection surface SECURITY
+ * flagged in PLAN review (TR-5).
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Coerce to a strictly-positive integer PID or throw. Never interpolate an unvalidated value. */
+export function assertValidPid(pid) {
+  const n = Number(pid);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`assertValidPid: not a valid PID: ${JSON.stringify(pid)}`);
+  return n;
+}
+
+/** Build the PowerShell command for a single, coerced-numeric PID. Pure -- no execution. */
+export function buildHandleCaptureCommand(pid) {
+  const safePid = assertValidPid(pid);
+  return {
+    program: 'powershell',
+    args: ['-NoProfile', '-NonInteractive', '-Command',
+      `(Get-Process -Id ${safePid} -ErrorAction SilentlyContinue).MainWindowHandle.ToInt64()`],
+  };
+}
+
+/** Parse the PowerShell handle-capture stdout. Returns a non-zero handle or null (window not yet created). */
+export function parseHandleOutput(stdout) {
+  const trimmed = String(stdout || '').trim();
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n !== 0 ? n : null;
+}
+
+async function defaultExec(program, args) {
+  return execFileAsync(program, args, { windowsHide: false, timeout: 5000 });
+}
+function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+/**
+ * Bounded poll/retry to capture MainWindowHandle for a just-spawned PID. Injectable execFn/sleepFn
+ * for tests (never invokes PowerShell in unit tests).
+ * @param {number} pid
+ * @param {{execFn?:Function, maxAttempts?:number, delayMs?:number, sleepFn?:Function}} [opts]
+ * @returns {Promise<{handle:number|null, handleCaptureFailed:boolean, attempts:number}>}
+ */
+export async function captureWindowHandle(pid, opts = {}) {
+  const { execFn = defaultExec, maxAttempts = 10, delayMs = 500, sleepFn = defaultSleep } = opts;
+  const cmd = buildHandleCaptureCommand(pid);
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const { stdout } = await execFn(cmd.program, cmd.args);
+    const handle = parseHandleOutput(stdout);
+    if (handle !== null) return { handle, handleCaptureFailed: false, attempts: attempt };
+    if (attempt < maxAttempts) await sleepFn(delayMs);
+  }
+  return { handle: null, handleCaptureFailed: true, attempts: maxAttempts };
+}
+
+/** Build the foreground-focus command for a captured handle. Pure -- no execution. */
+export function buildFocusCommand(handle) {
+  const n = Number(handle);
+  if (!Number.isFinite(n) || n === 0) throw new Error(`buildFocusCommand: invalid handle: ${JSON.stringify(handle)}`);
+  // SetForegroundWindow via a minimal inline P/Invoke -- handle passed as a coerced Int64, never a raw string.
+  return {
+    program: 'powershell',
+    args: ['-NoProfile', '-NonInteractive', '-Command',
+      `Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class FleetWin{[DllImport("user32.dll")]public static extern bool SetForegroundWindow(IntPtr h);}'; [FleetWin]::SetForegroundWindow([IntPtr]${n})`],
+  };
+}
+
+/**
+ * Focus a previously-captured window handle (FR-3 attach). Never throws -- a stale/invalid handle
+ * (window closed) returns false so the caller reports a clear degraded state instead of guessing.
+ */
+export async function focusWindow(handle, opts = {}) {
+  const { execFn = defaultExec } = opts;
+  try {
+    const cmd = buildFocusCommand(handle);
+    await execFn(cmd.program, cmd.args);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/fleet/session-registry-adapter.test.js
+++ b/tests/unit/fleet/session-registry-adapter.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 FR-8: DB adapter over SD-A's pure registry/manifest libs (TS-6).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  loadLiveSessionIdentity,
+  joinLiveSessionIdentity,
+  resolveLiveSession,
+  actualByRole,
+  computeLiveManifestDrift,
+} from '../../../lib/fleet/session-registry-adapter.js';
+
+function makeFakeSupabase(sessions, error = null) {
+  return {
+    from(table) {
+      expect(table).toBe('claude_sessions');
+      return {
+        select() {
+          return { in: async () => ({ data: sessions, error }) };
+        },
+      };
+    },
+  };
+}
+
+describe('loadLiveSessionIdentity', () => {
+  it('derives callsign from the SET_IDENTITY row (metadata.fleet_identity.callsign), never a column', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', pid: 111, metadata: { fleet_identity: { callsign: 'Alpha-5' } } },
+      { session_id: 's2', pid: 222, metadata: {} },
+    ]);
+    const { sessions, callsignBySession } = await loadLiveSessionIdentity(sb);
+    expect(sessions).toHaveLength(2);
+    expect(callsignBySession).toEqual({ s1: 'Alpha-5' });
+  });
+
+  it('fails soft to an empty set on a DB error', async () => {
+    const sb = makeFakeSupabase(null, { code: '42P01', message: 'relation does not exist' });
+    const result = await loadLiveSessionIdentity(sb);
+    expect(result.sessions).toEqual([]);
+    expect(result.callsignBySession).toEqual({});
+  });
+});
+
+describe('joinLiveSessionIdentity + resolveLiveSession (collision-visible, TS-6)', () => {
+  it('resolves a unique callsign to one identity', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', pid: 111, metadata: { fleet_identity: { callsign: 'Alpha-5' } } },
+    ]);
+    const result = await resolveLiveSession(sb, { by: 'callsign', value: 'Alpha-5' });
+    expect(result.resolved).toBe(true);
+    expect(result.identity.session_id).toBe('s1');
+  });
+
+  it('surfaces ambiguous when two sessions collide on the same key (never silently picks one)', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', pid: 111, metadata: { fleet_identity: { callsign: 'Alpha-5' } } },
+      { session_id: 's2', pid: 222, metadata: { fleet_identity: { callsign: 'Alpha-5' } } },
+    ]);
+    const joined = await joinLiveSessionIdentity(sb);
+    expect(joined).toHaveLength(2);
+    const result = await resolveLiveSession(sb, { by: 'callsign', value: 'Alpha-5' });
+    expect(result.resolved).toBe(false);
+    expect(result.reason).toBe('ambiguous');
+  });
+
+  it('surfaces not_found for a card with no matching live session', async () => {
+    const sb = makeFakeSupabase([]);
+    const result = await resolveLiveSession(sb, { by: 'callsign', value: 'Ghost-1' });
+    expect(result.resolved).toBe(false);
+    expect(result.reason).toBe('not_found');
+  });
+});
+
+describe('actualByRole + computeLiveManifestDrift (TS-6)', () => {
+  const roleOf = (callsign) => (callsign === 'Coordinator-1' ? 'coordinator' : callsign?.startsWith('Alpha') ? 'worker' : null);
+
+  it('identifies under-staffed roles from live data', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', metadata: { fleet_identity: { callsign: 'Alpha-5' } } },
+    ]);
+    const verdict = await computeLiveManifestDrift(sb, {
+      desired: [{ role: 'coordinator', min: 1 }, { role: 'worker', min: 2 }],
+      roleOf,
+    });
+    expect(verdict.drift).toBe(true);
+    expect(verdict.under).toEqual(
+      expect.arrayContaining([
+        { role: 'coordinator', desired: 1, actual: 0 },
+        { role: 'worker', desired: 2, actual: 1 },
+      ]),
+    );
+  });
+
+  it('reports satisfied when live counts meet the desired minimums', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', metadata: { fleet_identity: { callsign: 'Coordinator-1' } } },
+    ]);
+    const verdict = await computeLiveManifestDrift(sb, { desired: [{ role: 'coordinator', min: 1 }], roleOf });
+    expect(verdict.drift).toBe(false);
+  });
+
+  it('actualByRole ignores identities with no resolvable role', () => {
+    const joined = [{ callsign: 'Alpha-5' }, { callsign: null }, { callsign: 'Unknown-9' }];
+    expect(actualByRole(joined, roleOf)).toEqual({ worker: 1 });
+  });
+});

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -157,6 +157,44 @@ describe('spawn (FR-1)', () => {
     expect(result.handleCaptureFailed).toBe(false);
   });
 
+  it('ADVERSARIAL-REVIEW FIX: merges the captured handle into existing metadata, never overwrites the whole blob', async () => {
+    const nowMs = 1_800_000_000_000;
+    const child = { pid: 4242 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: 's1', pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), // freshly self-registered, well within the match window
+        metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true });
+    const merged = supabaseClient._store.get('s1').metadata;
+    // Pre-existing keys survive the write (would be wiped by a bare full-blob overwrite).
+    expect(merged.fleet_identity).toEqual({ callsign: 'Alpha-5' });
+    expect(merged.role).toBe('worker');
+    expect(merged.window_handle).toBe(131074);
+    expect(merged.handle_capture_failed).toBe(false);
+  });
+
+  it('ADVERSARIAL-REVIEW FIX: never writes metadata for a stale/recycled pid match (created_at outside the freshness window)', async () => {
+    const nowMs = 1_800_000_000_000;
+    const child = { pid: 4242 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: 's-old', pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 60 * 60 * 1000).toISOString(), // an hour old -- a different, unrelated session that happens to share the recycled OS pid
+        metadata: { fleet_identity: { callsign: 'Unrelated-Session' }, role: 'worker' },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true });
+    // Untouched -- the stale row's metadata must never be corrupted by a fresh spawn's recycled pid.
+    expect(supabaseClient._store.get('s-old').metadata).toEqual({ fleet_identity: { callsign: 'Unrelated-Session' }, role: 'worker' });
+  });
+
   it('FR-5: skips (never double-spawns) a callsign that already has a live session', async () => {
     const spawnFn = vi.fn();
     const supabaseClient = makeFakeSupabase({
@@ -244,11 +282,28 @@ describe('stop', () => {
 describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
   beforeEach(() => { sequenceSingletonRefresh.mockReset(); });
 
-  it('worker path: releases the old session and spawns a replacement without the singleton sequencer', async () => {
+  it('worker path (ADVERSARIAL-REVIEW FIX): never releases the old session when the replacement did NOT actually spawn live (dry-run)', async () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
     const result = await restart('Alpha-5', { supabaseClient, live: false });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('replacement_not_live');
+    expect(result.role).toBe('worker');
+    expect(sequenceSingletonRefresh).not.toHaveBeenCalled();
+    // Old session must remain untouched -- releasing it here would drop a tracked worker with
+    // no functioning replacement (the bug an adversarial review caught).
+    expect(supabaseClient._store.get('s1').status).toBe('active');
+  });
+
+  it('worker path: releases the old session only once the replacement genuinely spawned live', async () => {
+    const child = { pid: 4242 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    const result = await restart('Alpha-5', { supabaseClient, live: true, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.ok).toBe(true);
     expect(result.role).toBe('worker');
     expect(sequenceSingletonRefresh).not.toHaveBeenCalled();
@@ -289,17 +344,30 @@ describe('relaunchUnderProfile (FR-7)', () => {
     expect(dbTouch).not.toHaveBeenCalled();
   });
 
-  it('isolates the account switch to the target session; sibling untouched (worker path)', async () => {
+  it('isolates the account switch to the target session; sibling untouched (worker path, live spawn)', async () => {
+    const child = { pid: 4343 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
     const supabaseClient = makeFakeSupabase({
       sessions: [
         { session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } },
         { session_id: 's2', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-6' }, role: 'worker' } },
       ],
     });
-    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: false });
+    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.ok).toBe(true);
     expect(supabaseClient._store.get('s1').status).toBe('released');
     expect(supabaseClient._store.get('s2').status).toBe('active');
+  });
+
+  it('ADVERSARIAL-REVIEW FIX: never releases the old session when the replacement did not actually spawn live (dry-run)', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: false });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('replacement_not_live');
+    expect(supabaseClient._store.get('s1').status).toBe('active');
   });
 
   it('throws if the supervisor process.env.CLAUDE_CONFIG_DIR is mutated during the call (isolation invariant)', async () => {
@@ -376,9 +444,29 @@ describe('drainAndRestart (FR-6: never restarts mid-claim)', () => {
         last_tool_at: new Date(nowMs - 30 * 1000).toISOString(),
       },
     });
-    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: false });
+    const child = { pid: 5252 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: true, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.deferred).toBe(false);
     expect(result.verdict).toBe('PASS');
     expect(supabaseClient._store.get('s1').status).toBe('released');
+  });
+
+  it('ADVERSARIAL-REVIEW FIX: PASS verdict alone does not release the session if the replacement never actually spawned live', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeBoundarySupabase({
+      sessionRow: {
+        session_id: 's1', status: 'active',
+        metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
+        claimed_at: new Date(nowMs - 60 * 1000).toISOString(),
+        last_tool_at: new Date(nowMs - 30 * 1000).toISOString(),
+      },
+    });
+    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: false });
+    expect(result.verdict).toBe('PASS');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('replacement_not_live');
+    expect(supabaseClient._store.get('s1').status).toBe('active');
   });
 });

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -14,6 +14,7 @@ const {
   roleOf, isSingletonRole, resolveProfileDir, isLiveEnabled, buildLiveSpawnInvocation,
   spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart,
 } = await import('../../../lib/fleet/spawn-control.js');
+const { logCoordinationEvent } = await import('../../../lib/coordinator/coordination-events.cjs');
 const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
 
 /** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
@@ -154,6 +155,50 @@ describe('spawn (FR-1)', () => {
     expect(result.live).toBe(true);
     expect(result.handle).toBe(131074);
     expect(result.handleCaptureFailed).toBe(false);
+  });
+
+  it('FR-5: skips (never double-spawns) a callsign that already has a live session', async () => {
+    const spawnFn = vi.fn();
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
+    });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, supabaseClient });
+    expect(result.skipped).toBe(true);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('FR-5: skipDedup:true (internal replacement path) bypasses the already-live check', async () => {
+    const child = { pid: 4242 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
+    });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
+    expect(result.skipped).toBeUndefined();
+    expect(spawnFn).toHaveBeenCalled();
+  });
+});
+
+describe('FR-9 SECURITY: event payload is hard-locked to {verb, outcome, at}', () => {
+  it('never includes CLAUDE_CONFIG_DIR or any other field', async () => {
+    logCoordinationEvent.mockClear();
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
+    });
+    await stop('Alpha-5', { supabaseClient });
+    expect(logCoordinationEvent).toHaveBeenCalled();
+    const [, eventArg] = logCoordinationEvent.mock.calls.at(-1);
+    expect(Object.keys(eventArg.payload).sort()).toEqual(['at', 'outcome', 'verb']);
+    expect(JSON.stringify(eventArg.payload)).not.toContain('CLAUDE_CONFIG_DIR');
+  });
+});
+
+describe('FR-6 grep-pin: drainAndRestart never touches the unrelated message-kind drain concept', () => {
+  it('source contains no reference to drain-set-registry / role_drain_sets', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(new URL('../../../lib/fleet/spawn-control.js', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/drain-set-registry|role_drain_sets/);
   });
 });
 

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -1,0 +1,339 @@
+/**
+ * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 -- six-verb control API (TS-1..TS-10 unit-testable subset).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
+  logCoordinationEvent: vi.fn().mockResolvedValue({ ok: true }),
+}));
+vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
+  sequenceSingletonRefresh: vi.fn(),
+}));
+
+const {
+  roleOf, isSingletonRole, resolveProfileDir, isLiveEnabled, buildLiveSpawnInvocation,
+  spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart,
+} = await import('../../../lib/fleet/spawn-control.js');
+const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
+
+/** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
+function makeFakeSupabase({ sessions = [] } = {}) {
+  const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
+  return {
+    _store: store,
+    from(table) {
+      if (table === 'claude_sessions') {
+        return {
+          select() {
+            return {
+              in: async (col, vals) => ({ data: [...store.values()].filter((s) => vals.includes(s[col])) }),
+              eq: (col, val) => ({
+                maybeSingle: async () => ({ data: [...store.values()].find((s) => s[col] === val) || null }),
+              }),
+            };
+          },
+          update(patch) {
+            return {
+              eq: (col, val) => {
+                const row = [...store.values()].find((s) => s[col] === val);
+                if (row) Object.assign(row, patch);
+                return Promise.resolve({ error: row ? null : { message: 'not found' } });
+              },
+            };
+          },
+        };
+      }
+      if (table === 'session_coordination') {
+        return { select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('module surface (TS-10: exactly six named verbs, no more)', () => {
+  it('exports exactly {spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart} as the verb set', async () => {
+    const mod = await import('../../../lib/fleet/spawn-control.js');
+    const verbNames = ['spawn', 'attach', 'stop', 'restart', 'relaunchUnderProfile', 'drainAndRestart'];
+    for (const name of verbNames) expect(typeof mod[name]).toBe('function');
+    // Every OTHER export must be a helper, never an undocumented 7th verb.
+    const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation'];
+    const unexpected = Object.keys(mod).filter((k) => !verbNames.includes(k) && !helperNames.includes(k));
+    expect(unexpected).toEqual([]);
+  });
+});
+
+describe('FR-10: SD-E watchdog AUTH-LOST remediation names a real spawn-control verb (TS-9)', () => {
+  it('resolves to relaunchUnderProfile, not a dangling verb-name reference', async () => {
+    const { classifyWatchdogState } = await import('../../../lib/fleet/session-watchdog.js');
+    const nowMs = 1_800_000_000_000;
+    const result = classifyWatchdogState(
+      { session_id: 's1', heartbeat_at: new Date(nowMs - 60 * 60 * 1000).toISOString() },
+      { nowMs, staleThresholdMs: 5 * 60 * 1000, isPidAlive: () => true },
+    );
+    expect(result.state).toBe('AUTH-LOST');
+    expect(result.remediation).toMatch(/relaunch-under-profile/);
+    expect(result.remediation).toMatch(/relaunchUnderProfile\(\)/);
+    expect(typeof relaunchUnderProfile).toBe('function');
+  });
+});
+
+describe('roleOf / isSingletonRole', () => {
+  it('derives coordinator from is_coordinator metadata', () => {
+    expect(roleOf({ metadata: { is_coordinator: 'true' } })).toBe('coordinator');
+  });
+  it('derives adam/solomon from metadata.role', () => {
+    expect(roleOf({ metadata: { role: 'adam' } })).toBe('adam');
+    expect(roleOf({ metadata: { role: 'solomon' } })).toBe('solomon');
+  });
+  it('defaults to worker', () => {
+    expect(roleOf({ metadata: {} })).toBe('worker');
+    expect(roleOf(null)).toBe('worker');
+  });
+  it('isSingletonRole is true only for coordinator/adam/solomon', () => {
+    expect(isSingletonRole('coordinator')).toBe(true);
+    expect(isSingletonRole('adam')).toBe(true);
+    expect(isSingletonRole('solomon')).toBe(true);
+    expect(isSingletonRole('worker')).toBe(false);
+  });
+});
+
+describe('resolveProfileDir (TR-5 SECURITY: allowlist, no traversal)', () => {
+  it('resolves a bare alnum/dash/underscore name under the configured base dir', () => {
+    const dir = resolveProfileDir('account_b-2', { baseDir: 'C:\\profiles' });
+    expect(dir).toBe('C:\\profiles\\account_b-2');
+  });
+  it('rejects a traversal attempt', () => {
+    expect(() => resolveProfileDir('../../etc/passwd', { baseDir: 'C:\\profiles' })).toThrow(/invalid profile name/);
+  });
+  it('rejects an absolute path supplied as the profile name', () => {
+    expect(() => resolveProfileDir('C:\\Windows\\System32', { baseDir: 'C:\\profiles' })).toThrow(/invalid profile name/);
+  });
+  it('throws if no base dir is configured', () => {
+    expect(() => resolveProfileDir('account_b', {})).toThrow(/FLEET_ACCOUNT_PROFILES_DIR/);
+  });
+});
+
+describe('isLiveEnabled (TR-4: default-off)', () => {
+  it('is false by default', () => expect(isLiveEnabled({})).toBe(false));
+  it('is true only for the literal string "true"', () => {
+    expect(isLiveEnabled({ FLEET_SPAWN_CONTROL_LIVE: 'true' })).toBe(true);
+    expect(isLiveEnabled({ FLEET_SPAWN_CONTROL_LIVE: 'TRUE' })).toBe(true);
+    expect(isLiveEnabled({ FLEET_SPAWN_CONTROL_LIVE: 'yes' })).toBe(false);
+  });
+});
+
+describe('buildLiveSpawnInvocation (FR-7: env isolation)', () => {
+  it('injects CLAUDE_CONFIG_DIR only into the returned env object, never touching process.env', () => {
+    const before = process.env.CLAUDE_CONFIG_DIR;
+    const invocation = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Alpha-5', profileDir: '/profiles/b' });
+    expect(invocation.env.CLAUDE_CONFIG_DIR).toBe('/profiles/b');
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(before);
+  });
+  it('omits CLAUDE_CONFIG_DIR when no profileDir is given', () => {
+    const invocation = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Alpha-5' });
+    expect(invocation.env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+});
+
+describe('spawn (FR-1)', () => {
+  it('dry-run path (live=false) never spawns and logs the invocation', async () => {
+    const spawnFn = vi.fn();
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: false, spawnFn });
+    expect(result.live).toBe(false);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('live path spawns detached and captures the window handle', async () => {
+    const child = { pid: 4242 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({ sessions: [] });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient });
+    expect(spawnFn).toHaveBeenCalledWith('wt.exe', expect.any(Array), expect.any(Object));
+    expect(result.live).toBe(true);
+    expect(result.handle).toBe(131074);
+    expect(result.handleCaptureFailed).toBe(false);
+  });
+});
+
+describe('attach (FR-3)', () => {
+  it('focuses the captured window handle for a resolved session', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, window_handle: 131074 } }],
+    });
+    const execFn = vi.fn().mockResolvedValue({ stdout: '' });
+    const result = await attach('Alpha-5', { supabaseClient, execFn });
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports a clear degraded state for a session with no captured handle (FR-1 honesty preserved)', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
+    });
+    const result = await attach('Alpha-5', { supabaseClient });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no_captured_handle');
+  });
+
+  it('reports not_found for an unresolvable card', async () => {
+    const supabaseClient = makeFakeSupabase({ sessions: [] });
+    const result = await attach('Ghost-1', { supabaseClient });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('not_found');
+  });
+});
+
+describe('stop', () => {
+  it('marks the resolved session released', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
+    });
+    const result = await stop('Alpha-5', { supabaseClient });
+    expect(result.ok).toBe(true);
+    expect(supabaseClient._store.get('s1').status).toBe('released');
+    expect(supabaseClient._store.get('s1').released_reason).toBe('manual_stop');
+  });
+});
+
+describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
+  beforeEach(() => { sequenceSingletonRefresh.mockReset(); });
+
+  it('worker path: releases the old session and spawns a replacement without the singleton sequencer', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    const result = await restart('Alpha-5', { supabaseClient, live: false });
+    expect(result.ok).toBe(true);
+    expect(result.role).toBe('worker');
+    expect(sequenceSingletonRefresh).not.toHaveBeenCalled();
+    expect(supabaseClient._store.get('s1').status).toBe('released');
+  });
+
+  it('singleton path defers until a newSessionId is supplied (never a bespoke retire-first sequence)', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { role: 'coordinator', is_coordinator: 'true' } }],
+    });
+    const result = await restart('s1', { supabaseClient, live: false, by: 'session_id' });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('awaiting_new_session_registration');
+    expect(sequenceSingletonRefresh).not.toHaveBeenCalled();
+    // old session must NOT be retired without the health-gated sequencer
+    expect(supabaseClient._store.get('s1').status).toBe('active');
+  });
+
+  it('singleton path with newSessionId calls the EXISTING register-then-retire mutex, never a bespoke one', async () => {
+    sequenceSingletonRefresh.mockResolvedValue({ action: 'retire_old', retired: true });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { role: 'coordinator', is_coordinator: 'true' } }],
+    });
+    const result = await restart('s1', { supabaseClient, live: false, by: 'session_id', newSessionId: 's2' });
+    expect(sequenceSingletonRefresh).toHaveBeenCalledWith(supabaseClient, { newSessionId: 's2', oldSessionId: 's1' });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('relaunchUnderProfile (FR-7)', () => {
+  beforeEach(() => { sequenceSingletonRefresh.mockReset(); });
+
+  it('rejects an invalid/traversal profile BEFORE touching the database', async () => {
+    const dbTouch = vi.fn();
+    const supabaseClient = { from: dbTouch };
+    await expect(relaunchUnderProfile('Alpha-5', '../../etc/passwd', { supabaseClient, baseDir: 'C:\\profiles' }))
+      .rejects.toThrow(/invalid profile name/);
+    expect(dbTouch).not.toHaveBeenCalled();
+  });
+
+  it('isolates the account switch to the target session; sibling untouched (worker path)', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [
+        { session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } },
+        { session_id: 's2', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-6' }, role: 'worker' } },
+      ],
+    });
+    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: false });
+    expect(result.ok).toBe(true);
+    expect(supabaseClient._store.get('s1').status).toBe('released');
+    expect(supabaseClient._store.get('s2').status).toBe('active');
+  });
+
+  it('throws if the supervisor process.env.CLAUDE_CONFIG_DIR is mutated during the call (isolation invariant)', async () => {
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    const spawnFn = vi.fn().mockImplementation(() => {
+      process.env.CLAUDE_CONFIG_DIR = '/tampered'; // simulate a hypothetical regression
+      return { pid: 999 };
+    });
+    await expect(relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn: vi.fn().mockResolvedValue({ stdout: '0' }), sleepFn: vi.fn() }))
+      .rejects.toThrow(/isolation invariant violated/);
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+});
+
+describe('drainAndRestart (FR-6: never restarts mid-claim)', () => {
+  function makeBoundarySupabase({ sessionRow, outboundCount = 0 }) {
+    const sessions = [sessionRow];
+    const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
+    return {
+      _store: store,
+      from(table) {
+        if (table === 'claude_sessions') {
+          return {
+            select() {
+              return {
+                in: async (col, vals) => ({ data: [...store.values()].filter((s) => vals.includes(s[col])) }),
+                eq: (col, val) => ({
+                  maybeSingle: async () => ({ data: [...store.values()].find((s) => s[col] === val) || null }),
+                }),
+              };
+            },
+            update(patch) {
+              return { eq: (col, val) => { const row = [...store.values()].find((s) => s[col] === val); if (row) Object.assign(row, patch); return Promise.resolve({ error: null }); } };
+            },
+          };
+        }
+        if (table === 'session_coordination') {
+          return { select: () => ({ eq: () => ({ gte: async () => ({ count: outboundCount }) }) }) };
+        }
+        throw new Error(`unexpected table: ${table}`);
+      },
+    };
+  }
+
+  it('defers (never restarts) when the boundary probe verdict is MISS (mid-claim)', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeBoundarySupabase({
+      sessionRow: {
+        session_id: 's1', status: 'active',
+        metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
+        claimed_at: new Date(nowMs - 20 * 60 * 1000).toISOString(),
+        // Within the boundary-grace neighborhood of the anchor (not "progressed past boundary"),
+        // window already elapsed, zero outbound -> the genuine freeze signature (MISS).
+        last_tool_at: new Date(nowMs - 19 * 60 * 1000).toISOString(),
+      },
+      outboundCount: 0,
+    });
+    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: false });
+    expect(result.ok).toBe(false);
+    expect(result.deferred).toBe(true);
+    expect(result.verdict).toBe('MISS');
+    expect(supabaseClient._store.get('s1').status).toBe('active');
+  });
+
+  it('proceeds to restart once the probe returns PASS (genuinely idle)', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeBoundarySupabase({
+      sessionRow: {
+        session_id: 's1', status: 'active',
+        metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
+        claimed_at: new Date(nowMs - 60 * 1000).toISOString(), // within the probe window -> PASS (window_not_elapsed)
+        last_tool_at: new Date(nowMs - 30 * 1000).toISOString(),
+      },
+    });
+    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: false });
+    expect(result.deferred).toBe(false);
+    expect(result.verdict).toBe('PASS');
+    expect(supabaseClient._store.get('s1').status).toBe('released');
+  });
+});

--- a/tests/unit/fleet/window-handle.test.js
+++ b/tests/unit/fleet/window-handle.test.js
@@ -18,7 +18,7 @@ describe('assertValidPid (TR-5 SECURITY guardrail)', () => {
   });
 
   it('rejects non-numeric, negative, zero, and NaN values', () => {
-    expect(() => assertValidPid('123; rm -rf /')).toThrow(/not a valid PID/);
+    expect(() => assertValidPid('123; shutdown /s')).toThrow(/not a valid PID/);
     expect(() => assertValidPid(-1)).toThrow(/not a valid PID/);
     expect(() => assertValidPid(0)).toThrow(/not a valid PID/);
     expect(() => assertValidPid('abc')).toThrow(/not a valid PID/);

--- a/tests/unit/fleet/window-handle.test.js
+++ b/tests/unit/fleet/window-handle.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 FR-1/FR-3, TR-5 (SECURITY: numeric-PID-only interpolation).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  assertValidPid,
+  buildHandleCaptureCommand,
+  parseHandleOutput,
+  captureWindowHandle,
+  buildFocusCommand,
+  focusWindow,
+} from '../../../lib/fleet/window-handle.js';
+
+describe('assertValidPid (TR-5 SECURITY guardrail)', () => {
+  it('accepts a positive integer', () => {
+    expect(assertValidPid(1234)).toBe(1234);
+    expect(assertValidPid('5678')).toBe(5678);
+  });
+
+  it('rejects non-numeric, negative, zero, and NaN values', () => {
+    expect(() => assertValidPid('123; rm -rf /')).toThrow(/not a valid PID/);
+    expect(() => assertValidPid(-1)).toThrow(/not a valid PID/);
+    expect(() => assertValidPid(0)).toThrow(/not a valid PID/);
+    expect(() => assertValidPid('abc')).toThrow(/not a valid PID/);
+    expect(() => assertValidPid(null)).toThrow(/not a valid PID/);
+  });
+});
+
+describe('buildHandleCaptureCommand', () => {
+  it('interpolates ONLY the coerced numeric PID into the command string', () => {
+    const cmd = buildHandleCaptureCommand('4242');
+    expect(cmd.program).toBe('powershell');
+    expect(cmd.args.join(' ')).toContain('Get-Process -Id 4242');
+    expect(cmd.args.join(' ')).not.toContain(';');
+  });
+
+  it('throws before building any command for an invalid PID', () => {
+    expect(() => buildHandleCaptureCommand('4242; malicious')).toThrow(/not a valid PID/);
+  });
+});
+
+describe('parseHandleOutput', () => {
+  it('parses a non-zero handle', () => {
+    expect(parseHandleOutput('  131074\n')).toBe(131074);
+  });
+
+  it('returns null for zero (window not yet created)', () => {
+    expect(parseHandleOutput('0')).toBeNull();
+  });
+
+  it('returns null for empty/garbage output', () => {
+    expect(parseHandleOutput('')).toBeNull();
+    expect(parseHandleOutput('garbage')).toBeNull();
+  });
+});
+
+describe('captureWindowHandle (bounded retry)', () => {
+  it('returns the handle on the first successful attempt', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn() });
+    expect(result).toEqual({ handle: 131074, handleCaptureFailed: false, attempts: 1 });
+    expect(execFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries while the window has not been created yet, then succeeds', async () => {
+    const execFn = vi.fn()
+      .mockResolvedValueOnce({ stdout: '0' })
+      .mockResolvedValueOnce({ stdout: '0' })
+      .mockResolvedValueOnce({ stdout: '99887766' });
+    const sleepFn = vi.fn().mockResolvedValue();
+    const result = await captureWindowHandle(4242, { execFn, sleepFn, maxAttempts: 5, delayMs: 10 });
+    expect(result).toEqual({ handle: 99887766, handleCaptureFailed: false, attempts: 3 });
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks handleCaptureFailed=true after exhausting maxAttempts (never silently null)', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '0' });
+    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn(), maxAttempts: 3, delayMs: 1 });
+    expect(result).toEqual({ handle: null, handleCaptureFailed: true, attempts: 3 });
+    expect(execFn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('buildFocusCommand', () => {
+  it('interpolates a coerced numeric handle', () => {
+    const cmd = buildFocusCommand(131074);
+    expect(cmd.args.join(' ')).toContain('[IntPtr]131074');
+  });
+
+  it('throws for an invalid handle', () => {
+    expect(() => buildFocusCommand(0)).toThrow(/invalid handle/);
+    expect(() => buildFocusCommand(null)).toThrow(/invalid handle/);
+  });
+});
+
+describe('focusWindow', () => {
+  it('returns true on success', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: '' });
+    expect(await focusWindow(131074, { execFn })).toBe(true);
+  });
+
+  it('returns false (never throws) for a stale/invalid handle', async () => {
+    const execFn = vi.fn().mockRejectedValue(new Error('window closed'));
+    expect(await focusWindow(131074, { execFn })).toBe(false);
+    expect(await focusWindow(0, {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the CONTROL layer of the chairman-approved fleet launcher (D-0719-BUILDGO=A + Solomon scope verdict G3/U1/U3): six governed verbs — `spawn` / `attach` / `stop` / `restart` / `relaunch-under-profile` / `drain-and-restart` — no more.
- Composes existing primitives rather than rebuilding them: `worker-spawn-executor.cjs`'s spawn-detached pattern, `singleton-refresh-sequencer.cjs`'s register-then-retire mutex, `claim-boundary-probe.cjs`'s idle-boundary probe, and a new thin DB adapter over SD-A's pure `session-registry.js`/`session-manifest.js` libs.
- Three genuinely-new pieces (validation-agent confirmed zero prior art): `lib/fleet/window-handle.js` (bounded-retry Windows `MainWindowHandle` capture + focus, numeric-PID-only interpolation), `lib/fleet/session-registry-adapter.js` (DB adapter), `lib/fleet/spawn-control.js` (the six verbs, default-OFF behind `FLEET_SPAWN_CONTROL_LIVE` mirroring `WORKER_SPAWN_EXECUTOR_LIVE`).
- `relaunch-under-profile` isolates `CLAUDE_CONFIG_DIR` injection to the spawned child's env only, with a runtime assertion the supervisor's own `process.env` is never mutated.
- `drain-and-restart` never busy-waits — defers to the caller's own tick cadence on a MISS/UNKNOWN boundary-probe verdict, matching every other `evaluateClaimBoundary()` consumer in this codebase.
- FR-10: `session-watchdog.js`'s AUTH-LOST remediation string now names the real `relaunchUnderProfile()` verb.
- An independent TESTING sub-agent EXEC-phase review caught 3 real gaps (FR-5 dedup never wired, FR-9's event payload had an unenforced open extension point, FR-6 missing a grep-pin test) — all fixed in a follow-up commit.

## Test plan
- [x] 65 new unit tests across `window-handle`, `session-registry-adapter`, `spawn-control` — all passing
- [x] `npx vitest run tests/unit/fleet/` — 667/667 passing, 0 regressions
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all new/modified files — clean
- [x] Live OS-spawn surface remains default-OFF behind `FLEET_SPAWN_CONTROL_LIVE` (never exercised against a real Windows Terminal in this session — flagged in the retrospective as a follow-up requiring operator host validation, matching the existing `worker-spawn-executor.cjs` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)