### PR TITLE
fix(SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001): stop a live parked worker losing its claim and its SD being re-advertised

### DIFF
--- a/docs/protocol/claim-ownership-vs-liveness.md
+++ b/docs/protocol/claim-ownership-vs-liveness.md
@@ -1,0 +1,59 @@
+# Claim ownership vs. liveness — the two-surface precedence rule
+
+*Ratified by SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 (FR-5).*
+
+Two columns describe a worker's relationship to an SD, and code across the fleet
+disagreed about which one "wins". The disagreement was real and it caused harm: it is
+the ambiguity underneath this SD's root-cause chain, where a live worker's claim was
+released out from under it and its SD was then re-advertised for auto-claim.
+
+The disagreement was never resolvable as stated, because **the two columns answer two
+different questions.** Neither is a cache of the other.
+
+## The rule
+
+| Question | Authoritative surface |
+|---|---|
+| **Who OWNS this SD?** Who holds the right to it, who may release it, who must not be displaced. | `strategic_directives_v2.claiming_session_id` |
+| **Is a worker CURRENTLY BUILDING this SD?** Is someone live and active on it right now. | `claude_sessions.sd_key` (+ a fresh `heartbeat_at`) |
+
+Ask an ownership question, read SDv2. Ask a liveness/activity question, read the
+session row. Do not describe either as "the source of truth" without naming the
+question — that phrasing is what produced the contradiction.
+
+## They diverge legitimately, in BOTH directions
+
+This is normal and transient. Code must not treat divergence as corruption:
+
+- **Claim set, `sd_key` NULL** — the SD is owned but nobody is building it this instant:
+  a parked worker between turns, a session that has not yet re-attached its worktree,
+  or the window right after a sweep touched the session surface. Observed live during
+  this SD: the coordinator's roster showed this worker idle while `quick_fixes` and
+  SDv2 still recorded its claims.
+- **`sd_key` set, claim NULL** — a worker is still building an SD whose claim was
+  cleared underneath it. This is precisely the root cause chain of this SD
+  (`103260605b3`), and the reason `coordinator-email-summary.mjs` derives the real
+  builder from the session surface rather than from SDv2.
+
+## Consequences for guards
+
+A guard must read the surface matching its question, and **fail closed when that
+surface cannot be read at all**:
+
+- An **empty** result is a real answer ("nobody is building"). Act on it.
+- A **failed** query is not an answer. Do not let it collapse into "empty" and drive a
+  destructive branch. Reading a discarded error as "no rows" is the proven production
+  root cause behind this SD.
+
+Because the surfaces diverge in both directions, a guard that consults only one of them
+is incomplete by construction. The claim-lapse chain needed BOTH: SDv2 to decide
+ownership, and `claude_sessions.sd_key` to confirm nobody was mid-build.
+
+## Call sites bound by this rule
+
+- `scripts/worker-checkin.cjs` — `findOwnSdClaim` asks an OWNERSHIP question → SDv2.
+- `scripts/coordinator-email-summary.mjs` — asks who is BUILDING → session `sd_key`.
+- `scripts/hooks/coordination-inbox.cjs` — `selectAvailableSds` asks whether a live
+  worker is mid-build before advertising an SD → session `sd_key` + `heartbeat_at`.
+- `lib/claim-validity-gate.js` — peer `sd_key` drift asks whether the peer has MOVED ON
+  (a liveness question), while `claiming_session_id` decides whose claim it is.

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -477,11 +477,24 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // for OWNERSHIP; sd_key is authoritative for whether a worker is CURRENTLY BUILDING.
     // This block asks a LIVENESS question (has the peer moved on?) → sd_key is correct
     // HERE. The surrounding claim decision is an ownership question → SDv2 governs it.
-    const { data: owner } = await supabase
+    const { data: owner, error: ownerErr } = await supabase
       .from('claude_sessions')
       .select('status, is_alive, sd_key, expected_silence_until, heartbeat_at')
       .eq('session_id', sd.claiming_session_id)
       .maybeSingle();
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-1 (same class as the root cause, one function
+    // over): this error was DISCARDED. On a transient failure `owner` is null, and a null owner is
+    // read as maximally dead — ownerIsDeadByLiveness(null) returns true, ownerIsSilenced is false,
+    // and ownerSdKeyMissing is false (it requires a row) — so control reached the legacy release
+    // tail and reaped a LIVE owner's claim, with only a host-local PID marker as a brake. That is
+    // "a failed query read as a real answer" driving a destructive branch: the exact defect this SD
+    // exists to eliminate. An EMPTY result (no such session) is still a real answer and still
+    // releases; only an ERRORED lookup is untrustworthy, and it now fails CLOSED by yielding to the
+    // foreign_claim path below rather than releasing on evidence we do not have.
+    const ownerLookupFailed = Boolean(ownerErr);
+    if (ownerLookupFailed) {
+      console.warn(`[claim-validity-gate] owner lookup FAILED for ${sd.claiming_session_id} on ${sdKey} (${ownerErr.message}) — suppressing auto-release this pass (fail-closed).`);
+    }
 
     // SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-1: trust heartbeat_at over the lagging
     // is_alive column — an is_alive===false owner is dead ONLY when its heartbeat is ALSO
@@ -515,7 +528,7 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // SEAM 1: drift releases when the owner is verifiably on ANOTHER SD; a NULL sd_key or a
     // dead-looking owner releases ONLY if not silence-armed and not PID-alive (a within-cap
     // silenced or process-alive holder yields to foreign_claim instead of being reaped).
-    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive, ownerSdKeyMissing })) {
+    if (!ownerLookupFailed && shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive, ownerSdKeyMissing })) {
       // Idempotent canonical claim-release — routes through the unified dual-surface
       // helper so the dead owner's session-side surface (claude_sessions.sd_key +
       // worktree_*) is co-cleared, not just the SD-side (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -274,8 +274,20 @@ export function ownerIsDeadByLiveness(owner, nowMs, ttlMs = CLAIM_TTL_MS) {
  * @param {{ownerHasSdKeyDrifted?:boolean, ownerIsDead?:boolean, ownerIsSilenced?:boolean, ownerPidAlive?:boolean}} args
  * @returns {boolean} true ⇒ release/reclaim the foreign claim; false ⇒ yield (owner keeps it).
  */
-export function shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive } = {}) {
-  if (ownerHasSdKeyDrifted) return true;                       // sd_key moved away — a real release signal
+export function shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive, ownerSdKeyMissing } = {}) {
+  // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3: drift used to release UNCONDITIONALLY, which
+  // made this a liveness-free claim steal — any path that nulled the session-side sd_key evicted a
+  // LIVE, heartbeating, PID-alive, silence-armed owner. detectSdKeyDrift returns 'drift' for TWO
+  // materially different situations and they must not share a verdict:
+  //   (a) owner.sd_key points at a DIFFERENT SD — the owner demonstrably moved on. Releasing is
+  //       correct even while it is alive; this is the genuine release signal the rule was written
+  //       for, and it stays unconditional.
+  //   (b) owner.sd_key is NULL — AMBIGUOUS. It means "left" OR "something just cleared it", and a
+  //       transient clear is exactly the observed defect. Require a NEGATIVE liveness signal here.
+  if (ownerHasSdKeyDrifted) {
+    if (!ownerSdKeyMissing) return true;                       // (a) owner is on another SD — real release signal
+    return !ownerIsSilenced && !ownerPidAlive;                 // (b) null sd_key — only release if not demonstrably alive
+  }
   return Boolean(ownerIsDead) && !ownerIsSilenced && !ownerPidAlive;
 }
 
@@ -487,10 +499,15 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // as ownerIsDead. detectSdKeyDrift returns 'drift'|'aligned'|'unknown'.
     const sdKeyDriftVerdict = detectSdKeyDrift(owner, sdKey);
     const ownerHasSdKeyDrifted = sdKeyDriftVerdict === 'drift';
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3: detectSdKeyDrift reports 'drift' both when
+    // the owner moved to ANOTHER sd_key and when its sd_key is simply NULL. Only the first is a
+    // genuine "owner left" signal; a NULL is ambiguous and is the observed lapse. Distinguish them.
+    const ownerSdKeyMissing = Boolean(owner) && !owner.sd_key;
 
-    // SEAM 1: drift always releases; a dead-looking owner releases ONLY if not within an armed
-    // silence window (a within-cap silenced holder yields to foreign_claim instead of being reaped).
-    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive })) {
+    // SEAM 1: drift releases when the owner is verifiably on ANOTHER SD; a NULL sd_key or a
+    // dead-looking owner releases ONLY if not silence-armed and not PID-alive (a within-cap
+    // silenced or process-alive holder yields to foreign_claim instead of being reaped).
+    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive, ownerSdKeyMissing })) {
       // Idempotent canonical claim-release — routes through the unified dual-surface
       // helper so the dead owner's session-side surface (claude_sessions.sd_key +
       // worktree_*) is co-cleared, not just the SD-side (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -468,7 +468,15 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
   if (sd.claiming_session_id !== mySessionId) {
     // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-2: also fetch owner.sd_key to detect
     // sd_key tag drift (peer's sd_key has moved away from this SD — peer is no longer
-    // working it). sd_key is the source-of-truth, NOT claiming_session_id.
+    // working it).
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-5: this comment previously read
+    // "sd_key is the source-of-truth, NOT claiming_session_id", which contradicted
+    // worker-checkin.cjs findOwnSdClaim ("sd_key is only ever a cache of this"). Both were
+    // right about their OWN question and wrong as a universal rule. The ratified split
+    // (docs/protocol/claim-ownership-vs-liveness.md): claiming_session_id is authoritative
+    // for OWNERSHIP; sd_key is authoritative for whether a worker is CURRENTLY BUILDING.
+    // This block asks a LIVENESS question (has the peer moved on?) → sd_key is correct
+    // HERE. The surrounding claim decision is an ownership question → SDv2 governs it.
     const { data: owner } = await supabase
       .from('claude_sessions')
       .select('status, is_alive, sd_key, expected_silence_until, heartbeat_at')

--- a/scripts/coordinator-email-summary.mjs
+++ b/scripts/coordinator-email-summary.mjs
@@ -62,7 +62,12 @@ const workableKeys = (workRows || []).filter(s => isClaimableSd(s, depStatus)).m
 const workable = workableKeys.length;
 
 // ── live workers + the SDs they ACTUALLY hold. claude_sessions.sd_key is the reliable build signal;
-//    SDv2.claiming_session_id drifts to NULL after a claim-sweep even while the worker keeps building. ──
+//    SDv2.claiming_session_id drifts to NULL after a claim-sweep even while the worker keeps building.
+//    This is a LIVENESS question, so the session surface governs it — ratified precedence rule in
+//    docs/protocol/claim-ownership-vs-liveness.md (SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-5).
+//    Do NOT generalize this into "sd_key always wins": ownership questions (who may release the SD)
+//    still read SDv2. The workaround noted here was correct but had never been propagated to the
+//    dispatch path, which is why coordination-inbox.cjs could advertise a busy SD (FR-4). ──
 const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,claimed_at,worktree_path,continuous_sds_completed,metadata').order('heartbeat_at', { ascending: false }).limit(60);
 // QF-20260607-608: identify a GENUINE worker the same way fleet-dashboard.cjs does, so the email
 // and the dashboard never disagree (the email was showing "9 workers" vs the dashboard's ~6 because

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -83,6 +83,13 @@ function getIdentityFile(resolvedSessionId) {
 // sessions = 24/min, well below capacity.
 const CHECK_INTERVAL_MS = parseInt(process.env.COORDINATION_CHECK_INTERVAL_MS, 10) || 15_000;
 const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
+// SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-4: how fresh a session heartbeat must be for that
+// session to count as a live builder holding its sd_key. 15min matches the claim TTL the fleet
+// already uses (chairman_dashboard_config), so a parked /loop worker on a 900-1800s wake cadence
+// is still recognised as building between ticks rather than having its SD advertised out from
+// under it. Deliberately generous: a false "held" only delays a dispatch, a false "free" causes
+// the second-dispatch collision this SD exists to prevent.
+const SESSION_LIVENESS_WINDOW_MS = 15 * 60 * 1000;
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 // SD-FDBK-FIX-WORKER-CHECK-SURFACES-001 (adversarial-review finding #1): only WORK_ASSIGNMENT
 // has a worker-side CLOSURE path for a busy worker (claim_sd/ackMessage stamps read_at when the
@@ -768,14 +775,57 @@ async function main() {
         .order('priority_score', { ascending: false })
         .limit(3);
 
-      if (availableSDs && availableSDs.length > 0) {
+      // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-4: claiming_session_id alone is NOT
+      // evidence an SD is free. A live worker parked on ScheduleWakeup can have its claim
+      // transiently cleared while it is still building, and this query would then advertise
+      // its SD for auto-claim — the second-dispatch risk this SD exists to close. Cross-check
+      // against the session side, the pattern coordinator-email-summary.mjs:64-66 already uses
+      // ("claiming_session_id drifts to NULL after a claim-sweep even while the worker keeps
+      // building"). That workaround existed in the email path and was never propagated here.
+      const { data: liveSessions } = await supabase
+        .from('claude_sessions')
+        .select('sd_key, heartbeat_at')
+        .not('sd_key', 'is', null);
+
+      const claimable = selectAvailableSds(availableSDs, liveSessions);
+      if (claimable.length > 0) {
         emitAutoClaimDirective(
-          availableSDs[0].sd_key,
-          availableSDs.map(sd => sd.sd_key)
+          claimable[0].sd_key,
+          claimable.map(sd => sd.sd_key)
         );
       }
     } catch { /* fail silently */ }
   }
+}
+
+/**
+ * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-7/FR-4 — the dispatch-availability predicate,
+ * extracted from main() so it can be asserted directly. It previously lived inline, which meant
+ * any test of it could only have mocked the query it was supposed to be testing.
+ *
+ * PURE. Returns the SDs that are genuinely claimable: those whose sd_key is NOT held by a live
+ * session. Fails CLOSED on an unusable session list — if we cannot prove nobody is building an
+ * SD, we do not advertise it. (Emptiness is not proof of absence: an unchecked query error
+ * returning null was the root cause of the claim lapse this SD came from.)
+ *
+ * @param {Array<{sd_key:string}>|null} sdRows        candidate SDs (claiming_session_id IS NULL)
+ * @param {Array<{sd_key:string, heartbeat_at:string}>|null} liveSessions  sessions holding an sd_key
+ * @param {{nowMs?:number, livenessWindowMs?:number}} [opts]
+ * @returns {Array<{sd_key:string}>}
+ */
+function selectAvailableSds(sdRows, liveSessions, opts = {}) {
+  const rows = Array.isArray(sdRows) ? sdRows : [];
+  if (rows.length === 0) return [];
+  // Fail closed: a null/undefined session list means the cross-check could not run.
+  if (!Array.isArray(liveSessions)) return [];
+  const nowMs = opts.nowMs ?? Date.now();
+  const windowMs = opts.livenessWindowMs ?? SESSION_LIVENESS_WINDOW_MS;
+  const heldByLive = new Set(
+    liveSessions
+      .filter((s) => s && s.sd_key && s.heartbeat_at && (nowMs - Date.parse(s.heartbeat_at)) <= windowMs)
+      .map((s) => s.sd_key)
+  );
+  return rows.filter((sd) => sd && sd.sd_key && !heldByLive.has(sd.sd_key));
 }
 
 if (require.main === module) {
@@ -783,6 +833,10 @@ if (require.main === module) {
 }
 
 module.exports = {
+  // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-7: exported so the dispatch-availability
+  // predicate can be asserted directly instead of through a mock of its own query.
+  selectAvailableSds,
+  SESSION_LIVENESS_WINDOW_MS,
   getCurrentSessionId,
   readSessionIdFromStdin,
   // QF-20260504-912 — exposed for per-session throttle/heartbeat tests

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -89,11 +89,21 @@ const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
 // is still recognised as building between ticks rather than having its SD advertised out from
 // under it. Deliberately generous: a false "held" only delays a dispatch, a false "free" causes
 // the second-dispatch collision this SD exists to prevent.
+// Retained for back-compat with callers/tests that import it. Liveness itself is NOT decided here
+// — selectAvailableSds delegates to the lib/fleet/session-liveness.cjs SSOT, which owns the
+// heartbeat threshold (LIVENESS_HEARTBEAT_SEC), the tick window and the armed-silence cap. Do not
+// re-derive any of those locally; that fork is what DEFECT-7 of this SD was.
 const SESSION_LIVENESS_WINDOW_MS = 15 * 60 * 1000;
-// Hard cap on an armed expected_silence_until window (mirrors the sweep's cap). A parked worker
-// is LIVE while its window is armed and within cap; beyond that the window is not trusted, so a
-// crashed worker that stamped a far-future timestamp cannot hold its SD indefinitely.
-const ARMED_SILENCE_CAP_MS = 30 * 60 * 1000;
+// The READ-TIME liveness SSOT. Guarded require so an unavailable lib degrades to a conservative
+// hold (see selectAvailableSds) rather than crashing the hook.
+let isSessionAlive;
+try {
+  ({ isSessionAlive } = require(path.resolve(__dirname, '../../lib/fleet/session-liveness.cjs')));
+} catch {
+  // Fail CLOSED: with no liveness oracle we cannot prove any worker is gone, so treat every
+  // session that names an SD as holding it. Suppresses dispatch rather than risking a collision.
+  isSessionAlive = () => ({ alive: true, reason: 'liveness_ssot_unavailable' });
+}
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 // SD-FDBK-FIX-WORKER-CHECK-SURFACES-001 (adversarial-review finding #1): only WORK_ASSIGNMENT
 // has a worker-side CLOSURE path for a busy worker (claim_sd/ackMessage stamps read_at when the
@@ -786,12 +796,14 @@ async function main() {
       // against the session side, the pattern coordinator-email-summary.mjs:64-66 already uses
       // ("claiming_session_id drifts to NULL after a claim-sweep even while the worker keeps
       // building"). That workaround existed in the email path and was never propagated here.
-      // expected_silence_until is selected because a PARKED worker stops heartbeating on purpose —
-      // see selectAvailableSds. Omitting it made this guard blind to the very worker state the SD
-      // is named for.
+      // Every column the session-liveness SSOT reads must be selected, or the cross-check silently
+      // degrades to whichever signals happen to be present — a PARKED worker stops heartbeating on
+      // purpose, and a busy one mid sub-agent call emits no heartbeat either, so heartbeat_at alone
+      // is not evidence that nobody is building. is_alive / terminal_id / process_alive_at carry the
+      // raw, PID and tick signals respectively.
       const { data: liveSessions, error: liveSessionsErr } = await supabase
         .from('claude_sessions')
-        .select('sd_key, heartbeat_at, expected_silence_until')
+        .select('sd_key, heartbeat_at, expected_silence_until, is_alive, terminal_id, process_alive_at')
         .not('sd_key', 'is', null);
       if (liveSessionsErr) {
         // The consequence is already safe (data is null on error → selectAvailableSds fails closed
@@ -833,28 +845,38 @@ function selectAvailableSds(sdRows, liveSessions, opts = {}) {
   // Fail closed: a null/undefined session list means the cross-check could not run.
   if (!Array.isArray(liveSessions)) return [];
   const nowMs = opts.nowMs ?? Date.now();
-  const windowMs = opts.livenessWindowMs ?? SESSION_LIVENESS_WINDOW_MS;
-  const silenceCapMs = opts.silenceCapMs ?? ARMED_SILENCE_CAP_MS;
 
-  // A worker is HOLDING its SD when either liveness signal is present:
-  //   (a) a fresh heartbeat, or
-  //   (b) an armed, within-cap expected_silence_until.
-  // (b) is not optional decoration — it is the whole persona this SD is named for. A parked
-  // /loop worker deliberately stops heartbeating and arms expected_silence_until to say
-  // "alive but silent"; the sweep and claim-validity-gate both honour it. Keying on heartbeat
-  // ALONE re-created the same blind spot one layer up: this worker's own loop arms wakeups of
-  // up to 1800s, which EXCEEDS the 900s heartbeat window, so a parked worker went invisible to
-  // this guard for the back half of every long nap and its SD was advertised for auto-claim.
-  // The cap is what keeps (b) from becoming an unbounded claim leak — a crashed worker's stale
-  // future timestamp cannot hold an SD forever.
+  // Liveness is delegated to the READ-TIME SSOT (lib/fleet/session-liveness.cjs), which declares
+  // itself "used by EVERY consumer" and covers FIVE signals: raw is_alive, fresh heartbeat, live
+  // PID marker, fresh process_alive_at tick, and an armed expected_silence_until window.
+  //
+  // This predicate first shipped with a hand-rolled two-signal check (heartbeat + silence). That
+  // left a worker which is PID-alive and tick-fresh but heartbeat-stale INVISIBLE here, so its SD
+  // was still advertised for auto-claim — the COLLISION direction, which is the harmful one. The
+  // omission is notable because FR-2 of this same SD went out of its way to compute an alive-PID
+  // set locally for the sweep, on the explicit reasoning that dropping the PID signal "would
+  // silently degrade shouldHoldClaim to heartbeat-only and lose exactly the PID-aliveness signal
+  // that distinguishes a parked-but-live worker from a dead one". That reasoning was correct and
+  // simply had not been carried one file over. Re-deriving liveness locally also forked a second
+  // heartbeat threshold and a fourth cap-constant name away from the SSOT.
+  //
+  // The SSOT's ONE-DIRECTIONAL contract is what makes it safe here: it can only ever read MORE
+  // alive than the raw flag, never less. For a dispatch-advertisement guard that is the correct
+  // asymmetry — a false HOLD costs a little dispatch delay, while a false FREE costs a collision
+  // with a live builder, which is the failure this SD exists to prevent.
+  //
+  // A dead session does not hold its SD forever: the sweep independently writes is_alive=false
+  // for genuinely dead sessions, which retires every raw/PID/tick signal here.
+  const aliveCcPids = opts.aliveCcPids ?? null;
   const isHolding = (s) => {
     if (!s || !s.sd_key) return false;
-    const hb = s.heartbeat_at ? Date.parse(s.heartbeat_at) : NaN;
-    if (Number.isFinite(hb) && (nowMs - hb) <= windowMs) return true;
-    const until = s.expected_silence_until ? Date.parse(s.expected_silence_until) : NaN;
-    if (!Number.isFinite(until)) return false;
-    // Armed (not yet expired) AND within cap — a runaway window is not a liveness signal.
-    return until > nowMs && (until - nowMs) <= silenceCapMs;
+    try {
+      return isSessionAlive(s, { nowMs, aliveCcPids }).alive === true;
+    } catch {
+      // Fail CLOSED for this row: if liveness cannot be determined we must not conclude the
+      // worker is gone. Treating an unanswerable check as "free" is the root-cause pattern.
+      return true;
+    }
   };
 
   const heldByLive = new Set(liveSessions.filter(isHolding).map((s) => s.sd_key));

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -90,6 +90,10 @@ const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
 // under it. Deliberately generous: a false "held" only delays a dispatch, a false "free" causes
 // the second-dispatch collision this SD exists to prevent.
 const SESSION_LIVENESS_WINDOW_MS = 15 * 60 * 1000;
+// Hard cap on an armed expected_silence_until window (mirrors the sweep's cap). A parked worker
+// is LIVE while its window is armed and within cap; beyond that the window is not trusted, so a
+// crashed worker that stamped a far-future timestamp cannot hold its SD indefinitely.
+const ARMED_SILENCE_CAP_MS = 30 * 60 * 1000;
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 // SD-FDBK-FIX-WORKER-CHECK-SURFACES-001 (adversarial-review finding #1): only WORK_ASSIGNMENT
 // has a worker-side CLOSURE path for a busy worker (claim_sd/ackMessage stamps read_at when the
@@ -782,10 +786,20 @@ async function main() {
       // against the session side, the pattern coordinator-email-summary.mjs:64-66 already uses
       // ("claiming_session_id drifts to NULL after a claim-sweep even while the worker keeps
       // building"). That workaround existed in the email path and was never propagated here.
-      const { data: liveSessions } = await supabase
+      // expected_silence_until is selected because a PARKED worker stops heartbeating on purpose —
+      // see selectAvailableSds. Omitting it made this guard blind to the very worker state the SD
+      // is named for.
+      const { data: liveSessions, error: liveSessionsErr } = await supabase
         .from('claude_sessions')
-        .select('sd_key, heartbeat_at')
+        .select('sd_key, heartbeat_at, expected_silence_until')
         .not('sd_key', 'is', null);
+      if (liveSessionsErr) {
+        // The consequence is already safe (data is null on error → selectAvailableSds fails closed
+        // → nothing advertised), but the surrounding block swallows exceptions, so a persistent
+        // claude_sessions failure would suppress dispatch INDEFINITELY and look identical to
+        // "nothing available". Given this fleet's belt-starvation history, make it observable.
+        console.error(`[coordination-inbox] live-session cross-check FAILED (${liveSessionsErr.message}) — suppressing auto-claim dispatch this tick (fail-closed).`);
+      }
 
       const claimable = selectAvailableSds(availableSDs, liveSessions);
       if (claimable.length > 0) {
@@ -820,11 +834,30 @@ function selectAvailableSds(sdRows, liveSessions, opts = {}) {
   if (!Array.isArray(liveSessions)) return [];
   const nowMs = opts.nowMs ?? Date.now();
   const windowMs = opts.livenessWindowMs ?? SESSION_LIVENESS_WINDOW_MS;
-  const heldByLive = new Set(
-    liveSessions
-      .filter((s) => s && s.sd_key && s.heartbeat_at && (nowMs - Date.parse(s.heartbeat_at)) <= windowMs)
-      .map((s) => s.sd_key)
-  );
+  const silenceCapMs = opts.silenceCapMs ?? ARMED_SILENCE_CAP_MS;
+
+  // A worker is HOLDING its SD when either liveness signal is present:
+  //   (a) a fresh heartbeat, or
+  //   (b) an armed, within-cap expected_silence_until.
+  // (b) is not optional decoration — it is the whole persona this SD is named for. A parked
+  // /loop worker deliberately stops heartbeating and arms expected_silence_until to say
+  // "alive but silent"; the sweep and claim-validity-gate both honour it. Keying on heartbeat
+  // ALONE re-created the same blind spot one layer up: this worker's own loop arms wakeups of
+  // up to 1800s, which EXCEEDS the 900s heartbeat window, so a parked worker went invisible to
+  // this guard for the back half of every long nap and its SD was advertised for auto-claim.
+  // The cap is what keeps (b) from becoming an unbounded claim leak — a crashed worker's stale
+  // future timestamp cannot hold an SD forever.
+  const isHolding = (s) => {
+    if (!s || !s.sd_key) return false;
+    const hb = s.heartbeat_at ? Date.parse(s.heartbeat_at) : NaN;
+    if (Number.isFinite(hb) && (nowMs - hb) <= windowMs) return true;
+    const until = s.expected_silence_until ? Date.parse(s.expected_silence_until) : NaN;
+    if (!Number.isFinite(until)) return false;
+    // Armed (not yet expired) AND within cap — a runaway window is not a liveness signal.
+    return until > nowMs && (until - nowMs) <= silenceCapMs;
+  };
+
+  const heldByLive = new Set(liveSessions.filter(isHolding).map((s) => s.sd_key));
   return rows.filter((sd) => sd && sd.sd_key && !heldByLive.has(sd.sd_key));
 }
 

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -161,10 +161,18 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
     const ownerPidAlive = isOwnerProcessAlive(ownerSessionId);
     // Owner's OWN session-side sd_key no longer points at this SD → they've moved on (drift).
     const ownerHasSdKeyDrifted = !!ownerRow && ownerRow.sd_key !== sdId;
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3: the predicate above is ALSO true when
+    // sd_key is NULL, which is ambiguous (a parked/live owner) rather than a genuine "moved on"
+    // signal. Omitting ownerSdKeyMissing here left it undefined, so shouldReleaseStaleOwner
+    // short-circuited on `if (!ownerSdKeyMissing) return true` and this gate reported "no real
+    // conflict" — passing a handoff against a LIVE, PID-alive, silence-armed owner. That is the
+    // exact harm FR-3 fixed at lib/claim-validity-gate.js; this is its second consumer and the
+    // fix had not been propagated. See docs/protocol/claim-ownership-vs-liveness.md.
+    const ownerSdKeyMissing = !!ownerRow && !ownerRow.sd_key;
 
-    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive })) {
+    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive, ownerSdKeyMissing })) {
       console.log(`   ✅ Surface-A owner ${ownerSessionId.substring(0, 24)}... is dead/drifted (delegated liveness check) — no real conflict, passing`);
-      console.log(`      (ownerIsDead=${ownerIsDead}, ownerIsSilenced=${ownerIsSilenced}, ownerPidAlive=${ownerPidAlive}, sdKeyDrifted=${ownerHasSdKeyDrifted})`);
+      console.log(`      (ownerIsDead=${ownerIsDead}, ownerIsSilenced=${ownerIsSilenced}, ownerPidAlive=${ownerPidAlive}, sdKeyDrifted=${ownerHasSdKeyDrifted}, sdKeyMissing=${ownerSdKeyMissing})`);
       return {
         pass: true,
         score: 100,

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1216,12 +1216,25 @@ async function runQaFixtureScan(ctx) {
 
   // 3b. QA — detect sessions working on completed SDs
   const claimedSdKeys = [...new Set(classified.map(s => s.sd_key).filter(Boolean))];
-  const { data: claimedSdStatus } = await supabase
+  const { data: claimedSdStatus, error: claimedSdStatusError } = await supabase
     .from('strategic_directives_v2')
     // FR-3 (SD-LEO-FIX-STALE-SESSION-SWEEP-001): claiming_session_id lets the cross-signal guard
     // distinguish a genuinely-held SD from one whose claim was already cleared (zombie-tick case).
     .select('sd_key, status, completion_date, claiming_session_id')
     .in('sd_key', claimedSdKeys);
+
+  // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-1/TS-9: this lookup used to discard `error`.
+  // orphanedClaims below is `!sdStatusMap[s.sd_key]` — ABSENCE means orphaned. So a TRANSIENT
+  // query failure yields data=null, an EMPTY map, and therefore EVERY claimed session classified
+  // as orphaned and released in one pass — against LIVE, heartbeating workers, because that
+  // branch never consults liveness. That is intermittent, self-recovering and liveness-blind:
+  // the exact shape of the four observed lapses. Emptiness is not absence; an unchecked error
+  // read as "no rows" is the same defect class that made an unrelated open-QF count read 0.
+  // FAIL CLOSED: if we cannot prove an SD is gone, we do not sweep anything this tick.
+  const sdLookupTrustworthy = !claimedSdStatusError && Array.isArray(claimedSdStatus);
+  if (!sdLookupTrustworthy) {
+    console.error(`[sweep] SD status lookup FAILED (${claimedSdStatusError?.message || 'no data'}) — skipping orphaned-claim release this tick (fail-closed, SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001)`);
+  }
 
   const sdStatusMap = {};
   (claimedSdStatus || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
@@ -1310,7 +1323,28 @@ async function runQaFixtureScan(ctx) {
     const ageSec = qfClaimAgeBySession.has(s.session_id) ? qfClaimAgeBySession.get(s.session_id) : Infinity;
     return ageSec < QF_CLAIM_GRACE_SECONDS;
   };
-  const orphanedClaims = classified.filter(s => !sdStatusMap[s.sd_key] && !isHeldQfClaim(s));
+  // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-2: two guards this branch never had.
+  // (1) sdLookupTrustworthy — never infer "orphaned" from a failed lookup (see above).
+  // (2) shouldHoldClaim — this branch released on ABSENCE alone, with no liveness check at all,
+  //     which is why a live parked worker lost its claim while heartbeating. shouldHoldClaim was
+  //     already imported at the top of this file but consulted only by the conflict-eviction path.
+  // aliveCcPids is built far below (~line 1909) inside a different function, so it is NOT in
+  // scope here — computing it locally from the same source rather than passing undefined, which
+  // would silently degrade shouldHoldClaim to heartbeat-only and lose exactly the PID-aliveness
+  // signal that distinguishes a parked-but-live worker from a dead one.
+  let orphanAliveCcPids = null;
+  try {
+    orphanAliveCcPids = new Set((detectIdentityCollisions().aliveMarkers || []).map(m => String(m.pid)));
+  } catch { orphanAliveCcPids = null; } // fail-soft: guard still applies heartbeat/source-side signals
+  const orphanedClaims = (sdLookupTrustworthy ? classified : []).filter(s => {
+    if (sdStatusMap[s.sd_key] || isHeldQfClaim(s)) return false;
+    const guard = shouldHoldClaim(s, { aliveCcPids: orphanAliveCcPids });
+    if (guard.hold) {
+      console.error(`[sweep] HOLDING orphaned-claim release for ${s.session_id?.slice(0, 8)} on ${s.sd_key}: ${guard.reason} (live holder, SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-2)`);
+      return false;
+    }
+    return true;
+  });
   for (const s of orphanedClaims) {
     const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
     // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1242,9 +1242,41 @@ async function runQaFixtureScan(ctx) {
   // QF-20260525-211 (B2): include 'cancelled', not just 'completed'. Cancelled SDs with a
   // live claiming session previously skipped this bilateral release and fell through to the
   // SD-only clear (FIX #2 below), leaving the session's stale sd_key to feed CLAIM_FIX churn.
+  // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-2: this is the SECOND of the two sweep seams the
+  // PRD names (the other is orphanedClaims below). Both write the same fingerprint the observed
+  // lapse carried — { sd_key: null, status: ACTIVE ? 'idle' : 'released' } — and both were
+  // unguarded, even though shouldHoldClaim was already imported at line 370 and consulted only for
+  // conflict-eviction at ~:2521.
+  //
+  // The two seams differ in RISK, which is worth recording because it explains why only one of them
+  // produced the incident: orphanedClaims releases on ABSENCE from sdStatusMap, so the root-cause
+  // discarded-error (which emptied that map) made every claimed session look orphaned. THIS seam
+  // requires a POSITIVE terminal-status match, so an empty/failed lookup makes it release NOTHING —
+  // it already fails safe against the root cause. It is guarded anyway because the PRD's invariant
+  // is about the HOLDER, not about which query shape happened to be dangerous: a live, heartbeating,
+  // PID-alive holder inside an armed-silence window must not lose its claim to an automated path.
+  //
+  // Holding here is cheap: the SD is terminal, so it is not dispatchable regardless, and the sweep
+  // re-evaluates every tick — the release lands as soon as the holder is genuinely gone.
+  // Computed ONCE and shared with the orphanedClaims guard below — detectIdentityCollisions() scans
+  // host-local marker files, so calling it per-seam would double that work every tick. aliveCcPids
+  // is built far below (~line 1909) inside a DIFFERENT function and is not in scope here; passing
+  // undefined would silently degrade shouldHoldClaim to heartbeat-only and lose exactly the
+  // PID-aliveness signal that distinguishes a parked-but-live worker from a dead one.
+  let sweepAliveCcPids = null;
+  try {
+    sweepAliveCcPids = new Set((detectIdentityCollisions().aliveMarkers || []).map(m => String(m.pid)));
+  } catch { sweepAliveCcPids = null; } // fail-soft: guard still applies heartbeat/source-side signals
+
   const workingOnCompleted = classified.filter(s => {
     const sd = sdStatusMap[s.sd_key];
-    return sd && (sd.status === 'completed' || sd.status === 'cancelled');
+    if (!sd || (sd.status !== 'completed' && sd.status !== 'cancelled')) return false;
+    const guard = shouldHoldClaim(s, { aliveCcPids: sweepAliveCcPids });
+    if (guard.hold) {
+      console.error(`[sweep] HOLDING completed-SD release for ${String(s.session_id).slice(0, 8)} on ${s.sd_key} (${guard.reason}) — live holder, SD is terminal so nothing is blocked.`);
+      return false;
+    }
+    return true;
   });
 
   for (const s of workingOnCompleted) {
@@ -1328,14 +1360,9 @@ async function runQaFixtureScan(ctx) {
   // (2) shouldHoldClaim — this branch released on ABSENCE alone, with no liveness check at all,
   //     which is why a live parked worker lost its claim while heartbeating. shouldHoldClaim was
   //     already imported at the top of this file but consulted only by the conflict-eviction path.
-  // aliveCcPids is built far below (~line 1909) inside a different function, so it is NOT in
-  // scope here — computing it locally from the same source rather than passing undefined, which
-  // would silently degrade shouldHoldClaim to heartbeat-only and lose exactly the PID-aliveness
-  // signal that distinguishes a parked-but-live worker from a dead one.
-  let orphanAliveCcPids = null;
-  try {
-    orphanAliveCcPids = new Set((detectIdentityCollisions().aliveMarkers || []).map(m => String(m.pid)));
-  } catch { orphanAliveCcPids = null; } // fail-soft: guard still applies heartbeat/source-side signals
+  // Uses the shared sweepAliveCcPids computed with the workingOnCompleted guard above (same tick,
+  // same marker scan) rather than re-scanning the host-local markers a second time.
+  const orphanAliveCcPids = sweepAliveCcPids;
   const orphanedClaims = (sdLookupTrustworthy ? classified : []).filter(s => {
     if (sdStatusMap[s.sd_key] || isHeldQfClaim(s)) return false;
     const guard = shouldHoldClaim(s, { aliveCcPids: orphanAliveCcPids });

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1267,8 +1267,13 @@ async function selfHealStaleClaim(sb, sessionId, sdKey) {
 /**
  * SD-LEO-INFRA-CHECKIN-OWN-CLAIM-DETECT-001: the authoritative query — does strategic_directives_v2
  * (the same columns sd:next and the coordinator read) say THIS session holds a live, unworked claim?
- * claude_sessions.sd_key is only ever a cache of this; this is the source of truth. Fail-open (null on
- * any error) so a query hiccup never turns a checkin into action=error.
+ * This is an OWNERSHIP question, so SDv2 governs it — see the ratified precedence rule in
+ * docs/protocol/claim-ownership-vs-liveness.md (SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-5).
+ * NOTE: this comment used to say "claude_sessions.sd_key is only ever a cache of this", which read as
+ * a universal rule and contradicted coordinator-email-summary.mjs. It is not a cache — it answers a
+ * DIFFERENT question (is a worker currently BUILDING), and the two surfaces diverge legitimately in
+ * both directions. Do not consult sd_key here; do not consult claiming_session_id for liveness.
+ * Fail-open (null on any error) so a query hiccup never turns a checkin into action=error.
  * @returns {Promise<string|null>} the sd_key of the owned claim, or null
  */
 async function findOwnSdClaim(sb, sessionId) {

--- a/tests/unit/claim-ownership-vs-liveness-precedence.test.js
+++ b/tests/unit/claim-ownership-vs-liveness-precedence.test.js
@@ -88,12 +88,22 @@ describe('FR-5: each site still reads the surface matching its OWN question', ()
     expect(body).not.toMatch(/from\('claude_sessions'\)/);
   });
 
-  it('selectAvailableSds (a liveness question) keys on the session surface + heartbeat', () => {
+  it('selectAvailableSds (a liveness question) keys on the session surface, not on SDv2', () => {
     const src = read('scripts/hooks/coordination-inbox.cjs');
     const start = src.indexOf('function selectAvailableSds');
     expect(start).toBeGreaterThan(0);
-    const body = src.slice(start, start + 900);
-    expect(body).toMatch(/s\.sd_key/);
+    // Bound the slice at the END OF THE FUNCTION, not at a fixed character count. The original
+    // `start + 900` pin broke within the hour, when a comment inside the function grew and pushed
+    // the asserted token past the window — a self-inflicted instance of the exact brittleness this
+    // file warns about. The bound is now structural, so prose changes cannot move it.
+    const after = src.indexOf('\nfunction ', start + 1);
+    const body = src.slice(start, after > start ? after : src.length);
+    expect(body).toMatch(/\bsd_key\b/);
+    // BOTH liveness signals — a parked worker stops heartbeating on purpose, so heartbeat alone
+    // is not sufficient evidence that nobody is building.
     expect(body).toMatch(/heartbeat_at/);
+    expect(body).toMatch(/expected_silence_until/);
+    // It must NOT reach for the ownership surface to answer a liveness question.
+    expect(body).not.toMatch(/claiming_session_id/);
   });
 });

--- a/tests/unit/claim-ownership-vs-liveness-precedence.test.js
+++ b/tests/unit/claim-ownership-vs-liveness-precedence.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-5 — the ownership/liveness precedence rule.
+ *
+ * Three sites disagreed in comments about which surface "wins":
+ *   - worker-checkin.cjs findOwnSdClaim: "claude_sessions.sd_key is only ever a cache of this"
+ *   - coordinator-email-summary.mjs:      "sd_key is the reliable build signal"
+ *   - claim-validity-gate.js:             "sd_key is the source-of-truth, NOT claiming_session_id"
+ *
+ * They were each right about their OWN question and wrong as a universal rule. The ambiguity is
+ * load-bearing, not cosmetic: FR-4 makes dispatch depend on the session surface being authoritative
+ * for LIVENESS, while claim release depends on SDv2 being authoritative for OWNERSHIP. A future
+ * edit that "resolves" the disagreement by picking one winner globally would reopen either the
+ * claim-lapse (this SD's root cause) or a claim leak.
+ *
+ * These are source-invariant assertions because the artifact under test IS the stated rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const read = (p) => readFileSync(resolve(REPO_ROOT, p), 'utf8');
+
+const DOC = 'docs/protocol/claim-ownership-vs-liveness.md';
+
+describe('FR-5: the rule is stated once, in a place all three sites can reference', () => {
+  it('the ratified doc exists', () => {
+    expect(existsSync(resolve(REPO_ROOT, DOC))).toBe(true);
+  });
+
+  it('it assigns OWNERSHIP to SDv2 and CURRENTLY-BUILDING to the session surface', () => {
+    const doc = read(DOC);
+    expect(doc).toMatch(/strategic_directives_v2\.claiming_session_id/);
+    expect(doc).toMatch(/claude_sessions\.sd_key/);
+    expect(doc).toMatch(/OWNS/);
+    expect(doc).toMatch(/CURRENTLY BUILDING/);
+  });
+
+  it('it records that the surfaces diverge in BOTH directions (neither is a cache)', () => {
+    const doc = read(DOC);
+    expect(doc).toMatch(/Claim set, `sd_key` NULL/);
+    expect(doc).toMatch(/`sd_key` set, claim NULL/);
+    expect(doc).toMatch(/Neither is a cache of the other/i);
+  });
+
+  it('it preserves the empty-vs-failed distinction that this SD was caused by', () => {
+    const doc = read(DOC);
+    expect(doc).toMatch(/An \*\*empty\*\* result is a real answer/);
+    expect(doc).toMatch(/A \*\*failed\*\* query is not an answer/);
+  });
+});
+
+describe('FR-5: the contradicting universal claims are gone from all three call sites', () => {
+  it('claim-validity-gate no longer asserts sd_key is the source-of-truth over claiming_session_id', () => {
+    const src = read('lib/claim-validity-gate.js');
+    // The exact phrasing that contradicted worker-checkin. Its removal is the fix.
+    expect(src).not.toMatch(/sd_key is the source-of-truth, NOT claiming_session_id\s*\./);
+    expect(src).toContain(DOC);
+  });
+
+  it('worker-checkin no longer calls sd_key a mere cache, and points at the rule', () => {
+    const src = read('scripts/worker-checkin.cjs');
+    expect(src).not.toMatch(/claude_sessions\.sd_key is only ever a cache of this; this is the source of truth/);
+    expect(src).toContain(DOC);
+  });
+
+  it('coordinator-email-summary keeps its build-signal rule but scopes it to liveness', () => {
+    const src = read('scripts/coordinator-email-summary.mjs');
+    // The behaviour it documents is correct and must NOT be reverted…
+    expect(src).toMatch(/claude_sessions\.sd_key is the reliable build signal/);
+    // …but it must no longer read as a global precedence claim.
+    expect(src).toMatch(/Do NOT generalize this into/);
+    expect(src).toContain(DOC);
+  });
+});
+
+describe('FR-5: each site still reads the surface matching its OWN question', () => {
+  it('findOwnSdClaim (an ownership question) queries SDv2, not claude_sessions', () => {
+    const src = read('scripts/worker-checkin.cjs');
+    const start = src.indexOf('async function findOwnSdClaim');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, start + 700);
+    expect(body).toMatch(/from\('strategic_directives_v2'\)/);
+    expect(body).toMatch(/\.eq\('claiming_session_id', sessionId\)/);
+    expect(body).not.toMatch(/from\('claude_sessions'\)/);
+  });
+
+  it('selectAvailableSds (a liveness question) keys on the session surface + heartbeat', () => {
+    const src = read('scripts/hooks/coordination-inbox.cjs');
+    const start = src.indexOf('function selectAvailableSds');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start, start + 900);
+    expect(body).toMatch(/s\.sd_key/);
+    expect(body).toMatch(/heartbeat_at/);
+  });
+});

--- a/tests/unit/claim-ownership-vs-liveness-precedence.test.js
+++ b/tests/unit/claim-ownership-vs-liveness-precedence.test.js
@@ -92,18 +92,38 @@ describe('FR-5: each site still reads the surface matching its OWN question', ()
     const src = read('scripts/hooks/coordination-inbox.cjs');
     const start = src.indexOf('function selectAvailableSds');
     expect(start).toBeGreaterThan(0);
-    // Bound the slice at the END OF THE FUNCTION, not at a fixed character count. The original
-    // `start + 900` pin broke within the hour, when a comment inside the function grew and pushed
-    // the asserted token past the window — a self-inflicted instance of the exact brittleness this
-    // file warns about. The bound is now structural, so prose changes cannot move it.
-    const after = src.indexOf('\nfunction ', start + 1);
-    const body = src.slice(start, after > start ? after : src.length);
+
+    // Bounding this slice has now gone wrong twice, so it is worth stating what the bound must do.
+    // v1 used a fixed `start + 900` and broke within the hour when a comment grew past it. v2 used
+    // `indexOf('\nfunction ', start+1)` and claimed to be "structural" — but selectAvailableSds is
+    // the LAST function declaration in the file, so that returns -1 and silently fell back to EOF.
+    // It passed for a reason unrelated to the stated one, and would have silently NARROWED the
+    // moment any function was appended below. Bind to the real terminator instead, and assert the
+    // bound actually resolved rather than trusting a fallback.
+    const end = src.indexOf('\nmodule.exports', start);
+    expect(end).toBeGreaterThan(start);
+    const body = src.slice(start, end);
+
     expect(body).toMatch(/\bsd_key\b/);
-    // BOTH liveness signals — a parked worker stops heartbeating on purpose, so heartbeat alone
-    // is not sufficient evidence that nobody is building.
-    expect(body).toMatch(/heartbeat_at/);
-    expect(body).toMatch(/expected_silence_until/);
+    // Liveness is DELEGATED to the read-time SSOT rather than re-derived here. Pinning the
+    // individual column names would now be wrong: the whole point of DEFECT-7 was that a local
+    // re-derivation covered 2 of 5 signals and forked its own thresholds.
+    expect(body).toMatch(/isSessionAlive\(/);
     // It must NOT reach for the ownership surface to answer a liveness question.
     expect(body).not.toMatch(/claiming_session_id/);
+    // …and it must not quietly re-derive liveness locally again.
+    expect(body).not.toMatch(/Date\.parse\(\s*s\.heartbeat_at/);
+  });
+
+  it('the dispatch query selects every column the liveness SSOT reads', () => {
+    // A delegated liveness check degrades silently if the caller under-selects: the SSOT would see
+    // undefined for is_alive / terminal_id / process_alive_at and fall back to whatever happens to
+    // be present. That is DEFECT-7 re-entering through the query rather than the predicate.
+    const src = read('scripts/hooks/coordination-inbox.cjs');
+    const q = src.match(/\.from\('claude_sessions'\)\s*\.select\('([^']*)'\)\s*\.not\('sd_key'/);
+    expect(q).toBeTruthy();
+    for (const col of ['sd_key', 'heartbeat_at', 'expected_silence_until', 'is_alive', 'terminal_id', 'process_alive_at']) {
+      expect(q[1]).toContain(col);
+    }
   });
 });

--- a/tests/unit/claim-validity-gate-sd-key-drift.test.js
+++ b/tests/unit/claim-validity-gate-sd-key-drift.test.js
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { shouldReleaseStaleOwner } from '../../lib/claim-validity-gate.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -52,9 +53,17 @@ describe('FR-2 fallthrough: sd_key drift triggers auto-release alongside ownerIs
     // inline condition into the pure shouldReleaseStaleOwner() and ADDED the !ownerPidAlive escape
     // (a busy worker mid Task() sub-agent call has a live PID and must not be reaped). The release is
     // now driven by that helper; the pure function still encodes drift-always / (dead && !silenced && !pid-alive).
-    expect(src).toMatch(/if\s*\(\s*shouldReleaseStaleOwner\(\s*\{\s*ownerHasSdKeyDrifted,\s*ownerIsDead,\s*ownerIsSilenced,\s*ownerPidAlive\s*\}\s*\)\s*\)/);
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3 added a 5th signal, ownerSdKeyMissing, so
+    // an AMBIGUOUS drift (owner.sd_key === null) can be distinguished from a genuine one (owner
+    // moved to another SD). The semantic this test pins — the auto-release decision routes through
+    // shouldReleaseStaleOwner carrying the liveness signals — is unchanged and now stronger.
+    expect(src).toMatch(/if\s*\(\s*shouldReleaseStaleOwner\(\s*\{\s*ownerHasSdKeyDrifted,\s*ownerIsDead,\s*ownerIsSilenced,\s*ownerPidAlive,\s*ownerSdKeyMissing\s*\}\s*\)\s*\)/);
     expect(src).toMatch(/function shouldReleaseStaleOwner/);
-    expect(src).toMatch(/if\s*\(\s*ownerHasSdKeyDrifted\s*\)\s*return true/);
+    // FR-3: the drift arm is now a BLOCK, not a bare `return true` — it releases unconditionally
+    // only when the owner is verifiably on ANOTHER sd_key, and requires a negative liveness signal
+    // when the sd_key is merely null (the ambiguous case that was evicting live owners).
+    expect(src).toMatch(/if\s*\(\s*ownerHasSdKeyDrifted\s*\)\s*\{/);
+    expect(src).toMatch(/if\s*\(\s*!ownerSdKeyMissing\s*\)\s*return true;/);
     expect(src).toMatch(/Boolean\(ownerIsDead\)\s*&&\s*!ownerIsSilenced\s*&&\s*!ownerPidAlive/);
   });
 
@@ -126,5 +135,44 @@ describe('cross-cutting: no claim_version usage (validation-agent P1)', () => {
   it('active code does NOT introduce claim_version (Option B compare-and-set lives in lifecycle helper)', () => {
     const codeOnly = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
     expect(codeOnly).not.toMatch(/claim_version/);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3 (TS-2 / TS-3) — behavioural, against the REAL
+ * exported predicate (no mocks: shouldReleaseStaleOwner is pure).
+ *
+ * Drift used to release UNCONDITIONALLY, which made this a liveness-free claim steal: any path
+ * that nulled the session-side sd_key evicted a LIVE, heartbeating, PID-alive, silence-armed
+ * owner. But 'drift' covers two materially different situations, and collapsing them is what
+ * caused the harm — so these tests pin BOTH directions. Over-correcting here would be a claim
+ * leak that starves the belt, which TS-3 exists to prevent.
+ */
+describe('FR-3: sd_key drift must not evict a live owner (TS-2/TS-3)', () => {
+  it('TS-2: a NULL sd_key does NOT release a PID-alive owner', () => {
+    expect(shouldReleaseStaleOwner({ ownerHasSdKeyDrifted: true, ownerSdKeyMissing: true, ownerPidAlive: true, ownerIsDead: true })).toBe(false);
+  });
+
+  it('TS-2: a NULL sd_key does NOT release a silence-armed owner', () => {
+    expect(shouldReleaseStaleOwner({ ownerHasSdKeyDrifted: true, ownerSdKeyMissing: true, ownerIsSilenced: true, ownerIsDead: true })).toBe(false);
+  });
+
+  it('TS-3: a NULL sd_key STILL releases an owner with no liveness signal (no claim leak)', () => {
+    expect(shouldReleaseStaleOwner({ ownerHasSdKeyDrifted: true, ownerSdKeyMissing: true, ownerPidAlive: false, ownerIsSilenced: false })).toBe(true);
+  });
+
+  it('TS-3: an owner verifiably on ANOTHER sd_key still releases unconditionally — the genuine signal is preserved', () => {
+    expect(shouldReleaseStaleOwner({ ownerHasSdKeyDrifted: true, ownerSdKeyMissing: false, ownerPidAlive: true, ownerIsSilenced: true })).toBe(true);
+  });
+
+  it('the non-drift dead-owner path is unchanged (silence and pid-alive still suppress)', () => {
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true })).toBe(true);
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true, ownerIsSilenced: true })).toBe(false);
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true, ownerPidAlive: true })).toBe(false);
+    expect(shouldReleaseStaleOwner({ ownerIsDead: false })).toBe(false);
+  });
+
+  it('the call site distinguishes a null sd_key from a moved one', () => {
+    expect(src).toMatch(/const ownerSdKeyMissing = Boolean\(owner\) && !owner\.sd_key/);
   });
 });

--- a/tests/unit/claim-validity-gate-sd-key-drift.test.js
+++ b/tests/unit/claim-validity-gate-sd-key-drift.test.js
@@ -57,7 +57,19 @@ describe('FR-2 fallthrough: sd_key drift triggers auto-release alongside ownerIs
     // an AMBIGUOUS drift (owner.sd_key === null) can be distinguished from a genuine one (owner
     // moved to another SD). The semantic this test pins — the auto-release decision routes through
     // shouldReleaseStaleOwner carrying the liveness signals — is unchanged and now stronger.
-    expect(src).toMatch(/if\s*\(\s*shouldReleaseStaleOwner\(\s*\{\s*ownerHasSdKeyDrifted,\s*ownerIsDead,\s*ownerIsSilenced,\s*ownerPidAlive,\s*ownerSdKeyMissing\s*\}\s*\)\s*\)/);
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-1 (2nd pass): this assertion previously pinned
+    // the ENTIRE `if (...)` including its opening paren, so it broke when the release site gained a
+    // fail-closed `!ownerLookupFailed &&` conjunct — a correct change (a discarded owner-lookup
+    // error was letting a failed query read as "owner is dead" and reap a LIVE claim). This is the
+    // 5th syntax pin in this repo to fail on a correct edit. Re-aimed at the SEMANTIC: the release
+    // decision routes through shouldReleaseStaleOwner carrying all five liveness signals. Any
+    // ADDITIONAL guard in front of it is by definition more conservative and must not fail here.
+    expect(src).toMatch(/shouldReleaseStaleOwner\(\s*\{\s*ownerHasSdKeyDrifted,\s*ownerIsDead,\s*ownerIsSilenced,\s*ownerPidAlive,\s*ownerSdKeyMissing\s*\}\s*\)/);
+    // …and the release is still gated by an `if`, not evaluated for side effects.
+    expect(src).toMatch(/if\s*\([^)]*shouldReleaseStaleOwner\(/);
+    // FR-1: an ERRORED owner lookup must suppress the release (a failed query is not an answer).
+    expect(src).toMatch(/!ownerLookupFailed\s*&&\s*shouldReleaseStaleOwner/);
+    expect(src).toMatch(/const ownerLookupFailed = Boolean\(ownerErr\)/);
     expect(src).toMatch(/function shouldReleaseStaleOwner/);
     // FR-3: the drift arm is now a BLOCK, not a bare `return true` — it releases unconditionally
     // only when the owner is verifiably on ANOTHER sd_key, and requires a negative liveness signal

--- a/tests/unit/multi-session-claim-gate.test.js
+++ b/tests/unit/multi-session-claim-gate.test.js
@@ -10,10 +10,15 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import {
   validateMultiSessionClaim,
   createMultiSessionClaimGate
 } from '../../scripts/modules/handoff/gates/multi-session-claim-gate.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Mock supabase for the Surface-A-first contract.
@@ -334,6 +339,82 @@ describe('Multi-Session Claim Conflict Gate', () => {
 
       expect(result.pass).toBe(true);
       expect(result.score).toBe(100);
+    });
+  });
+
+  /**
+   * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-3, second consumer.
+   *
+   * FR-3 taught shouldReleaseStaleOwner to distinguish an owner that MOVED to another sd_key
+   * (a genuine "they left" signal) from one whose sd_key is merely NULL (ambiguous — the
+   * observed lapse, where a parked-but-live worker looks abandoned). The fix landed at
+   * lib/claim-validity-gate.js but NOT here, even though this gate computes
+   * `ownerHasSdKeyDrifted = !!ownerRow && ownerRow.sd_key !== sdId`, which is TRUE for NULL.
+   * With ownerSdKeyMissing left undefined, the predicate short-circuited on
+   * `if (!ownerSdKeyMissing) return true` and this gate reported "no real conflict — passing",
+   * letting a handoff proceed against a LIVE worker's SD.
+   *
+   * Behavioural, through the real gate. Verified RED before the fix.
+   */
+  describe('FR-3 propagation: a NULL owner sd_key must not read as "they moved on"', () => {
+    const ARMED_SILENCE = () => new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+    it('BLOCKS when the owner is silence-armed and its sd_key is NULL (ambiguous, not drift)', async () => {
+      const supabase = createMockSupabase({
+        ownerSessionId: 'parked-live-owner-123',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: ARMED_SILENCE(), // parked worker: alive but deliberately silent
+          hostname: 'REMOTE-SERVER',
+          terminal_id: null,
+          tty: '/dev/pts/1',
+          sd_key: null,                            // ← the ambiguous signal, NOT a move
+          codebase: 'EHG_Engineer'
+        }
+      });
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456'
+      });
+
+      // Before the fix this returned pass:true ("dead/drifted — no real conflict").
+      expect(result.pass).toBe(false);
+    });
+
+    it('still PASSES when the owner verifiably MOVED to another sd_key (no claim leak)', async () => {
+      // The other direction matters just as much: over-guarding drift would strand claims and
+      // starve the belt. A genuine move is still a release signal even for a live, silenced owner.
+      const supabase = createMockSupabase({
+        ownerSessionId: 'moved-on-owner-789',
+        ownerSessionRow: {
+          status: 'active',
+          is_alive: true,
+          heartbeat_at: FRESH_HEARTBEAT(),
+          expected_silence_until: ARMED_SILENCE(),
+          hostname: 'REMOTE-SERVER',
+          terminal_id: null,
+          tty: '/dev/pts/1',
+          sd_key: 'SD-SOME-OTHER-SD-002',          // ← verifiably elsewhere
+          codebase: 'EHG_Engineer'
+        }
+      });
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456'
+      });
+
+      expect(result.pass).toBe(true);
+    });
+
+    it('passes ownerSdKeyMissing through to the shared predicate (both consumers agree)', () => {
+      const src = readFileSync(
+        resolve(__dirname, '../..', 'scripts/modules/handoff/gates/multi-session-claim-gate.js'),
+        'utf8'
+      );
+      expect(src).toMatch(/const ownerSdKeyMissing = !!ownerRow && !ownerRow\.sd_key/);
+      expect(src).toMatch(/shouldReleaseStaleOwner\([^)]*ownerSdKeyMissing/);
     });
   });
 

--- a/tests/unit/scripts/coordination-inbox-availability.test.js
+++ b/tests/unit/scripts/coordination-inbox-availability.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-4/FR-7 (TS-4, TS-5).
+ *
+ * The dispatch-availability seam. Before this SD it was an inline query inside main() that
+ * selected SDs on `claiming_session_id IS NULL` with NO session cross-check and NO liveness
+ * check, and there was NO test file for this hook at all. That combination is what allowed an
+ * SD to be advertised for auto-claim while a live worker was mid-build on it: a transient clear
+ * of claiming_session_id (see the sweep root cause, commit 103260605b3) made a busy SD look free.
+ *
+ * These tests run against the REAL exported predicate. That is the whole point of extracting it —
+ * asserting the old inline query would have required mocking the very thing under test, which is
+ * the test-masking mode this repo has been bitten by before.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { selectAvailableSds, SESSION_LIVENESS_WINDOW_MS } = require(
+  resolve(__dirname, '../../..', 'scripts/hooks/coordination-inbox.cjs')
+);
+
+const NOW = Date.parse('2026-07-25T18:00:00.000Z');
+const fresh = new Date(NOW - 60_000).toISOString();          // 1 min ago — clearly live
+const stale = new Date(NOW - 60 * 60 * 1000).toISOString();  // 1 hour ago — clearly gone
+
+describe('FR-4/TS-4: an SD with a live builder is never advertised', () => {
+  it('excludes an SD whose sd_key is held by a live session, even though its claim is NULL', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-BUSY' }, { sd_key: 'SD-FREE' }],
+      [{ sd_key: 'SD-BUSY', heartbeat_at: fresh }],
+      { nowMs: NOW }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-FREE']);
+  });
+
+  it('still offers an SD whose holder is long gone (no claim leak into dispatch starvation)', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-ABANDONED' }],
+      [{ sd_key: 'SD-ABANDONED', heartbeat_at: stale }],
+      { nowMs: NOW }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-ABANDONED']);
+  });
+
+  it('a parked worker inside the liveness window still holds its SD', () => {
+    const justInside = new Date(NOW - (SESSION_LIVENESS_WINDOW_MS - 1000)).toISOString();
+    const out = selectAvailableSds([{ sd_key: 'SD-PARKED' }], [{ sd_key: 'SD-PARKED', heartbeat_at: justInside }], { nowMs: NOW });
+    expect(out).toEqual([]);
+  });
+});
+
+describe('TS-5: the guarantee does not depend on SD phase', () => {
+  // The two near-misses were caught by worker-checkin isSdInFlight, which blocks self-claim when
+  // current_phase is not LEAD/LEAD_APPROVAL. That backstop is PHASE-based and would NOT have held
+  // for an SD still in LEAD. This predicate is phase-agnostic by construction: it keys on whether
+  // a live session holds the sd_key, nothing else.
+  it('excludes a live-held SD regardless of any phase field on the row', () => {
+    const rows = [
+      { sd_key: 'SD-LEAD', current_phase: 'LEAD' },
+      { sd_key: 'SD-EXEC', current_phase: 'EXEC' },
+    ];
+    const live = [
+      { sd_key: 'SD-LEAD', heartbeat_at: fresh },
+      { sd_key: 'SD-EXEC', heartbeat_at: fresh },
+    ];
+    expect(selectAvailableSds(rows, live, { nowMs: NOW })).toEqual([]);
+  });
+});
+
+describe('fails closed — emptiness is never treated as proof of absence', () => {
+  // The root cause of this whole SD was an unchecked query error read as "no rows". If the
+  // session cross-check cannot run, advertising every candidate would reproduce that defect here.
+  it('returns nothing when the session list is null (cross-check could not run)', () => {
+    expect(selectAvailableSds([{ sd_key: 'SD-A' }], null, { nowMs: NOW })).toEqual([]);
+  });
+
+  it('returns nothing when the session list is undefined', () => {
+    expect(selectAvailableSds([{ sd_key: 'SD-A' }], undefined, { nowMs: NOW })).toEqual([]);
+  });
+
+  it('an EMPTY session array is a real answer (nobody is building) and does not block dispatch', () => {
+    expect(selectAvailableSds([{ sd_key: 'SD-A' }], [], { nowMs: NOW })).toEqual([{ sd_key: 'SD-A' }]);
+  });
+
+  it('ignores session rows with no heartbeat rather than trusting them as live', () => {
+    const out = selectAvailableSds([{ sd_key: 'SD-A' }], [{ sd_key: 'SD-A', heartbeat_at: null }], { nowMs: NOW });
+    expect(out).toEqual([{ sd_key: 'SD-A' }]);
+  });
+
+  it('handles an empty or non-array candidate list without throwing', () => {
+    expect(selectAvailableSds([], [], { nowMs: NOW })).toEqual([]);
+    expect(selectAvailableSds(null, [], { nowMs: NOW })).toEqual([]);
+  });
+});
+
+describe('wiring: the call site uses the predicate, not the raw query result', () => {
+  it('emitAutoClaimDirective is fed from the cross-checked list', () => {
+    const { readFileSync } = require('node:fs');
+    const src = readFileSync(resolve(__dirname, '../../..', 'scripts/hooks/coordination-inbox.cjs'), 'utf8');
+    expect(src).toMatch(/const claimable = selectAvailableSds\(availableSDs, liveSessions\)/);
+    expect(src).toMatch(/emitAutoClaimDirective\(\s*claimable\[0\]\.sd_key/);
+  });
+});

--- a/tests/unit/scripts/coordination-inbox-availability.test.js
+++ b/tests/unit/scripts/coordination-inbox-availability.test.js
@@ -46,10 +46,64 @@ describe('FR-4/TS-4: an SD with a live builder is never advertised', () => {
     expect(out.map((s) => s.sd_key)).toEqual(['SD-ABANDONED']);
   });
 
-  it('a parked worker inside the liveness window still holds its SD', () => {
-    const justInside = new Date(NOW - (SESSION_LIVENESS_WINDOW_MS - 1000)).toISOString();
-    const out = selectAvailableSds([{ sd_key: 'SD-PARKED' }], [{ sd_key: 'SD-PARKED', heartbeat_at: justInside }], { nowMs: NOW });
+  it('a parked worker is held by its ARMED SILENCE, not by a long heartbeat window', () => {
+    // This test previously pinned a heartbeat of (SESSION_LIVENESS_WINDOW_MS - 1s), i.e. ~15min,
+    // back when this predicate re-derived liveness locally with its own 900s window. Liveness is
+    // now delegated to the lib/fleet/session-liveness.cjs SSOT, whose heartbeat threshold is 300s
+    // — so a 15-minute-old heartbeat is correctly NOT a liveness signal on its own. That is not a
+    // regression: a parked worker is protected by the signal it actually emits (an armed
+    // expected_silence_until), plus the PID/tick/raw signals below, rather than by stretching the
+    // heartbeat window to cover a worker that has deliberately stopped heartbeating.
+    const staleBeat = new Date(NOW - (SESSION_LIVENESS_WINDOW_MS - 1000)).toISOString();
+    const armed = new Date(NOW + 5 * 60 * 1000).toISOString();
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-PARKED' }],
+      [{ sd_key: 'SD-PARKED', heartbeat_at: staleBeat, expected_silence_until: armed }],
+      { nowMs: NOW }
+    );
     expect(out).toEqual([]);
+  });
+});
+
+describe('FR-4 (3rd pass): liveness comes from the SSOT, so ALL its signals count', () => {
+  // DEFECT-7. The hand-rolled predicate covered 2 of the SSOT's 5 signals, leaving a worker that
+  // is PID-alive or tick-fresh but heartbeat-stale invisible here — its SD was still advertised,
+  // which is the COLLISION direction. Each signal below independently holds the SD.
+  it('a raw is_alive session holds its SD even with no heartbeat at all', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-RAW' }],
+      [{ sd_key: 'SD-RAW', is_alive: true, heartbeat_at: null }],
+      { nowMs: NOW }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('a tick-fresh session holds its SD despite a stale heartbeat (mid sub-agent call)', () => {
+    // A worker inside a long Task()/Agent call emits no heartbeat but keeps stamping process_alive_at.
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-TICKING' }],
+      [{ sd_key: 'SD-TICKING', heartbeat_at: stale, process_alive_at: new Date(NOW - 30_000).toISOString() }],
+      { nowMs: NOW }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('a PID-alive session holds its SD (injected alive-pid set, host-local signal)', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-PID' }],
+      [{ sd_key: 'SD-PID', heartbeat_at: stale, terminal_id: 'win-cc-4001-12345' }],
+      { nowMs: NOW, aliveCcPids: new Set(['12345']) }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('a session with NO live signal at all is still released (no claim leak)', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-GONE' }],
+      [{ sd_key: 'SD-GONE', heartbeat_at: stale, is_alive: false, terminal_id: 'win-cc-4001-99999', process_alive_at: stale }],
+      { nowMs: NOW, aliveCcPids: new Set(['12345']) }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-GONE']);
   });
 });
 
@@ -166,7 +220,15 @@ describe('wiring: the call site uses the predicate, not the raw query result', (
   it('emitAutoClaimDirective is fed from the cross-checked list', () => {
     const { readFileSync } = require('node:fs');
     const src = readFileSync(resolve(__dirname, '../../..', 'scripts/hooks/coordination-inbox.cjs'), 'utf8');
-    expect(src).toMatch(/const claimable = selectAvailableSds\(availableSDs, liveSessions\)/);
+    // Pinned the exact expression `const claimable = selectAvailableSds(availableSDs, liveSessions)`
+    // until a later commit edited the query directly above it; it survived by luck. Exact-syntax and
+    // fixed-offset pins have now broken FOUR times inside this SD alone, so this asserts the two
+    // semantics instead: the predicate is fed from the raw query result, and the directive is fed
+    // from the predicate's output — never from the raw list. Renaming the local or adding an opts
+    // argument are both correct refactors and must not fail here.
+    expect(src).toMatch(/selectAvailableSds\(\s*availableSDs\s*,\s*liveSessions/);
     expect(src).toMatch(/emitAutoClaimDirective\(\s*claimable\[0\]\.sd_key/);
+    // The guard is worthless if the directive can still be fed straight from the unchecked list.
+    expect(src).not.toMatch(/emitAutoClaimDirective\(\s*availableSDs\[0\]/);
   });
 });

--- a/tests/unit/scripts/coordination-inbox-availability.test.js
+++ b/tests/unit/scripts/coordination-inbox-availability.test.js
@@ -53,6 +53,71 @@ describe('FR-4/TS-4: an SD with a live builder is never advertised', () => {
   });
 });
 
+describe('FR-4 (2nd pass): a PARKED worker is live — heartbeat alone is not enough', () => {
+  // The SD is named for a PARKED worker. Such a worker deliberately STOPS heartbeating and arms
+  // expected_silence_until to say "alive but silent"; the sweep and claim-validity-gate both
+  // honour that field. The first pass of this predicate keyed on heartbeat only, which re-created
+  // the same blind spot one layer up: this worker's own loop arms wakeups of up to 1800s, well
+  // beyond the 900s heartbeat window, so a parked worker's SD was advertised for auto-claim
+  // during the back half of every long nap.
+  const armed = (msFromNow) => new Date(NOW + msFromNow).toISOString();
+
+  it('holds the SD of a worker whose heartbeat is stale but whose silence window is armed', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-PARKED' }],
+      [{ sd_key: 'SD-PARKED', heartbeat_at: stale, expected_silence_until: armed(5 * 60 * 1000) }],
+      { nowMs: NOW }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('covers the 1800s nap that exceeds the 900s heartbeat window (the actual gap)', () => {
+    const napStart = new Date(NOW - 1500 * 1000).toISOString(); // last beat 25 min ago
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-LONG-NAP' }],
+      [{ sd_key: 'SD-LONG-NAP', heartbeat_at: napStart, expected_silence_until: armed(300 * 1000) }],
+      { nowMs: NOW }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('releases once the silence window has EXPIRED (no claim leak)', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-EXPIRED' }],
+      [{ sd_key: 'SD-EXPIRED', heartbeat_at: stale, expected_silence_until: armed(-60 * 1000) }],
+      { nowMs: NOW }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-EXPIRED']);
+  });
+
+  it('does NOT trust a runaway far-future window beyond the cap (crashed worker cannot hold forever)', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-RUNAWAY' }],
+      [{ sd_key: 'SD-RUNAWAY', heartbeat_at: stale, expected_silence_until: armed(24 * 60 * 60 * 1000) }],
+      { nowMs: NOW }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-RUNAWAY']);
+  });
+
+  it('a fresh heartbeat still holds the SD with no silence window at all', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-BUSY' }],
+      [{ sd_key: 'SD-BUSY', heartbeat_at: fresh, expected_silence_until: null }],
+      { nowMs: NOW }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('ignores an unparseable silence timestamp rather than treating it as live', () => {
+    const out = selectAvailableSds(
+      [{ sd_key: 'SD-JUNK' }],
+      [{ sd_key: 'SD-JUNK', heartbeat_at: stale, expected_silence_until: 'not-a-date' }],
+      { nowMs: NOW }
+    );
+    expect(out.map((s) => s.sd_key)).toEqual(['SD-JUNK']);
+  });
+});
+
 describe('TS-5: the guarantee does not depend on SD phase', () => {
   // The two near-misses were caught by worker-checkin isSdInFlight, which blocks self-claim when
   // current_phase is not LEAD/LEAD_APPROVAL. That backstop is PHASE-based and would NOT have held

--- a/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
+++ b/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
@@ -199,7 +199,40 @@ describe('SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001: orphaned-claim release is 
   it('TS-8: the guard receives a REAL PID set, not undefined (aliveCcPids is out of scope here)', () => {
     // Passing undefined would silently degrade shouldHoldClaim to heartbeat-only and lose the
     // PID-aliveness signal that distinguishes a parked-but-live worker from a dead one.
-    expect(SOURCE).toMatch(/orphanAliveCcPids = new Set\(\(detectIdentityCollisions\(\)\.aliveMarkers \|\| \[\]\)\.map/);
+    //
+    // Re-aimed (FR-2, 2nd pass): this pinned the exact assignment to the LOCAL name
+    // orphanAliveCcPids. When the second sweep seam (workingOnCompleted) was guarded, the marker
+    // scan was hoisted into a single shared `sweepAliveCcPids` so the host-local marker files are
+    // not scanned twice per tick — a correct change that broke the name-pinned form. The PROPERTY
+    // this test protects is that the PID set is really CONSTRUCTED from the marker source and
+    // really REACHES the guard; that is now asserted without naming the binding.
+    expect(SOURCE).toMatch(/new Set\(\(detectIdentityCollisions\(\)\.aliveMarkers \|\| \[\]\)\.map/);
+    // …and every shouldHoldClaim call in the release seams passes a named set, never undefined.
+    const calls = SOURCE.match(/shouldHoldClaim\([^)]*\{[^}]*\}\s*\)/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2); // workingOnCompleted + orphanedClaims
+    for (const c of calls) {
+      // Accept BOTH the explicit form ({ aliveCcPids: someSet }) and the ES6 shorthand
+      // ({ aliveCcPids }) used by the pre-existing conflict-eviction call — both pass a real
+      // binding. What must never appear is a literal undefined/null, which is the silent
+      // degradation to heartbeat-only that this test exists to prevent.
+      expect(c).toMatch(/aliveCcPids(\s*:\s*\w+)?\s*[,}]/);
+      expect(c).not.toMatch(/aliveCcPids\s*:\s*(undefined|null)/);
+    }
+  });
+
+  it('FR-2: BOTH named sweep seams consult shouldHoldClaim, not just the orphan branch', () => {
+    // The PRD names two sites: workingOnCompleted and orphanedClaims. Both write the same
+    // fingerprint the observed lapse carried, and guarding only one leaves the invariant
+    // ("a live holder never loses its claim to an automated path") undelivered at the other.
+    const wocIdx = SOURCE.indexOf('const workingOnCompleted =');
+    expect(wocIdx).toBeGreaterThan(0);
+    const wocEnd = SOURCE.indexOf('\n  });', wocIdx);
+    expect(wocEnd).toBeGreaterThan(wocIdx);
+    const woc = SOURCE.slice(wocIdx, wocEnd);
+    expect(woc).toMatch(/shouldHoldClaim\(/);
+    expect(woc).toMatch(/if \(guard\.hold\)/);
+    // The suppressed release must be observable, exactly as the orphan seam's is.
+    expect(woc).toMatch(/HOLDING completed-SD release/);
   });
 
   it('holding a live claim is logged, so a suppressed release is never silent', () => {

--- a/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
+++ b/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
@@ -162,3 +162,51 @@ describe('FR-1/FR-2 — no bare re-throw in the reset gate; reset helper is wrap
     expect(fnBody).toMatch(/WARN_RESET_SKIPPED/);
   });
 });
+
+/**
+ * SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 (TS-8, TS-9) — the orphaned-claim branch used to
+ * release a claim on ABSENCE ALONE, with no liveness check and no check that the absence was
+ * real. Two composing defects:
+ *   TS-9: the SD status lookup discarded `error`. A transient failure yields data=null, an EMPTY
+ *         sdStatusMap, and therefore EVERY claimed session classified orphaned and released in
+ *         one pass. Emptiness is not absence.
+ *   TS-8: even with a correct lookup, the branch never consulted liveness, so a LIVE parked
+ *         worker (heartbeating, PID-alive, silence-armed) lost its claim. shouldHoldClaim was
+ *         imported at the top of the file but only ever used by the conflict-eviction path.
+ * The orphaned-claim filter is inline inside a long non-exported function, so these are
+ * source-invariant tests per this file's established convention — they cannot ship green on
+ * dead code because they assert the guard exists AT the release site.
+ */
+describe('SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001: orphaned-claim release is guarded', () => {
+  it('TS-9: the SD status lookup captures `error` instead of discarding it', () => {
+    expect(SOURCE).toMatch(/const \{ data: claimedSdStatus, error: claimedSdStatusError \} = await supabase/);
+  });
+
+  it('TS-9: a failed/absent SD lookup is treated as untrustworthy, not as "no rows"', () => {
+    expect(SOURCE).toMatch(/const sdLookupTrustworthy = !claimedSdStatusError && Array\.isArray\(claimedSdStatus\)/);
+  });
+
+  it('TS-9: orphaned-claim release is SKIPPED entirely when the lookup is untrustworthy (fail-closed)', () => {
+    expect(SOURCE).toMatch(/const orphanedClaims = \(sdLookupTrustworthy \? classified : \[\]\)/);
+  });
+
+  it('TS-8: the orphaned-claim branch consults shouldHoldClaim before releasing', () => {
+    const branch = SOURCE.slice(SOURCE.indexOf('const orphanedClaims ='), SOURCE.indexOf('const orphanedClaims =') + 900);
+    expect(branch).toMatch(/shouldHoldClaim\(s, \{ aliveCcPids: orphanAliveCcPids \}\)/);
+    expect(branch).toMatch(/if \(guard\.hold\)/);
+  });
+
+  it('TS-8: the guard receives a REAL PID set, not undefined (aliveCcPids is out of scope here)', () => {
+    // Passing undefined would silently degrade shouldHoldClaim to heartbeat-only and lose the
+    // PID-aliveness signal that distinguishes a parked-but-live worker from a dead one.
+    expect(SOURCE).toMatch(/orphanAliveCcPids = new Set\(\(detectIdentityCollisions\(\)\.aliveMarkers \|\| \[\]\)\.map/);
+  });
+
+  it('holding a live claim is logged, so a suppressed release is never silent', () => {
+    expect(SOURCE).toMatch(/HOLDING orphaned-claim release for/);
+  });
+
+  it('shouldHoldClaim is imported before the orphaned-claim site uses it', () => {
+    expect(SOURCE.indexOf("require('../lib/fleet/claim-release-guard.cjs')")).toBeLessThan(SOURCE.indexOf('const orphanedClaims ='));
+  });
+});

--- a/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
+++ b/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
@@ -19,7 +19,24 @@ const src = fs.readFileSync(path.resolve('scripts/stale-session-sweep.cjs'), 'ut
 describe('QF-20260609-456: orphan classifier does not release live QF builders', () => {
   it('the orphan-claim filter excludes held QF claims (!isHeldQfClaim)', () => {
     // The step-3c orphan classifier must AND-in the QF-held guard, not key off sdStatusMap alone.
-    expect(src).toMatch(/orphanedClaims\s*=\s*classified\.filter\(\s*s\s*=>\s*!sdStatusMap\[s\.sd_key\]\s*&&\s*!isHeldQfClaim\(s\)\s*\)/);
+    //
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-1: this pinned the old SINGLE-EXPRESSION form
+    //   orphanedClaims = classified.filter(s => !sdStatusMap[s.sd_key] && !isHeldQfClaim(s))
+    // and broke when the filter became a BLOCK that additionally fails closed on an untrustworthy
+    // SD lookup (the root cause: a discarded Supabase error emptied sdStatusMap, so every claimed
+    // session read as orphaned and was released against LIVE workers) and consults shouldHoldClaim.
+    // The QF-exclusion SEMANTIC this test exists to protect is unchanged — a held QF claim still
+    // short-circuits to `return false` — so the assertion is re-aimed at that semantic.
+    //
+    // NOTE: tests/unit/scripts/sweep-residuals.test.js carries a DUPLICATE of this pin, which was
+    // re-aimed when the block landed; this second copy was missed, so the increment shipped with
+    // this file red. Two independent files pinning one predicate is how that happens.
+    const start = src.indexOf('const orphanedClaims =');
+    expect(start).toBeGreaterThan(0);
+    const orphanBlock = src.slice(start, start + 900);
+    expect(orphanBlock).toMatch(/if \(sdStatusMap\[s\.sd_key\] \|\| isHeldQfClaim\(s\)\) return false;/);
+    // …and the block is still driven by the classified session list.
+    expect(orphanBlock).toMatch(/classified/);
   });
 
   it('isHeldQfClaim treats an EXISTING quick_fix claim as held (not orphaned)', () => {

--- a/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
+++ b/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
@@ -31,12 +31,14 @@ describe('QF-20260609-456: orphan classifier does not release live QF builders',
     // NOTE: tests/unit/scripts/sweep-residuals.test.js carries a DUPLICATE of this pin, which was
     // re-aimed when the block landed; this second copy was missed, so the increment shipped with
     // this file red. Two independent files pinning one predicate is how that happens.
+    // Bound at the END of the filter block, not a fixed +900 offset — re-aiming one pin with the
+    // very idiom that broke the others just relocates the problem.
     const start = src.indexOf('const orphanedClaims =');
     expect(start).toBeGreaterThan(0);
-    const orphanBlock = src.slice(start, start + 900);
+    const end = src.indexOf('\n  });', start);
+    expect(end).toBeGreaterThan(start);
+    const orphanBlock = src.slice(start, end);
     expect(orphanBlock).toMatch(/if \(sdStatusMap\[s\.sd_key\] \|\| isHeldQfClaim\(s\)\) return false;/);
-    // …and the block is still driven by the classified session list.
-    expect(orphanBlock).toMatch(/classified/);
   });
 
   it('isHeldQfClaim treats an EXISTING quick_fix claim as held (not orphaned)', () => {

--- a/tests/unit/scripts/sweep-residuals.test.js
+++ b/tests/unit/scripts/sweep-residuals.test.js
@@ -71,7 +71,13 @@ describe('FR-2: QF-aware orphan path + claim-age grace', () => {
     expect(fr2).toMatch(/ageSec < QF_CLAIM_GRACE_SECONDS/);
   });
   it('excludes held QF claims from orphanedClaims (the real fix)', () => {
-    expect(SRC).toMatch(/const orphanedClaims = classified\.filter\(s => !sdStatusMap\[s\.sd_key\] && !isHeldQfClaim\(s\)\)/);
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 re-pinned this: the filter was rewritten from a
+    // one-line expression to a block that ALSO fail-closes on an untrustworthy SD lookup (TS-9)
+    // and consults shouldHoldClaim (TS-8). The QF-exclusion SEMANTIC this test protects is
+    // unchanged — held QF claims still short-circuit to `return false` — so the assertion is
+    // re-aimed at that semantic rather than at the old single-expression syntax.
+    const orphanBlock = SRC.slice(SRC.indexOf('const orphanedClaims ='), SRC.indexOf('const orphanedClaims =') + 900);
+    expect(orphanBlock).toMatch(/if \(sdStatusMap\[s\.sd_key\] \|\| isHeldQfClaim\(s\)\) return false;/);
   });
   it('grace window is env-tunable via QF_CLAIM_GRACE_SECONDS', () => {
     expect(fr2).toMatch(/process\.env\.QF_CLAIM_GRACE_SECONDS/);

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -93,10 +93,22 @@ describe('SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: CLAIM_FIX fixture-session guard
 
 describe('QF-20260525-211 (B2): workingOnCompleted covers cancelled', () => {
   it('workingOnCompleted filter matches completed OR cancelled', () => {
+    // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-2: re-aimed. This pinned the positive form
+    //   sd.status === 'completed' || sd.status === 'cancelled'
+    // inside a 250-char window. The filter became an early-return BLOCK when the seam gained a
+    // shouldHoldClaim liveness guard (a live holder must not lose its claim to an automated path),
+    // which both inverted the comparison to a negative guard clause and pushed it past the window.
+    // The SEMANTIC this test protects — B2's fix that BOTH terminal statuses are swept, not just
+    // 'completed' — is unchanged, so it is asserted directly and bounded at the block's end.
     const idx = src.indexOf('const workingOnCompleted');
     expect(idx).toBeGreaterThan(0);
-    const block = src.slice(idx, idx + 250);
-    expect(block).toMatch(/sd\.status === ['"]completed['"] \|\| sd\.status === ['"]cancelled['"]/);
+    const end = src.indexOf('\n  });', idx);
+    expect(end).toBeGreaterThan(idx);
+    const block = src.slice(idx, end);
+    expect(block).toMatch(/['"]completed['"]/);
+    expect(block).toMatch(/['"]cancelled['"]/);
+    // Guard against a regression to completed-only, in either the positive or negative form.
+    expect(block).toMatch(/sd\.status (===|!==) ['"]cancelled['"]/);
   });
 
   it('release reason reflects cancellation (SWEEP_SD_CANCELLED) distinctly', () => {


### PR DESCRIPTION
## Summary

A live worker parked on ScheduleWakeup could lose its SD claim, and dispatch would then advertise that SD as available while the worker was still mid-build. Three links, each independently sufficient to cause the incident, plus the ambiguity underneath them.

- **Root cause** (`103260605b3`) — `stale-session-sweep.cjs` **discarded the Supabase error** on its SD-status lookup. A transient failure yielded `data=null`, an EMPTY `sdStatusMap`, and therefore *every* claimed session classified as orphaned and released in one pass, against live workers. Now captures the error, fails closed for the tick, and consults `shouldHoldClaim` with a real alive-PID set.
- **FR-3** (`b32ff1a597f`) — a NULL session `sd_key` counted as drift and evicted a live owner. Now distinguishes an ambiguous NULL from a genuine move to another `sd_key`, which still releases unconditionally (guarding drift wholesale would leak claims and starve the belt).
- **FR-7 + FR-4** (`1d221d512ca`) — extracted `selectAvailableSds` as a pure exported predicate (this hook had **no test file at all**) and cross-checked dispatch against `claude_sessions.sd_key`.
- **FR-5** (`45a38ce9ff1`) — ratified `docs/protocol/claim-ownership-vs-liveness.md`. Three sites each asserted a *universal* precedence rule and contradicted each other; each was right only about its own question. `claiming_session_id` governs OWNERSHIP, `sd_key` governs CURRENTLY BUILDING. Neither is a cache of the other and they diverge legitimately in both directions.
- **Adversarial review fixes** (`529196f2ca4`) — FR-3 was **half-landed**: `multi-session-claim-gate.js` omitted `ownerSdKeyMissing` and so passed handoffs against live owners. Also closed a second discarded-error site in `claim-validity-gate.js` — the same root-cause pattern one function from where it had just been fixed.
- **DEFECT-7** (`a98571215c5`) — `selectAvailableSds` re-derived liveness locally, covering 2 of the 5 signals in the declared read-time SSOT, so a PID-alive or tick-fresh worker stayed invisible and its SD was still advertised (the collision direction). Now delegates to `isSessionAlive`.
- **FR-2 second seam** (`8a530261409`) — PLAN_VERIFICATION found FR-2 half-delivered; its AC names two sweep seams and only one was guarded.

## Known gaps (deliberate, for LEAD)

- **FR-1 was not delivered.** It required instrumenting every release seam to stamp caller + holder liveness at clear time, explicitly *before any guard*. No instrumentation was built. Its objective (identify the writer) was met analytically instead, and both identified seams are now guarded — but the deliverable does not exist.
- **AC-0 is unsatisfiable as written**: it depends on FR-1's stamped fields and a 24h live-fleet window. Needs LEAD adjudication.
- **FR-6 partially met** — no longer phase-dependent in `selectAvailableSds`, but a live worker with BOTH surfaces null in LEAD phase remains unprotected (pre-existing exposure this SD narrowed; needs the backstop at `worker-checkin.cjs:1235`).

## Test plan

- [x] Full `tests/unit` tree: **26367 passing**; 3 pre-existing failures proven identical at clean HEAD by stashing and independently confirmed import-graph-disjoint.
- [x] Every new behavioural assertion verified **RED** against the unfixed code.
- [x] Both directions proven when tightening release rules — genuine drift still releases, expired/runaway silence still releases — so no claim leak.
- [x] Nine source-invariant pins re-aimed at semantics (never bent, never deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)