### PR TITLE
fix(QF-20260722-842): sd-start --force-reclaim explicitly refuses a live owner

### DIFF
--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1137,6 +1137,20 @@ async function main() {
           console.log(`${colors.green}   ✅ TTL-expired claim released. Retrying...${colors.reset}`);
           autoReleased = true;
         }
+      } else if (forceReclaim) {
+        // QF-20260722-842: --force-reclaim must EXPLICITLY refuse against a provably-live
+        // owner (fresh heartbeat + active status), not silently fall through to a generic
+        // failure. Without this, an operator/coordinator can be misled into believing a
+        // reclaim "should have worked" when the TTL/PID safety net above correctly declined
+        // to release a genuinely alive claim — surfacing WHY makes the safety net legible
+        // instead of implicit-by-omission.
+        const ageSec = Math.round(heartbeatAge / 1000);
+        console.log(
+          `\n${colors.red}🚫 force-reclaim REFUSED — owner is genuinely live (heartbeat ${ageSec}s old, status=${ownerSession?.status}).${colors.reset}`
+        );
+        console.log(`   Owner session: ${claimResult.owner.session_id}`);
+        console.log('   This is not a stale/dead claim; --force-reclaim will not steal it.');
+        process.exit(1);
       }
     }
 

--- a/tests/unit/sd-start-claim-lifecycle.test.js
+++ b/tests/unit/sd-start-claim-lifecycle.test.js
@@ -94,6 +94,36 @@ describe('FR-2: sd_key drift telemetry enriches --force-reclaim audit (AC-2.1, A
   });
 });
 
+// ── QF-20260722-842: --force-reclaim explicit liveness refusal ──────────
+
+describe('QF-20260722-842: --force-reclaim explicitly refuses a genuinely-live owner', () => {
+  it('the refusal branch is the else-if sibling of the heartbeat-TTL isStale/isInactive release', () => {
+    const ttlIdx = src.indexOf("const CLAIM_TTL_MS = 30 * 60 * 1000");
+    const refuseIdx = src.indexOf('force-reclaim REFUSED');
+    expect(ttlIdx).toBeGreaterThan(0);
+    expect(refuseIdx).toBeGreaterThan(ttlIdx);
+    const between = src.slice(ttlIdx, refuseIdx);
+    expect(between).toMatch(/if\s*\(isStale\s*\|\|\s*isInactive\)/);
+    expect(between).toMatch(/\}\s*\}\s*else if\s*\(forceReclaim\)\s*\{/);
+  });
+
+  it('refusal exits non-zero without releasing the owner claim', () => {
+    const refuseIdx = src.indexOf('force-reclaim REFUSED');
+    const slice = src.slice(refuseIdx, refuseIdx + 500);
+    expect(slice).toMatch(/process\.exit\(1\)/);
+    expect(slice).not.toMatch(/release_sd/);
+  });
+
+  it('never fires when the owner is actually stale or inactive (mutually exclusive with auto-release)', () => {
+    const releaseIdx = src.indexOf("console.log(`[claimGuard] ${reason}");
+    const refuseIdx = src.indexOf('force-reclaim REFUSED');
+    const between = src.slice(releaseIdx, refuseIdx);
+    // The refusal branch must be inside an else-if attached to the SAME if(isStale || isInactive),
+    // not a parallel independent check — so it can never run in the same pass as the release.
+    expect(between).toMatch(/autoReleased = true;\s*\}\s*\}\s*else if \(forceReclaim\)/);
+  });
+});
+
 // ── Cross-cutting guards ─────────────────────────────────────────────────
 
 describe('sd-start.js wire-in: cross-cutting guards', () => {


### PR DESCRIPTION
## Summary
- Incident: coordinator dispatched a `--force-reclaim` recovery task against session 017c491c's CP3 claim, judging it "stale" from work-product signals (progress %, no SD update, zero fleet_verb) while the session's heartbeat was fresh and status active. The worker protested it wasn't a ghost (feedback f1fd97b1 → this QF).
- RCA: `sd-start.js --force-reclaim` already has a correct safety net (heartbeat-TTL/PID checks never release a genuinely live owner's claim) — but the refusal was implicit-by-omission, silently falling through to a generic failure instead of explaining why.
- Fix: add an explicit refusal branch — when `--force-reclaim` targets a provably-live owner (fresh heartbeat + active status), print a clear message and exit non-zero. Purely additive; reclaims of genuinely-dead sessions are unaffected.

## Test plan
- [x] `tests/unit/sd-start-claim-lifecycle.test.js` — 16/16 pass (3 new tests pin the refusal branch's position, exit behavior, and mutual exclusivity with the existing auto-release path)
- [x] All adjacent `sd-start-*` test suites (argv scanner, human-action gate, blocked-on-sd gate, terminal-target, cadence, non-interactive-own-conflict) — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)