### PR TITLE
fix(SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B): kill vacuous auto-pass TESTING/SECURITY gate shells (F2)

### DIFF
--- a/lib/sub-agents/security.js
+++ b/lib/sub-agents/security.js
@@ -217,6 +217,48 @@ export async function execute(sdId, subAgent, options = {}) {
       console.log('   ✅ RLS policies verified');
     }
 
+    // QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+    // Evidence-absence guard. Every scan helper swallows its own failure and returns
+    // { checked:false, error, <count>:0 } — and the phase blocks above inspect ONLY the
+    // count, never `checked`/`error`. So an all-errored scan (which found zero issues
+    // because it never ran) previously stayed PASS@100 — a zero-evidence result was
+    // structurally indistinguishable from a genuinely clean one. Detect the hard case
+    // (the critical scans could NOT run) and emit a NON-PASSING verdict the downstream
+    // gates reject. We use 'BLOCKED' (not a bare 'ERROR' — result-aggregation.js:18,34
+    // downgrades 'ERROR'/'FAIL'-with-non-critical-priority to WARNING/CONDITIONAL_PASS
+    // with can_proceed=true; 'BLOCKED' is unconditionally can_proceed=false). Fail-soft:
+    // we never throw — we downgrade the verdict and surface the errored scans loudly.
+    const scanEvidence = [
+      { name: 'authentication', critical: true, result: results.findings.authentication_check },
+      { name: 'authorization', critical: false, result: results.findings.authorization_check },
+      { name: 'input_validation', critical: true, result: results.findings.input_validation },
+      { name: 'data_protection', critical: true, result: results.findings.data_protection },
+      { name: 'rls_policies', critical: false, result: results.findings.rls_policies }
+    ];
+    const scanErrored = (r) => !r || r.checked === false || Boolean(r.error);
+    const erroredScans = scanEvidence.filter((s) => scanErrored(s.result));
+    const criticalScans = scanEvidence.filter((s) => s.critical);
+    const criticalErrored = criticalScans.filter((s) => scanErrored(s.result));
+    // Evidence is absent only when EVERY critical scan failed to run — a single errored
+    // non-critical scan (e.g. RLS fallback) must NOT flip a clean run to non-passing.
+    const evidenceAbsent = criticalErrored.length === criticalScans.length;
+
+    if (evidenceAbsent) {
+      const erroredNames = erroredScans.map((s) => s.name).join(', ');
+      console.log(`   ❌ Evidence absent: ${criticalErrored.length}/${criticalScans.length} critical security scans could not run (${erroredNames})`);
+      results.verdict = 'BLOCKED';
+      results.confidence = 0;
+      results.critical_issues.push({
+        severity: 'CRITICAL',
+        issue: `Security scans could not run — no evidence: ${erroredNames}`,
+        recommendation: 'Resolve the scan execution errors and re-run SECURITY. An errored scan is NOT a clean scan and must not pass.',
+        errored_scans: erroredScans.map((s) => ({ scan: s.name, error: s.result?.error || null }))
+      });
+      results.recommendations.push(
+        `EVIDENCE ABSENT: ${criticalErrored.length}/${criticalScans.length} critical security scans failed to execute — verdict is BLOCKED, not a silent PASS. Errored scans: ${erroredNames}`
+      );
+    }
+
     // Generate recommendations
     console.log('\n💡 Generating recommendations...');
     generateRecommendations(results);

--- a/lib/sub-agents/testing/phases/phase3-execution.js
+++ b/lib/sub-agents/testing/phases/phase3-execution.js
@@ -187,13 +187,17 @@ async function getCachedTestResults(sdId, supabase) {
     cache_age_minutes: Math.floor(testAge / 1000 / 60)
   };
 
