### PR TITLE
fix(QF-20260725-213): Proposal ingest silently drops description and four content arrays (mapProposalToCreateArgs)

### DIFF
--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -141,7 +141,46 @@ const PROPOSAL_META_DROP_KEYS = new Set([
   'target_repos', 'depends_on',
 ]);
 
+// QF-20260725-213 (part c): TOP-LEVEL proposal keys this mapper actually consumes. Deliberately
+// scoped to TOP-LEVEL ONLY — proposal.metadata is preserved wholesale minus PROPOSAL_META_DROP_KEYS,
+// so a guard written against authored keys generally would false-positive on every metadata key.
+const MAPPED_PROPOSAL_KEYS = new Set([
+  'title', 'type', 'priority', 'description', 'scope', 'rationale', 'success_criteria',
+  'key_changes', 'success_metrics', 'strategic_objectives', 'smoke_test_steps', 'metadata',
+  'provenance', 'roadmap_phase', 'tier_hint', 'gold_origin', 'necessity', 'dedup_note', 'sourced_by',
+]);
+// Structural keys a proposal legitimately carries that this mapper does not consume because
+// validateProposalShape() above already does (see its docstring: proposed_sd_key, title, sd_type,
+// priority, PROPOSAL===true, status_intended==='draft'). These reach the SD via `normalized`, or
+// are pure markers. Adding a key here asserts "consumed elsewhere", NOT "safe to drop".
+const IGNORABLE_PROPOSAL_KEYS = new Set(['PROPOSAL', 'proposed_sd_key', 'sd_type', 'status_intended']);
+// Leak-guard keys: dropping these IS the correct behavior, not an oversight. vision_key/arch_key
+// drive enrichFromVisionArch's orphan-FK re-activation and parent_id/parentId would forge an
+// orchestrator link, so a proposal must never set them (see the "never leak into mapped args" test).
+const DELIBERATELY_DROPPED_PROPOSAL_KEYS = new Set(['vision_key', 'arch_key', 'parent_id', 'parentId']);
+
+/**
+ * QF-20260725-213 (part c): FAIL LOUD rather than silently dropping authored content. The whole
+ * defect class here is a mapper that quietly ignores a key — so any top-level key we do not
+ * consume must stop ingest and name itself, instead of producing an SD that looks populated.
+ */
+export function assertAllProposalKeysMapped(proposal) {
+  if (!proposal || typeof proposal !== 'object') return;
+  const unmapped = Object.keys(proposal)
+    .filter((k) => !MAPPED_PROPOSAL_KEYS.has(k) && !IGNORABLE_PROPOSAL_KEYS.has(k)
+      && !DELIBERATELY_DROPPED_PROPOSAL_KEYS.has(k));
+  if (unmapped.length > 0) {
+    throw new Error(
+      `Proposal ingest would DROP unmapped top-level key(s): ${unmapped.join(', ')}. `
+      + 'Add each to the mapper in scripts/modules/leo-create-sd/proposal-lanes.js (and to '
+      + 'MAPPED_PROPOSAL_KEYS), or to IGNORABLE_PROPOSAL_KEYS if it is genuinely structural. '
+      + 'Refusing to create an SD that silently loses authored content (QF-20260725-213).',
+    );
+  }
+}
+
 export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {}) {
+  assertAllProposalKeysMapped(proposal);
   // FR-1: preserve the proposal's full metadata object (merge with canonical defaults rather than
   // replacing), MINUS the leak-guard keys. This carries Adam-sourcing keys (min_tier_rank,
   // requires_human_action, deferred/deferred_until, etc.) that the old closed whitelist dropped.
@@ -170,12 +209,27 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
     // description — when it led the description, the substantive ~1500ch scope was buried and workers
     // mis-flagged the SD as an 8-word stub. scope (the objective) is preferred; rationale is the
     // fallback only when scope is absent. Provenance still lives in `rationale` + metadata below.
-    description: proposal.scope || proposal.rationale || proposal.title,
+    // QF-20260725-213: proposal.description LEADS. It was never read at all, so an authored
+    // description was silently replaced by title-derived boilerplate from validate-sd-fields.js,
+    // and the resulting thin description is what invited the filename-search enrichment sweep to
+    // fill it (on SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 it filled with an unrelated document).
+    // scope MUST STAY AHEAD OF rationale — that ordering is the SD-REFILL-00229BH8 fix above, not
+    // an arbitrary preference. Do not reorder those two.
+    description: proposal.description || proposal.scope || proposal.rationale || proposal.title,
     // Sibling parity: UAT/learn/feedback/QF/plan/child all set an explicit rationale
     // (used by the LEAD evaluator). Fall back to a provenance line when absent.
     rationale: proposal.rationale || `Materialized from proposal ${filePath || 'unknown'}`,
     scope: proposal.scope || null,
     success_criteria: Array.isArray(proposal.success_criteria) ? proposal.success_criteria : null,
+    // QF-20260725-213: these four were never mapped, so authored content was replaced by
+    // title-derived boilerplate ("Implement core changes for X", "Implementation completeness",
+    // "Navigate to the relevant page for X"). success_criteria mapped correctly, which is why the
+    // SD looked populated on casual inspection and this evaded notice. Same null-when-absent shape
+    // as success_criteria so a proposal that omits them is byte-identical to pre-fix behavior.
+    key_changes: Array.isArray(proposal.key_changes) ? proposal.key_changes : null,
+    success_metrics: Array.isArray(proposal.success_metrics) ? proposal.success_metrics : null,
+    strategic_objectives: Array.isArray(proposal.strategic_objectives) ? proposal.strategic_objectives : null,
+    smoke_test_steps: Array.isArray(proposal.smoke_test_steps) ? proposal.smoke_test_steps : null,
     // SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001 (FR-1): a proposal that declares
     // metadata.depends_on must populate the CANONICAL `dependencies` column — that is
     // what lib/coordinator/claimable-work.cjs and scripts/modules/sd-next/dependency-resolver.js

--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -149,11 +149,15 @@ const MAPPED_PROPOSAL_KEYS = new Set([
   'key_changes', 'success_metrics', 'strategic_objectives', 'smoke_test_steps', 'metadata',
   'provenance', 'roadmap_phase', 'tier_hint', 'gold_origin', 'necessity', 'dedup_note', 'sourced_by',
 ]);
-// Structural keys a proposal legitimately carries that this mapper does not consume because
-// validateProposalShape() above already does (see its docstring: proposed_sd_key, title, sd_type,
-// priority, PROPOSAL===true, status_intended==='draft'). These reach the SD via `normalized`, or
-// are pure markers. Adding a key here asserts "consumed elsewhere", NOT "safe to drop".
-const IGNORABLE_PROPOSAL_KEYS = new Set(['PROPOSAL', 'proposed_sd_key', 'sd_type', 'status_intended']);
+// Keys a proposal legitimately carries that this mapper does not consume because another stage of
+// the ingest path already does. Two such stages: validateProposalShape() above (proposed_sd_key,
+// title, sd_type, priority, PROPOSAL===true, status_intended==='draft' — these reach the SD via
+// `normalized`) and ingestProposalObject() below (premise_descriptor drives the checkPremiseLiveness
+// stale-guard at the `proposal.premise_descriptor` branch).
+// Adding a key here asserts "consumed elsewhere, and I checked where", NOT "safe to drop".
+const IGNORABLE_PROPOSAL_KEYS = new Set([
+  'PROPOSAL', 'proposed_sd_key', 'sd_type', 'status_intended', 'premise_descriptor',
+]);
 // Leak-guard keys: dropping these IS the correct behavior, not an oversight. vision_key/arch_key
 // drive enrichFromVisionArch's orphan-FK re-activation and parent_id/parentId would forge an
 // orchestrator link, so a proposal must never set them (see the "never leak into mapped args" test).

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -226,6 +226,36 @@ describe('mapProposalToCreateArgs (pure field mapping)', () => {
     // a different/foreign value is also not coerced to 'adam'
     expect(mapProposalToCreateArgs(normalized, validProposal({ sourced_by: 'drain-intake' }), 'p.json').metadata.sourced_by).toBeUndefined();
   });
+
+  // QF-20260725-213: proposal.description was never read, so an authored spec was silently
+  // replaced downstream by title-derived boilerplate, and four authored content arrays were
+  // dropped outright. Live case: a 6.5KB sink-conformance spec became a 148-char description.
+  it('QF-213: authored description is mapped and LEADS scope/rationale', () => {
+    const p = validProposal({ description: 'AUTHORED SPEC BODY' });
+    expect(mapProposalToCreateArgs(normalized, p, 'p.json').description).toBe('AUTHORED SPEC BODY');
+    // precedence: no description → scope, NOT the title (title-derived boilerplate was the defect)
+    expect(mapProposalToCreateArgs(normalized, validProposal(), 'p.json').description).toBe('DOES: x. DOES NOT: y.');
+  });
+
+  it('QF-213: key_changes/success_metrics/strategic_objectives/smoke_test_steps are mapped', () => {
+    const p = validProposal({
+      key_changes: ['kc'], success_metrics: ['sm'], strategic_objectives: ['so'], smoke_test_steps: ['st'],
+    });
+    const args = mapProposalToCreateArgs(normalized, p, 'p.json');
+    expect(args.key_changes).toEqual(['kc']);
+    expect(args.success_metrics).toEqual(['sm']);
+    expect(args.strategic_objectives).toEqual(['so']);
+    expect(args.smoke_test_steps).toEqual(['st']);
+    // non-array authored values are not coerced into a bogus one-element array
+    expect(mapProposalToCreateArgs(normalized, validProposal({ key_changes: 'oops' }), 'p.json').key_changes).toBeNull();
+  });
+
+  it('QF-213: an unmapped top-level key FAILS LOUD instead of being silently dropped', () => {
+    expect(() => mapProposalToCreateArgs(normalized, validProposal({ authored_but_unread: 'x' }), 'p.json'))
+      .toThrow(/DROP unmapped top-level key\(s\): authored_but_unread/);
+    // premise pin: a clean proposal must NOT throw, so the assertion above cannot pass for the wrong reason
+    expect(() => mapProposalToCreateArgs(normalized, validProposal(), 'p.json')).not.toThrow();
+  });
 });
 
 describe('createFromProposal (dry-run + idempotency, injected deps, zero DB/FS)', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260725-213

**Type:** bug
**Severity:** high

### Issue Description
mapProposalToCreateArgs in scripts/modules/leo-create-sd/proposal-lanes.js never reads proposal.description, and never maps key_changes, success_metrics, strategic_objectives or smoke_test_steps. Authored content is silently replaced by title-derived boilerplate from validate-sd-fields.js, and the resulting thin description is what invites the filename-search enrichment sweep to fill it (on SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 it filled with an unrelated document). THREE PARTS, per Solomon refinements. (a) PRECEDENCE: change line 173 to proposal.description || proposal.scope || proposal.rationale || proposal.title. Description FIRST as the most specific authored field; scope MUST stay AHEAD of rationale or this re-introduces the exact stub-flagging defect SD-REFILL-00229BH8 closed (rationale carries provenance boilerplate that buried a 1500-char scope). Preserve that reasoning in-comment so the next author does not read scope-before-rationale as arbitrary and reorder it. (b) MAP the four arrays. (c) FAIL LOUD on unmapped TOP-LEVEL proposal keys - enumerate top-level keys, subtract the mapped set plus known-ignorables, error on any remainder. Scope it to TOP-LEVEL specifically: proposal.metadata is preserved wholesale minus PROPOSAL_META_DROP_KEYS, so a guard written against authored keys generally would false-positive on every metadata key. DO NOT TOUCH the LEAD-TO-PLAN placeholder-content gate - it correctly detected the boilerplate and Delta held at draft on that signal. Defense in depth worked, just late. The fix belongs at ingest; the gate stays as the backstop.

### Steps to Reproduce
1. Author a proposal JSON with a populated top-level description plus key_changes, success_metrics, strategic_objectives and smoke_test_steps. 2. Run SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-proposal <path>. 3. Read the created row back from strategic_directives_v2.

### Expected Behavior
All authored content lands, or creation fails loudly naming the dropped keys.

### Actual Behavior
Description equals the title verbatim; the four arrays contain title-derived boilerplate (Implement core changes for X, Implementation completeness, Navigate to the relevant page for X). success_criteria maps correctly, so the SD looks populated on casual inspection - which is why this evaded notice. The ingest reports success. Reproduced on both SDs sourced 2026-07-25.

### Changes
- **Files Changed:** 2
  - scripts/modules/leo-create-sd/proposal-lanes.js
  - tests/unit/leo-create-sd-from-proposal.test.js
- **LOC:** 85 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol