### PR TITLE
fix(QF-20260724-923): wire start-cp3-drills live path to emit fleet_verb_* evidence

### DIFF
--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -38,7 +38,7 @@ export function planDrills({ canaryProfile = 'canary', cwd, live = false } = {},
   const repoRoot = deps.resolveRepoRoot || resolveRepoRoot;
   const canaryProfileDir = resolveProfile(canaryProfile, { env }); // fail-loud precondition
   const startDir = (cwd && String(cwd).trim()) ? String(cwd) : repoRoot(env);
-  return { live: !!live, cwd: startDir, canaryProfileDir, legs: LEGS.map((l) => ({ ...l })) };
+  return { live: !!live, cwd: startDir, canaryProfile, canaryProfileDir, legs: LEGS.map((l) => ({ ...l })) };
 }
 
 /** Run the starter. Returns a result object; never runs live kill/reboot itself (delegates + self-gates). */
@@ -65,14 +65,46 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   return { ok: true, live: true, legs: plan.legs, results };
 }
 
-async function defaultRunDrills(plan, deps = {}) {
-  const { runRebootRespawnDrill } = await import('../../lib/fleet/reboot-respawn-drill-runner.js');
-  const { runU4Drill } = await import('../../lib/fleet/u4-drill-runner.js');
-  const supabase = deps.supabase || null; // real client supplied by the operator wrapper when live
-  // reboot-respawn + u4 both default-gate; kill-supervisor is exercised by the supervisor's own drill doc.
+/**
+ * QF-20260724-923: WIRE the live path so `--live` writes THREE real fleet_verb_* rows (was a stub that
+ * passed supabase=null + gave runU4Drill only {opts:{}} -> zero evidence). Every dependency is
+ * injectable so this is unit-testable with ZERO live spawn/kill; the canary-guard gating
+ * (assertCanaryTarget + FLEET_CANARY_KILL_ENABLED) still fail-closes a real run against a non-canary.
+ */
+export async function defaultRunDrills(plan, deps = {}) {
+  const load = async (p, name, injected) => injected || (await import(p))[name];
+  const runRebootRespawnDrill = await load('../../lib/fleet/reboot-respawn-drill-runner.js', 'runRebootRespawnDrill', deps.runRebootRespawnDrill);
+  const runU4Drill = await load('../../lib/fleet/u4-drill-runner.js', 'runU4Drill', deps.runU4Drill);
+  const cg = deps.canaryGuard || await import('../../lib/fleet/canary-guard.js');
+  const resolveCanary = deps.resolveCanaryTarget || cg.resolveCanaryTarget;
+  const canaryRestart = deps.canaryRestart || cg.canaryRestart;
+  const canaryRelaunchUnderProfile = deps.canaryRelaunchUnderProfile || cg.canaryRelaunchUnderProfile;
+
+  // (1) real SERVICE client so the drills can loadDesiredSlots + WRITE fleet_verb_* rows (was null).
+  const supabase = deps.supabase || (await import('../../lib/supabase-client.cjs')).createSupabaseServiceClient();
+
+  // Resolve the live canary session (canary-guard fail-closes if none / not a real canary).
+  const target = await resolveCanary(supabase, { by: 'account_profile', value: 'canary' });
+  const sessionId = target && (target.session_id || target.id);
+  const fromProfile = process.env.FLEET_LIVE_PROFILE || 'live';
+  const toProfile = plan?.canaryProfile || 'canary';
+  const queryEventsFn = deps.queryEventsFn || (async (sid) => {
+    const { data } = await supabase.from('coordination_events').select('event_type,payload,session_id')
+      .eq('session_id', sid).like('event_type', 'fleet_verb_%');
+    return data || [];
+  });
+
+  // G1a kill-supervisor -> fleet_verb_restart (canary-guarded).
+  const g1a = await Promise.resolve(canaryRestart(target, { supabase })).catch((e) => ({ error: e && e.message }));
+  // (3) G1b+G2 reboot-respawn -> fleet_verb_respawn (now with a real client, not null).
   const reboot = await runRebootRespawnDrill({ supabase, live: true }).catch((e) => ({ error: e && e.message }));
-  const u4 = await runU4Drill({ opts: {} }).catch((e) => ({ error: e && e.message }));
-  return { reboot, u4 };
+  // (2) G3+U4 relaunch-under-profile -> fleet_verb_relaunch_under_profile (required args wired, was {opts:{}}).
+  const u4 = await runU4Drill({
+    target, fromProfile, toProfile, sessionId,
+    relaunchFn: canaryRelaunchUnderProfile, resolveFn: resolveProfileDir, queryEventsFn, opts: { supabase },
+  }).catch((e) => ({ error: e && e.message }));
+
+  return { g1a, reboot, u4 };
 }
 
 const isMain = process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -1,6 +1,6 @@
 // SD-LEO-INFRA-LEO-APP-LAUNCHER-001 (FR-4) — worker-startable CP3 drill starter.
 import { describe, it, expect, vi } from 'vitest';
-import { planDrills, main } from '../../../scripts/fleet/start-cp3-drills.js';
+import { planDrills, main, defaultRunDrills } from '../../../scripts/fleet/start-cp3-drills.js';
 import { LaunchResolveError } from '../../../lib/fleet/build-session-launch.cjs';
 
 const OKENV = { FLEET_ACCOUNT_PROFILES_DIR: 'C:\\fleet\\profiles' };
@@ -37,5 +37,39 @@ describe('main — worker-startable, dry-run default', () => {
     expect(r.ok).toBe(true);
     expect(r.live).toBe(true);
     expect(runDrills).toHaveBeenCalledTimes(1);
+  });
+});
+
+// QF-20260724-923: the live path must WIRE all 3 legs to emit real fleet_verb_* evidence (was a stub).
+describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
+  it('uses a real supabase client, resolves the canary, and calls all 3 legs with the required args', async () => {
+    const supabase = { from: vi.fn() };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const resolveCanaryTarget = vi.fn(async () => target);
+    const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
+    const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
+    const runRebootRespawnDrill = vi.fn(async () => ({ pass: true }));
+    const runU4Drill = vi.fn(async () => ({ pass: true }));
+
+    const plan = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+    const res = await defaultRunDrills(plan, {
+      supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
+    });
+
+    // supabase is NOT null (was the stub bug); canary resolved.
+    expect(resolveCanaryTarget).toHaveBeenCalledWith(supabase, { by: 'account_profile', value: 'canary' });
+    // G1a kill-supervisor -> fleet_verb_restart.
+    expect(canaryRestart).toHaveBeenCalledWith(target, { supabase });
+    // G1b+G2 reboot-respawn gets a REAL client + live:true (was supabase=null).
+    expect(runRebootRespawnDrill).toHaveBeenCalledWith({ supabase, live: true });
+    // G3+U4 gets the REQUIRED args (was only {opts:{}} -> no-op): target, sessionId, relaunchFn, resolveFn, queryEventsFn.
+    const u4Args = runU4Drill.mock.calls[0][0];
+    expect(u4Args.target).toBe(target);
+    expect(u4Args.sessionId).toBe('canary-sess-1');
+    expect(u4Args.toProfile).toBe('canary');
+    expect(typeof u4Args.relaunchFn).toBe('function');
+    expect(typeof u4Args.resolveFn).toBe('function');
+    expect(typeof u4Args.queryEventsFn).toBe('function');
+    expect(res).toMatchObject({ g1a: expect.anything(), reboot: expect.anything(), u4: expect.anything() });
   });
 });


### PR DESCRIPTION
Capstone follow-on to SD-LEO-INFRA-LEO-APP-LAUNCHER-001 (FR-4). The `defaultRunDrills` live path was a stub — `supabase=null`, `runU4Drill` got only `{opts:{}}`, no G1a — so `start-cp3-drills.js --live` wrote **zero** `fleet_verb_*` rows.

Per Solomon's RCA (`cp3-drill-starter-stub-20260724`), wired all 3 legs:
- **G1a** kill-supervisor → `canaryRestart` → `fleet_verb_restart`
- **G1b+G2** reboot-respawn → `runRebootRespawnDrill({supabase, live:true})` → `fleet_verb_respawn`
- **G3+U4** → `runU4Drill` with the required args (`target`, `fromProfile`, `toProfile`, `sessionId`, `relaunchFn=canaryRelaunchUnderProfile`, `resolveFn`, `queryEventsFn`) → `fleet_verb_relaunch_under_profile`
- real `createSupabaseServiceClient` in `--live`; canary target via `resolveCanaryTarget`

Every dep injectable → unit-tested with **zero live spawn/kill** (new test asserts the 3 legs are called with correct args + a real client). `canary-guard`'s `assertCanaryTarget` + `FLEET_CANARY_KILL_ENABLED` still fail-close a real run against a non-canary; the live run itself stays CP3's gated acceptance step (Golf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)