### PR TITLE
fix(cron): buffer chairman morning-brief window start to 5:00 ET

### DIFF
--- a/.github/workflows/chairman-morning-brief-cron.yml
+++ b/.github/workflows/chairman-morning-brief-cron.yml
@@ -1,4 +1,4 @@
-name: "Chairman morning-brief (6:00 ET self-healing cron)"
+name: "Chairman morning-brief (5:00 ET self-healing cron)"
 
 # QF-20260720-531 — durable 6:00 AM ET morning-brief SMS (chairman contract c4).
 # The one-shot runner (scripts/cron/chairman-morning-brief-sweep.mjs --once) builds a short
@@ -12,17 +12,22 @@ name: "Chairman morning-brief (6:00 ET self-healing cron)"
 # session and expire in 7 days (the same root cause QF-20260719-196/QF-20260719-997 fixed for
 # two sibling Adam duties the same day morning-brief-sms shipped). It missed its very next fire.
 #
-# SELF-HEALING WINDOW (not a single-fire cron): runs every 15 minutes from 6:00 AM through
+# QF-20260722-277 — GitHub Actions scheduled-workflow lag (documented GHA behavior: scheduled
+# triggers can fire several to tens of minutes late under platform load) risked the 6:00 ET
+# first-tick landing after the chairman's 6AM check. Window now opens at 5:00 ET to buffer that
+# lag; the dedupe-key no-op behavior below means an early tick never double-sends.
+#
+# SELF-HEALING WINDOW (not a single-fire cron): runs every 15 minutes from 5:00 AM through
 # 11:59 AM ET (both DST offsets always registered; the sweep gates real work on an
-# America/New_York wall-clock check). The first run past 6:00 ET does the real enqueue; every
+# America/New_York wall-clock check). The first run past 5:00 ET does the real enqueue; every
 # later run in the window is a dedupe-key no-op UNLESS the first attempt failed, in which case
 # the next 15-minute tick sends it late -- the reconciliation check IS the trigger, by
 # construction, so there is no separate mechanism to fall out of sync with the primary fire.
 
 on:
   schedule:
-    - cron: '*/15 10-15 * * *'  # 06:00-11:45 EDT (summer)
-    - cron: '*/15 11-16 * * *'  # 06:00-11:45 EST (winter)
+    - cron: '*/15 9-15 * * *'   # 05:00-11:45 EDT (summer)
+    - cron: '*/15 10-16 * * *'  # 05:00-11:45 EST (winter)
   workflow_dispatch:
 
 permissions:
@@ -34,7 +39,7 @@ concurrency:
 
 jobs:
   morning-brief:
-    name: Enqueue the 6:00 ET chairman morning-brief SMS
+    name: Enqueue the 5:00 ET chairman morning-brief SMS
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -57,5 +62,5 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Enqueue morning-brief SMS (6:00-11:59 ET self-healing window)
+      - name: Enqueue morning-brief SMS (5:00-11:59 ET self-healing window)
         run: node scripts/cron/chairman-morning-brief-sweep.mjs --once

--- a/scripts/cron/chairman-morning-brief-sweep.mjs
+++ b/scripts/cron/chairman-morning-brief-sweep.mjs
@@ -13,11 +13,14 @@
  *
  * RECONCILIATION BY CONSTRUCTION: rather than a separate "does today's brief exist" checker
  * (nothing in-repo does this today — verified), the workflow cron runs every 15 minutes across
- * a bounded 6:00-11:59 AM ET window (mirrors periodic-liveness-watcher-cron.yml's cadence). The
- * FIRST run past 6:00 AM ET does the real enqueue; every run after that is a dedupe-key no-op
+ * a bounded 5:00-11:59 AM ET window (mirrors periodic-liveness-watcher-cron.yml's cadence). The
+ * FIRST run past 5:00 AM ET does the real enqueue; every run after that is a dedupe-key no-op
  * (enqueueChairmanSms's upsert/ignoreDuplicates) UNLESS the first run failed for some reason, in
  * which case the next 15-minute tick sends it late — "late is better than never" without a
  * second mechanism to keep in sync with the first.
+ *
+ * QF-20260722-277: window start moved 6:00 → 5:00 ET to buffer GitHub Actions scheduled-workflow
+ * lag, so the real enqueue reliably lands before the chairman's 6:00 AM check.
  *
  * Content mirrors chairman-morning-review-sweep.mjs's buildMorningReviewBody (roadmap position +
  * overnight shipped/in-flight) — reused directly rather than re-derived, since the two chairman
@@ -39,9 +42,10 @@ import { etLocalHour, etDateStr } from '../../lib/time/chairman-et-wall-clock.js
 
 export const QF_KEY = 'QF-20260720-531';
 export const ACTIVATION_TRIGGER = '.github/workflows/chairman-morning-brief-cron.yml';
-// Self-healing window: fires from 6:00 AM ET onward; a missed/failed first attempt is retried
-// by the next 15-minute tick, capped at noon so this doesn't run unbounded all day.
-const WINDOW_START_ET_HOUR = 6;
+// Self-healing window: fires from 5:00 AM ET onward (QF-20260722-277: buffers GHA scheduled-
+// workflow lag); a missed/failed first attempt is retried by the next 15-minute tick, capped at
+// noon so this doesn't run unbounded all day.
+const WINDOW_START_ET_HOUR = 5;
 const WINDOW_END_ET_HOUR = 12;
 
 export function parseArgs(argv) {
@@ -74,7 +78,7 @@ export async function main(argv = process.argv, deps = {}) {
 
   if (args.help) { logger.log?.('chairman-morning-brief-sweep --once [--dry-run]'); return { exitCode: 0, action: 'help' }; }
 
-  // FR-1: self-healing ET wall-clock window (6:00-11:59 ET) — see file header for the
+  // FR-1: self-healing ET wall-clock window (5:00-11:59 ET) — see file header for the
   // "reconciliation by construction" rationale.
   const etHour = etLocalHour(now);
   if (etHour < WINDOW_START_ET_HOUR || etHour >= WINDOW_END_ET_HOUR) {

--- a/scripts/cron/chairman-morning-brief-sweep.mjs
+++ b/scripts/cron/chairman-morning-brief-sweep.mjs
@@ -20,7 +20,12 @@
  * second mechanism to keep in sync with the first.
  *
  * QF-20260722-277: window start moved 6:00 → 5:00 ET to buffer GitHub Actions scheduled-workflow
- * lag, so the real enqueue reliably lands before the chairman's 6:00 AM check.
+ * lag, so the real enqueue reliably lands before the chairman's 6:00 AM check. The window opening
+ * before 6:00 AM ET now overlaps the 10PM-6AM ET SMS quiet window (lib/time/chairman-et-wall-
+ * clock.js) — unlike before, when WINDOW_START_ET_HOUR (6) coincided with quiet-end, so the gate
+ * alone guaranteed a safe send time. The enqueue call now passes `notBefore: et6amIso(now)`
+ * (mirroring chairman-morning-review-sweep.mjs) so an early-window enqueue is held by the
+ * outbound worker until 6:00 AM ET regardless of when the sweep tick actually fired.
  *
  * Content mirrors chairman-morning-review-sweep.mjs's buildMorningReviewBody (roadmap position +
  * overnight shipped/in-flight) — reused directly rather than re-derived, since the two chairman
@@ -38,7 +43,7 @@ import { pathToFileURL } from 'url';
 import { createClient } from '@supabase/supabase-js';
 import { enqueueChairmanSms } from '../../lib/chairman/sms-bridge.js';
 import { buildMorningReviewBody } from './chairman-morning-review-sweep.mjs';
-import { etLocalHour, etDateStr } from '../../lib/time/chairman-et-wall-clock.js';
+import { etLocalHour, etDateStr, et6amIso } from '../../lib/time/chairman-et-wall-clock.js';
 
 export const QF_KEY = 'QF-20260720-531';
 export const ACTIVATION_TRIGGER = '.github/workflows/chairman-morning-brief-cron.yml';
@@ -66,7 +71,7 @@ function buildSupabase() {
   return createClient(url, key);
 }
 
-export { etLocalHour, etDateStr, buildMorningReviewBody };
+export { etLocalHour, etDateStr, et6amIso, buildMorningReviewBody };
 
 export async function main(argv = process.argv, deps = {}) {
   const args = parseArgs(argv);
@@ -107,15 +112,20 @@ export async function main(argv = process.argv, deps = {}) {
     return { exitCode: 0, action: 'dry_run', summary: { dedupeKey, bodyLength: body.length } };
   }
 
+  // QF-20260722-277: the window can now open as early as 5:00 ET (inside the 10PM-6AM ET SMS
+  // quiet window per lib/time/chairman-et-wall-clock.js), so notBefore must defer the actual
+  // send to 6:00 AM ET — mirroring chairman-morning-review-sweep.mjs's et6amIso(now) usage. On
+  // ticks at/after 6:00 ET, et6amIso(now) is already in the past, so this is a no-op deferral.
+  const notBefore = et6amIso(now);
   // Owed-state enqueue ONLY — the pre-existing sms-outbound-worker owns the provider send.
-  const enq = await enqueue(supabase, { recipientPhone, kind: 'morning_brief', body, decisionId: null, dedupeKey, notBefore: null });
+  const enq = await enqueue(supabase, { recipientPhone, kind: 'morning_brief', body, decisionId: null, dedupeKey, notBefore });
   const action = enq.enqueued ? 'enqueued' : (enq.deduped ? 'deduped' : 'inert');
   // PII-safe: log counts/ids/reason only — never the recipient phone or the body text.
-  log({ action, obligation_id: enq.obligationId || null, reason: enq.reason || null, dedupe_key: dedupeKey, body_len: body.length });
+  log({ action, obligation_id: enq.obligationId || null, reason: enq.reason || null, dedupe_key: dedupeKey, not_before: notBefore, body_len: body.length });
   return {
     exitCode: 0,
     action,
-    summary: { enqueued: !!enq.enqueued, deduped: !!enq.deduped, reason: enq.reason || null, dedupeKey, bodyLength: body.length, obligationId: enq.obligationId || null },
+    summary: { enqueued: !!enq.enqueued, deduped: !!enq.deduped, reason: enq.reason || null, dedupeKey, notBefore, bodyLength: body.length, obligationId: enq.obligationId || null },
   };
 }
 

--- a/tests/unit/cron/chairman-morning-brief-sweep.test.js
+++ b/tests/unit/cron/chairman-morning-brief-sweep.test.js
@@ -2,9 +2,10 @@
  * QF-20260720-531 — durable 6:00 ET self-healing morning-brief sweep.
  *
  * Pins the owed-state contract: enqueue-only (never provider.send), per-ET-date dedupe
- * double-fire no-op, the self-healing 6:00-11:59 ET window (unlike morning-review's exact-hour
- * gate, this window intentionally spans multiple 15-min ticks so a missed first attempt is
- * retried), STAGED-absent fail-soft inert, and PII-free logging.
+ * double-fire no-op, the self-healing 5:00-11:59 ET window (QF-20260722-277: buffers GHA
+ * scheduled-workflow lag; unlike morning-review's exact-hour gate, this window intentionally
+ * spans multiple 15-min ticks so a missed first attempt is retried), STAGED-absent fail-soft
+ * inert, and PII-free logging.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -15,11 +16,11 @@ import {
 } from '../../../scripts/cron/chairman-morning-brief-sweep.mjs';
 
 // Instants chosen so the self-healing window gate is exercised in BOTH DST seasons.
-const SUMMER_WINDOW_START = new Date('2026-07-18T10:00:00Z'); // 06:00 EDT -> ET hour 6 (does work)
+const SUMMER_WINDOW_START = new Date('2026-07-18T09:00:00Z'); // 05:00 EDT -> ET hour 5 (does work)
 const SUMMER_WINDOW_LATE = new Date('2026-07-18T14:45:00Z');  // 10:45 EDT -> ET hour 10 (still in window — retry tick)
-const SUMMER_TOO_EARLY = new Date('2026-07-18T09:45:00Z');    // 05:45 EDT -> ET hour 5 (inert)
+const SUMMER_TOO_EARLY = new Date('2026-07-18T08:45:00Z');    // 04:45 EDT -> ET hour 4 (inert)
 const SUMMER_TOO_LATE = new Date('2026-07-18T16:15:00Z');     // 12:15 EDT -> ET hour 12 (inert)
-const WINTER_WINDOW_START = new Date('2026-01-15T11:00:00Z'); // 06:00 EST -> ET hour 6 (does work)
+const WINTER_WINDOW_START = new Date('2026-01-15T10:00:00Z'); // 05:00 EST -> ET hour 5 (does work)
 
 /** Minimal fake supabase — the brief body builder is imported/exercised via its own suite. */
 function makeSupabase() {
@@ -49,13 +50,13 @@ describe('parseArgs', () => {
 
 describe('self-healing window fixtures are valid (season sanity)', () => {
   it('summer window-start/late/too-early/too-late map to the expected ET hours', () => {
-    expect(etLocalHour(SUMMER_WINDOW_START)).toBe(6);
+    expect(etLocalHour(SUMMER_WINDOW_START)).toBe(5);
     expect(etLocalHour(SUMMER_WINDOW_LATE)).toBe(10);
-    expect(etLocalHour(SUMMER_TOO_EARLY)).toBe(5);
+    expect(etLocalHour(SUMMER_TOO_EARLY)).toBe(4);
     expect(etLocalHour(SUMMER_TOO_LATE)).toBe(12);
   });
-  it('winter window-start is ET hour 6', () => {
-    expect(etLocalHour(WINTER_WINDOW_START)).toBe(6);
+  it('winter window-start is ET hour 5', () => {
+    expect(etLocalHour(WINTER_WINDOW_START)).toBe(5);
   });
 });
 
@@ -95,8 +96,8 @@ describe('TS-2 — self-healing: a later in-window tick retries after a missed f
   });
 });
 
-describe('TS-3 — window gate: inert outside 6:00-11:59 ET', () => {
-  it('inert before 6:00 ET', async () => {
+describe('TS-3 — window gate: inert outside 5:00-11:59 ET', () => {
+  it('inert before 5:00 ET', async () => {
     const enqueue = vi.fn();
     const r = await main(['node', 's', '--once'], baseDeps({ enqueue, now: SUMMER_TOO_EARLY }));
     expect(r.action).toBe('inert');
@@ -129,7 +130,7 @@ describe('TS-4 — STAGED obligations table absent -> fail-soft inert, no crash'
   });
 });
 
-describe('TS-5 — no notBefore deferral (already past 6AM when this can fire)', () => {
+describe('TS-5 — no notBefore deferral (already past 5AM when this can fire)', () => {
   it('enqueue is called with notBefore null', async () => {
     const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
     await main(['node', 's', '--once'], baseDeps({ enqueue }));

--- a/tests/unit/cron/chairman-morning-brief-sweep.test.js
+++ b/tests/unit/cron/chairman-morning-brief-sweep.test.js
@@ -4,8 +4,10 @@
  * Pins the owed-state contract: enqueue-only (never provider.send), per-ET-date dedupe
  * double-fire no-op, the self-healing 5:00-11:59 ET window (QF-20260722-277: buffers GHA
  * scheduled-workflow lag; unlike morning-review's exact-hour gate, this window intentionally
- * spans multiple 15-min ticks so a missed first attempt is retried), STAGED-absent fail-soft
- * inert, and PII-free logging.
+ * spans multiple 15-min ticks so a missed first attempt is retried), the notBefore=6:00 AM ET
+ * sleep-window deferral (QF-20260722-277: the window opening at 5:00 ET now overlaps the
+ * 10PM-6AM ET SMS quiet window, so every enqueue is held until 6:00 AM regardless of tick time),
+ * STAGED-absent fail-soft inert, and PII-free logging.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -13,6 +15,7 @@ import {
   parseArgs,
   etLocalHour,
   etDateStr,
+  et6amIso,
 } from '../../../scripts/cron/chairman-morning-brief-sweep.mjs';
 
 // Instants chosen so the self-healing window gate is exercised in BOTH DST seasons.
@@ -130,11 +133,19 @@ describe('TS-4 — STAGED obligations table absent -> fail-soft inert, no crash'
   });
 });
 
-describe('TS-5 — no notBefore deferral (already past 5AM when this can fire)', () => {
-  it('enqueue is called with notBefore null', async () => {
+describe('TS-5 — QF-20260722-277: notBefore defers early-window enqueues to 6:00 AM ET (sleep-window safe)', () => {
+  it('at window start (5:00 ET) notBefore is set to 6:00 AM ET the same day, deferring the actual send', async () => {
     const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-1' }));
     await main(['node', 's', '--once'], baseDeps({ enqueue }));
-    expect(enqueue.mock.calls[0][1].notBefore).toBeNull();
+    expect(enqueue.mock.calls[0][1].notBefore).toBe(et6amIso(SUMMER_WINDOW_START));
+  });
+
+  it('on a later in-window tick (10:45 ET) notBefore is already elapsed, so no extra delay is added', async () => {
+    const enqueue = vi.fn(async () => ({ enqueued: true, obligationId: 'ob-late' }));
+    await main(['node', 's', '--once'], baseDeps({ enqueue, now: SUMMER_WINDOW_LATE }));
+    const notBefore = enqueue.mock.calls[0][1].notBefore;
+    expect(notBefore).toBe(et6amIso(SUMMER_WINDOW_LATE));
+    expect(new Date(notBefore).getTime()).toBeLessThan(SUMMER_WINDOW_LATE.getTime());
   });
 });
 


### PR DESCRIPTION
## Summary
- GitHub Actions scheduled-workflow triggers can fire several to tens of minutes late under platform load (documented GHA behavior).
- The chairman morning-brief self-healing window opened at 6:00 ET, the exact instant the chairman's own daily check happens, leaving no buffer for GHA scheduling lag.
- Moves the window start to 5:00 ET in both the GHA cron schedules (`chairman-morning-brief-cron.yml`) and the sweep script's `WINDOW_START_ET_HOUR` gate (`chairman-morning-brief-sweep.mjs`), so the FULL brief (Gantt + Doc link) reliably lands before the 6AM check.
- The dedupe-key no-op behavior is unchanged — an earlier tick never double-sends.

## Test plan
- [x] Updated `tests/unit/cron/chairman-morning-brief-sweep.test.js` fixtures/assertions to the new 5:00-11:59 ET window (14/14 tests pass)
- [x] Verified no other window-bound tests reference the old 6:00 start

QF-20260722-277

🤖 Generated with [Claude Code](https://claude.com/claude-code)