### PR TITLE
fix(QF-20260725-141): classify taper gauge on durable field, report unclassified

### DIFF
--- a/lib/fleet/exec-email-alignment.mjs
+++ b/lib/fleet/exec-email-alignment.mjs
@@ -23,6 +23,28 @@ export function isMetaSd(sdKey) {
   return META_PREFIX.test(String(sdKey || ''));
 }
 
+// QF-20260725-141: the key-prefix regex above is NOT a sound product/meta discriminant — it is
+// binary with a silent fallback, so every key it does not recognise lands in PRODUCT. Measured over
+// a live 30d window (979 rows) that silently counted 43 SD-FDBK, 20 SD-REFILL and 27 test fixtures
+// (SD-TEST/TEST-*/SD-UAT) as PRODUCT — i.e. it reported test rows to the chairman as product work.
+// target_application IS a durable field set at creation and was 100% populated over that window
+// (0 NULL): 'EHG_Engineer' is the harness itself, any other app is a venture. Same rows: the prefix
+// regex says 357 product, the durable field says 269 — an 88-row spread, the artifact this QF is for.
+const HARNESS_APP = 'EHG_Engineer';
+
+/**
+ * THREE-valued classification: 'meta' | 'product' | 'unclassified'.
+ * Deliberately NOT binary — an unrecognised row must surface as UNCLASSIFIED rather than inflate
+ * product, because "always returns A number" is exactly what let this gauge misinform silently.
+ */
+export function classifySdRow(row) {
+  const app = row && typeof row.target_application === 'string' ? row.target_application.trim() : '';
+  if (app) return app === HARNESS_APP ? 'meta' : 'product';
+  // No durable field on this row (historical/backfill gap): the key prefix can still positively
+  // identify meta, but absence of that prefix proves nothing — so it is unclassified, not product.
+  return isMetaSd(row && row.sd_key) ? 'meta' : 'unclassified';
+}
+
 /**
  * Compute the meta-to-product ratio over a window from a list of SD rows ({ sd_key }).
  * Pure — the caller supplies the rows. Returns { meta, product, ratio, line } or null if no rows.
@@ -30,13 +52,20 @@ export function isMetaSd(sdKey) {
 export function computeMetaToProductRatio(sdRows, { windowDays = 30 } = {}) {
   const rows = Array.isArray(sdRows) ? sdRows : [];
   if (rows.length === 0) return null;
-  let meta = 0, product = 0;
-  for (const r of rows) (isMetaSd(r && r.sd_key) ? meta++ : product++);
+  let meta = 0, product = 0, unclassified = 0;
+  for (const r of rows) {
+    const c = classifySdRow(r);
+    if (c === 'meta') meta++; else if (c === 'product') product++; else unclassified++;
+  }
   // ratio = meta per 1 product; product=0 → show meta count without a divide-by-zero.
   const ratio = product > 0 ? meta / product : null;
   const ratioStr = ratio == null ? `${meta} meta / 0 product` : `${ratio.toFixed(1)} : 1`;
-  const line = `Meta-to-product ratio (last ${windowDays}d filed): ${ratioStr} (${meta} meta vs ${product} product) — taper target: declining`;
-  return { meta, product, ratio, windowDays, line };
+  // QF-20260725-141: unclassified is reported EXPLICITLY, never folded into either side. A taper the
+  // chairman acts on must show what it could not classify, so a large bucket is visible as a data
+  // gap instead of silently moving the ratio.
+  const unclassifiedStr = unclassified > 0 ? `, ${unclassified} unclassified` : '';
+  const line = `Meta-to-product ratio (last ${windowDays}d filed): ${ratioStr} (${meta} meta vs ${product} product${unclassifiedStr}) — taper target: declining`;
+  return { meta, product, unclassified, ratio, windowDays, line };
 }
 
 /**
@@ -68,7 +97,10 @@ export async function computeAlignmentLines(io, { windowDays = 30, nowMs = null 
     const sinceMs = (typeof nowMs === 'number' ? nowMs : Date.parse(new Date().toISOString())) - windowDays * 24 * 3600 * 1000;
     const sinceIso = new Date(sinceMs).toISOString();
     const data = await fetchAllPaginated(() => db.from('strategic_directives_v2')
-      .select('sd_key')
+      // QF-20260725-141: target_application is REQUIRED here — classifySdRow reads it as the durable
+      // discriminant. Selecting sd_key alone would leave it undefined on every row and silently
+      // degrade the whole window to 'unclassified' (fix present but inert).
+      .select('sd_key, target_application')
       .gte('created_at', sinceIso)
       .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries (FR-6)
     const r = computeMetaToProductRatio(data, { windowDays });

--- a/lib/fleet/exec-email-alignment.test.js
+++ b/lib/fleet/exec-email-alignment.test.js
@@ -3,6 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isMetaSd,
+  classifySdRow,
   computeMetaToProductRatio,
   formatDistanceToQuitLine,
 } from './exec-email-alignment.mjs';
@@ -28,29 +29,60 @@ describe('computeMetaToProductRatio', () => {
     expect(computeMetaToProductRatio([])).toBeNull();
     expect(computeMetaToProductRatio(null)).toBeNull();
   });
-  it('counts meta vs product and computes the ratio', () => {
+  it('counts meta vs product and computes the ratio (durable target_application)', () => {
     const rows = [
-      { sd_key: 'SD-LEO-INFRA-A-001' },
-      { sd_key: 'SD-LEO-INFRA-B-001' },
-      { sd_key: 'SD-EHG-PRODUCT-C-001' },
-      { sd_key: 'SD-EHG-UIUX-RM-D-001' },
+      { sd_key: 'SD-LEO-INFRA-A-001', target_application: 'EHG_Engineer' },
+      { sd_key: 'SD-LEO-INFRA-B-001', target_application: 'EHG_Engineer' },
+      { sd_key: 'SD-EHG-PRODUCT-C-001', target_application: 'MarketLens' },
+      { sd_key: 'SD-EHG-UIUX-RM-D-001', target_application: 'DemandSense' },
     ];
     const r = computeMetaToProductRatio(rows, { windowDays: 30 });
     expect(r.meta).toBe(2);
     expect(r.product).toBe(2);
+    expect(r.unclassified).toBe(0);
     expect(r.ratio).toBe(1);
     expect(r.line).toContain('1.0 : 1');
     expect(r.line).toContain('2 meta vs 2 product');
+    expect(r.line).not.toContain('unclassified'); // omitted entirely when zero
     expect(r.line).toContain('last 30d');
   });
   it('avoids divide-by-zero when there are no product items', () => {
-    const r = computeMetaToProductRatio([{ sd_key: 'SD-LEO-INFRA-A-001' }]);
+    const r = computeMetaToProductRatio([{ sd_key: 'SD-LEO-INFRA-A-001', target_application: 'EHG_Engineer' }]);
     expect(r.ratio).toBeNull();
     expect(r.line).toContain('1 meta / 0 product');
   });
   it('honours the windowDays label', () => {
-    const r = computeMetaToProductRatio([{ sd_key: 'QF-1' }, { sd_key: 'SD-EHG-X-1' }], { windowDays: 7 });
+    const r = computeMetaToProductRatio(
+      [{ sd_key: 'QF-1', target_application: 'EHG_Engineer' }, { sd_key: 'SD-EHG-X-1', target_application: 'EHG' }],
+      { windowDays: 7 });
     expect(r.line).toContain('last 7d');
+  });
+
+  // QF-20260725-141 regression guards.
+  it('a row with NO durable field and no meta prefix is UNCLASSIFIED, never product', () => {
+    // The exact live shapes the prefix regex silently counted as product: feedback, belt-refill,
+    // and test fixtures. Inflating product is what made the taper unusable as a chairman input.
+    const rows = [
+      { sd_key: 'SD-FDBK-ENH-FOO-001' },
+      { sd_key: 'SD-REFILL-00ABCDEF' },
+      { sd_key: 'SD-TEST-FIXTURE-001' },
+    ];
+    const r = computeMetaToProductRatio(rows);
+    expect(r.product).toBe(0);
+    expect(r.unclassified).toBe(3);
+    expect(r.line).toContain('3 unclassified');
+  });
+  it('the durable field OVERRIDES the key prefix in both directions', () => {
+    // A meta-prefixed key targeting a venture repo is product work; a product-looking key targeting
+    // the harness is meta. Classifying on the key alone gets both of these backwards.
+    expect(classifySdRow({ sd_key: 'QF-20260725-141', target_application: 'MarketLens' })).toBe('product');
+    expect(classifySdRow({ sd_key: 'SD-EHG-PRODUCT-X-001', target_application: 'EHG_Engineer' })).toBe('meta');
+  });
+  it('classifySdRow is three-valued and treats blank/whitespace app as absent', () => {
+    expect(classifySdRow({ sd_key: 'SD-LEO-INFRA-A-001' })).toBe('meta');
+    expect(classifySdRow({ sd_key: 'SD-WHATEVER-1', target_application: '   ' })).toBe('unclassified');
+    expect(classifySdRow({})).toBe('unclassified');
+    expect(classifySdRow(null)).toBe('unclassified');
   });
 });
 


### PR DESCRIPTION
Closes QF-20260725-141.

The meta/product split feeding the **chairman-facing** taper gauge was computed by a key-prefix regex that is binary with a silent fallback — every key it didn't recognise landed in **product**. It always returned a confident number, so the disagreement was invisible.

## Measured, not asserted
Over a live 30d window (979 rows) the old path silently counted as PRODUCT:

| rows | prefix | actually |
|---|---|---|
| 43 | `SD-FDBK-` | feedback/harness |
| 20 | `SD-REFILL-` | belt-refill harness |
| 27 | `SD-TEST-`/`TEST-*`/`SD-UAT-` | **test fixtures** |

Test rows were being reported to the chairman as product work.

**Effect on the number:** 1.7:1 (622/357) under the regex vs **2.6:1 (708/269)** under the durable field, on identical rows — the old gauge understated the meta:product ratio by ~35%.

## Change
- `classifySdRow()` is **three-valued**: `meta | product | unclassified`.
- Classifies on `target_application` — durable, set at creation, **100% populated** over that window (0 NULL). `EHG_Engineer` = harness; any other app = venture.
- The durable field **overrides the key prefix in both directions** (a `QF-` key targeting a venture repo is product work; an `SD-EHG-` key targeting the harness is meta).
- A row with no durable field and no meta prefix is **unclassified, never product** — absence of a meta prefix proves nothing.
- The line reports the unclassified count **explicitly**, so a data gap is visible instead of silently moving the ratio.
- **The caller's `select` now fetches `target_application`.** Without that the fix would be present but **inert** — every row would degrade to unclassified.

## Notes
- `sd_type` (the field the QF suggested) is 100% populated but encodes work *kind* (infrastructure/feature/bugfix), not product-vs-meta — an infra `feature` is still meta. So it can't carry this distinction alone; `target_application` can.
- `isMetaSd` is retained unchanged for its other callers (`plan-drift-detectors.js` imports it) and now backs only the no-durable-field path.
- Four existing tests asserted the old "no meta prefix ⇒ product" behaviour; they encoded the bug and were updated to the durable-field semantics.

Tests: 136 passing across `lib/fleet` + `lib/governance`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)