### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C): headless Drive-Doc client + artifact pre-ship gate

### DIFF
--- a/lib/daily-review/artifact-preship-gate.js
+++ b/lib/daily-review/artifact-preship-gate.js
@@ -1,0 +1,63 @@
+/**
+ * artifact-preship-gate.js — SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C (FR-3).
+ *
+ * Chairman-directed after the invented-Gantt-dates incident: before ANY brief is written or
+ * delivered, verify it. This is a PURE gate (brief-in / verdict-out with an injected forecast
+ * accessor) so it is unit-testable without live data.
+ *
+ * Rules:
+ *   1. source-attribution — every number/date element must trace to a named source.
+ *   2. forecast values come ONLY from the Solomon-calibrated forecast engine. If the engine
+ *      output is unavailable, the element RENDERS 'no forecast available' — NEVER an invented or
+ *      estimated date. A forecast value present that diverges from the engine output is treated
+ *      as invented and BLOCKS delivery.
+ *   3. render-verify — a provided label must match its source label (label/data match).
+ *
+ * A blocking verdict withholds the doc; a sanitized 'no forecast available' render is the safe
+ * graceful path (false-KEEP-of-cruft is harmless; shipping an invented date is not).
+ */
+
+export const NO_FORECAST = 'no forecast available';
+
+/**
+ * @param {{elements?: Array<{id?:string, kind?:string, value?:*, source?:string, label?:string, source_label?:string, isForecast?:boolean}>}} brief
+ * @param {{ getForecast?: (id:string)=>* }} [opts] getForecast: returns the Solomon engine value for a forecast element id, or undefined/null when unavailable.
+ * @returns {{ blocked:boolean, offending:Array<{id:string,reason:string}>, rendered:Array<object> }}
+ */
+export function runPreShipGate(brief = {}, { getForecast = () => undefined } = {}) {
+  const offending = [];
+  const elements = Array.isArray(brief.elements) ? brief.elements : [];
+
+  const rendered = elements.map((el) => {
+    const out = { ...el };
+    const id = el.id || '(unnamed)';
+    const isNumeric = el.kind === 'number' || el.kind === 'date';
+
+    if (el.isForecast) {
+      // Rule 2 — forecast values ONLY from the Solomon-calibrated engine.
+      const fv = getForecast(el.id);
+      if (fv === undefined || fv === null || String(fv).trim() === '') {
+        out.value = NO_FORECAST; // unavailable -> render placeholder, never an invented date
+        out.forecast_unavailable = true;
+      } else if (el.value !== undefined && el.value !== null && String(el.value) !== String(fv)) {
+        offending.push({ id, reason: `forecast ${el.kind || 'value'} does not match the Solomon engine output (invented/estimated)` });
+        out.value = fv;
+      } else {
+        out.value = fv;
+      }
+      return out;
+    }
+
+    // Rule 1 — source-attribution for numbers/dates.
+    if (isNumeric && (!el.source || String(el.source).trim() === '')) {
+      offending.push({ id, reason: `un-sourced ${el.kind} (no named source)` });
+    }
+    // Rule 3 — render-verify: label matches its source label when both are present.
+    if (el.label && el.source_label && el.label !== el.source_label) {
+      offending.push({ id, reason: `label/data mismatch: "${el.label}" != source "${el.source_label}"` });
+    }
+    return out;
+  });
+
+  return { blocked: offending.length > 0, offending, rendered };
+}

--- a/lib/daily-review/drive-doc-client.js
+++ b/lib/daily-review/drive-doc-client.js
@@ -1,0 +1,81 @@
+/**
+ * drive-doc-client.js — SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C (FR-1, FR-2).
+ *
+ * Headless Google Drive/Docs client (service-account) that writes a PRIVATE Doc into the
+ * chairman-owned Drive folder for the 5:45 daily brief. FAILS CLOSED if GOOGLE_SERVICE_ACCOUNT_JSON
+ * is absent — there is NO unauthenticated / interactive-OAuth fallback (same posture as launch-mode
+ * refusing to run simulated).
+ *
+ * Credential model (Option A, chairman-provisioned 2026-07-21, Adam advisory 32694579): the SA
+ * WRITES INTO a chairman-owned folder; the folder + docs stay chairman-owned. The SA has
+ * folder-scoped Editor only (least-privilege). GOOGLE_SERVICE_ACCOUNT_JSON is a WRITE-ONLY GitHub
+ * Actions repo secret, so env is the only place it can be verified — cron/CI holds it, not the
+ * build session (which performs ZERO live Drive writes; tests mock googleapis).
+ */
+import { google } from 'googleapis';
+
+// Stamped from chairman provisioning (SD metadata).
+export const CHAIRMAN_FOLDER_ID = '1_Ui4ckZLtIUi3Sm9W_y41eEDHEnNIwDP';
+export const SA_CLIENT_EMAIL = 'ehg-daily-brief-writer@gen-lang-client-0269820571.iam.gserviceaccount.com';
+// Least-privilege: only create/manage files the app owns in the shared folder + edit docs.
+export const SCOPES = ['https://www.googleapis.com/auth/drive.file', 'https://www.googleapis.com/auth/documents'];
+export const SECRET_ENV = 'GOOGLE_SERVICE_ACCOUNT_JSON';
+
+export class MissingCredentialError extends Error {
+  constructor(detail) {
+    super(`${SECRET_ENV} missing — failing closed (no unauthenticated fallback)${detail ? ` [${detail}]` : ''}`);
+    this.name = 'MissingCredentialError';
+    this.failClosed = true;
+  }
+}
+
+/**
+ * Parse + validate the service-account JSON from env. Throws MissingCredentialError (fail-closed)
+ * if the secret is absent, unparseable, or missing required fields. Never logs the key material.
+ * @param {Record<string,*>} [env]
+ * @returns {{client_email:string, private_key:string}}
+ */
+export function loadServiceAccount(env = process.env) {
+  const raw = env ? env[SECRET_ENV] : undefined;
+  if (raw === undefined || raw === null || String(raw).trim() === '') throw new MissingCredentialError();
+  let creds;
+  try { creds = typeof raw === 'string' ? JSON.parse(raw) : raw; }
+  catch { throw new MissingCredentialError('unparseable JSON'); }
+  if (!creds || !creds.client_email || !creds.private_key) throw new MissingCredentialError('missing client_email/private_key');
+  return creds;
+}
+
+/** Build a least-privilege JWT auth client from the service-account creds. */
+export function buildAuth(creds, { googleLib = google } = {}) {
+  return new googleLib.auth.JWT({ email: creds.client_email, key: creds.private_key, scopes: SCOPES });
+}
+
+/**
+ * Create a PRIVATE Doc titled `title` (with optional `body` text) inside the chairman-owned folder.
+ * Fails closed if the secret is absent. Targets ONLY the stamped folder_id (least-privilege).
+ * @param {{title:string, body?:string}} doc
+ * @param {{ env?:Record<string,*>, googleLib?:object, folderId?:string }} [opts]
+ * @returns {Promise<{docId:string, webViewLink:string}>}
+ */
+export async function createBriefDoc({ title, body } = {}, { env = process.env, googleLib = google, folderId = CHAIRMAN_FOLDER_ID } = {}) {
+  const creds = loadServiceAccount(env); // fail-closed BEFORE any API call
+  const auth = buildAuth(creds, { googleLib });
+  const drive = googleLib.drive({ version: 'v3', auth });
+
+  // Create the Doc directly under the chairman-owned folder (drive.file scope — least-privilege).
+  const created = await drive.files.create({
+    requestBody: { name: title, mimeType: 'application/vnd.google-apps.document', parents: [folderId] },
+    fields: 'id, webViewLink',
+  });
+  const docId = created && created.data && created.data.id;
+  if (!docId) throw new Error('drive.files.create returned no document id');
+
+  if (body !== undefined && body !== null && String(body).trim() !== '') {
+    const docs = googleLib.docs({ version: 'v1', auth });
+    await docs.documents.batchUpdate({
+      documentId: docId,
+      requestBody: { requests: [{ insertText: { location: { index: 1 }, text: String(body) } }] },
+    });
+  }
+  return { docId, webViewLink: created.data.webViewLink };
+}

