### PR TITLE
fix(SD-LEO-INFRA-OUTBOUND-SINK-CONFORMANCE-001): close verified bypasses in the sink-conformance ratchet

### DIFF
--- a/lib/static-analysis/call-graph-builder.js
+++ b/lib/static-analysis/call-graph-builder.js
@@ -98,6 +98,13 @@ export function buildCallGraph(filePaths, rootDir, opts = {}) {
     // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-127 FR-2: literal-specifier dynamic imports
     // are resolved as edges. Non-literal ones (e.g. `import(dynamicVar)`) surface a
     // CAUTION so operators can audit them without blocking the gate.
+    // The walker recurses over the whole AST. acorn parses some pathological shapes
+    // iteratively (e.g. a 20k-deep member chain) that then overflow this recursion,
+    // and the throw previously escaped buildCallGraph entirely. That matters more now:
+    // this runs inside the SOLE required status check (enforce_admins=true), so an
+    // uncaught RangeError there would block every merge repo-wide and would also
+    // crash both live wire-check gates. Degrade to a warning like the parse guard.
+    try {
     walkForDynamicEdges(ast, {
       onRequire: (specifier) => add(specifier),
       onDynamicImport: (specifier) => add(specifier),
@@ -117,6 +124,9 @@ export function buildCallGraph(filePaths, rootDir, opts = {}) {
         warnings.push(`${normalizedPath}: non-literal dynamic import() detected — reachability may be incomplete (CAUTION)`);
       }
     });
+    } catch (walkErr) {
+      warnings.push(`Walk error in ${normalizedPath}: ${walkErr.message}`);
+    }
   }
 
   return { graph, warnings };

