### PR TITLE
feat(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): FR-3/4/5/6/7 — spawner-minted session id, window capture by set difference, -w new, canary skip, futile-poll deletion

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -96,9 +96,48 @@ function buildSessionLaunch(spec = {}, opts = {}) {
 
   // PERSISTENT visible wt.exe tab; -d sets the tab's start dir; NEVER headless -p/--print.
   const args = ['new-tab', '-d', startDir, '--', claudeCmd];
-  if (resumeUuid) args.push('--resume', String(resumeUuid));
 
-  return { program: 'wt.exe', args, env: childEnv, cwd: startDir, persistent: true };
+  // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-3 — MINT THE SESSION ID SPAWNER-SIDE.
+  //
+  // This removes the spawn->session correlation problem instead of solving it. Every previous
+  // approach tried to RECOGNISE the child afterwards and each one is dead:
+  //   - .eq('pid', pid) at spawn-control.js:202, canary-guard.js:167 and in the respawn runner
+  //     matches the wt.exe LAUNCHER pid against claude_sessions.pid, which holds the CLAUDE CODE
+  //     pid. wt.exe hands the tab to the running WindowsTerminal.exe host and exits, so the pid it
+  //     reports is gone before the child ever registers. It can never match.
+  //   - an env carrier (FLEET_SPAWN_TOKEN) cannot reach the hook: only six CLAUDE_-prefixed vars
+  //     propagate to hook subprocesses (lib/hooks/session-id.cjs:36-42). FLEET_AUTORESUME_SD has
+  //     zero readers repo-wide for exactly this reason.
+  // `claude --session-id <uuid>` (CLI 2.1.220: "Use a specific session ID for the conversation
+  // (must be a valid UUID)") lets the SPAWNER choose the id. The SessionStart hook then registers
+  // under that same id, so claude_sessions.session_id IS the value we already hold. No side
+  // channel, no polling, no recognition step.
+  //
+  // Mutually exclusive with --resume: resuming adopts an EXISTING conversation id, so passing both
+  // is contradictory (and --resume already gives the caller a known id).
+  let sessionId = null;
+  if (resumeUuid) {
+    args.push('--resume', String(resumeUuid));
+    sessionId = String(resumeUuid);
+  } else {
+    // Injectable so tests are deterministic; never Math.random-derived.
+    const mint = opts.uuidFn || (() => require('node:crypto').randomUUID());
+    const minted = spec.sessionId || mint();
+    if (isUuid(minted)) {
+      sessionId = String(minted);
+      args.push('--session-id', sessionId);
+    }
+    // A non-UUID is DROPPED rather than passed through: the CLI rejects a malformed --session-id and
+    // would fail the whole launch. Losing correlation is recoverable; losing the session is not.
+  }
+
+  return { program: 'wt.exe', args, env: childEnv, cwd: startDir, persistent: true, sessionId };
+}
+
+/** Strict RFC-4122 shape check — the CLI requires a valid UUID and rejects anything else. */
+function isUuid(v) {
+  return typeof v === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
 }
 
 /**

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -94,8 +94,18 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   if (sdToResume) childEnv.FLEET_AUTORESUME_SD = String(sdToResume); // SessionStart hook -> sd-start --force-reclaim
   if (startupPrompt) childEnv.FLEET_WORKER_STARTUP_PROMPT = String(startupPrompt); // persistent replacement for headless -p
 
-  // PERSISTENT visible wt.exe tab; -d sets the tab's start dir; NEVER headless -p/--print.
-  const args = ['new-tab', '-d', startDir, '--', claudeCmd];
+  // PERSISTENT visible wt.exe window; -d sets the start dir; NEVER headless -p/--print.
+  //
+  // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-5 — `-w new` IS A CORRECTNESS REQUIREMENT, NOT COSMETIC.
+  // Bare `wt new-tab` adds a TAB TO AN EXISTING WINDOW. A new tab creates NO new top-level window, so
+  // FR-4's before/after enumeration diff would see zero windows appear and every capture would return
+  // no_new_window -- the enumerator would be correct and still never fire. `-w new` forces a NEW
+  // WINDOW, which is the thing being counted. It also gives each session its own focusable window,
+  // which is what `attach`/Open needs; tabs of one window cannot be raised independently.
+  //
+  // `-w` is a GLOBAL wt option and MUST precede the `new-tab` subcommand -- `wt new-tab -w new` would
+  // be parsed as an argument to new-tab, not as the window selector. Hence the position here.
+  const args = ['-w', 'new', 'new-tab', '-d', startDir, '--', claudeCmd];
 
   // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-3 — MINT THE SESSION ID SPAWNER-SIDE.
   //
@@ -150,6 +160,13 @@ function assertLaunchContract(inv, { expectProfile = false, expectResume = false
   const args = (inv && inv.args) || [];
   const dIdx = args.indexOf('-d');
   if (dIdx < 0 || !args[dIdx + 1]) v.push('missing -d <cwd> explicit start directory');
+  // FR-5: a NEW WINDOW, not a tab on an existing one. Without this the FR-4 enumeration diff can
+  // never see a window appear (a tab adds none) and Open cannot raise the session independently.
+  // `-w` is GLOBAL, so it must come BEFORE the new-tab subcommand or wt parses it as new-tab's arg.
+  const wIdx = args.indexOf('-w');
+  const ntIdx = args.indexOf('new-tab');
+  if (wIdx < 0 || args[wIdx + 1] !== 'new') v.push('missing -w new (a tab on an existing window creates no new top-level window)');
+  else if (ntIdx >= 0 && wIdx > ntIdx) v.push('-w new must PRECEDE new-tab (-w is a global wt option)');
   if (args.includes('-p') || args.includes('--print')) v.push('headless -p/--print is forbidden (must be persistent)');
   const claudeTok = args[args.indexOf('--') + 1];
   if (!claudeTok || !/claude(\.cmd|\.exe)?$/i.test(claudeTok)) v.push('missing resolved claude launcher token after --');

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -154,7 +154,9 @@ export async function runRebootRespawn(opts = {}) {
       catch (e) { log(`[reboot-respawn] profile resolve failed for ${callsign} (${slot.account_profile}): ${e && e.message}`); profileDir = null; }
     }
 
-    const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid, startupPrompt });
+    // FR-3: forward opts so the minted --session-id is injectable (uuidFn) rather than only
+    // reachable via crypto.randomUUID inside the builder.
+    const invocation = buildInvocationFn({ role, callsign, profileDir, resumeUuid, startupPrompt }, opts);
 
     let spawned = false;
     let child = null;

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -22,7 +22,7 @@ import {
   loadLiveSessionIdentity,
 } from './session-registry-adapter.js';
 import { resolveSpawnDecisions } from './spawn-executor-core.cjs';
-import { captureWindowHandle, focusWindow } from './window-handle.js';
+import { captureNewWindowHandle, enumerateWindows, focusWindow } from './window-handle.js';
 import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
 
 const SINGLETON_ROLES = new Set(['coordinator', 'adam', 'solomon']);
@@ -185,9 +185,22 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     return child;
   });
 
+  // FR-4: the BEFORE snapshot must be taken BEFORE the process launches. Ordering this after the
+  // spawn would make the set difference always empty while every pure unit test still passed --
+  // green-and-dead, the failure mode this SD exists to close. Enumeration is read-only and
+  // fail-soft: on error it yields [], which degrades to no_new_window rather than a wrong handle.
+  const enumerate = opts.enumerateWindowsFn || enumerateWindows;
+  const beforeWindows = await enumerate(opts);
+
   const child = spawner(invocation.program, invocation.args, invocation.env);
   const pid = child && child.pid;
-  const handleResult = pid ? await captureWindowHandle(pid, opts) : { handle: null, handleCaptureFailed: true };
+
+  // FR-4: capture by set difference, not by (Get-Process -Id <launcher pid>).MainWindowHandle.
+  // wt.exe hands the tab to the running WindowsTerminal.exe host and exits, so that query ran
+  // against a dead process and could only ever fail; and MainWindowHandle is per-PROCESS, so it
+  // cannot name one session's window among the many sharing a host.
+  const captureFn = opts.captureNewWindowHandleFn || captureNewWindowHandle;
+  const handleResult = await captureFn(beforeWindows, opts);
 
   // QF-20260724-739: bind session_id via the spawned process's OWN SessionStart-registered
   // claude_sessions row (matched by pid), independent of window-handle capture success -- a captured
@@ -239,6 +252,11 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
               ...(current.metadata || {}),
               window_handle: handleResult.handle,
               handle_capture_failed: handleResult.handleCaptureFailed,
+              // FR-4: persist the DIAGNOSIS on failure so the one permitted live run yields an answer
+              // (nothing opened / filtered everything out / too many opened) instead of a bare retry.
+              ...(handleResult.handleCaptureFailed && handleResult.diagnostics
+                ? { window_handle_diagnostics: handleResult.diagnostics }
+                : {}),
               ...(accountProfile ? { account_profile: accountProfile } : {}),
             },
           }).eq('session_id', current.session_id);

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -79,8 +79,10 @@ export function isLiveEnabled(env = process.env) {
  * this hop did not, so a caller-supplied keepalive prompt was silently DISCARDED here and the launched
  * session came up with nothing to do: it heartbeat once and ghosted.
  */
-export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt } = {}) {
-  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt });
+export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId } = {}, opts = {}) {
+  // FR-3: sessionId/uuidFn forwarded so the minted id is injectable (deterministic tests) rather
+  // than only reachable through crypto.randomUUID inside the builder.
+  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId }, opts);
 }
 
 /**
@@ -160,7 +162,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
 
   let profileDir = null;
   if (accountProfile) profileDir = resolveProfileDir(accountProfile, opts);
-  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt });
+  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt }, opts);
 
   if (!live) {
     log(`[spawn-control] DRY-RUN would spawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
@@ -194,25 +196,51 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // every spawn/respawn/relaunch chain reported session_id:null even on a genuine successful bind.
   // A small bounded retry (mirrors window-handle.js's own injectable poll idiom) absorbs the residual
   // race where SessionStart registration lands just after captureWindowHandle's own poll exhausted.
+  //
+  // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-3: the pid match above could never succeed. `pid` is the
+  // wt.exe LAUNCHER pid, and wt.exe hands the tab to the running WindowsTerminal.exe host and exits
+  // immediately, while claude_sessions.pid holds the CLAUDE CODE pid. The freshness window and the
+  // 3-attempt retry were both compensating for a join that has no matching rows to find. Now that
+  // the spawner MINTS the session id and passes it as --session-id, the child registers under that
+  // exact id and correlation is a direct lookup -- no pid, no freshness heuristic (a minted UUID is
+  // unique per spawn, so there is no recycling to defend against), no recognition step.
+  // The pid path is retained only as a fallback for a caller that supplied no minted id.
   let boundSessionId = null;
-  if (supabase && pid) {
+  const mintedId = invocation && invocation.sessionId;
+  if (supabase && (mintedId || pid)) {
     const sleepFn = opts.sleepFn || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     const nowMs2 = opts.nowMs ?? Date.now();
     const freshMs = opts.pidMatchFreshMs ?? 2 * 60 * 1000;
     const maxAttempts = opts.sessionBindMaxAttempts ?? 3;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        // ADVERSARIAL-REVIEW FIX (data integrity, retained): a bare `.update({ metadata:{...} })
-        // .eq('pid', pid)` REPLACES the whole metadata JSONB blob and `pid` is OS-recyclable --
-        // read the current row first, merge client-side, and only write back to the SAME
-        // session_id just read (never a bare pid-scoped write), only when freshly created.
-        const { data: current } = await supabase.from('claude_sessions')
-          .select('session_id, metadata, created_at').eq('pid', pid).maybeSingle();
-        const isFresh = current && current.created_at && (nowMs2 - Date.parse(current.created_at)) <= freshMs;
+        // ADVERSARIAL-REVIEW FIX (data integrity, retained): a bare `.update({ metadata:{...} })`
+        // REPLACES the whole metadata JSONB blob -- read the current row first, merge client-side,
+        // and only write back to the SAME session_id just read.
+        const { data: current } = mintedId
+          ? await supabase.from('claude_sessions')
+            .select('session_id, metadata, created_at').eq('session_id', mintedId).maybeSingle()
+          : await supabase.from('claude_sessions')
+            .select('session_id, metadata, created_at').eq('pid', pid).maybeSingle();
+        // Freshness guards pid recycling only; a minted id is unique per spawn and needs no window.
+        const isFresh = mintedId
+          ? true
+          : current && current.created_at && (nowMs2 - Date.parse(current.created_at)) <= freshMs;
         if (current && isFresh) {
           boundSessionId = current.session_id;
+          // FR-1/FR-3: STAMP account_profile HERE, on the fresh-spawn path. Previously accountProfile
+          // was used only to resolve a profile DIRECTORY (L162) and never written, while the sole
+          // writer of account_profile (canary-guard.js:173 stampRespawnedCanary) sits on the RESPAWN
+          // path and is itself pid-dead. That is why zero sessions in 24h carried the stamp and
+          // resolveCanaryTarget(by account_profile) fail-closed even with canaries alive and
+          // heartbeating -- survival was sufficient, discoverability was not.
           await supabase.from('claude_sessions').update({
-            metadata: { ...(current.metadata || {}), window_handle: handleResult.handle, handle_capture_failed: handleResult.handleCaptureFailed },
+            metadata: {
+              ...(current.metadata || {}),
+              window_handle: handleResult.handle,
+              handle_capture_failed: handleResult.handleCaptureFailed,
+              ...(accountProfile ? { account_profile: accountProfile } : {}),
+            },
           }).eq('session_id', current.session_id);
           break;
         }

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -12,64 +12,33 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-/** Coerce to a strictly-positive integer PID or throw. Never interpolate an unvalidated value. */
-export function assertValidPid(pid) {
-  const n = Number(pid);
-  if (!Number.isInteger(n) || n <= 0) throw new Error(`assertValidPid: not a valid PID: ${JSON.stringify(pid)}`);
-  return n;
-}
-
-/** Build the PowerShell command for a single, coerced-numeric PID. Pure -- no execution. */
-export function buildHandleCaptureCommand(pid) {
-  const safePid = assertValidPid(pid);
-  return {
-    program: 'powershell',
-    args: ['-NoProfile', '-NonInteractive', '-Command',
-      `(Get-Process -Id ${safePid} -ErrorAction SilentlyContinue).MainWindowHandle.ToInt64()`],
-  };
-}
-
-/** Parse the PowerShell handle-capture stdout. Returns a non-zero handle or null (window not yet created). */
-export function parseHandleOutput(stdout) {
-  const trimmed = String(stdout || '').trim();
-  const n = Number(trimmed);
-  return Number.isFinite(n) && n !== 0 ? n : null;
-}
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-7 — THE PID-BASED CAPTURE FAMILY IS GONE.
+ *
+ * Retired here: assertValidPid, buildHandleCaptureCommand, parseHandleOutput and captureWindowHandle.
+ * They implemented `(Get-Process -Id <pid>).MainWindowHandle` against the wt.exe LAUNCHER pid --
+ * a process that has already exited by the time it is queried (wt.exe hands the tab to the running
+ * WindowsTerminal.exe host and returns). The 10-attempt / 500ms loop therefore burned ~5 SECONDS on
+ * every single spawn and could not succeed on any of them: a futile poll, not a slow one.
+ *
+ * Deleted rather than left in place. After FR-4 it had ZERO production callers (verified repo-wide:
+ * only its own definition and its own tests referenced it), and the whole family was reachable only
+ * through it. Leaving a known-broken exported capture path next to the working one is an invitation
+ * to wire the wrong one back up -- which is how it survived this long.
+ *
+ * WHAT REPLACED IT: enumerate top-level windows before/after the spawn and take the set difference
+ * (see below). QF-20260724-113's invariant -- capture must NEVER throw out of spawn(), because a
+ * throw there aborted bookkeeping AFTER the real OS spawn and left orphaned unstamped sessions --
+ * is preserved structurally on the new path: enumerateWindows swallows exec failures and returns [],
+ * and selectNewWindowHandle is pure and total. That invariant is re-asserted directly against
+ * captureNewWindowHandle in the tests, so retiring the old tests retires no protection.
+ */
 
 async function defaultExec(program, args) {
   return execFileAsync(program, args, { windowsHide: false, timeout: 5000 });
 }
 function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
-/**
- * Bounded poll/retry to capture MainWindowHandle for a just-spawned PID. Injectable execFn/sleepFn
- * for tests (never invokes PowerShell in unit tests).
- * @param {number} pid
- * @param {{execFn?:Function, maxAttempts?:number, delayMs?:number, sleepFn?:Function}} [opts]
- * @returns {Promise<{handle:number|null, handleCaptureFailed:boolean, attempts:number}>}
- */
-export async function captureWindowHandle(pid, opts = {}) {
-  const { execFn = defaultExec, maxAttempts = 10, delayMs = 500, sleepFn = defaultSleep } = opts;
-  const cmd = buildHandleCaptureCommand(pid);
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    let handle = null;
-    try {
-      const { stdout } = await execFn(cmd.program, cmd.args);
-      handle = parseHandleOutput(stdout);
-    } catch {
-      // QF-20260724-113: MainWindowHandle.ToInt64() throws in PowerShell when the property is
-      // genuinely $null (process hasn't rendered a window yet, not just a zero IntPtr) -- execFn
-      // then rejects. Treat exactly like "handle not yet available" instead of letting the throw
-      // escape uncaught: it previously aborted spawn-control's spawn()/restart()/relaunchUnderProfile()
-      // AFTER the real OS spawn but BEFORE DB bookkeeping (release old session + emit fleet_verb
-      // event) -- real processes spawned with zero evidence + orphaned unstamped sessions.
-      handle = null;
-    }
-    if (handle !== null) return { handle, handleCaptureFailed: false, attempts: attempt };
-    if (attempt < maxAttempts) await sleepFn(delayMs);
-  }
-  return { handle: null, handleCaptureFailed: true, attempts: maxAttempts };
-}
 
 /**
  * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-4 — TOP-LEVEL WINDOW ENUMERATION.
@@ -98,6 +67,20 @@ export const WINDOW_ENUM_COMMAND = "Add-Type -TypeDefinition 'using System;using
 
 /** The host process that owns fleet session windows. Windows Terminal, not the launcher. */
 export const TERMINAL_PROCESS_NAME = 'WindowsTerminal';
