### PR TITLE
fix(QF-20260720-887): Adam harness governance briefing uses exact count, not capped rows

### DIFF
--- a/lib/adam/briefings/harness.js
+++ b/lib/adam/briefings/harness.js
@@ -12,7 +12,6 @@
  * O-GOV objective). A signal whose mapped objective has NO live KR is EXCLUDED —
  * never given a fabricated anchor. hasLiveAnchor() therefore passes legitimately.
  */
-import { warnIfCapTruncated } from '../../db/fetch-all-paginated.mjs';
 
 /**
  * Static class -> O-GOV objective-code mapping. Each harness signal class is
@@ -135,7 +134,7 @@ export function buildCandidateFromSignal({
  * into scored candidate objects. PURE + DB-free (fully unit-testable).
  *
  * @param {object} args
- * @param {Array} [args.backlog]   feedback rows (harness_backlog)
+ * @param {Array|number} [args.backlog]   harness_backlog rows (legacy) OR an exact count
  * @param {Array} [args.retros]
  * @param {Array} [args.gateRecs]  gate-tuning recommendation rows
  * @param {Array} [args.evaRecs]   pending EVA consultant recs
@@ -148,6 +147,10 @@ export function summarizeHarness({
   evaRecs = [],
   krByObjective = new Map(),
 } = {}) {
+  // QF-20260720-887: backlog arrives as an array (legacy callers / unit tests) OR an exact
+  // count number (briefHarness now passes a head:true count:'exact' total immune to the
+  // PostgREST 1000-row cap). Normalize to a number either way — never a capped rows.length.
+  const backlogCount = Array.isArray(backlog) ? backlog.length : (Number(backlog) || 0);
   // Only gate-tuning recs that recommend an ACTUAL threshold change are actionable;
   // MONITOR rows are not a governance opportunity.
   const actionableGateRecs = (gateRecs || []).filter(
@@ -159,7 +162,7 @@ export function summarizeHarness({
   );
 
   const signals = {
-    open_harness_backlog: backlog.length,
+    open_harness_backlog: backlogCount,
     recent_retros: retros.length,
     gate_tuning_recs: gateRecs.length,
     actionable_gate_recs: actionableGateRecs.length,
@@ -174,13 +177,13 @@ export function summarizeHarness({
       signalClass: 'harness-backlog',
       objectiveCode: SIGNAL_CLASS_TO_OBJECTIVE['harness-backlog'],
       krRows: get(SIGNAL_CLASS_TO_OBJECTIVE['harness-backlog']),
-      count: backlog.length,
+      count: backlogCount,
       contribution_type: 'enabling',
       confidence: 0.6,
       dedup_key: 'harness-backlog-cleanup',
       copy: {
-        opportunity: `Burn down the open harness backlog (${backlog.length} item${backlog.length === 1 ? '' : 's'}) to advance Foundation Cleanup.`,
-        evidence: `feedback(category=harness_backlog,status=new) holds ${backlog.length} unresolved harness signal${backlog.length === 1 ? '' : 's'}.`,
+        opportunity: `Burn down the open harness backlog (${backlogCount} item${backlogCount === 1 ? '' : 's'}) to advance Foundation Cleanup.`,
+        evidence: `feedback(category=harness_backlog,status=new) holds ${backlogCount} unresolved harness signal${backlogCount === 1 ? '' : 's'}.`,
         rationale: 'A scoped cleanup SD reduces accumulated process/cleanup debt against the Foundation Cleanup KR.',
         risk: 'Some backlog items may be stale or already-superseded; triage before scoping.',
         counterfactual: 'If left to accumulate, the backlog grows and the cleanup KR drifts further from target.',
@@ -265,9 +268,18 @@ export async function fetchKrByObjective(supabase) {
 }
 
 export async function briefHarness(supabase) {
-  const backlog = await safe(async () =>
-    warnIfCapTruncated((await supabase.from('feedback').select('id').eq('category', 'harness_backlog').eq('status', 'new')).data, 'lib/adam/briefings/harness.js:269')
-  );
+  // QF-20260720-887: exact count via head:true + count:'exact'. The prior select('id')
+  // row-fetch silently capped at PostgREST's 1000-row default, truncating the harness-backlog
+  // count on any table >1000 rows (the count-discipline cap-truncation class). head:true
+  // returns NO rows and an exact total, so there is nothing to truncate — no cap guard needed.
+  const backlog = await safe(async () => {
+    const { count } = await supabase
+      .from('feedback')
+      .select('id', { count: 'exact', head: true })
+      .eq('category', 'harness_backlog')
+      .eq('status', 'new');
+    return count ?? 0;
+  });
   const retros = await safe(async () =>
     (await supabase.from('retrospectives').select('id').order('created_at', { ascending: false }).limit(20)).data
   );

--- a/tests/unit/adam/briefings.test.js
+++ b/tests/unit/adam/briefings.test.js
@@ -18,6 +18,12 @@ describe('summarizeHarness', () => {
     const r = summarizeHarness();
     expect(r.signals.open_harness_backlog).toBe(0);
   });
+  it('accepts an exact count number for backlog (QF-20260720-887 cap-safe count path)', () => {
+    // briefHarness now passes a head:true count:'exact' total (a number) instead of a
+    // capped rows array, so a value beyond the old 1000-row cap is reported faithfully.
+    expect(summarizeHarness({ backlog: 1500 }).signals.open_harness_backlog).toBe(1500);
+    expect(summarizeHarness({ backlog: 0 }).signals.open_harness_backlog).toBe(0);
+  });
 });
 
 describe('summarizePlatform', () => {


### PR DESCRIPTION
## QF-20260720-887 — harness governance briefing 1000-row cap

**Symptom:** `node scripts/adam-opportunity-scan.cjs --scan` logs a count-discipline warning — `lib/adam/briefings/harness.js:269` fetch returned **exactly 1000 rows** (PostgREST default cap), so the harness-scope governance briefing silently under-counts the backlog and can emit `ADAM_OK` on a truncated view.

### Root cause
`briefHarness` fetched `feedback(category=harness_backlog,status=new)` with `select('id')` and downstream `summarizeHarness` counted `backlog.length`. On the harness_backlog table (>3000 rows), the row-fetch caps at 1000 → `rows.length` lies. Classic count-discipline cap-truncation.

### Fix
- **`briefHarness`**: replace the capped row-fetch with a `head:true` + `count:'exact'` query — returns the exact total and **no rows**, so there is nothing to truncate. The `warnIfCapTruncated` guard (and its now-unused import) are removed on this path.
- **`summarizeHarness`**: normalize `backlog` to a count — `Array.isArray(backlog) ? backlog.length : (Number(backlog) || 0)` — so the **legacy array callers/tests** and the **new count-number path** both work (backward-compatible interface).

### Acceptance
- The briefing reads an accurate count with no silent 1000-row truncation; the warning no longer fires on a >1000-row table. ✔
- **Tests:** existing array-path tests unchanged (21 pass); new test asserts a number input (`1500`) is reported faithfully as the count.

### Scope
2 files, ~21 source additions. Est LOC 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)