### PR TITLE
fix(QF-20260721-891): document part-1-durability re-ask as moot (already closed by #6395)

### DIFF
--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -235,6 +235,12 @@ export const ADAM_LOOPS = [
     // restart; not a contract-named duty, so missingDurableDuties could not detect the gap. Now named durable
     // in the contract (CLAUDE_ADAM.md "DECISION-DRIVING-SWEEP DUTY (durable)") AND armed here so a fresh
     // /adam re-arms it and the contract<->tooling parity check holds. Minute-50 offset avoids fleet :00 collisions.
+    // QF-20260721-891 (part-1 durability re-ask, filed against a pre-#6395 snapshot): investigated and
+    // confirmed MOOT — PR #6395 (commit 0374ab2, 2026-07-21 17:16 ET, ~99min before QF-891 was filed) already
+    // wrote this duty into leo_protocol_sections id=601 AND this ADAM_LOOPS entry in the same PR. Re-verified
+    // live: missingDurableDuties(CLAUDE_ADAM.md) omits 'decision-driving-sweep' with the real ADAM_LOOPS
+    // (present-check), and flags it when the key is removed from the loops array (negative-check) — the
+    // contract<->tooling link is demonstrably live, not just co-existing text.
     key: 'decision-driving-sweep',
     label: 'Decision-driving sweep (3h: drive pending chairman decisions to resolution; propose-only, silence-by-default)',
     script: null, // agent-judgment tick — drive/reconcile decisions, no single script


### PR DESCRIPTION
## Summary
- QF-20260721-891 asked to write the decision-driving-sweep durable duty into the `leo_protocol_sections` `adam_role_contract` DB source and wire `ADAM_LOOPS` so `missingDurableDuties()` enforces it.
- Investigation found PR #6395 (QF-20260721-010, commit 0374ab2, merged 2026-07-21 17:16 ET) already shipped **both** halves — the DB row (id=601) and the `ADAM_LOOPS` entry — in the same PR, ~99 minutes before QF-891 was filed.
- Re-ran QF-891's own acceptance bar live against the real shipped state:
  - **PRESENT-CHECK**: `missingDurableDuties(CLAUDE_ADAM.md)` with the real `ADAM_LOOPS` does NOT flag `decision-driving-sweep` — no drift.
  - **NEGATIVE-CHECK**: with `decision-driving-sweep` removed from a copy of `ADAM_LOOPS`, `missingDurableDuties()` correctly flags it — the enforcement hook is demonstrably live, not just co-existing text.
- Added a provenance comment above the `decision-driving-sweep` `ADAM_LOOPS` entry documenting this so the gap isn't re-filed a third time.

## Test plan
- [x] `node --test tests/unit/adam-startup-check.test.mjs` — 18/18 pass (no regressions; comment-only change)
- [x] Live present-check + negative-check re-run against committed `CLAUDE_ADAM.md` and `ADAM_LOOPS` (see commit message)
- [x] Pre-commit hooks (smoke tests, DOCMON, LOC threshold, scope gate) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)