### PR TITLE
fix(QF-20260720-824): honor chairman quiet-hours window-extension for SMS

### DIFF
--- a/lib/comms/adam-outbound/quiet-hours-extension.js
+++ b/lib/comms/adam-outbound/quiet-hours-extension.js
@@ -1,0 +1,33 @@
+/**
+ * Chairman quiet-hours window-extension check — QF-20260720-824.
+ *
+ * rubric-engine/lint.js already accepts context.allowQuietHours as a pure override input
+ * (never modified here); this supplies it from a durable, chairman-authorized source: a
+ * chairman_preferences row Adam sets ONLY on the chairman's explicit verbal authorization
+ * ("keep texting me until <time>"). Fail-safe throughout: any read error, missing,
+ * malformed, or expired value returns false — the standard 22:00-06:00 ET window applies
+ * by default. This never weakens the default; only a valid recorded chairman
+ * authorization can extend it.
+ */
+import { ChairmanPreferenceStore } from '../../eva/chairman-preference-store.js';
+
+export const CHAIRMAN_ID = 'ehg_chairman';
+export const EXTEND_KEY = 'notifications.quiet_hours_extended_until';
+
+/**
+ * @param {Date} now
+ * @param {object} [opts] - { store? } injectable ChairmanPreferenceStore for tests
+ * @returns {Promise<boolean>}
+ */
+export async function resolveAllowQuietHours(now, opts = {}) {
+  try {
+    const store = opts.store || new ChairmanPreferenceStore();
+    const pref = await store.getPreference({ chairmanId: CHAIRMAN_ID, key: EXTEND_KEY });
+    if (!pref || typeof pref.value !== 'string') return false;
+    const extendedUntil = Date.parse(pref.value);
+    if (!Number.isFinite(extendedUntil)) return false;
+    return now.getTime() < extendedUntil;
+  } catch {
+    return false;
+  }
+}

--- a/lib/eva/chairman-preference-store.js
+++ b/lib/eva/chairman-preference-store.js
@@ -89,6 +89,16 @@ const KNOWN_KEY_VALIDATORS = {
     if (!Number.isInteger(v) || v < 1 || v > 60) return 'must be an integer between 1 and 60';
     return null;
   },
+  // QF-20260720-824: chairman-authorized SMS quiet-hours window extension (verbal
+  // "keep texting me until <time>"). ISO timestamp; consumed by
+  // lib/comms/adam-outbound/quiet-hours-extension.js. Not a recurring schedule change —
+  // a one-off, explicit, chairman-set extension for the current window only.
+  'notifications.quiet_hours_extended_until': (v) => {
+    if (v === null) return null;
+    if (typeof v !== 'string') return 'must be an ISO timestamp string or null';
+    if (!Number.isFinite(Date.parse(v))) return 'must be a valid ISO timestamp';
+    return null;
+  },
 };
 
 function validateValueType(value, valueType) {

--- a/scripts/adam-chairman-decision.mjs
+++ b/scripts/adam-chairman-decision.mjs
@@ -9,6 +9,7 @@ import 'dotenv/config';
 import crypto from 'crypto';
 import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
 import { sendChairmanSMS } from '../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+import { resolveAllowQuietHours } from '../lib/comms/adam-outbound/quiet-hours-extension.js';
 
 enforceCliSendGuard({
   scriptName: 'scripts/adam-chairman-decision.mjs',
@@ -55,11 +56,12 @@ const message = {
   decisionId: argValue('--decision-id') || null,
   dedupeKey: argValue('--dedupe-key') || null,
 };
-const context = { now: new Date() };
-
 if (DRY) {
   console.log('=== [ADAM CHAIRMAN DECISION — DRY RUN] no send ===\n' + JSON.stringify(message, null, 2));
 } else {
+  // QF-20260720-824: honor a recorded chairman window-extension; default window unchanged.
+  const now = new Date();
+  const context = { now, allowQuietHours: await resolveAllowQuietHours(now) };
   const r = await sendChairmanSMS(message, context);
   console.log('ADAM-CHAIRMAN-DECISION', JSON.stringify(r));
 }

--- a/scripts/adam-chairman-sms.mjs
+++ b/scripts/adam-chairman-sms.mjs
@@ -5,6 +5,7 @@
 import 'dotenv/config';
 import { enforceCliSendGuard } from '../lib/notifications/cli-send-guard.mjs';
 import { sendChairmanSMS } from '../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+import { resolveAllowQuietHours } from '../lib/comms/adam-outbound/quiet-hours-extension.js';
 
 enforceCliSendGuard({
   scriptName: 'scripts/adam-chairman-sms.mjs',
@@ -26,11 +27,13 @@ if (!body || !body.trim()) {
 }
 
 const message = { type: 'status', body: body.trim(), kind, dedupeKey };
-const context = { now: new Date() };
 
 if (DRY) {
   console.log('=== [ADAM CHAIRMAN SMS — DRY RUN] no send ===\nKIND: ' + kind + '\n---\n' + message.body + '\n---');
 } else {
+  // QF-20260720-824: honor a recorded chairman window-extension; default window unchanged.
+  const now = new Date();
+  const context = { now, allowQuietHours: await resolveAllowQuietHours(now) };
   const r = await sendChairmanSMS(message, context);
   console.log('ADAM-CHAIRMAN-SMS', JSON.stringify(r));
 }

--- a/tests/unit/comms/adam-outbound/quiet-hours-extension.test.js
+++ b/tests/unit/comms/adam-outbound/quiet-hours-extension.test.js
@@ -1,0 +1,45 @@
+// QF-20260720-824: chairman quiet-hours window-extension check. Fail-safe throughout —
+// only a valid, unexpired, chairman-set extension flips allowQuietHours to true; every
+// other case (absent/malformed/expired/error) leaves the standard 22:00-06:00 ET window
+// in force.
+import { describe, it, expect, vi } from 'vitest';
+import { resolveAllowQuietHours, CHAIRMAN_ID, EXTEND_KEY } from '../../../../lib/comms/adam-outbound/quiet-hours-extension.js';
+
+function fakeStore(pref) {
+  return { getPreference: vi.fn().mockResolvedValue(pref) };
+}
+
+describe('resolveAllowQuietHours', () => {
+  const now = new Date('2026-07-20T23:00:00.000-04:00'); // 23:00 ET — inside the quiet window
+
+  it('returns false when no preference is set', async () => {
+    const store = fakeStore(null);
+    expect(await resolveAllowQuietHours(now, { store })).toBe(false);
+  });
+
+  it('returns true when a valid, unexpired extension is recorded', async () => {
+    const store = fakeStore({ value: '2026-07-20T23:30:00.000-04:00' }); // 23:30 ET, still ahead of `now`
+    expect(await resolveAllowQuietHours(now, { store })).toBe(true);
+    expect(store.getPreference).toHaveBeenCalledWith({ chairmanId: CHAIRMAN_ID, key: EXTEND_KEY });
+  });
+
+  it('returns false when the recorded extension has already expired', async () => {
+    const store = fakeStore({ value: '2026-07-20T22:30:00.000-04:00' }); // 22:30 ET, before `now`
+    expect(await resolveAllowQuietHours(now, { store })).toBe(false);
+  });
+
+  it('returns false when the recorded value is not a parseable timestamp', async () => {
+    const store = fakeStore({ value: 'not-a-date' });
+    expect(await resolveAllowQuietHours(now, { store })).toBe(false);
+  });
+
+  it('returns false when the recorded value is not a string', async () => {
+    const store = fakeStore({ value: 12345 });
+    expect(await resolveAllowQuietHours(now, { store })).toBe(false);
+  });
+
+  it('fails safe (false) when the store throws', async () => {
+    const store = { getPreference: vi.fn().mockRejectedValue(new Error('db down')) };
+    expect(await resolveAllowQuietHours(now, { store })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `resolveAllowQuietHours()`, a fail-safe helper that reads a durable `chairman_preferences` row and populates the rubric-engine's ALREADY-EXISTING `context.allowQuietHours` override lever — closing the gap where a chairman-authorized window-extension had no path into the send flow
- Adam sets `notifications.quiet_hours_extended_until` ONLY on the chairman's explicit verbal authorization ("keep texting me until <time>"); absent/malformed/expired values fall back to the standard 22:00-06:00 ET window, unchanged
- Wired into both live send entry points (`adam-chairman-sms.mjs`, `adam-chairman-decision.mjs`) — no new table/migration, reuses the existing `chairman_preferences` CRUD

## Test plan
- [x] 6/6 new unit tests (unset/valid/expired/malformed/wrong-type/store-error cases)
- [x] 57/57 existing rubric-engine/preference-store/decision-scheduler tests passing — no regressions
- [x] Live end-to-end verification against the real `chairman_preferences` table: set future extension → allowed; set past extension → blocked; delete → blocked (default protection confirmed intact), no stray state left after cleanup
- [x] TypeScript compiles clean, dry-run CLI paths unaffected

QF-20260720-824

🤖 Generated with [Claude Code](https://claude.com/claude-code)