### PR TITLE
fix(QF-20260724-290): forward startupPrompt across both respawn hops so respawned sessions stop ghosting

### DIFF
--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -37,6 +37,17 @@ async function defaultLogFn(supabase, event) {
   return logCoordinationEvent(supabase, event);
 }
 
+/**
+ * QF-20260724-290: lazily resolve the CANONICAL fleet-worker keepalive prompt (CJS) — the same text
+ * worker-spawn-executor.cjs launches its workers with. A respawned tab that receives no prompt has
+ * nothing to do: it registers, heartbeats once, and exits (ghost), which is precisely what made the
+ * respawn leg unverifiable post-hoc. Single source of truth — never re-author the prompt text here.
+ */
+async function defaultStartupPrompt() {
+  const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
+  return FLEET_WORKER_STARTUP_PROMPT;
+}
+
 function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
 /** Best-effort insert into session_lifecycle_events; never throws (fail-soft, caller doesn't await for correctness). */
@@ -98,7 +109,8 @@ async function reconcileSpawnedSession(supabase, pid, opts = {}) {
  * @param {object}   [opts.supabase]           - service client (passed to loadFn/logFn)
  * @param {Function} [opts.loadFn]             - async (supabase)=>slots ; defaults to loadDesiredSlots
  * @param {Function} [opts.rosterFn]          - (slots)=>roster ; defaults to slotsToRoster
- * @param {Function} [opts.buildInvocationFn] - ({role,callsign,profileDir,resumeUuid})=>invocation ; defaults to buildLiveSpawnInvocation
+ * @param {Function} [opts.buildInvocationFn] - ({role,callsign,profileDir,resumeUuid,startupPrompt})=>invocation ; defaults to buildLiveSpawnInvocation
+ * @param {string|null} [opts.startupPrompt]  - keepalive prompt for each respawned tab; omit for the canonical FLEET_WORKER_STARTUP_PROMPT, null to opt out
  * @param {Function} [opts.spawnFn]           - (program,args,env)=>child ; ONLY invoked when live
  * @param {Function} [opts.logFn]             - async (supabase,event)=>result ; defaults to logCoordinationEvent
  * @param {Function} [opts.resolveProfileDirFn] - (name,opts)=>dir ; defaults to resolveProfileDir
@@ -120,6 +132,9 @@ export async function runRebootRespawn(opts = {}) {
     now = () => new Date().toISOString(),
   } = opts;
   const live = opts.live ?? isLiveEnabled();
+  // QF-20260724-290: resolve ONCE per run, not per slot. Explicit-key check (not `??`) so a caller can
+  // pass startupPrompt:null to deliberately respawn without a keepalive; absent means "use canonical".
+  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt();
 
   const slots = await loadFn(supabase);
   const roster = rosterFn(slots);
@@ -139,7 +154,7 @@ export async function runRebootRespawn(opts = {}) {
       catch (e) { log(`[reboot-respawn] profile resolve failed for ${callsign} (${slot.account_profile}): ${e && e.message}`); profileDir = null; }
     }
 
-    const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid });
+    const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid, startupPrompt });
 
     let spawned = false;
     let child = null;

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -73,9 +73,14 @@ export function isLiveEnabled(env = process.env) {
  * dir + CLAUDE_CONFIG_DIR + PERSISTENT wt.exe tab + auto-resume, fail-loud). No per-path launch logic
  * lives here anymore. `resumeUuid` still reattaches a captured session; `profileDir` is pre-resolved
  * by spawn() and passed through; the returned invocation additionally carries `cwd`+`persistent`.
+ *
+ * QF-20260724-290: `startupPrompt` is forwarded too. buildSessionLaunch has always destructured it
+ * (and sets childEnv.FLEET_WORKER_STARTUP_PROMPT — the persistent replacement for headless -p), but
+ * this hop did not, so a caller-supplied keepalive prompt was silently DISCARDED here and the launched
+ * session came up with nothing to do: it heartbeat once and ghosted.
  */
-export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume } = {}) {
-  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume });
+export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt } = {}) {
+  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt });
 }
 
 /**

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -208,3 +208,31 @@ describe('runRebootRespawn (QF-20260724-070): durable bind-time audit row', () =
     expect(writeLifecycleEventFn).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * QF-20260724-290 — the keepalive prompt must survive BOTH hops (runner -> buildLiveSpawnInvocation
+ * -> buildSessionLaunch) and land in the spawned child's env. Asserted on the env the REAL spawnFn
+ * seam receives, not on an intermediate call arg: a prompt that is passed but silently discarded one
+ * hop later is exactly the ghost this fixes, and an arg-level assertion would not have caught it.
+ */
+describe('runRebootRespawn keepalive prompt plumbing (QF-20260724-290)', () => {
+  it('forwards the canonical FLEET_WORKER_STARTUP_PROMPT into the respawned child env', async () => {
+    const { FLEET_WORKER_STARTUP_PROMPT } = await import('../../../lib/coordinator/coordination-events.cjs');
+    let childEnv = null;
+    await runRebootRespawn({
+      supabase: null, loadFn: async () => [SLOTS[0]], logFn: async () => ({ ok: true }), live: true,
+      spawnFn: (_p, _a, env) => { childEnv = env; return { pid: 0 }; },
+    });
+    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT.length).toBeGreaterThan(0);
+  });
+
+  it('honors an explicit startupPrompt:null opt-out (env var left unset)', async () => {
+    let childEnv = null;
+    await runRebootRespawn({
+      supabase: null, loadFn: async () => [SLOTS[0]], logFn: async () => ({ ok: true }), live: true,
+      startupPrompt: null, spawnFn: (_p, _a, env) => { childEnv = env; return { pid: 0 }; },
+    });
+    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem
Respawned fleet sessions launched with **no keepalive prompt**, heartbeat once, then exited (ghost). That is the mechanism that made the CP3 respawn leg unverifiable post-hoc.

Root cause is a two-hop plumbing omission, not a missing feature:

| Hop | File | Defect |
|---|---|---|
| 1 | `lib/fleet/reboot-respawn-runner.js:142` | `buildInvocationFn({role,callsign,profileDir,resumeUuid})` — `startupPrompt` never passed at all |
| 2 | `lib/fleet/spawn-control.js:77-79` | `buildLiveSpawnInvocation()` did not destructure or forward `startupPrompt`, so even a caller that passed it had the value **silently discarded** |
| terminus | `lib/fleet/build-session-launch.cjs:75,88` | already destructured `startupPrompt` and set `childEnv.FLEET_WORKER_STARTUP_PROMPT` — support existed; the two hops in front never wired it |

## Fix
- Hop 2 forwards `startupPrompt` through to `buildSessionLaunch`.
- Hop 1 resolves the **canonical** `FLEET_WORKER_STARTUP_PROMPT` (the same text `worker-spawn-executor.cjs` uses — single source of truth, not re-authored) once per run, with an explicit-key check so a caller can pass `startupPrompt: null` to deliberately opt out.

## Corrects the record
QF-20260724-070's description said to first verify whether passing the existing `startupPrompt` achieves persistence — **the answer is no**, because of hop 2.

## Verification
- Regression test asserts the prompt on the env the **real** `spawnFn` seam receives, not on an intermediate call arg — a value passed then discarded a hop later is exactly this ghost, and an arg-level assertion would not catch it.
- **Verified failing on unfixed code** (`expected undefined to be '/loop You are an autonomous LEO fleet…'`) before the fix, passing after — no test-masking.
- `tests/unit/fleet/` — 607 tests pass, 0 failures. (25 suites error out on `Cannot find module '@supabase/supabase-js'` — the QF worktree has no `node_modules`; environmental, unrelated.)

## Scope
Not a CP3 blocker (Solomon ruled a momentary real bind passes checkpoint-3; sustained persistence is not required). This is LEO-application-working scope per chairman priority 2026-07-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)