### PR TITLE
feat(SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A): fleet panel structured data-provider

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,6 +56,7 @@ import stage19Routes from './routes/stage19.js';
 import stage24Routes from './routes/stage24.js';
 import githubRepoRoutes from './routes/github-repo.js';
 import protocolLintRoutes, { requireAdminRole } from './routes/protocol-lint.js';
+import fleetPanelRoutes from './routes/fleet-panel.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
 // Payment webhook handler (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001)
@@ -198,6 +199,8 @@ app.use('/api/github', requireAuth, githubRepoRoutes);
 app.use('/api/admin/protocol-lint', requireAuth, requireAdminRole, protocolLintRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);
+// Fleet panel (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A): read-only, optional auth
+app.use('/api/fleet-panel', optionalAuth, fleetPanelRoutes);
 
 // Story API Routes (with auth)
 app.post('/api/stories/generate', requireAuth, storiesAPI.generate);

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -1,0 +1,90 @@
+/**
+ * Fleet panel API route — SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A
+ *
+ * Structured (non-console) data-provider for the fleet-panel view (mockup #1): manifest-table
+ * rows, per-account capacity chips, and the attention strip. Reuses the existing pure formatters
+ * (lib/fleet/fleet-view-badges.cjs) and read-only helpers (lib/fleet/attention-flag-writer.js) --
+ * scripts/fleet-dashboard.cjs's printWorkers()/printAttentionStrip() are console-only renderers
+ * (return undefined, tied to a module-level supabase singleton) and are deliberately NOT reused.
+ */
+
+import { Router } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { formatCapacityChip, computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
+import { getAttentionFlaggedSessions } from '../../lib/fleet/attention-flag-writer.js';
+import { loadStore } from '../../lib/fleet/account-capacity-gauge.cjs';
+import { getAccountIdentity } from '../../lib/fleet/account-identity.cjs';
+
+const router = Router();
+
+// Resolve a service-role Supabase client. Prefers an injected client
+// (req.app.locals.supabase) so route tests can supply a mock; falls back to a
+// fresh service-role client for the running server. Mirrors server/routes/ventures.js.
+function resolveServiceClient(req) {
+  return (
+    req?.app?.locals?.supabase ||
+    createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+    )
+  );
+}
+
+/** Format a session row from v_active_sessions into the manifest-table shape. */
+function formatSessionRow(row) {
+  const meta = row.metadata || {};
+  const identity = meta.fleet_identity || {};
+  const model = meta.model || '--';
+  const effort = meta.effort || '--';
+  return {
+    session_id: row.session_id,
+    callsign: identity.callsign || null,
+    color: identity.color || null,
+    role: identity.role || null,
+    account: identity.accountUuid8 || null,
+    model_effort: `${model}/${effort}`,
+    status: row.computed_status || 'unknown',
+    sd_key: row.sd_key || null,
+    heartbeat_age_human: row.heartbeat_age_human || null,
+    badge: computeSessionBadge({
+      loopState: meta.loop_state,
+      pAlive: meta.p_alive,
+      isSilent: meta.is_silent,
+      failCount: meta.fail_count,
+    }),
+  };
+}
+
+/**
+ * GET /api/fleet-panel handler — structured fleet-panel state: sessions[], accountChips[],
+ * attentionStrip[]. Never throws on missing/partial data (matches fleet-dashboard.cjs's own
+ * defensive posture). Exported separately (not just registered on the router) so unit tests
+ * can call it directly with mock req/res, without needing supertest or Router internals.
+ */
+export async function getFleetPanel(req, res) {
+  const supabase = resolveServiceClient(req);
+
+  const { data: sessionRows, error: sessionsError } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_key, computed_status, metadata, heartbeat_age_human')
+    .order('heartbeat_age_human', { ascending: true });
+
+  const sessions = sessionsError || !sessionRows ? [] : sessionRows.map(formatSessionRow);
+
+  const store = loadStore();
+  const identity = getAccountIdentity();
+  const accountChips = [formatCapacityChip(identity, store)];
+
+  let attentionStrip = [];
+  try {
+    attentionStrip = await getAttentionFlaggedSessions({ supabase });
+  } catch {
+    attentionStrip = [];
+  }
+
+  res.json({ sessions, accountChips, attentionStrip });
+}
+
+router.get('/', getFleetPanel);
+
+export default router;

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A — fleet panel route unit tests.
+ * Calls the exported handler directly with mock req/res (no supertest, no live DB) --
+ * the injected req.app.locals.supabase seam mirrors server/routes/ventures.js's own pattern.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../lib/fleet/account-capacity-gauge.cjs', () => ({
+  loadStore: vi.fn(() => ({})),
+}));
+vi.mock('../../../lib/fleet/account-identity.cjs', () => ({
+  getAccountIdentity: vi.fn(() => null),
+}));
+
+const { getFleetPanel } = await import('../../../server/routes/fleet-panel.js');
+
+function mockRes() {
+  const res = {};
+  res.json = vi.fn(() => res);
+  return res;
+}
+
+function mockReq(supabase) {
+  return { app: { locals: { supabase } } };
+}
+
+describe('GET /api/fleet-panel', () => {
+  it('returns structured sessions/accountChips/attentionStrip for populated sessions', async () => {
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'v_active_sessions') {
+          return {
+            select: () => ({
+              order: () => Promise.resolve({
+                data: [{
+                  session_id: 'abc-123',
+                  sd_key: 'SD-TEST-001',
+                  computed_status: 'active',
+                  heartbeat_age_human: '5s ago',
+                  metadata: {
+                    fleet_identity: { callsign: 'Golf-3', color: 'blue', role: 'worker' },
+                    model: 'sonnet',
+                    effort: 'xhigh',
+                  },
+                }],
+                error: null,
+              }),
+            }),
+          };
+        }
+        if (table === 'claude_sessions') {
+          return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+        }
+        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+      }),
+    };
+
+    const req = mockReq(supabase);
+    const res = mockRes();
+    await getFleetPanel(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.sessions).toHaveLength(1);
+    expect(payload.sessions[0]).toMatchObject({
+      session_id: 'abc-123',
+      callsign: 'Golf-3',
+      color: 'blue',
+      role: 'worker',
+      model_effort: 'sonnet/xhigh',
+      status: 'active',
+    });
+    expect(Array.isArray(payload.accountChips)).toBe(true);
+    expect(Array.isArray(payload.attentionStrip)).toBe(true);
+  });
+
+  it('degrades missing model/effort metadata to a placeholder, never a crash', async () => {
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'v_active_sessions') {
+          return {
+            select: () => ({
+              order: () => Promise.resolve({
+                data: [{
+                  session_id: 'no-meta-session',
+                  sd_key: null,
+                  computed_status: 'idle',
+                  heartbeat_age_human: '1m ago',
+                  metadata: {},
+                }],
+                error: null,
+              }),
+            }),
+          };
+        }
+        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+      }),
+    };
+
+    const req = mockReq(supabase);
+    const res = mockRes();
+    await getFleetPanel(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.sessions[0].model_effort).toBe('--/--');
+    expect(payload.sessions[0].callsign).toBeNull();
+  });
+
+  it('returns an empty attentionStrip array (not an error) when zero sessions are flagged', async () => {
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'v_active_sessions') {
+          return { select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) };
+        }
+        if (table === 'claude_sessions') {
+          return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+        }
+        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+      }),
+    };
+
+    const req = mockReq(supabase);
+    const res = mockRes();
+    await getFleetPanel(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.attentionStrip).toEqual([]);
+    expect(payload.sessions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/fleet-panel` serving structured JSON (sessions/accountChips/attentionStrip) for the fleet-launcher UI shell's fleet-panel view (mockup #1).
- Reuses existing pure formatters (`lib/fleet/fleet-view-badges.cjs`) and read-only helpers (`lib/fleet/attention-flag-writer.js`) rather than reimplementing badge/chip logic.
- Deliberately does NOT reuse `fleet-dashboard.cjs`'s `printWorkers()`/`printAttentionStrip()` (console-only renderers, confirmed unusable as structured data sources by a LEAD Explore pass).
- Child A of orchestrator SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001 (chairman TOP PRIORITY graphical launcher UI shell).

## Test plan
- [x] 3 new unit tests (populated sessions, missing model/effort placeholder, zero attention-flagged sessions) — all pass
- [x] Full `server/` + `tests/unit/server/` suite: 38/38 pass, no regressions
- [x] Handler exported separately for direct testability (no supertest dependency needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)