### PR TITLE
fix(fleet): skip canary sessions from callsign reassignment (QF-20260724-521)

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -385,6 +385,15 @@ async function main() {
 
   for (const worker of uniqueWorkers) {
     const identity = worker.metadata?.fleet_identity;
+    // QF-20260724-521: canary sessions (account_profile='canary', callsign 'Canary-N') live
+    // outside the NATO tier-band scheme entirely -- canary-guard requires the callsign to
+    // start with 'Canary-'. Without this skip, the tier-band check below always fails for
+    // them (Canary-1 is never in any NATO band), so they get demoted to needsAssignment and
+    // reassigned a NATO callsign, breaking canary-guard mid-drill.
+    if (worker.metadata?.account_profile === 'canary' || identity?.callsign?.startsWith('Canary-')) {
+      assignedRaw.push(worker);
+      continue;
+    }
     // QF-20260627-108 (FR-1): a worker is "assigned" ONLY if its callsign is in its tier band
     // (effort-encoded SoT). A callsign from the wrong band (e.g. a tier-2 worker still holding
     // "Bravo") is re-derived, so the chairman scheme self-heals instead of being preserved-wrong.

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -339,3 +339,33 @@ describe('filterOutGhostSessions + shared isFixtureSession (SD-FDBK-INFRA-SHARED
     expect(src).toContain('filterOutGhostSessions(nonCoordinators, claimedSessionIds, isFixtureSession)');
   });
 });
+
+// QF-20260724-521: assign-fleet-identities reassigned a live canary session's Canary-1
+// callsign to a NATO band callsign (Charlie), because Canary-1 is never in any tier band,
+// so it always fell to needsAssignment. This breaks canary-guard.js's assertCanaryTarget,
+// which requires the callsign to start with 'Canary-' (defence-in-depth alongside
+// account_profile==='canary'). The assignedRaw/needsAssignment split in main() must skip
+// canary sessions from tier-band reassignment entirely, mirroring the fixture/probe skip
+// in filterOutGhostSessions. main() is not exported (only called via require.main), so this
+// is a source-pin regex test on the call site, matching the pattern used above.
+describe('QF-20260724-521: canary sessions are skipped from callsign reassignment', () => {
+  const src = readFileSync(ASSIGNER, 'utf8');
+
+  it('the assignedRaw/needsAssignment loop checks account_profile===canary or a Canary- callsign', () => {
+    expect(src).toMatch(/account_profile\s*===\s*['"]canary['"]/);
+    expect(src).toMatch(/callsign\?\.startsWith\(['"]Canary-['"]\)/);
+  });
+
+  it('the canary check pushes straight to assignedRaw and continues, BEFORE the tier-band check', () => {
+    const loopStart = src.indexOf('const assignedRaw = [];');
+    const canaryCheckIdx = src.indexOf("account_profile === 'canary'", loopStart);
+    const tierBandCheckIdx = src.indexOf('callsignInTierBand(identity.callsign, tierRankOf(worker))', loopStart);
+    expect(loopStart).toBeGreaterThan(-1);
+    expect(canaryCheckIdx).toBeGreaterThan(loopStart);
+    expect(tierBandCheckIdx).toBeGreaterThan(canaryCheckIdx); // canary skip runs first
+    // the canary branch must `continue` (skip the tier-band check for that worker), not fall through
+    const canaryBlock = src.slice(canaryCheckIdx, tierBandCheckIdx);
+    expect(canaryBlock).toContain('assignedRaw.push(worker)');
+    expect(canaryBlock).toContain('continue;');
+  });
+});


### PR DESCRIPTION
## Summary
- `assign-fleet-identities.cjs` was reassigning a live canary session's `Canary-1` callsign to a NATO tier-band callsign (e.g. `Charlie`), because `Canary-1` never matches any tier band, so it always fell into `needsAssignment`.
- This broke `lib/fleet/canary-guard.js`'s `assertCanaryTarget`, which requires the callsign to start with `Canary-` (defence-in-depth alongside `account_profile==='canary'`), forcing any live canary drill (CP3) to pause the cron.
- Fix: skip sessions with `metadata.account_profile==='canary'` (or callsign `startsWith('Canary-')`) from the tier-band reassignment loop, mirroring the fixture/probe skip already in `filterOutGhostSessions`.

## Test plan
- [x] Added a source-pin regression test in `tests/unit/assign-fleet-identities-coordinator-filter.test.js` asserting the canary check exists, runs before the tier-band check, and `continue`s past it
- [x] `npx vitest run` on all 3 `assign-fleet-identities-*.test.js` files — 50/50 passing
- [x] `require()` sanity check confirms the module still loads cleanly

QF-20260724-521

🤖 Generated with [Claude Code](https://claude.com/claude-code)