### PR TITLE
fix(SD-LEO-INFRA-LEO-COMPLETION-001-D): wire reboot-respawn entry points for WIRE_CHECK reachability

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "adam:exec:email:cron": "node scripts/adam-exec-summary.mjs",
     "fleet:spawn-executor": "node scripts/fleet/worker-spawn-executor.cjs",
     "fleet:supersede-expired-spawns": "node scripts/fleet/supersede-expired-spawn-requests.mjs",
+    "fleet:reboot-respawn": "node scripts/fleet/reboot-respawn.cjs",
+    "fleet:setup-reboot-respawn-task": "node scripts/setup-reboot-respawn-task.mjs",
     "fleet:pulse": "node scripts/fleet-worker-pulse.mjs",
     "fleet:pulse:cron": "node scripts/fleet-worker-pulse.mjs",
     "fleet:down-alert": "node scripts/fleet-down-alert.mjs",


### PR DESCRIPTION
## What

Follow-up wiring fix for SD-LEO-INFRA-LEO-COMPLETION-001-D (PR #6382, already squash-merged). WIRE_CHECK_GATE flagged 5 of D's files as statically unreachable from any entry point at LEAD-FINAL-APPROVAL. This PR registers the reboot-respawn CLI entrypoints so the gate's static call-graph sees them (and their transitive imports) reachable — **no gate weakening, no bypass**.

## The fix

Two `package.json` scripts added (grouped with the existing `scripts/fleet/` entries):

- `fleet:reboot-respawn` → `node scripts/fleet/reboot-respawn.cjs` (the ONSTART/ONLOGON scheduled-task runner entrypoint)
- `fleet:setup-reboot-respawn-task` → `node scripts/setup-reboot-respawn-task.mjs` (the schtasks registrar CLI)

`WIRE_CHECK_GATE.discoverEntryPoints()` harvests any `node <path>` token from `package.json` scripts, so both files become entry points (and an entry point is reachable-from-itself). Their transitive imports resolve statically:

- `reboot-respawn.cjs` → string-literal `await import('../../lib/fleet/reboot-respawn-runner.js')` (the call-graph builder resolves literal dynamic `import()`)
- `reboot-respawn-runner.js` → static `import ... from './desired-slots-store.js'`

So `reboot-respawn-runner.js` and `desired-slots-store.js` are now reachable.

`lib/fleet/reboot-respawn-drill-runner.js` was already covered by an `@wire-check-exempt` marker in its header (no live invocation site until the deferred canary reboot drill), mirroring the sibling precedent `lib/fleet/u4-drill-runner.js` (SD-...-001-E) which uses the same marker mechanism. No change needed there.

## Verification

Ran the gate's real modules (`discoverEntryPoints` + `buildCallGraph` + `checkReachability`) against the worktree:

```
EXEMPT (@wire-check-exempt marker): lib/fleet/reboot-respawn-drill-runner.js
  entry contains scripts/fleet/reboot-respawn.cjs: true
  entry contains scripts/setup-reboot-respawn-task.mjs: true
--- Reachability of non-excluded candidates ---
  REACHABLE  : scripts/fleet/reboot-respawn.cjs
  REACHABLE  : scripts/setup-reboot-respawn-task.mjs
  REACHABLE  : lib/fleet/reboot-respawn-runner.js
  REACHABLE  : lib/fleet/desired-slots-store.js
RESULT: PASS - all non-excluded candidates reachable
```

`git diff --name-only --diff-filter=A origin/main...HEAD -- '*.js' '*.mjs' '*.cjs'` is empty — the 5 already-merged files are not re-flagged as new; only `package.json` (a modify) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)