### PR TITLE
feat(SD-LEO-INFRA-LEO-COMPLETION-001-C): killable fleet supervisor + de-mask kill-supervisor test (G1a)

### DIFF
--- a/docs/protocol/fleet-supervisor-live-drill.md
+++ b/docs/protocol/fleet-supervisor-live-drill.md
@@ -1,0 +1,74 @@
+# Fleet Supervisor — Kill-Survival Live Drill (G1a)
+
+**SD:** SD-LEO-INFRA-LEO-COMPLETION-001-C · **Owner acceptance:** Solomon re-run · **Tier:** LIVE (operator-run, not CI)
+
+This runbook proves the property that unit tests **cannot** (SIGKILL is uncatchable, and the gap G1a
+closes was itself caused by mocked seams): killing the fleet supervisor process with `kill -9` leaves
+its child sessions running, and a **real** (non-mocked) `fleet_verb_*` row lands in `coordination_events`.
+
+## ⚠️ Preconditions (all mandatory)
+
+1. **Canary account only.** Run on Child B's dedicated canary account/profile. The kill drill must
+   `assert account_profile === canary` before any kill (Child B assert-before-kill guard). NEVER run
+   against a live-fleet session.
+2. **Real Windows fleet host.** The survival property is Windows-specific (`wt.exe`, detached process
+   groups, Job Objects). Do **not** run under WSL/Linux CI — a parent Job Object with
+   `KILL_ON_JOB_CLOSE` would kill children regardless and give a false negative. Use the real host.
+3. **Live flag scoped to this shell only.** `FLEET_SPAWN_CONTROL_LIVE=true` for the drill shell; it is
+   default-OFF everywhere else and must never be set in a live-fleet session.
+
+## Steps
+
+1. **Start the supervisor (live).**
+   ```pwsh
+   $env:FLEET_SPAWN_CONTROL_LIVE = "true"
+   $env:FLEET_SUPERVISOR_ROSTER = '[{"role":"worker","callsign":"Canary-1","accountProfile":"canary"}]'
+   node scripts/fleet/fleet-supervisor.cjs
+   ```
+   Expect: the supervisor prints its own `pid` and `live=true`, spawns `Canary-1`, and a
+   `fleet_verb_spawn` row appears in `coordination_events`.
+
+2. **Record child identity.** Note the supervisor pid AND the child session. The captured pid is the
+   `wt.exe` window; the actual `claude` process is a **grandchild** — verify liveness by the
+   `claude_sessions` row (`heartbeat_at`, `pid`) for callsign `Canary-1`, not by the `wt.exe` pid alone.
+
+3. **Kill -9 the SUPERVISOR (not the child).**
+   ```pwsh
+   Stop-Process -Id <supervisor_pid> -Force   # SIGKILL-equivalent; uncatchable
+   ```
+
+4. **Verify survival (~30s later).** Re-check `Canary-1`'s `claude_sessions` row: `status` still active
+   and `heartbeat_at` advanced past the kill time → the child **survived** the supervisor's death
+   (detached + unref'd → OS re-parented it). A cascaded death = FAIL.
+
+5. **Verify a real event row.**
+   ```sql
+   SELECT id, event_type, created_at FROM coordination_events
+   WHERE event_type LIKE 'fleet_verb_%' AND created_at > '<drill_start_iso>'
+   ORDER BY created_at DESC;
+   ```
+   Expect ≥1 row (positive assertion — not "no throw"; `emitVerbEvent` is fail-open so absence is silent).
+
+## Pass criteria (maps to smoke_test_steps AC-1..AC-3)
+
+- Supervisor ran as a real killable OS process and tracked ≥1 canary child.
+- After `kill -9` of the supervisor, all canary children remain alive/heartbeating (~30s).
+- A real, non-mocked `coordination_events` `fleet_verb_*` row exists for the drill window.
+
+## Teardown / idempotency (MANDATORY — leave nothing hot)
+
+The graceful shutdown path is **non-cascading** (children survive a normal `SIGINT`/`SIGTERM`), so the
+surviving `Canary-1` must be cleaned up explicitly so a re-run does not orphan sessions:
+
+1. Stop the surviving canary child(ren): `node -e "..."` or the cockpit stop verb targeting `Canary-1`.
+2. Release their `claude_sessions` rows (`status='released'`).
+3. **Unset `FLEET_SPAWN_CONTROL_LIVE`** in the drill shell / close it.
+
+Re-running the drill from a clean canary account must reproduce the same pass criteria (idempotent).
+
+## Why unit tests are insufficient here
+
+`tests/unit/fleet/spawn-control.test.js` now asserts the **real** `detached:true`/`stdio:'ignore'`
+options reach `child_process.spawn` (mutation-verified: removing `detached:true` turns it red), and
+`tests/unit/fleet/fleet-supervisor.test.js` locks the non-cascading teardown + watch-loop remediation.
+But OS re-parenting under `kill -9` on the real Windows host is unmockable — hence this live tier.

--- a/scripts/fleet/fleet-supervisor.cjs
+++ b/scripts/fleet/fleet-supervisor.cjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Fleet supervisor -- SD-LEO-INFRA-LEO-COMPLETION-001-C (closes Solomon checkpoint-3 gap G1a).
+ *
+ * A REAL, persistent, KILLABLE launcher-shell supervisor process that owns/watches fleet child
+ * sessions by COMPOSING lib/fleet/spawn-control.js's six governed verbs (never reimplementing them).
+ * spawn-control.js today is spawn-and-forget (child.unref() at :148, zero retained reference, no
+ * watch loop); this adds the missing supervisor: a desired-state roster + a resident watch loop that
+ * re-spawns lost children in live mode and logs the intent in dry-run.
+ *
+ * KILL-SURVIVAL (the G1a property under test):
+ *   - Children are spawned DETACHED + unref'd by spawn-control.spawn, so a `kill -9` of THIS
+ *     supervisor process leaves them running -- the OS re-parents the detached children. SIGKILL is
+ *     uncatchable, so survival is a property of the detached spawn, provable only by a LIVE drill.
+ *   - The supervisor NEVER kills its children on its own death. Graceful SIGINT/SIGTERM teardown is
+ *     explicitly NON-CASCADING (stopWatch() clears the loop and exits; it does not stop/kill tracked
+ *     children). This is a distinct code path from `kill -9` and is asserted separately in unit tests
+ *     (TESTING gap #1): a graceful Ctrl-C must NOT cascade-kill the fleet.
+ *
+ * STAGED / INERT BY DEFAULT (mirrors WORKER_SPAWN_EXECUTOR_LIVE / spawn-control's own discipline):
+ *   every OS spawn/restart stays behind FLEET_SPAWN_CONTROL_LIVE (default OFF). With the flag unset
+ *   the watch loop only LOGS what it WOULD do -- it spawns/kills nothing. The live drill
+ *   (docs/protocol/fleet-supervisor-live-drill.md) runs ONLY on Child B's canary account.
+ *
+ * TESTABILITY: the pure supervisor core (createSupervisor) takes injectable seams (spawnControl,
+ * probeChild, clock, log) so the watch/detect/remediate logic is deterministic under test. The
+ * resident entrypoint (require.main === module) is a thin wrapper and does NOT auto-run on import.
+ */
+
+const path = require('node:path');
+
+/**
+ * SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001 pattern (mirrors lib/heartbeat-manager.mjs armUnrefInterval):
+ * a ref'd setInterval keeps the loop alive and, on Windows process exit, trips
+ * "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)" / the exit-143 hang. unref() takes the
+ * timer out of that force-close path; the loop still fires while genuine async work is pending.
+ */
+function armUnrefInterval(fn, ms) {
+  const timer = setInterval(fn, ms);
+  if (timer && typeof timer.unref === 'function') timer.unref();
+  return timer;
+}
+
+const DEFAULT_INTERVAL_MS = 30000;
+
+/**
+ * Create the pure supervisor core.
+ *
+ * @param {object}   deps
+ * @param {Array<{role:string,callsign:string,accountProfile?:string}>} deps.roster - desired children
+ * @param {object}   deps.spawnControl - the spawn-control verb module (spawn/restart/isLiveEnabled)
+ * @param {object}   [deps.supabase]   - service client (passed through to spawn-control verbs)
+ * @param {boolean}  [deps.live]       - override; defaults to spawnControl.isLiveEnabled()
+ * @param {number}   [deps.intervalMs] - watch cadence
+ * @param {Function} [deps.probeChild] - async (child)=>boolean liveness probe (injectable for tests)
+ * @param {Function} [deps.log]        - logger
+ * @param {Function} [deps.now]        - () => ms clock (injectable)
+ */
+function createSupervisor(deps = {}) {
+  const {
+    roster = [],
+    spawnControl,
+    supabase = null,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    log = () => {},
+    now = () => Date.now(),
+  } = deps;
+  if (!spawnControl || typeof spawnControl.spawn !== 'function') {
+    throw new Error('createSupervisor: deps.spawnControl (with spawn/restart) is required');
+  }
+  const live = deps.live ?? (typeof spawnControl.isLiveEnabled === 'function' ? spawnControl.isLiveEnabled() : false);
+  const probeChild = deps.probeChild || defaultProbeChild(supabase);
+
+  // Retained references -- the thing spawn-and-forget lacks. Keyed by callsign.
+  const tracked = new Map();
+  let timer = null;
+  let started = false;
+
+  async function spawnOne(child) {
+    const res = await spawnControl.spawn(
+      { role: child.role, callsign: child.callsign, accountProfile: child.accountProfile },
+      { supabaseClient: supabase, live },
+    );
+    tracked.set(child.callsign, { child, lastResult: res, spawnedAt: now() });
+    log(`[fleet-supervisor] ${live ? 'spawned' : 'DRY-RUN would spawn'} ${child.role}/${child.callsign}`);
+    return res;
+  }
+
+  /** Start: spawn the whole roster once, then arm the resident watch loop. */
+  async function start() {
+    if (started) return { started: true, already: true };
+    started = true;
+    for (const child of roster) await spawnOne(child);
+    timer = armUnrefInterval(() => { tick().catch((e) => log(`[fleet-supervisor] tick error: ${e && e.message}`)); }, intervalMs);
+    log(`[fleet-supervisor] watch loop armed (${intervalMs}ms, live=${live}, roster=${roster.length})`);
+    return { started: true, live, watching: roster.length };
+  }
+
+  /**
+   * One watch pass: for each tracked child, probe liveness; a lost child is re-spawned via
+   * spawn-control.restart in LIVE mode (which emits a real fleet_verb_restart event), or logged in
+   * dry-run. A no-op loop that never remediates would pass kill-survival vacuously -- this is what
+   * makes the supervisor actually supervise (TESTING gap #4).
+   */
+  async function tick() {
+    const outcomes = [];
+    for (const [callsign, entry] of tracked) {
+      const alive = await probeChild(entry.child);
+      if (alive) { outcomes.push({ callsign, action: 'alive' }); continue; }
+      if (!live) {
+        log(`[fleet-supervisor] DRY-RUN would restart lost child ${callsign}`);
+        outcomes.push({ callsign, action: 'would_restart' });
+        continue;
+      }
+      const res = await spawnControl.restart(callsign, { supabaseClient: supabase, live, by: 'callsign' });
+      entry.lastResult = res;
+      entry.spawnedAt = now();
+      outcomes.push({ callsign, action: 'restarted', ok: !!(res && res.ok) });
+      log(`[fleet-supervisor] restarted lost child ${callsign}: ok=${!!(res && res.ok)}`);
+    }
+    return outcomes;
+  }
+
+  /**
+   * Stop the watch loop. NON-CASCADING BY DEFAULT: this does NOT stop or kill tracked children --
+   * a graceful shutdown of the supervisor must leave the fleet running (kill-survival parity with
+   * the uncatchable `kill -9` path). Pass { cascade:true } ONLY for an intentional teardown.
+   */
+  async function stopWatch(opts = {}) {
+    if (timer) { clearInterval(timer); timer = null; }
+    started = false;
+    if (opts.cascade === true && typeof spawnControl.stop === 'function') {
+      for (const callsign of tracked.keys()) {
+        await spawnControl.stop(callsign, { supabaseClient: supabase, live, by: 'callsign' });
+      }
+      log('[fleet-supervisor] CASCADE stop: tracked children stopped');
+      return { stopped: true, cascade: true };
+    }
+    log('[fleet-supervisor] watch loop stopped (non-cascading -- children left running)');
+    return { stopped: true, cascade: false };
+  }
+
+  return {
+    start,
+    tick,
+    stopWatch,
+    get tracked() { return tracked; },
+    get live() { return live; },
+    isWatching: () => timer !== null,
+  };
+}
+
+/**
+ * Default liveness probe: a child is alive if a live claude_sessions row exists for its callsign.
+ * Uses the canonical resolver rather than a hand-rolled query. Fail-CLOSED (treat as not-alive on
+ * probe error) so a transient DB hiccup errs toward re-spawn attempts, never toward silent gaps.
+ */
+function defaultProbeChild(supabase) {
+  return async function probe(child) {
+    if (!supabase) return true; // no DB wired -> cannot judge; do not thrash
+    try {
+      const { resolveLiveSession } = await import('../../lib/fleet/session-registry-adapter.js');
+      const r = await resolveLiveSession(supabase, { by: 'callsign', value: child.callsign });
+      return !!(r && r.resolved);
+    } catch {
+      return false;
+    }
+  };
+}
+
+module.exports = { createSupervisor, armUnrefInterval, defaultProbeChild, DEFAULT_INTERVAL_MS };
+
+// Resident entrypoint -- thin wrapper; does NOT run on import (TESTING gap #3).
+if (require.main === module) {
+  (async () => {
+    const spawnControl = await import('../../lib/fleet/spawn-control.js');
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    const supabase = createSupabaseServiceClient();
+    // Roster comes from the desired-state manifest (Child B slot schema) in a full deployment; for
+    // the drill it is supplied via FLEET_SUPERVISOR_ROSTER (JSON) so the operator controls it.
+    let roster = [];
+    try { roster = JSON.parse(process.env.FLEET_SUPERVISOR_ROSTER || '[]'); } catch { roster = []; }
+    const sup = createSupervisor({ roster, spawnControl, supabase, log: (m) => console.log(m) });
+
+    // NON-CASCADING graceful teardown: stop watching, leave children running, then exit.
+    const shutdown = async (sig) => {
+      console.log(`[fleet-supervisor] ${sig} received -- non-cascading shutdown (children keep running)`);
+      await sup.stopWatch(); // default: cascade=false
+      process.exit(0);
+    };
+    process.on('SIGINT', () => { shutdown('SIGINT'); });
+    process.on('SIGTERM', () => { shutdown('SIGTERM'); });
+
+    await sup.start();
+    console.log(`[fleet-supervisor] resident (pid=${process.pid}, live=${sup.live}). kill -9 me; the fleet survives.`);
+  })().catch((e) => { console.error('[fleet-supervisor] fatal:', e && e.message); process.exit(1); });
+}

--- a/tests/unit/fleet/fleet-supervisor.test.js
+++ b/tests/unit/fleet/fleet-supervisor.test.js
@@ -1,0 +1,79 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-C — fleet supervisor core (G1a).
+ * Deterministic unit coverage of the supervisor logic via injected seams (spawnControl, probeChild,
+ * clock). The OS-level kill -9 survival property is unmockable and is proven by the operator LIVE
+ * DRILL (docs/protocol/fleet-supervisor-live-drill.md), not here — these tests lock the surrounding
+ * logic: default-OFF inertness, NON-CASCADING graceful teardown, and watch-loop detect→remediate.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { createSupervisor, armUnrefInterval } = require('../../../scripts/fleet/fleet-supervisor.cjs');
+
+function makeFakeSpawnControl({ live = false } = {}) {
+  return {
+    isLiveEnabled: () => live,
+    spawn: vi.fn(async (target, opts) => ({ live: opts.live, callsign: target.callsign, pid: 1234 })),
+    restart: vi.fn(async (callsign) => ({ ok: true, callsign })),
+    stop: vi.fn(async (callsign) => ({ ok: true, callsign })),
+  };
+}
+const BIG = 1e9; // never fires during a test; we drive tick() manually
+
+describe('createSupervisor: guards', () => {
+  it('requires a spawnControl with spawn()', () => {
+    expect(() => createSupervisor({})).toThrow(/spawnControl/);
+  });
+  it('exports armUnrefInterval helper (Windows exit-143-safe resident timer)', () => {
+    const t = armUnrefInterval(() => {}, BIG);
+    expect(t).toBeDefined();
+    clearInterval(t);
+  });
+});
+
+describe('createSupervisor: default-OFF inertness (FR-5)', () => {
+  it('dry-run start spawns via spawn-control with live:false and NEVER restarts a lost child', async () => {
+    const sc = makeFakeSpawnControl({ live: false });
+    const probeChild = vi.fn().mockResolvedValue(false); // child appears lost
+    const sup = createSupervisor({ roster: [{ role: 'worker', callsign: 'C-1' }], spawnControl: sc, probeChild, live: false, intervalMs: BIG });
+    await sup.start();
+    expect(sc.spawn).toHaveBeenCalledTimes(1);
+    expect(sc.spawn.mock.calls[0][1].live).toBe(false);
+    const outcomes = await sup.tick();
+    expect(sc.restart).not.toHaveBeenCalled();          // dry-run remediates NOTHING
+    expect(outcomes[0].action).toBe('would_restart');
+    await sup.stopWatch();
+  });
+});
+
+describe('createSupervisor: NON-CASCADING graceful teardown (kill-survival parity, TESTING gap #1)', () => {
+  it('stopWatch() (default) does NOT stop/kill tracked children; cascade:true does', async () => {
+    const sc = makeFakeSpawnControl({ live: true });
+    const sup = createSupervisor({ roster: [{ role: 'worker', callsign: 'C-1' }], spawnControl: sc, probeChild: vi.fn().mockResolvedValue(true), live: true, intervalMs: BIG });
+    await sup.start();
+    expect(sup.isWatching()).toBe(true);
+    const r = await sup.stopWatch();                    // graceful SIGINT/SIGTERM path
+    expect(r.cascade).toBe(false);
+    expect(sc.stop).not.toHaveBeenCalled();             // fleet must survive a graceful supervisor exit
+    expect(sup.isWatching()).toBe(false);
+    await sup.stopWatch({ cascade: true });             // explicit intentional teardown
+    expect(sc.stop).toHaveBeenCalledWith('C-1', expect.any(Object));
+  });
+});
+
+describe('createSupervisor: watch-loop detect→remediate (TESTING gap #4)', () => {
+  it('live tick restarts ONLY the lost child and leaves the alive one', async () => {
+    const sc = makeFakeSpawnControl({ live: true });
+    const probeChild = vi.fn()
+      .mockResolvedValueOnce(true)    // C-1 alive
+      .mockResolvedValueOnce(false);  // C-2 lost
+    const sup = createSupervisor({ roster: [{ role: 'worker', callsign: 'C-1' }, { role: 'worker', callsign: 'C-2' }], spawnControl: sc, probeChild, live: true, intervalMs: BIG });
+    await sup.start();
+    const outcomes = await sup.tick();
+    expect(sc.restart).toHaveBeenCalledTimes(1);
+    expect(sc.restart).toHaveBeenCalledWith('C-2', expect.any(Object));
+    expect(outcomes.find((o) => o.callsign === 'C-1').action).toBe('alive');
+    expect(outcomes.find((o) => o.callsign === 'C-2').action).toBe('restarted');
+    await sup.stopWatch();
+  });
+});

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -9,6 +9,15 @@ vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
 vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
   sequenceSingletonRefresh: vi.fn(),
 }));
+// SD-LEO-INFRA-LEO-COMPLETION-001-C (G1a de-mask): spy on the REAL node:child_process.spawn so the
+// default spawner closure in spawn-control.js:146-150 actually runs and its {detached:true,
+// stdio:'ignore'} options can be asserted. The prior "live path" test injected opts.spawnFn, which
+// short-circuited that closure -- its expect.any(Object) matched invocation.env, never the spawn
+// options, so detached:true was never exercised (the test-masking G1a closes).
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, spawn: vi.fn() };
+});
 
 const {
   roleOf, isSingletonRole, resolveProfileDir, isLiveEnabled, buildLiveSpawnInvocation,
@@ -16,6 +25,7 @@ const {
 } = await import('../../../lib/fleet/spawn-control.js');
 const { logCoordinationEvent } = await import('../../../lib/coordinator/coordination-events.cjs');
 const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
+const { spawn: childProcessSpawnSpy } = await import('node:child_process');
 
 /** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
 function makeFakeSupabase({ sessions = [] } = {}) {
@@ -145,13 +155,20 @@ describe('spawn (FR-1)', () => {
     expect(spawnFn).not.toHaveBeenCalled();
   });
 
-  it('live path spawns detached and captures the window handle', async () => {
-    const child = { pid: 4242 };
-    const spawnFn = vi.fn().mockReturnValue(child);
+  it('live path exercises the REAL detached spawn: detached:true + stdio:ignore reach child_process.spawn and the child is unref\'d (G1a de-mask)', async () => {
+    // DE-MASK: do NOT inject opts.spawnFn -- let the default spawner closure (spawn-control.js:146-150)
+    // run so the real detached:true/stdio:'ignore' options reach node:child_process.spawn.
+    const fakeChild = { pid: 4242, unref: vi.fn() };
+    childProcessSpawnSpy.mockReset();
+    childProcessSpawnSpy.mockReturnValue(fakeChild);
     const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
     const supabaseClient = makeFakeSupabase({ sessions: [] });
-    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient });
-    expect(spawnFn).toHaveBeenCalledWith('wt.exe', expect.any(Array), expect.any(Object));
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, execFn, sleepFn: vi.fn(), supabaseClient });
+    // LOAD-BEARING: kill-survival depends on detached:true (OS re-parents the child when the
+    // supervisor dies) + stdio:'ignore' (no inherited pipes tie it to the parent). Deleting
+    // detached:true from spawn-control.js:147 makes THIS assertion fail (mutation-verified).
+    expect(childProcessSpawnSpy).toHaveBeenCalledWith('wt.exe', expect.any(Array), expect.objectContaining({ detached: true, stdio: 'ignore' }));
+    expect(fakeChild.unref).toHaveBeenCalled(); // unref'd so it outlives the parent
     expect(result.live).toBe(true);
     expect(result.handle).toBe(131074);
     expect(result.handleCaptureFailed).toBe(false);


### PR DESCRIPTION
## SD-LEO-INFRA-LEO-COMPLETION-001-C — Launcher-shell supervisor + de-mask kill test (G1a)

Closes Solomon checkpoint-3 gap **G1a**: kill-supervisor survival was **test-masked** and no supervisor process existed.

### What
- **`scripts/fleet/fleet-supervisor.cjs`** (NEW): a real, persistent, **killable** launcher-shell supervisor that composes `lib/fleet/spawn-control.js`'s six verbs (does not reimplement them). Desired-state roster + resident, Windows-`exit-143`-safe unref'd watch loop that re-spawns lost children in live mode (logs in dry-run). **Kill-survival**: children are detached+unref'd, so `kill -9` of the supervisor leaves them running (OS re-parents). Graceful `SIGINT`/`SIGTERM` teardown is explicitly **NON-CASCADING**. Default-OFF behind `FLEET_SPAWN_CONTROL_LIVE`. Pure `createSupervisor` core + entrypoint that does not auto-run on import.
- **`tests/unit/fleet/spawn-control.test.js`**: **DE-MASKED** the G1a test. The old "live path" test injected `opts.spawnFn` (its `expect.any(Object)` matched `invocation.env`, never the spawn options), so `detached:true` was never exercised. Now spies the REAL `node:child_process.spawn` and asserts `objectContaining({detached:true, stdio:'ignore'})` + `child.unref()`. **Mutation-verified**: deleting `detached:true` from spawn-control.js turns this test red.
- **`tests/unit/fleet/fleet-supervisor.test.js`** (NEW): default-OFF inertness, non-cascading teardown, watch-loop detect→remediate.
- **`docs/protocol/fleet-supervisor-live-drill.md`** (NEW): operator runbook for Solomon's re-run on Child B's canary harness (canary-only, real Windows host, positive event-row assertion, mandatory teardown/idempotency).

### Acceptance
The OS `kill -9` survival property is unmockable → acceptance is the **operator LIVE DRILL** on Child B's canary harness (deferred to Solomon's re-run). Unit tests lock the surrounding logic. **739/739 fleet unit tests pass.**

### Evidence
VALIDATION `b9b594d2` · Explore `c05de4c4` · TESTING(PLAN) `5435226f` · TESTING(EXEC) `2a90744a` (739/739) · SECURITY(EXEC) `4c180b17` (PASS) · RETRO `1f098fe5` (quality 88). Handoffs: LEAD-TO-PLAN 93, PLAN-TO-EXEC 98, EXEC-TO-PLAN 94, PLAN-TO-LEAD 95.

### Follow-ups (SECURITY advisories, non-blocking, before broad live rollout)
- A1: thread `accountProfile` through `restart→spawnReplacement` (a re-spawn currently lands on the default account, not the pinned profile). Not reachable in the canary drill.
- A2: add per-callsign restart backoff / circuit-breaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)