### PR TITLE
fix(QF-20260725-139): scope CP3 reboot audit queries to THIS run — check 5 was arithmetically closed

### DIFF
--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -103,21 +103,46 @@ export async function defaultRunDrills(plan, deps = {}) {
       .eq('session_id', sid).like('event_type', 'fleet_verb_%');
     return data || [];
   });
+  // QF-20260725-139: SCOPE THE AUDIT POPULATION TO *THIS* RUN.
+  //
+  // Both reboot queries below read a TRAILING-50 window, i.e. recent history, not this invocation.
+  // respawn_bind_audited (reboot-respawn-drill-runner.js) passes iff auditedCount === boundSessionIds
+  // .length, and that window held 4 historical bound respawns from 2026-07-25T00:16-00:17Z against 0
+  // all-time RESPAWN_BIND_VERIFIED rows -- so the check evaluated 0 === 4, and a FLAWLESS run would
+  // have made it 1 === 5. Still red. It was not a threshold a good run could clear; it was
+  // arithmetically closed, and no drill outcome could pass while those rows stayed in the population.
+  //
+  // A predetermined red is worse than a plain bug: arriving in a chairman-watched acceptance run it
+  // reads as "the bind leg failed" and sends someone hunting a defect that does not exist.
+  //
+  // WHY TIME AND NOT sd_key: the run-correlator stamped by QF-20260724-335 defaults to 'CHECKPOINT-3',
+  // which is exactly what those 4 historical rows already carry -- filtering on it excludes NOTHING.
+  // (Recorded because it was tried.) Drill-start time IS the discriminator that separates them; a
+  // run-unique id in the payload would be stronger, but none is emitted today.
+  //
+  // THIS SCOPES THE POPULATION, IT DOES NOT WEAKEN THE CHECK -- the assertion is untouched, and it must
+  // still be able to fail: one bind + its audit row gives 1 === 1 and PASSES; a run whose bind emitter
+  // fails gives 0 === 1 and goes RED, and that red is now informative because it reflects THIS run.
+  const runStartedAt = deps.runStartedAt || new Date().toISOString();
   // QF-20260724-113 (FR-b): reboot-respawn's respawn_events_present check takes a NO-ARG
   // queryEventsFn (unlike U4's session-scoped one, since reboot-respawn creates one replacement
   // session PER slot, not a single target) -- without this the live CLI path always failed
   // respawn_events_present ("no queryEventsFn supplied") even on a genuinely successful respawn.
   const rebootQueryEventsFn = deps.rebootQueryEventsFn || (async () => {
     const { data } = await supabase.from('coordination_events').select('event_type,payload,session_id')
-      .eq('event_type', 'fleet_verb_respawn').order('created_at', { ascending: false }).limit(50);
+      .eq('event_type', 'fleet_verb_respawn').gte('created_at', runStartedAt)
+      .order('created_at', { ascending: false }).limit(50);
     return data || [];
   });
   // QF-20260724-070: wire the durable-bind-audit query so the live drill's respawn_bind_audited check
   // (a real heartbeat proof recorded AT BIND TIME, surviving the session later ghosting) has real
   // evidence to read -- without this the check would fail-closed on every genuine live bind.
