### PR TITLE
feat(SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A): F1 LEAD-FINAL surfaces retro known-issues

### DIFF
--- a/.prd-payloads/PRD-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A.json
+++ b/.prd-payloads/PRD-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A.json
@@ -1,0 +1,104 @@
+{
+  "executive_summary": "LEAD-FINAL-APPROVAL's canonical accepted sd_phase_handoffs row hardcodes known_issues to 'None at approval time' unconditionally at two write sites (the primary pre-completion writer at index.js:468, and the resume/reconcile writer at index.js's _reconcileCanonicalLfaRow), regardless of what the SD's own SD_COMPLETION retrospective actually says. This SD wires both writers to read the SD's retrospective via the existing getFilteredRetrospective() helper, filters out boilerplate via the existing RetrospectiveQualityRubric.detectBoilerplate() detector, and surfaces genuine caveats into known_issues -- closing Solomon checkpoint-3's F1 finding that the known-issues channel fails CLOSED instead of failing OPEN.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Extract a shared retro-known-issues helper",
+      "description": "Add a function (e.g. extractRetroKnownIssues(sd, supabase)) to scripts/modules/handoff/executors/lead-final-approval/index.js (or a shared sibling file) that: calls getFilteredRetrospective(sd.id, sd.created_at || null, supabase, sd.sd_key || null) (reusing the existing helper -- no new query); if a retrospective is returned, reads what_needs_improvement, dereferences each item as typeof item === 'string' ? item : (item.improvement || item) (existing shape-handling pattern from pre-handoff-warnings.js:186, since items are sometimes {improvement, is_boilerplate} objects); runs RetrospectiveQualityRubric.detectBoilerplate() (scripts/modules/rubrics/retrospective-quality-rubric.js) against the retrospective and drops items that are pure boilerplate; returns an array of {issue: <text>} objects for known_issues, or the existing fallback [{issue: 'None at approval time'}] when nothing genuine remains (no retro, empty list, or 100% boilerplate).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "extractRetroKnownIssues() reuses getFilteredRetrospective -- no duplicate/new retrospective query is introduced",
+        "Both plain-string and {improvement: '...'} object shapes in what_needs_improvement are handled without throwing",
+        "A retro with only boilerplate what_needs_improvement entries yields the fallback [{issue: 'None at approval time'}]"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Wire the primary pre-completion writer (index.js:468)",
+      "description": "Replace the hardcoded known_issues: [{ issue: 'None at approval time' }] at line 468 with a call to extractRetroKnownIssues(sd, this.supabase), awaited before the insert() call. Wrap in try/catch (or rely on extractRetroKnownIssues's own internal fail-open) so a retro-read failure NEVER blocks or fails the canonical write -- fall back to the existing hardcoded value on any error.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "An SD whose retro has genuine non-boilerplate what_needs_improvement entries shows those entries (not the placeholder) in the canonical row's known_issues",
+        "An SD with a clean/boilerplate-only retro, or no retro, still gets 'None at approval time' -- fallback preserved exactly as before",
+        "A simulated retro-read error does not fail or block the canonical write or the overall LEAD-FINAL-APPROVAL result"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Wire the resume/reconcile writer (_reconcileCanonicalLfaRow)",
+      "description": "Extend _reconcileCanonicalLfaRow's known_issues write to ALSO surface retro known-issues, using the same extractRetroKnownIssues() helper, while preserving its existing honest provenance context. Combine both: known_issues should include both the surfaced retro caveats (if any) AND the existing 'Row synthesized at verify-time...' provenance note, not replace one with the other -- both are true and useful simultaneously.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "The resume/reconcile path also surfaces genuine retro caveats when they exist, not just the primary writer",
+        "The existing 'Row synthesized at verify-time...' provenance message is preserved (not dropped) alongside any surfaced caveats",
+        "A resume-path SD with a clean retro still gets the original single provenance-only known_issues content, unchanged from current behavior"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "No new query -- reuse getFilteredRetrospective", "description": "scripts/modules/handoff/retro-filters.js's getFilteredRetrospective() is the single source of truth for 'the SD's latest SD_COMPLETION retro' -- both new call sites use it, matching the exact call signature already used at gates.js:397." },
+    { "id": "TR-2", "title": "Reuse the canonical boilerplate detector", "description": "RetrospectiveQualityRubric.detectBoilerplate() (scripts/modules/rubrics/retrospective-quality-rubric.js) is the actively-enforced boilerplate list -- do not hand-write a new deny-list." },
+    { "id": "TR-3", "title": "Fail-open, never fail-closed on this new read", "description": "This executor is the SINGLE canonical completion path for every SD in the fleet. Any error reading/parsing the retrospective must fall back silently to the existing hardcoded known_issues value -- it must NEVER become a new reason LEAD-FINAL-APPROVAL fails or blocks." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Retro with genuine non-boilerplate caveat", "type": "unit", "expected": "extractRetroKnownIssues() returns the caveat text, not the placeholder" },
+    { "id": "TS-2", "scenario": "Retro with only boilerplate what_needs_improvement", "type": "unit", "expected": "extractRetroKnownIssues() returns the fallback [{issue: 'None at approval time'}]" },
+    { "id": "TS-3", "scenario": "No retrospective exists for the SD", "type": "unit", "expected": "extractRetroKnownIssues() returns the fallback, no error thrown" },
+    { "id": "TS-4", "scenario": "what_needs_improvement item is an object {improvement: '...'} not a string", "type": "unit", "expected": "The object is dereferenced correctly, not stringified as [object Object] or thrown" },
+    { "id": "TS-5", "scenario": "getFilteredRetrospective throws/errors", "type": "unit", "expected": "extractRetroKnownIssues() catches and falls back to the placeholder -- never propagates the error" },
+    { "id": "TS-6", "scenario": "Primary writer (index.js:468) integration with a seeded retro caveat", "type": "integration", "expected": "The canonical sd_phase_handoffs row's known_issues field contains the caveat" },
+    { "id": "TS-7", "scenario": "Resume/reconcile writer with a seeded retro caveat", "type": "integration", "expected": "known_issues contains BOTH the caveat AND the existing 'Row synthesized at verify-time...' provenance text" }
+  ],
+  "acceptance_criteria": [
+    "LEAD-FINAL surfaces retro known-issues (F1): an SD whose retro records a known gap shows that gap at LEAD-FINAL approval -- never 'None at approval time' against a non-empty, non-boilerplate retro known-issues list",
+    "Boilerplate-only or missing retros still fall back to 'None at approval time' -- the fallback stays meaningful",
+    "No retro-read failure ever blocks or fails LEAD-FINAL-APPROVAL for any SD",
+    "Both the primary and resume/reconcile canonical writers surface retro known-issues, not just one (avoiding a partial fix)"
+  ],
+  "risks": [
+    { "risk": "A retro-read failure (DB error, malformed row) could accidentally block LEAD-FINAL-APPROVAL for every SD fleet-wide -- this executor is the single canonical completion path", "mitigation": "extractRetroKnownIssues wraps its own logic in try/catch and returns the existing fallback on ANY failure; FR-2/FR-3 never let the new read become a new failure mode for approval itself", "severity": "high" },
+    { "risk": "This SD's own LEAD-FINAL-APPROVAL run is the first live exercise of this new code path -- a bug here could block THIS SD from completing", "mitigation": "Extensive unit test coverage (TS-1..TS-7) before EXEC-TO-PLAN; fail-open design means even a bug degrades to the pre-existing (safe, known) hardcoded behavior, not a hard failure", "severity": "medium" }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "Every SD reaching LEAD-FINAL-APPROVAL fleet-wide -- this is the canonical, universal completion path"
+    ],
+    "dependencies": [
+      "scripts/modules/handoff/retro-filters.js getFilteredRetrospective() (existing -- direction: this SD calls it, read-only)",
+      "scripts/modules/rubrics/retrospective-quality-rubric.js RetrospectiveQualityRubric.detectBoilerplate() (existing -- direction: this SD calls it, read-only)",
+      "retrospectives table (existing -- direction: read-only; failure_mode: any read error falls back to the pre-existing hardcoded known_issues value per TR-3)"
+    ],
+    "data_contracts": [
+      "sd_phase_handoffs.known_issues (existing JSONB column) -- shape unchanged ([{issue: string}] array), only the CONTENT written changes from always-hardcoded to retro-derived-when-genuine"
+    ],
+    "runtime_config": ["No new env vars or flags required"],
+    "observability_rollout": [
+      "Rollout is observed by comparing known_issues content across newly-completed SDs' canonical rows before/after this change -- a query filtering known_issues NOT LIKE '%None at approval time%' shows adoption",
+      "Rollback: revert the two call sites back to the hardcoded literal; no data migration needed since this only affects new rows going forward"
+    ]
+  },
+  "system_architecture": {
+    "summary": "A new extractRetroKnownIssues(sd, supabase) helper, called from both existing canonical-write sites in lead-final-approval/index.js, composing two already-existing pure functions (getFilteredRetrospective, RetrospectiveQualityRubric.detectBoilerplate).",
+    "components": [
+      { "name": "scripts/modules/handoff/executors/lead-final-approval/index.js", "change": "MODIFIED -- new extractRetroKnownIssues() helper function + 2 call sites (line ~468 primary writer, _reconcileCanonicalLfaRow resume writer)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Add the shared helper first with full unit test coverage (fail-open by construction), then wire both call sites, then verify with an integration test seeding a real retro caveat.",
+    "steps": [
+      "Implement extractRetroKnownIssues(sd, supabase) composing getFilteredRetrospective + RetrospectiveQualityRubric.detectBoilerplate + the string-or-object dereference pattern",
+      "Write unit tests TS-1..TS-5 against the helper in isolation (mocked supabase client)",
+      "Wire FR-2 (primary writer, line ~468)",
+      "Wire FR-3 (resume/reconcile writer)",
+      "Write integration tests TS-6/TS-7"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Seed a test SD's retro with a genuine what_needs_improvement caveat, then run LEAD-FINAL-APPROVAL for that SD", "expected_outcome": "The canonical sd_phase_handoffs row's known_issues field contains the caveat text, not 'None at approval time'" },
+    { "step_number": 2, "instruction": "Run LEAD-FINAL-APPROVAL for an SD whose retro's what_needs_improvement is only boilerplate entries", "expected_outcome": "known_issues still reads 'None at approval time' -- fallback preserved" },
+    { "step_number": 3, "instruction": "Run LEAD-FINAL-APPROVAL for an SD with zero retrospective rows", "expected_outcome": "Approval completes successfully (fail-open); known_issues falls back to the placeholder, no error/block" }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A"
+  }
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -41,6 +41,10 @@ import { getWorkflowForType } from '../../cli/workflow-definitions.js';
 // UPDATE + loser-side pre-insert cleanup (post-merge automation vs worker race).
 import { attemptCasCompletion, cleanupLosingPreInsert } from './cas-completion.js';
 
+// SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A (F1): surface the SD's genuine retro
+// known-issues instead of a hardcoded placeholder. Non-throwing by construction (see module doc).
+import { extractRetroKnownIssues, combineKnownIssuesWithProvenance } from './retro-known-issues.js';
+
 /**
  * Auto-rescore the original SD after a corrective SD completes.
  * SD-MAN-INFRA-VISION-RESCORE-ON-COMPLETION-001
@@ -454,6 +458,9 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         .limit(1)
         .maybeSingle();
       if (!existingLfa) {
+        // F1: surface genuine retro known-issues instead of the hardcoded placeholder.
+        // extractRetroKnownIssues never throws (fail-open) -- see retro-known-issues.js.
+        const knownIssues = await extractRetroKnownIssues(sd, this.supabase);
         const { error: canonErr } = await this.supabase
           .from('sd_phase_handoffs')
           .insert({
@@ -465,7 +472,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
             executive_summary: `LEAD-FINAL-APPROVAL accepted for ${sd.sd_key || sd.id} (score ${normalizedScore}). Canonical row written pre-completion while the session claim is live (SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001); full validation detail on the leo_handoff_executions row.`,
             deliverables_manifest: { items: [{ name: 'final approval accepted', status: 'completed' }] },
             key_decisions: [{ decision: `Final approval granted (validation score ${normalizedScore})` }],
-            known_issues: [{ issue: 'None at approval time' }],
+            known_issues: knownIssues,
             resource_utilization: { execution_table: 'leo_handoff_executions' },
             action_items: [{ item: 'None — SD lifecycle complete; post-completion tail follows' }],
             completeness_report: { validation_score: normalizedScore },
@@ -968,6 +975,13 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         ? lheRows[0].validation_score
         : (gateResults && gateResults.actualScore != null ? gateResults.actualScore : 100);
 
+      // F1/FR-3: surface genuine retro known-issues on the resume/reconcile path too, combined
+      // with (never replacing) the existing honest provenance note. combineKnownIssuesWithProvenance
+      // drops the placeholder when the retro is clean, so a clean SD's known_issues is unchanged.
+      const retroKnownIssues = await extractRetroKnownIssues(sd, this.supabase);
+      const provenanceIssue = { issue: 'Row synthesized at verify-time; original completion-time gate context lives on the leo_handoff_executions execution row' };
+      const known_issues = combineKnownIssuesWithProvenance(retroKnownIssues, provenanceIssue);
+
       const { error: insErr } = await this.supabase
         .from('sd_phase_handoffs')
         .insert({
@@ -979,7 +993,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
           executive_summary: `Canonical LFA row reconciled for already-completed SD ${sd.sd_key || sd.id} (score ${srcScore}). Completion took the already-completed / resume-from-checkpoint path which skipped the pre-completion canonical writer; this idempotent reconcile clears the v_sd_completion_integrity ghost (SD-REFILL-0038AO42).`,
           deliverables_manifest: { items: [{ name: 'canonical LFA row reconciled (resume/already-completed path)', status: 'completed' }] },
           key_decisions: [{ decision: `Canonical row reconciled from accepted leo_handoff_executions${srcId ? ` ${srcId}` : ''} (score ${srcScore})` }],
-          known_issues: [{ issue: 'Row synthesized at verify-time; original completion-time gate context lives on the leo_handoff_executions execution row' }],
+          known_issues,
           resource_utilization: { execution_table: 'leo_handoff_executions', source_execution_id: srcId },
           action_items: [{ item: 'None — historical reconciliation; the already-completed path now self-heals via this branch' }],
           completeness_report: { validation_score: srcScore, source: 'leo_handoff_executions' },

--- a/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
@@ -40,13 +40,15 @@ export function isGenuineCaveat(text) {
   return true;
 }
 
+/**
+ * SECURITY review (EXEC-TO-PLAN): reference equality, not string content equality. A genuine
+ * retro caveat whose text happens to literally read "None at approval time" would otherwise be
+ * misdetected as the fallback via a content match. extractRetroKnownIssues() always returns the
+ * SAME NO_ISSUES_FALLBACK reference in its fallback path (never reconstructs an equivalent array),
+ * so identity comparison is both correct for the real call chain and immune to the string collision.
+ */
 export function isFallbackKnownIssues(knownIssues) {
-  return (
-    Array.isArray(knownIssues) &&
-    knownIssues.length === 1 &&
-    knownIssues[0] &&
-    knownIssues[0].issue === NO_ISSUES_FALLBACK[0].issue
-  );
+  return knownIssues === NO_ISSUES_FALLBACK;
 }
 
 /**

--- a/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
@@ -12,7 +12,11 @@
 import { getFilteredRetrospective } from '../../retro-filters.js';
 import { RetrospectiveQualityRubric } from '../../../rubrics/retrospective-quality-rubric.js';
 
-export const NO_ISSUES_FALLBACK = [{ issue: 'None at approval time' }];
+// Adversarial review: frozen so no future consumer can mutate this shared singleton (it is
+// returned by reference across every SD completion in a long-lived fleet process) and
+// accidentally corrupt the fallback -- or the reference-equality check in isFallbackKnownIssues
+// -- for every subsequent completion.
+export const NO_ISSUES_FALLBACK = Object.freeze([Object.freeze({ issue: 'None at approval time' })]);
 
 // Boilerplate detection reuses RetrospectiveQualityRubric.BOILERPLATE_PATTERNS PER-ITEM, not the
 // aggregate detectBoilerplate(retrospective) method -- that method returns ONE hasBoilerplate flag

--- a/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js
@@ -1,0 +1,88 @@
+/**
+ * F1: LEAD-FINAL surfaces retro known-issues instead of a hardcoded placeholder.
+ * SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A (Solomon checkpoint-3 verdict 2ef435e1).
+ *
+ * Isolated in its own module (not inline in index.js) so the logic that matters -- what counts
+ * as a "genuine" caveat vs boilerplate, and the fail-open contract -- is directly unit-testable
+ * without mocking the whole 1000-line LeadFinalApprovalExecutor. index.js's two write sites call
+ * only extractRetroKnownIssues() / combineKnownIssuesWithProvenance(), both non-throwing by
+ * construction: this executor is the SINGLE canonical completion path for every SD in the fleet,
+ * so a bug here must degrade to the pre-existing safe fallback, never become a new failure mode.
+ */
+import { getFilteredRetrospective } from '../../retro-filters.js';
+import { RetrospectiveQualityRubric } from '../../../rubrics/retrospective-quality-rubric.js';
+
+export const NO_ISSUES_FALLBACK = [{ issue: 'None at approval time' }];
+
+// Boilerplate detection reuses RetrospectiveQualityRubric.BOILERPLATE_PATTERNS PER-ITEM, not the
+// aggregate detectBoilerplate(retrospective) method -- that method returns ONE hasBoilerplate flag
+// across 5 fields (what_went_well, what_needs_improvement, key_learnings, action_items,
+// improvement_areas), so a boilerplate match in an unrelated field (e.g. what_went_well) would
+// incorrectly suppress a genuine what_needs_improvement caveat -- re-introducing the exact
+// fail-CLOSED bug this SD exists to fix.
+const SUPPLEMENTARY_NOISE_PATTERNS = [
+  /no specific issues identified/i,
+  /no significant challenges/i,
+  /handoff executed smoothly/i,
+];
+
+/** what_needs_improvement items are sometimes plain strings, sometimes {improvement, ...} objects. */
+export function dereferenceImprovementItem(item) {
+  if (typeof item === 'string') return item;
+  if (item && typeof item === 'object') return item.improvement || JSON.stringify(item);
+  return item == null ? '' : String(item);
+}
+
+export function isGenuineCaveat(text) {
+  if (!text || typeof text !== 'string' || !text.trim()) return false;
+  if (RetrospectiveQualityRubric.BOILERPLATE_PATTERNS.some((re) => re.test(text))) return false;
+  if (SUPPLEMENTARY_NOISE_PATTERNS.some((re) => re.test(text))) return false;
+  return true;
+}
+
+export function isFallbackKnownIssues(knownIssues) {
+  return (
+    Array.isArray(knownIssues) &&
+    knownIssues.length === 1 &&
+    knownIssues[0] &&
+    knownIssues[0].issue === NO_ISSUES_FALLBACK[0].issue
+  );
+}
+
+/**
+ * FR-1: the SD's genuine retro known-issues, or the existing fallback. NEVER throws -- any error
+ * (retro-read exception, malformed row, getFilteredRetrospective returning {error, retrospective:
+ * null}) falls back to NO_ISSUES_FALLBACK, matching the pre-existing hardcoded behavior exactly.
+ */
+export async function extractRetroKnownIssues(sd, supabase) {
+  try {
+    const { retrospective } = await getFilteredRetrospective(
+      sd && sd.id,
+      (sd && sd.created_at) || null,
+      supabase,
+      (sd && sd.sd_key) || null
+    );
+    if (!retrospective || !Array.isArray(retrospective.what_needs_improvement)) {
+      return NO_ISSUES_FALLBACK;
+    }
+    const genuine = retrospective.what_needs_improvement
+      .map(dereferenceImprovementItem)
+      .filter(isGenuineCaveat);
+    if (genuine.length === 0) return NO_ISSUES_FALLBACK;
+    return genuine.map((issue) => ({ issue }));
+  } catch {
+    return NO_ISSUES_FALLBACK;
+  }
+}
+
+/**
+ * FR-3: the resume/reconcile writer's known_issues combine both a surfaced retro caveat (if any)
+ * AND the existing honest provenance note -- never dropping one for the other. When the retro is
+ * clean (extractRetroKnownIssues returns only the fallback), the placeholder is DROPPED so the
+ * result is exactly the single provenance-only entry the resume path already wrote before this SD
+ * (no regression for clean SDs).
+ */
+export function combineKnownIssuesWithProvenance(retroKnownIssues, provenanceIssue) {
+  if (isFallbackKnownIssues(retroKnownIssues)) return [provenanceIssue];
+  return [...retroKnownIssues, provenanceIssue];
+}

--- a/tests/unit/handoff/executors/lead-final-approval/retro-known-issues.test.js
+++ b/tests/unit/handoff/executors/lead-final-approval/retro-known-issues.test.js
@@ -84,9 +84,8 @@ describe('isGenuineCaveat', () => {
 });
 
 describe('isFallbackKnownIssues', () => {
-  it('recognizes the exact fallback shape', () => {
+  it('recognizes the fallback via reference identity (the only shape extractRetroKnownIssues actually returns)', () => {
     expect(isFallbackKnownIssues(NO_ISSUES_FALLBACK)).toBe(true);
-    expect(isFallbackKnownIssues([{ issue: 'None at approval time' }])).toBe(true);
   });
 
   it('does not misfire on a genuine single-item list', () => {
@@ -95,6 +94,13 @@ describe('isFallbackKnownIssues', () => {
 
   it('does not misfire on a multi-item list', () => {
     expect(isFallbackKnownIssues([{ issue: 'a' }, { issue: 'b' }])).toBe(false);
+  });
+
+  it('SECURITY fix: a genuine caveat whose text happens to equal the fallback string is NOT misdetected (reference, not content, equality)', () => {
+    // A freshly-constructed array with matching CONTENT is not the same reference as
+    // NO_ISSUES_FALLBACK -- this is the exact collision the SECURITY review flagged as a risk
+    // under the old strict-string-equality implementation.
+    expect(isFallbackKnownIssues([{ issue: 'None at approval time' }])).toBe(false);
   });
 });
 

--- a/tests/unit/handoff/executors/lead-final-approval/retro-known-issues.test.js
+++ b/tests/unit/handoff/executors/lead-final-approval/retro-known-issues.test.js
@@ -1,0 +1,203 @@
+/**
+ * SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A (F1) -- covers PRD TS-1..TS-7 plus the 6
+ * gaps the TESTING sub-agent flagged during PLAN-TO-EXEC review: GAP-1 (write-site fail-open,
+ * proven here by extractRetroKnownIssues never throwing), GAP-2 (reconcile clean-retro
+ * regression), GAP-3 (aggregate-detector over-suppression -- boilerplate in an unrelated field
+ * must not hide a genuine caveat), GAP-4 (mixed genuine+boilerplate list, >100-char item), GAP-5
+ * (both getFilteredRetrospective failure modes: throw, and returned {error}), GAP-6 (write-site
+ * behavior tested via the directly-exported, non-DB functions rather than live integration).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../scripts/modules/handoff/retro-filters.js', () => ({
+  getFilteredRetrospective: vi.fn(),
+}));
+
+import { getFilteredRetrospective } from '../../../../../scripts/modules/handoff/retro-filters.js';
+import {
+  NO_ISSUES_FALLBACK,
+  dereferenceImprovementItem,
+  isGenuineCaveat,
+  isFallbackKnownIssues,
+  extractRetroKnownIssues,
+  combineKnownIssuesWithProvenance,
+} from '../../../../../scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js';
+
+const SD = { id: 'sd-uuid-1', created_at: '2026-01-01T00:00:00Z', sd_key: 'SD-TEST-001' };
+const SUPABASE = {};
+
+beforeEach(() => {
+  getFilteredRetrospective.mockReset();
+});
+
+describe('dereferenceImprovementItem', () => {
+  it('passes through plain strings', () => {
+    expect(dereferenceImprovementItem('a real caveat')).toBe('a real caveat');
+  });
+
+  it('extracts .improvement from object-shaped items', () => {
+    expect(dereferenceImprovementItem({ improvement: 'the caveat text', is_boilerplate: false })).toBe(
+      'the caveat text'
+    );
+  });
+
+  it('falls back to JSON.stringify for an object with no .improvement key', () => {
+    expect(dereferenceImprovementItem({ foo: 'bar' })).toBe('{"foo":"bar"}');
+  });
+
+  it('handles null/undefined without throwing', () => {
+    expect(dereferenceImprovementItem(null)).toBe('');
+    expect(dereferenceImprovementItem(undefined)).toBe('');
+  });
+});
+
+describe('isGenuineCaveat', () => {
+  it('rejects empty/whitespace-only text', () => {
+    expect(isGenuineCaveat('')).toBe(false);
+    expect(isGenuineCaveat('   ')).toBe(false);
+    expect(isGenuineCaveat(null)).toBe(false);
+  });
+
+  it('rejects known BOILERPLATE_PATTERNS phrasing', () => {
+    expect(isGenuineCaveat('improve communication going forward')).toBe(false);
+    expect(isGenuineCaveat('continue monitoring for improvement')).toBe(false);
+    expect(isGenuineCaveat('maintain momentum on this initiative')).toBe(false);
+  });
+
+  it('rejects the supplementary no-issues-identified family', () => {
+    expect(isGenuineCaveat('No specific issues identified - handoff executed smoothly')).toBe(false);
+    expect(isGenuineCaveat('No significant challenges encountered')).toBe(false);
+  });
+
+  it('accepts a genuine, specific caveat', () => {
+    expect(
+      isGenuineCaveat('FR-4 negative back-propagation ships with 0 live exact-matches today -- currently unexercised')
+    ).toBe(true);
+  });
+
+  it('accepts a genuine caveat longer than 100 chars (GAP-4: truncation must not affect per-item filtering)', () => {
+    const longCaveat =
+      'This is a genuinely specific finding that exceeds one hundred characters in length to verify the filter still works correctly end to end';
+    expect(longCaveat.length).toBeGreaterThan(100);
+    expect(isGenuineCaveat(longCaveat)).toBe(true);
+  });
+});
+
+describe('isFallbackKnownIssues', () => {
+  it('recognizes the exact fallback shape', () => {
+    expect(isFallbackKnownIssues(NO_ISSUES_FALLBACK)).toBe(true);
+    expect(isFallbackKnownIssues([{ issue: 'None at approval time' }])).toBe(true);
+  });
+
+  it('does not misfire on a genuine single-item list', () => {
+    expect(isFallbackKnownIssues([{ issue: 'a real caveat' }])).toBe(false);
+  });
+
+  it('does not misfire on a multi-item list', () => {
+    expect(isFallbackKnownIssues([{ issue: 'a' }, { issue: 'b' }])).toBe(false);
+  });
+});
+
+describe('extractRetroKnownIssues -- TS-1..TS-5, GAP-1, GAP-3, GAP-4', () => {
+  it('TS-1: returns the genuine caveat when what_needs_improvement has real content', async () => {
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: { what_needs_improvement: ['FR-4 ships with 0 live exact-matches today -- unexercised'] },
+      error: null,
+    });
+    const result = await extractRetroKnownIssues(SD, SUPABASE);
+    expect(result).toEqual([{ issue: 'FR-4 ships with 0 live exact-matches today -- unexercised' }]);
+  });
+
+  it('TS-2: falls back when what_needs_improvement is only boilerplate', async () => {
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: { what_needs_improvement: ['improve communication', 'continue monitoring for improvement'] },
+      error: null,
+    });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual(NO_ISSUES_FALLBACK);
+  });
+
+  it('TS-3: falls back when no retrospective exists', async () => {
+    getFilteredRetrospective.mockResolvedValue({ retrospective: null, error: null });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual(NO_ISSUES_FALLBACK);
+  });
+
+  it('TS-4: handles object-shaped what_needs_improvement items', async () => {
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: { what_needs_improvement: [{ improvement: 'a real object-shaped caveat', is_boilerplate: false }] },
+      error: null,
+    });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual([{ issue: 'a real object-shaped caveat' }]);
+  });
+
+  it('TS-5a (GAP-5): falls back when getFilteredRetrospective throws -- never propagates (GAP-1)', async () => {
+    getFilteredRetrospective.mockRejectedValue(new Error('simulated DB outage'));
+    await expect(extractRetroKnownIssues(SD, SUPABASE)).resolves.toEqual(NO_ISSUES_FALLBACK);
+  });
+
+  it('TS-5b (GAP-5): falls back when getFilteredRetrospective resolves with {error, retrospective:null} (its actual non-throwing failure shape)', async () => {
+    getFilteredRetrospective.mockResolvedValue({ retrospective: null, error: { message: 'query failed' } });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual(NO_ISSUES_FALLBACK);
+  });
+
+  it('GAP-3: a genuine what_needs_improvement caveat survives even when boilerplate-style text appears elsewhere', async () => {
+    // Deliberately does NOT call the aggregate detectBoilerplate(retrospective) -- only
+    // what_needs_improvement content is inspected, so a generic what_went_well entry never
+    // suppresses a genuine what_needs_improvement caveat.
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: {
+        what_went_well: ['maintain momentum on this initiative'], // boilerplate, unrelated field
+        what_needs_improvement: ['FR-4 negative back-propagation ships with 0 live exact-matches today'],
+      },
+      error: null,
+    });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual([
+      { issue: 'FR-4 negative back-propagation ships with 0 live exact-matches today' },
+    ]);
+  });
+
+  it('GAP-4: a mixed list of genuine + boilerplate items keeps only the genuine one', async () => {
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: {
+        what_needs_improvement: [
+          'continue monitoring for improvement', // boilerplate
+          'FR-4 negative back-propagation ships with 0 live exact-matches today', // genuine
+          'improve communication going forward', // boilerplate
+        ],
+      },
+      error: null,
+    });
+    expect(await extractRetroKnownIssues(SD, SUPABASE)).toEqual([
+      { issue: 'FR-4 negative back-propagation ships with 0 live exact-matches today' },
+    ]);
+  });
+
+  it('never throws even given a malformed sd argument (defensive)', async () => {
+    getFilteredRetrospective.mockResolvedValue({ retrospective: null, error: null });
+    await expect(extractRetroKnownIssues(null, SUPABASE)).resolves.toEqual(NO_ISSUES_FALLBACK);
+    await expect(extractRetroKnownIssues({}, SUPABASE)).resolves.toEqual(NO_ISSUES_FALLBACK);
+  });
+});
+
+describe('combineKnownIssuesWithProvenance -- FR-3, GAP-2', () => {
+  const provenance = {
+    issue: 'Row synthesized at verify-time; original completion-time gate context lives on the leo_handoff_executions execution row',
+  };
+
+  it('GAP-2: a clean retro yields ONLY the provenance entry -- the placeholder is dropped, not combined', () => {
+    const result = combineKnownIssuesWithProvenance(NO_ISSUES_FALLBACK, provenance);
+    expect(result).toEqual([provenance]);
+    expect(result).toHaveLength(1); // regression guard: must never be [placeholder, provenance]
+  });
+
+  it('a genuine caveat is combined WITH the provenance note, not replacing it', () => {
+    const retroIssues = [{ issue: 'a real caveat' }];
+    const result = combineKnownIssuesWithProvenance(retroIssues, provenance);
+    expect(result).toEqual([{ issue: 'a real caveat' }, provenance]);
+  });
+
+  it('multiple genuine caveats are all preserved alongside the provenance note', () => {
+    const retroIssues = [{ issue: 'caveat one' }, { issue: 'caveat two' }];
+    const result = combineKnownIssuesWithProvenance(retroIssues, provenance);
+    expect(result).toEqual([{ issue: 'caveat one' }, { issue: 'caveat two' }, provenance]);
+  });
+});


### PR DESCRIPTION
## Summary
- Child A of the acceptance-record-integrity orchestrator (SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001), fixing Solomon checkpoint-3's F1 finding: LEAD-FINAL-APPROVAL's canonical accepted `sd_phase_handoffs` row hardcoded `known_issues` to a fixed `'None at approval time'` placeholder at **both** its canonical write sites, regardless of what the SD's actual retrospective candidly recorded. Confirmed empirically against a real sibling SD's retro.
- Adds `lib/fleet` sibling module `scripts/modules/handoff/executors/lead-final-approval/retro-known-issues.js` -- isolated, directly-unit-testable logic (not inline in the 1000-line executor) that reuses the existing `getFilteredRetrospective()` helper, filters genuine caveats per-item against `RetrospectiveQualityRubric.BOILERPLATE_PATTERNS`, and is fail-open by construction (this executor is the single canonical completion path for every SD fleet-wide).
- Two rounds of adversarial sub-agent review: a **pre-implementation** TESTING design review caught 6 real gaps before any code was written (write-site fail-open, a reconcile clean-retro regression, aggregate-boilerplate-detector over-suppression risk, mixed-list filtering, both `getFilteredRetrospective` failure modes, DB-dependent test placement) -- all designed around up front. A **post-implementation** TESTING+SECURITY review both PASSED, with one LOW SECURITY finding (strict string-equality collision in fallback detection) fixed same-session via reference equality.

## Test plan
- [x] `npx vitest run tests/unit/handoff/executors/lead-final-approval/retro-known-issues.test.js` -- 25/25 passing
- [x] `npx vitest run tests/unit/handoff/` -- 82 files, 812/813 passing (1 pre-existing skip), zero regressions
- [x] `npx eslint` on all new/modified files -- clean (one pre-existing, unrelated lint error at index.js:288 left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)