### PR TITLE
fix(QF-20260725-614): require auth on /api/ventures — master-reset was reachable ANONYMOUSLY (PARTIAL fix, do not close QF)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -188,11 +188,7 @@ app.use('/fleet-ui', express.static(path.join(PROJECT_ROOT, 'server', 'public', 
 app.use('/api/backlog', optionalAuth, backlogRoutes);
 app.use('/api/feedback', requireAuth, feedbackRoutes);
 app.use('/api/testing/campaign', requireAuth, testingCampaignRoutes);
-app.use('/api/ventures', (req, res, next) => {
-  // Master reset uses service-role client internally — auth at RPC level (chairman check)
-  if (req.method === 'POST' && req.path === '/master-reset') return optionalAuth(req, res, next);
-  return requireAuth(req, res, next);
-}, venturesRoutes);
+app.use('/api/ventures', requireAuth, venturesRoutes);
 app.use('/api/competitor-analysis', requireAuth, venturesRoutes);
 app.use('/api/v2', requireAuth, v2ApiRoutes);
 app.use('/api/chairman', requireAuth, createChairmanScopeGuard({ blocking: true }), chairmanRoutes);


### PR DESCRIPTION
**P0.** `POST /api/ventures/master-reset` was mounted behind `optionalAuth`, which **permits anonymous callers**. `server/routes/ventures.js:302` then loops `deleteVentureFully` across **every venture** using a service-role client — no auth, no CSRF token, no confirmation, no undo.

localhost binding is not a mitigation: a CSRF POST originates from the operator's own browser.

```diff
-app.use('/api/ventures', (req, res, next) => {
-  // Master reset uses service-role client internally — auth at RPC level (chairman check)
-  if (req.method === 'POST' && req.path === '/master-reset') return optionalAuth(req, res, next);
-  return requireAuth(req, res, next);
-}, venturesRoutes);
+app.use('/api/ventures', requireAuth, venturesRoutes);
```

## The file already forbade this, two lines above

```js
// optionalAuth: ONLY for truly read-only route modules
// requireAuth: blocks unauthenticated access (any route with POST/PUT/PATCH/DELETE)
```

`master-reset` is a POST. The exception violated the file's own stated policy inline. This **restores the documented rule**, it doesn't invent one.

## The comment was deleted, not updated — and I verified its claim was false first

It asserted *"auth at RPC level (chairman check)"*. There is no such check:

- the master-reset handler body contains **no** chairman / auth / role / `req.user` test of any kind
- `resolveServiceClient()` merely returns a service-role client, with no authorization logic

A false safety comment is why this survived — it pre-answered the question a reviewer would have asked. The mount is now self-evident and needs no comment.

## Verified by execution, against the patched code on an isolated port

| Probe | Result |
|---|---|
| **unauthenticated** `POST /api/ventures/master-reset` | **401** `{"code":"NO_AUTH_HEADER"}` — handler never reached |
| unauthenticated `GET /api/ventures` | 401 |
| bad-credential request | 401 |
| server boot | clean — no `Router.use`/middleware construction error (a detached router throws at boot) |
| `/api/competitor-analysis` — an **untouched** mount of the *same* `venturesRoutes` behind `requireAuth` | responds identically, so the patched mount is now structurally the same shape as a known-good reference |

**Risk-ordered deliberately:** I proved the mount rejects unauthenticated requests *before* probing master-reset. Against the unpatched build that POST would have executed a full portfolio teardown, so it was only ever sent to the patched server.

## What I could NOT verify, and am not claiming

A fully **authenticated** ventures GET. `requireAuth` accepts either `INTERNAL_API_KEY` (not configured in this environment) or a Supabase user JWT via `supabase.auth.getUser`, and no legitimate user credential was available. I did not fabricate one.

The authenticated path is unchanged *by construction* — pre-patch, every non-master-reset request already went through `requireAuth`, so this alters the master-reset branch only — but that is an **argument, not a measurement**, and someone holding a real session should exercise it.

## ⚠️ PARTIAL FIX — do not close QF-20260725-614

This closes the **anonymous-access half only**. Still open and required:

- **CSRF protection**
- **an explicit confirmation step** for irreversible bulk teardown

A logged-in operator visiting a malicious page remains **one form post from total data loss**, and `requireAuth` does nothing about that — the browser supplies the credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)