### PR TITLE
fix(QF-20260724-245): tier-ladder normalizeModel exact-key lookup scores every real model ID as fable, not its true family

### DIFF
--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -80,12 +80,29 @@ let lastKnownTopRank = LADDER.length;
  * Unknown/missing model maps conservative-UP to the strongest known model — never
  * silently down to the weakest, so an unrecognized-but-possibly-powerful worker is
  * never under-restricted.
+ *
+ * QF-20260724-245: MODEL_STRENGTH's keys are bare FAMILY names, but workers self-report
+ * their real model ID at checkin ('claude-opus-5', 'claude-opus-5[1m]', 'claude-opus-4-8').
+ * An exact-key lookup misses every one of those and dropped them into the unknown branch,
+ * so genuine Opus/Sonnet/Haiku seats scored as fable-tier. That is not the conservative-UP
+ * rule working as intended — a recognizable id is not an unknown model. deriveLiveLadder
+ * dense-ranks on capabilityScore, so an all-Opus fleet could dense-rank as if it were fable
+ * seats, which matters under the 50% weekly Fable cap policy and fable_window_active gating.
+ * Resolve the family out of a full id BEFORE falling back. When more than one family name
+ * appears in a single id, take the STRONGEST match, so this stays in the same
+ * conservative-UP direction as the unknown fallback it precedes. Truly unrecognized and
+ * empty/missing values are untouched and still resolve to STRONGEST_MODEL.
  * @param {string} [model]
  * @returns {string} a key of MODEL_STRENGTH
  */
 function normalizeModel(model) {
   const key = typeof model === 'string' ? model.toLowerCase().trim() : '';
-  return Object.prototype.hasOwnProperty.call(MODEL_STRENGTH, key) ? key : STRONGEST_MODEL;
+  if (Object.prototype.hasOwnProperty.call(MODEL_STRENGTH, key)) return key;
+  const families = Object.keys(MODEL_STRENGTH).filter((family) => key.includes(family));
+  if (families.length > 0) {
+    return families.reduce((a, b) => (MODEL_STRENGTH[b] > MODEL_STRENGTH[a] ? b : a));
+  }
+  return STRONGEST_MODEL;
 }
 
 /**

--- a/tests/unit/tier-ladder-normalize-model-family.test.js
+++ b/tests/unit/tier-ladder-normalize-model-family.test.js
@@ -1,0 +1,78 @@
+/**
+ * QF-20260724-245 — normalizeModel() did an exact-key lookup against MODEL_STRENGTH, whose
+ * keys are bare FAMILY names (haiku|sonnet|opus|fable). Workers self-report their REAL model
+ * id at checkin ('claude-opus-5', 'claude-opus-5[1m]', 'claude-opus-4-8'), every one of which
+ * missed the map and fell into the unknown branch -> STRONGEST_MODEL='fable'. Genuine Opus
+ * seats therefore scored 14 (fable-tier) instead of 10 (opus-tier). deriveLiveLadder
+ * dense-ranks on capabilityScore, so an all-Opus fleet could dense-rank as if it were fable
+ * seats — material under the 50% weekly Fable cap policy and fable_window_active gating.
+ *
+ * The conservative-UP fallback for genuinely unknown models is DELIBERATE and must survive:
+ * these tests pin both halves — real ids resolve to their family, unknown/empty still go UP.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  normalizeModel,
+  capabilityScore,
+  MODEL_STRENGTH,
+} = require('../../lib/fleet/tier-ladder.cjs');
+
+describe('normalizeModel — resolves a full model ID to its family', () => {
+  it('maps the live specimen claude-opus-5[1m] to opus, not fable', () => {
+    // The exact value observed on worker 074ec1e1 when this was reported.
+    expect(normalizeModel('claude-opus-5[1m]')).toBe('opus');
+  });
+
+  it.each([
+    ['claude-opus-5', 'opus'],
+    ['claude-opus-4-8', 'opus'],
+    ['claude-sonnet-5', 'sonnet'],
+    ['claude-haiku-4-5-20251001', 'haiku'],
+    ['claude-fable-5', 'fable'],
+    ['us.anthropic.claude-opus-5-v1:0', 'opus'],
+  ])('maps %s -> %s', (id, family) => {
+    expect(normalizeModel(id)).toBe(family);
+  });
+
+  it('is case- and whitespace-insensitive on full ids', () => {
+    expect(normalizeModel('  CLAUDE-Opus-5[1M]  ')).toBe('opus');
+  });
+
+  it('still accepts the bare family names unchanged (no regression)', () => {
+    for (const family of Object.keys(MODEL_STRENGTH)) {
+      expect(normalizeModel(family)).toBe(family);
+    }
+  });
+});
+
+describe('normalizeModel — conservative-UP is preserved for genuinely unknown input', () => {
+  it.each([
+    ['gemini-3-5-pro'],
+    ['gpt-6'],
+    ['some-model-nobody-has-heard-of'],
+  ])('maps unrecognized %s UP to the strongest model', (id) => {
+    expect(normalizeModel(id)).toBe('fable');
+  });
+
+  it.each([[''], ['   '], [undefined], [null], [42], [{}]])(
+    'maps missing/non-string %s UP to the strongest model',
+    (bad) => {
+      expect(normalizeModel(bad)).toBe('fable');
+    },
+  );
+
+  it('takes the STRONGEST family when an id somehow names more than one', () => {
+    // Never resolve DOWN on an ambiguous id — same direction as the unknown fallback.
+    expect(normalizeModel('claude-opus-and-fable-hybrid')).toBe('fable');
+    expect(normalizeModel('haiku-sonnet-blend')).toBe('sonnet');
+  });
+});
+
+describe('capabilityScore — the actual regression this fixes', () => {
+  it('scores a full opus id identically to the bare family, not as fable', () => {
+    expect(capabilityScore('claude-opus-5[1m]', 'high')).toBe(capabilityScore('opus', 'high'));
+    expect(capabilityScore('claude-opus-5[1m]', 'high')).not.toBe(capabilityScore('fable', 'high'));
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260724-245

**Type:** bug
**Severity:** medium

### Issue Description
lib/fleet/tier-ladder.cjs normalizeModel() does an exact-key lookup against MODEL_STRENGTH, whose keys are bare family names (haiku|sonnet|opus|fable). Every real model ID a worker self-reports at checkin -- claude-opus-5, claude-opus-5[1m], claude-opus-4-8 -- misses that map and falls through to the conservative-UP default STRONGEST_MODEL=fable, scoring 14 (fable-tier) instead of 10 (opus-tier). The conservative-UP fallback is correct and deliberate for GENUINELY unknown models and must be preserved; the defect is that a plainly recognizable Opus id is treated as unknown. deriveLiveLadder dense-ranks on capabilityScore, so an all-Opus fleet can dense-rank as though it were fable seats -- material given the 50pct weekly Fable cap policy and any fable_window_active gating. Fix per the reporter FIX SHAPE: resolve a full model ID to its family (substring match) before falling back to unknown; when several families appear in one id, take the STRONGEST match so the conservative-UP direction is never violated. Unstamped/empty still resolves to STRONGEST_MODEL unchanged. Sourced from harness_backlog feedback 4f120922-0692-497b-8d77-ca3a6f48ee89 (live specimen: worker 074ec1e1 metadata.model=claude-opus-5[1m]).

### Steps to Reproduce
1. node -e require('./lib/fleet/tier-ladder.cjs').normalizeModel('claude-opus-5[1m']) 2. Observe it returns 'fable' rather than 'opus'. 3. Same for claude-opus-5, claude-opus-4-8, claude-sonnet-5, claude-haiku-4-5-20251001.

### Expected Behavior
normalizeModel resolves a full model ID to its family: claude-opus-5[1m] -> opus, claude-sonnet-5 -> sonnet, claude-haiku-4-5-20251001 -> haiku; unknown/empty still -> fable (conservative-UP).

### Actual Behavior
Every full model ID returns fable, so opus/sonnet/haiku seats are scored at fable capability in deriveLiveLadder dense-ranking.

### Changes
- **Files Changed:** 2
  - lib/fleet/tier-ladder.cjs
  - tests/unit/tier-ladder-normalize-model-family.test.js
- **LOC:** 96 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol