### PR TITLE
feat(SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B): SMS decision-class registration + stage-gate guardrails

### DIFF
--- a/.prd-payloads/CAPTURE-SOLOMON-SMS-DECISION-ROUTING.md
+++ b/.prd-payloads/CAPTURE-SOLOMON-SMS-DECISION-ROUTING.md
@@ -1,0 +1,20 @@
+# Solomon verdict — SMS decision-class routing (SD-LEO-FEAT-TWO-WAY-CHAIRMAN-001)
+
+Source: Solomon consult reply id=1a809123 (ref row 4e1a7094), b1f789ea, 2026-07-16. Confidence: high.
+Status of the SD: HELD at PLAN boundary until 10DLC (A2P campaign) lands. Fold this into the PLAN/spec when it unfences. escalate_to_chairman=false (rides the decision-with-default packet).
+
+## Verdict
+1. **NOTIFY-vs-DECIDE is the RIGHT primary cut.** One sharpening: the three admission conditions are DESIGN-TIME admission criteria, NOT the runtime predicate. Runtime = an ENUMERATED WHITELIST checked server-side at the bridge; unknown/unclassified → console; fail-closed; never trust the asking agent's self-label. An agent evaluating "is this reversible?" per-message is the rationalization hole; membership in a chairman-ratified class list is not.
+2. **NOTIFY may cover anything, with two guards:** (a) content-sensitivity axis governs EVERY body incl. notify (no venture financials on a lock screen — "decision waiting: console"); (b) deep-links carry NO auth (no magic links) — a token-bearing link makes SMS an auth surface and breaks L6 composition; plain console URL, normal login.
+3. **THRESHOLD:** default **$250/decision AND $500/day CUMULATIVE** across all SMS-approved spend, chairman-tunable. Cumulative cap matters more than per-decision (a spoofer must not clear N×$250 in a burst). Bounds the fully-compromised-channel worst case (SIM-swap answering genuinely-pending questions — the one attack nonce binding does NOT stop). "Reversible" for money = refundable/cancellable within the undo window.
+4. **ADD:** (a) UNDO WINDOW — SMS-decided spend executes after ~15min delay; confirm SMS says "reply UNDO by HH:MM" (converts reversible-in-principle to reversible-by-mechanism); (b) NO BATCHING — one decision per SMS question ("YES approves all 5" rebuilds high consequence from low pieces); (c) RATCHET — widening the whitelist IS a governance change → console-only, chairman-ratified (the routing policy can never be edited over the channel it governs); (d) AUDIT PARITY — SMS decisions land on the same `chairman_decisions` row with `channel='sms'`; (e) AUTO-SUSPEND — N consecutive invalid/unmatched inbound → suspend SMS-DECIDE to notify-only + console alert (degrade closed); (f) free-text replies are UNTRUSTED content relayed to the asker, never executed — SMS selects among presented options (affirms FR-2).
+5. **REJECT:** re-auth/confirmation-challenge as a third tier — a challenge over the same spoofable channel is fat-finger UX not auth. Two tiers only (whitelist-SMS, console); if a class tempts re-auth, that IS the console signal. Time-of-day: reuse FR-5 quiet window + TTL-fallback to email/console on unanswered (fire-once lesson). Self-reference explicit: kill-switch, autonomy grants, and THIS policy = console.
+6. **COUNTERFACTUAL:** a real cryptographic factor on the wrist (signed replies via app, not bare SMS) lifts the ceiling/caps — but that's a NEW channel decision, not a tweak. If notify volume breeds rubber-stamping, tighten notify eligibility before touching decide.
+
+## Next steps (owner: PLAN)
+1. Encode classes as a DB-backed whitelist keyed to the SAME L6 taxonomy.
+2. Thresholds as chairman-tunable config.
+3. Undo-window on spend classes.
+4. Auto-suspend counter on the webhook.
+5. Acceptance: unknown-class→console, batch rejected, whitelist-edit-over-SMS rejected, no magic links.
+6. VERIFICATION: red-team the webhook (spoofed/unmatched/batch replies) before trusting the pilot.

--- a/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
+++ b/database/migrations/20260721_chairman_decisions_channel_STAGED.sql
@@ -1,0 +1,36 @@
+-- Chairman-decisions AUDIT CHANNEL column — records WHICH channel a chairman decision was made
+-- over, so an SMS-decided stage-gate approval is distinguishable from an authenticated-console one
+-- on the SAME chairman_decisions row (audit parity).
+-- SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B (FR-2; child B of the high-consequence-stage
+-- orchestrator — registers 'blocking stage-gate approval' as an SMS decision class + guardrails
+-- on the already-shipped chairman SMS decision envelope, SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001/-A/-B).
+-- Solomon-ratified guardrail (3) "AUDIT PARITY": an SMS decision lands on the same
+-- chairman_decisions row as a console decision, distinguished ONLY by channel='sms'.
+--
+-- WHY a nullable column with NO new RLS policy: this is an ADDITIVE audit attribute on an
+-- EXISTING table. ADD COLUMN reuses chairman_decisions' existing RLS policies (do NOT author a
+-- new policy — mirrors the nullable amount_usd add in 20260717_sms_spend_envelope_STAGED.sql).
+-- NULL is the pre-existing/unknown state and is interpreted as console (the historical default);
+-- only an SMS decision is ever stamped 'sms'. The CHECK bounds the vocabulary to ('sms','console').
+--
+-- FAIL-SOFT PRE-APPLY: the referencing seam lib/chairman/sms-bridge.js (stampSmsChannel, called
+-- on the outbound-send + inbound-answer paths) writes channel='sms' as a SEPARATE best-effort
+-- UPDATE, wrapped so a missing column PRE-APPLY resolves to {error} and is swallowed — the live
+-- SMS decision path is never crashed or blocked, the row is simply left unstamped until this
+-- migration is applied. Console-path decisions never call the seam, so channel stays NULL (=console).
+--
+-- STAGED — NOT YET APPROVED FOR APPLY. requires-chairman-apply. Do NOT auto-apply on merge; no
+-- approved-by attestation on this file. APPLY RUNBOOK (chairman ceremony):
+--   (1) chairman verbal/written approval;
+--   (2) apply via the standard migration path with an approved-by attestation commit;
+--   (3) run `npm run schema:snapshot:lint` and commit the regenerated snapshot in the same PR
+--       (the schema-lint-disable-line pragma on the stampSmsChannel channel write then becomes
+--       unnecessary) — schema:snapshot:lint runs AT the ceremony, not now;
+--   (4) verify with a real service_role probe: stamp channel='sms' on a test SMS decision and
+--       confirm the CHECK accepts 'sms'/'console' and rejects any other value.
+
+ALTER TABLE chairman_decisions
+  ADD COLUMN IF NOT EXISTS channel TEXT CHECK (channel IN ('sms', 'console'));
+
+COMMENT ON COLUMN chairman_decisions.channel IS
+  'Audit channel a chairman decision was made over (SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-2). sms = decided over the chairman SMS decision channel; console = authenticated console. NULL = unknown/legacy, interpreted as console. Stamped fail-soft by lib/chairman/sms-bridge.js stampSmsChannel; ADD COLUMN reuses the table RLS policies (no new policy).';

--- a/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
+++ b/database/migrations/20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql
@@ -1,0 +1,45 @@
+-- SMS decision-class whitelist SEED — register 'blocking stage-gate approval' as an SMS-eligible
+-- decision class (owner-run at the chairman ceremony).
+-- SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B (FR-3; child B of the high-consequence-stage
+-- orchestrator). This is the ACTUAL registration referenced by the SD title — a single seed row
+-- in sms_decision_class_whitelist (the table created by
+-- 20260717_sms_decision_class_whitelist_STAGED.sql). Solomon-ratified guardrail (c) "RATCHET":
+-- widening the whitelist IS a governance change -> console-only, chairman-ratified (the routing
+-- policy can never be edited over the channel it governs). This seed is therefore authored as a
+-- STAGED owner-run migration, NOT a JS change and NOT applied by the worker.
+--
+-- WHY owner-only: INSERT/UPDATE/DELETE on sms_decision_class_whitelist are REVOKE'd from
+-- anon/authenticated/service_role at the TABLE-PRIVILEGE layer (see the parent whitelist migration).
+-- service_role BYPASSES RLS but NOT GRANT/REVOKE, so ONLY the table owner (postgres), acting
+-- through the chairman ceremony, can run this INSERT. The fleet worker can never seed the whitelist.
+--
+-- NORMALIZATION: the table CHECK requires decision_class = lower(btrim(decision_class)) AND <> ''.
+-- 'blocking stage-gate approval' is already lowercase/trimmed/non-empty, so it passes the CHECK.
+-- ON CONFLICT (decision_class) DO NOTHING makes re-running the ceremony idempotent (decision_class
+-- is UNIQUE) — a second apply seeds nothing and errors nothing.
+--
+-- RECONCILIATION NOTE (not a blocker — see PRD TR-2 / risk): registration ALONE does not guarantee
+-- SMS-eligibility. The whitelist gate in sms-bridge.js sits BEHIND the fail-closed HIGH-consequence
+-- backstop (consequence-classifier.js, default HIGH). A 'blocking stage-gate approval' whose
+-- title/context text trips HIGH_PATTERNS (governance/irreversible/kill-gate/etc.) still routes to
+-- CONSOLE and never reaches this whitelist — that fail-toward-HIGH behavior is intentional and is
+-- NOT loosened by this seed.
+--
+-- STAGED — NOT YET APPROVED FOR APPLY. requires-chairman-apply. Do NOT auto-apply on merge; no
+-- approved-by attestation on this file. APPLY RUNBOOK (chairman ceremony):
+--   (1) chairman verbal/written approval of registering this decision class;
+--   (2) apply via the standard migration path AS THE TABLE OWNER (postgres) with an approved-by
+--       attestation commit — the owner is exempt from the REVOKE and is the ONLY principal that
+--       may seed/widen the whitelist;
+--   (3) verify with a real service_role SELECT probe that the row exists + active=true — the SMS
+--       send path then treats the class as whitelist-eligible automatically (no code change), still
+--       behind the HIGH backstop above.
+
+INSERT INTO sms_decision_class_whitelist (decision_class, active, added_by, rationale)
+VALUES (
+  'blocking stage-gate approval',
+  true,
+  'chairman-ceremony',
+  'SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-3: registers blocking stage-gate approvals as SMS-eligible, behind the fail-closed HIGH backstop + $250/decision & $500/day spend envelope + 15m undo window. Solomon-ratified (.prd-payloads/CAPTURE-SOLOMON-SMS-DECISION-ROUTING.md).'
+)
+ON CONFLICT (decision_class) DO NOTHING;

--- a/lib/chairman/sms-bridge.js
+++ b/lib/chairman/sms-bridge.js
@@ -59,6 +59,25 @@ const INBOUND_RATE_WINDOW_MINUTES = 60;
 // past the window — unlike INBOUND_RATE_LIMIT's rolling block, a suspension is only
 // lifted by explicit operator action against sms_inbound_suspensions.cleared_at).
 const AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD = 5;
+// SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-4: a SEPARATE, additive auto-suspend counter for
+// UNMATCHED inbound answers, DISTINCT from the invalid_signature flood counter above (which is
+// left behaviorally unchanged). A from_phone that produces this many no_match/ambiguous outcomes
+// within INBOUND_RATE_WINDOW_MINUTES is degraded to notify-only (a PERSISTENT sms_inbound_suspensions
+// row, same mechanism/table as the invalid_signature trip) plus a console alert. Encodes Solomon
+// guardrail (e): "N consecutive invalid/UNMATCHED inbound -> notify-only + console alert (degrade
+// closed)". Env-overridable; a blank/malformed override falls back to the default (never silently
+// widens/zeros the threshold). Default 3 deliberately sits BELOW the 5/window inbound rate-limit
+// ceiling (INBOUND_RATE_LIMIT) so the counter can actually trip before rate-limiting masks further
+// unmatched replies.
+function readPositiveIntEnv(envName, fallback) {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === null || String(raw).trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 1 ? n : fallback;
+}
+const AUTO_SUSPEND_UNMATCHED_THRESHOLD = readPositiveIntEnv('SMS_AUTO_SUSPEND_UNMATCHED_THRESHOLD', 3);
+// The inbound outcomes that count as an UNMATCHED answer for the FR-4 counter above.
+const UNMATCHED_OUTCOMES = ['no_match', 'ambiguous'];
 // How many recent SMS-channel notifications to a phone number to consider when looking
 // for the most-recent-PENDING one (not just the most-recently-sent) — see the docstring
 // on handleInboundSmsReply below.
@@ -73,11 +92,92 @@ const AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD = 5;
 // is ever hit in practice.
 const CANDIDATE_NOTIFICATION_LOOKBACK = 5;
 
-function composeMessage(title) {
-  const suffix = ' Reply to answer.';
+// SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-5: single-digit reply indices ("Reply 1=.., 2=..").
+const SMS_MAX_OPTIONS = 9;
+
+/**
+ * SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-5: compose the outbound decision question. When
+ * enumerated `options` are supplied the body presents them as a MULTIPLE-CHOICE prompt ("Reply
+ * 1=Approve, 2=Reject.") and the inbound matcher then requires the reply to SELECT one — free text
+ * that matches no option stays untrusted (relayed, never executed). With no options the body is the
+ * pre-existing free-text form (backward-compatible; unchanged for legacy LOW/MEDIUM questions).
+ * @param {string} title
+ * @param {string[]} [options] normalized option labels (see normalizeSmsOptions)
+ */
+function composeMessage(title, options = []) {
+  const suffix = Array.isArray(options) && options.length > 0
+    ? ` Reply ${options.map((o, i) => `${i + 1}=${o}`).join(', ')}.`
+    : ' Reply to answer.';
   const budget = MAX_SMS_BODY_LENGTH - suffix.length;
-  const truncated = title.length > budget ? `${title.slice(0, budget - 1)}…` : title;
+  const truncated = title.length > budget ? `${title.slice(0, Math.max(0, budget - 1))}…` : title;
   return `${truncated}${suffix}`;
+}
+
+/**
+ * Normalize a caller-supplied options list to an array of non-empty trimmed string labels (max
+ * SMS_MAX_OPTIONS). Non-array input, non-string/blank entries are dropped. FR-5.
+ * @param {unknown} options
+ * @returns {string[]}
+ */
+function normalizeSmsOptions(options) {
+  if (!Array.isArray(options)) return [];
+  const out = [];
+  for (const o of options) {
+    if (typeof o !== 'string') continue;
+    const label = o.trim();
+    if (label === '') continue;
+    out.push(label);
+    if (out.length >= SMS_MAX_OPTIONS) break;
+  }
+  return out;
+}
+
+/**
+ * Match an inbound reply body against the presented enumerated options (FR-5). A reply matches
+ * ONLY by 1-based option index ("1"/"2") or an EXACT case-insensitive label ("approve"); any other
+ * free text does NOT match (relayed-not-executed). Mirrors the fail-closed spirit of the whitelist:
+ * uncertainty resolves to no-match, never a guessed option.
+ * @param {string} body raw inbound reply text
+ * @param {string[]} options presented option labels
+ * @returns {{matched: boolean, index?: number, label?: string}}
+ */
+function matchSmsOption(body, options) {
+  if (!Array.isArray(options) || options.length === 0) return { matched: false };
+  const trimmed = typeof body === 'string' ? body.trim() : '';
+  if (trimmed === '') return { matched: false };
+  if (/^\d+$/.test(trimmed)) {
+    const idx = parseInt(trimmed, 10) - 1;
+    if (idx >= 0 && idx < options.length) return { matched: true, index: idx, label: options[idx] };
+    return { matched: false };
+  }
+  const lc = trimmed.toLowerCase();
+  const idx = options.findIndex((o) => o.trim().toLowerCase() === lc);
+  if (idx >= 0) return { matched: true, index: idx, label: options[idx] };
+  return { matched: false };
+}
+
+/**
+ * SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-6: fail-soft stamp of channel='sms' on an SMS
+ * decision's chairman_decisions row (audit parity — an SMS decision is distinguishable from a
+ * console one on the SAME row; Solomon guardrail (3)). Done as a SEPARATE best-effort UPDATE so a
+ * missing column PRE-APPLY (the FR-2 migration is STAGED/unapplied) can never crash or block the
+ * live decision path — mirrors smsOutboundObligationsLive's fail-soft probe. NEVER throws; NEVER
+ * folded into the critical answer/token update (folding it in would make the whole update fail
+ * pre-apply and drop the reply). NULL/unstamped rows are interpreted as console.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} decisionId
+ * @returns {Promise<boolean>} true only when the stamp actually wrote (column present)
+ */
+async function stampSmsChannel(supabase, decisionId) {
+  try {
+    const { error } = await supabase
+      .from('chairman_decisions')
+      .update({ channel: 'sms' }) // schema-lint-disable-line staged col (20260721_chairman_decisions_channel_STAGED)
+      .eq('id', decisionId);
+    return !error;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -181,7 +281,30 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
 
   const token = crypto.randomBytes(16).toString('hex');
   const expiresAt = new Date(Date.now() + TOKEN_TTL_MS).toISOString();
-  const message = composeMessage(title);
+
+  // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-5: present ENUMERATED choice options when the
+  // caller supplies them; the inbound matcher then requires the reply to select one (free text
+  // that matches no option stays UNTRUSTED — relayed, never executed). Backward-compatible: with
+  // no options the message + reply handling are the pre-existing free-text form.
+  const options = normalizeSmsOptions(opts.options);
+  const message = composeMessage(title, options);
+
+  // Persist the presented options on the decision so handleInboundSmsReply can enforce the
+  // multiple-choice match. Stored under brief_data.sms_options (NOT sms_reply) — this is presented-
+  // QUESTION metadata, never the reply, so it is outside the free-text-untrusted seam and the
+  // anti-direct-read AST rule (which guards sms_reply only). Read+merge so existing brief_data keys
+  // are preserved; only touched when options are actually presented (legacy path unchanged).
+  let briefDataPatch = null;
+  if (options.length > 0) {
+    const { data: existingDecision } = await supabase
+      .from('chairman_decisions')
+      .select('brief_data')
+      .eq('id', decisionId)
+      .maybeSingle();
+    briefDataPatch = { ...((existingDecision && existingDecision.brief_data) || {}), sms_options: options };
+  }
+  const decisionUpdate = { sms_reply_token: token, sms_reply_token_expires_at: expiresAt, consequence_level: consequence };
+  if (briefDataPatch) decisionUpdate.brief_data = briefDataPatch;
 
   // SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-B FR-1: when the durable owed-state table is live,
   // ENQUEUE an owed obligation row instead of sending inline (the 201-as-success F1 defect). The
@@ -207,8 +330,11 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
 
     await supabase
       .from('chairman_decisions')
-      .update({ sms_reply_token: token, sms_reply_token_expires_at: expiresAt, consequence_level: consequence })
+      .update(decisionUpdate)
       .eq('id', decisionId);
+
+    // FR-6: this decision is being ASKED over SMS — stamp channel='sms' (fail-soft; no-op pre-apply).
+    await stampSmsChannel(supabase, decisionId);
 
     const enq = await enqueueChairmanSms(supabase, {
       recipientPhone: chairmanPhone,
@@ -243,12 +369,11 @@ export async function sendChairmanSmsQuestion(supabase, opts, provider = twilioP
 
   await supabase
     .from('chairman_decisions')
-    .update({
-      sms_reply_token: token,
-      sms_reply_token_expires_at: expiresAt,
-      consequence_level: consequence,
-    })
+    .update(decisionUpdate)
     .eq('id', decisionId);
+
+  // FR-6: this decision is being ASKED over SMS — stamp channel='sms' (fail-soft; no-op pre-apply).
+  await stampSmsChannel(supabase, decisionId);
 
   return { sent: true, consequence, token, provider_message_id: result.provider_message_id };
 }
@@ -302,6 +427,66 @@ async function checkAndApplyAutoSuspend(supabase, from, { justLoggedInvalidSigna
     return true;
   }
   return false;
+}
+
+/**
+ * SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-4: SEPARATE from checkAndApplyAutoSuspend's
+ * invalid_signature flood trip (which is unchanged). Counts recent UNMATCHED inbound answers
+ * (outcome in no_match/ambiguous) for a from_phone within INBOUND_RATE_WINDOW_MINUTES and, once
+ * AUTO_SUSPEND_UNMATCHED_THRESHOLD is crossed, degrades that number to notify-only by inserting a
+ * PERSISTENT sms_inbound_suspensions row (same mechanism/table as the invalid_signature trip) and
+ * emits a console alert. Called AFTER the no_match/ambiguous outcome has been logged, so the
+ * just-logged row is included in the count (mirrors the invalid_signature path's log-then-count).
+ * A number already actively suspended is a no-op (no duplicate row). FAIL-SOFT / best-effort: never
+ * throws into the inbound relay path.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} from
+ * @returns {Promise<boolean>} true if the number is (now) actively suspended
+ */
+async function checkAndApplyUnmatchedAutoSuspend(supabase, from) {
+  try {
+    const { data: existing } = await supabase
+      .from('sms_inbound_suspensions')
+      .select('from_phone, cleared_at')
+      .eq('from_phone', from)
+      .is('cleared_at', null)
+      .maybeSingle();
+    if (existing) return true;
+
+    const windowStart = new Date(Date.now() - INBOUND_RATE_WINDOW_MINUTES * 60 * 1000).toISOString();
+    const { count } = await supabase
+      .from('sms_inbound_log')
+      .select('*', { count: 'exact', head: true })
+      .eq('from_phone', from)
+      .in('outcome', UNMATCHED_OUTCOMES)
+      .gte('created_at', windowStart);
+
+    if ((count || 0) >= AUTO_SUSPEND_UNMATCHED_THRESHOLD) {
+      await supabase.from('sms_inbound_suspensions').insert({
+        from_phone: from,
+        reason: `${count} unmatched (no_match/ambiguous) replies within ${INBOUND_RATE_WINDOW_MINUTES}m — SMS-decide degraded to notify-only`,
+      });
+      // Console alert — Solomon guardrail (e): degrade closed AND surface it (notify-only).
+      console.warn(`[sms-bridge] AUTO-SUSPEND(unmatched): ${from} degraded to notify-only after ${count} unmatched replies within ${INBOUND_RATE_WINDOW_MINUTES}m. Cleared only by operator action on sms_inbound_suspensions.cleared_at.`);
+      return true;
+    }
+    return false;
+  } catch {
+    // Best-effort: a suspension-write/read failure must never break the inbound relay path.
+    return false;
+  }
+}
+
+/**
+ * Log an UNMATCHED (no_match/ambiguous) inbound outcome AND evaluate the FR-4 unmatched
+ * auto-suspend counter for the sender. Thin wrapper so every no_match/ambiguous logging site feeds
+ * the counter consistently (FR-4 wires the pre-existing no_match/ambiguous sites plus the new
+ * options-mismatch site). Does NOT touch the invalid_signature path (outcome must be in
+ * UNMATCHED_OUTCOMES).
+ */
+async function logInboundUnmatched(supabase, logArgs) {
+  await logInbound(supabase, logArgs);
+  await checkAndApplyUnmatchedAutoSuspend(supabase, logArgs.from);
 }
 
 /**
@@ -367,7 +552,8 @@ export async function handleInboundSmsReply(supabase, inbound) {
 
   const candidateIds = [...new Set((notifRows || []).map((r) => r.decision_id))];
   if (candidateIds.length === 0) {
-    await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match' });
+    // FR-4: no_match feeds the unmatched auto-suspend counter.
+    await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match' });
     return { resolved: false, outcome: 'no_match' };
   }
 
@@ -393,7 +579,8 @@ export async function handleInboundSmsReply(supabase, inbound) {
 
     if (undoEligible.length === 0) {
       // No open undo window (nothing to cancel) — never record "undo" as an answer.
-      await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: candidateIds[0] });
+      // FR-4: no_match feeds the unmatched auto-suspend counter.
+      await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: candidateIds[0] });
       return { resolved: false, outcome: 'no_match' };
     }
 
@@ -410,7 +597,8 @@ export async function handleInboundSmsReply(supabase, inbound) {
     if (!undone || undone.length === 0) {
       // Lost the race to a concurrent consume that claimed first (consumed_at set), or the
       // window closed between read and write — fail-closed, do not record an answer.
-      await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: target.id });
+      // FR-4: no_match feeds the unmatched auto-suspend counter.
+      await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: target.id });
       return { resolved: false, outcome: 'no_match' };
     }
 
@@ -424,7 +612,8 @@ export async function handleInboundSmsReply(supabase, inbound) {
 
   if (eligible.length > 1) {
     // FR-3: ambiguous — never guess which open question this reply answers.
-    await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'ambiguous', matchedDecisionId: candidateIds[0] });
+    // FR-4: ambiguous feeds the unmatched auto-suspend counter.
+    await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'ambiguous', matchedDecisionId: candidateIds[0] });
     return { resolved: false, outcome: 'ambiguous' };
   }
 
@@ -442,8 +631,34 @@ export async function handleInboundSmsReply(supabase, inbound) {
   }
 
   const decisionId = decision.id;
+
+  // SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B FR-5: when this decision presented ENUMERATED options
+  // (stored under brief_data.sms_options at send time), the reply MUST select one of them to be
+  // actionable. A reply matching no option is UNMATCHED (no_match) — relayed-not-executed, feeding
+  // the FR-4 unmatched auto-suspend counter — and is NEVER delivered as an answer (sms_reply is not
+  // written, the decision is not claimed, so a later valid-option reply can still resolve it). Free-
+  // text-untrusted is thereby preserved even here. Decisions sent WITHOUT options keep the pre-
+  // existing free-text delivery (backward-compatible).
+  const presentedOptions = decision.brief_data && Array.isArray(decision.brief_data.sms_options)
+    ? decision.brief_data.sms_options
+    : [];
+  let matchedOption = null;
+  if (presentedOptions.length > 0) {
+    const m = matchSmsOption(body, presentedOptions);
+    if (!m.matched) {
+      await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: decisionId });
+      return { resolved: false, outcome: 'no_match' };
+    }
+    matchedOption = m.label;
+  }
+
   const answeredAt = new Date().toISOString();
-  const mergedBriefData = { ...(decision.brief_data || {}), sms_reply: { text: body, answered_at: answeredAt, from } };
+  // The raw reply text stays INERT under sms_reply (only consumeSmsReply reads it, per the anti-
+  // direct-read AST rule). When an option matched we ADDITIVELY record the validated option label
+  // alongside the inert text — this adds trusted structure without removing the inert-text guarantee.
+  const replyPayload = { text: body, answered_at: answeredAt, from };
+  if (matchedOption !== null) replyPayload.option = matchedOption;
+  const mergedBriefData = { ...(decision.brief_data || {}), sms_reply: replyPayload };
 
   // SD-LEO-FEAT-SMS-CHAIRMAN-DECISION-001-B FR-3: for a SPEND-class decision, stamp the undo
   // window on a DEDICATED column (never brief_data) so consumeSmsReply is inert until it
@@ -464,9 +679,14 @@ export async function handleInboundSmsReply(supabase, inbound) {
 
   if (!updated || updated.length === 0) {
     // Lost the race to a concurrent request that claimed this decision first.
-    await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: decisionId });
+    // FR-4: no_match feeds the unmatched auto-suspend counter.
+    await logInboundUnmatched(supabase, { from, to, body, messageSid, signatureValid, outcome: 'no_match', matchedDecisionId: decisionId });
     return { resolved: false, outcome: 'no_match' };
   }
+
+  // FR-6: an SMS-answered decision is stamped channel='sms' (audit parity). Fail-soft & separate
+  // from the answer UPDATE above so a missing column pre-apply cannot drop the just-recorded reply.
+  await stampSmsChannel(supabase, decisionId);
 
   await logInbound(supabase, { from, to, body, messageSid, signatureValid, outcome: 'answered', matchedDecisionId: decisionId });
   return { resolved: true, outcome: 'answered', decisionId };
@@ -603,4 +823,14 @@ export async function drainSmsRelayStaging(supabase, { limit = 50 } = {}) {
   return { drained: results.length, results };
 }
 
-export { composeMessage, TOKEN_TTL_MS, MAX_SMS_BODY_LENGTH, INBOUND_RATE_LIMIT, AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD };
+export {
+  composeMessage,
+  normalizeSmsOptions,
+  matchSmsOption,
+  stampSmsChannel,
+  TOKEN_TTL_MS,
+  MAX_SMS_BODY_LENGTH,
+  INBOUND_RATE_LIMIT,
+  AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD,
+  AUTO_SUSPEND_UNMATCHED_THRESHOLD,
+};

--- a/tests/unit/chairman/sms-decision-guardrails.test.js
+++ b/tests/unit/chairman/sms-decision-guardrails.test.js
@@ -1,0 +1,305 @@
+/**
+ * SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B — guardrail suite for the three net-new SMS
+ * decision-channel guardrails wired into lib/chairman/sms-bridge.js:
+ *   FR-4  a SEPARATE unmatched-reply (no_match/ambiguous) auto-suspend counter that degrades a
+ *         from_phone to notify-only + console alert, WITHOUT touching the invalid_signature trip.
+ *   FR-5  multiple-choice-only reply enforcement: an outbound question may present enumerated
+ *         options and an inbound reply must select one; free text that matches no option is
+ *         no_match (relayed-not-executed) and the raw text stays INERT under brief_data.sms_reply.
+ *   FR-6  a fail-soft channel='sms' audit stamp that no-ops when the STAGED column is absent.
+ * Plus AC-6: the fail-closed HIGH-consequence backstop is NOT loosened.
+ *
+ * Stubbed in-memory supabase (no live DB / Twilio), extended from tests/unit/chairman/
+ * sms-bridge.test.js's fake with `.in`/`.gt` filters and a `channelColumnPresent` switch that
+ * models a STAGED/unapplied column (an UPDATE setting `channel` errors + mutates nothing, mirroring
+ * PostgREST's column-missing behavior).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  handleInboundSmsReply,
+  composeMessage,
+  matchSmsOption,
+  normalizeSmsOptions,
+  stampSmsChannel,
+  AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD,
+  AUTO_SUSPEND_UNMATCHED_THRESHOLD,
+} from '../../../lib/chairman/sms-bridge.js';
+import { classifyConsequence } from '../../../lib/chairman/consequence-classifier.js';
+
+function makeFakeSupabase(seed = {}, { channelColumnPresent = true } = {}) {
+  const tables = {
+    chairman_notifications: [...(seed.chairman_notifications || [])],
+    chairman_decisions: [...(seed.chairman_decisions || [])],
+    sms_inbound_log: [...(seed.sms_inbound_log || [])],
+    sms_inbound_suspensions: [...(seed.sms_inbound_suspensions || [])],
+    sms_relay_staging: [...(seed.sms_relay_staging || [])],
+    sms_decision_class_whitelist: [...(seed.sms_decision_class_whitelist || [])],
+    sms_approved_spend_ledger: [...(seed.sms_approved_spend_ledger || [])],
+  };
+  let seq = 0;
+
+  function applyFilters(rows, filters) {
+    return rows.filter((row) =>
+      filters.every(([col, op, val]) => {
+        if (op === 'eq') return row[col] === val;
+        if (op === 'gte') return (row[col] ?? null) !== null && row[col] >= val;
+        if (op === 'gt') return (row[col] ?? null) !== null && row[col] > val;
+        if (op === 'not_is_null') return row[col] !== null && row[col] !== undefined;
+        if (op === 'in') return Array.isArray(val) && val.includes(row[col]);
+        if (op === 'is') return (row[col] ?? null) === val;
+        return true;
+      })
+    );
+  }
+
+  function from(table) {
+    const ctx = { filters: [], order: null, limitN: null, mode: null, countMode: false, returnSelect: false };
+    const api = {
+      select(_cols, opts) {
+        if (ctx.mode === 'update' || ctx.mode === 'insert') { ctx.returnSelect = true; return api; }
+        ctx.mode = 'select';
+        if (opts?.count === 'exact' && opts?.head) ctx.countMode = true;
+        return api;
+      },
+      insert(row) { ctx.mode = 'insert'; ctx.row = { id: `row-${++seq}`, created_at: new Date().toISOString(), ...row }; return api; },
+      update(vals) { ctx.mode = 'update'; ctx.vals = vals; return api; },
+      eq(col, val) { ctx.filters.push([col, 'eq', val]); return api; },
+      gte(col, val) { ctx.filters.push([col, 'gte', val]); return api; },
+      gt(col, val) { ctx.filters.push([col, 'gt', val]); return api; },
+      not(col) { ctx.filters.push([col, 'not_is_null', null]); return api; },
+      in(col, arr) { ctx.filters.push([col, 'in', arr]); return api; },
+      is(col, val) { ctx.filters.push([col, 'is', val]); return api; },
+      order(col, { ascending } = {}) { ctx.order = { col, ascending: !!ascending }; return api; },
+      limit(n) { ctx.limitN = n; return api; },
+      async maybeSingle() {
+        const rows = applyFilters(tables[table], ctx.filters);
+        return { data: rows[0] || null, error: null };
+      },
+      then(resolve) {
+        if (ctx.mode === 'insert') {
+          tables[table].push(ctx.row);
+          resolve({ data: [{ id: ctx.row.id }], error: null });
+          return;
+        }
+        if (ctx.mode === 'update') {
+          // Model a STAGED/absent column: an UPDATE that sets `channel` while the column does not
+          // exist errors and mutates nothing (mirrors PostgREST's column-missing error).
+          if (!channelColumnPresent && ctx.vals && Object.prototype.hasOwnProperty.call(ctx.vals, 'channel')) {
+            resolve({ data: null, error: { message: 'column "channel" of relation "chairman_decisions" does not exist' } });
+            return;
+          }
+          const rows = applyFilters(tables[table], ctx.filters);
+          rows.forEach((r) => Object.assign(r, ctx.vals));
+          resolve({ data: ctx.returnSelect ? rows.map((r) => ({ id: r.id })) : null, error: null });
+          return;
+        }
+        let rows = applyFilters(tables[table], ctx.filters);
+        if (ctx.order) {
+          rows = [...rows].sort((a, b) => {
+            const cmp = a[ctx.order.col] < b[ctx.order.col] ? -1 : a[ctx.order.col] > b[ctx.order.col] ? 1 : 0;
+            return ctx.order.ascending ? cmp : -cmp;
+          });
+        }
+        if (ctx.limitN != null) rows = rows.slice(0, ctx.limitN);
+        if (ctx.countMode) resolve({ count: rows.length, data: null, error: null });
+        else resolve({ data: rows, error: null });
+      },
+    };
+    return api;
+  }
+
+  return { from, _tables: tables };
+}
+
+const future = () => new Date(Date.now() + 10 * 60_000).toISOString();
+
+// ---------------------------------------------------------------------------------------
+// FR-4: unmatched (no_match/ambiguous) auto-suspend counter — separate from invalid_signature.
+// ---------------------------------------------------------------------------------------
+describe('FR-4 unmatched-reply auto-suspend counter', () => {
+  it('N unmatched (no_match) inbound replies from one number trip a PERSISTENT notify-only suspend + console alert', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sb = makeFakeSupabase(); // no notifications => every valid inbound resolves as no_match
+    const from = '+15551110000';
+    let last;
+    for (let i = 0; i < AUTO_SUSPEND_UNMATCHED_THRESHOLD; i++) {
+      last = await handleInboundSmsReply(sb, { from, to: '+15559999999', body: `free text ${i}`, messageSid: `SM-nm-${i}`, signatureValid: true });
+      expect(last.outcome).toBe('no_match');
+    }
+    // A persistent suspension row now exists (degrade-closed to notify-only).
+    expect(sb._tables.sms_inbound_suspensions.some((s) => s.from_phone === from && !s.cleared_at)).toBe(true);
+    // Console alert was emitted (Solomon guardrail (e): degrade closed AND surface).
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('AUTO-SUSPEND(unmatched)'))).toBe(true);
+    // The NEXT inbound — even valid — is now fail-closed rejected as 'suspended'.
+    const after = await handleInboundSmsReply(sb, { from, to: '+15559999999', body: 'now valid', messageSid: 'SM-nm-post', signatureValid: true });
+    expect(after.outcome).toBe('suspended');
+    warnSpy.mockRestore();
+  });
+
+  it('an ambiguous outcome also feeds the unmatched counter', async () => {
+    const now = Date.now();
+    // 2 simultaneously-eligible candidates => ambiguous. Threshold-1 pre-seeded no_match rows means
+    // this single ambiguous crosses AUTO_SUSPEND_UNMATCHED_THRESHOLD.
+    const seedLog = [];
+    for (let i = 0; i < AUTO_SUSPEND_UNMATCHED_THRESHOLD - 1; i++) {
+      seedLog.push({ id: `pre-${i}`, from_phone: '+15551119999', outcome: 'no_match', created_at: new Date(now - 1000).toISOString() });
+    }
+    const sb = makeFakeSupabase({
+      sms_inbound_log: seedLog,
+      chairman_decisions: [
+        { id: 'dec-amb-a', status: 'pending', brief_data: {}, sms_reply_token_expires_at: future() },
+        { id: 'dec-amb-b', status: 'pending', brief_data: {}, sms_reply_token_expires_at: future() },
+      ],
+      chairman_notifications: [
+        { id: 'na', channel: 'sms', recipient_phone: '+15551119999', decision_id: 'dec-amb-a', created_at: new Date(now - 120_000).toISOString() },
+        { id: 'nb', channel: 'sms', recipient_phone: '+15551119999', decision_id: 'dec-amb-b', created_at: new Date(now - 60_000).toISOString() },
+      ],
+    });
+    const res = await handleInboundSmsReply(sb, { from: '+15551119999', to: '+15559999999', body: 'yes', messageSid: 'SM-amb', signatureValid: true });
+    expect(res.outcome).toBe('ambiguous');
+    expect(sb._tables.sms_inbound_suspensions.some((s) => s.from_phone === '+15551119999' && !s.cleared_at)).toBe(true);
+  });
+
+  it('the invalid_signature path is unchanged: its threshold is 5, distinct from the unmatched threshold, and unmatched counting ignores invalid_signature', async () => {
+    expect(AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD).toBe(5);
+    expect(AUTO_SUSPEND_UNMATCHED_THRESHOLD).not.toBe(AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD);
+    const sb = makeFakeSupabase();
+    const from = '+15552220000';
+    // Below the invalid_signature threshold: no suspension. These are invalid_signature outcomes,
+    // which the unmatched counter never counts — so the new counter cannot cross-trip here either,
+    // even though the count exceeds the (smaller) unmatched threshold.
+    for (let i = 0; i < AUTO_SUSPEND_INVALID_SIGNATURE_THRESHOLD - 1; i++) {
+      const r = await handleInboundSmsReply(sb, { from, to: '+15559999999', body: 'spoof', messageSid: `SM-sig-${i}`, signatureValid: false });
+      expect(r.outcome).toBe('invalid_signature');
+    }
+    expect(sb._tables.sms_inbound_suspensions.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------------------
+// FR-5: multiple-choice-only reply enforcement (free-text-untrusted preserved).
+// ---------------------------------------------------------------------------------------
+describe('FR-5 multiple-choice-only reply enforcement', () => {
+  it('composeMessage renders enumerated options as a multiple-choice prompt; legacy free-text form is unchanged', () => {
+    const msg = composeMessage('Approve stage-gate promotion for Venture X?', ['Approve', 'Reject']);
+    expect(msg).toContain('1=Approve');
+    expect(msg).toContain('2=Reject');
+    expect(composeMessage('Which time works, 2pm or 4pm?')).toContain('Reply to answer.');
+  });
+
+  it('matchSmsOption resolves ONLY by 1-based index or exact case-insensitive label; free text does not match', () => {
+    const opts = ['Approve', 'Reject'];
+    expect(matchSmsOption('1', opts)).toMatchObject({ matched: true, label: 'Approve' });
+    expect(matchSmsOption('2', opts)).toMatchObject({ matched: true, label: 'Reject' });
+    expect(matchSmsOption('approve', opts)).toMatchObject({ matched: true, label: 'Approve' });
+    expect(matchSmsOption('  ReJeCt ', opts)).toMatchObject({ matched: true, label: 'Reject' });
+    expect(matchSmsOption('3', opts).matched).toBe(false);            // index out of range
+    expect(matchSmsOption('maybe later', opts).matched).toBe(false);  // free text
+    expect(matchSmsOption('', opts).matched).toBe(false);
+    expect(normalizeSmsOptions(['  Approve ', '', 3, 'Reject'])).toEqual(['Approve', 'Reject']);
+  });
+
+  it('a decision presenting options: a non-option free-text reply is no_match, never executed, and leaves sms_reply INERT/unwritten', async () => {
+    const phone = '+15553330000';
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-opt', status: 'pending', brief_data: { sms_options: ['Approve', 'Reject'] }, sms_reply_token_expires_at: future() }],
+      chairman_notifications: [{ id: 'n-opt', channel: 'sms', recipient_phone: phone, decision_id: 'dec-opt', created_at: new Date().toISOString() }],
+    });
+    const res = await handleInboundSmsReply(sb, { from: phone, to: '+15559999999', body: 'let me think about it', messageSid: 'SM-opt-1', signatureValid: true });
+    expect(res.resolved).toBe(false);
+    expect(res.outcome).toBe('no_match');
+    const dec = sb._tables.chairman_decisions.find((d) => d.id === 'dec-opt');
+    expect(dec.sms_reply_used_at).toBeFalsy();       // decision NOT claimed
+    expect(dec.brief_data.sms_reply).toBeUndefined(); // raw free text NOT delivered as an answer
+    expect(sb._tables.sms_inbound_log[0].outcome).toBe('no_match');
+  });
+
+  it('a decision presenting options: a matching reply resolves as answered, records the validated option, keeps raw text inert', async () => {
+    const phone = '+15554440000';
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-opt2', status: 'pending', brief_data: { sms_options: ['Approve', 'Reject'] }, sms_reply_token_expires_at: future() }],
+      chairman_notifications: [{ id: 'n-opt2', channel: 'sms', recipient_phone: phone, decision_id: 'dec-opt2', created_at: new Date().toISOString() }],
+    });
+    const res = await handleInboundSmsReply(sb, { from: phone, to: '+15559999999', body: '1', messageSid: 'SM-opt-2', signatureValid: true });
+    expect(res.resolved).toBe(true);
+    expect(res.outcome).toBe('answered');
+    const dec = sb._tables.chairman_decisions.find((d) => d.id === 'dec-opt2');
+    expect(dec.brief_data.sms_reply.text).toBe('1');          // raw inert text preserved
+    expect(dec.brief_data.sms_reply.option).toBe('Approve');  // validated option additively recorded
+    expect(dec.brief_data.sms_options).toEqual(['Approve', 'Reject']); // options metadata preserved
+    expect(dec.status).toBe('pending'); // delivery only — the agent's next tick resolves it
+  });
+
+  it('a decision WITHOUT options keeps the pre-existing free-text delivery (backward-compatible)', async () => {
+    const phone = '+15555550000';
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-legacy', status: 'pending', brief_data: {}, sms_reply_token_expires_at: future() }],
+      chairman_notifications: [{ id: 'n-legacy', channel: 'sms', recipient_phone: phone, decision_id: 'dec-legacy', created_at: new Date().toISOString() }],
+    });
+    const res = await handleInboundSmsReply(sb, { from: phone, to: '+15559999999', body: 'looks good, proceed', messageSid: 'SM-legacy-1', signatureValid: true });
+    expect(res.outcome).toBe('answered');
+    const dec = sb._tables.chairman_decisions.find((d) => d.id === 'dec-legacy');
+    expect(dec.brief_data.sms_reply.text).toBe('looks good, proceed');
+    expect(dec.brief_data.sms_reply.option).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------------------
+// FR-6: fail-soft channel='sms' audit stamp.
+// ---------------------------------------------------------------------------------------
+describe('FR-6 fail-soft channel=sms audit stamp', () => {
+  it('stampSmsChannel writes channel=sms when the column exists', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-ch', status: 'pending', brief_data: {} }] }, { channelColumnPresent: true });
+    const ok = await stampSmsChannel(sb, 'dec-ch');
+    expect(ok).toBe(true);
+    expect(sb._tables.chairman_decisions.find((d) => d.id === 'dec-ch').channel).toBe('sms');
+  });
+
+  it('stampSmsChannel is fail-soft (no throw, no-op) when the channel column is absent pre-apply', async () => {
+    const sb = makeFakeSupabase({ chairman_decisions: [{ id: 'dec-ch2', status: 'pending', brief_data: {} }] }, { channelColumnPresent: false });
+    const ok = await stampSmsChannel(sb, 'dec-ch2');
+    expect(ok).toBe(false); // reported not-written — but did NOT throw
+    expect(sb._tables.chairman_decisions.find((d) => d.id === 'dec-ch2').channel).toBeUndefined();
+  });
+
+  it('the SMS answer path still resolves normally when the channel column is absent (fail-soft integration)', async () => {
+    const phone = '+15556660000';
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-fs', status: 'pending', brief_data: {}, sms_reply_token_expires_at: future() }],
+      chairman_notifications: [{ id: 'n-fs', channel: 'sms', recipient_phone: phone, decision_id: 'dec-fs', created_at: new Date().toISOString() }],
+    }, { channelColumnPresent: false });
+    const res = await handleInboundSmsReply(sb, { from: phone, to: '+15559999999', body: 'yes', messageSid: 'SM-fs-1', signatureValid: true });
+    expect(res.outcome).toBe('answered');        // decision path NOT blocked by the missing column
+    const dec = sb._tables.chairman_decisions.find((d) => d.id === 'dec-fs');
+    expect(dec.brief_data.sms_reply.text).toBe('yes'); // reply still delivered
+    expect(dec.channel).toBeUndefined();               // channel left unstamped (fail-soft)
+  });
+
+  it('when the channel column exists, an SMS-answered decision row is stamped channel=sms', async () => {
+    const phone = '+15557770000';
+    const sb = makeFakeSupabase({
+      chairman_decisions: [{ id: 'dec-ch3', status: 'pending', brief_data: {}, sms_reply_token_expires_at: future() }],
+      chairman_notifications: [{ id: 'n-ch3', channel: 'sms', recipient_phone: phone, decision_id: 'dec-ch3', created_at: new Date().toISOString() }],
+    }, { channelColumnPresent: true });
+    const res = await handleInboundSmsReply(sb, { from: phone, to: '+15559999999', body: 'yes', messageSid: 'SM-ch3-1', signatureValid: true });
+    expect(res.outcome).toBe('answered');
+    expect(sb._tables.chairman_decisions.find((d) => d.id === 'dec-ch3').channel).toBe('sms');
+  });
+});
+
+// ---------------------------------------------------------------------------------------
+// AC-6 / risk: the fail-closed HIGH-consequence backstop is NOT loosened by registration.
+// ---------------------------------------------------------------------------------------
+describe('AC-6 HIGH-consequence backstop is not loosened', () => {
+  it('a stage-gate approval whose text trips HIGH_PATTERNS (governance) classifies HIGH (console-only)', () => {
+    expect(classifyConsequence({ decisionType: 'blocking stage-gate approval', title: 'Approve governance stage-gate promotion?' })).toBe('high');
+  });
+
+  it('unrecognized/unmatched stage-gate text still fails closed to HIGH (default)', () => {
+    expect(classifyConsequence({ decisionType: 'blocking stage-gate approval', title: 'xyzzy' })).toBe('high');
+  });
+
+  it('a stage-gate approval with bounded medium text is not forced to HIGH (registration is reconcilable per TR-2)', () => {
+    expect(classifyConsequence({ decisionType: 'blocking stage-gate approval', title: 'Approve promotion to the next stage?' })).toBe('medium');
+  });
+});


### PR DESCRIPTION
## SD-LEO-FEAT-HIGH-CONSEQUENCE-STAGE-001-B — SMS decision-class registration + stage-gate guardrails

Registers "blocking stage-gate approval" as a new enumerated SMS decision class on the already-built SMS decision envelope, restores a stranded Solomon guardrail doc, and wires net-new guardrails. **Backend-only** (SMS bridge + STAGED migrations, no UI).

### What's implemented (autonomous — all SQL STAGED/unapplied)
- **Restored** `.prd-payloads/CAPTURE-SOLOMON-SMS-DECISION-ROUTING.md` from stranded commit `a0e14aa8a3d` (byte-identical, hash-verified).
- **2 NEW STAGED migrations (NOT applied — chairman-gated):** `20260721_chairman_decisions_channel_STAGED.sql` (nullable audit `channel` column) + `20260721_sms_whitelist_seed_stage_gate_class_STAGED.sql` (owner-run seed INSERT of the new class — INSERT is REVOKE'd from service_role).
- **`lib/chairman/sms-bridge.js` guardrails:** auto-suspend widening (unmatched `no_match`/`ambiguous` counter, threshold 3, separate from `invalid_signature`=5); multiple-choice-only reply enforcement (opt-in via `brief_data.sms_options`); fail-soft `channel='sms'` audit stamp (never throws if the STAGED column is absent). Free-text stays untrusted; eslint AST rule preserved; HIGH backstop untouched.

### Tests
98 unit tests passing (15 new RED-verified guardrail tests), lint clean.

### Gate notes
EXEC-TO-PLAN GATE2 (`2A:uiComponentsImplemented`) + PLAN-TO-LEAD GATE3 (`recommendationAdherence`, which requires GATE2) mis-fire on this no-UI backend SD — documented audit-logged bypasses used (gate-bug `1082aa54`; `BACKEND_ONLY_SD_TYPES` excludes `feature`).

### Deferred (chairman-gated completion-flags)
- **Chairman-apply ceremony**: apply 4 STAGED migrations (`20260717_sms_decision_class_whitelist_STAGED.sql`, `20260717_sms_spend_envelope_STAGED.sql`, + the 2 new) + the whitelist seed.
- Downstream stage-gate→SMS call site must pass `brief_data.sms_options` for the multiple-choice guardrail to fully bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
