### PR TITLE
fix(QF-20260721-010): make Adam decision-driving-sweep durable (contract duty + ADAM_LOOPS)

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e06168bad01331bc -->
+<!-- file_content_hash: 72a9769313ef9f37 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-20 3:47:06 PM
+**Generated**: 2026-07-21 4:56:22 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -97,6 +97,7 @@
 **2026-06-11 (handoff-drill fixes — durable encoding of session-fragile duties)**:
 - **BELT COUNTDOWN DUTY (durable)**: while the fleet is active, Adam posts a belt-countdown one-liner every 15 minutes — ONE line, Eastern time in 12-hour format, with a rolling ETA to belt-dry (claimable-SD depth vs current fleet burn). This duty previously lived only in session-scoped crons and DIED with every Adam session (confirmed by the 2026-06-11 handoff drill). Every `/adam` startup must RE-ARM it alongside the three canonical tick loops; countdown timestamps derive from DB rows — never hand-converted ET↔UTC.
 - **BOARD RECONCILE DUTY (durable)**: every recurring Adam tick, reconcile the durable `adam_task_ledger` board against live reality (open advisory threads, sourced SDs, awaited replies) via `lib/adam/task-rehydrate.js` `rehydrateBoard()`, wired into `scripts/adam-quiet-tick.mjs` (not only at `/adam` cold start, which already ran it once via `adam-startup-check.mjs`). SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B. This closes the same "durable but session-fragile" gap class the belt-countdown duty above closed.
+- **DECISION-DRIVING-SWEEP DUTY (durable)**: every 3 hours, Adam sweeps the pending chairman-decision queue (`node scripts/chairman-decisions.mjs list`) and DRIVES each pending decision toward resolution — surfacing an un-surfaced decision to the chairman as an SMS decision packet (labeled options + RECOMMENDED default + no-reply auto-default policy) via `node scripts/adam-chairman-decision.mjs` per the CHAIRMAN SMS CHANNEL DUTY, reconciling any in-flight no-reply retries (the ratified retry->auto-default clock, quiet-hours-paused), and re-surfacing chairman-gated blocks that are starving the belt (BELT-NEVER-DRY branch 3). Propose-only (CONST-002); silence-by-default on a truly-nothing sweep. This duty previously lived only in a session-scoped cron (Adam-armed 2026-07-21) and DIED with every Adam session; every `/adam` startup must RE-ARM it via ADAM_LOOPS (`scripts/adam-startup-check.mjs`) alongside the other durable tick loops. QF-20260721-010.
 - **FULL-INBOX SWEEP (sharpened — never trust ack state)**: the known auto-ack bug stamps read_at/acknowledged_at on rows Adam never processed (QF-20260610-623, sender_type-allowlist class). Sweep the coordination lane by created_at + payload.kind over the recent window (e.g. 24h) REGARDLESS of read/ack stamps; acknowledged_at-IS-NULL filtering alone provably hides chairman/coordinator directives.
 - **LIVE STATE LIVES IN THE DB, NOT MEMORY (handoff rule)**: experiment arm state (e.g. effort-tier `metadata.arms_log`), open-watch lists, and queue state must be re-read LIVE at session start; memory files are point-in-time and go stale within hours on an active fleet. A fresh Adam asserting experiment/queue state from memory without a live DB read is a D4 (verify-before-certainty) failure.
 
@@ -418,6 +419,6 @@ _Hierarchy note (chairman-ratified D-0719-ORGCHART "A", 2026-07-19): this partne
 
 ---
 
-*Generated from database: 2026-07-20*
+*Generated from database: 2026-07-21*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-20T19:47:06.145Z -->
-<!-- git_commit: 9c631a0a -->
+<!-- generated_at: 2026-07-21T20:56:22.701Z -->
+<!-- git_commit: aabafd10 -->
 <!-- db_snapshot_hash: 15274e313a3b8c43 -->