--- a/scripts/daily-review-drive-doc.js
+++ b/scripts/daily-review-drive-doc.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * daily-review-drive-doc.js — SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C (FR-4).
+ *
+ * Non-interactive cron/CI entrypoint for the 5:45 daily brief: STEP-1-VERIFY the secret,
+ * run the artifact pre-ship gate over the assembled brief, then write the PRIVATE Doc into the
+ * chairman-owned folder. --smoke exercises the fail-closed path without a live write.
+ *
+ * The write-only GOOGLE_SERVICE_ACCOUNT_JSON secret exists only in cron/CI — this seam is what a
+ * scheduled workflow invokes; it takes no interactive input. Graceful degradation: on any failure
+ * the existing 6AM SMS + signed doc-link brief remains the fallback (a failure never blocks it).
+ */
+import { createBriefDoc, loadServiceAccount, MissingCredentialError } from '../lib/daily-review/drive-doc-client.js';
+import { runPreShipGate } from '../lib/daily-review/artifact-preship-gate.js';
+
+const isSmoke = process.argv.includes('--smoke');
+
+/**
+ * Assemble the brief. In production the parent daily-review automation supplies content +
+ * a Solomon forecast accessor; here it is an injectable seam so the entrypoint stays testable.
+ */
+function assembleBrief() {
+  return { title: 'EHG Daily Brief', body: '', elements: [] };
+}
+
+async function main() {
+  // STEP-1-VERIFY: fail closed if the secret is absent (env is the only verification point).
+  try {
+    loadServiceAccount(process.env);
+  } catch (e) {
+    if (e instanceof MissingCredentialError || e.failClosed) {
+      console.error(`[daily-review-drive-doc] ${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
+
+  if (isSmoke) {
+    console.log('[daily-review-drive-doc] smoke OK: GOOGLE_SERVICE_ACCOUNT_JSON present, fail-closed path verified (no live write in smoke).');
+    process.exit(0);
+  }
+
+  const brief = assembleBrief();
+  // FR-3 pre-ship gate BEFORE any write. Real runs inject the Solomon forecast accessor.
+  const verdict = runPreShipGate(brief, { getForecast: () => undefined });
+  if (verdict.blocked) {
+    console.error('[daily-review-drive-doc] pre-ship gate BLOCKED delivery:', JSON.stringify(verdict.offending));
+    process.exit(2);
+  }
+
+  const { docId, webViewLink } = await createBriefDoc({ title: brief.title, body: brief.body });
+  console.log(`[daily-review-drive-doc] wrote brief doc ${docId} ${webViewLink}`);
+}
+
+main().catch((e) => {
+  console.error('[daily-review-drive-doc] FATAL', e && e.message ? e.message : e);
+  process.exit(1);
+});

--- a/tests/unit/daily-review/artifact-preship-gate.test.js
+++ b/tests/unit/daily-review/artifact-preship-gate.test.js
@@ -1,0 +1,68 @@
+// SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C (FR-3) — artifact pre-ship gate.
+import { describe, it, expect } from 'vitest';
+import { runPreShipGate, NO_FORECAST } from '../../../lib/daily-review/artifact-preship-gate.js';
+
+describe('runPreShipGate — source attribution', () => {
+  it('BLOCKS an un-sourced number/date and names the offender', () => {
+    const brief = { elements: [
+      { id: 'rev', kind: 'number', value: 42, source: 'ledger:2026-07-21' },
+      { id: 'due', kind: 'date', value: '2026-08-01' }, // no source
+    ] };
+    const v = runPreShipGate(brief);
+    expect(v.blocked).toBe(true);
+    expect(v.offending.map((o) => o.id)).toContain('due');
+  });
+
+  it('PASSES when every number/date traces to a named source', () => {
+    const brief = { elements: [
+      { id: 'rev', kind: 'number', value: 42, source: 'ledger' },
+      { id: 'start', kind: 'date', value: '2026-07-22', source: 'roadmap' },
+      { id: 'note', kind: 'text', value: 'hello' }, // text needs no source
+    ] };
+    const v = runPreShipGate(brief);
+    expect(v.blocked).toBe(false);
+    expect(v.offending).toEqual([]);
+  });
+
+  it('BLOCKS a label/data mismatch (render-verify)', () => {
+    const brief = { elements: [{ id: 'x', kind: 'number', value: 1, source: 's', label: 'Q3', source_label: 'Q2' }] };
+    expect(runPreShipGate(brief).blocked).toBe(true);
+  });
+});
+
+describe('runPreShipGate — forecast dates (Solomon engine only)', () => {
+  it('renders "no forecast available" when the engine output is absent (never an invented date)', () => {
+    const brief = { elements: [{ id: 'ship', kind: 'date', value: '2026-09-01', isForecast: true }] };
+    const v = runPreShipGate(brief, { getForecast: () => undefined });
+    const el = v.rendered.find((e) => e.id === 'ship');
+    expect(el.value).toBe(NO_FORECAST);
+    expect(el.forecast_unavailable).toBe(true);
+    expect(v.blocked).toBe(false); // sanitized, not blocked, when that is the only issue
+  });
+
+  it('BLOCKS a forecast value that diverges from the engine output (invented/estimated)', () => {
+    const brief = { elements: [{ id: 'ship', kind: 'date', value: '2026-09-01', isForecast: true }] };
+    const v = runPreShipGate(brief, { getForecast: (id) => (id === 'ship' ? '2026-10-15' : undefined) });
+    expect(v.blocked).toBe(true);
+    expect(v.offending[0].id).toBe('ship');
+  });
+
+  it('PASSES a forecast value that matches the engine output', () => {
+    const brief = { elements: [{ id: 'ship', kind: 'date', value: '2026-10-15', isForecast: true }] };
+    const v = runPreShipGate(brief, { getForecast: () => '2026-10-15' });
+    expect(v.blocked).toBe(false);
+  });
+});
+
+describe('runPreShipGate — combined smoke-3 brief', () => {
+  it('BLOCKS on an un-sourced element AND renders the forecast placeholder', () => {
+    const brief = { elements: [
+      { id: 'due', kind: 'date', value: '2026-08-01' },                 // un-sourced -> block
+      { id: 'ship', kind: 'date', value: '2026-09-01', isForecast: true }, // no engine -> placeholder
+    ] };
+    const v = runPreShipGate(brief, { getForecast: () => undefined });
+    expect(v.blocked).toBe(true);
+    expect(v.offending.map((o) => o.id)).toContain('due');
+    expect(v.rendered.find((e) => e.id === 'ship').value).toBe(NO_FORECAST);
+  });
+});

--- a/tests/unit/daily-review/drive-doc-client.test.js
+++ b/tests/unit/daily-review/drive-doc-client.test.js
@@ -1,0 +1,70 @@
+// SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C (FR-1, FR-2, FR-5) — headless Drive/Docs client.
+// googleapis is fully MOCKED — no live Drive write occurs from the test/build environment.
+import { describe, it, expect } from 'vitest';
+import {
+  loadServiceAccount, buildAuth, createBriefDoc, MissingCredentialError,
+  CHAIRMAN_FOLDER_ID, SCOPES, SECRET_ENV,
+} from '../../../lib/daily-review/drive-doc-client.js';
+
+const VALID_SA = JSON.stringify({ client_email: 'sa@proj.iam.gserviceaccount.com', private_key: '-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----\n' });
+
+// A googleapis-shaped mock that records calls instead of hitting the network.
+function makeMockGoogle() {
+  const calls = { jwt: null, filesCreate: null, batchUpdate: null };
+  const googleLib = {
+    auth: { JWT: class { constructor(opts) { this.opts = opts; calls.jwt = opts; } } },
+    drive: () => ({ files: { create: async (args) => { calls.filesCreate = args; return { data: { id: 'doc123', webViewLink: 'https://docs.google.com/document/d/doc123/edit' } }; } } }),
+    docs: () => ({ documents: { batchUpdate: async (args) => { calls.batchUpdate = args; return { data: {} }; } } }),
+  };
+  return { googleLib, calls };
+}
+
+describe('loadServiceAccount — fail-closed (FR-1)', () => {
+  it('throws MissingCredentialError when the secret is absent', () => {
+    expect(() => loadServiceAccount({})).toThrow(MissingCredentialError);
+    expect(() => loadServiceAccount({ [SECRET_ENV]: '' })).toThrow(MissingCredentialError);
+  });
+  it('throws MissingCredentialError on unparseable JSON or missing fields', () => {
+    expect(() => loadServiceAccount({ [SECRET_ENV]: 'not-json' })).toThrow(MissingCredentialError);
+    expect(() => loadServiceAccount({ [SECRET_ENV]: JSON.stringify({ client_email: 'x' }) })).toThrow(MissingCredentialError);
+  });
+  it('returns creds for a valid service-account JSON', () => {
+    const c = loadServiceAccount({ [SECRET_ENV]: VALID_SA });
+    expect(c.client_email).toMatch(/gserviceaccount\.com$/);
+    expect(c.private_key).toContain('PRIVATE KEY');
+  });
+});
+
+describe('buildAuth — least-privilege scopes (FR-2)', () => {
+  it('constructs a JWT auth client with drive.file + documents scopes only', () => {
+    const { googleLib, calls } = makeMockGoogle();
+    buildAuth({ client_email: 'a@b', private_key: 'k' }, { googleLib });
+    expect(calls.jwt.scopes).toEqual(SCOPES);
+    expect(SCOPES).toContain('https://www.googleapis.com/auth/drive.file');
+    expect(SCOPES).not.toContain('https://www.googleapis.com/auth/drive'); // no broad drive scope
+  });
+});
+
+describe('createBriefDoc — write to the chairman-owned folder (FR-2)', () => {
+  it('creates the Doc under the stamped folder_id and returns id + webViewLink', async () => {
+    const { googleLib, calls } = makeMockGoogle();
+    const out = await createBriefDoc({ title: 'EHG Daily Brief', body: 'hello' }, { env: { [SECRET_ENV]: VALID_SA }, googleLib });
+    expect(out).toEqual({ docId: 'doc123', webViewLink: 'https://docs.google.com/document/d/doc123/edit' });
+    expect(calls.filesCreate.requestBody.parents).toEqual([CHAIRMAN_FOLDER_ID]);
+    expect(calls.filesCreate.requestBody.mimeType).toBe('application/vnd.google-apps.document');
+    expect(calls.batchUpdate.documentId).toBe('doc123'); // body inserted
+  });
+
+  it('skips the docs batchUpdate when there is no body', async () => {
+    const { googleLib, calls } = makeMockGoogle();
+    await createBriefDoc({ title: 'Empty' }, { env: { [SECRET_ENV]: VALID_SA }, googleLib });
+    expect(calls.filesCreate).not.toBeNull();
+    expect(calls.batchUpdate).toBeNull();
+  });
+
+  it('FAILS CLOSED (no API call) when the secret is absent', async () => {
+    const { googleLib, calls } = makeMockGoogle();
+    await expect(createBriefDoc({ title: 'x' }, { env: {}, googleLib })).rejects.toThrow(MissingCredentialError);
+    expect(calls.filesCreate).toBeNull(); // no unauthenticated Drive call was attempted
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C — headless Drive-Doc client (daily-review child C)

Child C of the 5:45 chairman daily-review automation. A cron cannot call the interactive claude.ai MCP the manual brief used, and no Drive/Docs API client existed in-repo (googleapis was wired only for YouTube OAuth).

**Chairman-gate CLEARED** — credential provisioning COMPLETE 2026-07-21 (credential model Option A, Adam advisory `32694579`): SA `ehg-daily-brief-writer@...` created least-privilege with folder-scoped Editor on the chairman-owned folder; `GOOGLE_SERVICE_ACCOUNT_JSON` is a **write-only** GitHub Actions repo secret; Drive + Docs APIs enabled. `do_not_auto_dispatch=false`, `requires_human_action=false`; coordinator-unfenced + dispatch-ranked #1.

### Change (+340 LOC, additive)
- **`lib/daily-review/drive-doc-client.js`** (FR-1/FR-2): service-account-authenticated Drive/Docs client that creates a PRIVATE Doc under the stamped chairman folder_id using least-privilege (`drive.file` + `documents`) scopes. **Fails closed** if the secret is absent — no unauthenticated fallback. `googleLib` injectable for mocking.
- **`lib/daily-review/artifact-preship-gate.js`** (FR-3): pure gate (brief-in / verdict-out, injected forecast accessor) — source-attribution + forecast-dates-**only-from-the-Solomon-engine** (`'no forecast available'` when absent, never an invented date) + render-verify. Blocks delivery on failure.
- **`scripts/daily-review-drive-doc.js`** (FR-4): non-interactive cron/CI entrypoint (STEP-1-VERIFY → gate → write) with `--smoke`.
- **`tests/unit/daily-review/*`** (FR-5): 14 tests, googleapis fully **mocked** — ZERO live Drive writes from the build/CI-unit env.

### Safety
No live Drive writes occur from the LEO build session — the write-only secret exists only in cron/CI. Secret read from env only, never committed/hardcoded/logged (pre-commit secret scan clean). Smoke verified: `--smoke` with the secret unset exits 1 with the fail-closed message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)