### PR TITLE
fix(QF-20260725-879): dep-check belt depth so the integrity probe stops false-indicting the coordinator

### DIFF
--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -11,18 +11,23 @@
  *
  * WHY THIS IS A SHARED MODULE, not a filter in each caller: the two consumers drifted apart
  * precisely because each owned its own copy of the query. Depth is computed HERE, once, through
- * the same claim gate the dispatcher itself uses (classifyDispatchIneligibility), so a held row
- * can never again read as available work on one surface and not the other.
+ * the same claim gate the dispatcher itself uses (the structural classifyDispatchIneligibility
+ * axes PLUS the async evaluateDispatchEligibility dependency gate — QF-20260725-879), so a held
+ * or dep-blocked row can never again read as available work on one surface and not the other.
  *
  * Corroborated from three independent directions: Adam's metadata inspection, the coordinator
  * running the classifier across every non-terminal SD, and worker Echo's /checkin returning
  * belt_ranked_claimable=8 with belt_claimable_at_my_tier=0 continuously for ~2.5h.
  */
-const { classifyDispatchIneligibility } = require('./claim-eligibility.cjs');
+const { classifyDispatchIneligibility, draftDepsSatisfied } = require('./claim-eligibility.cjs');
 
 // The columns classifyDispatchIneligibility's axes actually read. Kept explicit (not select('*'))
 // so a schema change that drops one fails loudly here rather than silently un-gating a row.
-const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application';
+// QF-20260725-879: + dependencies — draftDepsSatisfied's ref extractor reads the top-level
+// `dependencies` column (metadata is already present for its metadata.* ref keys). WITHOUT this
+// column every row would look dependency-free and the dep gate would silently pass everything,
+// which is precisely the over-count this QF fixes.
+const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application, dependencies';
 
 /**
  * Count belt depth with ineligible rows excluded BEFORE emission.
@@ -53,8 +58,25 @@ async function countDispatchableBacklog(supabase) {
     // fenced, test fixture, not-before). Tier/fitness axes are per-worker and deliberately not
     // applied to a fleet-wide depth gauge.
     const reason = classifyDispatchIneligibility(row);
-    if (reason) ineligible[reason] = (ineligible[reason] || 0) + 1;
-    else dispatchable += 1;
+    if (reason) { ineligible[reason] = (ineligible[reason] || 0) + 1; continue; }
+    // QF-20260725-879: the sync classifier above is DB-BLIND BY DESIGN, so it cannot evaluate
+    // DEPENDENCIES at all — that gate is async and lived only in evaluateDispatchEligibility. A
+    // dep_blocked SD therefore survived this loop and was counted as dispatchable, manufacturing
+    // an integrity divergence that did not exist (measured: recomputed=1 vs self_reported=0,
+    // integrity_ok=false, falsely indicting the coordinator for a dispatch failure that never
+    // happened while everything downstream was genuinely blocked).
+    //
+    // Reuses draftDepsSatisfied — the SAME dependency predicate evaluateDispatchEligibility
+    // itself calls — so there is ONE dependency definition across depth, dispatch and the
+    // stale-session-sweep. Deliberately NOT evaluateDispatchEligibility(sb, sd_key): that
+    // re-fetches each row by key, and these rows are already in hand — it would add an N+1 and
+    // force every consumer's test seam to model a per-row SD fetch, for no added signal.
+    // Cost is near-zero: draftDepsSatisfied short-circuits before any query when a row carries
+    // no dependency refs, so only dep-carrying rows touch the DB.
+    // throwOnError: a dep-query fault must PROPAGATE — this gauge's contract is fail-loud, and
+    // silently treating an unverifiable row as dispatchable is the exact over-count being fixed.
+    if (await draftDepsSatisfied(supabase, row, { throwOnError: true })) dispatchable += 1;
+    else ineligible.dep_blocked = (ineligible.dep_blocked || 0) + 1;
   }
   return { dispatchable, raw: (rows || []).length, ineligible };
 }

--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -76,13 +76,16 @@ export async function computeUtilization(supabase, { nowMs = Date.now() } = {}) 
   // did not exist (measured: 8 reported, 0 truly claimable, 7 human-action-held). Depth now comes
   // from the shared gauge, which applies the same claim gate the dispatcher uses. Cap protection
   // is preserved inside that helper via fetchAllPaginated.
-  const { dispatchable: backlogSize } = await countDispatchableBacklog(supabase);
+  const { dispatchable: backlogSize, raw: rawUnclaimedDrafts } = await countDispatchableBacklog(supabase);
 
   return {
     live_workers: live.length,
     claimed: claimed.length,
     idle: idle.length,
     dispatchable_backlog_size: backlogSize,
+    // QF-20260725-879: the UNFILTERED draft+unclaimed head-count, kept alongside the filtered
+    // depth so the S4 raw-SQL cross-check can compare like with like (see its use below).
+    raw_unclaimed_drafts: rawUnclaimedDrafts,
   };
 }
 
@@ -360,7 +363,16 @@ export async function runProbe(supabase, opts = {}) {
         .from('strategic_directives_v2')
         .select('id', { count: 'exact', head: true })
         .in('status', ['in_progress', 'pending_approval', 'active']);
-      const probeCounts = { in_flight: inFlightCount, draft_unclaimed: utilization.dispatchable_backlog_size };
+      // QF-20260725-879: compare LIKE WITH LIKE. This passed dispatchable_backlog_size — the
+      // ELIGIBILITY-FILTERED depth — against a raw `status='draft' AND claiming_session_id IS
+      // NULL` SQL count, so the two sides measured different quantities BY DEFINITION and their
+      // difference was reported as an integrity breach (measured: probe=1 vs raw=9, both sides
+      // individually correct). The raw-SQL side is the unfiltered head-count, so the probe side
+      // must be the unfiltered head-count too; filtered depth is still emitted separately as
+      // utilization.dispatchable_backlog_size. A breach that fires on a definitional artifact
+      // trains everyone to discount recompute_ok=false, so the one time it means something it
+      // gets ignored.
+      const probeCounts = { in_flight: inFlightCount, draft_unclaimed: utilization.raw_unclaimed_drafts };
       const cmp = compareReadings(probeCounts, raw);
       recompute = { status: 'compared', ...cmp, probe: probeCounts, raw };
     } finally { await pg.end().catch(() => {}); }

--- a/tests/unit/fleet/belt-depth.test.js
+++ b/tests/unit/fleet/belt-depth.test.js
@@ -13,8 +13,13 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { countDispatchableBacklog } = require('../../../lib/fleet/belt-depth.cjs');
 
-/** Minimal builder covering exactly the chain the gauge uses, including .range() pagination. */
-function fakeClient(rows) {
+/**
+ * Minimal builder covering exactly the chain the gauge uses, including .range() pagination.
+ * QF-20260725-879: `.or()` added — the dependency gate resolves refs with a single
+ * `.select(...).or(sd_key.in.(...),id.in.(...))`. depRows is what that lookup returns; it is
+ * only ever reached for rows that actually carry dependency refs.
+ */
+function fakeClient(rows, depRows = []) {
   return {
     from: () => ({
       select: () => ({
@@ -23,6 +28,7 @@ function fakeClient(rows) {
             range: (from, to) => Promise.resolve({ data: rows.slice(from, to + 1), error: null }),
           }),
         }),
+        or: () => Promise.resolve({ data: depRows, error: null }),
       }),
     }),
   };
@@ -60,6 +66,40 @@ describe('countDispatchableBacklog', () => {
 
   it('reports an empty belt as 0 without inventing depth', async () => {
     expect(await countDispatchableBacklog(fakeClient([]))).toMatchObject({ dispatchable: 0, raw: 0 });
+  });
+
+  it('REGRESSION QF-20260725-879: a dep-blocked draft is NOT counted as dispatchable', async () => {
+    // The exact live shape: one unclaimed draft whose dependencies are incomplete. The sync
+    // classifier is DB-blind and passes it, so the gauge used to emit dispatchable=1 while the
+    // dispatcher and the sweep both said dep_blocked — recomputed=1 vs self_reported=0,
+    // integrity_ok=false, falsely indicting the coordinator.
+    const rows = [{ id: 'd1', sd_key: 'SD-DEP-BLOCKED', status: 'draft', metadata: {}, dependencies: ['SD-BLOCKER'] }];
+    const depRows = [{ id: 'b1', sd_key: 'SD-BLOCKER', status: 'in_progress' }]; // NOT completed
+    const result = await countDispatchableBacklog(fakeClient(rows, depRows));
+    expect(result.dispatchable).toBe(0);
+    expect(result.raw).toBe(1);
+    expect(result.ineligible.dep_blocked).toBe(1);
+  });
+
+  it('counts a draft whose dependencies are all completed', async () => {
+    const rows = [{ id: 'd1', sd_key: 'SD-DEP-OK', status: 'draft', metadata: {}, dependencies: ['SD-BLOCKER'] }];
+    const depRows = [{ id: 'b1', sd_key: 'SD-BLOCKER', status: 'completed' }];
+    const result = await countDispatchableBacklog(fakeClient(rows, depRows));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible).toEqual({});
+  });
+
+  it('does not query the dep gate at all for dependency-free rows (cost guard)', async () => {
+    // Keeps the gauge cheap: the dep lookup must short-circuit before any query when a row
+    // carries no refs. A client whose .or() throws proves the path is never taken.
+    const exploding = fakeClient([free(1), free(2)]);
+    exploding.from = () => ({
+      select: () => ({
+        eq: () => ({ is: () => ({ range: (f, t) => Promise.resolve({ data: [free(1), free(2)].slice(f, t + 1), error: null }) }) }),
+        or: () => { throw new Error('dep query must not run for dependency-free rows'); },
+      }),
+    });
+    await expect(countDispatchableBacklog(exploding)).resolves.toMatchObject({ dispatchable: 2 });
   });
 
   it('paginates past the PostgREST cap instead of under-reporting depth', async () => {


### PR DESCRIPTION
## Problem

The Adam dispatch-integrity probe reported `integrity_ok=false` on a divergence that did not exist (measured live: `recomputed=1` vs `self_reported=0`). Two independent causes.

**1. The depth gauge was DB-blind.** `countDispatchableBacklog` gated rows with the **sync** `classifyDispatchIneligibility`, which has no DB access *by design* and therefore cannot evaluate dependencies at all — that gate is async. Any `dep_blocked` SD was silently counted as dispatchable, manufacturing a divergence and attributing a dispatch failure to the coordinator that never happened (the fleet was idle because everything downstream was genuinely blocked).

**2. The S4 recompute compared unlike quantities.** `probeCounts.draft_unclaimed` passed the **eligibility-filtered** depth against a raw `status='draft' AND claiming_session_id IS NULL` SQL count. The two sides measured different things by definition, and their difference was reported as a breach (measured `probe=1` vs `raw=9` — both sides individually correct).

## Fix

- Reuse `draftDepsSatisfied` — the *same* dependency predicate `evaluateDispatchEligibility` itself calls — so depth, dispatch and the stale-session-sweep share **one** dependency definition.
  - Deliberately **not** `evaluateDispatchEligibility(sb, sd_key)`: it re-fetches each row by key, and the rows are already in hand. That would add an N+1 and force every consumer's test seam to model a per-row SD fetch, for no added signal.
  - Near-zero cost: `draftDepsSatisfied` short-circuits before any query when a row carries no dependency refs.
  - Errors propagate (`throwOnError`) — this gauge's contract is fail-loud; treating an unverifiable row as dispatchable is the exact over-count being fixed.
  - `ELIGIBILITY_COLUMNS` gains `dependencies`, without which every row would look dependency-free and the gate would pass everything.
- Probe side now passes the unfiltered head-count the gauge already returns, so the S4 comparison is like-for-like and live on both sides. Filtered depth is still emitted as `utilization.dispatchable_backlog_size`.

## Verification

**Live UAT (ground truth):** fixed gauge returns `dispatchable=0`, `raw=9`, `ineligible={dep_blocked:1, human_action_required:7, test_fixture_key:1}`. Cross-checked against `evaluateDispatchEligibility` over all 9 unclaimed drafts: **0 eligible — matches the gauge exactly.** Pre-fix it read `dispatchable=1`, which is precisely the false breach.

- +3 regression tests; the dep-blocked case was verified to **fail against pre-fix code**, so it is not vacuous. Includes a cost guard proving the dep query never runs for dependency-free rows.
- Full unit suite: **26248 passed**. The 3 residual failures reproduce identically on a clean tree with all changes stashed (venture-stage DB, SMS call-site audit, doctrine golden-refs) — unrelated.
- TypeScript clean.

## Note for the filer

The QF's second sub-claim attributed part of the `draft_unclaimed` divergence to a 37.7-minute-stale snapshot. In this code path `raw draft_unclaimed` is computed **live** by `recomputeViaRawSql`; `latest_snapshot_at` is a separate reported field and is not an input to the comparison. The definitional mismatch alone accounts for the divergence, so no temporal-skew fix was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)