### PR TITLE
fix(QF-20260725-089): gate belt-depth counts through the claim classifier

### DIFF
--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -1,0 +1,62 @@
+/**
+ * Belt/backlog DEPTH gauge — QF-20260725-089.
+ *
+ * THE BUG THIS REPLACES: both consumers independently ran
+ *   .eq('status','draft').is('claiming_session_id', null)
+ * and emitted the raw count as "dispatchable". Measured 2026-07-25 that read 8 while TRUE
+ * claimable depth was 0 — the 8 being 7x human_action_required plus orchestrator parents,
+ * deferred/fenced rows and a test fixture. One ungated number, two governance surfaces, wrong
+ * in OPPOSITE directions: it fired IDLE_WITH_BACKLOG against the coordinator (a dispatch gap
+ * that did not exist) while scoring Adam D1 5/5 for a full belt at the moment the belt was empty.
+ *
+ * WHY THIS IS A SHARED MODULE, not a filter in each caller: the two consumers drifted apart
+ * precisely because each owned its own copy of the query. Depth is computed HERE, once, through
+ * the same claim gate the dispatcher itself uses (classifyDispatchIneligibility), so a held row
+ * can never again read as available work on one surface and not the other.
+ *
+ * Corroborated from three independent directions: Adam's metadata inspection, the coordinator
+ * running the classifier across every non-terminal SD, and worker Echo's /checkin returning
+ * belt_ranked_claimable=8 with belt_claimable_at_my_tier=0 continuously for ~2.5h.
+ */
+const { classifyDispatchIneligibility } = require('./claim-eligibility.cjs');
+
+// The columns classifyDispatchIneligibility's axes actually read. Kept explicit (not select('*'))
+// so a schema change that drops one fails loudly here rather than silently un-gating a row.
+const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application';
+
+/**
+ * Count belt depth with ineligible rows excluded BEFORE emission.
+ *
+ * Deliberately fetches rows rather than using a head-count: eligibility cannot be expressed as a
+ * PostgREST filter, so the classifier needs the rows. The prior head-count existed to dodge the
+ * 1000-row cap (a truncated read would corrupt this invariant); fetchAllPaginated preserves that
+ * protection by range-paginating past the cap instead of silently under-reporting depth.
+ *
+ * @param {object} supabase
+ * @returns {Promise<{dispatchable:number, raw:number, ineligible:Record<string,number>}>}
+ */
+async function countDispatchableBacklog(supabase) {
+  const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
+  // queryFactory must return a FRESH builder per page and must NOT pre-range — fetchAllPaginated
+  // applies .range() itself.
+  const rows = await fetchAllPaginated(() =>
+    supabase
+      .from('strategic_directives_v2')
+      .select(ELIGIBILITY_COLUMNS)
+      .eq('status', 'draft')
+      .is('claiming_session_id', null));
+
+  const ineligible = {};
+  let dispatchable = 0;
+  for (const row of rows || []) {
+    // No ctx: this is the STRUCTURAL gate (orchestrator parent, human-action hold, deferred,
+    // fenced, test fixture, not-before). Tier/fitness axes are per-worker and deliberately not
+    // applied to a fleet-wide depth gauge.
+    const reason = classifyDispatchIneligibility(row);
+    if (reason) ineligible[reason] = (ineligible[reason] || 0) + 1;
+    else dispatchable += 1;
+  }
+  return { dispatchable, raw: (rows || []).length, ineligible };
+}
+
+module.exports = { countDispatchableBacklog, ELIGIBILITY_COLUMNS };

--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -19,11 +19,15 @@ import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
 import { computeWaveLinkageCoverage } from '../lib/roadmap/wave-linkage-coverage.js';
 import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
 import { getActiveCoordinatorId } from '../lib/coordinator/resolve.cjs';
+// QF-20260725-089: the ONE belt-depth gauge, eligibility-gated. Never re-derive a depth count here.
+import { countDispatchableBacklog } from '../lib/fleet/belt-depth.cjs';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: exact head-counts for the
 // gauge sites below (never rows.length on a capped read) + pagination for the sharpenings
 // SD-window read (strategic_directives_v2 is unbounded and iterated, not just counted).
-import { fetchAllPaginated, renderCount, POSTGREST_MAX_ROWS } from '../lib/db/fetch-all-paginated.mjs';
+// QF-20260725-089: renderCount dropped — both head-count gauges it guarded now route through
+// countDispatchableBacklog, which returns a plain number.
+import { fetchAllPaginated, POSTGREST_MAX_ROWS } from '../lib/db/fetch-all-paginated.mjs';
 // SD-LEO-INFRA-COORDINATOR-HEALTH-KPI-001: the 5-sharpening delta (Solomon cold-review).
 // KPI-0 outcome/flow is the PRIMARY axis; the base 3 KPIs stay untouched below.
 import { execSync } from 'child_process';
@@ -67,17 +71,12 @@ export async function computeUtilization(supabase, { nowMs = Date.now() } = {}) 
   const claimed = live.filter((s) => !!s.sd_key);
   const idle = live.filter((s) => !s.sd_key);
 
-  // FR-6 batch 9: this is a GAUGE (only the count is used below) — exact head-count instead
-  // of a rows.length on a .limit(1000) read, which is exactly the live-incident cap-masking
-  // shape (read silently truncated at 1000 while the true backlog was larger).
-  const { count: backlogCount, error: bErr } = await supabase
-    .from('strategic_directives_v2')
-    .select('id', { count: 'exact', head: true })
-    .eq('status', 'draft')
-    .is('claiming_session_id', null);
-  if (bErr) throw new Error(`utilization: backlog query failed: ${bErr.message}`);
-  const backlogSize = renderCount(backlogCount);
-  if (backlogSize === 'unavailable') throw new Error('utilization: backlog count measurement unavailable');
+  // QF-20260725-089: this counted raw draft_unclaimed rows with NO eligibility gate, so HELD work
+  // read as available and IDLE_WITH_BACKLOG fired against the coordinator for a dispatch gap that
+  // did not exist (measured: 8 reported, 0 truly claimable, 7 human-action-held). Depth now comes
+  // from the shared gauge, which applies the same claim gate the dispatcher uses. Cap protection
+  // is preserved inside that helper via fetchAllPaginated.
+  const { dispatchable: backlogSize } = await countDispatchableBacklog(supabase);
 
   return {
     live_workers: live.length,
@@ -148,17 +147,13 @@ export async function computeFailLoudIntegrity(supabase, { selfReportedCounts, c
   // exact invariant this KPI is built on). count===null (measurement failure, possibly with
   // error===null on a missing-relation edge case) is surfaced as integrity_ok=false too, per
   // this function's own "MUST NEVER be null-coalesced into a silent 0" contract above.
-  const { count, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('id', { count: 'exact', head: true })
-    .eq('status', 'draft')
-    .is('claiming_session_id', null);
-  if (error) {
+  // QF-20260725-089: recomputed now runs through the SAME eligibility gate as self_reported
+  // (previously a raw draft_unclaimed head-count), so the two sides finally measure the same thing.
+  let dispatchableCount;
+  try {
+    ({ dispatchable: dispatchableCount } = await countDispatchableBacklog(supabase));
+  } catch (error) {
     return { integrity_ok: false, error: error.message, divergent_fields: ['dispatchable_count'] };
-  }
-  const dispatchableCount = renderCount(count);
-  if (dispatchableCount === 'unavailable') {
-    return { integrity_ok: false, error: 'dispatchable_count measurement unavailable', divergent_fields: ['dispatchable_count'] };
   }
   const recomputed = { dispatchable_count: dispatchableCount };
 
@@ -173,23 +168,29 @@ export async function computeFailLoudIntegrity(supabase, { selfReportedCounts, c
     humanActionHeld = (leaves?.humanActionHolds || []).length;
   }
 
-  const divergentFields = Object.keys(recomputed).filter((k) => (selfReported[k] ?? 0) > recomputed[k]);
-  // QF-20260720-161: self_reported <= recomputed is the healthy narrowing invariant (deps/
-  // holds/fixtures only ever REMOVE candidates), so a wide gap alone is not evidence of a
-  // stale read — 3 vs 20 with 11 held for human-action is real, verified fleet state. But a
-  // gap NOT explained by known holds is exactly the "confident but wrong" shape that hid
-  // live_workers=0 — flag the instrument as suspect instead of printing two opaque numbers.
-  const dc = recomputed.dispatchable_count;
-  const unexplained = humanActionHeld === null ? null : dc - selfReported.dispatchable_count - humanActionHeld;
-  const instrumentSuspect = unexplained !== null && dc > 0 && unexplained / dc > 0.5;
-  if (instrumentSuspect) divergentFields.push('dispatchable_count_unexplained_gap');
+  // QF-20260725-089: ANY inequality is now a divergence.
+  //
+  // The prior rule flagged only self_reported > recomputed, justified (QF-20260720-161) by the
+  // "healthy narrowing invariant": recomputed was the RAW draft_unclaimed count and self_reported
+  // was the narrowed one, so self_reported <= recomputed was expected and a wide gap was tolerated
+  // if roughly explained by known holds. That asymmetry is obsolete now that recomputed runs
+  // through the SAME eligibility gate — both sides measure the identical quantity, so any
+  // disagreement is a real instrument fault, not expected narrowing.
+  //
+  // It also had to go: the tolerated direction is exactly how 8-vs-0 passed. recomputed=8,
+  // self_reported=0 never tripped `selfReported > recomputed`, and the unexplained-gap heuristic
+  // computed 8-0-7=1 (12.5%, under its 50% threshold), so the audit returned integrity_ok=true
+  // with divergent_fields=[] while staring at an 8-vs-0 disagreement. Exact equality subsumes that
+  // heuristic and is strictly stronger, so instrument_suspect retires with it.
+  const divergentFields = Object.keys(recomputed).filter((k) => (selfReported[k] ?? 0) !== recomputed[k]);
 
   return {
     integrity_ok: divergentFields.length === 0,
     recomputed,
     self_reported: selfReported,
     divergent_fields: divergentFields,
-    ...(humanActionHeld !== null ? { human_action_held: humanActionHeld, instrument_suspect: instrumentSuspect } : {}),
+    // Retained for observability — it explains WHY depth is low, and is no longer arithmetic input.
+    ...(humanActionHeld !== null ? { human_action_held: humanActionHeld } : {}),
   };
 }
 

--- a/scripts/adam-self-assessment-writer.cjs
+++ b/scripts/adam-self-assessment-writer.cjs
@@ -60,10 +60,21 @@ async function gatherSignals(sb) {
     }
   };
 
-  // D1: belt depth = unclaimed workable (draft) SDs
-  signals.belt_depth = await safeCount(() =>
-    sb.from('strategic_directives_v2').select('id', { count: 'exact', head: true }).eq('status', 'draft').is('claiming_session_id', null)
-  );
+  // D1: belt depth = unclaimed CLAIMABLE (draft) SDs.
+  // QF-20260725-089: this counted raw draft_unclaimed rows, so D1_proactive_sourcing scored 5/5 on
+  // belt_depth=8 at the exact moment the belt held 0 claimable work (7 human-action-held + a test
+  // fixture) — rewarding a full belt while it was empty, and making D1's own "belt starved while
+  // backlog rich" red-flag unobservable. Now routed through the shared eligibility-gated gauge,
+  // the SAME one the coordinator-health audit uses, so the two surfaces cannot drift apart again.
+  signals.belt_depth = await (async () => {
+    try {
+      const { countDispatchableBacklog } = require('../lib/fleet/belt-depth.cjs');
+      const { dispatchable } = await countDispatchableBacklog(sb);
+      return dispatchable;
+    } catch {
+      return null; // same fail-soft contract as safeCount: unmeasurable, never a silent 0
+    }
+  })();
 
   // D2: Adam-role sessions holding a non-null sd_key (should be 0 — Adam never claims).
   // NOTE: claude_sessions has no `callsign` column (role lives only in metadata.role) — this

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -171,10 +171,15 @@ describe('computePlanAdherence (TS-2)', () => {
 
 describe('computeFailLoudIntegrity (TS-3)', () => {
   it('fails loud (never null-coalesces to 0) on a query error in the recompute path', async () => {
-    const supabase = { from: () => ({ select: () => ({ eq: () => ({ is: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) };
+    // QF-20260725-089: the recompute now range-paginates (eligibility needs the rows, not a
+    // head-count), so the stub chain gains .range() — the seeded error must still surface verbatim.
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ is: () => ({ range: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) }) };
     const result = await computeFailLoudIntegrity(supabase, {});
     expect(result.integrity_ok).toBe(false);
-    expect(result.error).toBe('boom');
+    // The paginator wraps the cause with which page failed; assert the contract (the underlying
+    // error surfaces, never a silent 0) rather than an exact string the wrapper legitimately enriches.
+    expect(result.error).toContain('boom');
+    expect(result.divergent_fields).toEqual(['dispatchable_count']);
   });
 
   it('fails loud on an error from the self-reported (computeClaimableLeaves) source, never coalescing to 0', async () => {
@@ -192,9 +197,28 @@ describe('computeFailLoudIntegrity (TS-3)', () => {
     expect(result.divergent_fields).toEqual(['dispatchable_count']);
   });
 
-  it('does NOT flag a self-reported UNDER-count as a violation (ranker narrowing the raw set is healthy, not a divergence)', async () => {
-    const supabase = makeFakeSupabase({ strategic_directives_v2: [{ id: '1', status: 'draft', claiming_session_id: null }, { id: '2', status: 'draft', claiming_session_id: null }] });
+  // QF-20260725-089: this previously asserted an UNDER-count was healthy ("the ranker narrows the
+  // raw set"), which was true only while recomputed was the RAW draft_unclaimed count. recomputed
+  // now runs through the same eligibility gate as self_reported, so both measure the identical
+  // quantity and an under-count is a genuine divergence. This exact tolerance is how the live
+  // 8-vs-0 slipped through with integrity_ok=true and divergent_fields=[].
+  it('REGRESSION: flags a self-reported UNDER-count — both sides are eligibility-gated, so any disagreement is real', async () => {
+    // Two rows with no hold metadata => both eligible => recomputed=2 vs self_reported=0.
+    const supabase = makeFakeSupabase({ strategic_directives_v2: [{ id: '1', sd_key: 'SD-1', status: 'draft', claiming_session_id: null }, { id: '2', sd_key: 'SD-2', status: 'draft', claiming_session_id: null }] });
     const result = await computeFailLoudIntegrity(supabase, { selfReportedCounts: { dispatchable_count: 0 } });
+    expect(result.integrity_ok).toBe(false);
+    expect(result.divergent_fields).toEqual(['dispatchable_count']);
+  });
+
+  // QF-20260725-089: the live shape — held rows must not be counted as available work at all.
+  it('REGRESSION: human-action-HELD rows are excluded from recomputed, so a fully-held belt reads 0 and agrees with a 0 self-report', async () => {
+    const rows = Array.from({ length: 7 }, (_, i) => ({
+      id: `${i}`, sd_key: `SD-HELD-${i}`, status: 'draft', claiming_session_id: null,
+      metadata: { requires_human_action: true },
+    }));
+    const supabase = makeFakeSupabase({ strategic_directives_v2: rows });
+    const result = await computeFailLoudIntegrity(supabase, { selfReportedCounts: { dispatchable_count: 0 } });
+    expect(result.recomputed.dispatchable_count).toBe(0); // was 7 — the raw count that fired IDLE_WITH_BACKLOG
     expect(result.integrity_ok).toBe(true);
   });
 
@@ -216,32 +240,29 @@ describe('computeFailLoudIntegrity (TS-3)', () => {
     expect(result.integrity_ok).toBe(true);
   });
 
-  // QF-20260720-161
-  it('does NOT flag instrument_suspect when a wide self-reported/recomputed gap is explained by human-action holds (live-verified: 3 vs 20, 11 held)', async () => {
-    const rows = Array.from({ length: 20 }, (_, i) => ({ id: `${i}`, status: 'draft', claiming_session_id: null }));
-    const supabase = makeFakeSupabase({ strategic_directives_v2: rows });
+  // QF-20260720-161's instrument_suspect heuristic (a >50%-unexplained-gap proxy) is RETIRED by
+  // QF-20260725-089: it existed only because recomputed was raw and self_reported was narrowed, so
+  // the two could legitimately differ and only a *large unexplained* gap was suspicious. With both
+  // sides gated, exact equality is strictly stronger and subsumes it. The 3-vs-20-with-11-held
+  // scenario it was built around can no longer arise: those 11 holds are now excluded from
+  // recomputed rather than being tolerated inside a gap. human_action_held is still reported for
+  // observability — it explains WHY depth is low — but is no longer arithmetic input.
+  it('still surfaces human_action_held for observability, with held rows excluded from the count', async () => {
+    const held = Array.from({ length: 11 }, (_, i) => ({
+      id: `h${i}`, sd_key: `SD-HELD-${i}`, status: 'draft', claiming_session_id: null,
+      metadata: { requires_human_action: true },
+    }));
+    const free = Array.from({ length: 3 }, (_, i) => ({ id: `f${i}`, sd_key: `SD-${i}`, status: 'draft', claiming_session_id: null }));
+    const supabase = makeFakeSupabase({ strategic_directives_v2: [...held, ...free] });
     const claimableLeavesFn = vi.fn().mockResolvedValue({
       claimable: Array.from({ length: 3 }, (_, i) => ({ sd_key: `SD-${i}`, status: 'draft' })),
-      humanActionHolds: Array.from({ length: 11 }, (_, i) => ({ sd_key: `SD-HELD-${i}`, provenance: null })),
+      humanActionHolds: held.map((h) => ({ sd_key: h.sd_key, provenance: null })),
     });
     const result = await computeFailLoudIntegrity(supabase, { claimableLeavesFn });
+    expect(result.recomputed.dispatchable_count).toBe(3); // 14 raw - 11 held
     expect(result.human_action_held).toBe(11);
-    expect(result.instrument_suspect).toBe(false);
-    expect(result.integrity_ok).toBe(true);
-  });
-
-  it('flags instrument_suspect when the gap is NOT substantially explained by known human-action holds', async () => {
-    const rows = Array.from({ length: 20 }, (_, i) => ({ id: `${i}`, status: 'draft', claiming_session_id: null }));
-    const supabase = makeFakeSupabase({ strategic_directives_v2: rows });
-    const claimableLeavesFn = vi.fn().mockResolvedValue({
-      claimable: [{ sd_key: 'SD-0', status: 'draft' }],
-      humanActionHolds: [{ sd_key: 'SD-HELD-0', provenance: null }],
-    });
-    const result = await computeFailLoudIntegrity(supabase, { claimableLeavesFn });
-    expect(result.human_action_held).toBe(1);
-    expect(result.instrument_suspect).toBe(true);
-    expect(result.integrity_ok).toBe(false);
-    expect(result.divergent_fields).toContain('dispatchable_count_unexplained_gap');
+    expect(result.integrity_ok).toBe(true); // 3 === 3, genuine agreement rather than a tolerated gap
+    expect(result.instrument_suspect).toBeUndefined(); // retired
   });
 });
 

--- a/tests/unit/fleet/belt-depth.test.js
+++ b/tests/unit/fleet/belt-depth.test.js
@@ -1,0 +1,71 @@
+/**
+ * QF-20260725-089 — belt-depth gauge must exclude HELD rows before emitting a count.
+ *
+ * Measured live 2026-07-25: the gauge reported depth 8 while true claimable depth was 0 (7x
+ * human_action_required plus an orchestrator parent / deferred / fenced / test-fixture row). That
+ * one ungated number fired IDLE_WITH_BACKLOG against the coordinator AND scored Adam D1 5/5 for a
+ * full belt — wrong in opposite directions off the same read.
+ *
+ * Seam-injected fake client only — no live DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { countDispatchableBacklog } = require('../../../lib/fleet/belt-depth.cjs');
+
+/** Minimal builder covering exactly the chain the gauge uses, including .range() pagination. */
+function fakeClient(rows) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          is: () => ({
+            range: (from, to) => Promise.resolve({ data: rows.slice(from, to + 1), error: null }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+const free = (i) => ({ id: `f${i}`, sd_key: `SD-FREE-${i}`, status: 'draft', metadata: {} });
+
+describe('countDispatchableBacklog', () => {
+  it('REGRESSION: a fully human-action-held belt reads 0, not the raw row count', async () => {
+    const rows = Array.from({ length: 7 }, (_, i) => ({
+      id: `${i}`, sd_key: `SD-HELD-${i}`, status: 'draft', metadata: { requires_human_action: true },
+    }));
+    const result = await countDispatchableBacklog(fakeClient(rows));
+    expect(result.dispatchable).toBe(0);
+    expect(result.raw).toBe(7); // the number the old gauge emitted as "dispatchable"
+    expect(result.ineligible.human_action_required).toBe(7);
+  });
+
+  it('excludes orchestrator parents and test fixtures — never worker-claimable by charter', async () => {
+    const rows = [
+      { id: '1', sd_key: 'SD-PARENT', status: 'draft', sd_type: 'orchestrator', metadata: {} },
+      { id: '2', sd_key: 'SD-TEST-FIXTURE-001', status: 'draft', metadata: {} },
+      free(3),
+    ];
+    const result = await countDispatchableBacklog(fakeClient(rows));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible.orchestrator_parent).toBe(1);
+  });
+
+  it('counts genuinely claimable rows', async () => {
+    const result = await countDispatchableBacklog(fakeClient([free(1), free(2), free(3)]));
+    expect(result).toMatchObject({ dispatchable: 3, raw: 3 });
+    expect(result.ineligible).toEqual({});
+  });
+
+  it('reports an empty belt as 0 without inventing depth', async () => {
+    expect(await countDispatchableBacklog(fakeClient([]))).toMatchObject({ dispatchable: 0, raw: 0 });
+  });
+
+  it('paginates past the PostgREST cap instead of under-reporting depth', async () => {
+    // 1200 eligible rows: a single capped page would have reported 1000.
+    const rows = Array.from({ length: 1200 }, (_, i) => free(i));
+    const result = await countDispatchableBacklog(fakeClient(rows));
+    expect(result.dispatchable).toBe(1200);
+  });
+});


### PR DESCRIPTION
## Problem

One ungated count fed two governance surfaces and was wrong on both, **in opposite directions**.

Measured 2026-07-25: belt/backlog depth reported **8** by counting `draft_unclaimed` rows *without* running `classifyDispatchIneligibility`. True claimable depth was **0** — 7× `human_action_required` plus a test fixture.

| Consumer | Harm |
|---|---|
| `adam-coordinator-health.mjs` KPI-1 | Emitted `dispatchable_backlog_size=8` against `idle=5` and fired **IDLE_WITH_BACKLOG** — recording a dispatch gap against the **coordinator**, when the real condition is supply starvation owned by **Adam** |
| `adam-self-assessment-writer.cjs` | Scored Adam **D1_proactive_sourcing 5/5** on `belt_depth=8` — rewarding a full belt at the exact moment it was empty, making D1's own *"belt starved while backlog rich"* red-flag unobservable |

The audit even showed the tell in its own output: `recomputed=8` vs `self_reported=0` with `human_action_held=7`, yet `integrity_ok=true` and `divergent_fields=[]`.

## Fix

**`lib/fleet/belt-depth.cjs`** computes depth **once**, through the same `classifyDispatchIneligibility` gate the dispatcher uses. Deliberately a shared module, not a filter in each caller — per-consumer filtering is *precisely* how the two surfaces drifted apart. The prior head-count existed to dodge the 1000-row cap; eligibility needs the rows, so `fetchAllPaginated` preserves that protection by paginating past it (covered by a test).

**Integrity check**: any `recomputed` ≠ `self_reported` is now a divergence. The old rule flagged only `self_reported > recomputed`, justified by a *"healthy narrowing invariant"* that held **only while recomputed was the RAW count**. Both sides are now gated and measure the identical quantity, so the asymmetry is obsolete — and it's exactly how 8-vs-0 passed: it never tripped the one-directional check, and the unexplained-gap heuristic computed `8-0-7=1` (12.5%, under its 50% threshold). Exact equality is strictly stronger and subsumes that heuristic, so `instrument_suspect` retires with it; `human_action_held` stays for observability.

## Verified against the live belt

```
dispatchable = 0   ← what the gauge now emits
raw          = 8   ← what it emitted before
ineligible   = {"human_action_required":7,"test_fixture_key":1}
```

This matches all three independent witnesses: Adam's metadata inspection, the coordinator's classifier sweep across non-terminal SDs, and **this worker's own `/checkin`** returning `belt_ranked_claimable=8` with `belt_claimable_at_my_tier=0` continuously for ~2.5h.

## Testing

**111 suites / 1277 tests green.** New `tests/unit/fleet/belt-depth.test.js` (5 cases: fully-held belt reads 0, orchestrator-parent/fixture exclusion, cap pagination). Three tests in `adam-coordinator-health.test.js` encoded the old semantics and were rewritten — including one that asserted an under-count was *healthy*, a premise that dies with the shared gate. One fake-client stub gained `.range()` so the fail-loud path is genuinely exercised rather than short-circuiting.

## Scope

20 new code lines plus small consumer edits — inside the Tier-2 cap. `renderCount` import dropped (both head-count gauges it guarded are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
