### PR TITLE
fix(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): widen the session-bind window — measured, then proven live

### DIFF
--- a/.tmp-p.cjs
+++ b/.tmp-p.cjs
@@ -1,0 +1,33 @@
+const fs=require('fs');
+let a=fs.readFileSync('tests/unit/fleet/spawn-control.test.js','utf8');
+const oldH="    const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation'];";
+const newH="    // The guard exists to catch an undocumented 7th VERB, not to freeze the helper surface. The two\n    // session-bind constants are exported so the budget can be asserted directly instead of by\n    // wall-clock; they are values, not verbs, so they belong on this allowlist.\n    const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation',\n      'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS'];";
+if(a.split(oldH).length-1!==1) throw new Error('helper anchor');
+fs.writeFileSync('tests/unit/fleet/spawn-control.test.js', a.replace(oldH,newH));
+
+let b=fs.readFileSync('tests/unit/fleet/provision-canary-cli.test.js','utf8');
+const oldT=`  it('registration_timeout diagnosis names the STAMP as the suspect, not the spawn', () => {
+    // This is the whole value of the CLI: the one permitted live run must yield a diagnosis. A bare
+    // timeout looks identical whether the slot was unseeded, the spawn failed, or only the stamp did.
+    const d = DIAGNOSIS.registration_timeout;
+    expect(d).toMatch(/account_profile/);
+    expect(d).toMatch(/stamp/i);
+    expect(d).toMatch(/REGISTERED/);
+  });`;
+const newT=`  it('registration_timeout diagnosis gives an ORDERED procedure grounded in the real failure', () => {
+    // Rewritten after the first live run, which is the point: the original text guessed that the stamp
+    // was missing because FR-3 had not landed. FR-3 HAD landed; the real cause was the session-bind
+    // loop closing 1.3s before the child registered, discarding window_handle, account_profile and the
+    // session_id bind together. A diagnosis that names the wrong suspect is worse than a bare timeout,
+    // so this now asserts the three ordered checks an operator should actually perform.
+    const d = DIAGNOSIS.registration_timeout;
+    expect(d).toMatch(/claude_sessions row appear/i);   // (1) did anything register
+    expect(d).toMatch(/MINTED session id/i);            // (2) did --session-id take effect
+    expect(d).toMatch(/metadata EMPTY/i);               // (3) did the bind window miss
+    expect(d).toMatch(/bind/i);
+    // Must point at MEASURING the gap rather than re-running blind -- a re-run spawns another session.
+    expect(d).toMatch(/measure the gap/i);
+  });`;
+if(b.split(oldT).length-1!==1) throw new Error('diagnosis anchor');
+fs.writeFileSync('tests/unit/fleet/provision-canary-cli.test.js', b.replace(oldT,newT));
+console.log('both patched');

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -26,6 +26,16 @@ import { captureNewWindowHandle, enumerateWindows, focusWindow } from './window-
 import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
 
 const SINGLETON_ROLES = new Set(['coordinator', 'adam', 'solomon']);
+
+/**
+ * Session-bind budget, exported so it can be asserted directly rather than by wall-clock.
+ * 20 x 500ms = 10s. Sized from a MEASURED live spawn where registration completed ~3s after launch and
+ * the previous 1.5s budget missed it by 1.3s. Headroom is deliberate: a loaded host registers slower,
+ * and the cost of overshooting is a few seconds on a spawn that was already failing, whereas the cost
+ * of undershooting is a silently unstamped, undiscoverable session.
+ */
+export const SESSION_BIND_MAX_ATTEMPTS = 20;
+export const SESSION_BIND_DELAY_MS = 500;
 const PROFILE_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 /** Derive a session's role from its metadata (mirrors coordination-events.cjs's own convention). */
@@ -224,7 +234,22 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     const sleepFn = opts.sleepFn || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     const nowMs2 = opts.nowMs ?? Date.now();
     const freshMs = opts.pidMatchFreshMs ?? 2 * 60 * 1000;
-    const maxAttempts = opts.sessionBindMaxAttempts ?? 3;
+    // MEASURED ON A REAL SPAWN (2026-07-25), not guessed. The previous default was 3 attempts x 500ms
+    // ~= 1.5s, and the live provisioning run missed by 1.3 SECONDS: the bind loop closed at
+    // 20:29:42.6 (fleet_verb_spawn emitted immediately after it, outcome "ok") while Claude Code
+    // finished registering at 20:29:43.9. A real session needs roughly 3s from spawn to registration.
+    //
+    // WHY THAT ONE MISS COST EVERYTHING: the window_handle write, the account_profile stamp and the
+    // session_id bind ALL live inside this block, so a missed bind silently discards all three even
+    // though the spawn, the window capture and the registration each SUCCEEDED independently. The
+    // observable was a perfect-looking spawn with a completely empty metadata blob.
+    //
+    // NO UNIT TEST COULD HAVE CAUGHT THIS: every test injects a fake whose row is already present, so
+    // the row is never LATE. Registration latency is exactly what a mocked seam cannot show you.
+    //
+    // The budget is only fully spent when a session NEVER registers; a healthy spawn still binds on
+    // the first or second attempt, so this costs nothing on the happy path.
+    const maxAttempts = opts.sessionBindMaxAttempts ?? SESSION_BIND_MAX_ATTEMPTS;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         // ADVERSARIAL-REVIEW FIX (data integrity, retained): a bare `.update({ metadata:{...} })`
@@ -263,7 +288,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
           break;
         }
       } catch { /* fail-soft: try again below, or give up -- a later attach() re-resolves */ }
-      if (attempt < maxAttempts) await sleepFn(opts.sessionBindDelayMs ?? 500);
+      if (attempt < maxAttempts) await sleepFn(opts.sessionBindDelayMs ?? SESSION_BIND_DELAY_MS);
     }
   }
 

--- a/scripts/fleet/provision-canary.mjs
+++ b/scripts/fleet/provision-canary.mjs
@@ -63,12 +63,15 @@ export const DIAGNOSIS = {
   no_canary_slot_seeded:
     'fleet_desired_slots has no enabled canary slot. Provisioning cannot invent one — S3 seeding must run first.',
   registration_timeout:
-    'Spawned, but no session ever resolved by account_profile=canary. EXPECTED until FR-3 lands: '
-    + 'spawn() never writes metadata.account_profile (it uses accountProfile only for the profile dir, '
-    + 'spawn-control.js:162), and the sole writer stampRespawnedCanary (canary-guard.js:173) is both '
-    + 'off the fresh-spawn path and pid-correlation-dead (:167). Check whether a session REGISTERED at '
-    + 'all before blaming the spawn: if claude_sessions gained a row, the spawn worked and only the '
-    + 'stamp is missing.',
+    'Spawned, but no session resolved by account_profile=canary. DIAGNOSE IN THIS ORDER, because the '
+    + 'first live run showed all three earlier legs SUCCEEDING while this still failed: '
+    + '(1) did a claude_sessions row appear at all? If yes the spawn and registration both worked. '
+    + '(2) does that row carry the MINTED session id logged above? If yes, --session-id took effect. '
+    + '(3) is its metadata EMPTY? Then the session-bind loop in spawn-control closed BEFORE the child '
+    + 'registered -- window_handle, account_profile and the session_id bind are all written inside that '
+    + 'one block, so a missed bind silently discards all three. Measured 2026-07-25: the bind closed '
+    + '1.3s too early. The budget has since been widened (SESSION_BIND_MAX_ATTEMPTS); if this recurs, '
+    + 'measure the gap between fleet_verb_spawn and claude_sessions.created_at rather than re-running.',
 };
 
 /**
@@ -140,6 +143,12 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   }
 
   const outcome = classifyProvisionOutcome(result);
+  // Surface the MINTED session id. Without it the first live run could not be diagnosed from outside:
+  // a session had registered, but nothing logged the id the spawner chose, so there was no way to tell
+  // "the child ignored --session-id" from "the child registered under it, just later than we looked".
+  const minted = result && result.spawn && result.spawn.invocation && result.spawn.invocation.sessionId;
+  if (minted) log(`[provision-canary] minted session id: ${minted} — the child should register under exactly this`);
+  if (result && result.spawn && result.spawn.pid) log(`[provision-canary] launcher pid: ${result.spawn.pid} (wt.exe; exits immediately — NOT the Claude Code pid)`);
   log(`[provision-canary] ${outcome.status.toUpperCase()} reason=${outcome.reason}`);
   log(`[provision-canary] ${outcome.diagnosis}`);
   return { ...outcome, ok: outcome.exitCode === EXIT.OK, result };

--- a/tests/unit/fleet/provision-canary-cli.test.js
+++ b/tests/unit/fleet/provision-canary-cli.test.js
@@ -159,13 +159,21 @@ describe('FR-1 classifyProvisionOutcome — three-valued exit contract', () => {
     expect(classifyProvisionOutcome(null).status).toBe('infra');
   });
 
-  it('registration_timeout diagnosis names the STAMP as the suspect, not the spawn', () => {
-    // This is the whole value of the CLI: the one permitted live run must yield a diagnosis. A bare
-    // timeout looks identical whether the slot was unseeded, the spawn failed, or only the stamp did.
+  it('registration_timeout diagnosis gives an ORDERED procedure grounded in the real failure', () => {
+    // Rewritten after the first live run, and that rewrite is the point. The original text confidently
+    // named the stamp as the suspect "EXPECTED until FR-3 lands" -- but FR-3 HAD landed, and the real
+    // cause was the session-bind loop closing 1.3s before the child registered, which discards
+    // window_handle, account_profile AND the session_id bind together. A diagnosis that names the wrong
+    // suspect is worse than a bare timeout: it sends the next operator down a dead path with
+    // confidence. This now asserts the three ordered checks that actually discriminate.
     const d = DIAGNOSIS.registration_timeout;
-    expect(d).toMatch(/account_profile/);
-    expect(d).toMatch(/stamp/i);
-    expect(d).toMatch(/REGISTERED/);
+    expect(d).toMatch(/claude_sessions row appear/i); // (1) did anything register at all
+    expect(d).toMatch(/MINTED session id/i);          // (2) did --session-id take effect
+    expect(d).toMatch(/metadata EMPTY/i);             // (3) did the bind window miss
+    expect(d).toMatch(/bind/i);
+    // Must direct the operator to MEASURE the gap rather than re-run blind: a re-run spawns another
+    // real session, which is exactly the wrong response to a timing bug.
+    expect(d).toMatch(/measure the gap/i);
   });
 });
 

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -97,7 +97,11 @@ describe('module surface (TS-10: exactly six named verbs, no more)', () => {
     const verbNames = ['spawn', 'attach', 'stop', 'restart', 'relaunchUnderProfile', 'drainAndRestart'];
     for (const name of verbNames) expect(typeof mod[name]).toBe('function');
     // Every OTHER export must be a helper, never an undocumented 7th verb.
-    const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation'];
+    // The guard exists to catch an undocumented 7th VERB, not to freeze the helper surface. The two
+    // session-bind constants are exported so the budget can be asserted directly instead of by
+    // wall-clock; they are values, not verbs, so they belong on this allowlist.
+    const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation',
+      'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS'];
     const unexpected = Object.keys(mod).filter((k) => !verbNames.includes(k) && !helperNames.includes(k));
     expect(unexpected).toEqual([]);
   });


### PR DESCRIPTION
The first live provisioning run failed **while all three earlier legs succeeded**. That combination is what made it worth measuring instead of retrying.

| | |
|---|---|
| `fleet_verb_spawn` | **20:29:42.639** — outcome `"ok"`, `session_id` **NULL** |
| `claude_sessions` row | **20:29:43.930** — created, heartbeating, metadata **completely empty** |

The spawn worked. The window worked — there had been **zero** WindowsTerminal windows on this host all day and there was now exactly one, and outcome `"ok"` means FR-4 *captured* a handle rather than failing. The session registered. And nothing was stamped.

## Root cause: a 1.3-second race with everything riding inside it

The session-bind loop was 3 × 500ms (~1.5s), and the spawn event is emitted immediately after it. The loop closed at `20:29:42.6`; the child registered at `20:29:43.9`.

The `window_handle` write, the `account_profile` stamp, and the `session_id` bind **all live inside that one block** — so a missed bind silently discards all three. That is why the handle FR-4 had correctly captured was thrown away, and why the FR-3 stamp never ran.

**No unit test could have caught this, and that's the transferable part.** Every test injects a fake whose row is *already present*, so the row is never **late**. Registration latency is exactly what a mocked seam cannot show you — 1156 tests passed over a code path that could not work on a real host.

Budget is now 20 × 500ms = 10s, exported as `SESSION_BIND_MAX_ATTEMPTS` / `SESSION_BIND_DELAY_MS` so it's assertable directly rather than by wall-clock. It's only fully spent when a session *never* registers; a healthy spawn still binds on the first attempt.

## Proven live, verified at the consumer

Re-ran the provisioner — `canary registered after 1 attempt(s)` — then checked the DB directly rather than trusting the CLI's own claim:

- `claude_sessions` rows with `account_profile=canary`: **1** (the coordinator measured **zero** all day)
- `resolveCanaryTarget(by account_profile=canary)` → **`resolved: true`**
- `session_id 776d1356…` **=== the spawner-minted id** → `claude --session-id` genuinely takes effect on a real Windows launch. That was a PENDING-LIVE unknown; it is now measured.
- `window_handle 51383058`, `handle_capture_failed false` → FR-4 captured **and persisted**. A WT window from the earlier run was **already open**, so the set difference had a non-empty before-set and still picked the *new* window — the live validation a fixture cannot give.

## What this does NOT claim

`assertCanaryTarget` — the **fail-closed guard the drill legs actually use** — still returns `ok:false, reason:'not_canary_callsign'`, because the session has no `Canary-` callsign yet (identity is handed down via `SET_IDENTITY` at check-in, and this session hasn't checked in).

So the SD's stated criterion (**discoverable** via `resolveCanaryTarget`) is met; the stricter **drill-targetable** condition is not. Reporting both rather than the flattering half.

Also still unverified: **SEC-CANHOST-04** — `account_profile` is stamped from spawner *intent*, and I have no evidence `CLAUDE_CONFIG_DIR` reached the child. This canary may be discoverable-but-not-isolated.

## Diagnosis text rewritten

The old text confidently blamed the stamp, *"EXPECTED until FR-3 lands"* — but FR-3 **had** landed, so it would have sent the next operator down a dead path with confidence. It now gives three ordered checks (did a row appear / does it carry the minted id / is metadata empty) and directs the reader to **measure** the spawn-to-registration gap rather than re-run — a re-run spawns another real session, which is the wrong response to a timing bug.

The CLI now also prints the **minted session id** and the launcher pid; their absence is precisely why the first failure couldn't be diagnosed from outside.

`TS-10`'s verb-surface guard was extended for the two new constants — it exists to catch an undocumented 7th *verb*, and these are values.

## Verification

- **1156 tests / 101 files green** with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` all unset
- No drill run — provisioner only, per the coordinator's explicit instruction to exercise it
- Two live canary windows now exist (one unstamped orphan from the first run); reaping is fenced to the coordinator

🤖 Generated with [Claude Code](https://claude.com/claude-code)