### PR TITLE
fix(QF-20260725-470): add ADD COLUMN class so a partially-applied migration stops reporting PASS

### DIFF
--- a/scripts/verify-migration-apply-state.mjs
+++ b/scripts/verify-migration-apply-state.mjs
@@ -166,6 +166,42 @@ const CREATE_RES = [
   { cls: 'constraint', re: new RegExp(String.raw`\bADD\s+CONSTRAINT\s+(${ID})`, 'gi') },
 ];
 
+/**
+ * QF-20260725-470: ADD/DROP COLUMN class. The other classes are single-name statements, but one
+ * ALTER TABLE carries the table once and any number of comma-separated ADD/DROP COLUMN items (the
+ * SMS spend-envelope migration does exactly this), so columns cannot be pulled by a one-capture
+ * regex like the rest — the table must be paired with each item. Names are stored TABLE-QUALIFIED
+ * ('table.column') because a bare column name is not unique across the schema.
+ *
+ * DROP COLUMN is handled too, deliberately: foldLifecycle is drop-aware, and without the drop side
+ * a column added by one migration and dropped by a later one would be reported missing forever —
+ * turning this fix into a new false-alarm source instead of a gap detector.
+ */
+const ALTER_TABLE_STMT_RE = new RegExp(String.raw`\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(${ID})([\s\S]*?)(?=;|$)`, 'gi');
+const ADD_COLUMN_ITEM_RE = new RegExp(String.raw`\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(${ID})`, 'gi');
+const DROP_COLUMN_ITEM_RE = new RegExp(String.raw`\bDROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?(${ID})`, 'gi');
+
+export function extractColumnFacts(s) {
+  const creates = [];
+  const drops = [];
+  ALTER_TABLE_STMT_RE.lastIndex = 0;
+  let stmt;
+  while ((stmt = ALTER_TABLE_STMT_RE.exec(s)) !== null) {
+    const table = normalizeName(stmt[1]);
+    const body = stmt[2] || '';
+    if (!table) continue;
+    for (const [, raw] of body.matchAll(ADD_COLUMN_ITEM_RE)) {
+      const col = normalizeName(raw);
+      if (col) creates.push({ cls: 'column', name: `${table}.${col}` });
+    }
+    for (const [, raw] of body.matchAll(DROP_COLUMN_ITEM_RE)) {
+      const col = normalizeName(raw);
+      if (col) drops.push({ cls: 'column', name: `${table}.${col}` });
+    }
+  }
+  return { creates, drops };
+}
+
 const DROP_RES = [
   { cls: 'table',      re: new RegExp(String.raw`\bDROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(${ID})`, 'gi') },
   { cls: 'matview',    re: new RegExp(String.raw`\bDROP\s+MATERIALIZED\s+VIEW\s+(?:IF\s+EXISTS\s+)?(${ID})`, 'gi') },
@@ -191,7 +227,12 @@ export function extractDdlFacts(sql) {
     }
     return out;
   };
-  return { creates: pull(CREATE_RES), drops: pull(DROP_RES) };
+  // QF-20260725-470: merge the column facts (extracted from the SAME stripped SQL) into both sides.
+  const cols = extractColumnFacts(s);
+  return {
+    creates: [...pull(CREATE_RES), ...cols.creates],
+    drops: [...pull(DROP_RES), ...cols.drops],
+  };
 }
 
 // ── Stage 3: chronological fold ──────────────────────────────────────────────
@@ -261,6 +302,20 @@ async function resolveLive(client, expected) {
       [[...byClass.get('trigger')]]
     );
     mark('trigger', rows, 'name');
+  }
+  // QF-20260725-470: resolve 'table.column' pairs against information_schema.columns. Without this
+  // branch a declared column is structurally invisible and its migration can still contribute to a
+  // MIGRATION_APPLY_STATE_PASS — the exact ghost that let chairman-gated QF-20260719-281 close with
+  // ship_review_findings.metadata / .repo and quick_fixes.factory_lane still absent from prod.
+  if (byClass.get('column')?.size) {
+    const { rows } = await client.query(
+      `SELECT c.table_name || '.' || c.column_name AS name
+         FROM information_schema.columns c
+        WHERE c.table_schema = 'public'
+          AND (c.table_name || '.' || c.column_name) = ANY($1::text[])`,
+      [[...byClass.get('column')]]
+    );
+    mark('column', rows, 'name');
   }
   if (byClass.get('constraint')?.size) {
     const { rows } = await client.query(

--- a/tests/verify-migration-apply-state.test.js
+++ b/tests/verify-migration-apply-state.test.js
@@ -239,3 +239,89 @@ describe('wiring pins', () => {
     expect(src).toMatch(/\.then\(\(code\) => armCliTeardown\(code\)\)/);
   });
 });
+
+/**
+ * QF-20260725-470 — ADD COLUMN class. The verifier had NO column class, so a migration whose only
+ * DDL is ALTER TABLE ... ADD COLUMN was structurally invisible and could contribute to a
+ * MIGRATION_APPLY_STATE_PASS (live ghost 2026-07-25: chairman-gated QF-20260719-281 closed while
+ * ship_review_findings.metadata/.repo and quick_fixes.factory_lane were still absent from prod).
+ * Names are table-qualified because a bare column name is not unique across the schema.
+ */
+describe('extraction — ADD COLUMN class (QF-20260725-470)', () => {
+  it('extracts a single ADD COLUMN, table-qualified, incl. IF NOT EXISTS', () => {
+    const { creates } = extractDdlFacts('ALTER TABLE ship_review_findings ADD COLUMN IF NOT EXISTS metadata jsonb;');
+    expect(creates).toEqual([{ cls: 'column', name: 'ship_review_findings.metadata' }]);
+  });
+
+  it('pairs the table with EVERY item of a comma-separated multi-column ALTER', () => {
+    const { creates } = extractDdlFacts(
+      'ALTER TABLE sms_budget\n  ADD COLUMN IF NOT EXISTS envelope_cents int,\n  ADD COLUMN spent_cents int DEFAULT 0;'
+    );
+    expect(creates).toEqual([
+      { cls: 'column', name: 'sms_budget.envelope_cents' },
+      { cls: 'column', name: 'sms_budget.spent_cents' },
+    ]);
+  });
+
+  it('normalizes quoted and schema-qualified table/column names', () => {
+    const { creates } = extractDdlFacts('ALTER TABLE public."quick_fixes" ADD COLUMN "factory_lane" text;');
+    expect(creates).toEqual([{ cls: 'column', name: 'quick_fixes.factory_lane' }]);
+  });
+
+  it('handles a final statement with no trailing semicolon', () => {
+    const { creates } = extractDdlFacts('ALTER TABLE foo ADD COLUMN bar text');
+    expect(creates).toEqual([{ cls: 'column', name: 'foo.bar' }]);
+  });
+
+  it('keeps tables distinct across multiple ALTER statements', () => {
+    const { creates } = extractDdlFacts('ALTER TABLE a ADD COLUMN x int;\nALTER TABLE b ADD COLUMN y int;');
+    expect(creates.map((c) => c.name)).toEqual(['a.x', 'b.y']);
+  });
+
+  it('routes DROP COLUMN to drops so the lifecycle fold stays drop-aware', () => {
+    const { creates, drops } = extractDdlFacts('ALTER TABLE foo ADD COLUMN a int, DROP COLUMN b;');
+    expect(creates).toEqual([{ cls: 'column', name: 'foo.a' }]);
+    expect(drops).toEqual([{ cls: 'column', name: 'foo.b' }]);
+  });
+
+  it('a column added then dropped later does NOT survive as an expected object', () => {
+    const folded = foldLifecycle([
+      { file: '1_add.sql', ...extractDdlFacts('ALTER TABLE foo ADD COLUMN tmp int;') },
+      { file: '2_drop.sql', ...extractDdlFacts('ALTER TABLE foo DROP COLUMN tmp;') },
+    ]);
+    expect([...folded.expected.keys()]).not.toContain('column:foo.tmp');
+  });
+
+  it('an absent declared column classifies NOT_APPLIED, not APPLIED', () => {
+    const facts = [{ file: 'm.sql', ...extractDdlFacts('ALTER TABLE ship_review_findings ADD COLUMN metadata jsonb;') }];
+    const { expected, perFile } = foldLifecycle(facts);
+    const live = new Set(); // column absent live
+    const [row] = classifyFiles(['m.sql'], expected, perFile, live);
+    expect(row.status).toBe('NOT_APPLIED');
+    expect(row.missing).toEqual([{ cls: 'column', name: 'ship_review_findings.metadata' }]);
+  });
+
+  it('ignores ADD COLUMN inside comments and dollar-quoted bodies', () => {
+    const dq = '$' + '$';
+    const { creates } = extractDdlFacts(
+      `-- ALTER TABLE ghost ADD COLUMN nope text;\n` +
+      `CREATE FUNCTION f() RETURNS void AS ${dq} BEGIN EXECUTE 'ALTER TABLE ghost ADD COLUMN nope text'; END ${dq} LANGUAGE plpgsql;`
+    );
+    expect(creates.filter((c) => c.cls === 'column')).toEqual([]);
+  });
+
+  it('does not regress ADD CONSTRAINT, which shares the ALTER TABLE prefix', () => {
+    const { creates } = extractDdlFacts('ALTER TABLE foo ADD CONSTRAINT foo_pk PRIMARY KEY (id);');
+    expect(creates).toEqual([{ cls: 'constraint', name: 'foo_pk' }]);
+  });
+
+  it('an ALTER TABLE with no column items yields no facts', () => {
+    expect(extractDdlFacts('ALTER TABLE foo ENABLE ROW LEVEL SECURITY;').creates).toEqual([]);
+  });
+
+  it('the live resolver has a column branch querying information_schema.columns', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'scripts', 'verify-migration-apply-state.mjs'), 'utf8');
+    expect(src).toMatch(/byClass\.get\('column'\)/);
+    expect(src).toMatch(/information_schema\.columns/);
+  });
+});


### PR DESCRIPTION
## Problem
`verify-migration-apply-state.mjs` classified declared objects via `CREATE_RES` — tables, matviews, views, functions, triggers, constraints — but had **no column class**. A migration whose only DDL is `ALTER TABLE … ADD COLUMN` was structurally invisible: the verifier could not notice the column never landed, and the file still contributed to `MIGRATION_APPLY_STATE_PASS`.

**Proven by a live ghost completion, not theorised.** Chairman-gated QF-20260719-281 was released on this instrument exiting PASS with `RECENT gaps=0`, while three columns it existed to deliver were absent from prod. Downstream damage already observed:

- `ship_review_findings.metadata` is what `evaluateActorSeparation` reads in `lib/ship/merge-witness-ladder.mjs` → `P2.actorSeparation` could **never** evaluate (hit on PR #6450, unexplainable at the time).
- `quick_fixes.factory_lane` missing is what QF-20260724-598 shipped a workaround for — a fix compensating for a gap the guard called clean.

## Fix — two halves, both required
- **Extraction**: columns can't use the one-capture regex the other classes use, because a single `ALTER TABLE` carries the table once and any number of comma-separated `ADD`/`DROP COLUMN` items (the SMS spend-envelope migration does this). `extractColumnFacts()` matches the ALTER statement, then pairs the table with each item. Names are stored **table-qualified** (`table.column`) since a bare column name isn't unique across the schema.
- **Resolution**: `resolveLive()` gains a column branch verifying each pair against `information_schema.columns` — one bulk query, consistent with the existing no-N+1 design.

`DROP COLUMN` is routed to `drops` **deliberately**: `foldLifecycle` is drop-aware, and without the drop side a column added by one migration and dropped by a later one would report missing forever — turning a gap detector into a new false-alarm source.

## Verified against live prod, before and after

| | Outcome | `--strict` exit | Missing columns |
|---|---|---|---|
| `origin/main` | `MIGRATION_APPLY_STATE_PASS` | 0 (doesn't block) | **0** |
| this branch | `MIGRATION_APPLY_STATE_GAPS_FOUND` | **1 (blocks)** | **11** across 9 recent migrations |

The 11 include the 3 cited above plus `chairman_decisions.channel`, `operator_cash_burn_monthly.manual_revenue_usd` / `_last_synced_at`, `chairman_email_channel_health.last_chairman_digest_hash` / `_sent_at`, `hold_state_contract_violations.release_condition_predicate`, `evaluation_profiles.agentic_fit_params`, `sd_capabilities.scope` — **all previously invisible to the guard.**

> Note for reviewers: this makes `--strict` start failing on real pre-existing gaps. That is the intended behaviour (the QF requires absent columns to block), but it means any CI job running `--strict --recent-only` will now correctly go red until those migrations are applied or retired. Backfill remains a human decision, per the script's own contract.

## Tests
36 pass (24 pre-existing unchanged + 12 new). **8 of the 12 verified RED on unfixed code** before going green; the other 4 are negative/regression assertions (comment and dollar-quote suppression, `ADD CONSTRAINT` unregressed) that must hold in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)