### PR TITLE
fix(QF-20260726-956): reject a worktree that lost its .git pointer and binds upward to main

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -90,6 +90,29 @@ function isValidWorktree(wtPath) {
       return false; // Directory exists but is not a registered worktree
     }
 
+    // QF-20260726-956: THE DIRECTORY MUST BIND TO **ITSELF**, NOT UPWARD TO MAIN.
+    //
+    // Registration and the .git pointer live in two different places — registration in
+    // .git/worktrees/<name>/, the pointer in <worktree>/.git — and they DESYNC. When the
+    // pointer file is lost, git does not fail: because .worktrees/ is nested INSIDE the main
+    // checkout, it walks UP and silently binds to the MAIN repo. Every check above still
+    // passes (is-inside-work-tree is true, and `git worktree list` run from here reports the
+    // MAIN repo's registry, which still contains this path), so this function returned true
+    // for a directory whose every git verb targets the shared root.
+    //
+    // That is not theoretical: it deleted two source files out of the shared root when a
+    // routine `git restore` ran against MAIN's HEAD/index instead of the worktree's.
+    // Reproduced in an isolated repo — delete <worktree>/.git and --show-toplevel flips to
+    // the parent while registration is untouched.
+    //
+    // This is the one check that cannot be satisfied by the wrong repo, so it fails closed.
+    const toplevel = execSync('git rev-parse --show-toplevel', {
+      cwd: wtPath, encoding: 'utf8', stdio: 'pipe'
+    }).trim().replace(/\\/g, '/');
+    if (toplevel !== absPath) {
+      return false; // Lost .git pointer — bound to an ancestor repo, not this worktree
+    }
+
     return true;
   } catch {
     return false;
@@ -829,4 +852,6 @@ if (isMainScript) {
   });
 }
 
-export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot, resolveExistingBranch, rejectDescendantBranch };
+// isValidWorktree is exported for QF-20260726-956's binding test: the lost-pointer case is
+// only observable against a real on-disk repo, so the test builds one rather than mocking git.
+export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot, resolveExistingBranch, rejectDescendantBranch, isValidWorktree };

