### PR TITLE
fix(QF-20260724-113): captureWindowHandle never throws + wire rebootQueryEventsFn

### DIFF
--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -52,8 +52,19 @@ export async function captureWindowHandle(pid, opts = {}) {
   const { execFn = defaultExec, maxAttempts = 10, delayMs = 500, sleepFn = defaultSleep } = opts;
   const cmd = buildHandleCaptureCommand(pid);
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const { stdout } = await execFn(cmd.program, cmd.args);
-    const handle = parseHandleOutput(stdout);
+    let handle = null;
+    try {
+      const { stdout } = await execFn(cmd.program, cmd.args);
+      handle = parseHandleOutput(stdout);
+    } catch {
+      // QF-20260724-113: MainWindowHandle.ToInt64() throws in PowerShell when the property is
+      // genuinely $null (process hasn't rendered a window yet, not just a zero IntPtr) -- execFn
+      // then rejects. Treat exactly like "handle not yet available" instead of letting the throw
+      // escape uncaught: it previously aborted spawn-control's spawn()/restart()/relaunchUnderProfile()
+      // AFTER the real OS spawn but BEFORE DB bookkeeping (release old session + emit fleet_verb
+      // event) -- real processes spawned with zero evidence + orphaned unstamped sessions.
+      handle = null;
+    }
     if (handle !== null) return { handle, handleCaptureFailed: false, attempts: attempt };
     if (attempt < maxAttempts) await sleepFn(delayMs);
   }

--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -103,11 +103,20 @@ export async function defaultRunDrills(plan, deps = {}) {
       .eq('session_id', sid).like('event_type', 'fleet_verb_%');
     return data || [];
   });
+  // QF-20260724-113 (FR-b): reboot-respawn's respawn_events_present check takes a NO-ARG
+  // queryEventsFn (unlike U4's session-scoped one, since reboot-respawn creates one replacement
+  // session PER slot, not a single target) -- without this the live CLI path always failed
+  // respawn_events_present ("no queryEventsFn supplied") even on a genuinely successful respawn.
+  const rebootQueryEventsFn = deps.rebootQueryEventsFn || (async () => {
+    const { data } = await supabase.from('coordination_events').select('event_type,payload,session_id')
+      .eq('event_type', 'fleet_verb_respawn').order('created_at', { ascending: false }).limit(50);
+    return data || [];
+  });
 
   // G1a kill-supervisor -> fleet_verb_restart (canary-guarded).
   const g1a = await Promise.resolve(canaryRestart(target, { supabase })).catch((e) => ({ error: e && e.message }));
   // (3) G1b+G2 reboot-respawn -> fleet_verb_respawn (now with a real client, not null).
-  const reboot = await runRebootRespawnDrill({ supabase, live: true }).catch((e) => ({ error: e && e.message }));
+  const reboot = await runRebootRespawnDrill({ supabase, live: true, queryEventsFn: rebootQueryEventsFn }).catch((e) => ({ error: e && e.message }));
   // (2) G3+U4 relaunch-under-profile -> fleet_verb_relaunch_under_profile (required args wired, was {opts:{}}).
   const u4 = await runU4Drill({
     target, fromProfile, toProfile, sessionId,

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -71,8 +71,12 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
     expect(resolveCanaryTarget).toHaveBeenCalledWith(supabase, { by: 'account_profile', value: 'canary' });
     // G1a kill-supervisor -> fleet_verb_restart.
     expect(canaryRestart).toHaveBeenCalledWith(target, { supabase });
-    // G1b+G2 reboot-respawn gets a REAL client + live:true (was supabase=null).
-    expect(runRebootRespawnDrill).toHaveBeenCalledWith({ supabase, live: true });
+    // G1b+G2 reboot-respawn gets a REAL client + live:true (was supabase=null) + a queryEventsFn
+    // (QF-20260724-113 FR-b: without one, respawn_events_present always fails on a live run).
+    const rebootArgs = runRebootRespawnDrill.mock.calls[0][0];
+    expect(rebootArgs.supabase).toBe(supabase);
+    expect(rebootArgs.live).toBe(true);
+    expect(typeof rebootArgs.queryEventsFn).toBe('function');
     // G3+U4 gets the REQUIRED args (was only {opts:{}} -> no-op): target, sessionId, relaunchFn, resolveFn, queryEventsFn.
     const u4Args = runU4Drill.mock.calls[0][0];
     expect(u4Args.target).toBe(target);
@@ -82,5 +86,37 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
     expect(typeof u4Args.resolveFn).toBe('function');
     expect(typeof u4Args.queryEventsFn).toBe('function');
     expect(res).toMatchObject({ g1a: expect.anything(), reboot: expect.anything(), u4: expect.anything() });
+  });
+});
+
+// QF-20260724-113 (FR-b): the wired rebootQueryEventsFn must actually satisfy respawn_events_present
+// on a real live run (Golf-2-flagged gap: reboot-respawn's own queryEventsFn takes NO session-id arg,
+// unlike U4's session-scoped one, since a respawn drill creates one replacement session PER slot).
+describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', () => {
+  it('the default rebootQueryEventsFn queries fleet_verb_respawn events with no required argument', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const order = vi.fn().mockReturnThis();
+    const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'fleet_verb_respawn' }, { event_type: 'fleet_verb_respawn' }] });
+    const select = vi.fn(() => ({ eq, order, limit }));
+    const supabase = { from: vi.fn(() => ({ select })) };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const resolveCanaryTarget = vi.fn(async () => target);
+    const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
+    const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
+    const runRebootRespawnDrill = vi.fn(async (args) => {
+      // Exercise the injected queryEventsFn exactly as the real runner does (no arg).
+      const events = await args.queryEventsFn();
+      return { pass: events.length >= 2, checks: [] };
+    });
+    const runU4Drill = vi.fn(async () => ({ pass: true }));
+
+    const plan = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+    const res = await defaultRunDrills(plan, {
+      supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
+    });
+
+    expect(select).toHaveBeenCalledWith('event_type,payload,session_id');
+    expect(eq).toHaveBeenCalledWith('event_type', 'fleet_verb_respawn');
+    expect(res.reboot.pass).toBe(true);
   });
 });

--- a/tests/unit/fleet/window-handle.test.js
+++ b/tests/unit/fleet/window-handle.test.js
@@ -79,6 +79,29 @@ describe('captureWindowHandle (bounded retry)', () => {
     expect(result).toEqual({ handle: null, handleCaptureFailed: true, attempts: 3 });
     expect(execFn).toHaveBeenCalledTimes(3);
   });
+
+  // QF-20260724-113: MainWindowHandle.ToInt64() throws in PowerShell when the property is
+  // genuinely $null (process spawned but hasn't rendered a window yet) -- execFn rejects. This
+  // previously escaped captureWindowHandle uncaught, aborting spawn-control's spawn()/restart()/
+  // relaunchUnderProfile() AFTER the real OS spawn but BEFORE DB bookkeeping (release old session +
+  // emit fleet_verb event). Caught live during the CP3 canary drills (correlation_id=
+  // cp3-do-it-right-20260724).
+  it('NEVER throws when execFn rejects (PowerShell errors on a genuinely-null MainWindowHandle) -- retries instead (QF-20260724-113)', async () => {
+    const execFn = vi.fn()
+      .mockRejectedValueOnce(new Error('You cannot call a method on a null-valued expression.'))
+      .mockRejectedValueOnce(new Error('You cannot call a method on a null-valued expression.'))
+      .mockResolvedValueOnce({ stdout: '55443322' });
+    const sleepFn = vi.fn().mockResolvedValue();
+    const result = await captureWindowHandle(4242, { execFn, sleepFn, maxAttempts: 5, delayMs: 10 });
+    expect(result).toEqual({ handle: 55443322, handleCaptureFailed: false, attempts: 3 });
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks handleCaptureFailed=true (not a throw) when execFn rejects on every attempt (QF-20260724-113)', async () => {
+    const execFn = vi.fn().mockRejectedValue(new Error('You cannot call a method on a null-valued expression.'));
+    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn(), maxAttempts: 3, delayMs: 1 });
+    expect(result).toEqual({ handle: null, handleCaptureFailed: true, attempts: 3 });
+  });
 });
 
 describe('buildFocusCommand', () => {


### PR DESCRIPTION
FR-a: captureWindowHandle's execFn call had no try/catch -- PowerShell's MainWindowHandle.ToInt64() throws on a genuinely-null property (pre-render), the throw escaped uncaught, aborting spawn-control's spawn/restart/relaunchUnderProfile AFTER the real OS spawn but BEFORE DB bookkeeping. Root-caused live during the CP3 canary drills (correlation_id=cp3-do-it-right-20260724). FR-b: wired rebootQueryEventsFn on the live CLI path so respawn_events_present can pass on a real live run (was unwired, always failed). Live acceptance re-run is deferred to the CP3 claim owner's next drill, not attempted here -- there is active live cleanup in progress from tonight's incident. Tests: 858/858 fleet unit tests pass including new regression coverage for both fixes.