### PR TITLE
feat(SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D): fleet panel — 3 named-account chips + design status vocabulary

### DIFF
--- a/lib/fleet/account-capacity-gauge.cjs
+++ b/lib/fleet/account-capacity-gauge.cjs
@@ -97,6 +97,40 @@ function bestHeadroomAccount(store) {
   return ranked.length > 0 ? ranked[0] : null;
 }
 
+// SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D (FR-1/FR-2): the fleet-panel (mockup-1) shows THREE
+// named-account capacity chips, one per Max account the fleet rotates across. Matching is
+// NAME-BASED (against each store entry's orgName), NOT UUID-based: the real accountUuid8 values
+// for Rick Felix / Code Street are not reliably knowable — only Deep Soul (ca1de6e4) is a known
+// fixture — so we deliberately do NOT invent canonical UUIDs here.
+const NAMED_ACCOUNT_REGISTRY = [
+  { name: 'Deep Soul', match: /deep\s*soul/i },
+  { name: 'Rick Felix', match: /rick\s*felix/i },
+  { name: 'CodeStreet', match: /code\s*street/i },
+];
+
+/**
+ * Build the fleet-panel's THREE named-account capacity chips (mockup-1 / FR-1/FR-2).
+ *
+ * Always returns EXACTLY 3 chips (one per canonical account) so all three render even when the
+ * store is empty or partial. For each registry entry, the first store entry whose `orgName`
+ * matches the entry's regex supplies the reading; wkPct is the rounded binding weekly % used
+ * (see bindingWeeklyPct — the higher of the two weekly meters), or null ('wk --%') when this
+ * fleet has no matching reading yet.
+ *
+ * @param {object} store - loadStore() result (keyed by accountUuid8)
+ * @returns {Array<{name:string, wkPct:number|null}>} exactly 3 chips
+ */
+function buildNamedAccountChips(store) {
+  const entries = Object.values(store || {});
+  return NAMED_ACCOUNT_REGISTRY.map(({ name, match }) => {
+    const entry = entries.find(
+      (e) => e && typeof e.orgName === 'string' && match.test(e.orgName),
+    );
+    const wkPct = entry ? Math.round(bindingWeeklyPct(entry)) : null;
+    return { name, wkPct };
+  });
+}
+
 module.exports = {
   DEFAULT_STORE_PATH,
   loadStore,
@@ -104,4 +138,5 @@ module.exports = {
   bindingWeeklyPct,
   rankAccountsByHeadroom,
   bestHeadroomAccount,
+  buildNamedAccountChips,
 };

--- a/lib/fleet/fleet-view-badges.cjs
+++ b/lib/fleet/fleet-view-badges.cjs
@@ -30,18 +30,66 @@ function formatCapacityChip(identity, store) {
 }
 
 /**
- * Roll up already-rendered per-session columns into one glance token.
- * @param {{loopState?: string|null, pAlive?: number|null, isSilent?: boolean, failCount?: number}} row
- * @returns {'SILENT'|'STRUGGLING'|'STALLED'|'HEALTHY'|'UNKNOWN'}
+ * Roll up already-known per-session fields into one design-vocab glance token
+ * (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D / FR-3, mockup-1). Replaces the old
+ * SILENT/STRUGGLING/STALLED/HEALTHY/UNKNOWN vocabulary.
+ *
+ * DESIGN VOCABULARY — exactly these 7 labels:
+ *   WORKING        — alive and doing work (the default for a live session with a signal)
+ *   AWAITING INPUT — alive but silent (in a silent-until window → waiting on input)
+ *   DEEP WORK      — working on the heaviest tier (model === 'opus' AND effort high/xhigh)
+ *   IDLE           — loop_state === 'idle' (a sublabel, e.g. dwell reason, is out of scope
+ *                    for this pass — note only, not derived)
+ *   MECHANICAL     — PROXY: model === 'haiku' OR effort === 'low'. There is no dedicated
+ *                    "mechanical work" signal, so the cheap model/effort tier stands in for it.
+ *   PILOT WK1      — PLACEHOLDER: emitted ONLY when an explicit role === 'pilot' is passed.
+ *                    There is NO real pilot-session signal source in the codebase today (the
+ *                    only 'pilot' token is claim-eligibility.cjs's `pilot_throwaway`, a VENTURE
+ *                    flag — not a session/account role), so in practice this is never emitted.
+ *                    Do NOT fabricate one; wire this to a real pilot-session role when it exists.
+ *   OFF            — released/stopped/offline, or p_alive < 0.2, or no signal at all (the safe
+ *                    default that replaces the old UNKNOWN).
+ *
+ * Still a swappable rollup (same call site + string-return contract) — SD-E's
+ * classifyWatchdogState() can replace it later without a PRD amendment. Widened to also accept
+ * {computedStatus, role, model, effort}; every field is optional with a graceful default so
+ * existing callers passing only the original signals still get a valid label. (Legacy `failCount`
+ * is still accepted but no longer influences the label — STRUGGLING was retired.)
+ *
+ * @param {{loopState?:string|null, pAlive?:number|null, isSilent?:boolean, failCount?:number,
+ *   computedStatus?:string|null, role?:string|null, model?:string|null, effort?:string|null}} row
+ * @returns {'WORKING'|'AWAITING INPUT'|'DEEP WORK'|'IDLE'|'MECHANICAL'|'PILOT WK1'|'OFF'}
  */
-function computeSessionBadge({ loopState, pAlive, isSilent, failCount } = {}) {
-  if (isSilent) return 'SILENT';
-  if (Number(failCount) > 3) return 'STRUGGLING';
-  if (typeof pAlive === 'number' && Number.isFinite(pAlive)) {
-    return pAlive < 0.4 ? 'STALLED' : 'HEALTHY';
-  }
-  if (!loopState || loopState === 'unknown') return 'UNKNOWN';
-  return 'HEALTHY';
+function computeSessionBadge({
+  loopState, pAlive, isSilent, computedStatus, role, model, effort,
+} = {}) {
+  const pAliveNum = typeof pAlive === 'number' && Number.isFinite(pAlive) ? pAlive : null;
+
+  // OFF (highest priority): explicitly released/stopped/offline, or a decisively low p_alive.
+  if (['released', 'stopped', 'offline'].includes(computedStatus)) return 'OFF';
+  if (pAliveNum !== null && pAliveNum < 0.2) return 'OFF';
+
+  // PILOT WK1 is a design-vocab placeholder — derived ONLY from an explicit role === 'pilot'
+  // (never fabricated; there is no real pilot-session signal source yet).
+  if (role === 'pilot') return 'PILOT WK1';
+
+  // IDLE — loop_state says idle (sublabel/dwell-reason intentionally out of scope this pass).
+  if (loopState === 'idle') return 'IDLE';
+
+  // AWAITING INPUT — alive but silent = waiting on input.
+  if (isSilent) return 'AWAITING INPUT';
+
+  // MECHANICAL — PROXY for cheap/mechanical work via the model/effort tier.
+  if (model === 'haiku' || effort === 'low') return 'MECHANICAL';
+
+  // DEEP WORK — heaviest model/effort tier.
+  if (model === 'opus' && (effort === 'xhigh' || effort === 'high')) return 'DEEP WORK';
+
+  // No signal at all (no loop_state, no finite p_alive, no computed_status) → OFF is the safe
+  // default (replaces the old UNKNOWN).
+  if (!loopState && pAliveNum === null && !computedStatus) return 'OFF';
+
+  return 'WORKING';
 }
 
 module.exports = { formatCapacityChip, computeSessionBadge };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -518,9 +518,10 @@ function printWorkers(d) {
   } else {
     const csidHeader = hasCollision ? pad('CSID', 12) : '';
     const mcHeader = mcOk ? pad('P(alive)', 16) : '';
-    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('LoopState', 14) + pad('Badge', 12) + pad('Model/Effort', 16) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
+    console.log('  ' + pad('Terminal', 12) + csidHeader + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + pad('LoopState', 14) + pad('Badge', 14) + pad('Model/Effort', 16) + pad('Activity', 18) + pad('Silent until', 14) + mcHeader + 'Heartbeat');
     // SD-LEO-INFRA-LOOP-STATE-SIGNAL-001: LoopState column (14 chars) added between WIP and Activity → 14-char wider separator.
-    console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 150 : 134) : (mcOk ? 138 : 122)));
+    // SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D: Badge column widened 12→14 ('AWAITING INPUT' is 14 chars) → each separator width +2.
+    console.log('  ' + '─'.repeat(hasCollision ? (mcOk ? 152 : 136) : (mcOk ? 140 : 124)));
     for (const s of d.activeSessions) {
       // QF-20260704-737: d.children is scoped to ONE orchestrator's children — every other worker's
       // Progress always read as 0. d.sdStatusMap already covers any sd_key a worker is claiming.
@@ -550,9 +551,14 @@ function printWorkers(d) {
         pAlive: mcRow ? mcRow.p_alive : null,
         isSilent: Boolean(silent),
         failCount: s.handoff_fail_count,
+        // SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D: enrich with the design-vocab inputs when present;
+        // all are optional (graceful defaults) so the console render works even without them.
+        computedStatus: s.computed_status,
+        model: s.model,
+        effort: s.effort,
       });
       const modelEffortChip = formatModelEffortChip(s);
