### PR TITLE
fix(QF-20260725-697): closure probe for a stopped venture production line

### DIFF
--- a/.github/workflows/stage-line-closure-probe-cron.yml
+++ b/.github/workflows/stage-line-closure-probe-cron.yml
@@ -1,0 +1,47 @@
+name: "Stage-line closure probe (cron)"
+
+# QF-20260725-697 — the venture production line executed ZERO stages for eleven days
+# (2026-07-13 -> 2026-07-25) while eva-scheduler-watcher-cron and software-factory-poll both
+# stayed green. They monitor LIVENESS and the things they watch were alive; nothing asked
+# whether a stage RAN. This arms the closure probe so the same silence surfaces in hours.
+#
+# Armed at the same 15-minute cadence as eva-scheduler-watcher-cron; the probe is read-only
+# (one stage_executions row) and exits non-zero — a red run IS the alarm.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Did a stage actually run?
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Probe stage-line closure
+        run: node scripts/cron/stage-line-closure-probe.mjs --json

--- a/lib/eva/stage-line-closure.js
+++ b/lib/eva/stage-line-closure.js
@@ -1,0 +1,88 @@
+/**
+ * Stage-line CLOSURE health — the judgments a stopped venture production line turns on.
+ *
+ * QF-20260725-697 (LIVE INCIDENT 2026-07-25). The line executed ZERO stages for eleven days
+ * (last stage_executions row 2026-07-13T21:18Z, all succeeded) while every health signal in
+ * the chain stayed GREEN: eva-scheduler-watcher-cron reported "scheduler alive - no action",
+ * software-factory-poll green. Both were telling the truth — they monitor LIVENESS, and the
+ * things they watch were alive. Nothing asked whether a stage actually RAN.
+ *
+ * Liveness answers "is the process up". CLOSURE answers "did the work happen". This module is
+ * the second question, kept as pure predicates so the judgment is testable without a live DB
+ * or process table.
+ *
+ * The two failure modes are INDEPENDENT and each is separately actionable, so they are
+ * reported separately rather than AND-ed:
+ *   workerAbsent — the pidfile names a PID that is not running. The line CANNOT execute.
+ *                  This is the 07-13 shape: the supervisor in scripts/start-stage-worker.js
+ *                  respawns its CHILD on exit, but nothing supervises the supervisor, so once
+ *                  the supervisor process itself is gone the auto-restart is gone with it and
+ *                  a stale pidfile is all that remains. (That resolves the QF's open question:
+ *                  the watch IS running as designed — its design just cannot survive its own
+ *                  host process dying.)
+ *   lineSilent   — zero stage_executions in the window. The line DID not execute. Catches the
+ *                  worker-looks-alive-but-produces-nothing case that a PID check cannot see.
+ *
+ * DELIBERATELY NOT GATED ON PENDING-VENTURE COUNT. The obvious formulation is "alarm when zero
+ * executions AND ventures sit workflow_status=pending". It was rejected: the ventures table is
+ * roughly half unflagged test fixtures — of the 40 active+workflow_status=pending rows verified
+ * 2026-07-25, most are TS-fixture, HCGate and Pipeline-Test harness rows carrying
+ * is_demo=false, so the flag cannot separate them. Gating on that count makes the probe fire
+ * permanently (it is never zero) and so mean nothing. Silence of the execution table is the
+ * honest signal; it needs no venture classification to be correct.
+ *
+ * @module lib/eva/stage-line-closure
+ */
+
+/** Default silence tolerated before the line is called stalled. */
+export const DEFAULT_SILENT_HOURS = 6;
+
+/**
+ * Is the stage worker gone? True only when a pidfile names a PID that is NOT running — the
+ * exact stale-pidfile shape of the incident. Fail-QUIET on an unreadable/absent/malformed
+ * pidfile and on an unknown liveness result: "we cannot tell" must never be reported as
+ * "the worker is dead", or the probe cries wolf on any host that never ran the worker.
+ *
+ * @param {{pid?: number|string|null, pidAlive?: boolean|null}} input
+ *   pid — PID parsed from stage-execution-worker.pid (null/absent when there is no pidfile)
+ *   pidAlive — result of checking the live process table (null when it could not be checked)
+ * @returns {boolean}
+ */
+export function isWorkerAbsent({ pid, pidAlive } = {}) {
+  const parsed = Number.parseInt(pid, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return false;
+  if (pidAlive !== false) return false; // true = alive; null/undefined = unknown, stay quiet
+  return true;
+}
+
+/**
+ * Has the production line gone silent? Pure age comparison against the most recent
+ * stage_executions row. A NEVER-executed line (no timestamp at all) is NOT silent — a fresh
+ * deployment with an empty table is not a stopped line, and reporting it as one would make the
+ * very first green run of a new environment a false alarm.
+ *
+ * @param {{lastExecutionAt?: string|Date|null, now?: Date, silentHours?: number}} input
+ * @returns {boolean}
+ */
+export function isLineSilent({ lastExecutionAt, now = new Date(), silentHours = DEFAULT_SILENT_HOURS } = {}) {
+  if (!lastExecutionAt) return false;
+  const last = new Date(lastExecutionAt).getTime();
+  if (!Number.isFinite(last)) return false;
+  const hours = Number.isFinite(silentHours) && silentHours > 0 ? silentHours : DEFAULT_SILENT_HOURS;
+  return now.getTime() - last > hours * 3600_000;
+}
+
+/**
+ * Combine both probes into one verdict. `healthy` is false when EITHER fires, so a caller
+ * that only reads the boolean still cannot miss a stopped line.
+ *
+ * @returns {{healthy: boolean, workerAbsent: boolean, lineSilent: boolean, reasons: string[]}}
+ */
+export function classifyStageLine({ pid, pidAlive, lastExecutionAt, now, silentHours } = {}) {
+  const workerAbsent = isWorkerAbsent({ pid, pidAlive });
+  const lineSilent = isLineSilent({ lastExecutionAt, now, silentHours });
+  const reasons = [];
+  if (workerAbsent) reasons.push(`worker_absent: pidfile PID ${pid} is not running`);
+  if (lineSilent) reasons.push(`line_silent: no stage executed since ${new Date(lastExecutionAt).toISOString()}`);
+  return { healthy: !workerAbsent && !lineSilent, workerAbsent, lineSilent, reasons };
+}

--- a/scripts/cron/stage-line-closure-probe.mjs
+++ b/scripts/cron/stage-line-closure-probe.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Stage-line closure probe — asks whether a stage actually RAN. QF-20260725-697.
+ *
+ * The venture line produced nothing for eleven days behind green liveness dashboards (see
+ * lib/eva/stage-line-closure.js for the full incident + why pending-venture count is not a
+ * gate). This is the missing check. It is DB-only by design so it is correct from any host:
+ * a GitHub runner cannot see the worker host's process table, so `line_silent` — not the PID
+ * check — is the half that actually watches production from CI. The PID leg still runs and
+ * reports when a pidfile is present locally.
+ *
+ * Exit codes: 0 healthy · 1 stalled (line silent and/or worker absent) · 2 misconfigured.
+ * Usage: node scripts/cron/stage-line-closure-probe.mjs [--silent-hours N] [--json]
+ */
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { getRepoRoot } from '../../lib/repo-paths.js';
+import { classifyStageLine, DEFAULT_SILENT_HOURS } from '../../lib/eva/stage-line-closure.js';
+
+/** Read the worker pidfile; null when absent/unreadable (never throws — see isWorkerAbsent). */
+export function readWorkerPid(repoRoot, readFile = fs.readFileSync) {
+  try {
+    return Number.parseInt(String(readFile(path.join(repoRoot, 'stage-execution-worker.pid'), 'utf8')).trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+/** Is `pid` in the live process table? null = could not determine (stays quiet, never alarms). */
+export function isPidAlive(pid, kill = process.kill.bind(process)) {
+  if (!Number.isFinite(pid) || pid <= 0) return null;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ESRCH') return false;
+    return null; // EPERM: alive but not ours. Anything else: unknown.
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const hoursArg = argv.indexOf('--silent-hours');
+  const silentHours = hoursArg >= 0 ? Number(argv[hoursArg + 1]) : DEFAULT_SILENT_HOURS;
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[stage-line-probe] SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+    process.exitCode = 2;
+    return;
+  }
+
+  const { data, error } = await createClient(url, key)
+    .from('stage_executions')
+    .select('created_at')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) {
+    console.error(`[stage-line-probe] stage_executions read failed: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const repoRoot = getRepoRoot();
+  const pid = readWorkerPid(repoRoot);
+  const verdict = classifyStageLine({
+    pid,
+    pidAlive: isPidAlive(pid),
+    lastExecutionAt: data && data[0] ? data[0].created_at : null,
+    silentHours,
+  });
+
+  if (argv.includes('--json')) console.log(JSON.stringify({ ...verdict, pid, silentHours }, null, 2));
+  else if (verdict.healthy) console.log(`[stage-line-probe] line healthy (silence budget ${silentHours}h)`);
+  else console.error(`[stage-line-probe] STALLED — ${verdict.reasons.join('; ')}`);
+
+  // exitCode, NOT process.exit(): the supabase client leaves handles open, and forcing exit
+  // while they close aborts the process on Windows (libuv UV_HANDLE_CLOSING assertion, exit
+  // 127) — which would make the alarm's exit code non-deterministic on the worker's own host.
+  process.exitCode = verdict.healthy ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href) {
+  main();
+}

--- a/tests/unit/eva/stage-line-closure.test.js
+++ b/tests/unit/eva/stage-line-closure.test.js
@@ -1,0 +1,130 @@
+/**
+ * QF-20260725-697 — closure probe for the venture production line.
+ *
+ * The lead cases are the LIVE 2026-07-25 incident: pidfile PID 40684 not running, last
+ * stage_executions row 2026-07-13T21:18Z, eleven days silent behind green liveness probes.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isWorkerAbsent,
+  isLineSilent,
+  classifyStageLine,
+  DEFAULT_SILENT_HOURS,
+} from '../../../lib/eva/stage-line-closure.js';
+
+const INCIDENT_LAST_EXEC = '2026-07-13T21:18:21.426Z';
+const INCIDENT_NOW = new Date('2026-07-25T09:14:00.000Z');
+
+describe('isWorkerAbsent', () => {
+  it('THE INCIDENT: pidfile names PID 40684 and it is not running -> absent', () => {
+    expect(isWorkerAbsent({ pid: 40684, pidAlive: false })).toBe(true);
+  });
+
+  it('accepts the raw pidfile string (contents are read as text, not a number)', () => {
+    expect(isWorkerAbsent({ pid: '40684\n', pidAlive: false })).toBe(true);
+  });
+
+  it('a running worker is not absent', () => {
+    expect(isWorkerAbsent({ pid: 40684, pidAlive: true })).toBe(false);
+  });
+
+  it('no pidfile is NOT absent — a host that never ran the worker must not alarm', () => {
+    expect(isWorkerAbsent({ pid: null, pidAlive: null })).toBe(false);
+    expect(isWorkerAbsent({})).toBe(false);
+  });
+
+  it('UNKNOWN liveness is not absence — fail-quiet, never cry wolf on "cannot tell"', () => {
+    expect(isWorkerAbsent({ pid: 40684, pidAlive: null })).toBe(false);
+  });
+
+  it('a malformed pidfile is not absence', () => {
+    expect(isWorkerAbsent({ pid: 'garbage', pidAlive: false })).toBe(false);
+    expect(isWorkerAbsent({ pid: 0, pidAlive: false })).toBe(false);
+  });
+});
+
+describe('isLineSilent', () => {
+  it('THE INCIDENT: eleven days since the last execution -> silent', () => {
+    expect(isLineSilent({ lastExecutionAt: INCIDENT_LAST_EXEC, now: INCIDENT_NOW })).toBe(true);
+  });
+
+  it('a recent execution is not silence', () => {
+    const now = new Date('2026-07-25T09:14:00.000Z');
+    expect(isLineSilent({ lastExecutionAt: '2026-07-25T08:00:00.000Z', now })).toBe(false);
+  });
+
+  it('honours a custom window on both sides of the boundary', () => {
+    const now = new Date('2026-07-25T09:00:00.000Z');
+    const twoHoursAgo = '2026-07-25T07:00:00.000Z';
+    expect(isLineSilent({ lastExecutionAt: twoHoursAgo, now, silentHours: 1 })).toBe(true);
+    expect(isLineSilent({ lastExecutionAt: twoHoursAgo, now, silentHours: 6 })).toBe(false);
+  });
+
+  it('a NEVER-executed line is not silent — an empty table is a fresh deploy, not a stall', () => {
+    expect(isLineSilent({ lastExecutionAt: null, now: INCIDENT_NOW })).toBe(false);
+  });
+
+  it('an unparseable timestamp does not alarm', () => {
+    expect(isLineSilent({ lastExecutionAt: 'not-a-date', now: INCIDENT_NOW })).toBe(false);
+  });
+
+  it('defaults to the documented 6h budget', () => {
+    expect(DEFAULT_SILENT_HOURS).toBe(6);
+  });
+});
+
+describe('classifyStageLine', () => {
+  it('THE INCIDENT: both legs fire and the verdict is unhealthy with both reasons', () => {
+    const v = classifyStageLine({
+      pid: 40684,
+      pidAlive: false,
+      lastExecutionAt: INCIDENT_LAST_EXEC,
+      now: INCIDENT_NOW,
+    });
+    expect(v.healthy).toBe(false);
+    expect(v.workerAbsent).toBe(true);
+    expect(v.lineSilent).toBe(true);
+    expect(v.reasons).toHaveLength(2);
+    expect(v.reasons.join(' ')).toContain('40684');
+  });
+
+  it('LINE SILENT ALONE is unhealthy — the worker-alive-but-producing-nothing case a PID check cannot see', () => {
+    const v = classifyStageLine({
+      pid: 40684,
+      pidAlive: true,
+      lastExecutionAt: INCIDENT_LAST_EXEC,
+      now: INCIDENT_NOW,
+    });
+    expect(v.healthy).toBe(false);
+    expect(v.workerAbsent).toBe(false);
+    expect(v.lineSilent).toBe(true);
+  });
+
+  it('WORKER ABSENT ALONE is unhealthy even inside the silence budget', () => {
+    const now = new Date('2026-07-25T09:00:00.000Z');
+    const v = classifyStageLine({
+      pid: 40684,
+      pidAlive: false,
+      lastExecutionAt: '2026-07-25T08:30:00.000Z',
+      now,
+    });
+    expect(v.healthy).toBe(false);
+    expect(v.workerAbsent).toBe(true);
+    expect(v.lineSilent).toBe(false);
+  });
+
+  it('a live worker with recent executions is healthy and gives no reasons', () => {
+    const now = new Date('2026-07-25T09:00:00.000Z');
+    const v = classifyStageLine({
+      pid: 40684,
+      pidAlive: true,
+      lastExecutionAt: '2026-07-25T08:30:00.000Z',
+      now,
+    });
+    expect(v).toEqual({ healthy: true, workerAbsent: false, lineSilent: false, reasons: [] });
+  });
+
+  it('a host with no pidfile and no executions is healthy — nothing to report, no false alarm', () => {
+    expect(classifyStageLine({}).healthy).toBe(true);
+  });
+});


### PR DESCRIPTION
## Incident

The venture production line executed **ZERO stages for eleven days** (last `stage_executions` row `2026-07-13T21:18:21.426Z`, all `succeeded` — nothing failed, nothing was *attempted*) while every health signal stayed **GREEN**:

- `eva-scheduler-watcher-cron`: *"scheduler alive (age 25s) - no action"*
- `software-factory-poll`: green

Both were telling the truth. They monitor **LIVENESS**, and the things they watch were alive. **Nothing asked whether a stage actually RAN.** A stale pidfile sat beside a green dashboard for eleven days.

## Resolving the QF's open question (do not re-tread)

The QF flagged that `scripts/lib/stage-worker-watch.js` describes the worker as auto-restarting, and asked whether that watch was not running or running-and-failing. **Neither** — it IS running as designed, and the design cannot help here:

`scripts/start-stage-worker.js` respawns its supervisor **CHILD** on exit (circuit breaker, exponential backoff — all correct). **Nothing supervises the supervisor.** Once the supervisor process itself died, the restart capability died with it, and stale pidfile PID 40684 was all that remained.

## The fix

`lib/eva/stage-line-closure.js` — pure predicates for two **independent** failure modes, reported separately because each is separately actionable:

| leg | question | catches |
|---|---|---|
| `workerAbsent` | pidfile names a PID that is not running | the line **cannot** execute (the 07-13 shape) |
| `lineSilent` | zero executions in the window | the line **did not** execute — worker-alive-but-producing-nothing, which a PID check cannot see |

Both fail **quiet** on "cannot tell" (no pidfile, unknown liveness, never-executed table), so a host that never ran the worker and a fresh deploy never raise a false alarm.

### Deliberately NOT gated on pending-venture count

The obvious formulation — *"zero executions AND ventures sit `workflow_status=pending`"* — was rejected **on evidence**: of the 40 `active`+`pending` ventures verified 2026-07-25, most are `TS-fixture`/`HCGate`/`Pipeline-Test` harness rows carrying **`is_demo=false`**, so the flag cannot separate them. That count is never zero, so gating on it makes the probe fire permanently and therefore mean nothing. Silence of the execution table needs no venture classification to be correct.

## Reachability (not shipped-not-wired)

`scripts/cron/stage-line-closure-probe.mjs` + a 15-min GHA cron matching `eva-scheduler-watcher-cron`. **DB-only by design** — a GitHub runner cannot see the worker host's process table, so `lineSilent` is the half that watches production from CI; the PID leg still reports where a pidfile exists.

**Verified live** — the probe reproduces the incident exactly and exits 1:
```
worker_absent: pidfile PID 40684 is not running
line_silent: no stage executed since 2026-07-13T21:18:21.426Z
```
Uses `process.exitCode`, not `process.exit()`: forcing exit while the supabase client closes handles aborts on Windows (`UV_HANDLE_CLOSING`, exit 127) — which would make the alarm's exit code non-deterministic on the worker's own host.

## Scope note

**83 non-comment source LOC vs the 45 estimated.** The QF mandates both halves *and* the fix must be reachable; shipping only the pure module would be precisely the shipped-not-wired class this fix exists to catch. Flagged rather than trimmed.

## Tests

17 unit tests on the pure predicates, lead cases are the live incident (PID 40684, eleven-day silence). Full `tests/unit/eva` suite green: **519 files / 6731 tests**.

*(One `retro-pattern-grounding.db.test.js` failure seen mid-run was environmental — fresh worktrees have no `.env`; it passes on the shared root and in the worktree once env is present. Not related to this change.)*

## Not in scope

Restarting the worker now — per the QF, an operational call for the coordinator/chairman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)