### PR TITLE
fix(QF-20260724-070): durable bind-time audit for reboot-respawn CP3 checkpoint

### DIFF
--- a/lib/fleet/reboot-respawn-drill-runner.js
+++ b/lib/fleet/reboot-respawn-drill-runner.js
@@ -7,13 +7,16 @@
  *
  * Models u4-drill-runner.js: PASS/FAIL observable checks against the REAL runner
  * (lib/fleet/reboot-respawn-runner.js runRebootRespawn) via injectable seams, returning
- * {pass, checks:[{name,pass,detail}]}. The checks assert the four properties reboot-respawn must have:
+ * {pass, checks:[{name,pass,detail}]}. The checks assert the five properties reboot-respawn must have:
  *   1. manifest_loaded          — the desired manifest was read (>=1 slot)
  *   2. roster_built             — slotsToRoster produced a supervisor-shaped roster for every slot
  *   3. per_slot_resume_relaunch — each slot's relaunch invocation carries `--resume <its uuid>`
  *                                 (and a slot WITHOUT a resume_uuid stays on the back-compat no-resume
  *                                 path — never a spurious --resume)
  *   4. respawn_events_present   — a fleet_verb_respawn event exists per slot in coordination_events
+ *   5. respawn_bind_audited     — QF-20260724-070: every session-bound respawn carries a durable
+ *                                 RESPAWN_BIND_VERIFIED session_lifecycle_events row proving a REAL
+ *                                 heartbeat AT BIND TIME (survives the session later ghosting)
  *
  * ⚠️ ANTI-TEST-MASKING (Solomon R1 verdict 0e9e466e: no_unit_mock=true, trim_forbidden=true): a
  * mocked-seam UNIT test does NOT satisfy this SD's acceptance. The LOAD-BEARING proof is an in-session
@@ -46,7 +49,7 @@ import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
  * @param {object}   [args.opts]          - passthrough to runRebootRespawn (e.g. resolveProfileDir baseDir)
  * @returns {Promise<{pass:boolean, checks:Array<{name:string, pass:boolean, detail:string}>}>}
  */
