### PR TITLE
fix(QF-20260725-367): insertCoordinationRow silently drops an invalid message_type - three messages including a safety-critical merge hold were eaten with no error

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -863,7 +863,38 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     q = q.select(select);
     if (single) q = q.single();
   }
-  return await q;
+  const res = await q;
+  // QF-20260725-367: FAIL LOUDLY ON AN ENUM VIOLATION, matching this function's own precedent.
+  // THE ASYMMETRY WAS THE DEFECT, NOT THE TYPO: fed an unknown TARGET this helper already throws
+  // DISPATCH_TARGET_UNKNOWN and names the problem exactly; fed an invalid message_type it returned
+  // id=null, threw nothing, and inserted nothing. Three FENCE_NOTICE sends were silently discarded
+  // — and one of them was the re-send of a PR merge HOLD, i.e. the safety mechanism was itself the
+  // lost payload. The underlying Postgres error is perfectly clear ("invalid input value for enum
+  // coordination_message_type"); this helper was swallowing a real error, not failing to produce one.
+  //
+  // WHY THE MISTAKE IS NATURAL AND WILL RECUR: fence_notice IS legitimate — as a payload.kind (it is
+  // in DIRECTIVE_KINDS) — but NOT as a message_type. The two fields accept different vocabularies and
+  // share plausible names, so only the silence makes it undetectable.
+  //
+  // THE CLASS, named so it is recognisable elsewhere: A FAILURE THAT RETURNS EMPTY-OR-NULL INSTEAD OF
+  // RAISING IS INDISTINGUISHABLE FROM A LEGITIMATE EMPTY RESULT, so it is found only by someone who
+  // independently verifies. This one was caught solely because the coordinator reads rows back after
+  // sending. The same class bit PostgREST selects naming a nonexistent column, where the query errors,
+  // the caller reads data as empty, and a false negative is reported with confidence.
+  //
+  // Deliberately scoped to the enum-violation class rather than throwing on every insert error, so
+  // callers that legitimately inspect {data, error} for transient faults keep today's behaviour.
+  if (res && res.error && /invalid input value for enum/i.test(res.error.message || '')) {
+    const e = new Error(
+      `[dispatch] session_coordination insert REFUSED — ${res.error.message}. `
+      + `(message_type='${row.message_type}'; note that a value like 'fence_notice' is a valid payload.kind but NOT a valid message_type — the two fields take different vocabularies.) `
+      + `Previously this returned id=null and dropped the row silently.`
+    );
+    e.code = 'DISPATCH_INVALID_MESSAGE_TYPE';
+    e.cause = res.error;
+    throw e;
+  }
+  return res;
 }
 
 /**

--- a/tests/unit/dispatch-enum-violation-loud.test.js
+++ b/tests/unit/dispatch-enum-violation-loud.test.js
@@ -1,0 +1,84 @@
+/**
+ * QF-20260725-367 — insertCoordinationRow must FAIL LOUDLY on an enum violation.
+ *
+ * The defect was an ASYMMETRY, not a typo: an unknown TARGET already threw
+ * DISPATCH_TARGET_UNKNOWN and named the problem, while an invalid message_type returned
+ * id=null, threw nothing, and inserted nothing. Three FENCE_NOTICE sends were silently
+ * discarded; one was the re-send of a PR merge HOLD, so the safety mechanism was itself
+ * the lost payload.
+ *
+ * These pin BOTH directions: the enum violation now raises, and every OTHER insert error
+ * keeps today's {data, error} contract so callers inspecting transient faults are unaffected.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../../lib/coordinator/dispatch.cjs');
+
+// Minimal supabase double. target_session='broadcast' is a SENTINEL, which short-circuits
+// assertValidTarget entirely (dispatch.cjs SENTINEL_TARGETS), so the fixture only has to return a
+// canned insert result to exercise the post-insert branch under test.
+function fakeSupabase(insertResult) {
+  const api = {
+    select() { return api; },
+    eq() { return api; },
+    in() { return api; },
+    is() { return api; },
+    gte() { return api; },
+    order() { return api; },
+    limit() { return api; },
+    maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+    single() { return Promise.resolve(insertResult); },
+    insert() {
+      return {
+        select() { return { single: () => Promise.resolve(insertResult) }; },
+        then: (res, rej) => Promise.resolve(insertResult).then(res, rej),
+      };
+    },
+    then: (res, rej) => Promise.resolve({ data: [], error: null }).then(res, rej),
+  };
+  return { rpc: () => Promise.resolve({ data: null, error: null }), from: () => api };
+}
+
+const ENUM_ERR = {
+  data: null,
+  error: { message: 'invalid input value for enum coordination_message_type: "FENCE_NOTICE"', code: '22P02' },
+};
+const TARGET = 'broadcast'; // sentinel — skips the live-session lookup
+
+describe('QF-20260725-367 — enum violation is LOUD, not a silent drop', () => {
+  it('throws DISPATCH_INVALID_MESSAGE_TYPE instead of returning id=null', async () => {
+    const sb = fakeSupabase(ENUM_ERR);
+    const row = { target_session: TARGET, message_type: 'FENCE_NOTICE', payload: { kind: 'fence_notice' } };
+    await expect(insertCoordinationRow(sb, row)).rejects.toMatchObject({ code: 'DISPATCH_INVALID_MESSAGE_TYPE' });
+  });
+
+  it('surfaces the underlying Postgres message (the helper was swallowing a real error)', async () => {
+    const sb = fakeSupabase(ENUM_ERR);
+    const row = { target_session: TARGET, message_type: 'FENCE_NOTICE', payload: {} };
+    await expect(insertCoordinationRow(sb, row)).rejects.toThrow(/invalid input value for enum coordination_message_type/);
+  });
+
+  it('explains the payload.kind vs message_type vocabulary trap that makes this recur', async () => {
+    const sb = fakeSupabase(ENUM_ERR);
+    const row = { target_session: TARGET, message_type: 'FENCE_NOTICE', payload: {} };
+    await expect(insertCoordinationRow(sb, row)).rejects.toThrow(/payload\.kind but NOT a valid message_type/);
+  });
+
+  it('a NON-enum insert error keeps the {data, error} contract (no over-broad throwing)', async () => {
+    const transient = { data: null, error: { message: 'could not connect to server', code: '08006' } };
+    const sb = fakeSupabase(transient);
+    const row = { target_session: TARGET, message_type: 'INFO', payload: {} };
+    const res = await insertCoordinationRow(sb, row);
+    expect(res.error.code).toBe('08006'); // returned, not thrown
+  });
+
+  it('a successful insert is unchanged', async () => {
+    const ok = { data: [{ id: 'row-1' }], error: null };
+    const sb = fakeSupabase(ok);
+    const row = { target_session: TARGET, message_type: 'INFO', payload: {} };
+    const res = await insertCoordinationRow(sb, row);
+    expect(res.error).toBeNull();
+    expect(res.data[0].id).toBe('row-1');
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260725-367

**Type:** bug
**Severity:** critical

### Issue Description
REPORTED BY THE COORDINATOR 2026-07-25 after it caught the loss by reading rows back. THE ASYMMETRY IS THE DEFECT, NOT THE TYPO. insertCoordinationRow refuses an unknown TARGET loudly - fed a reconstructed session UUID it threw DISPATCH_TARGET_UNKNOWN and named the problem exactly. Fed an invalid message_type it returned id=null, threw nothing, and inserted nothing. Bad target equals loud refusal; bad type equals silent drop. One of those behaviours is right and it is not the second. WHAT WAS ACTUALLY LOST: three messages sent with message_type=FENCE_NOTICE, all silently discarded. The underlying database error exists and is perfectly clear when the insert is done directly - invalid input value for enum coordination_message_type: FENCE_NOTICE, valid values INFO, SET_IDENTITY, WORK_ASSIGNMENT, STALE_WARNING, CLAIM_RELEASED - so the helper is swallowing a real error rather than failing to produce one. ONE OF THE THREE WAS THE RE-SEND OF THE PR 6452 MERGE HOLD TO GOLF-2. That hold exists specifically to prevent silent loss on the chairman lane, and it was itself silently lost. That is the severity: not three messages, but the fact that the safety mechanism was the payload. WHY THE NAME IS NOT OBVIOUSLY WRONG, which is why a human will hit this again: fence_notice IS a legitimate value - it is in DIRECTIVE_KINDS - but as a payload.kind, NOT as a message_type. The two fields accept different vocabularies and share plausible names, so the mistake is natural and the silence makes it undetectable. FIX: throw on enum violation exactly as the same helper already throws on unknown target. The loud path already exists in this function; this is making the two failure modes consistent, not inventing error handling. THIS IS AN INSTANCE OF A CLASS WORTH NAMING IN THE FIX COMMENT: a failure that returns empty-or-null instead of raising is indistinguishable from a legitimate empty result, so it is discovered only by someone who independently verifies. The coordinator found this ONLY because it reads rows back after sending. Adam hit the same class three times the same evening on PostgREST selects naming a nonexistent column - the query errors, the caller reads data as empty, and a false negative is reported with confidence. Verification-by-readback is currently the only thing standing between this class of defect and silent data loss.

### Steps to Reproduce
1. Call insertCoordinationRow with message_type='FENCE_NOTICE'. 2. Observe the return value and whether anything throws. 3. Query session_coordination for the row. 4. Repeat with an unknown target session and compare the two behaviours.

### Expected Behavior
An invalid message_type raises loudly and names the invalid value plus the valid enum members, exactly as an unknown target already raises DISPATCH_TARGET_UNKNOWN.

### Actual Behavior
Returns id=null, throws nothing, inserts nothing. The enum error is produced by the database but swallowed by the helper. Three real messages were lost this way, one of them a merge hold.

### Changes
- **Files Changed:** 2
  - lib/coordinator/dispatch.cjs
  - tests/unit/dispatch-enum-violation-loud.test.js
- **LOC:** 117 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol