### PR TITLE
feat(SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001): auditable migration dispositions + drift-gate hardening

### DIFF
--- a/.github/workflows/migration-deploy-drift-guard.yml
+++ b/.github/workflows/migration-deploy-drift-guard.yml
@@ -96,20 +96,27 @@ jobs:
       - name: Disposition ledger is in sync with its seeder
         if: always()
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # NO service-role key here, deliberately: without --strict/--alert the verifier never
+          # emits a breakage alert, and the seeder touches no database at all. This step needs
+          # only the read credentials the verifier itself uses.
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
           SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set +e
-          node scripts/verify-migration-apply-state.mjs --json > /tmp/apply-state.json 2>/dev/null
-          # The verifier exits non-zero only under --strict, which is not passed here; a
-          # missing/short file means the DB was unreachable, in which case skip rather than
-          # fail — an outage must not be reported as ledger drift.
-          if ! grep -Fq '"gaps"' /tmp/apply-state.json; then
-            echo "::warning::Could not obtain apply-state JSON (DB unreachable?) — ledger sync check skipped."
+          node scripts/verify-migration-apply-state.mjs --json > /tmp/apply-state.json 2>/tmp/apply-state.err
+          # Branch on the verifier's own MARKER, not on the shape of its output. Inferring
+          # "DB unreachable" from a missing '"gaps"' key made every non-DB failure — a syntax
+          # error, an OOM, a bad flag — exit 0 while blaming the database. The marker goes to
+          # stderr under --json; -Fxq so a filename can never forge it.
+          if grep -Fxq '[MIGRATION_APPLY_STATE_INFRA_ERROR]' /tmp/apply-state.err; then
+            echo "::warning::DB unreachable — ledger sync check skipped this run (non-blocking transient)."
             exit 0
+          fi
+          if ! grep -Fq '"gaps"' /tmp/apply-state.json; then
+            echo "::error::Verifier produced no usable JSON and did not report a DB outage — this is a real failure, not a transient."
+            cat /tmp/apply-state.err
+            exit 1
           fi
           set -e
           node scripts/seed-migration-dispositions.mjs --gaps=/tmp/apply-state.json --write

--- a/.github/workflows/migration-deploy-drift-guard.yml
+++ b/.github/workflows/migration-deploy-drift-guard.yml
@@ -126,3 +126,18 @@ jobs:
             exit 1
           fi
           echo "Ledger is in sync with the seeder."
+
+      # The wiring test proves THIS workflow cannot be failed open by a corrupt ledger, so this
+      # workflow is where it belongs. It lives under tests/integration/, which vitest.config
+      # routes to the opt-in `db` project — and no workflow runs `npm run test:db` (db-guards.yml
+      # runs test:db-GUARDS, a static analyser, which is easy to misread as the same thing). So
+      # the SD's only end-to-end safety proof was unreachable in CI: green forever, asserting
+      # nothing. Runs AFTER the sync check so its ledger backup/restore can never be mistaken
+      # for seeder drift.
+      - name: FR-6 fail-open wiring proof
+        if: always()
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx vitest run tests/integration/migration-apply-state-ledger-wiring.test.js --project db

--- a/.github/workflows/migration-deploy-drift-guard.yml
+++ b/.github/workflows/migration-deploy-drift-guard.yml
@@ -21,6 +21,12 @@ on:
       - 'scripts/verify-migration-apply-state.mjs'
       - 'scripts/lib/migration-guards.js'
       - '.github/workflows/migration-deploy-drift-guard.yml'
+      # The disposition ledger and its reader are GATE INPUTS: editing either changes which
+      # migrations are suppressed from the fail set. Without these, a push that suppresses
+      # migrations — or that changes the suppression LOGIC — would not re-run this gate, and
+      # the change would first surface at the next cron, already green.
+      - 'docs/audits/migration-dispositions.json'
+      - 'scripts/lib/migration-disposition-ledger.mjs'
   schedule:
     - cron: '17 9 * * *'   # daily 09:17 UTC — catches drift even with no migration pushes
   workflow_dispatch:
@@ -60,13 +66,19 @@ jobs:
           # MISCONFIG (no DB credential at all) is an operator error, NOT a transient
           # outage — HARD FAIL so the gate can never sit permanently green while never
           # actually checking the live DB.
-          if echo "$out" | grep -q 'MIGRATION_APPLY_STATE_MISCONFIG'; then
+          # -Fxq, NOT -q: the verifier prints its verdict as a bracketed marker alone on a line,
+          # but $out also contains raw migration FILENAMES. An unanchored substring match let a
+          # committed file named e.g. 20200101_MIGRATION_APPLY_STATE_INFRA_ERROR_x.sql satisfy
+          # the INFRA branch below and exit 0 — permanently silencing this gate, including the
+          # daily cron, with a legacy-dated name that is itself never blocking. Fixed-string
+          # whole-line matching closes that. (SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001)
+          if echo "$out" | grep -Fxq '[MIGRATION_APPLY_STATE_MISCONFIG]'; then
             echo "::error::Deploy-drift gate has NO DB credential — set one of SUPABASE_DB_PASSWORD / SUPABASE_POOLER_URL / DATABASE_URL repo secrets. Failing loud: a credential-less gate verifies nothing."
             exit 1
           fi
           # INFRA = a genuine transient connect failure AFTER a credential was present —
           # non-blocking so an outage cannot red-X main.
-          if echo "$out" | grep -q 'MIGRATION_APPLY_STATE_INFRA_ERROR'; then
+          if echo "$out" | grep -Fxq '[MIGRATION_APPLY_STATE_INFRA_ERROR]'; then
             echo "::warning::DB temporarily unreachable — deploy-drift check skipped this run (non-blocking transient)."
             exit 0
           fi
@@ -74,3 +86,36 @@ jobs:
             echo "::error::RECENT committed-but-unapplied migration(s) detected (named above). Apply via 'node scripts/apply-migration.js <path> --prod-deploy' (3-factor @approved-by guard) or retire as legacy. Drift must not accumulate."
           fi
           exit "$code"
+
+      # SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 (FR-2). A pure-builder unit test proves
+      # buildLedger() is correct; it cannot prove the COMMITTED artifact matches what the
+      # seeder would produce today. Only re-running the seeder and diffing does that — without
+      # it, a hand-edited ledger silently diverges from its own generator and the suppressions
+      # in the gate stop being reproducible. Runs even when the gate above failed (if: always),
+      # because a stale ledger is worth reporting exactly when drift exists.
+      - name: Disposition ledger is in sync with its seeder
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set +e
+          node scripts/verify-migration-apply-state.mjs --json > /tmp/apply-state.json 2>/dev/null
+          # The verifier exits non-zero only under --strict, which is not passed here; a
+          # missing/short file means the DB was unreachable, in which case skip rather than
+          # fail — an outage must not be reported as ledger drift.
+          if ! grep -Fq '"gaps"' /tmp/apply-state.json; then
+            echo "::warning::Could not obtain apply-state JSON (DB unreachable?) — ledger sync check skipped."
+            exit 0
+          fi
+          set -e
+          node scripts/seed-migration-dispositions.mjs --gaps=/tmp/apply-state.json --write
+          if ! git diff --quiet -- docs/audits/migration-dispositions.json; then
+            echo "::error::docs/audits/migration-dispositions.json is out of sync with its seeder. Re-run 'npm run migration:dispositions:seed -- --gaps=<verifier --json> --write' and commit the result."
+            git --no-pager diff -- docs/audits/migration-dispositions.json
+            exit 1
+          fi
+          echo "Ledger is in sync with the seeder."

--- a/docs/audits/migration-dispositions.json
+++ b/docs/audits/migration-dispositions.json
@@ -1,0 +1,26 @@
+{
+  "20260712_ship_review_findings_repo_column.sql": {
+    "disposition": "DEFERRED",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "owner": "chairman",
+    "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
+    "recorded_at": "2026-07-25T18:27:30.734Z",
+    "source": "auto:chairman-gate-marker"
+  },
+  "20260716_chairman_email_channel_health_debounce.sql": {
+    "disposition": "DEFERRED",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "owner": "chairman",
+    "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
+    "recorded_at": "2026-07-25T18:27:30.734Z",
+    "source": "auto:chairman-gate-marker"
+  },
+  "20260724190000_add_manual_revenue_provenance_columns.sql": {
+    "disposition": "DEFERRED",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "owner": "chairman",
+    "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
+    "recorded_at": "2026-07-25T18:27:30.734Z",
+    "source": "auto:chairman-gate-marker"
+  }
+}

--- a/docs/audits/migration-dispositions.json
+++ b/docs/audits/migration-dispositions.json
@@ -4,7 +4,8 @@
     "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "recorded_at": "2026-07-25T19:13:40.087Z",
+    "review_by": "2026-10-23T19:13:40.087Z",
     "source": "auto:chairman-gate-marker",
     "corroborated": false
   },
@@ -13,7 +14,8 @@
     "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "recorded_at": "2026-07-25T19:13:40.087Z",
+    "review_by": "2026-10-23T19:13:40.087Z",
     "source": "auto:chairman-gate-marker",
     "corroborated": false
   },
@@ -22,7 +24,8 @@
     "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "recorded_at": "2026-07-25T19:13:40.087Z",
+    "review_by": "2026-10-23T19:13:40.087Z",
     "source": "auto:chairman-gate-marker",
     "corroborated": false
   }

--- a/docs/audits/migration-dispositions.json
+++ b/docs/audits/migration-dispositions.json
@@ -1,26 +1,29 @@
 {
   "20260712_ship_review_findings_repo_column.sql": {
     "disposition": "DEFERRED",
-    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:27:30.734Z",
-    "source": "auto:chairman-gate-marker"
+    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "source": "auto:chairman-gate-marker",
+    "corroborated": false
   },
   "20260716_chairman_email_channel_health_debounce.sql": {
     "disposition": "DEFERRED",
-    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:27:30.734Z",
-    "source": "auto:chairman-gate-marker"
+    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "source": "auto:chairman-gate-marker",
+    "corroborated": false
   },
   "20260724190000_add_manual_revenue_provenance_columns.sql": {
     "disposition": "DEFERRED",
-    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work.",
+    "reason": "Chairman-gated migration carrying no parseable \"-- @approved-by: <email>\" stamp, so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is SELF-ASSERTED in the migration file and is not corroborated against an external registry, so an author can obtain this deferral by adding one comment line to their own SQL. Treat as disclosed-but-unverified provenance when auditing.",
     "owner": "chairman",
     "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
-    "recorded_at": "2026-07-25T18:27:30.734Z",
-    "source": "auto:chairman-gate-marker"
+    "recorded_at": "2026-07-25T18:56:34.307Z",
+    "source": "auto:chairman-gate-marker",
+    "corroborated": false
   }
 }

--- a/docs/database/migration-disposition-ledger.md
+++ b/docs/database/migration-disposition-ledger.md
@@ -1,0 +1,174 @@
+---
+category: database
+status: approved
+version: 1.0.0
+author: rickfelix
+last_updated: 2026-07-25
+tags: [database, migrations, ci, governance]
+---
+
+# Migration disposition ledger
+
+**Source**: SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001.
+
+Every committed migration under `database/migrations/` that the apply-state verifier reports as
+a gap must have a recorded, readable decision. This is where that decision lives.
+
+## Why it exists
+
+`scripts/verify-migration-apply-state.mjs` was column-blind until QF-20260725-470. The corrected
+re-run found **126 forward migrations with schema gaps**. 117 of them predate
+`RETIRED_BEFORE=20260615` and therefore can never turn the CI gate red — so for 93% of the
+corpus, "has anyone actually decided what to do with this file?" was invisible to CI. A file
+could sit unapplied and undiscussed forever and every gate would stay green.
+
+The ledger makes the decision auditable independently of whether the gate passes. That
+separation is the whole point: **the definition of done is `undispositioned == 0`, not a green
+gate**, because a green gate can be produced by suppression while a zero undispositioned count
+cannot be produced without recording a real reason for every file.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `docs/audits/migration-dispositions.json` | The ledger. Source of truth. Committed. |
+| `scripts/lib/migration-disposition-ledger.mjs` | Reader + invariants. No DB, no side effects. |
+| `scripts/seed-migration-dispositions.mjs` | Derives entries from existing evidence. Pure core. |
+| `scripts/mirror-migration-dispositions-to-audit.mjs` | Governance trail into `public.audit_log`. |
+| `scripts/verify-migration-apply-state.mjs` | Consumes the ledger; reports and suppresses. |
+
+## Entry shape
+
+```json
+{
+  "20260716_chairman_email_channel_health_debounce.sql": {
+    "disposition": "DEFERRED",
+    "reason": "Chairman-gated migration carrying no parseable @approved-by stamp …",
+    "owner": "chairman",
+    "sd_key": "SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001",
+    "recorded_at": "2026-07-25T18:00:00.000Z",
+    "review_by": "2026-10-23T18:00:00.000Z",
+    "source": "auto:chairman-gate-marker",
+    "corroborated": false
+  }
+}
+```
+
+Keyed by **basename**, not path: `schema_migrations_applied` stores worktree-varying absolute
+Windows paths (229 distinct paths for 227 distinct basenames), so a path is not a stable key.
+
+| Disposition | Meaning | Suppresses the gate? |
+|---|---|---|
+| `RETIRED` | Deliberately never applying this. | Yes |
+| `DEFERRED` | Will decide/apply later; blocked or not yet worth it. | Yes |
+| `APPLIED` | It has been applied. | **Never** |
+
+## The four invariants
+
+**1. FAIL OPEN.** An absent, unreadable, malformed or wrong-shaped ledger yields an *empty*
+ledger — zero suppression, all drift still reported. A corrupt JSON must never be able to
+mass-suppress genuine drift. `inspectLedger()` additionally returns a `status` so a corrupt
+ledger is reported as corrupt rather than looking like "no decisions recorded yet".
+
+**2. REASON REQUIRED.** An entry whose reason isn't recognisably written by a human is ignored.
+This is an **allowlist** (`>= 3 words of 3+ letters`), not a strip of known-bad characters: a
+denylist loses to newly-chosen invisible codepoints, including U+3164 which Unicode classifies
+as a *letter* and U+2800 as a *symbol*, so even a `\p{C}`+`\p{Z}` filter can be defeated.
+
+**3. APPLIED NEVER SUPPRESSES, AND NEVER COUNTS AS DECIDED WHILE THE FILE IS IN THE GAP SET.**
+A genuinely applied migration cannot appear in the verifier's gap set at all. So an `APPLIED`
+entry for a file that *is* in the gap set proves itself false — either the ledger is wrong or
+an apply failed silently. Honouring it would turn the gate green with the columns still
+verifiably absent, which is exactly how QF-20260719-281 ghost-completed. Such entries are
+surfaced by `contradictoryBasenames()` and printed as `⚠ LEDGER CONTRADICTS SCHEMA`.
+
+Recording `APPLIED` *after* a real apply (when the file has left the gap set) is correct and
+expected — that is the disposition's legitimate use.
+
+**4. SUPPRESSION IS BOUNDED.** An optional `review_by` date ends a suppression. Past it, the
+entry stops suppressing *and* counts as undispositioned again, so the file resurfaces as real
+drift rather than decaying into a permanent exemption. Entries without `review_by` never
+expire. This matters because entries are carried forward even after their file leaves the gap
+set: without expiry, a migration that was applied and later *regressed* would be silently
+re-suppressed by a decision made about a situation that no longer exists.
+
+## How to adjudicate the remaining files
+
+As of this SD, **123 of 126 are undispositioned**. They need human judgement; the seeder
+deliberately does not invent decisions to drive the number down.
+
+1. Get the current gap set:
+   ```bash
+   node scripts/verify-migration-apply-state.mjs --json > /tmp/apply-state.json
+   ```
+   Note: stdout carries a dotenvx banner before the JSON, so slice from the first line that is
+   exactly `{` rather than parsing raw stdout.
+
+2. For each file, decide **RETIRED** or **DEFERRED** and write a reason that will still make
+   sense to someone in a year. State the evidence, not the conclusion — "zero live references
+   per <sweep doc>, consumers archived" rather than "not needed".
+
+3. Add the entry to `docs/audits/migration-dispositions.json` by hand. Hand-written entries are
+   **preserved verbatim** by the seeder (including `recorded_at`), so re-seeding never
+   overwrites a human verdict — even where an automatic rule would disagree.
+
+4. Re-run and confirm the count moved:
+   ```bash
+   npm run migration:dispositions:seed -- --gaps=/tmp/apply-state.json --write
+   node scripts/verify-migration-apply-state.mjs        # DISPOSITIONS: N of 126 …
+   npm run migration:dispositions:mirror -- --write     # governance trail
+   ```
+
+5. Commit the ledger. CI re-runs the seeder and fails on any diff, so the committed artifact
+   and its generator cannot silently diverge.
+
+### Auto-seeding rules
+
+Only two rules are trusted, both re-derivable from tracked sources:
+
+- **A — chairman-gated, unstamped → DEFERRED.** The file carries `@chairman-gated` /
+  `requires-chairman-apply` and no `@approved-by` the 3-factor guard would accept, so the apply
+  is genuinely blocked on a signature. Marked `corroborated: false`: the gate marker is
+  *self-asserted in the author's own SQL* and is not checked against any registry, so an author
+  can obtain this deferral by adding one comment line. It is time-boxed to 90 days for that
+  reason.
+- **B — the 2026-06-10 human sweep → its verdict**, but only when *every* object the verifier
+  reports missing for that file is covered by the doc **and** the doc cites that exact file.
+  Currently this yields zero files, because the sweep adjudicated tables and views from a
+  phantom-tables scan while the verifier reports the full DDL closure including functions,
+  triggers and indexes.
+
+The PRD also named `scripts/audit/migration-column-reachability.mjs` as a RETIRE-bucket source.
+It is **untracked in git**, exports nothing, and reads a `cols.tsv` from an expired session's
+scratchpad, so it throws at import and cannot run in CI or from a worktree. Re-deriving it as
+an importable module is the highest-value way to raise coverage beyond 3.
+
+## Applying a migration is a separate, gated act
+
+Nothing here applies anything. Applies go through `scripts/apply-migration.js --prod-deploy`,
+which requires all three factors: a clean git-committed file, an `@approved-by:` header
+matching `git config user.email`, and an issued `MIGRATION_APPLY_TOKEN`.
+
+At the time of writing, **1 of the 8 wave-1 migrations carries a valid stamp**; the other 7
+need a chairman to author one. Adding an `@approved-by` line to obtain an apply is forging
+chairman approval and defeats the guard — never do it. Escalate instead.
+
+## CI wiring
+
+`.github/workflows/migration-deploy-drift-guard.yml` runs the verifier, then checks the ledger
+is in sync with its seeder, then runs the FR-6 fail-open wiring proof.
+
+Two things about that workflow are load-bearing and easy to break:
+
+- Its marker greps are `grep -Fxq '[MARKER]'` — **fixed-string, whole-line**. They were
+  unanchored substring matches, which meant a committed file named
+  `20200101_MIGRATION_APPLY_STATE_INFRA_ERROR_x.sql` made the workflow take the INFRA branch
+  and `exit 0`, permanently silencing the gate including the daily cron. Filenames are also
+  newline-stripped before printing. Do not loosen either.
+- The ledger is loaded **outside** the verifier's DB `try` block, via a dynamic import. Inside
+  it, any throw prints `MIGRATION_APPLY_STATE_INFRA_ERROR`, which the workflow converts to
+  `exit 0` — so a corrupt ledger would turn the gate permanently and silently green. That is
+  the single most safety-critical property in this feature, and
+  `tests/integration/migration-apply-state-ledger-wiring.test.js` exists to prove it against
+  the real CLI. It runs from the drift-guard workflow because `tests/integration/` is routed to
+  vitest's opt-in `db` project, which no other workflow executes.

--- a/package.json
+++ b/package.json
@@ -606,6 +606,8 @@
     "validate:trigger-guard-pack": "node scripts/validate-trigger-guard-pack.mjs",
     "qf:create": "node scripts/create-quick-fix.js",
     "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",
+    "migration:dispositions:seed": "node scripts/seed-migration-dispositions.mjs",
+    "migration:dispositions:mirror": "node scripts/mirror-migration-dispositions-to-audit.mjs",
     "retention:check": "node scripts/retention-enforce.js",
     "retention:apply": "node scripts/retention-enforce.js --apply",
     "liveness:watch": "node scripts/periodic-liveness-watcher.mjs",

--- a/scripts/lib/migration-disposition-ledger.mjs
+++ b/scripts/lib/migration-disposition-ledger.mjs
@@ -1,0 +1,199 @@
+/**
+ * Migration disposition ledger — per-file APPLIED / RETIRED / DEFERRED decisions.
+ *
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001.
+ *
+ * WHY THIS EXISTS. verify-migration-apply-state.mjs was column-blind until
+ * QF-20260725-470; the re-run then exposed 126 forward migrations carrying gaps.
+ * 117 of them sit before RETIRED_BEFORE and can never turn the CI gate red, so
+ * "every file has a decision" is invisible to the verifier for 93% of the corpus.
+ * This module is the seam that makes the decision auditable instead.
+ *
+ * STANDALONE ON PURPOSE. It imports nothing from the verifier or the tier
+ * classifier. scripts/lib/migration-tier-classifier.mjs already imports
+ * stripNonDdl from the verifier, and pending-migrations-check.js (a handoff hot
+ * path) imports the classifier — routing this module through either would create
+ * a cycle and put ledger disk I/O on every handoff.
+ *
+ * THREE INVARIANTS, each guarding a specific way this could go wrong:
+ *
+ *   1. FAIL OPEN (FR-6). An unreadable, malformed, empty or wrong-shaped ledger
+ *      yields an EMPTY map — zero suppression, all real drift still reported. A
+ *      corrupt JSON must never be able to mass-suppress genuine drift.
+ *
+ *   2. REASON REQUIRED (FR-1). An entry with a missing, empty or whitespace-only
+ *      reason is IGNORED. Cloned from scripts/audit/count-truncation-inventory.mjs,
+ *      whose override loader ignores note-less entries — except that original uses
+ *      bare truthiness, which passes '   '. We trim.
+ *
+ *   3. APPLIED NEVER SUPPRESSES (FR-2b). This is the anti-ghost-completion guard.
+ *      A genuinely applied migration cannot appear in the verifier's gap set at
+ *      all, so a file that IS in gaps while marked APPLIED proves the disposition
+ *      false — most likely a seeder that mapped the reachability bucket's "APPLY
+ *      candidate" wording onto APPLIED before the apply actually happened. Honour
+ *      it and the gate goes green while the columns are still absent, which is
+ *      exactly how QF-20260719-281 ghost-completed. Only RETIRED and DEFERRED are
+ *      legitimate grounds for suppression.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/** Suppression is reachable only through these two. APPLIED is deliberately absent. */
+export const SUPPRESSING_DISPOSITIONS = Object.freeze(['RETIRED', 'DEFERRED']);
+
+/** The full recognised set. Anything outside this never suppresses (fail-closed enum). */
+export const KNOWN_DISPOSITIONS = Object.freeze(['APPLIED', 'RETIRED', 'DEFERRED']);
+
+export const DEFAULT_LEDGER_PATH = path.join('docs', 'audits', 'migration-dispositions.json');
+
+/**
+ * True when `entry` is a well-formed disposition that may suppress its file.
+ *
+ * Pure and total: never throws, whatever shape it is handed.
+ *
+ * @param {unknown} entry
+ * @returns {boolean}
+ */
+export function isSuppressingEntry(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+
+  // Invariant 2 — reason required. Trimmed, so '' and '   ' both fail.
+  const reason = entry.reason;
+  if (typeof reason !== 'string' || reason.trim() === '') return false;
+
+  const disposition = entry.disposition;
+  if (typeof disposition !== 'string') return false;
+
+  // Invariants 1 and 3 — unknown values and APPLIED both fall through to false.
+  return SUPPRESSING_DISPOSITIONS.includes(disposition);
+}
+
+/**
+ * Read the ledger, FAILING OPEN.
+ *
+ * Every failure mode — absent file, unreadable path, malformed JSON, a JSON array
+ * or scalar where an object was expected — resolves to an empty Map rather than an
+ * exception. The caller cannot tell the difference between "no ledger" and "broken
+ * ledger", and that is the point: both must suppress nothing.
+ *
+ * @param {string} [ledgerPath]
+ * @returns {Map<string, object>} basename -> entry. Empty on any failure.
+ */
+export function loadLedger(ledgerPath = DEFAULT_LEDGER_PATH) {
+  let raw;
+  try {
+    raw = fs.readFileSync(ledgerPath, 'utf8');
+  } catch {
+    return new Map(); // ENOENT, EACCES, EISDIR — all fail open.
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new Map(); // malformed, empty, whitespace-only, BOM-mangled.
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return new Map(); // valid JSON, wrong shape.
+  }
+
+  const out = new Map();
+  for (const [basename, entry] of Object.entries(parsed)) {
+    if (typeof basename === 'string' && basename) out.set(basename, entry);
+  }
+  return out;
+}
+
+/**
+ * The set of basenames this ledger legitimately suppresses.
+ *
+ * Only entries clearing all three invariants are included, so callers can treat
+ * membership as "a human recorded a real reason to stop reporting this".
+ *
+ * @param {Map<string, object>} ledger
+ * @returns {Set<string>}
+ */
+export function suppressedBasenames(ledger) {
+  const out = new Set();
+  if (!(ledger instanceof Map)) return out;
+  for (const [basename, entry] of ledger) {
+    if (isSuppressingEntry(entry)) out.add(basename);
+  }
+  return out;
+}
+
+/**
+ * Basename of a gap record, tolerating either a bare string or a `{file}` object,
+ * and normalising both POSIX and Windows separators.
+ *
+ * Basename rather than full path is deliberate: schema_migrations_applied stores
+ * worktree-varying absolute Windows paths (229 distinct paths, only 227 distinct
+ * basenames), so path is not a stable key across worktrees.
+ *
+ * @param {unknown} gap
+ * @returns {string}
+ */
+export function gapBasename(gap) {
+  const file = typeof gap === 'string' ? gap : gap && typeof gap === 'object' ? gap.file : '';
+  if (typeof file !== 'string' || !file) return '';
+  return file.replace(/^.*[\\/]/, '');
+}
+
+/**
+ * Partition gaps into those a ledger suppresses and those it does not.
+ *
+ * Total: with an empty ledger every gap lands in `remaining`, which is what makes
+ * the fail-open path byte-identical to having no ledger at all.
+ *
+ * @param {Array<object|string>} gaps
+ * @param {Map<string, object>} ledger
+ * @returns {{remaining: Array, suppressed: Array}}
+ */
+export function applyDispositions(gaps, ledger) {
+  const list = Array.isArray(gaps) ? gaps : [];
+  const suppressedSet = suppressedBasenames(ledger);
+  const remaining = [];
+  const suppressed = [];
+  for (const gap of list) {
+    if (suppressedSet.has(gapBasename(gap))) suppressed.push(gap);
+    else remaining.push(gap);
+  }
+  return { remaining, suppressed };
+}
+
+/**
+ * Basenames carrying no disposition at all — the machine-checkable definition of
+ * done (FR-3). "Every file has been decided" is provable by this reaching zero,
+ * independently of whether the verifier exits clean.
+ *
+ * A file whose entry is malformed or reason-less counts as UNDISPOSITIONED, not
+ * as decided: a decision nobody can read is not a decision.
+ *
+ * @param {Array<object|string>} gaps
+ * @param {Map<string, object>} ledger
+ * @returns {string[]} sorted, deduplicated
+ */
+export function undispositionedBasenames(gaps, ledger) {
+  const list = Array.isArray(gaps) ? gaps : [];
+  const decided = new Set();
+  if (ledger instanceof Map) {
+    for (const [basename, entry] of ledger) {
+      // Any well-formed known disposition counts as decided, INCLUDING APPLIED —
+      // APPLIED is a real decision, it just is not grounds for suppression.
+      if (
+        entry && typeof entry === 'object' && !Array.isArray(entry) &&
+        typeof entry.reason === 'string' && entry.reason.trim() !== '' &&
+        typeof entry.disposition === 'string' &&
+        KNOWN_DISPOSITIONS.includes(entry.disposition)
+      ) decided.add(basename);
+    }
+  }
+  const out = new Set();
+  for (const gap of list) {
+    const basename = gapBasename(gap);
+    if (basename && !decided.has(basename)) out.add(basename);
+  }
+  return [...out].sort();
+}

--- a/scripts/lib/migration-disposition-ledger.mjs
+++ b/scripts/lib/migration-disposition-ledger.mjs
@@ -47,17 +47,45 @@ export const KNOWN_DISPOSITIONS = Object.freeze(['APPLIED', 'RETIRED', 'DEFERRED
 
 export const DEFAULT_LEDGER_PATH = path.join('docs', 'audits', 'migration-dispositions.json');
 
-/** Characters that render as nothing but survive String.trim(). */
-const INVISIBLE_RE = /[\s​-‍­﻿]/g;
-
 /**
- * True when `reason` contains at least one character a human could actually read.
+ * True when `reason` reads like a sentence a human wrote.
+ *
+ * ALLOWLIST, NOT DENYLIST — this was originally a trim(), then a strip of six known invisible
+ * characters. Adversarial review defeated both: U+3164 is a Unicode LETTER and U+2800 a
+ * SYMBOL, so even stripping \p{C}+\p{Z} leaves characters that render blank while passing.
+ * Any "remove the bad characters" rule loses that race. Requiring positive evidence of real
+ * words cannot be beaten by adding new invisible codepoints, because they are not letters.
+ *
+ * The bar is deliberately low (three words of 3+ letters) — it rejects blank-looking reasons
+ * without dictating how anyone writes; the real seeded reasons run to several sentences.
  *
  * @param {unknown} reason
  * @returns {boolean}
  */
 export function hasReadableReason(reason) {
-  return typeof reason === 'string' && reason.replace(INVISIBLE_RE, '') !== '';
+  if (typeof reason !== 'string') return false;
+  return (reason.match(/[A-Za-z]{3,}/g) || []).length >= 3;
+}
+
+/**
+ * True when a suppressing entry has passed its own review date.
+ *
+ * A deferral is a decision to revisit, not a permanent exemption. Without an expiry, an entry
+ * suppresses forever — and since carry-forward retains entries whose file has left the gap
+ * set, a migration that regresses back INTO the gap set later would be silently re-suppressed
+ * by a decision made about a situation that no longer exists. `review_by` is optional: an
+ * entry without one never expires, so this is additive.
+ *
+ * @param {object} entry
+ * @param {number|Date} [now]
+ * @returns {boolean}
+ */
+export function isExpired(entry, now = Date.now()) {
+  const by = entry && entry.review_by;
+  if (typeof by !== 'string' || !by) return false;
+  const t = Date.parse(by);
+  if (Number.isNaN(t)) return false; // unparseable date must not silently expire a real decision
+  return t < (now instanceof Date ? now.getTime() : now);
 }
 
 /**
@@ -68,8 +96,11 @@ export function hasReadableReason(reason) {
  * @param {unknown} entry
  * @returns {boolean}
  */
-export function isSuppressingEntry(entry) {
+export function isSuppressingEntry(entry, now = Date.now()) {
   if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+
+  // A lapsed deferral stops suppressing and the gap resurfaces as real drift.
+  if (isExpired(entry, now)) return false;
 
   // Invariant 2 — reason required. Stripped rather than merely trimmed: String.trim()
   // removes only WhiteSpace/LineTerminator, so a reason of "​" (zero-width space),
@@ -147,11 +178,11 @@ export function inspectLedger(ledgerPath = DEFAULT_LEDGER_PATH) {
  * @param {Map<string, object>} ledger
  * @returns {Set<string>}
  */
-export function suppressedBasenames(ledger) {
+export function suppressedBasenames(ledger, now = Date.now()) {
   const out = new Set();
   if (!(ledger instanceof Map)) return out;
   for (const [basename, entry] of ledger) {
-    if (isSuppressingEntry(entry)) out.add(basename);
+    if (isSuppressingEntry(entry, now)) out.add(basename);
   }
   return out;
 }
@@ -234,13 +265,19 @@ export function undispositionedBasenames(gaps, ledger) {
   return [...out].sort();
 }
 
-/** A well-formed entry carrying a readable reason and a recognised disposition. */
-function isDecidedEntry(entry) {
+/**
+ * A well-formed, CURRENT entry: readable reason, recognised disposition, not lapsed.
+ * An expired decision counts as undispositioned — a decision nobody has revisited past its own
+ * review date is no longer a live decision, and it must resurface in the metric rather than
+ * keep crediting the file.
+ */
+function isDecidedEntry(entry, now = Date.now()) {
   return Boolean(
     entry && typeof entry === 'object' && !Array.isArray(entry)
     && hasReadableReason(entry.reason)
     && typeof entry.disposition === 'string'
     && KNOWN_DISPOSITIONS.includes(entry.disposition)
+    && !isExpired(entry, now)
   );
 }
 

--- a/scripts/lib/migration-disposition-ledger.mjs
+++ b/scripts/lib/migration-disposition-ledger.mjs
@@ -47,6 +47,19 @@ export const KNOWN_DISPOSITIONS = Object.freeze(['APPLIED', 'RETIRED', 'DEFERRED
 
 export const DEFAULT_LEDGER_PATH = path.join('docs', 'audits', 'migration-dispositions.json');
 
+/** Characters that render as nothing but survive String.trim(). */
+const INVISIBLE_RE = /[\s​-‍­﻿]/g;
+
+/**
+ * True when `reason` contains at least one character a human could actually read.
+ *
+ * @param {unknown} reason
+ * @returns {boolean}
+ */
+export function hasReadableReason(reason) {
+  return typeof reason === 'string' && reason.replace(INVISIBLE_RE, '') !== '';
+}
+
 /**
  * True when `entry` is a well-formed disposition that may suppress its file.
  *
@@ -58,9 +71,11 @@ export const DEFAULT_LEDGER_PATH = path.join('docs', 'audits', 'migration-dispos
 export function isSuppressingEntry(entry) {
   if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
 
-  // Invariant 2 — reason required. Trimmed, so '' and '   ' both fail.
-  const reason = entry.reason;
-  if (typeof reason !== 'string' || reason.trim() === '') return false;
+  // Invariant 2 — reason required. Stripped rather than merely trimmed: String.trim()
+  // removes only WhiteSpace/LineTerminator, so a reason of "​" (zero-width space),
+  // "‌", "­" (soft hyphen) or "﻿" survives it while rendering blank in every
+  // editor and diff — a reason no human can read, passing a check named "reason required".
+  if (!hasReadableReason(entry.reason)) return false;
 
   const disposition = entry.disposition;
   if (typeof disposition !== 'string') return false;
@@ -81,29 +96,46 @@ export function isSuppressingEntry(entry) {
  * @returns {Map<string, object>} basename -> entry. Empty on any failure.
  */
 export function loadLedger(ledgerPath = DEFAULT_LEDGER_PATH) {
+  return inspectLedger(ledgerPath).ledger;
+}
+
+/**
+ * loadLedger plus WHY it is empty.
+ *
+ * Fail-open means a corrupt ledger and an absent one behave identically, which is correct for
+ * suppression but wrong for reporting: an operator who corrupts the ledger would otherwise see
+ * "ledger entries=0" and read it as "no decisions recorded yet" — losing precisely the signal
+ * this module exists to provide. Suppression consumes `ledger`; humans consume `status`.
+ *
+ * @param {string} [ledgerPath]
+ * @returns {{ledger: Map<string, object>, status: 'ok'|'absent'|'unreadable'|'malformed'|'wrong-shape'}}
+ */
+export function inspectLedger(ledgerPath = DEFAULT_LEDGER_PATH) {
+  const empty = new Map();
   let raw;
   try {
     raw = fs.readFileSync(ledgerPath, 'utf8');
-  } catch {
-    return new Map(); // ENOENT, EACCES, EISDIR — all fail open.
+  } catch (e) {
+    // ENOENT is the ordinary "not created yet" state; anything else is a real problem.
+    return { ledger: empty, status: e && e.code === 'ENOENT' ? 'absent' : 'unreadable' };
   }
 
   let parsed;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return new Map(); // malformed, empty, whitespace-only, BOM-mangled.
+    return { ledger: empty, status: 'malformed' }; // malformed, empty, whitespace-only, BOM-mangled.
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return new Map(); // valid JSON, wrong shape.
+    return { ledger: empty, status: 'wrong-shape' }; // valid JSON, wrong shape.
   }
 
   const out = new Map();
   for (const [basename, entry] of Object.entries(parsed)) {
     if (typeof basename === 'string' && basename) out.set(basename, entry);
   }
-  return out;
+  return { ledger: out, status: 'ok' };
 }
 
 /**
@@ -180,20 +212,58 @@ export function undispositionedBasenames(gaps, ledger) {
   const decided = new Set();
   if (ledger instanceof Map) {
     for (const [basename, entry] of ledger) {
-      // Any well-formed known disposition counts as decided, INCLUDING APPLIED —
-      // APPLIED is a real decision, it just is not grounds for suppression.
-      if (
-        entry && typeof entry === 'object' && !Array.isArray(entry) &&
-        typeof entry.reason === 'string' && entry.reason.trim() !== '' &&
-        typeof entry.disposition === 'string' &&
-        KNOWN_DISPOSITIONS.includes(entry.disposition)
-      ) decided.add(basename);
+      // APPLIED IS NOT A DECISION *HERE*. This function is only ever asked about files that
+      // appear in the verifier's gap set, and a genuinely applied migration cannot appear
+      // there — so an APPLIED entry reaching this loop is self-contradictory by construction.
+      //
+      // Crediting it would let a hand-edited ledger marking all 123 residual files APPLIED
+      // drive this metric — the SD's machine-checkable definition of done — to zero while
+      // suppressing nothing and leaving every gap real. That is QF-20260719-281's ghost
+      // completion again, one layer up from the suppression path FR-2b already guards.
+      // The suppression guard alone was not enough: it protects what the gate BLOCKS on,
+      // this protects what the SD CLAIMS. Contradictory entries are surfaced separately by
+      // contradictoryBasenames() rather than silently ignored.
+      if (isDecidedEntry(entry) && entry.disposition !== 'APPLIED') decided.add(basename);
     }
   }
   const out = new Set();
   for (const gap of list) {
     const basename = gapBasename(gap);
     if (basename && !decided.has(basename)) out.add(basename);
+  }
+  return [...out].sort();
+}
+
+/** A well-formed entry carrying a readable reason and a recognised disposition. */
+function isDecidedEntry(entry) {
+  return Boolean(
+    entry && typeof entry === 'object' && !Array.isArray(entry)
+    && hasReadableReason(entry.reason)
+    && typeof entry.disposition === 'string'
+    && KNOWN_DISPOSITIONS.includes(entry.disposition)
+  );
+}
+
+/**
+ * Basenames whose ledger entry CONTRADICTS observed reality: marked APPLIED, yet still
+ * present in the verifier's gap set with objects genuinely missing from the live schema.
+ *
+ * Reported loudly rather than quietly discarded. A contradiction means either the ledger is
+ * lying or the apply silently failed, and both are worth an operator's attention — the
+ * QF-20260719-281 post-mortem turned on exactly this state going unnoticed.
+ *
+ * @param {Array<object|string>} gaps
+ * @param {Map<string, object>} ledger
+ * @returns {string[]} sorted, deduplicated
+ */
+export function contradictoryBasenames(gaps, ledger) {
+  const list = Array.isArray(gaps) ? gaps : [];
+  if (!(ledger instanceof Map)) return [];
+  const out = new Set();
+  for (const gap of list) {
+    const basename = gapBasename(gap);
+    const entry = basename ? ledger.get(basename) : null;
+    if (entry && isDecidedEntry(entry) && entry.disposition === 'APPLIED') out.add(basename);
   }
   return [...out].sort();
 }

--- a/scripts/mirror-migration-dispositions-to-audit.mjs
+++ b/scripts/mirror-migration-dispositions-to-audit.mjs
@@ -44,7 +44,7 @@ const EVENT_TYPE = 'MIGRATION_DISPOSITION';
  * @param {Map<string,string>} mirrored entity_id -> most recent disposition already in audit_log
  * @returns {{rows: object[], skipped: string[], invalid: string[]}}
  */
-export function buildAuditRows(ledger, mirrored = new Map()) {
+export function buildAuditRows(ledger, mirrored = new Map(), actor = null) {
   const rows = [];
   const skipped = [];
   const invalid = [];
@@ -63,6 +63,10 @@ export function buildAuditRows(ledger, mirrored = new Map()) {
       entity_type: 'migration',
       entity_id: basename,
       severity: 'info', // a recorded decision is not a warning
+      // The subject of this trail is "who authorised removing a migration from the CI fail
+      // set", so an actor is the one field it cannot omit. metadata.owner is an auto-derived
+      // ROLE (e.g. "chairman"), which is not the same as the identity that ran the write.
+      created_by: actor,
       metadata: {
         disposition: entry.disposition,
         owner: entry.owner || null,
@@ -101,17 +105,33 @@ if (isMain) {
   }
   const supabase = createClient(url, key);
 
+  // PAGINATE. PostgREST caps a select at 1000 rows and returns the cap SILENTLY, so an
+  // unpaginated read past 1000 MIGRATION_DISPOSITION rows would build `mirrored` from the
+  // oldest 1000 and re-insert everything newer — defeating the idempotence this is built on.
+  // Ascending order + last-write-wins means the final value per entity is its current one.
   const mirrored = new Map();
-  const { data, error } = await supabase
-    .from('audit_log').select('entity_id, metadata, created_at')
-    .eq('event_type', EVENT_TYPE).order('created_at', { ascending: true });
-  if (error) {
-    console.error(`Could not read existing audit rows (${error.message}) — refusing to write, to avoid duplicating the trail.`);
-    process.exit(0);
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('audit_log').select('entity_id, metadata, created_at')
+      .eq('event_type', EVENT_TYPE).order('created_at', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) {
+      console.error(`Could not read existing audit rows (${error.message}) — refusing to write, to avoid duplicating the trail.`);
+      process.exit(0);
+    }
+    for (const r of data || []) mirrored.set(r.entity_id, r.metadata?.disposition);
+    if (!data || data.length < PAGE) break;
   }
-  for (const r of data || []) mirrored.set(r.entity_id, r.metadata?.disposition);
 
-  const { rows, skipped, invalid } = buildAuditRows(ledger, mirrored);
+  // Actor identity for created_by — the same source the migration approver factor uses.
+  let actor = null;
+  try {
+    const { execFileSync } = await import('node:child_process');
+    actor = execFileSync('git', ['config', 'user.email'], { cwd: ROOT, encoding: 'utf8' }).trim() || null;
+  } catch { /* unattributed is better than a failed mirror */ }
+
+  const { rows, skipped, invalid } = buildAuditRows(ledger, mirrored, actor);
   console.log(`ledger entries: ${Object.keys(ledger).length}`);
   console.log(`already mirrored (unchanged): ${skipped.length}`);
   console.log(`to write: ${rows.length}`);

--- a/scripts/mirror-migration-dispositions-to-audit.mjs
+++ b/scripts/mirror-migration-dispositions-to-audit.mjs
@@ -44,6 +44,23 @@ const EVENT_TYPE = 'MIGRATION_DISPOSITION';
  * @param {Map<string,string>} mirrored entity_id -> most recent disposition already in audit_log
  * @returns {{rows: object[], skipped: string[], invalid: string[]}}
  */
+/**
+ * Stable fingerprint of the DECISION an entry records — everything an auditor would consider a
+ * different decision. Deliberately excludes recorded_at, so re-seeding alone never churns rows.
+ *
+ * @param {object} entry
+ * @returns {string}
+ */
+export function decisionFingerprint(entry) {
+  return JSON.stringify([
+    entry?.disposition ?? null,
+    (entry?.reason ?? '').trim(),
+    entry?.owner ?? null,
+    entry?.corroborated ?? null,
+    entry?.review_by ?? null,
+  ]);
+}
+
 export function buildAuditRows(ledger, mirrored = new Map(), actor = null) {
   const rows = [];
   const skipped = [];
@@ -54,7 +71,11 @@ export function buildAuditRows(ledger, mirrored = new Map(), actor = null) {
       invalid.push(basename);
       continue;
     }
-    if (mirrored.get(basename) === entry.disposition) {
+    // Keyed on the DECISION CONTENT, not the disposition alone. Keying on disposition let a
+    // materially reworded reason never reach the trail — observed for real: all three reasons
+    // were rewritten to add the self-assertion disclosure while the dispositions stayed
+    // DEFERRED, and this loop would have skipped every one of them.
+    if (mirrored.get(basename) === decisionFingerprint(entry)) {
       skipped.push(basename);
       continue;
     }
@@ -74,6 +95,12 @@ export function buildAuditRows(ledger, mirrored = new Map(), actor = null) {
         decided_at: entry.recorded_at || null,
         sd_key: entry.sd_key || null,
         source: entry.source || null,
+        // Provenance quality, as a queryable FIELD rather than only inside free-text prose:
+        // false means the grounds are self-asserted in the migration file and uncorroborated.
+        corroborated: entry.corroborated ?? null,
+        // When this suppression lapses and the file resurfaces as drift. null = never expires.
+        review_by: entry.review_by || null,
+        decision_fingerprint: decisionFingerprint(entry),
         // Whether this disposition actually removes the file from the strict fail set. APPLIED
         // is a legitimate record but NEVER suppresses (FR-2b), so a reader can tell a decision
         // that changed gate behaviour from one that only documented a fact.
@@ -120,7 +147,7 @@ if (isMain) {
       console.error(`Could not read existing audit rows (${error.message}) — refusing to write, to avoid duplicating the trail.`);
       process.exit(0);
     }
-    for (const r of data || []) mirrored.set(r.entity_id, r.metadata?.disposition);
+    for (const r of data || []) mirrored.set(r.entity_id, r.metadata?.decision_fingerprint ?? null);
     if (!data || data.length < PAGE) break;
   }
 

--- a/scripts/mirror-migration-dispositions-to-audit.mjs
+++ b/scripts/mirror-migration-dispositions-to-audit.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Mirror the migration disposition ledger into public.audit_log.
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 (FR-5).
+ *
+ * The committed JSON stays the SOURCE OF TRUTH; this is a durable governance trail on top of
+ * it. That direction matters: every audit_log writer in this repo needs SUPABASE_SERVICE_ROLE_KEY,
+ * so if the CI gate read audit_log it would need service-role credentials just to decide whether
+ * a migration is dispositioned. The gate reads the JSON and never calls this script.
+ *
+ * Convention copied from recordTierAudit() in
+ * scripts/modules/handoff/pre-checks/pending-migrations-check.js, including its non-fatal
+ * posture: a governance mirror must never break the caller.
+ *
+ * LIVE COLUMNS ONLY. public.audit_log is (id, event_type, entity_type, entity_id, old_value,
+ * new_value, metadata, severity, created_by, created_at) — verified against the live table.
+ * There are NO `action` or `details` columns; lib/claim-validity-gate.js documents a prior
+ * runtime break caused by inserting exactly those.
+ *
+ * Usage:
+ *   node scripts/mirror-migration-dispositions-to-audit.mjs           # dry run
+ *   node scripts/mirror-migration-dispositions-to-audit.mjs --write
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { DEFAULT_LEDGER_PATH, isSuppressingEntry, KNOWN_DISPOSITIONS } from './lib/migration-disposition-ledger.mjs';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const EVENT_TYPE = 'MIGRATION_DISPOSITION';
+
+/**
+ * Rows to insert, given the ledger and what audit_log already holds. PURE — no DB, no disk.
+ *
+ * IDEMPOTENT BY DISPOSITION, not by mere presence: an entity already mirrored is skipped only
+ * when its recorded disposition still matches. If a human re-adjudicates DEFERRED -> RETIRED, a
+ * NEW row is written so the trail shows the change rather than silently keeping the stale one.
+ *
+ * @param {Record<string, object>} ledger
+ * @param {Map<string,string>} mirrored entity_id -> most recent disposition already in audit_log
+ * @returns {{rows: object[], skipped: string[], invalid: string[]}}
+ */
+export function buildAuditRows(ledger, mirrored = new Map()) {
+  const rows = [];
+  const skipped = [];
+  const invalid = [];
+
+  for (const [basename, entry] of Object.entries(ledger || {})) {
+    if (!entry || typeof entry !== 'object' || !KNOWN_DISPOSITIONS.includes(entry.disposition)) {
+      invalid.push(basename);
+      continue;
+    }
+    if (mirrored.get(basename) === entry.disposition) {
+      skipped.push(basename);
+      continue;
+    }
+    rows.push({
+      event_type: EVENT_TYPE,
+      entity_type: 'migration',
+      entity_id: basename,
+      severity: 'info', // a recorded decision is not a warning
+      metadata: {
+        disposition: entry.disposition,
+        owner: entry.owner || null,
+        reason: entry.reason || null,
+        decided_at: entry.recorded_at || null,
+        sd_key: entry.sd_key || null,
+        source: entry.source || null,
+        // Whether this disposition actually removes the file from the strict fail set. APPLIED
+        // is a legitimate record but NEVER suppresses (FR-2b), so a reader can tell a decision
+        // that changed gate behaviour from one that only documented a fact.
+        suppresses_gate: isSuppressingEntry(entry),
+      },
+    });
+  }
+  return { rows, skipped, invalid };
+}
+
+// ── isMain: all I/O below ────────────────────────────────────────────────────
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const write = process.argv.includes('--write');
+  const ledgerPath = path.join(ROOT, DEFAULT_LEDGER_PATH);
+  if (!existsSync(ledgerPath)) {
+    console.log(`No ledger at ${DEFAULT_LEDGER_PATH} — nothing to mirror.`);
+    process.exit(0);
+  }
+  const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
+
+  require('dotenv').config({ path: path.join(ROOT, '.env') });
+  const { createClient } = require('@supabase/supabase-js');
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE credentials — the JSON ledger remains the source of truth; skipping mirror.');
+    process.exit(0); // non-fatal by design
+  }
+  const supabase = createClient(url, key);
+
+  const mirrored = new Map();
+  const { data, error } = await supabase
+    .from('audit_log').select('entity_id, metadata, created_at')
+    .eq('event_type', EVENT_TYPE).order('created_at', { ascending: true });
+  if (error) {
+    console.error(`Could not read existing audit rows (${error.message}) — refusing to write, to avoid duplicating the trail.`);
+    process.exit(0);
+  }
+  for (const r of data || []) mirrored.set(r.entity_id, r.metadata?.disposition);
+
+  const { rows, skipped, invalid } = buildAuditRows(ledger, mirrored);
+  console.log(`ledger entries: ${Object.keys(ledger).length}`);
+  console.log(`already mirrored (unchanged): ${skipped.length}`);
+  console.log(`to write: ${rows.length}`);
+  if (invalid.length) console.log(`SKIPPED as malformed: ${invalid.join(', ')}`);
+  for (const r of rows) console.log(`   ${r.metadata.disposition.padEnd(9)} ${r.entity_id}  suppresses_gate=${r.metadata.suppresses_gate}`);
+
+  if (!write) {
+    console.log('\n(dry run — pass --write to persist)');
+  } else if (rows.length) {
+    const { error: insErr } = await supabase.from('audit_log').insert(rows);
+    if (insErr) console.error(`⚠️ non-fatal: audit mirror failed (${insErr.message}). JSON ledger is unaffected.`);
+    else console.log(`\nwrote ${rows.length} audit_log row(s)`);
+  } else {
+    console.log('\nnothing to write — audit trail already matches the ledger');
+  }
+}

--- a/scripts/seed-migration-dispositions.mjs
+++ b/scripts/seed-migration-dispositions.mjs
@@ -38,6 +38,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const SD_KEY = 'SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001';
 
+/** How long an auto-seeded, uncorroborated deferral suppresses before it must be revisited. */
+export const REVIEW_WINDOW_DAYS = 90;
+
 /** The 3-factor guard's approver regex, verbatim from scripts/lib/migration-guards.js:30. */
 const APPROVED_BY_RE = /^\s*--\s*@approved-by:\s*([^\s<>"]+@[^\s<>"]+)\s*$/m;
 
@@ -126,6 +129,11 @@ export function buildLedger({ gaps, sql, sweep, existing = {}, now }) {
         owner: 'chairman',
         sd_key: SD_KEY,
         recorded_at: now,
+        // A self-asserted, uncorroborated deferral must be time-boxed, or one comment line in
+        // the author's own SQL buys a PERMANENT gate exemption. At expiry the file resurfaces
+        // as real drift and as undispositioned, forcing a fresh decision rather than decaying
+        // into a silent allowance.
+        review_by: new Date(Date.parse(now) + REVIEW_WINDOW_DAYS * 86400000).toISOString(),
         source: 'auto:chairman-gate-marker',
         corroborated: false,
       };

--- a/scripts/seed-migration-dispositions.mjs
+++ b/scripts/seed-migration-dispositions.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * Seed the migration disposition ledger from sources that already exist.
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 (FR-2).
+ *
+ * PURE CORE + isMain WRITES, mirroring buildInventory() in
+ * scripts/audit/count-truncation-inventory.mjs: buildLedger() takes everything it needs as
+ * arguments and returns a plain object, so it is unit-testable with no disk and no DB. All
+ * writes happen in the isMain block at the bottom.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO
+ *
+ *   It does not reach 126/126. The PRD named
+ *   scripts/audit/migration-column-reachability.mjs as the RETIRE-bucket source; that file is
+ *   UNTRACKED in git, exports nothing, and line 15 reads a cols.tsv from an expired session's
+ *   scratchpad, so it throws at import and can never run in CI or from a worktree. The PRD
+ *   carried a blocking AC for exactly this. Measured coverage of the surviving TRACKED sources
+ *   is 17 of 126; the rest is honestly left UNDISPOSITIONED and reported.
+ *
+ *   It NEVER emits APPLIED (FR-2b). A file in the verifier's gap set is by definition not
+ *   applied, so seeding APPLIED there would assert a falsehood AND suppress the gap — the
+ *   ghost-completion this SD exists to correct. APPLIED is only ever a post-apply fact.
+ *
+ *   It does not invent decisions to drive the undispositioned count to zero. A number moved by
+ *   fabricated reasons is worse than a number that stays high, because it looks finished.
+ *
+ * Usage:
+ *   node scripts/seed-migration-dispositions.mjs           # report only, writes nothing
+ *   node scripts/seed-migration-dispositions.mjs --write   # write the ledger
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { KNOWN_DISPOSITIONS, DEFAULT_LEDGER_PATH } from './lib/migration-disposition-ledger.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const SD_KEY = 'SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001';
+
+/** The 3-factor guard's approver regex, verbatim from scripts/lib/migration-guards.js:30. */
+const APPROVED_BY_RE = /^\s*--\s*@approved-by:\s*([^\s<>"]+@[^\s<>"]+)\s*$/m;
+
+/** The chairman gate marker, verbatim from parseChairmanGatedMarker() in check-migration-readiness.mjs. */
+const CHAIRMAN_GATED_RE = /^\s*--\s*(@chairman-gated|requires[-_]chairman[-_]apply)\b\s*[:=]?.*$/im;
+
+/**
+ * Parse the 2026-06-10 human sweep doc into object -> verdict.
+ *
+ * The doc is keyed by OBJECT with a defining-SQL path, under two headed sections. Only its
+ * `database/migrations/` citations can ever match a verifier gap file (the verifier scans that
+ * directory alone), so schema/, manual-updates/ and backups/ rows are parsed but never match.
+ *
+ * @returns {Map<string, {verdict:'DEFERRED'|'RETIRED', file:string}>} keyed by object name
+ */
+export function parseSweepDoc(markdown) {
+  const out = new Map();
+  let verdict = null;
+  for (const line of String(markdown || '').split(/\r?\n/)) {
+    if (/^##\s+DEFERRED/i.test(line)) { verdict = 'DEFERRED'; continue; }
+    if (/^##\s+RETIRE-CANDIDATES/i.test(line)) { verdict = 'RETIRED'; continue; }
+    if (/^##\s/.test(line)) { verdict = null; continue; } // e.g. the APPLIED-by-that-SD section
+    if (!verdict) continue;
+
+    // DEFERRED rows are markdown table rows: | object | refs | consumers | path |
+    const row = line.match(/^\|\s*([a-z0-9_]+)\s*\|.*\|\s*(database\/[^\s|]+\.sql)\s*\|/i);
+    if (row) { out.set(row[1].toLowerCase(), { verdict, file: row[2].split('/').pop() }); continue; }
+    // RETIRE rows are bullets: - object_name (path/to.sql)
+    const bullet = line.match(/^-\s+([a-z0-9_]+)\s+\((database\/[^\s)]+\.sql)\)/i);
+    if (bullet) out.set(bullet[1].toLowerCase(), { verdict, file: bullet[2].split('/').pop() });
+  }
+  return out;
+}
+
+/**
+ * Build the seeded ledger. PURE: no disk, no DB, no clock beyond the injected `now`.
+ *
+ * @param {object} args
+ * @param {Array<{file:string, missing:Array<{cls:string,name:string}>}>} args.gaps verifier gap set
+ * @param {Map<string,string>} args.sql basename -> file contents (only what the caller read)
+ * @param {Map<string,{verdict:string,file:string}>} args.sweep parsed sweep-doc verdicts
+ * @param {object} [args.existing] the ledger already committed on disk
+ * @param {string} args.now ISO timestamp for NEW entries only
+ * @returns {{ledger:object, seeded:string[], preserved:string[], residue:string[], reasons:object}}
+ */
+export function buildLedger({ gaps, sql, sweep, existing = {}, now }) {
+  const ledger = {};
+  const seeded = [];
+  const preserved = [];
+  const residue = [];
+  const reasons = {};
+
+  for (const gap of gaps) {
+    const base = String(gap.file).replace(/^.*[\\/]/, '');
+
+    // IDEMPOTENCE + HAND-ADJUDICATION SURVIVAL: an entry already on disk is copied through
+    // byte-for-byte, so recorded_at is never regenerated and a human verdict is never
+    // overwritten by a re-seed. This is what makes `git diff --exit-code` in CI meaningful.
+    if (existing[base]) {
+      ledger[base] = existing[base];
+      preserved.push(base);
+      continue;
+    }
+
+    // RULE A — chairman-gated with no valid approver stamp => DEFERRED.
+    // Fully machine-verifiable and re-derivable from the file itself: the gate marker is
+    // present and the 3-factor guard's own regex finds no usable @approved-by, so the apply
+    // is genuinely waiting on a chairman signature. That is a real deferral, not a guess.
+    const body = sql.get(base) || '';
+    if (CHAIRMAN_GATED_RE.test(body) && !APPROVED_BY_RE.test(body)) {
+      ledger[base] = {
+        disposition: 'DEFERRED',
+        reason: 'Chairman-gated migration carrying no parseable "-- @approved-by: <email>" stamp, '
+          + 'so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is '
+          + 'blocked on chairman sign-off, not on engineering work.',
+        owner: 'chairman',
+        sd_key: SD_KEY,
+        recorded_at: now,
+        source: 'auto:chairman-gate-marker',
+      };
+      seeded.push(base);
+      reasons[base] = 'A';
+      continue;
+    }
+
+    // RULE B — the 2026-06-10 human sweep, but ONLY at full object coverage.
+    //
+    // The doc records verdicts per OBJECT while this ledger is per FILE, and a single file can
+    // host objects with DIFFERENT verdicts (uat-structured-reports.sql appears under both
+    // DEFERRED and RETIRE-CANDIDATES). Promoting a partial object verdict to a file verdict
+    // would over-claim: the sweep simply never looked at the uncovered objects. So the file is
+    // dispositioned only when EVERY object the verifier reports missing is covered by the doc.
+    // FILE ANCHOR (the PRD's content-anchor requirement, FR-1). Matching on object NAME alone
+    // silently re-targets a verdict onto a different migration. Observed for real: the doc
+    // adjudicates v_sd_test_readiness in 20251210_unified_test_evidence.sql, but the verifier's
+    // lifecycle fold attributes that view to 20251211_unified_test_evidence_fixed.sql, which
+    // RECREATED it — so a name-only match stamped a "zero live references, retire-candidate"
+    // verdict onto a file the sweep never looked at. Requiring the doc's cited file to BE this
+    // file makes a drifted key fail safe to undispositioned instead of re-targeting.
+    const missing = Array.isArray(gap.missing) ? gap.missing : [];
+    const verdicts = missing.map((m) => {
+      const hit = sweep.get(String(m.name).toLowerCase());
+      return hit && hit.file === base ? hit.verdict : undefined;
+    });
+    if (missing.length && verdicts.every(Boolean)) {
+      // DEFERRED dominates RETIRED: one live-referenced object is enough to make retiring the
+      // whole file wrong. Conservative direction — never retire something still in use.
+      const verdict = verdicts.includes('DEFERRED') ? 'DEFERRED' : 'RETIRED';
+      ledger[base] = {
+        disposition: verdict,
+        reason: `Human sweep triage docs/database/committed-unapplied-sweep-2026-06-10.md `
+          + `(status: approved) classified all ${missing.length} missing object(s) `
+          + `[${missing.map((m) => m.name).join(', ')}] as ${verdict === 'RETIRED' ? 'zero-live-reference retire-candidates' : 'live-referenced, pending a per-case apply-vs-retire decision'}. `
+          + `File-level verdict is the conservative join over those objects.`,
+        owner: 'SD-LEO-INFRA-APPLY-RETIRE-COMMITTED-001',
+        sd_key: SD_KEY,
+        recorded_at: now,
+        source: 'auto:sweep-2026-06-10',
+      };
+      seeded.push(base);
+      reasons[base] = 'B';
+      continue;
+    }
+
+    // RULE C — no derivable verdict. Left OUT of the ledger on purpose so it keeps counting as
+    // UNDISPOSITIONED. Writing a placeholder here would move the metric without deciding
+    // anything, which is precisely the failure mode FR-3 exists to expose.
+    residue.push(base);
+  }
+
+  return { ledger, seeded, preserved, residue, reasons };
+}
+
+/** Sort keys so re-seeding produces a stable file and `git diff --exit-code` is meaningful. */
+export function serializeLedger(ledger) {
+  const sorted = {};
+  for (const k of Object.keys(ledger).sort()) sorted[k] = ledger[k];
+  return `${JSON.stringify(sorted, null, 2)}\n`;
+}
+
+// ── isMain: all I/O lives below this line ────────────────────────────────────
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const write = process.argv.includes('--write');
+  const gapsArg = process.argv.find((a) => a.startsWith('--gaps='));
+  if (!gapsArg) {
+    console.error('Usage: node scripts/seed-migration-dispositions.mjs --gaps=<verifier --json output> [--write]');
+    process.exit(2);
+  }
+
+  // The verifier prepends a dotenvx banner to stdout before its JSON (pre-existing on
+  // origin/main), so slice from the first line that is exactly '{' rather than parsing raw.
+  const lines = readFileSync(gapsArg.slice('--gaps='.length), 'utf8').split(/\r?\n/);
+  const start = lines.findIndex((l) => l.trim() === '{');
+  const report = JSON.parse(lines.slice(start).join('\n'));
+
+  const ledgerPath = path.join(ROOT, DEFAULT_LEDGER_PATH);
+  const existing = existsSync(ledgerPath) ? JSON.parse(readFileSync(ledgerPath, 'utf8')) : {};
+
+  const sql = new Map();
+  for (const g of report.gaps) {
+    const base = String(g.file).replace(/^.*[\\/]/, '');
+    const p = path.join(ROOT, 'database', 'migrations', base);
+    if (existsSync(p)) sql.set(base, readFileSync(p, 'utf8'));
+  }
+  const sweep = parseSweepDoc(readFileSync(path.join(ROOT, 'docs/database/committed-unapplied-sweep-2026-06-10.md'), 'utf8'));
+
+  const { ledger, seeded, preserved, residue, reasons } = buildLedger({
+    gaps: report.gaps, sql, sweep, existing, now: new Date().toISOString(),
+  });
+
+  const byRule = (r) => seeded.filter((f) => reasons[f] === r).length;
+  console.log(`gap files:      ${report.gaps.length}`);
+  console.log(`preserved:      ${preserved.length} (existing entries, untouched — recorded_at not regenerated)`);
+  console.log(`seeded:         ${seeded.length}  [rule A chairman-gate=${byRule('A')}, rule B sweep-doc=${byRule('B')}]`);
+  console.log(`UNDISPOSITIONED residue requiring human adjudication: ${residue.length}`);
+  console.log(`\nsweep doc parsed: ${sweep.size} object verdicts`);
+  if (seeded.length) {
+    console.log('\nSEEDED:');
+    for (const f of seeded) console.log(`   ${ledger[f].disposition.padEnd(9)} ${f}  (rule ${reasons[f]})`);
+  }
+
+  // Guard the FR-2b invariant at the point of writing, not only in the ledger reader: a future
+  // rule that emitted APPLIED for a gap file would suppress a genuinely-unapplied migration.
+  const bad = Object.entries(ledger).filter(([, e]) => !KNOWN_DISPOSITIONS.includes(e.disposition) || e.disposition === 'APPLIED');
+  if (bad.length) {
+    console.error(`\nREFUSING TO WRITE: ${bad.length} entr(ies) carry APPLIED or an unknown disposition: ${bad.map(([f]) => f).join(', ')}`);
+    console.error('A file in the gap set is by definition NOT applied (FR-2b).');
+    process.exit(1);
+  }
+
+  if (write) {
+    mkdirSync(path.dirname(ledgerPath), { recursive: true });
+    writeFileSync(ledgerPath, serializeLedger(ledger), 'utf8');
+    console.log(`\nwrote ${Object.keys(ledger).length} entries -> ${DEFAULT_LEDGER_PATH}`);
+  } else {
+    console.log('\n(dry run — pass --write to persist)');
+  }
+}

--- a/scripts/seed-migration-dispositions.mjs
+++ b/scripts/seed-migration-dispositions.mjs
@@ -90,6 +90,13 @@ export function buildLedger({ gaps, sql, sweep, existing = {}, now }) {
   const residue = [];
   const reasons = {};
 
+  // CARRY FORWARD EVERY EXISTING ENTRY FIRST, including ones whose file is no longer in the
+  // gap set. Seeding only over `gaps` would silently DELETE a recorded decision the moment its
+  // migration got applied or retired and therefore left the gap set — the audit trail erasing
+  // itself at exactly the moment a decision was fulfilled, which is the opposite of an audit
+  // trail. A disposition is a permanent record of a judgement, not a cache of current state.
+  for (const [basename, entry] of Object.entries(existing)) ledger[basename] = entry;
+
   for (const gap of gaps) {
     const base = String(gap.file).replace(/^.*[\\/]/, '');
 
@@ -112,11 +119,15 @@ export function buildLedger({ gaps, sql, sweep, existing = {}, now }) {
         disposition: 'DEFERRED',
         reason: 'Chairman-gated migration carrying no parseable "-- @approved-by: <email>" stamp, '
           + 'so the 3-factor guard in scripts/lib/migration-guards.js cannot admit it. Apply is '
-          + 'blocked on chairman sign-off, not on engineering work.',
+          + 'blocked on chairman sign-off, not on engineering work. NOTE: the gate marker is '
+          + 'SELF-ASSERTED in the migration file and is not corroborated against an external '
+          + 'registry, so an author can obtain this deferral by adding one comment line to their '
+          + 'own SQL. Treat as disclosed-but-unverified provenance when auditing.',
         owner: 'chairman',
         sd_key: SD_KEY,
         recorded_at: now,
         source: 'auto:chairman-gate-marker',
+        corroborated: false,
       };
       seeded.push(base);
       reasons[base] = 'A';

--- a/scripts/verify-migration-apply-state.mjs
+++ b/scripts/verify-migration-apply-state.mjs
@@ -86,9 +86,35 @@ export function isRecent(file, cutoff = RETIRED_BEFORE) {
   return token !== null && token.slice(0, 8) >= String(cutoff).slice(0, 8);
 }
 
-/** Filter a gaps array (objects with a .file) to only the RECENT ones — the strict-gate fail set. */
-export function partitionRecentGaps(gaps, cutoff = RETIRED_BEFORE) {
-  return (gaps || []).filter((g) => isRecent(g.file, cutoff));
+/**
+ * Basename of a gap's file, tolerating both path separators.
+ *
+ * Deliberately a local 1-liner rather than an import of gapBasename() from
+ * scripts/lib/migration-disposition-ledger.mjs: partitionRecentGaps is a PURE exported
+ * predicate that tests import directly, and the verifier must not carry a static
+ * dependency on the ledger module (see the dynamic-import rationale in main()).
+ */
+const gapFileBasename = (g) => String((g && g.file) || '').replace(/^.*[\\/]/, '');
+
+/**
+ * Filter a gaps array (objects with a .file) to only the RECENT ones — the strict-gate fail set.
+ *
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 FR-6: `suppressed` is an OPTIONAL THIRD
+ * parameter carrying basenames the disposition ledger has legitimately retired or deferred.
+ * It defaults to an empty Set, so every existing 1-arg and 2-arg call site — and the whole
+ * no-ledger path — behaves byte-identically to before this SD.
+ *
+ * isRecent is RETAINED as the fallback rather than replaced: RETIRED_BEFORE still governs
+ * which gaps can turn the gate red while the ledger fills. Suppression only ever REMOVES
+ * from the fail set; it can never admit a legacy gap into it.
+ *
+ * @param {Array<{file:string}>} gaps
+ * @param {string} [cutoff]
+ * @param {Set<string>} [suppressed] basenames with a valid RETIRED/DEFERRED disposition
+ */
+export function partitionRecentGaps(gaps, cutoff = RETIRED_BEFORE, suppressed = new Set()) {
+  const skip = suppressed instanceof Set ? suppressed : new Set();
+  return (gaps || []).filter((g) => isRecent(g.file, cutoff) && !skip.has(gapFileBasename(g)));
 }
 
 // ── Stage 1: list + deterministic order ──────────────────────────────────────
@@ -375,6 +401,31 @@ async function main() {
   }));
   const { expected, droppedLater, perFile } = foldLifecycle(fileFacts);
 
+  // ── Disposition ledger (FR-6) — loaded BEFORE the DB try, deliberately ──────
+  //
+  // CI FALSE-PASS GUARD. Inside the try below, ANY throw prints
+  // MIGRATION_APPLY_STATE_INFRA_ERROR, which migration-deploy-drift-guard.yml greps and
+  // converts to exit 0. A corrupt ledger reaching that path would turn the gate
+  // permanently and SILENTLY GREEN — the precise inversion of fail-open. So the ledger is
+  // read here, in its own guarded block that emits NO outcome marker: a failure degrades to
+  // zero suppression (all drift still reported) and the run continues to the real DB check.
+  //
+  // The import is DYNAMIC for the same reason. A static import that failed to resolve would
+  // reject before main() ever ran and be caught by the entry .catch, which also prints
+  // INFRA_ERROR — reintroducing the false-pass one layer up.
+  let ledger = new Map();
+  let ledgerApi = null;
+  let ledgerLoadError = null;
+  try {
+    ledgerApi = await import('./lib/migration-disposition-ledger.mjs');
+    ledger = ledgerApi.loadLedger(path.resolve(__dirname, '..', ledgerApi.DEFAULT_LEDGER_PATH));
+  } catch (e) {
+    ledgerLoadError = e.message; // stderr only, below — never an OUTCOME marker.
+    ledgerApi = null;
+    ledger = new Map();
+  }
+  if (ledgerLoadError) console.error(`Disposition ledger unavailable (suppressing nothing): ${ledgerLoadError}`);
+
   let live;
   let client;
   try {
@@ -418,12 +469,31 @@ async function main() {
   const gaps = results.filter((r) => r.status === 'PARTIAL' || r.status === 'NOT_APPLIED').reverse(); // newest first
 
   // FR-2 recent-vs-legacy partition. failSet drives the --strict exit + GAPS marker + alert.
-  const recentGaps = partitionRecentGaps(gaps, cutoff);
-  const legacyGaps = gaps.filter((g) => !isRecent(g.file, cutoff));
-  const failSet = recentOnly ? recentGaps : gaps;
+  // FR-6 layers ledger suppression on top: with no (or a broken) ledger every set below is
+  // byte-identical to the pre-SD behaviour, because suppressedSet is empty.
+  const suppressedSet = ledgerApi ? ledgerApi.suppressedBasenames(ledger) : new Set();
+  const suppressedGaps = gaps.filter((g) => suppressedSet.has(gapFileBasename(g)));
+  const activeGaps = gaps.filter((g) => !suppressedSet.has(gapFileBasename(g)));
+  const recentGaps = partitionRecentGaps(gaps, cutoff, suppressedSet);
+  const legacyGaps = activeGaps.filter((g) => !isRecent(g.file, cutoff));
+  const failSet = recentOnly ? recentGaps : activeGaps;
+
+  // FR-3: the machine-checkable definition of done. 117 of the 126 gap files sit behind
+  // RETIRED_BEFORE and can NEVER turn the gate red, so "every file has a decision" is
+  // invisible to a PASS/GAPS exit for 93% of the corpus. This count is computed over ALL
+  // gaps — recent and legacy alike — so completion is provable independently of the marker.
+  const undispositioned = ledgerApi ? ledgerApi.undispositionedBasenames(gaps, ledger) : gaps.map(gapFileBasename);
+  const dispositions = {
+    ledger_entries: ledger.size,
+    ledger_available: Boolean(ledgerApi) && !ledgerLoadError,
+    suppressed: suppressedGaps.length,
+    suppressed_files: suppressedGaps.map(gapFileBasename),
+    undispositioned: undispositioned.length,
+    undispositioned_files: undispositioned,
+  };
 
   if (asJson) {
-    console.log(JSON.stringify({ summary, gaps, recentGaps, legacyGaps, cutoff, recentOnly, droppedLater, files: results }, null, 2));
+    console.log(JSON.stringify({ summary, gaps, recentGaps, legacyGaps, dispositions, cutoff, recentOnly, droppedLater, files: results }, null, 2));
   } else {
     console.log('MIGRATION APPLY-STATE REPORT (advisory, read-only)');
     console.log(`  ordering: legacy non-dated files first (lexical), then date-prefixed (chronological)`);
@@ -443,13 +513,25 @@ async function main() {
           console.log(`  LEGACY gaps suppressed from the fail set (advisory): ${legacyGaps.map((g) => g.file).join(', ')}`);
         }
       } else {
-        console.log(`\n  COMMITTED-NOT-DEPLOYED GAPS (${gaps.length} file(s), newest first):`);
-        for (const g of gaps) {
+        console.log(`\n  COMMITTED-NOT-DEPLOYED GAPS (${activeGaps.length} file(s), newest first):`);
+        for (const g of activeGaps) {
           console.log(`   ${g.status.padEnd(12)} ${g.file}`);
           for (const m of g.missing) console.log(`     missing ${m.cls}: ${m.name}`);
         }
       }
+      // FR-6: suppressed files are dropped from BOTH recentGaps and legacyGaps, so without
+      // this line they would vanish from the report entirely — silent suppression is the
+      // failure mode this SD exists to prevent. BASENAMES ONLY: the ledger's `reason` is
+      // author-controlled text, and echoing it here could emit either OUTCOME literal, which
+      // migration-deploy-drift-guard.yml greps for — letting a reason string steer the gate.
+      if (suppressedGaps.length) {
+        console.log(`\n  SUPPRESSED BY LEDGER (${suppressedGaps.length}): ${suppressedGaps.map(gapFileBasename).join(', ')}`);
+        console.log(`  (reasons are recorded in the ledger and in audit_log; run --json for the machine-readable set)`);
+      }
     }
+    // FR-3: printed unconditionally — "0 undispositioned" is the completion signal, and a
+    // line that only appears when non-zero cannot be used to prove the zero.
+    console.log(`\n  DISPOSITIONS: ${dispositions.undispositioned} of ${gaps.length} gap file(s) undispositioned; ${dispositions.suppressed} suppressed; ledger entries=${dispositions.ledger_entries}${dispositions.ledger_available ? '' : ' (LEDGER UNAVAILABLE — suppressing nothing)'}`);
   }
 
   // SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-C (FR-C2): surface a committed-not-deployed migration gap

--- a/scripts/verify-migration-apply-state.mjs
+++ b/scripts/verify-migration-apply-state.mjs
@@ -395,10 +395,26 @@ async function main() {
   const cutoff = sinceVal || RETIRED_BEFORE;
 
   const { forward, down } = listForwardMigrations();
-  const fileFacts = forward.map((file) => ({
-    file,
-    ...extractDdlFacts(readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8')),
-  }));
+  // An unreadable entry is an operator error, not a transient outage, and it must FAIL CLOSED.
+  // Left unguarded, a committed DIRECTORY named `x.sql/` (git stores `x.sql/keep`) passes the
+  // .sql filter and makes readFileSync throw EISDIR, which escapes main() into the entry catch
+  // and prints INFRA_ERROR — which the drift-guard workflow converts to exit 0. That is a
+  // one-commit permanent gate silencer. MISCONFIG matches how this file already treats a
+  // missing credential: a gate that cannot verify must say so loudly, never pass quietly.
+  const unreadable = [];
+  const fileFacts = [];
+  for (const file of forward) {
+    try {
+      fileFacts.push({ file, ...extractDdlFacts(readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8')) });
+    } catch (e) {
+      unreadable.push(`${file} (${e.code || e.message})`);
+    }
+  }
+  if (unreadable.length) {
+    console.error(`Unreadable migration entr(ies) in ${MIGRATIONS_DIR}: ${unreadable.join(', ')}`);
+    console.log(`[${OUTCOME.MISCONFIG}]`);
+    return 2;
+  }
   const { expected, droppedLater, perFile } = foldLifecycle(fileFacts);
 
   // ── Disposition ledger (FR-6) — loaded BEFORE the DB try, deliberately ──────
@@ -416,15 +432,21 @@ async function main() {
   let ledger = new Map();
   let ledgerApi = null;
   let ledgerLoadError = null;
+  let ledgerStatus = 'unavailable';
   try {
     ledgerApi = await import('./lib/migration-disposition-ledger.mjs');
-    ledger = ledgerApi.loadLedger(path.resolve(__dirname, '..', ledgerApi.DEFAULT_LEDGER_PATH));
+    const seen = ledgerApi.inspectLedger(path.resolve(__dirname, '..', ledgerApi.DEFAULT_LEDGER_PATH));
+    ledger = seen.ledger;
+    ledgerStatus = seen.status;
   } catch (e) {
     ledgerLoadError = e.message; // stderr only, below — never an OUTCOME marker.
     ledgerApi = null;
     ledger = new Map();
+    ledgerStatus = 'unavailable';
   }
-  if (ledgerLoadError) console.error(`Disposition ledger unavailable (suppressing nothing): ${ledgerLoadError}`);
+  // A corrupt ledger suppresses nothing (fail-open), but must not LOOK like an empty one.
+  if (ledgerLoadError) console.error(`Disposition ledger module unavailable (suppressing nothing): ${ledgerLoadError}`);
+  else if (ledgerStatus !== 'ok' && ledgerStatus !== 'absent') console.error(`Disposition ledger is ${ledgerStatus} (suppressing nothing) — fix ${ledgerApi.DEFAULT_LEDGER_PATH}`);
 
   let live;
   let client;
@@ -482,14 +504,24 @@ async function main() {
   // RETIRED_BEFORE and can NEVER turn the gate red, so "every file has a decision" is
   // invisible to a PASS/GAPS exit for 93% of the corpus. This count is computed over ALL
   // gaps — recent and legacy alike — so completion is provable independently of the marker.
-  const undispositioned = ledgerApi ? ledgerApi.undispositionedBasenames(gaps, ledger) : gaps.map(gapFileBasename);
+  // The no-module fallback must report the SAME shape as the real path — deduplicated, sorted,
+  // and free of empty basenames — or the headline count silently changes meaning depending on
+  // whether the import resolved.
+  const undispositioned = ledgerApi
+    ? ledgerApi.undispositionedBasenames(gaps, ledger)
+    : [...new Set(gaps.map(gapFileBasename).filter(Boolean))].sort();
+  // Marked APPLIED yet still missing objects live — the ledger contradicts the schema.
+  const contradictory = ledgerApi ? ledgerApi.contradictoryBasenames(gaps, ledger) : [];
   const dispositions = {
     ledger_entries: ledger.size,
-    ledger_available: Boolean(ledgerApi) && !ledgerLoadError,
+    ledger_status: ledgerStatus,
+    ledger_available: Boolean(ledgerApi) && !ledgerLoadError && ledgerStatus === 'ok',
     suppressed: suppressedGaps.length,
     suppressed_files: suppressedGaps.map(gapFileBasename),
     undispositioned: undispositioned.length,
     undispositioned_files: undispositioned,
+    contradictory: contradictory.length,
+    contradictory_files: contradictory,
   };
 
   if (asJson) {
@@ -531,7 +563,13 @@ async function main() {
     }
     // FR-3: printed unconditionally — "0 undispositioned" is the completion signal, and a
     // line that only appears when non-zero cannot be used to prove the zero.
-    console.log(`\n  DISPOSITIONS: ${dispositions.undispositioned} of ${gaps.length} gap file(s) undispositioned; ${dispositions.suppressed} suppressed; ledger entries=${dispositions.ledger_entries}${dispositions.ledger_available ? '' : ' (LEDGER UNAVAILABLE — suppressing nothing)'}`);
+    console.log(`\n  DISPOSITIONS: ${dispositions.undispositioned} of ${gaps.length} gap file(s) undispositioned; ${dispositions.suppressed} suppressed; ledger entries=${dispositions.ledger_entries} (status=${ledgerStatus})`);
+    // A contradiction means the ledger claims APPLIED for a migration whose objects are
+    // verifiably absent live — either the ledger is lying or an apply failed silently.
+    // Both deserve an operator's eyes, so this prints even though it suppresses nothing.
+    if (dispositions.contradictory) {
+      console.log(`  ⚠ LEDGER CONTRADICTS SCHEMA (${dispositions.contradictory}): marked APPLIED but still missing live objects: ${dispositions.contradictory_files.join(', ')}`);
+    }
   }
 
   // SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-C (FR-C2): surface a committed-not-deployed migration gap
@@ -542,13 +580,22 @@ async function main() {
   // _DOWN migration is an expected gap, not a CRITICAL incident. Emit only when the operator has declared
   // the gaps actionable via --alert or --strict (strict already treats gaps as a failure exit).
   if (failSet.length > 0 && (args.includes('--alert') || strict)) {
-    const { createRequire } = await import('node:module');
-    const { emitBreakageAlert } = createRequire(import.meta.url)('../lib/breakage/emit-breakage-alert.cjs');
-    await emitBreakageAlert('migration-fail', 'migration-apply-state', {
-      message: `migration-apply-state: ${failSet.length} ${recentOnly ? 'recent ' : ''}committed-not-deployed migration gap(s)`,
-      sourceEntityId: failSet[0] ? failSet[0].file : null,
-      metadata: { gap_count: failSet.length, recent_only: recentOnly, gaps: failSet.map((g) => ({ file: g.file, status: g.status })) },
-    });
+    // emitBreakageAlert's BODY is fail-soft, but its MODULE LOAD is not: the require sits
+    // outside that boundary, and emit-breakage-alert.cjs top-level-requires alert-writer.cjs.
+    // A broken file there would throw past main() into the entry catch, print INFRA_ERROR, and
+    // the drift-guard workflow converts INFRA_ERROR to exit 0 — so the alerting path could fail
+    // the gate OPEN at precisely the moment it detected gaps. Contain load and call together.
+    try {
+      const { createRequire } = await import('node:module');
+      const { emitBreakageAlert } = createRequire(import.meta.url)('../lib/breakage/emit-breakage-alert.cjs');
+      await emitBreakageAlert('migration-fail', 'migration-apply-state', {
+        message: `migration-apply-state: ${failSet.length} ${recentOnly ? 'recent ' : ''}committed-not-deployed migration gap(s)`,
+        sourceEntityId: failSet[0] ? failSet[0].file : null,
+        metadata: { gap_count: failSet.length, recent_only: recentOnly, gaps: failSet.map((g) => ({ file: g.file, status: g.status })) },
+      });
+    } catch (e) {
+      console.error(`Breakage alert failed (non-fatal, gate verdict unaffected): ${e.message}`);
+    }
   }
 
   // failSet drives the marker + strict exit: with --recent-only, legacy gaps print

--- a/scripts/verify-migration-apply-state.mjs
+++ b/scripts/verify-migration-apply-state.mjs
@@ -97,6 +97,18 @@ export function isRecent(file, cutoff = RETIRED_BEFORE) {
 const gapFileBasename = (g) => String((g && g.file) || '').replace(/^.*[\\/]/, '');
 
 /**
+ * Collapse newlines before echoing any FILENAME to stdout.
+ *
+ * migration-deploy-drift-guard.yml decides the gate verdict by matching bracketed markers in
+ * this output. Anchoring those greps with -Fx closed the substring attack, but a filename
+ * containing an embedded newline could still contribute a line that IS exactly a marker, and
+ * the INFRA marker is converted to exit 0. Git refuses such paths under core.protectNTFS
+ * (default-on since 2.25), so this is defence in depth — but relying on another tool's input
+ * validation to keep a safety gate honest is not a property worth depending on.
+ */
+const printableFile = (f) => String(f).replace(/[\r\n]+/g, ' ');
+
+/**
  * Filter a gaps array (objects with a .file) to only the RECENT ones — the strict-gate fail set.
  *
  * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 FR-6: `suppressed` is an OPTIONAL THIRD
@@ -537,17 +549,17 @@ async function main() {
         if (recentGaps.length) {
           console.log(`  RECENT COMMITTED-NOT-DEPLOYED GAPS (newest first):`);
           for (const g of recentGaps) {
-            console.log(`   ${g.status.padEnd(12)} ${g.file}  [RECENT]`);
+            console.log(`   ${g.status.padEnd(12)} ${printableFile(g.file)}  [RECENT]`);
             for (const m of g.missing) console.log(`     missing ${m.cls}: ${m.name}`);
           }
         }
         if (legacyGaps.length) {
-          console.log(`  LEGACY gaps suppressed from the fail set (advisory): ${legacyGaps.map((g) => g.file).join(', ')}`);
+          console.log(`  LEGACY gaps suppressed from the fail set (advisory): ${legacyGaps.map((g) => printableFile(g.file)).join(', ')}`);
         }
       } else {
         console.log(`\n  COMMITTED-NOT-DEPLOYED GAPS (${activeGaps.length} file(s), newest first):`);
         for (const g of activeGaps) {
-          console.log(`   ${g.status.padEnd(12)} ${g.file}`);
+          console.log(`   ${g.status.padEnd(12)} ${printableFile(g.file)}`);
           for (const m of g.missing) console.log(`     missing ${m.cls}: ${m.name}`);
         }
       }
@@ -557,7 +569,7 @@ async function main() {
       // author-controlled text, and echoing it here could emit either OUTCOME literal, which
       // migration-deploy-drift-guard.yml greps for — letting a reason string steer the gate.
       if (suppressedGaps.length) {
-        console.log(`\n  SUPPRESSED BY LEDGER (${suppressedGaps.length}): ${suppressedGaps.map(gapFileBasename).join(', ')}`);
+        console.log(`\n  SUPPRESSED BY LEDGER (${suppressedGaps.length}): ${suppressedGaps.map((g) => printableFile(gapFileBasename(g))).join(', ')}`);
         console.log(`  (reasons are recorded in the ledger and in audit_log; run --json for the machine-readable set)`);
       }
     }
@@ -568,7 +580,7 @@ async function main() {
     // verifiably absent live — either the ledger is lying or an apply failed silently.
     // Both deserve an operator's eyes, so this prints even though it suppresses nothing.
     if (dispositions.contradictory) {
-      console.log(`  ⚠ LEDGER CONTRADICTS SCHEMA (${dispositions.contradictory}): marked APPLIED but still missing live objects: ${dispositions.contradictory_files.join(', ')}`);
+      console.log(`  ⚠ LEDGER CONTRADICTS SCHEMA (${dispositions.contradictory}): marked APPLIED but still missing live objects: ${dispositions.contradictory_files.map(printableFile).join(', ')}`);
     }
   }
 

--- a/tests/integration/migration-apply-state-ledger-wiring.test.js
+++ b/tests/integration/migration-apply-state-ledger-wiring.test.js
@@ -1,0 +1,116 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 — FR-6 wiring, end to end.
+ *
+ * WHY A SUBPROCESS TEST. Everything else in this SD is covered by pure unit tests, but the
+ * single most safety-critical claim is STRUCTURAL: the ledger is loaded OUTSIDE the DB try
+ * block, so a corrupt ledger can never print MIGRATION_APPLY_STATE_INFRA_ERROR — which
+ * .github/workflows/migration-deploy-drift-guard.yml converts to `exit 0`. If that placement
+ * ever regressed, a corrupt ledger would turn the drift gate permanently and SILENTLY GREEN.
+ *
+ * A unit test cannot see that: main() is not exported, and partitionRecentGaps only covers the
+ * easy half of the seam (a hand-built Set). The claim lived in a code comment, and
+ * correct-by-comment is not verified. This runs the real CLI against a deliberately corrupted
+ * ledger and asserts on its actual output.
+ *
+ * The real ledger is backed up and restored in a finally, so a failure here cannot leave the
+ * repo's committed artifact corrupted.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const VERIFIER = path.join(ROOT, 'scripts', 'verify-migration-apply-state.mjs');
+const LEDGER = path.join(ROOT, 'docs', 'audits', 'migration-dispositions.json');
+const INFRA = '[MIGRATION_APPLY_STATE_INFRA_ERROR]';
+const PASS = '[MIGRATION_APPLY_STATE_PASS]';
+
+/**
+ * Run the verifier, returning BOTH streams plus the exit code.
+ *
+ * spawnSync rather than execFileSync: the latter returns only stdout on success, which would
+ * silently drop the stderr diagnostics this test exists to assert on. The workflow itself
+ * captures `2>&1`, so combining them here matches what CI actually greps.
+ */
+function runVerifier(args = []) {
+  const r = spawnSync('node', [VERIFIER, ...args], { cwd: ROOT, encoding: 'utf8', timeout: 240000 });
+  return { out: `${r.stdout || ''}${r.stderr || ''}`, code: r.status ?? -1 };
+}
+
+let original = null;
+beforeAll(() => { if (fs.existsSync(LEDGER)) original = fs.readFileSync(LEDGER, 'utf8'); });
+afterAll(() => {
+  if (original !== null) fs.writeFileSync(LEDGER, original, 'utf8');
+  else if (fs.existsSync(LEDGER)) fs.rmSync(LEDGER);
+});
+
+describe('FR-6 wiring — a corrupt ledger must never fail the gate OPEN', () => {
+  it('a malformed ledger yields NO INFRA_ERROR and NO false PASS', () => {
+    fs.mkdirSync(path.dirname(LEDGER), { recursive: true });
+    fs.writeFileSync(LEDGER, '{ this is not valid json', 'utf8');
+
+    const { out } = runVerifier();
+
+    // The whole point: a ledger problem must not be reported as a DB infrastructure problem,
+    // because the workflow treats INFRA_ERROR as "skip, exit 0".
+    expect(out).not.toContain(INFRA);
+    // ...and it must not silently pass either. Real gaps are still present, so the verdict
+    // must remain GAPS_FOUND.
+    expect(out).not.toContain(PASS);
+    expect(out).toContain('[MIGRATION_APPLY_STATE_GAPS_FOUND]');
+    // The operator is told the ledger is broken rather than seeing a plausible "0 entries".
+    expect(out).toMatch(/ledger is malformed/i);
+  }, 300000);
+
+  it('a malformed ledger suppresses NOTHING — every gap is still reported', () => {
+    fs.writeFileSync(LEDGER, '{ broken', 'utf8');
+    const { out } = runVerifier();
+    expect(out).toMatch(/DISPOSITIONS: \d+ of \d+ gap file\(s\) undispositioned; 0 suppressed/);
+    expect(out).toContain('status=malformed');
+  }, 300000);
+
+  it('an ARRAY ledger (valid JSON, wrong shape) is refused, not iterated', () => {
+    fs.writeFileSync(LEDGER, '[{"disposition":"RETIRED","reason":"x"}]', 'utf8');
+    const { out } = runVerifier();
+    expect(out).not.toContain(INFRA);
+    expect(out).toContain('status=wrong-shape');
+    expect(out).toMatch(/0 suppressed/);
+  }, 300000);
+
+  it('an APPLIED ledger entry cannot suppress a real gap or fake completion, end to end', () => {
+    // The FR-2b guard proven through the actual CLI rather than through the pure function:
+    // claim every one of the recent gap files is APPLIED and confirm the gate stays red, the
+    // suppression count stays 0, and the contradiction is surfaced.
+    const forged = {
+      '20260713_quick_fixes_factory_lane.sql': {
+        disposition: 'APPLIED', reason: 'forged by a test to prove this cannot suppress',
+        owner: 'test', sd_key: 'SD-TEST', recorded_at: '2026-07-25T00:00:00.000Z',
+      },
+    };
+    fs.writeFileSync(LEDGER, JSON.stringify(forged, null, 2), 'utf8');
+
+    const { out, code } = runVerifier(['--strict', '--recent-only']);
+    expect(out).toContain('[MIGRATION_APPLY_STATE_GAPS_FOUND]');
+    expect(code).toBe(1); // still blocking
+    expect(out).toMatch(/0 suppressed/);
+    expect(out).toContain('LEDGER CONTRADICTS SCHEMA');
+    expect(out).toContain('20260713_quick_fixes_factory_lane.sql');
+  }, 300000);
+
+  it('the committed ledger is well-formed and its suppressions are all reason-carrying', () => {
+    // Guards the real artifact, not a fixture: a committed ledger that failed to parse would
+    // silently stop suppressing, and this SD would look finished while doing nothing.
+    expect(original, 'docs/audits/migration-dispositions.json should be committed').not.toBeNull();
+    const parsed = JSON.parse(original);
+    expect(Array.isArray(parsed)).toBe(false);
+    for (const [file, entry] of Object.entries(parsed)) {
+      expect(['APPLIED', 'RETIRED', 'DEFERRED'], `${file} disposition`).toContain(entry.disposition);
+      expect(entry.reason.replace(/[\s​-‍­﻿]/g, '').length, `${file} reason`).toBeGreaterThan(20);
+      expect(entry.sd_key, `${file} sd_key`).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/migration-disposition-ledger.test.js
+++ b/tests/unit/migration-disposition-ledger.test.js
@@ -1,0 +1,215 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 — disposition ledger invariants.
+ *
+ * Each describe block guards one specific way this SD could ghost-complete or
+ * cause harm. TS-6 is the load-bearing one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  isSuppressingEntry,
+  loadLedger,
+  suppressedBasenames,
+  applyDispositions,
+  undispositionedBasenames,
+  gapBasename,
+  SUPPRESSING_DISPOSITIONS,
+  KNOWN_DISPOSITIONS
+} from '../../scripts/lib/migration-disposition-ledger.mjs';
+
+const GOOD_REASON = 'superseded by 20260801_consolidated.sql; verified no live readers';
+
+function entry(over = {}) {
+  return { disposition: 'RETIRED', reason: GOOD_REASON, owner: 'Alpha-2', sd_key: 'SD-X', ...over };
+}
+
+let tmpdir;
+beforeEach(() => { tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'disp-ledger-')); });
+afterEach(() => { try { fs.rmSync(tmpdir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function writeLedger(contents) {
+  const p = path.join(tmpdir, 'ledger.json');
+  fs.writeFileSync(p, typeof contents === 'string' ? contents : JSON.stringify(contents), 'utf8');
+  return p;
+}
+
+describe('TS-6 GHOST-COMPLETION GUARD — APPLIED can never suppress (FR-2b)', () => {
+  // The single highest-risk path in this SD. The failure is auto-seeded and
+  // well-formed, so neither the reason-required test nor the fail-open test
+  // catches it: FR-2 seeds from reachability buckets whose vocabulary is
+  // "REACHABLE = APPLY candidates", and the natural mapping bug writes APPLIED
+  // for exactly the recent files that have NOT been applied yet.
+  it('does not suppress a file marked APPLIED even with a valid reason', () => {
+    expect(isSuppressingEntry(entry({ disposition: 'APPLIED' }))).toBe(false);
+  });
+
+  it('leaves an APPLIED-marked file in the reported gap set', () => {
+    const gaps = [{ file: 'database/migrations/20260724190000_add_manual_revenue.sql' }];
+    const ledger = new Map([['20260724190000_add_manual_revenue.sql', entry({ disposition: 'APPLIED' })]]);
+    const { remaining, suppressed } = applyDispositions(gaps, ledger);
+    expect(suppressed).toHaveLength(0);
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('still counts APPLIED as a real DECISION for the undispositioned tally', () => {
+    // APPLIED is a legitimate disposition — it just is not grounds for
+    // suppression. Conflating the two would force a false choice between
+    // "cannot record an apply" and "an apply hides drift".
+    const gaps = [{ file: 'a.sql' }];
+    const ledger = new Map([['a.sql', entry({ disposition: 'APPLIED' })]]);
+    expect(undispositionedBasenames(gaps, ledger)).toEqual([]);
+    expect(applyDispositions(gaps, ledger).suppressed).toHaveLength(0);
+  });
+
+  it('excludes APPLIED from the suppressing set but keeps it known', () => {
+    expect(SUPPRESSING_DISPOSITIONS).not.toContain('APPLIED');
+    expect(KNOWN_DISPOSITIONS).toContain('APPLIED');
+  });
+});
+
+describe('TS-1 reason-required invariant (FR-1)', () => {
+  it('ignores an entry with no reason key', () => {
+    const e = entry(); delete e.reason;
+    expect(isSuppressingEntry(e)).toBe(false);
+  });
+
+  it.each([['empty', ''], ['spaces', '   '], ['tab', '\t'], ['newline', '\n']])(
+    'ignores a %s reason — trimmed, so bare truthiness would wrongly pass',
+    (_label, reason) => { expect(isSuppressingEntry(entry({ reason }))).toBe(false); }
+  );
+
+  it.each([['null', null], ['zero', 0], ['false', false], ['object', {}], ['array', []]])(
+    'ignores a non-string reason (%s)',
+    (_label, reason) => { expect(isSuppressingEntry(entry({ reason }))).toBe(false); }
+  );
+
+  it('POSITIVE CONTROL — suppresses when the reason is genuinely present', () => {
+    expect(isSuppressingEntry(entry())).toBe(true);
+    expect(isSuppressingEntry(entry({ disposition: 'DEFERRED' }))).toBe(true);
+  });
+});
+
+describe('fail-closed enum — unknown dispositions never suppress', () => {
+  it.each([['APPLY', 'APPLY'], ['TODO', 'TODO'], ['retired lowercase', 'retired'], ['typo', 'RETIRD'], ['empty', '']])(
+    'ignores unrecognised disposition %s',
+    (_label, disposition) => { expect(isSuppressingEntry(entry({ disposition }))).toBe(false); }
+  );
+
+  it('ignores APPLY specifically — the reachability-bucket wording that causes the mapping bug', () => {
+    expect(isSuppressingEntry(entry({ disposition: 'APPLY' }))).toBe(false);
+  });
+});
+
+describe('TS-2 FAIL OPEN — a broken ledger suppresses nothing (FR-6)', () => {
+  it('returns an empty map when the file is absent', () => {
+    expect(loadLedger(path.join(tmpdir, 'nope.json')).size).toBe(0);
+  });
+
+  it.each([
+    ['malformed', '{ not json'],
+    ['truncated', '{"a":'],
+    ['empty', ''],
+    ['whitespace', '   \n  '],
+    ['array', '[]'],
+    ['scalar string', '"hello"'],
+    ['null', 'null']
+  ])('returns an empty map for %s content', (_label, body) => {
+    expect(loadLedger(writeLedger(body)).size).toBe(0);
+  });
+
+  it('returns an empty map for a directory instead of a file', () => {
+    const d = path.join(tmpdir, 'adir'); fs.mkdirSync(d);
+    expect(loadLedger(d).size).toBe(0);
+  });
+
+  it('MASS-SUPPRESSION TRIPWIRE — 126 gaps + corrupt ledger suppresses exactly 0', () => {
+    // Asserted as suppressed===0 rather than remaining.length>0, which would
+    // pass vacuously even if 125 of 126 were silently suppressed.
+    const gaps = Array.from({ length: 126 }, (_, i) => ({ file: `m${i}.sql` }));
+    const { remaining, suppressed } = applyDispositions(gaps, loadLedger(writeLedger('{ broken')));
+    expect(suppressed).toHaveLength(0);
+    expect(remaining).toHaveLength(126);
+  });
+
+  it('no-ledger behaviour is identical to empty-ledger behaviour', () => {
+    const gaps = [{ file: 'a.sql' }, { file: 'b.sql' }];
+    expect(applyDispositions(gaps, new Map()).remaining)
+      .toEqual(applyDispositions(gaps, loadLedger(path.join(tmpdir, 'absent.json'))).remaining);
+  });
+
+  it('tolerates wrong-shaped entries inside an otherwise valid ledger', () => {
+    const ledger = loadLedger(writeLedger({ 'a.sql': 'a string', 'b.sql': null, 'c.sql': [], 'd.sql': entry() }));
+    expect(suppressedBasenames(ledger)).toEqual(new Set(['d.sql']));
+  });
+});
+
+describe('FR-3 undispositioned count — the machine-checkable DoD', () => {
+  it('lists gaps carrying no ledger entry', () => {
+    const gaps = [{ file: 'a.sql' }, { file: 'b.sql' }, { file: 'c.sql' }];
+    const ledger = new Map([['b.sql', entry()]]);
+    expect(undispositionedBasenames(gaps, ledger)).toEqual(['a.sql', 'c.sql']);
+  });
+
+  it('counts a reason-less entry as UNDISPOSITIONED — a decision nobody can read is not a decision', () => {
+    const gaps = [{ file: 'a.sql' }];
+    expect(undispositionedBasenames(gaps, new Map([['a.sql', entry({ reason: '  ' })]]))).toEqual(['a.sql']);
+  });
+
+  it('counts an unknown-disposition entry as UNDISPOSITIONED', () => {
+    const gaps = [{ file: 'a.sql' }];
+    expect(undispositionedBasenames(gaps, new Map([['a.sql', entry({ disposition: 'APPLY' })]]))).toEqual(['a.sql']);
+  });
+
+  it('reaches zero only when every gap is genuinely decided', () => {
+    const gaps = [{ file: 'a.sql' }, { file: 'b.sql' }];
+    const ledger = new Map([['a.sql', entry()], ['b.sql', entry({ disposition: 'APPLIED' })]]);
+    expect(undispositionedBasenames(gaps, ledger)).toEqual([]);
+  });
+
+  it('returns sorted, deduplicated output', () => {
+    const gaps = [{ file: 'z.sql' }, { file: 'a.sql' }, { file: 'z.sql' }];
+    expect(undispositionedBasenames(gaps, new Map())).toEqual(['a.sql', 'z.sql']);
+  });
+});
+
+describe('basename keying — stable across worktrees', () => {
+  it.each([
+    ['posix path', 'database/migrations/20260711_x.sql'],
+    ['windows path', 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\database\\migrations\\20260711_x.sql'],
+    ['worktree path', 'C:/Users/rickf/.worktrees/SD-A/database/migrations/20260711_x.sql'],
+    ['bare basename', '20260711_x.sql']
+  ])('extracts the same basename from a %s', (_label, file) => {
+    expect(gapBasename({ file })).toBe('20260711_x.sql');
+  });
+
+  it('accepts a bare string gap as well as a {file} object', () => {
+    expect(gapBasename('database/migrations/a.sql')).toBe('a.sql');
+  });
+
+  it.each([['null', null], ['undefined', undefined], ['empty object', {}], ['number', 42]])(
+    'returns empty string for a malformed gap (%s)',
+    (_label, gap) => { expect(gapBasename(gap)).toBe(''); }
+  );
+
+  it('does not dereference fields beyond .file — gap objects may carry only {file}', () => {
+    expect(() => applyDispositions([{ file: 'a.sql' }], new Map())).not.toThrow();
+  });
+});
+
+describe('totality — no input shape throws', () => {
+  it.each([['null', null], ['undefined', undefined], ['string', 'x'], ['number', 1], ['array', []]])(
+    'isSuppressingEntry(%s) returns false rather than throwing',
+    (_label, v) => { expect(isSuppressingEntry(v)).toBe(false); }
+  );
+
+  it('applyDispositions tolerates a non-array gaps argument', () => {
+    expect(applyDispositions(null, new Map())).toEqual({ remaining: [], suppressed: [] });
+  });
+
+  it('suppressedBasenames tolerates a non-Map ledger', () => {
+    expect(suppressedBasenames({})).toEqual(new Set());
+  });
+});

--- a/tests/unit/migration-disposition-ledger.test.js
+++ b/tests/unit/migration-disposition-ledger.test.js
@@ -12,9 +12,12 @@ import path from 'path';
 import {
   isSuppressingEntry,
   loadLedger,
+  inspectLedger,
   suppressedBasenames,
   applyDispositions,
   undispositionedBasenames,
+  contradictoryBasenames,
+  hasReadableReason,
   gapBasename,
   SUPPRESSING_DISPOSITIONS,
   KNOWN_DISPOSITIONS
@@ -54,14 +57,34 @@ describe('TS-6 GHOST-COMPLETION GUARD — APPLIED can never suppress (FR-2b)', (
     expect(remaining).toHaveLength(1);
   });
 
-  it('still counts APPLIED as a real DECISION for the undispositioned tally', () => {
-    // APPLIED is a legitimate disposition — it just is not grounds for
-    // suppression. Conflating the two would force a false choice between
-    // "cannot record an apply" and "an apply hides drift".
+  it('APPLIED on a file still IN gaps counts as UNDISPOSITIONED, not decided', () => {
+    // This assertion was originally inverted — it credited APPLIED as a real decision, on the
+    // reasoning that APPLIED is legitimate and merely non-suppressing. Two independent
+    // adversarial reviews showed that hands over the completion metric: hand-writing APPLIED
+    // for all 123 residual files drives "undispositioned" to 0 while suppressing nothing and
+    // leaving every gap real. FR-2b guards what the GATE BLOCKS on; this guards what the SD
+    // CLAIMS. A file in the gap set is not applied, whatever the ledger says.
     const gaps = [{ file: 'a.sql' }];
     const ledger = new Map([['a.sql', entry({ disposition: 'APPLIED' })]]);
-    expect(undispositionedBasenames(gaps, ledger)).toEqual([]);
+    expect(undispositionedBasenames(gaps, ledger)).toEqual(['a.sql']);
     expect(applyDispositions(gaps, ledger).suppressed).toHaveLength(0);
+  });
+
+  it('surfaces the contradiction explicitly rather than discarding it', () => {
+    const gaps = [{ file: 'a.sql' }, { file: 'b.sql' }];
+    const ledger = new Map([['a.sql', entry({ disposition: 'APPLIED' })], ['b.sql', entry()]]);
+    expect(contradictoryBasenames(gaps, ledger)).toEqual(['a.sql']);
+  });
+
+  it('APPLIED for a file NOT in the gap set is not a contradiction — that is the normal post-apply fact', () => {
+    const ledger = new Map([['applied-and-gone.sql', entry({ disposition: 'APPLIED' })]]);
+    expect(contradictoryBasenames([{ file: 'other.sql' }], ledger)).toEqual([]);
+  });
+
+  it('a reason-less or unknown-disposition APPLIED entry is malformed, not a contradiction', () => {
+    const gaps = [{ file: 'a.sql' }];
+    expect(contradictoryBasenames(gaps, new Map([['a.sql', entry({ disposition: 'APPLIED', reason: '  ' })]]))).toEqual([]);
+    expect(contradictoryBasenames(gaps, new Map([['a.sql', entry({ disposition: 'APPLY' })]]))).toEqual([]);
   });
 
   it('excludes APPLIED from the suppressing set but keeps it known', () => {
@@ -89,6 +112,47 @@ describe('TS-1 reason-required invariant (FR-1)', () => {
   it('POSITIVE CONTROL — suppresses when the reason is genuinely present', () => {
     expect(isSuppressingEntry(entry())).toBe(true);
     expect(isSuppressingEntry(entry({ disposition: 'DEFERRED' }))).toBe(true);
+  });
+
+  // String.trim() strips only WhiteSpace/LineTerminator, so these pass a trim-based check
+  // while rendering blank in every editor and diff — a reason no human can read, satisfying
+  // a rule named "reason required". Found by adversarial review.
+  it.each([
+    ['zero-width space', '​'],
+    ['zero-width non-joiner', '‌'],
+    ['zero-width joiner', '‍'],
+    ['soft hyphen', '­'],
+    ['BOM', '﻿'],
+    ['mixed invisibles + spaces', ' ​ ­﻿ '],
+  ])('rejects an invisible-only reason (%s)', (_label, reason) => {
+    expect(isSuppressingEntry(entry({ reason }))).toBe(false);
+    expect(hasReadableReason(reason)).toBe(false);
+  });
+
+  it('accepts a reason that merely CONTAINS an invisible character', () => {
+    expect(hasReadableReason('superseded​ by 20260801')).toBe(true);
+    expect(isSuppressingEntry(entry({ reason: 'superseded​ by 20260801' }))).toBe(true);
+  });
+});
+
+describe('inspectLedger — fail-open suppression, but an honest status for humans', () => {
+  it('distinguishes absent from malformed so a corrupt ledger cannot read as "no decisions yet"', () => {
+    expect(inspectLedger(path.join(tmpdir, 'nope.json'))).toMatchObject({ status: 'absent' });
+    expect(inspectLedger(writeLedger('{ broken'))).toMatchObject({ status: 'malformed' });
+    expect(inspectLedger(writeLedger('[]'))).toMatchObject({ status: 'wrong-shape' });
+    expect(inspectLedger(writeLedger({ 'a.sql': entry() }))).toMatchObject({ status: 'ok' });
+  });
+
+  it('every non-ok status still yields an EMPTY map — reporting changed, fail-open did not', () => {
+    for (const body of ['{ broken', '[]', '"str"', 'null', '']) {
+      expect(inspectLedger(writeLedger(body)).ledger.size).toBe(0);
+    }
+    expect(inspectLedger(path.join(tmpdir, 'nope.json')).ledger.size).toBe(0);
+  });
+
+  it('loadLedger stays a thin wrapper returning just the map', () => {
+    const p = writeLedger({ 'a.sql': entry() });
+    expect(loadLedger(p)).toEqual(inspectLedger(p).ledger);
   });
 });
 
@@ -165,8 +229,16 @@ describe('FR-3 undispositioned count — the machine-checkable DoD', () => {
 
   it('reaches zero only when every gap is genuinely decided', () => {
     const gaps = [{ file: 'a.sql' }, { file: 'b.sql' }];
-    const ledger = new Map([['a.sql', entry()], ['b.sql', entry({ disposition: 'APPLIED' })]]);
+    const ledger = new Map([['a.sql', entry()], ['b.sql', entry({ disposition: 'DEFERRED' })]]);
     expect(undispositionedBasenames(gaps, ledger)).toEqual([]);
+  });
+
+  it('CANNOT be driven to zero by marking every gap APPLIED — the metric-spoofing path', () => {
+    const gaps = Array.from({ length: 123 }, (_, i) => ({ file: `m${i}.sql` }));
+    const ledger = new Map(gaps.map((g) => [g.file, entry({ disposition: 'APPLIED' })]));
+    expect(undispositionedBasenames(gaps, ledger)).toHaveLength(123);
+    expect(applyDispositions(gaps, ledger).suppressed).toHaveLength(0);
+    expect(contradictoryBasenames(gaps, ledger)).toHaveLength(123);
   });
 
   it('returns sorted, deduplicated output', () => {

--- a/tests/unit/migration-disposition-ledger.test.js
+++ b/tests/unit/migration-disposition-ledger.test.js
@@ -18,6 +18,7 @@ import {
   undispositionedBasenames,
   contradictoryBasenames,
   hasReadableReason,
+  isExpired,
   gapBasename,
   SUPPRESSING_DISPOSITIONS,
   KNOWN_DISPOSITIONS
@@ -129,9 +130,67 @@ describe('TS-1 reason-required invariant (FR-1)', () => {
     expect(hasReadableReason(reason)).toBe(false);
   });
 
-  it('accepts a reason that merely CONTAINS an invisible character', () => {
-    expect(hasReadableReason('superseded​ by 20260801')).toBe(true);
-    expect(isSuppressingEntry(entry({ reason: 'superseded​ by 20260801' }))).toBe(true);
+  it('accepts a real reason that merely CONTAINS an invisible character', () => {
+    const r = 'superseded​ by the consolidated migration, verified no live readers remain';
+    expect(hasReadableReason(r)).toBe(true);
+    expect(isSuppressingEntry(entry({ reason: r }))).toBe(true);
+  });
+
+  // The predicate is an ALLOWLIST for a reason: a denylist loses to new invisible codepoints,
+  // including ones Unicode classes as a LETTER (U+3164) or a SYMBOL (U+2800), which no
+  // \p{C}+\p{Z} strip would catch. Requiring positive evidence of words cannot be outrun.
+  it.each([
+    ['word joiner', '⁠'],
+    ['Mongolian vowel separator', '᠎'],
+    ['Hangul filler (a LETTER)', 'ㅤㅤㅤㅤ'],
+    ['Braille blank (a SYMBOL)', '⠀⠀⠀⠀'],
+    ['LTR mark', '‎'],
+    ['invisible separator', '⁣'],
+    ['tag space', '󠀠'],
+  ])('rejects an invisible-only reason built from %s', (_label, reason) => {
+    expect(hasReadableReason(reason)).toBe(false);
+    expect(isSuppressingEntry(entry({ reason }))).toBe(false);
+  });
+
+  it('rejects a too-thin reason like "x" or "n/a" that is technically visible', () => {
+    for (const r of ['x', 'n/a', '...', 'ok', '???']) expect(hasReadableReason(r)).toBe(false);
+  });
+});
+
+describe('review_by expiry — a deferral is a decision to revisit, not an exemption', () => {
+  const PAST = '2020-01-01T00:00:00.000Z';
+  const FUTURE = '2099-01-01T00:00:00.000Z';
+
+  it('stops suppressing once the review date has passed', () => {
+    expect(isSuppressingEntry(entry({ review_by: FUTURE }))).toBe(true);
+    expect(isSuppressingEntry(entry({ review_by: PAST }))).toBe(false);
+  });
+
+  it('an entry with NO review_by never expires — the field is additive', () => {
+    expect(isSuppressingEntry(entry())).toBe(true);
+    expect(isExpired(entry())).toBe(false);
+  });
+
+  it('an unparseable review_by does NOT silently expire a real decision', () => {
+    expect(isExpired(entry({ review_by: 'not a date' }))).toBe(false);
+    expect(isSuppressingEntry(entry({ review_by: 'not a date' }))).toBe(true);
+  });
+
+  it('an expired entry counts as UNDISPOSITIONED again, so it resurfaces in the metric', () => {
+    const gaps = [{ file: 'a.sql' }];
+    expect(undispositionedBasenames(gaps, new Map([['a.sql', entry({ review_by: PAST })]]))).toEqual(['a.sql']);
+    expect(undispositionedBasenames(gaps, new Map([['a.sql', entry({ review_by: FUTURE })]]))).toEqual([]);
+  });
+
+  it('SEC-11 REGRESSION GUARD: a carried-forward entry cannot suppress a file forever', () => {
+    // A migration dispositioned DEFERRED, then applied (leaving the gap set), then REGRESSED
+    // back into the gap set was invisible: suppressed, not undispositioned, not contradictory.
+    // Carry-forward retains the RECORD; expiry stops the record from being an open-ended grant.
+    const gaps = [{ file: 'm.sql' }];
+    const stale = new Map([['m.sql', entry({ review_by: PAST })]]);
+    expect(applyDispositions(gaps, stale).suppressed).toHaveLength(0);
+    expect(applyDispositions(gaps, stale).remaining).toHaveLength(1);
+    expect(undispositionedBasenames(gaps, stale)).toEqual(['m.sql']);
   });
 });
 

--- a/tests/unit/mirror-migration-dispositions.test.js
+++ b/tests/unit/mirror-migration-dispositions.test.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildAuditRows } from '../../scripts/mirror-migration-dispositions-to-audit.mjs';
+import { buildAuditRows, decisionFingerprint } from '../../scripts/mirror-migration-dispositions-to-audit.mjs';
 
 const entry = (over = {}) => ({
   disposition: 'DEFERRED', reason: 'blocked on chairman sign-off', owner: 'chairman',
@@ -45,16 +45,39 @@ describe('column contract — live audit_log columns only', () => {
 });
 
 describe('idempotence — by disposition, not by mere presence', () => {
-  it('skips an entity already mirrored with the SAME disposition', () => {
-    const { rows, skipped } = buildAuditRows({ 'a.sql': entry() }, new Map([['a.sql', 'DEFERRED']]));
+  it('skips an entity already mirrored with the SAME decision', () => {
+    const e = entry();
+    const { rows, skipped } = buildAuditRows({ 'a.sql': e }, new Map([['a.sql', decisionFingerprint(e)]]));
     expect(rows).toHaveLength(0);
     expect(skipped).toEqual(['a.sql']);
   });
 
   it('WRITES A NEW ROW when a human re-adjudicates, so the trail shows the change', () => {
-    const { rows } = buildAuditRows({ 'a.sql': entry({ disposition: 'RETIRED' }) }, new Map([['a.sql', 'DEFERRED']]));
+    const { rows } = buildAuditRows({ 'a.sql': entry({ disposition: 'RETIRED' }) }, new Map([['a.sql', decisionFingerprint(entry())]]));
     expect(rows).toHaveLength(1);
     expect(rows[0].metadata.disposition).toBe('RETIRED');
+  });
+
+  it('WRITES A NEW ROW when only the REASON changed — keying on disposition alone lost this', () => {
+    // Observed for real: all three reasons were rewritten to add the self-assertion
+    // disclosure while every disposition stayed DEFERRED. A disposition-keyed check skipped
+    // them, so the trail would have kept the superseded text indefinitely.
+    const before = entry();
+    const after = entry({ reason: `${before.reason} — now discloses self-asserted provenance` });
+    const { rows } = buildAuditRows({ 'a.sql': after }, new Map([['a.sql', decisionFingerprint(before)]]));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('re-seeding alone does NOT churn rows — recorded_at is excluded from the fingerprint', () => {
+    const a = entry({ recorded_at: '2026-01-01T00:00:00.000Z' });
+    const b = entry({ recorded_at: '2026-09-09T00:00:00.000Z' });
+    expect(decisionFingerprint(a)).toBe(decisionFingerprint(b));
+  });
+
+  it('carries provenance and expiry into the trail as queryable FIELDS, not just prose', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry({ corroborated: false, review_by: '2026-10-01T00:00:00.000Z' }) });
+    expect(rows[0].metadata.corroborated).toBe(false);
+    expect(rows[0].metadata.review_by).toBe('2026-10-01T00:00:00.000Z');
   });
 
   it('an empty ledger writes nothing', () => {

--- a/tests/unit/mirror-migration-dispositions.test.js
+++ b/tests/unit/mirror-migration-dispositions.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 — audit_log mirror (FR-5).
+ * buildAuditRows is pure, so none of this touches the DB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAuditRows } from '../../scripts/mirror-migration-dispositions-to-audit.mjs';
+
+const entry = (over = {}) => ({
+  disposition: 'DEFERRED', reason: 'blocked on chairman sign-off', owner: 'chairman',
+  sd_key: 'SD-X', recorded_at: '2026-07-25T00:00:00.000Z', source: 'auto:test', ...over,
+});
+
+describe('column contract — live audit_log columns only', () => {
+  it('emits exactly the columns that exist on the live table', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry() });
+    expect(Object.keys(rows[0]).sort()).toEqual(['entity_id', 'entity_type', 'event_type', 'metadata', 'severity']);
+  });
+
+  it('never emits the action/details columns that caused a prior runtime break', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry() });
+    expect(rows[0]).not.toHaveProperty('action');
+    expect(rows[0]).not.toHaveProperty('details');
+  });
+
+  it('uses the convention keys from recordTierAudit', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry() });
+    expect(rows[0]).toMatchObject({ event_type: 'MIGRATION_DISPOSITION', entity_type: 'migration', entity_id: 'a.sql' });
+    expect(rows[0].metadata).toMatchObject({
+      disposition: 'DEFERRED', owner: 'chairman', sd_key: 'SD-X', decided_at: '2026-07-25T00:00:00.000Z',
+    });
+  });
+});
+
+describe('idempotence — by disposition, not by mere presence', () => {
+  it('skips an entity already mirrored with the SAME disposition', () => {
+    const { rows, skipped } = buildAuditRows({ 'a.sql': entry() }, new Map([['a.sql', 'DEFERRED']]));
+    expect(rows).toHaveLength(0);
+    expect(skipped).toEqual(['a.sql']);
+  });
+
+  it('WRITES A NEW ROW when a human re-adjudicates, so the trail shows the change', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry({ disposition: 'RETIRED' }) }, new Map([['a.sql', 'DEFERRED']]));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.disposition).toBe('RETIRED');
+  });
+
+  it('an empty ledger writes nothing', () => {
+    expect(buildAuditRows({}).rows).toHaveLength(0);
+    expect(buildAuditRows(null).rows).toHaveLength(0);
+  });
+});
+
+describe('suppresses_gate distinguishes a gate-changing decision from a documented fact', () => {
+  it('is true for RETIRED and DEFERRED', () => {
+    expect(buildAuditRows({ 'a.sql': entry({ disposition: 'RETIRED' }) }).rows[0].metadata.suppresses_gate).toBe(true);
+    expect(buildAuditRows({ 'a.sql': entry({ disposition: 'DEFERRED' }) }).rows[0].metadata.suppresses_gate).toBe(true);
+  });
+
+  it('is FALSE for APPLIED — a legitimate record that never suppresses (FR-2b)', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry({ disposition: 'APPLIED' }) });
+    expect(rows[0].metadata.suppresses_gate).toBe(false);
+    expect(rows[0].metadata.disposition).toBe('APPLIED'); // still recorded, just not suppressing
+  });
+
+  it('is false when the reason is missing, matching the ledger reader', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry({ reason: '   ' }) });
+    expect(rows[0].metadata.suppresses_gate).toBe(false);
+  });
+});
+
+describe('malformed entries are reported, never written', () => {
+  it.each([['unknown disposition', { disposition: 'APPLY', reason: 'x' }], ['null', null], ['string', 'nope'], ['no disposition', { reason: 'x' }]])(
+    'routes %s to invalid rather than rows',
+    (_label, bad) => {
+      const { rows, invalid } = buildAuditRows({ 'a.sql': bad });
+      expect(rows).toHaveLength(0);
+      expect(invalid).toEqual(['a.sql']);
+    }
+  );
+
+  it('one malformed entry does not block the valid ones', () => {
+    const { rows, invalid } = buildAuditRows({ 'bad.sql': { disposition: 'APPLY' }, 'good.sql': entry() });
+    expect(rows.map((r) => r.entity_id)).toEqual(['good.sql']);
+    expect(invalid).toEqual(['bad.sql']);
+  });
+});

--- a/tests/unit/mirror-migration-dispositions.test.js
+++ b/tests/unit/mirror-migration-dispositions.test.js
@@ -13,8 +13,20 @@ const entry = (over = {}) => ({
 
 describe('column contract — live audit_log columns only', () => {
   it('emits exactly the columns that exist on the live table', () => {
+    // Live schema: id, event_type, entity_type, entity_id, old_value, new_value, metadata,
+    // severity, created_by, created_at. We write the subset we own.
     const { rows } = buildAuditRows({ 'a.sql': entry() });
-    expect(Object.keys(rows[0]).sort()).toEqual(['entity_id', 'entity_type', 'event_type', 'metadata', 'severity']);
+    expect(Object.keys(rows[0]).sort()).toEqual(['created_by', 'entity_id', 'entity_type', 'event_type', 'metadata', 'severity']);
+  });
+
+  it('records the ACTOR, not just the auto-derived owner role', () => {
+    const { rows } = buildAuditRows({ 'a.sql': entry() }, new Map(), 'codestreetlabs@gmail.com');
+    expect(rows[0].created_by).toBe('codestreetlabs@gmail.com');
+    expect(rows[0].metadata.owner).toBe('chairman'); // role, a different thing
+  });
+
+  it('an unavailable actor degrades to null rather than blocking the mirror', () => {
+    expect(buildAuditRows({ 'a.sql': entry() }).rows[0].created_by).toBeNull();
   });
 
   it('never emits the action/details columns that caused a prior runtime break', () => {

--- a/tests/unit/seed-migration-dispositions.test.js
+++ b/tests/unit/seed-migration-dispositions.test.js
@@ -119,6 +119,23 @@ describe('idempotence — re-seeding must produce no diff', () => {
     expect(ledger['a.sql'].disposition).toBe('RETIRED');
   });
 
+  it('CARRIES FORWARD an entry whose file has LEFT the gap set — the trail must not self-erase', () => {
+    // Seeding only over `gaps` deleted a recorded decision the moment its migration was
+    // applied or retired and therefore left the gap set: the audit trail erasing itself at
+    // exactly the moment a decision was fulfilled. Found by adversarial review.
+    const { ledger } = build({ gaps: [{ file: 'b.sql', missing: [] }], sql: new Map([['b.sql', PLAIN]]), existing });
+    expect(ledger['a.sql']).toEqual(existing['a.sql']);
+  });
+
+  it('carries forward even when the gap set is entirely empty', () => {
+    expect(build({ gaps: [], existing }).ledger).toEqual(existing);
+  });
+
+  it('a carried-forward APPLIED entry survives — APPLIED is legitimate once the file is applied', () => {
+    const applied = { 'a.sql': { disposition: 'APPLIED', reason: 'applied 2026-07-25 via apply-migration.js', owner: 'rick', sd_key: 'SD-X', recorded_at: '2026-07-25T00:00:00.000Z' } };
+    expect(build({ gaps: [], existing: applied }).ledger['a.sql'].disposition).toBe('APPLIED');
+  });
+
   it('serializeLedger sorts keys so re-seeding is byte-stable regardless of gap order', () => {
     expect(serializeLedger({ b: 1, a: 2 })).toBe(serializeLedger({ a: 2, b: 1 }));
     expect(Object.keys(JSON.parse(serializeLedger({ z: 1, a: 2 })))).toEqual(['a', 'z']);

--- a/tests/unit/seed-migration-dispositions.test.js
+++ b/tests/unit/seed-migration-dispositions.test.js
@@ -1,0 +1,162 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 — disposition seeder (FR-2).
+ *
+ * buildLedger is pure, so every case here runs with no disk and no DB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildLedger, parseSweepDoc, serializeLedger } from '../../scripts/seed-migration-dispositions.mjs';
+
+const NOW = '2026-07-25T00:00:00.000Z';
+const GATED = '-- requires-chairman-apply\nALTER TABLE t ADD COLUMN c int;';
+const GATED_STAMPED = '-- requires-chairman-apply\n-- @approved-by: codestreetlabs@gmail.com\nALTER TABLE t ADD COLUMN c int;';
+const PLAIN = '-- just a migration\nALTER TABLE t ADD COLUMN c int;';
+
+const build = (over = {}) => buildLedger({
+  gaps: [], sql: new Map(), sweep: new Map(), existing: {}, now: NOW, ...over,
+});
+
+describe('FR-2b — the seeder can never emit APPLIED', () => {
+  it('never writes APPLIED for any input combination', () => {
+    const { ledger } = build({
+      gaps: [{ file: 'a.sql', missing: [{ cls: 'table', name: 'x' }] }, { file: 'b.sql', missing: [] }],
+      sql: new Map([['a.sql', GATED], ['b.sql', PLAIN]]),
+      sweep: new Map([['x', { verdict: 'RETIRED', file: 'a.sql' }]]),
+    });
+    expect(Object.values(ledger).map((e) => e.disposition)).not.toContain('APPLIED');
+  });
+
+  it('a gap file is by definition unapplied — every emitted disposition suppresses or is absent', () => {
+    const { ledger } = build({
+      gaps: [{ file: 'a.sql', missing: [] }],
+      sql: new Map([['a.sql', GATED]]),
+    });
+    expect(['RETIRED', 'DEFERRED']).toContain(ledger['a.sql'].disposition);
+  });
+});
+
+describe('rule A — chairman-gated without a usable approver stamp', () => {
+  it('defers a gated file carrying no @approved-by', () => {
+    const { ledger, seeded } = build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', GATED]]) });
+    expect(seeded).toEqual(['a.sql']);
+    expect(ledger['a.sql']).toMatchObject({ disposition: 'DEFERRED', owner: 'chairman' });
+    expect(ledger['a.sql'].reason.length).toBeGreaterThan(20);
+  });
+
+  it('does NOT defer a gated file that already carries a valid stamp — it is genuinely applyable', () => {
+    // The live 20260711_ship_review_findings_actor_metadata.sql case: gated AND stamped, so it
+    // is waiting on the apply token, not on a signature. Deferring it would misreport why.
+    const { ledger, residue } = build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', GATED_STAMPED]]) });
+    expect(ledger['a.sql']).toBeUndefined();
+    expect(residue).toEqual(['a.sql']);
+  });
+
+  it('does not defer an ungated file', () => {
+    const { residue } = build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', PLAIN]]) });
+    expect(residue).toEqual(['a.sql']);
+  });
+
+  it('rejects a stamp with angle brackets — the real 20260712 "<pending chairman sign-off>" case', () => {
+    const pending = '-- requires-chairman-apply\n-- @approved-by: <pending chairman sign-off>\nALTER TABLE t ADD COLUMN c int;';
+    const { ledger } = build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', pending]]) });
+    expect(ledger['a.sql'].disposition).toBe('DEFERRED'); // placeholder is not an approval
+  });
+});
+
+describe('rule B — sweep-doc verdicts, only at full object coverage', () => {
+  const gaps = [{ file: 'a.sql', missing: [{ cls: 'table', name: 'tbl' }, { cls: 'index', name: 'idx' }] }];
+
+  it('disposition requires EVERY missing object to be covered', () => {
+    const partial = new Map([['tbl', { verdict: 'RETIRED', file: 'a.sql' }]]); // idx uncovered
+    expect(build({ gaps, sql: new Map([['a.sql', PLAIN]]), sweep: partial }).residue).toEqual(['a.sql']);
+  });
+
+  it('disposition is assigned when all objects are covered', () => {
+    const full = new Map([['tbl', { verdict: 'RETIRED', file: 'a.sql' }], ['idx', { verdict: 'RETIRED', file: 'a.sql' }]]);
+    expect(build({ gaps, sql: new Map([['a.sql', PLAIN]]), sweep: full }).ledger['a.sql'].disposition).toBe('RETIRED');
+  });
+
+  it('DEFERRED dominates RETIRED — one live-referenced object makes retiring the file wrong', () => {
+    const mixed = new Map([['tbl', { verdict: 'DEFERRED', file: 'a.sql' }], ['idx', { verdict: 'RETIRED', file: 'a.sql' }]]);
+    expect(build({ gaps, sql: new Map([['a.sql', PLAIN]]), sweep: mixed }).ledger['a.sql'].disposition).toBe('DEFERRED');
+  });
+
+  it('FILE ANCHOR: a verdict citing a DIFFERENT file never re-targets this one', () => {
+    // Observed live: the doc adjudicates v_sd_test_readiness in 20251210_unified_test_evidence.sql,
+    // but the lifecycle fold attributes that view to 20251211_unified_test_evidence_fixed.sql.
+    // Name-only matching stamped a retire verdict onto a file the sweep never examined.
+    const drifted = [{ file: '20251211_unified_test_evidence_fixed.sql', missing: [{ cls: 'view', name: 'v_sd_test_readiness' }] }];
+    const sweep = new Map([['v_sd_test_readiness', { verdict: 'RETIRED', file: '20251210_unified_test_evidence.sql' }]]);
+    const { ledger, residue } = build({ gaps: drifted, sql: new Map(), sweep });
+    expect(ledger).toEqual({});
+    expect(residue).toEqual(['20251211_unified_test_evidence_fixed.sql']);
+  });
+
+  it('a file with zero missing objects is never dispositioned by rule B', () => {
+    const sweep = new Map([['tbl', { verdict: 'RETIRED', file: 'a.sql' }]]);
+    expect(build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', PLAIN]]), sweep }).residue).toEqual(['a.sql']);
+  });
+});
+
+describe('idempotence — re-seeding must produce no diff', () => {
+  const existing = {
+    'a.sql': { disposition: 'RETIRED', reason: 'hand-adjudicated by a human', owner: 'rick', sd_key: 'SD-X', recorded_at: '2026-01-01T00:00:00.000Z' },
+  };
+
+  it('preserves an existing entry byte-for-byte and never regenerates recorded_at', () => {
+    const { ledger, preserved, seeded } = build({
+      gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', GATED]]), existing,
+    });
+    expect(ledger['a.sql']).toEqual(existing['a.sql']);
+    expect(ledger['a.sql'].recorded_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(preserved).toEqual(['a.sql']);
+    expect(seeded).toEqual([]);
+  });
+
+  it('a HAND-ADJUDICATED verdict survives re-seeding even where a rule would disagree', () => {
+    // rule A would say DEFERRED for this gated file; the human said RETIRED. Human wins.
+    const { ledger } = build({ gaps: [{ file: 'a.sql', missing: [] }], sql: new Map([['a.sql', GATED]]), existing });
+    expect(ledger['a.sql'].disposition).toBe('RETIRED');
+  });
+
+  it('serializeLedger sorts keys so re-seeding is byte-stable regardless of gap order', () => {
+    expect(serializeLedger({ b: 1, a: 2 })).toBe(serializeLedger({ a: 2, b: 1 }));
+    expect(Object.keys(JSON.parse(serializeLedger({ z: 1, a: 2 })))).toEqual(['a', 'z']);
+  });
+});
+
+describe('parseSweepDoc', () => {
+  const doc = `
+## APPLIED by this SD (live hot-path breaks)
+
+| Object | Migration | Live consumers |
+|---|---|---|
+| v_sd_completion_integrity | database/migrations/20260510_v.sql | scripts/x.js |
+
+## DEFERRED — live-referenced, needs per-case APPLY-vs-RETIRE decision
+
+| Object | Live refs | Sample consumers | Defining SQL |
+|---|---|---|---|
+| uat_reports | 1 | scripts/x.js | database/migrations/uat-structured-reports.sql |
+
+## RETIRE-CANDIDATES — zero live references
+
+- content_versions (database/migrations/032_content_forge_tables.sql)
+`;
+
+  it('extracts DEFERRED table rows and RETIRE bullets with their files', () => {
+    const m = parseSweepDoc(doc);
+    expect(m.get('uat_reports')).toEqual({ verdict: 'DEFERRED', file: 'uat-structured-reports.sql' });
+    expect(m.get('content_versions')).toEqual({ verdict: 'RETIRED', file: '032_content_forge_tables.sql' });
+  });
+
+  it('IGNORES the APPLIED section — those were applied by a prior SD, not dispositioned here', () => {
+    expect(parseSweepDoc(doc).has('v_sd_completion_integrity')).toBe(false);
+  });
+
+  it('returns an empty map for empty or malformed input rather than throwing', () => {
+    for (const bad of ['', null, undefined, '## DEFERRED\n\ngarbage']) {
+      expect(parseSweepDoc(bad).size).toBe(0);
+    }
+  });
+});

--- a/tests/verify-migration-apply-state.test.js
+++ b/tests/verify-migration-apply-state.test.js
@@ -214,6 +214,51 @@ describe('recent-vs-legacy classifier (FR-2)', () => {
     expect(isRecent('20260301_x.sql', '20260601')).toBe(false);
   });
 
+  // SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 FR-6: the optional THIRD parameter.
+  // The whole point of it being optional-and-last is that everything above this comment
+  // keeps passing untouched — those are the byte-identical-no-ledger-path assertions.
+  describe('ledger suppression seam (TRIAGE FR-6)', () => {
+    const gaps = [
+      { file: '20260701_real_new_drift.sql', status: 'NOT_APPLIED', missing: [] },
+      { file: '20260702_retired_thing.sql', status: 'NOT_APPLIED', missing: [] },
+      { file: '20260614_settled.sql', status: 'NOT_APPLIED', missing: [] },
+    ];
+
+    it('omitting the parameter suppresses nothing (no-ledger path unchanged)', () => {
+      expect(partitionRecentGaps(gaps, RETIRED_BEFORE).map((g) => g.file))
+        .toEqual(partitionRecentGaps(gaps).map((g) => g.file));
+      expect(partitionRecentGaps(gaps)).toHaveLength(2);
+    });
+
+    it('an empty suppression set is identical to omitting it', () => {
+      expect(partitionRecentGaps(gaps, RETIRED_BEFORE, new Set()).map((g) => g.file))
+        .toEqual(partitionRecentGaps(gaps).map((g) => g.file));
+    });
+
+    it('AC-2: a dispositioned file leaves failSet while an undispositioned recent file still fails', () => {
+      const recent = partitionRecentGaps(gaps, RETIRED_BEFORE, new Set(['20260702_retired_thing.sql']));
+      expect(recent.map((g) => g.file)).toEqual(['20260701_real_new_drift.sql']);
+      expect(recent.length > 0).toBe(true); // still red — suppression did not fake a pass
+    });
+
+    it('suppression can only REMOVE from the fail set, never admit a legacy gap into it', () => {
+      // A ledger naming a legacy file cannot pull it into recentGaps: isRecent still gates.
+      const recent = partitionRecentGaps(gaps, RETIRED_BEFORE, new Set(['20260614_settled.sql']));
+      expect(recent.map((g) => g.file)).toEqual(['20260701_real_new_drift.sql', '20260702_retired_thing.sql']);
+    });
+
+    it('matches on basename, so a path-qualified gap is still suppressed', () => {
+      const pathGaps = [{ file: 'database/migrations/20260701_real_new_drift.sql' }];
+      expect(partitionRecentGaps(pathGaps, RETIRED_BEFORE, new Set(['20260701_real_new_drift.sql']))).toHaveLength(0);
+    });
+
+    it('a non-Set argument degrades to no suppression rather than throwing', () => {
+      for (const bad of [null, undefined, ['20260701_real_new_drift.sql'], 'x', {}]) {
+        expect(partitionRecentGaps(gaps, RETIRED_BEFORE, bad)).toHaveLength(2);
+      }
+    });
+  });
+
   it('hasAnyDbCredential — MISCONFIG fires only when NO DB credential is present (FR-2 HIGH)', () => {
     expect(hasAnyDbCredential({})).toBe(false); // CI with no secrets => MISCONFIG (fail loud)
     expect(hasAnyDbCredential({ SUPABASE_DB_PASSWORD: 'x' })).toBe(true);
@@ -304,7 +349,7 @@ describe('extraction — ADD COLUMN class (QF-20260725-470)', () => {
   it('ignores ADD COLUMN inside comments and dollar-quoted bodies', () => {
     const dq = '$' + '$';
     const { creates } = extractDdlFacts(
-      `-- ALTER TABLE ghost ADD COLUMN nope text;\n` +
+      '-- ALTER TABLE ghost ADD COLUMN nope text;\n' +
       `CREATE FUNCTION f() RETURNS void AS ${dq} BEGIN EXECUTE 'ALTER TABLE ghost ADD COLUMN nope text'; END ${dq} LANGUAGE plpgsql;`
     );
     expect(creates.filter((c) => c.cls === 'column')).toEqual([]);


### PR DESCRIPTION
## What this does

`verify-migration-apply-state.mjs` was column-blind until QF-20260725-470. The corrected re-run found **126 forward migrations with schema gaps**, and **117 of them sit behind `RETIRED_BEFORE=20260615`**, so they can never turn the CI gate red. For 93% of the corpus, "has anyone actually decided what to do with this file?" was invisible to CI.

This adds a committed disposition ledger so that decision is auditable independently of whether the gate passes. The definition of done is `undispositioned == 0`, **not** a green gate — because a green gate can be produced by suppression, while a zero undispositioned count cannot be produced without recording a real reason per file.

## Read this part first — what did NOT ship

**FR-4 (apply 8 wave-1 migrations) and FR-7 are NOT delivered.** Tested against the real `APPROVED_BY_RE` guard regex in `scripts/lib/migration-guards.js`, **exactly 1 of 8** wave-1 files carries a valid approver stamp. The other 7 need a **chairman** to author one; `20260712` literally contains the placeholder `<pending chairman sign-off>`, which the regex rejects on the angle brackets. Even the valid one needs an issued `MIGRATION_APPLY_TOKEN`, which a worker cannot self-issue.

So: **zero migrations were applied, and the drift gate REMAINS RED** (6 recent gaps, down from 9 only because 3 chairman-gated-unstamped files are now honestly DEFERRED). FR-4 AC-3's red-to-green criterion is unmet **by design** — FR-2b forbids reaching green via suppression, and adding an approver stamp myself would be forging chairman approval and would defeat the very guard this work depends on.

**FR-2 coverage is 3 of 126.** Its PRD-named seed source (`scripts/audit/migration-column-reachability.mjs`) turned out to be untracked in git, exporting nothing, and reading a `cols.tsv` from an expired session's scratchpad — it throws at import and can never run in CI. The remaining **123 files are reported UNDISPOSITIONED** rather than papered over.

## The four invariants

1. **FAIL OPEN** — an absent, corrupt or wrong-shaped ledger suppresses nothing.
2. **REASON REQUIRED** — an allowlist (3+ real words), not a strip of known-bad characters, because a denylist loses to newly-chosen invisible codepoints: U+3164 is a Unicode *letter* and U+2800 a *symbol*, so even a `\p{C}`+`\p{Z}` filter is defeatable.
3. **APPLIED NEVER SUPPRESSES, AND NEVER COUNTS AS DECIDED WHILE THE FILE IS IN THE GAP SET** — an applied migration cannot appear in the gap set at all, so an `APPLIED` entry for a file that *is* there proves itself false. Surfaced as `LEDGER CONTRADICTS SCHEMA` rather than silently dropped.
4. **SUPPRESSION IS BOUNDED** — an optional `review_by`; past it the entry stops suppressing *and* counts as undispositioned again, so it resurfaces instead of decaying into a permanent exemption.

## Security fixes found by adversarial review

- **HIGH, pre-existing**: the drift-guard workflow matched its verdict with an **unanchored** grep over output that also contains raw filenames. Committing `20200101_MIGRATION_APPLY_STATE_INFRA_ERROR_x.sql` made it take the INFRA branch and `exit 0` — permanently silencing the gate, daily cron included, via a legacy-dated name that is itself never blocking. Proven end-to-end by the reviewer. Now `grep -Fxq` on the bracketed marker, plus filenames are newline-stripped at all five print sites.
- **HIGH**: the completion metric counted `APPLIED` as decided, so hand-writing APPLIED for all 123 residuals would drive "done" to zero while suppressing nothing and leaving every gap real. Same ghost-completion class as QF-20260719-281, one layer above the path FR-2b guards. Found independently by two reviewers.
- **MEDIUM**: `emitBreakageAlert`'s module load sat outside any try, and it only runs when gaps exist — a broken require would fail the gate **open** at exactly the moment it detected drift.
- **MEDIUM**: a committed directory named `x.sql/` threw EISDIR into the entry catch → INFRA_ERROR → exit 0, a one-commit gate silencer. Now fails closed as MISCONFIG.
- **MEDIUM**: the ledger and its reader were not in `on.push.paths`, so a push that changed suppression — or suppression *logic* — did not re-run the gate.
- **MEDIUM, self-inflicted**: my own fix for a self-erasing ledger silently made suppression permanent rather than bounded; caught in a second review round and fixed with `review_by`.

## Verification

- **168 tests** (163 unit + 5 integration). The 36 pre-existing verifier tests pass **untouched**, including the `RETIRED_BEFORE === 20260615` pin, which this SD deliberately does **not** move — moving it would admit the 117 legacy gaps into `recentGaps` and turn CI red.
- The no-ledger path is **byte-identical** to before this change (optional third parameter defaulting to an empty Set).
- A subprocess integration test proves against the real CLI that a corrupt ledger yields no `INFRA_ERROR` and no false PASS, and that a forged `APPLIED` entry leaves the gate red with 0 suppressed. It now runs from the drift-guard workflow, because `tests/integration/` routes to vitest's opt-in `db` project that no workflow executed — the proof was previously unreachable in CI, green forever while asserting nothing.
- Re-seed idempotence verified by sha256; the CI ledger-sync step was replayed locally and passes on a clean tree.

## PR size justification

**+1991 / −26 across 13 files**, exceeding the 400-LOC ceiling. Breakdown: ~810 lines of tests, ~206 of docs plus the ledger artifact, ~975 of production code across 4 new scripts. This is a new subsystem delivering 6 FRs for a Tier-3 SD (schema/migration risk keywords force Tier 3). Splitting it would ship the suppression seam without the guards that make suppression safe, which is the wrong seam to cut.

## Known pre-existing failure, disclosed

`ship-preflight` reports BLOCKED on test failures. Investigated rather than assumed: the unit project shows **3** failures, not the 120 preflight reports. `tests/unit/eva/complexity-scorer.test.js` is a load-sensitive 30-second timing test that passes on re-run. `tests/unit/golden-references/witness-emitter-acceptance.test.js` fails **identically on `main`**, which contains none of these changes, and imports `golden-references/witness-evidence-emitter/acceptance-locks.mjs` — not among the 13 files touched here. Neither failure is caused by this branch, and neither is fixed by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
