### PR TITLE
fix(QF-20260721-518): stale-test fix + moot-investigation note for Adam manifest parity

### DIFF
--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -44,6 +44,21 @@ export const RESPONSIBILITIES = [
 //   - governance-scan: the flag-gated read-only opportunity-scan (the heartbeat body).
 //   - inbox-monitor:   drain coordinator replies that arrived after a sync await timed out.
 //   - offer-help:      an agent-judgment tick (no script) — propose-only, silence-by-default.
+//
+// QF-20260721-518 (UAT-agent-filed, 2026-07-21): flagged 2 crons as missing from this
+// manifest -- "hourly heartbeat-SMS" and "decision-driving sweep every 3h". Investigation
+// found both premises stale by the time the QF was actioned:
+//   - heartbeat-SMS: already the 'heartbeat-sms' entry below (shipped by QF-20260719-343,
+//     TWO DAYS before this QF was filed).
+//   - "decision-driving sweep every 3h": no such CLAUDE_ADAM.md-declared duty exists
+//     (missingDurableDuties(readFileSync('CLAUDE_ADAM.md'), ADAM_LOOPS) returns []); the
+//     closest candidate, scripts/cron/adam-decision-scheduler-tick.mjs, is already durable
+//     via .github/workflows/adam-decision-scheduler-cron.yml (session_bound=false in
+//     periodic_process_registry) -- GHA crons survive session restarts on their own and do
+//     NOT need an ADAM_LOOPS entry, which exists specifically for session-scoped harness
+//     CronCreate jobs. No periodic_process_registry row for a session-bound 3h decision
+//     sweep was found either. Left here so a future UAT/parity re-check of this exact class
+//     doesn't re-flag the same already-closed gap.
 export const ADAM_LOOPS = [
   {
     // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: the quiet-tick cutover (docs/protocol/

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -24,7 +24,7 @@ import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 12 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 14 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
   // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
   // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties);
@@ -32,9 +32,11 @@ test('ADAM_LOOPS has the 12 expected tick loops with the expected keys', () => {
   // heartbeat-sms (was heartbeat-email, QF-20260702-433) + morning-brief-sms added by QF-20260719-343
   //   (contract c3/c4, leo_protocol_sections id=601, chairman-directed 2026-07-19);
   // quiet-tick added by SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001 (folds inbox-monitor/belt-countdown/offer-help);
-  // coordinator-health added by SD-LEO-INFRA-ADAM-COORDINATOR-HEALTH-001 (3-KPI coordinator oversight probe).
-  assert.equal(ADAM_LOOPS.length, 12);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'heartbeat-sms', 'morning-brief-sms']);
+  // coordinator-health added by SD-LEO-INFRA-ADAM-COORDINATOR-HEALTH-001 (3-KPI coordinator oversight probe);
+  // self-score + solomon-health added by QF-20260719-825 (chairman-directed deliberate-check cadence)
+  //   -- this assertion was stale at 12 for 2 days until QF-20260721-518 caught + fixed it.
+  assert.equal(ADAM_LOOPS.length, 14);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'self-score', 'solomon-health', 'heartbeat-sms', 'morning-brief-sms']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);


### PR DESCRIPTION
## Summary
- QF-20260721-518 asked to add 2 "missing" Adam crons (hourly heartbeat-SMS + a 3h decision-driving sweep) to the `ADAM_LOOPS` manifest. Investigation found both premises **stale by the time the QF was actioned**:
  - heartbeat-SMS is already the `heartbeat-sms` entry (shipped by QF-20260719-343, two days before this QF was filed).
  - "decision-driving sweep every 3h" has no matching `CLAUDE_ADAM.md` durable duty (`missingDurableDuties()` returns `[]`); the closest candidate, `adam-decision-scheduler-tick.mjs`, is already durable via `.github/workflows/adam-decision-scheduler-cron.yml` (`session_bound=false` in `periodic_process_registry`) — GHA crons don't need an `ADAM_LOOPS` entry, which exists specifically for session-scoped harness CronCreate jobs.
- Left a comment documenting this investigation so a future UAT/parity re-check of the same class doesn't re-flag an already-closed gap.
- While investigating, found `tests/unit/adam-startup-check.test.mjs`'s loop-count assertion was itself stale at 12 — the real manifest already has 14 loops (`self-score` + `solomon-health`, added by QF-20260719-825, were never reflected in this test). Fixed it since it's the exact "manifest parity" class this QF is about.

## Test plan
- [x] `node --test tests/unit/adam-startup-check.test.mjs` — 18/18 pass (was 17/18 before the stale-assertion fix)
- [x] `missingDurableDuties()` confirmed returns `[]` (no gap)
- [x] Cross-checked `periodic_process_registry` directly — no session-bound 3h decision-sweep row exists that would need registering

🤖 Generated with [Claude Code](https://claude.com/claude-code)