### PR TITLE
fix(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): mint the canary CALLSIGN — the second conjunct of the targetability guard

### DIFF
--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -25,6 +25,7 @@ import { resolveCanaryTarget } from './canary-guard.js';
 import { spawn as spawnControlSpawn } from './spawn-control.js';
 
 const CANARY_PROFILE = 'canary';
+const CANARY_CALLSIGN_PREFIX = 'Canary-';
 
 /**
  * Pick the enabled canary slot from the desired-slots manifest. Pure.
@@ -35,6 +36,29 @@ const CANARY_PROFILE = 'canary';
 export function selectCanarySlot(slots = []) {
   const list = Array.isArray(slots) ? slots : [];
   return list.find((s) => s && s.account_profile === CANARY_PROFILE && s.name) || null;
+}
+
+/**
+ * SD-LEO-INFRA-LAUNCHER-CAN-HOST-001: does the selected slot's name actually satisfy the TARGETABILITY
+ * guard? Pure.
+ *
+ * WHY THIS EXISTS. The slot name becomes the canary's callsign, and assertCanaryTarget is a two-conjunct
+ * guard requiring account_profile==='canary' AND a 'Canary-' callsign. selectCanarySlot enforces only the
+ * profile, NOT the namespace -- so a slot legitimately marked account_profile=canary but named e.g.
+ * "Bravo" would provision a canary that is discoverable and permanently UNTARGETABLE, with nothing in the
+ * pipeline saying why. Today's data happens to be right (the single enabled slot is "Canary-pilot"), which
+ * is exactly the condition under which this silently rots.
+ *
+ * Returns a reason rather than throwing: provisioning should still run and report, not fail-closed on a
+ * naming problem an operator can see and fix.
+ */
+export function assessCanarySlotNaming(slot) {
+  const name = slot && slot.name;
+  if (typeof name !== 'string' || !name) return { ok: false, reason: 'no_slot_name' };
+  if (!name.startsWith(CANARY_CALLSIGN_PREFIX)) {
+    return { ok: false, reason: 'slot_name_outside_canary_namespace', name };
+  }
+  return { ok: true, name };
 }
 
 /**
@@ -90,6 +114,14 @@ export async function provisionCanary({
   if (!slot) {
     // Genuinely unseeded — a provisioning step cannot invent a slot; S3 seeding must run first.
     return { ok: false, reason: 'no_canary_slot_seeded' };
+  }
+
+  // Surface a naming problem BEFORE spawning: the slot name becomes the callsign, and a name outside
+  // the canary namespace yields a canary that is discoverable but permanently untargetable.
+  const naming = assessCanarySlotNaming(slot);
+  if (!naming.ok) {
+    logFn(`[canary-provision] WARNING slot name ${JSON.stringify(slot.name)} is outside the 'Canary-' namespace `
+      + `(${naming.reason}) — the spawned session will be DISCOVERABLE but NOT targetable by assertCanaryTarget`);
   }
 
   const spawnResult = await spawnFn(

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -37,6 +37,20 @@ const SINGLETON_ROLES = new Set(['coordinator', 'adam', 'solomon']);
  */
 export const SESSION_BIND_MAX_ATTEMPTS = 20;
 export const SESSION_BIND_DELAY_MS = 500;
+
+/**
+ * Canary namespace, duplicated from canary-guard.js's CANARY_CALLSIGN_PREFIX / CANARY_PROFILE ON
+ * PURPOSE: canary-guard.js imports stop/restart/relaunchUnderProfile from THIS module, so importing
+ * it back would be a cycle. Duplication risks drift, so a test asserts these agree with the canonical
+ * constants -- the drift is caught rather than merely hoped against.
+ */
+export const CANARY_PROFILE = 'canary';
+export const CANARY_CALLSIGN_PREFIX = 'Canary-';
+
+/** True only for a callsign in the canary-only namespace. Mirrors canary-guard.js isCanaryCallsign. */
+function isCanaryNamespaceCallsign(callsign) {
+  return typeof callsign === 'string' && callsign.startsWith(CANARY_CALLSIGN_PREFIX);
+}
 const PROFILE_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 /** Derive a session's role from its metadata (mirrors coordination-events.cjs's own convention). */
@@ -342,6 +356,32 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
                 ? { window_handle_diagnostics: handleResult.diagnostics }
                 : {}),
               ...(accountProfile ? { account_profile: accountProfile } : {}),
+              // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 — MINT THE CANARY CALLSIGN.
+              //
+              // assertCanaryTarget is a TWO-CONJUNCT guard: account_profile==='canary' AND a
+              // 'Canary-' callsign. FR-3 stamped only the first, so the provisioned canary was
+              // DISCOVERABLE (resolveCanaryTarget resolved:true) but NOT TARGETABLE -- every CP3
+              // target-scoped leg still rejected it with not_canary_callsign. Half a predicate.
+              //
+              // stampRespawnedCanary CANNOT supply this. It is a CARRY-FORWARD, not a mint: its
+              // `callsign` comes from preResolveCanaryCallsign, which reads the target's CURRENT
+              // canary callsign and returns null when there is none, so its setCallsign is false for
+              // a first provisioning and it writes account_profile alone. The identity has to come
+              // from the SLOT NAME, which provisionCanary already passes here as `callsign`
+              // (canary-provision.js: callsign: slot.name -> 'Canary-pilot').
+              //
+              // DELIBERATELY CANARY-ONLY. Ordinary workers get their callsign from the coordinator's
+              // SET_IDENTITY plus the tier-band scheme; stamping one here would pre-empt that
+              // authority and collide with assign-fleet-identities. Gated on BOTH the canary profile
+              // and the canary namespace so a mis-named slot cannot mint a NATO name.
+              //
+              // MERGE, never replace: keeps color and any other fleet_identity keys. Idempotent --
+              // an existing canary callsign is left alone (same carry-forward semantics as the
+              // respawn stamper, which is the reusable part of it).
+              ...(accountProfile === CANARY_PROFILE && isCanaryNamespaceCallsign(callsign)
+                && !isCanaryNamespaceCallsign(((current.metadata || {}).fleet_identity || {}).callsign)
+                ? { fleet_identity: { ...((current.metadata || {}).fleet_identity || {}), callsign } }
+                : {}),
             },
           }).eq('session_id', current.session_id);
           break;

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -126,7 +126,8 @@ describe('module surface (TS-10: exactly six named verbs, no more)', () => {
     // session-bind constants are exported so the budget can be asserted directly instead of by
     // wall-clock; they are values, not verbs, so they belong on this allowlist.
     const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation',
-      'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS'];
+      'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS',
+      'CANARY_PROFILE', 'CANARY_CALLSIGN_PREFIX'];
     const unexpected = Object.keys(mod).filter((k) => !verbNames.includes(k) && !helperNames.includes(k));
     expect(unexpected).toEqual([]);
   });
