### PR TITLE
fix(QF-20260725-691): a merged PR is not scope acceptance — the merge witness lands NON-TERMINAL

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -92,6 +92,10 @@ export function parseArguments(args) {
       'actual-source-loc':  { type: 'string' },
       'actual-test-loc':    { type: 'string' },
       'pr-url':             { type: 'string' },
+      // QF-20260725-691: explicit attestation that the QF's STATED SCOPE is satisfied. The
+      // merged-PR witness alone proves only that code landed, so it now reconciles NON-TERMINAL;
+      // this flag is what makes 'completed' truthful. Value names who/why for the audit trail.
+      'scope-accepted':     { type: 'string' },
       'skip-tests':         { type: 'boolean' },
       'tests-pass':         { type: 'string' },
       'skip-typecheck':     { type: 'boolean' },
@@ -204,6 +208,7 @@ export function parseArguments(args) {
     actualSourceLoc:   values['actual-source-loc'] != null ? parseInt(values['actual-source-loc'], 10) : undefined,
     actualTestLoc:     values['actual-test-loc']   != null ? parseInt(values['actual-test-loc'], 10) : undefined,
     prUrl:             values['pr-url'],
+    scopeAccepted:     values['scope-accepted'],
     skipTestRun:       values['skip-tests']       || false,
     testsPass:         values['tests-pass']       != null ? values['tests-pass'].toLowerCase().startsWith('y') : undefined,
     skipTypeCheck:     values['skip-typecheck']   || false,

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -58,14 +58,42 @@ dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
  * @param {{ qf?:object, prUrl:string, mergeSha?:string|null, nowIso:string }} args
  * @returns {object} the UPDATE payload
  */
-export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso }) {
-  const reconcileNote = `Reconciled to completed from already-MERGED PR ${prUrl} (SD-REFILL-00QQ60BN merged-PR witness; UAT not re-run in reconcile path).`;
+export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null }) {
+  // QF-20260725-691: a merged PR witnesses that CODE LANDED. Terminal `completed` asserts that
+  // the QF's SCOPE WAS SATISFIED. Those are different propositions and this path used to
+  // substitute one for the other silently — invisible precisely because the merge really did
+  // happen. Demonstrated by QF-20260725-638: it named two surfaces, one shipped, it reached
+  // completed anyway, and the remainder had to be re-filed as QF-20260725-639.
+  //
+  // So the merge witness alone now lands NON-TERMINAL: it records the true fact (this PR merged)
+  // without asserting the false one. Terminal `completed` requires an explicit scope attestation
+  // (--scope-accepted). No status-CHECK widening: 'in_progress' is already in the enum
+  // ('open','in_progress','completed','escalated'), so this needs no migration.
+  const merged = `PR ${prUrl} MERGED and reachable from origin/main${mergeSha ? ` (${mergeSha})` : ''}`;
+  if (!scopeAcceptedBy) {
+    const witnessNote = `${merged} — merge witnessed, SCOPE ACCEPTANCE OUTSTANDING (QF-20260725-691: a merged PR proves code landed, not that this QF's scope is satisfied; UAT not re-run in the reconcile path). Attest with: node scripts/complete-quick-fix.js ${qf.id || '<QF>'} --pr-url ${prUrl} --scope-accepted "<who/why>".`;
+    return {
+      status: 'in_progress',
+      pr_url: prUrl,
+      commit_sha: mergeSha,
+      // The merge IS a genuine CI witness — that part was never the lie.
+      tests_passing: true,
+      verification_notes: [qf.verification_notes, witnessNote].filter(Boolean).join(' | '),
+      // QF-20260711-176 preserved: an unheld QF must not pin worktree reaping. The row is left
+      // discoverable rather than closed, which is the point — it is NOT finished.
+      claiming_session_id: null
+    };
+  }
+  const reconcileNote = `${merged}; SCOPE ACCEPTED by ${scopeAcceptedBy} (QF-20260725-691 attestation; UAT not re-run in reconcile path).`;
   const verification_notes = [qf.verification_notes, reconcileNote].filter(Boolean).join(' | ');
   return {
     status: 'completed',
     pr_url: prUrl,
     commit_sha: mergeSha,
     tests_passing: true,
+    // The completed_requires_verification CHECK wants (tests_passing AND uat_verified) OR
+    // force_completed. UAT genuinely did not re-run here, so force_completed carries it rather
+    // than fabricating uat_verified — unchanged from SD-REFILL-00QQ60BN.
     force_completed: true,
     verification_notes,
     completed_at: qf.completed_at || nowIso,
@@ -171,12 +199,23 @@ export async function completeQuickFix(qfId, options = {}) {
   try {
     const probeWitness = verifyQFMergeWitness({ qfId, prUrl: options.prUrl || qf.pr_url, testDir });
     if (probeWitness.verified) {
-      console.log(`\n✅ QF own PR ${probeWitness.prUrl} (head ${probeWitness.headBranch}) is MERGED + reachable from origin/main — reconciling ${qfId} to completed (idempotent short-circuit).\n`);
       const mergeSha = probeWitness.mergeSha || qf.commit_sha || null;
+      // QF-20260725-691: the witness proves the PR merged, not that scope was satisfied. Without
+      // an explicit --scope-accepted attestation this records the merge and leaves the QF OPEN.
+      const scopeAcceptedBy = options.scopeAccepted || null;
+      if (scopeAcceptedBy) {
+        console.log(`\n✅ QF own PR ${probeWitness.prUrl} (head ${probeWitness.headBranch}) is MERGED + reachable from origin/main, and SCOPE ACCEPTED by ${scopeAcceptedBy} — completing ${qfId}.\n`);
+      } else {
+        console.log(`\n📌 QF own PR ${probeWitness.prUrl} (head ${probeWitness.headBranch}) is MERGED + reachable from origin/main.`);
+        console.log(`   Recording the merge and leaving ${qfId} IN_PROGRESS — a merged PR proves the code landed, NOT that this QF's scope is satisfied (QF-20260725-691).`);
+        console.log(`   Re-read the QF's stated scope. If every named surface is genuinely done, attest it:`);
+        console.log(`     node scripts/complete-quick-fix.js ${qfId} --pr-url ${probeWitness.prUrl} --scope-accepted "<who/why>"`);
+        console.log(`   If only part shipped, file the remainder rather than closing this row.\n`);
+      }
       // SD-REFILL-00QQ60BN: preserve the verification-column stamping the
       // completed_requires_verification CHECK demands, now with the SELF-DERIVED pr_url.
       const reconcileUpdate = buildMergedReconcileUpdate({
-        qf, prUrl: probeWitness.prUrl, mergeSha, nowIso: new Date().toISOString()
+        qf, prUrl: probeWitness.prUrl, mergeSha, nowIso: new Date().toISOString(), scopeAcceptedBy
       });
       const { error: reconcileErr } = await supabase
         .from('quick_fixes')

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -19,9 +19,14 @@ describe('buildMergedReconcileUpdate (SD-REFILL-00QQ60BN)', () => {
   const prUrl = 'https://github.com/rickfelix/EHG_Engineer/pull/4587';
   const nowIso = '2026-06-22T16:00:00.000Z';
 
+  // QF-20260725-691: terminal completion now requires an explicit scope attestation, so the
+  // SD-REFILL-00QQ60BN CHECK-satisfaction contract is pinned on the ATTESTED path — the path that
+  // still writes status='completed'. The assertions themselves are unchanged.
+  const ATTEST = 'coordinator a59441f4: both surfaces verified';
+
   it('produces an UPDATE that satisfies completed_requires_verification for an un-stamped QF', () => {
     const qf = { tests_passing: null, uat_verified: null, force_completed: null, verification_notes: null };
-    const u = buildMergedReconcileUpdate({ qf, prUrl, mergeSha: 'abc123', nowIso });
+    const u = buildMergedReconcileUpdate({ qf, prUrl, mergeSha: 'abc123', nowIso, scopeAcceptedBy: ATTEST });
     expect(u.status).toBe('completed');
     expect(u.force_completed).toBe(true);      // the CHECK escape used — UAT did not re-run here
     expect(u.tests_passing).toBe(true);        // merged PR = CI witness
@@ -46,14 +51,77 @@ describe('buildMergedReconcileUpdate (SD-REFILL-00QQ60BN)', () => {
   });
 
   it('preserves an existing completed_at and falls back to nowIso otherwise', () => {
-    expect(buildMergedReconcileUpdate({ qf: { completed_at: '2026-01-01T00:00:00.000Z' }, prUrl, nowIso }).completed_at)
+    expect(buildMergedReconcileUpdate({ qf: { completed_at: '2026-01-01T00:00:00.000Z' }, prUrl, nowIso, scopeAcceptedBy: ATTEST }).completed_at)
       .toBe('2026-01-01T00:00:00.000Z');
-    expect(buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso }).completed_at).toBe(nowIso);
+    expect(buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso, scopeAcceptedBy: ATTEST }).completed_at).toBe(nowIso);
   });
 
   it('carries pr_url and mergeSha through', () => {
     const u = buildMergedReconcileUpdate({ qf: {}, prUrl, mergeSha: 'deadbeef', nowIso });
     expect(u.pr_url).toBe(prUrl);
     expect(u.commit_sha).toBe('deadbeef');
+  });
+});
+
+/**
+ * QF-20260725-691 — the witness is TRUE, it just witnesses the WRONG PROPOSITION. A merged PR
+ * proves CODE LANDED; terminal `completed` asserts SCOPE WAS SATISFIED. Silently substituting one
+ * for the other is invisible because the merge really did happen. Demonstrated by QF-20260725-638:
+ * it named two surfaces, one shipped, it reached completed anyway, and the remainder had to be
+ * re-filed as QF-20260725-639. So the merge witness alone now lands NON-TERMINAL.
+ */
+describe('buildMergedReconcileUpdate — merge witness is not scope acceptance (QF-20260725-691)', () => {
+  const prUrl = 'https://github.com/rickfelix/EHG_Engineer/pull/6471';
+  const nowIso = '2026-07-25T18:00:00.000Z';
+
+  it('without an attestation it does NOT reach terminal completed', () => {
+    const u = buildMergedReconcileUpdate({ qf: { id: 'QF-X' }, prUrl, mergeSha: 'abc', nowIso });
+    expect(u.status).toBe('in_progress');
+    expect(u.status).not.toBe('completed');
+  });
+
+  it('without an attestation it asserts no completion facts (no completed_at, no force_completed)', () => {
+    const u = buildMergedReconcileUpdate({ qf: { id: 'QF-X' }, prUrl, mergeSha: 'abc', nowIso });
+    expect(u.completed_at).toBeUndefined();
+    expect(u.force_completed).toBeUndefined();
+    expect(u.uat_verified).toBeUndefined();
+  });
+
+  it('still records the TRUE fact — the merge — and says scope acceptance is outstanding', () => {
+    const u = buildMergedReconcileUpdate({ qf: { id: 'QF-X' }, prUrl, mergeSha: 'abc', nowIso });
+    expect(u.pr_url).toBe(prUrl);
+    expect(u.commit_sha).toBe('abc');
+    expect(u.tests_passing).toBe(true); // a merged PR IS a genuine CI witness
+    expect(u.verification_notes).toMatch(/SCOPE ACCEPTANCE OUTSTANDING/);
+    expect(u.verification_notes).toContain(prUrl);
+  });
+
+  it('tells the operator exactly how to attest', () => {
+    const u = buildMergedReconcileUpdate({ qf: { id: 'QF-ABC' }, prUrl, nowIso });
+    expect(u.verification_notes).toMatch(/--scope-accepted/);
+    expect(u.verification_notes).toContain('QF-ABC');
+  });
+
+  it('an explicit attestation completes it and names the attester in the audit trail', () => {
+    const who = 'Foxtrot: both named surfaces verified against origin/main';
+    const u = buildMergedReconcileUpdate({ qf: { id: 'QF-X' }, prUrl, mergeSha: 'abc', nowIso, scopeAcceptedBy: who });
+    expect(u.status).toBe('completed');
+    expect(u.force_completed).toBe(true);
+    expect(u.completed_at).toBe(nowIso);
+    expect(u.verification_notes).toContain(who);
+    expect(u.verification_notes).toMatch(/SCOPE ACCEPTED by/);
+  });
+
+  it('uses only statuses already in the CHECK enum — no migration required', () => {
+    const allowed = ['open', 'in_progress', 'completed', 'escalated'];
+    const witness = buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso });
+    const attested = buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso, scopeAcceptedBy: 'x' });
+    expect(allowed).toContain(witness.status);
+    expect(allowed).toContain(attested.status);
+  });
+
+  it('never leaves a holder pinned on the row either way (QF-20260711-176 preserved)', () => {
+    expect(buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso }).claiming_session_id).toBeNull();
+    expect(buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso, scopeAcceptedBy: 'x' }).claiming_session_id).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem
The reconcile path closed a quick-fix on evidence that a **PR merged**. Terminal `completed` asserts that a **scope was satisfied**. Different propositions, silently substituted — invisible precisely because the merge really did happen.

**Demonstrated:** QF-20260725-638 named *two* surfaces (anchor stall alerts, parked-venture false-clear). Only the venture half shipped, yet it reached `status=completed` and 6 anchor alerts kept firing every tick. The remainder had to be re-filed as QF-20260725-639.

## What changed
The merged-PR witness alone now reconciles to **`in_progress`**, recording the *true* fact — this PR merged, with sha, and `tests_passing=true` because a merged PR **is** a genuine CI witness — without asserting the false one. Terminal `completed` requires an explicit `--scope-accepted "<who/why>"`, written into `verification_notes` so the claim is attributable.

The CLI now prints the exact next step, including the attest command, and says plainly that partial work should be re-filed rather than closed.

## Deliberately *not* make-reconcile-run-UAT
Per the QF: that path exists because a PR legitimately merges while the worker is gone. Making it expensive gets it bypassed, and killing it is worse than the defect. This only stops a merge witness being **sufficient** for terminal status.

## No migration
`in_progress` is already in the status CHECK enum (`open`,`in_progress`,`completed`,`escalated`), so the constraint is untouched — the QF asked to prefer a shape that avoids widening it, and one exists. A test pins that both paths use only enum values.

## Preserved, not discarded
- **SD-REFILL-00QQ60BN** — the `completed_requires_verification` contract (`tests_passing` + `force_completed`, never fabricating `uat_verified`) still holds. Its assertions now pin the **attested** path, which is where `status='completed'` is still written.
- **QF-20260711-176** — `claiming_session_id` is nulled on *both* paths, so an unheld row never pins worktree reaping.

## One surface only
This does **not** re-triage the 331 already-closed rows. Bundling that is precisely how a QF half-closes — the defect this row is about.

> ⚠️ **Fleet-wide behaviour change, for reviewers:** `complete-quick-fix.js --pr-url` will no longer close a QF by itself. Workers must re-read the stated scope and attest. That is the intent, but it changes the dominant ship path for everyone — worth a heads-up to the fleet on merge.

## Tests
13 pass (6 pre-existing re-pinned onto the attested path + 7 new), covering: not-terminal without attestation, no completion facts asserted, the merge still recorded, the attest instruction, attribution of the attester, enum-only statuses, and holder-nulling on both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)