### PR TITLE
fix(QF-20260725-529): make isProvisioned agree with assertCanaryTarget so the canary becomes targetable

### DIFF
--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -8,8 +8,9 @@
  * resolved:false/not_found, the drill fail-closes at the guard on all three legs, emits zero
  * fleet_verb_ rows, and burns the single clean run on a PARTIAL with nothing recoverable.
  *
- * THE GATE IS SESSION-LIVENESS, NOT SLOT EXISTENCE. isProvisioned() below asserts
- * resolveCanaryTarget resolved:true; a seeded slot alone can never again read as drill-ready.
+ * THE GATE IS DRILL-TARGETABILITY, NOT SLOT EXISTENCE. isProvisioned() below delegates to
+ * assertCanaryTarget, so a seeded slot alone -- and, since QF-20260725-529, a live-but-callsign-less
+ * session -- can never read as drill-ready.
  *
  * SURVIVABILITY: canary sessions previously died of the QF-20260724-290 keepalive drop. That QF fixed
  * buildLiveSpawnInvocation and the respawn runner, but spawn() -- the verb provisioning must use --
@@ -21,7 +22,7 @@
  * module never infers it. Running the CP3 drill itself is NOT in scope (Solomon owns legs S4-S7).
  */
 import { loadDesiredSlots } from './desired-slots-store.js';
-import { resolveCanaryTarget } from './canary-guard.js';
+import { resolveCanaryTarget, assertCanaryTarget } from './canary-guard.js';
 import { spawn as spawnControlSpawn } from './spawn-control.js';
 
 const CANARY_PROFILE = 'canary';
@@ -62,13 +63,33 @@ export function assessCanarySlotNaming(slot) {
 }
 
 /**
- * THE gate predicate: is a canary actually PROVISIONED (live, resolvable session)? Pure.
+ * THE gate predicate: is a canary actually PROVISIONED -- i.e. is it TARGETABLE by the drill? Pure.
  * Deliberately reads only the resolution -- never a slot row -- so slot-existence can never be
- * mistaken for drill-readiness. Fail-closed: anything but an explicit resolved:true is false.
- * @param {{resolved?:boolean}} resolution  a resolveCanaryTarget result
+ * mistaken for drill-readiness.
+ *
+ * QF-20260725-529 -- GATE-PREDICATE SCHISM. This used to be Boolean(resolution.resolved === true):
+ * ONE conjunct, satisfied by account_profile alone. assertCanaryTarget (canary-guard.js) requires
+ * TWO -- account_profile === 'canary' AND a Canary- prefixed callsign. The provisioner's readiness
+ * test was therefore WEAKER than the guard it provisions FOR, which is fail-OPEN relative to that
+ * guard, not the fail-closed this comment used to claim. A half-provisioned canary (profile set,
+ * callsign absent) permanently satisfied the weak predicate, so provisionCanary short-circuited at
+ * `already_live` and never minted the callsign -- the provisioner refusing to act because of the
+ * very defect it exists to fix, while all three target-scoped CP3 legs stayed un-runnable.
+ *
+ * This is the follow-on SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 explicitly deferred: that commit minted
+ * the callsign at SPAWN time (the guard's second conjunct) but recorded as a KNOWN LIMITATION that
+ * isProvisioned still read discoverability only, so an already-live half-provisioned canary never
+ * reached the new mint. Both halves are needed: theirs makes a fresh spawn targetable, this one makes
+ * the provisioner willing to spawn.
+ *
+ * We now DELEGATE to the guard rather than re-derive a parallel predicate: readiness is by
+ * construction whatever the guard will actually accept, so the two can never drift apart again.
+ * Note the direction -- provisioning is tightened UP to the guard; the guard is never relaxed DOWN,
+ * which would let CP3 target any profile-stamped session.
+ * @param {{resolved?:boolean, identity?:object}} resolution  a resolveCanaryTarget result
  */
 export function isProvisioned(resolution) {
-  return Boolean(resolution && resolution.resolved === true);
+  return assertCanaryTarget(resolution).ok === true;
 }
 
 /**

--- a/tests/unit/canary-provision.test.js
+++ b/tests/unit/canary-provision.test.js
@@ -10,10 +10,14 @@
  */
 import { describe, it, expect } from 'vitest';
 import { selectCanarySlot, isProvisioned, provisionCanary } from '../../lib/fleet/canary-provision.js';
+import { assertCanaryTarget } from '../../lib/fleet/canary-guard.js';
 
 const CANARY_SLOT = { name: 'Canary-pilot', role: 'worker', account_profile: 'canary', model: 'opus' };
 const RESOLVED = { resolved: true, identity: { callsign: 'Canary-pilot', account_profile: 'canary' } };
 const NOT_FOUND = { resolved: false, reason: 'not_found' };
+// QF-20260725-529: the state the LIVE canary was actually stuck in -- session resolves, profile
+// stamped, but NO Canary- callsign, so assertCanaryTarget rejects it as 'not_canary_callsign'.
+const HALF_PROVISIONED = { resolved: true, identity: { callsign: null, account_profile: 'canary' } };
 
 describe('isProvisioned — the gate', () => {
   it('REGRESSION: a seeded slot with no live session is NOT provisioned', () => {
@@ -28,6 +32,43 @@ describe('isProvisioned — the gate', () => {
   it('fails closed on malformed/absent resolutions', () => {
     for (const bad of [null, undefined, {}, { resolved: 'true' }, { resolved: 1 }]) {
       expect(isProvisioned(bad)).toBe(false);
+    }
+  });
+
+  // ---- QF-20260725-529: the gate-predicate schism -------------------------------------------
+  // These are the pins the ORIGINAL suite lacked. Every test above passes against the OLD weak
+  // predicate Boolean(resolution.resolved === true), because RESOLVED happens to carry both
+  // conjuncts -- so the suite was green while the defect was live. A test that cannot fail on the
+  // buggy code is not evidence.
+
+  it('REGRESSION: a live session with the profile but NO Canary- callsign is NOT provisioned', () => {
+    // Fails against the pre-fix predicate, which returned true here and made provisionCanary
+    // short-circuit at already_live without ever minting the callsign.
+    expect(isProvisioned(HALF_PROVISIONED)).toBe(false);
+  });
+
+  it('REGRESSION: a live session with a Canary- callsign but a non-canary profile is NOT provisioned', () => {
+    const wrongProfile = { resolved: true, identity: { callsign: 'Canary-pilot', account_profile: 'primary' } };
+    expect(isProvisioned(wrongProfile)).toBe(false);
+  });
+
+  it('CONTRACT: readiness agrees with assertCanaryTarget on every case — they can never drift apart', () => {
+    // The anti-drift pin. isProvisioned must BE the guard, not a parallel re-derivation of it;
+    // any future weakening of one side without the other fails here.
+    const cases = [
+      RESOLVED,
+      HALF_PROVISIONED,
+      NOT_FOUND,
+      { resolved: true, identity: { callsign: 'Canary-pilot', account_profile: 'primary' } },
+      { resolved: true, identity: { callsign: 'Alpha-3', account_profile: 'canary' } },
+      { resolved: true, identity: {} },
+      { resolved: true },
+      {},
+      null,
+      undefined,
+    ];
+    for (const c of cases) {
+      expect(isProvisioned(c)).toBe(assertCanaryTarget(c).ok);
     }
   });
 });
@@ -62,6 +103,37 @@ describe('provisionCanary', () => {
     });
     expect(res).toMatchObject({ ok: true, reason: 'already_live', alreadyLive: true });
     expect(spawned).toBe(0);
+  });
+
+  it('REGRESSION (QF-20260725-529): a callsign-less canary is NOT already_live — it gets provisioned', async () => {
+    // THE defect, end-to-end: the live canary had the profile but no callsign, so the weak
+    // readiness predicate reported already_live and the provisioner declined to act -- refusing to
+    // fix the very state it exists to fix, leaving all three target-scoped CP3 legs un-runnable.
+    // Post-fix the first probe rejects, so the spawn runs and the poll waits for a FULL identity.
+    let spawned = 0;
+    let probes = 0;
+    const res = await provisionCanary({
+      ...base, live: true,
+      // half-provisioned until the spawn lands, then fully targetable
+      resolveFn: async () => (++probes === 1 ? HALF_PROVISIONED : RESOLVED),
+      spawnFn: async () => { spawned++; return { live: true }; },
+    });
+    expect(spawned).toBe(1);
+    expect(res).toMatchObject({ ok: true, reason: 'provisioned' });
+    expect(res.alreadyLive).toBeUndefined();
+  });
+
+  it('REGRESSION (QF-20260725-529): the post-spawn poll does not accept a callsign-less session as registered', async () => {
+    // The same schism on the OTHER side of the spawn: the readiness poll must not declare victory
+    // on a session the guard would still reject, or provisioning reports ok while CP3 stays blocked.
+    let spawned = 0;
+    const res = await provisionCanary({
+      ...base, live: true, maxAttempts: 3,
+      resolveFn: async () => HALF_PROVISIONED, // never gains a callsign
+      spawnFn: async () => { spawned++; return { live: true }; },
+    });
+    expect(spawned).toBe(1);
+    expect(res).toMatchObject({ ok: false, reason: 'registration_timeout', attempts: 3 });
   });
 
   it('DEFAULTS TO DRY-RUN: never claims readiness and never spawns live', async () => {


### PR DESCRIPTION
## QF-20260725-529 — gate-predicate schism between provisioner and guard

`isProvisioned` (the provisioner's readiness test) was **weaker** than `assertCanaryTarget` (the guard it provisions *for*):

| | conjuncts |
|---|---|
| `isProvisioned` (canary-provision.js:46) | `resolution.resolved === true` — **one** (account_profile) |
| `assertCanaryTarget` (canary-guard.js:69) | `account_profile === 'canary'` **AND** `Canary-` callsign — **two** |

The live canary was half-provisioned (profile stamped, callsign absent), which permanently satisfied the weak predicate. So `provisionCanary` short-circuited at `already_live` and never minted the callsign — **the provisioner refusing to act because of the very defect it exists to fix**, leaving all three target-scoped CP3 legs un-runnable.

The comment claiming "fail-closed so a partial state is not mistaken for drill-readiness" was fail-**open** relative to the guard.

### Fix
`isProvisioned` now **delegates to `assertCanaryTarget`** rather than re-deriving a parallel predicate, so the two cannot drift apart again. Direction matters: provisioning is tightened **up** to the guard; the guard is **not** relaxed down (that would let CP3 target any profile-stamped session). No new caller — `scripts/fleet/provision-canary.mjs:44` already imports `provisionCanary`.

### Verified by execution, not by reading the diff

Live `assertCanaryTarget` against the real canary, before:
```
resolveCanaryTarget.resolved= true   callsign= null   profile= "canary"
assertCanaryTarget= {"ok":false,"reason":"not_canary_callsign"}
isProvisioned= true          <-- weak predicate says READY; guard says NO
```

Consumer A/B, same live DB, `provision-canary.mjs` dry-run:

| | reason | provisioner acts? |
|---|---|---|
| before (origin/main) | `already_live` — "no spawn needed" | no |
| after (this branch) | `dry_run` — "would spawn canary Canary-pilot; gate still unmet" | yes |

### The tests actually bite
Every pre-existing test passes against the **buggy** predicate (the `RESOLVED` fixture happens to carry both conjuncts), so the suite was green while the defect was live. Reverting `isProvisioned` to the old one-conjunct form fails **5** of the new tests, including the two end-to-end ones. Pins added:
- half-provisioned (profile, no callsign) is NOT provisioned
- `Canary-` callsign with a non-canary profile is NOT provisioned
- **anti-drift contract**: `isProvisioned(x) === assertCanaryTarget(x).ok` across a 10-case matrix
- behavioural: a callsign-less canary is not `already_live` — it gets provisioned
- behavioural: the post-spawn poll won't accept a callsign-less session as registered

Full fleet suite: **85 files / 1020 tests pass**.

### ⚠️ Operational precondition for the live run (not fixed here — flagging, not silently expanding scope)
`resolveSessionIdentity` is collision-visible: >1 match returns `{resolved:false, reason:'ambiguous'}` (session-registry.js:49). The stale half-provisioned canary still carries `account_profile=canary`, so a `--live` provision run **while it is alive** would spawn a second canary-profile session and resolution would go **ambiguous** — still not targetable, and `provisionCanary` would run to `registration_timeout`.

So the unfence sequence is: **release/stop the stale callsign-less canary first**, then `provision-canary.mjs --live` (requires both `--live` and `FLEET_SPAWN_CONTROL_LIVE=true` — a SECURITY-review double gate I deliberately did not bypass; the live mint is an operator/coordinator fleet-lifecycle action, not a worker's to take unilaterally).

Only after that does the QF's acceptance command print `{"ok":true}`.