--- a/tests/unit/resolve-sd-workdir/worktree-binding-fail-closed.test.js
+++ b/tests/unit/resolve-sd-workdir/worktree-binding-fail-closed.test.js
@@ -1,0 +1,76 @@
+/**
+ * QF-20260726-956 — a worktree that lost its .git pointer must NOT validate.
+ *
+ * THE DEFECT. Registration and the .git pointer live in two different places — registration
+ * in .git/worktrees/<name>/, the pointer in <worktree>/.git — and they can desync. Because
+ * .worktrees/ is nested INSIDE the main checkout, losing the pointer does not raise an error:
+ * git walks UP and silently binds the directory to the MAIN repo. isValidWorktree's two
+ * existing checks BOTH still pass in that state, so it returned true and callers went on to
+ * run git verbs that targeted the shared root instead of the worktree.
+ *
+ * WHAT IT COST (Alpha-3, 2026-07-26): a routine `git restore --source=HEAD --worktree --staged`
+ * ran against MAIN's HEAD and index and deleted two source files out of the shared checkout.
+ * Recoverable only because the work had already been pushed.
+ *
+ * WHY THIS TEST BUILDS A REAL REPO INSTEAD OF MOCKING GIT. The whole defect IS git's real
+ * upward-search behaviour. A mocked `git rev-parse` returns whatever the test author expects,
+ * which is precisely the wrong repo's answer being indistinguishable from the right one — the
+ * bug would survive its own test suite. So we create an actual repo + worktree in a temp dir
+ * and delete the pointer for real. No DB, no network, no shared-root mutation.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { isValidWorktree } from '../../../scripts/resolve-sd-workdir.js';
+
+let root, wt;
+const git = (args, cwd) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+const norm = (p) => path.resolve(p).replace(/\\/g, '/');
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'qf956-'));
+  git(['init', '-q', '.'], root);
+  git(['config', 'user.email', 'test@example.invalid'], root);
+  git(['config', 'user.name', 'qf956'], root);
+  fs.writeFileSync(path.join(root, 'a.txt'), 'hi\n');
+  git(['add', 'a.txt'], root);
+  git(['commit', '-qm', 'init'], root);
+  // Mirror production layout: worktrees nested INSIDE the main checkout. The nesting is what
+  // makes the failure silent — a sibling directory would simply not be a repo at all.
+  wt = path.join(root, '.worktrees', 'WT');
+  git(['worktree', 'add', '-q', wt, '-b', 'feat/wt'], root);
+});
+
+afterAll(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* temp dir */ }
+});
+
+describe('QF-956: isValidWorktree must reject an upward-bound worktree', () => {
+  it('ALLOWS a healthy worktree (the control — proves this is not an always-false guard)', () => {
+    // Without this arm, the refusal below is satisfied equally by a guard that rejects
+    // everything, which would break every legitimate worktree resolution instead of fixing it.
+    expect(fs.existsSync(path.join(wt, '.git'))).toBe(true);
+    expect(norm(git(['rev-parse', '--show-toplevel'], wt))).toBe(norm(wt));
+    expect(isValidWorktree(wt)).toBe(true);
+  });
+
+  it('REFUSES once the .git pointer is lost, even though it still looks valid', () => {
+    fs.rmSync(path.join(wt, '.git'), { force: true });
+
+    // THE TWO PRE-EXISTING CHECKS STILL PASS. This is the load-bearing part of the test: it
+    // documents WHY the third conjunct was needed rather than just asserting the new result.
+    expect(git(['rev-parse', '--is-inside-work-tree'], wt)).toBe('true');
+    const registered = git(['worktree', 'list', '--porcelain'], wt)
+      .split('\n').filter((l) => l.startsWith('worktree '))
+      .map((l) => norm(l.replace('worktree ', '').trim()));
+    expect(registered).toContain(norm(wt)); // still registered — desync is real
+
+    // And the directory now answers for the PARENT repo. This is the silent misbinding.
+    expect(norm(git(['rev-parse', '--show-toplevel'], wt))).toBe(norm(root));
+
+    // The predicate must fail closed on exactly that.
+    expect(isValidWorktree(wt)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`isValidWorktree()` returned **true** for a worktree directory that had lost its `.git` pointer file — a directory whose every subsequent git verb targets the **shared root** instead of the worktree.

## Why it was invisible

Registration and the pointer live in two different places and can desync:

| | location |
|---|---|
| registration | `.git/worktrees/<name>/` |
| pointer | `<worktree>/.git` |

Because `.worktrees/` is nested **inside** the main checkout, losing the pointer doesn't error — git walks **up** and binds to the main repo. Both existing checks still pass:

- `git rev-parse --is-inside-work-tree` → `true` (it *is* inside one — main's)
- `git worktree list --porcelain` from that cwd reports **main's** registry, which still contains the path

So the predicate said "valid" and callers proceeded to mutate the wrong repo.

## What it cost

Reported by Alpha-3: a routine `git restore --source=HEAD --worktree --staged -- tests` ran against **main's** HEAD/index rather than the worktree's and **deleted two source files out of the shared checkout**. Recoverable only because the work had already been pushed.

## Fix

Add the one conjunct the wrong repo cannot satisfy — `--show-toplevel` from the worktree must equal the worktree itself. Fails closed. ~6 lines of logic.

## Verification — by mutation, not by reading the diff

- Guard disabled → new test **fails**: `expected true to be false`
- Guard restored → **passes**; full `resolve-sd-workdir` suite 16/16
- The healthy-worktree arm passes in **both** directions, so this is not an always-false guard that would break every SD start
- Ran against all **23 real worktrees** on this host: 19 healthy ones still validate; the 4 rejected all genuinely lack a `.git` pointer

The test builds a **real** repo + worktree and deletes the pointer for real. Mocking git here would be worthless — the defect *is* git's real upward-search behaviour, and a mock returns whatever the author expects.

## Scope, stated honestly

None of those 4 pointer-less directories are currently *registered*, so **this changes no verdict on the present host state** — the existing registration check already rejects them. It closes a **reachable** state, reproduced in an isolated repo, not one that is armed right now.

## Not addressed here (reported separately)

`checkDirtyWorktree` is imported by `resolve-sd-workdir.js` and **never called** — dead code. It looked like the natural guard site; wiring into it would have shipped an inert guard.

Part (A) of the original report (stale 6.2h `index.lock` in the shared root) had already cleared by the time I checked, and `lib/git/clear-stale-index-lock.mjs` already exists for it.

Closes QF-20260726-956.
