### PR TITLE
SD-...-DISCRIMINATOR-001-A: zero-DDL real-build discriminator (GRF stage-vs-real-build)

### DIFF
--- a/lib/governance/real-build-discriminator.mjs
+++ b/lib/governance/real-build-discriminator.mjs
@@ -1,0 +1,85 @@
+/**
+ * Real-build discriminator — SD-LEO-INFRA-VENTURE-REAL-DISCRIMINATOR-AND-STALL-ALARM-001-A
+ * (Part 1 of a decomposed orchestrator; Part 2 = the stall alarm, a separate child).
+ *
+ * @wire-check-exempt: pure derived predicate consumed by the one-time backfill CLI
+ *   (scripts/one-time/backfill-real-build-provenance.mjs, itself wire-check-exempt) and by
+ *   the unit suite; registered as a GRF instance (data). No static import chain from a
+ *   package.json entry point today — the wiring (coordinator/stall-alarm surface) is the
+ *   Child B activation follow-on. Same shape as representation-faithfulness.js's exemption.
+ *
+ * THE DIVERGENCE THIS CATCHES (a Governing-Representation-Faithfulness instance):
+ *   R1 (source-of-truth) = whether a REAL build has actually started for the venture —
+ *      evidenced by deployment_url / repo_url / workflow_started_at, or launch_mode='live'.
+ *   R2 (governing gauge)  = current_lifecycle_stage, the number the whole lifecycle acts on.
+ *   A GENUINE (non-fixture) venture can advance R2 to a high stage while R1 stays false —
+ *      it "simulation-validated" its way forward without ever starting a real build. Canonical
+ *      live case: "ApexNiche AI" at stage-19, launch_mode='simulated', deployment_url / repo_url
+ *      / workflow_started_at all null. This module DERIVES that divergence and annotates it —
+ *      it NEVER writes or resets current_lifecycle_stage (the gauge is read-only here). See the
+ *      'stage-vs-real-build' entry in lib/governance/representation-faithfulness.js INSTANCE_REGISTRY.
+ *
+ * Pure (data-in / verdict-out): zero I/O, zero DB, zero schema dependency beyond the field names.
+ */
+
+/**
+ * STAGE_SIMULATION_OK — the highest EARLY lifecycle stage at which a simulation-only venture
+ * (no real-build evidence) is legitimately expected.
+ *
+ * Chosen conservatively at 18: in the venture lifecycle the real build begins at Stage 19
+ * (`ventures.build_model` is documented as the "SSOT venture build path at Stage 19"), so
+ * stages 1-18 are ideation / validation / design / naming where simulation-only is normal and
+ * correct. A venture PAST Stage 18 (i.e. stage > 18) with no real-build evidence has advanced
+ * its gauge beyond the point where a real build should have started — that is the divergence.
+ * This flags ApexNiche AI at stage-19 (19 > 18) while never flagging a genuinely-early simulated
+ * venture (stage <= 18).
+ *
+ * NOTE: this is a single flat threshold. Child B (the stall alarm) refines this with TIERED
+ * clocks (how LONG a venture has sat past the threshold without real-build evidence) — this
+ * constant is the divergence boundary, not the escalation policy.
+ * @type {number}
+ */
+export const STAGE_SIMULATION_OK = 18;
+
+/**
+ * Has a REAL build started for this venture? (R1 — source of truth.) Pure, no DB, no schema
+ * dependency: any ONE piece of real-build evidence is sufficient.
+ *   - deployment_url set  → something was deployed
+ *   - repo_url set        → a real repo exists
+ *   - workflow_started_at → the build workflow actually kicked off
+ *   - launch_mode==='live'→ explicitly a live (not simulated) launch
+ * @param {{deployment_url?:string|null, repo_url?:string|null, workflow_started_at?:string|null, launch_mode?:string|null}} v
+ * @returns {boolean}
+ */
+export function isRealBuildStarted(v = {}) {
+  return Boolean(v.deployment_url)
+    || Boolean(v.repo_url)
+    || Boolean(v.workflow_started_at)
+    || v.launch_mode === 'live';
+}
+
+/**
+ * Assess the stage-gauge-vs-real-build divergence for one venture. READ-ONLY on the stage
+ * gauge — this never writes or resets current_lifecycle_stage.
+ * divergent === true  iff  the real build has NOT started AND the stage gauge is past the
+ * simulation-OK boundary (stage > STAGE_SIMULATION_OK). Otherwise benign.
+ * @param {{current_lifecycle_stage?:number|null, launch_mode?:string|null, deployment_url?:string|null, repo_url?:string|null, workflow_started_at?:string|null}} v
+ * @returns {{ real_build_started:boolean, stage:number|null, launch_mode:string|null, divergent:boolean, annotation:string }}
+ */
+export function assessRealBuildDivergence(v = {}) {
+  const real_build_started = isRealBuildStarted(v);
+  const stage = v.current_lifecycle_stage ?? null;
+  const launch_mode = v.launch_mode ?? null;
+  const divergent = !real_build_started && Number(stage) > STAGE_SIMULATION_OK;
+
+  const annotation = divergent
+    ? `simulation-validated-vs-real-build divergence: stage=${stage} but real_build_started=false `
+      + `(launch_mode=${launch_mode}, no deployment/repo/workflow evidence) — gauge advanced past `
+      + `STAGE_SIMULATION_OK=${STAGE_SIMULATION_OK} without a real build`
+    : real_build_started
+      ? `real build started (launch_mode=${launch_mode}) — stage=${stage} is faithful to real-build state`
+      : `no real build yet, but stage=${stage} <= STAGE_SIMULATION_OK=${STAGE_SIMULATION_OK} — `
+        + `simulation-only is legitimately expected this early`;
+
+  return { real_build_started, stage, launch_mode, divergent, annotation };
+}

