### PR TITLE
fix(QF-20260725-761): tier on DDL, not on prose — inline comments no longer flip Tier-1 to Tier-2

### DIFF
--- a/scripts/lib/migration-tier-classifier.mjs
+++ b/scripts/lib/migration-tier-classifier.mjs
@@ -80,7 +80,47 @@ const CONST_DEFAULT = /^\s*(?:NULL|TRUE|FALSE|-?\d+(?:\.\d+)?|'(?:[^']|'')*'|"(?
 
 function T2(reason) { return { tier: 2, reason, matched: [] }; }
 
-/** Strip leading line/block comments, lowercase, collapse whitespace — for head matching. */
+/**
+ * Strip line/block comments that are OUTSIDE single-quoted string literals, replacing each with
+ * a space. Literal-aware by necessity — see the note in normalizeHead: a COMMENT ON ... IS '...'
+ * value legitimately contains '--' and '/*' as prose, and eating it corrupts the statement the
+ * head matchers must read. Mirrors countTopLevelSemicolons' scanner, including the SQL-standard
+ * doubled-quote ('') escape. Dollar-quoted bodies are already removed by stripNonDdl upstream.
+ */
+function stripCommentsOutsideStrings(s) {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inString) {
+      if (ch === "'") {
+        if (s[i + 1] === "'") { out += "''"; i++; continue; } // escaped '' stays inside the string
+        inString = false;
+      }
+      out += ch;
+      continue;
+    }
+    if (ch === "'") { inString = true; out += ch; continue; }
+    if (ch === '-' && s[i + 1] === '-') {
+      const nl = s.indexOf('\n', i);
+      out += ' ';
+      if (nl === -1) return out;   // line comment runs to end of input
+      i = nl - 1;                  // resume ON the newline so it is preserved
+      continue;
+    }
+    if (ch === '/' && s[i + 1] === '*') {
+      const end = s.indexOf('*/', i + 2);
+      out += ' ';
+      if (end === -1) return out;  // unterminated block comment swallows the rest
+      i = end + 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/** Strip leading comments, then all comments outside string literals; lowercase; collapse ws. */
 function normalizeHead(raw) {
   let s = String(raw);
   // strip leading -- line comments and /* */ block comments repeatedly
@@ -90,6 +130,26 @@ function normalizeHead(raw) {
     s = s.replace(/^\s*--[^\n]*\n?/, '');
     s = s.replace(/^\s*\/\*[\s\S]*?\*\//, '');
   } while (s !== prev);
+  // QF-20260725-761: the loop above is anchored, so it only removes comments that PRECEDE the
+  // statement. A TRAILING/INLINE comment survived into the head and made tier key on prose:
+  //   (a) it swallowed the following item — 'add column a text, -- note\n add column b text'
+  //       splits into ['add column a text', '-- note add column b text'], and the second item
+  //       fails Rule C's add-column match, so the whole ALTER falls to TIER-2; and
+  //   (b) it corrupted a constant DEFAULT — 'default 5 /* note */' fails CONST_DEFAULT.
+  // Both verified against the corpus: the flagship revenue migration 20260724190000 was TIER-2
+  // by a comment, not by risk.
+  //
+  // NOTE THE STRIPPER IS LITERAL-AWARE, and it must be: the security/body scans use the blunt
+  // stripSqlComments because over-stripping only makes a SCAN more conservative, but a head is
+  // MATCHED, so over-stripping corrupts legitimate DDL. Using stripSqlComments here regressed
+  // 20260710_venture_capabilities_evidence.sql from TIER-1 to TIER-2, because its COMMENT ON
+  // COLUMN ... IS '...' literal contains '--' as prose punctuation and the blunt stripper ate
+  // the rest of the statement. Same family as QF-20260711-804, where a COMMENT string's prose
+  // semicolons false-triggered the split checks — hence countTopLevelSemicolons above.
+  // This LOOSENS NO TIER-2 CRITERION: every check below still applies unchanged, and it cannot
+  // re-open the comment-split bypass because a stripped comment becomes a SPACE — an interior
+  // comment splits a token apart, it never fuses two fragments into a keyword.
+  s = stripCommentsOutsideStrings(s);
   return s.replace(/\s+/g, ' ').trim().toLowerCase();
 }
 

--- a/tests/unit/migration-tier-classifier.test.js
+++ b/tests/unit/migration-tier-classifier.test.js
@@ -176,3 +176,64 @@ describe('classifyMigration — invariants', () => {
     expect(r.reason).not.toBe('embedded_semicolon_ambiguity');
   });
 });
+
+/**
+ * QF-20260725-761 — a trailing/inline comment must not decide the tier. normalizeHead only
+ * stripped comments that PRECEDE a statement, so prose survived into the matched head and
+ * pushed provably-additive migrations to TIER-2 (a human ceremony sized by a comment).
+ * The stripper is literal-aware on purpose: the blunt stripSqlComments used by the security
+ * scan corrupts a COMMENT ON ... IS '...' value containing '--', which regressed
+ * 20260710_venture_capabilities_evidence.sql from TIER-1 to TIER-2 during development.
+ */
+describe('QF-20260725-761 — comments must not change the tier', () => {
+  const T1 = (sql) => expect(classifyMigration(sql).tier).toBe(1);
+  const T2 = (sql) => expect(classifyMigration(sql).tier).toBe(2);
+
+  it('trailing comment on a mid-list ADD COLUMN item stays TIER-1 (the swallow bug)', () => {
+    T1('ALTER TABLE operator_cash_burn_monthly\n  ADD COLUMN manual_revenue_usd numeric, -- operator-entered\n  ADD COLUMN manual_revenue_last_synced_at timestamptz;');
+  });
+
+  it('classifies identically with and without that comment', () => {
+    const withC = 'ALTER TABLE foo\n  ADD COLUMN a numeric, -- note\n  ADD COLUMN b timestamptz;';
+    const without = 'ALTER TABLE foo\n  ADD COLUMN a numeric,\n  ADD COLUMN b timestamptz;';
+    expect(classifyMigration(withC).tier).toBe(classifyMigration(without).tier);
+  });
+
+  it('inline comment between a constant DEFAULT and the next item stays TIER-1', () => {
+    T1('ALTER TABLE foo ADD COLUMN a int DEFAULT 5 -- note\n, ADD COLUMN b text;');
+  });
+
+  it('block comment after a constant DEFAULT stays TIER-1', () => {
+    T1('ALTER TABLE foo ADD COLUMN a int DEFAULT 5 /* note */;');
+  });
+
+  // The literal-awareness guard — this is the case that a blunt comment-stripper breaks.
+  it('a COMMENT ON value containing -- as prose is NOT eaten (stays TIER-1)', () => {
+    T1("ALTER TABLE venture_capabilities ADD COLUMN evidence jsonb;\nCOMMENT ON COLUMN venture_capabilities.evidence IS 'citation -- a live URL, an account ID -- so it reflects delivered reality';");
+  });
+
+  it('a COMMENT ON value containing /* as prose is NOT eaten (stays TIER-1)', () => {
+    T1("ALTER TABLE foo ADD COLUMN a jsonb;\nCOMMENT ON COLUMN foo.a IS 'shape /* documented but not enforced */ see docs';");
+  });
+
+  // Criteria must NOT loosen: a comment cannot launder a genuinely TIER-2 statement.
+  it('NOT NULL is still TIER-2 even with a reassuring comment', () => {
+    T2('ALTER TABLE foo ADD COLUMN a int NOT NULL; -- harmless, promise');
+  });
+
+  it('volatile DEFAULT is still TIER-2 even with a comment', () => {
+    T2('ALTER TABLE foo ADD COLUMN a timestamptz DEFAULT now(); -- additive only');
+  });
+
+  it('DROP COLUMN is still TIER-2 even when a comment sits beside it', () => {
+    T2('ALTER TABLE foo ADD COLUMN a int, DROP COLUMN b; -- tidy-up');
+  });
+
+  it('a comment cannot hide a DROP behind an additive head', () => {
+    T2('ALTER TABLE foo ADD COLUMN a int; /* nothing to see */ DROP TABLE bar;');
+  });
+
+  it('comment-split SECURITY DEFINER is still caught (stripping yields a space, not a fusion)', () => {
+    T2('CREATE FUNCTION f() RETURNS void LANGUAGE sql SECURITY/*x*/DEFINER AS $$ SELECT 1 $$;');
+  });
+});


### PR DESCRIPTION
## Problem
`normalizeHead` stripped only comments that **precede** a statement (the loop is `^`-anchored), so a trailing/inline comment survived into the head that the Rule C matchers read. Two consequences, both verified:

- **It swallowed the following item** — `add column a text, -- note\n add column b text` splits into `['add column a text', '-- note add column b text']`; the second item fails Rule C's add-column match, so the whole ALTER falls to TIER-2.
- **It corrupted a constant DEFAULT** — `default 5 /* note */` fails `CONST_DEFAULT`.

Net effect: the flagship revenue migration `20260724190000_add_manual_revenue_provenance_columns` was chairman-gated **by a comment, not by risk** — a human ceremony sized by a comment-parsing bug.

## The stripper is literal-aware, and that is load-bearing
The obvious fix — reuse the blunt `stripSqlComments` the security scan already runs — is **wrong here**. Over-stripping only makes a *scan* more conservative, but a head is **matched**, so over-stripping corrupts legitimate DDL.

I tried it that way first and it **regressed** `20260710_venture_capabilities_evidence.sql` from TIER-1 to TIER-2, because its `COMMENT ON COLUMN … IS '…'` value contains `--` as prose punctuation and the blunt stripper ate the rest of the statement. `stripCommentsOutsideStrings` mirrors the existing `countTopLevelSemicolons` scanner (same doubled-quote `''` handling) — the same family as QF-20260711-804, where a COMMENT string's prose semicolons false-triggered the split checks.

## No TIER-2 criterion is loosened
Every check is unchanged. Removing prose only stops a comment masquerading as risk, and a stripped comment becomes a **space**, so the comment-split bypass (`SECURITY/*x*/DEFINER`) is still caught — an interior comment splits a token, it never fuses one.

## Measured across all 1323 forward migrations (old vs new)

| | Count |
|---|---|
| Tier-2 → Tier-1 | **1** (`20260724190000_add_manual_revenue_provenance_columns.sql`) |
| Tier-1 → Tier-2 | **0** (no regressions) |
| Totals | 26/1297 → 27/1296 |

> Scope note for the reviewer: the QF cites a Tier-1=2 / Tier-2=124 split across the **126 committed-not-deployed** files. I measured all 1323 forward migrations, not that subset, and only one file flips. The fix does exactly what the QF asks and unblocks the revenue migration it names by name, but it does **not** broadly rebalance the delegatable lane — if the expectation was a larger shift, the remaining Tier-2 files are Tier-2 for reasons other than comments.

## Tests
86 pass (75 pre-existing unchanged + 11 new). The **4 behaviour-change tests were verified RED against `origin/main`** before going green; the other 7 are invariants that must hold in both directions — the literal-awareness guards plus the must-not-loosen cases (NOT NULL, volatile DEFAULT, DROP COLUMN, hidden DROP, comment-split SECURITY DEFINER).

🤖 Generated with [Claude Code](https://claude.com/claude-code)