### PR TITLE
fix(QF-20260725-743): Apply the agreed 72h resurface threshold: --threshold-hours 72 on the ledger-resurface cron (interim, expires 2026-07-27T09:59Z)

### DIFF
--- a/.github/workflows/solomon-ledger-resurface-cron.yml
+++ b/.github/workflows/solomon-ledger-resurface-cron.yml
@@ -42,4 +42,15 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Resurface aged Solomon ledger rows
-        run: node scripts/solomon-ledger-pending-resurface.cjs
+        # QF-20260725-743 — INTERIM 72h override, EXPIRES ~2026-07-27T09:59Z.
+        # Explicit at the call site (NOT a change to DEFAULT_THRESHOLD_HOURS, which stays 24)
+        # so the mitigation is visible and trivially reversible — delete the flag to revert.
+        # Grounding: Solomon measured disposition latency p50 37.5h / p75 77.2h, with only 26%
+        # of 507 disposed rows clearing within 24h; 72h tracks p75. At 24h, ~28 rows/day
+        # resurfaced into a 50-row oldest-first window and displaced live directed messages
+        # (three incidents 2026-07-25; the worst let a RETRACTED finding reach an already-
+        # completed governance SD because the retraction sat behind 27 resurface rows).
+        # This is a MITIGATION, not the fix: SD-LEO-INFRA-RESURFACE-DIGEST-BATCHING-001
+        # (digest batching) is the actual fix and must land before the expiry above, when the
+        # oldest pending row crosses 72h and resurfacing resumes.
+        run: node scripts/solomon-ledger-pending-resurface.cjs --threshold-hours 72


### PR DESCRIPTION
## Quick-Fix: QF-20260725-743

**Type:** bug
**Severity:** high

### Issue Description
ONE LINE. Add --threshold-hours 72 to the script invocation in .github/workflows/solomon-ledger-resurface-cron.yml. Do NOT change DEFAULT_THRESHOLD_HOURS in the script - the coordinator directed this be EXPLICIT AND INTERIM at the call site so it is visible and trivially reversible, not a buried default change. WHY THIS QF EXISTS AT ALL: 72h was agreed by three parties on 2026-07-25 - the coordinator proposed 48, Solomon measured disposition latency (p50 37.5h, p75 77.2h, only 26 percent of 507 disposed rows clear within 24h) and proposed 72, the coordinator accepted 72 on the p75 grounding. The number was agreed, justified and recorded in conversation. NOBODY WAS ASSIGNED TO WRITE IT. Verified 2026-07-25 19:24: DEFAULT_THRESHOLD_HOURS is still 24 at line 17 on origin/main and locally, and the cron passes no override. A DECISION WITH NO OWNER IS NOT A CHANGE - that is why this is a row rather than another agreement. ACTIVE HARM, NOT THEORETICAL: at 24h roughly 28 rows/day resurface into a 50-row oldest-first inbox window. Three displacement incidents on 2026-07-25, the worst of which let a RETRACTED finding be written into an already-completed governance SD because the retraction sat behind 27 resurface rows for 39 seconds. The Adam inbox backlog rose 85 to 118 in seven minutes during one resurface run while this was being discussed. NOTHING ACTIONABLE GETS HIDDEN: Solomon named five live items (S7 acceptance bar, two S7 gaps, reconcile-witness backfill, seat-vs-work inversion, scope-vs-diff sampling) and all are under 24h, so they were never resurfacing at any of these thresholds. The change asserts nothing false and is one line to revert. WHY NOT SKIP IT SINCE THE DIGEST SD IS IN FLIGHT: because the-digest-is-in-flight is not the-digest-has-landed. That SD is at LEAD. Declining a live mitigation on the strength of a build whose landing time nobody knows is the same reasoning error as agreed-is-not-applied and merged-is-not-running. EXPIRY, STATED SO THE MITIGATION CANNOT QUIETLY BECOME THE FIX: the oldest pending row is 32.7h, so it crosses 72h at approximately 2026-07-27T09:59Z and resurfacing resumes then. SD-LEO-INFRA-RESURFACE-DIGEST-BATCHING-001 (the digest) is the actual fix and must land before that.

### Steps to Reproduce
1. Open .github/workflows/solomon-ledger-resurface-cron.yml. 2. Change the run line to: node scripts/solomon-ledger-pending-resurface.cjs --threshold-hours 72. 3. Leave DEFAULT_THRESHOLD_HOURS at 24 in the script.

### Expected Behavior
The cron invokes with an explicit 72h threshold; rows younger than 72h stop resurfacing; the override is visible at the call site.

### Actual Behavior
The cron passes no threshold, so the 24h default applies and ~28 rows/day resurface, displacing live directed messages from a 50-row window.

### Changes
- **Files Changed:** 1
  - .github/workflows/solomon-ledger-resurface-cron.yml
- **LOC:** 12 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol