### PR TITLE
feat(SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F): enforce the fleet launch contract at the three spawn seams

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -151,7 +151,24 @@ function isUuid(v) {
 }
 
 /**
- * Assert a launch invocation satisfies the contract (used by the conformance test + callers).
+ * Assert a launch invocation satisfies the contract.
+ *
+ * ENFORCED AS OF SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F at three EXECUTION seams:
+ * spawn-control.js (before the spawner), worker-spawn-executor.cjs (in runExecutor), and
+ * reboot-respawn-runner.js (inside the live guard). Before that it had ZERO non-test callers.
+ *
+ * ⚠️ WHAT THIS CONTRACT DOES **NOT** COVER — do not over-trust it (FR-5):
+ *  1. It is checked only on invocations that flow through buildSessionLaunch. These production
+ *     surfaces spawn Claude WITHOUT ever reaching this builder, and violate every clause:
+ *       - scripts/execute-team.mjs      (headless `claude --print`, via cmd.exe)
+ *       - lib/drain-orchestrator.mjs    (headless `claude --print`)
+ *       - scripts/leo-continuous-loop.ps1 (PowerShell Start-Process — beyond any JS assertion)
+ *     Wiring this contract did NOT bring them under it; they need their own work item.
+ *  2. It inspects the DECLARED invocation.env, never the MERGED child environment — every spawner
+ *     spreads process.env underneath. It proves declared intent about launch shape, not what the
+ *     child actually receives.
+ *  3. The launcher-token clause is a SHAPE check, not launcher authenticity (see its comment below).
+ *
  * @returns {{ok:boolean, violations:string[]}}
  */
 function assertLaunchContract(inv, { expectProfile = false, expectResume = false } = {}) {
@@ -169,7 +186,22 @@ function assertLaunchContract(inv, { expectProfile = false, expectResume = false
   else if (ntIdx >= 0 && wIdx > ntIdx) v.push('-w new must PRECEDE new-tab (-w is a global wt option)');
   if (args.includes('-p') || args.includes('--print')) v.push('headless -p/--print is forbidden (must be persistent)');
   const claudeTok = args[args.indexOf('--') + 1];
-  if (!claudeTok || !/claude(\.cmd|\.exe)?$/i.test(claudeTok)) v.push('missing resolved claude launcher token after --');
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-4): name the operator lever in the
+  // violation itself. Now that this contract is ENFORCED at three spawn seams, this clause is the one
+  // an operator can actually trip — resolveClaudeCmd above returns FLEET_CLAUDE_CMD / CLAUDE_CLI_PATH
+  // VERBATIM, so a wrapper .cmd, a quoted path or an interpreter form ("node cli.js") refuses every
+  // spawn fleet-wide. Neither variable is documented anywhere, so a bare "missing token" message left
+  // the operator with no way to connect the refusal to the knob they set. Stated at the DEFINITION so
+  // all three seams inherit it rather than each re-deriving the hint.
+  // NOTE the regex is deliberately a SHAPE check, not launcher authenticity — it is unanchored at the
+  // start, so a path ending in "notclaude" passes. Do not read this clause as anti-hijack.
+  if (!claudeTok || !/claude(\.cmd|\.exe)?$/i.test(claudeTok)) {
+    // The offending VALUE is deliberately NOT echoed. Refusals reach logs and, via the fleet-actions
+    // route, an HTTP 500 body; a launcher override can embed a username or private directory layout.
+    // Every other violation string here is a static literal for the same reason — naming the KNOB is
+    // what the operator needs, not a reflection of what they typed.
+    v.push('missing resolved claude launcher token after -- (if FLEET_CLAUDE_CMD or CLAUDE_CLI_PATH is set it is used verbatim and must end in claude, claude.cmd or claude.exe — unquoted, no wrapper script, no interpreter prefix)');
+  }
   if (inv && inv.persistent !== true) v.push('persistent flag must be true');
   if (expectProfile && !(inv && inv.env && inv.env.CLAUDE_CONFIG_DIR)) v.push('expected CLAUDE_CONFIG_DIR (profile isolation)');
   if (expectResume && !(inv && inv.env && inv.env.FLEET_AUTORESUME_SD) && !args.includes('--resume')) v.push('expected auto-resume (FLEET_AUTORESUME_SD or --resume)');

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -30,6 +30,9 @@
  */
 import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
 import { buildLiveSpawnInvocation, resolveProfileDir, isLiveEnabled } from './spawn-control.js';
+// SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-1): the launch-contract predicate, wired
+// at the live spawn seam below. Same .cjs-from-ESM interop spawn-control.js already uses.
+import { assertLaunchContract } from './build-session-launch.cjs';
 
 /** Lazily resolve the real coordination-events writer (CJS) so callers need not import it. */
 async function defaultLogFn(supabase, event) {
@@ -180,6 +183,24 @@ export async function runRebootRespawn(opts = {}) {
     let child = null;
     if (live && typeof spawnFn === 'function') {
       try {
+        // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-1): enforce the launch contract at
+        // the EXECUTION seam. This is the HIGHEST-VALUE of the three, because buildInvocationFn above
+        // is caller-INJECTABLE — it is the only path by which a non-conformant invocation can reach a
+        // live spawn without editing the builder or manipulating env.
+        //
+        // FR-3: deliberately INSIDE the live guard. reboot-respawn-drill-runner.test.js:260 injects a
+        // degenerate invocation with live:false to prove a resume-masking check fires; that degenerate
+        // input is LOAD-BEARING for the test, and asserting outside this guard would abort before the
+        // check runs and destroy the test's purpose. Inside the guard it never reaches that test, so no
+        // opt-out flag is needed — one would be dead code.
+        //
+        // FR-2: STRUCTURAL clauses only. The fail-SOFT profile degrade documented above (an
+        // unresolvable profile still spawns, without CLAUDE_CONFIG_DIR) is preserved exactly —
+        // expectProfile stays FALSE, so that policy is untouched by this SD.
+        const contract = assertLaunchContract(invocation);
+        if (!contract.ok) {
+          throw new Error(`LAUNCH CONTRACT VIOLATION — refusing to respawn ${role}/${callsign}: ${contract.violations.join('; ')}`);
+        }
         child = spawnFn(invocation.program, invocation.args, invocation.env);
         spawned = true;
         log(`[reboot-respawn] respawned ${role}/${callsign} (resume=${resumeUuid || 'none'})`);

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -197,6 +197,11 @@ export async function runRebootRespawn(opts = {}) {
         // FR-2: STRUCTURAL clauses only. The fail-SOFT profile degrade documented above (an
         // unresolvable profile still spawns, without CLAUDE_CONFIG_DIR) is preserved exactly —
         // expectProfile stays FALSE, so that policy is untouched by this SD.
+        //
+        // SCOPE OF THE CHECK: it inspects the DECLARED invocation.env, not the merged child
+        // environment — reboot-respawn.cjs spreads process.env under invocation.env (and, unlike
+        // spawn-control, does not strip inherited CLAUDE_* session markers). So this proves declared
+        // intent about the launch shape, never the child's effective environment.
         const contract = assertLaunchContract(invocation);
         if (!contract.ok) {
           throw new Error(`LAUNCH CONTRACT VIOLATION — refusing to respawn ${role}/${callsign}: ${contract.violations.join('; ')}`);

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -16,7 +16,7 @@
  */
 import { spawn as spawnProcess } from 'node:child_process';
 import path from 'node:path';
-import { buildSessionLaunch } from './build-session-launch.cjs';
+import { buildSessionLaunch, assertLaunchContract } from './build-session-launch.cjs';
 import { enforceTreeCurrency } from './tree-currency.cjs';
 import {
   resolveLiveSession,
@@ -274,6 +274,25 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // fail-soft: on error it yields [], which degrades to no_new_window rather than a wrong handle.
   const enumerate = opts.enumerateWindowsFn || enumerateWindows;
   const beforeWindows = await enumerate(opts);
+
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-1): enforce the launch contract at the
+  // EXECUTION seam. assertLaunchContract had ZERO non-test callers, so every guarantee it makes was
+  // verified only in the unit tier. Placed here, not inside buildSessionLaunch, for exactly the
+  // reason the tree-currency invariant above is: the builder is synchronous, reboot-respawn-runner
+  // does not await it, and existing tests call it with no cwd.
+  //
+  // FR-2: STRUCTURAL clauses only — expectProfile/expectResume stay FALSE. reboot-respawn-runner
+  // documents an intentional fail-SOFT profile degrade (a launch with an unresolvable profile still
+  // spawns, without CLAUDE_CONFIG_DIR), and spawn-control legitimately builds without a profile when
+  // accountProfile is absent. Demanding a profile here would silently convert that documented policy
+  // into fail-closed — a behaviour change nobody asked for.
+  //
+  // SCOPE OF THE CHECK: it inspects the DECLARED invocation.env, not the merged child environment
+  // (the spawner below spreads process.env under invocation.env). It proves declared intent.
+  const contract = assertLaunchContract(invocation);
+  if (!contract.ok) {
+    throw new Error(`[spawn-control] LAUNCH CONTRACT VIOLATION — refusing to spawn ${callsign || '<unknown>'}: ${contract.violations.join('; ')}`);
+  }
 
   const child = spawner(invocation.program, invocation.args, invocation.env);
   const pid = child && child.pid;

--- a/scripts/fleet/worker-spawn-executor.cjs
+++ b/scripts/fleet/worker-spawn-executor.cjs
@@ -44,7 +44,7 @@ function isLiveEnabled(env = process.env) {
 // old headless `claude -p`, which does not reliably register/persist in claude_sessions) with the full
 // claude.cmd path + explicit repo-root cwd + fail-loud. The /loop startup prompt is carried in the
 // child env (FLEET_WORKER_STARTUP_PROMPT) for the SessionStart hook to seed into the persistent session.
-const { buildSessionLaunch } = require('../../lib/fleet/build-session-launch.cjs');
+const { buildSessionLaunch, assertLaunchContract } = require('../../lib/fleet/build-session-launch.cjs');
 function buildSpawnInvocation(callsign, prompt) {
   return buildSessionLaunch({ callsign, startupPrompt: prompt });
 }
@@ -88,6 +88,23 @@ async function runExecutor(o) {
       continue;
     }
     try {
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-1): enforce the launch contract at
+      // the EXECUTION seam. Deliberately HERE and not at the inline spawner inside main() — that
+      // closure is require.main-guarded and not exported, so every unit test injects its own spawner
+      // and an assertion there would execute in ZERO tests. main() routes through runExecutor, so
+      // this line still covers the live path while remaining reachable by the suite. A guard whose
+      // tests cannot reach it is not a guard.
+      //
+      // FR-2: STRUCTURAL clauses only. This path legitimately builds WITHOUT a profile or resume
+      // token (buildSpawnInvocation passes neither), so expectProfile/expectResume stay FALSE —
+      // demanding them here would turn every worker revival red.
+      //
+      // The check inspects the DECLARED invocation.env, not the merged child env (the spawner
+      // spreads process.env under it). It proves declared intent.
+      const contract = assertLaunchContract(invocation);
+      if (!contract.ok) {
+        throw new Error(`LAUNCH CONTRACT VIOLATION — refusing to spawn ${req.requested_callsign}: ${contract.violations.join('; ')}`);
+      }
       await o.spawner(invocation, req);
       await o.stampFulfilled(req);
       spawned++;

--- a/tests/unit/fleet/build-session-launch.test.js
+++ b/tests/unit/fleet/build-session-launch.test.js
@@ -60,6 +60,36 @@ describe('resolveClaudeCmd', () => {
   });
 });
 
+describe('SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-4): the launcher-token refusal names the operator knob', () => {
+  // Now that this contract is ENFORCED at three spawn seams, the launcher-token clause is the one an
+  // operator can actually trip: resolveClaudeCmd returns FLEET_CLAUDE_CMD / CLAUDE_CLI_PATH verbatim,
+  // so a wrapper .cmd or quoted path refuses every spawn fleet-wide. Neither variable is documented,
+  // so the message is the only place the operator can learn what to change. Without this test the
+  // guidance could be gutted silently — the EXEC review noted these seams had NO message-content test.
+  const badToken = { program: 'wt.exe', args: ['-w', 'new', 'new-tab', '-d', 'R:\\r', '--', 'node.exe'], env: {}, persistent: true };
+
+  it('names BOTH env vars and the accepted shape', () => {
+    const msg = assertLaunchContract(badToken).violations.join(' ');
+    expect(msg).toMatch(/FLEET_CLAUDE_CMD/);
+    expect(msg).toMatch(/CLAUDE_CLI_PATH/);
+    expect(msg).toMatch(/claude\.cmd|claude\.exe/);
+    expect(msg).toMatch(/unquoted|wrapper|interpreter/);
+  });
+
+  it('does NOT echo the offending value — refusals reach logs and an HTTP 500 body', () => {
+    // A launcher override can embed a username or private directory layout. Every violation string
+    // in this predicate is deliberately value-free; naming the KNOB is what the operator needs.
+    const secretish = { ...badToken, args: ['-w', 'new', 'new-tab', '-d', 'R:\\r', '--', 'C:\\Users\\somebody\\secret-dir\\wrapper.cmd'] };
+    const msg = assertLaunchContract(secretish).violations.join(' ');
+    expect(msg).not.toMatch(/somebody|secret-dir|wrapper\.cmd/);
+  });
+
+  it('a conformant token produces no launcher-token violation (the check is not always-on)', () => {
+    const good = { ...badToken, args: ['-w', 'new', 'new-tab', '-d', 'R:\\r', '--', 'claude.cmd'] };
+    expect(assertLaunchContract(good).ok).toBe(true);
+  });
+});
+
 describe('assertLaunchContract — the conformance predicate', () => {
   it('passes a compliant invocation and flags a non-compliant one', () => {
     const good = buildSessionLaunch({ callsign: 'W', profile: 'canary', cwd: 'R:\\r', sdToResume: 'SD-Y' }, { env: { FLEET_ACCOUNT_PROFILES_DIR: PROFILES } });

--- a/tests/unit/fleet/respawn-live-intent-preserved.test.js
+++ b/tests/unit/fleet/respawn-live-intent-preserved.test.js
@@ -23,7 +23,22 @@ function harness({ live, spawnFn }) {
       supabase: {},
       loadFn: async () => [SLOT],
       rosterFn: () => [{ callsign: 'Test-1', role: 'worker' }],
-      buildInvocationFn: () => ({ program: 'claude', args: [], env: {}, sessionId: 'sess-x' }),
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-3): this invocation was previously
+      // degenerate ({ program: 'claude', args: [] }). The launch contract is now enforced at the live
+      // spawn seam in reboot-respawn-runner, so a degenerate invocation is refused before spawnFn runs.
+      //
+      // Making it CONFORMANT is an adaptation, not a weakening: this file's assertions all target
+      // OUTCOME DERIVATION (live_requested / live / respawn_unbound / respawn_unattempted), and the
+      // argv was incidental to every one of them. Contrast reboot-respawn-drill-runner.test.js:260,
+      // where the degenerate invocation IS load-bearing — that test runs live:false, never reaches the
+      // guarded assert, and was deliberately left untouched.
+      buildInvocationFn: () => ({
+        program: 'wt.exe',
+        args: ['-w', 'new', 'new-tab', '-d', 'R:\\repo', '--', 'claude.cmd'],
+        env: {},
+        persistent: true,
+        sessionId: 'sess-x',
+      }),
       spawnFn,
       logFn: async (_sb, ev) => { emitted.push(ev); return { ok: true }; },
       live,
@@ -57,6 +72,37 @@ describe('QF-20260725-813 — live intent survives to the emitter', () => {
     expect(payload.outcome).toBe('dry_run');
     expect(payload.live_requested).toBe(false);
     expect(payload.live).toBe(false);
+  });
+
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F — TS-2. The reboot-respawn runner's
+  // buildInvocationFn is caller-INJECTABLE, making it the only path by which a non-conformant
+  // invocation can reach a LIVE spawn without editing the builder or manipulating env. That is the
+  // highest-value of the three seams, and this is its guard.
+  //
+  // SPAWN SAFETY: runRebootRespawn spawns nothing itself (spawnFn defaults to null), and this test
+  // injects an explicit vi.fn(). It never routes through start-cp3-drills.js or reboot-respawn.cjs —
+  // a non-mocked --live once produced 12-13 real worker spawns on the chairman's machine.
+  it('TS-2: a non-conformant injected invocation is REFUSED at the live seam and never reaches spawnFn', async () => {
+    const spawnFn = vi.fn(() => ({ pid: 9999 }));
+    const emitted = [];
+    await runRebootRespawn({
+      supabase: {},
+      loadFn: async () => [SLOT],
+      rosterFn: () => [{ callsign: 'Test-1', role: 'worker' }],
+      // Degenerate on purpose: bare program, no -d, no -w new, not persistent.
+      buildInvocationFn: () => ({ program: 'claude', args: [], env: {}, sessionId: 'sess-x' }),
+      spawnFn,
+      logFn: async (_sb, ev) => { emitted.push(ev); return { ok: true }; },
+      live: true,
+      now: () => '2026-07-26T00:00:00Z',
+      opts: {},
+    });
+    // The whole point: the spawn is refused, not merely reported after the fact.
+    expect(spawnFn).not.toHaveBeenCalled();
+    // And the refusal is observable rather than silent — the runner logs the failure and the
+    // emitted event records that nothing bound.
+    const payload = emitted[0]?.payload;
+    expect(payload?.live).toBe(false);
   });
 
   it('QF-20260724-911 invariant preserved: payload.live still derives from reconciliation, not from spawnFn returning', async () => {

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -263,6 +263,46 @@ describe('spawn (FR-1)', () => {
     expect(result.handleCaptureFailed).toBe(false);
   });
 
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F — MUTATION-KILLING seam test (condition C1).
+  //
+  // spawn() now asserts the launch contract immediately before the spawner. Without this test that
+  // enforcement could be DELETED OUTRIGHT and the entire suite would still pass — the EXEC-phase
+  // review demonstrated exactly that. An enforcement that can be silently removed while still being
+  // reported as present is the shipped-but-inert shape this SD exists to eliminate, so leaving it
+  // unpinned would have reproduced the SD's own defect inside the SD's own fix.
+  //
+  // Same corrective precedent as tests/unit/fleet/tree-currency.test.js, which added a
+  // mutation-killing block for this same function after the identical finding.
+  //
+  // FLEET_CLAUDE_CMD is the lever because it is the ONE operator-reachable clause today:
+  // resolveClaudeCmd returns it verbatim and the token regex requires a claude basename.
+  it('C1: spawn() REFUSES a contract-violating invocation — deleting the assert makes this fail', async () => {
+    const spawnFn = vi.fn();
+    await expect(spawn(
+      { role: 'worker', callsign: 'Probe-A' },
+      {
+        live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(), sleepFn: vi.fn(),
+        supabaseClient: makeFakeSupabase({ sessions: [] }), skipDedup: true,
+        env: { FLEET_CLAUDE_CMD: 'C:\\tools\\node.exe' }, // not a claude launcher token
+      },
+    )).rejects.toThrow(/LAUNCH CONTRACT VIOLATION/);
+    // The refusal must happen BEFORE the process is launched, not be reported after the fact.
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('C1 control: the SAME call without the override spawns (the refusal is not incidental)', async () => {
+    const spawnFn = vi.fn().mockReturnValue({ pid: 4242 });
+    const result = await spawn(
+      { role: 'worker', callsign: 'Probe-A' },
+      {
+        live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(), sleepFn: vi.fn(),
+        supabaseClient: makeFakeSupabase({ sessions: [] }), skipDedup: true,
+      },
+    );
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(result.live).toBe(true);
+  });
+
   it('ADVERSARIAL-REVIEW FIX: merges the captured handle into existing metadata, never overwrites the whole blob', async () => {
     const nowMs = 1_800_000_000_000;
     const child = { pid: 4242 };

--- a/tests/unit/fleet/worker-spawn-executor.test.js
+++ b/tests/unit/fleet/worker-spawn-executor.test.js
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { resolveSpawnDecisions } = require('../../../lib/fleet/spawn-executor-core.cjs');
 const { runExecutor, buildSpawnInvocation, resolvePerTickCap, isLiveEnabled } = require('../../../scripts/fleet/worker-spawn-executor.cjs');
+const { assertLaunchContract } = require('../../../lib/fleet/build-session-launch.cjs');
 
 const NOW = 1_000_000_000_000;
 const future = () => new Date(NOW + 60 * 60 * 1000).toISOString();
@@ -84,6 +85,51 @@ describe('runExecutor (FR-2, dry-run vs live)', () => {
     expect(stampFulfilled).toHaveBeenCalledTimes(2);
     expect(r.spawned).toBe(2);
     expect(r.errors).toBe(0);
+  });
+
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F — TS-3, the LOAD-BEARING guard for FR-2.
+  //
+  // The launch contract is now asserted at the execution seam in runExecutor. FR-2 requires that the
+  // seam checks STRUCTURAL clauses only, with expectProfile/expectResume FALSE. This path legitimately
+  // builds without a profile or resume token, so if a future edit hardcoded those expectations true,
+  // EVERY worker revival would stop spawning. This test is the tripwire for that.
+  //
+  // WHY THE SEAM MOVED: an earlier draft placed the assertion inside main()'s inline spawner closure,
+  // which is require.main-guarded and not exported — every test here injects its own spawner, so an
+  // assertion there would run in ZERO tests and this guard would be green against a correct AND a
+  // broken implementation. Verified RED against a hardcoded expectProfile/expectResume:true build
+  // (spawner not called, errors=1); GREEN as written.
+  it('TS-3: a no-profile / no-resume revival still spawns — the launch assert is structural-only', async () => {
+    const spawner = vi.fn().mockResolvedValue(undefined);
+    const stampFulfilled = vi.fn().mockResolvedValue(undefined);
+    const r = await runExecutor({
+      pendingRequests: [req('a', 'Echo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled, prompt: 'PROMPT',
+    });
+    // buildSpawnInvocation supplies neither CLAUDE_CONFIG_DIR nor a resume token — that is the
+    // legitimate shape this fleet revives workers with, and it must remain spawnable.
+    expect(spawner).toHaveBeenCalledTimes(1);
+    expect(r.spawned).toBe(1);
+    expect(r.errors).toBe(0);
+    const [invocation] = spawner.mock.calls[0];
+    expect(invocation.env?.CLAUDE_CONFIG_DIR).toBeUndefined();
+    expect(invocation.args).not.toContain('--resume');
+  });
+
+  it('TS-1: the invocation reaching the spawner is contract-conformant (argv unchanged by the assert)', async () => {
+    const spawner = vi.fn().mockResolvedValue(undefined);
+    await runExecutor({
+      pendingRequests: [req('a', 'Echo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled: vi.fn().mockResolvedValue(undefined), prompt: 'PROMPT',
+    });
+    const [invocation] = spawner.mock.calls[0];
+    // assertLaunchContract reads and returns {ok, violations}; it mutates nothing. Pin that the
+    // spawner still receives the same structural shape it did before enforcement was added.
+    expect(assertLaunchContract(invocation).ok).toBe(true);
+    expect(invocation.program).toBe('wt.exe');
+    expect(invocation.args).not.toContain('-p');
   });
 
   it('LIVE: a spawner error leaves the row un-fulfilled (no false fulfillment)', async () => {

--- a/tests/unit/fleet/worker-spawn-executor.test.js
+++ b/tests/unit/fleet/worker-spawn-executor.test.js
@@ -117,6 +117,52 @@ describe('runExecutor (FR-2, dry-run vs live)', () => {
     expect(invocation.args).not.toContain('--resume');
   });
 
+  // MUTATION-KILLING seam test (EXEC-phase adversarial review, condition C2).
+  //
+  // TS-3 above proves the seam does not FALSELY reject. It does NOT prove the seam exists: reverting
+  // the assertion entirely leaves TS-3 green, because with no assert the spawner is simply called.
+  // The review demonstrated that this seam and the spawn-control one could BOTH be deleted outright
+  // with the whole suite still passing — which is precisely the shipped-but-inert shape this SD was
+  // written to eliminate, reproduced in the SD's own delivery. This test kills that mutation.
+  //
+  // Precedent: tests/unit/fleet/tree-currency.test.js added an equivalent mutation-killing block for
+  // the same function after the identical finding.
+  //
+  // FLEET_CLAUDE_CMD is used because it is the ONE operator-reachable clause today —
+  // resolveClaudeCmd returns it verbatim and the token regex rejects a non-claude basename.
+  it('C2: the seam REFUSES a contract-violating invocation — deleting the assert makes this fail', async () => {
+    const prior = process.env.FLEET_CLAUDE_CMD;
+    process.env.FLEET_CLAUDE_CMD = 'C:\\tools\\node.exe'; // not a claude launcher token
+    try {
+      const spawner = vi.fn().mockResolvedValue(undefined);
+      const stampFulfilled = vi.fn().mockResolvedValue(undefined);
+      const r = await runExecutor({
+        pendingRequests: [req('a', 'Echo')],
+        liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+        live: true, spawner, stampFulfilled, prompt: 'PROMPT',
+      });
+      expect(spawner).not.toHaveBeenCalled();
+      expect(r.spawned).toBe(0);
+      expect(r.errors).toBe(1);
+      // The row must stay pending — a refused spawn must never be recorded as fulfilled.
+      expect(stampFulfilled).not.toHaveBeenCalled();
+    } finally {
+      if (prior === undefined) delete process.env.FLEET_CLAUDE_CMD;
+      else process.env.FLEET_CLAUDE_CMD = prior;
+    }
+  });
+
+  it('C2 control: the SAME call with no override spawns normally (the refusal is not incidental)', async () => {
+    const spawner = vi.fn().mockResolvedValue(undefined);
+    const r = await runExecutor({
+      pendingRequests: [req('a', 'Echo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled: vi.fn().mockResolvedValue(undefined), prompt: 'PROMPT',
+    });
+    expect(spawner).toHaveBeenCalledTimes(1);
+    expect(r.errors).toBe(0);
+  });
+
   it('TS-1: the invocation reaching the spawner is contract-conformant (argv unchanged by the assert)', async () => {
     const spawner = vi.fn().mockResolvedValue(undefined);
     await runExecutor({


### PR DESCRIPTION
## Summary

`assertLaunchContract` had **zero non-test callers** — a well-tested predicate nobody enforced. It is now called at the three production **execution** seams, immediately before the spawner:

| seam | file |
|---|---|
| spawn-control | `lib/fleet/spawn-control.js:292` |
| worker revival | `scripts/fleet/worker-spawn-executor.cjs:104` (in `runExecutor`) |
| reboot-respawn | `lib/fleet/reboot-respawn-runner.js:200` (inside the live guard) |

Not inside `buildSessionLaunch` — `spawn-control.js:208-231` already documents why the identical tree-currency invariant lives at the execution seam.

## Honest sizing

This is **defence-in-depth and a regression tripwire, not the closure of an active hole.** `buildSessionLaunch` is structurally incapable of violating most of its own contract (args literal and program/persistent hardcoded; `startDir` never empty) — nine probed shapes returned `ok=true`. The one operator-reachable clause today is the launcher token via `FLEET_CLAUDE_CMD`/`CLAUDE_CLI_PATH`, which is unset. The value is that the contract becomes *falsifiable* if the args literal is ever edited, and that the one caller-**injectable** builder seam gains a guard.

An earlier draft of this SD justified itself with the QF-20260724-119 12–13-spawn incident. **That was false** — those spawns were contract-*conformant*; this control would not have prevented them. Corrected in the SD description rather than left to be re-derived.

## The SD reproduced its own defect, and that got caught

Its thesis is "a predicate nobody calls is not enforcement." The EXEC review then measured that **two of the three seams it had just added could be deleted outright with all 1202 tests still green** — present, correct, and silently removable. Only the runner seam was pinned.

Fixed with paired refusal+control tests at every seam, verified by **neutering each seam in place** (not by revert — a revert leaves the no-false-reject tests green and proves nothing). Precedent for this exact function already existed at `tests/unit/fleet/tree-currency.test.js:314-327`.

## Behaviour deliberately preserved

`expectProfile`/`expectResume` stay **FALSE** at all three seams. Deriving them from caller intent would silently convert a documented **fail-soft** profile degrade into fail-closed and turn every worker revival red. The security review probed 11 launch shapes: all six legitimate production shapes still spawn, including worker revival (no profile, no resume) and the fail-soft degrade.

## Known limits, stated in code so nobody over-trusts this

- The check inspects the **declared** `invocation.env`, never the merged child environment.
- The launcher-token regex is a **shape** check, not launcher authenticity — it is unanchored, so a path ending `notclaude` passes.
- **Out of scope and still unprotected:** `execute-team.mjs`, `drain-orchestrator.mjs` (headless `claude --print`) and `leo-continuous-loop.ps1` (PowerShell). They violate every clause and never reach the builder.

## Test plan

- [x] `tests/unit/fleet`: 85 files, **1044 passing**.
- [x] Full `tests/unit`: 26721 passing; 4 pre-existing failures proven by reverting all source files and re-running.
- [x] Every new assertion verified RED against the code it guards — by **mutation** where a revert would not discriminate.
- [x] `reboot-respawn-drill-runner.test.js:260` untouched (its degenerate invocation is load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)