### PR TITLE
feat(QF-20260726-163): persist unclamped expected_wake_at on the arm edge

### DIFF
--- a/scripts/hooks/lib/session-telemetry-writer.cjs
+++ b/scripts/hooks/lib/session-telemetry-writer.cjs
@@ -238,9 +238,45 @@ async function writeTelemetryAwait(sessionId, patch, options) {
   }
 }
 
+/**
+ * QF-20260726-163: read a session's metadata so a caller can MERGE into it. A raw PATCH
+ * of `metadata` REPLACES the whole JSONB, which would silently drop sibling keys
+ * (e.g. last_git_metric_at_ms). Callers writing metadata must read-modify-write.
+ * Returns NULL when the metadata could not be read, and an object (possibly empty) only
+ * when it genuinely was. The distinction is load-bearing: a caller that cannot see the
+ * existing keys MUST NOT write metadata at all, or it silently destroys siblings it never
+ * saw — on a live seat that means wiping model/effort/tier_rank and rendering it
+ * undispatchable. Never collapse the two cases into {}.
+ */
+async function readSessionMetadata(sessionId) {
+  const cfg = getSupabaseConfig();
+  if (!cfg || !sessionId) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TELEMETRY_FETCH_TIMEOUT_MS);
+  try {
+    const url = `${cfg.url.replace(/\/$/, '')}/rest/v1/${TELEMETRY_TABLE}`
+      + `?session_id=eq.${encodeURIComponent(sessionId)}&select=metadata`;
+    const res = await fetch(url, {
+      headers: { apikey: cfg.key, Authorization: `Bearer ${cfg.key}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const rows = await res.json();
+    if (!Array.isArray(rows) || !rows.length) return null;
+    const md = rows[0].metadata;
+    if (md == null) return {};                       // row exists, metadata genuinely empty
+    return typeof md === 'object' && !Array.isArray(md) ? md : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 module.exports = {
   writeTelemetry,
   writeTelemetryAwait,
+  readSessionMetadata,
   TELEMETRY_TABLE,
   TELEMETRY_FETCH_TIMEOUT_MS,
 };

--- a/scripts/hooks/post-tool-loop-state.cjs
+++ b/scripts/hooks/post-tool-loop-state.cjs
@@ -76,14 +76,46 @@ function isOff(v) {
         // computeSilenceMinutes is pre-clamped to lib/fleet/silence-cap.cjs
         // SILENCE_HARD_CAP_MIN (writer<=reader); undefined wake => safe DEFAULT, still capped.
         const { computeSilenceMinutes } = require('../park-worker.cjs');
-        const { writeTelemetryAwait } = require('./lib/session-telemetry-writer.cjs');
+        const { writeTelemetryAwait, readSessionMetadata } = require('./lib/session-telemetry-writer.cjs');
         const silenceMin = computeSilenceMinutes(wakeMinutes);
         const nowMs = Date.now();
-        await writeTelemetryAwait(sessionId, {
+
+        // QF-20260726-163: record the UNCLAMPED expected wake instant, separately from
+        // expected_silence_until. Those answer DIFFERENT questions and must not be
+        // conflated: expected_silence_until is a do-not-sweep-me PERMISSION and is
+        // deliberately clamped by computeSilenceMinutes, which makes it useless as a
+        // deadline. expected_wake_at is a should-have-ticked-by-now DEADLINE, so it
+        // carries the true delay. Without it there is no instrument for "this seat armed
+        // a wakeup that never fired" — the failure that parked ten seats for 4-17h while
+        // every one of them looked healthy (status=active, heartbeat 0m old).
+        // Stored in the existing metadata JSONB deliberately: no DDL, so this stays out
+        // of schema-change routing. READ-MODIFY-WRITE because a metadata PATCH replaces
+        // the whole object and would drop sibling keys such as last_git_metric_at_ms.
+        // NOTE: this is only the ARM half. A detector must AND it with proof the seat
+        // acted after the arm, or it flags every seat that armed and then resumed —
+        // loop_state=awaiting_tick is a one-way latch that nothing clears on resume.
+        const patch = {
           heartbeat_at: new Date(nowMs).toISOString(),
           expected_silence_until: new Date(nowMs + silenceMin * 60000).toISOString(),
           last_activity_kind: 'idle',
-        });
+        };
+        // Only touch metadata when we could actually READ it (null => read failed) AND we
+        // have a real delay to record. Writing a merge over an unread object would destroy
+        // siblings we never saw — model/effort/tier_rank live there, and losing them makes
+        // the seat undispatchable. The silence/heartbeat columns above are unaffected, so a
+        // failed read costs us the deadline, never the existing state.
+        const priorMeta = typeof readSessionMetadata === 'function'
+          ? await readSessionMetadata(sessionId)
+          : null;
+        if (priorMeta && Number.isFinite(delaySeconds) && delaySeconds > 0) {
+          patch.metadata = {
+            ...priorMeta,
+            wake_armed_at: new Date(nowMs).toISOString(),
+            wake_delay_seconds: delaySeconds,
+            expected_wake_at: new Date(nowMs + delaySeconds * 1000).toISOString(),
+          };
+        }
+        await writeTelemetryAwait(sessionId, patch);
       } catch (e2) {
         process.stderr.write(`[post-tool-loop-state] silence-arm (non-fatal): ${e2.message}\n`);
       }


### PR DESCRIPTION
Second half of QF-20260726-163, per the coordinator's Tier-3 ruling: build **exactly** the arm instrument, nothing more. The detector is split off and blocked on QF-20260725-630.

The first half (PR #6507, merge `20bb7e7d78d`) fixed why telemetry writes never landed. This adds the missing deadline.

## What it does

`post-tool-loop-state.cjs` records the true expected wake instant in the existing `metadata` JSONB — **no DDL**, so this stays out of schema-change routing:

- `wake_armed_at`
- `wake_delay_seconds`
- `expected_wake_at`

## Why not reuse expected_silence_until

They answer different questions. `expected_silence_until` is a *do-not-sweep-me permission* and is clamped by `computeSilenceMinutes` — which is exactly what makes it useless as a deadline. `expected_wake_at` is a *should-have-ticked-by-now deadline* and carries the true delay.

Verified live: `delaySeconds=1500` → deadline +25 min while the clamped permission read +30 min; `delaySeconds=900` → +15 min. Unclamped in both.

## Read-modify-write is load-bearing

A `metadata` PATCH replaces the whole object. The live row carries 20 keys including `model`, `effort` and `tier_rank` — a naive write would wipe the seat's capability stamps and render it undispatchable.

So `readSessionMetadata` returns `null` when it could not read, and an object only when it genuinely did. Collapsing those into `{}` is what made the first cut dangerous, and it also broke 2 loop-state tests. The arm hook now skips the metadata write entirely on a failed read — a read failure costs the deadline, never the existing state.

## Deliberately NOT included

The overdue-tick detector. `loop_state=awaiting_tick` is a one-way latch that nothing clears on resume, so a detector on the deadline alone flags every seat that armed and resumed — it flagged me, actively working, as 17 h overdue. It has to AND the deadline with proof the seat acted after the arm, and that clear signal only began existing when #6507 landed.

## Tests

59 passing across `post-tool-loop-state`, `claim-boundary-probe`, `park-worker`, `stop-loop-park-recoverable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)