### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001): force bash for SECURITY sub-agent scans on Windows

### DIFF
--- a/lib/sub-agents/security.js
+++ b/lib/sub-agents/security.js
@@ -29,6 +29,14 @@ const __dirname = path.dirname(__filename);
 dotenv.config();
 
 const execAsync = promisify(exec);
+
+// SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001: child_process.exec defaults to cmd.exe on Windows,
+// which cannot parse the POSIX '2>/dev/null' redirects the scan commands below rely on
+// (fails closed with "The system cannot find the path specified", BLOCKING every scan).
+// Forcing bash makes the redirect and grep semantics portable; Linux/macOS CI already run
+// under a POSIX shell by default, so this is a no-op there.
+const EXEC_SHELL_OPTS = process.platform === 'win32' ? { shell: 'bash.exe' } : {};
+
 // Supabase client initialized in execute() to use async createSupabaseServiceClient
 let supabase = null;
 
@@ -294,7 +302,8 @@ async function checkAuthentication(repoPath) {
     // Filter: exclude test files, .test., .spec., __tests__
     const { stdout: localStorageTokens } = await execAsync(
       `cd "${repoPath}" && grep -r "localStorage.setItem.*token" src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|test.ts\\|spec.js\\|__tests__" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|test.ts\\|spec.js\\|__tests__" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     // Check for password variables assigned from form values (actual vulnerability)
@@ -302,7 +311,8 @@ async function checkAuthentication(repoPath) {
     // Filter: exclude password form inputs (type="password" is correct usage)
     const { stdout: plainPasswords } = await execAsync(
       `cd "${repoPath}" && grep -rE "password\\s*=\\s*(event\\.target\\.value|getFormValue|input\\.value|document\\.getElementById)" src 2>/dev/null | ` +
-      'grep -v "type=\\"password\\"" | wc -l'
+      'grep -v "type=\\"password\\"" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     const issues = parseInt(localStorageTokens.trim()) + parseInt(plainPasswords.trim());
@@ -337,14 +347,16 @@ async function checkAuthorization(repoPath) {
     // Pattern: path="..." or <Route path="..."
     const { stdout: allRoutes } = await execAsync(
       `cd "${repoPath}" && grep -r 'path=' src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|__tests__" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|__tests__" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     // Find protected routes (with proper auth middleware)
     // Pattern: ProtectedRoute, withAuth, requireAuth function calls
     const { stdout: protectedRoutes } = await execAsync(
       `cd "${repoPath}" && grep -r "ProtectedRoute\\|withAuth\\|requireAuth\\|isAuthenticated" src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|__tests__" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|__tests__" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     const total = parseInt(allRoutes.trim());
@@ -385,7 +397,8 @@ async function checkInputValidation(repoPath) {
     // SD-VENTURE-STAGE0-UI-001: Improved pattern to reduce false positives
     const { stdout: sqlConcat } = await execAsync(
       `cd "${repoPath}" && grep -rE "(sqlQuery|sql|SQL)\\s*\\+=" src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|__tests__\\|//\\|score +=\\|queryLower" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|__tests__\\|//\\|score +=\\|queryLower" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     // Check for eval usage (actual XSS risk)
@@ -394,14 +407,16 @@ async function checkInputValidation(repoPath) {
     // SD-VENTURE-STAGE0-UI-001: Improved pattern to exclude detection patterns and comments
     const { stdout: evalUsage } = await execAsync(
       `cd "${repoPath}" && grep -r "eval(" src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|__tests__\\|//\\|#\\|pattern.*eval\\|/.*eval" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|__tests__\\|//\\|#\\|pattern.*eval\\|/.*eval" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     // Check for dangerouslySetInnerHTML with user input (more context needed)
     // Pattern: dangerouslySetInnerHTML with variables (not strings)
     const { stdout: dangerousHtml } = await execAsync(
       `cd "${repoPath}" && grep -r "dangerouslySetInnerHTML.*__html" src 2>/dev/null | ` +
-      'grep -v "test.js\\|test.tsx\\|__tests__\\|__html: \'" | wc -l'
+      'grep -v "test.js\\|test.tsx\\|__tests__\\|__html: \'" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     const vulnerabilities = parseInt(sqlConcat.trim()) + parseInt(evalUsage.trim()) + parseInt(dangerousHtml.trim());
@@ -439,7 +454,8 @@ async function checkDataProtection(repoPath) {
     // Filter: exclude comments, env var references, test files
     const { stdout: secrets } = await execAsync(
       `cd "${repoPath}" && grep -r "API_KEY.*=\\|SECRET.*=\\|PASSWORD.*=" src 2>/dev/null | ` +
-      'grep -v "process.env\\|test.js\\|test.tsx\\|__tests__" | wc -l'
+      'grep -v "process.env\\|test.js\\|test.tsx\\|__tests__" | wc -l',
+      EXEC_SHELL_OPTS
     );
 
     const exposedSecrets = parseInt(secrets.trim());
@@ -485,7 +501,8 @@ async function checkRLSPolicies(_sdId) {
     if (tablesError) {
       // Fallback: check migration files for ENABLE ROW LEVEL SECURITY
       const { stdout: _migrationCheck } = await execAsync(
-        'grep -l "ENABLE ROW LEVEL SECURITY" database/migrations/*.sql 2>/dev/null | wc -l'
+        'grep -l "ENABLE ROW LEVEL SECURITY" database/migrations/*.sql 2>/dev/null | wc -l',
+        EXEC_SHELL_OPTS
       );
 
       return {
@@ -509,7 +526,8 @@ async function checkRLSPolicies(_sdId) {
     // Fallback to migration file check
     try {
       const { stdout: rlsEnabled } = await execAsync(
-        'grep -c "ENABLE ROW LEVEL SECURITY" database/migrations/*.sql 2>/dev/null || echo 0'
+        'grep -c "ENABLE ROW LEVEL SECURITY" database/migrations/*.sql 2>/dev/null || echo 0',
+        EXEC_SHELL_OPTS
       );
 
       const enabledCount = parseInt(rlsEnabled.trim());

--- a/tests/unit/sub-agents/security-windows-shell-fix.test.js
+++ b/tests/unit/sub-agents/security-windows-shell-fix.test.js
@@ -1,0 +1,50 @@
+/**
+ * SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001
+ *
+ * Regression: on Windows, child_process.exec defaults to cmd.exe, which cannot parse the
+ * POSIX '2>/dev/null' redirect the SECURITY scan commands rely on -- it fails with "The
+ * system cannot find the path specified", so every scan errors and execute() returns
+ * BLOCKED@0 even for a perfectly clean, non-vulnerable repo. This test does NOT mock
+ * child_process (unlike security-evidence-absent.test.js, which mocks it entirely) --
+ * it exercises the real shell execution path against a real directory that has no `src/`
+ * (mirroring EHG_Engineer itself), proving the scans complete without erroring.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../scripts/lib/supabase-connection.js', () => ({
+  createSupabaseServiceClient: vi.fn(async () => ({
+    rpc: async () => ({ data: [], error: null })
+  }))
+}));
+
+vi.mock('../../../scripts/lib/handoff-preflight.js', () => ({
+  quickPreflightCheck: vi.fn(async () => ({ ready: true, missing: [] }))
+}));
+
+vi.mock('../../../lib/sub-agents/resolve-repo.js', () => ({
+  // Real repo root, which (like EHG_Engineer) has no top-level src/ -- the exact shape
+  // that triggered the pre-fix Windows shell failure.
+  resolveSubAgentRepo: vi.fn(async () => ({ repoPath: process.cwd() })),
+  applySubAgentRepoVerdict: vi.fn()
+}));
+
+const { execute } = await import('../../../lib/sub-agents/security.js');
+
+describe('SECURITY execute() — real shell execution against a repo with no src/ (SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001)', () => {
+  it('scans complete without erroring, even when the redirect + missing src/ dir combination that broke Windows cmd.exe is present', async () => {
+    const results = await execute('SD-TEST-REAL-SHELL', {}, {});
+
+    // Pre-fix on Windows: every scan helper caught an execAsync rejection and returned
+    // { checked:false, error }, which makes execute() BLOCKED@0. Post-fix: the scans
+    // actually run (checked:true) regardless of whether src/ exists.
+    expect(results.findings.authentication_check.checked).toBe(true);
+    expect(results.findings.authorization_check.checked).toBe(true);
+    expect(results.findings.input_validation.checked).toBe(true);
+    expect(results.findings.data_protection.checked).toBe(true);
+
+    for (const key of ['authentication_check', 'authorization_check', 'input_validation', 'data_protection']) {
+      expect(results.findings[key].error).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- SECURITY sub-agent unconditionally returned BLOCKED@0 on Windows: `child_process.exec` defaults to `cmd.exe`, which cannot parse the POSIX `2>/dev/null` redirect used in all 10 grep-based scan commands, causing every scan to error.
- Fix: platform-gated `EXEC_SHELL_OPTS` constant forces `bash.exe` on win32 only; no-op on Linux/macOS CI.
- Verified live: `node scripts/execute-subagent.js --code SECURITY --sd-id <SD>` flips from BLOCKED@0 to PASS@100.
- Auto-generated by `/learn` from 3 recurring occurrences (feedback 78f94740, 714343de, cab0f9b6).

## Test plan
- [x] New non-mocked regression test (`security-windows-shell-fix.test.js`) proves the real shell path works
- [x] Existing fully-mocked evidence-absence suite (`security-evidence-absent.test.js`) unaffected
- [x] Full `tests/unit/sub-agents/` suite: 19 files / 161 tests pass
- [x] Live smoke test via `scripts/execute-subagent.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)