### PR TITLE
feat(SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001): merge-blocking outbound-sink conformance ratchet

### DIFF
--- a/lib/static-analysis/call-graph-builder.js
+++ b/lib/static-analysis/call-graph-builder.js
@@ -15,11 +15,38 @@ import { resolveModulePath } from './module-resolver.js';
  *
  * @param {string[]} filePaths - Absolute paths to JS files (forward slashes)
  * @param {string} rootDir - Project root directory
+ * @param {{ allowedRoots?: string[], resolveFileUrlIdiom?: boolean }} [opts] - OPTIONAL,
+ *   opt-in only; both default to prior behavior so the two live merge-blocking gates
+ *   that call this positionally are unaffected (SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001
+ *   FR-2). The default param keeps Function.length === 2.
+ *
+ *   allowedRoots: repo-relative POSIX prefixes. When set, an edge is kept only if its
+ *   RESOLVED target lies under one of them. This is SUBGRAPH RESTRICTION, deliberately
+ *   NOT depth-bounding: hub modules (supabase client, shared utils) otherwise collapse
+ *   the graph so that nearly everything "reaches" a transport (measured: 396 modules /
+ *   201 entrypoints / ~1% precision). Depth-bounding was tested and is the wrong knob.
+ *
+ *   resolveFileUrlIdiom: also resolve `import(pathToFileURL(resolve('lit')).href)`.
+ *   MUST stay opt-in: enabling it by default would add edges (loosening the live
+ *   WIRE_CHECK_GATE) and would delete the CAUTION warnings that gate propagates.
  * @returns {{ graph: Map<string, Set<string>>, warnings: string[] }}
  */
-export function buildCallGraph(filePaths, rootDir) {
+export function buildCallGraph(filePaths, rootDir, opts = {}) {
   const graph = new Map();
   const warnings = [];
+  const allowedRoots = Array.isArray(opts.allowedRoots) && opts.allowedRoots.length > 0
+    ? opts.allowedRoots.map((r) => r.replace(/\\/g, '/').replace(/\/+$/, ''))
+    : null;
+  const rootPrefix = String(rootDir || '').replace(/\\/g, '/').replace(/\/+$/, '');
+
+  /** Keep an edge only when its resolved target is inside the declared subgraph. */
+  const withinAllowedRoots = (resolvedAbs) => {
+    if (!allowedRoots) return true;
+    const relPath = rootPrefix && resolvedAbs.startsWith(`${rootPrefix}/`)
+      ? resolvedAbs.slice(rootPrefix.length + 1)
+      : resolvedAbs;
+    return allowedRoots.some((root) => relPath === root || relPath.startsWith(`${root}/`));
+  };
 
   for (const filePath of filePaths) {
     const normalizedPath = filePath.replace(/\\/g, '/');
@@ -47,21 +74,23 @@ export function buildCallGraph(filePaths, rootDir) {
       continue;
     }
 
+    const add = (specifier) => addEdge(edges, specifier, filePath, rootDir, opts, withinAllowedRoots);
+
     // Walk top-level nodes for import/export declarations and require() calls
     for (const node of ast.body) {
       // ESM: import ... from 'source'
       if (node.type === 'ImportDeclaration' && node.source?.value) {
-        addEdge(edges, node.source.value, filePath, rootDir);
+        add(node.source.value);
       }
 
       // ESM: export * from 'source' (barrel exports)
       if (node.type === 'ExportAllDeclaration' && node.source?.value) {
-        addEdge(edges, node.source.value, filePath, rootDir);
+        add(node.source.value);
       }
 
       // ESM: export { ... } from 'source' (re-exports)
       if (node.type === 'ExportNamedDeclaration' && node.source?.value) {
-        addEdge(edges, node.source.value, filePath, rootDir);
+        add(node.source.value);
       }
     }
 
@@ -70,9 +99,21 @@ export function buildCallGraph(filePaths, rootDir) {
     // are resolved as edges. Non-literal ones (e.g. `import(dynamicVar)`) surface a
     // CAUTION so operators can audit them without blocking the gate.
     walkForDynamicEdges(ast, {
-      onRequire: (specifier) => addEdge(edges, specifier, filePath, rootDir),
-      onDynamicImport: (specifier) => addEdge(edges, specifier, filePath, rootDir),
-      onNonLiteralDynamicImport: () => {
+      onRequire: (specifier) => add(specifier),
+      onDynamicImport: (specifier) => add(specifier),
+      onNonLiteralDynamicImport: (sourceNode) => {
+        // OPT-IN (opts.resolveFileUrlIdiom): recover the very common
+        // `import(pathToFileURL(resolve('lib/x.js')).href)` shape, whose source is a
+        // computed MemberExpression and therefore "non-literal". Off by default so the
+        // live WIRE_CHECK_GATE keeps both its edge set AND these CAUTION warnings.
+        if (opts.resolveFileUrlIdiom) {
+          const literal = extractFileUrlIdiomLiteral(sourceNode);
+          if (literal !== null) {
+            // resolve('lib/x.js') is repo-root-relative, so resolve against rootDir.
+            addEdge(edges, `./${literal.replace(/^\.?\//, '')}`, `${rootPrefix}/_`, rootDir, opts, withinAllowedRoots);
+            return;
+          }
+        }
         warnings.push(`${normalizedPath}: non-literal dynamic import() detected — reachability may be incomplete (CAUTION)`);
       }
     });
@@ -83,12 +124,44 @@ export function buildCallGraph(filePaths, rootDir) {
 
 /**
  * Add a resolved edge to the edge set.
+ *
+ * `opts` and `withinAllowedRoots` are optional and default to prior behavior, so
+ * the two internal call shapes stay equivalent when no options are supplied.
  */
-function addEdge(edges, specifier, fromFile, rootDir) {
-  const resolved = resolveModulePath(specifier, fromFile, rootDir);
-  if (resolved) {
-    edges.add(resolved);
+function addEdge(edges, specifier, fromFile, rootDir, opts = {}, withinAllowedRoots = null) {
+  const resolved = resolveModulePath(specifier, fromFile, rootDir, {
+    allowFileUrl: Boolean(opts.resolveFileUrlIdiom),
+  });
+  if (!resolved) return;
+  if (withinAllowedRoots && !withinAllowedRoots(resolved)) return;
+  edges.add(resolved);
+}
+
+/**
+ * Recover the string literal from `pathToFileURL(<lit>).href` or
+ * `pathToFileURL(resolve(<lit>)).href` (also tolerating `join`/`path.resolve`).
+ * Returns the literal, or null when the node is not that idiom.
+ *
+ * Measured: every occurrence of this idiom in the comms subgraph uses exactly this
+ * shape, so a targeted match covers 100% of live sites without a general evaluator.
+ */
+function extractFileUrlIdiomLiteral(sourceNode) {
+  if (!sourceNode || sourceNode.type !== 'MemberExpression') return null;
+  if (sourceNode.property?.name !== 'href') return null;
+
+  const call = sourceNode.object;
+  const calleeName = (node) => node?.callee?.name || node?.callee?.property?.name || null;
+  if (call?.type !== 'CallExpression' || calleeName(call) !== 'pathToFileURL') return null;
+
+  const arg = call.arguments?.[0];
+  if (arg?.type === 'Literal' && typeof arg.value === 'string') return arg.value;
+
+  // pathToFileURL(resolve('lit')) / pathToFileURL(path.join('lit'))
+  if (arg?.type === 'CallExpression' && ['resolve', 'join'].includes(calleeName(arg))) {
+    const inner = arg.arguments?.[0];
+    if (inner?.type === 'Literal' && typeof inner.value === 'string') return inner.value;
   }
+  return null;
 }
 
 /**
@@ -119,7 +192,9 @@ function walkForDynamicEdges(node, handlers) {
     if (src?.type === 'Literal' && typeof src.value === 'string') {
       handlers.onDynamicImport?.(src.value);
     } else {
-      handlers.onNonLiteralDynamicImport?.();
+      // Pass the source node so an opt-in handler can recognize known computed
+      // shapes (e.g. the pathToFileURL idiom) instead of only counting them.
+      handlers.onNonLiteralDynamicImport?.(src);
     }
   }
 

--- a/lib/static-analysis/module-resolver.js
+++ b/lib/static-analysis/module-resolver.js
@@ -7,6 +7,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 /** Extensions to try when resolving bare specifiers */
 const EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.tsx'];
@@ -19,16 +20,37 @@ const INDEX_FILES = ['index.js', 'index.mjs', 'index.ts', 'index.tsx'];
  * @param {string} importPath - The import/require specifier (e.g. './foo', '../bar')
  * @param {string} fromFile - Absolute path of the file containing the import
  * @param {string} rootDir - Project root directory
+ * @param {{ allowFileUrl?: boolean }} [opts] - OPTIONAL, opt-in only.
+ *   allowFileUrl: resolve `file://` specifiers (produced by the
+ *   `pathToFileURL(resolve(LIT)).href` idiom). Defaults FALSE so every existing
+ *   positional caller keeps byte-identical behavior — see
+ *   SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001 FR-2, which requires this to be
+ *   opt-in because enabling it by default would loosen the live merge-blocking
+ *   WIRE_CHECK_GATE. Note the default param keeps Function.length === 3.
  * @returns {string|null} Absolute resolved path or null if not found
  */
-export function resolveModulePath(importPath, fromFile, rootDir) {
-  // Skip bare specifiers (npm packages) — they are not project files
-  if (!importPath.startsWith('.') && !importPath.startsWith('/')) {
-    return null;
+export function resolveModulePath(importPath, fromFile, rootDir, opts = {}) {
+  let specifier = importPath;
+
+  // OPT-IN: file:// URL specifiers. Off by default (see opts.allowFileUrl above).
+  if (opts.allowFileUrl && specifier.startsWith('file://')) {
+    try {
+      specifier = fileURLToPath(specifier);
+    } catch {
+      return null;
+    }
+    const normalizedAbs = specifier.replace(/\\/g, '/');
+    return fs.existsSync(specifier) && fs.statSync(specifier).isFile() ? normalizedAbs : null;
   }
 
+  // Skip bare specifiers (npm packages) — they are not project files
+  if (!specifier.startsWith('.') && !specifier.startsWith('/')) {
+    return null;
+  }
+  const importPathResolved = specifier;
+
   const fromDir = path.dirname(fromFile);
-  const basePath = path.resolve(fromDir, importPath);
+  const basePath = path.resolve(fromDir, importPathResolved);
 
   // Normalize to forward slashes for consistency
   const normalize = (p) => p.replace(/\\/g, '/');

--- a/lib/static-analysis/reachability-checker.js
+++ b/lib/static-analysis/reachability-checker.js
@@ -56,3 +56,71 @@ export function checkReachability(graph, entryPoints, targetFiles) {
 
   return { reachable, unreachable };
 }
+
+/**
+ * Reachability WITH the chain that reached each target.
+ * SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001 FR-2 — the PRIMARY extension.
+ *
+ * checkReachability() above answers only "is this target reachable"; it keeps no
+ * predecessor information, so a conformance census cannot report WHICH import
+ * chain reaches an outbound sink. This is a SEPARATE export rather than a new
+ * parameter so checkReachability() stays byte-identical (and its arity stays 3)
+ * for the two live merge-blocking gates that call it positionally.
+ *
+ * @param {Map<string, Set<string>>} graph - Dependency graph (file -> Set<dependencies>)
+ * @param {string[]} entryPoints - Absolute paths of entry point files (forward slashes)
+ * @param {string[]} targetFiles - Absolute paths of files to check reachability for
+ * @returns {{ reachable: Set<string>, unreachable: Set<string>, chains: Map<string, string[]> }}
+ *   chains maps each REACHABLE target to the entry-point-first path that reached it.
+ */
+export function checkReachabilityWithChains(graph, entryPoints, targetFiles) {
+  const norm = (p) => p.replace(/\\/g, '/');
+  const predecessor = new Map();
+  const visited = new Set();
+  const queue = [];
+
+  for (const entry of entryPoints) {
+    const n = norm(entry);
+    if (!visited.has(n)) {
+      visited.add(n);
+      predecessor.set(n, null); // null marks an entry point (chain terminus)
+      queue.push(n);
+    }
+  }
+
+  // BFS. `visited` also terminates cycles, so a cyclic graph cannot loop forever.
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const neighbors = graph.get(current);
+    if (!neighbors) continue;
+    for (const neighbor of neighbors) {
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        predecessor.set(neighbor, current);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  const reachable = new Set();
+  const unreachable = new Set();
+  const chains = new Map();
+
+  for (const target of targetFiles) {
+    const n = norm(target);
+    if (!visited.has(n)) {
+      unreachable.add(n);
+      continue;
+    }
+    reachable.add(n);
+    // Walk predecessors back to the entry point, then reverse to entry-point-first.
+    const chain = [];
+    for (let hop = n; hop !== null && hop !== undefined; hop = predecessor.get(hop)) {
+      chain.push(hop);
+      if (predecessor.get(hop) === null) break;
+    }
+    chains.set(n, chain.reverse());
+  }
+
+  return { reachable, unreachable, chains };
+}

--- a/tests/unit/outbound-sink-conformance.test.js
+++ b/tests/unit/outbound-sink-conformance.test.js
@@ -1,0 +1,287 @@
+/**
+ * Outbound sink conformance census — SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001.
+ *
+ * THE DEFECT CLASS: a protective check wired at the LEAF-CALLER layer is
+ * absent-by-default on every chairman-reaching sink added afterward, while
+ * module-layer checks are inherited automatically. Measured on origin/main:
+ * execute-vs-escalate is imported by 6 lib modules, consequence-classifier by 2,
+ * but should-consult-solomon by 0 lib modules — it is the only leaf-placed check
+ * and the only one that failed to reach the chairman lane.
+ *
+ * THIS IS A RATCHET, NOT A CONFORMANCE ASSERTION — and that distinction is
+ * load-bearing. `.github/workflows/unit-tier.yml` triggers on pull_request with NO
+ * paths filter, and "Run Unit Tier (quarantine-aware)" is the SOLE entry in
+ * required_status_checks.contexts with enforce_admins=true. A test that is red from
+ * PRE-EXISTING tree state would therefore fail EVERY pull request repo-wide,
+ * regardless of what that PR touches, and could not be admin-overridden. So every
+ * currently-non-conformant sink is SEEDED into KNOWN_DEBT below and this suite ships
+ * GREEN; it fires only when a NEW non-conformant sink appears, or when a debt entry
+ * goes stale. Same shape as tests/unit/session-coordination-consumption-census.test.js,
+ * which seeded its 12 pre-existing sites and shipped green.
+ *
+ * HONEST LIMIT — do not read more into a green run than this. Allowlists are
+ * editable and an agent that writes a sink can also write the allowlist. What this
+ * buys is converting SILENT omission into VISIBLE, DIFFED, ATTRIBUTABLE omission.
+ * It is not bypass-proof. In particular, recall is measured against a KNOWN sink
+ * list, not the true send population: at least three real sends use raw fetch,
+ * import nothing, and are therefore structurally invisible to import-graph
+ * traversal (see NOT_A_SINK).
+ *
+ * PURITY: imports only vitest + node builtins + the static-analysis primitives.
+ * It never imports a scanned file (their top-level requires have side effects) and
+ * never imports the wire-check gates (they pull child_process/repo-paths at module
+ * scope, which would drag env/DB into the no-DB `unit` tier).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildCallGraph } from '../../lib/static-analysis/call-graph-builder.js';
+import { checkReachabilityWithChains } from '../../lib/static-analysis/reachability-checker.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const SELF_BASENAME = 'outbound-sink-conformance.test.js';
+
+/** Subgraph roots for SINK DISCOVERY. Deliberately narrow: unrestricted traversal
+ *  collapses through hub modules (measured 396 modules / 201 entrypoints, ~1%
+ *  precision). Depth-bounding was tested and is the wrong knob. */
+const DISCOVERY_ROOTS = [
+  'lib/comms',
+  'lib/chairman',
+  'lib/notifications',
+  'lib/adam',
+  'lib/messaging',
+  'lib/coordinator/adam-outbound-gate.js',
+];
+
+/** In-scope paths that lie OUTSIDE the discovery roots. Carried explicitly rather
+ *  than by widening the roots, which would reintroduce the hub-escape collapse. */
+const ADDITIONAL_SCOPE = [
+  { path: 'lib/integrations/todoist/chairman-notify.js', reason: 'Third outbound channel (Todoist) reached from the chairman lane; emits via raw fetch, so it is both a target and in-scope.' },
+  { path: 'lib/switch-automation/switchon-decision-packet.js', reason: 'Lib-layer originator of the second decision-packet stack; missed entirely if only entrypoints are enumerated.' },
+  { path: 'scripts/adam-decision-email.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom.' },
+  { path: 'scripts/adam-exec-summary.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom.' },
+  { path: 'scripts/adam-heartbeat-email.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom.' },
+];
+
+/** The real emitters. A module is a "sink" when it can reach one of these. */
+const TRANSPORT_TARGETS = [
+  'lib/messaging/providers/twilio-provider.js',
+  'lib/notifications/resend-adapter.js',
+  'lib/integrations/todoist/chairman-notify.js',
+];
+
+/** The protective check whose leaf placement caused the defect class. */
+const CONSULT_GATE = 'lib/adam/should-consult-solomon.js';
+
+/** NOT sinks. Kept strictly separate from KNOWN_DEBT so real debt can never be
+ *  laundered as "not a sink". */
+const NOT_A_SINK = [
+  { path: 'api/webhooks/twilio-sms.js', reason: 'INBOUND Twilio webhook, not an outbound sink. The single known false positive of the traversal.' },
+  { path: 'lib/marketing/ai/email-campaigns.js', reason: 'Sends via raw fetch to api.resend.com and imports nothing from lib/notifications, so it is structurally invisible to import-graph traversal. Named so the census never implies coverage it lacks.' },
+  { path: 'lib/services/sovereign-alert.js', reason: 'Sends via raw fetch to api.resend.com and imports nothing; structurally invisible to import-graph traversal.' },
+];
+
+/**
+ * Pre-existing non-conformant sinks — chairman-reaching modules that can reach an
+ * outbound transport WITHOUT inheriting the consult gate. Seeded from a measured run
+ * of this census against the tree at authoring time, so the suite ships GREEN and
+ * fires only on drift. This is the "visible, diffed, attributable" record the SD
+ * exists to produce: before this list existed, none of these was discoverable.
+ *
+ * This list is SHRINK-ONLY. Remediating any entry means wiring the consult gate into
+ * that module, deleting its line here, and LOWERING the ceiling below.
+ * Remediation itself is out of scope for this SD (it is a behavior change to live
+ * chairman comms); C4, the runtime gate-verdict envelope, is the deferred follow-on
+ * that constrains the transports themselves.
+ */
+const KNOWN_DEBT = [
+  { path: 'lib/adam/stall-alert.js', reason: 'Reaches a transport without the consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/chairman/record-pending-decision.mjs', reason: 'LIB-LAYER originator reaching a transport without the consult gate; invisible to grep because it holds no transport literal.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/chairman/sms-bridge.js', reason: 'Static import of the Twilio provider, no consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/chairman/sms-channel-health.js', reason: 'Reaches the SMS transport without the consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/chairman/sms-outbound-worker.js', reason: 'Static import of the Twilio provider, no consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/comms/adam-outbound/chairman-sms-gate/index.js', reason: 'Reaches the email transport via a literal dynamic import, no consult gate — and its own comment notes the gate "was absent here".', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/comms/adam-outbound/decision-scheduler/index.js', reason: 'Reaches a transport without the consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/notifications/channel-health-recorder.js', reason: 'Reaches the email transport without the consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/notifications/orchestrator.js', reason: 'Static consumer of the Resend adapter, no consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/notifications/scheduler.js', reason: 'Reaches the email transport without the consult gate. Pre-existing at census authoring.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'lib/switch-automation/switchon-decision-packet.js', reason: 'LIB-LAYER originator of the second decision-packet stack; missed entirely by entrypoint-only enumeration.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'scripts/adam-decision-email.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom; invisible to the census until that idiom was resolved.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'scripts/adam-exec-summary.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+  { path: 'scripts/adam-heartbeat-email.mjs', reason: 'Reaches the email transport only via the pathToFileURL dynamic-import idiom.', linked_ref: 'SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001' },
+];
+/** Committed ceiling — the ratchet. Never raise this; lowering it is the point. */
+const KNOWN_DEBT_CEILING = 14;
+
+const toPosix = (p) => p.replace(/\\/g, '/');
+const relPosix = (abs) => toPosix(path.relative(REPO_ROOT, abs));
+
+/** Recursively collect source files under a repo-relative dir (or return the file itself). */
+function collectFiles(relRoot) {
+  const abs = path.join(REPO_ROOT, relRoot);
+  if (!fs.existsSync(abs)) return [];
+  if (fs.statSync(abs).isFile()) return [toPosix(abs)];
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Explicit skips so developer scratch dirs cannot cause local-only failures.
+        if (['node_modules', '.git', '.worktrees'].includes(entry.name) || entry.name.startsWith('.')) continue;
+        walk(full);
+      } else if (/\.(js|mjs|cjs)$/.test(entry.name) && !/\.(test|spec)\.(js|mjs|cjs)$/.test(entry.name)) {
+        // Test/spec files are excluded by CLASS, not by allowlist: a test that
+        // imports a transport is exercising it, not emitting to the chairman.
+        // Measured: including them cost 2 false positives (the lib/chairman/__tests__
+        // SMS specs) and dropped precision from ~100% to ~90%.
+        out.push(toPosix(full));
+      }
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+/**
+ * Run the census. Returns non-conformant sinks as sorted repo-relative POSIX paths.
+ * @param {{ ignoreKnownDebt?: boolean }} [opts] ignoreKnownDebt proves the detector fires.
+ */
+function runCensus(opts = {}) {
+  const scopeRoots = [...DISCOVERY_ROOTS, ...ADDITIONAL_SCOPE.map((e) => e.path)];
+  const files = [...new Set(scopeRoots.flatMap(collectFiles))].sort();
+
+  // Subgraph-restricted so hub modules cannot collapse the graph, and opt into the
+  // pathToFileURL idiom so the three scripts/adam-*.mjs sites are visible at all.
+  const { graph } = buildCallGraph(files, REPO_ROOT, {
+    resolveFileUrlIdiom: true,
+  });
+
+  const abs = (rel) => toPosix(path.join(REPO_ROOT, rel));
+  const targets = TRANSPORT_TARGETS.map(abs).filter((p) => fs.existsSync(p));
+  const gateAbs = abs(CONSULT_GATE);
+
+  const notASink = new Set(NOT_A_SINK.map((e) => e.path));
+  const debt = new Set(opts.ignoreKnownDebt ? [] : KNOWN_DEBT.map((e) => e.path));
+  // The transports (and the barrel that re-exports one) are the EMITTERS, not
+  // callers of an emitter. The consult gate belongs on the code that decides to
+  // send, so a transport "reaching itself" is a self-edge artifact, not a finding.
+  // C4 (deferred to a follow-on SD) is what constrains the transports themselves.
+  const isTransportItself = new Set([...TRANSPORT_TARGETS, 'lib/notifications/index.js']);
+
+  const sinks = [];
+  const nonConformant = [];
+
+  for (const file of files) {
+    const rel = relPosix(file);
+    if (rel === relPosix(gateAbs)) continue; // the gate itself is not a sink
+    if (isTransportItself.has(rel)) continue;
+    const { reachable } = checkReachabilityWithChains(graph, [file], targets);
+    if (reachable.size === 0) continue;
+    if (notASink.has(rel)) continue;
+    sinks.push(rel);
+
+    const { reachable: gateReach } = checkReachabilityWithChains(graph, [file], [gateAbs]);
+    if (gateReach.size === 0 && !debt.has(rel)) nonConformant.push(rel);
+  }
+
+  return { sinks: sinks.sort(), nonConformant: nonConformant.sort() };
+}
+
+describe('outbound sink conformance — ratchet', () => {
+  it('discovers a non-empty sink set (guards against a vacuously-passing census)', () => {
+    const { sinks } = runCensus();
+    expect(sinks.length).toBeGreaterThan(0);
+  });
+
+  it('resolves every discovery root and additional-scope path on disk', () => {
+    const missing = [...DISCOVERY_ROOTS, ...ADDITIONAL_SCOPE.map((e) => e.path)]
+      .filter((rel) => !fs.existsSync(path.join(REPO_ROOT, rel)));
+    expect(missing).toEqual([]);
+  });
+
+  it('finds the transport targets in scope', () => {
+    const present = TRANSPORT_TARGETS.filter((rel) => fs.existsSync(path.join(REPO_ROOT, rel)));
+    expect(present.sort()).toEqual([...TRANSPORT_TARGETS].sort());
+  });
+
+  it('RATCHET: no NEW chairman-reaching sink lacks the consult gate', () => {
+    const { nonConformant } = runCensus();
+    // If this fails, either wire the consult gate into the listed module, or add a
+    // KNOWN_DEBT entry with a real reason + linked_ref. Do NOT add it to NOT_A_SINK.
+    expect(nonConformant).toEqual([]);
+  });
+
+  it('DETECTION PROOF: with KNOWN_DEBT ignored, the census still reports non-conformant sinks by name', () => {
+    // Guards the detector against being neutered into a no-op (TEST-MASKING).
+    const seeded = runCensus({ ignoreKnownDebt: true });
+    if (KNOWN_DEBT.length > 0) {
+      expect(seeded.nonConformant.length).toBeGreaterThan(0);
+      for (const entry of KNOWN_DEBT) expect(seeded.nonConformant).toContain(entry.path);
+    } else {
+      // No debt seeded: the tree is fully conformant, so the detector has nothing to
+      // report. Still assert it produced a real sink set rather than silently nothing.
+      expect(seeded.sinks.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('allowlist integrity', () => {
+  it('every NOT_A_SINK and ADDITIONAL_SCOPE entry carries a non-empty reason', () => {
+    const bad = [...NOT_A_SINK, ...ADDITIONAL_SCOPE].filter((e) => !e.reason || !e.reason.trim());
+    expect(bad).toEqual([]);
+  });
+
+  it('every KNOWN_DEBT entry carries a non-empty reason and a linked_ref', () => {
+    const bad = KNOWN_DEBT.filter((e) => !e.reason || !e.reason.trim() || !e.linked_ref || !e.linked_ref.trim());
+    expect(bad).toEqual([]);
+  });
+
+  it('KNOWN_DEBT is shrink-only: length stays at or below the committed ceiling', () => {
+    expect(KNOWN_DEBT.length).toBeLessThanOrEqual(KNOWN_DEBT_CEILING);
+  });
+
+  it('KNOWN_DEBT and NOT_A_SINK are disjoint — debt cannot be laundered as not-a-sink', () => {
+    const notSink = new Set(NOT_A_SINK.map((e) => e.path));
+    expect(KNOWN_DEBT.filter((e) => notSink.has(e.path))).toEqual([]);
+  });
+
+  it('no allowlist entry is stale — every listed path still exists', () => {
+    const stale = [...NOT_A_SINK, ...KNOWN_DEBT, ...ADDITIONAL_SCOPE]
+      .map((e) => e.path)
+      .filter((rel) => !fs.existsSync(path.join(REPO_ROOT, rel)));
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('self-protection — this census cannot be silently disabled', () => {
+  it('is not listed in the vitest quarantine manifest', () => {
+    const manifestPath = path.join(REPO_ROOT, 'tests', 'quarantine-manifest.json');
+    if (!fs.existsSync(manifestPath)) return; // fail-soft, same as loadQuarantineExclude
+    const raw = fs.readFileSync(manifestPath, 'utf8');
+    let manifest;
+    // Assert it parses rather than letting a raw SyntaxError surface: the loader is
+    // fail-soft, so a malformed manifest would silently quarantine nothing.
+    expect(() => { manifest = JSON.parse(raw); }).not.toThrow();
+    const entries = Array.isArray(manifest?.quarantined) ? manifest.quarantined : [];
+    // BASENAME-strict: the loader maps each entry to the suffix glob `**/${file}`,
+    // so a differently-pathed same-filename entry would still disable this file.
+    const hits = entries.filter((e) => path.basename(String(e?.file || '')) === SELF_BASENAME);
+    expect(hits).toEqual([]);
+  });
+
+  it('keeps the .test.js extension required by the unit project include globs', () => {
+    // A .test.mjs is NOT collected outside tests/unit/org/ and tests/unit/venture-email/,
+    // so renaming the extension would silently disable this census.
+    expect(SELF_BASENAME.endsWith('.test.js')).toBe(true);
+    expect(fs.existsSync(path.join(HERE, SELF_BASENAME))).toBe(true);
+  });
+
+  it('is not excluded by the vitest config', () => {
+    const configPath = path.join(REPO_ROOT, 'vitest.config.js');
+    if (!fs.existsSync(configPath)) return;
+    const config = fs.readFileSync(configPath, 'utf8');
+    expect(config).not.toContain(SELF_BASENAME);
+  });
+});

--- a/tests/unit/static-analysis/call-graph-characterization.test.js
+++ b/tests/unit/static-analysis/call-graph-characterization.test.js
@@ -1,0 +1,213 @@
+/**
+ * Characterization tests for lib/static-analysis primitives.
+ * SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001 (FR-2, TS-4).
+ *
+ * WHY THIS FILE EXISTS: buildCallGraph / checkReachability / resolveModulePath had
+ * ZERO direct test coverage, yet two LIVE merge-blocking gates depend on them —
+ * scripts/modules/handoff/executors/exec-to-plan/gates/wire-check-advisory.js and
+ * .../lead-final-approval/gates/wire-check-gate.js. Both call them STRICTLY
+ * POSITIONALLY and both read `warnings.length` into their returned payload. So
+ * before extending the primitives we pin present-day behavior, including the exact
+ * warning strings and the function arities. Any future extension that changes
+ * default behavior breaks these tests loudly instead of silently loosening a gate.
+ *
+ * DETERMINISM (TR-5): CI is ubuntu-latest, development is win32. Every assertion
+ * is on SORTED repo-relative POSIX paths — never absolute paths (Windows
+ * drive-letter casing varies with cwd) and never Set identity (readdirSync order
+ * is not filesystem-guaranteed).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildCallGraph } from '../../../lib/static-analysis/call-graph-builder.js';
+import { checkReachability } from '../../../lib/static-analysis/reachability-checker.js';
+import { resolveModulePath } from '../../../lib/static-analysis/module-resolver.js';
+
+/** Normalize an absolute path to a sorted-comparable POSIX path relative to the fixture root. */
+function rel(root, abs) {
+  return path.relative(root, abs).replace(/\\/g, '/');
+}
+
+/** Serialize a graph deterministically: sorted keys, sorted edge arrays, relative POSIX paths. */
+function serializeGraph(root, graph) {
+  const out = {};
+  for (const [file, edges] of graph) {
+    out[rel(root, file)] = [...edges].map((e) => rel(root, e)).sort();
+  }
+  return Object.fromEntries(Object.entries(out).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+let ROOT;
+const FILES = {};
+
+beforeAll(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'cgb-char-'));
+  const w = (relPath, src) => {
+    const abs = path.join(ROOT, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, src, 'utf8');
+    FILES[relPath] = abs.replace(/\\/g, '/');
+    return FILES[relPath];
+  };
+
+  // Static ESM import + a bare npm specifier (bare must NOT become an edge).
+  w('entry.js', "import './barrel.js';\nimport 'acorn';\nimport './leaf-a.js';\n");
+  // Barrel re-export forms: export * from and export { x } from.
+  w('barrel.js', "export * from './leaf-b.js';\nexport { thing } from './leaf-c.js';\n");
+  w('leaf-a.js', 'export const a = 1;\n');
+  w('leaf-b.js', 'export const b = 2;\n');
+  w('leaf-c.js', 'export const thing = 3;\n');
+  // CJS require with a string literal.
+  w('cjs-consumer.cjs', "const x = require('./leaf-a.js');\nmodule.exports = x;\n");
+  // Literal dynamic import() — resolves to a real edge.
+  w('dyn-literal.js', "export async function go() { return import('./leaf-b.js'); }\n");
+  // NON-literal dynamic import() — must produce a CAUTION warning and NO edge.
+  w('dyn-variable.js', 'export async function go(spec) { return import(spec); }\n');
+  // Unparseable source — must produce a Parse error warning.
+  w('broken.js', 'export const = ;;;\n');
+  // Directory import resolving through index.js.
+  w('pkg/index.js', 'export const p = 4;\n');
+  w('dir-import.js', "import './pkg';\n");
+});
+
+afterAll(() => {
+  if (ROOT) fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('buildCallGraph — characterization of present-day behavior', () => {
+  it('pins the resolved edge set as a golden sorted snapshot', () => {
+    const inputs = [
+      FILES['entry.js'], FILES['barrel.js'], FILES['leaf-a.js'], FILES['leaf-b.js'],
+      FILES['leaf-c.js'], FILES['cjs-consumer.cjs'], FILES['dyn-literal.js'],
+      FILES['dir-import.js'], FILES['pkg/index.js'],
+    ];
+    const { graph } = buildCallGraph(inputs, ROOT);
+
+    expect(serializeGraph(ROOT, graph)).toEqual({
+      'barrel.js': ['leaf-b.js', 'leaf-c.js'],
+      'cjs-consumer.cjs': ['leaf-a.js'],
+      'dir-import.js': ['pkg/index.js'],
+      'dyn-literal.js': ['leaf-b.js'],
+      'entry.js': ['barrel.js', 'leaf-a.js'],
+      'leaf-a.js': [],
+      'leaf-b.js': [],
+      'leaf-c.js': [],
+      'pkg/index.js': [],
+    });
+  });
+
+  it('resolves a LITERAL dynamic import to an edge and emits no warning', () => {
+    const { graph, warnings } = buildCallGraph([FILES['dyn-literal.js']], ROOT);
+    expect([...graph.get(FILES['dyn-literal.js'])].map((e) => rel(ROOT, e))).toEqual(['leaf-b.js']);
+    expect(warnings).toEqual([]);
+  });
+
+  it('emits the exact CAUTION warning for a NON-literal dynamic import and adds no edge', () => {
+    const { graph, warnings } = buildCallGraph([FILES['dyn-variable.js']], ROOT);
+    expect([...graph.get(FILES['dyn-variable.js'])]).toEqual([]);
+    // Both live consumers read warnings.length, so pin count AND text.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toBe(
+      `${FILES['dyn-variable.js']}: non-literal dynamic import() detected — reachability may be incomplete (CAUTION)`,
+    );
+  });
+
+  it('emits a Parse error warning for unparseable source, still registering an empty edge set', () => {
+    const { graph, warnings } = buildCallGraph([FILES['broken.js']], ROOT);
+    expect(graph.has(FILES['broken.js'])).toBe(true);
+    expect([...graph.get(FILES['broken.js'])]).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^Parse error in .*broken\.js: /);
+  });
+
+  it('emits a Could-not-read warning for a missing path, still registering an empty edge set', () => {
+    const missing = path.join(ROOT, 'does-not-exist.js').replace(/\\/g, '/');
+    const { graph, warnings } = buildCallGraph([missing], ROOT);
+    expect(graph.has(missing)).toBe(true);
+    expect([...graph.get(missing)]).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^Could not read .*does-not-exist\.js: /);
+  });
+
+  it('does not create edges for bare npm specifiers', () => {
+    const { graph } = buildCallGraph([FILES['entry.js']], ROOT);
+    const edges = [...graph.get(FILES['entry.js'])].map((e) => rel(ROOT, e)).sort();
+    expect(edges).toEqual(['barrel.js', 'leaf-a.js']);
+    expect(edges.some((e) => e.includes('acorn'))).toBe(false);
+  });
+
+  it('pins arity — the live gates call these strictly positionally', () => {
+    // Guards against a future extension turning a positional param into an options bag.
+    expect(buildCallGraph.length).toBe(2);
+    expect(checkReachability.length).toBe(3);
+    expect(resolveModulePath.length).toBe(3);
+  });
+});
+
+describe('checkReachability — characterization of present-day behavior', () => {
+  it('partitions targets into reachable and unreachable via BFS from entry points', () => {
+    const inputs = [
+      FILES['entry.js'], FILES['barrel.js'], FILES['leaf-a.js'],
+      FILES['leaf-b.js'], FILES['leaf-c.js'], FILES['dyn-literal.js'],
+    ];
+    const { graph } = buildCallGraph(inputs, ROOT);
+    const { reachable, unreachable } = checkReachability(
+      graph,
+      [FILES['entry.js']],
+      [FILES['leaf-b.js'], FILES['leaf-c.js'], FILES['dyn-literal.js']],
+    );
+
+    // Sorted arrays, never Set identity (TR-5).
+    expect([...reachable].map((p) => rel(ROOT, p)).sort()).toEqual(['leaf-b.js', 'leaf-c.js']);
+    expect([...unreachable].map((p) => rel(ROOT, p)).sort()).toEqual(['dyn-literal.js']);
+  });
+
+  it('terminates on a cycle rather than looping forever', () => {
+    const cycleRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cgb-cycle-'));
+    try {
+      const a = path.join(cycleRoot, 'a.js');
+      const b = path.join(cycleRoot, 'b.js');
+      fs.writeFileSync(a, "import './b.js';\n", 'utf8');
+      fs.writeFileSync(b, "import './a.js';\n", 'utf8');
+      const { graph } = buildCallGraph([a.replace(/\\/g, '/'), b.replace(/\\/g, '/')], cycleRoot);
+      const { reachable } = checkReachability(graph, [a.replace(/\\/g, '/')], [b.replace(/\\/g, '/')]);
+      expect([...reachable].map((p) => rel(cycleRoot, p))).toEqual(['b.js']);
+    } finally {
+      fs.rmSync(cycleRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a target as unreachable when no entry point leads to it', () => {
+    const { graph } = buildCallGraph([FILES['leaf-a.js'], FILES['leaf-b.js']], ROOT);
+    const { reachable, unreachable } = checkReachability(graph, [FILES['leaf-a.js']], [FILES['leaf-b.js']]);
+    expect([...reachable]).toEqual([]);
+    expect([...unreachable].map((p) => rel(ROOT, p))).toEqual(['leaf-b.js']);
+  });
+});
+
+describe('resolveModulePath — characterization of present-day behavior', () => {
+  it('returns null for bare npm specifiers', () => {
+    expect(resolveModulePath('acorn', FILES['entry.js'], ROOT)).toBeNull();
+  });
+
+  it('returns null for a file:// URL specifier — the pathToFileURL idiom is unresolved today', () => {
+    // Pinned deliberately: FR-2 extension (c) changes THIS, and only behind an opt-in flag.
+    const url = `file:///${FILES['leaf-a.js']}`;
+    expect(resolveModulePath(url, FILES['entry.js'], ROOT)).toBeNull();
+  });
+
+  it('resolves a relative specifier lacking an extension', () => {
+    const resolved = resolveModulePath('./leaf-a', FILES['entry.js'], ROOT);
+    expect(rel(ROOT, resolved)).toBe('leaf-a.js');
+  });
+
+  it('resolves a directory specifier through its index file', () => {
+    const resolved = resolveModulePath('./pkg', FILES['dir-import.js'], ROOT);
+    expect(rel(ROOT, resolved)).toBe('pkg/index.js');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(resolveModulePath('./nope', FILES['entry.js'], ROOT)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a **census** that discovers chairman-reaching outbound sinks by subgraph-restricted import-graph traversal and asserts each inherits the `should-consult-solomon` gate. Hosted as a vitest test under the sole required status check, so it is **merge-blocking with zero branch-protection changes**.

**The defect class:** a protective check wired at the LEAF-CALLER layer is absent-by-default on every sink added afterward, while module-layer checks are inherited automatically. Measured on `main`: `execute-vs-escalate` imported by 6 lib modules, `consequence-classifier` by 2, but `should-consult-solomon` by **0** lib modules — the only leaf-placed check, and the only one that missed the chairman lane.

## It is a RATCHET, and that is load-bearing

`unit-tier.yml` triggers on `pull_request` with **no paths filter**, and its check is the **only** entry in `required_status_checks.contexts`, with `enforce_admins: true`. A census red from *pre-existing* tree state would fail **every PR repo-wide**, block its own PR, and be un-overridable even by an admin.

So the **14 currently-non-conformant sinks are seeded as visible `KNOWN_DEBT`** (`{path, reason, linked_ref}`) and this ships **GREEN**, firing only when a *new* ungated sink appears or an entry goes stale. Same shape as `tests/unit/session-coordination-consumption-census.test.js`, which seeded its 12 pre-existing sites and shipped green.

`KNOWN_DEBT` is shrink-only (committed ceiling), kept **separate** from `NOT_A_SINK` so real debt cannot be laundered as "not a sink".

## Verified, not asserted

- Adding a new ungated sink turns the census **RED naming it exactly**; removing it returns **GREEN**.
- A separate **green** test proves detection by re-running with `KNOWN_DEBT` ignored and requiring all 14 be reported by name — regression-guarding the detector against being neutered into a no-op.
- Characterization tests captured on the **unmodified** primitives first, and pass unchanged after.

## Found what grep could not

- `lib/chairman/record-pending-decision.mjs` and `lib/switch-automation/switchon-decision-packet.js` — lib-layer originators holding no transport literal.
- The three `scripts/adam-*.mjs` — reach email only via the `pathToFileURL` dynamic-import idiom.

## Primitives extended, not rebuilt

`lib/static-analysis/{call-graph-builder,reachability-checker,module-resolver}.js` already back two live merge-blocking gates and had **zero** direct coverage. Every new param is optional + trailing, so all existing positional call sites are byte-identical:

- `checkReachabilityWithChains` — NEW export carrying predecessor chains. `checkReachability` untouched, arity still 3.
- `opts.allowedRoots` — optional subgraph restriction. Unrestricted traversal collapses through hubs (396 modules / 201 entrypoints, ~1% precision); depth-bounding was tested and is the wrong knob.
- `opts.resolveFileUrlIdiom` — **OFF by default**. Enabling it by default would add edges (loosening the live `WIRE_CHECK_GATE`) and delete the three CAUTION warnings that gate propagates at `wire-check-gate.js:418-419/:483-486`.

## Precision

14/14 reported sinks are genuine. Test/spec files excluded by **class** (a test importing a transport exercises it, it does not emit) and the transports themselves excluded as self-edge artifacts — together removing 6 false positives, precision 70% → ~100%.

## Honest limit — deliberately not overclaimed

Recall is measured against a **known** sink list, not the true send population. At least three real sends use raw `fetch`, import nothing, and are structurally invisible to import-graph traversal (`lib/marketing/ai/email-campaigns.js`, `lib/services/sovereign-alert.js`) — named explicitly in `NOT_A_SINK` so the census never implies coverage it lacks.

This is **not bypass-proof**: allowlists are editable and an agent that writes a sink can write the allowlist. It converts **silent** omission into **visible, diffed, attributable** omission. Nothing more.

## Scope

C1+C2 of four components. LEAD approved at `scope_reduction_percentage=60`; **C3** (eslint literal-ban) and **C4** (runtime gate-verdict envelope) are deferred to follow-on SDs. Remediating the 14 seeded sinks is out of scope — that is a behavior change to live chairman comms.

## Test evidence

- Full unit project: **30,326 passed**. The one failing file (`golden-references/witness-emitter-acceptance.test.js`) fails **identically on unmodified main** and is unrelated.
- Targeted: 49/49 across the census + all static-analysis tests.
- `required_status_checks.contexts` unchanged; no new path-filtered required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)