### PR TITLE
fix(QF-20260724-556): add worker-side ack path for coordinator_directive

### DIFF
--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -173,7 +173,7 @@ every write site already conforms, each traceable to a specific prior fix. No co
 as part of this SD; this section is the auditable record so a future session does not need
 to re-run the census.
 
-### Write sites (12) — already-correct or exempt, each cited
+### Write sites (13) — already-correct or exempt, each cited
 
 | Site | Classification | Citation |
 |---|---|---|
@@ -181,6 +181,7 @@ to re-run the census.
 | `scripts/adam-advisory.cjs` `awaitCoordinatorReply` consumption | exempt | atomic reply-consumption — a synchronously-awaited reply is definitionally both seen and actioned in one step |
 | `scripts/solomon-advisory.cjs` `stampSurfaced`/`ackRows` (mirrors adam-advisory) | already-correct | QF-20260710-593 |
 | `scripts/coordinator-ack-signal.cjs` | already-correct | explicit CLI ack command, genuine action |
+| `scripts/worker-ack-directive.cjs` | already-correct | explicit CLI ack command for a `coordinator_directive` addressed to a worker, genuine action (mirrors `coordinator-ack-signal.cjs`) — closes the "actioned directive resurfaces on every /checkin forever" gap for the worker role, since `DIRECTIVE_KINDS` deliberately blocks auto-ack in `scripts/worker-checkin.cjs`'s `surfaceCoordinatorMessages` | QF-20260724-556 |
 | `scripts/fleet-dashboard.cjs` (signal-inbox + advisory-inbox render) | already-correct | `read_at`-only, defers ack to explicit ack commands; advisory path additionally documents the `payload.actioned_at` dual-marker (see receipt-contract table above) |
 | `scripts/worker-checkin.cjs` `ackMessage`/`surfaceCoordinatorMessages` | exempt (deliberate bounded consumption for advisory-class; directives always wait for genuine action) | SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001, SD-LEO-INFRA-WORKER-INBOX-PUSH-DELIVERY-001, QF-20260610-545 |
 | `scripts/worker-signal.cjs` `awaitCoordinatorReply` consumption (x2) | exempt | atomic reply-consumption (same as adam-advisory.cjs) |

--- a/scripts/worker-ack-directive.cjs
+++ b/scripts/worker-ack-directive.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Worker-side ACK of a coordinator_directive once genuinely actioned — QF-20260724-556.
+ *
+ * A coordinator_directive addressed to a WORKER (target_session=<worker session id>) has
+ * NO worker-side ack path today: DIRECTIVE_KINDS deliberately blocks any auto-ack in
+ * surfaceCoordinatorMessages (scripts/worker-checkin.cjs L487-502), so an actioned
+ * directive resurfaces on EVERY /checkin forever. This is the sanctioned worker-side ack:
+ * once a worker has genuinely acted on a coordinator_directive, it stamps acknowledged_at
+ * (closes the read-ack split) plus payload.actioned_at/actioned_by (mirrors
+ * lib/coordinator/adam-action-ack.cjs's two-stage-ack marker convention) on the SAME row.
+ * Unlike chairman_directive_ack (a broadcast), a coordinator_directive is a single
+ * per-worker delivery, so no new reply row is needed — closing the original row suffices.
+ *
+ * Usage:
+ *   node scripts/worker-ack-directive.cjs --id <message_id> [--note "<text>"]
+ */
+'use strict';
+
+const { getServiceClient, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
+
+function argVal(argv, flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+
+async function ackDirective(supabase, id, { note = null, sessionId = null } = {}) {
+  const { data: row, error: readError } = await supabase
+    .from('session_coordination')
+    .select('id, payload, target_session, acknowledged_at')
+    .eq('id', id)
+    .single();
+  if (readError || !row) {
+    throw Object.assign(new Error(`row not found for id=${id}${readError ? `: ${readError.message}` : ''}`), { code: 'NOT_FOUND' });
+  }
+
+  const kind = row.payload && row.payload.kind;
+  if (!kind || !DIRECTIVE_KINDS.includes(kind)) {
+    throw Object.assign(
+      new Error(`refusing to ack — payload.kind='${kind}' is not a DIRECTIVE_KIND (this path is reserved for genuine directives, never advisory rows)`),
+      { code: 'NOT_A_DIRECTIVE' }
+    );
+  }
+  if (sessionId && row.target_session && row.target_session !== sessionId) {
+    throw Object.assign(
+      new Error(`refusing to ack — row target_session=${row.target_session} does not match this session (${sessionId})`),
+      { code: 'WRONG_SESSION' }
+    );
+  }
+  if (row.acknowledged_at) {
+    return { alreadyAcked: true, acknowledgedAt: row.acknowledged_at, kind };
+  }
+
+  const actionedAt = new Date().toISOString();
+  const mergedPayload = Object.assign({}, row.payload || {}, { actioned_at: actionedAt, actioned_by: sessionId });
+  if (note) mergedPayload.actioned_note = String(note);
+
+  const { error: updateError } = await supabase
+    .from('session_coordination')
+    .update({ acknowledged_at: actionedAt, payload: mergedPayload })
+    .eq('id', id);
+  if (updateError) throw Object.assign(new Error(updateError.message), { code: 'UPDATE_FAILED' });
+
+  return { alreadyAcked: false, acknowledgedAt: actionedAt, kind };
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const id = argVal(argv, '--id');
+  const note = argVal(argv, '--note');
+  if (!id) {
+    console.error('Usage: node scripts/worker-ack-directive.cjs --id <message_id> [--note "<text>"]');
+    process.exit(2);
+  }
+
+  const supabase = getServiceClient();
+  try {
+    const result = await ackDirective(supabase, id, { note, sessionId: process.env.CLAUDE_SESSION_ID || null });
+    if (result.alreadyAcked) {
+      console.log(`worker-ack-directive: id=${id} already acknowledged at ${result.acknowledgedAt} (idempotent no-op).`);
+    } else {
+      console.log(`✓ coordinator_directive acknowledged: id=${id} kind=${result.kind} actioned_at=${result.acknowledgedAt}`);
+    }
+  } catch (e) {
+    console.error(`worker-ack-directive: ${(e && e.message) || e}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { ackDirective };
+
+if (require.main === module) {
+  main();
+}

--- a/tests/unit/session-coordination-consumption-census.test.js
+++ b/tests/unit/session-coordination-consumption-census.test.js
@@ -3,7 +3,7 @@
  *
  * Regression guard for the consumption-semantics census (clause e, session_coordination row
  * 09189ed9): every scripts/*.cjs or lib/coordinator/*.cjs write to session_coordination's
- * read_at/acknowledged_at columns must be one of the 12 sites already classified and cited in
+ * read_at/acknowledged_at columns must be one of the 13 sites already classified and cited in
  * docs/protocol/coordinator-adam-comms.md. A NEW write site appearing outside this allowlist
  * means either a fresh (un-classified) drift, or the census doc needs updating alongside the
  * new site — this test forces that choice to be explicit rather than silent.
@@ -19,8 +19,9 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-// The 12 write sites classified in docs/protocol/coordinator-adam-comms.md's
-// "Consumption-semantics census" section (2026-07-11). Relative to REPO_ROOT, POSIX separators.
+// The 13 write sites classified in docs/protocol/coordinator-adam-comms.md's
+// "Consumption-semantics census" section (2026-07-11, +1 QF-20260724-556). Relative to
+// REPO_ROOT, POSIX separators.
 const ALLOWED_WRITE_FILES = new Set([
   'scripts/adam-advisory.cjs',
   'scripts/solomon-advisory.cjs',
@@ -28,6 +29,7 @@ const ALLOWED_WRITE_FILES = new Set([
   'scripts/fleet-dashboard.cjs',
   'scripts/worker-checkin.cjs',
   'scripts/worker-signal.cjs',
+  'scripts/worker-ack-directive.cjs',
   'scripts/fleet-coaching.cjs',
   'scripts/stale-session-sweep.cjs',
   'scripts/hooks/coordination-inbox.cjs',

--- a/tests/unit/worker-ack-directive.test.js
+++ b/tests/unit/worker-ack-directive.test.js
@@ -1,0 +1,87 @@
+/**
+ * QF-20260724-556 — worker-side ack path for coordinator_directive rows. Without this,
+ * a directive addressed to a worker resurfaces on EVERY /checkin forever (DIRECTIVE_KINDS
+ * deliberately blocks auto-ack in surfaceCoordinatorMessages). This is the sanctioned
+ * worker-side ack: stamps acknowledged_at + payload.actioned_at/actioned_by on the row.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { ackDirective } = require('../../scripts/worker-ack-directive.cjs');
+
+const ROW_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const WORKER_SESSION = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const OTHER_SESSION = '11111111-2222-3333-4444-555555555555';
+
+function stubSupabase(row) {
+  const updates = [];
+  return {
+    _updates: updates,
+    from(table) {
+      expect(table).toBe('session_coordination');
+      const chain = {
+        select() { return chain; },
+        eq(_col, val) { chain._eq = val; return chain; },
+        single() {
+          return Promise.resolve(chain._eq === ROW_ID ? { data: row, error: null } : { data: null, error: { message: 'not found' } });
+        },
+        update(patch) {
+          updates.push(patch);
+          return chain;
+        },
+        then(res, rej) {
+          return Promise.resolve({ error: null }).then(res, rej);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('ackDirective (QF-20260724-556)', () => {
+  it('acknowledges a genuine coordinator_directive row not yet acked', async () => {
+    const row = { id: ROW_ID, payload: { kind: 'coordinator_directive', subject: 'do a thing' }, target_session: WORKER_SESSION, acknowledged_at: null };
+    const sb = stubSupabase(row);
+    const result = await ackDirective(sb, ROW_ID, { sessionId: WORKER_SESSION });
+    expect(result.alreadyAcked).toBe(false);
+    expect(result.kind).toBe('coordinator_directive');
+    expect(sb._updates).toHaveLength(1);
+    expect(sb._updates[0].acknowledged_at).toBeTruthy();
+    expect(sb._updates[0].payload.actioned_at).toBeTruthy();
+    expect(sb._updates[0].payload.actioned_by).toBe(WORKER_SESSION);
+  });
+
+  it('is idempotent — a second ack on an already-acked row is a no-op', async () => {
+    const row = { id: ROW_ID, payload: { kind: 'coordinator_directive' }, target_session: WORKER_SESSION, acknowledged_at: '2026-01-01T00:00:00Z' };
+    const sb = stubSupabase(row);
+    const result = await ackDirective(sb, ROW_ID, { sessionId: WORKER_SESSION });
+    expect(result.alreadyAcked).toBe(true);
+    expect(sb._updates).toHaveLength(0);
+  });
+
+  it('refuses to ack a non-directive kind (never lets this path auto-ack an advisory row)', async () => {
+    const row = { id: ROW_ID, payload: { kind: 'coordinator_reply' }, target_session: WORKER_SESSION, acknowledged_at: null };
+    const sb = stubSupabase(row);
+    await expect(ackDirective(sb, ROW_ID, { sessionId: WORKER_SESSION })).rejects.toMatchObject({ code: 'NOT_A_DIRECTIVE' });
+    expect(sb._updates).toHaveLength(0);
+  });
+
+  it('refuses to ack a directive addressed to a different session', async () => {
+    const row = { id: ROW_ID, payload: { kind: 'coordinator_directive' }, target_session: OTHER_SESSION, acknowledged_at: null };
+    const sb = stubSupabase(row);
+    await expect(ackDirective(sb, ROW_ID, { sessionId: WORKER_SESSION })).rejects.toMatchObject({ code: 'WRONG_SESSION' });
+    expect(sb._updates).toHaveLength(0);
+  });
+
+  it('throws NOT_FOUND for an unknown row id', async () => {
+    const sb = stubSupabase(null);
+    await expect(ackDirective(sb, 'does-not-exist', { sessionId: WORKER_SESSION })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('preserves a caller-supplied note on the actioned payload', async () => {
+    const row = { id: ROW_ID, payload: { kind: 'coordinator_directive' }, target_session: WORKER_SESSION, acknowledged_at: null };
+    const sb = stubSupabase(row);
+    await ackDirective(sb, ROW_ID, { sessionId: WORKER_SESSION, note: 'landed the fix in PR #6428' });
+    expect(sb._updates[0].payload.actioned_note).toBe('landed the fix in PR #6428');
+  });
+});


### PR DESCRIPTION
## Summary
- `coordinator_directive` messages to workers had no worker-side ack path, so already-actioned directives resurfaced on every `/checkin` forever (`DIRECTIVE_KINDS` deliberately blocks auto-ack, and the only existing ack script is scoped to `chairman_directive` + adam/coordinator/solomon roles).
- Adds `scripts/worker-ack-directive.cjs`: a sanctioned worker-side ack that stamps `acknowledged_at` + `payload.actioned_at`/`actioned_by` on the same row once a worker has genuinely actioned a directive.

## Test plan
- [x] 6/6 new unit tests pass (genuine ack, idempotent re-ack, refuses non-directive kind, refuses wrong-session row, unknown-id error, note preservation)
- [x] Live acceptance check against the real Supabase client: inserted a real `coordinator_directive`, acked it, confirmed `acknowledged_at`/`payload.actioned_at`/`actioned_by` persisted correctly, confirmed idempotent second call, cleaned up test row

🤖 Generated with [Claude Code](https://claude.com/claude-code)