--- a/lib/governance/representation-faithfulness.js
+++ b/lib/governance/representation-faithfulness.js
@@ -89,6 +89,21 @@ export const INSTANCE_REGISTRY = Object.freeze([
     alarm_mechanism: 'MISSING — hand-derived each tick, so mis-derivable (a facet was missed on first pass)',
     derives_at_action_time: false, alarms_on_divergence: false, status: 'planned', divergence_detected_at: '2026-07-20T00:00:00Z',
   },
+  {
+    // SD-LEO-INFRA-VENTURE-REAL-DISCRIMINATOR-AND-STALL-ALARM-001-A (Part 1). A GENUINE
+    // venture can advance its stage gauge to a high number while never starting a real build
+    // (canonical live case: ApexNiche AI at stage-19, launch_mode='simulated', deployment_url/
+    // repo_url/workflow_started_at all null). lib/governance/real-build-discriminator.mjs derives
+    // R2-vs-R1 at assessment time and annotates the divergence (reversible metadata, never resets
+    // the stage). The alarm/escalation surface is Child B (the stall alarm) — hence 'planned'.
+    name: 'stage-vs-real-build',
+    r1_source: 'real-build state (deployment_url / repo_url / workflow_started_at evidence, or launch_mode=\'live\')',
+    r2_governing: 'current_lifecycle_stage — the stage gauge the whole venture lifecycle acts on',
+    derive_site: 'real-build-discriminator.mjs assessRealBuildDivergence derives R2-vs-R1 (stage > STAGE_SIMULATION_OK && !real_build_started) at assessment time',
+    alarm_mechanism: 'backfill sweep annotates metadata.build_provenance (Part 1); loud stall alarm is Child B (Part 2)',
+    derives_at_action_time: true, alarms_on_divergence: false, status: 'planned', divergence_detected_at: '2026-07-21T00:00:00Z',
+    sibling_sd: 'SD-LEO-INFRA-VENTURE-REAL-DISCRIMINATOR-AND-STALL-ALARM-001-A',
+  },
 ]);
 
 const REMEDIATION = Object.freeze({

--- a/scripts/one-time/backfill-real-build-provenance.mjs
+++ b/scripts/one-time/backfill-real-build-provenance.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Backfill real-build provenance — one-time, dry-run-DEFAULT, REVERSIBLE, ZERO-DDL.
+ * SD-LEO-INFRA-VENTURE-REAL-DISCRIMINATOR-AND-STALL-ALARM-001-A (Part 1, FR-4).
+ *
+ * Sweeps ACTIVE, GENUINE (non-fixture) ventures for the stage-gauge-vs-real-build divergence
+ * (see lib/governance/real-build-discriminator.mjs) and reversibly annotates each divergent
+ * venture under metadata.build_provenance. It NEVER touches current_lifecycle_stage or status —
+ * the annotation is a namespaced jsonb merge, fully reversible by clearing the key.
+ *
+ * Usage:
+ *   node scripts/one-time/backfill-real-build-provenance.mjs           # DRY-RUN (default): print divergent table + count, ZERO writes
+ *   node scripts/one-time/backfill-real-build-provenance.mjs --apply   # reversibly merge metadata.build_provenance on each divergent venture
+ *
+ * Idempotent: re-running --apply overwrites metadata.build_provenance with a fresh assessment
+ * (same divergence => same shape, new assessed_at). Fixtures are EXCLUDED via the canonical
+ * isFixtureVenture predicate — only genuine ventures are annotated.
+ *
+ * @wire-check-exempt: one-time backfill CLI under scripts/one-time/ — no permanent runtime entry
+ *   point by design (mirrors scripts/archive/one-time/soft-archive-fixture-ventures.mjs).
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { fetchAllPaginated } from '../../lib/db/fetch-all-paginated.mjs';
+import { isFixtureVenture } from '../../lib/governance/fixture-exclusion.mjs';
+import { assessRealBuildDivergence } from '../../lib/governance/real-build-discriminator.mjs';
+
+/** Parse CLI args → { apply }. Defaults to dry-run (apply=false). */
+export function parseArgs(argv = []) {
+  return { apply: argv.includes('--apply') };
+}
+
+/**
+ * Pure: from a set of venture rows, select the GENUINE (non-fixture) ones whose stage gauge
+ * diverges from real-build state. Returns [{ v, assessment }] for reporting/annotation.
+ */
+export function selectDivergent(ventures) {
+  const out = [];
+  for (const v of ventures || []) {
+    if (isFixtureVenture(v)) continue; // only annotate genuine ventures
+    const assessment = assessRealBuildDivergence(v);
+    if (assessment.divergent) out.push({ v, assessment });
+  }
+  return out;
+}
+
+async function main() {
+  const { apply } = parseArgs(process.argv.slice(2));
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+  const supabase = createClient(url, key);
+
+  // Load ALL active ventures, paginated (ventures is a portfolio table that grows — never
+  // trust a single ≤1000-row page: SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001).
+  const ventures = await fetchAllPaginated(() => supabase
+    .from('ventures')
+    .select('id, name, status, current_lifecycle_stage, launch_mode, deployment_url, repo_url, workflow_started_at, is_demo, metadata')
+    .eq('status', 'active')
+    .order('id', { ascending: true }));
+
+  const divergent = selectDivergent(ventures);
+
+  console.log(`\n── Backfill real-build provenance (${apply ? 'APPLY' : 'DRY-RUN'}) ──`);
+  console.log(`   active ventures scanned: ${ventures.length}`);
+  console.log(`   divergent (genuine):     ${divergent.length}`);
+  console.log('');
+  console.log('   id                                     stage  launch_mode  name');
+  for (const { v } of divergent) {
+    console.log(`   ${String(v.id).padEnd(38)} ${String(v.current_lifecycle_stage).padStart(5)}  ${String(v.launch_mode).padEnd(11)}  ${v.name}`);
+  }
+
+  if (divergent.length === 0) {
+    console.log('\n   No divergent genuine ventures — nothing to annotate. ✅');
+    return;
+  }
+
+  if (!apply) {
+    console.log('\n   DRY-RUN — zero writes. Re-run with --apply to reversibly annotate metadata.build_provenance. ✅');
+    return;
+  }
+
+  // ── APPLY: reversible namespaced jsonb merge (read row metadata, spread, set build_provenance) ──
+  const assessed_at = new Date().toISOString();
+  const affectedIds = [];
+  for (const { v, assessment } of divergent) {
+    const nextMetadata = {
+      ...(v.metadata && typeof v.metadata === 'object' ? v.metadata : {}),
+      build_provenance: {
+        real_build_started: assessment.real_build_started,
+        divergent: assessment.divergent,
+        annotation: assessment.annotation,
+        assessed_at,
+      },
+    };
+    // NEVER touch current_lifecycle_stage or status — metadata-only, reversible annotation.
+    const { error } = await supabase
+      .from('ventures')
+      .update({ metadata: nextMetadata })
+      .eq('id', v.id);
+    if (error) throw new Error(`annotate ${v.id} failed: ${error.message}`);
+    affectedIds.push(v.id);
+    console.log(`   annotated ${v.id} (${v.name})`);
+  }
+
+  console.log(`\n   ✅ Annotated ${affectedIds.length} venture(s) with metadata.build_provenance (stage/status untouched).`);
+  console.log('\n   ── ROLLBACK RECIPE (clears the annotation on each id) ──');
+  console.log(`   UPDATE ventures SET metadata = metadata - 'build_provenance' WHERE id IN (${affectedIds.map((id) => `'${id}'`).join(', ')});`);
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/tests/unit/governance/real-build-discriminator.test.js
+++ b/tests/unit/governance/real-build-discriminator.test.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the real-build discriminator (the stage-gauge-vs-real-build GRF instance).
+ * SD-LEO-INFRA-VENTURE-REAL-DISCRIMINATOR-AND-STALL-ALARM-001-A (Part 1, FR-5).
+ *
+ * These pin the DERIVED rule: divergent iff a real build has NOT started AND the stage gauge is
+ * past STAGE_SIMULATION_OK. They RED against a naive `stage>=N`-alone predicate (which would flag
+ * the real-build-at-stage-19 case) or a `launch_mode`-alone predicate (which would flag the
+ * early-stage simulated case), and GREEN only with the two-factor derived rule. No live DB —
+ * plain objects only.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isRealBuildStarted,
+  assessRealBuildDivergence,
+  STAGE_SIMULATION_OK,
+} from '../../../lib/governance/real-build-discriminator.mjs';
+
+describe('isRealBuildStarted — any one piece of real-build evidence => true', () => {
+  it('deployment_url set (alone) => true', () => {
+    expect(isRealBuildStarted({ deployment_url: 'https://x', repo_url: null, workflow_started_at: null, launch_mode: 'simulated' })).toBe(true);
+  });
+  it('repo_url set (alone) => true', () => {
+    expect(isRealBuildStarted({ deployment_url: null, repo_url: 'https://github.com/x/y', workflow_started_at: null, launch_mode: 'simulated' })).toBe(true);
+  });
+  it('workflow_started_at set (alone) => true', () => {
+    expect(isRealBuildStarted({ deployment_url: null, repo_url: null, workflow_started_at: '2026-07-21T00:00:00Z', launch_mode: 'simulated' })).toBe(true);
+  });
+  it("launch_mode==='live' (alone) => true", () => {
+    expect(isRealBuildStarted({ deployment_url: null, repo_url: null, workflow_started_at: null, launch_mode: 'live' })).toBe(true);
+  });
+  it('all null + launch_mode simulated => false', () => {
+    expect(isRealBuildStarted({ deployment_url: null, repo_url: null, workflow_started_at: null, launch_mode: 'simulated' })).toBe(false);
+  });
+  it('empty object => false (fail-open, no evidence)', () => {
+    expect(isRealBuildStarted({})).toBe(false);
+  });
+});
+
+describe('assessRealBuildDivergence — derived two-factor rule (not stage-alone, not launch_mode-alone)', () => {
+  it('ApexNiche-like (stage-19, simulated, all evidence null) => divergent with a non-empty annotation', () => {
+    const r = assessRealBuildDivergence({
+      current_lifecycle_stage: 19,
+      deployment_url: null,
+      repo_url: null,
+      workflow_started_at: null,
+      launch_mode: 'simulated',
+    });
+    expect(r.divergent).toBe(true);
+    expect(r.real_build_started).toBe(false);
+    expect(r.stage).toBe(19);
+    expect(r.annotation).toBeTruthy();
+    expect(r.annotation.length).toBeGreaterThan(0);
+    expect(r.annotation).toMatch(/divergence/i);
+  });
+
+  it('real-build-at-stage-19 (deployment_url set, launch_mode still simulated) => NOT divergent', () => {
+    // A naive `stage>=N`-alone predicate would FALSELY flag this — the real build has started.
+    const r = assessRealBuildDivergence({
+      current_lifecycle_stage: 19,
+      deployment_url: 'https://x',
+      repo_url: null,
+      workflow_started_at: null,
+      launch_mode: 'simulated',
+    });
+    expect(r.divergent).toBe(false);
+    expect(r.real_build_started).toBe(true);
+  });
+
+  it('early-stage simulated (stage <= STAGE_SIMULATION_OK, all null) => NOT divergent (no false positive)', () => {
+    // A naive `launch_mode==='simulated'`-alone predicate would FALSELY flag this early venture.
+    const r = assessRealBuildDivergence({
+      current_lifecycle_stage: STAGE_SIMULATION_OK,
+      deployment_url: null,
+      repo_url: null,
+      workflow_started_at: null,
+      launch_mode: 'simulated',
+    });
+    expect(r.divergent).toBe(false);
+    expect(r.real_build_started).toBe(false);
+  });
+
+  it('boundary: stage exactly at STAGE_SIMULATION_OK is benign; one past it diverges', () => {
+    const base = { deployment_url: null, repo_url: null, workflow_started_at: null, launch_mode: 'simulated' };
+    expect(assessRealBuildDivergence({ ...base, current_lifecycle_stage: STAGE_SIMULATION_OK }).divergent).toBe(false);
+    expect(assessRealBuildDivergence({ ...base, current_lifecycle_stage: STAGE_SIMULATION_OK + 1 }).divergent).toBe(true);
+  });
+
+  it('STAGE_SIMULATION_OK is a conservative early-stage boundary that flags stage-19', () => {
+    expect(STAGE_SIMULATION_OK).toBeGreaterThanOrEqual(1);
+    expect(STAGE_SIMULATION_OK).toBeLessThan(19); // must flag ApexNiche at stage-19
+  });
+});


### PR DESCRIPTION
## Summary
Child A / Part 1 of the decomposed venture real-discriminator orchestrator. A pure ZERO-DDL discriminator that makes "simulation-validated vs real-build-started" divergence first-class, so a genuine venture that advanced its stage gauge without starting a real build (canonical case: ApexNiche AI, stage-19, launch_mode=simulated, no deployment/repo/workflow) is flagged systematically — without ever resetting the stage number. ~307 LOC, 21/21 unit tests green.

## Deliverables
- **`lib/governance/real-build-discriminator.mjs`** — `isRealBuildStarted(v)` derived purely from existing columns (`deployment_url || repo_url || workflow_started_at || launch_mode==='live'`) + `assessRealBuildDivergence(v)` (`divergent = !real_build_started && current_lifecycle_stage > STAGE_SIMULATION_OK`). Reads stage, never resets it.
- **`STAGE_SIMULATION_OK = 18`** — grounded in the Stage-19 real-build SSOT (`ventures.build_model`); stages 1-18 are legitimately simulation-only.
- **`lib/governance/representation-faithfulness.js`** — registers the `stage-vs-real-build` GRF instance (R1=real-build truth, R2=stage gauge; derives_at_action_time; the loud alarm is Child B).
- **`scripts/one-time/backfill-real-build-provenance.mjs`** — dry-run-DEFAULT, reversible `metadata.build_provenance` annotation sweep; fixtures excluded; paginated. Dry-run: 78 active scanned → 1 divergent (ApexNiche), zero writes.
- **`tests/unit/governance/real-build-discriminator.test.js`** — 11 regressions.

## Safety
Zero DDL (derived + metadata annotation), no chairman-gated migration, stage number never mutated, backfill dry-run-default + reversible.

## Deferred (Child B / chairman)
- Child B (born-fenced): the tiered stall-alarm gauge consuming this discriminator (attaches to `checkVentureTraversalStalls` in `adam-quiet-tick.mjs`).
- Flagship-venture designation mechanism (needed for Child B's shorter clock) — deferred chairman decision.
- Production `--apply` backfill — separate reversible op; tooling ships dry-run-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)