### PR TITLE
fix(QF-20260724-119): fail-loud guard against real live-drill spawn under test runner

### DIFF
--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -60,6 +60,16 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   }
   // LIVE: delegate to the drill runners (which route launches through buildSessionLaunch and self-gate on
   // the live env flags). Injectable for tests so the unit path never spawns.
+  // QF-20260724-119: fail-loud (not silent) when --live is invoked under a test runner with no injected
+  // runDrills override -- this exact gap caused 12-13 real fleet-worker process spawns on the chairman's
+  // machine during CP3 drill-fix testing (correlation_id=cp3-do-it-right-20260724): a non-mocked test
+  // called main(['--live'], {...}) with no override, and the worktree's FLEET_SPAWN_CONTROL_LIVE=true let
+  // defaultRunDrills() spawn/kill for real.
+  if (!deps.runDrills && (process.env.VITEST || process.env.NODE_ENV === 'test')) {
+    const msg = '[start-cp3-drills] REFUSED: --live under a test runner (VITEST/NODE_ENV=test) with no injected deps.runDrills would fall through to the REAL defaultRunDrills() and risk live process spawns. Inject deps.runDrills.';
+    log(msg);
+    return { ok: false, error: msg };
+  }
   const run = deps.runDrills || defaultRunDrills;
   const results = await run(plan, deps);
   return { ok: true, live: true, legs: plan.legs, results };

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -38,6 +38,17 @@ describe('main — worker-startable, dry-run default', () => {
     expect(r.live).toBe(true);
     expect(runDrills).toHaveBeenCalledTimes(1);
   });
+
+  // QF-20260724-119: regression test for the cp3-do-it-right-20260724 incident (12-13 real fleet-worker
+  // process spawns caused by a non-mocked test invoking --live with no runDrills override).
+  it('REFUSES --live under the test runner when no runDrills override is injected (QF-20260724-119)', async () => {
+    const logs = [];
+    const r = await main(['--live'], { env: OKENV, log: (m) => logs.push(m) });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/REFUSED/);
+    expect(r.error).toMatch(/runDrills/);
+    expect(logs.join('\n')).toMatch(/REFUSED/);
+  });
 });
 
 // QF-20260724-923: the live path must WIRE all 3 legs to emit real fleet_verb_* evidence (was a stub).


### PR DESCRIPTION
Fail-loud guard preventing start-cp3-drills.js main() from silently falling through to the real defaultRunDrills() under a test runner with no injected runDrills override. Prevents recurrence of the cp3-do-it-right-20260724 incident. Regression test added, 7/7 pass.