### PR TITLE
feat(QF-20260725-085): detect orphaned COMPLETE work — branches with commits and no PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "audit:retro": "node scripts/audit-retro.mjs",
     "audit:rpc-grants": "node scripts/audit-rpc-execute-grants.mjs",
     "audit:orphan-prs": "node scripts/audit-orphan-prs.mjs",
+    "audit:unrouted-branches": "node scripts/audit-unrouted-branches.mjs",
     "audit:shared-tables": "node scripts/audit-shared-tables-residue.cjs",
     "audit:ghost-completed": "node scripts/audit-ghost-completed-sds.mjs",
     "audit:venture-design-pass": "node scripts/audit-venture-design-pass.mjs",

--- a/scripts/audit-unrouted-branches.mjs
+++ b/scripts/audit-unrouted-branches.mjs
@@ -34,6 +34,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { resolveGitHubRepo } from '../lib/repo-paths.js';
 
 const BASE = 'origin/main';
 const PROTECTED = new Set(['main', 'master', 'HEAD']);
@@ -150,7 +151,10 @@ function main() {
   const argv = process.argv.slice(2);
   const flag = (name) => (argv.includes(name) ? argv[argv.indexOf(name) + 1] : undefined);
   const json = flag('--format') === 'json';
-  const repo = flag('--repo') || 'rickfelix/EHG_Engineer';
+  // Never hard-code an owner/repo literal: lint-repo-resolution-drift exists to stop code
+  // assuming the platform only ever has two repos. Env first (in a GHA venue GITHUB_REPOSITORY
+  // is the authoritative match for the checkout we are scanning), then the canonical resolver.
+  const repo = flag('--repo') || process.env.GITHUB_REPOSITORY || resolveGitHubRepo('EHG_Engineer');
   const maxAgeDays = Number(flag('--max-age-days') ?? DEFAULT_MAX_AGE_DAYS);
 
   const rows = findUnroutedBranches(process.cwd(), repo, { maxAgeDays });

--- a/scripts/audit-unrouted-branches.mjs
+++ b/scripts/audit-unrouted-branches.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * audit-unrouted-branches — list branches carrying FINISHED work that no PR routes.
+ *
+ * QF-20260725-085. Sibling of audit-orphan-prs.mjs, which covers the inverse case
+ * (open PRs whose parent SD/QF is already completed).
+ *
+ * THE GAP THIS CLOSES: every existing surface tracks work that is CLAIMED, IN
+ * FLIGHT, or FAILING. Finished-but-unrouted work is none of those — it is invisible
+ * precisely BECAUSE it succeeded. Measured cost, twice in one day: branch
+ * fix/spawn-inherits-child-session-marker carried one pushed commit from 09:21 with
+ * zero conflicts against origin/main and no PR. It sat until 16:20 while being THE
+ * root blocker of the entire LEO chain, and every board looked clean throughout.
+ *
+ * MERGED-BY-ANY-ROUTE IS TWO CHECKS, NOT ONE. The QF says verify by ancestry rather
+ * than by branch name — correct, but ancestry ALONE is insufficient here: a SQUASH
+ * merge rewrites the commit, so the branch tip is not an ancestor of main even though
+ * the work landed. This repo squash-merges routinely, and the effect is dramatic —
+ * measured at authoring: 5050 branches total, 3418 of them "not merged" by ancestry,
+ * the vast majority of which DID land via squash. So we apply both:
+ *   1. ancestry — `git for-each-ref --no-merged=origin/main` (one call, free)
+ *   2. patch-equivalence — `git cherry origin/main <ref>` compares patch-ids and marks
+ *      '-' for commits already upstream, catching squash and rebase
+ * A branch is unrouted only if it fails BOTH. Branch names are never consulted.
+ *
+ * WHY AN AGE WINDOW IS LOAD-BEARING, NOT A SHORTCUT. Running the patch-equivalence
+ * check across all 3418 ancestry-unmerged refs takes many minutes (one git process
+ * each) and buries the signal in years of abandoned branches — branch cleanup is a
+ * different job with its own scripts. The failure mode this detector exists for is
+ * RECENT finished work falling through a gap between owners (the live case sat 7
+ * hours). So we bound by newest-commit age (default 14 days, --max-age-days) and
+ * report the age of every hit, which the QF asks for anyway so a fresh mid-work
+ * branch does not alarm.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const BASE = 'origin/main';
+const PROTECTED = new Set(['main', 'master', 'HEAD']);
+/**
+ * Default window, chosen from measurement rather than taste:
+ *   3d  ->  6 hits,  ~5s   (fast enough to surface inline anywhere)
+ *  14d  -> 36 hits, ~116s  (useful as a periodic sweep, too slow for a render)
+ * The cost is one `git cherry` per surviving ref, so runtime scales with the window.
+ * 3d also matches the failure mode: the live incident sat 7 HOURS, not weeks.
+ * Widen with --max-age-days for an occasional deeper audit.
+ */
+const DEFAULT_MAX_AGE_DAYS = 3;
+/** Below this, a branch is presumed still being worked and is not reported. */
+const DEFAULT_MIN_AGE_HOURS = 1;
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+/**
+ * Ancestry-unmerged refs with their commit dates, in ONE git call.
+ * De-duplicated by short branch name so a local/origin pair counts once.
+ */
+export function listUnmergedRefs(cwd) {
+  const raw = git(['for-each-ref', `--no-merged=${BASE}`, '--format=%(refname:short)\t%(committerdate:iso-strict)',
+    'refs/heads', 'refs/remotes/origin'], cwd);
+  const byBranch = new Map();
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    const [ref, date] = line.split('\t');
+    const branch = ref.replace(/^origin\//, '');
+    if (PROTECTED.has(branch)) continue;
+    if (!byBranch.has(branch)) byBranch.set(branch, { branch, ref, newestCommitISO: date || null });
+  }
+  return [...byBranch.values()];
+}
+
+/**
+ * Pure: is this ref inside the age window worth checking?
+ * Exported for testing without git.
+ */
+export function withinAgeWindow(newestCommitISO, { maxAgeDays = DEFAULT_MAX_AGE_DAYS, minAgeHours = DEFAULT_MIN_AGE_HOURS } = {}, now = Date.now()) {
+  const ts = newestCommitISO ? Date.parse(newestCommitISO) : NaN;
+  if (!Number.isFinite(ts)) return false;
+  const ageHours = (now - ts) / 3_600_000;
+  return ageHours >= minAgeHours && ageHours <= maxAgeDays * 24;
+}
+
+/**
+ * Pure: decide whether a branch holds unrouted work, given gathered facts.
+ * Exported so the merged-by-any-route logic is testable without git or gh.
+ */
+export function classifyBranch({ branch, ref, unmergedPatchCount, hasOpenPR, newestCommitISO }, now = Date.now()) {
+  if (unmergedPatchCount === 0) return null; // landed via squash or rebase
+  if (hasOpenPR) return null;                // already routed for review
+  const ts = newestCommitISO ? Date.parse(newestCommitISO) : null;
+  const ageHours = ts ? (now - ts) / 3_600_000 : null;
+  return {
+    branch,
+    ref,
+    unmerged_commits: unmergedPatchCount,
+    newest_commit: newestCommitISO || null,
+    age_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
+  };
+}
+
+function openPRBranches(repo) {
+  try {
+    const raw = execFileSync('gh', ['pr', 'list', '--repo', repo, '--state', 'open', '--limit', '1000', '--json', 'headRefName'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 60_000 });
+    return { set: new Set(JSON.parse(raw).map((p) => p.headRefName)), ok: true };
+  } catch (err) {
+    // Fail LOUD rather than silently reporting every branch as unrouted.
+    process.stderr.write(`[audit-unrouted-branches] gh pr list failed (${err.message}); cannot distinguish routed branches — aborting to avoid false positives\n`);
+    return { set: new Set(), ok: false };
+  }
+}
+
+/** Count commits with no patch-equivalent upstream ('+' rows from git cherry). */
+export function countUnmergedPatches(ref, cwd) {
+  try {
+    return git(['cherry', BASE, ref], cwd).split('\n').filter((l) => l.startsWith('+')).length;
+  } catch {
+    return 1; // conservative: assume unmerged so it surfaces rather than hides
+  }
+}
+
+export function findUnroutedBranches(cwd, repo, opts = {}) {
+  const { set: openPRs, ok } = openPRBranches(repo);
+  if (!ok) return null;
+  const found = [];
+  for (const cand of listUnmergedRefs(cwd)) {
+    if (!withinAgeWindow(cand.newestCommitISO, opts)) continue;
+    try {
+      const hit = classifyBranch({
+        ...cand,
+        unmergedPatchCount: countUnmergedPatches(cand.ref, cwd),
+        hasOpenPR: openPRs.has(cand.branch),
+      });
+      if (hit) found.push(hit);
+    } catch (err) {
+      process.stderr.write(`[audit-unrouted-branches] skipped ${cand.ref}: ${err.message}\n`);
+    }
+  }
+  return found.sort((a, b) => (b.age_hours ?? 0) - (a.age_hours ?? 0)); // oldest first
+}
+
+function fmtAge(h) {
+  if (h === null) return '?';
+  return h >= 24 ? `${Math.round(h / 24)}d` : `${h}h`;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const flag = (name) => (argv.includes(name) ? argv[argv.indexOf(name) + 1] : undefined);
+  const json = flag('--format') === 'json';
+  const repo = flag('--repo') || 'rickfelix/EHG_Engineer';
+  const maxAgeDays = Number(flag('--max-age-days') ?? DEFAULT_MAX_AGE_DAYS);
+
+  const rows = findUnroutedBranches(process.cwd(), repo, { maxAgeDays });
+  if (rows === null) { process.exit(0); return; } // gh unavailable; already warned
+
+  if (json) {
+    process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+  } else if (rows.length === 0) {
+    console.log(`[audit-unrouted-branches] No unrouted branches in the last ${maxAgeDays}d — everything ahead of ${BASE} is merged or has an open PR.`);
+  } else {
+    console.log(`[audit-unrouted-branches] ${rows.length} branch(es) with FINISHED work and NO open PR (last ${maxAgeDays}d):`);
+    for (const r of rows) {
+      console.log(`  - ${r.branch}  +${r.unmerged_commits} unmerged commit(s)  newest ${fmtAge(r.age_hours)} old`);
+    }
+    console.log('  → open a PR, or delete the branch if the work is abandoned.');
+  }
+  process.exit(0); // informational only; never block a caller
+}
+
+if (process.argv[1] && process.argv[1].endsWith('audit-unrouted-branches.mjs')) {
+  try { main(); } catch (err) {
+    process.stderr.write(`[audit-unrouted-branches] fatal: ${err.message}\n`);
+    process.exit(0);
+  }
+}

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -95,6 +95,14 @@ export const COMPOSED_CORES = [
   // periodic-cron lag are most likely to have gone unnoticed).
   { key: 'unranked-gauge', script: 'gauge-unranked-claimable-leaves.mjs', args: ['scripts/gauge-unranked-claimable-leaves.mjs'], quiescentSkip: false },
   { key: 'audit', script: 'coordinator-audit.mjs', args: ['scripts/coordinator-audit.mjs'], quiescentSkip: true },
+  // QF-20260725-085: NOT quiescentSkip. This detects FINISHED work that no PR routes —
+  // a branch with commits and no PR is invisible to every other surface, because those
+  // track work that is claimed, in flight, or failing, and this work is none of those:
+  // it is invisible precisely BECAUSE it succeeded. A quiet fleet is exactly when such
+  // a branch is most likely to be sitting unnoticed (live incident: one pushed commit
+  // was THE root blocker of the whole LEO chain for 7 hours while every board looked
+  // clean). Default 3d window runs in ~5s, well inside the 90s core timeout.
+  { key: 'unrouted-branches', script: 'audit-unrouted-branches.mjs', args: ['scripts/audit-unrouted-branches.mjs'], quiescentSkip: false },
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2: NOT
   // quiescentSkip -- a queued relay-request is exactly as urgent when the fleet is
   // otherwise quiet (a quiet fleet is precisely when a relay is most likely to sit

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -131,6 +131,18 @@ export const STANDARD_LOOPS = [
     prompt: 'node scripts/fleet-dashboard.cjs inbox' },
   { key: 'audit', folded: true,       label: 'Coordinator 3-source audit', script: 'coordinator-audit.mjs', cron: '*/15 * * * *',
     prompt: 'node scripts/coordinator-audit.mjs' },
+  // QF-20260725-085: FINISHED-but-unrouted work (a branch ahead of origin/main with no open PR) — the
+  // one class every other surface is blind to, because the others track work that is claimed, in
+  // flight, or failing, and this work is none of those: it is invisible precisely BECAUSE it
+  // succeeded. folded:true — composed by the quiet tick (COMPOSED_CORES key 'unrouted-branches'),
+  // registered here for the loop-parity census so a cutover cannot silently drop the duty. NEVER
+  // arm standalone. Deliberately NOT gha_backed: there is no unrouted-branches-cron.yml, and the
+  // ~5050-ref sweep belongs next to a local checkout rather than on a runner. The cron value
+  // mirrors the quiet tick's own cadence because that is the real fire rate — it is never armed,
+  // but parseStandardLoops derives expected_interval_seconds from it, so an honest value beats
+  // the 3600s no-cron fallback.
+  { key: 'unrouted-branches', folded: true, label: 'Unrouted finished-work detector (branches with commits and no open PR)', script: 'audit-unrouted-branches.mjs', cron: '0,15,30,45 * * * *',
+    prompt: 'node scripts/audit-unrouted-branches.mjs' },
   // SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001: durable charter-compliance self-audit (replaces the
   // lost session-only CronCreate). READ-ONLY detection; authoritative PID/armed-silence liveness; fail-loud
   // on a foundational query error; names a remediation per violation. The prompt compels REMEDIATE-THEN-VERIFY.

--- a/tests/unit/audit-unrouted-branches.test.js
+++ b/tests/unit/audit-unrouted-branches.test.js
@@ -1,0 +1,104 @@
+/**
+ * QF-20260725-085 — unit tests for the unrouted-branch detector's pure logic.
+ *
+ * The classification is the part that matters and the part naive versions get
+ * wrong: "already merged" is TWO checks, because this repo squash-merges, so a
+ * landed branch's tip is NOT an ancestor of main. Ancestry alone would report
+ * thousands of already-shipped branches as outstanding (measured at authoring:
+ * 3418 of 5050 refs are ancestry-unmerged, mostly squash-landed).
+ *
+ * Pure functions only — no git, no gh, no network, no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyBranch, withinAgeWindow } from '../../scripts/audit-unrouted-branches.mjs';
+
+const NOW = Date.parse('2026-07-25T18:00:00Z');
+const hoursAgo = (h) => new Date(NOW - h * 3_600_000).toISOString();
+
+describe('classifyBranch — merged-by-any-route detection', () => {
+  it('reports a branch with unmerged commits and no open PR', () => {
+    const hit = classifyBranch({
+      branch: 'fix/spawn-inherits-child-session-marker',
+      ref: 'origin/fix/spawn-inherits-child-session-marker',
+      unmergedPatchCount: 1,
+      hasOpenPR: false,
+      newestCommitISO: hoursAgo(7),
+    }, NOW);
+    // The live incident: one commit, pushed, no PR, sat 7 hours as the root blocker.
+    expect(hit).not.toBeNull();
+    expect(hit.branch).toBe('fix/spawn-inherits-child-session-marker');
+    expect(hit.unmerged_commits).toBe(1);
+    expect(hit.age_hours).toBe(7);
+  });
+
+  it('does NOT report a squash-merged branch (zero patch-equivalent commits remain)', () => {
+    // This is the case ancestry cannot see: the tip is not an ancestor of main,
+    // but git cherry finds every commit already applied upstream.
+    expect(classifyBranch({
+      branch: 'qf/QF-20260725-598',
+      ref: 'origin/qf/QF-20260725-598',
+      unmergedPatchCount: 0,
+      hasOpenPR: false,
+      newestCommitISO: hoursAgo(5),
+    }, NOW)).toBeNull();
+  });
+
+  it('does NOT report a branch that already has an open PR', () => {
+    expect(classifyBranch({
+      branch: 'feat/whatever',
+      ref: 'origin/feat/whatever',
+      unmergedPatchCount: 3,
+      hasOpenPR: true,
+      newestCommitISO: hoursAgo(2),
+    }, NOW)).toBeNull();
+  });
+
+  it('never consults the branch name — an unmerged main-ish name is still reported', () => {
+    // Guards the QF requirement to verify by ancestry/patch-id, not by naming.
+    const hit = classifyBranch({
+      branch: 'mainline-ish-name',
+      ref: 'origin/mainline-ish-name',
+      unmergedPatchCount: 2,
+      hasOpenPR: false,
+      newestCommitISO: hoursAgo(9),
+    }, NOW);
+    expect(hit).not.toBeNull();
+    expect(hit.unmerged_commits).toBe(2);
+  });
+
+  it('tolerates a missing commit date rather than throwing', () => {
+    const hit = classifyBranch({
+      branch: 'feat/no-date',
+      ref: 'origin/feat/no-date',
+      unmergedPatchCount: 1,
+      hasOpenPR: false,
+      newestCommitISO: null,
+    }, NOW);
+    expect(hit).not.toBeNull();
+    expect(hit.age_hours).toBeNull();
+    expect(hit.newest_commit).toBeNull();
+  });
+});
+
+describe('withinAgeWindow — bounds the expensive patch-equivalence pass', () => {
+  it('excludes a branch committed minutes ago so mid-work does not alarm', () => {
+    expect(withinAgeWindow(hoursAgo(0.2), {}, NOW)).toBe(false);
+  });
+
+  it('includes a branch a few hours old — the live incident window', () => {
+    expect(withinAgeWindow(hoursAgo(7), {}, NOW)).toBe(true);
+  });
+
+  it('excludes a branch older than the window (branch cleanup owns those)', () => {
+    expect(withinAgeWindow(hoursAgo(24 * 30), { maxAgeDays: 3 }, NOW)).toBe(false);
+  });
+
+  it('honours a widened window', () => {
+    expect(withinAgeWindow(hoursAgo(24 * 10), { maxAgeDays: 14 }, NOW)).toBe(true);
+  });
+
+  it('excludes an unparseable or missing date instead of throwing', () => {
+    expect(withinAgeWindow(null, {}, NOW)).toBe(false);
+    expect(withinAgeWindow('not-a-date', {}, NOW)).toBe(false);
+  });
+});


### PR DESCRIPTION
Every existing surface tracks work that is **claimed, in flight, or failing**. Finished-but-unrouted work is none of those — it is invisible *precisely because it succeeded*.

Measured cost, twice in one day: `fix/spawn-inherits-child-session-marker` carried one pushed commit from 09:21, zero conflicts against `origin/main`, no PR. It sat until 16:20 while being **the root blocker of the entire LEO chain**, and every board looked clean the whole time.

Adds `scripts/audit-unrouted-branches.mjs` — the sibling of `audit-orphan-prs.mjs`, which covers the inverse case (open PRs whose parent SD/QF is already completed).

## Merged-by-any-route is two checks, not one

The QF asks to verify by ancestry rather than by branch name. Correct — but ancestry **alone** is insufficient here: a squash merge rewrites the commit, so a landed branch's tip is not an ancestor of `main`. This repo squash-merges routinely, and the effect is dramatic.

Measured: **5050 refs total, 3418 "unmerged" by ancestry** — the vast majority of which *did* land.

So both checks apply, and a branch is reported only if it fails **both**:
1. `for-each-ref --no-merged=origin/main` — ancestry (merge / fast-forward), one call, free
2. `git cherry origin/main <ref>` — patch-id equivalence, catches squash and rebase

Branch names are never consulted.

## The age window is load-bearing, not a shortcut

My first implementation ran the patch-equivalence pass over every ref and **timed out at 6m40s** — 4 git processes per branch across 5050 branches. Worse, an unbounded scan buries the signal in years of abandoned branches, which is branch-cleanup's job, not this one.

The failure mode here is *recent* finished work falling through a gap between owners — the live case sat 7 hours. So the window is bounded and measured:

| Window | Hits | Runtime |
|---|---|---|
| **3d (default)** | 6 | **~5s** |
| 14d (`--max-age-days`) | 36 | ~116s |

Newest-commit age is reported per hit, which the QF wants anyway so a fresh mid-work branch doesn't alarm. A branch under 1h old is excluded as presumed in-work.

## Surfaced where it is actually read

The QF explicitly rejects "a report nobody opens" — and the sibling `audit-orphan-prs` is exactly that today: an npm script no automation invokes.

So this is registered in `COMPOSED_CORES` in `coordinator-quiet-tick.mjs` with `quiescentSkip: false`, because a quiet fleet is precisely when an unrouted branch sits unnoticed. Verified composing:

```
cores=[sweep:ok inbox:ok … audit:ok unrouted-branches:ok relay-drain:ok …]
```

An npm alias (`audit:unrouted-branches`) is added for manual runs.

Fails **loud**, not silently: if `gh pr list` is unavailable the run aborts with a warning rather than reporting every branch as unrouted. Exit code is always 0 — informational, never blocks a caller.

## Verified end-to-end, not asserted

Planted a branch with one commit and no PR, backdated 5h to mimic the incident:

```
- zz-unrouted-probe-DELETEME  +1 unmerged commit(s)  newest 5h old
```

Re-dated to now → **correctly excluded** as mid-work. Probe deleted, not committed.

A live run also surfaces real unrouted work, including `feat/SD-LEO-INFRA-LEO-LAUNCHER-LIVE-ACTIVATION-CHECKPOINT-3-001` with 6 commits sitting 16.5h — the exact shape the QF describes.

**10 unit tests** cover the pure logic with no git/gh/DB: squash-merged branch not reported, open-PR branch not reported, branch name never consulted, missing date tolerated, and the age-window bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)