-export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnFn, logFn, queryEventsFn, buildInvocationFn, live = false, now, opts = {} } = {}) {
+export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnFn, logFn, queryEventsFn, queryLifecycleEventsFn, buildInvocationFn, live = false, now, opts = {} } = {}) {
   const checks = [];
   const load = loadFn || loadDesiredSlots;
   const roster = rosterFn || slotsToRoster;
@@ -124,6 +127,28 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
     detail: typeof queryEventsFn === 'function'
       ? `session-bound fleet_verb_respawn events: ${respawnEvents} (need >= ${slots.length})`
       : 'no queryEventsFn supplied — cannot assert persisted respawn events (live drill MUST supply one)',
+  });
+
+  // Check 5 (QF-20260724-070, Solomon durable-bind-audit): every session-bound respawn ('ok' outcome)
+  // must carry a durable RESPAWN_BIND_VERIFIED session_lifecycle_events row proving a REAL heartbeat AT
+  // BIND TIME -- this survives the session later ghosting, unlike the session_id-populated-post-hoc
+  // event alone (the exact false-pass Solomon caught on the ephemeral canary drill).
+  const boundSessionIds = (events || [])
+    .filter((e) => e && e.event_type === 'fleet_verb_respawn' && e.payload?.outcome === 'ok' && e.session_id != null)
+    .map((e) => e.session_id);
+  let lifecycleEvents = [];
+  if (typeof queryLifecycleEventsFn === 'function') {
+    try { lifecycleEvents = await queryLifecycleEventsFn(); } catch { lifecycleEvents = []; }
+  }
+  const auditedIds = new Set((lifecycleEvents || [])
+    .filter((e) => e && e.event_type === 'RESPAWN_BIND_VERIFIED').map((e) => e.session_id));
+  const auditedCount = boundSessionIds.filter((id) => auditedIds.has(id)).length;
+  checks.push({
+    name: 'respawn_bind_audited',
+    pass: boundSessionIds.length === 0 || (typeof queryLifecycleEventsFn === 'function' && auditedCount === boundSessionIds.length),
+    detail: boundSessionIds.length === 0
+      ? 'no session-bound respawn events to audit (dry-run or unbound)'
+      : `${auditedCount}/${boundSessionIds.length} bound session(s) have a durable RESPAWN_BIND_VERIFIED audit row`,
   });
 
   return { pass: checks.every((c) => c.pass), checks };

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -39,6 +39,12 @@ async function defaultLogFn(supabase, event) {
 
 function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
+/** Best-effort insert into session_lifecycle_events; never throws (fail-soft, caller doesn't await for correctness). */
+async function defaultWriteLifecycleEvent(supabase, event) {
+  try { await supabase.from('session_lifecycle_events').insert(event); return true; }
+  catch { return false; }
+}
+
 /**
  * QF-20260724-911 (split from QF-20260724-739's widened scope, Solomon Mode-B deep-sweep b3c86f61):
  * a fire-and-forget spawnFn() returning without throwing is NOT evidence of a live session -- the
@@ -46,6 +52,13 @@ function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, 
  * Reconcile the spawned pid against a REAL, heartbeating claude_sessions row (bounded poll, never a
  * single point-in-time read) using the SAME health check singleton-refresh-sequencer.cjs already
  * uses to gate retirement decisions -- reused, not reimplemented.
+ *
+ * QF-20260724-070 (Solomon bar adjudication, durable-bind-audit): a session_id-populated-post-hoc
+ * result proves nothing once the bound session later ghosts (the exact false-pass Solomon caught on
+ * the ephemeral canary drill). So the instant a REAL healthy bind is confirmed, write an IMMUTABLE
+ * session_lifecycle_events audit row capturing that heartbeat proof -- acceptance then survives the
+ * session ending, without requiring sustained persistence (CP3 is a live-ACTIVATION checkpoint, not
+ * durable-recovery).
  * @returns {Promise<string|null>} the reconciled session_id, or null if never bound within budget.
  */
 async function reconcileSpawnedSession(supabase, pid, opts = {}) {
@@ -58,11 +71,21 @@ async function reconcileSpawnedSession(supabase, pid, opts = {}) {
   const nowMs = opts.nowMs ?? Date.now();
   const freshMs = opts.reconcileFreshMs ?? 30_000; // a just-spawned session's own fresh-heartbeat window
   const maxAttempts = opts.reconcileMaxAttempts ?? 5;
+  const writeLifecycleEventFn = opts.writeLifecycleEventFn || defaultWriteLifecycleEvent;
+  const nowFn = opts.now || (() => new Date().toISOString());
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const { data: session } = await supabase.from('claude_sessions')
         .select('session_id, heartbeat_at, loop_state').eq('pid', pid).maybeSingle();
-      if (checkNewSessionHealth(session, { nowMs, freshMs }).healthy) return session.session_id;
+      if (checkNewSessionHealth(session, { nowMs, freshMs }).healthy) {
+        await writeLifecycleEventFn(supabase, {
+          event_type: 'RESPAWN_BIND_VERIFIED',
+          session_id: session.session_id,
+          pid,
+          metadata: { heartbeat_at: session.heartbeat_at, loop_state: session.loop_state, sd_key: opts.sdKey ?? null, checked_at: nowFn() },
+        });
+        return session.session_id;
+      }
     } catch { /* fail-soft: try again below, or give up */ }
     if (attempt < maxAttempts) await sleepFn(opts.reconcileDelayMs ?? 500);
   }

--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -112,6 +112,14 @@ export async function defaultRunDrills(plan, deps = {}) {
       .eq('event_type', 'fleet_verb_respawn').order('created_at', { ascending: false }).limit(50);
     return data || [];
   });
+  // QF-20260724-070: wire the durable-bind-audit query so the live drill's respawn_bind_audited check
+  // (a real heartbeat proof recorded AT BIND TIME, surviving the session later ghosting) has real
+  // evidence to read -- without this the check would fail-closed on every genuine live bind.
+  const rebootQueryLifecycleEventsFn = deps.rebootQueryLifecycleEventsFn || (async () => {
+    const { data } = await supabase.from('session_lifecycle_events').select('event_type,session_id')
+      .eq('event_type', 'RESPAWN_BIND_VERIFIED').order('created_at', { ascending: false }).limit(50);
+    return data || [];
+  });
 
   // QF-20260724-335: an explicit, intentional run-correlator stamped on all 3 leg fleet_verb events
   // of this single --live invocation. Timing/session-proximity correlation is insufficient (a stray
