### PR TITLE
fix(QF-20260725-868): give the completion-flags witness a third state - could-not-determine

### DIFF
--- a/lib/governance/completion-flag-keys.js
+++ b/lib/governance/completion-flag-keys.js
@@ -20,3 +20,32 @@ export const COMPLETION_FLAG = Object.freeze({
   ORIGIN_VALUE: 'completion_flag',
   SOURCE_SD_KEY: 'source_sd',
 });
+
+/**
+ * QF-20260725-868 — the THIRD state of the completion-flags witness.
+ *
+ * The witness contract was two-valued: a reason STRING means "failed", null means "verified clean".
+ * Its catch block also returned null, so a CRASHED witness was byte-indistinguishable from a passing
+ * one — the mechanism built to prove the post-completion tail ran could not detect its own failure
+ * to run. This sentinel gives "could-not-determine" a representation so the CONSUMER decides what to
+ * do about it, mirroring pre-tool-enforce.cjs's `unknown` hash return.
+ *
+ * COORDINATOR DECISION (a59441f4), deliberately encoded here rather than left to a caller:
+ * this state SURFACES, it NEVER BLOCKS. The validator is a WITNESS sitting in a Stop hook between
+ * every worker and done — making it fail-closed would convert an OBSERVABILITY gap into an
+ * AVAILABILITY outage, where one transient Supabase error wedges the whole fleet. The defect is that
+ * a crash is indistinguishable from a pass, not that a crash fails to block.
+ *
+ * Lives beside the keys it guards so writer and consumer cannot drift on it either.
+ */
+export const WITNESS_INDETERMINATE = Object.freeze({
+  /** Distinct, non-null, and NOT a reason string — callers must test identity, never truthiness. */
+  STATE: 'could_not_determine',
+  /** Stable feedback category so the rate is COUNTABLE, not merely logged. */
+  FEEDBACK_CATEGORY: 'witness_indeterminate',
+});
+
+/** True only for the could-not-determine sentinel — never for a genuine reason string or null. */
+export function isWitnessIndeterminate(v) {
+  return v === WITNESS_INDETERMINATE.STATE;
+}

