### PR TITLE
fix(QF-20260725-469): assert finding-closure in pm_board — sourced or explicitly deferred

### DIFF
--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -341,6 +341,24 @@ export function probeDecisionRubric(facts = {}) {
     `${fresh.length} NEW likely over-ask(s) of ${totalExamined} in ${windowBasis}${exclNote} — Adam asked the chairman to ratify an already-determined, reversible decision matching no COMES-TO-HIM trigger (e.g. "${sample}…")${fpsTail}`);
 }
 
+// QF-20260725-469: what "actually sourced" means for a finding-class row's source_ref — a REAL
+// filed SD/QF key, not the synthetic slug (e.g. `taper-gauge-artifact-2026-07-25`) Adam writes when
+// it records the finding. The slug is what makes silent absorption invisible: it *looks* populated.
+export const FILED_KEY_RE = /^(?:SD|QF)-[A-Z0-9][A-Z0-9-]*$/i;
+
+// The deliberate-non-sourcing marker. Deliberately a MARKER, not "blocker is non-empty": every one
+// of the six 2026-07-25 finding rows carries blocker prose (including both orphans), so a
+// non-empty test would pass all of them and ship an inert probe. Free-text intent is not machine
+// -readable; an explicit token is. Adam stamps this when it decides NOT to source a finding.
+export const DEFERRAL_MARKER_RE = /\b(?:DEFERRED|NOT-SOURCED|WONT-SOURCE)\s*:/i;
+
+/** A finding-class ledger row terminates as 'sourced' | 'deferred' | 'orphan' (the drift state). */
+export function classifyFindingRow(row = {}) {
+  if (FILED_KEY_RE.test(String(row.source_ref ?? '').trim())) return 'sourced';
+  if (DEFERRAL_MARKER_RE.test(String(row.blocker ?? ''))) return 'deferred';
+  return 'orphan';
+}
+
 /**
  * P8 — PM board discipline. Governed duty: Adam maintains its project-management board
  * (adam_task_ledger) as the durable record of its own work, not informal recall. Drift =
@@ -352,12 +370,31 @@ export function probeDecisionRubric(facts = {}) {
  * inert. Instead this is a snapshot-diff against the PRIOR recorded check (the review script reads
  * it back from this probe's own last ledger row, mirroring probeDecisionRubric's history pattern).
  *
- * @param {{ pmBoardSnapshot?: Array<{id:string,status:string}>|null, pmBoardPriorSnapshot?: Map<string,string>|null }} facts
+ * ALSO asserts finding-closure (QF-20260725-469): every finding-class row must terminate either
+ * sourced (source_ref = a real filed SD/QF key) or explicitly deferred (a DEFERRED:/NOT-SOURCED:
+ * marker in blocker). Neither = silently absorbed, which is the gap between self-improving and
+ * self-improving AUTOMATICALLY.
+ *
+ * @param {{ pmBoardSnapshot?: Array<{id:string,status:string}>|null, pmBoardPriorSnapshot?: Map<string,string>|null, pmBoardFindings?: Array<{id:string,source_ref:string,blocker:string}>|null }} facts
  */
 export function probePmBoard(facts = {}) {
   const duty = 'pm-board discipline: Adam maintains adam_task_ledger as the durable record of its own work — adoption is the acceptance, not mere existence (adam_adoption_is_acceptance)';
   const current = facts.pmBoardSnapshot;
   const prior = facts.pmBoardPriorSnapshot;
+  // QF-20260725-469 (finding-closure). Evaluated FIRST, BEFORE every staleness early-return below
+  // — a finding can be orphaned while the board is empty or its prior snapshot is unresolved, and
+  // both of those paths return early. Placing this after them would make it unreachable in exactly
+  // the states it must still catch (the dead-code-behind-an-early-exit class).
+  const findings = facts.pmBoardFindings;
+  if (unresolved(findings) || !Array.isArray(findings)) {
+    return bar('pm_board', duty, VERDICT.UNKNOWN,
+      'pmBoardFindings unresolved — cannot confirm finding-closure discipline (not a pass)');
+  }
+  const orphans = findings.filter((r) => classifyFindingRow(r) === 'orphan');
+  if (orphans.length > 0) {
+    return bar('pm_board', duty, VERDICT.FAIL,
+      `${orphans.length} of ${findings.length} finding-class row(s) neither sourced nor explicitly deferred — silently absorbed: ${orphans.map((r) => r.id).join(', ')}`);
+  }
   if (unresolved(current) || !Array.isArray(current)) {
     return bar('pm_board', duty, VERDICT.UNKNOWN, 'pmBoardSnapshot unresolved — cannot confirm board discipline (not a pass)');
   }

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -55,6 +55,7 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     adamMachineRaisedNoiseInWindow: null,
     pmBoardSnapshot: null,
     pmBoardPriorSnapshot: null,
+    pmBoardFindings: null,
     // SD-LEO-INFRA-ROLE-MEASUREMENT-INTEGRITY-001 FR-1: the belt-starvation (D1) + dispatch-boundary
     // (D2) cardinal facts are now resolved in the retro audit from LIVE claim tables (below), so
     // those probes no longer degrade to 'unknown' here (the 297/297-unknown class).
@@ -275,6 +276,21 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
       .not('status', 'in', '(done,cancelled)');
     if (error) throw error;
     facts.pmBoardSnapshot = (openRows || []).map((r) => ({ id: r.id, status: r.status }));
+  } catch { /* leave null -> unknown */ }
+
+  // QF-20260725-469 pm-board (finding closure): the finding-class rows whose termination state the
+  // probe asserts. source_kind='manual' is the discriminator — 'sourced_sd' rows are already-filed
+  // items and 'advisory_thread' rows are mechanical comms threads, so neither is a finding and
+  // sweeping them in would produce false offenders. Windowed like every other fact here: a probe
+  // that re-indicts every historical row could never return to pass.
+  try {
+    const { data: findingRows, error } = await supabase
+      .from('adam_task_ledger')
+      .select('id, source_ref, blocker')
+      .eq('source_kind', 'manual')
+      .gte('created_at', since);
+    if (error) throw error;
+    facts.pmBoardFindings = (findingRows || []).map((r) => ({ id: r.id, source_ref: r.source_ref, blocker: r.blocker }));
   } catch { /* leave null -> unknown */ }
 
   // P8 pm-board (prior snapshot): read back the CURRENT snapshot this probe recorded on its own

