### PR TITLE
feat(SD-LEO-INFRA-LEO-COMPLETION-001-B): desired-state manifest slots + canary isolation harness + U4 spec

### DIFF
--- a/docs/protocol/fleet-spawn-control.md
+++ b/docs/protocol/fleet-spawn-control.md
@@ -69,6 +69,7 @@ Mirrors the existing `WORKER_SPAWN_EXECUTOR_LIVE` convention (`docs/protocol/coo
 ## Cross-References
 
 - [Coordinator-Side Worker Revival Contract](./coordinator-worker-revival.md) — sibling default-OFF live-spawn-gate pattern (`WORKER_SPAWN_EXECUTOR_LIVE`)
+- [U4 Cookie-Non-Leak Spec](./u4-cookie-non-leak-spec.md) — formal threat model + falsifiable proof mechanism binding to `relaunchUnderProfile`'s isolation assertion below (`SD-LEO-INFRA-LEO-COMPLETION-001-B`, FR-4)
 - Retrospective: `SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001` (quality_score 90) — documents the 2 CRITICAL data-integrity bugs an independent adversarial review caught and fixed before merge, and the CI-only cross-platform path-join bug
 
 ## Reference

--- a/docs/protocol/u4-cookie-non-leak-spec.md
+++ b/docs/protocol/u4-cookie-non-leak-spec.md
@@ -1,0 +1,118 @@
+# U4 — Agent-Browser Cookie-Non-Leak Guarantee
+
+**Origin:** SD-LEO-INFRA-LEO-COMPLETION-001-B (FR-4), per Solomon's checkpoint-3 final acceptance
+verdict, which called the underlying posture "structurally excellent" but noted it had never been
+formally written down. This document originates that formal spec: a threat model, the current proof
+substrate, and an explicit falsifiable failing case for Child E (SD-LEO-INFRA-LEO-COMPLETION-001-E,
+operator cockpit) to build its live proof against.
+
+Cross-reference: [`fleet-spawn-control.md`](./fleet-spawn-control.md) documents the six-verb control
+layer this spec's proof substrate lives inside.
+
+## 1. Threat model
+
+**Asset:** browser session cookies / auth state belonging to one Claude Code account.
+
+**Threat:** when a fleet session relaunches under a *different* account profile
+(`relaunchUnderProfile`, per `fleet-spawn-control.md`), the new process could inherit or leak the
+prior account's browser session cookies — either because the child process shares the supervisor's
+environment, or because two account profiles share the same on-disk profile directory.
+
+**Attacker/failure model:** not necessarily malicious — the primary risk is an *accidental* leak from
+process/env/directory isolation bugs, which is exactly the class of bug `relaunchUnderProfile`'s own
+isolation assertion (see §2) exists to catch.
+
+**Out of scope:** this spec does not cover browser-level XSS/CSRF or third-party cookie policy; it
+covers only the fleet's own account-profile-switching mechanism.
+
+## 2. Existing proof substrate (already shipped, cited here — no net-new mechanism specified)
+
+Per Solomon's checkpoint-3 verdict, these primitives are already structurally in place in
+`lib/fleet/spawn-control.js` (SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001, completed):
+
+1. **Per-session sandboxed profile directories, traversal-guarded.** `resolveProfileDir()`
+   (`lib/fleet/spawn-control.js:47-57`) resolves an account-profile *name* (not a path) against an
+   operator-configured base directory, rejecting anything but a bare `[A-Za-z0-9_-]+` name — never a
+   raw/absolute/traversal path from card input. Each account profile therefore gets its own directory
+   under `FLEET_ACCOUNT_PROFILES_DIR`; no two profiles can be coerced into sharing one directory via a
+   crafted name.
+
+2. **`CLAUDE_CONFIG_DIR` injected into the child's env only — never the supervisor's.**
+   `buildLiveSpawnInvocation()` (`lib/fleet/spawn-control.js:70-80`) places `CLAUDE_CONFIG_DIR` into a
+   *returned* env object handed to `child_process.spawn`'s `env` option — never assigned to
+   `process.env` directly.
+
+3. **The observable isolation assertion (THE proof mechanism this spec binds to).**
+   `relaunchUnderProfile()` (`lib/fleet/spawn-control.js:306-313`):
+
+   ```js
+   const supervisorConfigDirBefore = process.env.CLAUDE_CONFIG_DIR;
+   const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
+   const supervisorConfigDirAfter = process.env.CLAUDE_CONFIG_DIR;
+   if (supervisorConfigDirBefore !== supervisorConfigDirAfter) {
+     throw new Error('relaunchUnderProfile: supervisor process.env.CLAUDE_CONFIG_DIR changed -- isolation invariant violated');
+   }
+   ```
+
+   This is a **runtime, observable** assertion (not just a design claim): every relaunch-under-profile
+   call snapshots the supervisor's own `CLAUDE_CONFIG_DIR` before and after spawning the replacement,
+   and throws if it changed. Because a browser session's cookie jar lives under the profile directory
+   named by `CLAUDE_CONFIG_DIR`, an unchanged supervisor `CLAUDE_CONFIG_DIR` is the direct observable
+   proxy for "the supervisor's own browser-session cookies were never touched by this relaunch."
+
+4. **Default-OFF gate, re-checked every action.** `isLiveEnabled()`
+   (`lib/fleet/spawn-control.js:60-62`) gates the entire live-spawn surface behind
+   `FLEET_SPAWN_CONTROL_LIVE`, read fresh on every call (never cached) — no relaunch, and therefore no
+   profile-switch, can occur unless the operator has explicitly enabled it for that invocation.
+
+5. **Log-before-action.** Every verb emits a `fleet_verb_*` coordination event (`emitVerbEvent`,
+   `lib/fleet/spawn-control.js:91-100`) with a payload hard-locked to exactly `{verb, outcome, at}`
+   (FR-9/TR-6 of the sibling SD) — a relaunch's outcome is always durably recorded, never silent.
+
+## 3. PASS observable
+
+A `relaunchUnderProfile()` call for account profile `B` while the supervisor (or any sibling session)
+is running under profile `A` **PASSES U4** when, after the call:
+
+- `process.env.CLAUDE_CONFIG_DIR` on the supervisor is byte-identical before and after the call
+  (§2.3's existing assertion — already enforced, throws on violation), **and**
+- the spawned child's `CLAUDE_CONFIG_DIR` resolves to profile `B`'s own directory
+  (`resolveProfileDir('B')`), distinct from profile `A`'s directory, **and**
+- no cookie/session file present under profile `A`'s directory is copied into, symlinked from, or
+  otherwise reachable from profile `B`'s directory (a filesystem-level non-overlap check).
+
+## 4. FAIL observable (falsifiability — required by this spec, not present before)
+
+U4 is **falsified** — i.e. Child E's proof mechanism must be able to detect and report this — if
+**any** of the following is observed during or after a `relaunchUnderProfile('B')` call:
+
+- The supervisor's `process.env.CLAUDE_CONFIG_DIR` differs before vs. after the call (this already
+  throws per §2.3 — the falsifying observation is that the *throw itself* is the failure signal Child
+  E's proof must capture and assert on, not silently swallow), **or**
+- `resolveProfileDir('B')` returns a path that is equal to, or a parent/child of, `resolveProfileDir('A')`
+  for any two *distinct* account-profile names `A ≠ B` (a directory-collision/traversal escape), **or**
+- A file present under profile `A`'s resolved directory (e.g. a browser cookie-jar file) is also
+  readable via profile `B`'s resolved directory path (cross-profile filesystem reachability), **or**
+- A `fleet_verb_relaunch_under_profile` event is missing entirely for a call that mutated a live
+  session (log-before-action violated — the action happened with no durable record).
+
+A proof implementation that only asserts "no error was thrown" is **not sufficient** — it must
+actively check the directory-collision and cross-profile-reachability conditions above, since those
+are the classes of bug the existing runtime assertion (§2.3) cannot detect on its own (it only catches
+supervisor-env drift, not profile-directory collisions).
+
+## 5. Relationship to the canary isolation harness (FR-3, same SD)
+
+This spec is orthogonal to, but composable with, the canary isolation harness
+(`lib/fleet/canary-guard.js`, FR-3 of this same SD): the canary guard's `assert-before-kill` protects
+*which session* a mutation may target; this U4 spec protects *what leaks* when a relaunch-under-profile
+mutation is applied to a legitimately-targeted session. Child E's live proof should exercise both:
+a canary-targeted `relaunchUnderProfile` call, verified via the canary guard, whose profile-switch is
+then checked against the PASS/FAIL observables above.
+
+## 6. Acceptance boundary (PIN, no-trim)
+
+Per the parent program's Solomon acceptance pins: this document is a **specification**, not a live
+proof. Its own acceptance criterion (see PRD FR-4) is that it exists, cites the exact observable by
+file:line, and defines a falsifiable failing case — it does **not** itself constitute the S2 live-drill
+U4 spot-check, which remains Child E's live-proof responsibility, re-run by Solomon.

--- a/lib/fleet/canary-guard.js
+++ b/lib/fleet/canary-guard.js
@@ -1,0 +1,116 @@
+/**
+ * Canary isolation harness -- SD-LEO-INFRA-LEO-COMPLETION-001-B (FR-3).
+ *
+ * A thin, additive layer on top of the already-shipped lib/fleet/spawn-control.js (SD-LEO-INFRA-
+ * FLEET-SPAWN-CONTROL-001, completed) -- stop()/restart()/relaunchUnderProfile() are imported and
+ * reused as-is; this module adds ONLY the genuinely-new pieces: a canary-only callsign namespace, an
+ * independent canary-kill env flag, and a fail-closed assert-before-kill guard.
+ *
+ * WHY A GUARD IS NEEDED (risk-agent finding, verified): lib/fleet/session-registry-adapter.js's
+ * resolveLiveSession() resolves purely by session_id/callsign -- ZERO account_profile filtering.
+ * That means, absent this guard, a canary-drill call to stop()/restart()/relaunchUnderProfile()
+ * could target a live production coordinator/Adam/Solomon/worker session. This guard is the ONLY
+ * partition between a canary drill and killing production sessions.
+ *
+ * FAIL-CLOSED CONTRACT: the guard trusts ONLY the server-resolved session's metadata.account_profile
+ * -- it never reads account_profile from caller-supplied target/opts. Any resolution failure
+ * (not_found / ambiguous / absent field / non-canary value) rejects the mutation.
+ */
+import { loadLiveSessionIdentity } from './session-registry-adapter.js';
+import { resolveSessionIdentity } from './session-registry.js';
+import {
+  stop as spawnControlStop,
+  restart as spawnControlRestart,
+  relaunchUnderProfile as spawnControlRelaunchUnderProfile,
+} from './spawn-control.js';
+
+const CANARY_CALLSIGN_PREFIX = 'Canary-';
+
+/**
+ * True only when the operator has explicitly enabled the canary-kill surface. INDEPENDENT of
+ * FLEET_SPAWN_CONTROL_LIVE (FR-3 acceptance criterion) -- both default OFF, toggled separately.
+ */
+export function isCanaryKillEnabled(env = process.env) {
+  return String(env.FLEET_CANARY_KILL_ENABLED || '').toLowerCase() === 'true';
+}
+
+/** True only for a callsign in the canary-only namespace (defence-in-depth alongside the account_profile check). */
+export function isCanaryCallsign(callsign) {
+  return typeof callsign === 'string' && callsign.startsWith(CANARY_CALLSIGN_PREFIX);
+}
+
+/**
+ * Resolve a card/session identifier to ONE live identity WITH its server-side account_profile.
+ * session-registry-adapter.js's joinSessionIdentity carries no account_profile today -- this reads
+ * it directly from claude_sessions.metadata, additive/parallel to that adapter, touching nothing
+ * there. NEVER accepts an account_profile value from the caller.
+ * @param {object} supabase
+ * @param {{ by?:string, value?:any }} key
+ */
+export async function resolveCanaryTarget(supabase, { by, value } = {}) {
+  const { sessions, callsignBySession } = await loadLiveSessionIdentity(supabase);
+  const joined = (sessions || []).map((s) => ({
+    session_id: (s && s.session_id) || null,
+    terminal_id: (s && s.terminal_id) || null,
+    pid: s && s.pid != null ? s.pid : null,
+    callsign: (s && s.session_id && callsignBySession[s.session_id]) || null,
+    account_profile: (s && s.metadata && s.metadata.account_profile) || null,
+  }));
+  return resolveSessionIdentity(joined, { by, value });
+}
+
+/**
+ * FAIL-CLOSED assert-before-kill guard (FR-3 core). Requires a resolved session AND
+ * identity.account_profile === 'canary' (server-resolved) AND, defence-in-depth, a canary-namespace
+ * callsign. Any ambiguity/absence/mismatch -> REJECT. Never throws -- always returns a verdict.
+ * @param {{resolved:boolean, identity?:object, reason?:string}} resolution
+ * @returns {{ok:boolean, reason?:string}}
+ */
+export function assertCanaryTarget(resolution) {
+  if (!resolution || resolution.resolved !== true) {
+    return { ok: false, reason: (resolution && resolution.reason) || 'not_resolved' };
+  }
+  const identity = resolution.identity || {};
+  if (identity.account_profile !== 'canary') {
+    return { ok: false, reason: 'not_canary_profile' };
+  }
+  if (!isCanaryCallsign(identity.callsign)) {
+    return { ok: false, reason: 'not_canary_callsign' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Structural composition point every canary-guarded verb routes through (TS-5e): the canary-kill
+ * flag is checked FIRST (AND-composition, TS-6a -- a resolved canary session is still NOT killed
+ * when the flag is off), then the target is resolved server-side and the fail-closed guard applied,
+ * and ONLY on a full pass does the underlying spawn-control.js verb ever run.
+ */
+async function guardedVerb(verbFn, verbName, target, opts = {}) {
+  if (!isCanaryKillEnabled(opts.env)) {
+    return { ok: false, reason: 'canary_kill_disabled', verb: verbName, guarded: true };
+  }
+  const supabase = opts.supabaseClient;
+  const by = opts.by || 'callsign';
+  const resolution = await resolveCanaryTarget(supabase, { by, value: target });
+  const guard = assertCanaryTarget(resolution);
+  if (!guard.ok) {
+    return { ok: false, reason: guard.reason, verb: verbName, guarded: true };
+  }
+  return verbFn(target, opts);
+}
+
+/** Canary-guarded stop -- delegates to spawn-control.js's stop() ONLY after the guard passes. */
+export async function canaryStop(target, opts = {}) {
+  return guardedVerb(spawnControlStop, 'stop', target, opts);
+}
+
+/** Canary-guarded restart -- delegates to spawn-control.js's restart() ONLY after the guard passes. */
+export async function canaryRestart(target, opts = {}) {
+  return guardedVerb(spawnControlRestart, 'restart', target, opts);
+}
+
+/** Canary-guarded relaunch-under-profile -- delegates to spawn-control.js's relaunchUnderProfile() ONLY after the guard passes. */
+export async function canaryRelaunchUnderProfile(target, accountProfile, opts = {}) {
+  return guardedVerb((t, o) => spawnControlRelaunchUnderProfile(t, accountProfile, o), 'relaunch_under_profile', target, opts);
+}

--- a/lib/fleet/session-manifest.js
+++ b/lib/fleet/session-manifest.js
@@ -65,3 +65,66 @@ export function summarizeManifestDrift(verdict) {
     remediation: `ACTION: spawn/route sessions to satisfy the desired manifest roles: ${verdict.under.map((u) => u.role).join(', ')}`,
   };
 }
+
+// ---------------------------------------------------------------------------
+// DESIRED-STATE SLOT SCHEMA — SD-LEO-INFRA-LEO-COMPLETION-001-B (FR-1/FR-2).
+//
+// Solomon checkpoint-1 REQUIRED amendment (FR-3, cited verbatim): "the manifest
+// [must be] DESIRED state: the chairman-editable slot list (name/color/role/
+// account_profile/model/effort/worktree) that reboot-respawn spawns FROM and
+// that the reconciliation loop diffs AGAINST the registry." Plus resume_uuid
+// per the sibling FR-4 (respawn resume-consumer wiring, owned by Child D).
+//
+// These are NEW, additive exports. The three {role,min} functions above are
+// UNTOUCHED — lib/fleet/session-registry-adapter.js is a live runtime consumer
+// of their exact current signature/shape (SD-B validation finding), so this
+// SD adds a parallel slot-keyed schema rather than mutating the drift core.
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a desired-state slot list. Each slot is chairman-editable and keyed by `name` (the
+ * stable identifier reboot-respawn and the reconciliation loop diff against). Slots without a
+ * name are dropped — name is the one required field, everything else defaults to null so a
+ * partially-specified slot is still representable (and diffable) rather than rejected outright.
+ * @param {Array<{name?:string, color?:string, role?:string, account_profile?:string, model?:string, effort?:string, worktree?:string, resume_uuid?:string}>} desired
+ * @returns {Array<{name:string, color:string|null, role:string|null, account_profile:string|null, model:string|null, effort:string|null, worktree:string|null, resume_uuid:string|null}>}
+ */
+export function normalizeDesiredSlots(desired = []) {
+  return (Array.isArray(desired) ? desired : [])
+    .map((d) => ({
+      name: (d && d.name) || null,
+      color: (d && d.color) || null,
+      role: (d && d.role) || null,
+      account_profile: (d && d.account_profile) || null,
+      model: (d && d.model) || null,
+      effort: (d && d.effort) || null,
+      worktree: (d && d.worktree) || null,
+      resume_uuid: (d && d.resume_uuid) || null,
+    }))
+    .filter((s) => s.name);
+}
+
+/**
+ * Compute DRIFT of the actual live fleet vs the DESIRED slot list, keyed by slot `name` (not role —
+ * multiple slots may share a role, e.g. two "worker" slots with different names/accounts). A desired
+ * slot with no matching actual entry is MISSING; a matching entry is present (drift-free on presence;
+ * field-level mismatch is surfaced separately for the reconciliation loop to act on). Extra actual
+ * entries not in the desired list are surfaced as unexpected, mirroring computeManifestDrift's shape.
+ * @param {{ desired?: Array<object>, actualByKey?: Record<string, {name?:string, color?:string, role?:string, account_profile?:string, model?:string, effort?:string, worktree?:string, resume_uuid?:string}> }} input
+ * @returns {{ drift:boolean, missing:Array<{name:string}>, present:Array<{name:string, mismatches:string[]}>, unexpected:string[] }}
+ */
+export function computeSlotDrift({ desired = [], actualByKey = {} } = {}) {
+  const norm = normalizeDesiredSlots(desired);
+  const desiredNames = new Set(norm.map((d) => d.name));
+  const FIELDS = ['color', 'role', 'account_profile', 'model', 'effort', 'worktree', 'resume_uuid'];
+  const missing = [];
+  const present = [];
+  for (const d of norm) {
+    const actual = actualByKey[d.name];
+    if (!actual) { missing.push({ name: d.name }); continue; }
+    const mismatches = FIELDS.filter((f) => (actual[f] || null) !== (d[f] || null));
+    present.push({ name: d.name, mismatches });
+  }
+  const unexpected = Object.keys(actualByKey || {}).filter((name) => !desiredNames.has(name));
+  return { drift: missing.length > 0, missing, present, unexpected };
+}

--- a/lib/fleet/session-metering.js
+++ b/lib/fleet/session-metering.js
@@ -46,3 +46,25 @@ export function meterSessions(joined = [], { roleOf, modelOf } = {}) {
 export function actualByRole(snapshot) {
   return (snapshot && snapshot.byRole) || {};
 }
+
+/**
+ * Reduce joined session identities to the actual-per-NAME slot map computeSlotDrift expects
+ * (SD-LEO-INFRA-LEO-COMPLETION-001-B, FR-1/FR-2 desired-state slot schema). Slot identity is keyed
+ * by `name` (the chairman-editable slot identifier), not role — a live session's name/color/role/
+ * account_profile/model/effort/worktree/resume_uuid are read via the injected accessors so this stays
+ * decoupled from where each field actually lives (SET_IDENTITY row, claude_sessions.metadata, etc.).
+ * @param {Array<object>} joined - session identities (from joinSessionIdentity, FR-1)
+ * @param {{ nameOf?:(s:object)=>string|null, slotOf?:(s:object)=>object }} [accessors]
+ * @returns {Record<string, object>}
+ */
+export function actualByName(joined = [], { nameOf, slotOf } = {}) {
+  const list = Array.isArray(joined) ? joined : [];
+  const byName = {};
+  for (const s of list) {
+    if (!s) continue;
+    const name = nameOf ? nameOf(s) : s.name;
+    if (!name) continue;
+    byName[name] = slotOf ? slotOf(s) : s;
+  }
+  return byName;
+}

--- a/lib/fleet/session-registry-adapter.js
+++ b/lib/fleet/session-registry-adapter.js
@@ -4,7 +4,8 @@
  * this is the activation follow-up.
  */
 import { joinSessionIdentity, resolveSessionIdentity, tableAbsent } from './session-registry.js';
-import { computeManifestDrift, normalizeDesiredManifest } from './session-manifest.js';
+import { computeManifestDrift, normalizeDesiredManifest, computeSlotDrift, normalizeDesiredSlots } from './session-manifest.js';
+import { actualByName } from './session-metering.js';
 
 /** Read live sessions + resolve the SET_IDENTITY callsign source. Fail-soft: [] on any error. */
 export async function loadLiveSessionIdentity(supabase) {
@@ -54,4 +55,50 @@ export function actualByRole(joined, roleOf) {
 export async function computeLiveManifestDrift(supabase, { desired, roleOf } = {}) {
   const joined = await joinLiveSessionIdentity(supabase);
   return computeManifestDrift({ desired: normalizeDesiredManifest(desired), actualByRole: actualByRole(joined, roleOf) });
+}
+
+/**
+ * Live desired-state SLOT identity set (SD-LEO-INFRA-LEO-COMPLETION-001-B, FR-1/FR-2). The slot
+ * `name` is the live session's callsign (the stable, chairman-visible identifier) — additive query
+ * alongside loadLiveSessionIdentity, reading the extra per-slot fields from claude_sessions.metadata
+ * without touching that function's existing shape/consumers. Fail-soft: [] on any error.
+ * @param {object} supabase
+ * @returns {Promise<Array<{name:string, color:string|null, role:string|null, account_profile:string|null, model:string|null, effort:string|null, worktree:string|null, resume_uuid:string|null}>>}
+ */
+export async function loadLiveSlotIdentity(supabase) {
+  const { data: sessions, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, metadata, status')
+    .in('status', ['active', 'idle']);
+  if (error) return [];
+  const slots = [];
+  for (const s of sessions || []) {
+    const meta = (s && s.metadata) || {};
+    const name = meta.fleet_identity && meta.fleet_identity.callsign;
+    if (!name) continue;
+    slots.push({
+      name,
+      color: (meta.fleet_identity && meta.fleet_identity.color) || null,
+      role: meta.role || null,
+      account_profile: meta.account_profile || null,
+      model: meta.model || null,
+      effort: meta.effort || null,
+      worktree: meta.worktree || meta.worktree_path || null,
+      resume_uuid: meta.resume_uuid || null,
+    });
+  }
+  return slots;
+}
+
+/**
+ * Live desired-state SLOT drift: desired slots vs the actual live fleet, keyed by name (FR-1/FR-2).
+ * The real, actually-called consumer of the NEW slot schema — pairs with computeLiveManifestDrift
+ * above (which stays on the {role,min} shape, untouched, for its own existing callers).
+ * @param {object} supabase
+ * @param {{ desiredSlots?: Array<object> }} input
+ */
+export async function computeLiveSlotDrift(supabase, { desiredSlots } = {}) {
+  const liveSlots = await loadLiveSlotIdentity(supabase);
+  const actual = actualByName(liveSlots, { nameOf: (s) => s.name, slotOf: (s) => s });
+  return computeSlotDrift({ desired: normalizeDesiredSlots(desiredSlots), actualByKey: actual });
 }

--- a/tests/unit/fleet/canary-guard.test.js
+++ b/tests/unit/fleet/canary-guard.test.js
@@ -1,0 +1,184 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-B FR-3 -- canary isolation harness (fail-closed assert-before-kill).
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
+  logCoordinationEvent: vi.fn().mockResolvedValue({ ok: true }),
+}));
+vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
+  sequenceSingletonRefresh: vi.fn(),
+}));
+
+const {
+  isCanaryKillEnabled, isCanaryCallsign, resolveCanaryTarget, assertCanaryTarget,
+  canaryStop, canaryRestart, canaryRelaunchUnderProfile,
+} = await import('../../../lib/fleet/canary-guard.js');
+
+/** Same claude_sessions fake shape as spawn-control.test.js, extended with account_profile in metadata. */
+function makeFakeSupabase({ sessions = [] } = {}) {
+  const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
+  return {
+    _store: store,
+    from(table) {
+      if (table === 'claude_sessions') {
+        return {
+          select() {
+            return {
+              in: async (col, vals) => ({ data: [...store.values()].filter((s) => vals.includes(s[col])) }),
+              eq: (col, val) => ({
+                maybeSingle: async () => ({ data: [...store.values()].find((s) => s[col] === val) || null }),
+              }),
+            };
+          },
+          update(patch) {
+            return {
+              eq: (col, val) => {
+                const row = [...store.values()].find((s) => s[col] === val);
+                if (row) Object.assign(row, patch);
+                return Promise.resolve({ error: row ? null : { message: 'not found' } });
+              },
+            };
+          },
+        };
+      }
+      if (table === 'session_coordination') {
+        return { select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+const canarySession = { session_id: 's-canary', pid: 111, status: 'active', metadata: { fleet_identity: { callsign: 'Canary-1' }, account_profile: 'canary', role: 'worker' } };
+const prodSession = { session_id: 's-prod', pid: 222, status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, account_profile: 'default', role: 'worker' } };
+const noProfileSession = { session_id: 's-noprofile', pid: 333, status: 'active', metadata: { fleet_identity: { callsign: 'Canary-2' } } };
+
+describe('isCanaryKillEnabled (independent from FLEET_SPAWN_CONTROL_LIVE, default OFF)', () => {
+  it('is OFF by default', () => {
+    expect(isCanaryKillEnabled({})).toBe(false);
+  });
+  it('is ON only when explicitly true', () => {
+    expect(isCanaryKillEnabled({ FLEET_CANARY_KILL_ENABLED: 'true' })).toBe(true);
+    expect(isCanaryKillEnabled({ FLEET_CANARY_KILL_ENABLED: 'false' })).toBe(false);
+  });
+  it('is a DISTINCT flag from FLEET_SPAWN_CONTROL_LIVE (setting one does not imply the other)', () => {
+    expect(isCanaryKillEnabled({ FLEET_SPAWN_CONTROL_LIVE: 'true' })).toBe(false);
+  });
+});
+
+describe('isCanaryCallsign', () => {
+  it('matches only the canary-only namespace prefix', () => {
+    expect(isCanaryCallsign('Canary-1')).toBe(true);
+    expect(isCanaryCallsign('Alpha-5')).toBe(false);
+    expect(isCanaryCallsign(null)).toBe(false);
+  });
+});
+
+describe('resolveCanaryTarget: reads account_profile server-side from claude_sessions.metadata', () => {
+  it('resolves a canary session with its account_profile intact', async () => {
+    const sb = makeFakeSupabase({ sessions: [canarySession] });
+    const result = await resolveCanaryTarget(sb, { by: 'callsign', value: 'Canary-1' });
+    expect(result.resolved).toBe(true);
+    expect(result.identity.account_profile).toBe('canary');
+  });
+
+  it('resolves a non-canary session with its real (non-canary) account_profile -- never trusts caller claims', async () => {
+    const sb = makeFakeSupabase({ sessions: [prodSession] });
+    const result = await resolveCanaryTarget(sb, { by: 'callsign', value: 'Alpha-5' });
+    expect(result.resolved).toBe(true);
+    expect(result.identity.account_profile).toBe('default');
+  });
+});
+
+describe('assertCanaryTarget (FR-3 fail-closed core, TS-5/TS-5a-d)', () => {
+  it('ACCEPTS a genuinely resolved canary session', () => {
+    expect(assertCanaryTarget({ resolved: true, identity: { account_profile: 'canary', callsign: 'Canary-1' } })).toEqual({ ok: true });
+  });
+
+  it('TS-5: REJECTS a non-canary session', () => {
+    expect(assertCanaryTarget({ resolved: true, identity: { account_profile: 'default', callsign: 'Alpha-5' } })).toEqual({ ok: false, reason: 'not_canary_profile' });
+  });
+
+  it('TS-5a: REJECTS even if the resolution object appears to carry a spoofed canary claim outside the server-resolved identity (guard reads ONLY identity.account_profile)', () => {
+    // Simulates a caller trying to smuggle a canary claim anywhere other than the server-resolved field.
+    const spoofed = { resolved: true, identity: { account_profile: 'default', callsign: 'Alpha-5' }, account_profile: 'canary', claimed_canary: true };
+    expect(assertCanaryTarget(spoofed)).toEqual({ ok: false, reason: 'not_canary_profile' });
+  });
+
+  it('TS-5b: REJECTS on ambiguous resolution (fail-closed, not fail-open)', () => {
+    expect(assertCanaryTarget({ resolved: false, reason: 'ambiguous' })).toEqual({ ok: false, reason: 'ambiguous' });
+  });
+
+  it('TS-5c: REJECTS on not_found', () => {
+    expect(assertCanaryTarget({ resolved: false, reason: 'not_found' })).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('TS-5d: REJECTS when the resolved session has no account_profile field at all (absence != canary)', () => {
+    expect(assertCanaryTarget({ resolved: true, identity: { callsign: 'Canary-2' } })).toEqual({ ok: false, reason: 'not_canary_profile' });
+  });
+
+  it('REJECTS a canary-profile session whose callsign is outside the canary namespace (defence-in-depth)', () => {
+    expect(assertCanaryTarget({ resolved: true, identity: { account_profile: 'canary', callsign: 'Alpha-5' } })).toEqual({ ok: false, reason: 'not_canary_callsign' });
+  });
+});
+
+describe('canaryStop / canaryRestart / canaryRelaunchUnderProfile (guarded verbs, TS-6a)', () => {
+  it('TS-6a: canary-kill flag OFF -- a genuinely-resolved canary session is NOT killed (AND-composition, not OR)', async () => {
+    const sb = makeFakeSupabase({ sessions: [canarySession] });
+    const result = await canaryStop('Canary-1', { supabaseClient: sb, env: {} });
+    expect(result).toEqual({ ok: false, reason: 'canary_kill_disabled', verb: 'stop', guarded: true });
+    expect(sb._store.get('s-canary').status).toBe('active'); // underlying stop() never ran -- status unchanged
+  });
+
+  it('TS-5 (via canaryStop): flag ON but a non-canary session -- REJECTED, underlying verb never mutates the row', async () => {
+    const sb = makeFakeSupabase({ sessions: [prodSession] });
+    const result = await canaryStop('Alpha-5', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('not_canary_profile');
+    expect(sb._store.get('s-prod').status).toBe('active'); // underlying stop() never ran -- status unchanged
+  });
+
+  it('flag ON + genuine canary session -- guard passes and delegates to the real spawn-control.js stop()', async () => {
+    const sb = makeFakeSupabase({ sessions: [canarySession] });
+    const result = await canaryStop('Canary-1', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
+    expect(result.ok).toBe(true);
+    expect(sb._store.get('s-canary').status).toBe('released'); // real stop() ran
+  });
+
+  it('canaryRestart: flag ON but not a canary session -- rejected before restart()/spawn() ever runs', async () => {
+    const sb = makeFakeSupabase({ sessions: [prodSession] });
+    const result = await canaryRestart('Alpha-5', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
+    expect(result.ok).toBe(false);
+    expect(result.guarded).toBe(true);
+  });
+
+  it('canaryRelaunchUnderProfile: flag ON but not a canary session -- rejected before relaunchUnderProfile() ever runs', async () => {
+    const sb = makeFakeSupabase({ sessions: [prodSession] });
+    const result = await canaryRelaunchUnderProfile('Alpha-5', 'someprofile', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
+    expect(result.ok).toBe(false);
+    expect(result.guarded).toBe(true);
+  });
+
+  it('rejects a session with no account_profile metadata at all, even in canary-namespace callsign, when flag is on', async () => {
+    const sb = makeFakeSupabase({ sessions: [noProfileSession] });
+    const result = await canaryStop('Canary-2', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('not_canary_profile');
+  });
+});
+
+// STRUCTURAL GUARD-INVOCATION PIN (TS-5e): every canary-guarded verb routes through guardedVerb --
+// mirrors spawn-control.test.js's own FR-6 grep-pin / FR-9 payload-lock pattern, so a future canary
+// verb added without routing through the guard fails this test, not silently ships unguarded.
+describe('TS-5e structural pin: every canary verb is guarded', () => {
+  it('canaryStop/canaryRestart/canaryRelaunchUnderProfile each delegate through guardedVerb()', () => {
+    const src = readFileSync(new URL('../../../lib/fleet/canary-guard.js', import.meta.url), 'utf8');
+    const exportedVerbBodies = src.split(/export async function canary/).slice(1);
+    expect(exportedVerbBodies.length).toBe(3);
+    for (const body of exportedVerbBodies) {
+      expect(body).toMatch(/guardedVerb\(/);
+    }
+  });
+});

--- a/tests/unit/fleet/session-manifest.test.js
+++ b/tests/unit/fleet/session-manifest.test.js
@@ -1,7 +1,11 @@
 // SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 FR-3 — manifest = DESIRED state + drift (coordinator amendment).
 // Fully in-memory (no DB): proves the manifest models the TARGET fleet shape and surfaces drift.
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import { normalizeDesiredManifest, computeManifestDrift, summarizeManifestDrift } from '../../../lib/fleet/session-manifest.js';
+import {
+  normalizeDesiredManifest, computeManifestDrift, summarizeManifestDrift,
+  normalizeDesiredSlots, computeSlotDrift,
+} from '../../../lib/fleet/session-manifest.js';
 
 describe('session-manifest = DESIRED state (FR-3)', () => {
   const desired = [{ role: 'coordinator', min: 1 }, { role: 'adam', min: 1 }, { role: 'worker', min: 3 }];
@@ -40,5 +44,71 @@ describe('session-manifest = DESIRED state (FR-3)', () => {
   it('empty/absent input is drift-free (conservative)', () => {
     expect(computeManifestDrift().drift).toBe(false);
     expect(computeManifestDrift({ desired: [] }).drift).toBe(false);
+  });
+
+  // REGRESSION PIN (TS-2, SD-LEO-INFRA-LEO-COMPLETION-001-B): the three functions above are a live
+  // runtime dependency of lib/fleet/session-registry-adapter.js — this exact signature/shape must
+  // never change. Failing this test means a breaking change reached the pure core.
+  it('REGRESSION PIN: {role,min} core signatures/shapes are unchanged (live consumer: session-registry-adapter.js)', () => {
+    expect(normalizeDesiredManifest([{ role: 'worker', min: 2 }])).toEqual([{ role: 'worker', min: 2 }]);
+    const v = computeManifestDrift({ desired: [{ role: 'worker', min: 2 }], actualByRole: { worker: 1 } });
+    expect(v).toEqual({ drift: true, under: [{ role: 'worker', desired: 2, actual: 1 }], satisfied: [], unexpected: [] });
+  });
+});
+
+// DESIRED-STATE SLOT SCHEMA (SD-LEO-INFRA-LEO-COMPLETION-001-B, FR-1/FR-2) — additive, keyed by name.
+describe('session-manifest DESIRED-STATE SLOTS (FR-1, Solomon checkpoint-1 amendment verbatim)', () => {
+  const fullSlot = { name: 'Alpha-5', color: 'blue', role: 'worker', account_profile: 'default', model: 'sonnet', effort: 'high', worktree: 'C:/wt/alpha5', resume_uuid: 'uuid-1' };
+
+  it('normalizeDesiredSlots keeps the full 8-field slot shape and drops name-less entries', () => {
+    const n = normalizeDesiredSlots([fullSlot, { color: 'red' }, { name: 'Beta-1' }]);
+    expect(n).toEqual([
+      fullSlot,
+      { name: 'Beta-1', color: null, role: null, account_profile: null, model: null, effort: null, worktree: null, resume_uuid: null },
+    ]);
+  });
+
+  it('computeSlotDrift: MISSING when a desired slot has no actual entry', () => {
+    const v = computeSlotDrift({ desired: [fullSlot], actualByKey: {} });
+    expect(v.drift).toBe(true);
+    expect(v.missing).toEqual([{ name: 'Alpha-5' }]);
+  });
+
+  it('computeSlotDrift: present + field-level mismatches surfaced (not just presence)', () => {
+    const v = computeSlotDrift({ desired: [fullSlot], actualByKey: { 'Alpha-5': { ...fullSlot, model: 'opus' } } });
+    expect(v.drift).toBe(false);
+    expect(v.present).toEqual([{ name: 'Alpha-5', mismatches: ['model'] }]);
+  });
+
+  it('computeSlotDrift: unexpected actual entries not in the desired list are surfaced', () => {
+    const v = computeSlotDrift({ desired: [fullSlot], actualByKey: { 'Alpha-5': fullSlot, 'ghost': { name: 'ghost' } } });
+    expect(v.unexpected).toEqual(['ghost']);
+  });
+
+  it('computeSlotDrift: keyed by name, not role -- two same-role slots are distinct entries', () => {
+    const desired = [{ ...fullSlot, name: 'Alpha-5' }, { ...fullSlot, name: 'Alpha-6' }];
+    const v = computeSlotDrift({ desired, actualByKey: { 'Alpha-5': fullSlot } });
+    expect(v.missing).toEqual([{ name: 'Alpha-6' }]);
+  });
+
+  it('empty/absent input is drift-free (conservative, mirrors {role,min} core)', () => {
+    expect(computeSlotDrift().drift).toBe(false);
+    expect(computeSlotDrift({ desired: [] }).drift).toBe(false);
+  });
+
+  // STRUCTURAL TRIM-DETECTOR (TS-4): asserts the 8-field slot shape is present AND that the live
+  // consumers reference the new schema by name -- fails if either the shape or the reference is
+  // absent, i.e. if the {role,min} shape were ever reinstated as the ONLY manifest interface.
+  it('TRIM-DETECTOR: the 8-field desired-state slot shape exists and is referenced by both migrated consumers', () => {
+    const slotFields = ['name', 'color', 'role', 'account_profile', 'model', 'effort', 'worktree', 'resume_uuid'];
+    const sample = normalizeDesiredSlots([{ name: 'x' }])[0];
+    expect(Object.keys(sample).sort()).toEqual([...slotFields].sort());
+
+    const adapterSrc = readFileSync(new URL('../../../lib/fleet/session-registry-adapter.js', import.meta.url), 'utf8');
+    expect(adapterSrc).toMatch(/normalizeDesiredSlots/);
+    expect(adapterSrc).toMatch(/computeSlotDrift/);
+
+    const meteringSrc = readFileSync(new URL('../../../lib/fleet/session-metering.js', import.meta.url), 'utf8');
+    expect(meteringSrc).toMatch(/actualByName/);
   });
 });

--- a/tests/unit/fleet/session-metering.test.js
+++ b/tests/unit/fleet/session-metering.test.js
@@ -1,7 +1,7 @@
 // SD-LEO-INFRA-FLEET-REGISTRY-MANIFEST-001 FR-4 — pure metering surface + manifest-drift contract.
 import { describe, it, expect } from 'vitest';
-import { meterSessions, actualByRole } from '../../../lib/fleet/session-metering.js';
-import { computeManifestDrift } from '../../../lib/fleet/session-manifest.js';
+import { meterSessions, actualByRole, actualByName } from '../../../lib/fleet/session-metering.js';
+import { computeManifestDrift, computeSlotDrift } from '../../../lib/fleet/session-manifest.js';
 
 describe('session-metering surface (FR-4)', () => {
   const joined = [
@@ -37,5 +37,27 @@ describe('session-metering surface (FR-4)', () => {
     });
     expect(drift.drift).toBe(true); // worker 2/3 under-provisioned
     expect(drift.under).toEqual([{ role: 'worker', desired: 3, actual: 2 }]);
+  });
+
+  // DESIRED-STATE SLOT SCHEMA (SD-LEO-INFRA-LEO-COMPLETION-001-B, FR-1/FR-2) — actualByName is the
+  // "actual" side that pairs with computeSlotDrift, mirroring actualByRole's existing role-keyed pattern.
+  it('actualByName keys the actual side by slot name (identity passthrough by default)', () => {
+    const slotJoined = [{ name: 'Alpha-5', model: 'sonnet' }, { name: null, model: 'opus' }];
+    expect(actualByName(slotJoined)).toEqual({ 'Alpha-5': { name: 'Alpha-5', model: 'sonnet' } });
+  });
+
+  it('actualByName uses injected nameOf/slotOf accessors', () => {
+    const joinedByCallsign = [{ callsign: 'Bravo-1', model: 'opus' }];
+    const result = actualByName(joinedByCallsign, { nameOf: (s) => s.callsign, slotOf: (s) => ({ model: s.model }) });
+    expect(result).toEqual({ 'Bravo-1': { model: 'opus' } });
+  });
+
+  it('actualByName feeds computeSlotDrift (actual side of desired-vs-actual, keyed by name)', () => {
+    const drift = computeSlotDrift({
+      desired: [{ name: 'Alpha-5', model: 'sonnet' }],
+      actualByKey: actualByName([{ name: 'Alpha-5', model: 'opus' }]),
+    });
+    expect(drift.drift).toBe(false);
+    expect(drift.present).toEqual([{ name: 'Alpha-5', mismatches: ['model'] }]);
   });
 });

--- a/tests/unit/fleet/session-registry-adapter.test.js
+++ b/tests/unit/fleet/session-registry-adapter.test.js
@@ -8,6 +8,8 @@ import {
   resolveLiveSession,
   actualByRole,
   computeLiveManifestDrift,
+  loadLiveSlotIdentity,
+  computeLiveSlotDrift,
 } from '../../../lib/fleet/session-registry-adapter.js';
 
 function makeFakeSupabase(sessions, error = null) {
@@ -103,5 +105,36 @@ describe('actualByRole + computeLiveManifestDrift (TS-6)', () => {
   it('actualByRole ignores identities with no resolvable role', () => {
     const joined = [{ callsign: 'Alpha-5' }, { callsign: null }, { callsign: 'Unknown-9' }];
     expect(actualByRole(joined, roleOf)).toEqual({ worker: 1 });
+  });
+});
+
+// DESIRED-STATE SLOT DRIFT (SD-LEO-INFRA-LEO-COMPLETION-001-B, FR-1/FR-2) — the real call-site that
+// discharges the "new schema is actually called, not dead code" acceptance criterion (TS-3a).
+describe('loadLiveSlotIdentity + computeLiveSlotDrift (FR-1/FR-2)', () => {
+  it('loadLiveSlotIdentity reads name (callsign) + slot fields from claude_sessions.metadata', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', metadata: { fleet_identity: { callsign: 'Alpha-5', color: 'blue' }, role: 'worker', account_profile: 'default', model: 'sonnet', effort: 'high', worktree: 'C:/wt/a5', resume_uuid: 'u1' } },
+      { session_id: 's2', metadata: {} },
+    ]);
+    const slots = await loadLiveSlotIdentity(sb);
+    expect(slots).toEqual([
+      { name: 'Alpha-5', color: 'blue', role: 'worker', account_profile: 'default', model: 'sonnet', effort: 'high', worktree: 'C:/wt/a5', resume_uuid: 'u1' },
+    ]);
+  });
+
+  it('computeLiveSlotDrift: MISSING slot surfaced when no live session matches the desired name', async () => {
+    const sb = makeFakeSupabase([]);
+    const verdict = await computeLiveSlotDrift(sb, { desiredSlots: [{ name: 'Alpha-5', account_profile: 'default' }] });
+    expect(verdict.drift).toBe(true);
+    expect(verdict.missing).toEqual([{ name: 'Alpha-5' }]);
+  });
+
+  it('computeLiveSlotDrift: satisfied + field mismatch surfaced when live data diverges from desired', async () => {
+    const sb = makeFakeSupabase([
+      { session_id: 's1', metadata: { fleet_identity: { callsign: 'Alpha-5' }, model: 'opus' } },
+    ]);
+    const verdict = await computeLiveSlotDrift(sb, { desiredSlots: [{ name: 'Alpha-5', model: 'sonnet' }] });
+    expect(verdict.drift).toBe(false);
+    expect(verdict.present).toEqual([{ name: 'Alpha-5', mismatches: ['model'] }]);
   });
 });


### PR DESCRIPTION
## Summary

Shared substrate for the LEO-completion program (Solomon checkpoint-3 remediation). This child SD (B) delivers what sibling children C/D/E build on:

- **FR-1/FR-2**: Additive desired-state slot schema (`normalizeDesiredSlots`/`computeSlotDrift`, fields: `name/color/role/account_profile/model/effort/worktree/resume_uuid`) per Solomon's checkpoint-1 FR-3 amendment, cited verbatim in the PRD. The existing `{role,min}` functions in `lib/fleet/session-manifest.js` are untouched (live consumer: `session-registry-adapter.js`) — `computeLiveSlotDrift`/`actualByName` are the real, actually-called consumers of the new schema, plus a structural trim-detector regression test so the shape can never silently regress to the forbidden `{role,min}`-only shape again (which — per an adversarial risk-agent review — is still the live baseline on `main` today).
- **FR-3**: Canary isolation harness (`lib/fleet/canary-guard.js`) — a thin layer on top of the already-shipped `lib/fleet/spawn-control.js` (reused, not rebuilt): a fail-closed assert-before-kill guard, a canary-only callsign namespace, and an independent canary-kill env flag (`FLEET_CANARY_KILL_ENABLED`, distinct from `FLEET_SPAWN_CONTROL_LIVE`).
- **FR-4**: U4 cookie-non-leak spec (`docs/protocol/u4-cookie-non-leak-spec.md`) binding to the existing `relaunchUnderProfile` isolation observable, with explicit PASS/FAIL cases for falsifiability.

### PR size note (684 LOC, exceeds the ≤400 LOC tiered guideline)

This SD's own PRD explicitly requires the schema, consumer migration, trim-detector, guard, and spec to land **atomically in one PR** — a partial-migration window (new schema shipped, old consumers un-migrated) would recreate exactly the trim-repeat failure Solomon's checkpoint-3 verdict flagged. Of the 684 lines, ~315 are new/extended tests and ~118 are the U4 spec doc; net new/changed source is ~250 lines. Two independent TESTING sub-agent reviews (PLAN-phase strategy review + EXEC-phase code review, both stored in `sub_agent_execution_results`) confirmed no correctness/security defects.

## Test plan

- [x] 88 new/extended unit tests (20 new in `canary-guard.test.js`, extended coverage in the 3 migrated modules)
- [x] Full fleet suite: 768/768 passing, 0 regressions (`npx vitest run tests/unit/fleet/`)
- [x] LEAD-phase VALIDATION + RISK sub-agent review (RISK: CONDITIONAL_PASS, HIGH risk, 3 documented mitigations — all folded into the PRD)
- [x] PLAN-phase TESTING strategy review (confidence 82) — added 7 test cases for the CRITICAL assert-before-kill guard before EXEC started
- [x] EXEC-phase independent TESTING code review (confidence 92) — 0 defects, 3 minor INFO-level observations
- [x] Retrospective published (quality_score 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)