### PR TITLE
fix(QF-20260724-911): reconcile respawn events to a ground-truth heartbeating session

### DIFF
--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -37,6 +37,38 @@ async function defaultLogFn(supabase, event) {
   return logCoordinationEvent(supabase, event);
 }
 
+function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+/**
+ * QF-20260724-911 (split from QF-20260724-739's widened scope, Solomon Mode-B deep-sweep b3c86f61):
+ * a fire-and-forget spawnFn() returning without throwing is NOT evidence of a live session -- the
+ * code path taken on real recovery and on a silent no-op look IDENTICAL (forgeable-by-construction).
+ * Reconcile the spawned pid against a REAL, heartbeating claude_sessions row (bounded poll, never a
+ * single point-in-time read) using the SAME health check singleton-refresh-sequencer.cjs already
+ * uses to gate retirement decisions -- reused, not reimplemented.
+ * @returns {Promise<string|null>} the reconciled session_id, or null if never bound within budget.
+ */
+async function reconcileSpawnedSession(supabase, pid, opts = {}) {
+  if (!supabase || !pid) return null;
+  let checkNewSessionHealth;
+  try {
+    ({ checkNewSessionHealth } = await import('../coordinator/singleton-refresh-sequencer.cjs'));
+  } catch { return null; }
+  const sleepFn = opts.sleepFn || defaultSleep;
+  const nowMs = opts.nowMs ?? Date.now();
+  const freshMs = opts.reconcileFreshMs ?? 30_000; // a just-spawned session's own fresh-heartbeat window
+  const maxAttempts = opts.reconcileMaxAttempts ?? 5;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const { data: session } = await supabase.from('claude_sessions')
+        .select('session_id, heartbeat_at, loop_state').eq('pid', pid).maybeSingle();
+      if (checkNewSessionHealth(session, { nowMs, freshMs }).healthy) return session.session_id;
+    } catch { /* fail-soft: try again below, or give up */ }
+    if (attempt < maxAttempts) await sleepFn(opts.reconcileDelayMs ?? 500);
+  }
+  return null;
+}
+
 /**
  * Run the reboot-respawn sequence.
  * @param {object}   opts
@@ -87,9 +119,10 @@ export async function runRebootRespawn(opts = {}) {
     const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid });
 
     let spawned = false;
+    let child = null;
     if (live && typeof spawnFn === 'function') {
       try {
-        spawnFn(invocation.program, invocation.args, invocation.env);
+        child = spawnFn(invocation.program, invocation.args, invocation.env);
         spawned = true;
         log(`[reboot-respawn] respawned ${role}/${callsign} (resume=${resumeUuid || 'none'})`);
       } catch (e) {
@@ -99,12 +132,18 @@ export async function runRebootRespawn(opts = {}) {
       log(`[reboot-respawn] DRY-RUN would respawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
     }
 
+    // QF-20260724-911: payload.live is derived FROM ground-truth reconciliation, not from spawnFn()
+    // having returned without throwing -- see reconcileSpawnedSession() above.
+    const sessionId = spawned && child && child.pid ? await reconcileSpawnedSession(supabase, child.pid, opts) : null;
+    const boundLive = sessionId !== null;
+    const outcome = boundLive ? 'ok' : (spawned ? 'respawn_unbound' : 'dry_run');
+
     // FR-5: one fleet_verb_respawn event per slot (recorded in dry-run too, payload.live=false).
     let eventLogged = false;
     try {
       const res = await logFn(supabase, {
         event_type: 'fleet_verb_respawn',
-        session_id: null,
+        session_id: sessionId,
         // QF-20260724-335: explicit run-correlator (opt-in via opts.sdKey) so a set of drill legs
         // can be attributed to one invocation -- see spawn-control.js's emitVerbEvent for the same
         // convention on the other 2 CP3 legs.
@@ -114,14 +153,15 @@ export async function runRebootRespawn(opts = {}) {
           callsign,
           role,
           resume_uuid: resumeUuid,
-          live: spawned,
+          live: boundLive,
+          outcome,
           at: now(),
         },
       });
       eventLogged = !!(res && res.ok);
     } catch { /* fail-open: event emission never blocks a respawn outcome */ }
 
-    results.push({ callsign, role, invocation, resume_uuid: resumeUuid, spawned, eventLogged });
+    results.push({ callsign, role, invocation, resume_uuid: resumeUuid, spawned, live: boundLive, session_id: sessionId, eventLogged });
   }
 
   return { live, roster, slotCount: slots.length, results };

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -62,7 +62,7 @@ describe('runRebootRespawn live (FR-5)', () => {
     const spawnCalls = [];
     const spawnFn = vi.fn((program, args) => { spawnCalls.push({ program, args }); return { pid: 111 }; });
     const res = await runRebootRespawn({
-      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn: async () => ({ ok: true }), live: true, now: () => 'iso',
+      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn: async () => ({ ok: true }), live: true, now: () => 'iso', sleepFn: vi.fn(),
     });
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
@@ -77,7 +77,7 @@ describe('runRebootRespawn live (FR-5)', () => {
     const spawnFn = (program, args, env) => { spawnCalls.push(env); return { pid: 1 }; };
     const res = await runRebootRespawn({
       supabase: {}, loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'canary', resume_uuid: 'u-c' }],
-      spawnFn, logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: okResolver,
+      spawnFn, logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: okResolver, sleepFn: vi.fn(),
     });
     expect(spawnCalls[0].CLAUDE_CONFIG_DIR).toBe('C:\\profiles\\canary');
     expect(res.results[0].spawned).toBe(true);
@@ -87,9 +87,85 @@ describe('runRebootRespawn live (FR-5)', () => {
     const res2 = await runRebootRespawn({
       supabase: {}, loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'bad', resume_uuid: 'u-c' }],
       spawnFn: (p, a, e) => { spawnCalls2.push(e); return { pid: 1 }; },
-      logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: () => { throw new Error('bad profile'); },
+      logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: () => { throw new Error('bad profile'); }, sleepFn: vi.fn(),
     });
     expect(spawnCalls2[0]).not.toHaveProperty('CLAUDE_CONFIG_DIR');
     expect(res2.results[0].spawned).toBe(true);
+  });
+});
+
+describe('runRebootRespawn (QF-20260724-911): payload.live is ground-truth-reconciled, not spawnFn()-returned', () => {
+  /** Minimal fake supporting exactly the claude_sessions.select().eq('pid',...).maybeSingle() shape used. */
+  function makeFakeSupabase(sessionsByPid) {
+    return {
+      from: (table) => {
+        if (table !== 'claude_sessions') throw new Error(`unexpected table: ${table}`);
+        return { select: () => ({ eq: (_col, pid) => ({ maybeSingle: async () => ({ data: sessionsByPid[pid] || null }) }) }) };
+      },
+    };
+  }
+
+  it('binds session_id + live:true + outcome:ok when the spawned pid reconciles to a fresh, heartbeating session', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabase = makeFakeSupabase({ 111: { session_id: 's-new', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
+    const spawnFn = vi.fn(() => ({ pid: 111 }));
+    const events = [];
+    const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
+    const res = await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[0]], spawnFn, logFn, live: true, now: () => 'iso', sleepFn: vi.fn(), nowMs,
+    });
+    expect(res.results[0]).toMatchObject({ spawned: true, live: true, session_id: 's-new' });
+    expect(events[0].session_id).toBe('s-new');
+    expect(events[0].payload).toMatchObject({ live: true, outcome: 'ok' });
+  });
+
+  it('reports live:false + outcome:respawn_unbound + session_id:null (NOT true) when spawnFn returns without throwing but no session ever reconciles -- the exact forgeable case this fix closes (discriminating rule: a code path emitting live=true with session_id=null must fail a test like this one)', async () => {
+    const spawnFn = vi.fn(() => ({ pid: 999 })); // "succeeds" per the old fire-and-forget check
+    const supabase = makeFakeSupabase({}); // pid 999 never appears in claude_sessions -- child killed/failed before registering
+    const events = [];
+    const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
+    const res = await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[0]], spawnFn, logFn, live: true, now: () => 'iso', sleepFn: vi.fn(), reconcileMaxAttempts: 2,
+    });
+    expect(spawnFn).toHaveBeenCalled(); // the OS-level spawn call itself did succeed...
+    expect(res.results[0]).toMatchObject({ spawned: true, live: false, session_id: null }); // ...but it never bound
+    expect(events[0].session_id).toBeNull();
+    expect(events[0].payload).toMatchObject({ live: false, outcome: 'respawn_unbound' });
+  });
+
+  it('retries the reconcile lookup (bounded) when the session row has not landed yet on the first attempt', async () => {
+    const nowMs = 1_800_000_000_000;
+    let lookups = 0;
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => {
+              lookups++;
+              if (lookups < 2) return { data: null };
+              return { data: { session_id: 's-late', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } };
+            },
+          }),
+        }),
+      }),
+    };
+    const spawnFn = vi.fn(() => ({ pid: 111 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const res = await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[0]], spawnFn, logFn: async () => ({ ok: true }), live: true, sleepFn, nowMs,
+    });
+    expect(lookups).toBe(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+    expect(res.results[0].session_id).toBe('s-late');
+  });
+
+  it('dry-run (live:false at the runner level) never attempts reconciliation: outcome:dry_run, session_id:null', async () => {
+    const events = [];
+    const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
+    const res = await runRebootRespawn({
+      supabase: {}, loadFn: async () => [SLOTS[0]], spawnFn: vi.fn(), logFn, live: false, now: () => 'iso',
+    });
+    expect(res.results[0]).toMatchObject({ spawned: false, live: false, session_id: null });
+    expect(events[0].payload).toMatchObject({ live: false, outcome: 'dry_run' });
   });
 });


### PR DESCRIPTION
## Summary
- Split from QF-20260724-739's scope, widened mid-flight (22:37/22:44 per Solomon Mode-B deep-sweep b3c86f61) to also require this fix, but reverted back out of 739 to stay under the 75-source-LOC Tier-2 cap (combined 105 LOC; each fix independently fits Tier-2). 739 (spawn-control.js) merged via PR #6436.
- `reboot-respawn-runner.js`'s `fleet_verb_respawn` events set `payload.live = spawnFn()-returned-without-throwing` (true the instant a fire-and-forget spawn call returns, before the child authenticates/registers/heartbeats) and hardcoded `session_id:null` unconditionally -- the same forgeable-by-construction bug class as `spawn-control.js`'s `spawn()`, in the sibling reboot-respawn runner. Real recovery and a silent no-op looked identical on the wire (same class as the QF-923 mock-passed-green failure Solomon's widening referenced).
- Fix: after a spawn attempt, reconcile the child's pid against a REAL, heartbeating `claude_sessions` row via a bounded poll, reusing `singleton-refresh-sequencer.cjs`'s existing `checkNewSessionHealth` (fresh heartbeat + reachable loop_state) rather than reimplementing it. `payload.live` and the event's `session_id` are now derived from that reconciliation; when no session binds within the retry budget, the event honestly reports `live:false` / `outcome:'respawn_unbound'` instead of a false-positive `live:true`.
- Test suite satisfies the discriminating rule Solomon specified: a code path that emits `live=true` with `session_id=null` makes the negative-case test fail (uses a faithful in-memory Supabase fake requiring a real matching fresh row to pass, not a no-op stub) -- covers both the positive (binds) and negative (child killed before registering -> `respawn_unbound`) cases plus bounded-retry behavior.

## Test plan
- [x] `npx vitest run tests/unit/fleet/reboot-respawn-runner.test.js` -- 9/9 pass, including 4 new tests
- [x] `npx vitest run tests/unit/fleet/` -- 876/876 pass (no regressions)
- [x] `npx tsc --noEmit` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
