### PR TITLE
docs(SD-LEO-INFRA-LEO-COMPLETION-001-B): document FLEET_CANARY_KILL_ENABLED env gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,6 +310,16 @@ STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-signing-secret
 # FLEET_ACCOUNT_PROFILES_DIR=                               # base dir for per-account CLAUDE_CONFIG_DIR profiles; required for relaunch-under-profile
 
 # ==============================================================================
+# Fleet canary isolation harness (lib/fleet/canary-guard.js) — SD-LEO-INFRA-LEO-COMPLETION-001-B
+# ==============================================================================
+# OPERATOR GATE — do NOT enable autonomously. INDEPENDENT of FLEET_SPAWN_CONTROL_LIVE
+# above: canaryStop/canaryRestart/canaryRelaunchUnderProfile still require the resolved
+# target session's own metadata.account_profile === 'canary' AND a Canary- namespaced
+# callsign (fail-closed assert-before-kill guard) even when this flag is true. See
+# docs/protocol/u4-cookie-non-leak-spec.md for the isolation proof this harness composes with.
+# FLEET_CANARY_KILL_ENABLED=false                           # default off; canary-only stop/restart/relaunch-under-profile (operator-gated)
+
+# ==============================================================================
 # Fleet liveness signal gates (scripts/session-tick.cjs / stale-session-sweep.cjs)
 # ==============================================================================
 # process_alive_at (written only by the session-tick.cjs daemon) was historically

--- a/docs/protocol/fleet-spawn-control.md
+++ b/docs/protocol/fleet-spawn-control.md
@@ -35,6 +35,8 @@ Mirrors the existing `WORKER_SPAWN_EXECUTOR_LIVE` convention (`docs/protocol/coo
 
 **Operator gate before flipping `FLEET_SPAWN_CONTROL_LIVE=true`**: the exact `wt.exe` invocation in `buildLiveSpawnInvocation()` is host-specific and must be validated on the target fleet host first, exactly as `worker-spawn-executor.cjs`'s own README section requires for its live flag.
 
+**`FLEET_CANARY_KILL_ENABLED`** (default off, independent flag) — a separate gate for `lib/fleet/canary-guard.js`'s `canaryStop`/`canaryRestart`/`canaryRelaunchUnderProfile` (`SD-LEO-INFRA-LEO-COMPLETION-001-B`). Setting this true does NOT bypass the guard's own fail-closed check: the resolved target session must still carry `metadata.account_profile === 'canary'` and a `Canary-` namespaced callsign, or the mutation is rejected before any underlying verb runs. See [`u4-cookie-non-leak-spec.md`](./u4-cookie-non-leak-spec.md) for the isolation proof this harness composes with.
+
 ## Safety Invariants (enforced in code, not just documented)
 
 - **Spawn-detached**: every spawn uses `child_process.spawn(..., { detached: true, stdio: 'ignore' }); child.unref()` — the supervisor is never the OS process-parent, so a supervisor crash/kill never kills a fleet session.


### PR DESCRIPTION
## Summary

- Documents the `FLEET_CANARY_KILL_ENABLED` env flag in `.env.example`, mirroring the existing `FLEET_SPAWN_CONTROL_LIVE` convention (shipped in PR #6375 but not yet documented there).
- Adds a cross-reference note in `fleet-spawn-control.md` clarifying that the flag does NOT bypass the fail-closed `account_profile`/callsign guard.

## Test plan

- [x] Doc-only change, no code touched
- [x] Verified against the shipped `lib/fleet/canary-guard.js` (`isCanaryKillEnabled`) to confirm the flag name and default-OFF behavior match

🤖 Generated with [Claude Code](https://claude.com/claude-code)