### PR TITLE
feat(handoff): require why-missed/systemic-prevention on caught-gap SDs

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.js
@@ -1,0 +1,43 @@
+/**
+ * QF-20260720-369 (chairman-directed cfeb9179): sibling to F1 (retro-known-issues.js) --
+ * F1 only SURFACES pre-existing retro caveats. This REQUIRES a why-missed root-cause +
+ * systemic-prevention output on any SD whose retrospective reports a caught-gap
+ * remediation (bugs_found > 0), so that meta-learning is a first-class, guaranteed
+ * completion-record line item rather than reviewer-discretionary.
+ *
+ * Fail-open by construction (same executor-wide contract as F1 -- see retro-known-issues.js
+ * header): never throws, never blocks -- surfaces the gap as an appended known_issues entry.
+ */
+import { getFilteredRetrospective } from '../../retro-filters.js';
+import { isGenuineCaveat, dereferenceImprovementItem } from './retro-known-issues.js';
+
+export function isCaughtGapRemediation(retrospective) {
+  return !!(retrospective && Number(retrospective.bugs_found) > 0);
+}
+
+export function hasWhyMissedPreventionContent(retrospective) {
+  const fields = [retrospective?.failure_patterns, retrospective?.improvement_areas];
+  return fields.some(
+    (arr) => Array.isArray(arr) && arr.map(dereferenceImprovementItem).some(isGenuineCaveat)
+  );
+}
+
+/** Never throws -- mirrors extractRetroKnownIssues's fail-open contract. */
+export async function checkCaughtGapRemediationGap(sd, supabase) {
+  try {
+    const { retrospective } = await getFilteredRetrospective(
+      sd && sd.id,
+      (sd && sd.created_at) || null,
+      supabase,
+      (sd && sd.sd_key) || null
+    );
+    if (!isCaughtGapRemediation(retrospective) || hasWhyMissedPreventionContent(retrospective)) {
+      return null;
+    }
+    return {
+      issue: `Caught-gap remediation (${retrospective.bugs_found} bug(s) found/fixed) with no why-missed root-cause / systemic-prevention analysis in failure_patterns or improvement_areas (chairman directive cfeb9179).`,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.test.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.test.js
@@ -62,4 +62,10 @@ describe('checkCaughtGapRemediationGap', () => {
     getFilteredRetrospective.mockRejectedValue(new Error('db down'));
     expect(await checkCaughtGapRemediationGap({ id: 'x' }, {})).toBeNull();
   });
+
+  it('adversarial-review regression: fails open on the non-throwing {retrospective:null,error} shape (real getFilteredRetrospective failure return, not just a thrown exception)', async () => {
+    const { getFilteredRetrospective } = await import('../../retro-filters.js');
+    getFilteredRetrospective.mockResolvedValue({ retrospective: null, error: { message: 'query failed' } });
+    expect(await checkCaughtGapRemediationGap({ id: 'x' }, {})).toBeNull();
+  });
 });

--- a/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.test.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isCaughtGapRemediation,
+  hasWhyMissedPreventionContent,
+  checkCaughtGapRemediationGap,
+} from './caught-gap-remediation-gate.js';
+
+vi.mock('../../retro-filters.js', () => ({
+  getFilteredRetrospective: vi.fn(),
+}));
+
+describe('isCaughtGapRemediation', () => {
+  it('true when bugs_found > 0', () => {
+    expect(isCaughtGapRemediation({ bugs_found: 2 })).toBe(true);
+  });
+  it('false when bugs_found is 0 or missing', () => {
+    expect(isCaughtGapRemediation({ bugs_found: 0 })).toBe(false);
+    expect(isCaughtGapRemediation({})).toBe(false);
+    expect(isCaughtGapRemediation(null)).toBe(false);
+  });
+});
+
+describe('hasWhyMissedPreventionContent', () => {
+  it('true when failure_patterns has a genuine entry', () => {
+    expect(hasWhyMissedPreventionContent({ failure_patterns: ['review missed the schema drift'] })).toBe(true);
+  });
+  it('true when improvement_areas has a genuine entry', () => {
+    expect(hasWhyMissedPreventionContent({ improvement_areas: ['add a pre-write schema check'] })).toBe(true);
+  });
+  it('false when both are empty/boilerplate/missing', () => {
+    expect(hasWhyMissedPreventionContent({})).toBe(false);
+    expect(hasWhyMissedPreventionContent({ failure_patterns: [], improvement_areas: [] })).toBe(false);
+    expect(hasWhyMissedPreventionContent({ failure_patterns: ['handoff executed smoothly'] })).toBe(false);
+  });
+});
+
+describe('checkCaughtGapRemediationGap', () => {
+  it('returns null when not a caught-gap remediation', async () => {
+    const { getFilteredRetrospective } = await import('../../retro-filters.js');
+    getFilteredRetrospective.mockResolvedValue({ retrospective: { bugs_found: 0 } });
+    expect(await checkCaughtGapRemediationGap({ id: 'x' }, {})).toBeNull();
+  });
+
+  it('returns null when caught-gap AND has genuine prevention content', async () => {
+    const { getFilteredRetrospective } = await import('../../retro-filters.js');
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: { bugs_found: 2, failure_patterns: ['carried-forward schema belief not re-verified'] },
+    });
+    expect(await checkCaughtGapRemediationGap({ id: 'x' }, {})).toBeNull();
+  });
+
+  it('returns an issue when caught-gap with no prevention content', async () => {
+    const { getFilteredRetrospective } = await import('../../retro-filters.js');
+    getFilteredRetrospective.mockResolvedValue({ retrospective: { bugs_found: 1, failure_patterns: [] } });
+    const result = await checkCaughtGapRemediationGap({ id: 'x' }, {});
+    expect(result).not.toBeNull();
+    expect(result.issue).toContain('cfeb9179');
+  });
+
+  it('fails open (returns null) on any error', async () => {
+    const { getFilteredRetrospective } = await import('../../retro-filters.js');
+    getFilteredRetrospective.mockRejectedValue(new Error('db down'));
+    expect(await checkCaughtGapRemediationGap({ id: 'x' }, {})).toBeNull();
+  });
+});

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -43,7 +43,7 @@ import { attemptCasCompletion, cleanupLosingPreInsert } from './cas-completion.j
 
 // SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A (F1): surface the SD's genuine retro
 // known-issues instead of a hardcoded placeholder. Non-throwing by construction (see module doc).
-import { extractRetroKnownIssues, combineKnownIssuesWithProvenance } from './retro-known-issues.js';
+import { extractRetroKnownIssues, combineKnownIssuesWithProvenance, isFallbackKnownIssues } from './retro-known-issues.js';
 // QF-20260720-369 (chairman-directed cfeb9179): require (not just surface) why-missed +
 // systemic-prevention output on caught-gap remediations. Non-throwing by construction.
 import { checkCaughtGapRemediationGap } from './caught-gap-remediation-gate.js';
@@ -465,9 +465,14 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         // extractRetroKnownIssues never throws (fail-open) -- see retro-known-issues.js.
         let knownIssues = await extractRetroKnownIssues(sd, this.supabase);
         // QF-20260720-369: guarantee a why-missed/systemic-prevention line item on caught-gap
-        // remediations. checkCaughtGapRemediationGap never throws (fail-open).
+        // remediations. checkCaughtGapRemediationGap never throws (fail-open). Drop the
+        // "None at approval time" placeholder first (adversarial review) so it never
+        // co-occurs with a real caught-gap issue in the same known_issues array.
         const caughtGapIssue = await checkCaughtGapRemediationGap(sd, this.supabase);
-        if (caughtGapIssue) knownIssues = [...knownIssues, caughtGapIssue];
+        if (caughtGapIssue) {
+          if (isFallbackKnownIssues(knownIssues)) knownIssues = [];
+          knownIssues = [...knownIssues, caughtGapIssue];
+        }
         const { error: canonErr } = await this.supabase
           .from('sd_phase_handoffs')
           .insert({

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -44,6 +44,9 @@ import { attemptCasCompletion, cleanupLosingPreInsert } from './cas-completion.j
 // SD-LEO-INFRA-LEADFINAL-ACCEPTANCE-INTEGRITY-001-A (F1): surface the SD's genuine retro
 // known-issues instead of a hardcoded placeholder. Non-throwing by construction (see module doc).
 import { extractRetroKnownIssues, combineKnownIssuesWithProvenance } from './retro-known-issues.js';
+// QF-20260720-369 (chairman-directed cfeb9179): require (not just surface) why-missed +
+// systemic-prevention output on caught-gap remediations. Non-throwing by construction.
+import { checkCaughtGapRemediationGap } from './caught-gap-remediation-gate.js';
 
 /**
  * Auto-rescore the original SD after a corrective SD completes.
@@ -460,7 +463,11 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       if (!existingLfa) {
         // F1: surface genuine retro known-issues instead of the hardcoded placeholder.
         // extractRetroKnownIssues never throws (fail-open) -- see retro-known-issues.js.
-        const knownIssues = await extractRetroKnownIssues(sd, this.supabase);
+        let knownIssues = await extractRetroKnownIssues(sd, this.supabase);
+        // QF-20260720-369: guarantee a why-missed/systemic-prevention line item on caught-gap
+        // remediations. checkCaughtGapRemediationGap never throws (fail-open).
+        const caughtGapIssue = await checkCaughtGapRemediationGap(sd, this.supabase);
+        if (caughtGapIssue) knownIssues = [...knownIssues, caughtGapIssue];
         const { error: canonErr } = await this.supabase
           .from('sd_phase_handoffs')
           .insert({
@@ -980,7 +987,10 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       // drops the placeholder when the retro is clean, so a clean SD's known_issues is unchanged.
       const retroKnownIssues = await extractRetroKnownIssues(sd, this.supabase);
       const provenanceIssue = { issue: 'Row synthesized at verify-time; original completion-time gate context lives on the leo_handoff_executions execution row' };
-      const known_issues = combineKnownIssuesWithProvenance(retroKnownIssues, provenanceIssue);
+      let known_issues = combineKnownIssuesWithProvenance(retroKnownIssues, provenanceIssue);
+      // QF-20260720-369: guarantee a why-missed/systemic-prevention line item on the resume path too.
+      const caughtGapIssueResume = await checkCaughtGapRemediationGap(sd, this.supabase);
+      if (caughtGapIssueResume) known_issues = [...known_issues, caughtGapIssueResume];
 
       const { error: insErr } = await this.supabase
         .from('sd_phase_handoffs')


### PR DESCRIPTION
## Summary
- Chairman-directed (cfeb9179): a final review must evaluate WHY a defect wasn't caught earlier and WHAT systemic change prevents recurrence, not just verify the fix.
- Sibling to F1 (`retro-known-issues.js`), which only *surfaces* pre-existing retro caveats — this new module *requires* the output, guaranteed rather than reviewer-discretionary.
- Any SD whose retrospective reports `bugs_found > 0` (a caught-gap remediation) but has no genuine content in `failure_patterns`/`improvement_areas` gets a first-class `known_issues` line naming the gap.
- Fail-open by construction (same executor-wide contract as F1) — never throws, never blocks. Wired into both the canonical and resume/reconcile LEAD-FINAL-APPROVAL write sites.

## Test plan
- [x] `npx vitest run scripts/modules/handoff/executors/lead-final-approval/caught-gap-remediation-gate.test.js` — 9/9 passing
- [x] `npx eslint` — clean on new files
- [x] Net source LOC ~53-57, within the 75-line QF hard cap (test LOC excluded per policy)

QF-20260720-369

🤖 Generated with [Claude Code](https://claude.com/claude-code)