### PR TITLE
feat(SD-LEO-INFRA-LEO-COMPLETION-001-D): reboot-respawn runner (G1b/G2)

### DIFF
--- a/database/migrations/20260720_fleet_desired_slots_STAGED.sql
+++ b/database/migrations/20260720_fleet_desired_slots_STAGED.sql
@@ -1,0 +1,76 @@
+-- SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-1) — fleet_desired_slots.
+-- STAGED / chairman-gated apply (additive-only). Pattern precedent:
+-- 20260719_coordinator_succession_STAGED.sql (DO-block self-verify BEFORE COMMIT
+-- + _DOWN companion) and 20260720_role_drain_sets_STAGED.sql (RLS-at-create,
+-- service-role-only posture).
+--
+-- FR-1: fleet_desired_slots — the FROZEN desired-state slot manifest that
+-- reboot-respawn spawns FROM. Sibling B shipped the pure slot core
+-- (lib/fleet/session-manifest.js normalizeDesiredSlots/computeSlotDrift) and the
+-- live-drift adapter (loadLiveSlotIdentity) but NOTHING stored the desired set, so
+-- a host reboot (zero live sessions) had no manifest to read. This table is that
+-- manifest: one row per chairman-editable slot, keyed by `name`, mirroring the
+-- exact shape normalizeDesiredSlots normalizes.
+--
+-- Code paths (lib/fleet/desired-slots-store.js loadDesiredSlots) FAIL-SOFT with a
+-- loud stderr canary (return [] on table-absent) while this migration is merged-
+-- but-unapplied — so the reboot-respawn mechanism + its in-session drill are
+-- deliverable and testable BEFORE the chairman gate has fired (against a fixture
+-- or manually-seeded manifest). Applying this migration makes this table the SSOT
+-- for the desired slot set.
+--
+-- RLS ships IN THIS SAME MIGRATION (hard repo rule: RLS-at-create). Posture is
+-- SERVICE-ROLE ONLY, matching the recent-migration precedent (role_drain_sets /
+-- coordinator_succession): this table holds fleet-internal coordination vocabulary
+-- read (loadDesiredSlots) and written (upsertDesiredSlot / captureResumeUuid)
+-- EXCLUSIVELY by service-role clients; there is no authenticated/anon consumer. An
+-- unconditional authenticated USING(true) read is the SD-LEO-GEN-SCOPE-ANON-KEY-001
+-- / rls-anon-tenant-predicate-lint violation class, so no authenticated policy is
+-- created (deliberate deviation from a naive "authenticated read" default; if a UI
+-- reader is ever added, gate it with a scoped predicate, never USING(true)).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS fleet_desired_slots (
+  -- `name` is the stable, chairman-editable slot key reboot-respawn + the
+  -- reconciliation loop diff against (mirrors normalizeDesiredSlots's name-required
+  -- filter). PRIMARY KEY => implicitly UNIQUE and the upsert conflict target.
+  name            text PRIMARY KEY,
+  color           text NULL,
+  role            text NULL,
+  account_profile text NULL,
+  model           text NULL,
+  effort          text NULL,
+  worktree        text NULL,
+  -- The captured Claude Code session UUID (claude_sessions.session_id) that
+  -- `claude --resume <uuid>` reattaches to after a reboot. NULL until captured.
+  resume_uuid     text NULL,
+  enabled         boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Hot path: loadDesiredSlots reads enabled slots to build the respawn roster.
+CREATE INDEX IF NOT EXISTS idx_fleet_desired_slots_enabled
+  ON fleet_desired_slots (name) WHERE enabled = true;
+
+ALTER TABLE fleet_desired_slots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fleet_desired_slots_service_role_all ON fleet_desired_slots
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ── Self-verify (BEFORE COMMIT, so an ASSERT failure rolls back atomically) ──
+DO $verify$
+DECLARE
+  rls_enabled boolean;
+BEGIN
+  ASSERT to_regclass('public.fleet_desired_slots') IS NOT NULL,
+    'fleet_desired_slots missing after create';
+  SELECT relrowsecurity INTO rls_enabled FROM pg_class WHERE oid = 'public.fleet_desired_slots'::regclass;
+  ASSERT rls_enabled, 'RLS not enabled on fleet_desired_slots';
+  ASSERT (SELECT count(*) FROM pg_policies WHERE tablename = 'fleet_desired_slots') = 1,
+    'fleet_desired_slots must have exactly 1 policy (service-role-only)';
+END
+$verify$;
+
+COMMIT;

--- a/database/migrations/20260720_fleet_desired_slots_STAGED_DOWN.sql
+++ b/database/migrations/20260720_fleet_desired_slots_STAGED_DOWN.sql
@@ -1,0 +1,10 @@
+-- DOWN companion for 20260720_fleet_desired_slots_STAGED.sql
+-- (SD-LEO-INFRA-LEO-COMPLETION-001-D FR-1). Drops the additive desired-state slot
+-- table (its policy + index drop with it). Code fail-softs back to the tables-absent
+-- canary path (loadDesiredSlots returns []) — no code rollback required.
+
+BEGIN;
+
+DROP TABLE IF EXISTS fleet_desired_slots;
+
+COMMIT;

--- a/docs/protocol/fleet-reboot-respawn-drill.md
+++ b/docs/protocol/fleet-reboot-respawn-drill.md
@@ -1,0 +1,94 @@
+# Fleet Reboot-Respawn — Live Drill (G1b / G2)
+
+**SD:** SD-LEO-INFRA-LEO-COMPLETION-001-D · **Owner acceptance:** Solomon (canary leg) · **Tier:** LIVE (operator-run, not CI)
+
+This runbook proves the property unit tests **cannot**: after a host reboot kills every live fleet
+session, the reboot-respawn runner reads the **frozen desired manifest**, relaunches each slot via
+`claude --resume <uuid>`, and lands a **real** (non-mocked) `fleet_verb_respawn` row in
+`coordination_events`.
+
+> ⚠️ **Anti-test-masking (Solomon R1 verdict `0e9e466e`, `no_unit_mock=true` / `trim_forbidden=true`).**
+> A mocked-seam unit test does **not** satisfy acceptance. The mechanism (runner + `--resume` spawn path
+> + ONSTART/ONLOGON task + drill runner) ships **MECHANISM-READY**; the load-bearing proof is the live
+> drill below. **FULL canary live-execution (a real host reboot) is DEFERRED to Solomon on Child B's
+> canary account** and captured as a completion-flag follow-up — mirroring sibling E's `u4-drill-runner.js`
+> MECHANISM-READY-NOT-LIVE-EXECUTED state.
+
+## Mechanism (what shipped in D)
+
+| Piece | File |
+|---|---|
+| Desired-manifest table (chairman-gated DDL, **NOT applied**) | `database/migrations/20260720_fleet_desired_slots_STAGED.sql` (+ `_DOWN`) |
+| Reader / writer / capture / roster translator | `lib/fleet/desired-slots-store.js` (`loadDesiredSlots`, `upsertDesiredSlot`, `captureResumeUuid`, `slotsToRoster`) |
+| `resume_uuid` capture at SessionStart | `scripts/hooks/capture-session-id.cjs` (`metadata.resume_uuid := session_id`) |
+| `--resume` spawn path | `lib/fleet/spawn-control.js` `buildLiveSpawnInvocation({..., resumeUuid})` |
+| Runner (read → roster → per-slot resume relaunch → emit events) | `lib/fleet/reboot-respawn-runner.js` + entrypoint `scripts/fleet/reboot-respawn.cjs` |
+| ONSTART/ONLOGON scheduled task | `scripts/setup-reboot-respawn-task.mjs` |
+| Drill runner (PASS/FAIL checks) | `lib/fleet/reboot-respawn-drill-runner.js` |
+
+## ⚠️ Preconditions (all mandatory)
+
+1. **Desired manifest exists.** Either apply the chairman-gated migration and seed
+   `fleet_desired_slots`, or supply a fixture manifest. Each slot that should reattach needs a
+   `resume_uuid` (populated automatically at SessionStart, or via `captureResumeUuid`). With the table
+   unapplied, `loadDesiredSlots` fail-softs to `[]` and the runner respawns nothing (loud stderr canary).
+2. **Canary account only for the full run.** The FULL live-execution runs on Child B's dedicated canary
+   account/profile — never against a live-fleet session. (Solomon-owned.)
+3. **Live flag scoped to this shell only.** `FLEET_SPAWN_CONTROL_LIVE=true` for the drill shell; it is
+   default-OFF everywhere else and must never be set in a live-fleet session.
+4. **Desktop for `wt.exe`.** The scheduled task defaults to `/SC ONSTART`, which runs in **session 0 with
+   no desktop** — `wt.exe` may fail to open a visible tab. Prefer `--onlogon` (a logged-in desktop is
+   available) where acceptable; otherwise document/accept the headless session-0 constraint and validate
+   the wt.exe invocation on the real host before relying on it.
+
+## In-session NON-mocked simulated-reboot drill (deliverable now, pre-canary)
+
+1. **Seed / confirm the manifest.** Ensure `loadDesiredSlots(supabase)` returns the slot(s) with the
+   `resume_uuid` you expect (or upsert a fixture via `upsertDesiredSlot`).
+2. **Simulate the reboot.** Release/kill the target live sessions (canary only) so the fleet is at the
+   "zero live session" state reboot-respawn must recover from.
+3. **Run the real runner.**
+   ```pwsh
+   $env:FLEET_SPAWN_CONTROL_LIVE = "true"   # or leave unset for a dry-run mechanism check
+   node scripts/fleet/reboot-respawn.cjs
+   ```
+   Expect: one intended/attempted relaunch invocation per slot carrying `claude --resume <that slot's
+   uuid>`, and one `fleet_verb_respawn` row per slot in `coordination_events`.
+4. **Verify real event rows.**
+   ```sql
+   SELECT id, event_type, payload->>'callsign' AS callsign, payload->>'resume_uuid' AS resume_uuid, created_at
+   FROM coordination_events
+   WHERE event_type = 'fleet_verb_respawn' AND created_at > '<drill_start_iso>'
+   ORDER BY created_at DESC;
+   ```
+   Expect ≥1 row per slot (positive assertion — `logCoordinationEvent` is fail-open, so absence is silent).
+5. **Verify relaunch ATTEMPT semantics, not guaranteed reattachment.** A genuinely expired `--resume`
+   token degrades to a fresh session; the drill asserts the ATTEMPT (correct argv + event), which is the
+   honest observable.
+
+The drill runner `runRebootRespawnDrill({ loadFn, spawnFn, queryEventsFn, ... })` runs these same four
+PASS/FAIL checks (`manifest_loaded`, `roster_built`, `per_slot_resume_relaunch`, `respawn_events_present`)
+against the **real** seams.
+
+## Registering the reboot trigger
+
+```pwsh
+node scripts/setup-reboot-respawn-task.mjs --onlogon           # register (INERT wrapper by default)
+node scripts/setup-reboot-respawn-task.mjs --onlogon --live    # wrapper sets FLEET_SPAWN_CONTROL_LIVE=true
+node scripts/setup-reboot-respawn-task.mjs --dry-run           # print wrapper + schtasks argv, mutate nothing
+node scripts/setup-reboot-respawn-task.mjs --status            # query
+node scripts/setup-reboot-respawn-task.mjs --remove            # delete
+```
+
+## Full canary live-execution (DEFERRED → Solomon)
+
+The full run — register the ONSTART/ONLOGON task on the canary host, **actually reboot**, and confirm the
+fleet is relaunched with reattached sessions — is Solomon's, on Child B's canary account, and is tracked
+as a completion-flag follow-up. Do NOT claim a live pass anywhere until this has run for real.
+
+## Why unit tests are insufficient here
+
+`tests/unit/fleet/*` lock the pure/deterministic parts (fail-soft reader, roster shape, `--resume` argv
+append + back-compat, `schtasks` argv builder, and the drill checks via injected seams that exercise the
+REAL runner). But a real host reboot killing every session and the OS relaunching them via a scheduled
+task is unmockable — hence this live tier.

--- a/lib/fleet/desired-slots-store.js
+++ b/lib/fleet/desired-slots-store.js
@@ -1,0 +1,165 @@
+/**
+ * Fleet desired-state slot STORE — SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-1/FR-2/FR-3).
+ *
+ * Sibling B shipped the pure slot core (session-manifest.js normalizeDesiredSlots/computeSlotDrift)
+ * and the live-drift adapter (session-registry-adapter.js loadLiveSlotIdentity), but nothing STORED
+ * the desired set — so a reboot (zero live sessions) had no manifest to read. This module is the
+ * missing persistence + translation layer that reboot-respawn (FR-5) consumes:
+ *
+ *   FR-1  loadDesiredSlots(supabase)      → the frozen desired manifest, in normalizeDesiredSlots shape
+ *   FR-1  upsertDesiredSlot(supabase,slot)→ chairman/operator writes one desired slot
+ *   FR-2  captureResumeUuid(supabase,...) → get-then-merge metadata.resume_uuid on a live session
+ *   FR-3  slotsToRoster(slots)            → the FLEET_SUPERVISOR_ROSTER JSON the supervisor consumes
+ *
+ * FAIL-SOFT contract (mirrors loadLiveSlotIdentity): a missing fleet_desired_slots table (this SD's
+ * migration is chairman-gated DDL, merged-but-unapplied) degrades loadDesiredSlots to [] with a loud
+ * one-time stderr canary, so the whole reboot-respawn mechanism is deliverable and drill-able before
+ * the chairman gate has fired (against a fixture or manually-seeded manifest).
+ */
+import { normalizeDesiredSlots } from './session-manifest.js';
+
+const TABLE = 'fleet_desired_slots';
+
+// One-time loud canary so an unapplied migration is observable, not silent (mirrors the
+// merged-but-unapplied posture documented in the STAGED migration header). Deduped per-process.
+let _tableAbsentWarned = false;
+function warnTableAbsent(where, detail) {
+  if (_tableAbsentWarned) return;
+  _tableAbsentWarned = true;
+  try {
+    console.warn(`   ⚠️  [FLEET_DESIRED_SLOTS_ABSENT] ${where}: ${detail} — reboot-respawn is reading an EMPTY desired manifest until the chairman-gated migration 20260720_fleet_desired_slots_STAGED.sql is applied (non-fatal).`);
+  } catch { /* best effort */ }
+}
+
+/**
+ * FR-1: read the frozen desired-state slot manifest. Returns rows ALREADY in the exact
+ * normalizeDesiredSlots shape `{name,color,role,account_profile,model,effort,worktree,resume_uuid}`
+ * so computeSlotDrift / the reboot-respawn runner consume it without transformation. Only enabled
+ * slots are returned (disabled slots must not be respawned). FAIL-SOFT: [] on table-absent / any
+ * query error.
+ * @param {object} supabase
+ * @returns {Promise<Array<{name:string, color:string|null, role:string|null, account_profile:string|null, model:string|null, effort:string|null, worktree:string|null, resume_uuid:string|null}>>}
+ */
+export async function loadDesiredSlots(supabase) {
+  if (!supabase || typeof supabase.from !== 'function') return [];
+  let res;
+  try {
+    res = await supabase
+      .from(TABLE)
+      .select('name, color, role, account_profile, model, effort, worktree, resume_uuid, enabled');
+  } catch (e) {
+    warnTableAbsent('loadDesiredSlots', (e && e.message) || String(e));
+    return [];
+  }
+  const { data, error } = res || {};
+  if (error) {
+    warnTableAbsent('loadDesiredSlots', error.message || 'query error');
+    return [];
+  }
+  // enabled=false slots are excluded here (never respawned); normalizeDesiredSlots then drops any
+  // nameless row and canonicalizes the shape (its output does not carry `enabled`).
+  const enabled = (data || []).filter((r) => r && r.enabled !== false);
+  return normalizeDesiredSlots(enabled);
+}
+
+/**
+ * FR-1: upsert ONE desired slot (chairman/operator edit). Conflict target is the `name` PK. Bumps
+ * updated_at. FAIL-SOFT: returns {ok:false, error} rather than throwing on table-absent / write error.
+ * @param {object} supabase
+ * @param {{name:string, color?:string, role?:string, account_profile?:string, model?:string, effort?:string, worktree?:string, resume_uuid?:string, enabled?:boolean}} slot
+ * @returns {Promise<{ok:boolean, error?:string|null}>}
+ */
+export async function upsertDesiredSlot(supabase, slot = {}) {
+  if (!slot || !slot.name) return { ok: false, error: 'upsertDesiredSlot: slot.name is required' };
+  const row = {
+    name: slot.name,
+    color: slot.color ?? null,
+    role: slot.role ?? null,
+    account_profile: slot.account_profile ?? null,
+    model: slot.model ?? null,
+    effort: slot.effort ?? null,
+    worktree: slot.worktree ?? null,
+    resume_uuid: slot.resume_uuid ?? null,
+    enabled: slot.enabled === undefined ? true : !!slot.enabled,
+    updated_at: new Date().toISOString(),
+  };
+  try {
+    const { error } = await supabase.from(TABLE).upsert(row, { onConflict: 'name' });
+    return { ok: !error, error: error ? error.message : null };
+  } catch (e) {
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * FR-2: capture a live session's real Claude Code resume token — claude_sessions.session_id, the
+ * value captured by scripts/hooks/capture-session-id.cjs — into metadata.resume_uuid so a reboot can
+ * `claude --resume <uuid>` the RIGHT session. GET-then-MERGE scoped to the exact session_id (never a
+ * bare replace) so coordinator-stamped fleet_identity/callsign/tier_rank/role survive — the same
+ * discipline spawn-control.js's handle-capture write uses.
+ *
+ * The resume token IS the session UUID (Claude Code's `--resume` takes the session id), so
+ * metadata.resume_uuid := sessionId. When `name` (the slot callsign) is supplied, best-effort also
+ * mirror the token onto fleet_desired_slots.resume_uuid (fail-soft: the table may be unapplied).
+ * @param {object} supabase
+ * @param {{name?:string, sessionId:string}} args
+ * @returns {Promise<{ok:boolean, error?:string|null}>}
+ */
+export async function captureResumeUuid(supabase, { name, sessionId } = {}) {
+  if (!sessionId) return { ok: false, error: 'captureResumeUuid: sessionId is required' };
+  try {
+    const { data: current, error: readErr } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (readErr) return { ok: false, error: readErr.message };
+    const baseMeta = (current && current.metadata && typeof current.metadata === 'object' && !Array.isArray(current.metadata))
+      ? current.metadata
+      : {};
+    const merged = { ...baseMeta, resume_uuid: sessionId };
+    const { error: writeErr } = await supabase
+      .from('claude_sessions')
+      .update({ metadata: merged })
+      .eq('session_id', sessionId);
+
+    // Best-effort mirror onto the desired-slots row (FR-2 "and/or the fleet_desired_slots.resume_uuid
+    // column"). Fail-soft: the chairman-gated table may be absent; never let this block the primary
+    // metadata write's outcome.
+    if (name) {
+      try {
+        await supabase.from(TABLE)
+          .update({ resume_uuid: sessionId, updated_at: new Date().toISOString() })
+          .eq('name', name);
+      } catch { /* fail-soft: table absent / no matching slot */ }
+    }
+    return { ok: !writeErr, error: writeErr ? writeErr.message : null };
+  } catch (e) {
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * FR-3: translate stored/normalized desired slots into the roster JSON shape the resident supervisor
+ * (scripts/fleet/fleet-supervisor.cjs) parses from FLEET_SUPERVISOR_ROSTER (line 182):
+ * `{role, callsign, accountProfile}`. `name`→`callsign`, `account_profile`→`accountProfile`.
+ * `resume_uuid` is carried through as an EXTRA key so the reboot-respawn runner can thread it into
+ * the FR-4 `--resume` spawn path (the supervisor itself ignores unknown keys).
+ *
+ * Slots with `enabled=false` are excluded (raw input may still carry the flag); normalizeDesiredSlots
+ * then drops any nameless slot. The serialized array parses cleanly via JSON.parse exactly as the
+ * supervisor consumes it.
+ * @param {Array<object>} desiredSlots - raw OR normalizeDesiredSlots-shaped slots
+ * @returns {Array<{role:string, callsign:string, accountProfile:string|null, resume_uuid:string|null}>}
+ */
+export function slotsToRoster(desiredSlots = []) {
+  const list = Array.isArray(desiredSlots) ? desiredSlots : [];
+  // enabled=false explicitly excluded; undefined/true kept (normalized slots never carry `enabled`).
+  const kept = list.filter((s) => s && s.enabled !== false);
+  return normalizeDesiredSlots(kept).map((s) => ({
+    role: s.role || 'worker',
+    callsign: s.name,
+    accountProfile: s.account_profile || null,
+    resume_uuid: s.resume_uuid || null,
+  }));
+}

--- a/lib/fleet/reboot-respawn-drill-runner.js
+++ b/lib/fleet/reboot-respawn-drill-runner.js
@@ -1,0 +1,153 @@
+/**
+ * @wire-check-exempt: MECHANISM-READY, NOT LIVE-EXECUTED (see notice below) — the load-bearing proof
+ * is a LIVE reboot-respawn drill deferred to Solomon on Child B's canary account, so there is no real
+ * live invocation site to wire this into today. Mirrors u4-drill-runner.js's exemption reasoning.
+ *
+ * Reboot-respawn LIVE-DRILL runner — SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-7).
+ *
+ * Models u4-drill-runner.js: PASS/FAIL observable checks against the REAL runner
+ * (lib/fleet/reboot-respawn-runner.js runRebootRespawn) via injectable seams, returning
+ * {pass, checks:[{name,pass,detail}]}. The checks assert the four properties reboot-respawn must have:
+ *   1. manifest_loaded          — the desired manifest was read (>=1 slot)
+ *   2. roster_built             — slotsToRoster produced a supervisor-shaped roster for every slot
+ *   3. per_slot_resume_relaunch — each slot's relaunch invocation carries `--resume <its uuid>`
+ *                                 (and a slot WITHOUT a resume_uuid stays on the back-compat no-resume
+ *                                 path — never a spurious --resume)
+ *   4. respawn_events_present   — a fleet_verb_respawn event exists per slot in coordination_events
+ *
+ * ⚠️ ANTI-TEST-MASKING (Solomon R1 verdict 0e9e466e: no_unit_mock=true, trim_forbidden=true): a
+ * mocked-seam UNIT test does NOT satisfy this SD's acceptance. The LOAD-BEARING proof is an in-session
+ * NON-mocked simulated-reboot drill (kill live sessions → run the REAL runner against REAL supabase →
+ * observe REAL relaunch attempts + a REAL persisted coordination_events record) and, ultimately, a FULL
+ * canary live-execution on a real host reboot — DEFERRED to Solomon on Child B's canary account and
+ * captured as a completion-flag follow-up. This drill runner is the mechanism for BOTH: injected stubs
+ * make its checks deterministic under unit test, but the SAME checks run against the real seams in the
+ * live drill (see docs/protocol/fleet-reboot-respawn-drill.md). Do NOT claim a live pass anywhere until
+ * runRebootRespawnDrill has actually run against real killed sessions + real supabase.
+ */
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { runRebootRespawn } from './reboot-respawn-runner.js';
+import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
+
+/**
+ * Run the reboot-respawn drill. Wires the REAL runRebootRespawn with the supplied seams so the checks
+ * observe the runner's genuine output (invocation argv, emitted events) — never a stand-in for the
+ * assertion.
+ * @param {object}   args
+ * @param {object}   [args.supabase]      - real service client (live drill) or a fake (unit)
+ * @param {Function} [args.loadFn]        - async (supabase)=>slots ; defaults to loadDesiredSlots
+ * @param {Function} [args.rosterFn]      - (slots)=>roster ; defaults to slotsToRoster
+ * @param {Function} [args.spawnFn]       - (program,args,env)=>child ; only invoked when live
+ * @param {Function} [args.logFn]         - async (supabase,event)=>result ; the runner's event writer
+ * @param {Function} [args.queryEventsFn] - async ()=>Array<{event_type}> ; reads back coordination_events
+ * @param {boolean}  [args.live]          - respawn live flag (default false = dry-run mechanism check)
+ * @param {Function} [args.now]           - ()=>iso clock
+ * @param {object}   [args.opts]          - passthrough to runRebootRespawn (e.g. resolveProfileDir baseDir)
+ * @returns {Promise<{pass:boolean, checks:Array<{name:string, pass:boolean, detail:string}>}>}
+ */
+export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnFn, logFn, queryEventsFn, buildInvocationFn, live = false, now, opts = {} } = {}) {
+  const checks = [];
+  const load = loadFn || loadDesiredSlots;
+  const roster = rosterFn || slotsToRoster;
+
+  // Check 1: manifest loaded.
+  const slots = await load(supabase);
+  checks.push({
+    name: 'manifest_loaded',
+    pass: Array.isArray(slots) && slots.length > 0,
+    detail: Array.isArray(slots) && slots.length > 0
+      ? `desired manifest loaded: ${slots.length} slot(s)`
+      : 'desired manifest EMPTY (table unapplied or no seeded slots) — nothing to respawn',
+  });
+
+  // Check 2: roster built (one supervisor-shaped entry per named slot).
+  const builtRoster = roster(slots);
+  const namedSlots = (slots || []).filter((s) => s && s.name);
+  checks.push({
+    name: 'roster_built',
+    pass: Array.isArray(builtRoster) && builtRoster.length === namedSlots.length && builtRoster.every((r) => r.callsign && r.role),
+    detail: `roster entries: ${builtRoster.length} for ${namedSlots.length} named slot(s)`,
+  });
+
+  // Drive the REAL runner with the injected seams (feeding it the slots/roster we already loaded so
+  // check 1/2 and the run see the same manifest). This is the genuine behavior under test.
+  const runResult = await runRebootRespawn({
+    supabase,
+    loadFn: async () => slots,
+    rosterFn: () => builtRoster,
+    buildInvocationFn,
+    spawnFn,
+    logFn,
+    live,
+    now,
+    ...opts,
+  });
+
+  // Check 3: per-slot --resume relaunch attempted for every slot; the resume token appears in the argv
+  // for slots that HAVE one, and is absent for slots that do not (back-compat, never spurious).
+  const relaunchAttempted = runResult.results.length === slots.length;
+  const perSlotResumeOk = runResult.results.every((r, i) => {
+    const argv = (r.invocation && r.invocation.args) || [];
+    const uuid = slots[i] && slots[i].resume_uuid;
+    if (uuid) return argv.includes('--resume') && argv.includes(uuid);
+    return !argv.includes('--resume');
+  });
+  checks.push({
+    name: 'per_slot_resume_relaunch',
+    pass: relaunchAttempted && perSlotResumeOk,
+    detail: relaunchAttempted && perSlotResumeOk
+      ? `all ${runResult.results.length} slot(s) relaunched with the correct --resume token`
+      : `relaunch/resume mismatch (attempted ${runResult.results.length}/${slots.length})`,
+  });
+
+  // Check 4: a fleet_verb_respawn event exists per slot (log-before/at-action, spec parity with U4).
+  let events = [];
+  if (typeof queryEventsFn === 'function') {
+    try { events = await queryEventsFn(); } catch { events = []; }
+  }
+  const respawnEvents = (events || []).filter((e) => e && e.event_type === 'fleet_verb_respawn').length;
+  checks.push({
+    name: 'respawn_events_present',
+    pass: typeof queryEventsFn === 'function' ? respawnEvents >= slots.length : false,
+    detail: typeof queryEventsFn === 'function'
+      ? `fleet_verb_respawn events found: ${respawnEvents} (need >= ${slots.length})`
+      : 'no queryEventsFn supplied — cannot assert persisted respawn events (live drill MUST supply one)',
+  });
+
+  return { pass: checks.every((c) => c.pass), checks };
+}
+
+/**
+ * No-false-live-claim guardrail (mirrors u4-drill-runner.printLiveExecutionPrecondition). States the
+ * runner is mechanism-ready, NOT live-executed, and names the exact operator gate + the Solomon-deferred
+ * canary leg.
+ */
+export function printLiveExecutionPrecondition() {
+  return [
+    'Reboot-respawn drill runner is MECHANISM-READY, NOT live-executed against a real reboot.',
+    'The load-bearing proof (Solomon R1 verdict 0e9e466e: no_unit_mock=true, trim_forbidden=true) is a',
+    'LIVE reboot-respawn drill — a mocked-seam unit test does NOT satisfy acceptance.',
+    'In-session NON-mocked simulated-reboot drill (deliverable now) requires:',
+    '  1. A seeded desired manifest (fleet_desired_slots rows, or a fixture) with per-slot resume_uuid.',
+    '  2. FLEET_SPAWN_CONTROL_LIVE=true after host-validating the wt.exe invocation on this host',
+    '     (docs/protocol/fleet-reboot-respawn-drill.md).',
+    '  3. Real killed live sessions to observe relaunch ATTEMPTS + a persisted coordination_events',
+    '     fleet_verb_respawn record (queryEventsFn over the real table).',
+    'FULL canary live-execution (a real host reboot) is DEFERRED to Solomon on Child B\'s canary account',
+    'and captured as a completion-flag follow-up — mirroring u4-drill-runner.js\'s',
+    'MECHANISM-READY-NOT-LIVE-EXECUTED state. Do NOT claim a live pass until this has run for real.',
+  ].join('\n');
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  console.log(printLiveExecutionPrecondition());
+}

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -1,0 +1,124 @@
+/**
+ * Reboot-respawn RUNNER — SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-5, closes Solomon checkpoint-3 G1b/G2).
+ *
+ * The piece that makes "zero live session at trigger time" (a host reboot that killed every fleet
+ * session) recoverable. On trigger it:
+ *   1. loadDesiredSlots(supabase)            — read the FROZEN desired manifest (FR-1)
+ *   2. slotsToRoster(slots)                  — build the FLEET_SUPERVISOR_ROSTER-shaped roster (FR-3)
+ *   3. for each slot: buildLiveSpawnInvocation({...,resumeUuid}) — the FR-4 `--resume <uuid>` path so
+ *      each relaunched tab REATTACHES to its captured Claude Code session, then spawn (live) or log
+ *      the intended invocation (dry-run)
+ *   4. emit ONE `fleet_verb_respawn` coordination_events row per slot via logCoordinationEvent
+ *      (mirroring how spawn-control emits fleet_verb_*).
+ *
+ * The runner drives the `--resume` path DIRECTLY (rather than delegating to fleet-supervisor's
+ * createSupervisor) because the supervisor's roster shape does not thread resume_uuid into its
+ * spawn call — reattachment requires the per-slot uuid to reach buildLiveSpawnInvocation, which only
+ * this runner does. The roster is still produced (and returned / settable as FLEET_SUPERVISOR_ROSTER)
+ * so a full deployment can also hand it to the resident supervisor for ongoing watch/remediation.
+ *
+ * STAGED / INERT BY DEFAULT (mirrors spawn-control's FLEET_SPAWN_CONTROL_LIVE discipline): with the
+ * flag unset `live=false`, so the runner LOGS the intended per-slot resume invocation and the roster
+ * and spawns NO OS process — but STILL records a fleet_verb_respawn event per slot (payload.live=false)
+ * so the in-session drill (FR-7) can observe that the mechanism ran. Flipping the flag on requires the
+ * same operator host-validation gate spawn-control / worker-spawn-executor already document.
+ *
+ * TESTABILITY: injectable seams (supabase, loadFn, rosterFn, buildInvocationFn, spawnFn, logFn, now,
+ * live, resolveProfileDirFn) like u4-drill-runner.js — the read→translate→relaunch→emit logic is
+ * deterministic under test WITHOUT mocking away the real behavior (the injected spawnFn/logFn observe
+ * the REAL invocation argv and the REAL event payloads this runner builds).
+ */
+import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
+import { buildLiveSpawnInvocation, resolveProfileDir, isLiveEnabled } from './spawn-control.js';
+
+/** Lazily resolve the real coordination-events writer (CJS) so callers need not import it. */
+async function defaultLogFn(supabase, event) {
+  const { logCoordinationEvent } = await import('../coordinator/coordination-events.cjs');
+  return logCoordinationEvent(supabase, event);
+}
+
+/**
+ * Run the reboot-respawn sequence.
+ * @param {object}   opts
+ * @param {object}   [opts.supabase]           - service client (passed to loadFn/logFn)
+ * @param {Function} [opts.loadFn]             - async (supabase)=>slots ; defaults to loadDesiredSlots
+ * @param {Function} [opts.rosterFn]          - (slots)=>roster ; defaults to slotsToRoster
+ * @param {Function} [opts.buildInvocationFn] - ({role,callsign,profileDir,resumeUuid})=>invocation ; defaults to buildLiveSpawnInvocation
+ * @param {Function} [opts.spawnFn]           - (program,args,env)=>child ; ONLY invoked when live
+ * @param {Function} [opts.logFn]             - async (supabase,event)=>result ; defaults to logCoordinationEvent
+ * @param {Function} [opts.resolveProfileDirFn] - (name,opts)=>dir ; defaults to resolveProfileDir
+ * @param {boolean}  [opts.live]              - override; defaults to isLiveEnabled()
+ * @param {Function} [opts.log]               - line logger
+ * @param {Function} [opts.now]               - ()=>iso string clock
+ * @returns {Promise<{live:boolean, roster:Array<object>, slotCount:number, results:Array<{callsign:string, role:string, invocation:object, resume_uuid:string|null, spawned:boolean, eventLogged:boolean}>}>}
+ */
+export async function runRebootRespawn(opts = {}) {
+  const {
+    supabase = null,
+    loadFn = loadDesiredSlots,
+    rosterFn = slotsToRoster,
+    buildInvocationFn = buildLiveSpawnInvocation,
+    spawnFn = null,
+    logFn = defaultLogFn,
+    resolveProfileDirFn = resolveProfileDir,
+    log = () => {},
+    now = () => new Date().toISOString(),
+  } = opts;
+  const live = opts.live ?? isLiveEnabled();
+
+  const slots = await loadFn(supabase);
+  const roster = rosterFn(slots);
+  log(`[reboot-respawn] loaded ${slots.length} desired slot(s); live=${live}; roster=${JSON.stringify(roster)}`);
+
+  const results = [];
+  for (const slot of slots) {
+    const role = slot.role || 'worker';
+    const callsign = slot.name;
+    const resumeUuid = slot.resume_uuid || null;
+
+    // Resolve the account-profile dir the SAME way spawn-control does (allowlisted, non-traversal).
+    // Fail-soft: a bad/absent profile degrades to no CLAUDE_CONFIG_DIR rather than aborting the slot.
+    let profileDir = null;
+    if (slot.account_profile) {
+      try { profileDir = resolveProfileDirFn(slot.account_profile, opts); }
+      catch (e) { log(`[reboot-respawn] profile resolve failed for ${callsign} (${slot.account_profile}): ${e && e.message}`); profileDir = null; }
+    }
+
+    const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid });
+
+    let spawned = false;
+    if (live && typeof spawnFn === 'function') {
+      try {
+        spawnFn(invocation.program, invocation.args, invocation.env);
+        spawned = true;
+        log(`[reboot-respawn] respawned ${role}/${callsign} (resume=${resumeUuid || 'none'})`);
+      } catch (e) {
+        log(`[reboot-respawn] spawn FAILED for ${callsign}: ${e && e.message}`);
+      }
+    } else {
+      log(`[reboot-respawn] DRY-RUN would respawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
+    }
+
+    // FR-5: one fleet_verb_respawn event per slot (recorded in dry-run too, payload.live=false).
+    let eventLogged = false;
+    try {
+      const res = await logFn(supabase, {
+        event_type: 'fleet_verb_respawn',
+        session_id: null,
+        payload: {
+          verb: 'respawn',
+          callsign,
+          role,
+          resume_uuid: resumeUuid,
+          live: spawned,
+          at: now(),
+        },
+      });
+      eventLogged = !!(res && res.ok);
+    } catch { /* fail-open: event emission never blocks a respawn outcome */ }
+
+    results.push({ callsign, role, invocation, resume_uuid: resumeUuid, spawned, eventLogged });
+  }
+
+  return { live, roster, slotCount: slots.length, results };
+}

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -66,15 +66,24 @@ export function isLiveEnabled(env = process.env) {
  * optionally under a switched account profile. Returns a structured command; NEVER executes it here.
  * ⚠️ Host-specific, like worker-spawn-executor.cjs's buildSpawnInvocation -- operator-validate before
  * flipping FLEET_SPAWN_CONTROL_LIVE.
+ *
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-4): a `resumeUuid` appends `--resume <uuid>` to the argv so a
+ * reboot-respawn tab REATTACHES to the captured Claude Code session (claude_sessions.session_id)
+ * instead of starting fresh. BACK-COMPAT: without a resumeUuid the args are byte-identical to before
+ * (`['new-tab','--','claude']`). `--resume` adds only an argv token — it MUST NOT touch process.env,
+ * so the CLAUDE_CONFIG_DIR profile-into-child-env-only isolation invariant is unchanged.
  */
-export function buildLiveSpawnInvocation({ role, callsign, profileDir } = {}) {
+export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid } = {}) {
   const env = { FLEET_WORKER_CALLSIGN: callsign || '', FLEET_WORKER_ROLE: role || 'worker' };
   // FR-7 / SECURITY: CLAUDE_CONFIG_DIR is injected ONLY into this returned env object -- the caller
   // must pass it to child_process.spawn's env option, never assign to process.env directly.
   if (profileDir) env.CLAUDE_CONFIG_DIR = profileDir;
+  const args = ['new-tab', '--', 'claude'];
+  // FR-4: resume path. Only appended when a token is present -> the no-resume path stays identical.
+  if (resumeUuid) args.push('--resume', String(resumeUuid));
   return {
     program: 'wt.exe',
-    args: ['new-tab', '--', 'claude'],
+    args,
     env,
   };
 }

--- a/scripts/fleet/reboot-respawn.cjs
+++ b/scripts/fleet/reboot-respawn.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Reboot-respawn ENTRYPOINT — SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-5).
+ *
+ * Thin wrapper the ONSTART/ONLOGON scheduled task (scripts/setup-reboot-respawn-task.mjs) calls on
+ * host reboot. All logic lives in lib/fleet/reboot-respawn-runner.js (injectable-seam core); this
+ * file only wires the real supabase service client + the real detached spawner and invokes it. Does
+ * NOT run on import (require.main guard) so the core stays unit-testable.
+ *
+ * STAGED / INERT: the runner defaults to FLEET_SPAWN_CONTROL_LIVE (default OFF). Unset → logs the
+ * intended per-slot resume invocations + roster and spawns nothing. The scheduled-task wrapper sets
+ * the flag per the operator gate.
+ */
+if (require.main === module) {
+  (async () => {
+    const { runRebootRespawn } = await import('../../lib/fleet/reboot-respawn-runner.js');
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    const { spawn } = require('node:child_process');
+    const supabase = createSupabaseServiceClient();
+
+    // Real detached spawner — mirrors spawn-control.js's default spawner (detached + unref'd so the
+    // relaunched tabs survive this process's exit). Only invoked when live.
+    const spawnFn = (program, args, env) => {
+      const child = spawn(program, args, { detached: true, stdio: 'ignore', env: { ...process.env, ...env } });
+      if (child && typeof child.unref === 'function') child.unref();
+      return child;
+    };
+
+    const res = await runRebootRespawn({ supabase, spawnFn, log: (m) => console.log(m) });
+    console.log(`[reboot-respawn] done: live=${res.live}, slots=${res.slotCount}, respawned=${res.results.filter((r) => r.spawned).length}`);
+    process.exit(0);
+  })().catch((e) => { console.error('[reboot-respawn] fatal:', e && e.message); process.exit(1); });
+}

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -362,7 +362,13 @@ async function upsertSessionRow(sessionId, ccPid, source, model) {
     heartbeat_at: now,
     pid: Number.isFinite(pidNum) ? pidNum : null,
     hostname: require('os').hostname(),
-    metadata: buildSessionMetadata(existingMetadata, ccPid, source, model),
+    // SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-2): stamp the Claude Code resume token
+    // (metadata.resume_uuid) for EVERY captured session. The resume token IS the session UUID
+    // (`claude --resume <uuid>` takes claude_sessions.session_id), so resume_uuid := sessionId.
+    // Additive + merge-safe: buildSessionMetadata already get-then-merges the existing metadata
+    // (preserving fleet_identity/callsign/tier_rank), and this only adds the one extra key that
+    // loadLiveSlotIdentity (session-registry-adapter.js:87) and reboot-respawn read.
+    metadata: { ...buildSessionMetadata(existingMetadata, ccPid, source, model), resume_uuid: sessionId },
   });
 
   const MAX_ATTEMPTS = 3;

--- a/scripts/setup-reboot-respawn-task.mjs
+++ b/scripts/setup-reboot-respawn-task.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Register the reboot-respawn runner as a Windows Task Scheduler task that fires on HOST REBOOT —
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D (FR-6). This closes Solomon checkpoint-3 G2: a reboot that kills
+ * every live fleet session now has a scheduled trigger that reads the frozen desired manifest and
+ * relaunches each slot via `claude --resume <uuid>`.
+ *
+ * FORKED from scripts/setup-eva-watcher-task.mjs (NOT a mutation of it — that module is the live EVA-
+ * watcher registrar). Reuses its shape (pure argv/wrapper builders + execFileSync runner + a wrapper
+ * .cmd that carries env and cd's to the repo), but swaps the every-N-minutes trigger for:
+ *   /SC ONSTART   (default; runs in session 0 with NO desktop — wt.exe may not open a visible tab)
+ *   /SC ONLOGON   (--onlogon; runs with a logged-in desktop, which wt.exe needs)
+ * plus /RU (default SYSTEM; --ru <user> to override) and /RL HIGHEST, and /F for idempotent re-register.
+ *
+ * The wrapper .cmd sets FLEET_SPAWN_CONTROL_LIVE per the operator gate (default 'false' = INERT; pass
+ * --live to generate a wrapper that sets it 'true' after host-validating the wt.exe invocation),
+ * cd's to the D worktree repo root, and calls the runner entrypoint (scripts/fleet/reboot-respawn.cjs).
+ *
+ * ⚠️ ONSTART/session-0 caveat: wt.exe (the supervisor's launch program) needs an interactive desktop.
+ * Prefer --onlogon where a logged-in desktop is acceptable; the session-0 headless constraint + fallback
+ * are documented in docs/protocol/fleet-reboot-respawn-drill.md. Validate live only under the operator
+ * host-validation gate — this module NEVER spawns anything itself.
+ *
+ * Usage:
+ *   node scripts/setup-reboot-respawn-task.mjs                 # register on ONSTART (idempotent)
+ *   node scripts/setup-reboot-respawn-task.mjs --onlogon       # register on ONLOGON (desktop available)
+ *   node scripts/setup-reboot-respawn-task.mjs --live          # wrapper sets FLEET_SPAWN_CONTROL_LIVE=true
+ *   node scripts/setup-reboot-respawn-task.mjs --ru <user>     # run as <user> instead of SYSTEM
+ *   node scripts/setup-reboot-respawn-task.mjs --status        # query the task
+ *   node scripts/setup-reboot-respawn-task.mjs --remove        # delete the task
+ *   node scripts/setup-reboot-respawn-task.mjs --dry-run       # print what would run, mutate nothing
+ *
+ * win32-only: schtasks does not exist on POSIX. On a non-Windows host this exits 2 with a POSIX note.
+ */
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { execFileSync } from 'child_process';
+import { getRepoRoot } from '../lib/repo-paths.js';
+
+export const TASK_NAME = 'EHG Fleet Reboot-Respawn';
+export const RUNNER_REL_PATH = path.join('scripts', 'fleet', 'reboot-respawn.cjs');
+export const WRAPPER_REL_PATH = path.join('scripts', 'cron', 'reboot-respawn-task.cmd');
+export const DEFAULT_SCHEDULE = 'ONSTART';
+export const DEFAULT_RUN_AS = 'SYSTEM';
+/** Default wrapper env: INERT (FLEET_SPAWN_CONTROL_LIVE off) until the operator host-validates. */
+export const TASK_ENV = Object.freeze({ FLEET_SPAWN_CONTROL_LIVE: 'false' });
+
+/**
+ * Build the wrapper .cmd content (PURE). Sets the operator gate env, cd's to the repo root, and calls
+ * the reboot-respawn runner via `node`. `call` returns the runner's exit code; @echo off keeps the
+ * Task Scheduler history clean.
+ */
+export function buildRebootWrapperScript({ repoRoot, runnerRelPath = RUNNER_REL_PATH, env = TASK_ENV } = {}) {
+  if (!repoRoot) throw new Error('buildRebootWrapperScript: repoRoot required');
+  const lines = ['@echo off'];
+  for (const [k, v] of Object.entries(env)) lines.push(`set ${k}=${v}`);
+  lines.push(`cd /d "${repoRoot}"`);
+  lines.push(`call node ${runnerRelPath}`);
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * Build the `schtasks /Create` argv (PURE, no embedded quoting — execFileSync quotes spaced args).
+ * Reboot trigger via /SC ONSTART (default) or /SC ONLOGON, run-level /RL HIGHEST, run-as /RU <user>
+ * (default SYSTEM), and /F so re-running is idempotent. The /TR target is the wrapper batch.
+ */
+export function buildRebootSchtasksArgs({ taskName = TASK_NAME, wrapperPath, schedule = DEFAULT_SCHEDULE, runAs = DEFAULT_RUN_AS, extraArgs = [] } = {}) {
+  if (!wrapperPath) throw new Error('buildRebootSchtasksArgs: wrapperPath required');
+  const sc = String(schedule).toUpperCase();
+  if (sc !== 'ONSTART' && sc !== 'ONLOGON') {
+    throw new Error(`buildRebootSchtasksArgs: schedule must be ONSTART or ONLOGON, got ${schedule}`);
+  }
+  const args = ['/Create', '/TN', taskName, '/TR', wrapperPath, '/SC', sc, '/RL', 'HIGHEST', '/F'];
+  if (runAs) args.push('/RU', runAs);
+  return [...args, ...extraArgs];
+}
+
+export function buildRemoveArgs(taskName = TASK_NAME) {
+  return ['/Delete', '/TN', taskName, '/F'];
+}
+
+export function buildQueryArgs(taskName = TASK_NAME) {
+  return ['/Query', '/TN', taskName, '/V', '/FO', 'LIST'];
+}
+
+function runSchtasks(args, { logger = console } = {}) {
+  try {
+    const out = execFileSync('schtasks', args, { encoding: 'utf8' });
+    return { ok: true, stdout: out };
+  } catch (err) {
+    return { ok: false, code: err.status ?? 1, stdout: err.stdout?.toString?.() || '', stderr: err.stderr?.toString?.() || err.message };
+  }
+}
+
+export function parseArgs(argv) {
+  const args = { mode: 'register', dryRun: false, help: false, schedule: DEFAULT_SCHEDULE, runAs: DEFAULT_RUN_AS, live: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--remove' || a === '--delete') args.mode = 'remove';
+    else if (a === '--status' || a === '--query') args.mode = 'status';
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--onlogon') args.schedule = 'ONLOGON';
+    else if (a === '--onstart') args.schedule = 'ONSTART';
+    else if (a === '--live') args.live = true;
+    else if (a === '--ru') { args.runAs = argv[i + 1]; i++; }
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+const USAGE = 'setup-reboot-respawn-task [--onlogon|--onstart] [--live] [--ru <user>] [--status|--remove|--dry-run]  (Windows Task Scheduler ONSTART/ONLOGON host for the fleet reboot-respawn runner)';
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  const logger = deps.logger || console;
+  const tag = '[setup-reboot-respawn-task]';
+  if (args.help) { logger.log(USAGE); return { exitCode: 0, action: 'help' }; }
+
+  const platform = deps.platform || process.platform;
+  const repoRoot = deps.repoRoot || getRepoRoot();
+  const wrapperPath = path.join(repoRoot, WRAPPER_REL_PATH);
+  const wrapperEnv = { FLEET_SPAWN_CONTROL_LIVE: args.live ? 'true' : 'false' };
+
+  if (platform !== 'win32') {
+    logger.error(`${tag} win32-only (schtasks). On POSIX, register an @reboot cron line instead:`);
+    logger.error(`${tag}   @reboot cd ${repoRoot} && FLEET_SPAWN_CONTROL_LIVE=${args.live ? 'true' : 'false'} node ${RUNNER_REL_PATH}`);
+    return { exitCode: 2, action: 'not_win32' };
+  }
+
+  if (args.mode === 'status') {
+    if (args.dryRun) { logger.log(`${tag} DRY RUN — would run: schtasks ${buildQueryArgs().join(' ')}`); return { exitCode: 0, action: 'dry_run_status' }; }
+    const res = runSchtasks(buildQueryArgs(), { logger });
+    logger.log(res.stdout || res.stderr);
+    return { exitCode: res.ok ? 0 : 1, action: 'status', present: res.ok };
+  }
+
+  if (args.mode === 'remove') {
+    if (args.dryRun) { logger.log(`${tag} DRY RUN — would run: schtasks ${buildRemoveArgs().join(' ')}`); return { exitCode: 0, action: 'dry_run_remove' }; }
+    const res = runSchtasks(buildRemoveArgs(), { logger });
+    if (res.ok) { logger.log(`${tag} task '${TASK_NAME}' removed`); return { exitCode: 0, action: 'removed' }; }
+    logger.error(`${tag} remove failed: ${res.stderr}`);
+    return { exitCode: 1, action: 'remove_failed' };
+  }
+
+  // register (default): write the wrapper, then create/refresh the task.
+  const wrapperContent = buildRebootWrapperScript({ repoRoot, env: wrapperEnv });
+  const schtasksArgs = buildRebootSchtasksArgs({ wrapperPath, schedule: args.schedule, runAs: args.runAs });
+  if (args.dryRun) {
+    logger.log(`${tag} DRY RUN — would write wrapper ${wrapperPath}:`);
+    logger.log(wrapperContent.replace(/\r\n/g, '\n'));
+    logger.log(`${tag} would run: schtasks ${schtasksArgs.join(' ')}`);
+    return { exitCode: 0, action: 'dry_run_register', wrapperPath, schedule: args.schedule, live: args.live };
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(wrapperPath), { recursive: true });
+    fs.writeFileSync(wrapperPath, wrapperContent, 'utf8');
+  } catch (err) {
+    logger.error(`${tag} could not write wrapper ${wrapperPath}: ${err.message}`);
+    return { exitCode: 1, action: 'wrapper_write_failed' };
+  }
+
+  const res = runSchtasks(schtasksArgs, { logger });
+  if (!res.ok) {
+    logger.error(`${tag} schtasks /Create failed (code ${res.code}): ${res.stderr}`);
+    return { exitCode: 1, action: 'create_failed' };
+  }
+  logger.log(`${tag} registered '${TASK_NAME}' — /SC ${args.schedule} /RL HIGHEST /RU ${args.runAs} → ${WRAPPER_REL_PATH}`);
+  logger.log(`${tag} wrapper gate: FLEET_SPAWN_CONTROL_LIVE=${args.live ? 'true' : 'false'} (${args.live ? 'LIVE — host-validate wt.exe first' : 'INERT default; re-run with --live after host-validation'})`);
+  return { exitCode: 0, action: 'registered', wrapperPath, schedule: args.schedule, live: args.live };
+}
+
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main()
+    .then(({ exitCode }) => { process.exitCode = exitCode; })
+    .catch((err) => { console.error('setup-reboot-respawn-task fatal:', err.message); process.exitCode = 2; });
+}

--- a/tests/unit/fleet/desired-slots-store.test.js
+++ b/tests/unit/fleet/desired-slots-store.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D FR-1/FR-2/FR-3 — desired-state slot store.
+ * Pure/deterministic parts: fail-soft reader, normalized shape, roster translation, resume_uuid
+ * get-then-merge capture. (The LOAD-BEARING live reboot drill is separate — see FR-7 / runbook.)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  loadDesiredSlots,
+  upsertDesiredSlot,
+  captureResumeUuid,
+  slotsToRoster,
+} from '../../../lib/fleet/desired-slots-store.js';
+
+/** from(TABLE).select(cols) -> Promise<{data,error}> — the exact call loadDesiredSlots makes. */
+function makeSelectSupabase({ data = null, error = null } = {}) {
+  return { from: () => ({ select: () => Promise.resolve({ data, error }) }) };
+}
+
+/** Stateful fake covering the claude_sessions + fleet_desired_slots shapes captureResumeUuid touches. */
+function makeSessionSupabase({ sessions = {}, slots = {} } = {}) {
+  const sessionStore = JSON.parse(JSON.stringify(sessions));
+  const slotStore = JSON.parse(JSON.stringify(slots));
+  return {
+    _sessions: sessionStore,
+    _slots: slotStore,
+    from(table) {
+      if (table === 'claude_sessions') {
+        return {
+          select: () => ({ eq: (_c, val) => ({ maybeSingle: async () => ({ data: sessionStore[val] ? { metadata: sessionStore[val].metadata } : null, error: null }) }) }),
+          update: (patch) => ({ eq: async (_c, val) => { if (sessionStore[val]) Object.assign(sessionStore[val], patch); return { error: sessionStore[val] ? null : { message: 'not found' } }; } }),
+        };
+      }
+      if (table === 'fleet_desired_slots') {
+        return {
+          update: (patch) => ({ eq: async (_c, val) => { if (slotStore[val]) Object.assign(slotStore[val], patch); return { error: null }; } }),
+          upsert: async () => ({ error: null }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('loadDesiredSlots (FR-1) — fail-soft', () => {
+  it('returns [] when the table is absent (chairman-gated migration unapplied)', async () => {
+    const supabase = makeSelectSupabase({ data: null, error: { message: 'relation "fleet_desired_slots" does not exist', code: '42P01' } });
+    // RED against a non-fail-soft reader: a throw/undefined here instead of [] would fail this.
+    expect(await loadDesiredSlots(supabase)).toEqual([]);
+  });
+
+  it('returns [] on a null/absent client (never throws)', async () => {
+    expect(await loadDesiredSlots(null)).toEqual([]);
+    expect(await loadDesiredSlots({})).toEqual([]);
+  });
+
+  it('returns normalizeDesiredSlots-shaped rows, excluding disabled + nameless slots', async () => {
+    const supabase = makeSelectSupabase({
+      data: [
+        { name: 'Worker-1', color: 'blue', role: 'worker', account_profile: 'acctA', model: 'opus', effort: 'high', worktree: 'C:\\wt\\1', resume_uuid: 'u-1', enabled: true },
+        { name: 'Worker-2', color: null, role: 'worker', account_profile: null, model: null, effort: null, worktree: null, resume_uuid: null, enabled: false }, // disabled -> excluded
+        { name: null, color: 'red', enabled: true }, // nameless -> dropped by normalizeDesiredSlots
+      ],
+      error: null,
+    });
+    const slots = await loadDesiredSlots(supabase);
+    expect(slots).toEqual([
+      { name: 'Worker-1', color: 'blue', role: 'worker', account_profile: 'acctA', model: 'opus', effort: 'high', worktree: 'C:\\wt\\1', resume_uuid: 'u-1' },
+    ]);
+  });
+});
+
+describe('upsertDesiredSlot (FR-1)', () => {
+  it('rejects a nameless slot without touching the DB', async () => {
+    const res = await upsertDesiredSlot(makeSessionSupabase(), {});
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/name is required/);
+  });
+
+  it('upserts a named slot and reports ok', async () => {
+    const res = await upsertDesiredSlot(makeSessionSupabase(), { name: 'Worker-1', role: 'worker' });
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('captureResumeUuid (FR-2) — get-then-merge, never a bare replace', () => {
+  it('stamps metadata.resume_uuid = sessionId while preserving fleet_identity/callsign/tier_rank/role', async () => {
+    const supabase = makeSessionSupabase({
+      sessions: { 's-1': { metadata: { fleet_identity: { callsign: 'Golf', color: 'blue' }, callsign: 'Golf', tier_rank: 2, role: 'worker' } } },
+    });
+    const res = await captureResumeUuid(supabase, { name: 'Golf', sessionId: 's-1' });
+    expect(res.ok).toBe(true);
+    const md = supabase._sessions['s-1'].metadata;
+    // RED against a bare `.update({metadata:{resume_uuid}})` replace: those fields would be gone.
+    expect(md.resume_uuid).toBe('s-1');
+    expect(md.fleet_identity).toEqual({ callsign: 'Golf', color: 'blue' });
+    expect(md.callsign).toBe('Golf');
+    expect(md.tier_rank).toBe(2);
+    expect(md.role).toBe('worker');
+  });
+
+  it('is fail-soft on a missing sessionId', async () => {
+    const res = await captureResumeUuid(makeSessionSupabase(), { name: 'x' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/sessionId is required/);
+  });
+});
+
+describe('slotsToRoster (FR-3) — FLEET_SUPERVISOR_ROSTER shape', () => {
+  it('maps name->callsign, account_profile->accountProfile, role->role, carries resume_uuid', () => {
+    const roster = slotsToRoster([
+      { name: 'Worker-1', role: 'worker', account_profile: 'acctA', resume_uuid: 'u-1' },
+    ]);
+    expect(roster).toEqual([{ role: 'worker', callsign: 'Worker-1', accountProfile: 'acctA', resume_uuid: 'u-1' }]);
+  });
+
+  it('serializes to exactly the JSON fleet-supervisor.cjs parses (role/callsign/accountProfile)', () => {
+    const roster = slotsToRoster([{ name: 'Adam-1', role: 'adam', account_profile: 'canary', resume_uuid: 'u-9' }]);
+    const parsed = JSON.parse(JSON.stringify(roster));
+    expect(parsed[0]).toMatchObject({ role: 'adam', callsign: 'Adam-1', accountProfile: 'canary' });
+  });
+
+  it('excludes enabled=false slots and drops nameless ones; defaults missing role to worker', () => {
+    const roster = slotsToRoster([
+      { name: 'Keep', enabled: true, resume_uuid: 'u-k' },       // no role -> worker
+      { name: 'Drop', enabled: false },                           // disabled -> excluded
+      { name: null, role: 'worker' },                             // nameless -> dropped
+    ]);
+    expect(roster).toEqual([{ role: 'worker', callsign: 'Keep', accountProfile: null, resume_uuid: 'u-k' }]);
+  });
+});

--- a/tests/unit/fleet/reboot-respawn-drill-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-drill-runner.test.js
@@ -1,0 +1,75 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D FR-7 — reboot-respawn drill runner.
+ * The four PASS/FAIL checks run against the REAL runRebootRespawn via injected seams (spawnFn/logFn/
+ * queryEventsFn exercise real logic). NOTE (no_unit_mock=true): these unit checks do NOT satisfy the
+ * SD's live-drill acceptance — that is the separate in-session/canary drill (see runbook). This file
+ * only proves the drill MECHANISM is correct.
+ */
+import { describe, it, expect } from 'vitest';
+import { runRebootRespawnDrill, printLiveExecutionPrecondition } from '../../../lib/fleet/reboot-respawn-drill-runner.js';
+
+const SLOTS = [
+  { name: 'Worker-1', role: 'worker', account_profile: null, resume_uuid: 'u-1' },
+  { name: 'Worker-2', role: 'worker', account_profile: null, resume_uuid: 'u-2' },
+];
+
+/** logFn records events into a shared array; queryEventsFn reads them back — real emit->read path. */
+function makeEventSeams() {
+  const events = [];
+  return {
+    logFn: async (_s, ev) => { events.push(ev); return { ok: true }; },
+    queryEventsFn: async () => events,
+    events,
+  };
+}
+
+describe('runRebootRespawnDrill (FR-7)', () => {
+  it('PASSes all four checks when manifest loads, roster builds, --resume relaunches, and events persist', async () => {
+    const { logFn, queryEventsFn } = makeEventSeams();
+    const { pass, checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, queryEventsFn, live: false,
+    });
+    expect(checks.map((c) => c.name)).toEqual(['manifest_loaded', 'roster_built', 'per_slot_resume_relaunch', 'respawn_events_present']);
+    expect(pass).toBe(true);
+    expect(checks.every((c) => c.pass)).toBe(true);
+  });
+
+  it('FAILs overall when no fleet_verb_respawn events are observed (log-before-action violated)', async () => {
+    const { pass, checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+      logFn: async () => ({ ok: true }), queryEventsFn: async () => [], live: false,
+    });
+    expect(pass).toBe(false);
+    expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(false);
+  });
+
+  it('FAILs manifest_loaded when the desired manifest is empty (table unapplied / no seed)', async () => {
+    const { logFn, queryEventsFn } = makeEventSeams();
+    const { pass, checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => [], logFn, queryEventsFn, live: false,
+    });
+    expect(pass).toBe(false);
+    expect(checks.find((c) => c.name === 'manifest_loaded').pass).toBe(false);
+  });
+
+  it('per_slot_resume_relaunch FAILs if a slot with a resume_uuid is relaunched WITHOUT its --resume token', async () => {
+    const { logFn, queryEventsFn } = makeEventSeams();
+    // Inject a buildInvocationFn that "forgets" the resume token -> the check must catch the masking.
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, queryEventsFn, live: false,
+      buildInvocationFn: ({ callsign }) => ({ program: 'wt.exe', args: ['new-tab', '--', 'claude'], env: { FLEET_WORKER_CALLSIGN: callsign } }),
+    });
+    expect(checks.find((c) => c.name === 'per_slot_resume_relaunch').pass).toBe(false);
+  });
+});
+
+describe('printLiveExecutionPrecondition (no-false-live-claim guardrail)', () => {
+  it('states mechanism-ready NOT live-executed, the no_unit_mock pin, and the Solomon-deferred canary leg', () => {
+    const text = printLiveExecutionPrecondition();
+    expect(text).toMatch(/MECHANISM-READY, NOT live-executed/);
+    expect(text).toMatch(/no_unit_mock=true/);
+    expect(text).toMatch(/DEFERRED to Solomon/);
+    expect(text).toMatch(/FLEET_SPAWN_CONTROL_LIVE/);
+    expect(text).not.toMatch(/live drill (passed|complete|proven)/i);
+  });
+});

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D FR-5 — reboot-respawn runner.
+ * Exercises the REAL runner logic (real buildLiveSpawnInvocation argv, real event payloads) via
+ * injected loadFn/spawnFn/logFn seams — NOT mocking away the assertion. The load-bearing LIVE drill
+ * (no_unit_mock=true) is separate (FR-7 / runbook); these lock the deterministic mechanism.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runRebootRespawn } from '../../../lib/fleet/reboot-respawn-runner.js';
+
+const SLOTS = [
+  { name: 'Worker-1', role: 'worker', account_profile: null, resume_uuid: 'u-1' },
+  { name: 'Worker-2', role: 'worker', account_profile: null, resume_uuid: null }, // no token -> back-compat path
+];
+
+describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
+  it('spawns NOTHING, logs per-slot resume invocations, and emits one fleet_verb_respawn event per slot', async () => {
+    const events = [];
+    const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
+    const spawnFn = vi.fn();
+    const res = await runRebootRespawn({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn, live: false, now: () => '2026-07-20T00:00:00.000Z',
+    });
+
+    expect(spawnFn).not.toHaveBeenCalled(); // default-OFF: no OS process
+    expect(res.live).toBe(false);
+    expect(res.slotCount).toBe(2);
+    // One event per slot (recorded in dry-run too so the in-session drill can observe the run).
+    expect(events).toHaveLength(2);
+    expect(events.every((e) => e.event_type === 'fleet_verb_respawn')).toBe(true);
+    expect(events[0].payload).toMatchObject({ verb: 'respawn', callsign: 'Worker-1', resume_uuid: 'u-1', live: false });
+
+    // The per-slot invocation carries the correct --resume token (slot 1) / no token (slot 2).
+    expect(res.results[0].invocation.args).toEqual(['new-tab', '--', 'claude', '--resume', 'u-1']);
+    expect(res.results[1].invocation.args).toEqual(['new-tab', '--', 'claude']);
+  });
+
+  it('builds a supervisor-shaped roster from the slots', async () => {
+    const res = await runRebootRespawn({ supabase: {}, loadFn: async () => SLOTS, logFn: async () => ({ ok: true }), live: false });
+    expect(res.roster).toEqual([
+      { role: 'worker', callsign: 'Worker-1', accountProfile: null, resume_uuid: 'u-1' },
+      { role: 'worker', callsign: 'Worker-2', accountProfile: null, resume_uuid: null },
+    ]);
+  });
+});
+
+describe('runRebootRespawn live (FR-5)', () => {
+  it('invokes spawnFn per slot with the real --resume argv when live', async () => {
+    const spawnCalls = [];
+    const spawnFn = vi.fn((program, args) => { spawnCalls.push({ program, args }); return { pid: 111 }; });
+    const res = await runRebootRespawn({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn: async () => ({ ok: true }), live: true, now: () => 'iso',
+    });
+    expect(res.live).toBe(true);
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(spawnCalls[0]).toEqual({ program: 'wt.exe', args: ['new-tab', '--', 'claude', '--resume', 'u-1'] });
+    expect(spawnCalls[1].args).toEqual(['new-tab', '--', 'claude']); // slot 2 had no token
+    expect(res.results.map((r) => r.spawned)).toEqual([true, true]);
+  });
+
+  it('resolves account_profile into CLAUDE_CONFIG_DIR via the injected resolver, and is fail-soft if it throws', async () => {
+    const okResolver = (name) => `C:\\profiles\\${name}`;
+    const spawnCalls = [];
+    const spawnFn = (program, args, env) => { spawnCalls.push(env); return { pid: 1 }; };
+    const res = await runRebootRespawn({
+      supabase: {}, loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'canary', resume_uuid: 'u-c' }],
+      spawnFn, logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: okResolver,
+    });
+    expect(spawnCalls[0].CLAUDE_CONFIG_DIR).toBe('C:\\profiles\\canary');
+    expect(res.results[0].spawned).toBe(true);
+
+    // Throwing resolver -> profileDir null, slot still respawns (fail-soft), no CLAUDE_CONFIG_DIR.
+    const spawnCalls2 = [];
+    const res2 = await runRebootRespawn({
+      supabase: {}, loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'bad', resume_uuid: 'u-c' }],
+      spawnFn: (p, a, e) => { spawnCalls2.push(e); return { pid: 1 }; },
+      logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: () => { throw new Error('bad profile'); },
+    });
+    expect(spawnCalls2[0]).not.toHaveProperty('CLAUDE_CONFIG_DIR');
+    expect(res2.results[0].spawned).toBe(true);
+  });
+});

--- a/tests/unit/fleet/setup-reboot-respawn-task.test.js
+++ b/tests/unit/fleet/setup-reboot-respawn-task.test.js
@@ -1,0 +1,108 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D FR-6 — forked ONSTART/ONLOGON scheduled-task registrar.
+ * Pure argv/wrapper builders + parseArgs + a dry-run main that mutates nothing (NO live schtasks call).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildRebootSchtasksArgs,
+  buildRebootWrapperScript,
+  buildRemoveArgs,
+  buildQueryArgs,
+  parseArgs,
+  main,
+  TASK_NAME,
+  RUNNER_REL_PATH,
+} from '../../../scripts/setup-reboot-respawn-task.mjs';
+
+describe('buildRebootSchtasksArgs (FR-6)', () => {
+  it('emits /SC ONSTART with /RL HIGHEST, /RU SYSTEM and /F by default', () => {
+    const args = buildRebootSchtasksArgs({ wrapperPath: 'C:\\repo\\scripts\\cron\\reboot-respawn-task.cmd' });
+    expect(args).toContain('/Create');
+    expect(args).toContain('/TN');
+    expect(args).toContain(TASK_NAME);
+    // /SC ONSTART
+    expect(args[args.indexOf('/SC') + 1]).toBe('ONSTART');
+    // /RL HIGHEST
+    expect(args[args.indexOf('/RL') + 1]).toBe('HIGHEST');
+    // /RU SYSTEM
+    expect(args[args.indexOf('/RU') + 1]).toBe('SYSTEM');
+    // /F for idempotent re-register
+    expect(args).toContain('/F');
+  });
+
+  it('supports the /SC ONLOGON variant (desktop available for wt.exe)', () => {
+    const args = buildRebootSchtasksArgs({ wrapperPath: 'w.cmd', schedule: 'ONLOGON' });
+    expect(args[args.indexOf('/SC') + 1]).toBe('ONLOGON');
+  });
+
+  it('honors a custom /RU and appends extraArgs', () => {
+    const args = buildRebootSchtasksArgs({ wrapperPath: 'w.cmd', runAs: 'FLEET', extraArgs: ['/DELAY', '0000:30'] });
+    expect(args[args.indexOf('/RU') + 1]).toBe('FLEET');
+    expect(args).toContain('/DELAY');
+  });
+
+  it('throws on an unsupported schedule (never silently mis-registers)', () => {
+    expect(() => buildRebootSchtasksArgs({ wrapperPath: 'w.cmd', schedule: 'MINUTE' })).toThrow(/ONSTART or ONLOGON/);
+  });
+
+  it('throws when wrapperPath is missing', () => {
+    expect(() => buildRebootSchtasksArgs({})).toThrow(/wrapperPath required/);
+  });
+});
+
+describe('buildRebootWrapperScript (FR-6)', () => {
+  it('sets the FLEET_SPAWN_CONTROL_LIVE gate, cd\'s to the repo root, and calls the runner entrypoint', () => {
+    const cmd = buildRebootWrapperScript({ repoRoot: 'C:\\repo', env: { FLEET_SPAWN_CONTROL_LIVE: 'true' } });
+    expect(cmd).toMatch(/^@echo off/);
+    expect(cmd).toContain('set FLEET_SPAWN_CONTROL_LIVE=true');
+    expect(cmd).toContain('cd /d "C:\\repo"');
+    expect(cmd).toContain(`call node ${RUNNER_REL_PATH}`);
+    expect(cmd.endsWith('\r\n')).toBe(true);
+  });
+
+  it('throws when repoRoot is missing', () => {
+    expect(() => buildRebootWrapperScript({})).toThrow(/repoRoot required/);
+  });
+});
+
+describe('buildRemoveArgs / buildQueryArgs (parity with source module)', () => {
+  it('remove uses /Delete /F', () => {
+    expect(buildRemoveArgs()).toEqual(['/Delete', '/TN', TASK_NAME, '/F']);
+  });
+  it('query uses /Query /V /FO LIST', () => {
+    expect(buildQueryArgs()).toEqual(['/Query', '/TN', TASK_NAME, '/V', '/FO', 'LIST']);
+  });
+});
+
+describe('parseArgs (FR-6)', () => {
+  it('defaults to register on ONSTART, run-as SYSTEM, inert (live=false)', () => {
+    expect(parseArgs(['node', 'x'])).toMatchObject({ mode: 'register', schedule: 'ONSTART', runAs: 'SYSTEM', live: false, dryRun: false });
+  });
+  it('parses --onlogon, --live, --ru <user>, --dry-run, --remove, --status', () => {
+    expect(parseArgs(['node', 'x', '--onlogon', '--live'])).toMatchObject({ schedule: 'ONLOGON', live: true });
+    expect(parseArgs(['node', 'x', '--ru', 'FLEET'])).toMatchObject({ runAs: 'FLEET' });
+    expect(parseArgs(['node', 'x', '--dry-run'])).toMatchObject({ dryRun: true });
+    expect(parseArgs(['node', 'x', '--remove'])).toMatchObject({ mode: 'remove' });
+    expect(parseArgs(['node', 'x', '--status'])).toMatchObject({ mode: 'status' });
+  });
+});
+
+describe('main --dry-run (mutates nothing, no live schtasks)', () => {
+  it('prints the wrapper + schtasks argv and returns dry_run_register without writing', async () => {
+    const logs = [];
+    const logger = { log: (m) => logs.push(String(m)), error: (m) => logs.push(String(m)) };
+    const res = await main(['node', 'x', '--onlogon', '--live', '--dry-run'], { platform: 'win32', repoRoot: 'C:\\repo', logger });
+    expect(res).toMatchObject({ exitCode: 0, action: 'dry_run_register', schedule: 'ONLOGON', live: true });
+    const joined = logs.join('\n');
+    expect(joined).toContain('set FLEET_SPAWN_CONTROL_LIVE=true');
+    expect(joined).toContain('/SC ONLOGON');
+  });
+
+  it('is win32-only: on POSIX it returns not_win32 with a cron fallback note', async () => {
+    const logs = [];
+    const logger = { log: (m) => logs.push(String(m)), error: (m) => logs.push(String(m)) };
+    const res = await main(['node', 'x'], { platform: 'linux', repoRoot: '/repo', logger });
+    expect(res).toMatchObject({ exitCode: 2, action: 'not_win32' });
+    expect(logs.join('\n')).toMatch(/@reboot/);
+  });
+});

--- a/tests/unit/fleet/spawn-control-resume.test.js
+++ b/tests/unit/fleet/spawn-control-resume.test.js
@@ -1,0 +1,40 @@
+/**
+ * SD-LEO-INFRA-LEO-COMPLETION-001-D FR-4 — buildLiveSpawnInvocation `--resume` extension.
+ * Pure argv builder: resume append + strict back-compat (no-resume path byte-identical) + the
+ * CLAUDE_CONFIG_DIR-into-returned-env-only isolation invariant preserved.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildLiveSpawnInvocation } from '../../../lib/fleet/spawn-control.js';
+
+describe('buildLiveSpawnInvocation --resume (FR-4)', () => {
+  it('appends [--resume, <uuid>] to the argv when a resumeUuid is supplied', () => {
+    const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1', resumeUuid: 'abc-123' });
+    // RED against pre-change code (which had NO resume path): args would be ['new-tab','--','claude'].
+    expect(inv.args).toEqual(['new-tab', '--', 'claude', '--resume', 'abc-123']);
+    expect(inv.program).toBe('wt.exe');
+  });
+
+  it('is byte-identical to the legacy invocation when no resumeUuid is given (back-compat)', () => {
+    const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' });
+    expect(inv.args).toEqual(['new-tab', '--', 'claude']);
+  });
+
+  it('coerces a non-string resume token via String() (never leaks a raw object into argv)', () => {
+    const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 42 });
+    expect(inv.args).toEqual(['new-tab', '--', 'claude', '--resume', '42']);
+  });
+
+  it('injects CLAUDE_CONFIG_DIR only into the returned env, never process.env, and never as an argv token', () => {
+    const before = process.env.CLAUDE_CONFIG_DIR;
+    const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1', profileDir: 'C:\\profiles\\canary', resumeUuid: 'u-1' });
+    expect(inv.env.CLAUDE_CONFIG_DIR).toBe('C:\\profiles\\canary');
+    expect(inv.args).not.toContain('C:\\profiles\\canary');
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(before); // isolation invariant untouched
+  });
+
+  it('omits CLAUDE_CONFIG_DIR from env when no profileDir is given', () => {
+    const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 'u' });
+    expect(inv.env).not.toHaveProperty('CLAUDE_CONFIG_DIR');
+    expect(inv.env.FLEET_WORKER_CALLSIGN).toBe('W');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-LEO-COMPLETION-001-D — Reboot-respawn runner (G1b/G2)

Closes Solomon checkpoint-3 grounds **G1b+G2** ("respawn was unbuildable — no runner, no scheduled task, no `claude --resume` consumer"). Child of SD-LEO-INFRA-LEO-COMPLETION-001; builds on siblings B (slot schema), C (supervisor), E (drill template).

### What's implemented (7 FRs, all 4 dependency-gaps B under-delivered)
- **`fleet_desired_slots` table** — migration `20260720_fleet_desired_slots_STAGED.sql`, RLS service-role-only (matches `role_drain_sets` precedent). **STAGED — NOT applied** (chairman-gated DDL).
- **`lib/fleet/desired-slots-store.js`** — `loadDesiredSlots` (fail-soft), `upsertDesiredSlot`, `captureResumeUuid`, `slotsToRoster`.
- **`lib/fleet/spawn-control.js`** — `buildLiveSpawnInvocation` appends `--resume <uuid>` when present (no-resume path byte-identical).
- **`scripts/hooks/capture-session-id.cjs`** — additive `metadata.resume_uuid` stamp.
- **`lib/fleet/reboot-respawn-runner.js`** + **`scripts/fleet/reboot-respawn.cjs`** — runner (injectable seams) + entrypoint, default-inert behind `FLEET_SPAWN_CONTROL_LIVE`, emits `fleet_verb_respawn` events.
- **`scripts/setup-reboot-respawn-task.mjs`** — forked schtasks registrar (`/SC ONSTART`|`/SC ONLOGON`, `/RU` + `/RL HIGHEST`).
- **`lib/fleet/reboot-respawn-drill-runner.js`** + runbook — drill runner (mechanism-ready).

### Tests
37 new + 73 touched-suite unit tests passing; ESLint clean.

### Deferred (captured as completion-flags)
- **Live reboot-respawn canary drill** — deferred to Solomon on Child B's canary account (`no_unit_mock=true`; unit tests do NOT satisfy the live-drill AC; mirrors sibling E's MECHANISM-READY posture).
- **Apply STAGED `fleet_desired_slots` migration** — chairman DDL gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
