### PR TITLE
SD-0b: wire real-vs-simulated build_kind tag onto stage_executions (proven by live run)

### DIFF
--- a/lib/eva/build-kind-tag.mjs
+++ b/lib/eva/build-kind-tag.mjs
@@ -1,0 +1,65 @@
+/**
+ * build-kind-tag — SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b).
+ *
+ * Derives a `build_kind: 'real'|'simulated'` fact from the SHIPPED real-build
+ * discriminator (`lib/governance/real-build-discriminator.mjs isRealBuildStarted`)
+ * and merges it ADDITIVELY into a stage_executions.metadata jsonb blob. This is
+ * the emit-at-source tag SD-0a's audit chose `stage_executions.metadata` as the
+ * canonical, additive home for.
+ *
+ * Two pure helpers, zero I/O:
+ *   deriveBuildKind(venture) — 'real' | 'simulated' | null (FAIL-SOFT)
+ *   mergeBuildKind(meta, kind) — additive, idempotent merge into a metadata object
+ *
+ * FAIL-SOFT is the governing invariant: a null/undefined venture or a throwing
+ * discriminator NEVER throws here — it returns null (emit untagged) so a
+ * derivation error can never block or fail a stage. The consumer
+ * (lib/eva/stage-execution-worker.js) keeps its existing non-fatal wrapping.
+ *
+ * @module lib/eva/build-kind-tag
+ */
+
+import { isRealBuildStarted } from '../governance/real-build-discriminator.mjs';
+
+/**
+ * Derive the real-vs-simulated build_kind tag for a venture. Pure, fail-soft.
+ *
+ * build_kind = isRealBuildStarted(venture) ? 'real' : 'simulated'.
+ * Returns null (emit UNTAGGED) when the venture is null/undefined or the
+ * discriminator throws — a derivation error must never surface to the caller.
+ *
+ * @param {{deployment_url?:string|null, repo_url?:string|null, workflow_started_at?:string|null, launch_mode?:string|null}|null|undefined} venture
+ * @returns {'real'|'simulated'|null}
+ */
+export function deriveBuildKind(venture) {
+  if (venture === null || venture === undefined) return null;
+  try {
+    return isRealBuildStarted(venture) ? 'real' : 'simulated';
+  } catch {
+    // FAIL-SOFT: any discriminator error → untagged, never throw.
+    return null;
+  }
+}
+
+/**
+ * Additively merge a build_kind tag into a stage_executions metadata object.
+ * ADDITIVE + IDEMPOTENT: spreads any existing metadata (preserving every other
+ * key), then sets `build_kind`. When `buildKind` is null/undefined the existing
+ * metadata is returned UNCHANGED (tag omitted — never a `build_kind: null` key).
+ * Re-merging the same kind is a no-op for the tag.
+ *
+ * @param {object|null|undefined} existingMetadata - current metadata jsonb (may be null)
+ * @param {'real'|'simulated'|null|undefined} buildKind
+ * @returns {object} a NEW metadata object (never mutates the input)
+ */
+export function mergeBuildKind(existingMetadata, buildKind) {
+  const base =
+    existingMetadata && typeof existingMetadata === 'object' && !Array.isArray(existingMetadata)
+      ? existingMetadata
+      : {};
+  if (buildKind === null || buildKind === undefined) {
+    // Additive-omit: never introduce a null build_kind key; leave metadata as-is.
+    return { ...base };
+  }
+  return { ...base, build_kind: buildKind };
+}

--- a/lib/eva/lifecycle/exit-gate-enforcer.js
+++ b/lib/eva/lifecycle/exit-gate-enforcer.js
@@ -26,6 +26,16 @@
  *   Read once at module-load via process.env. Process restart required to
  *   change state (TR-3).
  *
+ * SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b / FR-3 — gate emission):
+ *   This enforcer does NOT write `stage_executions` (nor any exec-path record) — it only
+ *   READS `venture_stages.metadata.gates` config and writes advisory `system_events` rows
+ *   (EXIT_GATE_ANOMALY / EXIT_GATE_OBSERVE_ONLY). The real-vs-simulated `build_kind` tag is
+ *   therefore emitted at the entry/exit stage_executions writes in
+ *   lib/eva/stage-execution-worker.js (FR-2) — the stage_executions row for the GATED stage
+ *   already carries `metadata.build_kind`, so the gate transition is covered with NO change
+ *   required here. (If this enforcer ever gains its own stage_executions/exec-path write, add
+ *   the additive+fail-soft build_kind merge at that write, mirroring FR-2.)
+ *
  * @module lib/eva/lifecycle/exit-gate-enforcer
  */
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -35,6 +35,10 @@ import {
 import { emit } from './shared-services.js';
 import { checkAutonomy } from './autonomy-model.js';
 import { S20PauseController } from './s20-pause-controller.js';
+// SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b): derive + additively merge the
+// real-vs-simulated build_kind tag onto every stage_executions emission (entry/exit). Both
+// helpers are pure + fail-soft — a derivation error returns null (emit untagged), never throws.
+import { deriveBuildKind, mergeBuildKind } from './build-kind-tag.mjs';
 
 import { hostname } from 'os';
 import { createServer } from 'http';
@@ -2076,6 +2080,14 @@ export class StageExecutionWorker {
   async _createStageExecution(ventureId, stageNumber) {
     try {
       const now = new Date().toISOString();
+      // SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b / FR-1+FR-2): emit-at-source
+      // the real-vs-simulated build_kind tag ADDITIVELY into metadata. The derivation is
+      // fully fail-soft (fetch returns null on any error, deriveBuildKind returns null when
+      // untaggable), and mergeBuildKind omits the key entirely when build_kind is null — so
+      // this NEVER changes the insert's success behavior nor clobbers operating_mode.
+      const venture = await this._fetchVentureBuildSignals(ventureId);
+      const buildKind = deriveBuildKind(venture);
+      const metadata = mergeBuildKind({ operating_mode: getOperatingMode(stageNumber) }, buildKind);
       const { data, error } = await this._supabase
         .from('stage_executions')
         .insert({
@@ -2085,7 +2097,7 @@ export class StageExecutionWorker {
           status: 'running',
           started_at: now,
           heartbeat_at: now,
-          metadata: { operating_mode: getOperatingMode(stageNumber) },
+          metadata,
         })
         .select('id')
         .single();
@@ -2126,14 +2138,34 @@ export class StageExecutionWorker {
    */
   async _finalizeStageExecution(executionId, status, errorMessage) {
     try {
+      const update = {
+        status,
+        completed_at: new Date().toISOString(),
+        heartbeat_at: new Date().toISOString(),
+        error_message: errorMessage,
+      };
+
+      // SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b / FR-2): ensure build_kind is
+      // present on the FINALIZED row's metadata — ADDITIVELY (spread existing metadata, set the
+      // tag, never clobber other keys) and IDEMPOTENTLY (re-finalize re-derives the same value).
+      // Fully fail-soft: any read/derive error leaves the finalize update tag-free. NEVER throws.
+      try {
+        const buildKind = await this._deriveBuildKindForExecution(executionId);
+        if (buildKind !== null) {
+          const { data: existing } = await this._supabase
+            .from('stage_executions')
+            .select('metadata')
+            .eq('id', executionId)
+            .maybeSingle();
+          update.metadata = mergeBuildKind(existing?.metadata, buildKind);
+        }
+      } catch (tagErr) {
+        this._logger.warn(`[Worker] build_kind finalize merge skipped (non-fatal): ${tagErr.message}`);
+      }
+
       const { error } = await this._supabase
         .from('stage_executions')
-        .update({
-          status,
-          completed_at: new Date().toISOString(),
-          heartbeat_at: new Date().toISOString(),
-          error_message: errorMessage,
-        })
+        .update(update)
         .eq('id', executionId);
 
       if (error) {
@@ -2141,6 +2173,56 @@ export class StageExecutionWorker {
       }
     } catch (err) {
       this._logger.warn(`[Worker] stage_executions finalize error: ${err.message}`);
+    }
+  }
+
+  /**
+   * SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b / FR-1): fetch the venture's
+   * real-build signal columns for one stage execution. FAIL-SOFT: returns null on any error
+   * or missing row so the caller emits an untagged (never a throwing) build_kind.
+   *
+   * @param {string} ventureId
+   * @returns {Promise<{deployment_url:string|null, repo_url:string|null, workflow_started_at:string|null, launch_mode:string|null}|null>}
+   */
+  async _fetchVentureBuildSignals(ventureId) {
+    try {
+      if (!ventureId) return null;
+      const { data, error } = await this._supabase
+        .from('ventures')
+        .select('deployment_url, repo_url, workflow_started_at, launch_mode')
+        .eq('id', ventureId)
+        .maybeSingle();
+      if (error) {
+        this._logger.warn(`[Worker] build_kind venture fetch failed (non-fatal): ${error.message}`);
+        return null;
+      }
+      return data ?? null;
+    } catch (err) {
+      this._logger.warn(`[Worker] build_kind venture fetch error (non-fatal): ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b): resolve build_kind for an
+   * EXISTING stage_executions row (finalize path has only the executionId — look up its
+   * venture_id, then derive). FAIL-SOFT: returns null on any error / missing row.
+   *
+   * @param {string} executionId
+   * @returns {Promise<'real'|'simulated'|null>}
+   */
+  async _deriveBuildKindForExecution(executionId) {
+    try {
+      const { data: row, error } = await this._supabase
+        .from('stage_executions')
+        .select('venture_id')
+        .eq('id', executionId)
+        .maybeSingle();
+      if (error || !row?.venture_id) return null;
+      const venture = await this._fetchVentureBuildSignals(row.venture_id);
+      return deriveBuildKind(venture);
+    } catch {
+      return null;
     }
   }
 

--- a/scripts/verify/verify-build-kind-emission.mjs
+++ b/scripts/verify/verify-build-kind-emission.mjs
@@ -1,0 +1,192 @@
+/**
+ * @wire-check-exempt: one-off GROUND-TRUTH live-run verifier for SD-0b
+ *   (SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B). No permanent static import
+ *   chain by design — run on demand from the CLI to prove the real emission path,
+ *   then it stays as the anti-test-masking witness. scripts/verify/ is NOT in the
+ *   wire-check EXCLUSION_PATTERNS, so this marker is required.
+ *
+ * ANTI-TEST-MASKING GROUND-TRUTH PROOF (FR-4). This does NOT mock the insert. It:
+ *   1. Inserts a SAFE fixture venture (TEST- name → fixture-excluded; is_demo=true;
+ *      launch_mode='simulated'; deployment_url/repo_url/workflow_started_at all null →
+ *      build_kind MUST derive to 'simulated').
+ *   2. Instantiates the REAL StageExecutionWorker and calls its REAL
+ *      _createStageExecution(ventureId, stageNumber) — the actual code path that carries
+ *      the tag (a partial invocation of the worker: the exact insert method, not a
+ *      re-implemented insert, and not the full queue-driven poll loop).
+ *   3. Reads the emitted stage_executions row back FROM THE DB and asserts
+ *      metadata.build_kind === 'simulated'. Prints the actual row (ground truth).
+ *   4. Exercises the EXIT path: finalizes the row via the REAL _finalizeStageExecution
+ *      and re-asserts the tag survives (additive + idempotent).
+ *   5. Flips a real-build signal (deployment_url) on the fixture and re-emits via the
+ *      REAL insert to assert 'real' — demonstrating BOTH branches through live code.
+ *   6. TEARS DOWN: deletes emitted stage_executions rows + the fixture venture (reusing
+ *      the shared loud-teardown helper). Leaves the DB clean.
+ *
+ * NEVER touches the protected real ventures (Alt-Text / ApexNiche) — teardown deletes
+ * ONLY by the explicitly captured fixture id, guarded against the protected id set.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { StageExecutionWorker } from '../../lib/eva/stage-execution-worker.js';
+import { teardownFixtureVentures } from '../../tests/helpers/venture-fixture-teardown.mjs';
+
+// Protected real ventures — NEVER delete / mutate these (Alt-Text, ApexNiche).
+const PROTECTED_PREFIXES = ['50763b6a', '809ec7e7'];
+
+const FIXTURE_NAME = 'TEST-build-kind-emission-fixture';
+const STAGE_ENTRY = 5;
+const STAGE_REAL = 6;
+
+// Quiet logger so the worker's non-fatal warnings don't drown the ground-truth output.
+const quietLogger = { log: () => {}, warn: (m) => console.error(`  [worker.warn] ${m}`), error: (m) => console.error(`  [worker.error] ${m}`) };
+
+function assertNotProtected(id) {
+  if (typeof id === 'string' && PROTECTED_PREFIXES.some((p) => id.startsWith(p))) {
+    throw new Error(`REFUSING to touch protected venture ${id}`);
+  }
+}
+
+async function deleteStageExecutions(supabase, ventureId) {
+  assertNotProtected(ventureId);
+  const { error } = await supabase.from('stage_executions').delete().eq('venture_id', ventureId);
+  if (error) throw new Error(`stage_executions teardown failed: ${error.message}`);
+}
+
+/**
+ * Teardown ONE fixture venture. Primary path: the shared LOUD helper
+ * (tests/helpers/venture-fixture-teardown.mjs). RESILIENT fallback: that helper hard-
+ * references FK child tables via a fixed list, and one of them (venture_analysis_artifacts)
+ * is NOT present in this DB's PostgREST schema cache — the helper is designed to THROW on a
+ * missing child table (so a real FK blocker can't hide). To honor the anti-leak invariant
+ * regardless of that schema drift, on helper failure we fall back to a direct venture delete
+ * (this minimal fixture has no FK children other than stage_executions, already deleted).
+ */
+async function teardownFixtureVenture(supabase, ventureId) {
+  assertNotProtected(ventureId);
+  try {
+    await teardownFixtureVentures(supabase, [ventureId]);
+  } catch (helperErr) {
+    console.error(`  [teardown] shared helper failed (${helperErr.message}) — direct-delete fallback`);
+    const { error } = await supabase.from('ventures').delete().eq('id', ventureId);
+    if (error) throw new Error(`fallback venture delete failed: ${error.message}`);
+  }
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+  const supabase = createClient(url, key);
+
+  let ventureId = null;
+  let failed = false;
+
+  try {
+    // ── Pre-clean any leftover fixture from a prior failed run (by exact name only). ──
+    const { data: leftovers } = await supabase.from('ventures').select('id').eq('name', FIXTURE_NAME);
+    for (const v of leftovers ?? []) {
+      assertNotProtected(v.id);
+      await deleteStageExecutions(supabase, v.id);
+      await teardownFixtureVenture(supabase, v.id);
+    }
+
+    // ── 1. Create the SAFE simulated fixture venture. ──
+    const { data: created, error: insErr } = await supabase
+      .from('ventures')
+      .insert([{
+        name: FIXTURE_NAME,
+        description: 'SD-0b ground-truth build_kind emission fixture (auto-torn-down)',
+        problem_statement: 'SD-0b fixture — verifies build_kind emission (auto-torn-down)',
+        // 'paused' (a valid venture_status_enum) so no live worker poll loop can pick up
+        // this short-lived fixture; _createStageExecution does not gate on venture status.
+        status: 'paused',
+        is_demo: true,
+        launch_mode: 'simulated',
+        deployment_url: null,
+        repo_url: null,
+        workflow_started_at: null,
+        current_lifecycle_stage: STAGE_ENTRY,
+      }])
+      .select('id, name, launch_mode, deployment_url, repo_url, workflow_started_at')
+      .single();
+    if (insErr) throw new Error(`fixture venture insert failed: ${insErr.message}`);
+    ventureId = created.id;
+    assertNotProtected(ventureId);
+    console.log(`\n[1] Created fixture venture ${ventureId} (${created.name}, launch_mode=${created.launch_mode}, all real-build signals null)`);
+
+    // ── 2. Invoke the REAL worker insert path. ──
+    const worker = new StageExecutionWorker({ supabase, logger: quietLogger });
+    const execId = await worker._createStageExecution(ventureId, STAGE_ENTRY);
+    if (!execId) throw new Error('REAL _createStageExecution returned null — insert did not land (cannot prove ground truth)');
+    console.log(`[2] REAL worker._createStageExecution(${ventureId}, ${STAGE_ENTRY}) → stage_executions.id=${execId}`);
+
+    // ── 3. Read the emitted row back from the DB and assert 'simulated'. ──
+    const { data: row, error: readErr } = await supabase
+      .from('stage_executions')
+      .select('id, venture_id, lifecycle_stage, status, metadata')
+      .eq('id', execId)
+      .single();
+    if (readErr) throw new Error(`read-back failed: ${readErr.message}`);
+    console.log('[3] GROUND-TRUTH emitted row (read back from DB):');
+    console.log(JSON.stringify(row, null, 2));
+    if (row?.metadata?.build_kind !== 'simulated') {
+      throw new Error(`ASSERTION FAILED: expected metadata.build_kind='simulated', got ${JSON.stringify(row?.metadata?.build_kind)}`);
+    }
+    console.log(`    ✅ ASSERT metadata.build_kind === 'simulated' (and operating_mode preserved: ${JSON.stringify(row.metadata.operating_mode)})`);
+
+    // ── 4. EXIT path: finalize via the REAL method, tag must survive (additive/idempotent). ──
+    await worker._finalizeStageExecution(execId, 'succeeded', null);
+    const { data: finalized } = await supabase
+      .from('stage_executions')
+      .select('status, metadata')
+      .eq('id', execId)
+      .single();
+    console.log(`[4] REAL worker._finalizeStageExecution → status=${finalized?.status}, metadata=${JSON.stringify(finalized?.metadata)}`);
+    if (finalized?.metadata?.build_kind !== 'simulated') {
+      throw new Error(`ASSERTION FAILED (exit): expected build_kind='simulated' after finalize, got ${JSON.stringify(finalized?.metadata?.build_kind)}`);
+    }
+    console.log(`    ✅ ASSERT build_kind survives finalize (additive + idempotent), operating_mode preserved: ${JSON.stringify(finalized.metadata.operating_mode)}`);
+
+    // ── 5. Flip a real-build signal and re-emit → 'real' (both branches, live). ──
+    const { error: updErr } = await supabase
+      .from('ventures')
+      .update({ deployment_url: 'https://fixture.example.app' })
+      .eq('id', ventureId);
+    if (updErr) throw new Error(`fixture deployment_url flip failed: ${updErr.message}`);
+    const execId2 = await worker._createStageExecution(ventureId, STAGE_REAL);
+    const { data: row2 } = await supabase
+      .from('stage_executions')
+      .select('id, metadata')
+      .eq('id', execId2)
+      .single();
+    console.log(`[5] After deployment_url flip → REAL re-emit row: ${JSON.stringify(row2?.metadata)}`);
+    if (row2?.metadata?.build_kind !== 'real') {
+      throw new Error(`ASSERTION FAILED (real branch): expected build_kind='real', got ${JSON.stringify(row2?.metadata?.build_kind)}`);
+    }
+    console.log(`    ✅ ASSERT metadata.build_kind === 'real' on real-signal fixture`);
+
+    console.log('\n✅ GROUND-TRUTH PROOF PASSED: real worker emitted metadata.build_kind for both simulated and real branches.\n');
+  } catch (err) {
+    failed = true;
+    console.error(`\n❌ VERIFY FAILED: ${err.message}\n`);
+  } finally {
+    // ── 6. Teardown — delete emitted rows + fixture venture, by explicit id only. ──
+    if (ventureId) {
+      try {
+        await deleteStageExecutions(supabase, ventureId);
+        await teardownFixtureVenture(supabase, ventureId);
+        console.log(`[6] Teardown complete: stage_executions + fixture venture ${ventureId} deleted. DB clean.`);
+      } catch (teardownErr) {
+        console.error(`⚠️  TEARDOWN FAILED (fixture may leak): ${teardownErr.message}`);
+        failed = true;
+      }
+    }
+  }
+
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/eva/build-kind-emission.test.js
+++ b/tests/unit/eva/build-kind-emission.test.js
@@ -1,0 +1,90 @@
+/**
+ * SD-LEO-INFRA-VENTURE-DATA-CAPTURE-EMISSION-001-B (SD-0b / FR-5).
+ *
+ * Unit coverage for the real-vs-simulated build_kind tag helpers
+ * (lib/eva/build-kind-tag.mjs). Guards the FAIL-SOFT + ADDITIVE + IDEMPOTENT
+ * invariants that the stage-execution-worker emission relies on:
+ *   - deriveBuildKind: 'simulated' (no real-build signals), 'real' (any signal),
+ *     null (null/undefined venture or a throwing discriminator → never throws).
+ *   - mergeBuildKind: preserves every existing metadata key (RED vs a clobbering
+ *     merge), omits the key when build_kind is null, and is idempotent.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveBuildKind, mergeBuildKind } from '../../../lib/eva/build-kind-tag.mjs';
+
+describe('deriveBuildKind (FR-1 fail-soft derivation)', () => {
+  it("returns 'simulated' when no real-build signals are present", () => {
+    expect(
+      deriveBuildKind({
+        launch_mode: 'simulated',
+        deployment_url: null,
+        repo_url: null,
+        workflow_started_at: null,
+      })
+    ).toBe('simulated');
+  });
+
+  it("returns 'real' when deployment_url is set", () => {
+    expect(deriveBuildKind({ launch_mode: 'simulated', deployment_url: 'https://x.app' })).toBe('real');
+  });
+
+  it("returns 'real' when launch_mode === 'live'", () => {
+    expect(deriveBuildKind({ launch_mode: 'live' })).toBe('real');
+  });
+
+  it("returns 'real' when repo_url or workflow_started_at is set", () => {
+    expect(deriveBuildKind({ repo_url: 'https://github.com/x/y' })).toBe('real');
+    expect(deriveBuildKind({ workflow_started_at: '2026-07-22T00:00:00Z' })).toBe('real');
+  });
+
+  it('returns null when venture is null or undefined (fail-soft, emit untagged)', () => {
+    expect(deriveBuildKind(null)).toBeNull();
+    expect(deriveBuildKind(undefined)).toBeNull();
+  });
+
+  it('returns null (never throws) when the venture accessor throws', () => {
+    // A getter that throws simulates a discriminator-side error. Fail-soft must
+    // swallow it and return null rather than propagate.
+    const hostile = {
+      get deployment_url() {
+        throw new Error('boom');
+      },
+    };
+    expect(() => deriveBuildKind(hostile)).not.toThrow();
+    expect(deriveBuildKind(hostile)).toBeNull();
+  });
+});
+
+describe('mergeBuildKind (FR-2 additive + idempotent merge)', () => {
+  it('preserves existing metadata keys while adding build_kind (RED vs a clobbering merge)', () => {
+    const existing = { operating_mode: 'BUILD', trace_id: 'abc' };
+    const merged = mergeBuildKind(existing, 'simulated');
+    expect(merged).toEqual({ operating_mode: 'BUILD', trace_id: 'abc', build_kind: 'simulated' });
+    // additive: original untouched, and the two preserved keys survive.
+    expect(merged.operating_mode).toBe('BUILD');
+    expect(merged.trace_id).toBe('abc');
+  });
+
+  it('does not mutate the input metadata object', () => {
+    const existing = { operating_mode: 'BUILD' };
+    mergeBuildKind(existing, 'real');
+    expect(existing).toEqual({ operating_mode: 'BUILD' });
+    expect(existing.build_kind).toBeUndefined();
+  });
+
+  it('is idempotent — merging the same kind twice yields an equal result', () => {
+    const once = mergeBuildKind({ operating_mode: 'BUILD' }, 'simulated');
+    const twice = mergeBuildKind(once, 'simulated');
+    expect(twice).toEqual(once);
+  });
+
+  it('omits build_kind entirely when kind is null/undefined (never a null key)', () => {
+    expect(mergeBuildKind({ operating_mode: 'BUILD' }, null)).toEqual({ operating_mode: 'BUILD' });
+    expect('build_kind' in mergeBuildKind({ operating_mode: 'BUILD' }, undefined)).toBe(false);
+  });
+
+  it('handles null/non-object existing metadata by starting from an empty object', () => {
+    expect(mergeBuildKind(null, 'real')).toEqual({ build_kind: 'real' });
+    expect(mergeBuildKind(undefined, 'simulated')).toEqual({ build_kind: 'simulated' });
+  });
+});


### PR DESCRIPTION
## Summary
SD-0b (wire child, gated_by SD-0a) of the chairman-greenlit ai-swarm sprint substrate. Wires a `build_kind:'real'|'simulated'` tag — derived from the shipped `lib/governance/real-build-discriminator.mjs` — onto every `stage_executions` emission, in the existing `metadata` jsonb (SD-0a's canonical decision). Additive, no DDL, no parallel table, emit-at-source, idempotent, fail-soft. **Proven by a LIVE run, not a mock.** 453 LOC, 11/11 tests.

## Ground-truth proof (anti-test-masking)
`scripts/verify/verify-build-kind-emission.mjs` created a safe fixture venture (`is_demo`, fixture-name, `launch_mode=simulated`), invoked the **real** `StageExecutionWorker._createStageExecution`/`_finalizeStageExecution`, and read the emitted row back: `metadata.build_kind='simulated'` with `operating_mode` preserved (additive). Flipping `deployment_url` → `build_kind='real'`. Fixture + rows torn down; protected ventures (`50763b6a`, `809ec7e7`) untouched.

## Deliverables
- `lib/eva/build-kind-tag.mjs` — pure `deriveBuildKind()` (fail-soft) + `mergeBuildKind()` (additive).
- `lib/eva/stage-execution-worker.js` — emit at entry (`_createStageExecution`) + exit (`_finalizeStageExecution`), additive/idempotent/fail-soft.
- `lib/eva/lifecycle/exit-gate-enforcer.js` — comment only (it writes no stage_executions; FR-2 entry/exit covers the gate).
- `scripts/verify/verify-build-kind-emission.mjs` — live-run ground-truth verifier.
- `tests/unit/eva/build-kind-emission.test.js` — 11 tests.

## Unblocks
Sprint siblings SD-1 (L3) + SD-3 (L1) — they gate on this real-vs-simulated tag.

## Follow-up flagged
`tests/helpers/venture-fixture-teardown.mjs` (from the hygiene SD) hard-references the ABSENT `venture_analysis_artifacts` table (per SD-0a's audit) and throws — worked around here with a direct-delete fallback; the shared helper needs a fix (flagged as a completion flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)