### PR TITLE
SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001: reversible venture data-hygiene (pinned predicate + guardrailed soft-archive + TTL)

### DIFF
--- a/.github/workflows/venture-fixture-sweep.yml
+++ b/.github/workflows/venture-fixture-sweep.yml
@@ -1,0 +1,65 @@
+# Venture fixture residue sweep — weekly scheduled soft-delete of LIVE fixture ventures.
+# SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001 (FR-4b).
+#
+# Runs scripts/sweep-fixture-residue.mjs --fix, which SOFT-DELETES (deleted_at + status)
+# any fixture-class venture sitting live (never a hard delete) and already SPARES the
+# sanctioned canary. Recurrence prevention for the leak class this SD cleaned up.
+#
+# FLAG-GATED (cannot become a dormant switch): a first step reads
+# leo_feature_flags.VENTURE_FIXTURE_SWEEP_V1 and the sweep step runs ONLY when it is
+# enabled. The flag ships OFF (no row => disabled), so merging this workflow performs
+# ZERO writes until an operator enables it via the standard registry flow. Same
+# leo_feature_flags mechanism + SUPABASE_* secrets wiring as canary-venture-probe.yml.
+name: Venture Fixture Sweep
+
+on:
+  schedule:
+    - cron: '23 4 * * 6'   # Saturdays 04:23 UTC (low-traffic; distinct from the canary's Sun 06:17)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: venture-fixture-sweep
+  cancel-in-progress: false
+
+jobs:
+  fixture-sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts
+
+      - name: Feature-flag gate (VENTURE_FIXTURE_SWEEP_V1)
+        id: gate
+        run: |
+          node --input-type=module <<'EOF'
+          import { createClient } from '@supabase/supabase-js';
+          import fs from 'node:fs';
+          const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+          const { data } = await sb
+            .from('leo_feature_flags')
+            .select('is_enabled')
+            .eq('flag_key', 'VENTURE_FIXTURE_SWEEP_V1')
+            .maybeSingle();
+          const enabled = data?.is_enabled === true;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `enabled=${enabled}\n`);
+          console.log(enabled
+            ? 'VENTURE_FIXTURE_SWEEP_V1 enabled — sweep will run.'
+            : 'VENTURE_FIXTURE_SWEEP_V1 disabled (or absent) — quiet no-op.');
+          EOF
+
+      - name: Run fixture residue sweep (soft-delete; flag-gated)
+        if: steps.gate.outputs.enabled == 'true'
+        run: node scripts/sweep-fixture-residue.mjs --fix

--- a/lib/governance/venture-archive-predicate.mjs
+++ b/lib/governance/venture-archive-predicate.mjs
@@ -1,0 +1,37 @@
+// SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001 FR-1 — the PINNED reversible archive predicate.
+//
+// This is the ONLY predicate the one-time soft-archive CLI
+// (scripts/archive/one-time/soft-archive-fixture-ventures.mjs) may select rows by.
+//
+// CONTRACT: PRECISION OVER RECALL. A REAL venture row must NEVER be selected for
+// archival. A missed fixture is harmless (it stays live and is sweepable later); a
+// selected real row is a data-integrity incident. When a row cannot be positively
+// classified as a fixture, return FALSE.
+//
+// It DELEGATES fixture classification to the canonical lib/governance/fixture-exclusion.mjs
+// isFixtureVenture() (flag-first is_demo; FIXTURE_VENTURE_NAME_RE + EPOCH_TAIL_RE name
+// backstop; fail-open on missing fields) and adds exactly ONE hard exclusion on top: the
+// sanctioned live is_demo canary venture, which must never be archived even though it is
+// is_demo=true. Never references is_synthetic (absent on this DB); never keys on
+// status==='cancelled' alone.
+//
+// @wire-check-exempt: consumed only by the one-time archive CLI under
+//   scripts/archive/one-time/ + its unit test; no permanent runtime entry point by design.
+import { isFixtureVenture } from './fixture-exclusion.mjs';
+
+/** The one sanctioned permanently-flagged is_demo venture — must NEVER be archived. */
+export const CANARY_NAME = 'Canary Venture Probe';
+
+/**
+ * Is this ventures row an ARCHIVABLE fixture (safe to reversibly soft-archive)?
+ * FALSE for the canary (checked FIRST), FALSE for anything the canonical classifier
+ * cannot positively call a fixture (fail-open), TRUE only for a positively-classified
+ * fixture.
+ * @param {{name?: string|null, is_demo?: boolean, [k:string]: any}|null|undefined} v
+ * @returns {boolean}
+ */
+export function isArchivableFixtureVenture(v) {
+  if (!v || typeof v !== 'object') return false;
+  if (v.name === CANARY_NAME) return false; // hard exclusion, before anything else
+  return isFixtureVenture(v) === true;       // delegate to the canonical classifier
+}

--- a/scripts/archive/one-time/soft-archive-fixture-ventures.mjs
+++ b/scripts/archive/one-time/soft-archive-fixture-ventures.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Soft-archive fixture ventures — one-time, dry-run-DEFAULT, guardrailed, REVERSIBLE.
+ * SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001 (FR-2 + FR-3).
+ *
+ * Reversibly soft-archives fixture/test ventures (deleted_at + status='archived') using
+ * the PINNED precision-over-recall predicate (lib/governance/venture-archive-predicate.mjs).
+ * NEVER a hard delete. Idempotent: the `deleted_at IS NULL` write filter makes a 2nd
+ * --apply a no-op. The sanctioned live is_demo canary is excluded by the predicate.
+ *
+ * Usage:
+ *   node scripts/archive/one-time/soft-archive-fixture-ventures.mjs                 # DRY-RUN (default): print candidates + guardrails, zero writes
+ *   node scripts/archive/one-time/soft-archive-fixture-ventures.mjs --apply         # perform the reversible soft-archive
+ *   node scripts/archive/one-time/soft-archive-fixture-ventures.mjs --ceiling 130   # override the abort ceiling (default 130)
+ *
+ * GUARDRAILS (evaluated BEFORE any write, in BOTH modes):
+ *   (a) applications-row tripwire — ABORT (zero writes) if any candidate id is referenced
+ *       by an applications.venture_id (real ventures have an applications row).
+ *   (b) ceiling tripwire         — ABORT if candidate count > ceiling (default 130).
+ *   (c) empty set                — explicit "nothing to archive" no-op (zero writes, exit 0).
+ *
+ * @wire-check-exempt: one-time archive CLI under scripts/archive/one-time/ — no permanent
+ *   runtime entry point by design (mirrors venture-lifecycle.cjs).
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { fetchAllPaginated } from '../../../lib/db/fetch-all-paginated.mjs';
+import { isArchivableFixtureVenture } from '../../../lib/governance/venture-archive-predicate.mjs';
+
+export const DEFAULT_CEILING = 130;
+const CHUNK_SIZE = 200;
+
+/** Pure: candidate rows = ventures the pinned predicate positively classifies. */
+export function selectCandidates(ventures) {
+  return (ventures || []).filter(isArchivableFixtureVenture);
+}
+
+/** Why did a candidate match — for the dry-run report. */
+export function whyMatched(v) {
+  return v && v.is_demo === true ? 'is_demo' : 'name-pattern';
+}
+
+/** Parse CLI args → { apply, ceiling }. Defaults to dry-run (apply=false). */
+export function parseArgs(argv = []) {
+  const apply = argv.includes('--apply');
+  let ceiling = DEFAULT_CEILING;
+  const ci = argv.indexOf('--ceiling');
+  if (ci !== -1 && argv[ci + 1] != null) {
+    const n = Number(argv[ci + 1]);
+    if (Number.isFinite(n) && n > 0) ceiling = n;
+  }
+  return { apply, ceiling };
+}
+
+/**
+ * Pure guardrail evaluation. Returns {ok, abortReason, offendingIds}.
+ *   abortReason: 'applications_overlap' | 'empty' | 'over_ceiling' | null
+ *   'empty' is a no-op (not a failure); the caller exits 0 without writing.
+ */
+export function checkGuardrails(candidates, applicationsVentureIds, ceiling = DEFAULT_CEILING) {
+  const appSet = new Set((applicationsVentureIds || []).filter(Boolean));
+  const offendingIds = (candidates || []).filter((v) => appSet.has(v.id)).map((v) => v.id);
+  if (offendingIds.length > 0) {
+    return { ok: false, abortReason: 'applications_overlap', offendingIds };
+  }
+  if (!candidates || candidates.length === 0) {
+    return { ok: false, abortReason: 'empty', offendingIds: [] };
+  }
+  if (candidates.length > ceiling) {
+    return { ok: false, abortReason: 'over_ceiling', offendingIds: [] };
+  }
+  return { ok: true, abortReason: null, offendingIds: [] };
+}
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+async function main() {
+  const { apply, ceiling } = parseArgs(process.argv.slice(2));
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+  const supabase = createClient(url, key);
+
+  // Load ALL ventures + ALL applications venture refs (paginate — never trust a single page).
+  const ventures = await fetchAllPaginated(() => supabase.from('ventures').select('*').order('id', { ascending: true }));
+  const apps = await fetchAllPaginated(() => supabase.from('applications').select('venture_id').order('venture_id', { ascending: true }));
+  const applicationsVentureIds = apps.map((a) => a.venture_id).filter(Boolean);
+
+  const candidates = selectCandidates(ventures);
+  const guard = checkGuardrails(candidates, applicationsVentureIds, ceiling);
+
+  console.log(`\n── Soft-archive fixture ventures (${apply ? 'APPLY' : 'DRY-RUN'}) ──`);
+  console.log(`   ventures scanned:   ${ventures.length}`);
+  console.log(`   candidates matched: ${candidates.length}  (ceiling ${ceiling})`);
+  console.log('');
+  console.log('   id                                     why           name');
+  for (const v of candidates) {
+    console.log(`   ${String(v.id).padEnd(38)} ${whyMatched(v).padEnd(13)} ${v.name}`);
+  }
+
+  // ── Guardrail report ──
+  console.log('\n   Guardrails:');
+  console.log(`     applications-row tripwire: ${guard.abortReason === 'applications_overlap' ? `FAIL (${guard.offendingIds.length} real-ref candidate(s))` : 'PASS'}`);
+  console.log(`     ceiling (<= ${ceiling}):          ${guard.abortReason === 'over_ceiling' ? `FAIL (${candidates.length})` : 'PASS'}`);
+  console.log(`     non-empty:                 ${guard.abortReason === 'empty' ? 'no candidates' : 'PASS'}`);
+
+  if (guard.abortReason === 'empty') {
+    console.log('\n   Nothing to archive — 0 candidates. No writes. ✅');
+    return;
+  }
+  if (!guard.ok) {
+    if (guard.abortReason === 'applications_overlap') {
+      console.error(`\n   ⛔ ABORT: ${guard.offendingIds.length} candidate(s) are referenced by applications.venture_id — a REAL venture may be in the set. Zero writes.`);
+      for (const id of guard.offendingIds) console.error(`      offending: ${id}`);
+    } else if (guard.abortReason === 'over_ceiling') {
+      console.error(`\n   ⛔ ABORT: candidate count ${candidates.length} > ceiling ${ceiling} — implausibly large. Zero writes. Re-run with --ceiling N if intended.`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!apply) {
+    console.log('\n   DRY-RUN — guardrails PASS, zero writes. Re-run with --apply to soft-archive. ✅');
+    return;
+  }
+
+  // ── APPLY: reversible chunked soft-archive (deleted_at IS NULL filter ⇒ idempotent) ──
+  const ids = candidates.map((v) => v.id);
+  const archivedIds = [];
+  for (const group of chunk(ids, CHUNK_SIZE)) {
+    const { data, error } = await supabase
+      .from('ventures')
+      .update({ deleted_at: new Date().toISOString(), status: 'archived' })
+      .in('id', group)
+      .is('deleted_at', null)
+      .select('id');
+    if (error) throw new Error(`soft-archive chunk failed: ${error.message}`);
+    for (const row of data || []) archivedIds.push(row.id);
+  }
+
+  console.log(`\n   ✅ Soft-archived ${archivedIds.length} venture(s) (already-archived rows skipped by the deleted_at IS NULL filter).`);
+  console.log('\n   ── ROLLBACK RECIPE (reverse each id) ──');
+  for (const id of archivedIds) {
+    console.log(`   node scripts/archive/one-time/venture-lifecycle.cjs restore ${id}`);
+  }
+  if (archivedIds.length > 0) {
+    console.log('\n   Or reverse in one statement:');
+    console.log(`   UPDATE ventures SET deleted_at = NULL, status = 'active' WHERE id IN (${archivedIds.map((id) => `'${id}'`).join(', ')});`);
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/tests/helpers/venture-fixture-teardown.mjs
+++ b/tests/helpers/venture-fixture-teardown.mjs
@@ -1,0 +1,55 @@
+/**
+ * Reusable LOUD fixture-venture teardown for integration tests.
+ * SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001 (FR-4a).
+ *
+ * Mirrors the s17-parity `cleanParityFixtures` pattern: delete the known FK child rows
+ * FIRST, then the venture rows, and THROW on any delete error. The failure mode this
+ * prevents is the historical one — an unchecked ventures.delete() hits an FK violation,
+ * fails SILENTLY, and fixtures leak live for days while every later run's self-clean
+ * keeps silently failing too. A teardown that throws makes a future leak fail the suite
+ * instead of hiding it.
+ *
+ * Two entry points:
+ *   teardownFixtureVentures(supabase, ids)        — by explicit venture id list
+ *   teardownFixtureVenturesByName(supabase, like) — by name-prefix pattern (e.g. 'parity-test-%')
+ */
+
+// FK children observed blocking ventures.delete() in the 2026-06-10 leak. HARD-deleted
+// first so the ventures.delete() below cannot FK-violate. Order: children before parents.
+const FK_CHILD_TABLES = [
+  { table: 'chairman_decisions', column: 'venture_id' },
+  { table: 'venture_analysis_artifacts', column: 'venture_id' },
+  { table: 'factory_guardrail_state', column: 'venture_id' },
+];
+
+/**
+ * Delete fixture ventures + their FK children by explicit id list. THROWS on any error.
+ * @param {object} supabase - supabase client
+ * @param {string[]} ids - venture ids to remove
+ */
+export async function teardownFixtureVentures(supabase, ids) {
+  if (!ids || ids.length === 0) return;
+  for (const { table, column } of FK_CHILD_TABLES) {
+    const { error } = await supabase.from(table).delete().in(column, ids);
+    // A missing optional child table must not mask a real FK blocker — surface it.
+    if (error) throw new Error(`fixture teardown: ${table}.${column} delete failed: ${error.message}`);
+  }
+  const { error } = await supabase.from('ventures').delete().in('id', ids);
+  if (error) {
+    throw new Error(
+      `fixture venture teardown FAILED (fixtures would leak): ${error.message} — ` +
+      'an FK child is blocking the delete; find it and add it to FK_CHILD_TABLES.'
+    );
+  }
+}
+
+/**
+ * Name-pattern variant: resolve ids via a `LIKE` prefix, then delegate. THROWS on error.
+ * @param {object} supabase - supabase client
+ * @param {string} likePattern - e.g. 'parity-test-%'
+ */
+export async function teardownFixtureVenturesByName(supabase, likePattern) {
+  const { data, error } = await supabase.from('ventures').select('id').like('name', likePattern);
+  if (error) throw new Error(`fixture teardown: name lookup '${likePattern}' failed: ${error.message}`);
+  await teardownFixtureVentures(supabase, (data ?? []).map((v) => v.id));
+}

--- a/tests/unit/governance/venture-archive-predicate.test.js
+++ b/tests/unit/governance/venture-archive-predicate.test.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the pinned reversible archive predicate + the one-time soft-archive
+ * script's pure guardrail/selection logic.
+ * SD-LEO-INFRA-VENTURES-DATA-HYGIENE-001 (FR-5).
+ *
+ * These pin PRECISION OVER RECALL: a real venture row must NEVER be selected for
+ * archival. They RED against a naive "archive all cancelled" or "archive everything
+ * not explicitly is_demo=false" predicate (both would select the real cancelled row
+ * below) and GREEN with the precision-first one that delegates to the canonical
+ * fixture classifier and hard-excludes the canary. No live DB — plain arrays only.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  isArchivableFixtureVenture, CANARY_NAME,
+} from '../../../lib/governance/venture-archive-predicate.mjs';
+import {
+  selectCandidates, checkGuardrails, parseArgs, whyMatched, DEFAULT_CEILING,
+} from '../../../scripts/archive/one-time/soft-archive-fixture-ventures.mjs';
+
+describe('isArchivableFixtureVenture — precision over recall (FR-1)', () => {
+  test('is_demo=true fixture row → true', () => {
+    expect(isArchivableFixtureVenture({ name: 'Some Seed', is_demo: true })).toBe(true);
+  });
+
+  test('fixture-name rows → true', () => {
+    for (const name of ['parity-test-cli-1234567890', 'TEST-HARNESS-S20-x', '__e2e_foo', 'ZZZ_seed', 'test-stub-a']) {
+      expect(isArchivableFixtureVenture({ name, is_demo: false }), name).toBe(true);
+    }
+  });
+
+  test('real cancelled row → FALSE (status=cancelled alone must never select)', () => {
+    // A naive "archive all cancelled" / "archive all non-(is_demo=false)" predicate
+    // would select this — the fatal failure mode. Precision-first returns FALSE.
+    expect(isArchivableFixtureVenture({ name: 'Market Modeling SaaS', is_demo: false, status: 'cancelled' })).toBe(false);
+  });
+
+  test('sanctioned canary → FALSE even though is_demo=true (hard exclusion, checked first)', () => {
+    expect(isArchivableFixtureVenture({ name: CANARY_NAME, is_demo: true })).toBe(false);
+    expect(isArchivableFixtureVenture({ name: 'Canary Venture Probe', is_demo: true, status: 'active' })).toBe(false);
+  });
+
+  test('unclassifiable rows fail open → FALSE', () => {
+    expect(isArchivableFixtureVenture({ name: null })).toBe(false);           // null name, no flag
+    expect(isArchivableFixtureVenture({ name: undefined, is_demo: false })).toBe(false);
+    expect(isArchivableFixtureVenture({})).toBe(false);
+    expect(isArchivableFixtureVenture(null)).toBe(false);
+    expect(isArchivableFixtureVenture({ name: 'Testify Analytics', is_demo: false })).toBe(false); // real name, no separator
+  });
+});
+
+describe('selectCandidates — pure selection over plain arrays (FR-5)', () => {
+  test('keeps only positively-classified fixtures; drops real + canary', () => {
+    const rows = [
+      { id: 'r1', name: 'Market Modeling SaaS', is_demo: false, status: 'cancelled' }, // real
+      { id: 'r2', name: 'CronGenius', is_demo: false },                                // real
+      { id: 'f1', name: '__e2e_probe', is_demo: false },                               // fixture
+      { id: 'f2', name: 'Seed', is_demo: true },                                       // fixture flag
+      { id: 'c1', name: CANARY_NAME, is_demo: true },                                  // canary — excluded
+    ];
+    const ids = selectCandidates(rows).map((v) => v.id);
+    expect(ids).toEqual(['f1', 'f2']);
+  });
+
+  test('whyMatched distinguishes is_demo from name-pattern', () => {
+    expect(whyMatched({ is_demo: true })).toBe('is_demo');
+    expect(whyMatched({ name: '__e2e_x', is_demo: false })).toBe('name-pattern');
+  });
+});
+
+describe('checkGuardrails — abort tripwires (FR-2)', () => {
+  test('applications-row candidate → abort with offending ids', () => {
+    const g = checkGuardrails([{ id: 'v1', name: '__e2e' }, { id: 'v2', name: 'TEST-x' }], ['v1'], DEFAULT_CEILING);
+    expect(g.ok).toBe(false);
+    expect(g.abortReason).toBe('applications_overlap');
+    expect(g.offendingIds).toEqual(['v1']);
+  });
+
+  test('over-ceiling → abort', () => {
+    const candidates = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const g = checkGuardrails(candidates, [], 2);
+    expect(g.ok).toBe(false);
+    expect(g.abortReason).toBe('over_ceiling');
+  });
+
+  test('empty set → explicit no-op (not a hard abort)', () => {
+    const g = checkGuardrails([], [], DEFAULT_CEILING);
+    expect(g.ok).toBe(false);
+    expect(g.abortReason).toBe('empty');
+    expect(g.offendingIds).toEqual([]);
+  });
+
+  test('clean set under ceiling with no applications overlap → ok', () => {
+    const g = checkGuardrails([{ id: 'v1', name: '__e2e' }], ['other-venture'], DEFAULT_CEILING);
+    expect(g.ok).toBe(true);
+    expect(g.abortReason).toBeNull();
+  });
+
+  test('applications overlap takes precedence over ceiling', () => {
+    const candidates = [{ id: 'v1' }, { id: 'v2' }, { id: 'v3' }];
+    const g = checkGuardrails(candidates, ['v2'], 1); // both would trip; applications wins
+    expect(g.abortReason).toBe('applications_overlap');
+  });
+});
+
+describe('parseArgs — CLI defaults to dry-run (FR-2)', () => {
+  test('no args → dry-run, default ceiling', () => {
+    expect(parseArgs([])).toEqual({ apply: false, ceiling: DEFAULT_CEILING });
+  });
+
+  test('--apply flips to apply', () => {
+    expect(parseArgs(['--apply']).apply).toBe(true);
+  });
+
+  test('--ceiling N overrides; invalid ignored', () => {
+    expect(parseArgs(['--ceiling', '50']).ceiling).toBe(50);
+    expect(parseArgs(['--ceiling', '-5']).ceiling).toBe(DEFAULT_CEILING);
+    expect(parseArgs(['--ceiling']).ceiling).toBe(DEFAULT_CEILING);
+  });
+});


### PR DESCRIPTION
## Summary
EHG_Engineer (data-side) portion of the cross-repo, chairman-directed ventures data-hygiene SD. Delivers reversible, never-touch-real venture hygiene tooling. 436 LOC, 15/15 unit tests green.

## Deliverables
- **`lib/governance/venture-archive-predicate.mjs`** — pinned, precision-over-recall non-real predicate; delegates to canonical `fixture-exclusion.mjs` `isFixtureVenture`, hard-excludes the sanctioned `Canary Venture Probe`, fail-open (a real row is never selected), never reads the non-existent `ventures.is_synthetic`.
- **`scripts/archive/one-time/soft-archive-fixture-ventures.mjs`** — dry-run-DEFAULT, reversible (`deleted_at`+`status='archived'`, never hard-deletes), guardrailed one-time soft-archive. Abort tripwires: applications-row (provably-real), sanity ceiling (130), empty set. Idempotent; logs affected ids as the rollback recipe. Dry-run verified: 142 ventures → 120 candidates, all guardrails PASS, canary excluded, zero writes.
- **`tests/helpers/venture-fixture-teardown.mjs`** — shared loud teardown helper (mirrors s17-parity; throws on delete error).
- **`.github/workflows/venture-fixture-sweep.yml`** — flag-gated (`VENTURE_FIXTURE_SWEEP_V1`, ships OFF) weekly `sweep-fixture-residue.mjs --fix`.
- **`tests/unit/governance/venture-archive-predicate.test.js`** — 15 regressions (predicate precision, guardrail tripwires, dry-run/reversibility).

## Safety
Reversible-only (no hard deletes), dry-run by default, precision-over-recall. The ~19 ambiguous `is_demo=false`/non-fixture-name/`cancelled` "real-looking" ventures are DEFERRED to a chairman-pinned predicate (never archived on `status='cancelled'` alone).

## Deferred (completion flags)
- Chairman-pinned predicate for the ~19 ambiguous cancelled-named ventures (spec dependency).
- EHG-repo `rickfelix/ehg` Ventures show-all toggle (cross-repo sibling SD; route filter already shipped in EHG PR #688).
- The production `--apply` run (separate reversible, guardrailed op; tooling ships dry-run-default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)