### PR TITLE
fix(QF-20260722-851): corrective-finding sdType has no mapToDbType synonym

### DIFF
--- a/lib/sd-creation/pipeline.js
+++ b/lib/sd-creation/pipeline.js
@@ -358,6 +358,7 @@ export function mapToDbType(userType) {
     orch: 'orchestrator',
     qa: 'infrastructure',       // QF-251: 'qa' rejected by DB → infrastructure
     testing: 'infrastructure',  // QF-251: was 'qa', same rejection class
+    corrective: 'infrastructure', // QF-20260722-851: 'corrective' rejected by DB, no canonical type was ever added for it
     spike: 'discovery_spike',
     discovery_spike: 'discovery_spike',
     ux_debt: 'ux_debt',

--- a/scripts/__tests__/leo-create-sd-mapper.test.js
+++ b/scripts/__tests__/leo-create-sd-mapper.test.js
@@ -67,6 +67,12 @@ describe('QF-251 MAPPER-5: existing mappings preserved', () => {
   it('orch → orchestrator', () => { expect(probeMapper('orch')).toBe('orchestrator'); });
 });
 
+describe('QF-20260722-851 MAPPER-7: corrective maps to infrastructure (was corrective, rejected by DB)', () => {
+  it('returns infrastructure for corrective input', () => {
+    expect(probeMapper('corrective')).toBe('infrastructure');
+  });
+});
+
 describe('QF-251 MAPPER-6: the canonical sd_type list (now lib/sd-type-enum.js) excludes stale qa/library/fix', () => {
   it('CANONICAL_SD_TYPES aligns with the DB sd_type_check constraint', () => {
     // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: VALID_DB_SD_TYPES moved out of leo-create-sd.js into

--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -60,13 +60,16 @@ export function _isKnownDimensionKey(key) {
 }
 
 // SD type and priority per tier
-// Root Cause 2 fix: Use 'corrective' instead of 'feature' for gap-closure/escalation
-// Corrective type has 70% gate threshold (vs 85% for feature), lighter validation
+// Root Cause 2 fix: Use 'infrastructure' instead of 'feature' for gap-closure/escalation
+// (QF-20260722-851: 'corrective' was never added as a canonical sd_type / DB CHECK value,
+// so mapToDbType rejected it and every corrective-typed promote threw -- 10/14 rows stuck,
+// zero ever promoted. 'infrastructure' is the mapToDbType-valid type these gap-closure /
+// escalation rows resolve to anyway; category stays 'corrective' for labeling.)
 const TIER_CONFIG = {
   accept:      { action: 'accept',      sdType: null,            priority: null },
   minor:       { action: 'minor',       sdType: 'enhancement',   priority: 'medium' },
-  'gap-closure': { action: 'gap-closure', sdType: 'corrective',  priority: 'high' },
-  escalation:  { action: 'escalation',  sdType: 'corrective',    priority: 'critical' },
+  'gap-closure': { action: 'gap-closure', sdType: 'infrastructure', priority: 'high' },
+  escalation:  { action: 'escalation',  sdType: 'infrastructure',  priority: 'critical' },
 };
 
 // Orchestrator parent UUID (SD-MAN-ORCH-EVA-VISION-GOVERNANCE-001)
@@ -681,10 +684,12 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
   }
 
   // Groups to process: V-dims → corrective SD; A-dims → infrastructure SD; other → corrective SD
+  // (sdType is always a mapToDbType-valid value; category:'corrective' is retained as the
+  // human-facing label -- see QF-20260722-851)
   const groups = [
-    { dims: vDims,    sdType: 'corrective',       category: 'corrective',      label: 'Vision' },
+    { dims: vDims,    sdType: 'infrastructure',   category: 'corrective',      label: 'Vision' },
     { dims: aDims,    sdType: 'infrastructure',   category: 'infrastructure',  label: 'Architecture' },
-    { dims: otherDims, sdType: tier.sdType ?? 'corrective', category: tier.sdType ?? 'corrective', label: 'Vision' },
+    { dims: otherDims, sdType: tier.sdType ?? 'infrastructure', category: 'corrective', label: 'Vision' },
   ].filter(g => g.dims.length > 0);
 
   // Fall back to single lowest-dimension if no weak dims found (e.g. empty dimension_scores)
@@ -692,8 +697,8 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     const { dimId, dimensionName } = _extractLowestDimension(score.dimension_scores, score.total_score);
     groups.push({
       dims: [{ dimId, dimensionName, score: score.total_score }],
-      sdType: tier.sdType ?? 'corrective',
-      category: tier.sdType ?? 'corrective',
+      sdType: tier.sdType ?? 'infrastructure',
+      category: 'corrective',
       label: 'Vision',
     });
   }


### PR DESCRIPTION
## Summary
- `corrective-sd-generator.mjs` emitted `sd_type='corrective'`, a design-intent type never added to the DB CHECK constraint / `CANONICAL_SD_TYPES`
- `mapToDbType` had no synonym for it, so every corrective-typed feedback promotion (`corrective-triage.mjs promote`) threw `Invalid sd_type: corrective`
- Verified: 10 of 14 `category='corrective_finding'` feedback rows carry the broken type; zero have ever been promoted — this pathway has likely never worked
- Fix: add `corrective -> infrastructure` synonym to `mapToDbType` (mirrors existing `qa`/`testing` precedent) so both frozen metadata and future writes resolve, no DB migration needed; also updated the generator's own literals to emit `infrastructure` directly (category stays `corrective` for labeling)

## Test plan
- [x] `scripts/__tests__/leo-create-sd-mapper.test.js` — 11/11 pass (added new synonym test case)
- [x] All 8 `corrective-sd-generator*` test files — 136/136 pass, zero regressions
- [x] Manually re-ran `corrective-triage.mjs promote` against a real stuck row — the original crash is gone; a different, correctly-functioning scope-boundary guardrail now evaluates it as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)