### PR TITLE
fix(QF-20260725-027): derive the resurface default from the shared constant, killing the second source

### DIFF
--- a/.github/workflows/solomon-ledger-resurface-cron.yml
+++ b/.github/workflows/solomon-ledger-resurface-cron.yml
@@ -43,8 +43,17 @@ jobs:
 
       - name: Resurface aged Solomon ledger rows
         # QF-20260725-743 — INTERIM 72h override, EXPIRES ~2026-07-27T09:59Z.
-        # Explicit at the call site (NOT a change to DEFAULT_THRESHOLD_HOURS, which stays 24)
-        # so the mitigation is visible and trivially reversible — delete the flag to revert.
+        # QF-20260725-027 CORRECTED THIS COMMENT: it used to claim "NOT a change to
+        # DEFAULT_THRESHOLD_HOURS, which stays 24". Leaving the default at 24 was the actual
+        # defect — the bare invocation (an unenumerable call site: cron prompt bodies, human
+        # batches, ad-hoc runs) silently ran at 24h and inserted 100%-sub-threshold digests into
+        # the Adam inbox. Measured live 2026-07-26: 84 candidates at 24h, ZERO at 72h.
+        # The default is now DERIVED from lib/coordination/resurface-threshold.cjs, so there is
+        # exactly ONE threshold and no second source only the bare path can see.
+        # This flag is KEPT DELIBERATELY, now redundant-but-consistent rather than load-bearing:
+        # YAML cannot import the JS constant, and an explicit value keeps the mitigation visible
+        # and trivially reversible here. If the expiry below is actioned, change
+        # OPERATING_THRESHOLD_HOURS and this literal together — the test pins them equal.
         # Grounding: Solomon measured disposition latency p50 37.5h / p75 77.2h, with only 26%
         # of 507 disposed rows clearing within 24h; 72h tracks p75. At 24h, ~28 rows/day
         # resurfaced into a 50-row oldest-first window and displaced live directed messages

--- a/scripts/solomon-ledger-pending-resurface.cjs
+++ b/scripts/solomon-ledger-pending-resurface.cjs
@@ -8,14 +8,34 @@
  * ledger rows pending longer than the threshold and resurfaces each into Adam's inbox at most
  * once per row per day (payload.dedup_key checked before insert). Stamps nothing on the ledger
  * row itself -- it stays visible every day until a real decision is recorded.
- * Usage: node scripts/solomon-ledger-pending-resurface.cjs [--threshold-hours 24]
+ * Usage: node scripts/solomon-ledger-pending-resurface.cjs [--threshold-hours 72]
  */
 require('dotenv').config();
 const crypto = require('node:crypto');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
+// QF-20260725-027: the default IS the operating threshold, sourced from the shared constant.
+const { OPERATING_THRESHOLD_HOURS } = require('../lib/coordination/resurface-threshold.cjs');
 
-const DEFAULT_THRESHOLD_HOURS = 24;
+// QF-20260725-027. This was the literal 24 while the operating threshold was 72, and QF-20260725-342
+// "fixed" that by passing --threshold-hours 72 at the three call sites it could FIND — leaving the
+// default those sites fall back to still disagreeing with them.
+//
+// WHY THAT COULD NOT WORK: the bare invocation is an UNENUMERABLE FOURTH CALL SITE. Cron prompt
+// bodies, human batches, ad-hoc debugging and any future caller get the wrong answer, and you cannot
+// fix that by enumerating callers because the failing one is every invocation nobody wrote down. A
+// hand-maintained inventory of call sites cannot detect a call site nobody added to it.
+//
+// OBSERVED, twice in ~40 minutes: a bare invocation inserted digests of 64 then 65 members. At 72h
+// the same query returns ZERO, so those were 100% sub-threshold noise landing in the Adam inbox
+// looking exactly like a genuine backlog spike. The dedupe is CONTENT-HASHED, so one new ledger
+// member changes the key and a whole new digest is inserted — the wrong default therefore re-fires on
+// every growth tick rather than emitting once. The unchanged-or-already-notified guard stops a repeat
+// of the IDENTICAL set and nothing else.
+//
+// Sourcing the default FROM the shared constant (rather than typing 72 here) makes the two unable to
+// drift apart again — a re-divergence would now require deliberately reintroducing a literal.
+const DEFAULT_THRESHOLD_HOURS = OPERATING_THRESHOLD_HOURS;
 const DEFAULT_PAGE_SIZE = 50;
 // Safety cap on pages per invocation (10 * 50 = 500 rows/run) -- bounds worst-case query
 // volume for a sweep script without reintroducing the head-of-queue starvation this fixes.

--- a/tests/unit/coordination/resurface-threshold.test.js
+++ b/tests/unit/coordination/resurface-threshold.test.js
@@ -32,11 +32,46 @@ describe('QF-20260725-342 — resurface threshold reaches EVERY invocation site'
     expect(thresholdArgs()).toEqual(['--threshold-hours', String(OPERATING_THRESHOLD_HOURS)]);
   });
 
-  it('the operating threshold is NOT the script default (otherwise the flag proves nothing)', () => {
-    // If these ever coincide, every assertion below passes vacuously — a missing flag would be
-    // indistinguishable from a present one. Guard the guard.
+  // QF-20260725-027 RE-AIMED THIS ASSERTION — it previously required the two to DIFFER
+  // (`expect(OPERATING_THRESHOLD_HOURS).not.toBe(DEFAULT_THRESHOLD_HOURS)`), which pinned the very
+  // defect 027 fixes: while they differed, every bare invocation silently ran at 24h.
+  //
+  // Its stated intent was "guard the guard" — keep the flag assertions below discriminating, since a
+  // missing flag would otherwise be indistinguishable from a present one. That intent is now served
+  // differently and better: with the default correct BY CONSTRUCTION, a missing flag no longer
+  // produces a wrong answer, so the flag assertions become redundant rather than load-bearing. The
+  // property worth defending is no longer "the flag is present everywhere" but "there is ONE
+  // threshold and the bare path already has it".
+  //
+  // Kept and inverted rather than deleted: this is the assertion that fails if anyone reintroduces a
+  // separate literal default.
+  it('the script default IS the operating threshold — one value, no second source', () => {
     const { DEFAULT_THRESHOLD_HOURS } = require(join(REPO, 'scripts/solomon-ledger-pending-resurface.cjs'));
-    expect(OPERATING_THRESHOLD_HOURS).not.toBe(DEFAULT_THRESHOLD_HOURS);
+    expect(DEFAULT_THRESHOLD_HOURS).toBe(OPERATING_THRESHOLD_HOURS);
+  });
+
+  it('the BARE invocation resolves to the operating threshold (the unenumerable 4th call site)', () => {
+    // THE ACTUAL ACCEPTANCE. QF-342's tests were all source-scans of call sites, because with a wrong
+    // default the defect was only visible at an invocation. Now that the default is correct, the bare
+    // path IS testable in-process — and it is the one "call site" no inventory can enumerate.
+    const { parseThresholdHours } = require(join(REPO, 'scripts/solomon-ledger-pending-resurface.cjs'));
+    expect(parseThresholdHours([])).toBe(OPERATING_THRESHOLD_HOURS);
+    // Malformed / missing values must fall back to the operating threshold too, never to a stale 24.
+    expect(parseThresholdHours(['--threshold-hours'])).toBe(OPERATING_THRESHOLD_HOURS);
+    expect(parseThresholdHours(['--threshold-hours', 'abc'])).toBe(OPERATING_THRESHOLD_HOURS);
+    expect(parseThresholdHours(['--some-other-flag', '5'])).toBe(OPERATING_THRESHOLD_HOURS);
+    // An EXPLICIT value must still win — the fix must not hardcode past a deliberate override.
+    expect(parseThresholdHours(['--threshold-hours', '12'])).toBe(12);
+    expect(parseThresholdHours(['--threshold-hours', '0'])).toBe(0);
+  });
+
+  it('no separate numeric default literal survives in the script', () => {
+    // Pins the SEMANTIC (single source), not the number: the default must be DERIVED from the shared
+    // constant, so a future edit cannot quietly reintroduce a second value that only the bare path
+    // sees. Asserting on 72 instead would pass just as happily against a re-typed literal.
+    const src = read('scripts/solomon-ledger-pending-resurface.cjs');
+    expect(src).toContain('../lib/coordination/resurface-threshold.cjs');
+    expect(src).toMatch(/const DEFAULT_THRESHOLD_HOURS = OPERATING_THRESHOLD_HOURS;/);
   });
 
   it('coordinator-quiet-tick sources the threshold from the shared constant, not a literal', () => {


### PR DESCRIPTION
## The defect

`DEFAULT_THRESHOLD_HOURS` was the literal `24` while the operating threshold was `72`. QF-20260725-342 corrected the three call sites it could **find** and left the default those sites fall back to still disagreeing with them.

**Why enumerating call sites could not work:** the bare invocation is an *unenumerable fourth call site*. Cron prompt bodies, human batches, ad-hoc debugging and any future caller get the wrong answer — and you cannot fix that by finding callers, because the failing one is every invocation nobody wrote down.

## Measured live, not taken on trust

Read-only via `planStalePending` on 2026-07-26:

| threshold | candidates |
|---|---|
| 24h | **84** |
| 72h | **0** |

So every digest a bare invocation produced was **100% sub-threshold noise**, landing in the Adam inbox looking like a genuine backlog spike. The dedupe is content-hashed, so one new ledger member changes the key and a whole new digest is inserted — the wrong default re-fired on **every growth tick** rather than emitting once (64 then 65 members in ~40 minutes). The unchanged-or-already-notified guard stops a repeat of the *identical* set and nothing else.

## The fix is not "type 72 here"

The default is now **derived** from `lib/coordination/resurface-threshold.cjs`, the module QF-342 already established as the single source. Re-divergence would require deliberately reintroducing a literal rather than merely forgetting to update a second copy.

## The three explicit flags are KEPT — the row required this decision

They are now **redundant-but-consistent** rather than load-bearing. Two already source the shared constant; the GHA YAML cannot import a JS constant, so an explicit literal keeps the value visible and reversible at the site its own comment calls a mitigation. Removing them would trade self-documenting wiring for churn and make the cron depend on an implicit default.

## Corrected a comment that asserted the defect as intent

The workflow said *"NOT a change to `DEFAULT_THRESHOLD_HOURS`, which stays 24"*. Leaving it at 24 **was** the bug, and a comment rationalising the wrong state is exactly what made the 342 error read as deliberate — the same shape as the git-diff catch in QF-20260725-868 earlier tonight.

## Surfaced, not silently resolved

That workflow documents the 72h as an **interim override expiring ~2026-07-27T09:59Z**, with digest batching (`SD-LEO-INFRA-RESURFACE-DIGEST-BATCHING-001`, now landed) as the real fix. Whether the threshold should stay 72 past that expiry is **not this QF's call and is not decided here**. Deriving rather than hardcoding is deliberately correct under either answer: one edit to `OPERATING_THRESHOLD_HOURS` then moves the cron, both coordinator sites, and the bare path together. Raised to the coordinator separately.

## Tests

One QF-342 assertion was **re-aimed, not deleted**. It required the two values to *differ*, which pinned this very defect. Its stated intent — "guard the guard", keeping the flag assertions discriminating — is now served better, because with the default correct *by construction* a missing flag no longer produces a wrong answer. Inverted to assert they **agree**, so it fails if anyone reintroduces a separate literal.

Three new assertions, the first two of which QF-342 could not have written:

- the **bare path** resolves to the operating threshold — the one "call site" no inventory can enumerate, testable in-process only now that the default is correct. Covers missing value, non-numeric, and unrelated-flag argv.
- an **explicit** `--threshold-hours` still wins (`12` and `0`), proving **both directions**: a fix that hardcoded past a deliberate override would be just as broken.
- the default is **derived**, pinned on the semantic rather than on the number 72 — which would pass just as happily against a re-typed literal.

All three verified **RED** by mutating the default back to 24 and confirming the mutation landed before trusting the run.

`tests/unit/coordination`: **171 passing** (13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
