### PR TITLE
fix(QF-20260726-031): FIXTURE_KEY_RE does not recognise 6 of the 12 fixture keys the db-project claim tests actually use, so two consumers are blind to real test residue

### DIFF
--- a/lib/governance/fixture-exclusion.mjs
+++ b/lib/governance/fixture-exclusion.mjs
@@ -30,8 +30,24 @@
 // key is generator residue — e.g. TEST-F3-RACE-1784287684096-bl1; no real SD key carries
 // one). Recall loss on prefix-only fixtures (e.g. SD-TEST-MRO18ZP0) is accepted: a
 // missed fixture inflates a count slightly; an excluded real row silently loses work.
+// QF-20260726-031: the pattern had DRIFTED FROM THE FIXTURES. Run against the fixture keys the
+// db-project claim tests actually use, six did not match — the SD-FAKE-* family and both
+// QF-00000000-* keys carry no ZZZ_ prefix, no dunder, no UAT marker, no SD-DEMO- prefix and no
+// epoch stamp, so two consumers of this predicate treated live test residue as REAL DATA.
+// The shapes below were added only after confirming each catches ZERO real rows on the live DB
+// (SD-FAKE-% 0, SD-FIXTURE% 0, QF-00000000-% 0, QF-FIXTURE% 0), which is the PRECISION OVER
+// RECALL rule above: a missed fixture inflates a count, an excluded real row loses work.
+//
+// DELIBERATELY NOT ADDED, and this is the trap: the same enumeration surfaced keys like
+// SD-EVA-QUALITY-VISION-GOVERNANCE-TESTS-001, SD-MAN-INFRA-E2E-REGRESSION-TEST-001,
+// SD-FDBK-ENH-S17-PARITY-TEST-001 and SD-LEO-INFRA-BLOCK-TEST-SESSION-001. All four are REAL
+// COMPLETED SDs (verified live), so any broadening toward "contains TEST" would silently exclude
+// genuine shipped work — exactly the over-exclusion PR #6186 had to revert. Fixture-ness must come
+// from UNAMBIGUOUS markers (FAKE, FIXTURE, an all-zero date stamp), never from the word TEST.
+// The companion test enumerates the keys in ACTUAL USE and asserts BOTH directions, so the next
+// fixture shape someone adds to a test fails there instead of drifting outside this pattern again.
 export const FIXTURE_KEY_RE =
-  /^ZZZ_|^__|^UAT[-_]|^SD-DEMO-|^SD-UAT-FIX-TEST-|^SD-LEO-FEAT-TEST-E2E-|(?:^|-)TEST-E2E-\d{10,}(?:-|$)|[-_]\d{12,}(?:[-_][a-z0-9]{1,8})?$/i;
+  /^ZZZ_|^__|^UAT[-_]|^SD-DEMO-|^SD-UAT-FIX-TEST-|^SD-LEO-FEAT-TEST-E2E-|^(?:SD|QF)-FAKE-|^(?:SD|QF)-FIXTURE(?:$|[-_])|^QF-0{8}[-_]|(?:^|-)TEST-E2E-\d{10,}(?:-|$)|[-_]\d{12,}(?:[-_][a-z0-9]{1,8})?$/i;
 
 // wave-linkage-coverage.js's exclusion set, lifted verbatim (FR-3): that gauge's
 // semantics are DESIGNED-SIGNAL-sensitive (WAVE_LINKAGE_STARVATION) and must not be

--- a/tests/unit/governance/fixture-exclusion.test.js
+++ b/tests/unit/governance/fixture-exclusion.test.js
@@ -159,3 +159,44 @@ describe('worker-facing loaders exclude fixtures (TS-3, TS-4)', () => {
     expect(allSDs.has('TEST-F3-RACE-1784287684096-bl1')).toBe(false);
   });
 });
