### PR TITLE
feat(SD-LEO-INFRA-LEO-COMPLETION-001-E): operator cockpit wiring + model/effort chips + U4 drill mechanism

### DIFF
--- a/lib/fleet/u4-drill-runner.js
+++ b/lib/fleet/u4-drill-runner.js
@@ -1,0 +1,164 @@
+/**
+ * U4 (agent-browser cookie-non-leak) live-drill runner -- SD-LEO-INFRA-LEO-COMPLETION-001-E (FR-3).
+ *
+ * Implements the 4 PASS/FAIL observable checks from docs/protocol/u4-cookie-non-leak-spec.md
+ * (secs 3-4) against a real canaryRelaunchUnderProfile() call (lib/fleet/canary-guard.js) --
+ * "one command, zero code changes" once the canary precondition exists (Solomon guard G3).
+ *
+ * MECHANISM-READY, NOT LIVE-EXECUTED: this module has never been run against a real canary
+ * account. That precondition (a genuinely provisioned second Claude Code account/profile,
+ * FLEET_ACCOUNT_PROFILES_DIR + FLEET_SPAWN_CONTROL_LIVE + FLEET_CANARY_KILL_ENABLED, a real
+ * claude_sessions row with metadata.account_profile='canary') does not exist in this environment
+ * and requires chairman/operator action (SD-LEO-INFRA-LEO-COMPLETION-001-E LEAD phase finding,
+ * Solomon consult be988d3e / ruling 6922c7c9). Do NOT remove this notice or claim a live pass
+ * anywhere until runU4Drill() has actually been invoked against a real canary session (Solomon
+ * guard G4: delivered-mechanism + proof-pending is the honest state).
+ */
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolveProfileDir } from './spawn-control.js';
+import { canaryRelaunchUnderProfile } from './canary-guard.js';
+
+/**
+ * PASS/FAIL check 1: supervisor's own CLAUDE_CONFIG_DIR must be byte-identical before/after the
+ * call. relaunchUnderProfile() already throws on violation (spawn-control.js:306-313) -- this
+ * check captures that throw as an explicit, reportable observable rather than letting it escape
+ * uncaught (spec section 4: "the throw itself is the failure signal ... must capture and assert
+ * on, not silently swallow").
+ * @param {Function} relaunchFn - injectable seam for tests; defaults to canaryRelaunchUnderProfile
+ * @returns {Promise<{name:string, pass:boolean, detail:string, result?:object}>}
+ */
+export async function checkSupervisorEnvInvariant(target, accountProfile, opts, relaunchFn = canaryRelaunchUnderProfile) {
+  const before = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const result = await relaunchFn(target, accountProfile, opts);
+    const after = process.env.CLAUDE_CONFIG_DIR;
+    if (before !== after) {
+      return { name: 'supervisor_env_invariant', pass: false, detail: 'CLAUDE_CONFIG_DIR changed on the supervisor process', result };
+    }
+    return { name: 'supervisor_env_invariant', pass: true, detail: 'CLAUDE_CONFIG_DIR unchanged before/after', result };
+  } catch (err) {
+    return { name: 'supervisor_env_invariant', pass: false, detail: `relaunch threw: ${err.message}` };
+  }
+}
+
+/**
+ * PASS/FAIL check 2: resolveProfileDir(B) must be distinct from resolveProfileDir(A), and neither
+ * a parent nor a child path of the other (directory-collision/traversal escape).
+ * @param {Function} resolveFn - injectable seam; defaults to spawn-control.js's resolveProfileDir
+ */
+export function checkProfileDirNonCollision(profileA, profileB, opts = {}, resolveFn = resolveProfileDir) {
+  const dirA = resolveFn(profileA, opts);
+  const dirB = resolveFn(profileB, opts);
+  const normA = dirA.toLowerCase().replace(/\\+$/, '');
+  const normB = dirB.toLowerCase().replace(/\\+$/, '');
+  const collides = normA === normB || normA.startsWith(normB + '\\') || normB.startsWith(normA + '\\');
+  return {
+    name: 'profile_dir_non_collision',
+    pass: !collides,
+    detail: collides ? `profile dirs collide or nest: ${dirA} vs ${dirB}` : `distinct, non-nested dirs: ${dirA} vs ${dirB}`,
+  };
+}
+
+/**
+ * PASS/FAIL check 3: no file under profile A's directory is reachable via profile B's directory
+ * (copy/symlink/path-traversal). Injectable filesystem seam so this is fixture-testable without
+ * touching a real disk.
+ * @param {{listFiles: (dir:string) => string[], realpath: (p:string) => string}} fs - injectable
+ */
+export function checkCrossProfileFilesystemReachability(dirA, dirB, fs) {
+  let filesA;
+  try {
+    filesA = fs.listFiles(dirA);
+  } catch (err) {
+    return { name: 'cross_profile_filesystem_reachability', pass: true, detail: `profile A dir unreadable (nothing to leak): ${err.message}` };
+  }
+  const leaked = [];
+  for (const relPath of filesA) {
+    let realA;
+    let realB;
+    try {
+      realA = fs.realpath(`${dirA}\\${relPath}`);
+    } catch { continue; }
+    try {
+      realB = fs.realpath(`${dirB}\\${relPath}`);
+    } catch { continue; }
+    if (realA === realB) leaked.push(relPath);
+  }
+  return {
+    name: 'cross_profile_filesystem_reachability',
+    pass: leaked.length === 0,
+    detail: leaked.length === 0 ? 'no file under profile A reachable via profile B' : `reachable across profiles: ${leaked.join(', ')}`,
+  };
+}
+
+/**
+ * PASS/FAIL check 4: a fleet_verb_relaunch_under_profile event must exist for the drill's own
+ * invocation (log-before-action, spec section 2.5 / 4). Injectable query seam.
+ * @param {(sessionId:string) => Promise<Array<object>>} queryEventsFn
+ */
+export async function checkEventLogPresence(sessionId, queryEventsFn) {
+  const events = await queryEventsFn(sessionId);
+  const found = (events || []).some((e) => e && e.event_type === 'fleet_verb_relaunch_under_profile');
+  return {
+    name: 'event_log_presence',
+    pass: found,
+    detail: found ? 'fleet_verb_relaunch_under_profile event found' : 'no fleet_verb_relaunch_under_profile event recorded for this call',
+  };
+}
+
+/**
+ * Run all 4 checks against a canary-targeted relaunch-under-profile call. NOT executed live in
+ * this repo -- see module header. When the canary precondition exists, this is the "one command"
+ * Solomon's guard G3 requires: no code change needed, only a real target/profile/fs/query wiring.
+ * @param {{target:string, fromProfile:string, toProfile:string, sessionId:string, opts?:object,
+ *   relaunchFn?:Function, resolveFn?:Function, fs?:object, queryEventsFn?:Function}} args
+ * @returns {Promise<{pass:boolean, checks:Array<object>}>}
+ */
+export async function runU4Drill({ target, fromProfile, toProfile, sessionId, opts = {}, relaunchFn, resolveFn, fs, queryEventsFn }) {
+  const checks = [];
+  checks.push(await checkSupervisorEnvInvariant(target, toProfile, opts, relaunchFn));
+  checks.push(checkProfileDirNonCollision(fromProfile, toProfile, opts, resolveFn));
+  if (fs) {
+    const dirA = (resolveFn || resolveProfileDir)(fromProfile, opts);
+    const dirB = (resolveFn || resolveProfileDir)(toProfile, opts);
+    checks.push(checkCrossProfileFilesystemReachability(dirA, dirB, fs));
+  }
+  if (queryEventsFn) {
+    checks.push(await checkEventLogPresence(sessionId, queryEventsFn));
+  }
+  return { pass: checks.every((c) => c.pass), checks };
+}
+
+/**
+ * CLI entry -- explicitly states this has NOT run live and names the exact precondition.
+ * `node lib/fleet/u4-drill-runner.js --help` (or any invocation without a real canary session)
+ * prints this notice rather than attempting a mutation.
+ */
+export function printLiveExecutionPrecondition() {
+  return [
+    'U4 drill runner is MECHANISM-READY, not live-executed.',
+    'Live execution requires (all of):',
+    '  1. A canary CLAUDE_CONFIG_DIR profile logged into one of the chairman\'s existing accounts',
+    '     (not the fleet\'s current active account) -- Solomon: does NOT require a new Anthropic account.',
+    '  2. FLEET_ACCOUNT_PROFILES_DIR set to the profiles base directory.',
+    '  3. FLEET_SPAWN_CONTROL_LIVE=true and FLEET_CANARY_KILL_ENABLED=true, after host-validating',
+    '     the wt.exe live-spawn invocation on this host (docs/protocol/fleet-spawn-control.md).',
+    '  4. A real claude_sessions row with metadata.account_profile=\'canary\' and a Canary- callsign.',
+    'Owner: chairman. Once provisioned, run this module\'s runU4Drill() against the real canary',
+    'session -- zero code changes needed (Solomon guard G3).',
+  ].join('\n');
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  // eslint-disable-next-line no-console
+  console.log(printLiveExecutionPrecondition());
+}

--- a/lib/fleet/u4-drill-runner.js
+++ b/lib/fleet/u4-drill-runner.js
@@ -1,4 +1,11 @@
 /**
+ * @wire-check-exempt: deliberately NOT wired to a live caller -- the canary precondition (see
+ * below) does not exist yet, so there is no real invocation site to wire this into today. Mirrors
+ * session-detail-view.js's own exemption reasoning (built-ahead-of-its-consumer), except here the
+ * blocking precondition is an external chairman action, not a missing UI shell. Wire this in once
+ * the canary account is provisioned -- Solomon guard G3 requires that to be a one-command change,
+ * not a new integration.
+ *
  * U4 (agent-browser cookie-non-leak) live-drill runner -- SD-LEO-INFRA-LEO-COMPLETION-001-E (FR-3).
  *
  * Implements the 4 PASS/FAIL observable checks from docs/protocol/u4-cookie-non-leak-spec.md

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -48,6 +48,13 @@ const { getAccountIdentity } = require('../lib/fleet/account-identity.cjs');
 // SD-LEO-INFRA-FLEET-VIEW-BADGES-001 (FR-1/FR-2): capacity chip + per-session badge rollup.
 const { loadStore } = require('../lib/fleet/account-capacity-gauge.cjs');
 const { formatCapacityChip, computeSessionBadge } = require('../lib/fleet/fleet-view-badges.cjs');
+// SD-LEO-INFRA-LEO-COMPLETION-001-E (FR-2): per-session model/effort chip, sourced from
+// claude_sessions.metadata.model/.effort (already written by lib/checkin/steps/model-effort-merge.cjs).
+function formatModelEffortChip(s) {
+  const model = s.model || '-';
+  const effort = s.effort || '-';
+  return `${model}/${effort}`;
+}
 
 const STALE_THRESHOLD = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS, 10) || 300;
 
@@ -286,7 +293,7 @@ async function loadData() {
       // through this SAME already-working telemetry-merge seam instead of a new query.
       const { data: teleRows } = await supabase
         .from('claude_sessions')
-        .select('session_id,current_tool,current_tool_expected_end_at,expected_silence_until,process_alive_at,last_activity_kind,commits_since_claim,files_modified_since_claim,current_phase,handoff_fail_count,has_uncommitted_changes')
+        .select('session_id,current_tool,current_tool_expected_end_at,expected_silence_until,process_alive_at,last_activity_kind,commits_since_claim,files_modified_since_claim,current_phase,handoff_fail_count,has_uncommitted_changes,metadata')
         .in('session_id', ids);
       for (const row of teleRows || []) telemetryById.set(row.session_id, row);
     }
@@ -306,6 +313,9 @@ async function loadData() {
       current_phase: t.current_phase,
       handoff_fail_count: t.handoff_fail_count,
       has_uncommitted_changes: t.has_uncommitted_changes,
+      // SD-LEO-INFRA-LEO-COMPLETION-001-E (FR-2): model/effort chip source.
+      model: t.metadata && t.metadata.model,
+      effort: t.metadata && t.metadata.effort,
     });
   }
   const hasTickAlive = (s) => {
@@ -508,7 +518,7 @@ function printWorkers(d) {
   } else {
     const csidHeader = hasCollision ? pad('CSID', 12) : '';
     const mcHeader = mcOk ? pad('P(alive)', 16) : '';
-    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('LoopState', 14) + pad('Badge', 12) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
+    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('LoopState', 14) + pad('Badge', 12) + pad('Model/Effort', 16) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
     // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: LoopState column (14 chars) added between WIP and Activity → 14-char wider separator.
     console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 150 : 134) : (mcOk ? 138 : 122)));
     for (const s of d.activeSessions) {
@@ -541,7 +551,8 @@ function printWorkers(d) {
         isSilent: Boolean(silent),
         failCount: s.handoff_fail_count,
       });
-      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(loopCell, 14) + pad(badge, 12) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
+      const modelEffortChip = formatModelEffortChip(s);
+      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(loopCell, 14) + pad(badge, 12) + pad(modelEffortChip, 16) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
     }
   }
 
@@ -1591,6 +1602,79 @@ async function printAttentionStrip() {
   console.log('');
 }
 
+// ── Section: Operator cockpit session actions (SD-LEO-INFRA-LEO-COMPLETION-001-E, FR-1) ──
+// Wires lib/fleet/session-detail-view.js's buildSessionDetailView() and lib/fleet/browser-control.js's
+// requestBrowserSession()/signalTakeover() into REAL production callers (G3 no-unit-mock proof: these
+// were previously fully built, tested, and had ZERO callers anywhere in the repo). Each action does its
+// OWN targeted fetch (not the batch loadData()) per session-detail-view.js's own contract: "a caller
+// does the fetching, and passes the results in".
+async function resolveSessionRow(idOrCallsign) {
+  const { data } = await supabase
+    .from('claude_sessions')
+    .select('session_id,current_tool,last_tool_at,last_activity_kind,expected_silence_until,metadata,sd_key')
+    .or(`session_id.eq.${idOrCallsign},metadata->fleet_identity->>callsign.eq.${idOrCallsign}`)
+    .limit(2);
+  if (!data || data.length === 0) return { error: `no session found for '${idOrCallsign}'` };
+  if (data.length > 1) return { error: `ambiguous identifier '${idOrCallsign}' matched ${data.length} sessions` };
+  return { session: data[0] };
+}
+
+async function printSessionDetail(idOrCallsign) {
+  if (!idOrCallsign) { console.log('Usage: node scripts/fleet-dashboard.cjs detail <session-id-or-callsign>'); return; }
+  const { buildSessionDetailView } = await import('../lib/fleet/session-detail-view.js');
+  const { attach } = await import('../lib/fleet/spawn-control.js');
+  const { session, error } = await resolveSessionRow(idOrCallsign);
+  if (error) { console.log('  ' + error); return; }
+  const { data: ctxRows } = await supabase
+    .from('context_usage_log')
+    .select('usage_percent')
+    .eq('session_id', session.session_id)
+    .order('timestamp', { ascending: false })
+    .limit(1);
+  const ctxRow = ctxRows && ctxRows[0];
+  let attachResult = null;
+  try {
+    attachResult = await attach(idOrCallsign, { supabaseClient: supabase });
+  } catch (e) {
+    attachResult = { ok: false, reason: 'attach_threw' };
+  }
+  const view = buildSessionDetailView(session, { ctxRow, attachResult });
+  console.log('SESSION DETAIL — ' + session.session_id);
+  console.log('─'.repeat(72));
+  console.log('  Context used:   ' + (view.ctxPercent != null ? view.ctxPercent + '%' : 'unknown'));
+  console.log('  Last tool:      ' + (view.lastTool || '-') + (view.lastToolAt ? ' @ ' + view.lastToolAt : ''));
+  console.log('  Last activity:  ' + (view.lastActivityKind || '-'));
+  console.log('  Silent until:   ' + (view.silentUntil || '-'));
+  console.log('  Attach state:   ' + (view.attachState.message || (view.attachState.ok ? 'attached' : 'not attempted')));
+  console.log('');
+}
+
+async function printBrowserRequestAction(idOrCallsign) {
+  if (!idOrCallsign) { console.log('Usage: node scripts/fleet-dashboard.cjs browser-request <session-id-or-callsign>'); return; }
+  const { requestBrowserSession } = await import('../lib/fleet/browser-control.js');
+  const { session, error } = await resolveSessionRow(idOrCallsign);
+  if (error) { console.log('  ' + error); return; }
+  const result = requestBrowserSession(session);
+  if (!result.ok) { console.log('  browser session refused: ' + result.reason); return; }
+  console.log('BROWSER SESSION LAUNCH OPTIONS — ' + session.session_id);
+  console.log('─'.repeat(72));
+  console.log('  ' + JSON.stringify(result.launchOptions, null, 2).split('\n').join('\n  '));
+  console.log('');
+}
+
+async function printTakeoverAction(idOrCallsign) {
+  if (!idOrCallsign) { console.log('Usage: node scripts/fleet-dashboard.cjs takeover <session-id-or-callsign>'); return; }
+  const { signalTakeover } = await import('../lib/fleet/browser-control.js');
+  const { session, error } = await resolveSessionRow(idOrCallsign);
+  if (error) { console.log('  ' + error); return; }
+  try {
+    await signalTakeover(supabase, session.session_id, session.sd_key || null);
+    console.log('  Takeover signaled for ' + session.session_id + ' — agent-driven browser actions paused.');
+  } catch (e) {
+    console.log('  takeover failed: ' + e.message);
+  }
+}
+
 // ── Section: Adam advisory inbox (SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B) ──
 // Surfaces Adam advisories (payload.kind=adam_advisory) in a SEPARATE section from
 // the worker-friction inbox (printInbox). Adam advisories deliberately omit
@@ -2323,8 +2407,21 @@ async function printFeedback(d, deps = {}) {
 
 // ── Main ──
 
+// SD-LEO-INFRA-LEO-COMPLETION-001-E (FR-1): session-scoped actions take a 2nd positional arg
+// (session-id-or-callsign), so they are routed BEFORE the section-only dispatch below.
+const SESSION_SCOPED_ACTIONS = {
+  'detail': printSessionDetail,
+  'browser-request': printBrowserRequestAction,
+  'takeover': printTakeoverAction,
+};
+
 async function main() {
-  const section = (process.argv[2] || 'all').toLowerCase();
+  const command = (process.argv[2] || 'all').toLowerCase();
+  if (SESSION_SCOPED_ACTIONS[command]) {
+    await SESSION_SCOPED_ACTIONS[command](process.argv[3]);
+    return;
+  }
+  const section = command;
   const suppressEnabled = section === 'all' && process.env.FLEET_DASH_SUPPRESS !== 'false';
   const buf = []; const origLog = console.log;
   if (suppressEnabled) console.log = (...a) => buf.push(util.format(...a));

--- a/tests/unit/fleet/u4-drill-runner.test.js
+++ b/tests/unit/fleet/u4-drill-runner.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-E FR-3 -- U4 (agent-browser cookie-non-leak) live-drill runner.
+ * Fixture-tested against docs/protocol/u4-cookie-non-leak-spec.md's PASS/FAIL observables (secs 3-4).
+ * NOT a live drill: no canary account is provisioned in this environment (see module header).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  checkSupervisorEnvInvariant,
+  checkProfileDirNonCollision,
+  checkCrossProfileFilesystemReachability,
+  checkEventLogPresence,
+  runU4Drill,
+  printLiveExecutionPrecondition,
+} from '../../../lib/fleet/u4-drill-runner.js';
+
+describe('checkSupervisorEnvInvariant', () => {
+  it('PASSes when CLAUDE_CONFIG_DIR is unchanged before/after the relaunch call', async () => {
+    const before = process.env.CLAUDE_CONFIG_DIR;
+    const relaunchFn = vi.fn(async () => ({ ok: true }));
+    const result = await checkSupervisorEnvInvariant('Canary-1', 'B', {}, relaunchFn);
+    expect(result).toEqual({ name: 'supervisor_env_invariant', pass: true, detail: 'CLAUDE_CONFIG_DIR unchanged before/after', result: { ok: true } });
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(before);
+  });
+
+  it('FAILs and captures the throw when relaunchUnderProfile violates the isolation invariant', async () => {
+    const relaunchFn = vi.fn(async () => { throw new Error('relaunchUnderProfile: supervisor process.env.CLAUDE_CONFIG_DIR changed -- isolation invariant violated'); });
+    const result = await checkSupervisorEnvInvariant('Canary-1', 'B', {}, relaunchFn);
+    expect(result.pass).toBe(false);
+    expect(result.name).toBe('supervisor_env_invariant');
+    expect(result.detail).toMatch(/isolation invariant violated/);
+  });
+});
+
+describe('checkProfileDirNonCollision', () => {
+  it('PASSes on two distinct, non-nested directories', () => {
+    const resolveFn = (name) => `C:\\profiles\\${name}`;
+    const result = checkProfileDirNonCollision('A', 'B', {}, resolveFn);
+    expect(result).toEqual({ name: 'profile_dir_non_collision', pass: true, detail: 'distinct, non-nested dirs: C:\\profiles\\A vs C:\\profiles\\B' });
+  });
+
+  it('FAILs when both profiles resolve to the same directory (collision)', () => {
+    const resolveFn = () => 'C:\\profiles\\shared';
+    const result = checkProfileDirNonCollision('A', 'B', {}, resolveFn);
+    expect(result.pass).toBe(false);
+    expect(result.detail).toMatch(/collide/);
+  });
+
+  it('FAILs when one profile dir is nested inside the other (traversal-style escape)', () => {
+    const resolveFn = (name) => (name === 'A' ? 'C:\\profiles\\A' : 'C:\\profiles\\A\\sub');
+    const result = checkProfileDirNonCollision('A', 'B', {}, resolveFn);
+    expect(result.pass).toBe(false);
+    expect(result.detail).toMatch(/collide/);
+  });
+});
+
+describe('checkCrossProfileFilesystemReachability', () => {
+  it('PASSes when no file under profile A is reachable via profile B', () => {
+    const fs = {
+      listFiles: () => ['cookies.json'],
+      realpath: (p) => p, // no symlink resolution -> distinct real paths per dir
+    };
+    const result = checkCrossProfileFilesystemReachability('C:\\profiles\\A', 'C:\\profiles\\B', fs);
+    expect(result.pass).toBe(true);
+  });
+
+  it('FAILs when a file under profile A resolves to the SAME real path under profile B (symlink/copy leak)', () => {
+    const fs = {
+      listFiles: () => ['cookies.json'],
+      realpath: () => 'C:\\profiles\\A\\cookies.json', // both paths resolve identically -> leak
+    };
+    const result = checkCrossProfileFilesystemReachability('C:\\profiles\\A', 'C:\\profiles\\B', fs);
+    expect(result.pass).toBe(false);
+    expect(result.detail).toMatch(/cookies\.json/);
+  });
+
+  it('PASSes (nothing to leak) when profile A dir is unreadable', () => {
+    const fs = { listFiles: () => { throw new Error('ENOENT'); }, realpath: () => { throw new Error('n/a'); } };
+    const result = checkCrossProfileFilesystemReachability('C:\\profiles\\A', 'C:\\profiles\\B', fs);
+    expect(result.pass).toBe(true);
+  });
+});
+
+describe('checkEventLogPresence', () => {
+  it('PASSes when a fleet_verb_relaunch_under_profile event is recorded', async () => {
+    const queryEventsFn = vi.fn(async () => [{ event_type: 'fleet_verb_relaunch_under_profile' }]);
+    const result = await checkEventLogPresence('s-canary', queryEventsFn);
+    expect(result.pass).toBe(true);
+  });
+
+  it('FAILs (log-before-action violated) when no such event exists', async () => {
+    const queryEventsFn = vi.fn(async () => []);
+    const result = await checkEventLogPresence('s-canary', queryEventsFn);
+    expect(result.pass).toBe(false);
+    expect(result.detail).toMatch(/no fleet_verb_relaunch_under_profile event/);
+  });
+});
+
+describe('runU4Drill', () => {
+  it('PASSes overall when all wired checks pass', async () => {
+    const relaunchFn = vi.fn(async () => ({ ok: true }));
+    const resolveFn = (name) => `C:\\profiles\\${name}`;
+    const fs = { listFiles: () => [], realpath: (p) => p };
+    const queryEventsFn = vi.fn(async () => [{ event_type: 'fleet_verb_relaunch_under_profile' }]);
+    const { pass, checks } = await runU4Drill({
+      target: 'Canary-1', fromProfile: 'A', toProfile: 'B', sessionId: 's-canary',
+      relaunchFn, resolveFn, fs, queryEventsFn,
+    });
+    expect(pass).toBe(true);
+    expect(checks).toHaveLength(4);
+  });
+
+  it('overall FAILs if any single check fails', async () => {
+    const relaunchFn = vi.fn(async () => ({ ok: true }));
+    const resolveFn = () => 'C:\\profiles\\shared'; // collision
+    const fs = { listFiles: () => [], realpath: (p) => p };
+    const queryEventsFn = vi.fn(async () => [{ event_type: 'fleet_verb_relaunch_under_profile' }]);
+    const { pass, checks } = await runU4Drill({
+      target: 'Canary-1', fromProfile: 'A', toProfile: 'B', sessionId: 's-canary',
+      relaunchFn, resolveFn, fs, queryEventsFn,
+    });
+    expect(pass).toBe(false);
+    expect(checks.find((c) => c.name === 'profile_dir_non_collision').pass).toBe(false);
+  });
+});
+
+describe('printLiveExecutionPrecondition (no-false-live-claim guardrail)', () => {
+  it('explicitly states the runner is mechanism-ready, NOT live-executed, and names the owner + precondition', () => {
+    const text = printLiveExecutionPrecondition();
+    expect(text).toMatch(/MECHANISM-READY, not live-executed/);
+    expect(text).toMatch(/Owner: chairman/);
+    expect(text).toMatch(/FLEET_ACCOUNT_PROFILES_DIR/);
+    expect(text).toMatch(/FLEET_SPAWN_CONTROL_LIVE/);
+    expect(text).toMatch(/FLEET_CANARY_KILL_ENABLED/);
+    expect(text).not.toMatch(/live drill (passed|complete|proven)/i);
+  });
+});


### PR DESCRIPTION
## Summary
Closes Solomon checkpoint-3's G3 finding ("no operator surface") for the LEO-completion program and builds the U4 (agent-browser cookie-non-leak) live-drill mechanism against completed sibling Child B's formal spec (`docs/protocol/u4-cookie-non-leak-spec.md`).

- **G3 operator surface**: `lib/fleet/session-detail-view.js`'s `buildSessionDetailView()` and `lib/fleet/browser-control.js`'s `requestBrowserSession()`/`signalTakeover()` — fully built and unit-tested but confirmed (LEAD-phase Explore) to have **zero callers anywhere in the repo** — are now wired into `scripts/fleet-dashboard.cjs` as real, grep-provable CLI actions: `detail <id>`, `browser-request <id>`, `takeover <id>` (modeled on `scripts/working-context.cjs`'s cmd+positional pattern). Verified end-to-end against a real live session this session (not just unit-mocked), then reverted the harmless self-test state.
- **Model/effort chips**: `printWorkers()` now renders per-session model/effort, sourced from `claude_sessions.metadata.model`/`.effort` — already captured by `lib/checkin/steps/model-effort-merge.cjs`, previously unrendered anywhere.
- **U4 drill mechanism** (`lib/fleet/u4-drill-runner.js`): the 4 PASS/FAIL observable checks from the formal spec (supervisor-env invariant, profile-dir non-collision, cross-profile filesystem non-reachability, event-log presence), fixture-tested. Calls `canary-guard.js`'s `canaryRelaunchUnderProfile()` — one command, zero code changes once the canary precondition exists.

**Not executed live**: a LEAD-phase Explore pass — independently re-verified by validation-agent directly against the live DB and `.env` — confirmed no canary account/profile is provisioned in this environment (`FLEET_ACCOUNT_PROFILES_DIR`/`FLEET_SPAWN_CONTROL_LIVE`/`FLEET_CANARY_KILL_ENABLED` all unset; `account_profile='canary'` exists only in test fixtures). Provisioning one requires chairman/operator action outside an autonomous worker's authority. Routed via `solomon-consult` (correlation `be988d3e`) rather than guessed on, since this is exactly the U4 checkpoint Solomon authored. Solomon's ruling (`6922c7c9`) approved this split — build everything buildable now, defer only the live execution — with four binding guards, all honored here:
- **G1**: this known issue will be carried verbatim at LEAD-FINAL via `capture-completion-flags.js` (never "None at approval time").
- **G2**: the deferred drill is tracked as an explicit obligation (owner: chairman; release condition: canary profile + 3 env flags + host-validated `wt.exe`), not silent memory.
- **G3**: the runner is drill-*ready*, not drill-*shaped* — `runU4Drill()` needs zero code changes once a real canary target exists.
- **G4**: nothing anywhere (code, tests, comments, this PR) claims the live drill has run — delivered-mechanism + proof-pending is the honest state, enforced by a dedicated guardrail test.

## Test plan
- [x] `tests/unit/fleet/u4-drill-runner.test.js` (new, 13 tests): all 4 PASS/FAIL checks covered both ways, plus a guardrail test asserting the module's own output never claims a live pass.
- [x] Zero regressions: 828 tests across `tests/unit/fleet/` + every test file touching `fleet-dashboard.cjs` directly, all green.
- [x] Manual smoke run against the live fleet: `detail`/`browser-request`/`takeover` all exercised for real (including a real `signalTakeover` DB write + revert), confirming graceful degradation on bad/ambiguous session identifiers.
- [x] `grep -rn "buildSessionDetailView\|requestBrowserSession\|signalTakeover" scripts/fleet-dashboard.cjs` shows real call sites (the G3 no-unit-mock proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)