### PR TITLE
fix(QF-20260725-538): Fleet identity writer: nonexistent sd_id column + missing role/accountUuid8 keys (roster always idle, LEO panel columns blank)

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -22,6 +22,14 @@ const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', '
 // lib/fleet/tier-ladder.cjs module so K (ladderTopRank()) is never assumed to be 4.
 const { resolveWorkerTierRank, ladderTopRank, stampRankForWorker } = require('../lib/fleet/tier-ladder.cjs');
 
+// QF-20260725-538 (defect B): server/routes/fleet-panel.js formatSessionRow reads
+// identity.role and identity.accountUuid8, but this writer never wrote either, so the
+// chairman-facing LEO panel could NEVER populate its Role and Account columns. role comes
+// from the session's own metadata.role. accountUuid8 comes from the LOCAL process account
+// (lib/fleet/account-identity.cjs reads ~/.claude.json oauthAccount) -- see writeAccountUuid8
+// below for why that is deliberately NOT stamped on every session.
+const { getAccountIdentity } = require('../lib/fleet/account-identity.cjs');
+
 // QF-20260627-108 (FR-1): the chairman effort-encoded callsign scheme. A worker's callsign is
 // derived from its metadata.tier_rank (the source-of-truth), NOT flat first-available NATO order —
 // otherwise the 5-min cron re-clobbers the effort names every pass. Shared by the cron AND
