### PR TITLE
fix(QF-20260725-423): filter the fleet panel to live sessions and fix the guard that missed it

### DIFF
--- a/scripts/lint/fleet-liveness-select-lint.mjs
+++ b/scripts/lint/fleet-liveness-select-lint.mjs
@@ -6,8 +6,10 @@
 // tree scan). ADVISORY-FIRST: exit 0 by default; pass --enforce for exit 1.
 //
 // A read is SAFE (not flagged) when ANY of:
-//   • it carries a server-side bound: `.gte('heartbeat_at', …)` OR (`.order(` AND `.limit(`)
-//     — ordering by heartbeat_at/heartbeat_age_seconds means the cap only drops the STALEST rows;
+//   • it carries a server-side bound: `.gte('heartbeat_at', …)` OR `.limit(` OR an `.order(` on a
+//     real RECENCY column (heartbeat_at / heartbeat_age_seconds / created_at …) — only then does
+//     the cap drop the STALEST rows. An `.order()` on any other column (or on a `_human` display
+//     string) is NOT a bound; see orderIsRecencyBound and QF-20260725-423;
 //   • it is a single-row lookup: `.eq('session_id', …)` / `.single()` / `.maybeSingle()`;
 //   • it is an exact-count head query: `count:` + `head:`;
 //   • it routes through the canonical helper (lib/fleet/live-fleet-sessions.cjs — which is itself
