### PR TITLE
feat(SD-EHG-IDEATION-PIPELINE-SEAMS-001): nursery selection unification + writer/lifecycle fixes (FR-1,2,3-AC2,4 + COND-2)

### DIFF
--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -76,6 +76,22 @@ export const TEST_FIXTURE_NAME_PREFIXES = Object.freeze([
   'TEST-HARNESS-',
   'parity-test-',
   'TS-fixture-',
+  // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3. Six further fixture families were leaking
+  // into the operational WIP count. Established by ENUMERATING all 46 counted rows, not
+  // by sampling: 44 are gate/pipeline fixtures left behind by realdb suites, and exactly
+  // TWO are real ventures (ApexNiche AI, Image Alt Text Generator).
+  //
+  // These prefixes make the count reflect the real portfolio. They deliberately do NOT
+  // make the count small enough to clear the gate — the honest floor is 2 against a limit
+  // of 2, and the gate compares with >=, so it still refuses. That residual is a PORTFOLIO
+  // decision (raise capacity, or complete/cancel a venture), not something to engineer
+  // around by widening this list. Any prefix that would match a real venture is a defect.
+  'artifact-gate-test-',
+  'HCGate-RealDB-',
+  'ProductReviewGate-RealDB-',
+  'StageArtifactGate-RealDB-',
+  'Pipeline-Test-',
+  'Test Venture for ',
 ]);
 
 /**

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -25,6 +25,7 @@ import { parseRevenuePotential } from '../utils/parse-revenue.js';
 import { computeStrategicFit } from '../utils/strategic-fit.js';
 import { resolveActivePosture } from '../profile-service.js';
 import { loadCapabilityEnvelope, checkTraversability, parkFailedCandidate } from '../traversability-gate.js';
+import { applyPendingNurseryPredicate, NURSERY_PENDING_COLUMNS } from '../venture-nursery.js';
 import { resolveInputGrades, weakestLink, gradeDistribution, gradeAtLeast, E0_NEUTRAL } from '../evidence-grading.js';
 import { applyAntiGoalScreen } from '../anti-goal-filter.js';
 import { stalenessStamp, NO_DATA_MARKER } from '../data-pollers/staleness.js';
@@ -642,12 +643,15 @@ async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
 
   // Load parked ventures from nursery — LIVE schema (SD-LEO-INFRA-STAGE0-NURSERY-PARK-PATH-001
   // closed the CH-1 column drift: parked = not yet promoted; the rich brief rides source_ref).
-  const { data: nurseryItems, error } = await supabase
-    .from('venture_nursery')
-    .select('id, name, description, maturity_level, current_score, trigger_conditions, source_ref, next_evaluation_at, created_at')
-    .is('promoted_to_venture_id', null)
-    .order('created_at', { ascending: true })
-    .limit(candidateCount * 2);
+  // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: route through the AUTHORITATIVE predicate.
+  // This selection previously read next_evaluation_at into the column list but never
+  // compared it, and ordered created_at ASC — so the highest-scoring candidates (five
+  // rows tie at 90) were never prioritised and the schedule column was decorative here
+  // while checkNurseryTriggers treated the same column as a hard filter.
+  const { data: nurseryItems, error } = await applyPendingNurseryPredicate(
+    supabase.from('venture_nursery').select(NURSERY_PENDING_COLUMNS),
+    { now: deps.now }
+  ).limit(candidateCount * 2);
 
   if (error) {
     throw new Error(`Failed to load nursery items: ${error.message}`);

--- a/lib/eva/stage-zero/traversability-gate.js
+++ b/lib/eva/stage-zero/traversability-gate.js
@@ -173,6 +173,24 @@ export async function parkFailedCandidate(failure, context = {}, deps = {}) {
       maturity_level: 'seed',
       trigger_conditions: failure.resurfacing_conditions,
       current_score: Number.isFinite(c.composite_score) ? c.composite_score : null,
+      // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-2: the writer asymmetry that produced
+      // 16-of-16 NULL. parkVenture set this column; parkFailedCandidate did not, and
+      // parkFailedCandidate wrote every live row.
+      //
+      // The value is the PARK INSTANT, which makes the row eligible immediately. It is
+      // deliberately NOT parkVenture's calculateNextReview('90d'), because the selector
+      // admits `next_evaluation_at IS NULL OR <= now()` — a now+90d write would make the
+      // row INVISIBLE for 90 days. Today's 15 rows are only visible because the column is
+      // NULL, so naively "making both writers agree" would have emptied the selector and
+      // caused the very outage this SD exists to fix.
+      //
+      // Immediate eligibility is also the honest semantic: a candidate that just failed
+      // the capability envelope should be reconsidered as soon as anything is evaluated,
+      // not deferred by a quarter for no stated reason.
+      //
+      // evaluation_interval_days is intentionally NOT written: the column DEFAULT is 30
+      // and all 16 live rows already read 30, so writing it changes nothing observable.
+      next_evaluation_at: new Date(deps.now || Date.now()).toISOString(),
       source_type: 'discovery_mode',
       source_ref: {
         gate: 'traversability',

--- a/lib/eva/stage-zero/venture-nursery.js
+++ b/lib/eva/stage-zero/venture-nursery.js
@@ -278,6 +278,55 @@ export async function recordSynthesisFeedback(params, deps = {}) {
   return data;
 }
 
+// ── The authoritative nursery selection predicate ────────────────────────────
+//
+// SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1. Before this, THREE selectors read
+// venture_nursery and disagreed, which is why the nursery never promoted anything:
+//
+//   1. v_nursery_pending_evaluation — correct semantics, ordered by score, and with
+//      ZERO consumers anywhere in the repo. A correct-but-dead third opinion.
+//   2. checkNurseryTriggers — filtered `nextReview && nextReview <= now`, so the `&&`
+//      EXCLUDED NULL. Against live data that is 16/16 NULL it returned empty
+//      PERMANENTLY, which is the "empty selection forever" the SD describes.
+//   3. runNurseryReeval — the only WIRED reader; it selected next_evaluation_at but
+//      never compared it, and ordered created_at ASC, so the score-90 candidates were
+//      never prioritised.
+//
+// Both readers now route through this one predicate. Keeping it a query DECORATOR
+// rather than a fetch function lets the paginated sweep and the limited re-eval share
+// identical semantics without either owning the other's fetch strategy.
+//
+// NULL is ADMITTED deliberately: a freshly parked candidate has never been scheduled,
+// and "never scheduled" must mean "eligible now", not "invisible forever".
+
+/** Columns every nursery reader needs. Kept in one place so the two callers cannot drift. */
+export const NURSERY_PENDING_COLUMNS =
+  'id, name, description, maturity_level, current_score, trigger_conditions, source_ref, '
+  + 'next_evaluation_at, last_evaluated_at, promoted_to_venture_id, created_at';
+
+/**
+ * Apply the authoritative pending-evaluation predicate and ordering to a query.
+ *
+ * Ordering is score-first with a STABLE tiebreak. Score alone is not deterministic:
+ * five live rows tie at current_score 90, so `ORDER BY current_score DESC` on its own
+ * leaves "the top candidate" up to the planner. created_at then id makes it repeatable.
+ *
+ * @param {object} query a supabase query builder over venture_nursery
+ * @param {object} [opts]
+ * @param {Date|string} [opts.now] injectable clock, for tests
+ * @returns {object} the decorated query
+ */
+export function applyPendingNurseryPredicate(query, opts = {}) {
+  const nowIso = new Date(opts.now || Date.now()).toISOString();
+  return query
+    .is('promoted_to_venture_id', null)
+    // NULL means never scheduled => eligible now. The old `&&` guard dropped these.
+    .or(`next_evaluation_at.is.null,next_evaluation_at.lte.${nowIso}`)
+    .order('current_score', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+}
+
 /**
  * Check nursery items for trigger condition readiness.
  *
@@ -293,42 +342,39 @@ export async function checkNurseryTriggers(deps = {}) {
 
   logger.log('   Checking nursery triggers...');
 
-  // Fetch parked items (live schema: parked = not yet promoted; schedule lives in
-  // next_evaluation_at; trigger_conditions is a first-class column).
-  // Paginated (FR-6 batch 7): the trigger sweep must see every parked item.
+  // Fetch parked items through the AUTHORITATIVE predicate (FR-1), so eligibility is
+  // decided in one place. Paginated (FR-6 batch 7): the trigger sweep must see every
+  // eligible item.
+  //
+  // The filtering moved INTO the query. It used to happen in JS afterwards, behind a
+  // TRUTHINESS check on next_evaluation_at, which silently excluded every NULL-dated
+  // row — all 16 live rows — so this returned empty permanently while looking correct.
   let items;
   try {
-    items = await fetchAllPaginated(() => supabase
-      .from('venture_nursery')
-      .select('id, name, trigger_conditions, next_evaluation_at, promoted_to_venture_id, source_ref')
-      .is('promoted_to_venture_id', null)
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true }));
+    items = await fetchAllPaginated(() => applyPendingNurseryPredicate(
+      supabase.from('venture_nursery').select(NURSERY_PENDING_COLUMNS),
+      { now: deps.now }
+    ));
   } catch (e) {
     throw new Error(`Failed to fetch nursery items: ${e.message}`);
   }
   if (!items || items.length === 0) {
-    logger.log('   No parked items in nursery');
+    logger.log('   No items pending evaluation in nursery');
     return [];
   }
 
-  const now = new Date();
-  const readyForReview = [];
+  const readyForReview = items.map((item) => ({
+    id: item.id,
+    name: item.name,
+    // A NULL schedule is not a scheduled review — it is a candidate that was never
+    // scheduled at all. Reporting the distinction keeps the two causes separable.
+    reason: item.next_evaluation_at ? 'scheduled_review' : 'never_scheduled',
+    next_review_date: item.next_evaluation_at,
+    current_score: item.current_score,
+    trigger_conditions: item.trigger_conditions || [],
+  }));
 
-  for (const item of items) {
-    const nextReview = item.next_evaluation_at;
-    if (nextReview && new Date(nextReview) <= now) {
-      readyForReview.push({
-        id: item.id,
-        name: item.name,
-        reason: 'scheduled_review',
-        next_review_date: nextReview,
-        trigger_conditions: item.trigger_conditions || [],
-      });
-    }
-  }
-
-  logger.log(`   ${readyForReview.length} of ${items.length} item(s) ready for review`);
+  logger.log(`   ${readyForReview.length} item(s) pending evaluation`);
   return readyForReview;
 }
 

--- a/lib/eva/stage-zero/venture-nursery.js
+++ b/lib/eva/stage-zero/venture-nursery.js
@@ -278,6 +278,77 @@ export async function recordSynthesisFeedback(params, deps = {}) {
   return data;
 }
 
+/**
+ * Trigger types nursery_evaluation_log accepts.
+ *
+ * Mirrors the live CHECK constraint nursery_evaluation_log_trigger_type_check EXACTLY.
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-4 / TR-2: this list is a mirror, never a source
+ * of truth — extending it here without the corresponding chairman-gated DDL would produce
+ * inserts the database rejects. 'nursery_reeval' is NOT a member and must not be invented;
+ * 'periodic_review' covers a scheduled sweep and 'manual' covers a hand-run evaluation.
+ */
+export const NURSERY_EVAL_TRIGGER_TYPES = Object.freeze([
+  'capability_added', 'market_shift', 'portfolio_gap', 'related_outcome', 'periodic_review', 'manual',
+]);
+
+/**
+ * Record an evaluation against a nursery row.
+ *
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-4. nursery_evaluation_log was created by the
+ * 20260209 schema and has had ZERO writers and ZERO rows ever since — the audit table for
+ * the nursery was built and never wired. That is why "did anything evaluate this idea?"
+ * has been unanswerable, and it is why an empty log is a trustworthy witness: any row in
+ * it is attributable to the run that wrote it.
+ *
+ * triggerType is a REQUIRED PARAMETER rather than a constant. Hardcoding 'periodic_review'
+ * would label a hand-run demonstration as a periodic firing that never happened, which is
+ * precisely the kind of quiet mislabelling this SD exists to remove.
+ *
+ * @param {object} params
+ * @param {string} params.nurseryId FK to venture_nursery.id
+ * @param {string} params.triggerType one of NURSERY_EVAL_TRIGGER_TYPES
+ * @param {object} [params.triggerDetails]
+ * @param {number} [params.previousScore]
+ * @param {number} [params.newScore]
+ * @param {string} [params.notes]
+ * @param {string} [params.evaluatedBy]
+ * @param {object} deps
+ * @returns {Promise<object>} the inserted row
+ */
+export async function recordNurseryEvaluation(params, deps = {}) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+
+  const { nurseryId, triggerType, triggerDetails, previousScore, newScore, notes, evaluatedBy } = params || {};
+  if (!nurseryId) throw new Error('nurseryId is required');
+  // Fail in JS with a readable message rather than as an opaque CHECK violation, and name
+  // the legal set so the caller does not have to go read the constraint.
+  if (!NURSERY_EVAL_TRIGGER_TYPES.includes(triggerType)) {
+    throw new Error(
+      `triggerType must be one of ${NURSERY_EVAL_TRIGGER_TYPES.join(', ')} (got: ${triggerType}). `
+      + 'nursery_reeval is NOT a valid member — use periodic_review for a scheduled sweep or manual for a hand-run evaluation.'
+    );
+  }
+
+  const row = {
+    nursery_id: nurseryId,
+    trigger_type: triggerType,
+    trigger_details: triggerDetails || null,
+    previous_score: Number.isFinite(previousScore) ? previousScore : null,
+    new_score: Number.isFinite(newScore) ? newScore : null,
+    evaluation_notes: notes || null,
+  };
+  // evaluated_by is left to the column DEFAULT ('stage0_engine') unless a caller names
+  // itself, so the trail records an actual actor rather than a fabricated one.
+  if (evaluatedBy) row.evaluated_by = evaluatedBy;
+
+  const { data, error } = await supabase.from('nursery_evaluation_log').insert(row).select().single();
+  if (error) throw new Error(`Failed to record nursery evaluation for ${nurseryId}: ${error.message}`);
+
+  logger.log(`   Nursery evaluation recorded (${triggerType}) for ${nurseryId}`);
+  return data;
+}
+
 // ── The authoritative nursery selection predicate ────────────────────────────
 //
 // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1. Before this, THREE selectors read

--- a/lib/eva/stage-zero/venture-nursery.js
+++ b/lib/eva/stage-zero/venture-nursery.js
@@ -345,8 +345,75 @@ export async function recordNurseryEvaluation(params, deps = {}) {
   const { data, error } = await supabase.from('nursery_evaluation_log').insert(row).select().single();
   if (error) throw new Error(`Failed to record nursery evaluation for ${nurseryId}: ${error.message}`);
 
+  // ADVANCE THE SCHEDULE. Coupled to the log write on purpose (see advanceNurserySchedule):
+  // a caller that records an evaluation but forgets to reschedule is the exact defect this
+  // closes, so it must not be opt-in. Fail-soft — an evaluation that genuinely happened is
+  // still a true fact worth keeping even if the reschedule write fails.
+  if (params.skipAdvance !== true) {
+    try {
+      await advanceNurserySchedule(nurseryId, { supabase, logger, now: deps.now });
+    } catch (e) {
+      logger.warn?.(`   Evaluation recorded but reschedule failed for ${nurseryId}: ${e.message}`);
+    }
+  }
+
   logger.log(`   Nursery evaluation recorded (${triggerType}) for ${nurseryId}`);
   return data;
+}
+
+/**
+ * Move a nursery row's next_evaluation_at forward after it has been evaluated.
+ *
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001, adversarial-review condition COND-2. Adversarial
+ * review found this by grepping the whole write surface for an ABSENCE: across lib/,
+ * scripts/, src/ and api/ there is exactly ONE write to next_evaluation_at (the INSERT in
+ * parkVenture) and NO UPDATE of it anywhere. The column is WRITE-ONCE.
+ *
+ * That is harmless while nothing consumes the predicate on a schedule — which is true
+ * today — but it becomes a live defect the moment a scheduler exists: every row eligible
+ * once is eligible FOREVER, so each sweep re-selects and re-enqueues the same rows, and
+ * each re-enqueue drives a ~16-LLM-call chain. FR-2 (write an eligible date) and FR-6
+ * (wire a sweep) are each individually correct and JOINTLY broken without this.
+ *
+ * It is invisible to any single-run test; only a second sweep reveals it.
+ *
+ * evaluation_interval_days finally does something here — it has been decorative, sitting
+ * at its DEFAULT of 30 on all 16 live rows with nothing ever reading it.
+ *
+ * @param {string} nurseryId
+ * @param {object} deps
+ * @returns {Promise<{next_evaluation_at: string, interval_days: number}>}
+ */
+export async function advanceNurserySchedule(nurseryId, deps = {}) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+  if (!nurseryId) throw new Error('nurseryId is required');
+
+  const { data: row, error: readErr } = await supabase
+    .from('venture_nursery')
+    .select('evaluation_interval_days')
+    .eq('id', nurseryId)
+    .single();
+  if (readErr) throw new Error(`Failed to read nursery row ${nurseryId}: ${readErr.message}`);
+
+  // Fall back to the column DEFAULT rather than 0: a zero interval would reschedule to
+  // now and reproduce the permanent-eligibility bug this function exists to close.
+  const days = Number.isFinite(row?.evaluation_interval_days) && row.evaluation_interval_days > 0
+    ? row.evaluation_interval_days
+    : 30;
+
+  const now = new Date(deps.now || Date.now());
+  const next = new Date(now.getTime() + days * 86400000).toISOString();
+  const evaluatedAt = now.toISOString();
+
+  const { error: updErr } = await supabase
+    .from('venture_nursery')
+    .update({ next_evaluation_at: next, last_evaluated_at: evaluatedAt })
+    .eq('id', nurseryId);
+  if (updErr) throw new Error(`Failed to advance schedule for ${nurseryId}: ${updErr.message}`);
+
+  logger.log(`   Nursery schedule advanced ${days}d for ${nurseryId} → ${next}`);
+  return { next_evaluation_at: next, interval_days: days };
 }
 
 // ── The authoritative nursery selection predicate ────────────────────────────

--- a/scripts/one-off/_validation-write-result-sd-ehg-ideation-pipeline-seams-001.mjs
+++ b/scripts/one-off/_validation-write-result-sd-ehg-ideation-pipeline-seams-001.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * Write VALIDATION (Principal Systems Analyst) LEAD-phase verdict for
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001 ahead of its LEAD-TO-PLAN handoff.
+ *
+ * GATE 1 (LEAD Pre-Approval): independent verification of EVERY numeric claim in
+ * the SD against the LIVE database (named columns, queries recorded), duplicate /
+ * existing-infrastructure check across BOTH repos, backlog validation, and an
+ * adversarial attempt to refute the operator's BREAK-3 correction.
+ *
+ * Uses the canonical repo-evidence pattern (lib/sub-agents/resolve-repo.js
+ * applySubAgentRepoVerdict) + canonical storage (lib/sub-agent-executor/
+ * results-storage.js storeSubAgentResults) rather than a hand-rolled INSERT,
+ * per CLAUDE.md prologue rule 11. There are NO top-level repo_path/local_path
+ * columns — repo evidence lives at metadata.repo_path + executed_from_cwd.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '70f6fc06-e641-4a9b-9273-6a33665f49f0';
+const SD_KEY = 'SD-EHG-IDEATION-PIPELINE-SEAMS-001';
+
+const findings = [
+  {
+    id: 'V1-break3-numeric-claims-CONFIRMED',
+    severity: 'INFO',
+    summary: 'ALL BREAK-3 aggregate numbers CONFIRMED against live venture_nursery. Query: SELECT count(*), count(*) FILTER (WHERE next_evaluation_at IS NULL), count(*) FILTER (WHERE last_evaluated_at IS NULL), count(*) FILTER (WHERE promoted_to_venture_id IS NOT NULL), count(*) FILTER (WHERE source_type=\'discovery_mode\'), count(*) FILTER (WHERE maturity_level=\'seed\'), min/max(created_at) FROM venture_nursery. Result: total=16; next_evaluation_at IS NULL = 16/16 (CONFIRMED, including the promoted row); last_evaluated_at IS NULL = 15/16 (CONFIRMED "15 of 16 never evaluated"); promoted_to_venture_id NOT NULL = 1 (CONFIRMED "one promotion"); source_type=discovery_mode = 16/16 and distinct source_type = 1 (CONFIRMED); maturity_level=seed = 16/16 (CONFIRMED); created_at spread = 113.6 SECONDS (2026-07-10T19:09:10.784Z -> 19:11:04.388Z), age 15.06 days (CONFIRMED "one batch, exactly 15.0 days ago"). NOTE the SD used a `status` column that does NOT exist on venture_nursery — the live table has no status; parked/promoted is derived from promoted_to_venture_id (see venture-nursery.js:362 statusOf()). The SD\'s underlying counts are nonetheless correct.'
+  },
+  {
+    id: 'V2-break3-score-enumeration-PARTIALLY-CONFIRMED-misleading',
+    severity: 'MEDIUM',
+    summary: 'SD claim "Unevaluated scores include 90, 74, 65, 65" is TECHNICALLY TRUE but MATERIALLY MISLEADING — it omits the majority of the inventory. Query: SELECT current_score, count(*) FROM venture_nursery WHERE last_evaluated_at IS NULL GROUP BY 1. Actual unevaluated distribution (n=15): 90 x4, 80 x5, 74 x1, 70 x3, 65 x2. The SD enumerates 4 values and silently drops the five 80s and three 70s, understating the parked inventory by more than half. Anyone sizing the opportunity from the SD text will undercount. CORRECTION FOR PRD: 15 unevaluated ideas scoring 65-90, with 9 of 15 at >=80.'
+  },
+  {
+    id: 'V3-the-90-scorer-is-AMBIGUOUS-and-collides-with-a-live-revenue-venture',
+    severity: 'CRITICAL',
+    summary: 'The SD\'s first deliverable says "Use the 90-scorer" (definite article, singular). THERE ARE FIVE ROWS AT current_score=90.00. Query: SELECT name, current_score, promoted_to_venture_id, last_evaluated_at FROM venture_nursery ORDER BY current_score DESC NULLS LAST. The five: Chronos Concierge, Social Media Post Rephraser, HealScore Predict, Headline Transformer (all unpromoted, never evaluated) and **Image Alt Text Generator** — which is the ONE ALREADY-PROMOTED ROW (promoted_to_venture_id=50763b6a-1fad-4e1e-b2fc-296a1d66ebf9, promoted_at=2026-07-12T20:43:11Z, last_evaluated_at=2026-07-12T11:03:57Z) and is the live first-revenue venture. The SD\'s own statement "the 90 has sat untouched the entire time" is therefore FALSE for one of the five 90s. Because v_nursery_pending_evaluation ORDERs BY current_score DESC NULLS LAST with no tiebreaker, "the top of the list" is NON-DETERMINISTIC across four tied rows. An EXEC agent resolving "the 90-scorer" naively risks selecting the already-promoted revenue venture or a different row on each run. THE PRD MUST NAME THE TARGET ROW BY UUID, not by score.'
+  },
+  {
+    id: 'V4-break3-EMPTY-SELECTION-FOREVER-premise-is-TRUE-of-one-path-and-VACUOUS',
+    severity: 'CRITICAL',
+    summary: 'ADVERSARIAL REFUTATION ATTEMPT ON THE OPERATOR\'S CORRECTION — the operator asked whether any evaluator queries venture_nursery DIRECTLY with a next_evaluation_at < now() predicate (not the view). ANSWER: YES, ONE EXISTS. lib/eva/stage-zero/venture-nursery.js:289-333 checkNurseryTriggers() selects FROM venture_nursery (direct table, not the view) with .is(\'promoted_to_venture_id\', null), then filters IN JS at line 320: `if (nextReview && new Date(nextReview) <= now)`. The `nextReview &&` guard EXCLUDES NULL. With next_evaluation_at NULL on 16/16, checkNurseryTriggers() returns [] PERMANENTLY. The SD\'s "EMPTY SELECTION FOREVER" is LITERALLY TRUE of this function. HOWEVER the refutation is VACUOUS: checkNurseryTriggers has NO production caller. Grep across lib/ scripts/ src/ api/ server/ tests/ .github/ shows only the barrel re-export at lib/eva/stage-zero/index.js:55 and unit tests (tests/unit/eva/stage-zero/venture-nursery.test.js:319-344). It is never invoked by any scheduler, route, cron, or CLI. So the SD is right about the mechanism and wrong about the consequence: nothing is blocked by it TODAY because the function never runs. It is a LATENT trap, not the active cause.'
+  },
+  {
+    id: 'V5-the-ACTUAL-wired-traversal-ignores-next_evaluation_at-entirely',
+    severity: 'CRITICAL',
+    summary: 'THE REAL Nursery->Stage-0 TRAVERSAL PATH IS runNurseryReeval() at lib/eva/stage-zero/paths/discovery-mode.js:630-752. Its query (lines 645-650) is: .from(\'venture_nursery\').select(\'id, name, description, maturity_level, current_score, trigger_conditions, source_ref, next_evaluation_at, created_at\').is(\'promoted_to_venture_id\', null).order(\'created_at\', {ascending:true}).limit(candidateCount*2). It SELECTS next_evaluation_at into the column list but NEVER FILTERS OR COMPARES IT — no .lt(), no .lte(), no JS date comparison anywhere in the function. Therefore NULL scheduling does NOT block the wired path: runNurseryReeval would return min(15, candidateCount*2) rows RIGHT NOW. Two further consequences the SD misses: (a) it orders created_at ASCENDING (oldest-first), NOT score-descending — so the 90-scorers are NOT prioritized; the oldest row is "AI-Powered Niche Content Generator" (score 74). (b) THREE selection layers now disagree on the same table: the VIEW is NULL-tolerant (returns 15), checkNurseryTriggers is NULL-intolerant (returns 0 forever), runNurseryReeval ignores the column (returns 15, wrong order). This predicate schism is itself a first-class defect and must be unified in the PRD.'
+  },
+  {
+    id: 'V6-TRUE-ROOT-CAUSE-of-BREAK-3-nursery_reeval-has-never-been-REQUESTED',
+    severity: 'CRITICAL',
+    summary: 'GROUND-TRUTH ROOT CAUSE, measured not inferred. The chain is: Chairman UI (ehg/src/components/chairman-v3/opportunities/DiscoveryModeDialog.tsx offers strategy "nursery_reeval") -> INSERT stage_zero_requests -> scripts/stage-zero-queue-processor.js queue tick (line 232: `strategy: request.metadata?.strategy || \'trend_scanner\'`) -> executeDiscoveryMode -> runNurseryReeval (discovery-mode.js:134 runner map). Query: SELECT metadata->>\'strategy\', status, count(*), max(created_at) FROM stage_zero_requests GROUP BY 1,2. RESULT: only two strategies have EVER been requested — democratization_finder (1, dismissed, 2026-05-22) and simple_venture (3, dismissed, 2026-05-31). ZERO nursery_reeval requests, ever. Corroborating: SELECT count(*) FROM nursery_evaluation_log = 0 rows (the evaluation log has never been written). CONCLUSION: the nursery does not promote because the only wired traversal is a MANUALLY-TRIGGERED, UI-selected discovery strategy that NOBODY HAS EVER TRIGGERED, and there is NO scheduler that triggers it (no nursery/eval/stage0 workflow exists in .github/workflows/). This is precisely the Chairman\'s own stated acceptance gap — "AUTOMATED AND INTEGRATED, not a tool someone runs."'
+  },
+  {
+    id: 'V7-writer-consumer-asymmetry-explains-the-NULL-column',
+    severity: 'HIGH',
+    summary: 'WHY next_evaluation_at IS NULL ON 16/16 — identified at source, not guessed. There are TWO writers to venture_nursery. (1) parkVenture() lib/eva/stage-zero/venture-nursery.js:76-140 DOES set next_evaluation_at (line 105) and evaluation_interval_days (line 106). (2) parkFailedCandidate() lib/eva/stage-zero/traversability-gate.js:161-208 does NOT set next_evaluation_at at all — it writes name/description/maturity_level/trigger_conditions/current_score/source_type/source_ref only. Live proof that (2) wrote ALL 16: SELECT source_ref->>\'gate\', source_ref->>\'sd\', count(*), count(*) FILTER (WHERE source_ref ? \'park\'), count(*) FILTER (WHERE source_ref ? \'synthesis_snapshot\') FROM venture_nursery GROUP BY 1,2 returns gate=\'traversability\', sd=\'SD-LEO-INFRA-STAGE0-TRAVERSABILITY-GATE-001\', n=16, has_park_key=0, has_synthesis_snapshot=0. The traversability-gate module header (lines 19-21) states this DELIBERATELY: "venture-nursery.js parkVenture()/runNurseryReeval() are drifted against the live table (flagged separately, feedback ecab6c51) — this module deliberately writes the verified live columns and does not call them." So the ONLY writer that has ever run bypasses the scheduler-setting writer. This is a textbook PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 instance.'
+  },
+  {
+    id: 'V8-break2-scanner-never-wrote-nursery-CONFIRMED-plus-worse',
+    severity: 'HIGH',
+    summary: 'BREAK 2 CONFIRMED, and the true state is WORSE than the SD states. (a) "Scanner has never written a nursery row" — CONFIRMED by provenance, not just by counting: scripts/market-signal-scan.mjs:209 nominates via parkVentureFn (parkVenture), which stores scanner attribution at source_ref.synthesis_snapshot (parkVenture line 127). Live: ZERO of 16 rows have a synthesis_snapshot key and ZERO have a park key; all 16 carry gate=traversability. Independently corroborated by time: max(fetched_at) on market_signal_observations = 2026-07-20, while ALL 16 nursery rows were created 2026-07-10 — every nursery row PREDATES every observation. (b) WORSE: the scanner\'s AUTOMATION has never fired. Query: SELECT process_key, last_fired_at, last_state FROM periodic_process_registry. Row \'gha_cron:market-signal-scan.yml\' has last_fired_at = NULL, last_state = UNVERIFIED — the weekly GitHub Actions cron (13 9 * * 1) HAS NEVER RUN. The sibling row \'market-signal-scan\' shows last_fired_at 2026-07-20T11:55:26.413Z, matching max(fetched_at) exactly — i.e. all 4 observed scan cycles were MANUAL/local invocations, not scheduled ones. The SD calls this seam "unproven rather than broken"; the automation leg is measurably DEAD, which is stronger.'
+  },
+  {
+    id: 'V9-break2-hidden-DDL-blocker-source_type-CHECK-has-no-scanner-value',
+    severity: 'HIGH',
+    summary: 'UNDISCLOSED BLOCKER the SD does not mention. venture_nursery has CHECK constraint venture_nursery_source_type_check: source_type = ANY (ARRAY[\'brainstorm\',\'todoist\',\'youtube\',\'competitor_analysis\',\'discovery_mode\',\'manual\']). There is NO scanner / market_signal member. parkVenture maps via toNurserySourceType() (venture-nursery.js:47-51) which returns \'discovery_mode\' | \'competitor_analysis\' | \'manual\' only. CONSEQUENCE 1: a scanner-written row is INDISTINGUISHABLE from a traversability-gate row by source_type — both land as discovery_mode. BREAK 2\'s acceptance test therefore CANNOT use source_type to prove the scanner wrote a row; it must assert on source_ref.synthesis_snapshot.source / run_id / sd_key. CONSEQUENCE 2: giving the scanner honest provenance requires an ALTER TABLE ... DROP/ADD CONSTRAINT — a DDL migration. Per LEO work-item routing, schema keywords force Tier 3, and DDL is chairman-gated. This must be pre-flagged at LEAD, not discovered at EXEC.'
+  },
+  {
+    id: 'V10-break1-triangulation-claims-ALL-CONFIRMED-via-family-column',
+    severity: 'INFO',
+    summary: 'BREAK 1 fully re-verified using the REAL column name. The SD/operator could not find `signal_family` because the column is `family` (market_signal_observations: id, source, query_term, family, raw_value, content_hash, fetched_at, transform_version, created_at). Queries and results: (1) SELECT count(*), count(DISTINCT source), count(DISTINCT query_term), count(DISTINCT family) FROM market_signal_observations -> 40 / 1 / 5 / 2 — CONFIRMS "40 observations", "one source", "5 query terms". (2) SELECT source, count(*) GROUP BY 1 -> wordpress_plugins = 40 — CONFIRMS the single source is wordpress_plugins. (3) SELECT family, count(*) GROUP BY 1 -> money_in=20, stickiness=20 — CONFIRMS "money_in 20 and stickiness 20". (4) SELECT query_term, count(DISTINCT family) AS families_agreeing GROUP BY 1 ORDER BY 2 DESC -> ALL FIVE terms return exactly 2 (ai meeting notes, field service scheduling, invoice reminder automation, podcast transcription, shopify inventory sync) — CONFIRMS "max families agreeing on any single term = 2" and "terms reaching the 3-family bar = ZERO". (5) attention and structural have ZERO rows — CONFIRMS "ATTENTION and STRUCTURAL absent entirely". (6) "two of the design FOUR" is confirmed at SCHEMA level, not merely by convention: CHECK constraint market_signal_observations_family_check restricts family to exactly [money_in, stickiness, structural, attention].'
+  },
+  {
+    id: 'V11-break1-bar-unreachable-CONFIRMED-at-source-but-root-cause-is-MISATTRIBUTED',
+    severity: 'HIGH',
+    summary: 'The rule is CONFIRMED at source: lib/market-signal-scanner/scoring.js:33-34 TRIANGULATION_MIN_DISTINCT_FAMILIES=3, TRIANGULATION_REQUIRED_ANY_OF=[\'money_in\',\'stickiness\']; line 139-140 triangulationPassed = distinctFamilyCount >= 3 && hasRequiredFamily. With max 2 distinct families live, the gate can NEVER pass — "UNREACHABLE BY CONSTRUCTION" CONFIRMED. BUT the SD frames this as "COLLECTOR CANNOT TRIANGULATE", implying a collector/scoring defect. THE SCORING RULE IS CORRECT AND SHOULD NOT BE TOUCHED. The real cause is SOURCE COVERAGE: the family->source mapping is one-to-many-from-three-fetchers — sources/wordpress-plugins.js:159-165 emits money_in AND stickiness (2 families); sources/reddit.js:179,189 emits structural (1 family); sources/google-trends.js:200,210 emits attention (1 family). Only wordpress_plugins has ever written. So BREAK 1 decomposes into TWO UNRELATED defects: (i) STRUCTURAL missing because reddit.js ships INERT by design pending REDDIT_CLIENT_ID/REDDIT_CLIENT_SECRET (reddit.js:12-15,125-132; .github/workflows/market-signal-scan.yml:36-39 documents them as unset secrets) — this needs a HUMAN to register a free Reddit OAuth app, i.e. it is HUMAN-GATED and not AI-completable; (ii) ATTENTION missing because google-trends.js has NO credential gate but returns {readings:[], errors} on ~10 distinct runtime failure paths (lines 87-176) — it is failing at RUNTIME and needs debugging, with a real risk that Google Trends is unobtainable without a paid API. Enabling EITHER one alone reaches 3 families and unblocks the bar. Framing this as a collector fix will send EXEC to the wrong file.'
+  },
+  {
+    id: 'V12-view-has-ZERO-consumers-CONFIRMED-both-repos',
+    severity: 'HIGH',
+    summary: 'Operator claim "a repo-wide grep for v_nursery_pending_evaluation returns ZERO consumers" — CONFIRMED across BOTH repos. EHG_Engineer (C:/Users/rickf/Projects/_EHG/EHG_Engineer): the only hits are database/migrations/20260209_stage0_venture_entry_schema.sql:543,556 (the CREATE VIEW + COMMENT), database/migrations/20260211_fix_security_definer_views_and_rls.sql:88 (a name in a security-definer remediation list), and two schema-reference-snapshot.json entries. No .from(), no SELECT, no route, no script. EHG app (C:/Users/rickf/Projects/_EHG/ehg): the name appears ONLY in generated Supabase typings (src/integrations/supabase/types.ts:25902, 26370, 59811, 59837-59887). No .from("v_nursery_pending_evaluation") anywhere. Also confirmed in the EHG app: venture_nursery itself is never READ — its only statement is an FK detach on delete (supabase/migrations/20260307_002_create_delete_venture_rpc.sql:61 UPDATE venture_nursery SET promoted_to_venture_id = NULL WHERE promoted_to_venture_id = p_venture_id). The user-facing "Nursery" UI (src/hooks/useNurseryVentures.ts:22-26) reads the VENTURES table WHERE status=\'paused\' — a completely different data set. The view definition itself was verified live via pg_get_viewdef and matches the operator\'s quote verbatim, returning 15 rows.'
+  },
+  {
+    id: 'V13-DUPLICATE-first-deliverable-driver-ALREADY-EXISTS',
+    severity: 'CRITICAL',
+    summary: 'GATE 1 DUPLICATE CHECK — POSITIVE HIT. The SD\'s "FIRST DELIVERABLE ... PROVE ONE ALREADY-SEEDED IDEA TRAVERSES NURSERY -> STAGE-0 ... Demonstrated by execution" is ALREADY IMPLEMENTED as scripts/one-off/run-nursery-reeval.mjs (67 LOC, from SD-LEO-INFRA-STAGE0-ENVELOPE-REGISTRATION-001 FR-7/FR-8). It calls executeDiscoveryMode({strategy:\'nursery_reeval\', constraints:{}, candidateCount:20}) directly and prints the traversability pass/fail slate. Its own header states the exact gap this SD rediscovered: "nursery_reeval has no standalone entry point today -- only reachable via scripts/stage-zero-queue-processor.js\'s queue tick." Building a new driver would duplicate ~8-10 hours. RECOMMENDATION: the first deliverable should RUN this existing script (or promote it out of one-off/ into a supported entry point) and capture its output as evidence, NOT write a new traversal harness. This is exactly the SD-UAT-020 reuse pattern.'
+  },
+  {
+    id: 'V14-COSMETIC-SATISFACTION-RISK-precedent-already-exists-in-this-table',
+    severity: 'CRITICAL',
+    summary: 'THE OPERATOR\'S GHOST-COMPLETION FEAR IS NOT HYPOTHETICAL — IT HAS ALREADY HAPPENED ONCE IN THIS EXACT TABLE, AND IT IS DOCUMENTED IN THE REPO. scripts/backfill-venture-nursery-promotion-links.mjs lines 17-20 state verbatim: "Live-data check at authoring time (2026-07-12): 16 total venture_nursery rows, 1 already stamped (VIA AN OUT-OF-BAND MANUAL PATCH, NOT BY ANY REPEATABLE CODE PATH), the other 15 unpromoted..." That single stamped row is Image Alt Text Generator — the same 90-scorer the SD points EXEC at. The SD\'s own SHARPENING section reaches the right conclusion ("the seam has carried ZERO traffic") but by the wrong evidence (it infers this from next_evaluation_at being NULL; the actual proof is this source comment). FOUR NAMED COSMETIC-SATISFACTION VECTORS the PRD must forbid by acceptance criteria: (1) direct UPDATE venture_nursery SET promoted_to_venture_id=... — the precedent path; (2) running scripts/backfill-venture-nursery-promotion-links.mjs --apply, which is a NAME-MATCH HEURISTIC UPDATE (lines 48-63, 106-111) and is explicitly documented as "HEURISTIC, not exact" — it would stamp a promotion link WITHOUT any traversal occurring; (3) calling lib/eva/stage-zero/chairman-review.js:54-57 stampNurseryPromotion() in isolation, which is a bare guarded UPDATE of promoted_to_venture_id/promoted_at; (4) selecting Image Alt Text Generator as "the 90-scorer" and declaring the ALREADY-EXISTING stamp to be the proof. ACCEPTANCE MUST BE: a NEW row transitions, evidenced by (a) a nursery_evaluation_log row (table currently has 0 rows — a clean, unfalsifiable baseline), (b) a stage_zero_requests row with metadata.strategy=\'nursery_reeval\' (currently ZERO such rows ever — equally clean baseline), and (c) a ventures row whose creation timestamp postdates the request. All three counters are at zero today, which makes them ideal tamper-evident witnesses.'
+  },
+  {
+    id: 'V15-GATE1-BLOCKER-zero-backlog-items',
+    severity: 'CRITICAL',
+    summary: 'GATE 1 BACKLOG VALIDATION FAILS. Query: SELECT count(*) FROM sd_backlog_map WHERE sd_id IN (\'SD-EHG-IDEATION-PIPELINE-SEAMS-001\', \'70f6fc06-e641-4a9b-9273-6a33665f49f0\') -> 0. The SD has ZERO backlog items. Per the documented GATE 1 rule (and the SD-EXPORT-001 precedent: approved with 0 backlog items -> scope ambiguity -> late-stage rework), an SD cannot move to status=\'active\' without >=1 backlog item. This is a hard, mechanical blocker independent of the diagnostic findings above and must be cleared before LEAD-TO-PLAN completes. Given the three-seam structure, the natural decomposition is one backlog item per seam plus one for the predicate-schism unification.'
+  },
+  {
+    id: 'V16-scope-shape-ONE-SD-with-sequenced-FRs-not-three-children',
+    severity: 'HIGH',
+    summary: 'GATE 1 SCOPE ASSESSMENT. The SD explicitly forbids staffing as three independent items ("they would land in whatever order they get picked up"). That instruction is SOUND and is corroborated by the dependency measurements: BREAK 1\'s output (a triangulated nomination) flows through parkVenture, whose rows DO carry next_evaluation_at — so BREAK 1 nominations would be invisible to checkNurseryTriggers-style consumers ONLY if the predicate schism (V5) is left unfixed; and BREAK 2\'s honest-provenance need (V9) requires the DDL that BREAK 1\'s nominations would then depend on for attribution. However "one SD" vs "orchestrator+children" is NOT the same question as "independent items". RECOMMENDATION: ONE SD with STRICTLY SEQUENCED FRs and a hard gate between them — NOT an orchestrator with parallel children (children get claimed in parallel by the fleet, which reintroduces exactly the ordering loss the Chairman forbade), and NOT three sibling SDs. LOC feasibility supports this: the corrected BREAK 3 fix is small (wire a scheduled nursery_reeval request-enqueuer + unify three predicates, est. 60-120 LOC), BREAK 2 is a DDL migration + provenance assertion (est. 40-80 LOC), BREAK 1 is credential provisioning + one fetcher debug (est. 20-60 LOC + a human action). Each FR lands as its own <=100 LOC PR under one SD, preserving order via FR sequencing rather than via SD decomposition. If the fleet requires parallelism, an orchestrator is acceptable ONLY with explicit min-dependency edges child1->child2->child3 encoded so no child can be claimed out of order.'
+  },
+  {
+    id: 'V17-seam-ORDER-still-holds-but-for-a-DIFFERENT-reason',
+    severity: 'HIGH',
+    summary: 'GATE 1 ORDER ASSESSMENT — the mandated back-to-front order SURVIVES the corrected BREAK 3 diagnosis, but the justification changes and one refinement is required. ORIGINAL justification: "nothing is scheduled, so any evaluator finds nothing" — that is now known to be true only of an UNCALLED function (V4) and false of the wired path (V5). CORRECTED justification for keeping promotion first: the wired traversal has never been REQUESTED even once (V6, zero nursery_reeval rows in stage_zero_requests) and there is no scheduler, so any nomination produced by fixing BREAK 2 or BREAK 1 would land in venture_nursery and sit exactly as the current 16 do. The SD\'s stated consequence — "repairing the collector first produces NOMINATIONS THAT GO NOWHERE" — is INDEPENDENTLY CONFIRMED and remains the correct sequencing argument. Fixing "no consumer" first therefore DOES still unblock 2 then 1. REQUIRED REFINEMENT: BREAK 3 must be widened from "prove one traversal" to "prove one traversal AND unify the three disagreeing selection predicates (view / checkNurseryTriggers / runNurseryReeval)". Without the unification, a later engineer who wires the obvious-looking checkNurseryTriggers() will ship a permanently-empty sweep that LOOKS correct and passes review — the SD\'s original EMPTY-SELECTION-FOREVER prediction would then come true as a REGRESSION INTRODUCED BY THE FIX ITSELF. Ordering within BREAK 3: unify predicates + set next_evaluation_at on the traversability-gate writer BEFORE wiring any scheduler.'
+  },
+  {
+    id: 'V18-LEAD-readiness-PRD-writability',
+    severity: 'MEDIUM',
+    summary: 'GATE 1 PRD-WRITABILITY. The SD is NOT yet PRD-writable as authored, for four mechanical reasons, all fixable at LEAD: (1) zero backlog items (V15); (2) the first deliverable\'s target is ambiguous — "the 90-scorer" resolves to 5 rows, one of them already promoted (V3); (3) the BREAK 3 causal claim is wrong in mechanism, so acceptance criteria derived from it would test the wrong thing — a PRD that says "set next_evaluation_at so the evaluator selects" would pass while the pipeline stays dead, because the wired evaluator ignores that column (V5); (4) BREAK 1\'s true remediation includes a HUMAN-GATED credential action (Reddit OAuth app registration) that no AI agent can complete, so the SD needs an explicit human-dependency flag or BREAK 1 must be scoped to google_trends only (V11). Additionally the description and scope columns are BYTE-IDENTICAL for the first 3052 characters (description 3861 chars, scope 3052) — scope is a truncated copy of description carrying no distinct scope statement, no explicit out-of-scope list, and no acceptance criteria. Every other input a PRD needs (measured baselines, named files, named columns, dependency order) is now available in this evidence row.'
+  },
+  {
+    id: 'V19-infrastructure-reuse-inventory',
+    severity: 'INFO',
+    summary: 'GATE 1 EXISTING-INFRASTRUCTURE CHECK — substantial reusable infrastructure exists; this SD should be mostly WIRING, not building. Reusable as-is: scripts/one-off/run-nursery-reeval.mjs (traversal driver, V13); lib/eva/stage-zero/paths/discovery-mode.js runNurseryReeval (the traversal itself, working); scripts/stage-zero-queue-processor.js (queue tick, already dispatches by metadata.strategy and already runs under leo-stack per scripts/leo-stack.ps1|sh); stage_zero_requests table (the enqueue surface — needs only a producer); nursery_evaluation_log table (exists, 0 rows, ready as an evidence sink); periodic_process_registry + lib/periodic-liveness/stamp-last-fired.js (the liveness pattern the scanner already uses, directly copyable for a nursery sweep); v_nursery_pending_evaluation (correct NULL-tolerant selection, needs only a consumer); lib/market-signal-scanner/* (complete 3-source/4-family scanner; only credentials and one runtime bug stand between it and a live triangulation). NOT needed: a new evaluator, a new scheduler framework, a new nursery schema, or any change to scoring.js.'
+  },
+];
+
+const warnings = [
+  {
+    severity: 'CRITICAL',
+    issue: 'SD has 0 backlog items (sd_backlog_map) — GATE 1 blocking; SD cannot reach status=active.',
+    recommendation: 'Create >=4 backlog items before completing LEAD-TO-PLAN: one per seam plus one for the selection-predicate unification.',
+  },
+  {
+    severity: 'CRITICAL',
+    issue: 'BREAK 3 mechanism is misdiagnosed. Acceptance criteria derived from "nothing is scheduled, so the evaluator selects nothing" would validate the wrong behaviour — the wired evaluator (runNurseryReeval) never reads next_evaluation_at.',
+    recommendation: 'Rewrite BREAK 3 in the PRD as: (a) unify three disagreeing selection predicates, (b) make the traversability-gate writer set next_evaluation_at, (c) enqueue a scheduled nursery_reeval stage_zero_request. Do not accept "next_evaluation_at is now populated" as evidence of a working seam.',
+  },
+  {
+    severity: 'CRITICAL',
+    issue: '"Use the 90-scorer" is ambiguous across 5 rows, one of which is the already-promoted live first-revenue venture (Image Alt Text Generator).',
+    recommendation: 'Name the target nursery row by UUID in the PRD. Explicitly exclude promoted_to_venture_id IS NOT NULL rows from the traversal demonstration.',
+  },
+  {
+    severity: 'CRITICAL',
+    issue: 'Cosmetic-satisfaction of the first deliverable is highly reachable via four named paths, one of which (an out-of-band manual UPDATE) is the documented provenance of the ONLY existing promotion in this table.',
+    recommendation: 'Acceptance must require a new stage_zero_requests row with metadata.strategy=nursery_reeval, a new nursery_evaluation_log row, and a ventures row created after the request. All three counters are at 0 today, making them tamper-evident. Explicitly forbid backfill-venture-nursery-promotion-links.mjs --apply and bare stampNurseryPromotion() as evidence.',
+  },
+  {
+    severity: 'HIGH',
+    issue: 'BREAK 2 requires an undisclosed DDL migration (venture_nursery_source_type_check has no scanner member), which forces Tier 3 and is chairman-gated.',
+    recommendation: 'Pre-flag the DDL at LEAD. Until it lands, BREAK 2 acceptance must assert on source_ref.synthesis_snapshot, not source_type.',
+  },
+  {
+    severity: 'HIGH',
+    issue: 'BREAK 1 remediation includes a HUMAN-GATED action (register a free Reddit OAuth app to supply REDDIT_CLIENT_ID/SECRET). No AI agent can complete it.',
+    recommendation: 'Either flag the human dependency explicitly on the SD, or scope BREAK 1 to repairing the google_trends fetcher only (attention family), which alone reaches the 3-family bar.',
+  },
+  {
+    severity: 'MEDIUM',
+    issue: 'SD scope column is a byte-identical truncated copy of description; no distinct scope, out-of-scope list, or acceptance criteria exists.',
+    recommendation: 'Author a real scope statement with explicit out-of-scope (e.g. "scoring.js triangulation rule is NOT to be changed").',
+  },
+  {
+    severity: 'MEDIUM',
+    issue: 'SD claim "Unevaluated scores include 90, 74, 65, 65" understates inventory by omitting five 80s and three 70s.',
+    recommendation: 'Correct to: 15 unevaluated ideas scoring 65-90, 9 of them >=80.',
+  },
+];
+
+const recommendations = [
+  'CLEAR THE GATE 1 BLOCKER: create >=4 sd_backlog_map items before completing LEAD-TO-PLAN.',
+  'KEEP the back-to-front seam order (3 -> 2 -> 1); it survives verification, but replace the justification with the measured one: zero nursery_reeval requests have ever been enqueued and no scheduler exists.',
+  'RESCOPE BREAK 3 to three sequenced sub-items: (1) unify the three disagreeing selection predicates onto the NULL-tolerant view semantics; (2) make parkFailedCandidate set next_evaluation_at/evaluation_interval_days like parkVenture does; (3) add a scheduled producer that enqueues a nursery_reeval stage_zero_request. Order matters: 1 and 2 BEFORE 3, or the scheduler ships a permanently-empty sweep.',
+  'REUSE scripts/one-off/run-nursery-reeval.mjs for the first deliverable rather than building a new traversal harness (~8-10 hrs saved).',
+  'NAME THE TARGET ROW BY UUID; exclude already-promoted rows from the demonstration.',
+  'MAKE THE FIRST DELIVERABLE TAMPER-EVIDENT: require new rows in stage_zero_requests (strategy=nursery_reeval), nursery_evaluation_log, and ventures. All three are at 0/never today.',
+  'STAFF AS ONE SD WITH SEQUENCED FRs, not three siblings and not a parallel-children orchestrator. If an orchestrator is required, encode hard child1->child2->child3 dependency edges.',
+  'PRE-FLAG the chairman-gated DDL (venture_nursery source_type CHECK) for BREAK 2 now, at LEAD.',
+  'REFRAME BREAK 1 from "collector cannot triangulate" to "2 of 3 source fetchers have never produced an observation". Do NOT modify lib/market-signal-scanner/scoring.js — the triangulation rule is correct.',
+  'FLAG the Reddit OAuth human dependency, or descope BREAK 1 to google_trends.',
+  'ADD a fourth, unstated seam to scope consideration: the scanner GHA cron (gha_cron:market-signal-scan.yml) has last_fired_at=NULL and has never run. The Chairman asked for AUTOMATED; a never-firing cron defeats BREAK 2 even if the nursery write works.',
+];
+
+const summary = 'GATE 1 VALIDATION for SD-EHG-IDEATION-PIPELINE-SEAMS-001. Every numeric claim in the SD was re-measured against the live consolidated database with named columns. ALL BREAK-1 and BREAK-2 numbers CONFIRMED; ALL BREAK-3 aggregate numbers CONFIRMED. However the BREAK-3 CAUSAL MECHANISM is REFUTED: the wired Nursery->Stage-0 traversal (runNurseryReeval, discovery-mode.js:630) never reads next_evaluation_at, so NULL scheduling is not what blocks promotion. The operator\'s correction is substantially right but needs one amendment: an evaluator with the SD\'s exact NULL-intolerant predicate DOES exist (checkNurseryTriggers, venture-nursery.js:320) — it simply has no caller, making the SD\'s premise true-but-vacuous rather than false. The measured root cause is that ZERO nursery_reeval requests have ever been enqueued in stage_zero_requests and no scheduler exists. Three selection layers disagree on the same table. The first deliverable is already implemented (run-nursery-reeval.mjs) and is cosmetically satisfiable via four named paths, one of which is the documented provenance of the only existing promotion. GATE 1 BLOCKS on 0 backlog items.';
+
+const justification = [
+  'VERDICT: CONDITIONAL_PASS at confidence 92.',
+  '',
+  'The SD\'s STRATEGIC THESIS SURVIVES VERIFICATION: three seams exist, the collector really is the smallest, and the back-to-front order is correct. Every headline number is accurate. That is a materially better-evidenced SD than most that reach LEAD, and it should proceed.',
+  '',
+  'It is CONDITIONAL, not PASS, for three independent reasons. (1) MECHANICAL BLOCKER: zero sd_backlog_map items, which prevents status=active and is non-negotiable. (2) DIAGNOSTIC DEFECT: the BREAK-3 causal chain is wrong in a way that would produce a PRD testing the wrong behaviour — acceptance criteria written from "nothing is scheduled so the evaluator finds nothing" can be fully satisfied while the pipeline remains dead, because the evaluator that actually runs ignores the column in question. (3) INTEGRITY RISK: the first deliverable is cosmetically satisfiable, and the precedent is not hypothetical — the single existing promotion in this table is documented in-repo as "an out-of-band manual patch, not by any repeatable code path", and it happens to be one of the five rows matching the SD\'s own "use the 90-scorer" instruction.',
+  '',
+  'I attempted the refutation the operator asked for and PARTIALLY SUCCEEDED AGAINST THEM: checkNurseryTriggers does query venture_nursery directly with an effective next_evaluation_at <= now() predicate that excludes NULL, exactly as the SD describes. The operator\'s blanket claim that "empty selection forever is FALSE" is therefore too strong. But the finding does not rescue the SD, because that function has no production caller, and the function that IS wired does not use the predicate at all. Both parties were reasoning from one selection layer each; there are three, and they disagree. That schism is the finding neither the SD nor the operator had, and it is the one most likely to cause a regression during the fix.',
+  '',
+  'Confidence is 92 rather than higher because two questions remain open that only execution can close: whether the google_trends fetcher failure is a transient/network issue or a hard unavailability (I read its ~10 failure-return paths but did not execute it), and whether runNurseryReeval\'s LLM step actually yields promotable candidates against the current capability envelope (run-nursery-reeval.mjs exists precisely to answer this and has not been run in this session). Neither uncertainty affects the blocking findings.',
+].join('\n');
+
+async function main() {
+  const supabase = await getSupabaseClient();
+
+  const resolution = await resolveSubAgentRepo({
+    sdId: SD_KEY,
+    targetApplication: 'EHG_Engineer',
+    subAgentCode: 'VALIDATION',
+    supabase,
+  });
+
+  let results = {
+    verdict: 'CONDITIONAL_PASS',
+    confidence: 92,
+    findings,
+    warnings,
+    recommendations,
+    summary,
+    justification,
+    critical_issues: [
+      'GATE 1 BLOCKER: 0 backlog items in sd_backlog_map — SD cannot reach status=active.',
+      'BREAK 3 causal mechanism REFUTED: runNurseryReeval (the only wired traversal) never filters on next_evaluation_at; NULL scheduling does not block promotion.',
+      '"The 90-scorer" resolves to 5 rows, one of which is the already-promoted live first-revenue venture (Image Alt Text Generator).',
+      'First deliverable is cosmetically satisfiable via 4 named paths; the sole existing promotion is documented in-repo as an out-of-band manual patch.',
+      'Undisclosed chairman-gated DDL required for BREAK 2 (venture_nursery source_type CHECK has no scanner member).',
+    ],
+    conditions: [
+      'Create >=4 sd_backlog_map items before LEAD-TO-PLAN completes.',
+      'Correct the BREAK 3 diagnosis in the SD/PRD to the measured root cause (zero nursery_reeval requests ever enqueued; no scheduler) and add predicate unification as an explicit deliverable.',
+      'Name the traversal target nursery row by UUID and exclude promoted rows.',
+      'Define tamper-evident acceptance: new rows in stage_zero_requests (strategy=nursery_reeval) + nursery_evaluation_log + ventures; explicitly forbid backfill --apply and bare stampNurseryPromotion() as evidence.',
+      'Pre-flag the BREAK 2 DDL as chairman-gated.',
+      'Flag the Reddit OAuth human dependency or descope BREAK 1 to google_trends.',
+    ],
+    metadata: {
+      gate: 'GATE_1_LEAD_PRE_APPROVAL',
+      validation_type: 'claim_verification_duplicate_check_and_scope_assessment',
+      claims_confirmed: 14,
+      claims_refuted: 2,
+      claims_partially_confirmed: 2,
+      claims_unverifiable: 0,
+      backlog_items_found: 0,
+      duplicate_implementations_found: 1,
+      model: 'Opus 5 (1M context)',
+      model_id: 'claude-opus-5[1m]',
+      invoked_at: new Date().toISOString(),
+      e2e_applicable: false,
+      e2e_exemption_reason: 'LEAD pre-approval claim verification against live DB + source reading; no implementation exists yet to test.',
+    },
+    detailed_analysis: {
+      sd_key: SD_KEY,
+      tables_queried: ['venture_nursery', 'market_signal_observations', 'v_nursery_pending_evaluation', 'nursery_evaluation_log', 'stage_zero_requests', 'periodic_process_registry', 'sd_backlog_map', 'strategic_directives_v2', 'information_schema.columns', 'pg_constraint', 'pg_trigger'],
+      columns_corrected: {
+        'venture_nursery.status': 'DOES NOT EXIST — parked/promoted derived from promoted_to_venture_id',
+        'market_signal_observations.signal_family': 'DOES NOT EXIST — the column is `family`',
+      },
+      claim_verdicts: {
+        'nursery 16 rows': 'CONFIRMED',
+        'next_evaluation_at NULL 16/16': 'CONFIRMED',
+        '15/16 never evaluated': 'CONFIRMED',
+        '1 promotion in 15 days': 'CONFIRMED',
+        'all discovery_mode + seed': 'CONFIRMED',
+        'one batch 15.0 days ago': 'CONFIRMED (113.6s spread)',
+        'unevaluated scores 90/74/65/65': 'PARTIALLY CONFIRMED — omits 80x5 and 70x3',
+        'EMPTY SELECTION FOREVER': 'REFUTED as stated — true only of uncalled checkNurseryTriggers; wired path ignores the column',
+        'the 90-scorer sat untouched': 'REFUTED — 5 rows at 90; one is promoted and was evaluated 2026-07-12',
+        'scanner never wrote a nursery row': 'CONFIRMED (provenance + chronology)',
+        '40 observations': 'CONFIRMED',
+        'money_in 20 / stickiness 20': 'CONFIRMED',
+        '1 source (wordpress_plugins)': 'CONFIRMED',
+        '5 query terms': 'CONFIRMED',
+        'max families per term = 2': 'CONFIRMED',
+        'terms reaching 3-family bar = 0': 'CONFIRMED',
+        'attention + structural absent': 'CONFIRMED',
+        'bar unreachable by construction': 'CONFIRMED (scoring.js:33-34,139-140) — but root cause is source coverage, not the rule',
+        'view returns 15 rows, 90-scorer first': 'CONFIRMED',
+        'view has zero consumers': 'CONFIRMED both repos',
+      },
+    },
+    phase: 'LEAD',
+    validation_mode: 'prospective',
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+
+  const stored = await storeSubAgentResults(
+    'VALIDATION',
+    SD_ID,
+    { name: 'Principal Systems Analyst (validation-agent)' },
+    results,
+    { sdKey: SD_KEY, phase: 'LEAD' }
+  );
+
+  console.log('VERDICT WRITTEN:');
+  console.log('  ID:', stored.id);
+  console.log('  verdict:', stored.verdict, '@ confidence', stored.confidence);
+  console.log('  phase:', stored.phase);
+  console.log('  repo_path:', stored.metadata?.repo_path);
+  console.log('  repo_resolved:', stored.metadata?.repo_resolved);
+  console.log('  executed_from_cwd:', stored.metadata?.executed_from_cwd);
+  process.exit(0);
+}
+
+main().catch(e => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/tests/unit/discovery-mode.test.js
+++ b/tests/unit/discovery-mode.test.js
@@ -135,18 +135,23 @@ function createMockSupabase({ strategies = STRATEGY_CONFIGS, nurseryItems = DEFA
       if (table === 'venture_nursery') {
         // SD-LEO-INFRA-STAGE0-NURSERY-PARK-PATH-001: the live SELECT filters
         // promoted_to_venture_id via .is() (the phantom .eq('status') is gone).
-        return {
-          select: vi.fn().mockReturnValue({
-            is: vi.fn().mockReturnValue({
-              order: vi.fn().mockReturnValue({
-                limit: vi.fn().mockResolvedValue({
-                  data: nurseryError ? null : nurseryItems,
-                  error: nurseryError,
-                }),
-              }),
-            }),
+        //
+        // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: rebuilt as a SELF-RETURNING chain.
+        // The reader now routes through applyPendingNurseryPredicate, which adds .or()
+        // for the NULL-means-eligible-now branch and THREE .order() calls for the stable
+        // score-first tiebreak. The previous nested-return shape hard-coded exactly one
+        // .order() and had no .or() at all, so it threw before reaching .limit().
+        const chain = {
+          select: vi.fn(() => chain),
+          is: vi.fn(() => chain),
+          or: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn().mockResolvedValue({
+            data: nurseryError ? null : nurseryItems,
+            error: nurseryError,
           }),
         };
+        return chain;
       }
       return { select: vi.fn().mockReturnValue({ eq: vi.fn() }) };
     }),

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -736,6 +736,47 @@ describe('ChairmanReview', () => {
       );
     });
 
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3. The WIP wall cannot be cleared honestly:
+    // all 46 counted rows were enumerated, 44 are fixtures and exactly two are real, so
+    // the floor is 2 against a limit of 2 and the gate compares with >=. That residual is
+    // a PORTFOLIO decision. The standing pressure is therefore to widen this list until
+    // the count drops — these tests exist so that widening cannot silently swallow a real
+    // venture, and the two are named by UUID in the PRD for the same reason.
+    describe('FR-3: fixture prefixes must never match a REAL venture', () => {
+      const matchesAnyPrefix = (name) =>
+        TEST_FIXTURE_NAME_PREFIXES.some((p) => name.toLowerCase().startsWith(p.toLowerCase()));
+
+      it.each([
+        ['ApexNiche AI', '809ec7e7'],
+        ['Image Alt Text Generator', '50763b6a'],
+      ])('does not classify %s (%s) as a test fixture', (name) => {
+        expect(matchesAnyPrefix(name)).toBe(false);
+      });
+
+      it('DOES classify every known fixture family, so the count reflects the real portfolio', () => {
+        for (const name of [
+          'artifact-gate-test-1784287687683',
+          'HCGate-RealDB-daemon-advisory-1784238026383',
+          'ProductReviewGate-RealDB-adv-1784287676240',
+          'StageArtifactGate-RealDB-complete-1784287689752',
+          'Pipeline-Test-1784249314251',
+          'Test Venture for Owned-Audience Loop',
+          '__e2e_thing', 'TEST-HARNESS-thing', 'parity-test-thing', 'TS-fixture-thing',
+        ]) {
+          expect(matchesAnyPrefix(name), `should be a fixture: ${name}`).toBe(true);
+        }
+      });
+
+      it('no prefix is broad enough to swallow an ordinary venture name', () => {
+        // A prefix like "Test" or "" would match real work. Guarding the shape rather than
+        // only the two known names keeps this honest as the portfolio grows.
+        for (const name of ['Alt Text Generator', 'Apex Analytics', 'Testimonial Engine', 'Venture One']) {
+          expect(matchesAnyPrefix(name), `must not be a fixture: ${name}`).toBe(false);
+        }
+        for (const p of TEST_FIXTURE_NAME_PREFIXES) expect(p.length).toBeGreaterThan(5);
+      });
+    });
+
     it('same-name idempotent re-run returns the existing venture BEFORE the WIP gate', async () => {
       const existing = { id: 'v-existing', name: 'TestVenture', status: 'active' };
       const ventures = {

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -45,6 +45,10 @@ function nurserySupabase(items) {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         is: vi.fn().mockReturnThis(),
+        // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: the reader now routes through the
+        // shared applyPendingNurseryPredicate, which adds .or() for the
+        // "NULL means never scheduled, so eligible now" branch.
+        or: vi.fn().mockReturnThis(),
         order: vi.fn().mockReturnThis(),
         limit: vi.fn().mockResolvedValue({ data: items, error: null }),
       };

--- a/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode.test.js
@@ -56,6 +56,9 @@ function createMockSupabase(strategyData = null, nurseryItems = []) {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     is: vi.fn().mockReturnThis(),
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: shared nursery predicate adds .or()
+    // for the NULL-means-eligible-now branch.
+    or: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue({ data: strategyData, error: strategyData ? null : { message: 'not found' } }),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockResolvedValue({ data: nurseryItems, error: null }),

--- a/tests/unit/eva/stage-zero/traversability-gate.test.js
+++ b/tests/unit/eva/stage-zero/traversability-gate.test.js
@@ -137,12 +137,80 @@ describe('parkFailedCandidate — LIVE venture_nursery schema (FR-3 / criterion 
     expect(inserted[0].table).toBe('venture_nursery');
     const row = inserted[0].row;
     // Live schema columns only (the drifted parkVenture columns must NOT appear).
-    expect(Object.keys(row).sort()).toEqual(['current_score', 'description', 'maturity_level', 'name', 'source_ref', 'source_type', 'trigger_conditions']);
+    // next_evaluation_at added by SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-2 (the writer
+    // asymmetry). evaluation_interval_days is deliberately still absent: the column
+    // DEFAULT is 30 and every live row already reads 30, so writing it is a no-op.
+    expect(Object.keys(row).sort()).toEqual(['current_score', 'description', 'maturity_level', 'name', 'next_evaluation_at', 'source_ref', 'source_type', 'trigger_conditions']);
     expect(row.maturity_level).toBe('seed');            // live CHECK: seed|sprout|ready
     expect(row.source_type).toBe('discovery_mode');     // live CHECK includes discovery_mode
     expect(row.trigger_conditions[0]).toMatchObject({ type: 'capability_ships', capability: 'shopify integration' });
     expect(row.source_ref.gate).toBe('traversability');
     expect(row.source_ref.posture_version).toBe('phase_1_process_proving@v1');
+  });
+
+  // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-2. These assert the COLUMN VALUE on a row this
+  // writer actually produced. Both weaker forms were considered and rejected:
+  //   - asserting only "the row is eligible" is VACUOUS, because the selector admits NULL
+  //     via its IS NULL branch, so such a test passes against completely unmodified code;
+  //   - asserting on a hand-built row would pass with parkFailedCandidate untouched —
+  //     the right property measured on the wrong producer.
+  describe('FR-2: parkFailedCandidate writes an IMMEDIATELY-eligible next_evaluation_at', () => {
+    function captureInsert() {
+      const inserted = [];
+      const supabase = {
+        from: vi.fn(() => ({
+          insert: vi.fn((row) => {
+            inserted.push(row);
+            return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 'n1', ...row }, error: null }) }) };
+          }),
+        })),
+      };
+      return { supabase, inserted };
+    }
+    const failure = {
+      candidate: { name: 'X', problem_statement: 'p', solution: 's', composite_score: 90, required_capabilities: [] },
+      missing: [{ name: 'cap', kind: 'integration' }],
+      resurfacing_conditions: [],
+    };
+
+    test('writes a NON-NULL next_evaluation_at that is already <= now — the selector predicate', async () => {
+      const now = new Date('2026-07-25T12:00:00.000Z');
+      const { supabase, inserted } = captureInsert();
+      await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger, now });
+      const written = inserted[0].next_evaluation_at;
+      expect(written).not.toBeNull();
+      expect(written).toBe('2026-07-25T12:00:00.000Z');
+      expect(new Date(written).getTime()).toBeLessThanOrEqual(now.getTime());
+    });
+
+    test('REGRESSION GUARD: does NOT write a future date — now+90d would hide the row for 90 days', async () => {
+      const now = new Date('2026-07-25T12:00:00.000Z');
+      const { supabase, inserted } = captureInsert();
+      await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger, now });
+      const written = new Date(inserted[0].next_evaluation_at).getTime();
+      // parkVenture's calculateNextReview('90d') would land here. The selector admits
+      // only `IS NULL OR <= now()`, so a row written that way is INVISIBLE — and the 15
+      // currently-visible rows are visible precisely BECAUSE the column is NULL. Copying
+      // that convention would have emptied the selector and caused this SD's own outage.
+      const ninetyDaysOut = now.getTime() + 90 * 86400000;
+      expect(written).toBeLessThan(ninetyDaysOut);
+      expect(written).toBeLessThanOrEqual(now.getTime());
+    });
+
+    test('does NOT write evaluation_interval_days — the column DEFAULT already supplies 30', async () => {
+      const { supabase, inserted } = captureInsert();
+      await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger });
+      expect(inserted[0]).not.toHaveProperty('evaluation_interval_days');
+    });
+
+    test('defaults to the real clock when none is injected, and still lands in the past', async () => {
+      const before = Date.now();
+      const { supabase, inserted } = captureInsert();
+      await parkFailedCandidate(failure, {}, { supabase, logger: silentLogger });
+      const written = new Date(inserted[0].next_evaluation_at).getTime();
+      expect(written).toBeGreaterThanOrEqual(before);
+      expect(written).toBeLessThanOrEqual(Date.now());
+    });
   });
 
   // QF-20260711-607: parkFailedCandidate's persisted candidate snapshot previously

--- a/tests/unit/eva/stage-zero/venture-nursery.test.js
+++ b/tests/unit/eva/stage-zero/venture-nursery.test.js
@@ -18,6 +18,7 @@ import {
   reactivateVenture,
   recordSynthesisFeedback,
   checkNurseryTriggers,
+  applyPendingNurseryPredicate,
   getNurseryHealth,
   toNurseryMaturityLevel,
   toNurserySourceType,
@@ -55,7 +56,7 @@ const LIVE_COLUMNS = new Set([
 
 /** Capturing mock: records insert/update payloads + select cols; FIFO list/single data. */
 function captureSb({ selectData = [], singleData = undefined, insertResult = undefined } = {}) {
-  const captured = { inserts: [], updates: [], selects: [] };
+  const captured = { inserts: [], updates: [], selects: [], ors: [], orders: [], filters: [] };
   const supabase = { from: (table) => {
     const state = { table, filters: [] };
     const c = {
@@ -63,8 +64,11 @@ function captureSb({ selectData = [], singleData = undefined, insertResult = und
       update: (payload) => { captured.updates.push({ table, payload, filters: state.filters }); return c; },
       select: (cols) => { captured.selects.push({ table, cols }); return c; },
       eq: (col, v) => { state.filters.push(['eq', col, v]); return c; },
-      is: (col, v) => { state.filters.push(['is', col, v]); return c; },
-      order: () => c,
+      is: (col, v) => { state.filters.push(['is', col, v]); captured.filters.push(['is', col, v]); return c; },
+      // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: the eligibility filter moved from JS
+      // into the QUERY, so the mock must record .or() or the predicate is untestable.
+      or: (expr) => { captured.ors.push(expr); return c; },
+      order: (col, opts) => { captured.orders.push([col, opts]); return c; },
       limit: () => c,
       // fetch-all-paginated (FR-6) awaits .range() as the paginated terminal.
       range: () => Promise.resolve({ data: selectData, error: null }),
@@ -326,20 +330,81 @@ describe('checkNurseryTriggers (FR-2: next_evaluation_at + promoted_to_venture_i
     expect(await checkNurseryTriggers({ supabase, logger: silentLogger })).toEqual([]);
   });
 
-  test('returns items whose next_evaluation_at has passed; live columns only', async () => {
+  // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1. Eligibility filtering moved from JS into
+  // the QUERY, so these assert the PREDICATE rather than post-fetch filtering. That is
+  // deliberate and it is the honest unit-level claim: a mock cannot evaluate SQL, so a
+  // test that fed it two rows and expected one back would only be re-testing the mock.
+  // Whether the database actually returns the right rows is TS-1, an integration test.
+  test('admits NULL next_evaluation_at — the "empty selection forever" regression guard', async () => {
+    const { supabase, captured } = captureSb({ selectData: [] });
+    await checkNurseryTriggers({ supabase, logger: silentLogger });
+    const or = captured.ors.join(' ');
+    // The old code filtered `nextReview && nextReview <= now` in JS. That `&&` excluded
+    // NULL, and all 16 live rows are NULL, so it returned empty PERMANENTLY.
+    expect(or).toContain('next_evaluation_at.is.null');
+    expect(or).toContain('next_evaluation_at.lte.');
+    expect(captured.filters).toContainEqual(['is', 'promoted_to_venture_id', null]);
+  });
+
+  test('orders score-first with a STABLE tiebreak — five live rows tie at 90', async () => {
+    const { supabase, captured } = captureSb({ selectData: [] });
+    await checkNurseryTriggers({ supabase, logger: silentLogger });
+    const cols = captured.orders.map(([c]) => c);
+    expect(cols[0]).toBe('current_score');
+    expect(captured.orders[0][1]).toMatchObject({ ascending: false });
+    // Score alone is non-deterministic across the five 90s; created_at then id fixes it.
+    expect(cols).toEqual(['current_score', 'created_at', 'id']);
+  });
+
+  test('distinguishes never_scheduled from scheduled_review, and selects live columns only', async () => {
     const pastDate = new Date(Date.now() - 86400000).toISOString();
-    const futureDate = new Date(Date.now() + 86400000 * 30).toISOString();
     const { supabase, captured } = captureSb({ selectData: [
-      { id: 'n1', name: 'Ready', next_evaluation_at: pastDate, trigger_conditions: ['market_shift'] },
-      { id: 'n2', name: 'Not Ready', next_evaluation_at: futureDate, trigger_conditions: [] },
+      { id: 'n1', name: 'Scheduled', next_evaluation_at: pastDate, current_score: 90, trigger_conditions: ['market_shift'] },
+      { id: 'n2', name: 'Never scheduled', next_evaluation_at: null, current_score: 74, trigger_conditions: [] },
     ] });
     const result = await checkNurseryTriggers({ supabase, logger: silentLogger });
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ id: 'n1', reason: 'scheduled_review', trigger_conditions: ['market_shift'] });
+    // A NULL schedule is not a scheduled review — it was never scheduled at all, and
+    // keeping the two causes separable is what made the original defect diagnosable.
+    expect(result[1]).toMatchObject({ id: 'n2', reason: 'never_scheduled', next_review_date: null });
     const sel = captured.selects.find((s) => s.table === 'venture_nursery');
     expect(sel.cols).toContain('next_evaluation_at');
+    expect(sel.cols).toContain('current_score');
     expect(sel.cols).not.toContain('metadata');
     expect(sel.cols).not.toContain('status');
+  });
+
+  test('the injected clock reaches the predicate, so eligibility is testable without waiting', async () => {
+    const { supabase, captured } = captureSb({ selectData: [] });
+    await checkNurseryTriggers({ supabase, logger: silentLogger, now: new Date('2030-01-01T00:00:00.000Z') });
+    expect(captured.ors.join(' ')).toContain('next_evaluation_at.lte.2030-01-01T00:00:00.000Z');
+  });
+});
+
+describe('applyPendingNurseryPredicate (FR-1: the single authoritative selector)', () => {
+  function fakeQuery(sink) {
+    const q = {
+      is: (c, v) => { sink.filters.push(['is', c, v]); return q; },
+      or: (e) => { sink.ors.push(e); return q; },
+      order: (c, o) => { sink.orders.push([c, o]); return q; },
+    };
+    return q;
+  }
+
+  test('excludes promoted rows, admits NULL schedules, and orders deterministically', () => {
+    const sink = { filters: [], ors: [], orders: [] };
+    applyPendingNurseryPredicate(fakeQuery(sink), { now: new Date('2026-07-25T00:00:00.000Z') });
+    expect(sink.filters).toContainEqual(['is', 'promoted_to_venture_id', null]);
+    expect(sink.ors[0]).toBe('next_evaluation_at.is.null,next_evaluation_at.lte.2026-07-25T00:00:00.000Z');
+    expect(sink.orders.map(([c]) => c)).toEqual(['current_score', 'created_at', 'id']);
+    expect(sink.orders[0][1]).toEqual({ ascending: false, nullsFirst: false });
+  });
+
+  test('returns the query so it composes with .limit() and with fetchAllPaginated', () => {
+    const sink = { filters: [], ors: [], orders: [] };
+    const q = fakeQuery(sink);
+    expect(applyPendingNurseryPredicate(q, {})).toBe(q);
   });
 });
 
@@ -390,10 +455,30 @@ describe('source pins (FR-2: phantom columns gone from BOTH files)', () => {
   it("discovery-mode's nursery_reeval SELECT is live-schema and the KNOWN-BROKEN pragma is GONE", () => {
     const start = discoverySrc.indexOf('async function runNurseryReeval');
     const reevalBlock = discoverySrc.slice(start, start + 3500);
-    expect(reevalBlock).toContain("is('promoted_to_venture_id', null)");
-    expect(reevalBlock).toContain('source_ref');
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-1: the promoted-row filter moved OUT of this
+    // block and into applyPendingNurseryPredicate. Pinning the shared selector is a
+    // STRONGER assertion than the old inline-literal pin — it fails if this reader ever
+    // re-grows its own private predicate, which is the drift that caused the three
+    // disagreeing selectors in the first place.
+    expect(reevalBlock).toContain('applyPendingNurseryPredicate');
+    expect(reevalBlock).toContain('NURSERY_PENDING_COLUMNS');
+    expect(reevalBlock).not.toContain("is('promoted_to_venture_id', null)");
     expect(reevalBlock).not.toContain('schema-lint-disable-line');
     expect(reevalBlock).not.toContain('original_score');
     expect(reevalBlock).not.toContain("eq('status'");
+  });
+
+  it('the authoritative predicate lives in exactly ONE place', () => {
+    // The whole point of FR-1. If a second module grows its own eligibility filter, the
+    // "empty selection forever" class returns. NURSERY_PENDING_COLUMNS must carry
+    // current_score, since score-first ordering is what surfaces the 90s.
+    expect(nurserySrc).toContain('export function applyPendingNurseryPredicate');
+    expect(nurserySrc).toMatch(/next_evaluation_at\.is\.null/);
+    expect(nurserySrc).toContain('current_score');
+    // The JS-side truthiness guard that excluded NULL must not come back. Comments are
+    // stripped first: the header deliberately QUOTES the old broken expression to explain
+    // the defect, and a naive source scan would flag that documentation as the bug itself.
+    const codeOnly = nurserySrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/nextReview\s*&&/);
   });
 });

--- a/tests/unit/eva/stage-zero/venture-nursery.test.js
+++ b/tests/unit/eva/stage-zero/venture-nursery.test.js
@@ -19,6 +19,8 @@ import {
   recordSynthesisFeedback,
   checkNurseryTriggers,
   applyPendingNurseryPredicate,
+  recordNurseryEvaluation,
+  NURSERY_EVAL_TRIGGER_TYPES,
   getNurseryHealth,
   toNurseryMaturityLevel,
   toNurserySourceType,
@@ -379,6 +381,76 @@ describe('checkNurseryTriggers (FR-2: next_evaluation_at + promoted_to_venture_i
     const { supabase, captured } = captureSb({ selectData: [] });
     await checkNurseryTriggers({ supabase, logger: silentLogger, now: new Date('2030-01-01T00:00:00.000Z') });
     expect(captured.ors.join(' ')).toContain('next_evaluation_at.lte.2030-01-01T00:00:00.000Z');
+  });
+});
+
+describe('recordNurseryEvaluation (FR-4: the witness writer that never existed)', () => {
+  test('throws on missing supabase and on missing nurseryId', async () => {
+    await expect(recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual' }, {}))
+      .rejects.toThrow('supabase client is required');
+    const { supabase } = captureSb();
+    await expect(recordNurseryEvaluation({ triggerType: 'manual' }, { supabase, logger: silentLogger }))
+      .rejects.toThrow('nurseryId is required');
+  });
+
+  test('REJECTS nursery_reeval — the value the strategy uses is NOT a legal trigger_type', async () => {
+    const { supabase } = captureSb();
+    // The queue strategy is called nursery_reeval, so reaching for it here is the natural
+    // mistake; the CHECK constraint does not admit it. Failing in JS names the legal set
+    // instead of surfacing an opaque constraint violation from the driver.
+    await expect(recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'nursery_reeval' }, { supabase, logger: silentLogger }))
+      .rejects.toThrow(/nursery_reeval is NOT a valid member/);
+  });
+
+  test.each(['capability_added', 'market_shift', 'portfolio_gap', 'related_outcome', 'periodic_review', 'manual'])(
+    'accepts the live CHECK member %s',
+    async (triggerType) => {
+      const { supabase, captured } = captureSb();
+      await recordNurseryEvaluation({ nurseryId: 'n1', triggerType }, { supabase, logger: silentLogger });
+      expect(captured.inserts[0].payload.trigger_type).toBe(triggerType);
+    }
+  );
+
+  test('the mirror list matches the live CHECK constraint exactly', () => {
+    // A mirror, never a source of truth: adding a member here without the chairman-gated
+    // DDL would produce inserts the database rejects.
+    expect([...NURSERY_EVAL_TRIGGER_TYPES].sort()).toEqual(
+      ['capability_added', 'manual', 'market_shift', 'periodic_review', 'portfolio_gap', 'related_outcome']
+    );
+    expect(NURSERY_EVAL_TRIGGER_TYPES).not.toContain('nursery_reeval');
+  });
+
+  test('trigger type is a PARAMETER — a manual demo is not labelled a periodic firing', async () => {
+    const { supabase, captured } = captureSb();
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual' }, { supabase, logger: silentLogger });
+    await recordNurseryEvaluation({ nurseryId: 'n2', triggerType: 'periodic_review' }, { supabase, logger: silentLogger });
+    expect(captured.inserts.map((i) => i.payload.trigger_type)).toEqual(['manual', 'periodic_review']);
+  });
+
+  test('writes only live columns, and leaves evaluated_by to the DEFAULT unless named', async () => {
+    const LIVE_LOG_COLUMNS = new Set([
+      'nursery_id', 'trigger_type', 'trigger_details', 'previous_score', 'new_score',
+      'previous_maturity', 'new_maturity', 'evaluation_notes', 'evaluated_by',
+    ]);
+    const { supabase, captured } = captureSb();
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual', previousScore: 90, newScore: 92, notes: 'n' }, { supabase, logger: silentLogger });
+    const payload = captured.inserts[0].payload;
+    for (const k of Object.keys(payload)) expect(LIVE_LOG_COLUMNS.has(k), `phantom column: ${k}`).toBe(true);
+    expect(payload).not.toHaveProperty('evaluated_by'); // column DEFAULT stage0_engine
+    expect(payload).toMatchObject({ nursery_id: 'n1', previous_score: 90, new_score: 92, evaluation_notes: 'n' });
+  });
+
+  test('records a named actor when one is supplied', async () => {
+    const { supabase, captured } = captureSb();
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual', evaluatedBy: 'alpha-2-demo' }, { supabase, logger: silentLogger });
+    expect(captured.inserts[0].payload.evaluated_by).toBe('alpha-2-demo');
+  });
+
+  test('non-numeric scores become NULL rather than NaN', async () => {
+    const { supabase, captured } = captureSb();
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual', previousScore: undefined, newScore: 'x' }, { supabase, logger: silentLogger });
+    expect(captured.inserts[0].payload.previous_score).toBeNull();
+    expect(captured.inserts[0].payload.new_score).toBeNull();
   });
 });
 

--- a/tests/unit/eva/stage-zero/venture-nursery.test.js
+++ b/tests/unit/eva/stage-zero/venture-nursery.test.js
@@ -20,6 +20,7 @@ import {
   checkNurseryTriggers,
   applyPendingNurseryPredicate,
   recordNurseryEvaluation,
+  advanceNurserySchedule,
   NURSERY_EVAL_TRIGGER_TYPES,
   getNurseryHealth,
   toNurseryMaturityLevel,
@@ -451,6 +452,86 @@ describe('recordNurseryEvaluation (FR-4: the witness writer that never existed)'
     await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual', previousScore: undefined, newScore: 'x' }, { supabase, logger: silentLogger });
     expect(captured.inserts[0].payload.previous_score).toBeNull();
     expect(captured.inserts[0].payload.new_score).toBeNull();
+  });
+});
+
+// COND-2 from adversarial review, found by grepping the whole write surface for an
+// ABSENCE: exactly ONE write to next_evaluation_at exists (parkVenture's INSERT) and no
+// UPDATE of it anywhere, so the column is WRITE-ONCE. Harmless while nothing consumes the
+// predicate on a schedule; a live defect the moment FR-6 wires a sweep, because every row
+// eligible once stays eligible forever and each sweep re-enqueues a ~16-LLM-call chain.
+describe('advanceNurserySchedule (COND-2: the write-once lifecycle gap)', () => {
+  test('throws on missing supabase or nurseryId', async () => {
+    await expect(advanceNurserySchedule('n1', {})).rejects.toThrow('supabase client is required');
+    const { supabase } = captureSb({ singleData: { evaluation_interval_days: 30 } });
+    await expect(advanceNurserySchedule(null, { supabase, logger: silentLogger })).rejects.toThrow('nurseryId is required');
+  });
+
+  test('moves next_evaluation_at INTO THE FUTURE by the row interval, and stamps last_evaluated_at', async () => {
+    const now = new Date('2026-07-25T00:00:00.000Z');
+    const { supabase, captured } = captureSb({ singleData: { evaluation_interval_days: 30 } });
+    const out = await advanceNurserySchedule('n1', { supabase, logger: silentLogger, now });
+    expect(out).toEqual({ next_evaluation_at: '2026-08-24T00:00:00.000Z', interval_days: 30 });
+    const upd = captured.updates.find((u) => u.table === 'venture_nursery');
+    expect(upd.payload.next_evaluation_at).toBe('2026-08-24T00:00:00.000Z');
+    expect(upd.payload.last_evaluated_at).toBe('2026-07-25T00:00:00.000Z');
+    // The whole point: after advancing, the row is NO LONGER eligible under the selector.
+    expect(new Date(upd.payload.next_evaluation_at).getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  test('honours a non-default interval', async () => {
+    const now = new Date('2026-07-25T00:00:00.000Z');
+    const { supabase, captured } = captureSb({ singleData: { evaluation_interval_days: 7 } });
+    await advanceNurserySchedule('n1', { supabase, logger: silentLogger, now });
+    expect(captured.updates[0].payload.next_evaluation_at).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  test.each([[0], [null], [undefined], [-5], ['x']])(
+    'falls back to the 30d DEFAULT for a non-positive/absent interval (%s) rather than rescheduling to now',
+    async (evaluation_interval_days) => {
+      const now = new Date('2026-07-25T00:00:00.000Z');
+      const { supabase, captured } = captureSb({ singleData: { evaluation_interval_days } });
+      await advanceNurserySchedule('n1', { supabase, logger: silentLogger, now });
+      // A zero interval would reschedule to NOW and reproduce permanent eligibility —
+      // the exact bug this function closes.
+      expect(captured.updates[0].payload.next_evaluation_at).toBe('2026-08-24T00:00:00.000Z');
+      expect(new Date(captured.updates[0].payload.next_evaluation_at).getTime()).toBeGreaterThan(now.getTime());
+    }
+  );
+
+  test('TWO-RUN GUARD: recording an evaluation advances the schedule, so a second sweep skips the row', async () => {
+    const now = new Date('2026-07-25T00:00:00.000Z');
+    const { supabase, captured } = captureSb({ singleData: { evaluation_interval_days: 30 } });
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'periodic_review' }, { supabase, logger: silentLogger, now });
+    const upd = captured.updates.find((u) => u.table === 'venture_nursery');
+    expect(upd, 'recording an evaluation MUST advance the schedule').toBeDefined();
+    // Single-run tests cannot see this defect — it only appears on the second sweep, when
+    // an unadvanced row is re-selected and re-enqueued.
+    expect(new Date(upd.payload.next_evaluation_at).getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  test('advancement is NOT opt-in — the failure mode is a caller that forgets', async () => {
+    const { supabase, captured } = captureSb({ singleData: { evaluation_interval_days: 30 } });
+    await recordNurseryEvaluation({ nurseryId: 'n1', triggerType: 'manual' }, { supabase, logger: silentLogger });
+    expect(captured.updates.some((u) => u.table === 'venture_nursery')).toBe(true);
+  });
+
+  test('an evaluation that happened is still recorded even if the reschedule write fails', async () => {
+    // Fail-soft: the evaluation is a true fact worth keeping. Losing the log row because
+    // the follow-up UPDATE failed would discard evidence to protect a schedule.
+    const supabase = { from: (table) => ({
+      insert: () => ({ select: () => ({ single: async () => ({ data: { id: 'log-1' }, error: null }) }) }),
+      select: () => ({ eq: () => ({ single: async () => ({ data: null, error: { message: 'read boom' } }) }) }),
+      update: () => ({ eq: async () => ({ error: { message: 'boom' } }) }),
+      _t: table,
+    }) };
+    const warn = vi.fn();
+    const result = await recordNurseryEvaluation(
+      { nurseryId: 'n1', triggerType: 'manual' },
+      { supabase, logger: { log: vi.fn(), warn } }
+    );
+    expect(result).toMatchObject({ id: 'log-1' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('reschedule failed'));
   });
 });
 


### PR DESCRIPTION
Ships **FR-1, FR-2, FR-3 AC-2, FR-4 and COND-2** of SD-EHG-IDEATION-PIPELINE-SEAMS-001. FR-5, FR-6 and FR-7 follow in a second PR — FR-5 is blocked on a chairman capacity decision (see below), FR-6 is sequenced after it, and FR-7 is last by the SD's back-to-front rule. Merging these five first is the SD's own binding merge order, and it is decision-independent: none of options A/B/C below would revert any of it.

## What the SD is for

The venture ideation pipeline doesn't carry an idea from signal to chairman gate without a human moving it between stages. The nursery has promoted exactly one idea in 15 days, and that one was an out-of-band manual patch the repo itself documents — not a repeatable code path.

## The diagnosis moved twice, and both corrections are load-bearing

The SD said NULL `next_evaluation_at` on 16/16 rows causes an "empty selection forever". I first reported that as simply false. **Both were partly wrong.**

There are **three** selection layers over `venture_nursery` and they disagree:

| selector | admits NULL? | ordering | consumers |
|---|---|---|---|
| `v_nursery_pending_evaluation` | yes | score DESC | **zero** — correct but dead |
| `checkNurseryTriggers` | **no** (`&&` excludes NULL) | none | zero production callers |
| `runNurseryReeval` | ignores the column entirely | `created_at` ASC | the only wired reader |

So "empty selection forever" is literally true — of a function nothing calls. Meanwhile the *wired* reader never compares the column at all and sorts oldest-first, so the score-90 candidates were never prioritised. Measured root cause: **zero** `stage_zero_requests` rows with `strategy=nursery_reeval` have ever been enqueued, and `nursery_evaluation_log` has zero rows.

## What's in this branch

- **FR-1** — `applyPendingNurseryPredicate`: one authoritative selector, both readers routed through it. NULL is admitted deliberately (never scheduled must mean eligible now, not invisible forever). Score-first with a **stable tiebreak**, because five live rows tie at 90 and one of them is the live first-revenue venture — a non-deterministic top-of-list isn't acceptable there.
- **FR-2** — `parkFailedCandidate` (which wrote *all 16* live rows) now writes an **immediately-eligible** `next_evaluation_at`. Explicitly **not** `parkVenture`'s `now+90d`: the predicate admits `IS NULL OR <= now()`, so copying that convention would have made rows invisible for 90 days and caused the very outage this SD exists to fix.
- **FR-3 AC-2** — six fixture families excluded from the WIP count, established by enumerating all 46 counted rows rather than sampling.
- **FR-4** — the `nursery_evaluation_log` writer that never existed. Trigger type is a **parameter** so a hand-run demo is never labelled a periodic firing; `nursery_reeval` is rejected in JS with the legal set named, and the CHECK constraint is not altered.
- **COND-2** — `next_evaluation_at` was **write-once**: one INSERT, no UPDATE anywhere in the repo. Harmless today, but the moment FR-6 wires a sweep every row eligible once stays eligible forever, re-enqueuing the same 15 rows on every run at ~16 LLM calls each. FR-2 and FR-6 were individually correct and **jointly broken**.

**Nothing here changes runtime behaviour today.** Both FR-1 and FR-2 alter what happens *when something reads the nursery on a schedule* — and wiring that reader is FR-6, which is the whole point of the SD. There is no scheduled consumer to perturb.

## Why FR-3 does not clear the WIP wall

Deliberate. Enumerating all 46 rows the gate counts: 44 are fixtures, and exactly **two are real** — ApexNiche AI and Image Alt Text Generator (the live first-revenue venture). The limit is 2 and the gate compares with `>=`, so it still refuses.

**The gate is working correctly.** The portfolio genuinely holds two live ventures and the SD asks to promote a third. That's a portfolio decision, not an engineering fix, so `eva_config stage0.wip_limit` is untouched and three tests exist specifically so the standing pressure to widen the fixture list can't silently swallow a real venture.

## Verification

**841 stage-zero tests green** (56 files); full unit project re-run after a fourth nursery mock outside the edited directory was caught only by CI. Two notes on test honesty:

- FR-1 moved eligibility filtering from JS **into the query**, so the old "feed the mock two rows, expect one back" test was only ever testing the mock — a mock can't evaluate SQL. The unit tests now assert the **predicate shape** and say so; whether the database returns the right rows is an integration scenario.
- COND-2 is **invisible to any single-run test**; it first appears on the second sweep. Hence an explicit two-run guard.

A source-pin test broke when the filter moved into a shared function. It wasn't deleted — it now pins the *shared selector*, which is strictly stronger: it fails if either reader ever re-grows a private predicate, which is the drift that produced three selectors. Its no-regression scan strips comments first, because the new header deliberately quotes the old broken expression to explain the defect.

## Blocked on a chairman decision — and the ask is smaller than first stated

FR-5 (prove one named row traverses to Stage-0 by execution) needs one of:

- **A** — raise `stage0.wip_limit` 2→3 as a recorded capacity decision *(recommended)*
- **B** — complete or cancel a live venture
- **C** — descope FR-5 to terminate at the capacity refusal, creating no venture

Re-reading `chairman-review.js` sharpens what A actually authorises. The WIP gate sits at line 230 inside `persistVentureBrief`, **not** in `conductChairmanReview` — and the venture it guards is inserted with `status: 'paused'` and `awaiting_chairman_decision: true`, then hands off to a *separate* authentic-approval gate (`decision-activation.js`) before anything goes live. So **A does not approve a third live venture** — it lets a third venture reach the chairman's decision queue, where it still needs an explicit approval. Two gates in series, not one.

That also means **C proves more than it sounds like**: everything upstream of the insert executes for real, so both witnesses that are empty today — a `stage_zero_requests` row with `strategy=nursery_reeval` and a `nursery_evaluation_log` row — get written, and the run terminates at a *correct refusal*. Only the third witness (a `ventures` row) needs capacity.

## Size

**+915 / −44 across 10 files**, over the 400-LOC ceiling. Roughly 430 lines are tests and ~330 production across five sequenced requirements for a Tier-3 SD. Splitting further would ship the shared predicate without the writer that makes it correct, or the sweep without the lifecycle advancement that stops it re-enqueuing forever — both are the wrong seams to cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
