### PR TITLE
fix(QF-20260724-703): treat deferred children as terminal in PLAN-TO-LEAD parent rollup

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -208,7 +208,7 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
   if (childSDs && childSDs.length > 0) {
     console.log(`   ℹ️  Parent SD detected with ${childSDs.length} children`);
 
-    const terminalStatuses = ['completed', 'cancelled'];
+    const terminalStatuses = ['completed', 'cancelled', 'deferred'];
     const completedChildren = childSDs.filter(c => terminalStatuses.includes(c.status));
     const incompleteChildren = childSDs.filter(c => !terminalStatuses.includes(c.status));
 

--- a/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-deferred-child.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-deferred-child.test.js
@@ -1,0 +1,73 @@
+/**
+ * Regression test for QF-20260724-703: PREREQUISITE_HANDOFF_CHECK (PLAN-TO-LEAD)
+ * terminalStatuses was missing 'deferred', so a deferred child was excluded from
+ * completedChildren but ALSO landed in incompleteChildren, causing the parent
+ * orchestrator's PLAN-TO-LEAD gate to WAIT forever on a child whose scope was
+ * deliberately not delivered (matches SD-LEO-INFRA-DRAIN-SET-REGISTRY-001).
+ */
+import { describe, it, expect } from 'vitest';
+import { createPrerequisiteCheckGate } from '../../../../../scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js';
+
+function makeParentSupabase({ parentId, children }) {
+  const emptyTail = {
+    eq: () => emptyTail,
+    order: () => ({ limit: async () => ({ data: [], error: null }) }),
+  };
+  return {
+    from(table) {
+      return {
+        select() {
+          return {
+            eq(column, value) {
+              if (table === 'strategic_directives_v2' && column === 'parent_sd_id' && value === parentId) {
+                return { async then(resolve) { resolve({ data: children, error: null }); return Promise.resolve(); } };
+              }
+              return { async maybeSingle() { return { data: null, error: null }; }, ...emptyTail };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('QF-20260724-703: PREREQUISITE_HANDOFF_CHECK deferred-child rollup', () => {
+  it('does not WAIT when the only non-completed child is deferred', async () => {
+    const parentId = 'parent-uuid';
+    const children = [
+      { id: 'child-a', sd_key: 'SD-CHILD-A', status: 'completed' },
+      { id: 'child-b', sd_key: 'SD-CHILD-B', status: 'completed' },
+      { id: 'child-c', sd_key: 'SD-CHILD-C', status: 'completed' },
+      { id: 'child-e', sd_key: 'SD-CHILD-E', status: 'deferred' },
+    ];
+
+    const supabase = makeParentSupabase({ parentId, children });
+    const gate = createPrerequisiteCheckGate(supabase);
+    const ctx = { sd: { id: parentId, sd_key: 'SD-PARENT', metadata: {} }, sdId: parentId };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.wait).not.toBe(true);
+    expect(result.passed).toBe(true);
+    expect(result.details.total_children).toBe(4);
+  });
+
+  it('still WAITs on a genuinely incomplete (non-terminal) child alongside a deferred one', async () => {
+    const parentId = 'parent-uuid-2';
+    const children = [
+      { id: 'child-a', sd_key: 'SD-CHILD-A', status: 'completed' },
+      { id: 'child-e', sd_key: 'SD-CHILD-E', status: 'deferred' },
+      { id: 'child-f', sd_key: 'SD-CHILD-F', status: 'in_progress' },
+    ];
+
+    const supabase = makeParentSupabase({ parentId, children });
+    const gate = createPrerequisiteCheckGate(supabase);
+    const ctx = { sd: { id: parentId, sd_key: 'SD-PARENT-2', metadata: {} }, sdId: parentId };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.wait).toBe(true);
+    expect(result.wait_reason).toContain('SD-CHILD-F');
+    expect(result.wait_reason).not.toContain('SD-CHILD-E');
+  });
+});


### PR DESCRIPTION
## Summary
- `terminalStatuses` in `prerequisite-check.js` (PLAN-TO-LEAD parent orchestrator rollup) was missing `'deferred'`, so a deferred child landed in both `completedChildren` exclusion AND `incompleteChildren` inclusion — causing the gate to WAIT forever on scope that was deliberately not delivered.
- Fixed by adding `'deferred'` to `terminalStatuses`, matching the existing `CHILD_SCOPE_COVERAGE` gate's treatment of deferred children as non-blocking.
- Unblocks `SD-LEO-INFRA-DRAIN-SET-REGISTRY-001` (3 completed + 1 deferred child, stuck ~42h).

## Test plan
- [x] New unit test: deferred-only remainder passes (no WAIT)
- [x] New unit test: a genuinely incomplete sibling alongside a deferred child still correctly WAITs (and excludes the deferred child from the wait reason)
- [x] Full `tests/unit/handoff/` suite: 814 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)