### PR TITLE
docs(SD-LEO-INFRA-LAUNCHER-CAN-HOST-001): retire a stale present-tense banner and record the gate's sequencing precondition

### DIFF
--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -89,6 +89,17 @@ export function assessCanarySlotNaming(slot) {
  * @param {{resolved?:boolean, identity?:object}} resolution  a resolveCanaryTarget result
  */
 export function isProvisioned(resolution) {
+  // SEQUENCING NOTE (SD-LEO-INFRA-LAUNCHER-CAN-HOST-001), added alongside QF-20260725-529's fix
+  // because the ORDER this landed in is load-bearing and invisible from the code alone:
+  //
+  // This two-conjunct gate is only safe BECAUSE spawn() already mints the 'Canary-' callsign. With a
+  // gate demanding both conjuncts and a spawn that stamps only account_profile, every provisioning run
+  // would spawn a fresh canary that STILL failed the gate — an unbounded spawn loop, windows piling up,
+  // no convergence. Taken in the other order this predicate is a foot-gun rather than a fix.
+  //
+  // So: do not port this predicate to a tree whose spawn path does not mint the callsign. The residual
+  // re-spawn risk here is bounded by spawn()'s own dedup-by-callsign — once a canary carries
+  // 'Canary-pilot', a second provisioning finds it live and skips.
   return assertCanaryTarget(resolution).ok === true;
 }
 

--- a/scripts/fleet/provision-canary.mjs
+++ b/scripts/fleet/provision-canary.mjs
@@ -2,10 +2,17 @@
 /**
  * provision-canary.mjs — SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 (FR-1).
  *
- * THE GAP THIS CLOSES. provisionCanary (lib/fleet/canary-provision.js:69) is imported by NOTHING
- * outside its own unit test — repo-wide grep confirms it; the only other match,
- * scripts/canary/run-canary-probe.mjs:67, is an unrelated same-named LOCAL function. So the
- * provisioning step exists, is tested, and has never once run. This file is the missing caller.
+ * WHAT THIS FILE IS. The CLI entrypoint for provisionCanary (lib/fleet/canary-provision.js). It
+ * imports that function below and calls it — this file IS the caller, and provisionCanary RUNS.
+ *
+ * This header used to open with "provisionCanary is imported by NOTHING outside its own unit test …
+ * has never once run", in the PRESENT TENSE. That was the problem statement this file was created to
+ * close, and it became false the moment the file existed. It is not a harmless leftover: a reader
+ * verified by direct inspection that the function WAS wired, then let this banner talk them back out
+ * of their own correct finding, and spent a full retraction cycle on it.
+ *
+ * A problem statement written in the present tense outlives the problem. Record the gap in the commit
+ * that closes it, not in a banner on the fix.
  *
  * HISTORY, KEPT SHORT AND CURRENT. This header used to say the CLI could not close discoverability:
  * that spawn() had no stamp step, that the only account_profile writer was stampRespawnedCanary on the


### PR DESCRIPTION
**Comment-only. No behaviour change.** 26 lines.

This is what remained after **QF-20260725-529** landed the gate fix I had independently built. I closed my duplicate (#6489) rather than merge churn onto a converged fix, and kept only the two pieces genuinely missing from main.

## 1. A stale banner that cost a reader a retraction cycle

`provision-canary.mjs` opened with:

> *"provisionCanary is imported by NOTHING outside its own unit test … has never once run"*

in the **present tense** — inside the very file that imports and calls it. That was the problem statement the file was created to close, and it became false the moment the file existed.

It is not a harmless leftover. A reader verified by direct inspection that the function **was** wired, then let this banner talk them back out of their own correct finding, and spent a full retraction cycle on it.

> A problem statement written in the present tense outlives the problem. Record the gap in the commit that closes it, not in a banner on the fix.

I had already corrected a *different* stale block in this same file and left this one — the third time in this SD I fixed an instance instead of the family (pid-join across three sites, the column-blind test fake, and now this).

## 2. The gate's sequencing precondition, invisible from the code

The two-conjunct `isProvisioned` gate is only safe **because** `spawn()` already mints the `Canary-` callsign.

With a gate demanding both conjuncts and a spawn stamping only `account_profile`, every provisioning run would spawn a fresh canary that **still** failed the gate — an unbounded spawn loop, windows piling up, no convergence. In the other order this predicate is a foot-gun rather than a fix.

Recorded at the predicate so nobody ports it to a tree whose spawn path doesn't mint. Also notes that the residual re-spawn risk is bounded by `spawn()`'s own dedup-by-callsign.

## Convergence note

QF-20260725-529 and I reached the same fix independently — same predicate, same discriminating half-provisioned test, same anti-drift equivalence pin, same `assessCanarySlotNaming` guard. **Theirs landed first.**

Checking whether the fleet had already fixed it *before* merging is what turned a conflicted 92-line duplicate into a 20-line comment.

## Verification

**1168 tests / 97 files green** with `CLAUDE_SESSION_ID`, `APPDATA`, `FLEET_ACCOUNT_PROFILES_DIR`, `FLEET_SPAWN_CONTROL_LIVE` all unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)