### PR TITLE
fix(QF-20260725-738): enqueue is not delivery — chairman SMS reported sent for messages that never left

### DIFF
--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -12,10 +12,15 @@
  *      SMS. If the rubric/gate is unavailable (evaluate throws), a DECISION is FAIL-CLOSED — held
  *      + console-logged, never sent ungated.
  *   3. TRANSPORT HONESTY (QF-20260719-509, LIVE INCIDENT 2026-07-19) — sent:true is reported ONLY
- *      when the sender actually delivered/durably-enqueued the message. A soft-failed transport
+ *      when the sender actually handed the message to Twilio. A soft-failed transport
  *      (durable table absent, no recipient, etc.) reports sent:false and fires a REAL fallback
  *      (defaultFallbackSend) — this module previously reported sent:true on a soft-failed
  *      transport while claiming a fallback had fired that never existed.
+ *      QF-20260725-738 (LIVE INCIDENT 2026-07-25) NARROWED THIS: the clause above used to read
+ *      "delivered/durably-enqueued", and that OR is precisely what licensed the bug — a durable
+ *      enqueue counted as sent, so sent:true was returned for a message still at status='owed'
+ *      that had not reached Twilio. Enqueue is NOT delivery. send() now dispatches inline and
+ *      verifies the obligation reached status='sent' before any sid is returned.
  *
  * The Twilio sender, the rubric evaluate(), the console, and the fallback sender are all
  * INJECTABLE (opts) so unit tests open zero live Twilio/email connections. Production wires a
@@ -30,6 +35,20 @@ import { evaluate as defaultEvaluate, effectiveType } from '../rubric-engine/ind
  * Twilio config; a real send without a configured/injected sender fails closed (never silent).
  * @returns {{ send: (message:object) => Promise<{sid?:string}> }}
  */
