### PR TITLE
fix(QF-20260725-613): Orchestrator parent that never ran LEAD-TO-PLAN is unreachable by every automated path

### DIFF
--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -108,6 +108,8 @@ async function gatherDetectorInputs(supabase, opts) {
     adamCount: 0, adams: [], // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C (FR-1): MULTIPLE_ADAMS feed
     idleWorkers: 0, unclaimedItems: 0,
     signals: [], claims: [], sessions: [], sdClaims: [],
+    sds: [], // QF-20260725-613 — PRE_LEAD_PARENT_DEADLOCK input; [] on the fetch-failure path
+
   };
 
   // 1) claude_sessions — derive coordinators, idle workers, sessions, claims.
@@ -148,11 +150,20 @@ async function gatherDetectorInputs(supabase, opts) {
   try {
     const data = await fapPaginate(() => supabase
       .from('strategic_directives_v2')
-      .select('sd_key, claiming_session_id, status, current_phase, updated_at, is_working_on')
+      // QF-20260725-613: id/sd_type/parent_sd_id added for PRE_LEAD_PARENT_DEADLOCK — the
+      // detector groups children by parent_sd_id (which references the parent's `id`, not its
+      // sd_key) and keys the parent on sd_type==='orchestrator'. Without these three columns
+      // the detector receives rows it cannot classify and silently reports nothing.
+      .select('id, sd_key, sd_type, parent_sd_id, claiming_session_id, status, current_phase, updated_at, is_working_on')
       .not('status', 'in', '(completed,cancelled,archived,superseded,deferred)')
       .order('sd_key')); // unique-key tiebreaker for stable pagination
     sds = data || [];
   } catch (_) { sds = []; }
+
+  // QF-20260725-613: expose the SD rows so detectPreLeadParentDeadlock can see parent/child
+  // structure. NOTE the status filter on the query above excludes terminal SDs, which is what
+  // we want: a cancelled child is not "blocked", and a completed parent is not deadlocked.
+  bundle.sds = sds;
 
   const sdByKey = new Map(sds.map((s) => [s.sd_key, s]));
   bundle.sdClaims = sds.filter((s) => s.claiming_session_id).map((s) => ({ sd_key: s.sd_key, claiming_session_id: s.claiming_session_id }));

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -526,6 +526,81 @@ function maskedStallSessionIds(data) {
  * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases, deployGapMs, loopExpiryWarnMs, stalledLoopFreshMs, evaSchedulerStaleMs }
  * @returns {Array<{ event_type: string, severity: string, reason: string, evidence: object }>}
  */
+// QF-20260725-613 item 1: the PRE-LEAD ORCHESTRATOR PARENT deadlock, made visible.
+//
+// A parent decomposed into children BEFORE its own LEAD-TO-PLAN ran is unreachable by every
+// automated path: dispatch refuses it (claim-eligibility keys on sd_type==='orchestrator'),
+// self-claim filters it out (worker-checkin's .neq(sd_type,orchestrator) pools), children stay
+// parent_lead_pending until the parent moves PAST LEAD, and sd-start's descent finds no
+// buildable leaf. The exclusions are CORRECT for a post-LEAD parent — that one legitimately
+// sits claimless while children build. Nobody modelled the pre-LEAD parent.
+//
+// WHY A DETECTOR IS ITEM 1 AND SHIPS ALONE: the defect was not that the cycle existed, it is
+// that it was SILENT. Six seats idled for hours while every gauge read clean — including
+// unranked_claimable_leaves=0 — because the blocked leaf was excluded from the claimable
+// population BY THE VERY FENCE THAT BLOCKED IT. A gauge that cannot see the blocked item
+// reports zero blocked items. Until this exists, nobody can tell whether a fix worked.
+//
+// PRECISE, NOT HEURISTIC: parentLeadPending is true exactly while the parent's current_phase is
+// LEAD or LEAD_APPROVAL and it is not completed. So a non-terminal child of such a parent IS
+// blocked on parent_lead_pending by construction — no need to re-derive eligibility here, which
+// would also mean computing the verdict from the same data that produced the deadlock.
+// Read-only and advisory: it reports, it never moves an SD. Auto-advancing a stuck parent was
+// explicitly REJECTED — this SD has a recorded LEAD->PLAN rejection at 23:41 followed by an
+// acceptance at 03:07, so auto-advance would have forced through exactly what the gates
+// correctly refused.
+const PRE_LEAD_PHASES = Object.freeze(['LEAD', 'LEAD_APPROVAL']);
+const TERMINAL_SD_STATUSES = Object.freeze(['completed', 'cancelled', 'archived', 'superseded', 'deferred']);
+
+function detectPreLeadParentDeadlock(data) {
+  const sds = (data && data.sds) || [];
+  if (sds.length === 0) return { matched: false, reason: 'no_sd_data', evidence: {} };
+
+  const isTerminal = (s) => TERMINAL_SD_STATUSES.includes(String(s.status || '').toLowerCase());
+  const phaseOf = (s) => String(s.current_phase || '').toUpperCase();
+
+  // Children grouped by the parent's row id (children carry parent_sd_id -> parent.id).
+  const childrenByParent = new Map();
+  for (const s of sds) {
+    if (!s || !s.parent_sd_id) continue;
+    if (!childrenByParent.has(s.parent_sd_id)) childrenByParent.set(s.parent_sd_id, []);
+    childrenByParent.get(s.parent_sd_id).push(s);
+  }
+
+  const deadlocked = [];
+  for (const parent of sds) {
+    if (!parent || parent.sd_type !== 'orchestrator') continue;
+    if (isTerminal(parent)) continue;
+    if (!PRE_LEAD_PHASES.includes(phaseOf(parent))) continue;   // past LEAD => exclusions are correct
+    const kids = (childrenByParent.get(parent.id) || []).filter((k) => !isTerminal(k));
+    if (kids.length === 0) continue;                            // no children waiting => no deadlock
+    deadlocked.push({
+      parent_sd_key: parent.sd_key,
+      parent_phase: phaseOf(parent),
+      parent_status: parent.status ?? null,
+      parent_claimed: Boolean(parent.claiming_session_id),
+      blocked_child_count: kids.length,
+      blocked_children: kids.slice(0, 10).map((k) => k.sd_key),
+    });
+  }
+
+  if (deadlocked.length > 0) {
+    return {
+      matched: true,
+      reason: 'pre_lead_parent_deadlock',
+      evidence: {
+        parent_count: deadlocked.length,
+        blocked_child_total: deadlocked.reduce((n, d) => n + d.blocked_child_count, 0),
+        // The escape hatch, carried in the evidence so a reader is never left without the action:
+        // handoff.js has NO claim precondition, so this needs no seat and no claim.
+        remedy: 'node scripts/handoff.js execute LEAD-TO-PLAN <parent-sd-key>',
+        parents: deadlocked.slice(0, 10),
+      },
+    };
+  }
+  return { matched: false, reason: 'no_pre_lead_parent_with_blocked_children', evidence: {} };
+}
+
 function runDetectors(data, opts) {
   opts = opts || {};
   const now = opts.now ?? Date.now();
@@ -537,6 +612,10 @@ function runDetectors(data, opts) {
     { event_type: 'REPLY_STARVATION', severity: 'warning', res: detectReplyStarvation({ signals: data && data.signals, now, thresholdMs: opts.replyStarvationMs }) },
     { event_type: 'STUCK_WORKER', severity: 'warning', res: detectStuckWorker({ claims: data && data.claims, now, thresholdMs: opts.stuckWorkerMs, priorPhases: opts.priorPhases }) },
     { event_type: 'CLAIM_HALF_WRITE', severity: 'info', res: detectClaimHalfWrite(data) },
+    // QF-20260725-613: pre-LEAD orchestrator parent whose children are all blocked on it.
+    // 'warning' — it is a real work stoppage (six seats idled for hours on the recorded
+    // instance), but it is advisory: the remedy is a handoff run, never an automated advance.
+    { event_type: 'PRE_LEAD_PARENT_DEADLOCK', severity: 'warning', res: detectPreLeadParentDeadlock(data) },
     // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: advisory (severity 'info' — coordination_events.severity
     // CHECK allows only info/warning/critical; DEPLOY_GAP is discriminated by event_type + payload).
     { event_type: 'DEPLOY_GAP', severity: 'info', res: detectDeployGap({ sessions: data && data.sessions, mergesByRole: data && data.mergesByRole, now }, { maxGapMs: opts.deployGapMs }) },
@@ -676,6 +755,9 @@ module.exports = {
   detectReplyStarvation,
   detectStuckWorker,
   detectClaimHalfWrite,
+  // QF-20260725-613 — pre-LEAD orchestrator parent deadlock (read-only, advisory).
+  detectPreLeadParentDeadlock,
+  PRE_LEAD_PHASES,
   detectGhostCompletion,
   runDetectors,
   DEFAULT_INERT_WORKER_AGE_MS,

--- a/tests/unit/coordinator/pre-lead-parent-deadlock.test.js
+++ b/tests/unit/coordinator/pre-lead-parent-deadlock.test.js
@@ -1,0 +1,111 @@
+/**
+ * QF-20260725-613 item 1 — the PRE-LEAD ORCHESTRATOR PARENT deadlock detector.
+ *
+ * THE DEADLOCK: a parent decomposed into children BEFORE its own LEAD-TO-PLAN ran is
+ * unreachable by every automated path — dispatch refuses orchestrator parents, worker-checkin
+ * filters them out of every self-claim pool, children stay parent_lead_pending until the parent
+ * moves PAST LEAD, and sd-start's descent finds no buildable leaf.
+ *
+ * WHY THE DETECTOR MATTERS MORE THAN THE CYCLE: the cycle was SILENT. Six seats idled for hours
+ * while every gauge read clean — including unranked_claimable_leaves=0 — because the blocked leaf
+ * was excluded from the claimable population BY THE VERY FENCE THAT BLOCKED IT. A gauge that
+ * cannot see the blocked item reports zero blocked items.
+ *
+ * So the controls here are the point: a detector that can only be shown NOT to fire is
+ * indistinguishable from one that never fires, and that is precisely the failure it exists to
+ * catch. Every negative case below is paired with the positive.
+ */
+import { describe, it, expect } from 'vitest';
+import detectors from '../../../lib/coordinator/detectors.cjs';
+
+const { detectPreLeadParentDeadlock, runDetectors } = detectors;
+
+const PARENT_ID = 'a39d0d4c-0000-0000-0000-000000000000';
+
+/** Shaped after the real SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001 family. */
+function family({ parentPhase = 'LEAD', parentStatus = 'draft', childStatuses = ['draft', 'draft'] } = {}) {
+  return [
+    {
+      id: PARENT_ID,
+      sd_key: 'SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001',
+      sd_type: 'orchestrator',
+      parent_sd_id: null,
+      current_phase: parentPhase,
+      status: parentStatus,
+      claiming_session_id: null,
+    },
+    ...childStatuses.map((status, i) => ({
+      id: `child-${i}`,
+      sd_key: `SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-${'ABCDEF'[i]}`,
+      sd_type: 'infrastructure',
+      parent_sd_id: PARENT_ID,
+      current_phase: 'LEAD',
+      status,
+      claiming_session_id: null,
+    })),
+  ];
+}
+
+describe('QF-613: detectPreLeadParentDeadlock — the armed case', () => {
+  it('FIRES on a pre-LEAD orchestrator parent with non-terminal children', () => {
+    const r = detectPreLeadParentDeadlock({ sds: family() });
+    expect(r.matched).toBe(true);
+    expect(r.reason).toBe('pre_lead_parent_deadlock');
+    expect(r.evidence.parent_count).toBe(1);
+    expect(r.evidence.blocked_child_total).toBe(2);
+    expect(r.evidence.parents[0].parent_sd_key).toContain('SESSION-SPAWN-AND-PROMPT-LIBRARY-001');
+    // The evidence must carry the action, because handoff.js needs no claim and no seat —
+    // a reader who cannot see the remedy is back to "nobody can reach this parent".
+    expect(r.evidence.remedy).toContain('handoff.js execute LEAD-TO-PLAN');
+  });
+
+  it('FIRES at LEAD_APPROVAL too — the fence spans both pre-LEAD phases', () => {
+    expect(detectPreLeadParentDeadlock({ sds: family({ parentPhase: 'LEAD_APPROVAL' }) }).matched).toBe(true);
+  });
+});
+
+describe('QF-613: the controls — it must be able to say NO', () => {
+  it('does NOT fire once the parent is PAST lead (the exclusions are correct there)', () => {
+    // This is the post-LEAD parent the design intends: claimless while children build.
+    const r = detectPreLeadParentDeadlock({ sds: family({ parentPhase: 'PLAN_PRD', parentStatus: 'in_progress' }) });
+    expect(r.matched).toBe(false);
+    expect(r.reason).toBe('no_pre_lead_parent_with_blocked_children');
+  });
+
+  it('does NOT fire when every child is terminal — nothing is actually blocked', () => {
+    const r = detectPreLeadParentDeadlock({ sds: family({ childStatuses: ['cancelled', 'completed'] }) });
+    expect(r.matched).toBe(false);
+  });
+
+  it('does NOT fire for a pre-LEAD parent with NO children (not yet decomposed)', () => {
+    const r = detectPreLeadParentDeadlock({ sds: family({ childStatuses: [] }) });
+    expect(r.matched).toBe(false);
+  });
+
+  it('does NOT fire for a non-orchestrator parent-shaped row', () => {
+    const sds = family();
+    sds[0].sd_type = 'infrastructure';
+    expect(detectPreLeadParentDeadlock({ sds }).matched).toBe(false);
+  });
+
+  it('reports no_sd_data rather than a false clean when the input is absent', () => {
+    // Distinguishing "nothing blocked" from "I could not see" is the whole lesson of this QF.
+    expect(detectPreLeadParentDeadlock({}).reason).toBe('no_sd_data');
+    expect(detectPreLeadParentDeadlock({ sds: [] }).reason).toBe('no_sd_data');
+  });
+});
+
+describe('QF-613: it is WIRED, not merely exported', () => {
+  it('runDetectors emits PRE_LEAD_PARENT_DEADLOCK for the armed family', () => {
+    // A detector nobody dispatches is the defect one level up. Pin the registration.
+    const matches = runDetectors({ sds: family() }, { now: Date.now() });
+    const hit = matches.find((m) => m.event_type === 'PRE_LEAD_PARENT_DEADLOCK');
+    expect(hit).toBeTruthy();
+    expect(hit.severity).toBe('warning');
+  });
+
+  it('runDetectors does NOT emit it for a past-LEAD parent', () => {
+    const matches = runDetectors({ sds: family({ parentPhase: 'PLAN_PRD' }) }, { now: Date.now() });
+    expect(matches.find((m) => m.event_type === 'PRE_LEAD_PARENT_DEADLOCK')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260725-613

**Type:** bug
**Severity:** critical

### Issue Description
A REAL STRUCTURAL DEADLOCK, MEASURED ON A LIVE CHAIRMAN-PRIORITY SD. SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001 sat at draft/LEAD, 60 percent, CLAIMED BY NOBODY, with ZERO handoffs across the entire family - its LEAD-TO-PLAN has never run. Three children all returned parent_lead_pending at ranks 2, 3 and 4. SIX SEATS WERE IDLE at the time.

THE FOUR CLOSED DOORS, each verified at source rather than inferred:
(1) DISPATCH IS FORBIDDEN BY DESIGN. evaluateDispatchEligibility returns {eligible:false, reason:orchestrator_parent} at EVERY rank, keyed on sd_type===orchestrator at claim-eligibility.cjs:192. The charter states it outright - never dispatch a parent.
(2) SELF-CLAIM IS FILTERED OUT. worker-checkin.cjs applies .neq(sd_type, orchestrator) in FIVE separate candidate pools - lines 811, 845, 887, 923, 1166. A worker can never self-claim a parent. The comment at :1166 gives the intent: parents are in_progress/no-claim BY DESIGN while children run.
(3) CHILDREN CANNOT PROCEED. parentLeadPending returns true while the parent current_phase is LEAD or LEAD_APPROVAL and it is not completed, so children unblock ONLY when the parent moves PAST LEAD.
(4) THE DESCEND PATH FINDS NOTHING. queue-resolver.cjs documents TWO ORCHESTRATOR PRIMITIVES ON PURPOSE - worker-checkin EXCLUDES parents while sd-start DESCENDS into them via resolveLeafWorkItem to find a buildable leaf. Every leaf here returns parent_lead_pending, so the descent has nothing to land on.

SO THE CYCLE IS CLOSED: children need the parent past LEAD; the parent moves past LEAD only when someone runs its LEAD-TO-PLAN; nobody can be dispatched to it and nobody can self-claim it. THE ONLY WAY IN IS A HUMAN-DIRECTED INSTRUCTION.

THE DESIGN ASSUMPTION THAT FAILS: the exclusions are correct FOR A PARENT WHOSE LEAD HAS ALREADY RUN - that parent legitimately sits claimless while children build, exactly as the :1166 comment describes. NOBODY MODELLED THE PRE-LEAD PARENT. A parent decomposed into children BEFORE its own LEAD-TO-PLAN ran is in a state every automated path refuses to touch. Decomposing at LEAD is not unusual - it is what happened here.

OBSERVED FAILURE MODE, worth recording because it LOOKS like worker flakiness and is not: two workers (Echo, then Golf-3) each HELD the parent and RELEASED it within minutes without running the handoff. A directed hold IS possible; what is missing is any instruction telling the holder that running LEAD-TO-PLAN is the job. Do not read those releases as workers misbehaving.

DO NOT FIX BY REMOVING THE EXCLUSIONS - they are right for the post-LEAD case, and removing them would put workers on parents that legitimately have no work. The fix wants a path open ONLY for a parent whose LEAD has never run. Three candidate shapes, different blast radii, pick one deliberately: (a) make such a parent dispatchable/self-claimable SPECIFICALLY to run its first handoff; (b) have decomposition REFUSE to create children until the parent is past LEAD; (c) auto-advance a parent whose children are ALL blocked solely on parent_lead_pending.

=== COORDINATOR SCOPE (a59441f4) — RESOLVED INSTANCE + THE DESIGN CALL SOLOMON DEFERRED ===

STATUS OF THE LIVE INSTANCE: CLEARED at ~03:10Z, by hand, before this QF was claimed. The parent is now
in_progress / PLAN_PRD / 60% under Echo; -D, -E and -F all returned eligible=true; Foxtrot SELF-CLAIMED -F
the moment the fence lifted. So this QF is about the RECURRENCE, not about unblocking anything today.
HOW IT CLEARED, since it is the manual escape hatch worth keeping: a directed WORK_ASSIGNMENT naming the JOB
rather than the SD - "clear SMOKE_TEST_BYPASSED and SUBAGENT_EVIDENCE_MISSING, then re-run the handoff".
A parent is never dispatchable and never self-claimable, but it IS holdable. Also confirmed by Solomon:
handoff.js has NO claim precondition, so LEAD-TO-PLAN can be run without solving the claim problem first.

BUILD ORDER — TWO ITEMS, AND ITEM 1 SHIPS EVEN IF ITEM 2 DOES NOT:

1. THE DETECTOR, FIRST. A read-only check for: parent pre-LEAD AND every child blocked SOLELY on
   parent_lead_pending. Zero blast radius, and it catches the NEXT unmodelled cycle rather than only this one.
   THE REASON IT COMES FIRST: the defect was not that the cycle existed, it is that it was SILENT. Six seats
   idle for hours and EVERY gauge reported clean - including unranked_claimable_leaves=0 - because the blocked
   leaf was excluded from the claimable population BY THE VERY FENCE THAT BLOCKED IT. A gauge that cannot see
   the blocked item reports zero blocked items. Without the detector nobody can tell whether item 2 worked.

2. THEN make a pre-LEAD parent claimable FOR THE FIRST HANDOFF ONLY — as ONE SHARED PREDICATE, never six edits.
   *** DO NOT PATCH SIX SITES. *** Five-of-six is indistinguishable from fixed until it is not, and this repo
   already produced a third-dead-site from exactly that shortcut tonight.
   THE WORK IS SMALLER THAN IT LOOKS, because the invariant already exists and has drifted:
     claim-eligibility.cjs carries the guardrail comment "Never fork axis logic between the two exports —
     extend THIS table", i.e. INELIGIBILITY_AXES is already declared the SSOT.
     worker-checkin.cjs:1171 refers to a "Shared classifier (same predicate as the draft tier + coordinator
     sweep)" that ALREADY EXISTS - yet five sites (811, 845, 887, 923, 1166) hand-roll .neq(sd_type,orchestrator).
   So: route those five through the existing classifier, THEN add the pre-LEAD exception ONCE in the axis table.
   This is RESTORING A DECLARED INVARIANT, not inventing a new one.

REJECTED — DO NOT IMPLEMENT: auto-advancing a parent whose children are all parent_lead_pending. It moves an SD
through LEAD WITHOUT LEAD's artifact (the gate-passed-without-the-work class), and its trigger would be computed
from THE SAME DATA THAT PRODUCED THE DEADLOCK - so a wrong computation auto-advances SDs that should not move.
Also rejected: refusing decomposition until the parent is past LEAD. Decomposition is often how the plan is
discovered, and forbidding it invites a hollow handoff run to satisfy the precondition - trading a deadlock for
a false gate pass.

NOT A WORKER-RELIABILITY BUG: two workers held this parent and released it correctly, because nothing told them
the deliverable was a PHASE TRANSITION rather than a build. That was an instruction gap, not flakiness.

=== EVIDENCED ARGUMENT AGAINST AUTO-ADVANCE (coordinator a59441f4, from Solomon) — NOT HYPOTHETICAL ===
The parent has TWO LEAD->PLAN handoff rows, and the pair settles the design question:
    LEAD -> PLAN | rejected | 2026-07-25T23:41:52
    LEAD -> PLAN | ACCEPTED | 2026-07-26T03:07:17
SOMEBODY RAN THE HANDOFF AT 23:41 AND THE GATES REJECTED IT. So the "no automated path can reach the parent"
framing was right about CLAIMING and INCOMPLETE about ACTION - the action was attempted hours earlier, failed
the gates honestly, and needed real work (smoke steps + sub-agent evidence) before it could pass.
THEREFORE: the auto-advance shape would have FORCED THROUGH AT 23:41 EXACTLY WHAT THE GATES CORRECTLY REFUSED.
That is no longer a predicted failure mode, it is a recorded one on this very SD. Keep this row as the argument.
The corollary is the reason to prefer the manual escape hatch: running handoff.js is SUBMITTING TO THE GATE,
not manufacturing an approval, and a gate REJECTION there is the valuable outcome rather than the failure.

=== DOCUMENTED WORKAROUND until this gap is fixed (coordinator a59441f4, Solomon-corrected) ===
THE MECHANISM — this is what actually moves a pre-LEAD orchestrator parent:
    node scripts/handoff.js execute LEAD-TO-PLAN <parent-sd-key>
NO claim, NO hold, NO seat required. handoff.js has no claim precondition (script and gate libs both checked),
and BOTH handoff rows on the live instance carry created_by=UNIFIED-HANDOFF-SYSTEM rather than any session id,
so the advance is not attributed to a holder. THE CLAIM WAS NEVER LOAD-BEARING.
Running it is SUBMITTING TO THE GATE, not manufacturing an approval — a REJECTION there is a useful outcome.

THE OPERATIONAL NOTE — how to get an agent to type it:
A directed WORK_ASSIGNMENT that NAMES THE JOB rather than the SD. On the live instance two dispatches failed
(dispatch is forbidden on a parent by design) and TWO WORKERS HELD THE PARENT AND RELEASED IT within minutes,
because nothing told them what the job WAS — both correctly concluded there was nothing to BUILD on a draft
parent. What worked was naming it: clear SMOKE_TEST_BYPASSED and SUBAGENT_EVIDENCE_MISSING, then re-run the
handoff, do not release until it lands. Claim re-taken 3m48s after that message; accepted handoff 11min later.

DO NOT RECORD THE HOLD AS THE MECHANISM. A hold on its own moves nothing, and someone who tries it and sees
nothing happen will conclude the mechanism is broken. The hold is a way to route a human-equivalent agent to
the command; the command is the mechanism. ||| CORRECTED 2026-07-26 - THE OBSERVED FAILURE MODE PARAGRAPH ABOVE IS WRONG AND THE CORRECTION MATTERS FOR WHOEVER FIXES THIS. I wrote that two workers HELD the parent and RELEASED it without running the handoff, and that what was missing was any instruction telling the holder that running LEAD-TO-PLAN was the job. THAT IS NOT WHAT HAPPENED. Echo LOST the claim to a mechanical release WHILE ACTIVELY RUNNING HANDOFFS. release_sd is SESSION-SCOPED and takes NO SD ARGUMENT (see QF-20260726-593): running sd-start against one SD releases whatever claim the SESSION holds, and its default reason string is the literal word manual - which is why a mechanical release is byte-identical to a deliberate one and why both the coordinator and I read it as a choice. The parent-unreachability analysis in this row STANDS - dispatch forbidden, self-claim filtered, children blocked, descent finds nothing, all verified at source. What does NOT stand is the inference that workers chose to walk away. Do not design a fix around telling holders what the job is; that was never the gap.

### Steps to Reproduce
1. see body

### Expected Behavior
reachable

### Actual Behavior
unreachable

### Changes
- **Files Changed:** 3
  - lib/coordinator/coordination-events.cjs
  - lib/coordinator/detectors.cjs
  - tests/unit/coordinator/pre-lead-parent-deadlock.test.js
- **LOC:** 138 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol