### PR TITLE
feat(SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001): counted, reasoned roadmap-link exception

### DIFF
--- a/lib/sd-creation/pipeline.js
+++ b/lib/sd-creation/pipeline.js
@@ -33,6 +33,8 @@ import { validateWaveDisposition, applyWaveDisposition } from '../roadmap/wave-d
 import { validateSDFields } from '../../scripts/modules/validate-sd-fields.js';
 // SD-LEO-INFRA-SOURCING-ENGINE-REGISTER-FIRST-001: pure register-first helpers (FR-2 warn-only decision).
 import { shouldWarnRegisterFirst } from '../sourcing-engine/register-first.js';
+// SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001: counted, reasoned roadmap-link exception.
+import { buildRoadmapLinkException } from '../sourcing-engine/roadmap-link-exception.js';
 // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: path-based target detector
 import { detectFromKeyChanges } from '../../scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js';
 import { assertValidSdType } from '../sd-type-enum.js';
@@ -625,6 +627,13 @@ async function createSD(options) {
     // events — creation requires an explicit wave disposition ({ waveId } or
     // { noWave: reason }); enforced below once dbType resolves.
     wave_disposition = null,
+    // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2): OPTIONAL operator reason for
+    // creating without a preceding roadmap registration. Omitting it is legal and never refuses —
+    // it records an explicit no-reason marker instead, so the gap is counted rather than silent.
+    // Deliberately NOT routed through wave_disposition: that field is read as "linked" by
+    // lib/roadmap/wave-linkage-coverage.js:69, so reusing it would inflate the very coverage
+    // number this exception must be measured beside.
+    roadmap_link_reason = null,
   } = options;
 
   // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-1/FR-2/FR-3): resolve the effective sd_type. An explicit
@@ -954,6 +963,23 @@ async function createSD(options) {
     || detectFromKeyChanges(finalKeyChanges)
     || null;
 
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-3 + TR-2): resolve the roadmap-link
+  // exception BEFORE the insert so it rides the single write at the insert below, rather than a
+  // post-insert update that can silently miss (the failure mode applyWaveDisposition documents
+  // for itself). FAIL-SOFT END TO END: any fault here leaves roadmapLinkException null and
+  // creation proceeds untouched — FR-1 forbids ANY refusal path on this seam.
+  let roadmapLinkException = null;
+  try {
+    const { data: regRows } = await supabase
+      .from('roadmap_wave_items').select('id').eq('promoted_to_sd_key', sdKey).limit(1);
+    const hasRegistration = Array.isArray(regRows) && regRows.length > 0;
+    // Reuse the EXISTING exemption predicate (children / fixtures / roadmap-sourced /
+    // SD-TEST|DEMO) rather than re-deriving it — one definition, no drift.
+    if (shouldWarnRegisterFirst({ sd_key: sdKey, metadata }, hasRegistration, parentId)) {
+      roadmapLinkException = buildRoadmapLinkException(sdKey, roadmap_link_reason, new Date().toISOString());
+    }
+  } catch { /* fail-soft: never block SD creation */ }
+
   const sdData = {
     id: randomUUID(),
     sd_key: sdKey,
@@ -1008,7 +1034,12 @@ async function createSD(options) {
       // intent and skip auto-correction when target_application was set
       // explicitly (CLI override or `## Target Application` plan header).
       // Inferred-from-key_changes is NOT considered explicit.
-      target_application_explicit: Boolean(explicitTargetApp || process.env.VENTURE)
+      target_application_explicit: Boolean(explicitTargetApp || process.env.VENTURE),
+      // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-3): the counted exception, stamped
+      // pre-insert. Spread so it is ABSENT (not null) when the SD is linked or exempt — absence
+      // is what countRoadmapLinkExceptions treats as "no exception", and a null would otherwise
+      // read as a recorded-but-empty exception.
+      ...(roadmapLinkException ? { roadmap_link_exception: roadmapLinkException } : {})
     }
   };
 
@@ -1271,15 +1302,15 @@ async function createSD(options) {
   // default-wave / source-id minting convention is owned by the deferred parent engine and must not be
   // invented on this universal create path. One lightweight check, fully fail-soft; disable via
   // REGISTER_FIRST_WARN=off. shouldWarnRegisterFirst skips children/fixtures/roadmap-sourced SDs.
-  if (process.env.REGISTER_FIRST_WARN !== 'off') {
-    try {
-      const { data: reg } = await supabase
-        .from('roadmap_wave_items').select('id').eq('promoted_to_sd_key', data.sd_key).limit(1);
-      const hasRegistration = Array.isArray(reg) && reg.length > 0;
-      if (shouldWarnRegisterFirst({ sd_key: data.sd_key, metadata }, hasRegistration, parentId)) {
-        console.warn(`   ⚠️  register-first: ${data.sd_key} created without a preceding roadmap registration (warn-only; auto-register awaits the roadmap-engine convention).`);
-      }
-    } catch { /* warn-only must never block SD creation */ }
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001: the bypass is no longer FREE and no longer
+  // INVISIBLE — the exception was already recorded pre-insert (see roadmapLinkException above),
+  // so this is now a report of a durable, countable record rather than a warning that vanishes
+  // with the process. It remains warn-only: nothing here can block creation.
+  if (process.env.REGISTER_FIRST_WARN !== 'off' && roadmapLinkException) {
+    const suffix = roadmapLinkException.reason_supplied
+      ? `reason recorded: "${roadmapLinkException.operator_reason}"`
+      : 'NO REASON RECORDED — pass a roadmap-link reason so this is not counted against the drive-to-zero target';
+    console.warn(`   ⚠️  register-first: ${data.sd_key} created without a preceding roadmap registration — counted exception recorded; ${suffix}`);
   }
 
   // Vision pre-screen at SD conception (SD-LEO-INFRA-VISION-SD-CONCEPTION-GATE-001)

--- a/lib/sourcing-engine/roadmap-link-exception.js
+++ b/lib/sourcing-engine/roadmap-link-exception.js
@@ -33,9 +33,41 @@
  *  no-reason case is countable rather than indistinguishable from "not applicable". */
 export const NO_REASON_MARKER = 'no-reason-supplied';
 
+/** Upper bound on the stored reason. Unbounded free text on a jsonb column written at EVERY
+ *  unlinked creation is re-transferred by the health probe on every run (it selects full
+ *  metadata), so one oversized reason is paid for forever. Bounded reason fields are established
+ *  practice here (bypass_ledger CHECK length >= 20; venture_capability_scores.rationale <= 200;
+ *  brand_variants.notes <= 1000). Truncation is silent BY DESIGN: refusing an over-long reason
+ *  would be a refusal path, and FR-1 forbids those outright. */
+export const REASON_MAX_CHARS = 1000;
+
+/** Control characters that must never reach the stored reason. */
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g;
+
+/**
+ * SECURITY (SEC-2): strip control characters before storing.
+ *
+ * THIS IS NOT COSMETIC — a NUL byte in the reason DEFEATS FR-1. The exception is spread into the
+ * SD's metadata and rides the single INSERT, and Postgres rejects a NUL escape in jsonb
+ * ("unsupported Unicode escape sequence"), so the insert fails, createSD returns
+ * {ok:false, code:'INSERT_FAILED'} and the CLI exits 1. That is a REFUSAL PATH on the very seam
+ * this SD's first line forbids — expressed by Postgres rather than by JavaScript, which is
+ * exactly why the static no-throw / no-exit scan cannot see it.
+ *
+ * It also closes the log-forgery class: an embedded newline would otherwise let crafted text emit
+ * a second stderr line shape-identical to a genuine warn for a different SD. Nothing
+ * machine-parses that text today, so the damage there is to a human audit transcript rather than
+ * to a machine decision — but one normalisation closes both, and ANSI escapes with them.
+ */
+function sanitizeReason(raw) {
+  return raw.replace(CONTROL_CHARS, ' ').replace(/\s+/g, ' ').trim();
+}
+
 /** Stable shape stamped onto metadata.roadmap_link_exception. */
 export function buildRoadmapLinkException(sdKey, operatorReason, nowIso) {
-  const raw = typeof operatorReason === 'string' ? operatorReason.trim() : '';
+  const raw = typeof operatorReason === 'string'
+    ? sanitizeReason(operatorReason).slice(0, REASON_MAX_CHARS)
+    : '';
   const supplied = raw.length > 0;
   return {
     sd_key: sdKey,
@@ -47,8 +79,8 @@ export function buildRoadmapLinkException(sdKey, operatorReason, nowIso) {
 }
 
 /** Pure: count exceptions across a set of SD rows, split so the drive-to-zero target is readable.
- *  `without_reason` is the number to drive to zero — NOT the total, which is expected to be
- *  non-zero indefinitely because the bypass stays legitimately available. */
+ *  `without_reason` is the number to drive to zero — NOT the total, which is expected to stay
+ *  non-zero indefinitely because the bypass remains legitimately available. */
 export function countRoadmapLinkExceptions(rows) {
   let total = 0;
   let with_reason = 0;
@@ -61,4 +93,6 @@ export function countRoadmapLinkExceptions(rows) {
   return { total, with_reason, without_reason: total - with_reason };
 }
 
-export default { buildRoadmapLinkException, countRoadmapLinkExceptions, NO_REASON_MARKER };
+export default {
+  buildRoadmapLinkException, countRoadmapLinkExceptions, NO_REASON_MARKER, REASON_MAX_CHARS,
+};

--- a/lib/sourcing-engine/roadmap-link-exception.js
+++ b/lib/sourcing-engine/roadmap-link-exception.js
@@ -1,0 +1,64 @@
+// SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 — the counted, reasoned roadmap-link exception.
+//
+// THE DEFECT: lib/sd-creation/pipeline.js warned when an SD was created without a preceding
+// roadmap registration and did nothing else. A warn-only signal on a convention that matters IS
+// fail-open: the warning lives only in the stdout of the creating process, so it is not merely
+// unread, it is UNREADABLE AFTER THE FACT and nothing can count it.
+//
+// EXPLICITLY NOT A BLOCKING GATE. The SD's own first line forbids a refusal, and the measured
+// reason is force-completion: 553 of 905 completed quick_fixes carry force_completed=true, and
+// the GENUINE human-override share is 19.1% all-time / 13.1% over 30 days (the rest is machine
+// reconcile). An escape hatch normalized at that rate is what a hard gate becomes when it meets
+// real urgency, and a blocking gate would bind hardest on the most productive sourcing days.
+// Nothing in this module may throw, exit, or refuse.
+//
+// WHY metadata.roadmap_link_exception AND NOT metadata.wave_disposition:
+// lib/roadmap/wave-linkage-coverage.js:69 computes linkage as
+//   promotedKeys.has(sd_key) || Boolean(s.metadata?.wave_disposition)
+// Boolean of ANY disposition. Storing the exception there would put every recorded exception into
+// the LINKED numerator and RAISE plan-adherence coverage — the exception would become invisible
+// in, and would actively falsify, the exact gauge it must be surfaced beside. Verified: that
+// module reads ONLY promoted_to_sd_key and wave_disposition, so this key cannot inflate coverage.
+//
+// WHY AN OPERATOR REASON IS KEPT DISTINCT FROM THE AUTO-DERIVED BUCKET:
+// lib/sd-creation/plan-linkage-classifier.js already classifies every unlinked creation, but its
+// reason is DERIVED FROM THE SD-KEY PREFIX (harness-upkeep / venture-ops / emergent-fix) — it
+// restates the key rather than saying why THIS SD skipped registration. A field that is always
+// populated is never informative. The cautionary precedent is quick_fixes.force_completed, which
+// has five writers and zero production JS readers: a recorded exception that nothing reads is
+// functionally identical to no exception at all. Hence `operator_reason` is separate, and
+// `reason_supplied` makes the gap COUNTED rather than silent so it can be driven to zero.
+
+/** Marker recorded when creation proceeded with no operator reason. Explicit, never null, so the
+ *  no-reason case is countable rather than indistinguishable from "not applicable". */
+export const NO_REASON_MARKER = 'no-reason-supplied';
+
+/** Stable shape stamped onto metadata.roadmap_link_exception. */
+export function buildRoadmapLinkException(sdKey, operatorReason, nowIso) {
+  const raw = typeof operatorReason === 'string' ? operatorReason.trim() : '';
+  const supplied = raw.length > 0;
+  return {
+    sd_key: sdKey,
+    // Kept DISTINCT from plan_linkage's auto-derived unlinked_reason (see header).
+    operator_reason: supplied ? raw : NO_REASON_MARKER,
+    reason_supplied: supplied,
+    recorded_at: nowIso,
+  };
+}
+
+/** Pure: count exceptions across a set of SD rows, split so the drive-to-zero target is readable.
+ *  `without_reason` is the number to drive to zero — NOT the total, which is expected to be
+ *  non-zero indefinitely because the bypass stays legitimately available. */
+export function countRoadmapLinkExceptions(rows) {
+  let total = 0;
+  let with_reason = 0;
+  for (const row of rows || []) {
+    const ex = row && row.metadata && row.metadata.roadmap_link_exception;
+    if (!ex) continue;
+    total += 1;
+    if (ex.reason_supplied === true) with_reason += 1;
+  }
+  return { total, with_reason, without_reason: total - with_reason };
+}
+
+export default { buildRoadmapLinkException, countRoadmapLinkExceptions, NO_REASON_MARKER };

--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -17,6 +17,9 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { liveFleetWorkers } from '../lib/fleet/genuine-worker.mjs';
 import { computeWaveLinkageCoverage } from '../lib/roadmap/wave-linkage-coverage.js';
+// SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-5): surface the counted exception beside
+// the adherence number. Shared pure tally — never re-derived here.
+import { countRoadmapLinkExceptions } from '../lib/sourcing-engine/roadmap-link-exception.js';
 import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
 import { getActiveCoordinatorId } from '../lib/coordinator/resolve.cjs';
 // QF-20260725-089: the ONE belt-depth gauge, eligibility-gated. Never re-derive a depth count here.
@@ -99,8 +102,19 @@ export async function computeUtilization(supabase, { nowMs = Date.now() } = {}) 
  */
 export async function computePlanAdherence(supabase) {
   const result = await computeWaveLinkageCoverage(supabase);
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-5): a recorded exception that nothing
+  // READS is no exception at all — the precedent is quick_fixes.force_completed, which has five
+  // writers and zero production JS readers. So the count is surfaced HERE, beside the adherence
+  // number, and it is fetched BEFORE the branch below because the unmeasurable branch returns
+  // early: a field added only to the measured branch reads `undefined` whenever there are zero
+  // claimable leaves. `without_reason` is the figure to drive to zero — NOT `total`, since the
+  // bypass stays legitimately available and its total is expected to remain non-zero.
+  const roadmap_link_exceptions = await countRoadmapLinkExceptionsLive(supabase);
   if (result.coverage === null) {
-    return { status: 'unmeasurable_until_linkage', coverage: null, linked: result.linked, total: result.total };
+    return {
+      status: 'unmeasurable_until_linkage', coverage: null, linked: result.linked, total: result.total,
+      roadmap_link_exceptions,
+    };
   }
 
   const candidateKeys = result.unlinkedKeys.length ? result.unlinkedKeys : ['__none__'];
@@ -118,7 +132,28 @@ export async function computePlanAdherence(supabase) {
     total: result.total,
     starved: result.starved,
     in_flight_unlinked: (inFlightRows || []).map((r) => r.sd_key),
+    roadmap_link_exceptions,
   };
+}
+
+/**
+ * IO for FR-5's counter. Paginated (the 1000-row PostgREST cap would otherwise silently
+ * under-count on a table of this size) and FAIL-SOFT — a fault returns zeros rather than
+ * throwing, because this gauge is advisory and must never break the health probe.
+ * The tally itself is the shared pure function, not a re-derivation.
+ */
+async function countRoadmapLinkExceptionsLive(supabase) {
+  try {
+    const { fetchAllPaginated } = await import('../lib/db/fetch-all-paginated.mjs');
+    const rows = await fetchAllPaginated(() => supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, metadata')
+      .not('metadata->roadmap_link_exception', 'is', null)
+      .order('sd_key', { ascending: true }));
+    return countRoadmapLinkExceptions(rows || []);
+  } catch {
+    return { total: 0, with_reason: 0, without_reason: 0, unmeasured: true };
+  }
 }
 
 /**

--- a/scripts/modules/leo-create-sd/direct-lane.js
+++ b/scripts/modules/leo-create-sd/direct-lane.js
@@ -38,7 +38,13 @@ export async function runDirectCreation(args) {
     '--migration-reviewed', '--security-reviewed', '--yes', '-y',
     // SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001 (FR-2): wave disposition flags,
     // required when the direct lane creates an orchestrator parent.
-    '--wave', '--no-wave'
+    '--wave', '--no-wave',
+    // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2): OPTIONAL operator reason for
+    // creating without a preceding roadmap registration. Never required — omitting it records an
+    // explicit no-reason marker so the gap is COUNTED rather than silent. Deliberately separate
+    // from --no-wave: that one writes metadata.wave_disposition, which the linkage gauge reads as
+    // LINKED, so reusing it would inflate the coverage number this exception is measured beside.
+    '--roadmap-link-reason'
   ]);
   const unknownFlags = args.filter(a => a.startsWith('-') && !knownDirectFlags.has(a));
   if (unknownFlags.length > 0) {
@@ -56,7 +62,15 @@ export async function runDirectCreation(args) {
   const [source, type, ...titleParts] = args;
   // Strip flags and their values from the title (SD-DISTILLTOBRAINSTORM quality fix)
   // Without this, --vision-key VALUE --arch-key VALUE leak into the title text
-  const flagsWithValues = new Set(['--venture', '--vision-key', '--arch-key', '--target-repos']);
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001: --roadmap-link-reason takes a free-text
+  // value, so it MUST be listed here or the reason text is swallowed into the SD title.
+  // Adding --wave/--no-wave at the same time: they take values too and were never listed, so
+  // their values have been leaking into titles since SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001. Same
+  // one-line set, strictly a fix — found while wiring the flag beside them.
+  const flagsWithValues = new Set([
+    '--venture', '--vision-key', '--arch-key', '--target-repos',
+    '--wave', '--no-wave', '--roadmap-link-reason',
+  ]);
   const cleanedTitleParts = [];
   for (let i = 0; i < titleParts.length; i++) {
     if (flagsWithValues.has(titleParts[i])) {
@@ -356,12 +370,18 @@ export async function runDirectCreation(args) {
     ? { waveId: args[directWaveIdx + 1] }
     : (directNoWaveIdx !== -1 ? { noWave: args[directNoWaveIdx + 1] } : null);
 
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2): optional; absent is legal and
+  // records the explicit no-reason marker rather than refusing.
+  const directRoadmapLinkIdx = args.indexOf('--roadmap-link-reason');
+  const directRoadmapLinkReason = directRoadmapLinkIdx !== -1 ? args[directRoadmapLinkIdx + 1] : null;
+
   const createRes = await createSD({
     sdKey,
     title,
     description: enriched?.description || title,
     type,
     wave_disposition: directWaveDisposition,
+    roadmap_link_reason: directRoadmapLinkReason,
     rationale: enriched?.rationale || 'Created via /leo create',
     success_criteria: enriched?.success_criteria || null,
     key_changes: enriched?.key_changes || null,

--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -148,6 +148,9 @@ const MAPPED_PROPOSAL_KEYS = new Set([
   'title', 'type', 'priority', 'description', 'scope', 'rationale', 'success_criteria',
   'key_changes', 'success_metrics', 'strategic_objectives', 'smoke_test_steps', 'metadata',
   'provenance', 'roadmap_phase', 'tier_hint', 'gold_origin', 'necessity', 'dedup_note', 'sourced_by',
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2): optional operator reason, consumed
+  // by the mapper above. Listed here so the authored-key guard does not flag it as unmapped.
+  'roadmap_link_reason',
 ]);
 // Keys a proposal legitimately carries that this mapper does not consume because another stage of
 // the ingest path already does. Two such stages: validateProposalShape() above (proposed_sd_key,
@@ -247,6 +250,17 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
     // FR-2: the primary target repo becomes the canonical top-level target_application that the
     // branch-resolver / gate / repo-path resolution read (mirrors the --target-repos flag path).
     ...(proposalTargetRepos ? { target_application: proposalTargetRepos[0] } : {}),
+    // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2): carry the OPTIONAL operator reason
+    // for creating without a preceding roadmap registration.
+    // WHY THIS LANE SPECIFICALLY: --from-proposal / --proposal-b64 / --proposal-stdin are the
+    // canonical Adam sourcing routes, so they are where unlinked SDs are actually born at volume.
+    // Wiring only direct-lane left this path recording NO_REASON_MARKER unconditionally — the
+    // drive-to-zero target could not be moved by the very route that produces most of the gap,
+    // which is the "recorded but unmovable" defect this SD exists to close, reproduced inside its
+    // own fix. Absent is legal and still records the explicit marker; it never refuses.
+    ...(typeof proposal.roadmap_link_reason === 'string' && proposal.roadmap_link_reason.trim()
+      ? { roadmap_link_reason: proposal.roadmap_link_reason }
+      : {}),
     metadata: {
       // FR-1: full proposal metadata preserved (minus leak-guard keys), then canonical defaults
       // below WIN over any same-named proposal key (source, provenance, validated target_repos, …).

--- a/tests/unit/leo-create-sd-proposal-roadmap-link-reason.test.js
+++ b/tests/unit/leo-create-sd-proposal-roadmap-link-reason.test.js
@@ -1,0 +1,73 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-2) — the roadmap-link reason must reach
+ * createSD from the PROPOSAL lane, not only from the direct lane.
+ *
+ * WHY THIS TEST EXISTS: the first cut of this SD wired --roadmap-link-reason into direct-lane.js
+ * only. --from-proposal / --proposal-b64 / --proposal-stdin share mapProposalToCreateArgs and are
+ * the CANONICAL Adam sourcing routes — i.e. where unlinked SDs are actually born at volume — so
+ * every SD created there recorded NO_REASON_MARKER with no shipped way to supply a reason. The
+ * drive-to-zero target could not be moved by the route that produces most of the gap: the exact
+ * "recorded but unmovable" defect this SD exists to close, reproduced inside its own fix.
+ *
+ * PURE: exercises the exported mapper directly. ZERO live DB access.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapProposalToCreateArgs } from '../../scripts/leo-create-sd.js';
+
+const NORMALIZED = {
+  sdKey: 'SD-LEO-INFRA-UNLINKED-001',
+  title: 'An unlinked SD',
+  type: 'infrastructure',
+  priority: 'medium',
+  rawType: 'infrastructure',
+};
+
+function proposal(extra = {}) {
+  return {
+    PROPOSAL: true,
+    status_intended: 'draft',
+    proposed_sd_key: 'SD-LEO-INFRA-UNLINKED-001',
+    title: 'An unlinked SD',
+    sd_type: 'infrastructure',
+    priority: 'medium',
+    rationale: 'sourced without a preceding roadmap registration',
+    scope: 'DOES: x. DOES NOT: y.',
+    metadata: {},
+    ...extra,
+  };
+}
+
+describe('mapProposalToCreateArgs — roadmap_link_reason passthrough (FR-2)', () => {
+  it('passes a declared reason through to createSD args', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({ roadmap_link_reason: 'harness upkeep, no wave exists yet' }));
+    expect(args.roadmap_link_reason).toBe('harness upkeep, no wave exists yet');
+  });
+
+  it('omits the key entirely when the proposal declares no reason (closed-whitelist invariant)', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal());
+    expect(Object.prototype.hasOwnProperty.call(args, 'roadmap_link_reason')).toBe(false);
+  });
+
+  it('treats an empty or whitespace-only reason as absent rather than as a supplied reason', () => {
+    for (const blank of ['', '   ']) {
+      const args = mapProposalToCreateArgs(NORMALIZED, proposal({ roadmap_link_reason: blank }));
+      expect(Object.prototype.hasOwnProperty.call(args, 'roadmap_link_reason')).toBe(false);
+    }
+  });
+
+  it('ignores a non-string reason instead of coercing it', () => {
+    for (const junk of [42, true, {}, [], null]) {
+      const args = mapProposalToCreateArgs(NORMALIZED, proposal({ roadmap_link_reason: junk }));
+      expect(Object.prototype.hasOwnProperty.call(args, 'roadmap_link_reason')).toBe(false);
+    }
+  });
+
+  it('NO-REGRESSION: adding the key does not disturb the other mapped args', () => {
+    const withReason = mapProposalToCreateArgs(NORMALIZED, proposal({ roadmap_link_reason: 'a reason' }));
+    const without = mapProposalToCreateArgs(NORMALIZED, proposal());
+    expect(withReason.sdKey).toBe(without.sdKey);
+    expect(withReason.title).toBe(without.title);
+    expect(withReason.type).toBe(without.type);
+    expect(withReason.metadata).toEqual(without.metadata);
+  });
+});

--- a/tests/unit/sd-creation/create-sd-no-exit.test.js
+++ b/tests/unit/sd-creation/create-sd-no-exit.test.js
@@ -121,4 +121,25 @@ describe('SD-ARCH-HOTSPOT-LEO-CREATE-001: lib/sd-creation contains no process.ex
       expect(src.includes(needle), `${path.relative(root, file)} must not contain ${needle}`).toBe(false);
     }
   });
+
+  // SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 (FR-1): the scan above walks ONLY
+  // lib/sd-creation/, but the register-first predicate and the roadmap-link exception builder it
+  // now calls live in lib/sourcing-engine/. A refusal added there would run on the creation path
+  // and be invisible to the walk above — the blind spot is the point of this second assertion.
+  it('the sourcing-engine modules on the creation path contain no process.exit invocation', () => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const onPath = ['register-first.js', 'roadmap-link-exception.js']
+      .map((f) => path.resolve(__dirname, '../../../lib/sourcing-engine', f));
+    const needle = 'process.' + 'exit(';
+    for (const file of onPath) {
+      expect(fs.existsSync(file), `${path.basename(file)} must exist — it is on the SD-creation path`).toBe(true);
+      const src = fs.readFileSync(file, 'utf8');
+      expect(src.includes(needle), `${path.basename(file)} must not contain ${needle}`).toBe(false);
+      // FR-1 also forbids a THROWN refusal from the exception seam. The builder is pure and must
+      // stay that way — a throw here would propagate into createSD's metadata assembly.
+      if (file.endsWith('roadmap-link-exception.js')) {
+        expect(src.includes('throw '), 'roadmap-link-exception.js must not throw — FR-1 forbids any refusal path').toBe(false);
+      }
+    }
+  });
 });

--- a/tests/unit/sd-creation/create-sd-no-exit.test.js
+++ b/tests/unit/sd-creation/create-sd-no-exit.test.js
@@ -128,18 +128,33 @@ describe('SD-ARCH-HOTSPOT-LEO-CREATE-001: lib/sd-creation contains no process.ex
   // and be invisible to the walk above — the blind spot is the point of this second assertion.
   it('the sourcing-engine modules on the creation path contain no process.exit invocation', () => {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const onPath = ['register-first.js', 'roadmap-link-exception.js']
-      .map((f) => path.resolve(__dirname, '../../../lib/sourcing-engine', f));
-    const needle = 'process.' + 'exit(';
-    for (const file of onPath) {
-      expect(fs.existsSync(file), `${path.basename(file)} must exist — it is on the SD-creation path`).toBe(true);
-      const src = fs.readFileSync(file, 'utf8');
-      expect(src.includes(needle), `${path.basename(file)} must not contain ${needle}`).toBe(false);
-      // FR-1 also forbids a THROWN refusal from the exception seam. The builder is pure and must
-      // stay that way — a throw here would propagate into createSD's metadata assembly.
-      if (file.endsWith('roadmap-link-exception.js')) {
-        expect(src.includes('throw '), 'roadmap-link-exception.js must not throw — FR-1 forbids any refusal path').toBe(false);
+    // Walk the DIRECTORY rather than hard-coding filenames — the sibling scan above walks, and a
+    // hard-coded list silently stops covering any module added to this path later.
+    const root = path.resolve(__dirname, '../../../lib/sourcing-engine');
+    const files = [];
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (/\.(js|mjs|cjs)$/.test(entry.name)) files.push(full);
       }
+    };
+    walk(root);
+    expect(files.length).toBeGreaterThanOrEqual(2);
+    const needle = 'process.' + 'exit(';
+    for (const file of files) {
+      const src = fs.readFileSync(file, 'utf8');
+      expect(src.includes(needle), `${path.relative(root, file)} must not contain ${needle}`).toBe(false);
     }
+
+    // FR-1 also forbids a THROWN refusal from the exception seam. Scan CODE ONLY: a naive
+    // src.includes('throw ') matches the module's own prose ("may throw, exit, or refuse") and
+    // fails on a comment edit — it did exactly that once. Strip comments first so the assertion
+    // tracks behaviour rather than wording.
+    const target = path.join(root, 'roadmap-link-exception.js');
+    const codeOnly = fs.readFileSync(target, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')      // block comments (incl. JSDoc)
+      .split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+    expect(/\bthrow\b/.test(codeOnly), 'roadmap-link-exception.js must not throw — FR-1 forbids any refusal path').toBe(false);
   });
 });

--- a/tests/unit/sourcing-engine/roadmap-link-exception.test.js
+++ b/tests/unit/sourcing-engine/roadmap-link-exception.test.js
@@ -13,8 +13,10 @@ import {
   buildRoadmapLinkException,
   countRoadmapLinkExceptions,
   NO_REASON_MARKER,
+  REASON_MAX_CHARS,
 } from '../../../lib/sourcing-engine/roadmap-link-exception.js';
 import { computeWaveLinkageCoverage } from '../../../lib/roadmap/wave-linkage-coverage.js';
+import { computePlanAdherence } from '../../../scripts/adam-coordinator-health.mjs';
 
 const NOW = '2026-07-25T22:00:00.000Z';
 
@@ -39,6 +41,39 @@ describe('buildRoadmapLinkException — FR-3 (record unconditionally, operator r
     const ex = buildRoadmapLinkException('SD-X-001', 'a reason', NOW);
     expect(ex).not.toHaveProperty('wave_disposition');
     expect(Object.keys(ex).sort()).toEqual(['operator_reason', 'reason_supplied', 'recorded_at', 'sd_key']);
+  });
+
+  // SEC-2. A NUL byte here is not cosmetic: the exception rides the SD's single INSERT, and
+  // Postgres rejects a NUL escape in jsonb, so an unsanitised reason makes createSD return
+  // {ok:false, INSERT_FAILED} and the CLI exit 1 — a REFUSAL PATH, which FR-1 forbids outright.
+  // The static no-throw/no-exit scan cannot see it because the refusal is expressed by Postgres,
+  // not by JavaScript. This is the only assertion that can.
+  it('SEC-2: strips a NUL byte, which would otherwise fail the jsonb insert and refuse creation', () => {
+    const withNul = `before${String.fromCharCode(0)}after`;
+    const ex = buildRoadmapLinkException('SD-X-001', withNul, NOW);
+    expect(ex.operator_reason).not.toContain(String.fromCharCode(0));
+    expect(ex.operator_reason).toBe('before after');
+    expect(JSON.stringify(ex)).not.toContain('\\u0000');
+  });
+
+  it('SEC-2: collapses newlines so a crafted reason cannot forge a second warn line', () => {
+    const forged = `real reason${String.fromCharCode(10)}   ⚠️  register-first: SD-FAKE-001 created without`;
+    const ex = buildRoadmapLinkException('SD-X-001', forged, NOW);
+    expect(ex.operator_reason).not.toContain(String.fromCharCode(10));
+    expect(ex.operator_reason.split(String.fromCharCode(10))).toHaveLength(1);
+  });
+
+  it('SEC-2: strips ANSI escapes rather than passing them to an operator console', () => {
+    const ansi = `red${String.fromCharCode(27)}[31mtext`;
+    expect(buildRoadmapLinkException('SD-X-001', ansi, NOW).operator_reason)
+      .not.toContain(String.fromCharCode(27));
+  });
+
+  it('SEC-1: caps an oversized reason instead of storing it verbatim, and NEVER refuses', () => {
+    const huge = 'z'.repeat(5000);
+    const ex = buildRoadmapLinkException('SD-X-001', huge, NOW);
+    expect(ex.operator_reason).toHaveLength(REASON_MAX_CHARS);
+    expect(ex.reason_supplied).toBe(true); // truncated, not rejected — refusing would fail FR-1
   });
 });
 
@@ -102,5 +137,67 @@ describe('TS-4 — a recorded exception must NOT raise plan-linkage coverage', (
     expect(good.linked).toBe(0);
     expect(bad.linked).toBe(1); // wave-linkage-coverage.js:69 Boolean(wave_disposition)
     expect(bad.linked).toBeGreaterThan(good.linked);
+  });
+});
+
+describe('FR-5 — computePlanAdherence surfaces the count on BOTH return branches', () => {
+  // A recorded exception that nothing READS is no exception at all (the force_completed
+  // precedent: five writers, zero production JS readers). These assertions exist because
+  // deleting the field from the unmeasurable branch previously left the whole suite green —
+  // FR-5's headline property had zero coverage despite the commit message warning about
+  // exactly that regression.
+  const exWith = buildRoadmapLinkException('SD-A', 'a stated reason', NOW);
+  const exWithout = buildRoadmapLinkException('SD-B', null, NOW);
+
+  /** `leaves` drives which branch fires: zero claimable leaves => unmeasurable_until_linkage. */
+  function fake({ leaves }) {
+    const exceptionRows = [{ metadata: { roadmap_link_exception: exWith } }, { metadata: { roadmap_link_exception: exWithout } }];
+    function terminal(data) {
+      const b = { order: () => b, range: async () => ({ data, error: null }) };
+      return b;
+    }
+    return {
+      from: (table) => {
+        if (table === 'roadmap_wave_items') return { select: () => ({ not: () => terminal([]) }) };
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: () => ({
+              // the coverage SSOT path
+              not: () => terminal(leaves),
+              // the in-flight filter on the measured branch
+              in: () => ({ in: async () => ({ data: [], error: null }) }),
+            }),
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      },
+      __exceptionRows: exceptionRows,
+    };
+  }
+
+  it('MEASURED branch carries a real, non-zero split', async () => {
+    const leaves = [{ sd_key: 'SD-A', sd_type: 'infrastructure', status: 'draft', metadata: {} }];
+    const r = await computePlanAdherence(fake({ leaves }));
+    expect(r.status).toBe('measured');
+    expect(r.roadmap_link_exceptions).toBeTruthy();
+    expect(typeof r.roadmap_link_exceptions.without_reason).toBe('number');
+  });
+
+  it('UNMEASURABLE branch carries the SAME field — it returns early, so it is the regression risk', async () => {
+    const r = await computePlanAdherence(fake({ leaves: [] }));
+    expect(r.status).toBe('unmeasurable_until_linkage');
+    // `toBeDefined()` alone would be too weak here: the branch fires at zero leaves, where a
+    // genuine read also plausibly returns zero. Assert the SHAPE is fully present instead.
+    expect(r.roadmap_link_exceptions).toBeTruthy();
+    expect(r.roadmap_link_exceptions).toHaveProperty('total');
+    expect(r.roadmap_link_exceptions).toHaveProperty('with_reason');
+    expect(r.roadmap_link_exceptions).toHaveProperty('without_reason');
+  });
+
+  it('the pure tally underneath is what makes the split meaningful', () => {
+    expect(countRoadmapLinkExceptions([
+      { metadata: { roadmap_link_exception: exWith } },
+      { metadata: { roadmap_link_exception: exWithout } },
+    ])).toEqual({ total: 2, with_reason: 1, without_reason: 1 });
   });
 });

--- a/tests/unit/sourcing-engine/roadmap-link-exception.test.js
+++ b/tests/unit/sourcing-engine/roadmap-link-exception.test.js
@@ -1,0 +1,106 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-LINK-COUNTED-EXCEPTION-001 — the counted, reasoned roadmap-link exception.
+ *
+ * TS-4 NOTE (why the coverage test is shaped the way it is): a test that merely records an
+ * exception and then asserts coverage is unchanged is a TAUTOLOGY — computeWaveLinkageCoverage
+ * never reads the exception record at all, so that assertion passes for ANY implementation,
+ * including the wrong one that stores it in metadata.wave_disposition. The only form that can
+ * fail is one that feeds the recorded metadata THROUGH the real coverage function and separately
+ * asserts the wave_disposition key is absent. Both are done below.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildRoadmapLinkException,
+  countRoadmapLinkExceptions,
+  NO_REASON_MARKER,
+} from '../../../lib/sourcing-engine/roadmap-link-exception.js';
+import { computeWaveLinkageCoverage } from '../../../lib/roadmap/wave-linkage-coverage.js';
+
+const NOW = '2026-07-25T22:00:00.000Z';
+
+describe('buildRoadmapLinkException — FR-3 (record unconditionally, operator reason kept distinct)', () => {
+  it('records a supplied operator reason verbatim and flags it as supplied', () => {
+    const ex = buildRoadmapLinkException('SD-X-001', '  urgent revenue false-gate, sourced in minutes  ', NOW);
+    expect(ex.operator_reason).toBe('urgent revenue false-gate, sourced in minutes');
+    expect(ex.reason_supplied).toBe(true);
+    expect(ex.sd_key).toBe('SD-X-001');
+    expect(ex.recorded_at).toBe(NOW);
+  });
+
+  it('records an EXPLICIT marker when no reason is supplied — never null, so the gap is countable', () => {
+    for (const missing of [null, undefined, '', '   ']) {
+      const ex = buildRoadmapLinkException('SD-X-001', missing, NOW);
+      expect(ex.operator_reason).toBe(NO_REASON_MARKER);
+      expect(ex.reason_supplied).toBe(false);
+    }
+  });
+
+  it('never produces a wave_disposition key — that field is read as LINKED by the coverage gauge', () => {
+    const ex = buildRoadmapLinkException('SD-X-001', 'a reason', NOW);
+    expect(ex).not.toHaveProperty('wave_disposition');
+    expect(Object.keys(ex).sort()).toEqual(['operator_reason', 'reason_supplied', 'recorded_at', 'sd_key']);
+  });
+});
+
+describe('countRoadmapLinkExceptions — FR-5 (the count must be READ, split so zero is drivable)', () => {
+  it('splits with_reason from without_reason so the drive-to-zero target is readable', () => {
+    const rows = [
+      { metadata: { roadmap_link_exception: buildRoadmapLinkException('a', 'because', NOW) } },
+      { metadata: { roadmap_link_exception: buildRoadmapLinkException('b', null, NOW) } },
+      { metadata: { roadmap_link_exception: buildRoadmapLinkException('c', null, NOW) } },
+    ];
+    expect(countRoadmapLinkExceptions(rows)).toEqual({ total: 3, with_reason: 1, without_reason: 2 });
+  });
+
+  it('ignores rows with no exception, and tolerates absent/!malformed metadata', () => {
+    const rows = [{}, { metadata: null }, { metadata: {} }, null, { metadata: { roadmap_link_exception: null } }];
+    expect(countRoadmapLinkExceptions(rows)).toEqual({ total: 0, with_reason: 0, without_reason: 0 });
+    expect(countRoadmapLinkExceptions(null)).toEqual({ total: 0, with_reason: 0, without_reason: 0 });
+  });
+});
+
+describe('TS-4 — a recorded exception must NOT raise plan-linkage coverage', () => {
+  /** Mirrors the paginated-builder fake in tests/unit/wave-linkage-coverage.test.js:12-30 —
+   *  computeWaveLinkageCoverage goes through fetchAllPaginated, so .not() must return a
+   *  chainable builder whose .range() resolves, not a bare Promise. */
+  function fakeSupabase(sdRows) {
+    function terminal(data) {
+      const builder = { order: () => builder, range: async () => ({ data, error: null }) };
+      return builder;
+    }
+    return {
+      from: (table) => ({
+        strategic_directives_v2: { select: () => ({ not: () => terminal(sdRows) }) },
+        roadmap_wave_items: { select: () => ({ not: () => terminal([]) }) },
+      })[table],
+    };
+  }
+
+  it('feeding the RECORDED metadata through the REAL coverage function does not increase linked', async () => {
+    const ex = buildRoadmapLinkException('SD-UNLINKED-001', 'harness upkeep, no wave yet', NOW);
+    const withException = [{ sd_key: 'SD-UNLINKED-001', sd_type: 'infrastructure', status: 'draft', metadata: { roadmap_link_exception: ex } }];
+    const withoutException = [{ sd_key: 'SD-UNLINKED-001', sd_type: 'infrastructure', status: 'draft', metadata: {} }];
+
+    const a = await computeWaveLinkageCoverage(fakeSupabase(withException));
+    const b = await computeWaveLinkageCoverage(fakeSupabase(withoutException));
+
+    // The exception must be INERT to the gauge — identical linked count either way.
+    expect(a.linked).toBe(b.linked);
+    expect(a.coverage).toBe(b.coverage);
+  });
+
+  it('MUTATION GUARD: storing the same record under wave_disposition WOULD inflate linked', async () => {
+    // This is the wrong implementation FR-4 forbids. Asserting it genuinely inflates proves the
+    // test above is measuring something real rather than passing vacuously.
+    const ex = buildRoadmapLinkException('SD-UNLINKED-001', 'harness upkeep', NOW);
+    const correct = [{ sd_key: 'SD-UNLINKED-001', sd_type: 'infrastructure', status: 'draft', metadata: { roadmap_link_exception: ex } }];
+    const wrong = [{ sd_key: 'SD-UNLINKED-001', sd_type: 'infrastructure', status: 'draft', metadata: { wave_disposition: { kind: 'no_wave', reason: 'harness upkeep' } } }];
+
+    const good = await computeWaveLinkageCoverage(fakeSupabase(correct));
+    const bad = await computeWaveLinkageCoverage(fakeSupabase(wrong));
+
+    expect(good.linked).toBe(0);
+    expect(bad.linked).toBe(1); // wave-linkage-coverage.js:69 Boolean(wave_disposition)
+    expect(bad.linked).toBeGreaterThan(good.linked);
+  });
+});


### PR DESCRIPTION
## What

SD creation walked past roadmap linkage with a `console.warn` that had **no persistent side effect**, so the bypass was free and invisible — the warning lived only in the creating process's stdout, making it not merely unread but *unreadable after the fact*. It is now a **counted, reasoned exception**.

## Explicitly NOT a blocking gate

The SD is failed by any refusal path, and the measured reason is force-completion: genuine human overrides run **19.1% all-time / 13.1% over 30 days**. An escape hatch normalized at that rate is what a hard gate becomes under real urgency — and a blocking gate would bind hardest on the most productive sourcing days.

- Records **unconditionally**: an operator reason when supplied, an explicit no-reason marker when not, so the gap is *counted* rather than silent and can be driven to zero.
- Stamped **pre-insert**, riding the single write rather than a post-insert update that can silently miss.
- **Fail-soft end to end** — any fault leaves the record null and creation proceeds.

## The trap this deliberately avoids

`wave-linkage-coverage.js:69` computes linkage as `promotedKeys.has(sd_key) || Boolean(metadata.wave_disposition)` — `Boolean` of **any** disposition. Storing the exception there would put every recorded exception into the **linked numerator** and *raise* the coverage number the exception must be measured beside.

A **mutation-guard test** asserts exactly this: correct storage yields `linked=0`, the forbidden storage yields `linked=1`. That guard is what makes the primary assertion meaningful — without it, "record an exception, assert coverage unchanged" is a tautology against a gauge that never reads the record.

## Why the operator reason is kept separate

`plan_linkage`'s existing reason is **auto-derived from the SD-key prefix**, so it restates the key rather than saying why *this* SD skipped registration. The cautionary precedent is `quick_fixes.force_completed`: five writers, **zero production JS readers** — a recorded exception nothing reads is no exception at all.

Hence the count is surfaced in `computePlanAdherence`, fetched **before** the branch so it appears on **both** return shapes (the unmeasurable branch returns early, so a field added only to the measured branch reads `undefined` at zero claimable leaves).

Also extends the static no-refusal scan to `lib/sourcing-engine/` — the existing invariant walks only `lib/sd-creation/`, so a refusal in the register-first predicate or the new builder would run on the creation path unseen.

## Verification

418 tests green across the coupled suites; 312 green on the creation + sourcing-engine subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
