### PR TITLE
fix(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): act on the adversarial review — 5 findings, 3 of them mine

### DIFF
--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -72,8 +72,21 @@ async function defaultWriteLifecycleEvent(supabase, event) {
  * durable-recovery).
  * @returns {Promise<string|null>} the reconciled session_id, or null if never bound within budget.
  */
-async function reconcileSpawnedSession(supabase, pid, opts = {}) {
-  if (!supabase || !pid) return null;
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 follow-up (TESTING adversarial review F1): this used to look the
+ * spawned session up by `.eq('pid', pid)` ONLY -- the same dead join FR-3 replaced in spawn-control.js.
+ * `pid` here is the wt.exe LAUNCHER pid, already exited, while claude_sessions.pid holds the CLAUDE CODE
+ * pid, so it could never match. FR-3 taught the runner to MINT and emit `claude --session-id <uuid>`
+ * (reboot-respawn-runner.js buildInvocationFn call) but stopped short of consuming it here, so
+ * payload.live, session_id and the QF-20260724-070 RESPAWN_BIND_VERIFIED audit all still rode on a join
+ * that build-session-launch.cjs itself documents as unmatched. Correct argv, dead correlation -- this
+ * SD's own defect, one module over.
+ *
+ * Now prefers the MINTED session id and keeps pid only as a fallback for a caller that minted none.
+ * @param {{pid:number|null, sessionId:string|null}} ids
+ */
+async function reconcileSpawnedSession(supabase, { pid, sessionId } = {}, opts = {}) {
+  if (!supabase || (!pid && !sessionId)) return null;
   let checkNewSessionHealth;
   try {
     ({ checkNewSessionHealth } = await import('../coordinator/singleton-refresh-sequencer.cjs'));
@@ -86,8 +99,13 @@ async function reconcileSpawnedSession(supabase, pid, opts = {}) {
   const nowFn = opts.now || (() => new Date().toISOString());
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const { data: session } = await supabase.from('claude_sessions')
-        .select('session_id, heartbeat_at, loop_state').eq('pid', pid).maybeSingle();
+      // Prefer the spawner-MINTED id: the child registers under exactly that value, so this is a
+      // direct lookup rather than a join against a launcher pid that has already exited.
+      const { data: session } = sessionId
+        ? await supabase.from('claude_sessions')
+          .select('session_id, heartbeat_at, loop_state').eq('session_id', sessionId).maybeSingle()
+        : await supabase.from('claude_sessions')
+          .select('session_id, heartbeat_at, loop_state').eq('pid', pid).maybeSingle();
       if (checkNewSessionHealth(session, { nowMs, freshMs }).healthy) {
         await writeLifecycleEventFn(supabase, {
           event_type: 'RESPAWN_BIND_VERIFIED',
@@ -174,7 +192,11 @@ export async function runRebootRespawn(opts = {}) {
 
     // QF-20260724-911: payload.live is derived FROM ground-truth reconciliation, not from spawnFn()
     // having returned without throwing -- see reconcileSpawnedSession() above.
-    const sessionId = spawned && child && child.pid ? await reconcileSpawnedSession(supabase, child.pid, opts) : null;
+    // F1: pass the MINTED id (invocation.sessionId) alongside the launcher pid so reconciliation
+    // joins on the value the child actually registers under.
+    const sessionId = spawned && child && child.pid
+      ? await reconcileSpawnedSession(supabase, { pid: child.pid, sessionId: invocation.sessionId }, opts)
+      : null;
     const boundLive = sessionId !== null;
     const outcome = boundLive ? 'ok' : (spawned ? 'respawn_unbound' : 'dry_run');
 

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -63,7 +63,7 @@ function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, 
  * The command is a CONSTANT — zero interpolation, so there is no injection surface at all (contrast
  * buildHandleCaptureCommand above, which must coerce a pid).
  */
-export const WINDOW_ENUM_COMMAND = "Add-Type -TypeDefinition 'using System;using System.Text;using System.Collections.Generic;using System.Runtime.InteropServices;public class FleetEnum{public delegate bool EnumProc(IntPtr h,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool EnumWindows(EnumProc cb,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool IsWindowVisible(IntPtr h);[DllImport(\"user32.dll\")] public static extern int GetWindowTextLength(IntPtr h);[DllImport(\"user32.dll\",CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h,StringBuilder s,int n);[DllImport(\"user32.dll\")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint pid);public static List<string> List(){var r=new List<string>();EnumWindows((h,l)=>{if(IsWindowVisible(h)){uint p;GetWindowThreadProcessId(h,out p);int len=GetWindowTextLength(h);var sb=new StringBuilder(len+1);GetWindowText(h,sb,sb.Capacity);r.Add(h.ToInt64()+\"|\"+p+\"|\"+sb.ToString());}return true;},IntPtr.Zero);return r;}}'; [FleetEnum]::List() | ForEach-Object { $f = $_.Split([char]124); $n = (Get-Process -Id ([int]$f[1]) -ErrorAction SilentlyContinue).ProcessName; \"$($f[0])|$($f[1])|$n|$($f[2])\" }";
+export const WINDOW_ENUM_COMMAND = "Add-Type -TypeDefinition 'using System;using System.Text;using System.Collections.Generic;using System.Runtime.InteropServices;public class FleetEnum{public delegate bool EnumProc(IntPtr h,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool EnumWindows(EnumProc cb,IntPtr l);[DllImport(\"user32.dll\")] public static extern bool IsWindowVisible(IntPtr h);[DllImport(\"user32.dll\")] public static extern int GetWindowTextLength(IntPtr h);[DllImport(\"user32.dll\",CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h,StringBuilder s,int n);[DllImport(\"user32.dll\")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint pid);public static List<string> List(){var r=new List<string>();EnumWindows((h,l)=>{if(IsWindowVisible(h)){uint p;GetWindowThreadProcessId(h,out p);int len=GetWindowTextLength(h);var sb=new StringBuilder(len+1);GetWindowText(h,sb,sb.Capacity);r.Add(h.ToInt64()+\"|\"+p+\"|\"+sb.ToString());}return true;},IntPtr.Zero);return r;}}'; [FleetEnum]::List() | ForEach-Object { $f = $_.Split([char]124); $n = (Get-Process -Id ([int]$f[1]) -ErrorAction SilentlyContinue).ProcessName; $t = $f[2] -replace '[\\r\\n]',' '; \"$($f[0])|$($f[1])|$n|$t\" }";
 
 /** The host process that owns fleet session windows. Windows Terminal, not the launcher. */
 export const TERMINAL_PROCESS_NAME = 'WindowsTerminal';
@@ -93,13 +93,24 @@ export function buildWindowEnumCommand() {
 /**
  * Parse enumeration stdout into rows. Pure. Shape per line: `handle|pid|processName|title`.
  *
- * Real-capture edge cases this handles (all present in the committed fixture, none hypothetical):
+ * OBSERVED in the committed real capture (tests/unit/fleet/window-enum.test.js):
  *   - an EMPTY title (11 of 17 rows) — a row is still valid; titles are not required
  *   - a process name containing a SPACE ("Wispr Flow") — so never tokenize on whitespace
- *   - a title that itself contains "|" — the split is LIMITED to 4 fields so the remainder stays
- *     in the title rather than silently truncating the row or dropping it
+ *
+ * DEFENSIVE, not observed in that capture — corrected after a TESTING review caught this comment
+ * claiming all four cases were "all present in the committed fixture, none hypothetical". The fixture
+ * has exactly 3 pipes per row and no non-numeric handle, so these two are constructed cases:
+ *   - a title containing "|" — everything after the 3rd separator is rejoined into the title rather
+ *     than truncating the row or dropping it
  *   - a non-numeric or absent handle — the row is DROPPED rather than yielding NaN, which would
  *     otherwise poison the set difference
+ *
+ * SECURITY (SEC-CANHOST-01): a window title is attacker-controllable by any unprivileged local process
+ * and may contain CR/LF. Emitted verbatim it would split one window across two output lines, letting a
+ * hostile title FORGE an extra row — demonstrated to yield {handle:99999, reason:'ok'}, defeating the
+ * fail-closed contract (bounded: a handle only ever reaches SetForegroundWindow as a coerced IntPtr, so
+ * no code execution). The emitter now strips CR/LF from the title before output, so one window is
+ * always exactly one line.
  * @returns {Array<{handle:number, pid:number|null, proc:string, title:string}>}
  */
 export function parseWindowListOutput(stdout) {

--- a/scripts/fleet/provision-canary.mjs
+++ b/scripts/fleet/provision-canary.mjs
@@ -27,10 +27,19 @@
  * instead of a re-run. Discoverability closes when FR-3 fixes correlation and stamps the fresh-spawn
  * path; this CLI is its prerequisite and its instrument, not its completion.
  *
- * SAFETY: dry-run is the DEFAULT. --live is an explicit opt-in that this module never infers, and it
- * only reaches spawn-control, which self-gates behind FLEET_SPAWN_CONTROL_LIVE. Running the CP3 drill
- * is NOT in scope and this file cannot start one — it never imports start-cp3-drills.js, canaryRestart,
- * runRebootRespawnDrill or runU4Drill.
+ * SAFETY: dry-run is the DEFAULT. --live is an explicit opt-in that this module never infers.
+ *
+ * CORRECTION (SECURITY adversarial review, SEC-CANHOST-02): an earlier version of this comment claimed
+ * --live "only reaches spawn-control, which self-gates behind FLEET_SPAWN_CONTROL_LIVE". THAT WAS FALSE
+ * and it was the dangerous kind of false — a safety claim on an operator-facing CLI. canary-provision.js
+ * forwards `live` as opts.live, and spawn-control.js reads `opts.live ?? isLiveEnabled()`, so an explicit
+ * opt OVERRIDES the env gate. `provision-canary.mjs --live` really did spawn with
+ * FLEET_SPAWN_CONTROL_LIVE unset. The `??` override is pre-existing and used deliberately elsewhere, so
+ * rather than change that shared semantic, THIS CLI now requires BOTH: the --live flag AND
+ * FLEET_SPAWN_CONTROL_LIVE=true. The comment is now true of this entrypoint because the code enforces it.
+ *
+ * Running the CP3 drill is NOT in scope and this file cannot start one — it never imports
+ * start-cp3-drills.js, canaryRestart, runRebootRespawnDrill or runU4Drill.
  */
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -87,8 +96,21 @@ export function classifyProvisionOutcome(result) {
  */
 export async function main(argv = process.argv.slice(2), deps = {}) {
   const log = deps.log || ((m) => console.log(m));
-  const live = argv.includes('--live');
   const provision = deps.provisionFn || provisionCanary;
+
+  // SEC-CANHOST-02: BOTH conditions required. --live alone would override spawn-control's env gate
+  // (`opts.live ?? isLiveEnabled()`), so the flag by itself is not the second factor it reads as.
+  const env = deps.env || process.env;
+  const requestedLive = argv.includes('--live');
+  const envAllowsLive = String(env.FLEET_SPAWN_CONTROL_LIVE || '').toLowerCase() === 'true';
+  const live = requestedLive && envAllowsLive;
+  if (requestedLive && !envAllowsLive) {
+    // Refuse rather than silently downgrading to dry-run: an operator who typed --live and got a
+    // "DRY-RUN" line could easily read it as "it ran". Say exactly which factor is missing.
+    log('[provision-canary] REFUSING --live: FLEET_SPAWN_CONTROL_LIVE is not set to true.');
+    log('[provision-canary] Both are required. Nothing was spawned.');
+    return { ok: false, exitCode: EXIT.INFRA, status: 'infra', reason: 'live_requires_env_gate' };
+  }
 
   // Client is constructed INSIDE main and only when not injected — the unit project does not load
   // .env and CI has no secrets, so a module-scope client would red the whole file in CI.

--- a/tests/unit/fleet/provision-canary-cli.test.js
+++ b/tests/unit/fleet/provision-canary-cli.test.js
@@ -100,14 +100,44 @@ describe('FR-1 provision-canary — real resolution, not a stubbed verdict', () 
     expect(r.exitCode).toBe(EXIT.GATE_UNMET);
   });
 
-  it('passes live:true through only when --live is given explicitly', async () => {
+  it('passes live:true only when --live AND FLEET_SPAWN_CONTROL_LIVE are BOTH present', async () => {
     let seenLive = null;
     await main(['--live'], {
       supabase: fakeSupabase({ sessions: [], slots: [CANARY_SLOT] }),
+      env: { FLEET_SPAWN_CONTROL_LIVE: 'true' },
       provisionFn: async (args) => { seenLive = args.live; return { ok: true, reason: 'provisioned' }; },
       log: silent,
     });
     expect(seenLive).toBe(true);
+  });
+
+  it('SEC-CANHOST-02: REFUSES --live when FLEET_SPAWN_CONTROL_LIVE is unset, and never reaches provision', async () => {
+    // The original docstring claimed --live "only reaches spawn-control, which self-gates behind
+    // FLEET_SPAWN_CONTROL_LIVE". That was FALSE: canary-provision forwards live as opts.live and
+    // spawn-control reads `opts.live ?? isLiveEnabled()`, so the explicit opt OVERRIDES the env gate --
+    // `--live` alone really did spawn. A false safety claim on an operator-facing CLI is the dangerous
+    // kind. This CLI now enforces both factors, which is what makes the comment true.
+    let reachedProvision = false;
+    const r = await main(['--live'], {
+      supabase: fakeSupabase({ sessions: [], slots: [CANARY_SLOT] }),
+      env: {}, // FLEET_SPAWN_CONTROL_LIVE unset
+      provisionFn: async () => { reachedProvision = true; return { ok: true, reason: 'provisioned' }; },
+      log: silent,
+    });
+    expect(reachedProvision, 'must not spawn when only one factor is present').toBe(false);
+    expect(r.reason).toBe('live_requires_env_gate');
+    expect(r.exitCode).toBe(EXIT.INFRA);
+  });
+
+  it('SEC-CANHOST-02: REFUSES rather than silently downgrading to dry-run', async () => {
+    // Downgrading would be the tempting fail-safe, but an operator who typed --live and saw "DRY-RUN"
+    // could reasonably read it as "it ran". A non-zero exit and an explicit refusal cannot be misread.
+    const r = await main(['--live'], {
+      supabase: fakeSupabase({ sessions: [], slots: [CANARY_SLOT] }),
+      env: {}, provisionFn: async () => ({ ok: false, reason: 'dry_run' }), log: silent,
+    });
+    expect(r.reason).not.toBe('dry_run');
+    expect(r.ok).toBe(false);
   });
 });
 

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -109,22 +109,53 @@ describe('runRebootRespawn (QF-20260724-911): payload.live is ground-truth-recon
     return {
       from: (table) => {
         if (table !== 'claude_sessions') throw new Error(`unexpected table: ${table}`);
-        return { select: () => ({ eq: (_col, pid) => ({ maybeSingle: async () => ({ data: sessionsByPid[pid] || null }) }) }) };
+        // FR-3 follow-up (TESTING adversarial review F2): this fake USED to be `eq: (_col, pid)`,
+        // discarding the column name. A mutation to .eq('utterly_bogus_column_xyz', pid) stayed 13/13
+        // GREEN, so no test on this path could detect a join-column error -- which is exactly why the
+        // dead pid join here survived FR-3. Recording the column makes that detectable.
+        return { select: () => ({ eq: (col, val) => ({ maybeSingle: async () => {
+          if (col !== 'session_id' && col !== 'pid') throw new Error(`unexpected join column: ${col}`);
+          const row = col === 'session_id'
+            ? Object.values(sessionsByPid).find((r) => r && r.session_id === val)
+            : sessionsByPid[val];
+          return { data: row || null };
+        } }) }) };
       },
     };
   }
 
+  it('F1: reconciles by the MINTED session id, not by the wt.exe launcher pid', async () => {
+    // THE DISCRIMINATING FIXTURE, and the reason F1 went unnoticed: every other fixture in this file
+    // keys the row on the SAME pid spawnFn returns, so a pid join and a session_id join give identical
+    // results and no test can tell them apart. Here they DISAGREE -- the row carries a different pid,
+    // which is the real-world case (wt.exe exits; claude_sessions.pid is the Claude Code pid). A pid
+    // join finds nothing and reports respawn_unbound; the minted-id join binds.
+    const nowMs = 1_800_000_000_000;
+    const supabase = makeFakeSupabase({
+      999999: { session_id: MINTED, heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' },
+    });
+    const events = [];
+    const res = await runRebootRespawn({
+      supabase, loadFn: async () => [SLOTS[1]], // slot 2 has no resume token -> an id IS minted
+      spawnFn: vi.fn(() => ({ pid: 111 })),     // launcher pid 111 != the row's pid 999999
+      logFn: vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; }),
+      live: true, now: () => 'iso', sleepFn: vi.fn(), nowMs, uuidFn: () => MINTED,
+    });
+    expect(res.results[0]).toMatchObject({ spawned: true, live: true, session_id: MINTED });
+    expect(events[0].payload).toMatchObject({ live: true, outcome: 'ok' });
+  });
+
   it('binds session_id + live:true + outcome:ok when the spawned pid reconciles to a fresh, heartbeating session', async () => {
     const nowMs = 1_800_000_000_000;
-    const supabase = makeFakeSupabase({ 111: { session_id: 's-new', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
+    const supabase = makeFakeSupabase({ 111: { session_id: 'u-1', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
     const spawnFn = vi.fn(() => ({ pid: 111 }));
     const events = [];
     const logFn = vi.fn(async (_s, ev) => { events.push(ev); return { ok: true }; });
     const res = await runRebootRespawn({
       supabase, loadFn: async () => [SLOTS[0]], spawnFn, logFn, live: true, now: () => 'iso', sleepFn: vi.fn(), nowMs,
     });
-    expect(res.results[0]).toMatchObject({ spawned: true, live: true, session_id: 's-new' });
-    expect(events[0].session_id).toBe('s-new');
+    expect(res.results[0]).toMatchObject({ spawned: true, live: true, session_id: 'u-1' });
+    expect(events[0].session_id).toBe('u-1');
     expect(events[0].payload).toMatchObject({ live: true, outcome: 'ok' });
   });
 
@@ -184,14 +215,24 @@ describe('runRebootRespawn (QF-20260724-070): durable bind-time audit row', () =
     return {
       from: (table) => {
         if (table !== 'claude_sessions') throw new Error(`unexpected table: ${table}`);
-        return { select: () => ({ eq: (_col, pid) => ({ maybeSingle: async () => ({ data: sessionsByPid[pid] || null }) }) }) };
+        // FR-3 follow-up (TESTING adversarial review F2): this fake USED to be `eq: (_col, pid)`,
+        // discarding the column name. A mutation to .eq('utterly_bogus_column_xyz', pid) stayed 13/13
+        // GREEN, so no test on this path could detect a join-column error -- which is exactly why the
+        // dead pid join here survived FR-3. Recording the column makes that detectable.
+        return { select: () => ({ eq: (col, val) => ({ maybeSingle: async () => {
+          if (col !== 'session_id' && col !== 'pid') throw new Error(`unexpected join column: ${col}`);
+          const row = col === 'session_id'
+            ? Object.values(sessionsByPid).find((r) => r && r.session_id === val)
+            : sessionsByPid[val];
+          return { data: row || null };
+        } }) }) };
       },
     };
   }
 
   it('writes an immutable RESPAWN_BIND_VERIFIED session_lifecycle_events row the instant the bind is confirmed healthy', async () => {
     const nowMs = 1_800_000_000_000;
-    const supabase = makeFakeSupabase({ 111: { session_id: 's-new', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
+    const supabase = makeFakeSupabase({ 111: { session_id: 'u-1', heartbeat_at: new Date(nowMs - 1000).toISOString(), loop_state: 'active' } });
     const spawnFn = vi.fn(() => ({ pid: 111 }));
     const auditEvents = [];
     const writeLifecycleEventFn = vi.fn(async (_s, ev) => { auditEvents.push(ev); return true; });
@@ -201,7 +242,7 @@ describe('runRebootRespawn (QF-20260724-070): durable bind-time audit row', () =
     });
     expect(auditEvents).toHaveLength(1);
     expect(auditEvents[0]).toMatchObject({
-      event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-new', pid: 111,
+      event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'u-1', pid: 111,
       metadata: { heartbeat_at: expect.any(String), loop_state: 'active', sd_key: 'CHECKPOINT-3', checked_at: 'iso-checked-at' },
     });
   });

--- a/tests/unit/fleet/window-enum.test.js
+++ b/tests/unit/fleet/window-enum.test.js
@@ -269,8 +269,14 @@ describe('FR-7 captureNewWindowHandle — bounded budget, asserted by call count
     // and orphaned unstamped sessions. The new path preserves it structurally (enumerateWindows
     // swallows and returns [], selectNewWindowHandle is pure and total), and this proves it.
     const execFn = vi.fn().mockRejectedValue(new Error('powershell is not recognized'));
-    await expect(captureNewWindowHandle([], { execFn, sleepFn: vi.fn() })).resolves.toMatchObject({
+    const sleepFn = vi.fn();
+    await expect(captureNewWindowHandle([], { execFn, sleepFn })).resolves.toMatchObject({
       handle: null, handleCaptureFailed: true,
     });
+    // THE RETRY-BUDGET HALF, restored after a TESTING review found it lost in the FR-7 deletion. The
+    // never-throws assertion alone is insufficient: enumerateWindows swallows a rejection into [], so a
+    // reject is indistinguishable from "no windows yet" and a change that BROKE the loop on error would
+    // keep the assertion above green while silently spending one attempt instead of the full budget.
+    expect(execFn).toHaveBeenCalledTimes(CAPTURE_POLL_MAX_ATTEMPTS);
   });
 });

--- a/tests/unit/worker-checkin-canary-identity-skip.test.js
+++ b/tests/unit/worker-checkin-canary-identity-skip.test.js
@@ -30,7 +30,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
  * Fake covering only the shapes this function touches. RECORDS every update so a silent rename is
  * detectable -- asserting the return value alone would miss a write that clobbers the stored identity.
  */
-function fakeClient(metadata, { live = [] } = {}) {
+function fakeClient(metadata, { live = [], onLiveQuery } = {}) {
   const updates = [];
   return {
     updates,
@@ -39,10 +39,13 @@ function fakeClient(metadata, { live = [] } = {}) {
         select: () => builder,
         eq: () => builder,
         neq: () => builder,
-        gte: async () => ({ data: live }),
+        // The slot-picking query over live sessions. Instrumented because REACHING it is what
+        // distinguishes "fell through to re-derive" from "short-circuited by the canary branch" --
+        // the returned callsign cannot tell those apart.
+        gte: async () => { if (onLiveQuery) onLiveQuery(); return { data: live }; },
         maybeSingle: async () => ({ data: { metadata }, error: null }),
         update: (patch) => { updates.push(patch); return { eq: async () => ({ error: null }) }; },
-        then: (resolve) => Promise.resolve({ data: live, error: null }).then(resolve),
+        then: (resolve) => { if (onLiveQuery) onLiveQuery(); return Promise.resolve({ data: live, error: null }).then(resolve); },
       };
       return builder;
     },
@@ -108,14 +111,35 @@ describe('FR-6 canary identity skip — the second clobber writer', () => {
     expect(canaryLine).toBeLessThan(tierBandLine);
   });
 
-  it('does NOT skip an ordinary worker (the guard must stay narrow)', async () => {
-    // Negative control: an over-broad guard would freeze every worker's identity and silently disable
-    // the tier-band self-heal this function exists to perform.
-    const client = fakeClient({ fleet_identity: { callsign: 'Delta', color: 'red' }, tier_rank: 1 });
-    const r = await assignFleetIdentityAtCheckin(client, 'sess-worker-1', null);
-    // Either it returned the in-band identity, or it re-derived -- but it must NOT be short-circuited
-    // by the canary branch, which would return 'Delta' without consulting the tier band at all.
-    expect(r === null || typeof r.callsign === 'string').toBe(true);
-    expect(r?.callsign).not.toBe('Canary-1');
+  it('does NOT skip an ordinary worker — the guard must stay narrow', async () => {
+    // THIS CONTROL WAS VACUOUS AND A TESTING REVIEW PROVED IT. The original asserted
+    //   expect(r === null || typeof r.callsign === 'string').toBe(true)   // tautology
+    //   expect(r?.callsign).not.toBe('Canary-1')                          // never true for a 'Delta' fixture
+    // Widening the guard to `if (existing || ...)` — which freezes EVERY worker's identity and disables
+    // the tier-band self-heal this function exists to perform — still passed 5/5. A negative control
+    // that cannot fail is worse than none: it advertises coverage that does not exist.
+    //
+    // The real discriminator is REACHABILITY, not the returned value. The canary branch returns BEFORE
+    // the live-identity query used to pick a free slot; an ordinary worker must reach that query. So we
+    // record whether it happened rather than inspecting the callsign.
+    let reachedLiveQuery = false;
+    const client = fakeClient(
+      { fleet_identity: { callsign: 'Delta', color: 'red' }, tier_rank: 1 },
+      { onLiveQuery: () => { reachedLiveQuery = true; } },
+    );
+    await assignFleetIdentityAtCheckin(client, 'sess-worker-1', null);
+    expect(reachedLiveQuery, 'an ordinary worker must NOT be short-circuited by the canary branch').toBe(true);
+  });
+
+  it('a CANARY is short-circuited before that same query (the positive half of the control)', async () => {
+    // Pairs with the test above: same instrumentation, opposite expectation. Together they pin that the
+    // branch is taken for exactly one of the two, which neither test alone establishes.
+    let reachedLiveQuery = false;
+    const client = fakeClient(
+      { fleet_identity: { callsign: 'Canary-1', color: 'yellow' }, tier_rank: 1 },
+      { onLiveQuery: () => { reachedLiveQuery = true; } },
+    );
+    await assignFleetIdentityAtCheckin(client, CANARY_ID, null);
+    expect(reachedLiveQuery, 'a canary must return before the slot-picking query').toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #6474 / #6475. The TESTING and SECURITY sub-agents were asked to **attack** the merged work rather than confirm it. They did, and these are worth fixing rather than handing to PLAN.

---

## F1 (HIGH) — this SD's own defect, recurring one module over

FR-3 taught `reboot-respawn-runner.js` to mint and emit `claude --session-id <uuid>`, but `reconcileSpawnedSession` still looked the child up with **`.eq('pid', pid)`** — the same dead join FR-3 removed from `spawn-control.js`.

That pid is the **wt.exe launcher** pid, already exited, while `claude_sessions.pid` holds the Claude Code pid. So `payload.live`, `session_id`, and the QF-20260724-070 `RESPAWN_BIND_VERIFIED` durable audit all rode on a join that `build-session-launch.cjs` itself documents as unmatched. **Correct argv, dead correlation.**

Now prefers the minted id; pid stays only as a fallback for a caller that minted none.

## F2 (HIGH) — why F1 survived my own FR-3 sweep

The fakes at `reboot-respawn-runner.test.js:110/:185` were `eq: (_col, pid) => …`, **discarding the column name**. The reviewer mutated the join to `.eq('utterly_bogus_column_xyz', pid)` and got **13/13 green** — no test on that path could detect *any* join-column error.

I had flagged this exact column-blind fake when writing FR-2, and fixed it only in the file I was touching. The same blindness one module over is what let F1 through. Both fakes are now column-aware, plus a **discriminating fixture** (row pid `999999` vs launcher pid `111`) — every other fixture keys the row on the same pid `spawnFn` returns, so the two joins are indistinguishable there.

## SEC-CANHOST-02 (MEDIUM) — a false safety claim I wrote

`provision-canary.mjs`'s docstring claimed `--live` *"only reaches spawn-control, which self-gates behind FLEET_SPAWN_CONTROL_LIVE"*.

**False.** `canary-provision.js` forwards `live` as `opts.live`, and `spawn-control.js` reads `opts.live ?? isLiveEnabled()` — the explicit opt **overrides** the env gate. `provision-canary.mjs --live` really did spawn with `FLEET_SPAWN_CONTROL_LIVE` unset. A wrong safety claim on a new operator-facing CLI is worse than no claim.

The `??` override is pre-existing and deliberate elsewhere, so rather than change that shared semantic I made **this entrypoint require both factors**. It **refuses** rather than silently downgrading to dry-run — an operator who typed `--live` and saw "DRY-RUN" could reasonably read it as "it ran".

## SEC-CANHOST-01 (MEDIUM) — CRLF forgery defeated fail-closed

A window title is attacker-controllable by any unprivileged local process and may contain CR/LF. Emitted verbatim as the last field, it splits one window across two lines — the reviewer demonstrated a title yielding `{handle:99999, reason:'ok'}`, a **fully forged "new window"**. Bounded (a handle only reaches `SetForegroundWindow` as a coerced `IntPtr`, so no code execution), but it defeats the fail-closed contract.

The emitter now strips CR/LF. **Re-validated end to end through node → PowerShell**: still 17 rows, zero titles containing CR/LF — a constant-string change that is only unit-tested is exactly the green-and-dead shape this SD exists to close.

## TESTING #4 — my FR-6 negative control was vacuous, and they proved it

It asserted `r === null || typeof r.callsign === 'string'` (tautology) and `r?.callsign !== 'Canary-1'` (never true for its `'Delta'` fixture). Widening the guard to `if (existing || …)` — which **freezes every worker's identity** and disables the tier-band self-heal the function exists to perform — still passed 5/5.

A negative control that cannot fail is worse than none: it advertises coverage that doesn't exist. Replaced with a **reachability** discriminator (does an ordinary worker reach the slot-picking query?), plus its positive half for a canary — neither alone pins that the branch is taken for exactly one.

## TESTING #3 and #2 — smaller, same theme

- FR-7 carried forward the *never-throws* half of a deleted assertion but lost the **retry-budget** half. Since `enumerateWindows` swallows a rejection into `[]`, a reject is indistinguishable from "no windows yet" — a change breaking the loop on error would have stayed green. Restored as a call-count assertion.
- A source comment claimed four parse edge cases were *"all present in the committed fixture, none hypothetical"*. The fixture has exactly 3 pipes per row and no non-numeric handle, so **two of the four are constructed**. Split into OBSERVED vs DEFENSIVE — the point of citing a real capture is that the citation is true.

---

## Mutations — 4 run, and two first attempts discarded as non-evidence

| Mutation | Result |
|---|---|
| revert F1 to the pid join | 1 failed / 13 passed ✓ (the discriminating test, exactly) |
| bogus join column | 3 failed / 11 passed ✓ (what F2 could not catch before) |
| the exact over-broad canary guard | 2 failed / 4 passed ✓ |
| remove the `--live` refusal block | 2 failed / 10 passed ✓ |

Both first attempts were thrown away:
- the F1 mutation **did not apply** (sed anchor) and the suite stayed green;
- the `--live` mutation **did apply but was behaviourally inert** — it changed the variable while the refusal branch still guarded the path, so its green proved nothing either.

A mutation that doesn't actually restore the hazard isn't a passing test; it just looks like one.

## Verification

- **1194 tests / 105 files green** with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` **all unset**
- `start-cp3-drills.js` byte-identical to `origin/main`
- No drill exercised, no `live:true` verb; the PowerShell re-validation was read-only

## Not fixed here — recorded for PLAN

- **SEC-CANHOST-03**: `spawn-control` and `stampSpawnCorrelation` both do non-atomic client-side read-merge-write on the same JSONB during the child's registration window. A safe idiom already exists at `lib/fleet/attention-flag-writer.js:43-47`.
- **SEC-CANHOST-04**: `account_profile` is stamped from spawner **intent**, with no evidence `CLAUDE_CONFIG_DIR` reached the child — so the isolation stamp could read as proof of something unverified. Worth checking on the permitted live run.
- **LOW**: `spec.sessionId || mint()` lets a caller-supplied id outrank the mint with no uniqueness check; no caller passes one today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)