### PR TITLE
fix(QF-20260724-335): stamp explicit run-correlator on all 3 CP3 drill leg events

### DIFF
--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -105,6 +105,10 @@ export async function runRebootRespawn(opts = {}) {
       const res = await logFn(supabase, {
         event_type: 'fleet_verb_respawn',
         session_id: null,
+        // QF-20260724-335: explicit run-correlator (opt-in via opts.sdKey) so a set of drill legs
+        // can be attributed to one invocation -- see spawn-control.js's emitVerbEvent for the same
+        // convention on the other 2 CP3 legs.
+        sd_key: opts.sdKey ?? null,
         payload: {
           verb: 'respawn',
           callsign,

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -87,12 +87,17 @@ function verbEventPayload({ verb, outcome }) {
   return { verb, outcome, at: new Date().toISOString() };
 }
 
-async function emitVerbEvent(supabase, { verb, session_id, outcome }) {
+async function emitVerbEvent(supabase, { verb, session_id, outcome, sdKey }) {
   try {
     const { logCoordinationEvent } = await import('../coordinator/coordination-events.cjs');
     await logCoordinationEvent(supabase, {
       event_type: `fleet_verb_${verb}`,
       session_id: session_id ?? null,
+      // QF-20260724-335: an explicit, intentional run-correlator (opt-in via opts.sdKey, e.g.
+      // 'CHECKPOINT-3') so a set of drill-run events can be attributed to one invocation --
+      // timing/session-proximity alone is insufficient (a stray dry-run batch can collide with a
+      // real run). Defaults to null (unchanged behavior for every existing non-drill caller).
+      sd_key: sdKey ?? null,
       payload: verbEventPayload({ verb, outcome }),
     });
   } catch { /* fail-open: event emission never blocks a verb outcome */ }
@@ -240,9 +245,10 @@ async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opt
 export async function restart(target, opts = {}) {
   const supabase = opts.supabaseClient;
   const by = opts.by || 'callsign';
+  const sdKey = opts.sdKey;
   const resolution = await resolveLiveSession(supabase, { by, value: target });
   if (!resolution.resolved) {
-    await emitVerbEvent(supabase, { verb: 'restart', outcome: `not_resolved:${resolution.reason}` });
+    await emitVerbEvent(supabase, { verb: 'restart', outcome: `not_resolved:${resolution.reason}`, sdKey });
     return { ok: false, reason: resolution.reason };
   }
 
@@ -259,11 +265,11 @@ export async function restart(target, opts = {}) {
     // caller supply it once the spawned process self-registers).
     const { sequenceSingletonRefresh } = await import('../coordinator/singleton-refresh-sequencer.cjs');
     if (!opts.newSessionId) {
-      await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration' });
+      await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration', sdKey });
       return { ok: false, reason: 'awaiting_new_session_registration', spawnResult, role: 'singleton' };
     }
     const seqResult = await sequenceSingletonRefresh(supabase, { newSessionId: opts.newSessionId, oldSessionId: oldIdentity.session_id });
-    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: seqResult.action });
+    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: seqResult.action, sdKey });
     return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
   }
 
@@ -275,13 +281,13 @@ export async function restart(target, opts = {}) {
   // dry-run mode, spawnReplacement() never launches a process -- releasing the old session anyway
   // would silently drop the tracked worker from the registry with no functioning replacement.
   if (!spawnResult || spawnResult.live !== true) {
-    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'replacement_not_live' });
+    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: 'replacement_not_live', sdKey });
     return { ok: false, reason: 'replacement_not_live', role: 'worker', spawnResult };
   }
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'restart',
   }).eq('session_id', oldIdentity.session_id);
-  await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok' });
+  await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok', sdKey });
   return { ok: !error, role: 'worker', spawnResult };
 }
 
@@ -289,13 +295,14 @@ export async function restart(target, opts = {}) {
 export async function relaunchUnderProfile(target, accountProfile, opts = {}) {
   const supabase = opts.supabaseClient;
   const by = opts.by || 'callsign';
+  const sdKey = opts.sdKey;
 
   // Fail loud before touching anything if the profile doesn't resolve to a safe, allowlisted path.
   resolveProfileDir(accountProfile, opts);
 
   const resolution = await resolveLiveSession(supabase, { by, value: target });
   if (!resolution.resolved) {
-    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', outcome: `not_resolved:${resolution.reason}` });
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', outcome: `not_resolved:${resolution.reason}`, sdKey });
     return { ok: false, reason: resolution.reason };
   }
 
@@ -315,24 +322,24 @@ export async function relaunchUnderProfile(target, accountProfile, opts = {}) {
   if (isSingletonRole(role)) {
     const { sequenceSingletonRefresh } = await import('../coordinator/singleton-refresh-sequencer.cjs');
     if (!opts.newSessionId) {
-      await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration' });
+      await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'awaiting_new_session_registration', sdKey });
       return { ok: false, reason: 'awaiting_new_session_registration', spawnResult, role: 'singleton' };
     }
     const seqResult = await sequenceSingletonRefresh(supabase, { newSessionId: opts.newSessionId, oldSessionId: oldIdentity.session_id });
-    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: seqResult.action });
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: seqResult.action, sdKey });
     return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
   }
 
   // ADVERSARIAL-REVIEW FIX: same guard as restart()'s worker path -- never release the old session
   // unless the replacement genuinely spawned live.
   if (!spawnResult || spawnResult.live !== true) {
-    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'replacement_not_live' });
+    await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: 'replacement_not_live', sdKey });
     return { ok: false, reason: 'replacement_not_live', role: 'worker', spawnResult };
   }
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'relaunch_under_profile',
   }).eq('session_id', oldIdentity.session_id);
-  await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok' });
+  await emitVerbEvent(supabase, { verb: 'relaunch_under_profile', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok', sdKey });
   return { ok: !error, role: 'worker', spawnResult };
 }
 

--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -113,14 +113,20 @@ export async function defaultRunDrills(plan, deps = {}) {
     return data || [];
   });
 
+  // QF-20260724-335: an explicit, intentional run-correlator stamped on all 3 leg fleet_verb events
+  // of this single --live invocation. Timing/session-proximity correlation is insufficient (a stray
+  // dry-run/accidental-spawn batch can collide with a real run) -- Solomon's S7 acceptance requires a
+  // unique intentional binding of the 3 legs to one CP3 run.
+  const sdKey = deps.sdKey || 'CHECKPOINT-3';
+
   // G1a kill-supervisor -> fleet_verb_restart (canary-guarded).
-  const g1a = await Promise.resolve(canaryRestart(target, { supabase })).catch((e) => ({ error: e && e.message }));
+  const g1a = await Promise.resolve(canaryRestart(target, { supabase, sdKey })).catch((e) => ({ error: e && e.message }));
   // (3) G1b+G2 reboot-respawn -> fleet_verb_respawn (now with a real client, not null).
-  const reboot = await runRebootRespawnDrill({ supabase, live: true, queryEventsFn: rebootQueryEventsFn }).catch((e) => ({ error: e && e.message }));
+  const reboot = await runRebootRespawnDrill({ supabase, live: true, queryEventsFn: rebootQueryEventsFn, opts: { sdKey } }).catch((e) => ({ error: e && e.message }));
   // (2) G3+U4 relaunch-under-profile -> fleet_verb_relaunch_under_profile (required args wired, was {opts:{}}).
   const u4 = await runU4Drill({
     target, fromProfile, toProfile, sessionId,
-    relaunchFn: canaryRelaunchUnderProfile, resolveFn: resolveProfileDir, queryEventsFn, opts: { supabase },
+    relaunchFn: canaryRelaunchUnderProfile, resolveFn: resolveProfileDir, queryEventsFn, opts: { supabase, sdKey },
   }).catch((e) => ({ error: e && e.message }));
 
   return { g1a, reboot, u4 };

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -35,6 +35,19 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
     expect(res.results[1].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd()]);
   });
 
+  // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
+  // (e.g. 'CHECKPOINT-3') so the G1b/G2 leg's events are attributable to the same intentional CP3 run
+  // as the other 2 legs (Solomon S7 acceptance).
+  it('threads opts.sdKey onto every per-slot fleet_verb_respawn event (QF-20260724-335)', async () => {
+    const events = [];
+    const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
+    await runRebootRespawn({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: vi.fn(), logFn, live: false, sdKey: 'CHECKPOINT-3',
+    });
+    expect(events).toHaveLength(2);
+    expect(events.every((e) => e.sd_key === 'CHECKPOINT-3')).toBe(true);
+  });
+
   it('builds a supervisor-shaped roster from the slots', async () => {
     const res = await runRebootRespawn({ supabase: {}, loadFn: async () => SLOTS, logFn: async () => ({ ok: true }), live: false });
     expect(res.roster).toEqual([

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -348,6 +348,22 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
     expect(sequenceSingletonRefresh).toHaveBeenCalledWith(supabaseClient, { newSessionId: 's2', oldSessionId: 's1' });
     expect(result.ok).toBe(true);
   });
+
+  // QF-20260724-335: an explicit opts.sdKey must be stamped on the fleet_verb_restart event so a set
+  // of CP3 drill legs can be attributed to one intentional run (Solomon S7 acceptance).
+  it('threads opts.sdKey through to the emitted fleet_verb_restart event (QF-20260724-335)', async () => {
+    logCoordinationEvent.mockClear();
+    const child = { pid: 5151 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    await restart('Alpha-5', { supabaseClient, live: true, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
+    const [, eventArg] = logCoordinationEvent.mock.calls.at(-1);
+    expect(eventArg.event_type).toBe('fleet_verb_restart');
+    expect(eventArg.sd_key).toBe('CHECKPOINT-3');
+  });
 });
 
 describe('relaunchUnderProfile (FR-7)', () => {
@@ -398,6 +414,22 @@ describe('relaunchUnderProfile (FR-7)', () => {
     await expect(relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn: vi.fn().mockResolvedValue({ stdout: '0' }), sleepFn: vi.fn() }))
       .rejects.toThrow(/isolation invariant violated/);
     delete process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  // QF-20260724-335: same run-correlator convention as restart() -- required for the G3/U4 leg's
+  // fleet_verb_relaunch_under_profile event to be attributable to the same CP3 run as the other 2 legs.
+  it('threads opts.sdKey through to the emitted fleet_verb_relaunch_under_profile event (QF-20260724-335)', async () => {
+    logCoordinationEvent.mockClear();
+    const child = { pid: 6161 };
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+    await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
+    const [, eventArg] = logCoordinationEvent.mock.calls.at(-1);
+    expect(eventArg.event_type).toBe('fleet_verb_relaunch_under_profile');
+    expect(eventArg.sd_key).toBe('CHECKPOINT-3');
   });
 });
 

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -70,7 +70,7 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
     // supabase is NOT null (was the stub bug); canary resolved.
     expect(resolveCanaryTarget).toHaveBeenCalledWith(supabase, { by: 'account_profile', value: 'canary' });
     // G1a kill-supervisor -> fleet_verb_restart.
-    expect(canaryRestart).toHaveBeenCalledWith(target, { supabase });
+    expect(canaryRestart).toHaveBeenCalledWith(target, { supabase, sdKey: 'CHECKPOINT-3' });
     // G1b+G2 reboot-respawn gets a REAL client + live:true (was supabase=null) + a queryEventsFn
     // (QF-20260724-113 FR-b: without one, respawn_events_present always fails on a live run).
     const rebootArgs = runRebootRespawnDrill.mock.calls[0][0];
@@ -118,5 +118,50 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
     expect(select).toHaveBeenCalledWith('event_type,payload,session_id');
     expect(eq).toHaveBeenCalledWith('event_type', 'fleet_verb_respawn');
     expect(res.reboot.pass).toBe(true);
+  });
+});
+
+// QF-20260724-335: an explicit, intentional run-correlator must be stamped on all 3 leg events of one
+// --live invocation (timing/session-proximity alone is insufficient -- a stray batch can collide with
+// a real run; Solomon S7 acceptance requires unique intentional binding of the 3 legs to one CP3 run).
+describe('defaultRunDrills — run-correlator stamped on all 3 legs (QF-20260724-335)', () => {
+  it('passes the SAME sdKey to canaryRestart, runRebootRespawnDrill, and runU4Drill', async () => {
+    const supabase = { from: vi.fn() };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const resolveCanaryTarget = vi.fn(async () => target);
+    const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
+    const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
+    const runRebootRespawnDrill = vi.fn(async () => ({ pass: true }));
+    const runU4Drill = vi.fn(async () => ({ pass: true }));
+
+    const plan = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+    await defaultRunDrills(plan, {
+      supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
+    });
+
+    // Default run-correlator is the SD-scoped literal 'CHECKPOINT-3'.
+    expect(canaryRestart.mock.calls[0][1].sdKey).toBe('CHECKPOINT-3');
+    expect(runRebootRespawnDrill.mock.calls[0][0].opts.sdKey).toBe('CHECKPOINT-3');
+    expect(runU4Drill.mock.calls[0][0].opts.sdKey).toBe('CHECKPOINT-3');
+  });
+
+  it('honors an injected deps.sdKey override (e.g. a per-invocation run_id) for all 3 legs', async () => {
+    const supabase = { from: vi.fn() };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const resolveCanaryTarget = vi.fn(async () => target);
+    const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
+    const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
+    const runRebootRespawnDrill = vi.fn(async () => ({ pass: true }));
+    const runU4Drill = vi.fn(async () => ({ pass: true }));
+
+    const plan = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+    await defaultRunDrills(plan, {
+      supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
+      sdKey: 'run-2026-07-24T22-00-00Z',
+    });
+
+    expect(canaryRestart.mock.calls[0][1].sdKey).toBe('run-2026-07-24T22-00-00Z');
+    expect(runRebootRespawnDrill.mock.calls[0][0].opts.sdKey).toBe('run-2026-07-24T22-00-00Z');
+    expect(runU4Drill.mock.calls[0][0].opts.sdKey).toBe('run-2026-07-24T22-00-00Z');
   });
 });


### PR DESCRIPTION
start-cp3-drills.js --live fired 3 legs but every fleet_verb event landed sd_key=NULL, so 0 legs were CP3-attributable -- Solomon S7 rejects timing/session-proximity correlation as insufficient (a stray batch can collide with a real run, proven live in tonight's incident). Threads an explicit opts.sdKey (default 'CHECKPOINT-3') through spawn-control.js's emitVerbEvent/restart/relaunchUnderProfile, reboot-respawn-runner.js's per-slot event, and start-cp3-drills.js's defaultRunDrills so a single --live invocation stamps all 3 leg events with the same run-correlator. Part of the CP3 S7-unblock set alongside QF-295 (canary self-stamp) and QF-20260724-113 (handle-capture). Live acceptance deferred to the CP3 claim owner once all 3 land. Tests: 863/863 fleet unit tests pass including new regression coverage.