### PR TITLE
fix(QF-20260725-342): route resurface threshold through one shared constant

### DIFF
--- a/lib/coordination/resurface-threshold.cjs
+++ b/lib/coordination/resurface-threshold.cjs
@@ -1,0 +1,42 @@
+'use strict';
+/**
+ * QF-20260725-342 — the ONE source of truth for the Solomon ledger-pending resurface threshold.
+ *
+ * THE BUG THIS FIXES: the 72h threshold shipped (QF-20260725-743) scoped to the GitHub Actions
+ * cron ONLY. There are THREE invocation sites and only one passed the flag:
+ *   1. .github/workflows/solomon-ledger-resurface-cron.yml  --threshold-hours 72   CORRECT
+ *   2. scripts/coordinator-quiet-tick.mjs                   no flag -> 24h default
+ *   3. scripts/coordinator-startup-check.mjs                no flag -> 24h default
+ * Proven at runtime, not inferred: 34 resurface rows landed in a single batch at 20:35 on
+ * 2026-07-25. The GHA cron fires at :13 and :43, so 20:35 was the coordinator tick — and with
+ * the oldest pending ledger row at 34.8h, a 72h threshold has a crossing set of ZERO. Those 34
+ * rows are positive proof the 24h default was still live on that path.
+ *
+ * WHY A SHARED CONSTANT RATHER THAN ADDING THE FLAG TWICE: adding the flag at each site is the
+ * same shape as the defect — the next threshold change would again have to find all three call
+ * sites and would again miss some. This module makes "the operating threshold" a single value
+ * every JS invoker imports. The GHA workflow cannot import JS, so it keeps a literal, and
+ * tests/unit/coordination/resurface-threshold.test.js pins that literal to this constant so the
+ * two cannot drift silently.
+ *
+ * SAME CLASS AS QF-20260725-141: a corrected value that reaches one consumer and leaves the
+ * others on the old path. Verifying at the merge is not verifying at the consumer, and verifying
+ * ONE consumer is not verifying ALL of them.
+ *
+ * NOTE ON THE VALUE: 72 is a MITIGATION, not the end state — it was chosen to sit just under the
+ * measured p75 disposition latency (77.2h) so the signal fires on the genuine tail. Once
+ * SD-LEO-INFRA-RESURFACE-DIGEST-BATCHING-001's digest batching is confirmed live, this can
+ * return to a latency-grounded value; changing it HERE now reaches every JS invoker at once.
+ *
+ * @module lib/coordination/resurface-threshold
+ */
+
+/** Hours a solomon_advice_outcome_ledger row must sit at decision='pending' before it resurfaces. */
+const OPERATING_THRESHOLD_HOURS = 72;
+
+/** CLI args form, so an invoker cannot pass the value in a subtly different shape. */
+function thresholdArgs() {
+  return ['--threshold-hours', String(OPERATING_THRESHOLD_HOURS)];
+}
+
+module.exports = { OPERATING_THRESHOLD_HOURS, thresholdArgs };

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -32,6 +32,8 @@ const require = createRequire(import.meta.url);
 const { createClient } = require('@supabase/supabase-js');
 const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
+// QF-20260725-342: single source of truth for the resurface threshold (see that module's header).
+const { thresholdArgs } = require('../lib/coordination/resurface-threshold.cjs');
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const { hasUndeliveredChairmanEscalation } = require('../lib/coordinator/undelivered-escalation.cjs');
 // QF-20260719-138: emit the cross-party ping row ourselves (mechanical, byte-identical) rather
@@ -116,7 +118,12 @@ export const COMPOSED_CORES = [
   // stale ledger row per day via its own payload.dedup_key, so running it every tick is safe. NOT
   // quiescentSkip: an aged pending recommendation is exactly as stale-and-worth-surfacing during a
   // quiet fleet window as during an active one.
-  { key: 'solomon-ledger-resurface', script: 'solomon-ledger-pending-resurface.cjs', args: ['scripts/solomon-ledger-pending-resurface.cjs'], quiescentSkip: false },
+  // QF-20260725-342: this site passed NO --threshold-hours, so it silently ran at the script's
+  // 24h DEFAULT while only the GHA cron honored the 72h operating threshold. Proven at runtime:
+  // 34 rows landed in one batch at 20:35 (the cron fires :13/:43), when a 72h threshold has a
+  // crossing set of zero. Sourced from the shared constant so the value cannot reach one
+  // invoker and miss the others again.
+  { key: 'solomon-ledger-resurface', script: 'solomon-ledger-pending-resurface.cjs', args: ['scripts/solomon-ledger-pending-resurface.cjs', ...thresholdArgs()], quiescentSkip: false },
   // QF-20260720-638: encodes the coordinator's manual idle-QF claim-hint intervention as
   // standing behavior (Solomon-designed, Adam-sourced). PROPOSE-ONLY (writes an advisory hint
   // row per idle worker, never claims/mutates quick_fixes) with belt-and-suspenders chairman-

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -21,6 +21,9 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
 import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
+// QF-20260725-342: single source of truth for the resurface threshold (see that module's header).
+import { createRequire as _createRequireQF342 } from 'node:module';
+const { OPERATING_THRESHOLD_HOURS } = _createRequireQF342(import.meta.url)('../lib/coordination/resurface-threshold.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -314,9 +317,12 @@ export const STANDARD_LOOPS = [
   // + per-row dedup check), fail-open (no active Adam session -> no-op), and self-rate-limits
   // to once per stale ledger row per day via its own payload.dedup_key, so a frequent tick is
   // safe. Also composed into scripts/coordinator-quiet-tick.mjs's COMPOSED_CORES.
+  // QF-20260725-342: this prompt carried NO --threshold-hours, so the registered loop ran at the
+  // script's 24h DEFAULT while only the GHA cron honored the 72h operating threshold. Built from
+  // the shared constant so a future threshold change reaches every invoker at once.
   { key: 'solomon-ledger-resurface', label: 'Solomon ledger-pending resurface (aged advice-outcome rows -> Adam inbox)', script: 'solomon-ledger-pending-resurface.cjs', cron: '13,43 * * * *',
     gha_backed: true,
-    prompt: 'node scripts/solomon-ledger-pending-resurface.cjs' },
+    prompt: `node scripts/solomon-ledger-pending-resurface.cjs --threshold-hours ${OPERATING_THRESHOLD_HOURS}` },
   // QF-20260720-638 (Solomon-designed, Adam-sourced): encodes the coordinator's manual
   // idle-QF claim-hint intervention as standing behavior. PROPOSE-ONLY (advisory hint row per
   // idle worker, never claims/mutates quick_fixes); belt-and-suspenders chairman-gated

--- a/tests/unit/coordination/resurface-threshold.test.js
+++ b/tests/unit/coordination/resurface-threshold.test.js
@@ -1,0 +1,89 @@
+/**
+ * QF-20260725-342 — every invoker of solomon-ledger-pending-resurface.cjs must use the SAME
+ * threshold.
+ *
+ * THE DEFECT: the 72h threshold reached only 1 of 3 invocation sites. The GHA cron passed
+ * --threshold-hours 72; scripts/coordinator-quiet-tick.mjs and scripts/coordinator-startup-check.mjs
+ * passed nothing and silently ran at the script's 24h DEFAULT. Proven at runtime — 34 resurface
+ * rows in one batch at 20:35 on 2026-07-25, when the cron fires only at :13/:43 and a 72h
+ * threshold has a crossing set of zero.
+ *
+ * WHY THESE TESTS ARE SOURCE-SCANS RATHER THAN BEHAVIOUR TESTS: the failure is a MISSING
+ * ARGUMENT at a call site, which no unit test of the script itself can observe — the script
+ * behaves correctly for whatever threshold it is given. The only place the defect is visible is
+ * the invocation. So these assert the wiring, which is exactly where the bug lived.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const { OPERATING_THRESHOLD_HOURS, thresholdArgs } = require(join(REPO, 'lib/coordination/resurface-threshold.cjs'));
+
+const read = (rel) => readFileSync(join(REPO, rel), 'utf8');
+
+describe('QF-20260725-342 — resurface threshold reaches EVERY invocation site', () => {
+  it('exposes a single numeric operating threshold and a CLI-args helper', () => {
+    expect(Number.isFinite(OPERATING_THRESHOLD_HOURS)).toBe(true);
+    expect(OPERATING_THRESHOLD_HOURS).toBeGreaterThan(0);
+    expect(thresholdArgs()).toEqual(['--threshold-hours', String(OPERATING_THRESHOLD_HOURS)]);
+  });
+
+  it('the operating threshold is NOT the script default (otherwise the flag proves nothing)', () => {
+    // If these ever coincide, every assertion below passes vacuously — a missing flag would be
+    // indistinguishable from a present one. Guard the guard.
+    const { DEFAULT_THRESHOLD_HOURS } = require(join(REPO, 'scripts/solomon-ledger-pending-resurface.cjs'));
+    expect(OPERATING_THRESHOLD_HOURS).not.toBe(DEFAULT_THRESHOLD_HOURS);
+  });
+
+  it('coordinator-quiet-tick sources the threshold from the shared constant, not a literal', () => {
+    const src = read('scripts/coordinator-quiet-tick.mjs');
+    expect(src).toContain('../lib/coordination/resurface-threshold.cjs');
+    const line = src.split('\n').find((l) => l.includes("script: 'solomon-ledger-pending-resurface.cjs'"));
+    expect(line).toBeTruthy();
+    expect(line).toContain('...thresholdArgs()');
+  });
+
+  it('coordinator-startup-check builds its prompt from the shared constant', () => {
+    const src = read('scripts/coordinator-startup-check.mjs');
+    expect(src).toContain('../lib/coordination/resurface-threshold.cjs');
+    const line = src.split('\n').find((l) => l.includes('prompt:') && l.includes('solomon-ledger-pending-resurface.cjs'));
+    expect(line).toBeTruthy();
+    expect(line).toContain('${OPERATING_THRESHOLD_HOURS}');
+  });
+
+  it('the GHA workflow literal MATCHES the shared constant (it cannot import JS, so pin it)', () => {
+    const yml = read('.github/workflows/solomon-ledger-resurface-cron.yml');
+    const m = yml.match(/solomon-ledger-pending-resurface\.cjs\s+--threshold-hours\s+(\d+)/);
+    expect(m).toBeTruthy();
+    expect(Number(m[1])).toBe(OPERATING_THRESHOLD_HOURS);
+  });
+
+  it('NO invoker of the resurface script omits the threshold (catches a future 4th site)', () => {
+    // The generalised guard: the defect was not "two sites were wrong", it was "a new call site
+    // silently inherits the default". Any invocation that names the script must also carry a
+    // threshold — via the shared constant, the helper, or the pinned YAML literal.
+    const files = [
+      'scripts/coordinator-quiet-tick.mjs',
+      'scripts/coordinator-startup-check.mjs',
+      '.github/workflows/solomon-ledger-resurface-cron.yml',
+    ];
+    for (const f of files) {
+      for (const line of read(f).split('\n')) {
+        // An INVOCATION is a shell command line or an execFile args array — NOT a registry
+        // metadata field like `script:`, which merely names the file and is paired with a
+        // `prompt:` on another line that carries the actual command.
+        const invokes = line.includes('solomon-ledger-pending-resurface.cjs')
+          && (line.includes('node scripts/') || line.includes('args:'));
+        if (!invokes) continue;
+        const carriesThreshold = line.includes('thresholdArgs()')
+          || line.includes('OPERATING_THRESHOLD_HOURS')
+          || /--threshold-hours\s+\d+/.test(line);
+        expect(carriesThreshold, `${f}: invocation without a threshold -> silently uses the 24h default:\n${line.trim()}`).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

The 72h resurface threshold shipped scoped to the GitHub Actions cron only. There are **three** invocation sites and just one passed the flag:

| Site | Threshold |
|---|---|
| `.github/workflows/solomon-ledger-resurface-cron.yml` | `--threshold-hours 72` ✅ |
| `scripts/coordinator-quiet-tick.mjs` | no flag → **24h default** ❌ |
| `scripts/coordinator-startup-check.mjs` | no flag → **24h default** ❌ |

## Proven at runtime, not inferred

34 resurface rows landed in a **single batch at 20:35** on 2026-07-25. The GHA cron fires at `:13`/`:43`, so 20:35 was the coordinator tick — and with the oldest pending ledger row at 34.8h, a 72h threshold has a crossing set of **zero**. Those 34 rows are positive proof the 24h default was still live on that path.

## Why a shared constant rather than adding the flag twice

Adding the flag per-site is the *same shape as the defect* — the next threshold change would again have to find all three call sites and could again miss some. `lib/coordination/resurface-threshold.cjs` makes the operating threshold one value every JS invoker imports. The GHA workflow can't import JS, so it keeps a literal and a test pins that literal to the constant.

## Verification

- `tests/unit/coordination/resurface-threshold.test.js` includes a **generalised guard** that fails on *any* invocation naming the script without a threshold, so a future 4th site cannot silently inherit the default.
- **Verified RED against the original defect**: reverting the quiet-tick hunk fails both the specific and the generalised assertion.
- **Guards the guard**: asserts the operating threshold differs from the script default — if they ever coincide, a missing flag becomes indistinguishable from a present one and every other assertion would pass vacuously.
- Both invokers verified to load and resolve to 72 at runtime.
- 218 tests green across the coupled suites.

Same class as QF-20260725-141: verifying at the merge is not verifying at the consumer, and verifying **one** consumer is not verifying **all** of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