-      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(loopCell, 14) + pad(badge, 12) + pad(modelEffortChip, 16) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
+      console.log('  ' + pad(s.tty, 12) + csid + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + pad(loopCell, 14) + pad(badge, 14) + pad(modelEffortChip, 16) + pad(activity, 18) + pad(silent, 14) + mcCell + s.heartbeat_age_human + struggleTag);
     }
   }
 

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -10,10 +10,9 @@
 
 import { Router } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { formatCapacityChip, computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
+import { computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
 import { getAttentionFlaggedSessions } from '../../lib/fleet/attention-flag-writer.js';
-import { loadStore } from '../../lib/fleet/account-capacity-gauge.cjs';
-import { getAccountIdentity } from '../../lib/fleet/account-identity.cjs';
+import { loadStore, buildNamedAccountChips } from '../../lib/fleet/account-capacity-gauge.cjs';
 
 const router = Router();
 
@@ -51,6 +50,10 @@ function formatSessionRow(row) {
       pAlive: meta.p_alive,
       isSilent: meta.is_silent,
       failCount: meta.fail_count,
+      computedStatus: row.computed_status,
+      role: identity.role,
+      model,
+      effort,
     }),
   };
 }
@@ -71,9 +74,9 @@ export async function getFleetPanel(req, res) {
 
   const sessions = sessionsError || !sessionRows ? [] : sessionRows.map(formatSessionRow);
 
-  const store = loadStore();
-  const identity = getAccountIdentity();
-  const accountChips = [formatCapacityChip(identity, store)];
+  // FR-1/FR-2: three named-account capacity chips (mockup-1) — always exactly 3, even when the
+  // capacity store is empty/partial (unmatched accounts render 'wk --%').
+  const accountChips = buildNamedAccountChips(loadStore());
 
   let attentionStrip = [];
   try {

--- a/tests/unit/fleet/account-capacity-gauge.test.js
+++ b/tests/unit/fleet/account-capacity-gauge.test.js
@@ -19,6 +19,7 @@ const {
   bindingWeeklyPct,
   rankAccountsByHeadroom,
   bestHeadroomAccount,
+  buildNamedAccountChips,
 } = require('../../../lib/fleet/account-capacity-gauge.cjs');
 
 const DEEPSOUL = { email: 'deepsoulsessionslabel@gmail.com', orgName: "Deep Soul Sessions's Organization", accountUuid8: 'ca1de6e4' };
@@ -117,5 +118,48 @@ describe('rankAccountsByHeadroom / bestHeadroomAccount (pure)', () => {
 
   it('bestHeadroomAccount returns null for an empty store', () => {
     expect(bestHeadroomAccount({})).toBeNull();
+  });
+});
+
+describe('buildNamedAccountChips (pure — mockup-1 FR-1/FR-2)', () => {
+  it('returns EXACTLY 3 named chips (Deep Soul / Rick Felix / CodeStreet), all null, for an empty store', () => {
+    const chips = buildNamedAccountChips({});
+    expect(chips).toHaveLength(3);
+    expect(chips.map((c) => c.name)).toEqual(['Deep Soul', 'Rick Felix', 'CodeStreet']);
+    expect(chips.every((c) => c.wkPct === null)).toBe(true);
+  });
+
+  it('still returns 3 chips (all null) for an undefined/null store, never throwing', () => {
+    expect(buildNamedAccountChips(undefined)).toHaveLength(3);
+    expect(buildNamedAccountChips(null).every((c) => c.wkPct === null)).toBe(true);
+  });
+
+  it('carries the rounded binding weekly % for orgName-matched accounts; unmatched stay null', () => {
+    // Store keyed by ARBITRARY uuid8 (no invented canonical UUIDs) — matching is by orgName regex.
+    const store = {
+      deadbeef: { orgName: "Deep Soul Sessions's Organization", weeklyAllModelsPct: 53, weeklyFablePct: 80 }, // binding 80
+      feedface: { orgName: "Rick Felix 2000's Organization", weeklyAllModelsPct: 27.4, weeklyFablePct: 12 },  // binding 27.4 -> 27
+      // no Code Street entry present
+    };
+    expect(buildNamedAccountChips(store)).toEqual([
+      { name: 'Deep Soul', wkPct: 80 },
+      { name: 'Rick Felix', wkPct: 27 },
+      { name: 'CodeStreet', wkPct: null },
+    ]);
+  });
+
+  it('matches orgName loosely on case/spacing (e.g. "CodeStreet Labs" -> CodeStreet)', () => {
+    const store = { aa11bb22: { orgName: 'CodeStreet Labs', weeklyAllModelsPct: 10, weeklyFablePct: 5 } };
+    const chips = buildNamedAccountChips(store);
+    expect(chips.find((c) => c.name === 'CodeStreet').wkPct).toBe(10);
+    expect(chips.find((c) => c.name === 'Deep Soul').wkPct).toBeNull();
+    expect(chips.find((c) => c.name === 'Rick Felix').wkPct).toBeNull();
+  });
+
+  it('ignores store entries with a missing/non-string orgName without throwing', () => {
+    const store = { x: { weeklyAllModelsPct: 99 }, y: { orgName: 42, weeklyAllModelsPct: 88 } };
+    const chips = buildNamedAccountChips(store);
+    expect(chips).toHaveLength(3);
+    expect(chips.every((c) => c.wkPct === null)).toBe(true);
   });
 });

--- a/tests/unit/fleet/fleet-view-badges.test.js
+++ b/tests/unit/fleet/fleet-view-badges.test.js
@@ -23,30 +23,70 @@ describe('formatCapacityChip', () => {
   });
 });
 
-describe('computeSessionBadge', () => {
-  it('returns SILENT when the session is in a silent-until window', () => {
-    expect(computeSessionBadge({ isSilent: true, pAlive: 0.9 })).toBe('SILENT');
+describe('computeSessionBadge (design vocab — SD-...-SHELL-001-D / mockup-1 FR-3)', () => {
+  const RETIRED = ['SILENT', 'STRUGGLING', 'STALLED', 'HEALTHY', 'UNKNOWN'];
+
+  it('returns WORKING for a live working session (default)', () => {
+    expect(computeSessionBadge({ loopState: 'looping', pAlive: 0.95 })).toBe('WORKING');
   });
 
-  it('returns STRUGGLING when handoff failures exceed the threshold', () => {
-    expect(computeSessionBadge({ failCount: 4, pAlive: 0.9 })).toBe('STRUGGLING');
+  it('returns AWAITING INPUT when alive but silent (waiting on input)', () => {
+    expect(computeSessionBadge({ isSilent: true, pAlive: 0.9, loopState: 'looping' })).toBe('AWAITING INPUT');
   });
 
-  it('returns STALLED when P(alive) is low', () => {
-    expect(computeSessionBadge({ pAlive: 0.1 })).toBe('STALLED');
+  it('returns DEEP WORK for the heaviest model/effort tier (opus + high/xhigh)', () => {
+    expect(computeSessionBadge({ loopState: 'looping', model: 'opus', effort: 'xhigh' })).toBe('DEEP WORK');
+    expect(computeSessionBadge({ loopState: 'looping', model: 'opus', effort: 'high' })).toBe('DEEP WORK');
   });
 
-  it('returns HEALTHY when P(alive) is high', () => {
-    expect(computeSessionBadge({ pAlive: 0.95 })).toBe('HEALTHY');
+  it("returns IDLE when loop_state is 'idle'", () => {
+    expect(computeSessionBadge({ loopState: 'idle', pAlive: 0.9 })).toBe('IDLE');
   });
 
-  it('falls back to loop_state when P(alive) is unavailable (MC disabled)', () => {
-    expect(computeSessionBadge({ loopState: 'looping' })).toBe('HEALTHY');
-    expect(computeSessionBadge({ loopState: 'unknown' })).toBe('UNKNOWN');
-    expect(computeSessionBadge({ loopState: null })).toBe('UNKNOWN');
+  it('returns MECHANICAL for the cheap/mechanical proxy (model=haiku OR effort=low)', () => {
+    expect(computeSessionBadge({ loopState: 'looping', model: 'haiku' })).toBe('MECHANICAL');
+    expect(computeSessionBadge({ loopState: 'looping', effort: 'low' })).toBe('MECHANICAL');
   });
 
-  it('SILENT takes priority over STRUGGLING and STALLED', () => {
-    expect(computeSessionBadge({ isSilent: true, failCount: 10, pAlive: 0.01 })).toBe('SILENT');
+  it('returns OFF for released/stopped/offline status', () => {
+    expect(computeSessionBadge({ computedStatus: 'released' })).toBe('OFF');
+    expect(computeSessionBadge({ computedStatus: 'stopped' })).toBe('OFF');
+    expect(computeSessionBadge({ computedStatus: 'offline' })).toBe('OFF');
+  });
+
+  it('returns OFF when P(alive) is decisively low (< 0.2)', () => {
+    expect(computeSessionBadge({ pAlive: 0.1, loopState: 'looping' })).toBe('OFF');
+  });
+
+  it('returns OFF when there is no signal at all (safe default that replaces old UNKNOWN)', () => {
+    expect(computeSessionBadge({})).toBe('OFF');
+    expect(computeSessionBadge()).toBe('OFF');
+    expect(computeSessionBadge({ loopState: null, pAlive: null })).toBe('OFF');
+  });
+
+  it("emits PILOT WK1 ONLY for an explicit role:'pilot' (design placeholder — no real signal source)", () => {
+    expect(computeSessionBadge({ role: 'pilot' })).toBe('PILOT WK1');
+    // Any non-pilot role (or absent role) never yields PILOT WK1.
+    expect(computeSessionBadge({ role: 'worker', loopState: 'looping' })).not.toBe('PILOT WK1');
+    expect(computeSessionBadge({ loopState: 'looping' })).not.toBe('PILOT WK1');
+  });
+
+  it('OFF takes priority over every other signal', () => {
+    expect(
+      computeSessionBadge({ computedStatus: 'stopped', isSilent: true, model: 'opus', effort: 'xhigh', role: 'pilot' })
+    ).toBe('OFF');
+  });
+
+  it('NEGATIVE: never returns any of the 5 retired vocab words for any input', () => {
+    const inputs = [
+      {}, undefined,
+      { isSilent: true }, { failCount: 4 }, { pAlive: 0.1 }, { pAlive: 0.95 },
+      { loopState: 'looping' }, { loopState: 'unknown' }, { loopState: 'idle' },
+      { model: 'opus', effort: 'high' }, { model: 'haiku' }, { effort: 'low' },
+      { role: 'pilot' }, { computedStatus: 'released' }, { computedStatus: 'active' },
+    ];
+    for (const input of inputs) {
+      expect(RETIRED).not.toContain(computeSessionBadge(input));
+    }
   });
 });

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -5,12 +5,12 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../../../lib/fleet/account-capacity-gauge.cjs', () => ({
-  loadStore: vi.fn(() => ({})),
-}));
-vi.mock('../../../lib/fleet/account-identity.cjs', () => ({
-  getAccountIdentity: vi.fn(() => null),
-}));
+// loadStore is mocked to an empty store (no FS); buildNamedAccountChips is the REAL pure
+// function (via importActual) so the route genuinely renders exactly 3 named chips.
+vi.mock('../../../lib/fleet/account-capacity-gauge.cjs', async (importActual) => {
+  const actual = await importActual();
+  return { ...actual, loadStore: vi.fn(() => ({})) };
+});
 
 const { getFleetPanel } = await import('../../../server/routes/fleet-panel.js');
 
@@ -70,7 +70,11 @@ describe('GET /api/fleet-panel', () => {
       model_effort: 'sonnet/xhigh',
       status: 'active',
     });
+    // FR-1/FR-2: exactly 3 named-account chips render (empty store → all wkPct null).
     expect(Array.isArray(payload.accountChips)).toBe(true);
+    expect(payload.accountChips).toHaveLength(3);
+    expect(payload.accountChips.map((c) => c.name)).toEqual(['Deep Soul', 'Rick Felix', 'CodeStreet']);
+    expect(payload.accountChips.every((c) => c.wkPct === null)).toBe(true);
     expect(Array.isArray(payload.attentionStrip)).toBe(true);
   });
 


### PR DESCRIPTION
## SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-D — fleet-panel mockup-1 conformance

Fast-follow child of SHELL-001, closing 2 coverage-diff gaps in the fleet panel Child A shipped (PR #6408), per Solomon (correlation 0c25f5ab). Owned under the parent acceptance boundary — no racing side-QF.

### Changes (7 files, +221/−41)
- **`lib/fleet/account-capacity-gauge.cjs`**: new pure `buildNamedAccountChips(store)` + a **name-based** `NAMED_ACCOUNT_REGISTRY` (Deep Soul / Rick Felix / CodeStreet). Always returns exactly 3 `{name, wkPct}` chips — matched to the store by `orgName` regex, placeholder `wk --%` when no reading. Sidesteps inventing `accountUuid8` values that aren't reliably knowable. `formatCapacityChip` left untouched.
- **`server/routes/fleet-panel.js`**: `accountChips = buildNamedAccountChips(loadStore())` (was a single current-account chip); badge call enriched with `computed_status/role/model/effort`.
- **`lib/fleet/fleet-view-badges.cjs`**: `computeSessionBadge` rewritten to the design vocabulary **WORKING / AWAITING INPUT / DEEP WORK / IDLE / MECHANICAL / PILOT WK1 / OFF** (widened inputs, graceful defaults). MECHANICAL is a documented proxy (haiku/low); **PILOT WK1** is a documented placeholder (no live pilot-session signal exists — emitted only for explicit `role:'pilot'`).
- **`scripts/fleet-dashboard.cjs`**: Badge column `pad(...,12)→14` + separators (the console shares `computeSessionBadge`; "AWAITING INPUT" is 14 chars).

### Verification
**836 tests pass** (full `tests/unit/fleet/` + route). TESTING (`bca63aa1`) + SECURITY (`3b571c66`, PASS — chip exposes only name+wk%, not emails; `optionalAuth` unchanged) both PASS. Handoffs: LEAD-TO-PLAN 95, PLAN-TO-EXEC 100, EXEC-TO-PLAN 96, PLAN-TO-LEAD 96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)