### PR TITLE
fix(QF-20260725-076): scope the CP3 reboot-respawn queries to the RUN, not all history

### DIFF
--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -103,29 +103,65 @@ export async function defaultRunDrills(plan, deps = {}) {
       .eq('session_id', sid).like('event_type', 'fleet_verb_%');
     return data || [];
   });
-  // QF-20260724-113 (FR-b): reboot-respawn's respawn_events_present check takes a NO-ARG
-  // queryEventsFn (unlike U4's session-scoped one, since reboot-respawn creates one replacement
-  // session PER slot, not a single target) -- without this the live CLI path always failed
-  // respawn_events_present ("no queryEventsFn supplied") even on a genuinely successful respawn.
-  const rebootQueryEventsFn = deps.rebootQueryEventsFn || (async () => {
-    const { data } = await supabase.from('coordination_events').select('event_type,payload,session_id')
-      .eq('event_type', 'fleet_verb_respawn').order('created_at', { ascending: false }).limit(50);
-    return data || [];
-  });
-  // QF-20260724-070: wire the durable-bind-audit query so the live drill's respawn_bind_audited check
-  // (a real heartbeat proof recorded AT BIND TIME, surviving the session later ghosting) has real
-  // evidence to read -- without this the check would fail-closed on every genuine live bind.
-  const rebootQueryLifecycleEventsFn = deps.rebootQueryLifecycleEventsFn || (async () => {
-    const { data } = await supabase.from('session_lifecycle_events').select('event_type,session_id')
-      .eq('event_type', 'RESPAWN_BIND_VERIFIED').order('created_at', { ascending: false }).limit(50);
-    return data || [];
-  });
+  // QF-20260725-076: SCOPE THE REBOOT QUERIES TO THE RUN. Both selected the 50 most recent rows IN
+  // ALL OF HISTORY, and the checks then reasoned over them as if they were this run. One cause, two
+  // opposite breakages:
+  //   - CERTAIN FALSE FAIL on check 5 (respawn_bind_audited): four bound-but-unaudited respawns from
+  //     2026-07-25T00:17Z sit in the window while RESPAWN_BIND_VERIFIED is 0 rows ALL-TIME, so the
+  //     check evaluated auditedCount === boundSessionIds.length as 0 === 4. A flawless run did not
+  //     save it — one perfect new bind made it 1 === 5, still red. NO drill outcome could pass.
+  //   - FALSE PASS on check 4 (respawn_events_present): those same historical rows counted toward
+  //     respawnEvents >= slots.length, so it could go green even if this run emitted nothing.
+  // QF-20260724-828 hardened the PREDICATE and left the POPULATION — tightening what counts as a
+  // valid row does nothing when the row set is the wrong row set.
+  //
+  // The correlator is a run-start TIMESTAMP, not sdKey alone: sdKey defaults to the constant
+  // 'CHECKPOINT-3' and is stamped on every CP3 run ever, so filtering on it would still admit prior
+  // runs. Events from THIS invocation can only be created after this instant.
+  const runStartedAt = deps.runStartedAt || new Date().toISOString();
 
   // QF-20260724-335: an explicit, intentional run-correlator stamped on all 3 leg fleet_verb events
   // of this single --live invocation. Timing/session-proximity correlation is insufficient (a stray
   // dry-run/accidental-spawn batch can collide with a real run) -- Solomon's S7 acceptance requires a
   // unique intentional binding of the 3 legs to one CP3 run.
+  // QF-20260725-076 moved this ABOVE the reboot query closures that now read it. It previously sat
+  // below them and worked only because those closures are invoked later; any earlier call would have
+  // thrown a TDZ ReferenceError. Declaring it before its consumers removes the trap.
   const sdKey = deps.sdKey || 'CHECKPOINT-3';
+
+  // QF-20260724-113 (FR-b): reboot-respawn's respawn_events_present check takes a NO-ARG
+  // queryEventsFn (unlike U4's session-scoped one, since reboot-respawn creates one replacement
+  // session PER slot, not a single target) -- without this the live CLI path always failed
+  // respawn_events_present ("no queryEventsFn supplied") even on a genuinely successful respawn.
+  const rebootQueryEventsFn = deps.rebootQueryEventsFn || (async () => {
+    const { data, error } = await supabase.from('coordination_events').select('event_type,payload,session_id')
+      .eq('event_type', 'fleet_verb_respawn')
+      .eq('sd_key', sdKey)                     // intentional run correlator (QF-20260724-335)
+      .gte('created_at', runStartedAt)         // THIS run only (QF-20260725-076)
+      .order('created_at', { ascending: false }).limit(50);
+    // A FAILED query is not "no events": returning [] on error would let a broken lookup read as
+    // "this run emitted nothing" and fail the drill for the wrong reason. Surface it instead.
+    if (error) throw new Error(`rebootQueryEventsFn: coordination_events lookup failed: ${error.message}`);
+    return data || [];
+  });
+  // QF-20260724-070: wire the durable-bind-audit query so the live drill's respawn_bind_audited check
+  // (a real heartbeat proof recorded AT BIND TIME, surviving the session later ghosting) has real
+  // evidence to read -- without this the check would fail-closed on every genuine live bind.
+  // QF-20260725-076: run-scoped for the SAME reason as the events query above, and this is the half
+  // that made check 5 unsatisfiable. It counts audited binds; pairing an all-history audited count
+  // with an all-history bound count is what made the equality impossible to satisfy. Scoping BOTH
+  // sides to this run is what makes auditedCount === boundSessionIds.length describe one run.
+  // session_lifecycle_events has no sd_key column, so the timestamp is the only correlator here.
+  const rebootQueryLifecycleEventsFn = deps.rebootQueryLifecycleEventsFn || (async () => {
+    const { data, error } = await supabase.from('session_lifecycle_events').select('event_type,session_id')
+      .eq('event_type', 'RESPAWN_BIND_VERIFIED')
+      .gte('created_at', runStartedAt)         // THIS run only (QF-20260725-076)
+      .order('created_at', { ascending: false }).limit(50);
+    // Same fail-loud rationale: [] on a failed lookup would understate auditedCount and fail check 5
+    // as if the binds were unaudited — the exact defect this QF exists to remove.
+    if (error) throw new Error(`rebootQueryLifecycleEventsFn: session_lifecycle_events lookup failed: ${error.message}`);
+    return data || [];
+  });
 
   // QF-20260724-499: defaultRunDrills only ever runs after main()'s `if (!live) return` gate, so
   // live is ALREADY known true here -- pass it explicitly on every leg (as reboot already did)

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -99,8 +99,10 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
   it('the default rebootQueryEventsFn queries fleet_verb_respawn events with no required argument', async () => {
     const eq = vi.fn().mockReturnThis();
     const order = vi.fn().mockReturnThis();
+    // QF-20260725-076: the query is now RUN-SCOPED, so the chain includes .gte('created_at', ...).
+    const gte = vi.fn().mockReturnThis();
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'fleet_verb_respawn' }, { event_type: 'fleet_verb_respawn' }] });
-    const select = vi.fn(() => ({ eq, order, limit }));
+    const select = vi.fn(() => ({ eq, order, gte, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
     const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
     const resolveCanaryTarget = vi.fn(async () => target);
@@ -122,6 +124,67 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
     expect(eq).toHaveBeenCalledWith('event_type', 'fleet_verb_respawn');
     expect(res.reboot.pass).toBe(true);
   });
+
+  // QF-20260725-076: the query must describe THIS RUN. Unscoped, it returned the 50 most recent
+  // respawn events in ALL OF HISTORY and the checks reasoned over them as if they were this run —
+  // making check 5 permanently unpassable (auditedCount === boundSessionIds.length evaluated
+  // 0 === 4 against four stale bound rows, and a flawless run only made it 1 === 5) while check 4
+  // could pass VACUOUSLY on those same stale rows even if this run emitted nothing.
+  it('scopes respawn events to THIS RUN by created_at, and to the run correlator', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const order = vi.fn().mockReturnThis();
+    const gte = vi.fn().mockReturnThis();
+    const limit = vi.fn().mockResolvedValue({ data: [] });
+    const select = vi.fn(() => ({ eq, order, gte, limit }));
+    const supabase = { from: vi.fn(() => ({ select })) };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    const runRebootRespawnDrill = vi.fn(async (args) => { await args.queryEventsFn(); return { pass: true, checks: [] }; });
+
+    const before = new Date().toISOString();
+    await defaultRunDrills({ canaryProfile: 'canary', cwd: 'R:\\r', legs: [] }, {
+      supabase,
+      resolveCanaryTarget: vi.fn(async () => target),
+      canaryRestart: vi.fn(async () => ({ outcome: 'ok' })),
+      canaryRelaunchUnderProfile: vi.fn(async () => ({ outcome: 'ok' })),
+      runRebootRespawnDrill,
+      runU4Drill: vi.fn(async () => ({ pass: true })),
+    });
+
+    // A created_at lower bound exists and is not some historical constant — it is >= the instant
+    // this run began, which is what makes "this run" actually mean this run.
+    const gteCall = gte.mock.calls.find((c) => c[0] === 'created_at');
+    expect(gteCall, 'expected a .gte("created_at", ...) run scope').toBeTruthy();
+    expect(Date.parse(gteCall[1])).toBeGreaterThanOrEqual(Date.parse(before) - 1000);
+    // …and the intentional run correlator is still applied (QF-20260724-335).
+    expect(eq).toHaveBeenCalledWith('sd_key', 'CHECKPOINT-3');
+  });
+
+  it('FAILS LOUD on a query error instead of returning [] (an empty set would read as "no events")', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const order = vi.fn().mockReturnThis();
+    const gte = vi.fn().mockReturnThis();
+    const limit = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const select = vi.fn(() => ({ eq, order, gte, limit }));
+    const supabase = { from: vi.fn(() => ({ select })) };
+    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    let caught = null;
+    const runRebootRespawnDrill = vi.fn(async (args) => {
+      try { await args.queryEventsFn(); } catch (e) { caught = e; }
+      return { pass: true, checks: [] };
+    });
+
+    await defaultRunDrills({ canaryProfile: 'canary', cwd: 'R:\\r', legs: [] }, {
+      supabase,
+      resolveCanaryTarget: vi.fn(async () => target),
+      canaryRestart: vi.fn(async () => ({ outcome: 'ok' })),
+      canaryRelaunchUnderProfile: vi.fn(async () => ({ outcome: 'ok' })),
+      runRebootRespawnDrill,
+      runU4Drill: vi.fn(async () => ({ pass: true })),
+    });
+
+    expect(caught, 'a failed lookup must not be swallowed into an empty event set').toBeTruthy();
+    expect(caught.message).toMatch(/lookup failed/);
+  });
 });
 
 // QF-20260724-070: the live drill must be wired with a queryLifecycleEventsFn so the new
@@ -130,8 +193,10 @@ describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-
   it('threads a default queryLifecycleEventsFn into runRebootRespawnDrill that reads RESPAWN_BIND_VERIFIED rows', async () => {
     const eq = vi.fn().mockReturnThis();
     const order = vi.fn().mockReturnThis();
+    // QF-20260725-076: run-scoped too — BOTH sides of check 5's equality must describe the same run.
+    const gte = vi.fn().mockReturnThis();
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-1' }] });
-    const select = vi.fn(() => ({ eq, order, limit }));
+    const select = vi.fn(() => ({ eq, order, gte, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
     const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
     const resolveCanaryTarget = vi.fn(async () => target);
@@ -151,6 +216,11 @@ describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-
     expect(select).toHaveBeenCalledWith('event_type,session_id');
     expect(eq).toHaveBeenCalledWith('event_type', 'RESPAWN_BIND_VERIFIED');
     expect(res.reboot.pass).toBe(true);
+    // QF-20260725-076: the audited-bind side is run-scoped as well. Without this, check 5 compared
+    // an all-history audited count against an all-history bound count — and since
+    // RESPAWN_BIND_VERIFIED had ZERO rows all-time while four stale bound rows sat in the window,
+    // no drill outcome whatsoever could satisfy it.
+    expect(gte).toHaveBeenCalledWith('created_at', expect.any(String));
   });
 });
 


### PR DESCRIPTION
## Summary

The last blocker on an admissible CP3 verdict. Both reboot queries in `defaultRunDrills` selected the **50 most recent rows in all of history** — no time bound, no run correlator, no session filter — and the drill checks reasoned over them as though they were this run.

**One cause, two opposite breakages:**

- **Certain false FAIL on check 5** (`respawn_bind_audited`). Four bound-but-unaudited respawns from 2026-07-25T00:17Z sit in the window while `RESPAWN_BIND_VERIFIED` has **zero rows all-time**, so `auditedCount === boundSessionIds.length` evaluated `0 === 4`. A flawless run doesn't save it — one perfect new bind makes it `1 === 5`, still red. **No drill outcome could pass** while those rows were in the population.
- **False PASS on check 4** (`respawn_events_present`). The same historical rows counted toward `respawnEvents >= slots.length`, so it could go green even if this run emitted nothing.

Verified against the live DB *before* fixing: most recent `fleet_verb_respawn` rows are ~23h old, and `RESPAWN_BIND_VERIFIED` returns 0 rows all-time.

QF-20260724-828 hardened the **predicate** and left the **population**. Tightening what counts as a valid row does nothing when the row set is the wrong row set.

## Why the correlator is a timestamp, not sdKey

`sdKey` defaults to the constant `'CHECKPOINT-3'` and is stamped on *every* CP3 run ever, so filtering on it alone would still admit prior runs. A run-start instant is captured before the legs execute; events from this invocation can only be created after it. `sdKey` is still applied to the `coordination_events` leg as the second intentional correlator (QF-20260724-335). `session_lifecycle_events` has no `sd_key` column, so the timestamp is the only correlator there — which is the point: **both sides of check 5's equality must describe the same run.**

## Also fixed (same class as the defect)

Both queries **discarded their Supabase error**. Returning `[]` on a failed lookup lets a broken query read as "this run emitted nothing" and fails the drill for the wrong reason — an empty result is a real answer, a failed one is not. Both now throw with the table named.

Moved the `sdKey` declaration **above** the closures that now read it; it sat below them and worked only because they're invoked later — any earlier call would have thrown a TDZ `ReferenceError`.

## Scope

Changes **only** the drill's query scoping. No drill was run and `.worktrees/cp3-drill-run` was not touched — verified no drill in flight first (no processes, drill worktree idle ~17h, respawn events 23.3h old).

## Test plan

- [x] 2 new tests, both verified **RED** against the unscoped queries (3 RED in total, including the existing lifecycle-wiring test which now pins its run scope).
- [x] The mock chain gained `.gte` because the query genuinely gained a scoping call — the scoping was **not** weakened to satisfy an outdated mock.
- [x] `tests/unit/fleet`: 84 files, **1012 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)