@@ -446,7 +454,7 @@ async function main() {
   let refreshed = 0;
   for (const w of assigned) {
     const id = w.metadata.fleet_identity;
-    const currentSdLabel = w.sd_id || 'idle';
+    const currentSdLabel = w.sd_key || 'idle';
     const expectedDisplayName = `${id.callsign} | ${currentSdLabel}`;
     const expectedIdentity = { callsign: id.callsign, color: id.color, display_name: expectedDisplayName };
     if (identityNeedsRebroadcast(w, expectedIdentity)) {
@@ -462,7 +470,7 @@ async function main() {
         .from('session_coordination')
         .insert({
           target_session: w.session_id,
-          target_sd: w.sd_id || null,
+          target_sd: w.sd_key || null,
           message_type: 'SET_IDENTITY',
           subject: `Identity update: ${id.callsign} now on ${currentSdLabel}`,
           body: `Your display name updated to "${expectedDisplayName}" (SD changed).`,
@@ -482,7 +490,7 @@ async function main() {
     for (const w of assigned) {
       const id = w.metadata.fleet_identity;
       const ansi = ANSI[id.color] || '';
-      const sdLabel = w.sd_id || 'idle';
+      const sdLabel = w.sd_key || 'idle';
       console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${w.session_id.substring(0, 12)}...  ${sdLabel}`);
     }
     console.log('');
@@ -508,11 +516,13 @@ async function main() {
   for (const w of assigned) {
     const id = w.metadata.fleet_identity;
     const ansi = ANSI[id.color] || '';
-    const sdLabel = w.sd_id || 'idle';
+    const sdLabel = w.sd_key || 'idle';
     console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${w.session_id.substring(0, 12)}...  ${sdLabel} ${ANSI.dim}(existing)${ANSI.reset}`);
   }
 
   // Assign new workers
+  // QF-20260725-538: resolved ONCE per tick (one ~/.claude.json read), not per session.
+  const localAccount = getAccountIdentity();
   let newCount = 0;
   for (const worker of needsAssignment) {
     const callsign = pickCallsignForTier(tierRankOf(worker), usedCallsigns);
@@ -520,7 +530,7 @@ async function main() {
     usedCallsigns.add(callsign);
     usedColors.add(color);
 
-    const sdLabel = worker.sd_id || 'idle';
+    const sdLabel = worker.sd_key || 'idle';
     const displayName = `${callsign} | ${sdLabel}`;
 
     // Store identity in session metadata
@@ -529,6 +539,11 @@ async function main() {
       color,
       callsign,
       display_name: displayName,
+      // QF-20260725-538 (defect B): fleet-panel.js formatSessionRow reads identity.role and
+      // identity.accountUuid8 — without these two the chairman's Role/Account columns are
+      // structurally unpopulatable. role is the session's own metadata.role.
+      role: worker.metadata?.role || null,
+      accountUuid8: identityAccountUuid8(worker.metadata, localAccount),
       assigned_at: new Date().toISOString()
     };
     // QF-20260703-040: stamp what we're about to broadcast so a later tick can detect drift.
@@ -549,7 +564,7 @@ async function main() {
       .from('session_coordination')
       .insert({
         target_session: worker.session_id,
-        target_sd: worker.sd_id || null,
+        target_sd: worker.sd_key || null,
         message_type: 'SET_IDENTITY',
         subject: `Identity: ${callsign} (${color})`,
         body: `The coordinator assigned you callsign "${callsign}" with color "${color}". Your statusline will update automatically. You may also run: /color ${color}\n\nCommunication: send signals back via /signal (try /signal --help for types). Use it when stuck on a gate >2x, about to bypass, or seeing protocol/spec friction.`,
@@ -573,7 +588,23 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, identityNeedsRebroadcast };
+/**
+ * QF-20260725-538 (defect B): the accountUuid8 to stamp on a session's fleet_identity, or null.
+ * PURE + injectable so a test never has to read the real ~/.claude.json.
+ *
+ * getAccountIdentity() resolves the account of THIS process from the single global
+ * ~/.claude.json oauthAccount pointer. It cannot distinguish per-session accounts, and that
+ * pointer is known to be flip-prone across a relaunch (CP3 HF-1). So a session that declares its
+ * own account_profile -- canary deliberately runs a SEPARATE account -- gets null rather than the
+ * coordinator's account. A blank Account column is honest; a confidently-wrong one is worse than
+ * blank, which is the whole failure class this QF is fixing.
+ */
+function identityAccountUuid8(metadata, accountIdentity) {
+  if (metadata && metadata.account_profile) return null;
+  return (accountIdentity && accountIdentity.accountUuid8) || null;
+}
+
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, identityNeedsRebroadcast, identityAccountUuid8 };
 
 if (require.main === module) {
   main().then(async () => {

--- a/tests/unit/assign-fleet-identities-sdkey-and-panel-fields.test.js
+++ b/tests/unit/assign-fleet-identities-sdkey-and-panel-fields.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const mod = require('../../scripts/assign-fleet-identities.cjs');
+const { identityAccountUuid8 } = mod;
+
+/**
+ * QF-20260725-538 — two producer/consumer contract mismatches in the same writer.
+ *
+ * A) The writer read w.sd_id, a column that does NOT exist on claude_sessions (it is sd_key).
+ *    Supabase returns undefined for a nonexistent column rather than erroring, so every roster
+ *    line fell back to 'idle' and every SET_IDENTITY carried target_sd=null — a broken reading
+ *    that looked legitimate. VERIFIED LIVE: session 9301234a held QF-20260725-538 while its
+ *    fleet_identity.display_name read "Alpha | idle".
+ *
+ * B) server/routes/fleet-panel.js formatSessionRow reads identity.role and identity.accountUuid8;
+ *    the writer wrote neither, so those two chairman-facing columns could never populate.
+ */
+describe('QF-20260725-538 defect A: sd_key is the real column, sd_id does not exist', () => {
+  it('the writer source contains NO w.sd_id / worker.sd_id reads', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'scripts', 'assign-fleet-identities.cjs'),
+      'utf-8',
+    );
+    // The bug was six sites reading a nonexistent column. Pin that none come back.
+    expect(src).not.toMatch(/\bw\.sd_id\b/);
+    expect(src).not.toMatch(/\bworker\.sd_id\b/);
+    // ...and that the correct column is what the label/target logic reads.
+    expect(src).toMatch(/\bw\.sd_key\b/);
+    expect(src).toMatch(/\bworker\.sd_key\b/);
+  });
+
+  it('the DB select still fetches sd_key, so the reads above resolve', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'scripts', 'assign-fleet-identities.cjs'),
+      'utf-8',
+    );
+    expect(src).toMatch(/\.select\(['"]session_id, sd_key, metadata, heartbeat_at['"]\)/);
+  });
+});
+
+describe('QF-20260725-538 defect B: identityAccountUuid8 scoping', () => {
+  const ACCOUNT = { email: 'a@b.c', orgName: 'Org', accountUuid8: 'ca1de6e4' };
+
+  it('stamps the local account for a session with no declared account_profile', () => {
+    expect(identityAccountUuid8({ role: 'worker' }, ACCOUNT)).toBe('ca1de6e4');
+    expect(identityAccountUuid8({}, ACCOUNT)).toBe('ca1de6e4');
+    expect(identityAccountUuid8(null, ACCOUNT)).toBe('ca1de6e4');
+  });
+
+  it('returns null for a session that declares its OWN account_profile (canary runs a separate account)', () => {
+    // The single global ~/.claude.json oauthAccount pointer cannot speak for a session running
+    // under a different account. Blank beats confidently-wrong.
+    expect(identityAccountUuid8({ account_profile: 'canary' }, ACCOUNT)).toBeNull();
+    expect(identityAccountUuid8({ account_profile: 'other' }, ACCOUNT)).toBeNull();
+  });
+
+  it('returns null when the local account identity is unavailable (never throws, never invents)', () => {
+    expect(identityAccountUuid8({}, null)).toBeNull();
+    expect(identityAccountUuid8({}, undefined)).toBeNull();
+    expect(identityAccountUuid8({}, {})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260725-538

**Type:** bug
**Severity:** high

### Issue Description
TWO producer/consumer contract mismatches in the SAME writer, scripts/assign-fleet-identities.cjs. Bundled per coordinator a59441f4 (msg 8233735c). Both are the same shape: code that cannot possibly do its job, reporting success. DEFECT A - DISPATCH SAFETY. The file reads w.sd_id, a column that does not exist on claude_sessions (the real column is sd_key). Line 289 correctly selects session_id, sd_key, metadata, heartbeat_at, and lines 171/311 correctly use w.sd_key for cohort logic - but line 449 currentSdLabel = w.sd_id, lines 485/511/523 sdLabel = w.sd_id, and lines 465/552 target_sd = w.sd_id are all undefined. So the roster ALWAYS prints idle for every session and every SET_IDENTITY row carries target_sd=null. Selecting a nonexistent column returns undefined rather than erroring, so the fallback value (idle, null) looks like a legitimate reading and nothing ever looks broken. DEFECT B - CHAIRMAN-FACING LEO PANEL. Line 528 writes metadata.fleet_identity = { color, callsign, display_name, assigned_at } and never writes role or accountUuid8. But server/routes/fleet-panel.js formatSessionRow reads identity.role (line 41) and identity.accountUuid8 (line 42). Those two columns of the LEO fleet panel therefore can NEVER populate. Callsign and color render fine because they come from the same object and ARE written - which is what makes the gap look like a UI bug rather than a writer omission.

### Steps to Reproduce
1. Run the fleet roster and compare its idle labels against claude_sessions rows that have a non-null sd_key. 2. Open the LEO fleet panel at http://localhost:3000/fleet-ui/fleet-panel.html and read the Role and Account columns. 3. GET /api/fleet-panel and inspect any session object.

### Expected Behavior
Roster shows the held SD key for sessions that hold one; SET_IDENTITY rows carry the real target_sd; the LEO panel Role and Account columns show the session role and account.

### Actual Behavior
VERIFIED LIVE 2026-07-25. Roster printed all 8 sessions idle while Alpha-3 (074ec1e1) held SD-LEO-INFRA-ADAM-INBOUND-BACKLOG-WATCHDOG-001 and Golf-2 (d2e3b799) held QF-20260725-972, both status=active with uncommitted changes. LEO panel rendered every row with a dash in Role and Account (chairman viewed it on screen); /api/fleet-panel returns role:null and account:null on every session while callsign=Alpha-4 and model_effort=opus/xhigh populate correctly. FIX: rename w.sd_id to w.sd_key at 449/465/485/511 and worker.sd_id to worker.sd_key at 523/552 (six sites, no logic change); and add role plus accountUuid8 to the fleet_identity object written at 528. IMPACT: the roster is the primary human-facing fleet view, so its idle labels invite double-assigning live builders mid-build; and it corrupted the coordinator's own idle counts reported to Adam, which are being treated as unverified.

### Changes
- **Files Changed:** 2
  - scripts/assign-fleet-identities.cjs
  - tests/unit/assign-fleet-identities-sdkey-and-panel-fields.test.js
- **LOC:** 38 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol