### PR TITLE
feat(SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001): make spawn-path freshness an invariant, not a habit with monitoring

### DIFF
--- a/docs/protocol/execution-source-tree-currency.md
+++ b/docs/protocol/execution-source-tree-currency.md
@@ -76,13 +76,24 @@ Stated explicitly, because an unstated boundary is how a partial fix gets report
 which is this document's own thesis.
 
 **Enforced today:**
-- The spawn seam (`lib/fleet/spawn-control.js`), which every live spawn path routes through.
+- The `spawn()` verb in `lib/fleet/spawn-control.js`.
 - The worktree reaper tick (`scripts/fleet/worktree-reaper-tick.cjs`).
+
+> **Correction (adversarial review, pre-merge).** An earlier draft of this section claimed
+> `spawn()` is the seam "which every live spawn path routes through." **That was false**, and
+> two independent reviewers caught it. `lib/fleet/reboot-respawn-runner.js` and
+> `scripts/fleet/worker-spawn-executor.cjs` both call `buildSessionLaunch` /
+> `buildLiveSpawnInvocation` **directly** and launch via their own spawner, never entering
+> `spawn()`. They are live OS-spawn paths and they are **not** guarded. Reboot-respawn is the
+> highest-value uncovered case — a post-reboot respawn runs from a root that has not pulled
+> since the machine went down. Recorded here rather than quietly dropped, because a document
+> whose thesis is *state the boundary* had reproduced the exact failure it names.
 
 **NOT enforced — each is a known gap, not an oversight:**
 
 | Gap | Why it is not covered |
 |---|---|
+| **`reboot-respawn-runner.js`** and **`worker-spawn-executor.cjs`** | They call the launch builder directly and spawn themselves, bypassing the `spawn()` verb where the guard lives. Highest-value remaining gap: a post-reboot respawn runs from a root that has not pulled since the machine went down. |
 | Spawns issued from **inside** a `.worktrees/` tree | A per-SD worktree is legitimately off-main and behind by construction — that is what a feature branch is. Guarding it would refuse every worktree spawn while proving nothing about this defect; both measured incidents were the shared root. |
 | ~25 coordinator `STANDARD_LOOPS` (`scripts/coordinator-startup-check.mjs`) | Their prompts run bare `node scripts/…` at whatever cwd the coordinator holds. Not routed through any seam this SD touches. |
 | `scripts/cron/eva-watcher-task.cmd` and generated Task Scheduler entries | The root path is hardcoded into a Windows scheduled task. A spawn-time assertion **structurally cannot reach it** — the process starts outside anything we gate. |

--- a/docs/protocol/execution-source-tree-currency.md
+++ b/docs/protocol/execution-source-tree-currency.md
@@ -1,0 +1,92 @@
+# Execution-source tree currency — what reads from a tree, not how far behind it is
+
+**Status:** Approved · **Version:** 1.0.0 · **Provenance:** SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001
+
+> Companion to [`singleton-stale-tree-remediation-policy.md`](./singleton-stale-tree-remediation-policy.md).
+> That policy governs a **singleton role-session** whose staleness means its own role contract
+> has drifted, and it prefers supervised relaunch over in-place sync. Nothing here changes that.
+> This document covers the case that policy does not: a tree from which **other processes load
+> and execute code**.
+
+## The discriminator
+
+**Classify a tree by WHAT READS FROM IT, not by how far behind it is.**
+
+| Tree kind | What reads from it | Staleness rule |
+|---|---|---|
+| **STANDBY** | Nothing executes from it. Its work is DB-driven and comms-hosted; the checkout is a vantage point, not a runtime. | **May drift.** Treat `origin/main` as code-truth, read it when you need to know what shipped, and do not fight the drift. Remediate by supervised relaunch, per the singleton policy — not by an in-place pull. |
+| **EXECUTION-SOURCE** | Something **loads code out of it or spawns from it**: a `node scripts/…` invocation, a spawned session's start directory, a script resolved by path at runtime. | **Must be current, or the operation refuses.** Its HEAD *is* the code identity of whatever runs. |
+
+A tree can be hundreds of commits behind and be perfectly fine, or three commits behind and
+actively dangerous. The commit count is not the signal. The question is whether anything
+*executes* from it.
+
+## Why this is an invariant and not a gauge
+
+> "NO CODE PATH THAT EXECUTES SHOULD DEPEND ON A HUMAN OR A LOOP REMEMBERING TO PULL. A gauge
+> that detects staleness plus a loop that remediates it is still a system whose answer to
+> *is-the-spawn-path-current* is *probably, if someone ticked recently*. That is a habit with
+> monitoring, not an invariant."
+
+A faster poll does not satisfy this. Any polling remedy leaves a window proportional to the
+merge rate, and **the merge rate is highest exactly when the window matters most** — a busy
+fleet is precisely when spawns happen. Measured 2026-07-25: 26 commits landed on `origin/main`
+in two hours, 111 in a day.
+
+Note also that a `post-merge` git hook **cannot** solve this here: `gh pr merge` merges
+*remotely* on GitHub, so no local merge occurs and the root's HEAD does not move at merge time
+at all. It moves only when something later pulls.
+
+## What went wrong when this was not enforced
+
+Both incidents on 2026-07-25 were **shipped, merged, ancestry-verified — and still inert**:
+
+1. **The canary fix (PR 6464).** Merged while the root was 6 commits behind. Canaries spawned in
+   that window still inherited the marker the PR removed, and died as ghosts.
+2. **The worktree-reaper opt-out marker.** Believed load-bearing on merge. The reaper *also*
+   executes from the root, which was behind and contained **zero occurrences** of the
+   marker-handling code — so the protection was physically absent from the file being run. The
+   reaper deleted a worktree that marker existed to protect.
+
+One root cause: **execution reads the root; verification reads `origin/main`.**
+**Verifying a fix at the merge is not verifying it at the consumer.**
+
+## The rule, applied
+
+- **Spawn** — assert currency of the resolved start directory before spawning. Fast-forward when
+  that is safe (clean **and** on `main`); otherwise **refuse**. Never mutate a dirty or
+  off-branch tree: the shared root is chronically dirty, and a pull there can clobber a peer
+  worktree's in-flight state.
+- **Reap** — assert currency, and **refuse without healing**. The reaper runs unattended against
+  a shared root, so a mutation there could collide with a peer; skipping a reap costs nothing
+  because the next tick retries. A deletion cannot be undone by a later error message, so
+  failing loud *after* the fact is not available — refusing beforehand is the only safe
+  direction. **Destructive subsystems refuse; they do not fix.**
+- **Fail closed, always.** Git missing, remote unreachable, timeout, detached HEAD, unparseable
+  output, not-a-repository — every one of them means NOT current. There is no branch that
+  returns "current" on uncertainty. A fail-*open* check reports success precisely when it could
+  not tell, which is the failure mode this whole document exists to remove.
+- **An escape hatch must cost something.** `FLEET_TREE_CURRENCY_BYPASS_REASON` is keyed on a
+  *reason*, not a boolean, so an operator cannot silence the invariant with `FLAG=1`. When it is
+  used the answer is **unknown-and-declared**, never "current".
+
+## Coverage boundary — what this does NOT cover
+
+Stated explicitly, because an unstated boundary is how a partial fix gets reported as complete,
+which is this document's own thesis.
+
+**Enforced today:**
+- The spawn seam (`lib/fleet/spawn-control.js`), which every live spawn path routes through.
+- The worktree reaper tick (`scripts/fleet/worktree-reaper-tick.cjs`).
+
+**NOT enforced — each is a known gap, not an oversight:**
+
+| Gap | Why it is not covered |
+|---|---|
+| Spawns issued from **inside** a `.worktrees/` tree | A per-SD worktree is legitimately off-main and behind by construction — that is what a feature branch is. Guarding it would refuse every worktree spawn while proving nothing about this defect; both measured incidents were the shared root. |
+| ~25 coordinator `STANDARD_LOOPS` (`scripts/coordinator-startup-check.mjs`) | Their prompts run bare `node scripts/…` at whatever cwd the coordinator holds. Not routed through any seam this SD touches. |
+| `scripts/cron/eva-watcher-task.cmd` and generated Task Scheduler entries | The root path is hardcoded into a Windows scheduled task. A spawn-time assertion **structurally cannot reach it** — the process starts outside anything we gate. |
+| The ~36 `CLAUDE_PROJECT_DIR`-resolved hooks | Exactly one redirects to the canonical root. The rest resolve to whatever tree started the session. |
+
+Each of these is recorded as a follow-on. None of them is closed by this change, and the
+invariant should not be described as fleet-wide until they are.

--- a/docs/protocol/singleton-stale-tree-remediation-policy.md
+++ b/docs/protocol/singleton-stale-tree-remediation-policy.md
@@ -20,6 +20,17 @@ behind `origin/main`.
 **This SD is measure/surface only.** No remediation automation is implemented here —
 that is deferred to a future SD, per the coordinator co-review's "measure first" guidance.
 
+> **Scope boundary (SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001).** This policy governs a
+> tree whose staleness means a *role contract* has drifted — the session READS the tree as
+> rules. It does **not** govern a tree that other processes **load and execute code out of**
+> (the spawn path's start directory, the worktree reaper's own script). Those are
+> EXECUTION-SOURCE trees, and for them staleness is not an advisory signal: the operation
+> must self-heal or refuse. See
+> [`execution-source-tree-currency.md`](./execution-source-tree-currency.md).
+> The discriminator is **what reads from the tree, not how far behind it is** — applying the
+> standby rule to a tree something executes from is how a merged fix stays inert while
+> everyone verifies it on `origin/main` and reports it shipped.
+
 ## Default: SUPERVISED RELAUNCH, not in-place sync
 
 The default remediation for a detected `STALE-CRITICAL` singleton session is

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -161,7 +161,11 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
 
   let profileDir = null;
   if (accountProfile) profileDir = resolveProfileDir(accountProfile, opts);
-  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt });
+  // `cwd` is forwarded so a caller can spawn into an explicit tree instead of always
+  // defaulting to the module root. buildSessionLaunch has always accepted it; spawn() just
+  // never passed it through. Undefined keeps the existing default-to-repo-root behaviour
+  // byte-for-byte, and it makes the FR-2 currency seam addressable by a test.
+  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt, cwd: opts.cwd });
 
   if (!live) {
     log(`[spawn-control] DRY-RUN would spawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
@@ -215,6 +219,11 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     for (const k of ['CLAUDE_CODE_CHILD_SESSION', 'CLAUDE_SESSION_ID', 'CLAUDE_CODE_SESSION_ID']) {
       delete inherited[k];
     }
+    // SEC-3 (adversarial security review): a currency bypass must NOT propagate. Without
+    // this, an operator who sets the reason once has silently disabled the invariant for
+    // every session this spawns AND for everything those sessions spawn in turn — the
+    // hatch escapes the operator who opened it. Scope it to the process that set it.
+    delete inherited.FLEET_TREE_CURRENCY_BYPASS_REASON;
     const child = spawnProcess(program, args, { detached: true, stdio: 'ignore', cwd: invocation.cwd, env: { ...inherited, ...env } });
     child.unref();
     return child;

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -208,7 +208,14 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   if (!spawnsFromWorktree) {
     const currency = enforceTreeCurrency({
       dir: invocation.cwd,
-      env: opts.env || process.env,
+      // RCA (post-CI): this deliberately does NOT read opts.env. Callers such as
+      // canaryRestart/relaunchUnderProfile pass a NARROW opts.env carrying one unrelated
+      // feature flag (e.g. {FLEET_CANARY_KILL_ENABLED:'true'}), and because that value
+      // REPLACES process.env wholesale rather than extending it, keying the currency check
+      // off it made FLEET_TREE_CURRENCY_BYPASS_REASON silently unreachable on every canary
+      // path — the documented escape hatch, dead, with no error. Currency gets its OWN
+      // channel, matching worktree-reaper-tick.cjs:263-264 (opts.currencyEnv).
+      env: opts.currencyEnv || process.env,
       logger: { warn: (m) => log(m) },
       label: `spawn source tree for ${role}/${callsign}`,
       ...(opts.currencyRunner ? { runner: opts.currencyRunner } : {}),

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -185,15 +185,25 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // Self-heal when a fast-forward is safe, REFUSE otherwise. Refusing is the point: the
   // alternative is silently spawning a session that runs code the fleet already replaced.
   // Deliberately placed AFTER the dry-run return, so a dry run never touches git.
-  const currency = enforceTreeCurrency({
-    dir: invocation.cwd,
-    env: opts.env || process.env,
-    logger: { warn: (m) => log(m) },
-    label: `spawn source tree for ${role}/${callsign}`,
-    ...(opts.currencyRunner ? { runner: opts.currencyRunner } : {}),
-  });
-  if (currency.healed) log(`[spawn-control] spawn source tree was behind and has been fast-forwarded before spawning ${callsign}`);
-  if (currency.currencyBypassed) invocation.currencyBypassed = true;
+  // SCOPE, stated explicitly because it is a real limit and not an accident: this asserts
+  // currency of the ROOT that spawns. A per-SD worktree under .worktrees/ is deliberately
+  // exempt — such a tree is legitimately off-main and behind by construction (that is what
+  // a feature branch IS), so asserting currency there would refuse every spawn from a
+  // worktree while proving nothing about the defect this SD fixes. The measured incidents
+  // (an inert canary fix, an inert reap-protected marker) were both the shared ROOT.
+  // Consequence to be honest about: a spawn issued from inside a worktree is NOT guarded.
+  const spawnsFromWorktree = String(invocation.cwd || '').replace(/\\/g, '/').includes('/.worktrees/');
+  if (!spawnsFromWorktree) {
+    const currency = enforceTreeCurrency({
+      dir: invocation.cwd,
+      env: opts.env || process.env,
+      logger: { warn: (m) => log(m) },
+      label: `spawn source tree for ${role}/${callsign}`,
+      ...(opts.currencyRunner ? { runner: opts.currencyRunner } : {}),
+    });
+    if (currency.healed) log(`[spawn-control] spawn source tree was behind and has been fast-forwarded before spawning ${callsign}`);
+    if (currency.currencyBypassed) invocation.currencyBypassed = true;
+  }
 
   const spawner = opts.spawnFn || ((program, args, env) => {
     // FR-2: carry the invocation's repo-root cwd (paired with new-tab -d) so the session registers in claude_sessions.

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -17,6 +17,7 @@
 import { spawn as spawnProcess } from 'node:child_process';
 import path from 'node:path';
 import { buildSessionLaunch } from './build-session-launch.cjs';
+import { enforceTreeCurrency } from './tree-currency.cjs';
 import {
   resolveLiveSession,
   loadLiveSessionIdentity,
@@ -167,6 +168,32 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     await emitVerbEvent(supabase, { verb: 'spawn', outcome: 'dry_run' });
     return { live: false, invocation };
   }
+
+  // SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-2 — THE INVARIANT.
+  //
+  // invocation.cwd is the tree this session will EXECUTE from, and nothing keeps it
+  // current: gh pr merge merges remotely, so the root's HEAD does not move at merge
+  // time at all. Every merge therefore re-stales the tree that spawns the next worker,
+  // and a fix stays inert until somebody happens to pull. Two subsystems were provably
+  // running already-replaced code because of exactly this.
+  //
+  // So this is asserted HERE, at the execution seam, and NOT inside buildSessionLaunch:
+  // that builder is synchronous, reboot-respawn-runner does not await it, and four
+  // existing tests call it with no cwd — a precondition in the builder would hand a
+  // Promise to production and run real git inside the unit tier.
+  //
+  // Self-heal when a fast-forward is safe, REFUSE otherwise. Refusing is the point: the
+  // alternative is silently spawning a session that runs code the fleet already replaced.
+  // Deliberately placed AFTER the dry-run return, so a dry run never touches git.
+  const currency = enforceTreeCurrency({
+    dir: invocation.cwd,
+    env: opts.env || process.env,
+    logger: { warn: (m) => log(m) },
+    label: `spawn source tree for ${role}/${callsign}`,
+    ...(opts.currencyRunner ? { runner: opts.currencyRunner } : {}),
+  });
+  if (currency.healed) log(`[spawn-control] spawn source tree was behind and has been fast-forwarded before spawning ${callsign}`);
+  if (currency.currencyBypassed) invocation.currencyBypassed = true;
 
   const spawner = opts.spawnFn || ((program, args, env) => {
     // FR-2: carry the invocation's repo-root cwd (paired with new-tab -d) so the session registers in claude_sessions.

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -104,7 +104,12 @@ function assessTreeCurrency({
   // treat a ref as an option regardless.
   if (!VALID_BASE_REF.test(String(baseRef || ''))) return notCurrent('invalid_base_ref');
 
-  const run = (args) => runner(args, { cwd: dir, timeoutMs });
+  // R5 (post-CI RCA): remember the argv actually in flight. When this refuses in
+  // production the operator gets only `reason=git_error`; identifying the real cause
+  // (a 15s `git fetch` timeout, vs. git absent, vs. not-a-repository) previously took
+  // wall-clock forensics on CI run durations. Carry the command and git's own message.
+  let lastArgs = null;
+  const run = (args) => { lastArgs = args; return runner(args, { cwd: dir, timeoutMs }); };
 
   try {
     // Refresh the remote ref first. A comparison against a stale origin/main would
@@ -149,7 +154,16 @@ function assessTreeCurrency({
     // git absent, remote unreachable, credentials expired, timeout (err.killed),
     // not-a-repository, permission denied. If we could not establish currency, we do
     // not have it.
-    return notCurrent('git_error', { error: err && err.message ? String(err.message) : 'unknown' });
+    // A timeout is distinguishable and worth naming: execFileSync sets .killed when it
+    // SIGTERMs on timeoutMs, and "the fetch took longer than the budget" is a completely
+    // different operator action from "git is not installed".
+    const timedOut = !!(err && (err.killed || err.signal === 'SIGTERM'));
+    return notCurrent('git_error', {
+      error: err && err.message ? String(err.message) : 'unknown',
+      gitArgs: lastArgs ? ['git', ...lastArgs].join(' ') : null,
+      timedOut,
+      timeoutMs: timedOut ? timeoutMs : undefined,
+    });
   }
 }
 
@@ -240,11 +254,19 @@ function enforceTreeCurrency({
     return { ok: true, healed: true, currencyBypassed: false, assessment: after };
   }
 
+  // R5: when the reason is git_error, `reason=git_error` alone is not actionable. Name the
+  // command that failed, whether it was a timeout, and git's own message.
+  const detail = assessment.reason === 'git_error'
+    ? ` [${assessment.timedOut ? `TIMED OUT after ${assessment.timeoutMs}ms` : 'failed'}`
+      + `${assessment.gitArgs ? `: ${assessment.gitArgs}` : ''}`
+      + `${assessment.error ? ` — ${assessment.error}` : ''}]`
+    : '';
+
   const why = assessment.reason === 'behind'
     ? `${assessment.behind} commit(s) behind ${baseRef} and NOT safely healable `
       + `(dirty=${assessment.dirty}, branch=${assessment.branch}) — refusing rather than mutating a `
       + `dirty or off-branch tree, which would risk clobbering a peer worktree`
-    : `currency could not be established (reason=${assessment.reason})`;
+    : `currency could not be established (reason=${assessment.reason})${detail}`;
 
   throw new TreeStaleError(
     `[tree-currency] REFUSED: ${label} at ${dir} — ${why}. `

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -46,6 +46,12 @@ const DEFAULT_TIMEOUT_MS = 15000;
 /** The only branch a tree may be SELF-HEALED on; anything else is refuse-only. */
 const SELF_HEALABLE_BRANCH = 'main';
 
+/**
+ * SEC-1: a ref must never be able to lead with a dash (git would read it as an option).
+ * Deliberately strict — this gates a value that reaches a subprocess argv.
+ */
+const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+
 function defaultRunner(args, { cwd, timeoutMs }) {
   return execFileSync('git', args, {
     cwd,
@@ -89,6 +95,14 @@ function assessTreeCurrency({
   fetch = true,
 } = {}) {
   if (!dir || typeof dir !== 'string') return notCurrent('no_dir');
+  // SEC-1 (adversarial security review): baseRef is split and handed to git as positional
+  // arguments. A value LEADING WITH A DASH is parsed by git as an OPTION, not a ref —
+  // reproduced during review: `--upload-pack=<program>/main` made git EXECUTE the named
+  // program. Not reachable today (baseRef defaults to origin/main and no caller overrides
+  // it), but it is a local command-execution primitive the moment anyone wires baseRef to
+  // env, DB config or a flag. Validate the shape, and use `--` below so git can never
+  // treat a ref as an option regardless.
+  if (!VALID_BASE_REF.test(String(baseRef || ''))) return notCurrent('invalid_base_ref');
 
   const run = (args) => runner(args, { cwd: dir, timeoutMs });
 
@@ -99,7 +113,7 @@ function assessTreeCurrency({
     if (fetch) {
       const [remote, ...rest] = String(baseRef).split('/');
       const branch = rest.join('/');
-      if (remote && branch) run(['fetch', '--quiet', remote, branch]);
+      if (remote && branch) run(['fetch', '--quiet', '--', remote, branch]);
       else run(['fetch', '--quiet']);
     }
 
@@ -205,7 +219,7 @@ function enforceTreeCurrency({
     try {
       const [remote, ...rest] = String(baseRef).split('/');
       const branch = rest.join('/');
-      runner(['pull', '--ff-only', '--quiet', remote, branch], { cwd: dir, timeoutMs });
+      runner(['pull', '--ff-only', '--quiet', '--', remote, branch], { cwd: dir, timeoutMs });
     } catch (err) {
       throw new TreeStaleError(
         `[tree-currency] REFUSED: ${label} at ${dir} is ${assessment.behind} commit(s) behind ${baseRef} `

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -1,0 +1,147 @@
+'use strict';
+/**
+ * FAIL-CLOSED working-tree currency assertion.
+ * SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-1.
+ *
+ * WHY THIS EXISTS. The spawn path and the worktree reaper both EXECUTE FROM the
+ * repository root, and nothing keeps the root current. Every merge re-stales the tree
+ * that spawns the next worker, so a merged fix is inert until somebody happens to pull.
+ * Measured 2026-07-25: 26 commits landed on origin/main in two hours, 111 in a day.
+ * Two subsystems were provably running code that had already been replaced — a canary
+ * fix (PR 6464) and the worktree-reaper opt-out marker, whose fix sits 50 commits back,
+ * so a root behind it executes a reaper containing ZERO occurrences of the protection.
+ *
+ * WHY IT IS NOT lib/governance/checkout-freshness.js. That module answers a similar
+ * question but FAILS OPEN: every git error returns FRESH. It has five advisory
+ * startup-badge consumers, so inverting it in place would silently change all of them.
+ * More importantly, a fail-open gauge is exactly the thing this SD rejects — the
+ * acceptance bar is that no executing path may depend on a human or a loop remembering
+ * to pull, and a check that reports CURRENT when it could not actually tell is a habit
+ * with monitoring, not an invariant. So: a separate module, failing CLOSED, and that one
+ * left untouched.
+ *
+ * FAIL-CLOSED means EVERY abnormal outcome — git missing, remote unreachable, timeout,
+ * detached HEAD, unparseable output, not-a-repository — yields current:false. There is
+ * no branch that returns current:true on uncertainty.
+ *
+ * BEHIND-COUNT SEMANTICS (FR-1 / correction C4, stated because it surprised us):
+ * `git rev-list --count HEAD..<baseRef>` counts EVERY commit reachable from baseRef but
+ * not from HEAD — not the first-parent distance. On a merge-heavy history a rewind of 3
+ * merge commits reported 10, because each merge drags in the commits it merged. That is
+ * the correct number for "how much code am I missing", which is the question that
+ * matters here, so it is what we use — but any assertion on this value must expect the
+ * reachability count, not the number of `git reset` steps.
+ *
+ * PURITY: all git invocation goes through an injectable `runner`, so the decision table
+ * is unit-testable without a live git, and so callers can supply their own timeout.
+ */
+const { execFileSync } = require('child_process');
+
+/** The ref an execution-source tree must be current with respect to. */
+const DEFAULT_BASE_REF = 'origin/main';
+
+/** Bound every git call — a hung fetch must not convert a spawn into an unbounded stall. */
+const DEFAULT_TIMEOUT_MS = 15000;
+
+/** The only branch a tree may be SELF-HEALED on; anything else is refuse-only. */
+const SELF_HEALABLE_BRANCH = 'main';
+
+function defaultRunner(args, { cwd, timeoutMs }) {
+  return execFileSync('git', args, {
+    cwd,
+    timeout: timeoutMs,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function notCurrent(reason, extra = {}) {
+  return {
+    current: false,
+    selfHealable: false,
+    reason,
+    behind: null,
+    dirty: null,
+    branch: null,
+    ...extra,
+  };
+}
+
+/**
+ * Assess whether a working tree is current with respect to a base ref.
+ *
+ * @param {object}   opts
+ * @param {string}   opts.dir        the working tree to assess
+ * @param {string}   [opts.baseRef]  defaults to origin/main
+ * @param {Function} [opts.runner]   (args, {cwd, timeoutMs}) => stdout; injected for tests
+ * @param {number}   [opts.timeoutMs]
+ * @param {boolean}  [opts.fetch]    fetch before comparing (default true — without it the
+ *                                   comparison is against a possibly-ancient remote ref,
+ *                                   which is the same lie in a different place)
+ * @returns {{current:boolean, selfHealable:boolean, reason:string,
+ *            behind:number|null, dirty:boolean|null, branch:string|null}}
+ */
+function assessTreeCurrency({
+  dir,
+  baseRef = DEFAULT_BASE_REF,
+  runner = defaultRunner,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetch = true,
+} = {}) {
+  if (!dir || typeof dir !== 'string') return notCurrent('no_dir');
+
+  const run = (args) => runner(args, { cwd: dir, timeoutMs });
+
+  try {
+    // Refresh the remote ref first. A comparison against a stale origin/main would
+    // report CURRENT for a tree that is in fact behind — the exact failure this exists
+    // to prevent, relocated one level down.
+    if (fetch) {
+      const [remote, ...rest] = String(baseRef).split('/');
+      const branch = rest.join('/');
+      if (remote && branch) run(['fetch', '--quiet', remote, branch]);
+      else run(['fetch', '--quiet']);
+    }
+
+    const branch = String(run(['rev-parse', '--abbrev-ref', 'HEAD'])).trim();
+    // 'HEAD' is git's answer for a detached HEAD. It is never current for our purposes:
+    // we cannot know what it is supposed to track, and we must not guess.
+    if (!branch || branch === 'HEAD') {
+      return notCurrent('detached_head', { branch: branch || null });
+    }
+
+    const dirty = String(run(['status', '--porcelain'])).trim().length > 0;
+
+    const rawBehind = String(run(['rev-list', '--count', `HEAD..${baseRef}`])).trim();
+    const behind = Number.parseInt(rawBehind, 10);
+    // An unparseable count must NOT collapse to 0 — that would silently read as current.
+    if (!Number.isFinite(behind) || behind < 0) {
+      return notCurrent('unparseable_behind_count', { branch, dirty });
+    }
+
+    if (behind === 0) {
+      return { current: true, selfHealable: false, reason: 'current', behind: 0, dirty, branch };
+    }
+
+    // Behind. Self-heal is permitted ONLY when a fast-forward is safe: clean and on the
+    // base branch. The shared root is chronically dirty (lib/coordinator/checkout-
+    // staleness.cjs documents this), and mutating a dirty or off-branch tree risks
+    // clobbering a peer worktree or a session's in-flight state — the hazard that
+    // tests/restart-skill-content.test.js encodes. Everything else is refuse-only.
+    const selfHealable = !dirty && branch === SELF_HEALABLE_BRANCH;
+    return { current: false, selfHealable, reason: 'behind', behind, dirty, branch };
+  } catch (err) {
+    // EVERY failure lands here and every one of them is NOT-CURRENT. No exceptions:
+    // git absent, remote unreachable, credentials expired, timeout (err.killed),
+    // not-a-repository, permission denied. If we could not establish currency, we do
+    // not have it.
+    return notCurrent('git_error', { error: err && err.message ? String(err.message) : 'unknown' });
+  }
+}
+
+module.exports = {
+  assessTreeCurrency,
+  DEFAULT_BASE_REF,
+  DEFAULT_TIMEOUT_MS,
+  SELF_HEALABLE_BRANCH,
+};

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -180,6 +180,13 @@ function enforceTreeCurrency({
   env = process.env,
   logger = console,
   label = 'execution-source tree',
+  // Whether this caller may FIX a stale tree, or may only refuse. The spawn seam heals
+  // (a fast-forward on a clean main is safe and keeps the fleet moving). The REAPER does
+  // not: it runs unattended against a shared root, a mutation there can collide with a
+  // peer worktree, and refusing costs it nothing — the next tick simply tries again. When
+  // the only options are "mutate someone else's tree" and "do nothing", a destructive
+  // subsystem should do nothing.
+  allowSelfHeal = true,
 } = {}) {
   const bypassReason = String((env && env[BYPASS_REASON_ENV]) || '').trim();
   if (bypassReason) {
@@ -194,7 +201,7 @@ function enforceTreeCurrency({
     return { ok: true, healed: false, currencyBypassed: false, assessment };
   }
 
-  if (assessment.selfHealable) {
+  if (assessment.selfHealable && allowSelfHeal) {
     try {
       const [remote, ...rest] = String(baseRef).split('/');
       const branch = rest.join('/');

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -139,8 +139,105 @@ function assessTreeCurrency({
   }
 }
 
+/**
+ * The escape hatch (FR-2 / correction C5). Deliberately keyed on a REASON rather than a
+ * boolean: an operator cannot silence this by setting a flag to 1, they have to say why,
+ * and that reason is carried into the log line and onto the invocation. Default OFF —
+ * an unset or blank value is not a bypass.
+ *
+ * Why a hatch exists at all: fail-closed on git error means an offline or air-gapped
+ * host, an expired credential, a proxy outage or a shallow CI checkout would make the
+ * ENTIRE fleet unspawnable. That is a worse failure than the one we are fixing. But the
+ * hatch must never be mistaken for currency: when it is used the answer is
+ * UNKNOWN-AND-DECLARED, never CURRENT, and `currencyBypassed` says so out loud.
+ */
+const BYPASS_REASON_ENV = 'FLEET_TREE_CURRENCY_BYPASS_REASON';
+
+/** Thrown when an execution-source tree is not current and cannot be safely healed. */
+class TreeStaleError extends Error {
+  constructor(message, detail) {
+    super(message);
+    this.name = 'TreeStaleError';
+    this.code = 'TREE_NOT_CURRENT';
+    this.detail = detail;
+  }
+}
+
+/**
+ * Enforce currency on a tree something is about to EXECUTE from: self-heal when that is
+ * safe, refuse otherwise. This is the invariant — not a gauge, not a warning. The caller
+ * either proceeds from a tree known to be current, or does not proceed.
+ *
+ * @returns {{ok:true, healed:boolean, currencyBypassed:boolean, assessment:object}}
+ * @throws  {TreeStaleError} when the tree is not current and not safely healable
+ */
+function enforceTreeCurrency({
+  dir,
+  baseRef = DEFAULT_BASE_REF,
+  runner = defaultRunner,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetch = true,
+  env = process.env,
+  logger = console,
+  label = 'execution-source tree',
+} = {}) {
+  const bypassReason = String((env && env[BYPASS_REASON_ENV]) || '').trim();
+  if (bypassReason) {
+    // LOUD. Every bypassed run says so, names the operator's reason, and is greppable.
+    const warn = (logger && logger.warn) ? logger.warn.bind(logger) : () => {};
+    warn(`[tree-currency] CURRENCY_BYPASSED ${label} at ${dir} — currency is UNKNOWN, not verified. Reason: ${bypassReason}`);
+    return { ok: true, healed: false, currencyBypassed: true, bypassReason, assessment: null };
+  }
+
+  const assessment = assessTreeCurrency({ dir, baseRef, runner, timeoutMs, fetch });
+  if (assessment.current) {
+    return { ok: true, healed: false, currencyBypassed: false, assessment };
+  }
+
+  if (assessment.selfHealable) {
+    try {
+      const [remote, ...rest] = String(baseRef).split('/');
+      const branch = rest.join('/');
+      runner(['pull', '--ff-only', '--quiet', remote, branch], { cwd: dir, timeoutMs });
+    } catch (err) {
+      throw new TreeStaleError(
+        `[tree-currency] REFUSED: ${label} at ${dir} is ${assessment.behind} commit(s) behind ${baseRef} `
+        + `and the fast-forward failed (${err && err.message ? err.message : 'unknown'}). Not proceeding from a stale tree.`,
+        { ...assessment, healAttempted: true },
+      );
+    }
+    // Re-assess rather than assume the pull worked. Trusting the exit code here would be
+    // the same "verified at the merge, not at the consumer" mistake this SD exists for.
+    const after = assessTreeCurrency({ dir, baseRef, runner, timeoutMs, fetch: false });
+    if (!after.current) {
+      throw new TreeStaleError(
+        `[tree-currency] REFUSED: ${label} at ${dir} was still not current after a fast-forward `
+        + `(reason=${after.reason}, behind=${after.behind}). Not proceeding from a stale tree.`,
+        { ...after, healAttempted: true },
+      );
+    }
+    return { ok: true, healed: true, currencyBypassed: false, assessment: after };
+  }
+
+  const why = assessment.reason === 'behind'
+    ? `${assessment.behind} commit(s) behind ${baseRef} and NOT safely healable `
+      + `(dirty=${assessment.dirty}, branch=${assessment.branch}) — refusing rather than mutating a `
+      + `dirty or off-branch tree, which would risk clobbering a peer worktree`
+    : `currency could not be established (reason=${assessment.reason})`;
+
+  throw new TreeStaleError(
+    `[tree-currency] REFUSED: ${label} at ${dir} — ${why}. `
+    + `Remedy: from a clean checkout on ${SELF_HEALABLE_BRANCH}, run git pull --ff-only. `
+    + `To proceed without verifying currency, set ${BYPASS_REASON_ENV} to an explicit reason.`,
+    assessment,
+  );
+}
+
 module.exports = {
   assessTreeCurrency,
+  enforceTreeCurrency,
+  TreeStaleError,
+  BYPASS_REASON_ENV,
   DEFAULT_BASE_REF,
   DEFAULT_TIMEOUT_MS,
   SELF_HEALABLE_BRANCH,

--- a/scripts/fleet/worktree-reaper-tick.cjs
+++ b/scripts/fleet/worktree-reaper-tick.cjs
@@ -22,6 +22,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
+// SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-3: resolved from this module's own
+// location, so the reaper's root is a property of the installed code rather than of
+// whatever directory the caller happened to be standing in.
+const CANONICAL_REPO_ROOT = path.resolve(__dirname, '..', '..');
+
 const DEFAULT_CADENCE = 12; // every 12th sweep ≈ 1 hour at 5-min intervals
 const STATE_RELATIVE = path.join('.claude', 'worktree-reaper-state.json');
 const STATE_SCHEMA_VERSION = 1;
@@ -197,7 +202,16 @@ function buildReaperArgs({ reaperScript, execute, stage2, allPools }) {
  * @returns {object} { invoked, counter, cadence, result, enabled }
  */
 function tick(opts = {}) {
-  const repoRoot = opts.repoRoot || process.cwd();
+  // SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-3: the fallback was process.cwd(),
+  // which meant the reaper's ROOT — and therefore, via reaperScript below, the reaper's
+  // own CODE — came from whatever directory the caller happened to be standing in. The
+  // only production caller (scripts/stale-session-sweep.cjs) passes no repoRoot, and the
+  // sweep routinely runs from a worktree. That is how the reap-protected marker shipped
+  // inert: its fix sits 50 commits back, so a root behind it executes a worktree-reaper.mjs
+  // in which the protection is physically absent.
+  // opts.repoRoot is PRESERVED — 12 tests inject it, and it is the seam that lets the
+  // refuse-to-reap test below run against a temp dir instead of the real repo.
+  const repoRoot = opts.repoRoot || CANONICAL_REPO_ROOT;
   const cadence = Number.isFinite(opts.cadence) && opts.cadence > 0 ? opts.cadence : DEFAULT_CADENCE;
   const logger = opts.logger || ((m) => console.log(m));
   const statePath = path.join(repoRoot, STATE_RELATIVE);
@@ -222,6 +236,39 @@ function tick(opts = {}) {
     state.last_result = 'script_missing';
     writeState(statePath, state);
     return { invoked: false, counter: state.sweep_counter, cadence, result: 'script_missing', enabled: true };
+  }
+
+  // SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-3 — REFUSE TO REAP FROM A STALE TREE.
+  //
+  // reaperScript above is resolved OUT OF repoRoot, so the reaper's code identity is that
+  // tree's HEAD. Reaping is destructive and unrecoverable: a deleted worktree cannot be
+  // restored by a later error message, so failing loud AFTER the fact is not available to
+  // us. The only safe direction is to refuse before executing. This is precisely how the
+  // reap-protected marker came to be inert — the guard existed on origin/main and was
+  // physically absent from the file being run.
+  //
+  // Deliberately placed AFTER the enabled/cadence/script-exists checks so those keep
+  // reporting their own reasons, and so a disabled or not-due tick never touches git.
+  try {
+    const { enforceTreeCurrency } = require('../../lib/fleet/tree-currency.cjs');
+    enforceTreeCurrency({
+      dir: repoRoot,
+      logger: { warn: (m) => logger(m) },
+      label: 'worktree-reaper source tree',
+      // The reaper REFUSES; it never heals. It runs unattended against a shared root, so a
+      // fast-forward here could collide with a peer worktree's in-flight state. Skipping a
+      // reap costs nothing — the next tick retries — while a bad mutation on the shared
+      // root is exactly the hazard the auto-pull prohibition exists to prevent.
+      allowSelfHeal: false,
+      ...(opts.currencyRunner ? { runner: opts.currencyRunner } : {}),
+      ...(opts.currencyEnv ? { env: opts.currencyEnv } : {}),
+    });
+  } catch (err) {
+    logger(`WORKTREE REAPER TICK: sweep=${state.sweep_counter} — REFUSING TO REAP: ${err && err.message ? err.message : 'currency check failed'}`);
+    state.last_run_at = new Date().toISOString();
+    state.last_result = 'refused_stale_tree';
+    writeState(statePath, state);
+    return { invoked: false, counter: state.sweep_counter, cadence, result: 'refused_stale_tree', enabled: true };
   }
 
   // Single-flight guard: if the previous reaper is still running, do not stack a

--- a/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
+++ b/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
@@ -28,6 +28,21 @@ vi.mock('../../../lib/coordinator/singleton-refresh-sequencer.cjs', () => ({
 
 const { canaryRestart, canaryRelaunchUnderProfile } = await import('../../../lib/fleet/canary-guard.js');
 
+/**
+ * FR-2 tree-currency seam (post-CI RCA). See the fuller rationale in spawn-control.test.js.
+ * These two canary legs reach a live spawn, so they cross the guard and would otherwise run
+ * real git -- in CI that meant a 15-SECOND `git fetch` timeout each (DEFAULT_TIMEOUT_MS),
+ * because vitest's forked pool had several workers fetching concurrently into one shallow
+ * .git. Slow AND nondeterministic, on top of the detached-HEAD refusal.
+ */
+const CURRENT_RUNNER = (args) => {
+  if (args[0] === 'fetch') return '';
+  if (args.includes('--abbrev-ref')) return 'main\n';
+  if (args[0] === 'status') return '';
+  if (args[0] === 'rev-list') return '0\n';
+  return '';
+};
+
 /** Same in-memory fake shape as spawn-control.test.js / canary-guard.test.js. */
 function makeFakeSupabase({ sessions = [] } = {}) {
   const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
@@ -80,7 +95,7 @@ describe('QF-20260724-499: restart/relaunch honor an explicit opts.live even whe
     const supabase = makeFakeSupabase({ sessions: [canaryWorker] });
 
     const result = await canaryRestart('Canary-Alpha-1', {
-      supabase, by: 'callsign', env: GUARD_ENV, live: true, spawnFn, execFn, sleepFn: vi.fn(),
+      supabase, by: 'callsign', env: GUARD_ENV, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(),
     });
 
     expect(result.ok).toBe(true);
@@ -111,7 +126,7 @@ describe('QF-20260724-499: restart/relaunch honor an explicit opts.live even whe
     const supabase = makeFakeSupabase({ sessions: [{ ...canaryWorker, session_id: 's-canary-worker-3' }] });
 
     const result = await canaryRelaunchUnderProfile('Canary-Alpha-1', 'canary', {
-      supabase, by: 'callsign', env: GUARD_ENV, baseDir: 'C:\\profiles', live: true, spawnFn, execFn, sleepFn: vi.fn(),
+      supabase, by: 'callsign', env: GUARD_ENV, baseDir: 'C:\\profiles', live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(),
     });
 
     expect(result.ok).toBe(true);
@@ -140,7 +155,7 @@ describe('QF-20260724-499: restart/relaunch honor an explicit opts.live even whe
       sessions: [{ session_id: 's-prod', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, account_profile: 'default', role: 'worker' } }],
     });
 
-    const result = await canaryRestart('Alpha-5', { supabase, by: 'callsign', env: GUARD_ENV, live: true, spawnFn });
+    const result = await canaryRestart('Alpha-5', { supabase, by: 'callsign', env: GUARD_ENV, live: true, currencyRunner: CURRENT_RUNNER, spawnFn });
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('not_canary_profile');

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -28,6 +28,31 @@ const {
   roleOf, isSingletonRole, resolveProfileDir, isLiveEnabled, buildLiveSpawnInvocation,
   spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart,
 } = await import('../../../lib/fleet/spawn-control.js');
+
+/**
+ * SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-2 + post-CI RCA.
+ *
+ * Every live-path call below crosses the tree-currency seam in spawn-control.js. Injecting a
+ * fake git runner is NOT mocking the gate: the gate is the enforceTreeCurrency CALL at that
+ * seam plus its decision table, and both still execute in full (fetch -> branch -> dirty ->
+ * behind -> current). `runner` is only the guard's I/O dependency, and tree-currency.cjs
+ * documents it as the injection seam; tests/unit/worktree-reaper/tick.test.js:181 already
+ * does exactly this. Deleting the enforcement block still turns the FR-2 seam suite red.
+ *
+ * WHY THIS IS REQUIRED, not cosmetic: without it these tests shell out to REAL git against
+ * whatever tree the checkout happens to live in. That passed on the author's machine purely
+ * because the runs happened inside .worktrees/ (which the guard deliberately exempts) and
+ * failed in CI, where actions/checkout leaves a DETACHED HEAD and the guard correctly
+ * refuses -- 21 red tests whose behaviour depended on the physical location of the checkout.
+ * A unit test must never depend on real git state or on network egress.
+ */
+const CURRENT_RUNNER = (args) => {
+  if (args[0] === 'fetch') return '';
+  if (args.includes('--abbrev-ref')) return 'main\n';
+  if (args[0] === 'status') return '';
+  if (args[0] === 'rev-list') return '0\n';
+  return '';
+};
 const { logCoordinationEvent } = await import('../../../lib/coordinator/coordination-events.cjs');
 const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
 const { spawn: childProcessSpawnSpy } = await import('node:child_process');
@@ -222,7 +247,7 @@ describe('spawn (FR-1)', () => {
     childProcessSpawnSpy.mockReturnValue(fakeChild);
     const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({ sessions: [] });
-    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, execFn, sleepFn: vi.fn(), supabaseClient });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, currencyRunner: CURRENT_RUNNER, execFn, sleepFn: vi.fn(), supabaseClient });
     // LOAD-BEARING: kill-survival depends on detached:true (OS re-parents the child when the
     // supervisor dies) + stdio:'ignore' (no inherited pipes tie it to the parent). Deleting
     // detached:true from spawn-control.js:147 makes THIS assertion fail (mutation-verified).
@@ -247,7 +272,7 @@ describe('spawn (FR-1)', () => {
         metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
       }],
     });
-    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
     const merged = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
     // Pre-existing keys survive the write (would be wiped by a bare full-blob overwrite).
     expect(merged.fleet_identity).toEqual({ callsign: 'Alpha-5' });
@@ -272,7 +297,7 @@ describe('spawn (FR-1)', () => {
     // would make this test pass VACUOUSLY. uuidFn returns a non-UUID so buildSessionLaunch drops it
     // (the CLI would reject a malformed --session-id) and spawn falls back to the pid path — which is
     // exactly the path whose freshness window this test exists to guard. Keeps its teeth.
-    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => 'not-a-uuid' });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => 'not-a-uuid' });
     // Untouched -- the stale row's metadata must never be corrupted by a fresh spawn's recycled pid.
     expect(supabaseClient._store.get('s-old').metadata).toEqual({ fleet_identity: { callsign: 'Unrelated-Session' }, role: 'worker' });
   });
@@ -282,7 +307,7 @@ describe('spawn (FR-1)', () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
     });
-    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, supabaseClient });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, supabaseClient });
     expect(result.skipped).toBe(true);
     expect(spawnFn).not.toHaveBeenCalled();
   });
@@ -294,7 +319,7 @@ describe('spawn (FR-1)', () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' } } }],
     });
-    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
+    const result = await spawn({ role: 'worker', callsign: 'Alpha-5' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
     expect(result.skipped).toBeUndefined();
     expect(spawnFn).toHaveBeenCalled();
   });
@@ -314,7 +339,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     logCoordinationEvent.mockClear();
-    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
+    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
 
     expect(result.session_id).toBe(MINTED_SESSION_ID);
     const spawnEventCall = logCoordinationEvent.mock.calls.find((c) => c[1].event_type === 'fleet_verb_spawn');
@@ -336,7 +361,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, {
-      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
       execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
     });
@@ -357,7 +382,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     await spawn({ role: 'worker', callsign: 'Canary-1', accountProfile: 'canary' }, {
-      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
       execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
       baseDir: 'C:/fake', // resolveProfileDir(name, opts) honours opts.baseDir — no FLEET_* env needed
@@ -375,7 +400,7 @@ describe('spawn (FR-1)', () => {
     const order = [];
     const supabaseClient = makeFakeSupabase({ sessions: [] });
     await spawn({ role: 'worker', callsign: 'Beta-1' }, {
-      live: true,
+      live: true, currencyRunner: CURRENT_RUNNER,
       enumerateWindowsFn: async () => { order.push('enumerate'); return []; },
       spawnFn: () => { order.push('spawn'); return { pid: 4242 }; },
       captureNewWindowHandleFn: async () => { order.push('capture'); return { handle: 1, handleCaptureFailed: false, attempts: 1, diagnostics: {} }; },
@@ -396,7 +421,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     await spawn({ role: 'worker', callsign: 'Beta-1' }, {
-      live: true,
+      live: true, currencyRunner: CURRENT_RUNNER,
       spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
       enumerateWindowsFn: async () => [],
       captureNewWindowHandleFn: async () => ({
@@ -419,7 +444,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     await spawn({ role: 'worker', callsign: 'Beta-1' }, {
-      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
       enumerateWindowsFn: async () => [],
       captureNewWindowHandleFn: async () => ({ handle: 777, handleCaptureFailed: false, attempts: 1, diagnostics: { reason: 'ok' } }),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
@@ -438,7 +463,7 @@ describe('spawn (FR-1)', () => {
       }],
     });
     await spawn({ role: 'worker', callsign: 'Beta-1' }, {
-      live: true, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
       execFn: enumExec(),
       sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID,
     });
@@ -473,7 +498,7 @@ describe('spawn (FR-1)', () => {
       },
     };
     const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn, supabaseClient, nowMs, skipDedup: true });
+    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn, supabaseClient, nowMs, skipDedup: true });
 
     expect(lookups).toBe(2);
     expect(sleepFn).toHaveBeenCalledTimes(1); // slept once between attempt 1 and attempt 2
@@ -485,7 +510,7 @@ describe('spawn (FR-1)', () => {
     const spawnFn = vi.fn().mockReturnValue(child);
     const execFn = enumExec();
     const supabaseClient = makeFakeSupabase({ sessions: [] }); // never self-registers
-    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
+    const result = await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, skipDedup: true });
 
     expect(result.session_id).toBeNull();
     expect(result.live).toBe(true); // spawn itself still succeeded -- only the session-bind is unresolved
@@ -577,7 +602,7 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
-    const result = await restart('Alpha-5', { supabaseClient, live: true, spawnFn, execFn, sleepFn: vi.fn() });
+    const result = await restart('Alpha-5', { supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.ok).toBe(true);
     expect(result.role).toBe('worker');
     expect(sequenceSingletonRefresh).not.toHaveBeenCalled();
@@ -616,7 +641,7 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
-    await restart('Alpha-5', { supabaseClient, live: true, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
+    await restart('Alpha-5', { supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
     const [, eventArg] = logCoordinationEvent.mock.calls.at(-1);
     expect(eventArg.event_type).toBe('fleet_verb_restart');
     expect(eventArg.sd_key).toBe('CHECKPOINT-3');
@@ -644,7 +669,7 @@ describe('relaunchUnderProfile (FR-7)', () => {
         { session_id: 's2', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-6' }, role: 'worker' } },
       ],
     });
-    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn, sleepFn: vi.fn() });
+    const result = await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.ok).toBe(true);
     expect(supabaseClient._store.get('s1').status).toBe('released');
     expect(supabaseClient._store.get('s2').status).toBe('active');
@@ -668,7 +693,7 @@ describe('relaunchUnderProfile (FR-7)', () => {
       process.env.CLAUDE_CONFIG_DIR = '/tampered'; // simulate a hypothetical regression
       return { pid: 999 };
     });
-    await expect(relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn: vi.fn().mockResolvedValue({ stdout: '0' }), sleepFn: vi.fn() }))
+    await expect(relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: vi.fn().mockResolvedValue({ stdout: '0' }), sleepFn: vi.fn() }))
       .rejects.toThrow(/isolation invariant violated/);
     delete process.env.CLAUDE_CONFIG_DIR;
   });
@@ -683,7 +708,7 @@ describe('relaunchUnderProfile (FR-7)', () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
     });
-    await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
+    await relaunchUnderProfile('Alpha-5', 'account_b', { supabaseClient, baseDir: 'C:\\profiles', live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), sdKey: 'CHECKPOINT-3' });
     const [, eventArg] = logCoordinationEvent.mock.calls.at(-1);
     expect(eventArg.event_type).toBe('fleet_verb_relaunch_under_profile');
     expect(eventArg.sd_key).toBe('CHECKPOINT-3');
@@ -753,7 +778,7 @@ describe('drainAndRestart (FR-6: never restarts mid-claim)', () => {
     const child = { pid: 5252 };
     const spawnFn = vi.fn().mockReturnValue(child);
     const execFn = enumExec();
-    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: true, spawnFn, execFn, sleepFn: vi.fn() });
+    const result = await drainAndRestart('Alpha-5', { supabaseClient, nowMs, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn() });
     expect(result.deferred).toBe(false);
     expect(result.verdict).toBe('PASS');
     expect(supabaseClient._store.get('s1').status).toBe('released');

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -1,0 +1,214 @@
+/**
+ * SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 — FR-1 + TS-1/TS-2/TS-3.
+ *
+ * THE ACCEPTANCE BAR THIS FILE EXISTS TO MAKE FALSIFIABLE, verbatim from the SD:
+ * "NO CODE PATH THAT EXECUTES SHOULD DEPEND ON A HUMAN OR A LOOP REMEMBERING TO
+ * PULL. A gauge that detects staleness plus a loop that remediates it is still a
+ * system whose answer to is-the-spawn-path-current is probably-if-someone-ticked-
+ * recently. That is a habit with monitoring, not an invariant."
+ *
+ * So "we pulled and it was fresh" must not be able to pass. TS-1 below builds a
+ * REAL git repository, rewinds it, and asserts a POSITIVE discriminator — either an
+ * identifiable NOT-CURRENT verdict, or an observed `pull --ff-only` that actually
+ * converges behind to 0. A bare not.toThrow() would be a test failure.
+ *
+ * WHY A SYNTHETIC REPO RATHER THAN THIS ONE (measured at PLAN):
+ *   - .github/workflows/unit-tier.yml checks out at fetch-depth 1, so HEAD~3 does
+ *     not exist in CI and origin/main is not guaranteed to resolve. Rewinding the
+ *     real repo cannot run there.
+ *   - `git worktree add` against the real repo costs ~11.9s, mutates .git/worktrees
+ *     right next to the chairman's protected .worktrees/cp3-drill-run, AND lands
+ *     off-main, so the guard would refuse before the self-heal path is ever reached.
+ *   - A disposable clone of the real repo costs ~17.8s and dies on CI's depth-1 parent.
+ * The synthetic repo is ~1.5s, offline-safe, shallow-CI-safe, and touches nothing
+ * outside its own temp directory.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { assessTreeCurrency, DEFAULT_BASE_REF } = require('../../../lib/fleet/tree-currency.cjs');
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+let tmp; let upstream; let downstream;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tree-currency-'));
+  upstream = path.join(tmp, 'upstream');
+  downstream = path.join(tmp, 'downstream');
+
+  fs.mkdirSync(upstream, { recursive: true });
+  git(['init', '--quiet', '-b', 'main'], upstream);
+  git(['config', 'user.email', 'test@example.invalid'], upstream);
+  git(['config', 'user.name', 'Tree Currency Test'], upstream);
+  for (let i = 1; i <= 5; i += 1) {
+    fs.writeFileSync(path.join(upstream, `f${i}.txt`), `commit ${i}\n`);
+    git(['add', '.'], upstream);
+    git(['commit', '--quiet', '-m', `commit ${i}`], upstream);
+  }
+
+  git(['clone', '--quiet', upstream, downstream], tmp);
+  git(['config', 'user.email', 'test@example.invalid'], downstream);
+  git(['config', 'user.name', 'Tree Currency Test'], downstream);
+});
+
+afterAll(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('TS-1: the adversarial staleness test (real git, hermetic repo)', () => {
+  it('a tree level with its remote is CURRENT', () => {
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/main' });
+    expect(r.current).toBe(true);
+    expect(r.behind).toBe(0);
+    expect(r.branch).toBe('main');
+    expect(r.dirty).toBe(false);
+  });
+
+  it('a REWOUND tree is NOT-CURRENT and reports how far behind it is', () => {
+    git(['reset', '--hard', '--quiet', 'HEAD~3'], downstream);
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/main' });
+    // The positive discriminator: not merely "did not throw" — an explicit verdict
+    // with a behind-count that matches the rewind.
+    expect(r.current).toBe(false);
+    expect(r.reason).toBe('behind');
+    expect(r.behind).toBe(3);
+    expect(r.branch).toBe('main');
+    expect(r.dirty).toBe(false);
+  });
+
+  it('SELF-HEAL: a ff-only pull actually converges behind to 0, proven by re-assessing', () => {
+    // This is the half a seam-injected test can never prove — that the git command
+    // we emit is correct and that it genuinely fixes the tree.
+    git(['pull', '--ff-only', '--quiet', 'origin', 'main'], downstream);
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/main' });
+    expect(r.current).toBe(true);
+    expect(r.behind).toBe(0);
+  });
+
+  it('a DIRTY tree is reported dirty, so the caller can refuse rather than mutate it', () => {
+    fs.writeFileSync(path.join(downstream, 'f1.txt'), 'locally modified\n');
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/main' });
+    expect(r.dirty).toBe(true);
+    git(['checkout', '--quiet', '--', 'f1.txt'], downstream);
+  });
+
+  it('a DETACHED HEAD is NOT-CURRENT — fail closed, with real git', () => {
+    git(['checkout', '--quiet', 'HEAD~1'], downstream);
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/main' });
+    expect(r.current).toBe(false);
+    git(['checkout', '--quiet', 'main'], downstream);
+  });
+
+  it('a MISSING remote ref is NOT-CURRENT — fail closed, with real git', () => {
+    const r = assessTreeCurrency({ dir: downstream, baseRef: 'origin/does-not-exist' });
+    expect(r.current).toBe(false);
+  });
+
+  it('a directory that is not a git repository at all is NOT-CURRENT', () => {
+    const notARepo = path.join(tmp, 'not-a-repo');
+    fs.mkdirSync(notARepo, { recursive: true });
+    const r = assessTreeCurrency({ dir: notARepo, baseRef: 'origin/main' });
+    expect(r.current).toBe(false);
+  });
+});
+
+// TS-2 / TS-3 — the decision table. Real git cannot cheaply reach a timeout or an
+// exotic failure mode, so those branches are covered through the injected runner.
+// These are REQUIRED IN ADDITION TO TS-1, never instead of it: on their own they
+// prove the decision logic but say nothing about whether the emitted git commands
+// are correct, which is exactly the gap that lets a fix ship inert.
+describe('TS-2: FAIL-CLOSED on every abnormal path (injected runner)', () => {
+  const ok = (out) => () => out;
+
+  it('a throwing runner yields NOT-CURRENT, never CURRENT', () => {
+    const r = assessTreeCurrency({
+      dir: '/anywhere',
+      runner: () => { throw new Error('git exploded'); },
+    });
+    expect(r.current).toBe(false);
+    expect(r.reason).toBe('git_error');
+  });
+
+  it('a TIMEOUT yields NOT-CURRENT', () => {
+    const r = assessTreeCurrency({
+      dir: '/anywhere',
+      runner: () => { const e = new Error('timed out'); e.killed = true; e.signal = 'SIGTERM'; throw e; },
+    });
+    expect(r.current).toBe(false);
+  });
+
+  it('an unparseable behind-count yields NOT-CURRENT rather than a silent 0', () => {
+    const r = assessTreeCurrency({
+      dir: '/anywhere',
+      runner: (args) => {
+        if (args[0] === 'fetch') return '';
+        if (args.includes('--abbrev-ref')) return 'main\n';
+        if (args[0] === 'status') return '';
+        return 'not-a-number\n';
+      },
+    });
+    expect(r.current).toBe(false);
+  });
+
+  it('this is the DELIBERATE INVERSE of lib/governance/checkout-freshness.js', () => {
+    // That module returns FRESH on any git error (its :112-117 fail-open branch) and
+    // has five advisory startup-badge consumers, so it is left untouched rather than
+    // inverted in place. A fail-open gauge is the habit-with-monitoring this SD rejects.
+    const freshness = require('../../../lib/governance/checkout-freshness.js');
+    expect(freshness).toBeDefined();
+    const r = assessTreeCurrency({ dir: '/anywhere', runner: () => { throw new Error('boom'); } });
+    expect(r.current).toBe(false);
+  });
+});
+
+describe('TS-3: the decision table (injected runner)', () => {
+  const runnerFor = ({ branch = 'main', behind = '0', dirty = '' }) => (args) => {
+    if (args[0] === 'fetch') return '';
+    if (args.includes('--abbrev-ref')) return `${branch}\n`;
+    if (args[0] === 'status') return dirty;
+    if (args[0] === 'rev-list') return `${behind}\n`;
+    return '';
+  };
+
+  it('current + clean + main => CURRENT', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({}) });
+    expect(r.current).toBe(true);
+  });
+
+  it('behind + clean + main => NOT-CURRENT, and SELF-HEALABLE', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4' }) });
+    expect(r.current).toBe(false);
+    expect(r.behind).toBe(4);
+    expect(r.selfHealable).toBe(true);
+  });
+
+  it('behind + DIRTY => NOT-CURRENT and NOT self-healable (never mutate a dirty tree)', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4', dirty: ' M a.txt\n' }) });
+    expect(r.current).toBe(false);
+    expect(r.selfHealable).toBe(false);
+  });
+
+  it('behind + OFF-MAIN => NOT-CURRENT and NOT self-healable', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4', branch: 'feat/x' }) });
+    expect(r.current).toBe(false);
+    expect(r.selfHealable).toBe(false);
+  });
+
+  it('DETACHED HEAD => NOT-CURRENT and NOT self-healable', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4', branch: 'HEAD' }) });
+    expect(r.current).toBe(false);
+    expect(r.selfHealable).toBe(false);
+  });
+
+  it('exposes a default base ref so callers do not each hardcode one', () => {
+    expect(DEFAULT_BASE_REF).toBe('origin/main');
+  });
+});

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -310,3 +310,110 @@ describe('FR-2: enforceTreeCurrency self-heals or REFUSES', () => {
     expect(warnings.join(' ')).toMatch(/air-gapped host, incident 123/);
   });
 });
+
+/**
+ * FR-2 SEAM PINNING — added after the EXEC-TO-PLAN review proved the enforcement was
+ * UNPINNED.
+ *
+ * The reviewer deleted the entire enforcement block from lib/fleet/spawn-control.js,
+ * left this module fully intact, and every test in the branch still passed. That is this
+ * SD's own thesis turned on itself: an enforcement that can be silently removed while
+ * still being reported as present is exactly the shipped-but-inert shape the SD exists to
+ * eliminate. Testing the primitive is not testing the invariant — the invariant lives at
+ * the SEAM.
+ *
+ * These tests fail if the call in spawn() is removed, weakened, or moved before the
+ * dry-run return.
+ */
+describe('FR-2 seam: spawn() itself enforces currency (mutation-killing)', () => {
+  const staleRunner = (args) => {
+    if (args[0] === 'fetch') return '';
+    if (args.includes('--abbrev-ref')) return 'main\n';
+    if (args[0] === 'status') return ' M dirty.txt\n';   // dirty => NOT self-healable
+    if (args[0] === 'rev-list') return '9\n';
+    return '';
+  };
+
+  it('a live spawn from a STALE, non-worktree tree is REFUSED by spawn() itself', async () => {
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    await expect(spawn(
+      { role: 'worker', callsign: 'Pin-1' },
+      {
+        live: true,
+        cwd: 'C:/fake/repo-root',   // NOT under .worktrees/, so the guard applies
+        currencyRunner: staleRunner,
+        env: {},
+        spawnFn: () => { throw new Error('spawn must NOT be reached when the tree is stale'); },
+      },
+    )).rejects.toThrow(/REFUSED/);
+  });
+
+  it('a DRY RUN never touches git — the guard sits after the dry-run return', async () => {
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    let touched = false;
+    const res = await spawn(
+      { role: 'worker', callsign: 'Pin-2' },
+      { live: false, currencyRunner: () => { touched = true; return ''; }, env: {} },
+    );
+    expect(res.live).toBe(false);
+    expect(touched).toBe(false);
+  });
+
+  it('the .worktrees/ exemption is real and is scoped to a genuine path segment', async () => {
+    const { assessTreeCurrency } = await import('../../../lib/fleet/tree-currency.cjs');
+    expect(typeof assessTreeCurrency).toBe('function');
+    // Pinned as a pure predicate so the exemption cannot silently widen: a directory that
+    // merely CONTAINS the word must not be treated as a worktree.
+    const BACKSLASH = String.fromCharCode(92);
+    const isExempt = (p) => String(p || '').split(BACKSLASH).join('/').includes('/.worktrees/');
+    expect(isExempt('C:/repo/.worktrees/SD-X')).toBe(true);
+    expect(isExempt(['C:', 'repo', '.worktrees', 'SD-X'].join(BACKSLASH))).toBe(true);
+    expect(isExempt('C:/repo/my-.worktrees-backup/x')).toBe(false);
+    expect(isExempt('C:/repo')).toBe(false);
+  });
+});
+
+describe('SEC-1: a base ref can never be smuggled to git as an option', () => {
+  it('a dash-leading baseRef is rejected before any git call', () => {
+    let called = false;
+    const r = assessTreeCurrency({
+      dir: '/x',
+      baseRef: '--upload-pack=cmd.exe /c echo PWNED/main',
+      runner: () => { called = true; return ''; },
+    });
+    expect(r.current).toBe(false);
+    expect(r.reason).toBe('invalid_base_ref');
+    // The load-bearing assertion: git was never invoked at all.
+    expect(called).toBe(false);
+  });
+
+  it('the fetch and pull invocations carry an end-of-options separator', () => {
+    const seen = [];
+    assessTreeCurrency({
+      dir: '/x',
+      runner: (args) => {
+        seen.push(args);
+        if (args.includes('--abbrev-ref')) return 'main\n';
+        if (args[0] === 'status') return '';
+        if (args[0] === 'rev-list') return '0\n';
+        return '';
+      },
+    });
+    const fetchCall = seen.find((a) => a[0] === 'fetch');
+    expect(fetchCall).toContain('--');
+  });
+
+  it('a legitimate baseRef still works', () => {
+    const r = assessTreeCurrency({
+      dir: '/x',
+      baseRef: 'origin/main',
+      runner: (args) => {
+        if (args.includes('--abbrev-ref')) return 'main\n';
+        if (args[0] === 'status') return '';
+        if (args[0] === 'rev-list') return '0\n';
+        return '';
+      },
+    });
+    expect(r.current).toBe(true);
+  });
+});

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -126,8 +126,6 @@ describe('TS-1: the adversarial staleness test (real git, hermetic repo)', () =>
 // prove the decision logic but say nothing about whether the emitted git commands
 // are correct, which is exactly the gap that lets a fix ship inert.
 describe('TS-2: FAIL-CLOSED on every abnormal path (injected runner)', () => {
-  const ok = (out) => () => out;
-
   it('a throwing runner yields NOT-CURRENT, never CURRENT', () => {
     const r = assessTreeCurrency({
       dir: '/anywhere',

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -359,17 +359,57 @@ describe('FR-2 seam: spawn() itself enforces currency (mutation-killing)', () =>
     expect(touched).toBe(false);
   });
 
-  it('the .worktrees/ exemption is real and is scoped to a genuine path segment', async () => {
-    const { assessTreeCurrency } = await import('../../../lib/fleet/tree-currency.cjs');
-    expect(typeof assessTreeCurrency).toBe('function');
-    // Pinned as a pure predicate so the exemption cannot silently widen: a directory that
-    // merely CONTAINS the word must not be treated as a worktree.
-    const BACKSLASH = String.fromCharCode(92);
-    const isExempt = (p) => String(p || '').split(BACKSLASH).join('/').includes('/.worktrees/');
-    expect(isExempt('C:/repo/.worktrees/SD-X')).toBe(true);
-    expect(isExempt(['C:', 'repo', '.worktrees', 'SD-X'].join(BACKSLASH))).toBe(true);
-    expect(isExempt('C:/repo/my-.worktrees-backup/x')).toBe(false);
-    expect(isExempt('C:/repo')).toBe(false);
+  /**
+   * R4 (post-CI RCA) — the exemption needs pinning at the seam for exactly the same reason
+   * the enforcement did.
+   *
+   * The test that stood here re-declared its own `isExempt` copy in the test body and made
+   * assertions about THAT. It therefore pinned a copy, not the code: mutating production to
+   * `.includes('worktrees')` (widening the exemption so any path containing the word skips
+   * the guard) or to a flat `false` left all 32 tests GREEN. That is this SD's own CRITICAL
+   * C1 finding recurring one line further down — enforcement pinned, exemption not — in an
+   * SD whose entire thesis is that an invariant must live at the seam.
+   *
+   * Both tests below drive the REAL spawn() and are discriminating: each one goes red under
+   * a different mutation of the predicate.
+   */
+  it('a decoy path merely CONTAINING "worktrees" is NOT exempt — the guard still refuses', async () => {
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    // Kills the widening mutation `.includes('worktrees')`: under it this path becomes
+    // exempt, the guard is skipped, and spawnFn is reached instead of a refusal.
+    await expect(spawn(
+      { role: 'worker', callsign: 'Pin-3' },
+      {
+        live: true,
+        cwd: 'C:/fake/worktrees-decoy/repo',
+        currencyRunner: staleRunner,
+        env: {},
+        spawnFn: () => { throw new Error('spawn must NOT be reached: a decoy path is not a worktree'); },
+      },
+    )).rejects.toThrow(/REFUSED/);
+  });
+
+  it('a genuine /.worktrees/ path IS exempt — the guard never runs git at all', async () => {
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    // Kills the mutation that deletes the exemption (`spawnsFromWorktree = false`): under it
+    // the guard runs, staleRunner reports 9-behind-and-dirty, and this REFUSES instead of
+    // spawning. Asserting the runner is untouched is the positive half of the predicate.
+    let gitCalls = 0;
+    const recordingRunner = (args) => { gitCalls += 1; return staleRunner(args); };
+    const res = await spawn(
+      { role: 'worker', callsign: 'Pin-4' },
+      {
+        live: true,
+        cwd: 'C:/fake/.worktrees/SD-X',
+        currencyRunner: recordingRunner,
+        env: {},
+        spawnFn: () => ({ pid: 4242 }),
+        execFn: async () => ({ stdout: '0' }),
+        sleepFn: () => {},
+      },
+    );
+    expect(gitCalls).toBe(0);
+    expect(res.live).toBe(true);
   });
 });
 

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -210,3 +210,103 @@ describe('TS-3: the decision table (injected runner)', () => {
     expect(DEFAULT_BASE_REF).toBe('origin/main');
   });
 });
+
+// FR-2 — enforcement. assessTreeCurrency only ANSWERS; this is the part that makes the
+// answer binding. The distinction matters: a gauge that reports staleness and lets the
+// caller proceed anyway is the habit-with-monitoring the acceptance bar rejects.
+describe('FR-2: enforceTreeCurrency self-heals or REFUSES', () => {
+  const { enforceTreeCurrency, TreeStaleError, BYPASS_REASON_ENV } = require('../../../lib/fleet/tree-currency.cjs');
+  const silent = { warn() {} };
+
+  const runnerFor = ({ branch = 'main', behind = '0', dirty = '', calls = [], healTo = '0' }) => {
+    let pulled = false;
+    return (args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'pull') { pulled = true; return ''; }
+      if (args.includes('--abbrev-ref')) return `${branch}\n`;
+      if (args[0] === 'status') return dirty;
+      if (args[0] === 'rev-list') return `${pulled ? healTo : behind}\n`;
+      return '';
+    };
+  };
+
+  it('a CURRENT tree proceeds without healing', () => {
+    const r = enforceTreeCurrency({ dir: '/x', runner: runnerFor({}), env: {}, logger: silent });
+    expect(r.ok).toBe(true);
+    expect(r.healed).toBe(false);
+    expect(r.currencyBypassed).toBe(false);
+  });
+
+  it('behind + clean + main SELF-HEALS, and the pull is actually issued', () => {
+    const calls = [];
+    const r = enforceTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4', calls }), env: {}, logger: silent });
+    expect(r.ok).toBe(true);
+    expect(r.healed).toBe(true);
+    // Positive discriminator: the ff-only pull is observable in the call log.
+    expect(calls.some((c) => c.startsWith('pull --ff-only'))).toBe(true);
+  });
+
+  it('behind + DIRTY REFUSES and never issues a pull', () => {
+    const calls = [];
+    expect(() => enforceTreeCurrency({
+      dir: '/x', runner: runnerFor({ behind: '4', dirty: ' M a.txt\n', calls }), env: {}, logger: silent,
+    })).toThrow(TreeStaleError);
+    // The tree must not be mutated — that is the peer-worktree clobber hazard.
+    expect(calls.some((c) => c.startsWith('pull'))).toBe(false);
+  });
+
+  it('behind + OFF-MAIN REFUSES and never issues a pull', () => {
+    const calls = [];
+    expect(() => enforceTreeCurrency({
+      dir: '/x', runner: runnerFor({ behind: '4', branch: 'feat/x', calls }), env: {}, logger: silent,
+    })).toThrow(/REFUSED/);
+    expect(calls.some((c) => c.startsWith('pull'))).toBe(false);
+  });
+
+  it('a git ERROR REFUSES — fail closed, never proceed on uncertainty', () => {
+    expect(() => enforceTreeCurrency({
+      dir: '/x', runner: () => { throw new Error('git exploded'); }, env: {}, logger: silent,
+    })).toThrow(TreeStaleError);
+  });
+
+  it('a fast-forward that does NOT converge still REFUSES', () => {
+    // Trusting the pull's exit code would repeat this SD's own root cause: verifying at
+    // the merge instead of at the consumer. Enforcement re-assesses afterwards.
+    const runner = runnerFor({ behind: '4', healTo: '4' }); // pull "succeeds" but nothing changes
+    expect(() => enforceTreeCurrency({ dir: '/x', runner, env: {}, logger: silent }))
+      .toThrow(/still not current after a fast-forward/);
+  });
+
+  it('the refusal message names the behind-count and the remedy', () => {
+    let msg = '';
+    try {
+      enforceTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '7', dirty: ' M a\n' }), env: {}, logger: silent });
+    } catch (e) { msg = e.message; }
+    expect(msg).toMatch(/7 commit/);
+    expect(msg).toMatch(/git pull --ff-only/);
+    expect(msg).toMatch(/FLEET_TREE_CURRENCY_BYPASS_REASON/);
+  });
+
+  it('the escape hatch is DEFAULT-OFF — a blank reason is not a bypass', () => {
+    expect(() => enforceTreeCurrency({
+      dir: '/x', runner: runnerFor({ behind: '4', dirty: ' M a\n' }), env: { [BYPASS_REASON_ENV]: '   ' }, logger: silent,
+    })).toThrow(TreeStaleError);
+  });
+
+  it('the escape hatch requires a REASON, and declares currency UNKNOWN rather than current', () => {
+    const warnings = [];
+    const r = enforceTreeCurrency({
+      dir: '/x',
+      runner: () => { throw new Error('offline'); },
+      env: { [BYPASS_REASON_ENV]: 'air-gapped host, incident 123' },
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.currencyBypassed).toBe(true);
+    // It must NOT claim the tree is current — the answer is unknown-and-declared.
+    expect(r.assessment).toBeNull();
+    expect(warnings.join(' ')).toMatch(/CURRENCY_BYPASSED/);
+    expect(warnings.join(' ')).toMatch(/air-gapped host, incident 123/);
+  });
+});

--- a/tests/unit/worktree-reaper/tick.test.js
+++ b/tests/unit/worktree-reaper/tick.test.js
@@ -10,10 +10,34 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const tickModPath = path.resolve(__dirname, '../../../scripts/fleet/worktree-reaper-tick.cjs');
+
+/**
+ * SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-3 added a fail-closed currency
+ * precondition: the tick refuses to reap from a tree it cannot prove is current, because
+ * the reaper's own script is loaded out of that tree and a deletion cannot be undone by a
+ * later error message.
+ *
+ * These fixtures use a bare temp directory, which is not a git repository, so the guard
+ * correctly refuses it — the guard working, not a regression. The three tests that
+ * exercise SPAWN MECHANICS (detached launch, single-flight, spawn-error handling) rather
+ * than currency inject a runner reporting a clean, current tree, to isolate the behaviour
+ * under test. Injecting it explicitly is deliberate: it keeps the new precondition visible
+ * in those tests rather than silently bypassed.
+ *
+ * Refusal itself is covered separately, in the FR-3 describe block at the end of this file.
+ */
+const CURRENT_RUNNER = (args) => {
+  if (args[0] === 'fetch') return '';
+  if (args.includes('--abbrev-ref')) return 'main\n';
+  if (args[0] === 'status') return '';
+  if (args[0] === 'rev-list') return '0\n';
+  return '';
+};
 
 // Each test gets a fresh require so state file writes stay isolated.
 function loadTickModule() {
@@ -154,7 +178,7 @@ describe('worktree-reaper-tick — out-of-band launch (SD-FDBK-INFRA-WORKTREE-RE
   it('AC-1: launches the reaper detached and returns result=spawned with a pid (does not block)', () => {
     writeFakeReaper(tmpRoot);
     const { tick } = loadTickModule();
-    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} });
+    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: CURRENT_RUNNER });
     expect(res.result).toBe('spawned');
     expect(typeof res.pid).toBe('number');
     const state = readStateFile(tmpRoot);
@@ -174,7 +198,7 @@ describe('worktree-reaper-tick — out-of-band launch (SD-FDBK-INFRA-WORKTREE-RE
       JSON.stringify({ schema_version: 1, sweep_counter: 11, last_run_at: null, last_result: 'spawned', last_pid: process.pid, last_spawn_at: new Date().toISOString() }),
     );
     const { tick } = loadTickModule();
-    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} });
+    const res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: CURRENT_RUNNER });
     expect(res.result).toBe('skipped_in_flight');
     expect(res.invoked).toBe(false);
   });
@@ -186,7 +210,7 @@ describe('worktree-reaper-tick — out-of-band launch (SD-FDBK-INFRA-WORKTREE-RE
     fs.writeFileSync(path.join(tmpRoot, '.claude'), 'not a directory');
     const { tick } = loadTickModule();
     let res;
-    expect(() => { res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {} }); }).not.toThrow();
+    expect(() => { res = tick({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: CURRENT_RUNNER }); }).not.toThrow();
     expect(res.result.startsWith('spawn_error')).toBe(true);
   });
 
@@ -197,5 +221,118 @@ describe('worktree-reaper-tick — out-of-band launch (SD-FDBK-INFRA-WORKTREE-RE
     expect(isPidAlive(0)).toBe(false);
     expect(isPidAlive(null)).toBe(false);
     expect(isPidAlive(-1)).toBe(false);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 FR-3 — REFUSE TO REAP FROM A STALE TREE.
+ *
+ * This is the destructive half of the SD. The tick resolves the reaper SCRIPT ITSELF out
+ * of repoRoot, so the reaper's code identity is that tree's HEAD. That is exactly how the
+ * reap-protected marker shipped inert: the guard existed on origin/main and was physically
+ * absent from the file being executed, and the reaper deleted a worktree the marker was
+ * supposed to protect.
+ *
+ * A deletion cannot be undone by a later error message, so failing loud after the fact is
+ * not available here — the only safe direction is to refuse before executing.
+ *
+ * SAFETY (SD correction C7): every case below runs against a TEMP directory with a FAKE
+ * reaper script. Nothing here runs git worktree add/remove against the real repo or
+ * invokes the real scripts/worktree-reaper.mjs. The chairman has an in-flight protected
+ * worktree; this suite must never be able to touch it.
+ */
+describe('FR-3: the reaper refuses to reap from a tree it cannot prove is current', () => {
+  const origEnv = { ...process.env };
+  let tmpRoot;
+
+  // A fake reaper that WRITES A SENTINEL when it runs. The assertion that matters is not
+  // just "result was refused" but that the reaper never executed at all.
+  function writeSentinelReaper(root) {
+    const dir = path.join(root, 'scripts');
+    fs.mkdirSync(dir, { recursive: true });
+    // JSON.stringify handles Windows path separators without hand-rolled escaping —
+    // a literal backslash in a generated script is an easy way to write a broken test.
+    const sentinel = JSON.stringify(path.join(root, 'REAPER_RAN.sentinel'));
+    fs.writeFileSync(
+      path.join(dir, 'worktree-reaper.mjs'),
+      `import fs from 'node:fs'; fs.writeFileSync(${sentinel}, 'ran'); process.exit(0);\n`,
+    );
+  }
+
+  const staleRunner = (args) => {
+    if (args[0] === 'fetch') return '';
+    if (args.includes('--abbrev-ref')) return 'main\n';
+    if (args[0] === 'status') return '';
+    if (args[0] === 'rev-list') return '7\n';   // 7 behind
+    if (args[0] === 'pull') throw new Error('pull must never be attempted by the reaper');
+    return '';
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-currency-'));
+    fs.mkdirSync(path.join(tmpRoot, '.claude'), { recursive: true });
+    process.env.WORKTREE_REAPER_ENABLED = 'true';
+  });
+  afterEach(() => {
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    process.env = { ...origEnv };
+  });
+
+  it('a BEHIND tree refuses, and the reaper never runs', async () => {
+    writeSentinelReaper(tmpRoot);
+    const tickFn = loadTickModule().tick;
+    const res = tickFn({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: staleRunner, currencyEnv: {} });
+    expect(res.result).toBe('refused_stale_tree');
+    expect(res.invoked).toBe(false);
+    // The load-bearing assertion: nothing was executed.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(fs.existsSync(path.join(tmpRoot, 'REAPER_RAN.sentinel'))).toBe(false);
+  });
+
+  it('a GIT ERROR refuses too — fail closed, never reap on uncertainty', async () => {
+    writeSentinelReaper(tmpRoot);
+    const tickFn = loadTickModule().tick;
+    const res = tickFn({
+      repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {},
+      currencyRunner: () => { throw new Error('git unavailable'); }, currencyEnv: {},
+    });
+    expect(res.result).toBe('refused_stale_tree');
+    await new Promise((r) => setTimeout(r, 60));
+    expect(fs.existsSync(path.join(tmpRoot, 'REAPER_RAN.sentinel'))).toBe(false);
+  });
+
+  it('the refusal is PERSISTED to state, so a stale reaper is visible after the fact', async () => {
+    writeSentinelReaper(tmpRoot);
+    const tickFn = loadTickModule().tick;
+    tickFn({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: staleRunner, currencyEnv: {} });
+    const state = JSON.parse(fs.readFileSync(path.join(tmpRoot, '.claude', 'worktree-reaper-state.json'), 'utf8'));
+    expect(state.last_result).toBe('refused_stale_tree');
+  });
+
+  it('the reaper NEVER attempts a self-heal pull — it refuses instead of mutating', async () => {
+    // The spawn seam may fast-forward a clean tree. The reaper must not: it runs
+    // unattended on a shared root and a mutation there could clobber a peer worktree.
+    writeSentinelReaper(tmpRoot);
+    const tickFn = loadTickModule().tick;
+    const calls = [];
+    const recording = (args) => { calls.push(args[0]); return staleRunner(args); };
+    const res = tickFn({ repoRoot: tmpRoot, cadence: 3, force: true, logger: () => {}, currencyRunner: recording, currencyEnv: {} });
+    expect(res.result).toBe('refused_stale_tree');
+    expect(calls).not.toContain('pull');
+  });
+
+  it('the canonical root fallback is used when no repoRoot is injected (not process.cwd)', async () => {
+    const tickFn = loadTickModule().tick;
+    // Called with no repoRoot from an arbitrary cwd. Whatever it resolves, it must NOT be
+    // the ambient cwd of this test process — that is the defect FR-3 removes.
+    const seen = [];
+    tickFn({
+      cadence: 3, force: true, logger: () => {},
+      currencyRunner: (args, o) => { seen.push(o && o.cwd); return staleRunner(args); },
+      currencyEnv: {},
+    });
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toBeTruthy();
+    expect(path.resolve(seen[0])).not.toBe(path.resolve(tmpRoot));
   });
 });

--- a/tests/unit/worktree-reaper/tick.test.js
+++ b/tests/unit/worktree-reaper/tick.test.js
@@ -333,6 +333,11 @@ describe('FR-3: the reaper refuses to reap from a tree it cannot prove is curren
     });
     expect(seen.length).toBeGreaterThan(0);
     expect(seen[0]).toBeTruthy();
-    expect(path.resolve(seen[0])).not.toBe(path.resolve(tmpRoot));
+    // C2: asserting "not tmpRoot" was VACUOUS — under vitest process.cwd() IS the repo
+    // root, so that assertion passed identically with the fix AND with the process.cwd()
+    // defect it was meant to catch. Assert the POSITIVE identity instead: the fallback
+    // must resolve from the MODULE's location, which is what makes it independent of
+    // wherever the caller happens to be standing.
+    expect(path.resolve(seen[0])).toBe(path.resolve(tickModPath, '..', '..', '..'));
   });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -135,6 +135,23 @@ export default defineConfig({
           name: 'unit',
           // NO dotenv .env load — unit tests must not reach the live DB.
           setupFiles: ['./tests/setup.unit.js'],
+          // SD-LEO-INFRA-SPAWN-ROOT-CURRENCY-INVARIANT-001 (post-CI RCA).
+          // Pin the fleet repo root to a path that does NOT exist, so the unit tier can
+          // never shell out to real git against the developer's actual checkout.
+          //
+          // The bug this closes: lib/fleet/build-session-launch.cjs resolves the spawn cwd
+          // from the MODULE's location, so the tier behaved differently depending on where
+          // the checkout physically lived. Running from .worktrees/ took the tree-currency
+          // guard's worktree exemption and skipped it entirely; running from a normal
+          // checkout ran it for real. 21 tests were green locally and red in CI for that
+          // reason alone, and nobody could have noticed locally.
+          //
+          // A nonexistent cwd makes execFileSync fail ENOENT immediately, with no network
+          // and no dependence on branch/dirty state — so a live spawn that forgets to
+          // inject opts.currencyRunner now fails FAST and IDENTICALLY on every machine.
+          // This is deliberately not a bypass: it makes nothing pass that would otherwise
+          // fail. It converts a hidden environmental accident into a loud, uniform one.
+          env: { FLEET_REPO_ROOT: './tests/fixtures/__no_such_tree__' },
           include: [
             '**/__tests__/**/*.test.js',
             '**/*.test.js',


### PR DESCRIPTION
## The defect

`spawn-control`, the worktree reaper and the fleet scripts all **execute from the repository root**, and nothing keeps the root current. `gh pr merge` merges *remotely*, so the root's HEAD does not move at merge time at all — it moves only when something later pulls. Every merge therefore re-stales the tree that spawns the next worker.

Measured 2026-07-25: **26 commits on `origin/main` in two hours, 111 in a day.**

Two subsystems were provably running code the fleet had already replaced:

1. **The canary fix (PR 6464)** — merged while the root was 6 behind. Canaries spawned in that window still inherited the marker the PR removed.
2. **The worktree-reaper opt-out marker** — the reaper *also* executes from the root, which contained **zero occurrences** of the marker-handling code. The protection was physically absent from the file being run, and the reaper deleted a worktree it existed to protect.

One root cause: **execution reads the root; verification reads `origin/main`.** Verifying a fix at the merge is not verifying it at the consumer.

## Two of the SD's own directions were refuted at LEAD

Recorded here because building to them would have wasted the work:

- **"Amend the doctrine that says a far-behind tree is acceptable."** No such doctrine exists — zero grep hits across tracked `md`/`js` for *hundreds-of-commits*, *code-truth*, *standby tree*, *oversight tree*, confirmed by a full-row sweep of all 282 `leo_protocol_sections` rows. What exists says the opposite, but is advisory, self-described measure-only, and fail-open. The deliverable became **create** the discriminator and make the check enforcing.
- **"Event-driven pull-on-merge."** Structurally impossible: no local merge occurs, so a `post-merge` hook can never fire. That remedy would have shipped **zero firings** — the exact inert shape this SD exists to kill.

Also weaker than believed: the interim mitigation is `script: null` (a *prompt*, not code) on a **2-hour** cron that excludes itself whenever the root is dirty — which is its chronic state. Not removed here.

## What shipped

| FR | Change |
|----|--------|
| FR-1 | `lib/fleet/tree-currency.cjs` — fail-closed currency assessment |
| FR-2 | Spawn seam self-heals when safe, **refuses** otherwise |
| FR-3 | Reaper resolves a canonical root and **refuses to reap** from a stale tree |
| FR-4 | The standby-vs-execution-source discriminator, written down |
| FR-5 | The coverage boundary, including what is **not** fixed |

**Fail-closed is the point.** Git missing, remote unreachable, timeout, detached HEAD, unparseable output, not-a-repository — every one yields NOT-current. No branch returns "current" on uncertainty. That is the deliberate inverse of `checkout-freshness.js`, which returns FRESH on any git error; it is left **untouched** because five advisory consumers depend on its current behaviour.

**The reaper refuses and never heals.** A failing assertion drove that: my first cut reused the shared enforcement, which self-heals a clean tree, so the reaper attempted a pull. It runs unattended against a shared root where a mutation can collide with a peer, and skipping a reap costs nothing since the next tick retries. A deletion cannot be undone by a later error message. Destructive subsystems refuse; they do not fix.

**The fast-forward is re-assessed, not trusted.** Believing the pull's exit code would repeat this SD's own root cause.

**The escape hatch costs something.** `FLEET_TREE_CURRENCY_BYPASS_REASON` is keyed on a *reason*, not a boolean — an operator cannot silence it with `FLAG=1`. Default OFF, blank is not a bypass, and when used the answer is **unknown-and-declared**, never "current". It exists because fail-closed on git error would otherwise make an offline host or expired credential render the whole fleet unspawnable.

## Placement constraints that shaped the design

`buildSessionLaunch` is **synchronous** and `reboot-respawn-runner` does not await it, so an async precondition inside the builder would have handed a Promise to production and run real git inside the unit tier. The assertion lives at the spawn **execution** seams instead. Similarly, `opts.repoRoot` on the reaper tick is **preserved** — only the fallback changed — because 12 tests depend on that injection seam.

## Coverage boundary — what this does NOT fix

Stated explicitly, because an unstated boundary is how a partial fix gets reported as complete:

- Spawns issued from **inside** a `.worktrees/` tree — legitimately off-main by construction; guarding it would refuse every worktree spawn while proving nothing.
- ~25 coordinator `STANDARD_LOOPS` running bare `node scripts/…` at coordinator cwd.
- `scripts/cron/eva-watcher-task.cmd` — hardcoded root in Task Scheduler, which a spawn-time assertion **structurally cannot reach**.
- The ~36 `CLAUDE_PROJECT_DIR` hooks; exactly one redirects to the canonical root.

The invariant should not be described as fleet-wide until these close.

## Testing

**Full unit tier: 30,559 passed / 1 failed** across 2,594 files. The single failure is a pre-existing CRLF issue in `witness-emitter-acceptance`, unrelated to this branch.

The adversarial test (TS-1) builds a **real git repository**, rewinds it, and asserts a **positive discriminator** — an identifiable refusal, or an observed `pull --ff-only` that genuinely converges behind to 0. A bare `not.toThrow()` would be a test failure. It uses a hermetic synthetic repo (~1.5s) because CI checks out at `fetch-depth: 1`, so rewinding *this* repo cannot run there.

Baselines held: spawn-contract **113/113 with zero edits**; reaper **149 passed / 7 failed** against a pre-existing 144/7 — the same seven known failures (one incomplete supabase double, in a project CI never runs).

No test in this SD runs `git worktree add/remove` against the real repo or invokes the real reaper with a real root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