--- a/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
+++ b/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
@@ -180,14 +180,37 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
     const healSkipSources = ['heal', 'corrective'];
     const sdSource = (sd.source || '').toLowerCase();
     if (!healSkipSources.includes(sdSource)) {
-      const { data: healScores } = await supabase
-        .from('eva_heal_scores')
+      // QF-20260725-868, THIRD SITE in this same function. This queried `eva_heal_scores`
+      // .eq('sd_key', ...) — a table that DOES NOT EXIST and, per `git grep`, never did: no
+      // migration anywhere in the repo, and this was its only reference in the codebase. The probe
+      // therefore errored on every run, `data` came back null, `hasHeal` was false, and 'HEAL' was
+      // pushed for EVERY code-producing SD whether /heal ran or not.
+      //
+      // Same defect as the two catches above, inverted: a check that COULD NOT SEE the constraint
+      // still reported a verdict, with the direction picked by the code path rather than by evidence.
+      // It is also the pattern completion-flag-keys.js's own docblock names —
+      // PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001 — as TABLE-name drift instead of metadata-key
+      // drift: writer and consumer never met.
+      //
+      // The real writer is scripts/eva/heal-command.mjs: `/heal sd` inserts into `eva_vision_scores`
+      // with `sd_id: sdScore.sd_key` and `rubric_snapshot.mode = 'sd-heal'`, and `/heal status` reads
+      // "latest SD heal scores" back from that same table via `sd_id IS NOT NULL`. NOTE THE TRAP:
+      // `eva_vision_scores.sd_id` holds the SD *KEY* string, not a UUID FK (portfolio-level vision
+      // scores are the rows where it is NULL) — so this filters on sdKey, not sd.id.
+      //
+      // The error is now CAPTURED rather than discarded, so an unreachable table can no longer
+      // masquerade as "HEAL missing". Consistent with the decision above, indeterminate SURFACES
+      // under its own label and never blocks.
+      const { data: healScores, error: healErr } = await supabase
+        .from('eva_vision_scores')
         .select('id')
-        .eq('sd_key', sdKey)
+        .eq('sd_id', sdKey)
         .limit(1);
 
-      const hasHeal = healScores && healScores.length > 0;
-      if (!hasHeal) {
+      if (healErr) {
+        console.error(`   ⚠️  HEAL witness could NOT be determined for ${sdKey} (${healErr.message}) — surfaced, not blocking`);
+        missingRecommended.push('HEAL_CHECK_INDETERMINATE');
+      } else if (!healScores || healScores.length === 0) {
         missingRecommended.push('HEAL');
       }
     }

--- a/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
+++ b/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
@@ -12,7 +12,7 @@
  */
 
 import { execSync } from 'child_process';
-import { COMPLETION_FLAG } from '../../../lib/governance/completion-flag-keys.js';
+import { COMPLETION_FLAG, WITNESS_INDETERMINATE, isWitnessIndeterminate } from '../../../lib/governance/completion-flag-keys.js';
 
 /**
  * SD-LEO-INFRA-COMPLETION-FLAGS-DURABLE-001 / FR-4 + TR-6.
@@ -54,8 +54,46 @@ async function _checkCompletionFlagsWitness(supabase, sdKey) {
     }
 
     return null;
+  } catch (e) {
+    // QF-20260725-868: this catch used to `return null` — BYTE-IDENTICAL to the success path above,
+    // so a CRASHED witness reported VERIFIED-CLEAN and no caller could tell the difference. The
+    // mechanism built to prove the post-completion tail ran could not detect its own failure to run.
+    //
+    // It stays FAIL-SOFT (coordinator decision a59441f4): this is a witness inside a Stop hook
+    // standing between every worker and "done". Blocking on a crash would turn an observability gap
+    // into an availability outage — one transient Supabase error would wedge the fleet. The fix is
+    // to make the state DISTINGUISHABLE, not to make it blocking.
+    await _recordIndeterminate(supabase, sdKey, e);
+    return WITNESS_INDETERMINATE.STATE;
+  }
+}
+
+/**
+ * QF-20260725-868: make could-not-determine COUNTABLE, not merely logged.
+ *
+ * "A non-blocking marker nobody can count is the same defect wearing a different value" — all four
+ * AEGIS adapters already logged, and logging is exactly what let that class persist unnoticed. This
+ * writes one queryable row per occurrence so the rate can be checked later.
+ *
+ * Best-effort by construction: it is wrapped so it can NEVER throw. A telemetry failure must not
+ * escalate into the blocking path we just decided against — that would reintroduce the availability
+ * risk through the back door.
+ */
+async function _recordIndeterminate(supabase, sdKey, err) {
+  try {
+    console.error(`   ⚠️  COMPLETION_FLAGS witness could NOT be determined for ${sdKey} (${err && err.message}) — surfaced, not blocking`);
+    if (!supabase) return;
+    await supabase.from('feedback').insert({
+      type: 'harness',
+      category: WITNESS_INDETERMINATE.FEEDBACK_CATEGORY,
+      severity: 'medium',
+      title: `completion-flags witness indeterminate for ${sdKey}`,
+      description: `The completion-flags witness threw and could not determine whether the post-completion tail ran. Surfaced non-blocking per QF-20260725-868. Error: ${err && err.message}`,
+      error_message: String((err && err.message) || err || 'unknown'),
+      metadata: { sd_key: sdKey, state: WITNESS_INDETERMINATE.STATE, qf: 'QF-20260725-868' },
+    });
   } catch {
-    return null; // fail-soft
+    // Deliberately swallowed — telemetry must never affect the hook's decision.
   }
 }
 
@@ -112,11 +150,19 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
           missingRequired.push('SHIP');
         }
       }
-    } catch {
-      // If diff fails (branch deleted after merge, or on main), don't assume ship is needed
-      // The completion_date check above should handle completed/shipped SDs
-      // Only log for debugging - don't block
-      console.error(`   ℹ️  Git diff failed for ${sdKey} - branch may already be merged`);
+    } catch (e) {
+      // QF-20260725-868, SECOND SITE, same shape as the witness catch. This silently SKIPS
+      // missingRequired.push('SHIP'), so a git error RETIRES A SHIP REQUIREMENT inside the
+      // enforcement path — and the original comment rationalised the skip, which is exactly why it
+      // read as intentional rather than as a swallowed unknown.
+      //
+      // The skip itself is KEPT deliberately: pushing SHIP here would put an indeterminate state on
+      // the BLOCKING path (missingRequired triggers exit 2), which is the failure mode the
+      // coordinator decision forbids — a git hiccup would wedge completion. What changes is that the
+      // unknown is now NAMED and surfaced under its own non-blocking label instead of vanishing into
+      // an informational log that nobody counts.
+      console.error(`   ⚠️  Git diff could NOT be determined for ${sdKey} (${e && e.message}) — SHIP requirement not evaluated; surfaced, not blocking`);
+      missingRecommended.push('SHIP_CHECK_INDETERMINATE');
     }
   }
 
@@ -161,8 +207,17 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
   // including orchestrators and non-code SDs) should carry the durable completion-flags record.
   // Reminder-first: this only ever appends to missingRecommended (never missingRequired), so it
   // can never trigger the process.exit(2) BLOCK path below.
+  // QF-20260725-868: THREE states, tested by identity — never by truthiness.
+  //   null                        -> verified clean
+  //   WITNESS_INDETERMINATE.STATE -> the witness crashed; we do NOT know either way
+  //   any other string            -> a genuine reason the record is missing/incomplete
+  // Collapsing indeterminate into "missing" would be the same defect inverted: asserting a finding
+  // from a check that never produced one. It is surfaced under its own label instead, and remains
+  // non-blocking (missingRecommended never reaches the exit-2 path below).
   const completionFlagsWarn = await _checkCompletionFlagsWitness(supabase, sdKey);
-  if (completionFlagsWarn) {
+  if (isWitnessIndeterminate(completionFlagsWarn)) {
+    missingRecommended.push('COMPLETION_FLAGS_WITNESS_INDETERMINATE');
+  } else if (completionFlagsWarn) {
     missingRecommended.push('COMPLETION_FLAGS');
   }
 

--- a/tests/unit/governance/completion-flags.test.js
+++ b/tests/unit/governance/completion-flags.test.js
@@ -20,7 +20,7 @@ import {
   captureCompletionFlags,
   formatCompletionFlagsBlock,
 } from '../../../scripts/capture-completion-flags.js';
-import { COMPLETION_FLAG } from '../../../lib/governance/completion-flag-keys.js';
+import { COMPLETION_FLAG, WITNESS_INDETERMINATE, isWitnessIndeterminate } from '../../../lib/governance/completion-flag-keys.js';
 import { emitFeedback } from '../../../lib/governance/emit-feedback.js';
 
 // REAL consumer functions (TS-3) — assert the witness tuple against actual behavior.
@@ -268,6 +268,91 @@ describe('TS-4 validator placement (reminder-first, never exit(2))', () => {
     expect(exitSpy).not.toHaveBeenCalled();
     const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
     expect(advisories).not.toMatch(/completion-flags record (missing|incomplete)/i);
+  });
+
+  // QF-20260725-868 — the witness could not detect its OWN failure to run. Its catch returned null,
+  // byte-identical to the success path, so a CRASH reported VERIFIED-CLEAN.
+  //
+  // The QF's acceptance is explicit: demonstrate AT THE CONSUMER that a thrown validator is observed
+  // as could-not-determine AND that completion is NOT blocked. A green CI shows neither half, so
+  // these force the throw rather than asserting on the predicate in isolation.
+  describe('QF-20260725-868: a crashed witness is distinguishable from a clean one, and never blocks', () => {
+    /** A client whose completion-flags probe THROWS, with every other path intact. */
+    function buildThrowingWitnessSupabase() {
+      const base = buildValidatorSupabase({ feedbackRows: [] });
+      const inserted = [];
+      return {
+        _inserted: inserted,
+        from(table) {
+          if (table === 'feedback') {
+            return {
+              // The witness read path explodes...
+              select: () => { throw new Error('supabase exploded'); },
+              // ...but the countability write path must still be reachable.
+              insert: (row) => { inserted.push(row); return Promise.resolve({ data: null, error: null }); },
+            };
+          }
+          return base.from(table);
+        },
+      };
+    }
+
+    it('HALF 1 — the crash is OBSERVED as indeterminate, not silently reported clean', async () => {
+      const supabase = buildThrowingWitnessSupabase();
+      await validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001');
+      const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(advisories).toMatch(/could NOT be determined/i);
+      expect(advisories).toContain('COMPLETION_FLAGS_WITNESS_INDETERMINATE');
+      // It must NOT masquerade as a genuine "record missing" finding — that would be the same
+      // defect inverted: asserting a result from a check that never produced one.
+      expect(advisories).not.toMatch(/completion-flags record missing/i);
+    });
+
+    it('HALF 2 — completion is NOT blocked (surface, never block)', async () => {
+      const supabase = buildThrowingWitnessSupabase();
+      await validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001');
+      // A witness that blocks when it fails turns an observability gap into an availability outage:
+      // this sits in a Stop hook between every worker and done, so one transient DB error would
+      // wedge the fleet. exit(2) is the blocking path.
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('the indeterminate state is COUNTABLE, not merely logged', async () => {
+      const supabase = buildThrowingWitnessSupabase();
+      await validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001');
+      // "A non-blocking marker nobody can count is the same defect wearing a different value."
+      const row = supabase._inserted.find(r => r?.category === WITNESS_INDETERMINATE.FEEDBACK_CATEGORY);
+      expect(row, 'expected a queryable feedback row for the indeterminate state').toBeTruthy();
+      expect(row.metadata.sd_key).toBe('SD-INFRA-XYZ-001');
+      expect(row.metadata.state).toBe(WITNESS_INDETERMINATE.STATE);
+    });
+
+    it('telemetry failure cannot escalate into the blocking path', async () => {
+      // If recording the crash also throws, the hook must still not block — otherwise the
+      // availability risk we just rejected returns through the back door.
+      const base = buildValidatorSupabase({ feedbackRows: [] });
+      const supabase = {
+        from(table) {
+          if (table === 'feedback') {
+            return {
+              select: () => { throw new Error('read exploded'); },
+              insert: () => { throw new Error('write exploded too'); },
+            };
+          }
+          return base.from(table);
+        },
+      };
+      await expect(validatePostCompletion(supabase, sd, 'SD-INFRA-XYZ-001')).resolves.not.toThrow();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('the sentinel is tested by IDENTITY, never truthiness', () => {
+      // A genuine reason string is also truthy; only the sentinel is could-not-determine.
+      expect(isWitnessIndeterminate(WITNESS_INDETERMINATE.STATE)).toBe(true);
+      expect(isWitnessIndeterminate('completion-flags record missing for SD-X')).toBe(false);
+      expect(isWitnessIndeterminate(null)).toBe(false);
+      expect(isWitnessIndeterminate(undefined)).toBe(false);
+    });
   });
 });
 

--- a/tests/unit/governance/completion-flags.test.js
+++ b/tests/unit/governance/completion-flags.test.js
@@ -85,15 +85,20 @@ function buildEmitSupabase({ existingByHash = {} } = {}) {
  * The `feedback` table responds to the completion-flags witness query
  * (.eq('metadata->>origin', ...).eq('metadata->>source_sd', ...)).
  */
-function buildValidatorSupabase({ feedbackRows = [], retros = [], prRecords = [], docmon = [] } = {}) {
+function buildValidatorSupabase({ feedbackRows = [], retros = [], prRecords = [], docmon = [], healRows = [], tablesSeen = null } = {}) {
   const terminal = (data) => Promise.resolve({ data, error: null });
 
   function tableHandler(table) {
+    if (tablesSeen) tablesSeen.push(table);
     // Generic chainable builder; .then resolves to the canned data for non-feedback tables.
+    // NOTE (QF-20260725-868): this fixture answers ANY table name with `[]`, which is precisely
+    // why it never caught the `eva_heal_scores` phantom — a stub that satisfies every name cannot
+    // discriminate a wrong one. Hence the explicit table-name assertion in the HEAL suite below.
     const result =
       table === 'retrospectives' ? retros :
       table === 'sd_scope_deliverables' ? prRecords :
       table === 'sub_agent_execution_results' ? docmon :
+      table === 'eva_vision_scores' ? healRows :
       [];
 
     const chain = {
@@ -352,6 +357,89 @@ describe('TS-4 validator placement (reminder-first, never exit(2))', () => {
       expect(isWitnessIndeterminate('completion-flags record missing for SD-X')).toBe(false);
       expect(isWitnessIndeterminate(null)).toBe(false);
       expect(isWitnessIndeterminate(undefined)).toBe(false);
+    });
+  });
+
+  // QF-20260725-868, THIRD SITE — surfaced by this PR's own schema-reference-lint failure.
+  //
+  // The HEAL check queried `eva_heal_scores`, a table that does not exist and never did (no
+  // migration in the repo; that line was its only reference anywhere). So the probe errored every
+  // run, the discarded error left `data` null, and 'HEAL' was pushed for EVERY code-producing SD
+  // whether /heal ran or not — a permanent false positive in the same advisory list this QF's new
+  // labels report into. The real writer is scripts/eva/heal-command.mjs, which inserts into
+  // `eva_vision_scores` with `sd_id: <sd_key>`.
+  describe('QF-20260725-868: the HEAL witness queries the table the writer actually writes', () => {
+    let exitSpy, errSpy, logSpy;
+    beforeEach(() => {
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('UNEXPECTED_EXIT'); });
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+    afterEach(() => { exitSpy.mockRestore(); errSpy.mockRestore(); logSpy.mockRestore(); });
+
+    // Code-producing so the isCodeProducing branch (and therefore the HEAL check) actually runs.
+    const codeSd = {
+      id: 'sd-uuid-FEAT',
+      sd_key: 'SD-FEAT-ABC-001',
+      sd_type: 'feature',
+      source: 'manual',
+      completion_date: '2026-06-04T00:00:00Z',
+    };
+
+    it('a present heal score clears the HEAL advisory (RED before the fix)', async () => {
+      // THE DISCRIMINATING TEST. Pre-fix this could not pass for any input: the phantom table meant
+      // HEAL was pushed unconditionally, so "heal ran" and "heal did not run" were indistinguishable.
+      const supabase = buildValidatorSupabase({
+        healRows: [{ id: 'vs-1' }],
+        feedbackRows: [{ id: 'fb-1', metadata: { reflection: { checklist_items: 4 } } }],
+      });
+      await validatePostCompletion(supabase, codeSd, 'SD-FEAT-ABC-001');
+      const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(advisories).not.toMatch(/\bHEAL\b/);
+    });
+
+    it('no heal score still reports HEAL — the fix must not silence the real signal', async () => {
+      // Proving BOTH directions: a table-name fix that always cleared HEAL would be just as broken.
+      const supabase = buildValidatorSupabase({ healRows: [] });
+      await validatePostCompletion(supabase, codeSd, 'SD-FEAT-ABC-001');
+      const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(advisories).toMatch(/\bHEAL\b/);
+      expect(advisories).toContain('/heal sd');
+    });
+
+    it('queries eva_vision_scores and never the phantom eva_heal_scores', async () => {
+      // Pins the SEMANTIC that broke — writer and consumer must name the same relation. The generic
+      // fixture answers any table with [], so without this assertion a re-drift to another
+      // nonexistent name would keep every test green.
+      const tablesSeen = [];
+      const supabase = buildValidatorSupabase({ healRows: [{ id: 'vs-1' }], tablesSeen });
+      await validatePostCompletion(supabase, codeSd, 'SD-FEAT-ABC-001');
+      expect(tablesSeen).toContain('eva_vision_scores');
+      expect(tablesSeen).not.toContain('eva_heal_scores');
+    });
+
+    it('an unreachable heal table surfaces as indeterminate, not as "HEAL missing"', async () => {
+      // The original defect in miniature: a probe that cannot see the constraint must not report a
+      // verdict. Non-blocking, consistent with the coordinator decision.
+      const base = buildValidatorSupabase({});
+      const supabase = {
+        from(table) {
+          if (table === 'eva_vision_scores') {
+            const chain = {
+              select: () => chain,
+              eq: () => chain,
+              limit: () => Promise.resolve({ data: null, error: { message: 'relation does not exist' } }),
+            };
+            return chain;
+          }
+          return base.from(table);
+        },
+      };
+      await validatePostCompletion(supabase, codeSd, 'SD-FEAT-ABC-001');
+      const advisories = errSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(advisories).toContain('HEAL_CHECK_INDETERMINATE');
+      expect(advisories).toMatch(/HEAL witness could NOT be determined/i);
+      expect(exitSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## The defect

`_checkCompletionFlagsWitness` had a two-valued contract — a reason **string** means failed, `null` means verified-clean. Its `catch` block **also returned `null`**, byte-identical to the success path, so a **crashed witness reported VERIFIED-CLEAN** and no caller could tell the difference.

CLAUDE.md names this validator as *the* completion-flags witness — the check that proves the post-completion tail actually ran. So this is the witness problem itself: the mechanism built to detect skipped completion work could not detect its own failure to run.

## Surface, never block

The coordinator made this call explicitly and it is non-reopenable, so it is encoded in the sentinel's own docblock rather than left to a reader.

The obvious fix is dangerous: returning a reason string from the `catch` would make the state **blocking**, because callers treat strings as blocking reasons. This sits in a Stop hook between every worker and "done" — fail-closed means one transient Supabase error wedges the fleet. The defect is that a crash is *indistinguishable from a pass*, not that a crash fails to block.

Three states, tested by **identity** and never truthiness (a genuine reason string is also truthy):

| value | meaning | blocks? |
|---|---|---|
| `null` | verified clean | no (unchanged) |
| `<reason string>` | failed | no — `missingRecommended` (unchanged) |
| `WITNESS_INDETERMINATE.STATE` | could not determine | **no** (new) |

Follows the in-tree precedent rather than inventing one: `pre-tool-enforce.cjs` returns the literal `'unknown'` when its hash computation throws — distinguishable to the consumer, and *the consumer decides*. The sentinel lives in `completion-flag-keys.js` beside the keys it guards, so writer and consumer cannot drift on it either.

## Countable, not merely logged

Every occurrence writes one queryable `feedback` row (`category='witness_indeterminate'`). This half is mandatory — *a non-blocking marker nobody can count is the same defect wearing a different value*, and logging is exactly what let this class persist unnoticed. The recorder is wrapped so it can **never** throw: a telemetry failure must not escalate into the blocking path we just rejected. A test pins that.

## Second site, same shape

The git-diff `catch` silently skipped `missingRequired.push('SHIP')` — a git error **retired a SHIP requirement inside the enforcement path**, and its comment rationalised the skip, which is why it read as intentional. The skip is **kept deliberately** (pushing SHIP would put an indeterminate state on the blocking path, exactly what the decision forbids), but the unknown is now named and surfaced as `SHIP_CHECK_INDETERMINATE` instead of vanishing into an informational log.

## Acceptance — demonstrated at the consumer

The QF requires both halves shown at the caller, not at the merge; a green CI demonstrates neither. Five new tests force the validator to throw and assert separately that the caller **observes** could-not-determine and that completion is **not** blocked.

- 2 discriminating tests verified **RED** against the pre-fix `catch`.
- 2 fail-soft guards pass in both states *by design* — the property they protect must not change.
- `tests/unit/governance`: fully green.
- One pre-existing failure in `tests/unit/hooks/session-register-created-emission.test.js`, proven identical by stashing this change and re-running.

## Class note

A could-not-determine state collapsed into a verdict, with the direction chosen by the code path rather than by the evidence — the fourth instance of this shape in one night. Fixed the same way each time: give the third state a representation and make the consumer handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