@@ -128,7 +136,7 @@ export async function defaultRunDrills(plan, deps = {}) {
   // G1a kill-supervisor -> fleet_verb_restart (canary-guarded).
   const g1a = await Promise.resolve(canaryRestart(target, { supabase, sdKey, live: true })).catch((e) => ({ error: e && e.message }));
   // (3) G1b+G2 reboot-respawn -> fleet_verb_respawn (now with a real client, not null).
-  const reboot = await runRebootRespawnDrill({ supabase, live: true, queryEventsFn: rebootQueryEventsFn, opts: { sdKey } }).catch((e) => ({ error: e && e.message }));
+  const reboot = await runRebootRespawnDrill({ supabase, live: true, queryEventsFn: rebootQueryEventsFn, queryLifecycleEventsFn: rebootQueryLifecycleEventsFn, opts: { sdKey } }).catch((e) => ({ error: e && e.message }));
   // (2) G3+U4 relaunch-under-profile -> fleet_verb_relaunch_under_profile (required args wired, was {opts:{}}).
   const u4 = await runU4Drill({
     target, fromProfile, toProfile, sessionId,

--- a/tests/unit/fleet/reboot-respawn-drill-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-drill-runner.test.js
@@ -24,12 +24,12 @@ function makeEventSeams() {
 }
 
 describe('runRebootRespawnDrill (FR-7)', () => {
-  it('PASSes all four checks when manifest loads, roster builds, --resume relaunches, and events persist', async () => {
+  it('PASSes all five checks when manifest loads, roster builds, --resume relaunches, and events persist', async () => {
     const { logFn, queryEventsFn } = makeEventSeams();
     const { pass, checks } = await runRebootRespawnDrill({
       supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, queryEventsFn, live: false,
     });
-    expect(checks.map((c) => c.name)).toEqual(['manifest_loaded', 'roster_built', 'per_slot_resume_relaunch', 'respawn_events_present']);
+    expect(checks.map((c) => c.name)).toEqual(['manifest_loaded', 'roster_built', 'per_slot_resume_relaunch', 'respawn_events_present', 'respawn_bind_audited']);
     expect(pass).toBe(true);
     expect(checks.every((c) => c.pass)).toBe(true);
   });
@@ -77,6 +77,49 @@ describe('runRebootRespawnDrill (FR-7)', () => {
     });
     expect(pass).toBe(false);
     expect(checks.find((c) => c.name === 'manifest_loaded').pass).toBe(false);
+  });
+
+  it('respawn_bind_audited PASSES when every session-bound respawn has a matching RESPAWN_BIND_VERIFIED audit row (QF-20260724-070)', async () => {
+    const { logFn } = makeEventSeams();
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, live: false,
+      queryEventsFn: async () => [
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-1', payload: { outcome: 'ok' } },
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-2', payload: { outcome: 'ok' } },
+      ],
+      queryLifecycleEventsFn: async () => [
+        { event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'sess-1' },
+        { event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'sess-2' },
+      ],
+    });
+    expect(checks.find((c) => c.name === 'respawn_bind_audited').pass).toBe(true);
+  });
+
+  it('respawn_bind_audited FAILs when a session-bound respawn has NO matching audit row -- session_id-populated-post-hoc alone is not proof (QF-20260724-070)', async () => {
+    const { logFn } = makeEventSeams();
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, live: false,
+      queryEventsFn: async () => [
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-1', payload: { outcome: 'ok' } },
+        { event_type: 'fleet_verb_respawn', session_id: 'sess-2', payload: { outcome: 'ok' } },
+      ],
+      queryLifecycleEventsFn: async () => [
+        { event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'sess-1' }, // sess-2 never audited
+      ],
+    });
+    expect(checks.find((c) => c.name === 'respawn_bind_audited').pass).toBe(false);
+  });
+
+  it('respawn_bind_audited PASSES trivially when no session-bound respawns exist (dry-run/unbound), even without queryLifecycleEventsFn', async () => {
+    const { logFn } = makeEventSeams();
+    const { checks } = await runRebootRespawnDrill({
+      supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, live: false,
+      queryEventsFn: async () => [
+        { event_type: 'fleet_verb_respawn', session_id: null, payload: { outcome: 'dry_run' } },
+        { event_type: 'fleet_verb_respawn', session_id: null, payload: { outcome: 'dry_run' } },
+      ],
+    });
+    expect(checks.find((c) => c.name === 'respawn_bind_audited').pass).toBe(true);
   });
 
   it('per_slot_resume_relaunch FAILs if a slot with a resume_uuid is relaunched WITHOUT its --resume token', async () => {

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -169,3 +169,42 @@ describe('runRebootRespawn (QF-20260724-911): payload.live is ground-truth-recon
     expect(events[0].payload).toMatchObject({ live: false, outcome: 'dry_run' });
   });
 });
