### PR TITLE
fix(QF-20260724-598): sd-next loadOpenQuickFixes 42703s on staged factory_lane column, hiding ALL open QFs fleet-wide

### DIFF
--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -429,14 +429,33 @@ export async function loadOpenQuickFixes(supabase) {
     // only checks the line containing the .select( match itself (RCA'd during
     // this SD's own round-2 adversarial review after the pragma-on-its-own-line
     // form above silently failed to suppress the lint).
-    const { data, error } = await supabase
+    //
+    // QF-20260724-598: because factory_lane is not applied yet, PostgREST fails the
+    // WHOLE multi-column select with 42703 (data:null) rather than degrading per-row --
+    // so this loader returned [] on every run and sd:next showed ZERO open QFs
+    // fleet-wide (Track C display AND the AUTO_PROCEED_ACTION:qf_start recommendation
+    // path both went dark, so idle workers concluded the belt was empty). This is the
+    // identical outage QF-20260720-763 fixed in scripts/worker-checkin.cjs
+    // selfClaimQuickFix(); data-loaders.js was never given the twin fallback. Retry
+    // once without factory_lane on exactly that error code -- qf.factory_lane then
+    // comes back undefined, which the `qf.factory_lane === true` check in
+    // display/quick-fixes.js already treats identically to the column's own DEFAULT
+    // false, so behavior is unchanged once the column lands and the retry simply stops
+    // firing (self-heals, no follow-up code change).
+    const QF_DISPLAY_COLUMNS = 'id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane, owner, release_condition'; // schema-lint-disable-line: factory_lane staged, see comment above
+    const baseQuery = (columns) => supabase
       .from('quick_fixes')
-      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id, pr_url, commit_sha, not_before, factory_lane, owner, release_condition') // schema-lint-disable-line: factory_lane staged, see comment above
+      .select(columns)
       .in('status', ['open', 'in_progress'])
       .is('pr_url', null)
       .is('commit_sha', null)
       .order('created_at', { ascending: true })
       .limit(50);
+
+    let { data, error } = await baseQuery(QF_DISPLAY_COLUMNS);
+    if (error && error.code === '42703') {
+      ({ data, error } = await baseQuery(QF_DISPLAY_COLUMNS.replace(', factory_lane', '')));
+    }
 
     if (error) {
       logQueryFailure('loadOpenQuickFixes', error, { table: 'quick_fixes' });

--- a/tests/unit/sd-next/load-open-quick-fixes-factory-lane-retry.test.js
+++ b/tests/unit/sd-next/load-open-quick-fixes-factory-lane-retry.test.js
@@ -1,0 +1,138 @@
+/**
+ * QF-20260724-598 — loadOpenQuickFixes selects quick_fixes.factory_lane, a
+ * staged-not-yet-applied column (database/migrations/20260713_quick_fixes_factory_lane.sql).
+ * A missing column fails the WHOLE multi-column select (Postgres 42703, data:null), not per-row,
+ * so the loader hit its `if (error) return []` arm on every run — sd:next displayed ZERO open
+ * QFs fleet-wide (Track C display AND the AUTO_PROCEED_ACTION:qf_start recommendation path both
+ * went dark) while 50+ open rows sat in quick_fixes, leading idle workers to conclude the belt
+ * was empty.
+ *
+ * This is the twin of QF-20260720-763, which fixed the identical outage in
+ * scripts/worker-checkin.cjs selfClaimQuickFix(); data-loaders.js was never given the same
+ * fallback. The fix retries the same query without factory_lane on exactly error.code==='42703'.
+ */
+import { describe, it, expect } from 'vitest';
+import { loadOpenQuickFixes } from '../../../scripts/modules/sd-next/data-loaders.js';
+
+const OPEN_QF = {
+  id: 'QF-20260724-001',
+  title: 'A real open quick fix',
+  type: 'bug',
+  severity: 'medium',
+  status: 'open',
+  estimated_loc: 10,
+  description: 'plain open work',
+  created_at: '2026-07-24T00:00:00Z',
+  target_application: 'EHG_Engineer',
+  claiming_session_id: null,
+  pr_url: null,
+  commit_sha: null,
+  not_before: null,
+  owner: null,
+  release_condition: null,
+};
+
+/**
+ * Fake supabase whose quick_fixes select fails with 42703 whenever factory_lane is requested,
+ * mirroring the live PostgREST behavior against the unapplied column.
+ */
+function makeFakeSupabase({ onSelect, retryRows = [], failOnFactoryLane = true } = {}) {
+  return {
+    from(table) {
+      let selectedCols = '';
+      const builder = {
+        select(cols) {
+          selectedCols = cols || '';
+          onSelect?.(selectedCols);
+          return builder;
+        },
+        in() { return builder; },
+        is() { return builder; },
+        order() { return builder; },
+        limit() {
+          if (table !== 'quick_fixes') return Promise.resolve({ data: [], error: null });
+          if (failOnFactoryLane && selectedCols.includes('factory_lane')) {
+            return Promise.resolve({
+              data: null,
+              error: { code: '42703', message: 'column quick_fixes.factory_lane does not exist' },
+            });
+          }
+          return Promise.resolve({ data: retryRows, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('loadOpenQuickFixes — retries without factory_lane on 42703', () => {
+  it('retries without the missing column instead of reporting an empty queue', async () => {
+    const selects = [];
+    const supabase = makeFakeSupabase({
+      onSelect: (cols) => selects.push(cols),
+      retryRows: [OPEN_QF],
+    });
+
+    const result = await loadOpenQuickFixes(supabase);
+
+    expect(selects.length).toBe(2);
+    expect(selects[0]).toContain('factory_lane');
+    expect(selects[1]).not.toContain('factory_lane');
+    // The regression: pre-fix this was [] and sd:next showed no open QFs at all.
+    expect(result.map((q) => q.id)).toEqual(['QF-20260724-001']);
+  });
+
+  it('does not issue a second query when the first attempt succeeds', async () => {
+    const selects = [];
+    const supabase = makeFakeSupabase({
+      onSelect: (cols) => selects.push(cols),
+      retryRows: [OPEN_QF],
+      failOnFactoryLane: false,
+    });
+
+    await loadOpenQuickFixes(supabase);
+
+    expect(selects.length).toBe(1);
+    expect(selects[0]).toContain('factory_lane');
+  });
+
+  it('still returns [] for a non-42703 error rather than retrying', async () => {
+    const selects = [];
+    const supabase = {
+      from() {
+        const builder = {
+          select(cols) { selects.push(cols); return builder; },
+          in() { return builder; },
+          is() { return builder; },
+          order() { return builder; },
+          limit() {
+            return Promise.resolve({
+              data: null,
+              error: { code: '42P01', message: 'relation "quick_fixes" does not exist' },
+            });
+          },
+        };
+        return builder;
+      },
+    };
+
+    const result = await loadOpenQuickFixes(supabase);
+
+    expect(selects.length).toBe(1);
+    expect(result).toEqual([]);
+  });
+
+  it('keeps the chairman-gated / fixture exclusions applied to the retried rows', async () => {
+    const supabase = makeFakeSupabase({
+      retryRows: [
+        OPEN_QF,
+        { ...OPEN_QF, id: 'QF-CHAIRMAN', owner: 'chairman', release_condition: 'chairman approves the DDL' },
+      ],
+    });
+
+    const result = await loadOpenQuickFixes(supabase);
+
+    // The retry must not become a back door around the exclusion predicates.
+    expect(result.map((q) => q.id)).toEqual(['QF-20260724-001']);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260724-598

**Type:** bug
**Severity:** high

### Issue Description
loadOpenQuickFixes (scripts/modules/sd-next/data-loaders.js:434) selects quick_fixes.factory_lane, a staged-but-never-applied column (database/migrations/20260713_quick_fixes_factory_lane.sql). PostgREST fails the ENTIRE multi-column select with 42703, so the function logs a query failure and returns [] -- sd:next shows zero open QFs to every worker, and the Track C / AUTO_PROCEED_ACTION qf_start recommendation path is dead. scripts/worker-checkin.cjs selfClaimQuickFix already carries the exact retry-without-factory_lane fallback for this same column (QF-20260720-763, PR 6334); data-loaders.js was never given the twin fix. Mirror that fallback here. Once the column lands the retry stops firing and behavior is unchanged (factory_lane undefined === column DEFAULT false for the qf.factory_lane === true check in display/quick-fixes.js:145), so it self-heals with no follow-up change.

### Steps to Reproduce
1. Ensure 20260713_quick_fixes_factory_lane.sql is unapplied (current prod state). 2. Run npm run sd:next. 3. Observe [sd-next:query-failure] loadOpenQuickFixes column quick_fixes.factory_lane does not exist (42703) and an empty open-QF section, despite 50+ open rows in quick_fixes.

### Expected Behavior
sd:next lists open quick fixes; the 42703 is absorbed by a retry without factory_lane, matching worker-checkin.cjs selfClaimQuickFix.

### Actual Behavior
loadOpenQuickFixes returns [] on every run; open QFs are invisible in the queue, so idle workers conclude the belt is empty.

### Changes
- **Files Changed:** 2
  - scripts/modules/sd-next/data-loaders.js
  - tests/unit/sd-next/load-open-quick-fixes-factory-lane-retry.test.js
- **LOC:** 23 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol