### PR TITLE
fix(QF-20260725-652): Over-ask gate is wired on the COORDINATOR lane but absent on the CHAIRMAN lane -- classifyDecision never runs before Adam asks the chairman, so vision principle 2 (override authority, not approval authority) is unenforced at the surface where it matters most

### DIFF
--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -154,11 +154,44 @@ async function defaultFallbackSend({ message, reason }) {
 }
 
 /**
+ * QF-20260725-652 — the OVER-ASK gate on the CHAIRMAN lane.
+ *
+ * The deterministic 3-gate execute-vs-escalate rubric already guards the COORDINATOR lane
+ * (scripts/adam-advisory.cjs -> lib/coordinator/adam-outbound-gate.js). It was absent here, on the
+ * lane where an over-ask is expensive: an unguarded ask converts the chairman from exception-
+ * governor into an approval gate, inverting vision principle 2 ("override authority, not approval
+ * authority"). The post-hoc decision_rubric probe DOES catch these, but hours later — detection
+ * after delivery cannot prevent delivery.
+ *
+ * Reuses classifyDecisionQuestion (lib/adam/adherence-probes.js) as the SINGLE authority — it
+ * already routes its verdict through classifyDecision via gatesFromSignals. No second classifier.
+ * Its `overAsk` is conservative by construction: it requires NO COMES-TO-HIM trigger, an
+ * ADAM-DECIDES default sitting PROXIMATE to a decision-ASK, *and* an EXECUTE verdict. A heartbeat,
+ * a status line, or a genuine ESCALATE-class packet therefore never trips it.
+ *
+ * Degrade-safe: FAILS OPEN. A gate bug must never hard-block Adam's comms (CONST-002).
+ * @returns {Promise<{held:boolean, reason:string, decision?:object}>}
+ */
+async function evalOverAsk(message, context, opts) {
+  // Scope: this gates ADAM-INITIATED asks only. A chairman-initiated exchange is never held.
+  if (context.chairmanInitiated === true) return { held: false, reason: 'chairman-initiated exchange' };
+  if (opts.overAskAttested === true || process.env.ADAM_OVERASK_VERIFIED === '1') {
+    return { held: false, reason: 'attested (ADAM_OVERASK_VERIFIED)' };
+  }
+  const classify = typeof opts.classifyOverAsk === 'function'
+    ? opts.classifyOverAsk
+    : (await import('../../../adam/adherence-probes.js')).classifyDecisionQuestion;
+  const c = classify(message.body);
+  if (!c || c.overAsk !== true) return { held: false, reason: 'not an over-ask' };
+  return { held: true, reason: 'decision classifies EXECUTE — Adam should act and inform', decision: c.decision };
+}
+
+/**
  * The sole chairman-SMS send path.
  * @param {object} message - the message (see rubric-engine evaluate() shape)
- * @param {object} context - rubric context (quiet-hours, rate cap, etc.)
- * @param {object} opts - { sender?, evaluate?, console?, fallbackSend? } injectable seams
- * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, transportFailed?:boolean, fallbackFired?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[]}>}
+ * @param {object} context - rubric context (quiet-hours, rate cap, chairmanInitiated?)
+ * @param {object} opts - { sender?, evaluate?, console?, fallbackSend?, classifyOverAsk?, overAskAttested? } injectable seams
+ * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, transportFailed?:boolean, fallbackFired?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[], overAsk?:boolean}>}
  */
 export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   const sender = opts.sender || makeDefaultSender();
@@ -166,6 +199,18 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   const fallbackSend = typeof opts.fallbackSend === 'function' ? opts.fallbackSend : defaultFallbackSend;
   const log = opts.console || console;
   const isDecision = effectiveType(message) === 'decision'; // classifier hardening (FR-4)
+
+  // QF-20260725-652: over-ask gate — runs BEFORE the rubric gate, mirroring how adam-advisory.cjs
+  // runs the Adam Outbound Gate before dispatch. HELD (not sent) when the ask was Adam's to execute.
+  try {
+    const overAsk = await evalOverAsk(message, context, opts);
+    if (overAsk.held) {
+      log.warn(`[chairman-sms-gate] OVER-ASK HELD (execute-vs-escalate): ${overAsk.reason}. Execute and inform instead.`);
+      return { sent: false, held: true, overAsk: true, reason: 'over_ask_held', verdict: null };
+    }
+  } catch (err) {
+    log.warn(`[chairman-sms-gate] over-ask gate unavailable, failing OPEN: ${err.message}`);
+  }
 
   // Rubric gate — FAIL-CLOSED on unavailability (FR-3).
   let result;

--- a/tests/unit/comms/chairman-sms-gate/over-ask-gate.test.js
+++ b/tests/unit/comms/chairman-sms-gate/over-ask-gate.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendChairmanSMS } from '../../../../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+
+/**
+ * QF-20260725-652 — the over-ask gate on the CHAIRMAN lane.
+ *
+ * The deterministic execute-vs-escalate rubric guarded the coordinator lane but not this one, so an
+ * Adam-initiated ask that the rubric classifies EXECUTE reached the chairman and was only detected
+ * hours later by the post-hoc decision_rubric probe. These tests pin the PREVENTION, and equally
+ * pin the scope guardrails: a genuine ESCALATE packet, a status send, and a chairman-initiated
+ * exchange must all still pass through untouched.
+ */
+const DAYTIME = { nowHourET: 14, rateCap: 10, sentInWindow: 0 };
+const makeSender = () => ({ send: vi.fn(async () => ({ sid: 'SM-test', dispatched: true })) });
+const silentConsole = () => ({ warn: vi.fn(), error: vi.fn(), log: vi.fn() });
+
+// The WITNESSED over-ask (QF description, same day): a stated default sitting proximate to an ask,
+// no COMES-TO-HIM trigger => classifyDecision returns EXECUTE. Filing a DRAFT SD is reversible and
+// in-role, so this was Adam's to do and report.
+const OVER_ASK_BODY = 'I recommend we defer the inbox correlation-suppression fix — should I source that?';
+
+describe('chairman-sms-gate over-ask gate (QF-20260725-652)', () => {
+  it('HOLDS an Adam-initiated ask that classifies EXECUTE, and never reaches the sender', async () => {
+    const sender = makeSender();
+    const log = silentConsole();
+    const res = await sendChairmanSMS({ type: 'decision', body: OVER_ASK_BODY }, DAYTIME, { sender, console: log });
+    expect(res.sent).toBe(false);
+    expect(res.held).toBe(true);
+    expect(res.overAsk).toBe(true);
+    expect(res.reason).toBe('over_ask_held');
+    expect(sender.send).not.toHaveBeenCalled();
+    // The hold must NAME the gate that classified it so Adam can act instead of guessing.
+    expect(log.warn.mock.calls.flat().join(' ')).toMatch(/OVER-ASK HELD/);
+  });
+
+  it('does NOT hold a genuine ESCALATE-class decision (a COMES-TO-HIM trigger fired)', async () => {
+    const sender = makeSender();
+    const body = 'I recommend we defer the irreversible vendor migration — should I proceed?';
+    const res = await sendChairmanSMS({ type: 'decision', body }, DAYTIME, { sender, console: silentConsole() });
+    expect(res.reason).not.toBe('over_ask_held');
+    expect(res.overAsk).toBeUndefined();
+  });
+
+  it('does NOT hold a plain status/heartbeat send (no decision-ask shape)', async () => {
+    const sender = makeSender();
+    const body = 'Heartbeat: fleet green, 3 QFs shipped, nothing needed from you.';
+    const res = await sendChairmanSMS({ type: 'status', body }, DAYTIME, { sender, console: silentConsole() });
+    expect(res.reason).not.toBe('over_ask_held');
+  });
+
+  it('does NOT hold a chairman-INITIATED exchange even when the body reads as an over-ask', async () => {
+    const sender = makeSender();
+    const res = await sendChairmanSMS(
+      { type: 'decision', body: OVER_ASK_BODY },
+      { ...DAYTIME, chairmanInitiated: true },
+      { sender, console: silentConsole() },
+    );
+    expect(res.reason).not.toBe('over_ask_held');
+  });
+
+  it('is overridable by an explicit attestation (mirrors --outbound-verified)', async () => {
+    const sender = makeSender();
+    const res = await sendChairmanSMS(
+      { type: 'decision', body: OVER_ASK_BODY },
+      DAYTIME,
+      { sender, console: silentConsole(), overAskAttested: true },
+    );
+    expect(res.reason).not.toBe('over_ask_held');
+  });
+
+  it('FAILS OPEN when the classifier throws — a gate bug never hard-blocks Adam', async () => {
+    const sender = makeSender();
+    const log = silentConsole();
+    const classifyOverAsk = () => { throw new Error('classifier exploded'); };
+    const res = await sendChairmanSMS(
+      { type: 'decision', body: OVER_ASK_BODY },
+      DAYTIME,
+      { sender, console: log, classifyOverAsk },
+    );
+    expect(res.reason).not.toBe('over_ask_held');
+    expect(log.warn.mock.calls.flat().join(' ')).toMatch(/failing OPEN/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260725-652

**Type:** bug
**Severity:** high

### Issue Description
ASYMMETRY VERIFIED AT SOURCE 2026-07-25: scripts/adam-advisory.cjs:1046 composes lib/adam/execute-vs-escalate.js classifyDecision together with the rationale-bar into a PRE-SEND gate on the coordinator-facing choke. scripts/adam-chairman-sms.mjs and scripts/adam-chairman-decision.mjs contain ZERO references to classifyDecision or execute-vs-escalate -- grep returns nothing. So the deterministic 3-gate over-ask classifier guards the lane where an over-ask is cheap, and does not guard the lane where it is expensive. WHY THIS IS A VISION VIOLATION AND NOT A STYLE ISSUE: docs/vision/ehg-mission-vision-canonical.md principle 2 reads The Chairman governs by exception. Override authority, not approval authority. Reviews decisions, never enters data. Principle 7 reads Everything compounds and self-improves... getting smarter without the Chairman involvement. An unguarded ask converts the chairman from exception-governor into an approval gate, which inverts principle 2 directly. WITNESSED INSTANCE, same day: Adam diagnosed a defect (the inbox correlation-suppression bug), proposed the fix, then ASKED the chairman shall I source that. The 3-gate rubric classifies that action EXECUTE -- filing a DRAFT SD is reversible, in-role (sourcing is Adam lane per NEVER HOLD SOURCING, explicitly never GO-gated), and not flagship/governance/data-loss. The chairman had to reply source it, then separately instruct Adam to stop asking and self-improve automatically. THE EXISTING DETECTOR IS POST-HOC, WHICH IS THE ROOT: the decision_rubric probe in scripts/adam-self-adherence-review.mjs DID catch this -- it reported 1 NEW likely over-ask in the 1-day rolling window. But it runs every 6 hours, writes to adam_adherence_ledger, and emits a propose-only remediation. It tells Adam hours later that an ask already reached the chairman. Detection after delivery cannot prevent delivery. FIX: wire classifyDecision into the chairman-facing send path the same way scripts/adam-advisory.cjs:1046 already wires it for the coordinator path. When the verdict is EXECUTE, the ask does not go out -- it is HELD and surfaced back to Adam naming the gate that classified it, so Adam executes and informs instead. When the verdict is ESCALATE, it proceeds unchanged. Reuse the existing classifier as the single authority (the file comment at execute-vs-escalate.js:74 already states the intent that callers route through classifyDecision instead of a parallel boolean) -- do NOT write a second classifier. NOTE ON SCOPE: this gates ADAM-INITIATED asks. It must NOT block a chairman-initiated exchange, a genuine ESCALATE-class decision packet, or a heartbeat/status send -- only an outbound whose content is Adam asking the chairman to authorize something the rubric says Adam should already do.

### Steps to Reproduce
1. grep classifyDecision scripts/adam-advisory.cjs -- present at line 1046 composing the pre-send gate. 2. grep classifyDecision scripts/adam-chairman-sms.mjs scripts/adam-chairman-decision.mjs -- zero matches. 3. Compose an Adam-initiated chairman message whose content asks permission for a reversible in-role action (for example filing a DRAFT SD). 4. Observe it sends with no gate evaluation. 5. Run scripts/adam-self-adherence-review.mjs and observe the decision_rubric probe reports the over-ask only after the fact.

### Expected Behavior
An Adam-initiated chairman ask is classified by classifyDecision before sending; an EXECUTE verdict holds the message and tells Adam to act and inform instead, so the chairman only receives genuine ESCALATE-class decisions.

### Actual Behavior
No classifier runs on the chairman lane. Any Adam-initiated ask reaches the chairman regardless of verdict, and the over-ask is only detected up to 6 hours later in an adherence ledger.

### Changes
- **Files Changed:** 2
  - lib/comms/adam-outbound/chairman-sms-gate/index.js
  - tests/unit/comms/chairman-sms-gate/over-ask-gate.test.js
- **LOC:** 48 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol