### PR TITLE
fix(SD-LEO-INFRA-RECONCILE-EHG-REPO-001): advance_venture_stage RPC reads venture_stages.gate_type SSOT

### DIFF
--- a/database/migrations/20260722_DOWN_stage_advancement_advance_venture_stage_gate_type_ssot.sql
+++ b/database/migrations/20260722_DOWN_stage_advancement_advance_venture_stage_gate_type_ssot.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- DOWN Migration (DEFAULT / PREFERRED): data-level partial revert for
+--                 advance_venture_stage's SSOT-based gate check.
+-- SD: SD-LEO-INFRA-RECONCILE-EHG-REPO-001 (incident mitigation)
+-- Date: 2026-07-22
+--
+-- PURPOSE: If the SSOT-based gate check causes an incident (e.g. a chairman-
+-- approval backlog blocks a fleet of ventures newly gated at S10/S16/S19/S25),
+-- this is the DEFAULT, PREFERRED rollback lever: relax ONLY the newly-enforced
+-- promotion gates by setting their gate_type to 'none' in the SSOT. This is a
+-- pure data change — the fixed RPC code (SSOT read + 23/24 label fix) stays
+-- intact, so the confirmed-active bypass and the 23/24 label swap are NOT
+-- reopened.
+--
+-- Per security-agent finding (sub_agent_execution_results
+-- 24319524-85a9-4614-b019-7246d4f9bede): reverting to the pre-fix RPC CODE is
+-- NEVER an acceptable steady state, because it restores a confirmed-exploited
+-- authorization bypass (6 of 45 historical advances from these stages already
+-- had no approved chairman decision). If the incident is "too many ventures
+-- newly blocked", the fix is to relax the DATA (this file), not the CODE.
+--
+-- This SSOT-level relaxation also affects fn_advance_venture_stage and all
+-- frontend derived views/hooks (they all read the same venture_stages table)
+-- -- which is the point: one SSOT, one lever.
+--
+-- A separate, genuinely-last-resort full-function code revert (only for the
+-- scenario where the NEW CODE ITSELF is broken, not merely "too many ventures
+-- blocked") is provided in:
+--   20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
+-- Do not reach for that file for an approval-backlog incident -- use this one.
+--
+-- Idempotent: UPDATE ... WHERE, safe to re-run.
+-- =============================================================================
+
+-- Re-open ONLY the newly-enforced promotion gates (10, 16, 19, 25). Run this
+-- during an incident to immediately stop new blocking at these 4 stages.
+UPDATE venture_stages
+  SET gate_type = 'none'
+  WHERE stage_number IN (10, 16, 19, 25);
+
+-- ---------------------------------------------------------------------------
+-- Self-verification: confirm the relaxation landed and nothing else moved.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_relaxed_count INTEGER;
+  v_other_gates_intact INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_relaxed_count
+    FROM venture_stages
+    WHERE stage_number IN (10, 16, 19, 25) AND gate_type = 'none';
+  ASSERT v_relaxed_count = 4, 'partial-revert: expected all 4 stages (10,16,19,25) relaxed to gate_type=none';
+
+  SELECT COUNT(*) INTO v_other_gates_intact
+    FROM venture_stages
+    WHERE stage_number IN (3, 5, 13, 23) AND gate_type = 'kill';
+  ASSERT v_other_gates_intact = 4, 'partial-revert: kill gates (3,5,13,23) must remain intact';
+END
+$verify$;
+
+-- ---------------------------------------------------------------------------
+-- RESTORE (when the approval backlog clears / the incident is resolved):
+-- Re-apply the canonical promotion classification to close the gates again.
+-- Uncomment and run when ready to restore full enforcement:
+--
+--   UPDATE venture_stages SET gate_type = 'promotion'
+--   WHERE stage_number IN (10, 16, 19, 25);
+-- ---------------------------------------------------------------------------

--- a/database/migrations/20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
+++ b/database/migrations/20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
@@ -1,8 +1,9 @@
+-- @chairman-gated
 -- =============================================================================
 -- EMERGENCY-ONLY Full Code Revert: advance_venture_stage(uuid,int,int,text)
 --                 back to its pre-SD-LEO-INFRA-RECONCILE-EHG-REPO-001 LIVE def.
 -- SD: SD-LEO-INFRA-RECONCILE-EHG-REPO-001
--- Date: 2026-07-22
+-- Date: 2026-07-24
 --
 -- !!! DO NOT USE THIS FOR AN APPROVAL-BACKLOG / "TOO MANY VENTURES BLOCKED"
 -- !!! INCIDENT. Use the data-level partial revert instead:

--- a/database/migrations/20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
+++ b/database/migrations/20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
@@ -1,0 +1,215 @@
+-- =============================================================================
+-- EMERGENCY-ONLY Full Code Revert: advance_venture_stage(uuid,int,int,text)
+--                 back to its pre-SD-LEO-INFRA-RECONCILE-EHG-REPO-001 LIVE def.
+-- SD: SD-LEO-INFRA-RECONCILE-EHG-REPO-001
+-- Date: 2026-07-22
+--
+-- !!! DO NOT USE THIS FOR AN APPROVAL-BACKLOG / "TOO MANY VENTURES BLOCKED"
+-- !!! INCIDENT. Use the data-level partial revert instead:
+-- !!!   20260722_DOWN_stage_advancement_advance_venture_stage_gate_type_ssot.sql
+--
+-- This file is a genuine last resort, reserved ONLY for the scenario where the
+-- NEW RPC CODE ITSELF is broken (e.g. a syntax/logic defect causes advance_
+-- venture_stage to error or misbehave for ALL callers, not just newly-gated
+-- ones) and a forward-fix cannot land fast enough.
+--
+-- WARNING -- applying this REOPENS a CONFIRMED, ALREADY-EXPLOITED authorization
+-- bypass: gate_type='promotion' stages 10/16/19/25 lose ALL chairman-gate
+-- enforcement again (6 of 45 historical advances from these stages already had
+-- no approved chairman decision -- see the forensic query in this SD's PRD,
+-- acceptance artifact TS-7), and the 23/24 gate_type response labels re-swap
+-- (kill/promotion reversed vs the venture_stages SSOT).
+-- Per security-agent (sub_agent_execution_results 24319524-85a9-4614-b019-
+-- 7246d4f9bede): restoring this code is NEVER an acceptable steady state. If
+-- you reach for this file, open an incident ticket, get explicit chairman
+-- sign-off, and treat it as time-boxed -- revert to the fixed def the moment
+-- the forward-fix is ready.
+--
+-- Restores the EXACT function body that was LIVE before this SD (retrieved
+-- 2026-07-22 via pg_get_functiondef, identical to 20260704_stage_advancement_
+-- advance_venture_stage_artifact_gate.sql) -- hardcoded arrays
+-- kill=[3,5,13,24], promotion=[17,18,23], all=[3,5,13,17,18,23,24], with the
+-- artifact-precondition block intact.
+--
+-- Idempotent: CREATE OR REPLACE.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.advance_venture_stage(p_venture_id uuid, p_from_stage integer, p_to_stage integer, p_transition_type text DEFAULT 'normal'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  v_kill_gates INTEGER[] := ARRAY[3, 5, 13, 24];
+  v_promotion_gates INTEGER[] := ARRAY[17, 18, 23];
+  v_all_gates INTEGER[] := ARRAY[3, 5, 13, 17, 18, 23, 24];
+  v_gate_decision RECORD;
+  v_gate_decision_id UUID := NULL;
+  v_idempotency UUID;
+  v_precondition JSONB;
+BEGIN
+  IF NOT (public.fn_is_service_role() OR public.fn_is_chairman()
+          OR public.fn_user_has_venture_access(p_venture_id)) THEN
+    RAISE EXCEPTION 'access denied: venture access required (SD-MAN-FIX-SECURITY-GUARD-PACK-001)';
+  END IF;
+
+  SELECT current_lifecycle_stage, name
+    INTO v_current_stage, v_venture_name
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'venture_not_found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'stage_mismatch',
+      'current_stage', v_current_stage,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_to_stage',
+      'to_stage', p_to_stage
+    );
+  END IF;
+
+  IF p_from_stage = ANY(v_all_gates) THEN
+    SELECT id, decision, status INTO v_gate_decision
+      FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+        AND decision IN ('pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release')
+      ORDER BY created_at DESC
+      LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_not_approved',
+        'gate_stage', p_from_stage,
+        'gate_type', CASE
+          WHEN p_from_stage = ANY(v_kill_gates) THEN 'kill'
+          WHEN p_from_stage = ANY(v_promotion_gates) THEN 'promotion'
+          ELSE 'unknown'
+        END,
+        'message', format('Chairman approval required at stage %s before advancing', p_from_stage)
+      );
+    END IF;
+
+    v_gate_decision_id := v_gate_decision.id;
+  END IF;
+
+  v_precondition := public.fn_stage_artifact_precondition(p_venture_id, p_from_stage);
+  IF (v_precondition->>'blocked')::boolean THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'artifact_precondition_unmet',
+      'missing_artifacts', v_precondition->'missing_artifacts',
+      'deviated_artifacts', v_precondition->'deviated_artifacts',
+      'source', v_precondition->>'source',
+      'venture_id', p_venture_id,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  UPDATE venture_stage_work
+    SET stage_status = 'completed',
+        completed_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_from_stage;
+
+  UPDATE ventures
+    SET current_lifecycle_stage = p_to_stage,
+        updated_at = NOW()
+    WHERE id = p_venture_id;
+
+  UPDATE venture_stage_work
+    SET stage_status = 'in_progress',
+        started_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_to_stage;
+
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_from_stage, 'STAGE_COMPLETE',
+    jsonb_build_object('advanced_to', p_to_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_to_stage, 'STAGE_ENTRY',
+    jsonb_build_object('advanced_from', p_from_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  v_idempotency := uuid_generate_v5(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    p_venture_id::text || ':' || p_from_stage::text || ':' || p_to_stage::text
+      || ':' || COALESCE(
+        (SELECT COUNT(*)::text FROM venture_stage_transitions
+         WHERE venture_id = p_venture_id
+           AND from_stage = p_from_stage
+           AND to_stage = p_to_stage),
+        '0')
+  );
+
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, p_transition_type,
+    'system:advance', jsonb_build_object(
+      'gate_decision_id', v_gate_decision_id,
+      'venture_name', v_venture_name
+    ), v_idempotency
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage,
+    'transition_type', p_transition_type,
+    'gate_created', false,
+    'idempotency_key', v_idempotency
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'venture_id', p_venture_id,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage
+  );
+END;
+$function$;
+
+-- Self-verification: confirm the emergency revert restored the hardcoded arrays.
+DO $verify$
+DECLARE
+  v_def TEXT;
+BEGIN
+  v_def := pg_get_functiondef('public.advance_venture_stage(uuid,integer,integer,text)'::regprocedure);
+  ASSERT v_def LIKE '%v_all_gates INTEGER[] := ARRAY[3, 5, 13, 17, 18, 23, 24]%', 'emergency revert: hardcoded v_all_gates not restored';
+  ASSERT v_def LIKE '%fn_stage_artifact_precondition%', 'emergency revert: artifact-precondition block missing';
+END
+$verify$;

--- a/database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql
+++ b/database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql
@@ -1,0 +1,294 @@
+-- =============================================================================
+-- Migration: advance_venture_stage(uuid,int,int,text) -- converge hard-gate
+--            membership onto the venture_stages SSOT (delete hardcoded arrays)
+-- SD: SD-LEO-INFRA-RECONCILE-EHG-REPO-001
+-- Date: 2026-07-22
+-- Design-informed-by: DESIGN sub_agent_execution_results 44e48a95-91b2-4ae9-9097-d9a1d808523f
+--                     (CONDITIONAL_PASS@88, conditions #4 + #5 hand this migration to DATABASE)
+--
+-- STATUS: STAGED — NOT self-applied. Per the chairman-gated migration convention
+-- (SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001) applying this is a
+-- separate, explicit chairman GO decision. NEVER self-apply via apply-migration.js
+-- --prod-deploy. This migration has a NON-ZERO behavior change (see BEHAVIOR
+-- DELTA below) and a documented deploy-time blast radius — the pre-deploy census
+-- query at the bottom MUST be run and its result reviewed before GO.
+--
+-- BUG being fixed (docs/architecture; DESIGN DSN-C2 / DSN-W2):
+--   The LIVE advance_venture_stage hardcodes gate membership as three literal
+--   arrays: v_kill_gates=[3,5,13,24], v_promotion_gates=[17,18,23],
+--   v_all_gates=[3,5,13,17,18,23,24]. This diverges from the ratified SSOT
+--   (per-stage venture_stages.gate_type, retired chairman_dashboard_config.
+--   hard_gate_stages on 2026-05-12 per SD-LEO-REFAC-GATE-AUTO-ADVANCE-001) in
+--   two independent ways:
+--     (1) OMISSION: gate_type='promotion' stages 10, 16, 19, 25 are absent from
+--         v_all_gates, so frontend-initiated advances FROM those stages (via
+--         src/lib/ventures/advanceStage.ts + ventureWorkflowBootstrap.ts in the
+--         ehg repo, both -> supabase.rpc('advance_venture_stage')) get ZERO
+--         chairman-gate enforcement today. This is an ACTIVE bypass, not a
+--         future risk.
+--     (2) LABEL SWAP: the response gate_type field labels stage 24 as 'kill' and
+--         stage 23 as 'promotion'; the SSOT says 23=kill, 24=promotion. Swapped.
+--   The sibling function fn_advance_venture_stage(uuid,int,int,jsonb,uuid) (EVA
+--   daemon path, migration 20260716_high_consequence_stage_gates.sql) ALREADY
+--   reads venture_stages per-stage correctly and is the reference implementation
+--   mirrored here. It is NOT in this SD's scope.
+--
+-- FIX (3 deltas vs the LIVE def; everything else preserved verbatim):
+--   DELTA 1 (DECLARE): delete v_kill_gates / v_promotion_gates / v_all_gates
+--     literals; add `v_gate_type TEXT;`.
+--   DELTA 2 (gate block): replace `IF p_from_stage = ANY(v_all_gates)` with a
+--     single-row PK read of venture_stages.gate_type for p_from_stage (fresh per
+--     call, FOR SHARE — byte-identical to what fn_advance_venture_stage already
+--     does; DESIGN DSN-R3: NO cache/materialization, that is exactly the
+--     staleness that let hard_gate_stages drift). Enforce iff
+--     gate_type IN ('kill','promotion').
+--   DELTA 3 (response): set the gate_not_approved response 'gate_type' field
+--     directly from the venture_stages column (v_gate_type), replacing the
+--     CASE-over-hardcoded-arrays expression. This is what corrects the 23/24
+--     label swap — the label now comes from the SSOT.
+--
+--   PRESERVED VERBATIM (no regression): access guard, ventures FOR UPDATE lock,
+--   venture_not_found / stage_mismatch / invalid_to_stage guards, the approved
+--   chairman_decisions lookup + decision-verb allow-list, v_gate_decision_id
+--   NULL-for-non-gate handling (SD-LEO-FIX-FIX-ADVANCE-VENTURE-001,
+--   20260606_fix_advance_venture_stage_nongate.sql), the artifact-precondition
+--   block (fn_stage_artifact_precondition, SD-LEO-INFRA-STAGE-ADVANCEMENT-
+--   ARTIFACT-001), stage_events emits, uuid_generate_v5 idempotency, the
+--   transitions INSERT with ON CONFLICT DO NOTHING, and the EXCEPTION handler.
+--
+-- BEHAVIOR DELTA (DESIGN DSN-R7 — this is NOT behavior-neutral):
+--   * S10/S16/S19/S25: chairman promotion-gate enforcement BEGINS (bypass closed).
+--   * S23: response gate_type corrects to 'kill' (was 'promotion').
+--   * S24: response gate_type corrects to 'promotion' (was 'kill').
+--   * S3/S5/S13 (kill) and S17/S18 (promotion): UNCHANGED — still enforced.
+--   Note: high-consequence-hold + review_mode='review' gate parity with
+--   fn_advance_venture_stage is DELIBERATELY OUT OF SCOPE here (would newly block
+--   review-mode stages 7/8/9/11/21/22 — a far larger blast radius than this SD's
+--   PRD enumerated). Residual divergence logged as follow-up (DESIGN DSN-W3).
+--
+-- BASIS: This CREATE OR REPLACE was built from the LIVE definition retrieved via
+--   pg_get_functiondef('public.advance_venture_stage(uuid,integer,integer,text)'
+--   ::regprocedure) on 2026-07-22 (kill=[3,5,13,24] promotion=[17,18,23]
+--   all=[3,5,13,17,18,23,24], artifact-precondition block present) — NOT from any
+--   stale on-disk migration.
+-- Idempotent: CREATE OR REPLACE. Rollback levers provided separately:
+--   PREFERRED (data-level, incident default):
+--     20260722_DOWN_stage_advancement_advance_venture_stage_gate_type_ssot.sql
+--   EMERGENCY-ONLY (full code revert, only if the new code itself is broken):
+--     20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.advance_venture_stage(p_venture_id uuid, p_from_stage integer, p_to_stage integer, p_transition_type text DEFAULT 'normal'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  -- DELTA 1: hardcoded gate arrays removed; gate membership now read per-stage
+  --          from the venture_stages SSOT (SD-LEO-INFRA-RECONCILE-EHG-REPO-001).
+  v_gate_type TEXT;
+  v_gate_decision RECORD;
+  v_gate_decision_id UUID := NULL;  -- NULL for non-gate stages (20260606)
+  v_idempotency UUID;
+  v_precondition JSONB;
+BEGIN
+  IF NOT (public.fn_is_service_role() OR public.fn_is_chairman()
+          OR public.fn_user_has_venture_access(p_venture_id)) THEN
+    RAISE EXCEPTION 'access denied: venture access required (SD-MAN-FIX-SECURITY-GUARD-PACK-001)';
+  END IF;
+
+  SELECT current_lifecycle_stage, name
+    INTO v_current_stage, v_venture_name
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'venture_not_found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'stage_mismatch',
+      'current_stage', v_current_stage,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_to_stage',
+      'to_stage', p_to_stage
+    );
+  END IF;
+
+  -- DELTA 2: gate membership from the venture_stages SSOT (fresh per call, no
+  -- cache), mirroring fn_advance_venture_stage. A missing/unknown row defaults
+  -- to 'none' (no gate) — fail-open only for stages absent from the canonical
+  -- 26-stage table, which cannot occur for a valid p_from_stage.
+  SELECT COALESCE(gate_type, 'none') INTO v_gate_type
+    FROM venture_stages
+    WHERE stage_number = p_from_stage
+    FOR SHARE;
+  v_gate_type := COALESCE(v_gate_type, 'none');
+
+  IF v_gate_type IN ('kill', 'promotion') THEN
+    SELECT id, decision, status INTO v_gate_decision
+      FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+        AND decision IN ('pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release')
+      ORDER BY created_at DESC
+      LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_not_approved',
+        'gate_stage', p_from_stage,
+        -- DELTA 3: label straight from the SSOT column (fixes the 23/24 swap).
+        'gate_type', v_gate_type,
+        'message', format('Chairman approval required at stage %s before advancing', p_from_stage)
+      );
+    END IF;
+
+    v_gate_decision_id := v_gate_decision.id;
+  END IF;
+
+  -- Artifact-precondition check (SD-LEO-INFRA-STAGE-ADVANCEMENT-ARTIFACT-001,
+  -- FR-3) — preserved verbatim, runs for gate and non-gate stages alike.
+  v_precondition := public.fn_stage_artifact_precondition(p_venture_id, p_from_stage);
+  IF (v_precondition->>'blocked')::boolean THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'artifact_precondition_unmet',
+      'missing_artifacts', v_precondition->'missing_artifacts',
+      'deviated_artifacts', v_precondition->'deviated_artifacts',
+      'source', v_precondition->>'source',
+      'venture_id', p_venture_id,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  UPDATE venture_stage_work
+    SET stage_status = 'completed',
+        completed_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_from_stage;
+
+  UPDATE ventures
+    SET current_lifecycle_stage = p_to_stage,
+        updated_at = NOW()
+    WHERE id = p_venture_id;
+
+  UPDATE venture_stage_work
+    SET stage_status = 'in_progress',
+        started_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_to_stage;
+
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_from_stage, 'STAGE_COMPLETE',
+    jsonb_build_object('advanced_to', p_to_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_to_stage, 'STAGE_ENTRY',
+    jsonb_build_object('advanced_from', p_from_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  v_idempotency := uuid_generate_v5(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    p_venture_id::text || ':' || p_from_stage::text || ':' || p_to_stage::text
+      || ':' || COALESCE(
+        (SELECT COUNT(*)::text FROM venture_stage_transitions
+         WHERE venture_id = p_venture_id
+           AND from_stage = p_from_stage
+           AND to_stage = p_to_stage),
+        '0')
+  );
+
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, p_transition_type,
+    'system:advance', jsonb_build_object(
+      'gate_decision_id', v_gate_decision_id,
+      'venture_name', v_venture_name
+    ), v_idempotency
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage,
+    'transition_type', p_transition_type,
+    'gate_created', false,
+    'idempotency_key', v_idempotency
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'venture_id', p_venture_id,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.advance_venture_stage(uuid, integer, integer, text) IS
+'Frontend-initiated venture stage advance (src/lib/ventures/advanceStage.ts,
+ventureWorkflowBootstrap.ts). Gate membership is read per-stage from the
+venture_stages.gate_type SSOT (SD-LEO-INFRA-RECONCILE-EHG-REPO-001) — the
+hardcoded kill/promotion arrays were deleted; they had omitted promotion gates
+10/16/19/25 (an active bypass) and mislabeled 23/24. Enforces an approved
+chairman_decisions row when gate_type IN (kill,promotion). Preserves the
+artifact-precondition check (SD-LEO-INFRA-STAGE-ADVANCEMENT-ARTIFACT-001) and the
+non-gate v_gate_decision_id NULL handling (SD-LEO-FIX-FIX-ADVANCE-VENTURE-001).
+review_mode and high-consequence-hold parity with fn_advance_venture_stage is
+intentionally out of scope here (see DESIGN DSN-W3 follow-up).';
+
+-- ---------------------------------------------------------------------------
+-- Self-verification: fail the deploy if the arrays did not get deleted, if the
+-- SSOT read did not land, or if any preserved behavior regressed.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_def TEXT;
+BEGIN
+  v_def := pg_get_functiondef('public.advance_venture_stage(uuid,integer,integer,text)'::regprocedure);
+  -- Arrays are gone
+  ASSERT v_def NOT LIKE '%v_kill_gates%',       'advance_venture_stage: v_kill_gates literal not deleted';
+  ASSERT v_def NOT LIKE '%v_promotion_gates%',  'advance_venture_stage: v_promotion_gates literal not deleted';
+  ASSERT v_def NOT LIKE '%v_all_gates%',        'advance_venture_stage: v_all_gates literal not deleted';
+  ASSERT v_def NOT LIKE '%ARRAY[3, 5, 13%',     'advance_venture_stage: a hardcoded gate array survived';
+  -- SSOT read landed
+  ASSERT v_def LIKE '%FROM venture_stages%',    'advance_venture_stage: venture_stages SSOT read missing';
+  ASSERT v_def LIKE '%v_gate_type IN (''kill'', ''promotion'')%', 'advance_venture_stage: gate_type enforcement branch missing';
+  -- Preserved behavior (no regression)
+  ASSERT v_def LIKE '%gate_not_approved%',              'advance_venture_stage: gate check regressed';
+  ASSERT v_def LIKE '%fn_stage_artifact_precondition%', 'advance_venture_stage: artifact-precondition regressed';
+  ASSERT v_def LIKE '%artifact_precondition_unmet%',    'advance_venture_stage: artifact error code regressed';
+  ASSERT v_def LIKE '%v_gate_decision_id%',             'advance_venture_stage: non-gate NULL handling regressed';
+END
+$verify$;

--- a/database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql
+++ b/database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql
@@ -1,3 +1,4 @@
+-- @chairman-gated
 -- =============================================================================
 -- Migration: advance_venture_stage(uuid,int,int,text) -- converge hard-gate
 --            membership onto the venture_stages SSOT (delete hardcoded arrays)

--- a/docs/architecture/stage-advancement-path-census.md
+++ b/docs/architecture/stage-advancement-path-census.md
@@ -18,7 +18,7 @@ Every function/code path found (via full-estate grep, not a hand-picked list) th
 |---|------|----------|--------------|-------|
 | 1 | `fn_advance_venture_stage` | `database/migrations/20260704_chairman_product_review_gate_scoped_precondition_fixture_bypass.sql` | **GATED** | The chokepoint. Reads `venture_stages.required_artifacts` (canonical) with a `stage_artifact_requirements` legacy fallback; also enforces `chairman_decisions` review/kill/promotion gates and the 23->24 product-review gate. |
 | 2 | `rescan_stage_20` | `database/migrations/20260530_rescan_stage20_reason.sql` | **BYPASSED (staged fix, chairman-gated, FR-3)** | Raw `UPDATE ventures SET current_lifecycle_stage = 21` after checking only SD-completion + `deployment_url`. Never reads artifacts. Amendment migration staged, not applied. |
-| 3 | `advance_venture_stage(uuid,int,int,text)` | `database/migrations/20260611_guard_pack_secdef_fns.sql` | **BYPASSED (staged fix, chairman-gated, FR-3)** | Enforces chairman kill/promotion gate arrays but zero artifact check. Amendment migration staged, not applied. |
+| 3 | `advance_venture_stage(uuid,int,int,text)` | `database/migrations/20260704_stage_advancement_advance_venture_stage_artifact_gate.sql` (live artifact check, shipped) + `database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql` (staged, chairman-gated, SD-LEO-INFRA-RECONCILE-EHG-REPO-001) | **PARTIALLY FIXED (artifact check live; gate-array SSOT fix staged, chairman-gated)** | Artifact-precondition check now live (closed by the 20260704 migration referenced in this row, superseding this row's original "zero artifact check" note). Separately, the chairman kill/promotion gate enforcement itself was hardcoded (`v_kill_gates`/`v_promotion_gates`/`v_all_gates` SQL arrays) and had drifted from the `venture_stages.gate_type` SSOT — omitting promotion gates 10/16/19/25 entirely (a confirmed-active, forensically-proven-exploited bypass: 6 of 45 historical advances from those stages had no approved chairman decision) and swapping the 23/24 kill/promotion labels. `20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql` replaces the 3 hardcoded arrays with a per-call SSOT read; staged only, requires a separate chairman GO before production apply (with a pre-deploy census + forensic-query artifact attached to that request). |
 | 4 | `advance_venture_to_stage(uuid,int,text,text)` | `database/migrations/20260611_guard_pack_secdef_fns.sql` | **BYPASSED (staged fix, chairman-gated, FR-3)** | Only validates `p_target_stage = current+1` and an access guard -- zero gate/artifact check whatsoever. Used by the sibling EHG app's `advanceStage.ts`/`BuildMethodSelector.tsx`/`LeoBridgeBuildPanel.tsx`. Amendment migration staged, not applied. |
 | 5 | `lib/eva/stage-execution-worker.js::_advanceStage` | JS, daemon walk | **FIXED (this SD, FR-2, ships normally)** | The daemon-walk's single side-effecting advance for ALL stages, called from 8+ call sites. Was a raw `.update()` with zero artifact check -- the most consequential bypass (the MarketLens incident's root cause). Now calls `checkStageArtifactPrecondition()` (an independent JS mirror of the RPC's artifact-check logic, reusing `deviation-ledger.js` for documented skips) before the raw update. |
 | 6 | `lib/eva/saga-coordinator.js::createStageCompensation` | JS, saga rollback | **DELIBERATELY EXEMPT** | Revert-only compensation write (moves `current_lifecycle_stage` back to a previous stage on rollback), never a forward advance. Out of scope by definition -- reverting never needs an artifact precondition. |
@@ -173,6 +173,29 @@ re-examined specifically for whether they write to the NEWLY-gated stages (3/19/
   no-re-entry assumption would need re-examination before it can be relied on for
   `ventures`-side logic. Documented as an open risk, not resolved here (same "needs its own
   investigation" disposition as 2026-07-04).
+
+## Post-census addition (2026-07-24)
+
+**`database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql`**
+(SD-LEO-INFRA-RECONCILE-EHG-REPO-001) — amends path #3 (`advance_venture_stage(uuid,int,int,text)`).
+Discovery: the chairman kill/promotion gate check that path #3's original entry credited as working
+("enforces chairman kill/promotion gate arrays") was itself running on 3 hardcoded SQL arrays
+(`v_kill_gates`/`v_promotion_gates`/`v_all_gates`) that had drifted from the ratified
+`venture_stages.gate_type` SSOT — omitting promotion gates 10/16/19/25 entirely. This is a confirmed-
+active, forensically-proven-exploited authorization bypass (a query against
+`venture_stage_transitions` joined to `chairman_decisions` found 6 of 45 historical advances FROM
+those 4 stages had no approved decision, including 3 named real ventures: DataDistill, CronGenius at
+Stage 19; Market Modeling SaaS at Stage 16), not merely a code-hygiene issue. The migration deletes the
+3 arrays and reads `venture_stages.gate_type` per-call instead, mirroring how path #1
+(`fn_advance_venture_stage`) already reads the SSOT. Also fixes an independent 23/24 kill/promotion
+label swap in the same function's response. STAGED ONLY — chairman-gated per
+SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001, same convention as path #3's original
+FR-3 amendment; requires a separate chairman GO with the pre-deploy census and forensic-query results
+attached. A companion `20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql` restores
+the pre-fix function body as a genuine last resort ONLY (never the default incident lever — the
+default rollback is a data-level `UPDATE venture_stages SET gate_type='none'` for the 4 affected
+stages, which does not reopen the confirmed bypass). Disposition: staged amendment to path #3, same
+class as the original FR-3 entry.
 
 ## Disposition summary
 

--- a/scripts/lint/stage-advancement-chokepoint-allowlist.json
+++ b/scripts/lint/stage-advancement-chokepoint-allowlist.json
@@ -47,6 +47,8 @@
     "database/migrations/20260611_fix_advance_stage_required_artifacts_cast.sql",
     "database/migrations/20260704_chairman_product_review_gate_scoped_precondition.sql",
     "database/migrations/20260716_high_consequence_stage_gates.sql",
-    "database/migrations/20260722_high_consequence_actuation_completeness.sql"
+    "database/migrations/20260722_high_consequence_actuation_completeness.sql",
+    "database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql",
+    "database/migrations/20260722_EMERGENCY_ONLY_full_code_revert_advance_venture_stage.sql"
   ]
 }

--- a/tests/unit/database/migrations/advance-venture-gate-type-ssot.db.test.js
+++ b/tests/unit/database/migrations/advance-venture-gate-type-ssot.db.test.js
@@ -1,0 +1,270 @@
+/**
+ * Regression test for advance_venture_stage(uuid,integer,integer,text) — the
+ * SSOT gate-type fix (SD-LEO-INFRA-RECONCILE-EHG-REPO-001,
+ * 20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql).
+ *
+ * BUG BEING FIXED: the LIVE function hardcodes gate membership as
+ * v_kill_gates=[3,5,13,24], v_promotion_gates=[17,18,23],
+ * v_all_gates=[3,5,13,17,18,23,24] — omitting promotion-gate stages 10, 16,
+ * 19, 25 entirely (a confirmed-active chairman-gate bypass) and swapping the
+ * 23/24 kill/promotion labels versus the venture_stages.gate_type SSOT.
+ *
+ * The migration is chairman-gated (SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-
+ * GATED-EXEMPT-001) and MUST NOT be applied to production by this suite. To
+ * prove the fix without ever touching the live definition, this test applies
+ * the migration's CREATE OR REPLACE FUNCTION INSIDE the outer transaction
+ * (which is rolled back in afterAll), tests behavior against that
+ * transaction-local definition, then discards it entirely on rollback —
+ * mirroring the zero-leak contract of advance-venture-nongate.db.test.js, one
+ * level further: this suite also stages the code change itself inside the
+ * disposable transaction, not just the seeded data.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { HAS_REAL_DB } from '../../../helpers/db-available.js';
+
+const describeDb = describe.skipIf(!HAS_REAL_DB);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_SQL = readFileSync(
+  join(__dirname, '../../../../database/migrations/20260722_stage_advancement_advance_venture_stage_gate_type_ssot.sql'),
+  'utf8',
+);
+
+// Live SSOT (verified 2026-07-22): kill={3,5,13,23}, promotion={10,16,17,18,19,24,25}
+const KILL_GATES = [3, 5, 13, 23];
+const PROMOTION_GATES = [10, 16, 17, 18, 19, 24, 25];
+const NEWLY_ENFORCED = [10, 16, 19, 25]; // omitted by the OLD hardcoded arrays
+const PREVIOUSLY_ENFORCED_PROMOTION = [17, 18]; // were correct before too
+const NON_GATE_STAGE = 1;
+
+const RUN_ID = `ADVSSOT-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+let rawClient;
+let spCounter = 0;
+let companyId;
+
+async function seedVenture(stage, { tier = 1 } = {}) {
+  await rawClient.query('SET LOCAL leo.stage0_bypass = \'true\'');
+  const { rows } = await rawClient.query(
+    `INSERT INTO ventures (name, problem_statement, current_lifecycle_stage, company_id, tier)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    [`${RUN_ID} venture s${stage}`, `SSOT gate-type fixture ${RUN_ID}`, stage, companyId, tier],
+  );
+  return rows[0].id;
+}
+
+/** Seed the artifact fn_stage_artifact_precondition requires for a given
+ *  stage, so tests that assert a clean {success:true} aren't incidentally
+ *  blocked by the unrelated, preserved-verbatim artifact-precondition check
+ *  (SD-LEO-INFRA-STAGE-ADVANCEMENT-ARTIFACT-001) - out of scope for this fix. */
+async function seedRequiredArtifact(ventureId, stage, artifactType) {
+  await rawClient.query(
+    `INSERT INTO venture_artifacts (id, venture_id, lifecycle_stage, artifact_type, title, is_current)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, true)`,
+    [ventureId, stage, artifactType, `${RUN_ID} required artifact for stage ${stage}`],
+  );
+}
+
+async function approveGate(ventureId, stage) {
+  const { rows } = await rawClient.query(
+    `INSERT INTO chairman_decisions (venture_id, lifecycle_stage, decision, status, decision_type)
+     VALUES ($1, $2, 'go', 'approved', 'gate_review')
+     RETURNING id`,
+    [ventureId, stage],
+  );
+  return rows[0].id;
+}
+
+async function callAdvance(ventureId, fromStage, toStage) {
+  const { rows } = await rawClient.query(
+    'SELECT advance_venture_stage($1, $2, $3, \'normal\') AS result',
+    [ventureId, fromStage, toStage],
+  );
+  return rows[0].result;
+}
+
+describeDb('advance_venture_stage — SSOT gate-type fix (live DB, transaction-local migration apply, savepoint-isolated)', () => {
+  beforeAll(async () => {
+    const { createDatabaseClient } = await import('../../../../lib/supabase-connection.js');
+    rawClient = await createDatabaseClient('engineer');
+    await rawClient.query('BEGIN'); // outer txn — rolled back in afterAll; NOTHING here reaches prod
+
+    const { rows: companies } = await rawClient.query('SELECT id FROM companies LIMIT 1');
+    expect(companies.length).toBe(1);
+    companyId = companies[0].id;
+
+    // Sanity: confirm the pre-fix bug is real BEFORE applying the migration,
+    // so this suite fails loudly if the SSOT itself drifted since PLAN phase.
+    const { rows: ssot } = await rawClient.query(
+      'SELECT stage_number, gate_type FROM venture_stages WHERE stage_number = ANY($1) ORDER BY stage_number',
+      [[...KILL_GATES, ...PROMOTION_GATES]],
+    );
+    const ssotMap = Object.fromEntries(ssot.map((r) => [r.stage_number, r.gate_type]));
+    for (const s of KILL_GATES) expect(ssotMap[s]).toBe('kill');
+    for (const s of PROMOTION_GATES) expect(ssotMap[s]).toBe('promotion');
+
+    // Apply the migration's CREATE OR REPLACE + self-verify DO block, entirely
+    // inside this transaction. Discarded on ROLLBACK in afterAll below.
+    await rawClient.query(MIGRATION_SQL);
+  });
+
+  afterAll(async () => {
+    if (rawClient) {
+      await rawClient.query('ROLLBACK'); // discards seeded rows AND the function replacement
+      const { rows } = await rawClient.query(
+        'SELECT count(*)::int AS n FROM ventures WHERE name LIKE $1',
+        [`${RUN_ID}%`],
+      );
+      expect(rows[0].n).toBe(0);
+      await rawClient.end();
+    }
+  });
+
+  let testSp;
+  beforeEach(async () => {
+    testSp = `sp_advssot_${++spCounter}`;
+    await rawClient.query(`SAVEPOINT ${testSp}`);
+    return async () => {
+      await rawClient.query(`ROLLBACK TO SAVEPOINT ${testSp}`);
+      await rawClient.query(`RELEASE SAVEPOINT ${testSp}`);
+    };
+  });
+
+  // --- TS-9: SSOT canonical-snapshot guard -------------------------------
+  it('TS-9: venture_stages gate_type snapshot matches the pinned canonical set for all known gate/non-gate stages', async () => {
+    const { rows } = await rawClient.query(
+      'SELECT stage_number, gate_type FROM venture_stages WHERE stage_number = ANY($1) ORDER BY stage_number',
+      [[...KILL_GATES, ...PROMOTION_GATES, 20]],
+    );
+    const map = Object.fromEntries(rows.map((r) => [r.stage_number, r.gate_type]));
+    for (const s of KILL_GATES) expect(map[s]).toBe('kill');
+    for (const s of PROMOTION_GATES) expect(map[s]).toBe('promotion');
+    expect(map[20]).toBe('none'); // S20 quality-verdict path must remain a non-gate stage
+  });
+
+  // --- TS-1 + TS-10: new enforcement, zero side effects on rejection -----
+  it.each(NEWLY_ENFORCED)('TS-1/TS-10: advancing FROM stage %i (newly-enforced) without an approved decision is rejected with zero write side effects', async (stage) => {
+    const ventureId = await seedVenture(stage);
+    const result = await callAdvance(ventureId, stage, stage + 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('gate_not_approved');
+    expect(result.gate_type).toBe('promotion');
+
+    const { rows: transitions } = await rawClient.query(
+      'SELECT count(*)::int AS n FROM venture_stage_transitions WHERE venture_id = $1',
+      [ventureId],
+    );
+    expect(transitions[0].n).toBe(0); // no partial write on rejection
+  });
+
+  // --- TS-4: approved decision still allows advance at newly-enforced stages
+  it('TS-4: an approved decision at a newly-enforced stage (19) allows the advance to succeed', async () => {
+    const ventureId = await seedVenture(19);
+    await approveGate(ventureId, 19);
+    await seedRequiredArtifact(ventureId, 19, 'build_mvp_build'); // unrelated precondition, not this fix's concern
+
+    const result = await callAdvance(ventureId, 19, 20);
+    expect(result.success).toBe(true);
+    expect(result.from_stage).toBe(19);
+    expect(result.to_stage).toBe(20);
+  });
+
+  // --- TS-2: no regression at previously-correct kill/promotion stages ---
+  it.each(KILL_GATES)('TS-2: kill stage %i without an approved decision is still rejected exactly as before (no regression)', async (stage) => {
+    const ventureId = await seedVenture(stage);
+    const result = await callAdvance(ventureId, stage, stage + 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('gate_not_approved');
+    expect(result.gate_type).toBe('kill');
+  });
+
+  it.each(PREVIOUSLY_ENFORCED_PROMOTION)('TS-2: promotion stage %i without an approved decision is still rejected exactly as before (no regression)', async (stage) => {
+    const ventureId = await seedVenture(stage);
+    const result = await callAdvance(ventureId, stage, stage + 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('gate_not_approved');
+    expect(result.gate_type).toBe('promotion');
+  });
+
+  // --- TS-3: 23/24 label swap fixed ---------------------------------------
+  it('TS-3: stage 23 reports gate_type="kill" (was mislabeled "promotion" pre-fix)', async () => {
+    const ventureId = await seedVenture(23);
+    const result = await callAdvance(ventureId, 23, 24);
+    expect(result.success).toBe(false);
+    expect(result.gate_type).toBe('kill');
+  });
+
+  it('TS-3: stage 24 reports gate_type="promotion" (was mislabeled "kill" pre-fix)', async () => {
+    const ventureId = await seedVenture(24);
+    const result = await callAdvance(ventureId, 24, 25);
+    expect(result.success).toBe(false);
+    expect(result.gate_type).toBe('promotion');
+  });
+
+  // --- Non-gate stage still advances freely (no regression vs 20260606 fix)
+  it('non-gate stage advance is unaffected (gate_decision_id remains NULL, no "record not assigned" error)', async () => {
+    const ventureId = await seedVenture(NON_GATE_STAGE);
+    await seedRequiredArtifact(ventureId, NON_GATE_STAGE, 'truth_idea_brief'); // unrelated precondition, not this fix's concern
+    const result = await callAdvance(ventureId, NON_GATE_STAGE, NON_GATE_STAGE + 1);
+    expect(result.success).toBe(true);
+
+    const { rows } = await rawClient.query(
+      'SELECT handoff_data FROM venture_stage_transitions WHERE venture_id = $1',
+      [ventureId],
+    );
+    expect(rows[0].handoff_data.gate_decision_id).toBeNull();
+  });
+
+  // --- TS-13: forensic bypass-detection query self-test -------------------
+  it('TS-13: the forensic bypass-detection query correctly identifies a planted un-approved historical advance at a newly-enforced stage', async () => {
+    // Plant a historical transition FROM stage 16 with NO approved decision,
+    // simulating exactly the kind of gap this migration closes going forward.
+    const ventureId = await seedVenture(17); // venture now sits at 17 (post-advance)
+    await rawClient.query(
+      `INSERT INTO venture_stage_transitions (venture_id, from_stage, to_stage, transition_type, approved_by, handoff_data, idempotency_key)
+       VALUES ($1, 16, 17, 'normal', NULL, '{"gate_decision_id": null}'::jsonb, gen_random_uuid())`,
+      [ventureId],
+    );
+
+    const { rows } = await rawClient.query(
+      `SELECT DISTINCT t.venture_id
+         FROM venture_stage_transitions t
+         WHERE t.from_stage = ANY($1)
+           AND NOT EXISTS (
+             SELECT 1 FROM chairman_decisions cd
+             WHERE cd.venture_id = t.venture_id
+               AND cd.lifecycle_stage = t.from_stage
+               AND cd.status = 'approved'
+               AND cd.decision IN ('pass','go','proceed','approve','conditional_pass','conditional_go','continue','release')
+           )`,
+      [NEWLY_ENFORCED],
+    );
+    const flagged = rows.map((r) => r.venture_id);
+    expect(flagged).toContain(ventureId);
+  });
+
+  // --- STRUCTURAL guards: transaction-local live definition ---------------
+  it('STRUCTURAL guard: hardcoded gate arrays are gone and the SSOT read landed', async () => {
+    const { rows } = await rawClient.query(
+      'SELECT pg_get_functiondef(\'public.advance_venture_stage(uuid,integer,integer,text)\'::regprocedure) AS def',
+    );
+    const def = rows[0].def;
+
+    expect(def).not.toMatch(/v_kill_gates/);
+    expect(def).not.toMatch(/v_promotion_gates/);
+    expect(def).not.toMatch(/v_all_gates/);
+    expect(def).toMatch(/FROM venture_stages/);
+    expect(def).toMatch(/v_gate_type IN \('kill', 'promotion'\)/);
+
+    // Preserved behavior (no regression in the non-gate / artifact-precondition paths)
+    expect(def).toMatch(/gate_not_approved/);
+    expect(def).toMatch(/fn_stage_artifact_precondition/);
+    expect(def).toMatch(/artifact_precondition_unmet/);
+    expect(def).toMatch(/v_gate_decision_id/);
+  });
+});


### PR DESCRIPTION
## Summary
- `advance_venture_stage` (the RPC the ehg frontend calls to advance a venture) hardcoded its own gate arrays, independent of the `venture_stages.gate_type` SSOT. This omitted promotion gates 10/16/19/25 entirely — a confirmed-active chairman-gate bypass (6 of 45 historical advances from those stages had no approved decision; 3 named real ventures) — and swapped the 23/24 kill/promotion labels.
- Migration replaces the hardcoded arrays with a per-call SSOT read, mirroring the sibling `fn_advance_venture_stage` (EVA-daemon path) which already reads correctly.
- **STAGED ONLY** — chairman-gated per SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001, never self-applied to production. Requires an explicit chairman GO decision, with the pre-deploy census (real ventures at 10/16/19 lacking approval) and the forensic historical-bypass query attached to that request.
- DOWN migration defaults to a data-level partial revert (`gate_type='none'` for the 4 stages) — restoring the buggy code is never an acceptable rollback since it reopens a confirmed-exploited bypass. A separate, loudly-labeled `EMERGENCY_ONLY` file holds the full code revert as a genuine last resort.

## Test plan
- [x] 17/17 DB tests pass (`tests/unit/database/migrations/advance-venture-gate-type-ssot.db.test.js`) — transaction-local migration apply, savepoint-isolated, zero-leak to production
- [x] New enforcement at stages 10/16/19/25, no regression at 3/5/13/17/18/23/24, label fix, forensic-query self-test, structural guard on live `pg_get_functiondef`
- [x] Independently re-verified by both testing-agent and security-agent at EXEC-TO-PLAN

Companion PR: rickfelix/ehg #770 — the frontend gate-membership reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)