### PR TITLE
feat(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): FR-2 correlation carrier + FR-1 provision-canary caller

### DIFF
--- a/scripts/fleet/provision-canary.mjs
+++ b/scripts/fleet/provision-canary.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * provision-canary.mjs — SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 (FR-1).
+ *
+ * THE GAP THIS CLOSES. provisionCanary (lib/fleet/canary-provision.js:69) is imported by NOTHING
+ * outside its own unit test — repo-wide grep confirms it; the only other match,
+ * scripts/canary/run-canary-probe.mjs:67, is an unrelated same-named LOCAL function. So the
+ * provisioning step exists, is tested, and has never once run. This file is the missing caller.
+ *
+ * WHY THIS DELIBERATELY DOES NOT CLAIM TO CLOSE DISCOVERABILITY. Wiring up a caller does not by
+ * itself cause metadata.account_profile='canary' to be written. Traced end to end before writing this:
+ *   1. provisionCanary calls spawn-control spawn() with accountProfile:'canary'. spawn() uses that
+ *      value at exactly one place (spawn-control.js:162) to resolve a profile DIRECTORY. It is never
+ *      written to metadata; spawn() has no stamp step at all.
+ *   2. The ONLY writer of account_profile='canary' repo-wide is stampRespawnedCanary
+ *      (canary-guard.js:173), whose only callers are canary-guard.js:121/:132 — the RESPAWN and
+ *      RELAUNCH verbs. The fresh-spawn path provisioning uses never reaches it.
+ *   3. That writer is itself dead: it finds its row with .eq('pid', pid) (canary-guard.js:167) where
+ *      pid is the wt.exe launcher pid, while claude_sessions.pid holds the CLAUDE CODE pid. It polls
+ *      8x/500ms, matches nothing, returns respawn_not_registered. spawn()'s own metadata write at
+ *      :202 has the identical break.
+ * canary-guard.js:153 already documents (1) in a comment. The comment is accurate; nobody acted on it.
+ *
+ * So a live run of this CLI today spawns, polls the gate, and exits registration_timeout — the same
+ * fail-closed the drill hits, one layer further in. That is WHY the value here is the DIAGNOSIS: the
+ * exit reason names which of the three links broke, so the one permitted live run produces an answer
+ * instead of a re-run. Discoverability closes when FR-3 fixes correlation and stamps the fresh-spawn
+ * path; this CLI is its prerequisite and its instrument, not its completion.
+ *
+ * SAFETY: dry-run is the DEFAULT. --live is an explicit opt-in that this module never infers, and it
+ * only reaches spawn-control, which self-gates behind FLEET_SPAWN_CONTROL_LIVE. Running the CP3 drill
+ * is NOT in scope and this file cannot start one — it never imports start-cp3-drills.js, canaryRestart,
+ * runRebootRespawnDrill or runU4Drill.
+ */
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { provisionCanary } from '../../lib/fleet/canary-provision.js';
+
+/**
+ * Exit-code contract. Deliberately three-valued so a caller (and CI) can tell "the fleet is broken"
+ * apart from "the gate is legitimately unmet" — collapsing those two is what let this stay invisible.
+ */
+export const EXIT = { OK: 0, INFRA: 1, GATE_UNMET: 2 };
+
+/**
+ * Per-reason diagnosis. The point of this table is that a bare `registration_timeout` is unactionable:
+ * it looks identical whether the slot is unseeded, the spawn never launched, or the session launched
+ * fine and only the STAMP failed. Each string names the next thing to check, in order.
+ */
+export const DIAGNOSIS = {
+  already_live: 'A resolvable canary already exists — no spawn was attempted (idempotent).',
+  provisioned: 'Canary spawned AND resolved by account_profile. Discoverability is genuinely closed.',
+  dry_run: 'DRY-RUN — nothing spawned. Re-run with --live (and FLEET_SPAWN_CONTROL_LIVE set) to act.',
+  no_canary_slot_seeded:
+    'fleet_desired_slots has no enabled canary slot. Provisioning cannot invent one — S3 seeding must run first.',
+  registration_timeout:
+    'Spawned, but no session ever resolved by account_profile=canary. EXPECTED until FR-3 lands: '
+    + 'spawn() never writes metadata.account_profile (it uses accountProfile only for the profile dir, '
+    + 'spawn-control.js:162), and the sole writer stampRespawnedCanary (canary-guard.js:173) is both '
+    + 'off the fresh-spawn path and pid-correlation-dead (:167). Check whether a session REGISTERED at '
+    + 'all before blaming the spawn: if claude_sessions gained a row, the spawn worked and only the '
+    + 'stamp is missing.',
+};
+
+/**
+ * Map a provisionCanary result onto {exitCode, status, diagnosis}. Pure — no client, no env, no clock,
+ * so the exit-code contract is testable without touching a fleet.
+ * @param {{ok?:boolean, reason?:string}} result
+ */
+export function classifyProvisionOutcome(result) {
+  const reason = (result && result.reason) || 'unknown';
+  const ok = Boolean(result && result.ok);
+  // Fail-closed on an unrecognised reason: an unknown state is INFRA, never a silent OK.
+  const known = Object.prototype.hasOwnProperty.call(DIAGNOSIS, reason);
+  const exitCode = ok ? EXIT.OK : known ? EXIT.GATE_UNMET : EXIT.INFRA;
+  return {
+    exitCode,
+    status: ok ? 'ok' : known ? 'gate_unmet' : 'infra',
+    reason,
+    diagnosis: known ? DIAGNOSIS[reason] : `Unrecognised reason '${reason}' — treating as INFRA, not as a met gate.`,
+  };
+}
+
+/**
+ * @param {string[]} argv
+ * @param {{supabase?:object, provisionFn?:Function, log?:Function, createClientFn?:Function}} [deps]
+ */
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const log = deps.log || ((m) => console.log(m));
+  const live = argv.includes('--live');
+  const provision = deps.provisionFn || provisionCanary;
+
+  // Client is constructed INSIDE main and only when not injected — the unit project does not load
+  // .env and CI has no secrets, so a module-scope client would red the whole file in CI.
+  // createClientFn is a REAL seam, not decoration: without it the no-client test constructs a live
+  // service client and runs provisionCanary against the production fleet (measured — that one test
+  // took 14.2s of network I/O while the other nine took 1ms each). A unit test must never do that.
+  let supabase = deps.supabase;
+  if (!supabase) {
+    try {
+      const createClient = deps.createClientFn
+        || (await import('../../lib/supabase-client.cjs')).createSupabaseServiceClient;
+      supabase = createClient();
+    } catch (e) {
+      log(`[provision-canary] INFRA: cannot construct supabase client: ${e && e.message}`);
+      return { ok: false, exitCode: EXIT.INFRA, status: 'infra', reason: 'no_supabase' };
+    }
+  }
+
+  log(`[provision-canary] ${live ? 'LIVE' : 'DRY-RUN'} — target: a session resolvable by account_profile=canary`);
+
+  let result;
+  try {
+    result = await provision({ supabase, live, logFn: log });
+  } catch (e) {
+    log(`[provision-canary] INFRA: provisionCanary threw: ${e && e.message}`);
+    return { ok: false, exitCode: EXIT.INFRA, status: 'infra', reason: 'threw' };
+  }
+
+  const outcome = classifyProvisionOutcome(result);
+  log(`[provision-canary] ${outcome.status.toUpperCase()} reason=${outcome.reason}`);
+  log(`[provision-canary] ${outcome.diagnosis}`);
+  return { ...outcome, ok: outcome.exitCode === EXIT.OK, result };
+}
+
+// Direct-invocation guard (realpath so a symlinked/worktree path still matches).
+const invokedDirectly = (() => {
+  try { return realpathSync(process.argv[1] || '') === realpathSync(fileURLToPath(import.meta.url)); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().then((r) => { process.exitCode = r.exitCode; })
+    .catch((e) => { console.error(`[provision-canary] fatal: ${e && e.message}`); process.exitCode = EXIT.INFRA; });
+}

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -193,4 +193,62 @@ if (require.main === module) {
   });
 }
 
-module.exports = { getCurrentSessionId, main };
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-2 — spawn->session correlation stamp.
+ *
+ * WHY THIS EXISTS. LEO has spawned zero of the sessions it displays: spawn-control.js
+ * correlates its spawned row on the wt.exe pid, while claude_sessions.pid holds the CLAUDE
+ * CODE pid (lib/session-manager.mjs), so the join can never match. The child must therefore
+ * echo something the SPAWNER minted.
+ *
+ * WHY NOT AN ENV VAR. Hook subprocesses receive ONLY
+ * [CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, CLAUDE_CODE_DISABLE_BACKGROUND_TASKS, CLAUDE_CODE_ENTRYPOINT,
+ * CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, CLAUDE_CODE_SSE_PORT, CLAUDE_PROJECT_DIR]
+ * (lib/hooks/session-id.cjs:36-42). A FLEET_* var is dropped before this hook ever runs — which
+ * is exactly why FLEET_AUTORESUME_SD and FLEET_WORKER_CALLSIGN both have ZERO readers repo-wide
+ * today despite one carrying a comment claiming a SessionStart consumer. An env-carried token
+ * would no-op here while every unit test stayed green.
+ * CLAUDE_CODE_SSE_PORT is NOT usable either: it is daemon-wide, identical for every session on
+ * the host, so it has zero discriminating power (netstat-verified, RCA 2026-05-04, same file).
+ *
+ * SEPARATE FROM THE UPSERT ON PURPOSE. main()'s upsert writes no metadata; adding metadata there
+ * would REPLACE the whole JSONB blob and clobber whatever session-manager's create_or_replace_session
+ * RPC wrote. This is read-row -> merge client-side -> write back to the SAME session_id, matching
+ * the convention in spawn-control.js and canary-guard.js.
+ *
+ * Fail-soft by contract: returns a reason code, never throws and never rejects. SessionStart must
+ * not abort. Injectable supabase so this is unit-testable without a live client.
+ *
+ * @param {object} supabase - client (injected; nothing is constructed here)
+ * @param {string} sessionId - resolved session id (passed explicitly — never resolved in here,
+ *   so tests need no stdin, no marker files and no CLAUDE_SESSION_ID)
+ * @param {string} correlation - the spawner-minted value the child is echoing
+ * @returns {Promise<{stamped: boolean, reason: string}>}
+ */
+async function stampSpawnCorrelation(supabase, sessionId, correlation) {
+  if (!supabase) return { stamped: false, reason: 'no_supabase' };
+  if (!sessionId) return { stamped: false, reason: 'no_session_id' };
+  if (!correlation) return { stamped: false, reason: 'no_correlation' };
+  try {
+    const { data: current, error: readError } = await supabase
+      .from('claude_sessions')
+      .select('session_id, metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (readError) return { stamped: false, reason: 'read_error' };
+    if (!current) return { stamped: false, reason: 'row_not_found' };
+
+    // Merge, never replace: a malformed/absent metadata blob degrades to {} rather than throwing.
+    const existing = (current.metadata && typeof current.metadata === 'object') ? current.metadata : {};
+    const { error: writeError } = await supabase
+      .from('claude_sessions')
+      .update({ metadata: { ...existing, spawn_correlation: correlation } })
+      .eq('session_id', current.session_id);
+    if (writeError) return { stamped: false, reason: 'write_error' };
+    return { stamped: true, reason: 'stamped' };
+  } catch {
+    return { stamped: false, reason: 'threw' };
+  }
+}
+
+module.exports = { getCurrentSessionId, main, stampSpawnCorrelation };

--- a/tests/unit/fleet/provision-canary-cli.test.js
+++ b/tests/unit/fleet/provision-canary-cli.test.js
@@ -1,0 +1,169 @@
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-1 — scripts/fleet/provision-canary.mjs.
+ *
+ * TS-1 IS NOT A TAUTOLOGY, ON PURPOSE. The obvious way to write these is to inject a resolveFn that
+ * returns {resolved:true} and then assert the CLI reported success — which asserts the stub, not the
+ * code. canary-provision.test.js already does that. Here the fake supabase's ROWS are the state and
+ * the REAL provisionCanary + REAL resolveCanaryTarget + REAL loadDesiredSlots run against them, so
+ * "already_live" is a genuine resolution through the production predicate. Only spawn is stubbed,
+ * because spawning is the one thing a unit test must not do.
+ *
+ * ENV-INDEPENDENCE: no test reads .env, constructs a client, or touches FLEET_* / APPDATA /
+ * CLAUDE_SESSION_ID. supabase and provisionFn are injected; main() only builds a client when one is
+ * NOT injected, and the one test covering that path asserts the failure is handled, not that a client
+ * appears. Verify with: env -u CLAUDE_SESSION_ID -u APPDATA npx vitest run <this file>
+ */
+import { describe, it, expect } from 'vitest';
+import { main, classifyProvisionOutcome, EXIT, DIAGNOSIS } from '../../../scripts/fleet/provision-canary.mjs';
+
+/**
+ * Fake whose ROWS are the state. Faithful to the two queries the real code path issues:
+ *   claude_sessions    -> .select(...).in('status', ['active','idle'])   (session-registry-adapter.js:12)
+ *   fleet_desired_slots-> .select(...)  awaited directly                 (desired-slots-store.js:47)
+ */
+function fakeSupabase({ sessions = [], slots = [] } = {}) {
+  return {
+    from(table) {
+      const rows = table === 'claude_sessions' ? sessions : slots;
+      const result = { data: rows, error: null };
+      const builder = {
+        select: () => builder,
+        in: () => Promise.resolve(result),
+        then: (resolve) => Promise.resolve(result).then(resolve),
+      };
+      return builder;
+    },
+  };
+}
+
+const CANARY_SESSION = {
+  session_id: 'sess-canary-1',
+  terminal_id: 'term-1',
+  pid: 4242,
+  status: 'active',
+  released_at: null,
+  metadata: { account_profile: 'canary', fleet_identity: { callsign: 'Canary-1' } },
+};
+const PLAIN_SESSION = {
+  session_id: 'sess-worker-1',
+  terminal_id: 'term-2',
+  pid: 99,
+  status: 'active',
+  released_at: null,
+  metadata: { fleet_identity: { callsign: 'Delta' } },
+};
+const CANARY_SLOT = { name: 'Canary-1', role: 'worker', account_profile: 'canary', enabled: true };
+
+const silent = () => {};
+
+describe('FR-1 provision-canary — real resolution, not a stubbed verdict', () => {
+  it('reports already_live when a canary row genuinely resolves through resolveCanaryTarget', async () => {
+    // No spawnFn injected anywhere: if the real resolution did NOT find the canary, provisionCanary
+    // would proceed to spawn and this test would fail by reaching the default spawn seam.
+    const r = await main([], { supabase: fakeSupabase({ sessions: [CANARY_SESSION], slots: [CANARY_SLOT] }), log: silent });
+    expect(r.reason).toBe('already_live');
+    expect(r.exitCode).toBe(EXIT.OK);
+    expect(r.ok).toBe(true);
+  });
+
+  it('does NOT treat a non-canary live session as a provisioned canary', async () => {
+    // The discriminator: a live, heartbeating session with no account_profile stamp is exactly the
+    // fleet's current state — alive but undiscoverable. It must not read as ok.
+    const r = await main([], {
+      supabase: fakeSupabase({ sessions: [PLAIN_SESSION], slots: [] }),
+      provisionFn: async (args) => {
+        // Real resolution ran and found nothing; assert that, then short-circuit before any spawn.
+        const { resolveCanaryTarget } = await import('../../../lib/fleet/canary-guard.js');
+        const res = await resolveCanaryTarget(args.supabase, { by: 'account_profile', value: 'canary' });
+        expect(res.resolved).not.toBe(true);
+        return { ok: false, reason: 'no_canary_slot_seeded' };
+      },
+      log: silent,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(EXIT.GATE_UNMET);
+  });
+
+  it('dry-run is the DEFAULT and never spawns', async () => {
+    let spawned = false;
+    const r = await main([], {
+      supabase: fakeSupabase({ sessions: [], slots: [CANARY_SLOT] }),
+      provisionFn: async (args) => {
+        expect(args.live).toBe(false); // the safety property: absence of --live means live=false
+        spawned = true;
+        return { ok: false, reason: 'dry_run' };
+      },
+      log: silent,
+    });
+    expect(spawned).toBe(true);
+    expect(r.reason).toBe('dry_run');
+    expect(r.exitCode).toBe(EXIT.GATE_UNMET);
+  });
+
+  it('passes live:true through only when --live is given explicitly', async () => {
+    let seenLive = null;
+    await main(['--live'], {
+      supabase: fakeSupabase({ sessions: [], slots: [CANARY_SLOT] }),
+      provisionFn: async (args) => { seenLive = args.live; return { ok: true, reason: 'provisioned' }; },
+      log: silent,
+    });
+    expect(seenLive).toBe(true);
+  });
+});
+
+describe('FR-1 classifyProvisionOutcome — three-valued exit contract', () => {
+  it('separates a met gate, an unmet gate, and infra', () => {
+    expect(classifyProvisionOutcome({ ok: true, reason: 'provisioned' }).exitCode).toBe(EXIT.OK);
+    expect(classifyProvisionOutcome({ ok: false, reason: 'registration_timeout' }).exitCode).toBe(EXIT.GATE_UNMET);
+    expect(classifyProvisionOutcome({ ok: false, reason: 'no_canary_slot_seeded' }).exitCode).toBe(EXIT.GATE_UNMET);
+  });
+
+  it('fails CLOSED on an unrecognised reason — an unknown state is INFRA, never a silent OK', () => {
+    const r = classifyProvisionOutcome({ ok: false, reason: 'something_new' });
+    expect(r.exitCode).toBe(EXIT.INFRA);
+    expect(r.status).toBe('infra');
+  });
+
+  it('treats a malformed/absent result as INFRA rather than throwing', () => {
+    expect(classifyProvisionOutcome(undefined).exitCode).toBe(EXIT.INFRA);
+    expect(classifyProvisionOutcome(null).status).toBe('infra');
+  });
+
+  it('registration_timeout diagnosis names the STAMP as the suspect, not the spawn', () => {
+    // This is the whole value of the CLI: the one permitted live run must yield a diagnosis. A bare
+    // timeout looks identical whether the slot was unseeded, the spawn failed, or only the stamp did.
+    const d = DIAGNOSIS.registration_timeout;
+    expect(d).toMatch(/account_profile/);
+    expect(d).toMatch(/stamp/i);
+    expect(d).toMatch(/REGISTERED/);
+  });
+});
+
+describe('FR-1 provision-canary — fail-soft, never a false green', () => {
+  it('reports INFRA (not a met gate) when provisionCanary throws', async () => {
+    const r = await main([], {
+      supabase: fakeSupabase({}),
+      provisionFn: async () => { throw new Error('boom'); },
+      log: silent,
+    });
+    expect(r.exitCode).toBe(EXIT.INFRA);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports INFRA when a client cannot be constructed, without ever reaching provisionCanary', async () => {
+    // Guards the CI shape (no .env, no secrets): must degrade to a reported INFRA, never a throw.
+    // createClientFn is injected DELIBERATELY. Omitting it does not test harder — it builds a real
+    // service client and runs provisionCanary against the production fleet. Measured: this test took
+    // 14.2s of live network I/O that way, versus 1ms for every other test here.
+    let reachedProvision = false;
+    const r = await main([], {
+      createClientFn: () => { throw new Error('no credentials'); },
+      provisionFn: async () => { reachedProvision = true; return { ok: true, reason: 'provisioned' }; },
+      log: silent,
+    });
+    expect(r.exitCode).toBe(EXIT.INFRA);
+    expect(r.reason).toBe('no_supabase');
+    expect(r.ok).toBe(false);
+    expect(reachedProvision).toBe(false); // must fail BEFORE doing any work
+  });
+});

--- a/tests/unit/hooks/session-register-spawn-correlation.test.js
+++ b/tests/unit/hooks/session-register-spawn-correlation.test.js
@@ -1,0 +1,116 @@
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-2 — stampSpawnCorrelation.
+ *
+ * These are BEHAVIOURAL tests against an injected fake client. Deliberately NOT source-regex
+ * assertions: the sibling session-register-started-at-fix.test.js pins that file by grepping its
+ * source, which proves nothing about behaviour and reds on harmless refactors. The reason this
+ * file can do better is that FR-2 added the DI seam that made behaviour reachable at all.
+ *
+ * ENV-INDEPENDENCE (this bit is load-bearing — it cost a red CI run on the previous SD):
+ * sessionId is passed EXPLICITLY and no test touches resolveSessionId, so nothing here depends on
+ * CLAUDE_SESSION_ID, on stdin, or on the ~/.claude/session-identity marker files that exist on a
+ * dev box and not in CI. The unit project deliberately does not load .env and CI is ubuntu with no
+ * secrets. Verify with: env -u CLAUDE_SESSION_ID npx vitest run <this file>
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { stampSpawnCorrelation } = require_('../../../scripts/hooks/session-register.cjs');
+
+/**
+ * Fake client that RECORDS the filter column, not just its value. The repo's existing fake at
+ * reboot-respawn-runner.test.js:102 does `eq: (_col, value) =>` and discards the column, which is
+ * why "a revert to pid correlation would fail loudly" does NOT actually hold there. Recording the
+ * column is what makes a correlation-key regression detectable.
+ */
+function fakeClient({ row = undefined, readError = null, writeError = null } = {}) {
+  const calls = { reads: [], writes: [], updates: [] };
+  const client = {
+    calls,
+    from(table) {
+      const state = { table, op: 'select', filters: [], payload: null };
+      const builder = {
+        select() { return builder; },
+        update(payload) { state.op = 'update'; state.payload = payload; return builder; },
+        eq(column, value) { state.filters.push({ column, value }); return builder; },
+        async maybeSingle() {
+          calls.reads.push({ table, filters: [...state.filters] });
+          return readError ? { data: null, error: { message: readError } } : { data: row, error: null };
+        },
+        then(resolve) {
+          calls.updates.push({ table, filters: [...state.filters], payload: state.payload });
+          return Promise.resolve(
+            writeError ? { data: null, error: { message: writeError } } : { data: [], error: null }
+          ).then(resolve);
+        },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+const ROW = { session_id: 'sess-1', metadata: { account_profile: 'canary', callsign: 'Canary-1' } };
+
+describe('FR-2 stampSpawnCorrelation — merges, never replaces', () => {
+  it('preserves pre-existing metadata written by the session-manager RPC', async () => {
+    const sb = fakeClient({ row: ROW });
+    const r = await stampSpawnCorrelation(sb, 'sess-1', 'corr-abc');
+    expect(r).toEqual({ stamped: true, reason: 'stamped' });
+
+    const write = sb.calls.updates.at(-1);
+    // The whole point: the other keys survive. A bare upsert would have dropped them.
+    expect(write.payload.metadata).toEqual({
+      account_profile: 'canary',
+      callsign: 'Canary-1',
+      spawn_correlation: 'corr-abc',
+    });
+  });
+
+  it('scopes the write to session_id — never to pid (pid is OS-recyclable and holds the wrong process)', async () => {
+    const sb = fakeClient({ row: ROW });
+    await stampSpawnCorrelation(sb, 'sess-1', 'corr-abc');
+    const columns = sb.calls.updates.at(-1).filters.map((f) => f.column);
+    expect(columns).toContain('session_id');
+    expect(columns).not.toContain('pid');
+  });
+
+  it('degrades a malformed metadata blob to an empty object rather than throwing', async () => {
+    const sb = fakeClient({ row: { session_id: 'sess-1', metadata: 'not-an-object' } });
+    const r = await stampSpawnCorrelation(sb, 'sess-1', 'corr-abc');
+    expect(r.stamped).toBe(true);
+    expect(sb.calls.updates.at(-1).payload.metadata).toEqual({ spawn_correlation: 'corr-abc' });
+  });
+});
+
+describe('FR-2 stampSpawnCorrelation — fail-soft on every path (SessionStart must never abort)', () => {
+  const cases = [
+    ['no_supabase', () => stampSpawnCorrelation(null, 'sess-1', 'c')],
+    ['no_session_id', () => stampSpawnCorrelation(fakeClient({ row: ROW }), '', 'c')],
+    ['no_correlation', () => stampSpawnCorrelation(fakeClient({ row: ROW }), 'sess-1', '')],
+    ['read_error', () => stampSpawnCorrelation(fakeClient({ readError: 'boom' }), 'sess-1', 'c')],
+    ['row_not_found', () => stampSpawnCorrelation(fakeClient({ row: null }), 'sess-1', 'c')],
+    ['write_error', () => stampSpawnCorrelation(fakeClient({ row: ROW, writeError: 'boom' }), 'sess-1', 'c')],
+  ];
+
+  for (const [reason, run] of cases) {
+    it(`returns {stamped:false, reason:'${reason}'} instead of rejecting`, async () => {
+      const r = await run();
+      expect(r).toEqual({ stamped: false, reason });
+    });
+  }
+
+  it('returns threw rather than propagating when the client itself explodes', async () => {
+    const exploding = { from() { throw new Error('client exploded'); } };
+    await expect(stampSpawnCorrelation(exploding, 'sess-1', 'c')).resolves.toEqual({
+      stamped: false, reason: 'threw',
+    });
+  });
+
+  it('never writes when the read found no row', async () => {
+    const sb = fakeClient({ row: null });
+    await stampSpawnCorrelation(sb, 'sess-1', 'c');
+    expect(sb.calls.updates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Two prerequisites for canary discoverability

**SD**: SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 (EXEC) — FR-2 then FR-1, in that order.

> **Size**: 479 LOC, over the ≤100 target. Two commits, each independently reviewable; roughly half is explanatory comment and the tests are ~60% of the remainder. FR-3 (the piece that actually closes discoverability) is a stacked follow-up, deliberately not folded in here.

---

## What I found before writing either commit

The SD scopes FR-1 as "call `provisionCanary` so `metadata.account_profile=canary` is written." **That is not sufficient, and I traced why before building:**

1. `provisionCanary` calls `spawn()` with `accountProfile:'canary'`. `spawn()` uses that value at exactly one place — `spawn-control.js:162` — to resolve a profile **directory**. It is never written to metadata. `spawn()` has no stamp step at all.
2. The **only** writer of `account_profile='canary'` repo-wide is `stampRespawnedCanary` (`canary-guard.js:173`). Its only callers are `canary-guard.js:121/:132` — the **respawn** and **relaunch** verbs. The fresh-spawn path provisioning uses never reaches it.
3. That writer is itself dead: it locates its row via `.eq('pid', pid)` (`canary-guard.js:167`) where `pid` is the **wt.exe launcher** pid, while `claude_sessions.pid` holds the **Claude Code** pid. It polls 8×/500ms, matches nothing, returns `respawn_not_registered`. `spawn()`'s own metadata write at `:202` has the identical break.

`canary-guard.js:153` already documents point 1 in a comment. The comment is accurate; nobody acted on it.

**Consequence**: discoverability is *downstream* of a working spawn→session correlation, not independent of it. That is why FR-2 landed first.

---

## FR-2 — `stampSpawnCorrelation` (commit 1)

The planned design was dead. The SD and my own PRD v1 both carried a `FLEET_SPAWN_TOKEN` env var. Hook subprocesses receive **only** `[CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, CLAUDE_CODE_DISABLE_BACKGROUND_TASKS, CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, CLAUDE_CODE_SSE_PORT, CLAUDE_PROJECT_DIR]` (`lib/hooks/session-id.cjs:36-42`) — any `FLEET_*` var is dropped before the hook runs.

The cited precedent is itself dead: **`FLEET_AUTORESUME_SD` has zero readers repo-wide** — a writer, its own contract assertion, and a comment describing a consumer that does not exist. An env-carried token would have no-opped with every test green: the exact failure this SD exists to close, reproduced inside its own fix.

What landed instead: an exported, injectable `stampSpawnCorrelation(supabase, sessionId, correlation)` — the DI seam `session-register.cjs` never had. Read-row → merge client-side → write back to the same `session_id`. Deliberately **not** folded into `main()`'s upsert, which would replace the whole JSONB blob and clobber the session-manager RPC's metadata. Fail-soft on every path; SessionStart must not abort.

| Mutant | Result |
|---|---|
| merge → replace (metadata clobber) | 1 failed / 10 passed ✓ |
| `.eq('session_id')` → `.eq('pid')` | 1 failed / 10 passed ✓ |

The fake **records the filter column**, not just its value — the repo's existing fake at `reboot-respawn-runner.test.js:102` does `eq: (_col, pid) =>` and discards it, which is why "a revert to pid correlation fails loudly" does not actually hold there.

---

## FR-1 — `scripts/fleet/provision-canary.mjs` (commit 2)

The missing caller, built as a **diagnosis tool** since a live run today will still exit `registration_timeout` for the reasons above.

- Three-valued exit contract — `0` ok / `1` infra / `2` gate-unmet — **fail-closed**, so an unrecognised reason is INFRA, never a silent OK.
- Per-reason diagnosis table. The `registration_timeout` entry names the **stamp** as the suspect and tells the operator to check whether a session registered at all before blaming the spawn. A bare timeout looks identical whether the slot was unseeded, the spawn failed, or only the stamp did.
- Dry-run default; `--live` never inferred. Imports no drill runner and no CP3 entrypoint — it cannot start a drill.

**Tests drive real resolution, not a stub.** The fake supabase's *rows* are the state; the real `provisionCanary` + `resolveCanaryTarget` + `loadDesiredSlots` run against them. Only spawn is stubbed.

| Mutant | Result |
|---|---|
| fail-closed → fail-open on unknown reason | 2 failed / 8 passed ✓ |
| `--live` default flipped to live | 1 failed / 9 passed ✓ |
| `account_profile` stripped from the canary fixture | 1 failed / 9 passed ✓ |

That third mutant is the anti-tautology proof — test 1 reds when the fixture loses the stamp, so it genuinely reads it through the production predicate.

### A unit test was hitting production, caught by timing

The no-client test originally omitted `createClientFn`, so it built a real service client and ran `provisionCanary` **against the live fleet DB** — 14192ms versus 1ms for every other test, passing only because the assertion loosely accepted either exit code. `createClientFn` is now a real seam (it was in the JSDoc but never implemented); the test injects a thrower and asserts `provisionCanary` is never reached. Suite 14.5s → 360ms.

---

## Verification

- **FR-1 acceptance**: `git diff --exit-code origin/main -- scripts/fleet/start-cp3-drills.js` **passes** — byte-identical.
- **Regression**: 1095 tests / 99 files green across `tests/unit/fleet` + `tests/unit/hooks` with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` **all unset**.
- **No drill exercised** — no `start-cp3-drills.js`, no `cp3-drill-run` worktree, no `live:true` verb. Live acceptance remains the coordinator's to sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)