@@ -25,6 +27,26 @@ const ALLOWLIST_PATH = resolve(ROOT, 'scripts/lint/fleet-liveness-select-allowli
 
 const TARGET_TABLES = ['claude_sessions', 'v_active_sessions'];
 
+// An `.order()` that genuinely bounds the row cap must sort by a real recency value. Ordering by
+// anything else (a session_id, or a human-rendered age string) leaves the page arbitrary, so the
+// cap can still drop every live row. Deliberately a column-NAME test, not a direction test:
+// ascending on an age and descending on a timestamp are both newest-first.
+//
+// `_human`-suffixed columns are EXCLUDED even though they contain a recency word: heartbeat_age_human
+// is display text ("6s ago" / "4500h ago") that sorts lexicographically, which is the defect itself.
+// Matching on "heartbeat" alone would re-admit the exact query this rule exists to reject.
+const RECENCY_COL = /^[^'"]*(heartbeat|created_at|updated_at|last_seen|last_active)[^'"]*$/;
+const ORDER_COL = /\.order\(\s*['"]([^'"]+)['"]/;
+
+/** Does this chain's `.order()` sort by a real (non-display) recency column? */
+export function orderIsRecencyBound(chain) {
+  const m = chain.match(ORDER_COL);
+  if (!m) return false;
+  const col = m[1];
+  if (/_human$/.test(col)) return false;
+  return RECENCY_COL.test(col);
+}
+
 /**
  * Strip // line and block comments so commented-out queries do not register, PRESERVING line
  * count (block comments become the same newlines they spanned; line comments keep their newline)
@@ -40,15 +62,21 @@ export function stripComments(src) {
  * Is this claude_sessions/v_active_sessions read SAFE from the 1000-row cap? This guard targets the
  * exact pattern the SD names — an UNFILTERED select (like assessFleetActivity's original bare
  * `.from('v_active_sessions').select(cols)`), which PostgREST caps at the OLDEST 1000 rows. A read
- * is SAFE when it carries ANY server-side narrowing/paging: any filter, an `.order()` (ordering by
- * heartbeat desc returns the NEWEST 1000), a `.limit()`, a single-row read, or a count-head query.
+ * is SAFE when it carries ANY server-side narrowing/paging: any filter, an `.order()` ON A RECENCY
+ * COLUMN (which makes the page newest-first, so the cap drops only the stalest), a `.limit()`, a
+ * single-row read, or a count-head query.
  * (Status-filtered-but-unbounded scans, e.g. `.in('status',[active,idle])` with no limit, are a
  * broader latent class the SD scopes OUT — they filter server-side and are safe at today's < 1000
  * active; a follow-up may tighten them. This guard prevents the UNFILTERED regression.)
  */
 function isSafeChain(chain) {
   if (/\.limit\(/.test(chain)) return true;
-  if (/\.order\(/.test(chain)) return true; // order(heartbeat desc) => newest 1000 in the page
+  // `.order()` only bounds the cap when it orders by a RECENCY column — that is what makes the
+  // dropped rows the stalest ones. QF-20260725-423: server/routes/fleet-panel.js ordered by
+  // `heartbeat_age_human`, a rendered STRING ("6s ago" / "4500h ago"), so the page was
+  // lexicographic and the cap kept an arbitrary 1000 of which 994 were dead — yet this guard
+  // passed it, because it only asked whether `.order(` appeared at all.
+  if (orderIsRecencyBound(chain)) return true;
   if (/\.maybeSingle\(\)|\.single\(\)/.test(chain)) return true;
   // ANY server-side narrowing filter means it is not the "unfiltered" pattern.
   if (/\.(eq|in|not|filter|gt|gte|lt|lte|is|like|ilike|neq|contains|match|or|overlaps)\(/.test(chain)) return true;

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -16,6 +16,15 @@ import { loadStore, buildNamedAccountChips } from '../../lib/fleet/account-capac
 
 const router = Router();
 
+// A session counts as live if it heartbeat within this window. Generous on purpose: the point is
+// to drop months-dead rows, not to hide a session that went briefly quiet. Live sessions observed
+// at 3s-15m; dead ones at 4000h+, so anything in this range separates them cleanly.
+const LIVE_WINDOW_SECONDS = 3600;
+
+// Explicit cap so a truncated page is reported rather than mistaken for the true total
+// (PostgREST silently defaults to 1000, which is exactly what made the old list look complete).
+const PANEL_ROW_CAP = 500;
+
 // Resolve a service-role Supabase client. Prefers an injected client
 // (req.app.locals.supabase) so route tests can supply a mock; falls back to a
 // fresh service-role client for the running server. Mirrors server/routes/ventures.js.
@@ -30,14 +39,34 @@ function resolveServiceClient(req) {
 }
 
 /** Format a session row from v_active_sessions into the manifest-table shape. */
+/**
+ * A session carries an identity if it is a named fleet worker OR a known role session
+ * (coordinator / adam / solomon). Rows with NONE of these are ghosts: dead processes whose
+ * rows are still being heartbeated. Observed 2026-07-25 — four such rows heartbeating every
+ * few seconds whose entire metadata was the audit trail of an is_alive repair-then-revert,
+ * with no role, callsign, model or effort. Heartbeat recency cannot separate them, because
+ * they heartbeat; the absence of ANY identity is what distinguishes them.
+ */
+function sessionIdentityKind(meta = {}) {
+  if (meta.fleet_identity?.callsign) return 'worker';
+  if (meta.is_coordinator) return 'coordinator';
+  if (meta.role) return String(meta.role);
+  if (meta.model) return 'unstamped';   // real session, identity not yet assigned
+  return null;                          // no identity at all -> ghost
+}
+
 function formatSessionRow(row) {
   const meta = row.metadata || {};
   const identity = meta.fleet_identity || {};
   const model = meta.model || '--';
   const effort = meta.effort || '--';
+  const kind = sessionIdentityKind(meta);
   return {
     session_id: row.session_id,
-    callsign: identity.callsign || null,
+    // Fall back to the role name so the coordinator/Adam/Solomon rows read as themselves
+    // instead of as blanks. Fleet callsign still wins when present.
+    callsign: identity.callsign || (kind && kind !== 'unstamped' ? kind : null),
+    identity_kind: kind,
     color: identity.color || null,
     role: identity.role || null,
     account: identity.accountUuid8 || null,
@@ -67,12 +96,34 @@ function formatSessionRow(row) {
 export async function getFleetPanel(req, res) {
   const supabase = resolveServiceClient(req);
 
-  const { data: sessionRows, error: sessionsError } = await supabase
-    .from('v_active_sessions')
-    .select('session_id, sd_key, computed_status, metadata, heartbeat_age_human')
-    .order('heartbeat_age_human', { ascending: true });
+  // v_active_sessions is "active" in name only — it carries every session ever registered
+  // (measured 2026-07-25: 1000 rows returned, 6 with a heartbeat under 1h, oldest ~234 days).
+  // Default the panel to genuinely-live sessions; ?all=1 restores the full history, so this
+  // FILTERS the view without destroying the signal behind it.
+  const showAll = String(req?.query?.all ?? '') === '1';
+  const windowSeconds = Number.parseInt(req?.query?.windowSeconds, 10) || LIVE_WINDOW_SECONDS;
 
-  const sessions = sessionsError || !sessionRows ? [] : sessionRows.map(formatSessionRow);
+  // Order by the NUMERIC age, not heartbeat_age_human — that column is display text
+  // ("6s ago", "15m ago", "4500h ago") and sorting it lexicographically scrambled the list.
+  let query = supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_key, computed_status, metadata, heartbeat_age_human, heartbeat_age_seconds')
+    .order('heartbeat_age_seconds', { ascending: true })
+    .limit(PANEL_ROW_CAP);
+
+  if (!showAll) query = query.lt('heartbeat_age_seconds', windowSeconds);
+
+  const { data: sessionRows, error: sessionsError } = await query;
+
+  const allRows = sessionsError || !sessionRows ? [] : sessionRows.map(formatSessionRow);
+  // Drop identity-less ghosts from the default view (they heartbeat, so the recency filter
+  // above cannot catch them). ?all=1 still shows everything.
+  const sessions = showAll ? allRows : allRows.filter((r) => r.identity_kind !== null);
+  const ghostsHidden = allRows.length - sessions.length;
+
+  // Surface truncation rather than silently returning a capped page (PostgREST defaults to 1000,
+  // which reads as a real total). Callers can tell "that is all of them" from "there are more".
+  const truncated = !sessionsError && Array.isArray(sessionRows) && sessionRows.length >= PANEL_ROW_CAP;
 
   // FR-1/FR-2: three named-account capacity chips (mockup-1) — always exactly 3, even when the
   // capacity store is empty/partial (unmatched accounts render 'wk --%').
@@ -85,7 +136,12 @@ export async function getFleetPanel(req, res) {
     attentionStrip = [];
   }
 
-  res.json({ sessions, accountChips, attentionStrip });
+  res.json({
+    sessions,
+    accountChips,
+    attentionStrip,
+    filter: { liveOnly: !showAll, windowSeconds, truncated, ghostsHidden },
+  });
 }
 
 router.get('/', getFleetPanel);

--- a/tests/unit/lint/fleet-liveness-select-lint.test.js
+++ b/tests/unit/lint/fleet-liveness-select-lint.test.js
@@ -2,7 +2,7 @@
 // The guard flags UNFILTERED claude_sessions/v_active_sessions selects (the 1000-row-cap shape)
 // and leaves any server-side-narrowed/bounded/scoped read alone.
 import { describe, it, expect } from 'vitest';
-import { extractUnboundedLivenessSelects, stripComments, loadAllowlist } from '../../../scripts/lint/fleet-liveness-select-lint.mjs';
+import { extractUnboundedLivenessSelects, stripComments, loadAllowlist, orderIsRecencyBound } from '../../../scripts/lint/fleet-liveness-select-lint.mjs';
 
 describe('extractUnboundedLivenessSelects', () => {
   it('FLAGS a bare unfiltered v_active_sessions select (the assessFleetActivity-class bug)', () => {
@@ -17,9 +17,35 @@ describe('extractUnboundedLivenessSelects', () => {
     expect(extractUnboundedLivenessSelects(src)).toHaveLength(1);
   });
 
-  it('does NOT flag a select bounded by .order() (newest-first => cap drops only the stalest)', () => {
-    const src = `await sb.from('claude_sessions').select('session_id').order('heartbeat_at', { ascending: false });`;
-    expect(extractUnboundedLivenessSelects(src)).toHaveLength(0);
+  it('does NOT flag a select ordered by a RECENCY column (cap drops only the stalest)', () => {
+    const ts = `await sb.from('claude_sessions').select('session_id').order('heartbeat_at', { ascending: false });`;
+    const age = `await sb.from('v_active_sessions').select('session_id').order('heartbeat_age_seconds', { ascending: true });`;
+    expect(extractUnboundedLivenessSelects(ts)).toHaveLength(0);
+    expect(extractUnboundedLivenessSelects(age)).toHaveLength(0);
+  });
+
+  // QF-20260725-423 — the regression this guard MISSED. server/routes/fleet-panel.js ordered by
+  // heartbeat_age_human, a rendered string, so the page was lexicographic and the cap returned
+  // 1000 rows of which 994 were dead. The old rule accepted any `.order(` and passed it.
+  it('FLAGS a select ordered by a _human display string — that is not a recency bound', () => {
+    const src = `await sb.from('v_active_sessions').select('session_id, metadata').order('heartbeat_age_human', { ascending: true });`;
+    const hits = extractUnboundedLivenessSelects(src);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].table).toBe('v_active_sessions');
+  });
+
+  it('FLAGS a select ordered by an unrelated column (session_id orders the page arbitrarily)', () => {
+    const src = `await sb.from('claude_sessions').select('session_id, metadata').order('session_id');`;
+    expect(extractUnboundedLivenessSelects(src)).toHaveLength(1);
+  });
+
+  it('orderIsRecencyBound: accepts real recency columns, rejects display strings and other columns', () => {
+    expect(orderIsRecencyBound(`.order('heartbeat_at', { ascending: false })`)).toBe(true);
+    expect(orderIsRecencyBound(`.order('heartbeat_age_seconds', { ascending: true })`)).toBe(true);
+    expect(orderIsRecencyBound(`.order("created_at")`)).toBe(true);
+    expect(orderIsRecencyBound(`.order('heartbeat_age_human')`)).toBe(false);
+    expect(orderIsRecencyBound(`.order('session_id')`)).toBe(false);
+    expect(orderIsRecencyBound(`.select('session_id')`)).toBe(false);
   });
 
   it('does NOT flag a select bounded by .gte(heartbeat_at) or .limit()', () => {

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -2,6 +2,14 @@
  * SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-A — fleet panel route unit tests.
  * Calls the exported handler directly with mock req/res (no supertest, no live DB) --
  * the injected req.app.locals.supabase seam mirrors server/routes/ventures.js's own pattern.
+ *
+ * QF-20260725-423 extended these to cover the liveness filter. The mock below is now a
+ * CHAINABLE builder rather than `select().order()` returning a promise directly: the route
+ * builds `.select().order().limit()` and conditionally `.lt()`, so a mock that resolves at
+ * `.order()` would throw "limit is not a function" and never exercise the real path. The
+ * builder also RECORDS the calls, so the tests can assert the query was ordered by the
+ * numeric `heartbeat_age_seconds` and not the display string `heartbeat_age_human` — that
+ * substitution is the actual defect, and it is invisible in the response body.
  */
 import { describe, it, expect, vi } from 'vitest';
 
@@ -20,44 +28,63 @@ function mockRes() {
   return res;
 }
 
-function mockReq(supabase) {
-  return { app: { locals: { supabase } } };
+function mockReq(supabase, query = {}) {
+  return { app: { locals: { supabase } }, query };
 }
+
+/**
+ * Chainable v_active_sessions query builder. `calls` captures what the route asked for so a
+ * test can assert on the QUERY, not just the payload. Thenable so `await query` resolves.
+ */
+function sessionsBuilder(rows, calls) {
+  const builder = {
+    select: (cols) => { calls.select = cols; return builder; },
+    order: (col, opts) => { calls.order = { col, opts }; return builder; },
+    limit: (n) => { calls.limit = n; return builder; },
+    lt: (col, value) => { calls.lt = { col, value }; return builder; },
+    then: (resolve) => resolve({ data: rows, error: null }),
+  };
+  return builder;
+}
+
+function mockSupabase(rows, calls = {}) {
+  return {
+    calls,
+    from: vi.fn((table) => {
+      if (table === 'v_active_sessions') return sessionsBuilder(rows, calls);
+      return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+    }),
+  };
+}
+
+const LIVE_WORKER = {
+  session_id: 'abc-123',
+  sd_key: 'SD-TEST-001',
+  computed_status: 'active',
+  heartbeat_age_human: '5s ago',
+  heartbeat_age_seconds: 5,
+  metadata: {
+    fleet_identity: { callsign: 'Golf-3', color: 'blue', role: 'worker' },
+    model: 'sonnet',
+    effort: 'xhigh',
+  },
+};
+
+// No callsign, no role, no model — heartbeating but identity-less. This is the ghost shape.
+const GHOST = {
+  session_id: 'ghost-1',
+  sd_key: null,
+  computed_status: 'active',
+  heartbeat_age_human: '3s ago',
+  heartbeat_age_seconds: 3,
+  metadata: {},
+};
 
 describe('GET /api/fleet-panel', () => {
   it('returns structured sessions/accountChips/attentionStrip for populated sessions', async () => {
-    const supabase = {
-      from: vi.fn((table) => {
-        if (table === 'v_active_sessions') {
-          return {
-            select: () => ({
-              order: () => Promise.resolve({
-                data: [{
-                  session_id: 'abc-123',
-                  sd_key: 'SD-TEST-001',
-                  computed_status: 'active',
-                  heartbeat_age_human: '5s ago',
-                  metadata: {
-                    fleet_identity: { callsign: 'Golf-3', color: 'blue', role: 'worker' },
-                    model: 'sonnet',
-                    effort: 'xhigh',
-                  },
-                }],
-                error: null,
-              }),
-            }),
-          };
-        }
-        if (table === 'claude_sessions') {
-          return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
-        }
-        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
-      }),
-    };
-
-    const req = mockReq(supabase);
+    const supabase = mockSupabase([LIVE_WORKER]);
     const res = mockRes();
-    await getFleetPanel(req, res);
+    await getFleetPanel(mockReq(supabase), res);
 
     expect(res.json).toHaveBeenCalledTimes(1);
     const payload = res.json.mock.calls[0][0];
@@ -78,57 +105,134 @@ describe('GET /api/fleet-panel', () => {
     expect(Array.isArray(payload.attentionStrip)).toBe(true);
   });
 
-  it('degrades missing model/effort metadata to a placeholder, never a crash', async () => {
-    const supabase = {
-      from: vi.fn((table) => {
-        if (table === 'v_active_sessions') {
-          return {
-            select: () => ({
-              order: () => Promise.resolve({
-                data: [{
-                  session_id: 'no-meta-session',
-                  sd_key: null,
-                  computed_status: 'idle',
-                  heartbeat_age_human: '1m ago',
-                  metadata: {},
-                }],
-                error: null,
-              }),
-            }),
-          };
-        }
-        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
-      }),
-    };
+  it('orders by the NUMERIC heartbeat_age_seconds, never the display string', async () => {
+    const supabase = mockSupabase([LIVE_WORKER]);
+    await getFleetPanel(mockReq(supabase), mockRes());
 
-    const req = mockReq(supabase);
+    // The original defect: ordering by heartbeat_age_human sorted "15m ago" before "5s ago".
+    expect(supabase.calls.order).toEqual({ col: 'heartbeat_age_seconds', opts: { ascending: true } });
+    expect(supabase.calls.select).toContain('heartbeat_age_seconds');
+  });
+
+  it('defaults to live-only: filters on the 1h window and reports liveOnly', async () => {
+    const supabase = mockSupabase([LIVE_WORKER]);
     const res = mockRes();
-    await getFleetPanel(req, res);
+    await getFleetPanel(mockReq(supabase), res);
+
+    expect(supabase.calls.lt).toEqual({ col: 'heartbeat_age_seconds', value: 3600 });
+    expect(res.json.mock.calls[0][0].filter).toMatchObject({ liveOnly: true, windowSeconds: 3600 });
+  });
+
+  it('?all=1 drops the liveness filter so the history stays reachable', async () => {
+    const supabase = mockSupabase([LIVE_WORKER, GHOST]);
+    const res = mockRes();
+    await getFleetPanel(mockReq(supabase, { all: '1' }), res);
+
+    // The fix FILTERS the default view; it must not destroy access to the rows behind it.
+    expect(supabase.calls.lt).toBeUndefined();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.filter.liveOnly).toBe(false);
+    expect(payload.sessions).toHaveLength(2);
+    expect(payload.filter.ghostsHidden).toBe(0);
+  });
+
+  it('?windowSeconds= overrides the window; a non-numeric value falls back to the default', async () => {
+    const custom = mockSupabase([LIVE_WORKER]);
+    const customRes = mockRes();
+    await getFleetPanel(mockReq(custom, { windowSeconds: '300' }), customRes);
+    expect(custom.calls.lt.value).toBe(300);
+    expect(customRes.json.mock.calls[0][0].filter.windowSeconds).toBe(300);
+
+    const junk = mockSupabase([LIVE_WORKER]);
+    await getFleetPanel(mockReq(junk, { windowSeconds: 'abc' }), mockRes());
+    expect(junk.calls.lt.value).toBe(3600);
+  });
+
+  it('hides identity-less ghosts by default and counts them, but keeps them under ?all=1', async () => {
+    const supabase = mockSupabase([LIVE_WORKER, GHOST]);
+    const res = mockRes();
+    await getFleetPanel(mockReq(supabase), res);
+
+    // Ghosts heartbeat, so the recency filter above cannot catch them — the absence of any
+    // identity is what separates them from a real session that is simply not stamped yet.
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.sessions.map((s) => s.session_id)).toEqual(['abc-123']);
+    expect(payload.filter.ghostsHidden).toBe(1);
+  });
+
+  it('keeps role sessions and not-yet-stamped workers, which are NOT ghosts', async () => {
+    const roleSession = {
+      session_id: 'coord-1',
+      sd_key: null,
+      computed_status: 'active',
+      heartbeat_age_human: '2s ago',
+      heartbeat_age_seconds: 2,
+      metadata: { role: 'solomon' },
+    };
+    const unstamped = {
+      session_id: 'fresh-1',
+      sd_key: null,
+      computed_status: 'active',
+      heartbeat_age_human: '1s ago',
+      heartbeat_age_seconds: 1,
+      metadata: { model: 'opus' },
+    };
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([roleSession, unstamped])), res);
 
     const payload = res.json.mock.calls[0][0];
-    expect(payload.sessions[0].model_effort).toBe('--/--');
+    expect(payload.filter.ghostsHidden).toBe(0);
+    expect(payload.sessions).toHaveLength(2);
+    // A role session reads as itself rather than as a blank row.
+    expect(payload.sessions[0]).toMatchObject({ callsign: 'solomon', identity_kind: 'solomon' });
+    // A freshly spawned worker has no callsign yet — that is honest, not a ghost.
+    expect(payload.sessions[1]).toMatchObject({ callsign: null, identity_kind: 'unstamped' });
+  });
+
+  it('reports truncated=true when the page hits the row cap, false otherwise', async () => {
+    const full = Array.from({ length: 500 }, (_, i) => ({
+      ...LIVE_WORKER,
+      session_id: `s-${i}`,
+      heartbeat_age_seconds: i,
+    }));
+    const cappedRes = mockRes();
+    await getFleetPanel(mockReq(mockSupabase(full)), cappedRes);
+    // A capped page must never be presented as the true total — that is what made 1000 rows
+    // of mostly-dead sessions read as a complete list.
+    expect(cappedRes.json.mock.calls[0][0].filter.truncated).toBe(true);
+
+    const shortRes = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), shortRes);
+    expect(shortRes.json.mock.calls[0][0].filter.truncated).toBe(false);
+  });
+
+  it('degrades missing model/effort metadata to a placeholder, never a crash', async () => {
+    // REWRITTEN for QF-20260725-423: this case previously used a row with `metadata: {}` and
+    // asserted it still rendered. Under the ghost filter such a row is hidden by default, so
+    // the row now carries a model (making it a real, not-yet-stamped session) — which is what
+    // the assertion was always about: absent model/effort must degrade, not throw.
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([{
+      session_id: 'no-meta-session',
+      sd_key: null,
+      computed_status: 'idle',
+      heartbeat_age_human: '1m ago',
+      heartbeat_age_seconds: 60,
+      metadata: { model: 'opus' },
+    }])), res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.sessions[0].model_effort).toBe('opus/--');
     expect(payload.sessions[0].callsign).toBeNull();
   });
 
   it('returns an empty attentionStrip array (not an error) when zero sessions are flagged', async () => {
-    const supabase = {
-      from: vi.fn((table) => {
-        if (table === 'v_active_sessions') {
-          return { select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) };
-        }
-        if (table === 'claude_sessions') {
-          return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
-        }
-        return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
-      }),
-    };
-
-    const req = mockReq(supabase);
     const res = mockRes();
-    await getFleetPanel(req, res);
+    await getFleetPanel(mockReq(mockSupabase([])), res);
 
     const payload = res.json.mock.calls[0][0];
     expect(payload.attentionStrip).toEqual([]);
     expect(payload.sessions).toEqual([]);
+    expect(payload.filter.truncated).toBe(false);
   });
 });


### PR DESCRIPTION
Closes QF-20260725-423 (chairman-reported).

## The measurement
`GET /api/fleet-panel` returned **1000 session rows, 6 with a heartbeat under an hour** — the chairman's primary view of the LEO application was ~0.6% signal, oldest row ~234 days stale.

## What was wrong
- **No liveness predicate.** `v_active_sessions` is "active" in name only; it carries essentially every session ever registered, and the route selected from it with no filter at all.
- **Ordered by a display string.** `heartbeat_age_human` renders as `6s ago` / `4500h ago`, so the list sorted lexicographically and read as randomly arranged. The view already exposes numeric `heartbeat_age_seconds`.
- **1000 is the PostgREST cap**, so the response was a silently truncated page presented as a complete list.

## The fix
Default to `heartbeat_age_seconds < 3600`, with `?all=1` and `?windowSeconds=` escape hatches — the history is **filtered from the default view, not destroyed**. Order by the numeric column. Explicit `PANEL_ROW_CAP=500` with `filter.truncated` reported. Identity-less ghost rows are hidden by default (they heartbeat, so recency can't catch them; only the absence of *any* identity separates them from a not-yet-stamped worker) and remain visible under `?all=1`.

The route change itself was applied live by Adam so the chairman had a usable panel same-day; this PR is the review, the tests, and the commit.

## Why the existing guard didn't catch it
`scripts/lint/fleet-liveness-select-lint.mjs` treats a chain as row-cap-safe if it contains `.order(`. That reasoning only holds when the ordering is **by a recency column** — order by a display string and the page is arbitrary, so the cap can still drop every live row. The old query had `.order(...)`, so the guard passed it.

Tightened to require a real recency column, explicitly excluding `_human` display columns (matching on `heartbeat` alone would re-admit the exact query the rule exists to reject), and corrected the doc-comment contract that stated the loose rule.

**Measured before changing:** exactly 2 additional call sites surface tree-wide, both `.order('session_id')` — the same latent shape. The lint is advisory (exit 0 without `--enforce`), so CI is unaffected. Those two are pre-existing and deliberately out of scope here.

## Tests
Route tests were rewritten around a **chainable builder mock that records the query**. Two reasons, both load-bearing:
- the old mock resolved at `.order()` and would throw `limit is not a function` against the new chain;
- asserting on the response body alone **cannot see which column was ordered** — and that substitution *is* the defect.

Covers: liveOnly default · `?all=1` · `?windowSeconds=` incl. non-numeric fallback · numeric ordering · truncation true **and** false · ghost hiding vs role/unstamped retention.

One pre-existing case was rewritten with rationale in-file: it used `metadata: {}` and asserted the row rendered, which is now precisely the ghost shape. It now carries a model (a real, not-yet-stamped session), which is what the assertion was always about — absent model/effort must degrade, not throw.

## Verification
Checked against the **live view** before writing any test: `heartbeat_age_seconds` exists and is filterable (17 live rows under 3600s), and an unfiltered page hits the 500 cap — so `truncated: true` is a real state, not a theoretical one. `npx vitest run tests/unit/server tests/unit/lint/fleet-liveness-select-lint.test.js` → **35 passed**.

The front-end (`server/public/fleet-ui/fleet-panel.js`) reads only `data.sessions`, so the added `filter` object is backward-compatible. Surfacing truncation *in the UI* is a follow-on, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)