+
+/**
+ * FR-7: the capture poll BUDGET, exported so it can be asserted directly instead of by wall-clock.
+ * A timing-based test ("capture takes under N seconds") is flaky on a loaded CI box and, worse, still
+ * passes when the poll is futile -- the retired pid-based capture burned its full budget on every
+ * spawn and no clock assertion would have called that a bug. Asserting the exported budget and the
+ * injected-execFn CALL COUNT measures the thing that actually matters: how many attempts are spent.
+ *
+ * Unlike the retired poll, these attempts are not futile: they cover a real race (the window renders
+ * shortly after the process launches). The budget is deliberately unchanged at ~5s so the fix is
+ * behavioural, not a timing tweak dressed up as one.
+ */
+export const CAPTURE_POLL_MAX_ATTEMPTS = 10;
+export const CAPTURE_POLL_DELAY_MS = 500;
 
 /** Build the enumeration command. Pure, and CONSTANT — takes no argument by design. */
 export function buildWindowEnumCommand() {
@@ -224,7 +207,11 @@ export async function enumerateWindows(opts = {}) {
  * @returns {Promise<{handle:number|null, handleCaptureFailed:boolean, attempts:number, diagnostics:object}>}
  */
 export async function captureNewWindowHandle(before, opts = {}) {
-  const { maxAttempts = 10, delayMs = 500, sleepFn = defaultSleep } = opts;
+  const {
+    maxAttempts = CAPTURE_POLL_MAX_ATTEMPTS,
+    delayMs = CAPTURE_POLL_DELAY_MS,
+    sleepFn = defaultSleep,
+  } = opts;
   let selection = { handle: null, reason: 'no_new_window', diagnostics: { reason: 'no_new_window' } };
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const after = await enumerateWindows(opts);

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -71,6 +71,183 @@ export async function captureWindowHandle(pid, opts = {}) {
   return { handle: null, handleCaptureFailed: true, attempts: maxAttempts };
 }
 
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-4 — TOP-LEVEL WINDOW ENUMERATION.
+ *
+ * WHY captureWindowHandle ABOVE CANNOT WORK FOR A FLEET SPAWN. It runs
+ * `(Get-Process -Id <pid>).MainWindowHandle` against the pid spawn-control holds, which is the
+ * wt.exe LAUNCHER pid. `wt.exe new-tab` hands the tab to the already-running WindowsTerminal.exe
+ * host and EXITS IMMEDIATELY, so that query runs against a dead process, retries 10x, and always
+ * fails. Worse, MainWindowHandle is per-PROCESS: many terminal windows share ONE host process, so
+ * even against the live host it cannot name the window belonging to a particular session.
+ *
+ * THE FIX IS A SET DIFFERENCE, NOT A LOOKUP. Enumerate top-level windows immediately BEFORE and
+ * AFTER the spawn and take (after MINUS before). Deliberately NOT a symmetric difference: a window
+ * CLOSING between the two snapshots is a normal event and must not be mistaken for an opening.
+ *
+ * NEVER MATCH ON TITLE. Verified against a real enumeration on this host (see the fixture header in
+ * tests/unit/fleet/window-enum.test.js): two DIFFERENT processes both presented a window titled
+ * exactly "Settings", and 11 of 17 visible windows had an EMPTY title. Titles are neither unique nor
+ * reliably present. The SD's own field note says both observed session windows were titled simply
+ * "Claude Code".
+ *
+ * The command is a CONSTANT — zero interpolation, so there is no injection surface at all (contrast
+ * buildHandleCaptureCommand above, which must coerce a pid).
+ */
+export const WINDOW_ENUM_COMMAND = "Add-Type -TypeDefinition 'using System;using System.Text;using System.Collections.Generic;using System.Runtime.InteropServices;public class FleetEnum{public delegate bool EnumProc(IntPtr h,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool EnumWindows(EnumProc cb,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool IsWindowVisible(IntPtr h);[DllImport(\"user32.dll\")] public static extern int GetWindowTextLength(IntPtr h);[DllImport(\"user32.dll\",CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h,StringBuilder s,int n);[DllImport(\"user32.dll\")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint pid);public static List<string> List(){var r=new List<string>();EnumWindows((h,l)=>{if(IsWindowVisible(h)){uint p;GetWindowThreadProcessId(h,out p);int len=GetWindowTextLength(h);var sb=new StringBuilder(len+1);GetWindowText(h,sb,sb.Capacity);r.Add(h.ToInt64()+\"|\"+p+\"|\"+sb.ToString());}return true;},IntPtr.Zero);return r;}}'; [FleetEnum]::List() | ForEach-Object { $f = $_.Split([char]124); $n = (Get-Process -Id ([int]$f[1]) -ErrorAction SilentlyContinue).ProcessName; \"$($f[0])|$($f[1])|$n|$($f[2])\" }";
+
+/** The host process that owns fleet session windows. Windows Terminal, not the launcher. */
+export const TERMINAL_PROCESS_NAME = 'WindowsTerminal';
+
+/** Build the enumeration command. Pure, and CONSTANT — takes no argument by design. */
+export function buildWindowEnumCommand() {
+  return {
+    program: 'powershell',
+    args: ['-NoProfile', '-NonInteractive', '-Command', WINDOW_ENUM_COMMAND],
+  };
+}
+
+/**
+ * Parse enumeration stdout into rows. Pure. Shape per line: `handle|pid|processName|title`.
+ *
+ * Real-capture edge cases this handles (all present in the committed fixture, none hypothetical):
+ *   - an EMPTY title (11 of 17 rows) — a row is still valid; titles are not required
+ *   - a process name containing a SPACE ("Wispr Flow") — so never tokenize on whitespace
+ *   - a title that itself contains "|" — the split is LIMITED to 4 fields so the remainder stays
+ *     in the title rather than silently truncating the row or dropping it
+ *   - a non-numeric or absent handle — the row is DROPPED rather than yielding NaN, which would
+ *     otherwise poison the set difference
+ * @returns {Array<{handle:number, pid:number|null, proc:string, title:string}>}
+ */
+export function parseWindowListOutput(stdout) {
+  const out = [];
+  for (const raw of String(stdout || '').split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Limit to 4 fields: everything after the 3rd separator belongs to the title.
+    const parts = line.split('|');
+    if (parts.length < 3) continue;
+    const handle = Number(parts[0]);
+    if (!Number.isFinite(handle) || handle === 0) continue;
+    const pidNum = Number(parts[1]);
+    out.push({
+      handle,
+      pid: Number.isFinite(pidNum) ? pidNum : null,
+      proc: (parts[2] || '').trim(),
+      title: parts.slice(3).join('|'),
+    });
+  }
+  return out;
+}
+
+/** Normalise a row/handle of either numeric or string type to a Number, or null. PowerShell emits text. */
+function toHandle(v) {
+  const n = Number(v && typeof v === 'object' ? v.handle : v);
+  return Number.isFinite(n) && n !== 0 ? n : null;
+}
+
+/**
+ * Pick the ONE window that appeared between two snapshots. Pure. FAILS CLOSED.
+ *
+ * Accepts rows (from parseWindowListOutput) or bare handles, in either number or string form —
+ * PowerShell output is text and a caller may pass either side through unchanged.
+ *
+ * @param {Array} before  snapshot taken BEFORE the spawn
+ * @param {Array} after   snapshot taken AFTER the spawn
+ * @param {{processName?:string|null}} [opts] restrict to one owning process (default: Windows
+ *   Terminal). Narrowing to the host process is what keeps an unrelated app opening a window
+ *   mid-spawn from turning every capture into `ambiguous`. Pass null to disable filtering.
+ * @returns {{handle:number|null, reason:string, diagnostics:object}}
+ */
+export function selectNewWindowHandle(before = [], after = [], opts = {}) {
+  const processName = ('processName' in opts) ? opts.processName : TERMINAL_PROCESS_NAME;
+  const keep = (r) => {
+    if (!processName) return true;
+    // Bare handles carry no process name; they cannot be filtered, so they are kept.
+    if (!r || typeof r !== 'object') return true;
+    return String(r.proc || '').toLowerCase() === String(processName).toLowerCase();
+  };
+
+  const beforeSet = new Set(
+    (Array.isArray(before) ? before : []).map(toHandle).filter((h) => h !== null),
+  );
+  const afterRows = (Array.isArray(after) ? after : []).filter(keep);
+  // AFTER MINUS BEFORE -- never a symmetric difference. A window that CLOSED between the snapshots
+  // appears only in `before`; treating that as a change would invent a handle that no longer exists.
+  const appeared = [...new Set(
+    afterRows.map(toHandle).filter((h) => h !== null && !beforeSet.has(h)),
+  )];
+
+  const diagnostics = {
+    beforeCount: beforeSet.size,
+    afterCount: afterRows.length,
+    appearedCount: appeared.length,
+    appeared: appeared.slice(0, 8), // bounded: a diagnostic, not a dump
+    processFilter: processName || null,
+  };
+
+  if (appeared.length === 0) {
+    return { handle: null, reason: 'no_new_window', diagnostics: { ...diagnostics, reason: 'no_new_window' } };
+  }
+  if (appeared.length > 1) {
+    // Fail CLOSED. Guessing here would bind a session card to someone else's window.
+    return { handle: null, reason: 'ambiguous', diagnostics: { ...diagnostics, reason: 'ambiguous' } };
+  }
+  return { handle: appeared[0], reason: 'ok', diagnostics: { ...diagnostics, reason: 'ok' } };
+}
+
+/** Run one enumeration. Injectable execFn so unit tests never invoke PowerShell. Fail-soft: [] on error. */
+export async function enumerateWindows(opts = {}) {
+  const { execFn = defaultExec } = opts;
+  try {
+    const cmd = buildWindowEnumCommand();
+    const { stdout } = await execFn(cmd.program, cmd.args);
+    return parseWindowListOutput(stdout);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Capture the handle of the window that appeared after a spawn, given the BEFORE snapshot.
+ *
+ * CALL ORDER IS LOAD-BEARING: the caller must take `before` BEFORE launching the process. Taking it
+ * afterwards makes the diff always empty while every pure unit test still passes -- the exact
+ * green-and-dead shape this SD exists to close. spawn-control's spawn() is ordered accordingly.
+ *
+ * POLLS ONLY THE RACE IT CAN WIN. `no_new_window` is a genuine race (the window renders slightly
+ * after the process launches), so it retries. `ambiguous` is NOT retried: two windows already
+ * appeared, and waiting cannot un-appear one -- polling there would just burn the same futile ~5s
+ * FR-7 exists to retire. Fails closed either way.
+ *
+ * @param {Array} before snapshot taken BEFORE the spawn
+ * @returns {Promise<{handle:number|null, handleCaptureFailed:boolean, attempts:number, diagnostics:object}>}
+ */
+export async function captureNewWindowHandle(before, opts = {}) {
+  const { maxAttempts = 10, delayMs = 500, sleepFn = defaultSleep } = opts;
+  let selection = { handle: null, reason: 'no_new_window', diagnostics: { reason: 'no_new_window' } };
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const after = await enumerateWindows(opts);
+    selection = selectNewWindowHandle(before, after, opts);
+    if (selection.handle !== null) {
+      return {
+        handle: selection.handle,
+        handleCaptureFailed: false,
+        attempts: attempt,
+        diagnostics: { ...selection.diagnostics, attempts: attempt },
+      };
+    }
+    if (selection.reason === 'ambiguous') break; // retrying cannot resolve it
+    if (attempt < maxAttempts) await sleepFn(delayMs);
+  }
+  return {
+    handle: null,
+    handleCaptureFailed: true,
+    attempts: selection.reason === 'ambiguous' ? 1 : maxAttempts,
+    diagnostics: { ...selection.diagnostics, reason: selection.reason },
+  };
+}
+
 /** Build the foreground-focus command for a captured handle. Pure -- no execution. */
 export function buildFocusCommand(handle) {
   const n = Number(handle);

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1364,6 +1364,26 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
       if (isFixtureSession(sessionId)) return null;
     } catch { /* superset unavailable — retained isTestSessionId pre-filter still guards */ }
     const existing = myMeta.fleet_identity;
+    // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-6: the SECOND, previously unguarded clobber writer.
+    // QF-20260724-521 added this canary skip to assign-fleet-identities.cjs:401 (the cron path) but
+    // NOT here, and this function applies the identical callsignInTierBand gate below. Canary sessions
+    // live outside the NATO tier-band scheme entirely -- canary-guard fail-closed REQUIRES a callsign
+    // starting with 'Canary-' -- so 'Canary-1' is in no NATO band, falls through to re-derive, and the
+    // canary is silently renamed to a NATO callsign mid-drill. Both writers must skip, or closing one
+    // just moves the clobber to the other.
+    //
+    // MUST be checked BEFORE the tier-band idempotency check below: that check returns early only for
+    // an in-band callsign, so placing this after it would let every canary reach the re-derive path
+    // first and the guard would never fire. Ordering is pinned by a test.
+    //
+    // Two independent conditions, matching the cron's: the account_profile stamp (authoritative, but
+    // written only once FR-1/FR-3 land) OR the 'Canary-' callsign prefix (works today). Deliberately
+    // an OR so this is NOT inert while the stamp is still being wired.
+    if (myMeta.account_profile === 'canary' || (existing && typeof existing.callsign === 'string' && existing.callsign.startsWith('Canary-'))) {
+      return existing && existing.callsign && existing.color
+        ? { callsign: existing.callsign, color: existing.color }
+        : null;
+    }
     // QF-20260627-108: idempotent ONLY when the existing callsign is in this worker's tier band
     // (effort-encoded SoT). A wrong-band callsign (e.g. a tier-2 worker still holding "Bravo") falls
     // through to re-derive, so check-in self-heals to the scheme just like the cron.

--- a/tests/unit/fleet/launch-contract-conformance.test.js
+++ b/tests/unit/fleet/launch-contract-conformance.test.js
@@ -35,6 +35,48 @@ describe('launch-contract conformance — every spawn path routes through buildS
     expect(assertLaunchContract({ program: 'wt.exe', args: ['new-tab', '--', 'claude'], env: {}, persistent: true }).ok).toBe(false); // missing -d cwd
   });
 
+  // --- SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-5: `-w new` is a CORRECTNESS requirement ---
+  //
+  // Bare `wt new-tab` adds a TAB TO AN EXISTING WINDOW, which creates NO new top-level window. FR-4
+  // captures the session's window by diffing a before/after enumeration, so without `-w new` that diff
+  // sees nothing appear and every capture returns no_new_window -- a correct enumerator that can never
+  // fire. It also gives each session its own focusable window; tabs of one window cannot be raised
+  // independently, which is what attach/Open needs.
+  it('FR-5: every spawn path forces a NEW WINDOW, not a tab on an existing one', () => {
+    for (const p of PATHS) {
+      const args = p.make().args;
+      const wIdx = args.indexOf('-w');
+      expect(wIdx, `${p.name} must pass -w`).toBeGreaterThanOrEqual(0);
+      expect(args[wIdx + 1], `${p.name} must pass -w new`).toBe('new');
+    }
+  });
+
+  it('FR-5: -w new PRECEDES the new-tab subcommand (-w is a GLOBAL wt option)', () => {
+    // Ordering is not stylistic: `wt new-tab -w new` parses -w as an argument TO new-tab rather than
+    // as the window selector, so the window would silently still be a tab.
+    for (const p of PATHS) {
+      const args = p.make().args;
+      const ntIdx = args.indexOf('new-tab');
+      if (ntIdx < 0) continue;
+      expect(args.indexOf('-w'), `${p.name}: -w must come before new-tab`).toBeLessThan(ntIdx);
+    }
+  });
+
+  it('FR-5 NEGATIVE control: the contract REJECTS a bare new-tab and a mis-ordered -w', () => {
+    const base = (args) => ({ program: 'wt.exe', args, env: {}, persistent: true });
+    const claude = 'C:\\x\\claude.cmd';
+    // Missing -w new entirely -> a tab, no new window for the enumerator to find.
+    const bare = assertLaunchContract(base(['new-tab', '-d', 'R:\\r', '--', claude]));
+    expect(bare.ok).toBe(false);
+    expect(bare.violations.join(' ')).toMatch(/-w new/);
+    // -w AFTER new-tab -> parsed as new-tab's argument; still a tab. Must be caught distinctly.
+    const misordered = assertLaunchContract(base(['new-tab', '-w', 'new', '-d', 'R:\\r', '--', claude]));
+    expect(misordered.ok).toBe(false);
+    expect(misordered.violations.join(' ')).toMatch(/PRECEDE/);
+    // A -w with the wrong value is not a new window either.
+    expect(assertLaunchContract(base(['-w', '0', 'new-tab', '-d', 'R:\\r', '--', claude])).ok).toBe(false);
+  });
+
   it('profile + auto-resume expectations are enforced when applicable', () => {
     const inv = buildSessionLaunch({ callsign: 'C', profile: 'canary', cwd: 'R:\\r', sdToResume: 'SD-Z' }, { env: { FLEET_ACCOUNT_PROFILES_DIR: 'C:\\p' } });
     expect(assertLaunchContract(inv, { expectProfile: true, expectResume: true }).ok).toBe(true);

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -38,10 +38,10 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
     expect(events[0].payload).toMatchObject({ verb: 'respawn', callsign: 'Worker-1', resume_uuid: 'u-1', live: false });
 
     // The per-slot invocation carries the correct --resume token (slot 1) / no token (slot 2).
-    expect(res.results[0].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    expect(res.results[0].invocation.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
     // FR-3: a slot with no resume token gets a MINTED --session-id instead, so the spawner knows in
     // advance the id the child will register under. Injected via uuidFn for determinism.
-    expect(res.results[1].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(res.results[1].invocation.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
   });
 
   // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
@@ -75,8 +75,8 @@ describe('runRebootRespawn live (FR-5)', () => {
     });
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
-    expect(spawnCalls[0]).toEqual({ program: 'wt.exe', args: ['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1'] });
-    expect(spawnCalls[1].args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
+    expect(spawnCalls[0]).toEqual({ program: 'wt.exe', args: ['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1'] });
+    expect(spawnCalls[1].args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
     expect(res.results.map((r) => r.spawned)).toEqual([true, true]);
   });
 

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -13,13 +13,20 @@ const SLOTS = [
   { name: 'Worker-2', role: 'worker', account_profile: null, resume_uuid: null }, // no token -> back-compat path
 ];
 
+/**
+ * FR-3: with no resume token the spawner mints a session id and passes `claude --session-id <uuid>`,
+ * so the child registers under a value the spawner already holds -- replacing the wt.exe-pid join that
+ * could never match. Injected via uuidFn so argv assertions stay EXACT rather than being loosened.
+ */
+const MINTED = '11111111-2222-4333-8444-555555555555';
+
 describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
   it('spawns NOTHING, logs per-slot resume invocations, and emits one fleet_verb_respawn event per slot', async () => {
     const events = [];
     const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
     const spawnFn = vi.fn();
     const res = await runRebootRespawn({
-      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn, live: false, now: () => '2026-07-20T00:00:00.000Z',
+      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn, live: false, now: () => '2026-07-20T00:00:00.000Z', uuidFn: () => MINTED,
     });
 
     expect(spawnFn).not.toHaveBeenCalled(); // default-OFF: no OS process
@@ -32,7 +39,9 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
 
     // The per-slot invocation carries the correct --resume token (slot 1) / no token (slot 2).
     expect(res.results[0].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
-    expect(res.results[1].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd()]);
+    // FR-3: a slot with no resume token gets a MINTED --session-id instead, so the spawner knows in
+    // advance the id the child will register under. Injected via uuidFn for determinism.
+    expect(res.results[1].invocation.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
   });
 
   // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
@@ -62,12 +71,12 @@ describe('runRebootRespawn live (FR-5)', () => {
     const spawnCalls = [];
     const spawnFn = vi.fn((program, args) => { spawnCalls.push({ program, args }); return { pid: 111 }; });
     const res = await runRebootRespawn({
-      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn: async () => ({ ok: true }), live: true, now: () => 'iso', sleepFn: vi.fn(),
+      supabase: {}, loadFn: async () => SLOTS, spawnFn, logFn: async () => ({ ok: true }), live: true, now: () => 'iso', sleepFn: vi.fn(), uuidFn: () => MINTED,
     });
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
     expect(spawnCalls[0]).toEqual({ program: 'wt.exe', args: ['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1'] });
-    expect(spawnCalls[1].args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd()]); // slot 2 had no token
+    expect(spawnCalls[1].args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
     expect(res.results.map((r) => r.spawned)).toEqual([true, true]);
   });
 

--- a/tests/unit/fleet/spawn-control-resume.test.js
+++ b/tests/unit/fleet/spawn-control-resume.test.js
@@ -11,7 +11,7 @@ import { resolveClaudeCmd, resolveRepoRoot } from '../../../lib/fleet/build-sess
 describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)', () => {
   it('appends [--resume, <uuid>] after the base argv (new-tab -d <root> -- <claude>)', () => {
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1', resumeUuid: 'abc-123' });
-    expect(inv.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'abc-123']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'abc-123']);
     expect(inv.program).toBe('wt.exe');
   });
 
@@ -20,7 +20,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
     // what the child will register as. uuidFn is injected purely for determinism.
     const MINTED = '11111111-2222-4333-8444-555555555555';
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' }, { uuidFn: () => MINTED });
-    expect(inv.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
     expect(inv.sessionId).toBe(MINTED);
     expect(inv.cwd).toBe(resolveRepoRoot());
     expect(inv.persistent).toBe(true);
@@ -50,7 +50,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
 
   it('coerces a non-string resume token via String() (never leaks a raw object into argv)', () => {
     const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 42 });
-    expect(inv.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', '42']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', '42']);
   });
 
   it('injects CLAUDE_CONFIG_DIR only into the returned env, never process.env, and never as an argv token', () => {

--- a/tests/unit/fleet/spawn-control-resume.test.js
+++ b/tests/unit/fleet/spawn-control-resume.test.js
@@ -15,11 +15,37 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
     expect(inv.program).toBe('wt.exe');
   });
 
-  it('builds the base argv + repo-root cwd + persistent when no resumeUuid is given', () => {
-    const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' });
-    expect(inv.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd()]);
+  it('builds the base argv + a MINTED --session-id + repo-root cwd + persistent when no resumeUuid is given', () => {
+    // FR-3: with no conversation to resume, the spawner mints the session id so it knows in advance
+    // what the child will register as. uuidFn is injected purely for determinism.
+    const MINTED = '11111111-2222-4333-8444-555555555555';
+    const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' }, { uuidFn: () => MINTED });
+    expect(inv.args).toEqual(['new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(inv.sessionId).toBe(MINTED);
     expect(inv.cwd).toBe(resolveRepoRoot());
     expect(inv.persistent).toBe(true);
+  });
+
+  it('FR-3: --session-id and --resume are mutually exclusive (resuming adopts an existing id)', () => {
+    const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 'abc-123' });
+    expect(inv.args).not.toContain('--session-id');
+    expect(inv.sessionId).toBe('abc-123'); // still known to the caller, via the resume token
+  });
+
+  it('FR-3: DROPS a malformed minted id rather than passing a value the CLI would reject', () => {
+    // The CLI requires a valid UUID and fails the launch on anything else. Losing correlation is
+    // recoverable; losing the session is not — so a bad id degrades to no --session-id at all.
+    const inv = buildLiveSpawnInvocation({ callsign: 'W' }, { uuidFn: () => 'not-a-uuid' });
+    expect(inv.args).not.toContain('--session-id');
+    expect(inv.args).not.toContain('not-a-uuid');
+    expect(inv.sessionId).toBeNull();
+  });
+
+  it('FR-3: mints a DISTINCT id per spawn (two sessions must never collide on one id)', () => {
+    const a = buildLiveSpawnInvocation({ callsign: 'W1' });
+    const b = buildLiveSpawnInvocation({ callsign: 'W2' });
+    expect(a.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    expect(a.sessionId).not.toBe(b.sessionId);
   });
 
   it('coerces a non-string resume token via String() (never leaks a raw object into argv)', () => {

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -40,6 +40,22 @@ const { spawn: childProcessSpawnSpy } = await import('node:child_process');
  */
 const MINTED_SESSION_ID = '11111111-2222-4333-8444-555555555555';
 
+/**
+ * FR-4: spawn() now captures the window by ENUMERATION DIFF rather than by reading a per-process
+ * MainWindowHandle, so execFn must return enumeration-shaped stdout (`handle|pid|proc|title`).
+ * Call 1 is the BEFORE snapshot (no windows); every later call is an AFTER snapshot containing one
+ * new WindowsTerminal window. The old shape -- a bare number -- parses to ZERO rows, so the capture
+ * correctly fails; that is exactly why these tests went red until updated, and it is the signal that
+ * the production call path really changed rather than the tests being loosened around it.
+ */
+function enumExec(handle = 131074) {
+  let call = 0;
+  return vi.fn(async () => {
+    call += 1;
+    return { stdout: call === 1 ? '' : `${handle}|5555|WindowsTerminal|Claude Code` };
+  });
+}
+
 /** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
 function makeFakeSupabase({ sessions = [] } = {}) {
   const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
@@ -204,7 +220,7 @@ describe('spawn (FR-1)', () => {
     const fakeChild = { pid: 4242, unref: vi.fn() };
     childProcessSpawnSpy.mockReset();
     childProcessSpawnSpy.mockReturnValue(fakeChild);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({ sessions: [] });
     const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, execFn, sleepFn: vi.fn(), supabaseClient });
     // LOAD-BEARING: kill-survival depends on detached:true (OS re-parents the child when the
@@ -221,7 +237,7 @@ describe('spawn (FR-1)', () => {
     const nowMs = 1_800_000_000_000;
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     // FR-3: the child now registers under the SPAWNER-MINTED --session-id, so the row is keyed on
     // that id rather than on the wt.exe launcher pid (which never matched claude_sessions.pid).
     const supabaseClient = makeFakeSupabase({
@@ -244,7 +260,7 @@ describe('spawn (FR-1)', () => {
     const nowMs = 1_800_000_000_000;
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{
         session_id: 's-old', pid: 4242, status: 'active',
@@ -274,7 +290,7 @@ describe('spawn (FR-1)', () => {
   it('FR-5: skipDedup:true (internal replacement path) bypasses the already-live check', async () => {
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
     });
@@ -289,7 +305,7 @@ describe('spawn (FR-1)', () => {
     const nowMs = 1_800_000_000_000;
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{
         session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
@@ -321,7 +337,7 @@ describe('spawn (FR-1)', () => {
     });
     const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, {
       live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
-      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
     });
     expect(result.session_id).toBe(MINTED_SESSION_ID);
@@ -342,13 +358,75 @@ describe('spawn (FR-1)', () => {
     });
     await spawn({ role: 'worker', callsign: 'Canary-1', accountProfile: 'canary' }, {
       live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
-      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
       baseDir: 'C:/fake', // resolveProfileDir(name, opts) honours opts.baseDir — no FLEET_* env needed
     });
     const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
     expect(md.account_profile).toBe('canary');
     expect(md.fleet_identity).toEqual({ callsign: 'Canary-1' }); // merged, not replaced
+  });
+
+  it('FR-4: takes the BEFORE snapshot strictly BEFORE launching the process (call-order pin)', async () => {
+    // THE most important test in FR-4, and the one the pure diff tests cannot give us. If the
+    // before-snapshot is taken AFTER the spawn, the set difference is always empty in production
+    // while every pure selectNewWindowHandle test still passes -- green and dead. Only an ordering
+    // assertion catches that, so this records the real interleaving rather than each call in isolation.
+    const order = [];
+    const supabaseClient = makeFakeSupabase({ sessions: [] });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, {
+      live: true,
+      enumerateWindowsFn: async () => { order.push('enumerate'); return []; },
+      spawnFn: () => { order.push('spawn'); return { pid: 4242 }; },
+      captureNewWindowHandleFn: async () => { order.push('capture'); return { handle: 1, handleCaptureFailed: false, attempts: 1, diagnostics: {} }; },
+      sleepFn: vi.fn(), supabaseClient, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+    });
+    expect(order).toEqual(['enumerate', 'spawn', 'capture']);
+    expect(order.indexOf('enumerate')).toBeLessThan(order.indexOf('spawn'));
+  });
+
+  it('FR-4: persists the capture DIAGNOSIS into metadata when the handle cannot be resolved', async () => {
+    // So the one permitted live run is a diagnosis, not a re-run: the counts distinguish "nothing
+    // opened" from "the process filter excluded everything" from "too many opened at once".
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), metadata: {},
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, {
+      live: true,
+      spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      enumerateWindowsFn: async () => [],
+      captureNewWindowHandleFn: async () => ({
+        handle: null, handleCaptureFailed: true, attempts: 1,
+        diagnostics: { reason: 'ambiguous', beforeCount: 1, afterCount: 3, appearedCount: 2 },
+      }),
+      sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md.handle_capture_failed).toBe(true);
+    expect(md.window_handle_diagnostics).toMatchObject({ reason: 'ambiguous', appearedCount: 2 });
+  });
+
+  it('FR-4: does NOT persist diagnostics on a SUCCESSFUL capture (noise, not signal)', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), metadata: {},
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, {
+      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      enumerateWindowsFn: async () => [],
+      captureNewWindowHandleFn: async () => ({ handle: 777, handleCaptureFailed: false, attempts: 1, diagnostics: { reason: 'ok' } }),
+      sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md.window_handle).toBe(777);
+    expect(md.window_handle_diagnostics).toBeUndefined();
   });
 
   it('FR-1/FR-3: does NOT stamp account_profile when none was requested', async () => {
@@ -361,7 +439,7 @@ describe('spawn (FR-1)', () => {
     });
     await spawn({ role: 'worker', callsign: 'Beta-1' }, {
       live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
-      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
     });
     expect(supabaseClient._store.get(MINTED_SESSION_ID).metadata.account_profile).toBeUndefined();
@@ -371,7 +449,7 @@ describe('spawn (FR-1)', () => {
     const nowMs = 1_800_000_000_000;
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     let lookups = 0;
     const supabaseClient = {
       from(table) {
@@ -405,7 +483,7 @@ describe('spawn (FR-1)', () => {
   it('QF-20260724-739: gives up cleanly (session_id stays null, no throw) when the SessionStart row never lands within the bounded retry budget', async () => {
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({ sessions: [] }); // never self-registers
     const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
 
@@ -495,7 +573,7 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
   it('worker path: releases the old session only once the replacement genuinely spawned live', async () => {
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
@@ -534,7 +612,7 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
     logCoordinationEvent.mockClear();
     const child = { pid: 5151 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
@@ -559,7 +637,7 @@ describe('relaunchUnderProfile (FR-7)', () => {
   it('isolates the account switch to the target session; sibling untouched (worker path, live spawn)', async () => {
     const child = { pid: 4343 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [
         { session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } },
@@ -601,7 +679,7 @@ describe('relaunchUnderProfile (FR-7)', () => {
     logCoordinationEvent.mockClear();
     const child = { pid: 6161 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
@@ -674,7 +752,7 @@ describe('drainAndRestart (FR-6: never restarts mid-claim)', () => {
     });
     const child = { pid: 5252 };
     const spawnFn = vi.fn().mockReturnValue(child);
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    const execFn = enumExec();
     const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: true, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.deferred).toBe(false);
     expect(result.verdict).toBe('PASS');

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -32,6 +32,14 @@ const { logCoordinationEvent } = await import('../../../lib/coordinator/coordina
 const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
 const { spawn: childProcessSpawnSpy } = await import('node:child_process');
 
+/**
+ * FR-3: the spawner MINTS the session id and passes it as `claude --session-id <uuid>`, so the child
+ * registers under this exact value and correlation is a direct lookup. Injected via opts.uuidFn to keep
+ * tests deterministic. Must be a syntactically valid UUID — buildSessionLaunch DROPS a malformed one
+ * rather than passing it to the CLI (which would reject it and fail the whole launch).
+ */
+const MINTED_SESSION_ID = '11111111-2222-4333-8444-555555555555';
+
 /** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
 function makeFakeSupabase({ sessions = [] } = {}) {
   const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
@@ -214,15 +222,17 @@ describe('spawn (FR-1)', () => {
     const child = { pid: 4242 };
     const spawnFn = vi.fn().mockReturnValue(child);
     const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
+    // FR-3: the child now registers under the SPAWNER-MINTED --session-id, so the row is keyed on
+    // that id rather than on the wt.exe launcher pid (which never matched claude_sessions.pid).
     const supabaseClient = makeFakeSupabase({
       sessions: [{
-        session_id: 's1', pid: 4242, status: 'active',
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
         created_at: new Date(nowMs - 5_000).toISOString(), // freshly self-registered, well within the match window
         metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
       }],
     });
-    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true });
-    const merged = supabaseClient._store.get('s1').metadata;
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
+    const merged = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
     // Pre-existing keys survive the write (would be wiped by a bare full-blob overwrite).
     expect(merged.fleet_identity).toEqual({ callsign: 'Alpha-5' });
     expect(merged.role).toBe('worker');
@@ -242,7 +252,11 @@ describe('spawn (FR-1)', () => {
         metadata: { fleet_identity: { callsign: 'Unrelated-Session' }, role: 'worker' },
       }],
     });
-    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true });
+    // FR-3: a valid minted id makes the bind a direct session_id lookup that never consults pid, which
+    // would make this test pass VACUOUSLY. uuidFn returns a non-UUID so buildSessionLaunch drops it
+    // (the CLI would reject a malformed --session-id) and spawn falls back to the pid path — which is
+    // exactly the path whose freshness window this test exists to guard. Keeps its teeth.
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => 'not-a-uuid' });
     // Untouched -- the stale row's metadata must never be corrupted by a fresh spawn's recycled pid.
     expect(supabaseClient._store.get('s-old').metadata).toEqual({ fleet_identity: { callsign: 'Unrelated-Session' }, role: 'worker' });
   });
@@ -278,18 +292,79 @@ describe('spawn (FR-1)', () => {
     const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
     const supabaseClient = makeFakeSupabase({
       sessions: [{
-        session_id: 's1', pid: 4242, status: 'active',
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
         created_at: new Date(nowMs - 5_000).toISOString(),
         metadata: { fleet_identity: { callsign: 'Beta-1' }, role: 'worker' },
       }],
     });
     logCoordinationEvent.mockClear();
-    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true });
+    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
 
-    expect(result.session_id).toBe('s1');
+    expect(result.session_id).toBe(MINTED_SESSION_ID);
     const spawnEventCall = logCoordinationEvent.mock.calls.find((c) => c[1].event_type === 'fleet_verb_spawn');
     expect(spawnEventCall).toBeTruthy();
-    expect(spawnEventCall[1].session_id).toBe('s1'); // was hardcoded null before this fix
+    expect(spawnEventCall[1].session_id).toBe(MINTED_SESSION_ID); // was hardcoded null before QF-20260724-739
+  });
+
+  it('FR-3: binds by the MINTED session id, not by the wt.exe launcher pid', async () => {
+    // The regression this pins: reverting to a pid join re-breaks correlation silently. The row here
+    // carries a DIFFERENT pid than the launcher reports, which is the real-world case -- wt.exe exits
+    // and claude_sessions.pid is the Claude Code pid. A pid-based bind finds nothing; the minted-id
+    // bind finds the row.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 999999, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(),
+        metadata: {},
+      }],
+    });
+    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, {
+      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+    });
+    expect(result.session_id).toBe(MINTED_SESSION_ID);
+  });
+
+  it('FR-1/FR-3: stamps metadata.account_profile on the FRESH-spawn path (the discoverability fix)', async () => {
+    // Before this, accountProfile was used only to resolve a profile DIRECTORY (spawn-control.js:162)
+    // and never written, while the sole writer (canary-guard.js:173) sat on the RESPAWN path and was
+    // itself pid-dead. Net effect: zero sessions carried the stamp and resolveCanaryTarget fail-closed
+    // even with canaries alive -- survival was sufficient, discoverability was not.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(),
+        metadata: { fleet_identity: { callsign: 'Canary-1' } },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Canary-1', accountProfile: 'canary' }, {
+      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+      baseDir: 'C:/fake', // resolveProfileDir(name, opts) honours opts.baseDir — no FLEET_* env needed
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md.account_profile).toBe('canary');
+    expect(md.fleet_identity).toEqual({ callsign: 'Canary-1' }); // merged, not replaced
+  });
+
+  it('FR-1/FR-3: does NOT stamp account_profile when none was requested', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), metadata: {},
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, {
+      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: vi.fn().mockResolvedValue({ stdout: '131074' }),
+      sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
+    });
+    expect(supabaseClient._store.get(MINTED_SESSION_ID).metadata.account_profile).toBeUndefined();
   });
 
   it('QF-20260724-739: retries the session-bind lookup (bounded) when the SessionStart row has not landed yet on the first attempt', async () => {

--- a/tests/unit/fleet/window-enum.test.js
+++ b/tests/unit/fleet/window-enum.test.js
@@ -1,0 +1,220 @@
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-4 — top-level window enumeration + set-difference selection.
+ *
+ * THE FIXTURE BELOW IS REAL CAPTURED STDOUT, not hand-written. Captured 2026-07-25 on the fleet host
+ * with ONE read-only enumeration (no spawn, no drill, nothing mutated), by running the exported
+ * WINDOW_ENUM_COMMAND verbatim:
+ *
+ *   node -e "import('./lib/fleet/window-handle.js').then(async m => {
+ *     const {promisify} = await import('node:util'); const {execFile} = await import('node:child_process');
+ *     const c = m.buildWindowEnumCommand();
+ *     console.log((await promisify(execFile)(c.program, c.args)).stdout); })"
+ *
+ * WHAT THE REAL CAPTURE PROVED, and why each shaped the implementation:
+ *   - 11 of 17 visible windows had an EMPTY title. Titles are not reliably present.
+ *   - TWO DIFFERENT processes (SystemSettings and ApplicationFrameHost) both presented a window
+ *     titled exactly "Settings". Titles are not unique either. Between those two facts, matching on
+ *     title is unsound -- which is why selection is a SET DIFFERENCE on handles. The SD's own field
+ *     note agrees: both observed session windows were titled simply "Claude Code".
+ *   - A process name contains a SPACE ("Wispr Flow"), so parsing must never tokenize on whitespace.
+ *   - ZERO WindowsTerminal windows existed at capture time: the fleet on this host is running under
+ *     Cursor. That is consistent with the SD's premise that LEO has spawned none of the sessions it
+ *     displays. It also means the WindowsTerminal rows in the SYNTHETIC fixtures further down are
+ *     labelled as such -- they are constructed, and only the shape is borrowed from the real capture.
+ *
+ * ENV-INDEPENDENCE: every test here is pure or uses an injected execFn. Nothing shells to PowerShell,
+ * so these are identical on the Windows fleet host and on ubuntu CI.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WINDOW_ENUM_COMMAND,
+  TERMINAL_PROCESS_NAME,
+  buildWindowEnumCommand,
+  parseWindowListOutput,
+  selectNewWindowHandle,
+  enumerateWindows,
+} from '../../../lib/fleet/window-handle.js';
+
+/** VERBATIM real stdout — 17 lines, unedited. */
+const REAL_CAPTURE = [
+  '18418318|61288|explorer|',
+  '264098|57304|Wispr Flow|Status',
+  '198798|20604|Cursor|EHG_Engineer - Cursor',
+  '197144|61288|explorer|',
+  '10230602|61288|explorer|',
+  '10361732|23728|TextInputHost|Windows Input Experience',
+  '18418244|61288|explorer|',
+  '1508424|61288|explorer|',
+  '10355186|61288|explorer|',
+  '262624|61288|explorer|',
+  '197084|61288|explorer|',
+  '197070|61288|explorer|',
+  '197068|61288|explorer|',
+  '198868|41504|Superhuman.WebUI|',
+  '788846|15964|SystemSettings|Settings',
+  '1050702|27040|ApplicationFrameHost|Settings',
+  '331588|61288|explorer|Program Manager',
+].join('\r\n');
+
+/** SYNTHETIC (no WindowsTerminal window existed at capture time) — shape copied from the real rows. */
+const wt = (handle, title = 'Claude Code') => ({ handle, pid: 5555, proc: 'WindowsTerminal', title });
+
+describe('FR-4 buildWindowEnumCommand — constant, zero injection surface', () => {
+  it('interpolates NOTHING and takes no argument', () => {
+    // Contrast buildHandleCaptureCommand, which must coerce a pid. This one has no inputs at all,
+    // so there is no injection surface to reason about.
+    expect(buildWindowEnumCommand.length).toBe(0);
+    expect(buildWindowEnumCommand().args[3]).toBe(WINDOW_ENUM_COMMAND);
+    expect(buildWindowEnumCommand().args[3]).toBe(buildWindowEnumCommand().args[3]);
+    expect(WINDOW_ENUM_COMMAND).not.toMatch(/\$\{/); // no template interpolation survived into the constant
+  });
+
+  it('runs non-interactively without loading a profile', () => {
+    const { program, args } = buildWindowEnumCommand();
+    expect(program).toBe('powershell');
+    expect(args).toContain('-NoProfile');
+    expect(args).toContain('-NonInteractive');
+  });
+
+  it('enumerates TOP-LEVEL windows rather than reading a per-process MainWindowHandle', () => {
+    // The distinction is the whole point: MainWindowHandle is per-PROCESS, and many terminal windows
+    // share one host process, so it can never name a particular session's window.
+    expect(WINDOW_ENUM_COMMAND).toMatch(/EnumWindows/);
+    expect(WINDOW_ENUM_COMMAND).not.toMatch(/MainWindowHandle/);
+  });
+});
+
+describe('FR-4 parseWindowListOutput — against REAL captured stdout', () => {
+  it('parses every row of the real capture', () => {
+    expect(parseWindowListOutput(REAL_CAPTURE)).toHaveLength(17);
+  });
+
+  it('keeps rows with an EMPTY title (11 of 17 in the real capture)', () => {
+    const rows = parseWindowListOutput(REAL_CAPTURE);
+    expect(rows.filter((r) => r.title === '')).toHaveLength(11);
+  });
+
+  it('handles a process name containing a space', () => {
+    const rows = parseWindowListOutput(REAL_CAPTURE);
+    expect(rows.find((r) => r.handle === 264098)).toEqual({
+      handle: 264098, pid: 57304, proc: 'Wispr Flow', title: 'Status',
+    });
+  });
+
+  it('shows why title matching is unsound: one title, two different processes', () => {
+    const settings = parseWindowListOutput(REAL_CAPTURE).filter((r) => r.title === 'Settings');
+    expect(settings).toHaveLength(2);
+    expect(new Set(settings.map((r) => r.proc)).size).toBe(2);
+  });
+
+  it('keeps a "|" that belongs to the TITLE instead of truncating or dropping the row', () => {
+    const rows = parseWindowListOutput('123|44|WindowsTerminal|Claude Code | EHG_Engineer');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('Claude Code | EHG_Engineer');
+  });
+
+  it('DROPS a row with a non-numeric or zero handle rather than emitting NaN', () => {
+    // A NaN handle would poison the set difference downstream and could never be matched or excluded.
+    const rows = parseWindowListOutput(['abc|1|explorer|x', '0|1|explorer|y', '5|1|explorer|z'].join('\n'));
+    expect(rows.map((r) => r.handle)).toEqual([5]);
+  });
+
+  it('tolerates junk, blank lines and CRLF without throwing', () => {
+    expect(parseWindowListOutput('\r\n\r\n')).toEqual([]);
+    expect(parseWindowListOutput(undefined)).toEqual([]);
+    expect(parseWindowListOutput('nonsense')).toEqual([]);
+  });
+});
+
+describe('FR-4 selectNewWindowHandle — set difference, FAILS CLOSED', () => {
+  it('returns the one window that appeared', () => {
+    const before = [wt(100), wt(200)];
+    const after = [wt(100), wt(200), wt(300)];
+    const r = selectNewWindowHandle(before, after);
+    expect(r.handle).toBe(300);
+    expect(r.reason).toBe('ok');
+  });
+
+  it('is AFTER MINUS BEFORE, not a symmetric difference — a window CLOSING is not an opening', () => {
+    // The regression this pins: a symmetric difference would surface the CLOSED window's handle and
+    // bind a session card to a window that no longer exists.
+    const before = [wt(100), wt(200)];
+    const after = [wt(100)]; // 200 closed between snapshots; nothing opened
+    const r = selectNewWindowHandle(before, after);
+    expect(r.handle).toBeNull();
+    expect(r.reason).toBe('no_new_window');
+  });
+
+  it('still resolves when a window closes AND another opens in the same interval', () => {
+    const before = [wt(100), wt(200)];
+    const after = [wt(100), wt(300)]; // 200 closed, 300 opened
+    expect(selectNewWindowHandle(before, after).handle).toBe(300);
+  });
+
+  it('fails CLOSED on zero new windows', () => {
+    expect(selectNewWindowHandle([wt(1)], [wt(1)])).toMatchObject({ handle: null, reason: 'no_new_window' });
+  });
+
+  it('fails CLOSED on two new windows rather than guessing', () => {
+    // Guessing would bind this session card to another session's window.
+    const r = selectNewWindowHandle([wt(1)], [wt(1), wt(2), wt(3)]);
+    expect(r.handle).toBeNull();
+    expect(r.reason).toBe('ambiguous');
+  });
+
+  it('treats string and number handles as the SAME window (PowerShell output is text)', () => {
+    // A mixed-type snapshot must not make an already-present window look new.
+    const r = selectNewWindowHandle(['100', 200], [100, '200']);
+    expect(r.reason).toBe('no_new_window');
+  });
+
+  it('filters to the terminal host so an unrelated app opening a window does not force ambiguous', () => {
+    const before = [wt(100)];
+    const after = [wt(100), wt(300), { handle: 999, pid: 7, proc: 'Cursor', title: 'EHG_Engineer - Cursor' }];
+    expect(selectNewWindowHandle(before, after).handle).toBe(300);
+  });
+
+  it('honours processName:null to disable filtering', () => {
+    const after = [{ handle: 999, pid: 7, proc: 'Cursor', title: 'x' }];
+    expect(selectNewWindowHandle([], after, { processName: null }).handle).toBe(999);
+  });
+
+  it('deduplicates a handle repeated within the after snapshot', () => {
+    expect(selectNewWindowHandle([], [wt(300), wt(300)]).handle).toBe(300);
+  });
+
+  it('returns diagnostics on FAILURE so one live run is a diagnosis, not a re-run', () => {
+    // This is the operational point of FR-4: a bare "capture failed" is unactionable. The counts
+    // distinguish "nothing opened" from "the filter excluded everything" from "too many opened".
+    const r = selectNewWindowHandle([wt(1)], [wt(1), wt(2), wt(3)]);
+    expect(r.diagnostics).toMatchObject({
+      beforeCount: 1, afterCount: 3, appearedCount: 2, reason: 'ambiguous', processFilter: TERMINAL_PROCESS_NAME,
+    });
+    expect(r.diagnostics.appeared).toEqual([2, 3]);
+  });
+
+  it('bounds the diagnostics payload rather than dumping every handle', () => {
+    const after = Array.from({ length: 50 }, (_, i) => wt(1000 + i));
+    expect(selectNewWindowHandle([], after).diagnostics.appeared).toHaveLength(8);
+  });
+
+  it('degrades to no_new_window on malformed/absent snapshots instead of throwing', () => {
+    expect(selectNewWindowHandle(undefined, undefined).reason).toBe('no_new_window');
+    expect(selectNewWindowHandle(null, [null, undefined]).reason).toBe('no_new_window');
+  });
+});
+
+describe('FR-4 enumerateWindows — fail-soft, never shells in unit tests', () => {
+  it('parses injected stdout without invoking PowerShell', async () => {
+    const execFn = vi.fn().mockResolvedValue({ stdout: REAL_CAPTURE });
+    const rows = await enumerateWindows({ execFn });
+    expect(rows).toHaveLength(17);
+    expect(execFn.mock.calls[0][0]).toBe('powershell');
+  });
+
+  it('returns [] rather than throwing when the shell fails', async () => {
+    // An empty snapshot degrades to no_new_window downstream -- fail-closed, never a wrong handle.
+    const rows = await enumerateWindows({ execFn: vi.fn().mockRejectedValue(new Error('powershell missing')) });
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/unit/fleet/window-enum.test.js
+++ b/tests/unit/fleet/window-enum.test.js
@@ -33,6 +33,9 @@ import {
   parseWindowListOutput,
   selectNewWindowHandle,
   enumerateWindows,
+  captureNewWindowHandle,
+  CAPTURE_POLL_MAX_ATTEMPTS,
+  CAPTURE_POLL_DELAY_MS,
 } from '../../../lib/fleet/window-handle.js';
 
 /** VERBATIM real stdout — 17 lines, unedited. */
@@ -216,5 +219,58 @@ describe('FR-4 enumerateWindows — fail-soft, never shells in unit tests', () =
     // An empty snapshot degrades to no_new_window downstream -- fail-closed, never a wrong handle.
     const rows = await enumerateWindows({ execFn: vi.fn().mockRejectedValue(new Error('powershell missing')) });
     expect(rows).toEqual([]);
+  });
+});
+
+describe('FR-7 captureNewWindowHandle — bounded budget, asserted by call count not wall-clock', () => {
+  it('spends AT MOST the exported attempt budget when no window ever appears', async () => {
+    // Asserted against the exported constant and the injected execFn CALL COUNT, never a clock. A
+    // timing assertion would be flaky on a loaded runner and -- the real problem -- would still pass
+    // while the poll was futile: the retired pid-based capture burned its whole budget on every spawn
+    // and no wall-clock test would ever have called that a bug.
+    const execFn = vi.fn().mockResolvedValue({ stdout: '' });
+    const sleepFn = vi.fn();
+    const r = await captureNewWindowHandle([], { execFn, sleepFn });
+    expect(execFn).toHaveBeenCalledTimes(CAPTURE_POLL_MAX_ATTEMPTS);
+    expect(sleepFn).toHaveBeenCalledTimes(CAPTURE_POLL_MAX_ATTEMPTS - 1); // no sleep after the last try
+    expect(sleepFn.mock.calls.every((c) => c[0] === CAPTURE_POLL_DELAY_MS)).toBe(true);
+    expect(r).toMatchObject({ handle: null, handleCaptureFailed: true, attempts: CAPTURE_POLL_MAX_ATTEMPTS });
+  });
+
+  it('stops as soon as the window appears rather than draining the budget', async () => {
+    let call = 0;
+    const execFn = vi.fn(async () => {
+      call += 1;
+      return { stdout: call < 3 ? '' : '4242|5555|WindowsTerminal|Claude Code' };
+    });
+    const sleepFn = vi.fn();
+    const r = await captureNewWindowHandle([], { execFn, sleepFn });
+    expect(r).toMatchObject({ handle: 4242, handleCaptureFailed: false, attempts: 3 });
+    expect(execFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT poll on ambiguous — waiting cannot un-appear a window (the futile-poll lesson)', async () => {
+    // This is FR-7's actual principle: only retry a race you can win. Two windows already appeared,
+    // so spending the remaining 9 attempts would reproduce exactly the futile budget being retired.
+    const execFn = vi.fn().mockResolvedValue({
+      stdout: ['1|5|WindowsTerminal|Claude Code', '2|5|WindowsTerminal|Claude Code'].join('\n'),
+    });
+    const sleepFn = vi.fn();
+    const r = await captureNewWindowHandle([], { execFn, sleepFn });
+    expect(execFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+    expect(r).toMatchObject({ handle: null, handleCaptureFailed: true });
+    expect(r.diagnostics.reason).toBe('ambiguous');
+  });
+
+  it('QF-20260724-113 invariant, carried forward: NEVER throws when the shell rejects', async () => {
+    // Re-asserted here because FR-7 deleted the tests that used to hold it. A throw out of capture
+    // aborted spawn()'s DB bookkeeping AFTER the real OS spawn -- real processes with zero evidence
+    // and orphaned unstamped sessions. The new path preserves it structurally (enumerateWindows
+    // swallows and returns [], selectNewWindowHandle is pure and total), and this proves it.
+    const execFn = vi.fn().mockRejectedValue(new Error('powershell is not recognized'));
+    await expect(captureNewWindowHandle([], { execFn, sleepFn: vi.fn() })).resolves.toMatchObject({
+      handle: null, handleCaptureFailed: true,
+    });
   });
 });

--- a/tests/unit/fleet/window-handle.test.js
+++ b/tests/unit/fleet/window-handle.test.js
@@ -1,108 +1,19 @@
 /**
- * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 FR-1/FR-3, TR-5 (SECURITY: numeric-PID-only interpolation).
+ * window-handle.js — focus surface.
+ *
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-7: the assertValidPid / buildHandleCaptureCommand /
+ * parseHandleOutput / captureWindowHandle describes that used to live here were REMOVED along with the
+ * functions themselves. That family implemented `(Get-Process -Id <pid>).MainWindowHandle` against the
+ * wt.exe LAUNCHER pid -- a process already exited by the time it was queried -- so its 10x500ms loop
+ * burned ~5s on every spawn and could never succeed. After FR-4 it had zero production callers.
+ *
+ * NO PROTECTION WAS RETIRED WITH THEM. The load-bearing assertion in that set was QF-20260724-113's
+ * "capture must never throw out of spawn()" (a throw there aborted DB bookkeeping AFTER the real OS
+ * spawn, leaving orphaned unstamped sessions). That invariant is now asserted directly against the
+ * replacement, captureNewWindowHandle, in window-enum.test.js.
  */
 import { describe, it, expect, vi } from 'vitest';
-import {
-  assertValidPid,
-  buildHandleCaptureCommand,
-  parseHandleOutput,
-  captureWindowHandle,
-  buildFocusCommand,
-  focusWindow,
-} from '../../../lib/fleet/window-handle.js';
-
-describe('assertValidPid (TR-5 SECURITY guardrail)', () => {
-  it('accepts a positive integer', () => {
-    expect(assertValidPid(1234)).toBe(1234);
-    expect(assertValidPid('5678')).toBe(5678);
-  });
-
-  it('rejects non-numeric, negative, zero, and NaN values', () => {
-    expect(() => assertValidPid('123; shutdown /s')).toThrow(/not a valid PID/);
-    expect(() => assertValidPid(-1)).toThrow(/not a valid PID/);
-    expect(() => assertValidPid(0)).toThrow(/not a valid PID/);
-    expect(() => assertValidPid('abc')).toThrow(/not a valid PID/);
-    expect(() => assertValidPid(null)).toThrow(/not a valid PID/);
-  });
-});
-
-describe('buildHandleCaptureCommand', () => {
-  it('interpolates ONLY the coerced numeric PID into the command string', () => {
-    const cmd = buildHandleCaptureCommand('4242');
-    expect(cmd.program).toBe('powershell');
-    expect(cmd.args.join(' ')).toContain('Get-Process -Id 4242');
-    expect(cmd.args.join(' ')).not.toContain(';');
-  });
-
-  it('throws before building any command for an invalid PID', () => {
-    expect(() => buildHandleCaptureCommand('4242; malicious')).toThrow(/not a valid PID/);
-  });
-});
-
-describe('parseHandleOutput', () => {
-  it('parses a non-zero handle', () => {
-    expect(parseHandleOutput('  131074\n')).toBe(131074);
-  });
-
-  it('returns null for zero (window not yet created)', () => {
-    expect(parseHandleOutput('0')).toBeNull();
-  });
-
-  it('returns null for empty/garbage output', () => {
-    expect(parseHandleOutput('')).toBeNull();
-    expect(parseHandleOutput('garbage')).toBeNull();
-  });
-});
-
-describe('captureWindowHandle (bounded retry)', () => {
-  it('returns the handle on the first successful attempt', async () => {
-    const execFn = vi.fn().mockResolvedValue({ stdout: '131074' });
-    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn() });
-    expect(result).toEqual({ handle: 131074, handleCaptureFailed: false, attempts: 1 });
-    expect(execFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('retries while the window has not been created yet, then succeeds', async () => {
-    const execFn = vi.fn()
-      .mockResolvedValueOnce({ stdout: '0' })
-      .mockResolvedValueOnce({ stdout: '0' })
-      .mockResolvedValueOnce({ stdout: '99887766' });
-    const sleepFn = vi.fn().mockResolvedValue();
-    const result = await captureWindowHandle(4242, { execFn, sleepFn, maxAttempts: 5, delayMs: 10 });
-    expect(result).toEqual({ handle: 99887766, handleCaptureFailed: false, attempts: 3 });
-    expect(sleepFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('marks handleCaptureFailed=true after exhausting maxAttempts (never silently null)', async () => {
-    const execFn = vi.fn().mockResolvedValue({ stdout: '0' });
-    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn(), maxAttempts: 3, delayMs: 1 });
-    expect(result).toEqual({ handle: null, handleCaptureFailed: true, attempts: 3 });
-    expect(execFn).toHaveBeenCalledTimes(3);
-  });
-
-  // QF-20260724-113: MainWindowHandle.ToInt64() throws in PowerShell when the property is
-  // genuinely $null (process spawned but hasn't rendered a window yet) -- execFn rejects. This
-  // previously escaped captureWindowHandle uncaught, aborting spawn-control's spawn()/restart()/
-  // relaunchUnderProfile() AFTER the real OS spawn but BEFORE DB bookkeeping (release old session +
-  // emit fleet_verb event). Caught live during the CP3 canary drills (correlation_id=
-  // cp3-do-it-right-20260724).
-  it('NEVER throws when execFn rejects (PowerShell errors on a genuinely-null MainWindowHandle) -- retries instead (QF-20260724-113)', async () => {
-    const execFn = vi.fn()
-      .mockRejectedValueOnce(new Error('You cannot call a method on a null-valued expression.'))
-      .mockRejectedValueOnce(new Error('You cannot call a method on a null-valued expression.'))
-      .mockResolvedValueOnce({ stdout: '55443322' });
-    const sleepFn = vi.fn().mockResolvedValue();
-    const result = await captureWindowHandle(4242, { execFn, sleepFn, maxAttempts: 5, delayMs: 10 });
-    expect(result).toEqual({ handle: 55443322, handleCaptureFailed: false, attempts: 3 });
-    expect(sleepFn).toHaveBeenCalledTimes(2);
-  });
-
-  it('marks handleCaptureFailed=true (not a throw) when execFn rejects on every attempt (QF-20260724-113)', async () => {
-    const execFn = vi.fn().mockRejectedValue(new Error('You cannot call a method on a null-valued expression.'));
-    const result = await captureWindowHandle(4242, { execFn, sleepFn: vi.fn(), maxAttempts: 3, delayMs: 1 });
-    expect(result).toEqual({ handle: null, handleCaptureFailed: true, attempts: 3 });
-  });
-});
+import { buildFocusCommand, focusWindow } from '../../../lib/fleet/window-handle.js';
 
 describe('buildFocusCommand', () => {
   it('interpolates a coerced numeric handle', () => {

--- a/tests/unit/worker-checkin-canary-identity-skip.test.js
+++ b/tests/unit/worker-checkin-canary-identity-skip.test.js
@@ -1,0 +1,121 @@
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-6 — canary skip in assignFleetIdentityAtCheckin.
+ *
+ * THE GAP: QF-20260724-521 added a canary skip to assign-fleet-identities.cjs:401 (the cron writer)
+ * but NOT to assignFleetIdentityAtCheckin, which applies the IDENTICAL callsignInTierBand gate. Canary
+ * sessions live outside the NATO tier-band scheme entirely -- canary-guard is fail-closed and REQUIRES
+ * a callsign starting with 'Canary-' -- so 'Canary-1' is in no NATO band, falls through to re-derive,
+ * and the canary gets silently renamed mid-drill. Closing one writer just moves the clobber to the
+ * other, which is exactly what happened.
+ *
+ * WHY THIS FILE AND NOT worker-checkin-fleet-identity.test.js: that file is QUARANTINED
+ * (tests/quarantine-manifest.json:1327) and excluded from --project unit, so an assertion added there
+ * would not run in CI. This is a new, non-quarantined file alongside the two that do provide real CI
+ * protection for this function (worker-checkin-callsign-collision-fix, worker-checkin-metadata-race).
+ *
+ * ENV-INDEPENDENCE: assignFleetIdentityAtCheckin is called with an injected fake client and an explicit
+ * sessionId, so nothing here reads .env, builds a client, or depends on CLAUDE_SESSION_ID.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require_ = createRequire(import.meta.url);
+const { assignFleetIdentityAtCheckin } = require_('../../scripts/worker-checkin.cjs');
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fake covering only the shapes this function touches. RECORDS every update so a silent rename is
+ * detectable -- asserting the return value alone would miss a write that clobbers the stored identity.
+ */
+function fakeClient(metadata, { live = [] } = {}) {
+  const updates = [];
+  return {
+    updates,
+    from() {
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        neq: () => builder,
+        gte: async () => ({ data: live }),
+        maybeSingle: async () => ({ data: { metadata }, error: null }),
+        update: (patch) => { updates.push(patch); return { eq: async () => ({ error: null }) }; },
+        then: (resolve) => Promise.resolve({ data: live, error: null }).then(resolve),
+      };
+      return builder;
+    },
+  };
+}
+
+const CANARY_ID = 'sess-canary-1';
+
+describe('FR-6 canary identity skip — the second clobber writer', () => {
+  it('keeps a Canary- callsign instead of re-deriving a NATO one', async () => {
+    // 'Canary-1' is in no NATO tier band, so without the skip this falls through to re-derive.
+    const client = fakeClient({
+      fleet_identity: { callsign: 'Canary-1', color: 'yellow' },
+      tier_rank: 1,
+    });
+    const r = await assignFleetIdentityAtCheckin(client, CANARY_ID, null);
+    expect(r).toEqual({ callsign: 'Canary-1', color: 'yellow' });
+    expect(client.updates).toHaveLength(0); // never rewrote the identity
+  });
+
+  it('skips on the account_profile stamp even when the callsign is NOT canary-prefixed', async () => {
+    // The OR is deliberate. Once FR-1/FR-3 land, account_profile is the authoritative marker; a canary
+    // that has already been renamed by an earlier clobber must still be recognised and left alone.
+    const client = fakeClient({
+      account_profile: 'canary',
+      fleet_identity: { callsign: 'Bravo', color: 'blue' },
+      tier_rank: 1,
+    });
+    const r = await assignFleetIdentityAtCheckin(client, CANARY_ID, null);
+    expect(r).toEqual({ callsign: 'Bravo', color: 'blue' });
+    expect(client.updates).toHaveLength(0);
+  });
+
+  it('is NOT inert before the account_profile stamp is wired — the callsign prefix alone suffices', async () => {
+    // FR-6 is sequenced after FR-1, so it would be easy to write a guard that only reads
+    // account_profile and therefore does nothing until FR-1 merges. This pins that it works today.
+    const client = fakeClient({ fleet_identity: { callsign: 'Canary-7', color: 'red' }, tier_rank: 3 });
+    const r = await assignFleetIdentityAtCheckin(client, CANARY_ID, null);
+    expect(r.callsign).toBe('Canary-7');
+    expect(client.updates).toHaveLength(0);
+  });
+
+  it('ORDERING PIN: the canary check runs BEFORE the tier-band idempotency check', async () => {
+    // Load-bearing. The tier-band check returns early only for an IN-BAND callsign; 'Canary-1' is in
+    // no band, so if the canary guard were placed after it, every canary would reach the re-derive
+    // path and the guard would never fire. A guard in the wrong position looks present and does
+    // nothing -- indistinguishable from correct unless the ordering itself is asserted.
+    const source = fs.readFileSync(path.join(HERE, '../../scripts/worker-checkin.cjs'), 'utf8');
+    const fnStart = source.indexOf('async function assignFleetIdentityAtCheckin');
+    expect(fnStart).toBeGreaterThan(-1);
+    // CODE LINES ONLY. The first version of this assertion scanned raw text and matched
+    // "callsignInTierBand" inside the explanatory COMMENT above the guard, reporting the guard as
+    // mis-ordered when it was correct. Comments describe the code they sit next to, so any
+    // position assertion over raw source will eventually match prose instead of behaviour.
+    const codeLines = source
+      .slice(fnStart, fnStart + 4000)
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/*'));
+    const canaryLine = codeLines.findIndex((l) => l.includes("startsWith('Canary-')"));
+    const tierBandLine = codeLines.findIndex((l) => l.includes('callsignInTierBand('));
+    expect(canaryLine, 'canary guard not found in code').toBeGreaterThan(-1);
+    expect(tierBandLine, 'tier-band check not found in code').toBeGreaterThan(-1);
+    expect(canaryLine).toBeLessThan(tierBandLine);
+  });
+
+  it('does NOT skip an ordinary worker (the guard must stay narrow)', async () => {
+    // Negative control: an over-broad guard would freeze every worker's identity and silently disable
+    // the tier-band self-heal this function exists to perform.
+    const client = fakeClient({ fleet_identity: { callsign: 'Delta', color: 'red' }, tier_rank: 1 });
+    const r = await assignFleetIdentityAtCheckin(client, 'sess-worker-1', null);
+    // Either it returned the in-band identity, or it re-derived -- but it must NOT be short-circuited
+    // by the canary branch, which would return 'Delta' without consulting the tier band at all.
+    expect(r === null || typeof r.callsign === 'string').toBe(true);
+    expect(r?.callsign).not.toBe('Canary-1');
+  });
+});


### PR DESCRIPTION
> **Stacked on #6474** (FR-2 + FR-1). Base is `feat/SD-LEO-INFRA-LAUNCHER-CAN-HOST-001` — merge #6474 first. Five commits, each independently reviewable. **Rebased onto current main** (was 21 commits behind).

Completes the SD: every one of FR-1…FR-7 is now built.

---

## FR-3 — remove the correlation problem rather than solve it

Every prior approach tried to *recognise* the spawned child afterwards. All dead:

- **`.eq('pid', pid)`** matches the **wt.exe launcher** pid against `claude_sessions.pid`, which holds the **Claude Code** pid. `wt.exe` hands the tab to the running host and exits, so the pid is gone before the child registers. The freshness window and 3-attempt retry were compensating for a join with no rows to find.
- **An env carrier** (the SD's design and my own PRD v1's) cannot reach the hook — only six `CLAUDE_`-prefixed vars propagate (`lib/hooks/session-id.cjs:36-42`). That is why `FLEET_AUTORESUME_SD` has zero readers repo-wide.

`claude --session-id <uuid>` (CLI 2.1.220, no `--print` restriction) lets the **spawner choose the id**; the child registers under it, so `claude_sessions.session_id` **is** a value we already hold. A malformed id is dropped rather than passed — the CLI would reject it and fail the launch.

**Discoverability**: `metadata.account_profile` is now stamped on the **fresh-spawn** path. Previously it only resolved a profile *directory* and was never written, while the sole writer sat on the respawn path behind the dead pid join. Hence zero sessions carrying the stamp while canaries lived 47 and 43 minutes — survival was sufficient, discoverability was not.

## FR-4 — capture by set difference

`MainWindowHandle` had **two independent breaks**: it queried an already-exited launcher process, *and* it is per-**process** while many terminal windows share one host. Replaced with `after MINUS before` over a top-level enumeration — never symmetric, since a window *closing* between snapshots is normal and must not read as an opening.

**One read-only enumeration corrected the design.** 17 visible windows: 11 had an **empty title**; **two different processes** both titled exactly `Settings`; one process name contained a space (`Wispr Flow`); and **zero WindowsTerminal windows** existed — the fleet here runs under **Cursor**, which is the SD's premise observed directly. The first two facts make title-matching unsound.

The command is a **constant** (no interpolation, no injection surface) and was validated **end to end through node → PowerShell**, not just behind an injected `execFn` — a broken constant passes every unit test and is dead in production.

**Call order is load-bearing.** The before-snapshot must precede `spawnProcess()`; ordered the other way the diff is always empty in production while every pure test still passes. Pinned by an explicit `['enumerate','spawn','capture']` assertion.

## FR-5 — `-w new` is what makes FR-4 able to fire

Bare `wt new-tab` adds a **tab to an existing window**, creating no new top-level window — so without this, FR-4's diff sees nothing appear and every capture returns `no_new_window`. A correct enumerator that could never fire. The two only work as a pair.

`-w` is a **global** option: `wt new-tab -w new` parses it as new-tab's argument and you silently still get a tab. Presence *and* position are enforced as **distinct** violations. All four spawn paths passed the new contract rule immediately — positive evidence they genuinely route through the canonical builder.

## FR-7 — delete the futile ~5s poll

After FR-4 the pid-capture family (`captureWindowHandle` + the three helpers only it reached) had **zero production callers**. It burned ~5s per spawn on a lookup that could never succeed. Deleted rather than left beside the working path.

**No protection was retired with it.** QF-20260724-113's "capture must never throw out of `spawn()`" is preserved structurally and **re-asserted directly against the replacement**. The budget is now exported and asserted by **call count, never wall-clock** — a timing assertion would have passed happily against the futile poll it is meant to catch.

## FR-6 — the second identity-clobber writer

QF-20260724-521 added the canary skip to the cron writer but **not** to `assignFleetIdentityAtCheckin`, which runs the identical tier-band gate. `Canary-1` is in no NATO band, so it fell through and the canary was renamed mid-drill — closing one writer just moved the clobber. The guard keys on the `Canary-` prefix **as well as** `account_profile`, so it is **not inert** while FR-1/FR-3 are unmerged.

---

## Mutation results — 11 total, each confirmed applied before the result was trusted

| Mutation | Result |
|---|---|
| revert bind to the pid join | 1 failed ✓ |
| drop the `account_profile` stamp | 1 failed ✓ |
| `isUuid` always true | 1 failed ✓ |
| after-minus-before → symmetric difference | 7 failed ✓ |
| `ambiguous` → fail open | 2 failed ✓ |
| before-snapshot moved after the spawn | 1 failed ✓ |
| drop `-w new` | 12 failed ✓ |
| move `-w` after `new-tab` | 12 failed ✓ |
| contract stops enforcing `-w new` | 1 failed ✓ |
| poll on `ambiguous` too | 1 failed ✓ |
| remove the canary guard | 4 failed ✓ |

Three needed care rather than acceptance:

- The **pid-join** mutation reds only **one** test — correct, not weak coverage. Every legacy fixture has `pid` matching by construction; only the new FR-3 test has them differ.
- The **call-order** mutation's first attempt **did not apply** (anchor mismatch) and the suite stayed green. That green was discarded and the mutation redone line-wise. A mutation that never mutated is not evidence.
- My first **FR-6 ordering assertion was wrong** — it matched `callsignInTierBand` inside the explanatory comment above the guard, reporting a correctly-placed guard as mis-ordered. Now filtered to non-comment lines.

## Verification

- **1190 tests / 105 files green** on the **rebased** tree with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` **all unset**
- `git diff --exit-code origin/main -- scripts/fleet/start-cp3-drills.js` **passes** against current main
- Main touched `worker-checkin.cjs` too (model-registry work); its tests pass alongside FR-6 — no semantic collision
- **No drill exercised**, no `live:true` verb, no `cp3-drill-run` worktree. The enumeration was read-only.

## PENDING-LIVE

Not checkable on ubuntu CI, not self-sequenced: `--session-id` accepted by the real launch, the child registering under the minted id, the stamp landing end to end, the P/Invoke compiling on real Windows, real stdout matching the fixture, `wt -w new` yielding exactly one new window, the after-snapshot timing race, and `SetForegroundWindow` focusability.

**There are currently zero WindowsTerminal windows on the fleet host**, so no window leg can be exercised until a terminal-hosted session exists.

## Not in this PR

`canary-guard.js:167` `stampRespawnedCanary` and `reconcileSpawnedSession` still correlate on pid — both on the **respawn** path, not the fresh-spawn path the discoverability criterion needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)