+/**
+ * QF-20260725-738: did THIS obligation actually leave for Twilio? Pure, so the judgment the fix
+ * turns on is testable without a live Twilio/Supabase connection.
+ *
+ * 'sent' is the bar: the outbound worker stamps it only after Twilio accepts the message
+ * (provider_message_id set). 'delivered' (callback-only) also counts. Everything else — notably
+ * 'owed', the exact state the live incident sat in for 33 minutes — is NOT dispatched. Fail-closed
+ * on a missing/!malformed row: never report a send we cannot evidence.
+ * @param {{status?:string}|null} row an sms_outbound_obligations row
+ */
+export function obligationDispatched(row) {
+  return Boolean(row && (row.status === 'sent' || row.status === 'delivered'));
+}
+
 function makeDefaultSender() {
   return {
     // SD-LEO-INFRA-ADAM-OUTBOUND-WIRE-LIVE-001 (Part 1): the production wiring point now DELEGATES to
@@ -66,7 +85,40 @@ function makeDefaultSender() {
           decisionId: message.decisionId || null,
           dedupeKey: message.dedupeKey || null,
         });
-        return enq.enqueued ? { sid: enq.obligationId } : { sid: null, softFailed: true, reason: enq.reason || 'not_enqueued' };
+        if (!enq.enqueued) return { sid: null, softFailed: true, reason: enq.reason || 'not_enqueued' };
+
+        // QF-20260725-738 (LIVE INCIDENT 2026-07-25): enqueue is NOT delivery. This returned
+        // sid=obligationId here, so sendChairmanSMS reported sent:true for a message still sitting
+        // at status='owed'. One observed message stayed unsent for 33 minutes — surfaced only by a
+        // Twilio ground-truth check — while the chairman texted three times asking if anyone was
+        // there. An operator reading sent:true reasonably stops, which is exactly the failure mode.
+        //
+        // So DISPATCH INLINE and then VERIFY THIS obligation actually left. reconcileOutboundSms is
+        // idempotent and serialized (claim predicate `WHERE status='owed' AND claimed_at IS NULL`),
+        // so calling it here cannot double-send and cannot race the cron sweep. Verification reads
+        // the row back rather than trusting the sweep's aggregate counts — per the sweep's own
+        // header it runs FAIL-SOFT while the STAGED obligations migration is unapplied, so its
+        // counters are not authoritative for a specific message.
+        //
+        // status='sent' is the honest bar: the worker stamps it only after Twilio accepts the
+        // message (provider_message_id set). 'delivered' is callback-only and NOT required here —
+        // claiming delivery would be the same over-claim in a new place.
+        try {
+          const { reconcileOutboundSms } = await import('../../../chairman/sms-outbound-worker.js');
+          await reconcileOutboundSms(supabase, { batchLimit: 25 });
+        } catch (err) {
+          return { sid: null, softFailed: true, reason: `dispatch_error: ${err.message}` };
+        }
+        const { data: row } = await supabase
+          .from('sms_outbound_obligations')
+          .select('status, provider_message_id')
+          .eq('id', enq.obligationId)
+          .maybeSingle();
+        if (!obligationDispatched(row)) {
+          // Enqueued but still owed/failed — report the truth so the email fallback fires.
+          return { sid: null, softFailed: true, reason: `enqueued_not_dispatched: status=${row ? row.status : 'row_missing'}` };
+        }
+        return { sid: row.provider_message_id || enq.obligationId, dispatched: true };
       } catch (err) {
         // Transport fail-soft — never throw (email fallback covers delivery).
         return { sid: null, softFailed: true, reason: `durable_path_error: ${err.message}` };

--- a/tests/unit/comms/chairman-sms-enqueue-is-not-sent.test.js
+++ b/tests/unit/comms/chairman-sms-enqueue-is-not-sent.test.js
@@ -1,0 +1,69 @@
+/**
+ * QF-20260725-738 — enqueue is NOT delivery.
+ *
+ * LIVE INCIDENT 2026-07-25: adam-chairman-sms.mjs returned {"sent":true,"reason":"sent",
+ * "verdict":"pass"} at ~05:26Z for a message Twilio never received. It sat at status='owed' for 33
+ * minutes until an unrelated reconcile sweep dispatched it — surfaced only by a Twilio ground-truth
+ * check. Meanwhile the chairman texted three times asking whether Adam was still there. An operator
+ * reading sent:true reasonably concludes the chairman was reached and stops; that is the failure.
+ *
+ * The gate's contract clause used to read "delivered/durably-enqueued" — that OR is what licensed
+ * the bug. These tests pin the narrowed contract.
+ *
+ * No live Twilio/Supabase connection: pure predicate + injected sender (matching TS-7's convention
+ * in chairman-sms-gate.test.js).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { obligationDispatched, sendChairmanSMS } from '../../../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+
+describe('obligationDispatched — the honesty bar', () => {
+  it("REGRESSION: status='owed' is NOT dispatched (the exact 33-minute live-incident state)", () => {
+    expect(obligationDispatched({ status: 'owed' })).toBe(false);
+  });
+
+  it("counts 'sent' (Twilio accepted, provider_message_id stamped) and 'delivered' (callback)", () => {
+    expect(obligationDispatched({ status: 'sent', provider_message_id: 'SM123' })).toBe(true);
+    expect(obligationDispatched({ status: 'delivered' })).toBe(true);
+  });
+
+  it('does NOT count in-flight or terminal-failure states', () => {
+    for (const status of ['sending', 'failed', 'owed_escalate']) {
+      expect(obligationDispatched({ status })).toBe(false);
+    }
+  });
+
+  it('fails closed on a missing/malformed row — never claim a send we cannot evidence', () => {
+    for (const row of [null, undefined, {}, { status: null }, { status: 'SENT' }]) {
+      expect(obligationDispatched(row)).toBe(false);
+    }
+  });
+});
+
+describe('sendChairmanSMS — an enqueued-but-undispatched transport is not a send', () => {
+  // Mirrors TS-1..TS-8's convention in chairman-sms-gate.test.js: inject the sender and assert
+  // sendChairmanSMS's own honesty, independent of makeDefaultSender's internals.
+  const DAYTIME = { nowHourET: 14, rateCap: 10, sentInWindow: 0 };
+  const silentConsole = { warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+  const statusMessage = { type: 'status', body: 'Adam heartbeat: still here.', kind: 'heartbeat_status' };
+
+  it('REGRESSION: reports sent:false and FIRES the fallback when the message never left', async () => {
+    // The shape send() now returns when the obligation is still 'owed' after an inline dispatch
+    // attempt. Before QF-738 this path returned a sid (the obligationId) and the gate said sent:true.
+    const sender = { send: vi.fn(async () => ({ sid: null, softFailed: true, reason: 'enqueued_not_dispatched: status=owed' })) };
+    const fallbackSend = vi.fn(async () => ({ fired: true }));
+    const res = await sendChairmanSMS(statusMessage, DAYTIME, { sender, console: silentConsole, fallbackSend });
+    expect(res.sent).toBe(false);
+    expect(res.transportFailed).toBe(true);
+    expect(res.fallbackFired).toBe(true); // the chairman still gets reached, by email
+    expect(res.reason).toContain('enqueued_not_dispatched');
+    expect(fallbackSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports sent:true only when the transport actually handed off to Twilio', async () => {
+    const sender = { send: vi.fn(async () => ({ sid: 'SM123', dispatched: true })) };
+    const fallbackSend = vi.fn();
+    const res = await sendChairmanSMS(statusMessage, DAYTIME, { sender, console: silentConsole, fallbackSend });
+    expect(res).toMatchObject({ sent: true, reason: 'sent', authorityClass: 'sms' });
+    expect(fallbackSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

**Live incident 2026-07-25.** `adam-chairman-sms.mjs` returned `{"sent":true,"reason":"sent","verdict":"pass"}` at ~05:26Z for a message Twilio never received. It sat at `status='owed'` for **33 minutes** until an unrelated reconcile sweep dispatched it — surfaced only by a Twilio ground-truth check.

Meanwhile **the chairman texted three times overnight asking whether Adam was still there.** The channel itself was healthy; the messages that were swept delivered fine with no error codes. The gap was messages that *reported sent and never left*. An operator or agent reading `sent:true` reasonably concludes the chairman was reached and stops — which is exactly the failure mode.

## Root cause — and it was written down

The module's own TRANSPORT HONESTY clause read:

> sent:true is reported ONLY when the sender actually **delivered/durably-enqueued** the message

That `OR` is what licensed the bug. `send()` returned `{sid: enq.obligationId}` — an **obligation id, not a Twilio SID** — so a durable enqueue satisfied the contract and the gate reported `sent: true`.

## Fix

Option 1 from the QF (its preferred one): `send()` now **dispatches inline** via `reconcileOutboundSms`, then **verifies this specific obligation reached `status='sent'`** before returning any sid.

- `reconcileOutboundSms` is idempotent and serialized (claim predicate `WHERE status='owed' AND claimed_at IS NULL`), so calling it here cannot double-send and cannot race the cron sweep.
- Verification **re-reads the row** rather than trusting the sweep's aggregate counters — per that sweep's own header it runs FAIL-SOFT while the STAGED obligations migration is unapplied, so its counts aren't authoritative for a given message.
- On failure the existing email fallback fires, so the chairman is still reached.
- `status='sent'` is the honest bar (the worker stamps it only once Twilio accepts). `'delivered'` is callback-only and deliberately **not** required — demanding it would be the same over-claim relocated.

The contract doc is corrected too, since the old wording is what permitted this.

## Testing

**28 suites / 344 tests green**, including all 51 pre-existing comms tests. New `chairman-sms-enqueue-is-not-sent.test.js` (6 cases): the judgment the fix turns on is extracted as a pure exported `obligationDispatched()` so it's directly testable — `'owed'` (the exact 33-minute state) is **not** dispatched, and it fails closed on missing/malformed rows. Gate-level cases pin the end-to-end contract using the existing suite's sender-injection convention.

## Not verified by a live send — deliberately

This is an outbound path to a real person and it is ~06:00Z, **inside the chairman's 10pm–6am ET sleep window**. I verified by code-reading the enqueue/dispatch seam plus seam-injected tests with zero live Twilio/Supabase connections. **No message was sent.** Live end-to-end proof should be a deliberate daytime action by someone with authority to text the chairman, not a 2am worker verification.

Two follow-ups the QF names are **out of scope** here and still open: `TWILIO_STATUS_CALLBACK_URL` is unset (delivery callbacks disabled, so `sent` rows reconcile only via a timeout safety net), and the STAGED `sms_outbound_obligations` migration is unapplied.

19 code lines — inside the Tier-2 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
