### PR TITLE
fix(QF-20260726-921): surface unanswered worker signals in the sweep tick line

### DIFF
--- a/lib/coordinator/worker-signal-starvation.cjs
+++ b/lib/coordinator/worker-signal-starvation.cjs
@@ -1,0 +1,103 @@
+// QF-20260726-921 — surface UNANSWERED WORKER SIGNALS in the sweep tick line. Read-side only.
+//
+// THE STARVATION THIS MAKES VISIBLE (measured by Bravo, coordinator-endorsed): 17 coordinator_reply
+// rows since 00:00Z — SIXTEEN to Adam, ZERO to any worker — while a worker sat blocked 80 minutes on a
+// prd-ambiguous signal that explicitly gated its SD. The coordinator drained the Adam advisory lane
+// every tick per standing instruction and never once queried payload->>signal_type, so worker signals
+// lived behind a filter nobody was running. This was a LANE ASYMMETRY, not neglect and not a dead
+// coordinator.
+//
+// WHY IT WAS INVISIBLE FROM BOTH ENDS AT ONCE, which is the part worth keeping: a starved worker's only
+// legal moves are PREPARE and RE-ASK (the wind-down rule correctly forbids dropping the claim), so it
+// cannot distinguish a saturated lane from being ignored — both present as silence — and therefore
+// cannot escalate differently. Meanwhile the coordinator cannot see what it is not querying. Neither
+// side can observe the failure, so it persists without anyone being at fault.
+//
+// WHY THIS PRINTS UNCONDITIONALLY, INCLUDING =0. The compounding misread was reading
+// `SIGNAL ROUTER: promoted=0` as "nothing needs attention" when it only means "nothing AUTO-promoted" —
+// a queue of hand-needing signals reported identically to an empty queue. A counter that appears only
+// when non-zero reproduces that exact ambiguity, so the explicit `=0` is the point: it distinguishes
+// measured-and-empty from not-measured. Same not-measured-rendered-as-measured family seen repeatedly
+// on 2026-07-25/26.
+//
+// NOT GATED BEHIND COORD_DETECTORS_V2, ON PURPOSE. detectReplyStarvation already exists and is wired
+// into runDetectors, but runAndLogDetectors returns [] unless that flag is truthy and it defaults to
+// 'false' (verified undefined in the live env) — so REPLY_STARVATION is dead by default and could never
+// have surfaced this incident. A visibility counter behind a default-off flag is not visibility.
+//
+// THE DETECTOR IS REUSED, NOT REIMPLEMENTED. Its "answered" semantics are subtle — acknowledged_at OR
+// payload.routed_to_feedback_id OR hasCorrelatedReply, because a reply routinely arrives as a fresh
+// correlated row rather than an ack stamp (class C6) — and a second copy would drift from it.
+//
+// ONE IMPLEMENTATION, CALLED BY BOTH SWEEP TWINS. lib/sweep/passes/coordination-detectors.cjs and the
+// SWEEP_PASS_REGISTRY=off re-implementation in lib/sweep/legacy-fallback.cjs both call this, so the
+// counter cannot become a one-sided improvement that leaves the fallback on pre-fix behavior — the
+// failure mode tests/ci/sweep-legacy-twin-parity.test.js exists to prevent.
+//
+// ALREADY DONE ELSEWHERE, DELIBERATELY NOT REDONE HERE: the current coordinator moved worker-signal
+// drain to its first tick duty. That fixes THIS coordinator; this counter is what fixes the next one,
+// because a reordering lives in one session and a counter lives in the code.
+//
+// @module lib/coordinator/worker-signal-starvation
+
+'use strict';
+
+const DEFAULT_THRESHOLD_SEC = 1800; // 30m, matching detectors.cjs DEFAULT_REPLY_STARVATION_MS
+const LOOKBACK_MS = 24 * 3600 * 1000;
+const MAX_SIGNALS = 500;
+const MAX_SAMPLES_LOGGED = 5;
+
+/** Resolve the starvation threshold (ms) from env, mirroring coordination-events.resolveThresholds. */
+function resolveThresholdMs(env) {
+  env = env || process.env;
+  return (Number(env.COORD_REPLY_STARVATION_SEC) || DEFAULT_THRESHOLD_SEC) * 1000;
+}
+
+/**
+ * Count unanswered worker signals older than the threshold and print the count to the tick line.
+ * READ-ONLY: never writes. Fail-OPEN, but says so out loud — a silent catch would recreate the
+ * not-measured-looks-like-measured bug this exists to remove.
+ *
+ * @param {object} supabase
+ * @param {{ env?:object, log?:Function, now?:number, detectors?:object }} [opts] injectable seams
+ * @returns {Promise<{ measured:boolean, starved:number, thresholdMs:number, oldestMin:number }>}
+ */
+async function reportWorkerSignalStarvation(supabase, opts = {}) {
+  const log = opts.log || ((m) => console.log(m));
+  const thresholdMs = resolveThresholdMs(opts.env);
+  const mins = Math.round(thresholdMs / 60000);
+  try {
+    const detectors = opts.detectors || require('./detectors.cjs');
+    const now = opts.now ?? Date.now();
+    const sinceIso = new Date(now - LOOKBACK_MS).toISOString();
+    const { data: signals } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, sender_type, message_type, acknowledged_at, read_at, payload, created_at')
+      .gte('created_at', sinceIso)
+      .order('created_at', { ascending: false })
+      .limit(MAX_SIGNALS);
+    const res = detectors.detectReplyStarvation({ signals: signals || [], now, thresholdMs });
+    const samples = (res && res.evidence && res.evidence.samples) || [];
+    const starved = (res && res.evidence && res.evidence.starved_count) || 0;
+    const oldestMin = samples.length
+      ? Math.round(Math.max(...samples.map((s) => s.age_ms || 0)) / 60000)
+      : 0;
+    log('WORKER SIGNALS: unanswered_over_' + mins + 'm=' + starved
+      + (starved > 0 ? ' oldest=' + oldestMin + 'm' : '')
+      + ' (worker lane; 0 means measured-and-empty, not unmeasured)');
+    for (const s of samples.slice(0, MAX_SAMPLES_LOGGED)) {
+      log('  WORKER_SIGNAL_UNANSWERED: id=' + s.id + ' sender=' + s.sender
+        + ' age_min=' + Math.round((s.age_ms || 0) / 60000));
+    }
+    return { measured: true, starved, thresholdMs, oldestMin };
+  } catch (err) {
+    log('WORKER SIGNALS: NOT MEASURED (' + ((err && err.message) || 'unknown') + ')');
+    return { measured: false, starved: 0, thresholdMs, oldestMin: 0 };
+  }
+}
+
+module.exports = {
+  reportWorkerSignalStarvation,
+  resolveThresholdMs,
+  DEFAULT_THRESHOLD_SEC,
+};

--- a/lib/sweep/legacy-fallback.cjs
+++ b/lib/sweep/legacy-fallback.cjs
@@ -25,6 +25,7 @@ const DECONFLICTION_ENABLED = process.env.CROSS_SESSION_DECONFLICTION === 'true'
 const INTENT_WINDOW_MIN = Number(process.env.CROSS_SESSION_INTENT_WINDOW_MIN) || 24 * 60;
 const signalRouterModule = require('../coordinator/signal-router.cjs');
 const coordEventsModule = require('../coordinator/coordination-events.cjs');
+const workerSignalStarvationModule = require('../coordinator/worker-signal-starvation.cjs');
 
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 8 (GUARD) — runDeadLetterLegacy fetches the
 // FULL unread-coordination set to plan dead-lettering; a silent 1000-row cap leaves dead-targeted
@@ -111,6 +112,9 @@ async function runCoordinationDetectorsLegacy(ctx) {
   } catch (routerErr) {
     console.log('SIGNAL ROUTER: ' + (routerErr && routerErr.message ? routerErr.message : 'unknown'));
   }
+  // QF-20260726-921: mirrors the coordination-detectors pass so SWEEP_PASS_REGISTRY=off does NOT
+  // silently lose the worker-signal starvation counter. Shared helper, not a second implementation.
+  await workerSignalStarvationModule.reportWorkerSignalStarvation(supabase);
   try {
     if (coordEventsModule.coordDetectorsEnabled()) {
       const coordInputs = await coordEventsModule.gatherDetectorInputs(supabase, {});

--- a/lib/sweep/passes/coordination-detectors.cjs
+++ b/lib/sweep/passes/coordination-detectors.cjs
@@ -10,6 +10,7 @@
 
 const signalRouterModule = require('../../coordinator/signal-router.cjs');
 const coordEventsModule = require('../../coordinator/coordination-events.cjs');
+const workerSignalStarvationModule = require('../../coordinator/worker-signal-starvation.cjs');
 
 async function run(ctx) {
   const { supabase } = ctx;
@@ -28,6 +29,11 @@ async function run(ctx) {
   } catch (routerErr) {
     console.log('SIGNAL ROUTER: ' + (routerErr && routerErr.message ? routerErr.message : 'unknown'));
   }
+
+  // QF-20260726-921: worker-signal starvation COUNT in the tick line (read-only, always printed even
+  // at =0, deliberately NOT behind COORD_DETECTORS_V2). Full rationale lives in the helper, which the
+  // SWEEP_PASS_REGISTRY=off twin in legacy-fallback.cjs calls too so this cannot become a one-sided fix.
+  await workerSignalStarvationModule.reportWorkerSignalStarvation(supabase);
 
   // Coordination anomaly detectors — DEFAULT-OFF behind COORD_DETECTORS_V2.
   // READ-ONLY over claim state; fail-open; fully inert when the flag is off.

--- a/tests/unit/coordinator/worker-signal-starvation.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation.test.js
@@ -1,0 +1,123 @@
+// QF-20260726-921 — worker-signal starvation counter in the sweep tick line.
+//
+// The incident: 16 of 17 coordinator replies went to Adam, ZERO to workers, while a worker sat blocked
+// 80 minutes. The coordinator never queried the worker lane, and `SIGNAL ROUTER: promoted=0` read as
+// "nothing needs attention" when it only meant "nothing AUTO-promoted" — an empty queue and a queue of
+// hand-needing signals printed identically.
+//
+// These tests pin the properties that make starvation VISIBLE. The load-bearing one is the =0 case:
+// a counter that only appears when non-zero reproduces the exact ambiguity that hid the incident.
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const { reportWorkerSignalStarvation, resolveThresholdMs, DEFAULT_THRESHOLD_SEC } =
+  require('../../../lib/coordinator/worker-signal-starvation.cjs');
+
+const NOW = Date.parse('2026-07-26T05:00:00.000Z');
+const minsAgo = (m) => new Date(NOW - m * 60000).toISOString();
+
+/** supabase stub whose builder resolves the supplied rows. */
+function fakeSupabase(rows, { throwOn = false } = {}) {
+  const api = {
+    select() { return api; },
+    gte() { return api; },
+    order() { return api; },
+    limit() {
+      if (throwOn) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ data: rows });
+    },
+  };
+  return { from: vi.fn(() => api) };
+}
+
+function capture() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(m) };
+}
+
+describe('reportWorkerSignalStarvation', () => {
+  it('LOAD-BEARING: prints an explicit =0 when nothing is starved, so measured-and-empty is distinguishable from unmeasured', async () => {
+    const { lines, log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([]), { now: NOW, log, env: {} });
+    const line = lines.find((l) => l.startsWith('WORKER SIGNALS:'));
+    expect(line).toBeDefined();               // it MUST print even with nothing to report
+    expect(line).toContain('unanswered_over_30m=0');
+    expect(line).not.toContain('NOT MEASURED');
+    expect(r).toMatchObject({ measured: true, starved: 0 });
+  });
+
+  it('counts an unanswered worker signal past the threshold and reports the oldest age', async () => {
+    const { lines, log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([
+      { id: 's-old', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(80), payload: {} },
+      { id: 's-mid', sender_session: 'w2', sender_type: 'worker', created_at: minsAgo(45), payload: {} },
+    ]), { now: NOW, log, env: {} });
+    expect(r.starved).toBe(2);
+    expect(r.oldestMin).toBe(80);
+    const line = lines.find((l) => l.startsWith('WORKER SIGNALS:'));
+    expect(line).toContain('unanswered_over_30m=2');
+    expect(line).toContain('oldest=80m');
+    // sample lines make it actionable, not just a number
+    expect(lines.filter((l) => l.includes('WORKER_SIGNAL_UNANSWERED')).length).toBe(2);
+  });
+
+  it('does NOT count signals that are answered, read, routed, or under threshold, or non-worker senders', async () => {
+    const { log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([
+      { id: 'a', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), acknowledged_at: minsAgo(5), payload: {} },
+      { id: 'b', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), read_at: minsAgo(5), payload: {} },
+      { id: 'c', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), payload: { routed_to_feedback_id: 'f-1' } },
+      { id: 'd', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(10), payload: {} },   // too young
+      { id: 'e', sender_session: 'adam', sender_type: 'adam', created_at: minsAgo(90), payload: {} },  // not a worker
+    ]), { now: NOW, log, env: {} });
+    expect(r.starved).toBe(0);
+  });
+
+  it('REGRESSION: fails OPEN but says NOT MEASURED out loud — a silent catch would recreate the bug', async () => {
+    const { lines, log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([], { throwOn: true }), { now: NOW, log, env: {} });
+    expect(r.measured).toBe(false);
+    const line = lines.find((l) => l.startsWith('WORKER SIGNALS:'));
+    expect(line).toContain('NOT MEASURED');
+    // and it must NOT masquerade as a clean zero
+    expect(line).not.toContain('unanswered_over_30m=0');
+  });
+
+  it('CONTRACT: runs regardless of COORD_DETECTORS_V2 — a visibility counter behind a default-off flag is not visibility', async () => {
+    const { lines, log } = capture();
+    // COORD_DETECTORS_V2 explicitly off (its real default) — the counter must still report.
+    await reportWorkerSignalStarvation(fakeSupabase([
+      { id: 'z', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(99), payload: {} },
+    ]), { now: NOW, log, env: { COORD_DETECTORS_V2: 'false' } });
+    expect(lines.find((l) => l.startsWith('WORKER SIGNALS:'))).toContain('unanswered_over_30m=1');
+  });
+
+  it('threshold is env-tunable and defaults to the detector default (30m)', () => {
+    expect(DEFAULT_THRESHOLD_SEC).toBe(1800);
+    expect(resolveThresholdMs({})).toBe(1800 * 1000);
+    expect(resolveThresholdMs({ COORD_REPLY_STARVATION_SEC: '600' })).toBe(600 * 1000);
+  });
+
+  it('is READ-ONLY: only session_coordination is read, and no write verb is ever invoked', async () => {
+    const { log } = capture();
+    const sb = fakeSupabase([]);
+    await reportWorkerSignalStarvation(sb, { now: NOW, log, env: {} });
+    expect(sb.from).toHaveBeenCalledWith('session_coordination');
+    expect(sb.from).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('both sweep twins report the counter (QF-20260726-921 parity)', () => {
+  it('the pass AND the SWEEP_PASS_REGISTRY=off legacy fallback both call the shared helper', () => {
+    // Pinning the require + call in BOTH twins: the parity test in tests/ci only counts five other
+    // functions, so nothing else would catch a one-sided addition here.
+    const fs = require('node:fs');
+    const pass = fs.readFileSync('lib/sweep/passes/coordination-detectors.cjs', 'utf8');
+    const legacy = fs.readFileSync('lib/sweep/legacy-fallback.cjs', 'utf8');
+    for (const [name, src] of [['pass', pass], ['legacy-fallback', legacy]]) {
+      expect(src, name + ' must require the shared helper').toContain('worker-signal-starvation.cjs');
+      expect(src, name + ' must call it').toContain('reportWorkerSignalStarvation(supabase)');
+    }
+  });
+});


### PR DESCRIPTION
## QF-20260726-921 — worker signals starved silently

Measured by Bravo, coordinator-endorsed: **17 `coordinator_reply` rows since 00:00Z — sixteen to Adam, zero to any worker**, while a worker sat blocked 80 minutes on a `prd-ambiguous` signal that gated its SD.

A **lane asymmetry**, not neglect and not a dead coordinator: the Adam advisory lane was drained every tick per standing instruction, and `payload->>signal_type` was never queried, so worker signals lived behind a filter nobody was running.

**Invisible from both ends at once** — the part worth keeping. A starved worker's only legal moves are PREPARE and RE-ASK (wind-down correctly forbids dropping the claim), so it cannot distinguish a saturated lane from being ignored; both present as silence. Meanwhile the coordinator cannot see what it isn't querying. Neither side can observe the failure.

### Fix
A read-only count of unanswered worker signals older than a threshold (30m, `COORD_REPLY_STARVATION_SEC`-tunable) in the sweep tick line, plus up to 5 sample ids so it's actionable rather than just a number.

**Printed unconditionally, including `=0`.** The compounding misread was reading `SIGNAL ROUTER: promoted=0` as "nothing needs attention" when it only means "nothing AUTO-promoted" — a queue of hand-needing signals printed identically to an empty queue. A counter that appears only when non-zero rebuilds that exact ambiguity, so the explicit `=0` is the point. Failure prints `NOT MEASURED` rather than catching silently.

**Deliberately NOT behind `COORD_DETECTORS_V2`.** `detectReplyStarvation` already exists and is wired into `runDetectors` — but `runAndLogDetectors` returns `[]` unless that flag is truthy and it defaults to `'false'` (verified `undefined` in the live env). So `REPLY_STARVATION` is dead by default and could never have surfaced this. A visibility counter behind a default-off flag is not visibility.

**The detector is reused, not reimplemented.** Its "answered" semantics are subtle — `acknowledged_at` OR `payload.routed_to_feedback_id` OR `hasCorrelatedReply`, because a reply routinely arrives as a fresh correlated row rather than an ack stamp (class C6). A second copy would drift.

**One helper, called by BOTH sweep twins.** `tests/ci/sweep-legacy-twin-parity.test.js` only counts five other functions, so it would *not* have caught a one-sided addition here — which is precisely the failure mode that file exists to prevent. `lib/sweep/legacy-fallback.cjs` calls the same helper so `SWEEP_PASS_REGISTRY=off` doesn't silently lose the counter.

### Live evidence — it fires immediately on a real condition
Read-only run against the live DB:
```
WORKER SIGNALS: unanswered_over_30m=20 oldest=37m (worker lane; 0 means measured-and-empty, not unmeasured)
  WORKER_SIGNAL_UNANSWERED: id=f3504edb… sender=9301234a… age_min=31
  WORKER_SIGNAL_UNANSWERED: id=41c9a862… sender=61d2bb66… age_min=32
  …
RETURN: {"measured":true,"starved":20,"thresholdMs":1800000,"oldestMin":37}
```
**20 starved signals, oldest 37m, right now** — including one from this session. None of that appeared anywhere in the tick line before.

### Tests bite
8 new tests. Mutation-verified, with the mutation confirmed present via `grep -c` before reading each result:
- making the `=0` line conditional → the load-bearing test fails (`expected undefined to be defined`)
- removing the legacy-twin call → the parity test fails, naming the diverging twin

Also pinned: answered/read/routed/under-threshold/non-worker are all excluded; failure reports `NOT MEASURED` and must **not** masquerade as a clean zero; runs with `COORD_DETECTORS_V2=false`; read-only (`session_coordination` only, exactly one `from()`).

Suites: **44 files / 523 tests pass** (coordinator + sweep), including the twin-parity CI test.

### Not redone here
The current coordinator already moved worker-signal drain to its first tick duty — the QF says explicitly not to redo it. That fixes *this* coordinator; the counter fixes the next one, because a reordering lives in one session and a counter lives in the code.
