### PR TITLE
fix(QF-20260726-642): emit per-session account name/email so Sessions element 5 can render

### DIFF
--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -55,7 +55,9 @@ function sessionIdentityKind(meta = {}) {
   return null;                          // no identity at all -> ghost
 }
 
-function formatSessionRow(row) {
+// QF-20260726-642: exported (additively, no behaviour change) so the per-session account fields
+// below are unit-testable. An emitted field with no test is how element 5 got dropped the first time.
+export function formatSessionRow(row) {
   const meta = row.metadata || {};
   const identity = meta.fleet_identity || {};
   const model = meta.model || '--';
@@ -70,6 +72,20 @@ function formatSessionRow(row) {
     color: identity.color || null,
     role: identity.role || null,
     account: identity.accountUuid8 || null,
+    // QF-20260726-642 element 5 — the per-session ACCOUNT the chairman named. The published
+    // artifact renders a NAME ("Deep Soul Sessions", "Rick Felix 2000"), so the display value is
+    // account_org_name FIRST and account_email only as a fallback; `account` above is an
+    // accountUuid8 fragment and was never a name. Written per session by
+    // scripts/hooks/session-register.cjs (QF-20260726-514, merged 13:22Z), resolved via
+    // CLAUDE_CONFIG_DIR — deliberately NOT .account-identity-last.json, which is host-global and
+    // last-writer-wins and would render every row identically.
+    //
+    // NULL IS EXPECTED, NOT BROKEN: the field stamps at SessionStart with no backfill, so every
+    // session that predates the merge reports null until it restarts. The UI must render that as
+    // "not captured" rather than a blank — a session predating the writer is not an account-less
+    // session. No placeholder is invented here; null is passed through honestly.
+    account_email: meta.account_email || null,
+    account_org_name: meta.account_org_name || null,
     model_effort: `${model}/${effort}`,
     status: row.computed_status || 'unknown',
     sd_key: row.sd_key || null,

--- a/tests/unit/server/fleet-panel-account-fields.test.js
+++ b/tests/unit/server/fleet-panel-account-fields.test.js
@@ -1,0 +1,80 @@
+/**
+ * QF-20260726-642 element 5 — the per-session ACCOUNT the chairman named, emitted by
+ * server/routes/fleet-panel.js formatSessionRow.
+ *
+ * The element was dropped originally because the comparison was run against mockup.html, which
+ * contains ZERO account references, so nothing ever surfaced it. These tests pin the emit so it
+ * cannot silently disappear again.
+ *
+ * KEY POINT ON NULL: a null account is EXPECTED, not broken. The writer
+ * (scripts/hooks/session-register.cjs, QF-20260726-514) stamps at SessionStart with no backfill,
+ * so every session predating that merge reports null until it restarts. This layer passes null
+ * through honestly and never invents a placeholder — the UI is the only place where "not captured"
+ * can be distinguished from "no account".
+ */
+import { describe, it, expect } from 'vitest';
+import { formatSessionRow } from '../../../server/routes/fleet-panel.js';
+
+const baseRow = (metadata) => ({
+  session_id: 'sess-1',
+  sd_key: null,
+  computed_status: 'active',
+  heartbeat_age_human: '5s ago',
+  metadata,
+});
+
+describe('formatSessionRow — account fields (QF-20260726-642 element 5)', () => {
+  it('emits the ORG NAME, because the artifact renders a name like "Deep Soul Sessions"', () => {
+    const out = formatSessionRow(
+      baseRow({ model: 'opus', effort: 'xhigh', account_org_name: 'Deep Soul Sessions', account_email: 'x@y.z' }),
+    );
+    expect(out.account_org_name).toBe('Deep Soul Sessions');
+    expect(out.account_email).toBe('x@y.z');
+  });
+
+  it('emits account_email even when no org name exists, so the UI has a fallback', () => {
+    const out = formatSessionRow(baseRow({ model: 'opus', effort: 'high', account_email: 'solo@example.com' }));
+    expect(out.account_email).toBe('solo@example.com');
+    expect(out.account_org_name).toBeNull();
+  });
+
+  it('emits NULL (never a placeholder) for a session that predates the account writer', () => {
+    const out = formatSessionRow(baseRow({ model: 'opus', effort: 'medium' }));
+    expect(out.account_email).toBeNull();
+    expect(out.account_org_name).toBeNull();
+    // Explicitly present-but-null rather than absent, so the UI can distinguish the states.
+    expect('account_email' in out).toBe(true);
+    expect('account_org_name' in out).toBe(true);
+  });
+
+  it('does NOT confuse the account name with the accountUuid8 fragment', () => {
+    const out = formatSessionRow(
+      baseRow({
+        model: 'opus',
+        effort: 'max',
+        account_org_name: 'Rick Felix 2000',
+        fleet_identity: { callsign: 'Alpha-4', accountUuid8: 'ca1de6e4' },
+      }),
+    );
+    // `account` was never a name — that is why the column looked implemented but wasn't.
+    expect(out.account).toBe('ca1de6e4');
+    expect(out.account_org_name).toBe('Rick Felix 2000');
+    expect(out.account_org_name).not.toBe(out.account);
+  });
+
+  it('tolerates a row with no metadata at all without throwing', () => {
+    const out = formatSessionRow({ session_id: 's', metadata: null });
+    expect(out.account_email).toBeNull();
+    expect(out.account_org_name).toBeNull();
+  });
+
+  it('leaves the pre-existing emitted fields untouched (no regression from the addition)', () => {
+    const out = formatSessionRow(
+      baseRow({ model: 'opus', effort: 'medium', fleet_identity: { callsign: 'Bravo', color: '#4fbf7f', role: 'worker' } }),
+    );
+    expect(out.callsign).toBe('Bravo');
+    expect(out.color).toBe('#4fbf7f');
+    expect(out.model_effort).toBe('opus/medium');
+    expect(out.status).toBe('active');
+  });
+});


### PR DESCRIPTION
Companion **backend** change for QF-20260726-642 (Sessions design restoration). The frontend is a separate PR in `rickfelix/ehg` — **land this one FIRST**, or element 5 renders "not captured" for every row.

## What was wrong

`formatSessionRow` emitted only `account: identity.accountUuid8` — a UUID fragment, never a name. So the column *looked* implemented while the chairman's actual ask (per-terminal account visibility) was unrenderable.

## What this does

Also emits `account_org_name` and `account_email` from session metadata, written per session by `scripts/hooks/session-register.cjs` (QF-20260726-514, merged 13:22Z) and resolved via `CLAUDE_CONFIG_DIR`.

Deliberately **not** `.account-identity-last.json`, which is host-global and last-writer-wins — it would render every row identically and look correct right up until the fleet splits across accounts, the one moment the column earns its place.

**Org name is the display value.** The published artifact renders `Deep Soul Sessions` / `Rick Felix 2000`, so the UI prefers `account_org_name` and falls back to `account_email`. This is a small correction to the source pin, which named `account_email` — right row, wrong field for a *label*.

**Null is passed through honestly**, no placeholder invented. The field stamps at SessionStart with no backfill, so every session predating that merge reports null until it restarts — currently 0 of 19 live sessions carry it, which is correct behaviour. The UI is the only layer that can distinguish "not captured" from "no account", and it does.

`formatSessionRow` is now exported (additively, no behaviour change) so these fields are unit-testable. An emitted field with no test is precisely how element 5 got dropped the first time.

## Verification

23 tests pass — 6 new: org-name emit, email fallback, present-but-null for pre-writer sessions, name-is-not-the-uuid8-fragment, null metadata tolerated, and no regression to existing emitted fields.

## Not done / gate

This does **not** complete QF-20260726-642. `uat_verified` stays false: the chairman has an absolute review gate on the rendered page, and tests + CI + a merged PR are explicitly insufficient for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)