### PR TITLE
chore(SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C): wire daily-review-drive-doc entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,6 +453,7 @@
     "review:generate": "node scripts/pipeline/management-review-generator.js",
     "review:history": "node scripts/pipeline/management-review-generator.js --history",
     "review:trigger": "node scripts/eva/management-review-round.mjs",
+    "daily-review:drive-doc": "node scripts/daily-review-drive-doc.js",
     "sd:claim": "node scripts/claude-session-coordinator.mjs claim",
     "sd:release": "node scripts/claude-session-coordinator.mjs release",
     "sd:verify": "node scripts/sd-verify.js",


### PR DESCRIPTION
Follow-up to #6402 (SD-LEO-INFRA-CHAIRMAN-DAILY-REVIEW-DOC-001-C).

Adds an npm script alias so `scripts/daily-review-drive-doc.js` is a **discovered entry point** for `WIRE_CHECK_GATE` (which reads `package.json` scripts). This gives the headless Drive-Doc client a real invocation path — the seam a cron/workflow invokes (`npm run daily-review:drive-doc`) — and transitively makes `lib/daily-review/drive-doc-client.js` + `artifact-preship-gate.js` reachable from the static call graph. The code shipped in #6402 without an entry point; this closes the wiring so it is not dead code.

1-line change (package.json scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)