### PR TITLE
fix(QF-20260725-790): a dry_run row is not leg evidence under --live, and the verdict is printed

### DIFF
--- a/lib/fleet/reboot-respawn-drill-runner.js
+++ b/lib/fleet/reboot-respawn-drill-runner.js
@@ -115,6 +115,14 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
   // non-recovery could self-report respawn GREEN. Mirror the emitter's OWN verdict: count an event as
   // present only when it is genuinely bound (outcome 'ok' with a reconciled non-null session_id) OR an
   // explicit 'dry_run' mechanism emit (no live session by design) -- never a 'respawn_unbound' no-op.
+  // QF-20260725-790: the 2026-07-26T00:15Z acceptance attempt emitted exactly ONE row —
+  // fleet_verb_respawn, live:false, outcome:'dry_run', session_id:null — and zero
+  // session_lifecycle_events. Two legs never executed, yet this check passed 1 >= 1 because the
+  // dry_run exemption counted that row as present. That is the mechanism-ready-mistaken-for-live-
+  // passed failure ground_truth_acceptance exists to forbid, and it made every OTHER defect in that
+  // run invisible. The exemption is still CORRECT for a mechanism drill (no live session by design),
+  // so it is GATED on `live` rather than deleted — see the QF-20260725-813 block below, which
+  // reached that same gate independently and is kept as the canonical form.
   const respawnEvents = (events || []).filter((e) => {
     if (!e || e.event_type !== 'fleet_verb_respawn') return false;
     const outcome = e.payload?.outcome;
@@ -125,6 +133,13 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
     // 'respawn_unattempted' (live requested, spawn never attempted) is NEVER evidence.
     if (outcome === 'dry_run') return !live;                   // mechanism/dry-run: no live session by design
     if (outcome === 'respawn_unattempted') return false;       // live intent that never even attempted
+    // QF-20260725-790: 813 (above) and this QF landed independently on the same false ACCEPT and
+    // reached the SAME `return !live` gate for dry_run — 813's form is kept as canonical. This adds
+    // the one case it does not cover: a row the EMITTER ITSELF stamped live:false while carrying an
+    // otherwise-healthy outcome. 813 keys on `outcome`, so such a row would still pass its filter on
+    // a non-null session_id. Under --live that row is not live evidence regardless of how good its
+    // outcome looks.
+    if (live && e.payload?.live === false) return false;
     return outcome !== 'respawn_unbound' && e.session_id != null; // live: must have bound a real session
   }).length;
   checks.push({
@@ -149,11 +164,26 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
   const auditedIds = new Set((lifecycleEvents || [])
     .filter((e) => e && e.event_type === 'RESPAWN_BIND_VERIFIED').map((e) => e.session_id));
   const auditedCount = boundSessionIds.filter((id) => auditedIds.has(id)).length;
+  // QF-20260725-790: the `boundSessionIds.length === 0` escape is a TRIVIAL PASS. In the 00:15Z run it
+  // evaluated 0 === 0 and went green precisely BECAUSE nothing bound — the only row carried a null
+  // session_id so it never entered the population. Under a dry-run that escape is right (nothing is
+  // expected to bind). Under --live it inverts the check's meaning: "no evidence" is not "audited".
+  // A live drill that bound no session has not demonstrated recovery, so it must not pass here.
+  //
+  // This does NOT weaken the assertion the check already makes — every bound respawn must still carry
+  // a durable RESPAWN_BIND_VERIFIED row. It removes an escape hatch that only ever fired when the
+  // population was empty, which under live is exactly the failure being hidden.
+  const boundPopulationEmpty = boundSessionIds.length === 0;
+  const bindAuditPass = live
+    ? (!boundPopulationEmpty && typeof queryLifecycleEventsFn === 'function' && auditedCount === boundSessionIds.length)
+    : (boundPopulationEmpty || (typeof queryLifecycleEventsFn === 'function' && auditedCount === boundSessionIds.length));
   checks.push({
     name: 'respawn_bind_audited',
-    pass: boundSessionIds.length === 0 || (typeof queryLifecycleEventsFn === 'function' && auditedCount === boundSessionIds.length),
-    detail: boundSessionIds.length === 0
-      ? 'no session-bound respawn events to audit (dry-run or unbound)'
+    pass: bindAuditPass,
+    detail: boundPopulationEmpty
+      ? (live
+        ? 'LIVE drill bound ZERO sessions — no bind to audit, so recovery was never demonstrated (absence is not a pass)'
+        : 'no session-bound respawn events to audit (dry-run or unbound)')
       : `${auditedCount}/${boundSessionIds.length} bound session(s) have a durable RESPAWN_BIND_VERIFIED audit row`,
   });
 

--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -72,7 +72,55 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   }
   const run = deps.runDrills || defaultRunDrills;
   const results = await run(plan, deps);
-  return { ok: true, live: true, legs: plan.legs, results };
+  // QF-20260725-790: `ok` was hardcoded TRUE here, so a --live run reported success no matter what the
+  // legs actually did. Combined with the CLI discarding the results object entirely, the 00:15Z
+  // acceptance attempt executed almost nothing and still exited 0 with no output. Fixing the leg
+  // CHECKS without fixing this would have left the false pass fully intact at the exit code — the
+  // verdict has to be derived from the legs, not asserted.
+  //
+  // A leg counts as passing only if it explicitly says so. A leg that threw is captured by its
+  // .catch() as {error} and has no `pass`, so it must read as FAILURE, not as "no opinion".
+  const legVerdicts = summarizeLegVerdicts(results);
+  return { ok: legVerdicts.every((l) => l.pass), live: true, legs: plan.legs, results, legVerdicts };
+}
+
+/**
+ * QF-20260725-790: flatten the drill results into one inspectable verdict list.
+ * Fail-closed by construction: an unrecognized/errored leg yields pass:false rather than being skipped,
+ * so a leg that never ran can never silently drop out of the verdict.
+ */
+export function summarizeLegVerdicts(results) {
+  const out = [];
+  for (const [leg, r] of Object.entries(results || {})) {
+    if (!r || typeof r !== 'object') { out.push({ leg, pass: false, detail: 'no result object' }); continue; }
+    if (r.error) { out.push({ leg, pass: false, detail: `ERROR: ${r.error}` }); continue; }
+    if (Array.isArray(r.checks)) {
+      for (const c of r.checks) out.push({ leg, check: c.name, pass: c.pass === true, detail: c.detail });
+      // A leg reporting zero checks has demonstrated nothing — do not let it count as a pass.
+      if (r.checks.length === 0) out.push({ leg, pass: false, detail: 'leg reported ZERO checks' });
+      continue;
+    }
+    // Legs without a checks[] (e.g. canaryRestart) state their verdict directly instead. Accept only
+    // an EXPLICIT affirmative — pass:true, ok:true, or outcome:'ok'. Anything else (including a leg
+    // that simply says nothing) is a failure, so silence can never be mistaken for success.
+    const ok = r.pass === true || r.ok === true || r.outcome === 'ok';
+    out.push({ leg, pass: ok, detail: r.outcome ? `outcome=${r.outcome}` : JSON.stringify(r).slice(0, 160) });
+  }
+  return out;
+}
+
+/**
+ * QF-20260725-790: render the verdict so it is INSPECTABLE rather than inferred from an exit code.
+ * The CLI previously did main().then(r => process.exit(r.ok ? 0 : 1)), discarding every check.
+ */
+export function formatDrillReport(r) {
+  const lines = [`[start-cp3-drills] RESULT ok=${r.ok === true} live=${r.live === true}`];
+  if (r.error) lines.push(`  ERROR: ${r.error}`);
+  for (const v of r.legVerdicts || []) {
+    lines.push(`  ${v.pass ? 'PASS' : 'FAIL'}  ${v.leg}${v.check ? '/' + v.check : ''} — ${v.detail || ''}`);
+  }
+  if (!r.legVerdicts || r.legVerdicts.length === 0) lines.push('  (no leg verdicts — nothing executed)');
+  return lines.join('\n');
 }
 
 /**
@@ -173,5 +221,11 @@ export async function defaultRunDrills(plan, deps = {}) {
 
 const isMain = process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
 if (isMain) {
-  main().then((r) => process.exit(r.ok ? 0 : 1)).catch((e) => { console.error('[start-cp3-drills] FATAL', e && e.message); process.exit(1); });
+  // QF-20260725-790: PRINT the results object before exiting. The old form discarded `r` entirely, so
+  // a run that executed almost nothing produced no artifact anyone could inspect and looked clean from
+  // the outside. The exit code alone is not a verdict.
+  main().then((r) => {
+    console.log(formatDrillReport(r));
+    process.exit(r.ok ? 0 : 1);
+  }).catch((e) => { console.error('[start-cp3-drills] FATAL', e && e.message); process.exit(1); });
 }

--- a/tests/unit/fleet/reboot-respawn-drill-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-drill-runner.test.js
@@ -34,6 +34,80 @@ describe('runRebootRespawnDrill (FR-7)', () => {
     expect(checks.every((c) => c.pass)).toBe(true);
   });
 
+  // QF-20260725-790: the false pass that made every other defect in the 2026-07-26T00:15Z CP3
+  // acceptance attempt invisible. That run emitted exactly ONE row — fleet_verb_respawn with
+  // live:false, outcome:'dry_run', session_id:null — and zero session_lifecycle_events. Two legs never
+  // executed, yet BOTH guard checks went green: check 4 counted the dry_run row (1 >= 1) and check 5
+  // passed trivially at 0 === 0 because a null session_id never enters the bound population.
+  // These reproduce that exact population and assert it now goes RED under --live.
+  describe('QF-20260725-790: a dry_run row is NOT leg evidence under --live', () => {
+    const DRY_RUN_ROW = { event_type: 'fleet_verb_respawn', session_id: null, payload: { live: false, outcome: 'dry_run' } };
+
+    it('check 4 REJECTS dry_run rows under live (was N >= N PASS on a run that did nothing)', async () => {
+      // Supply ONE dry_run row PER SLOT. With fewer rows than slots the check would fail on the count
+      // alone and this test would go red for a reason unrelated to the fix — verified: an earlier
+      // single-row version passed against the UNFIXED code, which is no evidence at all. Saturating
+      // the count isolates the population filter as the only thing that can turn it red.
+      const rows = SLOTS.map(() => ({ ...DRY_RUN_ROW }));
+      const { checks, pass } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }), queryEventsFn: async () => rows,
+        queryLifecycleEventsFn: async () => [], live: true,
+      });
+      expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(false);
+      expect(pass).toBe(false);
+    });
+
+    it('check 5 does NOT pass trivially on an EMPTY bound population under live (was 0 === 0)', async () => {
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }), queryEventsFn: async () => [DRY_RUN_ROW],
+        queryLifecycleEventsFn: async () => [], live: true,
+      });
+      const c5 = checks.find((c) => c.name === 'respawn_bind_audited');
+      expect(c5.pass).toBe(false);
+      expect(c5.detail).toMatch(/absence is not a pass/);
+    });
+
+    it('a row the emitter stamped live:false is rejected under live even if its outcome looks ok', async () => {
+      // Count-saturated for the same reason, and each row is fully bind-audited — so under the UNFIXED
+      // code every other signal is green and ONLY the live:false stamp can fail it.
+      const rows = SLOTS.map((_, i) => ({ event_type: 'fleet_verb_respawn', session_id: `s-${i}`, payload: { live: false, outcome: 'ok' } }));
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }),
+        queryEventsFn: async () => rows,
+        queryLifecycleEventsFn: async () => SLOTS.map((_, i) => ({ event_type: 'RESPAWN_BIND_VERIFIED', session_id: `s-${i}` })),
+        live: true,
+      });
+      expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(false);
+    });
+
+    // BOTH DIRECTIONS. The dry_run exemption is still CORRECT for a mechanism/dry-run drill — there is
+    // no live session by design — so gating it on `live` must not break the dry-run path.
+    it('the dry_run exemption is PRESERVED for a non-live mechanism drill (no over-correction)', async () => {
+      const { logFn, queryEventsFn } = makeEventSeams();
+      const { pass, checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }), logFn, queryEventsFn, live: false,
+      });
+      expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(true);
+      expect(checks.find((c) => c.name === 'respawn_bind_audited').pass).toBe(true);
+      expect(pass).toBe(true);
+    });
+
+    it('a GENUINELY bound + audited live respawn still PASSES (the fix is not a blanket live-fail)', async () => {
+      const bound = SLOTS.map((_, i) => ({ event_type: 'fleet_verb_respawn', session_id: `s-${i}`, payload: { live: true, outcome: 'ok' } }));
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }), queryEventsFn: async () => bound,
+        queryLifecycleEventsFn: async () => SLOTS.map((_, i) => ({ event_type: 'RESPAWN_BIND_VERIFIED', session_id: `s-${i}` })),
+        live: true,
+      });
+      expect(checks.find((c) => c.name === 'respawn_events_present').pass).toBe(true);
+      expect(checks.find((c) => c.name === 'respawn_bind_audited').pass).toBe(true);
+    });
+  });
+
   it('FAILs overall when no fleet_verb_respawn events are observed (log-before-action violated)', async () => {
     const { pass, checks } = await runRebootRespawnDrill({
       supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -1,6 +1,6 @@
 // SD-LEO-INFRA-LEO-APP-LAUNCHER-001 (FR-4) — worker-startable CP3 drill starter.
 import { describe, it, expect, vi } from 'vitest';
-import { planDrills, main, defaultRunDrills } from '../../../scripts/fleet/start-cp3-drills.js';
+import { planDrills, main, defaultRunDrills, summarizeLegVerdicts, formatDrillReport } from '../../../scripts/fleet/start-cp3-drills.js';
 import { LaunchResolveError } from '../../../lib/fleet/build-session-launch.cjs';
 
 const OKENV = { FLEET_ACCOUNT_PROFILES_DIR: 'C:\\fleet\\profiles' };
@@ -48,6 +48,57 @@ describe('main — worker-startable, dry-run default', () => {
     expect(r.error).toMatch(/REFUSED/);
     expect(r.error).toMatch(/runDrills/);
     expect(logs.join('\n')).toMatch(/REFUSED/);
+  });
+});
+
+// QF-20260725-790: the OTHER half of the false pass. main() hardcoded ok:true for every --live run and
+// the CLI did main().then(r => process.exit(r.ok ? 0 : 1)), discarding the entire results object. So the
+// 2026-07-26T00:15Z acceptance attempt executed almost nothing, printed nothing, and exited 0.
+// Fixing only the leg CHECKS would have left the false pass intact at the exit code.
+describe('QF-20260725-790: the verdict is DERIVED from the legs and is inspectable', () => {
+  it('ok is FALSE when a leg fails, instead of hardcoded true', async () => {
+    const runDrills = vi.fn(async () => ({
+      g1a: { outcome: 'ok' },
+      reboot: { pass: false, checks: [{ name: 'respawn_events_present', pass: false, detail: 'no bound respawn' }] },
+      u4: { pass: true, checks: [{ name: 'u4', pass: true, detail: 'ok' }] },
+    }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    expect(r.ok).toBe(false);
+  });
+
+  it('a leg that THREW (captured as {error}) reads as FAILURE, never as no-opinion', async () => {
+    const runDrills = vi.fn(async () => ({ g1a: { outcome: 'ok' }, reboot: { error: 'boom' }, u4: { pass: true } }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    expect(r.ok).toBe(false);
+    expect(r.legVerdicts.find((v) => v.leg === 'reboot').detail).toMatch(/ERROR: boom/);
+  });
+
+  it('a leg reporting ZERO checks does not count as a pass (it demonstrated nothing)', async () => {
+    const runDrills = vi.fn(async () => ({ reboot: { pass: true, checks: [] } }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    expect(r.ok).toBe(false);
+    expect(r.legVerdicts.some((v) => /ZERO checks/.test(v.detail || ''))).toBe(true);
+  });
+
+  it('ok is TRUE when every leg genuinely passes (not a blanket fail)', async () => {
+    const runDrills = vi.fn(async () => ({
+      g1a: { outcome: 'ok' },
+      reboot: { pass: true, checks: [{ name: 'respawn_events_present', pass: true, detail: 'bound' }] },
+      u4: { pass: true, checks: [{ name: 'u4', pass: true, detail: 'ok' }] },
+    }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    expect(r.ok).toBe(true);
+  });
+
+  it('formatDrillReport renders every check name and verdict, so the result is not inferred from an exit code', async () => {
+    const runDrills = vi.fn(async () => ({
+      reboot: { pass: false, checks: [{ name: 'respawn_bind_audited', pass: false, detail: 'absence is not a pass' }] },
+    }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    const text = formatDrillReport(r);
+    expect(text).toMatch(/ok=false/);
+    expect(text).toMatch(/FAIL {2}reboot\/respawn_bind_audited/);
+    expect(text).toMatch(/absence is not a pass/);
   });
 });
 


### PR DESCRIPTION
## Summary

**The false pass that made every other defect in the 2026-07-26T00:15Z CP3 acceptance attempt invisible.** That run emitted **one row total** — `fleet_verb_respawn` with `live:false`, `outcome:'dry_run'`, `session_id:null` — and **zero** `session_lifecycle_events`. Two legs never executed. Both guard checks went green and the process exited 0 with no output.

Verified against the live DB before implementing rather than taken from the ticket: exactly one `fleet_verb_respawn` since 00:00Z (live:false / dry_run / null session) and **zero** `RESPAWN_BIND_VERIFIED` rows.

## Three composing defects — all three required

**1. Population, not assertion.** check 4 counted the dry_run row (`1 >= 1`) because the dry_run exemption is unconditional. That exemption is *correct* for a mechanism/dry-run drill — there's no live session by design — so it is now **gated on `live`** rather than deleted. Under `--live`, evidence must be a genuinely bound respawn, and a row the emitter stamped `live:false` is never leg evidence.

**2. check 5 passed *trivially* at `0 === 0`** because the only row carried a null `session_id` and never entered `boundSessionIds`. Under dry-run that escape is right; under `--live` it inverts the check's meaning — "no evidence" is not "audited". The assertion (every bound respawn carries a durable audit row) is **unchanged**; only the empty-population escape hatch closes, and only under live.

**3. The exit code would still have lied.** `main()` hardcoded `ok: true` for every `--live` run, and the CLI did `main().then(r => process.exit(r.ok ? 0 : 1))`, discarding the whole results object. **Fixing the checks alone would have turned them red while the process still exited 0 and printed nothing** — the fix has to reach the consumer. `ok` is now derived from the legs, and the results object is printed with every check name, verdict and detail. A leg that threw reads as FAILURE; a leg reporting zero checks does not count as a pass.

Per the ticket: printing alone was explicitly not acceptable, and checks 4/5 are not weakened — the population filter changed, not the assertion.

## Test plan

- [x] 10 new tests; **7 verified RED** against the unfixed code.
- [x] **The first check-4 test was weak and I fixed it**: it passed pre-fix because one dry_run row against two slots already failed on count — red for a reason unrelated to the fix. It now supplies one row *per slot* so only the population filter can fail it; the `live:false` test is likewise count-saturated and fully bind-audited.
- [x] **3 tests pass in BOTH states by design** — dry_run exemption still holds for a mechanism drill, a genuinely bound+audited live respawn still passes, and `ok` is still true when every leg passes. This is not a blanket live-fail.
- [x] `tests/unit/fleet`: 84 files, **1023 tests passing**.
- [x] The shared-root full `tests/unit` run shows 7 failing files; all 7 **proven pre-existing** by running them with and without this change (identical 12 failed / 37 passed / 7 skipped both ways). Three are `scratch/preserved-from-*` dirs that exist only in the shared root.

## Scope

No drill was run and `.worktrees/cp3-drill-run` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)