+
+describe('runRebootRespawn (QF-20260724-070): durable bind-time audit row', () => {
+  function makeFakeSupabase(sessionsByPid) {
+    return {
+      from: (table) => {
+        if (table !== 'claude_sessions') throw new Error(`unexpected table: ${table}`);
+        return { select: () => ({ eq: (_col, pid) => ({ maybeSingle: async () => ({ data: sessionsByPid[pid] || null }) }) }) };
+      },
+    };
+  }
+
+  it('writes an immutable RESPAWN_BIND_VERIFIED session_lifecycle_events row the instant the bind is confirmed healthy', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabase = makeFakeSupabase({ 111: { session_id: 's-new', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
+    const spawnFn = vi.fn(() => ({ pid: 111 }));
+    const auditEvents = [];
+    const writeLifecycleEventFn = vi.fn(async (_s, ev) => { auditEvents.push(ev); return true; });
+    await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[0]], spawnFn, logFn: async () => ({ ok: true }), live: true,
+      sleepFn: vi.fn(), nowMs, writeLifecycleEventFn, sdKey: 'CHECKPOINT-3', now: () => 'iso-checked-at',
+    });
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toMatchObject({
+      event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-new', pid: 111,
+      metadata: { heartbeat_at: expect.any(String), loop_state: 'active', sd_key: 'CHECKPOINT-3', checked_at: 'iso-checked-at' },
+    });
+  });
+
+  it('never writes an audit row when the session never binds (respawn_unbound)', async () => {
+    const supabase = makeFakeSupabase({});
+    const writeLifecycleEventFn = vi.fn(async () => true);
+    const res = await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[0]], spawnFn: vi.fn(() => ({ pid: 999 })), logFn: async () => ({ ok: true }),
+      live: true, sleepFn: vi.fn(), reconcileMaxAttempts: 2, writeLifecycleEventFn,
+    });
+    expect(res.results[0].session_id).toBeNull();
+    expect(writeLifecycleEventFn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -124,6 +124,36 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
   });
 });
 
+// QF-20260724-070: the live drill must be wired with a queryLifecycleEventsFn so the new
+// respawn_bind_audited check has real session_lifecycle_events evidence to read on a genuine bind.
+describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-070)', () => {
+  it('threads a default queryLifecycleEventsFn into runRebootRespawnDrill that reads RESPAWN_BIND_VERIFIED rows', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const order = vi.fn().mockReturnThis();
+    const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-1' }] });
+    const select = vi.fn(() => ({ eq, order, limit }));
+    const supabase = { from: vi.fn(() => ({ select })) };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const resolveCanaryTarget = vi.fn(async () => target);
+    const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
+    const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
+    const runRebootRespawnDrill = vi.fn(async (args) => {
+      const rows = await args.queryLifecycleEventsFn();
+      return { pass: rows.length >= 1, checks: [] };
+    });
+    const runU4Drill = vi.fn(async () => ({ pass: true }));
+
+    const plan = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+    const res = await defaultRunDrills(plan, {
+      supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
+    });
+
+    expect(select).toHaveBeenCalledWith('event_type,session_id');
+    expect(eq).toHaveBeenCalledWith('event_type', 'RESPAWN_BIND_VERIFIED');
+    expect(res.reboot.pass).toBe(true);
+  });
+});
+
 // QF-20260724-335: an explicit, intentional run-correlator must be stamped on all 3 leg events of one
 // --live invocation (timing/session-proximity alone is insufficient -- a stray batch can collide with
 // a real run; Solomon S7 acceptance requires unique intentional binding of the 3 legs to one CP3 run).


### PR DESCRIPTION
## Summary
- `reconcileSpawnedSession` now writes an immutable `RESPAWN_BIND_VERIFIED` `session_lifecycle_events` audit row the instant a spawned respawn session reconciles healthy (heartbeat + reachable `loop_state`) — durable proof survives the session later ghosting, unlike a session_id-populated-post-hoc event alone.
- `reboot-respawn-drill-runner.js` gains a 5th check, `respawn_bind_audited`: every session-bound (`outcome:'ok'`) respawn leg must have a matching audit row, or the drill fails. Trivially passes when there are no session-bound legs (dry-run/unbound).
- `scripts/fleet/start-cp3-drills.js` wires a default `queryLifecycleEventsFn` (reads `session_lifecycle_events` for `RESPAWN_BIND_VERIFIED` rows) into the live reboot-respawn drill call, so the CP3 live run has real evidence for the new check instead of fail-closing on every genuine bind.

Rerouted by Solomon (bar adjudication 2026-07-25) from an escalate-to-SD proposal down to QF-tier: CP3 is a live-ACTIVATION checkpoint, so a durable audit of a real heartbeat at bind time satisfies acceptance — sustained canary persistence is not required.

## Test plan
- [x] `npx vitest run tests/unit/fleet/reboot-respawn-runner.test.js tests/unit/fleet/reboot-respawn-drill-runner.test.js tests/unit/fleet/start-cp3-drills.test.js` — 32/32 pass
- [x] `npx vitest run tests/unit/fleet/` — 889/889 pass (no regressions)
- [x] New tests cover: audit row written only on confirmed healthy bind (never on `respawn_unbound`), drill check passes when every bound session has a matching audit row, fails when one is missing, passes trivially with zero bound sessions, and the live-drill wiring queries the correct table/event_type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)