### PR TITLE
fix(QF-20260726-253): Dead-letter planning equates not-a-claim-holder with dead: 90 percent of machine mail to the coordinator was destroyed, including the ACCOUNT_SWITCH notice that would have prevented a wrong root-cause diagnosis

### DIFF
--- a/lib/sweep/legacy-fallback.cjs
+++ b/lib/sweep/legacy-fallback.cjs
@@ -68,7 +68,14 @@ async function runIntentCollisionLegacy(ctx) {
 
 async function runDeadLetterLegacy(ctx) {
   const { supabase, classified, actions, nowMs } = ctx;
-  const allSessionIds = new Set(classified.map(s => s.session_id));
+  // QF-20260726-253: kept in lockstep with lib/sweep/passes/dead-letter-planning.cjs — both
+  // resolve the live-session set through sweepModule.loadLiveSessionIds rather than deriving it
+  // from `classified`, which is CLAIM-HOLDERS ONLY and made every idle/role session read as gone.
+  const allSessionIds = await sweepModule.loadLiveSessionIds(supabase);
+  if (!allSessionIds) {
+    console.log('GUARD_UNAVAILABLE: dead-letter pass skipped this tick — live-session set unreadable; messages retried next sweep');
+    return;
+  }
   const deadIds = new Set(classified.filter(s => s.status === 'DEAD').map(s => s.session_id));
 
   let unreadMsgs;

--- a/lib/sweep/passes/dead-letter-planning.cjs
+++ b/lib/sweep/passes/dead-letter-planning.cjs
@@ -30,7 +30,15 @@ async function run(ctx) {
   // invoked (retained there for both flag modes) — do NOT also call it here, or registry
   // mode double-fires the RPC (adversarial-review fix, PR #5755).
 
-  const allSessionIds = new Set(classified.map(s => s.session_id));
+  // QF-20260726-253: was `new Set(classified.map(...))` — but `classified` is the CLAIM-HOLDER
+  // set (main()'s query filters .not('sd_key','is',null)), so every session that holds no SD by
+  // design — the coordinator, Adam, Solomon and every idle worker — read as "gone" and had its
+  // mail destroyed. Resolve the real live-session set instead; see loadLiveSessionIds.
+  const allSessionIds = await sweepModule.loadLiveSessionIds(supabase);
+  if (!allSessionIds) {
+    console.log('GUARD_UNAVAILABLE: dead-letter pass skipped this tick — live-session set unreadable; messages retried next sweep');
+    return;
+  }
   const deadIds = new Set(classified.filter(s => s.status === 'DEAD').map(s => s.session_id));
   const nowMs = now.getTime();
 

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -3451,6 +3451,54 @@ function planDeadLetters(unreadMsgs, { allSessionIds, deadIds }, nowMs) {
     }));
 }
 
+/**
+ * QF-20260726-253 — the "does this message's target still exist?" set.
+ *
+ * planDeadLetters treats a target ABSENT from allSessionIds as gone, which is correct and
+ * deliberate (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001 FR-4). The defect was the SET it
+ * was handed: main()'s session query filters `.not('sd_key','is',null)` because its OTHER
+ * consumers are claim logic, so the set is CLAIM-HOLDERS, not sessions-that-exist. Dead-letter
+ * planning consumed it anyway, silently equating "holds no SD" with "dead or gone".
+ *
+ * The coordinator, Adam, Solomon and every IDLE worker hold no SD by design and are therefore
+ * permanently outside that set — 146 of 162 machine messages addressed to the coordinator were
+ * destroyed, including an ACCOUNT_SWITCH notice whose loss produced a wrong fleet-wide
+ * root-cause diagnosis. Fixing the predicate's COVERAGE (allow-listing the role sessions by
+ * name) would leave every idle worker still being dead-lettered, and idle is exactly when a
+ * worker most needs to receive a dispatch. So the set is widened instead.
+ *
+ * LIVENESS, NOT MERE EXISTENCE — measured before choosing the predicate. v_active_sessions holds
+ * 5926 rows, of which computed_status is 'stale' for 5911; only 15 are 'active'/'idle' (matching
+ * the count with a heartbeat under the sweep's own 15-min definitely-dead bound) and only 9 hold
+ * an sd_key. So keying on "present in the view" would have made dead-lettering fire essentially
+ * never and quietly gutted FR-4, trading one silent failure for another. The live set is 15 vs
+ * the old 9: it adds exactly the alive-but-unclaimed sessions (coordinator, Adam, Solomon, idle
+ * workers) and still dead-letters mail aimed at the 5911 stale ones.
+ *
+ * The filter is EXCLUSION-based (drop the known-dead status) rather than an allow-list of
+ * 'active','idle'. Both give the same 15 today, but they fail in opposite directions: an
+ * unrecognised or NULL future status would drop out of an allow-list and have its mail
+ * destroyed, whereas here it is retained. Toward delivery, always.
+ *
+ * Returns null when liveness could not be established. Callers MUST skip the pass on null and
+ * never fall back to the claim-filtered set: a set we failed to read is not evidence that its
+ * members are gone, and the cost of guessing here is destroying live mail.
+ */
+const DEAD_SESSION_STATUS = 'stale';
+async function loadLiveSessionIds(supabase) {
+  try {
+    const rows = await fapPaginate(() => supabase
+      .from('v_active_sessions')
+      .select('session_id, computed_status')
+      .or(`computed_status.is.null,computed_status.neq.${DEAD_SESSION_STATUS}`)
+      .order('session_id', { ascending: true })); // unique tiebreaker (FR-6)
+    if (!Array.isArray(rows)) return null;
+    return new Set(rows.map((r) => r && r.session_id).filter(Boolean));
+  } catch {
+    return null;
+  }
+}
+
 // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful sweep tick,
 // regardless of which internal early-return branch main() took (e.g. the "no sessions with
 // claims" all-clear path) — this reflects loop liveness (the tick ran to completion), not
@@ -3520,6 +3568,10 @@ module.exports.__setExecContextGuardForTest = (mock) => { _execContextGuardCache
 // implementation (no duplicate logic — see each wrapper's header comment).
 module.exports.clearStaleQfClaims = clearStaleQfClaims;
 module.exports.splitCollidingSessions = splitCollidingSessions;
+// QF-20260726-253: exported so BOTH dead-letter twins (lib/sweep/passes/dead-letter-planning.cjs
+// and the SWEEP_PASS_REGISTRY=off lib/sweep/legacy-fallback.cjs) resolve the live-session set
+// through one implementation — parity here is structural, not a thing a reviewer must remember.
+module.exports.loadLiveSessionIds = loadLiveSessionIds;
 
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): export the guarded
 // WORK_ASSIGNMENT dispatch so the single-writer gate is unit-testable (assert NO sender_type:'sweep'

--- a/tests/ci/sweep-legacy-twin-parity.test.js
+++ b/tests/ci/sweep-legacy-twin-parity.test.js
@@ -40,6 +40,11 @@ function makeSupabaseSpy({ unreadMsgs = [] } = {}) {
       return {
         select() { return this; },
         is() { return this; },
+        // QF-20260726-253: the dead-letter twins now resolve their live-session set via
+        // sweepModule.loadLiveSessionIds, which adds an .or() liveness filter. Without this the
+        // builder throws, both twins take their fail-safe skip, and the fixture stops exercising
+        // the dead-letter path at all (parity still held — it was the sanity assertion that caught it).
+        or() { return this; },
         // FR-6 batch 8: the dead-letter read now paginates via fetchAllPaginated, which appends
         // .order() and applies .range() itself — extend the builder mock to support both. .range()
         // resolves the SAME { data, error } the prior `await builder` (then) produced.

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -487,3 +487,80 @@ describe('full-lane safety net: read-adam-directives covers EVERY directive send
     expect(DIRECTIVE_SENDERS).toContain('orchestrator');
   });
 });
