### PR TITLE
feat(SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-C): control-verb action buttons (corrected 4-button mapping)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -57,6 +57,7 @@ import stage24Routes from './routes/stage24.js';
 import githubRepoRoutes from './routes/github-repo.js';
 import protocolLintRoutes, { requireAdminRole } from './routes/protocol-lint.js';
 import fleetPanelRoutes from './routes/fleet-panel.js';
+import fleetActionsRoutes from './routes/fleet-actions.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
 // Payment webhook handler (SD-FDBK-FIX-BLOCKING-STRIPE-LIVE-001)
@@ -201,6 +202,9 @@ app.use('/api/admin/protocol-lint', requireAuth, requireAdminRole, protocolLintR
 app.use('/api', optionalAuth, dashboardRoutes);
 // Fleet panel (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A): read-only, optional auth
 app.use('/api/fleet-panel', optionalAuth, fleetPanelRoutes);
+// Fleet action buttons (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-C): can spawn/relaunch real
+// processes -- requireAuth, not optionalAuth (matches the mutating-action convention below).
+app.use('/api/fleet-actions', requireAuth, fleetActionsRoutes);
 
 // Story API Routes (with auth)
 app.post('/api/stories/generate', requireAuth, storiesAPI.generate);

--- a/server/routes/fleet-actions.js
+++ b/server/routes/fleet-actions.js
@@ -1,0 +1,113 @@
+/**
+ * Fleet action-button routes — SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-C
+ *
+ * Surfaces the 4 real design buttons from the ratified mockup-1 image (docs/design/
+ * mockup-1-fleet-launcher.png): "Respawn fleet from manifest", "Relaunch session under other
+ * account", "Add session", "Snapshot manifest". These call the existing spawn-control.js verbs
+ * (many-to-one, not a 1:1 six-verb-as-six-button mapping) plus one genuinely new capability
+ * (snapshot). stop/drainAndRestart are explicitly OUT of this MVP -- the ratified image shows no
+ * per-row context menu or secondary-action affordance for them.
+ */
+
+import { Router } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { spawn, relaunchUnderProfile, isLiveEnabled } from '../../lib/fleet/spawn-control.js';
+import { loadDesiredSlots } from '../../lib/fleet/desired-slots-store.js';
+import { computeLiveSlotDrift } from '../../lib/fleet/session-registry-adapter.js';
+
+const router = Router();
+
+// Resolve a service-role Supabase client. Prefers an injected client
+// (req.app.locals.supabase) so route tests can supply a mock; falls back to a
+// fresh service-role client for the running server. Mirrors server/routes/ventures.js
+// and server/routes/fleet-panel.js.
+function resolveServiceClient(req) {
+  return (
+    req?.app?.locals?.supabase ||
+    createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+    )
+  );
+}
+
+/**
+ * POST /api/fleet-actions/respawn-fleet — "Respawn fleet from manifest".
+ * Compares fleet_desired_slots against live sessions (computeLiveSlotDrift) and spawns only the
+ * missing/stale slots. Reuses spawn()'s own dedup-by-callsign check -- never a second, competing
+ * comparison layer.
+ */
+export async function respawnFleet(req, res) {
+  const supabase = resolveServiceClient(req);
+  const desiredSlots = await loadDesiredSlots(supabase);
+  const drift = await computeLiveSlotDrift(supabase, { desiredSlots });
+
+  const results = [];
+  for (const missingSlot of drift.missing) {
+    const desired = desiredSlots.find((d) => d.name === missingSlot.name) || {};
+    const result = await spawn(
+      { role: desired.role, callsign: missingSlot.name, accountProfile: desired.account_profile },
+      { supabaseClient: supabase },
+    );
+    results.push({ name: missingSlot.name, ...result });
+  }
+
+  res.json({ live: isLiveEnabled(), respawned: results, unchanged: drift.present.length });
+}
+
+/**
+ * POST /api/fleet-actions/relaunch-under-profile — "Relaunch session under other account".
+ * Maps 1:1 to spawn-control.js's relaunchUnderProfile().
+ */
+export async function relaunchSessionUnderProfile(req, res) {
+  const supabase = resolveServiceClient(req);
+  const { target, accountProfile, newSessionId } = req.body || {};
+  if (!target || !accountProfile) {
+    res.status(400).json({ ok: false, reason: 'target and accountProfile are required' });
+    return;
+  }
+  const result = await relaunchUnderProfile(target, accountProfile, { supabaseClient: supabase, newSessionId });
+  res.json({ live: isLiveEnabled(), ...result });
+}
+
+/**
+ * POST /api/fleet-actions/add-session — "Add session".
+ * Maps 1:1 to spawn-control.js's spawn() for a single ad-hoc (non-manifest) session.
+ */
+export async function addSession(req, res) {
+  const supabase = resolveServiceClient(req);
+  const { role, callsign, accountProfile } = req.body || {};
+  if (!role || !callsign) {
+    res.status(400).json({ ok: false, reason: 'role and callsign are required' });
+    return;
+  }
+  const result = await spawn({ role, callsign, accountProfile }, { supabaseClient: supabase });
+  res.json({ live: isLiveEnabled(), ...result });
+}
+
+/**
+ * GET /api/fleet-actions/snapshot-manifest — "Snapshot manifest".
+ * NEW read-only capability (confirmed via repo-wide grep at PLAN phase: no existing function does
+ * this): a timestamped export combining the desired manifest and live-session drift state. Never
+ * mutates fleet_desired_slots or claude_sessions. Degrades to an empty snapshot (never a crash) if
+ * fleet_desired_slots is unapplied -- matches desired-slots-store.js's own fail-soft contract.
+ */
+export async function snapshotManifest(req, res) {
+  const supabase = resolveServiceClient(req);
+  let desiredSlots = [];
+  let drift = { drift: false, missing: [], present: [], unexpected: [] };
+  try {
+    desiredSlots = await loadDesiredSlots(supabase);
+    drift = await computeLiveSlotDrift(supabase, { desiredSlots });
+  } catch {
+    // fail-soft: matches loadDesiredSlots' own contract for a missing/unapplied table
+  }
+  res.json({ snapshot_at: new Date().toISOString(), desiredSlots, drift });
+}
+
+router.post('/respawn-fleet', respawnFleet);
+router.post('/relaunch-under-profile', relaunchSessionUnderProfile);
+router.post('/add-session', addSession);
+router.get('/snapshot-manifest', snapshotManifest);
+
+export default router;

--- a/tests/unit/server/fleet-actions-route.test.js
+++ b/tests/unit/server/fleet-actions-route.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-C — fleet action-button route unit tests.
+ * Mocks lib/fleet/spawn-control.js + desired-slots-store.js + session-registry-adapter.js
+ * directly (already unit-tested elsewhere) so these tests isolate the route's own composition
+ * logic. Calls exported handlers directly with mock req/res, matching Child A's established
+ * fleet-panel-route.test.js pattern -- no supertest, no live DB.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({ live: false }));
+
+vi.mock('../../../lib/fleet/spawn-control.js', () => ({
+  spawn: vi.fn(async ({ role, callsign, accountProfile }) => ({ live: state.live, invocation: { role, callsign, accountProfile } })),
+  relaunchUnderProfile: vi.fn(async (target, accountProfile) => ({ ok: true, role: 'worker', target, accountProfile })),
+  isLiveEnabled: vi.fn(() => state.live),
+}));
+
+vi.mock('../../../lib/fleet/desired-slots-store.js', () => ({
+  loadDesiredSlots: vi.fn(async () => ([
+    { name: 'Golf-3', role: 'worker', account_profile: 'RickFelix' },
+    { name: 'Golf-4', role: 'worker', account_profile: 'RickFelix' },
+  ])),
+}));
+
+vi.mock('../../../lib/fleet/session-registry-adapter.js', () => ({
+  computeLiveSlotDrift: vi.fn(async () => ({
+    drift: true,
+    missing: [{ name: 'Golf-4' }],
+    present: [{ name: 'Golf-3', mismatches: [] }],
+    unexpected: [],
+  })),
+}));
+
+const { respawnFleet, relaunchSessionUnderProfile, addSession, snapshotManifest } = await import('../../../server/routes/fleet-actions.js');
+const { spawn, relaunchUnderProfile } = await import('../../../lib/fleet/spawn-control.js');
+
+function mockRes() {
+  const res = {};
+  res.json = vi.fn(() => res);
+  res.status = vi.fn(() => res);
+  return res;
+}
+
+function mockReq(body = {}) {
+  return { app: { locals: { supabase: {} } }, body };
+}
+
+describe('POST /api/fleet-actions/respawn-fleet', () => {
+  it('spawns only the missing/stale slots, not the already-present ones', async () => {
+    const req = mockReq();
+    const res = mockRes();
+    await respawnFleet(req, res);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ callsign: 'Golf-4', role: 'worker', accountProfile: 'RickFelix' }),
+      expect.anything(),
+    );
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.respawned).toHaveLength(1);
+    expect(payload.unchanged).toBe(1);
+  });
+});
+
+describe('POST /api/fleet-actions/relaunch-under-profile', () => {
+  it('calls relaunchUnderProfile with target + accountProfile', async () => {
+    const req = mockReq({ target: 'Golf-3', accountProfile: 'CodeStreet' });
+    const res = mockRes();
+    await relaunchSessionUnderProfile(req, res);
+
+    expect(relaunchUnderProfile).toHaveBeenCalledWith('Golf-3', 'CodeStreet', expect.anything());
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it('returns 400 when target or accountProfile is missing', async () => {
+    const req = mockReq({ target: 'Golf-3' });
+    const res = mockRes();
+    await relaunchSessionUnderProfile(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('POST /api/fleet-actions/add-session', () => {
+  it('calls spawn with role/callsign/accountProfile', async () => {
+    const req = mockReq({ role: 'worker', callsign: 'Hotel-1', accountProfile: 'DeepSoul' });
+    const res = mockRes();
+    await addSession(req, res);
+
+    expect(spawn).toHaveBeenCalledWith({ role: 'worker', callsign: 'Hotel-1', accountProfile: 'DeepSoul' }, expect.anything());
+  });
+
+  it('returns 400 when role or callsign is missing', async () => {
+    const req = mockReq({ role: 'worker' });
+    const res = mockRes();
+    await addSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('GET /api/fleet-actions/snapshot-manifest', () => {
+  it('returns a read-only snapshot combining desired slots and drift', async () => {
+    const req = mockReq();
+    const res = mockRes();
+    await snapshotManifest(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.desiredSlots).toHaveLength(2);
+    expect(payload.drift.missing).toEqual([{ name: 'Golf-4' }]);
+    expect(typeof payload.snapshot_at).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `server/routes/fleet-actions.js` exposing the 4 real design buttons from the ratified mockup-1 image: **Respawn fleet from manifest** (bulk, via `computeLiveSlotDrift`), **Relaunch session under other account** (`relaunchUnderProfile`), **Add session** (`spawn`), **Snapshot manifest** (new read-only export).
- Corrects the original decomposition-time assumption of a 1:1 six-spawn-control-verb-as-six-button mapping — the real mockup shows a different 4-button set (caught by an independent worker image review, confirmed by Solomon).
- `stop`/`drainAndRestart` are explicitly scoped OUT of this MVP — the ratified image shows no per-row context menu or secondary-action affordance for them (named exclusion, tracked as a follow-up, not silently dropped).
- Child C of orchestrator SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001 (chairman TOP PRIORITY graphical launcher UI shell).

## Test plan
- [x] 6 new unit tests (respawn-fleet selective spawning, relaunch-under-profile + 400 validation, add-session + 400 validation, snapshot-manifest read-only export) — all pass
- [x] Full `server/` + `tests/unit/server/` suite: 44/44 pass, no regressions
- [x] Reuses `computeLiveSlotDrift` (existing primitive, found via VALIDATION sub-agent review) rather than hand-rolling the manifest-vs-live comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)