### PR TITLE
fix(QF-20260721-951): check live readers before KILL rec in flag-governance digest

### DIFF
--- a/lib/feature-flags/flag-reader-scan.js
+++ b/lib/feature-flags/flag-reader-scan.js
@@ -1,0 +1,81 @@
+/**
+ * flag-reader-scan.js — QF-20260721-951.
+ *
+ * Decide whether a feature flag is LOAD-BEARING by checking for LIVE READERS in the source
+ * tree, not just its registry STATE. The flag-governance digest previously recommended KILL
+ * for a disabled/aging flag from state alone; that false-KILL'd COORD_DETECTORS_V2 +
+ * SURFACE_INERT_WORKER_V1 (both read by real runtime code) and fenced a whole SD. This encodes,
+ * as a reusable predicate, the by-hand discrimination Charlie did (grep 9c0ee842):
+ *
+ *   COUNT as a live reader = a non-comment reference in real runtime code (lib/**, and
+ *                            production/fleet scripts) — code that actually gates behavior.
+ *   EXCLUDE (NOT a reader) = *.test.* / *.spec.* / __tests__, one-time backfill/migration/seed
+ *                            scripts, the feature-flag machinery itself (registry / evaluator /
+ *                            governance / index), and comment-only mentions.
+ *
+ * FAIL-SAFE DIRECTION: on ambiguity the caller defaults to KEEP, never KILL — a false-KEEP is
+ * harmless cruft; a false-KILL strands live callers (the bug that caused the fence). So this
+ * scanner errs toward reporting a reader when unsure (file-level substring, not AST precision).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Real runtime source roots. A flag referenced (in code, not a comment) under one of these
+// gates behavior. Tests, docs, migrations, node_modules and worktrees are never scanned.
+const SOURCE_DIRS = ['lib', 'scripts', 'src', 'api', 'app', 'server'];
+const SKIP_DIRS = new Set(['node_modules', '.git', '.worktrees', 'tests', '__tests__', 'docs', 'coverage', 'dist', 'build']);
+
+// A file whose repo-relative PATH matches this MENTIONS flag keys without being a
+// behavior-gating reader: tests, one-time backfill/migration/seed tooling, and the
+// feature-flag machinery itself (which enumerates keys by definition, not as a reader).
+const EXCLUDE_FILE_RE = /(?:\.(?:test|spec)\.|(?:^|\/)(?:backfill|migration|migrate|seed)|feature-flags\/(?:registry|evaluator|governance-review|index)|flag-governance-review|flag-reader-scan)/i;
+
+const CODE_FILE_RE = /\.(?:m?js|cjs|ts|tsx)$/;
+
+function walk(dir, acc) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      walk(path.join(dir, e.name), acc);
+    } else if (e.isFile() && CODE_FILE_RE.test(e.name)) {
+      acc.push(path.join(dir, e.name));
+    }
+  }
+  return acc;
+}
+
+// Strip block + line comments so a flag key mentioned ONLY in a comment does NOT count as a
+// reader (a commented-out reference is, by definition, not a live reader). The `[^:]` guard
+// leaves `://` in URLs alone; we only care whether the flag key survives in the code portion.
+export function stripComments(src) {
+  return String(src).replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
+ * Build a predicate over a set of flag keys: does this flag have >=1 live reader?
+ * One tree-walk; short-circuits once every key is found.
+ * @param {string} repoRoot absolute repo root
+ * @param {string[]} flagKeys flag keys to resolve
+ * @returns {(flagKey:string)=>boolean}
+ */
+export function buildLiveReaderIndex(repoRoot, flagKeys = []) {
+  const keys = [...new Set((flagKeys || []).filter((k) => typeof k === 'string' && k.length >= 3))];
+  const found = new Set();
+  if (!keys.length) return () => false;
+  const files = [];
+  for (const d of SOURCE_DIRS) walk(path.join(repoRoot, d), files);
+  for (const file of files) {
+    if (found.size === keys.length) break;
+    const rel = path.relative(repoRoot, file).replace(/\\/g, '/');
+    if (EXCLUDE_FILE_RE.test(rel)) continue;
+    let src;
+    try { src = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    const remaining = keys.filter((k) => !found.has(k));
+    if (!remaining.some((k) => src.includes(k))) continue; // cheap pre-filter before comment strip
+    const code = stripComments(src);
+    for (const k of remaining) if (code.includes(k)) found.add(k);
+  }
+  return (flagKey) => found.has(flagKey);
+}

--- a/lib/feature-flags/governance-review.js
+++ b/lib/feature-flags/governance-review.js
@@ -32,9 +32,11 @@ function ageDays(ts, now) {
  * Classify a single flag's staleness. Returns null when the flag is healthy.
  * @param {object} flag - a leo_feature_flags row
  * @param {number} now - epoch ms (injected for testability)
- * @param {object} [opts] - { env } — runtime env snapshot for registry-vs-runtime
- *   drift detection (QF-20260610-863). Injected, never read globally (stays pure).
- * @returns {{flag_key:string, reasons:string[], recommendation:'enable'|'graduate'|'kill'|'extend'|'review'|'reconcile', detail:string}|null}
+ * @param {object} [opts] - { env, hasLiveReaders } — env: runtime snapshot for registry-vs-runtime
+ *   drift detection (QF-20260610-863); hasLiveReaders(flagKey): optional predicate that returns
+ *   true when the flag still has live code readers, so a KILL is downgraded to KEEP
+ *   (QF-20260721-951). Both injected, never read globally (stays pure).
+ * @returns {{flag_key:string, reasons:string[], recommendation:'enable'|'graduate'|'kill'|'keep'|'extend'|'review'|'reconcile', detail:string}|null}
  */
 export function classifyFlag(flag, now, opts = {}) {
   const reasons = [];
@@ -113,6 +115,15 @@ export function classifyFlag(flag, now, opts = {}) {
   else if (disabledAging) recommendation = 'kill';
   else if (enabledNeverRolledOut) recommendation = 'graduate';
   else recommendation = 'review';
+
+  // QF-20260721-951: a disabled-aging flag that STILL has live code readers is load-bearing,
+  // not dead weight — killing it would strand callers (the false-KILL that fenced an SD). When
+  // the injected reader-scan reports a live reader, downgrade KILL → KEEP. FAIL-SAFE: absent a
+  // scanner we preserve legacy behavior; verify liveness against live READERS, not static STATE.
+  if (recommendation === 'kill' && typeof opts.hasLiveReaders === 'function' && opts.hasLiveReaders(flag.flag_key)) {
+    recommendation = 'keep';
+    reasons.push('load-bearing (live readers)');
+  }
 
   return {
     flag_key: flag.flag_key,

--- a/scripts/flag-governance-review.mjs
+++ b/scripts/flag-governance-review.mjs
@@ -10,11 +10,15 @@
 // Gated behind its OWN registered flag FLAG_GOVERNANCE_REVIEW_V1 (default-OFF until
 // baselined): when OFF it is a cheap no-op. Pass --force to run regardless (baseline/smoke).
 import 'dotenv/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 import { computeStaleFlags, formatDigest } from '../lib/feature-flags/governance-review.js';
+import { buildLiveReaderIndex } from '../lib/feature-flags/flag-reader-scan.js';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const GATE_FLAG = 'FLAG_GOVERNANCE_REVIEW_V1';
 
 export async function reviewMain({ force = false } = {}) {
@@ -34,7 +38,10 @@ export async function reviewMain({ force = false } = {}) {
 
   // Compute the digest BEFORE stamping so never-reviewed flags surface once.
   // env injected for the registry-vs-runtime drift detector (QF-20260610-863).
-  const result = computeStaleFlags(flags || [], Date.now(), { env: process.env });
+  // hasLiveReaders (QF-20260721-951): scan the source tree ONCE for each flag's live code
+  // readers so a disabled-aging-but-still-read flag is KEPT (load-bearing), not falsely KILLED.
+  const hasLiveReaders = buildLiveReaderIndex(REPO_ROOT, (flags || []).map((f) => f.flag_key).filter(Boolean));
+  const result = computeStaleFlags(flags || [], Date.now(), { env: process.env, hasLiveReaders });
   console.log(formatDigest(result));
 
   // Stamp last_reviewed_at on every reviewed flag (the automated review touched them this cycle).

--- a/tests/unit/feature-flags/flag-governance-live-readers.test.js
+++ b/tests/unit/feature-flags/flag-governance-live-readers.test.js
@@ -1,0 +1,90 @@
+// QF-20260721-951 — flag-governance digest must check LIVE READERS before recommending KILL.
+// A disabled-aging flag that still has live code readers is load-bearing → KEEP, not KILL.
+// (The false-KILL of COORD_DETECTORS_V2 + SURFACE_INERT_WORKER_V1 fenced an SD; this closes the class.)
+import { describe, it, expect, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifyFlag, computeStaleFlags } from '../../../lib/feature-flags/governance-review.js';
+import { buildLiveReaderIndex, stripComments } from '../../../lib/feature-flags/flag-reader-scan.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const NOW = Date.parse('2026-07-21T00:00:00Z');
+
+// A flag old enough (created long ago) + disabled/off + no expiry/rollout → the "disabled-aging" KILL path.
+function disabledAgingFlag(key) {
+  return {
+    flag_key: key, lifecycle_state: 'disabled', is_enabled: false,
+    created_at: '2020-01-01T00:00:00Z', last_reviewed_at: '2020-01-02T00:00:00Z',
+    expiry_at: null, rolled_out_at: null,
+  };
+}
+
+describe('classifyFlag KILL→KEEP downgrade when a flag has live readers', () => {
+  it('disabled-aging flag with NO live readers → kill (unchanged behavior)', () => {
+    const c = classifyFlag(disabledAgingFlag('DEAD_FLAG_X'), NOW, { hasLiveReaders: () => false });
+    expect(c.reasons).toContain('disabled-aging');
+    expect(c.recommendation).toBe('kill');
+  });
+
+  it('disabled-aging flag WITH live readers → keep (load-bearing)', () => {
+    const c = classifyFlag(disabledAgingFlag('LOAD_BEARING_FLAG'), NOW, { hasLiveReaders: (k) => k === 'LOAD_BEARING_FLAG' });
+    expect(c.recommendation).toBe('keep');
+    expect(c.reasons.join(' ')).toMatch(/load-bearing/);
+  });
+
+  it('no hasLiveReaders predicate injected → preserves legacy KILL (fail-safe: never crashes)', () => {
+    const c = classifyFlag(disabledAgingFlag('DEAD_FLAG_Y'), NOW, {});
+    expect(c.recommendation).toBe('kill');
+  });
+
+  it('computeStaleFlags threads hasLiveReaders through per flag', () => {
+    const r = computeStaleFlags(
+      [disabledAgingFlag('KEEPER'), disabledAgingFlag('KILLER')],
+      NOW,
+      { hasLiveReaders: (k) => k === 'KEEPER' },
+    );
+    const keep = r.stale.find((s) => s.flag_key === 'KEEPER');
+    const kill = r.stale.find((s) => s.flag_key === 'KILLER');
+    expect(keep.recommendation).toBe('keep');
+    expect(kill.recommendation).toBe('kill');
+    expect(r.byRecommendation.keep).toBe(1);
+    expect(r.byRecommendation.kill).toBe(1);
+  });
+});
+
+describe('buildLiveReaderIndex — real-repo ACCEPTANCE (the two flags that caused the fence)', () => {
+  it('COORD_DETECTORS_V2 + SURFACE_INERT_WORKER_V1 have live readers; a nonexistent flag does not', () => {
+    const has = buildLiveReaderIndex(REPO_ROOT, ['COORD_DETECTORS_V2', 'SURFACE_INERT_WORKER_V1', 'NONEXISTENT_FLAG_QF951_ZZZ']);
+    expect(has('COORD_DETECTORS_V2')).toBe(true);
+    expect(has('SURFACE_INERT_WORKER_V1')).toBe(true);
+    expect(has('NONEXISTENT_FLAG_QF951_ZZZ')).toBe(false);
+  }, 30000);
+});
+
+describe('buildLiveReaderIndex — reader DISCRIMINATION (Charlie grep 9c0ee842, encoded)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'flagscan-'));
+  afterAll(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+  it('counts real runtime code, but NOT comments / *.test.* / backfill scripts', () => {
+    fs.mkdirSync(path.join(tmp, 'lib'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'lib', 'live.js'), 'export const on = () => Boolean(process.env.FLAG_REAL_951);');
+    fs.writeFileSync(path.join(tmp, 'lib', 'commented.js'), '// FLAG_COMMENT_951 was removed; no longer read\nexport const x = 1;\n');
+    fs.writeFileSync(path.join(tmp, 'lib', 'thing.test.js'), 'expect(process.env.FLAG_TESTONLY_951).toBeTruthy();');
+    fs.writeFileSync(path.join(tmp, 'scripts', 'backfill-flags.mjs'), "const seed = { flag_key: 'FLAG_BACKFILL_951' };");
+
+    const has = buildLiveReaderIndex(tmp, ['FLAG_REAL_951', 'FLAG_COMMENT_951', 'FLAG_TESTONLY_951', 'FLAG_BACKFILL_951']);
+    expect(has('FLAG_REAL_951')).toBe(true);   // real runtime read → live reader
+    expect(has('FLAG_COMMENT_951')).toBe(false); // comment-only → not a reader (fail-safe still KEEPs elsewhere)
+    expect(has('FLAG_TESTONLY_951')).toBe(false); // *.test.* excluded
+    expect(has('FLAG_BACKFILL_951')).toBe(false); // one-time backfill script excluded
+  });
+
+  it('stripComments drops // and /* */ mentions but leaves code (and URLs) intact', () => {
+    expect(stripComments('const a = 1; // FLAG_IN_COMMENT').includes('FLAG_IN_COMMENT')).toBe(false);
+    expect(stripComments('/* FLAG_BLOCK */ const b = 2;').includes('FLAG_BLOCK')).toBe(false);
+    expect(stripComments('const u = "https://x.example/FLAG_URL";').includes('FLAG_URL')).toBe(true);
+  });
+});


### PR DESCRIPTION
## QF-20260721-951 — close the false-KILL class in the flag-governance digest

The `feature_flag_governance` daily digest recommended **KILL** for a disabled/aging flag from registry **STATE** alone, without checking whether the flag still has **LIVE READERS** in the code. That false-KILL'd `COORD_DETECTORS_V2` + `SURFACE_INERT_WORKER_V1` (both read by real runtime code in `lib/coordinator/coordination-events.cjs`) and fenced an SD (since cancelled void-premise). This closes the **systemic** false-KILL class, not just the instance.

### Change
- **`lib/feature-flags/flag-reader-scan.js` (new)** — `buildLiveReaderIndex(repoRoot, keys)` scans the source tree once and returns a `hasLiveReaders(flagKey)` predicate. Encodes the by-hand discrimination Charlie did (grep `9c0ee842`):
  - **COUNT** as a live reader: a non-comment reference in real runtime code (`lib/**`, prod/fleet scripts).
  - **EXCLUDE**: `*.test.*` / `__tests__`, one-time backfill/migration/seed scripts, the feature-flag machinery itself, and comment-only mentions.
  - **Fail-safe**: on ambiguity a reference counts (→ KEEP); never a false-KILL.
- **`governance-review.js`** — `classifyFlag` downgrades `kill` → `keep` (load-bearing) when the injected `hasLiveReaders` reports a reader. Absent a scanner, legacy behavior is preserved (pure, injection-only).
- **`flag-governance-review.mjs`** — builds the reader index from the live flag set and threads `hasLiveReaders` into `computeStaleFlags`.

### Acceptance
The digest emits **NO** kill rec for a flag with live readers; re-running against `COORD_DETECTORS_V2` + `SURFACE_INERT_WORKER_V1` yields **KEEP**, a nonexistent flag stays KILL-eligible. **7 new tests** (classifier downgrade + `computeStaleFlags` threading + real-repo acceptance + synthetic exclusion proof); **60 existing** governance tests still green.

GRF reachability-faithfulness instance: verify liveness against live **READERS**, not static **STATE**. Provenance: Adam advisory `e961e2af` (committed `9fed8639`); Solomon-confirmed class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)