### PR TITLE
fix(QF-20260720-729): Pre-send Solomon consult sends full body via loss-proof capBody

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -89,6 +89,16 @@ function advisoryExpiresAt(nowMs) {
   return new Date(base + ADVISORY_TTL_MS).toISOString();
 }
 
+// QF-20260720-729: build the pre-send Solomon-consult body through the loss-proof capBody
+// primitive (fail-loud on the 4096-char hard cap — the caller must split, never silently clip)
+// instead of a .slice(0, 300) that let Solomon validate only the first 300 chars of the outbound
+// body ('your packet ends mid-sentence at Two; the findings this consult exists FOR are invisible
+// to me' — Solomon advisory 97cf4e3e, recurred ~9x). The prefix is inside the cap so the tail the
+// consult exists to check is never dropped. PURE + exported for tests.
+function buildPreSendConsultBody(body) {
+  return capBody(`[PRE-SEND CONSULT] ${body ?? ''}`);
+}
+
 // SD-REFILL-00XK256L: the 2-hypothesis-bar guard for Adam urgent operational broadcasts. Adam's web-
 // research sweep has TWICE (2026-06-11 stall misdiagnosis; 2026-06-13 advisory 4f6082eb) produced a
 // HALLUCINATED fleet-wide operational alarm — a fabricated "model cutoff" naming a NON-EXISTENT model
@@ -1075,7 +1085,7 @@ async function main() {
             let solomonId = null;
             try { solomonId = await getActiveSolomonId(supabase); } catch { solomonId = null; }
             const correlationId = crypto.randomUUID();
-            const cp = buildSolomonConsultPayload({ correlationId, body: `[PRE-SEND CONSULT] ${payload.body.slice(0, 300)}`, senderCallsign, repo: process.cwd(), severity: 'high', isAwait: true });
+            const cp = buildSolomonConsultPayload({ correlationId, body: buildPreSendConsultBody(payload.body), senderCallsign, repo: process.cwd(), severity: 'high', isAwait: true });
             await insertCoordinationRow(supabase, { sender_session: sessionId, sender_type: 'adam', target_session: solomonId || 'broadcast-solomon', message_type: 'INFO', subject: `[SOLOMON_CONSULT] pre-send`, body: cp.body, payload: cp, expires_at: expiresAt }, { targetRoleHint: 'solomon' });
             const reply = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs: consultTimeoutMs });
             return reply.timedOut ? null : ((reply.reply && (readCanonicalBody(reply.reply) || reply.reply.body)) || { received: true });
@@ -1179,7 +1189,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS, KNOWN_SEND_KINDS };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, buildPreSendConsultBody, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS, KNOWN_SEND_KINDS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/unit/adam-advisory-presend-consult-body.test.js
+++ b/tests/unit/adam-advisory-presend-consult-body.test.js
@@ -1,0 +1,43 @@
+/**
+ * QF-20260720-729 — the pre-send Solomon consult must give Solomon the FULL outbound body
+ * (loss-proof, capBody-bounded, fail-loud on overflow), not a silent .slice(0, 300) fragment.
+ * Solomon flagged the clip directly ('your packet ends mid-sentence at Two; the findings this
+ * consult exists FOR are invisible to me' — advisory 97cf4e3e, recurred ~9x). These tests pin
+ * buildPreSendConsultBody so the truncation cannot silently return.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { buildPreSendConsultBody } = require('../../scripts/adam-advisory.cjs');
+
+describe('buildPreSendConsultBody (QF-20260720-729)', () => {
+  it('preserves the tail beyond char 300 (the old slice(0,300) dropped it)', () => {
+    // Char 300+ was invisible under the bug. VISIBLE_TAIL sits at index ~370 — it MUST survive.
+    const body = 'x'.repeat(350) + 'VISIBLE_TAIL';
+    const out = buildPreSendConsultBody(body);
+    expect(out).toContain('VISIBLE_TAIL');
+    expect(out.length).toBeGreaterThan(300); // not truncated to a 300-char fragment
+  });
+
+  it('prefixes the consult marker inside the cap (prefix + body, tail intact)', () => {
+    const out = buildPreSendConsultBody('hello world');
+    expect(out).toBe('[PRE-SEND CONSULT] hello world');
+  });
+
+  it('fails LOUD on genuine overflow instead of silently clipping (loss-proof contract)', () => {
+    // > 4096-char hard cap => capBody throws BODY_TOO_LONG; the degrade-safe caller fails OPEN
+    // (consult skipped) rather than consulting on a misleading fragment.
+    let thrown;
+    try { buildPreSendConsultBody('a'.repeat(5000)); } catch (e) { thrown = e; }
+    expect(thrown).toBeDefined();
+    expect(thrown.code).toBe('BODY_TOO_LONG');
+    expect(thrown.message).toMatch(/4096-char hard cap/);
+  });
+
+  it('handles null/undefined body without emitting the literal "null"/"undefined"', () => {
+    const outNull = buildPreSendConsultBody(null);
+    const outUndef = buildPreSendConsultBody(undefined);
+    expect(outNull).toBe('[PRE-SEND CONSULT] ');
+    expect(outUndef).toBe('[PRE-SEND CONSULT] ');
+  });
+});


### PR DESCRIPTION
## QF-20260720-729

**Bug:** `scripts/adam-advisory.cjs` `performBoundedConsult` pre-send consult passed `` `[PRE-SEND CONSULT] ${payload.body.slice(0, 300)}` `` into `buildSolomonConsultPayload`, so Solomon — asked to *validate* an outbound Adam advisory — only ever saw the first 300 chars. Solomon flagged it directly ("your packet ends mid-sentence at Two; the findings this consult exists FOR are invisible to me" — advisory 97cf4e3e, 2026-07-19); it recurred ~9×.

**Root cause:** `buildSolomonConsultPayload` already applies the loss-proof `capBody` internally (`worker-signal.cjs:495`), but the caller **defeated** it by pre-truncating to 300 chars before the body ever reached the cap — so `capBody` had nothing left to protect.

**Fix:** Route the full prefixed body through the already-imported `capBody` at the call site via a pure, exported `buildPreSendConsultBody(body)`. Solomon now sees the whole body up to the 4096-char hard cap; a genuine overflow throws `BODY_TOO_LONG` (fail-loud) into the existing degrade-safe fail-open path rather than silently clipping to a misleading fragment.

## Changes
- `scripts/adam-advisory.cjs`: add pure `buildPreSendConsultBody` (uses loss-proof `capBody`); use it at the pre-send consult; export it. Net +10 LOC.
- `tests/unit/adam-advisory-presend-consult-body.test.js`: 4 tests — tail beyond char 300 survives, prefix intact, fail-loud on >4096, null-safe.

## Tests
- New: 4/4 pass. Regression: `adam-quiet-tick-presend-consult`, `should-consult-solomon`, `adam-advisory-comms`, `adam-advisory-framing-class` — 41/41 pass.
- QF compliance: 100/100 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)