### PR TITLE
fix(QF-20260725-450): Chairman decision queue flooded: framing_escalation auto-creates a pending chairman decision per flagged inter-role advisory (114 pending, ~1 per 15min), and the CLI renders them as critical Stage 0 Chairman Approval

### DIFF
--- a/database/migrations/20260725_chairman_queue_truthful_render_PROPOSED.sql
+++ b/database/migrations/20260725_chairman_queue_truthful_render_PROPOSED.sql
@@ -1,0 +1,47 @@
+-- QF-20260725-450 (part 3 of 3) — PROPOSED, NOT APPLIED. Requires chairman/coordinator
+-- approval before apply; stamp @approved-by and drop the _PROPOSED suffix at that point.
+--
+-- DEFECT (gauge-vs-reality): chairman_unified_decisions Source 4 hardcodes
+--   'chairman_approval'::text AS decision_type
+--   concat('Stage ', cd.lifecycle_stage, ' Chairman Approval') AS title
+--   'critical'::text AS priority
+-- for EVERY chairman_decisions row, discarding cd.decision_type and cd.blocking. So a
+-- non-blocking framing flag rendered to an operator as a "[critical] Stage 0 Chairman
+-- Approval" gate. Measured 2026-07-25: 114 such rows. The renderer
+-- (scripts/chairman-decisions.mjs) was NOT at fault — it faithfully prints what this view
+-- hands it. QF-20260725-450 parts 1+2 stopped the flood and cancelled the backlog; this
+-- part closes the latent display path so the next misrouted decision_type cannot repeat it.
+--
+-- WHY decision_type STAYS 'chairman_approval': it is the ROUTING KEY, not a label —
+-- lib/chairman/decision-queue.mjs::routeDecision switches on it to pick the
+-- fn_chairman_decide RPC (case 'chairman_approval'). Emitting the raw cd.decision_type
+-- here would make every such row hit "unknown decision_type" and become UNDECIDABLE.
+-- So the routing key is preserved and the DISPLAY is made truthful instead:
+--   * priority follows blocking (critical only when the row actually blocks)
+--   * title carries the real subtype instead of a synthesized approval-gate string
+-- Age escalation in chairman_pending_decisions is unchanged (visibility only).
+--
+-- APPLY: replace ONLY the Source 4 branch of chairman_unified_decisions from
+-- database/migrations/20260611_chairman_decision_queue.sql, preserving every other
+-- branch verbatim and the WITH (security_invoker = on) option. Rollback = re-run
+-- 20260611_chairman_decision_queue.sql.
+--
+-- Source 4 branch, corrected (splice into the CREATE OR REPLACE VIEW):
+--
+--   SELECT cd.id,
+--     'chairman_approval'::text AS decision_type,          -- routing key, unchanged
+--     CASE
+--       WHEN COALESCE(cd.decision_type, 'chairman_approval') = 'chairman_approval'
+--         THEN concat('Stage ', cd.lifecycle_stage, ' Chairman Approval')
+--       ELSE concat(cd.decision_type, ': ', COALESCE(left(cd.summary, 120), '(no summary)'))
+--     END AS title,
+--     CASE WHEN COALESCE(cd.blocking, false) THEN 'critical'::text
+--          ELSE 'medium'::text END AS priority,
+--     ... (all remaining columns exactly as in 20260611) ...
+--
+-- VERIFY after apply:
+--   1. node scripts/chairman-decisions.mjs list  -> no non-blocking row labelled critical
+--   2. decide still routes: node scripts/chairman-decisions.mjs decide chairman_approval:<id> defer --rationale "wire check"
+--   3. SELECT count(*) FROM chairman_pending_decisions;  -- matches pending chairman_decisions
+
+-- (intentionally no executable DDL — approval-gated)

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -522,45 +522,58 @@ async function renderChairmanDirectives(supabase, role, { quiet = false } = {}) 
  * acknowledged_at IS NULL tier) until Adam genuinely acts.
  */
 /**
- * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (FR-2/FR-3): record a chairman-escalation
- * pending decision for a pick/unproven oracle framing. Idempotent per advisory row id
- * (probe-before-insert on brief_data->context->>advisory_row_id; drainInbox is
- * single-process so retries serialize). Returns true iff the row is durably queued
- * (pre-existing counts). NEVER throws — fail-soft for drain liveness, loud on failure.
+ * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C (FR-2/FR-3): record a pick/unproven oracle
+ * framing flag. Idempotent per advisory row id. Returns true iff the row is durably
+ * recorded. NEVER throws — fail-soft for drain liveness, loud on failure.
+ *
+ * QF-20260725-450: DESTINATION CORRECTED. This previously wrote a pending row into
+ * chairman_decisions, which flooded the chairman decision queue at ~1 row per 15-min
+ * sweep tick (114 pending, 28h of ticks, none chairman-actionable) with verbatim
+ * excerpts of inter-role engineering correspondence. Framing quality on an inter-role
+ * message is an adherence/comms-quality signal, NOT a decision the chairman can make.
+ * It now lands in the comms-quality feedback lane. The detector is unchanged — only
+ * the destination was wrong.
  */
 async function recordFramingEscalation(supabase, r, routed) {
   try {
+    // Permanent (not per-day) idempotency per advisory row. emitFeedback's own dedup
+    // hash embeds today's date, so a row re-drained tomorrow would flag again; this
+    // probe preserves the original write-once-per-advisory contract.
     const { data: existing } = await supabase
-      .from('chairman_decisions')
+      .from('feedback')
       .select('id')
-      .eq('brief_data->context->>advisory_row_id', String(r.id))
+      .eq('category', 'comms_quality')
+      .eq('metadata->>advisory_row_id', String(r.id))
       .limit(1);
-    if (existing && existing.length > 0) return true; // already queued (idempotent)
+    if (existing && existing.length > 0) return true;
     const body = (r.payload && r.payload.body) || r.body || r.subject || '';
-    const { recordPendingDecision } = await import('../lib/chairman/record-pending-decision.mjs');
-    const res = await recordPendingDecision(supabase, {
-      title: `Framing escalation (${routed.reason}): ${String(body).slice(0, 120) || '(no body)'}`,
-      // RISK condition (a): blocking:false + non-session_question decisionType makes
-      // shouldAutoEscalate() provably false — queue-only, zero per-row standout email/SMS.
-      decisionType: 'framing_escalation',
-      blocking: false,
-      raisedBy: 'adam',
-      context: {
+    const { emitFeedback } = await import('../lib/governance/emit-feedback.js');
+    const res = await emitFeedback({
+      supabase,
+      title: `Framing flag (${routed.reason}): ${String(body).slice(0, 90) || '(no body)'}`,
+      description: `Inter-role advisory flagged as ${(r.payload && r.payload.framing_class) || 'unproven'} framing `
+        + `(reason: ${routed.reason}, lane analog: ${routed.laneAnalog}).\n\nExcerpt:\n${String(body).slice(0, 400)}`,
+      type: 'issue',
+      category: 'comms_quality',
+      severity: 'low',
+      // Idempotent per advisory row: dedup_key joins the emitter's dedup_hash so a
+      // re-drain of the same row cannot create a second flag.
+      dedup_key: `framing:${String(r.id)}`,
+      metadata: {
         advisory_row_id: String(r.id),
         framing_class: (r.payload && r.payload.framing_class) || 'unproven',
         reason: routed.reason,
         lane_analog: routed.laneAnalog,
         sender_session: r.sender_session || null,
-        excerpt: String(body).slice(0, 400),
       },
     });
-    if (!res || res.recorded !== true) {
-      console.error(`  ✖ ESCALATION WRITE FAILED (id=${r.id}): ${(res && res.error) || 'unknown'}`);
+    if (!res || (!res.id && !res.deduped)) {
+      console.error(`  ✖ FRAMING FLAG WRITE FAILED (id=${r.id}): ${(res && res.error) || 'unknown'}`);
       return false;
     }
     return true;
   } catch (e) {
-    console.error(`  ✖ ESCALATION WRITE FAILED (id=${r.id}): ${(e && e.message) || e}`);
+    console.error(`  ✖ FRAMING FLAG WRITE FAILED (id=${r.id}): ${(e && e.message) || e}`);
     return false;
   }
 }

--- a/scripts/one-off/qf-20260725-450-resolve-framing-escalations.mjs
+++ b/scripts/one-off/qf-20260725-450-resolve-framing-escalations.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * QF-20260725-450 backfill: clear misrouted framing_escalation rows out of the
+ * chairman decision queue.
+ *
+ * WHY: scripts/adam-advisory.cjs::recordFramingEscalation wrote one pending
+ * chairman_decisions row per flagged inter-role advisory (~1 per 15-min sweep
+ * tick, 114 accumulated ≈ 28h of ticks). None are chairman-actionable — they are
+ * comms-quality flags carrying verbatim excerpts of inter-role engineering
+ * correspondence. The writer is fixed to emit feedback(category='comms_quality');
+ * this clears the rows already queued.
+ *
+ * CONSTITUTIONAL: this does NOT decide anything. These rows were never chairman
+ * questions, so they are marked 'cancelled' (an existing status) with a rationale —
+ * never 'approved'/'rejected', which would assert a decision the chairman never made.
+ * `decision` is left untouched.
+ *
+ * Dry-run by default. Pass --apply to write.
+ *   node scripts/one-off/qf-20260725-450-resolve-framing-escalations.mjs [--apply]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const db = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const { data: rows, error } = await db
+  .from('chairman_decisions')
+  .select('id, created_at')
+  .eq('status', 'pending')
+  .eq('decision_type', 'framing_escalation');
+
+if (error) {
+  console.error('QUERY FAILED: ' + error.message);
+  process.exit(1);
+}
+
+console.log(`pending framing_escalation rows: ${rows.length}`);
+if (rows.length === 0) {
+  console.log('nothing to do.');
+  process.exit(0);
+}
+console.log(`oldest: ${rows.map((r) => r.created_at).sort()[0]}`);
+
+if (!APPLY) {
+  console.log('DRY RUN — re-run with --apply to cancel these rows.');
+  process.exit(0);
+}
+
+// Scoped UPDATE: the same two predicates that selected the rows, so a row that
+// changed decision_type/status between select and update is not swept up.
+const { data: updated, error: upErr } = await db
+  .from('chairman_decisions')
+  .update({
+    status: 'cancelled',
+    rationale: 'QF-20260725-450: misrouted comms-quality flag — never a chairman decision. '
+      + 'Framing flags now land in feedback(category=comms_quality).',
+    updated_at: new Date().toISOString(),
+  })
+  .eq('status', 'pending')
+  .eq('decision_type', 'framing_escalation')
+  .select('id');
+
+if (upErr) {
+  console.error('UPDATE FAILED: ' + upErr.message);
+  process.exit(1);
+}
+console.log(`cancelled ${updated.length} rows.`);

--- a/tests/unit/adam-advisory-framing-class.test.js
+++ b/tests/unit/adam-advisory-framing-class.test.js
@@ -2,22 +2,28 @@
  * SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C — fail-closed pick-vs-instrument ROUTING in
  * drainInbox (supersedes sibling -B's interim PICK-CLASS warn, whose assertions this file
  * previously pinned: routing is now REAL, so the warn is replaced by routed behavior).
- * pick/unproven oracle framings -> chairman-escalation queue via recordPendingDecision with
- * provably non-auto-escalating params; instrument -> renders sourcing-eligible; non-oracle
- * advisories untouched. -B's framing:<value> rendering tag is retained.
+ * pick/unproven oracle framings are FLAGGED; instrument -> renders sourcing-eligible;
+ * non-oracle advisories untouched. -B's framing:<value> rendering tag is retained.
+ *
+ * QF-20260725-450: DESTINATION CORRECTED. These assertions previously pinned a write into
+ * chairman_decisions, which is what flooded the chairman decision queue (114 pending
+ * non-actionable rows). Framing quality is an adherence/comms-quality signal, so the flag
+ * now lands in feedback(category='comms_quality'). The ROUTING DECISION is unchanged and
+ * still pinned below — only the destination table moved.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const m = require('../../scripts/adam-advisory.cjs');
-import { shouldAutoEscalate } from '../../lib/chairman/record-pending-decision.mjs';
 
 /**
  * Table-aware supabase mock: session_coordination selects return `inboxRows`;
- * chairman_decisions selects return `decisionProbeRows` (idempotency probe), inserts are
- * recorded (and fail when failDecisionInsert), updates recorded per-table.
+ * feedback selects return `flagProbeRows` (idempotency probe), inserts are
+ * recorded (and fail when failFlagInsert). chairman_decisions writes are recorded
+ * separately so the test can assert the chairman queue is NEVER touched.
  */
-function makeTableMock({ inboxRows = [], decisionProbeRows = [], failDecisionInsert = false } = {}) {
+function makeTableMock({ inboxRows = [], flagProbeRows = [], failFlagInsert = false } = {}) {
+  const flagInserts = [];
   const decisionInserts = [];
   const decisionUpdates = [];
   function chain(table) {
@@ -32,14 +38,18 @@ function makeTableMock({ inboxRows = [], decisionProbeRows = [], failDecisionIns
       then: (res, rej) => finish().then(res, rej),
     };
     async function finish() {
-      if (table === 'chairman_decisions') {
+      if (table === 'feedback') {
         if (state.op === 'insert') {
-          if (failDecisionInsert) return { data: null, error: { message: 'boom' } };
-          decisionInserts.push(state.payload);
-          return { data: [{ id: `dec-${decisionInserts.length}` }], error: null };
+          if (failFlagInsert) return { data: null, error: { message: 'boom' } };
+          flagInserts.push(state.payload);
+          return { data: [{ id: `fb-${flagInserts.length}` }], error: null };
         }
+        return { data: flagProbeRows, error: null };
+      }
+      if (table === 'chairman_decisions') {
+        if (state.op === 'insert') { decisionInserts.push(state.payload); return { data: [{ id: 'dec-x' }], error: null }; }
         if (state.op === 'update') { decisionUpdates.push(state.payload); return { data: [], error: null }; }
-        return { data: decisionProbeRows, error: null };
+        return { data: [], error: null };
       }
       // SD-LEO-INFRA-DRAIN-SET-REGISTRY-001-C (Child B): drainInbox now also queries
       // role_drain_sets via the registry-reader — route it as PGRST205-style table-not-found
@@ -51,7 +61,7 @@ function makeTableMock({ inboxRows = [], decisionProbeRows = [], failDecisionIns
     }
     return c;
   }
-  return { supabase: { from: chain }, decisionInserts, decisionUpdates };
+  return { supabase: { from: chain }, flagInserts, decisionInserts, decisionUpdates };
 }
 
 const oracleRow = (id, framing, body = 'systemic finding') => ({
@@ -70,82 +80,81 @@ async function drainWith(mock) {
 }
 
 describe('SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C: fail-closed routing in drainInbox', () => {
-  it('TS-1: pick row -> one pending decision + routing:chairman-escalation (framing tag retained)', async () => {
+  it('TS-1: pick row -> one comms-quality flag + routing:chairman-escalation (framing tag retained)', async () => {
     const mock = makeTableMock({ inboxRows: [oracleRow('p1', 'pick')] });
     const { logs } = await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(1);
+    expect(mock.flagInserts).toHaveLength(1);
     expect(logs).toMatch(/framing:pick/);
     expect(logs).toMatch(/routing:chairman-escalation/);
   });
 
-  it('TS-2: instrument row -> zero decision writes + routing:adam-sourcing', async () => {
+  it('TS-2: instrument row -> zero flag writes + routing:adam-sourcing', async () => {
     const mock = makeTableMock({ inboxRows: [oracleRow('i1', 'instrument')] });
     const { logs } = await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(0);
+    expect(mock.flagInserts).toHaveLength(0);
     expect(logs).toMatch(/framing:instrument/);
     expect(logs).toMatch(/routing:adam-sourcing/);
   });
 
-  it('TS-3/TS-7: unproven (missing or garbage framing_class) oracle rows escalate fail-closed', async () => {
+  it('TS-3/TS-7: unproven (missing or garbage framing_class) oracle rows flag fail-closed', async () => {
     const mock = makeTableMock({ inboxRows: [oracleRow('u1', null), oracleRow('u2', 'garbage')] });
     const { logs } = await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(2);
+    expect(mock.flagInserts).toHaveLength(2);
     expect(logs.match(/routing:chairman-escalation/g)).toHaveLength(2);
     expect(logs).not.toMatch(/routing:adam-sourcing/);
   });
 
-  it('TS-4: non-oracle advisory rows render with no routing/framing tags and no escalation', async () => {
+  it('TS-4: non-oracle advisory rows render with no routing/framing tags and no flag', async () => {
     const mock = makeTableMock({
       inboxRows: [{ id: 'n1', created_at: new Date().toISOString(), payload: { kind: 'adam_advisory', body: 'plain advisory' } }],
     });
     const { logs } = await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(0);
+    expect(mock.flagInserts).toHaveLength(0);
     expect(logs).not.toMatch(/framing:/);
     expect(logs).not.toMatch(/routing:/);
   });
 
-  it('TS-5: re-drain of an already-queued row is idempotent (probe hit -> no duplicate insert)', async () => {
+  it('TS-5: re-drain of an already-flagged row is idempotent (probe hit -> no duplicate insert)', async () => {
     const mock = makeTableMock({
       inboxRows: [oracleRow('p2', 'pick')],
-      decisionProbeRows: [{ id: 'dec-existing' }],
+      flagProbeRows: [{ id: 'fb-existing' }],
     });
     const { logs } = await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(0); // probe found existing -> skip
+    expect(mock.flagInserts).toHaveLength(0); // probe found existing -> skip
     expect(logs).toMatch(/routing:chairman-escalation/); // still rendered as routed
   });
 
-  it('TS-6: decision-write failure is loud, drain continues, row not rendered as routed', async () => {
-    const mock = makeTableMock({ inboxRows: [oracleRow('p3', 'pick'), oracleRow('i2', 'instrument')], failDecisionInsert: true });
+  it('TS-6: flag-write failure is loud, drain continues, row not rendered as routed', async () => {
+    const mock = makeTableMock({ inboxRows: [oracleRow('p3', 'pick'), oracleRow('i2', 'instrument')], failFlagInsert: true });
     const { logs, errs } = await drainWith(mock);
-    expect(errs).toMatch(/ESCALATION WRITE FAILED/);
+    expect(errs).toMatch(/FRAMING FLAG WRITE FAILED/);
     expect(logs).toMatch(/routing:escalation-write-failed/);
     expect(logs).toMatch(/routing:adam-sourcing/); // drain continued to the next row
   });
 
-  it('TS-8: legacy-backlog drain (5 pick/unproven rows) fires ZERO standout escalations', async () => {
+  it('QF-20260725-450: framing flags NEVER write to the chairman decision queue', async () => {
     const mock = makeTableMock({
       inboxRows: [oracleRow('b1', 'pick'), oracleRow('b2', null), oracleRow('b3', 'pick'), oracleRow('b4', null), oracleRow('b5', 'garbage')],
     });
     await drainWith(mock);
-    expect(mock.decisionInserts).toHaveLength(5); // all queued...
-    for (const row of mock.decisionInserts) {
-      // ...with provably non-auto-escalating params (RISK conditions a+b):
-      expect(row.blocking).toBe(false);
-      expect(row.decision_type).toBe('framing_escalation');
-      expect(shouldAutoEscalate({ decisionType: row.decision_type, blocking: row.blocking, raisedBy: row.brief_data && row.brief_data.raised_by })).toBe(false);
-    }
-    // and zero escalation-path updates on chairman_decisions (no CAS/email-marker write):
+    expect(mock.flagInserts).toHaveLength(5); // all flagged...
+    // ...and the chairman queue is untouched — this is the regression that flooded it
+    // with 114 non-actionable pending rows at ~1 per 15-min sweep tick.
+    expect(mock.decisionInserts).toHaveLength(0);
     expect(mock.decisionUpdates).toHaveLength(0);
+    for (const row of mock.flagInserts) {
+      expect(row.category).toBe('comms_quality');
+      expect(row.severity).toBe('low');
+    }
   });
 
-  it('FR-3: pending-decision brief_data carries the framing context', async () => {
+  it('FR-3: the comms-quality flag carries the framing context', async () => {
     const mock = makeTableMock({ inboxRows: [oracleRow('c1', 'pick', 'portfolio kill/scale reversal')] });
     await drainWith(mock);
-    const ctx = mock.decisionInserts[0].brief_data.context;
-    expect(ctx.advisory_row_id).toBe('c1');
-    expect(ctx.framing_class).toBe('pick');
-    expect(ctx.lane_analog).toBe('chairman-gated');
-    expect(ctx.excerpt).toMatch(/portfolio kill\/scale reversal/);
-    expect(mock.decisionInserts[0].status).toBe('pending'); // records, never decides
+    const row = mock.flagInserts[0];
+    expect(row.metadata.advisory_row_id).toBe('c1');
+    expect(row.metadata.framing_class).toBe('pick');
+    expect(row.metadata.lane_analog).toBe('chairman-gated');
+    expect(row.description).toMatch(/portfolio kill\/scale reversal/);
   });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260725-450

**Type:** bug
**Severity:** high

### Issue Description
The chairman decision queue is 120 pending, of which 114 are decision_type=framing_escalation, and NONE are chairman-actionable. MEASURED 2026-07-25T05:20Z. WHAT THEY ACTUALLY ARE: rows auto-created when an inter-role coordination message is flagged with reason=unproven framing. brief_data.context.excerpt holds a verbatim slice of the advisory body. The three most recent were stamped 05:14:11, 04:59:14, 04:44:12 — EXACTLY 15 minutes apart, i.e. one per sweep tick with nothing consuming them. 114 pending is roughly 28 hours of ticks. The newest is an excerpt of a Solomon advisory about a session-liveness ladder defect: a technical exchange between Adam, Solomon and the coordinator, escalated to the CHAIRMAN as a pending decision he can neither act on nor should ever see. CATEGORY ERROR: framing quality on an inter-role message is an adherence/comms-quality signal. It belongs in an adherence lane (adam_adherence_ledger or a comms-quality feedback category), NOT in chairman_decisions. The chairman decision queue is the surface Adam drives and surfaces by SMS under the CHAIRMAN SMS CHANNEL DUTY; filling it with advisory excerpts makes the real queue unreadable and would, if any consumer surfaced them naively, text the chairman fragments of engineering correspondence. SECOND DEFECT, DISPLAY: scripts/chairman-decisions.mjs list renders these as [critical] Stage 0 Chairman Approval — because lifecycle_stage=0 is formatted as Stage 0 and the type is shown as chairman_approval. The DB rows carry blocking=false and decision_type=framing_escalation. So 114 non-blocking framing flags present to an operator as 114 CRITICAL stage-0 approval gates. That is the gauge-vs-reality class again: the render disagrees with the row and the render is the thing a human reads. THIRD, LATENT: the table carries sms_reply_token / sms_reply_token_expires_at / consequence_level columns, so a future consumer that surfaces pending decisions by SMS would target these rows. They are not populated today — flagging so the fix closes the path, not just the symptom. FIX: (1) stop routing framing_escalation into chairman_decisions; write it to the adherence/comms-quality lane instead. (2) Backfill-resolve or soft-delete the 114 existing pending framing_escalation rows so the queue reflects real chairman-pending work. (3) Correct the list renderer so decision_type and blocking are shown truthfully and non-blocking rows are not labelled critical. NOT IN SCOPE: changing what counts as unproven framing — the detector may well be right, it is the destination that is wrong.

### Steps to Reproduce
1. Run node scripts/chairman-decisions.mjs list and observe ~121 pending, most rendered as [critical] Stage 0 Chairman Approval. 2. Query chairman_decisions where status=pending and observe decision_type breakdown framing_escalation=114, session_question=4, stage_gate=1, portfolio_review=1 — zero rows whose content is a stage-0 approval. 3. Inspect any framing_escalation row and observe blocking=false, lifecycle_stage=0, and brief_data.context.excerpt containing a verbatim inter-role advisory body. 4. Compare created_at across the newest three and observe an exact 15-minute cadence.

### Expected Behavior
framing-quality flags land in an adherence/comms-quality lane; the chairman decision queue contains only decisions the chairman can actually make; and the list renderer reports decision_type and blocking truthfully rather than labelling non-blocking rows as critical stage-0 approvals.

### Actual Behavior
Every flagged inter-role advisory becomes a pending chairman decision at ~1 per 15 minutes, 114 have accumulated, and the CLI presents all of them to an operator as critical Stage 0 Chairman Approval gates.

### Changes
- **Files Changed:** 4
  - database/migrations/20260725_chairman_queue_truthful_render_PROPOSED.sql
  - scripts/adam-advisory.cjs
  - scripts/one-off/qf-20260725-450-resolve-framing-escalations.mjs
  - tests/unit/adam-advisory-framing-class.test.js
- **LOC:** 266 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol