### PR TITLE
fix(QF-20260724-295): CP3 canary respawn self-stamp + drill opts-key reconcile

### DIFF
--- a/lib/fleet/canary-guard.js
+++ b/lib/fleet/canary-guard.js
@@ -90,14 +90,20 @@ async function guardedVerb(verbFn, verbName, target, opts = {}) {
   if (!isCanaryKillEnabled(opts.env)) {
     return { ok: false, reason: 'canary_kill_disabled', verb: verbName, guarded: true };
   }
-  const supabase = opts.supabaseClient;
+  // QF-20260724-295: accept opts.supabase (the CP3 drill's key, start-cp3-drills.js) as well as
+  // opts.supabaseClient (spawn-control's canonical key), then INJECT the canonical key before
+  // delegating so BOTH the guard resolution here AND the underlying spawn-control verb resolve the
+  // client. Without this, the drill's { supabase } leaves guardedVerb + spawn-control with an
+  // undefined client, the guard cannot resolve the canary, and every target-scoped leg no-ops.
+  const supabase = opts.supabaseClient || opts.supabase;
+  const vopts = supabase ? { ...opts, supabaseClient: supabase } : opts;
   const by = opts.by || 'callsign';
   const resolution = await resolveCanaryTarget(supabase, { by, value: target });
   const guard = assertCanaryTarget(resolution);
   if (!guard.ok) {
     return { ok: false, reason: guard.reason, verb: verbName, guarded: true };
   }
-  return verbFn(target, opts);
+  return verbFn(target, vopts);
 }
 
 /** Canary-guarded stop -- delegates to spawn-control.js's stop() ONLY after the guard passes. */
@@ -105,12 +111,73 @@ export async function canaryStop(target, opts = {}) {
   return guardedVerb(spawnControlStop, 'stop', target, opts);
 }
 
-/** Canary-guarded restart -- delegates to spawn-control.js's restart() ONLY after the guard passes. */
+/**
+ * Canary-guarded restart -- delegates to spawn-control.js's restart() ONLY after the guard passes, then
+ * self-stamps the LIVE respawn (QF-20260724-295) so an ACTIVE stamped canary target always exists.
+ */
 export async function canaryRestart(target, opts = {}) {
-  return guardedVerb(spawnControlRestart, 'restart', target, opts);
+  const callsign = await preResolveCanaryCallsign(target, opts);
+  const result = await guardedVerb(spawnControlRestart, 'restart', target, opts);
+  await stampLiveRespawn(result, callsign, opts);
+  return result;
 }
 
-/** Canary-guarded relaunch-under-profile -- delegates to spawn-control.js's relaunchUnderProfile() ONLY after the guard passes. */
+/**
+ * Canary-guarded relaunch-under-profile -- delegates to spawn-control.js's relaunchUnderProfile() ONLY
+ * after the guard passes, then self-stamps the LIVE respawn (QF-20260724-295).
+ */
 export async function canaryRelaunchUnderProfile(target, accountProfile, opts = {}) {
-  return guardedVerb((t, o) => spawnControlRelaunchUnderProfile(t, accountProfile, o), 'relaunch_under_profile', target, opts);
+  const callsign = await preResolveCanaryCallsign(target, opts);
+  const result = await guardedVerb((t, o) => spawnControlRelaunchUnderProfile(t, accountProfile, o), 'relaunch_under_profile', target, opts);
+  await stampLiveRespawn(result, callsign, opts);
+  return result;
+}
+
+/** QF-20260724-295: cheap read of the target's CURRENT canary callsign, captured BEFORE the verb runs so it can be carried forward onto the (unstamped) respawn. Fail-soft: null on any failure. */
+async function preResolveCanaryCallsign(target, opts) {
+  try {
+    const pre = await resolveCanaryTarget(opts.supabaseClient || opts.supabase, { by: opts.by || 'callsign', value: target });
+    return (pre && pre.identity && pre.identity.callsign) || null;
+  } catch { return null; }
+}
+
+/** QF-20260724-295: self-stamp the new session ONLY when the verb genuinely LIVE-respawned (has a pid). */
+async function stampLiveRespawn(result, callsign, opts) {
+  if (result && result.spawnResult && result.spawnResult.live === true && result.spawnResult.pid != null) {
+    await stampRespawnedCanary(opts.supabaseClient || opts.supabase, { pid: result.spawnResult.pid, callsign }, opts);
+  }
+}
+
+/**
+ * QF-20260724-295: SELF-STAMP a respawned canary. spawn-control.js's spawn() re-launches the replacement
+ * with the callsign via env but does NOT set metadata.account_profile='canary' on the new session, so the
+ * CP3 target-scoped legs (which fail-closed require account_profile==='canary' + a Canary- callsign)
+ * silently no-op against the unstamped respawn. Bounded-wait, fail-soft, idempotent -- mirrors
+ * spawn-control.js's window_handle bounded-wait + client-side metadata MERGE (read row -> merge -> write
+ * back to the SAME session_id, NEVER a bare pid-scoped overwrite that would clobber fleet_identity).
+ * Stamping is a side effect that NEVER throws / never breaks the verb.
+ */
+export async function stampRespawnedCanary(supabase, { pid, callsign } = {}, opts = {}) {
+  if (!supabase || pid == null) return { stamped: false, reason: 'no_pid' };
+  const attempts = opts.stampAttempts ?? 8;
+  const gapMs = opts.stampGapMs ?? 500;
+  const sleep = opts.sleepFn || ((ms) => new Promise((r) => setTimeout(r, ms)));
+  try {
+    for (let i = 0; i < attempts; i++) {
+      const { data: row } = await supabase.from('claude_sessions').select('session_id, metadata').eq('pid', pid).maybeSingle();
+      if (row && row.session_id) {
+        const md = row.metadata || {};
+        const fi = md.fleet_identity || {};
+        const setCallsign = isCanaryCallsign(callsign) && !isCanaryCallsign(fi.callsign);
+        if (md.account_profile === 'canary' && !setCallsign) return { stamped: true, already: true, session_id: row.session_id };
+        const metadata = { ...md, account_profile: 'canary', ...(setCallsign ? { fleet_identity: { ...fi, callsign } } : {}) };
+        await supabase.from('claude_sessions').update({ metadata }).eq('session_id', row.session_id);
+        return { stamped: true, session_id: row.session_id };
+      }
+      if (i < attempts - 1) await sleep(gapMs);
+    }
+    return { stamped: false, reason: 'respawn_not_registered' };
+  } catch {
+    return { stamped: false, reason: 'stamp_error' };
+  }
 }

--- a/tests/unit/fleet/canary-guard.test.js
+++ b/tests/unit/fleet/canary-guard.test.js
@@ -10,10 +10,17 @@ vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
 vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
   sequenceSingletonRefresh: vi.fn(),
 }));
+// QF-20260724-295: partial mock so canaryRestart's LIVE-respawn wiring can be exercised without a real
+// OS spawn -- only restart() is replaced; stop()/relaunchUnderProfile() stay REAL for the existing tests.
+vi.mock('../../../lib/fleet/spawn-control.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, restart: vi.fn() };
+});
 
+const { restart: spawnControlRestartMock } = await import('../../../lib/fleet/spawn-control.js');
 const {
   isCanaryKillEnabled, isCanaryCallsign, resolveCanaryTarget, assertCanaryTarget,
-  canaryStop, canaryRestart, canaryRelaunchUnderProfile,
+  canaryStop, canaryRestart, canaryRelaunchUnderProfile, stampRespawnedCanary,
 } = await import('../../../lib/fleet/canary-guard.js');
 
 /** Same claude_sessions fake shape as spawn-control.test.js, extended with account_profile in metadata. */
@@ -166,6 +173,71 @@ describe('canaryStop / canaryRestart / canaryRelaunchUnderProfile (guarded verbs
     const result = await canaryStop('Canary-2', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' } });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('not_canary_profile');
+  });
+});
+
+// QF-20260724-295: self-stamp the respawned canary so CP3 target-scoped legs (which fail-closed require
+// account_profile==='canary' + a Canary- callsign) resolve against the ACTIVE respawn rather than no-op.
+describe('QF-20260724-295 stampRespawnedCanary + canaryRestart wiring', () => {
+  const noSleep = () => Promise.resolve();
+
+  it('(a) stamps account_profile=canary on the pid session, MERGING (never clobbering) existing metadata', async () => {
+    // Respawn is unstamped: no account_profile, and its callsign is NOT yet in the canary namespace.
+    const respawn = { session_id: 's-respawn', pid: 6980, status: 'active', metadata: { fleet_identity: { callsign: 'worker-tmp', color: 'red' }, role: 'worker' } };
+    const sb = makeFakeSupabase({ sessions: [respawn] });
+    const res = await stampRespawnedCanary(sb, { pid: 6980, callsign: 'Canary-1' }, { sleepFn: noSleep });
+    expect(res.stamped).toBe(true);
+    const md = sb._store.get('s-respawn').metadata;
+    expect(md.account_profile).toBe('canary');              // stamped
+    expect(md.fleet_identity.callsign).toBe('Canary-1');    // carried forward from the old canary
+    expect(md.fleet_identity.color).toBe('red');            // merged, not clobbered
+    expect(md.role).toBe('worker');                         // merged, not clobbered
+  });
+
+  it('(b) is idempotent: an already-stamped canary is NOT re-written ({already:true}, no update call)', async () => {
+    const respawn = { session_id: 's-c', pid: 42, status: 'active', metadata: { fleet_identity: { callsign: 'Canary-9' }, account_profile: 'canary', role: 'worker' } };
+    const sb = makeFakeSupabase({ sessions: [respawn] });
+    const before = sb._store.get('s-c').metadata;
+    const res = await stampRespawnedCanary(sb, { pid: 42, callsign: 'Canary-9' }, { sleepFn: noSleep });
+    expect(res).toEqual({ stamped: true, already: true, session_id: 's-c' });
+    expect(sb._store.get('s-c').metadata).toBe(before);     // same reference => no write occurred
+  });
+
+  it('(c) fail-soft: returns {stamped:false,reason:respawn_not_registered} when the pid never registers', async () => {
+    const sb = makeFakeSupabase({ sessions: [] });
+    const res = await stampRespawnedCanary(sb, { pid: 999999, callsign: 'Canary-1' }, { sleepFn: noSleep, stampAttempts: 2 });
+    expect(res).toEqual({ stamped: false, reason: 'respawn_not_registered' });
+  });
+
+  it('returns {stamped:false,reason:no_pid} when supabase/pid is missing (never throws)', async () => {
+    expect(await stampRespawnedCanary(null, { pid: 1 })).toEqual({ stamped: false, reason: 'no_pid' });
+    const sb = makeFakeSupabase({ sessions: [] });
+    expect(await stampRespawnedCanary(sb, { pid: null })).toEqual({ stamped: false, reason: 'no_pid' });
+  });
+
+  it('(d) canaryRestart WIRES stampRespawnedCanary: a LIVE respawn stamps the new pid session, return value unchanged', async () => {
+    const respawn = { session_id: 's-respawn', pid: 6980, status: 'active', metadata: { role: 'worker' } }; // unstamped respawn
+    const sb = makeFakeSupabase({ sessions: [canarySession, respawn] });
+    spawnControlRestartMock.mockResolvedValue({ ok: true, role: 'worker', spawnResult: { live: true, pid: 6980 } });
+    const result = await canaryRestart('Canary-1', { supabaseClient: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' }, sleepFn: noSleep });
+    expect(result).toEqual({ ok: true, role: 'worker', spawnResult: { live: true, pid: 6980 } }); // stamping is a side effect
+    const md = sb._store.get('s-respawn').metadata;
+    expect(md.account_profile).toBe('canary');
+    expect(md.fleet_identity.callsign).toBe('Canary-1');    // carried forward from the released canary
+  });
+
+  it('(e) accepts the CP3 drill opts key: { supabase } (not { supabaseClient }) still resolves the guard + stamps the respawn', async () => {
+    // start-cp3-drills.js calls the verbs with { supabase }; before QF-295 that left guardedVerb +
+    // spawn-control with an undefined client so the guard could not resolve -> every leg no-op.
+    const respawn = { session_id: 's-respawn2', pid: 7001, status: 'active', metadata: { role: 'worker' } };
+    const sb = makeFakeSupabase({ sessions: [canarySession, respawn] });
+    spawnControlRestartMock.mockResolvedValue({ ok: true, role: 'worker', spawnResult: { live: true, pid: 7001 } });
+    const result = await canaryRestart('Canary-1', { supabase: sb, env: { FLEET_CANARY_KILL_ENABLED: 'true' }, sleepFn: noSleep });
+    expect(result.ok).toBe(true);                            // guard resolved via opts.supabase (was undefined before)
+    // spawn-control verb received the injected canonical key so it could resolve too
+    expect(spawnControlRestartMock.mock.lastCall[1].supabaseClient).toBe(sb);
+    const md = sb._store.get('s-respawn2').metadata;
+    expect(md.account_profile).toBe('canary');               // respawn self-stamped
   });
 });
 


### PR DESCRIPTION
## QF-20260724-295 — CP3 target-scoped drill legs silently no-op

Two coupled defects (both fixed, contained to `lib/fleet/canary-guard.js`):

1. **Self-stamp respawn** — spawn-control's respawn re-launches with the callsign via env but doesn't set `metadata.account_profile='canary'` on the new session, so `resolveCanaryTarget` (fail-closed requires `account_profile==='canary'` + Canary- callsign) can't resolve the respawn. Added `stampRespawnedCanary` (bounded-wait, fail-soft, idempotent, client-side metadata MERGE — mirrors spawn-control's `window_handle` pattern), wired into `canaryRestart` + `canaryRelaunchUnderProfile`.
2. **Opts-key reconcile** — `start-cp3-drills.js` calls the verbs with `{ supabase }`, but `guardedVerb` + spawn-control read `opts.supabaseClient` → the drill left both with an undefined client, so the guard couldn't resolve at all (prereq for the stamp to fire). `guardedVerb` now accepts either key and injects the canonical one before delegating. **`start-cp3-drills.js` untouched** (avoids colliding with the live CP3 run).

Observed live 2026-07-24 21:47 (restart released `0da751ed`, respawned `6980fa26` unstamped). Sibling of QF-521 / QF-113. **864/864 fleet unit tests pass** (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)