+
+// QF-20260726-031: the pattern had drifted from the fixtures. These keys are ENUMERATED FROM
+// ACTUAL USE (grepped out of tests/integration, tests/database and tests/db-invariants) rather
+// than from the shapes anyone remembered — a hand-maintained pattern cannot detect a key nobody
+// added to it, so the enumeration is the durable mechanism and this test is where drift surfaces.
+describe('QF-031: fixture keys in ACTUAL USE by db-project tests (drift pin)', () => {
+  // Six of these did not match before this QF: the SD-FAKE-* family and both QF-00000000-* keys.
+  const IN_USE_FIXTURE_KEYS = [
+    'SD-FAKE-001', 'SD-FAKE-TEST-001', 'SD-FAKE-PROBE-000',
+    'SD-FAKE-FOR-CLI-TEST', 'SD-FAKE-SWITCH-TARGET-000', 'SD-FAKE-PROBE-PHANTOM-GUARD-000',
+    'QF-00000000-000', 'QF-00000000-switch',
+    'SD-FIXTURE', 'SD-FIXTURE-HOLD-SWEEP', 'SD-FIXTURE-EXEC-BOUNDARY-HOLD', 'QF-FIXTURE-LEAK',
+  ];
+
+  test.each(IN_USE_FIXTURE_KEYS)('%s is recognised as fixture residue', (key) => {
+    expect(FIXTURE_KEY_RE.test(key)).toBe(true);
+  });
+
+  // THE CONTROL, and it is what makes the block above evidence instead of an inert pattern that
+  // returns true for everything. All four are REAL COMPLETED SDs verified against the live DB.
+  // They contain TEST/TESTS, which is precisely why fixture-ness must never be inferred from that
+  // word: broadening this predicate toward "contains TEST" is the over-exclusion PR #6186 reverted,
+  // and an excluded real row silently loses shipped work.
+  test.each([
+    'SD-EVA-QUALITY-VISION-GOVERNANCE-TESTS-001',
+    'SD-MAN-INFRA-E2E-REGRESSION-TEST-001',
+    'SD-FDBK-ENH-S17-PARITY-TEST-001',
+    'SD-LEO-INFRA-BLOCK-TEST-SESSION-001',
+  ])('REAL completed SD %s is NOT excluded', (key) => {
+    expect(FIXTURE_KEY_RE.test(key)).toBe(false);
+  });
+
+  // Guard the new shapes against over-reach: a plausible REAL key that merely starts similarly
+  // must not match, so the anchors are doing work rather than the substring.
+  test('new shapes are prefix-anchored, not substring matches', () => {
+    expect(FIXTURE_KEY_RE.test('SD-FAKEOUT-DETECTION-001')).toBe(false); // FAKE- boundary required
+    expect(FIXTURE_KEY_RE.test('SD-FIXTURES-LIBRARY-001')).toBe(false);  // FIXTURE boundary required
+    expect(FIXTURE_KEY_RE.test('QF-20260726-031')).toBe(false);          // a real dated QF id
+    expect(FIXTURE_KEY_RE.test('SD-LEO-INFRA-FAKE-DATA-DETECTOR-001')).toBe(false); // not at prefix
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260726-031

**Type:** bug
**Severity:** high

### Issue Description
FOUND AND MEASURED BY THE COORDINATOR. *** DO NOT ABSORB THIS INTO QF-20260726-459 - fixing either one alone leaves the other live. *** 459 is about db-project tests reaching PRODUCTION; this is about the fixture-residue definition being blind to the keys those same tests use. Different predicates, different files, different failure.

THE ITEM: lib/governance/fixture-exclusion.mjs FIXTURE_KEY_RE is the in-house definition of TEST RESIDUE. Run against the twelve fixture keys the db-project claim tests actually use, SIX DO NOT MATCH - the four SD-FAKE-* keys and both QF-00000000-* keys. They carry no ZZZ_ prefix, no dunder, no UAT marker, no SD-DEMO- prefix and no epoch stamp, so the pattern does not see them.

THE CONTROL IS WHAT MAKES THIS EVIDENCE RATHER THAN A HUNCH, and it was run: SD-DEMO-RACE-001 and ZZZ_TEST-001 DO match. So the check COULD have said otherwise - a clean result on the other six is a real negative, not an inert pattern returning false for everything.

CONSEQUENCE: two consumers that rely on FIXTURE_KEY_RE to exclude test residue are blind to half the fixture keys in active use. Fixture rows written by those tests are therefore treated as REAL DATA by anything downstream that filters on this predicate.

FIX: extend FIXTURE_KEY_RE to recognise the SD-FAKE-* and QF-00000000-* shapes, and add the twelve real keys as test cases so the pattern is pinned against the keys actually in use rather than against the shapes someone remembered.

DO NOT ACCEPT: adding only the two shapes named here. The lesson is that the pattern drifted from the fixtures - ENUMERATE THE FIXTURE KEYS IN ACTUAL USE and pin the pattern against that list, so the next fixture shape added to a test does not silently fall outside it again. A hand-maintained pattern cannot detect a key nobody added to it.

CLASS: FIXTURE_KEY_RE returns an HONEST FALSE for six keys - it correctly reports that they do not match the pattern it encodes. The defect is that the pattern encodes the wrong set. Same family as the rest of 2026-07-25/26: a correct value answering a question that has drifted from the one being asked.

### Steps to Reproduce
see body

### Expected Behavior
see body

### Actual Behavior
see body

### Changes
- **Files Changed:** 2
  - lib/governance/fixture-exclusion.mjs
  - tests/unit/governance/fixture-exclusion.test.js
- **LOC:** 58 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol