### PR TITLE
fix: stop LEO-spawned sessions inheriting the spawner's child-session marker

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -83,6 +83,13 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   const startDir = (cwd && String(cwd).trim()) ? String(cwd) : resolveRepoRoot(env);
 
   const childEnv = { FLEET_WORKER_CALLSIGN: callsign || '', FLEET_WORKER_ROLE: role || 'worker' };
+  // A spawned fleet session is an INDEPENDENT session, not a child of whoever spawned it.
+  // spawn-control merges `{...process.env, ...childEnv}`, so without this the spawner's own
+  // CLAUDE_CODE_CHILD_SESSION marker is inherited, Claude Code disables session persistence
+  // ("Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker"), and the session
+  // NEVER REGISTERS — which is why provisioning polled 10 times and found nothing.
+  // childEnv wins the merge, so setting the documented override here is the durable fix.
+  childEnv.CLAUDE_CODE_FORCE_SESSION_PERSISTENCE = '1';
   if (profileDir) childEnv.CLAUDE_CONFIG_DIR = profileDir; // isolation, child env only
   if (sdToResume) childEnv.FLEET_AUTORESUME_SD = String(sdToResume); // SessionStart hook -> sd-start --force-reclaim
   if (startupPrompt) childEnv.FLEET_WORKER_STARTUP_PROMPT = String(startupPrompt); // persistent replacement for headless -p

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -170,7 +170,15 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
 
   const spawner = opts.spawnFn || ((program, args, env) => {
     // FR-2: carry the invocation's repo-root cwd (paired with new-tab -d) so the session registers in claude_sessions.
-    const child = spawnProcess(program, args, { detached: true, stdio: 'ignore', cwd: invocation.cwd, env: { ...process.env, ...env } });
+    // Strip the spawner's OWN Claude Code session markers before inheriting. These identify the
+    // PARENT session; carrying them into an independent fleet session makes Claude Code treat it
+    // as a child, which switches off session persistence so it never registers. Setting the
+    // override in childEnv is not sufficient on its own — the stale marker must actually be gone.
+    const inherited = { ...process.env };
+    for (const k of ['CLAUDE_CODE_CHILD_SESSION', 'CLAUDE_SESSION_ID', 'CLAUDE_CODE_SESSION_ID']) {
+      delete inherited[k];
+    }
+    const child = spawnProcess(program, args, { detached: true, stdio: 'ignore', cwd: invocation.cwd, env: { ...inherited, ...env } });
     child.unref();
     return child;
   });


### PR DESCRIPTION
Ships the already-committed fix on `fix/spawn-inherits-child-session-marker` (b345590eb8c, authored 2026-07-25 09:21). The commit sat on origin all day with **no PR**, which is the only reason it never landed.

> **Scope corrected after review.** An earlier revision of this description called this change the root cause of the canary outage. That was wrong, and measurement disproved it — see "What this does not fix". It is a real and necessary **mitigation**, not the blocker.

## The change

- `build-session-launch.cjs` — set `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` in `childEnv` (childEnv wins the merge)
- `spawn-control.js` — strip the spawner's own `CLAUDE_CODE_CHILD_SESSION` / `CLAUDE_SESSION_ID` / `CLAUDE_CODE_SESSION_ID` before inheriting, since the override alone is insufficient while the stale marker is present

16 insertions, 1 deletion, 2 files.

Without it, a spawned fleet session inherits the spawner's `CLAUDE_CODE_CHILD_SESSION` marker through `{...process.env, ...childEnv}`; Claude Code treats it as a child, disables session persistence, and the session dies as a ghost on first heartbeat.

## What this fixes: session **lifespan**

Measured on the two canaries provisioned today:

| session | lifespan | `account_profile` |
|---|---|---|
| `84c939a3` | 47m | **not set** |
| `a0b2eec2` | 43m | **not set** |

Both survived well past first check-in. Before this fix they were ghosts on first heartbeat.

## What this does **not** fix: canary **discoverability**

The CP3 blocker is a separate defect. `provisionCanary` (`lib/fleet/canary-provision.js:69`) is imported by **nothing outside its own unit test** — verified: the only other match, `scripts/canary/run-canary-probe.mjs:67`, is an unrelated same-named local function.

Consequence: `metadata.account_profile = 'canary'` is **never written**. **Zero** sessions in the last 24h carry that stamp. So `resolveCanary(by account_profile=canary)` finds nothing and `scripts/fleet/start-cp3-drills.js` fail-closes at target resolution.

Two canaries were alive and heartbeating for ~45 minutes today while zero canaries were resolvable, simultaneously. **Survival was sufficient; discoverability was not.**

That gap is item C of `SD-LEO-INFRA-LAUNCHER-CAN-HOST-001`, which is now scoped as the critical path — with this PR reclassified as a landed mitigation to verify rather than build.

## Merge safety

- Applies cleanly onto `origin/main` (`git merge-tree` — no conflict markers)
- Both files **untouched on main** since the merge-base; the 18-commit lag is lag, not drift
- Fix **absent** from main by any other route (0 occurrences of either symbol)

## Verification note

This lands a capability. It does **not** constitute CP3 live acceptance — CP3 remains fenced under `needs_coordinator_review`, and its acceptance is sequenced separately against live `fleet_verb_*` evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
