### PR TITLE
fix(QF-20260725-985): CP3 drills passed the resolution WRAPPER as the target, so two legs emitted nothing

### DIFF
--- a/scripts/fleet/start-cp3-drills.js
+++ b/scripts/fleet/start-cp3-drills.js
@@ -142,8 +142,30 @@ export async function defaultRunDrills(plan, deps = {}) {
   const supabase = deps.supabase || (await import('../../lib/supabase-client.cjs')).createSupabaseServiceClient();
 
   // Resolve the live canary session (canary-guard fail-closes if none / not a real canary).
-  const target = await resolveCanary(supabase, { by: 'account_profile', value: 'canary' });
-  const sessionId = target && (target.session_id || target.id);
+  // QF-20260725-985: resolveCanaryTarget returns a RESOLUTION WRAPPER {resolved, identity, reason},
+  // not an identity. The old code passed that wrapper on as `target` and read `target.session_id`,
+  // which is undefined because those fields live on `.identity`. Downstream, guardedVerb re-resolves
+  // via resolveSessionIdentity, whose match is `j[by] === value` — a STRICT SCALAR comparison — so an
+  // object value can never match and every target-scoped leg was rejected with not_found. G1a and
+  // G3+U4 emitted ZERO fleet_verb_* rows. The guard was right; it was handed nonsense and fail-closed
+  // exactly as designed, which is why the run still looked clean.
+  //
+  // NOTE the fix is `identity.callsign`, NOT `identity` — guardedVerb defaults to by:'callsign' and
+  // compares scalars, so passing the identity OBJECT (the literal remedy named in the QF) would fail
+  // in exactly the same way. Verified against resolveSessionIdentity (lib/fleet/session-registry.js:47).
+  const resolution = await resolveCanary(supabase, { by: 'account_profile', value: 'canary' });
+  const identity = (resolution && resolution.identity) || null;
+  const target = identity && identity.callsign;
+  const sessionId = identity && identity.session_id;
+  // Fail LOUD rather than proceeding with undefined identifiers: an unresolved canary previously
+  // sailed on and produced an empty-but-successful-looking run, which is the failure mode this QF
+  // and its companion acceptance-integrity QF both exist to end.
+  if (!resolution || resolution.resolved !== true || !target) {
+    return {
+      ok: false,
+      error: `canary target unresolved (${(resolution && resolution.reason) || 'no_resolution'}) — refusing to run drills that could emit no evidence`,
+    };
+  }
   const fromProfile = process.env.FLEET_LIVE_PROFILE || 'live';
   const toProfile = plan?.canaryProfile || 'canary';
   const queryEventsFn = deps.queryEventsFn || (async (sid) => {

--- a/tests/unit/fleet/start-cp3-drills.test.js
+++ b/tests/unit/fleet/start-cp3-drills.test.js
@@ -102,11 +102,70 @@ describe('QF-20260725-790: the verdict is DERIVED from the legs and is inspectab
   });
 });
 
+// QF-20260725-985: the wrapper-vs-identity defect and its fail-loud guard.
+describe('defaultRunDrills — canary target resolution (QF-20260725-985)', () => {
+  const legs = { canaryRestart: null, runRebootRespawnDrill: null, runU4Drill: null };
+
+  it('an UNRESOLVED canary aborts loudly instead of running drills that emit nothing', async () => {
+    // THE POINT OF THIS SD. Previously an unresolved canary sailed straight on: sessionId was
+    // undefined, guardedVerb fail-closed with not_found, and G1a + G3+U4 emitted ZERO fleet_verb_*
+    // rows — while the run still exited looking clean. An empty run that reports success is worse
+    // than a red one, because it sends someone hunting a defect in the verbs that does not exist.
+    const supabase = { from: vi.fn() };
+    const resolveCanaryTarget = vi.fn(async () => ({ resolved: false, reason: 'not_found' }));
+    const canaryRestart = vi.fn();
+    const runRebootRespawnDrill = vi.fn();
+    const runU4Drill = vi.fn();
+
+    const out = await defaultRunDrills({ canaryProfile: 'canary', cwd: 'R:\\r', legs: [] }, {
+      supabase, resolveCanaryTarget, canaryRestart,
+      canaryRelaunchUnderProfile: vi.fn(), runRebootRespawnDrill, runU4Drill,
+    });
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/not_found/);
+    // No leg may run: each would have been rejected at the guard and emitted nothing anyway.
+    expect(canaryRestart).not.toHaveBeenCalled();
+    expect(runRebootRespawnDrill).not.toHaveBeenCalled();
+    expect(runU4Drill).not.toHaveBeenCalled();
+    void legs;
+  });
+
+  it('never passes the resolution WRAPPER (or the identity object) to a verb', async () => {
+    // Regression guard on the exact defect. guardedVerb compares `j[by] === value` with by='callsign',
+    // so ANY object — wrapper or identity — can only ever resolve not_found. The literal remedy named
+    // in the QF ("pass target.identity") would therefore NOT have fixed it; the value must be scalar.
+    const supabase = { from: vi.fn() };
+    const identity = { session_id: 'canary-sess-9', callsign: 'Canary-9', account_profile: 'canary' };
+    const resolution = { resolved: true, identity };
+    const canaryRestart = vi.fn(async () => ({ outcome: 'ok' }));
+
+    await defaultRunDrills({ canaryProfile: 'canary', cwd: 'R:\\r', legs: [] }, {
+      supabase,
+      resolveCanaryTarget: vi.fn(async () => resolution),
+      canaryRestart,
+      canaryRelaunchUnderProfile: vi.fn(async () => ({ outcome: 'ok' })),
+      runRebootRespawnDrill: vi.fn(async () => ({ pass: true })),
+      runU4Drill: vi.fn(async () => ({ pass: true })),
+    });
+
+    const passed = canaryRestart.mock.calls[0][0];
+    expect(typeof passed).toBe('string');
+    expect(passed).toBe('Canary-9');
+    expect(passed).not.toBe(resolution);
+    expect(passed).not.toBe(identity);
+  });
+});
+
 // QF-20260724-923: the live path must WIRE all 3 legs to emit real fleet_verb_* evidence (was a stub).
 describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
   it('uses a real supabase client, resolves the canary, and calls all 3 legs with the required args', async () => {
     const supabase = { from: vi.fn() };
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     const resolveCanaryTarget = vi.fn(async () => target);
     const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
     const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
@@ -122,7 +181,11 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
     expect(resolveCanaryTarget).toHaveBeenCalledWith(supabase, { by: 'account_profile', value: 'canary' });
     // G1a kill-supervisor -> fleet_verb_restart. QF-20260724-499: live:true explicit (was missing,
     // causing restart to fall through to spawn-control's isLiveEnabled() and dry-run).
-    expect(canaryRestart).toHaveBeenCalledWith(target, { supabase, sdKey: 'CHECKPOINT-3', live: true });
+    // QF-20260725-985: the verb must receive the CALLSIGN, not the wrapper and not the identity
+    // object. guardedVerb re-resolves via resolveSessionIdentity, whose match is `j[by] === value`
+    // with by defaulting to 'callsign' — a strict SCALAR comparison, so any object fails not_found
+    // and the leg emits nothing while the guard looks like it behaved correctly (it did).
+    expect(canaryRestart).toHaveBeenCalledWith('Canary-1', { supabase, sdKey: 'CHECKPOINT-3', live: true });
     // G1b+G2 reboot-respawn gets a REAL client + live:true (was supabase=null) + a queryEventsFn
     // (QF-20260724-113 FR-b: without one, respawn_events_present always fails on a live run).
     const rebootArgs = runRebootRespawnDrill.mock.calls[0][0];
@@ -131,7 +194,9 @@ describe('defaultRunDrills — wired live path (QF-20260724-923)', () => {
     expect(typeof rebootArgs.queryEventsFn).toBe('function');
     // G3+U4 gets the REQUIRED args (was only {opts:{}} -> no-op): target, sessionId, relaunchFn, resolveFn, queryEventsFn.
     const u4Args = runU4Drill.mock.calls[0][0];
-    expect(u4Args.target).toBe(target);
+    expect(u4Args.target).toBe('Canary-1');
+    // The sessionId that used to be undefined — the field that made two legs emit zero rows.
+    expect(u4Args.sessionId).toBe('canary-sess-1');
     expect(u4Args.sessionId).toBe('canary-sess-1');
     expect(u4Args.toProfile).toBe('canary');
     expect(typeof u4Args.relaunchFn).toBe('function');
@@ -154,7 +219,11 @@ describe('defaultRunDrills — rebootQueryEventsFn wiring (QF-20260724-113)', ()
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'fleet_verb_respawn' }, { event_type: 'fleet_verb_respawn' }] });
     const select = vi.fn(() => ({ eq, gte, order, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     const resolveCanaryTarget = vi.fn(async () => target);
     const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
     const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
@@ -186,7 +255,11 @@ describe('defaultRunDrills — rebootQueryLifecycleEventsFn wiring (QF-20260724-
     const limit = vi.fn().mockResolvedValue({ data: [{ event_type: 'RESPAWN_BIND_VERIFIED', session_id: 's-1' }] });
     const select = vi.fn(() => ({ eq, gte, order, limit }));
     const supabase = { from: vi.fn(() => ({ select })) };
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     const resolveCanaryTarget = vi.fn(async () => target);
     const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
     const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
@@ -246,7 +319,11 @@ describe('defaultRunDrills — reboot audit queries are scoped to THIS run (QF-2
   }
 
   function harness(tables) {
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     return {
       supabase: filteringSupabase(tables),
       runStartedAt: RUN_STARTED_AT,
@@ -309,7 +386,11 @@ describe('defaultRunDrills — reboot audit queries are scoped to THIS run (QF-2
 describe('defaultRunDrills — run-correlator stamped on all 3 legs (QF-20260724-335)', () => {
   it('passes the SAME sdKey to canaryRestart, runRebootRespawnDrill, and runU4Drill', async () => {
     const supabase = { from: vi.fn() };
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     const resolveCanaryTarget = vi.fn(async () => target);
     const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
     const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));
@@ -329,7 +410,11 @@ describe('defaultRunDrills — run-correlator stamped on all 3 legs (QF-20260724
 
   it('honors an injected deps.sdKey override (e.g. a per-invocation run_id) for all 3 legs', async () => {
     const supabase = { from: vi.fn() };
-    const target = { session_id: 'canary-sess-1', metadata: { account_profile: 'canary' } };
+    // QF-20260725-985: the REAL resolveCanaryTarget returns a WRAPPER {resolved, identity} — never a
+    // bare session row. The old fixture invented {session_id, metadata}, a shape production never
+    // produces, so these tests certified a caller that could not work and the defect shipped green.
+    const identity = { session_id: 'canary-sess-1', callsign: 'Canary-1', account_profile: 'canary' };
+    const target = { resolved: true, identity };
     const resolveCanaryTarget = vi.fn(async () => target);
     const canaryRestart = vi.fn(async () => ({ verb: 'fleet_verb_restart', outcome: 'ok' }));
     const canaryRelaunchUnderProfile = vi.fn(async () => ({ verb: 'fleet_verb_relaunch_under_profile', outcome: 'ok' }));


### PR DESCRIPTION
## Summary

`start-cp3-drills.js` called `resolveCanaryTarget`, which returns a **wrapper** `{resolved, identity, reason}` — then passed that whole object on as `target` and read `target.session_id`, which is `undefined` because those fields live on `.identity`.

Downstream, `guardedVerb` re-resolves via `resolveSessionIdentity`, whose match is `j[by] === value` (`session-registry.js:47`) — a **strict scalar comparison** — so an object can only ever return `not_found`. G1a (kill-supervisor) and G3+U4 (relaunch/cookie) were rejected at the guard and emitted **zero** `fleet_verb_restart` / `fleet_verb_relaunch_under_profile` rows.

**The guard was never at fault.** Handed a nonsense identifier, it fail-closed exactly as designed. This is a caller defect; the guard is untouched.

### One correction to the QF's prescribed fix

The QF says *"pass `target.identity` rather than the wrapper."* Implementing that literally **would not have fixed it** — `identity` is still an object, and the comparison is scalar equality against `by='callsign'`. The correct value is `identity.callsign`. Verified by reading `resolveSessionIdentity` rather than trusting the prescription.

### Audit (required by the QF before closing)

Every other `resolveCanaryTarget` caller is correct: `canary-provision.js` hands the resolution to `isProvisioned(resolution)`, which treats it as a wrapper by contract, and `canary-guard.js` internals read `.identity`. `start-cp3-drills.js` was the **only** defective caller.

### Fail-loud guard

An unresolved canary now aborts with a reason instead of proceeding with undefined identifiers. That is the real harm here — the old path produced an empty run that still looked clean, which cost a full acceptance attempt and sent people hunting a defect in the verbs that did not exist.

## Why the suite was green over this

The tests stubbed `resolveCanaryTarget` to return `{session_id, metadata}` — **a shape the real function never returns**. The fixture invented a contract, so the tests certified a caller that could not work.

This is the same defect class as the consult-lane SD merged an hour ago, where a stubbed writer let a total production no-op ship green. Wherever a test stubs the very collaborator whose contract is in question, treat that contract as unverified regardless of suite colour.

## Test plan

- [x] Fixtures corrected to the real wrapper shape
- [x] New guards: the verb must receive a **scalar** callsign; neither wrapper nor identity object may be passed; an unresolved canary aborts and runs no legs
- [x] **Mutation-tested** with the edit verified to apply — restoring `target = resolution` turns 2 tests RED
- [x] 85 files / 1029 tests green across `tests/unit/fleet`; 21 in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