+
+// ─────────── QF-20260726-253 — existence, not SD-claim membership ───────────
+//
+// planDeadLetters treating an ABSENT target as gone is correct and stays (FR-4 above pins it).
+// The defect was the SET: it came from the claim-holder query (.not('sd_key','is',null)), so the
+// coordinator, Adam, Solomon and every IDLE worker — none of which hold an SD by design — read as
+// gone. 146 of 162 machine messages to the coordinator were destroyed, including an ACCOUNT_SWITCH
+// notice whose loss produced a wrong fleet-wide root-cause diagnosis.
+describe('QF-20260726-253: the live-session set is existence-based, not claim-based', () => {
+  const IDLE_NO_SD = 'aaaaaaaa-1111-4222-8333-444444444444';
+  const CLAIM_HOLDER = 'bbbbbbbb-1111-4222-8333-444444444444';
+
+  // Minimal builder for the .select().or().order().range() chain fetchAllPaginated drives.
+  // `orArg` is captured so the liveness filter itself can be asserted, not just its output.
+  const captured = {};
+  const sbReturning = (rows, { fail = false } = {}) => ({
+    from() {
+      return {
+        select() { return this; },
+        or(expr) { captured.or = expr; return this; },
+        order() { return this; },
+        range() {
+          return fail
+            ? Promise.resolve({ data: null, error: { message: 'view unreadable' } })
+            : Promise.resolve({ data: rows, error: null });
+        },
+      };
+    },
+  });
+
+  it('includes a live session that holds NO sd_key — the whole point of the fix', async () => {
+    const ids = await sweep.loadLiveSessionIds(sbReturning([
+      { session_id: IDLE_NO_SD, computed_status: 'idle' },   // coordinator / Adam / idle worker
+      { session_id: CLAIM_HOLDER, computed_status: 'active' },
+    ]));
+    expect(ids).toBeInstanceOf(Set);
+    expect(ids.has(IDLE_NO_SD)).toBe(true);
+    expect(ids.has(CLAIM_HOLDER)).toBe(true);
+  });
+
+  it('an alive-but-unclaimed session keeps its mail (the 146-of-162 regression)', async () => {
+    const ids = await sweep.loadLiveSessionIds(sbReturning([{ session_id: IDLE_NO_SD, computed_status: 'idle' }]));
+    const plan = sweep.planDeadLetters(
+      [{ id: 'm1', target_session: IDLE_NO_SD, message_type: 'INFO', payload: { kind: 'ACCOUNT_SWITCH' }, expires_at: null }],
+      { allSessionIds: ids, deadIds: new Set() },
+      NOW,
+    );
+    expect(plan).toHaveLength(0);
+  });
+
+  it('a STALE target is still dead-lettered — FR-4 preserved, not relaxed into never firing', async () => {
+    // The stale session is excluded server-side by the liveness filter, so it never reaches the
+    // Set and remains "gone" to planDeadLetters. Measured live: 5911 of 5926 rows are stale, so a
+    // set keyed on mere existence would have made dead-lettering fire essentially never.
+    const ids = await sweep.loadLiveSessionIds(sbReturning([{ session_id: CLAIM_HOLDER, computed_status: 'active' }]));
+    const plan = sweep.planDeadLetters(
+      [{ id: 'm1', target_session: IDLE_NO_SD, message_type: 'INFO', payload: {}, expires_at: null }],
+      { allSessionIds: ids, deadIds: new Set() },
+      NOW,
+    );
+    expect(plan).toHaveLength(1);
+  });
+
+  it('filters by EXCLUDING the dead status, so an unknown/NULL status keeps its mail', async () => {
+    await sweep.loadLiveSessionIds(sbReturning([]));
+    // An allow-list of active/idle would silently destroy mail for any future status; the
+    // exclusion form retains it. Pin the direction, not just today's result.
+    expect(captured.or).toBe('computed_status.is.null,computed_status.neq.stale');
+  });
+
+  it('returns null when the view cannot be read — callers skip rather than guess', async () => {
+    // A set we could not read is not evidence its members are gone, and falling back to the
+    // claim-filtered set is exactly how live mail got destroyed. Fail toward DELIVERY.
+    expect(await sweep.loadLiveSessionIds(sbReturning(null, { fail: true }))).toBeNull();
+    expect(await sweep.loadLiveSessionIds({ from() { throw new Error('boom'); } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260726-253

**Type:** bug
**Severity:** critical

### Issue Description
FOUND BY THE COORDINATOR WHILE VERIFYING ITS OWN SENDS. MECHANISM RE-VERIFIED AT SOURCE BY ADAM BEFORE FILING.

*** 146 OF 162 MACHINE-GENERATED MESSAGES ADDRESSED TO THE COORDINATOR SESSION WERE DESTROYED - 90 PERCENT. ***

THE MECHANISM, TRACED THROUGH THREE FILES AND CONFIRMED LINE BY LINE:
  1. scripts/stale-session-sweep.cjs:1846 loads its session set from v_active_sessions with .not(sd_key, is, null). Its own comment reads Get all sessions with SD claims. The classified set is therefore ONLY claim-holders.
  2. lib/sweep/passes/dead-letter-planning.cjs:33 builds allSessionIds from that classified set: new Set(classified.map(s => s.session_id)).
  3. planDeadLetters (stale-session-sweep.cjs:3435) dead-letters any message where !allSessionIds.has(target_session).
  4. THE COORDINATOR, ADAM, SOLOMON AND EVERY IDLE WORKER HOLD NO SD BY DESIGN. They are permanently outside that set. So NOT-A-CLAIM-HOLDER IS SILENTLY EQUATED WITH DEAD-OR-GONE.
  5. Machine mail carries a ONE-HOUR TTL and a filter admits anything past expires_at, so any such message unread for an hour is dead-lettered on the next sweep, stamped read_at, and per the code comment drops out of every unread selector.

*** THE MEASURED COST, AND IT IS NOT HYPOTHETICAL. *** The row [ACCOUNT_SWITCH] Adam session Claude account changed, body switched from deepsoulsessionslabel to codestreetlabs, created 10:18:24Z and ADDRESSED TO THE COORDINATOR, was among the destroyed messages.
CONSEQUENCE: the coordinator never learned the fleet had changed accounts. It then diagnosed a FLEET-WIDE WAKEUP DELIVERY FAILURE (QF-20260726-163) and Adam independently corroborated it. Both were wrong. The actual cause was deepsoul weekly quota exhaustion, and it was only established when the CHAIRMAN SAID SO IN CONVERSATION. The notification designed to prevent exactly that misdiagnosis had already been destroyed by this defect.
So the cost is not lost mail in the abstract - IT IS A WRONG ROOT-CAUSE DIAGNOSIS THAT CONSUMED TWO ROLE SESSIONS AND PRODUCED A CRITICAL QF THAT NEEDED THREE CORRECTIONS.

FIX: dead-letter planning must key on ACTUAL SESSION LIVENESS, not on SD-claim membership. The sweep already computes computed_status and heartbeat_age_seconds on that same view - use them. A session with a fresh heartbeat and no SD is ALIVE AND IDLE, which is the normal steady state for every role session.

DO NOT ACCEPT: adding the role sessions to the allow-set by name or by role tag. That fixes the three named roles and leaves EVERY IDLE WORKER still silently dead-lettered - and idle is precisely when a worker most needs to receive a dispatch. The predicate is wrong, not its coverage.

CLASS: the dominant family again. .not(sd_key, is, null) returns an HONEST TRUE ANSWER to the question WHICH SESSIONS HOLD CLAIMS, and it is consumed as WHICH SESSIONS EXIST. No could-not-determine representation helps; the value is correct and the question is wrong. This is now the second confirmed instance where a wrong-question predicate caused a wrong root-cause diagnosis rather than merely a wrong number.

### Steps to Reproduce
see body

### Expected Behavior
see body

### Actual Behavior
see body

### Changes
- **Files Changed:** 5
  - lib/sweep/legacy-fallback.cjs
  - lib/sweep/passes/dead-letter-planning.cjs
  - scripts/stale-session-sweep.cjs
  - tests/ci/sweep-legacy-twin-parity.test.js
  - tests/unit/coord-adam-comms-resilient.test.js
- **LOC:** 71 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol