### PR TITLE
feat(SD-LEO-INFRA-LEO-APP-RENDERED-001-B): complete session-view render layer (TTY pane, agent-browser pane, F/B/A nav)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-boundaries": "^5.1.0",
         "eslint-plugin-playwright": "^2.3.0",
         "husky": "^9.1.7",
+        "jsdom": "^29.1.1",
         "minimatch": "^10.2.5",
         "puppeteer": "^24.23.0",
         "typescript": "^5.9.2",
@@ -93,6 +94,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@axe-core/playwright": {
       "version": "4.11.1",
@@ -260,6 +312,19 @@
         "node": ">=18.18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -268,6 +333,146 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@doist/todoist-api-typescript": {
@@ -1006,6 +1211,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -4435,6 +4658,16 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -5121,6 +5354,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -5153,6 +5400,68 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -7281,6 +7590,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7690,6 +8012,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -7849,6 +8178,144 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -8617,6 +9084,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -10310,6 +10784,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -10780,6 +11267,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
@@ -10918,6 +11412,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
     "node_modules/tldts-core": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
@@ -10934,6 +11441,13 @@
       "dependencies": {
         "tldts-core": "^6.1.86"
       }
+    },
+    "node_modules/tldts/node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.1.0",
@@ -11139,9 +11653,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -11473,6 +11987,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
@@ -11694,6 +12221,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -678,6 +678,7 @@
     "eslint-plugin-boundaries": "^5.1.0",
     "eslint-plugin-playwright": "^2.3.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "minimatch": "^10.2.5",
     "puppeteer": "^24.23.0",
     "typescript": "^5.9.2",

--- a/server/public/fleet-ui/session-view.css
+++ b/server/public/fleet-ui/session-view.css
@@ -12,6 +12,10 @@
   --sv-bg: #0f172a;
   --sv-fg: #e2e8f0;
   --sv-panel: #1e293b;
+  /* mockup-2 (docs/design/mockup-2-session-view-terminal-agent-browser.png) accent -- additive,
+   * does not replace any existing token above. */
+  --sv-agent: #7c5cff;
+  --sv-agent-bg: #1a1330;
 }
 
 * { box-sizing: border-box; }
@@ -24,9 +28,76 @@ body {
 }
 
 #session-view {
-  max-width: 640px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 16px;
+}
+
+/* FR-1: app header -- identity chips, status pill, F/B/A key legend. */
+.sv-appheader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--sv-panel);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.sv-identity-chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.sv-id-chip {
+  font-size: 12px;
+  color: #cbd5e1;
+  background: #1f2937;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.sv-status-pill {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: #052e16;
+  color: #4ade80;
+  border: 1px solid var(--sv-ok);
+}
+.sv-status-pill--off { background: #1f2937; color: #94a3b8; border-color: var(--sv-neutral); }
+.sv-status-pill--idle { background: #1f2937; color: #94a3b8; border-color: var(--sv-neutral); }
+.sv-status-pill--awaiting-input { background: #451a03; color: #fbbf24; border-color: var(--sv-warn); }
+.sv-status-pill--mechanical { background: #1f2937; color: #cbd5e1; border-color: var(--sv-neutral); }
+.sv-status-pill--deep-work { background: var(--sv-agent-bg); color: #c4b5fd; border-color: var(--sv-agent); }
+.sv-status-pill--pilot-wk1 { background: #1f2937; color: #cbd5e1; border-color: var(--sv-neutral); }
+
+.sv-key-legend {
+  margin-left: auto;
+  font-size: 12px;
+  color: #94a3b8;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+}
+
+.sv-account-panel {
+  background: var(--sv-panel);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+}
+.sv-account-field { margin: 2px 0; color: #cbd5e1; font-size: 13px; }
+
+/* Two-pane mockup-2 layout: TTY (left) + agent-browser (right). */
+.sv-shell {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  align-items: start;
+}
+@media (max-width: 860px) {
+  .sv-shell { grid-template-columns: 1fr; }
 }
 
 .sv-hidden { display: none !important; }
@@ -183,6 +254,103 @@ body {
   color: #cbd5e1;
 }
 .sv-log-empty { color: #64748b; font-family: inherit; }
+
+/* FR-2: TTY / terminal pane (left column). */
+.sv-tty {
+  background: #0b1220;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+}
+.sv-tty-header {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+  border-bottom: 1px solid #1e293b;
+}
+.sv-tty-scrollback {
+  flex: 1;
+  padding: 12px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 13px;
+  color: #cbd5e1;
+  overflow-y: auto;
+}
+.sv-tty-placeholder { color: #64748b; }
+.sv-attach-row { display: flex; gap: 8px; padding: 0 12px; }
+.sv-tty-footer {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #94a3b8;
+  border-top: 1px solid #1e293b;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+}
+
+/* FR-3/FR-4: agent-browser pane (right column). */
+.sv-agent-browser {
+  background: var(--sv-panel);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.sv-url-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f8fafc;
+  color: #0f172a;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin-bottom: 10px;
+}
+.sv-url-dots {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #ef4444;
+  box-shadow: 16px 0 0 #f59e0b, 32px 0 0 #22c55e;
+  margin-right: 24px;
+}
+.sv-url-text { flex: 1; font-family: ui-monospace, "Cascadia Code", monospace; font-size: 13px; }
+.sv-agent-badge {
+  background: var(--sv-agent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+
+/* FR-3: narration stream -- purple-accented per the ratified mockup. */
+.sv-narration {
+  border: 1px solid var(--sv-agent);
+  background: var(--sv-agent-bg);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 10px 0;
+}
+.sv-narration-heading {
+  margin: 0 0 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #c4b5fd;
+  letter-spacing: 0.04em;
+}
+.sv-narration-list {
+  list-style: none;
+  margin: 0 0 6px;
+  padding: 0;
+  font-size: 13px;
+  color: #e9e4ff;
+}
+.sv-narration-line { margin: 2px 0; }
+.sv-narration-hint { margin: 0; font-size: 12px; color: #a78bfa; }
 
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; }

--- a/server/public/fleet-ui/session-view.js
+++ b/server/public/fleet-ui/session-view.js
@@ -79,12 +79,18 @@
   /**
    * FR-3: numbered narration lines derived 1:1 from real browser-log events. Never fabricates
    * content beyond a friendly label + the event's own timestamp (TS-2/TS-7).
+   *
+   * ADVERSARIAL REVIEW FIX (pre-merge): GET /:id/browser-log orders its rows newest-first
+   * (`created_at` descending) -- a numbered narration must read oldest-first to tell the
+   * story in causal order, so this sorts ascending by `created_at` before numbering rather
+   * than trusting the input array's order.
    * @param {Array<{event_type:string, created_at:string}>|null|undefined} events
    * @returns {string[]}
    */
   function buildNarrationLines(events) {
     if (!events || events.length === 0) return [];
-    return events.map((ev, i) => {
+    const chronological = events.slice().sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+    return chronological.map((ev, i) => {
       const label = NARRATION_EVENT_LABELS[ev.event_type] || ev.event_type;
       return `${i + 1}. ${label} (${ev.created_at})`;
     });

--- a/server/public/fleet-ui/session-view.js
+++ b/server/public/fleet-ui/session-view.js
@@ -1,102 +1,93 @@
 /**
- * Session View pane (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-B) -- framework-free vanilla JS.
+ * Session View pane (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-B, completed by
+ * SD-LEO-INFRA-LEO-APP-RENDERED-001-B) -- framework-free vanilla JS.
  *
  * Renders lib/fleet/session-detail-view.js's buildSessionDetailView()/mapAttachState() shape
- * (served via GET /api/fleet/sessions/:id) and drives the 4 action routes (attach,
+ * (served via GET /api/fleet/sessions/:id, now additionally carrying badge/model/effort/role/
+ * callsign per SD-LEO-INFRA-LEO-APP-RENDERED-001-B TR-1) and drives the 4 action routes (attach,
  * browser-session, takeover, hand-back). All server-sourced text is set via textContent, never
  * innerHTML, so no HTML-escaping helper is needed here for XSS safety.
  *
- * SCOPE NOTE: this fragment renders the sandbox pane's frame and controls only. Actually
- * connecting a live CDP viewport to the returned launchOptions requires a host that can embed
- * a real browser process (e.g. the parent shell's native/Electron layer) -- browser-control.js's
- * own contract is "return launch options, never launch a browser here", and this fragment
- * honors that same boundary rather than attempting to spawn anything client-side.
+ * Matches docs/design/mockup-2-session-view-terminal-agent-browser.png: an app header (identity
+ * chips + status pill + F/B/A key legend), a left TTY/terminal pane with a ctx/last-tool/wakeup
+ * footer, and a right agent-browser pane (URL bar + AGENT badge + narration stream + the existing
+ * sandboxed-browser controls + browser action log).
  *
- * KNOWN INTEGRATION GAP (adversarial review, pre-merge): the fetch() calls below carry no
- * Authorization/x-internal-api-key header, so every action 401s (fails closed) when this
- * fragment is loaded standalone. Fresh-fails-closed is safe, but the credential-passthrough
- * mechanism is genuinely undecided -- it depends on how the parent SD's assembly shell hosts
- * this fragment (e.g. relaying its own session token). Tracked as an open dependency on the
+ * SCOPE NOTE (honest placeholders, no fabrication -- VALIDATION sub-agent, LEAD phase): no
+ * narration/transcript backend data source exists anywhere in the fleet namespace. The narration
+ * stream below is synthesized from the REAL, already-recorded browser-log events (takeover/
+ * hand-back), never fabricated dialogue -- see buildNarrationLines(). Likewise this fragment
+ * renders the sandbox pane's frame and controls only; actually connecting a live CDP viewport
+ * requires a host that can embed a real browser process, which is out of scope here (same
+ * boundary browser-control.js itself draws: "return launch options, never launch a browser here").
+ *
+ * KNOWN INTEGRATION GAP (adversarial review, pre-merge, carried over from LAUNCHER-SHELL-001-B):
+ * the fetch() calls below carry no Authorization/x-internal-api-key header, so every action 401s
+ * (fails closed) when this fragment is loaded standalone. Tracked as an open dependency on the
  * parent shell's integration work, not fixable from this child alone.
+ *
+ * TESTABLE SEAM (TESTING sub-agent, PLAN-TO-EXEC): pure, DOM-free helpers are exported via a
+ * UMD-style guard so unit tests can exercise them directly under Node/vitest without a DOM. The
+ * DOM-building/fetch/event-wiring code only runs when `window`+`document` are present (a real
+ * browser, or a jsdom-environment test that wants full integration coverage).
  */
-(function () {
-  const API_BASE = '/api/fleet/sessions';
-  const sessionId = new URLSearchParams(location.search).get('id');
-  const root = document.getElementById('session-view');
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    factory();
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
 
-  if (!sessionId) {
-    root.textContent = 'No session id provided (?id=<session_id>).';
-    return;
+  // ---------------------------------------------------------------------
+  // Pure helpers (no DOM, no fetch) -- exported for unit testing.
+  // ---------------------------------------------------------------------
+
+  /** FR-2: "last tool N ago" footer field. Returns '—' for missing/unparseable input. */
+  function formatTimeAgo(isoString, nowMs) {
+    if (!isoString) return '—';
+    const then = Date.parse(isoString);
+    if (!Number.isFinite(then)) return '—';
+    const now = typeof nowMs === 'number' ? nowMs : Date.now();
+    const deltaSec = Math.max(0, Math.round((now - then) / 1000));
+    if (deltaSec < 60) return `${deltaSec}s ago`;
+    const deltaMin = Math.round(deltaSec / 60);
+    if (deltaMin < 60) return `${deltaMin}m ago`;
+    const deltaHr = Math.round(deltaMin / 60);
+    return `${deltaHr}h ago`;
   }
 
-  const els = {};
-
-  function el(tag, className, text) {
-    const e = document.createElement(tag);
-    if (className) e.className = className;
-    if (text != null) e.textContent = text;
-    return e;
+  /** FR-2: "wakeup armed HH:MM" footer field, 'none' when there's no future silent-until. */
+  function formatWakeupLabel(silentUntil, nowMs) {
+    if (!silentUntil) return 'none';
+    const endMs = Date.parse(silentUntil);
+    const now = typeof nowMs === 'number' ? nowMs : Date.now();
+    if (!Number.isFinite(endMs) || endMs <= now) return 'none';
+    const d = new Date(endMs);
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `armed ${hh}:${mm}`;
   }
 
-  function buildLayout() {
-    root.textContent = '';
-    root.dataset.sessionId = sessionId;
+  /** FR-3/TR-2: friendly narration labels, extending the existing LOG_EVENT_LABELS convention. */
+  const NARRATION_EVENT_LABELS = Object.freeze({
+    browser_takeover: 'Human took control',
+    browser_handback: 'Control returned to agent',
+  });
 
-    const header = el('header', 'sv-header');
-    els.attachChip = el('span', 'sv-chip sv-chip--resting', 'Attach: unknown');
-    els.pauseChip = el('span', 'sv-chip sv-chip--resting', 'Agent active');
-    header.append(els.attachChip, els.pauseChip);
-    root.appendChild(header);
-
-    els.pausedBanner = el('div', 'sv-paused-banner sv-hidden', 'HUMAN IN CONTROL');
-    els.pausedBanner.setAttribute('role', 'status');
-    els.pausedBanner.setAttribute('aria-live', 'assertive');
-    root.appendChild(els.pausedBanner);
-
-    const telemetry = el('section', 'sv-telemetry');
-    telemetry.setAttribute('aria-label', 'Session telemetry');
-    els.ctxBarFill = el('div', 'sv-ctx-fill');
-    const ctxBar = el('div', 'sv-ctx-bar');
-    ctxBar.appendChild(els.ctxBarFill);
-    els.ctxLabel = el('span', 'sv-ctx-label', 'Context: unknown');
-    telemetry.append(els.ctxLabel, ctxBar);
-    els.lastTool = el('p', 'sv-field', 'Last tool: —');
-    els.lastActivity = el('p', 'sv-field', 'Activity: —');
-    els.silentUntil = el('p', 'sv-field', 'Silent until: —');
-    telemetry.append(els.lastTool, els.lastActivity, els.silentUntil);
-    root.appendChild(telemetry);
-
-    const attachSection = el('section', 'sv-attach');
-    attachSection.setAttribute('aria-label', 'Attach focus');
-    els.attachButton = el('button', 'sv-button', 'Attach-focus');
-    els.attachButton.type = 'button';
-    els.attachMessage = el('p', 'sv-attach-message', '');
-    els.attachMessage.setAttribute('aria-live', 'polite');
-    attachSection.append(els.attachButton, els.attachMessage);
-    root.appendChild(attachSection);
-
-    const browserSection = el('section', 'sv-browser');
-    browserSection.setAttribute('aria-label', 'Sandboxed browser');
-    els.browserButton = el('button', 'sv-button', 'Open sandboxed browser');
-    els.browserButton.type = 'button';
-    els.browserGateNote = el('p', 'sv-browser-gate sv-hidden',
-      'Browser control is disabled for this session (browser_mcp_enabled is not set).');
-    els.browserPane = el('div', 'sv-browser-pane sv-hidden');
-    els.browserPane.setAttribute('role', 'region');
-    els.browserPane.setAttribute('aria-label', 'Sandboxed browser pane (isolated profile)');
-    const ribbon = el('div', 'sv-browser-ribbon', 'SANDBOXED — isolated profile, never your real browser');
-    els.browserPaneBody = el('p', 'sv-browser-pane-body',
-      'No live viewport is embedded here — connect a CDP client to the reported launch options.');
-    els.takeoverButton = el('button', 'sv-button sv-button--takeover', 'Take control');
-    els.takeoverButton.type = 'button';
-    els.handBackButton = el('button', 'sv-button sv-button--handback sv-hidden', 'Return control to agent');
-    els.handBackButton.type = 'button';
-    const logHeading = el('p', 'sv-log-heading', 'BROWSER ACTION LOG (auditable)');
-    els.browserLog = el('ul', 'sv-log-list');
-    els.browserLog.setAttribute('aria-label', 'Auditable take-over / hand-back log');
-    els.browserPane.append(ribbon, els.browserPaneBody, els.takeoverButton, els.handBackButton, logHeading, els.browserLog);
-    browserSection.append(els.browserButton, els.browserGateNote, els.browserPane);
-    root.appendChild(browserSection);
+  /**
+   * FR-3: numbered narration lines derived 1:1 from real browser-log events. Never fabricates
+   * content beyond a friendly label + the event's own timestamp (TS-2/TS-7).
+   * @param {Array<{event_type:string, created_at:string}>|null|undefined} events
+   * @returns {string[]}
+   */
+  function buildNarrationLines(events) {
+    if (!events || events.length === 0) return [];
+    return events.map((ev, i) => {
+      const label = NARRATION_EVENT_LABELS[ev.event_type] || ev.event_type;
+      return `${i + 1}. ${label} (${ev.created_at})`;
+    });
   }
 
   const ATTACH_STYLES = {
@@ -118,120 +109,330 @@
     return ATTACH_STYLES.other;
   }
 
-  function renderAttachState(attachState) {
-    const style = attachStyleFor(attachState);
-    els.attachChip.className = 'sv-chip ' + style.cls;
-    els.attachChip.textContent = style.label;
-    els.attachMessage.textContent = (attachState && attachState.message) || '';
+  /** FR-5: header legend key -> semantic action. Case-insensitive, unmapped keys return null. */
+  const KEY_ACTIONS = Object.freeze({ f: 'fleet-view', b: 'toggle-browser', a: 'toggle-account' });
+  function resolveKeyAction(key) {
+    if (typeof key !== 'string' || key.length !== 1) return null;
+    return KEY_ACTIONS[key.toLowerCase()] || null;
   }
 
-  function renderPaused(paused) {
-    els.pauseChip.textContent = paused ? 'Human in control' : 'Agent active';
-    els.pauseChip.className = 'sv-chip ' + (paused ? 'sv-chip--paused' : 'sv-chip--resting');
-    els.pausedBanner.classList.toggle('sv-hidden', !paused);
-    els.takeoverButton.classList.toggle('sv-hidden', paused);
-    els.handBackButton.classList.toggle('sv-hidden', !paused);
+  /** FR-5: true when the given element is a text-entry target (keydown nav must no-op). */
+  function isEditableTarget(target) {
+    if (!target) return false;
+    const tag = typeof target.tagName === 'string' ? target.tagName.toLowerCase() : '';
+    if (tag === 'input' || tag === 'textarea') return true;
+    return !!target.isContentEditable;
   }
 
-  function renderGate(browserMcpEnabled) {
-    els.browserButton.disabled = !browserMcpEnabled;
-    els.browserButton.setAttribute('aria-disabled', String(!browserMcpEnabled));
-    els.browserGateNote.classList.toggle('sv-hidden', browserMcpEnabled);
+  const STATUS_BADGE_LABELS = new Set([
+    'WORKING', 'AWAITING INPUT', 'DEEP WORK', 'IDLE', 'MECHANICAL', 'PILOT WK1', 'OFF',
+  ]);
+
+  /** FR-1: falls back to a safe '—' for any badge value outside the canonical 7-label vocabulary. */
+  function normalizeBadge(badge) {
+    return STATUS_BADGE_LABELS.has(badge) ? badge : '—';
   }
 
-  function renderView(view) {
-    els.ctxLabel.textContent = view.ctxPercent == null ? 'Context: unknown' : `Context: ${view.ctxPercent}%`;
-    els.ctxBarFill.style.width = (view.ctxPercent == null ? 0 : view.ctxPercent) + '%';
-    els.lastTool.textContent = 'Last tool: ' + (view.lastTool || '—');
-    els.lastActivity.textContent = 'Activity: ' + (view.lastActivityKind || '—');
-    els.silentUntil.textContent = 'Silent until: ' + (view.silentUntil || '—');
-    renderAttachState(view.attachState);
-    renderPaused(!!view.paused);
-    renderGate(!!view.browserMcpEnabled);
-  }
+  // ---------------------------------------------------------------------
+  // Browser-only init: DOM building, fetch, event wiring.
+  // ---------------------------------------------------------------------
 
-  const LOG_EVENT_LABELS = { browser_takeover: 'Human took control', browser_handback: 'Control returned to agent' };
+  function initBrowser() {
+    const API_BASE = '/api/fleet/sessions';
+    const sessionId = new URLSearchParams(location.search).get('id');
+    const root = document.getElementById('session-view');
+    if (!root) return;
 
-  function renderBrowserLog(events, errored) {
-    els.browserLog.textContent = '';
-    if (errored) {
-      els.browserLog.appendChild(el('li', 'sv-log-empty', 'Unable to load browser action log.'));
+    if (!sessionId) {
+      root.textContent = 'No session id provided (?id=<session_id>).';
       return;
     }
-    if (!events || events.length === 0) {
-      els.browserLog.appendChild(el('li', 'sv-log-empty', 'No take-over/hand-back events recorded yet.'));
-      return;
+
+    const els = {};
+    let paused = false;
+
+    function el(tag, className, text) {
+      const e = document.createElement(tag);
+      if (className) e.className = className;
+      if (text != null) e.textContent = text;
+      return e;
     }
-    for (const ev of events) {
-      const label = LOG_EVENT_LABELS[ev.event_type] || ev.event_type;
-      els.browserLog.appendChild(el('li', 'sv-log-entry', `${ev.created_at} — ${label}`));
+
+    function buildLayout() {
+      root.textContent = '';
+      root.dataset.sessionId = sessionId;
+
+      // FR-1: app header -- identity chips, status pill, F/B/A key legend.
+      const appHeader = el('header', 'sv-appheader');
+      els.identityChips = el('div', 'sv-identity-chips');
+      els.statusPill = el('span', 'sv-status-pill sv-status-pill--off', '—');
+      els.keyLegend = el('span', 'sv-key-legend', '[F] Fleet view · [B] toggle browser · [A] account');
+      appHeader.append(els.identityChips, els.statusPill, els.keyLegend);
+      root.appendChild(appHeader);
+
+      els.accountPanel = el('div', 'sv-account-panel sv-hidden');
+      els.accountPanel.setAttribute('aria-label', 'Account details');
+      root.appendChild(els.accountPanel);
+
+      const shell = el('div', 'sv-shell');
+      root.appendChild(shell);
+
+      // FR-2: TTY pane (left).
+      const ttyPane = el('section', 'sv-tty');
+      ttyPane.setAttribute('aria-label', 'Live terminal');
+      const ttyHeader = el('div', 'sv-tty-header', 'TERMINAL — live TTY (attach to type)');
+      els.ttyScrollback = el('div', 'sv-tty-scrollback');
+      els.ttyScrollback.appendChild(el('p', 'sv-tty-placeholder', 'Attach to begin.'));
+
+      const attachRow = el('div', 'sv-attach-row');
+      els.attachChip = el('span', 'sv-chip sv-chip--resting', 'Attach: unknown');
+      els.pauseChip = el('span', 'sv-chip sv-chip--resting', 'Agent active');
+      attachRow.append(els.attachChip, els.pauseChip);
+
+      els.attachButton = el('button', 'sv-button', 'Attach-focus');
+      els.attachButton.type = 'button';
+      els.attachMessage = el('p', 'sv-attach-message', '');
+      els.attachMessage.setAttribute('aria-live', 'polite');
+
+      els.pausedBanner = el('div', 'sv-paused-banner sv-hidden', 'HUMAN IN CONTROL');
+      els.pausedBanner.setAttribute('role', 'status');
+      els.pausedBanner.setAttribute('aria-live', 'assertive');
+
+      els.ttyFooter = el('div', 'sv-tty-footer', 'ctx — % · last tool — · wakeup none');
+
+      ttyPane.append(ttyHeader, els.ttyScrollback, attachRow, els.attachButton, els.attachMessage, els.pausedBanner, els.ttyFooter);
+      shell.appendChild(ttyPane);
+
+      // FR-3/FR-4: agent-browser pane (right).
+      const browserSection = el('section', 'sv-agent-browser');
+      browserSection.setAttribute('aria-label', 'Agent-controlled browser');
+
+      const urlBar = el('div', 'sv-url-bar');
+      const dots = el('span', 'sv-url-dots');
+      els.urlText = el('span', 'sv-url-text', 'about:blank');
+      const agentBadge = el('span', 'sv-agent-badge', 'AGENT ⚡');
+      urlBar.append(dots, els.urlText, agentBadge);
+
+      els.browserButton = el('button', 'sv-button', 'Open sandboxed browser');
+      els.browserButton.type = 'button';
+      els.browserGateNote = el('p', 'sv-browser-gate sv-hidden',
+        'Browser control is disabled for this session (browser_mcp_enabled is not set).');
+
+      els.browserPane = el('div', 'sv-browser-pane sv-hidden');
+      els.browserPane.setAttribute('role', 'region');
+      els.browserPane.setAttribute('aria-label', 'Sandboxed browser pane (isolated profile)');
+      const ribbon = el('div', 'sv-browser-ribbon', 'SANDBOXED — isolated profile, never your real browser');
+      els.browserPaneBody = el('p', 'sv-browser-pane-body',
+        'No live viewport is embedded here — connect a CDP client to the reported launch options.');
+
+      const narrationBox = el('div', 'sv-narration');
+      narrationBox.setAttribute('role', 'status');
+      const narrationHeading = el('p', 'sv-narration-heading', 'AGENT DRIVING THIS PAGE (MCP browser control)');
+      els.narrationList = el('ul', 'sv-narration-list');
+      els.narrationList.setAttribute('aria-label', 'Agent narration stream');
+      const narrationHint = el('p', 'sv-narration-hint', 'You can take over anytime — agent yields on your first click.');
+      narrationBox.append(narrationHeading, els.narrationList, narrationHint);
+
+      els.takeoverButton = el('button', 'sv-button sv-button--takeover', 'Take control');
+      els.takeoverButton.type = 'button';
+      els.handBackButton = el('button', 'sv-button sv-button--handback sv-hidden', 'Return control to agent');
+      els.handBackButton.type = 'button';
+
+      const logHeading = el('p', 'sv-log-heading', 'BROWSER ACTION LOG (auditable)');
+      els.browserLog = el('ul', 'sv-log-list');
+      els.browserLog.setAttribute('aria-label', 'Auditable take-over / hand-back log');
+
+      els.browserPane.append(ribbon, els.browserPaneBody, narrationBox, els.takeoverButton, els.handBackButton, logHeading, els.browserLog);
+      browserSection.append(urlBar, els.browserButton, els.browserGateNote, els.browserPane);
+      shell.appendChild(browserSection);
+
+      els.agentBrowserPane = els.browserPane;
     }
-  }
 
-  async function fetchView() {
-    const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}`, { method: 'GET' });
-    if (!res.ok) throw new Error(`view fetch failed: ${res.status}`);
-    return res.json();
-  }
-
-  async function fetchBrowserLog() {
-    const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/browser-log`, { method: 'GET' });
-    if (!res.ok) throw new Error(`browser-log fetch failed: ${res.status}`);
-    return res.json();
-  }
-
-  async function refresh() {
-    try {
-      renderView(await fetchView());
-    } catch {
-      els.attachMessage.textContent = 'Unable to load session state.';
+    function renderAttachState(attachState) {
+      const style = attachStyleFor(attachState);
+      els.attachChip.className = 'sv-chip ' + style.cls;
+      els.attachChip.textContent = style.label;
+      els.attachMessage.textContent = (attachState && attachState.message) || '';
     }
-    try {
-      const log = await fetchBrowserLog();
-      renderBrowserLog(log.events, false);
-    } catch {
-      renderBrowserLog(null, true);
+
+    function renderPaused(nextPaused) {
+      paused = !!nextPaused;
+      els.pauseChip.textContent = paused ? 'Human in control' : 'Agent active';
+      els.pauseChip.className = 'sv-chip ' + (paused ? 'sv-chip--paused' : 'sv-chip--resting');
+      els.pausedBanner.classList.toggle('sv-hidden', !paused);
+      els.takeoverButton.classList.toggle('sv-hidden', paused);
+      els.handBackButton.classList.toggle('sv-hidden', !paused);
     }
-  }
 
-  buildLayout();
-
-  els.attachButton.addEventListener('click', async () => {
-    els.attachButton.disabled = true;
-    try {
-      const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/attach`, { method: 'POST' });
-      renderAttachState(await res.json());
-    } finally {
-      els.attachButton.disabled = false;
+    function renderGate(browserMcpEnabled) {
+      els.browserButton.disabled = !browserMcpEnabled;
+      els.browserButton.setAttribute('aria-disabled', String(!browserMcpEnabled));
+      els.browserGateNote.classList.toggle('sv-hidden', browserMcpEnabled);
     }
-  });
 
-  els.browserButton.addEventListener('click', async () => {
-    els.browserButton.disabled = true;
-    try {
-      const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/browser-session`, { method: 'POST' });
-      const body = await res.json();
-      if (body.ok) {
-        els.browserPane.classList.remove('sv-hidden');
-        els.browserGateNote.classList.add('sv-hidden');
-      } else {
-        els.browserGateNote.textContent = 'Browser session unavailable: ' + (body.reason || 'unknown');
-        els.browserGateNote.classList.remove('sv-hidden');
+    function renderIdentity(view) {
+      els.identityChips.textContent = '';
+      const parts = [view.role, view.callsign, view.model, view.effort].filter(Boolean);
+      parts.forEach((p) => els.identityChips.appendChild(el('span', 'sv-id-chip', String(p))));
+      const badge = normalizeBadge(view.badge);
+      els.statusPill.textContent = badge;
+      els.statusPill.className = 'sv-status-pill sv-status-pill--' + badge.toLowerCase().replace(/\s+/g, '-');
+
+      els.accountPanel.textContent = '';
+      els.accountPanel.appendChild(el('p', 'sv-account-field', 'Callsign: ' + (view.callsign || '—')));
+      els.accountPanel.appendChild(el('p', 'sv-account-field', 'Model: ' + (view.model || '—') + ' · Effort: ' + (view.effort || '—')));
+    }
+
+    function renderView(view) {
+      els.ttyFooter.textContent =
+        `ctx ${view.ctxPercent == null ? '—' : view.ctxPercent + '%'} · ` +
+        `last tool ${formatTimeAgo(view.lastToolAt)} · ` +
+        `wakeup ${formatWakeupLabel(view.silentUntil)}`;
+      renderAttachState(view.attachState);
+      renderPaused(!!view.paused);
+      renderGate(!!view.browserMcpEnabled);
+      renderIdentity(view);
+    }
+
+    function renderNarration(events, errored) {
+      els.narrationList.textContent = '';
+      if (errored) {
+        els.narrationList.appendChild(el('li', 'sv-log-empty', 'Unable to load agent narration.'));
+        return;
       }
-    } finally {
-      els.browserButton.disabled = false;
+      const lines = buildNarrationLines(events);
+      if (lines.length === 0) {
+        els.narrationList.appendChild(el('li', 'sv-log-empty', 'No agent actions recorded yet.'));
+        return;
+      }
+      lines.forEach((line) => els.narrationList.appendChild(el('li', 'sv-narration-line', line)));
     }
-  });
 
-  els.takeoverButton.addEventListener('click', async () => {
-    await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/takeover`, { method: 'POST' });
-    await refresh();
-  });
+    const LOG_EVENT_LABELS = { browser_takeover: 'Human took control', browser_handback: 'Control returned to agent' };
 
-  els.handBackButton.addEventListener('click', async () => {
-    await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/hand-back`, { method: 'POST' });
-    await refresh();
-  });
+    function renderBrowserLog(events, errored) {
+      els.browserLog.textContent = '';
+      if (errored) {
+        els.browserLog.appendChild(el('li', 'sv-log-empty', 'Unable to load browser action log.'));
+        return;
+      }
+      if (!events || events.length === 0) {
+        els.browserLog.appendChild(el('li', 'sv-log-empty', 'No take-over/hand-back events recorded yet.'));
+        return;
+      }
+      for (const ev of events) {
+        const label = LOG_EVENT_LABELS[ev.event_type] || ev.event_type;
+        els.browserLog.appendChild(el('li', 'sv-log-entry', `${ev.created_at} — ${label}`));
+      }
+    }
 
-  refresh();
-})();
+    async function fetchView() {
+      const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}`, { method: 'GET' });
+      if (!res.ok) throw new Error(`view fetch failed: ${res.status}`);
+      return res.json();
+    }
+
+    async function fetchBrowserLog() {
+      const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/browser-log`, { method: 'GET' });
+      if (!res.ok) throw new Error(`browser-log fetch failed: ${res.status}`);
+      return res.json();
+    }
+
+    async function refresh() {
+      try {
+        renderView(await fetchView());
+      } catch {
+        els.attachMessage.textContent = 'Unable to load session state.';
+      }
+      try {
+        const log = await fetchBrowserLog();
+        renderBrowserLog(log.events, false);
+        renderNarration(log.events, false);
+      } catch {
+        renderBrowserLog(null, true);
+        renderNarration(null, true);
+      }
+    }
+
+    buildLayout();
+
+    els.attachButton.addEventListener('click', async () => {
+      els.attachButton.disabled = true;
+      try {
+        const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/attach`, { method: 'POST' });
+        renderAttachState(await res.json());
+      } finally {
+        els.attachButton.disabled = false;
+      }
+    });
+
+    els.browserButton.addEventListener('click', async () => {
+      els.browserButton.disabled = true;
+      try {
+        const res = await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/browser-session`, { method: 'POST' });
+        const body = await res.json();
+        if (body.ok) {
+          els.browserPane.classList.remove('sv-hidden');
+          els.browserGateNote.classList.add('sv-hidden');
+        } else {
+          els.browserGateNote.textContent = 'Browser session unavailable: ' + (body.reason || 'unknown');
+          els.browserGateNote.classList.remove('sv-hidden');
+        }
+      } finally {
+        els.browserButton.disabled = false;
+      }
+    });
+
+    els.takeoverButton.addEventListener('click', async () => {
+      await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/takeover`, { method: 'POST' });
+      await refresh();
+    });
+
+    els.handBackButton.addEventListener('click', async () => {
+      await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/hand-back`, { method: 'POST' });
+      await refresh();
+    });
+
+    // FR-4: take-over-on-first-click -- any click inside the browser pane while the agent is
+    // driving yields control, mirroring the explicit "Take control" button. Excludes the
+    // take-over/hand-back buttons themselves (they already have dedicated handlers above; without
+    // this exclusion a click on "Take control" would fire the POST twice).
+    els.agentBrowserPane.addEventListener('click', async (evt) => {
+      if (paused) return;
+      if (els.takeoverButton.contains(evt.target) || els.handBackButton.contains(evt.target)) return;
+      await fetch(`${API_BASE}/${encodeURIComponent(sessionId)}/takeover`, { method: 'POST' });
+      await refresh();
+    });
+
+    // FR-5: F/B/A keyboard navigation, suppressed while a form field has focus.
+    document.addEventListener('keydown', (evt) => {
+      if (isEditableTarget(document.activeElement)) return;
+      const action = resolveKeyAction(evt.key);
+      if (!action) return;
+      if (action === 'fleet-view') {
+        location.href = '/fleet-ui/fleet-panel.html';
+      } else if (action === 'toggle-browser') {
+        els.agentBrowserPane.classList.toggle('sv-hidden');
+      } else if (action === 'toggle-account') {
+        els.accountPanel.classList.toggle('sv-hidden');
+      }
+    });
+
+    refresh();
+  }
+
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    initBrowser();
+  }
+
+  return {
+    formatTimeAgo,
+    formatWakeupLabel,
+    buildNarrationLines,
+    attachStyleFor,
+    resolveKeyAction,
+    isEditableTarget,
+    normalizeBadge,
+  };
+});

--- a/server/public/fleet-ui/session-view.test.js
+++ b/server/public/fleet-ui/session-view.test.js
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unit + integration tests for the session-view mockup-2 render completion
+ * (SD-LEO-INFRA-LEO-APP-RENDERED-001-B). Covers PRD test_scenarios TS-1..TS-7.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function loadModule() {
+  vi.resetModules();
+  return import('./session-view.js');
+}
+
+function setLocation(pathAndQuery) {
+  window.history.pushState({}, '', pathAndQuery);
+}
+
+function mountRoot() {
+  document.body.innerHTML = '<main id="session-view"></main>';
+}
+
+// -------------------------------------------------------------------------
+// Pure helpers (no DOM needed) -- TS-2/TS-4/TS-5
+// -------------------------------------------------------------------------
+
+describe('pure helpers', () => {
+  it('formatTimeAgo: seconds/minutes/hours buckets, and — for missing/unparseable input', async () => {
+    const { formatTimeAgo } = await loadModule();
+    const now = Date.parse('2026-01-01T00:10:00Z');
+    expect(formatTimeAgo(null, now)).toBe('—');
+    expect(formatTimeAgo('not-a-date', now)).toBe('—');
+    expect(formatTimeAgo('2026-01-01T00:09:57Z', now)).toBe('3s ago');
+    expect(formatTimeAgo('2026-01-01T00:07:00Z', now)).toBe('3m ago');
+    expect(formatTimeAgo('2025-12-31T22:10:00Z', now)).toBe('2h ago');
+  });
+
+  it("formatWakeupLabel: 'none' for missing/past, 'armed HH:MM' for a future silent-until", async () => {
+    const { formatWakeupLabel } = await loadModule();
+    const now = Date.parse('2026-01-01T14:00:00Z');
+    expect(formatWakeupLabel(null, now)).toBe('none');
+    expect(formatWakeupLabel('2026-01-01T13:00:00Z', now)).toBe('none'); // in the past
+    const future = new Date(now + 26 * 60 * 1000).toISOString();
+    const label = formatWakeupLabel(future, now);
+    expect(label).toMatch(/^armed \d{2}:\d{2}$/);
+  });
+
+  it('TS-2: buildNarrationLines derives numbered lines 1:1 from real events, empty array when none', async () => {
+    const { buildNarrationLines } = await loadModule();
+    expect(buildNarrationLines(null)).toEqual([]);
+    expect(buildNarrationLines([])).toEqual([]);
+    const events = [
+      { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
+      { event_type: 'browser_handback', created_at: '2026-01-01T00:05:00Z' },
+      { event_type: 'unknown_event', created_at: '2026-01-01T00:06:00Z' },
+    ];
+    const lines = buildNarrationLines(events);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('1. Human took control (2026-01-01T00:00:00Z)');
+    expect(lines[1]).toBe('2. Control returned to agent (2026-01-01T00:05:00Z)');
+    expect(lines[2]).toBe('3. unknown_event (2026-01-01T00:06:00Z)');
+  });
+
+  it('TS-4: resolveKeyAction maps F/B/A (case-insensitive) to their semantic actions, others to null', async () => {
+    const { resolveKeyAction } = await loadModule();
+    expect(resolveKeyAction('f')).toBe('fleet-view');
+    expect(resolveKeyAction('F')).toBe('fleet-view');
+    expect(resolveKeyAction('b')).toBe('toggle-browser');
+    expect(resolveKeyAction('B')).toBe('toggle-browser');
+    expect(resolveKeyAction('a')).toBe('toggle-account');
+    expect(resolveKeyAction('A')).toBe('toggle-account');
+    expect(resolveKeyAction('x')).toBeNull();
+    expect(resolveKeyAction('Enter')).toBeNull();
+    expect(resolveKeyAction(null)).toBeNull();
+  });
+
+  it('TS-5: isEditableTarget recognizes input/textarea/contenteditable, rejects everything else', async () => {
+    const { isEditableTarget } = await loadModule();
+    expect(isEditableTarget(null)).toBe(false);
+    expect(isEditableTarget({ tagName: 'INPUT' })).toBe(true);
+    expect(isEditableTarget({ tagName: 'TEXTAREA' })).toBe(true);
+    expect(isEditableTarget({ tagName: 'DIV', isContentEditable: true })).toBe(true);
+    expect(isEditableTarget({ tagName: 'DIV', isContentEditable: false })).toBe(false);
+    expect(isEditableTarget({ tagName: 'BODY' })).toBe(false);
+  });
+
+  it('normalizeBadge falls back to — for any value outside the canonical 7-label vocabulary', async () => {
+    const { normalizeBadge } = await loadModule();
+    expect(normalizeBadge('WORKING')).toBe('WORKING');
+    expect(normalizeBadge('OFF')).toBe('OFF');
+    expect(normalizeBadge('bogus')).toBe('—');
+    expect(normalizeBadge(undefined)).toBe('—');
+  });
+
+  it('attachStyleFor: resting/ok/degraded reasons map to distinct styles', async () => {
+    const { attachStyleFor } = await loadModule();
+    expect(attachStyleFor(null).label).toBe('Attach: unknown');
+    expect(attachStyleFor({ ok: true }).label).toBe('Attached');
+    expect(attachStyleFor({ ok: false, reason: 'stale_handle' }).label).toBe('Window handle stale');
+    expect(attachStyleFor({ ok: false, reason: 'not_found' }).label).toBe('Could not resolve target');
+  });
+});
+
+// -------------------------------------------------------------------------
+// Integration (stubbed fetch, real jsdom render) -- TS-1/TS-3/TS-6
+// -------------------------------------------------------------------------
+
+describe('integration (rendered DOM)', () => {
+  beforeEach(() => {
+    mountRoot();
+    setLocation('/fleet-ui/session-view.html?id=sess-1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetchSequence({ view, browserLog, viewOk = true, logOk = true }) {
+    const fetchMock = vi.fn((url) => {
+      if (String(url).endsWith('/browser-log')) {
+        return Promise.resolve({
+          ok: logOk,
+          status: logOk ? 200 : 500,
+          json: () => Promise.resolve(browserLog),
+        });
+      }
+      return Promise.resolve({
+        ok: viewOk,
+        status: viewOk ? 200 : 500,
+        json: () => Promise.resolve(view),
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  it('TS-1: happy-path render shows header, TTY footer, and empty-state narration', async () => {
+    stubFetchSequence({
+      view: {
+        ctxPercent: 41, lastTool: 'Read', lastToolAt: '2026-01-01T00:09:57Z',
+        lastActivityKind: 'tool', silentUntil: null, attachState: { ok: null },
+        paused: false, browserMcpEnabled: true,
+        badge: 'WORKING', role: 'advisor', model: 'sonnet', effort: 'high', callsign: 'Alpha-5',
+      },
+      browserLog: { ok: true, events: [] },
+    });
+
+    await loadModule();
+    // Flush the two chained fetch()/json() promise ticks inside refresh().
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const header = document.querySelector('.sv-appheader');
+    expect(header).not.toBeNull();
+    expect(header.textContent).toContain('[F] Fleet view · [B] toggle browser · [A] account');
+    expect(document.querySelector('.sv-status-pill').textContent).toBe('WORKING');
+    expect(document.querySelector('.sv-tty-footer').textContent).toContain('ctx 41%');
+    expect(document.querySelector('.sv-narration-list').textContent).toContain('No agent actions recorded yet.');
+  });
+
+  it('TS-3: narration renders numbered lines matching real browser-log events, 1:1', async () => {
+    stubFetchSequence({
+      view: {
+        ctxPercent: 10, lastToolAt: null, silentUntil: null, attachState: { ok: null },
+        paused: false, browserMcpEnabled: true, badge: 'WORKING',
+      },
+      browserLog: {
+        ok: true,
+        events: [
+          { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
+          { event_type: 'browser_handback', created_at: '2026-01-01T00:05:00Z' },
+        ],
+      },
+    });
+
+    await loadModule();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const items = document.querySelectorAll('.sv-narration-line');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('1. Human took control (2026-01-01T00:00:00Z)');
+    expect(items[1].textContent).toBe('2. Control returned to agent (2026-01-01T00:05:00Z)');
+  });
+
+  it('TS-6: graceful degradation when the session-detail fetch fails', async () => {
+    stubFetchSequence({ view: null, viewOk: false, browserLog: { ok: true, events: [] } });
+
+    await loadModule();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    expect(document.querySelector('.sv-attach-message').textContent).toBe('Unable to load session state.');
+    // No thrown exception reached here means the catch path held; status pill stays at its safe default.
+    expect(document.querySelector('.sv-status-pill').textContent).toBe('—');
+  });
+
+  it('B toggles the agent-browser pane visibility; A toggles the account panel; guarded while typing', async () => {
+    stubFetchSequence({
+      view: { ctxPercent: 0, attachState: { ok: null }, paused: false, browserMcpEnabled: true, badge: 'WORKING' },
+      browserLog: { ok: true, events: [] },
+    });
+    await loadModule();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const browserPane = document.querySelector('.sv-browser-pane');
+    const accountPanel = document.querySelector('.sv-account-panel');
+    expect(browserPane.classList.contains('sv-hidden')).toBe(true);
+    expect(accountPanel.classList.contains('sv-hidden')).toBe(true);
+
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+    expect(browserPane.classList.contains('sv-hidden')).toBe(false);
+
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    expect(accountPanel.classList.contains('sv-hidden')).toBe(false);
+
+    // Guard: typing 'b' inside an input must not toggle anything back.
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+    expect(browserPane.classList.contains('sv-hidden')).toBe(false); // unchanged
+  });
+});
+
+// -------------------------------------------------------------------------
+// TS-7: no fabricated mockup dialogue ships in the source.
+// -------------------------------------------------------------------------
+
+describe('TS-7: no fabricated mockup dialogue', () => {
+  it('the shipped source never contains the mockup-illustrative dialogue literals', () => {
+    const source = readFileSync(path.join(__dirname, 'session-view.js'), 'utf8');
+    const forbidden = [
+      'Help me visualize the launcher layer',
+      'Superforecasters',
+      'forecastbench.org',
+      'Ran 2 shell commands',
+      'MOCK_LIVE drive.google.com',
+    ];
+    for (const literal of forbidden) {
+      expect(source).not.toContain(literal);
+    }
+  });
+});

--- a/server/public/fleet-ui/session-view.test.js
+++ b/server/public/fleet-ui/session-view.test.js
@@ -53,13 +53,16 @@ describe('pure helpers', () => {
     const { buildNarrationLines } = await loadModule();
     expect(buildNarrationLines(null)).toEqual([]);
     expect(buildNarrationLines([])).toEqual([]);
+    // ADVERSARIAL REVIEW FIX: GET /:id/browser-log returns newest-first (descending
+    // created_at) -- this fixture matches that real ordering, not an idealized ascending one.
     const events = [
-      { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
-      { event_type: 'browser_handback', created_at: '2026-01-01T00:05:00Z' },
       { event_type: 'unknown_event', created_at: '2026-01-01T00:06:00Z' },
+      { event_type: 'browser_handback', created_at: '2026-01-01T00:05:00Z' },
+      { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
     ];
     const lines = buildNarrationLines(events);
     expect(lines).toHaveLength(3);
+    // Narration must number in causal (ascending) order regardless of input order.
     expect(lines[0]).toBe('1. Human took control (2026-01-01T00:00:00Z)');
     expect(lines[1]).toBe('2. Control returned to agent (2026-01-01T00:05:00Z)');
     expect(lines[2]).toBe('3. unknown_event (2026-01-01T00:06:00Z)');
@@ -169,9 +172,10 @@ describe('integration (rendered DOM)', () => {
       },
       browserLog: {
         ok: true,
+        // Real endpoint order: newest-first (descending created_at).
         events: [
-          { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
           { event_type: 'browser_handback', created_at: '2026-01-01T00:05:00Z' },
+          { event_type: 'browser_takeover', created_at: '2026-01-01T00:00:00Z' },
         ],
       },
     });

--- a/server/routes/fleet-sessions.js
+++ b/server/routes/fleet-sessions.js
@@ -35,6 +35,7 @@ import {
   isBrowserMcpEnabled,
 } from '../../lib/fleet/browser-control.js';
 import { buildSessionDetailView, mapAttachState } from '../../lib/fleet/session-detail-view.js';
+import { computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
 
 function getSupabase() {
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -46,11 +47,41 @@ function getSupabase() {
 async function fetchFreshSession(supabase, sessionId) {
   const { data, error } = await supabase
     .from('claude_sessions')
-    .select('session_id, status, current_tool, last_tool_at, last_activity_kind, expected_silence_until, metadata')
+    .select('session_id, status, loop_state, current_tool, last_tool_at, last_activity_kind, expected_silence_until, metadata')
     .eq('session_id', sessionId)
     .maybeSingle();
   if (error) throw new Error(`fetchFreshSession: ${error.message}`);
   return data;
+}
+
+/** Whether `expected_silence_until` is still in the future (PRD TR-1). Mirrors
+ * scripts/fleet-dashboard.cjs's formatSilentUntil/isSilent inline logic -- no shared helper
+ * exists yet, so this is a deliberate small duplication rather than a new cross-module dep. */
+function isSilentNow(expectedSilenceUntil) {
+  if (!expectedSilenceUntil) return false;
+  const endMs = Date.parse(expectedSilenceUntil);
+  return Number.isFinite(endMs) && endMs > Date.now();
+}
+
+/** PRD TR-1: additive identity/badge fields for the header bar. `pAlive` has no cheap
+ * per-row source (it requires the fleet-wide Monte-Carlo liveness subprocess) so it is
+ * omitted (null) here -- computeSessionBadge() degrades gracefully without it. */
+function buildIdentityFields(session) {
+  const meta = session?.metadata || {};
+  const role = meta.fleet_identity?.role ?? null;
+  const model = meta.model ?? null;
+  const effort = meta.effort ?? null;
+  const callsign = meta.fleet_identity?.callsign ?? meta.callsign ?? null;
+  const badge = computeSessionBadge({
+    loopState: session?.loop_state ?? null,
+    pAlive: null,
+    isSilent: isSilentNow(session?.expected_silence_until),
+    computedStatus: session?.status ?? null,
+    role,
+    model,
+    effort,
+  });
+  return { badge, role, model, effort, callsign };
 }
 
 const router = Router();
@@ -74,7 +105,12 @@ router.get('/:id', async (req, res) => {
     const session = await fetchFreshSession(supabase, req.params.id);
     if (!session) return res.status(404).json({ ok: false, reason: 'session_not_found' });
     const view = buildSessionDetailView(session);
-    res.json({ ...view, paused: isPaused(session), browserMcpEnabled: isBrowserMcpEnabled(session) });
+    res.json({
+      ...view,
+      paused: isPaused(session),
+      browserMcpEnabled: isBrowserMcpEnabled(session),
+      ...buildIdentityFields(session),
+    });
   } catch (error) {
     console.error('[fleet-sessions] GET /:id failed:', error.message);
     res.status(500).json({ ok: false, reason: 'internal_error', message: error.message });

--- a/server/routes/fleet-sessions.test.js
+++ b/server/routes/fleet-sessions.test.js
@@ -96,6 +96,38 @@ describe('GET /:id', () => {
     expect(payload.browserMcpEnabled).toBe(true);
     expect(payload.attachState).toEqual({ ok: null, reason: null, degraded: false, message: null });
   });
+
+  it('SD-LEO-INFRA-LEO-APP-RENDERED-001-B TR-1: includes additive badge/model/effort/role/callsign fields', async () => {
+    mockFromReturningSession({
+      session_id: 'sess-1', status: 'active', loop_state: 'active', current_tool: 'Read',
+      last_tool_at: '2026-01-01T00:00:00Z', last_activity_kind: 'tool', expected_silence_until: null,
+      metadata: { model: 'opus', effort: 'xhigh', fleet_identity: { role: 'advisor', callsign: 'Alpha-5' } },
+    });
+    mockIsPaused.mockReturnValue(false);
+    mockIsBrowserMcpEnabled.mockReturnValue(true);
+
+    const { res } = await invokeRoute('GET', '/:id', { params: { id: 'sess-1' } });
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.badge).toBe('DEEP WORK');
+    expect(payload.model).toBe('opus');
+    expect(payload.effort).toBe('xhigh');
+    expect(payload.role).toBe('advisor');
+    expect(payload.callsign).toBe('Alpha-5');
+  });
+
+  it('SD-LEO-INFRA-LEO-APP-RENDERED-001-B TR-1: additive fields degrade to null/safe defaults when metadata is empty', async () => {
+    mockFromReturningSession({ session_id: 'sess-1', status: 'active', metadata: {} });
+    mockIsPaused.mockReturnValue(false);
+    mockIsBrowserMcpEnabled.mockReturnValue(false);
+
+    const { res } = await invokeRoute('GET', '/:id', { params: { id: 'sess-1' } });
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.badge).toBe('WORKING');
+    expect(payload.model).toBeNull();
+    expect(payload.effort).toBeNull();
+    expect(payload.role).toBeNull();
+    expect(payload.callsign).toBeNull();
+  });
 });
 
 describe('GET /:id/browser-log', () => {


### PR DESCRIPTION
## Summary
- Completes the render layer of `server/public/fleet-ui/session-view.{html,js,css}` to match the ratified mockup-2 image (`docs/design/mockup-2-session-view-terminal-agent-browser.png`): app header (identity chips + 7-label status pill + F/B/A key legend), a TTY/terminal pane with a ctx%/last-tool/wakeup footer, and an agent-browser pane (URL bar + AGENT badge + numbered narration stream + take-over-on-first-click).
- `GET /api/fleet/sessions/:id` gains additive `badge`/`model`/`effort`/`role`/`callsign` fields, reusing the existing `computeSessionBadge()` (zero logic duplication).
- Narration is synthesized from real browser-log events only — no fabricated dialogue, enforced by a merge-blocking static string-search test (TS-7).
- Existing attach/browser-session/takeover/hand-back functionality is unchanged (19 pre-existing route tests still pass, zero regressions).

**PR size note**: exceeds the ≤100 LOC target / documented-justification 400 LOC ceiling (~830 real added lines across 3 rewritten files + 1 new test file). Justification: single cohesive child SD scoped to one ratified mockup (chairman priority #1, LEO app launcher lane); LEAD-phase VALIDATION sub-agent evaluated and rejected further splitting as non-duplicative, atomic scope. Most volume is UI-structural DOM-building code + a comprehensive test suite (245 lines), not complex logic.

## Test plan
- [x] `npx vitest run server/routes/fleet-sessions.test.js server/public/fleet-ui/session-view.test.js` — 31/31 passing
- [x] All 7 PRD test_scenarios (TS-1..TS-7) covered by real, distinct tests (verified by TESTING sub-agent)
- [x] Real Playwright screenshot taken during EXEC, visually compared against the ratified mockup — caught and fixed a narration double-numbering bug before merge
- [x] SECURITY sub-agent PASS (92% confidence) — no new XSS/injection/authZ risk
- [x] TESTING sub-agent PASS (92% confidence) — dual-test requirement satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)