### PR TITLE
fix(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): align the provisioning gate with its consumer — close the predicate schism

### DIFF
--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -8,8 +8,9 @@
  * resolved:false/not_found, the drill fail-closes at the guard on all three legs, emits zero
  * fleet_verb_ rows, and burns the single clean run on a PARTIAL with nothing recoverable.
  *
- * THE GATE IS SESSION-LIVENESS, NOT SLOT EXISTENCE. isProvisioned() below asserts
- * resolveCanaryTarget resolved:true; a seeded slot alone can never again read as drill-ready.
+ * THE GATE IS TARGETABILITY, NOT SLOT EXISTENCE AND NOT MERE LIVENESS. isProvisioned() below defers
+ * to assertCanaryTarget -- BOTH account_profile==='canary' AND a 'Canary-' callsign -- so neither a
+ * seeded slot nor a half-provisioned session can read as drill-ready.
  *
  * SURVIVABILITY: canary sessions previously died of the QF-20260724-290 keepalive drop. That QF fixed
  * buildLiveSpawnInvocation and the respawn runner, but spawn() -- the verb provisioning must use --
@@ -21,7 +22,7 @@
  * module never infers it. Running the CP3 drill itself is NOT in scope (Solomon owns legs S4-S7).
  */
 import { loadDesiredSlots } from './desired-slots-store.js';
-import { resolveCanaryTarget } from './canary-guard.js';
+import { resolveCanaryTarget, assertCanaryTarget } from './canary-guard.js';
 import { spawn as spawnControlSpawn } from './spawn-control.js';
 
 const CANARY_PROFILE = 'canary';
@@ -62,13 +63,35 @@ export function assessCanarySlotNaming(slot) {
 }
 
 /**
- * THE gate predicate: is a canary actually PROVISIONED (live, resolvable session)? Pure.
+ * THE gate predicate: is a canary actually PROVISIONED, i.e. TARGETABLE by the drill? Pure.
  * Deliberately reads only the resolution -- never a slot row -- so slot-existence can never be
- * mistaken for drill-readiness. Fail-closed: anything but an explicit resolved:true is false.
+ * mistaken for drill-readiness. Fail-closed: it defers to assertCanaryTarget, so anything short of
+ * both conjuncts is false.
  * @param {{resolved?:boolean}} resolution  a resolveCanaryTarget result
  */
 export function isProvisioned(resolution) {
-  return Boolean(resolution && resolution.resolved === true);
+  // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 — GATE-PREDICATE SCHISM, fixed by aligning the gate with its
+  // CONSUMER rather than by patching the data.
+  //
+  // This used to be `resolution.resolved === true`, i.e. resolveCanaryTarget alone, which matches on
+  // account_profile ONLY (canary-guard.js). But the consumer of a "provisioned" canary is
+  // assertCanaryTarget, which requires account_profile==='canary' AND a 'Canary-' callsign. ONE
+  // CONJUNCT VERSUS TWO, and the gate was the weaker one.
+  //
+  // WHY THAT WAS SELF-SEALING. A half-provisioned canary (profile stamped, no callsign) SATISFIED the
+  // gate, so provisionCanary short-circuited on already_live and never minted the callsign — while the
+  // drill's guard rejected that same session. The provisioner could not repair the state because its
+  // own gate reported the state was fine, and re-running or re-wiring could never escape it. A gate
+  // that means LESS than its consumer will always let a broken state look finished.
+  //
+  // SEQUENCING NOTE, load-bearing: this change is only safe BECAUSE the callsign mint landed first.
+  // With a gate demanding both conjuncts and a spawn that stamps only one, every run would spawn a
+  // fresh canary that still failed the gate — an unbounded spawn loop. The mint is what makes a
+  // re-provision converge. Do not port this predicate to a tree without it.
+  //
+  // Residual risk is bounded by spawn()'s own dedup-by-callsign: once a canary carries 'Canary-pilot',
+  // a second provisioning finds that callsign live and skips rather than spawning again.
+  return assertCanaryTarget(resolution).ok === true;
 }
 
 /**

--- a/scripts/fleet/provision-canary.mjs
+++ b/scripts/fleet/provision-canary.mjs
@@ -2,10 +2,16 @@
 /**
  * provision-canary.mjs — SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 (FR-1).
  *
- * THE GAP THIS CLOSES. provisionCanary (lib/fleet/canary-provision.js:69) is imported by NOTHING
- * outside its own unit test — repo-wide grep confirms it; the only other match,
- * scripts/canary/run-canary-probe.mjs:67, is an unrelated same-named LOCAL function. So the
- * provisioning step exists, is tested, and has never once run. This file is the missing caller.
+ * WHAT THIS FILE IS. The CLI entrypoint for provisionCanary (lib/fleet/canary-provision.js). It
+ * imports it below and calls it — this file IS the caller, and provisionCanary RUNS.
+ *
+ * The header used to open with "provisionCanary is imported by NOTHING outside its own unit test …
+ * has never once run", written in the PRESENT TENSE. That was the problem statement this file was
+ * created to close, not a description of current state, and once the file existed it was simply
+ * false. It cost a reader a full retraction cycle: they verified by direct inspection that the
+ * function was wired, then let this header talk them back out of their own correct finding. A
+ * problem statement left in the present tense outlives the problem and actively misinforms — record
+ * the gap in the commit that closed it, not in a banner on the fix.
  *
  * HISTORY, KEPT SHORT AND CURRENT. This header used to say the CLI could not close discoverability:
  * that spawn() had no stamp step, that the only account_profile writer was stampRespawnedCanary on the

--- a/tests/unit/canary-provision.test.js
+++ b/tests/unit/canary-provision.test.js
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { selectCanarySlot, isProvisioned, provisionCanary } from '../../lib/fleet/canary-provision.js';
+import { assertCanaryTarget } from '../../lib/fleet/canary-guard.js';
 
 const CANARY_SLOT = { name: 'Canary-pilot', role: 'worker', account_profile: 'canary', model: 'opus' };
 const RESOLVED = { resolved: true, identity: { callsign: 'Canary-pilot', account_profile: 'canary' } };
@@ -21,8 +22,48 @@ describe('isProvisioned — the gate', () => {
     expect(isProvisioned(NOT_FOUND)).toBe(false);
   });
 
-  it('is true only on an explicit resolved:true', () => {
+  it('is true when BOTH conjuncts hold (profile AND canary callsign)', () => {
     expect(isProvisioned(RESOLVED)).toBe(true);
+  });
+
+  it('GATE-PREDICATE SCHISM: a HALF-provisioned canary is NOT provisioned', () => {
+    // THE discriminating case, and the one this fixture set was missing — which is why the schism
+    // survived. RESOLVED already carried BOTH conjuncts, so the gate could be tightened from one to
+    // two without a single test reding. `isProvisioned` had zero other references in the suite.
+    //
+    // The real state that blocked CP3 for hours: account_profile stamped, NO callsign. It satisfied
+    // the old gate (resolveCanaryTarget matches on account_profile alone), so provisionCanary
+    // short-circuited on already_live and never minted the callsign — while assertCanaryTarget, the
+    // actual consumer, rejected that same session with not_canary_callsign. The provisioner could not
+    // repair the state because its own gate said the state was fine. Self-sealing.
+    const halfProvisioned = {
+      resolved: true,
+      identity: { account_profile: 'canary', callsign: null },
+    };
+    expect(isProvisioned(halfProvisioned)).toBe(false);
+  });
+
+  it('GATE-PREDICATE SCHISM: the gate agrees with its CONSUMER on every shape', () => {
+    // The durable property, stronger than any single case: whatever assertCanaryTarget accepts is
+    // exactly what counts as provisioned. A gate that means LESS than its consumer lets a broken
+    // state look finished; pinning the equivalence stops the two drifting apart again.
+    const shapes = [
+      RESOLVED,
+      NOT_FOUND,
+      { resolved: true, identity: { account_profile: 'canary', callsign: null } },
+      { resolved: true, identity: { account_profile: 'canary', callsign: 'Bravo' } },
+      { resolved: true, identity: { account_profile: null, callsign: 'Canary-pilot' } },
+      { resolved: true, identity: {} },
+    ];
+    for (const s of shapes) {
+      expect(isProvisioned(s), JSON.stringify(s)).toBe(assertCanaryTarget(s).ok);
+    }
+  });
+
+  it('a non-canary callsign does not satisfy the gate even with the profile stamped', () => {
+    // Guards the selectCanarySlot naming gap: a slot marked canary but named "Bravo" provisions a
+    // session that must NOT read as drill-ready.
+    expect(isProvisioned({ resolved: true, identity: { account_profile: 'canary', callsign: 'Bravo' } })).toBe(false);
   });
 
   it('fails closed on malformed/absent resolutions', () => {


### PR DESCRIPTION
The coordinator asked for a judgement between **(A)** align the gate and **(B)** stamp the existing session. This is **(A)** — with the sequencing fact that makes it safe now and would have made it dangerous an hour ago.

## The defect

`isProvisioned()` read `resolveCanaryTarget().resolved`, which matches on `account_profile` **alone**. Its consumer, `assertCanaryTarget`, requires `account_profile==='canary'` **AND** a `Canary-` callsign. One conjunct versus two — and the **gate** was the weaker one.

**Why it was self-sealing**, which is what makes it worth fixing as a class rather than patching a row: a half-provisioned canary (profile stamped, no callsign) *satisfied the gate*, so `provisionCanary` short-circuited on `already_live` and never minted the callsign — while the drill's guard rejected that same session. The provisioner could not repair the state because its own gate reported the state was fine. No amount of re-running or re-wiring escapes that.

> A gate that means **less** than its consumer will always let a broken state look finished.

## Why (A) over (B)

(B) fixes today's row and leaves the asymmetry for the next half-provisioned canary. (A) makes the class impossible.

The stated risk of (A) — re-spawning — is bounded twice over: the re-spawn only fires when the state is genuinely unusable, which is exactly when you want it; and `spawn()`'s own dedup-by-callsign means once a canary carries `Canary-pilot`, a second provisioning finds it live and skips.

## Sequencing — the part I'd least want lost

**(A) is only safe because the callsign mint landed first (#6486).** With a gate demanding both conjuncts and a spawn that stamps only one, every run would spawn a fresh canary that still failed the gate — an **unbounded spawn loop**, worse than the defect. Taken an hour ago this would have been a foot-gun. The predicate carries that note inline.

## The gate had zero test references — which is why the schism survived

Tightening it from one conjunct to two turned **nothing** red: the existing `RESOLVED` fixture already carried both, and no other test touched `isProvisioned`.

Added the discriminating case (profile stamped, callsign `null` → **not** provisioned) plus an **equivalence property** asserting the gate agrees with `assertCanaryTarget` across six shapes, so the two cannot drift apart again.

| Mutation | Result |
|---|---|
| revert to the one-conjunct gate | 3 failed / 10 passed ✓ |

## A comment of mine that cost a reader a retraction cycle

`provision-canary.mjs` opened with *"provisionCanary is imported by NOTHING outside its own unit test … has never once run"* — in the **present tense**, inside the very file that imports and calls it. That was the problem statement the file was created to close; once the file existed it was simply false.

The coordinator verified by direct inspection that the function was wired, then let this header talk them back out of their own correct finding.

I had already corrected a *different* stale block in this same file and left this one — **the third time in this SD I fixed an instance instead of the family**. A problem statement in the present tense outlives the problem: record the gap in the commit that closes it, not in a banner on the fix. Two stale doc comments describing `isProvisioned` as *"asserts resolved:true"* were corrected in the same pass rather than left for a fourth round.

## Verification

**1203 tests / 103 files green** with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` all unset.

## One pre-existing failure — not mine, not fixed here, reported because it's a fleet-wide trap

`tests/unit/hooks/session-register-created-emission.test.js` (QF-20260725-480) asserts:

```js
src.indexOf(".from('claude_sessions')\n    .upsert(")
```

against the **working-tree** file. `core.autocrlf=true` on this host, so the repo blob is LF and the checkout is **CRLF** — the `\n`-joined needle can never match, and `indexOf` returns `-1`.

It **passes in CI (ubuntu, LF) and fails for every Windows worker.** Diagnosed to the byte, not guessed. One-line fix is to normalise before matching: `src.replace(/\r\n/g, '\n')`. Left to its owning QF rather than edited from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)