@@ -456,6 +457,103 @@ describe('spawn (FR-1)', () => {
     const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
     expect(md.window_handle).toBe(777);
     expect(md.window_handle_diagnostics).toBeUndefined();
+  });
+
+  it('CALLSIGN MINT: stamps fleet_identity.callsign for a canary so assertCanaryTarget can pass', async () => {
+    // The SECOND conjunct. assertCanaryTarget requires account_profile==='canary' AND a 'Canary-'
+    // callsign. FR-3 stamped only the first, so the live canary came back DISCOVERABLE but
+    // not_canary_callsign — half a predicate, and every CP3 target-scoped leg still rejected it.
+    // stampRespawnedCanary cannot supply this: it is a CARRY-FORWARD whose callsign comes from the
+    // target's CURRENT canary identity, which is null on a first provisioning.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(),
+        metadata: { role: 'worker' },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: enumExec(), sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true,
+      uuidFn: () => MINTED_SESSION_ID, baseDir: 'C:/fake',
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md.account_profile).toBe('canary');
+    expect(md.fleet_identity.callsign).toBe('Canary-pilot'); // both conjuncts now satisfiable
+    expect(md.role).toBe('worker');                          // merged, not clobbered
+  });
+
+  it('CALLSIGN MINT: NEVER stamps a callsign for an ordinary worker', async () => {
+    // Load-bearing safety property. Ordinary callsigns come from the coordinator's SET_IDENTITY and
+    // the tier-band scheme; minting one here would pre-empt that authority and collide with
+    // assign-fleet-identities. An over-broad mint would look harmless in this test file and cause a
+    // fleet-wide identity fight.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), metadata: {},
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Bravo' }, {
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: enumExec(), sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true,
+      uuidFn: () => MINTED_SESSION_ID,
+    });
+    expect(supabaseClient._store.get(MINTED_SESSION_ID).metadata.fleet_identity).toBeUndefined();
+  });
+
+  it('CALLSIGN MINT: a canary PROFILE with a non-canary slot name mints NOTHING', async () => {
+    // Defence in depth against the gap the coordinator flagged: selectCanarySlot enforces the profile
+    // but NOT the namespace, so a slot marked canary yet named "Bravo" must not mint a NATO callsign
+    // into the canary namespace check. It stays discoverable-but-untargetable, and canary-provision
+    // warns — better than silently minting something the guard will reject anyway.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(), metadata: {},
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Bravo', accountProfile: 'canary' }, {
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: enumExec(), sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true,
+      uuidFn: () => MINTED_SESSION_ID, baseDir: 'C:/fake',
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md.account_profile).toBe('canary');
+    expect(md.fleet_identity).toBeUndefined();
+  });
+
+  it('CALLSIGN MINT: idempotent — an existing canary callsign is left alone', async () => {
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(),
+        metadata: { fleet_identity: { callsign: 'Canary-9', color: 'yellow' } },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, currencyRunner: CURRENT_RUNNER, spawnFn: vi.fn().mockReturnValue({ pid: 4242 }),
+      execFn: enumExec(), sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true,
+      uuidFn: () => MINTED_SESSION_ID, baseDir: 'C:/fake',
+    });
+    const fi = supabaseClient._store.get(MINTED_SESSION_ID).metadata.fleet_identity;
+    expect(fi.callsign).toBe('Canary-9'); // carry-forward wins over a re-mint
+    expect(fi.color).toBe('yellow');
+  });
+
+  it('the duplicated canary constants agree with canary-guard (cycle-forced duplication must not drift)', async () => {
+    // spawn-control cannot import canary-guard (canary-guard imports stop/restart/relaunch from here,
+    // so it would be a cycle), hence the local copies. This pins them against the canonical source so
+    // a rename in one place is caught rather than silently diverging.
+    const mod = await import('../../../lib/fleet/spawn-control.js');
+    const guard = await import('../../../lib/fleet/canary-guard.js');
+    expect(guard.isCanaryCallsign(`${mod.CANARY_CALLSIGN_PREFIX}1`)).toBe(true);
+    expect(guard.isCanaryCallsign('Bravo')).toBe(false);
+    expect(mod.CANARY_PROFILE).toBe('canary');
   });
 
   it('FR-1/FR-3: does NOT stamp account_profile when none was requested', async () => {


### PR DESCRIPTION
`assertCanaryTarget` is a **two-conjunct** guard: `account_profile==='canary'` **AND** a `Canary-` callsign. FR-3 stamped only the first.

So the provisioned canary was **discoverable** (`resolveCanaryTarget` → `resolved:true`) and **not targetable** — every CP3 target-scoped leg still rejected it with `not_canary_callsign`. Half a predicate.

I had already flagged this rather than claiming the criterion, so PLAN/LEAD weren't misled. But the coordinator's framing is the useful one: **items B and C were never two problems.** The canary is not failing to *survive* — it's at 75+ minutes, well past the 43m and 47m marks that killed both predecessors. It was failing to be *targetable*. Survival was never the blocker; we were measuring the wrong conjunct.

## Why not mirror `stampRespawnedCanary`

It's a **carry-forward, not a mint**, and structurally cannot create a first identity. Its `callsign` comes from `preResolveCanaryCallsign`, which reads the target's *current* canary callsign and returns null when there is none — so `setCallsign` is false on a first provisioning and the write reduces to `account_profile` alone. A no-op on exactly this case.

What *is* reusable is its **shape**: bounded-wait, fail-soft, idempotent, read-modify-**merge** back to the same `session_id` so `fleet_identity` is never clobbered. Shape taken, function not cloned.

## The mint is the slot name

`canary-provision.js` already spawns with `callsign: slot.name`, and `fleet_desired_slots` holds exactly one enabled row — `name="Canary-pilot"` — which satisfies the prefix. `spawn()` had that callsign in scope the whole time and simply never wrote it. One conditional, in the metadata write FR-3 already owns.

**Deliberately canary-only**, and this is the load-bearing safety property: ordinary callsigns come from the coordinator's `SET_IDENTITY` plus the tier-band scheme, so minting one here would pre-empt that authority and collide with `assign-fleet-identities`. Gated on **both** the canary profile and the canary namespace, so a slot marked canary but named `Bravo` mints nothing rather than injecting a NATO name.

## Naming gap closed

`selectCanarySlot` requires `account_profile==='canary'` and a name, but **not** the `Canary-` prefix — so a legitimately-profiled slot named `Bravo` would provision a canary that is discoverable and permanently untargetable, with nothing saying why. Today's data happens to be right, which is exactly the condition under which that rots silently.

`assessCanarySlotNaming()` now reports it and `provisionCanary` **warns** before spawning. It warns rather than fail-closing: an operator can see and fix a naming problem, and refusing to provision would be a worse failure than provisioning something at least diagnosable.

## Mutations (applied-and-confirmed)

| Mutation | Result |
|---|---|
| drop the canary gate — mint for **every** spawn | 3 failed / 53 passed ✓ |
| drop the idempotency guard (re-mint over existing) | 1 failed / 55 passed ✓ |

The first is the one that matters: an over-broad mint reds the *"never stamps an ordinary worker"* test — the property that keeps this out of a fleet-wide identity fight.

## Notes

- Canary constants are **duplicated on purpose**: `canary-guard.js` imports `stop`/`restart`/`relaunchUnderProfile` from `spawn-control`, so importing it back is a cycle. A test asserts the local copies still agree with `canary-guard`'s canonical `isCanaryCallsign`, so drift is caught rather than hoped against.
- The four new tests needed `opts.currencyRunner` — the tree-currency seam this file documents. That injects the guard's I/O dependency; it does not mock the gate.
- **1185 tests / 101 files green** with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` all unset.

## Known limitation — not fixed here, because it spawns windows

`provisionCanary` short-circuits on `already_live`, and `isProvisioned()` reads only `resolveCanaryTarget` — i.e. **discoverability**. So the canary now live (`776d1356`), discoverable but callsign-less, will **not** be re-stamped: provisioning returns `already_live` and never reaches the mint. **The fix applies to the next provisioning.**

Making `isProvisioned` require full `assertCanaryTarget` targetability would be more correct on both the pre-check and the success-check — but it would cause a spawn whenever an untargetable canary exists. That's a capacity decision I'm not taking unilaterally under the standing fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)