### PR TITLE
fix(QF-20260725-821): Worktree reaper has no opt-OUT: any operator/drill/ops worktree without an SD-key basename and a DB claim is auto-deleted, mid-run

### DIFF
--- a/lib/worktree-reaper/reap-protected-marker.js
+++ b/lib/worktree-reaper/reap-protected-marker.js
@@ -1,0 +1,92 @@
+/**
+ * Reap-PROTECTED marker (QF-20260725-821) — the opt-OUT, symmetric counterpart to
+ * lib/worktree-reaper/reap-eligible-marker.js.
+ *
+ * WHY THIS EXISTS. LIVE INCIDENT 2026-07-25T12:20:21Z: the reaper deleted the chairman's
+ * in-flight CP3 acceptance-drill worktree (.worktrees/cp3-drill-run, branch drill/cp3-live-run)
+ * mid-run, verdict=stage2_remove reason=orphan-sd, because its basename did not resolve to an
+ * sd_key and it carried no DB claim. Before this module the reaper had exactly TWO protections —
+ * isCursorWorktree (a path pattern) and an active DB claim — so EVERY operator-created, drill,
+ * and ops worktree matched the reapable profile. The existing .reap-eligible.json marker is
+ * opt-IN TO REAPING; there was no opt-OUT of any kind, so recurrence was certain on the next
+ * 5-minute sweep.
+ *
+ * Deliberately NOT solved by fabricating a claude_sessions row or a claim to make the tree look
+ * owned — the coordinator rejected that as inventing evidence, which is the correct call.
+ *
+ * Filesystem-level by design (no DDL), matching the reap-eligible marker convention so the two
+ * markers are read the same way. Presence alone is the signal; contents are advisory metadata for
+ * a human reading the tree later.
+ *
+ * NOTE ON SCOPE: this is fix option (1) of the three the incident report ranked. Residency-based
+ * protection (option 3 — HEAD/mtime advanced recently means in use) is the general operator fix
+ * and is deliberately NOT bundled here.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export const PROTECTED_MARKER_FILENAME = '.reap-protected.json';
+
+/**
+ * Write the protection marker at the worktree root. Best-effort — a failure must never throw
+ * into a caller's flow (mirrors writeReapEligibleMarker's contract).
+ * @param {string} wtPath - worktree root
+ * @param {{ reason?: string, protected_by?: string|null, expires_at?: string|null }} [fields]
+ * @returns {{ written: boolean, markerPath: string|null, error: string|null }}
+ */
+export function writeReapProtectedMarker(wtPath, fields = {}) {
+  const markerPath = path.join(wtPath, PROTECTED_MARKER_FILENAME);
+  try {
+    const payload = {
+      reason: fields.reason ?? null,
+      protected_by: fields.protected_by ?? process.env.CLAUDE_SESSION_ID ?? null,
+      expires_at: fields.expires_at ?? null,
+      protected_at: new Date().toISOString(),
+    };
+    fs.writeFileSync(markerPath, JSON.stringify(payload, null, 2), 'utf8');
+    return { written: true, markerPath, error: null };
+  } catch (e) {
+    return { written: false, markerPath: null, error: e?.message || String(e) };
+  }
+}
+
+/**
+ * Read the marker if present and parseable.
+ * @param {string} wtPath - worktree root
+ * @returns {object|null} marker payload, or null when absent/corrupt
+ */
+export function readReapProtectedMarker(wtPath) {
+  try {
+    const raw = fs.readFileSync(path.join(wtPath, PROTECTED_MARKER_FILENAME), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the worktree is marked protected.
+ *
+ * FAIL-SAFE ASYMMETRY, on purpose: a CORRUPT marker still protects. Presence is checked with
+ * existsSync, not by parsing — the cost of honoring an unparseable marker is one un-reaped
+ * worktree, while the cost of ignoring it is deleting a tree an operator is standing in. This is
+ * the opposite bias from readReapProtectedMarker(), which returns null on corruption because its
+ * job is reporting metadata, not deciding safety.
+ *
+ * @param {string} wtPath @returns {boolean}
+ */
+export function hasReapProtectedMarker(wtPath) {
+  try {
+    return fs.existsSync(path.join(wtPath, PROTECTED_MARKER_FILENAME));
+  } catch {
+    return false;
+  }
+}
+
+export default {
+  PROTECTED_MARKER_FILENAME,
+  writeReapProtectedMarker,
+  readReapProtectedMarker,
+  hasReapProtectedMarker,
+};

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -66,6 +66,12 @@ import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
 import { liveClaimBlocksRemoval } from '../lib/worktree-reaper/live-claim-guard.js';
 import { heartbeatResidencyBlocksRemoval } from '../lib/worktree-reaper/residency-guard.js';
 import { hasReapEligibleMarker, readReapEligibleMarker } from '../lib/worktree-reaper/reap-eligible-marker.js';
+// QF-20260725-821: the opt-OUT marker. .reap-eligible.json is opt-IN TO REAPING; before this
+// there was no way to say "do not reap me", so any operator/drill/ops worktree without an
+// sd_key basename and a DB claim was auto-removed at stage 2 (live incident: the chairman's
+// in-flight CP3 drill tree, deleted mid-run). Honored at BOTH points that already honor the
+// cursor-protection convention — the main classification loop and selectStage0Reclaim.
+import { hasReapProtectedMarker, readReapProtectedMarker } from '../lib/worktree-reaper/reap-protected-marker.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
 // These three used to be defined locally below; the canonical home is now
 // lib/worktree-reapability.js so every removal path shares one implementation.
@@ -780,6 +786,7 @@ export function selectStage0Reclaim(worktrees, ctx = {}) {
   const out = [];
   for (const wt of worktrees || []) {
     if (isCursorWorktree(wt.path)) continue; // inherit cursor-protection convention
+    if (hasReapProtectedMarker(wt.path)) continue; // QF-20260725-821: opt-OUT marker (stage-0 reclaim also destroys)
     const v = classifyStage0(wt, ctx);
     if (v.reclaim) out.push({ path: wt.path, branch: wt.branch, sd_key: v.sd_key, reason: v.reason });
   }
@@ -1224,6 +1231,23 @@ export async function main(argv = process.argv) {
       records.push(rec);
       emitJsonLine(rec);
       console.log(humanTableRow({ wtPath: wt.path, branch: wt.branch || '', categories: [], dirtyCount: 0, unpushedCount: 0, ageDays: null, verdict: 'keep:cursor', preserveCount: 0 }));
+      continue;
+    }
+
+    // QF-20260725-821: opt-OUT marker. Checked immediately after the cursor guard and BEFORE any
+    // classification, so a protected tree can never reach stage1/stage2 removal regardless of
+    // whether its basename resolves to an sd_key or it carries a DB claim.
+    if (hasReapProtectedMarker(wt.path)) {
+      const rec = buildRecord({
+        schema_version: SCHEMA_VERSION, wt, categories: [], verdict: 'keep',
+        reason: 'reap_protected_marker',
+        claim_status: 'n/a', dirtyCount: 0, unpushedCount: 0, ageDays: null,
+        preserveCount: 0, shipStatus: 'protected',
+        evidence: { marker: readReapProtectedMarker(wt.path) || {} },
+      });
+      records.push(rec);
+      emitJsonLine(rec);
+      console.log(humanTableRow({ wtPath: wt.path, branch: wt.branch || '', categories: [], dirtyCount: 0, unpushedCount: 0, ageDays: null, verdict: 'keep:protected', preserveCount: 0 }));
       continue;
     }
 

--- a/tests/unit/worktree-reaper-protected-marker.test.js
+++ b/tests/unit/worktree-reaper-protected-marker.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  PROTECTED_MARKER_FILENAME,
+  writeReapProtectedMarker,
+  readReapProtectedMarker,
+  hasReapProtectedMarker,
+} from '../../lib/worktree-reaper/reap-protected-marker.js';
+
+/**
+ * QF-20260725-821 — the reaper had NO opt-out.
+ *
+ * LIVE INCIDENT 2026-07-25T12:20:21Z: .worktrees/cp3-drill-run (branch drill/cp3-live-run) was
+ * removed mid-run (verdict=stage2_remove, reason=orphan-sd) while the chairman and Adam were
+ * running the CP3 acceptance drill out of it — because its basename did not resolve to an sd_key
+ * and it held no DB claim, which is the profile of EVERY operator/drill/ops worktree. The only
+ * pre-existing protections were a cursor path pattern and an active DB claim; .reap-eligible.json
+ * is opt-IN TO REAPING, not protection.
+ */
+let tmp;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reap-protected-')); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe('reap-protected marker (QF-20260725-821)', () => {
+  it('an unmarked worktree is NOT protected (default stays reapable — no behaviour change)', () => {
+    expect(hasReapProtectedMarker(tmp)).toBe(false);
+    expect(readReapProtectedMarker(tmp)).toBeNull();
+  });
+
+  it('writing the marker protects the worktree, and the payload round-trips', () => {
+    const res = writeReapProtectedMarker(tmp, { reason: 'CP3 acceptance drill in flight', protected_by: 'coordinator' });
+    expect(res.written).toBe(true);
+    expect(res.error).toBeNull();
+    expect(hasReapProtectedMarker(tmp)).toBe(true);
+
+    const marker = readReapProtectedMarker(tmp);
+    expect(marker.reason).toBe('CP3 acceptance drill in flight');
+    expect(marker.protected_by).toBe('coordinator');
+    expect(typeof marker.protected_at).toBe('string');
+  });
+
+  it('is the OPT-OUT counterpart: its filename is distinct from the opt-in reap-eligible marker', async () => {
+    const { MARKER_FILENAME } = await import('../../lib/worktree-reaper/reap-eligible-marker.js');
+    expect(PROTECTED_MARKER_FILENAME).toBe('.reap-protected.json');
+    expect(PROTECTED_MARKER_FILENAME).not.toBe(MARKER_FILENAME);
+  });
+
+  it('a CORRUPT marker STILL protects — fail-safe toward keeping the tree', () => {
+    // Deliberate asymmetry: presence decides safety, parseability only decides metadata.
+    // Honoring an unparseable marker costs one un-reaped worktree; ignoring it deletes a tree
+    // someone is standing in, which is the incident this QF exists to prevent.
+    fs.writeFileSync(path.join(tmp, PROTECTED_MARKER_FILENAME), '{ not valid json', 'utf8');
+    expect(hasReapProtectedMarker(tmp)).toBe(true);
+    expect(readReapProtectedMarker(tmp)).toBeNull();
+  });
+
+  it('hasReapProtectedMarker never throws on a nonexistent path', () => {
+    expect(() => hasReapProtectedMarker(path.join(tmp, 'does', 'not', 'exist'))).not.toThrow();
+    expect(hasReapProtectedMarker(path.join(tmp, 'does', 'not', 'exist'))).toBe(false);
+  });
+});
+
+describe('QF-20260725-821: the reaper honors the marker at BOTH protection points', () => {
+  const src = fs.readFileSync(
+    path.join(process.cwd(), 'scripts', 'worktree-reaper.mjs'),
+    'utf-8',
+  );
+
+  it('imports the protected-marker module', () => {
+    expect(src).toMatch(/reap-protected-marker\.js/);
+  });
+
+  it('guards selectStage0Reclaim (stage-0 reclaim also destroys the tree)', () => {
+    // The cursor convention is honored in two places; a fix that covered only the main loop
+    // would still let stage-0 reclaim delete a protected tree.
+    const stage0 = src.slice(src.indexOf('export function selectStage0Reclaim'));
+    const body = stage0.slice(0, stage0.indexOf('\n}'));
+    expect(body).toMatch(/hasReapProtectedMarker/);
+  });
+
+  it('emits a keep verdict with reason reap_protected_marker in the classification loop', () => {
+    expect(src).toMatch(/reason: 'reap_protected_marker'/);
+    expect(src).toMatch(/keep:protected/);
+  });
+
+  it('checks the marker BEFORE classification, so a protected tree can never reach stage1/stage2', () => {
+    // Order is the whole safety property: the live incident removed the tree at stage 2 via
+    // orphan-sd, which is decided from the basename/claim lookup below. Guarding after that
+    // would still classify (and could still act) before the protection was consulted.
+    const loopStart = src.indexOf('for (const wt of allWorktrees)');
+    expect(loopStart).toBeGreaterThan(-1);
+    const loop = src.slice(loopStart);
+    const guardAt = loop.indexOf('hasReapProtectedMarker');
+    const classifyAt = loop.indexOf('const basename = path.basename(wt.path)');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(classifyAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(classifyAt);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260725-821

**Type:** bug
**Severity:** high

### Issue Description
LIVE INCIDENT 2026-07-25T12:20:21.795Z, found by coordinator a59441f4 (msg 7c378a98): scripts/worktree-reaper.mjs DELETED the chairman in-flight CP3 drill worktree .worktrees/cp3-drill-run (branch drill/cp3-live-run, base f13c4975e66) while the chairman and Adam were actively running the checkpoint-3 acceptance drill out of it. Reaper record: verdict=stage2_remove, reason=orphan-sd, orphan-sd.matched=true, reason=sdkey_not_in_db, candidates=[cp3-drill-run], claim_status=absent, method=git-worktree-remove. INDEPENDENTLY WITNESSED BY ADAM: the same worktree lost its .env and node_modules mid-session, which presented as a confusing FLEET_ACCOUNT_PROFILES_DIR precondition failure and cost real diagnostic time before the coordinator incident report explained it. NO WORK WAS LOST (dirty_file_count=0, unpushed_commit_count=0, branch ref survived) and the coordinator restored the tree, but the run was interrupted. ROOT CAUSE, general and not CP3-specific: worktree-reaper.mjs has exactly TWO protections - isCursorWorktree, a path pattern at line 1217, and activeClaim from claimMap keyed on normalizePath(worktree_path) at line 1251. Everything else is reapable. So ANY worktree whose basename does not resolve to an sd_key AND which carries no DB claim is auto-removed at stage 2. That is the exact profile of every operator-created, drill, and ops worktree. THERE IS NO OPT-OUT: the .reap-eligible.json marker is opt-IN TO REAPING, not protection; there is no exemption env var, no allowlist, no protected-paths config. RECURRENCE IS CERTAIN, not hypothetical - cadence is 12 sweeps at 5 minutes, so the next pass removes the restored tree again. Protecting it by fabricating a claude_sessions row or a claim was explicitly REJECTED by the coordinator as inventing evidence, which is the correct call and is why this needs a real fix. FIX OPTIONS, cheapest first (coordinator ranked, logged to harness_backlog): (1) honor an opt-OUT marker .reap-protected.json, symmetric with the existing opt-in marker; (2) exempt reserved branch prefixes such as drill/ and ops/; (3) treat RESIDENCY as protection - HEAD or mtime advanced within the last N minutes means in use. Ship (1) now; (3) is the general operator fix and should follow.

### Steps to Reproduce
1. Create a worktree whose basename is not an sd_key and take no DB claim on it, e.g. git worktree add .worktrees/cp3-drill-run -b drill/cp3-live-run origin/main. 2. Run the reaper sweep with execute=true stage2=true. 3. Observe the directory is removed.

### Expected Behavior
A worktree an operator is actively working in is not deleted out from under them; some supported way exists to mark a tree as protected.

### Actual Behavior
Removed at stage 2 with reason=orphan-sd. No opt-out mechanism exists in the script at all. Verified live: the chairman CP3 acceptance drill worktree was deleted mid-run and had to be restored by hand, and will be deleted again on the next sweep.

### Changes
- **Files Changed:** 3
  - lib/worktree-reaper/reap-protected-marker.js
  - scripts/worktree-reaper.mjs
  - tests/unit/worktree-reaper-protected-marker.test.js
- **LOC:** 116 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol