### PR TITLE
fix(QF-20260724-652): never release a live worker on the PID leg alone

### DIFF
--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -629,9 +629,13 @@ export async function updateHeartbeat(sessionId) {
   // SD-FDBK-INFRA-CASCADE-TRIGGER-OVERREACH-001 (FR-3): extended to 'stale' too.
   // .in('status', [...]) filter ensures we only write when the row was previously
   // released or stale — 'active' sessions are untouched.
+  // QF-20260724-652: also clear released_reason. It previously cleared stale_reason
+  // but NOT released_reason, so a merely-'stale' session self-recovered here while a
+  // 'released' one stayed permanently undispatchable — the exact asymmetry that left
+  // Alpha-3/-4 stranded while Charlie recovered under identical code.
   await supabase
     .from('claude_sessions')
-    .update({ status: 'active', stale_reason: null, stale_at: null })
+    .update({ status: 'active', stale_reason: null, stale_at: null, released_reason: null })
     .eq('session_id', sessionId)
     .in('status', ['released', 'stale']);
 
@@ -677,6 +681,26 @@ export async function getClaimedSessions() {
  * Cleanup stale sessions (>5 min no heartbeat)
  * SD-LEO-INFRA-ISL-001: Enhanced with PID validation (FR-2/US-003) and status file cleanup (US-006)
  */
+/**
+ * QF-20260724-652: both-legs staleness predicate.
+ *
+ * A session is only stale when a dead-PID probe AND a stale heartbeat agree.
+ * The PID leg alone is not trustworthy — a subprocess-intermediary PID can read
+ * as gone while the session is demonstrably alive (heartbeat seconds fresh).
+ * Trusting it alone released 3 of 16 live workers into undispatchable limbo on
+ * 2026-07-25. Heartbeat is the leg a stale PID probe cannot fake, so it holds veto.
+ *
+ * Pure (no fs/DB) so it is testable without touching the shared claude_sessions table.
+ *
+ * @param {{heartbeatAgeSeconds: number, pidAlive: boolean, staleThresholdSeconds?: number}} p
+ * @returns {boolean} true only when BOTH legs report dead
+ */
+export function isSessionStale({ heartbeatAgeSeconds, pidAlive, staleThresholdSeconds = STALE_THRESHOLD_SECONDS }) {
+  if (pidAlive) return false;
+  if (!Number.isFinite(heartbeatAgeSeconds)) return false; // unknown heartbeat → never release on the PID leg alone
+  return heartbeatAgeSeconds > staleThresholdSeconds;
+}
+
 export async function cleanupStaleSessions() {
   const results = {
     localCleaned: 0,
@@ -700,8 +724,10 @@ export async function cleanupStaleSessions() {
       const heartbeatAge = (Date.now() - new Date(data.heartbeat_at).getTime()) / 1000;
       const pidAlive = data.pid ? isProcessRunning(data.pid) : false;
 
-      // FR-2/US-003: PID validation for local sessions
-      if (!pidAlive && data.machine_id === localMachineId) {
+      // FR-2/US-003: PID validation for local sessions.
+      // QF-20260724-652: gated on the both-legs predicate — never the PID leg alone.
+      const sessionStale = isSessionStale({ heartbeatAgeSeconds: heartbeatAge, pidAlive });
+      if (sessionStale && data.machine_id === localMachineId) {
         results.pidValidationFailed++;
         // Report PID validation failure to database (silent fail for telemetry)
         try {
@@ -712,8 +738,9 @@ export async function cleanupStaleSessions() {
         } catch { /* telemetry - silent fail */ }
       }
 
-      // Stale if heartbeat too old OR process not running
-      if (heartbeatAge > STALE_THRESHOLD_SECONDS || !pidAlive) {
+      // QF-20260724-652: was `heartbeatAge > STALE || !pidAlive` — that OR let the
+      // untrustworthy PID leg delete a live, heartbeating session's file on its own.
+      if (sessionStale) {
         fs.unlinkSync(filePath);
         results.localCleaned++;
       }

--- a/tests/unit/session-stale-both-legs.test.js
+++ b/tests/unit/session-stale-both-legs.test.js
@@ -1,0 +1,46 @@
+/**
+ * QF-20260724-652 — the staleness sweep must never release a live worker.
+ *
+ * Witnessed live 2026-07-25: 3 of 16 workers sat in undispatchable limbo (Charlie
+ * stale, Alpha-3/-4 released/STALE_CLEANUP) while their heartbeat_at was SECONDS
+ * fresh. The PID leg reported PID_NOT_FOUND with process_alive_at frozen ~46min,
+ * and the sweep trusted that leg alone. Releasing now requires BOTH a dead-PID
+ * probe AND a stale heartbeat — heartbeat is the leg a stale PID probe cannot fake.
+ *
+ * Pure predicate only — no claude_sessions access, matching the convention in
+ * stale-session-sweep-dormancy-gate.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSessionStale } from '../../lib/session-manager.mjs';
+
+const STALE = 900; // lib/session-manager.mjs STALE_THRESHOLD_SECONDS
+
+describe('isSessionStale — both-legs rule', () => {
+  it('REGRESSION: does not release a seconds-fresh heartbeat on a dead PID probe alone', () => {
+    // The exact Alpha-3/-4 shape: PID probe says gone, heartbeat says alive.
+    expect(isSessionStale({ heartbeatAgeSeconds: 3, pidAlive: false })).toBe(false);
+  });
+
+  it('does not release when the PID is alive, however old the heartbeat', () => {
+    expect(isSessionStale({ heartbeatAgeSeconds: STALE * 10, pidAlive: true })).toBe(false);
+  });
+
+  it('releases only when BOTH legs report dead', () => {
+    expect(isSessionStale({ heartbeatAgeSeconds: STALE + 1, pidAlive: false })).toBe(true);
+  });
+
+  it('holds the session at exactly the threshold (strictly-greater boundary)', () => {
+    expect(isSessionStale({ heartbeatAgeSeconds: STALE, pidAlive: false })).toBe(false);
+  });
+
+  it('fails safe when the heartbeat age is unknown — never releases on the PID leg alone', () => {
+    // A missing/corrupt heartbeat_at yields NaN; that must not become a release.
+    expect(isSessionStale({ heartbeatAgeSeconds: NaN, pidAlive: false })).toBe(false);
+    expect(isSessionStale({ heartbeatAgeSeconds: Infinity, pidAlive: false })).toBe(false);
+  });
+
+  it('honours a caller-supplied threshold', () => {
+    expect(isSessionStale({ heartbeatAgeSeconds: 60, pidAlive: false, staleThresholdSeconds: 30 })).toBe(true);
+    expect(isSessionStale({ heartbeatAgeSeconds: 20, pidAlive: false, staleThresholdSeconds: 30 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The staleness sweep released workers that were **demonstrably alive**. Witnessed live 2026-07-25 by Alpha-2 (feedback `7aadf364`), independently verified by Solomon: 3 of 16 workers sat in undispatchable limbo — Charlie `stale`, Alpha-3/-4 `released`/`STALE_CLEANUP` — while their `heartbeat_at` was **seconds fresh**. The PID leg reported `PID_NOT_FOUND` with `process_alive_at` frozen ~46 minutes, and the sweep trusted that leg alone.

Net effect: present, healthy capacity becomes unassignable, and it is invisible from outside because those sessions never go quiet. Second-order, this puts a **false floor on belt-starvation diagnosis** — idle seats read as "workers lacking work" when some are live workers wrongly released.

## Fix

**Root half** — new pure predicate `isSessionStale()` requires **both** legs: a dead-PID probe *and* a stale heartbeat. Heartbeat is the leg a stale PID probe cannot fake, so it holds veto. Applied at both sweep sites in `cleanupStaleSessions()`:

| Site | Before | After |
|---|---|---|
| `report_pid_validation_failure` RPC | `!pidAlive` alone | both legs |
| local session-file delete | `heartbeatAge > STALE \|\| !pidAlive` | both legs |

That second one is worth calling out: the `||` let the untrustworthy PID leg delete a live, heartbeating session's file on its own. Unknown/NaN heartbeat fails safe (never releases).

**Cheap half** — the re-activation path now also clears `released_reason`. It cleared `stale_reason` but *not* `released_reason`, so a merely-`stale` session self-recovered while a `released` one stayed permanently undispatchable. That asymmetry is exactly why Charlie self-recovered under existing code while Alpha-3/-4 were stuck.

## Testing

`tests/unit/session-stale-both-legs.test.js` — 6 cases, pure predicate only, no `claude_sessions` access (matching the convention in `stale-session-sweep-dormancy-gate.test.js`). The lead case reproduces the exact Alpha-3/-4 shape (3s heartbeat + dead PID) and fails against the old logic. Neighbouring suites re-run green: `stale-session-sweep-dormancy-gate` (4), `periodic-liveness-watcher` (24), `claim-lifecycle-release` (18).

## Notes

- `process_alive_at` deliberately **left untouched** — Solomon kept it that way so the PID-rediscovery defect stays visible rather than masked. Not "fixed" here.
- `validateAndReportPid()` in `lib/heartbeat-manager.mjs` carries the same PID-leg-alone shape, but it is exported with **zero callers**, so it is left unchanged rather than widening this QF. Flagged for a follow-up if it ever gains one.
- 32 insertions / 5 deletions in source — within the QF bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
