### PR TITLE
fix(QF-20260725-757): canary provisioning step for CP3 + close the third keepalive-drop hop

### DIFF
--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -1,0 +1,118 @@
+/**
+ * Canary PROVISIONING step -- QF-20260725-757.
+ *
+ * THE GAP THIS CLOSES: the CP3 playbook goes reset-worktree -> unfence -> one --live run, presuming a
+ * live canary that nothing creates. fleet_desired_slots holds an enabled Canary-pilot row and
+ * metadata.canary_seed_pending=false is ACCURATE -- but a seeded SLOT and a running SESSION are
+ * different facts, and only the slot was ever checked. With no session, resolveCanaryTarget returns
+ * resolved:false/not_found, the drill fail-closes at the guard on all three legs, emits zero
+ * fleet_verb_ rows, and burns the single clean run on a PARTIAL with nothing recoverable.
+ *
+ * THE GATE IS SESSION-LIVENESS, NOT SLOT EXISTENCE. isProvisioned() below asserts
+ * resolveCanaryTarget resolved:true; a seeded slot alone can never again read as drill-ready.
+ *
+ * SURVIVABILITY: canary sessions previously died of the QF-20260724-290 keepalive drop. That QF fixed
+ * buildLiveSpawnInvocation and the respawn runner, but spawn() -- the verb provisioning must use --
+ * was a THIRD hop that still passed no startupPrompt, so a provisioned canary would have ghosted
+ * exactly as before. Fixed in spawn-control.js's spawn() alongside this module; without that fix this
+ * provisioning step could not produce a surviving canary.
+ *
+ * SAFETY: dry-run by default. A live spawn requires an explicit live:true from the caller -- this
+ * module never infers it. Running the CP3 drill itself is NOT in scope (Solomon owns legs S4-S7).
+ */
+import { loadDesiredSlots } from './desired-slots-store.js';
+import { resolveCanaryTarget } from './canary-guard.js';
+import { spawn as spawnControlSpawn } from './spawn-control.js';
+
+const CANARY_PROFILE = 'canary';
+
+/**
+ * Pick the enabled canary slot from the desired-slots manifest. Pure.
+ * Returns null when the manifest has no canary slot (S3 seeding genuinely incomplete) -- distinct
+ * from "slot seeded but no session", which is the case this whole module exists for.
+ * @param {Array<object>} slots  normalized desired slots
+ */
+export function selectCanarySlot(slots = []) {
+  const list = Array.isArray(slots) ? slots : [];
+  return list.find((s) => s && s.account_profile === CANARY_PROFILE && s.name) || null;
+}
+
+/**
+ * THE gate predicate: is a canary actually PROVISIONED (live, resolvable session)? Pure.
+ * Deliberately reads only the resolution -- never a slot row -- so slot-existence can never be
+ * mistaken for drill-readiness. Fail-closed: anything but an explicit resolved:true is false.
+ * @param {{resolved?:boolean}} resolution  a resolveCanaryTarget result
+ */
+export function isProvisioned(resolution) {
+  return Boolean(resolution && resolution.resolved === true);
+}
+
+/**
+ * Provision the canary for the seeded slot and WAIT until it registers a live, resolvable session.
+ *
+ * Order is deliberate: check first (idempotent -- an already-live canary is a no-op, never a second
+ * spawn), then spawn, then poll the GATE. Every seam is injectable so this is testable without
+ * touching a real fleet.
+ *
+ * @param {object}   args
+ * @param {object}   args.supabase
+ * @param {boolean}  [args.live=false]      false => dry-run; a live spawn requires an explicit true
+ * @param {number}   [args.maxAttempts=10]  registration polls after spawning
+ * @param {number}   [args.delayMs=3000]    delay between polls
+ * @param {Function} [args.loadSlotsFn]     defaults to loadDesiredSlots
+ * @param {Function} [args.resolveFn]       defaults to resolveCanaryTarget
+ * @param {Function} [args.spawnFn]         defaults to spawn-control spawn()
+ * @param {Function} [args.sleepFn]         defaults to real setTimeout
+ * @param {Function} [args.logFn]
+ * @returns {Promise<{ok:boolean, reason:string, slot?:object, alreadyLive?:boolean, attempts?:number, spawn?:object}>}
+ */
+export async function provisionCanary({
+  supabase,
+  live = false,
+  maxAttempts = 10,
+  delayMs = 3000,
+  loadSlotsFn = loadDesiredSlots,
+  resolveFn = resolveCanaryTarget,
+  spawnFn = spawnControlSpawn,
+  sleepFn = (ms) => new Promise((r) => setTimeout(r, ms)),
+  logFn = () => {},
+} = {}) {
+  const byProfile = { by: 'account_profile', value: CANARY_PROFILE };
+
+  // Idempotence: an already-resolvable canary needs no spawn.
+  const pre = await resolveFn(supabase, byProfile);
+  if (isProvisioned(pre)) {
+    logFn('[canary-provision] canary already live — no spawn needed');
+    return { ok: true, reason: 'already_live', alreadyLive: true, attempts: 0 };
+  }
+
+  const slot = selectCanarySlot(await loadSlotsFn(supabase));
+  if (!slot) {
+    // Genuinely unseeded — a provisioning step cannot invent a slot; S3 seeding must run first.
+    return { ok: false, reason: 'no_canary_slot_seeded' };
+  }
+
+  const spawnResult = await spawnFn(
+    { role: slot.role || 'worker', callsign: slot.name, accountProfile: CANARY_PROFILE },
+    { supabaseClient: supabase, live, log: logFn },
+  );
+
+  if (!live) {
+    // Dry-run reports the PLAN and makes the un-met gate explicit; it never claims readiness.
+    logFn(`[canary-provision] DRY-RUN would spawn canary ${slot.name}; gate still unmet`);
+    return { ok: false, reason: 'dry_run', slot, spawn: spawnResult, attempts: 0 };
+  }
+
+  // Poll the GATE (session resolvable), not the spawn's own return -- a spawned process that never
+  // registers is exactly the failure mode this step exists to catch.
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await sleepFn(delayMs);
+    const resolution = await resolveFn(supabase, byProfile);
+    if (isProvisioned(resolution)) {
+      logFn(`[canary-provision] canary registered after ${attempt} attempt(s)`);
+      return { ok: true, reason: 'provisioned', slot, spawn: spawnResult, attempts: attempt };
+    }
+  }
+
+  return { ok: false, reason: 'registration_timeout', slot, spawn: spawnResult, attempts: maxAttempts };
+}

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -84,6 +84,16 @@ export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUui
 }
 
 /**
+ * QF-20260725-757: the canonical keepalive prompt, mirroring reboot-respawn-runner.js's private
+ * helper of the same name. Lazy dynamic import keeps this ESM module free of a load-time dependency
+ * on the .cjs coordination-events surface (same idiom as the respawn runner).
+ */
+async function defaultStartupPrompt() {
+  const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
+  return FLEET_WORKER_STARTUP_PROMPT;
+}
+
+/**
  * Restricted event payload -- HARD-LOCKED to exactly {verb, outcome, at}, never
  * CLAUDE_CONFIG_DIR/profile paths/argv (FR-9, TR-6). No extension point: a future verb needing a
  * new field must widen this allowlist explicitly here, never spread arbitrary caller data through.
@@ -118,6 +128,12 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   const supabase = opts.supabaseClient;
   const live = opts.live ?? isLiveEnabled();
   const log = opts.log || (() => {});
+  // QF-20260725-757: spawn() is the THIRD hop of the QF-20260724-290 keepalive drop. That QF fixed
+  // buildLiveSpawnInvocation (L82) and reboot-respawn-runner, but spawn() still built its invocation
+  // with no startupPrompt at all, so every session created through the generic spawn verb came up
+  // with nothing to do, heartbeat once, and ghosted. Same opt-out semantics as the respawn runner
+  // (reboot-respawn-runner.js:137): absent => canonical prompt, explicit null => deliberately none.
+  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt();
 
   // ADVERSARIAL-REVIEW NOTE (known, accepted limitation): this dedup check reads liveCallsigns at a
   // point in time with no reservation/lock written before the OS spawn -- two near-simultaneous calls
@@ -144,7 +160,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
 
   let profileDir = null;
   if (accountProfile) profileDir = resolveProfileDir(accountProfile, opts);
-  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir });
+  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt });
 
   if (!live) {
     log(`[spawn-control] DRY-RUN would spawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);

--- a/tests/unit/canary-provision.test.js
+++ b/tests/unit/canary-provision.test.js
@@ -1,0 +1,109 @@
+/**
+ * QF-20260725-757 — canary provisioning for CP3.
+ *
+ * The bug: fleet_desired_slots had an enabled Canary-pilot row and canary_seed_pending=false, so the
+ * playbook read as drill-ready — but every canary session was status=released (~304 min stale) and
+ * resolveCanaryTarget returned resolved:false/not_found. A seeded SLOT and a running SESSION are
+ * different facts. The gate must be session-liveness, never slot existence.
+ *
+ * Pure/seam-injected only — no real fleet, no claude_sessions access.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectCanarySlot, isProvisioned, provisionCanary } from '../../lib/fleet/canary-provision.js';
+
+const CANARY_SLOT = { name: 'Canary-pilot', role: 'worker', account_profile: 'canary', model: 'opus' };
+const RESOLVED = { resolved: true, identity: { callsign: 'Canary-pilot', account_profile: 'canary' } };
+const NOT_FOUND = { resolved: false, reason: 'not_found' };
+
+describe('isProvisioned — the gate', () => {
+  it('REGRESSION: a seeded slot with no live session is NOT provisioned', () => {
+    // The exact CP3 state: slot seeded, canary_seed_pending=false, zero live sessions.
+    expect(isProvisioned(NOT_FOUND)).toBe(false);
+  });
+
+  it('is true only on an explicit resolved:true', () => {
+    expect(isProvisioned(RESOLVED)).toBe(true);
+  });
+
+  it('fails closed on malformed/absent resolutions', () => {
+    for (const bad of [null, undefined, {}, { resolved: 'true' }, { resolved: 1 }]) {
+      expect(isProvisioned(bad)).toBe(false);
+    }
+  });
+});
+
+describe('selectCanarySlot', () => {
+  it('picks the canary-profile slot and ignores production slots', () => {
+    const slots = [{ name: 'Alpha-3', account_profile: 'primary' }, CANARY_SLOT];
+    expect(selectCanarySlot(slots)).toEqual(CANARY_SLOT);
+  });
+
+  it('returns null when nothing is seeded, and tolerates junk input', () => {
+    expect(selectCanarySlot([{ name: 'Alpha-3', account_profile: 'primary' }])).toBeNull();
+    expect(selectCanarySlot([])).toBeNull();
+    expect(selectCanarySlot(undefined)).toBeNull();
+    expect(selectCanarySlot([null, { account_profile: 'canary' }])).toBeNull(); // nameless slot rejected
+  });
+});
+
+describe('provisionCanary', () => {
+  const base = {
+    supabase: {},
+    loadSlotsFn: async () => [CANARY_SLOT],
+    sleepFn: async () => {},
+  };
+
+  it('is idempotent — an already-live canary is never spawned again', async () => {
+    let spawned = 0;
+    const res = await provisionCanary({
+      ...base, live: true,
+      resolveFn: async () => RESOLVED,
+      spawnFn: async () => { spawned++; return {}; },
+    });
+    expect(res).toMatchObject({ ok: true, reason: 'already_live', alreadyLive: true });
+    expect(spawned).toBe(0);
+  });
+
+  it('DEFAULTS TO DRY-RUN: never claims readiness and never spawns live', async () => {
+    let liveFlag;
+    const res = await provisionCanary({
+      ...base,
+      resolveFn: async () => NOT_FOUND,
+      spawnFn: async (_t, opts) => { liveFlag = opts.live; return { live: false }; },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('dry_run');
+    expect(liveFlag).toBe(false);
+  });
+
+  it('reports the unseeded case distinctly from the seeded-but-dead case', async () => {
+    const res = await provisionCanary({
+      ...base, live: true,
+      loadSlotsFn: async () => [],
+      resolveFn: async () => NOT_FOUND,
+      spawnFn: async () => { throw new Error('must not spawn without a slot'); },
+    });
+    expect(res).toMatchObject({ ok: false, reason: 'no_canary_slot_seeded' });
+  });
+
+  it('waits for REGISTRATION, not merely a returned spawn', async () => {
+    let calls = 0;
+    // Spawn "succeeds" immediately but the session only registers on the 3rd poll.
+    const res = await provisionCanary({
+      ...base, live: true, maxAttempts: 5,
+      resolveFn: async () => (++calls >= 4 ? RESOLVED : NOT_FOUND),
+      spawnFn: async () => ({ live: true, pid: 123 }),
+    });
+    expect(res).toMatchObject({ ok: true, reason: 'provisioned', attempts: 3 });
+  });
+
+  it('REGRESSION: a spawn that never registers is a FAILURE, not a pass', async () => {
+    // The ghosting canary — process started, session never came up. Must not report ok.
+    const res = await provisionCanary({
+      ...base, live: true, maxAttempts: 3,
+      resolveFn: async () => NOT_FOUND,
+      spawnFn: async () => ({ live: true, pid: 123 }),
+    });
+    expect(res).toMatchObject({ ok: false, reason: 'registration_timeout', attempts: 3 });
+  });
+});

--- a/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
+++ b/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
@@ -16,7 +16,10 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
+// QF-20260725-757: spread the ORIGINAL module — spawn() now reads the canonical
+// FLEET_WORKER_STARTUP_PROMPT from here, and a wholesale stub dropped that export.
+vi.mock('../../../lib/coordinator/coordination-events.cjs', async (importOriginal) => ({
+  ...(await importOriginal()),
   logCoordinationEvent: vi.fn().mockResolvedValue({ ok: true }),
 }));
 vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -3,7 +3,12 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../../../lib/coordinator/coordination-events.cjs', () => ({
+// QF-20260725-757: spread the ORIGINAL module rather than replacing it wholesale. spawn() now reads
+// the canonical FLEET_WORKER_STARTUP_PROMPT from here (the keepalive it must forward), and a
+// stub that dropped that export made every spawn() test throw. Only logCoordinationEvent is
+// overridden; everything else stays real so the stub cannot drift from the module's contract again.
+vi.mock('../../../lib/coordinator/coordination-events.cjs', async (importOriginal) => ({
+  ...(await importOriginal()),
   logCoordinationEvent: vi.fn().mockResolvedValue({ ok: true }),
 }));
 vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
@@ -153,6 +158,27 @@ describe('buildLiveSpawnInvocation (FR-7: env isolation)', () => {
   it('omits CLAUDE_CONFIG_DIR when no profileDir is given', () => {
     const invocation = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Alpha-5' });
     expect(invocation.env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+});
+
+describe('spawn (FR-1) — keepalive forwarding (QF-20260725-757)', () => {
+  // spawn() was the THIRD hop of the QF-20260724-290 keepalive drop: that QF fixed
+  // buildLiveSpawnInvocation and the respawn runner, but spawn() built its invocation with NO
+  // startupPrompt, so every session created through the generic spawn verb came up with nothing to
+  // do, heartbeat once, and ghosted. This is why provisioned canaries kept dying.
+  it('REGRESSION: forwards the canonical keepalive prompt into the invocation env', async () => {
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false });
+    expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBeTruthy();
+  });
+
+  it('honours an explicit startupPrompt override', async () => {
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false, startupPrompt: 'custom-keepalive' });
+    expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBe('custom-keepalive');
+  });
+
+  it('honours an explicit null as a deliberate no-keepalive opt-out (respawn-runner parity)', async () => {
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false, startupPrompt: null });
+    expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

CP3 cannot run. The playbook goes reset-worktree → unfence → one `--live` run, **presuming a live canary that nothing creates**. Verified live 2026-07-25: `resolveCanaryTarget(by=account_profile, value=canary)` returns `resolved:false / not_found`, flags are fine (`isCanaryKillEnabled=true`) — there is simply no target. A `--live` run in that state fail-closes at the guard on all three legs, emits zero `fleet_verb_` rows, and burns the single clean run on a PARTIAL with nothing recoverable.

The precise gap: `fleet_desired_slots` holds an enabled Canary-pilot row, so S3 seeding IS complete and `canary_seed_pending=false` is **accurate** — but **a seeded SLOT and a running SESSION are different facts**, and only the slot was ever checked.

## Fix

**`lib/fleet/canary-provision.js`** — provisions the canary for the seeded slot and waits for it to *register*.

- **The gate is `isProvisioned()` → `resolveCanaryTarget` `resolved:true`, never slot-row existence.** A seeded slot can never again read as drill-ready.
- **Idempotent**: an already-live canary is a no-op, never a second spawn.
- **Dry-run by default**; a live spawn requires an explicit `live:true`. It polls the *gate*, not the spawn's own return — a process that starts but never registers is a `registration_timeout` failure, which is precisely the ghosting mode this exists to catch.
- Distinguishes `no_canary_slot_seeded` (S3 genuinely incomplete) from seeded-but-dead.

## The part that makes it actually work

`spawn()` was a **third hop** of the QF-20260724-290 keepalive drop. That QF fixed `buildLiveSpawnInvocation` (L82) and `reboot-respawn-runner`, but `spawn()` — the verb provisioning must use — built its invocation with **no `startupPrompt` and didn't accept one**:

```js
const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir }); // ← keepalive dropped
```

So a canary provisioned through it would have come up with nothing to do, heartbeat once, and ghosted exactly as its predecessors did. The QF's premise that "a canary is survivable now" held only for the respawn path. `spawn()` now resolves and forwards the canonical keepalive, with the same opt-out semantics as the respawn runner (absent ⇒ canonical, explicit `null` ⇒ deliberately none).

## Testing

**80 fleet suites / 901 tests green.** New `tests/unit/canary-provision.test.js` (10 cases, pure + seam-injected, no real fleet, no `claude_sessions`), plus 3 keepalive-forwarding regressions in `spawn-control.test.js`. The lead cases reproduce the exact failures: a seeded slot with no session is **not** provisioned, and a spawn that never registers is a **failure**, not a pass.

Two existing suites stubbed `coordination-events.cjs` wholesale and dropped the `FLEET_WORKER_STARTUP_PROMPT` export `spawn()` now reads; both now spread `importOriginal()` so the stub cannot drift from the module's contract again. That is making the stub faithful, not weakening the source to fit it.

## Scope / safety

- **NOT IN SCOPE**: running the CP3 drill. Solomon owns legs S4-S7; the SD is fenced `owned_by` Solomon/chairman. **No live canary was spawned and no `--live` run was consumed.**
- 56 code lines (50 new + 6 changed), within the Tier-2 cap of 75 — no SD escalation needed.
- The QF asked for coordinator review before a worker started; it reached me via the automated self-claim lane, which has no review hook. Flagged to the coordinator — happy to have this held if that lane should have gated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