-  // If we have a valid cached verdict but no test data, accept the verdict
+  // QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+  // Do NOT fabricate a synthetic 1/1-passed from a bare prior PASS/CONDITIONAL_PASS
+  // verdict that carried no real execution counts. Synthesizing tests_executed:1 from a
+  // verdict-with-no-numbers manufactured evidence out of thin air, which let phase5
+  // generateVerdict treat "we once said PASS" as "tests ran and passed". A verdict
+  // without real execution counts is zero evidence: only the real cachedData counts
+  // extracted above are carried forward; otherwise tests_executed stays 0 so phase5
+  // correctly treats it as no-evidence (non-passing). Fail-soft: we only log.
   if (results.tests_executed === 0 && (previousTest.verdict === 'PASS' || previousTest.verdict === 'CONDITIONAL_PASS')) {
-    console.log('      ⚠️  Cached verdict found but test execution data missing');
-    console.log('      💡 Accepting cached verdict:', previousTest.verdict);
-    results.tests_executed = 1;
-    results.tests_passed = previousTest.verdict === 'PASS' ? 1 : 1;
-    results.failed_tests = previousTest.verdict === 'CONDITIONAL_PASS' ? 1 : 0;
+    console.log('      ⚠️  Cached verdict found but real execution counts are missing');
+    console.log('      💡 Not fabricating synthetic results - leaving tests_executed:0 (no evidence)');
   }
 
   return results;

--- a/lib/sub-agents/testing/phases/phase5-verdict.js
+++ b/lib/sub-agents/testing/phases/phase5-verdict.js
@@ -86,8 +86,12 @@ export function generateVerdict(results, validationMode = 'prospective') {
     if (validationMode === 'retrospective') {
       const testsPassed = findings.phase3_execution?.tests_passed || 0;
       const testFilesFound = findings.phase4_evidence?.test_files_found || 0;
-      const userStoriesWithE2E = results.critical_issues?.length === 0;
-      const hasTestEvidence = testsPassed > 0 || testFilesFound > 0 || userStoriesWithE2E;
+      // QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+      // Removed the `userStoriesWithE2E = critical_issues.length === 0` fake-evidence:
+      // "no critical issues" is the ABSENCE of a negative signal, NOT proof any test
+      // ran, so it let zero-executed + zero-issues masquerade as CONDITIONAL_PASS@75.
+      // Real evidence exists ONLY when tests actually ran or real test files were found.
+      const hasTestEvidence = testsPassed > 0 || testFilesFound > 0;
 
       if (hasTestEvidence) {
         verdict = 'CONDITIONAL_PASS';
@@ -130,9 +134,26 @@ export function generateVerdict(results, validationMode = 'prospective') {
   }
   // All passed = PASS
   else {
-    verdict = 'PASS';
-    confidence = 95;
-    recommendations.push('All tests passed - ready for deployment');
+    // QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+    // Guard the default fall-through. This branch is reached when phase3_execution is
+    // ABSENT/undefined (the `tests_executed === 0` guard above uses strict === so
+    // `undefined === 0` is false and is skipped) — an absent execution object is ZERO
+    // evidence, not a pass, yet it previously returned PASS@95. Only a REAL run
+    // (tests_executed>0 with tests_passed>0) may PASS here; otherwise emit a
+    // non-passing verdict the EXEC-TO-PLAN gate rejects.
+    const testsExecuted = findings.phase3_execution?.tests_executed || 0;
+    const testsPassed = findings.phase3_execution?.tests_passed || 0;
+
+    if (testsExecuted > 0 && testsPassed > 0) {
+      verdict = 'PASS';
+      confidence = 95;
+      recommendations.push('All tests passed - ready for deployment');
+    } else {
+      verdict = 'BLOCKED';
+      confidence = 100;
+      recommendations.push('No test execution evidence found - a passing verdict requires a real test run (tests_executed > 0)');
+      recommendations.push('Execute E2E tests with --full-e2e before approval');
+    }
   }
 
   // Additional recommendations

--- a/tests/unit/sub-agents/security-evidence-absent.test.js
+++ b/tests/unit/sub-agents/security-evidence-absent.test.js
@@ -1,0 +1,85 @@
+/**
+ * QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+ *
+ * Regression: SECURITY execute() must FAIL LOUD when its scans could not run. Each scan
+ * helper swallows its own error and returns { checked:false, error, <count>:0 }, and the
+ * phase blocks inspect only the count — so pre-fix an ALL-errored scan stayed PASS@100
+ * (a zero-evidence result indistinguishable from a clean one). This RED-pre-fix test
+ * drives every scan to error (via execAsync rejection + a throwing supabase.rpc) and
+ * asserts the verdict is NOT PASS and confidence is NOT 100. A companion test proves a
+ * genuinely-clean scan (all helpers ran, zero issues) still yields PASS@100.
+ *
+ * The scan helpers are not exported, so we stub their sole I/O seam: execAsync =
+ * promisify(exec). We mock child_process.exec with a util.promisify.custom implementation
+ * whose behavior is toggled by `state.mode`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({ mode: 'error' }));
+
+// child_process.exec — security.js does `const execAsync = promisify(exec)`. Attaching the
+// promisify.custom symbol makes promisify(exec) resolve to this function directly, so every
+// grep|wc-l scan either rejects (mode 'error') or resolves stdout '0' (mode 'clean').
+vi.mock('child_process', async () => {
+  const { promisify } = await import('util');
+  const exec = function exec() {};
+  exec[promisify.custom] = () => {
+    if (state.mode === 'error') {
+      return Promise.reject(new Error('scan command failed: command not found'));
+    }
+    return Promise.resolve({ stdout: '0\n', stderr: '' });
+  };
+  return { exec, default: { exec } };
+});
+
+// Supabase client used by checkRLSPolicies + set as module-level `supabase`.
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({
+    rpc: async () => {
+      // In error mode, throw so RLS falls through to the (also-erroring) migration
+      // fallback and returns { checked:false, error }. In clean mode, report zero
+      // unprotected tables.
+      if (state.mode === 'error') throw new Error('rpc get_tables_without_rls failed');
+      return { data: [], error: null };
+    }
+  }))
+}));
+
+vi.mock('../../../scripts/lib/handoff-preflight.js', () => ({
+  quickPreflightCheck: vi.fn(async () => ({ ready: true, missing: [] }))
+}));
+
+vi.mock('../../../lib/sub-agents/resolve-repo.js', () => ({
+  resolveSubAgentRepo: vi.fn(async () => ({ repoPath: '/fake/repo' })),
+  applySubAgentRepoVerdict: vi.fn()
+}));
+
+const { execute } = await import('../../../lib/sub-agents/security.js');
+
+describe('QF/F2 SECURITY execute() — evidence-absence is non-passing', () => {
+  beforeEach(() => {
+    state.mode = 'error';
+  });
+
+  it('every scan errors (checked:false) => verdict NOT PASS, confidence NOT 100', async () => {
+    state.mode = 'error';
+    const results = await execute('SD-TEST-EVIDENCE-ABSENT', {}, {});
+
+    expect(results.verdict).not.toBe('PASS');
+    expect(results.confidence).not.toBe(100);
+    // Must be a verdict result-aggregation.js treats as unconditionally non-passing.
+    expect(results.verdict).toBe('BLOCKED');
+    expect(results.confidence).toBe(0);
+    // The errored scans are surfaced loudly, not silently counted as issues:0-and-secure.
+    expect(results.critical_issues.some(ci => /could not run|no evidence/i.test(ci.issue))).toBe(true);
+  });
+
+  it('clean scan (all helpers ran, zero issues) still yields PASS@100', async () => {
+    state.mode = 'clean';
+    const results = await execute('SD-TEST-CLEAN', {}, {});
+
+    expect(results.verdict).toBe('PASS');
+    expect(results.confidence).toBe(100);
+  });
+});

--- a/tests/unit/testing-subagent/phase5-verdict-zero-evidence.test.js
+++ b/tests/unit/testing-subagent/phase5-verdict-zero-evidence.test.js
@@ -1,0 +1,87 @@
+/**
+ * QF/F2 SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B
+ *
+ * Regression: TESTING generateVerdict() must NOT emit a passing verdict without a real
+ * test result. Pre-fix defects (RED against old logic):
+ *   (i)  retrospective + tests_executed:0 + zero critical issues => CONDITIONAL_PASS@75
+ *        (the `userStoriesWithE2E = critical_issues.length === 0` fake-evidence).
+ *   (ii) absent phase3_execution => default fall-through PASS@95 (`undefined === 0` is
+ *        false so the no-tests guard is skipped).
+ * A REAL run (tests_executed>0, tests_passed>0) MUST still PASS/CONDITIONAL_PASS.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateVerdict } from '../../../lib/sub-agents/testing/phases/phase5-verdict.js';
+
+const PASSING = ['PASS', 'CONDITIONAL_PASS'];
+
+describe('QF/F2 phase5 generateVerdict — no pass without real test evidence', () => {
+  it('(i) tests_executed:0 + zero critical issues does NOT return PASS/CONDITIONAL_PASS (retrospective)', () => {
+    // Retrospective is the mode where the old userStoriesWithE2E fake-evidence produced
+    // a vacuous CONDITIONAL_PASS@75. This is the RED case pre-fix.
+    const results = {
+      findings: { phase3_execution: { tests_executed: 0, tests_passed: 0, failed_tests: 0 } },
+      critical_issues: [],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'retrospective');
+    expect(PASSING).not.toContain(out.verdict);
+    expect(out.confidence).not.toBe(75);
+  });
+
+  it('(i-prospective) tests_executed:0 + zero critical issues does NOT pass (prospective)', () => {
+    const results = {
+      findings: { phase3_execution: { tests_executed: 0, tests_passed: 0, failed_tests: 0 } },
+      critical_issues: [],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'prospective');
+    expect(PASSING).not.toContain(out.verdict);
+  });
+
+  it('(ii) absent phase3_execution does NOT return PASS@95', () => {
+    // No execution object at all — zero evidence. Pre-fix returned PASS@95 (RED).
+    const results = {
+      findings: {},
+      critical_issues: [],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'prospective');
+    expect(PASSING).not.toContain(out.verdict);
+    expect(out.confidence).not.toBe(95);
+    // Must be a verdict the EXEC-TO-PLAN gate rejects (not PASS/CONDITIONAL_PASS).
+    expect(out.verdict).toBe('BLOCKED');
+  });
+
+  it('(iii) a real run (tests_executed>0, tests_passed>0) still returns PASS (unchanged)', () => {
+    const results = {
+      findings: { phase3_execution: { tests_executed: 10, tests_passed: 10, failed_tests: 0 } },
+      critical_issues: [],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'prospective');
+    expect(out.verdict).toBe('PASS');
+    expect(PASSING).toContain(out.verdict);
+  });
+
+  it('(iii-retrospective) real retrospective evidence (tests_passed>0) still CONDITIONAL_PASSes', () => {
+    // Honest retrospective path preserved: real tests passed but --full-e2e not run.
+    const results = {
+      findings: { phase3_execution: { tests_executed: 0, tests_passed: 8, failed_tests: 0 } },
+      critical_issues: [],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'retrospective');
+    expect(PASSING).toContain(out.verdict);
+  });
+
+  it('preserves negative signals: critical issues still BLOCK', () => {
+    const results = {
+      findings: { phase3_execution: { tests_executed: 5, tests_passed: 5, failed_tests: 0 } },
+      critical_issues: [{ issue: 'boom' }],
+      warnings: []
+    };
+    const out = generateVerdict(results, 'prospective');
+    expect(out.verdict).toBe('BLOCKED');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-B — F2 (Solomon checkpoint-3)

**Defect:** TESTING/SECURITY sub-agents emitted `PASS` with **zero real evidence**, so a gate that genuinely verified was structurally indistinguishable from one that ran nothing — letting *built-but-never-run* code reach LEAD-FINAL as fully validated.

### Fixes (source-level — honest verdicts flow through existing gates)
- **`lib/sub-agents/security.js`**: evidence-absence guard — when every **critical** scan errored (`checked===false`/`error`), verdict → `BLOCKED`/confidence 0 (not the seeded `PASS@100`), naming the errored scans. `BLOCKED` (not `ERROR`/`FAIL`) so `result-aggregation.js` can't downgrade it to `can_proceed`. A genuinely-clean scan still `PASS`es@100.
- **`lib/sub-agents/testing/phases/phase5-verdict.js`**: removed the `critical_issues.length===0` fake-evidence (zero-executed + zero-issues no longer `CONDITIONAL_PASS`); default fall-through requires a **real run** (`tests_executed>0 && tests_passed>0`) else `BLOCKED`.
- **`lib/sub-agents/testing/phases/phase3-execution.js`**: stop fabricating a synthetic `1/1-passed` from a bare prior verdict.

### Tests
Two regression tests (SECURITY all-errored; TESTING zero-evidence) — **RED-verified against pre-fix**, and the full `tests/unit/sub-agents/` + `tests/unit/testing-subagent/` sweep is green (**168 pass**).

### Follow-up (out of scope, noted in retro)
A deeper hardening is a persisted, gate-read execution-evidence field (`tests_run`/`scans_executed`) — the real "did work run" signal is currently not projected into any queryable column.

Scope: 3 source files + 2 tests, +250/−11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)