--- a/lib/static-analysis/module-resolver.js
+++ b/lib/static-analysis/module-resolver.js
@@ -35,12 +35,21 @@ export function resolveModulePath(importPath, fromFile, rootDir, opts = {}) {
   // OPT-IN: file:// URL specifiers. Off by default (see opts.allowFileUrl above).
   if (opts.allowFileUrl && specifier.startsWith('file://')) {
     try {
-      specifier = fileURLToPath(specifier);
+      const absolute = fileURLToPath(specifier);
+      const normalizedAbs = absolute.replace(/\\/g, '/');
+      // CONTAINMENT: a file:// specifier is an ABSOLUTE path, so without this a
+      // scanned source containing import("file:///C:/Windows/win.ini") would inject
+      // an out-of-repo node into the graph. Nothing is ever read or executed here,
+      // but a fabricated node means fabricated reachability — which matters because
+      // these primitives feed a live merge-blocking gate. Refuse anything outside
+      // rootDir. statSync stays inside this try so a TOCTOU delete or EPERM cannot
+      // throw uncaught.
+      const rootNormalized = String(rootDir || '').replace(/\\/g, '/').replace(/\/+$/, '');
+      if (rootNormalized && !normalizedAbs.startsWith(`${rootNormalized}/`)) return null;
+      return fs.existsSync(absolute) && fs.statSync(absolute).isFile() ? normalizedAbs : null;
     } catch {
       return null;
     }
-    const normalizedAbs = specifier.replace(/\\/g, '/');
-    return fs.existsSync(specifier) && fs.statSync(specifier).isFile() ? normalizedAbs : null;
   }
 
   // Skip bare specifiers (npm packages) — they are not project files

--- a/tests/unit/outbound-sink-conformance.test.js
+++ b/tests/unit/outbound-sink-conformance.test.js
@@ -75,8 +75,13 @@ const TRANSPORT_TARGETS = [
 /** The protective check whose leaf placement caused the defect class. */
 const CONSULT_GATE = 'lib/adam/should-consult-solomon.js';
 
-/** NOT sinks. Kept strictly separate from KNOWN_DEBT so real debt can never be
- *  laundered as "not a sink". */
+/** NOT sinks — genuine classification errors of the traversal, not deferred work.
+ *  An earlier revision of this comment claimed that keeping this list separate from
+ *  KNOWN_DEBT meant real debt "can never be laundered as not a sink". That was FALSE:
+ *  adversarial review proved that MOVING an entry from KNOWN_DEBT into NOT_A_SINK
+ *  passed every test, because set disjointness is preserved by a move and runCensus()
+ *  skips NOT_A_SINK paths BEFORE evaluating conformance. The guarantee now comes from
+ *  EXPECTED_NON_CONFORMANT + NOT_A_SINK_EXPECTED below, not from disjointness. */
 const NOT_A_SINK = [
   { path: 'api/webhooks/twilio-sms.js', reason: 'INBOUND Twilio webhook, not an outbound sink. The single known false positive of the traversal.' },
   { path: 'lib/marketing/ai/email-campaigns.js', reason: 'Sends via raw fetch to api.resend.com and imports nothing from lib/notifications, so it is structurally invisible to import-graph traversal. Named so the census never implies coverage it lacks.' },
@@ -114,6 +119,44 @@ const KNOWN_DEBT = [
 ];
 /** Committed ceiling — the ratchet. Never raise this; lowering it is the point. */
 const KNOWN_DEBT_CEILING = 14;
+
+/**
+ * IDENTITY BASELINE — the actual anti-laundering guarantee.
+ *
+ * The frozen set of paths that were non-conformant when this control was authored,
+ * measured with BOTH allowlists ignored. Pinned by IDENTITY rather than by count or
+ * by set-disjointness, so none of these can be silently reclassified: moving one into
+ * NOT_A_SINK, deleting it from KNOWN_DEBT without remediating, or narrowing the
+ * discovery roots all make it vanish from the census and fail the subset assertion.
+ * Removing an entry here is therefore a deliberate, diffed, reviewable edit — which
+ * is the whole point of the control.
+ *
+ * Shrinking this is legitimate ONLY when the sink genuinely inherits the consult gate
+ * (or the module is gone).
+ */
+const EXPECTED_NON_CONFORMANT = [
+  'lib/adam/stall-alert.js',
+  'lib/chairman/record-pending-decision.mjs',
+  'lib/chairman/sms-bridge.js',
+  'lib/chairman/sms-channel-health.js',
+  'lib/chairman/sms-outbound-worker.js',
+  'lib/comms/adam-outbound/chairman-sms-gate/index.js',
+  'lib/comms/adam-outbound/decision-scheduler/index.js',
+  'lib/notifications/channel-health-recorder.js',
+  'lib/notifications/orchestrator.js',
+  'lib/notifications/scheduler.js',
+  'lib/switch-automation/switchon-decision-packet.js',
+  'scripts/adam-decision-email.mjs',
+  'scripts/adam-exec-summary.mjs',
+  'scripts/adam-heartbeat-email.mjs',
+];
+
+/** Exact expected NOT_A_SINK membership — parking a real sink here now fails loudly. */
+const NOT_A_SINK_EXPECTED = [
+  'api/webhooks/twilio-sms.js',
+  'lib/marketing/ai/email-campaigns.js',
+  'lib/services/sovereign-alert.js',
+];
 
 const toPosix = (p) => p.replace(/\\/g, '/');
 const relPosix = (abs) => toPosix(path.relative(REPO_ROOT, abs));
@@ -162,7 +205,9 @@ function runCensus(opts = {}) {
   const targets = TRANSPORT_TARGETS.map(abs).filter((p) => fs.existsSync(p));
   const gateAbs = abs(CONSULT_GATE);
 
-  const notASink = new Set(NOT_A_SINK.map((e) => e.path));
+  // ignoreNotASink is what makes the identity baseline un-launderable: with it set, a
+  // path moved into NOT_A_SINK is still evaluated, so it cannot vanish quietly.
+  const notASink = new Set(opts.ignoreNotASink ? [] : NOT_A_SINK.map((e) => e.path));
   const debt = new Set(opts.ignoreKnownDebt ? [] : KNOWN_DEBT.map((e) => e.path));
   // The transports (and the barrel that re-exports one) are the EMITTERS, not
   // callers of an emitter. The consult gate belongs on the code that decides to
@@ -242,9 +287,39 @@ describe('allowlist integrity', () => {
     expect(KNOWN_DEBT.length).toBeLessThanOrEqual(KNOWN_DEBT_CEILING);
   });
 
-  it('KNOWN_DEBT and NOT_A_SINK are disjoint — debt cannot be laundered as not-a-sink', () => {
+  it('the committed ceiling itself is pinned — raising it is a one-line ratchet kill', () => {
+    // Without this, `KNOWN_DEBT.length <= CEILING` is trivially satisfiable by editing
+    // the constant. Lowering it as debt is genuinely remediated is the only intended
+    // change, and it must be a deliberate diffed edit here too.
+    expect(KNOWN_DEBT_CEILING).toBe(14);
+  });
+
+  it('KNOWN_DEBT and NOT_A_SINK are disjoint (blocks duplication, NOT migration)', () => {
+    // Necessary but far from sufficient: a MOVE preserves disjointness. The real
+    // anti-laundering guarantee is the identity baseline assertion below.
     const notSink = new Set(NOT_A_SINK.map((e) => e.path));
     expect(KNOWN_DEBT.filter((e) => notSink.has(e.path))).toEqual([]);
+  });
+
+  it('ANTI-LAUNDERING: every baseline non-conformant path is still reported with BOTH allowlists ignored', () => {
+    // Catches what disjointness cannot: reclassifying debt as not-a-sink, deleting a
+    // debt entry without remediating, or narrowing the roots to hide it.
+    const bare = runCensus({ ignoreKnownDebt: true, ignoreNotASink: true });
+    for (const p of EXPECTED_NON_CONFORMANT) {
+      expect(bare.nonConformant, `baseline sink no longer reported: ${p}`).toContain(p);
+    }
+  });
+
+  it('NOT_A_SINK membership is pinned exactly — a real sink cannot be parked here', () => {
+    expect(NOT_A_SINK.map((e) => e.path).sort()).toEqual([...NOT_A_SINK_EXPECTED].sort());
+  });
+
+  it('the honest-limit disclosure is present in the shipped source', () => {
+    // Load-bearing: a green run must never be read as full coverage, since raw-fetch
+    // sends are structurally invisible to this traversal.
+    const src = fs.readFileSync(path.join(HERE, SELF_BASENAME), 'utf8');
+    expect(src).toMatch(/not bypass-proof/i);
+    expect(src).toMatch(/structurally invisible/i);
   });
 
   it('no allowlist entry is stale — every listed path still exists', () => {

--- a/tests/unit/static-analysis/call-graph-characterization.test.js
+++ b/tests/unit/static-analysis/call-graph-characterization.test.js
@@ -69,6 +69,14 @@ beforeAll(() => {
   // Directory import resolving through index.js.
   w('pkg/index.js', 'export const p = 4;\n');
   w('dir-import.js', "import './pkg';\n");
+  // The pathToFileURL idiom. Distinct from dyn-variable.js above: that one is a bare
+  // variable, THIS is the computed-MemberExpression shape opts.resolveFileUrlIdiom
+  // recognizes. Without this fixture the default-OFF contract is unpinned — verified by
+  // adversarial review: patching the signature to `opts = { resolveFileUrlIdiom: true }`
+  // passed the entire suite, leaving the highest-consequence regression in this change
+  // unguarded (it would add edges, loosening the live WIRE_CHECK_GATE, and delete the
+  // CAUTION warnings that gate propagates via warnings.length).
+  w('dyn-fileurl.js', "import { pathToFileURL } from 'node:url';\nimport { resolve } from 'node:path';\nexport async function go() { return import(pathToFileURL(resolve('leaf-b.js')).href); }\n");
 });
 
 afterAll(() => {
@@ -135,6 +143,48 @@ describe('buildCallGraph — characterization of present-day behavior', () => {
     const edges = [...graph.get(FILES['entry.js'])].map((e) => rel(ROOT, e)).sort();
     expect(edges).toEqual(['barrel.js', 'leaf-a.js']);
     expect(edges.some((e) => e.includes('acorn'))).toBe(false);
+  });
+
+  it('DEFAULT-OFF CONTRACT: the pathToFileURL idiom yields a CAUTION and NO edge with no opts', () => {
+    // The guard this suite previously lacked. Both live merge-blocking gates call
+    // buildCallGraph positionally, so this default must never drift.
+    const { graph, warnings } = buildCallGraph([FILES['dyn-fileurl.js']], ROOT);
+    expect([...graph.get(FILES['dyn-fileurl.js'])]).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('non-literal dynamic import() detected');
+  });
+
+  it('OPT-IN: with resolveFileUrlIdiom the same idiom resolves to an edge and drops the CAUTION', () => {
+    const { graph, warnings } = buildCallGraph([FILES['dyn-fileurl.js']], ROOT, { resolveFileUrlIdiom: true });
+    expect([...graph.get(FILES['dyn-fileurl.js'])].map((e) => rel(ROOT, e))).toEqual(['leaf-b.js']);
+    expect(warnings).toEqual([]);
+  });
+
+  it('allowedRoots keeps only edges resolving inside the declared subgraph', () => {
+    // Shipped with no production consumer (the census restricts its input file set
+    // instead), so this is the option's only exercise — pin it deliberately.
+    const inputs = [FILES['entry.js'], FILES['barrel.js'], FILES['leaf-a.js'], FILES['leaf-b.js'], FILES['leaf-c.js']];
+    const { graph } = buildCallGraph(inputs, ROOT, { allowedRoots: ['pkg'] });
+    expect([...graph.values()].flatMap((edges) => [...edges])).toEqual([]);
+    const { graph: unfiltered } = buildCallGraph(inputs, ROOT);
+    expect([...unfiltered.get(FILES['entry.js'])].length).toBeGreaterThan(0);
+  });
+
+  it('degrades a walker overflow to a warning instead of throwing out of buildCallGraph', () => {
+    // This runs in the sole required status check, so an uncaught RangeError would
+    // block every merge repo-wide. acorn parses this shape fine; the recursive walk
+    // is what overflows.
+    const deepRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cgb-deep-'));
+    try {
+      const deep = path.join(deepRoot, 'deep.js');
+      fs.writeFileSync(deep, `const v = a${'.b'.repeat(20000)};\n`, 'utf8');
+      const abs = deep.replace(/\\/g, '/');
+      let result;
+      expect(() => { result = buildCallGraph([abs], deepRoot); }).not.toThrow();
+      expect(result.graph.has(abs)).toBe(true);
+    } finally {
+      fs.rmSync(deepRoot, { recursive: true, force: true });
+    }
   });
 
   it('pins arity — the live gates call these strictly positionally', () => {


### PR DESCRIPTION
Follow-up to #6456. Adversarial TESTING and SECURITY reviews of the merged control each **independently reproduced** defects that undermined it. All were durability gaps in the guards rather than live behavior bugs — shipped behavior was correct — but a control whose entire value is durability has to actually be durable.

## 1. The shipped code made a false claim

The comment asserted that real debt "can never be laundered as not a sink." Both reviewers disproved it: **moving** an entry from `KNOWN_DEBT` into `NOT_A_SINK` passed all 13 tests. Disjointness is preserved by a move, `runCensus` skips `NOT_A_SINK` *before* evaluating conformance, and the detection-proof iterated the already-shortened list. The debt count would drop 14 → 13, reading as remediation progress when nothing was fixed.

The claim is deleted and replaced with what is actually true.

## 2. Anti-laundering now rests on an identity baseline

`EXPECTED_NON_CONFORMANT` freezes the 14 paths and is asserted against a census run with **both** allowlists ignored (new `opts.ignoreNotASink`). Reclassifying an entry, deleting it without remediating, or hiding it by narrowing the discovery roots now all fail. `NOT_A_SINK` membership is pinned exactly, and `KNOWN_DEBT_CEILING` is pinned to 14 — previously only `length <= CEILING` was asserted, making that constant a one-line ratchet kill.

## 3. The default-OFF contract was unpinned — highest-consequence gap

Patching `buildCallGraph` to `opts = { resolveFileUrlIdiom: true }` passed all 49 tests. The only non-literal fixture was `import(spec)` — a bare variable, not the `pathToFileURL` shape — and a *populated* default param still keeps `Function.length === 2`, so the arity pin missed it.

A future default-flip would have silently added graph edges (loosening the live merge-blocking `WIRE_CHECK_GATE`) and deleted the CAUTION warnings that gate propagates via `warnings.length`, with **zero** test failures. Added a `dyn-fileurl` fixture asserting CAUTION + no edge by default, and edge + no warning when opted in.

## 4. Walker overflow escaped `buildCallGraph`

acorn parses a 20k-deep member chain iteratively, then the recursive `walkForDynamicEdges` overflows — and that call sat *outside* the parse try/catch, so an uncaught `RangeError` propagated out. Pre-existing, but this SD moved it into the **sole required status check with `enforce_admins=true`**, where an uncaught throw blocks every merge repo-wide unoverridably, and it also crashes both live wire-check gates. Now degrades to a warning, with a test.

## 5. `file://` resolution had no containment

`resolveModulePath` with `allowFileUrl` returned absolute out-of-repo paths (verified: `file:///C:/Windows/win.ini`), injecting a fabricated node into the graph. Nothing is read or executed and the option is off by default, so severity is genuinely low — but a fabricated node means fabricated reachability in a gate. Now refuses anything outside `rootDir`, and `statSync` moved inside the try so TOCTOU/EPERM cannot throw uncaught.

## 6. Corrected a misleading comment

Subgraph restriction in the census comes from the **input file set**, not `opts.allowedRoots`. That option shipped with no production consumer; it now has a dedicated test rather than only a claim.

Also added a test asserting the honest-limit disclosure stays in the source, so a future edit cannot quietly strip the statement that recall is measured against a known list and that the control is not bypass-proof.

## Verification

**57 tests pass across 6 files** (was 49). Each of the three bypasses was re-run against the hardened suite and now fails with the exact intended assertion:

| Bypass attempt | Result |
|---|---|
| Move `sms-bridge.js` from `KNOWN_DEBT` → `NOT_A_SINK` | ✗ fails — *NOT_A_SINK membership is pinned exactly* |
| Flip `resolveFileUrlIdiom` default ON | ✗ fails — *DEFAULT-OFF CONTRACT* |
| Raise `KNOWN_DEBT_CEILING` 14 → 99 | ✗ fails — *committed ceiling is pinned* |

Restored state: 57/57 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)