+  // QF-20260725-139: scoped to this run for the SAME reason -- an audit row from an earlier run must
+  // never be able to satisfy a bind performed by this one.
   const rebootQueryLifecycleEventsFn = deps.rebootQueryLifecycleEventsFn || (async () => {
     const { data } = await supabase.from('session_lifecycle_events').select('event_type,session_id')
-      .eq('event_type', 'RESPAWN_BIND_VERIFIED').order('created_at', { ascending: false }).limit(50);
+      .eq('event_type', 'RESPAWN_BIND_VERIFIED').gte('created_at', runStartedAt)
+      .order('created_at', { ascending: false }).limit(50);
     return data || [];
   });
 

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -98,9 +98,10 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
 describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', () => {
   it('the default rebootQueryEventsFn queries fleet_verb_respawn events with no required argument', async () => {
     const eq = vi.fn().mockReturnThis();
+    const gte = vi.fn().mockReturnThis();
     const order = vi.fn().mockReturnThis();
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'fleet_verb_respawn' }, { event_type: 'fleet_verb_respawn' }] });
-    const select = vi.fn(() => ({ eq, order, limit }));
+    const select = vi.fn(() => ({ eq, gte, order, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
     const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
     const resolveCanaryTarget = vi.fn(async () => target);
@@ -129,9 +130,10 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
 describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-070)', () => {
   it('threads a default queryLifecycleEventsFn into runRebootRespawnDrill that reads RESPAWN_BIND_VERIFIED rows', async () => {
     const eq = vi.fn().mockReturnThis();
+    const gte = vi.fn().mockReturnThis();
     const order = vi.fn().mockReturnThis();
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-1' }] });
-    const select = vi.fn(() => ({ eq, order, limit }));
+    const select = vi.fn(() => ({ eq, gte, order, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
     const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
     const resolveCanaryTarget = vi.fn(async () => target);
@@ -151,6 +153,102 @@ describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-
     expect(select).toHaveBeenCalledWith('event_type,session_id');
     expect(eq).toHaveBeenCalledWith('event_type', 'RESPAWN_BIND_VERIFIED');
     expect(res.reboot.pass).toBe(true);
+  });
+});
+
+// QF-20260725-139: check 5 (respawn_bind_audited) was ARITHMETICALLY CLOSED, not merely failing.
+// boundSessionIds came from a TRAILING-50 window holding 4 historical bound respawns (2026-07-25T00:16
+// -00:17Z) while RESPAWN_BIND_VERIFIED was 0 all-time => 0 === 4, and a flawless run only reached
+// 1 === 5. No drill outcome could pass. These tests pin the POPULATION, not the assertion.
+//
+// Deliberately a filtering fake rather than `expect(gte).toHaveBeenCalled()`: asserting the call is a
+// proxy: it would stay green if the bound value were wrong, or if a later edit passed a value that
+// excluded nothing (exactly the sd_key='CHECKPOINT-3' no-op that was already tried and rejected).
+// Filtering real fixture rows measures the thing that actually matters -- what survives the query.
+describe('defaultRunDrills — reboot audit queries are scoped to THIS run (QF-20260725-139)', () => {
+  const RUN_STARTED_AT = '2026-07-25T23:40:00.000Z';
+  // The 4 real historical rows that closed the check, plus one respawn from this run.
+  const HISTORICAL = [
+    { event_type: 'fleet_verb_respawn', session_id: '283ca94a', created_at: '2026-07-25T00:17:17.527Z', payload: { outcome: 'ok' } },
+    { event_type: 'fleet_verb_respawn', session_id: '283ca94a', created_at: '2026-07-25T00:17:17.459Z', payload: { outcome: 'ok' } },
+    { event_type: 'fleet_verb_respawn', session_id: '8dc4f150', created_at: '2026-07-25T00:16:58.028Z', payload: { outcome: 'ok' } },
+    { event_type: 'fleet_verb_respawn', session_id: '8dc4f150', created_at: '2026-07-25T00:16:57.964Z', payload: { outcome: 'ok' } },
+  ];
+  const THIS_RUN = { event_type: 'fleet_verb_respawn', session_id: 'new-sess', created_at: '2026-07-25T23:40:05.000Z', payload: { outcome: 'ok' } };
+
+  /** Minimal PostgREST-ish fake that HONOURS eq/gte instead of ignoring them. */
+  function filteringSupabase(tables) {
+    const make = (table) => {
+      let rows = (tables[table] || []).slice();
+      const api = {
+        select: () => api,
+        eq: (col, val) => { rows = rows.filter((r) => r[col] === val); return api; },
+        gte: (col, val) => { rows = rows.filter((r) => r[col] >= val); return api; },
+        like: () => api,
+        order: () => api,
+        limit: () => Promise.resolve({ data: rows }),
+        then: (res) => res({ data: rows }),
+      };
+      return api;
+    };
+    return { from: vi.fn((t) => make(t)) };
+  }
+
+  function harness(tables) {
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    return {
+      supabase: filteringSupabase(tables),
+      runStartedAt: RUN_STARTED_AT,
+      resolveCanaryTarget: vi.fn(async () => target),
+      canaryRestart: vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' })),
+      canaryRelaunchUnderProfile: vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' })),
+      runU4Drill: vi.fn(async () => ({ pass: true })),
+    };
+  }
+  const PLAN = { canaryProfile: 'canary', cwd: 'R:\\r', legs: [] };
+
+  it('REGRESSION: the 4 historical bound respawns are EXCLUDED — only this run\'s respawn survives', async () => {
+    let seen = null;
+    const deps = {
+      ...harness({ coordination_events: [...HISTORICAL, THIS_RUN] }),
+      runRebootRespawnDrill: vi.fn(async (args) => { seen = await args.queryEventsFn(); return { pass: true, checks: [] }; }),
+    };
+    await defaultRunDrills(PLAN, deps);
+    // Pre-fix this returned all 5 and check 5 evaluated 1 === 5. Never passable.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].session_id).toBe('new-sess');
+  });
+
+  it('REGRESSION: an audit row from an EARLIER run cannot satisfy a bind performed by this one', async () => {
+    let seen = null;
+    const deps = {
+      ...harness({
+        session_lifecycle_events: [
+          { event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'stale', created_at: '2026-07-25T00:17:00.000Z' },
+          { event_type: 'RESPAWN_BIND_VERIFIED', session_id: 'new-sess', created_at: '2026-07-25T23:40:06.000Z' },
+        ],
+      }),
+      runRebootRespawnDrill: vi.fn(async (args) => { seen = await args.queryLifecycleEventsFn(); return { pass: true, checks: [] }; }),
+    };
+    await defaultRunDrills(PLAN, deps);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].session_id).toBe('new-sess');
+  });
+
+  it('the scoped population still lets check 5 GO RED — scoping is not weakening', async () => {
+    // This run binds a session but its audit row never lands: 0 === 1 => RED, and that red is
+    // informative because it reflects THIS run. If scoping had weakened the check, this would pass.
+    const deps = {
+      ...harness({ coordination_events: [...HISTORICAL, THIS_RUN], session_lifecycle_events: [] }),
+      runRebootRespawnDrill: vi.fn(async (args) => {
+        const { runRebootRespawnDrill: real } = await import('../../../lib/fleet/reboot-respawn-drill-runner.js');
+        return real({ ...args, live: false });
+      }),
+    };
+    const res = await defaultRunDrills(PLAN, deps);
+    const check5 = (res.reboot.checks || []).find((c) => c.name === 'respawn_bind_audited');
+    expect(check5.pass).toBe(false);
+    expect(check5.detail).toContain('0/1');
   });
 });
 


### PR DESCRIPTION
## QF-20260725-139 — CP3 check 5 was arithmetically closed, not merely failing

`respawn_bind_audited` passes iff `auditedCount === boundSessionIds.length`. Its population came from a **trailing-50 window** — recent history, not this invocation.

Measured live before changing anything:
```
trailing-50 fleet_verb_respawn rows: 50
  outcome=ok AND session_id!=null (boundSessionIds): 4   <- 2026-07-25T00:16-00:17Z, 2 distinct sessions
RESPAWN_BIND_VERIFIED rows (all-time): 0
=> check 5 evaluates: 0 === 4
```
A **flawless** run only reaches `1 === 5`. Still red. There was no drill outcome that could pass while those rows stayed in the population.

That matters beyond correctness: a predetermined red arriving in a chairman-watched acceptance run reads as *"the bind leg failed"* and sends someone hunting a defect that does not exist.

### Fix
Both reboot audit queries in `start-cp3-drills.js` are now bounded by drill-start time (`runStartedAt`, injectable for tests).

**Why time and not `sd_key`:** the QF-20260724-335 run-correlator defaults to `'CHECKPOINT-3'`, which is exactly what the 4 historical rows already carry — `.eq('sd_key','CHECKPOINT-3')` excludes **nothing**. Verified at source, and recorded in-code so it is not retried. A run-unique id in the payload would be stronger, but none is emitted today (checked: payload is `{at, live, role, verb, outcome, callsign, resume_uuid}`).

The lifecycle query is scoped for the same reason — an audit row from an earlier run must never satisfy a bind performed by this one.

### This scopes the POPULATION; it does not weaken the check
The assertion in `reboot-respawn-drill-runner.js` is **untouched**. The pre-existing runner tests covering both directions (pass at `1===1`, fail at `0===1`) still pass unmodified, and a new test pins that the check can still go red after scoping: a run that binds a session whose audit row never lands gives `0 === 1` → **RED**, and that red is now informative because it reflects *this* run.

### The tests actually bite
Reverting the two `.gte` calls fails **3** of the new tests — the third reproduces the defect verbatim:
```
expected '0/5 bound session(s) have a durable R…' to contain '0/1'
```
That `0/5` *is* the arithmetically-closed state.

Pins use a **filtering fake client** rather than `expect(gte).toHaveBeenCalled()`. Asserting the call is a proxy: it stays green if the bound value is wrong or excludes nothing — which is precisely the `sd_key` no-op failure mode. Filtering real fixture rows (the 4 actual historical rows + one from this run) measures what survives the query.

Full fleet suite: **84 files / 1013 tests pass**.
