### PR TITLE
fix(QF-20260725-790): print the EVIDENCE ROW IDS, completing scope part 2

### DIFF
--- a/lib/fleet/reboot-respawn-drill-runner.js
+++ b/lib/fleet/reboot-respawn-drill-runner.js
@@ -34,6 +34,35 @@ import { runRebootRespawn } from './reboot-respawn-runner.js';
 import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
 
 /**
+ * Does a coordination_events row count as respawn leg evidence?
+ *
+ * EXTRACTED (QF-20260725-790, scope part 2) so the COUNT that decides check 4 and the EVIDENCE LIST
+ * printed alongside it are computed by the SAME predicate. Re-deriving this rule in two places is how
+ * a report ends up disagreeing with the verdict it is supposed to explain — and a report that
+ * contradicts its own check is worse than no report, because it is trusted.
+ *
+ * @param {object} e     coordination_events row
+ * @param {boolean} live was this drill invoked --live?
+ */
+export function countsAsRespawnEvidence(e, live) {
+  if (!e || e.event_type !== 'fleet_verb_respawn') return false;
+  const outcome = e.payload?.outcome;
+  // QF-20260725-813: 'dry_run' counts as evidence ONLY when this drill was NOT invoked live.
+  // Previously it counted unconditionally, so a LIVE acceptance run whose respawn never reached
+  // spawnFn emitted dry_run and the guard passed it — the run went green having proven nothing.
+  // 'respawn_unattempted' (live requested, spawn never attempted) is NEVER evidence.
+  if (outcome === 'dry_run') return !live;                   // mechanism/dry-run: no live session by design
+  if (outcome === 'respawn_unattempted') return false;       // live intent that never even attempted
+  // QF-20260725-790: 813 (above) and that QF landed independently on the same false ACCEPT and reached
+  // the SAME `return !live` gate for dry_run — 813's form is canonical. This adds the one case it does
+  // not cover: a row the EMITTER ITSELF stamped live:false while carrying an otherwise-healthy
+  // outcome. 813 keys on `outcome`, so such a row would still pass its filter on a non-null
+  // session_id. Under --live that row is not live evidence regardless of how good its outcome looks.
+  if (live && e.payload?.live === false) return false;
+  return outcome !== 'respawn_unbound' && e.session_id != null; // live: must have bound a real session
+}
+
+/**
  * Run the reboot-respawn drill. Wires the REAL runRebootRespawn with the supplied seams so the checks
  * observe the runner's genuine output (invocation argv, emitted events) — never a stand-in for the
  * assertion.
@@ -123,31 +152,27 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
   // run invisible. The exemption is still CORRECT for a mechanism drill (no live session by design),
   // so it is GATED on `live` rather than deleted — see the QF-20260725-813 block below, which
   // reached that same gate independently and is kept as the canonical form.
-  const respawnEvents = (events || []).filter((e) => {
-    if (!e || e.event_type !== 'fleet_verb_respawn') return false;
-    const outcome = e.payload?.outcome;
-    // QF-20260725-813: 'dry_run' counts as evidence ONLY when this drill was NOT invoked live.
-    // Previously it counted unconditionally, so a LIVE acceptance run whose respawn never reached
-    // spawnFn emitted dry_run and the guard passed it — the run went green having proven nothing.
-    // Combined with the acceptance-integrity defect that made the composition a false ACCEPT.
-    // 'respawn_unattempted' (live requested, spawn never attempted) is NEVER evidence.
-    if (outcome === 'dry_run') return !live;                   // mechanism/dry-run: no live session by design
-    if (outcome === 'respawn_unattempted') return false;       // live intent that never even attempted
-    // QF-20260725-790: 813 (above) and this QF landed independently on the same false ACCEPT and
-    // reached the SAME `return !live` gate for dry_run — 813's form is kept as canonical. This adds
-    // the one case it does not cover: a row the EMITTER ITSELF stamped live:false while carrying an
-    // otherwise-healthy outcome. 813 keys on `outcome`, so such a row would still pass its filter on
-    // a non-null session_id. Under --live that row is not live evidence regardless of how good its
-    // outcome looks.
-    if (live && e.payload?.live === false) return false;
-    return outcome !== 'respawn_unbound' && e.session_id != null; // live: must have bound a real session
-  }).length;
+  const respawnEvents = (events || []).filter((e) => countsAsRespawnEvidence(e, live)).length;
   checks.push({
     name: 'respawn_events_present',
     pass: typeof queryEventsFn === 'function' ? respawnEvents >= slots.length : false,
     detail: typeof queryEventsFn === 'function'
       ? `session-bound fleet_verb_respawn events: ${respawnEvents} (need >= ${slots.length})`
       : 'no queryEventsFn supplied — cannot assert persisted respawn events (live drill MUST supply one)',
+    // QF-20260725-790 (scope part 2): name the EVIDENCE ROWS this verdict was computed from. A verdict
+    // without them tells the reader a leg failed but not what it saw — on the 00:15Z run the whole
+    // question was "which row satisfied this check?", and the answer was unobtainable after the fact.
+    // Every row in the window is listed, INCLUDING ones the filter rejected, with why: a report that
+    // showed only accepted rows would hide exactly the dry_run row that caused the false pass.
+    evidence: (events || [])
+      .filter((e) => e && e.event_type === 'fleet_verb_respawn')
+      .map((e) => ({
+        id: e.id ?? null,
+        session_id: e.session_id ?? null,
+        outcome: e.payload?.outcome ?? null,
+        live: e.payload?.live ?? null,
+        counted: countsAsRespawnEvidence(e, live),
+      })),
   });
 
   // Check 5 (QF-20260724-070, Solomon durable-bind-audit): every session-bound respawn ('ok' outcome)
@@ -185,6 +210,15 @@ export async function runRebootRespawnDrill({ supabase, loadFn, rosterFn, spawnF
         ? 'LIVE drill bound ZERO sessions — no bind to audit, so recovery was never demonstrated (absence is not a pass)'
         : 'no session-bound respawn events to audit (dry-run or unbound)')
       : `${auditedCount}/${boundSessionIds.length} bound session(s) have a durable RESPAWN_BIND_VERIFIED audit row`,
+    // QF-20260725-790 (scope part 2): name the audit rows, and name the bound sessions that have NO
+    // audit row. The unaudited list is the actionable half — "2/3 audited" does not tell you WHICH
+    // bind is unproven.
+    evidence: {
+      audit_rows: (lifecycleEvents || [])
+        .filter((e) => e && e.event_type === 'RESPAWN_BIND_VERIFIED')
+        .map((e) => ({ id: e.id ?? null, session_id: e.session_id ?? null })),
+      unaudited_bound_sessions: boundSessionIds.filter((id) => !auditedIds.has(id)),
+    },
   });
 
   return { pass: checks.every((c) => c.pass), checks };

--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -95,7 +95,7 @@ export function summarizeLegVerdicts(results) {
     if (!r || typeof r !== 'object') { out.push({ leg, pass: false, detail: 'no result object' }); continue; }
     if (r.error) { out.push({ leg, pass: false, detail: `ERROR: ${r.error}` }); continue; }
     if (Array.isArray(r.checks)) {
-      for (const c of r.checks) out.push({ leg, check: c.name, pass: c.pass === true, detail: c.detail });
+      for (const c of r.checks) out.push({ leg, check: c.name, pass: c.pass === true, detail: c.detail, evidence: c.evidence });
       // A leg reporting zero checks has demonstrated nothing — do not let it count as a pass.
       if (r.checks.length === 0) out.push({ leg, pass: false, detail: 'leg reported ZERO checks' });
       continue;
@@ -113,11 +113,38 @@ export function summarizeLegVerdicts(results) {
  * QF-20260725-790: render the verdict so it is INSPECTABLE rather than inferred from an exit code.
  * The CLI previously did main().then(r => process.exit(r.ok ? 0 : 1)), discarding every check.
  */
+/**
+ * QF-20260725-790 (scope part 2): render a check's evidence rows as inspectable lines.
+ * Shape-tolerant by design — check 4 attaches an array of event rows, check 5 an object with
+ * audit_rows + unaudited_bound_sessions, and most checks attach nothing at all. An unrecognised
+ * shape is stringified rather than dropped: silently omitting evidence is the failure mode this
+ * whole QF exists to remove.
+ */
+export function formatEvidenceLines(evidence) {
+  if (!evidence) return [];
+  if (Array.isArray(evidence)) {
+    if (evidence.length === 0) return ['evidence: (no rows in this run\'s window)'];
+    return evidence.map((e) => `evidence row ${e.id ?? '<no id>'} session=${e.session_id ?? 'null'} outcome=${e.outcome ?? 'null'} live=${e.live ?? 'null'} counted=${e.counted === true}`);
+  }
+  if (typeof evidence === 'object') {
+    const lines = [];
+    for (const a of evidence.audit_rows || []) lines.push(`audit row ${a.id ?? '<no id>'} session=${a.session_id ?? 'null'}`);
+    for (const s of evidence.unaudited_bound_sessions || []) lines.push(`UNAUDITED bound session=${s}`);
+    if (lines.length === 0) lines.push('evidence: (no audit rows in this run\'s window)');
+    return lines;
+  }
+  return [`evidence: ${String(evidence)}`];
+}
+
 export function formatDrillReport(r) {
   const lines = [`[start-cp3-drills] RESULT ok=${r.ok === true} live=${r.live === true}`];
   if (r.error) lines.push(`  ERROR: ${r.error}`);
   for (const v of r.legVerdicts || []) {
     lines.push(`  ${v.pass ? 'PASS' : 'FAIL'}  ${v.leg}${v.check ? '/' + v.check : ''} — ${v.detail || ''}`);
+    // QF-20260725-790 (scope part 2): print the EVIDENCE ROW IDS under their check. On the 00:15Z run
+    // the unanswerable question was "which row satisfied this?" — rows are listed with whether they
+    // were COUNTED, so a rejected dry_run row is visible rather than silently absent.
+    for (const ev of formatEvidenceLines(v.evidence)) lines.push(`        ${ev}`);
   }
   if (!r.legVerdicts || r.legVerdicts.length === 0) lines.push('  (no leg verdicts — nothing executed)');
   return lines.join('\n');
@@ -176,8 +203,11 @@ export async function defaultRunDrills(plan, deps = {}) {
   // queryEventsFn (unlike U4's session-scoped one, since reboot-respawn creates one replacement
   // session PER slot, not a single target) -- without this the live CLI path always failed
   // respawn_events_present ("no queryEventsFn supplied") even on a genuinely successful respawn.
+  // QF-20260725-790 (scope part 2): select `id` so the printed verdict can name the EVIDENCE ROW,
+  // not just the check outcome. Without a row id the report says a leg failed but gives the reader no
+  // way to go look at what it actually saw — which is the inspectability the QF asked for.
   const rebootQueryEventsFn = deps.rebootQueryEventsFn || (async () => {
-    const { data } = await supabase.from('coordination_events').select('event_type,payload,session_id')
+    const { data } = await supabase.from('coordination_events').select('id,event_type,payload,session_id')
       .eq('event_type', 'fleet_verb_respawn').gte('created_at', runStartedAt)
       .order('created_at', { ascending: false }).limit(50);
     return data || [];
@@ -188,7 +218,8 @@ export async function defaultRunDrills(plan, deps = {}) {
   // QF-20260725-139: scoped to this run for the SAME reason -- an audit row from an earlier run must
   // never be able to satisfy a bind performed by this one.
   const rebootQueryLifecycleEventsFn = deps.rebootQueryLifecycleEventsFn || (async () => {
-    const { data } = await supabase.from('session_lifecycle_events').select('event_type,session_id')
+    // QF-20260725-790 (scope part 2): `id` for the same reason as the events query above.
+    const { data } = await supabase.from('session_lifecycle_events').select('id,event_type,session_id')
       .eq('event_type', 'RESPAWN_BIND_VERIFIED').gte('created_at', runStartedAt)
       .order('created_at', { ascending: false }).limit(50);
     return data || [];

--- a/tests/unit/fleet/reboot-respawn-drill-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-drill-runner.test.js
@@ -108,6 +108,62 @@ describe('runRebootRespawnDrill (FR-7)', () => {
     });
   });
 
+  // QF-20260725-790 scope part 2: "print every check name, verdict AND THE EVIDENCE ROW ID". The first
+  // pass shipped name+verdict only; these cover the row-id half. On the 00:15Z run the unanswerable
+  // question was "which row satisfied this check?" — the verdict has to name its evidence.
+  describe('QF-20260725-790: checks carry the EVIDENCE ROW IDS their verdict was computed from', () => {
+    it('check 4 lists every row in the window, including ones it REJECTED and why', async () => {
+      const rows = [
+        { id: 'evt-dry', event_type: 'fleet_verb_respawn', session_id: null, payload: { live: false, outcome: 'dry_run' } },
+        { id: 'evt-ok', event_type: 'fleet_verb_respawn', session_id: 's-1', payload: { live: true, outcome: 'ok' } },
+      ];
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }), queryEventsFn: async () => rows,
+        queryLifecycleEventsFn: async () => [], live: true,
+      });
+      const ev = checks.find((c) => c.name === 'respawn_events_present').evidence;
+      expect(ev.map((e) => e.id)).toEqual(['evt-dry', 'evt-ok']);
+      // The REJECTED row must still appear — a report that hid it would hide the false pass itself.
+      expect(ev.find((e) => e.id === 'evt-dry').counted).toBe(false);
+      expect(ev.find((e) => e.id === 'evt-ok').counted).toBe(true);
+    });
+
+    it('the evidence list agrees with the COUNT — one predicate, not two re-derivations', async () => {
+      const rows = [
+        { id: 'a', event_type: 'fleet_verb_respawn', session_id: 's-1', payload: { live: true, outcome: 'ok' } },
+        { id: 'b', event_type: 'fleet_verb_respawn', session_id: null, payload: { live: true, outcome: 'respawn_unbound' } },
+        { id: 'c', event_type: 'fleet_verb_respawn', session_id: 's-2', payload: { live: true, outcome: 'ok' } },
+      ];
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }), queryEventsFn: async () => rows,
+        queryLifecycleEventsFn: async () => SLOTS.map((_, i) => ({ id: `au-${i}`, event_type: 'RESPAWN_BIND_VERIFIED', session_id: `s-${i + 1}` })),
+        live: true,
+      });
+      const c4 = checks.find((c) => c.name === 'respawn_events_present');
+      const countedInEvidence = c4.evidence.filter((e) => e.counted).length;
+      // The detail string states the count the verdict used; the evidence must not contradict it.
+      expect(c4.detail).toContain(`events: ${countedInEvidence}`);
+      expect(countedInEvidence).toBe(2);
+    });
+
+    it('check 5 names the audit rows AND the bound sessions that have NO audit row', async () => {
+      const { checks } = await runRebootRespawnDrill({
+        supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),
+        logFn: async () => ({ ok: true }),
+        queryEventsFn: async () => SLOTS.map((_, i) => ({ id: `e-${i}`, event_type: 'fleet_verb_respawn', session_id: `s-${i}`, payload: { live: true, outcome: 'ok' } })),
+        queryLifecycleEventsFn: async () => [{ id: 'audit-0', event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-0' }],
+        live: true,
+      });
+      const c5 = checks.find((c) => c.name === 'respawn_bind_audited');
+      expect(c5.pass).toBe(false);
+      expect(c5.evidence.audit_rows).toEqual([{ id: 'audit-0', session_id: 's-0' }]);
+      // The actionable half: WHICH bind is unproven, not just "1/2".
+      expect(c5.evidence.unaudited_bound_sessions).toEqual(['s-1']);
+    });
+  });
+
   it('FAILs overall when no fleet_verb_respawn events are observed (log-before-action violated)', async () => {
     const { pass, checks } = await runRebootRespawnDrill({
       supabase: {}, loadFn: async () => SLOTS, spawnFn: () => ({ pid: 1 }),

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -1,6 +1,6 @@
 // SD-LEO-INFRA-LEO-APP-LAUNCHER-001 (FR-4) — worker-startable CP3 drill starter.
 import { describe, it, expect, vi } from 'vitest';
-import { planDrills, main, defaultRunDrills, summarizeLegVerdicts, formatDrillReport } from '../../../scripts/fleet/start-cp3-drills.js';
+import { planDrills, main, defaultRunDrills, summarizeLegVerdicts, formatDrillReport, formatEvidenceLines } from '../../../scripts/fleet/start-cp3-drills.js';
 import { LaunchResolveError } from '../../../lib/fleet/build-session-launch.cjs';
 
 const OKENV = { FLEET_ACCOUNT_PROFILES_DIR: 'C:\\fleet\\profiles' };
@@ -90,6 +90,44 @@ describe('QF-20260725-790: the verdict is DERIVED from the legs and is inspectab
     expect(r.ok).toBe(true);
   });
 
+  it('formatDrillReport prints the EVIDENCE ROW IDS under their check (scope part 2)', async () => {
+    const runDrills = vi.fn(async () => ({
+      reboot: {
+        pass: false,
+        checks: [
+          {
+            name: 'respawn_events_present',
+            pass: false,
+            detail: 'session-bound fleet_verb_respawn events: 0 (need >= 1)',
+            evidence: [{ id: 'evt-dry', session_id: null, outcome: 'dry_run', live: false, counted: false }],
+          },
+          {
+            name: 'respawn_bind_audited',
+            pass: false,
+            detail: '0/1 bound session(s) audited',
+            evidence: { audit_rows: [], unaudited_bound_sessions: ['s-9'] },
+          },
+        ],
+      },
+    }));
+    const r = await main(['--live'], { env: OKENV, log: () => {}, runDrills });
+    const text = formatDrillReport(r);
+    // The rejected row is NAMED, with why it did not count — the 00:15Z question was "which row?".
+    expect(text).toMatch(/evidence row evt-dry/);
+    expect(text).toMatch(/outcome=dry_run/);
+    expect(text).toMatch(/counted=false/);
+    // And the unproven bind is named, not just counted.
+    expect(text).toMatch(/UNAUDITED bound session=s-9/);
+  });
+
+  it('formatEvidenceLines never silently drops an unrecognised evidence shape', () => {
+    // Dropping evidence is the exact failure class this QF removes, so an unknown shape is
+    // stringified rather than omitted.
+    expect(formatEvidenceLines(undefined)).toEqual([]);
+    expect(formatEvidenceLines([])).toEqual(["evidence: (no rows in this run's window)"]);
+    expect(formatEvidenceLines('weird')).toEqual(['evidence: weird']);
+  });
+
   it('formatDrillReport renders every check name and verdict, so the result is not inferred from an exit code', async () => {
     const runDrills = vi.fn(async () => ({
       reboot: { pass: false, checks: [{ name: 'respawn_bind_audited', pass: false, detail: 'absence is not a pass' }] },
@@ -170,7 +208,12 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
       supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
     });
 
-    expect(select).toHaveBeenCalledWith('event_type,payload,session_id');
+    // QF-20260725-790: re-aimed from an exact-string select pin to a REQUIRED-COLUMNS pin. The query
+    // gained `id` so the printed verdict can name the evidence row; pinning the literal column list
+    // made a correct addition fail. What actually matters is that every column the checks and the
+    // report read is selected — an under-selected query degrades them silently.
+    const projection = select.mock.calls[0][0];
+    for (const col of ['event_type', 'payload', 'session_id', 'id']) expect(projection).toContain(col);
     expect(eq).toHaveBeenCalledWith('event_type', 'fleet_verb_respawn');
     expect(res.reboot.pass).toBe(true);
   });
@@ -201,7 +244,9 @@ describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-
       supabase, resolveCanaryTarget, canaryRestart, canaryRelaunchUnderProfile, runRebootRespawnDrill, runU4Drill,
     });
 
-    expect(select).toHaveBeenCalledWith('event_type,session_id');
+    // QF-20260725-790: required-columns pin, same reasoning as the events query above (gained `id`).
+    const lcProjection = select.mock.calls[0][0];
+    for (const col of ['event_type', 'session_id', 'id']) expect(lcProjection).toContain(col);
     expect(eq).toHaveBeenCalledWith('event_type', 'RESPAWN_BIND_VERIFIED');
     expect(res.reboot.pass).toBe(true);
   });


### PR DESCRIPTION
## Summary

Completes **QF-20260725-790 scope part 2**, which reads: *"PRINT THE RESULTS OBJECT — every check name, verdict **and the evidence row id**"*. PR #6498 shipped check name + verdict but **not the row ids**.

`complete-quick-fix.js` refused to close the QF on a merged PR — *"a merged PR proves the code landed, NOT that this QF's scope is satisfied"* — and it was right. This is the remainder, not a new ask.

**Why the row id is the load-bearing half:** on the 00:15Z run the unanswerable question was *which row satisfied this check?* A verdict that says a leg passed without naming what it read cannot be audited after the fact — and being unauditable is how that run went green having proven nothing.

## Changes

- Both reboot queries now select `id`.
- **check 4** attaches every `fleet_verb_respawn` row in the run window with whether it was **counted** and why (`outcome`/`live`). **Rejected rows are listed, not omitted** — a report showing only accepted rows would hide exactly the dry_run row that caused the false pass.
- **check 5** attaches the audit rows **and `unaudited_bound_sessions`**. "2/3 audited" doesn't tell you *which* bind is unproven; that list is the actionable half.
- `formatDrillReport` prints them indented under their check.

## One predicate, not two re-derivations

Extracted `countsAsRespawnEvidence(e, live)` so the **count** that decides check 4 and the **evidence list** printed beside it come from the same function. Re-deriving the rule twice is how a report ends up contradicting the verdict it explains — and a report that disagrees with its own check is worse than none, because it's trusted. A test pins that the two agree.

`formatEvidenceLines` is shape-tolerant and stringifies an unrecognised shape rather than dropping it — silently omitting evidence is the failure class this QF removes.

## Test plan

- [x] 5 new tests, **all verified RED** against `origin/main`.
- [x] Two exact-string select pins re-aimed to **required-columns** pins — the queries gained `id`, and pinning the literal list made a correct addition fail.
- [x] `tests/unit/fleet`: 85 files, **1032 passing**.
- [x] No drill was run; `.worktrees/cp3-drill-run` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)