-<!-- file_content_hash: f19b1b68ce93788d -->
+<!-- file_content_hash: 195087f52fdb6378 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -228,6 +228,19 @@ export const ADAM_LOOPS = [
     cron: '0 6 * * *',
     prompt: 'Adam morning-brief-sms tick: compose a self-contained, plan-first morning brief (roadmap position + overnight Slipped/Committing/Done condensed to phone scale, professional-casual), then run node scripts/adam-chairman-sms.mjs --kind morning_brief --dedupe-key "adam-morning-brief-<YYYY-MM-DD ET>" --body "<brief>". If a later tick finds today\'s dedupe key was never sent (the 6:00 fire was missed), compose and send it then instead -- late is better than never.',
   },
+  {
+    // QF-20260721-010 (contract, leo_protocol_sections id=601, mirrors the belt-countdown/board-reconcile
+    // durable-encoding pattern): the DECISION-DRIVING-SWEEP DUTY. A 3-hourly sweep that DRIVES pending
+    // chairman decisions to resolution. Was SESSION-ONLY (Adam-armed 2026-07-21) and DIED on every /adam
+    // restart; not a contract-named duty, so missingDurableDuties could not detect the gap. Now named durable
+    // in the contract (CLAUDE_ADAM.md "DECISION-DRIVING-SWEEP DUTY (durable)") AND armed here so a fresh
+    // /adam re-arms it and the contract<->tooling parity check holds. Minute-50 offset avoids fleet :00 collisions.
+    key: 'decision-driving-sweep',
+    label: 'Decision-driving sweep (3h: drive pending chairman decisions to resolution; propose-only, silence-by-default)',
+    script: null, // agent-judgment tick — drive/reconcile decisions, no single script
+    cron: '50 */3 * * *',
+    prompt: 'Adam decision-driving-sweep tick: read the pending chairman-decision queue (node scripts/chairman-decisions.mjs list) and DRIVE each pending decision toward resolution — for an un-surfaced decision that survives the pre-send rubric, send the SMS decision packet (labeled options + RECOMMENDED default + no-reply auto-default policy) via node scripts/adam-chairman-decision.mjs per the CHAIRMAN SMS CHANNEL DUTY; reconcile any in-flight no-reply retries (the ratified retry->auto-default clock, quiet-hours-paused); and re-surface chairman-gated blocks starving the belt (BELT-NEVER-DRY branch 3). Propose-only (CONST-002); if nothing is pending, STAY SILENT (silence-by-default).',
+  },
 ];
 
 // Parse the armed-cron basenames/prompts the agent passes from its CronList output.

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -24,7 +24,7 @@ import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 14 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 15 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
   // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
   // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties);
@@ -35,8 +35,10 @@ test('ADAM_LOOPS has the 14 expected tick loops with the expected keys', () => {
   // coordinator-health added by SD-LEO-INFRA-ADAM-COORDINATOR-HEALTH-001 (3-KPI coordinator oversight probe);
   // self-score + solomon-health added by QF-20260719-825 (chairman-directed deliberate-check cadence)
   //   -- this assertion was stale at 12 for 2 days until QF-20260721-518 caught + fixed it.
-  assert.equal(ADAM_LOOPS.length, 14);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'self-score', 'solomon-health', 'heartbeat-sms', 'morning-brief-sms']);
+  // decision-driving-sweep added by QF-20260721-010 (durable contract duty — DECISION-DRIVING-SWEEP DUTY (durable),
+  //   leo_protocol_sections id=601; was session-only + undetectable by missingDurableDuties until named).
+  assert.equal(ADAM_LOOPS.length, 15);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['quiet-tick', 'governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'coordinator-health', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'self-score', 'solomon-health', 'heartbeat-sms', 'morning-brief-sms', 'decision-driving-sweep']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);


### PR DESCRIPTION
Makes Adam's 3h decision-driving-sweep durable — PART 1: named DECISION-DRIVING-SWEEP DUTY (durable) in adam_role_contract (leo_protocol_sections id=601) + regenerated CLAUDE_ADAM.md; PART 2: added to ADAM_LOOPS in scripts/adam-startup-check.mjs (cron 50 */3, derived — reconcile vs Adam's live session cron). missingDurableDuties parity=[]; 18/18 tests. Provenance: Adam 054e2bdd + Solomon f350e3c7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>