--- a/tests/unit/adam/adherence-probes.test.js
+++ b/tests/unit/adam/adherence-probes.test.js
@@ -6,7 +6,7 @@ import { describe, it, expect } from 'vitest';
 import {
   probeSourcingCadence, probeVisionMonitoring, probeFrictionSignaling, probeProposeOnly,
   probePmBoard, encodeFingerprintsTail, parseFingerprintsTail, encodeSnapshotTail, parseSnapshotTail,
-  runAdherenceProbes, hasDrift, ADHERENCE_PROBES, VERDICT,
+  runAdherenceProbes, hasDrift, ADHERENCE_PROBES, VERDICT, classifyFindingRow,
 } from '../../../lib/adam/adherence-probes.js';
 
 describe('probeSourcingCadence (P1)', () => {
@@ -69,7 +69,7 @@ describe('runAdherenceProbes + hasDrift', () => {
       sourcedInWindow: 1, visionGaugeReadInWindow: true, recurrencesInWindow: 0, signalsInWindow: 0,
       adamAuthoredBuildsInWindow: 0, claimableBelt: 1, idleWorkers: 0, sourceableBacklogCount: 0,
       advisoryBody: 'ok', adamChairmanDecisionQuestionsInWindow: [], adamMachineRaisedNoiseInWindow: [],
-      pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map(),
+      pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map(), pmBoardFindings: []
     });
     expect(bars).toHaveLength(8);
     for (const b of bars) {
@@ -89,28 +89,28 @@ describe('runAdherenceProbes + hasDrift', () => {
 describe('probePmBoard (P8) — SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C', () => {
   it('unknown when pmBoardSnapshot is unresolved', () => {
     expect(probePmBoard({}).verdict).toBe('unknown');
-    expect(probePmBoard({ pmBoardSnapshot: null, pmBoardPriorSnapshot: new Map() }).verdict).toBe('unknown');
+    expect(probePmBoard({ pmBoardSnapshot: null, pmBoardPriorSnapshot: new Map(), pmBoardFindings: [] }).verdict).toBe('unknown');
   });
 
   it('PASS on an empty board, regardless of prior/history state (no baseline needed to know nothing is stalled)', () => {
-    expect(probePmBoard({ pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map() }).verdict).toBe('pass');
-    expect(probePmBoard({ pmBoardSnapshot: [], pmBoardPriorSnapshot: null }).verdict).toBe('pass');
+    expect(probePmBoard({ pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map(), pmBoardFindings: [] }).verdict).toBe('pass');
+    expect(probePmBoard({ pmBoardSnapshot: [], pmBoardPriorSnapshot: null, pmBoardFindings: [] }).verdict).toBe('pass');
   });
 
   it('unknown on a non-empty board with no prior recorded check (first-ever run — no baseline to judge staleness)', () => {
-    const r = probePmBoard({ pmBoardSnapshot: [{ id: 'a', status: 'open' }], pmBoardPriorSnapshot: null });
+    const r = probePmBoard({ pmBoardSnapshot: [{ id: 'a', status: 'open' }], pmBoardPriorSnapshot: null, pmBoardFindings: [] });
     expect(r.verdict).toBe('unknown');
   });
 
   it('PASS when prior was legitimately empty and current has new items (board newly in use, not a stall)', () => {
-    const r = probePmBoard({ pmBoardSnapshot: [{ id: 'a', status: 'open' }], pmBoardPriorSnapshot: new Map() });
+    const r = probePmBoard({ pmBoardSnapshot: [{ id: 'a', status: 'open' }], pmBoardPriorSnapshot: new Map(), pmBoardFindings: [] });
     expect(r.verdict).toBe('pass');
   });
 
   it('FAIL — true regression-to-non-use: current identical to prior, nothing moved', () => {
     const r = probePmBoard({
       pmBoardSnapshot: [{ id: 'a', status: 'open' }],
-      pmBoardPriorSnapshot: new Map([['a', 'open']]),
+      pmBoardPriorSnapshot: new Map([['a', 'open']]), pmBoardFindings: []
     });
     expect(r.verdict).toBe('fail');
     expect(r.detail).toMatch(/regression-to-non-use/);
@@ -119,7 +119,7 @@ describe('probePmBoard (P8) — SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DIS
   it('PASS — a shared item transitioned status since the prior check', () => {
     const r = probePmBoard({
       pmBoardSnapshot: [{ id: 'a', status: 'in_progress' }],
-      pmBoardPriorSnapshot: new Map([['a', 'open']]),
+      pmBoardPriorSnapshot: new Map([['a', 'open']]), pmBoardFindings: []
     });
     expect(r.verdict).toBe('pass');
   });
@@ -127,7 +127,7 @@ describe('probePmBoard (P8) — SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DIS
   it('PASS — a prior item completed/left the open set since the prior check', () => {
     const r = probePmBoard({
       pmBoardSnapshot: [{ id: 'b', status: 'open' }], // 'a' is gone (completed/cancelled)
-      pmBoardPriorSnapshot: new Map([['a', 'open']]),
+      pmBoardPriorSnapshot: new Map([['a', 'open']]), pmBoardFindings: []
     });
     expect(r.verdict).toBe('pass');
   });
@@ -135,7 +135,7 @@ describe('probePmBoard (P8) — SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DIS
   it('FAIL despite a brand-new unrelated item appearing (regression test: new-item churn alone must not mask a true stall)', () => {
     const r = probePmBoard({
       pmBoardSnapshot: [{ id: 'a', status: 'open' }, { id: 'b', status: 'open' }], // b is new; a unchanged
-      pmBoardPriorSnapshot: new Map([['a', 'open']]),
+      pmBoardPriorSnapshot: new Map([['a', 'open']]), pmBoardFindings: []
     });
     expect(r.verdict).toBe('fail');
   });
@@ -146,8 +146,54 @@ describe('probePmBoard (P8) — SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DIS
     // replaces would have silently masked this exact case.
     const r = probePmBoard({
       pmBoardSnapshot: [{ id: 'a', status: 'blocked' }],
-      pmBoardPriorSnapshot: new Map([['a', 'blocked']]),
+      pmBoardPriorSnapshot: new Map([['a', 'blocked']]), pmBoardFindings: []
     });
+    expect(r.verdict).toBe('fail');
+  });
+});
+
+describe('probePmBoard finding-closure (QF-20260725-469)', () => {
+  const clean = { pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map() };
+
+  it('unknown when pmBoardFindings is unresolved — fail-loud, never a silent pass', () => {
+    expect(probePmBoard({ ...clean, pmBoardFindings: null }).verdict).toBe('unknown');
+    expect(probePmBoard({ ...clean }).verdict).toBe('unknown');
+  });
+
+  it('FAIL and names the offending row ids when a finding is neither sourced nor deferred', () => {
+    const r = probePmBoard({ ...clean, pmBoardFindings: [
+      { id: 'row-a', source_ref: 'taper-gauge-artifact-2026-07-25', blocker: 'Needs a real classifier before it can be trusted' },
+    ] });
+    expect(r.verdict).toBe('fail');
+    expect(r.detail).toMatch(/row-a/);
+    expect(r.detail).toMatch(/silently absorbed/);
+  });
+
+  it('PASS when sourced (real filed key) or explicitly deferred (marker)', () => {
+    const r = probePmBoard({ ...clean, pmBoardFindings: [
+      { id: 'sourced', source_ref: 'QF-20260725-697', blocker: '' },
+      { id: 'deferred', source_ref: 'promotion-gap-2026-07-25', blocker: 'DEFERRED: wants a Solomon shape-consult first' },
+    ] });
+    expect(r.verdict).toBe('pass');
+  });
+
+  it('a synthetic slug in source_ref is NOT sourced — the exact shape that made absorption invisible', () => {
+    expect(classifyFindingRow({ source_ref: 'venture-stall-2026-07-25' })).toBe('orphan');
+    expect(classifyFindingRow({ source_ref: 'QF-20260725-697' })).toBe('sourced');
+    expect(classifyFindingRow({ source_ref: 'SD-LEO-INFRA-ADAM-INBOUND-BACKLOG-WATCHDOG-001' })).toBe('sourced');
+  });
+
+  it('blocker prose alone does NOT count as deferral — otherwise the probe ships inert', () => {
+    // Regression guard for the real defect: all six 2026-07-25 finding rows carry blocker prose,
+    // including both orphans. A non-empty-blocker test would have passed every one of them.
+    expect(classifyFindingRow({ source_ref: 'x-2026-07-25', blocker: 'Root cause not yet diagnosed' })).toBe('orphan');
+    expect(classifyFindingRow({ source_ref: 'x-2026-07-25', blocker: 'NOT-SOURCED: superseded by the venture-line diagnosis' })).toBe('deferred');
+  });
+
+  it('is reachable on an EMPTY board — the orphan check must not sit behind the clean-board early return', () => {
+    const r = probePmBoard({ pmBoardSnapshot: [], pmBoardPriorSnapshot: new Map(), pmBoardFindings: [
+      { id: 'orphan-1', source_ref: 'anchor-stall-false-positive-2026-07-25', blocker: 'DO NOT simply flip their status' },
+    ] });
     expect(r.verdict).toBe('fail');
   });
 });


### PR DESCRIPTION
Closes QF-20260725-469 (chairman-directed, high severity).

Adam's board could **silently absorb** a recorded finding-with-evidence: a row could end a session neither sourced nor deliberately deferred, and would die with the session. That is the gap between self-improving and self-improving *automatically*.

## Approach
Extends the **existing** `pm_board` adherence probe — which already fires and already auto-sources a propose-only remediation on drift — rather than adding a new loop. No schema change, no DDL, per the QF's leverage-existing-machinery instruction.

- `classifyFindingRow()`: `sourced` (source_ref is a real SD/QF key) | `deferred` (explicit `DEFERRED:`/`NOT-SOURCED:` marker) | `orphan`.
- **Deferral requires a MARKER, not merely a non-empty `blocker`.** All six 2026-07-25 finding rows carry blocker prose — *including both orphans* — so a non-empty test would have passed every one of them and shipped an inert probe.
- A synthetic slug (`venture-stall-2026-07-25`) is **not** sourced; that shape is exactly what made the absorption invisible.
- The assertion runs **first**, before pm_board's staleness early-returns — a finding can be orphaned while the board is empty or its prior snapshot is unresolved, and both paths return early.
- Unresolved findings fact → `unknown`, never a silent pass (fail-loud contract).

## Verification
Live read-only run of `resolveFacts` + probe against prod: **fail**, naming 6 of 7 finding rows, and the one genuinely back-linked row (`QF-20260725-697`) correctly classified `sourced`.

Tests: 397 passing across 32 adam-related suites (27 in the probe suite, 6 new).

## Notes
- The probe will fail loudly on its first real run naming ~6 rows; that is intended — the marker convention is new, so nothing is stamped yet. I did **not** backfill markers into Adam's rows: deciding which findings were deliberately deferred is Adam's judgment, not mine.
- `priorStatus` unused-var lint at line 421 is **pre-existing on origin/main** (line 384), not introduced here; left untouched to avoid unrelated-change creep.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)