### PR TITLE
fix(QF-20260724-828): respawn_events_present self-check session-bound, not count

### DIFF
--- a/lib/fleet/reboot-respawn-drill-runner.js
+++ b/lib/fleet/reboot-respawn-drill-runner.js
@@ -106,12 +106,23 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
   if (typeof queryEventsFn === 'function') {
     try { events = await queryEventsFn(); } catch { events = []; }
   }
-  const respawnEvents = (events || []).filter((e) => e && e.event_type === 'fleet_verb_respawn').length;
+  // QF-20260724-828: session-BOUND, not count. After QF-20260724-911 (#6438) reconciled the emitter,
+  // a LIVE respawn that binds NO heartbeating session honestly reports payload.outcome:'respawn_unbound'
+  // + session_id:null (a no-op). A count-based check false-passes on that no-op, so a silent
+  // non-recovery could self-report respawn GREEN. Mirror the emitter's OWN verdict: count an event as
+  // present only when it is genuinely bound (outcome 'ok' with a reconciled non-null session_id) OR an
+  // explicit 'dry_run' mechanism emit (no live session by design) -- never a 'respawn_unbound' no-op.
+  const respawnEvents = (events || []).filter((e) => {
+    if (!e || e.event_type !== 'fleet_verb_respawn') return false;
+    const outcome = e.payload?.outcome;
+    if (outcome === 'dry_run') return true;                    // mechanism/dry-run: no live session by design
+    return outcome !== 'respawn_unbound' && e.session_id != null; // live: must have bound a real session
+  }).length;
   checks.push({
     name: 'respawn_events_present',
     pass: typeof queryEventsFn === 'function' ? respawnEvents >= slots.length : false,
     detail: typeof queryEventsFn === 'function'
-      ? `fleet_verb_respawn events found: ${respawnEvents} (need >= ${slots.length})`
+      ? `session-bound fleet_verb_respawn events: ${respawnEvents} (need >= ${slots.length})`
       : 'no queryEventsFn supplied — cannot assert persisted respawn events (live drill MUST supply one)',
   });
 

--- a/tests/unit/fleet/reboot-respawn-drill-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-drill-runner.test.js
@@ -43,6 +43,33 @@ describe('runRebootRespawnDrill (FR-7)', () => {
     expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(false);
   });
 
+  it('respawn_events_present FAILs when the events are respawn_unbound no-ops even though the COUNT meets slots (QF-20260724-828)', async () => {
+    const { logFn } = makeEventSeams();
+    // Post-QF-911 a live respawn that binds no heartbeating session emits outcome:'respawn_unbound' +
+    // session_id:null. Two such events meet the count (2 >= slots.length) yet bound NO session — the
+    // old count-based check false-passed on this no-op; the session-bound check must FAIL it.
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, live: false,
+      queryEventsFn: async () => [
+        { event_type: 'fleet_verb_respawn', session_id: null, payload: { outcome: 'respawn_unbound' } },
+        { event_type: 'fleet_verb_respawn', session_id: null, payload: { outcome: 'respawn_unbound' } },
+      ],
+    });
+    expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(false);
+  });
+
+  it('respawn_events_present PASSES when events are session-bound (outcome ok + non-null session_id) (QF-20260724-828)', async () => {
+    const { logFn } = makeEventSeams();
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, live: false,
+      queryEventsFn: async () => [
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-1', payload: { outcome: 'ok' } },
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-2', payload: { outcome: 'ok' } },
+      ],
+    });
+    expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(true);
+  });
+
   it('FAILs manifest_loaded when the desired manifest is empty (table unapplied / no seed)', async () => {
     const { logFn, queryEventsFn } = makeEventSeams();
     const { pass, checks } = await runRebootRespawnDrill({


### PR DESCRIPTION
## QF-20260724-828 — drill self-report hygiene (LOW, non-blocking)

`reboot-respawn-drill-runner.js` Check 4 (`respawn_events_present`) passed on `respawnEvents.length >= slots.length` — a **count** of `fleet_verb_respawn` events with no session/bound filter.

After **QF-20260724-911 (#6438)** reconciled the emitter (`runRebootRespawn` now derives `session_id` + `payload.outcome` from a ground-truth heartbeating-session poll, emitting `outcome:'respawn_unbound'` + `session_id:null` when nothing binds), the count-based self-check **still counted a `respawn_unbound` no-op as present** → could self-report respawn GREEN on a silent non-recovery.

### Fix
Mirror the emitter's **own verdict**. Count an event as present only when it is:
- genuinely **bound** (`outcome:'ok'` with a reconciled non-null `session_id`), **or**
- an explicit **`dry_run`** mechanism emit (no live session by design)

…never a `respawn_unbound` no-op. Keying on `outcome` (not merely `session_id!=null`) preserves the legitimate `live:false` dry-run mechanism path (`session_id:null` + `outcome:'dry_run'`) while killing the exact `--live` false-pass QF-828 describes.

### Scope / severity
NOT a run/acceptance blocker — Solomon's independent session-bound depth-verify is the authoritative S7 gate and catches an unbound respawn regardless. This is drill-internal self-report hygiene; the tail of cancelled QF-099 that did not land in #6438. Source change: +13/-2.

### Test
Discriminating regression: two `respawn_unbound` events **meet the count** (2 ≥ slots) yet bound no session → `respawn_events_present` now **FAILs** (fails on the old count-based code, passes on the new); a session-bound (`outcome:ok` + non-null `session_id`) pair PASSes. 7/7 drill-runner + 45/45 sibling CP3 suites green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)